### PR TITLE
api: add DOCKER_DEBUG_TRACE to return stack-traces in API error responses

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1989,6 +1989,14 @@ definitions:
         description: "The error message."
         type: "string"
         x-nullable: false
+      details:
+        description: |
+          Additional details about the error (for debugging purposes).
+
+          This field is only propagated if the daemon is started with
+          the `DOCKER_DEBUG_TRACE` variable set, and omitted otherwise.
+        type: "string"
+        x-nullable: true
     example:
       message: "Something went wrong."
 

--- a/api/types/error_response.go
+++ b/api/types/error_response.go
@@ -7,6 +7,13 @@ package types
 // swagger:model ErrorResponse
 type ErrorResponse struct {
 
+	// Additional details about the error (for debugging purposes).
+	//
+	// This field is only propagated if the daemon is started with
+	// the `DOCKER_DEBUG_TRACE` variable set, and omitted otherwise.
+	//
+	Details *string `json:"details,omitempty"`
+
 	// The error message.
 	// Required: true
 	Message string `json:"message"`

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -40,6 +40,10 @@ keywords: "API, Docker, rcli, REST, documentation"
   was used and the architecture was ignored. If no `platform` option is set, the
   host's operating system and architecture as used as default. This change is not
   versioned, and affects all API versions if the daemon has this patch.
+* The API `ErrorResponse` now has a `details` field. This field is omitted by
+  default but can contain debugging information if the `DOCKER_DEBUG_TRACE`
+  environment variable is set when the daemon is started. This option should only
+  be used for debugging purposes and not recommended for production environments. 
 
 ## v1.41 API changes
 


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/43249#issuecomment-1042300580

This introduces a DOCKER_DEBUG_TRACE which, when set, will propagate a new `details` field in error-responses, containing the error's stack-trace (if any).

With this patch applied, the daemon can be started with `DOCKER_DEBUG_TRACE=1 dockerd` to propagate `.details` field if the error contains a stacktrace:

```bash
docker container create --name foo busybox

docker kill foo
Error response from daemon: Cannot kill container: foo: Container 3045f49c661c85c4289e92cc471a357dc64e2cb1603269e8711dec0992fe9daa is not running

curl -s -X POST --unix-socket /var/run/docker.sock http://localhost/v1.41/containers/foo/kill | jq -r .details
Container 3045f49c661c85c4289e92cc471a357dc64e2cb1603269e8711dec0992fe9daa is not running
Cannot kill container: foo
github.com/docker/docker/api/server/router/container.(*containerRouter).postContainersKill
	/go/src/github.com/docker/docker/api/server/router/container/container_routes.go:267
github.com/docker/docker/api/server/middleware.ExperimentalMiddleware.WrapHandler.func1
	/go/src/github.com/docker/docker/api/server/middleware/experimental.go:26
github.com/docker/docker/api/server/middleware.VersionMiddleware.WrapHandler.func1
	/go/src/github.com/docker/docker/api/server/middleware/version.go:62
github.com/docker/docker/pkg/authorization.(*Middleware).WrapHandler.func1
	/go/src/github.com/docker/docker/pkg/authorization/middleware.go:59
github.com/docker/docker/api/server/middleware.DebugRequestMiddleware.func1
	/go/src/github.com/docker/docker/api/server/middleware/debug.go:53
github.com/docker/docker/api/server.(*Server).makeHTTPHandler.func1
	/go/src/github.com/docker/docker/api/server/server.go:141
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2047
github.com/docker/docker/vendor/github.com/gorilla/mux.(*Router).ServeHTTP
	/go/src/github.com/docker/docker/vendor/github.com/gorilla/mux/mux.go:210
net/http.serverHandler.ServeHTTP
	/usr/local/go/src/net/http/server.go:2879
net/http.(*conn).serve
	/usr/local/go/src/net/http/server.go:1930
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1581
```

It's worth noting that many errors we currently generate do not (yet) contain a
stack-trace, but we could consider updating the `errdefs` helpers to add these.
(which could be optional as well, e.g., gated by the same env-var).

For example, the `errdefs.NotExist()` does not include a stack-trace (unless the
wrapped error is created with one);

```bash
curl -s --unix-socket /var/run/docker.sock "http://localhost/v1.41/containers/nosuch/json" | jq -r .details
null
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

