### PR TITLE
Remove various leftover LCOW checks

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -18,7 +18,6 @@ import (
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/pkg/stringid"
-	"github.com/docker/docker/pkg/system"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/moby/buildkit/frontend/dockerfile/shell"
@@ -319,9 +318,6 @@ func (b *Builder) dispatchDockerfileWithCancellation(parseResult []instructions.
 //
 // TODO: Remove?
 func BuildFromConfig(config *container.Config, changes []string, os string) (*container.Config, error) {
-	if !system.IsOSSupported(os) {
-		return nil, errdefs.InvalidParameter(system.ErrNotSupportedOperatingSystem)
-	}
 	if len(changes) == 0 {
 		return config, nil
 	}

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -246,27 +246,19 @@ func (d *dispatchRequest) getImageOrStage(name string, platform *specs.Platform)
 		platform = d.builder.platform
 	}
 
-	// Windows cannot support a container with no base image unless it is LCOW.
+	// Windows cannot support a container with no base image.
 	if name == api.NoBaseImageSpecifier {
-		p := platforms.DefaultSpec()
-		if platform != nil {
-			p = *platform
-		}
-		imageImage := &image.Image{}
-		imageImage.OS = p.OS
-
-		// old windows scratch handling
-		// TODO: scratch should not have an os. It should be nil image.
-		// Windows supports scratch. What is not supported is running containers
-		// from it.
+		// Windows supports scratch. What is not supported is running containers from it.
 		if runtime.GOOS == "windows" {
-			if platform == nil || platform.OS == "linux" {
-				return nil, errors.New("Linux containers are not supported on this system")
-			} else if platform.OS == "windows" {
-				return nil, errors.New("Windows does not support FROM scratch")
-			} else {
-				return nil, errors.Errorf("platform %s is not supported", platforms.Format(p))
-			}
+			return nil, errors.New("Windows does not support FROM scratch")
+		}
+
+		// TODO: scratch should not have an os. It should be nil image.
+		imageImage := &image.Image{}
+		if platform != nil {
+			imageImage.OS = platform.OS
+		} else {
+			imageImage.OS = runtime.GOOS
 		}
 		return builder.Image(imageImage), nil
 	}

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -117,7 +117,7 @@ func TestFromScratch(t *testing.T) {
 	err := initializeStage(sb, cmd)
 
 	if runtime.GOOS == "windows" {
-		assert.Check(t, is.Error(err, "Linux containers are not supported on this system"))
+		assert.Check(t, is.Error(err, "Windows does not support FROM scratch"))
 		return
 	}
 

--- a/builder/dockerfile/evaluator.go
+++ b/builder/dockerfile/evaluator.go
@@ -21,7 +21,6 @@ package dockerfile // import "github.com/docker/docker/builder/dockerfile"
 
 import (
 	"reflect"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -216,9 +215,6 @@ func (s *dispatchState) beginStage(stageName string, image builder.Image) error 
 	s.stageName = stageName
 	s.imageID = image.ImageID()
 	s.operatingSystem = image.OperatingSystem()
-	if s.operatingSystem == "" { // In case it isn't set
-		s.operatingSystem = runtime.GOOS
-	}
 	if !system.IsOSSupported(s.operatingSystem) {
 		return system.ErrNotSupportedOperatingSystem
 	}

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -123,10 +123,10 @@ func (daemon *Daemon) create(opts createOpts) (retC *container.Container, retErr
 			return nil, err
 		}
 		os = img.OperatingSystem()
-		imgID = img.ID()
 		if !system.IsOSSupported(os) {
-			return nil, errors.New("operating system on which parent image was created is not Windows")
+			return nil, system.ErrNotSupportedOperatingSystem
 		}
+		imgID = img.ID()
 	} else if isWindows {
 		os = "linux" // 'scratch' case.
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -948,7 +948,6 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		IDMapping:                 idMapping,
 		PluginGetter:              d.PluginStore,
 		ExperimentalEnabled:       config.Experimental,
-		OS:                        runtime.GOOS,
 	})
 	if err != nil {
 		return nil, err

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -77,7 +77,7 @@ func (daemon *Daemon) rmLink(container *container.Container, name string) error 
 
 // cleanupContainer unregisters a container from the daemon, stops stats
 // collection and cleanly removes contents and metadata from the filesystem.
-func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemove, removeVolume bool) (err error) {
+func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemove, removeVolume bool) error {
 	if container.IsRunning() {
 		if !forceRemove {
 			state := container.StateString()
@@ -97,7 +97,7 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 	// if stats are currently getting collected.
 	daemon.statsCollector.StopCollection(container)
 
-	if err = daemon.containerStop(container, 3); err != nil {
+	if err := daemon.containerStop(container, 3); err != nil {
 		return err
 	}
 
@@ -116,8 +116,7 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 	// When container creation fails and `RWLayer` has not been created yet, we
 	// do not call `ReleaseRWLayer`
 	if container.RWLayer != nil {
-		err := daemon.imageService.ReleaseLayer(container.RWLayer)
-		if err != nil {
+		if err := daemon.imageService.ReleaseLayer(container.RWLayer); err != nil {
 			err = errors.Wrapf(err, "container %s", container.ID)
 			container.SetRemovalError(err)
 			return err
@@ -126,9 +125,9 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 	}
 
 	if err := system.EnsureRemoveAll(container.Root); err != nil {
-		e := errors.Wrapf(err, "unable to remove filesystem for %s", container.ID)
-		container.SetRemovalError(e)
-		return e
+		err = errors.Wrapf(err, "unable to remove filesystem for %s", container.ID)
+		container.SetRemovalError(err)
+		return err
 	}
 
 	linkNames := daemon.linkIndex.delete(container)
@@ -136,8 +135,8 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 	daemon.idIndex.Delete(container.ID)
 	daemon.containers.Delete(container.ID)
 	daemon.containersReplica.Delete(container)
-	if e := daemon.removeMountPoints(container, removeVolume); e != nil {
-		logrus.Error(e)
+	if err := daemon.removeMountPoints(container, removeVolume); err != nil {
+		logrus.Error(err)
 	}
 	for _, name := range linkNames {
 		daemon.releaseName(name)

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -92,9 +92,6 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 			return fmt.Errorf("Could not kill running container %s, cannot remove - %v", container.ID, err)
 		}
 	}
-	if !system.IsOSSupported(container.OS) {
-		return fmt.Errorf("cannot remove %s: %s ", container.ID, system.ErrNotSupportedOperatingSystem)
-	}
 
 	// stop collection of stats for the container regardless
 	// if stats are currently getting collected.

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -116,7 +116,7 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 	// When container creation fails and `RWLayer` has not been created yet, we
 	// do not call `ReleaseRWLayer`
 	if container.RWLayer != nil {
-		err := daemon.imageService.ReleaseLayer(container.RWLayer, container.OS)
+		err := daemon.imageService.ReleaseLayer(container.RWLayer)
 		if err != nil {
 			err = errors.Wrapf(err, "container %s", container.ID)
 			container.SetRemovalError(err)

--- a/daemon/export.go
+++ b/daemon/export.go
@@ -52,7 +52,7 @@ func (daemon *Daemon) containerExport(container *container.Container) (arch io.R
 	}
 	defer func() {
 		if err != nil {
-			daemon.imageService.ReleaseLayer(rwlayer, container.OS)
+			daemon.imageService.ReleaseLayer(rwlayer)
 		}
 	}()
 
@@ -73,7 +73,7 @@ func (daemon *Daemon) containerExport(container *container.Container) (arch io.R
 	arch = ioutils.NewReadCloserWrapper(archv, func() error {
 		err := archv.Close()
 		rwlayer.Unmount()
-		daemon.imageService.ReleaseLayer(rwlayer, container.OS)
+		daemon.imageService.ReleaseLayer(rwlayer)
 		return err
 	})
 	daemon.LogContainerEvent(container, "export")

--- a/daemon/export.go
+++ b/daemon/export.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/ioutils"
-	"github.com/docker/docker/pkg/system"
 )
 
 // ContainerExport writes the contents of the container to the given
@@ -47,9 +46,6 @@ func (daemon *Daemon) ContainerExport(name string, out io.Writer) error {
 }
 
 func (daemon *Daemon) containerExport(container *container.Container) (arch io.ReadCloser, err error) {
-	if !system.IsOSSupported(container.OS) {
-		return nil, fmt.Errorf("cannot export %s: %s ", container.ID, system.ErrNotSupportedOperatingSystem)
-	}
 	rwlayer, err := daemon.imageService.GetLayerByID(container.ID)
 	if err != nil {
 		return nil, err

--- a/daemon/images/image_delete.go
+++ b/daemon/images/image_delete.go
@@ -11,7 +11,6 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/stringid"
-	"github.com/docker/docker/pkg/system"
 	"github.com/pkg/errors"
 )
 
@@ -67,9 +66,6 @@ func (i *ImageService) ImageDelete(imageRef string, force, prune bool) ([]types.
 	img, err := i.GetImage(imageRef, nil)
 	if err != nil {
 		return nil, err
-	}
-	if !system.IsOSSupported(img.OperatingSystem()) {
-		return nil, errors.Errorf("unable to delete image: %q", system.ErrNotSupportedOperatingSystem)
 	}
 
 	imgID := img.ID()

--- a/daemon/images/image_history.go
+++ b/daemon/images/image_history.go
@@ -7,7 +7,6 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/layer"
-	"github.com/docker/docker/pkg/system"
 )
 
 // ImageHistory returns a slice of ImageHistory structures for the specified image
@@ -31,9 +30,6 @@ func (i *ImageService) ImageHistory(name string) ([]*image.HistoryResponseItem, 
 		if !h.EmptyLayer {
 			if len(img.RootFS.DiffIDs) <= layerCounter {
 				return nil, fmt.Errorf("too many non-empty layers in History section")
-			}
-			if !system.IsOSSupported(img.OperatingSystem()) {
-				return nil, system.ErrNotSupportedOperatingSystem
 			}
 			rootFS.Append(img.RootFS.DiffIDs[layerCounter])
 			l, err := i.layerStore.Get(rootFS.ChainID())

--- a/daemon/images/image_import.go
+++ b/daemon/images/image_import.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
+	"github.com/docker/docker/pkg/system"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
@@ -58,7 +59,9 @@ func (i *ImageService) ImportImage(src string, repository string, platform *spec
 		p := platforms.DefaultSpec()
 		platform = &p
 	}
-
+	if !system.IsOSSupported(platform.OS) {
+		return errdefs.InvalidParameter(system.ErrNotSupportedOperatingSystem)
+	}
 	config, err := dockerfile.BuildFromConfig(&container.Config{}, changes, platform.OS)
 	if err != nil {
 		return err

--- a/daemon/images/image_inspect.go
+++ b/daemon/images/image_inspect.go
@@ -7,7 +7,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
-	"github.com/docker/docker/pkg/system"
 	"github.com/pkg/errors"
 )
 
@@ -18,9 +17,7 @@ func (i *ImageService) LookupImage(name string) (*types.ImageInspect, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "no such image: %s", name)
 	}
-	if !system.IsOSSupported(img.OperatingSystem()) {
-		return nil, system.ErrNotSupportedOperatingSystem
-	}
+
 	refs := i.referenceStore.References(img.ID().Digest())
 	repoTags := []string{}
 	repoDigests := []string{}

--- a/daemon/images/images.go
+++ b/daemon/images/images.go
@@ -285,9 +285,6 @@ func (i *ImageService) SquashImage(id, parent string) (string, error) {
 		rootFS := image.NewRootFS()
 		parentImg = &image.Image{RootFS: rootFS}
 	}
-	if !system.IsOSSupported(img.OperatingSystem()) {
-		return "", errors.Wrap(err, system.ErrNotSupportedOperatingSystem.Error())
-	}
 	l, err := i.layerStore.Get(img.RootFS.ChainID())
 	if err != nil {
 		return "", errors.Wrap(err, "error getting image layer")

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -187,7 +187,7 @@ func (i *ImageService) GraphDriverName() string {
 
 // ReleaseLayer releases a layer allowing it to be removed
 // called from delete.go Daemon.cleanupContainer(), and Daemon.containerExport()
-func (i *ImageService) ReleaseLayer(rwlayer layer.RWLayer, containerOS string) error {
+func (i *ImageService) ReleaseLayer(rwlayer layer.RWLayer) error {
 	metadata, err := i.layerStore.ReleaseRWLayer(rwlayer)
 	layer.LogReleaseMetadata(metadata)
 	if err != nil && !errors.Is(err, layer.ErrMountDoesNotExist) && !errors.Is(err, os.ErrNotExist) {

--- a/image/store.go
+++ b/image/store.go
@@ -229,12 +229,9 @@ func (is *store) Delete(id ID) ([]layer.Metadata, error) {
 	if imageMeta == nil {
 		return nil, fmt.Errorf("unrecognized image ID %s", id.String())
 	}
-	img, err := is.Get(id)
+	_, err := is.Get(id)
 	if err != nil {
 		return nil, fmt.Errorf("unrecognized image %s, %v", id.String(), err)
-	}
-	if !system.IsOSSupported(img.OperatingSystem()) {
-		return nil, fmt.Errorf("unsupported image operating system %q", img.OperatingSystem())
 	}
 	for id := range imageMeta.children {
 		is.fs.DeleteMetadata(id.Digest(), "parent")

--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/docker/distribution"
@@ -149,17 +148,13 @@ func (l *tarexporter) takeLayerReference(id image.ID, imgDescr *imageDescriptor)
 	if err != nil {
 		return err
 	}
+	if os := img.OperatingSystem(); !system.IsOSSupported(os) {
+		return fmt.Errorf("os %q is not supported", os)
+	}
 	imgDescr.image = img
 	topLayerID := img.RootFS.ChainID()
 	if topLayerID == "" {
 		return nil
-	}
-	os := img.OS
-	if os == "" {
-		os = runtime.GOOS
-	}
-	if !system.IsOSSupported(os) {
-		return fmt.Errorf("os %q is not supported", os)
 	}
 	layer, err := l.lss.Get(topLayerID)
 	if err != nil {

--- a/integration/image/remove_unix_test.go
+++ b/integration/image/remove_unix_test.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -53,7 +52,6 @@ func TestRemoveImageGarbageCollector(t *testing.T) {
 		IDMapping:                 &idtools.IdentityMapping{},
 		PluginGetter:              nil,
 		ExperimentalEnabled:       false,
-		OS:                        runtime.GOOS,
 	})
 	i := images.NewImageService(images.ImageServiceConfig{
 		LayerStore: layerStore,

--- a/layer/layer_test.go
+++ b/layer/layer_test.go
@@ -69,7 +69,7 @@ func newTestStore(t *testing.T) (Store, string, func()) {
 
 	graph, graphcleanup := newTestGraphDriver(t)
 
-	ls, err := newStoreFromGraphDriver(td, graph, runtime.GOOS)
+	ls, err := newStoreFromGraphDriver(td, graph)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -395,7 +395,7 @@ func TestStoreRestore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ls2, err := newStoreFromGraphDriver(ls.(*layerStore).store.root, ls.(*layerStore).driver, runtime.GOOS)
+	ls2, err := newStoreFromGraphDriver(ls.(*layerStore).store.root, ls.(*layerStore).driver)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/layer/migration_test.go
+++ b/layer/migration_test.go
@@ -88,7 +88,7 @@ func TestLayerMigration(t *testing.T) {
 	}
 
 	root := filepath.Join(td, "layers")
-	ls, err := newStoreFromGraphDriver(root, graph, runtime.GOOS)
+	ls, err := newStoreFromGraphDriver(root, graph)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -213,7 +213,7 @@ func TestLayerMigrationNoTarsplit(t *testing.T) {
 	}
 
 	root := filepath.Join(td, "layers")
-	ls, err := newStoreFromGraphDriver(root, graph, runtime.GOOS)
+	ls, err := newStoreFromGraphDriver(root, graph)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/layer/ro_layer.go
+++ b/layer/ro_layer.go
@@ -3,6 +3,7 @@ package layer // import "github.com/docker/docker/layer"
 import (
 	"fmt"
 	"io"
+	"runtime"
 
 	"github.com/docker/distribution"
 	digest "github.com/opencontainers/go-digest"
@@ -146,7 +147,7 @@ func storeLayer(tx *fileMetadataTransaction, layer *roLayer) error {
 			return err
 		}
 	}
-	return tx.setOS(layer.layerStore.os)
+	return tx.setOS(runtime.GOOS)
 }
 
 func newVerifiedReadCloser(rc io.ReadCloser, dgst digest.Digest) (io.ReadCloser, error) {


### PR DESCRIPTION
### daemon/images: remove leftover LCOW platform checks

This removes some of the checks that were added in 0cba7740d41369eee33b671f26276325580bc07b (https://github.com/moby/moby/pull/34859), but should no longer be needed.

- `ImageService.ImageDelete()`: no need to validate image platform to delete it.
- `ImageService.ImageHistory()`: no need to validate image platform to show its
  history; if it made it into the local image cache, it should be valid.
- `ImageService.ImportImage()`: `dockerfile.BuildFromConfig()` is used for
  `docker (container) commmit` and `docker (image) import`. For `docker import`,
  it's more transparent to perform validation early.
- `ImageService.LookupImage()`: no need to validate image platform to inspect it;
  if it made it into the local image cache, it should be valid.
- `ImageService.SquashImage()`: same. This code was actually broken, because it
  wrapped an `err` that was always `nil`, so would never return an error.

### image: remove leftover LCOW platform checks

This removes some of the checks that were added in 0cba7740d41369eee33b671f26276325580bc07b (https://github.com/moby/moby/pull/34859), but should no longer be needed.

- `image/store.Delete()`: no need to validate image platform to delete it.
- `image/tarexporter/takeLayerReference()`: use `image.OperatingSystem()` and
  fail early to prevent constructing the `ChainID()`.

### builder/dockerfile: remove leftover LCOW platform checks

This removes some of the checks that were added in 0cba7740d41369eee33b671f26276325580bc07b (https://github.com/moby/moby/pull/34859), but should no longer be needed.

- `dockerfile.BuildFromConfig()` is used for `docker (container) commmit` and
  `docker (image) import`. For `docker import`, we're failing early already.
  For `commit`, it won't be possible to have a container that doesn't have the
  right operating-system, so there's no need to validate.
- `dispatchRequest.getImageOrStage()`: simplify the check; all checks resulted
  in an error on Windows, so it came down to "Windows does not support FROM scratch".
- `dispatchState.beginStage()`: `image.OperatingSystem()` already defaults to the
  `runtime.GOOS` if unset, so remove the local default fallback.

### daemon: remove leftover LCOW platform checks

This removes some of the checks that were added in 0cba7740d41369eee33b671f26276325580bc07b (https://github.com/moby/moby/pull/34859), but should no longer be needed.

- `Daemon.create()`: fix the error message, which assumed it could only occur on Windows.
- `Daemon.cleanupContainer()`: no need to validate container platform to delete it.
- `Daemon.containerExport`: if a container was created, we should be able to
  export it; no need to validate.

### ImageService.ReleaseLayer(): remove unused containerOS argument

This looks to be a leftover from LCOW.

### daemon.cleanupContainer() remove named return variable

It only made the code more difficult to read, adding cognitive overload.

### layer: remove OS from layerstore

This was added in commits fc21bf280bac39377d3a236efa87f5c8cbadfb9f (https://github.com/moby/moby/pull/33241) and 0380fbff37922cadf294851b1546f4c212c7f364 (https://github.com/moby/moby/pull/34642) in support of LCOW, but was now always set to runtime.GOOS.
