### PR TITLE
Windows: require Windows Server RS5 / ltsc2019 (build 17763) as minimum

### DIFF
--- a/cmd/dockerd/service_windows.go
+++ b/cmd/dockerd/service_windows.go
@@ -12,7 +12,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"golang.org/x/sys/windows"
@@ -167,19 +166,11 @@ func registerService() error {
 	}
 	defer m.Disconnect()
 
-	depends := []string{}
-
-	// This dependency is required on build 14393 (RS1)
-	// it is added to the platform in newer builds
-	if osversion.Build() == osversion.RS1 {
-		depends = append(depends, "ConDrv")
-	}
-
 	c := mgr.Config{
 		ServiceType:  windows.SERVICE_WIN32_OWN_PROCESS,
 		StartType:    mgr.StartAutomatic,
 		ErrorControl: mgr.ErrorNormal,
-		Dependencies: depends,
+		Dependencies: []string{},
 		DisplayName:  "Docker Engine",
 	}
 

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -550,13 +550,13 @@ func (daemon *Daemon) stats(c *container.Container) (*types.StatsJSON, error) {
 // setDefaultIsolation determine the default isolation mode for the
 // daemon to run in. This is only applicable on Windows
 func (daemon *Daemon) setDefaultIsolation() error {
-	daemon.defaultIsolation = containertypes.Isolation("process")
-
 	// On client SKUs, default to Hyper-V. @engine maintainers. This
 	// should not be removed. Ping Microsoft folks is there are PRs to
 	// to change this.
 	if system.IsWindowsClient() {
-		daemon.defaultIsolation = containertypes.Isolation("hyperv")
+		daemon.defaultIsolation = containertypes.IsolationHyperV
+	} else {
+		daemon.defaultIsolation = containertypes.IsolationProcess
 	}
 	for _, option := range daemon.configStore.ExecOptions {
 		key, val, err := parsers.ParseKeyValueOpt(option)
@@ -571,10 +571,10 @@ func (daemon *Daemon) setDefaultIsolation() error {
 				return fmt.Errorf("Invalid exec-opt value for 'isolation':'%s'", val)
 			}
 			if containertypes.Isolation(val).IsHyperV() {
-				daemon.defaultIsolation = containertypes.Isolation("hyperv")
+				daemon.defaultIsolation = containertypes.IsolationHyperV
 			}
 			if containertypes.Isolation(val).IsProcess() {
-				daemon.defaultIsolation = containertypes.Isolation("process")
+				daemon.defaultIsolation = containertypes.IsolationProcess
 			}
 		default:
 			return fmt.Errorf("Unrecognised exec-opt '%s'\n", key)

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -253,14 +253,11 @@ func operatingSystem() (operatingSystem string) {
 	} else {
 		operatingSystem = s
 	}
-	// Don't do containerized check on Windows
-	if runtime.GOOS != "windows" {
-		if inContainer, err := operatingsystem.IsContainerized(); err != nil {
-			logrus.Errorf("Could not determine if daemon is containerized: %v", err)
-			operatingSystem += " (error determining if containerized)"
-		} else if inContainer {
-			operatingSystem += " (containerized)"
-		}
+	if inContainer, err := operatingsystem.IsContainerized(); err != nil {
+		logrus.Errorf("Could not determine if daemon is containerized: %v", err)
+		operatingSystem += " (error determining if containerized)"
+	} else if inContainer {
+		operatingSystem += " (containerized)"
 	}
 
 	return operatingSystem

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Microsoft/hcsshim/osversion"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
@@ -259,9 +258,6 @@ func (daemon *Daemon) createSpecWindowsFields(c *container.Container, s *specs.S
 	if len(c.HostConfig.Devices) > 0 {
 		if isHyperV {
 			return errors.New("device assignment is not supported for HyperV containers")
-		}
-		if osversion.Build() < osversion.RS5 {
-			return errors.New("device assignment requires Windows builds RS5 (17763+) or later")
 		}
 		for _, deviceMapping := range c.HostConfig.Devices {
 			srcParts := strings.SplitN(deviceMapping.PathOnHost, "/", 2)

--- a/integration-cli/docker_api_containers_windows_test.go
+++ b/integration-cli/docker_api_containers_windows_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	winio "github.com/Microsoft/go-winio"
-	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
@@ -22,8 +21,6 @@ import (
 )
 
 func (s *DockerSuite) TestContainersAPICreateMountsBindNamedPipe(c *testing.T) {
-	testRequires(c, testEnv.IsLocalDaemon, DaemonIsWindowsAtLeastBuild(osversion.RS3)) // Named pipe support was added in RS3
-
 	// Create a host pipe to map into the container
 	hostPipeName := fmt.Sprintf(`\\.\pipe\docker-cli-test-pipe-%x`, rand.Uint64())
 	pc := &winio.PipeConfig{

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -4,18 +4,14 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"runtime"
-	"strconv"
 	"strings"
 	"testing"
 
-	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
-	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
 )
@@ -59,17 +55,6 @@ func (s *DockerSuite) TestAPIImagesFilter(c *testing.T) {
 }
 
 func (s *DockerSuite) TestAPIImagesSaveAndLoad(c *testing.T) {
-	if runtime.GOOS == "windows" {
-		// Note we parse kernel.GetKernelVersion rather than osversion.Build()
-		// as test binaries aren't manifested, so would otherwise report build 9200.
-		v, err := kernel.GetKernelVersion()
-		assert.NilError(c, err)
-		buildNumber, _ := strconv.Atoi(strings.Split(strings.SplitN(v.String(), " ", 3)[2][1:], ".")[0])
-		if buildNumber <= osversion.RS3 {
-			c.Skip("Temporarily disabled on RS3 and older because they are too slow. See #39909")
-		}
-	}
-
 	testRequires(c, Network)
 	buildImageSuccessfully(c, "saveandload", build.WithDockerfile("FROM busybox\nENV FOO bar"))
 	id := getIDByName(c, "saveandload")
@@ -141,17 +126,6 @@ func (s *DockerSuite) TestAPIImagesHistory(c *testing.T) {
 }
 
 func (s *DockerSuite) TestAPIImagesImportBadSrc(c *testing.T) {
-	if runtime.GOOS == "windows" {
-		// Note we parse kernel.GetKernelVersion rather than osversion.Build()
-		// as test binaries aren't manifested, so would otherwise report build 9200.
-		v, err := kernel.GetKernelVersion()
-		assert.NilError(c, err)
-		buildNumber, _ := strconv.Atoi(strings.Split(strings.SplitN(v.String(), " ", 3)[2][1:], ".")[0])
-		if buildNumber == osversion.RS3 {
-			c.Skip("Temporarily disabled on RS3 builds")
-		}
-	}
-
 	testRequires(c, Network, testEnv.IsLocalDaemon)
 
 	server := httptest.NewServer(http.NewServeMux())

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -303,7 +303,7 @@ func (s *DockerSuite) TestCreateWithWorkdir(c *testing.T) {
 	// Windows does not create the workdir until the container is started
 	if testEnv.OSType == "windows" {
 		dockerCmd(c, "start", name)
-		if IsolationIsHyperv() {
+		if testEnv.DaemonInfo.Isolation.IsHyperV() {
 			// Hyper-V isolated containers do not allow file-operations on a
 			// running container. This test currently uses `docker cp` to verify
 			// that the WORKDIR was automatically created, which cannot be done

--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -171,7 +171,7 @@ func (s *DockerSuite) TestRestartContainerSuccess(c *testing.T) {
 	// such that it assumes there is a host process to kill. In Hyper-V
 	// containers, the process is inside the utility VM, not on the host.
 	if DaemonIsWindows() {
-		testRequires(c, IsolationIsProcess)
+		testRequires(c, testEnv.DaemonInfo.Isolation.IsProcess)
 	}
 
 	out := runSleepingContainer(c, "-d", "--restart=always")
@@ -247,7 +247,7 @@ func (s *DockerSuite) TestRestartPolicyAfterRestart(c *testing.T) {
 	// such that it assumes there is a host process to kill. In Hyper-V
 	// containers, the process is inside the utility VM, not on the host.
 	if DaemonIsWindows() {
-		testRequires(c, IsolationIsProcess)
+		testRequires(c, testEnv.DaemonInfo.Isolation.IsProcess)
 	}
 
 	out := runSleepingContainer(c, "-d", "--restart=always")

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4099,7 +4099,7 @@ func (s *DockerSuite) TestRunWindowsWithCPUPercent(c *testing.T) {
 }
 
 func (s *DockerSuite) TestRunProcessIsolationWithCPUCountCPUSharesAndCPUPercent(c *testing.T) {
-	testRequires(c, IsolationIsProcess)
+	testRequires(c, DaemonIsWindows, testEnv.DaemonInfo.Isolation.IsProcess)
 
 	out, _ := dockerCmd(c, "run", "--cpu-count=1", "--cpu-shares=1000", "--cpu-percent=80", "--name", "test", "busybox", "echo", "testing")
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), "WARNING: Conflicting options: CPU count takes priority over CPU shares on Windows Server Containers. CPU shares discarded"))
@@ -4116,7 +4116,7 @@ func (s *DockerSuite) TestRunProcessIsolationWithCPUCountCPUSharesAndCPUPercent(
 }
 
 func (s *DockerSuite) TestRunHypervIsolationWithCPUCountCPUSharesAndCPUPercent(c *testing.T) {
-	testRequires(c, IsolationIsHyperv)
+	testRequires(c, DaemonIsWindows, testEnv.DaemonInfo.Isolation.IsHyperV)
 
 	out, _ := dockerCmd(c, "run", "--cpu-count=1", "--cpu-shares=1000", "--cpu-percent=80", "--name", "test", "busybox", "echo", "testing")
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), "testing"))

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
@@ -1875,11 +1874,6 @@ func (s *DockerSuite) TestRunBindMounts(c *testing.T) {
 	testRequires(c, testEnv.IsLocalDaemon)
 	if testEnv.OSType == "linux" {
 		testRequires(c, DaemonIsLinux, NotUserNamespace)
-	}
-
-	if testEnv.OSType == "windows" {
-		// Disabled prior to RS5 due to how volumes are mapped
-		testRequires(c, DaemonIsWindowsAtLeastBuild(osversion.RS5))
 	}
 
 	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
@@ -4413,7 +4407,7 @@ func (s *DockerSuite) TestRunAddDeviceCgroupRule(c *testing.T) {
 
 // Verifies that running as local system is operating correctly on Windows
 func (s *DockerSuite) TestWindowsRunAsSystem(c *testing.T) {
-	testRequires(c, DaemonIsWindowsAtLeastBuild(osversion.RS3))
+	testRequires(c, DaemonIsWindows)
 	out, _ := dockerCmd(c, "run", "--net=none", `--user=nt authority\system`, "--hostname=XYZZY", minimalBaseImage(), "cmd", "/c", `@echo %USERNAME%`)
 	assert.Equal(c, strings.TrimSpace(out), "XYZZY$")
 }

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -2,15 +2,11 @@ package main
 
 import (
 	"fmt"
-	"runtime"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/docker/docker/integration-cli/cli"
-	"github.com/docker/docker/pkg/parsers/kernel"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
 )
@@ -190,18 +186,6 @@ func (s *DockerSuite) TestStartAttachWithRename(c *testing.T) {
 }
 
 func (s *DockerSuite) TestStartReturnCorrectExitCode(c *testing.T) {
-	// Note we parse kernel.GetKernelVersion rather than system.GetOSVersion
-	// as test binaries aren't manifested, so would otherwise report the wrong
-	// build number.
-	if runtime.GOOS == "windows" {
-		v, err := kernel.GetKernelVersion()
-		assert.NilError(c, err)
-		build, _ := strconv.Atoi(strings.Split(strings.SplitN(v.String(), " ", 3)[2][1:], ".")[0])
-		if build < osversion.RS3 {
-			c.Skip("FLAKY on Windows RS1, see #38521")
-		}
-	}
-
 	dockerCmd(c, "create", "--restart=on-failure:2", "--name", "withRestart", "busybox", "sh", "-c", "exit 11")
 	dockerCmd(c, "create", "--rm", "--name", "withRm", "busybox", "sh", "-c", "exit 12")
 

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -25,17 +24,6 @@ func ArchitectureIsNot(arch string) bool {
 
 func DaemonIsWindows() bool {
 	return testEnv.OSType == "windows"
-}
-
-func DaemonIsWindowsAtLeastBuild(buildNumber int) func() bool {
-	return func() bool {
-		if testEnv.OSType != "windows" {
-			return false
-		}
-		version := testEnv.DaemonInfo.KernelVersion
-		numVersion, _ := strconv.Atoi(strings.Split(version, " ")[1])
-		return numVersion >= buildNumber
-	}
 }
 
 func DaemonIsLinux() bool {

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -142,21 +142,9 @@ func UserNamespaceInKernel() bool {
 
 func IsPausable() bool {
 	if testEnv.OSType == "windows" {
-		return testEnv.DaemonInfo.Isolation == "hyperv"
+		return testEnv.DaemonInfo.Isolation.IsHyperV()
 	}
 	return true
-}
-
-func IsolationIs(expectedIsolation string) bool {
-	return testEnv.OSType == "windows" && string(testEnv.DaemonInfo.Isolation) == expectedIsolation
-}
-
-func IsolationIsHyperv() bool {
-	return IsolationIs("hyperv")
-}
-
-func IsolationIsProcess() bool {
-	return IsolationIs("process")
 }
 
 // RegistryHosting returns whether the host can host a registry (v2) or not

--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim"
-	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	containerderrdefs "github.com/containerd/containerd/errdefs"
@@ -305,18 +304,12 @@ func (c *client) createWindows(id string, spec *specs.Spec, runtimeOptions inter
 		}
 	}
 	configuration.MappedDirectories = mds
-	if len(mps) > 0 && osversion.Build() < osversion.RS3 {
-		return errors.New("named pipe mounts are not supported on this version of Windows")
-	}
 	configuration.MappedPipes = mps
 
 	if len(spec.Windows.Devices) > 0 {
 		// Add any device assignments
 		if configuration.HvPartition {
 			return errors.New("device assignment is not supported for HyperV containers")
-		}
-		if osversion.Build() < osversion.RS5 {
-			return errors.New("device assignment requires Windows builds RS5 (17763+) or later")
 		}
 		for _, d := range spec.Windows.Devices {
 			configuration.AssignedDevices = append(configuration.AssignedDevices, hcsshim.AssignedDevice{InterfaceClassGUID: d.ID})

--- a/libnetwork/drivers/windows/windows.go
+++ b/libnetwork/drivers/windows/windows.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 
 	"github.com/Microsoft/hcsshim"
-	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/discoverapi"
 	"github.com/docker/docker/libnetwork/driverapi"
@@ -218,9 +217,6 @@ func (d *driver) parseNetworkOptions(id string, genericOptions map[string]string
 			}
 			config.VSID = uint(vsid)
 		case EnableOutboundNat:
-			if osversion.Build() <= 16236 {
-				return nil, fmt.Errorf("Invalid network option. OutboundNat is not supported on this OS version")
-			}
 			b, err := strconv.ParseBool(value)
 			if err != nil {
 				return nil, err

--- a/libnetwork/service_windows.go
+++ b/libnetwork/service_windows.go
@@ -4,7 +4,6 @@ import (
 	"net"
 
 	"github.com/Microsoft/hcsshim"
-	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/sirupsen/logrus"
 )
 
@@ -23,98 +22,96 @@ func (n *network) addLBBackend(ip net.IP, lb *loadBalancer) {
 	vip := lb.vip
 	ingressPorts := lb.service.ingressPorts
 
-	if osversion.Build() > 16236 {
-		lb.Lock()
-		defer lb.Unlock()
-		//find the load balancer IP for the network.
-		var sourceVIP string
-		for _, e := range n.Endpoints() {
-			epInfo := e.Info()
-			if epInfo == nil {
-				continue
-			}
-			if epInfo.LoadBalancer() {
-				sourceVIP = epInfo.Iface().Address().IP.String()
-				break
-			}
+	lb.Lock()
+	defer lb.Unlock()
+	//find the load balancer IP for the network.
+	var sourceVIP string
+	for _, e := range n.Endpoints() {
+		epInfo := e.Info()
+		if epInfo == nil {
+			continue
 		}
-
-		if sourceVIP == "" {
-			logrus.Errorf("Failed to find load balancer IP for network %s", n.Name())
-			return
+		if epInfo.LoadBalancer() {
+			sourceVIP = epInfo.Iface().Address().IP.String()
+			break
 		}
+	}
 
-		var endpoints []hcsshim.HNSEndpoint
+	if sourceVIP == "" {
+		logrus.Errorf("Failed to find load balancer IP for network %s", n.Name())
+		return
+	}
 
-		for eid, be := range lb.backEnds {
-			if be.disabled {
-				continue
-			}
-			//Call HNS to get back ID (GUID) corresponding to the endpoint.
-			hnsEndpoint, err := hcsshim.GetHNSEndpointByName(eid)
-			if err != nil {
-				logrus.Errorf("Failed to find HNS ID for endpoint %v: %v", eid, err)
-				return
-			}
+	var endpoints []hcsshim.HNSEndpoint
 
-			endpoints = append(endpoints, *hnsEndpoint)
+	for eid, be := range lb.backEnds {
+		if be.disabled {
+			continue
 		}
-
-		if policies, ok := lbPolicylistMap[lb]; ok {
-
-			if policies.ilb != nil {
-				policies.ilb.Delete()
-				policies.ilb = nil
-			}
-
-			if policies.elb != nil {
-				policies.elb.Delete()
-				policies.elb = nil
-			}
-			delete(lbPolicylistMap, lb)
-		}
-
-		ilbPolicy, err := hcsshim.AddLoadBalancer(endpoints, true, sourceVIP, vip.String(), 0, 0, 0)
+		//Call HNS to get back ID (GUID) corresponding to the endpoint.
+		hnsEndpoint, err := hcsshim.GetHNSEndpointByName(eid)
 		if err != nil {
-			logrus.Errorf("Failed to add ILB policy for service %s (%s) with endpoints %v using load balancer IP %s on network %s: %v",
-				lb.service.name, vip.String(), endpoints, sourceVIP, n.Name(), err)
+			logrus.Errorf("Failed to find HNS ID for endpoint %v: %v", eid, err)
 			return
 		}
 
-		lbPolicylistMap[lb] = &policyLists{
-			ilb: ilbPolicy,
+		endpoints = append(endpoints, *hnsEndpoint)
+	}
+
+	if policies, ok := lbPolicylistMap[lb]; ok {
+
+		if policies.ilb != nil {
+			policies.ilb.Delete()
+			policies.ilb = nil
 		}
 
-		publishedPorts := make(map[uint32]uint32)
+		if policies.elb != nil {
+			policies.elb.Delete()
+			policies.elb = nil
+		}
+		delete(lbPolicylistMap, lb)
+	}
 
-		for i, port := range ingressPorts {
-			protocol := uint16(6)
+	ilbPolicy, err := hcsshim.AddLoadBalancer(endpoints, true, sourceVIP, vip.String(), 0, 0, 0)
+	if err != nil {
+		logrus.Errorf("Failed to add ILB policy for service %s (%s) with endpoints %v using load balancer IP %s on network %s: %v",
+			lb.service.name, vip.String(), endpoints, sourceVIP, n.Name(), err)
+		return
+	}
 
-			// Skip already published port
-			if publishedPorts[port.PublishedPort] == port.TargetPort {
-				continue
+	lbPolicylistMap[lb] = &policyLists{
+		ilb: ilbPolicy,
+	}
+
+	publishedPorts := make(map[uint32]uint32)
+
+	for i, port := range ingressPorts {
+		protocol := uint16(6)
+
+		// Skip already published port
+		if publishedPorts[port.PublishedPort] == port.TargetPort {
+			continue
+		}
+
+		if port.Protocol == ProtocolUDP {
+			protocol = 17
+		}
+
+		// check if already has udp matching to add wild card publishing
+		for j := i + 1; j < len(ingressPorts); j++ {
+			if ingressPorts[j].TargetPort == port.TargetPort &&
+				ingressPorts[j].PublishedPort == port.PublishedPort {
+				protocol = 0
 			}
+		}
 
-			if port.Protocol == ProtocolUDP {
-				protocol = 17
-			}
+		publishedPorts[port.PublishedPort] = port.TargetPort
 
-			// check if already has udp matching to add wild card publishing
-			for j := i + 1; j < len(ingressPorts); j++ {
-				if ingressPorts[j].TargetPort == port.TargetPort &&
-					ingressPorts[j].PublishedPort == port.PublishedPort {
-					protocol = 0
-				}
-			}
-
-			publishedPorts[port.PublishedPort] = port.TargetPort
-
-			lbPolicylistMap[lb].elb, err = hcsshim.AddLoadBalancer(endpoints, false, sourceVIP, "", protocol, uint16(port.TargetPort), uint16(port.PublishedPort))
-			if err != nil {
-				logrus.Errorf("Failed to add ELB policy for service %s (ip:%s target port:%v published port:%v) with endpoints %v using load balancer IP %s on network %s: %v",
-					lb.service.name, vip.String(), uint16(port.TargetPort), uint16(port.PublishedPort), endpoints, sourceVIP, n.Name(), err)
-				return
-			}
+		lbPolicylistMap[lb].elb, err = hcsshim.AddLoadBalancer(endpoints, false, sourceVIP, "", protocol, uint16(port.TargetPort), uint16(port.PublishedPort))
+		if err != nil {
+			logrus.Errorf("Failed to add ELB policy for service %s (ip:%s target port:%v published port:%v) with endpoints %v using load balancer IP %s on network %s: %v",
+				lb.service.name, vip.String(), uint16(port.TargetPort), uint16(port.PublishedPort), endpoints, sourceVIP, n.Name(), err)
+			return
 		}
 	}
 }
@@ -124,30 +121,28 @@ func (n *network) rmLBBackend(ip net.IP, lb *loadBalancer, rmService bool, fullR
 		return
 	}
 
-	if osversion.Build() > 16236 {
-		if numEnabledBackends(lb) > 0 {
-			//Reprogram HNS (actually VFP) with the existing backends.
-			n.addLBBackend(ip, lb)
-		} else {
-			lb.Lock()
-			defer lb.Unlock()
-			logrus.Debugf("No more backends for service %s (ip:%s).  Removing all policies", lb.service.name, lb.vip.String())
+	if numEnabledBackends(lb) > 0 {
+		// Reprogram HNS (actually VFP) with the existing backends.
+		n.addLBBackend(ip, lb)
+	} else {
+		lb.Lock()
+		defer lb.Unlock()
+		logrus.Debugf("No more backends for service %s (ip:%s).  Removing all policies", lb.service.name, lb.vip.String())
 
-			if policyLists, ok := lbPolicylistMap[lb]; ok {
-				if policyLists.ilb != nil {
-					policyLists.ilb.Delete()
-					policyLists.ilb = nil
-				}
-
-				if policyLists.elb != nil {
-					policyLists.elb.Delete()
-					policyLists.elb = nil
-				}
-				delete(lbPolicylistMap, lb)
-
-			} else {
-				logrus.Errorf("Failed to find policies for service %s (%s)", lb.service.name, lb.vip.String())
+		if policyLists, ok := lbPolicylistMap[lb]; ok {
+			if policyLists.ilb != nil {
+				policyLists.ilb.Delete()
+				policyLists.ilb = nil
 			}
+
+			if policyLists.elb != nil {
+				policyLists.elb.Delete()
+				policyLists.elb = nil
+			}
+			delete(lbPolicylistMap, lb)
+
+		} else {
+			logrus.Errorf("Failed to find policies for service %s (%s)", lb.service.name, lb.vip.String())
 		}
 	}
 }

--- a/pkg/parsers/operatingsystem/operatingsystem_windows.go
+++ b/pkg/parsers/operatingsystem/operatingsystem_windows.go
@@ -52,8 +52,7 @@ func withCurrentVersionRegistryKey(f func(registry.Key) (string, error)) (string
 
 // GetOperatingSystemVersion gets the version of the current operating system, as a string.
 func GetOperatingSystemVersion() (string, error) {
-	version := osversion.Get()
-	return fmt.Sprintf("%d.%d.%d", version.MajorVersion, version.MinorVersion, version.Build), nil
+	return osversion.Get().ToString(), nil
 }
 
 // IsContainerized returns true if we are running inside a container.


### PR DESCRIPTION
Windows Server 2016 (RS1) reached end of support, and Docker Desktop requires
Windows 10 V19H2 (version 1909, build 18363) as a minimum.

This patch makes Windows Server RS5 /  ltsc2019 (build 17763) the minimum version
to run the daemon, and removes some hacks for older versions of Windows.

There is one check remaining that checks for Windows RS3 for a workaround
on older versions, but recent changes in Windows seemed to have regressed
on the same issue, so I kept that code for now to check if we may need that
workaround (again) (see https://github.com/moby/moby/pull/43145);

https://github.com/moby/moby/blob/085c6a98d54720e70b28354ccec6da9b1b9e7fcf/daemon/graphdriver/windows/windows.go#L319-L341

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

