### PR TITLE
Fix daemon.json and daemon --seccomp-profile not accepting "unconfined", and rename default profile to "builtin"

### DIFF
--- a/cmd/dockerd/config_unix.go
+++ b/cmd/dockerd/config_unix.go
@@ -58,7 +58,7 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.StringVar(&conf.InitPath, "init-path", "", "Path to the docker-init binary")
 	flags.Int64Var(&conf.CPURealtimePeriod, "cpu-rt-period", 0, "Limit the CPU real-time period in microseconds for the parent cgroup for all containers")
 	flags.Int64Var(&conf.CPURealtimeRuntime, "cpu-rt-runtime", 0, "Limit the CPU real-time runtime in microseconds for the parent cgroup for all containers")
-	flags.StringVar(&conf.SeccompProfile, "seccomp-profile", "", "Path to seccomp profile")
+	flags.StringVar(&conf.SeccompProfile, "seccomp-profile", config.SeccompProfileDefault, `Path to seccomp profile. Use "unconfined" to disable the default seccomp profile`)
 	flags.Var(&conf.ShmSize, "default-shm-size", "Default shm size for containers")
 	flags.BoolVar(&conf.NoNewPrivileges, "no-new-privileges", false, "Set no-new-privileges by default for new containers")
 	flags.StringVar(&conf.IpcMode, "default-ipc-mode", config.DefaultIpcMode, `Default mode for containers ipc ("shareable" | "private")`)

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -60,7 +60,7 @@ const (
 	LinuxV2RuntimeName = "io.containerd.runc.v2"
 
 	// SeccompProfileDefault is the built-in default seccomp profile.
-	SeccompProfileDefault = "default"
+	SeccompProfileDefault = "builtin"
 	// SeccompProfileUnconfined is a special profile name for seccomp to use an
 	// "unconfined" seccomp profile.
 	SeccompProfileUnconfined = "unconfined"

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -58,6 +58,12 @@ const (
 	LinuxV1RuntimeName = "io.containerd.runtime.v1.linux"
 	// LinuxV2RuntimeName is the runtime used to specify the containerd v2 runc shim
 	LinuxV2RuntimeName = "io.containerd.runc.v2"
+
+	// SeccompProfileDefault is the built-in default seccomp profile.
+	SeccompProfileDefault = "default"
+	// SeccompProfileUnconfined is a special profile name for seccomp to use an
+	// "unconfined" seccomp profile.
+	SeccompProfileUnconfined = "unconfined"
 )
 
 var builtinRuntimes = map[string]bool{

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1706,7 +1706,7 @@ func maybeCreateCPURealTimeFile(configValue int64, file string, path string) err
 }
 
 func (daemon *Daemon) setupSeccompProfile() error {
-	if daemon.configStore.SeccompProfile != "" {
+	if daemon.configStore.SeccompProfile != "" && daemon.configStore.SeccompProfile != config.SeccompProfileDefault {
 		daemon.seccompProfilePath = daemon.configStore.SeccompProfile
 		if daemon.configStore.SeccompProfile != config.SeccompProfileUnconfined {
 			b, err := ioutil.ReadFile(daemon.configStore.SeccompProfile)

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1708,11 +1708,13 @@ func maybeCreateCPURealTimeFile(configValue int64, file string, path string) err
 func (daemon *Daemon) setupSeccompProfile() error {
 	if daemon.configStore.SeccompProfile != "" {
 		daemon.seccompProfilePath = daemon.configStore.SeccompProfile
-		b, err := ioutil.ReadFile(daemon.configStore.SeccompProfile)
-		if err != nil {
-			return fmt.Errorf("opening seccomp profile (%s) failed: %v", daemon.configStore.SeccompProfile, err)
+		if daemon.configStore.SeccompProfile != config.SeccompProfileUnconfined {
+			b, err := ioutil.ReadFile(daemon.configStore.SeccompProfile)
+			if err != nil {
+				return fmt.Errorf("opening seccomp profile (%s) failed: %v", daemon.configStore.SeccompProfile, err)
+			}
+			daemon.seccompProfile = b
 		}
-		daemon.seccompProfile = b
 	}
 	return nil
 }

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1706,15 +1706,18 @@ func maybeCreateCPURealTimeFile(configValue int64, file string, path string) err
 }
 
 func (daemon *Daemon) setupSeccompProfile() error {
-	if daemon.configStore.SeccompProfile != "" && daemon.configStore.SeccompProfile != config.SeccompProfileDefault {
-		daemon.seccompProfilePath = daemon.configStore.SeccompProfile
-		if daemon.configStore.SeccompProfile != config.SeccompProfileUnconfined {
-			b, err := ioutil.ReadFile(daemon.configStore.SeccompProfile)
-			if err != nil {
-				return fmt.Errorf("opening seccomp profile (%s) failed: %v", daemon.configStore.SeccompProfile, err)
-			}
-			daemon.seccompProfile = b
+	switch profile := daemon.configStore.SeccompProfile; profile {
+	case "", config.SeccompProfileDefault:
+		daemon.seccompProfilePath = config.SeccompProfileDefault
+	case config.SeccompProfileUnconfined:
+		daemon.seccompProfilePath = config.SeccompProfileUnconfined
+	default:
+		daemon.seccompProfilePath = profile
+		b, err := ioutil.ReadFile(profile)
+		if err != nil {
+			return fmt.Errorf("opening seccomp profile (%s) failed: %v", profile, err)
 		}
+		daemon.seccompProfile = b
 	}
 	return nil
 }

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -176,6 +176,9 @@ func (daemon *Daemon) fillSecurityOptions(v *types.Info, sysInfo *sysinfo.SysInf
 		if profile == "" {
 			profile = config.SeccompProfileDefault
 		}
+		if profile != config.SeccompProfileDefault {
+			v.Warnings = append(v.Warnings, "WARNING: daemon is not using the default seccomp profile")
+		}
 		securityOptions = append(securityOptions, fmt.Sprintf("name=seccomp,profile=%s", profile))
 	}
 	if selinux.GetEnabled() {

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -172,14 +172,10 @@ func (daemon *Daemon) fillSecurityOptions(v *types.Info, sysInfo *sysinfo.SysInf
 		securityOptions = append(securityOptions, "name=apparmor")
 	}
 	if sysInfo.Seccomp && supportsSeccomp {
-		profile := daemon.seccompProfilePath
-		if profile == "" {
-			profile = config.SeccompProfileDefault
-		}
-		if profile != config.SeccompProfileDefault {
+		if daemon.seccompProfilePath != config.SeccompProfileDefault {
 			v.Warnings = append(v.Warnings, "WARNING: daemon is not using the default seccomp profile")
 		}
-		securityOptions = append(securityOptions, fmt.Sprintf("name=seccomp,profile=%s", profile))
+		securityOptions = append(securityOptions, "name=seccomp,profile="+daemon.seccompProfilePath)
 	}
 	if selinux.GetEnabled() {
 		securityOptions = append(securityOptions, "name=selinux")

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -174,7 +174,7 @@ func (daemon *Daemon) fillSecurityOptions(v *types.Info, sysInfo *sysinfo.SysInf
 	if sysInfo.Seccomp && supportsSeccomp {
 		profile := daemon.seccompProfilePath
 		if profile == "" {
-			profile = "default"
+			profile = config.SeccompProfileDefault
 		}
 		securityOptions = append(securityOptions, fmt.Sprintf("name=seccomp,profile=%s", profile))
 	}

--- a/daemon/seccomp_disabled.go
+++ b/daemon/seccomp_disabled.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containerd/containerd/containers"
 	coci "github.com/containerd/containerd/oci"
 	"github.com/docker/docker/container"
+	dconfig "github.com/docker/docker/daemon/config"
 )
 
 const supportsSeccomp = false
@@ -16,7 +17,7 @@ const supportsSeccomp = false
 // WithSeccomp sets the seccomp profile
 func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {
 	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
-		if c.SeccompProfile != "" && c.SeccompProfile != "unconfined" {
+		if c.SeccompProfile != "" && c.SeccompProfile != dconfig.SeccompProfileUnconfined {
 			return fmt.Errorf("seccomp profiles are not supported on this daemon, you cannot specify a custom seccomp profile")
 		}
 		return nil

--- a/daemon/seccomp_linux.go
+++ b/daemon/seccomp_linux.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containerd/containerd/containers"
 	coci "github.com/containerd/containerd/oci"
 	"github.com/docker/docker/container"
+	dconfig "github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/profiles/seccomp"
 	"github.com/sirupsen/logrus"
 )
@@ -18,7 +19,7 @@ const supportsSeccomp = true
 // WithSeccomp sets the seccomp profile
 func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {
 	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
-		if c.SeccompProfile == "unconfined" {
+		if c.SeccompProfile == dconfig.SeccompProfileUnconfined {
 			return nil
 		}
 		if c.HostConfig.Privileged {
@@ -29,7 +30,7 @@ func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {
 				return fmt.Errorf("seccomp is not enabled in your kernel, cannot run a custom seccomp profile")
 			}
 			logrus.Warn("seccomp is not enabled in your kernel, running container without default profile")
-			c.SeccompProfile = "unconfined"
+			c.SeccompProfile = dconfig.SeccompProfileUnconfined
 			return nil
 		}
 		var err error

--- a/daemon/seccomp_linux.go
+++ b/daemon/seccomp_linux.go
@@ -26,7 +26,7 @@ func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {
 			return nil
 		}
 		if !daemon.seccompEnabled {
-			if c.SeccompProfile != "" {
+			if c.SeccompProfile != "" && c.SeccompProfile != dconfig.SeccompProfileDefault {
 				return fmt.Errorf("seccomp is not enabled in your kernel, cannot run a custom seccomp profile")
 			}
 			logrus.Warn("seccomp is not enabled in your kernel, running container without default profile")
@@ -35,6 +35,8 @@ func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		}
 		var err error
 		switch {
+		case c.SeccompProfile == dconfig.SeccompProfileDefault:
+			s.Linux.Seccomp, err = seccomp.GetDefaultProfile(s)
 		case c.SeccompProfile != "":
 			s.Linux.Seccomp, err = seccomp.LoadProfile(c.SeccompProfile, s)
 		case daemon.seccompProfile != nil:

--- a/daemon/seccomp_linux.go
+++ b/daemon/seccomp_linux.go
@@ -39,6 +39,8 @@ func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {
 			s.Linux.Seccomp, err = seccomp.LoadProfile(c.SeccompProfile, s)
 		case daemon.seccompProfile != nil:
 			s.Linux.Seccomp, err = seccomp.LoadProfile(string(daemon.seccompProfile), s)
+		case daemon.seccompProfilePath == dconfig.SeccompProfileUnconfined:
+			c.SeccompProfile = dconfig.SeccompProfileUnconfined
 		default:
 			s.Linux.Seccomp, err = seccomp.GetDefaultProfile(s)
 		}

--- a/daemon/seccomp_linux_test.go
+++ b/daemon/seccomp_linux_test.go
@@ -8,6 +8,7 @@ import (
 	coci "github.com/containerd/containerd/oci"
 	config "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
+	dconfig "github.com/docker/docker/daemon/config"
 	doci "github.com/docker/docker/oci"
 	"github.com/docker/docker/profiles/seccomp"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -32,7 +33,7 @@ func TestWithSeccomp(t *testing.T) {
 				seccompEnabled: true,
 			},
 			c: &container.Container{
-				SeccompProfile: "unconfined",
+				SeccompProfile: dconfig.SeccompProfileUnconfined,
 				HostConfig: &config.HostConfig{
 					Privileged: false,
 				},

--- a/integration-cli/docker_cli_info_unix_test.go
+++ b/integration-cli/docker_cli_info_unix_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/daemon/config"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -27,6 +28,6 @@ func (s *DockerSuite) TestInfoSecurityOptions(c *testing.T) {
 		assert.Check(c, is.Contains(info.SecurityOptions, "name=apparmor"))
 	}
 	if seccompEnabled() {
-		assert.Check(c, is.Contains(info.SecurityOptions, "name=seccomp,profile=default"))
+		assert.Check(c, is.Contains(info.SecurityOptions, "name=seccomp,profile="+config.SeccompProfileDefault))
 	}
 }

--- a/integration/daemon/daemon_test.go
+++ b/integration/daemon/daemon_test.go
@@ -117,6 +117,11 @@ func TestConfigDaemonSeccompProfiles(t *testing.T) {
 			expectedProfile: config.SeccompProfileDefault,
 		},
 		{
+			doc:             "default profile",
+			profile:         config.SeccompProfileDefault,
+			expectedProfile: config.SeccompProfileDefault,
+		},
+		{
 			doc:             "unconfined profile",
 			profile:         config.SeccompProfileUnconfined,
 			expectedProfile: config.SeccompProfileUnconfined,

--- a/integration/daemon/daemon_test.go
+++ b/integration/daemon/daemon_test.go
@@ -8,11 +8,11 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/skip"
-
 	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/skip"
 )
 
 func TestConfigDaemonLibtrustID(t *testing.T) {
@@ -96,6 +96,49 @@ func TestDaemonConfigValidation(t *testing.T) {
 			} else {
 				assert.NilError(t, err)
 			}
+		})
+	}
+}
+
+func TestConfigDaemonSeccompProfiles(t *testing.T) {
+	skip.If(t, runtime.GOOS != "linux")
+
+	d := daemon.New(t)
+	defer d.Stop(t)
+
+	tests := []struct {
+		doc             string
+		profile         string
+		expectedProfile string
+	}{
+		{
+			doc:             "empty profile set",
+			profile:         "",
+			expectedProfile: config.SeccompProfileDefault,
+		},
+		{
+			doc:             "unconfined profile",
+			profile:         config.SeccompProfileUnconfined,
+			expectedProfile: config.SeccompProfileUnconfined,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.doc, func(t *testing.T) {
+			d.Start(t, "--seccomp-profile="+tc.profile)
+			info := d.Info(t)
+			assert.Assert(t, is.Contains(info.SecurityOptions, "name=seccomp,profile="+tc.expectedProfile))
+			d.Stop(t)
+
+			cfg := filepath.Join(d.RootDir(), "daemon.json")
+			err := ioutil.WriteFile(cfg, []byte(`{"seccomp-profile": "`+tc.profile+`"}`), 0644)
+			assert.NilError(t, err)
+
+			d.Start(t, "--config-file", cfg)
+			info = d.Info(t)
+			assert.Assert(t, is.Contains(info.SecurityOptions, "name=seccomp,profile="+tc.expectedProfile))
+			d.Stop(t)
 		})
 	}
 }


### PR DESCRIPTION
waiting for https://github.com/moby/moby/pull/42393, then I can add some tests.
Possibly will be splitting this PR in some chunks as well, in case we want to backport the "unconfined" daemon configuration fix.

- Add const for "unconfined" and "default" seccomp profiles
- Fix daemon.json and daemon --seccomp-profile not accepting "unconfined"
    Commit b237189e6c8a4f97be59f08c63cdcb1f2f4680a8 implemented an option to
    set the default seccomp profile in the daemon configuration. When that PR
    was reviewed, it was discussed to have the option accept the path to a custom
    profile JSON file; https://github.com/moby/moby/pull/26276#issuecomment-253546966

    However, in the implementation, the special "unconfined" value was not taken into
    account. The "unconfined" value is meant to disable seccomp (more factually:
    run with an empty profile).

    While it's likely possible to achieve this by creating a file with an an empty
    (`{}`) profile, and passing the path to that file, it's inconsistent with the
    `--security-opt seccomp=unconfined` option on `docker run` and `docker create`,
    which is both confusing, and makes it harder to use (especially on Docker Desktop,
    where there's no direct access to the VM's filesystem).

    This patch adds the missing check for the special "unconfined" value.
- daemon: allow "builtin" as valid value for seccomp profiles
    This allows containers to use the embedded default profile if a different
    default is set (e.g. "unconfined") in the daemon configuration. Without this
    option, users would have to copy the default profile to a file in order to
    use the default.
- daemon: move custom seccomp profile warning from CLI to daemon side



**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

