### PR TITLE
[WIP]add SetContainerBaseFS to set container's base fs

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -48,6 +48,7 @@ import (
 	"github.com/docker/docker/libnetwork"
 	"github.com/docker/docker/libnetwork/cluster"
 	nwconfig "github.com/docker/docker/libnetwork/config"
+	"github.com/docker/docker/pkg/containerfs"
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/plugingetter"
@@ -1271,6 +1272,25 @@ func (daemon *Daemon) Shutdown() error {
 	}
 
 	return daemon.cleanupMounts()
+}
+
+// SetContainerBaseFS called when container create. For overlay and overlay2,
+// can walk around mount and umount to get the container's base fs dir. This
+// will accelerate container create. Maybe for other storage driver also can be
+// optimized with a layer interface like container.RWLaye.GetBaseFS
+func (daemon *Daemon) SetContainerBaseFS(container *container.Container) error {
+	if container.RWLayer == nil {
+		return errors.New("RWLayer of container " + container.ID + " is unexpectedly nil")
+	}
+	metadata, err := container.RWLayer.Metadata()
+	if err != nil {
+		return err
+	}
+	merged := metadata["MergedDir"]
+	fs := containerfs.NewLocalContainerFS(merged)
+	container.BaseFS = fs
+
+	return nil
 }
 
 // Mount sets container.BaseFS


### PR DESCRIPTION
For overlay and overlay2 storage, can walk arount mount and umount
get the container's base fs dir to accelerate container create.

Signed-off-by: Jeff Zvier zvier20@gmail.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

