### PR TITLE
Do not panic on empty quoted string argument

### DIFF
--- a/opts/quotedstring.go
+++ b/opts/quotedstring.go
@@ -22,6 +22,10 @@ func (s *QuotedString) String() string {
 }
 
 func trimQuotes(value string) string {
+	if len(value) < 2 {
+		return value
+	}
+
 	lastIndex := len(value) - 1
 	for _, char := range []byte{'\'', '"'} {
 		if value[0] == char && value[lastIndex] == char {

--- a/opts/quotedstring_test.go
+++ b/opts/quotedstring_test.go
@@ -16,15 +16,19 @@ func TestQuotedStringSetWithQuotes(t *testing.T) {
 }
 
 func TestQuotedStringSetWithMismatchedQuotes(t *testing.T) {
-	value := ""
-	qs := NewQuotedString(&value)
+	qs := NewQuotedString(new(string))
 	assert.Check(t, qs.Set(`"something'`))
 	assert.Check(t, is.Equal(`"something'`, qs.String()))
 }
 
 func TestQuotedStringSetWithNoQuotes(t *testing.T) {
-	value := ""
-	qs := NewQuotedString(&value)
+	qs := NewQuotedString(new(string))
 	assert.Check(t, qs.Set("something"))
 	assert.Check(t, is.Equal("something", qs.String()))
+}
+
+func TestQuotedStringEmptyOrSingleCharString(t *testing.T) {
+	qs := NewQuotedString(new(string))
+	assert.Check(t, qs.Set(""))
+	assert.Check(t, qs.Set("'"))
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix the handling of empty or single characters command line arguments such as
--tlscacert="" or --tlscacert="'"

**- How I did it**

Ensure the argument is at least 2 characters.

**- How to verify it**

Added a unit test to handle both cases

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Currently, calling `dockerd --tlscacert=""` make Docker to panic.

**- A picture of a cute animal (not mandatory but encouraged)**

