### PR TITLE
docker save: adjust timestamp on the duplicated layers.

### DIFF
--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -401,14 +401,18 @@ func (s *saveSession) saveLayer(id layer.ChainID, legacyImg image.V1Image, creat
 			return distribution.Descriptor{}, err
 		}
 
-		for _, fname := range []string{"", legacyVersionFileName, legacyConfigFileName, legacyLayerFileName} {
-			// todo: maybe save layer created timestamp?
-			if err := system.Chtimes(filepath.Join(outDir, fname), createdTime, createdTime); err != nil {
+		s.diffIDPaths[l.DiffID()] = layerPath
+	}
+	// Adjust file times, prefer to not following symbol links,
+	// resort to default behavior if `no follow` not supported.
+	for _, fname := range []string{"", legacyVersionFileName, legacyConfigFileName, legacyLayerFileName} {
+		// todo: maybe save layer created timestamp?
+		if err := system.ChtimesNoFollow(filepath.Join(outDir, fname), createdTime, createdTime); err != nil {
+			err = system.Chtimes(filepath.Join(outDir, fname), createdTime, createdTime)
+			if err != nil {
 				return distribution.Descriptor{}, err
 			}
 		}
-
-		s.diffIDPaths[l.DiffID()] = layerPath
 	}
 	s.savedLayers[legacyImg.ID] = struct{}{}
 

--- a/pkg/system/chtimes_linux_test.go
+++ b/pkg/system/chtimes_linux_test.go
@@ -7,6 +7,16 @@ import (
 	"time"
 )
 
+var (
+	testData = []struct {
+		effectValue, expectedValue time.Time
+	}{
+		{time.Unix(0, 0).Add(-100 * time.Second), time.Unix(0, 0)},
+		{time.Unix(0, 0), time.Unix(0, 0)},
+		{time.Unix(100, 0), time.Unix(100, 0)},
+	}
+)
+
 // TestChtimesLinux tests Chtimes access time on a tempfile on Linux
 func TestChtimesLinux(t *testing.T) {
 	file, dir := prepareTempFile(t)
@@ -85,5 +95,80 @@ func TestChtimesLinux(t *testing.T) {
 	aTime = time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec)) //nolint: unconvert
 	if aTime.Truncate(time.Second) != unixMaxTime.Truncate(time.Second) {
 		t.Fatalf("Expected: %s, got: %s", unixMaxTime.Truncate(time.Second), aTime.Truncate(time.Second))
+	}
+}
+
+// TestChtimesNoFollowLinux tests ChtimesNoFollow access time on a tempfile and its symbol link on Linux
+func TestChtimesNoFollowLinux(t *testing.T) {
+	file, dir := prepareTempFile(t)
+	link := file + ".lnk"
+	if err := os.Symlink(file, link); err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	// test realfile
+	for _, aTimeData := range testData {
+		for _, mTimeData := range testData {
+			if aTimeData.effectValue.Before(mTimeData.effectValue) {
+				continue
+			}
+			ChtimesNoFollow(file, aTimeData.effectValue, mTimeData.effectValue)
+			Chtimes(file, aTimeData.effectValue, mTimeData.effectValue)
+			f, err := os.Lstat(file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			stat := f.Sys().(*syscall.Stat_t)
+			aTime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec)) //nolint: unconvert
+			if aTime != aTimeData.expectedValue {
+				t.Fatalf("Expected: %s after set %s, got: %s", aTimeData.expectedValue, aTimeData.effectValue, aTime)
+			}
+		}
+	}
+
+	// test linkfile
+	for _, aTimeData := range testData {
+		for _, mTimeData := range testData {
+			if aTimeData.effectValue.Before(mTimeData.effectValue) {
+				continue
+			}
+			ChtimesNoFollow(link, aTimeData.effectValue, mTimeData.effectValue)
+			f, err := os.Lstat(link)
+			if err != nil {
+				t.Fatal(err)
+			}
+			stat := f.Sys().(*syscall.Stat_t)
+			aTime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec)) //nolint: unconvert
+			if aTime != aTimeData.expectedValue {
+				t.Fatalf("Symbol link, expected: %s after set %s, got: %s", aTimeData.expectedValue, aTimeData.effectValue, aTime)
+			}
+		}
+	}
+
+	// test link and real files
+	for _, realfileTimeData := range testData {
+		for _, linkfileTimeData := range testData {
+			ChtimesNoFollow(file, realfileTimeData.effectValue, realfileTimeData.effectValue)
+			ChtimesNoFollow(link, linkfileTimeData.effectValue, linkfileTimeData.effectValue)
+			f, err := os.Lstat(file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			stat := f.Sys().(*syscall.Stat_t)
+			aTime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec)) //nolint: unconvert
+			if aTime != realfileTimeData.expectedValue {
+				t.Fatalf("Realfile, expected: %s after set %s, got: %s", realfileTimeData.expectedValue, realfileTimeData.effectValue, aTime)
+			}
+			f, err = os.Lstat(link)
+			if err != nil {
+				t.Fatal(err)
+			}
+			stat = f.Sys().(*syscall.Stat_t)
+			aTime = time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec)) //nolint: unconvert
+			if aTime != linkfileTimeData.expectedValue {
+				t.Fatalf("Linkfile, expected: %s after set %s, got: %s", linkfileTimeData.expectedValue, linkfileTimeData.effectValue, aTime)
+			}
+		}
 	}
 }

