### PR TITLE
42865 - Improve OomKillDisable error on cgroup2

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -479,7 +479,11 @@ func verifyPlatformContainerResources(resources *containertypes.Resources, sysIn
 		// only produce warnings if the setting wasn't to *disable* the OOM Kill; no point
 		// warning the caller if they already wanted the feature to be off
 		if *resources.OomKillDisable {
-			warnings = append(warnings, "Your kernel does not support OomKillDisable. OomKillDisable discarded.")
+			if cgroups.Mode() == cgroups.Unified {
+				warnings = append(warnings, "You are using cgroups v2 which does not support OomKillDisable. OomKillDisable discarded.")
+			} else {
+				warnings = append(warnings, "Your kernel does not support OomKillDisable. OomKillDisable discarded.")
+			}
 		}
 		resources.OomKillDisable = nil
 	}

--- a/daemon/daemon_unix_test.go
+++ b/daemon/daemon_unix_test.go
@@ -319,6 +319,7 @@ func TestVerifyPlatformContainerResources(t *testing.T) {
 			},
 			sysInfo: sysInfo(t, withMemoryLimit),
 			expectedWarnings: []string{
+				"You are using cgroups v2 which does not support OomKillDisable. OomKillDisable discarded.",
 				"Your kernel does not support OomKillDisable. OomKillDisable discarded.",
 			},
 		},


### PR DESCRIPTION
Signed-off-by: Grant Millar <rid@cylo.io>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added a different error when cgroups v2 is in use vs. when the kernel does not support OOM kill disabled.

**- How I did it**
Added an extra check.

**- How to verify it**
Run dockerd on a machine with cgroups v2 enabled and use --oom-kill-disable when running a container.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Improve OomKillDisable error on cgroup2

**- A picture of a cute animal (not mandatory but encouraged)**
🐨
