### PR TITLE
Dockerfile: simplify utility-install script, and update gotestsum to v1.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,7 +149,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
         . /tmp/install/tomll.installer && PREFIX=/build install_tomll
 
 FROM base AS vndr
-ARG VNDR_COMMIT
+ARG VNDR_VERSION
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=bind,src=hack/dockerfile/install,target=/tmp/install \
@@ -161,28 +161,28 @@ RUN --mount=type=cache,sharing=locked,id=moby-containerd-aptlib,target=/var/lib/
     --mount=type=cache,sharing=locked,id=moby-containerd-aptcache,target=/var/cache/apt \
         apt-get update && apt-get install -y --no-install-recommends \
             libbtrfs-dev
-ARG CONTAINERD_COMMIT
+ARG CONTAINERD_VERSION
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=bind,src=hack/dockerfile/install,target=/tmp/install \
         PREFIX=/build /tmp/install/install.sh containerd
 
 FROM base AS golangci_lint
-ARG GOLANGCI_LINT_COMMIT
+ARG GOLANGCI_LINT_VERSION
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=bind,src=hack/dockerfile/install,target=/tmp/install \
         PREFIX=/build /tmp/install/install.sh golangci_lint
 
 FROM base AS gotestsum
-ARG GOTESTSUM_COMMIT
+ARG GOTESTSUM_VERSION
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=bind,src=hack/dockerfile/install,target=/tmp/install \
         PREFIX=/build /tmp/install/install.sh gotestsum
 
 FROM base AS shfmt
-ARG SHFMT_COMMIT
+ARG SHFMT_VERSION
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=bind,src=hack/dockerfile/install,target=/tmp/install \
@@ -197,7 +197,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
         PREFIX=/build /tmp/install/install.sh dockercli
 
 FROM runtime-dev AS runc
-ARG RUNC_COMMIT
+ARG RUNC_VERSION
 ARG RUNC_BUILDTAGS
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
@@ -206,7 +206,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM dev-base AS tini
 ARG DEBIAN_FRONTEND
-ARG TINI_COMMIT
+ARG TINI_VERSION
 RUN --mount=type=cache,sharing=locked,id=moby-tini-aptlib,target=/var/lib/apt \
     --mount=type=cache,sharing=locked,id=moby-tini-aptcache,target=/var/cache/apt \
         apt-get update && apt-get install -y --no-install-recommends \
@@ -218,7 +218,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
         PREFIX=/build /tmp/install/install.sh tini
 
 FROM dev-base AS rootlesskit
-ARG ROOTLESSKIT_COMMIT
+ARG ROOTLESSKIT_VERSION
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=bind,src=hack/dockerfile/install,target=/tmp/install \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -167,7 +167,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ARG GO_VERSION=1.17.0
 ARG CONTAINERD_VERSION=1.5.5
-ARG GOTESTSUM_COMMIT=v0.5.3
+ARG GOTESTSUM_VERSION=v0.5.3
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.
@@ -179,7 +179,7 @@ ENV GO_VERSION=${GO_VERSION} `
     GOPATH=C:\gopath `
     GO111MODULE=off `
     FROM_DOCKERFILE=1 `
-    GOTESTSUM_COMMIT=${GOTESTSUM_COMMIT}
+    GOTESTSUM_VERSION=${GOTESTSUM_VERSION}
 
 RUN `
   Function Test-Nano() { `
