### PR TITLE
Pin arm64 machines to a specific Ubuntu version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -939,7 +939,7 @@ pipeline {
                         beforeAgent true
                         expression { params.arm64 }
                     }
-                    agent { label 'arm64 && linux' }
+                    agent { label 'arm64 && ubuntu-2004' }
                     environment {
                         TEST_SKIP_INTEGRATION_CLI = '1'
                     }


### PR DESCRIPTION
Signed-off-by: Stefan Scherer <stefan.scherer@docker.com>

**- What I did**

Use better Jenkins labels for arm64. The label `linux` is very vague and randomly picks Ubuntu 16.04 machines.

**- How I did it**

**- How to verify it**

Check CI nodes, no ubuntu-1604-overlay2-arm64v8 node should appear any longer.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

