### PR TITLE
[20.10] fix vendor validation

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -76,7 +76,7 @@ github.com/ishidawataru/sctp                        f2269e66cdee387bd321445d5d30
 go.etcd.io/bbolt                                    232d8fc87f50244f9c808f4745759e08a304c029 # v1.3.5
 
 # get graph and distribution packages
-github.com/docker/distribution                      58f99e93b767ebacbf8e62a9074844712d31a177 github.com/samuelkarp/docker-distribution
+github.com/docker/distribution                      58f99e93b767ebacbf8e62a9074844712d31a177 https://github.com/samuelkarp/docker-distribution.git
 github.com/vbatts/tar-split                         620714a4c508c880ac1bdda9c8370a2b19af1a55 # v0.11.1
 github.com/opencontainers/go-digest                 ea51bea511f75cfa3ef6098cc253c5c3609b037a # v1.0.0
 
@@ -130,7 +130,7 @@ github.com/googleapis/gax-go                        bd5b16380fd03dc758d11cef74ba
 google.golang.org/genproto                          3f1135a288c9a07e340ae8ba4cc6c7065a3160e8
 
 # containerd
-github.com/containerd/containerd                    e048c115a3a89caf63941d363858e207c28bccd6 github.com/moby/containerd # master (v1.5.0-dev) + patch for CVE-2021-41190
+github.com/containerd/containerd                    e048c115a3a89caf63941d363858e207c28bccd6 https://github.com/moby/containerd.git # master (v1.5.0-dev) + patch for CVE-2021-41190
 github.com/containerd/fifo                          0724c46b320cf96bb172a0550c19a4b1fca4dacb
 github.com/containerd/continuity                    efbc4488d8fe1bdc16bde3b2d2990d9b3a899165
 github.com/containerd/cgroups                       0b889c03f102012f1d93a97ddd3ef71cd6f4f510
@@ -151,7 +151,7 @@ github.com/google/certificate-transparency-go       37a384cd035e722ea46e55029093
 golang.org/x/crypto                                 c1f2f97bffc9c53fc40a1a28a5b460094c0050d9
 golang.org/x/time                                   555d28b269f0569763d25dbe1a237ae74c6bcc82
 github.com/hashicorp/go-memdb                       cb9a474f84cc5e41b273b20c6927680b2a8776ad
-github.com/hashicorp/go-immutable-radix             826af9ccf0feeee615d546d69b11f8e98da8c8f1 git://github.com/tonistiigi/go-immutable-radix.git
+github.com/hashicorp/go-immutable-radix             826af9ccf0feeee615d546d69b11f8e98da8c8f1 https://github.com/tonistiigi/go-immutable-radix.git
 github.com/hashicorp/golang-lru                     7f827b33c0f158ec5dfbba01bb0b14a4541fd81d # v0.5.3
 github.com/coreos/pkg                               3ac0863d7acf3bc44daf49afef8919af12f704ef # v3
 code.cloudfoundry.org/clock                         02e53af36e6c978af692887ed449b74026d76fec # v1.0.0


### PR DESCRIPTION
Looks like vndr didn't like the replace rule missing a scheme;

    github.com/docker/distribution: Err: exit status 128, out: fatal: repository 'github.com/samuelkarp/docker-distribution' does not exist
    github.com/containerd/containerd: Err: exit status 128, out: fatal: repository 'github.com/moby/containerd' does not exist

While at it, I also replaced the schem for go-immutable-radix, because GitHub
is deprecating the git:// protocol.

