### PR TITLE
vendor: github.com/moby/sys/mountinfo v0.4.1, github.com/moby/sys/mount v0.2.0+

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -14,7 +14,7 @@ github.com/moby/term                                bea5bbe245bf407372d477f1361d
 # tool (vndr) currently does not support submodules / vendoring sub-paths, so we vendor
 # the top-level moby/sys repository (which contains both) and pick the most recent tag,
 # which could be either `mountinfo/vX.Y.Z`, `mount/vX.Y.Z`, or `symlink/vX.Y.Z`.
-github.com/moby/sys                                 1bc8673b57550ddf85262eb0fed0aac651a37dab # symlink/v0.1.0
+github.com/moby/sys                                 b0f1fd7235275d01bd35cc4421e884e522395f45 # mountinfo/v0.4.1
 
 github.com/creack/pty                               2a38352e8b4d7ab6c336eef107e42a55e72e7fbc # v1.1.11
 github.com/sirupsen/logrus                          6699a89a232f3db797f2e280639854bbc4b89725 # v1.7.0

--- a/vendor/github.com/moby/sys/mount/go.mod
+++ b/vendor/github.com/moby/sys/mount/go.mod
@@ -3,6 +3,6 @@ module github.com/moby/sys/mount
 go 1.14
 
 require (
-	github.com/moby/sys/mountinfo v0.3.1
+	github.com/moby/sys/mountinfo v0.4.0
 	golang.org/x/sys v0.0.0-20200922070232-aee5d888a860
 )

--- a/vendor/github.com/moby/sys/mount/mounter_freebsd.go
+++ b/vendor/github.com/moby/sys/mount/mounter_freebsd.go
@@ -1,4 +1,4 @@
-// +build freebsd,cgo openbsd,cgo
+// +build freebsd,cgo
 
 package mount
 

