### PR TITLE
[20.10] update containerd binary to v1.4.11

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=e25210fe30a0a703442421b0f60afac609f950a3}" # v1.4.9
+: "${CONTAINERD_COMMIT:=8848fdb7c4ae3815afcc990a8a99d663dda1b590}" # v1.4.10
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=8848fdb7c4ae3815afcc990a8a99d663dda1b590}" # v1.4.10
+: "${CONTAINERD_COMMIT:=5b46e404f6b9f661a205e28d59c982d3634148f8}" # v1.4.11
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
- Update runc to v1.0.2
- Update hcsshim to v0.8.21
- Support "clone3" in default seccomp profile
- Fix panic in metadata content writer on copy error

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

