### PR TITLE
profiles/seccomp: use conditional (hard-coded) errNoRet for MIPS/non-MIPS

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -635,6 +635,36 @@
 			],
 			"action": "SCMP_ACT_ERRNO",
 			"errnoRet": 38,
+			"comment": "ENOSYS for clone3 on non-mips architectures",
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				],
+				"arches": [
+					"mips3l64n32",
+					"mips64",
+					"mips64n32",
+					"mipsel",
+					"mipsel64"
+				]
+			}
+		},
+		{
+			"names": [
+				"clone3"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"errnoRet": 89,
+			"comment": "ENOSYS for clone3 on mips architectures",
+			"includes": {
+				"arches": [
+					"mips3l64n32",
+					"mips64",
+					"mips64n32",
+					"mipsel",
+					"mipsel64"
+				]
+			},
 			"excludes": {
 				"caps": [
 					"CAP_SYS_ADMIN"

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -41,9 +41,26 @@ func arches() []Architecture {
 	}
 }
 
+const (
+	enosys     uint = 0x26 // enosys for non-mips architectures.
+	enosysMIPS uint = 0x59 // enosys for mips architectures.
+)
+
 // DefaultProfile defines the allowed syscalls for the default seccomp profile.
 func DefaultProfile() *Seccomp {
-	nosys := uint(unix.ENOSYS)
+	// The value of ENOSYS differs between MIPS and non-MIPS architectures. While
+	// this is not problematic for the embedded seccomp profile, it prevents the
+	// profile from being saved as a portable JSON file that can be used for both
+	// architectures.
+	// To work around this situation, we include conditional rules for both arches.
+	// and hard-code the value for ENOSYS in both.
+	// For more details, refer to https://github.com/moby/moby/pull/42836#issuecomment-963429850
+	// and https://github.com/opencontainers/runtime-spec/pull/1087#issuecomment-963463475
+	var (
+		nosys     = enosys
+		nosysMIPS = enosysMIPS
+	)
+
 	syscalls := []*Syscall{
 		{
 			LinuxSyscall: specs.LinuxSyscall{
@@ -625,6 +642,24 @@ func DefaultProfile() *Seccomp {
 				},
 				Action:   specs.ActErrno,
 				ErrnoRet: &nosys,
+			},
+			Comment: "ENOSYS for clone3 on non-mips architectures",
+			Excludes: &Filter{
+				Arches: []string{"mips3l64n32", "mips64", "mips64n32", "mipsel", "mipsel64"},
+				Caps:   []string{"CAP_SYS_ADMIN"},
+			},
+		},
+		{
+			LinuxSyscall: specs.LinuxSyscall{
+				Names: []string{
+					"clone3",
+				},
+				Action:   specs.ActErrno,
+				ErrnoRet: &nosysMIPS,
+			},
+			Comment: "ENOSYS for clone3 on mips architectures",
+			Includes: &Filter{
+				Arches: []string{"mips3l64n32", "mips64", "mips64n32", "mipsel", "mipsel64"},
 			},
 			Excludes: &Filter{
 				Caps: []string{"CAP_SYS_ADMIN"},

--- a/profiles/seccomp/fixtures/conditional_clone3.json
+++ b/profiles/seccomp/fixtures/conditional_clone3.json
@@ -1,0 +1,34 @@
+{
+  "defaultAction": "SCMP_ACT_ERRNO",
+  "syscalls": [
+    {
+      "names": ["clone3"],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": ["CAP_SYS_ADMIN"]
+      }
+    },
+    {
+      "names": ["clone3"],
+      "action": "SCMP_ACT_ERRNO",
+      "errnoRet": 38,
+      "comment": "ENOSYS for clone3 on non-mips architectures",
+      "excludes": {
+        "caps": ["CAP_SYS_ADMIN"],
+        "arches": ["mips3l64n32", "mips64", "mips64n32", "mipsel", "mipsel64"]
+      }
+    },
+    {
+      "names": ["clone3"],
+      "action": "SCMP_ACT_ERRNO",
+      "errnoRet": 89,
+      "comment": "ENOSYS for clone3 on mips architectures",
+      "includes": {
+        "arches": ["mips3l64n32", "mips64", "mips64n32", "mipsel", "mipsel64"]
+      },
+      "excludes": {
+        "caps": ["CAP_SYS_ADMIN"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/42836#issuecomment-963429850
- https://github.com/moby/moby/pull/42681#issuecomment-963433969
- https://github.com/opencontainers/runtime-spec/pull/1087#issuecomment-963463475


The value of ENOSYS differs between MIPS and non-MIPS architectures. While
this is not problematic for the embedded seccomp profile, it prevents the
profile from being saved as a portable JSON file that can be used for both
architectures.

To work around this situation, we include conditional rules for both arches.
and hard-code the value for ENOSYS in both.

For more details, refer to https://github.com/moby/moby/pull/42836#issuecomment-963429850
and https://github.com/opencontainers/runtime-spec/pull/1087#issuecomment-963463475

A test was added, which can be run with:

    go test --tags=seccomp -run TestLoadConditionalClone3 -v ./profiles/seccomp/

    === RUN   TestLoadConditionalClone3
    === RUN   TestLoadConditionalClone3/clone3_default_amd64
    === RUN   TestLoadConditionalClone3/clone3_default_mips
    === RUN   TestLoadConditionalClone3/clone3_cap_sys_admin_amd64
    === RUN   TestLoadConditionalClone3/clone3_cap_sys_admin_mips
    --- PASS: TestLoadConditionalClone3 (0.01s)
        --- PASS: TestLoadConditionalClone3/clone3_default_amd64 (0.00s)
        --- PASS: TestLoadConditionalClone3/clone3_default_mips (0.00s)
        --- PASS: TestLoadConditionalClone3/clone3_cap_sys_admin_amd64 (0.00s)
        --- PASS: TestLoadConditionalClone3/clone3_cap_sys_admin_mips (0.00s)
    PASS
    ok  	github.com/docker/docker/profiles/seccomp	0.015s

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

