### PR TITLE
[20.10 backport] Use v2 capabilities in layer archives

### DIFF
--- a/integration/build/build_userns_linux_test.go
+++ b/integration/build/build_userns_linux_test.go
@@ -118,15 +118,6 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 	_, err = stdcopy.StdCopy(actualStdout, actualStderr, logReader)
 	assert.NilError(t, err)
 	if strings.TrimSpace(actualStdout.String()) != "/bin/sleep cap_net_bind_service=eip" {
-		// Activate when fix is merged: https://github.com/moby/moby/pull/41724
-		//t.Fatalf("run produced invalid output: %q, expected %q", actualStdout.String(), "/bin/sleep cap_net_bind_service=eip")
-		// t.Logf("run produced invalid output (expected until #41724 merges): %q, expected %q",
-		// 	actualStdout.String(),
-		// 	"/bin/sleep cap_net_bind_service=eip")
-	} else {
-		// Shouldn't happen until fix is merged: https://github.com/moby/moby/pull/41724
-		t.Fatalf("run produced valid output (unexpected until #41724 merges): %q, expected %q",
-			actualStdout.String(),
-			"/bin/sleep cap_net_bind_service=eip")
+		t.Fatalf("run produced invalid output: %q, expected %q", actualStdout.String(), "/bin/sleep cap_net_bind_service=eip")
 	}
 }


### PR DESCRIPTION
Cherry-pick https://github.com/moby/moby/pull/41724

- - -
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixes #41723 

When building images in a user-namespaced container, v3 capabilities are
stored including the root UID of the creator of the user-namespace.

This UID does not make sense outside the build environment however. If
the image is run in a non-user-namespaced runtime, or if a user-namespaced
runtime uses a different UID, the capabilities requested by the effective
bit will not be honoured by `execve(2)` due to this mismatch.

Instead, we convert v3 capabilities to v2, dropping the root UID on the
fly.

**- How I did it**

Patched `ReadSecurityXattrToTarHeader()` to automatically convert v3 capabilities to v2 by switching the version identifier and dropping the root UID data.

**- How to verify it**

[This reproducer](https://github.com/EricMountain/dishonoured-capabilities) can be used.

Compared with the output in issue #41723 this produces:

```
    default: + docker run --rm capabilities-built-with-no-userns:1.0 /bin/bash -c '(/usr/local/bin/sleep-test infinity & ); sleep 1; grep Cap /proc/$(pgrep sleep-test)/status'
    default: CapInh:	00000000a80425fb
    default: CapPrm:	0000000000000400
    default: CapEff:	0000000000000400
    default: CapBnd:	00000000a80425fb
    default: CapAmb:	0000000000000000
    default: + docker run --rm capabilities-built-with-userns:1.0 /bin/bash -c '(/usr/local/bin/sleep-test infinity & ); sleep 1; grep Cap /proc/$(pgrep sleep-test)/status'
    default: CapInh:	00000000a80425fb
    default: CapPrm:	0000000000000400
    default: CapEff:	0000000000000400
    default: CapBnd:	00000000a80425fb
    default: CapAmb:	0000000000000000
```

So we see that in the 2nd case also `execve(2)` honoured the effective bit.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Capabilities in image layers are stored in v2 format even when built inside a non-root user-namespace.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/5504362/100465186-2c07bc00-30cf-11eb-8965-9d25ede51a9c.png)
