### PR TITLE
fix: don't attempt to set unavailable capabilities in privileged mode

### DIFF
--- a/oci/caps/utils.go
+++ b/oci/caps/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/containerd/containerd/pkg/cap"
 	"github.com/docker/docker/errdefs"
 	"github.com/syndtr/gocapability/capability"
 )
@@ -21,18 +22,14 @@ var (
 )
 
 func init() {
-	last := capability.CAP_LAST_CAP
-	rawCaps := capability.List()
-	allCaps = make([]string, min(int(last+1), len(rawCaps)))
-	capabilityList = make(map[string]*capability.Cap, len(rawCaps))
+	allCaps, _ = cap.Current()
+	rawCaps := cap.Known()
+	capabilityList := make(map[string]*capability.Cap, len(rawCaps))
+
 	for i, c := range rawCaps {
-		capName := "CAP_" + strings.ToUpper(c.String())
-		if c > last {
-			capabilityList[capName] = nil
-			continue
-		}
-		allCaps[i] = capName
-		capabilityList[capName] = &c
+		cc := capability.Cap(i)
+
+		capabilityList[c] = &cc
 	}
 }
 


### PR DESCRIPTION
fixes #42906

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

**- What I did**

Filtering capabilities via the `dockerd` process capabilities.

**- How I did it**

**- How to verify it**

There should be no changes if `dockerd` runs with full caps.

But if the `dockerd` capabilities are reduced, `docker run --privileged <anything>` fails with `apply caps: not permitted`.

**- Description for the changelog**

Set only available capabilities when container runs in --privileged mode.


**- A picture of a cute animal (not mandatory but encouraged)**

