### PR TITLE
quota: adjust build-tags to allow build without CGO

### DIFF
--- a/quota/projectquota.go
+++ b/quota/projectquota.go
@@ -396,9 +396,9 @@ func getDirFd(dir *C.DIR) uintptr {
 	return uintptr(C.dirfd(dir))
 }
 
-// Get the backing block device of the driver home directory
-// and create a block device node under the home directory
-// to be used by quotactl commands
+// makeBackingFsDev gets the backing block device of the driver home directory
+// and creates a block device node under the home directory to be used by
+// quotactl commands.
 func makeBackingFsDev(home string) (string, error) {
 	var stat unix.Stat_t
 	if err := unix.Stat(home, &stat); err != nil {

--- a/quota/testhelpers.go
+++ b/quota/testhelpers.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,!exclude_disk_quota,cgo
 
 package quota // import "github.com/docker/docker/quota"
 


### PR DESCRIPTION
This is to allow quota package (without tests) to be built without cgo.
makeBackingFsDev was used in helpers but not defined in projectquota_unsupported.go

Also adjust some GoDoc to follow the standard format.