### PR TITLE
fix port forwarding with ipv6.disable=1

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -47,7 +47,7 @@ github.com/grpc-ecosystem/go-grpc-middleware        3c51f7f332123e8be5a157c0802a
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        b3507428be5b458cb0e2b4086b13531fb0706e46
+github.com/docker/libnetwork                        7b9c2905883df5171fda10a364a81b8c6176c8e2 https://github.com/AkihiroSuda/libnetwork.git # https://github.com/moby/libnetwork/pull/2635
 github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/drivers/bridge/port_mapping.go
+++ b/vendor/github.com/docker/libnetwork/drivers/bridge/port_mapping.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sync"
 
 	"github.com/docker/libnetwork/types"
 	"github.com/ishidawataru/sctp"
@@ -48,6 +49,13 @@ func (n *bridgeNetwork) allocatePortsInternal(bindings []types.PortBinding, cont
 				return nil, err
 			}
 			bs = append(bs, bIPv4)
+		}
+
+		// skip adding implicit v6 addr, when the kernel was booted with `ipv6.disable=1`
+		// https://github.com/moby/moby/issues/42288
+		isV6Binding := c.HostIP != nil && c.HostIP.To4() == nil
+		if !isV6Binding && !IsV6Listenable() {
+			continue
 		}
 
 		// Allocate IPv6 Port mappings
@@ -210,4 +218,27 @@ func (n *bridgeNetwork) releasePort(bnd types.PortBinding) error {
 	}
 
 	return portmapper.Unmap(host)
+}
+
+var (
+	v6ListenableCached bool
+	v6ListenableOnce   sync.Once
+)
+
+// IsV6Listenable returns true when `[::1]:0` is listenable.
+// IsV6Listenable returns false mostly when the kernel was booted with `ipv6.disable=1` option.
+func IsV6Listenable() bool {
+	v6ListenableOnce.Do(func() {
+		ln, err := net.Listen("tcp6", "[::1]:0")
+		if err != nil {
+			// When the kernel was booted with `ipv6.disable=1`,
+			// we get err "listen tcp6 [::1]:0: socket: address family not supported by protocol"
+			// https://github.com/moby/moby/issues/42288
+			logrus.Debugf("port_mapping: v6Listenable=false (%v)", err)
+		} else {
+			v6ListenableCached = true
+			ln.Close()
+		}
+	})
+	return v6ListenableCached
 }


### PR DESCRIPTION
# Marked as draft until https://github.com/moby/libnetwork/pull/2635 gets merged



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Make `docker run -p 80:80` functional again on environments with kernel boot parameter `ipv6.disable=1`.

Fix moby/moby#42288
Fix https://github.com/docker/for-linux/issues/1233


**- How I did it**

Skip listening on v6 addr when `net.Listen("tcp6", "[::1]:p")` fails 

**- How to verify it**
Tested on Ubuntu 21.04 host.

- Boot the host with kernel cmdline `ipv6.disable=1`.
- Make sure `docker run -p 80:80 nginx:alpine` succeeds. Previously, this was failing with `Error starting userland proxy: listen tcp6 [::]:80: socket: address family not supported by protocol.`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix port forwarding with ipv6.disable=1

**- A picture of a cute animal (not mandatory but encouraged)**

:penguin: