### PR TITLE
[20.10] Bump swarmkit to get fix for rollback

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -142,7 +142,7 @@ github.com/gogo/googleapis                          01e0f9cca9b92166042241267ee2
 github.com/cilium/ebpf                              1c8d4c9ef7759622653a1d319284a44652333b28
 
 # cluster
-github.com/docker/swarmkit                          c9afb5fd44bb419bae719f400f31671712bcb99e # bump_20.10
+github.com/docker/swarmkit                          286f4575a2d2853c1574e1be10eb1a2450692dfc # bump_20.10
 github.com/gogo/protobuf                            5628607bb4c51c3157aacc3a50f0ab707582b805 # v1.3.1
 github.com/golang/protobuf                          84668698ea25b64748563aa20726db66a6b8d299 # v1.3.5
 github.com/cloudflare/cfssl                         5d63dbd981b5c408effbb58c442d54761ff94fbd # 1.3.2

--- a/vendor/github.com/docker/swarmkit/manager/orchestrator/update/updater.go
+++ b/vendor/github.com/docker/swarmkit/manager/orchestrator/update/updater.go
@@ -280,6 +280,11 @@ slotsLoop:
 	wg.Wait()
 
 	if !stopped {
+		// if a delay is set we need to monitor for a period longer than the delay
+		// otherwise we will leave the monitorLoop before the task is done delaying
+		if updateConfig.Delay >= monitoringPeriod {
+			monitoringPeriod = updateConfig.Delay + 1*time.Second
+		}
 		// Keep watching for task failures for one more monitoringPeriod,
 		// before declaring the update complete.
 		doneMonitoring := time.After(monitoringPeriod)


### PR DESCRIPTION
Signed-off-by: Adam Williams <awilliams@mirantis.com>
**- What I did**
Update Swarmkit version to get fix for rollback issue [3003](https://github.com/docker/swarmkit/pull/3003)/ [3014](https://github.com/docker/swarmkit/pull/3014)

_When the updateConfig delay parameter is larger than the monitor parameter an error in updating can be missed and rollback not performed. This fix will check for the case where monitor < delay and use the larger of the two._
**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

