### PR TITLE
Fix log statement 'failed to exit' timeout accuracy

### DIFF
--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -83,7 +83,7 @@ func (daemon *Daemon) containerStop(container *containerpkg.Container, seconds i
 		return err
 	}
 
-	logrus.WithField("container", container.ID).Infof("Container failed to exit within %d seconds of signal %d - using the force", seconds, stopSignal)
+	logrus.WithField("container", container.ID).Infof("Container failed to exit within %s of signal %d - using the force", wait, stopSignal)
 	// Stop either failed or container didnt exit, so fallback to kill.
 	if err := daemon.Kill(container); err != nil {
 		// got a kill error, but give container 2 more seconds to exit just in case


### PR DESCRIPTION
log statement should reflect how long it actually waited, not how long
it theoretically could wait based on the 'seconds' integer passed in.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

If killPossiblyDeadProcess fails then `wait` is modified to only wait 2 seconds rather than keeping the original timeout of `seconds`

Since this log message was still logging `seconds`, this could lead to these strange messages in the logs (notice how the log message says it waited 30 seconds, but the message was logged only 2 seconds later):

```
time="2021-06-08T20:09:54.614066632Z" level=debug msg="Sending kill signal 15 to container cf5a81802409f5fe73406546afa3f77dd495b0046c0dc9c78582c632b278215a"
time="2021-06-08T20:09:56.614434823Z" level=error msg="Error sending stop (signal 15) to container" container=cf5a81802409f5fe73406546afa3f77dd495b0046c0dc9c78582c632b278215a error="CONTAINER KILL FAILED AHHHHHHHHHHH"
time="2021-06-08T20:09:56.614461182Z" level=info msg="Container failed to exit within 30 seconds of signal 15 - using the force" container=cf5a81802409f5fe73406546afa3f77dd495b0046c0dc9c78582c632b278215a
```

After this change the log messages accurately reflects that it only waited 2 seconds:

```
time="2021-06-08T20:26:36.094058401Z" level=debug msg="Sending kill signal 15 to container 30560ce2477e7d8a71cf28d47d4e29b73db6f17d2fb07cfd0d14d4c1380566c7"
time="2021-06-08T20:26:38.094387498Z" level=error msg="Error sending stop (signal 15) to container" container=30560ce2477e7d8a71cf28d47d4e29b73db6f17d2fb07cfd0d14d4c1380566c7 error="CONTAINER KILL FAILED AHHHHHHHHHHH"
time="2021-06-08T20:26:38.094516426Z" level=info msg="Container failed to exit within 2s of signal 15 - using the force" container=30560ce2477e7d8a71cf28d47d4e29b73db6f17d2fb07cfd0d14d4c1380566c7
```

**- How to verify it**

modify code to always return error from `killWithSignal`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

NA (follow-up to #41588)

**- A picture of a cute animal (not mandatory but encouraged)**

