### PR TITLE
(v2) cmd: dockerd: make systemd specific cgroups tweaks build-time optional

### DIFF
--- a/cmd/dockerd/daemon_nosystemd_unix.go
+++ b/cmd/dockerd/daemon_nosystemd_unix.go
@@ -1,0 +1,15 @@
+//go:build no_systemd
+
+package main
+
+import (
+	"github.com/docker/docker/daemon/config"
+)
+
+func newCgroupParent(config *config.Config) string {
+	if config.CgroupParent == "" {
+		return "docker"
+	} else {
+		return config.CgroupParent
+	}
+}

--- a/cmd/dockerd/daemon_systemd_unix.go
+++ b/cmd/dockerd/daemon_systemd_unix.go
@@ -1,0 +1,23 @@
+//go:build linux && !no_systemd
+
+package main
+
+import (
+	"github.com/docker/docker/daemon"
+	"github.com/docker/docker/daemon/config"
+)
+
+func newCgroupParent(config *config.Config) string {
+	cgroupParent := "docker"
+	useSystemd := daemon.UsingSystemd(config)
+	if useSystemd {
+		cgroupParent = "system.slice"
+	}
+	if config.CgroupParent != "" {
+		cgroupParent = config.CgroupParent
+	}
+	if useSystemd {
+		cgroupParent = cgroupParent + ":" + "docker" + ":"
+	}
+	return cgroupParent
+}

--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -12,8 +12,6 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/log"
-	"github.com/docker/docker/daemon"
-	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/libcontainerd/supervisor"
 	"github.com/docker/docker/libnetwork/portallocator"
 	"github.com/docker/docker/pkg/homedir"
@@ -99,21 +97,6 @@ func allocateDaemonPort(addr string) error {
 		}
 	}
 	return nil
-}
-
-func newCgroupParent(config *config.Config) string {
-	cgroupParent := "docker"
-	useSystemd := daemon.UsingSystemd(config)
-	if useSystemd {
-		cgroupParent = "system.slice"
-	}
-	if config.CgroupParent != "" {
-		cgroupParent = config.CgroupParent
-	}
-	if useSystemd {
-		cgroupParent = cgroupParent + ":" + "docker" + ":"
-	}
-	return cgroupParent
 }
 
 func (cli *DaemonCli) initContainerd(ctx context.Context) (func(time.Duration) error, error) {


### PR DESCRIPTION
When running under systemd, we have to do some tweaks for systemd's
non standard cgroups setups. This isn't required if we'll never be running
in such an environment (eg. there're many distros free of such Lennartisms).

Therefore make it possible to opt out at build time by settings the
'no_systemd' tag.

changes v2: fixed danling import
            renamed 'nosystemd' tag to 'no_systemd'

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

