### PR TITLE
Fix windows rxReservedNames

### DIFF
--- a/volume/mounts/windows_parser.go
+++ b/volume/mounts/windows_parser.go
@@ -47,7 +47,7 @@ const (
 	rxName = `[^\\/:*?"<>|\r\n]+`
 
 	// RXReservedNames are reserved names not possible on Windows
-	rxReservedNames = `(con)|(prn)|(nul)|(aux)|(com[1-9])|(lpt[1-9])`
+	rxReservedNames = `(con|prn|nul|aux|com[1-9]|lpt[1-9])`
 
 	// rxPipe is a named path pipe (starts with `\\.\pipe\`, possibly with / instead of \)
 	rxPipe = `[/\\]{2}.[/\\]pipe[/\\][^:*?"<>|\r\n]+`

--- a/volume/mounts/windows_parser_test.go
+++ b/volume/mounts/windows_parser_test.go
@@ -22,6 +22,7 @@ func TestWindowsParseMountRaw(t *testing.T) {
 		`c:\program files:d:\s p a c e i n h o s t d i r`,
 		`0123456789name:d:`,
 		`MiXeDcAsEnAmE:d:`,
+		`test-aux-volume:d:`, // includes reserved word, but is not one itself
 		`name:D:`,
 		`name:D::rW`,
 		`name:D::RW`,


### PR DESCRIPTION
This regex is currently matching volumes that include a reserved word (ex. test-aux-volume)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**

Fixes rejecting windows volume names that merely contain a reserved word instead of matching exactly


