### PR TITLE
rootless: Set service type to `notify`

### DIFF
--- a/contrib/dockerd-rootless-setuptool.sh
+++ b/contrib/dockerd-rootless-setuptool.sh
@@ -306,7 +306,8 @@ install_systemd() {
 			LimitCORE=infinity
 			TasksMax=infinity
 			Delegate=yes
-			Type=simple
+			Type=notify
+			NotifyAccess=all
 			KillMode=mixed
 
 			[Install]


### PR DESCRIPTION
**- What I did**

This mirrors what the non-rootless version does, and lets `systemd` understand when the service is fully up and running. This also guarantees that services that depend on docker only run after docker has fully initialised.

**- How I did it**

Simply updated the generated service file.

`NotifyAccess=all` is required, since the main process is the wrapper script, and it's the child process that emits the signal.

**- How to verify it**

- Update the service file.
- Make sure you reload (e.g.: `systemctl --user daemon-reload`)
- Start docker via `systemctl --user start docker.service`

You'll notice that starting does not return immediately, but only after docker has fully initialised.

Having services which rely on docker is another (far more complex) way to verify that this prevents race conditions.

**- Description for the changelog**

rootless: systemd.service type is now `notify`.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/730811/109161652-39385380-776f-11eb-88de-660b7562ff4a.png)
([source](https://www.reddit.com/r/aww/comments/lruywy/does_my_new_pal_fit_here_frog_my_12_week_old_baby/))