### PR TITLE
[20.10 backport] Dockerfile: update yamllint to v1.26.1 to fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -300,7 +300,7 @@ RUN update-alternatives --set iptables  /usr/sbin/iptables-legacy  || true \
  && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy || true \
  && update-alternatives --set arptables /usr/sbin/arptables-legacy || true
 
-RUN pip3 install yamllint==1.16.0
+RUN pip3 install yamllint==1.26.1
 
 COPY --from=dockercli     /build/ /usr/local/cli
 COPY --from=frozen-images /build/ /docker-frozen-images


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/42296

Installation of yamllint started failing, on non-amd64 builds, which could
be if the version we were using wasn't specific enough about a dependency
to install.

    copying Cython/Utility/CppSupport.cpp -> build/lib.linux-aarch64-3.7/Cython/Utility
    running build_ext
    building 'Cython.Plex.Scanners' extension
    creating build/temp.linux-aarch64-3.7
    creating build/temp.linux-aarch64-3.7/tmp
    creating build/temp.linux-aarch64-3.7/tmp/pip-install-jasgbmp7
    creating build/temp.linux-aarch64-3.7/tmp/pip-install-jasgbmp7/Cython
    creating build/temp.linux-aarch64-3.7/tmp/pip-install-jasgbmp7/Cython/Cython
    creating build/temp.linux-aarch64-3.7/tmp/pip-install-jasgbmp7/Cython/Cython/Plex
    aarch64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/usr/include/python3.7m -c /tmp/pip-install-jasgbmp7/Cython/Cython/Plex/Scanners.c -o build/temp.linux-aarch64-3.7/tmp/pip-install-jasgbmp7/Cython/Cython/Plex/Scanners.o
         /tmp/pip-install-jasgbmp7/Cython/Cython/Plex/Scanners.c:21:10: fatal error: Python.h: No such file or directory
          #include "Python.h"
                   ^~~~~~~~~~
         compilation terminated.
         error: command 'aarch64-linux-gnu-gcc' failed with exit status 1

         ----------------------------------------
     Command "/usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-jasgbmp7/Cython/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-record-if5qclwe/install-record.txt --single-version-externally-managed --prefix /tmp/pip-build-env-_dtiuyfw --compile" failed with error code 1 in /tmp/pip-install-jasgbmp7/Cython/

      ----------------------------------------
    Command "/usr/bin/python3 -m pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-_dtiuyfw --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- setuptools wheel Cython" failed with error code 1 in None
    #22 ERROR: executor failed running [/bin/sh -c pip3 install yamllint==1.16.0]: exit code: 1

Trying if updating to the latest version fixes this.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit c35cefb48913fe7a77e99a5b9088cdfccac8ee13)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

