### PR TITLE
dockerd-rootless.sh: Fix variable not double quotes cause unexpected behavior

### DIFF
--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -24,11 +24,11 @@ case "$1" in
 		exit 1
 		;;
 esac
-if ! [ -w $XDG_RUNTIME_DIR ]; then
+if ! [ -w "$XDG_RUNTIME_DIR" ]; then
 	echo "XDG_RUNTIME_DIR needs to be set and writable"
 	exit 1
 fi
-if ! [ -d $HOME ]; then
+if ! [ -d "$HOME" ]; then
 	echo "HOME needs to be set and exist."
 	exit 1
 fi
@@ -40,7 +40,7 @@ for f in docker-rootlesskit rootlesskit; do
 		break
 	fi
 done
-if [ -z $rootlesskit ]; then
+if [ -z "$rootlesskit" ]; then
 	echo "rootlesskit needs to be installed"
 	exit 1
 fi
@@ -52,19 +52,19 @@ fi
 : "${DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SECCOMP:=auto}"
 net=$DOCKERD_ROOTLESS_ROOTLESSKIT_NET
 mtu=$DOCKERD_ROOTLESS_ROOTLESSKIT_MTU
-if [ -z $net ]; then
+if [ -z "$net" ]; then
 	if command -v slirp4netns > /dev/null 2>&1; then
 		# If --netns-type is present in --help, slirp4netns is >= v0.4.0.
 		if slirp4netns --help | grep -qw -- --netns-type; then
 			net=slirp4netns
-			if [ -z $mtu ]; then
+			if [ -z "$mtu" ]; then
 				mtu=65520
 			fi
 		else
 			echo "slirp4netns found but seems older than v0.4.0. Falling back to VPNKit."
 		fi
 	fi
-	if [ -z $net ]; then
+	if [ -z "$net" ]; then
 		if command -v vpnkit > /dev/null 2>&1; then
 			net=vpnkit
 		else
@@ -73,11 +73,11 @@ if [ -z $net ]; then
 		fi
 	fi
 fi
-if [ -z $mtu ]; then
+if [ -z "$mtu" ]; then
 	mtu=1500
 fi
 
-if [ -z $_DOCKERD_ROOTLESS_CHILD ]; then
+if [ -z "$_DOCKERD_ROOTLESS_CHILD" ]; then
 	_DOCKERD_ROOTLESS_CHILD=1
 	export _DOCKERD_ROOTLESS_CHILD
 	if [ "$(id -u)" = "0" ]; then
@@ -107,7 +107,7 @@ if [ -z $_DOCKERD_ROOTLESS_CHILD ]; then
 		$DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS \
 		$0 $@
 else
-	[ $_DOCKERD_ROOTLESS_CHILD = 1 ]
+	[ "$_DOCKERD_ROOTLESS_CHILD" = 1 ]
 	# remove the symlinks for the existing files in the parent namespace if any,
 	# so that we can create our own files in our mount namespace.
 	rm -f /run/docker /run/containerd /run/xtables.lock


### PR DESCRIPTION
**- What I did**

`XDG_RUNTIME_DIR` variable not setting, check should be fail.

```
[root@master ~]# echo $XDG_RUNTIME_DIR
/run/user/0
[root@master ~]# su - foouser
Last login: Sun Oct 17 17:52:14 CST 2021 on pts/0
[foouser@master ~]$ id foouser
uid=1000(foouser) gid=1000(foouser) groups=1000(foouser)
[foouser@master ~]$ echo $XDG_RUNTIME_DIR

[foouser@master ~]$ systemctl --user show-environment
Failed to get D-Bus connection: Connection refused
```
```
$ cat test.sh

echo "orign value=$XDG_RUNTIME_DIR"

echo "1. with [ ] not quote ..."
[ -w $XDG_RUNTIME_DIR ]
echo "get 1 ret_code: $?"

echo "2. with [ ] and quote ..."
[ -w "$XDG_RUNTIME_DIR" ]
echo "get 2 ret_code: $?"

$ sh ./test.sh
orign value=
1. with [ ] not quote ...
get 1 ret_code: 0
2. with [ ] and quote ...
get 2 ret_code: 1
[foouser@bk-master ~]$ bash ./test.sh
orign value=
1. with [ ] not quote ...
get 1 ret_code: 0
2. with [ ] and quote ...
get 2 ret_code: 1
```

**- How I did it**

Quoted from `Advanced Bash-Scripting Guide`  https://tldp.org/LDP/abs/html/gotchas.html

> Sometimes variables within "test" brackets ([ ]) need to be quoted (double quotes). Failure to do so
may cause unexpected behavior. See Example 7-6, Example 20-5, and Example 9-6.

**- How to verify it**

Updated `/bin/dockerd-rootless.sh` manually and run it:
```
[foouser@bk-master ~]$ echo $XDG_RUNTIME_DIR

[foouser@bk-master ~]$ dockerd-rootless.sh --help
+ case "$1" in
+ '[' -w '' ']'
+ echo 'XDG_RUNTIME_DIR needs to be set and writable'
XDG_RUNTIME_DIR needs to be set and writable
+ exit 1
```

**- Description for the changelog**

dockerd-rootless.sh: Fix variable not double quotes cause unexpected behavior

Signed-off-by: Chenyang Yan <memory.yancy@gmail.com>