### PR TITLE
seccomp.Seccomp: embed oci-spec LinuxSeccomp, add support for seccomp flags

### DIFF
--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -1473,7 +1473,7 @@ func (s *DockerDaemonSuite) TestRunSeccompJSONNoNameAndNames(c *testing.T) {
 
 	out, err := s.d.Cmd("run", "--security-opt", "seccomp="+tmpFile.Name(), "busybox", "chmod", "777", ".")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "'name' and 'names' were specified in the seccomp profile, use either 'name' or 'names'"))
+	assert.Assert(c, strings.Contains(out, "use either 'name' or 'names'"))
 }
 
 func (s *DockerDaemonSuite) TestRunSeccompJSONNoArchAndArchMap(c *testing.T) {
@@ -1510,7 +1510,7 @@ func (s *DockerDaemonSuite) TestRunSeccompJSONNoArchAndArchMap(c *testing.T) {
 
 	out, err := s.d.Cmd("run", "--security-opt", "seccomp="+tmpFile.Name(), "busybox", "chmod", "777", ".")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "'architectures' and 'archMap' were specified in the seccomp profile, use either 'architectures' or 'archMap'"))
+	assert.Assert(c, strings.Contains(out, "use either 'architectures' or 'archMap'"))
 }
 
 func (s *DockerDaemonSuite) TestRunWithDaemonDefaultSeccompProfile(c *testing.T) {

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -740,8 +740,10 @@ func DefaultProfile() *Seccomp {
 	}
 
 	return &Seccomp{
-		DefaultAction: specs.ActErrno,
-		ArchMap:       arches(),
-		Syscalls:      syscalls,
+		LinuxSeccomp: specs.LinuxSeccomp{
+			DefaultAction: specs.ActErrno,
+		},
+		ArchMap:  arches(),
+		Syscalls: syscalls,
 	}
 }

--- a/profiles/seccomp/seccomp.go
+++ b/profiles/seccomp/seccomp.go
@@ -10,15 +10,12 @@ import (
 )
 
 // Seccomp represents the config for a seccomp profile for syscall restriction.
+// It is used to marshal/unmarshal the JSON profiles as accepted by docker, and
+// extends the runtime-spec's specs.LinuxSeccomp, overriding some fields to
+// provide the ability to define conditional rules based on the host's kernel
+// version, architecture, and the container's capabilities.
 type Seccomp struct {
-	DefaultAction    specs.LinuxSeccompAction `json:"defaultAction"`
-	DefaultErrnoRet  *uint                    `json:"defaultErrnoRet,omitempty"`
-	ListenerPath     string                   `json:"listenerPath,omitempty"`
-	ListenerMetadata string                   `json:"listenerMetadata,omitempty"`
-
-	// Architectures is kept to maintain backward compatibility with the old
-	// seccomp profile.
-	Architectures []specs.Arch `json:"architectures,omitempty"`
+	specs.LinuxSeccomp
 
 	// ArchMap contains a list of Architectures and Sub-architectures for the
 	// profile. When generating the profile, this list is expanded to a

--- a/profiles/seccomp/seccomp.go
+++ b/profiles/seccomp/seccomp.go
@@ -18,9 +18,19 @@ type Seccomp struct {
 
 	// Architectures is kept to maintain backward compatibility with the old
 	// seccomp profile.
-	Architectures []specs.Arch   `json:"architectures,omitempty"`
-	ArchMap       []Architecture `json:"archMap,omitempty"`
-	Syscalls      []*Syscall     `json:"syscalls"`
+	Architectures []specs.Arch `json:"architectures,omitempty"`
+
+	// ArchMap contains a list of Architectures and Sub-architectures for the
+	// profile. When generating the profile, this list is expanded to a
+	// []specs.Arch, to propagate the Architectures field of the profile.
+	ArchMap []Architecture `json:"archMap,omitempty"`
+
+	// Syscalls contains lists of syscall rules. Rules can define conditions
+	// for them to be included or excluded in the resulting profile (based on
+	// on kernel version, architecture, capabilities, etc.). These lists are
+	// expanded to an specs.Syscall  When generating the profile, these lists
+	// are expanded to a []specs.LinuxSyscall.
+	Syscalls []*Syscall `json:"syscalls"`
 }
 
 // Architecture is used to represent a specific architecture

--- a/profiles/seccomp/seccomp_linux.go
+++ b/profiles/seccomp/seccomp_linux.go
@@ -85,7 +85,7 @@ func setupSeccomp(config *Seccomp, rs *specs.Spec) (*specs.LinuxSeccomp, error) 
 	newConfig := &specs.LinuxSeccomp{}
 
 	if len(config.Architectures) != 0 && len(config.ArchMap) != 0 {
-		return nil, errors.New("'architectures' and 'archMap' were specified in the seccomp profile, use either 'architectures' or 'archMap'")
+		return nil, errors.New("both 'architectures' and 'archMap' are specified in the seccomp profile, use either 'architectures' or 'archMap'")
 	}
 
 	// if config.Architectures == 0 then libseccomp will figure out the architecture to use
@@ -94,9 +94,7 @@ func setupSeccomp(config *Seccomp, rs *specs.Spec) (*specs.LinuxSeccomp, error) 
 	}
 
 	arch := goToNative[runtime.GOARCH]
