### PR TITLE
[20.10 backport] builder-next: relax second cache key requirements for schema1

### DIFF
--- a/builder/builder-next/adapters/containerimage/pull.go
+++ b/builder/builder-next/adapters/containerimage/pull.go
@@ -333,12 +333,12 @@ func (p *puller) CacheKey(ctx context.Context, g session.Group, index int) (stri
 		return dgst.String(), nil, false, nil
 	}
 
-	if len(p.config) == 0 {
+	if len(p.config) == 0 && p.desc.MediaType != images.MediaTypeDockerSchema1Manifest {
 		return "", nil, false, errors.Errorf("invalid empty config file resolved for %s", p.src.Reference.String())
 	}
 
 	k := cacheKeyFromConfig(p.config).String()
-	if k == "" {
+	if k == "" || p.desc.MediaType == images.MediaTypeDockerSchema1Manifest {
 		dgst, err := p.mainManifestKey(p.platform)
 		if err != nil {
 			return "", nil, false, err


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/42371
fixes https://github.com/moby/buildkit/issues/2033

Schema1 images can not have a config based cache key
before the layers are pulled. Avoid validation and reuse
manifest digest as a second key.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

