### PR TITLE
libnetwork: iptables: make systemd/firewalld specific hacks optional

### DIFF
--- a/libnetwork/iptables/no_systemd.go
+++ b/libnetwork/iptables/no_systemd.go
@@ -1,0 +1,25 @@
+//go:build linux && no_systemd
+
+package iptables
+
+const firewalldRunning = false
+
+func initFirewalld() {
+}
+
+// Raw calls 'iptables' system command, passing supplied arguments.
+func (iptable IPTable) Raw(args ...string) ([]byte, error) {
+	return iptable.raw(args...)
+}
+
+func AddInterfaceFirewalld(intf string) error {
+	return nil
+}
+
+func DelInterfaceFirewalld(intf string) error {
+	return nil
+}
+
+// OnReloaded add callback
+func OnReloaded(callback func()) {
+}


### PR DESCRIPTION
When running on a pure Linux machine (as opposed to Lennartix), we don't
need any systemd specific code - in that case it's just unnecessary
complexity and a lot of code (with dependencies around 10kLoC) that
needs to be maintained and audited.

Therefore make it all optional by setting 'no_systemd' build tag.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

