### PR TITLE
Disable go modules when compiling binaries used in tests

### DIFF
--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -874,6 +874,7 @@ Try {
             } else  {
                 $env:DOCKER_HOST=$DASHH_CUT  
                 $env:PATH="$env:TEMP\binary;$env:PATH;"  # Force to use the test binaries, not the host ones.
+                $env:GO111MODULE="off"
                 Write-Host -ForegroundColor Green "INFO: DOCKER_HOST at $DASHH_CUT"
 
                 $ErrorActionPreference = "SilentlyContinue"

--- a/integration/plugin/logging/helpers_test.go
+++ b/integration/plugin/logging/helpers_test.go
@@ -31,7 +31,7 @@ func ensurePlugin(t *testing.T, name string) string {
 	}
 
 	cmd := exec.Command(goBin, "build", "-o", installPath, "./"+filepath.Join("cmd", name))
-	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0", "GO111MODULE=off")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatal(errors.Wrapf(err, "error building basic plugin bin: %s", string(out)))
 	}

--- a/integration/plugin/volumes/helpers_test.go
+++ b/integration/plugin/volumes/helpers_test.go
@@ -36,7 +36,7 @@ func ensurePlugin(t *testing.T, name string) string {
 	assert.NilError(t, err)
 
 	cmd := exec.Command(goBin, "build", "-o", installPath, "./"+filepath.Join("cmd", name))
-	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0", "GO111MODULE=off")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatal(errors.Wrapf(err, "error building basic plugin bin: %s", string(out)))
 	}

--- a/testutil/fixtures/plugin/plugin.go
+++ b/testutil/fixtures/plugin/plugin.go
@@ -222,7 +222,7 @@ func ensureBasicPluginBin() (string, error) {
 	installPath := filepath.Join(os.Getenv("GOPATH"), "bin", name)
 	sourcePath := filepath.Join("github.com", "docker", "docker", "testutil", "fixtures", "plugin", "basic")
 	cmd := exec.Command(goBin, "build", "-o", installPath, sourcePath)
-	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0", "GO111MODULE=off")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", errors.Wrapf(err, "error building basic plugin bin: %s", string(out))
 	}


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/40353

These caused CI to fail when using Go 1.16, so disabling Go modules to prevent that