### PR TITLE
[20.10 backport] vendor: github.com/moby/buildkit v0.8.2

### DIFF
--- a/builder/builder-next/adapters/localinlinecache/inlinecache.go
+++ b/builder/builder-next/adapters/localinlinecache/inlinecache.go
@@ -22,6 +22,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+func init() {
+	// See https://github.com/moby/buildkit/pull/1993.
+	v1.EmptyLayerRemovalSupported = false
+}
+
 // ResolveCacheImporterFunc returns a resolver function for local inline cache
 func ResolveCacheImporterFunc(sm *session.Manager, resolverFunc docker.RegistryHosts, cs content.Store, rs reference.Store, is imagestore.Store) remotecache.ResolveCacheImporterFunc {
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -33,7 +33,7 @@ github.com/imdario/mergo                            1afb36080aec31e0d1528973ebe6
 golang.org/x/sync                                   cd5d95a43a6e21273425c7ae415d3df9ea832eeb
 
 # buildkit
-github.com/moby/buildkit                            68bb095353c65bc3993fd534c26cf77fe05e61b1 # v0.8 branch
+github.com/moby/buildkit                            9065b18ba4633c75862befca8188de4338d9f94a # v0.8.2
 github.com/tonistiigi/fsutil                        0834f99b7b85462efb69b4f571a4fa3ca7da5ac9
 github.com/tonistiigi/units                         6950e57a87eaf136bbe44ef2ec8e75b9e3569de2
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746

--- a/vendor/github.com/moby/buildkit/cache/remotecache/v1/utils.go
+++ b/vendor/github.com/moby/buildkit/cache/remotecache/v1/utils.go
@@ -10,6 +10,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+// EmptyLayerRemovalSupported defines if implementation supports removal of empty layers. Buildkit image exporter
+// removes empty layers, but moby layerstore based implementation does not.
+var EmptyLayerRemovalSupported = true
+
 // sortConfig sorts the config structure to make sure it is deterministic
 func sortConfig(cc *CacheConfig) {
 	type indexedLayer struct {
@@ -239,7 +243,7 @@ func marshalRemote(r *solver.Remote, state *marshalState) string {
 	}
 	desc := r.Descriptors[len(r.Descriptors)-1]
 
-	if desc.Digest == exptypes.EmptyGZLayer {
+	if desc.Digest == exptypes.EmptyGZLayer && EmptyLayerRemovalSupported {
 		return parentID
 	}
 

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/bflag.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/bflag.go
@@ -108,6 +108,15 @@ func (fl *Flag) IsUsed() bool {
 	return false
 }
 
+// Used returns a slice of flag names that are set
+func (bf *BFlags) Used() []string {
+	used := make([]string, 0, len(bf.used))
+	for f := range bf.used {
+		used = append(used, f)
+	}
+	return used
+}
+
 // IsTrue checks if a bool flag is true
 func (fl *Flag) IsTrue() bool {
 	if fl.flagType != boolType {

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands.go
@@ -269,6 +269,7 @@ type RunCommand struct {
 	withNameAndCode
 	withExternalData
 	ShellDependantCmdLine
+	FlagsUsed []string
 }
 
 // CmdCommand : CMD foo

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/parse.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/parse.go
@@ -375,7 +375,7 @@ func parseRun(req parseRequest) (*RunCommand, error) {
 	if err := req.flags.Parse(); err != nil {
 		return nil, err
 	}
-
+	cmd.FlagsUsed = req.flags.Used()
 	cmd.ShellDependantCmdLine = parseShellDependentCommand(req, false)
 	cmd.withNameAndCode = newWithNameAndCode(req)
 

--- a/vendor/github.com/moby/buildkit/frontend/gateway/container.go
+++ b/vendor/github.com/moby/buildkit/frontend/gateway/container.go
@@ -127,6 +127,7 @@ type MountRef struct {
 type MountMutableRef struct {
 	Ref        cache.MutableRef
 	MountIndex int
+	NoCommit   bool
 }
 
 type MakeMutable func(m *opspb.Mount, ref cache.ImmutableRef) (cache.MutableRef, error)
@@ -196,6 +197,7 @@ func PrepareMounts(ctx context.Context, mm *mounts.MountManager, cm cache.Manage
 			p.Actives = append(p.Actives, MountMutableRef{
 				MountIndex: i,
 				Ref:        active,
+				NoCommit:   true,
 			})
 			if m.Output != opspb.SkipOutput && ref != nil {
 				p.OutputRefs = append(p.OutputRefs, MountRef{

--- a/vendor/github.com/moby/buildkit/solver/llbsolver/errdefs/exec.go
+++ b/vendor/github.com/moby/buildkit/solver/llbsolver/errdefs/exec.go
@@ -21,10 +21,15 @@ func (e *ExecError) Unwrap() error {
 }
 
 func (e *ExecError) EachRef(fn func(solver.Result) error) (err error) {
+	m := map[solver.Result]struct{}{}
 	for _, res := range e.Inputs {
 		if res == nil {
 			continue
 		}
+		if _, ok := m[res]; ok {
+			continue
+		}
+		m[res] = struct{}{}
 		if err1 := fn(res); err1 != nil && err == nil {
 			err = err1
 		}
@@ -33,6 +38,10 @@ func (e *ExecError) EachRef(fn func(solver.Result) error) (err error) {
 		if res == nil {
 			continue
 		}
+		if _, ok := m[res]; ok {
+			continue
+		}
+		m[res] = struct{}{}
 		if err1 := fn(res); err1 != nil && err == nil {
 			err = err1
 		}

--- a/vendor/github.com/moby/buildkit/solver/llbsolver/ops/exec_binfmt.go
+++ b/vendor/github.com/moby/buildkit/solver/llbsolver/ops/exec_binfmt.go
@@ -27,6 +27,7 @@ var qemuArchMap = map[string]string{
 	"arm":     "arm",
 	"s390x":   "s390x",
 	"ppc64le": "ppc64le",
+	"386":     "i386",
 }
 
 type emulator struct {

--- a/vendor/github.com/moby/buildkit/solver/result.go
+++ b/vendor/github.com/moby/buildkit/solver/result.go
@@ -47,7 +47,7 @@ type splitResult struct {
 
 func (r *splitResult) Release(ctx context.Context) error {
 	if atomic.AddInt64(&r.released, 1) > 1 {
-		err := errors.Errorf("releasing already released reference")
+		err := errors.Errorf("releasing already released reference %+v", r.Result.ID())
 		logrus.Error(err)
 		return err
 	}
@@ -78,8 +78,12 @@ func NewSharedCachedResult(res CachedResult) *SharedCachedResult {
 	}
 }
 
-func (r *SharedCachedResult) Clone() CachedResult {
+func (r *SharedCachedResult) CloneCachedResult() CachedResult {
 	return &clonedCachedResult{Result: r.SharedResult.Clone(), cr: r.CachedResult}
+}
+
+func (r *SharedCachedResult) Clone() Result {
+	return r.CloneCachedResult()
 }
 
 func (r *SharedCachedResult) Release(ctx context.Context) error {

--- a/vendor/github.com/moby/buildkit/solver/scheduler.go
+++ b/vendor/github.com/moby/buildkit/solver/scheduler.go
@@ -244,7 +244,7 @@ func (s *scheduler) build(ctx context.Context, edge Edge) (CachedResult, error) 
 	if err := p.Receiver.Status().Err; err != nil {
 		return nil, err
 	}
-	return p.Receiver.Status().Value.(*edgeState).result.Clone(), nil
+	return p.Receiver.Status().Value.(*edgeState).result.CloneCachedResult(), nil
 }
 
 // newPipe creates a new request pipe between two edges

--- a/vendor/github.com/moby/buildkit/solver/types.go
+++ b/vendor/github.com/moby/buildkit/solver/types.go
@@ -61,6 +61,7 @@ type Result interface {
 	ID() string
 	Release(context.Context) error
 	Sys() interface{}
+	Clone() Result
 }
 
 // CachedResult is a result connected with its cache key

--- a/vendor/github.com/moby/buildkit/worker/result.go
+++ b/vendor/github.com/moby/buildkit/worker/result.go
@@ -52,3 +52,11 @@ func (r *workerRefResult) Release(ctx context.Context) error {
 func (r *workerRefResult) Sys() interface{} {
 	return r.WorkerRef
 }
+
+func (r *workerRefResult) Clone() solver.Result {
+	r2 := *r
+	if r.ImmutableRef != nil {
+		r.ImmutableRef = r.ImmutableRef.Clone()
+	}
+	return &r2
+}


### PR DESCRIPTION
Backport of #42056

full diff: https://github.com/moby/buildkit/compare/68bb095353c65bc3993fd534c26cf77fe05e61b1...9065b18ba4633c75862befca8188de4338d9f94a

- moby/buildkit#1955 / moby/buildkit#1967 fix seccomp compatibility in 32bit arm
    - fixes moby/buildkit#1946 Unable to build alpine:edge containers for armv7
    - fixes docker/buildx#511 Buildx failing to build for arm/v7 platform on arm64 machine
- moby/buildkit#1957 / moby/buildkit#1969 resolver: avoid error caching on token fetch
    - fixes moby/buildkit#1928 Error: i/o timeout should not be cached
- moby/buildkit#1965 / moby/buildkit#1970 fileop: fix checksum to contain indexes of inputs
- moby/buildkit#1954 / moby/buildkit#1971 frontend/dockerfile: add RunCommand.FlagsUsed field
    - relates to moby/moby#41912 "builder: produce error when using unsupported Dockerfile option"
    - relates to moby/moby#41911 [20.10] Classic builder silently ignores unsupported Dockerfile command flags
- moby/buildkit#1953 / moby/buildkit#1968 update qemu emulators
    - relates to https://github.com/docker/buildx/issues/528#issuecomment-774070063 "Impossible to run git clone inside buildx with non x86 architecture"
- moby/buildkit#1963 / moby/buildkit#1990 Fix reference count issues on typed errors with mount references
    - fixes moby/buildkit#1958 errors on releasing mounts with typed execerror refs
    - fixes / addresses docker/for-linux#1203 invalid mutable ref when using shared cache mounts
- moby/buildkit#1916 / moby/buildkit#1990 dockerfile/docs: fix frontend image tags
    - fixes moby/buildkit#1907
- moby/buildkit#1987 / moby/buildkit#1991 git: set token only for main remote access
    - fixes docker/build-push-action#300 "Loading repositories with submodules is repeated. Failed to clone submodule from googlesource"
- moby/buildkit#1998 allow skipping empty layer detection on cache export
    - relates to moby/buildkit#1992 moby/buildkit#1981

Changes in moby:
- builder: fix incorrect cache match for inline cache with empty layers
    - fixes moby/buildkit#1992 moby/buildkit#1981

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
Signed-off-by: Tibor Vass <tibor@docker.com>