### PR TITLE
hack/validate: skip DCO in "default"

### DIFF
--- a/hack/validate/default
+++ b/hack/validate/default
@@ -4,7 +4,8 @@
 
 export SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-. "${SCRIPTDIR}"/dco
+# Skip DCO check here, as it's already checked in a separate stage in the Jenkinsfile
+#. "${SCRIPTDIR}"/dco
 . "${SCRIPTDIR}"/default-seccomp
 . "${SCRIPTDIR}"/pkg-imports
 . "${SCRIPTDIR}"/swagger


### PR DESCRIPTION
noticed in https://github.com/moby/moby/pull/42373 that we were validating this twice (or 3 times if we count the DCO bot)

We perform a DCO check before we run all other tests, so we can skip it as part of the validate step.

Leaving the line in for visibility, and in case we switch from Jenkins to (e.g.) GitHub actions.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

