### PR TITLE
[master] prevent an invalid image from crashing docker daemon (CVE-2021-21285)

### DIFF
--- a/builder/builder-next/adapters/containerimage/pull.go
+++ b/builder/builder-next/adapters/containerimage/pull.go
@@ -524,6 +524,9 @@ func (p *puller) Snapshot(ctx context.Context, g session.Group) (cache.Immutable
 	layers := make([]xfer.DownloadDescriptor, 0, len(mfst.Layers))
 
 	for i, desc := range mfst.Layers {
+		if err := desc.Digest.Validate(); err != nil {
+			return nil, errors.Wrap(err, "layer digest could not be validated")
+		}
 		ongoing.add(desc)
 		layers = append(layers, &layerDescriptor{
 			desc:    desc,

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -528,6 +528,9 @@ func (p *v2Puller) pullSchema1(ctx context.Context, ref reference.Reference, unv
 	// to top-most, so that the downloads slice gets ordered correctly.
 	for i := len(verifiedManifest.FSLayers) - 1; i >= 0; i-- {
 		blobSum := verifiedManifest.FSLayers[i].BlobSum
+		if err = blobSum.Validate(); err != nil {
+			return "", "", errors.Wrapf(err, "could not validate layer digest %q", blobSum)
+		}
 
 		var throwAway struct {
 			ThrowAway bool `json:"throwaway,omitempty"`
@@ -626,6 +629,9 @@ func (p *v2Puller) pullSchema2Layers(ctx context.Context, target distribution.De
 	// Note that the order of this loop is in the direction of bottom-most
 	// to top-most, so that the downloads slice gets ordered correctly.
 	for _, d := range layers {
+		if err := d.Digest.Validate(); err != nil {
+			return "", errors.Wrapf(err, "could not validate layer digest %q", d.Digest)
+		}
 		layerDescriptor := &v2LayerDescriptor{
 			digest:            d.Digest,
 			repo:              p.repo,


### PR DESCRIPTION
This forward-ports the changes related to [CVE-2021-21285](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-21285) (Advisory: https://github.com/moby/moby/security/advisories/GHSA-6fj5-m822-rqx8).

These changes are already included in the [v20.10.3](https://github.com/moby/moby/releases/tag/v20.10.3) and [v19.03.15](https://github.com/moby/moby/releases/tag/v19.03.15) security releases, and this PR forwards those changes to the master branch

cherry-pick was clean

```
git cherry-pick -s -S -x a7d4af8
```
