### PR TITLE
Deprecate `BuilderSize` in API versions >= 1.42

### DIFF
--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -113,12 +113,14 @@ func (s *systemRouter) getDiskUsage(ctx context.Context, w http.ResponseWriter, 
 		return err
 	}
 
-	var builderSize int64
-	for _, b := range buildCache {
-		builderSize += b.Size
+	if versions.LessThan(httputils.VersionFromContext(ctx), "1.42") {
+		var builderSize int64
+		for _, b := range buildCache {
+			builderSize += b.Size
+		}
+		du.BuilderSize = builderSize
 	}
 
-	du.BuilderSize = builderSize
 	du.BuildCache = buildCache
 	if buildCache == nil {
 		// Ensure empty `BuildCache` field is represented as empty JSON array(`[]`)

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -538,7 +538,7 @@ type DiskUsage struct {
 	Containers  []*Container
 	Volumes     []*Volume
 	BuildCache  []*BuildCache
-	BuilderSize int64 // deprecated
+	BuilderSize int64 `json:",omitempty"` // Deprecated: deprecated in API 1.38, and no longer used since API 1.40.
 }
 
 // ContainersPruneReport contains the response for Engine API:

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -17,6 +17,11 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.42](https://docs.docker.com/engine/api/v1.42/) documentation
 
+* Removed the `BuilderSize` field on the `GET /system/df` endpoint. This field
+  was introduced in API 1.31 as part of an experimental feature, and no longer
+  used since API 1.40.
+  Use field `BuildCache` instead to track storage used by the builder component.
+
 ## v1.41 API changes
 
 [Docker Engine API v1.41](https://docs.docker.com/engine/api/v1.41/) documentation


### PR DESCRIPTION
Refs https://github.com/moby/moby/pull/42605#discussion_r666065924

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Ensure `BuilderSize` is not set for API versions >= 1.42

**- How I did it**
- Add a version check in the router
- Add `omitempty` JSON tag
- Document in version history doc

**- How to verify it**
```
curl -s --unix-socket /var/run/docker.sock http://localhost/system/df | jq
```
Should not show `BuilderSize` field

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

