### PR TITLE
Makefile: do not tag docker-dev image with GIT_BRANCH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,9 +118,7 @@ endif # ifndef DOCKER_MOUNT
 # This allows to set the docker-dev container name
 DOCKER_CONTAINER_NAME := $(if $(CONTAINER_NAME),--name $(CONTAINER_NAME),)
 
-GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
-GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
-DOCKER_IMAGE := docker-dev$(if $(GIT_BRANCH_CLEAN),:$(GIT_BRANCH_CLEAN))
+DOCKER_IMAGE := docker-dev
 DOCKER_PORT_FORWARD := $(if $(DOCKER_PORT),-p "$(DOCKER_PORT)",)
 
 DOCKER_FLAGS := $(DOCKER) run --rm -i --privileged $(DOCKER_CONTAINER_NAME) $(DOCKER_ENVS) $(DOCKER_MOUNT) $(DOCKER_PORT_FORWARD)


### PR DESCRIPTION
When building the dev image, the Makefile generates a tag-name for the image, based on the current git branch. As a result of this naming, old images will collect on a developer's machine (especially when building from different branches, for example when reviewing pull requests):

    REPOSITORY   TAG                                                 IMAGE ID       CREATED        SIZE
    docker-dev   HEAD                                                9785a8fb82f5   30 hours ago   2.13GB
    docker-dev   master                                              9785a8fb82f5   30 hours ago   2.13GB
    docker-dev   seccomp-closer-to-oci                               9785a8fb82f5   30 hours ago   2.13GB
    docker-dev   move-stackdump                                      06882c142bfd   2 days ago     2.13GB
    docker-dev   add-dns-to-docker-info                              2961ed1b99bd   10 days ago    2.13GB
    docker-dev   add-platform-info                                   2961ed1b99bd   10 days ago    2.13GB
    docker-dev   rata-seccomp-new-fields                             2961ed1b99bd   10 days ago    2.13GB
    docker-dev   swagger-wip                                         2961ed1b99bd   10 days ago    2.13GB
    docker-dev   system-df-types                                     2961ed1b99bd   10 days ago    2.13GB
    docker-dev   use-oci-platform                                    2961ed1b99bd   10 days ago    2.13GB
    docker-dev   update-swagger-fork                                 3eeedecca85a   2 weeks ago    2.13GB
    docker-dev   remove-lcow-step5-alternative                       51f9720bbc19   2 weeks ago    2.13GB
    docker-dev   update-s390x-ubuntu-2004                            51f9720bbc19   2 weeks ago    2.13GB
    docker-dev   fix-image-shared-size                               09e9aa46694a   2 weeks ago    2.13GB
    docker-dev   remove-discovery                                    11823223ae83   3 weeks ago    2.13GB
    docker-dev   daemon-config                                       355643e371b0   4 weeks ago    2.12GB
    docker-dev   jenkins-windows-containerd                          68199214b860   4 weeks ago    2.11GB
    docker-dev   unfork-buildkit                                     68199214b860   4 weeks ago    2.11GB
    docker-dev   warn-on-non-matching-platform                       bc014b94017f   5 weeks ago    2.11GB
    docker-dev   remove-lcow                                         3a43c0900282   6 weeks ago    2.11GB
    docker-dev   remove-lcow-part5                                   3a43c0900282   6 weeks ago    2.11GB
    docker-dev   remove-lcow-step3                                   3a43c0900282   6 weeks ago    2.11GB
    docker-dev   remove-lcow-step4                                   3a43c0900282   6 weeks ago    2.11GB
    docker-dev   seccomp-unconfined-daemon                           3a43c0900282   6 weeks ago    2.11GB
    docker-dev   update-authors                                      3a43c0900282   6 weeks ago    2.11GB
    docker-dev   payall4u-fix-creating-sandbox-when-disable-bridge   114c0f2ceb17   6 weeks ago    2.12GB
    docker-dev   catch-almost-all                                    f437d2bc512b   8 weeks ago    2.12GB
    docker-dev   bin-criu                                            c72894ae66f3   2 months ago   2.12GB
    docker-dev   bump-golang-1-14                                    395932141809   2 months ago   2.14GB
    docker-dev   upstream-systemd-units                              d0cb07f9473c   2 months ago   2.12GB
    docker-dev   bump-criu                                           6ed9e8fcf59f   2 months ago   2.12GB

This images are a bit of a pain to clean up, and because they are tagged, `docker image prune` or `docker system prune` doesn't help (unless `--all` is used).

Looking at the background of this naming, a found that it was originally added in a95712899e33f267a3061fa94d05189e7c371eaa (https://github.com/moby/moby/pull/3494), after a discussion on https://github.com/moby/moby/pull/3471. At the time, the image name was used to check if the image needed building, and otherwise building was skipped in the makefile.

This is no longer the case; the image is built unconditionally, and the build-cache helps (where possible) speed up rebuilding the image.

In _theory_ having unique names would allow for multiple dev containers (from different branches) to be started in parallel, but in most situations, the source-code will be mounted (`BIND_MOUNT=.`), so I'm not sure if that should be a compelling reason to keep the current naming.

This patch removes the unique tag, and will always tag the image locally as `docker-dev:latest`.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

