### PR TITLE
contrib: init: sysvinit-debian: rename $DOCKERD to $DEAMON

### DIFF
--- a/contrib/init/sysvinit-debian/docker
+++ b/contrib/init/sysvinit-debian/docker
@@ -22,7 +22,7 @@ export PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
 BASE=docker
 
 # modify these in /etc/default/$BASE (/etc/default/docker)
-DOCKERD=/usr/bin/dockerd
+DAEMON=/usr/bin/dockerd
 # This is the pid file managed by docker itself
 DOCKER_PIDFILE=/var/run/$BASE.pid
 # This is the pid file created/managed by start-stop-daemon
@@ -39,8 +39,8 @@ if [ -f /etc/default/$BASE ]; then
 fi
 
 # Check docker is present
-if [ ! -x $DOCKERD ]; then
-	log_failure_msg "$DOCKERD not present or not executable"
+if [ ! -x $DAEMON ]; then
+	log_failure_msg "$DAEMON not present or not executable"
 	exit 1
 fi
 
@@ -106,7 +106,7 @@ case "$1" in
 		log_begin_msg "Starting $DOCKER_DESC: $BASE"
 		start-stop-daemon --start --background \
 			--no-close \
-			--exec "$DOCKERD" \
+			--exec "$DAEMON" \
 			--pidfile "$DOCKER_SSD_PIDFILE" \
 			--make-pidfile \
 			-- \
@@ -146,7 +146,7 @@ case "$1" in
 
 	status)
 		check_init
-		status_of_proc -p "$DOCKER_SSD_PIDFILE" "$DOCKERD" "$DOCKER_DESC"
+		status_of_proc -p "$DOCKER_SSD_PIDFILE" "$DAEMON" "$DOCKER_DESC"
 		;;
 
 	*)


### PR DESCRIPTION
Make it a bit more aligned to debian init script standards. The idea behind is
is all init scripts should look more or less the same, with minimal difference.
(eg. for easier reviews, linting, etc) The name of the actual daemon binary is
put into the name DAEMON.

Therefore fix it up to be a little bit aligned better to debian standards.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

