### PR TITLE
[20.10 backport] seccomp: add support for "clone3" syscall in default policy

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -591,6 +591,7 @@
 			"names": [
 				"bpf",
 				"clone",
+				"clone3",
 				"fanotify_init",
 				"fsconfig",
 				"fsmount",
@@ -664,6 +665,21 @@
 					"s390x"
 				]
 			},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				]
+			}
+		},
+		{
+			"names": [
+				"clone3"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"errnoRet": 38,
+			"args": [],
+			"comment": "",
+			"includes": {},
 			"excludes": {
 				"caps": [
 					"CAP_SYS_ADMIN"

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -42,6 +42,7 @@ func arches() []Architecture {
 
 // DefaultProfile defines the allowed syscalls for the default seccomp profile.
 func DefaultProfile() *Seccomp {
+	nosys := uint(unix.ENOSYS)
 	syscalls := []*Syscall{
 		{
 			Names: []string{
@@ -522,6 +523,7 @@ func DefaultProfile() *Seccomp {
 			Names: []string{
 				"bpf",
 				"clone",
+				"clone3",
 				"fanotify_init",
 				"fsconfig",
 				"fsmount",
@@ -583,6 +585,17 @@ func DefaultProfile() *Seccomp {
 			Includes: Filter{
 				Arches: []string{"s390", "s390x"},
 			},
+			Excludes: Filter{
+				Caps: []string{"CAP_SYS_ADMIN"},
+			},
+		},
+		{
+			Names: []string{
+				"clone3",
+			},
+			Action:   specs.ActErrno,
+			ErrnoRet: &nosys,
+			Args:     []*specs.LinuxSeccompArg{},
 			Excludes: Filter{
 				Caps: []string{"CAP_SYS_ADMIN"},
 			},

--- a/profiles/seccomp/seccomp.go
+++ b/profiles/seccomp/seccomp.go
@@ -45,6 +45,7 @@ type Syscall struct {
 	Name     string                   `json:"name,omitempty"`
 	Names    []string                 `json:"names,omitempty"`
 	Action   specs.LinuxSeccompAction `json:"action"`
+	ErrnoRet *uint                    `json:"errnoRet,omitempty"`
 	Args     []*specs.LinuxSeccompArg `json:"args"`
 	Comment  string                   `json:"comment"`
 	Includes Filter                   `json:"includes"`

--- a/profiles/seccomp/seccomp_linux.go
+++ b/profiles/seccomp/seccomp_linux.go
@@ -150,29 +150,25 @@ Loop:
 			}
 		}
 
+		newCall := specs.LinuxSyscall{
+			Action:   call.Action,
+			ErrnoRet: call.ErrnoRet,
+		}
 		if call.Name != "" && len(call.Names) != 0 {
 			return nil, errors.New("'name' and 'names' were specified in the seccomp profile, use either 'name' or 'names'")
 		}
-
 		if call.Name != "" {
-			newConfig.Syscalls = append(newConfig.Syscalls, createSpecsSyscall([]string{call.Name}, call.Action, call.Args))
+			newCall.Names = []string{call.Name}
 		} else {
-			newConfig.Syscalls = append(newConfig.Syscalls, createSpecsSyscall(call.Names, call.Action, call.Args))
+			newCall.Names = call.Names
 		}
+		// Loop through all the arguments of the syscall and convert them
+		for _, arg := range call.Args {
+			newCall.Args = append(newCall.Args, *arg)
+		}
+
+		newConfig.Syscalls = append(newConfig.Syscalls, newCall)
 	}
 
 	return newConfig, nil
-}
-
-func createSpecsSyscall(names []string, action specs.LinuxSeccompAction, args []*specs.LinuxSeccompArg) specs.LinuxSyscall {
-	newCall := specs.LinuxSyscall{
-		Names:  names,
-		Action: action,
-	}
-
-	// Loop through all the arguments of the syscall and convert them
-	for _, arg := range args {
-		newCall.Args = append(newCall.Args, *arg)
-	}
-	return newCall
 }


### PR DESCRIPTION
This is a backport of 9f6b562dd12ef7b1f9e2f8e6f2ab6477790a6594 (#42681, see also #42680), adapted to avoid the refactoring that happened in d92739713c633c155c0f3d8065c8278b1d8a44e7 (#42005).

fixes https://github.com/moby/moby/issues/42963
fixes https://github.com/moby/moby/issues/42876