### PR TITLE
[20.10] Remove cli test for duplicate --net/--network opts

### DIFF
--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1696,9 +1696,6 @@ func (s *DockerNetworkSuite) TestDockerNetworkFlagAlias(c *testing.T) {
 	output, status := dockerCmd(c, "run", "--rm", "--network=user", "--network-alias=foo", "busybox", "true")
 	assert.Equal(c, status, 0, fmt.Sprintf("unexpected status code %d (%s)", status, output))
 
-	output, status, _ = dockerCmdWithError("run", "--rm", "--net=user", "--network=user", "busybox", "true")
-	assert.Equal(c, status, 0, fmt.Sprintf("unexpected status code %d (%s)", status, output))
-
 	output, status, _ = dockerCmdWithError("run", "--rm", "--network=user", "--net-alias=foo", "--network-alias=bar", "busybox", "true")
 	assert.Equal(c, status, 0, fmt.Sprintf("unexpected status code %d (%s)", status, output))
 }


### PR DESCRIPTION
This seems to be testing a strange case, specifically that one can set
the `--net` and `--network` in the same command with the same network.

Indeed this used to work with older CLIs but newer ones error out when
validating the request before sending it to the daemon.

Opening this for discussion because:

1. This doesn't seem to be testing anything at all related to the rest
   of the test
2. Not really providing any value here.
3. Is testing that a technically invalid option is successful (whether
   the option should be valid as it relates to the CLI accepting it is
   debatable).
4. Such a case seems fringe and even a bug in whatever is calling the
   CLI with such options.

Signed-off-by: Brian Goff <cpuguy83@gmail.com>
(cherry picked from commit e31086320ea0305e2cc70490160ee30480471680)
Signed-off-by: Brian Goff <cpuguy83@gmail.com>

-- 

Backporting #42163 to 20.10 and that should clean up this the failing test shown below
https://github.com/cpuguy83/docker-testing/runs/2152215086?check_suite_focus=true

<img width="871" alt="image" src="https://user-images.githubusercontent.com/799078/111850721-4a880200-88ce-11eb-93cd-1aaeb2c2e4d5.png">
