### PR TITLE
Fix incorrect operating system information reported on Windows

### DIFF
--- a/pkg/parsers/operatingsystem/operatingsystem_windows.go
+++ b/pkg/parsers/operatingsystem/operatingsystem_windows.go
@@ -2,43 +2,80 @@ package operatingsystem // import "github.com/docker/docker/pkg/parsers/operatin
 
 import (
 	"fmt"
+	"syscall"
+	"unsafe"
 
 	"github.com/Microsoft/hcsshim/osversion"
+	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
+)
+
+var (
+	libWinbrand          = windows.NewLazySystemDLL("winbrand.dll")
+	libKernel32          = windows.NewLazySystemDLL("kernel32.dll")
+	brandingFormatString = libWinbrand.NewProc("BrandingFormatString")
+	globalFree           = libKernel32.NewProc("GlobalFree")
 )
 
 // GetOperatingSystem gets the name of the current operating system.
 func GetOperatingSystem() (string, error) {
-	os, err := withCurrentVersionRegistryKey(func(key registry.Key) (os string, err error) {
-		if os, _, err = key.GetStringValue("ProductName"); err != nil {
-			return "", err
-		}
+	os, err := callBrandingFormatString()
+	if err != nil {
+		// Default return value
+		return "Unknown Operating System", nil
+	}
 
-		releaseId, _, err := key.GetStringValue("ReleaseId")
-		if err != nil {
-			return
+	version, err := withCurrentVersionRegistryKey(func(key registry.Key) (version string, err error) {
+		version, _, err = key.GetStringValue("DisplayVersion")
+		if err != nil || version == "" {
+			// Fallback.
+			version, _, err = key.GetStringValue("ReleaseId")
+			if err != nil {
+				return "", err
+			}
 		}
-		os = fmt.Sprintf("%s Version %s", os, releaseId)
-
 		buildNumber, _, err := key.GetStringValue("CurrentBuildNumber")
 		if err != nil {
-			return
+			return "", err
 		}
 		ubr, _, err := key.GetIntegerValue("UBR")
 		if err != nil {
-			return
+			return "", err
 		}
-		os = fmt.Sprintf("%s (OS Build %s.%d)", os, buildNumber, ubr)
 
-		return
+		return fmt.Sprintf("Version %s (OS Build %s.%d)", version, buildNumber, ubr), nil
 	})
-
-	if os == "" {
-		// Default return value
-		os = "Unknown Operating System"
+	if err != nil {
+		return "", err
 	}
 
-	return os, err
+	return fmt.Sprintf("%s %s", os, version), nil
+}
+
+func callBrandingFormatString() (string, error) {
+	if err := brandingFormatString.Find(); err != nil {
+		return "", err
+	}
+
+	arg, err := windows.UTF16PtrFromString("%WINDOWS_LONG%")
+	if err != nil {
+		return "", err
+	}
+	r1, _, err := brandingFormatString.Call(uintptr(unsafe.Pointer(arg)))
+	if err != syscall.Errno(0) {
+		return "", err
+	}
+	defer callGlobalFree(r1)
+
+	return windows.UTF16PtrToString((*uint16)(unsafe.Pointer(r1))), nil
+}
+
+func callGlobalFree(v uintptr) {
+	// Just in case.
+	if err := globalFree.Find(); err != nil {
+		return
+	}
+	globalFree.Call(v)
 }
 
 func withCurrentVersionRegistryKey(f func(registry.Key) (string, error)) (string, error) {


### PR DESCRIPTION
Signed-off-by: Kitae Kim <superkkt@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Fixes #43284


**- What I did**
Making `docker info` reports correct operating system's information on Windows.

**- How I did it**
Retrieves such information from the system via Win32API, which `winver` uses, and querying the registry. No additional dependency is needed.

**- How to verify it**
Checks whether `docker info` shows correct information on Windows 11.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**