### PR TITLE
libnetwork: remove unused "testutils" imports

### DIFF
--- a/cmd/docker-proxy/network_proxy_test.go
+++ b/cmd/docker-proxy/network_proxy_test.go
@@ -13,9 +13,6 @@ import (
 
 	"github.com/ishidawataru/sctp"
 	"gotest.tools/v3/skip"
-
-	// this takes care of the incontainer flag
-	_ "github.com/docker/docker/libnetwork/testutils"
 )
 
 var testBuf = []byte("Buffalo buffalo Buffalo buffalo buffalo buffalo Buffalo buffalo")

--- a/libnetwork/bitseq/sequence_test.go
+++ b/libnetwork/bitseq/sequence_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/libnetwork/datastore"
-	_ "github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/store/boltdb"
 )

--- a/libnetwork/config/config_test.go
+++ b/libnetwork/config/config_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/netlabel"
-	_ "github.com/docker/docker/libnetwork/testutils"
 )
 
 func TestInvalidConfig(t *testing.T) {

--- a/libnetwork/datastore/datastore_test.go
+++ b/libnetwork/datastore/datastore_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/libnetwork/options"
-	_ "github.com/docker/docker/libnetwork/testutils"
 	"gotest.tools/v3/assert"
 )
 

--- a/libnetwork/driverapi/driverapi_test.go
+++ b/libnetwork/driverapi/driverapi_test.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"testing"
 
-	_ "github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/libnetwork/types"
 )
 

--- a/libnetwork/drivers/host/host_test.go
+++ b/libnetwork/drivers/host/host_test.go
@@ -3,7 +3,6 @@ package host
 import (
 	"testing"
 
-	_ "github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/libnetwork/types"
 )
 

--- a/libnetwork/drivers/ipvlan/ipvlan_test.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/libnetwork/driverapi"
-	_ "github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/pkg/plugingetter"
 )
 

--- a/libnetwork/drivers/macvlan/macvlan_test.go
+++ b/libnetwork/drivers/macvlan/macvlan_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/libnetwork/driverapi"
-	_ "github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/pkg/plugingetter"
 )
 

--- a/libnetwork/drivers/null/null_test.go
+++ b/libnetwork/drivers/null/null_test.go
@@ -3,7 +3,6 @@ package null
 import (
 	"testing"
 
-	_ "github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/libnetwork/types"
 )
 

--- a/libnetwork/drivers/overlay/overlay_test.go
+++ b/libnetwork/drivers/overlay/overlay_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/docker/docker/libnetwork/discoverapi"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/netlabel"
-	_ "github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/libkv/store/consul"
 	"github.com/vishvananda/netlink/nl"

--- a/libnetwork/drivers/overlay/ovmanager/ovmanager_test.go
+++ b/libnetwork/drivers/overlay/ovmanager/ovmanager_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/idm"
 	"github.com/docker/docker/libnetwork/netlabel"
-	_ "github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/libnetwork/types"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"

--- a/libnetwork/drivers/overlay/peerdb_test.go
+++ b/libnetwork/drivers/overlay/peerdb_test.go
@@ -5,8 +5,6 @@ package overlay
 import (
 	"net"
 	"testing"
-
-	_ "github.com/docker/docker/libnetwork/testutils"
 )
 
 func TestPeerMarshal(t *testing.T) {

--- a/libnetwork/drivers/remote/driver_test.go
+++ b/libnetwork/drivers/remote/driver_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/discoverapi"
 	"github.com/docker/docker/libnetwork/driverapi"
-	_ "github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/docker/docker/pkg/plugins"
 )

--- a/libnetwork/drvregistry/drvregistry_test.go
+++ b/libnetwork/drvregistry/drvregistry_test.go
@@ -14,9 +14,6 @@ import (
 	remoteIpam "github.com/docker/docker/libnetwork/ipams/remote"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
-
-	// this takes care of the incontainer flag
-	_ "github.com/docker/docker/libnetwork/testutils"
 )
 
 const mockDriverName = "mock-driver"

--- a/libnetwork/etchosts/etchosts_test.go
+++ b/libnetwork/etchosts/etchosts_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"testing"
 
-	_ "github.com/docker/docker/libnetwork/testutils"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/libnetwork/hostdiscovery/hostdiscovery_test.go
+++ b/libnetwork/hostdiscovery/hostdiscovery_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	mapset "github.com/deckarep/golang-set"
-	_ "github.com/docker/docker/libnetwork/testutils"
 
 	"github.com/docker/docker/pkg/discovery"
 )

