### PR TITLE
quota: Make package compile when `cgo` is disabled

### DIFF
--- a/quota/projectquota_unsupported.go
+++ b/quota/projectquota_unsupported.go
@@ -17,3 +17,7 @@ func (q *Control) SetQuota(targetPath string, quota Quota) error {
 func (q *Control) GetQuota(targetPath string, quota *Quota) error {
 	return ErrQuotaNotSupported
 }
+
+func makeBackingFsDev(home string) (string, error) {
+	return "", ErrQuotaNotSupported
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Writing a plugin that imports the `overlay2` package.

**- How I did it**
Simply import the `overlay2` (or transitive `quota`) package on non-Linux or Linux without CGo.

**- How to verify it**
You will you get this error:
```
# github.com/docker/docker/quota
../.go_workspace/pkg/mod/github.com/docker/docker@v20.10.8+incompatible/quota/testhelpers.go:100:24: undefined: makeBackingFsDev
```

Backporting this to the `20.10.x` series would be very much appreciated, as we can't compile our plug-in any more without unpleasant hacks at the moment.

**- Description for the changelog**
Add missing `makeBackingFsDev` to "unsupported" functions in `quota` package.

