### PR TITLE
hack/test/unit: run `libnetwork` tests sequentially

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -199,7 +199,7 @@ pipeline {
                             }
                             post {
                                 always {
-                                    junit testResults: 'bundles/junit-report.xml', allowEmptyResults: true
+                                    junit testResults: 'bundles/junit-report*.xml', allowEmptyResults: true
                                 }
                             }
                         }
@@ -238,7 +238,7 @@ pipeline {
                                 sh '''
                                 bundleName=unit
                                 echo "Creating ${bundleName}-bundles.tar.gz"
-                                tar -czvf ${bundleName}-bundles.tar.gz bundles/junit-report.xml bundles/go-test-report.json bundles/profile.out
+                                tar -czvf ${bundleName}-bundles.tar.gz bundles/junit-report*.xml bundles/go-test-report*.json bundles/profile*.out
                                 '''
 
                                 archiveArtifacts artifacts: '*-bundles.tar.gz', allowEmptyArchive: true
@@ -599,7 +599,7 @@ pipeline {
                             }
                             post {
                                 always {
-                                    junit testResults: 'bundles/junit-report.xml', allowEmptyResults: true
+                                    junit testResults: 'bundles/junit-report*.xml', allowEmptyResults: true
                                 }
                             }
                         }
@@ -801,7 +801,7 @@ pipeline {
                             }
                             post {
                                 always {
-                                    junit testResults: 'bundles/junit-report.xml', allowEmptyResults: true
+                                    junit testResults: 'bundles/junit-report*.xml', allowEmptyResults: true
                                 }
                             }
                         }
@@ -1000,7 +1000,7 @@ pipeline {
                             }
                             post {
                                 always {
-                                    junit testResults: 'bundles/junit-report.xml', allowEmptyResults: true
+                                    junit testResults: 'bundles/junit-report*.xml', allowEmptyResults: true
                                 }
                             }
                         }

--- a/hack/test/unit
+++ b/hack/test/unit
@@ -18,16 +18,35 @@ TESTDIRS="${TESTDIRS:-./...}"
 exclude_paths='/vendor/|/integration'
 pkg_list=$(go list $TESTDIRS | grep -vE "($exclude_paths)")
 
-echo "${pkg_list}" | grep --fixed-strings "libnetwork/drivers/bridge" \
+base_pkg_list=$(echo "${pkg_list}" | grep --fixed-strings -v "/libnetwork" || :)
+libnetwork_pkg_list=$(echo "${pkg_list}" | grep --fixed-strings "/libnetwork" || :)
+
+echo "${libnetwork_pkg_list}" | grep --fixed-strings "libnetwork/drivers/bridge" \
 	&& if ! type docker-proxy; then
 		hack/make.sh binary-proxy install-proxy
 	fi
 
 mkdir -p bundles
-gotestsum --format=standard-quiet --jsonfile=bundles/go-test-report.json --junitfile=bundles/junit-report.xml -- \
-	"${BUILDFLAGS[@]}" \
-	-cover \
-	-coverprofile=bundles/profile.out \
-	-covermode=atomic \
-	${TESTFLAGS} \
-	${pkg_list}
+
+if [ -n "${base_pkg_list}" ]; then
+	gotestsum --format=standard-quiet --jsonfile=bundles/go-test-report.json --junitfile=bundles/junit-report.xml -- \
+		"${BUILDFLAGS[@]}" \
+		-cover \
+		-coverprofile=bundles/profile.out \
+		-covermode=atomic \
+		${TESTFLAGS} \
+		${base_pkg_list}
+fi
+if [ -n "${libnetwork_pkg_list}" ]; then
+	# libnetwork tests invoke iptables, and cannot be run in parallel. Execute
+	# tests within /libnetwork with '-p=1' to run them sequentially. See
+	# https://github.com/moby/moby/issues/42458#issuecomment-873216754 for details.
+	gotestsum --format=standard-quiet --jsonfile=bundles/go-test-report-libnetwork.json --junitfile=bundles/junit-report-libnetwork.xml -- \
+		"${BUILDFLAGS[@]}" \
+		-cover \
+		-coverprofile=bundles/profile-libnetwork.out \
+		-covermode=atomic \
+		-p=1 \
+		${TESTFLAGS} \
+		${libnetwork_pkg_list}
+fi


### PR DESCRIPTION
**- What I did**
Run `libnetwork` tests sequentially. See https://github.com/moby/moby/issues/42458#issuecomment-873216754 for explanation.
Closes #42458 maybe more

Note, that many tests in `libnetwork/...` already depend on the assumption that they are run sequentially and do not "easily" support things like `-run` due to that fact. E.g. this test is a prime example of such behavior: https://github.com/moby/moby/blob/45b45ad65b6f4a76f2bd0f768ef6edb10ebcc0bc/libnetwork/iptables/iptables_test.go#L1-L327

I, personally, don't think that `-p=1` is the "correct" solution here. Although, to do this "right" I think we'd have to rewrite a large portion of `libnetwork` tests and I do not think that is worth it at this point.

**- How I did it**
Run `gotestsum` at most twice and pass `-p=1` when running unit tests in `/libnetwork` namespace

**- How to verify it**
e.g. `TESTDIRS='github.com/docker/docker/libnetwork/iptables github.com/docker/docker/libnetwork/drivers/bridge' make test-unit` should pass (and sometimes fail without this change)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

