### PR TITLE
[20.10 backport] Update documentation links

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2,7 +2,7 @@
 Package client is a Go client for the Docker Engine API.
 
 For more information about the Engine API, see the documentation:
-https://docs.docker.com/engine/reference/api/
+https://docs.docker.com/engine/api/
 
 Usage
 

--- a/contrib/dockerd-rootless-setuptool.sh
+++ b/contrib/dockerd-rootless-setuptool.sh
@@ -4,7 +4,7 @@
 #
 # Typical usage: dockerd-rootless-setuptool.sh install --force
 #
-# Documentation: https://docs.docker.com/engine/security/rootless/
+# Documentation: https://docs.docker.com/go/rootless/
 set -eu
 
 # utility functions
@@ -290,7 +290,7 @@ install_systemd() {
 		cat <<- EOT > "${unit_file}"
 			[Unit]
 			Description=Docker Application Container Engine (Rootless)
-			Documentation=https://docs.docker.com/engine/security/rootless/
+			Documentation=https://docs.docker.com/go/rootless/
 
 			[Service]
 			Environment=PATH=$BIN:/sbin:/usr/sbin:$PATH
@@ -400,7 +400,7 @@ usage() {
 	echo
 	echo "A setup tool for Rootless Docker (${DOCKERD_ROOTLESS_SH})."
 	echo
-	echo "Documentation: https://docs.docker.com/engine/security/rootless/"
+	echo "Documentation: https://docs.docker.com/go/rootless/"
 	echo
 	echo "Options:"
 	echo "  -f, --force                Ignore rootful Docker (/var/run/docker.sock)"

--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -15,7 +15,7 @@
 # * DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SANDBOX=(auto|true|false): whether to protect slirp4netns with a dedicated mount namespace. Defaults to "auto".
 # * DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SECCOMP=(auto|true|false): whether to protect slirp4netns with seccomp. Defaults to "auto".
 #
-# See the documentation for the further information: https://docs.docker.com/engine/security/rootless/
+# See the documentation for the further information: https://docs.docker.com/go/rootless/
 
 set -e -x
 case "$1" in

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -209,7 +209,7 @@ func (daemon *Daemon) fillAPIInfo(v *types.Info) {
 	const warn string = `
          Access to the remote API is equivalent to root access on the host. Refer
          to the 'Docker daemon attack surface' section in the documentation for
-         more information: https://docs.docker.com/engine/security/security/#docker-daemon-attack-surface`
+         more information: https://docs.docker.com/go/attack-surface/`
 
 	cfg := daemon.configStore
 	for _, host := range cfg.Hosts {

--- a/docs/api/v1.25.yaml
+++ b/docs/api/v1.25.yaml
@@ -105,7 +105,7 @@ tags:
   - name: "Network"
     x-displayName: "Networks"
     description: |
-      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/engine/userguide/networking/) for more information.
+      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/network/) for more information.
   - name: "Volume"
     x-displayName: "Volumes"
     description: |

--- a/docs/api/v1.26.yaml
+++ b/docs/api/v1.26.yaml
@@ -106,7 +106,7 @@ tags:
   - name: "Network"
     x-displayName: "Networks"
     description: |
-      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/engine/userguide/networking/) for more information.
+      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/network/) for more information.
   - name: "Volume"
     x-displayName: "Volumes"
     description: |

--- a/docs/api/v1.27.yaml
+++ b/docs/api/v1.27.yaml
@@ -107,7 +107,7 @@ tags:
   - name: "Network"
     x-displayName: "Networks"
     description: |
-      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/engine/userguide/networking/) for more information.
+      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/network/) for more information.
   - name: "Volume"
     x-displayName: "Volumes"
     description: |

--- a/docs/api/v1.28.yaml
+++ b/docs/api/v1.28.yaml
@@ -108,7 +108,7 @@ tags:
   - name: "Network"
     x-displayName: "Networks"
     description: |
-      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/engine/userguide/networking/) for more information.
+      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/network/) for more information.
   - name: "Volume"
     x-displayName: "Volumes"
     description: |

--- a/docs/api/v1.29.yaml
+++ b/docs/api/v1.29.yaml
@@ -109,7 +109,7 @@ tags:
   - name: "Network"
     x-displayName: "Networks"
     description: |
-      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/engine/userguide/networking/) for more information.
+      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/network/) for more information.
   - name: "Volume"
     x-displayName: "Volumes"
     description: |

