### PR TITLE
Daemon configuration for restricted image access

### DIFF
--- a/api/types/registry/registry.go
+++ b/api/types/registry/registry.go
@@ -8,7 +8,7 @@ import (
 )
 
 type RegistryConfig struct {
-	Url      string   `json:"url,omitempty"`
+	Name     string   `json:"name"`
 	Prefixes []string `json:"prefixes,omitempty"`
 	Actions  []string `json:"actions,omitempty"`
 }
@@ -20,6 +20,7 @@ type ServiceConfig struct {
 	InsecureRegistryCIDRs                   []*NetIPNet           `json:"InsecureRegistryCIDRs"`
 	IndexConfigs                            map[string]*IndexInfo `json:"IndexConfigs"`
 	Mirrors                                 []string
+	Restricted                              bool
 }
 
 // NetIPNet is the net.IPNet type, which can be marshalled and
@@ -88,12 +89,18 @@ type IndexInfo struct {
 	// Official indicates whether this is an official registry
 	Official bool
 
-	// Prefixes is a set of repositories allowed for actions
-	Prefixes []string
-	// Actions is a list with enabled actions - by default both pull and
-	// push are enabled
-	Actions []string
+	// Prefixes holds repository pull/push permissions
+	Prefixes RepositoryPrefixes
 }
