### PR TITLE
Check iptables options before looking for ip6tables binary

### DIFF
--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -56,7 +55,6 @@ var (
 	iptablesPath  string
 	ip6tablesPath string
 	supportsXlock = false
-	supportsCOpt  = false
 	xLockWaitMsg  = "Another app is currently holding the xtables lock"
 	// used to lock iptables commands if xtables lock is not supported
 	bestEffortLock sync.Mutex
@@ -96,17 +94,12 @@ func detectIptables() {
 	}
 	iptablesPath = path
 
+	// The --wait flag was added in iptables v1.6.0.
+	// TODO remove this check once we drop support for CentOS/RHEL 7, which uses an older version of iptables
 	if out, err := exec.Command(path, "--wait", "-L", "-n").CombinedOutput(); err != nil {
 		logrus.WithError(err).Infof("unable to detect if iptables supports xlock: 'iptables --wait -L -n': `%s`", strings.TrimSpace(string(out)))
 	} else {
 		supportsXlock = true
-	}
-
-	mj, mn, mc, err := GetVersion()
-	if err != nil {
-		logrus.Warnf("Failed to read iptables version: %v", err)
-	} else {
-		supportsCOpt = supportsCOption(mj, mn, mc)
 	}
 
 	path, err = exec.LookPath("ip6tables")
@@ -463,26 +456,9 @@ func (iptable IPTable) exists(native bool, table Table, chain string, rule ...st
 		return false
 	}
 
-	if supportsCOpt {
-		// if exit status is 0 then return true, the rule exists
-		_, err := f(append([]string{"-t", string(table), "-C", chain}, rule...)...)
-		return err == nil
-	}
-
-	// parse "iptables -S" for the rule (it checks rules in a specific chain
-	// in a specific table and it is very unreliable)
-	return iptable.existsRaw(table, chain, rule...)
-}
-
-func (iptable IPTable) existsRaw(table Table, chain string, rule ...string) bool {
-	path := iptablesPath
-	if iptable.Version == IPv6 {
-		path = ip6tablesPath
-	}
-	ruleString := fmt.Sprintf("%s %s\n", chain, strings.Join(rule, " "))
-	existingRules, _ := exec.Command(path, "-t", string(table), "-S", chain).Output()
-
-	return strings.Contains(string(existingRules), ruleString)
+	// if exit status is 0 then return true, the rule exists
+	_, err := f(append([]string{"-t", string(table), "-C", chain}, rule...)...)
+	return err == nil
 }
 
 // Maximum duration that an iptables operation can take
@@ -580,34 +556,12 @@ func (iptable IPTable) ExistChain(chain string, table Table) bool {
 	return false
 }
 
-// GetVersion reads the iptables version numbers during initialization
-func GetVersion() (major, minor, micro int, err error) {
-	out, err := exec.Command(iptablesPath, "--version").CombinedOutput()
-	if err == nil {
-		major, minor, micro = parseVersionNumbers(string(out))
-	}
-	return
-}
-
 // SetDefaultPolicy sets the passed default policy for the table/chain
 func (iptable IPTable) SetDefaultPolicy(table Table, chain string, policy Policy) error {
 	if err := iptable.RawCombinedOutput("-t", string(table), "-P", chain, string(policy)); err != nil {
 		return fmt.Errorf("setting default policy to %v in %v chain failed: %v", policy, chain, err)
 	}
 	return nil
-}
-
-func parseVersionNumbers(input string) (major, minor, micro int) {
-	re := regexp.MustCompile(`v\d*.\d*.\d*`)
-	line := re.FindString(input)
-	fmt.Sscanf(line, "v%d.%d.%d", &major, &minor, &micro)
-	return
-}
-
-// iptables -C, --check option was added in v.1.4.11
-// http://ftp.netfilter.org/pub/iptables/changes-iptables-1.4.11.txt
-func supportsCOption(mj, mn, mc int) bool {
-	return mj > 1 || (mj == 1 && (mn > 4 || (mn == 4 && mc >= 11)))
 }
 
 // AddReturnRule adds a return rule for the chain in the filter table

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -116,11 +116,7 @@ func detectIptables() {
 		return
 	}
 	iptablesPath = path
