### PR TITLE
pkg/plugins: fix compatibility with go1.16

### DIFF
--- a/pkg/plugins/discovery.go
+++ b/pkg/plugins/discovery.go
@@ -3,7 +3,6 @@ package plugins // import "github.com/docker/docker/pkg/plugins"
 import (
 	"encoding/json"
 	"fmt"
-	"io/fs"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -41,7 +40,7 @@ func Scan() ([]string, error) {
 				continue
 			}
 
-			entry = fs.FileInfoToDirEntry(fi)
+			entry = fileInfoToDirEntry(fi)
 		}
 
 		if entry.Type()&os.ModeSocket != 0 {

--- a/pkg/plugins/utils.go
+++ b/pkg/plugins/utils.go
@@ -1,0 +1,8 @@
+//go:build go1.17
+// +build go1.17
+
+package plugins
+
+import "io/fs"
+
+var fileInfoToDirEntry = fs.FileInfoToDirEntry

--- a/pkg/plugins/utils_go1.16.go
+++ b/pkg/plugins/utils_go1.16.go
@@ -1,0 +1,47 @@
+//go:build !go1.17
+// +build !go1.17
+
+// This code is taken from https://github.com/golang/go/blob/go1.17/src/io/fs/readdir.go#L49-L77
+// and provides the io/fs.FileInfoToDirEntry() utility for go1.16. Go 1.16 and up
+// provide a new implementation of ioutil.ReadDir() (in os.ReadDir()) that returns
+// an os.DirEntry instead of fs.FileInfo. go1.17 added the io/fs.FileInfoToDirEntry()
+// utility to allow existing uses of ReadDir() to get the old type. This utility
+// is not available in go1.16, so we copied it to assist the migration to os.ReadDir().
+
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package plugins
+
+import "os"
+
+// dirInfo is a DirEntry based on a FileInfo.
+type dirInfo struct {
+	fileInfo os.FileInfo
+}
+
+func (di dirInfo) IsDir() bool {
+	return di.fileInfo.IsDir()
+}
+
+func (di dirInfo) Type() os.FileMode {
+	return di.fileInfo.Mode().Type()
+}
+
+func (di dirInfo) Info() (os.FileInfo, error) {
+	return di.fileInfo, nil
+}
+
+func (di dirInfo) Name() string {
+	return di.fileInfo.Name()
+}
+
+// fileInfoToDirEntry returns a DirEntry that returns information from info.
+// If info is nil, fileInfoToDirEntry returns nil.
+func fileInfoToDirEntry(info os.FileInfo) os.DirEntry {
+	if info == nil {
+		return nil
+	}
+	return dirInfo{fileInfo: info}
+}


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/42792#issuecomment-907482023

commit c55a4ac7795c7606b548b38e24673733481e2167 (https://github.com/moby/moby/pull/42792) changed the ioutil utilities
to use the new os variants, per recommendation from the go 1.16 release notes:
https://golang.org/doc/go1.16#ioutil

> we encourage new code to use the new definitions in the io and os packages.
> Here is a list of the new locations of the names exported by io/ioutil:

However, the devil is in the detail, and io.ReadDir() is not a direct
replacement for ioutil.ReadDir();

> ReadDir => os.ReadDir (note: returns a slice of os.DirEntry rather than a slice of fs.FileInfo)

go1.17 added a io.FileInfoToDirEntry() utility to concert a DirEntry to
a FileInfo, but it's not available in go1.16

This patch copies the FileInfoToDirEntry code, and uses it for go1.16.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

