### PR TITLE
vendor: github.com/moby/buildkit v0.8.3-3-g244e8cde

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -33,7 +33,7 @@ github.com/imdario/mergo                            1afb36080aec31e0d1528973ebe6
 golang.org/x/sync                                   6e8e738ad208923de99951fe0b48239bfd864f28
 
 # buildkit
-github.com/moby/buildkit                            81c2cbd8a418918d62b71e347a00034189eea455 # v0.8.3
+github.com/moby/buildkit                            244e8cde639f71a05a1a2e0670bd88e0206ce55c # v0.8.3-3-g244e8cde
 github.com/tonistiigi/fsutil                        0834f99b7b85462efb69b4f571a4fa3ca7da5ac9
 github.com/tonistiigi/units                         6950e57a87eaf136bbe44ef2ec8e75b9e3569de2
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746

--- a/vendor.conf
+++ b/vendor.conf
@@ -33,7 +33,7 @@ github.com/imdario/mergo                            1afb36080aec31e0d1528973ebe6
 golang.org/x/sync                                   6e8e738ad208923de99951fe0b48239bfd864f28
 
 # buildkit
-github.com/moby/buildkit                            9065b18ba4633c75862befca8188de4338d9f94a # v0.8.2
+github.com/moby/buildkit                            81c2cbd8a418918d62b71e347a00034189eea455 # v0.8.3
 github.com/tonistiigi/fsutil                        0834f99b7b85462efb69b4f571a4fa3ca7da5ac9
 github.com/tonistiigi/units                         6950e57a87eaf136bbe44ef2ec8e75b9e3569de2
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746

--- a/vendor/github.com/moby/buildkit/cache/contenthash/checksum.go
+++ b/vendor/github.com/moby/buildkit/cache/contenthash/checksum.go
@@ -406,17 +406,19 @@ func (cc *cacheContext) ChecksumWildcard(ctx context.Context, mountable cache.Mo
 		return digest.FromBytes([]byte{}), nil
 	}
 
