### PR TITLE
[20.10] Bump hcsshim for error details fix

### DIFF
--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -141,11 +141,10 @@ func translateContainerdStartErr(cmd string, setExitCode func(int), err error) e
 	// if we receive an internal error from the initial start of a container then lets
 	// return it instead of entering the restart loop
 	// set to 127 for container cmd not found/does not exist)
-	if contains(errDesc, cmd) &&
-		(contains(errDesc, "executable file not found") ||
-			contains(errDesc, "no such file or directory") ||
-			contains(errDesc, "system cannot find the file specified") ||
-			contains(errDesc, "failed to run runc create/exec call")) {
+	if contains(errDesc, "executable file not found") ||
+		contains(errDesc, "no such file or directory") ||
+		contains(errDesc, "system cannot find the file specified") ||
+		contains(errDesc, "failed to run runc create/exec call") {
 		setExitCode(127)
 		retErr = startInvalidConfigError(errDesc)
 	}

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,5 @@
 github.com/Azure/go-ansiterm                        d6e3b3328b783f23731bc4d058875b0371ff8109
-github.com/Microsoft/hcsshim                        9dcb42f100215f8d375b4a9265e5bba009217a85 # moby branch
+github.com/Microsoft/hcsshim                        89a9a3b524264d34985f1d48793ab2b2d2e430f6 # moby branch
 github.com/Microsoft/go-winio                       5b44b70ab3ab4d291a7c1d28afe7b4afeced0ed4 # v0.4.15
 github.com/docker/libtrust                          9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/golang/gddo                              72a348e765d293ed6d1ded7b699591f14d6cd921

--- a/vendor/github.com/Microsoft/hcsshim/errors.go
+++ b/vendor/github.com/Microsoft/hcsshim/errors.go
@@ -83,7 +83,6 @@ type NetworkNotFoundError = hns.NetworkNotFoundError
 type ProcessError struct {
 	Process   *process
 	Operation string
-	ExtraInfo string
 	Err       error
 	Events    []hcs.ErrorEvent
 }
@@ -92,7 +91,6 @@ type ProcessError struct {
 type ContainerError struct {
 	Container *container
 	Operation string
-	ExtraInfo string
 	Err       error
 	Events    []hcs.ErrorEvent
 }
@@ -125,10 +123,6 @@ func (e *ContainerError) Error() string {
 		s += "\n" + ev.String()
 	}
 
-	if e.ExtraInfo != "" {
-		s += " extra info: " + e.ExtraInfo
-	}
-
 	return s
 }
 
@@ -137,7 +131,7 @@ func makeContainerError(container *container, operation string, extraInfo string
 	if _, ok := err.(*ContainerError); ok {
 		return err
 	}
-	containerError := &ContainerError{Container: container, Operation: operation, ExtraInfo: extraInfo, Err: err}
+	containerError := &ContainerError{Container: container, Operation: operation, Err: err}
 	return containerError
 }
 
@@ -176,7 +170,7 @@ func makeProcessError(process *process, operation string, extraInfo string, err 
 	if _, ok := err.(*ProcessError); ok {
 		return err
 	}
-	processError := &ProcessError{Process: process, Operation: operation, ExtraInfo: extraInfo, Err: err}
+	processError := &ProcessError{Process: process, Operation: operation, Err: err}
 	return processError
 }
 
@@ -244,7 +238,7 @@ func getInnerError(err error) error {
 
 func convertSystemError(err error, c *container) error {
 	if serr, ok := err.(*hcs.SystemError); ok {
-		return &ContainerError{Container: c, Operation: serr.Op, ExtraInfo: serr.Extra, Err: serr.Err, Events: serr.Events}
+		return &ContainerError{Container: c, Operation: serr.Op, Err: serr.Err, Events: serr.Events}
 	}
 	return err
 }

--- a/vendor/github.com/Microsoft/hcsshim/internal/hcs/errors.go
+++ b/vendor/github.com/Microsoft/hcsshim/internal/hcs/errors.go
@@ -171,7 +171,6 @@ type SystemError struct {
 	ID     string
 	Op     string
 	Err    error
-	Extra  string
 	Events []ErrorEvent
 }
 
@@ -181,9 +180,6 @@ func (e *SystemError) Error() string {
 	s := e.Op + " " + e.ID + ": " + e.Err.Error()
 	for _, ev := range e.Events {
 		s += "\n" + ev.String()
-	}
-	if e.Extra != "" {
-		s += "\n(extra info: " + e.Extra + ")"
 	}
 	return s
 }
@@ -198,7 +194,7 @@ func (e *SystemError) Timeout() bool {
 	return ok && err.Timeout()
 }
 
-func makeSystemError(system *System, op string, extra string, err error, events []ErrorEvent) error {
+func makeSystemError(system *System, op string, err error, events []ErrorEvent) error {
 	// Don't double wrap errors
 	if _, ok := err.(*SystemError); ok {
 		return err
@@ -206,7 +202,6 @@ func makeSystemError(system *System, op string, extra string, err error, events 
 	return &SystemError{
 		ID:     system.ID(),
 		Op:     op,
-		Extra:  extra,
 		Err:    err,
 		Events: events,
 	}

--- a/vendor/github.com/Microsoft/hcsshim/internal/hcs/system.go
+++ b/vendor/github.com/Microsoft/hcsshim/internal/hcs/system.go
@@ -75,7 +75,7 @@ func CreateComputeSystem(ctx context.Context, id string, hcsDocumentInterface in
 			// Terminate the compute system if it still exists. We're okay to
 			// ignore a failure here.
 			computeSystem.Terminate(ctx)
-			return nil, makeSystemError(computeSystem, operation, "", err, nil)
+			return nil, makeSystemError(computeSystem, operation, err, nil)
 		}
 	}
 
@@ -86,7 +86,7 @@ func CreateComputeSystem(ctx context.Context, id string, hcsDocumentInterface in
 			// ignore a failure here.
 			computeSystem.Terminate(ctx)
 		}
-		return nil, makeSystemError(computeSystem, operation, hcsDocument, err, events)
+		return nil, makeSystemError(computeSystem, operation, err, events)
 	}
 	go computeSystem.waitBackground()
 	if err = computeSystem.getCachedProperties(ctx); err != nil {
@@ -103,7 +103,7 @@ func OpenComputeSystem(ctx context.Context, id string) (*System, error) {
 	handle, resultJSON, err := vmcompute.HcsOpenComputeSystem(ctx, id)
 	events := processHcsResult(ctx, resultJSON)
 	if err != nil {
-		return nil, makeSystemError(computeSystem, operation, "", err, events)
+		return nil, makeSystemError(computeSystem, operation, err, events)
 	}
 	computeSystem.handle = handle
 	defer func() {
@@ -112,7 +112,7 @@ func OpenComputeSystem(ctx context.Context, id string) (*System, error) {
 		}
 	}()
 	if err = computeSystem.registerCallback(ctx); err != nil {
-		return nil, makeSystemError(computeSystem, operation, "", err, nil)
+		return nil, makeSystemError(computeSystem, operation, err, nil)
 	}
 	go computeSystem.waitBackground()
 	if err = computeSystem.getCachedProperties(ctx); err != nil {
@@ -188,13 +188,13 @@ func (computeSystem *System) Start(ctx context.Context) (err error) {
 	defer computeSystem.handleLock.RUnlock()
 
 	if computeSystem.handle == 0 {
-		return makeSystemError(computeSystem, operation, "", ErrAlreadyClosed, nil)
+		return makeSystemError(computeSystem, operation, ErrAlreadyClosed, nil)
 	}
 
 	resultJSON, err := vmcompute.HcsStartComputeSystem(ctx, computeSystem.handle, "")
 	events, err := processAsyncHcsResult(ctx, err, resultJSON, computeSystem.callbackNumber, hcsNotificationSystemStartCompleted, &timeout.SystemStart)
 	if err != nil {
-		return makeSystemError(computeSystem, operation, "", err, events)
+		return makeSystemError(computeSystem, operation, err, events)
 	}
 
 	return nil
@@ -221,7 +221,7 @@ func (computeSystem *System) Shutdown(ctx context.Context) error {
 	switch err {
 	case nil, ErrVmcomputeAlreadyStopped, ErrComputeSystemDoesNotExist, ErrVmcomputeOperationPending:
 	default:
-		return makeSystemError(computeSystem, operation, "", err, events)
+		return makeSystemError(computeSystem, operation, err, events)
 	}
 	return nil
 }
@@ -242,7 +242,7 @@ func (computeSystem *System) Terminate(ctx context.Context) error {
 	switch err {
 	case nil, ErrVmcomputeAlreadyStopped, ErrComputeSystemDoesNotExist, ErrVmcomputeOperationPending:
 	default:
-		return makeSystemError(computeSystem, operation, "", err, events)
+		return makeSystemError(computeSystem, operation, err, events)
 	}
 	return nil
 }
@@ -264,10 +264,10 @@ func (computeSystem *System) waitBackground() {
 		log.G(ctx).Debug("system exited")
 	case ErrVmcomputeUnexpectedExit:
 		log.G(ctx).Debug("unexpected system exit")
-		computeSystem.exitError = makeSystemError(computeSystem, operation, "", err, nil)
+		computeSystem.exitError = makeSystemError(computeSystem, operation, err, nil)
 		err = nil
 	default:
-		err = makeSystemError(computeSystem, operation, "", err, nil)
+		err = makeSystemError(computeSystem, operation, err, nil)
 	}
 	computeSystem.closedWaitOnce.Do(func() {
 		computeSystem.waitError = err
@@ -305,13 +305,13 @@ func (computeSystem *System) Properties(ctx context.Context, types ...schema1.Pr
 
 	queryBytes, err := json.Marshal(schema1.PropertyQuery{PropertyTypes: types})
 	if err != nil {
-		return nil, makeSystemError(computeSystem, operation, "", err, nil)
+		return nil, makeSystemError(computeSystem, operation, err, nil)
 	}
 
 	propertiesJSON, resultJSON, err := vmcompute.HcsGetComputeSystemProperties(ctx, computeSystem.handle, string(queryBytes))
 	events := processHcsResult(ctx, resultJSON)
 	if err != nil {
-		return nil, makeSystemError(computeSystem, operation, "", err, events)
+		return nil, makeSystemError(computeSystem, operation, err, events)
 	}
 
 	if propertiesJSON == "" {
@@ -319,7 +319,7 @@ func (computeSystem *System) Properties(ctx context.Context, types ...schema1.Pr
 	}
 	properties := &schema1.ContainerProperties{}
 	if err := json.Unmarshal([]byte(propertiesJSON), properties); err != nil {
-		return nil, makeSystemError(computeSystem, operation, "", err, nil)
+		return nil, makeSystemError(computeSystem, operation, err, nil)
 	}
 
 	return properties, nil
@@ -334,13 +334,13 @@ func (computeSystem *System) PropertiesV2(ctx context.Context, types ...hcsschem
 
 	queryBytes, err := json.Marshal(hcsschema.PropertyQuery{PropertyTypes: types})
 	if err != nil {
-		return nil, makeSystemError(computeSystem, operation, "", err, nil)
+		return nil, makeSystemError(computeSystem, operation, err, nil)
 	}
 
 	propertiesJSON, resultJSON, err := vmcompute.HcsGetComputeSystemProperties(ctx, computeSystem.handle, string(queryBytes))
 	events := processHcsResult(ctx, resultJSON)
 	if err != nil {
-		return nil, makeSystemError(computeSystem, operation, "", err, events)
+		return nil, makeSystemError(computeSystem, operation, err, events)
 	}
 
 	if propertiesJSON == "" {
@@ -348,7 +348,7 @@ func (computeSystem *System) PropertiesV2(ctx context.Context, types ...hcsschem
 	}
 	properties := &hcsschema.Properties{}
 	if err := json.Unmarshal([]byte(propertiesJSON), properties); err != nil {
-		return nil, makeSystemError(computeSystem, operation, "", err, nil)
+		return nil, makeSystemError(computeSystem, operation, err, nil)
 	}
 
 	return properties, nil
@@ -369,13 +369,13 @@ func (computeSystem *System) Pause(ctx context.Context) (err error) {
 	defer computeSystem.handleLock.RUnlock()
 
 	if computeSystem.handle == 0 {
-		return makeSystemError(computeSystem, operation, "", ErrAlreadyClosed, nil)
+		return makeSystemError(computeSystem, operation, ErrAlreadyClosed, nil)
 	}
 
 	resultJSON, err := vmcompute.HcsPauseComputeSystem(ctx, computeSystem.handle, "")
 	events, err := processAsyncHcsResult(ctx, err, resultJSON, computeSystem.callbackNumber, hcsNotificationSystemPauseCompleted, &timeout.SystemPause)
 	if err != nil {
-		return makeSystemError(computeSystem, operation, "", err, events)
+		return makeSystemError(computeSystem, operation, err, events)
 	}
 
 	return nil
@@ -396,13 +396,13 @@ func (computeSystem *System) Resume(ctx context.Context) (err error) {
 	defer computeSystem.handleLock.RUnlock()
 
 	if computeSystem.handle == 0 {
-		return makeSystemError(computeSystem, operation, "", ErrAlreadyClosed, nil)
+		return makeSystemError(computeSystem, operation, ErrAlreadyClosed, nil)
 	}
 
 	resultJSON, err := vmcompute.HcsResumeComputeSystem(ctx, computeSystem.handle, "")
 	events, err := processAsyncHcsResult(ctx, err, resultJSON, computeSystem.callbackNumber, hcsNotificationSystemResumeCompleted, &timeout.SystemResume)
 	if err != nil {
-		return makeSystemError(computeSystem, operation, "", err, events)
+		return makeSystemError(computeSystem, operation, err, events)
 	}
 
 	return nil
@@ -413,19 +413,19 @@ func (computeSystem *System) createProcess(ctx context.Context, operation string
 	defer computeSystem.handleLock.RUnlock()
 
 	if computeSystem.handle == 0 {
-		return nil, nil, makeSystemError(computeSystem, operation, "", ErrAlreadyClosed, nil)
+		return nil, nil, makeSystemError(computeSystem, operation, ErrAlreadyClosed, nil)
 	}
 
 	configurationb, err := json.Marshal(c)
 	if err != nil {
-		return nil, nil, makeSystemError(computeSystem, operation, "", err, nil)
+		return nil, nil, makeSystemError(computeSystem, operation, err, nil)
 	}
 
 	configuration := string(configurationb)
 	processInfo, processHandle, resultJSON, err := vmcompute.HcsCreateProcess(ctx, computeSystem.handle, configuration)
 	events := processHcsResult(ctx, resultJSON)
 	if err != nil {
-		return nil, nil, makeSystemError(computeSystem, operation, configuration, err, events)
+		return nil, nil, makeSystemError(computeSystem, operation, err, events)
 	}
 
 	log.G(ctx).WithField("pid", processInfo.ProcessId).Debug("created process pid")
@@ -447,7 +447,7 @@ func (computeSystem *System) CreateProcess(ctx context.Context, c interface{}) (
 
 	pipes, err := makeOpenFiles([]syscall.Handle{processInfo.StdInput, processInfo.StdOutput, processInfo.StdError})
 	if err != nil {
-		return nil, makeSystemError(computeSystem, operation, "", err, nil)
+		return nil, makeSystemError(computeSystem, operation, err, nil)
 	}
 	process.stdin = pipes[0]
 	process.stdout = pipes[1]
@@ -455,7 +455,7 @@ func (computeSystem *System) CreateProcess(ctx context.Context, c interface{}) (
 	process.hasCachedStdio = true
 
 	if err = process.registerCallback(ctx); err != nil {
-		return nil, makeSystemError(computeSystem, operation, "", err, nil)
+		return nil, makeSystemError(computeSystem, operation, err, nil)
 	}
 	go process.waitBackground()
 
@@ -470,18 +470,18 @@ func (computeSystem *System) OpenProcess(ctx context.Context, pid int) (*Process
 	operation := "hcsshim::System::OpenProcess"
 
 	if computeSystem.handle == 0 {
-		return nil, makeSystemError(computeSystem, operation, "", ErrAlreadyClosed, nil)
+		return nil, makeSystemError(computeSystem, operation, ErrAlreadyClosed, nil)
 	}
 
 	processHandle, resultJSON, err := vmcompute.HcsOpenProcess(ctx, computeSystem.handle, uint32(pid))
 	events := processHcsResult(ctx, resultJSON)
 	if err != nil {
-		return nil, makeSystemError(computeSystem, operation, "", err, events)
+		return nil, makeSystemError(computeSystem, operation, err, events)
 	}
 
 	process := newProcess(processHandle, pid, computeSystem)
 	if err = process.registerCallback(ctx); err != nil {
-		return nil, makeSystemError(computeSystem, operation, "", err, nil)
+		return nil, makeSystemError(computeSystem, operation, err, nil)
 	}
 	go process.waitBackground()
 
@@ -505,12 +505,12 @@ func (computeSystem *System) Close() (err error) {
 	}
 
 	if err = computeSystem.unregisterCallback(ctx); err != nil {
-		return makeSystemError(computeSystem, operation, "", err, nil)
+		return makeSystemError(computeSystem, operation, err, nil)
 	}
 
 	err = vmcompute.HcsCloseComputeSystem(ctx, computeSystem.handle)
 	if err != nil {
-		return makeSystemError(computeSystem, operation, "", err, nil)
+		return makeSystemError(computeSystem, operation, err, nil)
 	}
 
 	computeSystem.handle = 0
@@ -587,7 +587,7 @@ func (computeSystem *System) Modify(ctx context.Context, config interface{}) err
 	operation := "hcsshim::System::Modify"
 
 	if computeSystem.handle == 0 {
-		return makeSystemError(computeSystem, operation, "", ErrAlreadyClosed, nil)
+		return makeSystemError(computeSystem, operation, ErrAlreadyClosed, nil)
 	}
 
 	requestBytes, err := json.Marshal(config)
@@ -599,7 +599,7 @@ func (computeSystem *System) Modify(ctx context.Context, config interface{}) err
 	resultJSON, err := vmcompute.HcsModifyComputeSystem(ctx, computeSystem.handle, requestJSON)
 	events := processHcsResult(ctx, resultJSON)
 	if err != nil {
-		return makeSystemError(computeSystem, operation, requestJSON, err, events)
+		return makeSystemError(computeSystem, operation, err, events)
 	}
 
 	return nil


### PR DESCRIPTION
This pulls in fixes from the moby branch for hcsshim that 20.10 uses.
Not bumping up to the latest release because the diff is huge.

