### PR TITLE
Provide a mechanism to add custom HTTP headers for ImagePull requests.

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"io"
 	"net"
+	"net/http"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
@@ -255,6 +256,8 @@ type ImagePullOptions struct {
 	RegistryAuth  string // RegistryAuth is the base64 encoded credentials for the registry
 	PrivilegeFunc RequestPrivilegeFunc
 	Platform      string
+	// Headers are additional HTTP headers to add for this operation.
+	Headers http.Header
 }
 
 // RequestPrivilegeFunc is a function interface that

--- a/client/image_pull.go
+++ b/client/image_pull.go
@@ -34,13 +34,13 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options types.I
 		query.Set("platform", strings.ToLower(options.Platform))
 	}
 
-	resp, err := cli.tryImageCreate(ctx, query, options.RegistryAuth)
+	resp, err := cli.tryImageCreate(ctx, query, options.Headers, options.RegistryAuth)
 	if errdefs.IsUnauthorized(err) && options.PrivilegeFunc != nil {
 		newAuthHeader, privilegeErr := options.PrivilegeFunc()
 		if privilegeErr != nil {
 			return nil, privilegeErr
 		}
-		resp, err = cli.tryImageCreate(ctx, query, newAuthHeader)
+		resp, err = cli.tryImageCreate(ctx, query, options.Headers, newAuthHeader)
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Some registries require custom HTTP headers for auth. Right now headers
can only be set at a per client level, which means tokens are sent to
all registries.

Signed-off-by: Simon Newton <sjn@uber.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Provide a mechanism to add custom HTTP headers for ImagePull requests.

**- How I did it**
Added a `Headers` field to the ImagePullOptions struct.

**- How to verify it**
Run the unit test. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Provide a mechanism to add custom HTTP headers for ImagePull requests.

**- A picture of a cute animal (not mandatory but encouraged)**

![Screen Shot 2021-03-30 at 10 53 59 AM](https://user-images.githubusercontent.com/4355332/113033806-479ad600-9146-11eb-83e3-515aa1556205.png)