### PR TITLE
DefaultDockerHost defines os specific default if DOCKER_HOST is unset

### DIFF
--- a/client/options.go
+++ b/client/options.go
@@ -78,6 +78,9 @@ func WithDialContext(dialContext func(ctx context.Context, network, addr string)
 // WithHost overrides the client host with the specified one.
 func WithHost(host string) Opt {
 	return func(c *Client) error {
+		if host == "" {
+			host = DefaultDockerHost
+		}
 		hostURL, err := ParseHostURL(host)
 		if err != nil {
 			return err


### PR DESCRIPTION
docker api version: 1.41
DefaultDockerHost defines os specific default if DOCKER_HOST is unset
When my host does not set a value, the default value is not used