### PR TITLE
Make daemon proxy settings configurable through daemon.json

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -99,6 +99,10 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.StringVar(&conf.ContainerdNamespace, "containerd-namespace", daemon.ContainersNamespace, "Containerd namespace to use")
 	flags.StringVar(&conf.ContainerdPluginNamespace, "containerd-plugins-namespace", containerd.PluginNamespace, "Containerd namespace to use for plugins")
 
+	flags.StringVar(&conf.HTTPProxy, "http-proxy", "", "HTTP proxy url for outgoing traffic (example: http://user:pass@proxy.corp.example.com:8080)")
+	flags.StringVar(&conf.HTTPSProxy, "https-proxy", "", "HTTPS proxy url for outgoing traffic (example: https://user:pass@proxy.corp.example.com:8080)")
+	flags.StringVar(&conf.NoProxy, "no-proxy", "", "Comma-separated list of hosts, IP addresses for which the proxy is passed")
+
 	return nil
 }
 

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -162,6 +162,9 @@ type CommonConfig struct {
 	ExecRoot              string                    `json:"exec-root,omitempty"`
 	SocketGroup           string                    `json:"group,omitempty"`
 	CorsHeaders           string                    `json:"api-cors-header,omitempty"`
+	HTTPProxy             string                    `json:"http-proxy,omitempty"`
+	HTTPSProxy            string                    `json:"https-proxy,omitempty"`
+	NoProxy               string                    `json:"no-proxy,omitempty"`
 
 	// TrustKeyPath is used to generate the daemon ID and for signing schema 1 manifests
 	// when pushing to a registry which does not support schema 2. This field is marked as

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -64,9 +64,9 @@ func (daemon *Daemon) SystemInfo() *types.Info {
 		Labels:             daemon.configStore.Labels,
 		ExperimentalBuild:  daemon.configStore.Experimental,
 		ServerVersion:      dockerversion.Version,
-		HTTPProxy:          maskCredentials(getEnvAny("HTTP_PROXY", "http_proxy")),
-		HTTPSProxy:         maskCredentials(getEnvAny("HTTPS_PROXY", "https_proxy")),
-		NoProxy:            getEnvAny("NO_PROXY", "no_proxy"),
+		HTTPProxy:          maskCredentials(getEnvOrConfig(daemon.configStore.HTTPProxy, "HTTP_PROXY", "http_proxy")),
+		HTTPSProxy:         maskCredentials(getEnvOrConfig(daemon.configStore.HTTPSProxy, "HTTPS_PROXY", "https_proxy")),
+		NoProxy:            getEnvOrConfig(daemon.configStore.NoProxy, "NO_PROXY", "no_proxy"),
 		LiveRestoreEnabled: daemon.configStore.LiveRestoreEnabled,
 		Isolation:          daemon.defaultIsolation,
 	}
@@ -307,4 +307,19 @@ func getEnvAny(names ...string) string {
 		}
 	}
 	return ""
+}
+
+func getEnvOrConfig(config string, env ...string) string {
+	val := getEnvAny(env...)
+	if val != "" {
+		return val
+	}
+
+	if config == "" {
+		return ""
+	}
+	for _, e := range env {
+		os.Setenv(e, config)
+	}
+	return config
 }


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/24758

Added proxy properties to daemon configuration (config file and dockerd flags).

**- How to verify it**

```
$ cat daemon.json 
{
    "http-proxy": "http://proxytest.example.com:80",
    "https-proxy": "https://proxytest.example.com:443"
}

$ dockerd --config-file daemon.json
```

```
$ docker pull busybox
Using default tag: latest
Error response from daemon: Get "https://registry-1.docker.io/v2/": proxyconnect tcp: dial tcp: lookup proxytest.example.com on 127.0.0.11:53: no such host


# docker build .     
Sending build context to Docker daemon  89.28MB
Step 1/3 : FROM golang:1.16-alpine AS base
Get "https://registry-1.docker.io/v2/": proxyconnect tcp: dial tcp: lookup proxytest.example.com on 127.0.0.11:53: no such host

```
