### PR TITLE
libnetwork: processEndpointCreate: Fix deadlock between getSvcRecords and processEndpointCreate

### DIFF
--- a/libnetwork/store.go
+++ b/libnetwork/store.go
@@ -340,8 +340,11 @@ func (c *controller) processEndpointCreate(nmap map[string]*netWatch, ep *endpoi
 		return
 	}
 
+	networkID := n.ID()
+	endpointID := ep.ID()
+
 	c.Lock()
-	nw, ok := nmap[n.ID()]
+	nw, ok := nmap[networkID]
 	c.Unlock()
 
 	if ok {
@@ -349,12 +352,12 @@ func (c *controller) processEndpointCreate(nmap map[string]*netWatch, ep *endpoi
 		n.updateSvcRecord(ep, c.getLocalEps(nw), true)
 
 		c.Lock()
-		nw.localEps[ep.ID()] = ep
+		nw.localEps[endpointID] = ep
 
 		// If we had learned that from the kv store remove it
 		// from remote ep list now that we know that this is
 		// indeed a local endpoint
-		delete(nw.remoteEps, ep.ID())
+		delete(nw.remoteEps, endpointID)
 		c.Unlock()
 		return
 	}
@@ -370,8 +373,8 @@ func (c *controller) processEndpointCreate(nmap map[string]*netWatch, ep *endpoi
 	n.updateSvcRecord(ep, c.getLocalEps(nw), true)
 
 	c.Lock()
-	nw.localEps[ep.ID()] = ep
-	nmap[n.ID()] = nw
+	nw.localEps[endpointID] = ep
+	nmap[networkID] = nw
 	nw.stopCh = make(chan struct{})
 	c.Unlock()
 


### PR DESCRIPTION
Another similar case occured with a fixed build. Removed holding multiple locks for processEndpointCreate aswell.

In terms of lock hierarchy I also thought about locking `n.ctrlr.Lock()` before `n.Lock()` in
`getSvcRecords()` to possibly prevent other cases where the locking can't be split like here (e.g. both looks need to be held). 
But that might be not wanted because of data races (accessing networks data before its locked).
If the controller of a network cant change, it probably would be prefered though.

References https://github.com/moby/moby/pull/42545

@thaJeztah

