### PR TITLE
pkg/sysinfo: use containerd/pkg/seccomp.IsEnabled()

### DIFF
--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -6,12 +6,11 @@ import (
 	"os"
 	"path"
 	"strings"
-	"sync"
 
 	cdcgroups "github.com/containerd/cgroups"
+	cdseccomp "github.com/containerd/containerd/pkg/seccomp"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 )
 
 func findCgroupMountpoints() (map[string]string, error) {
@@ -246,23 +245,9 @@ func applyCgroupNsInfo(info *SysInfo) {
 	}
 }
 
-var (
-	seccompOnce    sync.Once
-	seccompEnabled bool
-)
-
 // applySeccompInfo checks if Seccomp is supported, via CONFIG_SECCOMP.
 func applySeccompInfo(info *SysInfo) {
-	seccompOnce.Do(func() {
-		// Check if Seccomp is supported, via CONFIG_SECCOMP.
-		if err := unix.Prctl(unix.PR_GET_SECCOMP, 0, 0, 0, 0); err != unix.EINVAL {
-			// Make sure the kernel has CONFIG_SECCOMP_FILTER.
-			if err := unix.Prctl(unix.PR_SET_SECCOMP, unix.SECCOMP_MODE_FILTER, 0, 0, 0); err != unix.EINVAL {
-				seccompEnabled = true
-			}
-		}
-	})
-	info.Seccomp = seccompEnabled
+	info.Seccomp = cdseccomp.IsEnabled()
 }
 
 func cgroupEnabled(mountPoint, name string) bool {

--- a/vendor/github.com/containerd/containerd/pkg/seccomp/seccomp.go
+++ b/vendor/github.com/containerd/containerd/pkg/seccomp/seccomp.go
@@ -1,0 +1,25 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package seccomp
+
+// IsEnabled checks whether seccomp support is enabled. On Linux, it returns
+// true if the kernel has been configured to support seccomp (kernel options
+// CONFIG_SECCOMP and CONFIG_SECCOMP_FILTER are set). On non-Linux, it always
+// returns false.
+func IsEnabled() bool {
+	return isEnabled()
+}

--- a/vendor/github.com/containerd/containerd/pkg/seccomp/seccomp_linux.go
+++ b/vendor/github.com/containerd/containerd/pkg/seccomp/seccomp_linux.go
@@ -1,0 +1,80 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+   Copyright The runc Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package seccomp
+
+import (
+	"sync"
+
+	"golang.org/x/sys/unix"
+)
+
+var (
+	enabled     bool
+	enabledOnce sync.Once
+)
+
+// isEnabled returns whether the kernel has been configured to support seccomp
+// (including the check for CONFIG_SECCOMP_FILTER kernel option).
+func isEnabled() bool {
+	// Excerpts from prctl(2), section ERRORS:
+	//
+	// EACCES
+	//      option is PR_SET_SECCOMP and arg2 is SECCOMP_MODE_FILTER, but
+	//      the process does not have the CAP_SYS_ADMIN capability or has
+	//      not set the no_new_privs attribute <...>.
+	// <...>
+	// EFAULT
+	//      option is PR_SET_SECCOMP, arg2 is SECCOMP_MODE_FILTER, the
+	//      system was built with CONFIG_SECCOMP_FILTER, and arg3 is an
+	//      invalid address.
+	// <...>
+	// EINVAL
+	//      option is PR_SET_SECCOMP or PR_GET_SECCOMP, and the kernel
+	//      was not configured with CONFIG_SECCOMP.
+	//
+	// EINVAL
+	//      option is PR_SET_SECCOMP, arg2 is SECCOMP_MODE_FILTER,
+	//      and the kernel was not configured with CONFIG_SECCOMP_FILTER.
+	// <end of quote>
+	//
+	// Meaning, in case these kernel options are set (this is what we check
+	// for here), we will get some other error (most probably EACCES or
+	// EFAULT). IOW, EINVAL means "seccomp not supported", any other error
+	// means it is supported.
+
+	enabledOnce.Do(func() {
+		enabled = unix.Prctl(unix.PR_SET_SECCOMP, unix.SECCOMP_MODE_FILTER, 0, 0, 0) != unix.EINVAL
+	})
+
+	return enabled
+}

--- a/vendor/github.com/containerd/containerd/pkg/seccomp/seccomp_unsupported.go
+++ b/vendor/github.com/containerd/containerd/pkg/seccomp/seccomp_unsupported.go
@@ -1,0 +1,23 @@
+// +build !linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package seccomp
+
+func isEnabled() bool {
+	return false
+}


### PR DESCRIPTION
This replaces the local SeccompSupported() utility for the implementation in containerd,
which performs the same check, and brings in the improvements made in https://github.com/containerd/containerd/pull/5256.


**- A picture of a cute animal (not mandatory but encouraged)**

