### PR TITLE
docs: fix image name in testing guide

### DIFF
--- a/docs/contributing/test.md
+++ b/docs/contributing/test.md
@@ -108,10 +108,10 @@ Try this now.
 2.  Start a Moby development image.
 
     If you are following along with this guide, you should have a
-    `dry-run-test` image.
+    `docker-dev:dry-run-test` image.
 
     ```bash
-    $ docker run --privileged --rm -ti -v `pwd`:/go/src/github.com/docker/docker dry-run-test /bin/bash
+    $ docker run --privileged --rm -ti -v `pwd`:/go/src/github.com/docker/docker docker-dev:dry-run-test /bin/bash
     ```
 
 3.  Run the unit tests using the `hack/test/unit` script.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I followed the contributing guide and encountered (a) few issues.

Note, this also did not work out for me:
https://github.com/moby/moby/blob/5e62ca1a05f2aab49066d91c9070cb7dc7ad2461/docs/contributing/set-up-dev-env.md#L231-L242
Although I am not sure if I just did not understand what the doc is suggesting or it actually is broken.
After doing this, `docker` binary was not available in the container.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

<img src="https://i.redd.it/3tb4vxbbfyh21.jpg" width="250x" height="250x">