### PR TITLE
discovery & test: Fix goroutine leaks by adding 1 buffer to channel

### DIFF
--- a/daemon/cluster/controllers/plugin/controller_test.go
+++ b/daemon/cluster/controllers/plugin/controller_test.go
@@ -108,7 +108,7 @@ func TestWaitCancel(t *testing.T) {
 	}
 
 	ctxCancel, cancel := context.WithCancel(ctx)
-	chErr := make(chan error)
+	chErr := make(chan error, 1)
 	go func() {
 		chErr <- c.Wait(ctxCancel)
 	}()
@@ -134,7 +134,7 @@ func TestWaitDisabled(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	chErr := make(chan error)
+	chErr := make(chan error, 1)
 	go func() {
 		chErr <- c.Wait(ctx)
 	}()
@@ -215,7 +215,7 @@ func TestWaitEnabled(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	chErr := make(chan error)
+	chErr := make(chan error, 1)
 	go func() {
 		chErr <- c.Wait(ctx)
 	}()

--- a/daemon/graphdriver/devmapper/devmapper_test.go
+++ b/daemon/graphdriver/devmapper/devmapper_test.go
@@ -136,7 +136,7 @@ func TestDevmapperLockReleasedDeviceDeletion(t *testing.T) {
 	// DeviceSet Lock. If lock has not been released, this will hang.
 	driver.DeviceSet.cleanupDeletedDevices()
 
-	doneChan := make(chan bool)
+	doneChan := make(chan bool, 1)
 
 	go func() {
 		driver.DeviceSet.Lock()

--- a/pkg/discovery/file/file.go
+++ b/pkg/discovery/file/file.go
@@ -60,8 +60,8 @@ func (s *Discovery) fetch() (discovery.Entries, error) {
 
 // Watch is exported
 func (s *Discovery) Watch(stopCh <-chan struct{}) (<-chan discovery.Entries, <-chan error) {
-	ch := make(chan discovery.Entries)
-	errCh := make(chan error)
+	ch := make(chan discovery.Entries, 1)
+	errCh := make(chan error, 1)
 	ticker := time.NewTicker(s.heartbeat)
 
 	go func() {

--- a/pkg/discovery/memory/memory.go
+++ b/pkg/discovery/memory/memory.go
@@ -33,8 +33,8 @@ func (s *Discovery) Initialize(_ string, heartbeat time.Duration, _ time.Duratio
 
 // Watch sends periodic discovery updates to a channel.
 func (s *Discovery) Watch(stopCh <-chan struct{}) (<-chan discovery.Entries, <-chan error) {
-	ch := make(chan discovery.Entries)
-	errCh := make(chan error)
+	ch := make(chan discovery.Entries, 1)
+	errCh := make(chan error, 1)
 	ticker := time.NewTicker(s.heartbeat)
 
 	go func() {

--- a/pkg/discovery/nodes/nodes.go
+++ b/pkg/discovery/nodes/nodes.go
@@ -39,7 +39,7 @@ func (s *Discovery) Initialize(uris string, _ time.Duration, _ time.Duration, _ 
 
 // Watch is exported
 func (s *Discovery) Watch(stopCh <-chan struct{}) (<-chan discovery.Entries, <-chan error) {
-	ch := make(chan discovery.Entries)
+	ch := make(chan discovery.Entries, 1)
 	go func() {
 		defer close(ch)
 		ch <- s.entries


### PR DESCRIPTION
Signed-off-by: Ziheng Liu <lzhfromustc@gmail.com>

**- What I did**
Fixed a few channels that can lead to goroutine leaks in pkg/discovery and a few unit tests.

**- How I did it**
These channels all share the same pattern:
```Go
ch := make(chan type)
go func() {
    ...
    ch <- value
}()
...
select {
case <-timeout:
    return
case <-ch:
...
}
```
They are fixed by giving 1 buffer to these channels. So no goroutine will be blocked at the send operations, and the receive operations in select won't be influenced.

**- How to verify it**
This patch is similar to #40144
For the four channels in unit tests, I ran these unit tests and they all passed.
For the channels in those `func (s *Discovery) Watch()`, adding 1 buffer to them may seem to change the semantics because send is now not blocking. However, I checked all functions that can use these channels, and found that this won't change the behavior of the program. They are: `TestDaemonDiscoveryReload`, `TestDaemonDiscoveryReloadFromEmptyDiscovery`, `(*DiscoverySuite) TestWatch`, `TestDaemonReloadNetworkDiagnosticPort`, `vendor/.../hostdiscovery/(*hostDiscovery) Watch`. I also ran all related unit tests, and they all pass.

**- Description for the changelog**
None
