### PR TITLE
Prepare tests for Windows containerd support

### DIFF
--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -440,7 +440,7 @@ func (s *DockerSuite) TestEventsCopy(c *testing.T) {
 }
 
 func (s *DockerSuite) TestEventsResize(c *testing.T) {
-	out := runSleepingContainer(c, "-d")
+	out := runSleepingContainer(c, "-d", "-t")
 	cID := strings.TrimSpace(out)
 	assert.NilError(c, waitRun(cID))
 

--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -35,14 +35,19 @@ func TestCopyFromContainerPathDoesNotExist(t *testing.T) {
 
 func TestCopyFromContainerPathIsNotDir(t *testing.T) {
 	defer setupTest(t)()
-	skip.If(t, testEnv.OSType == "windows")
 
 	ctx := context.Background()
 	apiclient := testEnv.APIClient()
 	cid := container.Create(ctx, t, apiclient)
 
-	_, _, err := apiclient.CopyFromContainer(ctx, cid, "/etc/passwd/")
-	assert.Assert(t, is.ErrorContains(err, "not a directory"))
+	path := "/etc/passwd/"
+	expected := "not a directory"
+	if testEnv.OSType == "windows" {
+		path = "c:/windows/system32/drivers/etc/hosts/"
+		expected = "The filename, directory name, or volume label syntax is incorrect."
+	}
+	_, _, err := apiclient.CopyFromContainer(ctx, cid, path)
+	assert.Assert(t, is.ErrorContains(err, expected))
 }
 
 func TestCopyToContainerPathDoesNotExist(t *testing.T) {
@@ -60,13 +65,16 @@ func TestCopyToContainerPathDoesNotExist(t *testing.T) {
 
 func TestCopyToContainerPathIsNotDir(t *testing.T) {
 	defer setupTest(t)()
-	skip.If(t, testEnv.OSType == "windows")
 
 	ctx := context.Background()
 	apiclient := testEnv.APIClient()
 	cid := container.Create(ctx, t, apiclient)
 
-	err := apiclient.CopyToContainer(ctx, cid, "/etc/passwd/", nil, types.CopyToContainerOptions{})
+	path := "/etc/passwd/"
+	if testEnv.OSType == "windows" {
+		path = "c:/windows/system32/drivers/etc/hosts/"
+	}
+	err := apiclient.CopyToContainer(ctx, cid, path, nil, types.CopyToContainerOptions{})
 	assert.Assert(t, is.ErrorContains(err, "not a directory"))
 }
 

--- a/integration/container/pause_test.go
+++ b/integration/container/pause_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	containerderrdefs "github.com/containerd/containerd/errdefs"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
@@ -62,7 +63,7 @@ func TestPauseFailsOnWindowsServerContainers(t *testing.T) {
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	err := client.ContainerPause(ctx, cID)
-	assert.Check(t, is.ErrorContains(err, "cannot pause Windows Server Containers"))
+	assert.Check(t, is.ErrorContains(err, containerderrdefs.ErrNotImplemented.Error()))
 }
 
 func TestPauseStopPausedContainer(t *testing.T) {

--- a/integration/container/rename_test.go
+++ b/integration/container/rename_test.go
@@ -123,7 +123,6 @@ func TestRenameInvalidName(t *testing.T) {
 // This test is to make sure once the container has been renamed,
 // the service discovery for the (re)named container works.
 func TestRenameAnonymousContainer(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := testEnv.APIClient()

--- a/integration/container/resize_test.go
+++ b/integration/container/resize_test.go
@@ -21,7 +21,7 @@ func TestResize(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(ctx, t, client)
+	cID := container.Run(ctx, t, client, container.WithTty(true))
 
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
@@ -34,7 +34,6 @@ func TestResize(t *testing.T) {
 
 func TestResizeWithInvalidSize(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.32"), "broken in earlier versions")
-	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	client := testEnv.APIClient()
 	ctx := context.Background()

--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -22,6 +22,7 @@ import (
 	opengcs "github.com/Microsoft/opengcs/client"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
+	containerderrdefs "github.com/containerd/containerd/errdefs"
 
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libcontainerd/queue"
@@ -985,7 +986,7 @@ func (c *client) Pause(_ context.Context, containerID string) error {
 	}
 
 	if ctr.ociSpec.Windows.HyperV == nil {
-		return errors.New("cannot pause Windows Server Containers")
+		return containerderrdefs.ErrNotImplemented
 	}
 
 	ctr.Lock()


### PR DESCRIPTION
**- What I did**
As part of Windows + ContainerD CI work on #41479 I noticed that some tests need to be slightly modified that for that purpose. Additionally I enabled some tests which have been disabled on Windows earlier.

**- How I did it**
On way that those should works both with and without ContainerD on Windows.

**- How to verify it**
Pass CI here and you can also check from #41479 build log that these tests have passed.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/6213926/111674791-13114b00-8825-11eb-84f3-1d942445f387.png)

