### PR TITLE
fix(client): Actually use DOCKER_HOST

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -117,6 +117,10 @@ func CheckRedirect(req *http.Request, via []*http.Request) error {
 // highly recommended that you set a version or your client may break if the
 // server is upgraded.
 func NewClientWithOpts(ops ...Opt) (*Client, error) {
+	dockerhost := os.Getenv("DOCKER_HOST")
+	if dockerhost == "" {
+		dockerhost = DefaultDockerHost
+	}
 	client, err := defaultHTTPClient(DefaultDockerHost)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I use rootless docker and tried to use it in my golang program. It ignored DOCKER_HOST and tried to connect to standard global path.

**- How I did it**
`go run main.go`

**- How to verify it**
try moving docker.sock and changing DOCKER_HOST

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/95982233/147003001-6a87ad71-53b7-4291-a6c0-d90ed3b62dbe.png)
