### PR TITLE
libnetwork/overlay:fix join sandbox deadlock

### DIFF
--- a/libnetwork/drivers/overlay/peerdb.go
+++ b/libnetwork/drivers/overlay/peerdb.go
@@ -246,12 +246,11 @@ func (d *driver) peerDbDelete(nid, eid string, peerIP net.IP, peerIPMask net.IPM
 // networkDB has already delivered some events of peers already available on remote nodes,
 // these peers are saved into the peerDB and this function is used to properly configure
 // the network sandbox with all those peers that got previously notified.
-// Note also that this method sends a single message on the channel and the go routine on the
-// other side, will atomically loop on the whole table of peers and will program their state
+// Note also that this method will atomically loop on the whole table of peers and will program their state
 // in one single atomic operation. This is fundamental to guarantee consistency, and avoid that
 // new peerAdd or peerDelete gets reordered during the sandbox init.
 func (d *driver) initSandboxPeerDB(nid string) {
-	d.peerInit(nid)
+	d.peerInitOp(nid)
 }
 
 type peerOperationType int32

--- a/libnetwork/drivers/overlay/peerdb.go
+++ b/libnetwork/drivers/overlay/peerdb.go
@@ -300,15 +300,6 @@ func (d *driver) peerOpRoutine(ctx context.Context, ch chan *peerOperation) {
 	}
 }
 
