### PR TITLE
API: fix 404 status description on container create

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5583,12 +5583,12 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
         404:
-          description: "no such container"
+          description: "no such image"
           schema:
             $ref: "#/definitions/ErrorResponse"
           examples:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              message: "No such image: c2ada9df5af8"
         409:
           description: "conflict"
           schema:

--- a/docs/api/v1.18.md
+++ b/docs/api/v1.18.md
@@ -317,7 +317,7 @@ Create a container
 
 -   **201** – no error
 -   **400** – bad parameter
--   **404** – no such container
+-   **404** – no such image
 -   **406** – impossible to attach (container not running)
 -   **409** – conflict
 -   **500** – server error

--- a/docs/api/v1.19.md
+++ b/docs/api/v1.19.md
@@ -327,7 +327,7 @@ Create a container
 
 -   **201** – no error
 -   **400** – bad parameter
--   **404** – no such container
+-   **404** – no such image
 -   **406** – impossible to attach (container not running)
 -   **409** – conflict
 -   **500** – server error

--- a/docs/api/v1.20.md
+++ b/docs/api/v1.20.md
@@ -331,7 +331,7 @@ Create a container
 
 -   **201** – no error
 -   **400** – bad parameter
--   **404** – no such container
+-   **404** – no such image
 -   **406** – impossible to attach (container not running)
 -   **409** – conflict
 -   **500** – server error

--- a/docs/api/v1.21.md
+++ b/docs/api/v1.21.md
@@ -352,7 +352,7 @@ Create a container
 
 -   **201** – no error
 -   **400** – bad parameter
--   **404** – no such container
+-   **404** – no such image
 -   **406** – impossible to attach (container not running)
 -   **409** – conflict
 -   **500** – server error

--- a/docs/api/v1.22.md
+++ b/docs/api/v1.22.md
@@ -467,7 +467,7 @@ Create a container
 
 -   **201** – no error
 -   **400** – bad parameter
--   **404** – no such container
+-   **404** – no such image
 -   **406** – impossible to attach (container not running)
 -   **409** – conflict
 -   **500** – server error

--- a/docs/api/v1.23.md
+++ b/docs/api/v1.23.md
@@ -493,7 +493,7 @@ Create a container
 
 -   **201** – no error
 -   **400** – bad parameter
--   **404** – no such container
+-   **404** – no such image
 -   **406** – impossible to attach (container not running)
 -   **409** – conflict
 -   **500** – server error

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -535,7 +535,7 @@ Create a container
 
 -   **201** – no error
 -   **400** – bad parameter
--   **404** – no such container
+-   **404** – no such image
 -   **406** – impossible to attach (container not running)
 -   **409** – conflict
 -   **500** – server error

--- a/docs/api/v1.25.yaml
+++ b/docs/api/v1.25.yaml
@@ -2786,12 +2786,12 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
         404:
-          description: "no such container"
+          description: "no such image"
           schema:
             $ref: "#/definitions/ErrorResponse"
           examples:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              message: "No such image: c2ada9df5af8"
         406:
           description: "impossible to attach"
           schema:

--- a/docs/api/v1.26.yaml
+++ b/docs/api/v1.26.yaml
@@ -2791,12 +2791,12 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
         404:
-          description: "no such container"
+          description: "no such image"
           schema:
             $ref: "#/definitions/ErrorResponse"
           examples:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              message: "No such image: c2ada9df5af8"
         406:
           description: "impossible to attach"
           schema:

--- a/docs/api/v1.27.yaml
+++ b/docs/api/v1.27.yaml
@@ -2851,12 +2851,12 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
         404:
-          description: "no such container"
+          description: "no such image"
           schema:
             $ref: "#/definitions/ErrorResponse"
           examples:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              message: "No such image: c2ada9df5af8"
         406:
           description: "impossible to attach"
           schema:

--- a/docs/api/v1.28.yaml
+++ b/docs/api/v1.28.yaml
@@ -2941,12 +2941,12 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
         404:
-          description: "no such container"
+          description: "no such image"
           schema:
             $ref: "#/definitions/ErrorResponse"
           examples:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              message: "No such image: c2ada9df5af8"
         406:
           description: "impossible to attach"
           schema:

--- a/docs/api/v1.29.yaml
+++ b/docs/api/v1.29.yaml
@@ -2975,12 +2975,12 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
         404:
