### PR TITLE
integration-cli: TestSlowStdinClosing: add logs, and potential naming conflict

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4157,17 +4157,19 @@ func (s *DockerSuite) TestRunEmptyEnv(c *testing.T) {
 
 // #28658
 func (s *DockerSuite) TestSlowStdinClosing(c *testing.T) {
-	name := "testslowstdinclosing"
-	repeat := 3 // regression happened 50% of the time
+	const repeat = 3 // regression happened 50% of the time
 	for i := 0; i < repeat; i++ {
 		cmd := icmd.Cmd{
-			Command: []string{dockerBinary, "run", "--rm", "--name", name, "-i", "busybox", "cat"},
+			Command: []string{dockerBinary, "run", "--rm", "-i", "busybox", "cat"},
 			Stdin:   &delayedReader{},
 		}
 		done := make(chan error, 1)
 		go func() {
-			err := icmd.RunCmd(cmd).Error
-			done <- err
+			result := icmd.RunCmd(cmd)
+			if out := result.Combined(); out != "" {
+				c.Log(out)
+			}
+			done <- result.Error
 		}()
 
 		select {


### PR DESCRIPTION
addresses ~(hopefully fixes)~ https://github.com/moby/moby/issues/43012

This test has become quite flaky on Windows / Windows with Containerd.

Looking at the test, I noticed that it's running a test three times (according
to the comment "as it failed ~ 50% of the time"). However;

- it uses the `--rm` option to clean up the container after it terminated
- it uses a fixed name for the containers that are started

I had a quick look at the issue that it was created for, and neither of those
options were mentioned in the reported bug (so are just part of the test setup).

I think the test was written when the `--rm` option was still client-side, in which
case the cli would not terminate until it removed the container (making the
remove synchronous). Current versions of docker have moved the `--rm` to the
daemon side, and (if I'm not mistaken) performed asynchronous.

~Due to the above, it's possible that, when iterating, the previous container still exists (Windows tends to be slower, so may also be slower to remove the container); combined with the test using a fixed name, this would cause a name conflict, causing the run to fail.~

This patch:

- removes the fixed name (the test doesn't require the container to have a
  specific name, so we can just use a random name)
- adds logs to capture the stderr and stdout output of the run (so that we're
  able to capture failure messages).

### integration-cli: TestSlowStdinClosing: use sub-tests
Use sub-tests so that the iterations can run in parallel (instead of
sequential), and to make failures show up for the iteration that they're
part of.

Note that changing to subtests means that we'll always run 3 iterations of
the test, and no longer fail early (but the test still fails if any of
those iterations fails.


Update: (see below); the failure looks to be specific to the Windows on containerd case, and is failing with;

```
=== RUN   TestDockerSuite/TestSlowStdinClosing
    docker_cli_run_test.go:4163: 
    docker_cli_run_test.go:4163: 
    docker_cli_run_test.go:4163: d:\CI\PR-43264\6\binary\docker.exe: Error response from daemon: failed to create shim: open \\.\pipe\containerd-29565631f602b7418a1df4233d21fb4d2a663689601e20424981c188624a6f9d-init-stdin: The system cannot find the file specified.: not found.
        
    docker_cli_run_test.go:4171: assertion failed: error is not nil: exit status 127
    --- FAIL: TestDockerSuite/TestSlowStdinClosing (7.95s)
```

