### PR TITLE
daemon: listeners: make systemd listener optional

### DIFF
--- a/daemon/listeners/listeners_linux.go
+++ b/daemon/listeners/listeners_linux.go
@@ -5,10 +5,8 @@ import (
 	"crypto/tls"
 	"net"
 	"os"
-	"strconv"
 
 	"github.com/containerd/containerd/log"
-	"github.com/coreos/go-systemd/v22/activation"
 	"github.com/docker/docker/pkg/homedir"
 	"github.com/docker/go-connections/sockets"
 	"github.com/pkg/errors"
@@ -57,52 +55,4 @@ func Init(proto, addr, socketGroup string, tlsConfig *tls.Config) ([]net.Listene
 	}
 
 	return ls, nil
-}
-
-// listenFD returns the specified socket activated files as a slice of
-// net.Listeners or all of the activated files if "*" is given.
-func listenFD(addr string, tlsConfig *tls.Config) ([]net.Listener, error) {
-	var (
-		err       error
-		listeners []net.Listener
-	)
-	// socket activation
-	if tlsConfig != nil {
-		listeners, err = activation.TLSListeners(tlsConfig)
-	} else {
-		listeners, err = activation.Listeners()
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	if len(listeners) == 0 {
-		return nil, errors.New("no sockets found via socket activation: make sure the service was started by systemd")
-	}
-
-	// default to all fds just like unix:// and tcp://
-	if addr == "" || addr == "*" {
-		return listeners, nil
-	}
-
-	fdNum, err := strconv.Atoi(addr)
-	if err != nil {
-		return nil, errors.Errorf("failed to parse systemd fd address: should be a number: %v", addr)
-	}
-	fdOffset := fdNum - 3
-	if len(listeners) < fdOffset+1 {
-		return nil, errors.New("too few socket activated files passed in by systemd")
-	}
-	if listeners[fdOffset] == nil {
-		return nil, errors.Errorf("failed to listen on systemd activated file: fd %d", fdOffset+3)
-	}
-	for i, ls := range listeners {
-		if i == fdOffset || ls == nil {
-			continue
-		}
-		if err := ls.Close(); err != nil {
-			return nil, errors.Wrapf(err, "failed to close systemd activated file: fd %d", fdOffset+3)
-		}
-	}
-	return []net.Listener{listeners[fdOffset]}, nil
 }

--- a/daemon/listeners/listenfd_nosystemd.go
+++ b/daemon/listeners/listenfd_nosystemd.go
@@ -1,0 +1,13 @@
+//go:build linux && no_systemd
+
+package listeners // import "github.com/docker/docker/daemon/listeners"
+
+import (
+	"crypto/tls"
+	"errors"
+	"net"
+)
+
+func listenFD(addr string, tlsConfig *tls.Config) ([]net.Listener, error) {
+	return nil, errors.New("listenFD not implemented")
+}

--- a/daemon/listeners/listenfd_systemd.go
+++ b/daemon/listeners/listenfd_systemd.go
@@ -1,0 +1,60 @@
+//go:build linux && !no_systemd
+
+package listeners // import "github.com/docker/docker/daemon/listeners"
+
+import (
+	"crypto/tls"
+	"net"
+	"strconv"
+
+	"github.com/coreos/go-systemd/v22/activation"
+	"github.com/pkg/errors"
+)
+
+// listenFD returns the specified socket activated files as a slice of
+// net.Listeners or all of the activated files if "*" is given.
+func listenFD(addr string, tlsConfig *tls.Config) ([]net.Listener, error) {
+	var (
+		err       error
+		listeners []net.Listener
+	)
+	// socket activation
+	if tlsConfig != nil {
+		listeners, err = activation.TLSListeners(tlsConfig)
+	} else {
+		listeners, err = activation.Listeners()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if len(listeners) == 0 {
+		return nil, errors.New("no sockets found via socket activation: make sure the service was started by systemd")
+	}
+
+	// default to all fds just like unix:// and tcp://
+	if addr == "" || addr == "*" {
+		return listeners, nil
+	}
+
+	fdNum, err := strconv.Atoi(addr)
+	if err != nil {
+		return nil, errors.Errorf("failed to parse systemd fd address: should be a number: %v", addr)
+	}
+	fdOffset := fdNum - 3
+	if len(listeners) < fdOffset+1 {
+		return nil, errors.New("too few socket activated files passed in by systemd")
+	}
+	if listeners[fdOffset] == nil {
+		return nil, errors.Errorf("failed to listen on systemd activated file: fd %d", fdOffset+3)
+	}
+	for i, ls := range listeners {
+		if i == fdOffset || ls == nil {
+			continue
+		}
+		if err := ls.Close(); err != nil {
+			return nil, errors.Wrapf(err, "failed to close systemd activated file: fd %d", fdOffset+3)
+		}
+	}
+	return []net.Listener{listeners[fdOffset]}, nil
+}


### PR DESCRIPTION
On non systemd systems, the systemd-based activation is not needed at all,
thus make it build-time optional. It won't be built in if the 'nosystemd'
tag is set.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

