### PR TITLE
Builder: auto select the default branch of a git repository

### DIFF
--- a/builder/remotecontext/git/gitutils.go
+++ b/builder/remotecontext/git/gitutils.go
@@ -20,8 +20,7 @@ type gitRepo struct {
 	subdir string
 }
 
-// nolint: gosimple
-var defaultBranch = regexp.MustCompile("refs\\/heads\\/([^\\s]+)")
+var defaultBranch = regexp.MustCompile(`refs/heads/(\S+)`)
 
 // Clone clones a repository into a newly created directory which
 // will be under "docker-build-git"

--- a/builder/remotecontext/git/gitutils.go
+++ b/builder/remotecontext/git/gitutils.go
@@ -241,7 +241,7 @@ func getScheme(address string) string {
 func getDefaultBranch(remoteURL string) (string, error) {
 	out, err := git("ls-remote", "--symref", remoteURL, "HEAD")
 	if err != nil {
-		return "", err
+		return "", errors.Errorf("error fetching default branch for repository %s: %v", remoteURL, err)
 	}
 
 	ss := defaultBranch.FindAllStringSubmatch(string(out), -1)

--- a/builder/remotecontext/git/gitutils.go
+++ b/builder/remotecontext/git/gitutils.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/moby/sys/symlink"
@@ -18,6 +19,9 @@ type gitRepo struct {
 	ref    string
 	subdir string
 }
+
+// nolint: gosimple
+var defaultBranch = regexp.MustCompile("refs\\/heads\\/([^\\s]+)")
 
 // Clone clones a repository into a newly created directory which
 // will be under "docker-build-git"
@@ -100,6 +104,13 @@ func parseRemoteURL(remoteURL string) (gitRepo, error) {
 		repo.ref, repo.subdir = getRefAndSubdir(u.Fragment)
 		u.Fragment = ""
 		repo.remote = u.String()
+
+		if repo.ref == "" {
+			repo.ref, err = getDefaultBranch(repo.remote)
+			if err != nil {
+				return repo, err
+			}
+		}
 	}
 
 	if strings.HasPrefix(repo.ref, "-") {
@@ -111,7 +122,7 @@ func parseRemoteURL(remoteURL string) (gitRepo, error) {
 
 func getRefAndSubdir(fragment string) (ref string, subdir string) {
 	refAndDir := strings.SplitN(fragment, ":", 2)
-	ref = "master"
+	ref = ""
 	if len(refAndDir[0]) != 0 {
 		ref = refAndDir[0]
 	}
@@ -224,4 +235,18 @@ func getScheme(address string) string {
 		return ""
 	}
 	return u.Scheme
+}
+
+// getDefaultBranch gets the default branch of a repository using ls-remote
+func getDefaultBranch(remoteURL string) (string, error) {
+	out, err := git("ls-remote", "--symref", remoteURL, "HEAD")
+	if err != nil {
+		return "", err
+	}
+
+	ss := defaultBranch.FindAllStringSubmatch(string(out), -1)
+	if len(ss) == 0 || len(ss[0]) != 2 {
+		return "", errors.Errorf("could not find default branch for repository: %s", remoteURL)
+	}
+	return ss[0][1], nil
 }

--- a/builder/remotecontext/git/gitutils_test.go
+++ b/builder/remotecontext/git/gitutils_test.go
@@ -26,17 +26,17 @@ func TestParseRemoteURL(t *testing.T) {
 	}{
 		{
 			doc: "git scheme uppercase, no url-fragment",
-			url: "GIT://github.com/user/repo.git",
+			url: "GIT://github.com/moby/moby.git",
 			expected: gitRepo{
-				remote: "git://github.com/user/repo.git",
+				remote: "git://github.com/moby/moby.git",
 				ref:    "master",
 			},
 		},
 		{
 			doc: "git scheme, no url-fragment",
-			url: "git://github.com/user/repo.git",
+			url: "git://github.com/moby/moby.git",
 			expected: gitRepo{
-				remote: "git://github.com/user/repo.git",
+				remote: "git://github.com/moby/moby.git",
 				ref:    "master",
 			},
 		},
@@ -51,9 +51,9 @@ func TestParseRemoteURL(t *testing.T) {
 		},
 		{
 			doc: "https scheme, no url-fragment",
-			url: "https://github.com/user/repo.git",
+			url: "https://github.com/moby/moby.git",
 			expected: gitRepo{
-				remote: "https://github.com/user/repo.git",
+				remote: "https://github.com/moby/moby.git",
 				ref:    "master",
 			},
 		},
@@ -67,28 +67,12 @@ func TestParseRemoteURL(t *testing.T) {
 			},
 		},
 		{
-			doc: "git@, no url-fragment",
-			url: "git@github.com:user/repo.git",
-			expected: gitRepo{
-				remote: "git@github.com:user/repo.git",
-				ref:    "master",
-			},
-		},
-		{
 			doc: "git@, with url-fragment",
 			url: "git@github.com:user/repo.git#mybranch:mydir/mysubdir/",
 			expected: gitRepo{
 				remote: "git@github.com:user/repo.git",
 				ref:    "mybranch",
 				subdir: "mydir/mysubdir/",
-			},
-		},
-		{
-			doc: "ssh, no url-fragment",
-			url: "ssh://github.com/user/repo.git",
-			expected: gitRepo{
-				remote: "ssh://github.com/user/repo.git",
-				ref:    "master",
 			},
 		},
 		{

--- a/builder/remotecontext/git/gitutils_test.go
+++ b/builder/remotecontext/git/gitutils_test.go
@@ -41,6 +41,14 @@ func TestParseRemoteURL(t *testing.T) {
 			},
 		},
 		{
+			doc: "git scheme, no url-fragment, non-master branch",
+			url: "git://github.com/docker/compose-cli.git",
+			expected: gitRepo{
+				remote: "git://github.com/docker/compose-cli.git",
+				ref:    "main",
+			},
+		},
+		{
 			doc: "git scheme, with url-fragment",
 			url: "git://github.com/user/repo.git#mybranch:mydir/mysubdir/",
 			expected: gitRepo{
@@ -55,6 +63,14 @@ func TestParseRemoteURL(t *testing.T) {
 			expected: gitRepo{
 				remote: "https://github.com/moby/moby.git",
 				ref:    "master",
+			},
+		},
+		{
+			doc: "https scheme, no url-fragment, non-master branch",
+			url: "https://github.com/docker/compose-cli.git",
+			expected: gitRepo{
+				remote: "https://github.com/docker/compose-cli.git",
+				ref:    "main",
 			},
 		},
 		{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I added functionality to find the true default branch of a git repository, whereas previously it was hardcoded to `master`.

Fixes #41914

**- How I did it**

I added a function that uses `ls-remote` to find the default branch, and then wrote a regex to parse the result.

**- How to verify it**

```
docker build https://github.com/docker/compose-cli.git
```
(Make sure to pull the `gitutils.go` file into the vendors folder of the cli and then rebuild it)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

`Automatically select the default branch of a git repository`

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/54278938/109405160-a39def00-793b-11eb-8d3c-72a4254f8455.png)
