### PR TITLE
daemon: improve handling of ROOTLESSKIT_PARENT_EUID

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1712,15 +1712,13 @@ func (daemon *Daemon) setupSeccompProfile() error {
 
 // RawSysInfo returns *sysinfo.SysInfo .
 func (daemon *Daemon) RawSysInfo(quiet bool) *sysinfo.SysInfo {
-	var opts []sysinfo.Opt
+	var siOpts []sysinfo.Opt
 	if daemon.getCgroupDriver() == cgroupSystemdDriver {
-		rootlesskitParentEUID := os.Getenv("ROOTLESSKIT_PARENT_EUID")
-		if rootlesskitParentEUID != "" {
-			groupPath := fmt.Sprintf("/user.slice/user-%s.slice", rootlesskitParentEUID)
-			opts = append(opts, sysinfo.WithCgroup2GroupPath(groupPath))
+		if euid := os.Getenv("ROOTLESSKIT_PARENT_EUID"); euid != "" {
+			siOpts = append(siOpts, sysinfo.WithCgroup2GroupPath("/user.slice/user-"+euid+".slice"))
 		}
 	}
-	return sysinfo.New(quiet, opts...)
+	return sysinfo.New(quiet, siOpts...)
 }
 
 func recursiveUnmount(target string) error {

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -97,7 +97,11 @@ func WithRootless(daemon *Daemon) coci.SpecOpts {
 			if rootlesskitParentEUID == "" {
 				return errors.New("$ROOTLESSKIT_PARENT_EUID is not set (requires RootlessKit v0.8.0)")
 			}
-			controllersPath := fmt.Sprintf("/sys/fs/cgroup/user.slice/user-%s.slice/cgroup.controllers", rootlesskitParentEUID)
+			euid, err := strconv.Atoi(rootlesskitParentEUID)
+			if err != nil {
+				return errors.Wrap(err, "invalid $ROOTLESSKIT_PARENT_EUID: must be a numeric value")
+			}
+			controllersPath := fmt.Sprintf("/sys/fs/cgroup/user.slice/user-%d.slice/cgroup.controllers", euid)
 			controllersFile, err := ioutil.ReadFile(controllersPath)
 			if err != nil {
 				return err


### PR DESCRIPTION
- daemon.WithRootless():  make sure ROOTLESSKIT_PARENT_EUID is valid int
- daemon.RawSysInfo(): minor simplification, and rename variable that
  clashed with imported package.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

