### PR TITLE
distribution: fix multi-arch Windows image preference

### DIFF
--- a/distribution/pull_v2_unix.go
+++ b/distribution/pull_v2_unix.go
@@ -47,6 +47,11 @@ func checkImageCompatibility(imageOS, imageOSVersion string) error {
 	return nil
 }
 
+// checkImageCompatibility is a Windows-specific function. No-op on Linux
+func getComparableOSVersion() uint32 {
+	return 0
+}
+
 func withDefault(p specs.Platform) specs.Platform {
 	def := platforms.DefaultSpec()
 	if p.OS == "" {


### PR DESCRIPTION
Signed-off-by: fsiegmund <siegmund@slb.com>

**- What I did**

Changes in pull_vs2_windows.go:

- Fix #42423:  prefer UBR match, if exists
- Resolved "TODO: Split version by parts and compare"
- Resolved "TODO: Prefer versions which have a greater version"

**- How I did it**

Change sorting logic of image, using comparable image versions. Images that exactly match host OS version will be moved to the  top, followed by versions that match host build, in descending order.

**- How to verify it**

See  #42423. Create multi arch image and pull. The image with exact host version will be preferred. Otherwise as logic above.

**- Description for the changelog**

- consider UBR in Windows multi-arch image pull

**- A picture of a cute animal (not mandatory but encouraged)**

ฅ ̳͒•ˑ̫• ̳͒ฅ