-	if len(wildcards) > 1 {
-		digester := digest.Canonical.Digester()
-		for i, w := range wildcards {
-			if i != 0 {
-				digester.Hash().Write([]byte{0})
-			}
-			digester.Hash().Write([]byte(w.Record.Digest))
-		}
-		return digester.Digest(), nil
+	if len(wildcards) == 1 && path.Base(p) == path.Base(wildcards[0].Path) {
+		return wildcards[0].Record.Digest, nil
 	}
-	return wildcards[0].Record.Digest, nil
+
+	digester := digest.Canonical.Digester()
+	for i, w := range wildcards {
+		if i != 0 {
+			digester.Hash().Write([]byte{0})
+		}
+		digester.Hash().Write([]byte(path.Base(w.Path)))
+		digester.Hash().Write([]byte(w.Record.Digest))
+	}
+	return digester.Digest(), nil
 }
 
 func (cc *cacheContext) Checksum(ctx context.Context, mountable cache.Mountable, p string, followLinks bool, s session.Group) (digest.Digest, error) {

--- a/vendor/github.com/moby/buildkit/go.mod
+++ b/vendor/github.com/moby/buildkit/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Microsoft/hcsshim v0.8.10
 	github.com/codahale/hdrhistogram v0.0.0-20160425231609-f8ad88b59a58 // indirect
 	github.com/containerd/console v1.0.1
+	// containerd: the actual version is replaced in replace()
 	github.com/containerd/containerd v1.4.1-0.20201117152358-0edc412565dc
 	github.com/containerd/continuity v0.0.0-20200710164510-efbc4488d8fe
 	github.com/containerd/go-cni v1.0.1
@@ -71,6 +72,11 @@ require (
 )
 
 replace (
+	// containerd: Forked from 0edc412565dcc6e3d6125ff9e4b009ad4b89c638 (20201117) with:
+	// - `Adjust overlay tests to expect "index=off"`        (#4719, for ease of cherry-picking #5076)
+	// - `overlay: support "userxattr" option (kernel 5.11)` (#5076)
+	// - `docker: avoid concurrent map access panic`         (#4855)
+	github.com/containerd/containerd => github.com/AkihiroSuda/containerd v1.1.1-0.20210312044057-48f85a131bb8
 	// protobuf: corresponds to containerd
 	github.com/golang/protobuf => github.com/golang/protobuf v1.3.5
 	github.com/hashicorp/go-immutable-radix => github.com/tonistiigi/go-immutable-radix v0.0.0-20170803185627-826af9ccf0fe

--- a/vendor/github.com/moby/buildkit/solver/llbsolver/ops/exec.go
+++ b/vendor/github.com/moby/buildkit/solver/llbsolver/ops/exec.go
@@ -240,7 +240,7 @@ func (e *execOp) Exec(ctx context.Context, g session.Group, inputs []solver.Resu
 		}
 	}
 
-	p, err := gateway.PrepareMounts(ctx, e.mm, e.cm, g, e.op.Mounts, refs, func(m *pb.Mount, ref cache.ImmutableRef) (cache.MutableRef, error) {
+	p, err := gateway.PrepareMounts(ctx, e.mm, e.cm, g, e.op.Meta.Cwd, e.op.Mounts, refs, func(m *pb.Mount, ref cache.ImmutableRef) (cache.MutableRef, error) {
 		desc := fmt.Sprintf("mount %s from exec %s", m.Dest, strings.Join(e.op.Meta.Args, " "))
 		return e.cm.New(ctx, ref, g, cache.WithDescription(desc))
 	})

--- a/vendor/github.com/moby/buildkit/solver/llbsolver/ops/exec.go
+++ b/vendor/github.com/moby/buildkit/solver/llbsolver/ops/exec.go
@@ -69,8 +69,8 @@ func cloneExecOp(old *pb.ExecOp) pb.ExecOp {
 	}
 	n.Meta = &meta
 	n.Mounts = nil
-	for i := range n.Mounts {
-		m := *n.Mounts[i]
+	for i := range old.Mounts {
+		m := *old.Mounts[i]
 		n.Mounts = append(n.Mounts, &m)
 	}
 	return n
@@ -95,6 +95,22 @@ func (e *execOp) CacheMap(ctx context.Context, g session.Group, index int) (*sol
 			Architecture: e.platform.Architecture,
 			Variant:      e.platform.Variant,
 		}
+	}
+
+	// Special case for cache compatibility with buggy versions that wrongly
+	// excluded Exec.Mounts: for the default case of one root mount (i.e. RUN
+	// inside a Dockerfile), do not include the mount when generating the cache
+	// map.
+	if len(op.Mounts) == 1 &&
+		op.Mounts[0].Dest == "/" &&
+		op.Mounts[0].Selector == "" &&
+		!op.Mounts[0].Readonly &&
+		op.Mounts[0].MountType == pb.MountType_BIND &&
+		op.Mounts[0].CacheOpt == nil &&
+		op.Mounts[0].SSHOpt == nil &&
+		op.Mounts[0].SecretOpt == nil &&
+		op.Mounts[0].ResultID == "" {
+		op.Mounts = nil
 	}
 
 	dt, err := json.Marshal(struct {

--- a/vendor/github.com/moby/buildkit/util/contentutil/copy.go
+++ b/vendor/github.com/moby/buildkit/util/contentutil/copy.go
@@ -65,7 +65,7 @@ func CopyChain(ctx context.Context, ingester content.Ingester, provider content.
 	handlers := []images.Handler{
 		images.ChildrenHandler(provider),
 		filterHandler,
-		retryhandler.New(remotes.FetchHandler(ingester, &localFetcher{provider}), nil),
+		retryhandler.New(remotes.FetchHandler(ingester, &localFetcher{provider}), func(_ []byte) {}),
 	}
 
 	if err := images.Dispatch(ctx, images.Handlers(handlers...), nil, desc); err != nil {

--- a/vendor/github.com/moby/buildkit/util/imageutil/config.go
+++ b/vendor/github.com/moby/buildkit/util/imageutil/config.go
@@ -101,7 +101,7 @@ func Config(ctx context.Context, str string, resolver remotes.Resolver, cache Co
 	children := childrenConfigHandler(cache, platform)
 
 	handlers := []images.Handler{
-		retryhandler.New(remotes.FetchHandler(cache, fetcher), nil),
+		retryhandler.New(remotes.FetchHandler(cache, fetcher), func(_ []byte) {}),
 		children,
 	}
 	if err := images.Dispatch(ctx, images.Handlers(handlers...), nil, desc); err != nil {

--- a/vendor/github.com/moby/buildkit/util/progress/logs/logs.go
+++ b/vendor/github.com/moby/buildkit/util/progress/logs/logs.go
@@ -132,6 +132,7 @@ func (sw *streamWriter) Close() error {
 func LoggerFromContext(ctx context.Context) func([]byte) {
 	return func(dt []byte) {
 		pw, _, _ := progress.FromContext(ctx)
+		defer pw.Close()
 		pw.Write(identity.NewID(), client.VertexLog{
 			Stream: stderr,
 			Data:   []byte(dt),

--- a/vendor/github.com/moby/buildkit/util/resolver/retryhandler/retry.go
+++ b/vendor/github.com/moby/buildkit/util/resolver/retryhandler/retry.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/images"
+	remoteserrors "github.com/containerd/containerd/remotes/errors"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
@@ -47,6 +48,14 @@ func New(f images.HandlerFunc, logger func([]byte)) images.HandlerFunc {
 }
 
 func retryError(err error) bool {
+	// Retry on 5xx errors
+	var errUnexpectedStatus remoteserrors.ErrUnexpectedStatus
+	if errors.As(err, &errUnexpectedStatus) &&
+		errUnexpectedStatus.StatusCode >= 500 &&
+		errUnexpectedStatus.StatusCode <= 599 {
+		return true
+	}
+
 	if errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) {
 		return true
 	}


### PR DESCRIPTION
### vendor: github.com/moby/buildkit v0.8.3-3-g244e8cde

full diff: https://github.com/moby/buildkit/compare/v0.8.3...v0.8.3-3-g244e8cde

- Transform relative mountpoints for exec mounts in the executor
- Add test for handling relative mountpoints

### vendor: github.com/moby/buildkit v0.8.3

full diff: https://github.com/moby/buildkit/compare/v0.8.2...v0.8.3

- vendor containerd (required for rootless overlayfs on kernel 5.11)
    - not included to avoid depending on a fork
- Add retry on image push 5xx errors
- contenthash: include basename in content checksum for wildcards
- Fix missing mounts in execOp cache map
- Add regression test for run cache not considering mounts
- Add hack to preserve Dockerfile RUN cache compatibility after mount cache bugfix

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

