### PR TITLE
Jenkinsfile: update check-config script to latest version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
         DOCKER_EXPERIMENTAL = '1'
         DOCKER_GRAPHDRIVER  = 'overlay2'
         APT_MIRROR          = 'cdn-fastly.deb.debian.org'
-        CHECK_CONFIG_COMMIT = '2b0755b936416834e14208c6c37b36977e67ea35'
+        CHECK_CONFIG_COMMIT = '33a3680e08d1007e72c3b3f1454f823d8e9948ee'
         TESTDEBUG           = '0'
         TIMEOUT             = '120m'
     }


### PR DESCRIPTION
Diff:

    git diff 2b0755b936416834e14208c6c37b36977e67ea35...33a3680e08d1007e72c3b3f1454f823d8e9948ee -- contrib/check-config.sh


<details>

```patch
diff --git a/contrib/check-config.sh b/contrib/check-config.sh
index 253595ef90..617eb93893 100755
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 set -e
 
 EXITCODE=0
@@ -6,20 +6,20 @@ EXITCODE=0
 # bits of this were adapted from lxc-checkconfig
 # see also https://github.com/lxc/lxc/blob/lxc-1.0.2/src/lxc/lxc-checkconfig.in
 
-possibleConfigs=(
-	'/proc/config.gz'
-	"/boot/config-$(uname -r)"
-	"/usr/src/linux-$(uname -r)/.config"
-	'/usr/src/linux/.config'
-)
+possibleConfigs="
+	/proc/config.gz
+	/boot/config-$(uname -r)
+	/usr/src/linux-$(uname -r)/.config
+	/usr/src/linux/.config
+"
 
 if [ $# -gt 0 ]; then
 	CONFIG="$1"
 else
-	: "${CONFIG:="${possibleConfigs[0]}"}"
+	: "${CONFIG:=/proc/config.gz}"
 fi
 
-if ! command -v zgrep &> /dev/null; then
+if ! command -v zgrep > /dev/null 2>&1; then
 	zgrep() {
 		zcat "$2" | grep "$1"
 	}
@@ -41,13 +41,13 @@ is_set_as_module() {
 }
 
 color() {
-	local codes=()
+	codes=
 	if [ "$1" = 'bold' ]; then
-		codes=("${codes[@]}" '1')
+		codes='1'
 		shift
 	fi
 	if [ "$#" -gt 0 ]; then
-		local code=
+		code=
 		case "$1" in
 			# see https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
 			black) code=30 ;;
@@ -60,17 +60,16 @@ color() {
 			white) code=37 ;;
 		esac
 		if [ "$code" ]; then
-			codes=("${codes[@]}" "$code")
+			codes="${codes:+$codes;}$code"
 		fi
 	fi
-	local IFS=';'
-	echo -en '\033['"${codes[*]}"'m'
+	printf '\033[%sm' "$codes"
 }
 wrap_color() {
 	text="$1"
 	shift
 	color "$@"
-	echo -n "$text"
+	printf '%s' "$text"
 	color reset
 	echo
 }
@@ -98,7 +97,7 @@ check_flag() {
 
 check_flags() {
 	for flag in "$@"; do
-		echo -n "- "
+		printf -- '- '
 		check_flag "$flag"
 	done
 }
@@ -122,20 +121,26 @@ check_device() {
 }
 
 check_distro_userns() {
-	source /etc/os-release 2> /dev/null || /bin/true
-	if [[ "${ID}" =~ ^(centos|rhel)$ && "${VERSION_ID}" =~ ^7 ]]; then
-		# this is a CentOS7 or RHEL7 system
-		grep -q "user_namespace.enable=1" /proc/cmdline || {
-			# no user namespace support enabled
-			wrap_bad "  (RHEL7/CentOS7" "User namespaces disabled; add 'user_namespace.enable=1' to boot command line)"
-			EXITCODE=1
-		}
-	fi
+	. /etc/os-release 2> /dev/null || /bin/true
+	case "$ID" in
+		centos | rhel)
+			case "$VERSION_ID" in
+				7*)
+					# this is a CentOS7 or RHEL7 system
+					grep -q 'user_namespace.enable=1' /proc/cmdline || {
+						# no user namespace support enabled
+						wrap_bad "  (RHEL7/CentOS7" "User namespaces disabled; add 'user_namespace.enable=1' to boot command line)"
+						EXITCODE=1
+					}
+					;;
+			esac
+			;;
+	esac
 }
 
 if [ ! -e "$CONFIG" ]; then
 	wrap_warning "warning: $CONFIG does not exist, searching other paths for kernel config ..."
-	for tryConfig in "${possibleConfigs[@]}"; do
+	for tryConfig in $possibleConfigs; do
 		if [ -e "$tryConfig" ]; then
 			CONFIG="$tryConfig"
 			break
@@ -154,11 +159,25 @@ echo
 
 echo 'Generally Necessary:'
 
-echo -n '- '
+printf -- '- '
 if [ "$(stat -f -c %t /sys/fs/cgroup 2> /dev/null)" = '63677270' ]; then
-	echo "$(wrap_good 'cgroup hierarchy' 'cgroupv2')"
+	wrap_good 'cgroup hierarchy' 'cgroupv2'
+	cgroupv2ControllerFile='/sys/fs/cgroup/cgroup.controllers'
+	if [ -f "$cgroupv2ControllerFile" ]; then
+		echo '  Controllers:'
+		for controller in cpu cpuset io memory pids; do
+			if grep -qE '(^| )'"$controller"'($| )' "$cgroupv2ControllerFile"; then
+				echo "  - $(wrap_good "$controller" 'available')"
+			else
+				echo "  - $(wrap_bad "$controller" 'missing')"
+			fi
+		done
+	else
+		wrap_bad "$cgroupv2ControllerFile" 'nonexistent??'
+	fi
+	# TODO find an efficient way to check if cgroup.freeze exists in subdir
 else
-	cgroupSubsystemDir="$(awk '/[, ](cpu|cpuacct|cpuset|devices|freezer|memory)[, ]/ && $3 == "cgroup" { print $2 }' /proc/mounts | head -n1)"
+	cgroupSubsystemDir="$(sed -rne '/^[^ ]+ ([^ ]+) cgroup ([^ ]*,)?(cpu|cpuacct|cpuset|devices|freezer|memory)[, ].*$/ { s//\1/p; q }' /proc/mounts)"
 	cgroupDir="$(dirname "$cgroupSubsystemDir")"
 	if [ -d "$cgroupDir/cpu" ] || [ -d "$cgroupDir/cpuacct" ] || [ -d "$cgroupDir/cpuset" ] || [ -d "$cgroupDir/devices" ] || [ -d "$cgroupDir/freezer" ] || [ -d "$cgroupDir/memory" ]; then
 		echo "$(wrap_good 'cgroup hierarchy' 'properly mounted') [$cgroupDir]"
@@ -174,15 +193,15 @@ else
 fi
 
 if [ "$(cat /sys/module/apparmor/parameters/enabled 2> /dev/null)" = 'Y' ]; then
-	echo -n '- '
-	if command -v apparmor_parser &> /dev/null; then
+	printf -- '- '
+	if command -v apparmor_parser > /dev/null 2>&1; then
 		wrap_good 'apparmor' 'enabled and tools installed'
 	else
 		wrap_bad 'apparmor' 'enabled, but apparmor_parser missing'
-		echo -n '    '
-		if command -v apt-get &> /dev/null; then
+		printf '    '
+		if command -v apt-get > /dev/null 2>&1; then
 			wrap_color '(use "apt-get install apparmor" to fix this)'
-		elif command -v yum &> /dev/null; then
+		elif command -v yum > /dev/null 2>&1; then
 			wrap_color '(your best bet is "yum install apparmor-parser")'
 		else
 			wrap_color '(look for an "apparmor" package for your distribution)'
@@ -191,20 +210,20 @@ if [ "$(cat /sys/module/apparmor/parameters/enabled 2> /dev/null)" = 'Y' ]; then
 	fi
 fi
 
-flags=(
-	NAMESPACES {NET,PID,IPC,UTS}_NS
-	CGROUPS CGROUP_CPUACCT CGROUP_DEVICE CGROUP_FREEZER CGROUP_SCHED CPUSETS MEMCG
-	KEYS
-	VETH BRIDGE BRIDGE_NETFILTER
-	IP_NF_FILTER IP_NF_TARGET_MASQUERADE
-	NETFILTER_XT_MATCH_{ADDRTYPE,CONNTRACK,IPVS}
-	NETFILTER_XT_MARK
-	IP_NF_NAT NF_NAT
-
-	# required for bind-mounting /dev/mqueue into containers
+check_flags \
+	NAMESPACES NET_NS PID_NS IPC_NS UTS_NS \
+	CGROUPS CGROUP_CPUACCT CGROUP_DEVICE CGROUP_FREEZER CGROUP_SCHED CPUSETS MEMCG \
+	KEYS \
+	VETH BRIDGE BRIDGE_NETFILTER \
+	IP_NF_FILTER IP_NF_TARGET_MASQUERADE \
+	NETFILTER_XT_MATCH_ADDRTYPE \
+	NETFILTER_XT_MATCH_CONNTRACK \
+	NETFILTER_XT_MATCH_IPVS \
+	NETFILTER_XT_MARK \
+	IP_NF_NAT NF_NAT \
 	POSIX_MQUEUE
-)
-check_flags "${flags[@]}"
+# (POSIX_MQUEUE is required for bind-mounting /dev/mqueue into containers)
+
 if [ "$kernelMajor" -lt 4 ] || ([ "$kernelMajor" -eq 4 ] && [ "$kernelMinor" -lt 8 ]); then
 	check_flags DEVPTS_MULTIPLE_INSTANCES
 fi
@@ -216,6 +235,10 @@ fi
 if [ "$kernelMajor" -lt 5 ] || [ "$kernelMajor" -eq 5 -a "$kernelMinor" -le 2 ]; then
 	check_flags NF_NAT_NEEDED
 fi
+# check availability of BPF_CGROUP_DEVICE support
+if [ "$kernelMajor" -ge 5 ] || ([ "$kernelMajor" -eq 4 ] && [ "$kernelMinor" -ge 15 ]); then
+	check_flags CGROUP_BPF
+fi
 
 echo
 
@@ -251,14 +274,14 @@ echo 'Optional Features:'
 }
 {
 	if is_set LEGACY_VSYSCALL_NATIVE; then
-		echo -n "- "
+		printf -- '- '
 		wrap_bad "CONFIG_LEGACY_VSYSCALL_NATIVE" 'enabled'
 		echo "    $(wrap_color '(dangerous, provides an ASLR-bypassing target with usable ROP gadgets.)' bold black)"
 	elif is_set LEGACY_VSYSCALL_EMULATE; then
-		echo -n "- "
+		printf -- '- '
 		wrap_good "CONFIG_LEGACY_VSYSCALL_EMULATE" 'enabled'
 	elif is_set LEGACY_VSYSCALL_NONE; then
-		echo -n "- "
+		printf -- '- '
 		wrap_bad "CONFIG_LEGACY_VSYSCALL_NONE" 'enabled'
 		echo "    $(wrap_color '(containers using eglibc <= 2.13 will not work. Switch to' bold black)"
 		echo "    $(wrap_color ' "CONFIG_VSYSCALL_[NATIVE|EMULATE]" or use "vsyscall=[native|emulate]"' bold black)"
@@ -289,22 +312,20 @@ if [ "$kernelMajor" -lt 5 ]; then
 	check_flags IOSCHED_CFQ CFQ_GROUP_IOSCHED
 fi
 
-flags=(
-	BLK_CGROUP BLK_DEV_THROTTLING
-	CGROUP_PERF
-	CGROUP_HUGETLB
-	NET_CLS_CGROUP $netprio
-	CFS_BANDWIDTH FAIR_GROUP_SCHED RT_GROUP_SCHED
-	IP_NF_TARGET_REDIRECT
-	IP_VS
-	IP_VS_NFCT
-	IP_VS_PROTO_TCP
-	IP_VS_PROTO_UDP
-	IP_VS_RR
-	SECURITY_SELINUX
+check_flags \
+	BLK_CGROUP BLK_DEV_THROTTLING \
+	CGROUP_PERF \
+	CGROUP_HUGETLB \
+	NET_CLS_CGROUP $netprio \
+	CFS_BANDWIDTH FAIR_GROUP_SCHED RT_GROUP_SCHED \
+	IP_NF_TARGET_REDIRECT \
+	IP_VS \
+	IP_VS_NFCT \
+	IP_VS_PROTO_TCP \
+	IP_VS_PROTO_UDP \
+	IP_VS_RR \
+	SECURITY_SELINUX \
 	SECURITY_APPARMOR
-)
-check_flags "${flags[@]}"
 
 if ! is_set EXT4_USE_FOR_EXT2; then
 	check_flags EXT3_FS EXT3_FS_XATTR EXT3_FS_POSIX_ACL EXT3_FS_SECURITY
@@ -369,11 +390,11 @@ check_flags OVERLAY_FS | sed 's/^/    /'
 EXITCODE=0
 
 echo "  - \"$(wrap_color 'zfs' blue)\":"
-echo -n "    - "
+printf '    - '
 check_device /dev/zfs
-echo -n "    - "
+printf '    - '
 check_command zfs
-echo -n "    - "
+printf '    - '
 check_command zpool
 [ "$EXITCODE" = 0 ] && STORAGE=0
 EXITCODE=0
```


</details>
