### PR TITLE
seccomp: add support for "swapcontext" syscall in default policy

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -474,7 +474,8 @@
 		},
 		{
 			"names": [
-				"sync_file_range2"
+				"sync_file_range2",
+				"swapcontext"
 			],
 			"action": "SCMP_ACT_ALLOW",
 			"includes": {

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -474,6 +474,7 @@ func DefaultProfile() *Seccomp {
 			LinuxSyscall: specs.LinuxSyscall{
 				Names: []string{
 					"sync_file_range2",
+					"swapcontext",
 				},
 				Action: specs.ActAllow,
 			},


### PR DESCRIPTION
**- What I did**
**- How I did it**
The swapcontext system call is only available on the 32- and 64-bit PowerPC architecture, it is
used by modern programming language implementations (such as gcc-go) to
implement coroutine features through userspace context switches.

Other container environment, such as Systemd nspawn already whitelist
this system call in their seccomp profile [\[1\]][1] [\[2\]][2]. As such, it would be
nice to also whitelist it in moby.

Issues with the current default seccomp profile were encountered on Alpine Linux's GitLab CI system, which uses
docker, when attempting to execute software compiled with gcc-go and [libucontext](https://github.com/kaniini/libucontext) on ppc64le.

**- How to verify it**

Try running a program using `setcontext(3)` on ppc64 in a docker container environment, see [systemd nspawn][2] for example code.

**- Description for the changelog**

Whitelist the PPC `swapcontext` system call in the default seccomp profile.

[1]: https://github.com/systemd/systemd/pull/9487
[2]: https://github.com/systemd/systemd/issues/9485