### PR TITLE
pkg/fileutils: PatternMatcher.Matches(): remove debug logging

### DIFF
--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -9,8 +9,6 @@ import (
 	"regexp"
 	"strings"
 	"text/scanner"
-
-	"github.com/sirupsen/logrus"
 )
 
 // PatternMatcher allows checking paths against a list of patterns
@@ -87,10 +85,6 @@ func (pm *PatternMatcher) Matches(file string) (bool, error) {
 		if match {
 			matched = !negative
 		}
-	}
-
-	if matched {
-		logrus.Debugf("Skipping excluded path: %s", file)
 	}
 
 	return matched, nil


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/42491

Trying to avoid logging code in "libraries" used elsewhere. If this debug log is important, it should be easy to add in code that's calling it.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

