### PR TITLE
[20.10] update containerd binary to v1.4.6

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=8263eb3eaee447b16856eeb8839d5df4c9cca71a}" # v1.4.5
+: "${CONTAINERD_COMMIT:=d71fcd7d8303cbf684402823e425e9dd2e99285d}" # v1.4.6
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
full diff: https://github.com/containerd/containerd/compare/v1.4.5...v1.4.6

The sixth patch release for containerd 1.4 is a security release to update
runc for CVE-2021-30465

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

