### PR TITLE
Remove io/ioutil again

### DIFF
--- a/daemon/logger/local/read_test.go
+++ b/daemon/logger/local/read_test.go
@@ -2,7 +2,6 @@ package local
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -23,7 +22,7 @@ func TestDecode(t *testing.T) {
 }
 
 func testDecode(t *testing.T, buf []byte, split int) {
-	fw, err := ioutil.TempFile("", t.Name())
+	fw, err := os.CreateTemp("", t.Name())
 	assert.NilError(t, err)
 	defer os.Remove(fw.Name())
 

--- a/hack/validate/golangci-lint.yml
+++ b/hack/validate/golangci-lint.yml
@@ -1,6 +1,7 @@
 linters:
   enable:
     - deadcode
+    - depguard
     - goimports
     - golint
     - gosec
@@ -31,7 +32,13 @@ linters:
 linters-settings:
   govet:
     check-shadowing: false
-
+  depguard:
+    list-type: blacklist
+    include-go-root: true
+    packages:
+      # The io/ioutil package has been deprecated.
+      # https://go.dev/doc/go1.16#ioutil
+      - io/ioutil
 issues:
   # The default exclusion rules are a bit too permissive, so copying the relevant ones below
   exclude-use-default: false


### PR DESCRIPTION
I've added io/ioutil again due to #43043. This PR adds golangci-lint check and removes io/ioutil.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Add golangci-lint check regarding io/ioutil
- Remove io/ioutil

**- How I did it**

Same as above :)

**- How to verify it**

I pushed the changes separately to make sure that golangci-lint catches the issue correctly.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![6a010535647bf3970b0282e139621a200b-800wi](https://user-images.githubusercontent.com/19111/147272717-8aa6215f-415e-4c97-afb1-1c9b9db92447.jpg)

