### PR TITLE
api: remove HostConfig.LxcConf field from swagger and docs

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5915,7 +5915,6 @@ paths:
                       property1: "string"
                       property2: "string"
                 IpcMode: ""
-                LxcConf: []
                 Memory: 0
                 MemorySwap: 0
                 MemoryReservation: 0

--- a/docs/api/v1.22.md
+++ b/docs/api/v1.22.md
@@ -553,7 +553,6 @@ Return low-level information on the container `id`
 			"ExtraHosts": null,
 			"IpcMode": "",
 			"Links": null,
-			"LxcConf": [],
 			"Memory": 0,
 			"MemorySwap": 0,
 			"MemoryReservation": 0,

--- a/docs/api/v1.23.md
+++ b/docs/api/v1.23.md
@@ -579,7 +579,6 @@ Return low-level information on the container `id`
 			"ExtraHosts": null,
 			"IpcMode": "",
 			"Links": null,
-			"LxcConf": [],
 			"Memory": 0,
 			"MemorySwap": 0,
 			"MemoryReservation": 0,

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -624,7 +624,6 @@ Return low-level information on the container `id`
 			"ExtraHosts": null,
 			"IpcMode": "",
 			"Links": null,
-			"LxcConf": [],
 			"Memory": 0,
 			"MemorySwap": 0,
 			"MemoryReservation": 0,

--- a/docs/api/v1.25.yaml
+++ b/docs/api/v1.25.yaml
@@ -2975,7 +2975,6 @@ paths:
                 CpuRealtimeRuntime: 10000
                 Devices: []
                 IpcMode: ""
-                LxcConf: []
                 Memory: 0
                 MemorySwap: 0
                 MemoryReservation: 0

--- a/docs/api/v1.26.yaml
+++ b/docs/api/v1.26.yaml
@@ -2980,7 +2980,6 @@ paths:
                 CpuRealtimeRuntime: 10000
                 Devices: []
                 IpcMode: ""
-                LxcConf: []
                 Memory: 0
                 MemorySwap: 0
                 MemoryReservation: 0

--- a/docs/api/v1.27.yaml
+++ b/docs/api/v1.27.yaml
@@ -3040,7 +3040,6 @@ paths:
                 CpuRealtimeRuntime: 10000
                 Devices: []
                 IpcMode: ""
-                LxcConf: []
                 Memory: 0
                 MemorySwap: 0
                 MemoryReservation: 0

--- a/docs/api/v1.28.yaml
+++ b/docs/api/v1.28.yaml
@@ -3130,7 +3130,6 @@ paths:
                 CpuRealtimeRuntime: 10000
                 Devices: []
                 IpcMode: ""
-                LxcConf: []
                 Memory: 0
                 MemorySwap: 0
                 MemoryReservation: 0

--- a/docs/api/v1.29.yaml
+++ b/docs/api/v1.29.yaml
@@ -3164,7 +3164,6 @@ paths:
                 CpuRealtimeRuntime: 10000
                 Devices: []
                 IpcMode: ""
-                LxcConf: []
                 Memory: 0
                 MemorySwap: 0
                 MemoryReservation: 0

--- a/docs/api/v1.30.yaml
+++ b/docs/api/v1.30.yaml
@@ -3382,7 +3382,6 @@ paths:
                 CpuRealtimeRuntime: 10000
                 Devices: []
                 IpcMode: ""
-                LxcConf: []
                 Memory: 0
                 MemorySwap: 0
                 MemoryReservation: 0

--- a/docs/api/v1.31.yaml
+++ b/docs/api/v1.31.yaml
@@ -3452,7 +3452,6 @@ paths:
                 CpuRealtimeRuntime: 10000
                 Devices: []
                 IpcMode: ""
-                LxcConf: []
                 Memory: 0
                 MemorySwap: 0
                 MemoryReservation: 0

