### PR TITLE
testing: update docker-py 5.0.0

### DIFF
--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -7,7 +7,7 @@ source hack/make/.integration-test-helpers
 # TODO docker 17.06 cli client used in CI fails to build using a sha;
 # unable to prepare context: unable to 'git clone' to temporary context directory: error fetching: error: no such remote ref ead0bb9e08c13dd3d1712759491eee06bf5a5602
 #: exit status 128
-: "${DOCKER_PY_COMMIT:=4.4.1}"
+: "${DOCKER_PY_COMMIT:=5.0.0}"
 
 # custom options to pass py.test
 #


### PR DESCRIPTION
drops support for python 2.

full diff: https://github.com/docker/docker-py/compare/4.4.1...5.0.0


**- A picture of a cute animal (not mandatory but encouraged)**

