### PR TITLE
[20.10 backport] CI: update tests to be more resilient against CLI output format and for libnetwork changes

### DIFF
--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -297,7 +297,7 @@ func waitForExec(c *testing.T, id string) {
 }
 
 func inspectContainer(c *testing.T, id string, out interface{}) {
-	resp, body, err := request.Get(fmt.Sprintf("/containers/%s/json", id))
+	resp, body, err := request.Get("/containers/" + id + "/json")
 	assert.NilError(c, err)
 	defer body.Close()
 	assert.Equal(c, resp.StatusCode, http.StatusOK)

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -594,20 +594,16 @@ func (s *DockerSuite) TestPsImageIDAfterUpdate(c *testing.T) {
 
 func (s *DockerSuite) TestPsNotShowPortsOfStoppedContainer(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	dockerCmd(c, "run", "--name=foo", "-d", "-p", "5000:5000", "busybox", "top")
+	dockerCmd(c, "run", "--name=foo", "-d", "-p", "6000:5000", "busybox", "top")
 	assert.Assert(c, waitRun("foo") == nil)
-	out, _ := dockerCmd(c, "ps")
-	lines := strings.Split(strings.TrimSpace(out), "\n")
-	expected := "0.0.0.0:5000->5000/tcp"
-	fields := strings.Fields(lines[1])
-	assert.Equal(c, fields[len(fields)-2], expected, fmt.Sprintf("Expected: %v, got: %v", expected, fields[len(fields)-2]))
+	ports, _ := dockerCmd(c, "ps", "--format", "{{ .Ports }}", "--filter", "name=foo")
+	expected := ":6000->5000/tcp"
+	assert.Assert(c, is.Contains(ports, expected), "Expected: %v, got: %v", expected, ports)
 
 	dockerCmd(c, "kill", "foo")
 	dockerCmd(c, "wait", "foo")
-	out, _ = dockerCmd(c, "ps", "-l")
-	lines = strings.Split(strings.TrimSpace(out), "\n")
-	fields = strings.Fields(lines[1])
-	assert.Assert(c, fields[len(fields)-2] != expected, "Should not got %v", expected)
+	ports, _ = dockerCmd(c, "ps", "--format", "{{ .Ports }}", "--filter", "name=foo")
+	assert.Equal(c, ports, "", "Should not got %v", expected)
 }
 
 func (s *DockerSuite) TestPsShowMounts(c *testing.T) {

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2063,12 +2063,11 @@ func (s *DockerSuite) TestRunAllocatePortInReservedRange(c *testing.T) {
 	out, _ := dockerCmd(c, "run", "-d", "-P", "-p", "80", "busybox", "top")
 
 	id := strings.TrimSpace(out)
-	out, _ = dockerCmd(c, "port", id, "80")
-
-	strPort := strings.Split(strings.TrimSpace(out), ":")[1]
-	port, err := strconv.ParseInt(strPort, 10, 64)
+	out, _ = dockerCmd(c, "inspect", "--format", `{{index .NetworkSettings.Ports "80/tcp" 0 "HostPort" }}`, id)
+	out = strings.TrimSpace(out)
+	port, err := strconv.ParseInt(out, 10, 64)
 	if err != nil {
-		c.Fatalf("invalid port, got: %s, error: %s", strPort, err)
+		c.Fatalf("invalid port, got: %s, error: %s", out, err)
 	}
 
 	// allocate a static port and a dynamic port together, with static port
@@ -2278,7 +2277,7 @@ func (s *DockerSuite) TestRunAllowPortRangeThroughExpose(c *testing.T) {
 		if portnum < 3000 || portnum > 3003 {
 			c.Fatalf("Port %d is out of range ", portnum)
 		}
-		if binding == nil || len(binding) != 1 || len(binding[0].HostPort) == 0 {
+		if len(binding) == 0 || len(binding[0].HostPort) == 0 {
 			c.Fatalf("Port is not mapped for the port %s", port)
 		}
 	}
@@ -2497,13 +2496,12 @@ func (s *DockerSuite) TestRunPortFromDockerRangeInUse(c *testing.T) {
 	out, _ := dockerCmd(c, "run", "-d", "-p", ":80", "busybox", "top")
 
 	id := strings.TrimSpace(out)
-	out, _ = dockerCmd(c, "port", id)
 
+	out, _ = dockerCmd(c, "inspect", "--format", `{{index .NetworkSettings.Ports "80/tcp" 0 "HostPort" }}`, id)
 	out = strings.TrimSpace(out)
 	if out == "" {
 		c.Fatal("docker port command output is empty")
 	}
-	out = strings.Split(out, ":")[1]
 	lastPort, err := strconv.Atoi(out)
 	if err != nil {
 		c.Fatal(err)
@@ -2637,7 +2635,7 @@ func (s *DockerSuite) TestRunAllowPortRangeThroughPublish(c *testing.T) {
 		if portnum < 3000 || portnum > 3003 {
 			c.Fatalf("Port %d is out of range ", portnum)
 		}
-		if binding == nil || len(binding) != 1 || len(binding[0].HostPort) == 0 {
+		if len(binding) == 0 || len(binding[0].HostPort) == 0 {
 			c.Fatal("Port is not mapped for the port "+port, out)
 		}
 	}


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/42050

relates to / in preparation of https://github.com/moby/moby/pull/41908 ("vendor: docker/libnetwork b3507428be5b458cb0e2b4086b13531fb0706e46")

### integration/container: wrap some long lines for readability

Just some minor code-style changes for readability

### integration: update getExternalAddress to prefer IPv4

Rootlesskit doesn't currently handle IPv6 addresses, causing TestNetworkLoopbackNat and TestNetworkNat to fail;

    Error starting userland proxy:
    error while calling PortManager.AddPort(): listen tcp: address :::8080: too many colons in address

This patch:

- Updates `getExternalAddress()` to pick IPv4 address if both IPv6 and IPv4 are found
- Update TestNetworkNat to net.JoinHostPort(), so that square brackets are used for IPv6 addresses (e.g. `[::]:8080`)

### integration-cli: rely less on "docker port" output format

Also re-formatting some lines for readability.