### PR TITLE
[20.10 backport] backport various testing fixes

### DIFF
--- a/Dockerfile.buildx
+++ b/Dockerfile.buildx
@@ -1,5 +1,5 @@
 ARG GO_VERSION=1.13.15
-ARG BUILDX_COMMIT=v0.3.1
+ARG BUILDX_COMMIT=v0.5.1
 ARG BUILDX_REPO=https://github.com/docker/buildx.git
 
 FROM golang:${GO_VERSION}-buster AS build

--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -7,7 +7,7 @@ source hack/make/.integration-test-helpers
 # TODO docker 17.06 cli client used in CI fails to build using a sha;
 # unable to prepare context: unable to 'git clone' to temporary context directory: error fetching: error: no such remote ref ead0bb9e08c13dd3d1712759491eee06bf5a5602
 #: exit status 128
-: "${DOCKER_PY_COMMIT:=4.3.0}"
+: "${DOCKER_PY_COMMIT:=4.4.1}"
 
 # custom options to pass py.test
 #

--- a/integration/build/build_userns_linux_test.go
+++ b/integration/build/build_userns_linux_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/testutil/daemon"
 	"github.com/docker/docker/testutil/fakecontext"
@@ -66,17 +67,10 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 		})
 	assert.NilError(t, err)
 	defer resp.Body.Close()
-	buf := make([]byte, 1024)
-	for {
-		n, err := resp.Body.Read(buf)
-		if err != nil && err != io.EOF {
-			t.Fatalf("Error reading ImageBuild response: %v", err)
-			break
-		}
-		if n == 0 {
-			break
-		}
-	}
+
+	buf := bytes.NewBuffer(nil)
+	err = jsonmessage.DisplayJSONMessagesStream(resp.Body, buf, 0, false, nil)
+	assert.NilError(t, err)
 
 	reader, err := clientUserRemap.ImageSave(ctx, []string{imageTag})
 	assert.NilError(t, err, "failed to download capabilities image")
@@ -106,16 +100,9 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 	loadResp, err := clientNoUserRemap.ImageLoad(ctx, tarReader, false)
 	assert.NilError(t, err, "failed to load image tar file")
 	defer loadResp.Body.Close()
-	for {
-		n, err := loadResp.Body.Read(buf)
-		if err != nil && err != io.EOF {
-			t.Fatalf("Error reading ImageLoad response: %v", err)
-			break
-		}
-		if n == 0 {
-			break
-		}
-	}
+	buf = bytes.NewBuffer(nil)
+	err = jsonmessage.DisplayJSONMessagesStream(loadResp.Body, buf, 0, false, nil)
+	assert.NilError(t, err)
 
 	cid := container.Run(ctx, t, clientNoUserRemap,
 		container.WithImage(imageTag),

--- a/integration/build/build_userns_linux_test.go
+++ b/integration/build/build_userns_linux_test.go
@@ -41,7 +41,7 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 	ctx := context.Background()
 	clientUserRemap := dUserRemap.NewClientT(t)
 
-	err = load.FrozenImagesLinux(clientUserRemap, "buildpack-deps:buster")
+	err = load.FrozenImagesLinux(clientUserRemap, "debian:bullseye")
 	assert.NilError(t, err)
 
 	dUserRemapRunning := true

--- a/integration/build/build_userns_linux_test.go
+++ b/integration/build/build_userns_linux_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/testutil/daemon"
 	"github.com/docker/docker/testutil/fakecontext"
+	"github.com/docker/docker/testutil/fixtures/load"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/skip"
 )
@@ -36,7 +37,13 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 	defer os.RemoveAll(tmp)
 
 	dUserRemap := daemon.New(t)
