### PR TITLE
[20.10 backport] info: unset cgroup-related fields when CgroupDriver == none

### DIFF
--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -25,16 +25,18 @@ func (daemon *Daemon) fillPlatformInfo(v *types.Info, sysInfo *sysinfo.SysInfo) 
 		v.CgroupVersion = "2"
 	}
 
-	v.MemoryLimit = sysInfo.MemoryLimit
-	v.SwapLimit = sysInfo.SwapLimit
-	v.KernelMemory = sysInfo.KernelMemory
-	v.KernelMemoryTCP = sysInfo.KernelMemoryTCP
-	v.OomKillDisable = sysInfo.OomKillDisable
-	v.CPUCfsPeriod = sysInfo.CPUCfs
-	v.CPUCfsQuota = sysInfo.CPUCfs
-	v.CPUShares = sysInfo.CPUShares
-	v.CPUSet = sysInfo.Cpuset
-	v.PidsLimit = sysInfo.PidsLimit
+	if v.CgroupDriver != cgroupNoneDriver {
+		v.MemoryLimit = sysInfo.MemoryLimit
+		v.SwapLimit = sysInfo.SwapLimit
+		v.KernelMemory = sysInfo.KernelMemory
+		v.KernelMemoryTCP = sysInfo.KernelMemoryTCP
+		v.OomKillDisable = sysInfo.OomKillDisable
+		v.CPUCfsPeriod = sysInfo.CPUCfs
+		v.CPUCfsQuota = sysInfo.CPUCfs
+		v.CPUShares = sysInfo.CPUShares
+		v.CPUSet = sysInfo.Cpuset
+		v.PidsLimit = sysInfo.PidsLimit
+	}
 	v.Runtimes = daemon.configStore.GetAllRuntimes()
 	v.DefaultRuntime = daemon.configStore.GetDefaultRuntimeName()
 	v.InitBinary = daemon.configStore.GetInitPath()


### PR DESCRIPTION

Cherry-pick https://github.com/moby/moby/pull/42152 (clean)

- - -
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->


Fix #42151 

**- What I did**
unset cgroup-related fields when CgroupDriver == none

**- How I did it**
Modified `daemon/info_unix.goP

**- How to verify it**

- Boot the host with cgroup v1
- `dockerd-rootless-setuptool.sh install`
- `docker info --format {{ json. }}`

```json
{
...
  "MemoryLimit": false,
  "SwapLimit": false,
  "KernelMemory": false,
  "KernelMemoryTCP": false,
  "CpuCfsPeriod": false,
  "CpuCfsQuota": false,
  "CPUShares": false,
  "CPUSet": false,
  "PidsLimit": false,
...
  "CgroupDriver": "none",
...
}
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

info: unset cgroup-related fields when CgroupDriver == none

**- A picture of a cute animal (not mandatory but encouraged)**

:penguin: