### PR TITLE
[20.10 backport] Fix setting swaplimit=true without checking

### DIFF
--- a/pkg/sysinfo/cgroup2_linux.go
+++ b/pkg/sysinfo/cgroup2_linux.go
@@ -2,11 +2,13 @@ package sysinfo // import "github.com/docker/docker/pkg/sysinfo"
 
 import (
 	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 
 	cgroupsV2 "github.com/containerd/cgroups/v2"
 	"github.com/containerd/containerd/sys"
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/sirupsen/logrus"
 )
 
@@ -66,6 +68,24 @@ func newV2(quiet bool, opts *opts) *SysInfo {
 	return sysInfo
 }
 
+func getSwapLimitV2() bool {
+	groups, err := cgroups.ParseCgroupFile("/proc/self/cgroup")
+	if err != nil {
+		return false
+	}
+
+	g := groups[""]
+	if g == "" {
+		return false
+	}
+
+	cGroupPath := path.Join("/sys/fs/cgroup", g, "memory.swap.max")
+	if _, err = os.Stat(cGroupPath); os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
 func applyMemoryCgroupInfoV2(info *SysInfo, controllers map[string]struct{}, _ string) []string {
 	var warnings []string
 	if _, ok := controllers["memory"]; !ok {
@@ -74,7 +94,7 @@ func applyMemoryCgroupInfoV2(info *SysInfo, controllers map[string]struct{}, _ s
 	}
 
 	info.MemoryLimit = true
-	info.SwapLimit = true
+	info.SwapLimit = getSwapLimitV2()
 	info.MemoryReservation = true
 	info.OomKillDisable = false
 	info.MemorySwappiness = false


### PR DESCRIPTION
Cherry-pick https://github.com/moby/moby/pull/42071


- - -
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
fixes #41926

**- How I did it**
Added one condition to moby/pkg/sysinfo/cgroup2_linux.go 

**- How to verify it**
Actually, I wanted to create unit tests for this one. The problem is certain files must be present on FS, so I see 2 solutions:
1) use mocks (of os.Stat for example)
2) since part of the path is passed as an argument, choose a different dir for tests (eg /tmp?)

I do not know what is the common practice in the project (1st PR), so I decided just to simply open a PR and ask.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixes setting swaplimit=true without checking memory.swap.max

**- A picture of a cute animal (not mandatory but encouraged)**
Another time :)

