### PR TITLE
pkg/archive: Use pigz for compression in docker push

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -80,6 +80,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.IntVar(&maxConcurrentDownloads, "max-concurrent-downloads", config.DefaultMaxConcurrentDownloads, "Set the max concurrent downloads for each pull")
 	flags.IntVar(&maxConcurrentUploads, "max-concurrent-uploads", config.DefaultMaxConcurrentUploads, "Set the max concurrent uploads for each push")
 	flags.IntVar(&maxDownloadAttempts, "max-download-attempts", config.DefaultDownloadAttempts, "Set the max download attempts for each pull")
+	flags.IntVar(&conf.CompressionThreads, "compression-threads", 1, "Set to 2 or above to use multiple threads(pigz) when compressing image pushes(default gzip)")
 	flags.IntVar(&conf.ShutdownTimeout, "shutdown-timeout", defaultShutdownTimeout, "Set the default shutdown timeout")
 	flags.IntVar(&conf.NetworkDiagnosticPort, "network-diagnostic-port", 0, "TCP port number of the network diagnostic server")
 	_ = flags.MarkHidden("network-diagnostic-port")

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -202,6 +202,10 @@ type CommonConfig struct {
 	// may take place at a time for each push.
 	MaxDownloadAttempts *int `json:"max-download-attempts,omitempty"`
 
+	// CompressionThreads sets the number of threads to use for compression on image push;
+	// when greater than 1, we use pgzip instead of the normal compress/gzip library.
+	CompressionThreads int `json:"compression-threads,omitempty"`
+
 	// ShutdownTimeout is the timeout value (in seconds) the daemon will wait for the container
 	// to stop when daemon is being shutdown
 	ShutdownTimeout int `json:"shutdown-timeout,omitempty"`

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -277,7 +277,7 @@ func (pd *v2PushDescriptor) DiffID() layer.DiffID {
 	return pd.layer.DiffID()
 }
 
-func (pd *v2PushDescriptor) Upload(ctx context.Context, progressOutput progress.Output) (distribution.Descriptor, error) {
+func (pd *v2PushDescriptor) Upload(ctx context.Context, progressOutput progress.Output, compressionThreads int) (distribution.Descriptor, error) {
 	// Skip foreign layers unless this registry allows nondistributable artifacts.
 	if !pd.endpoint.AllowNondistributableArtifacts {
 		if fs, ok := pd.layer.(distribution.Describable); ok {
@@ -427,7 +427,7 @@ func (pd *v2PushDescriptor) Upload(ctx context.Context, progressOutput progress.
 	}
 	defer layerUpload.Close()
 	// upload the blob
-	return pd.uploadUsingSession(ctx, progressOutput, diffID, layerUpload)
+	return pd.uploadUsingSession(ctx, progressOutput, diffID, layerUpload, compressionThreads)
 }
 
 func (pd *v2PushDescriptor) SetRemoteDescriptor(descriptor distribution.Descriptor) {
@@ -443,6 +443,7 @@ func (pd *v2PushDescriptor) uploadUsingSession(
 	progressOutput progress.Output,
 	diffID layer.DiffID,
 	layerUpload distribution.BlobWriter,
+	compressionThreads int,
 ) (distribution.Descriptor, error) {
 	var reader io.ReadCloser
 
@@ -457,7 +458,7 @@ func (pd *v2PushDescriptor) uploadUsingSession(
 
 	switch m := pd.layer.MediaType(); m {
 	case schema2.MediaTypeUncompressedLayer:
-		compressedReader, compressionDone := compress(reader)
+		compressedReader, compressionDone := compress(reader, compressionThreads)
 		defer func(closer io.Closer) {
 			closer.Close()
 			<-compressionDone

--- a/distribution/xfer/upload.go
+++ b/distribution/xfer/upload.go
@@ -16,8 +16,9 @@ const maxUploadAttempts = 5
 // LayerUploadManager provides task management and progress reporting for
 // uploads.
 type LayerUploadManager struct {
-	tm           TransferManager
-	waitDuration time.Duration
+	tm                 TransferManager
+	waitDuration       time.Duration
+	compressionThreads int
 }
 
 // SetConcurrency sets the max concurrent uploads for each push
@@ -53,7 +54,7 @@ type UploadDescriptor interface {
 	// DiffID should return the DiffID for this layer.
 	DiffID() layer.DiffID
 	// Upload is called to perform the Upload.
-	Upload(ctx context.Context, progressOutput progress.Output) (distribution.Descriptor, error)
+	Upload(ctx context.Context, progressOutput progress.Output, compressionThreads int) (distribution.Descriptor, error)
 	// SetRemoteDescriptor provides the distribution.Descriptor that was
 	// returned by Upload. This descriptor is not to be confused with
 	// the UploadDescriptor interface, which is used for internally
@@ -124,7 +125,7 @@ func (lum *LayerUploadManager) makeUploadFunc(descriptor UploadDescriptor) DoFun
 
 			retries := 0
 			for {
-				remoteDescriptor, err := descriptor.Upload(u.Transfer.Context(), progressOutput)
+				remoteDescriptor, err := descriptor.Upload(u.Transfer.Context(), progressOutput, lum.compressionThreads)
 				if err == nil {
 					u.remoteDescriptor = remoteDescriptor
 					break

--- a/distribution/xfer/upload_test.go
+++ b/distribution/xfer/upload_test.go
@@ -40,7 +40,7 @@ func (u *mockUploadDescriptor) SetRemoteDescriptor(remoteDescriptor distribution
 }
 
 // Upload is called to perform the upload.
-func (u *mockUploadDescriptor) Upload(ctx context.Context, progressOutput progress.Output) (distribution.Descriptor, error) {
+func (u *mockUploadDescriptor) Upload(ctx context.Context, progressOutput progress.Output, compressionThreads int) (distribution.Descriptor, error) {
 	if u.currentUploads != nil {
 		defer atomic.AddInt32(u.currentUploads, -1)
 


### PR DESCRIPTION
Fix: https://github.com/moby/moby/issues/41987

Signed-off-by: Da McGrady <dabkb@aol.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


> 
> 1. have you tested with a remote registry or with Docker Hub? at what point does it make sense to use more threads?
> 2. what about using too much CPU on the host where the Docker daemon runs? Have you tested to see how the high CPU usage on the Docker daemon affects the other workloads running on that host?
> 3. how thoroughly tested is this library? have you run into any problems with it? have you tested this code with huge layers?
> 4. does pgzip/pigz have any known gotchas or issues?

1. Yes, using pigz to push or pull images significantly improves performance.
2. Actually, the circumstances for Docker users may vary, so some may use a single core CPU machine with a super fast network, while others may use a 64 core CPU system with a slower network. I believe it should be an option for users who want to speed up their pipelines with a high-performance machine.
3. Yes, take a look at the performance section below.
4. As far as I know, there arent' any knonw gotchas. 

### Compatibility
This feature is disabled by default, which implies that single thread version gzip is always the default config unless users change the `compression-threads` setting.

### Performance

<img src="https://user-images.githubusercontent.com/82504881/129694427-8e581987-38e1-45b2-936f-6884b472585a.png" width="650">

### Determinism
From issue https://github.com/containerd/containerd/issues/1896.
> Note that we should not parallelize compression, as it breaks determinism.

As the author of pigz sard: https://github.com/madler/pigz/issues/90

Actually, pigz is determinism, which means for a given version of pigz and a given version of zlib, it will produce the same thing as itself.

