### PR TITLE
Closing reader for container logs

### DIFF
--- a/client/container_logs.go
+++ b/client/container_logs.go
@@ -73,6 +73,7 @@ func (cli *Client) ContainerLogs(ctx context.Context, container string, options 
 	query.Set("tail", options.Tail)
 
 	resp, err := cli.get(ctx, "/containers/"+container+"/logs", query, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return nil, wrapResponseError(err, resp, "container", container)
 	}


### PR DESCRIPTION
Reading container logs can cause `Too many open files`. This defers a call to `ensureReaderClosed` to ensure that it is closed.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

