### PR TITLE
TestConntrackFlowsLeak: use busybox "nc"

### DIFF
--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1747,12 +1747,12 @@ func (s *DockerNetworkSuite) TestConntrackFlowsLeak(c *testing.T) {
 	assertNwIsAvailable(c, "testbind")
 
 	// Launch the server, this will remain listening on an exposed port and reply to any request in a ping/pong fashion
-	cmd := "while true; do echo hello | nc -w 1 -lu 8080; done"
-	cli.DockerCmd(c, "run", "-d", "--name", "server", "--net", "testbind", "-p", "8080:8080/udp", "appropriate/nc", "sh", "-c", cmd)
+	cmd := "while true; do echo hello | nc -w 1 -l -u -p 8080; done"
+	cli.DockerCmd(c, "run", "-d", "--name", "server", "--net", "testbind", "-p", "8080:8080/udp", "busybox", "sh", "-c", cmd)
 
 	// Launch a container client, here the objective is to create a flow that is natted in order to expose the bug
-	cmd = "echo world | nc -q 1 -u 192.168.10.1 8080"
-	cli.DockerCmd(c, "run", "-d", "--name", "client", "--net=host", "appropriate/nc", "sh", "-c", cmd)
+	cmd = "echo world | nc -w 1 -u 192.168.10.1 8080"
+	cli.DockerCmd(c, "run", "-d", "--name", "client", "--net=host", "busybox", "sh", "-c", cmd)
 
 	// Get all the flows using netlink
 	flows, err := netlink.ConntrackTableList(netlink.ConntrackTable, unix.AF_INET)


### PR DESCRIPTION
extracted from https://github.com/moby/moby/pull/42300
this is another attempt at https://github.com/moby/moby/pull/34832
replaces / closes  https://github.com/moby/moby/pull/34832

to address:

- (part of) https://github.com/moby/moby/issues/39563
- https://github.com/moby/moby/pull/32505#discussion_r136242314
- https://github.com/moby/moby/pull/42300#issuecomment-973014869

The appropriate/nc image was last built over 6 years ago, and uses the deprecated v2 schema 1 format; https://github.com/appropriate/docker-nc/tree/master/latest

The image is just a plain "apk install" of netbsd-netcat, but was added in 1c4286bcffcdc6668f84570a2754c78cccbbf7e1 (https://github.com/moby/moby/pull/32505), because at the time the busybox nc had some bugs.

These appear to be resolved, so we can use the busybox nc, from the frozen images.