### PR TITLE
Added missing test cleanup for temporary directory

### DIFF
--- a/daemon/graphdriver/copy/copy_test.go
+++ b/daemon/graphdriver/copy/copy_test.go
@@ -33,6 +33,7 @@ func TestCopyWithoutRange(t *testing.T) {
 func TestCopyDir(t *testing.T) {
 	srcDir, err := ioutil.TempDir("", "srcDir")
 	assert.NilError(t, err)
+	defer os.RemoveAll(srcDir)
 	populateSrcDir(t, srcDir, 3)
 
 	dstDir, err := ioutil.TempDir("", "testdst")
@@ -111,7 +112,7 @@ func doCopyTest(t *testing.T, copyWithFileRange, copyWithFileClone *bool) {
 	assert.NilError(t, err)
 	defer os.RemoveAll(dir)
 	srcFilename := filepath.Join(dir, "srcFilename")
-	dstFilename := filepath.Join(dir, "dstilename")
+	dstFilename := filepath.Join(dir, "dstFilename")
 
 	r := rand.New(rand.NewSource(0))
 	buf := make([]byte, 1024)


### PR DESCRIPTION
**- What I did**
While going through one of the test files, I noticed that one temporary directory was not being removed at the end of the test so I fixed that. There was also a typo in a directory name. Although it was a minor thing I fixed that one too.

**- How I did it**
I added the missing deferred `os.RemoveAll` call to the test.

**- How to verify it**
The changed `copy_test.go` file can be checked for verification purposes.

**- Description for the changelog**
As it was a change in one test file only, so there's no need to mention anything in the changelog in my opinion.


**- A picture of a cute animal (not mandatory but encouraged)**
![10417382613_cb61b5f72b_b](https://user-images.githubusercontent.com/16489712/116782919-86e57b00-aa94-11eb-92e5-fffbcbe0e56e.jpeg)

