### PR TITLE
[20.10 backport] update containerd binary v1.5.9, runc v1.0.3, and some script changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -159,7 +159,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
         PREFIX=/build /tmp/install/install.sh tomlv
 
 FROM base AS vndr
-ARG VNDR_COMMIT
+ARG VNDR_VERSION
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=bind,src=hack/dockerfile/install,target=/tmp/install \
@@ -171,7 +171,7 @@ RUN --mount=type=cache,sharing=locked,id=moby-containerd-aptlib,target=/var/lib/
     --mount=type=cache,sharing=locked,id=moby-containerd-aptcache,target=/var/cache/apt \
         apt-get update && apt-get install -y --no-install-recommends \
             libbtrfs-dev
-ARG CONTAINERD_COMMIT
+ARG CONTAINERD_VERSION
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=bind,src=hack/dockerfile/install,target=/tmp/install \
@@ -185,21 +185,21 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
         PREFIX=/build /tmp/install/install.sh proxy
 
 FROM base AS golangci_lint
-ARG GOLANGCI_LINT_COMMIT
+ARG GOLANGCI_LINT_VERSION
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=bind,src=hack/dockerfile/install,target=/tmp/install \
         PREFIX=/build /tmp/install/install.sh golangci_lint
 
 FROM base AS gotestsum
-ARG GOTESTSUM_COMMIT
+ARG GOTESTSUM_VERSION
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=bind,src=hack/dockerfile/install,target=/tmp/install \
         PREFIX=/build /tmp/install/install.sh gotestsum
 
 FROM base AS shfmt
-ARG SHFMT_COMMIT
+ARG SHFMT_VERSION
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=bind,src=hack/dockerfile/install,target=/tmp/install \
@@ -214,7 +214,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
         PREFIX=/build /tmp/install/install.sh dockercli
 
 FROM runtime-dev AS runc
-ARG RUNC_COMMIT
+ARG RUNC_VERSION
 ARG RUNC_BUILDTAGS
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
@@ -223,7 +223,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM dev-base AS tini
 ARG DEBIAN_FRONTEND
-ARG TINI_COMMIT
+ARG TINI_VERSION
 RUN --mount=type=cache,sharing=locked,id=moby-tini-aptlib,target=/var/lib/apt \
     --mount=type=cache,sharing=locked,id=moby-tini-aptcache,target=/var/cache/apt \
         apt-get update && apt-get install -y --no-install-recommends \
@@ -235,7 +235,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
         PREFIX=/build /tmp/install/install.sh tini
 
 FROM dev-base AS rootlesskit
-ARG ROOTLESSKIT_COMMIT
+ARG ROOTLESSKIT_VERSION
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=bind,src=hack/dockerfile/install,target=/tmp/install \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -261,21 +261,20 @@ RUN `
   C:\git\cmd\git config --global core.autocrlf true;
 
 RUN `
