### PR TITLE
Fix use of unsafe ptr #42444

### DIFF
--- a/daemon/graphdriver/graphtest/graphtest_unix.go
+++ b/daemon/graphdriver/graphtest/graphtest_unix.go
@@ -4,8 +4,8 @@ package graphtest // import "github.com/docker/docker/daemon/graphdriver/graphte
 
 import (
 	"bytes"
+	"crypto/rand"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"path"
 	"testing"

--- a/daemon/graphdriver/graphtest/graphtest_unix.go
+++ b/daemon/graphdriver/graphtest/graphtest_unix.go
@@ -8,9 +8,7 @@ import (
 	"math/rand"
 	"os"
 	"path"
-	"reflect"
 	"testing"
-	"unsafe"
 
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/pkg/stringid"
@@ -294,19 +292,11 @@ func DriverTestChanges(t testing.TB, drivername string, driverOptions ...string)
 }
 
 func writeRandomFile(path string, size uint64) error {
-	buf := make([]int64, size/8)
-
-	r := rand.NewSource(0)
-	for i := range buf {
-		buf[i] = r.Int63()
+	data := make([]byte, size)
+	_, err := rand.Read(data)
+	if err != nil {
+		return err
 	}
-
-	// Cast to []byte
-	header := *(*reflect.SliceHeader)(unsafe.Pointer(&buf)) //nolint:govet // FIXME: unsafeptr: possible misuse of reflect.SliceHeader (govet) see https://github.com/moby/moby/issues/42444
-	header.Len *= 8
-	header.Cap *= 8
-	data := *(*[]byte)(unsafe.Pointer(&header)) //nolint:govet // FIXME: unsafeptr: possible misuse of reflect.SliceHeader (govet) see https://github.com/moby/moby/issues/42444
-
 	return ioutil.WriteFile(path, data, 0700)
 }
 


### PR DESCRIPTION
Signed-off-by: Adam Williams <awilliams@mirantis.com>
**- What I did**
Fix unsafe pointer conversion.  Fixes issue [42444](https://github.com/moby/moby/issues/42444)
**- How I did it**
Refactor to just create an array of random bytes instead of int64's and converting to bytes.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

