### PR TITLE
daemon: fix TestVerifyPlatformContainerResources not capturing variable

### DIFF
--- a/daemon/daemon_unix_test.go
+++ b/daemon/daemon_unix_test.go
@@ -356,6 +356,7 @@ func TestVerifyPlatformContainerResources(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			warnings, err := verifyPlatformContainerResources(&tc.resources, &tc.sysInfo, tc.update)


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/42870/files#r713827750

looks like I introduced this in https://github.com/moby/moby/pull/38393 😞 😅 😓 

This test runs with t.Parallel() _and_ uses subtests, but didn't capture the `tc` variable, which potentialy (likely) makes it test the same testcase multiple times.

**- A picture of a cute animal (not mandatory but encouraged)**

