### PR TITLE
dockerd-rootless.sh: prohibit running as root

### DIFF
--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -74,6 +74,10 @@ fi
 if [ -z $_DOCKERD_ROOTLESS_CHILD ]; then
 	_DOCKERD_ROOTLESS_CHILD=1
 	export _DOCKERD_ROOTLESS_CHILD
+	if [ "$(id -u)" = "0" ]; then
+		echo "This script must be executed as a non-privileged user"
+		exit 1
+	fi
 	# Re-exec the script via RootlessKit, so as to create unprivileged {user,mount,network} namespaces.
 	#
 	# --copy-up allows removing/creating files in the directories by creating tmpfs and symlinks


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Prohibit running `dockerd-rootless.sh` as root

**- How I did it**

Added `if [ $(id -u) = 0 ]; then echo "(error)"; exit 1; fi`

**- How to verify it**

```console
$ sudo dockerd-rootless.sh 
...
Must not run as root
+ exit 1
```


**- A picture of a cute animal (not mandatory but encouraged)**
:penguin:
