### PR TITLE
Dockerfile: update CRIU to v3.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,10 @@ RUN --mount=type=cache,sharing=locked,id=moby-criu-aptlib,target=/var/lib/apt \
             libprotobuf-dev \
             protobuf-c-compiler \
             protobuf-compiler \
-            python-protobuf
+            python3-protobuf
 
 # Install CRIU for checkpoint/restore support
-ARG CRIU_VERSION=3.14
+ARG CRIU_VERSION=3.15
 RUN mkdir -p /usr/src/criu \
     && curl -sSL https://github.com/checkpoint-restore/criu/archive/v${CRIU_VERSION}.tar.gz | tar -C /usr/src/criu/ -xz --strip-components=1 \
     && cd /usr/src/criu \


### PR DESCRIPTION
extracting this from https://github.com/moby/moby/pull/42143


full diff: https://github.com/checkpoint-restore/criu/compare/v3.14...v3.15

Also switching to use the python3 packages where possible; see
https://github.com/checkpoint-restore/criu/commit/3957d9533b4973635e2f53b1e0282dde7707f31b

