### PR TITLE
awslogs: replace channel-based mocks

### DIFF
--- a/daemon/logger/awslogs/cwlogsiface_mock_test.go
+++ b/daemon/logger/awslogs/cwlogsiface_mock_test.go
@@ -6,75 +6,29 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 )
 
-type mockcwlogsclient struct {
-	createLogGroupArgument  chan *cloudwatchlogs.CreateLogGroupInput
-	createLogGroupResult    chan *createLogGroupResult
-	createLogStreamArgument chan *cloudwatchlogs.CreateLogStreamInput
-	createLogStreamResult   chan *createLogStreamResult
-	putLogEventsArgument    chan *cloudwatchlogs.PutLogEventsInput
-	putLogEventsResult      chan *putLogEventsResult
+type mockClient struct {
+	createLogGroupFunc  func(input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error)
+	createLogStreamFunc func(input *cloudwatchlogs.CreateLogStreamInput) (*cloudwatchlogs.CreateLogStreamOutput, error)
+	putLogEventsFunc    func(input *cloudwatchlogs.PutLogEventsInput) (*cloudwatchlogs.PutLogEventsOutput, error)
 }
 
-type createLogGroupResult struct {
-	successResult *cloudwatchlogs.CreateLogGroupOutput
-	errorResult   error
+func (m *mockClient) CreateLogGroup(input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error) {
+	return m.createLogGroupFunc(input)
 }
 
-type createLogStreamResult struct {
-	successResult *cloudwatchlogs.CreateLogStreamOutput
-	errorResult   error
+func (m *mockClient) CreateLogStream(input *cloudwatchlogs.CreateLogStreamInput) (*cloudwatchlogs.CreateLogStreamOutput, error) {
+	return m.createLogStreamFunc(input)
 }
 
-type putLogEventsResult struct {
-	successResult *cloudwatchlogs.PutLogEventsOutput
-	errorResult   error
-}
-
-func newMockClient() *mockcwlogsclient {
-	return &mockcwlogsclient{
-		createLogGroupArgument:  make(chan *cloudwatchlogs.CreateLogGroupInput, 1),
-		createLogGroupResult:    make(chan *createLogGroupResult, 1),
-		createLogStreamArgument: make(chan *cloudwatchlogs.CreateLogStreamInput, 1),
-		createLogStreamResult:   make(chan *createLogStreamResult, 1),
-		putLogEventsArgument:    make(chan *cloudwatchlogs.PutLogEventsInput, 1),
-		putLogEventsResult:      make(chan *putLogEventsResult, 1),
+func (m *mockClient) PutLogEvents(input *cloudwatchlogs.PutLogEventsInput) (*cloudwatchlogs.PutLogEventsOutput, error) {
+	if err := checkPutLogEventsConstraints(input); err != nil {
+		return nil, err
 	}
+	return m.putLogEventsFunc(input)
 }
 
-func newMockClientBuffered(buflen int) *mockcwlogsclient {
-	return &mockcwlogsclient{
-		createLogStreamArgument: make(chan *cloudwatchlogs.CreateLogStreamInput, buflen),
-		createLogStreamResult:   make(chan *createLogStreamResult, buflen),
-		putLogEventsArgument:    make(chan *cloudwatchlogs.PutLogEventsInput, buflen),
-		putLogEventsResult:      make(chan *putLogEventsResult, buflen),
-	}
-}
-
-func (m *mockcwlogsclient) CreateLogGroup(input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error) {
-	m.createLogGroupArgument <- input
-	output := <-m.createLogGroupResult
-	return output.successResult, output.errorResult
-}
-
-func (m *mockcwlogsclient) CreateLogStream(input *cloudwatchlogs.CreateLogStreamInput) (*cloudwatchlogs.CreateLogStreamOutput, error) {
-	m.createLogStreamArgument <- input
-	output := <-m.createLogStreamResult
-	return output.successResult, output.errorResult
-}
-
-func (m *mockcwlogsclient) PutLogEvents(input *cloudwatchlogs.PutLogEventsInput) (*cloudwatchlogs.PutLogEventsOutput, error) {
-	events := make([]*cloudwatchlogs.InputLogEvent, len(input.LogEvents))
-	copy(events, input.LogEvents)
-	m.putLogEventsArgument <- &cloudwatchlogs.PutLogEventsInput{
-		LogEvents:     events,
-		SequenceToken: input.SequenceToken,
-		LogGroupName:  input.LogGroupName,
-		LogStreamName: input.LogStreamName,
-	}
-
-	// Intended mock output
-	output := <-m.putLogEventsResult
-
+func checkPutLogEventsConstraints(input *cloudwatchlogs.PutLogEventsInput) error {
+	events := input.LogEvents
 	// Checked enforced limits in mock
 	totalBytes := 0
 	for _, evt := range events {
@@ -84,7 +38,7 @@ func (m *mockcwlogsclient) PutLogEvents(input *cloudwatchlogs.PutLogEventsInput)
 		eventBytes := len([]byte(*evt.Message))
 		if eventBytes > maximumBytesPerEvent {
 			// exceeded per event message size limits
-			return nil, fmt.Errorf("maximum bytes per event exceeded: Event too large %d, max allowed: %d", eventBytes, maximumBytesPerEvent)
+			return fmt.Errorf("maximum bytes per event exceeded: Event too large %d, max allowed: %d", eventBytes, maximumBytesPerEvent)
 		}
 		// total event bytes including overhead
 		totalBytes += eventBytes + perEventBytes
@@ -92,10 +46,9 @@ func (m *mockcwlogsclient) PutLogEvents(input *cloudwatchlogs.PutLogEventsInput)
 
 	if totalBytes > maximumBytesPerPut {
 		// exceeded per put maximum size limit
-		return nil, fmt.Errorf("maximum bytes per put exceeded: Upload too large %d, max allowed: %d", totalBytes, maximumBytesPerPut)
+		return fmt.Errorf("maximum bytes per put exceeded: Upload too large %d, max allowed: %d", totalBytes, maximumBytesPerPut)
 	}
-
-	return output.successResult, output.errorResult
+	return nil
 }
 
 type mockmetadataclient struct {


### PR DESCRIPTION
**- What I did**
awslogs: replace channel-based mocks

(related to https://github.com/moby/moby/issues/42690)

**- How I did it**
Rewrote the mock so tests define mock functions rather than specifying inputs and outputs via channels.  This reduces the overall number and use of channels in the unit tests.

**- How to verify it**

`GO111MODULE=off go test ./daemon/logger/awslogs`

**- Description for the changelog**
N/A
