### PR TITLE
overlay2: pquota: Just tell me how it is when it fails to configure

### DIFF
--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -199,15 +199,15 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		if d.quotaCtl, err = quota.NewControl(home); err == nil {
 			projectQuotaSupported = true
 		} else {
-			// like let me know what the error is because there are gazillion
-			// reasons why this might not be enabled?
-			logger.Warnf("Unable to enable quota, reason: %s", err.Error())
+
+			if opts.quota.Size > 0 {
+				return nil, fmt.Errorf("Storage option overlay2.size not supported. Filesystem does not support Project Quota: %v", err)
+			}
+			// But what if there was no setting in daemon config but the thing still
+			// returned an error?
+			logger.Warnf("overlay2 unable to enable quota, reason: %s", err.Error())
 		}
-		// and test totally different condition under it's own if because how
-		// can quota size > 0 be an else if of error != nil..
-		if opts.quota.Size > 0 {
-			return nil, fmt.Errorf("Storage option overlay2.size not supported. Filesystem does not support Project Quota: %v", err)
-		}
+		
 	} else if opts.quota.Size > 0 {
 		// if xfs is not the backing fs then error out if the storage-opt overlay2.size is used.
 		return nil, fmt.Errorf("Storage Option overlay2.size only supported for backingFS XFS. Found %v", backingFs)

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -198,7 +198,14 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		// Try to enable project quota support over xfs.
 		if d.quotaCtl, err = quota.NewControl(home); err == nil {
 			projectQuotaSupported = true
-		} else if opts.quota.Size > 0 {
+		} else {
+			// like let me know what the error is because there are gazillion
+			// reasons why this might not be enabled?
+			logger.Warnf("Unable to enable quota, reason: %s", err.Error())
+		}
+		// and test totally different condition under it's own if because how
+		// can quota size > 0 be an else if of error != nil..
+		if opts.quota.Size > 0 {
 			return nil, fmt.Errorf("Storage option overlay2.size not supported. Filesystem does not support Project Quota: %v", err)
 		}
 	} else if opts.quota.Size > 0 {


### PR DESCRIPTION
With how the error is being handled in `Init`, it is perfectly possible that someone sends options with `size` but the driver failed to configure `pquota`.

If I did not configure `overlay2.size` in daemon config, I will never know why `pquota` configuration failed.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

I have added a warning log if quota configuration failed but `overlay2.size` in daemon configuration isn't set.

**- A picture of a cute animal (not mandatory but encouraged)**