-	seccompArch, archExists := nativeToSeccomp[arch]
-
-	if len(config.ArchMap) != 0 && archExists {
+	if seccompArch, ok := nativeToSeccomp[arch]; ok {
 		for _, a := range config.ArchMap {
 			if a.Arch == seccompArch {
 				newConfig.Architectures = append(newConfig.Architectures, a.Arch)
@@ -112,8 +110,14 @@ func setupSeccomp(config *Seccomp, rs *specs.Spec) (*specs.LinuxSeccomp, error) 
 	newConfig.ListenerMetadata = config.ListenerMetadata
 
 Loop:
-	// Loop through all syscall blocks and convert them to libcontainer format after filtering them
+	// Convert Syscall to OCI runtimes-spec specs.LinuxSyscall after filtering them.
 	for _, call := range config.Syscalls {
+		if call.Name != "" {
+			if len(call.Names) != 0 {
+				return nil, errors.New("both 'name' and 'names' are specified in the seccomp profile, use either 'name' or 'names'")
+			}
+			call.Names = []string{call.Name}
+		}
 		if call.Excludes != nil {
 			if len(call.Excludes.Arches) > 0 {
 				if inSlice(call.Excludes.Arches, arch) {
@@ -156,14 +160,6 @@ Loop:
 				}
 			}
 		}
-
-		if call.Name != "" {
-			if len(call.Names) != 0 {
-				return nil, errors.New("'name' and 'names' were specified in the seccomp profile, use either 'name' or 'names'")
-			}
-			call.Names = append(call.Names, call.Name)
-		}
-
 		newConfig.Syscalls = append(newConfig.Syscalls, call.LinuxSyscall)
 	}
 

--- a/profiles/seccomp/seccomp_test.go
+++ b/profiles/seccomp/seccomp_test.go
@@ -24,32 +24,32 @@ func TestLoadProfile(t *testing.T) {
 	}
 	var expectedErrno uint = 12345
 	expected := specs.LinuxSeccomp{
-		DefaultAction: "SCMP_ACT_ERRNO",
+		DefaultAction: specs.ActErrno,
 		Syscalls: []specs.LinuxSyscall{
 			{
 				Names:  []string{"clone"},
-				Action: "SCMP_ACT_ALLOW",
+				Action: specs.ActAllow,
 				Args: []specs.LinuxSeccompArg{{
 					Index:    0,
 					Value:    2114060288,
 					ValueTwo: 0,
-					Op:       "SCMP_CMP_MASKED_EQ",
+					Op:       specs.OpMaskedEqual,
 				}},
 			},
 			{
 
 				Names:  []string{"open"},
-				Action: "SCMP_ACT_ALLOW",
+				Action: specs.ActAllow,
 				Args:   []specs.LinuxSeccompArg{},
 			},
 			{
 				Names:  []string{"close"},
-				Action: "SCMP_ACT_ALLOW",
+				Action: specs.ActAllow,
 				Args:   []specs.LinuxSeccompArg{},
 			},
 			{
 				Names:    []string{"syslog"},
-				Action:   "SCMP_ACT_ERRNO",
+				Action:   specs.ActErrno,
 				ErrnoRet: &expectedErrno,
 				Args:     []specs.LinuxSeccompArg{},
 			},
@@ -72,7 +72,7 @@ func TestLoadProfileWithDefaultErrnoRet(t *testing.T) {
 
 	expectedErrnoRet := uint(6)
 	expected := specs.LinuxSeccomp{
-		DefaultAction:   "SCMP_ACT_ERRNO",
+		DefaultAction:   specs.ActErrno,
 		DefaultErrnoRet: &expectedErrnoRet,
 	}
 
@@ -92,7 +92,7 @@ func TestLoadProfileWithListenerPath(t *testing.T) {
 	}
 
 	expected := specs.LinuxSeccomp{
-		DefaultAction:    "SCMP_ACT_ERRNO",
+		DefaultAction:    specs.ActErrno,
 		ListenerPath:     "/var/run/seccompaget.sock",
 		ListenerMetadata: "opaque-metadata",
 	}

--- a/profiles/seccomp/seccomp_test.go
+++ b/profiles/seccomp/seccomp_test.go
@@ -100,6 +100,18 @@ func TestLoadProfileWithListenerPath(t *testing.T) {
 	assert.DeepEqual(t, expected, *p)
 }
 
+func TestLoadProfileWithFlag(t *testing.T) {
+	profile := `{"defaultAction": "SCMP_ACT_ERRNO", "flags": ["SECCOMP_FILTER_FLAG_SPEC_ALLOW", "SECCOMP_FILTER_FLAG_LOG"]}`
+	expected := specs.LinuxSeccomp{
+		DefaultAction: specs.ActErrno,
+		Flags:         []specs.LinuxSeccompFlag{"SECCOMP_FILTER_FLAG_SPEC_ALLOW", "SECCOMP_FILTER_FLAG_LOG"},
+	}
+	rs := createSpec()
+	p, err := LoadProfile(profile, &rs)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, expected, *p)
+}
+
 // TestLoadProfileValidation tests that invalid profiles produce the correct error.
 func TestLoadProfileValidation(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Fixes https://github.com/moby/moby/issues/42619 (Feature request: ability to set SECCOMP_FILTER_FLAG_SPEC_ALLOW in seccomp profiles)

- seccomp: improve GoDoc for Seccomp fields
- seccomp: use oci-spec consts in tests
- seccomp: add additional unit-tests
    Add test to verify profile validation, and to verify that the legacy format actually loads the profile as expected (instead of only verifying it doesn't produce an error).
- seccomp: setupSeccomp(): update errors and remove redundant check
    Make the error message slightly more informative, and remove the redundant `len(config.ArchMap) != 0` check, as iterating over an empty, or 'nil' slice is a no-op already. This allows to use a slightly more idiomatic "if ok := xx; ok" condition.
    Also move validation to the start of the loop (early return), and explicitly create a new slice for "names" if the legacy "Name" field is used.
- seccomp: Seccomp: embed oci-spec Seccomp, add support for seccomp flags
  This patch, similar to https://github.com/moby/moby/commit/d92739713c633c155c0f3d8065c8278b1d8a44e7 (https://github.com/moby/moby/pull/42005), embeds the type of the runtime-spec, so that we can support all options provided by the spec, and decorates it with our own fields.

  With this, profiles can make use of the recently added "Flags" field, to specify flags that must be passed to seccomp(2) when installing the filter.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

