### PR TITLE
file mkimage-rinse.sh has been abort, should modify the script annotation

### DIFF
--- a/contrib/mkimage-yum.sh
+++ b/contrib/mkimage-yum.sh
@@ -3,8 +3,7 @@
 # Create a base CentOS Docker image.
 #
 # This script is useful on systems with yum installed (e.g., building
-# a CentOS image on CentOS).  See contrib/mkimage-rinse.sh for a way
-# to build CentOS images on other systems.
+# a CentOS image on CentOS).
 
 set -e
 


### PR DESCRIPTION


Signed-off-by: dingwei <dingwei@cmss.chinamobile.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
delete the annotation of script
**- How I did it**
delete the annotation of script 
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
there is no file named mkimage-rinse.sh in contrib floder, should delete it

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/19324666/123615725-27a7ab00-d838-11eb-8288-608804e17179.png)