@@ -275,11 +275,11 @@ RUN `
 
 RUN `
   Function Build-GoTestSum() { `
-    Write-Host "INFO: Building gotestsum version $Env:GOTESTSUM_COMMIT in $Env:GOPATH"; `
+    Write-Host "INFO: Building gotestsum version $Env:GOTESTSUM_VERSION in $Env:GOPATH"; `
     $Env:GO111MODULE = 'on'; `
     $tmpGobin = "${Env:GOBIN_TMP}"; `
     $Env:GOBIN = """${Env:GOPATH}`\bin"""; `
-    &go get -buildmode=exe "gotest.tools/gotestsum@${Env:GOTESTSUM_COMMIT}"; `
+    &go get -buildmode=exe "gotest.tools/gotestsum@${Env:GOTESTSUM_VERSION}"; `
     $Env:GOBIN = "${tmpGobin}"; `
     $Env:GO111MODULE = 'off'; `
     if ($LASTEXITCODE -ne 0) {  `

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -274,21 +274,20 @@ RUN `
   C:\git\cmd\git config --global core.autocrlf true;
 
 RUN `
-  Function Build-GoTestSum() { `
-    Write-Host "INFO: Building gotestsum version $Env:GOTESTSUM_VERSION in $Env:GOPATH"; `
+  Function Install-GoTestSum() { `
     $Env:GO111MODULE = 'on'; `
     $tmpGobin = "${Env:GOBIN_TMP}"; `
     $Env:GOBIN = """${Env:GOPATH}`\bin"""; `
-    &go get -buildmode=exe "gotest.tools/gotestsum@${Env:GOTESTSUM_VERSION}"; `
+    Write-Host "INFO: Installing gotestsum version $Env:GOTESTSUM_VERSION in $Env:GOBIN"; `
+    &go install "gotest.tools/gotestsum@${Env:GOTESTSUM_VERSION}"; `
     $Env:GOBIN = "${tmpGobin}"; `
     $Env:GO111MODULE = 'off'; `
     if ($LASTEXITCODE -ne 0) {  `
-      Throw '"gotestsum build failed..."'; `
+      Throw '"gotestsum install failed..."'; `
     } `
-    Write-Host "INFO:     Build done for gotestsum..."; `
   } `
   `
-  Build-GoTestSum
+  Install-GoTestSum
 
 # Make PowerShell the default entrypoint
 ENTRYPOINT ["powershell.exe"]

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -167,7 +167,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ARG GO_VERSION=1.17.0
 ARG CONTAINERD_VERSION=1.5.5
-ARG GOTESTSUM_VERSION=v0.5.3
+ARG GOTESTSUM_VERSION=v1.7.0
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -1,16 +1,27 @@
 #!/bin/sh
 set -e
 
