### PR TITLE
Fix: don't create sandbox when bridge is none to avoid docker restart hang.

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -1014,7 +1014,10 @@ func (daemon *Daemon) releaseNetwork(container *container.Container) {
 	if daemon.netController == nil {
 		return
 	}
-	if container.HostConfig.NetworkMode.IsContainer() || container.Config.NetworkDisabled {
+	if container.HostConfig.NetworkMode.IsContainer() {
+		return
+	}
+	if container.NetworkSettings == nil {
 		return
 	}
 


### PR DESCRIPTION

From #42461 
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
If we create container with docker daemon disable bridge, we'll create needless sandbox.
And when the container be removed, the sandbox will be stayed here. Only when dockerd be restarted, those sandbox would be deleted by [sandboxCleanup()](https://github.com/moby/moby/blob/7c6a9484ee37b28fa314f716581bdb268cd78ce2/vendor/github.com/docker/libnetwork/controller.go#L248). 4000 such sandbox will cost nearly 10 minutes. It means restarting docker daemon will hang more then 10 minutes.

``` go
func (daemon *Daemon) allocateNetwork(container *container.Container) (retErr error) {
	var (
		start          = time.Now()
		controller     = daemon.netController
	)

	// container.Config.NetworkDisabled never be assigned.
	if container.Config.NetworkDisabled && container.HostConfig.NetworkMode.IsContainer() {
		return nil
	}
	// ...
        // container.Config.NetworkDisabled will be true here (in connectToNetwork).
	// when we create set NetworkDisabled, we won't delete sandbox after deleting container.
	if nConf, ok := container.NetworkSettings.Networks[defaultNetName]; ok {
		cleanOperationalData(nConf)
		if err := daemon.connectToNetwork(container, defaultNetName, nConf.EndpointSettings, updateSettings); err != nil {
			return err
		}

	}

	networks := make(map[string]*network.EndpointSettings)
	for n, epConf := range container.NetworkSettings.Networks {
		if n == defaultNetName {
			continue
		}

		networks[n] = epConf
	}
	// len of networks is 0, we'll create sandbox here
	if len(networks) == 0 {
	}
}
```
So I think we should assign the `NetworkDisabled` earlier.
**- How I did it**
I fix the bug by setting NetworkDisabled correctly.

**- How to verify it**
1. Update the docker config set `"bridge": "none"`
2. Use `for i in $(seq 1 4000); do docker run --rm ubuntu; done` to create many sandbox.
3. Restart docker and wait.(We can verify it by read network local-kv.db directly.)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Setting NetworkDisabled correctly to avoid restart docker hang.

**- A picture of a cute animal (not mandatory but encouraged)**
🐧🐧🐧