### PR TITLE
Mount (accessible) host devices in `--privileged` rootless containers

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -862,7 +862,7 @@ func WithDevices(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		var devs []specs.LinuxDevice
 		devPermissions := s.Linux.Resources.Devices
 
-		if c.HostConfig.Privileged && !userns.RunningInUserNS() {
+		if c.HostConfig.Privileged {
 			hostDevices, err := coci.HostDevices()
 			if err != nil {
 				return err


### PR DESCRIPTION
fixes #42406

**- What I did**

* Enabled host-device discovery in `--privileged` rootless containers.
* ~Use `containerd/oci.HostDevices()` that skips device sub-directories which are not accessible by the user.~
    Merged in https://github.com/moby/moby/pull/43053

**- How I did it**

* Removed the condition that skipped that process in rootless mode.
* `containerd/oci.HostDevices()` ignores permission errors when running in a user namespace.

**- How to verify it**

Integration tests are included.

**- Description for the changelog**

Mount (accessible) host devices in `--privileged` rootless containers