### PR TITLE
pkg/archive: Unpack() use 0755 permissions for missing directories

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -956,7 +956,7 @@ loop:
 			parent := filepath.Dir(hdr.Name)
 			parentPath := filepath.Join(dest, parent)
 			if _, err := os.Lstat(parentPath); err != nil && os.IsNotExist(err) {
-				err = idtools.MkdirAllAndChownNew(parentPath, 0777, rootIDs)
+				err = idtools.MkdirAllAndChownNew(parentPath, 0755, rootIDs)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
together with https://github.com/moby/moby/pull/41984, this fixes https://github.com/moby/moby/issues/41978 If I create a compressed tar ball with etc/password in it
replaces/closes https://github.com/moby/moby/pull/41990


Commit edb62a3ace8c4303822a391b38231e577f8c2ee8 / https://github.com/moby/moby/pull/35541 fixed a bug in `MkdirAllAndChown()` that caused the specified permissions to not be applied correctly. As a result of that bug, the configured umask would be applied.

When extracting archives, `Unpack()` used `0777` permissions when creating missing parent directories for files that were extracted. Before edb62a3ace8c4303822a391b38231e577f8c2ee8, this resulted in actual permissions of the directories to be `0755` on most configurations (using a default `022` umask).

Creating these directories should not depend on the host's umask configuration. This patch changes the permissions to `0755` to match the previous behavior, and to reflect the original intent of using `0755` as default.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
Fix permissions for newly created dirs in ADD
```


**- A picture of a cute animal (not mandatory but encouraged)**

