### PR TITLE
distribution: remove use of deprecated dial.DualStack

### DIFF
--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -68,7 +68,6 @@ func NewV2Repository(
 	direct := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
-		DualStack: true,
 	}
 
 	// TODO(dmcgowan): Call close idle connections when complete, use keep alive

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -175,7 +175,6 @@ func NewTransport(tlsConfig *tls.Config) *http.Transport {
 	direct := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
-		DualStack: true,
 	}
 
 	base := &http.Transport{


### PR DESCRIPTION
From the field's description [1]:

    DualStack previously enabled RFC 6555 Fast Fallback
    support, also known as "Happy Eyeballs", in which IPv4 is
    tried soon if IPv6 appears to be misconfigured and
    hanging.

    Deprecated: Fast Fallback is enabled by default. To
    disable, set FallbackDelay to a negative value.

This field was deprecated in https://github.com/golang/go/commit/efc185029bf770894defe63cec2c72a4c84b2ee9,
which is included in Go 1.12beta1 and up.

[1]: https://github.com/golang/go/blob/2ebe77a2fda1ee9ff6fd9a3e08933ad1ebaea039/src/net/dial.go#L54-L61


**- A picture of a cute animal (not mandatory but encouraged)**

