### PR TITLE
daemon: logger: make journald support completely optional

### DIFF
--- a/daemon/logdrivers_journald_linux.go
+++ b/daemon/logdrivers_journald_linux.go
@@ -1,0 +1,9 @@
+//go:build linux && !no_systemd
+
+package daemon // import "github.com/docker/docker/daemon"
+
+import (
+	// Importing packages here only to make sure their init gets called and
+	// therefore they register themselves to the logdriver factory.
+	_ "github.com/docker/docker/daemon/logger/journald"
+)

--- a/daemon/logdrivers_linux.go
+++ b/daemon/logdrivers_linux.go
@@ -7,7 +7,6 @@ import (
 	_ "github.com/docker/docker/daemon/logger/fluentd"
 	_ "github.com/docker/docker/daemon/logger/gcplogs"
 	_ "github.com/docker/docker/daemon/logger/gelf"
-	_ "github.com/docker/docker/daemon/logger/journald"
 	_ "github.com/docker/docker/daemon/logger/jsonfilelog"
 	_ "github.com/docker/docker/daemon/logger/local"
 	_ "github.com/docker/docker/daemon/logger/logentries"


### PR DESCRIPTION
The journald logger is already (somewhat) optional, only built if the
'journald' tag set. But not setting this tag still leaves a lot of dummy
code, that just sits there and does nothing.

In order to reduce unneeded code, make sure everything is skipped unless
'journald' tag is set.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

