### PR TITLE
remove some redundant fmt.Sprintf()'s

### DIFF
--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -74,7 +74,7 @@ func (d *Daemon) inspectFilter(name, filter string) (string, error) {
 }
 
 func (d *Daemon) inspectFieldWithError(name, field string) (string, error) {
-	return d.inspectFilter(name, fmt.Sprintf(".%s", field))
+	return d.inspectFilter(name, "."+field)
 }
 
 // CheckActiveContainerCount returns the number of active containers

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -96,13 +96,13 @@ func inspectFilter(name, filter string) (string, error) {
 
 // Deprecated: use cli.Inspect
 func inspectFieldWithError(name, field string) (string, error) {
-	return inspectFilter(name, fmt.Sprintf(".%s", field))
+	return inspectFilter(name, "."+field)
 }
 
 // Deprecated: use cli.Inspect
 func inspectField(c *testing.T, name, field string) string {
 	c.Helper()
-	out, err := inspectFilter(name, fmt.Sprintf(".%s", field))
+	out, err := inspectFilter(name, "."+field)
 	assert.NilError(c, err)
 	return out
 }
@@ -110,7 +110,7 @@ func inspectField(c *testing.T, name, field string) string {
 // Deprecated: use cli.Inspect
 func inspectFieldJSON(c *testing.T, name, field string) string {
 	c.Helper()
-	out, err := inspectFilter(name, fmt.Sprintf("json .%s", field))
+	out, err := inspectFilter(name, "json ."+field)
 	assert.NilError(c, err)
 	return out
 }

--- a/libnetwork/networkdb/cluster.go
+++ b/libnetwork/networkdb/cluster.go
@@ -397,7 +397,7 @@ func (nDB *NetworkDB) reapTableEntries() {
 	// The lock is taken at the beginning of the cycle and the deletion is inline
 	for _, nid := range nodeNetworks {
 		nDB.Lock()
-		nDB.indexes[byNetwork].WalkPrefix(fmt.Sprintf("/%s", nid), func(path string, v interface{}) bool {
+		nDB.indexes[byNetwork].WalkPrefix("/"+nid, func(path string, v interface{}) bool {
 			// timeCompensation compensate in case the lock took some time to be released
 			timeCompensation := time.Since(cycleStart)
 			entry, ok := v.(*entry)
@@ -630,7 +630,7 @@ func (nDB *NetworkDB) bulkSyncNode(networks []string, node string, unsolicited b
 	}
 
 	for _, nid := range networks {
-		nDB.indexes[byNetwork].WalkPrefix(fmt.Sprintf("/%s", nid), func(path string, v interface{}) bool {
+		nDB.indexes[byNetwork].WalkPrefix("/"+nid, func(path string, v interface{}) bool {
 			entry, ok := v.(*entry)
 			if !ok {
 				return false

--- a/libnetwork/networkdb/networkdb.go
+++ b/libnetwork/networkdb/networkdb.go
@@ -498,7 +498,7 @@ func (nDB *NetworkDB) deleteNodeNetworkEntries(nid, node string) {
 	// Indicates if the delete is triggered for the local node
 	isNodeLocal := node == nDB.config.NodeID
 
-	nDB.indexes[byNetwork].WalkPrefix(fmt.Sprintf("/%s", nid),
+	nDB.indexes[byNetwork].WalkPrefix("/"+nid,
 		func(path string, v interface{}) bool {
 			oldEntry := v.(*entry)
 			params := strings.Split(path[1:], "/")
@@ -579,7 +579,7 @@ func (nDB *NetworkDB) deleteNodeTableEntries(node string) {
 func (nDB *NetworkDB) WalkTable(tname string, fn func(string, string, []byte, bool) bool) error {
 	nDB.RLock()
 	values := make(map[string]interface{})
-	nDB.indexes[byTable].WalkPrefix(fmt.Sprintf("/%s", tname), func(path string, v interface{}) bool {
+	nDB.indexes[byTable].WalkPrefix("/"+tname, func(path string, v interface{}) bool {
 		values[path] = v
 		return false
 	})

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -3,7 +3,6 @@ package daemon // import "github.com/docker/docker/testutil/daemon"
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
@@ -102,7 +101,7 @@ func NewDaemon(workingDir string, ops ...Option) (*Daemon, error) {
 		return nil, errors.Wrapf(err, "failed to create daemon socket root %q", SockRoot)
 	}
 
-	id := fmt.Sprintf("d%s", stringid.TruncateID(stringid.GenerateRandomID()))
+	id := "d" + stringid.TruncateID(stringid.GenerateRandomID())
 	dir := filepath.Join(workingDir, id)
 	daemonFolder, err := filepath.Abs(dir)
 	if err != nil {
@@ -248,7 +247,7 @@ func (d *Daemon) StorageDriver() string {
 
 // Sock returns the socket path of the daemon
 func (d *Daemon) Sock() string {
-	return fmt.Sprintf("unix://" + d.sockPath())
+	return "unix://" + d.sockPath()
 }
 
 func (d *Daemon) sockPath() string {
@@ -347,7 +346,7 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 		"--data-root", d.Root,
 		"--exec-root", d.execRoot,
 		"--pidfile", d.pidFile,
-		fmt.Sprintf("--userland-proxy=%t", d.userlandProxy),
+		"--userland-proxy="+strconv.FormatBool(d.userlandProxy),
 		"--containerd-namespace", d.id,
 		"--containerd-plugins-namespace", d.id+"p",
 	)


### PR DESCRIPTION
Had this stashed in my local git, so thought to push it as a PR; most changes are in test-code, except for the libnetwork/networkdb code.