### PR TITLE
Enable `process_vm_readv` and `process_vm_writev` for kernel >= 4.8

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -401,6 +401,8 @@
 		},
 		{
 			"names": [
+				"process_vm_readv",
+				"process_vm_writev",
 				"ptrace"
 			],
 			"action": "SCMP_ACT_ALLOW",

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -390,7 +390,11 @@ func DefaultProfile() *Seccomp {
 			Args:   []*specs.LinuxSeccompArg{},
 		},
 		{
-			Names:  []string{"ptrace"},
+			Names: []string{
+				"process_vm_readv",
+				"process_vm_writev",
+				"ptrace",
+			},
 			Action: specs.ActAllow,
 			Includes: Filter{
 				MinKernel: &KernelVersion{4, 8},


### PR DESCRIPTION
These syscalls were disabled in #18971 due to them requiring CAP_PTRACE. CAP_PTRACE was blocked by default due to a ptrace related exploit. This has been patched in the Linux kernel (version 4.8) and thus `ptrace` has been re-enabled. However, these associated syscalls seem to have been left behind. This commit brings them in line with `ptrace`, and re-enables it for kernel > 4.8.

**- What I did**
Re-enabled `process_vm_readv` and `process_vm_writev`
**- How I did it**
Added them to the `ptrace` profile in the seccomp defaults.
**- How to verify it**

1. Start a standard Docker container
2. Run a program that uses these functions (as root, or targeting a same-user process)

**- Description for the changelog**
Re-enabled `process_vm_readv` and `process_vm_writev` by default for kernel >= 4.8

