### PR TITLE
vendor: github.com/docker/libnetwork 64b7a4574d1426139437d20e81c0b6d391130ec8

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-: "${LIBNETWORK_COMMIT:=b3507428be5b458cb0e2b4086b13531fb0706e46}"
+: "${LIBNETWORK_COMMIT:=64b7a4574d1426139437d20e81c0b6d391130ec8}"
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -47,7 +47,7 @@ github.com/grpc-ecosystem/go-grpc-middleware        3c51f7f332123e8be5a157c0802a
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        b3507428be5b458cb0e2b4086b13531fb0706e46
+github.com/docker/libnetwork                        64b7a4574d1426139437d20e81c0b6d391130ec8
 github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor.conf
+++ b/vendor.conf
@@ -70,7 +70,7 @@ github.com/coreos/etcd                              2c834459e1aab78a5d5219c7dfe4
 github.com/coreos/go-semver                         8ab6407b697782a06568d4b7f1db25550ec2e4c6 # v0.2.0
 github.com/hashicorp/consul                         9a9cc9341bb487651a0399e3fc5e1e8a42e62dd9 # v0.5.2
 github.com/miekg/dns                                6c0c4e6581f8e173cc562c8b3363ab984e4ae071 # v1.1.27
-github.com/ishidawataru/sctp                        6e2cb1366111dcf547c13531e3a263a067715847
+github.com/ishidawataru/sctp                        f2269e66cdee387bd321445d5d300893449805be
 go.etcd.io/bbolt                                    232d8fc87f50244f9c808f4745759e08a304c029 # v1.3.5
 github.com/json-iterator/go                         a1ca0830781e007c66b225121d2cdb3a649421f6 # v1.1.10
 github.com/modern-go/concurrent                     bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94 # 1.0.3

--- a/vendor/github.com/docker/libnetwork/drivers/bridge/port_mapping.go
+++ b/vendor/github.com/docker/libnetwork/drivers/bridge/port_mapping.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sync"
 
 	"github.com/docker/libnetwork/types"
 	"github.com/ishidawataru/sctp"
@@ -48,6 +49,13 @@ func (n *bridgeNetwork) allocatePortsInternal(bindings []types.PortBinding, cont
 				return nil, err
 			}
 			bs = append(bs, bIPv4)
+		}
+
+		// skip adding implicit v6 addr, when the kernel was booted with `ipv6.disable=1`
+		// https://github.com/moby/moby/issues/42288
+		isV6Binding := c.HostIP != nil && c.HostIP.To4() == nil
+		if !isV6Binding && !IsV6Listenable() {
+			continue
 		}
 
 		// Allocate IPv6 Port mappings
@@ -210,4 +218,27 @@ func (n *bridgeNetwork) releasePort(bnd types.PortBinding) error {
 	}
 
 	return portmapper.Unmap(host)
+}
+
+var (
+	v6ListenableCached bool
+	v6ListenableOnce   sync.Once
+)
+
+// IsV6Listenable returns true when `[::1]:0` is listenable.
+// IsV6Listenable returns false mostly when the kernel was booted with `ipv6.disable=1` option.
+func IsV6Listenable() bool {
+	v6ListenableOnce.Do(func() {
+		ln, err := net.Listen("tcp6", "[::1]:0")
+		if err != nil {
+			// When the kernel was booted with `ipv6.disable=1`,
+			// we get err "listen tcp6 [::1]:0: socket: address family not supported by protocol"
+			// https://github.com/moby/moby/issues/42288
+			logrus.Debugf("port_mapping: v6Listenable=false (%v)", err)
+		} else {
+			v6ListenableCached = true
+			ln.Close()
+		}
+	})
+	return v6ListenableCached
 }