--- a/pkg/system/chtimes_nowindows.go
+++ b/pkg/system/chtimes_nowindows.go
@@ -5,11 +5,27 @@ package system // import "github.com/docker/docker/pkg/system"
 
 import (
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 // setCTime will set the create time on a file. On Unix, the create
 // time is updated as a side effect of setting the modified time, so
 // no action is required.
 func setCTime(path string, ctime time.Time) error {
+	return nil
+}
+
+// setAMTimeNoFollow will set access/modification time on a file,
+// without following symbol link.
+func setAMTimeNoFollow(path string, atime time.Time, mtime time.Time) error {
+	uts := []unix.Timespec{
+		unix.NsecToTimespec(atime.UnixNano()),
+		unix.NsecToTimespec(mtime.UnixNano()),
+	}
+	return unix.UtimesNanoAt(unix.AT_FDCWD, path, uts, unix.AT_SYMLINK_NOFOLLOW)
+}
+
+func setCTimeNoFollow(path string, ctime time.Time) error {
 	return nil
 }

--- a/pkg/system/chtimes_windows.go
+++ b/pkg/system/chtimes_windows.go
@@ -24,3 +24,17 @@ func setCTime(path string, ctime time.Time) error {
 	c := windows.NsecToFiletime(windows.TimespecToNsec(ctimespec))
 	return windows.SetFileTime(h, &c, nil, nil)
 }
+
+// setAMTimeNoFollow means to set access/modification time on a file,
+// without following symbol link.
+// The implementation returns ErrNotSupportedPlatform on windows, ATM.
+func setAMTimeNoFollow(path string, atime time.Time, mtime time.Time) error {
+	return ErrNotSupportedPlatform
+}
+
+// setCTimeNoFollow means to set creation time on a file,
+// without following symbol link.
+// The implementation returns ErrNotSupportedPlatform on windows, ATM.
+func setCTimeNoFollow(path string, ctime time.Time) error {
+	return ErrNotSupportedPlatform
+}


### PR DESCRIPTION
The issue raised in https://github.com/moby/moby/issues/42766 concerns the timestamp for the files in the duplicated layers generated by `docker save`. This code change would change the timestamp for the version/config files, and try to change the layer tar symbol link file. Before this change, the duplicate layer would have newly created timestamp, and `docker save` would yield different result for each runs, when the image somehow has several duplicated layers. 


But this code alone would not fix the issue  #42766 , because golang would follow symbol link when modifying file timestamp and leave the timestamp of the symbol link alone.  There currently is no api in golang to modify the timestamp of a symbol link. 
https://github.com/golang/go/pull/48138 is trying to address it for linux  

EDIT:
This change add a new function `ChtimesNoFollow` in pkg/system which would change access/modification time on the file without following symbol links.

TODO:
Non-unix platform needs further verification/adjustment.

To reproduce the issue, build a image using following dockerfile
```
FROM alpine
RUN touch /t
RUN touch /t
RUN touch /t
RUN touch /t
RUN touch /t
RUN touch /t
RUN touch /t
RUN touch /t
RUN touch /t
RUN touch /t
```
`docker build -t hashtest:0.0.1 .`
`docker inspect` would show several groups of layers with same id
```
docker insepct hashtest:0.0.1
        "RootFS": {
            "Type": "layers",
            "Layers": [
                "sha256:bc276c40b172b1c5467277d36db5308a203a48262d5f278766cf083947d05466",
                "sha256:6144a1f7246aab540b9219ec681fbca6280a99b96b2fae05edf1e62d4f9f76f8",
                "sha256:aaf17c837decf2f3a1889a97922f961d912367149f874ff288759d3a50357fa2",
                "sha256:01501f252e30fdcd0167536a64696c1ddd992df2adb36c1b3ef9b7eb9d354c7b",
                "sha256:01501f252e30fdcd0167536a64696c1ddd992df2adb36c1b3ef9b7eb9d354c7b",
                "sha256:01501f252e30fdcd0167536a64696c1ddd992df2adb36c1b3ef9b7eb9d354c7b",
                "sha256:fb8c24d40c1ed5fbfcf238101a4f4771e46baaf173f15db983360e21d695f488",
                "sha256:fb8c24d40c1ed5fbfcf238101a4f4771e46baaf173f15db983360e21d695f488",
                "sha256:6f4c80a3fd32eb0f46f257b36640aa6aef32971000bb5b5325eb488435c9efd1",
                "sha256:ae92784b7e606d13014937f20f23ceea873559eb1297aee60ac758999e02a862",
                "sha256:ae92784b7e606d13014937f20f23ceea873559eb1297aee60ac758999e02a862"
            ]
        },
```
Check the hash value for each `docker save`
```
$ for i in {1..10}; do  docker save hashtest:0.0.1 | md5sum; sleep 1; done
2d5484745665a413c042c93d909779a0  -
c893d5aeb17484797563a8ce294e5478  -
17950a0fc5b9fb150201c4397d515f7a  -
96c3153c45beed59d079913c00b9c6d8  -
33419bacc6d84f5d5d930fba3c5a0f3a  -
6315d57625842eea2fd9b0711b7db519  -
d394ead51e2b2fd3645bb2f85312411a  -
4704a56bb9c61bff6ddbe3eecba78207  -
8538f1b4d4b8beff9f9903f916a3cbf8  -
9a3b06f9e54b3cc871bfac8260405ab0  -
```
With this code change and the golang changes, each round of `docker save` would yield identical file
```
$ for i in {1..10}; do  docker save hashtest:0.0.1 | md5sum; sleep 1; done
5f467dad8d44f733737450685eb37ec2  -
5f467dad8d44f733737450685eb37ec2  -
5f467dad8d44f733737450685eb37ec2  -
5f467dad8d44f733737450685eb37ec2  -
5f467dad8d44f733737450685eb37ec2  -
5f467dad8d44f733737450685eb37ec2  -
5f467dad8d44f733737450685eb37ec2  -
5f467dad8d44f733737450685eb37ec2  -
5f467dad8d44f733737450685eb37ec2  -
5f467dad8d44f733737450685eb37ec2  -
```