### PR TITLE
libnetwork/types: remove unused functions

### DIFF
--- a/libnetwork/types/types.go
+++ b/libnetwork/types/types.go
@@ -146,51 +146,6 @@ func (p *PortBinding) String() string {
 	return ret
 }
 
-// FromString reads the PortBinding structure from string s.
-// String s is a triple of "protocol/containerIP:port/hostIP:port"
-// containerIP and hostIP can be in dotted decimal ("192.0.2.1") or IPv6 ("2001:db8::68") form.
-// Zoned addresses ("169.254.0.23%eth0" or "fe80::1ff:fe23:4567:890a%eth0") are not supported.
-// If string s is incorrectly formatted or the IP addresses or ports cannot be parsed, FromString
-// returns an error.
-func (p *PortBinding) FromString(s string) error {
-	ps := strings.Split(s, "/")
-	if len(ps) != 3 {
-		return BadRequestErrorf("invalid format for port binding: %s", s)
-	}
-
-	p.Proto = ParseProtocol(ps[0])
-
-	var err error
-	if p.IP, p.Port, err = parseIPPort(ps[1]); err != nil {
-		return BadRequestErrorf("failed to parse Container IP/Port in port binding: %s", err.Error())
-	}
-
-	if p.HostIP, p.HostPort, err = parseIPPort(ps[2]); err != nil {
-		return BadRequestErrorf("failed to parse Host IP/Port in port binding: %s", err.Error())
-	}
-
-	return nil
-}
-
-func parseIPPort(s string) (net.IP, uint16, error) {
-	hoststr, portstr, err := net.SplitHostPort(s)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	ip := net.ParseIP(hoststr)
-	if ip == nil {
-		return nil, 0, BadRequestErrorf("invalid ip: %s", hoststr)
-	}
-
-	port, err := strconv.ParseUint(portstr, 10, 16)
-	if err != nil {
-		return nil, 0, BadRequestErrorf("invalid port: %s", portstr)
-	}
-
-	return ip, uint16(port), nil
-}
-
 // Equal checks if this instance of PortBinding is equal to the passed one
 func (p *PortBinding) Equal(o *PortBinding) bool {
 	if p == o {

--- a/libnetwork/types/types.go
+++ b/libnetwork/types/types.go
@@ -342,21 +342,6 @@ func GetMinimalIP(ip net.IP) net.IP {
 	return ip
 }
 
-// GetMinimalIPNet returns a copy of the passed IP Network with congruent ip and mask notation
-func GetMinimalIPNet(nw *net.IPNet) *net.IPNet {
-	if nw == nil {
-		return nil
-	}
-	if len(nw.IP) == 16 && nw.IP.To4() != nil {
-		m := nw.Mask
-		if len(m) == 16 {
-			m = m[12:16]
-		}
-		return &net.IPNet{IP: nw.IP.To4(), Mask: m}
-	}
-	return nw
-}
-
 // IsIPNetValid returns true if the ipnet is a valid network/mask
 // combination. Otherwise returns false.
 func IsIPNetValid(nw *net.IPNet) bool {

--- a/libnetwork/types/types.go
+++ b/libnetwork/types/types.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 
 	"github.com/ishidawataru/sctp"
@@ -67,19 +66,6 @@ func (t *TransportPort) GetCopy() TransportPort {
 // String returns the TransportPort structure in string form
 func (t *TransportPort) String() string {
 	return fmt.Sprintf("%s/%d", t.Proto.String(), t.Port)
-}
-
-// FromString reads the TransportPort structure from string
-func (t *TransportPort) FromString(s string) error {
-	ps := strings.Split(s, "/")
-	if len(ps) == 2 {
-		t.Proto = ParseProtocol(ps[0])
-		if p, err := strconv.ParseUint(ps[1], 10, 16); err == nil {
-			t.Port = uint16(p)
-			return nil
-		}
-	}
-	return BadRequestErrorf("invalid format for transport port: %s", s)
 }
 
 // PortBinding represents a port binding between the container and the host

--- a/libnetwork/types/types_test.go
+++ b/libnetwork/types/types_test.go
@@ -3,9 +3,6 @@ package types
 import (
 	"net"
 	"testing"
-
-	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestTransportPortConv(t *testing.T) {
@@ -22,64 +19,6 @@ func TestTransportPortConv(t *testing.T) {
 	}
 	if !tp.Equal(rc) {
 		t.Fatalf("FromString() method failed")
-	}
-}
-
-func TestTransportPortBindingConv(t *testing.T) {
-	input := []struct {
-		sform      string
-		pb         PortBinding
-		shouldFail bool
-	}{
-		{ // IPv4 -> IPv4
-			sform: "tcp/172.28.30.23:80/112.0.43.56:8001",
-			pb: PortBinding{
-				Proto:    TCP,
-				IP:       net.IPv4(172, 28, 30, 23),
-				Port:     uint16(80),
-				HostIP:   net.IPv4(112, 0, 43, 56),
-				HostPort: uint16(8001),
-			},
-		},
-		{ // IPv6 -> IPv4
-			sform: "tcp/[2001:db8::1]:80/112.0.43.56:8001",
-			pb: PortBinding{
-				Proto:    TCP,
-				IP:       net.IP{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
-				Port:     uint16(80),
-				HostIP:   net.IPv4(112, 0, 43, 56),
-				HostPort: uint16(8001),
-			},
-		},
-		{ // IPv4inIPv6 -> IPv4
-			sform: "tcp/[::ffff:172.28.30.23]:80/112.0.43.56:8001",
-			pb: PortBinding{
-				Proto:    TCP,
-				IP:       net.IPv4(172, 28, 30, 23),
-				Port:     uint16(80),
-				HostIP:   net.IPv4(112, 0, 43, 56),
-				HostPort: uint16(8001),
-			},
-		},
-		{ // IPv4 -> IPv4 zoned
-			sform:      "tcp/172.28.30.23:80/169.254.0.23%eth0:8001",
-			shouldFail: true,
-		},
-		{ // IPv4 -> IPv6 zoned
-			sform:      "tcp/172.28.30.23:80/[fe80::1ff:fe23:4567:890a%eth0]:8001",
-			shouldFail: true,
-		},
-	}
-
-	for _, in := range input {
-		rc := new(PortBinding)
-		err := rc.FromString(in.sform)
-		if in.shouldFail {
-			assert.Assert(t, is.ErrorContains(err, ""), "Unexpected success parsing %s", in.sform)
-		} else {
-			assert.NilError(t, err)
-			assert.Assert(t, is.DeepEqual(in.pb, *rc), "input %s: expected %#v, got %#v", in.sform, in.pb, rc)
-		}
 	}
 }
 

--- a/libnetwork/types/types_test.go
+++ b/libnetwork/types/types_test.go
@@ -5,23 +5,6 @@ import (
 	"testing"
 )
 
-func TestTransportPortConv(t *testing.T) {
-	sform := "tcp/23"
-	tp := &TransportPort{Proto: TCP, Port: uint16(23)}
-
-	if sform != tp.String() {
-		t.Fatalf("String() method failed")
-	}
-
-	rc := new(TransportPort)
-	if err := rc.FromString(sform); err != nil {
-		t.Fatal(err)
-	}
-	if !tp.Equal(rc) {
-		t.Fatalf("FromString() method failed")
-	}
-}
-
 func TestErrorConstructors(t *testing.T) {
 	var err error
 


### PR DESCRIPTION
Removes 

- ibnetwork/types: remove GetMinimalIPNet() as it's unused
  this was added in https://github.com/moby/libnetwork/commit/4e48ff3aabbfbb8e6e164be753c055e4ced76e81, but never used.
- libnetwork/types: remove PortBinding.FromString() as it's unused
- libnetwork/types: remove TransportPort.FromString() as it's unused


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

