### PR TITLE
archive.OverlayWhiteoutFormat: support userxattr

### DIFF
--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -691,6 +691,7 @@ func (d *Driver) ApplyDiff(id string, parent string, diff io.Reader) (size int64
 		GIDMaps:        d.gidMaps,
 		WhiteoutFormat: archive.OverlayWhiteoutFormat,
 		InUserNS:       sys.RunningInUserNS(),
+		UserXAttr:      userxattr != "",
 	}); err != nil {
 		return 0, err
 	}
@@ -728,6 +729,8 @@ func (d *Driver) Diff(id, parent string) (io.ReadCloser, error) {
 		UIDMaps:        d.uidMaps,
 		GIDMaps:        d.gidMaps,
 		WhiteoutFormat: archive.OverlayWhiteoutFormat,
+		InUserNS:       sys.RunningInUserNS(),
+		UserXAttr:      userxattr != "",
 	})
 }
 

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -54,6 +54,9 @@ type (
 		// replaced with the matching name from this map.
 		RebaseNames map[string]string
 		InUserNS    bool
+		// Use "user.*" xattrs instead of "trusted.*" ones.
+		// Only meaningful for OverlayWhiteoutFormat.
+		UserXAttr bool
 	}
 )
 
@@ -759,7 +762,7 @@ func TarWithOptions(srcPath string, options *TarOptions) (io.ReadCloser, error) 
 			compressWriter,
 			options.ChownOpts,
 		)
-		ta.WhiteoutConverter = getWhiteoutConverter(options.WhiteoutFormat, options.InUserNS)
+		ta.WhiteoutConverter = getWhiteoutConverter(options.WhiteoutFormat, options.InUserNS, options.UserXAttr)
 
 		defer func() {
 			// Make sure to check the error on Close.
@@ -917,7 +920,7 @@ func Unpack(decompressedArchive io.Reader, dest string, options *TarOptions) err
 	var dirs []*tar.Header
 	idMapping := idtools.NewIDMappingsFromMaps(options.UIDMaps, options.GIDMaps)
 	rootIDs := idMapping.RootPair()
-	whiteoutConverter := getWhiteoutConverter(options.WhiteoutFormat, options.InUserNS)
+	whiteoutConverter := getWhiteoutConverter(options.WhiteoutFormat, options.InUserNS, options.UserXAttr)
 
 	// Iterate through the files in the archive.
 loop:

--- a/pkg/archive/archive_other.go
+++ b/pkg/archive/archive_other.go
@@ -2,6 +2,6 @@
 
 package archive // import "github.com/docker/docker/pkg/archive"
 
-func getWhiteoutConverter(format WhiteoutFormat, inUserNS bool) tarWhiteoutConverter {
+func getWhiteoutConverter(format WhiteoutFormat, inUserNS, userXAttr bool) tarWhiteoutConverter {
 	return nil
 }


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix #42177 .

**- How I did it**

When `overlay2` driver is running with `userxattr` mode, let archiver use `user.*` xattrs instead of `trusted.*` ones.

**- How to verify it**
- Set up Ubuntu 20.10 host with kernel 5.11  (https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.11/amd64/)
- Set up rootless docker, with `overlay2` driver
- Make sure `docker --context=rootless pull python:3.9` succeeds. Previously, this was failing with the following I/O error:
```console
$ docker --context=rootless pull python:3.9
3.9: Pulling from library/python
e22122b926a1: Pull complete 
f29e09ae8373: Extracting [==================================================>]  7.832MB/7.832MB
e319e3daef68: Download complete 
e499244fe254: Download complete 
5a6ebed20e89: Download complete 
56b703a5a371: Download complete 
4dd0a64393b6: Download complete 
1d2280ee5e8b: Download complete 
8b6ce844793f: Download complete 
failed to register layer: Error processing tar file(exit status 1): replaceDirWithOverlayOpaque("/etc/ca-certificates") failed: createDirWithOverlayOpaque("/etc/rdwoo068623238") failed: failed to mkdir /etc/rdwoo068623238/m/d: mkdir /etc/rdwoo068623238/m/d: input/output error
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


archive.OverlayWhiteoutFormat: support userxattr

**- A picture of a cute animal (not mandatory but encouraged)**

:penguin: