### PR TITLE
Support small ipv4 networks

### DIFF
--- a/libnetwork/ipam/allocator.go
+++ b/libnetwork/ipam/allocator.go
@@ -348,12 +348,15 @@ func (a *Allocator) insertBitMask(key SubnetKey, pool *net.IPNet) error {
 		return err
 	}
 
-	// Do not let network identifier address be reserved
-	// Do the same for IPv6 so that bridge ip starts with XXXX...::1
-	h.Set(0)
+	// Pre-reserve the network address on IPv4 networks large
+	// enough to have one (i.e., anything bigger than a /31.
+	if !(ipVer == v4 && numAddresses <= 2) {
+		h.Set(0)
+	}
 
-	// Do not let broadcast address be reserved
-	if ipVer == v4 {
+	// Pre-reserve the broadcast address on IPv4 networks large
+	// enough to have one (i.e., anything bigger than a /31).
+	if ipVer == v4 && numAddresses > 2 {
 		h.Set(numAddresses - 1)
 	}
 


### PR DESCRIPTION
This was originally in https://github.com/moby/libnetwork/pull/2624, which has been closed since the code was moved here.  It fixes #32444 and https://github.com/moby/libnetwork/issues/2249.

## What I did

When creating a new network, IPAM's address allocator attempts to reserve the network and broadcast addresses on IPv4 networks of all sizes. For RFC 3021 point-to-point networks (IPv4 /31s), this consumes both available addresses and renders any attempt to allocate an address from the block unsuccessful. 

This change prevents those reservations from taking place on IPv4 networks having two or fewer addresses (i.e., /31s and /32s) while retaining the existing behavior for larger IPv4 blocks and all IPv6 blocks.

In case you're wondering why anyone would allocate /31s:  I work for a network service provider.  We use a lot of point-to-point networks.  This cuts our address space utilization for those by 50%, which makes ARIN happy.

## How I did it

The network allocator was modified to recognize when an network is too small for network and broadcast addresses and skip those reservations.

## How to verify it

There are additional unit tests to make sure the functions involved behave as expected.

Try these out:
 * `docker network create --driver bridge --subnet 10.200.1.0/31 --ip-range 10.200.1.0/31 test-31`
 * `docker network create --driver bridge --subnet 10.200.1.0/32 --ip-range 10.200.1.0/32 test-32`

My installation has been running this patch in production with /31s since March.


## Description for the changelog

Added support for RFC 3021 point-to-point networks (IPv4 /31s) and single hosts (IPv4 /32s).


## A picture of a cute animal (not mandatory but encouraged)

How about Linda Ball's ASCII art bunny?
```
  //
 ('>
 /rr
*\))_
```

