### PR TITLE
API: update API version to v1.42

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -3,7 +3,7 @@ package api // import "github.com/docker/docker/api"
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of Current REST API
-	DefaultVersion = "1.41"
+	DefaultVersion = "1.42"
 
 	// NoBaseImageSpecifier is the symbol used by the FROM
 	// command to specify that no base image is to be used.

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -19,10 +19,10 @@ produces:
 consumes:
   - "application/json"
   - "text/plain"
-basePath: "/v1.41"
+basePath: "/v1.42"
 info:
   title: "Docker Engine API"
-  version: "1.41"
+  version: "1.42"
   x-logo:
     url: "https://docs.docker.com/images/logo-docker-main.png"
   description: |
@@ -55,8 +55,8 @@ info:
     the URL is not supported by the daemon, a HTTP `400 Bad Request` error message
     is returned.
 
-    If you omit the version-prefix, the current version of the API (v1.41) is used.
-    For example, calling `/info` is the same as calling `/v1.41/info`. Using the
+    If you omit the version-prefix, the current version of the API (v1.42) is used.
+    For example, calling `/info` is the same as calling `/v1.42/info`. Using the
     API without a version-prefix is deprecated and will be removed in a future release.
 
     Engine releases in the near future should support this version of the API,

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -13,6 +13,10 @@ keywords: "API, Docker, rcli, REST, documentation"
      will be rejected.
 -->
 
+## v1.42 API changes
+
+[Docker Engine API v1.42](https://docs.docker.com/engine/api/v1.42/) documentation
+
 ## v1.41 API changes
 
 [Docker Engine API v1.41](https://docs.docker.com/engine/api/v1.41/) documentation


### PR DESCRIPTION
Opening as a separate PR (as draft) in preparation of API changes


Docker 20.10 was released with API v1.41, so any change in the API should now target v1.42.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
Update API version to v1.42
```



**- A picture of a cute animal (not mandatory but encouraged)**

