### PR TITLE
integration/container: use ipv4 for some tests to reduce flakiness

### DIFF
--- a/integration/container/nat_test.go
+++ b/integration/container/nat_test.go
@@ -29,7 +29,7 @@ func TestNetworkNat(t *testing.T) {
 	startServerContainer(t, msg, 8080)
 
 	endpoint := getExternalAddress(t)
-	conn, err := net.Dial("tcp", net.JoinHostPort(endpoint.String(), "8080"))
+	conn, err := net.Dial("tcp4", net.JoinHostPort(endpoint.String(), "8080"))
 	assert.NilError(t, err)
 	defer conn.Close()
 
@@ -46,7 +46,7 @@ func TestNetworkLocalhostTCPNat(t *testing.T) {
 	msg := "hi yall"
 	startServerContainer(t, msg, 8081)
 
-	conn, err := net.Dial("tcp", "localhost:8081")
+	conn, err := net.Dial("tcp4", "localhost:8081")
 	assert.NilError(t, err)
 	defer conn.Close()
 
@@ -70,7 +70,7 @@ func TestNetworkLoopbackNat(t *testing.T) {
 	ctx := context.Background()
 
 	cID := container.Run(ctx, t, client,
-		container.WithCmd("sh", "-c", fmt.Sprintf("stty raw && nc -w 1 %s 8080", endpoint.String())),
+		container.WithCmd("sh", "-c", fmt.Sprintf("stty raw && nc -4 -w 1 %s 8080", endpoint.String())),
 		container.WithTty(true),
 		container.WithNetworkMode("container:"+serverContainerID),
 	)

--- a/integration/container/rename_test.go
+++ b/integration/container/rename_test.go
@@ -159,7 +159,7 @@ func TestRenameAnonymousContainer(t *testing.T) {
 			networkName: {},
 		}
 		c.HostConfig.NetworkMode = containertypes.NetworkMode(networkName)
-	}, container.WithCmd("ping", count, "1", container1Name))
+	}, container.WithCmd("ping", "-4", count, "1", container1Name))
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
 
 	inspect, err := client.ContainerInspect(ctx, cID)


### PR DESCRIPTION
I noticed when updating libnetwork, that the s390x and ppc64le machines have
IPv6 enabled, and wondered if this could be responsible for the flakiness
in these tests.

hopefully addresses https://github.com/moby/moby/issues/41561

