### PR TITLE
Clean-up container disk usage output

### DIFF
--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -157,11 +157,6 @@ func (s *systemRouter) getDiskUsage(ctx context.Context, w http.ResponseWriter, 
 			if err != nil {
 				return errors.Wrap(err, "error getting build cache usage")
 			}
-			if buildCache == nil {
-				// Ensure empty `BuildCache` field is represented as empty JSON array(`[]`)
-				// instead of `null` to be consistent with `Images`, `Containers` etc.
-				buildCache = []*types.BuildCache{}
-			}
 			return nil
 		})
 	}
@@ -196,6 +191,15 @@ func (s *systemRouter) getDiskUsage(ctx context.Context, w http.ResponseWriter, 
 		du.Containers = systemDiskUsage.Containers
 		du.Volumes = systemDiskUsage.Volumes
 	}
+
+	// Ensure empty fields are represented as empty JSON array(`[]`) instead of `null` when selected.
+	if getContainers && du.Containers == nil {
+		du.Containers = []*types.ContainerUsage{}
+	}
+	if getBuildCache && du.BuildCache == nil {
+		du.BuildCache = []*types.BuildCache{}
+	}
+
 	var out interface{} = du
 	if versions.LessThan(version, "1.42") {
 		type pre142Container struct {

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1972,7 +1972,7 @@ definitions:
         type: "string"
         description: "Mount path of the volume on the host."
         x-nullable: false
-        example: "/var/lib/docker/volumes/tardis"
+        example: "/var/lib/docker/volumes/tardis/_data"
       CreatedAt:
         type: "string"
         format: "dateTime"
@@ -2040,6 +2040,7 @@ definitions:
               driver. For volumes created with other volume drivers, this field
               is set to `-1` ("not available")
             x-nullable: false
+            example: 10920104
           RefCount:
             type: "integer"
             format: "int64"
@@ -2048,6 +2049,7 @@ definitions:
               The number of containers referencing this volume. This field
               is set to `-1` if the reference-count is not available.
             x-nullable: false
+            example: 2
 
   VolumeCreateOptions:
     description: "Volume configuration"
@@ -2326,6 +2328,29 @@ definitions:
       UsageCount:
         type: "integer"
         example: 26
+    example:
+      -
+        ID: "hw53o5aio51xtltp5xjp8v7fx"
+        Parents: []
+        Type: "regular"
+        Description: "pulled from docker.io/library/debian@sha256:234cb88d3020898631af0ccbbcca9a66ae7306ecd30c9720690858c1b007d2a0"
+        InUse: false
+        Shared: true
+        Size: 0
+        CreatedAt: "2021-06-28T13:31:01.474619385Z"
+        LastUsedAt: "2021-07-07T22:02:32.738075951Z"
+        UsageCount: 26
+      -
+        ID: "ndlpt0hhvkqcdfkputsk4cq9c"
+        Parents: ["ndlpt0hhvkqcdfkputsk4cq9c"]
+        Type: "regular"
+        Description: "mount / from exec /bin/sh -c echo 'Binary::apt::APT::Keep-Downloaded-Packages \"true\";' > /etc/apt/apt.conf.d/keep-cache"
+        InUse: false
+        Shared: true
+        Size: 51
+        CreatedAt: "2021-06-28T13:31:03.002625487Z"
+        LastUsedAt: "2021-07-07T22:02:32.773909517Z"
+        UsageCount: 26
 
   ImageID:
     type: "object"
@@ -9013,6 +9038,7 @@ paths:
               LayersSize:
                 type: "integer"
                 format: "int64"
+                example: 1092588
               Images:
                 type: "array"
                 items:
@@ -9021,6 +9047,38 @@ paths:
                 type: "array"
                 items:
                   $ref: "#/definitions/ContainerSummary"
+                example:
+                  -
+                    Id: "e575172ed11dc01bfce087fb27bee502db149e1a0fad7c296ad300bbff178148"
+                    Names:
+                      - "/top"
+                    Image: "busybox"
+                    ImageID: "sha256:2b8fd9751c4c0f5dd266fcae00707e67a2545ef34f9a29354585f93dac906749"
+                    Command: "top"
+                    Created: 1472592424
+                    Ports: []
+                    SizeRootFs: 1092588
+                    Labels: {}
+                    State: "exited"
+                    Status: "Exited (0) 56 minutes ago"
+                    HostConfig:
+                      NetworkMode: "default"
+                    NetworkSettings:
+                      Networks:
+                        bridge:
+                          IPAMConfig: null
+                          Links: null
+                          Aliases: null
+                          NetworkID: "d687bc59335f0e5c9ee8193e5612e8aee000c8c62ea170cfb99c098f95899d92"
+                          EndpointID: "8ed5115aeaad9abb174f68dcf135b49f11daf597678315231a32ca28441dec6a"
+                          Gateway: "172.18.0.1"
+                          IPAddress: "172.18.0.2"
+                          IPPrefixLen: 16
+                          IPv6Gateway: ""
+                          GlobalIPv6Address: ""
+                          GlobalIPv6PrefixLen: 0
+                          MacAddress: "02:42:ac:12:00:02"
+                    Mounts: []
               Volumes:
                 type: "array"
                 items:
@@ -9029,88 +9087,6 @@ paths:
                 type: "array"
                 items:
                   $ref: "#/definitions/BuildCache"
-            example:
-              LayersSize: 1092588
-              Images:
-                -
-                  Id: "sha256:2b8fd9751c4c0f5dd266fcae00707e67a2545ef34f9a29354585f93dac906749"
-                  ParentId: ""
-                  RepoTags:
-                    - "busybox:latest"
-                  RepoDigests:
-                    - "busybox@sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6"
-                  Created: 1466724217
-                  Size: 1092588
-                  SharedSize: 0
-                  VirtualSize: 1092588
-                  Labels: {}
-                  Containers: 1
-              Containers:
-                -
-                  Id: "e575172ed11dc01bfce087fb27bee502db149e1a0fad7c296ad300bbff178148"
-                  Names:
-                    - "/top"
-                  Image: "busybox"
-                  ImageID: "sha256:2b8fd9751c4c0f5dd266fcae00707e67a2545ef34f9a29354585f93dac906749"
-                  Command: "top"
-                  Created: 1472592424
-                  Ports: []
-                  SizeRootFs: 1092588
-                  Labels: {}
-                  State: "exited"
-                  Status: "Exited (0) 56 minutes ago"
-                  HostConfig:
-                    NetworkMode: "default"
-                  NetworkSettings:
-                    Networks:
-                      bridge:
-                        IPAMConfig: null
-                        Links: null
-                        Aliases: null
-                        NetworkID: "d687bc59335f0e5c9ee8193e5612e8aee000c8c62ea170cfb99c098f95899d92"
-                        EndpointID: "8ed5115aeaad9abb174f68dcf135b49f11daf597678315231a32ca28441dec6a"
-                        Gateway: "172.18.0.1"
-                        IPAddress: "172.18.0.2"
-                        IPPrefixLen: 16
-                        IPv6Gateway: ""
-                        GlobalIPv6Address: ""
-                        GlobalIPv6PrefixLen: 0
-                        MacAddress: "02:42:ac:12:00:02"
-                  Mounts: []
-              Volumes:
-                -
-                  Name: "my-volume"
-                  Driver: "local"
-                  Mountpoint: "/var/lib/docker/volumes/my-volume/_data"
-                  Labels: null
-                  Scope: "local"
-                  Options: null
-                  UsageData:
-                    Size: 10920104
-                    RefCount: 2
-              BuildCache:
-                -
-                  ID: "hw53o5aio51xtltp5xjp8v7fx"
-                  Parents: []
-                  Type: "regular"
-                  Description: "pulled from docker.io/library/debian@sha256:234cb88d3020898631af0ccbbcca9a66ae7306ecd30c9720690858c1b007d2a0"
-                  InUse: false
-                  Shared: true
-                  Size: 0
-                  CreatedAt: "2021-06-28T13:31:01.474619385Z"
-                  LastUsedAt: "2021-07-07T22:02:32.738075951Z"
-                  UsageCount: 26
-                -
-                  ID: "ndlpt0hhvkqcdfkputsk4cq9c"
-                  Parents: ["ndlpt0hhvkqcdfkputsk4cq9c"]
-                  Type: "regular"
-                  Description: "mount / from exec /bin/sh -c echo 'Binary::apt::APT::Keep-Downloaded-Packages \"true\";' > /etc/apt/apt.conf.d/keep-cache"
-                  InUse: false
-                  Shared: true
-                  Size: 51
-                  CreatedAt: "2021-06-28T13:31:03.002625487Z"
-                  LastUsedAt: "2021-07-07T22:02:32.773909517Z"
-                  UsageCount: 26
         500:
           description: "server error"
           schema:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4637,6 +4637,14 @@ definitions:
       Spec:
         $ref: "#/definitions/ConfigSpec"
 
+  ContainerStateStatus:
+    description: |
+      String representation of the container state. Can be one of "created",
+      "running", "paused", "restarting", "removing", "exited", or "dead".
+    type: "string"
+    enum: ["created", "running", "paused", "restarting", "removing", "exited", "dead"]
+    example: "running"
+
   ContainerState:
     description: |
       ContainerState stores container's running state. It's part of ContainerJSONBase
@@ -4645,12 +4653,7 @@ definitions:
     x-nullable: true
     properties:
       Status:
-        description: |
-          String representation of the container state. Can be one of "created",
-          "running", "paused", "restarting", "removing", "exited", or "dead".
-        type: "string"
-        enum: ["created", "running", "paused", "restarting", "removing", "exited", "dead"]
-        example: "running"
+        $ref: "#/definitions/ContainerStateStatus"
       Running:
         description: |
           Whether this container is running.

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4522,6 +4522,68 @@ definitions:
         items:
           $ref: "#/definitions/MountPoint"
 
+  ContainerUsage:
+    description: "ContainerUsage describes the data usage of a container"
+    type: "object"
+    properties:
+      Id:
+        description: "The ID of this container"
+        type: "string"
+        x-go-name: "ID"
+        example: "e575172ed11dc01bfce087fb27bee502db149e1a0fad7c296ad300bbff178148"
+      Names:
+        description: "The names that this container has been given"
+        type: "array"
+        items:
+          type: "string"
+        example: ["thirsty_lederberg"]
+      Image:
+        description: "The name of the image used when creating this container"
+        type: "string"
+        example: "busybox"
+      ImageID:
+        description: "The ID of the image that this container was created from"
+        type: "string"
+        example: "sha256:2b8fd9751c4c0f5dd266fcae00707e67a2545ef34f9a29354585f93dac906749"
+      Command:
+        type: "string"
+        description: "Command to run when starting this container"
+        example: "top"
+      Created:
+        description: "When the container was created"
+        type: "integer"
+        format: "int64"
+        example: 1472592424
+      Ports:
+        description: "The ports exposed by this container"
+        type: "array"
+        items:
+          $ref: "#/definitions/Port"
+      SizeRw:
+        description: "The size of files that have been created or changed by this container"
+        type: "integer"
+        format: "int64"
+      SizeRootFs:
+        description: "The total size of all the files in this container"
+        type: "integer"
+        format: "int64"
+        example: 1092588
+      Labels:
+        description: "User-defined key/value metadata."
+        type: "object"
+        additionalProperties:
+          type: "string"
+      State:
+        $ref: "#/definitions/ContainerStateStatus"
+      Status:
+        description: "Additional human-readable status of this container"
+        type: "string"
+        example: "Exited (0) 56 minutes ago"
+      Mounts:
+        type: "array"
+        items:
+          $ref: "#/definitions/MountPoint"
+
   Driver:
     description: "Driver represents a driver (network, logging, secrets)."
     type: "object"
@@ -9049,39 +9111,7 @@ paths:
               Containers:
                 type: "array"
                 items:
-                  $ref: "#/definitions/ContainerSummary"
-                example:
-                  -
-                    Id: "e575172ed11dc01bfce087fb27bee502db149e1a0fad7c296ad300bbff178148"
-                    Names:
-                      - "/top"
-                    Image: "busybox"
-                    ImageID: "sha256:2b8fd9751c4c0f5dd266fcae00707e67a2545ef34f9a29354585f93dac906749"
-                    Command: "top"
-                    Created: 1472592424
-                    Ports: []
-                    SizeRootFs: 1092588
-                    Labels: {}
-                    State: "exited"
-                    Status: "Exited (0) 56 minutes ago"
-                    HostConfig:
-                      NetworkMode: "default"
-                    NetworkSettings:
-                      Networks:
-                        bridge:
-                          IPAMConfig: null
-                          Links: null
-                          Aliases: null
-                          NetworkID: "d687bc59335f0e5c9ee8193e5612e8aee000c8c62ea170cfb99c098f95899d92"
-                          EndpointID: "8ed5115aeaad9abb174f68dcf135b49f11daf597678315231a32ca28441dec6a"
-                          Gateway: "172.18.0.1"
-                          IPAddress: "172.18.0.2"
-                          IPPrefixLen: 16
-                          IPv6Gateway: ""
-                          GlobalIPv6Address: ""
-                          GlobalIPv6PrefixLen: 0
-                          MacAddress: "02:42:ac:12:00:02"
-                    Mounts: []
+                  $ref: "#/definitions/ContainerUsage"
               Volumes:
                 type: "array"
                 items:

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -689,12 +689,30 @@ type DiskUsageOptions struct {
 	Types []DiskUsageObject
 }
 
+// ContainerUsage contains container usage part of response of Engine API:
+// GET "/system/df"
+type ContainerUsage struct {
+	ID         string `json:"Id"` // Use "Id" in JSON for backward-compatibility with API < 1.42
+	Names      []string
+	Image      string
+	ImageID    string
+	Command    string
+	Created    int64
+	Ports      []Port
+	SizeRw     int64 `json:",omitempty"`
+	SizeRootFs int64 `json:",omitempty"`
+	Labels     map[string]string
+	State      string
+	Status     string
+	Mounts     []MountPoint
+}
+
 // DiskUsage contains response of Engine API:
 // GET "/system/df"
 type DiskUsage struct {
 	LayersSize  int64
 	Images      []*ImageSummary
-	Containers  []*Container
+	Containers  []*ContainerUsage
 	Volumes     []*volume.Volume
 	BuildCache  []*BuildCache
 	BuilderSize int64 `json:",omitempty"` // Deprecated: deprecated in API 1.38, and no longer used since API 1.40.

--- a/client/disk_usage_test.go
+++ b/client/disk_usage_test.go
@@ -35,8 +35,15 @@ func TestDiskUsage(t *testing.T) {
 			du := types.DiskUsage{
 				LayersSize: int64(100),
 				Images:     nil,
-				Containers: nil,
-				Volumes:    nil,
+				Containers: []*types.ContainerUsage{
+					{
+						ID:         "test-id",
+						Names:      []string{"test-names"},
+						SizeRw:     42,
+						SizeRootFs: 4242,
+					},
+				},
+				Volumes: nil,
 			}
 
 			b, err := json.Marshal(du)

--- a/daemon/disk_usage.go
+++ b/daemon/disk_usage.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ContainerDiskUsage returns information about container data disk usage.
-func (daemon *Daemon) ContainerDiskUsage(ctx context.Context) ([]*types.Container, error) {
+func (daemon *Daemon) ContainerDiskUsage(ctx context.Context) ([]*types.ContainerUsage, error) {
 	ch := daemon.usage.DoChan("ContainerDiskUsage", func() (interface{}, error) {
 		// Retrieve container list
 		containers, err := daemon.Containers(&types.ContainerListOptions{
@@ -21,7 +21,25 @@ func (daemon *Daemon) ContainerDiskUsage(ctx context.Context) ([]*types.Containe
 		if err != nil {
 			return nil, fmt.Errorf("failed to retrieve container list: %v", err)
 		}
-		return containers, nil
+		us := make([]*types.ContainerUsage, 0, len(containers))
+		for _, c := range containers {
+			us = append(us, &types.ContainerUsage{
+				ID:         c.ID,
+				Image:      c.Image,
+				ImageID:    c.ImageID,
+				Command:    c.Command,
+				Created:    c.Created,
+				Ports:      c.Ports,
+				Names:      c.Names,
+				SizeRw:     c.SizeRw,
+				SizeRootFs: c.SizeRootFs,
+				Labels:     c.Labels,
+				State:      c.State,
+				Status:     c.Status,
+				Mounts:     c.Mounts,
+			})
+		}
+		return us, nil
 	})
 	select {
 	case <-ctx.Done():
@@ -30,7 +48,7 @@ func (daemon *Daemon) ContainerDiskUsage(ctx context.Context) ([]*types.Containe
 		if res.Err != nil {
 			return nil, res.Err
 		}
-		return res.Val.([]*types.Container), nil
+		return res.Val.([]*types.ContainerUsage), nil
 	}
 }
 
@@ -39,7 +57,7 @@ func (daemon *Daemon) ContainerDiskUsage(ctx context.Context) ([]*types.Containe
 func (daemon *Daemon) SystemDiskUsage(ctx context.Context, opts system.DiskUsageOptions) (*types.DiskUsage, error) {
 	eg, ctx := errgroup.WithContext(ctx)
 
-	var containers []*types.Container
+	var containers []*types.ContainerUsage
 	if opts.Containers {
 		eg.Go(func() error {
 			var err error

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -23,6 +23,10 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.42](https://docs.docker.com/engine/api/v1.42/) documentation
 
+* Removed `HostConfig` and `NetworkSettings`  fields
+  from container usage data returned by `GET /system/df`.
+  `GET /containers/json?all=true&size=true` can be used instead to access values of the
+  removed fields along with the size information.
 * Removed the `BuilderSize` field on the `GET /system/df` endpoint. This field
   was introduced in API 1.31 as part of an experimental feature, and no longer
   used since API 1.40.

--- a/integration/system/disk_usage_test.go
+++ b/integration/system/disk_usage_test.go
@@ -37,7 +37,7 @@ func TestDiskUsage(t *testing.T) {
 				assert.NilError(t, err)
 				assert.DeepEqual(t, du, types.DiskUsage{
 					Images:     []*types.ImageSummary{},
-					Containers: []*types.Container{},
+					Containers: []*types.ContainerUsage{},
 					Volumes:    []*volume.Volume{},
 					BuildCache: []*types.BuildCache{},
 				})
@@ -53,6 +53,7 @@ func TestDiskUsage(t *testing.T) {
 				assert.NilError(t, err)
 				assert.Assert(t, du.LayersSize > 0)
 				assert.Equal(t, len(du.Images), 1)
+				assert.Assert(t, du.Images[0].ID != "")
 				assert.DeepEqual(t, du, types.DiskUsage{
 					LayersSize: du.LayersSize,
 					Images: []*types.ImageSummary{
@@ -64,7 +65,7 @@ func TestDiskUsage(t *testing.T) {
 							VirtualSize: du.LayersSize,
 						},
 					},
-					Containers: []*types.Container{},
+					Containers: []*types.ContainerUsage{},
 					Volumes:    []*volume.Volume{},
 					BuildCache: []*types.BuildCache{},
 				})
@@ -79,8 +80,11 @@ func TestDiskUsage(t *testing.T) {
 				du, err := client.DiskUsage(ctx, types.DiskUsageOptions{})
 				assert.NilError(t, err)
 				assert.Equal(t, len(du.Containers), 1)
-				assert.Equal(t, len(du.Containers[0].Names), 1)
+				assert.Assert(t, du.Containers[0].Command != "")
 				assert.Assert(t, du.Containers[0].Created >= prev.Images[0].Created)
+				assert.Equal(t, len(du.Containers[0].Names), 1)
+				assert.Assert(t, du.Containers[0].Names[0] != "")
+				assert.Assert(t, du.Containers[0].Status != "")
 				assert.DeepEqual(t, du, types.DiskUsage{
 					LayersSize: prev.LayersSize,
 					Images: []*types.ImageSummary{
@@ -90,22 +94,20 @@ func TestDiskUsage(t *testing.T) {
 							return &sum
 						}(),
 					},
-					Containers: []*types.Container{
+					Containers: []*types.ContainerUsage{
 						{
-							ID:              cID,
-							Names:           du.Containers[0].Names,
-							Image:           "busybox",
-							ImageID:         prev.Images[0].ID,
-							Command:         du.Containers[0].Command, // not relevant for the test
-							Created:         du.Containers[0].Created,
-							Ports:           du.Containers[0].Ports, // not relevant for the test
-							SizeRootFs:      prev.Images[0].Size,
-							Labels:          du.Containers[0].Labels,          // not relevant for the test
-							State:           du.Containers[0].State,           // not relevant for the test
-							Status:          du.Containers[0].Status,          // not relevant for the test
-							HostConfig:      du.Containers[0].HostConfig,      // not relevant for the test
-							NetworkSettings: du.Containers[0].NetworkSettings, // not relevant for the test
-							Mounts:          du.Containers[0].Mounts,          // not relevant for the test
+							ID:         cID,
+							Image:      "busybox",
+							ImageID:    prev.Images[0].ID,
+							Command:    du.Containers[0].Command,
+							Created:    du.Containers[0].Created,
+							Ports:      []types.Port{},
+							Names:      du.Containers[0].Names,
+							SizeRootFs: prev.Images[0].Size,
+							Labels:     map[string]string{},
+							State:      "running",
+							Status:     du.Containers[0].Status,
+							Mounts:     []types.MountPoint{},
 						},
 					},
 					Volumes:    []*volume.Volume{},


### PR DESCRIPTION
**- What I did**

- Introduce and use a scoped `types.ContainerUsage` type to avoid returning a lot of unnecessary data on `/system/df` (see example below and integration test changes)
- Refactor and simplify container listing functionality in the daemon to allow ranging over `types.Container` directly without constructing a `[]*types.Container`

**- How to verify it**

```sh
$ docker system df -v
<...>
CONTAINER ID        IMAGE               COMMAND                  LOCAL VOLUMES       SIZE                CREATED ago              STATUS                          NAMES
a6482ad2ce56        alpine              "sh -c 'echo test ..."   1                   5B                  2 seconds ago ago        Exited (0) 1 second ago         xenodochial_antonelli
```


Before:
```
curl -s --unix-socket /var/run/docker.sock http://localhost/system/df?type='container' | jq '.Containers'
[
  {
    "Id": "61578390b6c12b86d1b2c4b327685cfa154e2a6f7802e83e7457d92df33cd072",
    "Names": [
      "/stoic_elbakyan"
    ],
    "Image": "alpine",
    "ImageID": "sha256:021b3423115ff662225e83d7e2606475217de7b55fde83ce3447a54019a77aa2",
    "Command": "sh -c '/bin/echo test > testfile'",
    "Created": 1628607865,
    "Ports": [],
    "SizeRw": 5,
    "SizeRootFs": 5595297,
    "Labels": {},
    "State": "exited",
    "Status": "Exited (0) About a minute ago",
    "HostConfig": {
      "NetworkMode": "default"
    },
    "NetworkSettings": {
      "Networks": {
        "bridge": {
          "IPAMConfig": null,
          "Links": null,
          "Aliases": null,
          "NetworkID": "f124243560fa68100744675eddc958cd0f9cb54451751a5c3cc9855e4261f411",
          "EndpointID": "",
          "Gateway": "",
          "IPAddress": "",
          "IPPrefixLen": 0,
          "IPv6Gateway": "",
          "GlobalIPv6Address": "",
          "GlobalIPv6PrefixLen": 0,
          "MacAddress": "",
          "DriverOpts": null
        }
      }
    },
    "Mounts": [
      {
        "Type": "bind",
        "Source": "/tmp/tmp.35S1m8WikS",
        "Destination": "/some/path/in/container",
        "Mode": "",
        "RW": true,
        "Propagation": "rprivate"
      }
    ]
  }
]
```

After:
```
curl -s --unix-socket /var/run/docker.sock http://localhost/system/df?type='container' | jq '.Containers'
[
  {
    "Id": "61578390b6c12b86d1b2c4b327685cfa154e2a6f7802e83e7457d92df33cd072",
    "Image": "alpine",
    "ImageID": "sha256:021b3423115ff662225e83d7e2606475217de7b55fde83ce3447a54019a77aa2",
    "Command": "sh -c '/bin/echo test > testfile'",
    "Created": 1628607865,
    "Names": [
      "/stoic_elbakyan"
    ],
    "SizeRw": 5,
    "SizeRootFs": 5595297,
    "Status": "Exited (0) 50 seconds ago",
    "Mounts": [
      {
        "Type": "bind",
        "Source": "/tmp/tmp.35S1m8WikS",
        "Destination": "/some/path/in/container",
        "Mode": "",
        "RW": true,
        "Propagation": "rprivate"
      }
    ]
  }
]
```
