### PR TITLE
Expand the scope of transaction in the process of deleting device

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -1995,14 +1995,7 @@ func (devices *DeviceSet) markForDeferredDeletion(info *devInfo) error {
 }
 
 // Should be called with devices.Lock() held.
-func (devices *DeviceSet) deleteTransaction(info *devInfo, syncDelete bool) error {
-	if err := devices.openTransaction(info.Hash, info.DeviceID); err != nil {
-		logrus.WithField("storage-driver", "devicemapper").Debugf("Error opening transaction hash = %s deviceId = %d", "", info.DeviceID)
-		return err
-	}
-
-	defer devices.closeTransaction()
-
+func (devices *DeviceSet) deleteDeviceNoLock(info *devInfo, syncDelete bool) error {
 	err := devicemapper.DeleteDevice(devices.getPoolDevName(), info.DeviceID)
 	if err != nil {
 		// If syncDelete is true, we want to return error. If deferred
@@ -2066,6 +2059,13 @@ func (devices *DeviceSet) issueDiscard(info *devInfo) error {
 
 // Should be called with devices.Lock() held.
 func (devices *DeviceSet) deleteDevice(info *devInfo, syncDelete bool) error {
+	if err := devices.openTransaction(info.Hash, info.DeviceID); err != nil {
+		logrus.WithField("storage-driver", "devicemapper").Debugf("Error opening transaction hash = %s deviceId = %d", info.Hash, info.DeviceID)
+		return err
+	}
+
+	defer devices.closeTransaction()
+
 	if devices.doBlkDiscard {
 		devices.issueDiscard(info)
 	}
@@ -2085,7 +2085,7 @@ func (devices *DeviceSet) deleteDevice(info *devInfo, syncDelete bool) error {
 		return err
 	}
 
-	return devices.deleteTransaction(info, syncDelete)
+	return devices.deleteDeviceNoLock(info, syncDelete)
 }
 
 // DeleteDevice will return success if device has been marked for deferred


### PR DESCRIPTION
When "docker load $image" and "docker rmi $image" commands are
repeatedly executed in the background, the dockerd daemon process is
killed. As a result, the DM device where the image resides may be
unavailable. The image can be queried, but the container fails to be
run. After function “devices.issueDiscard(info)” is executed and before
function "devices.deleteTransaction(info, syncDelete)" is executed, at
this point, dockerd daemon's withdrawal would result in dm device
discarded. Howerver, the dm device is not deleted at the same time.

Ref:https://github.com/containers/storage/pull/894

Signed-off-by: gaohuatao <gaohuatao@huawei.com>

**- What I did**
```
docker load -i $image
docker rmi $image
```
Execute the commands repeatedly and kill -9 `/var/run/docker.pid`
**- How I did it**

**- How to verify it**
```
docker inspect $image
docker run -tid $image /bin/sh
```
docker inspect success but docker run failed



