### PR TITLE
update rootlesskit to v0.14.0

### DIFF
--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# v0.13.1
-: "${ROOTLESSKIT_COMMIT:=5c30c9c2586add2ad659132990fdc230f05035fa}"
+# v0.14.0
+: "${ROOTLESSKIT_COMMIT:=81d7d047d09a5b93645817ec580181de7a984082}"
 
 install_rootlesskit() {
 	case "$1" in


### PR DESCRIPTION
relates to / needed for https://github.com/moby/moby/pull/41908

full diff: https://github.com/rootless-containers/rootlesskit/compare/v0.13.1...v0.14.0

v0.14.0 Changes (since v0.13.2)
--------------------------------------

- CLI: improve --help output
- API: support GET /info
- Port API: support specifying IP version explicitly ("tcp4", "tcp6")
- rootlesskit-docker-proxy: support libnetwork >= 20201216 convention
- Allow vendoring with moby/sys/mountinfo@v0.1.3 as well as @v0.4.0
- Remove socat port driver
    - socat driver has been deprecated since v0.7.1 (Dec 2019)
- New experimental flag: --ipv6
    - Enables IPv6 routing (slirp4netns --enable-ipv6). Unrelated to port driver.

v0.13.2
--------------------------------------

- Fix cleaning up crashed state dir
- Update Go to 1.16
- Misc fixes

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

