### PR TITLE
api/types/events: add "Type" type for event-type enum

### DIFF
--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -1,33 +1,26 @@
 package events // import "github.com/docker/docker/api/types/events"
 
+// Type is used for event-types.
+type Type = string
+
+// List of known event types.
 const (
-	// BuilderEventType is the event type that the builder generates
-	BuilderEventType = "builder"
-	// ContainerEventType is the event type that containers generate
-	ContainerEventType = "container"
-	// DaemonEventType is the event type that daemon generate
-	DaemonEventType = "daemon"
-	// ImageEventType is the event type that images generate
-	ImageEventType = "image"
-	// NetworkEventType is the event type that networks generate
-	NetworkEventType = "network"
-	// PluginEventType is the event type that plugins generate
-	PluginEventType = "plugin"
-	// VolumeEventType is the event type that volumes generate
-	VolumeEventType = "volume"
-	// ServiceEventType is the event type that services generate
-	ServiceEventType = "service"
-	// NodeEventType is the event type that nodes generate
-	NodeEventType = "node"
-	// SecretEventType is the event type that secrets generate
-	SecretEventType = "secret"
-	// ConfigEventType is the event type that configs generate
-	ConfigEventType = "config"
+	BuilderEventType   Type = "builder"   // BuilderEventType is the event type that the builder generates.
+	ConfigEventType    Type = "config"    // ConfigEventType is the event type that configs generate.
+	ContainerEventType Type = "container" // ContainerEventType is the event type that containers generate.
+	DaemonEventType    Type = "daemon"    // DaemonEventType is the event type that daemon generate.
+	ImageEventType     Type = "image"     // ImageEventType is the event type that images generate.
+	NetworkEventType   Type = "network"   // NetworkEventType is the event type that networks generate.
+	NodeEventType      Type = "node"      // NodeEventType is the event type that nodes generate.
+	PluginEventType    Type = "plugin"    // PluginEventType is the event type that plugins generate.
+	SecretEventType    Type = "secret"    // SecretEventType is the event type that secrets generate.
+	ServiceEventType   Type = "service"   // ServiceEventType is the event type that services generate.
+	VolumeEventType    Type = "volume"    // VolumeEventType is the event type that volumes generate.
 )
 
 // Actor describes something that generates events,
 // like a container, or a network, or a volume.
-// It has a defined name and a set or attributes.
+// It has a defined name and a set of attributes.
 // The container attributes are its labels, other actors
 // can generate these attributes from other properties.
 type Actor struct {
@@ -39,11 +32,11 @@ type Actor struct {
 type Message struct {
 	// Deprecated information from JSONMessage.
 	// With data only in container events.
-	Status string `json:"status,omitempty"`
-	ID     string `json:"id,omitempty"`
-	From   string `json:"from,omitempty"`
+	Status string `json:"status,omitempty"` // Deprecated: use Action instead.
+	ID     string `json:"id,omitempty"`     // Deprecated: use Actor.ID instead.
+	From   string `json:"from,omitempty"`   // Deprecated: use Actor.Attributes["image"] instead.
 
-	Type   string
+	Type   Type
 	Action string
 	Actor  Actor
 	// Engine events are local scope. Cluster events are swarm scope.

--- a/client/events_test.go
+++ b/client/events_test.go
@@ -91,17 +91,17 @@ func TestEvents(t *testing.T) {
 			},
 			events: []events.Message{
 				{
-					Type:   "container",
+					Type:   events.BuilderEventType,
 					ID:     "1",
 					Action: "create",
 				},
 				{
-					Type:   "container",
+					Type:   events.BuilderEventType,
 					ID:     "2",
 					Action: "die",
 				},
 				{
-					Type:   "container",
+					Type:   events.BuilderEventType,
 					ID:     "3",
 					Action: "create",
 				},

--- a/daemon/events/events.go
+++ b/daemon/events/events.go
@@ -79,7 +79,7 @@ func (e *Events) Evict(l chan interface{}) {
 }
 
 // Log creates a local scope message and publishes it
-func (e *Events) Log(action, eventType string, actor eventtypes.Actor) {
+func (e *Events) Log(action string, eventType eventtypes.Type, actor eventtypes.Actor) {
 	now := time.Now().UTC()
 	jm := eventtypes.Message{
 		Action:   action,

--- a/daemon/events/filter.go
+++ b/daemon/events/filter.go
@@ -102,7 +102,7 @@ func (ef *Filter) matchConfig(ev events.Message) bool {
 	return ef.fuzzyMatchName(ev, events.ConfigEventType)
 }
 
-func (ef *Filter) fuzzyMatchName(ev events.Message, eventType string) bool {
+func (ef *Filter) fuzzyMatchName(ev events.Message, eventType events.Type) bool {
 	return ef.filter.FuzzyMatch(eventType, ev.Actor.ID) ||
 		ef.filter.FuzzyMatch(eventType, ev.Actor.Attributes["name"])
 }


### PR DESCRIPTION
Currently just an alias for string, but we can change it to be  an actual type.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

