### PR TITLE
Swarm config: use absolute paths for mount destination strings

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -717,6 +717,17 @@ func getSecretTargetPath(r *swarmtypes.SecretReference) string {
 	return filepath.Join(containerSecretMountPath, r.File.Name)
 }
 
+// getConfigTargetPath makes sure that config paths inside the container are
+// absolute, as required by the runtime spec, and enforced by runc >= 1.0.0-rc94.
+// see https://github.com/opencontainers/runc/issues/2928
+func getConfigTargetPath(r *swarmtypes.ConfigReference) string {
+	if filepath.IsAbs(r.File.Name) {
+		return r.File.Name
+	}
+
+	return filepath.Join(containerConfigMountPath, r.File.Name)
+}
+
 // CreateDaemonEnvironment creates a new environment variable slice for this container.
 func (container *Container) CreateDaemonEnvironment(tty bool, linkedEnv []string) []string {
 	// Setup environment

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -27,6 +27,7 @@ const (
 	// for the graceful container stop before forcefully terminating it.
 	DefaultStopTimeout = 10
 
+	containerConfigMountPath = "/"
 	containerSecretMountPath = "/run/secrets"
 )
 
@@ -242,7 +243,7 @@ func (container *Container) SecretMounts() ([]Mount, error) {
 		}
 		mounts = append(mounts, Mount{
 			Source:      fPath,
-			Destination: r.File.Name,
+			Destination: getConfigTargetPath(r),
 			Writable:    false,
 		})
 	}

--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -12,6 +12,7 @@ import (
 )
 
 const (
+	containerConfigMountPath         = `C:\`
 	containerSecretMountPath         = `C:\ProgramData\Docker\secrets`
 	containerInternalSecretMountPath = `C:\ProgramData\Docker\internal\secrets`
 	containerInternalConfigsDirPath  = `C:\ProgramData\Docker\internal\configs`
@@ -87,7 +88,7 @@ func (container *Container) CreateConfigSymlinks() error {
 		if configRef.File == nil {
 			continue
 		}
-		resolvedPath, _, err := container.ResolvePath(configRef.File.Name)
+		resolvedPath, _, err := container.ResolvePath(getConfigTargetPath(configRef))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/42369

taking from https://github.com/moby/moby/pull/42308, with my review suggestions from https://github.com/moby/moby/pull/42308#discussion_r627474648 applied


Needed for runc >= 1.0.0-rc94.

See runc issue https://github.com/opencontainers/runc/issues/2928 (introduced in https://github.com/opencontainers/runc/pull/2917).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

