### PR TITLE
apparmor.InstallDefault(): fix order of remove/close and fix linting warnings

### DIFF
--- a/contrib/apparmor/main.go
+++ b/contrib/apparmor/main.go
@@ -46,7 +46,9 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	if err := compiled.Execute(f, data); err != nil {
 		log.Fatalf("executing template failed: %v", err)

--- a/profiles/apparmor/apparmor.go
+++ b/profiles/apparmor/apparmor.go
@@ -98,8 +98,10 @@ func InstallDefault(name string) error {
 	}
 	profilePath := f.Name()
 
-	defer f.Close()
-	defer os.Remove(profilePath)
+	defer func() {
+		_ = f.Close()
+		_ = os.Remove(profilePath)
+	}()
 
 	if err := p.generateDefault(f); err != nil {
 		return err
@@ -115,7 +117,9 @@ func IsLoaded(name string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	r := bufio.NewReader(file)
 	for {


### PR DESCRIPTION
splitting this from https://github.com/moby/moby/pull/42303

Current versions of gosec showed warnings for these:

    contrib/apparmor/main.go:49:2: G307: Deferring unsafe method "Close" on type "*os.File" (gosec)
        defer f.Close()
        ^
    profiles/apparmor/apparmor.go:101:2: G307: Deferring unsafe method "Close" on type "*os.File" (gosec)
        defer f.Close()
        ^
    profiles/apparmor/apparmor.go:118:2: G307: Deferring unsafe method "Close" on type "*os.File" (gosec)
        defer file.Close()
        ^

Looking at the existing code: https://github.com/moby/moby/blob/7b9275c0da707b030e62c96b679a976f31f929d3/profiles/apparmor/apparmor.go#L99-L102

It looks like these will be executed in the incorrect order; defer statements
are executed in _reverse_ order in which they're added. For example:

    package main

    import "fmt"

    func main() {
        defer fmt.Println("executing f.Close()")
        defer fmt.Println("executing os.Remove(profilePath)")
    }

Will print:

    executing os.Remove(profilePath)
    executing f.Close()

Grouping them together in a single defer makes sure they're executed in the expected order, and makes it slightly less error-prone.

(those defers were added in https://github.com/moby/moby/commit/2f7596aaef3a9f8ec1f2d0937462d9263bee8b6b / https://github.com/moby/moby/pull/26518)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

