### PR TITLE
archive: avoid creating parent dirs for XGlobalHeader

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -931,6 +931,12 @@ loop:
 			return err
 		}
 
+		// ignore XGlobalHeader early to avoid creating parent directories for them
+		if hdr.Typeflag == tar.TypeXGlobalHeader {
+			logrus.Debugf("PAX Global Extended Headers found for %s and ignored", hdr.Name)
+			continue
+		}
+
 		// Normalize name, for safety and for a simple is-root check
 		// This keeps "../" as-is, but normalizes "/../" to "/". Or Windows:
 		// This keeps "..\" as-is, but normalizes "\..\" to "\".


### PR DESCRIPTION
fixes #41978 (the part about created `tmp` dir, not 777 permissions)

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
