### PR TITLE
Add Samuel Karp as a maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -34,6 +34,7 @@
 			"kolyshkin",
 			"mhbauer",
 			"runcom",
+			"samuelkarp",
 			"stevvooe",
 			"thajeztah",
 			"tianon",
@@ -441,6 +442,11 @@
 	Name = "Antonio Murdaca"
 	Email = "runcom@redhat.com"
 	GitHub = "runcom"
+
+	[people.samuelkarp]
+	Name = "Samuel Karp"
+	Email = "skarp@amazon.com"
+	GitHub = "samuelkarp"
 
 	[people.samwhited]
 	Name = "Sam Whited"


### PR DESCRIPTION
@samuelkarp has been a long-time supporter of the container ecosystem.  He is an active security advisor for the containerd project, has spent a lot of time with the awslogs logging driver, and has been helping with review and triage of pull requests here for a while, and I believe his experience with both Go and containers at large would be a very valuable addition to the maintainer team. :hugs: