### PR TITLE
add .gitconfig to handle case-only renames

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,2 @@
+[core]
+	ignorecase = false


### PR DESCRIPTION
In preparation for an upcoming update of the ebpf dependency, which contains
a rename of `readme.md` to `README.md`, which may cause git or vendor validation
to fail.

If you're on a case-insensitive (but case-preserving) filesystem, such as on
macOS or Windows, this is the equivalent of;

    git config core.ignorecase false

Or to configure it globally:

    git config --global core.ignorecase false


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