-	dUserRemap.StartWithBusybox(t, "--userns-remap", "default")
+	dUserRemap.Start(t, "--userns-remap", "default")
+	ctx := context.Background()
+	clientUserRemap := dUserRemap.NewClientT(t)
+
+	err = load.FrozenImagesLinux(clientUserRemap, "buildpack-deps:buster")
+	assert.NilError(t, err)
+
 	dUserRemapRunning := true
 	defer func() {
 		if dUserRemapRunning {
@@ -49,11 +56,9 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 		RUN setcap CAP_NET_BIND_SERVICE=+eip /bin/sleep
 	`
 
-	ctx := context.Background()
 	source := fakecontext.New(t, "", fakecontext.WithDockerfile(dockerfile))
 	defer source.Close()
 
-	clientUserRemap := dUserRemap.NewClientT(t)
 	resp, err := clientUserRemap.ImageBuild(ctx,
 		source.AsTarReader(t),
 		types.ImageBuildOptions{
@@ -89,7 +94,7 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 	dUserRemapRunning = false
 
 	dNoUserRemap := daemon.New(t)
-	dNoUserRemap.StartWithBusybox(t)
+	dNoUserRemap.Start(t)
 	defer dNoUserRemap.Stop(t)
 
 	clientNoUserRemap := dNoUserRemap.NewClientT(t)

--- a/integration/container/daemon_linux_test.go
+++ b/integration/container/daemon_linux_test.go
@@ -193,7 +193,7 @@ func TestRestartDaemonWithRestartingContainer(t *testing.T) {
 	defer d.Cleanup(t)
 
 	d.StartWithBusybox(t, "--iptables=false")
-	defer d.Kill()
+	defer d.Stop(t)
 
 	ctx := context.Background()
 	client := d.NewClientT(t)
@@ -203,8 +203,7 @@ func TestRestartDaemonWithRestartingContainer(t *testing.T) {
 	// We will manipulate the on disk state later
 	id := container.Create(ctx, t, client, container.WithRestartPolicy("always"), container.WithCmd("/bin/sh", "-c", "exit 1"))
 
-	// SIGKILL the daemon
-	assert.NilError(t, d.Kill())
+	d.Stop(t)
 
 	configPath := filepath.Join(d.Root, "containers", id, "config.v2.json")
 	configBytes, err := ioutil.ReadFile(configPath)


### PR DESCRIPTION
Backports:

- https://github.com/moby/moby/pull/41855 Make test work with rootless mode
- https://github.com/moby/moby/pull/41865 integration: fix TestBuildUserNamespaceValidateCapabilitiesAreV2 not using frozen image
- https://github.com/moby/moby/pull/41709 testing: update docker-py 4.4.1
- https://github.com/moby/moby/pull/41932 Dockerfile.buildx: update buildx to v0.5.1
- https://github.com/moby/moby/pull/41936 [testing] fix TestBuildUserNamespaceValidateCapabilitiesAreV2 failures


```bash
# https://github.com/moby/moby/pull/41855 Make test work with rootless mode
git cherry-pick -s -S -x e6591a9c7abf8bfef8e8c4f1f560c13acf342f4a

# https://github.com/moby/moby/pull/41865 integration: fix TestBuildUserNamespaceValidateCapabilitiesAreV2 not using frozen image
git cherry-pick -s -S -x 46dfc313421a2f59a82343d8b812de799b3a0251

# https://github.com/moby/moby/pull/41709 testing: update docker-py 4.4.1
git cherry-pick -s -S -x 14fb1650856f52928cb9f9fd3b495c3e14776069

# https://github.com/moby/moby/pull/41932 Dockerfile.buildx: update buildx to v0.5.1
git cherry-pick -s -S -x 30b20a6bdd6ea3439da9b44bd15e34f679530fbe

# https://github.com/moby/moby/pull/41936 [testing] fix TestBuildUserNamespaceValidateCapabilitiesAreV2 failures
git cherry-pick -s -S -x 26965fbfa0e68d7dee49406b21fc0b8e01994205 fa480403c75c90880a6bc79bab9e10b012379006
```