### PR TITLE
[20.10 backport] Move cgroup v2 out of experimental

### DIFF
--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -122,9 +122,6 @@ func (daemon *Daemon) fillPlatformInfo(v *types.Info, sysInfo *sysinfo.SysInfo) 
 		if !v.CPUSet {
 			v.Warnings = append(v.Warnings, "WARNING: No cpuset support")
 		}
-		if v.CgroupVersion == "2" {
-			v.Warnings = append(v.Warnings, "WARNING: Support for cgroup v2 is experimental")
-		}
 		// TODO add fields for these options in types.Info
 		if !sysInfo.BlkioWeight && v.CgroupVersion == "2" {
 			// blkio weight is not available on cgroup v1 since kernel 5.0.


### PR DESCRIPTION
Cherry-pick https://github.com/moby/moby/pull/42031

- - -

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

We have upgraded runc to rc93 and added CI for cgroup 2.
So we can move cgroup v2 out of experimental.

Close #41916


**- How I did it**

Removed `WARNING: Support for cgroup v2 is experimental` from `docker info`

**- How to verify it**
Run `docker info`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Move cgroup v2 out of experimental

**- A picture of a cute animal (not mandatory but encouraged)**
:penguin:
