### PR TITLE
Remove VALIDATE_REPO

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,6 @@ pipeline {
                 sh '''
                 docker run --rm \
                   -v "$WORKSPACE:/workspace" \
-                  -e VALIDATE_REPO=${GIT_URL} \
                   -e VALIDATE_BRANCH=${CHANGE_TARGET} \
                   alpine sh -c 'apk add --no-cache -q bash git openssh-client && cd /workspace && hack/validate/dco'
                 '''
@@ -100,7 +99,6 @@ pipeline {
                                   -e DOCKER_GITCOMMIT=${GIT_COMMIT} \
                                   -e DOCKER_GRAPHDRIVER \
                                   -e TEST_FORCE_VALIDATE \
-                                  -e VALIDATE_REPO=${GIT_URL} \
                                   -e VALIDATE_BRANCH=${CHANGE_TARGET} \
                                   docker:${GIT_COMMIT} \
                                   hack/validate/default
@@ -116,7 +114,6 @@ pipeline {
                                   -e DOCKER_EXPERIMENTAL \
                                   -e DOCKER_GITCOMMIT=${GIT_COMMIT} \
                                   -e DOCKER_GRAPHDRIVER \
-                                  -e VALIDATE_REPO=${GIT_URL} \
                                   -e VALIDATE_BRANCH=${CHANGE_TARGET} \
                                   docker:${GIT_COMMIT} \
                                   hack/make.sh \
@@ -186,7 +183,6 @@ pipeline {
                                   -e DOCKER_EXPERIMENTAL \
                                   -e DOCKER_GITCOMMIT=${GIT_COMMIT} \
                                   -e DOCKER_GRAPHDRIVER \
-                                  -e VALIDATE_REPO=${GIT_URL} \
                                   -e VALIDATE_BRANCH=${CHANGE_TARGET} \
                                   docker:${GIT_COMMIT} \
                                   hack/test/unit
@@ -208,7 +204,6 @@ pipeline {
                                   -e DOCKER_GITCOMMIT=${GIT_COMMIT} \
                                   -e DOCKER_GRAPHDRIVER \
                                   -e TEST_FORCE_VALIDATE \
-                                  -e VALIDATE_REPO=${GIT_URL} \
                                   -e VALIDATE_BRANCH=${CHANGE_TARGET} \
                                   docker:${GIT_COMMIT} \
                                   hack/validate/vendor
@@ -296,7 +291,6 @@ pipeline {
                                           -e DOCKER_GITCOMMIT=${GIT_COMMIT} \
                                           -e DOCKER_GRAPHDRIVER \
                                           -e TIMEOUT \
-                                          -e VALIDATE_REPO=${GIT_URL} \
                                           -e VALIDATE_BRANCH=${CHANGE_TARGET} \
                                           docker:${GIT_COMMIT} \
                                           hack/make.sh \
@@ -415,7 +409,6 @@ pipeline {
                                   -e DOCKER_ROOTLESS \
                                   -e TEST_SKIP_INTEGRATION_CLI \
                                   -e TIMEOUT \
-                                  -e VALIDATE_REPO=${GIT_URL} \
                                   -e VALIDATE_BRANCH=${CHANGE_TARGET} \
                                   docker:${GIT_COMMIT} \
                                   hack/make.sh \
@@ -497,7 +490,6 @@ pipeline {
                                   -e DOCKER_SYSTEMD \
                                   -e TEST_SKIP_INTEGRATION_CLI \
                                   -e TIMEOUT \
-                                  -e VALIDATE_REPO=${GIT_URL} \
                                   -e VALIDATE_BRANCH=${CHANGE_TARGET} \
                                   docker:${GIT_COMMIT} \
                                   hack/make.sh \
@@ -579,7 +571,6 @@ pipeline {
                                   -e DOCKER_EXPERIMENTAL \
                                   -e DOCKER_GITCOMMIT=${GIT_COMMIT} \
                                   -e DOCKER_GRAPHDRIVER \
-                                  -e VALIDATE_REPO=${GIT_URL} \
                                   -e VALIDATE_BRANCH=${CHANGE_TARGET} \
                                   docker:${GIT_COMMIT} \
                                   hack/test/unit
@@ -604,7 +595,6 @@ pipeline {
                                   -e TESTDEBUG \
                                   -e TEST_SKIP_INTEGRATION_CLI \
                                   -e TIMEOUT \
-                                  -e VALIDATE_REPO=${GIT_URL} \
                                   -e VALIDATE_BRANCH=${CHANGE_TARGET} \
                                   docker:${GIT_COMMIT} \
                                   hack/make.sh \
@@ -687,7 +677,6 @@ pipeline {
                                   -e DOCKER_GRAPHDRIVER \
                                   -e TEST_SKIP_INTEGRATION \
                                   -e TIMEOUT \
-                                  -e VALIDATE_REPO=${GIT_URL} \
                                   -e VALIDATE_BRANCH=${CHANGE_TARGET} \
                                   docker:${GIT_COMMIT} \
                                   hack/make.sh \
@@ -774,7 +763,6 @@ pipeline {
                                   -e DOCKER_EXPERIMENTAL \
                                   -e DOCKER_GITCOMMIT=${GIT_COMMIT} \
                                   -e DOCKER_GRAPHDRIVER \
-                                  -e VALIDATE_REPO=${GIT_URL} \
                                   -e VALIDATE_BRANCH=${CHANGE_TARGET} \
                                   docker:${GIT_COMMIT} \
                                   hack/test/unit
@@ -799,7 +787,6 @@ pipeline {
                                   -e TESTDEBUG \
                                   -e TEST_SKIP_INTEGRATION_CLI \
                                   -e TIMEOUT \
-                                  -e VALIDATE_REPO=${GIT_URL} \
                                   -e VALIDATE_BRANCH=${CHANGE_TARGET} \
                                   docker:${GIT_COMMIT} \
                                   hack/make.sh \
@@ -889,7 +876,6 @@ pipeline {
                                   -e DOCKER_GRAPHDRIVER \
                                   -e TEST_SKIP_INTEGRATION \
                                   -e TIMEOUT \
-                                  -e VALIDATE_REPO=${GIT_URL} \
                                   -e VALIDATE_BRANCH=${CHANGE_TARGET} \
                                   docker:${GIT_COMMIT} \
                                   hack/make.sh \
@@ -970,7 +956,6 @@ pipeline {
                                   -e DOCKER_EXPERIMENTAL \
                                   -e DOCKER_GITCOMMIT=${GIT_COMMIT} \
                                   -e DOCKER_GRAPHDRIVER \
-                                  -e VALIDATE_REPO=${GIT_URL} \
                                   -e VALIDATE_BRANCH=${CHANGE_TARGET} \
                                   docker:${GIT_COMMIT} \
                                   hack/test/unit
@@ -995,7 +980,6 @@ pipeline {
                                   -e TESTDEBUG \
                                   -e TEST_SKIP_INTEGRATION_CLI \
                                   -e TIMEOUT \
-                                  -e VALIDATE_REPO=${GIT_URL} \
                                   -e VALIDATE_BRANCH=${CHANGE_TARGET} \
                                   docker:${GIT_COMMIT} \
                                   hack/make.sh \

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,8 @@ DOCKERFILE := $(shell bash -c 'source hack/make/.detect-daemon-osarch && echo $$
 DOCKER_GITCOMMIT := $(shell git rev-parse --short HEAD || echo unsupported)
 export DOCKER_GITCOMMIT
 
-# allow overriding the repository and branch that validation scripts are running
-# against these are used in hack/validate/.validate to check what changed in the PR.
-export VALIDATE_REPO
+# allow overriding the branch that validation scripts are running against. These
+# are used in hack/validate/.validate to check what changed in the PR.
 export VALIDATE_BRANCH
 export VALIDATE_ORIGIN_BRANCH
 
@@ -77,7 +76,6 @@ DOCKER_ENVS := \
 	-e TESTFLAGS_INTEGRATION_CLI \
 	-e TEST_FILTER \
 	-e TIMEOUT \
-	-e VALIDATE_REPO \
 	-e VALIDATE_BRANCH \
 	-e VALIDATE_ORIGIN_BRANCH \
 	-e HTTP_PROXY \


### PR DESCRIPTION
This partially reverts https://github.com/moby/moby/pull/38655

This variable was used to allow running CI on the docker/engine repository (and our internal "docker-ee" repositories).

Now that release branches have moved back to the upstream repository, there's no longer a need to set these overrides.

I kept the variable in `hack/validate/.validate`, in case someone wants to override it manually, but it's unused otherwise.


**- A picture of a cute animal (not mandatory but encouraged)**

