### PR TITLE
testutil: don't import "opts" package

### DIFF
--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -18,7 +18,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/testutil/request"
@@ -43,6 +42,8 @@ const (
 	defaultDockerdBinary         = "dockerd"
 	defaultContainerdSocket      = "/var/run/docker/containerd/containerd.sock"
 	defaultDockerdRootlessBinary = "dockerd-rootless.sh"
+	defaultUnixSocket            = "/var/run/docker.sock"
+	defaultTLSHost               = "localhost:2376"
 )
 
 var errDaemonNotStarted = errors.New("daemon not started")
@@ -739,11 +740,11 @@ func (d *Daemon) getClientConfig() (*clientConfig, error) {
 		transport = &http.Transport{
 			TLSClientConfig: tlsConfig,
 		}
-		addr = fmt.Sprintf("%s:%d", opts.DefaultHTTPHost, opts.DefaultTLSHTTPPort)
+		addr = defaultTLSHost
 		scheme = "https"
 		proto = "tcp"
 	} else if d.UseDefaultHost {
-		addr = opts.DefaultUnixSocket
+		addr = defaultUnixSocket
 		proto = "unix"
 		scheme = "http"
 		transport = &http.Transport{}

--- a/testutil/request/request.go
+++ b/testutil/request/request.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/testutil/environment"
 	"github.com/docker/go-connections/sockets"
@@ -180,7 +179,7 @@ func getTLSConfig() (*tls.Config, error) {
 
 // DaemonHost return the daemon host string for this test execution
 func DaemonHost() string {
-	daemonURLStr := "unix://" + opts.DefaultUnixSocket
+	daemonURLStr := client.DefaultDockerHost
 	if daemonHostVar := os.Getenv("DOCKER_HOST"); daemonHostVar != "" {
 		daemonURLStr = daemonHostVar
 	}


### PR DESCRIPTION
It was only used for two consts, which are unlikely to change, but the
"opts" package currently also imports libnetwork/ipamutils, which has
an `init()` function that does some heavy lifting, and not needed for
this utility's purpose.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

