### PR TITLE
Ensure empty build cache is represented as empty JSON array

### DIFF
--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -120,6 +120,11 @@ func (s *systemRouter) getDiskUsage(ctx context.Context, w http.ResponseWriter, 
 
 	du.BuilderSize = builderSize
 	du.BuildCache = buildCache
+	if buildCache == nil {
+		// Ensure empty `BuildCache` field is represented as empty JSON array(`[]`)
+		// instead of `null` to be consistent with `Images`, `Containers` etc.
+		du.BuildCache = []*types.BuildCache{}
+	}
 
 	return httputils.WriteJSON(w, http.StatusOK, du)
 }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8339,7 +8339,29 @@ paths:
                   UsageData:
                     Size: 10920104
                     RefCount: 2
-              BuildCache: []
+              BuildCache:
+                -
+                  ID: "hw53o5aio51xtltp5xjp8v7fx"
+                  Parent: ""
+                  Type: "regular"
+                  Description: "pulled from docker.io/library/debian@sha256:234cb88d3020898631af0ccbbcca9a66ae7306ecd30c9720690858c1b007d2a0"
+                  InUse: false
+                  Shared: true
+                  Size: 0
+                  CreatedAt: "2021-06-28T13:31:01.474619385Z"
+                  LastUsedAt: "2021-07-07T22:02:32.738075951Z"
+                  UsageCount: 26
+                -
+                  ID: "ndlpt0hhvkqcdfkputsk4cq9c"
+                  Parent: "hw53o5aio51xtltp5xjp8v7fx"
+                  Type: "regular"
+                  Description: "mount / from exec /bin/sh -c echo 'Binary::apt::APT::Keep-Downloaded-Packages \"true\";' > /etc/apt/apt.conf.d/keep-cache"
+                  InUse: false
+                  Shared: true
+                  Size: 51
+                  CreatedAt: "2021-06-28T13:31:03.002625487Z"
+                  LastUsedAt: "2021-07-07T22:02:32.773909517Z"
+                  UsageCount: 26
         500:
           description: "server error"
           schema:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8339,6 +8339,7 @@ paths:
                   UsageData:
                     Size: 10920104
                     RefCount: 2
+              BuildCache: []
         500:
           description: "server error"
           schema:


### PR DESCRIPTION
Closes #42605 Refs https://github.com/moby/moby/pull/42605#discussion_r666055470
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Ensure empty `BuildCache` field is represented as empty JSON array(`[]`) instead of `null` to be consistent with `Images`, `Containers` etc.

**- How I did it**
Initialize the struct field with an empty slice if `buildCache` is `nil`.
Note, the empty slice could be potentially defined as global variable and reused to avoid unnecessary allocations, but that is an optimization not worth doing here in my opinion

**- How to verify it**
`curl -s --unix-socket /var/run/docker.sock http://localhost/system/df | jq` on empty daemon should output:
```json
{
  "LayersSize": 0,
  "Images": [],
  "Containers": [],
  "Volumes": [],
  "BuildCache": [],
  "BuilderSize": 0
}
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

