### PR TITLE
Strip reserved (com.docker. io.docker, org.dockerproject) labels on docker commit

### DIFF
--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -13,17 +13,22 @@ import (
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/v2/daemon/builder/dockerfile"
 	"github.com/moby/moby/v2/daemon/internal/metrics"
+	"github.com/moby/moby/v2/daemon/pkg/opts"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/pkg/errors"
 )
+
+type mergeOptions struct {
+	keepReservedLabels bool
+}
 
 // merge merges two Config, the image container configuration (defaults values),
 // and the user container configuration, either passed by the API or generated
 // by the cli.
 // It will mutate the specified user configuration (userConf) with the image
 // configuration where the user configuration is incomplete.
-func merge(userConf, imageConf *containertypes.Config) error {
+func merge(userConf, imageConf *containertypes.Config, options mergeOptions) error {
 	if userConf.User == "" {
 		userConf.User = imageConf.User
 	}
@@ -65,6 +70,9 @@ func merge(userConf, imageConf *containertypes.Config) error {
 		userConf.Labels = map[string]string{}
 	}
 	for l, v := range imageConf.Labels {
+		if !options.keepReservedLabels && opts.IsReservedLabelNamespace(l) {
+			continue
+		}
 		if _, ok := userConf.Labels[l]; !ok {
 			userConf.Labels[l] = v
 		}
@@ -157,7 +165,7 @@ func (daemon *Daemon) CreateImageFromContainer(ctx context.Context, name string,
 	if err != nil {
 		return "", err
 	}
-	if err := merge(newConfig, container.Config); err != nil {
+	if err := merge(newConfig, container.Config, mergeOptions{}); err != nil {
 		return "", err
 	}
 

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -348,7 +348,7 @@ func (daemon *Daemon) generateSecurityOpt(hostConfig *containertypes.HostConfig)
 
 func (daemon *Daemon) mergeAndVerifyConfig(config *containertypes.Config, img *image.Image) error {
 	if img != nil && img.Config != nil {
-		if err := merge(config, img.Config); err != nil {
+		if err := merge(config, img.Config, mergeOptions{keepReservedLabels: true}); err != nil {
 			return err
 		}
 	}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -230,6 +230,10 @@ func TestMerge(t *testing.T) {
 			"/test1": {},
 			"/test2": {},
 		},
+		Labels: map[string]string{
+			"com.docker.foo": "bar",
+			"my-label":       "my-value",
+		},
 	}
 
 	configUser := &containertypes.Config{
@@ -243,7 +247,7 @@ func TestMerge(t *testing.T) {
 		},
 	}
 
-	if err := merge(configUser, configImage); err != nil {
+	if err := merge(configUser, configImage, mergeOptions{keepReservedLabels: true}); err != nil {
 		t.Error(err)
 	}
 
@@ -273,24 +277,34 @@ func TestMerge(t *testing.T) {
 		}
 	}
 
+	assert.DeepEqual(t, configUser.Labels, configImage.Labels)
+
 	configImage2 := &containertypes.Config{
 		ExposedPorts: map[network.Port]struct{}{
 			network.MustParsePort("0/tcp"): {},
 		},
+		Labels: map[string]string{
+			"com.docker.foo": "bar",
+			"my-label":       "my-value",
+		},
+	}
+	configUser2 := &containertypes.Config{
+		ExposedPorts: portsUser,
 	}
 
-	if err := merge(configUser, configImage2); err != nil {
+	if err := merge(configUser2, configImage2, mergeOptions{}); err != nil {
 		t.Error(err)
 	}
 
-	if len(configUser.ExposedPorts) != 4 {
+	if len(configUser2.ExposedPorts) != 4 {
 		t.Fatalf("Expected 4 ExposedPorts, 0000, 1111, 2222 and 3333, found %d", len(configUser.ExposedPorts))
 	}
-	for portSpecs := range configUser.ExposedPorts {
+	for portSpecs := range configUser2.ExposedPorts {
 		if portSpecs.Num() != 0 && portSpecs.Num() != 1111 && portSpecs.Num() != 2222 && portSpecs.Num() != 3333 {
 			t.Fatalf("Expected %d or %d or %d or %d, found %d", 0, 1111, 2222, 3333, portSpecs)
 		}
 	}
+	assert.DeepEqual(t, configUser2.Labels, map[string]string{"my-label": "my-value"})
 }
 
 func TestValidateContainerIsolation(t *testing.T) {

--- a/daemon/pkg/opts/opts.go
+++ b/daemon/pkg/opts/opts.go
@@ -331,19 +331,33 @@ func validateDomain(val string) (string, error) {
 // and returns it.
 // Labels are in the form on key=value.
 func ValidateLabel(val string) (string, error) {
-	if strings.Count(val, "=") < 1 {
+	kv := strings.SplitN(val, "=", 2)
+	if len(kv) != 2 {
 		return "", fmt.Errorf("bad attribute format: %s", val)
 	}
 
-	lowered := strings.ToLower(val)
-	if strings.HasPrefix(lowered, "com.docker.") || strings.HasPrefix(lowered, "io.docker.") ||
-		strings.HasPrefix(lowered, "org.dockerproject.") {
+	if IsReservedLabelNamespace(kv[0]) {
 		return "", fmt.Errorf(
 			"label %s is not allowed: the namespaces com.docker.*, io.docker.*, and org.dockerproject.* are reserved for internal use",
 			val)
 	}
 
 	return val, nil
+}
+
+var reservedLabelNamespaces = []string{"com.docker", "io.docker", "org.dockerproject"}
+
+// IsReservedLabelNamespace checks if a given label uses a reserved namespace
+// Reserved namespaces are com.docker.*, io.docker.*, and org.dockerproject.*
+// (case insensitive).
+func IsReservedLabelNamespace(name string) bool {
+	lowered := strings.ToLower(name)
+	for _, ns := range reservedLabelNamespaces {
+		if lowered == ns || strings.HasPrefix(lowered, ns+".") {
+			return true
+		}
+	}
+	return false
 }
 
 // ValidateSingleGenericResource validates that a single entry in the

--- a/daemon/pkg/opts/opts_test.go
+++ b/daemon/pkg/opts/opts_test.go
@@ -314,6 +314,86 @@ func TestValidateLabel(t *testing.T) {
 	}
 }
 
+func TestIsReservedLabelNamespace(t *testing.T) {
+	tests := []struct {
+		label    string
+		expected bool
+	}{
+		{
+			label:    "my-label",
+			expected: false,
+		},
+		{
+			label:    "com.dockerpsychnotreserved.label",
+			expected: false,
+		},
+		{
+			label:    "io.dockerproject.not",
+			expected: false,
+		},
+		{
+			label:    "org.docker.not",
+			expected: false,
+		},
+		{
+			label:    "com.docker",
+			expected: true,
+		},
+		{
+			label:    "com.docker.",
+			expected: true,
+		},
+		{
+			label:    "com.docker.feature",
+			expected: true,
+		},
+		{
+			label:    "COM.docker.feature",
+			expected: true,
+		},
+		{
+			label:    "io.docker",
+			expected: true,
+		},
+		{
+			label:    "io.docker.",
+			expected: true,
+		},
+		{
+			label:    "io.docker.feature",
+			expected: true,
+		},
+		{
+			label:    "io.docker.feature",
+			expected: true,
+		},
+		{
+			label:    "org.dockerproject",
+			expected: true,
+		},
+		{
+			label:    "org.dockerproject.",
+			expected: true,
+		},
+		{
+			label:    "org.dockerproject.feature",
+			expected: true,
+		},
+		{
+			label:    "org.dockerproject.feature",
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		testCase := tc
+		t.Run(testCase.label, func(t *testing.T) {
+			result := IsReservedLabelNamespace(testCase.label)
+			assert.Equal(t, result, testCase.expected)
+		})
+	}
+}
+
 func logOptsValidator(val string) (string, error) {
 	allowedKeys := map[string]string{"max-size": "1", "max-file": "2"}
 	vals := strings.Split(val, "=")


### PR DESCRIPTION
- relates to https://github.com/docker/for-win/issues/10409
- fixes https://github.com/moby/moby/issues/36321

Docker uses reserved label namespaces on containers to store runtime information.
For example, when creating a service (`docker service create`), deploying a stack
(`docker stack deploy`), or running a compose project (`docker-compose up`),
docker respectively adds `com.docker.swarm`, `com.docker.stack`, and
`com.docker.compose` labels to store metadata used at runtime.

These labels are not set by users, but when commiting such a container, they
currently end up in the image that was committed.

This patch updates `CreateImageFromContainer` to remove labels in the reserved
namespace.

Some remarks should be made to this change:

- This patch only accounts for `docker commit`; `docker build` still allows
  committing labels in the reserved namespaces
- Because of the above, committing a container that was started from an image
  that has labels in the reserved namespaces, will strip these labels, and
  thus remove the labels from the image that is created.
- Other actions (`docker run`, `docker create`) still allow these labels to be
  set, and also inherit these labels if they're started from an image that
  has labels in the reserved namespaces.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```markdown
When committing a container to an image using `docker commit`, reserved labels
(`com.docker.*`. `io.docker.*`, `org.dockerproject.*`) are no longer preserved in
the image that is created. These labels are automatically set by docker to store
runtime metadata, and should not preserved when committing to an image.
```

**- A picture of a cute animal (not mandatory but encouraged)**

