### PR TITLE
[20.10 backport] pkg/archive: TestUntarParentPathPermissions requires root

### DIFF
--- a/pkg/archive/archive_unix_test.go
+++ b/pkg/archive/archive_unix_test.go
@@ -160,6 +160,7 @@ func TestTarWithHardLinkAndRebase(t *testing.T) {
 // TestUntarParentPathPermissions is a regression test to check that missing
 // parent directories are created with the expected permissions
 func TestUntarParentPathPermissions(t *testing.T) {
+	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 	buf := &bytes.Buffer{}
 	w := tar.NewWriter(buf)
 	err := w.WriteHeader(&tar.Header{Name: "foo/bar"})


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/42094

```
=== RUN   TestUntarParentPathPermissions
    archive_unix_test.go:171: assertion failed: error is not nil: chown /tmp/TestUntarParentPathPermissions694189715/foo: operation not permitted
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

