### PR TITLE
vendor: github.com/fluent/fluent-logger-golang v1.9.0

### DIFF
--- a/daemon/logger/fluentd/fluentd_test.go
+++ b/daemon/logger/fluentd/fluentd_test.go
@@ -1,0 +1,24 @@
+package fluentd // import "github.com/docker/docker/daemon/logger/fluentd"
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestValidateLogOptReconnectInterval(t *testing.T) {
+	invalidIntervals := []string{"-1", "1", "-1s", "99ms", "11s"}
+	for _, v := range invalidIntervals {
+		t.Run("invalid "+v, func(t *testing.T) {
+			err := ValidateLogOpt(map[string]string{asyncReconnectIntervalKey: v})
+			assert.ErrorContains(t, err, "invalid value for fluentd-async-reconnect-interval:")
+		})
+	}
+
+	validIntervals := []string{"100ms", "10s"}
+	for _, v := range validIntervals {
+		t.Run("valid "+v, func(t *testing.T) {
+			err := ValidateLogOpt(map[string]string{asyncReconnectIntervalKey: v})
+			assert.NilError(t, err)
+		})
+	}
+}

--- a/vendor.conf
+++ b/vendor.conf
@@ -103,7 +103,7 @@ github.com/godbus/dbus/v5                           c88335c0b1d28a30e7fc76d526a0
 github.com/Graylog2/go-gelf                         1550ee647df0510058c9d67a45c56f18911d80b8 # v2 branch
 
 # fluent-logger-golang deps
-github.com/fluent/fluent-logger-golang              0b652e850a9140d0b1db6390d8925d0601e952db # v1.8.0
+github.com/fluent/fluent-logger-golang              5538e904aeb515c10a624da620581bdf420d4b8a # v1.9.0
 github.com/philhofer/fwd                            bb6d471dc95d4fe11e432687f8b70ff496cf3136 # v1.0.0
 github.com/tinylib/msgp                             af6442a0fcf6e2a1b824f70dd0c734f01e817751 # v1.1.0
 

--- a/vendor/github.com/fluent/fluent-logger-golang/README.md
+++ b/vendor/github.com/fluent/fluent-logger-golang/README.md
@@ -132,6 +132,11 @@ When Async is enabled, if this is callback is provided, it will be called on eve
 takes two arguments - a `[]byte` of the message that was to be sent and an `error`. If the `error` is not nil this means the 
 delivery of the message was unsuccessful.
 
+### AsyncReconnectInterval
+When async is enabled, this option defines the interval (ms) at which the connection
+to the fluentd-address is re-established. This option is useful if the address
+may resolve to one or more IP addresses, e.g. a Consul service address.
+
 ### SubSecondPrecision
 
 Enable time encoding as EventTime, which contains sub-second precision values. The messages encoded with this option can be received only by Fluentd v0.14 or later.

--- a/vendor/github.com/fluent/fluent-logger-golang/fluent/version.go
+++ b/vendor/github.com/fluent/fluent-logger-golang/fluent/version.go
@@ -1,3 +1,3 @@
 package fluent
 
-const Version = "1.4.0"
+const Version = "1.9.0"


### PR DESCRIPTION
**- What I did**

Updated fluent-logger-golang dependency to v1.9.0 and added support in the logger for the new `AsyncReconnectInterval` parameter.

**- How to verify it**

Run a Docker container with the fluentd logging driver here and set the `fluentd-address` log-opt to an address with a host that could resolve to multiple IPs, e.g. `fluentd.service.consul:24224`. Set the `fluentd-async-reconnect-interval` to a value greater than 0 (value in ms). Observe that the container will periodically reconnect to the `fluentd-address`. You can force a reconnection by removing one of the fluent hosts from the service pool (or equivalent). 

**- Description for the changelog**
Support AsyncReconnectInterval parameter in fluentd logging driver. This option is useful if the address
may resolve to one or more IP addresses, e.g. a Consul service address.


**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/43791257/147109066-ded741df-6f92-44b8-b8b4-2fd9dcbcc36a.png)
