### PR TITLE
docker: fix docker kill command block

### DIFF
--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -137,6 +137,8 @@ func (daemon *Daemon) Kill(container *containerpkg.Container) error {
 		return errNotRunning(container.ID)
 	}
 
+	waitStop := container.GetWaitStop()
+
 	// 1. Send SIGKILL
 	if err := daemon.killPossiblyDeadProcess(container, int(syscall.SIGKILL)); err != nil {
 		// While normally we might "return err" here we're not going to
@@ -171,7 +173,7 @@ func (daemon *Daemon) Kill(container *containerpkg.Container) error {
 
 	// Wait for exit with no timeout.
 	// Ignore returned status.
-	<-container.Wait(context.Background(), containerpkg.WaitConditionNotRunning)
+	<-container.Wait3(context.Background(), containerpkg.WaitConditionNotRunning, waitStop)
 
 	return nil
 }


### PR DESCRIPTION
fix #42113 

docker kill command block when executes with start/restart concurrently
script to reproduce it

```
function do_test() {
    local cid
    local pid_list
    local timeout_pid
	opt_list=("restart" "stop" "start" "inspect" "kill")
    cid=$(docker run -itd ubuntu bash)
    for i in $(seq 1 100); do
        pid_list=()
        for opt in ${opt_list[*]}; do
            docker "${opt}" "${cid}" &
            #docker exec "${cid}" ps &
        done
        wait
    done
}
```
When docker kill command execute with start/restart command
concurrently, kill command may block at <-container.Wait.
As s.waitStop is variable, so there is case that waitStop in Wait
function get a new s.waitStop(the old one is already closed before).
So kill command blocked to wait the new s.waitStop close.

