### PR TITLE
hack/vendor.sh: allow go version to be specified with .0

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -17,8 +17,8 @@ if [ $# -eq 0 ] || [ "$1" = "archive/tar" ]; then
 	: "${GO_VERSION:=$(awk -F '[ =]' '$1 == "ARG" && $2 == "GO_VERSION" { print $3; exit }' ./Dockerfile)}"
 	rm -rf vendor/archive
 	mkdir -p ./vendor/archive/tar
-	echo "downloading: https://golang.org/dl/go${GO_VERSION}.src.tar.gz"
-	curl -fsSL "https://golang.org/dl/go${GO_VERSION}.src.tar.gz" \
+	echo "downloading: https://golang.org/dl/go${GO_VERSION%.0}.src.tar.gz"
+	curl -fsSL "https://golang.org/dl/go${GO_VERSION%.0}.src.tar.gz" \
 		| tar --extract --gzip --directory=vendor/archive/tar --strip-components=4 go/src/archive/tar
 	patch --strip=4 --directory=vendor/archive/tar --input="$PWD/patches/0001-archive-tar-do-not-populate-user-group-names.patch"
 fi


### PR DESCRIPTION
Golang '.0' releases are released without a trailing .0 (i.e. go1.17
is equal to go1.17.0). For the base image, we want to specify the go
version including their patch release (golang:1.17 is equivalent to
go1.17.x), so adjust the script to also accept the trailing .0, because
otherwise the download-URL is not found:

    hack/vendor.sh archive/tar
    update vendored copy of archive/tar
    downloading: https://golang.org/dl/go1.17.0.src.tar.gz
    curl: (22) The requested URL returned error: 404


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

