### PR TITLE
Improve swagger.yaml to match the 1.41 api version

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -382,11 +382,13 @@ definitions:
         type: "string"
         description: |
           - Empty string means not to restart
+          - `no` Do not automatically restart
           - `always` Always restart
           - `unless-stopped` Restart always except when the user has manually stopped the container
           - `on-failure` Restart only when the container exit code is non-zero
         enum:
           - ""
+          - "no"
           - "always"
           - "unless-stopped"
           - "on-failure"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4024,73 +4024,71 @@ definitions:
       Warning: "unable to pin image doesnotexist:latest to digest: image library/doesnotexist:latest not found"
 
   ContainerSummary:
-    type: "array"
-    items:
-      type: "object"
-      properties:
-        Id:
-          description: "The ID of this container"
+    type: "object"
+    properties:
+      Id:
+        description: "The ID of this container"
+        type: "string"
+        x-go-name: "ID"
+      Names:
+        description: "The names that this container has been given"
+        type: "array"
+        items:
           type: "string"
-          x-go-name: "ID"
-        Names:
-          description: "The names that this container has been given"
-          type: "array"
-          items:
+      Image:
+        description: "The name of the image used when creating this container"
+        type: "string"
+      ImageID:
+        description: "The ID of the image that this container was created from"
+        type: "string"
+      Command:
+        description: "Command to run when starting the container"
+        type: "string"
+      Created:
+        description: "When the container was created"
+        type: "integer"
+        format: "int64"
+      Ports:
+        description: "The ports exposed by this container"
+        type: "array"
+        items:
+          $ref: "#/definitions/Port"
+      SizeRw:
+        description: "The size of files that have been created or changed by this container"
+        type: "integer"
+        format: "int64"
+      SizeRootFs:
+        description: "The total size of all the files in this container"
+        type: "integer"
+        format: "int64"
+      Labels:
+        description: "User-defined key/value metadata."
+        type: "object"
+        additionalProperties:
+          type: "string"
+      State:
+        description: "The state of this container (e.g. `Exited`)"
+        type: "string"
+      Status:
+        description: "Additional human-readable status of this container (e.g. `Exit 0`)"
+        type: "string"
+      HostConfig:
+        type: "object"
+        properties:
+          NetworkMode:
             type: "string"
-        Image:
-          description: "The name of the image used when creating this container"
-          type: "string"
-        ImageID:
-          description: "The ID of the image that this container was created from"
-          type: "string"
-        Command:
-          description: "Command to run when starting the container"
-          type: "string"
-        Created:
-          description: "When the container was created"
-          type: "integer"
-          format: "int64"
-        Ports:
-          description: "The ports exposed by this container"
-          type: "array"
-          items:
-            $ref: "#/definitions/Port"
-        SizeRw:
-          description: "The size of files that have been created or changed by this container"
-          type: "integer"
-          format: "int64"
-        SizeRootFs:
-          description: "The total size of all the files in this container"
-          type: "integer"
-          format: "int64"
-        Labels:
-          description: "User-defined key/value metadata."
-          type: "object"
-          additionalProperties:
-            type: "string"
-        State:
-          description: "The state of this container (e.g. `Exited`)"
-          type: "string"
-        Status:
-          description: "Additional human-readable status of this container (e.g. `Exit 0`)"
-          type: "string"
-        HostConfig:
-          type: "object"
-          properties:
-            NetworkMode:
-              type: "string"
-        NetworkSettings:
-          description: "A summary of the container's network settings"
-          type: "object"
-          properties:
-            Networks:
-              type: "object"
-              additionalProperties:
-                $ref: "#/definitions/EndpointSettings"
-        Mounts:
-          type: "array"
-          items:
-            $ref: "#/definitions/Mount"
+      NetworkSettings:
+        description: "A summary of the container's network settings"
+        type: "object"
+        properties:
+          Networks:
+            type: "object"
+            additionalProperties:
+              $ref: "#/definitions/EndpointSettings"
+      Mounts:
+        type: "array"
+        items:
+          $ref: "#/definitions/Mount"
 
   Driver:
     description: "Driver represents a driver (network, logging, secrets)."
