### PR TITLE
daemon: use RWMutex for stateCounter

### DIFF
--- a/daemon/metrics.go
+++ b/daemon/metrics.go
@@ -65,7 +65,7 @@ func init() {
 }
 
 type stateCounter struct {
-	mu     sync.Mutex
+	mu     sync.RWMutex
 	states map[string]string
 	desc   *prometheus.Desc
 }
@@ -78,8 +78,8 @@ func newStateCounter(desc *prometheus.Desc) *stateCounter {
 }
 
 func (ctr *stateCounter) get() (running int, paused int, stopped int) {
-	ctr.mu.Lock()
-	defer ctr.mu.Unlock()
+	ctr.mu.RLock()
+	defer ctr.mu.RUnlock()
 
 	states := map[string]int{
 		"running": 0,


### PR DESCRIPTION
Use an RWMutex to allow concurrent reads of these counters

Originally added in https://github.com/moby/moby/pull/29554 to address https://github.com/moby/moby/pull/28912 / https://github.com/moby/moby/pull/26668 / https://github.com/moby/moby/issues/26666

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

