### PR TITLE
Remove needless check

### DIFF
--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -28,8 +28,8 @@ if ! [ -w $XDG_RUNTIME_DIR ]; then
 	echo "XDG_RUNTIME_DIR needs to be set and writable"
 	exit 1
 fi
-if ! [ -w $HOME ]; then
-	echo "HOME needs to be set and writable"
+if ! [ -d $HOME ]; then
+	echo "HOME needs to be set and exist."
 	exit 1
 fi
 


### PR DESCRIPTION
**- What I did**

Starting `dockerd-rootless.sh` checks that `$HOME` is writeable, but does not
require it to be so. It failed to start with a read-only `$HOME`.

Make the check more precise, and check that it actually exists and is a
directory.

**- How to verify it**

1. Move this into `/usr/bin`.
2. Run it.
3. It works.

**- Description for the changelog**

- rootless: Remove unnecessary permissions check.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/730811/115453415-23935780-a20f-11eb-856f-d42cb243f1a6.png)
[(source)](https://www.reddit.com/r/aww/comments/muu6th/akali_was_returned_to_the_shelter_by_her_first/)