### PR TITLE
Allow switching Windows runtimes.

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -99,6 +99,8 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.StringVar(&conf.ContainerdNamespace, "containerd-namespace", daemon.ContainersNamespace, "Containerd namespace to use")
 	flags.StringVar(&conf.ContainerdPluginNamespace, "containerd-plugins-namespace", containerd.PluginNamespace, "Containerd namespace to use for plugins")
 
+	flags.StringVar(&conf.DefaultRuntime, "default-runtime", config.StockRuntimeName, "Default OCI runtime for containers")
+
 	return nil
 }
 

--- a/cmd/dockerd/config_common_unix.go
+++ b/cmd/dockerd/config_common_unix.go
@@ -60,6 +60,4 @@ func installUnixConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.BoolVar(&conf.BridgeConfig.InterContainerCommunication, "icc", true, "Enable inter-container communication")
 	flags.Var(opts.NewIPOpt(&conf.BridgeConfig.DefaultIP, "0.0.0.0"), "ip", "Default IP when binding container ports")
 	flags.Var(opts.NewNamedRuntimeOpt("runtimes", &conf.Runtimes, config.StockRuntimeName), "add-runtime", "Register an additional OCI compatible runtime")
-	flags.StringVar(&conf.DefaultRuntime, "default-runtime", config.StockRuntimeName, "Default OCI runtime for containers")
-
 }

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -48,9 +48,7 @@ const (
 	// DefaultRuntimeBinary is the default runtime to be used by
 	// containerd if none is specified
 	DefaultRuntimeBinary = "runc"
-	// StockRuntimeName is the reserved name/alias used to represent the
-	// OCI runtime being shipped with the docker daemon package.
-	StockRuntimeName = "runc"
+
 	// LinuxV1RuntimeName is the runtime used to specify the containerd v1 shim with the runc binary
 	// Note this is different than io.containerd.runc.v1 which would be the v1 shim using the v2 shim API.
 	// This is specifically for the v1 shim using the v1 shim API.
@@ -273,6 +271,8 @@ type CommonConfig struct {
 
 	ContainerdNamespace       string `json:"containerd-namespace,omitempty"`
 	ContainerdPluginNamespace string `json:"containerd-plugin-namespace,omitempty"`
+
+	DefaultRuntime string `json:"default-runtime,omitempty"`
 }
 
 // IsValueSet returns true if a configuration value
@@ -635,4 +635,13 @@ func ModifiedDiscoverySettings(config *Config, backendType, advertise string, cl
 	}
 
 	return !reflect.DeepEqual(config.ClusterOpts, clusterOpts)
+}
+
+// GetDefaultRuntimeName returns the current default runtime
+func (conf *Config) GetDefaultRuntimeName() string {
+	conf.Lock()
+	rt := conf.DefaultRuntime
+	conf.Unlock()
+
+	return rt
 }

--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -19,6 +19,10 @@ const (
 
 	// DefaultCgroupV1NamespaceMode is the default mode for containers cgroup namespace when using cgroups v1.
 	DefaultCgroupV1NamespaceMode = containertypes.CgroupnsModeHost
+
+	// StockRuntimeName is the reserved name/alias used to represent the
+	// OCI runtime being shipped with the docker daemon package.
+	StockRuntimeName = "runc"
 )
 
 // BridgeConfig stores all the bridge driver specific
@@ -51,7 +55,6 @@ type Config struct {
 
 	// Fields below here are platform specific.
 	Runtimes             map[string]types.Runtime `json:"runtimes,omitempty"`
-	DefaultRuntime       string                   `json:"default-runtime,omitempty"`
 	DefaultInitBinary    string                   `json:"default-init,omitempty"`
 	CgroupParent         string                   `json:"cgroup-parent,omitempty"`
 	EnableSelinuxSupport bool                     `json:"selinux-enabled,omitempty"`
@@ -81,15 +84,6 @@ func (conf *Config) GetRuntime(name string) *types.Runtime {
 		return &rt
 	}
 	return nil
-}
-
-// GetDefaultRuntimeName returns the current default runtime
-func (conf *Config) GetDefaultRuntimeName() string {
-	conf.Lock()
-	rt := conf.DefaultRuntime
-	conf.Unlock()
-
-	return rt
 }
 
 // GetAllRuntimes returns a copy of the runtimes map

--- a/daemon/config/config_linux_test.go
+++ b/daemon/config/config_linux_test.go
@@ -150,7 +150,9 @@ func TestUnixValidateConfigurationErrors(t *testing.T) {
 				Runtimes: map[string]types.Runtime{
 					"foo": {},
 				},
-				DefaultRuntime: "bar",
+				CommonConfig: CommonConfig{
+					DefaultRuntime: "bar",
+				},
 			},
 		},
 	}

--- a/daemon/config/config_windows.go
+++ b/daemon/config/config_windows.go
@@ -4,6 +4,12 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
+const (
+	// This is used by the `default-runtime` flag in dockerd as the default value.
+	// On windows we'd prefer to keep this empty so the value is auto-detected based on other options.
+	StockRuntimeName = ""
+)
+
 // BridgeConfig stores all the bridge driver specific
 // configuration.
 type BridgeConfig struct {
@@ -24,11 +30,6 @@ type Config struct {
 // runtime name
 func (conf *Config) GetRuntime(name string) *types.Runtime {
 	return nil
-}
-
-// GetDefaultRuntimeName returns the current default runtime
-func (conf *Config) GetDefaultRuntimeName() string {
-	return StockRuntimeName
 }
 
 // GetAllRuntimes returns a copy of the runtimes map

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -29,6 +29,7 @@ import (
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/daemon/initlayer"
 	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/libcontainerd/remote"
 	"github.com/docker/docker/libnetwork"
 	nwconfig "github.com/docker/docker/libnetwork/config"
 	"github.com/docker/docker/libnetwork/drivers/bridge"
@@ -1735,4 +1736,16 @@ func (daemon *Daemon) RawSysInfo() *sysinfo.SysInfo {
 
 func recursiveUnmount(target string) error {
 	return mount.RecursiveUnmount(target)
+}
+
+func (daemon *Daemon) initLibcontainerd(ctx context.Context) error {
+	var err error
+	daemon.containerd, err = remote.NewClient(
+		ctx,
+		daemon.containerdCli,
+		filepath.Join(daemon.configStore.ExecRoot, "containerd"),
+		daemon.configStore.ContainerdNamespace,
+		daemon,
+	)
+	return err
 }


### PR DESCRIPTION
This adds support for 2 runtimes on Windows, one that uses the built-in
HCSv1 integration and another which uses containerd with the runhcs
shim.

---

Related to #41455