### PR TITLE
integration-cli: cleanup some of the test-utilities

### DIFF
--- a/integration-cli/cli/cli.go
+++ b/integration-cli/cli/cli.go
@@ -32,12 +32,12 @@ func DockerCmd(t testing.TB, args ...string) *icmd.Result {
 
 // BuildCmd executes the specified docker build command and expect a success
 func BuildCmd(t testing.TB, name string, cmdOperators ...CmdOperator) *icmd.Result {
-	return Docker(Build(name), cmdOperators...).Assert(t, icmd.Success)
+	return Docker(Args("build", "-t", name), cmdOperators...).Assert(t, icmd.Success)
 }
 
 // InspectCmd executes the specified docker inspect command and expect a success
 func InspectCmd(t testing.TB, name string, cmdOperators ...CmdOperator) *icmd.Result {
-	return Docker(Inspect(name), cmdOperators...).Assert(t, icmd.Success)
+	return Docker(Args("inspect", name), cmdOperators...).Assert(t, icmd.Success)
 }
 
 // WaitRun will wait for the specified container to be running, maximum 5 seconds.
@@ -120,16 +120,6 @@ func validateArgs(args ...string) error {
 		}
 	}
 	return nil
-}
-
-// Build executes the specified docker build command
-func Build(name string) icmd.Cmd {
-	return icmd.Command("build", "-t", name)
-}
-
-// Inspect executes the specified docker inspect command
-func Inspect(name string) icmd.Cmd {
-	return icmd.Command("inspect", name)
 }
 
 // Format sets the specified format with --format flag

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -106,12 +106,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithVolumesRefs(c *testing.T) {
 		c.Fatal(err, out)
 	}
 
