### PR TITLE
Include VPNkit binary for arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG SYSTEMD="false"
 # IMPORTANT: When updating this please note that stdlib archive/tar pkg is vendored
 ARG GO_VERSION=1.13.15
 ARG DEBIAN_FRONTEND=noninteractive
-ARG VPNKIT_VERSION=0.4.0
+ARG VPNKIT_VERSION=0.5.0
 ARG DOCKER_BUILDTAGS="apparmor seccomp"
 
 ARG BASE_DEBIAN_DISTRO="buster"
@@ -241,7 +241,13 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 COPY ./contrib/dockerd-rootless.sh /build
 COPY ./contrib/dockerd-rootless-setuptool.sh /build
 
-FROM djs55/vpnkit:${VPNKIT_VERSION} AS vpnkit
+FROM --platform=amd64 djs55/vpnkit:${VPNKIT_VERSION} AS vpnkit-amd64
+
+FROM --platform=arm64 djs55/vpnkit:${VPNKIT_VERSION} AS vpnkit-arm64
+
+FROM scratch AS vpnkit
+COPY --from=vpnkit-amd64 /vpnkit /build/vpnkit.x86_64
+COPY --from=vpnkit-arm64 /vpnkit /build/vpnkit.aarch64
 
 # TODO: Some of this is only really needed for testing, it would be nice to split this up
 FROM runtime-dev AS dev-systemd-false
@@ -308,7 +314,7 @@ COPY --from=shfmt         /build/ /usr/local/bin/
 COPY --from=runc          /build/ /usr/local/bin/
 COPY --from=containerd    /build/ /usr/local/bin/
 COPY --from=rootlesskit   /build/ /usr/local/bin/
-COPY --from=vpnkit        /vpnkit /usr/local/bin/vpnkit.x86_64
+COPY --from=vpnkit        /build/ /usr/local/bin/
 COPY --from=proxy         /build/ /usr/local/bin/
 ENV PATH=/usr/local/cli:$PATH
 ARG DOCKER_BUILDTAGS
@@ -356,7 +362,7 @@ COPY --from=runc        /build/ /usr/local/bin/
 COPY --from=containerd  /build/ /usr/local/bin/
 COPY --from=rootlesskit /build/ /usr/local/bin/
 COPY --from=proxy       /build/ /usr/local/bin/
-COPY --from=vpnkit      /vpnkit /usr/local/bin/vpnkit.x86_64
+COPY --from=vpnkit      /build/ /usr/local/bin/
 WORKDIR /go/src/github.com/docker/docker
 
 FROM binary-base AS build-binary

--- a/hack/make/binary-daemon
+++ b/hack/make/binary-daemon
@@ -21,7 +21,7 @@ copy_binaries() {
 		fi
 	done
 
-	# vpnkit is amd64 only
+	# vpnkit is available for x86_64 and aarch64
 	if command -v "vpnkit.$(uname -m)" 2>&1 > /dev/null; then
 		cp -f "$(command -v "vpnkit.$(uname -m)")" "$dir/vpnkit"
 		if [ "$hash" = "hash" ]; then


### PR DESCRIPTION
Previously, VPNkit binary was installed only for amd64.
