### PR TITLE
Add support for CpuCount/CpuPercent to image build

### DIFF
--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -115,6 +115,14 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 		options.Ulimits = buildUlimits
 	}
 
+	if versions.GreaterThanOrEqualTo(version, "1.42") {
+		options.CPUCount = httputils.Int64ValueOrZero(r, "cpucount")
+	}
+
+	if versions.GreaterThanOrEqualTo(version, "1.42") {
+		options.CPUPercent = httputils.Int64ValueOrZero(r, "cpupercent")
+	}
+
 	// Note that there are two ways a --build-arg might appear in the
 	// json of the query param:
 	//     "foo":"bar"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8032,6 +8032,25 @@ paths:
           in: "query"
           description: "Microseconds of CPU time that the container can get in a CPU period."
           type: "integer"
+        # Applicable to Windows
+        - name: "cpucount"
+          in: "query"
+          description: |
+            The number of usable CPUs (Windows only).
+
+            On Windows Server containers, the processor resource controls are
+            mutually exclusive. The order of precedence is `CPUCount` first, then
+            `CPUShares`, and `CPUPercent` last.
+          type: "integer"
+        - name: "cpupercent"
+          in: "query"
+          description: |
+            The usable percentage of the available CPUs (Windows only).
+
+            On Windows Server containers, the processor resource controls are
+            mutually exclusive. The order of precedence is `CPUCount` first, then
+            `CPUShares`, and `CPUPercent` last.
+          type: "integer"
         - name: "buildargs"
           in: "query"
           description: >

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -175,6 +175,11 @@ type ImageBuildOptions struct {
 	ShmSize        int64
 	Dockerfile     string
 	Ulimits        []*units.Ulimit
+
+	// Applicable to Windows
+	CPUCount   int64 `json:"CpuCount"`   // CPU count
+	CPUPercent int64 `json:"CpuPercent"` // CPU percent
+
 	// BuildArgs needs to be a *string instead of just a string so that
 	// we can tell the difference between "" (empty string) and no value
 	// at all (nil). See the parsing of buildArgs in

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -410,6 +410,8 @@ func hostConfigFromOptions(options *types.ImageBuildOptions) *container.HostConf
 		Memory:       options.Memory,
 		MemorySwap:   options.MemorySwap,
 		Ulimits:      options.Ulimits,
+		CPUCount:     options.CPUCount,
+		CPUPercent:   options.CPUPercent,
 	}
 
 	hc := &container.HostConfig{

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -104,6 +104,19 @@ func (cli *Client) imageBuildOptionsToQuery(options types.ImageBuildOptions) (ur
 	}
 	query.Set("ulimits", string(ulimitsJSON))
 
+	if options.CPUCount > 0 {
+		if err := cli.NewVersionError("1.42", "CPUCount"); err != nil {
+			return query, err
+		}
+		query.Set("cpucount", strings.ToLower(strconv.FormatInt(options.CPUCount, 10)))
+	}
+	if options.CPUPercent > 0 {
+		if err := cli.NewVersionError("1.42", "CPUPercent"); err != nil {
+			return query, err
+		}
+		query.Set("cpupercent", strings.ToLower(strconv.FormatInt(options.CPUPercent, 10)))
+	}
+
 	buildArgsJSON, err := json.Marshal(options.BuildArgs)
 	if err != nil {
 		return query, err


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I added support for CpuCount/CpuPercent to image building

**- How I did it**

I added CpuCount/CpuPercent to ImageBuildOptions struct, pass them through docker API from client to server and populate HostConfig with values.

**- How to verify it**

Not sure, given that `docker build` doesn't have yet support for this. It requires a separate PR to https://github.com/docker/cli repo.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add support for CpuCount/CpuPercent to image build

Resolves #38387
