### PR TITLE
Use syscall.Timespec.Unix

### DIFF
--- a/daemon/graphdriver/copy/copy.go
+++ b/daemon/graphdriver/copy/copy.go
@@ -228,8 +228,8 @@ func DirCopy(srcDir, dstDir string, copyMode Mode, copyXattrs bool) error {
 		if f.IsDir() {
 			dirsToSetMtimes.PushFront(&dirMtimeInfo{dstPath: &dstPath, stat: stat})
 		} else if !isSymlink {
-			aTime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
-			mTime := time.Unix(int64(stat.Mtim.Sec), int64(stat.Mtim.Nsec))
+			aTime := time.Unix(stat.Atim.Unix())
+			mTime := time.Unix(stat.Mtim.Unix())
 			if err := system.Chtimes(dstPath, aTime, mTime); err != nil {
 				return err
 			}

--- a/pkg/system/chtimes_linux_test.go
+++ b/pkg/system/chtimes_linux_test.go
@@ -26,7 +26,7 @@ func TestChtimesLinux(t *testing.T) {
 	}
 
 	stat := f.Sys().(*syscall.Stat_t)
-	aTime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec)) //nolint: unconvert
+	aTime := time.Unix(stat.Atim.Unix())
 	if aTime != unixEpochTime {
 		t.Fatalf("Expected: %s, got: %s", unixEpochTime, aTime)
 	}
@@ -40,7 +40,7 @@ func TestChtimesLinux(t *testing.T) {
 	}
 
 	stat = f.Sys().(*syscall.Stat_t)
-	aTime = time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec)) //nolint: unconvert
+	aTime = time.Unix(stat.Atim.Unix())
 	if aTime != unixEpochTime {
 		t.Fatalf("Expected: %s, got: %s", unixEpochTime, aTime)
 	}
@@ -54,7 +54,7 @@ func TestChtimesLinux(t *testing.T) {
 	}
 
 	stat = f.Sys().(*syscall.Stat_t)
-	aTime = time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec)) //nolint: unconvert
+	aTime = time.Unix(stat.Atim.Unix())
 	if aTime != unixEpochTime {
 		t.Fatalf("Expected: %s, got: %s", unixEpochTime, aTime)
 	}
@@ -68,7 +68,7 @@ func TestChtimesLinux(t *testing.T) {
 	}
 
 	stat = f.Sys().(*syscall.Stat_t)
-	aTime = time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec)) //nolint: unconvert
+	aTime = time.Unix(stat.Atim.Unix())
 	if aTime != afterUnixEpochTime {
 		t.Fatalf("Expected: %s, got: %s", afterUnixEpochTime, aTime)
 	}
@@ -82,7 +82,7 @@ func TestChtimesLinux(t *testing.T) {
 	}
 
 	stat = f.Sys().(*syscall.Stat_t)
-	aTime = time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec)) //nolint: unconvert
+	aTime = time.Unix(stat.Atim.Unix())
 	if aTime.Truncate(time.Second) != unixMaxTime.Truncate(time.Second) {
 		t.Fatalf("Expected: %s, got: %s", unixMaxTime.Truncate(time.Second), aTime.Truncate(time.Second))
 	}


### PR DESCRIPTION
Use the syscall method instead of repeating the type conversions for
the syscall.Stat_t Atim/Mtim members. This also allows to drop the
//nolint: unconvert comments.