### PR TITLE
fix TestInvalidRemoteDriver() to check underlying error

### DIFF
--- a/libnetwork/libnetwork_test.go
+++ b/libnetwork/libnetwork_test.go
@@ -4,6 +4,7 @@
 package libnetwork_test
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -1285,7 +1286,7 @@ func TestInvalidRemoteDriver(t *testing.T) {
 		t.Fatal("Expected to fail. But instead succeeded")
 	}
 
-	if err != plugins.ErrNotImplements {
+	if !errors.Is(err, plugins.ErrNotImplements) {
 		t.Fatalf("Did not fail with expected error. Actual error: %v", err)
 	}
 }


### PR DESCRIPTION
commit b1a3fe49341bec714c1017067bd17d9052e5a2d6 (https://github.com/moby/moby/pull/41215) changed how the error was
returned (which is now wrapped), causing the test to fail:

    === RUN   TestInvalidRemoteDriver
        libnetwork_test.go:1289: Did not fail with expected error. Actual error: Plugin does not implement the requested driver: plugin="invalid-network-driver", requested implementation="NetworkDriver"
    --- FAIL: TestInvalidRemoteDriver (0.01s)

Changing the test to use errors.Is()




**- A picture of a cute animal (not mandatory but encouraged)**

