### PR TITLE
Fix for lack of synchronization in daemon/update.go

### DIFF
--- a/daemon/update.go
+++ b/daemon/update.go
@@ -42,20 +42,25 @@ func (daemon *Daemon) update(name string, hostConfig *container.HostConfig) erro
 
 	restoreConfig := false
 	backupHostConfig := *ctr.HostConfig
+
 	defer func() {
 		if restoreConfig {
 			ctr.Lock()
-			ctr.HostConfig = &backupHostConfig
-			ctr.CheckpointTo(daemon.containersReplica)
+			if !ctr.RemovalInProgress && !ctr.Dead {
+				ctr.HostConfig = &backupHostConfig
+				ctr.CheckpointTo(daemon.containersReplica)
+			}
 			ctr.Unlock()
 		}
 	}()
 
+	ctr.Lock()
+
 	if ctr.RemovalInProgress || ctr.Dead {
+		ctr.Unlock()
 		return errCannotUpdate(ctr.ID, fmt.Errorf("container is marked for removal and cannot be \"update\""))
 	}
 
-	ctr.Lock()
 	if err := ctr.UpdateContainer(hostConfig); err != nil {
 		restoreConfig = true
 		ctr.Unlock()
@@ -66,6 +71,7 @@ func (daemon *Daemon) update(name string, hostConfig *container.HostConfig) erro
 		ctr.Unlock()
 		return errCannotUpdate(ctr.ID, err)
 	}
+
 	ctr.Unlock()
 
 	// if Restart Policy changed, we need to update container monitor


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/41988

Signed-off-by: dmytro.iakovliev <dmytro.iakovliev@zodiacsystems.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Reordered operations to fix race.

**- How I did it**

The container state checking has been placed between container.Lock() and container.Unlock(). Added container state checking into the defer handler.

**- How to verify it**

See script to reproduce failing conditions in https://github.com/moby/moby/issues/41988.

**- Description for the changelog**

Fix for lack of syncronization in daemon/update.go.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
