### PR TITLE
libnet/ipam: Lazily sub-divide pools into subnets

### DIFF
--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -165,7 +165,8 @@ func TestDaemonConfigurationMergeDefaultAddressPools(t *testing.T) {
 
 		config, err := MergeDaemonConfigurations(&conf, flags, emptyConfigFile)
 		assert.NilError(t, err)
-		assert.DeepEqual(t, config.DefaultAddressPools.Value(), expected)
+		assert.DeepEqual(t, config.DefaultAddressPools.Value(), expected,
+			cmpopts.IgnoreUnexported(ipamutils.NetworkToSplit{}))
 	})
 
 	t.Run("config file", func(t *testing.T) {
@@ -175,7 +176,8 @@ func TestDaemonConfigurationMergeDefaultAddressPools(t *testing.T) {
 
 		config, err := MergeDaemonConfigurations(&conf, flags, configFile)
 		assert.NilError(t, err)
-		assert.DeepEqual(t, config.DefaultAddressPools.Value(), expected)
+		assert.DeepEqual(t, config.DefaultAddressPools.Value(), expected,
+			cmpopts.IgnoreUnexported(ipamutils.NetworkToSplit{}))
 	})
 
 	t.Run("with conflicting options", func(t *testing.T) {

--- a/libnetwork/ipam/allocator_test.go
+++ b/libnetwork/ipam/allocator_test.go
@@ -54,7 +54,7 @@ func TestKeyString(t *testing.T) {
 }
 
 func TestAddSubnets(t *testing.T) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetDefaultLocalScopeSubnetter(), ipamutils.GetDefaultGlobalScopeSubnetter())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +116,7 @@ func TestAddSubnets(t *testing.T) {
 // TestDoublePoolRelease tests that releasing a pool which has already
 // been released raises an error.
 func TestDoublePoolRelease(t *testing.T) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetDefaultLocalScopeSubnetter(), ipamutils.GetDefaultGlobalScopeSubnetter())
 	assert.NilError(t, err)
 
 	pid0, _, _, err := a.RequestPool(localAddressSpace, "10.0.0.0/8", "", nil, false)
@@ -130,7 +130,7 @@ func TestDoublePoolRelease(t *testing.T) {
 }
 
 func TestAddReleasePoolID(t *testing.T) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetDefaultLocalScopeSubnetter(), ipamutils.GetDefaultGlobalScopeSubnetter())
 	assert.NilError(t, err)
 
 	var k0, k1 PoolID
@@ -257,7 +257,7 @@ func TestAddReleasePoolID(t *testing.T) {
 }
 
 func TestPredefinedPool(t *testing.T) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetDefaultLocalScopeSubnetter(), ipamutils.GetDefaultGlobalScopeSubnetter())
 	assert.NilError(t, err)
 
 	pid, nw, _, err := a.RequestPool(localAddressSpace, "", "", nil, false)
@@ -284,7 +284,7 @@ func TestPredefinedPool(t *testing.T) {
 }
 
 func TestRemoveSubnet(t *testing.T) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetDefaultLocalScopeSubnetter(), ipamutils.GetDefaultGlobalScopeSubnetter())
 	assert.NilError(t, err)
 
 	input := []struct {
@@ -318,7 +318,7 @@ func TestRemoveSubnet(t *testing.T) {
 }
 
 func TestGetSameAddress(t *testing.T) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetDefaultLocalScopeSubnetter(), ipamutils.GetDefaultGlobalScopeSubnetter())
 	assert.NilError(t, err)
 
 	pid, _, _, err := a.RequestPool(localAddressSpace, "192.168.100.0/24", "", nil, false)
@@ -339,7 +339,7 @@ func TestGetSameAddress(t *testing.T) {
 }
 
 func TestPoolAllocationReuse(t *testing.T) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetDefaultLocalScopeSubnetter(), ipamutils.GetDefaultGlobalScopeSubnetter())
 	assert.NilError(t, err)
 
 	// First get all pools until they are exhausted to
@@ -376,7 +376,7 @@ func TestPoolAllocationReuse(t *testing.T) {
 }
 
 func TestGetAddressSubPoolEqualPool(t *testing.T) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetDefaultLocalScopeSubnetter(), ipamutils.GetDefaultGlobalScopeSubnetter())
 	assert.NilError(t, err)
 
 	// Requesting a subpool of same size of the master pool should not cause any problem on ip allocation
