### PR TITLE
registry: remove const for 'Docker-Distribution-Api-Version' header

### DIFF
--- a/registry/config.go
+++ b/registry/config.go
@@ -29,10 +29,6 @@ type serviceConfig struct {
 const (
 	// DefaultNamespace is the default namespace
 	DefaultNamespace = "docker.io"
-	// DefaultRegistryVersionHeader is the name of the default HTTP header
-	// that carries Registry version info
-	DefaultRegistryVersionHeader = "Docker-Distribution-Api-Version"
-
 	// IndexHostname is the index hostname
 	IndexHostname = "index.docker.io"
 	// IndexServer is used for user auth and image search


### PR DESCRIPTION
noticed this when looking at https://github.com/docker/cli/issues/3161

This header was used for fallbacks to v1 registries, but it's no longer used since https://github.com/moby/moby/pull/41757, and marked optional / legacy in the OCI distribution-spec:

https://github.com/opencontainers/distribution-spec/blob/v1.0.0/spec.md#legacy-docker-support-http-headers

> Because of the origins this specification, the client MAY encounter
> Docker-specific headers, such as `Docker-Content-Digest`, or
> `Docker-Distribution-API-Version`. These headers are OPTIONAL and
> clients SHOULD NOT depend on them.

