### PR TITLE
[20.10 backport] Check the length of the correct variable #42039

### DIFF
--- a/daemon/logger/loginfo.go
+++ b/daemon/logger/loginfo.go
@@ -42,7 +42,7 @@ func (info *Info) ExtraAttributes(keyMod func(string) string) (map[string]string
 	}
 
 	labelsRegex, ok := info.Config["labels-regex"]
-	if ok && len(labels) > 0 {
+	if ok && len(labelsRegex) > 0 {
 		re, err := regexp.Compile(labelsRegex)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/42044

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Closes #42039

**- A picture of a cute animal (not mandatory but encouraged)**

