### PR TITLE
Fix file capabilites droping in Dockerfile

### DIFF
--- a/daemon/graphdriver/copy/copy.go
+++ b/daemon/graphdriver/copy/copy.go
@@ -110,11 +110,13 @@ type dirMtimeInfo struct {
 	stat    *syscall.Stat_t
 }
 
-// DirCopy copies or hardlinks the contents of one directory to another,
-// properly handling xattrs, and soft links
+// DirCopy copies or hardlinks the contents of one directory to another, properly
+// handling soft links, "security.capability" and (optionally) "trusted.overlay.opaque"
+// xattrs.
 //
-// Copying xattrs can be opted out of by passing false for copyXattrs.
-func DirCopy(srcDir, dstDir string, copyMode Mode, copyXattrs bool) error {
+// The copyOpaqueXattrs controls if "trusted.overlay.opaque" xattrs are copied.
+// Passing false disables copying "trusted.overlay.opaque" xattrs.
+func DirCopy(srcDir, dstDir string, copyMode Mode, copyOpaqueXattrs bool) error {
 	copyWithFileRange := true
 	copyWithFileClone := true
 
@@ -207,7 +209,11 @@ func DirCopy(srcDir, dstDir string, copyMode Mode, copyXattrs bool) error {
 			return err
 		}
 
-		if copyXattrs {
+		if err := copyXattr(srcPath, dstPath, "security.capability"); err != nil {
+			return err
+		}
+
+		if copyOpaqueXattrs {
 			if err := doCopyXattrs(srcPath, dstPath); err != nil {
 				return err
 			}
@@ -256,10 +262,6 @@ func DirCopy(srcDir, dstDir string, copyMode Mode, copyXattrs bool) error {
 }
 
 func doCopyXattrs(srcPath, dstPath string) error {
-	if err := copyXattr(srcPath, dstPath, "security.capability"); err != nil {
-		return err
-	}
-
 	// We need to copy this attribute if it appears in an overlay upper layer, as
 	// this function is used to copy those. It is set by overlay if a directory
 	// is removed and then re-created and should not inherit anything from the


### PR DESCRIPTION
fixes #42655 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
moved copyXattr function out of doCopyXattrs function, so that security capabilities are copied
**- How I did it**
doCopyXattrs() never reached due to copyXattrs boolean being false, as a result file capabilities not being copied.

**- How to verify it**

***Test Case***

```dockerfile
FROM registry1-docker-io.repo.lab.pl.alcatel-lucent.com/library/alpine:latest
RUN apk --no-cache add libcap && setcap cap_net_admin=eip /sbin/apk
RUN setcap -v cap_net_admin=eip /sbin/apk
```

***Test Result***
```
Sending build context to Docker daemon  2.048kB
Step 1/3 : FROM registry1-docker-io.repo.lab.pl.alcatel-lucent.com/library/alpine:latest
latest: Pulling from library/alpine
a0d0a0d46f8b: Pull complete
Digest: sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a
Status: Downloaded newer image for registry1-docker-io.repo.lab.pl.alcatel-lucent.com/library/alpine:latest
 ---> 14119a10abf4
Step 2/3 : RUN apk --no-cache add libcap && setcap cap_net_admin=eip /sbin/apk
 ---> Running in 923b46395907
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
(1/1) Installing libcap (2.50-r0)
Executing busybox-1.33.1-r3.trigger
OK: 6 MiB in 15 packages
Removing intermediate container 923b46395907
 ---> 97d6ec51d4b3
Step 3/3 : RUN setcap -v cap_net_admin=eip /sbin/apk
 ---> Running in 33260d42c77d
/sbin/apk: OK
Removing intermediate container 33260d42c77d
 ---> 5fc3c8660150
Successfully built 5fc3c8660150
Successfully tagged test:cap
```

**- Description for the changelog**
Fixed issue of file capabilities dropping when moving to next command in Dockerfile  during image building.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
