### PR TITLE
seccomp: Sync fields with runtime-spec fields

### DIFF
--- a/profiles/seccomp/seccomp.go
+++ b/profiles/seccomp/seccomp.go
@@ -11,7 +11,11 @@ import (
 
 // Seccomp represents the config for a seccomp profile for syscall restriction.
 type Seccomp struct {
-	DefaultAction specs.LinuxSeccompAction `json:"defaultAction"`
+	DefaultAction    specs.LinuxSeccompAction `json:"defaultAction"`
+	DefaultErrnoRet  *uint                    `json:"defaultErrnoRet,omitempty"`
+	ListenerPath     string                   `json:"listenerPath,omitempty"`
+	ListenerMetadata string                   `json:"listenerMetadata,omitempty"`
+
 	// Architectures is kept to maintain backward compatibility with the old
 	// seccomp profile.
 	Architectures []specs.Arch   `json:"architectures,omitempty"`

--- a/profiles/seccomp/seccomp_linux.go
+++ b/profiles/seccomp/seccomp_linux.go
@@ -107,6 +107,9 @@ func setupSeccomp(config *Seccomp, rs *specs.Spec) (*specs.LinuxSeccomp, error) 
 	}
 
 	newConfig.DefaultAction = config.DefaultAction
+	newConfig.DefaultErrnoRet = config.DefaultErrnoRet
+	newConfig.ListenerPath = config.ListenerPath
+	newConfig.ListenerMetadata = config.ListenerMetadata
 
 Loop:
 	// Loop through all syscall blocks and convert them to libcontainer format after filtering them

--- a/profiles/seccomp/seccomp_test.go
+++ b/profiles/seccomp/seccomp_test.go
@@ -59,6 +59,47 @@ func TestLoadProfile(t *testing.T) {
 	assert.DeepEqual(t, expected, *p)
 }
 
+func TestLoadProfileWithDefaultErrnoRet(t *testing.T) {
+	var profile = []byte(`{
+"defaultAction": "SCMP_ACT_ERRNO",
+"defaultErrnoRet": 6
+}`)
+	rs := createSpec()
+	p, err := LoadProfile(string(profile), &rs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedErrnoRet := uint(6)
+	expected := specs.LinuxSeccomp{
+		DefaultAction:   "SCMP_ACT_ERRNO",
+		DefaultErrnoRet: &expectedErrnoRet,
+	}
+
+	assert.DeepEqual(t, expected, *p)
+}
+
+func TestLoadProfileWithListenerPath(t *testing.T) {
+	var profile = []byte(`{
+"defaultAction": "SCMP_ACT_ERRNO",
+"listenerPath": "/var/run/seccompaget.sock",
+"listenerMetadata": "opaque-metadata"
+}`)
+	rs := createSpec()
+	p, err := LoadProfile(string(profile), &rs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := specs.LinuxSeccomp{
+		DefaultAction:    "SCMP_ACT_ERRNO",
+		ListenerPath:     "/var/run/seccompaget.sock",
+		ListenerMetadata: "opaque-metadata",
+	}
+
+	assert.DeepEqual(t, expected, *p)
+}
+
 // TestLoadLegacyProfile tests loading a seccomp profile in the old format
 // (before https://github.com/docker/docker/pull/24510)
 func TestLoadLegacyProfile(t *testing.T) {


### PR DESCRIPTION
The runtime spec we are using has support for these 3 fields[1], but
moby doesn't have them in its seccomp struct. This patch just adds and
copies them when they are in the profile.

DefaultErrnoRet is implemented in the runc version moby is using (it is
implemented since runc-rc95[2]) but if we create a container without
this moby patch, we don't see an error nor the expected behavior. This
is not clear for the user (the profile they specify is valid, the syntax
is ok, but the wrong behavior is seen).

This is because the DefaultErrnoRet field is not copied to the config
passed ultimately to runc (i.e. is like the field was not specified).
With this patch, we see the expected behavior.

The other two fileds are in the runtime-spec but not yet in runc (a PR
is open and targets 1.1.0 milestone[3]). However, I took the liberty to
copy them now too for two reasons:

1. If we don't add them now and end up using a runc version that
supports them, then the error that the user will see is not clear at
all:

	docker: Error response from daemon: OCI runtime create failed: container_linux.go:380: starting container process caused: listenerPath is not set: unknown.

And it is not obvious to debug for the user, as the field _is_ set in
the profile they specify (just not copied by moby to the profile moby
specifies ultimately to runc).

2. When using a runc without seccomp notify support (like today), the
error we see is the same with and without this moby patch (when using a
seccomp profile with the new fields):

	docker: Error response from daemon: OCI runtime create failed: string SCMP_ACT_NOTIFY is not a valid action for seccomp: unknown.

Then, it seems like a clear win to add them now: we don't have to do it
later (that implies not clear errors to the user if we forget, like we
did with DefaultErrnoRet) and the user sees the exact same error when
using a runc version that doesn't support these fields.

[1]: Note we are vendoring version 1c3f411f041711bbeecf35ff7e93461ea6789220 and this version has these 3 fields https://github.com/opencontainers/runtime-spec/blob/1c3f411f041711bbeecf35ff7e93461ea6789220/config-linux.md#seccomp
[2]: https://github.com/opencontainers/runc/pull/2954/
[3]: https://github.com/opencontainers/runc/pull/2682

Signed-off-by: Rodrigo Campos <rodrigo@kinvolk.io>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Sync moby struct seccomp fields with runtime-spec seccomp fields. This makes DefaultErrnoRet field in the seccomp spec work and prepares for other runc changes in the future. 

**- How I did it**
Added the fields to the moby struct and copied them.

**- How to verify it**

I tested this with runc 1.0 compiled locally, but should work with runc-rc95 too.

Download the attached  [seccomp-defaulterrno.txt](https://github.com/moby/moby/files/6778728/seccomp-defaulterrno.txt), let's say you save it as /tmp/seccomp-default-errno.txt.

Then, you should expect the following when running dockerd with this patch:

```
docker run --rm -it --security-opt seccomp=/tmp/seccomp-defaulterrno.txt debian mkdir a`
mkdir: cannot create directory 'a': No such device or address
```
This is because the seccomp profile is using errno 6:
```
$ errno 6
ENXIO 6 No such device or address
```
If you run dockerd without this patch, you should see EPERM (the DefaultErrnoRet option is ignored without this patch, and therefore it defaults to EPERM):

```
$ docker run --rm -it --security-opt seccomp=/tmp/seccomp-defaulterrno.txt debian mkdir a
mkdir: cannot create directory 'a': Operation not permitted
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Honor DefaultErrnoRet in seccomp profile

**- A picture of a cute animal (not mandatory but encouraged)**
Of course I chose a rat :smile: 

![](https://www.kinderundjugendmedien.de/images/Ratatouille_pixar.jpg)

