### PR TITLE
API: add "Swarm" header to _ping endpoint

### DIFF
--- a/api/server/router/system/backend.go
+++ b/api/server/router/system/backend.go
@@ -38,3 +38,8 @@ type Backend interface {
 type ClusterBackend interface {
 	Info() swarm.Info
 }
+
+// StatusProvider provides methods to get the swarm status of the current node.
+type StatusProvider interface {
+	Status() string
+}

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8377,6 +8377,13 @@ paths:
             Docker-Experimental:
               type: "boolean"
               description: "If the server is running with experimental mode enabled"
+            Swarm:
+              type: "string"
+              enum: ["inactive", "pending", "error", "locked", "active/worker", "active/manager"]
+              description: |
+                Contains information about Swarm status of the daemon,
+                and if the daemon is acting as a manager or worker node.
+              default: "inactive"
             Cache-Control:
               type: "string"
               default: "no-cache, no-store, must-revalidate"
@@ -8416,6 +8423,13 @@ paths:
             Docker-Experimental:
               type: "boolean"
               description: "If the server is running with experimental mode enabled"
+            Swarm:
+              type: "string"
+              enum: ["inactive", "pending", "error", "locked", "active/worker", "active/manager"]
+              description: |
+                Contains information about Swarm status of the daemon,
+                and if the daemon is acting as a manager or worker node.
+              default: "inactive"
             Cache-Control:
               type: "string"
               default: "no-cache, no-store, must-revalidate"

--- a/api/types/swarm/swarm.go
+++ b/api/types/swarm/swarm.go
@@ -213,6 +213,16 @@ type Info struct {
 	Warnings []string `json:",omitempty"`
 }
 
+// Status provides information about the current swarm status and role,
+// obtained from the "Swarm" header in the API response.
+type Status struct {
+	// NodeState represents the state of the node.
+	NodeState LocalNodeState
+
+	// ControlAvailable indicates if the node is a swarm manager.
+	ControlAvailable bool
+}
+
 // Peer represents a peer.
 type Peer struct {
 	NodeID string

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -188,6 +188,15 @@ type Ping struct {
 	OSType         string
 	Experimental   bool
 	BuilderVersion BuilderVersion
+
+	// SwarmStatus provides information about the current swarm status of the
+	// engine, obtained from the "Swarm" header in the API response.
+	//
+	// It can be a nil struct if the API version does not provide this header
+	// in the ping response, or if an error occurred, in which case the client
+	// should use other ways to get the current swarm status, such as the /swarm
+	// endpoint.
+	SwarmStatus *swarm.Status
 }
 
 // ComponentVersion describes the version information for a specific component.

--- a/client/ping_test.go
+++ b/client/ping_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api/types/swarm"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -25,6 +26,7 @@ func TestPingFail(t *testing.T) {
 				resp.Header = http.Header{}
 				resp.Header.Set("API-Version", "awesome")
 				resp.Header.Set("Docker-Experimental", "true")
+				resp.Header.Set("Swarm", "inactive")
 			}
 			resp.Body = io.NopCloser(strings.NewReader("some error with the server"))
 			return resp, nil
@@ -35,12 +37,15 @@ func TestPingFail(t *testing.T) {
 	assert.ErrorContains(t, err, "some error with the server")
 	assert.Check(t, is.Equal(false, ping.Experimental))
 	assert.Check(t, is.Equal("", ping.APIVersion))
+	var si *swarm.Status
+	assert.Check(t, is.Equal(si, ping.SwarmStatus))
 
 	withHeader = true
 	ping2, err := client.Ping(context.Background())
 	assert.ErrorContains(t, err, "some error with the server")
 	assert.Check(t, is.Equal(true, ping2.Experimental))
 	assert.Check(t, is.Equal("awesome", ping2.APIVersion))
+	assert.Check(t, is.Equal(swarm.Status{NodeState: "inactive"}, *ping2.SwarmStatus))
 }
 
 // TestPingWithError tests the case where there is a protocol error in the ping.
@@ -52,6 +57,7 @@ func TestPingWithError(t *testing.T) {
 			resp.Header = http.Header{}
 			resp.Header.Set("API-Version", "awesome")
 			resp.Header.Set("Docker-Experimental", "true")
+			resp.Header.Set("Swarm", "active/manager")
 			resp.Body = io.NopCloser(strings.NewReader("some error with the server"))
 			return resp, errors.New("some error")
 		}),
@@ -61,6 +67,8 @@ func TestPingWithError(t *testing.T) {
 	assert.ErrorContains(t, err, "some error")
 	assert.Check(t, is.Equal(false, ping.Experimental))
 	assert.Check(t, is.Equal("", ping.APIVersion))
+	var si *swarm.Status
+	assert.Check(t, is.Equal(si, ping.SwarmStatus))
 }
 
 // TestPingSuccess tests that we are able to get the expected API headers/ping
