### PR TITLE
Reduce TestClientWithRequestTimeout flakiness

### DIFF
--- a/pkg/plugins/client_test.go
+++ b/pkg/plugins/client_test.go
@@ -242,7 +242,7 @@ func TestClientWithRequestTimeout(t *testing.T) {
 
 	timeout := 1 * time.Millisecond
 	testHandler := func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(timeout + 1*time.Millisecond)
+		time.Sleep(timeout + 10*time.Millisecond)
 		w.WriteHeader(http.StatusOK)
 	}
 


### PR DESCRIPTION
hopefully addresses part of https://github.com/moby/moby/issues/38587

The test sometimes failed because no error was returned:

    === Failed
    === FAIL: pkg/plugins TestClientWithRequestTimeout (0.00s)
         client_test.go:254: assertion failed: expected an error, got nil: expected error

Possibly caused by a race condition, as the sleep was just 1 ms longer than the timeout;
this patch is increasing the sleep in the response to try to reduce flakiness.
