### PR TITLE
integration/network: remove dead code

### DIFF
--- a/integration/network/dns_test.go
+++ b/integration/network/dns_test.go
@@ -16,7 +16,7 @@ import (
 func TestDaemonDNSFallback(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot start daemon on remote test run")
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
-	skip.If(t, IsUserNamespace())
+	skip.If(t, testEnv.IsUserNamespace)
 
 	d := daemon.New(t)
 	d.StartWithBusybox(t, "-b", "none", "--dns", "127.127.127.1", "--dns", "8.8.8.8")

--- a/integration/network/helpers.go
+++ b/integration/network/helpers.go
@@ -5,7 +5,6 @@ package network
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/docker/docker/api/types"
@@ -85,10 +84,4 @@ func CheckKernelMajorVersionGreaterOrEqualThen(kernelVersion int, majorVersion i
 		return false
 	}
 	return true
-}
-
-// IsUserNamespace returns whether the user namespace remapping is enabled
-func IsUserNamespace() bool {
-	root := os.Getenv("DOCKER_REMAP_ROOT")
-	return root != ""
 }

--- a/integration/network/helpers.go
+++ b/integration/network/helpers.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/parsers/kernel"
 	"gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
 )
@@ -72,16 +71,4 @@ func IsNetworkNotAvailable(c client.NetworkAPIClient, name string) cmp.Compariso
 		}
 		return cmp.ResultSuccess
 	}
-}
-
-// CheckKernelMajorVersionGreaterOrEqualThen returns whether the kernel version is greater or equal than the one provided
-func CheckKernelMajorVersionGreaterOrEqualThen(kernelVersion int, majorVersion int) bool {
-	kv, err := kernel.GetKernelVersion()
-	if err != nil {
-		return false
-	}
-	if kv.Kernel < kernelVersion || (kv.Kernel == kernelVersion && kv.Major < majorVersion) {
-		return false
-	}
-	return true
 }

--- a/integration/network/helpers_windows.go
+++ b/integration/network/helpers_windows.go
@@ -3,7 +3,6 @@ package network
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -40,10 +39,4 @@ func IsNetworkNotAvailable(c client.NetworkAPIClient, name string) cmp.Compariso
 		}
 		return cmp.ResultSuccess
 	}
-}
-
-// IsUserNamespace returns whether the user namespace remapping is enabled
-func IsUserNamespace() bool {
-	root := os.Getenv("DOCKER_REMAP_ROOT")
-	return root != ""
 }

--- a/integration/network/network_test.go
+++ b/integration/network/network_test.go
@@ -23,7 +23,7 @@ import (
 func TestRunContainerWithBridgeNone(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot start daemon on remote test run")
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
-	skip.If(t, IsUserNamespace())
+	skip.If(t, testEnv.IsUserNamespace)
 	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
 
 	d := daemon.New(t)


### PR DESCRIPTION
- integration/network: remove unused `CheckKernelMajorVersionGreaterOrEqualThen()`
- integration/network: remove IsUserNamespace in favor of testenv equivalent (We're already using testenv here, so might as well use the exact same function that it provides).


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

