### PR TITLE
[master] Ensure AppArmor and SELinux profiles are applied when building with BuildKit

### DIFF
--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -75,6 +75,7 @@ type Opt struct {
 	Rootless            bool
 	IdentityMapping     *idtools.IdentityMapping
 	DNSConfig           config.DNSConfig
+	ApparmorProfile     string
 }
 
 // Builder can build using BuildKit backend

--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -132,7 +132,7 @@ func newController(rt http.RoundTripper, opt Opt) (*control.Controller, error) {
 
 	dns := getDNSConfig(opt.DNSConfig)
 
-	exec, err := newExecutor(root, opt.DefaultCgroupParent, opt.NetworkController, dns, opt.Rootless, opt.IdentityMapping)
+	exec, err := newExecutor(root, opt.DefaultCgroupParent, opt.NetworkController, dns, opt.Rootless, opt.IdentityMapping, opt.ApparmorProfile)
 	if err != nil {
 		return nil, err
 	}

--- a/builder/builder-next/executor_unix.go
+++ b/builder/builder-next/executor_unix.go
@@ -25,7 +25,7 @@ import (
 
 const networkName = "bridge"
 
-func newExecutor(root, cgroupParent string, net libnetwork.NetworkController, dnsConfig *oci.DNSConfig, rootless bool, idmap *idtools.IdentityMapping) (executor.Executor, error) {
+func newExecutor(root, cgroupParent string, net libnetwork.NetworkController, dnsConfig *oci.DNSConfig, rootless bool, idmap *idtools.IdentityMapping, apparmorProfile string) (executor.Executor, error) {
 	netRoot := filepath.Join(root, "net")
 	networkProviders := map[pb.NetMode]network.Provider{
 		pb.NetMode_UNSET: &bridgeProvider{NetworkController: net, Root: netRoot},
@@ -52,6 +52,7 @@ func newExecutor(root, cgroupParent string, net libnetwork.NetworkController, dn
 		NoPivot:             os.Getenv("DOCKER_RAMDISK") != "",
 		IdentityMapping:     idmap,
 		DNS:                 dnsConfig,
+		ApparmorProfile:     apparmorProfile,
 	}, networkProviders)
 }
 

--- a/builder/builder-next/executor_windows.go
+++ b/builder/builder-next/executor_windows.go
@@ -11,7 +11,7 @@ import (
 	"github.com/moby/buildkit/executor/oci"
 )
 
-func newExecutor(_, _ string, _ libnetwork.NetworkController, _ *oci.DNSConfig, _ bool, _ *idtools.IdentityMapping) (executor.Executor, error) {
+func newExecutor(_, _ string, _ libnetwork.NetworkController, _ *oci.DNSConfig, _ bool, _ *idtools.IdentityMapping, _ string) (executor.Executor, error) {
 	return &winExecutor{}, nil
 }
 

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -297,6 +297,7 @@ func newRouterOptions(config *config.Config, d *daemon.Daemon) (routerOptions, e
 		Rootless:            d.Rootless(),
 		IdentityMapping:     d.IdentityMapping(),
 		DNSConfig:           config.DNSConfig,
+		ApparmorProfile:     daemon.DefaultApparmorProfile(),
 	})
 	if err != nil {
 		return opts, err

--- a/daemon/apparmor_default.go
+++ b/daemon/apparmor_default.go
@@ -15,6 +15,14 @@ const (
 	defaultAppArmorProfile    = "docker-default"
 )
 
+// DefaultApparmorProfile returns the name of the default apparmor profile
+func DefaultApparmorProfile() string {
+	if apparmor.IsEnabled() {
+		return defaultAppArmorProfile
+	}
+	return ""
+}
+
 func ensureDefaultAppArmorProfile() error {
 	if apparmor.IsEnabled() {
 		loaded, err := aaprofile.IsLoaded(defaultAppArmorProfile)

--- a/daemon/apparmor_default_unsupported.go
+++ b/daemon/apparmor_default_unsupported.go
@@ -5,3 +5,8 @@ package daemon // import "github.com/docker/docker/daemon"
 func ensureDefaultAppArmorProfile() error {
 	return nil
 }
+
+// DefaultApparmorProfile returns an empty string.
+func DefaultApparmorProfile() string {
+	return ""
+}

--- a/vendor.conf
+++ b/vendor.conf
@@ -33,7 +33,7 @@ github.com/imdario/mergo                            1afb36080aec31e0d1528973ebe6
 golang.org/x/sync                                   cd5d95a43a6e21273425c7ae415d3df9ea832eeb
 
 # buildkit
-github.com/moby/buildkit                            8142d66b5ebde79846b869fba30d9d30633e74aa # v0.8.1
+github.com/moby/buildkit                            68bb095353c65bc3993fd534c26cf77fe05e61b1 # v0.8 branch
 github.com/tonistiigi/fsutil                        0834f99b7b85462efb69b4f571a4fa3ca7da5ac9
 github.com/tonistiigi/units                         6950e57a87eaf136bbe44ef2ec8e75b9e3569de2
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746

--- a/vendor/github.com/moby/buildkit/cmd/buildkitd/config/config.go
+++ b/vendor/github.com/moby/buildkit/cmd/buildkitd/config/config.go
@@ -87,6 +87,10 @@ type OCIConfig struct {
 	// Decoding this is delayed in order to remove the dependency from this
 	// config pkg to stargz snapshotter's config pkg.
 	StargzSnapshotterConfig toml.Primitive `toml:"stargzSnapshotter"`
+
+	// ApparmorProfile is the name of the apparmor profile that should be used to constrain build containers.
+	// The profile should already be loaded (by a higher level system) before creating a worker.
+	ApparmorProfile string `toml:"apparmor-profile"`
 }
 
 type ContainerdConfig struct {
@@ -98,6 +102,10 @@ type ContainerdConfig struct {
 	GCConfig
 	NetworkConfig
 	Snapshotter string `toml:"snapshotter"`
+
+	// ApparmorProfile is the name of the apparmor profile that should be used to constrain build containers.
+	// The profile should already be loaded (by a higher level system) before creating a worker.
+	ApparmorProfile string `toml:"apparmor-profile"`
 }
 
 type GCPolicy struct {

--- a/vendor/github.com/moby/buildkit/executor/oci/spec_windows.go
+++ b/vendor/github.com/moby/buildkit/executor/oci/spec_windows.go
@@ -14,7 +14,7 @@ func generateMountOpts(resolvConf, hostsFile string) ([]oci.SpecOpts, error) {
 }
 
 // generateSecurityOpts may affect mounts, so must be called after generateMountOpts
-func generateSecurityOpts(mode pb.SecurityMode) ([]oci.SpecOpts, error) {
+func generateSecurityOpts(mode pb.SecurityMode, apparmorProfile string) ([]oci.SpecOpts, error) {
 	if mode == pb.SecurityMode_INSECURE {
 		return nil, errors.New("no support for running in insecure mode on Windows")
 	}

--- a/vendor/github.com/moby/buildkit/go.mod
+++ b/vendor/github.com/moby/buildkit/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.1
 	github.com/opencontainers/runc v1.0.0-rc92
 	github.com/opencontainers/runtime-spec v1.0.3-0.20200728170252-4d89ac9fbff6
+	github.com/opencontainers/selinux v1.8.0
 	github.com/opentracing-contrib/go-stdlib v1.0.0
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pkg/errors v0.9.1


### PR DESCRIPTION
These changes are already included in the [v20.10.3](https://github.com/moby/moby/releases/tag/v20.10.3) and [v19.03.15](https://github.com/moby/moby/releases/tag/v19.03.15) security releases, and this PR forwards those changes to the master branch

```
git cherry-pick -s -S -x 4afe620 611eb6f
```

Second commit did not apply cleanly, because https://github.com/moby/moby/commit/7c7e1689021afdd3775eecdd1e60ad8c0cc44678 (https://github.com/moby/moby/pull/41863) was merged on master, and is not yet in the 20.10 branch

```patch
diff --cc builder/builder-next/executor_unix.go
index 29c9787798,cefbb8a56f..0000000000
--- a/builder/builder-next/executor_unix.go
+++ b/builder/builder-next/executor_unix.go
@@@ -25,10 -24,9 +25,14 @@@ import

  const networkName = "bridge"

++<<<<<<< HEAD
 +func newExecutor(root, cgroupParent string, net libnetwork.NetworkController, dnsConfig *oci.DNSConfig, rootless bool, idmap *idtools.IdentityMapping) (executor.Executor, error) {
 +      netRoot := filepath.Join(root, "net")
++=======
+ func newExecutor(root, cgroupParent string, net libnetwork.NetworkController, dnsConfig *oci.DNSConfig, rootless bool, idmap *idtools.IdentityMapping, apparmorProfile string) (executor.Executor, error) {
++>>>>>>> 611eb6ffb3 (buildkit: Apply apparmor profile)
        networkProviders := map[pb.NetMode]network.Provider{
 -              pb.NetMode_UNSET: &bridgeProvider{NetworkController: net, Root: filepath.Join(root, "net")},
 +              pb.NetMode_UNSET: &bridgeProvider{NetworkController: net, Root: netRoot},
                pb.NetMode_HOST:  network.NewHostProvider(),
                pb.NetMode_NONE:  network.NewNoneProvider(),
        }
```