--- a/libnetwork/idm/idm_test.go
+++ b/libnetwork/idm/idm_test.go
@@ -2,8 +2,6 @@ package idm
 
 import (
 	"testing"
-
-	_ "github.com/docker/docker/libnetwork/testutils"
 )
 
 func TestNew(t *testing.T) {

--- a/libnetwork/internal/caller/caller_test.go
+++ b/libnetwork/internal/caller/caller_test.go
@@ -2,8 +2,6 @@ package caller
 
 import (
 	"testing"
-
-	_ "github.com/docker/docker/libnetwork/testutils"
 )
 
 func fun1() string {

--- a/libnetwork/internal/setmatrix/setmatrix_test.go
+++ b/libnetwork/internal/setmatrix/setmatrix_test.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	_ "github.com/docker/docker/libnetwork/testutils"
 )
 
 func TestSetSerialInsertDelete(t *testing.T) {

--- a/libnetwork/ipam/allocator_test.go
+++ b/libnetwork/ipam/allocator_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/docker/docker/libnetwork/bitseq"
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/ipamapi"
-	_ "github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/store/boltdb"

--- a/libnetwork/ipams/null/null_test.go
+++ b/libnetwork/ipams/null/null_test.go
@@ -3,7 +3,6 @@ package null
 import (
 	"testing"
 
-	_ "github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/libnetwork/types"
 )
 

--- a/libnetwork/ipams/remote/remote_test.go
+++ b/libnetwork/ipams/remote/remote_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/libnetwork/ipamapi"
-	_ "github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/pkg/plugins"
 )
 

--- a/libnetwork/ipams/windowsipam/windowsipam_test.go
+++ b/libnetwork/ipams/windowsipam/windowsipam_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/docker/docker/libnetwork/ipamapi"
 	"github.com/docker/docker/libnetwork/netlabel"
-	_ "github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/libnetwork/types"
 )
 

--- a/libnetwork/ipamutils/utils_test.go
+++ b/libnetwork/ipamutils/utils_test.go
@@ -4,7 +4,6 @@ import (
 	"net"
 	"testing"
 
-	_ "github.com/docker/docker/libnetwork/testutils"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/libnetwork/iptables/iptables_test.go
+++ b/libnetwork/iptables/iptables_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	_ "github.com/docker/docker/libnetwork/testutils"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/libnetwork/netlabel/labels_test.go
+++ b/libnetwork/netlabel/labels_test.go
@@ -2,8 +2,6 @@ package netlabel
 
 import (
 	"testing"
-
-	_ "github.com/docker/docker/libnetwork/testutils"
 )
 
 var input = []struct {

--- a/libnetwork/networkdb/networkdb_test.go
+++ b/libnetwork/networkdb/networkdb_test.go
@@ -18,9 +18,6 @@ import (
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/poll"
-
-	// this takes care of the incontainer flag
-	_ "github.com/docker/docker/libnetwork/testutils"
 )
 
 var dbPort int32 = 10000

--- a/libnetwork/options/options_test.go
+++ b/libnetwork/options/options_test.go
@@ -4,8 +4,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-
-	_ "github.com/docker/docker/libnetwork/testutils"
 )
 
 func TestGenerate(t *testing.T) {

--- a/libnetwork/osl/kernel/knobs_linux_test.go
+++ b/libnetwork/osl/kernel/knobs_linux_test.go
@@ -6,8 +6,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
-
-	_ "github.com/docker/docker/libnetwork/testutils"
 )
 
 func TestReadWriteKnobs(t *testing.T) {

--- a/libnetwork/portallocator/portallocator_test.go
+++ b/libnetwork/portallocator/portallocator_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"net"
 	"testing"
-
-	_ "github.com/docker/docker/libnetwork/testutils"
 )
 
 func resetPortAllocator() {

--- a/libnetwork/portmapper/mapper_linux_test.go
+++ b/libnetwork/portmapper/mapper_linux_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/libnetwork/iptables"
-	_ "github.com/docker/docker/libnetwork/testutils"
 )
 
 func init() {

--- a/libnetwork/resolvconf/resolvconf_linux_test.go
+++ b/libnetwork/resolvconf/resolvconf_linux_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 
-	_ "github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/docker/docker/pkg/ioutils"
 )

--- a/libnetwork/types/types_test.go
+++ b/libnetwork/types/types_test.go
@@ -4,7 +4,6 @@ import (
 	"net"
 	"testing"
 
-	_ "github.com/docker/docker/libnetwork/testutils"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )


### PR DESCRIPTION
Perhaps the testutils package in the past had an `init()` function to set up
specific things, but it no longer has. so these imports were doing nothing.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

