### PR TITLE
volumes: only send "create" event when actually creating volume

### DIFF
--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -182,15 +182,14 @@ func (s *DockerSuite) TestVolumeEvents(c *testing.T) {
 	until := daemonUnixTime(c)
 	out, _ := dockerCmd(c, "events", "--since", since, "--until", until)
 	events := strings.Split(strings.TrimSpace(out), "\n")
-	assert.Assert(c, len(events) > 4)
+	assert.Assert(c, len(events) > 3)
 
 	volumeEvents := eventActionsByIDAndType(c, events, "test-event-volume-local", "volume")
-	assert.Equal(c, len(volumeEvents), 5)
+	assert.Equal(c, len(volumeEvents), 4)
 	assert.Equal(c, volumeEvents[0], "create")
-	assert.Equal(c, volumeEvents[1], "create")
-	assert.Equal(c, volumeEvents[2], "mount")
-	assert.Equal(c, volumeEvents[3], "unmount")
-	assert.Equal(c, volumeEvents[4], "destroy")
+	assert.Equal(c, volumeEvents[1], "mount")
+	assert.Equal(c, volumeEvents[2], "unmount")
+	assert.Equal(c, volumeEvents[3], "destroy")
 }
 
 func (s *DockerSuite) TestNetworkEvents(c *testing.T) {


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/40047

The VolumesService did not have information wether or not a volume was _created_ or if a volume already existed in the driver, and the existing volume was used.

As a result, multiple "create" events could be generated for the same volume. For example:

1. Run `docker events` in a shell to start listening for events
2. Create a volume:

    docker volume create myvolume

3. Start a container that uses that volume:

    docker run -dit -v myvolume:/foo busybox

4. Check the events that were generated:

    2021-02-15T18:49:55.874621004+01:00 volume create myvolume (driver=local)
    2021-02-15T18:50:11.442759052+01:00 volume create myvolume (driver=local)
    2021-02-15T18:50:11.487104176+01:00 container create 45112157c8b1382626bf5e01ef18445a4c680f3846c5e32d01775dddee8ca6d1 (image=busybox, name=gracious_hypatia)
    2021-02-15T18:50:11.519288102+01:00 network connect a19f6bb8d44ff84d478670fa4e34c5bf5305f42786294d3d90e790ac74b6d3e0 (container=45112157c8b1382626bf5e01ef18445a4c680f3846c5e32d01775dddee8ca6d1, name=bridge, type=bridge)
    2021-02-15T18:50:11.526407799+01:00 volume mount myvolume (container=45112157c8b1382626bf5e01ef18445a4c680f3846c5e32d01775dddee8ca6d1, destination=/foo, driver=local, propagation=, read/write=true)
    2021-02-15T18:50:11.864134043+01:00 container start 45112157c8b1382626bf5e01ef18445a4c680f3846c5e32d01775dddee8ca6d1 (image=busybox, name=gracious_hypatia)

5. Notice that a "volume create" event is created twice;

    - once when `docker volume create` was ran
    - once when `docker run ...` was ran

This patch moves the generation of (most) events to the volume _store_, and only generates an event if the volume did not yet exist.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
Fix multiple "volume create" events being created when using an existing volume
```

**- A picture of a cute animal (not mandatory but encouraged)**