-	out, err := s.d.Cmd("inspect", "-f", "{{json .Mounts}}", "volrestarttest1")
-	assert.NilError(c, err, out)
-
-	if _, err := inspectMountPointJSON(out, "/foo"); err != nil {
-		c.Fatalf("Expected volume to exist: /foo, error: %v\n", err)
-	}
+	out, err := s.d.Cmd("inspect", "-f", `{{range .Mounts}}{{.Destination}}{{"\n"}}{{end}}`, "volrestarttest1")
+	assert.Check(c, err)
+	assert.Check(c, is.Contains(strings.Split(out, "\n"), "/foo"))
 }
 
 // #11008

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -178,7 +178,7 @@ func (s *DockerDaemonSuite) TestDaemonRestartOnFailure(c *testing.T) {
 
 	// wait test1 to stop
 	hostArgs := []string{"--host", s.d.Sock()}
-	err = waitInspectWithArgs("test1", "{{.State.Running}} {{.State.Restarting}}", "false false", 10*time.Second, hostArgs...)
+	err = daemon.WaitInspectWithArgs(dockerBinary, "test1", "{{.State.Running}} {{.State.Restarting}}", "false false", 10*time.Second, hostArgs...)
 	assert.NilError(c, err, "test1 should exit but not")
 
 	// record last start time
@@ -189,7 +189,7 @@ func (s *DockerDaemonSuite) TestDaemonRestartOnFailure(c *testing.T) {
 	s.d.Restart(c)
 
 	// test1 shouldn't restart at all
-	err = waitInspectWithArgs("test1", "{{.State.Running}} {{.State.Restarting}}", "false false", 0, hostArgs...)
+	err = daemon.WaitInspectWithArgs(dockerBinary, "test1", "{{.State.Running}} {{.State.Restarting}}", "false false", 0, hostArgs...)
 	assert.NilError(c, err, "test1 should exit but not")
 
 	// make sure test1 isn't restarted when daemon restart

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3943,7 +3943,7 @@ func (s *DockerCLIRunSuite) TestRunRm(c *testing.T) {
 	name := "miss-me-when-im-gone"
 	cli.DockerCmd(c, "run", "--name="+name, "--rm", "busybox")
 
-	cli.Docker(cli.Inspect(name), cli.Format(".name")).Assert(c, icmd.Expected{
+	cli.Docker(cli.Args("inspect", name), cli.Format(".name")).Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "No such object: " + name,
 	})
@@ -3955,7 +3955,7 @@ func (s *DockerCLIRunSuite) TestRunRmPre125Api(c *testing.T) {
 	envs := appendBaseEnv(os.Getenv("DOCKER_TLS_VERIFY") != "", "DOCKER_API_VERSION=1.24")
 	cli.Docker(cli.Args("run", "--name="+name, "--rm", "busybox"), cli.WithEnvironmentVariables(envs...)).Assert(c, icmd.Success)
 
-	cli.Docker(cli.Inspect(name), cli.Format(".name")).Assert(c, icmd.Expected{
+	cli.Docker(cli.Args("inspect", name), cli.Format(".name")).Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "No such object: " + name,
 	})

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -311,7 +311,7 @@ func createTmpFile(c *testing.T, content string) string {
 // waitRun will wait for the specified container to be running, maximum 5 seconds.
 // Deprecated: use cli.WaitFor
 func waitRun(contID string) error {
-	return waitInspect(contID, "{{.State.Running}}", "true", 5*time.Second)
+	return daemon.WaitInspectWithArgs(dockerBinary, contID, "{{.State.Running}}", "true", 5*time.Second)
 }
 
 // waitInspect will wait for the specified container to have the specified string
@@ -319,12 +319,7 @@ func waitRun(contID string) error {
 // is reached.
 // Deprecated: use cli.WaitFor
 func waitInspect(name, expr, expected string, timeout time.Duration) error {
-	return waitInspectWithArgs(name, expr, expected, timeout)
-}
-
-// Deprecated: use cli.WaitFor
-func waitInspectWithArgs(name, expr, expected string, timeout time.Duration, arg ...string) error {
-	return daemon.WaitInspectWithArgs(dockerBinary, name, expr, expected, timeout, arg...)
+	return daemon.WaitInspectWithArgs(dockerBinary, name, expr, expected, timeout)
 }
 
 func getInspectBody(c *testing.T, version, id string) []byte {

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -132,6 +132,8 @@ func inspectMountSourceField(name, destination string) (string, error) {
 	return m.Source, nil
 }
 
+var errMountNotFound = errors.New("mount point not found")
+
 // Deprecated: use cli.Docker
 func inspectMountPoint(name, destination string) (types.MountPoint, error) {
 	out, err := inspectFilter(name, "json .Mounts")
@@ -139,15 +141,8 @@ func inspectMountPoint(name, destination string) (types.MountPoint, error) {
 		return types.MountPoint{}, err
 	}
 
-	return inspectMountPointJSON(out, destination)
-}
-
-var errMountNotFound = errors.New("mount point not found")
-
-// Deprecated: use cli.Docker
-func inspectMountPointJSON(j, destination string) (types.MountPoint, error) {
 	var mp []types.MountPoint
-	if err := json.Unmarshal([]byte(j), &mp); err != nil {
+	if err := json.Unmarshal([]byte(out), &mp); err != nil {
 		return types.MountPoint{}, err
 	}
 

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -84,7 +84,7 @@ func inspectFieldAndUnmarshall(c *testing.T, name, field string, output interfac
 	assert.Assert(c, err == nil, "failed to unmarshal: %v", err)
 }
 
-// Deprecated: use cli.Inspect
+// Deprecated: use cli.Docker
 func inspectFilter(name, filter string) (string, error) {
 	format := fmt.Sprintf("{{%s}}", filter)
 	result := icmd.RunCommand(dockerBinary, "inspect", "-f", format, name)
@@ -94,12 +94,12 @@ func inspectFilter(name, filter string) (string, error) {
 	return strings.TrimSpace(result.Combined()), nil
 }
 
-// Deprecated: use cli.Inspect
+// Deprecated: use cli.Docker
 func inspectFieldWithError(name, field string) (string, error) {
 	return inspectFilter(name, "."+field)
 }
 
-// Deprecated: use cli.Inspect
+// Deprecated: use cli.Docker
 func inspectField(c *testing.T, name, field string) string {
 	c.Helper()
 	out, err := inspectFilter(name, "."+field)
@@ -107,7 +107,7 @@ func inspectField(c *testing.T, name, field string) string {
 	return out
 }
 
-// Deprecated: use cli.Inspect
+// Deprecated: use cli.Docker
 func inspectFieldJSON(c *testing.T, name, field string) string {
 	c.Helper()
 	out, err := inspectFilter(name, "json ."+field)
@@ -115,7 +115,7 @@ func inspectFieldJSON(c *testing.T, name, field string) string {
 	return out
 }
 
-// Deprecated: use cli.Inspect
+// Deprecated: use cli.Docker
 func inspectFieldMap(c *testing.T, name, path, field string) string {
 	c.Helper()
 	out, err := inspectFilter(name, fmt.Sprintf("index .%s %q", path, field))
@@ -123,7 +123,7 @@ func inspectFieldMap(c *testing.T, name, path, field string) string {
 	return out
 }
 
-// Deprecated: use cli.Inspect
+// Deprecated: use cli.Docker
 func inspectMountSourceField(name, destination string) (string, error) {
 	m, err := inspectMountPoint(name, destination)
 	if err != nil {
@@ -132,7 +132,7 @@ func inspectMountSourceField(name, destination string) (string, error) {
 	return m.Source, nil
 }
 
-// Deprecated: use cli.Inspect
+// Deprecated: use cli.Docker
 func inspectMountPoint(name, destination string) (types.MountPoint, error) {
 	out, err := inspectFilter(name, "json .Mounts")
 	if err != nil {
@@ -144,7 +144,7 @@ func inspectMountPoint(name, destination string) (types.MountPoint, error) {
 
 var errMountNotFound = errors.New("mount point not found")
 
-// Deprecated: use cli.Inspect
+// Deprecated: use cli.Docker
 func inspectMountPointJSON(j, destination string) (types.MountPoint, error) {
 	var mp []types.MountPoint
 	if err := json.Unmarshal([]byte(j), &mp); err != nil {
@@ -173,15 +173,15 @@ func getIDByName(c *testing.T, name string) string {
 	return id
 }
 
-// Deprecated: use cli.Build
+// Deprecated: use cli.Docker
 func buildImageSuccessfully(c *testing.T, name string, cmdOperators ...cli.CmdOperator) {
 	c.Helper()
 	buildImage(name, cmdOperators...).Assert(c, icmd.Success)
 }
 
-// Deprecated: use cli.Build
+// Deprecated: use cli.Docker
 func buildImage(name string, cmdOperators ...cli.CmdOperator) *icmd.Result {
-	return cli.Docker(cli.Build(name), cmdOperators...)
+	return cli.Docker(cli.Args("build", "-t", name), cmdOperators...)
 }
 
 // Write `content` to the file at path `dst`, creating it if necessary,


### PR DESCRIPTION
Had some of these changes stashed; lots more to be cleaned up (and remove abstraction layers that make things hard to follow), but let me just start with pushing these small changes.


### integration-cli: remove WaitRestart(), un-export WaitForInspectResult()

- Remove `WaitRestart()` as it was no longer used
- Un-export `WaitForInspectResult()` as it was only used internally, and we want to reduce uses of these utilities.
- Inline `appendDocker()` into `Docker()` as it was the only place it was used, and the name was incorrect anyway (should've been named `prependXX`).
- Simplify `Args()`, as it was first splitting the slice (into `command` and `args`),   only to join them again into a single slice (in `icmd.Command()`).

### integration-cli: remove cli.Build(), cli.Inspect()

They were just small wrappers arround cli.Args(), and the abstraction made one wonder if they were doing some "magic" things, but they weren't, so just inlining the `cli.Args()` makes it more transparent what's executed.
