### PR TITLE
rootless: fix "x509: certificate signed by unknown authority" on openSUSE Tumbleweed

### DIFF
--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -118,5 +118,15 @@ else
 		# https://github.com/moby/moby/issues/41230
 		chcon system_u:object_r:iptables_var_run_t:s0 /run
 	fi
+
+	if [ "$(stat -c %T -f /etc)" = "tmpfs" ] && [ -L "/etc/ssl" ]; then
+		# Workaround for "x509: certificate signed by unknown authority" on openSUSE Tumbleweed.
+		# https://github.com/rootless-containers/rootlesskit/issues/225
+		realpath_etc_ssl=$(realpath /etc/ssl)
+		rm -f /etc/ssl
+		mkdir /etc/ssl
+		mount --rbind ${realpath_etc_ssl} /etc/ssl
+	fi
+
 	exec dockerd $@
 fi


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix "x509: certificate signed by unknown authority" error on openSUSE Tumbleweed.

openSUSE Tumbleweed was facing this error, as `/etc/ssl/ca-bundle.pem` is provided as a symlink to `../../var/lib/ca-certificates/ca-bundle.pem`, which was not supported by `rootlesskit --copy-up=/etc` .

See rootless-containers/rootlesskit#225

**- How I did it**

By bind-mounting `/etc/ssl` from the parent namespace into the child.

**- How to verify it**
Run `docker --context=rootless pull hello-world` on an openSUSE Tumbleweed host.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
rootless: fix "x509: certificate signed by unknown authority" on openSUSE Tumbleweed

**- A picture of a cute animal (not mandatory but encouraged)**
:penguin:
