### PR TITLE
pkg/fileutils: escape additional regex meta characters

### DIFF
--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -373,6 +373,9 @@ func TestMatches(t *testing.T) {
 		{"abc/**", "abc/def/ghi", true},
 		{"**/.foo", ".foo", true},
 		{"**/.foo", "bar.foo", false},
+		{"a(b)c/def", "a(b)c/def", true},
+		{"a(b)c/def", "a(b)c/xyz", false},
+		{"a.|)$(}+{bc", "a.|)$(}+{bc", true},
 	}
 
 	if runtime.GOOS != "windows" {


### PR DESCRIPTION
**- What I did**
Add additional regex meta characters to escape set for path matcher.

**- How I did it**
Adapt code from Go stdlib `regex::QuoteMeta`.

**- How to verify it**
Unit tests included.

**- Description for the changelog**
Allow use of special characters in `.dockerignore` patterns

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/841263/138482780-8362b805-d71c-4422-89d3-5c4cef058434.png)
From the [Smithsonian cheetah cub cam](https://nationalzoo.si.edu/webcams/cheetah-cub-cam)