### PR TITLE
Add partial message metadata to json-file log driver (closes #36777)

### DIFF
--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -135,12 +135,24 @@ func marshalMessage(msg *logger.Message, extra json.RawMessage, buf *bytes.Buffe
 	if msg.PLogMetaData == nil || (msg.PLogMetaData != nil && msg.PLogMetaData.Last) {
 		logLine = append(msg.Line, '\n')
 	}
-	err := (&jsonlog.JSONLogs{
-		Log:      logLine,
-		Stream:   msg.Source,
-		Created:  msg.Timestamp,
-		RawAttrs: extra,
-	}).MarshalJSONBuf(buf)
+	var err error
+	if msg.PLogMetaData != nil {
+		err = (&jsonlog.JSONLogs{
+			Log:      logLine,
+			Stream:   msg.Source,
+			Created:  msg.Timestamp,
+			RawAttrs: extra,
+			PartialMessage: "true",
+		}).MarshalJSONBuf(buf)
+	} else {
+		err = (&jsonlog.JSONLogs{
+			Log:      logLine,
+			Stream:   msg.Source,
+			Created:  msg.Timestamp,
+			RawAttrs: extra,
+		}).MarshalJSONBuf(buf)
+
+	}
 	if err != nil {
 		return errors.Wrap(err, "error writing log message to buffer")
 	}

--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -135,24 +135,27 @@ func marshalMessage(msg *logger.Message, extra json.RawMessage, buf *bytes.Buffe
 	if msg.PLogMetaData == nil || (msg.PLogMetaData != nil && msg.PLogMetaData.Last) {
 		logLine = append(msg.Line, '\n')
 	}
-	var err error
+	var jl *jsonlog.JSONLogs
 	if msg.PLogMetaData != nil {
-		err = (&jsonlog.JSONLogs{
+		jl = &jsonlog.JSONLogs{
 			Log:      logLine,
 			Stream:   msg.Source,
 			Created:  msg.Timestamp,
 			RawAttrs: extra,
 			PartialMessage: "true",
-		}).MarshalJSONBuf(buf)
+			PartialId: msg.PLogMetaData.ID,
+			PartialOrdinal: msg.PLogMetaData.Ordinal,
+			PartialLast: msg.PLogMetaData.Last,
+		}
 	} else {
-		err = (&jsonlog.JSONLogs{
+		jl = &jsonlog.JSONLogs{
 			Log:      logLine,
 			Stream:   msg.Source,
 			Created:  msg.Timestamp,
 			RawAttrs: extra,
-		}).MarshalJSONBuf(buf)
-
+		}
 	}
+	err := jl.MarshalJSONBuf(buf)
 	if err != nil {
 		return errors.Wrap(err, "error writing log message to buffer")
 	}

--- a/daemon/logger/jsonfilelog/jsonfilelog_test.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog_test.go
@@ -373,8 +373,8 @@ func TestPartialLogs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := `{"log":"1234","stream":"stdout","time":"0001-01-01T00:00:00Z"}
-{"log":"5678\n","stream":"stdout","time":"0001-01-01T00:00:00Z"}
+	expected := `{"log":"1234","stream":"stdout","time":"0001-01-01T00:00:00Z","partial_message":"true"}
+{"log":"5678\n","stream":"stdout","time":"0001-01-01T00:00:00Z","partial_message":"true"}
 `
 	if string(res) != expected {
 		t.Fatalf("Wrong log content: %q, expected %q", res, expected)

--- a/daemon/logger/jsonfilelog/jsonfilelog_test.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog_test.go
@@ -340,9 +340,11 @@ func TestPartialLogs(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
+	partialMessageId := "message_id";
+
 	partialMD1 := &backend.PartialLogMetaData{
 		Last: false,
-		ID: "asdf",
+		ID: partialMessageId,
 		Ordinal: 0,
 	}
 	msg1 := &logger.Message{
@@ -356,7 +358,7 @@ func TestPartialLogs(t *testing.T) {
 
 	partialMD2 := &backend.PartialLogMetaData{
 		Last: true,
-		ID: "asdf",
+		ID: partialMessageId,
 		Ordinal: 1,
 	}
 	msg2 := &logger.Message{
@@ -373,8 +375,8 @@ func TestPartialLogs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := `{"log":"1234","stream":"stdout","time":"0001-01-01T00:00:00Z","partial_message":"true"}
-{"log":"5678\n","stream":"stdout","time":"0001-01-01T00:00:00Z","partial_message":"true"}
+	expected := `{"log":"1234","stream":"stdout","time":"0001-01-01T00:00:00Z","partial_message":"true","partial_id":"message_id","partial_ordinal":0,"partial_last":"false"}
+{"log":"5678\n","stream":"stdout","time":"0001-01-01T00:00:00Z","partial_message":"true","partial_id":"message_id","partial_ordinal":1,"partial_last":"true"}
 `
 	if string(res) != expected {
 		t.Fatalf("Wrong log content: %q, expected %q", res, expected)

--- a/daemon/logger/jsonfilelog/jsonlog/jsonlogbytes.go
+++ b/daemon/logger/jsonfilelog/jsonlog/jsonlogbytes.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"time"
 	"unicode/utf8"
+	"strconv"
 )
 
 // JSONLogs marshals encoded JSONLog objects
@@ -12,7 +13,11 @@ type JSONLogs struct {
 	Log     []byte    `json:"log,omitempty"`
 	Stream  string    `json:"stream,omitempty"`
 	Created time.Time `json:"time"`
+
 	PartialMessage string `json:"partial_message,omitempty"`
+	PartialId string      `json:"partial_id,omitempty"`
+	PartialOrdinal int    `json:"partial_ordinal,omitempty"`
+	PartialLast bool      `json:"partial_last,omitempty"`
 
 	// json-encoded bytes
 	RawAttrs json.RawMessage `json:"attrs,omitempty"`
@@ -59,10 +64,15 @@ func (mj *JSONLogs) MarshalJSONBuf(buf *bytes.Buffer) error {
 	buf.WriteString(`"time":`)
 	buf.WriteString(created)
 	if len(mj.PartialMessage) != 0 {
-		buf.WriteString(`,`)
 		// Is partial message
-		buf.WriteString(`"partial_message":`)
+		buf.WriteString(`,"partial_message":`)
 		ffjsonWriteJSONBytesAsString(buf, []byte(mj.PartialMessage))
+		buf.WriteString(`,"partial_id":`)
+		ffjsonWriteJSONBytesAsString(buf, []byte(mj.PartialId))
+		buf.WriteString(`,"partial_ordinal":`)
+		buf.WriteString(strconv.Itoa(mj.PartialOrdinal))
+		buf.WriteString(`,"partial_last":`)
+		ffjsonWriteJSONBytesAsString(buf, []byte(strconv.FormatBool(mj.PartialLast)))
 	}
 
 	buf.WriteString(`}`)

--- a/daemon/logger/jsonfilelog/jsonlog/jsonlogbytes.go
+++ b/daemon/logger/jsonfilelog/jsonlog/jsonlogbytes.go
@@ -12,6 +12,7 @@ type JSONLogs struct {
 	Log     []byte    `json:"log,omitempty"`
 	Stream  string    `json:"stream,omitempty"`
 	Created time.Time `json:"time"`
+	PartialMessage string `json:"partial_message,omitempty"`
 
 	// json-encoded bytes
 	RawAttrs json.RawMessage `json:"attrs,omitempty"`
@@ -57,6 +58,13 @@ func (mj *JSONLogs) MarshalJSONBuf(buf *bytes.Buffer) error {
 
 	buf.WriteString(`"time":`)
 	buf.WriteString(created)
+	if len(mj.PartialMessage) != 0 {
+		buf.WriteString(`,`)
+		// Is partial message
+		buf.WriteString(`"partial_message":`)
+		ffjsonWriteJSONBytesAsString(buf, []byte(mj.PartialMessage))
+	}
+
 	buf.WriteString(`}`)
 	return nil
 }


### PR DESCRIPTION

closes #36777
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Include partial message metadata in the json-file log driver logs
**- How I did it**
When we receive a non-nil value for `msg.PLogMetaData`, we add the partial message metadata into the `JSONLogs` object. This information is then serialized when marshalling this log into json format. I have more or less followed the structure that is used in the fluentd logger.
**- How to verify it**
I have added tests that verify that this info is correctly added when marshalling the log into json format.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Implement partial message metadata in json-file log driver 

**- A picture of a cute animal (not mandatory but encouraged)**

