### PR TITLE
client: remove deprecated SetCustomHTTPHeaders(), CustomHTTPHeaders()

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -282,6 +282,7 @@ func ParseHostURL(host string) (*url.URL, error) {
 }
 
 // CustomHTTPHeaders returns the custom http headers stored by the client.
+// Deprecated: this function was unused, and will be removed in the next release.
 func (cli *Client) CustomHTTPHeaders() map[string]string {
 	m := make(map[string]string)
 	for k, v := range cli.customHTTPHeaders {

--- a/client/client.go
+++ b/client/client.go
@@ -281,22 +281,6 @@ func ParseHostURL(host string) (*url.URL, error) {
 	}, nil
 }
 
-// CustomHTTPHeaders returns the custom http headers stored by the client.
-// Deprecated: this function was unused, and will be removed in the next release.
-func (cli *Client) CustomHTTPHeaders() map[string]string {
-	m := make(map[string]string)
-	for k, v := range cli.customHTTPHeaders {
-		m[k] = v
-	}
-	return m
-}
-
-// SetCustomHTTPHeaders that will be set on every HTTP request made by the client.
-// Deprecated: use WithHTTPHeaders when creating the client.
-func (cli *Client) SetCustomHTTPHeaders(headers map[string]string) {
-	cli.customHTTPHeaders = headers
-}
-
 // Dialer returns a dialer for a raw stream connection, with HTTP/1.1 header, that can be used for proxying the daemon connection.
 // Used by `docker dial-stdio` (docker/cli#889).
 func (cli *Client) Dialer() func(context.Context) (net.Conn, error) {


### PR DESCRIPTION
### client: deprecate client.CustomHTTPHeaders()

This function was added in a754d89b4058d8508cf3cee29f6107b2f93f3001 (https://github.com/moby/moby/pull/27622), but not used. Currently, the only consumer of this function I could find was docker/cli, which used it in a unit-test (this test has already been updated to not depend on this function); https://grep.app/search?q=.CustomHTTPHeaders%28%29&filter[lang][0]=Go

Given that commit a68ae4a2d95b1ff143025a435195af0f1ab30ace (https://github.com/moby/moby/pull/34899) deprecated the corresponding `client.SetCustomHTTPHeaders()` function, and because there is no active use for this function, it should be ok to deprecate.

We can include this in a patch-release (to be sure nobody else is depending on it, and (if someone is) to notify them of the deprecation.

As a follow-up to this commit, I'll remove both functions.

### client: remove deprecated SetCustomHTTPHeaders(), CustomHTTPHeaders()

Both of these function were added in a754d89b4058d8508cf3cee29f6107b2f93f3001 (https://github.com/moby/moby/pull/27622).

The `CustomHTTPHeaders()` was not used, except for a unit test in docker/cli (this test has already been updated to not depend on this function in https://github.com/docker/cli/pull/3221); https://grep.app/search?q=.CustomHTTPHeaders%28%29&filter[lang][0]=Go

Commit a68ae4a2d95b1ff143025a435195af0f1ab30ace (https://github.com/moby/moby/pull/34899)  deprecated `SetCustomHTTPHeaders()`, and looks to be unused; https://grep.app/search?q=.SetCustomHTTPHeaders%28&filter[lang][0]=Go


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

