### PR TITLE
hack/vendor.sh: run "go mod tidy" before vendoring

### DIFF
--- a/hack/validate/vendor
+++ b/hack/validate/vendor
@@ -3,11 +3,6 @@
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "${SCRIPTDIR}/.validate"
 
-go_mod_tidy(){
-	${SCRIPTDIR}/../go-mod-prepare.sh
-	GO111MODULE=auto go mod tidy -modfile 'vendor.mod' -compat 1.17
-}
-
 validate_vendor_diff(){
 	IFS=$'\n'
 	check_files=( 'vendor.sum' 'vendor.mod' 'vendor/' )
@@ -54,6 +49,5 @@ validate_vendor_used() {
 	done
 }
 
-go_mod_tidy
 validate_vendor_diff
 validate_vendor_used

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -8,9 +8,10 @@ set -e
 set -x
 
 SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-${SCRIPTDIR}/go-mod-prepare.sh
+"${SCRIPTDIR}"/go-mod-prepare.sh
 
 if [ $# -eq 0 ] || [ "$1" != "archive/tar" ]; then
+	GO111MODULE=auto go mod tidy -modfile 'vendor.mod' -compat 1.17
 	GO111MODULE=auto go mod vendor -modfile vendor.mod
 fi
 


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/43083 (https://github.com/moby/moby/pull/43083#issuecomment-1030574640)
- https://github.com/moby/moby/pull/43101 (https://github.com/moby/moby/pull/43101#issuecomment-999773526)
- https://github.com/moby/moby/pull/43075 (https://github.com/moby/moby/pull/43075#discussion_r768578627)

The hack/vendor.sh script is used to (re)vendor dependencies. However, it did
not run `go mod tidy` before doing so, wheras the vendor _validation_ script
did.

This could result in vendor validation failing if go mod tidy resulted in
changes (which could be in `vendor.sum`).

In "usual" situations, this could be easily done by the user (`go mod tidy`
before running `go mod vendor`), but due to our (curent) uses of `vendor.mod`,
and having to first set up a (dummy) `go.mod`, this is more complicated.

Instead, just make the script do this, so that `hack/vendor.sh` will always
produce the expected result.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

