### PR TITLE
[20.10 backport] pkg/signal: ignore SIGURG on all platforms

### DIFF
--- a/pkg/signal/signal.go
+++ b/pkg/signal/signal.go
@@ -12,13 +12,13 @@ import (
 )
 
 // CatchAll catches all signals and relays them to the specified channel.
-// On Linux, SIGURG is not handled, as it's used by the Go runtime to support
+// SIGURG is not handled, as it's used by the Go runtime to support
 // preemptable system calls.
 func CatchAll(sigc chan os.Signal) {
 	var handledSigs []os.Signal
-	for _, s := range SignalMap {
-		if isRuntimeSig(s) {
-			// Do not handle SIGURG on Linux, as in go1.14+, the go runtime issues
+	for n, s := range SignalMap {
+		if n == "URG" {
+			// Do not handle SIGURG, as in go1.14+, the go runtime issues
 			// SIGURG as an interrupt to support preemptable system calls on Linux.
 			continue
 		}

--- a/pkg/signal/signal_darwin.go
+++ b/pkg/signal/signal_darwin.go
@@ -1,7 +1,6 @@
 package signal // import "github.com/docker/docker/pkg/signal"
 
 import (
-	"os"
 	"syscall"
 )
 
@@ -39,8 +38,4 @@ var SignalMap = map[string]syscall.Signal{
 	"WINCH":  syscall.SIGWINCH,
 	"XCPU":   syscall.SIGXCPU,
 	"XFSZ":   syscall.SIGXFSZ,
-}
-
-func isRuntimeSig(_ os.Signal) bool {
-	return false
 }

--- a/pkg/signal/signal_freebsd.go
+++ b/pkg/signal/signal_freebsd.go
@@ -1,7 +1,6 @@
 package signal // import "github.com/docker/docker/pkg/signal"
 
 import (
-	"os"
 	"syscall"
 )
 
@@ -41,8 +40,4 @@ var SignalMap = map[string]syscall.Signal{
 	"WINCH":  syscall.SIGWINCH,
 	"XCPU":   syscall.SIGXCPU,
 	"XFSZ":   syscall.SIGXFSZ,
-}
-
-func isRuntimeSig(_ os.Signal) bool {
-	return false
 }

--- a/pkg/signal/signal_linux.go
+++ b/pkg/signal/signal_linux.go
@@ -3,7 +3,6 @@
 package signal // import "github.com/docker/docker/pkg/signal"
 
 import (
-	"os"
 	"syscall"
 
 	"golang.org/x/sys/unix"
@@ -81,8 +80,4 @@ var SignalMap = map[string]syscall.Signal{
 	"RTMAX-2":  sigrtmax - 2,
 	"RTMAX-1":  sigrtmax - 1,
 	"RTMAX":    sigrtmax,
-}
-
-func isRuntimeSig(s os.Signal) bool {
-	return s == unix.SIGURG
 }

--- a/pkg/signal/signal_linux_mipsx.go
+++ b/pkg/signal/signal_linux_mipsx.go
@@ -4,7 +4,6 @@
 package signal // import "github.com/docker/docker/pkg/signal"
 
 import (
-	"os"
 	"syscall"
 
 	"golang.org/x/sys/unix"
@@ -82,8 +81,4 @@ var SignalMap = map[string]syscall.Signal{
 	"RTMAX-2":  sigrtmax - 2,
 	"RTMAX-1":  sigrtmax - 1,
 	"RTMAX":    sigrtmax,
-}
-
-func isRuntimeSig(s os.Signal) bool {
-	return s == unix.SIGURG
 }

--- a/pkg/signal/signal_windows.go
+++ b/pkg/signal/signal_windows.go
@@ -1,7 +1,6 @@
 package signal // import "github.com/docker/docker/pkg/signal"
 
 import (
-	"os"
 	"syscall"
 )
 
@@ -24,8 +23,4 @@ const (
 var SignalMap = map[string]syscall.Signal{
 	"KILL": syscall.SIGKILL,
 	"TERM": syscall.SIGTERM,
-}
-
-func isRuntimeSig(_ os.Signal) bool {
-	return false
 }


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/42415

follow-up to https://github.com/moby/moby/pull/42397
relates to https://github.com/docker/cli/pull/3103


Other Unix platforms (e.g. Darwin) are also affected by the Go
runtime sending SIGURG.

This patch changes how we match the signal by just looking for the
"URG" name, which should handle any platform that has this signal
defined in the SignalMap.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