@@ -392,7 +392,7 @@ func TestGetAddressSubPoolEqualPool(t *testing.T) {
 }
 
 func TestRequestReleaseAddressFromSubPool(t *testing.T) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetDefaultLocalScopeSubnetter(), ipamutils.GetDefaultGlobalScopeSubnetter())
 	assert.NilError(t, err)
 
 	poolID, _, _, err := a.RequestPool(localAddressSpace, "172.28.0.0/16", "172.28.30.0/24", nil, false)
@@ -515,7 +515,7 @@ func TestRequestReleaseAddressFromSubPool(t *testing.T) {
 func TestSerializeRequestReleaseAddressFromSubPool(t *testing.T) {
 	opts := map[string]string{
 		ipamapi.AllocSerialPrefix: "true"}
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetDefaultLocalScopeSubnetter(), ipamutils.GetDefaultGlobalScopeSubnetter())
 	assert.NilError(t, err)
 
 	poolID, _, _, err := a.RequestPool(localAddressSpace, "172.28.0.0/16", "172.28.30.0/24", nil, false)
@@ -654,7 +654,7 @@ func TestRequestSyntaxCheck(t *testing.T) {
 		subPool = "192.168.0.0/24"
 	)
 
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetDefaultLocalScopeSubnetter(), ipamutils.GetDefaultGlobalScopeSubnetter())
 	assert.NilError(t, err)
 
 	_, _, _, err = a.RequestPool("", pool, "", nil, false)
@@ -800,7 +800,7 @@ func TestOverlappingRequests(t *testing.T) {
 	}
 
 	for _, tc := range input {
-		a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+		a, err := NewAllocator(ipamutils.GetDefaultLocalScopeSubnetter(), ipamutils.GetDefaultGlobalScopeSubnetter())
 		assert.NilError(t, err)
 
 		// Set up some existing allocations.  This should always succeed.
@@ -837,7 +837,7 @@ func TestUnusualSubnets(t *testing.T) {
 		{"192.168.0.3"},
 	}
 
-	allocator, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	allocator, err := NewAllocator(ipamutils.GetDefaultLocalScopeSubnetter(), ipamutils.GetDefaultGlobalScopeSubnetter())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -885,7 +885,7 @@ func TestRelease(t *testing.T) {
 		subnet = "192.168.0.0/23"
 	)
 
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetDefaultLocalScopeSubnetter(), ipamutils.GetDefaultGlobalScopeSubnetter())
 	assert.NilError(t, err)
 
 	pid, _, _, err := a.RequestPool(localAddressSpace, subnet, "", nil, false)
@@ -985,7 +985,7 @@ func assertNRequests(t *testing.T, subnet string, numReq int, lastExpectedIP str
 	)
 
 	lastIP := net.ParseIP(lastExpectedIP)
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetDefaultLocalScopeSubnetter(), ipamutils.GetDefaultGlobalScopeSubnetter())
 	assert.NilError(t, err)
 
 	pid, _, _, err := a.RequestPool(localAddressSpace, subnet, "", nil, false)
@@ -1027,7 +1027,7 @@ func BenchmarkRequest(b *testing.B) {
 	for _, subnet := range subnets {
 		name := fmt.Sprintf("%vSubnet", subnet)
 		b.Run(name, func(b *testing.B) {
-			a, _ := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+			a, _ := NewAllocator(ipamutils.GetDefaultLocalScopeSubnetter(), ipamutils.GetDefaultGlobalScopeSubnetter())
 			benchmarkRequest(b, a, subnet)
 		})
 	}
@@ -1041,7 +1041,7 @@ func TestAllocateRandomDeallocate(t *testing.T) {
 }
 
 func testAllocateRandomDeallocate(t *testing.T, pool, subPool string, num int, store bool) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetDefaultLocalScopeSubnetter(), ipamutils.GetDefaultGlobalScopeSubnetter())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1135,7 +1135,7 @@ func runParallelTests(t *testing.T, instance int) {
 	// The first instance creates the allocator, gives the start
 	// and finally checks the pools each instance was assigned
 	if instance == first {
-		allocator, err = NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+		allocator, err = NewAllocator(ipamutils.GetDefaultLocalScopeSubnetter(), ipamutils.GetDefaultGlobalScopeSubnetter())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1167,7 +1167,7 @@ func runParallelTests(t *testing.T, instance int) {
 }
 
 func TestRequestReleaseAddressDuplicate(t *testing.T) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetDefaultLocalScopeSubnetter(), ipamutils.GetDefaultGlobalScopeSubnetter())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/ipam/parallel_test.go
+++ b/libnetwork/ipam/parallel_test.go
@@ -37,7 +37,7 @@ type testContext struct {
 }
 
 func newTestContext(t *testing.T, mask int, options map[string]string) *testContext {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetDefaultLocalScopeSubnetter(), ipamutils.GetDefaultGlobalScopeSubnetter())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +77,7 @@ func (o *op) String() string {
 }
 
 func TestRequestPoolParallel(t *testing.T) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetDefaultLocalScopeSubnetter(), ipamutils.GetDefaultGlobalScopeSubnetter())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/ipam/structures.go