-func (d *driver) peerInit(nid string) {
-	callerName := caller.Name(1)
-	d.peerOpCh <- &peerOperation{
-		opType:     peerOperationINIT,
-		networkID:  nid,
-		callerName: callerName,
-	}
-}
-
 func (d *driver) peerInitOp(nid string) error {
 	return d.peerDbNetworkWalk(nid, func(pKey *peerKey, pEntry *peerEntry) bool {
 		// Local entries do not need to be added


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
We are using docker swarm with overlay network driver in the environment where stacks are very often updated. There was a problem several times a week when the docker daemon unexpectedly hangs forever, the docker daemon was unable to process update commands like remove and deploy stacks/services as well as container operations. The only thing that helped was the force-killing docker daemon and start it again. This problem often happens when we want to redeploy stack/service. When the docker gets stuck, the service from the given stack always remains in the _Remove_ state forever. It is very difficult to reproduce this problem and we didn't find a reliable way to trigger this deadlock issue. We could only wait for it to happen spontaneously (2-4 times a week).

The redeployment of the stack looks like this (process has been modified to minimize potential root causes): 
1. lock redeployment - so that no other redeployment or cluster modification can run
2. downscale all stack services one by one
3. remove all stack services from the cluster
4. wait until all services are successfully removed
5. delete stack
6. deploy updated stack

According to the stack trace logs, we were able to find out where is the [problematic code section](https://github.com/moby/moby/blob/master/libnetwork/drivers/overlay/peerdb.go#L253-L255):
```
goroutine 905 [chan send, 222 minutes]:
github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/overlay.(*driver).peerInit(0xc001dca200, 0xc09e5acd00, 0x19)
        /go/src/github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/overlay/peerdb.go:302 +0xb9
github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/overlay.(*driver).initSandboxPeerDB(...)
        /go/src/github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/overlay/peerdb.go:250
github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/overlay.(*network).joinSandbox.func1(0xc09dca4c80, 0xc00241fb77)
        /go/src/github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/overlay/ov_network.go:320 +0x69
github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/overlay.(*network).joinSandbox(0xc09dca4c80, 0xc09dc18cd0, 0x0, 0x0, 0x0)
        /go/src/github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/overlay/ov_network.go:352 +0x1a0
github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/overlay.(*driver).peerAddOp(0xc001dca200, 0xc09e5acd00, 0x19, 0xc086a1cbc0, 0x40, 0xc0ad8b0600, 0x10, 0x10, 0xc0ad8b05c8, 0x4, ...)
        /go/src/github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/overlay/peerdb.go:388 +0x30a
github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/overlay.(*driver).peerOpRoutine(0xc001dca200, 0x559f7bd09840, 0xc001644e40, 0xc00178d020)
        /go/src/github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/overlay/peerdb.go:287 +0x361
created by github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/overlay.Init
        /go/src/github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/overlay/overlay.go:77 +0x17f

goroutine 73207086 [chan send, 222 minutes]:
github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/overlay.(*driver).peerDelete(0xc001dca200, 0xc0a3fbfd60, 0x19, 0xc0b0218b40, 0x40, 0xc0b023afd0, 0x10, 0x10, 0xc0b023af78, 0x4, ...)
        /go/src/github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/overlay/peerdb.go:418 +0x1ae
github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/overlay.(*driver).EventNotify(0xc001dca200, 0xc0a3fbfd03, 0xc0a3fbfd60, 0x19, 0xc0b0227860, 0x12, 0xc0b0218b40, 0x40, 0xc0b022adb0, 0x2e, ...)
        /go/src/github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/overlay/joinleave.go:195 +0x3c0
github.com/docker/docker/vendor/github.com/docker/libnetwork.(*network).handleDriverTableEvent(0xc092768e00, 0x559f7ba15ac0, 0xc0b020fe00)
        /go/src/github.com/docker/docker/vendor/github.com/docker/libnetwork/agent.go:870 +0x275
github.com/docker/docker/vendor/github.com/docker/libnetwork.(*controller).handleTableEvents(0xc000a60a00, 0xc0932d79e0, 0xc0997ed910)
        /go/src/github.com/docker/docker/vendor/github.com/docker/libnetwork/agent.go:831 +0x53
created by github.com/docker/docker/vendor/github.com/docker/libnetwork.(*network).addDriverWatches
        /go/src/github.com/docker/docker/vendor/github.com/docker/libnetwork/agent.go:789 +0x341

goroutine 73213133 [chan send, 222 minutes]:
github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/overlay.(*driver).peerAdd(0xc001dca200, 0xc09d717300, 0x19, 0xc0b00b6500, 0x40, 0xc0b0afff40, 0x10, 0x10, 0xc0b0afff3c, 0x4, ...)
        /go/src/github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/overlay/peerdb.go:324 +0x1ca
github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/overlay.(*driver).EventNotify(0xc001dca200, 0xc09d717301, 0xc09d717300, 0x19, 0xc0af2b4ac0, 0x12, 0xc0b00b6500, 0x40, 0xc0aea55f80, 0x2e, ...)
        /go/src/github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/overlay/joinleave.go:199 +0x49d
github.com/docker/docker/vendor/github.com/docker/libnetwork.(*network).handleDriverTableEvent(0xc09a905500, 0x559f7ba23800, 0xc0b096e8c0)
        /go/src/github.com/docker/docker/vendor/github.com/docker/libnetwork/agent.go:870 +0x275
github.com/docker/docker/vendor/github.com/docker/libnetwork.(*controller).handleTableEvents(0xc000a60a00, 0xc09e1872a0, 0xc09e18f460)
        /go/src/github.com/docker/docker/vendor/github.com/docker/libnetwork/agent.go:831 +0x53
created by github.com/docker/docker/vendor/github.com/docker/libnetwork.(*network).addDriverWatches
        /go/src/github.com/docker/docker/vendor/github.com/docker/libnetwork/agent.go:789 +0x341

```
What we can see from the trace is:
1. peerOpRoutine() was in peerAddOp() 
2. peerAddOp() invoked joinSandbox()
3. joinSandbox() called initSandboxPeerDB()
https://github.com/moby/moby/blob/5176095455642c30642efacf6f35afc7c6dede92/libnetwork/drivers/overlay/ov_network.go#L318-L331
4.  peerInit() sent message via channel to the peerOpRoutine()
https://github.com/moby/moby/blob/5176095455642c30642efacf6f35afc7c6dede92/libnetwork/drivers/overlay/peerdb.go#L253-L255 
5. channel deadlock (peerOpCh)

It would never receive the peerInit message because peerOpRoutine() was already in processing peerAddOp(), so this situation creates deadlock.

Fixes reported issue https://github.com/moby/libnetwork/issues/2508. 

**- What I did**
I changed the way how the peerInit operation is called from joinSandbox() to avoid deadlock.

**- How I did it**
Originally joinSandbox() calls peerInitOp() through peerOpRoutine() channel machinery:
```
joinSandbox()->initSandboxPeerDB()->peerInit()-> peerOpCh (channel write) -> peerOpRoutine (channel read) -> peerInitOp()
``` 
Now joinSandbox() calls peerInitOp() directly without channel machinery:
```
joinSandbox()->initSandboxPeerDB()->peerInitOp()
```
This fix is very specific for the case when joinSandbox() needs to call peerInitOp(), so no other code paths are affected.

**- How to verify it**
Unfortunately, we were not able to find a way how we can reproduce this issue by using standard workflows. The fix is already deployed and monitored for more than three weeks without deadlock or other side effects. Everything seem to be working now.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix channel  deadlock in overlay driver.

**- A picture of a cute animal (not mandatory but encouraged)**
Cat deadlock :)
![Cat deadlock](https://media.giphy.com/media/YcFOfbeTcHtVS/giphy-downsized.gif?cid=ecf05e47952zqhdwdwwga1za7skk1p6qp7xjxik1u6hxffbp&rid=giphy-downsized.gif&ct=g)
