### PR TITLE
layer: remove unused error return from .Size() and .DiffSize()

### DIFF
--- a/builder/builder-next/adapters/snapshot/snapshot.go
+++ b/builder/builder-next/adapters/snapshot/snapshot.go
@@ -405,11 +405,7 @@ func (s *snapshotter) Usage(ctx context.Context, key string) (us snapshots.Usage
 	if l, err := s.getLayer(key, true); err != nil {
 		return usage, err
 	} else if l != nil {
-		s, err := l.DiffSize()
-		if err != nil {
-			return usage, err
-		}
-		usage.Size = s
+		usage.Size = l.DiffSize()
 		return usage, nil
 	}
 

--- a/daemon/images/image_history.go
+++ b/daemon/images/image_history.go
@@ -40,12 +40,8 @@ func (i *ImageService) ImageHistory(name string) ([]*image.HistoryResponseItem, 
 			if err != nil {
 				return nil, err
 			}
-			layerSize, err = l.DiffSize()
+			layerSize = l.DiffSize()
 			layer.ReleaseAndLog(i.layerStore, l)
-			if err != nil {
-				return nil, err
-			}
-
 			layerCounter++
 		}
 

--- a/daemon/images/image_inspect.go
+++ b/daemon/images/image_inspect.go
@@ -59,7 +59,7 @@ func (i *ImageService) LookupImage(name string) (*types.ImageInspect, error) {
 		return nil, err
 	}
 
-	imageInspect := &types.ImageInspect{
+	return &types.ImageInspect{
 		ID:              img.ID().String(),
 		RepoTags:        repoTags,
 		RepoDigests:     repoDigests,
@@ -77,16 +77,15 @@ func (i *ImageService) LookupImage(name string) (*types.ImageInspect, error) {
 		OsVersion:       img.OSVersion,
 		Size:            size,
 		VirtualSize:     size, // TODO: field unused, deprecate
-		RootFS:          rootFSToAPIType(img.RootFS),
+		GraphDriver: types.GraphDriverData{
+			Name: i.layerStore.DriverName(),
+			Data: layerMetadata,
+		},
+		RootFS: rootFSToAPIType(img.RootFS),
 		Metadata: types.ImageMetadata{
 			LastTagTime: lastUpdated,
 		},
-	}
-
-	imageInspect.GraphDriver.Name = i.layerStore.DriverName()
-	imageInspect.GraphDriver.Data = layerMetadata
-
-	return imageInspect, nil
+	}, nil
 }
 
 func rootFSToAPIType(rootfs *image.RootFS) types.RootFS {

--- a/daemon/images/image_inspect.go
+++ b/daemon/images/image_inspect.go
@@ -42,11 +42,7 @@ func (i *ImageService) LookupImage(name string) (*types.ImageInspect, error) {
 			return nil, err
 		}
 		defer layer.ReleaseAndLog(i.layerStore, l)
-		size, err = l.Size()
-		if err != nil {
-			return nil, err
-		}
-
+		size = l.Size()
 		layerMetadata, err = l.Metadata()
 		if err != nil {
 			return nil, err

--- a/daemon/images/image_prune.go
+++ b/daemon/images/image_prune.go
@@ -143,12 +143,7 @@ deleteImagesLoop:
 		if d.Deleted != "" {
 			chid := layer.ChainID(d.Deleted)
 			if l, ok := allLayers[chid]; ok {
-				diffSize, err := l.DiffSize()
-				if err != nil {
-					logrus.Warnf("failed to get layer %s size: %v", chid, err)
-					continue
-				}
-				rep.SpaceReclaimed += uint64(diffSize)
+				rep.SpaceReclaimed += uint64(l.DiffSize())
 			}
 		}
 	}

--- a/daemon/images/image_unix.go
+++ b/daemon/images/image_unix.go
@@ -33,10 +33,8 @@ func (i *ImageService) GetContainerLayerSize(containerID string) (int64, int64) 
 	}
 
 	if parent := rwlayer.Parent(); parent != nil {
-		sizeRootfs, err = parent.Size()
-		if err != nil {
-			sizeRootfs = -1
-		} else if sizeRw != -1 {
+		sizeRootfs = parent.Size()
+		if sizeRw != -1 {
 			sizeRootfs += sizeRw
 		}
 	}

--- a/daemon/images/images.go
+++ b/daemon/images/images.go
@@ -128,11 +128,8 @@ func (i *ImageService) Images(_ context.Context, opts types.ImageListOptions) ([
 				return nil, err
 			}
 
-			size, err = l.Size()
+			size = l.Size()
 			layer.ReleaseAndLog(i.layerStore, l)
-			if err != nil {
-				return nil, err
-			}
 		}
 
 		summary := newImageSummary(img, size)
@@ -244,11 +241,7 @@ func (i *ImageService) Images(_ context.Context, opts types.ImageListOptions) ([
 					if _, ok := allLayers[chid]; !ok {
 						return nil, fmt.Errorf("layer %v was not found (corruption?)", chid)
 					}
-					diffSize, err := allLayers[chid].DiffSize()
-					if err != nil {
-						return nil, err
-					}
-					summary.SharedSize += diffSize
+					summary.SharedSize += allLayers[chid].DiffSize()
 				}
 			}
 		}

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -209,13 +209,9 @@ func (i *ImageService) LayerDiskUsage(ctx context.Context) (int64, error) {
 			case <-ctx.Done():
 				return allLayersSize, ctx.Err()
 			default:
-				size, err := l.DiffSize()
-				if err == nil {
-					if _, ok := layerRefs[l.ChainID()]; ok {
-						allLayersSize += size
-					}
-				} else {
-					logrus.Warnf("failed to get diff size for layer %v", l.ChainID())
+				size := l.DiffSize()
+				if _, ok := layerRefs[l.ChainID()]; ok {
+					allLayersSize += size
 				}
 			}
 		}

--- a/distribution/config.go
+++ b/distribution/config.go
@@ -102,7 +102,7 @@ type PushLayer interface {
 	DiffID() layer.DiffID
 	Parent() PushLayer
 	Open() (io.ReadCloser, error)
-	Size() (int64, error)
+	Size() int64
 	MediaType() string
 	Release()
 }
@@ -229,8 +229,8 @@ func (l *storeLayer) Open() (io.ReadCloser, error) {
 	return l.Layer.TarStream()
 }
 
-func (l *storeLayer) Size() (int64, error) {
-	return l.Layer.DiffSize(), nil
+func (l *storeLayer) Size() int64 {
+	return l.Layer.DiffSize()
 }
 
 func (l *storeLayer) MediaType() string {

--- a/distribution/config.go
+++ b/distribution/config.go
@@ -230,7 +230,7 @@ func (l *storeLayer) Open() (io.ReadCloser, error) {
 }
 
 func (l *storeLayer) Size() (int64, error) {
-	return l.Layer.DiffSize()
+	return l.Layer.DiffSize(), nil
 }
 
 func (l *storeLayer) MediaType() string {

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -451,9 +451,7 @@ func (pd *v2PushDescriptor) uploadUsingSession(
 		return distribution.Descriptor{}, retryOnError(err)
 	}
 
-	size, _ := pd.layer.Size()
-
-	reader = progress.NewProgressReader(ioutils.NewCancelReadCloser(ctx, contentReader), progressOutput, size, pd.ID(), "Pushing")
+	reader = progress.NewProgressReader(ioutils.NewCancelReadCloser(ctx, contentReader), progressOutput, pd.layer.Size(), pd.ID(), "Pushing")
 
 	switch m := pd.layer.MediaType(); m {
 	case schema2.MediaTypeUncompressedLayer:
@@ -596,7 +594,7 @@ attempts:
 // decision is based on layer size. The smaller the layer, the fewer attempts shall be made because the cost
 // of upload does not outweigh a latency.
 func getMaxMountAndExistenceCheckAttempts(layer PushLayer) (maxMountAttempts, maxExistenceCheckAttempts int, checkOtherRepositories bool) {
-	size, err := layer.Size()
+	size := layer.Size()
 	switch {
 	// big blob
 	case size > middleLayerMaximumSize:
@@ -606,7 +604,7 @@ func getMaxMountAndExistenceCheckAttempts(layer PushLayer) (maxMountAttempts, ma
 		return 4, 3, true
 
 	// middle sized blobs; if we could not get the size, assume we deal with middle sized blob
-	case size > smallLayerMaximumSize, err != nil:
+	case size > smallLayerMaximumSize:
 		// 1st attempt to mount blobs of average size few times
 		// 2nd try at most 1 existence check if there's an existing mapping to the target repository
 		// then fallback to upload

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -48,12 +48,12 @@ func (ml *mockLayer) Parent() layer.Layer {
 	return ml.parent
 }
 
-func (ml *mockLayer) Size() (size int64, err error) {
-	return 0, nil
+func (ml *mockLayer) Size() int64 {
+	return 0
 }
 
-func (ml *mockLayer) DiffSize() (size int64, err error) {
-	return 0, nil
+func (ml *mockLayer) DiffSize() int64 {
+	return 0
 }
 
 func (ml *mockLayer) Metadata() (map[string]string, error) {

--- a/layer/empty.go
+++ b/layer/empty.go
@@ -42,12 +42,12 @@ func (el *emptyLayer) Parent() Layer {
 	return nil
 }
 
-func (el *emptyLayer) Size() (size int64, err error) {
-	return 0, nil
+func (el *emptyLayer) Size() int64 {
+	return 0
 }
 
-func (el *emptyLayer) DiffSize() (size int64, err error) {
-	return 0, nil
+func (el *emptyLayer) DiffSize() int64 {
+	return 0
 }
 
 func (el *emptyLayer) Metadata() (map[string]string, error) {

--- a/layer/empty_test.go
+++ b/layer/empty_test.go
@@ -20,11 +20,11 @@ func TestEmptyLayer(t *testing.T) {
 		t.Fatal("expected no parent for empty layer")
 	}
 
-	if size, err := EmptyLayer.Size(); err != nil || size != 0 {
+	if size := EmptyLayer.Size(); size != 0 {
 		t.Fatal("expected zero size for empty layer")
 	}
 
-	if diffSize, err := EmptyLayer.DiffSize(); err != nil || diffSize != 0 {
+	if diffSize := EmptyLayer.DiffSize(); diffSize != 0 {
 		t.Fatal("expected zero diffsize for empty layer")
 	}
 

--- a/layer/layer.go
+++ b/layer/layer.go
@@ -102,11 +102,11 @@ type Layer interface {
 
 	// Size returns the size of the entire layer chain. The size
 	// is calculated from the total size of all files in the layers.
-	Size() (int64, error)
+	Size() int64
 
 	// DiffSize returns the size difference of the top layer
 	// from parent layer.
-	DiffSize() (int64, error)
+	DiffSize() int64
 
 	// Metadata returns the low level storage metadata associated
 	// with layer.

--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -439,7 +439,7 @@ func (ls *layerStore) deleteLayer(layer *roLayer, metadata *Metadata) error {
 	}
 	metadata.DiffID = layer.diffID
 	metadata.ChainID = layer.chainID
-	metadata.Size, err = layer.Size()
+	metadata.Size = layer.Size()
 	if err != nil {
 		return err
 	}

--- a/layer/layer_test.go
+++ b/layer/layer_test.go
@@ -173,14 +173,9 @@ func getCachedLayer(l Layer) *roLayer {
 func createMetadata(layers ...Layer) []Metadata {
 	metadata := make([]Metadata, len(layers))
 	for i := range layers {
-		size, err := layers[i].Size()
-		if err != nil {
-			panic(err)
-		}
-
 		metadata[i].ChainID = layers[i].ChainID()
 		metadata[i].DiffID = layers[i].DiffID()
-		metadata[i].Size = size
+		metadata[i].Size = layers[i].Size()
 		metadata[i].DiffSize = getCachedLayer(layers[i]).size
 	}
 
@@ -229,15 +224,8 @@ func assertLayerEqual(t *testing.T, l1, l2 Layer) {
 		t.Fatalf("Mismatched DiffID: %s vs %s", l1.DiffID(), l2.DiffID())
 	}
 
-	size1, err := l1.Size()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	size2, err := l2.Size()
-	if err != nil {
-		t.Fatal(err)
-	}
+	size1 := l1.Size()
+	size2 := l2.Size()
 
 	if size1 != size2 {
 		t.Fatalf("Mismatched size: %d vs %d", size1, size2)
@@ -266,7 +254,7 @@ func TestMountAndRegister(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	size, _ := layer.Size()
+	size := layer.Size()
 	t.Logf("Layer size: %d", size)
 
 	mount2, err := ls.CreateRWLayer("new-test-mount", layer.ChainID(), nil)

--- a/layer/layer_unix_test.go
+++ b/layer/layer_unix_test.go
@@ -44,11 +44,7 @@ func TestLayerSize(t *testing.T) {
 		t.Fatalf("Unexpected diff size %d, expected %d", layer1DiffSize, len(content1))
 	}
 
-	layer1Size, err := layer1.Size()
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	layer1Size := layer1.Size()
 	if expected := len(content1); int(layer1Size) != expected {
 		t.Fatalf("Unexpected size %d, expected %d", layer1Size, expected)
 	}
@@ -62,10 +58,7 @@ func TestLayerSize(t *testing.T) {
 		t.Fatalf("Unexpected diff size %d, expected %d", layer2DiffSize, len(content2))
 	}
 
-	layer2Size, err := layer2.Size()
-	if err != nil {
-		t.Fatal(err)
-	}
+	layer2Size := layer2.Size()
 
 	if expected := len(content1) + len(content2); int(layer2Size) != expected {
 		t.Fatalf("Unexpected size %d, expected %d", layer2Size, expected)

--- a/layer/ro_layer.go
+++ b/layer/ro_layer.go
@@ -73,19 +73,17 @@ func (rl *roLayer) Parent() Layer {
 	return rl.parent
 }
 
-func (rl *roLayer) Size() (size int64, err error) {
+func (rl *roLayer) Size() int64 {
+	size := rl.size
 	if rl.parent != nil {
-		size, err = rl.parent.Size()
-		if err != nil {
-			return
-		}
+		size += rl.parent.Size()
 	}
 
-	return size + rl.size, nil
+	return size
 }
 
-func (rl *roLayer) DiffSize() (size int64, err error) {
-	return rl.size, nil
+func (rl *roLayer) DiffSize() int64 {
+	return rl.size
 }
 
 func (rl *roLayer) Metadata() (map[string]string, error) {


### PR DESCRIPTION
None of the implementations used return an error, so removing the error
return can simplify using these.

