### PR TITLE
Btrfs optimizations for storing and deleting layers

### DIFF
--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -201,33 +201,7 @@ func getDirFd(dir *C.DIR) uintptr {
 	return uintptr(C.dirfd(dir))
 }
 
-func subvolCreate(path, name string) error {
-	dir, err := openDir(path)
-	if err != nil {
-		return err
-	}
-	defer closeDir(dir)
-
-	var args C.struct_btrfs_ioctl_vol_args
-	for i, c := range []byte(name) {
-		args.name[i] = C.char(c)
-	}
-
-	_, _, errno := unix.Syscall(unix.SYS_IOCTL, getDirFd(dir), C.BTRFS_IOC_SUBVOL_CREATE,
-		uintptr(unsafe.Pointer(&args)))
-	if errno != 0 {
-		return fmt.Errorf("Failed to create btrfs subvolume: %v", errno.Error())
-	}
-	return nil
-}
-
 func subvolSnapshot(src, dest, name string) error {
-	srcDir, err := openDir(src)
-	if err != nil {
-		return err
-	}
-	defer closeDir(srcDir)
-
 	destDir, err := openDir(dest)
 	if err != nil {
 		return err
@@ -235,17 +209,29 @@ func subvolSnapshot(src, dest, name string) error {
 	defer closeDir(destDir)
 
 	var args C.struct_btrfs_ioctl_vol_args_v2
-	args.fd = C.__s64(getDirFd(srcDir))
+
+	var cmd uintptr = C.BTRFS_IOC_SUBVOL_CREATE_V2
+	if src != "" {
+		cmd = C.BTRFS_IOC_SNAP_CREATE_V2
+
+		srcDir, err := openDir(src)
+		if err != nil {
+			return err
+		}
+		defer closeDir(srcDir)
+
+		args.fd = C.__s64(getDirFd(srcDir))
+	}
 
 	var cs = C.CString(name)
 	C.set_name_btrfs_ioctl_vol_args_v2(&args, cs)
 	C.free(unsafe.Pointer(cs))
 
-	_, _, errno := unix.Syscall(unix.SYS_IOCTL, getDirFd(destDir), C.BTRFS_IOC_SNAP_CREATE_V2,
-		uintptr(unsafe.Pointer(&args)))
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, getDirFd(destDir), cmd, uintptr(unsafe.Pointer(&args)))
 	if errno != 0 {
-		return fmt.Errorf("Failed to create btrfs snapshot: %v", errno.Error())
+		return fmt.Errorf("Failed to create btrfs subvolume: %v", errno.Error())
 	}
+
 	return nil
 }
 
@@ -294,7 +280,7 @@ func subvolDelete(dirpath, name string, quotaEnabled bool) error {
 		}
 		return nil
 	}
