### PR TITLE
buildkit: normalize build target and local platform

### DIFF
--- a/builder/builder-next/adapters/containerimage/pull.go
+++ b/builder/builder-next/adapters/containerimage/pull.go
@@ -21,6 +21,7 @@ import (
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/containerd/remotes/docker/schema1"
 	distreference "github.com/docker/distribution/reference"
+	dimages "github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/distribution"
 	"github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/distribution/xfer"
@@ -853,11 +854,11 @@ func resolveModeToString(rm source.ResolveMode) string {
 }
 
 func platformMatches(img *image.Image, p *ocispec.Platform) bool {
-	if img.Architecture != p.Architecture {
-		return false
-	}
-	if img.Variant != "" && img.Variant != p.Variant {
-		return false
-	}
-	return img.OS == p.OS
+	return dimages.OnlyPlatformWithFallback(*p).Match(ocispec.Platform{
+		Architecture: img.Architecture,
+		OS:           img.OS,
+		OSVersion:    img.OSVersion,
+		OSFeatures:   img.OSFeatures,
+		Variant:      img.Variant,
+	})
 }


### PR DESCRIPTION
Fixes #42893
Fixes docker/buildx#795
Fixes docker/for-mac#6009

**- What I did**
When resolving a local reference to build an image with BuildKit, we need to normalize the two platforms (reference and target platform) before matching them otherwise it would fallback to remote and fail with:

```
[+] Building 1.9s (3/3) FINISHED                                                                                                                                                                      
 => [internal] load build definition from Dockerfile.child                                                                                                                                       0.1s
 => => transferring dockerfile: 102B                                                                                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                                                                0.1s
 => => transferring context: 2B                                                                                                                                                                  0.0s
 => ERROR [internal] load metadata for docker.io/local/foo-parent:latest                                                                                                                         1.3s
------
 > [internal] load metadata for docker.io/local/foo-parent:latest:
------
error: failed to solve: rpc error: code = Unknown desc = failed to solve with frontend dockerfile.v0: failed to create LLB definition: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
```

If we check daemon logs we have:

```
Requested build platform linux/arm64 does not match local image platform linux/arm64/v8, checking remote
```

**- How I did it**
Normalize local and target platform before matching them.

**- How to verify it**

On M1 host:

```dockerfile
# ./Dockerfile.foo
FROM alpine
RUN echo "Hello foo!"
```

```dockerfile
# ./Dockerfile.bar
FROM local/foo-parent
RUN echo "Hello bar!"
```

```shell
DOCKER_BUILDKIT=1 docker build -f Dockerfile.foo -t local/foo-parent .
DOCKER_BUILDKIT=1 docker build -f Dockerfile.bar -t local/foo-child .
```

**- A picture of a cute animal (not mandatory but encouraged)**

cc @thaJeztah @tonistiigi 