### PR TITLE
[do not merge] enable retry-loop on newer versions of Windows as well

### DIFF
--- a/daemon/graphdriver/windows/windows.go
+++ b/daemon/graphdriver/windows/windows.go
@@ -24,7 +24,6 @@ import (
 	"github.com/Microsoft/go-winio/backuptar"
 	"github.com/Microsoft/go-winio/vhd"
 	"github.com/Microsoft/hcsshim"
-	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/containerfs"
@@ -324,9 +323,9 @@ func (d *Driver) Remove(id string) error {
 		// not required.
 		computeSystems, err = hcsshim.GetContainers(hcsshim.ComputeSystemQuery{})
 		if err != nil {
-			if osversion.Build() >= osversion.RS3 {
-				return err
-			}
+			// if osversion.Build() >= osversion.RS3 {
+			// 	return err
+			// }
 			if (err == hcsshim.ErrVmcomputeOperationInvalidState) || (err == hcsshim.ErrVmcomputeOperationAccessIsDenied) {
 				if retryCount >= 500 {
 					break


### PR DESCRIPTION
I stumbled upon this comment when looking for code that could be removed now that
Windows RS1 reaches EOL:

    // We have a retry loop for ErrVmcomputeOperationInvalidState and
    // ErrVmcomputeOperationAccessIsDenied as there is a race condition
    // in RS1 and RS2 building during enumeration when a silo is going away
    // for example under it, in HCS. AccessIsDenied added to fix 30278.
    //
    // TODO: For RS3, we can remove the retries. Also consider
    // using platform APIs (if available) to get this more succinctly. Also
    // consider enhancing the Remove() interface to have context of why
    // the remove is being called - that could improve efficiency by not
    // enumerating compute systems during a remove of a container as it's
    // not required.

We're seeing various failures in CI recently since we updated / rebuilt Jenkins
agents;

    === FAIL: github.com/docker/docker/integration-cli TestDockerSuite/TestContainerAPIChunkedEncoding (0.12s)
    check_test.go:170: assertion failed: error is not nil: Error response from daemon: container 7819ec9f095a635eeb94806db9cbc767eef82837785085a202548c3e809b93c0: driver "windowsfilter" failed to remove root filesystem: failed to detach VHD: failed to detach virtual disk: The device is not ready.: rename D:\CI\PR-43138\2\daemon\windowsfilter\7819ec9f095a635eeb94806db9cbc767eef82837785085a202548c3e809b93c0 D:\CI\PR-43138\2\daemon\windowsfilter\7819ec9f095a635eeb94806db9cbc767eef82837785085a202548c3e809b93c0-removing: Access is denied.: failed to remove 7819ec9f095a635eeb94806db9cbc767eef82837785085a202548c3e809b93c0
    --- FAIL: TestDockerSuite/TestContainerAPIChunkedEncoding (0.12s)

Wondering if there's a regression in Windows that causes this problem (https://github.com/moby/moby/issues/30278) to be
reintroduced, so let's see if enabling this retry loop on current versions of
Windows resolves those CI failures.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

