### PR TITLE
Update seccomp policy to allow clone3()

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -72,6 +72,7 @@
 				"clock_getres_time64",
 				"clock_gettime",
 				"clock_gettime64",
+                               "clone3",
 				"clock_nanosleep",
 				"clock_nanosleep_time64",
 				"close",
@@ -623,18 +624,6 @@
 					"s390x"
 				]
 			},
-			"excludes": {
-				"caps": [
-					"CAP_SYS_ADMIN"
-				]
-			}
-		},
-		{
-			"names": [
-				"clone3"
-			],
-			"action": "SCMP_ACT_ERRNO",
-			"errnoRet": 38,
 			"excludes": {
 				"caps": [
 					"CAP_SYS_ADMIN"


### PR DESCRIPTION
**- What I did**

This pull request updates the default seccomp policy to allow `clone3()`. Please see [this comment](https://github.com/moby/moby/pull/42681#issuecomment-913866511) on #42681 for information about the issue that lead me to make this change. In a nutshell, `clone3()` is required for dnf to work on distros using glibc 2.34 and above.

**- How I did it**
See above
**- How to verify it**
N/A
**- Description for the changelog**

Allow the `clone3()` syscall in default seccomp profile.