### PR TITLE
log error message when receiving an unexpected type error

### DIFF
--- a/errdefs/http_helpers.go
+++ b/errdefs/http_helpers.go
@@ -100,10 +100,10 @@ func FromStatusCode(err error, statusCode int) error {
 			err = System(err)
 		}
 	default:
-		logrus.WithFields(logrus.Fields{
+		logrus.WithError(err).WithFields(logrus.Fields{
 			"module":      "api",
-			"status_code": fmt.Sprintf("%d", statusCode),
-		}).Debugf("FIXME: Got an status-code for which error does not match any expected type!!!: %d", statusCode)
+			"status_code": statusCode,
+		}).Debug("FIXME: Got an status-code for which error does not match any expected type!!!")
 
 		switch {
 		case statusCode >= 200 && statusCode < 400:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Log error message when receiving an error that doesn't match any expected type

**- How I did it**

Simply add `err.Error()` to logging message

**- How to verify it**

Stop docker api server, then use docker client to do `client.Info(ctx)`, log will be printed on client side.

**- Description for the changelog**

I found that if docker server is stopped, when client tries to connecto to server it will get an RST packet (since no one listens on port 2376), then client will print 
```
FIXME: Got an status-code for which error does not match any expected type!!!: -1  module=api status_code=-1
```
but there're too many possibilities to return -1, so maybe logging the detailed error message is a good way. 

Now it prints 
```
FIXME: Got an status-code for which error does not match any expected type!!!: -1  error="Cannot connect to the Docker daemon at tcp://127.0.0.1:2376. Is the docker daemon running?" module=api status_code=-1
```

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![IMG_8302](https://user-images.githubusercontent.com/1748597/140651012-5517d3a8-888a-446a-bad6-c8ec73675257.PNG)

