### PR TITLE
Fix flaky TestPortMappingV6Config

### DIFF
--- a/libnetwork/drivers/bridge/port_mapping_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/libnetwork/netlabel"
+	"github.com/docker/docker/libnetwork/ns"
 	"github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/docker/docker/pkg/reexec"
@@ -101,6 +102,10 @@ func TestPortMappingConfig(t *testing.T) {
 
 func TestPortMappingV6Config(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
+	if err := loopbackUp(); err != nil {
+		t.Fatalf("Could not bring loopback iface up: %v", err)
+	}
+
 	d := newDriver()
 
 	config := &configuration{
@@ -168,4 +173,13 @@ func TestPortMappingV6Config(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func loopbackUp() error {
+	nlHandle := ns.NlHandle()
+	iface, err := nlHandle.LinkByName("lo")
+	if err != nil {
+		return err
+	}
+	return nlHandle.LinkSetUp(iface)
 }


### PR DESCRIPTION
Since moby/libnetwork#2635 has been merged, allocatePortsInternal()
checks if IPv6 is enabled by calling IsV6Listenable(). This function
calls `net.Listen("tcp6", "[::1]:0")` and returns false when
net.Listen() fails.

TestPortMappingV6Config() starts by setting up a new net ns to run into
it. The loopback interface is not bring up in this net ns, thus
net.Listen() fails and IsV6Listenable() returns false. This change takes
care of bringing loopback iface up right after moving to the new net ns.

This test has been reported as flaky on s390x in #42468. For some
reason, this test seems to be consistently green on the CI (on amd64
arch) and when running `hack/test/unit` locally. However it consistently
fails when running `TESTFLAGS='-shuffle on' hack/test/unit` locally.