### PR TITLE
[20.10 backport] daemon.WithCommonOptions() fix detection of user-namespaces

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -767,7 +767,8 @@ func WithCommonOptions(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		// joining an existing namespace, only if we create a new net namespace.
 		if c.HostConfig.NetworkMode.IsPrivate() {
 			// We cannot set up ping socket support in a user namespace
-			if !c.HostConfig.UsernsMode.IsPrivate() && sysctlExists("net.ipv4.ping_group_range") {
+			userNS := daemon.configStore.RemappedRoot != "" && c.HostConfig.UsernsMode.IsPrivate()
+			if !userNS && !sys.RunningInUserNS() && sysctlExists("net.ipv4.ping_group_range") {
 				// allow unprivileged ICMP echo sockets without CAP_NET_RAW
 				s.Linux.Sysctl["net.ipv4.ping_group_range"] = "0 2147483647"
 			}

--- a/daemon/oci_linux_test.go
+++ b/daemon/oci_linux_test.go
@@ -120,7 +120,6 @@ func TestSysctlOverride(t *testing.T) {
 		HostConfig: &containertypes.HostConfig{
 			NetworkMode: "bridge",
 			Sysctls:     map[string]string{},
-			UsernsMode:  "host",
 		},
 	}
 	d := setupFakeDaemon(t, c)
@@ -148,6 +147,20 @@ func TestSysctlOverride(t *testing.T) {
 	assert.Equal(t, s.Hostname, "foobar")
 	assert.Equal(t, s.Linux.Sysctl["kernel.domainname"], c.HostConfig.Sysctls["kernel.domainname"])
 	assert.Equal(t, s.Linux.Sysctl["net.ipv4.ip_unprivileged_port_start"], c.HostConfig.Sysctls["net.ipv4.ip_unprivileged_port_start"])
+
+	// Ensure the ping_group_range is not set on a daemon with user-namespaces enabled
+	d.configStore.RemappedRoot = "dummy:dummy"
+	s, err = d.createSpec(c)
+	assert.NilError(t, err)
+	_, ok := s.Linux.Sysctl["net.ipv4.ping_group_range"]
+	assert.Assert(t, !ok)
+
+	// Ensure the ping_group_range is set on a container in "host" userns mode
+	// on a daemon with user-namespaces enabled
+	c.HostConfig.UsernsMode = "host"
+	s, err = d.createSpec(c)
+	assert.NilError(t, err)
+	assert.Equal(t, s.Linux.Sysctl["net.ipv4.ping_group_range"], "0 2147483647")
 }
 
 // TestSysctlOverrideHost ensures that any implicit network sysctls are not set
@@ -159,7 +172,6 @@ func TestSysctlOverrideHost(t *testing.T) {
 		HostConfig: &containertypes.HostConfig{
 			NetworkMode: "host",
 			Sysctls:     map[string]string{},
-			UsernsMode:  "host",
 		},
 	}
 	d := setupFakeDaemon(t, c)


### PR DESCRIPTION
Cherry-pick https://github.com/moby/moby/pull/42736

> Commit [dae652e](https://github.com/moby/moby/commit/dae652e2e5e47d99c8febd5bc81df0a3269beb74) (#41030) added support for non-privileged containers to use ICMP_PROTO (used for `ping`). This option cannot be set for containers that have user-namespaces enabled.
> 
> However, the detection looks to be incorrect; HostConfig.UsernsMode was added in [6993e89](https://github.com/moby/moby/commit/6993e891d10c760d22e0ea3d455f13858cd0de46) (#20111) / [ee21838](https://github.com/moby/moby/commit/ee2183881b0273ff1707501e71798a61018f50f0) (#20913), and the property only has meaning if the daemon is running with user namespaces enabled. In other situations, the property has no meaning.
> 
> As a result of the above, the sysctl would only be set for containers running with UsernsMode=host on a daemon running with user-namespaces enabled.
> 
> This patch adds a check if the daemon has user-namespaces enabled (RemappedRoot having a non-empty value) to fix the detection.
> 
> **- Description for the changelog**
> 
> **- A picture of a cute animal (not mandatory but encouraged)**




The cherry-pick was almost clean but `userns.RunningInUserNS()` -> `sys.RunningInUserNS()`.

```diff
diff --git a/daemon/oci_linux.go b/daemon/oci_linux.go
index 9b39b8f615..3d34dcb31d 100644
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -768,7 +768,7 @@ func WithCommonOptions(daemon *Daemon, c *container.Container) coci.SpecOpts {
                if c.HostConfig.NetworkMode.IsPrivate() {
                        // We cannot set up ping socket support in a user namespace
                        userNS := daemon.configStore.RemappedRoot != "" && c.HostConfig.UsernsMode.IsPrivate()
-                       if !userNS && !userns.RunningInUserNS() && sysctlExists("net.ipv4.ping_group_range") {
+                       if !userNS && !sys.RunningInUserNS() && sysctlExists("net.ipv4.ping_group_range") {
                                // allow unprivileged ICMP echo sockets without CAP_NET_RAW
                                s.Linux.Sysctl["net.ipv4.ping_group_range"] = "0 2147483647"
                        }
```

Fix docker/buildx#561

