### PR TITLE
cmd: dockerd: make systemd specific cgroups tweaks build-time optional

### DIFF
--- a/cmd/dockerd/daemon_nosystemd_unix.go
+++ b/cmd/dockerd/daemon_nosystemd_unix.go
@@ -1,0 +1,15 @@
+// +build nosystemd
+
+package main
+
+import (
+	"github.com/docker/docker/daemon/config"
+)
+
+func newCgroupParent(config *config.Config) string {
+	cgroupParent := "docker"
+	if config.CgroupParent != "" {
+		cgroupParent = config.CgroupParent
+	}
+	return cgroupParent
+}

--- a/cmd/dockerd/daemon_systemd_unix.go
+++ b/cmd/dockerd/daemon_systemd_unix.go
@@ -1,0 +1,24 @@
+// +build !nosystemd
+
+package main
+
+import (
+	"github.com/docker/docker/daemon"
+	"github.com/docker/docker/daemon/config"
+	systemdDaemon "github.com/coreos/go-systemd/v22/daemon"
+)
+
+func newCgroupParent(config *config.Config) string {
+	cgroupParent := "docker"
+	useSystemd := daemon.UsingSystemd(config)
+	if useSystemd {
+		cgroupParent = "system.slice"
+	}
+	if config.CgroupParent != "" {
+		cgroupParent = config.CgroupParent
+	}
+	if useSystemd {
+		cgroupParent = cgroupParent + ":" + "docker" + ":"
+	}
+	return cgroupParent
+}

--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/containerd/containerd/runtime/v1/linux"
 	"github.com/docker/docker/daemon"
-	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/libcontainerd/supervisor"
 	"github.com/docker/docker/pkg/homedir"
 	"github.com/docker/libnetwork/portallocator"
@@ -119,21 +118,6 @@ func allocateDaemonPort(addr string) error {
 		}
 	}
 	return nil
-}
-
-func newCgroupParent(config *config.Config) string {
-	cgroupParent := "docker"
-	useSystemd := daemon.UsingSystemd(config)
-	if useSystemd {
-		cgroupParent = "system.slice"
-	}
-	if config.CgroupParent != "" {
-		cgroupParent = config.CgroupParent
-	}
-	if useSystemd {
-		cgroupParent = cgroupParent + ":" + "docker" + ":"
-	}
-	return cgroupParent
 }
 
 func (cli *DaemonCli) initContainerD(ctx context.Context) (func(time.Duration) error, error) {


### PR DESCRIPTION
When running under systemd, we have to do some tweaks for systemd's
non standard cgroups setups. This isn't required if we'll never be running
in such an environment (eg. there're many distros free of such Lennartisms).

Therefore make it possible to opt out at build time by settings the
'nosystemd' tag.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

