### PR TITLE
[20.10 backport] Update rootlesskit to v0.13.1 to fix handling of IPv6 addresses

### DIFF
--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# v0.11.0
-: ${ROOTLESSKIT_COMMIT:=2886253e467c5444a4d2ac7084e53aa3cc50055d}
+# v0.13.1
+: "${ROOTLESSKIT_COMMIT:=5c30c9c2586add2ad659132990fdc230f05035fa}"
 
 install_rootlesskit() {
 	case "$1" in
@@ -25,12 +25,13 @@ install_rootlesskit_dynamic() {
 	_install_rootlesskit
 }
 
-_install_rootlesskit() {
+_install_rootlesskit() (
 	echo "Install rootlesskit version $ROOTLESSKIT_COMMIT"
 	git clone https://github.com/rootless-containers/rootlesskit.git "$GOPATH/src/github.com/rootless-containers/rootlesskit"
-	cd "$GOPATH/src/github.com/rootless-containers/rootlesskit"
+	cd "$GOPATH/src/github.com/rootless-containers/rootlesskit" || exit 1
 	git checkout -q "$ROOTLESSKIT_COMMIT"
+	export GO111MODULE=on
 	for f in rootlesskit rootlesskit-docker-proxy; do
 		go build $BUILD_MODE -ldflags="$ROOTLESSKIT_LDFLAGS" -o "${PREFIX}/$f" github.com/rootless-containers/rootlesskit/cmd/$f
 	done
-}
+)


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/42021
relates to https://github.com/moby/moby/pull/41908


v0.13.1

- Refactor `ParsePortSpec` to handle IPv6 addresses, and improve validation

v0.13.0

- `rootlesskit --pidns`: fix propagating exit status
- Support cgroup2 evacuation, e.g., `systemd-run -p Delegate=yes --user -t rootlesskit --cgroupns --pidns --evacuate-cgroup2=evac --net=slirp4netns bash`

v0.12.0

- Port forwarding API now supports setting `ChildIP`
- The `vendor` directory is no longer included in this repo. Run `go mod vendor` if you need

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit e32ae1973ae0b04b543a05b3578d1295c0c98e36)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

