### PR TITLE
daemon: load and cache sysInfo on initialization

### DIFF
--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -11,7 +11,7 @@ import (
 func (daemon *Daemon) saveAppArmorConfig(container *container.Container) error {
 	container.AppArmorProfile = "" // we don't care about the previous value.
 
-	if !daemon.apparmorEnabled {
+	if !daemon.RawSysInfo().AppArmor {
 		return nil // if apparmor is disabled there is nothing to do here.
 	}
 
@@ -19,13 +19,10 @@ func (daemon *Daemon) saveAppArmorConfig(container *container.Container) error {
 		return errdefs.InvalidParameter(err)
 	}
 
-	if !container.HostConfig.Privileged {
-		if container.AppArmorProfile == "" {
-			container.AppArmorProfile = defaultAppArmorProfile
-		}
-
-	} else {
+	if container.HostConfig.Privileged {
 		container.AppArmorProfile = unconfinedAppArmorProfile
+	} else if container.AppArmorProfile == "" {
+		container.AppArmorProfile = defaultAppArmorProfile
 	}
 	return nil
 }

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1731,19 +1731,14 @@ func (daemon *Daemon) setupSeccompProfile() error {
 	return nil
 }
 
-// RawSysInfo returns *sysinfo.SysInfo .
-func (daemon *Daemon) RawSysInfo() *sysinfo.SysInfo {
+func (daemon *Daemon) loadSysInfo() {
 	var siOpts []sysinfo.Opt
 	if daemon.getCgroupDriver() == cgroupSystemdDriver {
 		if euid := os.Getenv("ROOTLESSKIT_PARENT_EUID"); euid != "" {
 			siOpts = append(siOpts, sysinfo.WithCgroup2GroupPath("/user.slice/user-"+euid+".slice"))
 		}
 	}
-	return sysinfo.New(siOpts...)
-}
-
-func recursiveUnmount(target string) error {
-	return mount.RecursiveUnmount(target)
+	daemon.sysInfo = sysinfo.New(siOpts...)
 }
 
 func (daemon *Daemon) initLibcontainerd(ctx context.Context) error {
@@ -1756,4 +1751,8 @@ func (daemon *Daemon) initLibcontainerd(ctx context.Context) error {
 		daemon,
 	)
 	return err
+}
+
+func recursiveUnmount(target string) error {
+	return mount.RecursiveUnmount(target)
 }

--- a/daemon/daemon_unsupported.go
+++ b/daemon/daemon_unsupported.go
@@ -13,7 +13,6 @@ const platformSupported = false
 func setupResolvConf(config *config.Config) {
 }
 
-// RawSysInfo returns *sysinfo.SysInfo .
-func (daemon *Daemon) RawSysInfo() *sysinfo.SysInfo {
-	return sysinfo.New()
+func (daemon *Daemon) loadSysInfo() {
+	daemon.sysInfo = sysinfo.New()
 }

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -650,9 +650,8 @@ func (daemon *Daemon) initRuntimes(_ map[string]types.Runtime) error {
 func setupResolvConf(config *config.Config) {
 }
 
-// RawSysInfo returns *sysinfo.SysInfo .
-func (daemon *Daemon) RawSysInfo() *sysinfo.SysInfo {
-	return sysinfo.New()
+func (daemon *Daemon) loadSysInfo() {
+	daemon.sysInfo = sysinfo.New()
 }
 
 func (daemon *Daemon) initLibcontainerd(ctx context.Context) error {

--- a/daemon/seccomp_linux.go
+++ b/daemon/seccomp_linux.go
@@ -26,7 +26,7 @@ func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		if c.HostConfig.Privileged {
 			return nil
 		}
-		if !daemon.seccompEnabled {
+		if !daemon.RawSysInfo().Seccomp {
 			if c.SeccompProfile != "" && c.SeccompProfile != dconfig.SeccompProfileDefault {
 				return fmt.Errorf("seccomp is not enabled in your kernel, cannot run a custom seccomp profile")
 			}

--- a/daemon/seccomp_linux_test.go
+++ b/daemon/seccomp_linux_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/container"
 	dconfig "github.com/docker/docker/daemon/config"
 	doci "github.com/docker/docker/oci"
+	"github.com/docker/docker/pkg/sysinfo"
 	"github.com/docker/docker/profiles/seccomp"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"gotest.tools/v3/assert"
@@ -31,7 +32,7 @@ func TestWithSeccomp(t *testing.T) {
 		{
 			comment: "unconfined seccompProfile runs unconfined",
 			daemon: &Daemon{
-				seccompEnabled: true,
+				sysInfo: &sysinfo.SysInfo{Seccomp: true},
 			},
 			c: &container.Container{
 				SeccompProfile: dconfig.SeccompProfileUnconfined,
@@ -45,7 +46,7 @@ func TestWithSeccomp(t *testing.T) {
 		{
 			comment: "privileged container w/ custom profile runs unconfined",
 			daemon: &Daemon{
-				seccompEnabled: true,
+				sysInfo: &sysinfo.SysInfo{Seccomp: true},
 			},
 			c: &container.Container{
 				SeccompProfile: "{ \"defaultAction\": \"SCMP_ACT_LOG\" }",
@@ -59,7 +60,7 @@ func TestWithSeccomp(t *testing.T) {
 		{
 			comment: "privileged container w/ default runs unconfined",
 			daemon: &Daemon{
-				seccompEnabled: true,
+				sysInfo: &sysinfo.SysInfo{Seccomp: true},
 			},
 			c: &container.Container{
 				SeccompProfile: "",
@@ -73,7 +74,7 @@ func TestWithSeccomp(t *testing.T) {
 		{
 			comment: "privileged container w/ daemon profile runs unconfined",
 			daemon: &Daemon{
-				seccompEnabled: true,
+				sysInfo:        &sysinfo.SysInfo{Seccomp: true},
 				seccompProfile: []byte("{ \"defaultAction\": \"SCMP_ACT_ERRNO\" }"),
 			},
 			c: &container.Container{
@@ -88,7 +89,7 @@ func TestWithSeccomp(t *testing.T) {
 		{
 			comment: "custom profile when seccomp is disabled returns error",
 			daemon: &Daemon{
-				seccompEnabled: false,
+				sysInfo: &sysinfo.SysInfo{Seccomp: false},
 			},
 			c: &container.Container{
 				SeccompProfile: "{ \"defaultAction\": \"SCMP_ACT_ERRNO\" }",
@@ -103,7 +104,7 @@ func TestWithSeccomp(t *testing.T) {
 		{
 			comment: "empty profile name loads default profile",
 			daemon: &Daemon{
-				seccompEnabled: true,
+				sysInfo: &sysinfo.SysInfo{Seccomp: true},
 			},
 			c: &container.Container{
 				SeccompProfile: "",
@@ -122,7 +123,7 @@ func TestWithSeccomp(t *testing.T) {
 		{
 			comment: "load container's profile",
 			daemon: &Daemon{
-				seccompEnabled: true,
+				sysInfo: &sysinfo.SysInfo{Seccomp: true},
 			},
 			c: &container.Container{
 				SeccompProfile: "{ \"defaultAction\": \"SCMP_ACT_ERRNO\" }",
@@ -143,7 +144,7 @@ func TestWithSeccomp(t *testing.T) {
 		{
 			comment: "load daemon's profile",
 			daemon: &Daemon{
-				seccompEnabled: true,
+				sysInfo:        &sysinfo.SysInfo{Seccomp: true},
 				seccompProfile: []byte("{ \"defaultAction\": \"SCMP_ACT_ERRNO\" }"),
 			},
 			c: &container.Container{
@@ -165,7 +166,7 @@ func TestWithSeccomp(t *testing.T) {
 		{
 			comment: "load prioritise container profile over daemon's",
 			daemon: &Daemon{
-				seccompEnabled: true,
+				sysInfo:        &sysinfo.SysInfo{Seccomp: true},
 				seccompProfile: []byte("{ \"defaultAction\": \"SCMP_ACT_ERRNO\" }"),
 			},
 			c: &container.Container{
@@ -185,6 +186,7 @@ func TestWithSeccomp(t *testing.T) {
 			}(),
 		},
 	} {
+		x := x
 		t.Run(x.comment, func(t *testing.T) {
 			opts := WithSeccomp(x.daemon, x.c)
 			err := opts(nil, nil, nil, &x.inSpec)


### PR DESCRIPTION
The `daemon.RawSysInfo()` function can be a heavy operation, as it collects
information about all cgroups on the host, networking, AppArmor, Seccomp, etc.

While looking at our code, I noticed that various parts in the code call this
function, potentially even _multiple times_ per container, for example, it is
called from:

- `verifyPlatformContainerSettings()`
- `oci.WithCgroups()` if the daemon has `cpu-rt-period` or `cpu-rt-runtime` configured
- in `ContainerDecoder.DecodeConfig()`, which is called on boith `container create` and `container commit`

Given that this information is not expected to change during the daemon's
lifecycle, and various information coming from this (such as seccomp and
apparmor status) was already cached, we may as well load it once, and cache
the results in the daemon instance.

This patch updates `daemon.RawSysInfo()` to use a `sync.Once()` so that
it's only executed once for the daemon's lifecycle.

~For sake of completenes: I considered updating `daemon.RawSysInfo()` to use a `sync.Once()` instead (to make this automatic on first use), but (for now) decided against it, as it could complicate some tests, and for regular use of the daemon, the daemon would be constructed using `daemon.NewDaemon()`.~


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