-	path, err = exec.LookPath("ip6tables")
-	if err != nil {
-		return
-	}
-	ip6tablesPath = path
+
 	supportsXlock = exec.Command(iptablesPath, "--wait", "-L", "-n").Run() == nil
 	mj, mn, mc, err := GetVersion()
 	if err != nil {
@@ -128,6 +124,13 @@ func detectIptables() {
 		return
 	}
 	supportsCOpt = supportsCOption(mj, mn, mc)
+
+	path, err = exec.LookPath("ip6tables")
+	if err != nil {
+		return
+	} else {
+		ip6tablesPath = path
+	}
 }
 
 func initDependencies() {

--- a/libnetwork/iptables/iptables_test.go
+++ b/libnetwork/iptables/iptables_test.go
@@ -284,44 +284,15 @@ func TestExistsRaw(t *testing.T) {
 		if err != nil {
 			t.Fatalf("i=%d, err: %v", i, err)
 		}
-		if !iptable.existsRaw(Filter, testChain1, r.rule...) {
+		if !iptable.exists(true, Filter, testChain1, r.rule...) {
 			t.Fatalf("Failed to detect rule. i=%d", i)
 		}
 		// Truncate the rule
 		trg := r.rule[len(r.rule)-1]
 		trg = trg[:len(trg)-2]
 		r.rule[len(r.rule)-1] = trg
-		if iptable.existsRaw(Filter, testChain1, r.rule...) {
+		if iptable.exists(true, Filter, testChain1, r.rule...) {
 			t.Fatalf("Invalid detection. i=%d", i)
-		}
-	}
-}
-
-func TestGetVersion(t *testing.T) {
-	mj, mn, mc := parseVersionNumbers("iptables v1.4.19.1-alpha")
-	if mj != 1 || mn != 4 || mc != 19 {
-		t.Fatal("Failed to parse version numbers")
-	}
-}
-
-func TestSupportsCOption(t *testing.T) {
-	input := []struct {
-		mj int
-		mn int
-		mc int
-		ok bool
-	}{
-		{1, 4, 11, true},
-		{1, 4, 12, true},
-		{1, 5, 0, true},
-		{0, 4, 11, false},
-		{0, 5, 12, false},
-		{1, 3, 12, false},
-		{1, 4, 10, false},
-	}
-	for ind, inp := range input {
-		if inp.ok != supportsCOption(inp.mj, inp.mn, inp.mc) {
-			t.Fatalf("Incorrect check: %d", ind)
 		}
 	}
 }


### PR DESCRIPTION
**- What I did**

#### Check iptables options before looking for ip6tables

iptables package has a function `detectIptables()` called to initialize
some local variables. Since v20.10.0, it first looks for iptables bin,
then ip6tables and finally it checks what iptables flags are available
(including -C). It early exits when ip6tables isn't available, and
doesn't execute the last check.

To remove port mappings (eg. when a container stops/dies), Docker
first checks if those NAT rules exist and then deletes them. However, in
the particular case where there's no ip6tables bin available, iptables
`-C` flag is considered unavailable and thus it looks for NAT rules by
using some substring matching. This substring matching then fails
because `iptables -t nat -S POSTROUTING` dumps rules in a slighly different format
than what's expected.

For instance, here's what `iptables -t nat -S POSTROUTING` dumps:

```
-A POSTROUTING -s 172.18.0.2/32 -d 172.18.0.2/32 -p tcp -m tcp --dport 9999 -j MASQUERADE
```

And here's what Docker looks for:

```
POSTROUTING -p tcp -s 172.18.0.2 -d 172.18.0.2 --dport 9999 -j MASQUERADE
```

Because of that, those rules are considered non-existent by Docker and
thus never deleted. To fix that, this change reorders the code in
`detectIptables()`.


Fixes #42127.

#### Merge iptables.probe() into iptables.detectIptables() 

The former was doing some checks and logging warnings, whereas
the latter was doing the same checks but to set some internal variables.
As both are called only once and from the same place,
there're now merged together.

#### Always use iptables -C to look for rules 

iptables -C flag was introduced in v1.4.11, which was released ten
years ago. Thus, there're no more Linux distributions supported by
Docker using this version. As such, this commit removes the old way of
checking if an iptables rule exists (by using substring matching).

For reference, here's the list of versions of iptables for each supported distribution:

* Centos 7: 1.4.21
* Centos 8: 1.8.4
* Debian 11: 1.8.7
* Debian 10: 1.8.2
* Fedora 34: 1.8.7
* Fedora 35: 1.8.7
* RHEL 7: 1.4.21
* RHEL 8:
  * Most recent: 1.8.4
  * Oldest: 1.8.2
* SLES 15-SP2: 1.8.7
* SLES 15-SP3: 1.8.7
* Ubuntu Impish 21.10: 1.8.7
* Ubuntu Hirsute 21.04: 1.8.7
* Ubuntu Focal 20.04 (LTS): 1.8.4
* Ubuntu Bionic 18.04 (LTS): 1.6.1

**- How to verify it**

To test the 1st commit, you have to follow these steps:

* `make shell`
* And then in the container, `rm /usr/sbin/ip6tables`
* Start dockerd
* Run `docker run --rm -ti -p 9999:9999 hello-world`
* `iptables -t nat -L`

**This commit would require to bump the required version of iptables from v1.4 to v1.4.11.**

**- Description for the changelog**

`Fix NAT rules not being deleted when ip6tables binary isn't available`