### PR TITLE
rootless: fix getCurrentOOMScoreAdj (fix rootless docker in kubernetes)

### DIFF
--- a/rootless/specconv/specconv_linux.go
+++ b/rootless/specconv/specconv_linux.go
@@ -3,8 +3,10 @@ package specconv // import "github.com/docker/docker/rootless/specconv"
 import (
 	"io/ioutil"
 	"strconv"
+	"strings"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
 )
 
 // ToRootless converts spec to be compatible with "rootless" runc.
@@ -19,10 +21,13 @@ func ToRootless(spec *specs.Spec, v2Controllers []string) error {
 func getCurrentOOMScoreAdj() int {
 	b, err := ioutil.ReadFile("/proc/self/oom_score_adj")
 	if err != nil {
+		logrus.WithError(err).Warn("failed to read /proc/self/oom_score_adj")
 		return 0
 	}
-	i, err := strconv.Atoi(string(b))
+	s := string(b)
+	i, err := strconv.Atoi(strings.TrimSpace(s))
 	if err != nil {
+		logrus.WithError(err).Warnf("failed to parse /proc/self/oom_score_adj (%q)", s)
 		return 0
 	}
 	return i


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**


Fix #40068: `rootless docker in kubernetes: "getting the final child's pid from pipe caused \"EOF\": unknown"`


**- How I did it**

Fixed `getCurrentOOMScoreAdj()` to trim "\n" before calling `strconv.Atoi`.

**- How to verify it**
`rootless.yaml`:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: rootless
spec:
  containers:
    # dind:local is from "docker:20.10.5-dind" but the following files are updated:
    # - /usr/local/bin/dockerd     (for this PR)
    # - /usr/local/bin/containerd* (for https://github.com/containerd/containerd/pull/4845)
    - image: dind:local
      imagePullPolicy: Never
      name: rootless
      env:
        - name: DOCKER_HOST
          value: unix:///run/user/1000/docker.sock
      securityContext:
        privileged: true
```

```console
$ kind create cluster
$ kubectl apply -f rootless.yaml
$ kubectl exec rootless -- docker run hello-world
...
Hello from Docker!
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix `rootless docker in kubernetes: "getting the final child's pid from pipe caused \"EOF\": unknown"


**- A picture of a cute animal (not mandatory but encouraged)**
:penguin: 
