### PR TITLE
Fix handling of multiple networks having the same name

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -270,7 +270,7 @@ func (daemon *Daemon) updateNetworkSettings(container *container.Container, n li
 			continue
 		}
 
-		if sn.Name() == n.Name() {
+		if sn.ID() == n.ID() {
 			// If the network scope is swarm, then this
 			// is an attachable network, which may not
 			// be locally available previously.
@@ -291,6 +291,9 @@ func (daemon *Daemon) updateNetworkSettings(container *container.Container, n li
 		}
 	}
 
+	if endpointConfig.NetworkID == "" {
+		endpointConfig.NetworkID = n.ID()
+	}
 	container.NetworkSettings.Networks[n.Name()] = &network.EndpointSettings{
 		EndpointSettings: endpointConfig,
 	}
@@ -357,9 +360,9 @@ func (daemon *Daemon) updateNetwork(container *container.Container) error {
 }
 
 func (daemon *Daemon) findAndAttachNetwork(container *container.Container, idOrName string, epConfig *networktypes.EndpointSettings) (libnetwork.Network, *networktypes.NetworkingConfig, error) {
-	id := getNetworkID(idOrName, epConfig)
+	idOrName = getNetworkID(idOrName, epConfig)
 
-	n, err := daemon.FindNetwork(id)
+	n, err := daemon.FindNetwork(idOrName)
 	if err != nil {
 		// We should always be able to find the network for a
 		// managed container.
@@ -376,10 +379,10 @@ func (daemon *Daemon) findAndAttachNetwork(container *container.Container, idOrN
 		}
 		// Throw an error if the container is already attached to the network
 		if container.NetworkSettings.Networks != nil {
-			networkName := n.Name()
+			networkID := n.ID()
 			containerName := strings.TrimPrefix(container.Name, "/")
-			if nw, ok := container.NetworkSettings.Networks[networkName]; ok && nw.EndpointID != "" {
-				err := fmt.Errorf("%s is already attached to network %s", containerName, networkName)
+			if network := container.NetworkSettings.FindNetworkByID(networkID); network != nil && network.EndpointID != "" {
+				err := fmt.Errorf("%s is already attached to network %s", containerName, n.Name())
 				return n, nil, errdefs.Conflict(err)
 			}
 		}
@@ -402,8 +405,8 @@ func (daemon *Daemon) findAndAttachNetwork(container *container.Container, idOrN
 	)
 
 	if n == nil && daemon.attachableNetworkLock != nil {
-		daemon.attachableNetworkLock.Lock(id)
-		defer daemon.attachableNetworkLock.Unlock(id)
+		daemon.attachableNetworkLock.Lock(idOrName)
+		defer daemon.attachableNetworkLock.Unlock(idOrName)
 	}
 
 	for {
@@ -411,16 +414,16 @@ func (daemon *Daemon) findAndAttachNetwork(container *container.Container, idOrN
 		// trigger attachment in the swarm cluster manager.
 		if daemon.clusterProvider != nil {
 			var err error
-			config, err = daemon.clusterProvider.AttachNetwork(id, container.ID, addresses)
+			config, err = daemon.clusterProvider.AttachNetwork(idOrName, container.ID, addresses)
 			if err != nil {
 				return nil, nil, err
 			}
 		}
 
-		n, err = daemon.FindNetwork(id)
+		n, err = daemon.FindNetwork(idOrName)
 		if err != nil {
 			if daemon.clusterProvider != nil {
-				if err := daemon.clusterProvider.DetachNetwork(id, container.ID); err != nil {
+				if err := daemon.clusterProvider.DetachNetwork(idOrName, container.ID); err != nil {
 					logrus.Warnf("Could not rollback attachment for container %s to network %s: %v", container.ID, idOrName, err)
 				}
 			}
@@ -468,12 +471,14 @@ func (daemon *Daemon) updateContainerNetworkSettings(container *container.Contai
 		networkName = daemon.netController.Config().Daemon.DefaultNetwork
 	}
 
+	var networkID string = ""
 	if mode.IsUserDefined() {
 		var err error
 
 		n, err = daemon.FindNetwork(networkName)
 		if err == nil {
 			networkName = n.Name()
+			networkID = n.ID()
 		}
 	}
 
@@ -487,16 +492,29 @@ func (daemon *Daemon) updateContainerNetworkSettings(container *container.Contai
 		}
 
 		for name, epConfig := range endpointsConfig {
-			container.NetworkSettings.Networks[name] = &network.EndpointSettings{
+			networkName := name
+			if epConfig.NetworkID == "" {
+				en, err := daemon.FindNetwork(name)
+				if err == nil {
+					epConfig.NetworkID = en.ID()
+					// Make sure to internally store the per network endpoint config by network name
+					networkName = en.Name()
+				}
+			}
+			container.NetworkSettings.Networks[networkName] = &network.EndpointSettings{
 				EndpointSettings: epConfig,
 			}
 		}
 	}
 
 	if container.NetworkSettings.Networks == nil {
+		endpointSettings := &networktypes.EndpointSettings{}
+		if networkID != "" {
+			endpointSettings.NetworkID = networkID
+		}
 		container.NetworkSettings.Networks = make(map[string]*network.EndpointSettings)
 		container.NetworkSettings.Networks[networkName] = &network.EndpointSettings{
-			EndpointSettings: &networktypes.EndpointSettings{},
+			EndpointSettings: endpointSettings,
 		}
 	}
 
@@ -521,7 +539,6 @@ func (daemon *Daemon) updateContainerNetworkSettings(container *container.Contai
 		if nwConfig, ok := container.NetworkSettings.Networks[n.ID()]; ok {
 			container.NetworkSettings.Networks[networkName] = nwConfig
 			delete(container.NetworkSettings.Networks, n.ID())
-			return
 		}
 	}
 }
@@ -575,9 +592,13 @@ func (daemon *Daemon) allocateNetwork(container *container.Container) (retErr er
 		networks[n] = epConf
 	}
 
-	for netName, epConf := range networks {
+	for n, epConf := range networks {
 		cleanOperationalData(epConf)
-		if err := daemon.connectToNetwork(container, netName, epConf.EndpointSettings, updateSettings); err != nil {
+		idOrName := n
+		if epConf.EndpointSettings.NetworkID != "" {
+			idOrName = epConf.EndpointSettings.NetworkID
+		}
+		if err := daemon.connectToNetwork(container, idOrName, epConf.EndpointSettings, updateSettings); err != nil {
 			return err
 		}
 	}
@@ -1078,6 +1099,9 @@ func (daemon *Daemon) ConnectToNetwork(container *container.Container, idOrName 
 				return err
 			}
 		} else {
+			if n != nil && endpointConfig.NetworkID == "" {
+				endpointConfig.NetworkID = n.ID()
+			}
 			container.NetworkSettings.Networks[idOrName] = &network.EndpointSettings{
 				EndpointSettings: endpointConfig,
 			}

--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -175,8 +175,8 @@ func (daemon *Daemon) initializeNetworkingPaths(container *container.Container, 
 	container.NetworkSharedContainerID = nc.ID
 
 	if nc.NetworkSettings != nil {
-		for n := range nc.NetworkSettings.Networks {
-			sn, err := daemon.FindNetwork(n)
+		for _, n := range nc.NetworkSettings.Networks {
+			sn, err := daemon.FindNetwork(n.EndpointSettings.NetworkID)
 			if err != nil {
 				continue
 			}

--- a/daemon/network/settings.go
+++ b/daemon/network/settings.go
@@ -28,6 +28,16 @@ type Settings struct {
 	HasSwarmEndpoint       bool
 }
 
+// FindNetworkByID finds the correct EndpointSettings by its unique ID instead of name
+func (settings *Settings) FindNetworkByID(id string) *EndpointSettings {
+	for _, endpoint := range settings.Networks {
+		if endpoint.EndpointSettings.NetworkID == id {
+			return endpoint
+		}
+	}
+	return nil
+}
+
 // EndpointSettings is a package local wrapper for
 // networktypes.EndpointSettings which stores Endpoint state that
 // needs to be persisted to disk but not exposed in the api.

--- a/integration/network/network_test.go
+++ b/integration/network/network_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os/exec"
 	"strings"
@@ -146,4 +147,59 @@ func TestHostIPv4BridgeLabel(t *testing.T) {
 	assert.Assert(t, len(out.IPAM.Config) > 0)
 	// Make sure the SNAT rule exists
 	icmd.RunCommand("iptables", "-t", "nat", "-C", "POSTROUTING", "-s", out.IPAM.Config[0].Subnet, "!", "-o", bridgeName, "-j", "SNAT", "--to-source", ipv4SNATAddr).Assert(t, icmd.Success)
+}
+
+func TestRunContainerWithUniqueNetworkIDAndMatchingNetworkNames(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot start daemon on remote test run")
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, IsUserNamespace())
+	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
+
+	d := daemon.New(t)
+	d.StartWithBusybox(t, "-b", "none")
+	defer d.Stop(t)
+
+	c := d.NewClientT(t)
+	ctx := context.Background()
+
+	withNoCheckDuplicates := func(n *types.NetworkCreate) {
+		n.CheckDuplicate = false
+	}
+
+	// Create two networks with the same name.
+	netName := "clashingnetwork"
+	id1 := network.CreateNoError(ctx, t, c, netName,
+		network.WithDriver("bridge"),
+		withNoCheckDuplicates,
+	)
+	id2 := network.CreateNoError(ctx, t, c, netName,
+		network.WithDriver("bridge"),
+		withNoCheckDuplicates,
+	)
+
+	// Run in a subtest so we clean up after all the tests are done running.
+	t.Run("SpawnContainers", func(t *testing.T) {
+		// Be reasonably sure that a container started with the network ID A
+		// explicitly won't be started as part of network B by trying it a bunch of
+		// times.
+		for i := 0; i < 50; i++ {
+			t.Run(fmt.Sprintf("Spawn%d", i), func(t *testing.T) {
+				t.Parallel()
+
+				netId := id1
+				if i%2 == 0 {
+					netId = id2
+				}
+
+				ctrId := container.Run(ctx, t, c, container.WithNetworkMode(netId))
+				defer c.ContainerRemove(ctx, ctrId, types.ContainerRemoveOptions{Force: true})
+
+				ctr, err := c.ContainerInspect(ctx, ctrId)
+				assert.NilError(t, err)
+
+				// Make sure the network is the one we wanted.
+				assert.Equal(t, ctr.NetworkSettings.Networks[netName].NetworkID, netId)
+			})
+		}
+	})
 }


### PR DESCRIPTION
Signed-off-by: Angie Xiang <a.xiang@sap.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This is a contribution made and provided to me by Christian Füller at SAP.
It fixes a network mixup that can occur when multiple networks have the
same name.

**- How I did it**

This change no longer treats the network name as a unique identifier. Instead, the network ID is taken where possible.

**- How to verify it**

Create multiple networks on the same daemon with the same name and start containers with `--network <one-network-id>`. Before this fix, the container ended up in a random network despite the unique network ID.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
--> Fix handling of multiple networks having the same name


**- A picture of a cute animal (not mandatory but encouraged)**

A friend of mine gave me permission to use this photo of her cat. His name is Prince.

![photo5390946360875921599](https://user-images.githubusercontent.com/81235782/112179300-db2a4f00-8bfa-11eb-83f8-3515b24074d9.jpg)
