### PR TITLE
[19.03 backport] Update containerd v1.4.4, runc v1.0.0-rc93

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=7fb6e171309113ddcb8ea9599e34321550469250}" # v1.3.8
+: "${CONTAINERD_COMMIT:=8fba4e9a7d01810a393d5d25a3621dc101981175}" # v1.3.7
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=c623d1b36f09f8ef6536a057bd658b3aa8632828}" # v1.4.1
+: "${CONTAINERD_COMMIT:=b321d358e6eef9c82fa3f3bb8826dca3724c58c6}" # v1.4.2
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=269548fa27e0089a8b8278fc4fc781d7f65a939b}" # v1.4.3
+: "${CONTAINERD_COMMIT:=05f951a3781f4f2c1911b05e61c160e9c30eaa8e}" # v1.4.4
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=8fba4e9a7d01810a393d5d25a3621dc101981175}" # v1.3.7
+: "${CONTAINERD_COMMIT:=09814d48d50816305a8e6c1a4ae3e2bcc4ba725a}" # v1.4.0
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=09814d48d50816305a8e6c1a4ae3e2bcc4ba725a}" # v1.4.0
+: "${CONTAINERD_COMMIT:=c623d1b36f09f8ef6536a057bd658b3aa8632828}" # v1.4.1
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=ea765aba0d05254012b0b9e595e995c09186427f}" # v1.3.9
+: "${CONTAINERD_COMMIT:=7fb6e171309113ddcb8ea9599e34321550469250}" # v1.3.8
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=b321d358e6eef9c82fa3f3bb8826dca3724c58c6}" # v1.4.2
+: "${CONTAINERD_COMMIT:=269548fa27e0089a8b8278fc4fc781d7f65a939b}" # v1.4.3
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -4,7 +4,7 @@
 # The version of runc should match the version that is used by the containerd
 # version that is used. If you need to update runc, open a pull request in
 # the containerd project first, and update both after that is merged.
-: ${RUNC_COMMIT:=ff819c7e9184c13b7c2607fe6c30ae19403a7aff} # v1.0.0-rc92
+: ${RUNC_COMMIT:=12644e614e25b05da6fd08a38ffa0cfe1903fdec} # v1.0.0-rc93
 
 install_runc() {
 	# If using RHEL7 kernels (3.10.0 el7), disable kmem accounting/limiting
@@ -13,7 +13,7 @@ install_runc() {
 	fi
 
 	# Do not build with ambient capabilities support
-	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp apparmor selinux $RUNC_NOKMEM"}"
+	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp $RUNC_NOKMEM"}"
 
 	echo "Install runc version $RUNC_COMMIT (build tags: $RUNC_BUILDTAGS)"
 	git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc"

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -4,7 +4,7 @@
 # The version of runc should match the version that is used by the containerd
 # version that is used. If you need to update runc, open a pull request in
 # the containerd project first, and update both after that is merged.
-: ${RUNC_COMMIT:=dc9208a3303feef5b3839f4323d9beb36df0a9dd} # v1.0.0-rc10
+: ${RUNC_COMMIT:=24a3cf88a7ae5f4995f6750654c0e2ca61ef4bb2} # v1.0.0-rc91
 
 install_runc() {
 	# If using RHEL7 kernels (3.10.0 el7), disable kmem accounting/limiting

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -4,7 +4,7 @@
 # The version of runc should match the version that is used by the containerd
 # version that is used. If you need to update runc, open a pull request in
 # the containerd project first, and update both after that is merged.
-: ${RUNC_COMMIT:=24a3cf88a7ae5f4995f6750654c0e2ca61ef4bb2} # v1.0.0-rc91
+: ${RUNC_COMMIT:=ff819c7e9184c13b7c2607fe6c30ae19403a7aff} # v1.0.0-rc92
 
 install_runc() {
 	# If using RHEL7 kernels (3.10.0 el7), disable kmem accounting/limiting


### PR DESCRIPTION
So that the static binaries will have the same version of containerd as will be
installed when installing deb/rpm packages. Containerd 1.3 is also reaching EOL
in a few days.

Not sure we'll do this, so opening as draft

- revert https://github.com/moby/moby/pull/41731 [19.03] update containerd binary to v1.3.9 (address CVE-2020-15257)
- https://github.com/moby/moby/pull/40982 update containerd binary to v1.4.0
- https://github.com/moby/moby/pull/41450 update containerd vendor and binary to v1.4.1 (only binary)
- https://github.com/moby/moby/pull/41718 update containerd binary to v1.4.2
- https://github.com/moby/moby/pull/41732 update containerd binary to v1.4.3 (CVE-2020-15257)
- https://github.com/moby/moby/pull/41025 update runc binary to v1.0.0-rc91
- https://github.com/moby/moby/pull/41317 Update runc binary to v1.0.0-rc92
- https://github.com/moby/moby/pull/41994 Bump runc binary v1.0.0-rc93
- https://github.com/moby/moby/pull/42121 update containerd binary to v1.4.4


```
# revert https://github.com/moby/moby/pull/41731 [19.03] update containerd binary to v1.3.9 (address CVE-2020-15257)
git revert -s -S d3c550633005b8533683c7b9119625241d7cd55b 1babdf81e764c63a53c99dddaf08a9953ae2da16

# https://github.com/moby/moby/pull/40982 update containerd binary to v1.4.0
git cherry-pick -s -S -x 15292d7abfde0d934e4d30d8b19ca1ffb6d8d391

# https://github.com/moby/moby/pull/41450 update containerd vendor and binary to v1.4.1 (only binary)
git cherry-pick -s -S -x 1371a629d53a7c3639f1b12522a3a4021f5644b8

# https://github.com/moby/moby/pull/41718 update containerd binary to v1.4.2
git cherry-pick -s -S -x 703951197c3338631ee0529dd9dd814d16f037f0

# https://github.com/moby/moby/pull/41732 update containerd binary to v1.4.3 (CVE-2020-15257)
git cherry-pick -s -S -x 0a8c7692683cdaa14dc69c26155ec3d3751dbd11

# https://github.com/moby/moby/pull/41025 update runc binary to v1.0.0-rc91
git cherry-pick -s -S -x 91ca3e7a8dbc161b99ddf82c61812e7123865ed8

# https://github.com/moby/moby/pull/41317 Update runc binary to v1.0.0-rc92
git cherry-pick -s -S -x 2c7b48decda3335d96301285d25553d589e84801

# https://github.com/moby/moby/pull/41994 Bump runc binary v1.0.0-rc93
git cherry-pick -s -S -x 28e5a3c5a4db5d413d0834f432e8bebde62b0d74

# https://github.com/moby/moby/pull/42121 update containerd binary to v1.4.4
git cherry-pick -s -S -x 1a493934033919b91c4e471638ac1a8bbc5792c5
```