### PR TITLE
vendor: github.com/docker/swarmkit 3629f50980f6c0dd5ccd7dbfa0956b57ea0cd78d

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -142,7 +142,7 @@ github.com/klauspost/compress                       a3b7545c88eea469c2246bee0e6c
 github.com/pelletier/go-toml                        65ca8064882c8c308e5c804c5d5443d409e0738c # v1.8.1
 
 # cluster
-github.com/docker/swarmkit                          2dcf70aafdc9ea55af3aaaeca440638cde0ecda6  # master
+github.com/docker/swarmkit                          3629f50980f6c0dd5ccd7dbfa0956b57ea0cd78d  # master
 github.com/gogo/protobuf                            b03c65ea87cdc3521ede29f62fe3ce239267c1bc # v1.3.2
 github.com/golang/protobuf                          84668698ea25b64748563aa20726db66a6b8d299 # v1.3.5
 github.com/cloudflare/cfssl                         5d63dbd981b5c408effbb58c442d54761ff94fbd # 1.3.2

--- a/vendor/github.com/docker/swarmkit/vendor.conf
+++ b/vendor/github.com/docker/swarmkit/vendor.conf
@@ -31,7 +31,7 @@ github.com/prometheus/procfs                        46159f73e74d1cb8dc223deef9b2
 github.com/cespare/xxhash/v2                        d7df74196a9e781ede915320c11c378c1b2f3a1f # v2.1.1
 
 github.com/docker/distribution                      0d3efadf0154c2b8a4e7b6621fff9809655cc580
-github.com/docker/docker                            0ad2293d0e5bbf4c966a0e8b27c3ac3835265577 # master / v21.xx-dev
+github.com/docker/docker                            471fd27709777d2cce3251129887e14e8bb2e0c7 # master / v21.xx-dev
 github.com/docker/go-connections                    7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0
 github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
 github.com/docker/go-units                          519db1ee28dcc9fd2474ae59fca29a810482bfb1 # v0.4.0


### PR DESCRIPTION
removes use of the deprecated pkg/signal.

full diff: https://github.com/docker/swarmkit/compare/2dcf70aafdc9ea55af3aaaeca440638cde0ecda6...3629f50980f6c0dd5ccd7dbfa0956b57ea0cd78d

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

