### PR TITLE
RFC: runtime: enable kata as optional runtime

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/go-connections/nat"
+	ptypes "github.com/gogo/protobuf/types"
 )
 
 // RootFS returns Image's RootFS description including the layer IDs.
@@ -524,15 +525,13 @@ type Runtime struct {
 	Path string   `json:"path"`
 	Args []string `json:"runtimeArgs,omitempty"`
 
-	// This is exposed here only for internal use
-	// It is not currently supported to specify custom shim configs
-	Shim *ShimConfig `json:"-"`
+	Shim *ShimConfig `json:"shim,omitempty"`
 }
 
 // ShimConfig is used by runtime to configure containerd shims
 type ShimConfig struct {
-	Binary string
-	Opts   interface{}
+	Binary string      `json:"binary,omitempty"`
+	Opts   *ptypes.Any `json:"opts,omitempty"`
 }
 
 // DiskUsageObject represents an object type used for disk usage query filtering.

--- a/daemon/start_unix.go
+++ b/daemon/start_unix.go
@@ -4,7 +4,9 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	typeurl "github.com/containerd/typeurl"
 	"github.com/docker/docker/container"
+	"github.com/sirupsen/logrus"
 )
 
 // getLibcontainerdCreateOptions callers must hold a lock on the container
@@ -20,5 +22,9 @@ func (daemon *Daemon) getLibcontainerdCreateOptions(container *container.Contain
 		return "", nil, translateContainerdStartErr(container.Path, container.SetExitCode, err)
 	}
 
-	return rt.Shim.Binary, rt.Shim.Opts, nil
+	opts, err := typeurl.UnmarshalAny(rt.Shim.Opts)
+	if err != nil {
+		logrus.Errorf("Fail to UnmarshalAny option for runtime shim: %v", err)
+	}
+	return rt.Shim.Binary, opts, nil
 }


### PR DESCRIPTION
After kata move to 2.x, "--add-runtime" is no longer working as kata runtime changed into a containerd-shim. People enjoy starting kata using docker, but it seems there is no way to go. Here is just a proposal to enable kata as an optional runtime. It's not good enough but deserve a try.

Currently, containerd-shim-v2 is adopt by dockerd, thus we can easily
add containerd-shim-kata-v2 as docker runtime.
we can get it by just exporting shim config to user and people can add containerd kata shim through the config.

Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
enable containerd-shim based runtime like kata as docker optional runtime

**- How I did it**
export shim config to user
**- How to verify it**
add kata runtime in dockerd config like:
    {
       "runtimes":{
          "io.containerd.kata.v2":{
             "shim":{
                "binary":"io.containerd.kata.v2"
             }
          }
       }
    }
and specify runtime using "--runtime io.containerd.kata.v2" when start kata using docker

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

🐭 