### PR TITLE
update containerd binary to v1.5.10

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -166,7 +166,7 @@ FROM microsoft/windowsservercore
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG GO_VERSION=1.17.8
-ARG CONTAINERD_VERSION=1.5.9
+ARG CONTAINERD_VERSION=1.5.10
 ARG GOTESTSUM_VERSION=v1.7.0
 
 # Environment variable notes:

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.5.9}"
+: "${CONTAINERD_VERSION:=v1.5.10}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"


### PR DESCRIPTION
Welcome to the v1.5.10 release of containerd!

The tenth patch release for containerd 1.5 includes a fix for [CVE-2022-23648][1]
and other issues.

Notable Updates

- Use fs.RootPath when mounting volumes (GHSA-crp2-qrr5-8pq7)
- Return init pid when clean dead shim in runc.v1/v2 shims
- Handle sigint/sigterm in shimv2
- Use readonly mount to read user/group info

[1]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23648
[2]: https://github.com/containerd/containerd/security/advisories/GHSA-crp2-qrr5-8pq7

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