@@ -5263,7 +5261,9 @@ paths:
         200:
           description: "no error"
           schema:
-            $ref: "#/definitions/ContainerSummary"
+            type: "array"
+            items:
+              $ref: "#/definitions/ContainerSummary"
           examples:
             application/json:
               - Id: "8dfafdbc3a40"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4366,7 +4366,6 @@ definitions:
         type: "string"
         example: "2020-06-22T15:49:27.000000000+00:00"
 
-
   SystemInfo:
     type: "object"
     properties:
@@ -8545,6 +8544,7 @@ paths:
           description: "Exec configuration"
           schema:
             type: "object"
+            title: "ExecConfig"
             properties:
               AttachStdin:
                 type: "boolean"
@@ -8635,6 +8635,7 @@ paths:
           in: "body"
           schema:
             type: "object"
+            title: "ExecStartConfig"
             properties:
               Detach:
                 type: "boolean"
@@ -9169,6 +9170,7 @@ paths:
           required: true
           schema:
             type: "object"
+            title: "NetworkCreateRequest"
             required: ["Name"]
             properties:
               Name:
@@ -9279,6 +9281,7 @@ paths:
           required: true
           schema:
             type: "object"
+            title: "NetworkConnectRequest"
             properties:
               Container:
                 type: "string"
@@ -9325,6 +9328,7 @@ paths:
           required: true
           schema:
             type: "object"
+            title: "NetworkDisconnectRequest"
             properties:
               Container:
                 type: "string"
@@ -9984,6 +9988,7 @@ paths:
           required: true
           schema:
             type: "object"
+            title: "SwarmInitRequest"
             properties:
               ListenAddr:
                 description: |
@@ -10082,6 +10087,7 @@ paths:
           required: true
           schema:
             type: "object"
+            title: "SwarmJoinRequest"
             properties:
               ListenAddr:
                 description: |
@@ -10242,6 +10248,7 @@ paths:
           required: true
           schema:
             type: "object"
+            title: "SwarmUnlockRequest"
             properties:
               UnlockKey:
                 description: "The swarm's unlock key."

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2190,6 +2190,24 @@ definitions:
         type: "string"
         x-nullable: false
 
+  PluginPrivilegeItem:
+    description: |
+      Describes a permission the user has to accept upon installing
+      the plugin.
+    type: "object"
+    properties:
+      Name:
+        type: "string"
+        example: "network"
+      Description:
+        type: "string"
+      Value:
+        type: "array"
+        items:
+          type: "string"
+        example:
+          - "host"
+
   Plugin:
     description: "A plugin for the Engine API"
     type: "object"
@@ -2972,19 +2990,7 @@ definitions:
           PluginPrivilege:
             type: "array"
             items:
-              description: |
-                Describes a permission accepted by the user upon installing the
-                plugin.
-              type: "object"
-              properties:
-                Name:
-                  type: "string"
-                Description:
-                  type: "string"
-                Value:
-                  type: "array"
-                  items:
-                    type: "string"
+              $ref: "#/definitions/PluginPrivilegeItem"
       ContainerSpec:
         type: "object"
         description: |
@@ -9413,20 +9419,7 @@ paths:
           schema:
             type: "array"
             items:
-              description: |
-                Describes a permission the user has to accept upon installing
-                the plugin.
-              type: "object"
-              title: "PluginPrivilegeItem"
-              properties:
-                Name:
-                  type: "string"
-                Description:
-                  type: "string"
-                Value:
-                  type: "array"
-                  items:
-                    type: "string"
+              $ref: "#/definitions/PluginPrivilegeItem"
             example:
               - Name: "network"
                 Description: ""
@@ -9502,19 +9495,7 @@ paths:
           schema:
             type: "array"
             items:
-              description: |
-                Describes a permission accepted by the user upon installing the
-                plugin.
-              type: "object"
-              properties:
-                Name:
-                  type: "string"
-                Description:
-                  type: "string"
-                Value:
-                  type: "array"
-                  items:
-                    type: "string"
+              $ref: "#/definitions/PluginPrivilegeItem"
             example:
               - Name: "network"
                 Description: ""
