### PR TITLE
libnetwork: wait until t.Deadline() instead of hardcoded value

### DIFF
--- a/libnetwork/networkdb/networkdb_test.go
+++ b/libnetwork/networkdb/networkdb_test.go
@@ -481,7 +481,6 @@ func TestNetworkDBCRUDMediumCluster(t *testing.T) {
 }
 
 func TestNetworkDBNodeJoinLeaveIteration(t *testing.T) {
-	maxRetry := 5
 	dbs := createNetworkDBInstances(t, 2, "node", DefaultConfig())
 
 	// Single node Join/Leave
@@ -530,22 +529,12 @@ func TestNetworkDBNodeJoinLeaveIteration(t *testing.T) {
 	err = dbs[0].JoinNetwork("network1")
 	assert.NilError(t, err)
 
-	for i := 0; i < maxRetry; i++ {
-		if len(dbs[0].networkNodes["network1"]) == 2 {
-			break
-		}
-		time.Sleep(1 * time.Second)
-	}
+	dbs[0].verifyNetworkExistence(t, dbs[1].config.NodeID, "network1", true)
 	if len(dbs[0].networkNodes["network1"]) != 2 {
 		t.Fatalf("The networkNodes list has to have be 2 instead of %d - %v", len(dbs[0].networkNodes["network1"]), dbs[0].networkNodes["network1"])
 	}
 
-	for i := 0; i < maxRetry; i++ {
-		if len(dbs[1].networkNodes["network1"]) == 2 {
-			break
-		}
-		time.Sleep(1 * time.Second)
-	}
+	dbs[1].verifyNetworkExistence(t, dbs[0].config.NodeID, "network1", true)
 	if len(dbs[1].networkNodes["network1"]) != 2 {
 		t.Fatalf("The networkNodes list has to have be 2 instead of %d - %v", len(dbs[1].networkNodes["network1"]), dbs[1].networkNodes["network1"])
 	}

--- a/libnetwork/networkdb/networkdb_test.go
+++ b/libnetwork/networkdb/networkdb_test.go
@@ -99,7 +99,15 @@ func (db *NetworkDB) verifyNodeExistence(t *testing.T, node string, present bool
 
 func (db *NetworkDB) verifyNetworkExistence(t *testing.T, node string, id string, present bool) {
 	t.Helper()
-	for i := 0; i < 80; i++ {
+
+	const sleepInterval = 50 * time.Millisecond
+	var maxRetries int64
+	if dl, ok := t.Deadline(); ok {
+		maxRetries = int64(time.Until(dl) / sleepInterval)
+	} else {
+		maxRetries = 80
+	}
+	for i := int64(0); i < maxRetries; i++ {
 		db.RLock()
 		nn, nnok := db.networks[node]
 		db.RUnlock()
@@ -116,7 +124,7 @@ func (db *NetworkDB) verifyNetworkExistence(t *testing.T, node string, id string
 			}
 		}
 
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(sleepInterval)
 	}
 
 	t.Error("Network existence verification failed")


### PR DESCRIPTION
(hopefully?) closes https://github.com/moby/moby/issues/42698

**- What I did**
It seems that the flakiness is caused by the occasional slowness of the CI, hence wait until `t.Deadline` for node to appear instead of relying on a hard-coded value, which may or may not suffice in all environments.
Also applied the same "waiting" approach from #42625 in the unit test in question.

**- How I did it**
Check for `t.Deadline` and, if set, wait until at most that; use the previous hard-coded value otherwise. Since we set `timeout` in `hack/test/unit`, the deadline value should generally be set regardless of the environment, so this should work in CI, as well as locally (unless, of course, tests are run directly with `go test`).

**- How to verify it**
I suppose the only way would be to observe multiple CI runs

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

