### PR TITLE
[20.10 backport] rootless: overlay2: fix "createDirWithOverlayOpaque(...) ... input/output error"

### DIFF
--- a/daemon/graphdriver/overlay2/check.go
+++ b/daemon/graphdriver/overlay2/check.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/containerd/containerd/sys"
 	"github.com/docker/docker/pkg/system"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
@@ -19,7 +20,14 @@ import (
 // which copies up the opaque flag when copying up an opaque
 // directory or the kernel enable CONFIG_OVERLAY_FS_REDIRECT_DIR.
 // When these exist naive diff should be used.
+//
+// When running in a user namespace, returns errRunningInUserNS
+// immediately.
 func doesSupportNativeDiff(d string) error {
+	if sys.RunningInUserNS() {
+		return errors.New("running in a user namespace")
+	}
+
 	td, err := ioutil.TempDir(d, "opaque-bug-check")
 	if err != nil {
 		return err

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -678,7 +678,7 @@ func (d *Driver) isParent(id, parent string) bool {
 
 // ApplyDiff applies the new layer into a root
 func (d *Driver) ApplyDiff(id string, parent string, diff io.Reader) (size int64, err error) {
-	if !d.isParent(id, parent) {
+	if useNaiveDiff(d.home) || !d.isParent(id, parent) {
 		return d.naiveDiff.ApplyDiff(id, parent, diff)
 	}
 

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/containerd/containerd/sys"
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/daemon/graphdriver/overlayutils"
 	"github.com/docker/docker/pkg/archive"
@@ -682,6 +681,7 @@ func (d *Driver) ApplyDiff(id string, parent string, diff io.Reader) (size int64
 		return d.naiveDiff.ApplyDiff(id, parent, diff)
 	}
 
+	// never reach here if we are running in UserNS
 	applyDir := d.getDiffPath(id)
 
 	logger.Debugf("Applying tar in %s", applyDir)
@@ -690,7 +690,6 @@ func (d *Driver) ApplyDiff(id string, parent string, diff io.Reader) (size int64
 		UIDMaps:        d.uidMaps,
 		GIDMaps:        d.gidMaps,
 		WhiteoutFormat: archive.OverlayWhiteoutFormat,
-		InUserNS:       sys.RunningInUserNS(),
 	}); err != nil {
 		return 0, err
 	}
@@ -721,6 +720,7 @@ func (d *Driver) Diff(id, parent string) (io.ReadCloser, error) {
 		return d.naiveDiff.Diff(id, parent)
 	}
 
+	// never reach here if we are running in UserNS
 	diffPath := d.getDiffPath(id)
 	logger.Debugf("Tar with options on %s", diffPath)
 	return archive.TarWithOptions(diffPath, &archive.TarOptions{

--- a/pkg/archive/archive_linux.go
+++ b/pkg/archive/archive_linux.go
@@ -2,29 +2,26 @@ package archive // import "github.com/docker/docker/pkg/archive"
 
 import (
 	"archive/tar"
-	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
-	"github.com/containerd/continuity/fs"
 	"github.com/docker/docker/pkg/system"
-	"github.com/moby/sys/mount"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
-func getWhiteoutConverter(format WhiteoutFormat, inUserNS bool) tarWhiteoutConverter {
+func getWhiteoutConverter(format WhiteoutFormat, inUserNS bool) (tarWhiteoutConverter, error) {
 	if format == OverlayWhiteoutFormat {
-		return overlayWhiteoutConverter{inUserNS: inUserNS}
+		if inUserNS {
+			return nil, errors.New("specifying OverlayWhiteoutFormat is not allowed in userns")
+		}
+		return overlayWhiteoutConverter{}, nil
 	}
-	return nil
+	return nil, nil
 }
 
 type overlayWhiteoutConverter struct {
-	inUserNS bool
 }
 
 func (overlayWhiteoutConverter) ConvertWrite(hdr *tar.Header, path string, fi os.FileInfo) (wo *tar.Header, err error) {
@@ -77,13 +74,7 @@ func (c overlayWhiteoutConverter) ConvertRead(hdr *tar.Header, path string) (boo
 	if base == WhiteoutOpaqueDir {
 		err := unix.Setxattr(dir, "trusted.overlay.opaque", []byte{'y'}, 0)
 		if err != nil {
-			if c.inUserNS {
-				if err = replaceDirWithOverlayOpaque(dir); err != nil {
-					return false, errors.Wrapf(err, "replaceDirWithOverlayOpaque(%q) failed", dir)
-				}
-			} else {
-				return false, errors.Wrapf(err, "setxattr(%q, trusted.overlay.opaque=y)", dir)
-			}
+			return false, errors.Wrapf(err, "setxattr(%q, trusted.overlay.opaque=y)", dir)
 		}
 		// don't write the file itself
 		return false, err
@@ -95,19 +86,7 @@ func (c overlayWhiteoutConverter) ConvertRead(hdr *tar.Header, path string) (boo
 		originalPath := filepath.Join(dir, originalBase)
 
 		if err := unix.Mknod(originalPath, unix.S_IFCHR, 0); err != nil {
-			if c.inUserNS {
-				// Ubuntu and a few distros support overlayfs in userns.
-				//
-				// Although we can't call mknod directly in userns (at least on bionic kernel 4.15),
-				// we can still create 0,0 char device using mknodChar0Overlay().
-				//
-				// NOTE: we don't need this hack for the containerd snapshotter+unpack model.
-				if err := mknodChar0Overlay(originalPath); err != nil {
-					return false, errors.Wrapf(err, "failed to mknodChar0UserNS(%q)", originalPath)
-				}
-			} else {
-				return false, errors.Wrapf(err, "failed to mknod(%q, S_IFCHR, 0)", originalPath)
-			}
+			return false, errors.Wrapf(err, "failed to mknod(%q, S_IFCHR, 0)", originalPath)
 		}
 		if err := os.Chown(originalPath, hdr.Uid, hdr.Gid); err != nil {
 			return false, err
@@ -118,147 +97,4 @@ func (c overlayWhiteoutConverter) ConvertRead(hdr *tar.Header, path string) (boo
 	}
 
 	return true, nil
-}
-
-// mknodChar0Overlay creates 0,0 char device by mounting overlayfs and unlinking.
-// This function can be used for creating 0,0 char device in userns on Ubuntu.
-//
-// Steps:
-// * Mkdir lower,upper,merged,work
-// * Create lower/dummy
-// * Mount overlayfs
-// * Unlink merged/dummy
-// * Unmount overlayfs
-// * Make sure a 0,0 char device is created as upper/dummy
-// * Rename upper/dummy to cleansedOriginalPath
-func mknodChar0Overlay(cleansedOriginalPath string) error {
-	dir := filepath.Dir(cleansedOriginalPath)
-	tmp, err := ioutil.TempDir(dir, "mc0o")
-	if err != nil {
-		return errors.Wrapf(err, "failed to create a tmp directory under %s", dir)
-	}
-	defer os.RemoveAll(tmp)
-	lower := filepath.Join(tmp, "l")
-	upper := filepath.Join(tmp, "u")
-	work := filepath.Join(tmp, "w")
-	merged := filepath.Join(tmp, "m")
-	for _, s := range []string{lower, upper, work, merged} {
-		if err := os.MkdirAll(s, 0700); err != nil {
-			return errors.Wrapf(err, "failed to mkdir %s", s)
-		}
-	}
-	dummyBase := "d"
-	lowerDummy := filepath.Join(lower, dummyBase)
-	if err := ioutil.WriteFile(lowerDummy, []byte{}, 0600); err != nil {
-		return errors.Wrapf(err, "failed to create a dummy lower file %s", lowerDummy)
-	}
-	// lowerdir needs ":" to be escaped: https://github.com/moby/moby/issues/40939#issuecomment-627098286
-	lowerEscaped := strings.ReplaceAll(lower, ":", "\\:")
-	mOpts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerEscaped, upper, work)
-	if err := mount.Mount("overlay", merged, "overlay", mOpts); err != nil {
-		return err
-	}
-	mergedDummy := filepath.Join(merged, dummyBase)
-	if err := os.Remove(mergedDummy); err != nil {
-		syscall.Unmount(merged, 0)
-		return errors.Wrapf(err, "failed to unlink %s", mergedDummy)
-	}
-	if err := syscall.Unmount(merged, 0); err != nil {
-		return errors.Wrapf(err, "failed to unmount %s", merged)
-	}
-	upperDummy := filepath.Join(upper, dummyBase)
-	if err := isChar0(upperDummy); err != nil {
-		return err
-	}
-	if err := os.Rename(upperDummy, cleansedOriginalPath); err != nil {
-		return errors.Wrapf(err, "failed to rename %s to %s", upperDummy, cleansedOriginalPath)
-	}
-	return nil
-}
-
-func isChar0(path string) error {
-	osStat, err := os.Stat(path)
-	if err != nil {
-		return errors.Wrapf(err, "failed to stat %s", path)
-	}
-	st, ok := osStat.Sys().(*syscall.Stat_t)
-	if !ok {
-		return errors.Errorf("got unsupported stat for %s", path)
-	}
-	if os.FileMode(st.Mode)&syscall.S_IFMT != syscall.S_IFCHR {
-		return errors.Errorf("%s is not a character device, got mode=%d", path, st.Mode)
-	}
-	if st.Rdev != 0 {
-		return errors.Errorf("%s is not a 0,0 character device, got Rdev=%d", path, st.Rdev)
-	}
-	return nil
-}
-
-// replaceDirWithOverlayOpaque replaces path with a new directory with trusted.overlay.opaque
-// xattr. The contents of the directory are preserved.
-func replaceDirWithOverlayOpaque(path string) error {
-	if path == "/" {
-		return errors.New("replaceDirWithOverlayOpaque: path must not be \"/\"")
-	}
-	dir := filepath.Dir(path)
-	tmp, err := ioutil.TempDir(dir, "rdwoo")
-	if err != nil {
-		return errors.Wrapf(err, "failed to create a tmp directory under %s", dir)
-	}
-	defer os.RemoveAll(tmp)
-	// newPath is a new empty directory crafted with trusted.overlay.opaque xattr.
-	// we copy the content of path into newPath, remove path, and rename newPath to path.
-	newPath, err := createDirWithOverlayOpaque(tmp)
-	if err != nil {
-		return errors.Wrapf(err, "createDirWithOverlayOpaque(%q) failed", tmp)
-	}
-	if err := fs.CopyDir(newPath, path); err != nil {
-		return errors.Wrapf(err, "CopyDir(%q, %q) failed", newPath, path)
-	}
-	if err := os.RemoveAll(path); err != nil {
-		return err
-	}
-	return os.Rename(newPath, path)
-}
-
-// createDirWithOverlayOpaque creates a directory with trusted.overlay.opaque xattr,
-// without calling setxattr, so as to allow creating opaque dir in userns on Ubuntu.
-func createDirWithOverlayOpaque(tmp string) (string, error) {
-	lower := filepath.Join(tmp, "l")
-	upper := filepath.Join(tmp, "u")
-	work := filepath.Join(tmp, "w")
-	merged := filepath.Join(tmp, "m")
-	for _, s := range []string{lower, upper, work, merged} {
-		if err := os.MkdirAll(s, 0700); err != nil {
-			return "", errors.Wrapf(err, "failed to mkdir %s", s)
-		}
-	}
-	dummyBase := "d"
-	lowerDummy := filepath.Join(lower, dummyBase)
-	if err := os.MkdirAll(lowerDummy, 0700); err != nil {
-		return "", errors.Wrapf(err, "failed to create a dummy lower directory %s", lowerDummy)
-	}
-	// lowerdir needs ":" to be escaped: https://github.com/moby/moby/issues/40939#issuecomment-627098286
-	lowerEscaped := strings.ReplaceAll(lower, ":", "\\:")
-	mOpts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerEscaped, upper, work)
-	if err := mount.Mount("overlay", merged, "overlay", mOpts); err != nil {
-		return "", err
-	}
-	mergedDummy := filepath.Join(merged, dummyBase)
-	if err := os.Remove(mergedDummy); err != nil {
-		syscall.Unmount(merged, 0)
-		return "", errors.Wrapf(err, "failed to rmdir %s", mergedDummy)
-	}
-	// upperDummy becomes a 0,0-char device file here
-	if err := os.Mkdir(mergedDummy, 0700); err != nil {
-		syscall.Unmount(merged, 0)
-		return "", errors.Wrapf(err, "failed to mkdir %s", mergedDummy)
-	}
-	// upperDummy becomes a directory with trusted.overlay.opaque xattr
-	// (but can't be verified in userns)
-	if err := syscall.Unmount(merged, 0); err != nil {
-		return "", errors.Wrapf(err, "failed to unmount %s", merged)
-	}
-	upperDummy := filepath.Join(upper, dummyBase)
-	return upperDummy, nil
 }

--- a/pkg/archive/archive_other.go
+++ b/pkg/archive/archive_other.go
@@ -2,6 +2,6 @@
 
 package archive // import "github.com/docker/docker/pkg/archive"
 
-func getWhiteoutConverter(format WhiteoutFormat, inUserNS bool) tarWhiteoutConverter {
-	return nil
+func getWhiteoutConverter(format WhiteoutFormat, inUserNS bool) (tarWhiteoutConverter, error) {
+	return nil, nil
 }


### PR DESCRIPTION
Cherry-pick https://github.com/moby/moby/pull/42188

- - -
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix `createDirWithOverlayOpaque(...) ... input/output error` on rootless.

Fix https://github.com/docker/for-linux/issues/1055 (intermittent error, on Debian 10, kernel < 5.11)
Fix https://github.com/moby/moby/issues/42177 (100% reproducible error, on kernel >= 5.11)
Fix https://github.com/moby/moby/issues/42206

**- How I did it**

#### [bug fix] Commit 1: `overlay2: call d.naiveDiff.ApplyDiff when useNaiveDiff==true`
Previously, `d.naiveDiff.ApplyDiff` was not used even when `useNaiveDiff()==true`

#### [optimization] Commit 2: `overlay2: doesSupportNativeDiff: add fast path for userns`
When running in userns, returns error (i.e. "use naive, not native") immediately.

No substantial change to the logic.

#### [clean up] Commit 3: `archive: do not use overlayWhiteoutConverter for UserNS`
overlay2 no longer sets `archive.OverlayWhiteoutFormat` when running in UserNS, so we can remove the complicated logic in the archive package.

**- How to verify it**

```console
$ docker --context=rootless pull python:3.9
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
rootless: overlay2: fix "createDirWithOverlayOpaque(...) ... input/output error"

**- A picture of a cute animal (not mandatory but encouraged)**

:penguin:
