### PR TITLE
Remove containerd "platform" dependency from client

### DIFF
--- a/client/container_create.go
+++ b/client/container_create.go
@@ -16,7 +16,6 @@ type configWrapper struct {
 	*container.Config
 	HostConfig       *container.HostConfig
 	NetworkingConfig *network.NetworkingConfig
-	Platform         *specs.Platform
 }
 
 // ContainerCreate creates a new container based on the given configuration.

--- a/client/container_create.go
+++ b/client/container_create.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"net/url"
+	"path"
 
-	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/versions"
@@ -37,8 +37,8 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 	}
 
 	query := url.Values{}
-	if platform != nil {
-		query.Set("platform", platforms.Format(*platform))
+	if p := formatPlatform(platform); p != "" {
+		query.Set("platform", p)
 	}
 
 	if containerName != "" {
@@ -59,4 +59,16 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 
 	err = json.NewDecoder(serverResp.body).Decode(&response)
 	return response, err
+}
+
+// formatPlatform returns a formatted string representing platform (e.g. linux/arm/v7).
+//
+// Similar to containerd's platforms.Format(), but does allow components to be
+// omitted (e.g. pass "architecture" only, without "os":
+// https://github.com/containerd/containerd/blob/v1.5.2/platforms/platforms.go#L243-L263
+func formatPlatform(platform *specs.Platform) string {
+	if platform == nil {
+		return ""
+	}
+	return path.Join(platform.OS, platform.Architecture, platform.Variant)
 }


### PR DESCRIPTION
Note: once / if https://github.com/moby/moby/pull/42464 is merged/accepted, we should consider replacing `github.com/opencontainers/image-spec/specs-go/v1.Platform` with our own `ImagePlatform`, to remove the OCI spec from the API (if possible). If we do so, we can also remove the `formatPlatform` function here (as it would be provided by `ImagePlatform.String()`


This removes some of the containerd dependencies from the client:

- client: remove unused Platform field from configWrapper
    This field was added in 7a9cb29fb980c0ab3928272cdc24c7089b2fcf64, but appears to be unused, so removing it.
- client: remove containerd "platform" dependency


After this, there's no _direct_ dependency on containerd, but the `errdefs`  package still depends on containerd's errdefs. package. I'll have a look if we can refactor so that that doesn't end up in the client package. 