-          description: "no such container"
+          description: "no such image"
           schema:
             $ref: "#/definitions/ErrorResponse"
           examples:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              message: "No such image: c2ada9df5af8"
         406:
           description: "impossible to attach"
           schema:

--- a/docs/api/v1.30.yaml
+++ b/docs/api/v1.30.yaml
@@ -3181,12 +3181,12 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
         404:
-          description: "no such container"
+          description: "no such image"
           schema:
             $ref: "#/definitions/ErrorResponse"
           examples:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              message: "No such image: c2ada9df5af8"
         406:
           description: "impossible to attach"
           schema:

--- a/docs/api/v1.31.yaml
+++ b/docs/api/v1.31.yaml
@@ -3251,12 +3251,12 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
         404:
-          description: "no such container"
+          description: "no such image"
           schema:
             $ref: "#/definitions/ErrorResponse"
           examples:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              message: "No such image: c2ada9df5af8"
         406:
           description: "impossible to attach"
           schema:

--- a/docs/api/v1.32.yaml
+++ b/docs/api/v1.32.yaml
@@ -4494,12 +4494,12 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
         404:
-          description: "no such container"
+          description: "no such image"
           schema:
             $ref: "#/definitions/ErrorResponse"
           examples:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              message: "No such image: c2ada9df5af8"
         409:
           description: "conflict"
           schema:

--- a/docs/api/v1.33.yaml
+++ b/docs/api/v1.33.yaml
@@ -4499,12 +4499,12 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
         404:
-          description: "no such container"
+          description: "no such image"
           schema:
             $ref: "#/definitions/ErrorResponse"
           examples:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              message: "No such image: c2ada9df5af8"
         409:
           description: "conflict"
           schema:

--- a/docs/api/v1.34.yaml
+++ b/docs/api/v1.34.yaml
@@ -4528,12 +4528,12 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
         404:
-          description: "no such container"
+          description: "no such image"
           schema:
             $ref: "#/definitions/ErrorResponse"
           examples:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              message: "No such image: c2ada9df5af8"
         409:
           description: "conflict"
           schema:

--- a/docs/api/v1.35.yaml
+++ b/docs/api/v1.35.yaml
@@ -4510,12 +4510,12 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
         404:
-          description: "no such container"
+          description: "no such image"
           schema:
             $ref: "#/definitions/ErrorResponse"
           examples:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              message: "No such image: c2ada9df5af8"
         409:
           description: "conflict"
           schema:

--- a/docs/api/v1.36.yaml
+++ b/docs/api/v1.36.yaml
@@ -4525,12 +4525,12 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
         404:
-          description: "no such container"
+          description: "no such image"
           schema:
             $ref: "#/definitions/ErrorResponse"
           examples:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              message: "No such image: c2ada9df5af8"
         409:
           description: "conflict"
           schema:

--- a/docs/api/v1.37.yaml
+++ b/docs/api/v1.37.yaml
@@ -4545,12 +4545,12 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
         404:
-          description: "no such container"
+          description: "no such image"
           schema:
             $ref: "#/definitions/ErrorResponse"
           examples:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              message: "No such image: c2ada9df5af8"
         409:
           description: "conflict"
           schema:

--- a/docs/api/v1.38.yaml
+++ b/docs/api/v1.38.yaml
@@ -4599,12 +4599,12 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
         404:
-          description: "no such container"
+          description: "no such image"
           schema:
             $ref: "#/definitions/ErrorResponse"
           examples:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              message: "No such image: c2ada9df5af8"
         409:
           description: "conflict"
           schema:

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -5294,12 +5294,12 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
         404:
-          description: "no such container"
+          description: "no such image"
           schema:
             $ref: "#/definitions/ErrorResponse"
           examples:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              message: "No such image: c2ada9df5af8"
         409:
           description: "conflict"
           schema:

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -5425,12 +5425,12 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
         404:
-          description: "no such container"
+          description: "no such image"
           schema:
             $ref: "#/definitions/ErrorResponse"
           examples:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              message: "No such image: c2ada9df5af8"
         409:
           description: "conflict"
           schema:


### PR DESCRIPTION
This updates the current swagger file, and all docs versions with the same fix as ff1d9a3ec52e559443c7d36561c903755e57fa7d (https://github.com/moby/moby/pull/42047)

