### PR TITLE
api: add missing docs for KernelMemoryTCP, and fix error message

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4468,6 +4468,14 @@ definitions:
           > `kmem.limit_in_bytes`.
         type: "boolean"
         example: true
+      KernelMemoryTCP:
+        description: |
+          Indicates if the host has kernel memory TCP limit support enabled.
+
+          Kernel memory TCP limits are not supported when using cgroups v2, which
+          does not support the corresponding `memory.kmem.tcp.limit_in_bytes` cgroup.
+        type: "boolean"
+        example: true
       CpuCfsPeriod:
         description: |
           Indicates if CPU CFS(Completely Fair Scheduler) period is supported by

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -452,7 +452,7 @@ func verifyPlatformContainerResources(resources *containertypes.Resources, sysIn
 		resources.KernelMemory = 0
 	}
 	if resources.KernelMemory > 0 && resources.KernelMemory < linuxMinMemory {
-		return warnings, fmt.Errorf("Minimum kernel memory limit allowed is 4MB")
+		return warnings, fmt.Errorf("Minimum kernel memory limit allowed is 6MB")
 	}
 	if resources.KernelMemory > 0 && !kernel.CheckKernelVersion(4, 0, 0) {
 		warnings = append(warnings, "You specified a kernel memory limit on a kernel older than 4.0. Kernel memory limits are experimental on older kernels, it won't work as expected and can cause your system to be unstable.")

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -4346,6 +4346,14 @@ definitions:
         description: "Indicates if the host has kernel memory limit support enabled."
         type: "boolean"
         example: true
+      KernelMemoryTCP:
+        description: |
+          Indicates if the host has kernel memory TCP limit support enabled.
+
+          Kernel memory TCP limits are not supported when using cgroups v2, which
+          does not support the corresponding `memory.kmem.tcp.limit_in_bytes` cgroup.
+        type: "boolean"
+        example: true
       CpuCfsPeriod:
         description: |
           Indicates if CPU CFS(Completely Fair Scheduler) period is supported by

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -4467,6 +4467,14 @@ definitions:
           > `kmem.limit_in_bytes`.
         type: "boolean"
         example: true
+      KernelMemoryTCP:
+        description: |
+          Indicates if the host has kernel memory TCP limit support enabled.
+
+          Kernel memory TCP limits are not supported when using cgroups v2, which
+          does not support the corresponding `memory.kmem.tcp.limit_in_bytes` cgroup.
+        type: "boolean"
+        example: true
       CpuCfsPeriod:
         description: |
           Indicates if CPU CFS(Completely Fair Scheduler) period is supported by


### PR DESCRIPTION
Taken from https://github.com/moby/moby/pull/43214

- Add missing documentation for KernelMemoryTCP, which was added in API v1.40
- Fix the error message, which mentioned 4MB as minimum, but it was changed to 6MB in 20.10 (see https://github.com/moby/moby/pull/41168)