### PR TITLE
fix a potential deadlock (restartmanager/restartmanager.go)

### DIFF
--- a/restartmanager/restartmanager.go
+++ b/restartmanager/restartmanager.go
@@ -105,7 +105,7 @@ func (rm *restartManager) ShouldRestart(exitCode uint32, hasBeenManuallyStopped 
 	rm.active = true
 	rm.Unlock()
 
-	ch := make(chan error)
+	ch := make(chan error, 1)
 	go func() {
 		timeout := time.NewTimer(rm.timeout)
 		defer timeout.Stop()


### PR DESCRIPTION
Signed-off-by: Shihao Xia <charlesxsh@hotmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**
https://github.com/moby/moby/blob/d12fc17073431ebe74ff0b1b3e5a739301c1760a/restartmanager/restartmanager.go#L108-L125

If line 117 happened first, and there is no receiver for ch created at line 108, line 115 might be blocked forever. 

One example is https://github.com/moby/moby/blob/d12fc17073431ebe74ff0b1b3e5a739301c1760a/restartmanager/restartmanager_test.go#L13 

The channel returned is directly been omitted.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

