### PR TITLE
Port testutil/daemon to FreeBSD

### DIFF
--- a/testutil/daemon/daemon_freebsd.go
+++ b/testutil/daemon/daemon_freebsd.go
@@ -1,0 +1,18 @@
+//go:build freebsd
+// +build freebsd
+
+package daemon // import "github.com/docker/docker/testutil/daemon"
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func cleanupNetworkNamespace(_ testing.TB, _ *Daemon) {}
+
+// CgroupNamespace returns the cgroup namespace the daemon is running in
+func (d *Daemon) CgroupNamespace(t testing.TB) string {
+	assert.Assert(t, false, "cgroup namespaces are not supported on FreeBSD")
+	return ""
+}

--- a/testutil/daemon/daemon_linux.go
+++ b/testutil/daemon/daemon_linux.go
@@ -1,0 +1,37 @@
+package daemon // import "github.com/docker/docker/testutil/daemon"
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+	"gotest.tools/v3/assert"
+)
+
+func cleanupNetworkNamespace(t testing.TB, d *Daemon) {
+	t.Helper()
+	// Cleanup network namespaces in the exec root of this
+	// daemon because this exec root is specific to this
+	// daemon instance and has no chance of getting
+	// cleaned up when a new daemon is instantiated with a
+	// new exec root.
+	netnsPath := filepath.Join(d.execRoot, "netns")
+	filepath.Walk(netnsPath, func(path string, info os.FileInfo, err error) error {
+		if err := unix.Unmount(path, unix.MNT_DETACH); err != nil && err != unix.EINVAL && err != unix.ENOENT {
+			t.Logf("[%s] unmount of %s failed: %v", d.id, path, err)
+		}
+		os.Remove(path)
+		return nil
+	})
+}
+
+// CgroupNamespace returns the cgroup namespace the daemon is running in
+func (d *Daemon) CgroupNamespace(t testing.TB) string {
+	link, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/cgroup", d.Pid()))
+	assert.NilError(t, err)
+
+	return strings.TrimSpace(link)
+}

--- a/testutil/daemon/daemon_unix.go
+++ b/testutil/daemon/daemon_unix.go
@@ -4,17 +4,12 @@
 package daemon // import "github.com/docker/docker/testutil/daemon"
 
 import (
-	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
-	"strings"
 	"syscall"
 	"testing"
 
 	"github.com/moby/sys/mount"
 	"golang.org/x/sys/unix"
-	"gotest.tools/v3/assert"
 )
 
 // cleanupMount unmounts the daemon root directory, or logs a message if
@@ -24,31 +19,6 @@ func cleanupMount(t testing.TB, d *Daemon) {
 	if err := mount.Unmount(d.Root); err != nil {
 		d.log.Logf("[%s] unable to unmount daemon root (%s): %v", d.id, d.Root, err)
 	}
-}
-
-func cleanupNetworkNamespace(t testing.TB, d *Daemon) {
-	t.Helper()
-	// Cleanup network namespaces in the exec root of this
-	// daemon because this exec root is specific to this
-	// daemon instance and has no chance of getting
-	// cleaned up when a new daemon is instantiated with a
-	// new exec root.
-	netnsPath := filepath.Join(d.execRoot, "netns")
-	filepath.Walk(netnsPath, func(path string, info os.FileInfo, err error) error {
-		if err := unix.Unmount(path, unix.MNT_DETACH); err != nil && err != unix.EINVAL && err != unix.ENOENT {
-			t.Logf("[%s] unmount of %s failed: %v", d.id, path, err)
-		}
-		os.Remove(path)
-		return nil
-	})
-}
-
-// CgroupNamespace returns the cgroup namespace the daemon is running in
-func (d *Daemon) CgroupNamespace(t testing.TB) string {
-	link, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/cgroup", d.Pid()))
-	assert.NilError(t, err)
-
-	return strings.TrimSpace(link)
 }
 
 // SignalDaemonDump sends a signal to the daemon to write a dump file


### PR DESCRIPTION
testutil/daemon uses a generic unix implementation that assumes that
the host OS supports cgroups & network namespaces, which is not the
case for FreeBSD.

This change adds a FreeBSD-specific implementation for
`testutil/daemon`, namely for `cleanupNetworkNamespace` and
`CgroupNamespace` functions.

Signed-off-by: Artem Khramov <akhramov@pm.me>

