### PR TITLE
daemon: refactor translateContainerdStartErr() and remove unused argument

### DIFF
--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -176,6 +176,7 @@ func translateContainerdStartErr(setExitCode func(exitStatus), err error) error 
 	}
 
 	// TODO: it would be nice to get some better errors from containerd so we can return better errors here
+	setExitCode(exitUnknown)
 	return errdefs.Unknown(errors.New(errDesc))
 }
 

--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -132,7 +132,7 @@ func (e startInvalidConfigError) Error() string {
 
 func (e startInvalidConfigError) InvalidParameter() {} // Is this right???
 
-// exitStatus is the exit-code as set by translateContainerdStartErr
+// exitStatus is the exit-code as set by setExitCodeFromError
 type exitStatus = int
 
 const (
@@ -141,11 +141,11 @@ const (
 	exitUnknown     exitStatus = 128 // unknown error
 )
 
-// translateContainerdStartErr converts the error returned by containerd
+// setExitCodeFromError converts the error returned by containerd
 // when starting a container, and applies the corresponding exitStatus to the
 // container. It returns an errdefs error (either errdefs.ErrInvalidParameter
 // or errdefs.ErrUnknown).
-func translateContainerdStartErr(setExitCode func(exitStatus), err error) error {
+func setExitCodeFromError(setExitCode func(exitStatus), err error) error {
 	if err == nil {
 		return nil
 	}

--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -132,7 +132,7 @@ func (e startInvalidConfigError) Error() string {
 
 func (e startInvalidConfigError) InvalidParameter() {} // Is this right???
 
-func translateContainerdStartErr(cmd string, setExitCode func(int), err error) error {
+func translateContainerdStartErr(setExitCode func(int), err error) error {
 	errDesc := status.Convert(err).Message()
 	contains := func(s1, s2 string) bool {
 		return strings.Contains(strings.ToLower(s1), s2)

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -288,7 +288,7 @@ func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, optio
 	close(ec.Started)
 	if err != nil {
 		defer ec.Unlock()
-		return translateContainerdStartErr(ec.SetExitCode, err)
+		return setExitCodeFromError(ec.SetExitCode, err)
 	}
 	ec.Unlock()
 

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -288,7 +288,7 @@ func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, optio
 	close(ec.Started)
 	if err != nil {
 		defer ec.Unlock()
-		return translateContainerdStartErr(ec.Entrypoint, ec.SetExitCode, err)
+		return translateContainerdStartErr(ec.SetExitCode, err)
 	}
 	ec.Unlock()
 

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -124,7 +124,7 @@ func (daemon *Daemon) containerStart(ctx context.Context, container *container.C
 			container.SetError(retErr)
 			// if no one else has set it, make sure we don't leave it at zero
 			if container.ExitCode() == 0 {
-				container.SetExitCode(128)
+				container.SetExitCode(exitUnknown)
 			}
 			if err := container.CheckpointTo(daemon.containersReplica); err != nil {
 				logrus.Errorf("%s: failed saving state on start failure: %v", container.ID, err)

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -179,7 +179,7 @@ func (daemon *Daemon) containerStart(ctx context.Context, container *container.C
 
 	ctr, err := libcontainerd.ReplaceContainer(ctx, daemon.containerd, container.ID, spec, shim, createOptions)
 	if err != nil {
-		return translateContainerdStartErr(container.Path, container.SetExitCode, err)
+		return translateContainerdStartErr(container.SetExitCode, err)
 	}
 
 	// TODO(mlaventure): we need to specify checkpoint options here
@@ -191,7 +191,7 @@ func (daemon *Daemon) containerStart(ctx context.Context, container *container.C
 			logrus.WithError(err).WithField("container", container.ID).
 				Error("failed to delete failed start container")
 		}
-		return translateContainerdStartErr(container.Path, container.SetExitCode, err)
+		return translateContainerdStartErr(container.SetExitCode, err)
 	}
 
 	container.HasBeenManuallyRestarted = false

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -179,7 +179,7 @@ func (daemon *Daemon) containerStart(ctx context.Context, container *container.C
 
 	ctr, err := libcontainerd.ReplaceContainer(ctx, daemon.containerd, container.ID, spec, shim, createOptions)
 	if err != nil {
-		return translateContainerdStartErr(container.SetExitCode, err)
+		return setExitCodeFromError(container.SetExitCode, err)
 	}
 
 	// TODO(mlaventure): we need to specify checkpoint options here
@@ -191,7 +191,7 @@ func (daemon *Daemon) containerStart(ctx context.Context, container *container.C
 			logrus.WithError(err).WithField("container", container.ID).
 				Error("failed to delete failed start container")
 		}
-		return translateContainerdStartErr(container.SetExitCode, err)
+		return setExitCodeFromError(container.SetExitCode, err)
 	}
 
 	container.HasBeenManuallyRestarted = false

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -99,7 +99,7 @@ func (daemon *Daemon) ContainerStart(ctx context.Context, name string, hostConfi
 // container needs, such as storage and networking, as well as links
 // between containers. The container is left waiting for a signal to
 // begin running.
-func (daemon *Daemon) containerStart(ctx context.Context, container *container.Container, checkpoint string, checkpointDir string, resetRestartManager bool) (err error) {
+func (daemon *Daemon) containerStart(ctx context.Context, container *container.Container, checkpoint string, checkpointDir string, resetRestartManager bool) (retErr error) {
 	start := time.Now()
 	container.Lock()
 	defer container.Unlock()
@@ -120,8 +120,8 @@ func (daemon *Daemon) containerStart(ctx context.Context, container *container.C
 	// if we encounter an error during start we need to ensure that any other
 	// setup has been cleaned up properly
 	defer func() {
-		if err != nil {
-			container.SetError(err)
+		if retErr != nil {
+			container.SetError(retErr)
 			// if no one else has set it, make sure we don't leave it at zero
 			if container.ExitCode() == 0 {
 				container.SetExitCode(128)

--- a/daemon/start_unix.go
+++ b/daemon/start_unix.go
@@ -17,7 +17,7 @@ func (daemon *Daemon) getLibcontainerdCreateOptions(container *container.Contain
 
 	rt, err := daemon.getRuntime(container.HostConfig.Runtime)
 	if err != nil {
-		return "", nil, translateContainerdStartErr(container.Path, container.SetExitCode, err)
+		return "", nil, translateContainerdStartErr(container.SetExitCode, err)
 	}
 
 	return rt.Shim.Binary, rt.Shim.Opts, nil

--- a/daemon/start_unix.go
+++ b/daemon/start_unix.go
@@ -17,7 +17,7 @@ func (daemon *Daemon) getLibcontainerdCreateOptions(container *container.Contain
 
 	rt, err := daemon.getRuntime(container.HostConfig.Runtime)
 	if err != nil {
-		return "", nil, translateContainerdStartErr(container.SetExitCode, err)
+		return "", nil, setExitCodeFromError(container.SetExitCode, err)
 	}
 
 	return rt.Shim.Binary, rt.Shim.Opts, nil


### PR DESCRIPTION
### daemon: translateContainerdStartErr() remove unused cmd argument

This argument was no longer used since commit https://github.com/moby/moby/commit/225e046d9d1bdf0f06f4c97bef239b5909463885 (part of https://github.com/moby/moby/pull/42270)

for further details; look at individual commit messages