### PR TITLE
[WIP]daemon: set container exit when related shim process dead abnormally

### DIFF
--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -128,7 +128,10 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerdtypes.EventType, ei
 
 		daemon.LogContainerEvent(c, "oom")
 	case libcontainerdtypes.EventExit:
-		if int(ei.Pid) == c.Pid {
+		if ei.Pid == 0 {
+			logrus.Warnf("dead shim clean up event about container: %s", c.ID)
+		}
+		if int(ei.Pid) == c.Pid || ei.Pid == 0 {
 			return daemon.handleContainerExit(c, &ei)
 		}
 


### PR DESCRIPTION
When shim process dead abnormally, such as received kill 9 signal, panic
or other unkown reasons, the shim server can not reap runc container
and forward process exit event normally. This will lead the container
leaked in dockerd. On the other hand, when shim dead, containerd will
clean dead shim and forward shim exit event with pid 0. Therefore,
If dockerd received exit event with pid 0, need also clean the related
container managed by dockerd.

Signed-off-by: Jeff Zvier zvier20@gmail.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Recently, we continuously meet with shim and user process already dead but docker containers already dead. The root cause not found yet. But it is sure that the shim dead first and the runc container already cleanup by containerd. Because of docker still regard as it an UP state container, so the orchestration can not identify the abnormal and rebuild an new. More seriously, some job may trap into it. 

For above reason, I think if the docker container related shim process exit abnormally, the docker container  need also exit.

https://github.com/containerd/containerd/issues/6402

**- How I did it**
If dockerd received exit event with pid 0, this must be the shim exit abnormally.  For this case also call daemon.handleContainerExit method to set the container exit.

https://github.com/containerd/containerd/blob/140ecc9247386d3be21616fe285021c081f4ea08/runtime/v2/shim.go#L173

**- How to verify it**
1. docker run -itd busybox:latest top
2. kill the related containerd shim directly with: `kill -s 9 ${shim-pid}`
3. docker ps and this container's STATUS is `Exited`



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

