### PR TITLE
dockerd-rootless.sh: use `command -v` instead of `which`

### DIFF
--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -35,7 +35,7 @@ fi
 
 rootlesskit=""
 for f in docker-rootlesskit rootlesskit; do
-	if which $f > /dev/null 2>&1; then
+	if command -v $f > /dev/null 2>&1; then
 		rootlesskit=$f
 		break
 	fi
@@ -53,7 +53,7 @@ fi
 net=$DOCKERD_ROOTLESS_ROOTLESSKIT_NET
 mtu=$DOCKERD_ROOTLESS_ROOTLESSKIT_MTU
 if [ -z $net ]; then
-	if which slirp4netns > /dev/null 2>&1; then
+	if command -v slirp4netns > /dev/null 2>&1; then
 		# If --netns-type is present in --help, slirp4netns is >= v0.4.0.
 		if slirp4netns --help | grep -qw -- --netns-type; then
 			net=slirp4netns
@@ -65,7 +65,7 @@ if [ -z $net ]; then
 		fi
 	fi
 	if [ -z $net ]; then
-		if which vpnkit > /dev/null 2>&1; then
+		if command -v vpnkit > /dev/null 2>&1; then
 			net=vpnkit
 		else
 			echo "Either slirp4netns (>= v0.4.0) or vpnkit needs to be installed"


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Allow running rootless daemon without `which` binary

**- How I did it**
Use `command -v`

**- How to verify it**
Run `dockerd-rootless.sh`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
dockerd-rootless.sh: use `command -v` instead of `which`

**- A picture of a cute animal (not mandatory but encouraged)**
:penguin:
