### PR TITLE
revert Dockerfile: CRIU: disable GPG validation, due to expired signing key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,7 @@ ARG DEBIAN_FRONTEND
 ADD --chmod=0644 https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_10/Release.key /etc/apt/trusted.gpg.d/criu.gpg.asc
 RUN --mount=type=cache,sharing=locked,id=moby-criu-aptlib,target=/var/lib/apt \
     --mount=type=cache,sharing=locked,id=moby-criu-aptcache,target=/var/cache/apt \
-# FIXME(sebastiaan) temporariliy disable GPG validation for these packages, as the release key has expired (https://github.com/moby/moby/pull/42931#issuecomment-943080120)
-        echo 'deb [ allow-insecure=yes trusted=yes ] https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_10/ /' > /etc/apt/sources.list.d/criu.list \
+        echo 'deb https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_10/ /' > /etc/apt/sources.list.d/criu.list \
         && apt-get update \
         && apt-get install -y --no-install-recommends criu \
         && install -D /usr/sbin/criu /build/criu


### PR DESCRIPTION
this reverts the temporary workaround from https://github.com/moby/moby/pull/42935