### PR TITLE
integration/container: give s390x and ppc64le machines a moment to get container(s) networking ready before running tests

### DIFF
--- a/integration/container/nat_test.go
+++ b/integration/container/nat_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -111,6 +112,11 @@ func startServerContainer(t *testing.T, msg string, port int) string {
 		})
 
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+
+	// These platforms are slower which why want give them moment to start listening requested port
+	if runtime.GOARCH == "s390x" || runtime.GOARCH == "ppc64le" {
+		time.Sleep(2 * time.Second)
+	}
 
 	return cID
 }

--- a/integration/container/rename_test.go
+++ b/integration/container/rename_test.go
@@ -2,6 +2,7 @@ package container // import "github.com/docker/docker/integration/container"
 
 import (
 	"context"
+	"runtime"
 	"testing"
 	"time"
 
@@ -150,6 +151,11 @@ func TestRenameAnonymousContainer(t *testing.T) {
 	assert.NilError(t, err)
 
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+
+	// These platforms are slower which why want give them moment to get first container networking ready
+	if runtime.GOARCH == "s390x" || runtime.GOARCH == "ppc64le" {
+		time.Sleep(2 * time.Second)
+	}
 
 	count := "-c"
 	if testEnv.OSType == "windows" {

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -2,6 +2,7 @@ package container // import "github.com/docker/docker/integration/container"
 
 import (
 	"context"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -122,6 +123,11 @@ func TestHostnameDnsResolution(t *testing.T) {
 	})
 
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+
+	// These platforms are slower which why want give them moment to get container networking ready
+	if runtime.GOARCH == "s390x" || runtime.GOARCH == "ppc64le" {
+		time.Sleep(2 * time.Second)
+	}
 
 	inspect, err := client.ContainerInspect(ctx, cID)
 	assert.NilError(t, err)


### PR DESCRIPTION
Testing my theory that if networking configuration is actually (partly) asynchronous process which why s390x / ppc64le machines does not get them ready before tests start.

Alternative for #42231 to trying to address #41561