### PR TITLE
docker-rootless-setuptools.sh: use context after install

### DIFF
--- a/contrib/dockerd-rootless-setuptool.sh
+++ b/contrib/dockerd-rootless-setuptool.sh
@@ -364,6 +364,11 @@ cli_ctx_create() {
 	"${BIN}/docker" context create "${name}" --docker "host=${host}" --description "${description}" > /dev/null
 }
 
+cli_ctx_use() {
+	name="$1"
+	"${BIN}/docker" context use "${name}" > /dev/null
+}
+
 cli_ctx_rm() {
 	name="$1"
 	"${BIN}/docker" context rm -f "${name}" > /dev/null
@@ -385,6 +390,9 @@ cmd_entrypoint_install() {
 		cli_ctx_create "${CLI_CONTEXT}" "unix://${XDG_RUNTIME_DIR}/docker.sock" "Rootless mode"
 	fi
 
+	INFO "Use CLI context \"${CLI_CONTEXT}\""
+	cli_ctx_use "${CLI_CONTEXT}"
+
 	echo
 	INFO "Make sure the following environment variables are set (or add them to ~/.bashrc):"
 	echo
@@ -393,6 +401,7 @@ cmd_entrypoint_install() {
 		echo "export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}"
 	fi
 	echo "export PATH=${BIN}:\$PATH"
+	echo "Some applications may require the following environment variable too:"
 	echo "export DOCKER_HOST=unix://${XDG_RUNTIME_DIR}/docker.sock"
 	echo
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

`use` the rootless context after installation. closes #43020 

**- How I did it**

**- How to verify it**

```
$ contrib/dockerd-rootless-setuptool.sh install
...

[INFO] Creating CLI context "rootless"
Successfully created context "rootless"
[INFO] Use CLI context "rootless"
Current context is now "rootless"

[INFO] Make sure the following environment variables are set (or add them to ~/.bashrc):

export PATH=/usr/bin:$PATH
export DOCKER_HOST=unix:///run/user/1001/docker.sock
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

docker-rootless-setuptools.sh: `use` the rootless context after installation

**- A picture of a cute animal (not mandatory but encouraged)**
🐓
