### PR TITLE
Jenkinsfile: update Windows 2022 insider to latest tag (10.0.20348.1)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1206,7 +1206,8 @@ pipeline {
                         TESTRUN_SUBDIR         = "CI"
                         // TODO switch to mcr.microsoft.com/windows/servercore:2022 once published
                         WINDOWS_BASE_IMAGE     = 'mcr.microsoft.com/windows/servercore/insider'
-                        WINDOWS_BASE_IMAGE_TAG = '10.0.20295.1'
+                        // Available tags can be found at https://mcr.microsoft.com/v2/windows/servercore/insider/tags/list
+                        WINDOWS_BASE_IMAGE_TAG = '10.0.20348.1'
                     }
                     agent {
                         node {
@@ -1270,7 +1271,7 @@ pipeline {
                         // TODO switch to mcr.microsoft.com/windows/servercore:2022 once published
                         WINDOWS_BASE_IMAGE     = 'mcr.microsoft.com/windows/servercore/insider'
                         // Available tags can be found at https://mcr.microsoft.com/v2/windows/servercore/insider/tags/list
-                        WINDOWS_BASE_IMAGE_TAG = '10.0.20295.1'
+                        WINDOWS_BASE_IMAGE_TAG = '10.0.20348.1'
                         DOCKER_WINDOWS_CONTAINERD_RUNTIME = '1'
                     }
                     agent {


### PR DESCRIPTION
Tags can be found at https://mcr.microsoft.com/v2/windows/servercore/insider/tags/list