@@ -9686,19 +9667,7 @@ paths:
           schema:
             type: "array"
             items:
-              description: |
-                Describes a permission accepted by the user upon installing the
-                plugin.
-              type: "object"
-              properties:
-                Name:
-                  type: "string"
-                Description:
-                  type: "string"
-                Value:
-                  type: "array"
-                  items:
-                    type: "string"
+              $ref: "#/definitions/PluginPrivilegeItem"
             example:
               - Name: "network"
                 Description: ""

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -7507,6 +7507,18 @@ paths:
             Refer to the [authentication section](#section/Authentication) for
             details.
           type: "string"
+        - name: "changes"
+          in: "query"
+          description: |
+            Apply `Dockerfile` instructions to the image that is created,
+            for example: `changes=ENV DEBUG=true`.
+            Note that `ENV DEBUG=true` should be URI component encoded.
+
+            Supported `Dockerfile` instructions:
+            `CMD`|`ENTRYPOINT`|`ENV`|`EXPOSE`|`ONBUILD`|`USER`|`VOLUME`|`WORKDIR`
+          type: "array"
+          items:
+            type: "string"
         - name: "platform"
           in: "query"
           description: "Platform in the format os[/arch[/variant]]"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -11339,14 +11339,14 @@ paths:
                 description: |
                   A descriptor struct containing digest, media type, and size.
                 properties:
-                  MediaType:
+                  mediaType:
                     type: "string"
-                  Size:
+                  size:
                     type: "integer"
                     format: "int64"
-                  Digest:
+                  digest:
                     type: "string"
-                  URLs:
+                  urls:
                     type: "array"
                     items:
                       type: "string"
@@ -11357,17 +11357,17 @@ paths:
                 items:
                   type: "object"
                   properties:
-                    Architecture:
+                    architecture:
                       type: "string"
-                    OS:
+                    os:
                       type: "string"
-                    OSVersion:
+                    os.version:
                       type: "string"
-                    OSFeatures:
+                    os.features:
                       type: "array"
                       items:
                         type: "string"
-                    Variant:
+                    variant:
                       type: "string"
                     Features:
                       type: "array"
@@ -11382,12 +11382,12 @@ paths:
                 URLs:
                   - ""
               Platforms:
-                - Architecture: "amd64"
-                  OS: "linux"
-                  OSVersion: ""
-                  OSFeatures:
+                - architecture: "amd64"
+                  os: "linux"
+                  os.version: ""
+                  os.features:
                     - ""
-                  Variant: ""
+                  variant: ""
                   Features:
                     - ""
         401:


### PR DESCRIPTION
I recently tried to rely on the swagger.yaml for code generation of an api client. Some parts required manual fixes of the swagger docs to match the current api version 1.41.

All changes described below relate to a dedicated commit, because they aim at different parts of the api description and aren't releated per se. If you'd prefer to merge them all into a single commit, please leave a note.

**- What I did**

1. Add RestartPolicy "no" to swagger docs
2. Add "changes" query parameter for /image/create to swagger docs
3. Fix ContainerSummary swagger docs (flattened)
4. Use explicit object names for improved swagger based code generation (otherwise generic names had been generated)
5. Fix swagger docs to match the [opencontainers image-spec](https://github.com/opencontainers/image-spec/blob/5ced465cc63831baf25330431a428a9d9444e192/specs-go/v1/descriptor.go)

**- How I did it**

Used the 1.41 swagger.yaml with swagger's codegen to generate Java code. Used that code to perform requests to a 1.41 Docker engine. Applied some fixes and `hack/validate/swagger` and `make swagger-docs` to validate the changes.

**- How to verify it**

Compare the actual 1.41 api with the swagger.yaml.

**- Description for the changelog**

Update the swagger.yaml to match the version 1.41 api.

**- A picture of a cute animal (not mandatory but encouraged)**

![062321_JC_mountain-cat_feat](https://user-images.githubusercontent.com/432791/125209896-77588e80-e29c-11eb-9a5f-439f5f04a69b.jpeg)
