### PR TITLE
Jenkinsfile: also run unit-tests on rootless

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -404,6 +404,34 @@ pipeline {
                                 '''
                             }
                         }
+                        stage("Unit tests") {
+                            environment {
+                                DOCKER_ROOTLESS = '1'
+                            }
+                            steps {
+                                sh '''
+                                sudo modprobe ip6table_filter
+                                '''
+                                sh '''
+                                docker run --rm -t --privileged \
+                                  -v "$WORKSPACE/bundles:/go/src/github.com/docker/docker/bundles" \
+                                  --name docker-pr$BUILD_NUMBER \
+                                  -e DOCKER_EXPERIMENTAL \
+                                  -e DOCKER_GITCOMMIT=${GIT_COMMIT} \
+                                  -e DOCKER_GRAPHDRIVER \
+                                  -e DOCKER_ROOTLESS \
+                                  -e VALIDATE_REPO=${GIT_URL} \
+                                  -e VALIDATE_BRANCH=${CHANGE_TARGET} \
+                                  docker:${GIT_COMMIT} \
+                                  hack/test/unit
+                                '''
+                            }
+                            post {
+                                always {
+                                    junit testResults: 'bundles/junit-report*.xml', allowEmptyResults: true
+                                }
+                            }
+                        }
                         stage("Integration tests") {
                             environment {
                                 DOCKER_ROOTLESS = '1'


### PR DESCRIPTION
Not all of our unit tests are fully "unit", and some may depend on the
environment in which they're running, so let's also run these in the
rootless stage of our Jenkinsfile.


**- A picture of a cute animal (not mandatory but encouraged)**

