### PR TITLE
Revert "Added API to set ephemeral port allocator range."

### DIFF
--- a/libnetwork/config/config.go
+++ b/libnetwork/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -10,7 +9,6 @@ import (
 	"github.com/docker/docker/libnetwork/ipamutils"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/osl"
-	"github.com/docker/docker/libnetwork/portallocator"
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/libkv/store"
 	"github.com/pelletier/go-toml"
@@ -160,23 +158,6 @@ func OptionExperimental(exp bool) Option {
 	return func(c *Config) {
 		logrus.Debugf("Option Experimental: %v", exp)
 		c.Daemon.Experimental = exp
-	}
-}
-
-// OptionDynamicPortRange function returns an option setter for service port allocation range
-func OptionDynamicPortRange(in string) Option {
-	return func(c *Config) {
-		start, end := 0, 0
-		if len(in) > 0 {
-			n, err := fmt.Sscanf(in, "%d-%d", &start, &end)
-			if n != 2 || err != nil {
-				logrus.Errorf("Failed to parse range string with err %v", err)
-				return
-			}
-		}
-		if err := portallocator.Get().SetPortRange(start, end); err != nil {
-			logrus.Errorf("Failed to set port range with err %v", err)
-		}
 	}
 }
 

--- a/libnetwork/portallocator/portallocator.go
+++ b/libnetwork/portallocator/portallocator.go
@@ -91,8 +91,8 @@ func Get() *PortAllocator {
 func newInstance() *PortAllocator {
 	start, end, err := getDynamicPortRange()
 	if err != nil {
-		logrus.WithError(err).Infof("falling back to default port range %d-%d", DefaultPortRangeStart, DefaultPortRangeEnd)
-		start, end = DefaultPortRangeStart, DefaultPortRangeEnd
+		logrus.WithError(err).Infof("falling back to default port range %d-%d", defaultPortRangeStart, defaultPortRangeEnd)
+		start, end = defaultPortRangeStart, defaultPortRangeEnd
 	}
 	return &PortAllocator{
 		ipMap: ipMapping{},

--- a/libnetwork/portallocator/portallocator.go
+++ b/libnetwork/portallocator/portallocator.go
@@ -9,22 +9,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func sanitizePortRange(start int, end int) (newStart, newEnd int, err error) {
-	if start > defaultPortRangeEnd || end < defaultPortRangeStart || start > end {
-		return 0, 0, fmt.Errorf("Request out allowed range [%v, %v]",
-			defaultPortRangeStart, defaultPortRangeEnd)
-	}
-	err = nil
-	newStart, newEnd = start, end
-	if start < defaultPortRangeStart {
-		newStart = defaultPortRangeStart
-	}
-	if end > defaultPortRangeEnd {
-		newEnd = defaultPortRangeEnd
-	}
-	return
-}
-
 type ipMapping map[string]protoMap
 
 var (
@@ -104,20 +88,12 @@ func Get() *PortAllocator {
 	return instance
 }
 
-func getDefaultPortRange() (int, int) {
-	start, end, err := getDynamicPortRange()
-	if err == nil {
-		start, end, err = sanitizePortRange(start, end)
-	}
-	if err != nil {
-		logrus.WithError(err).Infof("falling back to default port range %d-%d", defaultPortRangeStart, defaultPortRangeEnd)
-		start, end = defaultPortRangeStart, defaultPortRangeEnd
-	}
-	return start, end
-}
-
 func newInstance() *PortAllocator {
-	start, end := getDefaultPortRange()
+	start, end, err := getDynamicPortRange()
+	if err != nil {
+		logrus.WithError(err).Infof("falling back to default port range %d-%d", DefaultPortRangeStart, DefaultPortRangeEnd)
+		start, end = DefaultPortRangeStart, DefaultPortRangeEnd
+	}
 	return &PortAllocator{
 		ipMap: ipMapping{},
 		Begin: start,
@@ -188,30 +164,6 @@ func (p *PortAllocator) ReleasePort(ip net.IP, proto string, port int) error {
 		return nil
 	}
 	delete(protomap[proto].p, port)
-	return nil
-}
-
-// SetPortRange sets dynamic port allocation range.
-// if both portBegin and portEnd are 0, the port range reverts to default
-// value. Otherwise they are sanitized against the default values to
-// ensure their validity.
-func (p *PortAllocator) SetPortRange(portBegin, portEnd int) error {
-	// if begin and end is zero, revert to default values
-	var begin, end int
-	var err error
-	if portBegin == 0 && portEnd == 0 {
-		begin, end = getDefaultPortRange()
-	} else if begin, end, err = sanitizePortRange(portBegin, portEnd); err != nil {
-		return err
-	}
-	logrus.Debugf("Setting up port allocator to range %v-%v, current %v-%v", begin, end, p.Begin, p.End)
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-	if p.Begin == begin && p.End == end {
-		return nil
-	}
-	p.ipMap = ipMapping{}
-	p.Begin, p.End = begin, end
 	return nil
 }
 

--- a/libnetwork/portallocator/portallocator_test.go
+++ b/libnetwork/portallocator/portallocator_test.go
@@ -1,7 +1,6 @@
 package portallocator
 
 import (
-	"fmt"
 	"net"
 	"testing"
 )
@@ -320,49 +319,5 @@ func TestNoDuplicateBPR(t *testing.T) {
 		t.Fatal(err)
 	} else if port == p.Begin {
 		t.Fatalf("Acquire(0) allocated the same port twice: %d", port)
-	}
-}
-
-func TestChangePortRange(t *testing.T) {
-	var tests = []struct {
-		begin  int
-		end    int
-		setErr error
-		reqRlt int
-	}{
-		{defaultPortRangeEnd + 1, defaultPortRangeEnd + 10, fmt.Errorf("begin out of range"), 0},
-		{defaultPortRangeStart - 10, defaultPortRangeStart - 1, fmt.Errorf("end out of range"), 0},
-		{defaultPortRangeEnd, defaultPortRangeStart, fmt.Errorf("out of order"), 0},
-		{defaultPortRangeStart + 100, defaultPortRangeEnd + 10, nil, defaultPortRangeStart + 100},
-		{0, 0, nil, defaultPortRangeStart}, // revert to default if no value given
-		{defaultPortRangeStart - 100, defaultPortRangeEnd, nil, defaultPortRangeStart + 1},
-	}
-	p := Get()
-	port := 0
-	for _, c := range tests {
-		t.Logf("test: port allocate range %v-%v, setErr=%v, reqPort=%v",
-			c.begin, c.end, c.setErr, c.reqRlt)
-		err := p.SetPortRange(c.begin, c.end)
-		if (c.setErr == nil && c.setErr != err) ||
-			(c.setErr != nil && err == nil) {
-			t.Fatalf("Unexpected set range result, expected=%v, actual=%v", c.setErr, err)
-		}
-		if err != nil {
-			continue
-		}
-		if port > 0 {
-			err := p.ReleasePort(defaultIP, "tcp", port)
-			if err != nil {
-				t.Fatalf("Releasing port %v failed, err=%v", port, err)
-			}
-		}
-
-		port, err = p.RequestPort(defaultIP, "tcp", 0)
-		if err != nil {
-			t.Fatalf("Request failed, err %v", err)
-		}
-		if port != c.reqRlt {
-			t.Fatalf("Incorrect port returned, expected=%v, actual=%v", c.reqRlt, port)
-		}
 	}
 }

--- a/libnetwork/portallocator/portallocator_unix.go
+++ b/libnetwork/portallocator/portallocator_unix.go
@@ -4,10 +4,10 @@
 package portallocator
 
 const (
-	// DefaultPortRangeStart indicates the first port in port range
-	DefaultPortRangeStart = 49153
-	// DefaultPortRangeEnd indicates the last port in port range
+	// defaultPortRangeStart indicates the first port in port range
+	defaultPortRangeStart = 49153
+	// defaultPortRangeEnd indicates the last port in port range
 	// consistent with default /proc/sys/net/ipv4/ip_local_port_range
 	// upper bound on linux
-	DefaultPortRangeEnd = 65535
+	defaultPortRangeEnd = 65535
 )

--- a/libnetwork/portallocator/portallocator_unix.go
+++ b/libnetwork/portallocator/portallocator_unix.go
@@ -4,10 +4,10 @@
 package portallocator
 
 const (
-	// defaultPortRangeStart indicates the first port in port range
-	defaultPortRangeStart = 49153
-	// defaultPortRangeEnd indicates the last port in port range
+	// DefaultPortRangeStart indicates the first port in port range
+	DefaultPortRangeStart = 49153
+	// DefaultPortRangeEnd indicates the last port in port range
 	// consistent with default /proc/sys/net/ipv4/ip_local_port_range
 	// upper bound on linux
-	defaultPortRangeEnd = 60999
+	DefaultPortRangeEnd = 65535
 )

--- a/libnetwork/portallocator/portallocator_windows.go
+++ b/libnetwork/portallocator/portallocator_windows.go
@@ -1,12 +1,12 @@
 package portallocator
 
 const (
-	// defaultPortRangeStart indicates the first port in port range
-	defaultPortRangeStart = 60000
-	// defaultPortRangeEnd indicates the last port in port range
-	defaultPortRangeEnd = 65000
+	// DefaultPortRangeStart indicates the first port in port range
+	DefaultPortRangeStart = 60000
+	// DefaultPortRangeEnd indicates the last port in port range
+	DefaultPortRangeEnd = 65000
 )
 
 func getDynamicPortRange() (start int, end int, err error) {
-	return defaultPortRangeStart, defaultPortRangeEnd, nil
+	return DefaultPortRangeStart, DefaultPortRangeEnd, nil
 }

--- a/libnetwork/portallocator/portallocator_windows.go
+++ b/libnetwork/portallocator/portallocator_windows.go
@@ -1,12 +1,12 @@
 package portallocator
 
 const (
-	// DefaultPortRangeStart indicates the first port in port range
-	DefaultPortRangeStart = 60000
-	// DefaultPortRangeEnd indicates the last port in port range
-	DefaultPortRangeEnd = 65000
+	// defaultPortRangeStart indicates the first port in port range
+	defaultPortRangeStart = 60000
+	// defaultPortRangeEnd indicates the last port in port range
+	defaultPortRangeEnd = 65000
 )
 
 func getDynamicPortRange() (start int, end int, err error) {
-	return DefaultPortRangeStart, DefaultPortRangeEnd, nil
+	return defaultPortRangeStart, defaultPortRangeEnd, nil
 }


### PR DESCRIPTION
**- What I did**

Since commit 2c4a868f64e6e13bf06589a6670122196651e82e, Docker doesn't
use the value of net.ipv4.ip_local_port_range when choosing an ephemeral
port. This change reverts back to the previous behavior.

Fixes #43054.

**- How to verify it**

1. `make shell`
2. In the container, `sysctl -w net.ipv4.ip_local_port_range="39000 40000"`
3. Start dockerd
4. Run `docker run --rm -it -p 80 nginx`
5. Check what port Docker has picked with `docker ps`

**- Description for the changelog**

`Use the value of net.ipv4.ip_local_port_range when choosing an ephemeral port`