### PR TITLE
Update containerd v1.5.4

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=0e8719f54c6dc6571fc1170da75a85e86c17636b}" # v1.5.3
+: "${CONTAINERD_COMMIT:=69107e47a62e1d690afa2b9b1d43f8ece3ff4483}" # v1.5.4
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/vendor.conf
+++ b/vendor.conf
@@ -128,7 +128,7 @@ github.com/googleapis/gax-go                        bd5b16380fd03dc758d11cef74ba
 google.golang.org/genproto                          3f1135a288c9a07e340ae8ba4cc6c7065a3160e8
 
 # containerd
-github.com/containerd/containerd                    0e8719f54c6dc6571fc1170da75a85e86c17636b # v1.5.3
+github.com/containerd/containerd                    69107e47a62e1d690afa2b9b1d43f8ece3ff4483 # v1.5.4
 github.com/containerd/fifo                          650e8a8a179d040123db61f016cb133143e7a581 # v1.0.0
 github.com/containerd/continuity                    bce1c3f9669b6f3e7f6656ee715b0b4d75fa64a6 # v0.1.0
 github.com/containerd/cgroups                       b9de8a2212026c07cec67baf3323f1fc0121e048 # v1.0.1

--- a/vendor/github.com/containerd/containerd/archive/tar.go
+++ b/vendor/github.com/containerd/containerd/archive/tar.go
@@ -393,9 +393,8 @@ func createTarFile(ctx context.Context, path, extractDir string, hdr *tar.Header
 		}
 	}
 
-	// There is no LChmod, so ignore mode for symlink. Also, this
-	// must happen after chown, as that can modify the file mode
-	if err := handleLChmod(hdr, path, hdrInfo); err != nil {
+	// call lchmod after lchown since lchown can modify the file mode
+	if err := lchmod(path, hdrInfo.Mode()); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/containerd/containerd/archive/tar_freebsd.go
+++ b/vendor/github.com/containerd/containerd/archive/tar_freebsd.go
@@ -18,7 +18,11 @@
 
 package archive
 
-import "golang.org/x/sys/unix"
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
 
 // mknod wraps unix.Mknod.  FreeBSD's unix.Mknod signature is different from
 // other Unix and Unix-like operating systems.
@@ -31,6 +35,14 @@ func lsetxattrCreate(link string, attr string, data []byte) error {
 	err := unix.Lsetxattr(link, attr, data, 0)
 	if err == unix.ENOTSUP || err == unix.EEXIST {
 		return nil
+	}
+	return err
+}
+
+func lchmod(path string, mode os.FileMode) error {
+	err := unix.Fchmodat(unix.AT_FDCWD, path, uint32(mode), unix.AT_SYMLINK_NOFOLLOW)
+	if err != nil {
+		err = &os.PathError{Op: "lchmod", Path: path, Err: err}
 	}
 	return err
 }

--- a/vendor/github.com/containerd/containerd/archive/tar_mostunix.go
+++ b/vendor/github.com/containerd/containerd/archive/tar_mostunix.go
@@ -18,7 +18,11 @@
 
 package archive
 
-import "golang.org/x/sys/unix"
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
 
 // mknod wraps Unix.Mknod and casts dev to int
 func mknod(path string, mode uint32, dev uint64) error {
@@ -33,4 +37,19 @@ func lsetxattrCreate(link string, attr string, data []byte) error {
 		return nil
 	}
 	return err
+}
+
+// lchmod checks for symlink and changes the mode if not a symlink
+func lchmod(path string, mode os.FileMode) error {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+
+	if fi.Mode()&os.ModeSymlink == 0 {
+		if err := os.Chmod(path, mode); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/vendor/github.com/containerd/containerd/archive/tar_unix.go
+++ b/vendor/github.com/containerd/containerd/archive/tar_unix.go
@@ -111,21 +111,6 @@ func handleTarTypeBlockCharFifo(hdr *tar.Header, path string) error {
 	return mknod(path, mode, unix.Mkdev(uint32(hdr.Devmajor), uint32(hdr.Devminor)))
 }
 
-func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {
-	if hdr.Typeflag == tar.TypeLink {
-		if fi, err := os.Lstat(hdr.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
-			if err := os.Chmod(path, hdrInfo.Mode()); err != nil && !os.IsNotExist(err) {
-				return err
-			}
-		}
-	} else if hdr.Typeflag != tar.TypeSymlink {
-		if err := os.Chmod(path, hdrInfo.Mode()); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func getxattr(path, attr string) ([]byte, error) {
 	b, err := sysx.LGetxattr(path, attr)
 	if err == unix.ENOTSUP || err == sysx.ENODATA {

--- a/vendor/github.com/containerd/containerd/archive/tar_windows.go
+++ b/vendor/github.com/containerd/containerd/archive/tar_windows.go
@@ -98,7 +98,7 @@ func handleTarTypeBlockCharFifo(hdr *tar.Header, path string) error {
 	return nil
 }
 
-func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {
+func lchmod(path string, mode os.FileMode) error {
 	return nil
 }
 

--- a/vendor/github.com/containerd/containerd/version/version.go
+++ b/vendor/github.com/containerd/containerd/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.5.3+unknown"
+	Version = "1.5.4+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Update to containerd v1.5.4 to address [CVE-2021-32760][1].

[1]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32760

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

