### PR TITLE
Crosscompilation for s390x and ppc64le

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,16 +127,12 @@ ARG DEBIAN_FRONTEND
 # on non-amd64 systems.
 # Additionally, the crossbuild-amd64 is currently only on debian:buster, so
 # other architectures cannnot crossbuild amd64.
-RUN echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list
 RUN --mount=type=cache,sharing=locked,id=moby-cross-true-aptlib,target=/var/lib/apt \
     --mount=type=cache,sharing=locked,id=moby-cross-true-aptcache,target=/var/cache/apt \
         apt-get update && apt-get install -y --no-install-recommends \
             libapparmor-dev:arm64 \
             libapparmor-dev:armel \
-            libapparmor-dev:armhf \
-            libseccomp-dev:arm64/buster-backports \
-            libseccomp-dev:armel/buster-backports \
-            libseccomp-dev:armhf/buster-backports
+            libapparmor-dev:armhf
 
 FROM runtime-dev-cross-${CROSS} AS runtime-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,12 +97,14 @@ ARG DEBIAN_FRONTEND
 RUN dpkg --add-architecture arm64
 RUN dpkg --add-architecture armel
 RUN dpkg --add-architecture armhf
+RUN dpkg --add-architecture ppc64el
 RUN --mount=type=cache,sharing=locked,id=moby-cross-true-aptlib,target=/var/lib/apt \
     --mount=type=cache,sharing=locked,id=moby-cross-true-aptcache,target=/var/cache/apt \
         apt-get update && apt-get install -y --no-install-recommends \
             crossbuild-essential-arm64 \
             crossbuild-essential-armel \
-            crossbuild-essential-armhf
+            crossbuild-essential-armhf \
+            crossbuild-essential-ppc64el
 
 FROM cross-${CROSS} as dev-base
 
@@ -132,7 +134,8 @@ RUN --mount=type=cache,sharing=locked,id=moby-cross-true-aptlib,target=/var/lib/
         apt-get update && apt-get install -y --no-install-recommends \
             libapparmor-dev:arm64 \
             libapparmor-dev:armel \
-            libapparmor-dev:armhf
+            libapparmor-dev:armhf \
+            libapparmor-dev:ppc64el
 
 FROM runtime-dev-cross-${CROSS} AS runtime-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,13 +98,15 @@ RUN dpkg --add-architecture arm64
 RUN dpkg --add-architecture armel
 RUN dpkg --add-architecture armhf
 RUN dpkg --add-architecture ppc64el
+RUN dpkg --add-architecture s390x
 RUN --mount=type=cache,sharing=locked,id=moby-cross-true-aptlib,target=/var/lib/apt \
     --mount=type=cache,sharing=locked,id=moby-cross-true-aptcache,target=/var/cache/apt \
         apt-get update && apt-get install -y --no-install-recommends \
             crossbuild-essential-arm64 \
             crossbuild-essential-armel \
             crossbuild-essential-armhf \
-            crossbuild-essential-ppc64el
+            crossbuild-essential-ppc64el \
+            crossbuild-essential-s390x
 
 FROM cross-${CROSS} as dev-base
 
@@ -135,7 +137,8 @@ RUN --mount=type=cache,sharing=locked,id=moby-cross-true-aptlib,target=/var/lib/
             libapparmor-dev:arm64 \
             libapparmor-dev:armel \
             libapparmor-dev:armhf \
-            libapparmor-dev:ppc64el
+            libapparmor-dev:ppc64el \
+            libapparmor-dev:s390x
 
 FROM runtime-dev-cross-${CROSS} AS runtime-dev
 

--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -65,6 +65,11 @@ hash_files() {
 				export CC="${CC:-x86_64-linux-gnu-gcc}"
 				export CGO_ENABLED=1
 				;;
+			linux/ppc64le)
+				export CC="${CC:-powerpc64le-linux-gnu-gcc}"
+				export CGO_ENABLED=1
+				;;
+
 		esac
 	fi
 

--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -69,7 +69,10 @@ hash_files() {
 				export CC="${CC:-powerpc64le-linux-gnu-gcc}"
 				export CGO_ENABLED=1
 				;;
-
+			linux/s390x)
+				export CC="${CC:-s390x-linux-gnu-gcc}"
+				export CGO_ENABLED=1
+				;;
 		esac
 	fi
 

--- a/hack/make/cross
+++ b/hack/make/cross
@@ -12,7 +12,7 @@ if [ -x "${DEST}/../binary-daemon/dockerd-${VERSION}" ]; then
 	echo "Created symlinks:" "${DEST}/linux/${arch}/"*
 fi
 
-DOCKER_CROSSPLATFORMS=${DOCKER_CROSSPLATFORMS:-"linux/amd64 windows/amd64 linux/ppc64le"}
+DOCKER_CROSSPLATFORMS=${DOCKER_CROSSPLATFORMS:-"linux/amd64 windows/amd64 linux/ppc64le linux/s390x"}
 
 for platform in ${DOCKER_CROSSPLATFORMS}; do
 	(

--- a/hack/make/cross
+++ b/hack/make/cross
@@ -12,7 +12,7 @@ if [ -x "${DEST}/../binary-daemon/dockerd-${VERSION}" ]; then
 	echo "Created symlinks:" "${DEST}/linux/${arch}/"*
 fi
 
-DOCKER_CROSSPLATFORMS=${DOCKER_CROSSPLATFORMS:-"linux/amd64 windows/amd64"}
+DOCKER_CROSSPLATFORMS=${DOCKER_CROSSPLATFORMS:-"linux/amd64 windows/amd64 linux/ppc64le"}
 
 for platform in ${DOCKER_CROSSPLATFORMS}; do
 	(


### PR DESCRIPTION
**- What I did**
Update build environment to provide cross compilation for linux/s390x and linux/ppc64le

**- How I did it**

Modify runtime-dev-cross-false and  runtime-dev-cross-true docker environments.
Use bullseye to provide libseccomp-dev as s390x and ppc64le in buster-backports are conflicting with other archs.

**- How to verify it**

```
$ make DOCKER_CROSSPLATFORMS="linux/s390x linux/ppc64le" cross
$ ls -l bundles/cross/linux/{s390x,ppc64le}-daemon
$ file bundles/cross/linux/{s390x,ppc64le}-daemon/dockerd-dev
```

SO FAR THE RESULTING BINARIES ARE UNTESTED

**- Description for the changelog**

Add cross compilation for s390x and ppc64le

**- A picture of a cute animal (not mandatory but encouraged)**

![choupinou2](https://user-images.githubusercontent.com/79831213/122037209-a7635d80-cdd4-11eb-99a1-dcdb6a4b4498.jpg)
