### PR TITLE
builder/dockerfile: add "ALL_PROXY" to list of default build args

### DIFF
--- a/builder/dockerfile/buildargs.go
+++ b/builder/dockerfile/buildargs.go
@@ -19,6 +19,8 @@ var builtinAllowedBuildArgs = map[string]bool{
 	"ftp_proxy":   true,
 	"NO_PROXY":    true,
 	"no_proxy":    true,
+	"ALL_PROXY":   true,
+	"all_proxy":   true,
 }
 
 // BuildArgs manages arguments used by the builder

--- a/builder/dockerfile/buildargs_test.go
+++ b/builder/dockerfile/buildargs_test.go
@@ -19,6 +19,7 @@ func TestGetAllAllowed(t *testing.T) {
 		"ArgOverriddenByOptions":              strPtr("fromopt2"),
 		"ArgNoDefaultInDockerfileFromOptions": strPtr("fromopt3"),
 		"HTTP_PROXY":                          strPtr("theproxy"),
+		"all_proxy":                           strPtr("theproxy2"),
 	})
 
 	buildArgs.AddMetaArg("ArgFromMeta", strPtr("frommeta1"))
@@ -35,6 +36,7 @@ func TestGetAllAllowed(t *testing.T) {
 	all := buildArgs.GetAllAllowed()
 	expected := map[string]string{
 		"HTTP_PROXY":                          "theproxy",
+		"all_proxy":                           "theproxy2",
 		"ArgOverriddenByOptions":              "fromopt2",
 		"ArgWithDefaultInDockerfile":          "fromdockerfile1",
 		"ArgNoDefaultInDockerfileFromOptions": "fromopt3",


### PR DESCRIPTION
equivalent change for buildkit: https://github.com/moby/buildkit/pull/2086

Relates to https://github.com/linuxkit/linuxkit/blob/a82fff637781877fc0d88c0f6e514fcd24699c46/docs/packages.md#proxies

> (..) the first four of these are the standard built-in build-arg options
> available for `docker build`
> (..) The last, `all_proxy`, is a standard var used for socks proxying. Since
> it is not built into `docker build`, if you want to use it, you will need to
> add the following line to the dockerfile:
>
> ARG all_proxy

Given the we support all other commonly known proxy env-vars by default, it makes sense to add this one as well.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->



**- A picture of a cute animal (not mandatory but encouraged)**

