### PR TITLE
[20.10] update containerd binary to v1.4.7

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=d71fcd7d8303cbf684402823e425e9dd2e99285d}" # v1.4.6
+: "${CONTAINERD_COMMIT:=3194fb46e8311ae0eeae5a7a5843573adfebb16d}" # v1.4.7
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
full diff: https://github.com/containerd/containerd/compare/v1.4.6...v1.4.7

Welcome to the v1.4.7 release of containerd!

The seventh patch release for containerd 1.4 updates runc to 1.0.0 and contains
various other fixes.

Notable Updates

- Update runc binary to 1.0.0
- Fix invalid validation error checking
- Fix error on image pull resume
- Fix symlink resolution for disk mounts on Windows

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

