### PR TITLE
Update containerd binary and vendor to v1.5.3

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=36cc874494a56a253cd181a1a685b44b58a2e34a}" # v1.5.2
+: "${CONTAINERD_COMMIT:=0e8719f54c6dc6571fc1170da75a85e86c17636b}" # v1.5.3
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/vendor.conf
+++ b/vendor.conf
@@ -127,7 +127,7 @@ github.com/googleapis/gax-go                        bd5b16380fd03dc758d11cef74ba
 google.golang.org/genproto                          3f1135a288c9a07e340ae8ba4cc6c7065a3160e8
 
 # containerd
-github.com/containerd/containerd                    36cc874494a56a253cd181a1a685b44b58a2e34a # v1.5.2
+github.com/containerd/containerd                    0e8719f54c6dc6571fc1170da75a85e86c17636b # v1.5.3
 github.com/containerd/fifo                          650e8a8a179d040123db61f016cb133143e7a581 # v1.0.0
 github.com/containerd/continuity                    bce1c3f9669b6f3e7f6656ee715b0b4d75fa64a6 # v0.1.0
 github.com/containerd/cgroups                       b9de8a2212026c07cec67baf3323f1fc0121e048 # v1.0.1

--- a/vendor/github.com/containerd/containerd/content/local/store.go
+++ b/vendor/github.com/containerd/containerd/content/local/store.go
@@ -500,7 +500,7 @@ func (s *store) resumeStatus(ref string, total int64, digester digest.Digester) 
 	if ref != status.Ref {
 		// NOTE(stevvooe): This is fairly catastrophic. Either we have some
 		// layout corruption or a hash collision for the ref key.
-		return status, errors.Wrapf(err, "ref key does not match: %v != %v", ref, status.Ref)
+		return status, errors.Errorf("ref key does not match: %v != %v", ref, status.Ref)
 	}
 
 	if total > 0 && status.Total > 0 && total != status.Total {

--- a/vendor/github.com/containerd/containerd/content/local/store_bsd.go
+++ b/vendor/github.com/containerd/containerd/content/local/store_bsd.go
@@ -1,4 +1,4 @@
-// +build linux solaris
+// +build darwin freebsd netbsd
 
 /*
    Copyright The containerd Authors.
@@ -26,7 +26,7 @@ import (
 
 func getATime(fi os.FileInfo) time.Time {
 	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
-		return time.Unix(int64(st.Atim.Sec), int64(st.Atim.Nsec)) //nolint: unconvert // int64 conversions ensure the line compiles for 32-bit systems as well.
+		return time.Unix(int64(st.Atimespec.Sec), int64(st.Atimespec.Nsec)) //nolint: unconvert // int64 conversions ensure the line compiles for 32-bit systems as well.
 	}
 
 	return fi.ModTime()

--- a/vendor/github.com/containerd/containerd/content/local/store_openbsd.go
+++ b/vendor/github.com/containerd/containerd/content/local/store_openbsd.go
@@ -1,4 +1,4 @@
-// +build linux solaris
+// +build openbsd
 
 /*
    Copyright The containerd Authors.

--- a/vendor/github.com/containerd/containerd/go.mod
+++ b/vendor/github.com/containerd/containerd/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/Microsoft/go-winio v0.4.17
-	github.com/Microsoft/hcsshim v0.8.16
+	github.com/Microsoft/hcsshim v0.8.18
 	github.com/containerd/aufs v1.0.0
 	github.com/containerd/btrfs v1.0.0
 	github.com/containerd/cgroups v1.0.1

--- a/vendor/github.com/containerd/containerd/metadata/containers.go
+++ b/vendor/github.com/containerd/containerd/metadata/containers.go
@@ -290,7 +290,7 @@ func validateContainer(container *containers.Container) error {
 
 	// image has no validation
 	for k, v := range container.Labels {
-		if err := labels.Validate(k, v); err == nil {
+		if err := labels.Validate(k, v); err != nil {
 			return errors.Wrapf(err, "containers.Labels")
 		}
 	}

--- a/vendor/github.com/containerd/containerd/metadata/content.go
+++ b/vendor/github.com/containerd/containerd/metadata/content.go
@@ -708,7 +708,7 @@ func (cs *contentStore) checkAccess(ctx context.Context, dgst digest.Digest) err
 
 func validateInfo(info *content.Info) error {
 	for k, v := range info.Labels {
-		if err := labels.Validate(k, v); err == nil {
+		if err := labels.Validate(k, v); err != nil {
 			return errors.Wrapf(err, "info.Labels")
 		}
 	}

--- a/vendor/github.com/containerd/containerd/remotes/docker/auth/fetch.go
+++ b/vendor/github.com/containerd/containerd/remotes/docker/auth/fetch.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/containerd/containerd/log"
 	remoteserrors "github.com/containerd/containerd/remotes/errors"
+	"github.com/containerd/containerd/version"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context/ctxhttp"
 )
@@ -109,6 +110,9 @@ func FetchTokenWithOAuth(ctx context.Context, client *http.Client, headers http.
 	for k, v := range headers {
 		req.Header[k] = append(req.Header[k], v...)
 	}
+	if len(req.Header.Get("User-Agent")) == 0 {
+		req.Header.Set("User-Agent", "containerd/"+version.Version)
+	}
 
 	resp, err := ctxhttp.Do(ctx, client, req)
 	if err != nil {
@@ -152,6 +156,9 @@ func FetchToken(ctx context.Context, client *http.Client, headers http.Header, t
 
 	for k, v := range headers {
 		req.Header[k] = append(req.Header[k], v...)
+	}
+	if len(req.Header.Get("User-Agent")) == 0 {
+		req.Header.Set("User-Agent", "containerd/"+version.Version)
 	}
 
 	reqParams := req.URL.Query()

--- a/vendor/github.com/containerd/containerd/remotes/docker/pusher.go
+++ b/vendor/github.com/containerd/containerd/remotes/docker/pusher.go
@@ -190,6 +190,7 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 				return nil, err
 			}
 		}
+		defer resp.Body.Close()
 
 		switch resp.StatusCode {
 		case http.StatusOK, http.StatusAccepted, http.StatusNoContent:
@@ -382,6 +383,7 @@ func (pw *pushWriter) Commit(ctx context.Context, size int64, expected digest.Di
 	if resp.err != nil {
 		return resp.err
 	}
+	defer resp.Response.Body.Close()
 
 	// 201 is specified return status, some registries return
 	// 200, 202 or 204.

--- a/vendor/github.com/containerd/containerd/version/version.go
+++ b/vendor/github.com/containerd/containerd/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.5.2+unknown"
+	Version = "1.5.3+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
### Update containerd binary to v1.5.3

full diff: https://github.com/containerd/containerd/compare/v1.5.2...v1.5.3

Welcome to the v1.5.3 release of containerd!

The third patch release for containerd 1.5 updates runc to 1.0.0 and contains
various other fixes.

Notable Updates

- Update runc binary to 1.0.0
- Send pod UID to CNI plugins as K8S_POD_UID
- Fix invalid validation error checking
- Fix error on image pull resume
- Fix User Agent sent to registry authentication server (changes default user-
  agent from "Go-http-client/1.1" to "containerd/v1.5.3")
- Fix symlink resolution for disk mounts on Windows



### vendor: github.com/containerd/containerd v1.5.3

full diff: https://github.com/containerd/containerd/compare/v1.5.2...v1.5.3

- Fix User Agent sent to registry authentication server (changes default user-
  agent from "Go-http-client/1.1" to "containerd/v1.5.3")
- Fix missing Body.Close() calls on push to docker remote
- Change Wrapf of non-error to an actual error
    - fixes Failed to pull image (unexpected commit digest)
- fix invalid validation error checking
- Update hcsshim to 0.8.18
- Update Go to 1.16.6
- content/local: inline sys.StatATimeAsTime()
- windows: Use GetFinalPathNameByHandle for ResolveSymbolicLink
- Fix cleanup context of teardownPodNetwork
    - fixes CRI fails to invoke CNI plugin to teardown network when RunPodSandbox times out
- sandbox: send pod UID to CNI plugins as K8S_POD_UID

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

