### PR TITLE
oci.Device() fix FileMode to match runtime spec

### DIFF
--- a/oci/devices_linux.go
+++ b/oci/devices_linux.go
@@ -9,6 +9,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/devices"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sys/unix"
 )
 
 // Device transforms a libcontainer configs.Device to a specs.LinuxDevice object.
@@ -18,7 +19,7 @@ func Device(d *configs.Device) specs.LinuxDevice {
 		Path:     d.Path,
 		Major:    d.Major,
 		Minor:    d.Minor,
-		FileMode: fmPtr(int64(d.FileMode)),
+		FileMode: fmPtr(int64(d.FileMode &^ unix.S_IFMT)), // strip file type, as OCI spec only expects file-mode to be included
 		UID:      u32Ptr(int64(d.Uid)),
 		GID:      u32Ptr(int64(d.Gid)),
 	}

--- a/oci/devices_linux_test.go
+++ b/oci/devices_linux_test.go
@@ -1,0 +1,31 @@
+package oci
+
+import (
+	"os"
+	"testing"
+
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"golang.org/x/sys/unix"
+	"gotest.tools/v3/assert"
+)
+
+func TestDeviceMode(t *testing.T) {
+	tests := []struct {
+		name string
+		in   os.FileMode
+		out  os.FileMode
+	}{
+		{name: "regular permissions", in: 0777, out: 0777},
+		{name: "block device", in: 0777 | unix.S_IFBLK, out: 0777},
+		{name: "character device", in: 0777 | unix.S_IFCHR, out: 0777},
+		{name: "fifo device", in: 0777 | unix.S_IFIFO, out: 0777},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			d := Device(&configs.Device{FileMode: tc.in})
+			assert.Equal(t, *d.FileMode, tc.out)
+		})
+	}
+}


### PR DESCRIPTION
relates to https://github.com/opencontainers/runtime-spec/pull/1082, https://github.com/containerd/containerd/pull/5028 and https://github.com/opencontainers/runc/pull/2804

The runtime spec expects the FileMode field to only hold file permissions, however `unix.Stat_t.Mode` contains both file type and mode.

This patch strips file type so that only file mode is included in the Device.

Thanks to Iceber Gu (@Iceber), who noticed the same issue in containerd and runc.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->



**- A picture of a cute animal (not mandatory but encouraged)**

