### PR TITLE
daemon/graphdriver/fuse-overlayfs: Init(): fix directory permissions (staticcheck)

### DIFF
--- a/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs.go
+++ b/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs.go
@@ -98,7 +98,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 	if err := idtools.MkdirAllAndChown(home, 0710, dirID); err != nil {
 		return nil, err
 	}
-	if err := idtools.MkdirAllAndChown(path.Join(home, linkDir), 700, currentID); err != nil {
+	if err := idtools.MkdirAllAndChown(path.Join(home, linkDir), 0700, currentID); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
extracting this from https://github.com/moby/moby/pull/43195, as this looked like a genuine bug (in case we want to backport this)


    daemon/graphdriver/fuse-overlayfs/fuseoverlayfs.go:101:63: SA9002: file mode '700' evaluates to 01274; did you mean '0700'? (staticcheck)
        if err := idtools.MkdirAllAndChown(path.Join(home, linkDir), 700, currentID); err != nil {
                                                                     ^


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

