### PR TITLE
testing: refactor uses of "getPrefixAndSlashFromDaemonPlatform()"

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1158,9 +1158,8 @@ func (s *DockerAPISuite) TestContainersAPICreateMountsValidation(c *testing.T) {
 		msg        string
 	}
 
-	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
-	destPath := prefix + slash + "foo"
-	notExistPath := prefix + slash + "notexist"
+	destPath := dPath("/foo")
+	notExistPath := dPath("/notexist")
 
 	tests := []testCase{
 		{
@@ -1472,8 +1471,6 @@ func (s *DockerAPISuite) TestContainersAPICreateMountsValidation(c *testing.T) {
 func (s *DockerAPISuite) TestContainerAPICreateMountsBindRead(c *testing.T) {
 	testRequires(c, NotUserNamespace, testEnv.IsLocalDaemon)
 	// also with data in the host side
-	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
-	destPath := prefix + slash + "foo"
 	tmpDir, err := os.MkdirTemp("", "test-mounts-api-bind")
 	assert.NilError(c, err)
 	defer os.RemoveAll(tmpDir)
@@ -1485,7 +1482,7 @@ func (s *DockerAPISuite) TestContainerAPICreateMountsBindRead(c *testing.T) {
 	}
 	hostConfig := container.HostConfig{
 		Mounts: []mount.Mount{
-			{Type: "bind", Source: tmpDir, Target: destPath},
+			{Type: "bind", Source: tmpDir, Target: dPath("/foo")},
 		},
 	}
 	apiClient, err := client.New(client.FromEnv)
@@ -1506,16 +1503,17 @@ func (s *DockerAPISuite) TestContainerAPICreateMountsBindRead(c *testing.T) {
 
 // Test Mounts comes out as expected for the MountPoint
 func (s *DockerAPISuite) TestContainersAPICreateMountsCreate(c *testing.T) {
-	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
-	destPath := prefix + slash + "foo"
-
-	var testImg string
+	var (
+		testImg  string
+		destPath = dPath("/foo")
+		destFile = dPath("/foo/bar")
+	)
 	if testEnv.DaemonInfo.OSType != "windows" {
 		testImg = "test-mount-config"
 		cli.BuildCmd(c, testImg, build.WithDockerfile(`
 	FROM busybox
-	RUN mkdir `+destPath+` && touch `+destPath+slash+`bar
-	CMD cat `+destPath+slash+`bar
+	RUN mkdir `+destPath+` && touch `+destFile+`
+	CMD cat `+destFile+`
 	`))
 	} else {
 		testImg = "busybox"
@@ -1531,6 +1529,7 @@ func (s *DockerAPISuite) TestContainersAPICreateMountsCreate(c *testing.T) {
 		selinuxSharedLabel = "z"
 	}
 
+	_, slash := getPrefixAndSlashFromDaemonPlatform()
 	tests := []testCase{
 		// use literal strings here for `Type` instead of the defined constants in the volume package to keep this honest
 		// Validation of the actual `Mount` struct is done in another test is not needed here

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -147,12 +147,11 @@ func (s *DockerCLICreateSuite) TestCreateEchoStdout(c *testing.T) {
 
 func (s *DockerCLICreateSuite) TestCreateVolumesCreated(c *testing.T) {
 	testRequires(c, testEnv.IsLocalDaemon)
-	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
 
 	const name = "test_create_volume"
-	cli.DockerCmd(c, "create", "--name", name, "-v", prefix+slash+"foo", "busybox")
+	cli.DockerCmd(c, "create", "--name", name, "-v", dPath("/foo"), "busybox")
 
-	mnt, err := inspectMountPoint(name, prefix+slash+"foo")
+	mnt, err := inspectMountPoint(name, dPath("/foo"))
 	assert.Assert(c, err == nil, "Error getting volume host path: %q", err)
 
 	if _, err := os.Stat(mnt.Source); err != nil && os.IsNotExist(err) {
@@ -239,8 +238,7 @@ func (s *DockerCLICreateSuite) TestCreateStopSignal(c *testing.T) {
 func (s *DockerCLICreateSuite) TestCreateWithWorkdir(c *testing.T) {
 	const name = "foo"
 
-	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
-	dir := prefix + slash + "home" + slash + "foo" + slash + "bar"
+	dir := dPath("/home/foo/bar")
 
 	cli.DockerCmd(c, "create", "--name", name, "-w", dir, "busybox")
 	// Windows does not create the workdir until the container is started
@@ -255,7 +253,7 @@ func (s *DockerCLICreateSuite) TestCreateWithWorkdir(c *testing.T) {
 		}
 	}
 	// TODO: rewrite this test to not use `docker cp` for verifying that the WORKDIR was created
-	cli.DockerCmd(c, "cp", fmt.Sprintf("%s:%s", name, dir), prefix+slash+"tmp")
+	cli.DockerCmd(c, "cp", fmt.Sprintf("%s:%s", name, dir), dPath("/tmp"))
 }
 
 func (s *DockerCLICreateSuite) TestCreateWithInvalidLogOpts(c *testing.T) {

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -176,9 +176,6 @@ func (s *DockerCLIInspectSuite) TestInspectContainerFilterInt(c *testing.T) {
 }
 
 func (s *DockerCLIInspectSuite) TestInspectBindMountPoint(c *testing.T) {
-	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
-	mopt := prefix + slash + "data:" + prefix + slash + "data"
-
 	mode := ""
 	if testEnv.DaemonInfo.OSType == "windows" {
 		// Linux creates the host directory if it doesn't exist. Windows does not.
@@ -187,11 +184,12 @@ func (s *DockerCLIInspectSuite) TestInspectBindMountPoint(c *testing.T) {
 		mode = "z" // Relabel
 	}
 
+	var modifier string
 	if mode != "" {
-		mopt += ":" + mode
+		modifier += ":" + mode
 	}
 
-	cli.DockerCmd(c, "run", "-d", "--name", "test", "-v", mopt, "busybox", "cat")
+	cli.DockerCmd(c, "run", "-d", "--name", "test", "-v", dPath("/data")+":"+dPath("/data")+modifier, "busybox", "cat")
 
 	vol := inspectFieldJSON(c, "test", "Mounts")
 
@@ -206,16 +204,14 @@ func (s *DockerCLIInspectSuite) TestInspectBindMountPoint(c *testing.T) {
 
 	assert.Equal(c, m.Name, "")
 	assert.Equal(c, m.Driver, "")
-	assert.Equal(c, m.Source, prefix+slash+"data")
-	assert.Equal(c, m.Destination, prefix+slash+"data")
+	assert.Equal(c, m.Source, dPath("/data"))
+	assert.Equal(c, m.Destination, dPath("/data"))
 	assert.Equal(c, m.Mode, mode)
 	assert.Equal(c, m.RW, true)
 }
 
 func (s *DockerCLIInspectSuite) TestInspectNamedMountPoint(c *testing.T) {
-	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
-
-	cli.DockerCmd(c, "run", "-d", "--name", "test", "-v", "data:"+prefix+slash+"data", "busybox", "cat")
+	cli.DockerCmd(c, "run", "-d", "--name", "test", "-v", "data:"+dPath("/data"), "busybox", "cat")
 
 	vol := inspectFieldJSON(c, "test", "Mounts")
 
@@ -231,7 +227,7 @@ func (s *DockerCLIInspectSuite) TestInspectNamedMountPoint(c *testing.T) {
 	assert.Equal(c, m.Name, "data")
 	assert.Equal(c, m.Driver, "local")
 	assert.Assert(c, m.Source != "")
-	assert.Equal(c, m.Destination, prefix+slash+"data")
+	assert.Equal(c, m.Destination, dPath("/data"))
 	assert.Equal(c, m.RW, true)
 }
 

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -613,9 +613,7 @@ func (s *DockerCLIPsSuite) TestPsNotShowPortsOfStoppedContainer(c *testing.T) {
 func (s *DockerCLIPsSuite) TestPsShowMounts(c *testing.T) {
 	existingContainers := ExistingContainerNames(c)
 
-	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
-
-	mp := prefix + slash + "test"
+	mp := dPath("/test")
 
 	cli.DockerCmd(c, "volume", "create", "ps-volume-test")
 	// volume mount containers
@@ -706,7 +704,7 @@ func (s *DockerCLIPsSuite) TestPsShowMounts(c *testing.T) {
 	assert.Equal(c, fields[1], bindMountSource)
 
 	// empty results filtering by unknown mount point
-	out = cli.DockerCmd(c, "ps", "--format", "{{.Names}} {{.Mounts}}", "--filter", "volume="+prefix+slash+"this-path-was-never-mounted").Stdout()
+	out = cli.DockerCmd(c, "ps", "--format", "{{.Names}} {{.Mounts}}", "--filter", "volume="+dPath("/this-path-was-never-mounted")).Stdout()
 	assert.Equal(c, len(strings.TrimSpace(out)), 0)
 }
 

--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -69,14 +69,13 @@ func (s *DockerCLIRestartSuite) TestRestartRunningContainer(c *testing.T) {
 
 // Test that restarting a container with a volume does not create a new volume on restart. Regression test for #819.
 func (s *DockerCLIRestartSuite) TestRestartWithVolumes(c *testing.T) {
-	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
-	cID := runSleepingContainer(c, "-d", "-v", prefix+slash+"test")
+	cID := runSleepingContainer(c, "-d", "-v", dPath("/test"))
 	out, err := inspectFilter(cID, "len .Mounts")
 	assert.NilError(c, err, "failed to inspect %s: %s", cID, out)
 	out = strings.Trim(out, " \n\r")
 	assert.Equal(c, out, "1")
 
-	mnt, err := inspectMountPoint(cID, prefix+slash+"test")
+	mnt, err := inspectMountPoint(cID, dPath("/test"))
 	assert.NilError(c, err)
 
 	cli.DockerCmd(c, "restart", cID)
@@ -86,7 +85,7 @@ func (s *DockerCLIRestartSuite) TestRestartWithVolumes(c *testing.T) {
 	out = strings.Trim(out, " \n\r")
 	assert.Equal(c, out, "1")
 
-	mountAfterRestart, err := inspectMountPoint(cID, prefix+slash+"test")
+	mountAfterRestart, err := inspectMountPoint(cID, dPath("/test"))
 	assert.NilError(c, err)
 	assert.Equal(c, mnt.Source, mountAfterRestart.Source)
 }

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -503,24 +503,23 @@ func (s *DockerCLIRunSuite) TestRunVolumesFromInReadWriteMode(c *testing.T) {
 
 func (s *DockerCLIRunSuite) TestVolumesFromGetsProperMode(c *testing.T) {
 	testRequires(c, testEnv.IsLocalDaemon)
-	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
 	hostpath := RandomTmpDirPath("test", testEnv.DaemonInfo.OSType)
 	if err := os.MkdirAll(hostpath, 0o755); err != nil {
 		c.Fatalf("Failed to create %s: %q", hostpath, err)
 	}
 	defer os.RemoveAll(hostpath)
 
-	cli.DockerCmd(c, "run", "--name", "parent", "-v", hostpath+":"+prefix+slash+"test:ro", "busybox", "true")
+	cli.DockerCmd(c, "run", "--name", "parent", "-v", hostpath+":"+dPath("/test")+":ro", "busybox", "true")
 
 	// Expect this "rw" mode to be ignored since the inherited volume is "ro"
-	if _, _, err := dockerCmdWithError("run", "--volumes-from", "parent:rw", "busybox", "touch", prefix+slash+"test"+slash+"file"); err == nil {
+	if _, _, err := dockerCmdWithError("run", "--volumes-from", "parent:rw", "busybox", "touch", dPath("/test/file")); err == nil {
 		c.Fatal("Expected volumes-from to inherit read-only volume even when passing in `rw`")
 	}
 
-	cli.DockerCmd(c, "run", "--name", "parent2", "-v", hostpath+":"+prefix+slash+"test:ro", "busybox", "true")
+	cli.DockerCmd(c, "run", "--name", "parent2", "-v", hostpath+":"+dPath("/test")+":ro", "busybox", "true")
 
 	// Expect this to be read-only since both are "ro"
-	if _, _, err := dockerCmdWithError("run", "--volumes-from", "parent2:ro", "busybox", "touch", prefix+slash+"test"+slash+"file"); err == nil {
+	if _, _, err := dockerCmdWithError("run", "--volumes-from", "parent2:ro", "busybox", "touch", dPath("/test/file")); err == nil {
 		c.Fatal("Expected volumes-from to inherit read-only volume even when passing in `ro`")
 	}
 }
@@ -1811,8 +1810,6 @@ func (s *DockerCLIRunSuite) TestRunBindMounts(c *testing.T) {
 		testRequires(c, DaemonIsLinux, NotUserNamespace)
 	}
 
-	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
-
 	tmpDir, err := os.MkdirTemp("", "docker-test-container")
 	if err != nil {
 		c.Fatal(err)
@@ -1822,7 +1819,7 @@ func (s *DockerCLIRunSuite) TestRunBindMounts(c *testing.T) {
 	writeFile(path.Join(tmpDir, "touch-me"), "", c)
 
 	// Test reading from a read-only bind mount
-	out := cli.DockerCmd(c, "run", "-v", fmt.Sprintf("%s:%s/tmpx:ro", tmpDir, prefix), "busybox", "ls", prefix+"/tmpx").Combined()
+	out := cli.DockerCmd(c, "run", "-v", fmt.Sprintf("%s:%s:ro", tmpDir, dPath("/tmpx")), "busybox", "ls", dPath("/tmpx")).Combined()
 	if !strings.Contains(out, "touch-me") {
 		c.Fatal("Container failed to read from bind mount")
 	}
@@ -1989,7 +1986,6 @@ func (s *DockerCLIRunSuite) TestRunAllocatePortInReservedRange(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunMountOrdering(c *testing.T) {
 	// TODO Windows: Post RS1. Windows does not support nested mounts.
 	testRequires(c, testEnv.IsLocalDaemon, DaemonIsLinux, NotUserNamespace)
-	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
 
 	tmpDir, err := os.MkdirTemp("", "docker_nested_mount_test")
 	if err != nil {
@@ -2022,19 +2018,19 @@ func (s *DockerCLIRunSuite) TestRunMountOrdering(c *testing.T) {
 	}
 
 	cli.DockerCmd(c, "run",
-		"-v", fmt.Sprintf("%s:"+prefix+"/tmp", tmpDir),
-		"-v", fmt.Sprintf("%s:"+prefix+"/tmp/foo", fooDir),
-		"-v", fmt.Sprintf("%s:"+prefix+"/tmp/tmp2", tmpDir2),
-		"-v", fmt.Sprintf("%s:"+prefix+"/tmp/tmp2/foo", fooDir),
+		"-v", fmt.Sprintf("%s:"+dPath("/tmp"), tmpDir),
+		"-v", fmt.Sprintf("%s:"+dPath("/tmp/foo"), fooDir),
+		"-v", fmt.Sprintf("%s:"+dPath("/tmp/tmp2"), tmpDir2),
+		"-v", fmt.Sprintf("%s:"+dPath("/tmp/tmp2/foo"), fooDir),
 		"busybox:latest", "sh", "-c",
-		"ls "+prefix+"/tmp/touch-me && ls "+prefix+"/tmp/foo/touch-me && ls "+prefix+"/tmp/tmp2/touch-me && ls "+prefix+"/tmp/tmp2/foo/touch-me")
+		"ls "+dPath("/tmp/touch-me")+" "+dPath("/tmp/foo/touch-me")+" "+dPath("/tmp/tmp2/touch-me")+" "+dPath("/tmp/tmp2/foo/touch-me"),
+	)
 }
 
 // Regression test for https://github.com/moby/moby/issues/8259
 func (s *DockerCLIRunSuite) TestRunReuseBindVolumeThatIsSymlink(c *testing.T) {
 	// Not applicable on Windows as Windows does not support volumes
 	testRequires(c, testEnv.IsLocalDaemon, DaemonIsLinux, NotUserNamespace)
-	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
 
 	tmpDir, err := os.MkdirTemp(os.TempDir(), "testlink")
 	if err != nil {
@@ -2049,11 +2045,11 @@ func (s *DockerCLIRunSuite) TestRunReuseBindVolumeThatIsSymlink(c *testing.T) {
 	defer os.RemoveAll(linkPath)
 
 	// Create first container
-	cli.DockerCmd(c, "run", "-v", fmt.Sprintf("%s:"+prefix+"/tmp/test", linkPath), "busybox", "ls", prefix+"/tmp/test")
+	cli.DockerCmd(c, "run", "-v", fmt.Sprintf("%s:"+dPath("/tmp/test"), linkPath), "busybox", "ls", dPath("/tmp/test"))
 
 	// Create second container with same symlinked path
 	// This will fail if the referenced issue is hit with a "Volume exists" error
-	cli.DockerCmd(c, "run", "-v", fmt.Sprintf("%s:"+prefix+"/tmp/test", linkPath), "busybox", "ls", prefix+"/tmp/test")
+	cli.DockerCmd(c, "run", "-v", fmt.Sprintf("%s:"+dPath("/tmp/test"), linkPath), "busybox", "ls", dPath("/tmp/test"))
 }
 
 // GH#10604: Test an "/etc" volume doesn't overlay special bind mounts in container
@@ -2082,11 +2078,10 @@ func (s *DockerCLIRunSuite) TestVolumesNoCopyData(c *testing.T) {
 	// TODO Windows (Post RS1). Windows does not support volumes which
 	// are pre-populated such as is built in the dockerfile used in this test.
 	testRequires(c, DaemonIsLinux)
-	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
 	cli.BuildCmd(c, "dataimage", build.WithDockerfile(`FROM busybox
 		RUN ["mkdir", "-p", "/foo"]
 		RUN ["touch", "/foo/bar"]`))
-	cli.DockerCmd(c, "run", "--name", "test", "-v", prefix+slash+"foo", "busybox")
+	cli.DockerCmd(c, "run", "--name", "test", "-v", dPath("/foo"), "busybox")
 
 	if out, _, err := dockerCmdWithError("run", "--volumes-from", "test", "dataimage", "ls", "-lh", "/foo/bar"); err == nil || !strings.Contains(out, "No such file or directory") {
 		c.Fatalf("Data was copied on volumes-from but shouldn't be:\n%q", out)
@@ -2113,31 +2108,37 @@ func (s *DockerCLIRunSuite) TestRunNoOutputFromPullInStdout(c *testing.T) {
 
 func (s *DockerCLIRunSuite) TestRunVolumesCleanPaths(c *testing.T) {
 	testRequires(c, testEnv.IsLocalDaemon)
-	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
+
+	// use forward slashes in Dockerfile
+	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
 	cli.BuildCmd(c, "run_volumes_clean_paths", build.WithDockerfile(`FROM busybox
 		VOLUME `+prefix+`/foo/`))
-	cli.DockerCmd(c, "run", "-v", prefix+"/foo", "-v", prefix+"/bar/", "--name", "dark_helmet", "run_volumes_clean_paths")
+	cli.DockerCmd(c, "run", "-v", dPath("/foo"), "-v", dPath("/bar/"), "--name", "dark_helmet", "run_volumes_clean_paths")
 
-	mnt, err := inspectMountPoint("dark_helmet", prefix+slash+"foo"+slash)
+	p := dPath("/foo/")
+	mnt, err := inspectMountPoint("dark_helmet", p)
 	if !errors.Is(err, errMountNotFound) {
-		c.Fatalf("Found unexpected volume entry for '%s/foo/' in volumes\n%q", prefix, mnt.Source)
+		c.Fatalf("Found unexpected volume entry for '%s' in volumes\n%q", p, mnt.Source)
 	}
 
-	mnt, err = inspectMountPoint("dark_helmet", prefix+slash+`foo`)
+	p = dPath("/foo")
+	mnt, err = inspectMountPoint("dark_helmet", p)
 	assert.NilError(c, err)
 	if !strings.Contains(strings.ToLower(mnt.Source), strings.ToLower(testEnv.PlatformDefaults.VolumesConfigPath)) {
-		c.Fatalf("Volume was not defined for %s/foo\n%q", prefix, mnt.Source)
+		c.Fatalf("Volume was not defined for %s\n%q", p, mnt.Source)
 	}
 
-	mnt, err = inspectMountPoint("dark_helmet", prefix+slash+"bar"+slash)
+	p = dPath("/bar/")
+	mnt, err = inspectMountPoint("dark_helmet", p)
 	if !errors.Is(err, errMountNotFound) {
-		c.Fatalf("Found unexpected volume entry for '%s/bar/' in volumes\n%q", prefix, mnt.Source)
+		c.Fatalf("Found unexpected volume entry for '%s' in volumes\n%q", p, mnt.Source)
 	}
 
-	mnt, err = inspectMountPoint("dark_helmet", prefix+slash+"bar")
+	p = dPath("/bar")
+	mnt, err = inspectMountPoint("dark_helmet", p)
 	assert.NilError(c, err)
 	if !strings.Contains(strings.ToLower(mnt.Source), strings.ToLower(testEnv.PlatformDefaults.VolumesConfigPath)) {
-		c.Fatalf("Volume was not defined for %s/bar\n%q", prefix, mnt.Source)
+		c.Fatalf("Volume was not defined for %s\n%q", p, mnt.Source)
 	}
 }
 
@@ -2655,8 +2656,7 @@ func (s *DockerCLIRunSuite) TestRunContainerWithReadonlyRootfsWithAddHostFlag(c 
 }
 
 func (s *DockerCLIRunSuite) TestRunVolumesFromRestartAfterRemoved(c *testing.T) {
-	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
-	runSleepingContainer(c, "--name=voltest", "-v", prefix+"/foo")
+	runSleepingContainer(c, "--name=voltest", "-v", dPath("/foo"))
 	runSleepingContainer(c, "--name=restarter", "--volumes-from", "voltest")
 
 	// Remove the main volume container and restart the consuming container
@@ -2906,22 +2906,20 @@ func (s *DockerCLIRunSuite) TestRunCapAddCHOWN(c *testing.T) {
 
 // https://github.com/moby/moby/pull/14498
 func (s *DockerCLIRunSuite) TestVolumeFromMixedRWOptions(c *testing.T) {
-	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
-
-	cli.DockerCmd(c, "run", "--name", "parent", "-v", prefix+"/test", "busybox", "true")
+	cli.DockerCmd(c, "run", "--name", "parent", "-v", dPath("/test"), "busybox", "true")
 
 	cli.DockerCmd(c, "run", "--volumes-from", "parent:ro", "--name", "test-volumes-1", "busybox", "true")
 	cli.DockerCmd(c, "run", "--volumes-from", "parent:rw", "--name", "test-volumes-2", "busybox", "true")
 
 	if testEnv.DaemonInfo.OSType != "windows" {
-		mRO, err := inspectMountPoint("test-volumes-1", prefix+slash+"test")
+		mRO, err := inspectMountPoint("test-volumes-1", dPath("/test"))
 		assert.NilError(c, err, "failed to inspect mount point")
 		if mRO.RW {
 			c.Fatalf("Expected RO volume was RW")
 		}
 	}
 
-	mRW, err := inspectMountPoint("test-volumes-2", prefix+slash+"test")
+	mRW, err := inspectMountPoint("test-volumes-2", dPath("/test"))
 	assert.NilError(c, err, "failed to inspect mount point")
 	if !mRW.RW {
 		c.Fatalf("Expected RW volume was RO")
@@ -3104,14 +3102,13 @@ func (s *DockerCLIRunSuite) TestRunCreateContainerFailedCleanUp(c *testing.T) {
 }
 
 func (s *DockerCLIRunSuite) TestRunNamedVolume(c *testing.T) {
-	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
 	testRequires(c, DaemonIsLinux)
-	cli.DockerCmd(c, "run", "--name=test", "-v", "testing:"+prefix+"/foo", "busybox", "sh", "-c", "echo hello > "+prefix+"/foo/bar")
+	cli.DockerCmd(c, "run", "--name=test", "-v", "testing:"+dPath("/foo"), "busybox", "sh", "-c", "echo hello > "+dPath("/foo/bar"))
 
-	out := cli.DockerCmd(c, "run", "--volumes-from", "test", "busybox", "sh", "-c", "cat "+prefix+"/foo/bar").Combined()
+	out := cli.DockerCmd(c, "run", "--volumes-from", "test", "busybox", "sh", "-c", "cat "+dPath("/foo/bar")).Combined()
 	assert.Equal(c, strings.TrimSpace(out), "hello")
 
-	out = cli.DockerCmd(c, "run", "-v", "testing:"+prefix+"/foo", "busybox", "sh", "-c", "cat "+prefix+"/foo/bar").Combined()
+	out = cli.DockerCmd(c, "run", "-v", "testing:"+dPath("/foo"), "busybox", "sh", "-c", "cat "+dPath("/foo/bar")).Combined()
 	assert.Equal(c, strings.TrimSpace(out), "hello")
 }
 
@@ -3679,16 +3676,14 @@ func (s *DockerCLIRunSuite) TestRunNamedVolumeCopyImageData(c *testing.T) {
 }
 
 func (s *DockerCLIRunSuite) TestRunNamedVolumeNotRemoved(c *testing.T) {
-	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
-
 	cli.DockerCmd(c, "volume", "create", "test")
 
-	cli.DockerCmd(c, "run", "--rm", "-v", "test:"+prefix+"/foo", "-v", prefix+"/bar", "busybox", "true")
+	cli.DockerCmd(c, "run", "--rm", "-v", "test:"+dPath("/foo"), "-v", dPath("/bar"), "busybox", "true")
 	cli.DockerCmd(c, "volume", "inspect", "test")
 	out := cli.DockerCmd(c, "volume", "ls", "-q").Combined()
 	assert.Assert(c, is.Contains(out, "test"))
 
-	cli.DockerCmd(c, "run", "--name=test", "-v", "test:"+prefix+"/foo", "-v", prefix+"/bar", "busybox", "true")
+	cli.DockerCmd(c, "run", "--name=test", "-v", "test:"+dPath("/foo"), "-v", dPath("/bar"), "busybox", "true")
 	cli.DockerCmd(c, "rm", "-fv", "test")
 	cli.DockerCmd(c, "volume", "inspect", "test")
 	out = cli.DockerCmd(c, "volume", "ls", "-q").Combined()
@@ -3696,10 +3691,8 @@ func (s *DockerCLIRunSuite) TestRunNamedVolumeNotRemoved(c *testing.T) {
 }
 
 func (s *DockerCLIRunSuite) TestRunNamedVolumesFromNotRemoved(c *testing.T) {
-	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
-
 	cli.DockerCmd(c, "volume", "create", "test")
-	cid := cli.DockerCmd(c, "run", "-d", "--name=parent", "-v", "test:"+prefix+"/foo", "-v", prefix+"/bar", "busybox", "true").Stdout()
+	cid := cli.DockerCmd(c, "run", "-d", "--name=parent", "-v", "test:"+dPath("/foo"), "-v", dPath("/bar"), "busybox", "true").Stdout()
 	cli.DockerCmd(c, "run", "--name=child", "--volumes-from=parent", "busybox", "true")
 
 	apiClient, err := client.New(client.FromEnv)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1826,15 +1826,15 @@ func (s *DockerCLIRunSuite) TestRunBindMounts(c *testing.T) {
 
 	// test writing to bind mount
 	if testEnv.DaemonInfo.OSType == "windows" {
-		cli.DockerCmd(c, "run", "-v", fmt.Sprintf(`%s:c:\tmp:rw`, tmpDir), "busybox", "touch", "c:/tmp/holla")
+		cli.DockerCmd(c, "run", "-v", tmpDir+`:c:\tmp:rw`, "busybox", "touch", "c:/tmp/holla")
 	} else {
-		cli.DockerCmd(c, "run", "-v", fmt.Sprintf("%s:/tmp:rw", tmpDir), "busybox", "touch", "/tmp/holla")
+		cli.DockerCmd(c, "run", "-v", tmpDir+`:/tmp:rw`, "busybox", "touch", "/tmp/holla")
 	}
 
 	readFile(path.Join(tmpDir, "holla"), c) // Will fail if the file doesn't exist
 
 	// test mounting to an illegal destination directory
-	_, _, err = dockerCmdWithError("run", "-v", fmt.Sprintf("%s:.", tmpDir), "busybox", "ls", ".")
+	_, _, err = dockerCmdWithError("run", "-v", tmpDir+":.", "busybox", "ls", ".")
 	if err == nil {
 		c.Fatal("Container bind mounted illegal directory")
 	}
@@ -1842,7 +1842,7 @@ func (s *DockerCLIRunSuite) TestRunBindMounts(c *testing.T) {
 	// Windows does not (and likely never will) support mounting a single file
 	if testEnv.DaemonInfo.OSType != "windows" {
 		// test mount a file
-		cli.DockerCmd(c, "run", "-v", fmt.Sprintf("%s/holla:/tmp/holla:rw", tmpDir), "busybox", "sh", "-c", "echo -n 'yotta' > /tmp/holla")
+		cli.DockerCmd(c, "run", "-v", tmpDir+"/holla:/tmp/holla:rw", "busybox", "sh", "-c", "echo -n 'yotta' > /tmp/holla")
 		content := readFile(path.Join(tmpDir, "holla"), c) // Will fail if the file doesn't exist
 		expected := "yotta"
 		if content != expected {
@@ -1910,10 +1910,10 @@ func (s *DockerCLIRunSuite) TestRunSetMacAddress(c *testing.T) {
 	mac := "12:34:56:78:9a:bc"
 	var out string
 	if testEnv.DaemonInfo.OSType == "windows" {
-		out = cli.DockerCmd(c, "run", "-i", "--rm", fmt.Sprintf("--mac-address=%s", mac), "busybox", "sh", "-c", "ipconfig /all | grep 'Physical Address' | awk '{print $12}'").Combined()
+		out = cli.DockerCmd(c, "run", "-i", "--rm", "--mac-address="+mac, "busybox", "sh", "-c", "ipconfig /all | grep 'Physical Address' | awk '{print $12}'").Combined()
 		mac = strings.ReplaceAll(strings.ToUpper(mac), ":", "-") // To Windows-style MACs
 	} else {
-		out = cli.DockerCmd(c, "run", "-i", "--rm", fmt.Sprintf("--mac-address=%s", mac), "busybox", "/bin/sh", "-c", "ip link show eth0 | tail -1 | awk '{print $2}'").Combined()
+		out = cli.DockerCmd(c, "run", "-i", "--rm", "--mac-address="+mac, "busybox", "/bin/sh", "-c", "ip link show eth0 | tail -1 | awk '{print $2}'").Combined()
 	}
 
 	actualMac := strings.TrimSpace(out)
@@ -2005,23 +2005,23 @@ func (s *DockerCLIRunSuite) TestRunMountOrdering(c *testing.T) {
 		c.Fatalf("failed to mkdir at %s - %s", fooDir, err)
 	}
 
-	if err := os.WriteFile(fmt.Sprintf("%s/touch-me", fooDir), []byte{}, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(fooDir, "touch-me"), []byte{}, 0o644); err != nil {
 		c.Fatal(err)
 	}
 
-	if err := os.WriteFile(fmt.Sprintf("%s/touch-me", tmpDir), []byte{}, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "touch-me"), []byte{}, 0o644); err != nil {
 		c.Fatal(err)
 	}
 
-	if err := os.WriteFile(fmt.Sprintf("%s/touch-me", tmpDir2), []byte{}, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir2, "touch-me"), []byte{}, 0o644); err != nil {
 		c.Fatal(err)
 	}
 
 	cli.DockerCmd(c, "run",
-		"-v", fmt.Sprintf("%s:"+dPath("/tmp"), tmpDir),
-		"-v", fmt.Sprintf("%s:"+dPath("/tmp/foo"), fooDir),
-		"-v", fmt.Sprintf("%s:"+dPath("/tmp/tmp2"), tmpDir2),
-		"-v", fmt.Sprintf("%s:"+dPath("/tmp/tmp2/foo"), fooDir),
+		"-v", tmpDir+":"+dPath("/tmp"),
+		"-v", fooDir+":"+dPath("/tmp/foo"),
+		"-v", tmpDir2+":"+dPath("/tmp/tmp2"),
+		"-v", fooDir+":"+dPath("/tmp/tmp2/foo"),
 		"busybox:latest", "sh", "-c",
 		"ls "+dPath("/tmp/touch-me")+" "+dPath("/tmp/foo/touch-me")+" "+dPath("/tmp/tmp2/touch-me")+" "+dPath("/tmp/tmp2/foo/touch-me"),
 	)
@@ -2045,11 +2045,11 @@ func (s *DockerCLIRunSuite) TestRunReuseBindVolumeThatIsSymlink(c *testing.T) {
 	defer os.RemoveAll(linkPath)
 
 	// Create first container
-	cli.DockerCmd(c, "run", "-v", fmt.Sprintf("%s:"+dPath("/tmp/test"), linkPath), "busybox", "ls", dPath("/tmp/test"))
+	cli.DockerCmd(c, "run", "-v", linkPath+":"+dPath("/tmp/test"), "busybox", "ls", dPath("/tmp/test"))
 
 	// Create second container with same symlinked path
 	// This will fail if the referenced issue is hit with a "Volume exists" error
-	cli.DockerCmd(c, "run", "-v", fmt.Sprintf("%s:"+dPath("/tmp/test"), linkPath), "busybox", "ls", dPath("/tmp/test"))
+	cli.DockerCmd(c, "run", "-v", linkPath+":"+dPath("/tmp/test"), "busybox", "ls", dPath("/tmp/test"))
 }
 
 // GH#10604: Test an "/etc" volume doesn't overlay special bind mounts in container
@@ -2237,7 +2237,7 @@ func (s *DockerCLIRunSuite) TestRunModeIpcContainerNotRunning(c *testing.T) {
 	id := cli.DockerCmd(c, "create", "busybox").Stdout()
 	id = strings.TrimSpace(id)
 
-	out, _, err := dockerCmdWithError("run", fmt.Sprintf("--ipc=container:%s", id), "busybox")
+	out, _, err := dockerCmdWithError("run", "--ipc=container:"+id, "busybox")
 	if err == nil {
 		c.Fatalf("Run container with ipc mode container should fail with non running container: %s\n%s", out, err)
 	}
@@ -2256,12 +2256,12 @@ func (s *DockerCLIRunSuite) TestRunModePIDContainer(c *testing.T) {
 	}
 	pid1 := inspectField(c, id, "State.Pid")
 
-	parentContainerPid, err := os.Readlink(fmt.Sprintf("/proc/%s/ns/pid", pid1))
+	parentContainerPid, err := os.Readlink(path.Join("/proc", pid1, "ns/pid"))
 	if err != nil {
 		c.Fatal(err)
 	}
 
-	out := cli.DockerCmd(c, "run", fmt.Sprintf("--pid=container:%s", id), "busybox", "readlink", "/proc/self/ns/pid").Combined()
+	out := cli.DockerCmd(c, "run", "--pid=container:"+id, "busybox", "readlink", "/proc/self/ns/pid").Combined()
 	out = strings.Trim(out, "\n")
 	if parentContainerPid != out {
 		c.Fatalf("PID different with --pid=container:%s %s != %s\n", id, parentContainerPid, out)
@@ -2284,7 +2284,7 @@ func (s *DockerCLIRunSuite) TestRunModePIDContainerNotRunning(c *testing.T) {
 	id := cli.DockerCmd(c, "create", "busybox").Stdout()
 	id = strings.TrimSpace(id)
 
-	out, _, err := dockerCmdWithError("run", fmt.Sprintf("--pid=container:%s", id), "busybox")
+	out, _, err := dockerCmdWithError("run", "--pid=container:"+id, "busybox")
 	if err == nil {
 		c.Fatalf("Run container with pid mode container should fail with non running container: %s\n%s", out, err)
 	}
@@ -2322,12 +2322,12 @@ func (s *DockerCLIRunSuite) TestContainerNetworkMode(c *testing.T) {
 	cli.WaitRun(c, id)
 	pid1 := inspectField(c, id, "State.Pid")
 
-	parentContainerNet, err := os.Readlink(fmt.Sprintf("/proc/%s/ns/net", pid1))
+	parentContainerNet, err := os.Readlink(path.Join("/proc", pid1, "ns/net"))
 	if err != nil {
 		c.Fatal(err)
 	}
 
-	out := cli.DockerCmd(c, "run", fmt.Sprintf("--net=container:%s", id), "busybox", "readlink", "/proc/self/ns/net").Combined()
+	out := cli.DockerCmd(c, "run", "--net=container:"+id, "busybox", "readlink", "/proc/self/ns/net").Combined()
 	out = strings.Trim(out, "\n")
 	if parentContainerNet != out {
 		c.Fatalf("NET different with --net=container:%s %s != %s\n", id, parentContainerNet, out)
@@ -2787,7 +2787,7 @@ func (s *DockerCLIRunSuite) TestRunReadFilteredProc(c *testing.T) {
 	}
 	for i, filePath := range testReadPaths {
 		name := fmt.Sprintf("procsieve-%d", i)
-		shellCmd := fmt.Sprintf("exec 3<%s", filePath)
+		shellCmd := "exec 3<" + filePath
 
 		out, exitCode, err := dockerCmdWithError("run", "--privileged", "--security-opt", "apparmor=docker-default", "--name", name, "busybox", "sh", "-c", shellCmd)
 		if exitCode != 0 {
@@ -2942,7 +2942,7 @@ func (s *DockerCLIRunSuite) TestRunWriteFilteredProc(c *testing.T) {
 	for i, filePath := range testWritePaths {
 		name := fmt.Sprintf("writeprocsieve-%d", i)
 
-		shellCmd := fmt.Sprintf("exec 3>%s", filePath)
+		shellCmd := "exec 3>" + filePath
 		out, code, err := dockerCmdWithError("run", "--privileged", "--security-opt", "apparmor=docker-default", "--name", name, "busybox", "sh", "-c", shellCmd)
 		if code != 0 {
 			return
@@ -3040,7 +3040,7 @@ func (s *DockerCLIRunSuite) TestPtraceContainerProcsFromHost(c *testing.T) {
 	cli.WaitRun(c, id)
 	pid1 := inspectField(c, id, "State.Pid")
 
-	_, err := os.Readlink(fmt.Sprintf("/proc/%s/ns/net", pid1))
+	_, err := os.Readlink(path.Join("/proc", pid1, "ns/net"))
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -3098,7 +3098,7 @@ func (s *DockerCLIRunSuite) TestRunCreateContainerFailedCleanUp(c *testing.T) {
 
 	containerID, err := inspectFilter(name, ".Id")
 	assert.Assert(c, err != nil, "Expected not to have this container: %s!", containerID)
-	assert.Equal(c, containerID, "", fmt.Sprintf("Expected not to have this container: %s!", containerID))
+	assert.Equal(c, containerID, "", "Expected not to have this container: %s!", containerID)
 }
 
 func (s *DockerCLIRunSuite) TestRunNamedVolume(c *testing.T) {
@@ -3761,7 +3761,7 @@ func (s *DockerCLIRunSuite) TestRunAttachFailedNoLeak(c *testing.T) {
 		strings.Contains(outLowerCase, "were not connected because a duplicate name exists") ||
 		strings.Contains(outLowerCase, "the specified port already exists") ||
 		strings.Contains(outLowerCase, "hns failed with error : failed to create endpoint") ||
-		strings.Contains(outLowerCase, "hns failed with error : the object already exists"), fmt.Sprintf("Output: %s", out))
+		strings.Contains(outLowerCase, "hns failed with error : the object already exists"), "Output: "+out)
 
 	out, err = d.Cmd("rm", "-f", "test")
 	assert.NilError(c, err, out)
@@ -4143,7 +4143,7 @@ func (s *DockerCLIRunSuite) TestRunMountReadOnlyDevShm(c *testing.T) {
 	assert.NilError(c, err)
 	defer os.RemoveAll(emptyDir)
 	out, _, err := dockerCmdWithError("run", "--rm", "--read-only",
-		"-v", fmt.Sprintf("%s:/dev/shm:ro", emptyDir),
+		"-v", emptyDir+":/dev/shm:ro",
 		"busybox", "touch", "/dev/shm/foo")
 	assert.ErrorContains(c, err, "", out)
 	assert.Assert(c, is.Contains(out, "Read-only file system"))
@@ -4257,7 +4257,7 @@ func (s *DockerCLIRunSuite) TestRunMount(c *testing.T) {
 				},
 				{
 					"--read-only",
-					"--volume", fmt.Sprintf("%s:/foo", mnt1),
+					"--volume", mnt1 + ":/foo",
 					"--mount", "type=volume,dst=/bar",
 				},
 			},
@@ -4282,7 +4282,7 @@ func (s *DockerCLIRunSuite) TestRunMount(c *testing.T) {
 					"--mount", fmt.Sprintf("type=bind,src=%s,target=/foo", mnt2),
 				},
 				{
-					"--volume", fmt.Sprintf("%s:/foo", mnt1),
+					"--volume", mnt1 + ":/foo",
 					"--mount", fmt.Sprintf("type=bind,src=%s,target=/foo", mnt2),
 				},
 			},
@@ -4291,7 +4291,7 @@ func (s *DockerCLIRunSuite) TestRunMount(c *testing.T) {
 		{
 			equivalents: [][]string{
 				{
-					"--volume", fmt.Sprintf("%s:/foo", mnt1),
+					"--volume", mnt1 + ":/foo",
 					"--mount", fmt.Sprintf("type=volume,src=%s,target=/foo", mnt2),
 				},
 			},
@@ -4358,7 +4358,7 @@ func (s *DockerCLIRunSuite) TestRunAddDeviceCgroupRule(c *testing.T) {
 		c.Fatalf("%s shouldn't been in the device.list", deviceRule)
 	}
 
-	out = cli.DockerCmd(c, "run", "--rm", fmt.Sprintf("--device-cgroup-rule=%s", deviceRule), "busybox", "grep", deviceRule, "/sys/fs/cgroup/devices/devices.list").Combined()
+	out = cli.DockerCmd(c, "run", "--rm", "--device-cgroup-rule="+deviceRule, "busybox", "grep", deviceRule, "/sys/fs/cgroup/devices/devices.list").Combined()
 	assert.Equal(c, strings.TrimSpace(out), deviceRule)
 }
 

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -79,13 +79,10 @@ func (s *DockerCLIVolumeSuite) TestVolumeCLIInspectMulti(c *testing.T) {
 }
 
 func (s *DockerCLIVolumeSuite) TestVolumeCLILs(c *testing.T) {
-	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
 	cli.DockerCmd(c, "volume", "create", "aaa")
-
 	cli.DockerCmd(c, "volume", "create", "test")
-
 	cli.DockerCmd(c, "volume", "create", "soo")
-	cli.DockerCmd(c, "run", "-v", "soo:"+prefix+"/foo", "busybox", "ls", "/")
+	cli.DockerCmd(c, "run", "-v", "soo:"+dPath("/foo"), "busybox", "ls", "/")
 
 	out := cli.DockerCmd(c, "volume", "ls", "-q").Stdout()
 	assertVolumesInList(c, out, []string{"aaa", "soo", "test"})
@@ -134,15 +131,14 @@ func assertVolumesInList(t *testing.T, out string, expected []string) {
 }
 
 func (s *DockerCLIVolumeSuite) TestVolumeCLILsFilterDangling(c *testing.T) {
-	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
 	cli.DockerCmd(c, "volume", "create", "testnotinuse1")
 	cli.DockerCmd(c, "volume", "create", "testisinuse1")
 	cli.DockerCmd(c, "volume", "create", "testisinuse2")
 
 	// Make sure both "created" (but not started), and started
 	// containers are included in reference counting
-	cli.DockerCmd(c, "run", "--name", "volume-test1", "-v", "testisinuse1:"+prefix+"/foo", "busybox", "true")
-	cli.DockerCmd(c, "create", "--name", "volume-test2", "-v", "testisinuse2:"+prefix+"/foo", "busybox", "true")
+	cli.DockerCmd(c, "run", "--name", "volume-test1", "-v", "testisinuse1:"+dPath("/foo"), "busybox", "true")
+	cli.DockerCmd(c, "create", "--name", "volume-test2", "-v", "testisinuse2:"+dPath("/foo"), "busybox", "true")
 
 	// No filter, all volumes should show
 	out := cli.DockerCmd(c, "volume", "ls").Stdout()
@@ -193,7 +189,6 @@ func (s *DockerCLIVolumeSuite) TestVolumeCLILsWithIncorrectFilterValue(c *testin
 }
 
 func (s *DockerCLIVolumeSuite) TestVolumeCLIRm(c *testing.T) {
-	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
 	id := cli.DockerCmd(c, "volume", "create").Stdout()
 	id = strings.TrimSpace(id)
 
@@ -202,7 +197,7 @@ func (s *DockerCLIVolumeSuite) TestVolumeCLIRm(c *testing.T) {
 	cli.DockerCmd(c, "volume", "rm", "test")
 
 	volumeID := "testing"
-	cli.DockerCmd(c, "run", "-v", volumeID+":"+prefix+"/foo", "--name=test", "busybox", "sh", "-c", "echo hello > /foo/bar")
+	cli.DockerCmd(c, "run", "-v", volumeID+":"+dPath("/foo"), "--name=test", "busybox", "sh", "-c", "echo hello > /foo/bar")
 
 	icmd.RunCommand(dockerBinary, "volume", "rm", "testing").Assert(c, icmd.Expected{
 		ExitCode: 1,
@@ -215,7 +210,7 @@ func (s *DockerCLIVolumeSuite) TestVolumeCLIRm(c *testing.T) {
 	cli.DockerCmd(c, "volume", "inspect", volumeID)
 	cli.DockerCmd(c, "rm", "-f", "test")
 
-	out = cli.DockerCmd(c, "run", "--name=test2", "-v", volumeID+":"+prefix+"/foo", "busybox", "sh", "-c", "cat /foo/bar").Combined()
+	out = cli.DockerCmd(c, "run", "--name=test2", "-v", volumeID+":"+dPath("/foo"), "busybox", "sh", "-c", "cat /foo/bar").Combined()
 	assert.Equal(c, strings.TrimSpace(out), "hello", "volume data was removed")
 	cli.DockerCmd(c, "rm", "test2")
 
@@ -393,8 +388,7 @@ func (s *DockerCLIVolumeSuite) TestVolumeCLIRmForceInUse(c *testing.T) {
 	id = strings.TrimSpace(id)
 	assert.Equal(c, id, name)
 
-	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
-	cid := cli.DockerCmd(c, "create", "-v", "testvolume:"+prefix+slash+"foo", "busybox").Stdout()
+	cid := cli.DockerCmd(c, "create", "-v", "testvolume:"+dPath("/foo"), "busybox").Stdout()
 	cid = strings.TrimSpace(cid)
 
 	_, _, err := dockerCmdWithError("volume", "rm", "-f", name)

--- a/integration-cli/utils_test.go
+++ b/integration-cli/utils_test.go
@@ -20,6 +20,15 @@ func getPrefixAndSlashFromDaemonPlatform() (prefix, slash string) {
 	return "", "/"
 }
 
+// dPath converts linux absolute paths to Windows absolute paths if the daemon
+// is running on Windows
+func dPath(path string) string {
+	if testEnv.DaemonInfo.OSType == "windows" {
+		return `c:` + strings.ReplaceAll(path, "/", `\`)
+	}
+	return path
+}
+
 // ParseCgroupPaths parses 'procCgroupData', which is output of '/proc/<pid>/cgroup', and returns
 // a map which cgroup name as key and path as value.
 func ParseCgroupPaths(procCgroupData string) map[string]string {

--- a/integration/container/remove_test.go
+++ b/integration/container/remove_test.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -16,11 +17,13 @@ import (
 	"gotest.tools/v3/skip"
 )
 
-func getPrefixAndSlashFromDaemonPlatform() (prefix, slash string) {
+// dPath converts linux absolute paths to Windows absolute paths if the daemon
+// is running on Windows
+func dPath(path string) string {
 	if testEnv.DaemonInfo.OSType == "windows" {
-		return "c:", `\`
+		return `c:` + strings.ReplaceAll(path, "/", `\`)
 	}
-	return "", "/"
+	return path
 }
 
 // Test case for #5244: `docker rm` fails if bind dir doesn't exist anymore
@@ -30,11 +33,9 @@ func TestRemoveContainerWithRemovedVolume(t *testing.T) {
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()
 
-	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
-
 	tempDir := fs.NewDir(t, "test-rm-container-with-removed-volume", fs.WithMode(0o755))
 
-	cID := container.Run(ctx, t, apiClient, container.WithCmd("true"), container.WithBind(tempDir.Path(), prefix+slash+"test"))
+	cID := container.Run(ctx, t, apiClient, container.WithCmd("true"), container.WithBind(tempDir.Path(), dPath("/test")))
 	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, containertypes.StateExited))
 
 	err := os.RemoveAll(tempDir.Path())
@@ -55,9 +56,7 @@ func TestRemoveContainerWithVolume(t *testing.T) {
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()
 
-	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
-
-	cID := container.Run(ctx, t, apiClient, container.WithVolume(prefix+slash+"srv"))
+	cID := container.Run(ctx, t, apiClient, container.WithVolume(dPath("/srv")))
 
 	inspect, err := apiClient.ContainerInspect(ctx, cID, client.ContainerInspectOptions{})
 	assert.NilError(t, err)


### PR DESCRIPTION
Implement a `dPath()` utility function that converts paths to Windows paths (add `c:` drive-letter, and convert to backslashes) if the daemon is running on Windows.

