### PR TITLE
seccomp: Use explicit DefaultErrnoRet

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -1,5 +1,6 @@
 {
 	"defaultAction": "SCMP_ACT_ERRNO",
+	"defaultErrnoRet": 1,
 	"archMap": [
 		{
 			"architecture": "SCMP_ARCH_X86_64",

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -739,9 +739,11 @@ func DefaultProfile() *Seccomp {
 		},
 	}
 
+	errnoRet := uint(unix.EPERM)
 	return &Seccomp{
 		LinuxSeccomp: specs.LinuxSeccomp{
-			DefaultAction: specs.ActErrno,
+			DefaultAction:   specs.ActErrno,
+			DefaultErrnoRet: &errnoRet,
 		},
 		ArchMap:  arches(),
 		Syscalls: syscalls,

--- a/profiles/seccomp/fixtures/example.json
+++ b/profiles/seccomp/fixtures/example.json
@@ -1,5 +1,6 @@
 {
     "defaultAction": "SCMP_ACT_ERRNO",
+    "defaultErrnoRet": 1,
     "syscalls": [
         {
             "name": "clone",

--- a/profiles/seccomp/seccomp_test.go
+++ b/profiles/seccomp/seccomp_test.go
@@ -23,8 +23,10 @@ func TestLoadProfile(t *testing.T) {
 		t.Fatal(err)
 	}
 	var expectedErrno uint = 12345
+	var expectedDefaultErrno uint = 1
 	expected := specs.LinuxSeccomp{
-		DefaultAction: specs.ActErrno,
+		DefaultAction:   specs.ActErrno,
+		DefaultErrnoRet: &expectedDefaultErrno,
 		Syscalls: []specs.LinuxSyscall{
 			{
 				Names:  []string{"clone"},


### PR DESCRIPTION
Since commit "seccomp: Sync fields with runtime-spec fields"
(5d244675bdb23e8fce427036c03517243f344cd4) we support to specify the
DefaultErrnoRet to be used.

Before that commit it was not specified and EPERM was used by default.
This commit keeps the same behaviour but just makes it explicit that the
default is EPERM.

Signed-off-by: Rodrigo Campos <rodrigo@kinvolk.io>

This a follow-up of https://github.com/moby/moby/pull/42604#issuecomment-876632771, as suggested by @thaJeztah. This just adds an explicit default to EPERM. Right now the default is EPERM but is implicit.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added the field `DefaultErrnoRet` to seccomp profiles

**- How I did it**
Added the field to default profile in `profiles/seccomp/default_linux.go`, then adjusted the tests to expect this new field

**- How to verify it**
You can run unit tests with: `TESTDIRS='github.com/docker/docker/profiles/seccomp' make test-unit`.
You can also run `hack/validate/default-seccomp` to verify nothing was missing in the changes.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add an explicit DefaultErrnoRet field in the default seccomp profile. No behavior change. 

**- A picture of a cute animal (not mandatory but encouraged)**
![](https://www.kinderundjugendmedien.de/images/Ratatouille_pixar.jpg)
