### PR TITLE
Prevent Docker Hub credentials from being sent to registry mirrors

### DIFF
--- a/daemon/images/image_pull.go
+++ b/daemon/images/image_pull.go
@@ -139,7 +139,12 @@ func (i *ImageService) GetRepository(ctx context.Context, ref reference.Named, a
 			continue
 		}
 
-		repository, confirmedV2, lastError = distribution.NewV2Repository(ctx, repoInfo, endpoint, nil, authConfig, "pull")
+		endpointAuthConfig := authConfig
+		if endpoint.Mirror {
+			endpointAuthConfig = &types.AuthConfig{}
+		}
+
+		repository, confirmedV2, lastError = distribution.NewV2Repository(ctx, repoInfo, endpoint, nil, endpointAuthConfig, "pull")
 		if lastError == nil && confirmedV2 {
 			break
 		}

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/pkg/progress"
 	refstore "github.com/docker/docker/reference"
@@ -105,9 +106,14 @@ func Pull(ctx context.Context, ref reference.Named, imagePullConfig *ImagePullCo
 			}
 		}
 
+		endpointImagePullConfig := *imagePullConfig
+		if endpoint.Mirror {
+			endpointImagePullConfig.AuthConfig = &types.AuthConfig{}
+		}
+
 		logrus.Debugf("Trying to pull %s from %s %s", reference.FamiliarName(repoInfo.Name), endpoint.URL, endpoint.Version)
 
-		puller, err := newPuller(endpoint, repoInfo, imagePullConfig, local)
+		puller, err := newPuller(endpoint, repoInfo, &endpointImagePullConfig, local)
 		if err != nil {
 			lastErr = err
 			continue


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Fixes #42022

**- What I did**
I prevented that requests going to registry mirrors would contain Docker Hub credentials.

**- How I did it**
I've replaced the AuthConfig instances with a zero-value object on endpoints that were marked as mirrors.

**- How to verify it**
I set the same environment as specified on #42022 and the result this time was the expected. No credentials were sent to the mirror even though I was logged into Docker Hub.

![image](https://user-images.githubusercontent.com/7753096/107858680-15dae380-6e14-11eb-8df1-7e0c82ab3101.png)

Additionally, I've pulled a private image that was only accessible by using my Docker Hub credentials and it also worked. The mirror returned that it couldn't find the image and the fallback to Docker Hub was authenticated, pulling the image successfully.

![image](https://user-images.githubusercontent.com/7753096/107858702-4884dc00-6e14-11eb-8785-626a94ac8943.png)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Registry Mirrors don't receive Docker Hub credentials anymore.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/7753096/107858650-e2985480-6e13-11eb-92a8-9590bde4e474.png)