### PR TITLE
[20.10 backport] Jenkinsfile: skip ppc64le and s390x by default on pull requests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,8 +14,8 @@ pipeline {
         booleanParam(name: 'rootless', defaultValue: true, description: 'amd64 (x86_64) Build/Test (Rootless mode)')
         booleanParam(name: 'cgroup2', defaultValue: true, description: 'amd64 (x86_64) Build/Test (cgroup v2)')
         booleanParam(name: 'arm64', defaultValue: true, description: 'ARM (arm64) Build/Test')
-        booleanParam(name: 's390x', defaultValue: true, description: 'IBM Z (s390x) Build/Test')
-        booleanParam(name: 'ppc64le', defaultValue: true, description: 'PowerPC (ppc64le) Build/Test')
+        booleanParam(name: 's390x', defaultValue: false, description: 'IBM Z (s390x) Build/Test')
+        booleanParam(name: 'ppc64le', defaultValue: false, description: 'PowerPC (ppc64le) Build/Test')
         booleanParam(name: 'windowsRS1', defaultValue: false, description: 'Windows 2016 (RS1) Build/Test')
         booleanParam(name: 'windowsRS5', defaultValue: true, description: 'Windows 2019 (RS5) Build/Test')
         booleanParam(name: 'dco', defaultValue: true, description: 'Run the DCO check')
@@ -547,7 +547,11 @@ pipeline {
                 stage('s390x') {
                     when {
                         beforeAgent true
-                        expression { params.s390x }
+                        // Skip this stage on PRs unless the checkbox is selected
+                        anyOf {
+                            not { changeRequest() }
+                            expression { params.s390x }
+                        }
                     }
                     agent { label 's390x-ubuntu-1804' }
 
@@ -735,7 +739,11 @@ pipeline {
                 stage('ppc64le') {
                     when {
                         beforeAgent true
-                        expression { params.ppc64le }
+                        // Skip this stage on PRs unless the checkbox is selected
+                        anyOf {
+                            not { changeRequest() }
+                            expression { params.ppc64le }
+                        }
                     }
                     agent { label 'ppc64le-ubuntu-1604' }
                     // ppc64le machines run on Docker 18.06, and buildkit has some


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/42374

This changes CI to skip these platforms by default. The ppc64le and s390x
machines are "pet machines", configuration may be outdated, and these
machines are known to be flaky.

Building and verifying packages for these platforms is being handed
over to the IBM team.

We can still run these platforms for specific pull requests by selecting
the checkboxes.

