### PR TITLE
Add container info log when create/start/stop a container successful

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -99,6 +99,7 @@ func (daemon *Daemon) containerCreate(opts createOpts) (containertypes.Container
 		return containertypes.ContainerCreateCreatedBody{Warnings: warnings}, err
 	}
 	containerActions.WithValues("create").UpdateSince(start)
+	logrus.Infof("Container create done with name: %s and id: %s", ctr.Name, ctr.ID)
 
 	if warnings == nil {
 		warnings = make([]string, 0) // Create an empty slice to avoid https://github.com/moby/moby/issues/38222

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -219,6 +219,7 @@ func (daemon *Daemon) containerStart(container *container.Container, checkpoint 
 
 	daemon.LogContainerEvent(container, "start")
 	containerActions.WithValues("start").UpdateSince(start)
+	logrus.Infof("Container start done with name: %s and id: %s", container.Name, container.ID)
 
 	return nil
 }

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -33,6 +33,7 @@ func (daemon *Daemon) ContainerStop(name string, timeout *int) error {
 	if err := daemon.containerStop(container, *timeout); err != nil {
 		return errdefs.System(errors.Wrapf(err, "cannot stop container: %s", name))
 	}
+	logrus.Infof("Container stop done with name: %s and id: %s", container.Name, container.ID)
 	return nil
 }
 


### PR DESCRIPTION
This info is very useful when analyze problems for ops or sre.
In some cases, for example k8s use, only container id is not enough
and the log time about create/start/stop is also important when
the container was removed by k8s paltform.

Signed-off-by: Jeff Zvier <zvier20@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"