+
+// RepositoryActions maps repository pull/push permissions
+type RepositoryActions struct {
+	Pull bool
+	Push bool
+}
+
+// RepositoryActions describes pull/push permissions per repository
+type RepositoryPrefixes map[string]RepositoryActions
 
 // SearchResult describes a search result returned from a registry
 type SearchResult struct {

--- a/api/types/registry/registry.go
+++ b/api/types/registry/registry.go
@@ -7,6 +7,12 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+type RegistryConfig struct {
+	Url      string   `json:"url,omitempty"`
+	Prefixes []string `json:"prefixes,omitempty"`
+	Actions  []string `json:"actions,omitempty"`
+}
+
 // ServiceConfig stores daemon registry services configuration.
 type ServiceConfig struct {
 	AllowNondistributableArtifactsCIDRs     []*NetIPNet
@@ -81,6 +87,12 @@ type IndexInfo struct {
 	Secure bool
 	// Official indicates whether this is an official registry
 	Official bool
+
+	// Prefixes is a set of repositories allowed for actions
+	Prefixes []string
+	// Actions is a list with enabled actions - by default both pull and
+	// push are enabled
+	Actions []string
 }
 
 // SearchResult describes a search result returned from a registry

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -452,10 +452,7 @@ func loadDaemonCliConfig(opts *daemonOptions) (*config.Config, error) {
 	if conf.TLSVerify == nil && conf.TLS != nil {
 		conf.TLSVerify = conf.TLS
 	}
-	/*println("===============>    END config: num registries = ", len(conf.Registries))
-	for k, v := range conf.ValuesSet {
-		println("confg set k =", k, "=", v)
-	}*/
+
 	return conf, nil
 }
 

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -452,7 +452,10 @@ func loadDaemonCliConfig(opts *daemonOptions) (*config.Config, error) {
 	if conf.TLSVerify == nil && conf.TLS != nil {
 		conf.TLSVerify = conf.TLS
 	}
-
+	/*println("===============>    END config: num registries = ", len(conf.Registries))
+	for k, v := range conf.ValuesSet {
+		println("confg set k =", k, "=", v)
+	}*/
 	return conf, nil
 }
 

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 
+	registrytypes "github.com/docker/docker/api/types/registry"
 	daemondiscovery "github.com/docker/docker/daemon/discovery"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/authorization"
@@ -84,8 +85,9 @@ var flatOptions = map[string]bool{
 // that will be skipped from findConfigurationConflicts
 // for unknown flag validation.
 var skipValidateOptions = map[string]bool{
-	"features": true,
-	"builder":  true,
+	"features":   true,
+	"builder":    true,
+	"registries": true,
 	// Corresponding flag has been removed because it was already unusable
 	"deprecated-key-path": true,
 }
@@ -289,6 +291,11 @@ func New() *Config {
 	return &config
 }
 
+// ParseRegistriesSettings parses the specified advertise settings
+func ParseRegistriesSettings(v []registrytypes.RegistryConfig) error {
+	return nil
+}
+
 // ParseClusterAdvertiseSettings parses the specified advertise settings
 func ParseClusterAdvertiseSettings(clusterStore, clusterAdvertise string) (string, error) {
 	if clusterAdvertise == "" {
@@ -408,6 +415,7 @@ func getConflictFreeConfiguration(configFile string, flags *pflag.FlagSet) (*Con
 		}
 
 		configSet := configValuesSet(jsonConfig)
+		println(string(b))
 
 		if err := findConfigurationConflicts(configSet, flags); err != nil {
 			return nil, err

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"sync"
 
-	registrytypes "github.com/docker/docker/api/types/registry"
 	daemondiscovery "github.com/docker/docker/daemon/discovery"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/authorization"
@@ -291,11 +290,6 @@ func New() *Config {
 	return &config
 }
 
-// ParseRegistriesSettings parses the specified advertise settings
-func ParseRegistriesSettings(v []registrytypes.RegistryConfig) error {
-	return nil
-}
-
 // ParseClusterAdvertiseSettings parses the specified advertise settings
 func ParseClusterAdvertiseSettings(clusterStore, clusterAdvertise string) (string, error) {
 	if clusterAdvertise == "" {
@@ -415,7 +409,6 @@ func getConflictFreeConfiguration(configFile string, flags *pflag.FlagSet) (*Con
 		}
 
 		configSet := configValuesSet(jsonConfig)
-		println(string(b))
 
 		if err := findConfigurationConflicts(configSet, flags); err != nil {
 			return nil, err

--- a/distribution/push.go
+++ b/distribution/push.go
@@ -31,6 +31,9 @@ const compressionBufSize = 32768
 // through to the underlying pusher implementation for use during the actual
 // push operation.
 func NewPusher(ref reference.Named, endpoint registry.APIEndpoint, repoInfo *registry.RepositoryInfo, imagePushConfig *ImagePushConfig) (Pusher, error) {
+	if endpoint.Restricted && !repoInfo.PushAllowed() {
+		return nil, fmt.Errorf("PUSH is not allowed for %s, check allowed repositories in the daemon configuration", repoInfo.Name.Name())
+	}
 	switch endpoint.Version {
 	case registry.APIVersion2:
 		return &v2Pusher{
@@ -57,7 +60,6 @@ func Push(ctx context.Context, ref reference.Named, imagePushConfig *ImagePushCo
 	if err != nil {
 		return err
 	}
-
 	endpoints, err := imagePushConfig.RegistryService.LookupPushEndpoints(reference.Domain(repoInfo.Name))
 	if err != nil {
 		return err

--- a/registry/service.go
+++ b/registry/service.go
@@ -46,8 +46,8 @@ type DefaultService struct {
 // NewService returns a new instance of DefaultService ready to be
 // installed into an engine.
 func NewService(options ServiceOptions) (*DefaultService, error) {
+	println("service options : ", len(options.Registries))
 	config, err := newServiceConfig(options)
-
 	return &DefaultService{config: config}, err
 }
 
@@ -244,6 +244,7 @@ type APIEndpoint struct {
 	Official                       bool
 	TrimHostname                   bool
 	TLSConfig                      *tls.Config
+	Prefixes                       []string
 }
 
 // ToV1Endpoint returns a V1 API endpoint based on the APIEndpoint
@@ -275,7 +276,13 @@ func (s *DefaultService) LookupPullEndpoints(hostname string) (endpoints []APIEn
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return s.lookupV2Endpoints(hostname)
+	endpoints, err = s.lookupV2Endpoints(hostname)
+	if err != nil {
+		return nil, err
+	}
+	println("PULL endpoints lookup: ", len(endpoints), " ", endpoints)
+
+	return endpoints, nil
 }
 
 // LookupPushEndpoints creates a list of v2 endpoints to try to push to, in order of preference.
@@ -292,5 +299,6 @@ func (s *DefaultService) LookupPushEndpoints(hostname string) (endpoints []APIEn
 			}
 		}
 	}
+	println("PUSH endpoints lookup: ", len(allEndpoints), " ", allEndpoints)
 	return endpoints, err
 }

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -74,6 +74,6 @@ func (s *DefaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndp
 			TLSConfig: tlsConfig,
 		})
 	}
-
+	println("Endpoints: ", len(endpoints), endpoints[0].URL)
 	return endpoints, nil
 }

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -28,6 +28,7 @@ func (s *DefaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndp
 				Mirror:       true,
 				TrimHostname: true,
 				TLSConfig:    mirrorTLSConfig,
+				Restricted:   s.Restricted,
 			})
 		}
 		endpoints = append(endpoints, APIEndpoint{
@@ -36,6 +37,7 @@ func (s *DefaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndp
 			Official:     true,
 			TrimHostname: true,
 			TLSConfig:    tlsConfig,
+			Restricted:   s.Restricted,
 		})
 
 		return endpoints, nil
@@ -58,6 +60,7 @@ func (s *DefaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndp
 			AllowNondistributableArtifacts: ana,
 			TrimHostname:                   true,
 			TLSConfig:                      tlsConfig,
+			Restricted:                     s.Restricted,
 		},
 	}
 
@@ -71,9 +74,10 @@ func (s *DefaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndp
 			AllowNondistributableArtifacts: ana,
 			TrimHostname:                   true,
 			// used to check if supposed to be secure via InsecureSkipVerify
-			TLSConfig: tlsConfig,
+			TLSConfig:  tlsConfig,
+			Restricted: s.Restricted,
 		})
 	}
-	println("Endpoints: ", len(endpoints), endpoints[0].URL)
+
 	return endpoints, nil
 }

--- a/registry/types.go
+++ b/registry/types.go
@@ -68,3 +68,20 @@ type RepositoryInfo struct {
 	// or "image".
 	Class string
 }
+
+func (r RepositoryInfo) IsPushAllowed() bool {
+	println("Is PUSH allowed? ", r.Name)
+
+	if r.Index.Prefixes == nil {
+		if r.Index.Actions == nil {
+			return true
+		}
+	}
+
+	if r.Index.Actions == nil && r.Index.Prefixes == nil {
+		return true
+	}
+
+	return true
+
+}


### PR DESCRIPTION
First implementation for image access configuration in the Docker Daemon as proposed in https://github.com/moby/moby/issues/42534

Example: allow access to Docker Hub only
```
$ cat daemon.json
{
  "registries": [
    {
      "name": "docker.io"
    }
  ]
}

$ docker pull nginx         
Using default tag: latest
latest: Pulling from library/nginx
69692152171a: Downloading [===============================>                   ]  17.31MB/27.15MB
30afc0b18f67: Downloading [===================>                               ]  10.49MB/26.58MB
...

$ docker pull mcr.microsoft.com/dotnet/aspnet
Using default tag: latest
Error response from daemon: PULL is not allowed for mcr.microsoft.com/dotnet/aspnet, check allowed repositories in the daemon configuration

```

Allowing pull access only for the official images on Docker Hub:

```
$ cat daemon.json
{
  "registries": [
    {
      "name": "docker.io",
      "prefixes": ["library"],
      "actions": ["pull"]
    }
  ]
}



$ docker pull nginx
Using default tag: latest
latest: Pulling from library/nginx
69692152171a: Pull complete 
...
Digest: sha256:6d75c99af15565a301e48297fa2d121e15d80ad526f8369c526324f0f7ccb750
Status: Downloaded newer image for nginx:latest


$ docker push nginx
The push refers to repository [docker.io/library/nginx]
PUSH is not allowed for docker.io/library/nginx, check allowed repositories in the daemon configuration


$ docker pull amd64/busybox
Using default tag: latest
Error response from daemon: PULL is not allowed for docker.io/amd64/busybox, check allowed repositories in the daemon configuration


```
Combination allowing:
- pulling official images from Docker Hub
- only push access for the docker official image
- pulling and pushing images from Microsoft's registry


```
$ cat daemon.json
{
  "registries": [
    {
      "name": "docker.io",
      "prefixes": [
	"library"
      ],
      "actions": ["pull"]
    },
    {
      "name": "docker.io",
      "prefixes": [
        "library/docker"
      ],
      "actions": ["push"]
    },
    {
      "name": "mcr.microsoft.com"
    }
  ]
}




$ docker pull nginx
Using default tag: latest
latest: Pulling from library/nginx
69692152171a: Pull complete 
30afc0b18f67: Pull complete 
596b1d696923: Pull complete 
febe5bd23e98: Pull complete 
8283eee92e2f: Pull complete 
351ad75a6cfa: Pull complete 
Digest: sha256:6d75c99af15565a301e48297fa2d121e15d80ad526f8369c526324f0f7ccb750
Status: Downloaded newer image for nginx:latest

$ docker push nginx
The push refers to repository [docker.io/library/nginx]
PUSH is not allowed for docker.io/library/nginx, check allowed repositories in the daemon configuration


$ docker pull docker
Using default tag: latest
Error response from daemon: PULL is not allowed for docker.io/library/docker, check allowed repositories in the daemon configuration

$ docker push docker
The push refers to repository [docker.io/library/docker]
An image does not exist locally with the tag: docker


$ docker pull mcr.microsoft.com/dotnet/aspnet
Using default tag: latest
latest: Pulling from dotnet/aspnet
...
Status: Downloaded newer image for mcr.microsoft.com/dotnet/aspnet:latest


```


