### PR TITLE
pkg/system: move maxTime init() back to Chtimes code and remove use of "unsafe"

### DIFF
--- a/daemon/internal/system/chtimes.go
+++ b/daemon/internal/system/chtimes.go
@@ -4,15 +4,17 @@ import (
 	"os"
 	"syscall"
 	"time"
-	"unsafe"
 )
 
 // Used by Chtimes
 var unixEpochTime, unixMaxTime time.Time
 
 func init() {
-	unixEpochTime = time.Unix(0, 0)
-	if unsafe.Sizeof(syscall.Timespec{}.Nsec) == 8 {
+	switch interface{}(syscall.Timespec{}.Nsec).(type) {
+	case int32:
+		// This is a 32 bit timespec
+		unixMaxTime = time.Unix(1<<31-1, 0)
+	default:
 		// This is a 64 bit timespec
 		// os.Chtimes limits time to the following
 		//
@@ -20,9 +22,6 @@ func init() {
 		// and nsec internally in time.Unix();
 		// https://github.com/golang/go/blob/go1.19.2/src/time/time.go#L1364-L1380
 		unixMaxTime = time.Unix(0, 1<<63-1)
-	} else {
-		// This is a 32 bit timespec
-		unixMaxTime = time.Unix(1<<31-1, 0)
 	}
 }
 

--- a/daemon/internal/system/chtimes.go
+++ b/daemon/internal/system/chtimes.go
@@ -1,8 +1,8 @@
 package system
 
 import (
+	"math"
 	"os"
-	"syscall"
 	"time"
 )
 
@@ -10,18 +10,17 @@ import (
 var unixEpochTime, unixMaxTime time.Time
 
 func init() {
-	switch interface{}(syscall.Timespec{}.Nsec).(type) {
-	case int32:
+	if math.MaxInt == math.MaxInt32 {
 		// This is a 32 bit timespec
-		unixMaxTime = time.Unix(1<<31-1, 0)
-	default:
+		unixMaxTime = time.Unix(math.MaxInt32, 0)
+	} else {
 		// This is a 64 bit timespec
 		// os.Chtimes limits time to the following
 		//
 		// Note that this intentionally sets nsec (not sec), which sets both sec
 		// and nsec internally in time.Unix();
 		// https://github.com/golang/go/blob/go1.19.2/src/time/time.go#L1364-L1380
-		unixMaxTime = time.Unix(0, 1<<63-1)
+		unixMaxTime = time.Unix(0, math.MaxInt64)
 	}
 }
 


### PR DESCRIPTION
### pkg/system: move maxTime init() back to Chtimes code

This code was moved to a separate file in https://github.com/moby/moby/commit/fe5b34ba8828dc2f2f7db180a102cee360fec6e0 (https://github.com/moby/moby/pull/33241), but it's unclear why it was moved (as this file is not excluded on Windows).

Moving the code back into the chtimes file, to move it closer to where it's used.

### pkg/system: add note about maxTime

This code caused me some head-scratches, and initially I wondered if this was a bug, but it looks to be intentional to set `nsec`, not `sec`, as `time.Unix()` internally divides `nsec`, and sets `sec` accordingly; https://github.com/golang/go/blob/go1.17.6/src/time/time.go#L1312-L1328

```go
// Unix returns the local Time corresponding to the given Unix time,
// sec seconds and nsec nanoseconds since January 1, 1970 UTC.
// It is valid to pass nsec outside the range [0, 999999999].
// Not all sec values have a corresponding time value. One such
// value is 1<<63-1 (the largest int64 value).
func Unix(sec int64, nsec int64) Time {
    if nsec < 0 || nsec >= 1e9 {
        n := nsec / 1e9
        sec += n
        nsec -= n * 1e9
        if nsec < 0 {
            nsec += 1e9
            sec--
        }
    }
    return unixTime(sec, int32(nsec))
}
```

### pkg/system: don't use "unsafe" to detect maxTime

### pkg/system: use math.MaxIntXX consts to detect 32-bit platform

This makes the code slightly easier to read, and allows the use of the consts for the maximum values (which may be easier to grasp as well).