--- a/vendor/github.com/docker/libnetwork/network.go
+++ b/vendor/github.com/docker/libnetwork/network.go
@@ -1409,21 +1409,21 @@ func (n *network) addSvcRecords(eID, name, serviceID string, epIP, epIPv6 net.IP
 	if n.ingress {
 		return
 	}
-
-	logrus.Debugf("%s (%.7s).addSvcRecords(%s, %s, %s, %t) %s sid:%s", eID, n.ID(), name, epIP, epIPv6, ipMapUpdate, method, serviceID)
+	networkID := n.ID()
+	logrus.Debugf("%s (%.7s).addSvcRecords(%s, %s, %s, %t) %s sid:%s", eID, networkID, name, epIP, epIPv6, ipMapUpdate, method, serviceID)
 
 	c := n.getController()
 	c.Lock()
 	defer c.Unlock()
 
-	sr, ok := c.svcRecords[n.ID()]
+	sr, ok := c.svcRecords[networkID]
 	if !ok {
 		sr = svcInfo{
 			svcMap:     setmatrix.NewSetMatrix(),
 			svcIPv6Map: setmatrix.NewSetMatrix(),
 			ipMap:      setmatrix.NewSetMatrix(),
 		}
-		c.svcRecords[n.ID()] = sr
+		c.svcRecords[networkID] = sr
 	}
 
 	if ipMapUpdate {
@@ -1445,14 +1445,14 @@ func (n *network) deleteSvcRecords(eID, name, serviceID string, epIP net.IP, epI
 	if n.ingress {
 		return
 	}
-
-	logrus.Debugf("%s (%.7s).deleteSvcRecords(%s, %s, %s, %t) %s sid:%s ", eID, n.ID(), name, epIP, epIPv6, ipMapUpdate, method, serviceID)
+	networkID := n.ID()
+	logrus.Debugf("%s (%.7s).deleteSvcRecords(%s, %s, %s, %t) %s sid:%s ", eID, networkID, name, epIP, epIPv6, ipMapUpdate, method, serviceID)
 
 	c := n.getController()
 	c.Lock()
 	defer c.Unlock()
 
-	sr, ok := c.svcRecords[n.ID()]
+	sr, ok := c.svcRecords[networkID]
 	if !ok {
 		return
 	}
@@ -1972,9 +1972,10 @@ func (n *network) ResolveName(req string, ipType int) ([]net.IP, bool) {
 	var ipv6Miss bool
 
 	c := n.getController()
+	networkID := n.ID()
 	c.Lock()
 	defer c.Unlock()
-	sr, ok := c.svcRecords[n.ID()]
+	sr, ok := c.svcRecords[networkID]
 
 	if !ok {
 		return nil, false
@@ -2012,10 +2013,11 @@ func (n *network) ResolveName(req string, ipType int) ([]net.IP, bool) {
 }
 
 func (n *network) HandleQueryResp(name string, ip net.IP) {
+	networkID := n.ID()
 	c := n.getController()
 	c.Lock()
 	defer c.Unlock()
-	sr, ok := c.svcRecords[n.ID()]
+	sr, ok := c.svcRecords[networkID]
 
 	if !ok {
 		return
@@ -2031,10 +2033,11 @@ func (n *network) HandleQueryResp(name string, ip net.IP) {
 }
 
 func (n *network) ResolveIP(ip string) string {
+	networkID := n.ID()
 	c := n.getController()
 	c.Lock()
 	defer c.Unlock()
-	sr, ok := c.svcRecords[n.ID()]
+	sr, ok := c.svcRecords[networkID]
 
 	if !ok {
 		return ""
@@ -2085,9 +2088,10 @@ func (n *network) ResolveService(name string) ([]*net.SRV, []net.IP) {
 	proto := parts[1]
 	svcName := strings.Join(parts[2:], ".")
 
+	networkID := n.ID()
 	c.Lock()
 	defer c.Unlock()
-	sr, ok := c.svcRecords[n.ID()]
+	sr, ok := c.svcRecords[networkID]
 
 	if !ok {
 		return nil, nil

--- a/vendor/github.com/docker/libnetwork/vendor.conf
+++ b/vendor/github.com/docker/libnetwork/vendor.conf
@@ -43,7 +43,7 @@ golang.org/x/net                                    ab34263943818b32f575efc978a3
 golang.org/x/sys                                    ed371f2e16b4b305ee99df548828de367527b76b
 golang.org/x/sync                                   cd5d95a43a6e21273425c7ae415d3df9ea832eeb
 github.com/pkg/errors                               614d223910a179a466c1767a985424175c39b465 # v0.9.1
-github.com/ishidawataru/sctp                        6e2cb1366111dcf547c13531e3a263a067715847
+github.com/ishidawataru/sctp                        f2269e66cdee387bd321445d5d300893449805be
 go.opencensus.io                                    9c377598961b706d1542bd2d84d538b5094d596e # v0.22.0
 
 gotest.tools/v3                                     bb0d8a963040ea5048dcef1a14d8f8b58a33d4b3 # v3.0.2

--- a/vendor/github.com/ishidawataru/sctp/NOTICE
+++ b/vendor/github.com/ishidawataru/sctp/NOTICE
@@ -1,0 +1,3 @@
+This source code includes following third party code
+
+- ipsock_linux.go : licensed by the Go authors, see GO_LICENSE file for the license which applies to the code

--- a/vendor/github.com/ishidawataru/sctp/go.mod
+++ b/vendor/github.com/ishidawataru/sctp/go.mod
@@ -1,0 +1,3 @@
+module github.com/ishidawataru/sctp
+
+go 1.12

--- a/vendor/github.com/ishidawataru/sctp/ipsock_linux.go
+++ b/vendor/github.com/ishidawataru/sctp/ipsock_linux.go
@@ -1,3 +1,7 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the GO_LICENSE file.
+
 package sctp
 
 import (

--- a/vendor/github.com/ishidawataru/sctp/sctp.go
+++ b/vendor/github.com/ishidawataru/sctp/sctp.go
@@ -1,3 +1,18 @@
+// Copyright 2019 Wataru Ishida. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package sctp
 
 import (
@@ -677,4 +692,38 @@ func (c *SCTPSndRcvInfoWrappedConn) SetReadDeadline(t time.Time) error {
 
 func (c *SCTPSndRcvInfoWrappedConn) SetWriteDeadline(t time.Time) error {
 	return c.conn.SetWriteDeadline(t)
+}
+
+func (c *SCTPSndRcvInfoWrappedConn) SetWriteBuffer(bytes int) error {
+	return c.conn.SetWriteBuffer(bytes)
+}
+
+func (c *SCTPSndRcvInfoWrappedConn) GetWriteBuffer() (int, error) {
+	return c.conn.GetWriteBuffer()
+}
+
+func (c *SCTPSndRcvInfoWrappedConn) SetReadBuffer(bytes int) error {
+	return c.conn.SetReadBuffer(bytes)
+}
+
+func (c *SCTPSndRcvInfoWrappedConn) GetReadBuffer() (int, error) {
+	return c.conn.GetReadBuffer()
+}
+
+// SocketConfig contains options for the SCTP socket.
+type SocketConfig struct {
+	// If Control is not nil it is called after the socket is created but before
+	// it is bound or connected.
+	Control func(network, address string, c syscall.RawConn) error
+
+	// InitMsg is the options to send in the initial SCTP message
+	InitMsg InitMsg
+}
+
+func (cfg *SocketConfig) Listen(net string, laddr *SCTPAddr) (*SCTPListener, error) {
+	return listenSCTPExtConfig(net, laddr, cfg.InitMsg, cfg.Control)
+}
+
+func (cfg *SocketConfig) Dial(net string, laddr, raddr *SCTPAddr) (*SCTPConn, error) {
+	return dialSCTPExtConfig(net, laddr, raddr, cfg.InitMsg, cfg.Control)
 }

--- a/vendor/github.com/ishidawataru/sctp/sctp_unsupported.go
+++ b/vendor/github.com/ishidawataru/sctp/sctp_unsupported.go
@@ -1,4 +1,18 @@
 // +build !linux linux,386
+// Copyright 2019 Wataru Ishida. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package sctp
 
@@ -6,6 +20,7 @@ import (
 	"errors"
 	"net"
 	"runtime"
+	"syscall"
 )
 
 var ErrUnsupported = errors.New("SCTP is unsupported on " + runtime.GOOS + "/" + runtime.GOARCH)
@@ -30,11 +45,31 @@ func (c *SCTPConn) Close() error {
 	return ErrUnsupported
 }
 
+func (c *SCTPConn) SetWriteBuffer(bytes int) error {
+	return ErrUnsupported
+}
+
+func (c *SCTPConn) GetWriteBuffer() (int, error) {
+	return 0, ErrUnsupported
+}
+
+func (c *SCTPConn) SetReadBuffer(bytes int) error {
+	return ErrUnsupported
+}
+
+func (c *SCTPConn) GetReadBuffer() (int, error) {
+	return 0, ErrUnsupported
+}
+
 func ListenSCTP(net string, laddr *SCTPAddr) (*SCTPListener, error) {
 	return nil, ErrUnsupported
 }
 
 func ListenSCTPExt(net string, laddr *SCTPAddr, options InitMsg) (*SCTPListener, error) {
+	return nil, ErrUnsupported
+}
+
+func listenSCTPExtConfig(network string, laddr *SCTPAddr, options InitMsg, control func(network, address string, c syscall.RawConn) error) (*SCTPListener, error) {
 	return nil, ErrUnsupported
 }
 
@@ -55,5 +90,9 @@ func DialSCTP(net string, laddr, raddr *SCTPAddr) (*SCTPConn, error) {
 }
 
 func DialSCTPExt(network string, laddr, raddr *SCTPAddr, options InitMsg) (*SCTPConn, error) {
+	return nil, ErrUnsupported
+}
+
+func dialSCTPExtConfig(network string, laddr, raddr *SCTPAddr, options InitMsg, control func(network, address string, c syscall.RawConn) error) (*SCTPConn, error) {
 	return nil, ErrUnsupported
 }


### PR DESCRIPTION
supersedes https://github.com/moby/moby/pull/42322
closes https://github.com/moby/moby/pull/42322

Update libnetwork to make `docker run -p 80:80` functional again on environments
with kernel boot parameter `ipv6.disable=1`.

full diff: https://github.com/docker/libnetwork/compare/b3507428be5b458cb0e2b4086b13531fb0706e46...64b7a4574d1426139437d20e81c0b6d391130ec8

- fix port forwarding with ipv6.disable=1
    - fixes https://github.com/moby/moby/issues/42288 Docker 20.10.6: all containers stopped and cannot start if ipv6 is disabled on host
    - fixes https://github.com/moby/libnetwork/issues/2629 Network issue with IPv6 following update to version 20.10.6
    - fixes https://github.com/docker/for-linux/issues/1233 Since 20.10.6 it's not possible to run docker on a machine with disabled IPv6 interfaces
    - relates to https://github.com/nginx-proxy/nginx-proxy/issues/1589 [BUG] Latest image - ENABLE_IPV6 not being honored?
    - relates to https://github.com/elabftw/elabftw/issues/2601 errors when restarting elabftw
    - relates to https://forums.docker.com/t/ipv6-disabled-on-my-computer-but-docker-network-seems-looking-for-it/107299
    - relates to https://github.com/jc21/nginx-proxy-manager/issues/1026 Docker 20.10.6 breaks IPV6
    - relates to https://github.com/aws/amazon-ecs-agent/issues/2870 Docker 20.10.6 IPv6 bindings shouldn't be mapped as network bindings for tasks for non IPv6 networks
- vendor: github.com/ishidawataru/sctp f2269e66cdee387bd321445d5d300893449805be
- Enforce order of lock acquisitions on network/controller, fixes #2632
    - fixes https://github.com/moby/libnetwork/issues/2632 Name resolution stuck due to deadlock between different network struct methods
    - fixes https://github.com/moby/moby/issues/42032 Docker deamon get's stuck, can't serve DNS requests

vendor: github.com/ishidawataru/sctp f2269e66cdee387bd321445d5d300893449805be

full diff: https://github.com/ishidawataru/sctp/compare/6e2cb1366111dcf547c13531e3a263a067715847...f2269e66cdee387bd321445d5d300893449805be

- support SO_SNDBUF/SO_RCVBUF handling
- Support Go Modules
- license clarificaton
- ci: drop 1.6, 1.7, 1.8 support
- Add support for SocketConfig
- support goarch mips64le architecture.
- fix possible socket leak when bind fails


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

