### PR TITLE
JSONProgress: skip width detection if no terminalFd is set

### DIFF
--- a/pkg/jsonmessage/jsonmessage.go
+++ b/pkg/jsonmessage/jsonmessage.go
@@ -125,9 +125,11 @@ func (p *JSONProgress) width() int {
 	if p.winSize != 0 {
 		return p.winSize
 	}
-	ws, err := term.GetWinsize(p.terminalFd)
-	if err == nil {
-		return int(ws.Width)
+	if p.terminalFd != 0 {
+		ws, err := term.GetWinsize(p.terminalFd)
+		if err == nil {
+			return int(ws.Width)
+		}
 	}
 	return 200
 }


### PR DESCRIPTION
I think we can skip detection if no FD is set