-# containerd is also pinned in vendor.conf. When updating the binary
-# version you may also need to update the vendor version to pick up bug
-# fixes or new APIs.
-: "${CONTAINERD_COMMIT:=72cec4be58a9eb6b2910f5d10f1c01ca47d231c0}" # v1.5.5
+# CONTAINERD_VERSION specifies the version of the containerd runtime binary
+# to install from the https://github.com/containerd/containerd repository.
+#
+# This version is used to build statically compiled containerd binaries, and
+# used for the integration tests. The distributed docker .deb and .rpm packages
+# depend on a separate (containerd.io) package, which may be a different version
+# as is specified here.
+#
+# Generally, the commit specified here should match a tagged release.
+#
+# The containerd golang package is also pinned in vendor.conf. When updating
+# the binary version you may also need to update the vendor version to pick up
+# bug fixes or new APIs, however, usually the Go packages are built from a
+# commit from the master branch.
+: "${CONTAINERD_VERSION:=v1.5.5}"
 
 install_containerd() (
-	echo "Install containerd version $CONTAINERD_COMMIT"
+	echo "Install containerd version $CONTAINERD_VERSION"
 	git clone https://github.com/containerd/containerd.git "$GOPATH/src/github.com/containerd/containerd"
 	cd "$GOPATH/src/github.com/containerd/containerd"
-	git checkout -q "$CONTAINERD_COMMIT"
+	git checkout -q "$CONTAINERD_VERSION"
 
 	export BUILDTAGS='netgo osusergo static_build'
 	export EXTRA_FLAGS=${GO_BUILDMODE}

--- a/hack/dockerfile/install/golangci_lint.installer
+++ b/hack/dockerfile/install/golangci_lint.installer
@@ -4,7 +4,7 @@
 
 install_golangci_lint() {
 	set -e
-	export GO111MODULE=on
-	GOBIN="${PREFIX}" go get "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"
+	echo "Install golangci-lint version ${GOLANGCI_LINT_VERSION}"
+	GOBIN="${PREFIX}" GO111MODULE=on go install "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"
 	"${PREFIX}"/golangci-lint --version
 }

--- a/hack/dockerfile/install/golangci_lint.installer
+++ b/hack/dockerfile/install/golangci_lint.installer
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-: "${GOLANGCI_LINT_COMMIT=v1.23.8}"
+: "${GOLANGCI_LINT_VERSION=v1.23.8}"
 
 install_golangci_lint() {
 	set -e
 	export GO111MODULE=on
-	GOBIN="${PREFIX}" go get "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_COMMIT}"
+	GOBIN="${PREFIX}" go get "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"
 	"${PREFIX}"/golangci-lint --version
 }

--- a/hack/dockerfile/install/gotestsum.installer
+++ b/hack/dockerfile/install/gotestsum.installer
@@ -4,6 +4,6 @@
 
 install_gotestsum() (
 	set -e
-	export GO111MODULE=on
-	GOBIN="${PREFIX}" go get "gotest.tools/gotestsum@${GOTESTSUM_VERSION}"
+	echo "Install gotestsum version ${GOTESTSUM_VERSION}"
+	GOBIN="${PREFIX}" GO111MODULE=on go install "gotest.tools/gotestsum@${GOTESTSUM_VERSION}"
 )

--- a/hack/dockerfile/install/gotestsum.installer
+++ b/hack/dockerfile/install/gotestsum.installer
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-: ${GOTESTSUM_COMMIT:=v0.5.3}
+: ${GOTESTSUM_VERSION:=v0.5.3}
 
 install_gotestsum() (
 	set -e
 	export GO111MODULE=on
-	GOBIN="${PREFIX}" go get "gotest.tools/gotestsum@${GOTESTSUM_COMMIT}"
+	GOBIN="${PREFIX}" go get "gotest.tools/gotestsum@${GOTESTSUM_VERSION}"
 )

--- a/hack/dockerfile/install/gotestsum.installer
+++ b/hack/dockerfile/install/gotestsum.installer
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-: ${GOTESTSUM_VERSION:=v0.5.3}
+: ${GOTESTSUM_VERSION:=v1.7.0}
 
 install_gotestsum() (
 	set -e

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -31,11 +31,6 @@ _install_rootlesskit() (
 	cd "$GOPATH/src/github.com/rootless-containers/rootlesskit" || exit 1
 	git checkout -q "$ROOTLESSKIT_COMMIT"
 	export GO111MODULE=on
-	# TODO remove GOPROXY override once we updated to Go 1.14+
-	# Using goproxy instead of "direct" to work around an issue in go mod
-	# on Go 1.13 not working with older git versions (default version on
-	# CentOS 7 is git 1.8), see https://github.com/golang/go/issues/38373
-	export GOPROXY="https://proxy.golang.org"
 	for f in rootlesskit rootlesskit-docker-proxy; do
 		go build $BUILD_MODE -ldflags="$ROOTLESSKIT_LDFLAGS" -o "${PREFIX}/$f" github.com/rootless-containers/rootlesskit/cmd/$f
 	done

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-# v0.14.4
-: "${ROOTLESSKIT_COMMIT:=87d443683ac1e8aba4110b8081f15aaae432aaa2}"
+: "${ROOTLESSKIT_VERSION:=v0.14.4}"
 
 install_rootlesskit() {
 	case "$1" in
@@ -26,12 +25,8 @@ install_rootlesskit_dynamic() {
 }
 
 _install_rootlesskit() (
-	echo "Install rootlesskit version $ROOTLESSKIT_COMMIT"
-	git clone https://github.com/rootless-containers/rootlesskit.git "$GOPATH/src/github.com/rootless-containers/rootlesskit"
-	cd "$GOPATH/src/github.com/rootless-containers/rootlesskit" || exit 1
-	git checkout -q "$ROOTLESSKIT_COMMIT"
-	export GO111MODULE=on
+	echo "Install rootlesskit version ${ROOTLESSKIT_VERSION}"
 	for f in rootlesskit rootlesskit-docker-proxy; do
-		go build $BUILD_MODE -ldflags="$ROOTLESSKIT_LDFLAGS" -o "${PREFIX}/$f" github.com/rootless-containers/rootlesskit/cmd/$f
+		GOBIN="${PREFIX}" GO111MODULE=on go install ${BUILD_MODE} -ldflags="$ROOTLESSKIT_LDFLAGS" "github.com/rootless-containers/rootlesskit/cmd/${f}@${ROOTLESSKIT_VERSION}"
 	done
 )

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 # When updating RUNC_COMMIT, also update runc in vendor.conf accordingly
 # The version of runc should match the version that is used by the containerd
@@ -7,13 +8,7 @@
 : ${RUNC_COMMIT:=52b36a2dd837e8462de8e01458bf02cf9eea47dd} # v1.0.2
 
 install_runc() {
-	# If using RHEL7 kernels (3.10.0 el7), disable kmem accounting/limiting
-	if uname -r | grep -q '^3\.10\.0.*\.el7\.'; then
-		: ${RUNC_NOKMEM='nokmem'}
-	fi
-
-	# Do not build with ambient capabilities support
-	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp $RUNC_NOKMEM"}"
+	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"
 
 	echo "Install runc version $RUNC_COMMIT (build tags: $RUNC_BUILDTAGS)"
 	git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc"

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -1,19 +1,23 @@
 #!/bin/sh
 set -e
 
-# When updating RUNC_COMMIT, also update runc in vendor.conf accordingly
+# RUNC_VERSION specifies the version of runc to install from the
+# https://github.com/opencontainers/runc repository.
+#
 # The version of runc should match the version that is used by the containerd
 # version that is used. If you need to update runc, open a pull request in
 # the containerd project first, and update both after that is merged.
-: ${RUNC_COMMIT:=52b36a2dd837e8462de8e01458bf02cf9eea47dd} # v1.0.2
+#
+# When updating RUNC_VERSION, consider updating runc in vendor.conf accordingly
+: "${RUNC_VERSION:=v1.0.2}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"
 
-	echo "Install runc version $RUNC_COMMIT (build tags: $RUNC_BUILDTAGS)"
+	echo "Install runc version $RUNC_VERSION (build tags: $RUNC_BUILDTAGS)"
 	git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc"
 	cd "$GOPATH/src/github.com/opencontainers/runc"
-	git checkout -q "$RUNC_COMMIT"
+	git checkout -q "$RUNC_VERSION"
 	if [ -z "$1" ]; then
 		target=static
 	else

--- a/hack/dockerfile/install/shfmt.installer
+++ b/hack/dockerfile/install/shfmt.installer
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-: "${SHFMT_COMMIT:=01725bdd30658db1fe1b9e02173c3060061fe86f}" # v3.0.2
+: "${SHFMT_VERSION:=v3.0.2}"
 
 install_shfmt() {
-	echo "Install shfmt version $SHFMT_COMMIT"
+	echo "Install shfmt version $SHFMT_VERSION"
 	git clone https://github.com/mvdan/sh.git "$GOPATH/src/github.com/mvdan/sh"
 	cd "$GOPATH/src/github.com/mvdan/sh" || exit 1
-	git checkout -q "$SHFMT_COMMIT"
+	git checkout -q "$SHFMT_VERSION"
 	GO111MODULE=on go build ${GO_BUILDMODE} -v -o "${PREFIX}/shfmt" ./cmd/shfmt
 }

--- a/hack/dockerfile/install/shfmt.installer
+++ b/hack/dockerfile/install/shfmt.installer
@@ -4,8 +4,5 @@
 
 install_shfmt() {
 	echo "Install shfmt version $SHFMT_VERSION"
-	git clone https://github.com/mvdan/sh.git "$GOPATH/src/github.com/mvdan/sh"
-	cd "$GOPATH/src/github.com/mvdan/sh" || exit 1
-	git checkout -q "$SHFMT_VERSION"
-	GO111MODULE=on go build ${GO_BUILDMODE} -v -o "${PREFIX}/shfmt" ./cmd/shfmt
+	GOBIN="${PREFIX}" GO111MODULE=on go install "mvdan.cc/sh/v3/cmd/shfmt@${SHFMT_VERSION}"
 }

--- a/hack/dockerfile/install/tini.installer
+++ b/hack/dockerfile/install/tini.installer
@@ -1,12 +1,15 @@
 #!/bin/sh
 
-: ${TINI_COMMIT:=de40ad007797e0dcd8b7126f27bb87401d224240} # v0.19.0
+# TINI_VERSION specifies the version of tini (docker-init) to build, and install
+# from the https://github.com/krallin/tini repository. This binary is used
+# when starting containers with the `--init` option.
+: "${TINI_VERSION:=v0.19.0}"
 
 install_tini() {
-	echo "Install tini version $TINI_COMMIT"
+	echo "Install tini version $TINI_VERSION"
 	git clone https://github.com/krallin/tini.git "$GOPATH/tini"
 	cd "$GOPATH/tini"
-	git checkout -q "$TINI_COMMIT"
+	git checkout -q "$TINI_VERSION"
 	cmake .
 	make tini-static
 	mkdir -p "${PREFIX}"

--- a/hack/dockerfile/install/tomll.installer
+++ b/hack/dockerfile/install/tomll.installer
@@ -4,6 +4,5 @@
 
 install_tomll() {
 	echo "Install go-toml version ${GOTOML_VERSION}"
-	# TODO remove GO111MODULE=on and change to 'go install -mod=mod ...' once we're at go 1.16+
-	GO111MODULE=on GOBIN="${PREFIX}" go get -v "github.com/pelletier/go-toml/cmd/tomll@${GOTOML_VERSION}"
+	GOBIN="${PREFIX}" GO111MODULE=on go install "github.com/pelletier/go-toml/cmd/tomll@${GOTOML_VERSION}"
 }

--- a/hack/dockerfile/install/vndr.installer
+++ b/hack/dockerfile/install/vndr.installer
@@ -4,8 +4,5 @@
 
 install_vndr() {
 	echo "Install vndr version $VNDR_VERSION"
-	git clone https://github.com/LK4D4/vndr.git "$GOPATH/src/github.com/LK4D4/vndr"
-	cd "$GOPATH/src/github.com/LK4D4/vndr" || exit 1
-	git checkout -q "$VNDR_VERSION"
-	go build ${GO_BUILDMODE} -v -o "${PREFIX}/vndr" .
+	GOBIN="${PREFIX}" GO111MODULE=on go install "github.com/LK4D4/vndr@${VNDR_VERSION}"
 }

--- a/hack/dockerfile/install/vndr.installer
+++ b/hack/dockerfile/install/vndr.installer
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-: "${VNDR_COMMIT:=f12b881cb8f081a5058408a58f429b9014833fc6}" # v0.1.2
+: "${VNDR_VERSION:=v0.1.2}"
 
 install_vndr() {
-	echo "Install vndr version $VNDR_COMMIT"
+	echo "Install vndr version $VNDR_VERSION"
 	git clone https://github.com/LK4D4/vndr.git "$GOPATH/src/github.com/LK4D4/vndr"
 	cd "$GOPATH/src/github.com/LK4D4/vndr" || exit 1
-	git checkout -q "$VNDR_COMMIT"
+	git checkout -q "$VNDR_VERSION"
 	go build ${GO_BUILDMODE} -v -o "${PREFIX}/vndr" .
 }


### PR DESCRIPTION
### Dockerfile: use version for some utilities instead of commit-sha

The golangci-lint, gotestsum, shfmt, and vndr utilities should generally
be ok to be pinned by version instead of a specific sha. Also rename
the corresponding env-vars / build-args accordingly:

- GOLANGCI_LINT_COMMIT -> GOLANGCI_LINT_VERSION
- GOTESTSUM_COMMIT -> GOTESTSUM_VERSION
- SHFMT_COMMIT -> SHFMT_VERSION
- VNDR_COMMIT -> VNDR_VERSION
- CONTAINERD_COMMIT -> CONTAINERD_VERSION
- RUNC_COMMIT -> RUNC_VERSION
- ROOTLESS_COMMIT -> ROOTLESS_VERSION

### Dockerfile: use "go install" to install utilities

### Dockerfile: remove GOPROXY override (was for go < 1.14)

### Dockerfile: update gotestsum to v1.7.0

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