+++ b/libnetwork/ipam/structures.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/docker/libnetwork/bitmap"
 	"github.com/docker/docker/libnetwork/ipamapi"
+	"github.com/docker/docker/libnetwork/ipamutils"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -37,8 +38,11 @@ type addrSpace struct {
 	subnets map[netip.Prefix]*PoolData
 
 	// Predefined pool for the address space
-	predefined           []netip.Prefix
-	predefinedStartIndex int
+	predefined map[ipamutils.IPVersion]*ipamutils.Subnetter
+
+	// reset indicates whether the predefined subnetters can be reset when all subnets
+	// have been enumerated but some have been released.
+	reset map[ipamutils.IPVersion]bool
 
 	sync.Mutex
 }
@@ -155,6 +159,8 @@ func (aSpace *addrSpace) releaseSubnet(nw, sub netip.Prefix) error {
 	} else {
 		p.autoRelease = true
 	}
+
+	aSpace.reset[ipamutils.IPVerFromPrefix(nw)] = true
 
 	if len(p.children) == 0 && p.autoRelease {
 		delete(aSpace.subnets, nw)

--- a/libnetwork/ipam/utils.go
+++ b/libnetwork/ipam/utils.go
@@ -17,24 +17,6 @@ func toIPNet(p netip.Prefix) *net.IPNet {
 	}
 }
 
-func toPrefix(n *net.IPNet) (netip.Prefix, bool) {
-	if ll := len(n.Mask); ll != net.IPv4len && ll != net.IPv6len {
-		return netip.Prefix{}, false
-	}
-
-	addr, ok := netip.AddrFromSlice(n.IP)
-	if !ok {
-		return netip.Prefix{}, false
-	}
-
-	ones, bits := n.Mask.Size()
-	if ones == 0 && bits == 0 {
-		return netip.Prefix{}, false
-	}
-
-	return netip.PrefixFrom(addr.Unmap(), ones), true
-}
-
 func hostID(addr netip.Addr, bits uint) uint64 {
 	return ipbits.Field(addr, bits, uint(addr.BitLen()))
 }

