### PR TITLE
libnetwork: ServeDNS(): don't panic on unsupported query types

### DIFF
--- a/libnetwork/resolver.go
+++ b/libnetwork/resolver.go
@@ -384,7 +384,8 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 	case dns.TypeSRV:
 		resp, err = r.handleSRVQuery(name, query)
 	default:
-		panic("error")
+		queryType := dns.TypeToString[query.Question[0].Qtype]
+		logrus.Debugf("[resolver] query type %s is not supported by the embedded DNS and will be forwarded to external DNS", queryType)
 	}
 
 	if err != nil {


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/42929

This was added in b3c883bb2f560fc935315102983092438f76be25 (https://github.com/moby/moby/pull/42262), but resulted in a panic if the embedded DNS had to handle an unsupported query-type, such as ANY.

This patch adds a debug log for this case (to better describe how it's handled.


**- A picture of a cute animal (not mandatory but encouraged)**

