### PR TITLE
Use designated test domains (RFC2606) in tests

### DIFF
--- a/cmd/dockerd/daemon_test.go
+++ b/cmd/dockerd/daemon_test.go
@@ -167,9 +167,9 @@ func TestLoadDaemonConfigWithEmbeddedOptions(t *testing.T) {
 
 func TestLoadDaemonConfigWithRegistryOptions(t *testing.T) {
 	content := `{
-		"allow-nondistributable-artifacts": ["allow-nondistributable-artifacts.com"],
-		"registry-mirrors": ["https://mirrors.docker.com"],
-		"insecure-registries": ["https://insecure.docker.com"]
+		"allow-nondistributable-artifacts": ["allow-nondistributable-artifacts.example.com"],
+		"registry-mirrors": ["https://mirrors.example.com"],
+		"insecure-registries": ["https://insecure-registry.example.com"]
 	}`
 	tempFile := fs.NewFile(t, "config", fs.WithContent(content))
 	defer tempFile.Remove()

--- a/daemon/reload_test.go
+++ b/daemon/reload_test.go
@@ -120,9 +120,9 @@ func TestDaemonReloadMirrors(t *testing.T) {
 	daemon.RegistryService, err = registry.NewService(registry.ServiceOptions{
 		InsecureRegistries: []string{},
 		Mirrors: []string{
-			"https://mirror.test1.com",
-			"https://mirror.test2.com", // this will be removed when reloading
-			"https://mirror.test3.com", // this will be removed when reloading
+			"https://mirror.test1.example.com",
+			"https://mirror.test2.example.com", // this will be removed when reloading
+			"https://mirror.test3.example.com", // this will be removed when reloading
 		},
 	})
 	if err != nil {
@@ -150,13 +150,13 @@ func TestDaemonReloadMirrors(t *testing.T) {
 		},
 		{
 			valid:   false,
-			mirrors: []string{"10.10.1.11:5000", "mirror.test1.com"}, // mirrors are invalid
+			mirrors: []string{"10.10.1.11:5000", "mirror.test1.example.com"}, // mirrors are invalid
 			after:   []string{},
 		},
 		{
 			valid:   true,
-			mirrors: []string{"https://mirror.test1.com", "https://mirror.test4.com"},
-			after:   []string{"https://mirror.test1.com/", "https://mirror.test4.com/"},
+			mirrors: []string{"https://mirror.test1.example.com", "https://mirror.test4.example.com"},
+			after:   []string{"https://mirror.test1.example.com/", "https://mirror.test4.example.com/"},
 		},
 	}
 
@@ -224,8 +224,8 @@ func TestDaemonReloadInsecureRegistries(t *testing.T) {
 			"127.0.0.0/8",
 			"10.10.1.11:5000",
 			"10.10.1.22:5000", // this will be removed when reloading
-			"docker1.com",
-			"docker2.com", // this will be removed when reloading
+			"docker1.example.com",
+			"docker2.example.com", // this will be removed when reloading
 		},
 	})
 	if err != nil {
@@ -235,11 +235,11 @@ func TestDaemonReloadInsecureRegistries(t *testing.T) {
 	daemon.configStore = &config.Config{}
 
 	insecureRegistries := []string{
-		"127.0.0.0/8",     // this will be kept
-		"10.10.1.11:5000", // this will be kept
-		"10.10.1.33:5000", // this will be newly added
-		"docker1.com",     // this will be kept
-		"docker3.com",     // this will be newly added
+		"127.0.0.0/8",         // this will be kept
+		"10.10.1.11:5000",     // this will be kept
+		"10.10.1.33:5000",     // this will be newly added
+		"docker1.example.com", // this will be kept
+		"docker3.example.com", // this will be newly added
 	}
 
 	valuesSets := make(map[string]interface{})
@@ -300,7 +300,7 @@ func TestDaemonReloadInsecureRegistries(t *testing.T) {
 	}
 
 	// assert if "docker2.com" is removed when reloading
-	if value, ok := dataMap["docker2.com"]; ok {
+	if value, ok := dataMap["docker2.example.com"]; ok {
 		t.Fatalf("Expected no insecure registry of docker2.com, got %d", value)
 	}
 }

--- a/integration/system/info_test.go
+++ b/integration/system/info_test.go
@@ -120,7 +120,7 @@ func TestInfoRegistryMirrors(t *testing.T) {
 
 	const (
 		registryMirror1 = "https://192.168.1.2"
-		registryMirror2 = "http://registry.mirror.com:5000"
+		registryMirror2 = "http://registry-mirror.example.com:5000"
 	)
 
 	d := daemon.New(t)

--- a/registry/auth_test.go
+++ b/registry/auth_test.go
@@ -58,7 +58,7 @@ func TestResolveAuthConfigFullURL(t *testing.T) {
 	expectedAuths := map[string]types.AuthConfig{
 		"registry.example.com": registryAuth,
 		"localhost:8000":       localAuth,
-		"registry.com":         localAuth,
+		"example.com":          localAuth,
 	}
 
 	validRegistries := map[string][]string{
@@ -74,11 +74,11 @@ func TestResolveAuthConfigFullURL(t *testing.T) {
 			"localhost:8000",
 			"localhost:8000/v1/",
 		},
-		"registry.com": {
-			"https://registry.com/v1/",
-			"http://registry.com/v1/",
-			"registry.com",
-			"registry.com/v1/",
+		"example.com": {
+			"https://example.com/v1/",
+			"http://example.com/v1/",
+			"example.com",
+			"example.com/v1/",
 		},
 	}
 

--- a/registry/config_test.go
+++ b/registry/config_test.go
@@ -52,20 +52,20 @@ func TestLoadAllowNondistributableArtifacts(t *testing.T) {
 		},
 
 		{
-			registries: []string{"http://mytest.com"},
-			err:        "allow-nondistributable-artifacts registry http://mytest.com should not contain '://'",
+			registries: []string{"http://myregistry.example.com"},
+			err:        "allow-nondistributable-artifacts registry http://myregistry.example.com should not contain '://'",
 		},
 		{
-			registries: []string{"https://mytest.com"},
-			err:        "allow-nondistributable-artifacts registry https://mytest.com should not contain '://'",
+			registries: []string{"https://myregistry.example.com"},
+			err:        "allow-nondistributable-artifacts registry https://myregistry.example.com should not contain '://'",
 		},
 		{
-			registries: []string{"HTTP://mytest.com"},
-			err:        "allow-nondistributable-artifacts registry HTTP://mytest.com should not contain '://'",
+			registries: []string{"HTTP://myregistry.example.com"},
+			err:        "allow-nondistributable-artifacts registry HTTP://myregistry.example.com should not contain '://'",
 		},
 		{
-			registries: []string{"svn://mytest.com"},
-			err:        "allow-nondistributable-artifacts registry svn://mytest.com should not contain '://'",
+			registries: []string{"svn://myregistry.example.com"},
+			err:        "allow-nondistributable-artifacts registry svn://myregistry.example.com should not contain '://'",
 		},
 		{
 			registries: []string{"-invalid-registry"},
@@ -80,16 +80,16 @@ func TestLoadAllowNondistributableArtifacts(t *testing.T) {
 			err:        `allow-nondistributable-artifacts registry 1200:0000:AB00:1234:0000:2552:7777:1313:8080 is not valid: invalid host "1200:0000:AB00:1234:0000:2552:7777:1313:8080"`,
 		},
 		{
-			registries: []string{`mytest.com:500000`},
-			err:        `allow-nondistributable-artifacts registry mytest.com:500000 is not valid: invalid port "500000"`,
+			registries: []string{`myregistry.example.com:500000`},
+			err:        `allow-nondistributable-artifacts registry myregistry.example.com:500000 is not valid: invalid port "500000"`,
 		},
 		{
-			registries: []string{`"mytest.com"`},
-			err:        `allow-nondistributable-artifacts registry "mytest.com" is not valid: invalid host "\"mytest.com\""`,
+			registries: []string{`"myregistry.example.com"`},
+			err:        `allow-nondistributable-artifacts registry "myregistry.example.com" is not valid: invalid host "\"myregistry.example.com\""`,
 		},
 		{
-			registries: []string{`"mytest.com:5000"`},
-			err:        `allow-nondistributable-artifacts registry "mytest.com:5000" is not valid: invalid host "\"mytest.com"`,
+			registries: []string{`"myregistry.example.com:5000"`},
+			err:        `allow-nondistributable-artifacts registry "myregistry.example.com:5000" is not valid: invalid host "\"myregistry.example.com"`,
 		},
 	}
 	for _, testCase := range testCases {
@@ -129,10 +129,10 @@ func TestLoadAllowNondistributableArtifacts(t *testing.T) {
 
 func TestValidateMirror(t *testing.T) {
 	valid := []string{
-		"http://mirror-1.com",
-		"http://mirror-1.com/",
-		"https://mirror-1.com",
-		"https://mirror-1.com/",
+		"http://mirror-1.example.com",
+		"http://mirror-1.example.com/",
+		"https://mirror-1.example.com",
+		"https://mirror-1.example.com/",
 		"http://localhost",
 		"https://localhost",
 		"http://localhost:5000",
@@ -145,18 +145,18 @@ func TestValidateMirror(t *testing.T) {
 
 	invalid := []string{
 		"!invalid!://%as%",
-		"ftp://mirror-1.com",
-		"http://mirror-1.com/?q=foo",
-		"http://mirror-1.com/v1/",
-		"http://mirror-1.com/v1/?q=foo",
-		"http://mirror-1.com/v1/?q=foo#frag",
-		"http://mirror-1.com?q=foo",
-		"https://mirror-1.com#frag",
-		"https://mirror-1.com/#frag",
-		"http://foo:bar@mirror-1.com/",
-		"https://mirror-1.com/v1/",
-		"https://mirror-1.com/v1/#",
-		"https://mirror-1.com?q",
+		"ftp://mirror-1.example.com",
+		"http://mirror-1.example.com/?q=foo",
+		"http://mirror-1.example.com/v1/",
+		"http://mirror-1.example.com/v1/?q=foo",
+		"http://mirror-1.example.com/v1/?q=foo#frag",
+		"http://mirror-1.example.com?q=foo",
+		"https://mirror-1.example.com#frag",
+		"https://mirror-1.example.com/#frag",
+		"http://foo:bar@mirror-1.example.com/",
+		"https://mirror-1.example.com/v1/",
+		"https://mirror-1.example.com/v1/#",
+		"https://mirror-1.example.com?q",
 	}
 
 	for _, address := range valid {
@@ -195,20 +195,20 @@ func TestLoadInsecureRegistries(t *testing.T) {
 			index:      "[2001:db8::1]:80",
 		},
 		{
-			registries: []string{"http://mytest.com"},
-			index:      "mytest.com",
+			registries: []string{"http://myregistry.example.com"},
+			index:      "myregistry.example.com",
 		},
 		{
-			registries: []string{"https://mytest.com"},
-			index:      "mytest.com",
+			registries: []string{"https://myregistry.example.com"},
+			index:      "myregistry.example.com",
 		},
 		{
-			registries: []string{"HTTP://mytest.com"},
-			index:      "mytest.com",
+			registries: []string{"HTTP://myregistry.example.com"},
+			index:      "myregistry.example.com",
 		},
 		{
-			registries: []string{"svn://mytest.com"},
-			err:        "insecure registry svn://mytest.com should not contain '://'",
+			registries: []string{"svn://myregistry.example.com"},
+			err:        "insecure registry svn://myregistry.example.com should not contain '://'",
 		},
 		{
 			registries: []string{"-invalid-registry"},
@@ -223,16 +223,16 @@ func TestLoadInsecureRegistries(t *testing.T) {
 			err:        `insecure registry 1200:0000:AB00:1234:0000:2552:7777:1313:8080 is not valid: invalid host "1200:0000:AB00:1234:0000:2552:7777:1313:8080"`,
 		},
 		{
-			registries: []string{`mytest.com:500000`},
-			err:        `insecure registry mytest.com:500000 is not valid: invalid port "500000"`,
+			registries: []string{`myregistry.example.com:500000`},
+			err:        `insecure registry myregistry.example.com:500000 is not valid: invalid port "500000"`,
 		},
 		{
-			registries: []string{`"mytest.com"`},
-			err:        `insecure registry "mytest.com" is not valid: invalid host "\"mytest.com\""`,
+			registries: []string{`"myregistry.example.com"`},
+			err:        `insecure registry "myregistry.example.com" is not valid: invalid host "\"myregistry.example.com\""`,
 		},
 		{
-			registries: []string{`"mytest.com:5000"`},
-			err:        `insecure registry "mytest.com:5000" is not valid: invalid host "\"mytest.com"`,
+			registries: []string{`"myregistry.example.com:5000"`},
+			err:        `insecure registry "myregistry.example.com:5000" is not valid: invalid host "\"myregistry.example.com"`,
 		},
 	}
 	for _, testCase := range testCases {
@@ -341,8 +341,8 @@ func TestValidateIndexName(t *testing.T) {
 			expect: "mytest-1.com",
 		},
 		{
-			index:  "mirror-1.com/v1/?q=foo",
-			expect: "mirror-1.com/v1/?q=foo",
+			index:  "mirror-1.example.com/v1/?q=foo",
+			expect: "mirror-1.example.com/v1/?q=foo",
 		},
 	}
 
@@ -370,8 +370,8 @@ func TestValidateIndexNameWithError(t *testing.T) {
 			err:   "invalid index name (-example.com). Cannot begin or end with a hyphen",
 		},
 		{
-			index: "mirror-1.com/v1/?q=foo-",
-			err:   "invalid index name (mirror-1.com/v1/?q=foo-). Cannot begin or end with a hyphen",
+			index: "mirror-1.example.com/v1/?q=foo-",
+			err:   "invalid index name (mirror-1.example.com/v1/?q=foo-). Cannot begin or end with a hyphen",
 		},
 	}
 	for _, testCase := range invalid {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -647,10 +647,10 @@ func TestAllowNondistributableArtifacts(t *testing.T) {
 		{"example.com:5000", []string{"42.42.42.42/8"}, true},
 		{"127.0.0.1:5000", []string{"127.0.0.0/8"}, true},
 		{"42.42.42.42:5000", []string{"42.1.1.1/8"}, true},
-		{"invalid.domain.com", []string{"42.42.0.0/16"}, false},
-		{"invalid.domain.com", []string{"invalid.domain.com"}, true},
-		{"invalid.domain.com:5000", []string{"invalid.domain.com"}, false},
-		{"invalid.domain.com:5000", []string{"invalid.domain.com:5000"}, true},
+		{"invalid.example.com", []string{"42.42.0.0/16"}, false},
+		{"invalid.example.com", []string{"invalid.example.com"}, true},
+		{"invalid.example.com:5000", []string{"invalid.example.com"}, false},
+		{"invalid.example.com:5000", []string{"invalid.example.com:5000"}, true},
 	}
 	for _, tt := range tests {
 		config, err := newServiceConfig(ServiceOptions{
@@ -692,10 +692,10 @@ func TestIsSecureIndex(t *testing.T) {
 		{"example.com:5000", []string{"42.42.42.42/8"}, false},
 		{"127.0.0.1:5000", []string{"127.0.0.0/8"}, false},
 		{"42.42.42.42:5000", []string{"42.1.1.1/8"}, false},
-		{"invalid.domain.com", []string{"42.42.0.0/16"}, true},
-		{"invalid.domain.com", []string{"invalid.domain.com"}, false},
-		{"invalid.domain.com:5000", []string{"invalid.domain.com"}, true},
-		{"invalid.domain.com:5000", []string{"invalid.domain.com:5000"}, false},
+		{"invalid.example.com", []string{"42.42.0.0/16"}, true},
+		{"invalid.example.com", []string{"invalid.example.com"}, false},
+		{"invalid.example.com:5000", []string{"invalid.example.com"}, true},
+		{"invalid.example.com:5000", []string{"invalid.example.com:5000"}, false},
 	}
 	for _, tt := range tests {
 		config, err := makeServiceConfig(nil, tt.insecureRegistries)


### PR DESCRIPTION
Some tests were using domain names that were intended to be "fake", but are
actually registered domain names (such as domain.com, registry.com, mytest.com).

Even though we were not actually making connections to these domains, it's
better to use domains that are designated for testing/examples in RFC2606:
https://tools.ietf.org/html/rfc2606
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

