### PR TITLE
client: use subtests for TestNetworkInspect

### DIFF
--- a/client/network_inspect_test.go
+++ b/client/network_inspect_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -13,66 +13,36 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
 
-func TestNetworkInspectError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-
-	_, err := client.NetworkInspect(context.Background(), "nothing", types.NetworkInspectOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
-}
-
-func TestNetworkInspectNotFoundError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusNotFound, "missing")),
-	}
-
-	_, err := client.NetworkInspect(context.Background(), "unknown", types.NetworkInspectOptions{})
-	assert.Check(t, is.Error(err, "Error: No such network: unknown"))
-	assert.Check(t, IsErrNotFound(err))
-}
-
-func TestNetworkInspectWithEmptyID(t *testing.T) {
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			return nil, errors.New("should not make request")
-		}),
-	}
-	_, _, err := client.NetworkInspectWithRaw(context.Background(), "", types.NetworkInspectOptions{})
-	if !IsErrNotFound(err) {
-		t.Fatalf("Expected NotFoundError, got %v", err)
-	}
-}
-
 func TestNetworkInspect(t *testing.T) {
-	expectedURL := "/networks/network_id"
 	client := &Client{
 		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
 			if req.Method != http.MethodGet {
-				return nil, fmt.Errorf("expected GET method, got %s", req.Method)
+				return nil, errors.New("expected GET method, got " + req.Method)
 			}
-
+			if req.URL.Path == "/networks/" {
+				return errorMock(http.StatusInternalServerError, "client should not make a request for empty IDs")(req)
+			}
+			if strings.HasPrefix(req.URL.Path, "/networks/unknown") {
+				return errorMock(http.StatusNotFound, "Error: No such network: unknown")(req)
+			}
+			if strings.HasPrefix(req.URL.Path, "/networks/test-500-response") {
+				return errorMock(http.StatusInternalServerError, "Server error")(req)
+			}
+			// other test-cases all use "network_id"
+			if !strings.HasPrefix(req.URL.Path, "/networks/network_id") {
+				return nil, errors.New("expected URL '/networks/network_id', got " + req.URL.Path)
+			}
+			if strings.Contains(req.URL.RawQuery, "scope=global") {
+				return errorMock(http.StatusNotFound, "Error: No such network: unknown")(req)
+			}
 			var (
 				content []byte
 				err     error
 			)
-			if strings.Contains(req.URL.RawQuery, "scope=global") {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(bytes.NewReader(content)),
-				}, nil
-			}
-
 			if strings.Contains(req.URL.RawQuery, "verbose=true") {
 				s := map[string]network.ServiceInfo{
 					"web": {},
@@ -90,32 +60,45 @@ func TestNetworkInspect(t *testing.T) {
 				return nil, err
 			}
 			return &http.Response{
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader(content)),
 			}, nil
 		}),
 	}
 
-	r, err := client.NetworkInspect(context.Background(), "network_id", types.NetworkInspectOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if r.Name != "mynetwork" {
-		t.Fatalf("expected `mynetwork`, got %s", r.Name)
-	}
-
-	r, err = client.NetworkInspect(context.Background(), "network_id", types.NetworkInspectOptions{Verbose: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if r.Name != "mynetwork" {
-		t.Fatalf("expected `mynetwork`, got %s", r.Name)
-	}
-	_, ok := r.Services["web"]
-	if !ok {
-		t.Fatalf("expected service `web` missing in the verbose output")
-	}
-
-	_, err = client.NetworkInspect(context.Background(), "network_id", types.NetworkInspectOptions{Scope: "global"})
-	assert.Check(t, is.Error(err, "Error: No such network: network_id"))
+	t.Run("empty ID", func(t *testing.T) {
+		// verify that the client does not create a request if the network-ID/name is empty.
+		_, err := client.NetworkInspect(context.Background(), "", types.NetworkInspectOptions{})
+		assert.Check(t, IsErrNotFound(err))
+	})
+	t.Run("no options", func(t *testing.T) {
+		r, err := client.NetworkInspect(context.Background(), "network_id", types.NetworkInspectOptions{})
+		assert.NilError(t, err)
+		assert.Equal(t, r.Name, "mynetwork")
+	})
+	t.Run("verbose", func(t *testing.T) {
+		r, err := client.NetworkInspect(context.Background(), "network_id", types.NetworkInspectOptions{Verbose: true})
+		assert.NilError(t, err)
+		assert.Equal(t, r.Name, "mynetwork")
+		_, ok := r.Services["web"]
+		if !ok {
+			t.Fatalf("expected service `web` missing in the verbose output")
+		}
+	})
+	t.Run("global scope", func(t *testing.T) {
+		_, err := client.NetworkInspect(context.Background(), "network_id", types.NetworkInspectOptions{Scope: "global"})
+		assert.Check(t, is.Error(err, "Error: No such network: network_id"))
+		assert.Check(t, IsErrNotFound(err))
+	})
+	t.Run("unknown network", func(t *testing.T) {
+		_, err := client.NetworkInspect(context.Background(), "unknown", types.NetworkInspectOptions{})
+		assert.Check(t, is.Error(err, "Error: No such network: unknown"))
+		assert.Check(t, IsErrNotFound(err))
+	})
+	t.Run("server error", func(t *testing.T) {
+		// Just testing that an internal server error is converted correctly by the client
+		_, err := client.NetworkInspect(context.Background(), "test-500-response", types.NetworkInspectOptions{})
+		assert.Check(t, errdefs.IsSystem(err))
+	})
 }


### PR DESCRIPTION
cleaning up some branches, and found this one 😂, so opening as a PR 🤷‍♂️ 


Unify the NetworkInspect tests to remove some boilerplating

Before this change:

    go test -v -run TestNetworkInspect ./client/
    === RUN   TestNetworkInspectError
    --- PASS: TestNetworkInspectError (0.00s)
    === RUN   TestNetworkInspectNotFoundError
    --- PASS: TestNetworkInspectNotFoundError (0.00s)
    === RUN   TestNetworkInspectWithEmptyID
    --- PASS: TestNetworkInspectWithEmptyID (0.00s)
    === RUN   TestNetworkInspect
    --- PASS: TestNetworkInspect (0.00s)
    PASS
    ok  	github.com/docker/docker/client	0.010s

With this change:

    go test -v -run TestNetworkInspect ./client/
    === RUN   TestNetworkInspect
    === RUN   TestNetworkInspect/empty_ID
    === RUN   TestNetworkInspect/no_options
    === RUN   TestNetworkInspect/verbose
    === RUN   TestNetworkInspect/global_scope
    === RUN   TestNetworkInspect/unknown_network
    === RUN   TestNetworkInspect/server_error
    --- PASS: TestNetworkInspect (0.00s)
        --- PASS: TestNetworkInspect/empty_ID (0.00s)
        --- PASS: TestNetworkInspect/no_options (0.00s)
        --- PASS: TestNetworkInspect/verbose (0.00s)
        --- PASS: TestNetworkInspect/global_scope (0.00s)
        --- PASS: TestNetworkInspect/unknown_network (0.00s)
        --- PASS: TestNetworkInspect/server_error (0.00s)
    PASS
    ok  	github.com/docker/docker/client	0.012s

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

