### PR TITLE
docs: fixing /exec/{id}/resize response code in API documentation

### DIFF
--- a/docs/api/v1.25.yaml
+++ b/docs/api/v1.25.yaml
@@ -5679,10 +5679,18 @@ paths:
       description: "Resize the TTY session used by an exec instance. This endpoint only works if `tty` was specified as part of creating and starting the exec instance."
       operationId: "ExecResize"
       responses:
-        201:
+        200:
           description: "No error"
+        400:
+          description: "bad parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         404:
           description: "No such exec instance"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        500:
+          description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:

--- a/docs/api/v1.26.yaml
+++ b/docs/api/v1.26.yaml
@@ -5688,10 +5688,18 @@ paths:
       description: "Resize the TTY session used by an exec instance. This endpoint only works if `tty` was specified as part of creating and starting the exec instance."
       operationId: "ExecResize"
       responses:
-        201:
+        200:
           description: "No error"
+        400:
+          description: "bad parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         404:
           description: "No such exec instance"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        500:
+          description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:

--- a/docs/api/v1.27.yaml
+++ b/docs/api/v1.27.yaml
@@ -5763,10 +5763,18 @@ paths:
       description: "Resize the TTY session used by an exec instance. This endpoint only works if `tty` was specified as part of creating and starting the exec instance."
       operationId: "ExecResize"
       responses:
-        201:
+        200:
           description: "No error"
+        400:
+          description: "bad parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         404:
           description: "No such exec instance"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        500:
+          description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:

--- a/docs/api/v1.28.yaml
+++ b/docs/api/v1.28.yaml
@@ -5879,10 +5879,18 @@ paths:
       description: "Resize the TTY session used by an exec instance. This endpoint only works if `tty` was specified as part of creating and starting the exec instance."
       operationId: "ExecResize"
       responses:
-        201:
+        200:
           description: "No error"
+        400:
+          description: "bad parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         404:
           description: "No such exec instance"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        500:
+          description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:

--- a/docs/api/v1.29.yaml
+++ b/docs/api/v1.29.yaml
@@ -5913,10 +5913,18 @@ paths:
       description: "Resize the TTY session used by an exec instance. This endpoint only works if `tty` was specified as part of creating and starting the exec instance."
       operationId: "ExecResize"
       responses:
-        201:
+        200:
           description: "No error"
+        400:
+          description: "bad parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         404:
           description: "No such exec instance"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        500:
+          description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:

--- a/docs/api/v1.30.yaml
+++ b/docs/api/v1.30.yaml
@@ -6149,10 +6149,18 @@ paths:
       description: "Resize the TTY session used by an exec instance. This endpoint only works if `tty` was specified as part of creating and starting the exec instance."
       operationId: "ExecResize"
       responses:
-        201:
+        200:
           description: "No error"
+        400:
+          description: "bad parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         404:
           description: "No such exec instance"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        500:
+          description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:

--- a/docs/api/v1.31.yaml
+++ b/docs/api/v1.31.yaml
@@ -6242,10 +6242,18 @@ paths:
       description: "Resize the TTY session used by an exec instance. This endpoint only works if `tty` was specified as part of creating and starting the exec instance."
       operationId: "ExecResize"
       responses:
-        201:
+        200:
           description: "No error"
+        400:
+          description: "bad parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         404:
           description: "No such exec instance"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        500:
+          description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:

--- a/docs/api/v1.32.yaml
+++ b/docs/api/v1.32.yaml
@@ -7279,10 +7279,18 @@ paths:
       description: "Resize the TTY session used by an exec instance. This endpoint only works if `tty` was specified as part of creating and starting the exec instance."
       operationId: "ExecResize"
       responses:
-        201:
+        200:
           description: "No error"
+        400:
+          description: "bad parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         404:
           description: "No such exec instance"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        500:
+          description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:

