### PR TITLE
api/swagger: fix validation because of empty description

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1303,7 +1303,6 @@ definitions:
 
       # TODO is SecondaryIPAddresses actually used?
       SecondaryIPAddresses:
-        description: ""
         type: "array"
         items:
           $ref: "#/definitions/Address"
@@ -1311,7 +1310,6 @@ definitions:
 
       # TODO is SecondaryIPv6Addresses actually used?
       SecondaryIPv6Addresses:
-        description: ""
         type: "array"
         items:
           $ref: "#/definitions/Address"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1468,7 +1468,7 @@ definitions:
       "53/udp":
         - HostIp: "0.0.0.0"
           HostPort: "53"
-      "2377/tcp": null
+      "2377/tcp": []
 
   PortBinding:
     description: |
@@ -1697,10 +1697,13 @@ definitions:
           Details are returned as a map with key/value pairs:
           `{"key":"value","key2":"value2"}`.
 
+          Values usually are strings, but other types can be returned.
+
           The `Status` field is optional, and is omitted if the volume driver
           does not support this feature.
         additionalProperties:
-          type: "object"
+          # status returns a map[string]interface{}, so type could be "any" here.
+          type: "string"
       Labels:
         type: "object"
         description: "User-defined key/value metadata."
@@ -1862,6 +1865,7 @@ definitions:
         type: "string"
       MacAddress:
         type: "string"
+        example: "02:42:ac:11:00:04"
       IPv4Address:
         type: "string"
       IPv6Address:
@@ -4829,7 +4833,7 @@ definitions:
             Size:
               description: "The network pool size"
               type: "integer"
-              example: "24"
+              example: 24
       Warnings:
         description: |
           List of warnings / informational messages about missing features, or
@@ -5440,7 +5444,7 @@ paths:
                 - "BAZ=quux"
               Cmd:
                 - "date"
-              Entrypoint: ""
+              Entrypoint: [""]
               Image: "ubuntu"
               Labels:
                 com.example.vendor: "Acme"
@@ -7375,6 +7379,7 @@ paths:
           in: "query"
           description: "BuildKit output configuration"
           type: "string"
+          x-nullable: true
           default: ""
       responses:
         200:

--- a/docs/api/v1.32.yaml
+++ b/docs/api/v1.32.yaml
@@ -927,7 +927,6 @@ definitions:
 
       # TODO is SecondaryIPAddresses actually used?
       SecondaryIPAddresses:
-        description: ""
         type: "array"
         items:
           $ref: "#/definitions/Address"
@@ -935,7 +934,6 @@ definitions:
 
       # TODO is SecondaryIPv6Addresses actually used?
       SecondaryIPv6Addresses:
-        description: ""
         type: "array"
         items:
           $ref: "#/definitions/Address"

--- a/docs/api/v1.33.yaml
+++ b/docs/api/v1.33.yaml
@@ -932,7 +932,6 @@ definitions:
 
       # TODO is SecondaryIPAddresses actually used?
       SecondaryIPAddresses:
-        description: ""
         type: "array"
         items:
           $ref: "#/definitions/Address"
@@ -940,7 +939,6 @@ definitions:
 
       # TODO is SecondaryIPv6Addresses actually used?
       SecondaryIPv6Addresses:
-        description: ""
         type: "array"
         items:
           $ref: "#/definitions/Address"

--- a/docs/api/v1.34.yaml
+++ b/docs/api/v1.34.yaml
@@ -943,7 +943,6 @@ definitions:
 
       # TODO is SecondaryIPAddresses actually used?
       SecondaryIPAddresses:
-        description: ""
         type: "array"
         items:
           $ref: "#/definitions/Address"
@@ -951,7 +950,6 @@ definitions:
 
       # TODO is SecondaryIPv6Addresses actually used?
       SecondaryIPv6Addresses:
-        description: ""
         type: "array"
         items:
           $ref: "#/definitions/Address"

--- a/docs/api/v1.35.yaml
+++ b/docs/api/v1.35.yaml
@@ -919,7 +919,6 @@ definitions:
 
       # TODO is SecondaryIPAddresses actually used?
       SecondaryIPAddresses:
