### PR TITLE
Correct type of Mounts in ContainerSummary

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4238,7 +4238,7 @@ definitions:
       Mounts:
         type: "array"
         items:
-          $ref: "#/definitions/Mount"
+          $ref: "#/definitions/MountPoint"
 
   Driver:
     description: "Driver represents a driver (network, logging, secrets)."

--- a/docs/api/v1.25.yaml
+++ b/docs/api/v1.25.yaml
@@ -2387,7 +2387,7 @@ definitions:
         Mounts:
           type: "array"
           items:
-            $ref: "#/definitions/Mount"
+            $ref: "#/definitions/MountPoint"
   SecretSpec:
     type: "object"
     properties:

--- a/docs/api/v1.26.yaml
+++ b/docs/api/v1.26.yaml
@@ -2392,7 +2392,7 @@ definitions:
         Mounts:
           type: "array"
           items:
-            $ref: "#/definitions/Mount"
+            $ref: "#/definitions/MountPoint"
   SecretSpec:
     type: "object"
     properties:

--- a/docs/api/v1.27.yaml
+++ b/docs/api/v1.27.yaml
@@ -2457,7 +2457,7 @@ definitions:
         Mounts:
           type: "array"
           items:
-            $ref: "#/definitions/Mount"
+            $ref: "#/definitions/MountPoint"
   SecretSpec:
     type: "object"
     properties:

--- a/docs/api/v1.28.yaml
+++ b/docs/api/v1.28.yaml
@@ -2545,7 +2545,7 @@ definitions:
         Mounts:
           type: "array"
           items:
-            $ref: "#/definitions/Mount"
+            $ref: "#/definitions/MountPoint"
   SecretSpec:
     type: "object"
     properties:

--- a/docs/api/v1.29.yaml
+++ b/docs/api/v1.29.yaml
@@ -2579,7 +2579,7 @@ definitions:
         Mounts:
           type: "array"
           items:
-            $ref: "#/definitions/Mount"
+            $ref: "#/definitions/MountPoint"
   SecretSpec:
     type: "object"
     properties:

--- a/docs/api/v1.30.yaml
+++ b/docs/api/v1.30.yaml
@@ -2753,7 +2753,7 @@ definitions:
         Mounts:
           type: "array"
           items:
-            $ref: "#/definitions/Mount"
+            $ref: "#/definitions/MountPoint"
   SecretSpec:
     type: "object"
     properties:

--- a/docs/api/v1.31.yaml
+++ b/docs/api/v1.31.yaml
@@ -2783,7 +2783,7 @@ definitions:
         Mounts:
           type: "array"
           items:
-            $ref: "#/definitions/Mount"
+            $ref: "#/definitions/MountPoint"
 
   Driver:
     description: "Driver represents a driver (network, logging, secrets)."

--- a/docs/api/v1.32.yaml
+++ b/docs/api/v1.32.yaml
@@ -3256,7 +3256,7 @@ definitions:
         Mounts:
           type: "array"
           items:
-            $ref: "#/definitions/Mount"
+            $ref: "#/definitions/MountPoint"
 
   Driver:
     description: "Driver represents a driver (network, logging, secrets)."

--- a/docs/api/v1.33.yaml
+++ b/docs/api/v1.33.yaml
@@ -3261,7 +3261,7 @@ definitions:
         Mounts:
           type: "array"
           items:
-            $ref: "#/definitions/Mount"
+            $ref: "#/definitions/MountPoint"
 
   Driver:
     description: "Driver represents a driver (network, logging, secrets)."

--- a/docs/api/v1.34.yaml
+++ b/docs/api/v1.34.yaml
@@ -3290,7 +3290,7 @@ definitions:
         Mounts:
           type: "array"
           items:
-            $ref: "#/definitions/Mount"
+            $ref: "#/definitions/MountPoint"
 
   Driver:
     description: "Driver represents a driver (network, logging, secrets)."

--- a/docs/api/v1.35.yaml
+++ b/docs/api/v1.35.yaml
@@ -3272,7 +3272,7 @@ definitions:
         Mounts:
           type: "array"
           items:
-            $ref: "#/definitions/Mount"
+            $ref: "#/definitions/MountPoint"
 
   Driver:
     description: "Driver represents a driver (network, logging, secrets)."

--- a/docs/api/v1.36.yaml
+++ b/docs/api/v1.36.yaml
@@ -3285,7 +3285,7 @@ definitions:
         Mounts:
           type: "array"
           items:
-            $ref: "#/definitions/Mount"
+            $ref: "#/definitions/MountPoint"
 
   Driver:
     description: "Driver represents a driver (network, logging, secrets)."

--- a/docs/api/v1.37.yaml
+++ b/docs/api/v1.37.yaml
@@ -3291,7 +3291,7 @@ definitions:
         Mounts:
           type: "array"
           items:
-            $ref: "#/definitions/Mount"
+            $ref: "#/definitions/MountPoint"
 
   Driver:
     description: "Driver represents a driver (network, logging, secrets)."

--- a/docs/api/v1.38.yaml
+++ b/docs/api/v1.38.yaml
@@ -3345,7 +3345,7 @@ definitions:
         Mounts:
           type: "array"
           items:
-            $ref: "#/definitions/Mount"
+            $ref: "#/definitions/MountPoint"
 
   Driver:
     description: "Driver represents a driver (network, logging, secrets)."

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -3959,7 +3959,7 @@ definitions:
         Mounts:
           type: "array"
           items:
-            $ref: "#/definitions/Mount"
+            $ref: "#/definitions/MountPoint"
 
   Driver:
     description: "Driver represents a driver (network, logging, secrets)."

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -4084,7 +4084,7 @@ definitions:
       Mounts:
         type: "array"
         items:
-          $ref: "#/definitions/Mount"
+          $ref: "#/definitions/MountPoint"
 
   Driver:
     description: "Driver represents a driver (network, logging, secrets)."

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -4238,7 +4238,7 @@ definitions:
       Mounts:
         type: "array"
         items:
-          $ref: "#/definitions/Mount"
+          $ref: "#/definitions/MountPoint"
 
   Driver:
     description: "Driver represents a driver (network, logging, secrets)."


### PR DESCRIPTION
- closes #42120
- closes https://github.com/docker/for-linux/issues/1361

Changed the type of ContainerSummary.Mounts from Mount to MountPoint in the Swagger Spec.
Signed-off-by: Michael Weidmann <michaelweidmann@web.de>

**- What I did**
Changed the type of ContainerSummary.Mounts from Mount to MountPoint in the Swagger Spec.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
Changed the type of ContainerSummary.Mounts from Mount to MountPoint in the Swagger Spec.

**- A picture of a cute animal (not mandatory but encouraged)**
My cat supported me! :)

![WhatsApp Image 2020-08-25 at 14 32 20](https://user-images.githubusercontent.com/37302540/110541256-c85a4980-8127-11eb-9724-eecbdc464f33.jpeg)
