### PR TITLE
fix a typo in comments

### DIFF
--- a/layer/layer.go
+++ b/layer/layer.go
@@ -126,7 +126,7 @@ type RWLayer interface {
 	Parent() Layer
 
 	// Mount mounts the RWLayer and returns the filesystem path
-	// the to the writable layer.
+	// to the writable layer.
 	Mount(mountLabel string) (containerfs.ContainerFS, error)
 
 	// Unmount unmounts the RWLayer. This should be called


### PR DESCRIPTION
Signed-off-by: Kaijie Chen <chen@kaijie.org>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed a typo in comments.

**- How I did it**
Removing an extra "the".

**- Description for the changelog**
// Mount mounts the RWLayer and returns the filesystem path
// ~~the~~ to the writable layer.
