### PR TITLE
daemon: SystemInfo() extract collecting data to more helper functions

### DIFF
--- a/daemon/auth.go
+++ b/daemon/auth.go
@@ -9,5 +9,5 @@ import (
 
 // AuthenticateToRegistry checks the validity of credentials in authConfig
 func (daemon *Daemon) AuthenticateToRegistry(ctx context.Context, authConfig *types.AuthConfig) (string, string, error) {
-	return daemon.RegistryService.Auth(ctx, authConfig, dockerversion.DockerUserAgent(ctx))
+	return daemon.registryService.Auth(ctx, authConfig, dockerversion.DockerUserAgent(ctx))
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -78,7 +78,7 @@ var (
 
 // Daemon holds information about the Docker daemon.
 type Daemon struct {
-	ID                    string
+	id                    string
 	repository            string
 	containers            container.Store
 	containersReplica     container.ViewDB
@@ -88,7 +88,7 @@ type Daemon struct {
 	configStore           *config.Config
 	statsCollector        *stats.Collector
 	defaultLogConfig      containertypes.LogConfig
-	RegistryService       registry.Service
+	registryService       registry.Service
 	EventsService         *events.Events
 	netController         libnetwork.NetworkController
 	volumes               *volumesservice.VolumesService
@@ -852,7 +852,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		}
 	}
 
-	d.RegistryService = registryService
+	d.registryService = registryService
 	logger.RegisterPluginGetter(d.PluginStore)
 
 	metricsSockPath, err := d.listenMetricsSock()
@@ -1021,7 +1021,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		return nil, errors.New("Devices cgroup isn't mounted")
 	}
 
-	d.ID = trustKey.PublicKey().KeyID()
+	d.id = trustKey.PublicKey().KeyID()
 	d.repository = daemonRepo
 	d.containers = container.NewMemoryStore()
 	if d.containersReplica, err = container.NewViewDB(); err != nil {

--- a/daemon/events.go
+++ b/daemon/events.go
@@ -91,7 +91,7 @@ func (daemon *Daemon) LogDaemonEventWithAttributes(action string, attributes map
 			attributes["name"] = info.Name
 		}
 		actor := events.Actor{
-			ID:         daemon.ID,
+			ID:         daemon.id,
 			Attributes: attributes,
 		}
 		daemon.EventsService.Log(action, events.DaemonEventType, actor)

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -32,7 +32,7 @@ func (daemon *Daemon) SystemInfo() *types.Info {
 	sysInfo := daemon.RawSysInfo()
 
 	v := &types.Info{
-		ID:                 daemon.ID,
+		ID:                 daemon.id,
 		Images:             daemon.imageService.CountImages(),
 		IPv4Forwarding:     !sysInfo.IPv4ForwardingDisabled,
 		BridgeNfIptables:   !sysInfo.BridgeNFCallIPTablesDisabled,
@@ -50,7 +50,7 @@ func (daemon *Daemon) SystemInfo() *types.Info {
 		IndexServerAddress: registry.IndexServer,
 		OSType:             platform.OSType,
 		Architecture:       platform.Architecture,
-		RegistryConfig:     daemon.RegistryService.ServiceConfig(),
+		RegistryConfig:     daemon.registryService.ServiceConfig(),
 		NCPU:               sysinfo.NumCPU(),
 		MemTotal:           memInfo().MemTotal,
 		GenericResources:   daemon.genericResources,

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -184,7 +184,7 @@ func (daemon *Daemon) reloadAllowNondistributableArtifacts(conf *config.Config, 
 	// Update corresponding configuration.
 	if conf.IsValueSet("allow-nondistributable-artifacts") {
 		daemon.configStore.AllowNondistributableArtifacts = conf.AllowNondistributableArtifacts
-		if err := daemon.RegistryService.LoadAllowNondistributableArtifacts(conf.AllowNondistributableArtifacts); err != nil {
+		if err := daemon.registryService.LoadAllowNondistributableArtifacts(conf.AllowNondistributableArtifacts); err != nil {
 			return err
 		}
 	}
@@ -209,7 +209,7 @@ func (daemon *Daemon) reloadInsecureRegistries(conf *config.Config, attributes m
 	// update corresponding configuration
 	if conf.IsValueSet("insecure-registries") {
 		daemon.configStore.InsecureRegistries = conf.InsecureRegistries
-		if err := daemon.RegistryService.LoadInsecureRegistries(conf.InsecureRegistries); err != nil {
+		if err := daemon.registryService.LoadInsecureRegistries(conf.InsecureRegistries); err != nil {
 			return err
 		}
 	}
@@ -234,7 +234,7 @@ func (daemon *Daemon) reloadRegistryMirrors(conf *config.Config, attributes map[
 	// update corresponding configuration
 	if conf.IsValueSet("registry-mirrors") {
 		daemon.configStore.Mirrors = conf.Mirrors
-		if err := daemon.RegistryService.LoadMirrors(conf.Mirrors); err != nil {
+		if err := daemon.registryService.LoadMirrors(conf.Mirrors); err != nil {
 			return err
 		}
 	}

--- a/daemon/reload_test.go
+++ b/daemon/reload_test.go
@@ -58,7 +58,7 @@ func TestDaemonReloadAllowNondistributableArtifacts(t *testing.T) {
 
 	var err error
 	// Initialize daemon with some registries.
-	daemon.RegistryService, err = registry.NewService(registry.ServiceOptions{
+	daemon.registryService, err = registry.NewService(registry.ServiceOptions{
 		AllowNondistributableArtifacts: []string{
 			"127.0.0.0/8",
 			"10.10.1.11:5000",
@@ -95,7 +95,7 @@ func TestDaemonReloadAllowNondistributableArtifacts(t *testing.T) {
 	}
 
 	var actual []string
-	serviceConfig := daemon.RegistryService.ServiceConfig()
+	serviceConfig := daemon.registryService.ServiceConfig()
 	for _, value := range serviceConfig.AllowNondistributableArtifactsCIDRs {
 		actual = append(actual, value.String())
 	}
@@ -113,7 +113,7 @@ func TestDaemonReloadMirrors(t *testing.T) {
 	muteLogs()
 
 	var err error
-	daemon.RegistryService, err = registry.NewService(registry.ServiceOptions{
+	daemon.registryService, err = registry.NewService(registry.ServiceOptions{
 		InsecureRegistries: []string{},
 		Mirrors: []string{
 			"https://mirror.test1.example.com",
@@ -180,7 +180,7 @@ func TestDaemonReloadMirrors(t *testing.T) {
 				// mirrors should be valid, should be no error
 				t.Fatal(err)
 			}
-			registryService := daemon.RegistryService.ServiceConfig()
+			registryService := daemon.registryService.ServiceConfig()
 
 			if len(registryService.Mirrors) != len(value.after) {
 				t.Fatalf("Expected %d daemon mirrors %s while get %d with %s",
@@ -215,7 +215,7 @@ func TestDaemonReloadInsecureRegistries(t *testing.T) {
 
 	var err error
 	// initialize daemon with existing insecure registries: "127.0.0.0/8", "10.10.1.11:5000", "10.10.1.22:5000"
-	daemon.RegistryService, err = registry.NewService(registry.ServiceOptions{
+	daemon.registryService, err = registry.NewService(registry.ServiceOptions{
 		InsecureRegistries: []string{
 			"127.0.0.0/8",
 			"10.10.1.11:5000",
@@ -256,7 +256,7 @@ func TestDaemonReloadInsecureRegistries(t *testing.T) {
 
 	// After Reload, daemon.RegistryService will be changed which is useful
 	// for registry communication in daemon.
-	registries := daemon.RegistryService.ServiceConfig()
+	registries := daemon.registryService.ServiceConfig()
 
 	// After Reload(), newConfig has come to registries.InsecureRegistryCIDRs and registries.IndexConfigs in daemon.
 	// Then collect registries.InsecureRegistryCIDRs in dataMap.


### PR DESCRIPTION
This makes it more inline with other data we collect, and can be used to make some info optional at some point to make the `/info` endpoint more modular (instead of one heavy operation to collect all data possible).

### daemon: SystemInfo() extract container counts to a helper function

### ~api: move container states to an embeded struct~ (removed)

### daemon: unexport Daemon.ID and Daemon.RegistryService

These are used internally only, and set by daemon.NewDaemon(). If they're
used externally, we should add an accessor added (which may be something
we want to do for daemon.registryService (which should be its own backend)

### daemon: SystemInfo() extract collecting debugging information to a helper

This makes it more inline with other data we collect, and can be used to make
some info optional at some point.

fillDebugInfo sets the current debugging state of the daemon, and additional
debugging information, such as the number of Go-routines, and file descriptors.

Note that this currently always collects the information, but the CLI only
prints it if the daemon has debug enabled. We should consider to either make
this information optional (cli to request "with debugging information"), or
only collect it if the daemon has debug enabled. For the CLI code, see
https://github.com/docker/cli/blob/v20.10.12/cli/command/system/info.go#L239-L244

```go
if info.Debug {
	fmt.Fprintln(dockerCli.Out(), "  File Descriptors:", info.NFd)
	fmt.Fprintln(dockerCli.Out(), "  Goroutines:", info.NGoroutines)
	fmt.Fprintln(dockerCli.Out(), "  System Time:", info.SystemTime)
	fmt.Fprintln(dockerCli.Out(), "  EventsListeners:", info.NEventsListener)
}
```

Additional note: the CLI considers info.SystemTime debugging information. This
felt a bit "odd" (daemon time could be useful for standard use), so I left this
out of this function.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

