### PR TITLE
[20.10 backport] Use docker media type for plugin layers

### DIFF
--- a/plugin/backend_linux.go
+++ b/plugin/backend_linux.go
@@ -492,7 +492,7 @@ func buildManifest(ctx context.Context, s content.Manager, config digest.Digest,
 			return m, errors.Wrapf(err, "error fetching info for content digest %s", l)
 		}
 		m.Layers = append(m.Layers, specs.Descriptor{
-			MediaType: specs.MediaTypeImageLayerGzip, // TODO: This is assuming everything is a gzip compressed layer, but that may not be true.
+			MediaType: images.MediaTypeDockerSchema2LayerGzip, // TODO: This is assuming everything is a gzip compressed layer, but that may not be true.
 			Digest:    l,
 			Size:      info.Size,
 		})


### PR DESCRIPTION
Cherry-picks #42210 to 20.10
fixes https://github.com/moby/moby/issues/42191


---


This was changed as part of a refactor to use containerd dist code. The
problem is the OCI media types are not compatible with older versions of
Docker.