### PR TITLE
Remove deprecated host-discovery and overlay networks with external k/v [step 1]

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -80,6 +80,9 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 	if cli.Config, err = loadDaemonCliConfig(opts); err != nil {
 		return err
 	}
+	if err := checkDeprecatedOptions(cli.Config); err != nil {
+		return err
+	}
 
 	if opts.Validate {
 		// If config wasn't OK we wouldn't have made it this far.
@@ -88,8 +91,6 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 	}
 
 	configureProxyEnv(cli.Config)
-
-	warnOnDeprecatedConfigOptions(cli.Config)
 
 	if err := configureDaemonLogs(cli.Config); err != nil {
 		return err
@@ -465,16 +466,12 @@ func loadDaemonCliConfig(opts *daemonOptions) (*config.Config, error) {
 	return conf, nil
 }
 
-func warnOnDeprecatedConfigOptions(config *config.Config) {
-	if config.ClusterAdvertise != "" {
-		logrus.Warn(`The "cluster-advertise" option is deprecated. To be removed soon.`)
+func checkDeprecatedOptions(config *config.Config) error {
+	// Overlay networks with external k/v stores have been deprecated
+	if config.ClusterAdvertise != "" || len(config.ClusterOpts) > 0 || config.ClusterStore != "" {
+		return errors.New("Host-discovery and overlay networks with external k/v stores are deprecated. The 'cluster-advertise', 'cluster-store', and 'cluster-store-opt' options have been removed")
 	}
-	if config.ClusterStore != "" {
-		logrus.Warn(`The "cluster-store" option is deprecated. To be removed soon.`)
-	}
-	if len(config.ClusterOpts) > 0 {
-		logrus.Warn(`The "cluster-store-opt" option is deprecated. To be removed soon.`)
-	}
+	return nil
 }
 
 func initRouter(opts routerOptions) {

--- a/cmd/dockerd/daemon_unix_test.go
+++ b/cmd/dockerd/daemon_unix_test.go
@@ -48,10 +48,7 @@ func TestLoadDaemonConfigWithNetwork(t *testing.T) {
 }
 
 func TestLoadDaemonConfigWithMapOptions(t *testing.T) {
-	content := `{
-		"cluster-store-opts": {"kv.cacertfile": "/var/lib/docker/discovery_certs/ca.pem"},
-		"log-opts": {"tag": "test"}
-}`
+	content := `{"log-opts": {"tag": "test"}}`
 	tempFile := fs.NewFile(t, "config", fs.WithContent(content))
 	defer tempFile.Remove()
 
@@ -59,10 +56,6 @@ func TestLoadDaemonConfigWithMapOptions(t *testing.T) {
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
 	assert.Assert(t, loadedConfig != nil)
-	assert.Check(t, loadedConfig.ClusterOpts != nil)
-
-	expectedPath := "/var/lib/docker/discovery_certs/ca.pem"
-	assert.Check(t, is.Equal(expectedPath, loadedConfig.ClusterOpts["kv.cacertfile"]))
 	assert.Check(t, loadedConfig.LogConfig.Config != nil)
 	assert.Check(t, is.Equal("test", loadedConfig.LogConfig.Config["tag"]))
 }

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -7,14 +7,11 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"reflect"
 	"strings"
 	"sync"
 
-	daemondiscovery "github.com/docker/docker/daemon/discovery"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/authorization"
-	"github.com/docker/docker/pkg/discovery"
 	"github.com/docker/docker/registry"
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
@@ -301,25 +298,8 @@ func New() *Config {
 			LogConfig: LogConfig{
 				Config: make(map[string]string),
 			},
-			ClusterOpts: make(map[string]string),
 		},
 	}
-}
-
-// ParseClusterAdvertiseSettings parses the specified advertise settings
-func ParseClusterAdvertiseSettings(clusterStore, clusterAdvertise string) (string, error) {
-	if clusterAdvertise == "" {
-		return "", daemondiscovery.ErrDiscoveryDisabled
-	}
-	if clusterStore == "" {
-		return "", errors.New("invalid cluster configuration. --cluster-advertise must be accompanied by --cluster-store configuration")
-	}
-
-	advertise, err := discovery.ParseAdvertise(clusterAdvertise)
-	if err != nil {
-		return "", errors.Wrap(err, "discovery advertise parsing failed")
-	}
-	return advertise, nil
 }
 
 // GetConflictFreeLabels validates Labels for conflict
@@ -634,21 +614,6 @@ func ValidateMaxDownloadAttempts(config *Config) error {
 		return fmt.Errorf("invalid max download attempts: %d", *config.MaxDownloadAttempts)
 	}
 	return nil
-}
-
-// ModifiedDiscoverySettings returns whether the discovery configuration has been modified or not.
-func ModifiedDiscoverySettings(config *Config, backendType, advertise string, clusterOpts map[string]string) bool {
-	if config.ClusterStore != backendType || config.ClusterAdvertise != advertise {
-		return true
-	}
-
-	if (config.ClusterOpts == nil && clusterOpts == nil) ||
-		(config.ClusterOpts == nil && len(clusterOpts) == 0) ||
-		(len(config.ClusterOpts) == 0 && clusterOpts == nil) {
-		return false
-	}
-
-	return !reflect.DeepEqual(config.ClusterOpts, clusterOpts)
 }
 
 // GetDefaultRuntimeName returns the current default runtime

--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -120,9 +120,6 @@ func (conf *Config) GetResolvConf() string {
 
 // IsSwarmCompatible defines if swarm mode can be enabled in this config
 func (conf *Config) IsSwarmCompatible() error {
-	if conf.ClusterStore != "" || conf.ClusterAdvertise != "" {
-		return fmt.Errorf("--cluster-store and --cluster-advertise daemon configurations are incompatible with swarm mode")
-	}
 	if conf.LiveRestoreEnabled {
 		return fmt.Errorf("--live-restore daemon configuration is incompatible with swarm mode")
 	}

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/daemon/discovery"
 	"github.com/docker/docker/libnetwork/ipamutils"
 	"github.com/docker/docker/opts"
 	"github.com/spf13/pflag"
@@ -35,23 +34,6 @@ func TestDaemonBrokenConfiguration(t *testing.T) {
 	_, err = MergeDaemonConfigurations(&Config{}, nil, configFile)
 	if err == nil {
 		t.Fatalf("expected error, got %v", err)
-	}
-}
-
-func TestParseClusterAdvertiseSettings(t *testing.T) {
-	_, err := ParseClusterAdvertiseSettings("something", "")
-	if err != discovery.ErrDiscoveryDisabled {
-		t.Fatalf("expected discovery disabled error, got %v\n", err)
-	}
-
-	_, err = ParseClusterAdvertiseSettings("", "something")
-	if err == nil {
-		t.Fatalf("expected discovery store error, got %v\n", err)
-	}
-
-	_, err = ParseClusterAdvertiseSettings("etcd", "127.0.0.1:8080")
-	if err != nil {
-		t.Fatal(err)
 	}
 }
 
@@ -444,67 +426,6 @@ func TestValidateConfiguration(t *testing.T) {
 			err := Validate(tc.config)
 			assert.NilError(t, err)
 		})
-	}
-}
-
-func TestModifiedDiscoverySettings(t *testing.T) {
-	cases := []struct {
-		current  *Config
-		modified *Config
-		expected bool
-	}{
-		{
-			current:  discoveryConfig("foo", "bar", map[string]string{}),
-			modified: discoveryConfig("foo", "bar", map[string]string{}),
-			expected: false,
-		},
-		{
-			current:  discoveryConfig("foo", "bar", map[string]string{"foo": "bar"}),
-			modified: discoveryConfig("foo", "bar", map[string]string{"foo": "bar"}),
-			expected: false,
-		},
-		{
-			current:  discoveryConfig("foo", "bar", map[string]string{}),
-			modified: discoveryConfig("foo", "bar", nil),
-			expected: false,
-		},
-		{
-			current:  discoveryConfig("foo", "bar", nil),
-			modified: discoveryConfig("foo", "bar", map[string]string{}),
-			expected: false,
-		},
-		{
-			current:  discoveryConfig("foo", "bar", nil),
-			modified: discoveryConfig("baz", "bar", nil),
-			expected: true,
-		},
-		{
-			current:  discoveryConfig("foo", "bar", nil),
-			modified: discoveryConfig("foo", "baz", nil),
-			expected: true,
-		},
-		{
-			current:  discoveryConfig("foo", "bar", nil),
-			modified: discoveryConfig("foo", "bar", map[string]string{"foo": "bar"}),
-			expected: true,
-		},
-	}
-
-	for _, c := range cases {
-		got := ModifiedDiscoverySettings(c.current, c.modified.ClusterStore, c.modified.ClusterAdvertise, c.modified.ClusterOpts)
-		if c.expected != got {
-			t.Fatalf("expected %v, got %v: current config %v, new config %v", c.expected, got, c.current, c.modified)
-		}
-	}
-}
-
-func discoveryConfig(backendAddr, advertiseAddr string, opts map[string]string) *Config {
-	return &Config{
-		CommonConfig: CommonConfig{
-			ClusterStore:     backendAddr,
-			ClusterAdvertise: advertiseAddr,
-			ClusterOpts:      opts,
-		},
 	}
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -14,7 +14,6 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"sync"
 	"time"
 
@@ -1050,12 +1049,6 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		return nil, err
 	}
 
-	// Discovery is only enabled when the daemon is launched with an address to advertise.  When
-	// initialized, the daemon is registered and we can store the discovery backend as it's read-only
-	if err := d.initDiscovery(config); err != nil {
-		return nil, err
-	}
-
 	sysInfo := d.RawSysInfo()
 	for _, w := range sysInfo.Warnings {
 		logrus.Warn(w)
@@ -1390,26 +1383,6 @@ func (daemon *Daemon) IsShuttingDown() bool {
 	return daemon.shutdown
 }
 
-// initDiscovery initializes the discovery watcher for this daemon.
-func (daemon *Daemon) initDiscovery(conf *config.Config) error {
-	advertise, err := config.ParseClusterAdvertiseSettings(conf.ClusterStore, conf.ClusterAdvertise)
-	if err != nil {
-		if err == discovery.ErrDiscoveryDisabled {
-			return nil
-		}
-		return err
-	}
-
-	conf.ClusterAdvertise = advertise
-	discoveryWatcher, err := discovery.Init(conf.ClusterStore, conf.ClusterAdvertise, conf.ClusterOpts)
-	if err != nil {
-		return fmt.Errorf("discovery initialization failed (%v)", err)
-	}
-
-	daemon.discoveryWatcher = discoveryWatcher
-	return nil
-}
-
 func isBridgeNetworkDisabled(conf *config.Config) bool {
 	return conf.BridgeConfig.Iface == config.DisableNetworkBridge
 }
@@ -1428,27 +1401,6 @@ func (daemon *Daemon) networkOptions(dconfig *config.Config, pg plugingetter.Plu
 	dn := runconfig.DefaultDaemonNetworkMode().NetworkName()
 	options = append(options, nwconfig.OptionDefaultDriver(string(dd)))
 	options = append(options, nwconfig.OptionDefaultNetwork(dn))
-
-	if strings.TrimSpace(dconfig.ClusterStore) != "" {
-		kv := strings.Split(dconfig.ClusterStore, "://")
-		if len(kv) != 2 {
-			return nil, errors.New("kv store daemon config must be of the form KV-PROVIDER://KV-URL")
-		}
-		options = append(options, nwconfig.OptionKVProvider(kv[0]))
-		options = append(options, nwconfig.OptionKVProviderURL(kv[1]))
-	}
-	if len(dconfig.ClusterOpts) > 0 {
-		options = append(options, nwconfig.OptionKVOpts(dconfig.ClusterOpts))
-	}
-
-	if daemon.discoveryWatcher != nil {
-		options = append(options, nwconfig.OptionDiscoveryWatcher(daemon.discoveryWatcher))
-	}
-
-	if dconfig.ClusterAdvertise != "" {
-		options = append(options, nwconfig.OptionDiscoveryAddress(dconfig.ClusterAdvertise))
-	}
-
 	options = append(options, nwconfig.OptionLabels(dconfig.Labels))
 	options = append(options, driverOptions(dconfig))
 

--- a/daemon/daemon_unix_test.go
+++ b/daemon/daemon_unix_test.go
@@ -250,30 +250,6 @@ func TestParseNNPSecurityOptions(t *testing.T) {
 	}
 }
 
-func TestNetworkOptions(t *testing.T) {
-	daemon := &Daemon{}
-	dconfigCorrect := &config.Config{
-		CommonConfig: config.CommonConfig{
-			ClusterStore:     "consul://localhost:8500",
-			ClusterAdvertise: "192.168.0.1:8000",
-		},
-	}
-
-	if _, err := daemon.networkOptions(dconfigCorrect, nil, nil); err != nil {
-		t.Fatalf("Expect networkOptions success, got error: %v", err)
-	}
-
-	dconfigWrong := &config.Config{
-		CommonConfig: config.CommonConfig{
-			ClusterStore: "consul://localhost:8500://test://bbb",
-		},
-	}
-
-	if _, err := daemon.networkOptions(dconfigWrong, nil, nil); err == nil {
-		t.Fatal("Expected networkOptions error, got nil")
-	}
-}
-
 func TestVerifyPlatformContainerResources(t *testing.T) {
 	t.Parallel()
 	var (

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -70,7 +70,6 @@ func (daemon *Daemon) SystemInfo() *types.Info {
 		Isolation:          daemon.defaultIsolation,
 	}
 
-	daemon.fillClusterInfo(v)
 	daemon.fillAPIInfo(v)
 	// Retrieve platform specific info
 	daemon.fillPlatformInfo(v, sysInfo)
@@ -129,16 +128,6 @@ func (daemon *Daemon) SystemVersion() types.Version {
 
 	daemon.fillPlatformVersion(&v)
 	return v
-}
-
-func (daemon *Daemon) fillClusterInfo(v *types.Info) {
-	v.ClusterAdvertise = daemon.configStore.ClusterAdvertise
-	v.ClusterStore = daemon.configStore.ClusterStore
-
-	if v.ClusterAdvertise != "" || v.ClusterStore != "" {
-		v.Warnings = append(v.Warnings, `WARNING: node discovery and overlay networks with an external k/v store (cluster-advertise,
-         cluster-store, cluster-store-opt) are deprecated and will be removed in a future release.`)
-	}
 }
 
 func (daemon *Daemon) fillDriverInfo(v *types.Info) {

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/daemon/config"
-	"github.com/docker/docker/daemon/discovery"
 	"github.com/sirupsen/logrus"
 )
 
@@ -63,9 +62,6 @@ func (daemon *Daemon) Reload(conf *config.Config) (err error) {
 	daemon.reloadShutdownTimeout(conf, attributes)
 	daemon.reloadFeatures(conf, attributes)
 
-	if err := daemon.reloadClusterDiscovery(conf, attributes); err != nil {
-		return err
-	}
 	if err := daemon.reloadLabels(conf, attributes); err != nil {
 		return err
 	}
@@ -158,81 +154,6 @@ func (daemon *Daemon) reloadShutdownTimeout(conf *config.Config, attributes map[
 
 	// prepare reload event attributes with updatable configurations
 	attributes["shutdown-timeout"] = fmt.Sprintf("%d", daemon.configStore.ShutdownTimeout)
-}
-
-// reloadClusterDiscovery updates configuration with cluster discovery options
-// and updates the passed attributes
-func (daemon *Daemon) reloadClusterDiscovery(conf *config.Config, attributes map[string]string) (err error) {
-	defer func() {
-		// prepare reload event attributes with updatable configurations
-		attributes["cluster-store"] = conf.ClusterStore
-		attributes["cluster-advertise"] = conf.ClusterAdvertise
-
-		attributes["cluster-store-opts"] = "{}"
-		if daemon.configStore.ClusterOpts != nil {
-			opts, err2 := json.Marshal(conf.ClusterOpts)
-			if err != nil {
-				err = err2
-			}
-			attributes["cluster-store-opts"] = string(opts)
-		}
-	}()
-
-	newAdvertise := conf.ClusterAdvertise
-	newClusterStore := daemon.configStore.ClusterStore
-	if conf.IsValueSet("cluster-advertise") {
-		if conf.IsValueSet("cluster-store") {
-			newClusterStore = conf.ClusterStore
-		}
-		newAdvertise, err = config.ParseClusterAdvertiseSettings(newClusterStore, conf.ClusterAdvertise)
-		if err != nil && err != discovery.ErrDiscoveryDisabled {
-			return err
-		}
-	}
-
-	if daemon.clusterProvider != nil {
-		if err := conf.IsSwarmCompatible(); err != nil {
-			return err
-		}
-	}
-
-	// check discovery modifications
-	if !config.ModifiedDiscoverySettings(daemon.configStore, newClusterStore, newAdvertise, conf.ClusterOpts) {
-		return nil
-	}
-
-	// enable discovery for the first time if it was not previously enabled
-	if daemon.discoveryWatcher == nil {
-		discoveryWatcher, err := discovery.Init(newClusterStore, newAdvertise, conf.ClusterOpts)
-		if err != nil {
-			return fmt.Errorf("failed to initialize discovery: %v", err)
-		}
-		daemon.discoveryWatcher = discoveryWatcher
-	} else if err == discovery.ErrDiscoveryDisabled {
-		// disable discovery if it was previously enabled and it's disabled now
-		daemon.discoveryWatcher.Stop()
-	} else if err = daemon.discoveryWatcher.Reload(conf.ClusterStore, newAdvertise, conf.ClusterOpts); err != nil {
-		// reload discovery
-		return err
-	}
-
-	daemon.configStore.ClusterStore = newClusterStore
-	daemon.configStore.ClusterOpts = conf.ClusterOpts
-	daemon.configStore.ClusterAdvertise = newAdvertise
-
-	if daemon.netController == nil {
-		return nil
-	}
-	netOptions, err := daemon.networkOptions(daemon.configStore, daemon.PluginStore, nil)
-	if err != nil {
-		logrus.WithError(err).Warn("failed to get options with network controller")
-		return nil
-	}
-	err = daemon.netController.ReloadConfiguration(netOptions...)
-	if err != nil {
-		logrus.Warnf("Failed to reload configuration with network controller: %v", err)
-	}
-	return nil
 }
 
 // reloadLabels updates configuration with engine labels

--- a/daemon/reload_test.go
+++ b/daemon/reload_test.go
@@ -2,15 +2,12 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"os"
-	"reflect"
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/libnetwork"
-	"github.com/docker/docker/pkg/discovery"
 	_ "github.com/docker/docker/pkg/discovery/memory"
 	"github.com/docker/docker/registry"
 	"github.com/sirupsen/logrus"
@@ -338,180 +335,6 @@ func TestDaemonReloadNotAffectOthers(t *testing.T) {
 	debug := daemon.configStore.Debug
 	if !debug {
 		t.Fatal("Expected debug 'enabled', got 'disabled'")
-	}
-}
-
-func TestDaemonDiscoveryReload(t *testing.T) {
-	daemon := &Daemon{
-		imageService: images.NewImageService(images.ImageServiceConfig{}),
-	}
-	muteLogs()
-	daemon.configStore = &config.Config{
-		CommonConfig: config.CommonConfig{
-			ClusterStore:     "memory://127.0.0.1",
-			ClusterAdvertise: "127.0.0.1:3333",
-		},
-	}
-
-	if err := daemon.initDiscovery(daemon.configStore); err != nil {
-		t.Fatal(err)
-	}
-
-	expected := discovery.Entries{
-		&discovery.Entry{Host: "127.0.0.1", Port: "3333"},
-	}
-
-	select {
-	case <-time.After(10 * time.Second):
-		t.Fatal("timeout waiting for discovery")
-	case <-daemon.discoveryWatcher.ReadyCh():
-	}
-
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	ch, errCh := daemon.discoveryWatcher.Watch(stopCh)
-
-	select {
-	case <-time.After(1 * time.Second):
-		t.Fatal("failed to get discovery advertisements in time")
-	case e := <-ch:
-		if !reflect.DeepEqual(e, expected) {
-			t.Fatalf("expected %v, got %v\n", expected, e)
-		}
-	case e := <-errCh:
-		t.Fatal(e)
-	}
-
-	valuesSets := make(map[string]interface{})
-	valuesSets["cluster-store"] = "memory://127.0.0.1:2222"
-	valuesSets["cluster-advertise"] = "127.0.0.1:5555"
-	newConfig := &config.Config{
-		CommonConfig: config.CommonConfig{
-			ClusterStore:     "memory://127.0.0.1:2222",
-			ClusterAdvertise: "127.0.0.1:5555",
-			ValuesSet:        valuesSets,
-		},
-	}
-
-	expected = discovery.Entries{
-		&discovery.Entry{Host: "127.0.0.1", Port: "5555"},
-	}
-
-	if err := daemon.Reload(newConfig); err != nil {
-		t.Fatal(err)
-	}
-
-	select {
-	case <-time.After(10 * time.Second):
-		t.Fatal("timeout waiting for discovery")
-	case <-daemon.discoveryWatcher.ReadyCh():
-	}
-
-	ch, errCh = daemon.discoveryWatcher.Watch(stopCh)
-
-	select {
-	case <-time.After(1 * time.Second):
-		t.Fatal("failed to get discovery advertisements in time")
-	case e := <-ch:
-		if !reflect.DeepEqual(e, expected) {
-			t.Fatalf("expected %v, got %v\n", expected, e)
-		}
-	case e := <-errCh:
-		t.Fatal(e)
-	}
-}
-
-func TestDaemonDiscoveryReloadFromEmptyDiscovery(t *testing.T) {
-	daemon := &Daemon{
-		imageService: images.NewImageService(images.ImageServiceConfig{}),
-	}
-	daemon.configStore = &config.Config{}
-	muteLogs()
-
-	valuesSet := make(map[string]interface{})
-	valuesSet["cluster-store"] = "memory://127.0.0.1:2222"
-	valuesSet["cluster-advertise"] = "127.0.0.1:5555"
-	newConfig := &config.Config{
-		CommonConfig: config.CommonConfig{
-			ClusterStore:     "memory://127.0.0.1:2222",
-			ClusterAdvertise: "127.0.0.1:5555",
-			ValuesSet:        valuesSet,
-		},
-	}
-
-	expected := discovery.Entries{
-		&discovery.Entry{Host: "127.0.0.1", Port: "5555"},
-	}
-
-	if err := daemon.Reload(newConfig); err != nil {
-		t.Fatal(err)
-	}
-
-	select {
-	case <-time.After(10 * time.Second):
-		t.Fatal("timeout waiting for discovery")
-	case <-daemon.discoveryWatcher.ReadyCh():
-	}
-
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	ch, errCh := daemon.discoveryWatcher.Watch(stopCh)
-
-	select {
-	case <-time.After(1 * time.Second):
-		t.Fatal("failed to get discovery advertisements in time")
-	case e := <-ch:
-		if !reflect.DeepEqual(e, expected) {
-			t.Fatalf("expected %v, got %v\n", expected, e)
-		}
-	case e := <-errCh:
-		t.Fatal(e)
-	}
-}
-
-func TestDaemonDiscoveryReloadOnlyClusterAdvertise(t *testing.T) {
-	daemon := &Daemon{
-		imageService: images.NewImageService(images.ImageServiceConfig{}),
-	}
-	daemon.configStore = &config.Config{
-		CommonConfig: config.CommonConfig{
-			ClusterStore: "memory://127.0.0.1",
-		},
-	}
-	valuesSets := make(map[string]interface{})
-	valuesSets["cluster-advertise"] = "127.0.0.1:5555"
-	newConfig := &config.Config{
-		CommonConfig: config.CommonConfig{
-			ClusterAdvertise: "127.0.0.1:5555",
-			ValuesSet:        valuesSets,
-		},
-	}
-	expected := discovery.Entries{
-		&discovery.Entry{Host: "127.0.0.1", Port: "5555"},
-	}
-
-	if err := daemon.Reload(newConfig); err != nil {
-		t.Fatal(err)
-	}
-
-	select {
-	case <-daemon.discoveryWatcher.ReadyCh():
-	case <-time.After(10 * time.Second):
-		t.Fatal("Timeout waiting for discovery")
-	}
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	ch, errCh := daemon.discoveryWatcher.Watch(stopCh)
-
-	select {
-	case <-time.After(1 * time.Second):
-		t.Fatal("failed to get discovery advertisements in time")
-	case e := <-ch:
-		if !reflect.DeepEqual(e, expected) {
-			t.Fatalf("expected %v, got %v\n", expected, e)
-		}
-	case e := <-errCh:
-		t.Fatal(e)
 	}
 }
 

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -597,6 +597,10 @@ func (s *DockerDaemonSuite) TestDaemonBridgeExternal(c *testing.T) {
 	assert.ErrorContains(c, err, "", `--bridge option with an invalid bridge should cause the daemon to fail`)
 	defer d.Restart(c)
 
+	// make sure the default docker0 bridge doesn't interfere with the test,
+	// which may happen if it was created with the same IP range.
+	deleteInterface(c, "docker0")
+
 	bridgeName := "external-bridge"
 	bridgeIP := "192.169.1.1/24"
 	_, bridgeIPNet, _ := net.ParseCIDR(bridgeIP)
@@ -712,6 +716,10 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithBridgeIPChange(c *testing.T) {
 func (s *DockerDaemonSuite) TestDaemonBridgeFixedCidr(c *testing.T) {
 	d := s.d
 
+	// make sure the default docker0 bridge doesn't interfere with the test,
+	// which may happen if it was created with the same IP range.
+	deleteInterface(c, "docker0")
+
 	bridgeName := "external-bridge"
 	bridgeIP := "192.169.1.1/24"
 
@@ -733,6 +741,10 @@ func (s *DockerDaemonSuite) TestDaemonBridgeFixedCidr(c *testing.T) {
 
 func (s *DockerDaemonSuite) TestDaemonBridgeFixedCidr2(c *testing.T) {
 	d := s.d
+
+	// make sure the default docker0 bridge doesn't interfere with the test,
+	// which may happen if it was created with the same IP range.
+	deleteInterface(c, "docker0")
 
 	bridgeName := "external-bridge"
 	bridgeIP := "10.2.2.1/16"
@@ -758,6 +770,10 @@ func (s *DockerDaemonSuite) TestDaemonBridgeFixedCidr2(c *testing.T) {
 
 func (s *DockerDaemonSuite) TestDaemonBridgeFixedCIDREqualBridgeNetwork(c *testing.T) {
 	d := s.d
+
+	// make sure the default docker0 bridge doesn't interfere with the test,
+	// which may happen if it was created with the same IP range.
+	deleteInterface(c, "docker0")
 
 	bridgeName := "external-bridge"
 	bridgeIP := "172.27.42.1/16"
@@ -843,6 +859,10 @@ func (s *DockerDaemonSuite) TestDaemonDefaultNetworkInvalidClusterConfig(c *test
 func (s *DockerDaemonSuite) TestDaemonIP(c *testing.T) {
 	d := s.d
 
+	// make sure the default docker0 bridge doesn't interfere with the test,
+	// which may happen if it was created with the same IP range.
+	deleteInterface(c, "docker0")
+
 	ipStr := "192.170.1.1/24"
 	ip, _, _ := net.ParseCIDR(ipStr)
 	args := []string{"--ip", ip.String()}
@@ -871,6 +891,10 @@ func (s *DockerDaemonSuite) TestDaemonICCPing(c *testing.T) {
 	testRequires(c, bridgeNfIptables)
 	d := s.d
 
+	// make sure the default docker0 bridge doesn't interfere with the test,
+	// which may happen if it was created with the same IP range.
+	deleteInterface(c, "docker0")
+
 	bridgeName := "external-bridge"
 	bridgeIP := "192.169.1.1/24"
 
@@ -893,6 +917,7 @@ func (s *DockerDaemonSuite) TestDaemonICCPing(c *testing.T) {
 	ifName := "icc-dummy"
 
 	createInterface(c, "dummy", ifName, ipStr)
+	defer deleteInterface(c, ifName)
 
 	// But, Pinging external or a Host interface must succeed
 	pingCmd := fmt.Sprintf("ping -c 1 %s -W 1", ip.String())
@@ -903,6 +928,10 @@ func (s *DockerDaemonSuite) TestDaemonICCPing(c *testing.T) {
 
 func (s *DockerDaemonSuite) TestDaemonICCLinkExpose(c *testing.T) {
 	d := s.d
+
+	// make sure the default docker0 bridge doesn't interfere with the test,
+	// which may happen if it was created with the same IP range.
+	deleteInterface(c, "docker0")
 
 	bridgeName := "external-bridge"
 	bridgeIP := "192.169.1.1/24"
@@ -926,6 +955,10 @@ func (s *DockerDaemonSuite) TestDaemonICCLinkExpose(c *testing.T) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonLinksIpTablesRulesWhenLinkAndUnlink(c *testing.T) {
+	// make sure the default docker0 bridge doesn't interfere with the test,
+	// which may happen if it was created with the same IP range.
+	deleteInterface(c, "docker0")
+
 	bridgeName := "external-bridge"
 	bridgeIP := "192.169.1.1/24"
 

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -601,7 +601,7 @@ func (s *DockerDaemonSuite) TestDaemonBridgeExternal(c *testing.T) {
 	// which may happen if it was created with the same IP range.
 	deleteInterface(c, "docker0")
 
-	bridgeName := "external-bridge"
+	bridgeName := "ext-bridge1"
 	bridgeIP := "192.169.1.1/24"
 	_, bridgeIPNet, _ := net.ParseCIDR(bridgeIP)
 
@@ -720,7 +720,7 @@ func (s *DockerDaemonSuite) TestDaemonBridgeFixedCidr(c *testing.T) {
 	// which may happen if it was created with the same IP range.
 	deleteInterface(c, "docker0")
 
-	bridgeName := "external-bridge"
+	bridgeName := "ext-bridge2"
 	bridgeIP := "192.169.1.1/24"
 
 	createInterface(c, "bridge", bridgeName, bridgeIP)
@@ -746,7 +746,7 @@ func (s *DockerDaemonSuite) TestDaemonBridgeFixedCidr2(c *testing.T) {
 	// which may happen if it was created with the same IP range.
 	deleteInterface(c, "docker0")
 
-	bridgeName := "external-bridge"
+	bridgeName := "ext-bridge3"
 	bridgeIP := "10.2.2.1/16"
 
 	createInterface(c, "bridge", bridgeName, bridgeIP)
@@ -775,7 +775,7 @@ func (s *DockerDaemonSuite) TestDaemonBridgeFixedCIDREqualBridgeNetwork(c *testi
 	// which may happen if it was created with the same IP range.
 	deleteInterface(c, "docker0")
 
-	bridgeName := "external-bridge"
+	bridgeName := "ext-bridge4"
 	bridgeIP := "172.27.42.1/16"
 
 	createInterface(c, "bridge", bridgeName, bridgeIP)
@@ -879,7 +879,7 @@ func (s *DockerDaemonSuite) TestDaemonICCPing(c *testing.T) {
 	// which may happen if it was created with the same IP range.
 	deleteInterface(c, "docker0")
 
-	bridgeName := "external-bridge"
+	bridgeName := "ext-bridge5"
 	bridgeIP := "192.169.1.1/24"
 
 	createInterface(c, "bridge", bridgeName, bridgeIP)
@@ -917,7 +917,7 @@ func (s *DockerDaemonSuite) TestDaemonICCLinkExpose(c *testing.T) {
 	// which may happen if it was created with the same IP range.
 	deleteInterface(c, "docker0")
 
-	bridgeName := "external-bridge"
+	bridgeName := "ext-bridge6"
 	bridgeIP := "192.169.1.1/24"
 
 	createInterface(c, "bridge", bridgeName, bridgeIP)
@@ -943,7 +943,7 @@ func (s *DockerDaemonSuite) TestDaemonLinksIpTablesRulesWhenLinkAndUnlink(c *tes
 	// which may happen if it was created with the same IP range.
 	deleteInterface(c, "docker0")
 
-	bridgeName := "external-bridge"
+	bridgeName := "ext-bridge7"
 	bridgeIP := "192.169.1.1/24"
 
 	createInterface(c, "bridge", bridgeName, bridgeIP)

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -840,22 +840,6 @@ func (s *DockerDaemonSuite) TestDaemonDefaultGatewayIPv4ExplicitOutsideContainer
 	s.d.Restart(c)
 }
 
-func (s *DockerDaemonSuite) TestDaemonDefaultNetworkInvalidClusterConfig(c *testing.T) {
-
-	// Start daemon without docker0 bridge
-	defaultNetworkBridge := "docker0"
-	deleteInterface(c, defaultNetworkBridge)
-
-	discoveryBackend := "consul://consuladdr:consulport/some/path"
-	s.d.Start(c, fmt.Sprintf("--cluster-store=%s", discoveryBackend))
-
-	// Start daemon with docker0 bridge
-	result := icmd.RunCommand("ifconfig", defaultNetworkBridge)
-	result.Assert(c, icmd.Success)
-
-	s.d.Restart(c, fmt.Sprintf("--cluster-store=%s", discoveryBackend))
-}
-
 func (s *DockerDaemonSuite) TestDaemonIP(c *testing.T) {
 	d := s.d
 
@@ -2227,51 +2211,6 @@ func (s *DockerDaemonSuite) TestDaemonDebugLog(c *testing.T) {
 	s.d.StartWithLogFile(tty, "--debug")
 	s.d.Stop(c)
 	assert.Assert(c, strings.Contains(b.String(), debugLog))
-}
-
-func (s *DockerDaemonSuite) TestDaemonDiscoveryBackendConfigReload(c *testing.T) {
-	testRequires(c, testEnv.IsLocalDaemon, DaemonIsLinux)
-
-	// daemon config file
-	daemonConfig := `{ "debug" : false }`
-	configFile, err := os.CreateTemp("", "test-daemon-discovery-backend-config-reload-config")
-	assert.Assert(c, err == nil, "could not create temp file for config reload")
-	configFilePath := configFile.Name()
-	defer func() {
-		configFile.Close()
-		os.RemoveAll(configFile.Name())
-	}()
-
-	_, err = configFile.Write([]byte(daemonConfig))
-	assert.NilError(c, err)
-
-	// --log-level needs to be set so that d.Start() doesn't add --debug causing
-	// a conflict with the config
-	s.d.Start(c, "--config-file", configFilePath, "--log-level=info")
-
-	// daemon config file
-	daemonConfig = `{
-	      "cluster-store": "consul://consuladdr:consulport/some/path",
-	      "cluster-advertise": "192.168.56.100:0",
-	      "debug" : false
-	}`
-
-	err = configFile.Truncate(0)
-	assert.NilError(c, err)
-	_, err = configFile.Seek(0, io.SeekStart)
-	assert.NilError(c, err)
-
-	_, err = configFile.Write([]byte(daemonConfig))
-	assert.NilError(c, err)
-
-	err = s.d.ReloadConfig()
-	assert.Assert(c, err == nil, "error reloading daemon config")
-
-	out, err := s.d.Cmd("info")
-	assert.NilError(c, err)
-
-	assert.Assert(c, strings.Contains(out, "Cluster Store: consul://consuladdr:consulport/some/path"))
-	assert.Assert(c, strings.Contains(out, "Cluster Advertise: 192.168.56.100:0"))
 }
 
 // Test for #21956

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -415,9 +415,6 @@ func (s *DockerDaemonSuite) TestDaemonEvents(c *testing.T) {
 	expectedSubstrings := []string{
 		" daemon reload " + info.ID + " ",
 		"(allow-nondistributable-artifacts=[",
-		" cluster-advertise=, ",
-		" cluster-store=, ",
-		" cluster-store-opts=",
 		" debug=true, ",
 		" default-ipc-mode=",
 		" default-runtime=",

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -152,16 +152,10 @@ func (s *DockerSwarmSuite) TestSwarmIncompatibleDaemon(c *testing.T) {
 	assert.Equal(c, info.LocalNodeState, swarm.LocalNodeStateActive)
 	d.Stop(c)
 
-	// start a daemon with --cluster-store and --cluster-advertise
-	err := d.StartWithError("--cluster-store=consul://consuladdr:consulport/some/path", "--cluster-advertise=1.1.1.1:2375")
+	// start a daemon with --live-restore
+	err := d.StartWithError("--live-restore")
 	assert.ErrorContains(c, err, "")
 	content, err := d.ReadLogFile()
-	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(string(content), "--cluster-store and --cluster-advertise daemon configurations are incompatible with swarm mode"))
-	// start a daemon with --live-restore
-	err = d.StartWithError("--live-restore")
-	assert.ErrorContains(c, err, "")
-	content, err = d.ReadLogFile()
 	assert.NilError(c, err)
 	assert.Assert(c, strings.Contains(string(content), "--live-restore daemon configuration is incompatible with swarm mode"))
 	// restart for teardown

--- a/integration/system/info_linux_test.go
+++ b/integration/system/info_linux_test.go
@@ -5,16 +5,12 @@ package system // import "github.com/docker/docker/integration/system"
 
 import (
 	"context"
-	"fmt"
-	"net"
 	"net/http"
 	"testing"
 
-	"github.com/docker/docker/testutil/daemon"
 	req "github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
-	"gotest.tools/v3/skip"
 )
 
 func TestInfoBinaryCommits(t *testing.T) {
@@ -47,73 +43,4 @@ func TestInfoAPIVersioned(t *testing.T) {
 	out := string(b)
 	assert.Check(t, is.Contains(out, "ExecutionDriver"))
 	assert.Check(t, is.Contains(out, "not supported"))
-}
-
-// TestInfoDiscoveryBackend verifies that a daemon run with `--cluster-advertise` and
-// `--cluster-store` properly returns the backend's endpoint in info output.
-func TestInfoDiscoveryBackend(t *testing.T) {
-	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
-
-	const (
-		discoveryBackend   = "consul://consuladdr:consulport/some/path"
-		discoveryAdvertise = "1.1.1.1:2375"
-	)
-
-	d := daemon.New(t)
-	d.Start(t, "--cluster-store="+discoveryBackend, "--cluster-advertise="+discoveryAdvertise)
-	defer d.Stop(t)
-
-	info := d.Info(t)
-	assert.Equal(t, info.ClusterStore, discoveryBackend)
-	assert.Equal(t, info.ClusterAdvertise, discoveryAdvertise)
-}
-
-// TestInfoDiscoveryInvalidAdvertise verifies that a daemon run with
-// an invalid `--cluster-advertise` configuration
-func TestInfoDiscoveryInvalidAdvertise(t *testing.T) {
-	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
-	d := daemon.New(t)
-
-	// --cluster-advertise with an invalid string is an error
-	err := d.StartWithError("--cluster-store=consul://consuladdr:consulport/some/path", "--cluster-advertise=invalid")
-	if err == nil {
-		d.Stop(t)
-	}
-	assert.ErrorContains(t, err, "", "expected error when starting daemon")
-
-	// --cluster-advertise without --cluster-store is also an error
-	err = d.StartWithError("--cluster-advertise=1.1.1.1:2375")
-	if err == nil {
-		d.Stop(t)
-	}
-	assert.ErrorContains(t, err, "", "expected error when starting daemon")
-}
-
-// TestInfoDiscoveryAdvertiseInterfaceName verifies that a daemon run with `--cluster-advertise`
-// configured with interface name properly show the advertise ip-address in info output.
-func TestInfoDiscoveryAdvertiseInterfaceName(t *testing.T) {
-	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
-	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
-	// TODO should we check for networking availability (integration-cli suite checks for networking through `Network()`)
-
-	d := daemon.New(t)
-	const (
-		discoveryStore     = "consul://consuladdr:consulport/some/path"
-		discoveryInterface = "eth0"
-	)
-
-	d.Start(t, "--cluster-store="+discoveryStore, fmt.Sprintf("--cluster-advertise=%s:2375", discoveryInterface))
-	defer d.Stop(t)
-
-	iface, err := net.InterfaceByName(discoveryInterface)
-	assert.NilError(t, err)
-	addrs, err := iface.Addrs()
-	assert.NilError(t, err)
-	assert.Assert(t, len(addrs) > 0)
-	ip, _, err := net.ParseCIDR(addrs[0].String())
-	assert.NilError(t, err)
-
-	info := d.Info(t)
-	assert.Equal(t, info.ClusterStore, discoveryStore)
-	assert.Equal(t, info.ClusterAdvertise, ip.String()+":2375")
 }


### PR DESCRIPTION
relates to / addresses part of https://github.com/moby/moby/issues/40383


Taking https://github.com/moby/moby/pull/42247 in smaller steps, as there was some failure in CI on that PR.

This one is the first 2 commits (I may add more)
