### PR TITLE
[20.10 backport] TestBuildUserNamespaceValidateCapabilitiesAreV2: cleanup daemon storage

### DIFF
--- a/integration/build/build_userns_linux_test.go
+++ b/integration/build/build_userns_linux_test.go
@@ -41,6 +41,7 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 	dUserRemap.Start(t, "--userns-remap", "default")
 	ctx := context.Background()
 	clientUserRemap := dUserRemap.NewClientT(t)
+	defer clientUserRemap.Close()
 
 	err = load.FrozenImagesLinux(clientUserRemap, "debian:bullseye")
 	assert.NilError(t, err)
@@ -49,6 +50,7 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 	defer func() {
 		if dUserRemapRunning {
 			dUserRemap.Stop(t)
+			dUserRemap.Cleanup(t)
 		}
 	}()
 
@@ -89,12 +91,17 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 
 	dNoUserRemap := daemon.New(t)
 	dNoUserRemap.Start(t)
-	defer dNoUserRemap.Stop(t)
+	defer func() {
+		dNoUserRemap.Stop(t)
+		dNoUserRemap.Cleanup(t)
+	}()
 
 	clientNoUserRemap := dNoUserRemap.NewClientT(t)
+	defer clientNoUserRemap.Close()
 
 	tarFile, err := os.Open(tmp + "/image.tar")
 	assert.NilError(t, err, "failed to open image tar file")
+	defer tarFile.Close()
 
 	tarReader := bufio.NewReader(tarFile)
 	loadResp, err := clientNoUserRemap.ImageLoad(ctx, tarReader, false)
@@ -112,6 +119,7 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 		ShowStdout: true,
 	})
 	assert.NilError(t, err)
+	defer logReader.Close()
 
 	actualStdout := new(bytes.Buffer)
 	actualStderr := ioutil.Discard

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -281,6 +281,7 @@ func (d *Daemon) Cleanup(t testing.TB) {
 	t.Helper()
 	cleanupMount(t, d)
 	cleanupRaftDir(t, d)
+	cleanupDaemonStorage(t, d)
 	cleanupNetworkNamespace(t, d)
 }
 
@@ -817,6 +818,39 @@ func cleanupRaftDir(t testing.TB, d *Daemon) {
 	t.Helper()
 	for _, p := range []string{"wal", "wal-v3-encrypted", "snap-v3-encrypted"} {
 		dir := filepath.Join(d.Root, "swarm/raft", p)
+		if err := os.RemoveAll(dir); err != nil {
+			t.Logf("[%s] error removing %v: %v", d.id, dir, err)
+		}
+	}
+}
+
+// cleanupDaemonStorage removes the daemon's storage directory.
+//
+// Note that we don't delete the whole directory, as some files (e.g. daemon
+// logs) are collected for inclusion in the "bundles" that are stored as Jenkins
+// artifacts.
+//
+// We currently do not include container logs in the bundles, so this also
+// removes the "containers" sub-directory.
+func cleanupDaemonStorage(t testing.TB, d *Daemon) {
+	t.Helper()
+	dirs := []string{
+		"builder",
+		"buildkit",
+		"containers",
+		"image",
+		"network",
+		"plugins",
+		"tmp",
+		"trust",
+		"volumes",
+		// note: this assumes storage-driver name matches the subdirectory,
+		// which is currently true, but not guaranteed.
+		d.storageDriver,
+	}
+
+	for _, p := range dirs {
+		dir := filepath.Join(d.Root, p)
 		if err := os.RemoveAll(dir); err != nil {
 			t.Logf("[%s] error removing %v: %v", d.id, dir, err)
 		}


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/42995

fixes https://github.com/moby/moby/issues/42974

### testutil: daemon.Cleanup(): cleanup more directories

The storage-driver directory caused Jenkins cleanup to fail. While at it, also
removing other directories that we do not include in the "bundles" that are
stored as Jenkins artifacts.

### TestBuildUserNamespaceValidateCapabilitiesAreV2: cleanup daemon storage

This should help with Jenkins failing to clean up the Workspace:

- make sure "cleanup" is also called in the defer for all daemons. keeping
  the daemon's storage around prevented Jenkins from cleaning up.
- close client connections and some readers (just to be sure)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

