### PR TITLE
Port pkg/system/mknod.go to FreeBSD

### DIFF
--- a/pkg/system/mknod.go
+++ b/pkg/system/mknod.go
@@ -7,12 +7,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// Mknod creates a filesystem node (file, device special file or named pipe) named path
-// with attributes specified by mode and dev.
-func Mknod(path string, mode uint32, dev int) error {
-	return unix.Mknod(path, mode, dev)
-}
-
 // Mkdev is used to build the value of linux devices (in /dev/) which specifies major
 // and minor number of the newly created device special file.
 // Linux device nodes are a bit weird due to backwards compat with 16 bit device nodes.

--- a/pkg/system/mknod_freebsd.go
+++ b/pkg/system/mknod_freebsd.go
@@ -1,0 +1,14 @@
+//go:build freebsd
+// +build freebsd
+
+package system // import "github.com/docker/docker/pkg/system"
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// Mknod creates a filesystem node (file, device special file or named pipe) named path
+// with attributes specified by mode and dev.
+func Mknod(path string, mode uint32, dev int) error {
+	return unix.Mknod(path, mode, uint64(dev))
+}

--- a/pkg/system/mknod_linux.go
+++ b/pkg/system/mknod_linux.go
@@ -1,0 +1,11 @@
+package system // import "github.com/docker/docker/pkg/system"
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// Mknod creates a filesystem node (file, device special file or named pipe) named path
+// with attributes specified by mode and dev.
+func Mknod(path string, mode uint32, dev int) error {
+	return unix.Mknod(path, mode, dev)
+}


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/42849

Because FreeBSD uses 64-bit device nodes (see
https://reviews.freebsd.org/rS318736), Linux implementation of
`system.Mknod` & `system.Mkdev` is not sufficient.

This change adds freebsd-specific implementations for `Mknod` and
`Mkdev`.


