### PR TITLE
WIP: Make /sys/fs/cgroup rw

### DIFF
--- a/oci/defaults.go
+++ b/oci/defaults.go
@@ -78,7 +78,7 @@ func DefaultLinuxSpec() specs.Spec {
 			Destination: "/sys/fs/cgroup",
 			Type:        "cgroup",
 			Source:      "cgroup",
-			Options:     []string{"ro", "nosuid", "noexec", "nodev"},
+			Options:     []string{"rw", "nosuid", "noexec", "nodev"},
 		},
 		{
 			Destination: "/dev/mqueue",


### PR DESCRIPTION
Fixes #42040 

**- What I did**

Makes /sys/fs/cgroup rw. This patch is an only intended as reference as I don't know how to make this change dependent upon the used cgroup version.

It should be rw for cgroup2 and ro for cgroup1 (because of container escapes).

**- How I did it**

**- How to verify it**

**- Description for the changelog**
Allow writing to /sys/fs/cgroup to allow containers to manage there own cgroup spaces and create child spaces. E.g. to run systemd within a container without unnecessary privileges.
