### PR TITLE
Dockerfile: update test-registry to v2.8.1 (latest release)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ WORKDIR /go/src/github.com/docker/distribution
 # from the https://github.com/docker/distribution repository. This version of
 # the registry is used to test both schema 1 and schema 2 manifests. Generally,
 # the version specified here should match a current release.
-ARG REGISTRY_VERSION=v2.3.0
+ARG REGISTRY_VERSION=v2.8.1
 
 # REGISTRY_VERSION_SCHEMA1 specifies the version of the registry to build and
 # install from the https://github.com/docker/distribution repository. This is


### PR DESCRIPTION

follow-up to https://github.com/moby/moby/pull/42881. Updating the version of the registry caused tests to fail, so moving it to a separate PR to dive into what's causing those failures (and if there's possibly an actual issue; either a bug or an issue in how we use the registry for testing)


**- A picture of a cute animal (not mandatory but encouraged)**

