### PR TITLE
WIP: Fix permissions for newly created dirs in ADD

### DIFF
--- a/pkg/idtools/idtools_unix.go
+++ b/pkg/idtools/idtools_unix.go
@@ -71,7 +71,7 @@ func mkdirAs(path string, mode os.FileMode, owner Identity, mkAll, chownExisting
 	// even if it existed, we will chown the requested path + any subpaths that
 	// didn't exist when we called MkdirAll
 	for _, pathComponent := range paths {
-		if err := setPermissions(pathComponent, mode, owner.UID, owner.GID, nil); err != nil {
+		if err := setPermissions(pathComponent, 0, owner.UID, owner.GID, nil); err != nil {
 			return err
 		}
 	}
@@ -225,7 +225,7 @@ func setPermissions(p string, mode os.FileMode, uid, gid int, stat *system.StatT
 			return err
 		}
 	}
-	if os.FileMode(stat.Mode()).Perm() != mode.Perm() {
+	if os.FileMode(0) != mode && os.FileMode(stat.Mode()).Perm() != mode.Perm() {
 		if err := os.Chmod(p, mode.Perm()); err != nil {
 			return err
 		}


### PR DESCRIPTION
edb62a3ace8c4303822a391b38231e577f8c2ee8 made it so permissions are set
for existing dirs, it also inadvertantly made it so `Chmod` is called
against (previously) non-existing dirs.
This had a side-effect that dir permissions are different than in
previous version of Docker when using `ADD` to add a tarball during
`docker build` (There may be other cases of this).

This makes it so we don't set perms for paths that we created as part of
`MkdirAll` since the perms should already be the ones we expect.


---
Related to #41978

I don't understand what's happening here.
Why is it different? Why does the dir created with prior to calling `chmod` have 0755 permissions even though the caller passed in 0777?