### PR TITLE
distribution/xfer: refactor to reduce public api/interface

### DIFF
--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -108,7 +108,7 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 	var (
 		topLayer       layer.Layer
 		topDownload    *downloadTransfer
-		watcher        *Watcher
+		watcher        *watcher
 		missingLayer   bool
 		transferKey    = ""
 		downloadsByKey = make(map[string]*downloadTransfer)

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -23,7 +23,7 @@ const maxDownloadAttempts = 5
 // layers.
 type LayerDownloadManager struct {
 	layerStore          layer.Store
-	tm                  TransferManager
+	tm                  *transferManager
 	waitDuration        time.Duration
 	maxDownloadAttempts int
 }
@@ -37,7 +37,7 @@ func (ldm *LayerDownloadManager) SetConcurrency(concurrency int) {
 func NewLayerDownloadManager(layerStore layer.Store, concurrencyLimit int, options ...func(*LayerDownloadManager)) *LayerDownloadManager {
 	manager := LayerDownloadManager{
 		layerStore:          layerStore,
-		tm:                  NewTransferManager(concurrencyLimit),
+		tm:                  newTransferManager(concurrencyLimit),
 		waitDuration:        time.Second,
 		maxDownloadAttempts: maxDownloadAttempts,
 	}

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -30,7 +30,7 @@ type LayerDownloadManager struct {
 
 // SetConcurrency sets the max concurrent downloads for each pull
 func (ldm *LayerDownloadManager) SetConcurrency(concurrency int) {
-	ldm.tm.SetConcurrency(concurrency)
+	ldm.tm.setConcurrency(concurrency)
 }
 
 // NewLayerDownloadManager returns a new LayerDownloadManager.
@@ -152,7 +152,7 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 		if existingDownload, ok := downloadsByKey[key]; ok {
 			xferFunc := ldm.makeDownloadFuncFromDownload(descriptor, existingDownload, topDownload)
 			defer topDownload.Transfer.Release(watcher)
-			topDownloadUncasted, watcher = ldm.tm.Transfer(transferKey, xferFunc, progressOutput)
+			topDownloadUncasted, watcher = ldm.tm.transfer(transferKey, xferFunc, progressOutput)
 			topDownload = topDownloadUncasted.(*downloadTransfer)
 			continue
 		}
@@ -167,7 +167,7 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 		} else {
 			xferFunc = ldm.makeDownloadFunc(descriptor, rootFS.ChainID(), nil)
 		}
-		topDownloadUncasted, watcher = ldm.tm.Transfer(transferKey, xferFunc, progressOutput)
+		topDownloadUncasted, watcher = ldm.tm.transfer(transferKey, xferFunc, progressOutput)
 		topDownload = topDownloadUncasted.(*downloadTransfer)
 		downloadsByKey[key] = topDownload
 	}

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -137,8 +137,7 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 					missingLayer = false
 					rootFS.Append(diffID)
 					// Register this repository as a source of this layer.
-					withRegistered, hasRegistered := descriptor.(DownloadDescriptorWithRegistered)
-					if hasRegistered { // As layerstore may set the driver
+					if withRegistered, ok := descriptor.(DownloadDescriptorWithRegistered); ok { // As layerstore may set the driver
 						withRegistered.Registered(diffID)
 					}
 					continue
@@ -360,8 +359,8 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 			}
 
 			progress.Update(progressOutput, descriptor.ID(), "Pull complete")
-			withRegistered, hasRegistered := descriptor.(DownloadDescriptorWithRegistered)
-			if hasRegistered {
+
+			if withRegistered, ok := descriptor.(DownloadDescriptorWithRegistered); ok {
 				withRegistered.Registered(d.layer.DiffID())
 			}
 
@@ -453,8 +452,7 @@ func (ldm *LayerDownloadManager) makeDownloadFuncFromDownload(descriptor Downloa
 				return
 			}
 
-			withRegistered, hasRegistered := descriptor.(DownloadDescriptorWithRegistered)
-			if hasRegistered {
+			if withRegistered, ok := descriptor.(DownloadDescriptorWithRegistered); ok {
 				withRegistered.Registered(d.layer.DiffID())
 			}
 

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -34,7 +34,7 @@ func (ldm *LayerDownloadManager) SetConcurrency(concurrency int) {
 }
 
 // NewLayerDownloadManager returns a new LayerDownloadManager.
-func NewLayerDownloadManager(layerStore layer.Store, concurrencyLimit int, options ...func(*LayerDownloadManager)) *LayerDownloadManager {
+func NewLayerDownloadManager(layerStore layer.Store, concurrencyLimit int, options ...DownloadOption) *LayerDownloadManager {
 	manager := LayerDownloadManager{
 		layerStore:          layerStore,
 		tm:                  newTransferManager(concurrencyLimit),
@@ -47,9 +47,12 @@ func NewLayerDownloadManager(layerStore layer.Store, concurrencyLimit int, optio
 	return &manager
 }
 
+// DownloadOption set options for the LayerDownloadManager.
+type DownloadOption func(*LayerDownloadManager)
+
 // WithMaxDownloadAttempts configures the maximum number of download
 // attempts for a download manager.
-func WithMaxDownloadAttempts(max int) func(*LayerDownloadManager) {
+func WithMaxDownloadAttempts(max int) DownloadOption {
 	return func(dlm *LayerDownloadManager) {
 		dlm.maxDownloadAttempts = max
 	}

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -94,6 +94,11 @@ type DownloadDescriptor interface {
 // DownloadDescriptorWithRegistered is successful.
 type DownloadDescriptorWithRegistered interface {
 	DownloadDescriptor
+
+	// TODO existing implementations in distribution and builder-next swallow errors
+	// when registering the diffID. Consider changing the Registered signature
+	// to return the error.
+
 	Registered(diffID layer.DiffID)
 }
 

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -225,7 +225,7 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor, parentLayer layer.ChainID, parentDownload *downloadTransfer) DoFunc {
 	return func(progressChan chan<- progress.Progress, start <-chan struct{}, inactive chan<- struct{}) Transfer {
 		d := &downloadTransfer{
-			Transfer:   NewTransfer(),
+			Transfer:   newTransfer(),
 			layerStore: ldm.layerStore,
 		}
 
@@ -389,7 +389,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 func (ldm *LayerDownloadManager) makeDownloadFuncFromDownload(descriptor DownloadDescriptor, sourceDownload *downloadTransfer, parentDownload *downloadTransfer) DoFunc {
 	return func(progressChan chan<- progress.Progress, start <-chan struct{}, inactive chan<- struct{}) Transfer {
 		d := &downloadTransfer{
-			Transfer:   NewTransfer(),
+			Transfer:   newTransfer(),
 			layerStore: ldm.layerStore,
 		}
 

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -166,7 +166,7 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 		// Layer is not known to exist - download and register it.
 		progress.Update(progressOutput, descriptor.ID(), "Pulling fs layer")
 
-		var xferFunc DoFunc
+		var xferFunc doFunc
 		if topDownload != nil {
 			xferFunc = ldm.makeDownloadFunc(descriptor, "", topDownload)
 			defer topDownload.transfer.release(watcher)
@@ -228,7 +228,7 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 // complete before the registration step, and registers the downloaded data
 // on top of parentDownload's resulting layer. Otherwise, it registers the
 // layer on top of the ChainID given by parentLayer.
-func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor, parentLayer layer.ChainID, parentDownload *downloadTransfer) DoFunc {
+func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor, parentLayer layer.ChainID, parentDownload *downloadTransfer) doFunc {
 	return func(progressChan chan<- progress.Progress, start <-chan struct{}, inactive chan<- struct{}) transfer {
 		d := &downloadTransfer{
 			transfer:   newTransfer(),
@@ -392,7 +392,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 // parentDownload. This function does not log progress output because it would
 // interfere with the progress reporting for sourceDownload, which has the same
 // Key.
-func (ldm *LayerDownloadManager) makeDownloadFuncFromDownload(descriptor DownloadDescriptor, sourceDownload *downloadTransfer, parentDownload *downloadTransfer) DoFunc {
+func (ldm *LayerDownloadManager) makeDownloadFuncFromDownload(descriptor DownloadDescriptor, sourceDownload *downloadTransfer, parentDownload *downloadTransfer) doFunc {
 	return func(progressChan chan<- progress.Progress, start <-chan struct{}, inactive chan<- struct{}) transfer {
 		d := &downloadTransfer{
 			transfer:   newTransfer(),

--- a/distribution/xfer/transfer.go
+++ b/distribution/xfer/transfer.go
@@ -263,13 +263,13 @@ func (t *xfer) close() {
 	t.mu.Unlock()
 }
 
-// DoFunc is a function called by the transferManager to actually perform
+// doFunc is a function called by the transferManager to actually perform
 // a transfer. It should be non-blocking. It should wait until the start channel
 // is closed before transferring any data. If the function closes inactive, that
 // signals to the transferManager that the job is no longer actively moving
 // data - for example, it may be waiting for a dependent transfer to finish.
 // This prevents it from taking up a slot.
-type DoFunc func(progressChan chan<- progress.Progress, start <-chan struct{}, inactive chan<- struct{}) transfer
+type doFunc func(progressChan chan<- progress.Progress, start <-chan struct{}, inactive chan<- struct{}) transfer
 
 // transferManager is used by LayerDownloadManager and LayerUploadManager to
 // schedule and deduplicate transfers. It is up to the transferManager
@@ -301,7 +301,7 @@ func (tm *transferManager) setConcurrency(concurrency int) {
 // transfer checks if a transfer matching the given key is in progress. If not,
 // it starts one by calling xferFunc. The caller supplies a channel which
 // receives progress output from the transfer.
-func (tm *transferManager) transfer(key string, xferFunc DoFunc, progressOutput progress.Output) (transfer, *watcher) {
+func (tm *transferManager) transfer(key string, xferFunc doFunc, progressOutput progress.Output) (transfer, *watcher) {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
 

--- a/distribution/xfer/transfer.go
+++ b/distribution/xfer/transfer.go
@@ -63,7 +63,7 @@ type transfer struct {
 	// running remains open as long as the transfer is in progress.
 	running chan struct{}
 	// released stays open until all watchers release the transfer and
-	// the transfer is no longer tracked by the transfer manager.
+	// the transfer is no longer tracked by the transferManager.
 	released chan struct{}
 
 	// broadcastDone is true if the main progress channel has closed.
@@ -242,7 +242,7 @@ func (t *transfer) Done() <-chan struct{} {
 }
 
 // Released returns a channel which is closed once all watchers release the
-// transfer AND the transfer is no longer tracked by the transfer manager.
+// transfer AND the transfer is no longer tracked by the transferManager.
 func (t *transfer) Released() <-chan struct{} {
 	return t.released
 }
@@ -252,7 +252,7 @@ func (t *transfer) Context() context.Context {
 	return t.ctx
 }
 
-// Close is called by the transfer manager when the transfer is no longer
+// Close is called by the transferManager when the transfer is no longer
 // being tracked.
 func (t *transfer) Close() {
 	t.mu.Lock()
@@ -263,10 +263,10 @@ func (t *transfer) Close() {
 	t.mu.Unlock()
 }
 
-// DoFunc is a function called by the transfer manager to actually perform
+// DoFunc is a function called by the transferManager to actually perform
 // a transfer. It should be non-blocking. It should wait until the start channel
 // is closed before transferring any data. If the function closes inactive, that
-// signals to the transfer manager that the job is no longer actively moving
+// signals to the transferManager that the job is no longer actively moving
 // data - for example, it may be waiting for a dependent transfer to finish.
 // This prevents it from taking up a slot.
 type DoFunc func(progressChan chan<- progress.Progress, start <-chan struct{}, inactive chan<- struct{}) Transfer

--- a/distribution/xfer/transfer.go
+++ b/distribution/xfer/transfer.go
@@ -291,17 +291,17 @@ func newTransferManager(concurrencyLimit int) *transferManager {
 	}
 }
 
-// SetConcurrency sets the concurrencyLimit
-func (tm *transferManager) SetConcurrency(concurrency int) {
+// setConcurrency sets the concurrencyLimit
+func (tm *transferManager) setConcurrency(concurrency int) {
 	tm.mu.Lock()
 	tm.concurrencyLimit = concurrency
 	tm.mu.Unlock()
 }
 
-// Transfer checks if a transfer matching the given key is in progress. If not,
+// transfer checks if a Transfer matching the given key is in progress. If not,
 // it starts one by calling xferFunc. The caller supplies a channel which
 // receives progress output from the transfer.
-func (tm *transferManager) Transfer(key string, xferFunc DoFunc, progressOutput progress.Output) (Transfer, *Watcher) {
+func (tm *transferManager) transfer(key string, xferFunc DoFunc, progressOutput progress.Output) (Transfer, *Watcher) {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
 

--- a/distribution/xfer/transfer.go
+++ b/distribution/xfer/transfer.go
@@ -77,8 +77,8 @@ type transfer struct {
 	broadcastSyncChan chan struct{}
 }
 
-// NewTransfer creates a new transfer.
-func NewTransfer() Transfer {
+// newTransfer creates a new transfer.
+func newTransfer() Transfer {
 	t := &transfer{
 		watchers:          make(map[chan struct{}]*Watcher),
 		running:           make(chan struct{}),

--- a/distribution/xfer/transfer_test.go
+++ b/distribution/xfer/transfer_test.go
@@ -50,7 +50,7 @@ func TestTransfer(t *testing.T) {
 	xfers := make([]Transfer, len(ids))
 	watchers := make([]*Watcher, len(ids))
 	for i, id := range ids {
-		xfers[i], watchers[i] = tm.Transfer(id, makeXferFunc(id), progress.ChanOutput(progressChan))
+		xfers[i], watchers[i] = tm.transfer(id, makeXferFunc(id), progress.ChanOutput(progressChan))
 	}
 
 	for i, xfer := range xfers {
@@ -108,7 +108,7 @@ func TestConcurrencyLimit(t *testing.T) {
 	xfers := make([]Transfer, len(ids))
 	watchers := make([]*Watcher, len(ids))
 	for i, id := range ids {
-		xfers[i], watchers[i] = tm.Transfer(id, makeXferFunc(id), progress.ChanOutput(progressChan))
+		xfers[i], watchers[i] = tm.transfer(id, makeXferFunc(id), progress.ChanOutput(progressChan))
 	}
 
 	for i, xfer := range xfers {
@@ -169,7 +169,7 @@ func TestInactiveJobs(t *testing.T) {
 	xfers := make([]Transfer, len(ids))
 	watchers := make([]*Watcher, len(ids))
 	for i, id := range ids {
-		xfers[i], watchers[i] = tm.Transfer(id, makeXferFunc(id), progress.ChanOutput(progressChan))
+		xfers[i], watchers[i] = tm.transfer(id, makeXferFunc(id), progress.ChanOutput(progressChan))
 	}
 
 	close(testDone)
@@ -237,7 +237,7 @@ func TestWatchRelease(t *testing.T) {
 	watchers[0].progressChan = make(chan progress.Progress)
 	watchers[0].progressDone = make(chan struct{})
 	watchers[0].receivedFirstProgress = make(chan struct{})
-	xfer, watchers[0].watcher = tm.Transfer("id1", makeXferFunc("id1"), progress.ChanOutput(watchers[0].progressChan))
+	xfer, watchers[0].watcher = tm.transfer("id1", makeXferFunc("id1"), progress.ChanOutput(watchers[0].progressChan))
 	go progressConsumer(watchers[0])
 
 	// Give it multiple watchers
@@ -295,7 +295,7 @@ func TestWatchFinishedTransfer(t *testing.T) {
 	// Start a transfer
 	watchers := make([]*Watcher, 3)
 	var xfer Transfer
-	xfer, watchers[0] = tm.Transfer("id1", makeXferFunc("id1"), progress.ChanOutput(make(chan progress.Progress)))
+	xfer, watchers[0] = tm.transfer("id1", makeXferFunc("id1"), progress.ChanOutput(make(chan progress.Progress)))
 
 	// Give it a watcher immediately
 	watchers[1] = xfer.Watch(progress.ChanOutput(make(chan progress.Progress)))
@@ -371,7 +371,7 @@ func TestDuplicateTransfer(t *testing.T) {
 		t.progressChan = make(chan progress.Progress)
 		t.progressDone = make(chan struct{})
 		t.receivedFirstProgress = make(chan struct{})
-		t.xfer, t.watcher = tm.Transfer("id1", makeXferFunc("id1"), progress.ChanOutput(t.progressChan))
+		t.xfer, t.watcher = tm.transfer("id1", makeXferFunc("id1"), progress.ChanOutput(t.progressChan))
 		go progressConsumer(*t)
 	}
 

--- a/distribution/xfer/transfer_test.go
+++ b/distribution/xfer/transfer_test.go
@@ -29,7 +29,7 @@ func TestTransfer(t *testing.T) {
 		}
 	}
 
-	tm := NewTransferManager(5)
+	tm := newTransferManager(5)
 	progressChan := make(chan progress.Progress)
 	progressDone := make(chan struct{})
 	receivedProgress := make(map[string]int64)
@@ -91,7 +91,7 @@ func TestConcurrencyLimit(t *testing.T) {
 		}
 	}
 
-	tm := NewTransferManager(concurrencyLimit)
+	tm := newTransferManager(concurrencyLimit)
 	progressChan := make(chan progress.Progress)
 	progressDone := make(chan struct{})
 	receivedProgress := make(map[string]int64)
@@ -152,7 +152,7 @@ func TestInactiveJobs(t *testing.T) {
 		}
 	}
 
-	tm := NewTransferManager(concurrencyLimit)
+	tm := newTransferManager(concurrencyLimit)
 	progressChan := make(chan progress.Progress)
 	progressDone := make(chan struct{})
 	receivedProgress := make(map[string]int64)
@@ -211,7 +211,7 @@ func TestWatchRelease(t *testing.T) {
 		}
 	}
 
-	tm := NewTransferManager(5)
+	tm := newTransferManager(5)
 
 	type watcherInfo struct {
 		watcher               *Watcher
@@ -290,7 +290,7 @@ func TestWatchFinishedTransfer(t *testing.T) {
 		}
 	}
 
-	tm := NewTransferManager(5)
+	tm := newTransferManager(5)
 
 	// Start a transfer
 	watchers := make([]*Watcher, 3)
@@ -343,7 +343,7 @@ func TestDuplicateTransfer(t *testing.T) {
 		}
 	}
 
-	tm := NewTransferManager(5)
+	tm := newTransferManager(5)
 
 	type transferInfo struct {
 		xfer                  Transfer

--- a/distribution/xfer/transfer_test.go
+++ b/distribution/xfer/transfer_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestTransfer(t *testing.T) {
-	makeXferFunc := func(id string) DoFunc {
+	makeXferFunc := func(id string) doFunc {
 		return func(progressChan chan<- progress.Progress, start <-chan struct{}, _ chan<- struct{}) transfer {
 			select {
 			case <-start:
@@ -71,7 +71,7 @@ func TestConcurrencyLimit(t *testing.T) {
 	const concurrencyLimit = 3
 	var runningJobs int32
 
-	makeXferFunc := func(id string) DoFunc {
+	makeXferFunc := func(id string) doFunc {
 		return func(progressChan chan<- progress.Progress, start <-chan struct{}, _ chan<- struct{}) transfer {
 			xfer := newTransfer()
 			go func() {
@@ -130,7 +130,7 @@ func TestInactiveJobs(t *testing.T) {
 	var runningJobs int32
 	testDone := make(chan struct{})
 
-	makeXferFunc := func(id string) DoFunc {
+	makeXferFunc := func(id string) doFunc {
 		return func(progressChan chan<- progress.Progress, start <-chan struct{}, inactive chan<- struct{}) transfer {
 			xfer := newTransfer()
 			go func() {
@@ -190,7 +190,7 @@ func TestInactiveJobs(t *testing.T) {
 func TestWatchRelease(t *testing.T) {
 	ready := make(chan struct{})
 
-	makeXferFunc := func(id string) DoFunc {
+	makeXferFunc := func(id string) doFunc {
 		return func(progressChan chan<- progress.Progress, start <-chan struct{}, _ chan<- struct{}) transfer {
 			xfer := newTransfer()
 			go func() {
@@ -279,7 +279,7 @@ func TestWatchRelease(t *testing.T) {
 }
 
 func TestWatchFinishedTransfer(t *testing.T) {
-	makeXferFunc := func(id string) DoFunc {
+	makeXferFunc := func(id string) doFunc {
 		return func(progressChan chan<- progress.Progress, _ <-chan struct{}, _ chan<- struct{}) transfer {
 			xfer := newTransfer()
 			go func() {
@@ -321,7 +321,7 @@ func TestDuplicateTransfer(t *testing.T) {
 
 	var xferFuncCalls int32
 
-	makeXferFunc := func(id string) DoFunc {
+	makeXferFunc := func(id string) doFunc {
 		return func(progressChan chan<- progress.Progress, _ <-chan struct{}, _ chan<- struct{}) transfer {
 			atomic.AddInt32(&xferFuncCalls, 1)
 			xfer := newTransfer()

--- a/distribution/xfer/transfer_test.go
+++ b/distribution/xfer/transfer_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestTransfer(t *testing.T) {
 	makeXferFunc := func(id string) DoFunc {
-		return func(progressChan chan<- progress.Progress, start <-chan struct{}, _ chan<- struct{}) Transfer {
+		return func(progressChan chan<- progress.Progress, start <-chan struct{}, _ chan<- struct{}) transfer {
 			select {
 			case <-start:
 			default:
@@ -47,7 +47,7 @@ func TestTransfer(t *testing.T) {
 
 	// Start a few transfers
 	ids := []string{"id1", "id2", "id3"}
-	xfers := make([]Transfer, len(ids))
+	xfers := make([]transfer, len(ids))
 	watchers := make([]*Watcher, len(ids))
 	for i, id := range ids {
 		xfers[i], watchers[i] = tm.transfer(id, makeXferFunc(id), progress.ChanOutput(progressChan))
@@ -72,7 +72,7 @@ func TestConcurrencyLimit(t *testing.T) {
 	var runningJobs int32
 
 	makeXferFunc := func(id string) DoFunc {
-		return func(progressChan chan<- progress.Progress, start <-chan struct{}, _ chan<- struct{}) Transfer {
+		return func(progressChan chan<- progress.Progress, start <-chan struct{}, _ chan<- struct{}) transfer {
 			xfer := newTransfer()
 			go func() {
 				<-start
@@ -105,7 +105,7 @@ func TestConcurrencyLimit(t *testing.T) {
 
 	// Start more transfers than the concurrency limit
 	ids := []string{"id1", "id2", "id3", "id4", "id5", "id6", "id7", "id8"}
-	xfers := make([]Transfer, len(ids))
+	xfers := make([]transfer, len(ids))
 	watchers := make([]*Watcher, len(ids))
 	for i, id := range ids {
 		xfers[i], watchers[i] = tm.transfer(id, makeXferFunc(id), progress.ChanOutput(progressChan))
@@ -131,7 +131,7 @@ func TestInactiveJobs(t *testing.T) {
 	testDone := make(chan struct{})
 
 	makeXferFunc := func(id string) DoFunc {
-		return func(progressChan chan<- progress.Progress, start <-chan struct{}, inactive chan<- struct{}) Transfer {
+		return func(progressChan chan<- progress.Progress, start <-chan struct{}, inactive chan<- struct{}) transfer {
 			xfer := newTransfer()
 			go func() {
 				<-start
@@ -166,7 +166,7 @@ func TestInactiveJobs(t *testing.T) {
 
 	// Start more transfers than the concurrency limit
 	ids := []string{"id1", "id2", "id3", "id4", "id5", "id6", "id7", "id8"}
-	xfers := make([]Transfer, len(ids))
+	xfers := make([]transfer, len(ids))
 	watchers := make([]*Watcher, len(ids))
 	for i, id := range ids {
 		xfers[i], watchers[i] = tm.transfer(id, makeXferFunc(id), progress.ChanOutput(progressChan))
@@ -191,7 +191,7 @@ func TestWatchRelease(t *testing.T) {
 	ready := make(chan struct{})
 
 	makeXferFunc := func(id string) DoFunc {
-		return func(progressChan chan<- progress.Progress, start <-chan struct{}, _ chan<- struct{}) Transfer {
+		return func(progressChan chan<- progress.Progress, start <-chan struct{}, _ chan<- struct{}) transfer {
 			xfer := newTransfer()
 			go func() {
 				defer func() {
@@ -233,7 +233,7 @@ func TestWatchRelease(t *testing.T) {
 
 	// Start a transfer
 	watchers := make([]watcherInfo, 5)
-	var xfer Transfer
+	var xfer transfer
 	watchers[0].progressChan = make(chan progress.Progress)
 	watchers[0].progressDone = make(chan struct{})
 	watchers[0].receivedFirstProgress = make(chan struct{})
@@ -280,7 +280,7 @@ func TestWatchRelease(t *testing.T) {
 
 func TestWatchFinishedTransfer(t *testing.T) {
 	makeXferFunc := func(id string) DoFunc {
-		return func(progressChan chan<- progress.Progress, _ <-chan struct{}, _ chan<- struct{}) Transfer {
+		return func(progressChan chan<- progress.Progress, _ <-chan struct{}, _ chan<- struct{}) transfer {
 			xfer := newTransfer()
 			go func() {
 				// Finish immediately
@@ -294,7 +294,7 @@ func TestWatchFinishedTransfer(t *testing.T) {
 
 	// Start a transfer
 	watchers := make([]*Watcher, 3)
-	var xfer Transfer
+	var xfer transfer
 	xfer, watchers[0] = tm.transfer("id1", makeXferFunc("id1"), progress.ChanOutput(make(chan progress.Progress)))
 
 	// Give it a watcher immediately
@@ -322,7 +322,7 @@ func TestDuplicateTransfer(t *testing.T) {
 	var xferFuncCalls int32
 
 	makeXferFunc := func(id string) DoFunc {
-		return func(progressChan chan<- progress.Progress, _ <-chan struct{}, _ chan<- struct{}) Transfer {
+		return func(progressChan chan<- progress.Progress, _ <-chan struct{}, _ chan<- struct{}) transfer {
 			atomic.AddInt32(&xferFuncCalls, 1)
 			xfer := newTransfer()
 			go func() {
@@ -346,7 +346,7 @@ func TestDuplicateTransfer(t *testing.T) {
 	tm := newTransferManager(5)
 
 	type transferInfo struct {
-		xfer                  Transfer
+		xfer                  transfer
 		watcher               *Watcher
 		progressChan          chan progress.Progress
 		progressDone          chan struct{}

--- a/distribution/xfer/transfer_test.go
+++ b/distribution/xfer/transfer_test.go
@@ -17,7 +17,7 @@ func TestTransfer(t *testing.T) {
 				t.Errorf("%s: transfer function not started even though concurrency limit not reached", id)
 			}
 
-			xfer := NewTransfer()
+			xfer := newTransfer()
 			go func() {
 				for i := 0; i <= 10; i++ {
 					progressChan <- progress.Progress{ID: id, Action: "testing", Current: int64(i), Total: 10}
@@ -73,7 +73,7 @@ func TestConcurrencyLimit(t *testing.T) {
 
 	makeXferFunc := func(id string) DoFunc {
 		return func(progressChan chan<- progress.Progress, start <-chan struct{}, _ chan<- struct{}) Transfer {
-			xfer := NewTransfer()
+			xfer := newTransfer()
 			go func() {
 				<-start
 				totalJobs := atomic.AddInt32(&runningJobs, 1)
@@ -132,7 +132,7 @@ func TestInactiveJobs(t *testing.T) {
 
 	makeXferFunc := func(id string) DoFunc {
 		return func(progressChan chan<- progress.Progress, start <-chan struct{}, inactive chan<- struct{}) Transfer {
-			xfer := NewTransfer()
+			xfer := newTransfer()
 			go func() {
 				<-start
 				totalJobs := atomic.AddInt32(&runningJobs, 1)
@@ -192,7 +192,7 @@ func TestWatchRelease(t *testing.T) {
 
 	makeXferFunc := func(id string) DoFunc {
 		return func(progressChan chan<- progress.Progress, start <-chan struct{}, _ chan<- struct{}) Transfer {
-			xfer := NewTransfer()
+			xfer := newTransfer()
 			go func() {
 				defer func() {
 					close(progressChan)
@@ -281,7 +281,7 @@ func TestWatchRelease(t *testing.T) {
 func TestWatchFinishedTransfer(t *testing.T) {
 	makeXferFunc := func(id string) DoFunc {
 		return func(progressChan chan<- progress.Progress, _ <-chan struct{}, _ chan<- struct{}) Transfer {
-			xfer := NewTransfer()
+			xfer := newTransfer()
 			go func() {
 				// Finish immediately
 				close(progressChan)
@@ -324,7 +324,7 @@ func TestDuplicateTransfer(t *testing.T) {
 	makeXferFunc := func(id string) DoFunc {
 		return func(progressChan chan<- progress.Progress, _ <-chan struct{}, _ chan<- struct{}) Transfer {
 			atomic.AddInt32(&xferFuncCalls, 1)
-			xfer := NewTransfer()
+			xfer := newTransfer()
 			go func() {
 				defer func() {
 					close(progressChan)

--- a/distribution/xfer/transfer_test.go
+++ b/distribution/xfer/transfer_test.go
@@ -48,7 +48,7 @@ func TestTransfer(t *testing.T) {
 	// Start a few transfers
 	ids := []string{"id1", "id2", "id3"}
 	xfers := make([]transfer, len(ids))
-	watchers := make([]*Watcher, len(ids))
+	watchers := make([]*watcher, len(ids))
 	for i, id := range ids {
 		xfers[i], watchers[i] = tm.transfer(id, makeXferFunc(id), progress.ChanOutput(progressChan))
 	}
@@ -106,7 +106,7 @@ func TestConcurrencyLimit(t *testing.T) {
 	// Start more transfers than the concurrency limit
 	ids := []string{"id1", "id2", "id3", "id4", "id5", "id6", "id7", "id8"}
 	xfers := make([]transfer, len(ids))
-	watchers := make([]*Watcher, len(ids))
+	watchers := make([]*watcher, len(ids))
 	for i, id := range ids {
 		xfers[i], watchers[i] = tm.transfer(id, makeXferFunc(id), progress.ChanOutput(progressChan))
 	}
@@ -167,7 +167,7 @@ func TestInactiveJobs(t *testing.T) {
 	// Start more transfers than the concurrency limit
 	ids := []string{"id1", "id2", "id3", "id4", "id5", "id6", "id7", "id8"}
 	xfers := make([]transfer, len(ids))
-	watchers := make([]*Watcher, len(ids))
+	watchers := make([]*watcher, len(ids))
 	for i, id := range ids {
 		xfers[i], watchers[i] = tm.transfer(id, makeXferFunc(id), progress.ChanOutput(progressChan))
 	}
@@ -214,7 +214,7 @@ func TestWatchRelease(t *testing.T) {
 	tm := newTransferManager(5)
 
 	type watcherInfo struct {
-		watcher               *Watcher
+		watcher               *watcher
 		progressChan          chan progress.Progress
 		progressDone          chan struct{}
 		receivedFirstProgress chan struct{}
@@ -293,7 +293,7 @@ func TestWatchFinishedTransfer(t *testing.T) {
 	tm := newTransferManager(5)
 
 	// Start a transfer
-	watchers := make([]*Watcher, 3)
+	watchers := make([]*watcher, 3)
 	var xfer transfer
 	xfer, watchers[0] = tm.transfer("id1", makeXferFunc("id1"), progress.ChanOutput(make(chan progress.Progress)))
 
@@ -347,7 +347,7 @@ func TestDuplicateTransfer(t *testing.T) {
 
 	type transferInfo struct {
 		xfer                  transfer
-		watcher               *Watcher
+		watcher               *watcher
 		progressChan          chan progress.Progress
 		progressDone          chan struct{}
 		receivedFirstProgress chan struct{}

--- a/distribution/xfer/transfer_test.go
+++ b/distribution/xfer/transfer_test.go
@@ -68,7 +68,7 @@ func TestTransfer(t *testing.T) {
 }
 
 func TestConcurrencyLimit(t *testing.T) {
-	concurrencyLimit := 3
+	const concurrencyLimit = 3
 	var runningJobs int32
 
 	makeXferFunc := func(id string) DoFunc {
@@ -126,7 +126,7 @@ func TestConcurrencyLimit(t *testing.T) {
 }
 
 func TestInactiveJobs(t *testing.T) {
-	concurrencyLimit := 3
+	const concurrencyLimit = 3
 	var runningJobs int32
 	testDone := make(chan struct{})
 

--- a/distribution/xfer/upload.go
+++ b/distribution/xfer/upload.go
@@ -22,7 +22,7 @@ type LayerUploadManager struct {
 
 // SetConcurrency sets the max concurrent uploads for each push
 func (lum *LayerUploadManager) SetConcurrency(concurrency int) {
-	lum.tm.SetConcurrency(concurrency)
+	lum.tm.setConcurrency(concurrency)
 }
 
 // NewLayerUploadManager returns a new LayerUploadManager.
@@ -79,7 +79,7 @@ func (lum *LayerUploadManager) Upload(ctx context.Context, layers []UploadDescri
 		}
 
 		xferFunc := lum.makeUploadFunc(descriptor)
-		upload, watcher := lum.tm.Transfer(descriptor.Key(), xferFunc, progressOutput)
+		upload, watcher := lum.tm.transfer(descriptor.Key(), xferFunc, progressOutput)
 		defer upload.Release(watcher)
 		uploads = append(uploads, upload.(*uploadTransfer))
 		dedupDescriptors[key] = upload.(*uploadTransfer)

--- a/distribution/xfer/upload.go
+++ b/distribution/xfer/upload.go
@@ -102,7 +102,7 @@ func (lum *LayerUploadManager) Upload(ctx context.Context, layers []UploadDescri
 	return nil
 }
 
-func (lum *LayerUploadManager) makeUploadFunc(descriptor UploadDescriptor) DoFunc {
+func (lum *LayerUploadManager) makeUploadFunc(descriptor UploadDescriptor) doFunc {
 	return func(progressChan chan<- progress.Progress, start <-chan struct{}, inactive chan<- struct{}) transfer {
 		u := &uploadTransfer{
 			transfer: newTransfer(),

--- a/distribution/xfer/upload.go
+++ b/distribution/xfer/upload.go
@@ -16,7 +16,7 @@ const maxUploadAttempts = 5
 // LayerUploadManager provides task management and progress reporting for
 // uploads.
 type LayerUploadManager struct {
-	tm           TransferManager
+	tm           *transferManager
 	waitDuration time.Duration
 }
 
@@ -28,7 +28,7 @@ func (lum *LayerUploadManager) SetConcurrency(concurrency int) {
 // NewLayerUploadManager returns a new LayerUploadManager.
 func NewLayerUploadManager(concurrencyLimit int, options ...func(*LayerUploadManager)) *LayerUploadManager {
 	manager := LayerUploadManager{
-		tm:           NewTransferManager(concurrencyLimit),
+		tm:           newTransferManager(concurrencyLimit),
 		waitDuration: time.Second,
 	}
 	for _, option := range options {

--- a/distribution/xfer/upload.go
+++ b/distribution/xfer/upload.go
@@ -105,7 +105,7 @@ func (lum *LayerUploadManager) Upload(ctx context.Context, layers []UploadDescri
 func (lum *LayerUploadManager) makeUploadFunc(descriptor UploadDescriptor) DoFunc {
 	return func(progressChan chan<- progress.Progress, start <-chan struct{}, inactive chan<- struct{}) Transfer {
 		u := &uploadTransfer{
-			Transfer: NewTransfer(),
+			Transfer: newTransfer(),
 		}
 
 		go func() {

--- a/distribution/xfer/upload_test.go
+++ b/distribution/xfer/upload_test.go
@@ -69,12 +69,12 @@ func (u *mockUploadDescriptor) Upload(ctx context.Context, progressOutput progre
 
 func uploadDescriptors(currentUploads *int32) []UploadDescriptor {
 	return []UploadDescriptor{
-		&mockUploadDescriptor{currentUploads, layer.DiffID("sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf"), 0},
-		&mockUploadDescriptor{currentUploads, layer.DiffID("sha256:1515325234325236634634608943609283523908626098235490238423902343"), 0},
-		&mockUploadDescriptor{currentUploads, layer.DiffID("sha256:6929356290463485374960346430698374523437683470934634534953453453"), 0},
-		&mockUploadDescriptor{currentUploads, layer.DiffID("sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf"), 0},
-		&mockUploadDescriptor{currentUploads, layer.DiffID("sha256:8159352387436803946235346346368745389534789534897538734598734987"), 1},
-		&mockUploadDescriptor{currentUploads, layer.DiffID("sha256:4637863963478346897346987346987346789346789364879364897364987346"), 0},
+		&mockUploadDescriptor{currentUploads: currentUploads, diffID: "sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf"},
+		&mockUploadDescriptor{currentUploads: currentUploads, diffID: "sha256:1515325234325236634634608943609283523908626098235490238423902343"},
+		&mockUploadDescriptor{currentUploads: currentUploads, diffID: "sha256:6929356290463485374960346430698374523437683470934634534953453453"},
+		&mockUploadDescriptor{currentUploads: currentUploads, diffID: "sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf"},
+		&mockUploadDescriptor{currentUploads: currentUploads, diffID: "sha256:8159352387436803946235346346368745389534789534897538734598734987", simulateRetries: 1},
+		&mockUploadDescriptor{currentUploads: currentUploads, diffID: "sha256:4637863963478346897346987346987346789346789364879364897364987346"},
 	}
 }
 


### PR DESCRIPTION
This is a follow-up to (commits of those PRs are currently included, so I'll rebase this when those are merged):

- https://github.com/moby/moby/pull/43174
- https://github.com/moby/moby/pull/43181
- https://github.com/moby/moby/pull/43182

The `distribution/xfer` package defined various interfaces and exported types that were only used internal to the package, and only had a single implementation. This PR un-exports many of those to reduce the public interface of this package.

See individual commits for details.

Before this PR:

<img width="1268" alt="Screenshot 2022-02-18 at 16 57 28" src="https://user-images.githubusercontent.com/1804568/154717443-157a8c5d-3460-4810-adad-e509b9c9ac8f.png">


After this PR:

<img width="1241" alt="Screenshot 2022-02-18 at 16 58 04" src="https://user-images.githubusercontent.com/1804568/154717490-4d6aeee4-bf86-4c91-b98e-b42a26263dc0.png">

