### PR TITLE
Add HTTP timeout to Splunk logger, fixes #43000

### DIFF
--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -53,8 +53,6 @@ const (
 const (
 	// How often do we send messages (if we are not reaching batch size)
 	defaultPostMessagesFrequency = 5 * time.Second
-	// HTTP timeout
-	defaultHTTPTimeout = 1 * time.Second
 	// How big can be batch of messages
 	defaultPostMessagesBatchSize = 1000
 	// Maximum number of messages we can store in buffer
@@ -231,7 +229,7 @@ func New(info logger.Info) (logger.Logger, error) {
 		}
 	}
 
-	timeout := defaultHTTPTimeout
+	var timeout time.Duration
 	if timeoutStr, ok := info.Config[splunkHTTPTimeout]; ok {
 		value, err := strconv.ParseInt(timeoutStr, 10, 64)
 

--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -23,8 +23,8 @@ import (
 	"github.com/docker/docker/daemon/logger/loggerutils"
 	"github.com/docker/docker/pkg/pools"
 	"github.com/docker/docker/pkg/urlutil"
-	"github.com/docker/docker/vendor/github.com/pkg/errors"
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 

--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -231,12 +231,12 @@ func New(info logger.Info) (logger.Logger, error) {
 
 	var timeout time.Duration
 	if timeoutStr, ok := info.Config[splunkHTTPTimeout]; ok {
-		value, err := strconv.ParseInt(timeoutStr, 10, 64)
+		value, err := time.ParseDuration(timeoutStr)
 
 		if err != nil {
 			return nil, err
 		}
-		timeout = time.Duration(value) * time.Millisecond
+		timeout = value
 	}
 
 	transport := &http.Transport{

--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -23,6 +23,7 @@ import (
 	"github.com/docker/docker/daemon/logger/loggerutils"
 	"github.com/docker/docker/pkg/pools"
 	"github.com/docker/docker/pkg/urlutil"
+	"github.com/docker/docker/vendor/github.com/pkg/errors"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 )
@@ -235,6 +236,9 @@ func New(info logger.Info) (logger.Logger, error) {
 
 		if err != nil {
 			return nil, err
+		}
+		if value < 0 {
+			return nil, errors.Errorf("negative timeout provided: %v", value)
 		}
 		timeout = value
 	}

--- a/daemon/logger/splunk/splunk_test.go
+++ b/daemon/logger/splunk/splunk_test.go
@@ -4,6 +4,7 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"runtime"
@@ -1390,5 +1391,61 @@ func TestDeadlockOnBlockedEndpoint(t *testing.T) {
 		t.Logf("STACK DUMP: \n\n%s\n\n", string(buf))
 		t.Fatal("timeout waiting for close to finish")
 	case <-done:
+	}
+}
+
+func TestCustomHttpTimeout(t *testing.T) {
+	tcpAddr := &net.TCPAddr{IP: []byte{127, 0, 0, 1}, Port: 0, Zone: ""}
+	tcpListener, err := net.ListenTCP("tcp", tcpAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	counter := 0
+	go http.Serve(tcpListener, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method == "POST" {
+			counter++
+			// block so connection will timeout.
+			time.Sleep(5000 * time.Millisecond)
+		}
+		writer.WriteHeader(200)
+	}))
+
+	info := logger.Info{
+		Config: map[string]string{
+			splunkURLKey:      "http://" + tcpListener.Addr().String(),
+			splunkTokenKey:    "1234",
+			splunkHTTPTimeout: "100",
+		},
+		ContainerID:        "containeriid",
+		ContainerName:      "/container_name",
+		ContainerImageID:   "contaimageid",
+		ContainerImageName: "container_image_name",
+	}
+
+	loggerDriver, err := New(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	batchSendTimeout = 1 * time.Second
+	start := time.Now()
+	if err := loggerDriver.Log(&logger.Message{Line: []byte("message1"), Source: "stdout", Timestamp: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	err = loggerDriver.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	duration := time.Since(start)
+	if duration > 1*time.Second {
+		t.Fatal("Sending didn't use the custom timeout")
+	}
+	if counter == 0 {
+		t.Fatal("No messages received")
+	}
+
+	err = tcpListener.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/daemon/logger/splunk/splunk_test.go
+++ b/daemon/logger/splunk/splunk_test.go
@@ -1414,7 +1414,7 @@ func TestCustomHttpTimeout(t *testing.T) {
 		Config: map[string]string{
 			splunkURLKey:      "http://" + tcpListener.Addr().String(),
 			splunkTokenKey:    "1234",
-			splunkHTTPTimeout: "100",
+			splunkHTTPTimeout: "100ms",
 		},
 		ContainerID:        "containeriid",
 		ContainerName:      "/container_name",

--- a/daemon/logger/splunk/splunk_test.go
+++ b/daemon/logger/splunk/splunk_test.go
@@ -1449,3 +1449,24 @@ func TestCustomHttpTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestNegativeTimeout(t *testing.T) {
+	info := logger.Info{
+		Config: map[string]string{
+			splunkURLKey:      "http://localhost:8000",
+			splunkTokenKey:    "1234",
+			splunkHTTPTimeout: "-100ms",
+		},
+		ContainerID:        "containeriid",
+		ContainerName:      "/container_name",
+		ContainerImageID:   "contaimageid",
+		ContainerImageName: "container_image_name",
+	}
+	_, err := New(info)
+	if err == nil {
+		t.Fatal("no error")
+	}
+	if err.Error() != "negative timeout provided: -100ms" {
+		t.Fatalf("unexpected error message: %s", err.Error())
+	}
+}


### PR DESCRIPTION
Signed-off-by: Antoine Toulme <antoine@lunar-ocean.com>

fixes #43000

**- What I did**
Made sure Splunk logging would timeout rather than block indefinitely if HTTP errors occur.

**- How I did **
Added a default HTTP timeout and a config key to set the HTTP timeout for the Splunk HEC logger.

**- How to verify it**
Unit test covers the use case.

**- Description for the changelog**
Add HTTP timeout to Splunk logger with a default of 1 second. Users can override with the `--splunk-timeout` flag.


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/16758/140697632-ee545d80-8341-4ddc-b065-679c186f2c23.png)

