### PR TITLE
API-client: remove unused ContainerListOptions.Quiet field

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -59,7 +59,6 @@ type ContainerExecInspect struct {
 
 // ContainerListOptions holds parameters to list containers with.
 type ContainerListOptions struct {
-	Quiet   bool
 	Size    bool
 	All     bool
 	Latest  bool

--- a/testutil/environment/clean.go
+++ b/testutil/environment/clean.go
@@ -50,7 +50,6 @@ func getPausedContainers(ctx context.Context, t testing.TB, client client.Contai
 	filter.Add("status", "paused")
 	containers, err := client.ContainerList(ctx, types.ContainerListOptions{
 		Filters: filter,
-		Quiet:   true,
 		All:     true,
 	})
 	assert.Check(t, err, "failed to list containers")
@@ -85,8 +84,7 @@ func deleteAllContainers(t testing.TB, apiclient client.ContainerAPIClient, prot
 func getAllContainers(ctx context.Context, t testing.TB, client client.ContainerAPIClient) []types.Container {
 	t.Helper()
 	containers, err := client.ContainerList(ctx, types.ContainerListOptions{
-		Quiet: true,
-		All:   true,
+		All: true,
 	})
 	assert.Check(t, err, "failed to list containers")
 	return containers


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/42092

This option was originally added in d05aa418b0466553a24d42896f99176cfa29765f (https://github.com/moby/moby/pull/18472), and moved in 8b15839ee85b291266d07f97d9ad6ca0326d1339 (after which it temporarily went to the docker/engine-api repository, and was brought back in this repository in 91e197d614547f0202e6ae9b8a24d88ee131d950 (https://github.com/moby/moby/pull/26349)).

However, it looks like this field was never used; the API always returns the standard information, and the "--quiet" option for `docker ps` is implemented on the CLI side, which uses different formatting when setting this option; https://github.com/moby/moby/blob/2ec468e2844365f0d7e2afd744f322cde25c077e/api/client/ps.go#L73-L79

This patch removes the unused field.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

