### PR TITLE
daemon/config: DefaultShmSize: minor tweak and improve docs

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -32,8 +32,8 @@ const (
 	// maximum number of attempts that
 	// may take place at a time for each pull when the connection is lost.
 	DefaultDownloadAttempts = 5
-	// DefaultShmSize is the default value for container's shm size
-	DefaultShmSize = int64(67108864)
+	// DefaultShmSize is the default value for container's shm size (64 MiB)
+	DefaultShmSize int64 = 64 * 1024 * 1024
 	// DefaultNetworkMtu is the default value for network MTU
 	DefaultNetworkMtu = 1500
 	// DisableNetworkBridge is the default value of the option to disable network bridge

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -17,7 +17,7 @@ import (
 	"github.com/containerd/containerd/pkg/userns"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
-	daemonconfig "github.com/docker/docker/daemon/config"
+	dconfig "github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/oci"
 	"github.com/docker/docker/oci/caps"
 	"github.com/docker/docker/pkg/idtools"
@@ -34,7 +34,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const inContainerInitPath = "/sbin/" + daemonconfig.DefaultInitBinary
+const inContainerInitPath = "/sbin/" + dconfig.DefaultInitBinary
 
 // WithRlimits sets the container's rlimits along with merging the daemon's rlimits
 func WithRlimits(daemon *Daemon, c *container.Container) coci.SpecOpts {
@@ -742,7 +742,7 @@ func WithCommonOptions(daemon *Daemon, c *container.Container) coci.SpecOpts {
 				s.Process.Args = append([]string{inContainerInitPath, "--", c.Path}, c.Args...)
 				path := daemon.configStore.InitPath
 				if path == "" {
-					path, err = exec.LookPath(daemonconfig.DefaultInitBinary)
+					path, err = exec.LookPath(dconfig.DefaultInitBinary)
 					if err != nil {
 						return err
 					}

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -22,6 +22,7 @@ import (
 	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
+	dconfig "github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/pkg/ioutils"
@@ -1441,7 +1442,7 @@ func (s *DockerSuite) TestPostContainersCreateShmSizeNegative(c *testing.T) {
 func (s *DockerSuite) TestPostContainersCreateShmSizeHostConfigOmitted(c *testing.T) {
 	// ShmSize is not supported on Windows
 	testRequires(c, DaemonIsLinux)
-	var defaultSHMSize int64 = 67108864
+
 	config := containertypes.Config{
 		Image: "busybox",
 		Cmd:   []string{"mount"},
@@ -1457,7 +1458,7 @@ func (s *DockerSuite) TestPostContainersCreateShmSizeHostConfigOmitted(c *testin
 	containerJSON, err := cli.ContainerInspect(context.Background(), container.ID)
 	assert.NilError(c, err)
 
-	assert.Equal(c, containerJSON.HostConfig.ShmSize, defaultSHMSize)
+	assert.Equal(c, containerJSON.HostConfig.ShmSize, dconfig.DefaultShmSize)
 
 	out, _ := dockerCmd(c, "start", "-i", containerJSON.ID)
 	shmRegexp := regexp.MustCompile(`shm on /dev/shm type tmpfs(.*)size=65536k`)


### PR DESCRIPTION
I had to check what the actual size was, so added it to the const's documentation.

While at it, also made use of it in a test, so that we're testing against the expected
value, and changed one alias to be consistent with other places where we alias this
import.

