### PR TITLE
info: remove "expected" check for tini version

### DIFF
--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/pkg/sysinfo"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -38,54 +37,43 @@ func (daemon *Daemon) fillPlatformInfo(v *types.Info, sysInfo *sysinfo.SysInfo) 
 	v.Runtimes = daemon.configStore.GetAllRuntimes()
 	v.DefaultRuntime = daemon.configStore.GetDefaultRuntimeName()
 	v.InitBinary = daemon.configStore.GetInitPath()
+	v.RuncCommit.ID = "N/A"
+	v.ContainerdCommit.ID = "N/A"
+	v.InitCommit.ID = "N/A"
 
 	defaultRuntimeBinary := daemon.configStore.GetRuntime(v.DefaultRuntime).Path
 	if rv, err := exec.Command(defaultRuntimeBinary, "--version").Output(); err == nil {
 		if _, _, commit, err := parseRuntimeVersion(string(rv)); err != nil {
 			logrus.Warnf("failed to parse %s version: %v", defaultRuntimeBinary, err)
-			v.RuncCommit.ID = "N/A"
 		} else {
 			v.RuncCommit.ID = commit
 		}
 	} else {
 		logrus.Warnf("failed to retrieve %s version: %v", defaultRuntimeBinary, err)
-		v.RuncCommit.ID = "N/A"
 	}
-
-	// runc is now shipped as a separate package. Set "expected" to same value
-	// as "ID" to prevent clients from reporting a version-mismatch
-	v.RuncCommit.Expected = v.RuncCommit.ID
 
 	if rv, err := daemon.containerd.Version(context.Background()); err == nil {
 		v.ContainerdCommit.ID = rv.Revision
 	} else {
 		logrus.Warnf("failed to retrieve containerd version: %v", err)
-		v.ContainerdCommit.ID = "N/A"
 	}
-
-	// containerd is now shipped as a separate package. Set "expected" to same
-	// value as "ID" to prevent clients from reporting a version-mismatch
-	v.ContainerdCommit.Expected = v.ContainerdCommit.ID
-
-	// TODO is there still a need to check the expected version for tini?
-	// if not, we can change this, and just set "Expected" to v.InitCommit.ID
-	v.InitCommit.Expected = dockerversion.InitCommitID
 
 	defaultInitBinary := daemon.configStore.GetInitPath()
 	if rv, err := exec.Command(defaultInitBinary, "--version").Output(); err == nil {
 		if _, commit, err := parseInitVersion(string(rv)); err != nil {
 			logrus.Warnf("failed to parse %s version: %s", defaultInitBinary, err)
-			v.InitCommit.ID = "N/A"
 		} else {
 			v.InitCommit.ID = commit
-			if len(dockerversion.InitCommitID) > len(commit) {
-				v.InitCommit.Expected = dockerversion.InitCommitID[0:len(commit)]
-			}
 		}
 	} else {
 		logrus.Warnf("failed to retrieve %s version: %s", defaultInitBinary, err)
-		v.InitCommit.ID = "N/A"
 	}
+
+	// Set expected and actual commits to the same value to prevent the client
+	// showing that the version does not match the "expected" version/commit.
+	v.RuncCommit.Expected = v.RuncCommit.ID
+	v.ContainerdCommit.Expected = v.ContainerdCommit.ID
+	v.InitCommit.Expected = v.InitCommit.ID
 
 	if v.CgroupDriver == cgroupNoneDriver {
 		if v.CgroupVersion == "2" {

--- a/dockerversion/version_lib.go
+++ b/dockerversion/version_lib.go
@@ -10,7 +10,6 @@ var (
 	Version               = "library-import"
 	BuildTime             = "library-import"
 	IAmStatic             = "library-import"
-	InitCommitID          = "library-import"
 	PlatformName          = ""
 	ProductName           = ""
 	DefaultProductLicense = ""

--- a/hack/make/.go-autogen
+++ b/hack/make/.go-autogen
@@ -14,7 +14,6 @@ LDFLAGS="${LDFLAGS} \
 	-X \"github.com/docker/docker/dockerversion.PlatformName=${PLATFORM}\" \
 	-X \"github.com/docker/docker/dockerversion.ProductName=${PRODUCT}\" \
 	-X \"github.com/docker/docker/dockerversion.DefaultProductLicense=${DEFAULT_PRODUCT_LICENSE}\" \
-	-X \"github.com/docker/docker/dockerversion.InitCommitID=${TINI_COMMIT}\" \
 "
 
 # Compile the Windows resources into the sources


### PR DESCRIPTION
These checks were added when we required a specific version of containerd
and runc (different versions were known to be incompatible). I don't think
we had a similar requirement for tini, so this check was redundant. Let's
remove the check altogether.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