-  Function Build-GoTestSum() { `
-    Write-Host "INFO: Building gotestsum version $Env:GOTESTSUM_VERSION in $Env:GOPATH"; `
+  Function Install-GoTestSum() { `
     $Env:GO111MODULE = 'on'; `
     $tmpGobin = "${Env:GOBIN_TMP}"; `
     $Env:GOBIN = """${Env:GOPATH}`\bin"""; `
-    &go get -buildmode=exe "gotest.tools/gotestsum@${Env:GOTESTSUM_VERSION}"; `
+    Write-Host "INFO: Installing gotestsum version $Env:GOTESTSUM_VERSION in $Env:GOBIN"; `
+    &go install "gotest.tools/gotestsum@${Env:GOTESTSUM_VERSION}"; `
     $Env:GOBIN = "${tmpGobin}"; `
     $Env:GO111MODULE = 'off'; `
     if ($LASTEXITCODE -ne 0) {  `
-      Throw '"gotestsum build failed..."'; `
+      Throw '"gotestsum install failed..."'; `
     } `
-    Write-Host "INFO:     Build done for gotestsum..."; `
   } `
   `
-  Build-GoTestSum
+  Install-GoTestSum
 
 # Make PowerShell the default entrypoint
 ENTRYPOINT ["powershell.exe"]

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -166,7 +166,7 @@ FROM microsoft/windowsservercore
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG GO_VERSION=1.16.13
-ARG GOTESTSUM_VERSION=v0.5.3
+ARG GOTESTSUM_VERSION=v1.7.0
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -166,7 +166,7 @@ FROM microsoft/windowsservercore
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG GO_VERSION=1.16.13
-ARG GOTESTSUM_COMMIT=v0.5.3
+ARG GOTESTSUM_VERSION=v0.5.3
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.
@@ -176,7 +176,7 @@ ENV GO_VERSION=${GO_VERSION} `
     GOPATH=C:\gopath `
     GO111MODULE=off `
     FROM_DOCKERFILE=1 `
-    GOTESTSUM_COMMIT=${GOTESTSUM_COMMIT}
+    GOTESTSUM_VERSION=${GOTESTSUM_VERSION}
 
 RUN `
   Function Test-Nano() { `
@@ -262,11 +262,11 @@ RUN `
 
 RUN `
   Function Build-GoTestSum() { `
-    Write-Host "INFO: Building gotestsum version $Env:GOTESTSUM_COMMIT in $Env:GOPATH"; `
+    Write-Host "INFO: Building gotestsum version $Env:GOTESTSUM_VERSION in $Env:GOPATH"; `
     $Env:GO111MODULE = 'on'; `
     $tmpGobin = "${Env:GOBIN_TMP}"; `
     $Env:GOBIN = """${Env:GOPATH}`\bin"""; `
-    &go get -buildmode=exe "gotest.tools/gotestsum@${Env:GOTESTSUM_COMMIT}"; `
+    &go get -buildmode=exe "gotest.tools/gotestsum@${Env:GOTESTSUM_VERSION}"; `
     $Env:GOBIN = "${tmpGobin}"; `
     $Env:GO111MODULE = 'off'; `
     if ($LASTEXITCODE -ne 0) {  `

--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/pkg/sysinfo"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -40,54 +39,43 @@ func (daemon *Daemon) fillPlatformInfo(v *types.Info, sysInfo *sysinfo.SysInfo) 
 	v.Runtimes = daemon.configStore.GetAllRuntimes()
 	v.DefaultRuntime = daemon.configStore.GetDefaultRuntimeName()
 	v.InitBinary = daemon.configStore.GetInitPath()
+	v.RuncCommit.ID = "N/A"
+	v.ContainerdCommit.ID = "N/A"
+	v.InitCommit.ID = "N/A"
 
 	defaultRuntimeBinary := daemon.configStore.GetRuntime(v.DefaultRuntime).Path
 	if rv, err := exec.Command(defaultRuntimeBinary, "--version").Output(); err == nil {
 		if _, _, commit, err := parseRuntimeVersion(string(rv)); err != nil {
 			logrus.Warnf("failed to parse %s version: %v", defaultRuntimeBinary, err)
-			v.RuncCommit.ID = "N/A"
 		} else {
 			v.RuncCommit.ID = commit
 		}
 	} else {
 		logrus.Warnf("failed to retrieve %s version: %v", defaultRuntimeBinary, err)
-		v.RuncCommit.ID = "N/A"
 	}
-
-	// runc is now shipped as a separate package. Set "expected" to same value
-	// as "ID" to prevent clients from reporting a version-mismatch
-	v.RuncCommit.Expected = v.RuncCommit.ID
 
 	if rv, err := daemon.containerd.Version(context.Background()); err == nil {
 		v.ContainerdCommit.ID = rv.Revision
 	} else {
 		logrus.Warnf("failed to retrieve containerd version: %v", err)
-		v.ContainerdCommit.ID = "N/A"
 	}
-
-	// containerd is now shipped as a separate package. Set "expected" to same
-	// value as "ID" to prevent clients from reporting a version-mismatch
-	v.ContainerdCommit.Expected = v.ContainerdCommit.ID
-
-	// TODO is there still a need to check the expected version for tini?
-	// if not, we can change this, and just set "Expected" to v.InitCommit.ID
-	v.InitCommit.Expected = dockerversion.InitCommitID
 
 	defaultInitBinary := daemon.configStore.GetInitPath()
 	if rv, err := exec.Command(defaultInitBinary, "--version").Output(); err == nil {
 		if _, commit, err := parseInitVersion(string(rv)); err != nil {
 			logrus.Warnf("failed to parse %s version: %s", defaultInitBinary, err)
-			v.InitCommit.ID = "N/A"
 		} else {
 			v.InitCommit.ID = commit
-			if len(dockerversion.InitCommitID) > len(commit) {
-				v.InitCommit.Expected = dockerversion.InitCommitID[0:len(commit)]
-			}
 		}
 	} else {
 		logrus.Warnf("failed to retrieve %s version: %s", defaultInitBinary, err)
-		v.InitCommit.ID = "N/A"
 	}
+
+	// Set expected and actual commits to the same value to prevent the client
+	// showing that the version does not match the "expected" version/commit.
+	v.RuncCommit.Expected = v.RuncCommit.ID
+	v.ContainerdCommit.Expected = v.ContainerdCommit.ID
+	v.InitCommit.Expected = v.InitCommit.ID
 
 	if v.CgroupDriver == cgroupNoneDriver {
 		if v.CgroupVersion == "2" {

--- a/dockerversion/version_lib.go
+++ b/dockerversion/version_lib.go
@@ -10,7 +10,6 @@ var (
 	Version               = "library-import"
 	BuildTime             = "library-import"
 	IAmStatic             = "library-import"
-	InitCommitID          = "library-import"
 	PlatformName          = ""
 	ProductName           = ""
 	DefaultProductLicense = ""

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=36cc874494a56a253cd181a1a685b44b58a2e34a}" # v1.5.2
+: "${CONTAINERD_COMMIT:=0e8719f54c6dc6571fc1170da75a85e86c17636b}" # v1.5.3
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -1,16 +1,27 @@
 #!/bin/sh
 set -e
 
-# containerd is also pinned in vendor.conf. When updating the binary
-# version you may also need to update the vendor version to pick up bug
-# fixes or new APIs.
-: "${CONTAINERD_COMMIT:=72cec4be58a9eb6b2910f5d10f1c01ca47d231c0}" # v1.5.5
+# CONTAINERD_VERSION specifies the version of the containerd runtime binary
+# to install from the https://github.com/containerd/containerd repository.
+#
+# This version is used to build statically compiled containerd binaries, and
+# used for the integration tests. The distributed docker .deb and .rpm packages
+# depend on a separate (containerd.io) package, which may be a different version
+# as is specified here.
+#
+# Generally, the commit specified here should match a tagged release.
+#
+# The containerd golang package is also pinned in vendor.conf. When updating
+# the binary version you may also need to update the vendor version to pick up
+# bug fixes or new APIs, however, usually the Go packages are built from a
+# commit from the master branch.
+: "${CONTAINERD_VERSION:=v1.5.5}"
 
 install_containerd() (
-	echo "Install containerd version $CONTAINERD_COMMIT"
+	echo "Install containerd version $CONTAINERD_VERSION"
 	git clone https://github.com/containerd/containerd.git "$GOPATH/src/github.com/containerd/containerd"
 	cd "$GOPATH/src/github.com/containerd/containerd"
-	git checkout -q "$CONTAINERD_COMMIT"
+	git checkout -q "$CONTAINERD_VERSION"
 
 	export BUILDTAGS='netgo osusergo static_build'
 	export EXTRA_FLAGS=${GO_BUILDMODE}

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.5.7}"
+: "${CONTAINERD_VERSION:=v1.5.8}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=0e8719f54c6dc6571fc1170da75a85e86c17636b}" # v1.5.3
+: "${CONTAINERD_COMMIT:=69107e47a62e1d690afa2b9b1d43f8ece3ff4483}" # v1.5.4
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=69107e47a62e1d690afa2b9b1d43f8ece3ff4483}" # v1.5.4
+: "${CONTAINERD_COMMIT:=72cec4be58a9eb6b2910f5d10f1c01ca47d231c0}" # v1.5.5
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=05f951a3781f4f2c1911b05e61c160e9c30eaa8e}" # v1.4.4
+: "${CONTAINERD_COMMIT:=8c906ff108ac28da23f69cc7b74f8e7a470d1df0}" # v1.5.0
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=8c906ff108ac28da23f69cc7b74f8e7a470d1df0}" # v1.5.0
+: "${CONTAINERD_COMMIT:=12dca9790f4cb6b18a6a7a027ce420145cb98ee7}" # v1.5.1
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.5.5}"
+: "${CONTAINERD_VERSION:=v1.5.6}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.5.6}"
+: "${CONTAINERD_VERSION:=v1.5.7}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.5.8}"
+: "${CONTAINERD_VERSION:=v1.5.9}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=12dca9790f4cb6b18a6a7a027ce420145cb98ee7}" # v1.5.1
+: "${CONTAINERD_COMMIT:=36cc874494a56a253cd181a1a685b44b58a2e34a}" # v1.5.2
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=d71fcd7d8303cbf684402823e425e9dd2e99285d}" # v1.4.6
+: "${CONTAINERD_COMMIT:=8263eb3eaee447b16856eeb8839d5df4c9cca71a}" # v1.4.5
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=e25210fe30a0a703442421b0f60afac609f950a3}" # v1.4.9
+: "${CONTAINERD_COMMIT:=7eba5930496d9bbe375fdf71603e610ad737d2b2}" # v1.4.8
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=8263eb3eaee447b16856eeb8839d5df4c9cca71a}" # v1.4.5
+: "${CONTAINERD_COMMIT:=05f951a3781f4f2c1911b05e61c160e9c30eaa8e}" # v1.4.4
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=5b46e404f6b9f661a205e28d59c982d3634148f8}" # v1.4.11
+: "${CONTAINERD_COMMIT:=8848fdb7c4ae3815afcc990a8a99d663dda1b590}" # v1.4.10
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=8848fdb7c4ae3815afcc990a8a99d663dda1b590}" # v1.4.10
+: "${CONTAINERD_COMMIT:=e25210fe30a0a703442421b0f60afac609f950a3}" # v1.4.9
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=3194fb46e8311ae0eeae5a7a5843573adfebb16d}" # v1.4.7
+: "${CONTAINERD_COMMIT:=d71fcd7d8303cbf684402823e425e9dd2e99285d}" # v1.4.6
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=7b11cfaabd73bb80907dd23182b9347b4245eb5d}" # v1.4.12
+: "${CONTAINERD_COMMIT:=5b46e404f6b9f661a205e28d59c982d3634148f8}" # v1.4.11
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=7eba5930496d9bbe375fdf71603e610ad737d2b2}" # v1.4.8
+: "${CONTAINERD_COMMIT:=3194fb46e8311ae0eeae5a7a5843573adfebb16d}" # v1.4.7
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/golangci_lint.installer
+++ b/hack/dockerfile/install/golangci_lint.installer
@@ -4,7 +4,7 @@
 
 install_golangci_lint() {
 	set -e
-	export GO111MODULE=on
-	GOBIN="${PREFIX}" go get "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"
+	echo "Install golangci-lint version ${GOLANGCI_LINT_VERSION}"
+	GOBIN="${PREFIX}" GO111MODULE=on go install "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"
 	"${PREFIX}"/golangci-lint --version
 }

--- a/hack/dockerfile/install/golangci_lint.installer
+++ b/hack/dockerfile/install/golangci_lint.installer
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-: "${GOLANGCI_LINT_COMMIT=v1.23.8}"
+: "${GOLANGCI_LINT_VERSION=v1.23.8}"
 
 install_golangci_lint() {
 	set -e
 	export GO111MODULE=on
-	GOBIN="${PREFIX}" go get "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_COMMIT}"
+	GOBIN="${PREFIX}" go get "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"
 	"${PREFIX}"/golangci-lint --version
 }

--- a/hack/dockerfile/install/gotestsum.installer
+++ b/hack/dockerfile/install/gotestsum.installer
@@ -4,6 +4,6 @@
 
 install_gotestsum() (
 	set -e
-	export GO111MODULE=on
-	GOBIN="${PREFIX}" go get "gotest.tools/gotestsum@${GOTESTSUM_VERSION}"
+	echo "Install gotestsum version ${GOTESTSUM_VERSION}"
+	GOBIN="${PREFIX}" GO111MODULE=on go install "gotest.tools/gotestsum@${GOTESTSUM_VERSION}"
 )

--- a/hack/dockerfile/install/gotestsum.installer
+++ b/hack/dockerfile/install/gotestsum.installer
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-: ${GOTESTSUM_COMMIT:=v0.5.3}
+: ${GOTESTSUM_VERSION:=v0.5.3}
 
 install_gotestsum() (
 	set -e
 	export GO111MODULE=on
-	GOBIN="${PREFIX}" go get "gotest.tools/gotestsum@${GOTESTSUM_COMMIT}"
+	GOBIN="${PREFIX}" go get "gotest.tools/gotestsum@${GOTESTSUM_VERSION}"
 )

--- a/hack/dockerfile/install/gotestsum.installer
+++ b/hack/dockerfile/install/gotestsum.installer
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-: ${GOTESTSUM_VERSION:=v0.5.3}
+: ${GOTESTSUM_VERSION:=v1.7.0}
 
 install_gotestsum() (
 	set -e

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -31,11 +31,6 @@ _install_rootlesskit() (
 	cd "$GOPATH/src/github.com/rootless-containers/rootlesskit" || exit 1
 	git checkout -q "$ROOTLESSKIT_COMMIT"
 	export GO111MODULE=on
-	# TODO remove GOPROXY override once we updated to Go 1.14+
-	# Using goproxy instead of "direct" to work around an issue in go mod
-	# on Go 1.13 not working with older git versions (default version on
-	# CentOS 7 is git 1.8), see https://github.com/golang/go/issues/38373
-	export GOPROXY="https://proxy.golang.org"
 	for f in rootlesskit rootlesskit-docker-proxy; do
 		go build $BUILD_MODE -ldflags="$ROOTLESSKIT_LDFLAGS" -o "${PREFIX}/$f" github.com/rootless-containers/rootlesskit/cmd/$f
 	done

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-# v0.14.4
-: "${ROOTLESSKIT_COMMIT:=87d443683ac1e8aba4110b8081f15aaae432aaa2}"
+: "${ROOTLESSKIT_VERSION:=v0.14.4}"
 
 install_rootlesskit() {
 	case "$1" in
@@ -26,12 +25,8 @@ install_rootlesskit_dynamic() {
 }
 
 _install_rootlesskit() (
-	echo "Install rootlesskit version $ROOTLESSKIT_COMMIT"
-	git clone https://github.com/rootless-containers/rootlesskit.git "$GOPATH/src/github.com/rootless-containers/rootlesskit"
-	cd "$GOPATH/src/github.com/rootless-containers/rootlesskit" || exit 1
-	git checkout -q "$ROOTLESSKIT_COMMIT"
-	export GO111MODULE=on
+	echo "Install rootlesskit version ${ROOTLESSKIT_VERSION}"
 	for f in rootlesskit rootlesskit-docker-proxy; do
-		go build $BUILD_MODE -ldflags="$ROOTLESSKIT_LDFLAGS" -o "${PREFIX}/$f" github.com/rootless-containers/rootlesskit/cmd/$f
+		GOBIN="${PREFIX}" GO111MODULE=on go install ${BUILD_MODE} -ldflags="$ROOTLESSKIT_LDFLAGS" "github.com/rootless-containers/rootlesskit/cmd/${f}@${ROOTLESSKIT_VERSION}"
 	done
 )

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.conf accordingly
-: "${RUNC_VERSION:=v1.0.2}"
+: "${RUNC_VERSION:=v1.0.3}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 # When updating RUNC_COMMIT, also update runc in vendor.conf accordingly
 # The version of runc should match the version that is used by the containerd
@@ -7,13 +8,7 @@
 : ${RUNC_COMMIT:=52b36a2dd837e8462de8e01458bf02cf9eea47dd} # v1.0.2
 
 install_runc() {
-	# If using RHEL7 kernels (3.10.0 el7), disable kmem accounting/limiting
-	if uname -r | grep -q '^3\.10\.0.*\.el7\.'; then
-		: ${RUNC_NOKMEM='nokmem'}
-	fi
-
-	# Do not build with ambient capabilities support
-	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp $RUNC_NOKMEM"}"
+	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"
 
 	echo "Install runc version $RUNC_COMMIT (build tags: $RUNC_BUILDTAGS)"
 	git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc"

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -1,19 +1,23 @@
 #!/bin/sh
 set -e
 
-# When updating RUNC_COMMIT, also update runc in vendor.conf accordingly
+# RUNC_VERSION specifies the version of runc to install from the
+# https://github.com/opencontainers/runc repository.
+#
 # The version of runc should match the version that is used by the containerd
 # version that is used. If you need to update runc, open a pull request in
 # the containerd project first, and update both after that is merged.
-: ${RUNC_COMMIT:=52b36a2dd837e8462de8e01458bf02cf9eea47dd} # v1.0.2
+#
+# When updating RUNC_VERSION, consider updating runc in vendor.conf accordingly
+: "${RUNC_VERSION:=v1.0.2}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"
 
-	echo "Install runc version $RUNC_COMMIT (build tags: $RUNC_BUILDTAGS)"
+	echo "Install runc version $RUNC_VERSION (build tags: $RUNC_BUILDTAGS)"
 	git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc"
 	cd "$GOPATH/src/github.com/opencontainers/runc"
-	git checkout -q "$RUNC_COMMIT"
+	git checkout -q "$RUNC_VERSION"
 	if [ -z "$1" ]; then
 		target=static
 	else

--- a/hack/dockerfile/install/shfmt.installer
+++ b/hack/dockerfile/install/shfmt.installer
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-: "${SHFMT_COMMIT:=01725bdd30658db1fe1b9e02173c3060061fe86f}" # v3.0.2
+: "${SHFMT_VERSION:=v3.0.2}"
 
 install_shfmt() {
-	echo "Install shfmt version $SHFMT_COMMIT"
+	echo "Install shfmt version $SHFMT_VERSION"
 	git clone https://github.com/mvdan/sh.git "$GOPATH/src/github.com/mvdan/sh"
 	cd "$GOPATH/src/github.com/mvdan/sh" || exit 1
-	git checkout -q "$SHFMT_COMMIT"
+	git checkout -q "$SHFMT_VERSION"
 	GO111MODULE=on go build ${GO_BUILDMODE} -v -o "${PREFIX}/shfmt" ./cmd/shfmt
 }

--- a/hack/dockerfile/install/shfmt.installer
+++ b/hack/dockerfile/install/shfmt.installer
@@ -4,8 +4,5 @@
 
 install_shfmt() {
 	echo "Install shfmt version $SHFMT_VERSION"
-	git clone https://github.com/mvdan/sh.git "$GOPATH/src/github.com/mvdan/sh"
-	cd "$GOPATH/src/github.com/mvdan/sh" || exit 1
-	git checkout -q "$SHFMT_VERSION"
-	GO111MODULE=on go build ${GO_BUILDMODE} -v -o "${PREFIX}/shfmt" ./cmd/shfmt
+	GOBIN="${PREFIX}" GO111MODULE=on go install "mvdan.cc/sh/v3/cmd/shfmt@${SHFMT_VERSION}"
 }

--- a/hack/dockerfile/install/tini.installer
+++ b/hack/dockerfile/install/tini.installer
@@ -1,12 +1,15 @@
 #!/bin/sh
 
-: ${TINI_COMMIT:=de40ad007797e0dcd8b7126f27bb87401d224240} # v0.19.0
+# TINI_VERSION specifies the version of tini (docker-init) to build, and install
+# from the https://github.com/krallin/tini repository. This binary is used
+# when starting containers with the `--init` option.
+: "${TINI_VERSION:=v0.19.0}"
 
 install_tini() {
-	echo "Install tini version $TINI_COMMIT"
+	echo "Install tini version $TINI_VERSION"
 	git clone https://github.com/krallin/tini.git "$GOPATH/tini"
 	cd "$GOPATH/tini"
-	git checkout -q "$TINI_COMMIT"
+	git checkout -q "$TINI_VERSION"
 	cmake .
 	make tini-static
 	mkdir -p "${PREFIX}"

--- a/hack/dockerfile/install/vndr.installer
+++ b/hack/dockerfile/install/vndr.installer
@@ -4,8 +4,5 @@
 
 install_vndr() {
 	echo "Install vndr version $VNDR_VERSION"
-	git clone https://github.com/LK4D4/vndr.git "$GOPATH/src/github.com/LK4D4/vndr"
-	cd "$GOPATH/src/github.com/LK4D4/vndr" || exit 1
-	git checkout -q "$VNDR_VERSION"
-	go build ${GO_BUILDMODE} -v -o "${PREFIX}/vndr" .
+	GOBIN="${PREFIX}" GO111MODULE=on go install "github.com/LK4D4/vndr@${VNDR_VERSION}"
 }

--- a/hack/dockerfile/install/vndr.installer
+++ b/hack/dockerfile/install/vndr.installer
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-: "${VNDR_COMMIT:=f12b881cb8f081a5058408a58f429b9014833fc6}" # v0.1.2
+: "${VNDR_VERSION:=v0.1.2}"
 
 install_vndr() {
-	echo "Install vndr version $VNDR_COMMIT"
+	echo "Install vndr version $VNDR_VERSION"
 	git clone https://github.com/LK4D4/vndr.git "$GOPATH/src/github.com/LK4D4/vndr"
 	cd "$GOPATH/src/github.com/LK4D4/vndr" || exit 1
-	git checkout -q "$VNDR_COMMIT"
+	git checkout -q "$VNDR_VERSION"
 	go build ${GO_BUILDMODE} -v -o "${PREFIX}/vndr" .
 }

--- a/hack/make/.go-autogen
+++ b/hack/make/.go-autogen
@@ -14,7 +14,6 @@ LDFLAGS="${LDFLAGS} \
 	-X \"github.com/docker/docker/dockerversion.PlatformName=${PLATFORM}\" \
 	-X \"github.com/docker/docker/dockerversion.ProductName=${PRODUCT}\" \
 	-X \"github.com/docker/docker/dockerversion.DefaultProductLicense=${DEFAULT_PRODUCT_LICENSE}\" \
-	-X \"github.com/docker/docker/dockerversion.InitCommitID=${TINI_COMMIT}\" \
 "
 
 # Compile the Windows resources into the sources


### PR DESCRIPTION
Per discussion on https://github.com/moby/moby/pull/43138 https://github.com/moby/moby/pull/43138#issuecomment-1009518557;

> Can we backport this to 20.10?
>
> containerd v1.4 EOL is very soon (February 3, 2022) https://github.com/containerd/containerd/blob/main/RELEASES.md#support-horizon

This backports the containerd binary changes to the 20.10 branch for testing, first roling back / reverting the 20.10-only commits, then cherry-picking the updates from master (to preserve history of those commits)

- revert https://github.com/moby/moby/pull/43024
- revert https://github.com/moby/moby/pull/42901
- revert https://github.com/moby/moby/pull/42695
- revert https://github.com/moby/moby/pull/42657
- revert https://github.com/moby/moby/pull/42637
- revert https://github.com/moby/moby/pull/42398
- revert https://github.com/moby/moby/pull/42372

- cherry-pick https://github.com/moby/moby/pull/42149
- cherry-pick https://github.com/moby/moby/pull/42383
- cherry-pick https://github.com/moby/moby/pull/42399
- cherry-pick https://github.com/moby/moby/pull/42636
    - only the first commit (containerd binary), not the vendoring changes
- cherry-pick https://github.com/moby/moby/pull/42656
    - only the first commit (containerd binary), not the vendoring changes
- cherry-pick https://github.com/moby/moby/pull/42697
    - only the first commit (containerd binary), not the vendoring changes
- cherry-pick https://github.com/moby/moby/pull/42776
- cherry-pick https://github.com/moby/moby/pull/42674
- cherry-pick https://github.com/moby/moby/pull/42902
- cherry-pick https://github.com/moby/moby/pull/43025
    - only the first commit (containerd binary), not the vendoring changes
- cherry-pick https://github.com/moby/moby/pull/43062
    - only the first commit (runc binary), not the vendoring changes
- cherry-pick https://github.com/moby/moby/pull/43138

details below:

<details>

```bash
# https://github.com/moby/moby/pull/43024
git revert -s -S d47de2a4c7f9638ab4db17ad8c4d149e771954b9

# https://github.com/moby/moby/pull/42901
git revert -s -S 129a2000cf752e0afbe935d9e258f916becf8367
git revert -s -S 6835d15f5523063f0a04a86d4810a637c6010d62

# https://github.com/moby/moby/pull/42695
git revert -s -S e8fb8f7acd461db932bce5d7752c33fc9d75020d

# https://github.com/moby/moby/pull/42657
git revert -s -S 067918a8c3018580c86e6c6e6326f68add162876

# https://github.com/moby/moby/pull/42637
git revert -s -S 793340a33a33088f9d5f76031a59062e7e290eba

# https://github.com/moby/moby/pull/42398
git revert -s -S 56541eca9a9ec79fefb750605285d3d88899fb00

# https://github.com/moby/moby/pull/42372
git revert -s -S 01f734cb4f432760fc94a0fb6f64207628ca0662

# https://github.com/moby/moby/pull/42149
git cherry-pick -s -S -x 9b2f55bc1ca1544e407082bbfc626c4bf1745d7c

# https://github.com/moby/moby/pull/42383
git cherry-pick -s -S -x 22c0291333281e2b5d3f39b3c7bf5a31db829522

# https://github.com/moby/moby/pull/42399
git cherry-pick -s -S -x 8e3186fc8f05569200129ee5fd055eb6f25bba20

# https://github.com/moby/moby/pull/42636
git cherry-pick -s -S -x 5ae2af41eebab4e54c730d2b987bd6889dde432c

# https://github.com/moby/moby/pull/42656
git cherry-pick -s -S -x cf1328cd46987b07285fdb9f60b1b7da631f672d

# https://github.com/moby/moby/pull/42697
git cherry-pick -s -S -x 4a07b89e9a23f61de06a9390e49a3e16283f3672

# https://github.com/moby/moby/pull/42776
git cherry-pick -s -S -x b585c64e2b01f924fc358fe059871baa469bb460

# https://github.com/moby/moby/pull/42674 - see if this works
git cherry-pick -s -S -x 3c7c18a4992138ccd6e1d2a63b5ca44327f663bd
git cherry-pick -s -S -x 3cec4b8cd42179e67dcfdda2adce03516c6a5cd1
# conflict in Dockerfile.windows not yet having CONTAINERD_VERSION in it (see below)
git cherry-pick -s -S -x a7a7c732c0dc02ee5b5515f4ca868ef50cafa4a1
# conflict because hack/dockerfile/install/tomll.installer is not in this branch
git cherry-pick -s -S -x 14ff070469d8a1e1f1ea61df9593281f3147e238
# conflict in Dockerfile.windows not yet having CONTAINERD_VERSION in it
git cherry-pick -s -S -x 1b8db067856387b4cc80bd5813993475382993b6

# https://github.com/moby/moby/pull/42902
# conflict in Dockerfile.windows not yet having CONTAINERD_VERSION in it (see below)
git cherry-pick -s -S -x b746a2bf9b2a86a1072e7be719f1207a64a576fb
git cherry-pick -s -S -x fa4a9702be2a2707e7d7345272d58ff9e381f393

# https://github.com/moby/moby/pull/43025
git cherry-pick -s -S -x aef782f34844e70c79481cbecd35b01c9bb25ffa

# https://github.com/moby/moby/pull/43062
git cherry-pick -s -S -x 53397ac5391c49ebd534d06cc57b6a2a12a739d3

# https://github.com/moby/moby/pull/43138
# conflict in Dockerfile.windows not yet having CONTAINERD_VERSION in it (see below)
git cherry-pick -s -S -x df3ea5da03fcff55a47277a8190967e91b7363fa
```

Conflicts in `a7a7c732c0dc02ee5b5515f4ca868ef50cafa4a1`, and cherry-picks after that due to Dockerfile.windows not yet having CONTAINERD_VERSION in it in the 20.10 branch;

```patch
diff --cc Dockerfile.windows
index 00de2b0941,d56fce719a..0000000000
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@@ -165,8 -165,9 +165,14 @@@ FROM microsoft/windowsservercor
  # Use PowerShell as the default shell
  SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

++<<<<<<< HEAD
 +ARG GO_VERSION=1.16.12
 +ARG GOTESTSUM_COMMIT=v0.5.3
++=======
+ ARG GO_VERSION=1.17.0
+ ARG CONTAINERD_VERSION=1.5.5
+ ARG GOTESTSUM_VERSION=v0.5.3
++>>>>>>> a7a7c732c0 (Dockerfile: use version for some utilities instead of commit-sha)

  # Environment variable notes:
  #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.
```

</details>
