### PR TITLE
Update containerd binary to v1.5.7

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -166,7 +166,7 @@ FROM microsoft/windowsservercore
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG GO_VERSION=1.17.2
-ARG CONTAINERD_VERSION=1.5.5
+ARG CONTAINERD_VERSION=1.5.6
 ARG GOTESTSUM_VERSION=v1.7.0
 
 # Environment variable notes:

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -166,7 +166,7 @@ FROM microsoft/windowsservercore
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG GO_VERSION=1.17.2
-ARG CONTAINERD_VERSION=1.5.6
+ARG CONTAINERD_VERSION=1.5.7
 ARG GOTESTSUM_VERSION=v1.7.0
 
 # Environment variable notes:

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.5.5}"
+: "${CONTAINERD_VERSION:=v1.5.6}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.5.6}"
+: "${CONTAINERD_VERSION:=v1.5.7}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"


### PR DESCRIPTION
### Update containerd binary to v1.5.7

The seventh patch release for containerd 1.5 is a security release to fix CVE-2021-41103.

Notable Updates:

- Fix insufficiently restricted permissions on container root and plugin directories
  GHSA-c2h3-6mxw-7mvq

### Update containerd binary to v1.5.6

- Install apparmor parser for arm64 and update seccomp to 2.5.1
- Update runc binary to 1.0.2
- Update hcsshim to v0.8.21 to fix layer issue on Windows Server 2019
- Add support for 'clone3' syscall to fix issue with certain images when seccomp is enabled
- Add image config labels in CRI container creation
- Fix panic in metadata content writer on copy error

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

