### PR TITLE
Prevent data race in version negotiation

### DIFF
--- a/client/container_list.go
+++ b/client/container_list.go
@@ -36,7 +36,7 @@ func (cli *Client) ContainerList(ctx context.Context, options types.ContainerLis
 
 	if options.Filters.Len() > 0 {
 		//nolint:staticcheck // ignore SA1019 for old code
-		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filters)
+		filterJSON, err := filters.ToParamWithVersion(cli.ClientVersion(), options.Filters)
 
 		if err != nil {
 			return nil, err

--- a/client/errors.go
+++ b/client/errors.go
@@ -117,8 +117,8 @@ func IsErrNotImplemented(err error) bool {
 // NewVersionError returns an error if the APIVersion required
 // if less than the current supported version
 func (cli *Client) NewVersionError(APIrequired, feature string) error {
-	if cli.version != "" && versions.LessThan(cli.version, APIrequired) {
-		return fmt.Errorf("%q requires API version %s, but the Docker daemon API version is %s", feature, APIrequired, cli.version)
+	if v := cli.ClientVersion(); v != "" && versions.LessThan(v, APIrequired) {
+		return fmt.Errorf("%q requires API version %s, but the Docker daemon API version is %s", feature, APIrequired, v)
 	}
 	return nil
 }

--- a/client/events.go
+++ b/client/events.go
@@ -25,7 +25,7 @@ func (cli *Client) Events(ctx context.Context, options types.EventsOptions) (<-c
 	go func() {
 		defer close(errs)
 
-		query, err := buildEventsQueryParams(cli.version, options)
+		query, err := buildEventsQueryParams(cli.ClientVersion(), options)
 		if err != nil {
 			close(started)
 			errs <- err

--- a/client/image_list.go
+++ b/client/image_list.go
@@ -17,7 +17,7 @@ func (cli *Client) ImageList(ctx context.Context, options types.ImageListOptions
 
 	optionFilters := options.Filters
 	referenceFilters := optionFilters.Get("reference")
-	if versions.LessThan(cli.version, "1.25") && len(referenceFilters) > 0 {
+	if versions.LessThan(cli.ClientVersion(), "1.25") && len(referenceFilters) > 0 {
 		query.Set("filter", referenceFilters[0])
 		for _, filterValue := range referenceFilters {
 			optionFilters.Del("reference", filterValue)
@@ -25,7 +25,7 @@ func (cli *Client) ImageList(ctx context.Context, options types.ImageListOptions
 	}
 	if optionFilters.Len() > 0 {
 		//nolint:staticcheck // ignore SA1019 for old code
-		filterJSON, err := filters.ToParamWithVersion(cli.version, optionFilters)
+		filterJSON, err := filters.ToParamWithVersion(cli.ClientVersion(), optionFilters)
 		if err != nil {
 			return images, err
 		}

--- a/client/network_list.go
+++ b/client/network_list.go
@@ -14,7 +14,7 @@ func (cli *Client) NetworkList(ctx context.Context, options types.NetworkListOpt
 	query := url.Values{}
 	if options.Filters.Len() > 0 {
 		//nolint:staticcheck // ignore SA1019 for old code
-		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filters)
+		filterJSON, err := filters.ToParamWithVersion(cli.ClientVersion(), options.Filters)
 		if err != nil {
 			return nil, err
 		}

--- a/client/plugin_list.go
+++ b/client/plugin_list.go
@@ -16,7 +16,7 @@ func (cli *Client) PluginList(ctx context.Context, filter filters.Args) (types.P
 
 	if filter.Len() > 0 {
 		//nolint:staticcheck // ignore SA1019 for old code
-		filterJSON, err := filters.ToParamWithVersion(cli.version, filter)
+		filterJSON, err := filters.ToParamWithVersion(cli.ClientVersion(), filter)
 		if err != nil {
 			return plugins, err
 		}

--- a/client/request.go
+++ b/client/request.go
@@ -229,7 +229,7 @@ func (cli *Client) checkResponseErr(serverResp serverResponse) error {
 	}
 
 	var errorMessage string
-	if (cli.version == "" || versions.GreaterThan(cli.version, "1.23")) && ct == "application/json" {
+	if v := cli.ClientVersion(); (v == "" || versions.GreaterThan(v, "1.23")) && ct == "application/json" {
 		var errorResponse types.ErrorResponse
 		if err := json.Unmarshal(body, &errorResponse); err != nil {
 			return errors.Wrap(err, "Error reading JSON")
@@ -246,7 +246,7 @@ func (cli *Client) addHeaders(req *http.Request, headers headers) *http.Request 
 	// Add CLI Config's HTTP Headers BEFORE we set the Docker headers
 	// then the user can't change OUR headers
 	for k, v := range cli.customHTTPHeaders {
-		if versions.LessThan(cli.version, "1.25") && http.CanonicalHeaderKey(k) == "User-Agent" {
+		if versions.LessThan(cli.ClientVersion(), "1.25") && http.CanonicalHeaderKey(k) == "User-Agent" {
 			continue
 		}
 		req.Header.Set(k, v)

--- a/client/service_create.go
+++ b/client/service_create.go
@@ -17,7 +17,7 @@ import (
 func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options types.ServiceCreateOptions) (types.ServiceCreateResponse, error) {
 	var response types.ServiceCreateResponse
 	headers := map[string][]string{
-		"version": {cli.version},
+		"version": {cli.ClientVersion()},
 	}
 
 	if options.EncodedRegistryAuth != "" {

--- a/client/service_update.go
+++ b/client/service_update.go
@@ -19,7 +19,7 @@ func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version 
 	)
 
 	headers := map[string][]string{
-		"version": {cli.version},
+		"version": {cli.ClientVersion()},
 	}
 
 	if options.EncodedRegistryAuth != "" {

--- a/client/volume_list.go
+++ b/client/volume_list.go
@@ -16,7 +16,7 @@ func (cli *Client) VolumeList(ctx context.Context, filter filters.Args) (volume.
 
 	if filter.Len() > 0 {
 		//nolint:staticcheck // ignore SA1019 for old code
-		filterJSON, err := filters.ToParamWithVersion(cli.version, filter)
+		filterJSON, err := filters.ToParamWithVersion(cli.ClientVersion(), filter)
 		if err != nil {
 			return volumes, err
 		}

--- a/client/volume_remove.go
+++ b/client/volume_remove.go
@@ -10,7 +10,7 @@ import (
 // VolumeRemove removes a volume from the docker host.
 func (cli *Client) VolumeRemove(ctx context.Context, volumeID string, force bool) error {
 	query := url.Values{}
-	if versions.GreaterThanOrEqualTo(cli.version, "1.25") {
+	if versions.GreaterThanOrEqualTo(cli.ClientVersion(), "1.25") {
 		if force {
 			query.Set("force", "1")
 		}


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/43729

Concurrent operations on the same client lead to data race during
version negotiation. This commit adds locks to `version` and
`negotiated` fields, and replaces all usages by methods protected by
locks.

<!--

Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed a data race that occurs during concurrent version negotiation.
**- How I did it**
I created two locks and made sure all concurrent usages of `version` and `negotiated` fields are protected.
**- How to verify it**
Create and use a client concurrently with race detector on.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Prevent data race in version negotiation.

**- A picture of a cute animal (not mandatory but encouraged)**
😼
