### PR TITLE
Fix error-handling in `daemon.ContainerExecStart()` and `daemon.getExecConfig()`

### DIFF
--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -158,7 +158,7 @@ func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, stdin
 
 	ec, err := daemon.getExecConfig(name)
 	if err != nil {
-		return errExecNotFound(name)
+		return err
 	}
 
 	ec.Lock()
@@ -176,6 +176,9 @@ func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, stdin
 	ec.Unlock()
 
 	c := daemon.containers.Get(ec.ContainerID)
+	if c == nil {
+		return containerNotFound(ec.ContainerID)
+	}
 	logrus.Debugf("starting exec command %s in container %s", ec.ID, c.ID)
 	attributes := map[string]string{
 		"execID": ec.ID,

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -59,7 +59,7 @@ func (daemon *Daemon) getExecConfig(name string) (*exec.Config, error) {
 		return nil, containerNotFound(name)
 	}
 	if !ctr.IsRunning() {
-		return nil, fmt.Errorf("Container %s is not running: %s", ctr.ID, ctr.State.String())
+		return nil, errNotRunning(ctr.ID)
 	}
 	if ctr.IsPaused() {
 		return nil, errExecPaused(ctr.ID)


### PR DESCRIPTION
extracting this from https://github.com/moby/moby/pull/42143, where I noticed this


### Fix `daemon.getExecConfig()`: not using typed `errNotRunning()` error

This makes daemon.getExecConfig return a errdefs.Conflict() error if the
container is not running.

This was originally the case, but a refactor of this code changed the typed
error (`derr.ErrorCodeContainerNotRunning`) to a non-typed error; https://github.com/moby/moby/commit/a793564b2591035aec5412fbcbcccf220c773a4c (https://github.com/moby/moby/pull/20699)

### `ContainerExecStart()`: don't wrap `getExecConfig()` errors, and prevent panic

`daemon.getExecConfig()` already returns typed errors; by wrapping those errors we may loose the actual reason for failures. Changing the error-type was originally added in https://github.com/moby/moby/commit/2d43d93410c29cec87deb9cd940c3b2a8af5fbbb (https://github.com/moby/moby/pull/16250), but (I think) it was not intentional to ignore already-typed errors. It was later refactored in https://github.com/moby/moby/commit/a793564b2591035aec5412fbcbcccf220c773a4c (https://github.com/moby/moby/pull/20699), which added helper functions to create these errors, but kept the same behavior.

Also adds error-handling to prevent a panic in situations where (although unlikely) `daemon.containers.Get()` would not return a container.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

