### PR TITLE
vendor: update tar-split to v0.11.2

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -75,7 +75,7 @@ github.com/modern-go/reflect2                       94122c33edd36123c84d5368cfb2
 
 # get graph and distribution packages
 github.com/docker/distribution                      0d3efadf0154c2b8a4e7b6621fff9809655cc580
-github.com/vbatts/tar-split                         620714a4c508c880ac1bdda9c8370a2b19af1a55 # v0.11.1
+github.com/vbatts/tar-split                         80a436fd6164c557b131f7c59ed69bd81af69761 # v0.11.2
 github.com/opencontainers/go-digest                 ea51bea511f75cfa3ef6098cc253c5c3609b037a # v1.0.0
 
 # get go-zfs packages

--- a/vendor/github.com/vbatts/tar-split/go.mod
+++ b/vendor/github.com/vbatts/tar-split/go.mod
@@ -1,0 +1,8 @@
+module github.com/vbatts/tar-split
+
+go 1.15
+
+require (
+	github.com/sirupsen/logrus v1.7.0
+	github.com/urfave/cli v1.22.4
+)

--- a/vendor/github.com/vbatts/tar-split/tar/storage/getter.go
+++ b/vendor/github.com/vbatts/tar-split/tar/storage/getter.go
@@ -92,11 +92,12 @@ func NewDiscardFilePutter() FilePutter {
 }
 
 type bitBucketFilePutter struct {
+	buffer [32 * 1024]byte // 32 kB is the buffer size currently used by io.Copy, as of August 2021.
 }
 
 func (bbfp *bitBucketFilePutter) Put(name string, r io.Reader) (int64, []byte, error) {
 	c := crc64.New(CRCTable)
-	i, err := io.Copy(c, r)
+	i, err := io.CopyBuffer(c, r, bbfp.buffer[:])
 	return i, c.Sum(nil), err
 }
 


### PR DESCRIPTION
Brings in https://github.com/vbatts/tar-split/pull/54

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>