### PR TITLE
[20.10 backport] pkg/signal.CatchAll: ignore SIGURG on Linux

### DIFF
--- a/pkg/signal/signal.go
+++ b/pkg/signal/signal.go
@@ -12,9 +12,16 @@ import (
 )
 
 // CatchAll catches all signals and relays them to the specified channel.
+// On Linux, SIGURG is not handled, as it's used by the Go runtime to support
+// preemptable system calls.
 func CatchAll(sigc chan os.Signal) {
 	var handledSigs []os.Signal
 	for _, s := range SignalMap {
+		if isRuntimeSig(s) {
+			// Do not handle SIGURG on Linux, as in go1.14+, the go runtime issues
+			// SIGURG as an interrupt to support preemptable system calls on Linux.
+			continue
+		}
 		handledSigs = append(handledSigs, s)
 	}
 	signal.Notify(sigc, handledSigs...)

--- a/pkg/signal/signal_darwin.go
+++ b/pkg/signal/signal_darwin.go
@@ -1,6 +1,7 @@
 package signal // import "github.com/docker/docker/pkg/signal"
 
 import (
+	"os"
 	"syscall"
 )
 
@@ -38,4 +39,8 @@ var SignalMap = map[string]syscall.Signal{
 	"WINCH":  syscall.SIGWINCH,
 	"XCPU":   syscall.SIGXCPU,
 	"XFSZ":   syscall.SIGXFSZ,
+}
+
+func isRuntimeSig(_ os.Signal) bool {
+	return false
 }

--- a/pkg/signal/signal_freebsd.go
+++ b/pkg/signal/signal_freebsd.go
@@ -1,6 +1,7 @@
 package signal // import "github.com/docker/docker/pkg/signal"
 
 import (
+	"os"
 	"syscall"
 )
 
@@ -40,4 +41,8 @@ var SignalMap = map[string]syscall.Signal{
 	"WINCH":  syscall.SIGWINCH,
 	"XCPU":   syscall.SIGXCPU,
 	"XFSZ":   syscall.SIGXFSZ,
+}
+
+func isRuntimeSig(_ os.Signal) bool {
+	return false
 }

--- a/pkg/signal/signal_linux.go
+++ b/pkg/signal/signal_linux.go
@@ -3,6 +3,7 @@
 package signal // import "github.com/docker/docker/pkg/signal"
 
 import (
+	"os"
 	"syscall"
 
 	"golang.org/x/sys/unix"
@@ -80,4 +81,8 @@ var SignalMap = map[string]syscall.Signal{
 	"RTMAX-2":  sigrtmax - 2,
 	"RTMAX-1":  sigrtmax - 1,
 	"RTMAX":    sigrtmax,
+}
+
+func isRuntimeSig(s os.Signal) bool {
+	return s == unix.SIGURG
 }

--- a/pkg/signal/signal_linux_mipsx.go
+++ b/pkg/signal/signal_linux_mipsx.go
@@ -4,6 +4,7 @@
 package signal // import "github.com/docker/docker/pkg/signal"
 
 import (
+	"os"
 	"syscall"
 
 	"golang.org/x/sys/unix"
@@ -81,4 +82,8 @@ var SignalMap = map[string]syscall.Signal{
 	"RTMAX-2":  sigrtmax - 2,
 	"RTMAX-1":  sigrtmax - 1,
 	"RTMAX":    sigrtmax,
+}
+
+func isRuntimeSig(s os.Signal) bool {
+	return s == unix.SIGURG
 }

--- a/pkg/signal/signal_windows.go
+++ b/pkg/signal/signal_windows.go
@@ -1,6 +1,7 @@
 package signal // import "github.com/docker/docker/pkg/signal"
 
 import (
+	"os"
 	"syscall"
 )
 
@@ -23,4 +24,8 @@ const (
 var SignalMap = map[string]syscall.Signal{
 	"KILL": syscall.SIGKILL,
 	"TERM": syscall.SIGTERM,
+}
+
+func isRuntimeSig(_ os.Signal) bool {
+	return false
 }


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/42397
relates to https://github.com/moby/moby/pull/40353 https://github.com/moby/moby/pull/40353#issuecomment-842930524

I copied the approach taken in https://github.com/docker/cli/pull/2929 to be consistent

Do not handle SIGURG on Linux, as in go1.14+, the go runtime issues
SIGURG as an interrupt to support preemptable system calls on Linux.

This issue was caught in TestCatchAll, which could fail when updating to Go 1.14 or above;

    === Failed
    === FAIL: pkg/signal TestCatchAll (0.01s)
        signal_linux_test.go:32: assertion failed: urgent I/O condition (string) != continued (string)
        signal_linux_test.go:32: assertion failed: continued (string) != hangup (string)
        signal_linux_test.go:32: assertion failed: hangup (string) != child exited (string)
        signal_linux_test.go:32: assertion failed: child exited (string) != illegal instruction (string)
        signal_linux_test.go:32: assertion failed: illegal instruction (string) != floating point exception (string)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

