### PR TITLE
Apply peformance tuning to new sandboxes also

### DIFF
--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -1082,6 +1082,14 @@ func (c *controller) NewSandbox(containerID string, options ...SandboxOption) (S
 
 	if sb.osSbox != nil {
 		// Apply operating specific knobs on the load balancer sandbox
+		err := sb.osSbox.InvokeFunc(func() {
+			sb.osSbox.ApplyOSTweaks(sb.oslTypes)
+		})
+
+		if err != nil {
+			logrus.Errorf("Failed to apply performance tuning sysctls to the sandbox: %v", err)
+		}
+		// Keep this just so performance is not changed
 		sb.osSbox.ApplyOSTweaks(sb.oslTypes)
 	}
 

--- a/libnetwork/osl/namespace_linux.go
+++ b/libnetwork/osl/namespace_linux.go
@@ -31,24 +31,13 @@ func init() {
 }
 
 var (
-	once               sync.Once
-	garbagePathMap     = make(map[string]bool)
-	gpmLock            sync.Mutex
-	gpmWg              sync.WaitGroup
-	gpmCleanupPeriod   = 60 * time.Second
-	gpmChan            = make(chan chan struct{})
-	prefix             = defaultPrefix
-	loadBalancerConfig = map[string]*kernel.OSValue{
-		// disables any special handling on port reuse of existing IPVS connection table entries
-		// more info: https://github.com/torvalds/linux/blob/master/Documentation/networking/ipvs-sysctl.txt#L25:1
-		"net.ipv4.vs.conn_reuse_mode": {Value: "0", CheckFn: nil},
-		// expires connection from the IPVS connection table when the backend is not available
-		// more info: https://github.com/torvalds/linux/blob/master/Documentation/networking/ipvs-sysctl.txt#L126:1
-		"net.ipv4.vs.expire_nodest_conn": {Value: "1", CheckFn: nil},
-		// expires persistent connections to destination servers with weights set to 0
-		// more info: https://github.com/torvalds/linux/blob/master/Documentation/networking/ipvs-sysctl.txt#L144:1
-		"net.ipv4.vs.expire_quiescent_template": {Value: "1", CheckFn: nil},
-	}
+	once             sync.Once
+	garbagePathMap   = make(map[string]bool)
+	gpmLock          sync.Mutex
+	gpmWg            sync.WaitGroup
+	gpmCleanupPeriod = 60 * time.Second
+	gpmChan          = make(chan chan struct{})
+	prefix           = defaultPrefix
 )
 
 // The networkNamespace type is the linux implementation of the Sandbox
@@ -689,8 +678,18 @@ func setIPv6(path, iface string, enable bool) error {
 func (n *networkNamespace) ApplyOSTweaks(types []SandboxType) {
 	for _, t := range types {
 		switch t {
-		case SandboxTypeLoadBalancer:
-			kernel.ApplyOSTweaks(loadBalancerConfig)
+		case SandboxTypeLoadBalancer, SandboxTypeIngress:
+			kernel.ApplyOSTweaks(map[string]*kernel.OSValue{
+				// disables any special handling on port reuse of existing IPVS connection table entries
+				// more info: https://github.com/torvalds/linux/blame/v5.15/Documentation/networking/ipvs-sysctl.rst#L32
+				"net.ipv4.vs.conn_reuse_mode": {Value: "0", CheckFn: nil},
+				// expires connection from the IPVS connection table when the backend is not available
+				// more info: https://github.com/torvalds/linux/blame/v5.15/Documentation/networking/ipvs-sysctl.rst#L133
+				"net.ipv4.vs.expire_nodest_conn": {Value: "1", CheckFn: nil},
+				// expires persistent connections to destination servers with weights set to 0
+				// more info: https://github.com/torvalds/linux/blame/v5.15/Documentation/networking/ipvs-sysctl.rst#L151
+				"net.ipv4.vs.expire_quiescent_template": {Value: "1", CheckFn: nil},
+			})
 		}
 	}
 }


### PR DESCRIPTION
relates to #35082, moby/libnetwork#2491

Previously, values for expire_quiescent_template, conn_reuse_mode,
and expire_nodest_conn were set only system-wide. Also apply them
for new lb_* and ingress_sbox sandboxes, so they are appropriately
propagated

Signed-off-by: Ryan Barry rbarry@mirantis.com

Signed-off-by: Ryan Barry <rbarry@mirantis.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

