### PR TITLE
[20.10 backport] rootless:  avoid /run/xtables.lock EACCES on SELinux hosts  ; disable overlay2 if running with SELinux ; fix "x509: certificate signed by unknown authority" on openSUSE Tumbleweed 

### DIFF
--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -118,5 +118,15 @@ else
 		# https://github.com/moby/moby/issues/41230
 		chcon system_u:object_r:iptables_var_run_t:s0 /run
 	fi
+
+	if [ "$(stat -c %T -f /etc)" = "tmpfs" ] && [ -L "/etc/ssl" ]; then
+		# Workaround for "x509: certificate signed by unknown authority" on openSUSE Tumbleweed.
+		# https://github.com/rootless-containers/rootlesskit/issues/225
+		realpath_etc_ssl=$(realpath /etc/ssl)
+		rm -f /etc/ssl
+		mkdir /etc/ssl
+		mount --rbind ${realpath_etc_ssl} /etc/ssl
+	fi
+
 	exec dockerd $@
 fi


### PR DESCRIPTION
Backport 
- https://github.com/moby/moby/pull/42199 
- https://github.com/moby/moby/pull/42334
- https://github.com/moby/moby/pull/42457

- - -
### https://github.com/moby/moby/pull/42199 (`dockerd-rootless.sh: avoid /run/xtables.lock EACCES on SELinux hosts`)
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix #41230

**- How I did it**

Previously, running dockerd-rootless.sh on SELinux-enabled hosts was failing with `can't open lock file /run/xtables.lock: Permission denied` error. (issue #41230).

This commit avoids hitting the error by relabeling /run in the RootlessKit child.
The actual /run on the parent is unaffected.
    
https://github.com/containers/podman/blob/e6fc34b71aa9d876b1218efe90e14f8b912b0603/libpod/networking_linux.go#L396-L401

**- How to verify it**
- Install Rootless Docker to Fedora 34, without disabling SELinux
- Make sure the daemon starts up without `can't open lock file /run/xtables.lock: Permission denied` error

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
dockerd-rootless.sh: avoid `can't open lock file /run/xtables.lock: Permission denied` errorSELinux hosts


**- A picture of a cute animal (not mandatory but encouraged)**
:penguin:

- - -
### https://github.com/moby/moby/pull/42334 (`rootless: disable overlay2 if running with SELinux`)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

       
Close #42333 (`rootless+overlay2 (kernel 5.11)+SELinux: mkdir /home/<USER>/.local/share/docker/overlay2/<CID>-init/merged/dev: permission denied. `)


**- How I did it**
Disable overlay2 when `$_DOCKERD_ROOTLESS_SELINUX` is set.

We can't rely on `go-selinux.GetEnabled()` because RootlessKit doesn't mount /sys/fs/selinux in the child: https://github.com/rootless-containers/rootlesskit/issues/94


**- How to verify it**
- Install to Fedora 34
- Make sure `docker info` shows `fuse-overlayfs` as the default storage driver on rootless, while retaining `overlay2` on rootful
- Make sure `docker run hello-world` works on rootless

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

rootless: disable overlay2 if running with SELinux
**- A picture of a cute animal (not mandatory but encouraged)**
:penguin:

---

###  https://github.com/moby/moby/pull/42457 (`rootless: fix "x509: certificate signed by unknown authority" on openSUSE Tumbleweed`)


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix "x509: certificate signed by unknown authority" error on openSUSE Tumbleweed.

openSUSE Tumbleweed was facing this error, as `/etc/ssl/ca-bundle.pem` is provided as a symlink to `../../var/lib/ca-certificates/ca-bundle.pem`, which was not supported by `rootlesskit --copy-up=/etc` .

See rootless-containers/rootlesskit#225

**- How I did it**

By bind-mounting `/etc/ssl` from the parent namespace into the child.

**- How to verify it**
Run `docker --context=rootless pull hello-world` on an openSUSE Tumbleweed host.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
rootless: fix "x509: certificate signed by unknown authority" on openSUSE Tumbleweed

**- A picture of a cute animal (not mandatory but encouraged)**
:penguin:
