### PR TITLE
fix potential goroutine leak by making channel non-blocking

### DIFF
--- a/container/state.go
+++ b/container/state.go
@@ -207,7 +207,7 @@ func (s *State) Wait(ctx context.Context, condition WaitCondition) <-chan StateS
 	// actually stopped.
 	waitRemove := s.waitRemove
 
-	resultC := make(chan StateStatus)
+	resultC := make(chan StateStatus, 1)
 
 	go func() {
 		select {


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixing a potential deadlock by making unbuffered channel to buffered channel.

**- How I did it**

https://github.com/moby/moby/blob/d12fc17073431ebe74ff0b1b3e5a739301c1760a/container/state_test.go#L134-L149
If line 138 happened first, there will be no receiver for waitC.

https://github.com/moby/moby/blob/d12fc17073431ebe74ff0b1b3e5a739301c1760a/container/state.go#L210-L235
If there is no receiver for resultC, line 216 will be blocked forever. 

The solution is to make resultC to be a buffered channel, so that sender's goroutine can exit properly.


**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
This PR fixes a potential deadlock.

**- A picture of a cute animal (not mandatory but encouraged)**

