### PR TITLE
Remove myself (lowenna aka jhowardmsft) from maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -33,7 +33,6 @@
 			"johnstep",
 			"justincormack",
 			"kolyshkin",
-			"lowenna",
 			"mhbauer",
 			"runcom",
 			"stevvooe",


### PR DESCRIPTION
Signed-off-by: John Howard <github@lowenna.com>

I think it's very doubtful at this point that I'm going to be able to positively contribute anything to the project now that I'm semi-retired, no longer working at Microsoft, have the tech to be able to run this stuff on Windows, nor have any "inside" knowledge some 18-months on. So time to bow out gracefully and watch from afar. I still use it daily, just on Linux 😂. So I'm giving up my maintainer role. 

Just hope I got my PR correct with the CR/LF vs LF. It's been waaaaay too long since I did anything cross-platform. It will make me laugh at least if I got it wrong, my machine is just defaults 🤣

@akihirosuda @anusha @coolljt0725 @cpuguy83 @crosbymichael @estesp @johnstep @justincormack @kolyshkin @mhbauer @runcom @stevvooe @thajeztah @tianon @tibor @tonistiigi @unclejack @vdemeester @vieux @yongtang