### PR TITLE
Default docker host

### DIFF
--- a/client/options.go
+++ b/client/options.go
@@ -78,6 +78,9 @@ func WithDialContext(dialContext func(ctx context.Context, network, addr string)
 // WithHost overrides the client host with the specified one.
 func WithHost(host string) Opt {
 	return func(c *Client) error {
+		if host == "" {
+			host = DefaultDockerHost
+		}
 		hostURL, err := ParseHostURL(host)
 		if err != nil {
 			return err

--- a/client/options.go
+++ b/client/options.go
@@ -78,9 +78,6 @@ func WithDialContext(dialContext func(ctx context.Context, network, addr string)
 // WithHost overrides the client host with the specified one.
 func WithHost(host string) Opt {
 	return func(c *Client) error {
-		if host == "" {
-			host = DefaultDockerHost
-		}
 		hostURL, err := ParseHostURL(host)
 		if err != nil {
 			return err


### PR DESCRIPTION
If DOCKER_HOST is not set, DefaultDockerHost defines the operating system specific default value,  However, if the host value is not set during use, an error is returned and the system default value is not used

