### PR TITLE
[20.10 backport] cmd/dockerd: add the link of "the documentation"

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -114,7 +114,7 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 
 	// return human-friendly error before creating files
 	if runtime.GOOS == "linux" && os.Geteuid() != 0 {
-		return fmt.Errorf("dockerd needs to be started with root. To see how to run dockerd in rootless mode with unprivileged user, see the documentation")
+		return fmt.Errorf("dockerd needs to be started with root privileges. To run dockerd in rootless mode as an unprivileged user, see https://docs.docker.com/go/rootless/")
 	}
 
 	system.InitLCOW(cli.Config.Experimental)


### PR DESCRIPTION
Add the link to `dockerd needs to be started with root. To see how to run dockerd in rootless mode with unprivileged user, see the documentation` error  for ease of reference

Cherry-pick https://github.com/moby/moby/pull/42791 (clean)