### PR TITLE
Freeze the namesgenerator package against new additions

### DIFF
--- a/pkg/namesgenerator/names-generator.go
+++ b/pkg/namesgenerator/names-generator.go
@@ -1,3 +1,14 @@
+// Package namesgenerator generates random names.
+//
+// This package is officially "frozen" - no new additions will be accepted.
+//
+// For a long time, this package provided a lot of joy within the project, but
+// at some point the conflicts of opinion became greater than the added joy.
+//
+// At some future time, this may be replaced with something that sparks less
+// controversy, but for now it will remain as-is.
+//
+// See also https://github.com/moby/moby/pull/43210#issuecomment-1029934277
 package namesgenerator // import "github.com/docker/docker/pkg/namesgenerator"
 
 import (


### PR DESCRIPTION
See the added comment/documentation within the package for more details.

We discussed this (and the problems it has caused historically) in today's maintainer meeting, and there was some consensus that starting with a freeze on the existing file is a good compromise for now.