### PR TITLE
[20.10 backport]: avoid creating parent dirs for XGlobalHeader, and fix permissions

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -917,6 +917,12 @@ loop:
 			return err
 		}
 
+		// ignore XGlobalHeader early to avoid creating parent directories for them
+		if hdr.Typeflag == tar.TypeXGlobalHeader {
+			logrus.Debugf("PAX Global Extended Headers found for %s and ignored", hdr.Name)
+			continue
+		}
+
 		// Normalize name, for safety and for a simple is-root check
 		// This keeps "../" as-is, but normalizes "/../" to "/". Or Windows:
 		// This keeps "..\" as-is, but normalizes "\..\" to "\".

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -942,7 +942,7 @@ loop:
 			parent := filepath.Dir(hdr.Name)
 			parentPath := filepath.Join(dest, parent)
 			if _, err := os.Lstat(parentPath); err != nil && os.IsNotExist(err) {
-				err = idtools.MkdirAllAndChownNew(parentPath, 0777, rootIDs)
+				err = idtools.MkdirAllAndChownNew(parentPath, 0755, rootIDs)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/41978

backport of:

- https://github.com/moby/moby/pull/41984 archive: avoid creating parent dirs for XGlobalHeader
- https://github.com/moby/moby/pull/42016 pkg/archive: Unpack() use 0755 permissions for missing directories

