### PR TITLE
[20.10 backport] Fix TestInspect(), and pin arm64 machines to a specific Ubuntu version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -939,7 +939,7 @@ pipeline {
                         beforeAgent true
                         expression { params.arm64 }
                     }
-                    agent { label 'arm64 && linux' }
+                    agent { label 'arm64 && ubuntu-2004' }
                     environment {
                         TEST_SKIP_INTEGRATION_CLI = '1'
                     }

--- a/integration/service/inspect_test.go
+++ b/integration/service/inspect_test.go
@@ -88,7 +88,7 @@ func fullSwarmServiceSpec(name string, replicas uint64) swarmtypes.ServiceSpec {
 				Image:           "busybox:latest",
 				Labels:          map[string]string{"container-label": "container-value"},
 				Command:         []string{"/bin/top"},
-				Args:            []string{"-u", "root"},
+				Args:            []string{"-d", "5"},
 				Hostname:        "hostname",
 				Env:             []string{"envvar=envvalue"},
 				Dir:             "/work",


### PR DESCRIPTION
cherry-picks of:

- https://github.com/moby/moby/pull/42251 Fix flaky TestInspect
- https://github.com/moby/moby/pull/42223 Pin arm64 machines to a specific Ubuntu version