-        description: ""
         type: "array"
         items:
           $ref: "#/definitions/Address"
@@ -927,7 +926,6 @@ definitions:
 
       # TODO is SecondaryIPv6Addresses actually used?
       SecondaryIPv6Addresses:
-        description: ""
         type: "array"
         items:
           $ref: "#/definitions/Address"

--- a/docs/api/v1.36.yaml
+++ b/docs/api/v1.36.yaml
@@ -919,7 +919,6 @@ definitions:
 
       # TODO is SecondaryIPAddresses actually used?
       SecondaryIPAddresses:
-        description: ""
         type: "array"
         items:
           $ref: "#/definitions/Address"
@@ -927,7 +926,6 @@ definitions:
 
       # TODO is SecondaryIPv6Addresses actually used?
       SecondaryIPv6Addresses:
-        description: ""
         type: "array"
         items:
           $ref: "#/definitions/Address"

--- a/docs/api/v1.37.yaml
+++ b/docs/api/v1.37.yaml
@@ -922,7 +922,6 @@ definitions:
 
       # TODO is SecondaryIPAddresses actually used?
       SecondaryIPAddresses:
-        description: ""
         type: "array"
         items:
           $ref: "#/definitions/Address"
@@ -930,7 +929,6 @@ definitions:
 
       # TODO is SecondaryIPv6Addresses actually used?
       SecondaryIPv6Addresses:
-        description: ""
         type: "array"
         items:
           $ref: "#/definitions/Address"

--- a/docs/api/v1.38.yaml
+++ b/docs/api/v1.38.yaml
@@ -933,7 +933,6 @@ definitions:
 
       # TODO is SecondaryIPAddresses actually used?
       SecondaryIPAddresses:
-        description: ""
         type: "array"
         items:
           $ref: "#/definitions/Address"
@@ -941,7 +940,6 @@ definitions:
 
       # TODO is SecondaryIPv6Addresses actually used?
       SecondaryIPv6Addresses:
-        description: ""
         type: "array"
         items:
           $ref: "#/definitions/Address"

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -1213,7 +1213,6 @@ definitions:
 
       # TODO is SecondaryIPAddresses actually used?
       SecondaryIPAddresses:
-        description: ""
         type: "array"
         items:
           $ref: "#/definitions/Address"
@@ -1221,7 +1220,6 @@ definitions:
 
       # TODO is SecondaryIPv6Addresses actually used?
       SecondaryIPv6Addresses:
-        description: ""
         type: "array"
         items:
           $ref: "#/definitions/Address"

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -1272,7 +1272,6 @@ definitions:
 
       # TODO is SecondaryIPAddresses actually used?
       SecondaryIPAddresses:
-        description: ""
         type: "array"
         items:
           $ref: "#/definitions/Address"
@@ -1280,7 +1279,6 @@ definitions:
 
       # TODO is SecondaryIPv6Addresses actually used?
       SecondaryIPv6Addresses:
-        description: ""
         type: "array"
         items:
           $ref: "#/definitions/Address"

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -1303,7 +1303,6 @@ definitions:
 
       # TODO is SecondaryIPAddresses actually used?
       SecondaryIPAddresses:
-        description: ""
         type: "array"
         items:
           $ref: "#/definitions/Address"
@@ -1311,7 +1310,6 @@ definitions:
 
       # TODO is SecondaryIPv6Addresses actually used?
       SecondaryIPv6Addresses:
-        description: ""
         type: "array"
         items:
           $ref: "#/definitions/Address"


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/42531#issuecomment-871539475

Removing the empty descriptions for SecondaryIPAddresses and SecondaryIPv6Addresses,
because (for unknown reasons) the swagger validation started failing on them:

    The swagger spec at "api/swagger.yaml" is invalid against swagger specification 2.0. see errors :
    - definitions.NetworkSettings.properties.SecondaryIPAddresses.description in body must be of type string: "null"
    - definitions.NetworkSettings.properties.SecondaryIPv6Addresses.description in body must be of type string: "null"


