### PR TITLE
pkg/system: remove unused HasWin32KSupport() and rewrite IsWindowsClient()

### DIFF
--- a/pkg/system/syscall_windows.go
+++ b/pkg/system/syscall_windows.go
@@ -1,10 +1,6 @@
 package system // import "github.com/docker/docker/pkg/system"
 
-import (
-	"unsafe"
-
-	"github.com/sirupsen/logrus"
-)
+import "golang.org/x/sys/windows"
 
 const (
 	// Deprecated: use github.com/docker/pkg/idtools.SeTakeOwnershipPrivilege
@@ -15,35 +11,13 @@ const (
 	ContainerUserSidString = "S-1-5-93-2-2"
 )
 
-var procGetVersionExW = modkernel32.NewProc("GetVersionExW")
-
-// https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexa
-// TODO: use golang.org/x/sys/windows.OsVersionInfoEx (needs OSVersionInfoSize to be exported)
-type osVersionInfoEx struct {
-	OSVersionInfoSize uint32
-	MajorVersion      uint32
-	MinorVersion      uint32
-	BuildNumber       uint32
-	PlatformID        uint32
-	CSDVersion        [128]uint16
-	ServicePackMajor  uint16
-	ServicePackMinor  uint16
-	SuiteMask         uint16
-	ProductType       byte
-	Reserve           byte
-}
+// VER_NT_WORKSTATION, see https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexa
+const verNTWorkstation = 0x00000001 // VER_NT_WORKSTATION
 
 // IsWindowsClient returns true if the SKU is client. It returns false on
 // Windows server, or if an error occurred when making the GetVersionExW
 // syscall.
 func IsWindowsClient() bool {
-	osviex := &osVersionInfoEx{OSVersionInfoSize: 284}
-	r1, _, err := procGetVersionExW.Call(uintptr(unsafe.Pointer(osviex)))
-	if r1 == 0 {
-		logrus.WithError(err).Warn("GetVersionExW failed - assuming server SKU")
-		return false
-	}
-	// VER_NT_WORKSTATION, see https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexa
-	const verNTWorkstation = 0x00000001 // VER_NT_WORKSTATION
-	return osviex.ProductType == verNTWorkstation
+	ver := windows.RtlGetVersion()
+	return ver != nil && ver.ProductType == verNTWorkstation
 }

--- a/pkg/system/syscall_windows.go
+++ b/pkg/system/syscall_windows.go
@@ -4,25 +4,18 @@ import (
 	"unsafe"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/windows"
 )
 
 const (
 	// Deprecated: use github.com/docker/pkg/idtools.SeTakeOwnershipPrivilege
 	SeTakeOwnershipPrivilege = "SeTakeOwnershipPrivilege"
-)
-
-const (
 	// Deprecated: use github.com/docker/pkg/idtools.ContainerAdministratorSidString
 	ContainerAdministratorSidString = "S-1-5-93-2-1"
 	// Deprecated: use github.com/docker/pkg/idtools.ContainerUserSidString
 	ContainerUserSidString = "S-1-5-93-2-2"
 )
 
-var (
-	ntuserApiset      = windows.NewLazyDLL("ext-ms-win-ntuser-window-l1-1-0")
-	procGetVersionExW = modkernel32.NewProc("GetVersionExW")
-)
+var procGetVersionExW = modkernel32.NewProc("GetVersionExW")
 
 // https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexa
 // TODO: use golang.org/x/sys/windows.OsVersionInfoEx (needs OSVersionInfoSize to be exported)
@@ -53,13 +46,4 @@ func IsWindowsClient() bool {
 	// VER_NT_WORKSTATION, see https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexa
 	const verNTWorkstation = 0x00000001 // VER_NT_WORKSTATION
 	return osviex.ProductType == verNTWorkstation
-}
-
-// HasWin32KSupport determines whether containers that depend on win32k can
-// run on this machine. Win32k is the driver used to implement windowing.
-func HasWin32KSupport() bool {
-	// For now, check for ntuser API support on the host. In the future, a host
-	// may support win32k in containers even if the host does not support ntuser
-	// APIs.
-	return ntuserApiset.Load() == nil
 }

--- a/pkg/system/syscall_windows_test.go
+++ b/pkg/system/syscall_windows_test.go
@@ -1,9 +1,0 @@
-package system // import "github.com/docker/docker/pkg/system"
-
-import "testing"
-
-func TestHasWin32KSupport(t *testing.T) {
-	s := HasWin32KSupport() // make sure this doesn't panic
-
-	t.Logf("win32k: %v", s) // will be different on different platforms -- informative only
-}


### PR DESCRIPTION
### pkg/system: remove unused HasWin32KSupport() 

This was added in 194eaa5c0f843257e66b68bd735786308a9d93b2 (#21272) to check image compatibility based on Platform.Features;

    // For now, hard code that all base images except nanoserver depend on win32k support
    if imageData.Name != "nanoserver" {
        imageData.OSFeatures = append(imageData.OSFeatures, "win32k")
    }

But no longer used since 1f59bc8c03df18686b93a0cd619cf2c55cbcf421 (#21819) and d231260868507174d60ff58b18b14fa5bc2d5b66 (#22022)

### pkg/system: rewrite IsWindowsClient() using golang.org/x/sys/windows

