### PR TITLE
Use containerd OCI defaults where possible

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -710,6 +710,20 @@ func sysctlExists(s string) bool {
 	return err == nil
 }
 
+// WithDefaultCapabilities sets the default capabilities for the container
+func WithDefaultCapabilities() coci.SpecOpts {
+	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
+		s.Process = &specs.Process{
+			Capabilities: &specs.LinuxCapabilities{
+				Bounding:  caps.DefaultCapabilities(),
+				Permitted: caps.DefaultCapabilities(),
+				Effective: caps.DefaultCapabilities(),
+			},
+		}
+		return nil
+	}
+}
+
 // WithCommonOptions sets common docker options
 func WithCommonOptions(daemon *Daemon, c *container.Container) coci.SpecOpts {
 	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
@@ -1004,6 +1018,8 @@ func (daemon *Daemon) createSpec(c *container.Container) (retSpec *specs.Spec, e
 		s    = oci.DefaultSpec()
 	)
 	opts = append(opts,
+		WithDefaultCapabilities(),
+		coci.WithDefaultUnixDevices,
 		WithCommonOptions(daemon, c),
 		WithCgroups(daemon, c),
 		WithResources(c),

--- a/oci/defaults.go
+++ b/oci/defaults.go
@@ -125,6 +125,7 @@ func DefaultLinuxSpec() specs.Spec {
 						Access: "rwm",
 					},
 					{
+						// "/dev/zero",
 						Allow:  true,
 						Type:   "c",
 						Major:  iPtr(1),
@@ -132,6 +133,7 @@ func DefaultLinuxSpec() specs.Spec {
 						Access: "rwm",
 					},
 					{
+						// "/dev/null",
 						Allow:  true,
 						Type:   "c",
 						Major:  iPtr(1),
@@ -139,6 +141,7 @@ func DefaultLinuxSpec() specs.Spec {
 						Access: "rwm",
 					},
 					{
+						// "/dev/urandom",
 						Allow:  true,
 						Type:   "c",
 						Major:  iPtr(1),
@@ -146,6 +149,7 @@ func DefaultLinuxSpec() specs.Spec {
 						Access: "rwm",
 					},
 					{
+						// "/dev/random",
 						Allow:  true,
 						Type:   "c",
 						Major:  iPtr(1),
@@ -153,6 +157,7 @@ func DefaultLinuxSpec() specs.Spec {
 						Access: "rwm",
 					},
 					{
+						// "/dev/tty",
 						Allow:  true,
 						Type:   "c",
 						Major:  iPtr(5),
@@ -160,6 +165,7 @@ func DefaultLinuxSpec() specs.Spec {
 						Access: "rwm",
 					},
 					{
+						// "/dev/console",
 						Allow:  true,
 						Type:   "c",
 						Major:  iPtr(5),
@@ -167,6 +173,7 @@ func DefaultLinuxSpec() specs.Spec {
 						Access: "rwm",
 					},
 					{
+						// "fuse"
 						Allow:  false,
 						Type:   "c",
 						Major:  iPtr(10),

--- a/oci/defaults.go
+++ b/oci/defaults.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/docker/docker/oci/caps"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -34,14 +33,8 @@ func DefaultWindowsSpec() specs.Spec {
 func DefaultLinuxSpec() specs.Spec {
 	return specs.Spec{
 		Version: specs.Version,
-		Process: &specs.Process{
-			Capabilities: &specs.LinuxCapabilities{
-				Bounding:  caps.DefaultCapabilities(),
-				Permitted: caps.DefaultCapabilities(),
-				Effective: caps.DefaultCapabilities(),
-			},
-		},
-		Root: &specs.Root{},
+		Process: &specs.Process{},
+		Root:    &specs.Root{},
 		Mounts: []specs.Mount{
 			{
 				Destination: "/proc",
@@ -119,68 +112,7 @@ func DefaultLinuxSpec() specs.Spec {
 			// See also: https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#default-devices
 			Devices: []specs.LinuxDevice{},
 			Resources: &specs.LinuxResources{
-				Devices: []specs.LinuxDeviceCgroup{
-					{
-						Allow:  false,
-						Access: "rwm",
-					},
-					{
-						// "/dev/zero",
-						Allow:  true,
-						Type:   "c",
-						Major:  iPtr(1),
-						Minor:  iPtr(5),
-						Access: "rwm",
-					},
-					{
-						// "/dev/null",
-						Allow:  true,
-						Type:   "c",
-						Major:  iPtr(1),
-						Minor:  iPtr(3),
-						Access: "rwm",
-					},
-					{
-						// "/dev/urandom",
-						Allow:  true,
-						Type:   "c",
-						Major:  iPtr(1),
-						Minor:  iPtr(9),
-						Access: "rwm",
-					},
-					{
-						// "/dev/random",
-						Allow:  true,
-						Type:   "c",
-						Major:  iPtr(1),
-						Minor:  iPtr(8),
-						Access: "rwm",
-					},
-					{
-						// "/dev/tty",
-						Allow:  true,
-						Type:   "c",
-						Major:  iPtr(5),
-						Minor:  iPtr(0),
-						Access: "rwm",
-					},
-					{
-						// "/dev/console",
-						Allow:  true,
-						Type:   "c",
-						Major:  iPtr(5),
-						Minor:  iPtr(1),
-						Access: "rwm",
-					},
-					{
-						// "fuse"
-						Allow:  false,
-						Type:   "c",
-						Major:  iPtr(10),
-						Minor:  iPtr(229),
-						Access: "rwm",
-					},
-				},
+				Devices: []specs.LinuxDeviceCgroup{},
 			},
 		},
 	}


### PR DESCRIPTION
There are some differences between docker and containerd:

Had this branch still around, and realised I didn't push it


Docker:

```
"" false rwm // what does this do? default permissions on `/dev`?
"/dev/console" true rwm
"/dev/null" true rwm
"/dev/random" true rwm
"/dev/tty" true rwm
"/dev/urandom" true rwm
"/dev/zero" true rwm
"fuse" false rwm
```

In docker, `/dev/pts` is specified as mount (spec.Mounts)

Containerd:

```
"/dev/console" true rwm
"/dev/full" true rwm
"/dev/null" true rwm
"/dev/ptmx" true rwm // /dev/ptmx -> /dev/pts/ptmx - pts namespaces are "coming soon"
"/dev/pts/" true rwm // pts namespaces are "coming soon"
"/dev/random" true rwm
"/dev/tty" true rwm
"/dev/urandom" true rwm
"/dev/zero" true rwm
"tuntap" true rwm
```