### PR TITLE
seccomp: add support for "clone3" syscall in default policy

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -553,6 +553,7 @@
 			"names": [
 				"bpf",
 				"clone",
+				"clone3",
 				"fanotify_init",
 				"fsconfig",
 				"fsmount",
@@ -621,6 +622,18 @@
 					"s390x"
 				]
 			},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				]
+			}
+		},
+		{
+			"names": [
+				"clone3"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"errnoRet": 38,
 			"excludes": {
 				"caps": [
 					"CAP_SYS_ADMIN"

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -42,6 +42,7 @@ func arches() []Architecture {
 
 // DefaultProfile defines the allowed syscalls for the default seccomp profile.
 func DefaultProfile() *Seccomp {
+	nosys := uint(unix.ENOSYS)
 	syscalls := []*Syscall{
 		{
 			LinuxSyscall: specs.LinuxSyscall{
@@ -546,6 +547,7 @@ func DefaultProfile() *Seccomp {
 				Names: []string{
 					"bpf",
 					"clone",
+					"clone3",
 					"fanotify_init",
 					"fsconfig",
 					"fsmount",
@@ -610,6 +612,18 @@ func DefaultProfile() *Seccomp {
 			Comment: "s390 parameter ordering for clone is different",
 			Includes: &Filter{
 				Arches: []string{"s390", "s390x"},
+			},
+			Excludes: &Filter{
+				Caps: []string{"CAP_SYS_ADMIN"},
+			},
+		},
+		{
+			LinuxSyscall: specs.LinuxSyscall{
+				Names: []string{
+					"clone3",
+				},
+				Action:   specs.ActErrno,
+				ErrnoRet: &nosys,
 			},
 			Excludes: &Filter{
 				Caps: []string{"CAP_SYS_ADMIN"},


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Modified the default seccomp profile so that clone3 is explicitly requested to give ENOSYS instead of the default EPERM, when CAP_SYS_ADMIN is unset.

If CAP_SYS_ADMIN is set, then clone3 is simply allowed unconditionally

**- How to verify it**
Test by using

  $ docker run registry.fedoraproject.org/fedora:rawhide curl google.com

It should dump the HTML if seccomp is correctly triggering fallback from clone3 to clone.

**- Description for the changelog**

Explicitly set clone3 syscall to return ENOSYS to ensure glibc will correctly fallback to using clone. This fixes ability to spawn threads in Fedora 35 rawhide container images which now default to clone3. The default errno of EPERM results in a fatal error making the images unusable when seccomp is enabled.

Fixes https://github.com/moby/moby/issues/42680
fixes https://github.com/moby/moby/issues/42963
fixes https://github.com/moby/moby/issues/42876
