### PR TITLE
Removed mentions of the deprecated Docker CE repo

### DIFF
--- a/docs/contributing/set-up-dev-env.md
+++ b/docs/contributing/set-up-dev-env.md
@@ -210,14 +210,10 @@ can take over 15 minutes to complete.
 
    Notice the split versions between client and server, which might be
    unexpected. In more recent times the Docker CLI component (which provides the
-   `docker` command) has split out from the Moby project and is now maintained in:
-   
-   * [docker/cli](https://github.com/docker/cli) - The Docker CLI source-code;
-   * [docker/docker-ce](https://github.com/docker/docker-ce) - The Docker CE
-     edition project, which assembles engine, CLI and other components.
+   `docker` command) has split out from the Moby project and is now maintained in [docker/cli](https://github.com/docker/cli).
    
    The Moby project now defaults to a [fixed
-   version](https://github.com/docker/docker-ce/commits/v17.06.0-ce) of the
+   version](https://github.com/docker/cli/commits/v17.06.0-ce) of the
    `docker` CLI for integration tests.
 
    You may have noticed the following message when starting the container with the `shell` command:
@@ -241,8 +237,8 @@ can take over 15 minutes to complete.
    Docker version 17.09.0-dev, build 
    ```
 
-    This Docker CLI should be built from the [docker-ce
-    project](https://github.com/docker/docker-ce) and needs to be a Linux
+    This Docker CLI should be built from the [docker-cli
+    project](https://github.com/docker/cli) and needs to be a Linux
     binary.
 
    Inside the container you are running a development version. This is the version


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Closes #43265.

**- What I did**
I removed the deprecated mentions of the Docker CE repository and replaced some references with the correct links. 

There are still some mentions of the `docker-ce` repository and scripts that pull from that repository, but that may be the scope of another pull request where the scripts are being revamped.