### PR TITLE
set dockerd rootless .service environment

### DIFF
--- a/contrib/dockerd-rootless-setuptool.sh
+++ b/contrib/dockerd-rootless-setuptool.sh
@@ -293,7 +293,9 @@ install_systemd() {
 			Documentation=https://docs.docker.com/go/rootless/
 
 			[Service]
-			Environment=PATH=$BIN:/sbin:/usr/sbin:$PATH
+			Environment="XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR"
+			Environment="DOCKER_HOST="unix://$XDG_RUNTIME_DIR/docker.sock"
+			Environment="PATH=$BIN:/sbin:/usr/sbin:$PATH"
 			ExecStart=$BIN/dockerd-rootless.sh $DOCKERD_ROOTLESS_SH_FLAGS
 			ExecReload=/bin/kill -s HUP \$MAINPID
 			TimeoutSec=0


### PR DESCRIPTION
This PR configures the rootless dockerd .service Environment variables.

ref https://github.com/docker/docker-install/issues/208

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>