### PR TITLE
Add support for `shared-size` parameter for images queries

### DIFF
--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -22,7 +22,7 @@ type Backend interface {
 type imageBackend interface {
 	ImageDelete(imageRef string, force, prune bool) ([]types.ImageDeleteResponseItem, error)
 	ImageHistory(imageName string) ([]*image.HistoryResponseItem, error)
-	Images(imageFilters filters.Args, all bool, withExtraAttrs bool) ([]*types.ImageSummary, error)
+	Images(ctx context.Context, opts types.ImageListOptions) ([]*types.ImageSummary, error)
 	LookupImage(name string) (*types.ImageInspect, error)
 	TagImage(imageName, repository, tag string) (string, error)
 	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*types.ImagesPruneReport, error)

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -229,13 +229,17 @@ func (s *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter, 
 
 	version := httputils.VersionFromContext(ctx)
 	if versions.LessThan(version, "1.41") {
+		// NOTE: filter is a shell glob string applied to repository names.
 		filterParam := r.Form.Get("filter")
 		if filterParam != "" {
 			imageFilters.Add("reference", filterParam)
 		}
 	}
 
-	images, err := s.backend.Images(imageFilters, httputils.BoolValue(r, "all"), false)
+	images, err := s.backend.Images(ctx, types.ImageListOptions{
+		Filters: imageFilters,
+		All:     httputils.BoolValue(r, "all"),
+	})
 	if err != nil {
 		return err
 	}

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -236,9 +236,16 @@ func (s *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter, 
 		}
 	}
 
+	var sharedSize bool
+	if versions.GreaterThanOrEqualTo(version, "1.42") {
+		// NOTE: Support for the "shared-size" parameter was added in API 1.42.
+		sharedSize = httputils.BoolValue(r, "shared-size")
+	}
+
 	images, err := s.backend.Images(ctx, types.ImageListOptions{
-		Filters: imageFilters,
-		All:     httputils.BoolValue(r, "all"),
+		All:        httputils.BoolValue(r, "all"),
+		Filters:    imageFilters,
+		SharedSize: sharedSize,
 	})
 	if err != nil {
 		return err

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -7202,6 +7202,11 @@ paths:
             - `reference`=(`<image-name>[:<tag>]`)
             - `since`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
           type: "string"
+        - name: "shared-size"
+          in: "query"
+          description: "Compute and show shared size as a `SharedSize` field on each image."
+          type: "boolean"
+          default: false
         - name: "digests"
           in: "query"
           description: "Show digest information as a `RepoDigests` field on each image."

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -235,10 +235,20 @@ type ImageImportOptions struct {
 	Platform string   // Platform is the target platform of the image
 }
 
-// ImageListOptions holds parameters to filter the list of images with.
+// ImageListOptions holds parameters to list images with.
 type ImageListOptions struct {
-	All     bool
+	// All controls whether all images in the graph are filtered, or just
+	// the heads.
+	All bool
+
+	// Filters is a JSON-encoded set of filter arguments.
 	Filters filters.Args
+
+	// SharedSize indicates whether the shared size of images should be computed.
+	SharedSize bool
+
+	// ContainerCount indicates whether container count should be computed.
+	ContainerCount bool
 }
 
 // ImageLoadResponse returns information to the client about a load process.

--- a/daemon/disk_usage.go
+++ b/daemon/disk_usage.go
@@ -26,7 +26,11 @@ func (daemon *Daemon) SystemDiskUsage(ctx context.Context) (*types.DiskUsage, er
 	}
 
 	// Get all top images with extra attributes
-	allImages, err := daemon.imageService.Images(filters.NewArgs(), false, true)
+	allImages, err := daemon.imageService.Images(ctx, types.ImageListOptions{
+		Filters:        filters.NewArgs(),
+		SharedSize:     true,
+		ContainerCount: true,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve image list: %v", err)
 	}

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -21,6 +21,9 @@ keywords: "API, Docker, rcli, REST, documentation"
   was introduced in API 1.31 as part of an experimental feature, and no longer
   used since API 1.40.
   Use field `BuildCache` instead to track storage used by the builder component.
+* `GET /images/json` now accepts query parameter `shared-size`. When set `true`,
+  images returned will include `SharedSize`, which provides the size on disk shared
+  with other images present on the system.
 
 ## v1.41 API changes
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Guard shared size computations with `shared-size` boolean URL parameter.
The reasoning for this change is to be able to query image shared size without having to rely on the more heavyweight `/system/df` endpoint.

**- How I did it**

Add an additional boolean parameter to `ImageService.Images` and add a URL parameter to the API endpoint mapping to it's value.
On a fast search over the codebase I did not see another URL parameter consisting of 2 words, so not sure about the naming convention, if there is one - went for kebab case.

**- How to verify it**

```sh
root@28f161c787d2:/go/src/github.com/docker/docker# docker build bundles -f bundles/ubuntu.Dockerfile 
Sending build context to Docker daemon  203.5MB
Step 1/2 : FROM ubuntu
 ---> 9873176a8ff5
Step 2/2 : RUN echo test > testfile
 ---> Running in 99dad2de2d7f
Removing intermediate container 99dad2de2d7f
 ---> 3036176f9a83
Successfully built 3036176f9a83
root@28f161c787d2:/go/src/github.com/docker/docker# curl --unix-socket /var/run/docker.sock http://localhost/images/json?shared-size=1 | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   998  100   998    0     0   974k      0 --:--:-- --:--:-- --:--:--  974k
[
  {
    "Containers": -1,
    "Created": 1624443646,
    "Id": "sha256:3036176f9a83226548a7b19a2d2bcc922945c5f43b3d591eec719e9dcb22e602",
    "Labels": null,
    "ParentId": "sha256:9873176a8ff5ac192ce4d7df8a403787558b9f3981a4c4d74afb3edceeda451c",
    "RepoDigests": [
      "<none>@<none>"
    ],
    "RepoTags": [
      "<none>:<none>"
    ],
    "SharedSize": 72742757,
    "Size": 72742762,
    "VirtualSize": 72742762
  },
  {
    "Containers": -1,
    "Created": 1623972689,
    "Id": "sha256:9873176a8ff5ac192ce4d7df8a403787558b9f3981a4c4d74afb3edceeda451c",
    "Labels": null,
    "ParentId": "",
    "RepoDigests": [
      "ubuntu@sha256:aba80b77e27148d99c034a987e7da3a287ed455390352663418c0f2ed40417fe"
    ],
    "RepoTags": [
      "ubuntu:latest"
    ],
    "SharedSize": 72742757,
    "Size": 72742757,
    "VirtualSize": 72742757
  }
] 
```

Also with filtering:
```sh
root@28f161c787d2:/go/src/github.com/docker/docker# curl --unix-socket /var/run/docker.sock 'http://localhost/images/json?shared-size=1&filters=%7B%22reference%22%3A%7B%22ubuntu%22%3Atrue%7D%7D'  | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   335  100   335    0     0   327k      0 --:--:-- --:--:-- --:--:--  327k
[
  {
    "Containers": -1,
    "Created": 1623972689,
    "Id": "sha256:9873176a8ff5ac192ce4d7df8a403787558b9f3981a4c4d74afb3edceeda451c",
    "Labels": null,
    "ParentId": "",
    "RepoDigests": [
      "ubuntu@sha256:aba80b77e27148d99c034a987e7da3a287ed455390352663418c0f2ed40417fe"
    ],
    "RepoTags": [
      "ubuntu:latest"
    ],
    "SharedSize": 72742757,
    "Size": 72742757,
    "VirtualSize": 72742757
  }
]
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

`/images` endpoint now supports boolean `shared-size` URL parameter, which enables shared size computation when set