-	if err := filepath.Walk(path.Join(dirpath, name), walkSubvolumes); err != nil {
+	if err := filepath.Walk(fullPath, walkSubvolumes); err != nil {
 		return fmt.Errorf("Recursively walking subvolumes for %s failed: %v", dirpath, err)
 	}
 
@@ -485,8 +471,8 @@ func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 
 // Create the filesystem with given id.
 func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
-	quotas := path.Join(d.home, "quotas")
-	subvolumes := path.Join(d.home, "subvolumes")
+	quotas := d.quotasDir()
+	subvolumes := d.subvolumesDir()
 	root := d.idMap.RootPair()
 
 	currentID := idtools.CurrentIdentity()
@@ -498,12 +484,9 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
 	if err := idtools.MkdirAllAndChown(subvolumes, 0710, dirID); err != nil {
 		return err
 	}
-	if parent == "" {
-		if err := subvolCreate(subvolumes, id); err != nil {
-			return err
-		}
-	} else {
-		parentDir := d.subvolumesDirID(parent)
+	parentDir := ""
+	if parent != "" {
+		parentDir = d.subvolumesDirID(parent)
 		st, err := os.Stat(parentDir)
 		if err != nil {
 			return err
@@ -511,9 +494,9 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
 		if !st.IsDir() {
 			return fmt.Errorf("%s: not a directory", parentDir)
 		}
-		if err := subvolSnapshot(parentDir, subvolumes, id); err != nil {
-			return err
-		}
+	}
+	if err := subvolSnapshot(parentDir, subvolumes, id); err != nil {
+		return err
 	}
 
 	var storageOpt map[string]string
@@ -521,19 +504,20 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
 		storageOpt = opts.StorageOpt
 	}
 
+	subvolumeDir := d.subvolumesDirID(id)
 	if _, ok := storageOpt["size"]; ok {
 		driver := &Driver{}
 		if err := d.parseStorageOpt(storageOpt, driver); err != nil {
 			return err
 		}
 
-		if err := d.setStorageSize(path.Join(subvolumes, id), driver); err != nil {
+		if err := d.setStorageSize(subvolumeDir, driver); err != nil {
 			return err
 		}
 		if err := idtools.MkdirAllAndChown(quotas, 0700, idtools.CurrentIdentity()); err != nil {
 			return err
 		}
-		if err := os.WriteFile(path.Join(quotas, id), []byte(fmt.Sprint(driver.options.size)), 0644); err != nil {
+		if err := os.WriteFile(d.quotasDirID(id), []byte(fmt.Sprint(driver.options.size)), 0644); err != nil {
 			return err
 		}
 	}
@@ -541,7 +525,7 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
 	// if we have a remapped root (user namespaces enabled), change the created snapshot
 	// dir ownership to match
 	if root.UID != 0 || root.GID != 0 {
-		if err := root.Chown(path.Join(subvolumes, id)); err != nil {
+		if err := root.Chown(subvolumeDir); err != nil {
 			return err
 		}
 	}
@@ -551,7 +535,7 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
 		mountLabel = opts.MountLabel
 	}
 
-	return label.Relabel(path.Join(subvolumes, id), mountLabel, false)
+	return label.Relabel(subvolumeDir, mountLabel, false)
 }
 
 // Parse btrfs storage options
@@ -654,8 +638,8 @@ func (d *Driver) Get(id, mountLabel string) (containerfs.ContainerFS, error) {
 
 // Put is not implemented for BTRFS as there is no cleanup required for the id.
 func (d *Driver) Put(id string) error {
-	// Get() creates no runtime resources (like e.g. mounts)
-	// so this doesn't need to do anything.
+	// Get() creates no runtime resources (like e.g. mounts),
+	// so this doesn't need to do anything
 	return nil
 }
 

--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -9,20 +9,26 @@ package btrfs // import "github.com/docker/docker/daemon/graphdriver/btrfs"
 #include <unistd.h>
 #include <btrfs/ctree.h>
 
-static int set_name_btrfs_ioctl_vol_args(struct btrfs_ioctl_vol_args* btrfs_struct, char* name) {
-    int r = snprintf(btrfs_struct->name,
-                     sizeof(btrfs_struct->name),
-                     "%s", name);
-    free(name);
-    return r;
+static int copy_GoString_to_CString(char *dst, size_t dst_size, const _GoString_ src) {
+    const size_t src_size = _GoStringLen(src);
+    if (src_size >= dst_size) {
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+    const char *psrc = _GoStringPtr(src);
+    memcpy(dst, psrc, src_size);
+    dst[src_size] = '\0';
+    return src_size;
 }
 
-static int set_name_btrfs_ioctl_vol_args_v2(struct btrfs_ioctl_vol_args_v2* btrfs_struct, char* name) {
-    int r = snprintf(btrfs_struct->name,
-                     sizeof(btrfs_struct->name),
-                     "%s", name);
-    free(name);
-    return r;
+#define GOSTR_TO_CSTR(src, dst) copy_GoString_to_CString(dst, sizeof(dst), src)
+
+static inline int set_name_btrfs_ioctl_vol_args(struct btrfs_ioctl_vol_args* btrfs_struct, const _GoString_ name) {
+    return GOSTR_TO_CSTR(name, btrfs_struct->name);
+}
+
+static inline int set_name_btrfs_ioctl_vol_args_v2(struct btrfs_ioctl_vol_args_v2* btrfs_struct, const _GoString_ name) {
+    return GOSTR_TO_CSTR(name, btrfs_struct->name);
 }
 
 static inline __u16 _le16toh(__le16 i) {return le16toh(i);}
@@ -291,7 +297,7 @@ func subvolSnapshot(src, dest, name string) error {
 		args.fd = C.__s64(getDirFd(srcDir))
 	}
 
-	if r, err := C.set_name_btrfs_ioctl_vol_args_v2(&args, C.CString(name)); r < 0 {
+	if r, err := C.set_name_btrfs_ioctl_vol_args_v2(&args, name); r < 0 {
 		return fmt.Errorf("Failed to copy subvolume name %s to args struct: %v", name, err)
 	}
 
@@ -396,7 +402,7 @@ func subvolDelete(dirpath, name string, subvolID C.__u64, quotaEnabled bool) err
 		}
 
 		var args C.struct_btrfs_ioctl_vol_args
-		if r, err := C.set_name_btrfs_ioctl_vol_args(&args, C.CString(name)); r < 0 {
+		if r, err := C.set_name_btrfs_ioctl_vol_args(&args, name); r < 0 {
 			return err.(syscall.Errno)
 		}
 		_, _, errno := unix.Syscall(unix.SYS_IOCTL, getDirFd(dir), C.BTRFS_IOC_SNAP_DESTROY,

--- a/daemon/graphdriver/btrfs/btrfs_test.go
+++ b/daemon/graphdriver/btrfs/btrfs_test.go
@@ -4,8 +4,11 @@
 package btrfs // import "github.com/docker/docker/daemon/graphdriver/btrfs"
 
 import (
+	"fmt"
 	"os"
 	"path"
+	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/docker/docker/daemon/graphdriver/graphtest"
@@ -40,15 +43,27 @@ func TestBtrfsSubvolDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer d.Put("test")
 
 	dir := dirFS.Path()
 
-	if err := subvolSnapshot("", dir, "subvoltest"); err != nil {
+	if err := subvolSnapshot("", dir, "subvoltest1"); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := os.Stat(path.Join(dir, "subvoltest")); err != nil {
+	if _, err := os.Stat(path.Join(dir, "subvoltest1")); err != nil {
+		t.Fatal(err)
+	}
+
+	idir := path.Join(dir, "intermediate")
+	if err := os.Mkdir(idir, 0777); err != nil {
+		t.Fatalf("Failed to create intermediate dir %s: %v", idir, err)
+	}
+
+	if err := subvolSnapshot("", idir, "subvoltest2"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := d.Put("test"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -56,8 +71,114 @@ func TestBtrfsSubvolDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := os.Stat(path.Join(dir, "subvoltest")); !os.IsNotExist(err) {
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
 		t.Fatalf("expected not exist error on nested subvol, got: %v", err)
+	}
+}
+
+func TestBtrfsSubvolLongPath(t *testing.T) {
+	d := graphtest.GetDriver(t, "btrfs")
+	defer graphtest.PutDriver(t)
+
+	wdir, _ := os.Getwd()
+
+	if err := d.Create("rootsubvol", "", nil); err != nil {
+		t.Fatalf("Failed to create rootsubvol: %v", err)
+	}
+	rootFS, err := d.Get("rootsubvol", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	subvoldir := rootFS.Path()
+
+	getMaxFilenameFormPattern := func(pattern string) string {
+		name := strings.Repeat(pattern, (syscall.NAME_MAX / len(pattern)))
+		return (name + pattern[:(syscall.NAME_MAX-len(name))])
+	}
+
+	os.Chdir(subvoldir)
+	defer os.Chdir(wdir)
+
+	for i, l := 1, len(subvoldir); l <= syscall.PathMax*2; i++ {
+		dfile, err := os.OpenFile("dummyFile", os.O_RDONLY|os.O_CREATE, 0666)
+		if err != nil {
+			t.Fatalf("Failed to create file at %s: %v", subvoldir, err)
+		}
+		if err := dfile.Close(); err != nil {
+			t.Fatal(err)
+		}
+		name := getMaxFilenameFormPattern(fmt.Sprintf("LongPathToFirstSubvol_LVL%d_", i))
+		if err := os.Mkdir(name, 0777); err != nil {
+			t.Fatalf("Failed to create dir %s/%s: %v", subvoldir, name, err)
+		}
+		if err := os.Chdir(name); err != nil {
+			t.Fatal(err)
+		}
+		l += len(name)
+		subvoldir = path.Join(subvoldir, name)
+	}
+
+	if err := subvolSnapshot("", subvoldir, "subvolLVL1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := subvolSnapshot("", subvoldir+"/..", "subvolLVL1_0"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir("subvolLVL1"); err != nil {
+		t.Fatal(err)
+	}
+	subvoldir = path.Join(subvoldir, "subvolLVL1")
+
+	i := 1
+	for l := 0; l < syscall.PathMax; i++ {
+		name := getMaxFilenameFormPattern(fmt.Sprintf("LongPathToNestedSub_1_LVL%d_", i))
+		if err := os.Mkdir(name, 0777); err != nil {
+			t.Fatalf("Failed to create dir %s/%s: %v", subvoldir, name, err)
+		}
+		if err := os.Chdir(name); err != nil {
+			t.Fatal(err)
+		}
+		l += len(name)
+		subvoldir = path.Join(subvoldir, name)
+	}
+
+	if err := subvolSnapshot("", subvoldir, "subvolLVL2_1"); err != nil {
+		t.Fatal(err)
+	}
+
+	for ; i > 1; i-- {
+		if err := os.Chdir(".."); err != nil {
+			t.Fatal(err)
+		}
+		subvoldir = path.Dir(subvoldir)
+	}
+
+	for i, l := 1, 0; l < syscall.PathMax*2; i++ {
+		name := getMaxFilenameFormPattern(fmt.Sprintf("LongPathToNestedSub_2_LVL%d_", i))
+		if err := os.Mkdir(name, 0777); err != nil {
+			t.Fatalf("Failed to create dir %s/%s: %v", subvoldir, name, err)
+		}
+		if err := os.Chdir(name); err != nil {
+			t.Fatal(err)
+		}
+		l += len(name)
+		subvoldir = path.Join(subvoldir, name)
+	}
+
+	if err := subvolSnapshot("", subvoldir, "subvolLVL2_3"); err != nil {
+		t.Fatal(err)
+	}
+	if err := subvolSnapshot("", subvoldir, "subvolLVL2_2"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := d.Put("rootsubvol"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := d.Remove("rootsubvol"); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/daemon/graphdriver/btrfs/btrfs_test.go
+++ b/daemon/graphdriver/btrfs/btrfs_test.go
@@ -44,7 +44,7 @@ func TestBtrfsSubvolDelete(t *testing.T) {
 
 	dir := dirFS.Path()
 
-	if err := subvolCreate(dir, "subvoltest"); err != nil {
+	if err := subvolSnapshot("", dir, "subvoltest"); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This changeset is a cherry-pick of the changes in #36536. Specifically, the changes related to optimizing deleting layers are included here. Changes related to quotas are not included here, as I don't use quotas and so can't reliably test the changes.

Changes related to storing layers as read-only in btrfs are not included, due to the behavior change that would be required if deleting the Docker data directory entirely on btrfs filesystems.

**- How I did it**

**- How to verify it**

I've tested the resulting dockerd binary and after deleting all caches and layers, I was able to run `make binary` for Docker. Additionally, a quick smoke test with some public containers seems to work fine. I've also verified with `strace` that when removing containers and layers, Docker is no longer traversing the entire layer.

**- Description for the changelog**

In summary, the changes in this branch will do the following:
1. Change the subvolume deletion code to ask btrfs for any nested subvolumes using ioctl calls, instead of traversing each layer. This will result in a huge performance improvement for large layers, as the number of system calls will be much lower.

With these changes, rootless mode appears to still work (at least for the basic container pull, start, and delete cases). However, container deletion in rootless mode will be significantly slower than in root mode, because the ioctl call to delete a subvolume (and check for nested subvolumes) requires root permissions. This, I believe, is the same as the current code.

Fixes #42973

**- A picture of a cute animal (not mandatory but encouraged)**

