### PR TITLE
WIP: Remove legacy LCOW code

### DIFF
--- a/builder/dockerfile/builder_unix.go
+++ b/builder/dockerfile/builder_unix.go
@@ -2,6 +2,6 @@
 
 package dockerfile // import "github.com/docker/docker/builder/dockerfile"
 
-func defaultShellForOS(os string) []string {
+func defaultShell() []string {
 	return []string{"/bin/sh", "-c"}
 }

--- a/builder/dockerfile/builder_windows.go
+++ b/builder/dockerfile/builder_windows.go
@@ -1,8 +1,5 @@
 package dockerfile // import "github.com/docker/docker/builder/dockerfile"
 
-func defaultShellForOS(os string) []string {
-	if os == "linux" {
-		return []string{"/bin/sh", "-c"}
-	}
+func defaultShell() []string {
 	return []string{"cmd", "/S", "/C"}
 }

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -305,7 +305,7 @@ func dispatchWorkdir(ctx context.Context, d dispatchRequest, c *instructions.Wor
 	}
 
 	comment := "WORKDIR " + runConfig.WorkingDir
-	runConfigWithCommentCmd := copyRunConfig(runConfig, withCmdCommentString(comment, d.state.operatingSystem))
+	runConfigWithCommentCmd := copyRunConfig(runConfig, withCmdCommentString(comment))
 
 	containerID, err := d.builder.probeAndCreate(ctx, d.state, runConfigWithCommentCmd)
 	if err != nil || containerID == "" {
@@ -325,7 +325,7 @@ func dispatchWorkdir(ctx context.Context, d dispatchRequest, c *instructions.Wor
 // the current SHELL which defaults to 'sh -c' under linux or 'cmd /S /C' under
 // Windows, in the event there is only one argument The difference in processing:
 //
-// RUN echo hi          # sh -c echo hi       (Linux and LCOW)
+// RUN echo hi          # sh -c echo hi       (Linux)
 // RUN echo hi          # cmd /S /C echo hi   (Windows)
 // RUN [ "echo", "hi" ] # echo hi
 func dispatchRun(ctx context.Context, d dispatchRequest, c *instructions.RunCommand) error {
@@ -339,7 +339,7 @@ func dispatchRun(ctx context.Context, d dispatchRequest, c *instructions.RunComm
 	}
 
 	stateRunConfig := d.state.runConfig
-	cmdFromArgs, argsEscaped := resolveCmdLine(c.ShellDependantCmdLine, stateRunConfig, d.state.operatingSystem, c.Name(), c.String())
+	cmdFromArgs, argsEscaped := resolveCmdLine(c.ShellDependantCmdLine, stateRunConfig, c.Name(), c.String())
 	buildArgs := d.state.buildArgs.FilterAllowed(stateRunConfig.Env)
 
 	saveCmd := cmdFromArgs
@@ -431,7 +431,7 @@ func prependEnvOnCmd(buildArgs *BuildArgs, buildArgVars []string, cmd []string) 
 // Argument handling is the same as RUN.
 func dispatchCmd(ctx context.Context, d dispatchRequest, c *instructions.CmdCommand) error {
 	runConfig := d.state.runConfig
-	cmd, argsEscaped := resolveCmdLine(c.ShellDependantCmdLine, runConfig, d.state.operatingSystem, c.Name(), c.String())
+	cmd, argsEscaped := resolveCmdLine(c.ShellDependantCmdLine, runConfig, c.Name(), c.String())
 
 	// We warn here as Windows shell processing operates differently to Linux.
 	// Linux:   /bin/sh -c "echo hello" world	--> hello
@@ -480,7 +480,7 @@ func dispatchHealthcheck(ctx context.Context, d dispatchRequest, c *instructions
 // is initialized at newBuilder time instead of through argument parsing.
 func dispatchEntrypoint(ctx context.Context, d dispatchRequest, c *instructions.EntrypointCommand) error {
 	runConfig := d.state.runConfig
-	cmd, argsEscaped := resolveCmdLine(c.ShellDependantCmdLine, runConfig, d.state.operatingSystem, c.Name(), c.String())
+	cmd, argsEscaped := resolveCmdLine(c.ShellDependantCmdLine, runConfig, c.Name(), c.String())
 
 	// This warning is a little more complex than in dispatchCmd(), as the Windows base images (similar
 	// universally to almost every Linux image out there) have a single .Cmd field populated so that

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -261,7 +261,7 @@ func TestCmd(t *testing.T) {
 
 	var expectedCommand []string
 	if runtime.GOOS == "windows" {
-		expectedCommand = []string{"cmd", "/S", "/C", "./executable"}
+		expectedCommand = []string{"cmd /S /C ./executable"}
 	} else {
 		expectedCommand = []string{"/bin/sh", "-c", "./executable"}
 	}
@@ -316,7 +316,7 @@ func TestEntrypoint(t *testing.T) {
 
 	var expectedEntrypoint []string
 	if runtime.GOOS == "windows" {
-		expectedEntrypoint = []string{"cmd", "/S", "/C", "/usr/sbin/nginx"}
+		expectedEntrypoint = []string{"cmd /S /C /usr/sbin/nginx"}
 	} else {
 		expectedEntrypoint = []string{"/bin/sh", "-c", "/usr/sbin/nginx"}
 	}

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -441,9 +441,9 @@ func TestRunWithBuildArgs(t *testing.T) {
 
 	var cmdWithShell []string
 	if runtime.GOOS == "windows" {
-		cmdWithShell = []string{strings.Join(append(getShell(runConfig, runtime.GOOS), []string{"echo foo"}...), " ")}
+		cmdWithShell = []string{strings.Join(append(getShell(runConfig), []string{"echo foo"}...), " ")}
 	} else {
-		cmdWithShell = append(getShell(runConfig, runtime.GOOS), "echo foo")
+		cmdWithShell = append(getShell(runConfig), "echo foo")
 	}
 
 	envVars := []string{"|1", "one=two"}

--- a/builder/dockerfile/dispatchers_unix.go
+++ b/builder/dockerfile/dispatchers_unix.go
@@ -27,10 +27,10 @@ func normalizeWorkdir(_ string, current string, requested string) (string, error
 
 // resolveCmdLine takes a command line arg set and optionally prepends a platform-specific
 // shell in front of it.
-func resolveCmdLine(cmd instructions.ShellDependantCmdLine, runConfig *container.Config, os, _, _ string) ([]string, bool) {
+func resolveCmdLine(cmd instructions.ShellDependantCmdLine, runConfig *container.Config, _, _ string) ([]string, bool) {
 	result := cmd.CmdLine
 	if cmd.PrependShell && result != nil {
-		result = append(getShell(runConfig, os), result...)
+		result = append(getShell(runConfig), result...)
 	}
 	return result, false
 }

--- a/builder/dockerfile/imagecontext.go
+++ b/builder/dockerfile/imagecontext.go
@@ -80,9 +80,9 @@ func (m *imageSources) Add(im *imageMount, platform *ocispec.Platform) {
 			platform = &p
 		}
 
-		// Windows does not support scratch except for LCOW
 		os := platform.OS
 		if runtime.GOOS == "windows" {
+			// Windows does not support scratch, so always linux
 			os = "linux"
 		}
 

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -39,7 +39,7 @@ func (b *Builder) commit(ctx context.Context, dispatchState *dispatchState, comm
 		return errors.New("Please provide a source image with `from` prior to commit")
 	}
 
-	runConfigWithCommentCmd := copyRunConfig(dispatchState.runConfig, withCmdComment(comment, dispatchState.operatingSystem))
+	runConfigWithCommentCmd := copyRunConfig(dispatchState.runConfig, withCmdComment(comment))
 	id, err := b.probeAndCreate(ctx, dispatchState, runConfigWithCommentCmd)
 	if err != nil || id == "" {
 		return err
@@ -130,7 +130,7 @@ func (b *Builder) performCopy(ctx context.Context, req dispatchRequest, inst cop
 	commentStr := fmt.Sprintf("%s %s%s in %s ", inst.cmdName, chownComment, srcHash, inst.dest)
 
 	// TODO: should this have been using origPaths instead of srcHash in the comment?
-	runConfigWithCommentCmd := copyRunConfig(state.runConfig, withCmdCommentString(commentStr, state.operatingSystem))
+	runConfigWithCommentCmd := copyRunConfig(state.runConfig, withCmdCommentString(commentStr))
 	hit, err := b.probeCache(state, runConfigWithCommentCmd)
 	if err != nil || hit {
 		return err
@@ -229,9 +229,9 @@ func withArgsEscaped(argsEscaped bool) runConfigModifier {
 
 // withCmdComment sets Cmd to a nop comment string. See withCmdCommentString for
 // why there are two almost identical versions of this.
-func withCmdComment(comment string, platform string) runConfigModifier {
+func withCmdComment(comment string) runConfigModifier {
 	return func(runConfig *container.Config) {
-		runConfig.Cmd = append(getShell(runConfig, platform), "#(nop) ", comment)
+		runConfig.Cmd = append(getShell(runConfig), "#(nop) ", comment)
 	}
 }
 
@@ -239,9 +239,9 @@ func withCmdComment(comment string, platform string) runConfigModifier {
 // A few instructions (workdir, copy, add) used a nop comment that is a single arg
 // where as all the other instructions used a two arg comment string. This
 // function implements the single arg version.
-func withCmdCommentString(comment string, platform string) runConfigModifier {
+func withCmdCommentString(comment string) runConfigModifier {
 	return func(runConfig *container.Config) {
-		runConfig.Cmd = append(getShell(runConfig, platform), "#(nop) "+comment)
+		runConfig.Cmd = append(getShell(runConfig), "#(nop) "+comment)
 	}
 }
 
@@ -322,9 +322,9 @@ func copyStringSlice(orig []string) []string {
 
 // getShell is a helper function which gets the right shell for prefixing the
 // shell-form of RUN, ENTRYPOINT and CMD instructions
-func getShell(c *container.Config, os string) []string {
+func getShell(c *container.Config) []string {
 	if 0 == len(c.Shell) {
-		return append([]string{}, defaultShellForOS(os)[:]...)
+		return defaultShell()
 	}
 	return append([]string{}, c.Shell[:]...)
 }

--- a/builder/dockerfile/internals_test.go
+++ b/builder/dockerfile/internals_test.go
@@ -103,9 +103,9 @@ func TestCopyRunConfig(t *testing.T) {
 		},
 		{
 			doc:       "Set the command to a comment",
-			modifiers: []runConfigModifier{withCmdComment("comment", runtime.GOOS)},
+			modifiers: []runConfigModifier{withCmdComment("comment")},
 			expected: &container.Config{
-				Cmd: append(defaultShellForOS(runtime.GOOS), "#(nop) ", "comment"),
+				Cmd: append(defaultShell(), "#(nop) ", "comment"),
 				Env: defaultEnv,
 			},
 		},

--- a/builder/dockerfile/internals_windows.go
+++ b/builder/dockerfile/internals_windows.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/containerd/platforms"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/errdefs"
@@ -62,14 +61,8 @@ func lookupNTAccount(ctx context.Context, builder *Builder, accountName string, 
 
 	target := "C:\\Docker"
 	targetExecutable := target + "\\containerutility.exe"
-
-	optionsPlatform, err := platforms.Parse(builder.options.Platform)
-	if err != nil {
-		return identity{}, errdefs.InvalidParameter(err)
-	}
-
 	runConfig := copyRunConfig(state.runConfig,
-		withCmdCommentString("internal run to obtain NT account information.", optionsPlatform.OS))
+		withCmdCommentString("internal run to obtain NT account information."))
 
 	runConfig.Cmd = []string{targetExecutable, "getaccountsid", accountName}
 


### PR DESCRIPTION
The LCOW implementation in dockerd has been deprecated in favor of re-implementation in containerd (in progress). Microsoft started removing the LCOW V1 code from the build dependencies we use in Microsoft/opengcs in https://github.com/microsoft/opengcs/commit/e972b276edcc73be63c6f05a53e623bf38e5332a (https://github.com/microsoft/opengcs/pull/390), soon to be part of Microsoft/hcshhim (https://github.com/microsoft/hcsshim/pull/973).

The (pre https://github.com/microsoft/opengcs/commit/e972b276edcc73be63c6f05a53e623bf38e5332a) version of opengcs we need for LCOW v1 is no longer compatible with current versions of runc/libcontainer (see https://github.com/microsoft/opengcs/pull/396), which means that we wouldn't be able to update our runtime (containerd, runc) dependencies without breaking LCOW v1.

With the above; and given that LCOW has been deprecated (but so far, not actively removed), we should make a start to remove this code.

### WARNING:

I should be clear that this is _not_ ready to be merged, and a really WIP branch. This branch is just "blindly" ripping out all LCOW-related code/code-paths. See it as a "what if we removed all bits.." to make visible where the LCOW code-paths live, and so that we can discuss what parts _should_ be removed, and possibly, what parts should be kept (For example, if we want to support LCOW based on containerd, possibly some of this code is still useful)