### PR TITLE
[20.10 backport] rootless: fix getCurrentOOMScoreAdj (fix rootless docker in kubernetes)

### DIFF
--- a/rootless/specconv/specconv_linux.go
+++ b/rootless/specconv/specconv_linux.go
@@ -3,8 +3,10 @@ package specconv // import "github.com/docker/docker/rootless/specconv"
 import (
 	"io/ioutil"
 	"strconv"
+	"strings"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
 )
 
 // ToRootless converts spec to be compatible with "rootless" runc.
@@ -19,10 +21,13 @@ func ToRootless(spec *specs.Spec, v2Controllers []string) error {
 func getCurrentOOMScoreAdj() int {
 	b, err := ioutil.ReadFile("/proc/self/oom_score_adj")
 	if err != nil {
+		logrus.WithError(err).Warn("failed to read /proc/self/oom_score_adj")
 		return 0
 	}
-	i, err := strconv.Atoi(string(b))
+	s := string(b)
+	i, err := strconv.Atoi(strings.TrimSpace(s))
 	if err != nil {
+		logrus.WithError(err).Warnf("failed to parse /proc/self/oom_score_adj (%q)", s)
 		return 0
 	}
 	return i


### PR DESCRIPTION
Cherry-pick https://github.com/moby/moby/pull/42189

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix `rootless docker in kubernetes: "getting the final child's pid from pipe caused "EOF": unknown"