--- a/vendor/github.com/moby/sys/mount/mounter_openbsd.go
+++ b/vendor/github.com/moby/sys/mount/mounter_openbsd.go
@@ -1,0 +1,77 @@
+// +build openbsd,cgo
+
+/*
+   Due to how OpenBSD mount(2) works, filesystem types need to be
+   supported explicitly since it uses separate structs to pass
+   filesystem-specific arguments.
+
+   For now only UFS/FFS is supported as it's the default fs
+   on OpenBSD systems.
+
+   See: https://man.openbsd.org/mount.2
+*/
+
+package mount
+
+/*
+#include <sys/types.h>
+#include <sys/mount.h>
+*/
+import "C"
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+func createExportInfo(readOnly bool) C.struct_export_args {
+	exportFlags := C.int(0)
+	if readOnly {
+		exportFlags = C.MNT_EXRDONLY
+	}
+	out := C.struct_export_args{
+		ex_root:  0,
+		ex_flags: exportFlags,
+	}
+	return out
+}
+
+func createUfsArgs(device string, readOnly bool) unsafe.Pointer {
+	out := &C.struct_ufs_args{
+		fspec:       C.CString(device),
+		export_info: createExportInfo(readOnly),
+	}
+	return unsafe.Pointer(out)
+}
+
+func mount(device, target, mType string, flag uintptr, data string) error {
+	readOnly := flag&RDONLY != 0
+
+	var fsArgs unsafe.Pointer
+
+	switch mType {
+	case "ffs":
+		fsArgs = createUfsArgs(device, readOnly)
+	default:
+		return &mountError{
+			op:     "mount",
+			source: device,
+			target: target,
+			flags:  flag,
+			err:    fmt.Errorf("unsupported file system type: %s", mType),
+		}
+	}
+
+	if errno := C.mount(C.CString(mType), C.CString(target), C.int(flag), fsArgs); errno != 0 {
+		return &mountError{
+			op:     "mount",
+			source: device,
+			target: target,
+			flags:  flag,
+			err:    syscall.Errno(errno),
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/moby/sys/mountinfo/mountinfo.go
+++ b/vendor/github.com/moby/sys/mountinfo/mountinfo.go
@@ -29,35 +29,38 @@ type Info struct {
 	// ID is a unique identifier of the mount (may be reused after umount).
 	ID int
 
-	// Parent indicates the ID of the mount parent (or of self for the top of the
-	// mount tree).
+	// Parent is the ID of the parent mount (or of self for the root
+	// of this mount namespace's mount tree).
 	Parent int
 
-	// Major indicates one half of the device ID which identifies the device class.
-	Major int
+	// Major and Minor are the major and the minor components of the Dev
+	// field of unix.Stat_t structure returned by unix.*Stat calls for
+	// files on this filesystem.
+	Major, Minor int
 
-	// Minor indicates one half of the device ID which identifies a specific
-	// instance of device.
-	Minor int
-
-	// Root of the mount within the filesystem.
+	// Root is the pathname of the directory in the filesystem which forms
+	// the root of this mount.
 	Root string
 
-	// Mountpoint indicates the mount point relative to the process's root.
+	// Mountpoint is the pathname of the mount point relative to the
+	// process's root directory.
 	Mountpoint string
 
-	// Options represents mount-specific options.
+	// Options is a comma-separated list of mount options.
 	Options string
 
-	// Optional represents optional fields.
+	// Optional are zero or more fields of the form "tag[:value]",
+	// separated by a space.  Currently, the possible optional fields are
+	// "shared", "master", "propagate_from", and "unbindable". For more
+	// information, see mount_namespaces(7) Linux man page.
 	Optional string
 
-	// FSType indicates the type of filesystem, such as EXT3.
+	// FSType is the filesystem type in the form "type[.subtype]".
 	FSType string
 
-	// Source indicates filesystem specific information or "none".
+	// Source is filesystem-specific information, or "none".
 	Source string
 
-	// VFSOptions represents per super block options.
+	// VFSOptions is a comma-separated list of superblock options.
 	VFSOptions string
 }

--- a/vendor/github.com/moby/sys/mountinfo/mountinfo_filters.go
+++ b/vendor/github.com/moby/sys/mountinfo/mountinfo_filters.go
@@ -14,11 +14,16 @@ import "strings"
 // stop: true if parsing should be stopped after the entry.
 type FilterFunc func(*Info) (skip, stop bool)
 
-// PrefixFilter discards all entries whose mount points
-// do not start with a specific prefix.
+// PrefixFilter discards all entries whose mount points do not start with, or
+// are equal to the path specified in prefix. The prefix path must be absolute,
+// have all symlinks resolved, and cleaned (i.e. no extra slashes or dots).
+//
+// PrefixFilter treats prefix as a path, not a partial prefix, which means that
+// given "/foo", "/foo/bar" and "/foobar" entries, PrefixFilter("/foo") returns
+// "/foo" and "/foo/bar", and discards "/foobar".
 func PrefixFilter(prefix string) FilterFunc {
 	return func(m *Info) (bool, bool) {
-		skip := !strings.HasPrefix(m.Mountpoint, prefix)
+		skip := !strings.HasPrefix(m.Mountpoint+"/", prefix+"/")
 		return skip, false
 	}
 }

--- a/vendor/github.com/moby/sys/mountinfo/mountinfo_linux.go
+++ b/vendor/github.com/moby/sys/mountinfo/mountinfo_linux.go
@@ -12,7 +12,8 @@ import (
 // GetMountsFromReader retrieves a list of mounts from the
 // reader provided, with an optional filter applied (use nil
 // for no filter). This can be useful in tests or benchmarks
-// that provide a fake mountinfo data.
+// that provide fake mountinfo data, or when a source other
+// than /proc/self/mountinfo needs to be read from.
 //
 // This function is Linux-specific.
 func GetMountsFromReader(r io.Reader, filter FilterFunc) ([]*Info, error) {
@@ -133,8 +134,6 @@ func GetMountsFromReader(r io.Reader, filter FilterFunc) ([]*Info, error) {
 	return out, nil
 }
 
-// Parse /proc/self/mountinfo because comparing Dev and ino does not work from
-// bind mounts
 func parseMountTable(filter FilterFunc) ([]*Info, error) {
 	f, err := os.Open("/proc/self/mountinfo")
 	if err != nil {

--- a/vendor/github.com/moby/sys/symlink/go.mod
+++ b/vendor/github.com/moby/sys/symlink/go.mod
@@ -1,5 +1,5 @@
 module github.com/moby/sys/symlink
 
-go 1.13
+go 1.14
 
 require golang.org/x/sys v0.0.0-20200922070232-aee5d888a860


### PR DESCRIPTION
full diff: https://github.com/moby/sys/compare/symlink/v0.1.0...mountinfo/v0.4.1

github.com/moby/sys/mountinfo v0.4.1
----------------------------------------------

- Fix PrefixFilter() being too greedy
- TestMountedBy*: add missing pre-checks
- Documentation improvements

github.com/moby/sys/mount v0.2.0
----------------------------------------------

Breaking changes:

- Remove stub-implementations for Windows for `Mount()`, `Unmount()`,
  `RecursiveUnmount()`, `MergeTmpfsOptions()`

Fixes and improvements:

- `go.mod`: update github.com/moby/sys/mountinfo to v0.4.0
- use `MNT_*` flags from golang.org/x/sys/unix on freebsd
- add support for OpenBSD in addition to FreeBSD
- fix package overview documentation not showing
- `RecursiveUnmount()`: minor improvements

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

