### PR TITLE
daemon: cleanupContainer(): pass ContainerRmConfig as parameter

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -152,8 +152,12 @@ func (daemon *Daemon) create(opts createOpts) (retC *container.Container, retErr
 	}
 	defer func() {
 		if retErr != nil {
-			if err := daemon.cleanupContainer(ctr, true, true); err != nil {
-				logrus.Errorf("failed to cleanup container on create error: %v", err)
+			err = daemon.cleanupContainer(ctr, &types.ContainerRmConfig{
+				ForceRemove:  true,
+				RemoveVolume: true,
+			})
+			if err != nil {
+				logrus.WithError(err).Error("failed to cleanup container on create error")
 			}
 		}
 	}()

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -43,7 +43,7 @@ func (daemon *Daemon) ContainerRm(name string, config *types.ContainerRmConfig) 
 		return daemon.rmLink(ctr, name)
 	}
 
-	err = daemon.cleanupContainer(ctr, config.ForceRemove, config.RemoveVolume)
+	err = daemon.cleanupContainer(ctr, config)
 	containerActions.WithValues("delete").UpdateSince(start)
 
 	return err
@@ -77,9 +77,9 @@ func (daemon *Daemon) rmLink(container *container.Container, name string) error 
 
 // cleanupContainer unregisters a container from the daemon, stops stats
 // collection and cleanly removes contents and metadata from the filesystem.
-func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemove, removeVolume bool) error {
+func (daemon *Daemon) cleanupContainer(container *container.Container, config *types.ContainerRmConfig) error {
 	if container.IsRunning() {
-		if !forceRemove {
+		if !config.ForceRemove {
 			state := container.StateString()
 			procedure := "Stop the container before attempting removal or force remove"
 			if state == "paused" {
@@ -139,7 +139,7 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 	daemon.idIndex.Delete(container.ID)
 	daemon.containers.Delete(container.ID)
 	daemon.containersReplica.Delete(container)
-	if e := daemon.removeMountPoints(container, removeVolume); e != nil {
+	if e := daemon.removeMountPoints(container, config.RemoveVolume); e != nil {
 		logrus.Error(e)
 	}
 	for _, name := range linkNames {


### PR DESCRIPTION
We already have this config, so might as well pass it, instead of passing each option as a separate argument.

First commit fixes some variable names that clashed with imports

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

