### PR TITLE
Remove the deprecated '--kernel-memory' option

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -435,6 +435,12 @@ func (s *containerRouter) postContainerUpdate(ctx context.Context, w http.Respon
 	if versions.LessThan(httputils.VersionFromContext(ctx), "1.40") {
 		updateConfig.PidsLimit = nil
 	}
+
+	if versions.GreaterThanOrEqualTo(httputils.VersionFromContext(ctx), "1.42") {
+		// Ignore KernelMemory removed in API 1.42.
+		updateConfig.KernelMemory = 0
+	}
+
 	if updateConfig.PidsLimit != nil && *updateConfig.PidsLimit <= 0 {
 		// Both `0` and `-1` are accepted to set "unlimited" when updating.
 		// Historically, any negative value was accepted, so treat them as
@@ -499,6 +505,11 @@ func (s *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 		if hostConfig.CgroupnsMode.IsEmpty() {
 			hostConfig.CgroupnsMode = container.CgroupnsModeHost
 		}
+	}
+
+	if hostConfig != nil && versions.GreaterThanOrEqualTo(version, "1.42") {
+		// Ignore KernelMemory removed in API 1.42.
+		hostConfig.KernelMemory = 0
 	}
 
 	var platform *specs.Platform

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -529,17 +529,6 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/DeviceRequest"
-      KernelMemory:
-        description: |
-          Kernel memory limit in bytes.
-
-          <p><br /></p>
-
-          > **Deprecated**: This field is deprecated as the kernel 5.4 deprecated
-          > `kmem.limit_in_bytes`.
-        type: "integer"
-        format: "int64"
-        example: 209715200
       KernelMemoryTCP:
         description: "Hard limit for kernel TCP buffer memory (in bytes)."
         type: "integer"
@@ -6664,7 +6653,7 @@ paths:
               Memory: 314572800
               MemorySwap: 514288000
               MemoryReservation: 209715200
-              KernelMemory: 52428800
+              KernelMemory: 0
               RestartPolicy:
                 MaximumRetryCount: 4
                 Name: "on-failure"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4446,16 +4446,6 @@ definitions:
         description: "Indicates if the host has memory swap limit support enabled."
         type: "boolean"
         example: true
-      KernelMemory:
-        description: |
-          Indicates if the host has kernel memory limit support enabled.
-
-          <p><br /></p>
-
-          > **Deprecated**: This field is deprecated as the kernel 5.4 deprecated
-          > `kmem.limit_in_bytes`.
-        type: "boolean"
-        example: true
       CpuCfsPeriod:
         description: |
           Indicates if CPU CFS(Completely Fair Scheduler) period is supported by
@@ -5614,7 +5604,6 @@ paths:
                 Memory: 0
                 MemorySwap: 0
                 MemoryReservation: 0
-                KernelMemory: 0
                 NanoCpus: 500000
                 CpuPercent: 80
                 CpuShares: 512
@@ -5908,7 +5897,6 @@ paths:
                 Memory: 0
                 MemorySwap: 0
                 MemoryReservation: 0
-                KernelMemory: 0
                 OomKillDisable: false
                 OomScoreAdj: 500
                 NetworkMode: "bridge"
@@ -6653,7 +6641,6 @@ paths:
               Memory: 314572800
               MemorySwap: 514288000
               MemoryReservation: 209715200
-              KernelMemory: 0
               RestartPolicy:
                 MaximumRetryCount: 4
                 Name: "on-failure"

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -463,17 +463,16 @@ func verifyPlatformContainerResources(resources *containertypes.Resources, sysIn
 		// Kernel memory limit is not supported on cgroup v2.
 		// Even on cgroup v1, kernel memory limit (`kmem.limit_in_bytes`) has been deprecated since kernel 5.4.
 		// https://github.com/torvalds/linux/commit/0158115f702b0ba208ab0b5adf44cae99b3ebcc7
-		warnings = append(warnings, "Specifying a kernel memory limit is deprecated and will be removed in a future release.")
-	}
-	if resources.KernelMemory > 0 && !sysInfo.KernelMemory {
-		warnings = append(warnings, "Your kernel does not support kernel memory limit capabilities or the cgroup is not mounted. Limitation discarded.")
-		resources.KernelMemory = 0
-	}
-	if resources.KernelMemory > 0 && resources.KernelMemory < linuxMinMemory {
-		return warnings, fmt.Errorf("Minimum kernel memory limit allowed is 4MB")
-	}
-	if resources.KernelMemory > 0 && !kernel.CheckKernelVersion(4, 0, 0) {
-		warnings = append(warnings, "You specified a kernel memory limit on a kernel older than 4.0. Kernel memory limits are experimental on older kernels, it won't work as expected and can cause your system to be unstable.")
+		if !sysInfo.KernelMemory {
+			warnings = append(warnings, "Your kernel does not support kernel memory limit capabilities or the cgroup is not mounted. Limitation discarded.")
+			resources.KernelMemory = 0
+		}
+		if resources.KernelMemory < linuxMinMemory {
+			return warnings, fmt.Errorf("Minimum kernel memory limit allowed is 4MB")
+		}
+		if !kernel.CheckKernelVersion(4, 0, 0) {
+			warnings = append(warnings, "You specified a kernel memory limit on a kernel older than 4.0. Kernel memory limits are experimental on older kernels, it won't work as expected and can cause your system to be unstable.")
+		}
 	}
 	if resources.OomKillDisable != nil && !sysInfo.OomKillDisable {
 		// only produce warnings if the setting wasn't to *disable* the OOM Kill; no point

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -34,6 +34,9 @@ keywords: "API, Docker, rcli, REST, documentation"
   (`a disk usage operation is already running`) would be returned in this
   situation. This change is not versioned, and affects all API versions if the
   daemon has this patch.
+* Removed the `KernelMemory` field from the `POST /containers/create` and
+  `POST /containers/{id}/update` endpoints, any value it is set to will be ignored.
+  This field has been deprecated in `v1.41`.
 
 ## v1.41 API changes
 

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -109,10 +109,6 @@ func applyMemoryCgroupInfo(info *SysInfo) {
 	if !info.MemorySwappiness {
 		info.Warnings = append(info.Warnings, "Your kernel does not support memory swappiness")
 	}
-	info.KernelMemory = cgroupEnabled(mountPoint, "memory.kmem.limit_in_bytes")
-	if !info.KernelMemory {
-		info.Warnings = append(info.Warnings, "Your kernel does not support kernel memory limit")
-	}
 	info.KernelMemoryTCP = cgroupEnabled(mountPoint, "memory.kmem.tcp.limit_in_bytes")
 	if !info.KernelMemoryTCP {
 		info.Warnings = append(info.Warnings, "Your kernel does not support kernel memory TCP limit")


### PR DESCRIPTION
Ignore the kernel memory option if set in `HostConfig` on container create. 
We keep the option in the API ( for the `containers/create` and `/info` endpoints) until the next API version release but ignore any value it is set to.

```
root@80b7d3e03521:~# curl --unix-socket /var/run/docker.sock -H "Content-Type: application/json" -d '{"Image": "alpine", "Cmd": ["echo", "hello world"], "HostConfig": {"KernelMemory": 299900}}' -X POST http://localhost/v1.41/containers/create
{"Id":"4d8537d9cee548938492d489b7d8394b46ae75992d89875fbf2b33971762a552","Warnings":["Specifying a kernel memory limit is not supported anymore."]}
```
```
root@80b7d3e03521:~# docker inspect 4d8537d9cee5
[
    {
        "Id": "4d8537d9cee548938492d489b7d8394b46ae75992d89875fbf2b33971762a552",
....
            "KernelMemory": 0,
            "KernelMemoryTCP": 0,
            "MemoryReservation": 0,
....

```
```
root@80b7d3e03521:~# curl -s --unix-socket /var/run/docker.sock http://localhost/info | jq .| grep KernelMemory
  "KernelMemory": false,
  "KernelMemoryTCP": false,
```
