### PR TITLE
ReplaceFileTarWrapper: permit to override file name

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -278,7 +278,9 @@ func ReplaceFileTarWrapper(inputTarStream io.ReadCloser, mods map[string]TarModi
 				return nil
 			}
 
-			header.Name = name
+			if header.Name == "" {
+				header.Name = name
+			}
 			header.Size = int64(len(data))
 			if err := tarWriter.WriteHeader(header); err != nil {
 				return err


### PR DESCRIPTION
**- What I did**
Just permit to override the tarHeader with a different name if it's needed. Normal behavior is unchanged. This permits to override the name with a custom callback.

**- How to verify it**
We have a test unit under the luet project.
https://github.com/mudler/luet/blob/master/pkg/helpers/archive_test.go#L54

I could integrate a test unit with an example from the luet project maybe?

**- Description for the changelog**
ReplaceFileTarWrapper callback now can be used to replace the unpacked file name.
