### PR TITLE
Make `validate` flag description more generic

### DIFF
--- a/cmd/dockerd/options.go
+++ b/cmd/dockerd/options.go
@@ -60,7 +60,7 @@ func (o *daemonOptions) InstallFlags(flags *pflag.FlagSet) {
 	}
 
 	flags.BoolVarP(&o.Debug, "debug", "D", false, "Enable debug mode")
-	flags.BoolVar(&o.Validate, "validate", false, "Validate configuration file and exit")
+	flags.BoolVar(&o.Validate, "validate", false, "Validate daemon configuration and exit")
 	flags.StringVarP(&o.LogLevel, "log-level", "l", "info", `Set the logging level ("debug"|"info"|"warn"|"error"|"fatal")`)
 	flags.BoolVar(&o.TLS, FlagTLS, DefaultTLSValue, "Use TLS; implied by --tlsverify")
 	flags.BoolVar(&o.TLSVerify, FlagTLSVerify, dockerTLSVerify || DefaultTLSValue, "Use TLS and verify the remote")


### PR DESCRIPTION
Update the `validate` flag description to be more generic as it validates the combination of flags (if set) and the configuration file.
