### PR TITLE
Fix grammar in client function comments

### DIFF
--- a/client/build_cancel.go
+++ b/client/build_cancel.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 )
 
-// BuildCancel requests the daemon to cancel ongoing build request
+// BuildCancel requests the daemon to cancel the ongoing build request.
 func (cli *Client) BuildCancel(ctx context.Context, id string) error {
 	query := url.Values{}
 	query.Set("id", id)

--- a/client/config_create.go
+++ b/client/config_create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 )
 
-// ConfigCreate creates a new Config.
+// ConfigCreate creates a new config.
 func (cli *Client) ConfigCreate(ctx context.Context, config swarm.ConfigSpec) (types.ConfigCreateResponse, error) {
 	var response types.ConfigCreateResponse
 	if err := cli.NewVersionError("1.30", "config create"); err != nil {

--- a/client/config_remove.go
+++ b/client/config_remove.go
@@ -2,7 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import "context"
 
-// ConfigRemove removes a Config.
+// ConfigRemove removes a config.
 func (cli *Client) ConfigRemove(ctx context.Context, id string) error {
 	if err := cli.NewVersionError("1.30", "config remove"); err != nil {
 		return err

--- a/client/config_update.go
+++ b/client/config_update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 )
 
-// ConfigUpdate attempts to update a Config
+// ConfigUpdate attempts to update a config
 func (cli *Client) ConfigUpdate(ctx context.Context, id string, version swarm.Version, config swarm.ConfigSpec) error {
 	if err := cli.NewVersionError("1.30", "config update"); err != nil {
 		return err

--- a/client/container_commit.go
+++ b/client/container_commit.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
-// ContainerCommit applies changes into a container and creates a new tagged image.
+// ContainerCommit applies changes to a container and creates a new tagged image.
 func (cli *Client) ContainerCommit(ctx context.Context, container string, options types.ContainerCommitOptions) (types.IDResponse, error) {
 	var repository, tag string
 	if options.Reference != "" {

--- a/client/container_copy.go
+++ b/client/container_copy.go
@@ -14,7 +14,7 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
-// ContainerStatPath returns Stat information about a path inside the container filesystem.
+// ContainerStatPath returns stat information about a path inside the container filesystem.
 func (cli *Client) ContainerStatPath(ctx context.Context, containerID, path string) (types.ContainerPathStat, error) {
 	query := url.Values{}
 	query.Set("path", filepath.ToSlash(path)) // Normalize the paths used in the API.

--- a/client/container_create.go
+++ b/client/container_create.go
@@ -19,7 +19,7 @@ type configWrapper struct {
 	Platform         *specs.Platform
 }
 
-// ContainerCreate creates a new container based in the given configuration.
+// ContainerCreate creates a new container based on the given configuration.
 // It can be associated with a name, but it's not mandatory.
 func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *specs.Platform, containerName string) (container.ContainerCreateCreatedBody, error) {
 	var response container.ContainerCreateCreatedBody

--- a/client/container_restart.go
+++ b/client/container_restart.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ContainerRestart stops and starts a container again.
-// It makes the daemon to wait for the container to be up again for
+// It makes the daemon wait for the container to be up again for
 // a specific amount of time, given the timeout.
 func (cli *Client) ContainerRestart(ctx context.Context, containerID string, timeout *time.Duration) error {
 	query := url.Values{}

--- a/client/container_update.go
+++ b/client/container_update.go
@@ -7,7 +7,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 )
 
-// ContainerUpdate updates resources of a container
+// ContainerUpdate updates the resources of a container.
 func (cli *Client) ContainerUpdate(ctx context.Context, containerID string, updateConfig container.UpdateConfig) (container.ContainerUpdateOKBody, error) {
 	var response container.ContainerUpdateOKBody
 	serverResp, err := cli.post(ctx, "/containers/"+containerID+"/update", nil, updateConfig, nil)

--- a/client/distribution_inspect.go
+++ b/client/distribution_inspect.go
@@ -8,7 +8,7 @@ import (
 	registrytypes "github.com/docker/docker/api/types/registry"
 )
 
-// DistributionInspect returns the image digest with full Manifest
+// DistributionInspect returns the image digest with the full manifest.
 func (cli *Client) DistributionInspect(ctx context.Context, image, encodedRegistryAuth string) (registrytypes.DistributionInspect, error) {
 	// Contact the registry to retrieve digest and platform information
 	var distributionInspect registrytypes.DistributionInspect

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -14,8 +14,8 @@ import (
 	"github.com/docker/docker/api/types/container"
 )
 
-// ImageBuild sends request to the daemon to build images.
-// The Body in the response implement an io.ReadCloser and it's up to the caller to
+// ImageBuild sends a request to the daemon to build images.
+// The Body in the response implements an io.ReadCloser and it's up to the caller to
 // close it.
 func (cli *Client) ImageBuild(ctx context.Context, buildContext io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error) {
 	query, err := cli.imageBuildOptionsToQuery(options)

--- a/client/image_create.go
+++ b/client/image_create.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
-// ImageCreate creates a new image based in the parent options.
+// ImageCreate creates a new image based on the parent options.
 // It returns the JSON content in the response body.
 func (cli *Client) ImageCreate(ctx context.Context, parentReference string, options types.ImageCreateOptions) (io.ReadCloser, error) {
 	ref, err := reference.ParseNormalizedNamed(parentReference)

--- a/client/image_import.go
+++ b/client/image_import.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
-// ImageImport creates a new image based in the source options.
+// ImageImport creates a new image based on the source options.
 // It returns the JSON content in the response body.
 func (cli *Client) ImageImport(ctx context.Context, source types.ImageImportSource, ref string, options types.ImageImportOptions) (io.ReadCloser, error) {
 	if ref != "" {

--- a/client/image_search.go
+++ b/client/image_search.go
@@ -12,7 +12,7 @@ import (
 	"github.com/docker/docker/errdefs"
 )
 
-// ImageSearch makes the docker host to search by a term in a remote registry.
+// ImageSearch makes the docker host search by a term in a remote registry.
 // The list of results is not sorted in any fashion.
 func (cli *Client) ImageSearch(ctx context.Context, term string, options types.ImageSearchOptions) ([]registry.SearchResult, error) {
 	var results []registry.SearchResult

--- a/client/secret_create.go
+++ b/client/secret_create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 )
 
-// SecretCreate creates a new Secret.
+// SecretCreate creates a new secret.
 func (cli *Client) SecretCreate(ctx context.Context, secret swarm.SecretSpec) (types.SecretCreateResponse, error) {
 	var response types.SecretCreateResponse
 	if err := cli.NewVersionError("1.25", "secret create"); err != nil {

--- a/client/secret_remove.go
+++ b/client/secret_remove.go
@@ -2,7 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import "context"
 
-// SecretRemove removes a Secret.
+// SecretRemove removes a secret.
 func (cli *Client) SecretRemove(ctx context.Context, id string) error {
 	if err := cli.NewVersionError("1.25", "secret remove"); err != nil {
 		return err

--- a/client/secret_update.go
+++ b/client/secret_update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 )
 
-// SecretUpdate attempts to update a Secret
+// SecretUpdate attempts to update a secret.
 func (cli *Client) SecretUpdate(ctx context.Context, id string, version swarm.Version, secret swarm.SecretSpec) error {
 	if err := cli.NewVersionError("1.25", "secret update"); err != nil {
 		return err

--- a/client/service_create.go
+++ b/client/service_create.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ServiceCreate creates a new Service.
+// ServiceCreate creates a new service.
 func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options types.ServiceCreateOptions) (types.ServiceCreateResponse, error) {
 	var response types.ServiceCreateResponse
 	headers := map[string][]string{

--- a/client/task_inspect.go
+++ b/client/task_inspect.go
@@ -9,7 +9,7 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 )
 
-// TaskInspectWithRaw returns the task information and its raw representation..
+// TaskInspectWithRaw returns the task information and its raw representation.
 func (cli *Client) TaskInspectWithRaw(ctx context.Context, taskID string) (swarm.Task, []byte, error) {
 	if taskID == "" {
 		return swarm.Task{}, nil, objectNotFoundError{object: "task", id: taskID}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I was looking through the client documentation and found a small grammar mistake in one of the comments, and ended up falling down this rabbit hole. I change certain words and added punctuation to the comments of functions. I didn't get everything, nor is my grammar perfect, and I'd be happy to move things around.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Grammar fixes in exported client functions

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/54278938/107890945-c535ba00-6ee9-11eb-9a83-bd4fbb4ec610.png)