--- a/docs/api/v1.30.yaml
+++ b/docs/api/v1.30.yaml
@@ -110,7 +110,7 @@ tags:
   - name: "Network"
     x-displayName: "Networks"
     description: |
-      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/engine/userguide/networking/) for more information.
+      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/network/) for more information.
   - name: "Volume"
     x-displayName: "Volumes"
     description: |

--- a/docs/api/v1.31.yaml
+++ b/docs/api/v1.31.yaml
@@ -111,7 +111,7 @@ tags:
   - name: "Network"
     x-displayName: "Networks"
     description: |
-      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/engine/userguide/networking/) for more information.
+      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/network/) for more information.
   - name: "Volume"
     x-displayName: "Volumes"
     description: |

--- a/docs/api/v1.32.yaml
+++ b/docs/api/v1.32.yaml
@@ -112,7 +112,7 @@ tags:
   - name: "Network"
     x-displayName: "Networks"
     description: |
-      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/engine/userguide/networking/) for more information.
+      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/network/) for more information.
   - name: "Volume"
     x-displayName: "Volumes"
     description: |

--- a/docs/api/v1.33.yaml
+++ b/docs/api/v1.33.yaml
@@ -113,7 +113,7 @@ tags:
   - name: "Network"
     x-displayName: "Networks"
     description: |
-      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/engine/userguide/networking/) for more information.
+      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/network/) for more information.
   - name: "Volume"
     x-displayName: "Volumes"
     description: |

--- a/docs/api/v1.34.yaml
+++ b/docs/api/v1.34.yaml
@@ -116,7 +116,7 @@ tags:
   - name: "Network"
     x-displayName: "Networks"
     description: |
-      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/engine/userguide/networking/) for more information.
+      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/network/) for more information.
   - name: "Volume"
     x-displayName: "Volumes"
     description: |

--- a/docs/api/v1.35.yaml
+++ b/docs/api/v1.35.yaml
@@ -104,7 +104,7 @@ tags:
   - name: "Network"
     x-displayName: "Networks"
     description: |
-      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/engine/userguide/networking/) for more information.
+      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/network/) for more information.
   - name: "Volume"
     x-displayName: "Volumes"
     description: |

--- a/docs/api/v1.36.yaml
+++ b/docs/api/v1.36.yaml
@@ -104,7 +104,7 @@ tags:
   - name: "Network"
     x-displayName: "Networks"
     description: |
-      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/engine/userguide/networking/) for more information.
+      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/network/) for more information.
   - name: "Volume"
     x-displayName: "Volumes"
     description: |

--- a/docs/api/v1.37.yaml
+++ b/docs/api/v1.37.yaml
@@ -104,7 +104,7 @@ tags:
   - name: "Network"
     x-displayName: "Networks"
     description: |
-      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/engine/userguide/networking/) for more information.
+      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/network/) for more information.
   - name: "Volume"
     x-displayName: "Volumes"
     description: |

--- a/docs/api/v1.38.yaml
+++ b/docs/api/v1.38.yaml
@@ -104,7 +104,7 @@ tags:
   - name: "Network"
     x-displayName: "Networks"
     description: |
-      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/engine/userguide/networking/) for more information.
+      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/network/) for more information.
   - name: "Volume"
     x-displayName: "Volumes"
     description: |

--- a/docs/rootless.md
+++ b/docs/rootless.md
@@ -1,3 +1,3 @@
-Moved to https://docs.docker.com/engine/security/rootless/
+Moved to https://docs.docker.com/go/rootless/
 
 <!-- do not remove this file, as there is a lot of links to https://github.com/moby/moby/blob/master/docs/rootless.md -->

--- a/pkg/authorization/authz.go
+++ b/pkg/authorization/authz.go
@@ -21,7 +21,7 @@ const maxBodySize = 1048576 // 1MB
 // Authenticate Request:
 // Call authZ plugins with current REST request and AuthN response
 // Request contains full HTTP packet sent to the docker daemon
-// https://docs.docker.com/engine/reference/api/
+// https://docs.docker.com/engine/api/
 //
 // Authenticate Response:
 // Call authZ plugins with full info about current REST request, REST response and AuthN response


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/42076

- Using "/go/" redirects for some topics, which allows us to
  redirect to new locations if topics are moved around in the
  documentation.
- Updated some old URLs to their new location.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit 328de0b8d961864f4915e44d7e77029c46141a5b)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

