### PR TITLE
fixes a potential deadlock (daemon/graphdriver/devmapper/devmapper_test.go)

### DIFF
--- a/daemon/graphdriver/devmapper/devmapper_test.go
+++ b/daemon/graphdriver/devmapper/devmapper_test.go
@@ -136,7 +136,7 @@ func TestDevmapperLockReleasedDeviceDeletion(t *testing.T) {
 	// DeviceSet Lock. If lock has not been released, this will hang.
 	driver.DeviceSet.cleanupDeletedDevices()
 
-	doneChan := make(chan bool)
+	doneChan := make(chan bool, 1)
 
 	go func() {
 		driver.DeviceSet.Lock()


### PR DESCRIPTION
Signed-off-by: Shihao Xia <charlesxsh@hotmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
fixes a potential deadlock

**- How I did it**

https://github.com/moby/moby/blob/d12fc17073431ebe74ff0b1b3e5a739301c1760a/daemon/graphdriver/devmapper/devmapper_test.go#L139-L159

If line 148 happened first, there will be no receiver for doneChan created at line 139. In that case, line 144, sending operation of doneChan might be blocked forever.



**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fixes a potential deadlock

**- A picture of a cute animal (not mandatory but encouraged)**

