### PR TITLE
Fix incorrect loop variable usage in parallel test closures

### DIFF
--- a/integration/container/container_test.go
+++ b/integration/container/container_test.go
@@ -13,7 +13,6 @@ func TestContainerInvalidJSON(t *testing.T) {
 	defer setupTest(t)()
 
 	endpoints := []string{
-		"/containers/foobar/copy",
 		"/containers/foobar/exec",
 		"/exec/foobar/start",
 	}

--- a/integration/container/container_test.go
+++ b/integration/container/container_test.go
@@ -19,6 +19,7 @@ func TestContainerInvalidJSON(t *testing.T) {
 	}
 
 	for _, ep := range endpoints {
+		ep := ep
 		t.Run(ep, func(t *testing.T) {
 			t.Parallel()
 

--- a/integration/network/network_test.go
+++ b/integration/network/network_test.go
@@ -72,6 +72,7 @@ func TestNetworkInvalidJSON(t *testing.T) {
 	}
 
 	for _, ep := range endpoints {
+		ep := ep
 		t.Run(ep, func(t *testing.T) {
 			t.Parallel()
 
@@ -105,6 +106,7 @@ func TestNetworkList(t *testing.T) {
 	}
 
 	for _, ep := range endpoints {
+		ep := ep
 		t.Run(ep, func(t *testing.T) {
 			t.Parallel()
 

--- a/integration/plugin/common/plugin_test.go
+++ b/integration/plugin/common/plugin_test.go
@@ -36,6 +36,7 @@ func TestPluginInvalidJSON(t *testing.T) {
 	endpoints := []string{"/plugins/foobar/set"}
 
 	for _, ep := range endpoints {
+		ep := ep
 		t.Run(ep, func(t *testing.T) {
 			t.Parallel()
 

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -110,6 +110,7 @@ func TestVolumesInvalidJSON(t *testing.T) {
 	endpoints := []string{"/volumes/create"}
 
 	for _, ep := range endpoints {
+		ep := ep
 		t.Run(ep, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
**- What I did**

Ensure that loop variables are copied for use within parallel test closures.

**- How I did it**
Discovered a few instances, where loop variable is incorrectly used
within a test closure, which is marked as parallel while working on #42559 
Few of these were actually loops over singleton slices, therefore the issue
might not have surfaced there (yet), but it is good to fix there as
well, as this is an incorrect pattern used across different tests.

There could potentially be (many) more, I just did a simple search for loops using `ep` within `/integration` and fixed incorrect usages. Perhaps a good idea to verify this across codebase as the next step? 