### PR TITLE
[20.10 backport] rootless: bind mount: fix "operation not permitted"

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -648,7 +648,7 @@ func WithMounts(daemon *Daemon, c *container.Container) coci.SpecOpts {
 			// "mount" when we bind-mount. The reason for this is that at the point
 			// when runc sets up the root filesystem, it is already inside a user
 			// namespace, and thus cannot change any flags that are locked.
-			if daemon.configStore.RemappedRoot != "" {
+			if daemon.configStore.RemappedRoot != "" || sys.RunningInUserNS() {
 				unprivOpts, err := getUnprivilegedMountFlags(m.Source)
 				if err != nil {
 					return err


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/42230
**- What I did**
Fix https://github.com/moby/moby/issues/42090 

Fix https://github.com/moby/moby/issues/41876

Fix the following issue
```console
$ sudo mount -t tmpfs -o noexec none /tmp/foo
$ docker --context=rootless run -it --rm -v /tmp/foo:/mnt:ro alpine
docker: Error response from daemon: OCI runtime create failed: container_linux.go:367: starting container process caused: process_linux.go:520: container init caused: rootfs_linux.go:60: mounting "/tmp/foo" to rootfs at "/home/suda/.local/share/docker/overlay2/b8e7ea02f6ef51247f7f10c7fb26edbfb308d2af8a2c77915260408ed3b0a8ec/merged/mnt" caused: operation not permitted: unknown.
```


**- How I did it**

Call `getUnprivilegedMountFlags(m.Source)`

**- How to verify it**

```console
$ sudo mount -t tmpfs -o noexec none /tmp/foo
$ docker --context=rootless run -it --rm -v /tmp/foo:/mnt:ro alpine
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
rootless: bind mount: fix "operation not permitted"


**- A picture of a cute animal (not mandatory but encouraged)**
:penguin:
