### PR TITLE
Fixing /exec/{id}/resize response code in API documentation

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8782,7 +8782,7 @@ paths:
         if `tty` was specified as part of creating and starting the exec instance.
       operationId: "ExecResize"
       responses:
-        201:
+        200:
           description: "No error"
         404:
           description: "No such exec instance"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8784,8 +8784,16 @@ paths:
       responses:
         200:
           description: "No error"
+        400:
+          description: "bad parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         404:
           description: "No such exec instance"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        500:
+          description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:


### PR DESCRIPTION
**- What I did**
These commits fix the `/exec/{id}/resize` endpoint documentation by updating the success code from `201 Created` to `200 OK` and adding errors such as `400` and `500` errors.

**- How I did it**
I modified the `api/swagger.yaml` file and updated/added the corresponding codes.
Maybe another commit is required to edit the files in `docs/api` as the docs are generated from these files in the `master` branch. In this case, which version of the documentation should be updated?

<!-- **- How to verify it** -->

**- Description for the changelog**
Fixed exec resize codes in API documentation

<!-- **- A picture of a cute animal (not mandatory but encouraged)** -->