--- a/libnetwork/ipamutils/utils.go
+++ b/libnetwork/ipamutils/utils.go
@@ -2,24 +2,61 @@
 package ipamutils
 
 import (
+	"errors"
 	"fmt"
-	"net"
+	"net/netip"
 	"sync"
+
+	"github.com/docker/docker/libnetwork/ipbits"
 )
 
 var (
-	// predefinedLocalScopeDefaultNetworks contains a list of 31 IPv4 private networks with host size 16 and 12
-	// (172.17-31.x.x/16, 192.168.x.x/20) which do not overlap with the networks in `PredefinedGlobalScopeDefaultNetworks`
-	predefinedLocalScopeDefaultNetworks []*net.IPNet
-	// predefinedGlobalScopeDefaultNetworks contains a list of 64K IPv4 private networks with host size 8
-	// (10.x.x.x/24) which do not overlap with the networks in `PredefinedLocalScopeDefaultNetworks`
-	predefinedGlobalScopeDefaultNetworks []*net.IPNet
-	mutex                                sync.Mutex
-	localScopeDefaultNetworks            = []*NetworkToSplit{{"172.17.0.0/16", 16}, {"172.18.0.0/16", 16}, {"172.19.0.0/16", 16},
-		{"172.20.0.0/14", 16}, {"172.24.0.0/14", 16}, {"172.28.0.0/14", 16},
-		{"192.168.0.0/16", 20}}
-	globalScopeDefaultNetworks = []*NetworkToSplit{{"10.0.0.0/8", 24}}
+	// defaultLocalScopeSubnetter contains a list of 31 IPv4 private networks with host size 16 and 12
+	// (172.17-31.x.x/16, 192.168.x.x/20) which do not overlap with the networks in `defaultGlobalScopeSubnetter`
+	defaultLocalScopeSubnetter Subnetter
+	// defaultGlobalScopeSubnetter contains a list of 64K IPv4 private networks with host size 8
+	// (10.x.x.x/24) which do not overlap with the networks in `defaultLocalScopeSubnetter`
+	defaultGlobalScopeSubnetter Subnetter
+	mutex                       sync.Mutex
+	defaultLocalScopeNetworks   = []*NetworkToSplit{
+		{Base: "172.17.0.0/16", Size: 16},
+		{Base: "172.18.0.0/16", Size: 16},
+		{Base: "172.19.0.0/16", Size: 16},
+		{Base: "172.20.0.0/14", Size: 16},
+		{Base: "172.24.0.0/14", Size: 16},
+		{Base: "172.28.0.0/14", Size: 16},
+		{Base: "192.168.0.0/16", Size: 20}}
+	defaultGlobalScopeNetworks = []*NetworkToSplit{
+		{Base: "10.0.0.0/8", Size: 24}}
 )
+
+// IPVersion represents the type of IP address.
+type IPVersion int
+
+// Constants for the IP address types.
+const (
+	IPv4 IPVersion = 4
+	IPv6 IPVersion = 6
+)
+
+func IPVerFromPrefix(p netip.Prefix) IPVersion {
+	if p.Addr().BitLen() == 32 {
+		return IPv4
+	}
+	return IPv6
+}
+
+// AddrLen returns the length in bits of an address
+func (ipVer IPVersion) AddrLen() int {
+	switch {
+	case ipVer == IPv4:
+		return 32
+	case ipVer == IPv6:
+		return 128
+	default:
+		panic(fmt.Sprintf("IPv%d is an invalid version of IP protocol", ipVer))
+	}
+}
 
 // NetworkToSplit represent a network that has to be split in chunks with mask length Size.
 // Each subnet in the set is derived from the Base pool. Base is to be passed
