### PR TITLE
don't use buildmode=pie on ppc64

### DIFF
--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -68,9 +68,10 @@ hash_files() {
 		esac
 	fi
 
-	# -buildmode=pie is not supported on Windows and Linux on mips and riscv64.
+	# -buildmode=pie is not supported on Windows and Linux on mips, riscv64 and ppc64be.
+	# https://github.com/golang/go/blob/master/src/cmd/internal/sys/supported.go#L89-L99
 	case "$(go env GOOS)/$(go env GOARCH)" in
-		windows/* | linux/mips* | linux/riscv*) ;;
+		windows/* | linux/mips* | linux/riscv* | linux/ppc64) ;;
 
 		*)
 			BUILDFLAGS+=("-buildmode=pie")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
made sure `buildmode=pie` is not passed on ppc64 (big-endian)
**- How I did it**
added exception in ` hack/make/.binary`
It's already omitted for ppc64 in
`hack/dockerfile/install/install.sh`
not using wildcard, because GOARCH=ppc64le supports pie

**- How to verify it**
apply provided patch and https://github.com/moby/moby/pull/42172
docker now builds and works on big-endian ppc64
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
don't pass buildmode=pie on ppc64be

**- A picture of a cute animal (not mandatory but encouraged)**

