### PR TITLE
Fix up vndr tooling

### DIFF
--- a/hack/validate/vendor
+++ b/hack/validate/vendor
@@ -21,7 +21,7 @@ validate_vendor_diff(){
 				echo
 				echo "$diffs"
 				echo
-				echo 'Please vendor your package with github.com/LK4D4/vndr.'
+				echo 'Please vendor your package with hack/vendor.sh.'
 				echo
 				if [ -n "$mfiles" ] ; then
 					git diff -- "$mfiles"

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -24,5 +24,5 @@ if [ $# -eq 0 ] || [ "$1" = "archive/tar" ]; then
 fi
 
 if [ $# -eq 0 ] || [ "$1" != "archive/tar" ]; then
-	vndr -whitelist=^archive/tar "$@"
+	vndr -whitelist='^archive[/\\]tar' "$@"
 fi


### PR DESCRIPTION
- Fix the error message in hack/validate/vendor to specify that
  hack/vendor.sh should be run instead of vndr.
- Fix hack/vendor.sh to also match on Windows paths for the whitelist.
  This allows the script to be run on Windows via Git Bash.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>