### PR TITLE
pkg/fileutils: TestMatches: remove cases no longer valid for go1.16

### DIFF
--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -377,8 +377,6 @@ func TestMatches(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		tests = append(tests, []matchesTestCase{
 			{"a\\*b", "a*b", true},
-			{"a\\", "a", false},
-			{"a\\", "a\\", false},
 		}...)
 	}
 


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/40353
fixes https://github.com/moby/moby/issues/41953

These tests were no longer valid on Go 1.16; related to https://tip.golang.org/doc/go1.16#path/filepath

> The Match and Glob functions now return an error if the unmatched part of
> the pattern has a syntax error. Previously, the functions returned early on
> a failed match, and thus did not report any later syntax error in the pattern.

Causing the test to fail:

    === RUN   TestMatches
        fileutils_test.go:388: assertion failed: error is not nil: syntax error in pattern: pattern="a\\" text="a"
    --- FAIL: TestMatches (0.00s)

