### PR TITLE
[20.10] update containerd binary to v1.4.9

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=7eba5930496d9bbe375fdf71603e610ad737d2b2}" # v1.4.8
+: "${CONTAINERD_COMMIT:=e25210fe30a0a703442421b0f60afac609f950a3}" # v1.4.9
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
relates to https://github.com/containerd/containerd/issues/5759
relates to https://github.com/moby/moby/issues/42677
relates to https://github.com/moby/moby/pull/42659


Welcome to the v1.4.9 release of containerd!

The ninth patch release for containerd 1.4 updates runc to 1.0.1 and contains
other minor updates.

Notable Updates

- Update runc binary to 1.0.1
- Update pull authorization logic on redirect
- Fix user agent used for fetching registry authentication tokens

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

