### PR TITLE
hack: use GOPROXY for rootlesskit to workaround issue with old git on CentOS/RHEL 7

### DIFF
--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -31,6 +31,11 @@ _install_rootlesskit() (
 	cd "$GOPATH/src/github.com/rootless-containers/rootlesskit" || exit 1
 	git checkout -q "$ROOTLESSKIT_COMMIT"
 	export GO111MODULE=on
+	# TODO remove GOPROXY override once we updated to Go 1.14+
+	# Using goproxy instead of "direct" to work around an issue in go mod
+	# on Go 1.13 not working with older git versions (default version on
+	# CentOS 7 is git 1.8), see https://github.com/golang/go/issues/38373
+	export GOPROXY="https://proxy.golang.org"
 	for f in rootlesskit rootlesskit-docker-proxy; do
 		go build $BUILD_MODE -ldflags="$ROOTLESSKIT_LDFLAGS" -o "${PREFIX}/$f" github.com/rootless-containers/rootlesskit/cmd/$f
 	done


### PR DESCRIPTION
… CentOS/RHEL 7

Since rootlesskit removed vendor folder, building it has to rely on go mod.

Dockerfile in docker-ce-packaging uses GOPROXY=direct, which makes "go mod"
commands use git to fetch modules. "go mod" in Go versions before 1.14.1 are
incompatible with older git versions, including the version of git that ships
with CentOS/RHEL 7 (which have git 1.8), see golang/go#38373

This patch switches rootlesskit install script to set GOPROXY to
https://proxy.golang.org so that git is not required for downloading modules.

Once all our code has upgraded to Go 1.14+, this workaround should be
removed.

Signed-off-by: Tibor Vass <tibor@docker.com>