### PR TITLE
[WIP]overlay2: async umount until kernel can process umount syscall completely

### DIFF
--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/daemon/graphdriver/overlayutils"
@@ -530,13 +531,9 @@ func (d *Driver) Get(id, mountLabel string) (_ containerfs.ContainerFS, retErr e
 	defer func() {
 		if retErr != nil {
 			if c := d.ctr.Decrement(mergedDir); c <= 0 {
-				if mntErr := unix.Unmount(mergedDir, 0); mntErr != nil {
-					logger.Errorf("error unmounting %v: %v", mergedDir, mntErr)
-				}
-				// Cleanup the created merged directory; see the comment in Put's rmdir
-				if rmErr := unix.Rmdir(mergedDir); rmErr != nil && !os.IsNotExist(rmErr) {
-					logger.Debugf("Failed to remove %s: %v: %v", id, rmErr, err)
-				}
+				ch := make(chan struct{})
+				go d.cleanMountPoint(mergedDir, id, ch)
+				<-ch
 			}
 		}
 	}()
@@ -596,8 +593,15 @@ func (d *Driver) Get(id, mountLabel string) (_ containerfs.ContainerFS, retErr e
 		mountTarget = path.Join(id, mergedDirName)
 	}
 
-	if err := mount("overlay", mountTarget, "overlay", 0, mountData); err != nil {
-		return nil, fmt.Errorf("error creating overlay mount to %s: %v", mergedDir, err)
+	for i := 0; i < 3; i++ {
+		var merr error
+		if merr = mount("overlay", mountTarget, "overlay", 0, mountData); merr == nil {
+			break
+		}
+		if i == 2 {
+			return nil, fmt.Errorf("error creating overlay mount to %s: %v", mergedDir, merr)
+		}
+		time.Sleep(1 * time.Second)
 	}
 
 	if !readonly {
@@ -631,9 +635,27 @@ func (d *Driver) Put(id string) error {
 	if count := d.ctr.Decrement(mountpoint); count > 0 {
 		return nil
 	}
+	ch := make(chan struct{})
+	go d.cleanMountPoint(mountpoint, id, ch)
+	<-ch
+
+	return nil
+}
+
+func (d *Driver) cleanMountPoint(mountpoint string, id string, ch chan<- struct{}) {
+	ch <- struct{}{}
+	logger.Infof("Start to umount mountpoint %s for %s", mountpoint, id)
 	if err := unix.Unmount(mountpoint, unix.MNT_DETACH); err != nil {
 		logger.Debugf("Failed to unmount %s overlay: %s - %v", id, mountpoint, err)
 	}
+	logger.Infof("Successful to umount mountpoint %s for %s", mountpoint, id)
+
+	d.locker.Lock(id)
+	defer d.locker.Unlock(id)
+	if count := d.ctr.Get(mountpoint); count > 0 {
+		return
+	}
+	logger.Infof("Start to remove %s overlay dir %s", id, mountpoint)
 	// Remove the mountpoint here. Removing the mountpoint (in newer kernels)
 	// will cause all other instances of this mount in other mount namespaces
 	// to be unmounted. This is necessary to avoid cases where an overlay mount
@@ -644,7 +666,8 @@ func (d *Driver) Put(id string) error {
 	if err := unix.Rmdir(mountpoint); err != nil && !os.IsNotExist(err) {
 		logger.Debugf("Failed to remove %s overlay: %v", id, err)
 	}
-	return nil
+	// The count delete here safely can avoid wrong mountpoint check
+	d.ctr.Delete(mountpoint)
 }
 
 // Exists checks to see if the id is already mounted.


### PR DESCRIPTION
Because unmount has a sync_filesystem call in the kernel, which may take
a lot of time in some cases. Especially when high io write data to docker root
dir, unmount may hang and lead k8s cri api call failed with 'context deadline
exceeded'. So, wrap umount and rmdir in an goroutine here.

Signed-off-by: zvier <zvier20@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Overlay2 umount optimization.

Relate to #42242

**- How I did it**
Use async umount with wrap umount and rmdir call in a goroutine. 

**- How to verify it**
`docker create`, `docker stop` and other docker commands execute as expect.

**- Description for the changelog**
Overlay2 umount optimization.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

