### PR TITLE
Fix typo in macvlan_setup.go

### DIFF
--- a/libnetwork/drivers/macvlan/macvlan_setup.go
+++ b/libnetwork/drivers/macvlan/macvlan_setup.go
@@ -150,7 +150,7 @@ func parseVlan(linkName string) (string, int, error) {
 	}
 	// Check if the interface exists
 	if !parentExists(parent) {
-		return "", 0, fmt.Errorf("-o parent interface does was not found on the host: %s", parent)
+		return "", 0, fmt.Errorf("-o parent interface was not found on the host: %s", parent)
 	}
 
 	return parent, vidInt, nil


### PR DESCRIPTION

**- What I did**
Fix typo in macvlan_setup.go
**- How I did it**
By removing unnecessary wordings.
**- How to verify it**
View the error message when macvlan driver creation failed because of parent interface not existing.
**- Description for the changelog**
Fix typo in error message

