### PR TITLE
registry: remove v1 leftovers, and refactor to reduce public api/interface

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -183,10 +183,8 @@ func (daemon *Daemon) RegistryHosts() docker.RegistryHosts {
 	}
 
 	for k, v := range m {
-		if d, err := registry.HostCertsDir(k); err == nil {
-			v.TLSConfigDir = []string{d}
-			m[k] = v
-		}
+		v.TLSConfigDir = []string{registry.HostCertsDir(k)}
+		m[k] = v
 	}
 
 	certsDir := registry.CertsDir()

--- a/daemon/images/image_search_test.go
+++ b/daemon/images/image_search_test.go
@@ -11,16 +11,15 @@ import (
 	"github.com/docker/docker/registry"
 )
 
-type FakeService struct {
-	registry.DefaultService
-
+type fakeService struct {
+	registry.Service
 	shouldReturnError bool
 
 	term    string
 	results []registrytypes.SearchResult
 }
 
-func (s *FakeService) Search(ctx context.Context, term string, limit int, authConfig *types.AuthConfig, userAgent string, headers map[string][]string) (*registrytypes.SearchResults, error) {
+func (s *fakeService) Search(ctx context.Context, term string, limit int, authConfig *types.AuthConfig, userAgent string, headers map[string][]string) (*registrytypes.SearchResults, error) {
 	if s.shouldReturnError {
 		return nil, errors.New("Search unknown error")
 	}
@@ -76,7 +75,7 @@ func TestSearchRegistryForImagesErrors(t *testing.T) {
 	}
 	for index, e := range errorCases {
 		daemon := &ImageService{
-			registryService: &FakeService{
+			registryService: &fakeService{
 				shouldReturnError: e.shouldReturnError,
 			},
 		}
@@ -322,7 +321,7 @@ func TestSearchRegistryForImages(t *testing.T) {
 	}
 	for index, s := range successCases {
 		daemon := &ImageService{
-			registryService: &FakeService{
+			registryService: &fakeService{
 				term:    term,
 				results: s.registryResults,
 			},

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -15,10 +15,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	// AuthClientID is used the ClientID used for the token server
-	AuthClientID = "docker"
-)
+// AuthClientID is used the ClientID used for the token server
+const AuthClientID = "docker"
 
 type loginCredentialStore struct {
 	authConfig *types.AuthConfig
@@ -109,8 +107,7 @@ func loginV2(authConfig *types.AuthConfig, endpoint APIEndpoint, userAgent strin
 	}
 
 	// TODO(dmcgowan): Attempt to further interpret result, status code and error code string
-	err = errors.Errorf("login attempt to %s failed with status: %d %s", endpointStr, resp.StatusCode, http.StatusText(resp.StatusCode))
-	return "", "", err
+	return "", "", errors.Errorf("login attempt to %s failed with status: %d %s", endpointStr, resp.StatusCode, http.StatusText(resp.StatusCode))
 }
 
 func v2AuthHTTPClient(endpoint *url.URL, authTransport http.RoundTripper, modifiers []transport.RequestModifier, creds auth.CredentialStore, scopes []auth.Scope) (*http.Client, error) {
@@ -129,10 +126,9 @@ func v2AuthHTTPClient(endpoint *url.URL, authTransport http.RoundTripper, modifi
 	tokenHandler := auth.NewTokenHandlerWithOptions(tokenHandlerOptions)
 	basicHandler := auth.NewBasicHandler(creds)
 	modifiers = append(modifiers, auth.NewAuthorizer(challengeManager, tokenHandler, basicHandler))
-	tr := transport.NewTransport(authTransport, modifiers...)
 
 	return &http.Client{
-		Transport: tr,
+		Transport: transport.NewTransport(authTransport, modifiers...),
 		Timeout:   15 * time.Second,
 	}, nil
 }
@@ -146,10 +142,7 @@ func ConvertToHostname(url string) string {
 	} else if strings.HasPrefix(url, "https://") {
 		stripped = strings.TrimPrefix(url, "https://")
 	}
-
-	nameParts := strings.SplitN(stripped, "/", 2)
-
-	return nameParts[0]
+	return strings.SplitN(stripped, "/", 2)[0]
 }
 
 // ResolveAuthConfig matches an auth configuration to a server address or a URL

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -80,7 +80,7 @@ func loginV2(authConfig *types.AuthConfig, endpoint APIEndpoint, userAgent strin
 	var (
 		endpointStr          = strings.TrimRight(endpoint.URL.String(), "/") + "/v2/"
 		modifiers            = Headers(userAgent, nil)
-		authTransport        = transport.NewTransport(NewTransport(endpoint.TLSConfig), modifiers...)
+		authTransport        = transport.NewTransport(newTransport(endpoint.TLSConfig), modifiers...)
 		credentialAuthConfig = *authConfig
 		creds                = loginCredentialStore{authConfig: &credentialAuthConfig}
 	)

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/distribution/registry/client/auth/challenge"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/api/types"
-	registrytypes "github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/api/types/registry"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -153,7 +153,7 @@ func ConvertToHostname(url string) string {
 }
 
 // ResolveAuthConfig matches an auth configuration to a server address or a URL
-func ResolveAuthConfig(authConfigs map[string]types.AuthConfig, index *registrytypes.IndexInfo) types.AuthConfig {
+func ResolveAuthConfig(authConfigs map[string]types.AuthConfig, index *registry.IndexInfo) types.AuthConfig {
 	configKey := GetAuthConfigKey(index)
 	// First try the happy case
 	if c, found := authConfigs[configKey]; found || index.Official {

--- a/registry/auth_test.go
+++ b/registry/auth_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"
+	"gotest.tools/v3/assert"
 )
 
 func buildAuthConfigs() map[string]types.AuthConfig {
@@ -32,10 +33,10 @@ func TestResolveAuthConfigIndexServer(t *testing.T) {
 	}
 
 	resolved := ResolveAuthConfig(authConfigs, officialIndex)
-	assertEqual(t, resolved, indexConfig, "Expected ResolveAuthConfig to return IndexServer")
+	assert.Equal(t, resolved, indexConfig, "Expected ResolveAuthConfig to return IndexServer")
 
 	resolved = ResolveAuthConfig(authConfigs, privateIndex)
-	assertNotEqual(t, resolved, indexConfig, "Expected ResolveAuthConfig to not return IndexServer")
+	assert.Check(t, resolved != indexConfig, "Expected ResolveAuthConfig to not return IndexServer")
 }
 
 func TestResolveAuthConfigFullURL(t *testing.T) {

--- a/registry/auth_test.go
+++ b/registry/auth_test.go
@@ -4,15 +4,15 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	registrytypes "github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/api/types/registry"
 	"gotest.tools/v3/assert"
 )
 
 func buildAuthConfigs() map[string]types.AuthConfig {
 	authConfigs := map[string]types.AuthConfig{}
 
-	for _, registry := range []string{"testIndex", IndexServer} {
-		authConfigs[registry] = types.AuthConfig{
+	for _, reg := range []string{"testIndex", IndexServer} {
+		authConfigs[reg] = types.AuthConfig{
 			Username: "docker-user",
 			Password: "docker-pass",
 		}
@@ -25,10 +25,10 @@ func TestResolveAuthConfigIndexServer(t *testing.T) {
 	authConfigs := buildAuthConfigs()
 	indexConfig := authConfigs[IndexServer]
 
-	officialIndex := &registrytypes.IndexInfo{
+	officialIndex := &registry.IndexInfo{
 		Official: true,
 	}
-	privateIndex := &registrytypes.IndexInfo{
+	privateIndex := &registry.IndexInfo{
 		Official: false,
 	}
 
@@ -88,19 +88,19 @@ func TestResolveAuthConfigFullURL(t *testing.T) {
 		if !ok {
 			t.Fail()
 		}
-		index := &registrytypes.IndexInfo{
+		index := &registry.IndexInfo{
 			Name: configKey,
 		}
-		for _, registry := range registries {
-			authConfigs[registry] = configured
+		for _, reg := range registries {
+			authConfigs[reg] = configured
 			resolved := ResolveAuthConfig(authConfigs, index)
 			if resolved.Username != configured.Username || resolved.Password != configured.Password {
-				t.Errorf("%s -> %v != %v\n", registry, resolved, configured)
+				t.Errorf("%s -> %v != %v\n", reg, resolved, configured)
 			}
-			delete(authConfigs, registry)
+			delete(authConfigs, reg)
 			resolved = ResolveAuthConfig(authConfigs, index)
 			if resolved.Username == configured.Username || resolved.Password == configured.Password {
-				t.Errorf("%s -> %v == %v\n", registry, resolved, configured)
+				t.Errorf("%s -> %v == %v\n", reg, resolved, configured)
 			}
 		}
 	}

--- a/registry/config.go
+++ b/registry/config.go
@@ -242,7 +242,7 @@ skip:
 // hostname should be a URL.Host (`host:port` or `host`) where the `host` part can be either a domain name
 // or an IP address. If it is a domain name, then it will be resolved to IP addresses for matching. If
 // resolution fails, CIDR matching is not performed.
-func allowNondistributableArtifacts(config *serviceConfig, hostname string) bool {
+func (config *serviceConfig) allowNondistributableArtifacts(hostname string) bool {
 	for _, h := range config.AllowNondistributableArtifactsHostnames {
 		if h == hostname {
 			return true
@@ -263,7 +263,7 @@ func allowNondistributableArtifacts(config *serviceConfig, hostname string) bool
 // or an IP address. If it is a domain name, then it will be resolved in order to check if the IP is contained
 // in a subnet. If the resolving is not successful, isSecureIndex will only try to match hostname to any element
 // of insecureRegistries.
-func isSecureIndex(config *serviceConfig, indexName string) bool {
+func (config *serviceConfig) isSecureIndex(indexName string) bool {
 	// Check for configured index, first.  This is needed in case isSecureIndex
 	// is called from anything besides newIndexInfo, in order to honor per-index configurations.
 	if index, ok := config.IndexConfigs[indexName]; ok {
@@ -385,7 +385,7 @@ func newIndexInfo(config *serviceConfig, indexName string) (*registry.IndexInfo,
 	return &registry.IndexInfo{
 		Name:     indexName,
 		Mirrors:  make([]string, 0),
-		Secure:   isSecureIndex(config, indexName),
+		Secure:   config.isSecureIndex(indexName),
 		Official: false,
 	}, nil
 }

--- a/registry/config.go
+++ b/registry/config.go
@@ -86,6 +86,21 @@ func newServiceConfig(options ServiceOptions) (*serviceConfig, error) {
 	return config, nil
 }
 
+// copy constructs a new ServiceConfig with a copy of the configuration in config.
+func (config *serviceConfig) copy() *registrytypes.ServiceConfig {
+	ic := make(map[string]*registrytypes.IndexInfo)
+	for key, value := range config.IndexConfigs {
+		ic[key] = value
+	}
+	return &registrytypes.ServiceConfig{
+		AllowNondistributableArtifactsCIDRs:     append([]*registrytypes.NetIPNet(nil), config.AllowNondistributableArtifactsCIDRs...),
+		AllowNondistributableArtifactsHostnames: append([]string(nil), config.AllowNondistributableArtifactsHostnames...),
+		InsecureRegistryCIDRs:                   append([]*registrytypes.NetIPNet(nil), config.InsecureRegistryCIDRs...),
+		IndexConfigs:                            ic,
+		Mirrors:                                 append([]string(nil), config.Mirrors...),
+	}
+}
+
 // loadAllowNondistributableArtifacts loads allow-nondistributable-artifacts registries into config.
 func (config *serviceConfig) loadAllowNondistributableArtifacts(registries []string) error {
 	cidrs := map[string]*registry.NetIPNet{}

--- a/registry/config.go
+++ b/registry/config.go
@@ -432,6 +432,11 @@ func ParseRepositoryInfo(reposName reference.Named) (*RepositoryInfo, error) {
 }
 
 // ParseSearchIndexInfo will use repository name to get back an indexInfo.
+//
+// TODO(thaJeztah) this function is only used by the CLI, and used to get
+// information of the registry (to provide credentials if needed). We should
+// move this function (or equivalent) to the CLI, as it's doing too much just
+// for that.
 func ParseSearchIndexInfo(reposName string) (*registrytypes.IndexInfo, error) {
 	indexName, _ := splitReposSearchTerm(reposName)
 

--- a/registry/config.go
+++ b/registry/config.go
@@ -161,11 +161,8 @@ func (config *serviceConfig) LoadMirrors(mirrors []string) error {
 
 // LoadInsecureRegistries loads insecure registries to config
 func (config *serviceConfig) LoadInsecureRegistries(registries []string) error {
-	// Localhost is by default considered as an insecure registry
-	// This is a stop-gap for people who are running a private registry on localhost (especially on Boot2docker).
-	//
-	// TODO: should we deprecate this once it is easier for people to set up a TLS registry or change
-	// daemon flags on boot2docker?
+	// Localhost is by default considered as an insecure registry. This is a
+	// stop-gap for people who are running a private registry on localhost.
 	registries = append(registries, "127.0.0.0/8")
 
 	// Store original InsecureRegistryCIDRs and IndexConfigs

--- a/registry/config.go
+++ b/registry/config.go
@@ -79,21 +79,21 @@ func newServiceConfig(options ServiceOptions) (*serviceConfig, error) {
 			// and Mirrors are only for the official registry anyways.
 		},
 	}
-	if err := config.LoadAllowNondistributableArtifacts(options.AllowNondistributableArtifacts); err != nil {
+	if err := config.loadAllowNondistributableArtifacts(options.AllowNondistributableArtifacts); err != nil {
 		return nil, err
 	}
-	if err := config.LoadMirrors(options.Mirrors); err != nil {
+	if err := config.loadMirrors(options.Mirrors); err != nil {
 		return nil, err
 	}
-	if err := config.LoadInsecureRegistries(options.InsecureRegistries); err != nil {
+	if err := config.loadInsecureRegistries(options.InsecureRegistries); err != nil {
 		return nil, err
 	}
 
 	return config, nil
 }
 
-// LoadAllowNondistributableArtifacts loads allow-nondistributable-artifacts registries into config.
-func (config *serviceConfig) LoadAllowNondistributableArtifacts(registries []string) error {
+// loadAllowNondistributableArtifacts loads allow-nondistributable-artifacts registries into config.
+func (config *serviceConfig) loadAllowNondistributableArtifacts(registries []string) error {
 	cidrs := map[string]*registrytypes.NetIPNet{}
 	hostnames := map[string]bool{}
 
@@ -129,9 +129,9 @@ func (config *serviceConfig) LoadAllowNondistributableArtifacts(registries []str
 	return nil
 }
 
-// LoadMirrors loads mirrors to config, after removing duplicates.
+// loadMirrors loads mirrors to config, after removing duplicates.
 // Returns an error if mirrors contains an invalid mirror.
-func (config *serviceConfig) LoadMirrors(mirrors []string) error {
+func (config *serviceConfig) loadMirrors(mirrors []string) error {
 	mMap := map[string]struct{}{}
 	unique := []string{}
 
@@ -159,8 +159,8 @@ func (config *serviceConfig) LoadMirrors(mirrors []string) error {
 	return nil
 }
 
-// LoadInsecureRegistries loads insecure registries to config
-func (config *serviceConfig) LoadInsecureRegistries(registries []string) error {
+// loadInsecureRegistries loads insecure registries to config
+func (config *serviceConfig) loadInsecureRegistries(registries []string) error {
 	// Localhost is by default considered as an insecure registry. This is a
 	// stop-gap for people who are running a private registry on localhost.
 	registries = append(registries, "127.0.0.0/8")

--- a/registry/config.go
+++ b/registry/config.go
@@ -110,12 +110,12 @@ func (config *serviceConfig) loadAllowNondistributableArtifacts(registries []str
 		}
 	}
 
-	config.AllowNondistributableArtifactsCIDRs = make([]*(registry.NetIPNet), 0)
+	config.AllowNondistributableArtifactsCIDRs = make([]*registry.NetIPNet, 0, len(cidrs))
 	for _, c := range cidrs {
 		config.AllowNondistributableArtifactsCIDRs = append(config.AllowNondistributableArtifactsCIDRs, c)
 	}
 
-	config.AllowNondistributableArtifactsHostnames = make([]string, 0)
+	config.AllowNondistributableArtifactsHostnames = make([]string, 0, len(hostnames))
 	for h := range hostnames {
 		config.AllowNondistributableArtifactsHostnames = append(config.AllowNondistributableArtifactsHostnames, h)
 	}
@@ -378,13 +378,12 @@ func newIndexInfo(config *serviceConfig, indexName string) (*registry.IndexInfo,
 	}
 
 	// Construct a non-configured index info.
-	index := &registry.IndexInfo{
+	return &registry.IndexInfo{
 		Name:     indexName,
 		Mirrors:  make([]string, 0),
+		Secure:   isSecureIndex(config, indexName),
 		Official: false,
-	}
-	index.Secure = isSecureIndex(config, indexName)
-	return index, nil
+	}, nil
 }
 
 // GetAuthConfigKey special-cases using the full index address of the official

--- a/registry/config_test.go
+++ b/registry/config_test.go
@@ -94,7 +94,7 @@ func TestLoadAllowNondistributableArtifacts(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		config := emptyServiceConfig
-		err := config.LoadAllowNondistributableArtifacts(testCase.registries)
+		err := config.loadAllowNondistributableArtifacts(testCase.registries)
 		if testCase.err == "" {
 			if err != nil {
 				t.Fatalf("expect no error, got '%s'", err)
@@ -237,7 +237,7 @@ func TestLoadInsecureRegistries(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		config := emptyServiceConfig
-		err := config.LoadInsecureRegistries(testCase.registries)
+		err := config.loadInsecureRegistries(testCase.registries)
 		if testCase.err == "" {
 			if err != nil {
 				t.Fatalf("expect no error, got '%s'", err)

--- a/registry/config_test.go
+++ b/registry/config_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -255,9 +256,8 @@ func TestLoadInsecureRegistries(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expect error '%s', got no error", testCase.err)
 			}
-			if !strings.Contains(err.Error(), testCase.err) {
-				t.Fatalf("expect error '%s', got '%s'", testCase.err, err)
-			}
+			assert.ErrorContains(t, err, testCase.err)
+			assert.Check(t, errdefs.IsInvalidParameter(err))
 		}
 	}
 }
@@ -313,6 +313,7 @@ func TestNewServiceConfig(t *testing.T) {
 		_, err := newServiceConfig(testCase.opts)
 		if testCase.errStr != "" {
 			assert.Check(t, is.Error(err, testCase.errStr))
+			assert.Check(t, errdefs.IsInvalidParameter(err))
 		} else {
 			assert.Check(t, err)
 		}
@@ -377,5 +378,6 @@ func TestValidateIndexNameWithError(t *testing.T) {
 	for _, testCase := range invalid {
 		_, err := ValidateIndexName(testCase.index)
 		assert.Check(t, is.Error(err, testCase.err))
+		assert.Check(t, errdefs.IsInvalidParameter(err))
 	}
 }

--- a/registry/endpoint_test.go
+++ b/registry/endpoint_test.go
@@ -63,7 +63,7 @@ func TestValidateEndpoint(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testEndpoint := V1Endpoint{
+	testEndpoint := v1Endpoint{
 		URL:    testServerURL,
 		client: httpClient(newTransport(nil)),
 	}

--- a/registry/endpoint_test.go
+++ b/registry/endpoint_test.go
@@ -65,7 +65,7 @@ func TestValidateEndpoint(t *testing.T) {
 
 	testEndpoint := V1Endpoint{
 		URL:    testServerURL,
-		client: HTTPClient(NewTransport(nil)),
+		client: httpClient(newTransport(nil)),
 	}
 
 	if err = validateEndpoint(&testEndpoint); err != nil {

--- a/registry/endpoint_v1.go
+++ b/registry/endpoint_v1.go
@@ -14,16 +14,16 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// V1Endpoint stores basic information about a V1 registry endpoint.
-type V1Endpoint struct {
+// v1Endpoint stores basic information about a V1 registry endpoint.
+type v1Endpoint struct {
 	client   *http.Client
 	URL      *url.URL
 	IsSecure bool
 }
 
-// NewV1Endpoint parses the given address to return a registry endpoint.
+// newV1Endpoint parses the given address to return a registry endpoint.
 // TODO: remove. This is only used by search.
-func NewV1Endpoint(index *registrytypes.IndexInfo, userAgent string, metaHeaders http.Header) (*V1Endpoint, error) {
+func newV1Endpoint(index *registrytypes.IndexInfo, userAgent string, metaHeaders http.Header) (*v1Endpoint, error) {
 	tlsConfig, err := newTLSConfig(index.Name, index.Secure)
 	if err != nil {
 		return nil, err
@@ -42,7 +42,7 @@ func NewV1Endpoint(index *registrytypes.IndexInfo, userAgent string, metaHeaders
 	return endpoint, nil
 }
 
-func validateEndpoint(endpoint *V1Endpoint) error {
+func validateEndpoint(endpoint *v1Endpoint) error {
 	logrus.Debugf("pinging registry endpoint %s", endpoint)
 
 	// Try HTTPS ping to registry
@@ -93,7 +93,7 @@ func trimV1Address(address string) (string, error) {
 	return address, nil
 }
 
-func newV1EndpointFromStr(address string, tlsConfig *tls.Config, userAgent string, metaHeaders http.Header) (*V1Endpoint, error) {
+func newV1EndpointFromStr(address string, tlsConfig *tls.Config, userAgent string, metaHeaders http.Header) (*v1Endpoint, error) {
 	if !strings.HasPrefix(address, "http://") && !strings.HasPrefix(address, "https://") {
 		address = "https://" + address
 	}
@@ -111,7 +111,7 @@ func newV1EndpointFromStr(address string, tlsConfig *tls.Config, userAgent strin
 	// TODO(tiborvass): make sure a ConnectTimeout transport is used
 	tr := newTransport(tlsConfig)
 
-	return &V1Endpoint{
+	return &v1Endpoint{
 		IsSecure: tlsConfig == nil || !tlsConfig.InsecureSkipVerify,
 		URL:      uri,
 		client:   httpClient(transport.NewTransport(tr, Headers(userAgent, metaHeaders)...)),
@@ -119,18 +119,18 @@ func newV1EndpointFromStr(address string, tlsConfig *tls.Config, userAgent strin
 }
 
 // Get the formatted URL for the root of this registry Endpoint
-func (e *V1Endpoint) String() string {
+func (e *v1Endpoint) String() string {
 	return e.URL.String() + "/v1/"
 }
 
 // Path returns a formatted string for the URL
 // of this endpoint with the given path appended.
-func (e *V1Endpoint) Path(path string) string {
+func (e *v1Endpoint) Path(path string) string {
 	return e.URL.String() + "/v1/" + path
 }
 
 // Ping returns a PingResult which indicates whether the registry is standalone or not.
-func (e *V1Endpoint) Ping() (PingResult, error) {
+func (e *v1Endpoint) Ping() (PingResult, error) {
 	if e.String() == IndexServer {
 		// Skip the check, we know this one is valid
 		// (and we never want to fallback to http in case of error)

--- a/registry/endpoint_v1.go
+++ b/registry/endpoint_v1.go
@@ -109,12 +109,12 @@ func newV1EndpointFromStr(address string, tlsConfig *tls.Config, userAgent strin
 	}
 
 	// TODO(tiborvass): make sure a ConnectTimeout transport is used
-	tr := NewTransport(tlsConfig)
+	tr := newTransport(tlsConfig)
 
 	return &V1Endpoint{
 		IsSecure: tlsConfig == nil || !tlsConfig.InsecureSkipVerify,
 		URL:      uri,
-		client:   HTTPClient(transport.NewTransport(tr, Headers(userAgent, metaHeaders)...)),
+		client:   httpClient(transport.NewTransport(tr, Headers(userAgent, metaHeaders)...)),
 	}, nil
 }
 

--- a/registry/endpoint_v1.go
+++ b/registry/endpoint_v1.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/docker/distribution/registry/client/transport"
-	registrytypes "github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/api/types/registry"
 	"github.com/sirupsen/logrus"
 )
 
@@ -35,7 +35,7 @@ type v1Endpoint struct {
 
 // newV1Endpoint parses the given address to return a registry endpoint.
 // TODO: remove. This is only used by search.
-func newV1Endpoint(index *registrytypes.IndexInfo, userAgent string, metaHeaders http.Header) (*v1Endpoint, error) {
+func newV1Endpoint(index *registry.IndexInfo, userAgent string, metaHeaders http.Header) (*v1Endpoint, error) {
 	tlsConfig, err := newTLSConfig(index.Name, index.Secure)
 	if err != nil {
 		return nil, err

--- a/registry/endpoint_v1.go
+++ b/registry/endpoint_v1.go
@@ -67,7 +67,7 @@ func validateEndpoint(endpoint *v1Endpoint) error {
 		}
 
 		// If registry is insecure and HTTPS failed, fallback to HTTP.
-		logrus.Debugf("Error from registry %q marked as insecure: %v. Insecurely falling back to HTTP", endpoint, err)
+		logrus.WithError(err).Debugf("error from registry %q marked as insecure - insecurely falling back to HTTP", endpoint)
 		endpoint.URL.Scheme = "http"
 
 		var err2 error
@@ -84,14 +84,9 @@ func validateEndpoint(endpoint *v1Endpoint) error {
 // trimV1Address trims the version off the address and returns the
 // trimmed address or an error if there is a non-V1 version.
 func trimV1Address(address string) (string, error) {
-	var (
-		chunks        []string
-		apiVersionStr string
-	)
-
 	address = strings.TrimSuffix(address, "/")
-	chunks = strings.Split(address, "/")
-	apiVersionStr = chunks[len(chunks)-1]
+	chunks := strings.Split(address, "/")
+	apiVersionStr := chunks[len(chunks)-1]
 	if apiVersionStr == "v1" {
 		return strings.Join(chunks[:len(chunks)-1], "/"), nil
 	}
@@ -168,7 +163,7 @@ func (e *v1Endpoint) ping() (v1PingResult, error) {
 		Standalone: true,
 	}
 	if err := json.Unmarshal(jsonString, &info); err != nil {
-		logrus.Debugf("Error unmarshaling the _ping v1PingResult: %s", err)
+		logrus.WithError(err).Debug("error unmarshaling _ping response")
 		// don't stop here. Just assume sane defaults
 	}
 	if hdr := resp.Header.Get("X-Docker-Registry-Version"); hdr != "" {

--- a/registry/errors.go
+++ b/registry/errors.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/docker/errdefs"
+	"github.com/pkg/errors"
 )
 
 func translateV2AuthError(err error) error {
@@ -20,4 +21,16 @@ func translateV2AuthError(err error) error {
 	}
 
 	return err
+}
+
+func invalidParam(err error) error {
+	return errdefs.InvalidParameter(err)
+}
+
+func invalidParamf(format string, args ...interface{}) error {
+	return errdefs.InvalidParameter(errors.Errorf(format, args...))
+}
+
+func invalidParamWrapf(err error, format string, args ...interface{}) error {
+	return errdefs.InvalidParameter(errors.Wrapf(err, format, args...))
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -16,13 +16,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// HostCertsDir returns the config directory for a specific host
-func HostCertsDir(hostname string) (string, error) {
-	certsDir := CertsDir()
-
-	hostDir := filepath.Join(certsDir, cleanPath(hostname))
-
-	return hostDir, nil
+// HostCertsDir returns the config directory for a specific host.
+func HostCertsDir(hostname string) string {
+	return filepath.Join(CertsDir(), cleanPath(hostname))
 }
 
 func newTLSConfig(hostname string, isSecure bool) (*tls.Config, error) {
@@ -32,11 +28,7 @@ func newTLSConfig(hostname string, isSecure bool) (*tls.Config, error) {
 	tlsConfig.InsecureSkipVerify = !isSecure
 
 	if isSecure && CertsDir() != "" {
-		hostDir, err := HostCertsDir(hostname)
-		if err != nil {
-			return nil, err
-		}
-
+		hostDir := HostCertsDir(hostname)
 		logrus.Debugf("hostDir: %s", hostDir)
 		if err := ReadCertsDirectory(tlsConfig, hostDir); err != nil {
 			return nil, err

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -120,9 +120,9 @@ func Headers(userAgent string, metaHeaders http.Header) []transport.RequestModif
 	return modifiers
 }
 
-// HTTPClient returns an HTTP client structure which uses the given transport
+// httpClient returns an HTTP client structure which uses the given transport
 // and contains the necessary headers for redirected requests
-func HTTPClient(transport http.RoundTripper) *http.Client {
+func httpClient(transport http.RoundTripper) *http.Client {
 	return &http.Client{
 		Transport:     transport,
 		CheckRedirect: addRequiredHeadersToRedirectedRequests,
@@ -165,9 +165,9 @@ func addRequiredHeadersToRedirectedRequests(req *http.Request, via []*http.Reque
 	return nil
 }
 
-// NewTransport returns a new HTTP transport. If tlsConfig is nil, it uses the
+// newTransport returns a new HTTP transport. If tlsConfig is nil, it uses the
 // default TLS configuration.
-func NewTransport(tlsConfig *tls.Config) *http.Transport {
+func newTransport(tlsConfig *tls.Config) *http.Transport {
 	if tlsConfig == nil {
 		tlsConfig = tlsconfig.ServerDefault()
 	}
@@ -177,7 +177,7 @@ func NewTransport(tlsConfig *tls.Config) *http.Transport {
 		KeepAlive: 30 * time.Second,
 	}
 
-	base := &http.Transport{
+	return &http.Transport{
 		Proxy:               http.ProxyFromEnvironment,
 		DialContext:         direct.DialContext,
 		TLSHandshakeTimeout: 10 * time.Second,
@@ -185,6 +185,4 @@ func NewTransport(tlsConfig *tls.Config) *http.Transport {
 		// TODO(dmcgowan): Call close idle connections when complete and use keep alive
 		DisableKeepAlives: true,
 	}
-
-	return base
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -20,6 +20,7 @@ func HostCertsDir(hostname string) string {
 	return filepath.Join(CertsDir(), cleanPath(hostname))
 }
 
+// newTLSConfig constructs a client TLS configuration based on server defaults
 func newTLSConfig(hostname string, isSecure bool) (*tls.Config, error) {
 	// PreferredServerCipherSuites should have no effect
 	tlsConfig := tlsconfig.ServerDefault()

--- a/registry/registry_mock_test.go
+++ b/registry/registry_mock_test.go
@@ -9,7 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	registrytypes "github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/api/types/registry"
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 	"gotest.tools/v3/assert"
@@ -75,22 +75,22 @@ func makeHTTPSURL(req string) string {
 	return testHTTPSServer.URL + req
 }
 
-func makeIndex(req string) *registrytypes.IndexInfo {
-	index := &registrytypes.IndexInfo{
+func makeIndex(req string) *registry.IndexInfo {
+	index := &registry.IndexInfo{
 		Name: makeURL(req),
 	}
 	return index
 }
 
-func makeHTTPSIndex(req string) *registrytypes.IndexInfo {
-	index := &registrytypes.IndexInfo{
+func makeHTTPSIndex(req string) *registry.IndexInfo {
+	index := &registry.IndexInfo{
 		Name: makeHTTPSURL(req),
 	}
 	return index
 }
 
-func makePublicIndex() *registrytypes.IndexInfo {
-	index := &registrytypes.IndexInfo{
+func makePublicIndex() *registry.IndexInfo {
+	index := &registry.IndexInfo{
 		Name:     IndexServer,
 		Secure:   true,
 		Official: true,
@@ -134,10 +134,10 @@ func handlerGetPing(w http.ResponseWriter, r *http.Request) {
 }
 
 func handlerSearch(w http.ResponseWriter, r *http.Request) {
-	result := &registrytypes.SearchResults{
+	result := &registry.SearchResults{
 		Query:      "fakequery",
 		NumResults: 1,
-		Results:    []registrytypes.SearchResult{{Name: "fakeimage", StarCount: 42}},
+		Results:    []registry.SearchResult{{Name: "fakeimage", StarCount: 42}},
 	}
 	writeResponse(w, result, http.StatusOK)
 }

--- a/registry/registry_mock_test.go
+++ b/registry/registry_mock_test.go
@@ -3,93 +3,21 @@ package registry // import "github.com/docker/docker/registry"
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
-	"strconv"
-	"strings"
 	"testing"
-	"time"
 
-	"github.com/docker/distribution/reference"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/gorilla/mux"
-
 	"github.com/sirupsen/logrus"
+	"gotest.tools/v3/assert"
 )
 
 var (
 	testHTTPServer  *httptest.Server
 	testHTTPSServer *httptest.Server
-	testLayers      = map[string]map[string]string{
-		"77dbf71da1d00e3fbddc480176eac8994025630c6590d11cfc8fe1209c2a1d20": {
-			"json": `{"id":"77dbf71da1d00e3fbddc480176eac8994025630c6590d11cfc8fe1209c2a1d20",
-				"comment":"test base image","created":"2013-03-23T12:53:11.10432-07:00",
-				"container_config":{"Hostname":"","User":"","Memory":0,"MemorySwap":0,
-				"CpuShares":0,"AttachStdin":false,"AttachStdout":false,"AttachStderr":false,
-				"Tty":false,"OpenStdin":false,"StdinOnce":false,
-				"Env":null,"Cmd":null,"Dns":null,"Image":"","Volumes":null,
-				"VolumesFrom":"","Entrypoint":null},"Size":424242}`,
-			"checksum_simple": "sha256:1ac330d56e05eef6d438586545ceff7550d3bdcb6b19961f12c5ba714ee1bb37",
-			"checksum_tarsum": "tarsum+sha256:4409a0685741ca86d38df878ed6f8cbba4c99de5dc73cd71aef04be3bb70be7c",
-			"ancestry":        `["77dbf71da1d00e3fbddc480176eac8994025630c6590d11cfc8fe1209c2a1d20"]`,
-			"layer": string([]byte{
-				0x1f, 0x8b, 0x08, 0x08, 0x0e, 0xb0, 0xee, 0x51, 0x02, 0x03, 0x6c, 0x61, 0x79, 0x65,
-				0x72, 0x2e, 0x74, 0x61, 0x72, 0x00, 0xed, 0xd2, 0x31, 0x0e, 0xc2, 0x30, 0x0c, 0x05,
-				0x50, 0xcf, 0x9c, 0xc2, 0x27, 0x48, 0xed, 0x38, 0x4e, 0xce, 0x13, 0x44, 0x2b, 0x66,
-				0x62, 0x24, 0x8e, 0x4f, 0xa0, 0x15, 0x63, 0xb6, 0x20, 0x21, 0xfc, 0x96, 0xbf, 0x78,
-				0xb0, 0xf5, 0x1d, 0x16, 0x98, 0x8e, 0x88, 0x8a, 0x2a, 0xbe, 0x33, 0xef, 0x49, 0x31,
-				0xed, 0x79, 0x40, 0x8e, 0x5c, 0x44, 0x85, 0x88, 0x33, 0x12, 0x73, 0x2c, 0x02, 0xa8,
-				0xf0, 0x05, 0xf7, 0x66, 0xf5, 0xd6, 0x57, 0x69, 0xd7, 0x7a, 0x19, 0xcd, 0xf5, 0xb1,
-				0x6d, 0x1b, 0x1f, 0xf9, 0xba, 0xe3, 0x93, 0x3f, 0x22, 0x2c, 0xb6, 0x36, 0x0b, 0xf6,
-				0xb0, 0xa9, 0xfd, 0xe7, 0x94, 0x46, 0xfd, 0xeb, 0xd1, 0x7f, 0x2c, 0xc4, 0xd2, 0xfb,
-				0x97, 0xfe, 0x02, 0x80, 0xe4, 0xfd, 0x4f, 0x77, 0xae, 0x6d, 0x3d, 0x81, 0x73, 0xce,
-				0xb9, 0x7f, 0xf3, 0x04, 0x41, 0xc1, 0xab, 0xc6, 0x00, 0x0a, 0x00, 0x00,
-			}),
-		},
-		"42d718c941f5c532ac049bf0b0ab53f0062f09a03afd4aa4a02c098e46032b9d": {
-			"json": `{"id":"42d718c941f5c532ac049bf0b0ab53f0062f09a03afd4aa4a02c098e46032b9d",
-				"parent":"77dbf71da1d00e3fbddc480176eac8994025630c6590d11cfc8fe1209c2a1d20",
-				"comment":"test base image","created":"2013-03-23T12:55:11.10432-07:00",
-				"container_config":{"Hostname":"","User":"","Memory":0,"MemorySwap":0,
-				"CpuShares":0,"AttachStdin":false,"AttachStdout":false,"AttachStderr":false,
-				"Tty":false,"OpenStdin":false,"StdinOnce":false,
-				"Env":null,"Cmd":null,"Dns":null,"Image":"","Volumes":null,
-				"VolumesFrom":"","Entrypoint":null},"Size":424242}`,
-			"checksum_simple": "sha256:bea7bf2e4bacd479344b737328db47b18880d09096e6674165533aa994f5e9f2",
-			"checksum_tarsum": "tarsum+sha256:68fdb56fb364f074eec2c9b3f85ca175329c4dcabc4a6a452b7272aa613a07a2",
-			"ancestry": `["42d718c941f5c532ac049bf0b0ab53f0062f09a03afd4aa4a02c098e46032b9d",
-				"77dbf71da1d00e3fbddc480176eac8994025630c6590d11cfc8fe1209c2a1d20"]`,
-			"layer": string([]byte{
-				0x1f, 0x8b, 0x08, 0x08, 0xbd, 0xb3, 0xee, 0x51, 0x02, 0x03, 0x6c, 0x61, 0x79, 0x65,
-				0x72, 0x2e, 0x74, 0x61, 0x72, 0x00, 0xed, 0xd1, 0x31, 0x0e, 0xc2, 0x30, 0x0c, 0x05,
-				0x50, 0xcf, 0x9c, 0xc2, 0x27, 0x48, 0x9d, 0x38, 0x8e, 0xcf, 0x53, 0x51, 0xaa, 0x56,
-				0xea, 0x44, 0x82, 0xc4, 0xf1, 0x09, 0xb4, 0xea, 0x98, 0x2d, 0x48, 0x08, 0xbf, 0xe5,
-				0x2f, 0x1e, 0xfc, 0xf5, 0xdd, 0x00, 0xdd, 0x11, 0x91, 0x8a, 0xe0, 0x27, 0xd3, 0x9e,
-				0x14, 0xe2, 0x9e, 0x07, 0xf4, 0xc1, 0x2b, 0x0b, 0xfb, 0xa4, 0x82, 0xe4, 0x3d, 0x93,
-				0x02, 0x0a, 0x7c, 0xc1, 0x23, 0x97, 0xf1, 0x5e, 0x5f, 0xc9, 0xcb, 0x38, 0xb5, 0xee,
-				0xea, 0xd9, 0x3c, 0xb7, 0x4b, 0xbe, 0x7b, 0x9c, 0xf9, 0x23, 0xdc, 0x50, 0x6e, 0xb9,
-				0xb8, 0xf2, 0x2c, 0x5d, 0xf7, 0x4f, 0x31, 0xb6, 0xf6, 0x4f, 0xc7, 0xfe, 0x41, 0x55,
-				0x63, 0xdd, 0x9f, 0x89, 0x09, 0x90, 0x6c, 0xff, 0xee, 0xae, 0xcb, 0xba, 0x4d, 0x17,
-				0x30, 0xc6, 0x18, 0xf3, 0x67, 0x5e, 0xc1, 0xed, 0x21, 0x5d, 0x00, 0x0a, 0x00, 0x00,
-			}),
-		},
-	}
-	testRepositories = map[string]map[string]string{
-		"foo42/bar": {
-			"latest": "42d718c941f5c532ac049bf0b0ab53f0062f09a03afd4aa4a02c098e46032b9d",
-			"test":   "42d718c941f5c532ac049bf0b0ab53f0062f09a03afd4aa4a02c098e46032b9d",
-		},
-	}
-	mockHosts = map[string][]net.IP{
-		"":            {net.ParseIP("0.0.0.0")},
-		"localhost":   {net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
-		"example.com": {net.ParseIP("42.42.42.42")},
-		"other.com":   {net.ParseIP("43.43.43.43")},
-	}
 )
 
 func init() {
@@ -97,14 +25,6 @@ func init() {
 
 	// /v1/
 	r.HandleFunc("/v1/_ping", handlerGetPing).Methods(http.MethodGet)
-	r.HandleFunc("/v1/images/{image_id:[^/]+}/{action:json|layer|ancestry}", handlerGetImage).Methods(http.MethodGet)
-	r.HandleFunc("/v1/images/{image_id:[^/]+}/{action:json|layer|checksum}", handlerPutImage).Methods(http.MethodPut)
-	r.HandleFunc("/v1/repositories/{repository:.+}/tags", handlerGetDeleteTags).Methods(http.MethodGet, http.MethodDelete)
-	r.HandleFunc("/v1/repositories/{repository:.+}/tags/{tag:.+}", handlerGetTag).Methods(http.MethodGet)
-	r.HandleFunc("/v1/repositories/{repository:.+}/tags/{tag:.+}", handlerPutTag).Methods(http.MethodPut)
-	r.HandleFunc("/v1/users{null:.*}", handlerUsers).Methods(http.MethodGet, http.MethodPost, http.MethodPut)
-	r.HandleFunc("/v1/repositories/{repository:.+}{action:/images|/}", handlerImages).Methods(http.MethodGet, http.MethodPut, http.MethodDelete)
-	r.HandleFunc("/v1/repositories/{repository:.+}/auth", handlerAuth).Methods(http.MethodPut)
 	r.HandleFunc("/v1/search", handlerSearch).Methods(http.MethodGet)
 
 	// /v2/
@@ -118,6 +38,12 @@ func init() {
 		if host == "127.0.0.1" {
 			// I believe in future Go versions this will fail, so let's fix it later
 			return net.LookupIP(host)
+		}
+		mockHosts := map[string][]net.IP{
+			"":            {net.ParseIP("0.0.0.0")},
+			"localhost":   {net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+			"example.com": {net.ParseIP("42.42.42.42")},
+			"other.com":   {net.ParseIP("43.43.43.43")},
 		}
 		for h, addrs := range mockHosts {
 			if host == h {
@@ -135,7 +61,7 @@ func init() {
 
 func handlerAccessLog(handler http.Handler) http.Handler {
 	logHandler := func(w http.ResponseWriter, r *http.Request) {
-		logrus.Debugf("%s \"%s %s\"", r.RemoteAddr, r.Method, r.URL)
+		logrus.Debugf(`%s "%s %s"`, r.RemoteAddr, r.Method, r.URL)
 		handler.ServeHTTP(w, r)
 	}
 	return http.HandlerFunc(logHandler)
@@ -203,245 +129,8 @@ func writeResponse(w http.ResponseWriter, message interface{}, code int) {
 	w.Write(body)
 }
 
-func readJSON(r *http.Request, dest interface{}) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(body, dest)
-}
-
-func apiError(w http.ResponseWriter, message string, code int) {
-	body := map[string]string{
-		"error": message,
-	}
-	writeResponse(w, body, code)
-}
-
-func assertEqual(t *testing.T, a interface{}, b interface{}, message string) {
-	if a == b {
-		return
-	}
-	if len(message) == 0 {
-		message = fmt.Sprintf("%v != %v", a, b)
-	}
-	t.Fatal(message)
-}
-
-func assertNotEqual(t *testing.T, a interface{}, b interface{}, message string) {
-	if a != b {
-		return
-	}
-	if len(message) == 0 {
-		message = fmt.Sprintf("%v == %v", a, b)
-	}
-	t.Fatal(message)
-}
-
-// Similar to assertEqual, but does not stop test
-func checkEqual(t *testing.T, a interface{}, b interface{}, messagePrefix string) {
-	if a == b {
-		return
-	}
-	message := fmt.Sprintf("%v != %v", a, b)
-	if len(messagePrefix) != 0 {
-		message = messagePrefix + ": " + message
-	}
-	t.Error(message)
-}
-
-// Similar to assertNotEqual, but does not stop test
-func checkNotEqual(t *testing.T, a interface{}, b interface{}, messagePrefix string) {
-	if a != b {
-		return
-	}
-	message := fmt.Sprintf("%v == %v", a, b)
-	if len(messagePrefix) != 0 {
-		message = messagePrefix + ": " + message
-	}
-	t.Error(message)
-}
-
-func requiresAuth(w http.ResponseWriter, r *http.Request) bool {
-	writeCookie := func() {
-		value := fmt.Sprintf("FAKE-SESSION-%d", time.Now().UnixNano())
-		cookie := &http.Cookie{Name: "session", Value: value, MaxAge: 3600}
-		http.SetCookie(w, cookie)
-		// FIXME(sam): this should be sent only on Index routes
-		value = fmt.Sprintf("FAKE-TOKEN-%d", time.Now().UnixNano())
-		w.Header().Add("X-Docker-Token", value)
-	}
-	if len(r.Cookies()) > 0 {
-		writeCookie()
-		return true
-	}
-	if len(r.Header.Get("Authorization")) > 0 {
-		writeCookie()
-		return true
-	}
-	w.Header().Add("WWW-Authenticate", "token")
-	apiError(w, "Wrong auth", http.StatusUnauthorized)
-	return false
-}
-
 func handlerGetPing(w http.ResponseWriter, r *http.Request) {
 	writeResponse(w, true, http.StatusOK)
-}
-
-func handlerGetImage(w http.ResponseWriter, r *http.Request) {
-	if !requiresAuth(w, r) {
-		return
-	}
-	vars := mux.Vars(r)
-	layer, exists := testLayers[vars["image_id"]]
-	if !exists {
-		http.NotFound(w, r)
-		return
-	}
-	writeHeaders(w)
-	layerSize := len(layer["layer"])
-	w.Header().Add("X-Docker-Size", strconv.Itoa(layerSize))
-	io.WriteString(w, layer[vars["action"]])
-}
-
-func handlerPutImage(w http.ResponseWriter, r *http.Request) {
-	if !requiresAuth(w, r) {
-		return
-	}
-	vars := mux.Vars(r)
-	imageID := vars["image_id"]
-	action := vars["action"]
-	layer, exists := testLayers[imageID]
-	if !exists {
-		if action != "json" {
-			http.NotFound(w, r)
-			return
-		}
-		layer = make(map[string]string)
-		testLayers[imageID] = layer
-	}
-	if checksum := r.Header.Get("X-Docker-Checksum"); checksum != "" {
-		if checksum != layer["checksum_simple"] && checksum != layer["checksum_tarsum"] {
-			apiError(w, "Wrong checksum", http.StatusBadRequest)
-			return
-		}
-	}
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		apiError(w, fmt.Sprintf("Error: %s", err), http.StatusInternalServerError)
-		return
-	}
-	layer[action] = string(body)
-	writeResponse(w, true, http.StatusOK)
-}
-
-func handlerGetDeleteTags(w http.ResponseWriter, r *http.Request) {
-	if !requiresAuth(w, r) {
-		return
-	}
-	repositoryName, err := reference.WithName(mux.Vars(r)["repository"])
-	if err != nil {
-		apiError(w, "Could not parse repository", http.StatusBadRequest)
-		return
-	}
-	tags, exists := testRepositories[repositoryName.String()]
-	if !exists {
-		apiError(w, "Repository not found", http.StatusNotFound)
-		return
-	}
-	if r.Method == http.MethodDelete {
-		delete(testRepositories, repositoryName.String())
-		writeResponse(w, true, http.StatusOK)
-		return
-	}
-	writeResponse(w, tags, http.StatusOK)
-}
-
-func handlerGetTag(w http.ResponseWriter, r *http.Request) {
-	if !requiresAuth(w, r) {
-		return
-	}
-	vars := mux.Vars(r)
-	repositoryName, err := reference.WithName(vars["repository"])
-	if err != nil {
-		apiError(w, "Could not parse repository", http.StatusBadRequest)
-		return
-	}
-	tagName := vars["tag"]
-	tags, exists := testRepositories[repositoryName.String()]
-	if !exists {
-		apiError(w, "Repository not found", http.StatusNotFound)
-		return
-	}
-	tag, exists := tags[tagName]
-	if !exists {
-		apiError(w, "Tag not found", http.StatusNotFound)
-		return
-	}
-	writeResponse(w, tag, http.StatusOK)
-}
-
-func handlerPutTag(w http.ResponseWriter, r *http.Request) {
-	if !requiresAuth(w, r) {
-		return
-	}
-	vars := mux.Vars(r)
-	repositoryName, err := reference.WithName(vars["repository"])
-	if err != nil {
-		apiError(w, "Could not parse repository", http.StatusBadRequest)
-		return
-	}
-	tagName := vars["tag"]
-	tags, exists := testRepositories[repositoryName.String()]
-	if !exists {
-		tags = make(map[string]string)
-		testRepositories[repositoryName.String()] = tags
-	}
-	tagValue := ""
-	readJSON(r, tagValue)
-	tags[tagName] = tagValue
-	writeResponse(w, true, http.StatusOK)
-}
-
-func handlerUsers(w http.ResponseWriter, r *http.Request) {
-	code := http.StatusOK
-	if r.Method == http.MethodPost {
-		code = http.StatusCreated
-	} else if r.Method == http.MethodPut {
-		code = http.StatusNoContent
-	}
-	writeResponse(w, "", code)
-}
-
-func handlerImages(w http.ResponseWriter, r *http.Request) {
-	u, _ := url.Parse(testHTTPServer.URL)
-	w.Header().Add("X-Docker-Endpoints", fmt.Sprintf("%s 	,  %s ", u.Host, "test.example.com"))
-	w.Header().Add("X-Docker-Token", fmt.Sprintf("FAKE-SESSION-%d", time.Now().UnixNano()))
-	if r.Method == http.MethodPut {
-		if strings.HasSuffix(r.URL.Path, "images") {
-			writeResponse(w, "", http.StatusNoContent)
-			return
-		}
-		writeResponse(w, "", http.StatusOK)
-		return
-	}
-	if r.Method == http.MethodDelete {
-		writeResponse(w, "", http.StatusNoContent)
-		return
-	}
-	var images []map[string]string
-	for imageID, layer := range testLayers {
-		image := make(map[string]string)
-		image["id"] = imageID
-		image["checksum"] = layer["checksum_tarsum"]
-		image["Tag"] = "latest"
-		images = append(images, image)
-	}
-	writeResponse(w, images, http.StatusOK)
-}
-
-func handlerAuth(w http.ResponseWriter, r *http.Request) {
-	writeResponse(w, "OK", http.StatusOK)
 }
 
 func handlerSearch(w http.ResponseWriter, r *http.Request) {
@@ -458,18 +147,6 @@ func TestPing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assertEqual(t, res.StatusCode, http.StatusOK, "")
-	assertEqual(t, res.Header.Get("X-Docker-Registry-Config"), "mock",
-		"This is not a Mocked Registry")
+	assert.Equal(t, res.StatusCode, http.StatusOK, "")
+	assert.Equal(t, res.Header.Get("X-Docker-Registry-Config"), "mock", "This is not a Mocked Registry")
 }
-
-/* Uncomment this to test Mocked Registry locally with curl
- * WARNING: Don't push on the repos uncommented, it'll block the tests
- *
-func TestWait(t *testing.T) {
-	logrus.Println("Test HTTP server ready and waiting:", testHTTPServer.URL)
-	c := make(chan int)
-	<-c
-}
-
-//*/

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -51,7 +51,7 @@ func TestPingRegistryEndpoint(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		regInfo, err := ep.Ping()
+		regInfo, err := ep.ping()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -519,7 +519,7 @@ func TestMirrorEndpointLookup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s := DefaultService{config: cfg}
+	s := defaultService{config: cfg}
 
 	imageName, err := reference.WithName(IndexName + "/test/image")
 	if err != nil {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -18,7 +18,7 @@ import (
 
 func spawnTestRegistrySession(t *testing.T) *Session {
 	authConfig := &types.AuthConfig{}
-	endpoint, err := NewV1Endpoint(makeIndex("/v1/"), "", nil)
+	endpoint, err := newV1Endpoint(makeIndex("/v1/"), "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func spawnTestRegistrySession(t *testing.T) *Session {
 func TestPingRegistryEndpoint(t *testing.T) {
 	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 	testPing := func(index *registrytypes.IndexInfo, expectedStandalone bool, assertMessage string) {
-		ep, err := NewV1Endpoint(index, "", nil)
+		ep, err := newV1Endpoint(index, "", nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -67,8 +67,8 @@ func TestPingRegistryEndpoint(t *testing.T) {
 func TestEndpoint(t *testing.T) {
 	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 	// Simple wrapper to fail test if err != nil
-	expandEndpoint := func(index *registrytypes.IndexInfo) *V1Endpoint {
-		endpoint, err := NewV1Endpoint(index, "", nil)
+	expandEndpoint := func(index *registrytypes.IndexInfo) *v1Endpoint {
+		endpoint, err := newV1Endpoint(index, "", nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -77,14 +77,14 @@ func TestEndpoint(t *testing.T) {
 
 	assertInsecureIndex := func(index *registrytypes.IndexInfo) {
 		index.Secure = true
-		_, err := NewV1Endpoint(index, "", nil)
+		_, err := newV1Endpoint(index, "", nil)
 		assert.ErrorContains(t, err, "insecure-registry", index.Name+": Expected insecure-registry  error for insecure index")
 		index.Secure = false
 	}
 
 	assertSecureIndex := func(index *registrytypes.IndexInfo) {
 		index.Secure = true
-		_, err := NewV1Endpoint(index, "", nil)
+		_, err := newV1Endpoint(index, "", nil)
 		assert.ErrorContains(t, err, "certificate signed by unknown authority", index.Name+": Expected cert error for secure index")
 		index.Secure = false
 	}
@@ -131,7 +131,7 @@ func TestEndpoint(t *testing.T) {
 	}
 	for _, address := range badEndpoints {
 		index.Name = address
-		_, err := NewV1Endpoint(index, "", nil)
+		_, err := newV1Endpoint(index, "", nil)
 		assert.Check(t, err != nil, "Expected error while expanding bad endpoint: %s", address)
 	}
 }

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -660,7 +660,7 @@ func TestAllowNondistributableArtifacts(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		if v := allowNondistributableArtifacts(config, tt.addr); v != tt.expected {
+		if v := config.allowNondistributableArtifacts(tt.addr); v != tt.expected {
 			t.Errorf("allowNondistributableArtifacts failed for %q %v, expected %v got %v", tt.addr, tt.registries, tt.expected, v)
 		}
 	}
@@ -703,7 +703,7 @@ func TestIsSecureIndex(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		if sec := isSecureIndex(config, tt.addr); sec != tt.expected {
+		if sec := config.isSecureIndex(tt.addr); sec != tt.expected {
 			t.Errorf("isSecureIndex failed for %q %v, expected %v got %v", tt.addr, tt.insecureRegistries, tt.expected, sec)
 		}
 	}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -23,9 +23,9 @@ func spawnTestRegistrySession(t *testing.T) *Session {
 		t.Fatal(err)
 	}
 	userAgent := "docker test client"
-	var tr http.RoundTripper = debugTransport{NewTransport(nil), t.Log}
+	var tr http.RoundTripper = debugTransport{newTransport(nil), t.Log}
 	tr = transport.NewTransport(AuthTransport(tr, authConfig, false), Headers(userAgent, nil)...)
-	client := HTTPClient(tr)
+	client := httpClient(tr)
 	r, err := NewSession(client, authConfig, endpoint)
 	if err != nil {
 		t.Fatal(err)

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/api/types"
-	registrytypes "github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/api/types/registry"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
@@ -48,7 +48,7 @@ func spawnTestRegistrySession(t *testing.T) *session {
 
 func TestPingRegistryEndpoint(t *testing.T) {
 	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
-	testPing := func(index *registrytypes.IndexInfo, expectedStandalone bool, assertMessage string) {
+	testPing := func(index *registry.IndexInfo, expectedStandalone bool, assertMessage string) {
 		ep, err := newV1Endpoint(index, "", nil)
 		if err != nil {
 			t.Fatal(err)
@@ -69,7 +69,7 @@ func TestPingRegistryEndpoint(t *testing.T) {
 func TestEndpoint(t *testing.T) {
 	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 	// Simple wrapper to fail test if err != nil
-	expandEndpoint := func(index *registrytypes.IndexInfo) *v1Endpoint {
+	expandEndpoint := func(index *registry.IndexInfo) *v1Endpoint {
 		endpoint, err := newV1Endpoint(index, "", nil)
 		if err != nil {
 			t.Fatal(err)
@@ -77,21 +77,21 @@ func TestEndpoint(t *testing.T) {
 		return endpoint
 	}
 
-	assertInsecureIndex := func(index *registrytypes.IndexInfo) {
+	assertInsecureIndex := func(index *registry.IndexInfo) {
 		index.Secure = true
 		_, err := newV1Endpoint(index, "", nil)
 		assert.ErrorContains(t, err, "insecure-registry", index.Name+": Expected insecure-registry  error for insecure index")
 		index.Secure = false
 	}
 
-	assertSecureIndex := func(index *registrytypes.IndexInfo) {
+	assertSecureIndex := func(index *registry.IndexInfo) {
 		index.Secure = true
 		_, err := newV1Endpoint(index, "", nil)
 		assert.ErrorContains(t, err, "certificate signed by unknown authority", index.Name+": Expected cert error for secure index")
 		index.Secure = false
 	}
 
-	index := &registrytypes.IndexInfo{}
+	index := &registry.IndexInfo{}
 	index.Name = makeURL("/v1/")
 	endpoint := expandEndpoint(index)
 	assert.Equal(t, endpoint.String(), index.Name, "Expected endpoint to be "+index.Name)
@@ -140,7 +140,7 @@ func TestEndpoint(t *testing.T) {
 
 func TestParseRepositoryInfo(t *testing.T) {
 	type staticRepositoryInfo struct {
-		Index         *registrytypes.IndexInfo
+		Index         *registry.IndexInfo
 		RemoteName    string
 		CanonicalName string
 		LocalName     string
@@ -149,7 +149,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 
 	expectedRepoInfos := map[string]staticRepositoryInfo{
 		"fooo/bar": {
-			Index: &registrytypes.IndexInfo{
+			Index: &registry.IndexInfo{
 				Name:     IndexName,
 				Official: true,
 			},
@@ -159,7 +159,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"library/ubuntu": {
-			Index: &registrytypes.IndexInfo{
+			Index: &registry.IndexInfo{
 				Name:     IndexName,
 				Official: true,
 			},
@@ -169,7 +169,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      true,
 		},
 		"nonlibrary/ubuntu": {
-			Index: &registrytypes.IndexInfo{
+			Index: &registry.IndexInfo{
 				Name:     IndexName,
 				Official: true,
 			},
@@ -179,7 +179,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"ubuntu": {
-			Index: &registrytypes.IndexInfo{
+			Index: &registry.IndexInfo{
 				Name:     IndexName,
 				Official: true,
 			},
@@ -189,7 +189,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      true,
 		},
 		"other/library": {
-			Index: &registrytypes.IndexInfo{
+			Index: &registry.IndexInfo{
 				Name:     IndexName,
 				Official: true,
 			},
@@ -199,7 +199,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"127.0.0.1:8000/private/moonbase": {
-			Index: &registrytypes.IndexInfo{
+			Index: &registry.IndexInfo{
 				Name:     "127.0.0.1:8000",
 				Official: false,
 			},
@@ -209,7 +209,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"127.0.0.1:8000/privatebase": {
-			Index: &registrytypes.IndexInfo{
+			Index: &registry.IndexInfo{
 				Name:     "127.0.0.1:8000",
 				Official: false,
 			},
@@ -219,7 +219,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"localhost:8000/private/moonbase": {
-			Index: &registrytypes.IndexInfo{
+			Index: &registry.IndexInfo{
 				Name:     "localhost:8000",
 				Official: false,
 			},
@@ -229,7 +229,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"localhost:8000/privatebase": {
-			Index: &registrytypes.IndexInfo{
+			Index: &registry.IndexInfo{
 				Name:     "localhost:8000",
 				Official: false,
 			},
@@ -239,7 +239,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"example.com/private/moonbase": {
-			Index: &registrytypes.IndexInfo{
+			Index: &registry.IndexInfo{
 				Name:     "example.com",
 				Official: false,
 			},
@@ -249,7 +249,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"example.com/privatebase": {
-			Index: &registrytypes.IndexInfo{
+			Index: &registry.IndexInfo{
 				Name:     "example.com",
 				Official: false,
 			},
@@ -259,7 +259,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"example.com:8000/private/moonbase": {
-			Index: &registrytypes.IndexInfo{
+			Index: &registry.IndexInfo{
 				Name:     "example.com:8000",
 				Official: false,
 			},
@@ -269,7 +269,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"example.com:8000/privatebase": {
-			Index: &registrytypes.IndexInfo{
+			Index: &registry.IndexInfo{
 				Name:     "example.com:8000",
 				Official: false,
 			},
@@ -279,7 +279,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"localhost/private/moonbase": {
-			Index: &registrytypes.IndexInfo{
+			Index: &registry.IndexInfo{
 				Name:     "localhost",
 				Official: false,
 			},
@@ -289,7 +289,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"localhost/privatebase": {
-			Index: &registrytypes.IndexInfo{
+			Index: &registry.IndexInfo{
 				Name:     "localhost",
 				Official: false,
 			},
@@ -299,7 +299,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		IndexName + "/public/moonbase": {
-			Index: &registrytypes.IndexInfo{
+			Index: &registry.IndexInfo{
 				Name:     IndexName,
 				Official: true,
 			},
@@ -309,7 +309,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"index." + IndexName + "/public/moonbase": {
-			Index: &registrytypes.IndexInfo{
+			Index: &registry.IndexInfo{
 				Name:     IndexName,
 				Official: true,
 			},
@@ -319,7 +319,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"ubuntu-12.04-base": {
-			Index: &registrytypes.IndexInfo{
+			Index: &registry.IndexInfo{
 				Name:     IndexName,
 				Official: true,
 			},
@@ -329,7 +329,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      true,
 		},
 		IndexName + "/ubuntu-12.04-base": {
-			Index: &registrytypes.IndexInfo{
+			Index: &registry.IndexInfo{
 				Name:     IndexName,
 				Official: true,
 			},
@@ -339,7 +339,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      true,
 		},
 		"index." + IndexName + "/ubuntu-12.04-base": {
-			Index: &registrytypes.IndexInfo{
+			Index: &registry.IndexInfo{
 				Name:     IndexName,
 				Official: true,
 			},
@@ -371,7 +371,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 }
 
 func TestNewIndexInfo(t *testing.T) {
-	testIndexInfo := func(config *serviceConfig, expectedIndexInfos map[string]*registrytypes.IndexInfo) {
+	testIndexInfo := func(config *serviceConfig, expectedIndexInfos map[string]*registry.IndexInfo) {
 		for indexName, expectedIndexInfo := range expectedIndexInfos {
 			index, err := newIndexInfo(config, indexName)
 			if err != nil {
@@ -387,7 +387,7 @@ func TestNewIndexInfo(t *testing.T) {
 
 	config := emptyServiceConfig
 	var noMirrors []string
-	expectedIndexInfos := map[string]*registrytypes.IndexInfo{
+	expectedIndexInfos := map[string]*registry.IndexInfo{
 		IndexName: {
 			Name:     IndexName,
 			Official: true,
@@ -422,7 +422,7 @@ func TestNewIndexInfo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedIndexInfos = map[string]*registrytypes.IndexInfo{
+	expectedIndexInfos = map[string]*registry.IndexInfo{
 		IndexName: {
 			Name:     IndexName,
 			Official: true,
@@ -472,7 +472,7 @@ func TestNewIndexInfo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedIndexInfos = map[string]*registrytypes.IndexInfo{
+	expectedIndexInfos = map[string]*registry.IndexInfo{
 		"example.com": {
 			Name:     "example.com",
 			Official: false,

--- a/registry/service.go
+++ b/registry/service.go
@@ -224,7 +224,7 @@ type APIEndpoint struct {
 // TLSConfig constructs a client TLS configuration based on server defaults
 func (s *defaultService) TLSConfig(hostname string) (*tls.Config, error) {
 	s.mu.RLock()
-	secure := isSecureIndex(s.config, hostname)
+	secure := s.config.isSecureIndex(hostname)
 	s.mu.RUnlock()
 
 	return newTLSConfig(hostname, secure)

--- a/registry/service.go
+++ b/registry/service.go
@@ -161,8 +161,8 @@ func splitReposSearchTerm(reposName string) (string, string) {
 // search terms, and returns the results.
 func (s *defaultService) Search(ctx context.Context, term string, limit int, authConfig *types.AuthConfig, userAgent string, headers map[string][]string) (*registrytypes.SearchResults, error) {
 	// TODO Use ctx when searching for repositories
-	if err := validateNoScheme(term); err != nil {
-		return nil, err
+	if hasScheme(term) {
+		return nil, errors.New(`invalid repository name (ex: "registry.domain.tld/myrepos")`)
 	}
 
 	indexName, remoteName := splitReposSearchTerm(term)

--- a/registry/service.go
+++ b/registry/service.go
@@ -218,7 +218,7 @@ func (s *DefaultService) Search(ctx context.Context, term string, limit int, aut
 		}
 	}
 
-	r := newSession(client, authConfig, endpoint)
+	r := newSession(client, endpoint)
 
 	if index.Official {
 		// If pull "library/foo", it's stored locally under "foo"

--- a/registry/service.go
+++ b/registry/service.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -117,7 +116,7 @@ func (s *defaultService) Auth(ctx context.Context, authConfig *types.AuthConfig,
 		}
 		u, err := url.Parse(serverAddress)
 		if err != nil {
-			return "", "", errdefs.InvalidParameter(errors.Errorf("unable to parse server address: %v", err))
+			return "", "", invalidParamWrapf(err, "unable to parse server address")
 		}
 		registryHostName = u.Host
 	}
@@ -127,7 +126,7 @@ func (s *defaultService) Auth(ctx context.Context, authConfig *types.AuthConfig,
 	// to a mirror.
 	endpoints, err := s.LookupPushEndpoints(registryHostName)
 	if err != nil {
-		return "", "", errdefs.InvalidParameter(err)
+		return "", "", invalidParam(err)
 	}
 
 	for _, endpoint := range endpoints {
@@ -162,7 +161,7 @@ func splitReposSearchTerm(reposName string) (string, string) {
 func (s *defaultService) Search(ctx context.Context, term string, limit int, authConfig *types.AuthConfig, userAgent string, headers map[string][]string) (*registrytypes.SearchResults, error) {
 	// TODO Use ctx when searching for repositories
 	if hasScheme(term) {
-		return nil, errors.New(`invalid repository name (ex: "registry.domain.tld/myrepos")`)
+		return nil, invalidParamf("invalid repository name: repository name (%s) should not have a scheme", term)
 	}
 
 	indexName, remoteName := splitReposSearchTerm(term)

--- a/registry/service.go
+++ b/registry/service.go
@@ -36,23 +36,23 @@ type Service interface {
 	LoadInsecureRegistries([]string) error
 }
 
-// DefaultService is a registry service. It tracks configuration data such as a list
+// defaultService is a registry service. It tracks configuration data such as a list
 // of mirrors.
-type DefaultService struct {
+type defaultService struct {
 	config *serviceConfig
 	mu     sync.Mutex
 }
 
-// NewService returns a new instance of DefaultService ready to be
+// NewService returns a new instance of defaultService ready to be
 // installed into an engine.
-func NewService(options ServiceOptions) (*DefaultService, error) {
+func NewService(options ServiceOptions) (Service, error) {
 	config, err := newServiceConfig(options)
 
-	return &DefaultService{config: config}, err
+	return &defaultService{config: config}, err
 }
 
 // ServiceConfig returns the public registry service configuration.
-func (s *DefaultService) ServiceConfig() *registrytypes.ServiceConfig {
+func (s *defaultService) ServiceConfig() *registrytypes.ServiceConfig {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -80,7 +80,7 @@ func (s *DefaultService) ServiceConfig() *registrytypes.ServiceConfig {
 }
 
 // LoadAllowNondistributableArtifacts loads allow-nondistributable-artifacts registries for Service.
-func (s *DefaultService) LoadAllowNondistributableArtifacts(registries []string) error {
+func (s *defaultService) LoadAllowNondistributableArtifacts(registries []string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -88,7 +88,7 @@ func (s *DefaultService) LoadAllowNondistributableArtifacts(registries []string)
 }
 
 // LoadMirrors loads registry mirrors for Service
-func (s *DefaultService) LoadMirrors(mirrors []string) error {
+func (s *defaultService) LoadMirrors(mirrors []string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -96,7 +96,7 @@ func (s *DefaultService) LoadMirrors(mirrors []string) error {
 }
 
 // LoadInsecureRegistries loads insecure registries for Service
-func (s *DefaultService) LoadInsecureRegistries(registries []string) error {
+func (s *defaultService) LoadInsecureRegistries(registries []string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -106,7 +106,7 @@ func (s *DefaultService) LoadInsecureRegistries(registries []string) error {
 // Auth contacts the public registry with the provided credentials,
 // and returns OK if authentication was successful.
 // It can be used to verify the validity of a client's credentials.
-func (s *DefaultService) Auth(ctx context.Context, authConfig *types.AuthConfig, userAgent string) (status, token string, err error) {
+func (s *defaultService) Auth(ctx context.Context, authConfig *types.AuthConfig, userAgent string) (status, token string, err error) {
 	// TODO Use ctx when searching for repositories
 	var registryHostName = IndexHostname
 
@@ -159,7 +159,7 @@ func splitReposSearchTerm(reposName string) (string, string) {
 
 // Search queries the public registry for images matching the specified
 // search terms, and returns the results.
-func (s *DefaultService) Search(ctx context.Context, term string, limit int, authConfig *types.AuthConfig, userAgent string, headers map[string][]string) (*registrytypes.SearchResults, error) {
+func (s *defaultService) Search(ctx context.Context, term string, limit int, authConfig *types.AuthConfig, userAgent string, headers map[string][]string) (*registrytypes.SearchResults, error) {
 	// TODO Use ctx when searching for repositories
 	if err := validateNoScheme(term); err != nil {
 		return nil, err
@@ -229,7 +229,7 @@ func (s *DefaultService) Search(ctx context.Context, term string, limit int, aut
 
 // ResolveRepository splits a repository name into its components
 // and configuration of the associated registry.
-func (s *DefaultService) ResolveRepository(name reference.Named) (*RepositoryInfo, error) {
+func (s *defaultService) ResolveRepository(name reference.Named) (*RepositoryInfo, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return newRepositoryInfo(s.config, name)
@@ -247,7 +247,7 @@ type APIEndpoint struct {
 }
 
 // TLSConfig constructs a client TLS configuration based on server defaults
-func (s *DefaultService) TLSConfig(hostname string) (*tls.Config, error) {
+func (s *defaultService) TLSConfig(hostname string) (*tls.Config, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -255,13 +255,13 @@ func (s *DefaultService) TLSConfig(hostname string) (*tls.Config, error) {
 }
 
 // tlsConfig constructs a client TLS configuration based on server defaults
-func (s *DefaultService) tlsConfig(hostname string) (*tls.Config, error) {
+func (s *defaultService) tlsConfig(hostname string) (*tls.Config, error) {
 	return newTLSConfig(hostname, isSecureIndex(s.config, hostname))
 }
 
 // LookupPullEndpoints creates a list of v2 endpoints to try to pull from, in order of preference.
 // It gives preference to mirrors over the actual registry, and HTTPS over plain HTTP.
-func (s *DefaultService) LookupPullEndpoints(hostname string) (endpoints []APIEndpoint, err error) {
+func (s *defaultService) LookupPullEndpoints(hostname string) (endpoints []APIEndpoint, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -270,7 +270,7 @@ func (s *DefaultService) LookupPullEndpoints(hostname string) (endpoints []APIEn
 
 // LookupPushEndpoints creates a list of v2 endpoints to try to push to, in order of preference.
 // It gives preference to HTTPS over plain HTTP. Mirrors are not included.
-func (s *DefaultService) LookupPushEndpoints(hostname string) (endpoints []APIEndpoint, err error) {
+func (s *defaultService) LookupPushEndpoints(hostname string) (endpoints []APIEndpoint, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/registry/service.go
+++ b/registry/service.go
@@ -177,7 +177,7 @@ func (s *defaultService) Search(ctx context.Context, term string, limit int, aut
 	}
 
 	// *TODO: Search multiple indexes.
-	endpoint, err := NewV1Endpoint(index, userAgent, headers)
+	endpoint, err := newV1Endpoint(index, userAgent, headers)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/service.go
+++ b/registry/service.go
@@ -224,7 +224,7 @@ func (s *defaultService) Search(ctx context.Context, term string, limit int, aut
 		// If pull "library/foo", it's stored locally under "foo"
 		remoteName = strings.TrimPrefix(remoteName, "library/")
 	}
-	return r.SearchRepositories(remoteName, limit)
+	return r.searchRepositories(remoteName, limit)
 }
 
 // ResolveRepository splits a repository name into its components

--- a/registry/service.go
+++ b/registry/service.go
@@ -84,7 +84,7 @@ func (s *defaultService) LoadAllowNondistributableArtifacts(registries []string)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return s.config.LoadAllowNondistributableArtifacts(registries)
+	return s.config.loadAllowNondistributableArtifacts(registries)
 }
 
 // LoadMirrors loads registry mirrors for Service
@@ -92,7 +92,7 @@ func (s *defaultService) LoadMirrors(mirrors []string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return s.config.LoadMirrors(mirrors)
+	return s.config.loadMirrors(mirrors)
 }
 
 // LoadInsecureRegistries loads insecure registries for Service
@@ -100,7 +100,7 @@ func (s *defaultService) LoadInsecureRegistries(registries []string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return s.config.LoadInsecureRegistries(registries)
+	return s.config.loadInsecureRegistries(registries)
 }
 
 // Auth contacts the public registry with the provided credentials,

--- a/registry/service.go
+++ b/registry/service.go
@@ -50,32 +50,11 @@ func NewService(options ServiceOptions) (Service, error) {
 	return &defaultService{config: config}, err
 }
 
-// ServiceConfig returns the public registry service configuration.
+// ServiceConfig returns a copy of the public registry service's configuration.
 func (s *defaultService) ServiceConfig() *registry.ServiceConfig {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-
-	servConfig := registry.ServiceConfig{
-		AllowNondistributableArtifactsCIDRs:     make([]*(registry.NetIPNet), 0),
-		AllowNondistributableArtifactsHostnames: make([]string, 0),
-		InsecureRegistryCIDRs:                   make([]*(registry.NetIPNet), 0),
-		IndexConfigs:                            make(map[string]*(registry.IndexInfo)),
-		Mirrors:                                 make([]string, 0),
-	}
-
-	// construct a new ServiceConfig which will not retrieve s.Config directly,
-	// and look up items in s.config with mu locked
-	servConfig.AllowNondistributableArtifactsCIDRs = append(servConfig.AllowNondistributableArtifactsCIDRs, s.config.ServiceConfig.AllowNondistributableArtifactsCIDRs...)
-	servConfig.AllowNondistributableArtifactsHostnames = append(servConfig.AllowNondistributableArtifactsHostnames, s.config.ServiceConfig.AllowNondistributableArtifactsHostnames...)
-	servConfig.InsecureRegistryCIDRs = append(servConfig.InsecureRegistryCIDRs, s.config.ServiceConfig.InsecureRegistryCIDRs...)
-
-	for key, value := range s.config.ServiceConfig.IndexConfigs {
-		servConfig.IndexConfigs[key] = value
-	}
-
-	servConfig.Mirrors = append(servConfig.Mirrors, s.config.ServiceConfig.Mirrors...)
-
-	return &servConfig
+	return s.config.copy()
 }
 
 // LoadAllowNondistributableArtifacts loads allow-nondistributable-artifacts registries for Service.

--- a/registry/service.go
+++ b/registry/service.go
@@ -11,7 +11,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/docker/api/types"
-	registrytypes "github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/errdefs"
 	"github.com/sirupsen/logrus"
 )
@@ -27,8 +27,8 @@ type Service interface {
 	LookupPullEndpoints(hostname string) (endpoints []APIEndpoint, err error)
 	LookupPushEndpoints(hostname string) (endpoints []APIEndpoint, err error)
 	ResolveRepository(name reference.Named) (*RepositoryInfo, error)
-	Search(ctx context.Context, term string, limit int, authConfig *types.AuthConfig, userAgent string, headers map[string][]string) (*registrytypes.SearchResults, error)
-	ServiceConfig() *registrytypes.ServiceConfig
+	Search(ctx context.Context, term string, limit int, authConfig *types.AuthConfig, userAgent string, headers map[string][]string) (*registry.SearchResults, error)
+	ServiceConfig() *registry.ServiceConfig
 	TLSConfig(hostname string) (*tls.Config, error)
 	LoadAllowNondistributableArtifacts([]string) error
 	LoadMirrors([]string) error
@@ -51,15 +51,15 @@ func NewService(options ServiceOptions) (Service, error) {
 }
 
 // ServiceConfig returns the public registry service configuration.
-func (s *defaultService) ServiceConfig() *registrytypes.ServiceConfig {
+func (s *defaultService) ServiceConfig() *registry.ServiceConfig {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	servConfig := registrytypes.ServiceConfig{
-		AllowNondistributableArtifactsCIDRs:     make([]*(registrytypes.NetIPNet), 0),
+	servConfig := registry.ServiceConfig{
+		AllowNondistributableArtifactsCIDRs:     make([]*(registry.NetIPNet), 0),
 		AllowNondistributableArtifactsHostnames: make([]string, 0),
-		InsecureRegistryCIDRs:                   make([]*(registrytypes.NetIPNet), 0),
-		IndexConfigs:                            make(map[string]*(registrytypes.IndexInfo)),
+		InsecureRegistryCIDRs:                   make([]*(registry.NetIPNet), 0),
+		IndexConfigs:                            make(map[string]*(registry.IndexInfo)),
 		Mirrors:                                 make([]string, 0),
 	}
 
@@ -158,7 +158,7 @@ func splitReposSearchTerm(reposName string) (string, string) {
 
 // Search queries the public registry for images matching the specified
 // search terms, and returns the results.
-func (s *defaultService) Search(ctx context.Context, term string, limit int, authConfig *types.AuthConfig, userAgent string, headers map[string][]string) (*registrytypes.SearchResults, error) {
+func (s *defaultService) Search(ctx context.Context, term string, limit int, authConfig *types.AuthConfig, userAgent string, headers map[string][]string) (*registry.SearchResults, error) {
 	// TODO Use ctx when searching for repositories
 	if hasScheme(term) {
 		return nil, invalidParamf("invalid repository name: repository name (%s) should not have a scheme", term)

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -16,7 +16,7 @@ func (s *defaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndp
 			}
 			mirrorURL, err := url.Parse(mirror)
 			if err != nil {
-				return nil, err
+				return nil, invalidParam(err)
 			}
 			mirrorTLSConfig, err := s.tlsConfig(mirrorURL.Host)
 			if err != nil {

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -7,7 +7,7 @@ import (
 	"github.com/docker/go-connections/tlsconfig"
 )
 
-func (s *DefaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, err error) {
+func (s *defaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, err error) {
 	tlsConfig := tlsconfig.ServerDefault()
 	if hostname == DefaultNamespace || hostname == IndexHostname {
 		for _, mirror := range s.config.Mirrors {

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -17,7 +17,7 @@ func (s *defaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndp
 			if err != nil {
 				return nil, invalidParam(err)
 			}
-			mirrorTLSConfig, err := newTLSConfig(mirrorURL.Host, isSecureIndex(s.config, mirrorURL.Host))
+			mirrorTLSConfig, err := newTLSConfig(mirrorURL.Host, s.config.isSecureIndex(mirrorURL.Host))
 			if err != nil {
 				return nil, err
 			}
@@ -40,12 +40,12 @@ func (s *defaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndp
 		return endpoints, nil
 	}
 
-	tlsConfig, err := newTLSConfig(hostname, isSecureIndex(s.config, hostname))
+	tlsConfig, err := newTLSConfig(hostname, s.config.isSecureIndex(hostname))
 	if err != nil {
 		return nil, err
 	}
 
-	ana := allowNondistributableArtifacts(s.config, hostname)
+	ana := s.config.allowNondistributableArtifacts(hostname)
 	endpoints = []APIEndpoint{
 		{
 			URL: &url.URL{

--- a/registry/session.go
+++ b/registry/session.go
@@ -169,7 +169,7 @@ func authorizeClient(client *http.Client, authConfig *types.AuthConfig, endpoint
 
 	jar, err := cookiejar.New(nil)
 	if err != nil {
-		return errors.New("cookiejar.New is not supposed to return an error")
+		return errdefs.System(errors.New("cookiejar.New is not supposed to return an error"))
 	}
 	client.Jar = jar
 
@@ -187,14 +187,14 @@ func newSession(client *http.Client, endpoint *v1Endpoint) *session {
 // searchRepositories performs a search against the remote repository
 func (r *session) searchRepositories(term string, limit int) (*registrytypes.SearchResults, error) {
 	if limit < 1 || limit > 100 {
-		return nil, errdefs.InvalidParameter(errors.Errorf("Limit %d is outside the range of [1, 100]", limit))
+		return nil, invalidParamf("limit %d is outside the range of [1, 100]", limit)
 	}
 	logrus.Debugf("Index server: %s", r.indexEndpoint)
 	u := r.indexEndpoint.String() + "search?q=" + url.QueryEscape(term) + "&n=" + url.QueryEscape(fmt.Sprintf("%d", limit))
 
 	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
-		return nil, errors.Wrap(errdefs.InvalidParameter(err), "Error building request")
+		return nil, invalidParamWrapf(err, "error building request")
 	}
 	// Have the AuthTransport send authentication, when logged in.
 	req.Header.Set("X-Docker-Token", "true")

--- a/registry/session.go
+++ b/registry/session.go
@@ -23,7 +23,7 @@ import (
 
 // A Session is used to communicate with a V1 registry
 type Session struct {
-	indexEndpoint *V1Endpoint
+	indexEndpoint *v1Endpoint
 	client        *http.Client
 	id            string
 }
@@ -147,7 +147,7 @@ func (tr *authTransport) CancelRequest(req *http.Request) {
 	}
 }
 
-func authorizeClient(client *http.Client, authConfig *types.AuthConfig, endpoint *V1Endpoint) error {
+func authorizeClient(client *http.Client, authConfig *types.AuthConfig, endpoint *v1Endpoint) error {
 	var alwaysSetBasicAuth bool
 
 	// If we're working with a standalone private registry over HTTPS, send Basic Auth headers
@@ -176,7 +176,7 @@ func authorizeClient(client *http.Client, authConfig *types.AuthConfig, endpoint
 	return nil
 }
 
-func newSession(client *http.Client, endpoint *V1Endpoint) *Session {
+func newSession(client *http.Client, endpoint *v1Endpoint) *Session {
 	return &Session{
 		client:        client,
 		indexEndpoint: endpoint,
@@ -186,7 +186,7 @@ func newSession(client *http.Client, endpoint *V1Endpoint) *Session {
 
 // NewSession creates a new session
 // TODO(tiborvass): remove authConfig param once registry client v2 is vendored
-func NewSession(client *http.Client, authConfig *types.AuthConfig, endpoint *V1Endpoint) (*Session, error) {
+func NewSession(client *http.Client, authConfig *types.AuthConfig, endpoint *v1Endpoint) (*Session, error) {
 	if err := authorizeClient(client, authConfig, endpoint); err != nil {
 		return nil, err
 	}

--- a/registry/session.go
+++ b/registry/session.go
@@ -153,7 +153,7 @@ func authorizeClient(client *http.Client, authConfig *types.AuthConfig, endpoint
 	// If we're working with a standalone private registry over HTTPS, send Basic Auth headers
 	// alongside all our requests.
 	if endpoint.String() != IndexServer && endpoint.URL.Scheme == "https" {
-		info, err := endpoint.Ping()
+		info, err := endpoint.ping()
 		if err != nil {
 			return err
 		}

--- a/registry/session.go
+++ b/registry/session.go
@@ -21,8 +21,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// A Session is used to communicate with a V1 registry
-type Session struct {
+// A session is used to communicate with a V1 registry
+type session struct {
 	indexEndpoint *v1Endpoint
 	client        *http.Client
 	id            string
@@ -176,26 +176,16 @@ func authorizeClient(client *http.Client, authConfig *types.AuthConfig, endpoint
 	return nil
 }
 
-func newSession(client *http.Client, endpoint *v1Endpoint) *Session {
-	return &Session{
+func newSession(client *http.Client, endpoint *v1Endpoint) *session {
+	return &session{
 		client:        client,
 		indexEndpoint: endpoint,
 		id:            stringid.GenerateRandomID(),
 	}
 }
 
-// NewSession creates a new session
-// TODO(tiborvass): remove authConfig param once registry client v2 is vendored
-func NewSession(client *http.Client, authConfig *types.AuthConfig, endpoint *v1Endpoint) (*Session, error) {
-	if err := authorizeClient(client, authConfig, endpoint); err != nil {
-		return nil, err
-	}
-
-	return newSession(client, endpoint), nil
-}
-
-// SearchRepositories performs a search against the remote repository
-func (r *Session) SearchRepositories(term string, limit int) (*registrytypes.SearchResults, error) {
+// searchRepositories performs a search against the remote repository
+func (r *session) searchRepositories(term string, limit int) (*registrytypes.SearchResults, error) {
 	if limit < 1 || limit > 100 {
 		return nil, errdefs.InvalidParameter(errors.Errorf("Limit %d is outside the range of [1, 100]", limit))
 	}

--- a/registry/session.go
+++ b/registry/session.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 
 	"github.com/docker/docker/api/types"
-	registrytypes "github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -185,7 +185,7 @@ func newSession(client *http.Client, endpoint *v1Endpoint) *session {
 }
 
 // searchRepositories performs a search against the remote repository
-func (r *session) searchRepositories(term string, limit int) (*registrytypes.SearchResults, error) {
+func (r *session) searchRepositories(term string, limit int) (*registry.SearchResults, error) {
 	if limit < 1 || limit > 100 {
 		return nil, invalidParamf("limit %d is outside the range of [1, 100]", limit)
 	}
@@ -209,6 +209,6 @@ func (r *session) searchRepositories(term string, limit int) (*registrytypes.Sea
 			Code:    res.StatusCode,
 		}
 	}
-	result := new(registrytypes.SearchResults)
+	result := new(registry.SearchResults)
 	return result, errors.Wrap(json.NewDecoder(res.Body).Decode(result), "error decoding registry search results")
 }

--- a/registry/session.go
+++ b/registry/session.go
@@ -25,9 +25,7 @@ import (
 type Session struct {
 	indexEndpoint *V1Endpoint
 	client        *http.Client
-	// TODO(tiborvass): remove authConfig
-	authConfig *types.AuthConfig
-	id         string
+	id            string
 }
 
 type authTransport struct {
@@ -178,9 +176,8 @@ func authorizeClient(client *http.Client, authConfig *types.AuthConfig, endpoint
 	return nil
 }
 
-func newSession(client *http.Client, authConfig *types.AuthConfig, endpoint *V1Endpoint) *Session {
+func newSession(client *http.Client, endpoint *V1Endpoint) *Session {
 	return &Session{
-		authConfig:    authConfig,
 		client:        client,
 		indexEndpoint: endpoint,
 		id:            stringid.GenerateRandomID(),
@@ -194,7 +191,7 @@ func NewSession(client *http.Client, authConfig *types.AuthConfig, endpoint *V1E
 		return nil, err
 	}
 
-	return newSession(client, authConfig, endpoint), nil
+	return newSession(client, endpoint), nil
 }
 
 // SearchRepositories performs a search against the remote repository

--- a/registry/types.go
+++ b/registry/types.go
@@ -5,23 +5,6 @@ import (
 	registrytypes "github.com/docker/docker/api/types/registry"
 )
 
-// RepositoryData tracks the image list, list of endpoints for a repository
-type RepositoryData struct {
-	// ImgList is a list of images in the repository
-	ImgList map[string]*ImgData
-	// Endpoints is a list of endpoints returned in X-Docker-Endpoints
-	Endpoints []string
-}
-
-// ImgData is used to transfer image checksums to and from the registry
-type ImgData struct {
-	// ID is an opaque string that identifies the image
-	ID              string `json:"id"`
-	Checksum        string `json:"checksum,omitempty"`
-	ChecksumPayload string `json:"-"`
-	Tag             string `json:",omitempty"`
-}
-
 // PingResult contains the information returned when pinging a registry. It
 // indicates the registry's version and whether the registry claims to be a
 // standalone registry.

--- a/registry/types.go
+++ b/registry/types.go
@@ -5,19 +5,6 @@ import (
 	registrytypes "github.com/docker/docker/api/types/registry"
 )
 
-// PingResult contains the information returned when pinging a registry. It
-// indicates the registry's version and whether the registry claims to be a
-// standalone registry.
-type PingResult struct {
-	// Version is the registry version supplied by the registry in an HTTP
-	// header
-	Version string `json:"version"`
-	// Standalone is set to true if the registry indicates it is a
-	// standalone registry in the X-Docker-Registry-Standalone
-	// header
-	Standalone bool `json:"standalone"`
-}
-
 // APIVersion is an integral representation of an API version (presently
 // either 1 or 2)
 type APIVersion int

--- a/registry/types.go
+++ b/registry/types.go
@@ -2,7 +2,7 @@ package registry // import "github.com/docker/docker/registry"
 
 import (
 	"github.com/docker/distribution/reference"
-	registrytypes "github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/api/types/registry"
 )
 
 // APIVersion is an integral representation of an API version (presently
@@ -28,7 +28,7 @@ var apiVersions = map[APIVersion]string{
 type RepositoryInfo struct {
 	Name reference.Named
 	// Index points to registry information
-	Index *registrytypes.IndexInfo
+	Index *registry.IndexInfo
 	// Official indicates whether the repository is considered official.
 	// If the registry is official, and the normalized name does not
 	// contain a '/' (e.g. "foo"), then it is considered an official repo.


### PR DESCRIPTION
This is a follow-up to https://github.com/moby/moby/pull/43183

The registry had a large "public" API, large parts of which were related to previous support of both V1 and V2 registries, and (no longer) used. This pull request reduces the public API of this package, and removes un-used bits (as well as general code cleanup, and some improvements around locking).

More changes will have to be done after this; this package is currently used both for registry interactions (push/pull) as well as to provide "search" (to back the `docker search` command). Searching was part of the V1 registry spec, but not part of the OCI distribution spec v2, however, is still provided by Docker Hub (and could be implemented by private/custom registries). Docker Hub already provides newer search APIs (V2 and V3), which are proprietary (but providing API docs is on the roadmap), and we may want to switch to those APIs at some point (to be decided wether that should be through the daemon, or a pure client-side implementation).

That said, we should (at least for now) preserve the functionality to use V1 search  (for backward compatibility, and to allow search for private/custom registries), but should separate the search code out from the main registry package.

This PR is a stepping-stone for that; making more code "private", and reducing  this package's public API will make it easier to refactor, and gives a clearer picture of "what's used" and what not.

Here's the "before" and "after" of the package's public API 

```bash
GO111MODULE=off godoc -http=localhost:6060

# then visit : http://localhost:6060/pkg/github.com/docker/docker/registry/
```

### before

<img width="1233" alt="before" src="https://user-images.githubusercontent.com/1804568/155883111-dc494847-76f4-4e3d-a891-ae13dc7ed63e.png">

### after

<img width="829" alt="after" src="https://user-images.githubusercontent.com/1804568/155883115-24796480-8b03-4ba5-b5b1-cf8b0fd06187.png">



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

