### PR TITLE
libnetwork: replace BurntSushi/toml with pelletier/go-toml

### DIFF
--- a/libnetwork/cmd/dnet/dnet.go
+++ b/libnetwork/cmd/dnet/dnet.go
@@ -19,7 +19,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/BurntSushi/toml"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/libnetwork"
 	"github.com/docker/docker/libnetwork/api"
@@ -35,6 +34,7 @@ import (
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/gorilla/mux"
 	"github.com/moby/term"
+	"github.com/pelletier/go-toml"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -70,7 +70,11 @@ func main() {
 func (d *dnetConnection) parseOrchestrationConfig(tomlCfgFile string) error {
 	dummy := &dnetConnection{}
 
-	if _, err := toml.DecodeFile(tomlCfgFile, dummy); err != nil {
+	data, err := ioutil.ReadFile(tomlCfgFile)
+	if err != nil {
+		return err
+	}
+	if err := toml.Unmarshal(data, dummy); err != nil {
 		return err
 	}
 

--- a/libnetwork/config/config.go
+++ b/libnetwork/config/config.go
@@ -2,9 +2,9 @@ package config
 
 import (
 	"fmt"
+	"io/ioutil"
 	"strings"
 
-	"github.com/BurntSushi/toml"
 	"github.com/docker/docker/libnetwork/cluster"
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/ipamutils"
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/docker/libkv/store"
+	"github.com/pelletier/go-toml"
 	"github.com/sirupsen/logrus"
 )
 
@@ -70,8 +71,11 @@ func ParseConfig(tomlCfgFile string) (*Config, error) {
 	cfg := &Config{
 		Scopes: map[string]*datastore.ScopeCfg{},
 	}
-
-	if _, err := toml.DecodeFile(tomlCfgFile, cfg); err != nil {
+	data, err := ioutil.ReadFile(tomlCfgFile)
+	if err != nil {
+		return nil, err
+	}
+	if err := toml.Unmarshal(data, cfg); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
replaces https://github.com/moby/libnetwork/pull/2627
relates to https://github.com/moby/moby/pull/42246

Dependency will go away once https://github.com/moby/moby/pull/42249 is merged



The BurntSushi project is no longer maintained, and the container ecosystem is moving to use the pelletier/go-toml project instead.

This patch moves libnetwork to use the pelletier/go-toml library, to reduce our dependency tree and use the same library in all places.

