### PR TITLE
[DNM] trigger CI with containerd v1.5.0-rc.3 + runc rc94-pre

### DIFF
--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -241,8 +241,11 @@ func (container *Container) SecretMounts() ([]Mount, error) {
 			return nil, err
 		}
 		mounts = append(mounts, Mount{
-			Source:      fPath,
-			Destination: r.File.Name,
+			Source: fPath,
+			// runc >= 1.0.0-rc94 wants Destination to be absolute,
+			// so we prepend "/" here.
+			// https://github.com/opencontainers/runc/issues/2928
+			Destination: "/" + r.File.Name,
 			Writable:    false,
 		})
 	}

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -4,7 +4,7 @@
 # The version of runc should match the version that is used by the containerd
 # version that is used. If you need to update runc, open a pull request in
 # the containerd project first, and update both after that is merged.
-: ${RUNC_COMMIT:=12644e614e25b05da6fd08a38ffa0cfe1903fdec} # v1.0.0-rc93
+: ${RUNC_COMMIT:=62250c13fe171a330340d8d95a9c6ef2b4a240a5} # v1.0.0-rc94-pre
 
 install_runc() {
 	# If using RHEL7 kernels (3.10.0 el7), disable kmem accounting/limiting

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -495,33 +495,6 @@ func (s *DockerSuite) TestRunWithInvalidCpuPeriod(c *testing.T) {
 	assert.Assert(c, strings.Contains(out, expected))
 }
 
-func (s *DockerSuite) TestRunWithKernelMemory(c *testing.T) {
-	testRequires(c, DaemonIsLinux, kernelMemorySupport)
-
-	file := "/sys/fs/cgroup/memory/memory.kmem.limit_in_bytes"
-	cli.DockerCmd(c, "run", "--kernel-memory", "50M", "--name", "test1", "busybox", "cat", file).Assert(c, icmd.Expected{
-		Out: "52428800",
-	})
-
-	cli.InspectCmd(c, "test1", cli.Format(".HostConfig.KernelMemory")).Assert(c, icmd.Expected{
-		Out: "52428800",
-	})
-}
-
-func (s *DockerSuite) TestRunWithInvalidKernelMemory(c *testing.T) {
-	testRequires(c, DaemonIsLinux, kernelMemorySupport)
-
-	out, _, err := dockerCmdWithError("run", "--kernel-memory", "2M", "busybox", "true")
-	assert.ErrorContains(c, err, "")
-	expected := "Minimum kernel memory limit allowed is 4MB"
-	assert.Assert(c, strings.Contains(out, expected))
-
-	out, _, err = dockerCmdWithError("run", "--kernel-memory", "-16m", "--name", "test2", "busybox", "echo", "test")
-	assert.ErrorContains(c, err, "")
-	expected = "invalid size"
-	assert.Assert(c, strings.Contains(out, expected))
-}
-
 func (s *DockerSuite) TestRunWithCPUShares(c *testing.T) {
 	testRequires(c, cpuShare)
 

--- a/integration-cli/requirements_unix_test.go
+++ b/integration-cli/requirements_unix_test.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/sysinfo"
 )
 
@@ -35,21 +34,6 @@ func oomControl() bool {
 
 func pidsLimit() bool {
 	return SysInfo.PidsLimit
-}
-
-func kernelMemorySupport() bool {
-	// TODO remove this once kmem support in RHEL kernels is fixed. See https://github.com/opencontainers/runc/pull/1921
-	daemonV, err := kernel.ParseRelease(testEnv.DaemonInfo.KernelVersion)
-	if err != nil {
-		return false
-	}
-	requiredV := kernel.VersionInfo{Kernel: 3, Major: 10}
-	if kernel.CompareKernelVersion(*daemonV, requiredV) < 1 {
-		// On Kernel 3.10 and under, don't consider kernel memory to be supported,
-		// even if the kernel (and thus the daemon) reports it as being supported
-		return false
-	}
-	return testEnv.DaemonInfo.KernelMemory
 }
 
 func memoryLimitSupport() bool {


### PR DESCRIPTION
Triggering CI with containerd v1.5.0-rc.2 for ensuring that containerd 1.5 is compatible with the current Moby.
