### PR TITLE
runconfig: decodeContainerConfig() return early if there's no HostConfig

### DIFF
--- a/runconfig/config_unix.go
+++ b/runconfig/config_unix.go
@@ -24,7 +24,7 @@ func (w *ContainerConfigWrapper) getHostConfig() *container.HostConfig {
 
 	if hc == nil && w.InnerHostConfig != nil {
 		hc = w.InnerHostConfig
-	} else if w.InnerHostConfig != nil {
+	} else if hc != nil && w.InnerHostConfig != nil {
 		if hc.Memory != 0 && w.InnerHostConfig.Memory == 0 {
 			w.InnerHostConfig.Memory = hc.Memory
 		}

--- a/runconfig/hostconfig_unix.go
+++ b/runconfig/hostconfig_unix.go
@@ -13,7 +13,7 @@ import (
 // DefaultDaemonNetworkMode returns the default network stack the daemon should
 // use.
 func DefaultDaemonNetworkMode() container.NetworkMode {
-	return container.NetworkMode("bridge")
+	return "bridge"
 }
 
 // IsPreDefinedNetwork indicates if a network is predefined by the daemon
@@ -25,24 +25,16 @@ func IsPreDefinedNetwork(network string) bool {
 // validateNetMode ensures that the various combinations of requested
 // network settings are valid.
 func validateNetMode(c *container.Config, hc *container.HostConfig) error {
-	// We may not be passed a host config, such as in the case of docker commit
-	if hc == nil {
-		return nil
-	}
-
 	err := validateNetContainerMode(c, hc)
 	if err != nil {
 		return err
 	}
-
 	if hc.UTSMode.IsHost() && c.Hostname != "" {
 		return ErrConflictUTSHostname
 	}
-
 	if hc.NetworkMode.IsHost() && len(hc.Links) > 0 {
 		return ErrConflictHostNetworkAndLinks
 	}
-
 	return nil
 }
 
@@ -50,10 +42,6 @@ func validateNetMode(c *container.Config, hc *container.HostConfig) error {
 // isolation in the hostconfig structure. Linux only supports "default"
 // which is LXC container isolation
 func validateIsolation(hc *container.HostConfig) error {
-	// We may not be passed a host config, such as in the case of docker commit
-	if hc == nil {
-		return nil
-	}
 	if !hc.Isolation.IsValid() {
 		return fmt.Errorf("Invalid isolation: %q - %s only supports 'default'", hc.Isolation, runtime.GOOS)
 	}
@@ -62,15 +50,9 @@ func validateIsolation(hc *container.HostConfig) error {
 
 // validateQoS performs platform specific validation of the QoS settings
 func validateQoS(hc *container.HostConfig) error {
-	// We may not be passed a host config, such as in the case of docker commit
-	if hc == nil {
-		return nil
-	}
-
 	if hc.IOMaximumBandwidth != 0 {
 		return fmt.Errorf("Invalid QoS settings: %s does not support configuration of maximum bandwidth", runtime.GOOS)
 	}
-
 	if hc.IOMaximumIOps != 0 {
 		return fmt.Errorf("Invalid QoS settings: %s does not support configuration of maximum IOPs", runtime.GOOS)
 	}
@@ -80,15 +62,9 @@ func validateQoS(hc *container.HostConfig) error {
 // validateResources performs platform specific validation of the resource settings
 // cpu-rt-runtime and cpu-rt-period can not be greater than their parent, cpu-rt-runtime requires sys_nice
 func validateResources(hc *container.HostConfig, si *sysinfo.SysInfo) error {
-	// We may not be passed a host config, such as in the case of docker commit
-	if hc == nil {
-		return nil
-	}
-
 	if (hc.Resources.CPURealtimePeriod != 0 || hc.Resources.CPURealtimeRuntime != 0) && !si.CPURealtime {
 		return fmt.Errorf("Your kernel does not support CPU real-time scheduler")
 	}
-
 	if hc.Resources.CPURealtimePeriod != 0 && hc.Resources.CPURealtimeRuntime != 0 && hc.Resources.CPURealtimeRuntime > hc.Resources.CPURealtimePeriod {
 		return fmt.Errorf("cpu real-time runtime cannot be higher than cpu real-time period")
 	}
@@ -96,11 +72,11 @@ func validateResources(hc *container.HostConfig, si *sysinfo.SysInfo) error {
 }
 
 // validatePrivileged performs platform specific validation of the Privileged setting
-func validatePrivileged(hc *container.HostConfig) error {
+func validatePrivileged(_ *container.HostConfig) error {
 	return nil
 }
 
 // validateReadonlyRootfs performs platform specific validation of the ReadonlyRootfs setting
-func validateReadonlyRootfs(hc *container.HostConfig) error {
+func validateReadonlyRootfs(_ *container.HostConfig) error {
 	return nil
 }

--- a/runconfig/hostconfig_windows.go
+++ b/runconfig/hostconfig_windows.go
@@ -10,7 +10,7 @@ import (
 // DefaultDaemonNetworkMode returns the default network stack the daemon should
 // use.
 func DefaultDaemonNetworkMode() container.NetworkMode {
-	return container.NetworkMode("nat")
+	return "nat"
 }
 
 // IsPreDefinedNetwork indicates if a network is predefined by the daemon
@@ -21,19 +21,12 @@ func IsPreDefinedNetwork(network string) bool {
 // validateNetMode ensures that the various combinations of requested
 // network settings are valid.
 func validateNetMode(c *container.Config, hc *container.HostConfig) error {
-	if hc == nil {
-		return nil
-	}
-
-	err := validateNetContainerMode(c, hc)
-	if err != nil {
+	if err := validateNetContainerMode(c, hc); err != nil {
 		return err
 	}
-
 	if hc.NetworkMode.IsContainer() && hc.Isolation.IsHyperV() {
 		return fmt.Errorf("Using the network stack of another container is not supported while using Hyper-V Containers")
 	}
-
 	return nil
 }
 
@@ -41,10 +34,6 @@ func validateNetMode(c *container.Config, hc *container.HostConfig) error {
 // isolation in the hostconfig structure. Windows supports 'default' (or
 // blank), 'process', or 'hyperv'.
 func validateIsolation(hc *container.HostConfig) error {
-	// We may not be passed a host config, such as in the case of docker commit
-	if hc == nil {
-		return nil
-	}
 	if !hc.Isolation.IsValid() {
 		return fmt.Errorf("Invalid isolation: %q. Windows supports 'default', 'process', or 'hyperv'", hc.Isolation)
 	}
@@ -52,16 +41,12 @@ func validateIsolation(hc *container.HostConfig) error {
 }
 
 // validateQoS performs platform specific validation of the Qos settings
-func validateQoS(hc *container.HostConfig) error {
+func validateQoS(_ *container.HostConfig) error {
 	return nil
 }
 
 // validateResources performs platform specific validation of the resource settings
-func validateResources(hc *container.HostConfig, si *sysinfo.SysInfo) error {
-	// We may not be passed a host config, such as in the case of docker commit
-	if hc == nil {
-		return nil
-	}
+func validateResources(hc *container.HostConfig, _ *sysinfo.SysInfo) error {
 	if hc.Resources.CPURealtimePeriod != 0 {
 		return fmt.Errorf("Windows does not support CPU real-time period")
 	}
@@ -73,10 +58,6 @@ func validateResources(hc *container.HostConfig, si *sysinfo.SysInfo) error {
 
 // validatePrivileged performs platform specific validation of the Privileged setting
 func validatePrivileged(hc *container.HostConfig) error {
-	// We may not be passed a host config, such as in the case of docker commit
-	if hc == nil {
-		return nil
-	}
 	if hc.Privileged {
 		return fmt.Errorf("Windows does not support privileged mode")
 	}
@@ -85,10 +66,6 @@ func validatePrivileged(hc *container.HostConfig) error {
 
 // validateReadonlyRootfs performs platform specific validation of the ReadonlyRootfs setting
 func validateReadonlyRootfs(hc *container.HostConfig) error {
-	// We may not be passed a host config, such as in the case of docker commit
-	if hc == nil {
-		return nil
-	}
 	if hc.ReadonlyRootfs {
 		return fmt.Errorf("Windows does not support root filesystem in read-only mode")
 	}


### PR DESCRIPTION
Each of the validation functions depended on HostConfig being not `nil`. Use an
early return, instead of continuing, and checking if it's `nil` in each of the
validate functions.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

