### PR TITLE
[20.10 backport] Dockerfile.simple: Fix compile docker binary error with btrfs

### DIFF
--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -18,13 +18,13 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#build-dependencies
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		btrfs-tools \
 		build-essential \
 		curl \
 		cmake \
 		gcc \
 		git \
 		libapparmor-dev \
+		libbtrfs-dev \
 		libdevmapper-dev \
 		libseccomp-dev \
 		ca-certificates \


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/41995

Use the image build from Dockerfile.simple to build docker binary failed
with not find <brtfs/ioctl.h>, we need to install libbtrfs-dev to fix this.
```
Building: bundles/dynbinary-daemon/dockerd-dev
GOOS="" GOARCH="" GOARM=""
.gopath/src/github.com/docker/docker/daemon/graphdriver/btrfs/btrfs.go:8:10: fatal error: btrfs/ioctl.h: No such file or directory
 #include <btrfs/ioctl.h>

```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

