### PR TITLE
daemon/images.NewImageService() don't print debug logs

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1073,6 +1073,9 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	// used above to run migration. They could be initialized in ImageService
 	// if migration is called from daemon/images. layerStore might move as well.
 	d.imageService = images.NewImageService(imgSvcConfig)
+	logrus.Debugf("Max Concurrent Downloads: %d", imgSvcConfig.MaxConcurrentDownloads)
+	logrus.Debugf("Max Concurrent Uploads: %d", imgSvcConfig.MaxConcurrentUploads)
+	logrus.Debugf("Max Download Attempts: %d", imgSvcConfig.MaxDownloadAttempts)
 
 	go d.execCommandGC()
 

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -54,9 +54,6 @@ type ImageServiceConfig struct {
 
 // NewImageService returns a new ImageService from a configuration
 func NewImageService(config ImageServiceConfig) *ImageService {
-	logrus.Debugf("Max Concurrent Downloads: %d", config.MaxConcurrentDownloads)
-	logrus.Debugf("Max Concurrent Uploads: %d", config.MaxConcurrentUploads)
-	logrus.Debugf("Max Download Attempts: %d", config.MaxDownloadAttempts)
 	return &ImageService{
 		containers:                config.ContainerStore,
 		distributionMetadataStore: config.DistributionMetadataStore,


### PR DESCRIPTION
These logs were meant to be logged when starting the daemon. Moving the logs
to the daemon startup code (which also prints similar messages) instead of
having the images service log them.

