### PR TITLE
Add oceanographer Sylvia Earle to namesgenerator.go

### DIFF
--- a/pkg/namesgenerator/names-generator.go
+++ b/pkg/namesgenerator/names-generator.go
@@ -304,6 +304,9 @@ var (
 
 		// Donna Dubinsky - played an integral role in the development of personal digital assistants (PDAs) serving as CEO of Palm, Inc. and co-founding Handspring. https://en.wikipedia.org/wiki/Donna_Dubinsky
 		"dubinsky",
+		
+		// Sylvia Earle - American oceanographer and marine biologist known for her research on marine algae and her books and documentaries designed to raise awareness of the threats that overfishing and pollution pose to the world’s oceans. https://en.wikipedia.org/wiki/Sylvia_Earle
+		"earle",
 
 		// Annie Easley - She was a leading member of the team which developed software for the Centaur rocket stage and one of the first African-Americans in her field. https://en.wikipedia.org/wiki/Annie_Easley
 		"easley",


### PR DESCRIPTION
Sylvia Earle is American oceanographer known for her research on marine algae and her books and documentaries designed to raise awareness of the threats that overfishing and pollution pose to the world’s oceans, and her work founding Mission Blue, an organization aimed to inspire action to explore and protect the ocean. https://en.wikipedia.org/wiki/Sylvia_Earle

Signed-off-by: Jonathan Elias Caicedo <jonathan@jcaicedo.com>

**- A picture of a cute animal (not mandatory but encouraged)**
![Earle and an albatross - courtesy of the U.S. Fish and Wildlife Service](https://user-images.githubusercontent.com/5911308/118842641-64769e80-b897-11eb-8df5-ddfd6ff41761.jpeg)
_Earle and an albatross - courtesy of the U.S. Fish and Wildlife Service_


