### PR TITLE
Display the statistics after docker pull is finished.

### DIFF
--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -2,6 +2,7 @@ package progress // import "github.com/docker/docker/pkg/progress"
 
 import (
 	"fmt"
+	"time"
 )
 
 // Progress represents the progress of a transfer.
@@ -25,7 +26,9 @@ type Progress struct {
 	// digests for push signing.
 	Aux interface{}
 
-	LastUpdate bool
+	LastUpdate   bool
+	DownloadCost time.Duration
+	ExtractCost  time.Duration
 }
 
 // Output is an interface for writing progress information. It's

--- a/pkg/streamformatter/streamformatter.go
+++ b/pkg/streamformatter/streamformatter.go
@@ -117,7 +117,14 @@ func (out *progressOutput) WriteProgress(prog progress.Progress) error {
 	if prog.Message != "" {
 		formatted = out.sf.formatStatus(prog.ID, prog.Message)
 	} else {
-		jsonProgress := jsonmessage.JSONProgress{Current: prog.Current, Total: prog.Total, HideCounts: prog.HideCounts, Units: prog.Units}
+		jsonProgress := jsonmessage.JSONProgress{
+			Current:      prog.Current,
+			Total:        prog.Total,
+			HideCounts:   prog.HideCounts,
+			Units:        prog.Units,
+			DownloadCost: prog.DownloadCost,
+			ExtractCost:  prog.ExtractCost,
+		}
 		formatted = out.sf.formatProgress(prog.ID, prog.Action, &jsonProgress, prog.Aux)
 	}
 	_, err := out.out.Write(formatted)


### PR DESCRIPTION
Fix: https://github.com/moby/moby/issues/42759

Signed-off-by: Da McGrady <dabkb@aol.com>

Related to issue #42759 

Display the layer size as well as the downloading and extraction costs. This would assist users understand what is causing the pipeline to slow down, whether it is the CPU or the network.

e.g.

```
➜ docker pull docker.io/library/golang:1.15

0ae6761270d6: Pull complete  167.5MB Download   2.215s, Extract   3.652s
8b7d058009f0: Pull complete     455B Download     99ms, Extract    396ms
98f97b2cc68a: Pull complete  117.1MB Download    1.96s, Extract   2.209s
```



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

<img src="https://user-images.githubusercontent.com/82504881/132505205-7e6ef71f-56c8-4831-97ac-29732c7bf98b.jpg" width=300>
