### PR TITLE
testing: skip TestBuildWCOWSandboxSize for now

### DIFF
--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -524,6 +524,7 @@ RUN for g in $(seq 0 8); do dd if=/dev/urandom of=rnd bs=1K count=1 seek=$((1024
 }
 
 func TestBuildWCOWSandboxSize(t *testing.T) {
+	t.Skip("FLAKY_TEST that needs to be fixed; see https://github.com/moby/moby/issues/42743")
 	skip.If(t, testEnv.DaemonInfo.OSType != "windows", "only Windows has sandbox size control")
 	ctx := context.TODO()
 	defer setupTest(t)()


### PR DESCRIPTION
This test is failing frequently once nodes have less disk space
available. Skipping the test for now, but we can continue looking
for a good solution.

Tracked through https://github.com/moby/moby/issues/42743

