### PR TITLE
Update runc binary to v1.0.0-rc94

### DIFF
--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -4,7 +4,7 @@
 # The version of runc should match the version that is used by the containerd
 # version that is used. If you need to update runc, open a pull request in
 # the containerd project first, and update both after that is merged.
-: ${RUNC_COMMIT:=12644e614e25b05da6fd08a38ffa0cfe1903fdec} # v1.0.0-rc93
+: ${RUNC_COMMIT:=2c7861bc5e1b3e756392236553ec14a78a09f8bf} # v1.0.0-rc94
 
 install_runc() {
 	# If using RHEL7 kernels (3.10.0 el7), disable kmem accounting/limiting

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -495,33 +495,6 @@ func (s *DockerSuite) TestRunWithInvalidCpuPeriod(c *testing.T) {
 	assert.Assert(c, strings.Contains(out, expected))
 }
 
-func (s *DockerSuite) TestRunWithKernelMemory(c *testing.T) {
-	testRequires(c, DaemonIsLinux, kernelMemorySupport)
-
-	file := "/sys/fs/cgroup/memory/memory.kmem.limit_in_bytes"
-	cli.DockerCmd(c, "run", "--kernel-memory", "50M", "--name", "test1", "busybox", "cat", file).Assert(c, icmd.Expected{
-		Out: "52428800",
-	})
-
-	cli.InspectCmd(c, "test1", cli.Format(".HostConfig.KernelMemory")).Assert(c, icmd.Expected{
-		Out: "52428800",
-	})
-}
-
-func (s *DockerSuite) TestRunWithInvalidKernelMemory(c *testing.T) {
-	testRequires(c, DaemonIsLinux, kernelMemorySupport)
-
-	out, _, err := dockerCmdWithError("run", "--kernel-memory", "2M", "busybox", "true")
-	assert.ErrorContains(c, err, "")
-	expected := "Minimum kernel memory limit allowed is 4MB"
-	assert.Assert(c, strings.Contains(out, expected))
-
-	out, _, err = dockerCmdWithError("run", "--kernel-memory", "-16m", "--name", "test2", "busybox", "echo", "test")
-	assert.ErrorContains(c, err, "")
-	expected = "invalid size"
-	assert.Assert(c, strings.Contains(out, expected))
-}
-
 func (s *DockerSuite) TestRunWithCPUShares(c *testing.T) {
 	testRequires(c, cpuShare)
 

--- a/integration-cli/requirements_unix_test.go
+++ b/integration-cli/requirements_unix_test.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/sysinfo"
 )
 
@@ -35,21 +34,6 @@ func oomControl() bool {
 
 func pidsLimit() bool {
 	return SysInfo.PidsLimit
-}
-
-func kernelMemorySupport() bool {
-	// TODO remove this once kmem support in RHEL kernels is fixed. See https://github.com/opencontainers/runc/pull/1921
-	daemonV, err := kernel.ParseRelease(testEnv.DaemonInfo.KernelVersion)
-	if err != nil {
-		return false
-	}
-	requiredV := kernel.VersionInfo{Kernel: 3, Major: 10}
-	if kernel.CompareKernelVersion(*daemonV, requiredV) < 1 {
-		// On Kernel 3.10 and under, don't consider kernel memory to be supported,
-		// even if the kernel (and thus the daemon) reports it as being supported
-		return false
-	}
-	return testEnv.DaemonInfo.KernelMemory
 }
 
 func memoryLimitSupport() bool {


### PR DESCRIPTION
full diff https://github.com/opencontainers/runc/compare/v1.0.0-rc93...v1.0.0-rc94


release notes (https://github.com/opencontainers/runc/releases/tag/v1.0.0-rc94):

### Potentially breaking changes:

- cgroupv1: kernel memory limits are now always ignored, as kmemcg has
  been effectively deprecated by the kernel. Users should make use of
  regular memory cgroup controls.
- libcontainer/cgroups: cgroup managers' Set now accept
  configs.Resources rather than configs.Cgroups
- libcontainer/cgroups/systemd: reconnect and retry in case dbus
  connection is closed (after dbus restart)
- libcontainer/cgroups/systemd: don't set limits in Apply

### Bugfixes:

- seccomp: fix 32-bit compilation errors (regression in rc93)
- cgroupv2: blkio weight value conversion fix
- runc init: fix a hang caused by deadlock in seccomp/ebpf loading code (regression in rc93)
- runc start: fix "chdir to cwd: permission denied" for some setups (regression in rc93)
- s390: fix broken terminal (regression in rc93)

### Improvements:

- runc start/exec: better diagnostics when container limits are too low
- runc start/exec: better cleanup after failed runc init
- cgroupv1: improve freezing chances
- cgroupv2: multiple GetStats improvements
- cgroupv2: fallback to setting io.weight if io.bfq.weight is not available
- capabilities: WARN, not ERROR, for unknown / unavailable capabilities



