### PR TITLE
Fix missing parent info case in MatchesUsingParentResults

### DIFF
--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -251,7 +251,7 @@ func (pm *PatternMatcher) MatchesUsingParentResults(file string, parentMatchInfo
 			// If the zero value of MatchInfo was passed in, we don't have
 			// any information about the parent dir's match results, and we
 			// apply the same logic as MatchesOrParentMatches.
-			if len(parentMatched) == 0 {
+			if !match && len(parentMatched) == 0 {
 				if parentPath := filepath.Dir(file); parentPath != "." {
 					parentPathDirs := strings.Split(parentPath, string(os.PathSeparator))
 					// Check to see if the pattern matches one of our parent dirs.

--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -465,6 +465,30 @@ func TestMatches(t *testing.T) {
 			check(pm, test.text, test.pass, desc)
 		}
 	})
+
+	t.Run("MatchesUsingParentResultsNoContext", func(t *testing.T) {
+		check := func(pm *PatternMatcher, text string, pass bool, desc string) {
+			res, _, _ := pm.MatchesUsingParentResults(text, MatchInfo{})
+			assert.Check(t, is.Equal(pass, res), desc)
+		}
+
+		for _, test := range tests {
+			desc := fmt.Sprintf("pattern=%q text=%q", test.pattern, test.text)
+			pm, err := NewPatternMatcher([]string{test.pattern})
+			assert.NilError(t, err, desc)
+
+			check(pm, test.text, test.pass, desc)
+		}
+
+		for _, test := range multiPatternTests {
+			desc := fmt.Sprintf("pattern=%q text=%q", test.patterns, test.text)
+			pm, err := NewPatternMatcher(test.patterns)
+			assert.NilError(t, err, desc)
+
+			check(pm, test.text, test.pass, desc)
+		}
+	})
+
 }
 
 func TestCleanPatterns(t *testing.T) {


### PR DESCRIPTION
Unfortunately, this check was missing in the original version. It could
cause a positive match to be overwritten by checking parent dirs.