### PR TITLE
[20.10 backport] Jenkinsfile: remove Windows RS1 as it reached end of support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,6 @@ pipeline {
         booleanParam(name: 'arm64', defaultValue: true, description: 'ARM (arm64) Build/Test')
         booleanParam(name: 's390x', defaultValue: false, description: 'IBM Z (s390x) Build/Test')
         booleanParam(name: 'ppc64le', defaultValue: false, description: 'PowerPC (ppc64le) Build/Test')
-        booleanParam(name: 'windowsRS1', defaultValue: false, description: 'Windows 2016 (RS1) Build/Test')
         booleanParam(name: 'windowsRS5', defaultValue: true, description: 'Windows 2019 (RS5) Build/Test')
         booleanParam(name: 'dco', defaultValue: true, description: 'Run the DCO check')
     }
@@ -1040,73 +1039,6 @@ pipeline {
                                 '''
 
                                 archiveArtifacts artifacts: '*-bundles.tar.gz', allowEmptyArchive: true
-                            }
-                        }
-                        cleanup {
-                            sh 'make clean'
-                            deleteDir()
-                        }
-                    }
-                }
-                stage('win-RS1') {
-                    when {
-                        beforeAgent true
-                        // Skip this stage on PRs unless the windowsRS1 checkbox is selected
-                        anyOf {
-                            not { changeRequest() }
-                            expression { params.windowsRS1 }
-                        }
-                    }
-                    environment {
-                        DOCKER_BUILDKIT        = '0'
-                        DOCKER_DUT_DEBUG       = '1'
-                        SKIP_VALIDATION_TESTS  = '1'
-                        SOURCES_DRIVE          = 'd'
-                        SOURCES_SUBDIR         = 'gopath'
-                        TESTRUN_DRIVE          = 'd'
-                        TESTRUN_SUBDIR         = "CI"
-                        WINDOWS_BASE_IMAGE     = 'mcr.microsoft.com/windows/servercore'
-                        WINDOWS_BASE_IMAGE_TAG = 'ltsc2016'
-                    }
-                    agent {
-                        node {
-                            customWorkspace 'd:\\gopath\\src\\github.com\\docker\\docker'
-                            label 'windows-2016'
-                        }
-                    }
-                    stages {
-                        stage("Print info") {
-                            steps {
-                                sh 'docker version'
-                                sh 'docker info'
-                            }
-                        }
-                        stage("Run tests") {
-                            steps {
-                                powershell '''
-                                $ErrorActionPreference = 'Stop'
-                                [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-                                Invoke-WebRequest https://github.com/moby/docker-ci-zap/blob/master/docker-ci-zap.exe?raw=true -OutFile C:/Windows/System32/docker-ci-zap.exe
-                                ./hack/ci/windows.ps1
-                                exit $LastExitCode
-                                '''
-                            }
-                        }
-                    }
-                    post {
-                        always {
-                            junit testResults: 'bundles/junit-report-*.xml', allowEmptyResults: true
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'Failed to create bundles.tar.gz') {
-                                powershell '''
-                                cd $env:WORKSPACE
-                                $bundleName="windowsRS1-integration"
-                                Write-Host -ForegroundColor Green "Creating ${bundleName}-bundles.zip"
-
-                                # archiveArtifacts does not support env-vars to , so save the artifacts in a fixed location
-                                Compress-Archive -Path "bundles/CIDUT.out", "bundles/CIDUT.err", "bundles/junit-report-*.xml" -CompressionLevel Optimal -DestinationPath "${bundleName}-bundles.zip"
-                                '''
-
-                                archiveArtifacts artifacts: '*-bundles.zip', allowEmptyArchive: true
                             }
                         }
                         cleanup {


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/43143
It was already disabled by default, but removing it now that it reached
end of the line.

