### PR TITLE
Remove platform argument from Puller interface.

### DIFF
--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -11,7 +11,6 @@ import (
 	refstore "github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
 	digest "github.com/opencontainers/go-digest"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -21,7 +20,7 @@ type Puller interface {
 	// Pull tries to pull the image referenced by `tag`
 	// Pull returns an error if any, as well as a boolean that determines whether to retry Pull on the next configured endpoint.
 	//
-	Pull(ctx context.Context, ref reference.Named, platform *specs.Platform) error
+	Pull(ctx context.Context, ref reference.Named) error
 }
 
 // newPuller returns a Puller interface that will pull from a v2 registry.
@@ -95,7 +94,7 @@ func Pull(ctx context.Context, ref reference.Named, imagePullConfig *ImagePullCo
 			continue
 		}
 
-		if err := puller.Pull(ctx, ref, imagePullConfig.Platform); err != nil {
+		if err := puller.Pull(ctx, ref); err != nil {
 			// Was this pull cancelled? If so, don't try to fall
 			// back.
 			fallback := false

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -60,7 +60,7 @@ type v2Puller struct {
 	manifestStore     *manifestStore
 }
 
-func (p *v2Puller) Pull(ctx context.Context, ref reference.Named, platform *specs.Platform) (err error) {
+func (p *v2Puller) Pull(ctx context.Context, ref reference.Named) (err error) {
 	// TODO(tiborvass): was ReceiveTimeout
 	p.repo, err = NewV2Repository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
 	if err != nil {
@@ -73,7 +73,7 @@ func (p *v2Puller) Pull(ctx context.Context, ref reference.Named, platform *spec
 		return err
 	}
 
-	if err = p.pullV2Repository(ctx, ref, platform); err != nil {
+	if err = p.pullV2Repository(ctx, ref); err != nil {
 		if _, ok := err.(fallbackError); ok {
 			return err
 		}
@@ -87,10 +87,10 @@ func (p *v2Puller) Pull(ctx context.Context, ref reference.Named, platform *spec
 	return err
 }
 
-func (p *v2Puller) pullV2Repository(ctx context.Context, ref reference.Named, platform *specs.Platform) (err error) {
+func (p *v2Puller) pullV2Repository(ctx context.Context, ref reference.Named) (err error) {
 	var layersDownloaded bool
 	if !reference.IsNameOnly(ref) {
-		layersDownloaded, err = p.pullV2Tag(ctx, ref, platform)
+		layersDownloaded, err = p.pullV2Tag(ctx, ref, p.config.Platform)
 		if err != nil {
 			return err
 		}
@@ -105,7 +105,7 @@ func (p *v2Puller) pullV2Repository(ctx context.Context, ref reference.Named, pl
 			if err != nil {
 				return err
 			}
-			pulledNew, err := p.pullV2Tag(ctx, tagRef, platform)
+			pulledNew, err := p.pullV2Tag(ctx, tagRef, p.config.Platform)
 			if err != nil {
 				// Since this is the pull-all-tags case, don't
 				// allow an error pulling a particular tag to

--- a/distribution/registry_unit_test.go
+++ b/distribution/registry_unit_test.go
@@ -83,7 +83,7 @@ func testTokenPassThru(t *testing.T, ts *httptest.Server) {
 	logrus.Debug("About to pull")
 	// We expect it to fail, since we haven't mock'd the full registry exchange in our handler above
 	tag, _ := reference.WithTag(n, "tag_goes_here")
-	_ = p.pullV2Repository(ctx, tag, nil)
+	_ = p.pullV2Repository(ctx, tag)
 }
 
 func TestTokenPassThru(t *testing.T) {


### PR DESCRIPTION
The `platform` argument is unneeded because `ImagePullConfig` is already in the `v2Puller` struct.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Remove platform argument from Puller interface.

**- How I did it**

The platform option was introduced in this [contribution](https://github.com/moby/moby/commit/0380fbff37922cadf294851b1546f4c212c7f364#diff-cd6eca1d1dbceb8e107577c74bf1760760204df66f0ff833c8ca35291e40cad0R24), but I don't think it's necessary, we can just use ImagePullConfig directly.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

