### PR TITLE
[do not merge] testing Jenkins after GitHub API changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@ pipeline {
         timestamps()
     }
     parameters {
+        // TESTING one two three
         booleanParam(name: 'unit_validate', defaultValue: true, description: 'amd64 (x86_64) unit tests and vendor check')
         booleanParam(name: 'validate_force', defaultValue: false, description: 'force validation steps to be run, even if no changes were detected')
         booleanParam(name: 'amd64', defaultValue: true, description: 'amd64 (x86_64) Build/Test')


### PR DESCRIPTION
We noticed Jenkins was broken on various repositories, due to a change deployed
by GitHub; https://github.community/t/github-api-collaborators-access-changed-today/201259

> You all caught this well before I could! We did push a recent update (4 hours
> ago, as of this writing) that now requires admin access via the API to see
> collaborators. This change brings our API in-line with the Web based experience,
> and should be more consistent. There’s quite an extensive reasoning behind this
> and if it’s necessary I can elevate those details. So yes, this was a deliberate
> action. For now, I don’t believe there is another permissions level outside of
> admin to perform this action. Alternatively, it is true that GitHub Integrations
> have the ability to list collaborators, but we will likely be reviewing that in
> the future.
>
> Edit: our team is currently in discussion about the impact this might have, and
> whether or not a reversion is warranted. Will update when there’s more to share.


