### PR TITLE
pkg/signal: remove DefaultStopSignal const, and un-export  container.DefaultStopTimeout

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -528,7 +528,7 @@ func (container *Container) StopTimeout() int {
 	if container.Config.StopTimeout != nil {
 		return *container.Config.StopTimeout
 	}
-	return DefaultStopTimeout
+	return defaultStopTimeout
 }
 
 // InitDNSHostConfig ensures that the dns fields are never nil.

--- a/container/container.go
+++ b/container/container.go
@@ -518,7 +518,7 @@ func (container *Container) StopSignal() int {
 	}
 
 	if int(stopSignal) == 0 {
-		stopSignal, _ = signal.ParseSignal(signal.DefaultStopSignal)
+		stopSignal, _ = signal.ParseSignal(defaultStopSignal)
 	}
 	return int(stopSignal)
 }

--- a/container/container_unit_test.go
+++ b/container/container_unit_test.go
@@ -19,7 +19,7 @@ func TestContainerStopSignal(t *testing.T) {
 		Config: &container.Config{},
 	}
 
-	def, err := signal.ParseSignal(signal.DefaultStopSignal)
+	def, err := signal.ParseSignal(defaultStopSignal)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/container/container_unit_test.go
+++ b/container/container_unit_test.go
@@ -44,8 +44,8 @@ func TestContainerStopTimeout(t *testing.T) {
 	}
 
 	s := c.StopTimeout()
-	if s != DefaultStopTimeout {
-		t.Fatalf("Expected %v, got %v", DefaultStopTimeout, s)
+	if s != defaultStopTimeout {
+		t.Fatalf("Expected %v, got %v", defaultStopTimeout, s)
 	}
 
 	stopTimeout := 15

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -23,6 +23,9 @@ import (
 )
 
 const (
+	// defaultStopSignal is the default syscall signal used to stop a container.
+	defaultStopSignal = "SIGTERM"
+
 	// defaultStopTimeout sets the default time, in seconds, to wait
 	// for the graceful container stop before forcefully terminating it.
 	defaultStopTimeout = 10

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -23,9 +23,9 @@ import (
 )
 
 const (
-	// DefaultStopTimeout sets the default time, in seconds, to wait
+	// defaultStopTimeout sets the default time, in seconds, to wait
 	// for the graceful container stop before forcefully terminating it.
-	DefaultStopTimeout = 10
+	defaultStopTimeout = 10
 
 	containerConfigMountPath = "/"
 	containerSecretMountPath = "/run/secrets"

--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -17,8 +17,8 @@ const (
 	containerInternalSecretMountPath = `C:\ProgramData\Docker\internal\secrets`
 	containerInternalConfigsDirPath  = `C:\ProgramData\Docker\internal\configs`
 
-	// DefaultStopTimeout is the timeout (in seconds) for the shutdown call on a container
-	DefaultStopTimeout = 30
+	// defaultStopTimeout is the timeout (in seconds) for the shutdown call on a container
+	defaultStopTimeout = 30
 )
 
 // UnmountIpcMount unmounts Ipc related mounts.

--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -17,6 +17,9 @@ const (
 	containerInternalSecretMountPath = `C:\ProgramData\Docker\internal\secrets`
 	containerInternalConfigsDirPath  = `C:\ProgramData\Docker\internal\configs`
 
+	// defaultStopSignal is the default syscall signal used to stop a container.
+	defaultStopSignal = "SIGTERM"
+
 	// defaultStopTimeout is the timeout (in seconds) for the shutdown call on a container
 	defaultStopTimeout = 30
 )

--- a/pkg/signal/signal_deprecated.go
+++ b/pkg/signal/signal_deprecated.go
@@ -48,7 +48,8 @@ const (
 	// SIGPIPE is a signal sent to a process when a pipe is written to before the other end is open for reading
 	// Deprecated: use github.com/moby/sys/signal.SIGPIPE instead
 	SIGPIPE = msignal.SIGPIPE
-	// DefaultStopSignal is the syscall signal used to stop a container in unix systems.
-	// Deprecated: use github.com/moby/sys/signal.DefaultStopSignal instead
-	DefaultStopSignal = msignal.DefaultStopSignal
+
+	// DefaultStopSignal has been deprecated and removed. The default value is
+	// now defined in github.com/docker/docker/container. Clients should omit
+	// the container's stop-signal field if the default should be used.
 )


### PR DESCRIPTION
This const was previously living in pkg/signal, but with that package being moved to its own module, it didn't make much sense to put docker's defaults in a generic module.

The const from the "signal" package is currenlty used *both* by the CLI and the daemon as a default value when creating containers. This put up some questions:

- a. should the default be non-exported, and private to the container package? After all, it's a _default_ (so should be used if _NOT_ set).
- b. should the client actually setting a default, or instead just omit the value, unless specified by the user? having the client set a default also means that the daemon cannot change the default value  because the client (or older clients) will override it.
- c. consider defaults from the client and defaults of the daemon to be  separate things, and create a default const in the CLI.

This patch implements option "a" (option "b" will be done separately, as it involves the CLI code). This still leaves "c" open as an option, if the CLI wants to set its own default.

Unfortunately, this change means we'll have to drop the alias for the deprecated pkg/signal.DefaultStopSignal const, but a comment was left instead, which can assist consumers of the const to find why it's no longer there (a search showed the Docker CLI as the only consumer though).