--- a/docs/api/v1.33.yaml
+++ b/docs/api/v1.33.yaml
@@ -7288,10 +7288,18 @@ paths:
       description: "Resize the TTY session used by an exec instance. This endpoint only works if `tty` was specified as part of creating and starting the exec instance."
       operationId: "ExecResize"
       responses:
-        201:
+        200:
           description: "No error"
+        400:
+          description: "bad parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         404:
           description: "No such exec instance"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        500:
+          description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:

--- a/docs/api/v1.34.yaml
+++ b/docs/api/v1.34.yaml
@@ -7334,10 +7334,18 @@ paths:
       description: "Resize the TTY session used by an exec instance. This endpoint only works if `tty` was specified as part of creating and starting the exec instance."
       operationId: "ExecResize"
       responses:
-        201:
+        200:
           description: "No error"
+        400:
+          description: "bad parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         404:
           description: "No such exec instance"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        500:
+          description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:

--- a/docs/api/v1.35.yaml
+++ b/docs/api/v1.35.yaml
@@ -7346,10 +7346,18 @@ paths:
       description: "Resize the TTY session used by an exec instance. This endpoint only works if `tty` was specified as part of creating and starting the exec instance."
       operationId: "ExecResize"
       responses:
-        201:
+        200:
           description: "No error"
+        400:
+          description: "bad parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         404:
           description: "No such exec instance"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        500:
+          description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:

--- a/docs/api/v1.36.yaml
+++ b/docs/api/v1.36.yaml
@@ -7380,10 +7380,18 @@ paths:
       description: "Resize the TTY session used by an exec instance. This endpoint only works if `tty` was specified as part of creating and starting the exec instance."
       operationId: "ExecResize"
       responses:
-        201:
+        200:
           description: "No error"
+        400:
+          description: "bad parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         404:
           description: "No such exec instance"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        500:
+          description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:

--- a/docs/api/v1.37.yaml
+++ b/docs/api/v1.37.yaml
@@ -7423,10 +7423,18 @@ paths:
       description: "Resize the TTY session used by an exec instance. This endpoint only works if `tty` was specified as part of creating and starting the exec instance."
       operationId: "ExecResize"
       responses:
-        201:
+        200:
           description: "No error"
+        400:
+          description: "bad parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         404:
           description: "No such exec instance"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        500:
+          description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:

--- a/docs/api/v1.38.yaml
+++ b/docs/api/v1.38.yaml
@@ -7484,10 +7484,18 @@ paths:
       description: "Resize the TTY session used by an exec instance. This endpoint only works if `tty` was specified as part of creating and starting the exec instance."
       operationId: "ExecResize"
       responses:
-        201:
+        200:
           description: "No error"
+        400:
+          description: "bad parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         404:
           description: "No such exec instance"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        500:
+          description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -8249,10 +8249,18 @@ paths:
         if `tty` was specified as part of creating and starting the exec instance.
       operationId: "ExecResize"
       responses:
-        201:
+        200:
           description: "No error"
+        400:
+          description: "bad parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         404:
           description: "No such exec instance"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        500:
+          description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -8437,10 +8437,18 @@ paths:
         if `tty` was specified as part of creating and starting the exec instance.
       operationId: "ExecResize"
       responses:
-        201:
+        200:
           description: "No error"
+        400:
+          description: "bad parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         404:
           description: "No such exec instance"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        500:
+          description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -8607,10 +8607,18 @@ paths:
         if `tty` was specified as part of creating and starting the exec instance.
       operationId: "ExecResize"
       responses:
-        201:
+        200:
           description: "No error"
+        400:
+          description: "bad parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         404:
           description: "No such exec instance"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        500:
+          description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:


### PR DESCRIPTION
This takes the changes from 1a933e113dc20c22c0d5906cf0b07d3f52098bba and 834272f978f0194b43770912b464f255e35edc92 (https://github.com/moby/moby/pull/43122), and applies them to older API versions in the docs directory (which are used for the actual documentation).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

