### PR TITLE
Adjust buildmode comment to link to commit

### DIFF
--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -69,9 +69,11 @@ hash_files() {
 	fi
 
 	# -buildmode=pie is not supported on Windows and Linux on mips, riscv64 and ppc64be.
-	# https://github.com/golang/go/blob/master/src/cmd/internal/sys/supported.go#L89-L99
+	# https://github.com/golang/go/blob/77aa209b386a184e7f4b44938f2a05a1b5c5a3cf/src/cmd/internal/sys/supported.go#L89-L99
 	case "$(go env GOOS)/$(go env GOARCH)" in
 		windows/* | linux/mips* | linux/riscv* | linux/ppc64) ;;
+		# TODO remove windows in Go 1.15+: https://github.com/golang/go/commit/95f382139043059a2a0780ba577b53893408f7e4
+		# TODO remove riscv64 in Go 1.16+: https://github.com/golang/go/commit/8eb846fd37eb7bded8a1cf6932be2c59069863e5
 
 		*)
 			BUILDFLAGS+=("-buildmode=pie")


### PR DESCRIPTION
This should make sure the link is still meaningful if that file drastically changes (which should make it easier to trace where the interesting block of code moved to and how it changes over time).

Also, add TODO items for Go 1.15+ and 1.16+ where we can "pie" more builds.

(This is a very minor follow-up to #42514)