### PR TITLE
Fixes subvol delete on a non-btrfs volume

### DIFF
--- a/contrib/nuke-graph-directory.sh
+++ b/contrib/nuke-graph-directory.sh
@@ -61,10 +61,12 @@ if command -v btrfs > /dev/null 2>&1; then
 	# Source: http://stackoverflow.com/a/32865333
 	for subvol in $(find "$dir" -type d -inum 256 | sort -r); do
 		if [ "$dir" != "$subvol" ]; then
-			(
-				set -x
-				btrfs subvolume delete "$subvol"
-			)
+			if [ "$(stat -f --format=%T $subvol)" == "btrfs" ]; then
+				(
+					set -x
+					btrfs subvolume delete "$subvol"
+				)
+			fi
 		fi
 	done
 fi

--- a/contrib/nuke-graph-directory.sh
+++ b/contrib/nuke-graph-directory.sh
@@ -60,13 +60,11 @@ if command -v btrfs > /dev/null 2>&1; then
 	# Find btrfs subvolumes under $dir checking for inode 256
 	# Source: http://stackoverflow.com/a/32865333
 	for subvol in $(find "$dir" -type d -inum 256 | sort -r); do
-		if [ "$dir" != "$subvol" ]; then
-			if [ "$(stat -f --format=%T $subvol)" == "btrfs" ]; then
-				(
-					set -x
-					btrfs subvolume delete "$subvol"
-				)
-			fi
+		if [ "$dir" != "$subvol" ] && subvolType="$(stat -f --format=%T "$subvol")" && [ "$subvolType" = "btrfs" ]; then
+			(
+				set -x
+				btrfs subvolume delete "$subvol"
+			)
 		fi
 	done
 fi


### PR DESCRIPTION
Inode numbers are guaranteed to be unique only within a filesystem.
As such there is an edge case where these predicates are true on a
non-btrfs filesystem.

Closes #42271

Signed-off-by: Brett Milford <brettmilford@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added an additional check for filesystem type.

**- How to verify it**
Tested this code block on btrfs and non-btrfs (zfs) filesystems.

**- Description for the changelog**
Fixed issue where `nuke-graph-directory.sh` executes btrfs subvolume delete on a non-btrfs file.


