### PR TITLE
pkg/archive: TestUntarParentPathPermissions requires root

### DIFF
--- a/pkg/archive/archive_unix_test.go
+++ b/pkg/archive/archive_unix_test.go
@@ -160,6 +160,7 @@ func TestTarWithHardLinkAndRebase(t *testing.T) {
 // TestUntarParentPathPermissions is a regression test to check that missing
 // parent directories are created with the expected permissions
 func TestUntarParentPathPermissions(t *testing.T) {
+	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 	buf := &bytes.Buffer{}
 	w := tar.NewWriter(buf)
 	err := w.WriteHeader(&tar.Header{Name: "foo/bar"})


### PR DESCRIPTION
```
=== RUN   TestUntarParentPathPermissions
    archive_unix_test.go:171: assertion failed: error is not nil: chown /tmp/TestUntarParentPathPermissions694189715/foo: operation not permitted
```
```
$ sudo ./archive.test -test.v -test.run TestUntarParentPathPermissions
=== RUN   TestUntarParentPathPermissions
--- PASS: TestUntarParentPathPermissions (0.00s)
PASS
```

**- Description for the changelog**

Only run TestUntarParentPathPermissions with root

**- A picture of a cute animal (not mandatory but encouraged)**

