### PR TITLE
api: remove deprecated RootFS.BaseLayer from type and docs

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1713,10 +1713,6 @@ definitions:
             example:
               - "sha256:1834950e52ce4d5a88a1bbd131c537f4d0e56d10ff0dd69e66be3b7dfa9df7e6"
               - "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
-          BaseLayer:
-            type: "string"
-            x-nullable: true
-            example: ""
       Metadata:
         description: |
           Additional metadata of the image in the local cache. This information

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -19,9 +19,8 @@ import (
 
 // RootFS returns Image's RootFS description including the layer IDs.
 type RootFS struct {
-	Type      string
-	Layers    []string `json:",omitempty"`
-	BaseLayer string   `json:",omitempty"`
+	Type   string   `json:",omitempty"`
+	Layers []string `json:",omitempty"`
 }
 
 // ImageInspect contains response of Engine API:

--- a/docs/api/v1.25.yaml
+++ b/docs/api/v1.25.yaml
@@ -889,8 +889,6 @@ definitions:
             type: "array"
             items:
               type: "string"
-          BaseLayer:
-            type: "string"
 
   ImageSummary:
     type: "object"

--- a/docs/api/v1.26.yaml
+++ b/docs/api/v1.26.yaml
@@ -890,8 +890,6 @@ definitions:
             type: "array"
             items:
               type: "string"
-          BaseLayer:
-            type: "string"
 
   ImageSummary:
     type: "object"

--- a/docs/api/v1.27.yaml
+++ b/docs/api/v1.27.yaml
@@ -896,8 +896,6 @@ definitions:
             type: "array"
             items:
               type: "string"
-          BaseLayer:
-            type: "string"
 
   ImageSummary:
     type: "object"

--- a/docs/api/v1.28.yaml
+++ b/docs/api/v1.28.yaml
@@ -935,8 +935,6 @@ definitions:
             type: "array"
             items:
               type: "string"
-          BaseLayer:
-            type: "string"
 
   ImageSummary:
     type: "object"

--- a/docs/api/v1.29.yaml
+++ b/docs/api/v1.29.yaml
@@ -942,8 +942,6 @@ definitions:
             type: "array"
             items:
               type: "string"
-          BaseLayer:
-            type: "string"
 
   ImageSummary:
     type: "object"

--- a/docs/api/v1.30.yaml
+++ b/docs/api/v1.30.yaml
@@ -945,8 +945,6 @@ definitions:
             type: "array"
             items:
               type: "string"
-          BaseLayer:
-            type: "string"
 
   ImageSummary:
     type: "object"

--- a/docs/api/v1.31.yaml
+++ b/docs/api/v1.31.yaml
@@ -946,8 +946,6 @@ definitions:
             type: "array"
             items:
               type: "string"
-          BaseLayer:
-            type: "string"
       Metadata:
         type: "object"
         properties:

--- a/docs/api/v1.32.yaml
+++ b/docs/api/v1.32.yaml
@@ -1204,8 +1204,6 @@ definitions:
             type: "array"
             items:
               type: "string"
-          BaseLayer:
-            type: "string"
       Metadata:
         type: "object"
         properties:

--- a/docs/api/v1.33.yaml
+++ b/docs/api/v1.33.yaml
@@ -1209,8 +1209,6 @@ definitions:
             type: "array"
             items:
               type: "string"
-          BaseLayer:
-            type: "string"
       Metadata:
         type: "object"
         properties:

--- a/docs/api/v1.34.yaml
+++ b/docs/api/v1.34.yaml
@@ -1220,8 +1220,6 @@ definitions:
             type: "array"
             items:
               type: "string"
-          BaseLayer:
-            type: "string"
       Metadata:
         type: "object"
         properties:

--- a/docs/api/v1.35.yaml
+++ b/docs/api/v1.35.yaml
@@ -1196,8 +1196,6 @@ definitions:
             type: "array"
             items:
               type: "string"
-          BaseLayer:
-            type: "string"
       Metadata:
         type: "object"
         properties:

--- a/docs/api/v1.36.yaml
+++ b/docs/api/v1.36.yaml
@@ -1196,8 +1196,6 @@ definitions:
             type: "array"
             items:
               type: "string"
-          BaseLayer:
-            type: "string"
       Metadata:
         type: "object"
         properties:

--- a/docs/api/v1.37.yaml
+++ b/docs/api/v1.37.yaml
@@ -1199,8 +1199,6 @@ definitions:
             type: "array"
             items:
               type: "string"
-          BaseLayer:
-            type: "string"
       Metadata:
         type: "object"
         properties:

--- a/docs/api/v1.38.yaml
+++ b/docs/api/v1.38.yaml
@@ -1210,8 +1210,6 @@ definitions:
             type: "array"
             items:
               type: "string"
-          BaseLayer:
-            type: "string"
       Metadata:
         type: "object"
         properties:

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -1620,10 +1620,6 @@ definitions:
             example:
               - "sha256:1834950e52ce4d5a88a1bbd131c537f4d0e56d10ff0dd69e66be3b7dfa9df7e6"
               - "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
-          BaseLayer:
-            type: "string"
-            x-nullable: true
-            example: ""
       Metadata:
         description: |
           Additional metadata of the image in the local cache. This information

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -1681,10 +1681,6 @@ definitions:
             example:
               - "sha256:1834950e52ce4d5a88a1bbd131c537f4d0e56d10ff0dd69e66be3b7dfa9df7e6"
               - "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
-          BaseLayer:
-            type: "string"
-            x-nullable: true
-            example: ""
       Metadata:
         description: |
           Additional metadata of the image in the local cache. This information

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -1713,10 +1713,6 @@ definitions:
             example:
               - "sha256:1834950e52ce4d5a88a1bbd131c537f4d0e56d10ff0dd69e66be3b7dfa9df7e6"
               - "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
-          BaseLayer:
-            type: "string"
-            x-nullable: true
-            example: ""
       Metadata:
         description: |
           Additional metadata of the image in the local cache. This information

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -384,6 +384,10 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `GET /version` now returns `MinAPIVersion`.
 * `POST /build` accepts `networkmode` parameter to specify network used during build.
 * `GET /images/(name)/json` now returns `OsVersion` if populated
+* `GET /images/(name)/json` no longer contains the `RootFS.BaseLayer` field. This
+  field was used for Windows images that used a base-image that was pre-installed
+  on the host (`RootFS.Type` `layers+base`), which is no longer supported, and
+  the `RootFS.BaseLayer` field has been removed.
 * `GET /info` now returns `Isolation`.
 * `POST /containers/create` now takes `AutoRemove` in HostConfig, to enable auto-removal of the container on daemon side when the container's process exits.
 * `GET /containers/json` and `GET /containers/(id or name)/json` now return `"removing"` as a value for the `State.Status` field if the container is being removed. Previously, "exited" was returned as status.


### PR DESCRIPTION
follow-up to https://github.com/moby/moby/pull/43300 (keeping it separate for visibility)

This field was used when Windows did not yet support regular images, and required
the base-image to pre-exist on the Windows machine (as those layers were not yet
allowed to be distributed).

Commit f342b27145d8f5af27cd5de1501551af275e899b (https://github.com/moby/moby/pull/25090) (docker 1.13.0, API v1.25) removed
usage of the field. The field was not documented in the API, but because it was not
removed from the Golang structs in the API, ended up in the API documentation when
we switched to using Swagger instead of plain MarkDown for the API docs.

Given that the field was never set in any of these API versions, and had an "omitempty",
it was never actually returned in a response, so should be fine to remove from these
API docs.
