### PR TITLE
Introduce config option for default generic network options of newly created networks

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -27,6 +27,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.StringVar(&conf.ContainerdAddr, "containerd", "", "containerd grpc address")
 	flags.BoolVar(&conf.CriContainerd, "cri-containerd", false, "start containerd with cri")
 
+	flags.Var(opts.NewNamedMapMapOpts("default-network-opts", conf.DefaultNetworkOpts, nil), "default-network-opt", "Default network options")
 	flags.IntVar(&conf.Mtu, "mtu", conf.Mtu, "Set the containers network MTU")
 	flags.IntVar(&conf.NetworkControlPlaneMTU, "network-control-plane-mtu", conf.NetworkControlPlaneMTU, "Network Control plane MTU")
 	flags.IntVar(&conf.NetworkDiagnosticPort, "network-diagnostic-port", 0, "TCP port number of the network diagnostic server")

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -126,6 +126,8 @@ type NetworkConfig struct {
 	DefaultAddressPools opts.PoolsOpt `json:"default-address-pools,omitempty"`
 	// NetworkControlPlaneMTU allows to specify the control plane MTU, this will allow to optimize the network use in some components
 	NetworkControlPlaneMTU int `json:"network-control-plane-mtu,omitempty"`
+	// Default options for newly created networks
+	DefaultNetworkOpts map[string]map[string]string `json:"default-network-opts,omitempty"`
 }
 
 // TLSOptions defines TLS configuration for the daemon server.
@@ -289,6 +291,7 @@ func New() (*Config, error) {
 			Mtu:                    DefaultNetworkMtu,
 			NetworkConfig: NetworkConfig{
 				NetworkControlPlaneMTU: DefaultNetworkMtu,
+				DefaultNetworkOpts:     make(map[string]map[string]string),
 			},
 			ContainerdNamespace:       DefaultContainersNamespace,
 			ContainerdPluginNamespace: DefaultPluginNamespace,

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -146,6 +146,83 @@ func (o *NamedListOpts) Name() string {
 	return o.name
 }
 
+// NamedMapMapOpts is a MapMapOpts with a configuration name.
+// This struct is useful to keep reference to the assigned
+// field name in the internal configuration struct.
+type NamedMapMapOpts struct {
+	name string
+	MapMapOpts
+}
+
+// NewNamedMapMapOpts creates a reference to a new NamedMapOpts struct.
+func NewNamedMapMapOpts(name string, values map[string]map[string]string, validator ValidatorFctType) *NamedMapMapOpts {
+	return &NamedMapMapOpts{
+		name:       name,
+		MapMapOpts: *NewMapMapOpts(values, validator),
+	}
+}
+
+// Name returns the name of the NamedListOpts in the configuration.
+func (o *NamedMapMapOpts) Name() string {
+	return o.name
+}
+
+// MapMapOpts holds a map of maps of values and a validation function.
+type MapMapOpts struct {
+	values    map[string]map[string]string
+	validator ValidatorFctType
+}
+
+// Set validates if needed the input value and add it to the
+// internal map, by splitting on '='.
+func (opts *MapMapOpts) Set(value string) error {
+	if opts.validator != nil {
+		v, err := opts.validator(value)
+		if err != nil {
+			return err
+		}
+		value = v
+	}
+	rk, rv, found := strings.Cut(value, "=")
+	if !found {
+		return fmt.Errorf("invalid value %q for map option, should be root-key=key=value", value)
+	}
+	k, v, found := strings.Cut(rv, "=")
+	if !found {
+		return fmt.Errorf("invalid value %q for map option, should be root-key=key=value", value)
+	}
+	if _, ok := opts.values[rk]; !ok {
+		opts.values[rk] = make(map[string]string)
+	}
+	opts.values[rk][k] = v
+	return nil
+}
+
+// GetAll returns the values of MapOpts as a map.
+func (opts *MapMapOpts) GetAll() map[string]map[string]string {
+	return opts.values
+}
+
+func (opts *MapMapOpts) String() string {
+	return fmt.Sprintf("%v", opts.values)
+}
+
+// Type returns a string name for this Option type
+func (opts *MapMapOpts) Type() string {
+	return "mapmap"
+}
+
+// NewMapMapOpts creates a new MapMapOpts with the specified map of values and a validator.
+func NewMapMapOpts(values map[string]map[string]string, validator ValidatorFctType) *MapMapOpts {
+	if values == nil {
+		values = make(map[string]map[string]string)
+	}
+	return &MapMapOpts{
+		values:    values,
+		validator: validator,
+	}
+}
+
 // MapOpts holds a map of values and a validation function.
 type MapOpts struct {
 	values    map[string]string


### PR DESCRIPTION
**- What I did**
I introduced a new command line parameter `--default-network-opt` to configure defaults for generic options for newly created networks (e.g. MTU).

For example you could configure the MTU for newly created bridge networks by using the following command line:

```shell
dockerd --default-network-opt=bridge=com.docker.network.driver.mtu=1234
```
**Precendence rules:**
* Should there be a configuration option specified as parameter of the network creation then this will always take precedence over the default provided via the cmdline

**- How I did it**
* I introduced a new cmdline param `--default-network-opts`. Its values are stored in a newly created `DefaultNetworkOpts` in the struct `NetworkConfig` found in the file `src/github.com/docker/docker/daemon/config/config.go`
* `createNetwork()` in `src/github.com/docker/docker/daemon/network.go` picks up the values from `NetworkConfig.DefaultNetworkOpts` and adds them to the network options provided when creating a new network based on the type of the created network.
  * Options provided as parameters for the network creation take precedence over the defaults

**- How to verify it**
* Run `dockerd --default-network-opt=bridge=com.docker.network.driver.mtu=1234` (or just `dockerd` without this PR)
* Create a new network via `docker network create mynet`
* Check the MTU of the newly created network with `docker run --rm --net mynet -it ubuntu  cat /sys/class/net/eth0/mtu`
  * Without this PR the MTU of the network should default to 1500
  * With this PR the MTU of the network is set to 1234

**- Description for the changelog**
Introduce the `--default-network-opt` configuration option for newly created networks.

- fixes #34981
- fixes https://github.com/moby/moby/issues/23938