### PR TITLE
client/request.go:157:8: SA1019: err.Temporary is deprecated (staticcheck)

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -154,10 +154,8 @@ func (cli *Client) doRequest(ctx context.Context, req *http.Request) (serverResp
 			if err.Timeout() {
 				return serverResp, ErrorConnectionFailed(cli.host)
 			}
-			if !err.Temporary() {
-				if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "dial unix") {
-					return serverResp, ErrorConnectionFailed(cli.host)
-				}
+			if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "dial unix") {
+				return serverResp, ErrorConnectionFailed(cli.host)
 			}
 		}
 


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/43194 https://github.com/moby/moby/pull/43194#issuecomment-1025757901


It's deprecated in Go 1.18:

    client/request.go:157:8: SA1019: err.Temporary is deprecated: Temporary errors are not well-defined. Most "temporary" errors are timeouts, and the few exceptions are surprising. Do not use this method. (staticcheck)
        if !err.Temporary() {
            ^



