### PR TITLE
wsContainersAttach attach to stdin/out/err streams as requested

### DIFF
--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -17,11 +17,8 @@ type ContainerAttachConfig struct {
 	Logs       bool
 	Stream     bool
 	DetachKeys string
-
-	// Used to signify that streams are multiplexed and therefore need a StdWriter to encode stdout/stderr messages accordingly.
-	// TODO @cpuguy83: This shouldn't be needed. It was only added so that http and websocket endpoints can use the same function, and the websocket function was not using a stdwriter prior to this change...
-	// HOWEVER, the websocket endpoint is using a single stream and SHOULD be encoded with stdout/stderr as is done for HTTP since it is still just a single stream.
-	// Since such a change is an API change unrelated to the current changeset we'll keep it as is here and change separately.
+	// Used to signify that streams must be multiplexed by producer as endpoint can't manage multiple streams.
+	// This is typically set by HTTP endpoint, while websocket can transport raw streams
 	MuxStreams bool
 }
 

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -87,6 +87,8 @@ keywords: "API, Docker, rcli, REST, documentation"
 * The `Volume` type, as returned by `Added new `ClusterVolume` fields 
 * Added a new `PUT /volumes{name}` endpoint to update cluster volumes (CNI).
   Cluster volumes are only supported if the daemon is a Swarm manager.
+* `/containers/{name}/attach/ws` endpoint only attach to configured streams
+  according to `stdin`, `stdout` and `stderr` parameters.
 
 ## v1.41 API changes
 


### PR DESCRIPTION
**- What I did**
`attach/ws` API applies stdlin/stdout/stderr parameters to select streams to attach to (as documented)
closes #43272

**- How I did it**
set parameters on `ContainerAttachConfig`. Also aligned struct initialization with `postContainersAttach` for consistency.

**- How to verify it**

curl -v -H 'Connection: upgrade' -H 'upgrade: websocket' -H 'Sec-Websocket-Key:hello' -H 'Sec-Websocket-Version: 13'tp://localhost:2375/v1.41/containers/$ID/attach/ws?stream=1&stdout=1"  --output -

**- Description for the changelog**
`containers/{ID}/attach/ws` only attach to streams according by `stdin`, `stdout` and `stderr` parameters.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/132757/156752804-8ab3f249-190e-483e-888b-49ce0efa1baf.png)

