### PR TITLE
test: fix a simple goroutine leak in distribution/xfer

### DIFF
--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -350,6 +350,7 @@ func TestCancelledDownload(t *testing.T) {
 	descriptors := downloadDescriptors(nil)
 	_, _, err := ldm.Download(ctx, *image.NewRootFS(), runtime.GOOS, descriptors, progress.ChanOutput(progressChan))
 	if err != context.Canceled {
+		close(progressChan)
 		t.Fatal("expected download to be cancelled")
 	}
 


### PR DESCRIPTION
**- What I did**

Fixed a leaked goroutine in a unit test.

**- How I did it**

Added close channel operation to make the leaked goroutine return

**- How to verify it**

`TestCancelledDownload` creates a channel `progressChan`, and creates a child goroutine to range from it. However, the close operations may not be reached due to `t.Fatal()`, which makes the child goroutine blocked even after the unit test returns. 

https://github.com/moby/moby/blob/ea96e160e437bb241ed638f5f279c2fd58f139c4/distribution/xfer/download_test.go#L331-L341

https://github.com/moby/moby/blob/ea96e160e437bb241ed638f5f279c2fd58f139c4/distribution/xfer/download_test.go#L352-L358

**- Description for the changelog**
None