### PR TITLE
hack/dind: fix cgroup v2 evacuation with `docker run --init`

### DIFF
--- a/hack/dind
+++ b/hack/dind
@@ -27,10 +27,11 @@ fi
 
 # cgroup v2: enable nesting
 if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
-	# move the init process (PID 1) from the root group to the /init group,
+	# move the processes from the root group to the /init group,
 	# otherwise writing subtree_control fails with EBUSY.
+	# An error during moving non-existent process (i.e., "cat") is ignored.
 	mkdir -p /sys/fs/cgroup/init
-	echo 1 > /sys/fs/cgroup/init/cgroup.procs
+	xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs || :
 	# enable controllers
 	sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers \
 		> /sys/fs/cgroup/cgroup.subtree_control


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix docker-library/docker#308


**- How I did it**
Evacuate all the processes in `/sys/fs/cgroup/cgroup.procs`, not just PID 1.



**- How to verify it**

Before:
```console
$ docker run --rm --privileged --init $(docker build -q .) cat /sys/fs/cgroup/cgroup.subtree_control
sed: couldn't flush stdout: Device or resource busy
```

After:
```console
$ docker run --rm --privileged --init $(docker build -q .) cat /sys/fs/cgroup/cgroup.subtree_control
cpuset cpu io memory hugetlb pids rdma
```



