### PR TITLE
daemon/images: ImageService.Cleanup(): return error instead of logging

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1206,7 +1206,9 @@ func (daemon *Daemon) Shutdown() error {
 	}
 
 	if daemon.imageService != nil {
-		daemon.imageService.Cleanup()
+		if err := daemon.imageService.Cleanup(); err != nil {
+			logrus.Error(err)
+		}
 	}
 
 	// If we are part of a cluster, clean up cluster's stuff

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -20,7 +20,6 @@ import (
 	"github.com/docker/libtrust"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -167,10 +166,11 @@ func (i *ImageService) GetLayerMountID(cid string) (string, error) {
 
 // Cleanup resources before the process is shutdown.
 // called from daemon.go Daemon.Shutdown()
-func (i *ImageService) Cleanup() {
+func (i *ImageService) Cleanup() error {
 	if err := i.layerStore.Cleanup(); err != nil {
-		logrus.Errorf("Error during layer Store.Cleanup(): %v", err)
+		return errors.Wrap(err, "error during layerStore.Cleanup()")
 	}
+	return nil
 }
 
 // GraphDriverName returns the name of the graph drvier


### PR DESCRIPTION
splitting this one from https://github.com/moby/moby/pull/43183 (to keep that one focussed on a single package)

This makes the function a bit more idiomatic, and leaves it to the caller to decide wether or not the error can be ignored.

