### PR TITLE
add SetContainerBaseFS to set container's base fs

### DIFF
--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -20,10 +20,9 @@ import (
 
 // createContainerOSSpecificSettings performs host-OS specific container create functionality
 func (daemon *Daemon) createContainerOSSpecificSettings(container *container.Container, config *containertypes.Config, hostConfig *containertypes.HostConfig) error {
-	if err := daemon.Mount(container); err != nil {
+	if err := daemon.SetContainerBaseFS(container); err != nil {
 		return err
 	}
-	defer daemon.Unmount(container)
 
 	rootIDs := daemon.idMapping.RootPair()
 	if err := container.SetupWorkingDirectory(rootIDs); err != nil {


### PR DESCRIPTION
For overlay and overlay2 storage, can walk arount mount and umount t
get the container's base fs dir to accelerate container create.

Signed-off-by: zvier <zvier20@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

