### PR TITLE
hack: add aarch64 cli condition

### DIFF
--- a/hack/dockerfile/install/dockercli.installer
+++ b/hack/dockerfile/install/dockercli.installer
@@ -8,7 +8,7 @@ install_dockercli() {
 
 	arch=$(uname -m)
 	# No official release of these platforms
-	if [ "$arch" != "x86_64" ] && [ "$arch" != "s390x" ] && [ "$arch" != "armhf" ]; then
+	if [ "$arch" != "x86_64" ] && [ "$arch" != "s390x" ] && [ "$arch" != "aarch64" ] && [ "$arch" != "armhf" ]; then
 		build_dockercli
 		return
 	fi


### PR DESCRIPTION
No idea why this was missing. The `build_dockercli` function does not work either as there are no tags in `docker-ce` repo.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>