--- a/docs/api/v1.32.yaml
+++ b/docs/api/v1.32.yaml
@@ -4691,7 +4691,6 @@ paths:
                 CpuRealtimeRuntime: 10000
                 Devices: []
                 IpcMode: ""
-                LxcConf: []
                 Memory: 0
                 MemorySwap: 0
                 MemoryReservation: 0

--- a/docs/api/v1.33.yaml
+++ b/docs/api/v1.33.yaml
@@ -4696,7 +4696,6 @@ paths:
                 CpuRealtimeRuntime: 10000
                 Devices: []
                 IpcMode: ""
-                LxcConf: []
                 Memory: 0
                 MemorySwap: 0
                 MemoryReservation: 0

--- a/docs/api/v1.34.yaml
+++ b/docs/api/v1.34.yaml
@@ -4725,7 +4725,6 @@ paths:
                 CpuRealtimeRuntime: 10000
                 Devices: []
                 IpcMode: ""
-                LxcConf: []
                 Memory: 0
                 MemorySwap: 0
                 MemoryReservation: 0

--- a/docs/api/v1.35.yaml
+++ b/docs/api/v1.35.yaml
@@ -4707,7 +4707,6 @@ paths:
                 CpuRealtimeRuntime: 10000
                 Devices: []
                 IpcMode: ""
-                LxcConf: []
                 Memory: 0
                 MemorySwap: 0
                 MemoryReservation: 0

--- a/docs/api/v1.36.yaml
+++ b/docs/api/v1.36.yaml
@@ -4723,7 +4723,6 @@ paths:
                 CpuRealtimeRuntime: 10000
                 Devices: []
                 IpcMode: ""
-                LxcConf: []
                 Memory: 0
                 MemorySwap: 0
                 MemoryReservation: 0

--- a/docs/api/v1.37.yaml
+++ b/docs/api/v1.37.yaml
@@ -4743,7 +4743,6 @@ paths:
                 CpuRealtimeRuntime: 10000
                 Devices: []
                 IpcMode: ""
-                LxcConf: []
                 Memory: 0
                 MemorySwap: 0
                 MemoryReservation: 0

--- a/docs/api/v1.38.yaml
+++ b/docs/api/v1.38.yaml
@@ -4804,7 +4804,6 @@ paths:
                 CpuRealtimeRuntime: 10000
                 Devices: []
                 IpcMode: ""
-                LxcConf: []
                 Memory: 0
                 MemorySwap: 0
                 MemoryReservation: 0

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -5459,7 +5459,6 @@ paths:
                 CpuRealtimeRuntime: 10000
                 Devices: []
                 IpcMode: ""
-                LxcConf: []
                 Memory: 0
                 MemorySwap: 0
                 MemoryReservation: 0

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -5600,7 +5600,6 @@ paths:
                       property1: "string"
                       property2: "string"
                 IpcMode: ""
-                LxcConf: []
                 Memory: 0
                 MemorySwap: 0
                 MemoryReservation: 0

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -5755,7 +5755,6 @@ paths:
                       property1: "string"
                       property2: "string"
                 IpcMode: ""
-                LxcConf: []
                 Memory: 0
                 MemorySwap: 0
                 MemoryReservation: 0

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -499,6 +499,8 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.22](v1.22.md) documentation
 
+* The `HostConfig.LxcConf` field has been removed, and is no longer available on
+  `POST /containers/create` and `GET /containers/(id)/json`.
 * `POST /container/(name)/update` updates the resources of a container.
 * `GET /containers/json` supports filter `isolation` on Windows.
 * `GET /containers/json` now returns the list of networks of containers.


### PR DESCRIPTION
Commit 3b5fac462d21ca164b3778647420016315289034 (https://github.com/moby/moby/pull/17700) / docker 1.10 removed support for the LXC runtime, and removed the corresponding fields from the API (v1.22).

This patch removes the `HostConfig.LxcConf` field from the swagger definition and documentation.
