### PR TITLE
libnetwork: more cleanups

### DIFF
--- a/libnetwork/drivers/bridge/bridge.go
+++ b/libnetwork/drivers/bridge/bridge.go
@@ -773,8 +773,8 @@ func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 		// Setup IP6Tables.
 		{config.EnableIPv6 && d.config.EnableIP6Tables, network.setupIP6Tables},
 
-		//We want to track firewalld configuration so that
-		//if it is started/reloaded, the rules can be applied correctly
+		// We want to track firewalld configuration so that
+		// if it is started/reloaded, the rules can be applied correctly
 		{d.config.EnableIPTables, network.setupFirewalld},
 		// same for IPv6
 		{config.EnableIPv6 && d.config.EnableIP6Tables, network.setupFirewalld6},
@@ -788,7 +788,7 @@ func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 		// Add inter-network communication rules.
 		{d.config.EnableIPTables, setupNetworkIsolationRules},
 
-		//Configure bridge networking filtering if ICC is off and IP tables are enabled
+		// Configure bridge networking filtering if ICC is off and IP tables are enabled
 		{!config.EnableICC && d.config.EnableIPTables, setupBridgeNetFiltering},
 	} {
 		if step.Condition {

--- a/libnetwork/drivers/bridge/setup_ipv6.go
+++ b/libnetwork/drivers/bridge/setup_ipv6.go
@@ -8,28 +8,18 @@ import (
 	"net"
 	"os"
 
-	"github.com/docker/docker/libnetwork/types"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
 
-var bridgeIPv6 *net.IPNet
+// bridgeIPv6 is the default, link-local IPv6 address for the bridge (fe80::1/64)
+var bridgeIPv6 = &net.IPNet{IP: net.ParseIP("fe80::1"), Mask: net.CIDRMask(64, 128)}
 
 const (
-	bridgeIPv6Str          = "fe80::1/64"
 	ipv6ForwardConfPerm    = 0644
 	ipv6ForwardConfDefault = "/proc/sys/net/ipv6/conf/default/forwarding"
 	ipv6ForwardConfAll     = "/proc/sys/net/ipv6/conf/all/forwarding"
 )
-
-func init() {
-	// We allow ourselves to panic in this special case because we indicate a
-	// failure to parse a compile-time define constant.
-	var err error
-	if bridgeIPv6, err = types.ParseCIDR(bridgeIPv6Str); err != nil {
-		panic(fmt.Sprintf("Cannot parse default bridge IPv6 address %q: %v", bridgeIPv6Str, err))
-	}
-}
 
 func setupBridgeIPv6(config *networkConfiguration, i *bridgeInterface) error {
 	procFile := "/proc/sys/net/ipv6/conf/" + config.BridgeName + "/disable_ipv6"

--- a/libnetwork/drivers/bridge/setup_ipv6_test.go
+++ b/libnetwork/drivers/bridge/setup_ipv6_test.go
@@ -43,14 +43,14 @@ func TestSetupIPv6(t *testing.T) {
 
 	var found bool
 	for _, addr := range addrsv6 {
-		if bridgeIPv6Str == addr.IPNet.String() {
+		if bridgeIPv6.String() == addr.IPNet.String() {
 			found = true
 			break
 		}
 	}
 
 	if !found {
-		t.Fatalf("Bridge device does not have requested IPv6 address %v", bridgeIPv6Str)
+		t.Fatalf("Bridge device does not have requested IPv6 address %v", bridgeIPv6)
 	}
 
 }

--- a/libnetwork/service_windows.go
+++ b/libnetwork/service_windows.go
@@ -13,11 +13,7 @@ type policyLists struct {
 	elb *hcsshim.PolicyList
 }
 
-var lbPolicylistMap map[*loadBalancer]*policyLists
-
-func init() {
-	lbPolicylistMap = make(map[*loadBalancer]*policyLists)
-}
+var lbPolicylistMap = make(map[*loadBalancer]*policyLists)
 
 func (n *network) addLBBackend(ip net.IP, lb *loadBalancer) {
 	if len(lb.vip) == 0 {


### PR DESCRIPTION
migrated from https://github.com/moby/libnetwork/pull/2599
closes https://github.com/moby/libnetwork/pull/2599

- windows: remove redundant init()
- drivers/bridge: dont use types.ParseCIDR() for fixed value
- drivers/bridge: format comments