@@ -27,17 +64,22 @@ var (
 // Example: a Base "10.10.0.0/16 with Size 24 will define the set of 256
 // 10.10.[0-255].0/24 address pools
 type NetworkToSplit struct {
-	Base string `json:"base"`
-	Size int    `json:"size"`
+	Base      string
+	Size      int
+	ipVersion IPVersion
+	// maxOffset stores the number of iterations that could be done on Base to produce subnets of the desired Size
+	maxOffset uint64
+	// Used to cache the transformation of Base into netip.Prefix
+	prefix netip.Prefix
 }
 
 func init() {
 	var err error
-	if predefinedGlobalScopeDefaultNetworks, err = SplitNetworks(globalScopeDefaultNetworks); err != nil {
+	if defaultGlobalScopeSubnetter, err = NewSubnetter(defaultGlobalScopeNetworks); err != nil {
 		panic("failed to initialize the global scope default address pool: " + err.Error())
 	}
 
-	if predefinedLocalScopeDefaultNetworks, err = SplitNetworks(localScopeDefaultNetworks); err != nil {
+	if defaultLocalScopeSubnetter, err = NewSubnetter(defaultLocalScopeNetworks); err != nil {
 		panic("failed to initialize the local scope default address pool: " + err.Error())
 	}
 }
@@ -50,68 +92,134 @@ func ConfigGlobalScopeDefaultNetworks(defaultAddressPool []*NetworkToSplit) erro
 	}
 	mutex.Lock()
 	defer mutex.Unlock()
-	defaultNetworks, err := SplitNetworks(defaultAddressPool)
+	defaultSubnetter, err := NewSubnetter(defaultAddressPool)
 	if err != nil {
 		return err
 	}
-	predefinedGlobalScopeDefaultNetworks = defaultNetworks
+	defaultGlobalScopeSubnetter = defaultSubnetter
 	return nil
 }
 
-// GetGlobalScopeDefaultNetworks returns a copy of the global-sopce network list.
-func GetGlobalScopeDefaultNetworks() []*net.IPNet {
+// GetDefaultGlobalScopeSubnetter returns a copy of the default global-sopce Subnetter.
+func GetDefaultGlobalScopeSubnetter() Subnetter {
 	mutex.Lock()
 	defer mutex.Unlock()
-	return append([]*net.IPNet(nil), predefinedGlobalScopeDefaultNetworks...)
+	return defaultGlobalScopeSubnetter
 }
 
-// GetLocalScopeDefaultNetworks returns a copy of the default local-scope network list.
-func GetLocalScopeDefaultNetworks() []*net.IPNet {
-	return append([]*net.IPNet(nil), predefinedLocalScopeDefaultNetworks...)
+// GetDefaultLocalScopeSubnetter returns a copy of the default local-scope Subnetter.
+func GetDefaultLocalScopeSubnetter() Subnetter {
+	return defaultLocalScopeSubnetter
 }
 
-// SplitNetworks takes a slice of networks, split them accordingly and returns them
-func SplitNetworks(list []*NetworkToSplit) ([]*net.IPNet, error) {
-	localPools := make([]*net.IPNet, 0, len(list))
+// Subnetter is an iterator lazily enumerating subnets from its NetworkToSplit. IPv6
+// subnets can't be enumerated eagerly, otherwise they might end up taking way too much
+// memory (eg. fd00::/8 split into /96). See https://github.com/moby/moby/issues/40275.
+// Subnetter is not safe for concurrent use.
+type Subnetter struct {
+	networks []NetworkToSplit
+	// index tracks what NetworkToSplit should be used for next allocation.
+	index int
+	// offset tracks how much of the current NetworkToSplit (indicated by index) has been consumed so far. It's
+	// reset every time index changes.
+	offset uint64
+}
 
-	for _, p := range list {
-		_, b, err := net.ParseCIDR(p.Base)
+// NewSubnetter creates a Subnetter from a list of NetworkToSplit. It returns an error if one of the
+// provided network is invalid (ie could not be parsed or wanted subnet Size is smaller than Base mask).
+func NewSubnetter(networks []*NetworkToSplit) (Subnetter, error) {
+	nets := make([]NetworkToSplit, len(networks))
+	for i, network := range networks {
+		nw := NetworkToSplit{Base: network.Base, Size: network.Size}
+		p, err := netip.ParsePrefix(nw.Base)
 		if err != nil {
-			return nil, fmt.Errorf("invalid base pool %q: %v", p.Base, err)
+			return Subnetter{}, fmt.Errorf("invalid base pool %q: %v", nw.Base, err)
 		}
-		ones, _ := b.Mask.Size()
-		if p.Size <= 0 || p.Size < ones {
-			return nil, fmt.Errorf("invalid pools size: %d", p.Size)
+
+		ones := p.Bits()
+		if nw.Size <= 0 || nw.Size < ones {
+			return Subnetter{}, fmt.Errorf("invalid pools size: %d", nw.Size)
 		}
-		localPools = append(localPools, splitNetwork(p.Size, b)...)
+
+		nw.prefix = p
+		nw.ipVersion = IPVerFromPrefix(p)
+		// When there's more than 2^64 subnets that could be enumerated from a network, just cap maxOffset
+		// to 2^64 as this is already a number that couldn't be realistically reached.
+		if nw.Size-ones > 64 {
+			nw.maxOffset = 1<<64 - 1
+		} else {
+			nw.maxOffset = 1<<uint(nw.Size-ones) - 1
+		}
+
+		nets[i] = nw
 	}
-	return localPools, nil
+
+	return Subnetter{
+		networks: nets,
+	}, nil
 }
 
-func splitNetwork(size int, base *net.IPNet) []*net.IPNet {
-	one, bits := base.Mask.Size()
-	mask := net.CIDRMask(size, bits)
-	n := 1 << uint(size-one)
-	s := uint(bits - size)
-	list := make([]*net.IPNet, 0, n)
-
-	for i := 0; i < n; i++ {
-		ip := copyIP(base.IP)
-		addIntToIP(ip, uint(i<<s))
-		list = append(list, &net.IPNet{IP: ip, Mask: mask})
-	}
-	return list
+// Reset resets the internal position of the iterator to the start of the collection.
+func (s *Subnetter) Reset() {
+	s.index = 0
+	s.offset = 0
 }
 
-func copyIP(from net.IP) net.IP {
-	ip := make([]byte, len(from))
-	copy(ip, from)
-	return ip
+// ipVerSubset returns a new Subnetter containing only IPv4 or IPv6 networks depending on ipVersion parameter.
+func (s *Subnetter) ipVerSubset(ipVersion IPVersion) *Subnetter {
+	newS := &Subnetter{
+		networks: make([]NetworkToSplit, 0),
+	}
+
+	for _, nw := range s.networks {
+		if nw.ipVersion == ipVersion {
+			newS.networks = append(newS.networks, nw)
+		}
+	}
+
+	return newS
 }
 
-func addIntToIP(array net.IP, ordinal uint) {
-	for i := len(array) - 1; i >= 0; i-- {
-		array[i] |= (byte)(ordinal & 0xff)
-		ordinal >>= 8
+func (s *Subnetter) V4() *Subnetter {
+	return s.ipVerSubset(IPv4)
+}
+
+func (s *Subnetter) V6() *Subnetter {
+	return s.ipVerSubset(IPv6)
+}
+
+// EndReached indicates whether there's at least one remaining subnet from its NetworkToSplit.
+func (s *Subnetter) EndReached() bool {
+	if s.index >= len(s.networks) {
+		return true
 	}
+	if len(s.networks) == 0 {
+		return true
+	}
+	return false
+}
+
+var ErrNoMoreSubnet = errors.New("no more subnet available")
+
+// NextSubnet returns a new subnet from its NetworkToSplit, or an error if all subnets have already been enumerated.
+func (s *Subnetter) NextSubnet() (netip.Prefix, error) {
+	if s.EndReached() {
+		return netip.Prefix{}, ErrNoMoreSubnet
+	}
+
+	nw := s.networks[s.index]
+	base := nw.prefix
+
+	ordinal := uint(nw.ipVersion.AddrLen() - nw.Size)
+	addr := ipbits.Add(base.Addr(), s.offset, ordinal)
+	subnet := netip.PrefixFrom(addr, nw.Size)
+
+	if s.offset == nw.maxOffset {
+		s.index++
+		s.offset = 0
+	} else if s.offset < nw.maxOffset {
+		s.offset++
+	}
+
+	return subnet, nil
 }

--- a/libnetwork/ipamutils/utils_test.go
+++ b/libnetwork/ipamutils/utils_test.go
@@ -2,6 +2,7 @@ package ipamutils
 
 import (
 	"net"
+	"net/netip"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -44,15 +45,17 @@ func initGlobalScopeNetworks() []*net.IPNet {
 }
 
 func TestDefaultNetwork(t *testing.T) {
-	for _, nw := range GetGlobalScopeDefaultNetworks() {
-		if ones, bits := nw.Mask.Size(); bits != 32 || ones != 24 {
-			t.Fatalf("Unexpected size for network in granular list: %v", nw)
+	globalNetworks := GetDefaultGlobalScopeSubnetter()
+	for nw, err := globalNetworks.NextSubnet(); err == nil; nw, err = globalNetworks.NextSubnet() {
+		if bits := nw.Bits(); bits != 24 {
+			t.Fatalf("Unexpected size for network in global list: %v", nw)
 		}
 	}
 
-	for _, nw := range GetLocalScopeDefaultNetworks() {
-		if ones, bits := nw.Mask.Size(); bits != 32 || (ones != 20 && ones != 16) {
-			t.Fatalf("Unexpected size for network in broad list: %v", nw)
+	localNetworks := GetDefaultLocalScopeSubnetter()
+	for nw, err := localNetworks.NextSubnet(); err == nil; nw, err = localNetworks.NextSubnet() {
+		if bits := nw.Bits(); bits != 20 && bits != 16 {
+			t.Fatalf("Unexpected size for network in local list: %v", nw)
 		}
 	}
 
@@ -61,7 +64,8 @@ func TestDefaultNetwork(t *testing.T) {
 	for _, v := range originalBroadNets {
 		m[v.String()] = true
 	}
-	for _, nw := range GetLocalScopeDefaultNetworks() {
+	localNetworks = GetDefaultLocalScopeSubnetter()
+	for nw, err := localNetworks.NextSubnet(); err == nil; nw, err = localNetworks.NextSubnet() {
 		_, ok := m[nw.String()]
 		assert.Check(t, ok)
 		delete(m, nw.String())
@@ -75,7 +79,8 @@ func TestDefaultNetwork(t *testing.T) {
 	for _, v := range originalGranularNets {
 		m[v.String()] = true
 	}
-	for _, nw := range GetGlobalScopeDefaultNetworks() {
+	globalNetworks = GetDefaultGlobalScopeSubnetter()
+	for nw, err := globalNetworks.NextSubnet(); err == nil; nw, err = globalNetworks.NextSubnet() {
 		_, ok := m[nw.String()]
 		assert.Check(t, ok)
 		delete(m, nw.String())
@@ -85,7 +90,7 @@ func TestDefaultNetwork(t *testing.T) {
 }
 
 func TestConfigGlobalScopeDefaultNetworks(t *testing.T) {
-	err := ConfigGlobalScopeDefaultNetworks([]*NetworkToSplit{{"30.0.0.0/8", 24}})
+	err := ConfigGlobalScopeDefaultNetworks([]*NetworkToSplit{{Base: "30.0.0.0/8", Size: 24}})
 	assert.NilError(t, err)
 
 	originalGlobalScopeNetworks := initGlobalScopeNetworks()
@@ -93,11 +98,98 @@ func TestConfigGlobalScopeDefaultNetworks(t *testing.T) {
 	for _, v := range originalGlobalScopeNetworks {
 		m[v.String()] = true
 	}
-	for _, nw := range GetGlobalScopeDefaultNetworks() {
-		_, ok := m[nw.String()]
+	globalNetworks := GetDefaultGlobalScopeSubnetter()
+	for nw, err := globalNetworks.NextSubnet(); err == nil; nw, err = globalNetworks.NextSubnet() {
+		str := nw.String()
+		_, ok := m[str]
 		assert.Check(t, ok)
-		delete(m, nw.String())
+		delete(m, str)
 	}
 
 	assert.Check(t, is.Len(m, 0))
+}
+
+func TestSubnetter(t *testing.T) {
+	s, err := NewSubnetter([]*NetworkToSplit{
+		{Base: "172.80.0.0/16", Size: 24},
+		{Base: "172.90.0.0/16", Size: 24}})
+	assert.NilError(t, err)
+
+	var nets []netip.Prefix
+	for i := 0; i < 512; i++ {
+		if nw, err := s.NextSubnet(); err == nil {
+			nets = append(nets, nw)
+		} else {
+			t.Fatal("Subnetter is smaller than expected.")
+		}
+	}
+
+	assert.Check(t, is.Equal(nets[0].String(), "172.80.0.0/24"))
+	assert.Check(t, is.Equal(nets[127].String(), "172.80.127.0/24"))
+	assert.Check(t, is.Equal(nets[255].String(), "172.80.255.0/24"))
+	assert.Check(t, is.Equal(nets[256].String(), "172.90.0.0/24"))
+	assert.Check(t, is.Equal(nets[383].String(), "172.90.127.0/24"))
+	assert.Check(t, is.Equal(nets[511].String(), "172.90.255.0/24"))
+}
+
+func TestInitPoolWithIPv6(t *testing.T) {
+	s, err := NewSubnetter([]*NetworkToSplit{
+		{Base: "2001:db8:1:1f00::/64", Size: 96},
+		{Base: "fd00::/8", Size: 96},
+		{Base: "fd00::/16", Size: 32},
+		{Base: "fd00:0:0:fff0::/63", Size: 65},
+		{Base: "fd00::/16", Size: 72},
+	})
+	assert.NilError(t, err)
+
+	// Iterating over the Subnetter would be way too long, so better change its offset and see what
+	// NextSubnet() returns.
+	s.offset = (1 << 32) - 1
+	nw, err := s.NextSubnet()
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(nw.String(), "2001:db8:1:1f00:ffff:ffff::/96"))
+
+	s.index = 1
+	s.offset = (1 << 64) - 1
+	nw, err = s.NextSubnet()
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(nw.String(), "fd00:0:ffff:ffff:ffff:ffff::/96"))
+
+	// Previous Get() call incremented index by 1. Next call yields a subnet from the 3rd NetworkToSplit.
+	nw, err = s.NextSubnet()
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(nw.String(), "fd00::/32"))
+
+	s.index = 2
+	s.offset = (1 << 16) - 3
+	nw, err = s.NextSubnet()
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(nw.String(), "fd00:fffd::/32"))
+
+	s.index = 3
+	s.offset = 1
+	nw, err = s.NextSubnet()
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(nw.String(), "fd00:0:0:fff0:8000::/65"))
+
+	s.index = 3
+	s.offset = 2
+	nw, err = s.NextSubnet()
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(nw.String(), "fd00:0:0:fff1::/65"))
+
+	s.index = 4
+	s.offset = 2000
+	nw, err = s.NextSubnet()
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(nw.String(), "fd00:0:0:7:d000::/72"))
+
+	s.offset = 1<<56 - 1
+	nw, err = s.NextSubnet()
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(nw.String(), "fd00:ffff:ffff:ffff:ff00::/72"))
+
+	// After the Subnetter yields the last subnet from the last NetworkToSplit, it should then return ErrNoMoreSubnet.
+	_, err = s.NextSubnet()
+	assert.ErrorIs(t, err, ErrNoMoreSubnet)
 }


### PR DESCRIPTION
I bundled these two commits together as the second one is easier to test with changes done in the first one. I can still break this PR into two parts and rewrite the unit test of the second commit to test it with the current master branch. Let me know if you prefer that (eg. if you want to cherry-pick this change into older releases or because it's a big diff to review).

**- 1st commit**

This commit resolves #40275 by implementing a custom iterator
named NetworkSplitter. It splits a set of NetworkToSplit into smaller
subnets on-demand by calling its Get method.

Prior to this change, the list of NetworkToSplit was split into smaller
subnets when ConfigLocalScopeDefaultNetworks or
ConfigGlobalScopeDefaultNetworks were called or when ipamutils package
was loaded. When one of the Config function was called with an IPv6 net
to split into small subnets all the available memory was consumed. For
instance, fd00::/8 split into /96 would take ~5*10^27 bytes.

Although this change trades memory consumption for computation cost, the
NetworkSplitter is used by libnetwork/ipam package in such a way that it
only have to compute the address of the next subnet. When
NetworkSplitter reach the end of NetworkToSplit, it's resetted by
libnetwork/ipam only if there were some subnets released beforehand. In
such case, ipam package might iterate over all the subnets before
finding one available subnet. This is the worst-case but it shall not be
really impactful as either many subnets exists (more than one host can
handle) or not so many subnets exists and full iteration over
NetworkSplitter is fast.

**- 2nd commit**

Prior to this change, IPv6 subnets generation was broken because of a
bitwise shift overflowing uint64.

To solve this issue, addIntToIP has been changed to take an addend and
computes two ordinals applied to respectively the lower 64 bits and the
upper 64 bits of IPv6 addresses.

Nothing change for IPv4 (ie. upperOrdinal is always 0).

**- How to verify it**

I added unit tests to confirm these changes are okay. Moreover, I tried to run dockerd with following config:

```json
{
	"log-level": "info",
	"ipv6": true,
	"experimental": true,
	"ip6tables": true,
	"fixed-cidr-v6": "2a01:e34:xxxx:yyyy::/64",
	"default-address-pools": [
		{ "base": "172.17.0.0/16", "size": 16 },
		{ "base": "172.18.0.0/16", "size": 16 },
		{ "base": "2a01:e34:xxxx:yyyy::/64", "size": 120 }
	]
}
```

When starting dockerd v20.10.10 with this config, the daemon crashes with this panic message message: `runtime error: makeslice: cap out of range`. When starting a patched version of dockerd, it doesn't crash.

**- Description for the changelog**

* Generate split subnets on-demand to not consume all the available memory when small IPv6 subnets are created from big subnets (fixes #40275)
* Properly shift bytes of IPv6 subnets (fixes #42801)

