### PR TITLE
docs/api: add node about concurrency on /system/df endpoint

### DIFF
--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -28,6 +28,12 @@ keywords: "API, Docker, rcli, REST, documentation"
   computes and returns data only for the specified object type.
   The parameter can be specified multiple times to select several object types.
   Supported values are: `container`, `image`, `volume`, `build-cache`.
+* `GET /system/df` can now be used concurrently. If a request is made while a
+  previous request is still being processed, the request will receive the result
+  of the already running calculation, once completed. Previously, an error
+  (`a disk usage operation is already running`) would be returned in this
+  situation. This change is not versioned, and affects all API versions if the
+  daemon has this patch.
 
 ## v1.41 API changes
 


### PR DESCRIPTION
follow-up to https://github.com/moby/moby/pull/42715. I realised we didn't add a mention in the API changes, but probably good to add for discoverability).

Commit 135cec5d4dd31bb1ce87432c119bb6160d45747c (https://github.com/moby/moby/pull/42715) added support for calling the /system/df endpoint concurrently.

This patch adds a note about this enhancement to the API changes.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

