### PR TITLE
fix(check-config.sh): Check for existence of /etc/os-release before sourcing

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -121,6 +121,9 @@ check_device() {
 }
 
 check_distro_userns() {
+	if [ ! -e /etc/os-release ]; then
+		return
+	fi
 	. /etc/os-release 2> /dev/null || /bin/true
 	case "$ID" in
 		centos | rhel)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed a bug in the `check-config.sh` script when the system does not have the file `/etc/os-release`. If this file does not exist, then the script dies when trying to source the file and does not continue with the rest of the checks. This was observed on an OpenWrt system.

**- How I did it**

In the function `check_distro_userns()`, added a check for the existence of the file `/etc/os-release` before sourcing it. 

**- How to verify it**

1. Remove/rename the file `/etc/os-release` to something else.
2. Run the `check-config.sh` script without these changes. The script should die after checking for `CONFIG_USER_NS`.
3. Run the `check-config.sh` script with these changes. The script should complete successfully.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fixed the check-config.sh script when the system does not have the /etc/os-release file.

**- A picture of a cute animal (not mandatory but encouraged)**

![IMG_3624](https://user-images.githubusercontent.com/11547946/153652062-3a3ecb75-badb-434f-bac5-72621f5aa082.jpg)

