### PR TITLE
registry: remove unused registry.ErrAlreadyExists

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -3,7 +3,6 @@ package registry // import "github.com/docker/docker/registry"
 
 import (
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -15,12 +14,6 @@ import (
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/sirupsen/logrus"
-)
-
-var (
-	// ErrAlreadyExists is an error returned if an image being pushed
-	// already exists on the remote side
-	ErrAlreadyExists = errors.New("Image already exists")
 )
 
 // HostCertsDir returns the config directory for a specific host


### PR DESCRIPTION
This error was no longer in use after the v1 push code was removed in 53dad9f0274fcc1ec742f9411142382c83d08ff9 (https://github.com/moby/moby/pull/39365)

**- A picture of a cute animal (not mandatory but encouraged)**

