### PR TITLE
daemon.WithCommonOptions() fix detection of user-namespaces

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -770,7 +770,8 @@ func WithCommonOptions(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		// joining an existing namespace, only if we create a new net namespace.
 		if c.HostConfig.NetworkMode.IsPrivate() {
 			// We cannot set up ping socket support in a user namespace
-			if !c.HostConfig.UsernsMode.IsPrivate() && sysctlExists("net.ipv4.ping_group_range") {
+			userNS := daemon.configStore.RemappedRoot != "" && c.HostConfig.UsernsMode.IsPrivate()
+			if !userNS && !userns.RunningInUserNS() && sysctlExists("net.ipv4.ping_group_range") {
 				// allow unprivileged ICMP echo sockets without CAP_NET_RAW
 				s.Linux.Sysctl["net.ipv4.ping_group_range"] = "0 2147483647"
 			}


### PR DESCRIPTION
Commit dae652e2e5e47d99c8febd5bc81df0a3269beb74 (https://github.com/moby/moby/pull/41030) added support for non-privileged containers to use ICMP_PROTO (used for `ping`). This option cannot be set for containers that have user-namespaces enabled.

However, the detection looks to be incorrect; HostConfig.UsernsMode was added in 6993e891d10c760d22e0ea3d455f13858cd0de46 (https://github.com/moby/moby/pull/20111) / ee2183881b0273ff1707501e71798a61018f50f0 (https://github.com/moby/moby/pull/20913), and the property only has meaning if the daemon is running with user namespaces enabled. In other situations, the property has no meaning.

As a result of the above, the sysctl would only be set for containers running with UsernsMode=host on a daemon running with user-namespaces enabled.

This patch adds a check if the daemon has user-namespaces enabled (RemappedRoot having a non-empty value) to fix the detection.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

