### PR TITLE
pkg/namesgenerator: replace uses of fmt.Sprintf()

### DIFF
--- a/pkg/namesgenerator/names-generator.go
+++ b/pkg/namesgenerator/names-generator.go
@@ -1,8 +1,8 @@
 package namesgenerator // import "github.com/docker/docker/pkg/namesgenerator"
 
 import (
-	"fmt"
 	"math/rand"
+	"strconv"
 )
 
 var (
@@ -840,13 +840,13 @@ var (
 // integer between 0 and 10 will be added to the end of the name, e.g `focused_turing3`
 func GetRandomName(retry int) string {
 begin:
-	name := fmt.Sprintf("%s_%s", left[rand.Intn(len(left))], right[rand.Intn(len(right))]) //nolint:gosec // G404: Use of weak random number generator (math/rand instead of crypto/rand)
+	name := left[rand.Intn(len(left))] + "_" + right[rand.Intn(len(right))] //nolint:gosec // G404: Use of weak random number generator (math/rand instead of crypto/rand)
 	if name == "boring_wozniak" /* Steve Wozniak is not boring */ {
 		goto begin
 	}
 
 	if retry > 0 {
-		name = fmt.Sprintf("%s%d", name, rand.Intn(10)) //nolint:gosec // G404: Use of weak random number generator (math/rand instead of crypto/rand)
+		name += strconv.Itoa(rand.Intn(10)) //nolint:gosec // G404: Use of weak random number generator (math/rand instead of crypto/rand)
 	}
 	return name
 }

--- a/pkg/namesgenerator/names-generator_test.go
+++ b/pkg/namesgenerator/names-generator_test.go
@@ -25,3 +25,12 @@ func TestNameRetries(t *testing.T) {
 	}
 
 }
+
+func BenchmarkGetRandomName(b *testing.B) {
+	b.ReportAllocs()
+	var out string
+	for n := 0; n < b.N; n++ {
+		out = GetRandomName(5)
+	}
+	b.Log("Last result:", out)
+}


### PR DESCRIPTION
had these changes from reviewing https://github.com/moby/moby/pull/42841, so might as well push them as a PR 🤷‍♂️ 

Looks like we don't need sprintf for how it's used. Replacing sprintf makes it more performant (~2.4x as fast), and less memory, allocations:

    BenchmarkGetRandomName-8      	 8203230	       142.4 ns/op	      37 B/op	       2 allocs/op
    BenchmarkGetRandomNameOld-8   	 3499509	       342.9 ns/op	      85 B/op	       5 allocs/op


**- A picture of a cute animal (not mandatory but encouraged)**

