### PR TITLE
contrib/check-config.sh: Remove awk dependency

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -163,7 +163,7 @@ printf -- '- '
 if [ "$(stat -f -c %t /sys/fs/cgroup 2> /dev/null)" = '63677270' ]; then
 	wrap_good 'cgroup hierarchy' 'cgroupv2'
 else
-	cgroupSubsystemDir="$(awk '/[, ](cpu|cpuacct|cpuset|devices|freezer|memory)[, ]/ && $3 == "cgroup" { print $2 }' /proc/mounts | head -n1)"
+	cgroupSubsystemDir="$(sed -rne '/^[^ ]+ ([^ ]+) cgroup ([^ ]*,)?(cpu|cpuacct|cpuset|devices|freezer|memory)[, ].*$/ { s//\1/p; q }' /proc/mounts)"
 	cgroupDir="$(dirname "$cgroupSubsystemDir")"
 	if [ -d "$cgroupDir/cpu" ] || [ -d "$cgroupDir/cpuacct" ] || [ -d "$cgroupDir/cpuset" ] || [ -d "$cgroupDir/devices" ] || [ -d "$cgroupDir/freezer" ] || [ -d "$cgroupDir/memory" ]; then
 		echo "$(wrap_good 'cgroup hierarchy' 'properly mounted') [$cgroupDir]"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Remove awk dependency in `contrib/check-config.sh`

**- How I did it**
Use grep and built-in functionality

**- How to verify it**
Run on host without awk

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Remove awk dependency in contrib/check-config.sh

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/47358365/119323587-2aceda80-bc7f-11eb-92cb-951476a9d46a.png)
