### PR TITLE
daemon: remove kernel version check and DOCKER_NOWARN_KERNEL_VERSION

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -302,25 +302,6 @@ func adjustParallelLimit(n int, limit int) int {
 	return softRlimit / overhead
 }
 
-func checkKernel() error {
-	// Check for unsupported kernel versions
-	// FIXME: it would be cleaner to not test for specific versions, but rather
-	// test for specific functionalities.
-	// Unfortunately we can't test for the feature "does not cause a kernel panic"
-	// without actually causing a kernel panic, so we need this workaround until
-	// the circumstances of pre-3.10 crashes are clearer.
-	// For details see https://github.com/docker/docker/issues/407
-	// Docker 1.11 and above doesn't actually run on kernels older than 3.4,
-	// due to containerd-shim usage of PR_SET_CHILD_SUBREAPER (introduced in 3.4).
-	if !kernel.CheckKernelVersion(3, 10, 0) {
-		v, _ := kernel.GetKernelVersion()
-		if os.Getenv("DOCKER_NOWARN_KERNEL_VERSION") == "" {
-			logrus.Fatalf("Your Linux kernel version %s is not supported for running docker. Please upgrade your kernel to 3.10.0 or newer.", v.String())
-		}
-	}
-	return nil
-}
-
 // adaptContainerSettings is called during container creation to modify any
 // settings necessary in the HostConfig structure.
 func (daemon *Daemon) adaptContainerSettings(hostConfig *containertypes.HostConfig, adjustCPUShares bool) error {
@@ -790,7 +771,7 @@ func verifyDaemonSettings(conf *config.Config) error {
 
 // checkSystem validates platform-specific requirements
 func checkSystem() error {
-	return checkKernel()
+	return nil
 }
 
 // configureMaxThreads sets the Go runtime max threads threshold

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -70,10 +70,6 @@ func setupInitLayer(idMapping *idtools.IdentityMapping) func(containerfs.Contain
 	return nil
 }
 
-func checkKernel() error {
-	return nil
-}
-
 func (daemon *Daemon) getCgroupDriver() string {
 	return ""
 }

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -59,10 +59,6 @@ func getPluginExecRoot(root string) string {
 }
 
 func (daemon *Daemon) parseSecurityOpt(container *container.Container, hostConfig *containertypes.HostConfig) error {
-	return parseSecurityOpt(container, hostConfig)
-}
-
-func parseSecurityOpt(container *container.Container, config *containertypes.HostConfig) error {
 	return nil
 }
 
@@ -70,17 +66,9 @@ func setupInitLayer(idMapping *idtools.IdentityMapping) func(containerfs.Contain
 	return nil
 }
 
-func (daemon *Daemon) getCgroupDriver() string {
-	return ""
-}
-
 // adaptContainerSettings is called during container creation to modify any
 // settings necessary in the HostConfig structure.
 func (daemon *Daemon) adaptContainerSettings(hostConfig *containertypes.HostConfig, adjustCPUShares bool) error {
-	if hostConfig == nil {
-		return nil
-	}
-
 	return nil
 }
 
@@ -639,12 +627,7 @@ func (daemon *Daemon) loadRuntimes() error {
 	return nil
 }
 
-func (daemon *Daemon) initRuntimes(_ map[string]types.Runtime) error {
-	return nil
-}
-
-func setupResolvConf(config *config.Config) {
-}
+func setupResolvConf(config *config.Config) {}
 
 // RawSysInfo returns *sysinfo.SysInfo .
 func (daemon *Daemon) RawSysInfo() *sysinfo.SysInfo {


### PR DESCRIPTION
All regular, non-EOL Linux distros now come with more recent kernels
out of the box. There may still be users trying to run on kernel 3.10
or older (some embedded systems, e.g.), but those should be a rare
exception, which we don't have to take into account.

This patch removes the kernel version check on Linux, and the corresponding
DOCKER_NOWARN_KERNEL_VERSION environment that was there to skip this
check.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

