### PR TITLE
volume/mounts: pre-compile regular expressions

### DIFF
--- a/volume/mounts/lcow_parser.go
+++ b/volume/mounts/lcow_parser.go
@@ -2,8 +2,10 @@ package mounts // import "github.com/docker/docker/volume/mounts"
 
 import (
 	"errors"
+	"fmt"
 	"path"
 	"regexp"
+	"strings"
 
 	"github.com/docker/docker/api/types/mount"
 )
@@ -37,8 +39,8 @@ var lcowValidators mountValidator = func(m *mount.Mount) error {
 	if m.Type == mount.TypeNamedPipe {
 		return errors.New("Linux containers on Windows do not support named pipe mounts")
 	}
-	if err := windowsValidateRegex(m.Target, lcowMountDestinationRegex); err != nil {
-		return err
+	if !lcowMountDestinationRegex.MatchString(strings.ToLower(m.Target)) {
+		return fmt.Errorf("invalid mount path: '%s'", m.Target)
 	}
 	return nil
 }

--- a/volume/mounts/lcow_parser.go
+++ b/volume/mounts/lcow_parser.go
@@ -49,7 +49,7 @@ func (p *lcowParser) ValidateMountConfig(mnt *mount.Mount) error {
 }
 
 func (p *lcowParser) ParseMountRaw(raw, volumeDriver string) (*MountPoint, error) {
-	arr, err := p.windowsSplitRawSpec(raw, lcowSplitRawSpec)
+	arr, err := p.splitRawSpec(raw, lcowSplitRawSpec)
 	if err != nil {
 		return nil, err
 	}

--- a/volume/mounts/windows_parser.go
+++ b/volume/mounts/windows_parser.go
@@ -88,7 +88,7 @@ var (
 
 type mountValidator func(mnt *mount.Mount) error
 
-func (p *windowsParser) windowsSplitRawSpec(raw string, splitRegexp *regexp.Regexp) ([]string, error) {
+func (p *windowsParser) splitRawSpec(raw string, splitRegexp *regexp.Regexp) ([]string, error) {
 	match := splitRegexp.FindStringSubmatch(strings.ToLower(raw))
 	if len(match) == 0 {
 		return nil, errInvalidSpec(raw)
@@ -299,7 +299,7 @@ func (p *windowsParser) validateMountConfigReg(mnt *mount.Mount, destRegex *rege
 }
 
 func (p *windowsParser) ParseMountRaw(raw, volumeDriver string) (*MountPoint, error) {
-	arr, err := p.windowsSplitRawSpec(raw, windowsSplitRawSpecRegexp)
+	arr, err := p.splitRawSpec(raw, windowsSplitRawSpecRegexp)
 	if err != nil {
 		return nil, err
 	}

--- a/volume/mounts/windows_parser.go
+++ b/volume/mounts/windows_parser.go
@@ -78,12 +78,18 @@ const (
 	rxMode = `(:(?P<mode>(?i)ro|rw))?`
 )
 
+var (
+	volumeNameRegexp          = regexp.MustCompile(`^` + rxName + `$`)
+	reservedNameRegexp        = regexp.MustCompile(`^` + rxReservedNames + `$`)
+	hostDirRegexp             = regexp.MustCompile(`^` + rxHostDir + `$`)
+	mountDestinationRegexp    = regexp.MustCompile(`^` + rxDestination + `$`)
+	windowsSplitRawSpecRegexp = regexp.MustCompile(`^` + rxSource + rxDestination + rxMode + `$`)
+)
+
 type mountValidator func(mnt *mount.Mount) error
 
-func (p *windowsParser) windowsSplitRawSpec(raw, destRegex string) ([]string, error) {
-	specExp := regexp.MustCompile(`^` + rxSource + destRegex + rxMode + `$`)
-	match := specExp.FindStringSubmatch(strings.ToLower(raw))
-
+func (p *windowsParser) windowsSplitRawSpec(raw string, splitRegexp *regexp.Regexp) ([]string, error) {
+	match := splitRegexp.FindStringSubmatch(strings.ToLower(raw))
 	// Must have something back
 	if len(match) == 0 {
 		return nil, errInvalidSpec(raw)
@@ -92,7 +98,7 @@ func (p *windowsParser) windowsSplitRawSpec(raw, destRegex string) ([]string, er
 	var split []string
 	matchgroups := make(map[string]string)
 	// Pull out the sub expressions from the named capture groups
-	for i, name := range specExp.SubexpNames() {
+	for i, name := range splitRegexp.SubexpNames() {
 		matchgroups[name] = strings.ToLower(match[i])
 	}
 	if source, exists := matchgroups["source"]; exists {
@@ -115,11 +121,8 @@ func (p *windowsParser) windowsSplitRawSpec(raw, destRegex string) ([]string, er
 	// situation where the user intention was to map a file into a container through
 	// a local volume, but this is not supported by the platform.
 	if matchgroups["source"] == "" && matchgroups["destination"] != "" {
-		volExp := regexp.MustCompile(`^` + rxName + `$`)
-		reservedNameExp := regexp.MustCompile(`^` + rxReservedNames + `$`)
-
-		if volExp.MatchString(matchgroups["destination"]) {
-			if reservedNameExp.MatchString(matchgroups["destination"]) {
+		if volumeNameRegexp.MatchString(matchgroups["destination"]) {
+			if reservedNameRegexp.MatchString(matchgroups["destination"]) {
 				return nil, fmt.Errorf("volume name %q cannot be a reserved word for Windows filenames", matchgroups["destination"])
 			}
 		} else {
@@ -153,14 +156,14 @@ var windowsSpecificValidators mountValidator = func(mnt *mount.Mount) error {
 	return windowsValidateNotRoot(mnt.Target)
 }
 
-func windowsValidateRegex(p, r string) error {
-	if regexp.MustCompile(`^` + r + `$`).MatchString(strings.ToLower(p)) {
+func windowsValidateRegex(p string, r *regexp.Regexp) error {
+	if r.MatchString(strings.ToLower(p)) {
 		return nil
 	}
 	return fmt.Errorf("invalid mount path: '%s'", p)
 }
 func windowsValidateAbsolute(p string) error {
-	if err := windowsValidateRegex(p, rxDestination); err != nil {
+	if err := windowsValidateRegex(p, mountDestinationRegexp); err != nil {
 		return fmt.Errorf("invalid mount path: '%s' mount path must be absolute", p)
 	}
 	return nil
@@ -169,7 +172,7 @@ func windowsValidateAbsolute(p string) error {
 func windowsDetectMountType(p string) mount.Type {
 	if strings.HasPrefix(p, `\\.\pipe\`) {
 		return mount.TypeNamedPipe
-	} else if regexp.MustCompile(`^` + rxHostDir + `$`).MatchString(p) {
+	} else if hostDirRegexp.MatchString(p) {
 		return mount.TypeBind
 	} else {
 		return mount.TypeVolume
@@ -182,18 +185,16 @@ func (p *windowsParser) ReadWrite(mode string) bool {
 
 // ValidateVolumeName checks a volume name in a platform specific manner.
 func (p *windowsParser) ValidateVolumeName(name string) error {
-	nameExp := regexp.MustCompile(`^` + rxName + `$`)
-	if !nameExp.MatchString(name) {
+	if !volumeNameRegexp.MatchString(name) {
 		return errors.New("invalid volume name")
 	}
-	nameExp = regexp.MustCompile(`^` + rxReservedNames + `$`)
-	if nameExp.MatchString(name) {
+	if reservedNameRegexp.MatchString(name) {
 		return fmt.Errorf("volume name %q cannot be a reserved word for Windows filenames", name)
 	}
 	return nil
 }
 func (p *windowsParser) ValidateMountConfig(mnt *mount.Mount) error {
-	return p.validateMountConfigReg(mnt, rxDestination, windowsSpecificValidators)
+	return p.validateMountConfigReg(mnt, mountDestinationRegexp, windowsSpecificValidators)
 }
 
 type fileInfoProvider interface {
@@ -214,7 +215,7 @@ func (defaultFileInfoProvider) fileInfo(path string) (exist, isDir bool, err err
 	return true, fi.IsDir(), nil
 }
 
-func (p *windowsParser) validateMountConfigReg(mnt *mount.Mount, destRegex string, additionalValidators ...mountValidator) error {
+func (p *windowsParser) validateMountConfigReg(mnt *mount.Mount, destRegex *regexp.Regexp, additionalValidators ...mountValidator) error {
 
 	for _, v := range additionalValidators {
 		if err := v(mnt); err != nil {
@@ -299,15 +300,14 @@ func (p *windowsParser) validateMountConfigReg(mnt *mount.Mount, destRegex strin
 	return nil
 }
 func (p *windowsParser) ParseMountRaw(raw, volumeDriver string) (*MountPoint, error) {
-	return p.parseMountRaw(raw, volumeDriver, rxDestination, true, windowsSpecificValidators)
-}
-
-func (p *windowsParser) parseMountRaw(raw, volumeDriver, destRegex string, convertTargetToBackslash bool, additionalValidators ...mountValidator) (*MountPoint, error) {
-	arr, err := p.windowsSplitRawSpec(raw, destRegex)
+	arr, err := p.windowsSplitRawSpec(raw, windowsSplitRawSpecRegexp)
 	if err != nil {
 		return nil, err
 	}
+	return p.parseMount(arr, raw, volumeDriver, mountDestinationRegexp, true, windowsSpecificValidators)
+}
 
+func (p *windowsParser) parseMount(arr []string, raw, volumeDriver string, destRegex *regexp.Regexp, convertTargetToBackslash bool, additionalValidators ...mountValidator) (*MountPoint, error) {
 	var spec mount.Mount
 	var mode string
 	switch len(arr) {
@@ -367,9 +367,9 @@ func (p *windowsParser) parseMountRaw(raw, volumeDriver, destRegex string, conve
 }
 
 func (p *windowsParser) ParseMountSpec(cfg mount.Mount) (*MountPoint, error) {
-	return p.parseMountSpec(cfg, rxDestination, true, windowsSpecificValidators)
+	return p.parseMountSpec(cfg, mountDestinationRegexp, true, windowsSpecificValidators)
 }
-func (p *windowsParser) parseMountSpec(cfg mount.Mount, destRegex string, convertTargetToBackslash bool, additionalValidators ...mountValidator) (*MountPoint, error) {
+func (p *windowsParser) parseMountSpec(cfg mount.Mount, destRegex *regexp.Regexp, convertTargetToBackslash bool, additionalValidators ...mountValidator) (*MountPoint, error) {
 	if err := p.validateMountConfigReg(&cfg, destRegex, additionalValidators...); err != nil {
 		return nil, err
 	}

--- a/volume/mounts/windows_parser.go
+++ b/volume/mounts/windows_parser.go
@@ -155,17 +155,14 @@ var windowsValidators mountValidator = func(m *mount.Mount) error {
 	if err := windowsValidateNotRoot(m.Target); err != nil {
 		return err
 	}
-	return windowsValidateRegex(m.Target, mountDestinationRegexp)
+	if !mountDestinationRegexp.MatchString(strings.ToLower(m.Target)) {
+		return fmt.Errorf("invalid mount path: '%s'", m.Target)
+	}
+	return nil
 }
 
-func windowsValidateRegex(p string, r *regexp.Regexp) error {
-	if r.MatchString(strings.ToLower(p)) {
-		return nil
-	}
-	return fmt.Errorf("invalid mount path: '%s'", p)
-}
 func windowsValidateAbsolute(p string) error {
-	if err := windowsValidateRegex(p, mountDestinationRegexp); err != nil {
+	if !mountDestinationRegexp.MatchString(strings.ToLower(p)) {
 		return fmt.Errorf("invalid mount path: '%s' mount path must be absolute", p)
 	}
 	return nil

--- a/volume/mounts/windows_parser.go
+++ b/volume/mounts/windows_parser.go
@@ -90,7 +90,6 @@ type mountValidator func(mnt *mount.Mount) error
 
 func (p *windowsParser) windowsSplitRawSpec(raw string, splitRegexp *regexp.Regexp) ([]string, error) {
 	match := splitRegexp.FindStringSubmatch(strings.ToLower(raw))
-	// Must have something back
 	if len(match) == 0 {
 		return nil, errInvalidSpec(raw)
 	}
@@ -216,7 +215,6 @@ func (defaultFileInfoProvider) fileInfo(path string) (exist, isDir bool, err err
 }
 
 func (p *windowsParser) validateMountConfigReg(mnt *mount.Mount, destRegex *regexp.Regexp, additionalValidators ...mountValidator) error {
-
 	for _, v := range additionalValidators {
 		if err := v(mnt); err != nil {
 			return &errMountConfig{mnt, err}
@@ -299,6 +297,7 @@ func (p *windowsParser) validateMountConfigReg(mnt *mount.Mount, destRegex *rege
 	}
 	return nil
 }
+
 func (p *windowsParser) ParseMountRaw(raw, volumeDriver string) (*MountPoint, error) {
 	arr, err := p.windowsSplitRawSpec(raw, windowsSplitRawSpecRegexp)
 	if err != nil {
@@ -439,21 +438,23 @@ func (p *windowsParser) ParseVolumesFrom(spec string) (string, string, error) {
 }
 
 func (p *windowsParser) DefaultPropagationMode() mount.Propagation {
-	return mount.Propagation("")
+	return ""
 }
 
 func (p *windowsParser) ConvertTmpfsOptions(opt *mount.TmpfsOptions, readOnly bool) (string, error) {
 	return "", fmt.Errorf("%s does not support tmpfs", runtime.GOOS)
 }
+
 func (p *windowsParser) DefaultCopyMode() bool {
 	return false
 }
+
 func (p *windowsParser) IsBackwardCompatible(m *MountPoint) bool {
 	return false
 }
 
 func (p *windowsParser) ValidateTmpfsMountDestination(dest string) error {
-	return errors.New("Platform does not support tmpfs")
+	return errors.New("platform does not support tmpfs")
 }
 
 func (p *windowsParser) HasResource(m *MountPoint, absolutePath string) bool {


### PR DESCRIPTION
follow-up to https://github.com/moby/moby/pull/42520
closes https://github.com/moby/moby/issues/42667

Compile the regular expression, instead of 'ad-hoc'. For this to work, I moved
the splitting was moved out of parseMountRaw() into ParseMountRaw(), and the
former was renamed to parseMount(). This function still receives the 'raw' string,
as it's used to include the "raw" spec for inclusion in error messages.



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

