### PR TITLE
Dockerfile: CRIU: disable GPG validation, due to expired signing key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ ARG DEBIAN_FRONTEND
 ADD --chmod=0644 https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_10/Release.key /etc/apt/trusted.gpg.d/criu.gpg.asc
 RUN --mount=type=cache,sharing=locked,id=moby-criu-aptlib,target=/var/lib/apt \
     --mount=type=cache,sharing=locked,id=moby-criu-aptcache,target=/var/cache/apt \
-        echo 'deb https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_10/ /' > /etc/apt/sources.list.d/criu.list \
+# FIXME(sebastiaan) temporariliy disable GPG validation for these packages, as the release key has expired (https://github.com/moby/moby/pull/42931#issuecomment-943080120)
+        echo 'deb [ allow-insecure=yes trusted=yes ] https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_10/ /' > /etc/apt/sources.list.d/criu.list \
         && apt-get update \
         && apt-get install -y --no-install-recommends criu \
         && install -D /usr/sbin/criu /build/criu


### PR DESCRIPTION
This is a horrible thing to do, but CRIU installed here is only used as
part of our CI / integration tests. We should of course remove this
hack ASAP once the opensuse packagers have set up a new key, but at
least this allows us to unblock CI, which is currently completely
broken:

    ADD --chmod=0644 https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_10/Release.key /etc/apt/trusted.gpg.d/criu.gpg.asc
    RUN --mount=type=cache,sharing=locked,id=moby-criu-aptlib,target=/var/lib/apt \
        --mount=type=cache,sharing=locked,id=moby-criu-aptcache,target=/var/cache/apt \
             echo 'deb https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_10/ /' > /etc/apt/sources.list.d/criu.list \
             && apt-get update \
             && apt-get install -y --no-install-recommends criu \
             && install -D /usr/sbin/criu /build/criu

    Hit:1 http://cdn-fastly.deb.debian.org/debian bullseye InRelease
    Hit:2 http://cdn-fastly.deb.debian.org/debian-security bullseye-security InRelease
    Hit:3 http://cdn-fastly.deb.debian.org/debian bullseye-updates InRelease
    Get:4 https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_10  InRelease [1540 B]
    Err:4 https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_10  InRelease
      The following signatures were invalid: EXPKEYSIG 30A8343A498D5A23 devel:tools OBS Project <devel:tools@build.opensuse.org>
    Reading package lists...
    W: GPG error: https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_10  InRelease: The following signatures were invalid: EXPKEYSIG 30A8343A498D5A23 devel:tools OBS Project <devel:tools@build.opensuse.org>
    E: The repository 'https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_10  InRelease' is not signed.

And, checking the signing key (with `apt-key list`):

    /etc/apt/trusted.gpg.d/criu.gpg.asc
    -----------------------------------
    pub   rsa2048 2015-05-03 [SC] [expired: 2021-10-13]
          428E 4E34 8405 CE79 00DB  99C2 30A8 343A 498D 5A23
    uid           [ expired] devel:tools OBS Project <devel:tools@build.opensuse.org>

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

