### PR TITLE
restartmanager:  Remove RestartManager interface, and unused error return

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -557,13 +557,7 @@ func (container *Container) InitDNSHostConfig() {
 
 // UpdateMonitor updates monitor configure for running container
 func (container *Container) UpdateMonitor(restartPolicy containertypes.RestartPolicy) {
-	type policySetter interface {
-		SetPolicy(containertypes.RestartPolicy)
-	}
-
-	if rm, ok := container.RestartManager().(policySetter); ok {
-		rm.SetPolicy(restartPolicy)
-	}
+	container.RestartManager().SetPolicy(restartPolicy)
 }
 
 // FullHostname returns hostname and optional domain appended to it.

--- a/container/container.go
+++ b/container/container.go
@@ -93,7 +93,7 @@ type Container struct {
 	// logDriver for closing
 	LogDriver      logger.Logger  `json:"-"`
 	LogCopier      *logger.Copier `json:"-"`
-	restartManager restartmanager.RestartManager
+	restartManager *restartmanager.RestartManager
 	attachContext  *attachContext
 
 	// Fields here are specific to Unix platforms
@@ -570,7 +570,7 @@ func (container *Container) FullHostname() string {
 }
 
 // RestartManager returns the current restartmanager instance connected to container.
-func (container *Container) RestartManager() restartmanager.RestartManager {
+func (container *Container) RestartManager() *restartmanager.RestartManager {
 	if container.restartManager == nil {
 		container.restartManager = restartmanager.New(container.HostConfig.RestartPolicy, container.RestartCount)
 	}

--- a/restartmanager/restartmanager.go
+++ b/restartmanager/restartmanager.go
@@ -21,7 +21,7 @@ var ErrRestartCanceled = errors.New("restart canceled")
 
 // RestartManager defines object that controls container restarting rules.
 type RestartManager interface {
-	Cancel() error
+	Cancel()
 	ShouldRestart(exitCode uint32, hasBeenManuallyStopped bool, executionDuration time.Duration) (bool, chan error, error)
 }
 
@@ -125,12 +125,11 @@ func (rm *restartManager) ShouldRestart(exitCode uint32, hasBeenManuallyStopped 
 	return true, ch, nil
 }
 
-func (rm *restartManager) Cancel() error {
+func (rm *restartManager) Cancel() {
 	rm.Do(func() {
 		rm.Lock()
 		rm.canceled = true
 		close(rm.cancel)
 		rm.Unlock()
 	})
-	return nil
 }

--- a/restartmanager/restartmanager.go
+++ b/restartmanager/restartmanager.go
@@ -23,6 +23,7 @@ var ErrRestartCanceled = errors.New("restart canceled")
 type RestartManager interface {
 	Cancel()
 	ShouldRestart(exitCode uint32, hasBeenManuallyStopped bool, executionDuration time.Duration) (bool, chan error, error)
+	SetPolicy(policy container.RestartPolicy)
 }
 
 type restartManager struct {

--- a/restartmanager/restartmanager_test.go
+++ b/restartmanager/restartmanager_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestRestartManagerTimeout(t *testing.T) {
-	rm := New(container.RestartPolicy{Name: "always"}, 0).(*restartManager)
+	rm := New(container.RestartPolicy{Name: "always"}, 0)
 	var duration = 1 * time.Second
 	should, _, err := rm.ShouldRestart(0, false, duration)
 	if err != nil {
@@ -23,7 +23,7 @@ func TestRestartManagerTimeout(t *testing.T) {
 }
 
 func TestRestartManagerTimeoutReset(t *testing.T) {
-	rm := New(container.RestartPolicy{Name: "always"}, 0).(*restartManager)
+	rm := New(container.RestartPolicy{Name: "always"}, 0)
 	rm.timeout = 5 * time.Second
 	var duration = 10 * time.Second
 	_, _, err := rm.ShouldRestart(0, false, duration)


### PR DESCRIPTION
- restartmanager: RestartManager.Cancel(): remove unused error return
    This function would never return an error, and no code was handling errors.
- restartmanager: add SetPolicy() to the RestartManager interface
- ~container.UpdateMonitor(): don't instance restartmanager if not needed When updating a container to set a "no" restart policy, and the container does not have a restart-policy set, there should be no need to instance a restartmanager.~ (removed)
- restartmanager: remove RestartManager interface; it only had a single implementation.


**- A picture of a cute animal (not mandatory but encouraged)**

