### PR TITLE
integration-cli: remove manifest v2 schema 1 push tests

### DIFF
--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -17,21 +17,12 @@ import (
 	"gotest.tools/v3/icmd"
 )
 
-// Pushing an image to a private registry.
-func testPushBusyboxImage(c *testing.T) {
+func (s *DockerRegistrySuite) TestPushBusyboxImage(c *testing.T) {
 	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
 	// tag the image to upload it to the private registry
 	dockerCmd(c, "tag", "busybox", repoName)
 	// push the image to the registry
 	dockerCmd(c, "push", repoName)
-}
-
-func (s *DockerRegistrySuite) TestPushBusyboxImage(c *testing.T) {
-	testPushBusyboxImage(c)
-}
-
-func (s *DockerSchema1RegistrySuite) TestPushBusyboxImage(c *testing.T) {
-	testPushBusyboxImage(c)
 }
 
 // pushing an image without a prefix should throw an error
@@ -40,7 +31,7 @@ func (s *DockerSuite) TestPushUnprefixedRepo(c *testing.T) {
 	assert.ErrorContains(c, err, "", "pushing an unprefixed repo didn't result in a non-zero exit status: %s", out)
 }
 
-func testPushUntagged(c *testing.T) {
+func (s *DockerRegistrySuite) TestPushUntagged(c *testing.T) {
 	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
 	expected := "An image does not exist locally with the tag"
 
@@ -49,15 +40,7 @@ func testPushUntagged(c *testing.T) {
 	assert.Assert(c, strings.Contains(out, expected), "pushing the image failed")
 }
 
-func (s *DockerRegistrySuite) TestPushUntagged(c *testing.T) {
-	testPushUntagged(c)
-}
-
-func (s *DockerSchema1RegistrySuite) TestPushUntagged(c *testing.T) {
-	testPushUntagged(c)
-}
-
-func testPushBadTag(c *testing.T) {
+func (s *DockerRegistrySuite) TestPushBadTag(c *testing.T) {
 	repoName := fmt.Sprintf("%v/dockercli/busybox:latest", privateRegistryURL)
 	expected := "does not exist"
 
@@ -66,15 +49,7 @@ func testPushBadTag(c *testing.T) {
 	assert.Assert(c, strings.Contains(out, expected), "pushing the image failed")
 }
 
-func (s *DockerRegistrySuite) TestPushBadTag(c *testing.T) {
-	testPushBadTag(c)
-}
-
-func (s *DockerSchema1RegistrySuite) TestPushBadTag(c *testing.T) {
-	testPushBadTag(c)
-}
-
-func testPushMultipleTags(c *testing.T) {
+func (s *DockerRegistrySuite) TestPushMultipleTags(c *testing.T) {
 	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
 	repoTag1 := fmt.Sprintf("%v/dockercli/busybox:t1", privateRegistryURL)
 	repoTag2 := fmt.Sprintf("%v/dockercli/busybox:t2", privateRegistryURL)
@@ -112,15 +87,7 @@ func testPushMultipleTags(c *testing.T) {
 	assert.DeepEqual(c, out1Lines, out2Lines)
 }
 
-func (s *DockerRegistrySuite) TestPushMultipleTags(c *testing.T) {
-	testPushMultipleTags(c)
-}
-
-func (s *DockerSchema1RegistrySuite) TestPushMultipleTags(c *testing.T) {
-	testPushMultipleTags(c)
-}
-
-func testPushEmptyLayer(c *testing.T) {
+func (s *DockerRegistrySuite) TestPushEmptyLayer(c *testing.T) {
 	repoName := fmt.Sprintf("%v/dockercli/emptylayer", privateRegistryURL)
 	emptyTarball, err := os.CreateTemp("", "empty_tarball")
 	assert.NilError(c, err, "Unable to create test file")
@@ -143,17 +110,9 @@ func testPushEmptyLayer(c *testing.T) {
 	assert.NilError(c, err, "pushing the image to the private registry has failed: %s", out)
 }
 
-func (s *DockerRegistrySuite) TestPushEmptyLayer(c *testing.T) {
-	testPushEmptyLayer(c)
-}
-
-func (s *DockerSchema1RegistrySuite) TestPushEmptyLayer(c *testing.T) {
-	testPushEmptyLayer(c)
-}
-
-// testConcurrentPush pushes multiple tags to the same repo
+// TestConcurrentPush pushes multiple tags to the same repo
 // concurrently.
-func testConcurrentPush(c *testing.T) {
+func (s *DockerRegistrySuite) TestConcurrentPush(c *testing.T) {
 	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
 
 	var repos []string
@@ -197,14 +156,6 @@ func testConcurrentPush(c *testing.T) {
 	}
 }
 
-func (s *DockerRegistrySuite) TestConcurrentPush(c *testing.T) {
-	testConcurrentPush(c)
-}
-
-func (s *DockerSchema1RegistrySuite) TestConcurrentPush(c *testing.T) {
-	testConcurrentPush(c)
-}
-
 func (s *DockerRegistrySuite) TestCrossRepositoryLayerPush(c *testing.T) {
 	sourceRepoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
 	// tag the image to upload it to the private registry
@@ -245,39 +196,6 @@ func (s *DockerRegistrySuite) TestCrossRepositoryLayerPush(c *testing.T) {
 	dockerCmd(c, "pull", destRepoName)
 	out4, _ := dockerCmd(c, "run", destRepoName, "echo", "-n", "hello world")
 	assert.Equal(c, out4, "hello world")
-}
-
-func (s *DockerSchema1RegistrySuite) TestCrossRepositoryLayerPushNotSupported(c *testing.T) {
-	sourceRepoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
-	// tag the image to upload it to the private registry
-	dockerCmd(c, "tag", "busybox", sourceRepoName)
-	// push the image to the registry
-	out1, _, err := dockerCmdWithError("push", sourceRepoName)
-	assert.NilError(c, err, fmt.Sprintf("pushing the image to the private registry has failed: %s", out1))
-	// ensure that none of the layers were mounted from another repository during push
-	assert.Assert(c, !strings.Contains(out1, "Mounted from"))
-
-	digest1 := reference.DigestRegexp.FindString(out1)
-	assert.Assert(c, len(digest1) > 0, "no digest found for pushed manifest")
-
-	destRepoName := fmt.Sprintf("%v/dockercli/crossrepopush", privateRegistryURL)
-	// retag the image to upload the same layers to another repo in the same registry
-	dockerCmd(c, "tag", "busybox", destRepoName)
-	// push the image to the registry
-	out2, _, err := dockerCmdWithError("push", destRepoName)
-	assert.NilError(c, err, fmt.Sprintf("pushing the image to the private registry has failed: %s", out2))
-	// schema1 registry should not support cross-repo layer mounts, so ensure that this does not happen
-	assert.Assert(c, !strings.Contains(out2, "Mounted from"))
-
-	digest2 := reference.DigestRegexp.FindString(out2)
-	assert.Assert(c, len(digest2) > 0, "no digest found for pushed manifest")
-	assert.Assert(c, digest1 != digest2)
-
-	// ensure that we can pull and run the second pushed repository
-	dockerCmd(c, "rmi", destRepoName)
-	dockerCmd(c, "pull", destRepoName)
-	out3, _ := dockerCmd(c, "run", destRepoName, "echo", "-n", "hello world")
-	assert.Assert(c, out3 == "hello world")
 }
 
 func (s *DockerRegistryAuthHtpasswdSuite) TestPushNoCredentialsNoRetry(c *testing.T) {


### PR DESCRIPTION
Pushing manifest v2, schema 1 images has been deprecated in commits 4866f5139a0b0bc026aa4b0c916ee1071c6951 (https://github.com/moby/moby/pull/39365) and 6302dbbf46dd40d824238487a5afece551d5 (https://github.com/moby/moby/pull/41295) (docker 20.10). While it's still used in some tests to provision a legacy registry to test _pulling_ legacy images (which is still "supported"), we should no longer have to validate pushing for other scenarios.

This patch removes the schema 1 push tests, and inlines the code that was extracted in non-exported functions (for them to be shared between schema 2 and schema 1 tests).

Relates to:

- https://github.com/docker/roadmap/issues/173
- https://github.com/moby/moby/pull/39384
- https://github.com/moby/moby/pull/39736
- https://github.com/moby/moby/pull/41295
- https://github.com/moby/moby/pull/42300


**- A picture of a cute animal (not mandatory but encouraged)**

