### PR TITLE
[20.10 backport] update runc binary to v1.0.2

### DIFF
--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -4,7 +4,7 @@
 # The version of runc should match the version that is used by the containerd
 # version that is used. If you need to update runc, open a pull request in
 # the containerd project first, and update both after that is merged.
-: ${RUNC_COMMIT:=4144b63817ebcc5b358fc2c8ef95f7cddd709aa7} # v1.0.1
+: ${RUNC_COMMIT:=52b36a2dd837e8462de8e01458bf02cf9eea47dd} # v1.0.2
 
 install_runc() {
 	# If using RHEL7 kernels (3.10.0 el7), disable kmem accounting/limiting


### PR DESCRIPTION
https://github.com/opencontainers/runc/releases/tag/v1.0.2

---
Cherry-pick the first commit of https://github.com/moby/moby/pull/42764 (clean), but leaving vendor.conf as-is