@@ -72,6 +80,7 @@ func TestPingSuccess(t *testing.T) {
 			resp.Header = http.Header{}
 			resp.Header.Set("API-Version", "awesome")
 			resp.Header.Set("Docker-Experimental", "true")
+			resp.Header.Set("Swarm", "active/manager")
 			resp.Body = io.NopCloser(strings.NewReader("OK"))
 			return resp, nil
 		}),
@@ -80,6 +89,7 @@ func TestPingSuccess(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(true, ping.Experimental))
 	assert.Check(t, is.Equal("awesome", ping.APIVersion))
+	assert.Check(t, is.Equal(swarm.Status{NodeState: "active", ControlAvailable: true}, *ping.SwarmStatus))
 }
 
 // TestPingHeadFallback tests that the client falls back to GET if HEAD fails.

--- a/daemon/cluster/swarm.go
+++ b/daemon/cluster/swarm.go
@@ -492,6 +492,23 @@ func (c *Cluster) Info() types.Info {
 	return info
 }
 
+// Status returns a textual representation of the node's swarm status and role (manager/worker)
+func (c *Cluster) Status() string {
+	c.mu.RLock()
+	s := c.currentNodeState()
+	c.mu.RUnlock()
+
+	state := string(s.status)
+	if s.status == types.LocalNodeStateActive {
+		if s.IsActiveManager() || s.IsManager() {
+			state += "/manager"
+		} else {
+			state += "/worker"
+		}
+	}
+	return state
+}
+
 func validateAndSanitizeInitRequest(req *types.InitRequest) error {
 	var err error
 	req.ListenAddr, err = validateAddr(req.ListenAddr)

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -50,6 +50,21 @@ keywords: "API, Docker, rcli, REST, documentation"
   if they are not set.
 * `GET /info` now omits the `KernelMemory` and `KernelMemoryTCP` if they are not
   supported by the host or host's configuration (if cgroups v2 are in use).
+* `GET /_ping` and `HEAD /_ping` now return a `Swarm` header, which allows a
+  client to detect if Swarm is enabled on the daemon, without having to call
+  additional endpoints.
+  This change is not versioned, and affects all API versions if the daemon has
+  this patch. Clients must consider this header "optional", and fall back to
+  using other endpoints to get this information if the header is not present.
+
+  The `Swarm` header can contain one of the following values:
+
+    - "inactive"
+    - "pending"
+    - "error"
+    - "locked"
+    - "active/worker"
+    - "active/manager"
 
 ## v1.41 API changes
 

--- a/integration/system/ping_test.go
+++ b/integration/system/ping_test.go
@@ -1,11 +1,14 @@
 package system // import "github.com/docker/docker/integration/system"
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/testutil/daemon"
 	"github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/skip"
@@ -48,6 +51,46 @@ func TestPingHead(t *testing.T) {
 	assert.Equal(t, 0, len(b))
 	assert.Equal(t, res.StatusCode, http.StatusOK)
 	assert.Check(t, hdr(res, "API-Version") != "")
+}
+
+func TestPingSwarmHeader(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon)
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+
+	defer setupTest(t)()
+	d := daemon.New(t)
+	d.Start(t)
+	defer d.Stop(t)
+	client := d.NewClientT(t)
+	defer client.Close()
+	ctx := context.TODO()
+
+	t.Run("before swarm init", func(t *testing.T) {
+		res, _, err := request.Get("/_ping")
+		assert.NilError(t, err)
+		assert.Equal(t, res.StatusCode, http.StatusOK)
+		assert.Equal(t, hdr(res, "Swarm"), "inactive")
+	})
+
+	_, err := client.SwarmInit(ctx, swarm.InitRequest{ListenAddr: "127.0.0.1", AdvertiseAddr: "127.0.0.1:2377"})
+	assert.NilError(t, err)
+
+	t.Run("after swarm init", func(t *testing.T) {
+		res, _, err := request.Get("/_ping", request.Host(d.Sock()))
+		assert.NilError(t, err)
+		assert.Equal(t, res.StatusCode, http.StatusOK)
+		assert.Equal(t, hdr(res, "Swarm"), "active/manager")
+	})
+
+	err = client.SwarmLeave(ctx, true)
+	assert.NilError(t, err)
+
+	t.Run("after swarm leave", func(t *testing.T) {
+		res, _, err := request.Get("/_ping", request.Host(d.Sock()))
+		assert.NilError(t, err)
+		assert.Equal(t, res.StatusCode, http.StatusOK)
+		assert.Equal(t, hdr(res, "Swarm"), "inactive")
+	})
 }
 
 func hdr(res *http.Response, name string) string {


### PR DESCRIPTION
### depends on https://github.com/moby/moby/pull/42063

This adds an additional "Swarm" header to the _ping endpoint response, which allows a client to detect if Swarm is enabled on the daemon, without having to call additional endpoints.

This change is not versioned in the API, and will be returned irregardless of the API version that is used. Clients should fall back to using other endpoints to get this information if the header is not present.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```markdown
The `GET /_ping` and `HEAD /_ping` API endpoints now return a `Swarm` header,
which allows a client to detect if Swarm is enabled on the daemon, without
having to call additional endpoints.
```

**- A picture of a cute animal (not mandatory but encouraged)**

