### PR TITLE
[20.10] TestPushMultipleTags: Add support for 20.10 CLI

### DIFF
--- a/integration-cli/cli/cli.go
+++ b/integration-cli/cli/cli.go
@@ -26,6 +26,7 @@ type CmdOperator func(*icmd.Cmd) func()
 
 // DockerCmd executes the specified docker command and expect a success
 func DockerCmd(t testing.TB, args ...string) *icmd.Result {
+	t.Helper()
 	return Docker(Args(args...)).Assert(t, icmd.Success)
 }
 

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
@@ -81,7 +82,15 @@ func testPushMultipleTags(c *testing.T) {
 	// tag the image and upload it to the private registry
 	dockerCmd(c, "tag", "busybox", repoTag1)
 	dockerCmd(c, "tag", "busybox", repoTag2)
-	dockerCmd(c, "push", repoName)
+
+	args := []string{"push"}
+	if versions.GreaterThanOrEqualTo(DockerCLIVersion(c), "20.10.0") {
+		// 20.10 CLI removed implicit push all tags and requires the "--all" flag
+		args = append(args, "--all-tags")
+	}
+	args = append(args, repoName)
+
+	dockerCmd(c, args...)
 
 	imageAlreadyExists := ": Image already exists"
 

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -41,6 +41,7 @@ func dockerCmdWithError(args ...string) (string, int, error) {
 
 // Deprecated: use cli.Docker or cli.DockerCmd
 func dockerCmd(c testing.TB, args ...string) (string, int) {
+	c.Helper()
 	result := cli.DockerCmd(c, args...)
 	return result.Combined(), result.ExitCode
 }

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -189,6 +189,15 @@ func TODOBuildkit() bool {
 	return os.Getenv("DOCKER_BUILDKIT") == ""
 }
 
+func DockerCLIVersion(t testing.TB) string {
+	out, _ := dockerCmd(t, "--version")
+	version := strings.Fields(out)
+	if len(version) < 3 {
+		t.Fatal("unknown version output", version)
+	}
+	return version[2]
+}
+
 // testRequires checks if the environment satisfies the requirements
 // for the test to run or skips the tests.
 func testRequires(t *testing.T, requirements ...requirement.Test) {


### PR DESCRIPTION
In 20.10 we no longer implicitly push all tags and require a
"--all-tags" flag, so add this to the test when the CLI is >= 20.10

Signed-off-by: Brian Goff <cpuguy83@gmail.com>
(cherry picked from commit 601707a655071e4ab2d3c7ee3f7f868af1774321)
Signed-off-by: Brian Goff <cpuguy83@gmail.com>

--

Backporting #42167 test change will clear up the failing test for the 20.10 branch
https://github.com/cpuguy83/docker-testing/runs/2152215086?check_suite_focus=true

<img width="659" alt="image" src="https://user-images.githubusercontent.com/799078/111850556-d8afb880-88cd-11eb-8258-724e5b70762b.png">

