### PR TITLE
libcontainerd: remove unused win32 errors and consts

### DIFF
--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -61,16 +61,6 @@ type container struct {
 	terminateInvoked bool
 }
 
-// Win32 error codes that are used for various workarounds
-// These really should be ALL_CAPS to match golangs syscall library and standard
-// Win32 error conventions, but golint insists on CamelCase.
-const (
-	CoEClassstring     = syscall.Errno(0x800401F3) // Invalid class string
-	ErrorNoNetwork     = syscall.Errno(1222)       // The network is not present or not started
-	ErrorBadPathname   = syscall.Errno(161)        // The specified path is invalid
-	ErrorInvalidObject = syscall.Errno(0x800710D8) // The object identifier does not represent a valid object
-)
-
 // defaultOwner is a tag passed to HCS to allow it to differentiate between
 // container creator management stacks. We hard code "docker" in the case
 // of docker.

--- a/libcontainerd/remote/client_windows.go
+++ b/libcontainerd/remote/client_windows.go
@@ -16,11 +16,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	runtimeName       = "io.containerd.runhcs.v1"
-	shimV2RuntimeName = runtimeName
-)
-
 func summaryFromInterface(i interface{}) (*libcontainerdtypes.Summary, error) {
 	switch pd := i.(type) {
 	case *options.ProcessDetails:


### PR DESCRIPTION
These were added in 94d70d835500bec3b171425271916d3e40f29635 (https://github.com/moby/moby/pull/20662) for Windows TP4, but no longer used after 331c8a86d489e573fcbf1df3c4f813bbc3168624 (https://github.com/moby/moby/pull/21809) removed support for TP4.

**- A picture of a cute animal (not mandatory but encouraged)**

