### PR TITLE
Makefile.standalone: add makefile for standalone builds (w/o docker)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ go-test-report.json
 junit-report.xml
 profile.out
 test.main
+/go.mod
+/dockerd
+/docker-proxy

--- a/Makefile.standalone
+++ b/Makefile.standalone
@@ -1,0 +1,44 @@
+
+## path configuration (FHS-style)
+PREFIX  ?= /usr
+SBINDIR ?= $(PREFIX)/sbin
+
+## toolchain commands
+export GO ?= go
+export LDFLAGS=-s -w
+
+PROGS=$(CURDIR)/dockerd $(CURDIR)/docker-proxy
+
+all: compile
+
+compile: $(PROGS)
+
+## generate go.mod from vendor tree
+$(CURDIR)/go.mod: vendor/modules.txt
+	@( \
+		echo "module github.com/docker/docker" ; \
+		echo "" ; \
+		echo "go 1.19" ; \
+		echo "" ; \
+		echo "require (" ; \
+		cat $< | grep -E '^# ' | grep -Ev '^## ' | sed -e 's~^# ~\t~;' ; \
+		echo ")" ; \
+	) > $@
+
+$(CURDIR)/dockerd: $(CURDIR)/go.mod
+	$(GO) build -tags "$(GO_BUILD_TAGS)" -ldflags "$(LDFLAGS)" -mod=vendor -o $@ $(CURDIR)/cmd/dockerd
+
+$(CURDIR)/docker-proxy: $(CURDIR)/go.mod
+	$(GO) build -tags "$(GO_BUILD_TAGS)" -ldflags "$(LDFLAGS)" -mod=vendor -o $@ $(CURDIR)/cmd/docker-proxy
+
+clean:
+	rm -Rf $(CURDIR)/go.mod $(PROGS)
+
+install: compile
+	install -D -m755 $(CURDIR)/contrib/init/sysvinit-debian/docker $(DESTDIR)/etc/init.d/docker
+	install -D -m755 $(CURDIR)/dockerd                             $(DESTDIR)/$(SBINDIR)/dockerd
+	install -D -m755 $(CURDIR)/docker-proxy                        $(DESTDIR)/$(SBINDIR)/docker-proxy
+	install -d $(DESTDIR)/etc/docker
+	install -d $(DESTDIR)/var/lib/docker
+
+.PHONY: all


### PR DESCRIPTION
Allow building the moby engine without a running docker installation,
using locally installed go toolchain.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

