### PR TITLE
Add mayhem for API as a github workflow

### DIFF
--- a/.github/workflows/mapi.yml
+++ b/.github/workflows/mapi.yml
@@ -1,0 +1,40 @@
+name: 'Mayhem for API'
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+    steps:
+    - uses: actions/checkout@v2
+    - run: make build binary
+    - run: make run DOCKER_PORT=3333 &
+    - run: while [ -z $(docker ps -q --filter "expose=3333") ]; do echo "waiting for container"; sleep 1; done
+    - run: echo "API_URL=http://$(docker port $(docker ps -q -f expose=3333) 3333 | head -1)/" >> $GITHUB_ENV
+    - run: while ! curl -s ${{ env.API_URL }}; do echo "waiting for api server"; sleep 1; done
+
+    # Run Mayhem for API
+    - name: Run Mayhem for API
+      uses: ForAllSecure/mapi-action@v1
+      continue-on-error: true
+      with:
+        mapi-token: ${{ secrets.MAPI_TOKEN }}
+        api-url: ${{ env.API_URL }}
+        api-spec: api/swagger.yaml
+        target: makesoftwaresafe/moby
+        duration: 1min
+        sarif-report: mapi.sarif
+        html-report: mapi.html
+
+    # Archive HTML report
+    - name: Archive Mayhem for API report
+      uses: actions/upload-artifact@v2
+      with:
+        name: mapi-report
+        path: mapi.html
+
+    # Upload SARIF file (only available on public repos or github enterprise)
+    - name: Upload SARIF file
+      uses: github/codeql-action/upload-sarif@v1
+      with:
+        sarif_file: mapi.sarif

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1028,7 +1028,7 @@ definitions:
           SecurityOpt:
             type: "array"
             description: "A list of string values to customize labels for MLS
-            systems, such as SELinux."
+              systems, such as SELinux."
             items:
               type: "string"
           StorageOpt:


### PR DESCRIPTION
**- What I did**

Added a github action to run [Mayhem for API](https://mayhem4api.forallsecure.com/) (which is a free automated testing tool for http APIs) against dockerd: given the openapi spec and api server, it generates and runs random test payloads, looking for exceptional behavior.

Disclosure: working on this tool is my day job!

**- How I did it**

The action builds and runs dockerd listening on a tcp port. There's a little bit of jiggery-pokery waiting for the server to start (without which the action is flaky, which nobody wants.) Then it runs mapi for 60 seconds; the results are reported as SARIF ("Code scanning results").

This is probably the easiest/most straightforward way to integrate. If you like mapi but aren't thrilled about the specifics of this workflow, there are lots of options, and I'd be more than happy to help get something working!

**- How to verify it**

Merging new workflows across forks is a bit weird. You can see some results in my fork, without doing any other work:

the action: https://github.com/makesoftwaresafe/moby/actions/runs/1850050316
the scan results: https://github.com/makesoftwaresafe/moby/pull/1/checks?check_run_id=5209023377
the details in the mayhem for API ui: https://mayhem4api.forallsecure.com/job/10840

To make it work in the upstream repo, there's a bit of out-of-PR effort to integrate:

- sign up for a free mapi account, creating a moby organization
- create a mapi service account within the moby organization
- modify the mapi.yaml action in this PR to point at your mapi organization
- add the service account's API token to github as a repository secret named MAPI_TOKEN

**- Description for the changelog**

"Add mayhem for API as a github workflow"

**- A picture of a cute animal (not mandatory but encouraged)**

![Screen Shot 2022-02-15 at 4 08 53 PM](https://user-images.githubusercontent.com/146075/154171174-6c7a145e-7cca-4132-b0f3-a34db288833e.png)