### PR TITLE
[20.10] update containerd binary to v1.4.5

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=05f951a3781f4f2c1911b05e61c160e9c30eaa8e}" # v1.4.4
+: "${CONTAINERD_COMMIT:=8263eb3eaee447b16856eeb8839d5df4c9cca71a}" # v1.4.5
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
release notes: https://github.com/containerd/containerd/releases/tag/v1.4.5

- Update runc to rc94
- Fix leaking socket path in runc shim v2
- Fix cleanup logic in new container in runc shim v2
- Fix registry mirror authorization logic in CRI plugin
- Add support for userxattr in overlay snapshotter for kernel 5.11+

(Note that the update to runc is done separately)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

