### PR TITLE
[Windows] cmd/dockerd: create panic.log file without readonly flag

### DIFF
--- a/cmd/dockerd/service_windows.go
+++ b/cmd/dockerd/service_windows.go
@@ -372,7 +372,7 @@ Loop:
 
 func initPanicFile(path string) error {
 	var err error
-	panicFile, err = os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0)
+	panicFile, err = os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o200)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fixes / addresses:

- https://github.com/docker/for-win/issues/11899
- https://github.com/docker/for-win/issues/11901
- https://github.com/docker/for-win/issues/11912
- https://github.com/docker/for-win/issues/11915
- https://github.com/docker/for-win/issues/11925
- https://github.com/docker/for-win/issues/11933
- https://github.com/docker/for-win/issues/11934
- https://github.com/docker/for-win/issues/11935
- https://github.com/docker/for-win/issues/11943
- https://github.com/docker/for-win/issues/11945
- https://github.com/docker/for-win/issues/11954
- https://github.com/docker/for-win/issues/11968
- https://github.com/docker/for-win/issues/11976
- https://github.com/docker/for-win/issues/11977
- https://github.com/docker/for-win/issues/11978
- https://github.com/docker/for-win/issues/11981
- https://github.com/docker/for-win/issues/11987
- https://github.com/docker/for-win/issues/12001
- https://github.com/docker/for-win/issues/12003
- https://github.com/docker/for-win/issues/12008
- https://github.com/docker/for-win/issues/12016
- https://github.com/docker/for-win/issues/12358

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Create panic.log on Windows without the Read-only attribute

**- How I did it**
Set the bit 0o200 (owner write permission):
`os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o200)`

**- How to verify it**
ReadOnly should not be set:
```
PS > (Get-Item C:\ProgramData\docker\panic.log).Attributes
Archive, NotContentIndexed
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
After docker EE bump to version 20.10.8, docker service doesn't start properly after reboot with error:
`fatal: open C:\ProgramData\docker\panic.log: Access is denied.`

Docker 20.10.7 and Go version  go1.13.15:
```
PS > docker version
Server: Mirantis Container Runtime
 Engine:
  Version:          20.10.7
  API version:      1.41 (minimum version 1.24)
  Go version:       go1.13.15
  Git commit:       e1bf5b9c13
  Built:            08/19/2021 18:53:20
  OS/Arch:          windows/amd64
  Experimental:     false
```
Docker 20.10.8 and Go version   go1.16.7m5:
```
PS > docker version
Server: Mirantis Container Runtime
 Engine:
  Version:          20.10.8
  API version:      1.41 (minimum version 1.24)
  Go version:       go1.16.7m5
  Git commit:       785245d4b8
  Built:            10/28/2021 16:06:43
  OS/Arch:          windows/amd64
  Experimental:     false
```

After version of Go runtime bumped above 1.13 the behavior of OpenFile API is changed (https://golang.org/doc/go1.14#windows):


> Windows
> Go binaries on Windows now have DEP (Data Execution Prevention) enabled.
> 
> On Windows, creating a file via os.OpenFile with the os.O_CREATE flag, or via syscall.Open with the syscall.O_CREAT flag, will now create the file as read-only if the bit 0o200 (owner write permission) is not set in the permission argument. This makes the behavior on Windows more like that on Unix systems.

For example:

```
package main

import (
	"log"
	"os"
)

func main() {
	f, err := os.OpenFile("panic.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0)
	if err != nil {
		log.Fatal(err)
	}
	if err := f.Close(); err != nil {
		log.Fatal(err)
	}
}
```

Go 1.13.15:
```
PS > C:\go1.13.15.windows-amd64\go\bin\go.exe run .\create_file.go
PS > (Get-Item .\panic.log).Attributes
Archive, NotContentIndexed


Desired Access:	Append Data/Add Subdirectory/Create Pipe Instance, Read Attributes, Synchronize
Disposition:	OpenIf
Options:	Synchronous IO Non-Alert, Non-Directory File
Attributes:	N
ShareMode:	Read, Write
AllocationSize:	0
OpenResult:	Created
```

Go 1.16.7:
```
PS > C:\go1.16.7.windows-amd64\go\bin\go.exe run .\create_file.go
PS > (Get-Item .\panic.log).Attributes
ReadOnly, Archive, NotContentIndexed

Desired Access:	Append Data/Add Subdirectory/Create Pipe Instance, Read Attributes, Synchronize
Disposition:	OpenIf
Options:	Synchronous IO Non-Alert, Non-Directory File
Attributes:	R
ShareMode:	Read, Write
AllocationSize:	0
OpenResult:	Created
```

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/47745270/139876568-69dbe6cd-39bb-4149-9931-8aea61d76032.png)
