### PR TITLE
cmd: dockerd: make systemd notification optional

### DIFF
--- a/cmd/dockerd/notify_nosystemd_unix.go
+++ b/cmd/dockerd/notify_nosystemd_unix.go
@@ -1,3 +1,5 @@
+// +build nosystemd freebsd
+
 package main
 
 // preNotifyReady sends a message to the host when the API is active, but before the daemon is

--- a/cmd/dockerd/notify_systemd_unix.go
+++ b/cmd/dockerd/notify_systemd_unix.go
@@ -1,3 +1,5 @@
+// +build !nosystemd,!freebsd
+
 package main
 
 import systemdDaemon "github.com/coreos/go-systemd/v22/daemon"


### PR DESCRIPTION
systemd service notification is not generic to all linux systems,
only useful on those really running systemd (Lennartix platforms),
but it introduces dependencies that aren't desired on class Linux targets.

For freebsd target we already have dummy functions that we can use on
classic Linux. Restructuring in a way that these are used on freebsd
and on linux when 'nosystemd' tag is set.

Opting out via 'nosystemd' tag, so downstreams dont change suddenly,
w/o setting any additional tags.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

