### PR TITLE
Delete orphaned vxlan interface in host namespace

### DIFF
--- a/libnetwork/drivers/overlay/ov_utils.go
+++ b/libnetwork/drivers/overlay/ov_utils.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package overlay
 
 import (
@@ -11,6 +9,7 @@ import (
 	"github.com/docker/docker/libnetwork/netutils"
 	"github.com/docker/docker/libnetwork/ns"
 	"github.com/docker/docker/libnetwork/osl"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
@@ -71,7 +70,7 @@ func createVxlan(name string, vni uint32, mtu int) error {
 	}
 
 	if err := ns.NlHandle().LinkAdd(vxlan); err != nil {
-		return fmt.Errorf("error creating vxlan interface: %v", err)
+		return errors.Wrapf(err, "failed to create vxlan interface with name %q", name)
 	}
 
 	return nil
@@ -113,11 +112,11 @@ func deleteInterface(name string) error {
 
 	link, err := ns.NlHandle().LinkByName(name)
 	if err != nil {
-		return fmt.Errorf("failed to find interface with name %s: %v", name, err)
+		return errors.Wrapf(err, "failed to find interface with name %s", name)
 	}
 
 	if err := ns.NlHandle().LinkDel(link); err != nil {
-		return fmt.Errorf("error deleting interface with name %s: %v", name, err)
+		return errors.Wrapf(err, "error deleting interface with name %s", name)
 	}
 
 	return nil


### PR DESCRIPTION

Signed-off-by: Xinfeng Liu <xinfeng.liu@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
In a highly churned docker swarm cluster, sometimes the error `creating vxlan interface: file exists` emerges, then it is needed to manually clean up the orphaned `vx-xxxxx` interfaces in host namespace.

This PR is to avoid this manual operation.


**- How I did it**
Instead of directly returning the error on `createVxlan()`, I added the codes to check the error, if it is `file exists` error, the codes will try fixing it by removing the old vxlan interface then re-running `createVxlan()`. 

**- How to verify it**
Sorry I'm not able to reproduce the original issue deliberately. The code change is based on the error analysis.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

