### PR TITLE
testing: remove some defer cleanup in favor of test.Cleanup()

### DIFF
--- a/builder/dockerfile/copy_test.go
+++ b/builder/dockerfile/copy_test.go
@@ -11,9 +11,7 @@ import (
 
 func TestIsExistingDirectory(t *testing.T) {
 	tmpfile := fs.NewFile(t, "file-exists-test", fs.WithContent("something"))
-	defer tmpfile.Remove()
 	tmpdir := fs.NewDir(t, "dir-exists-test")
-	defer tmpdir.Remove()
 
 	testcases := []struct {
 		doc      string

--- a/builder/remotecontext/remote_test.go
+++ b/builder/remotecontext/remote_test.go
@@ -175,7 +175,6 @@ func TestUnknownContentLength(t *testing.T) {
 func TestDownloadRemote(t *testing.T) {
 	contextDir := fs.NewDir(t, "test-builder-download-remote",
 		fs.WithFile(builder.DefaultDockerfileName, dockerfileContents))
-	defer contextDir.Remove()
 
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)

--- a/cmd/dockerd/daemon_test.go
+++ b/cmd/dockerd/daemon_test.go
@@ -53,7 +53,6 @@ func TestLoadDaemonCliConfigWithTLS(t *testing.T) {
 
 func TestLoadDaemonCliConfigWithConflicts(t *testing.T) {
 	tempFile := fs.NewFile(t, "config", fs.WithContent(`{"labels": ["l3=foo"]}`))
-	defer tempFile.Remove()
 	configFile := tempFile.Path()
 
 	opts := defaultOptions(t, configFile)
@@ -69,7 +68,6 @@ func TestLoadDaemonCliConfigWithConflicts(t *testing.T) {
 
 func TestLoadDaemonCliWithConflictingNodeGenericResources(t *testing.T) {
 	tempFile := fs.NewFile(t, "config", fs.WithContent(`{"node-generic-resources": ["foo=bar", "bar=baz"]}`))
-	defer tempFile.Remove()
 	configFile := tempFile.Path()
 
 	opts := defaultOptions(t, configFile)
@@ -107,7 +105,6 @@ func TestLoadDaemonCliWithDuplicateLabels(t *testing.T) {
 
 func TestLoadDaemonCliConfigWithTLSVerify(t *testing.T) {
 	tempFile := fs.NewFile(t, "config", fs.WithContent(`{"tlsverify": true}`))
-	defer tempFile.Remove()
 
 	opts := defaultOptions(t, tempFile.Path())
 	opts.TLSOptions.CAFile = "/tmp/ca.pem"
@@ -120,7 +117,6 @@ func TestLoadDaemonCliConfigWithTLSVerify(t *testing.T) {
 
 func TestLoadDaemonCliConfigWithExplicitTLSVerifyFalse(t *testing.T) {
 	tempFile := fs.NewFile(t, "config", fs.WithContent(`{"tlsverify": false}`))
-	defer tempFile.Remove()
 
 	opts := defaultOptions(t, tempFile.Path())
 	opts.TLSOptions.CAFile = "/tmp/ca.pem"
@@ -133,7 +129,6 @@ func TestLoadDaemonCliConfigWithExplicitTLSVerifyFalse(t *testing.T) {
 
 func TestLoadDaemonCliConfigWithoutTLSVerify(t *testing.T) {
 	tempFile := fs.NewFile(t, "config", fs.WithContent(`{}`))
-	defer tempFile.Remove()
 
 	opts := defaultOptions(t, tempFile.Path())
 	opts.TLSOptions.CAFile = "/tmp/ca.pem"
@@ -146,7 +141,6 @@ func TestLoadDaemonCliConfigWithoutTLSVerify(t *testing.T) {
 
 func TestLoadDaemonCliConfigWithLogLevel(t *testing.T) {
 	tempFile := fs.NewFile(t, "config", fs.WithContent(`{"log-level": "warn"}`))
-	defer tempFile.Remove()
 
 	opts := defaultOptions(t, tempFile.Path())
 	loadedConfig, err := loadDaemonCliConfig(opts)
@@ -178,7 +172,6 @@ func TestLoadDaemonCliConfigWithInvalidLogFormat(t *testing.T) {
 func TestLoadDaemonConfigWithEmbeddedOptions(t *testing.T) {
 	content := `{"tlscacert": "/etc/certs/ca.pem", "log-driver": "syslog"}`
 	tempFile := fs.NewFile(t, "config", fs.WithContent(content))
-	defer tempFile.Remove()
 
 	opts := defaultOptions(t, tempFile.Path())
 	loadedConfig, err := loadDaemonCliConfig(opts)
@@ -194,7 +187,6 @@ func TestLoadDaemonConfigWithRegistryOptions(t *testing.T) {
 		"insecure-registries": ["https://insecure-registry.example.com"]
 	}`
 	tempFile := fs.NewFile(t, "config", fs.WithContent(content))
-	defer tempFile.Remove()
 
 	opts := defaultOptions(t, tempFile.Path())
 	loadedConfig, err := loadDaemonCliConfig(opts)

--- a/cmd/dockerd/daemon_unix_test.go
+++ b/cmd/dockerd/daemon_unix_test.go
@@ -14,7 +14,6 @@ import (
 func TestLoadDaemonCliConfigWithDaemonFlags(t *testing.T) {
 	content := `{"log-opts": {"max-size": "1k"}}`
 	tempFile := fs.NewFile(t, "config", fs.WithContent(content))
-	defer tempFile.Remove()
 
 	opts := defaultOptions(t, tempFile.Path())
 	opts.Debug = true
@@ -35,7 +34,6 @@ func TestLoadDaemonCliConfigWithDaemonFlags(t *testing.T) {
 func TestLoadDaemonConfigWithNetwork(t *testing.T) {
 	content := `{"bip": "127.0.0.2/8", "bip6": "fd98:e5f2:e637::1/64", "ip": "127.0.0.1"}`
 	tempFile := fs.NewFile(t, "config", fs.WithContent(content))
-	defer tempFile.Remove()
 
 	opts := defaultOptions(t, tempFile.Path())
 	loadedConfig, err := loadDaemonCliConfig(opts)
@@ -50,7 +48,6 @@ func TestLoadDaemonConfigWithNetwork(t *testing.T) {
 func TestLoadDaemonConfigWithMapOptions(t *testing.T) {
 	content := `{"log-opts": {"tag": "test"}}`
 	tempFile := fs.NewFile(t, "config", fs.WithContent(content))
-	defer tempFile.Remove()
 
 	opts := defaultOptions(t, tempFile.Path())
 	loadedConfig, err := loadDaemonCliConfig(opts)
@@ -63,7 +60,6 @@ func TestLoadDaemonConfigWithMapOptions(t *testing.T) {
 func TestLoadDaemonConfigWithTrueDefaultValues(t *testing.T) {
 	content := `{ "userland-proxy": false }`
 	tempFile := fs.NewFile(t, "config", fs.WithContent(content))
-	defer tempFile.Remove()
 
 	opts := defaultOptions(t, tempFile.Path())
 	loadedConfig, err := loadDaemonCliConfig(opts)
@@ -82,7 +78,6 @@ func TestLoadDaemonConfigWithTrueDefaultValues(t *testing.T) {
 
 func TestLoadDaemonConfigWithTrueDefaultValuesLeaveDefaults(t *testing.T) {
 	tempFile := fs.NewFile(t, "config", fs.WithContent(`{}`))
-	defer tempFile.Remove()
 
 	opts := defaultOptions(t, tempFile.Path())
 	loadedConfig, err := loadDaemonCliConfig(opts)

--- a/daemon/config/builder_test.go
+++ b/daemon/config/builder_test.go
@@ -57,7 +57,6 @@ func TestBuilderGC_DeprecatedKeepStorage(t *testing.T) {
     }
   }
 }`))
-	defer tempFile.Remove()
 	configFile := tempFile.Path()
 
 	cfg, err := MergeDaemonConfigurations(&Config{}, nil, configFile)

--- a/daemon/logger/jsonfilelog/jsonfilelog_test.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog_test.go
@@ -101,7 +101,6 @@ func TestJSONFileLoggerWithTags(t *testing.T) {
 
 func BenchmarkJSONFileLoggerLog(b *testing.B) {
 	tmp := fs.NewDir(b, "bench-jsonfilelog")
-	defer tmp.Remove()
 
 	jsonlogger, err := New(logger.Info{
 		ContainerID: "a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657",

--- a/daemon/oci_windows_test.go
+++ b/daemon/oci_windows_test.go
@@ -22,9 +22,6 @@ import (
 func TestSetWindowsCredentialSpecInSpec(t *testing.T) {
 	// we need a temp directory to act as the daemon's root
 	tmpDaemonRoot := fs.NewDir(t, t.Name()).Path()
-	defer func() {
-		assert.NilError(t, os.RemoveAll(tmpDaemonRoot))
-	}()
 
 	daemon := &Daemon{
 		root: tmpDaemonRoot,

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -85,7 +85,6 @@ func (s *DockerSwarmSuite) TestSwarmUpdate(c *testing.T) {
 
 	// passing an invalid external CA fails
 	tempFile := fs.NewFile(c, "testfile", fs.WithContent("fakecert"))
-	defer tempFile.Remove()
 
 	result := cli.Docker(cli.Args("swarm", "update",
 		"--external-ca", fmt.Sprintf("protocol=cfssl,url=https://something.org,cacert=%s", tempFile.Path())),
@@ -107,7 +106,6 @@ func (s *DockerSwarmSuite) TestSwarmInit(c *testing.T) {
 
 	// passing an invalid external CA fails
 	tempFile := fs.NewFile(c, "testfile", fs.WithContent("fakecert"))
-	defer tempFile.Remove()
 
 	result := cli.Docker(cli.Args("swarm", "init", "--cert-expiry", "30h", "--dispatcher-heartbeat", "11s",
 		"--external-ca", fmt.Sprintf("protocol=cfssl,url=https://somethingelse.org,cacert=%s", tempFile.Path())),

--- a/integration/container/ipcmode_linux_test.go
+++ b/integration/container/ipcmode_linux_test.go
@@ -278,7 +278,6 @@ func testDaemonIpcFromConfig(t *testing.T, mode string, mustExist bool) {
 	config := `{"default-ipc-mode": "` + mode + `"}`
 	// WithMode is needed for rootless
 	file := fs.NewFile(t, "test-daemon-ipc-config", fs.WithContent(config), fs.WithMode(0o644))
-	defer file.Remove()
 
 	testDaemonIpcPrivateShareable(t, mustExist, "--config-file", file.Path())
 }

--- a/integration/container/mounts_linux_test.go
+++ b/integration/container/mounts_linux_test.go
@@ -38,8 +38,6 @@ func TestContainerNetworkMountsNoChown(t *testing.T) {
 	ctx := setupTest(t)
 
 	tmpDir := fs.NewDir(t, "network-file-mounts", fs.WithMode(0o755), fs.WithFile("nwfile", "network file bind mount", fs.WithMode(0o644)))
-	defer tmpDir.Remove()
-
 	tmpNWFileMount := tmpDir.Join("nwfile")
 
 	config := containertypes.Config{
@@ -226,13 +224,9 @@ func TestContainerBindMountNonRecursive(t *testing.T) {
 
 	ctx := setupTest(t)
 
-	tmpDir1 := fs.NewDir(t, "tmpdir1", fs.WithMode(0o755),
-		fs.WithDir("mnt", fs.WithMode(0o755)))
-	defer tmpDir1.Remove()
+	tmpDir1 := fs.NewDir(t, "tmpdir1", fs.WithMode(0o755), fs.WithDir("mnt", fs.WithMode(0o755)))
 	tmpDir1Mnt := filepath.Join(tmpDir1.Path(), "mnt")
-	tmpDir2 := fs.NewDir(t, "tmpdir2", fs.WithMode(0o755),
-		fs.WithFile("file", "should not be visible when NonRecursive", fs.WithMode(0o644)))
-	defer tmpDir2.Remove()
+	tmpDir2 := fs.NewDir(t, "tmpdir2", fs.WithMode(0o755), fs.WithFile("file", "should not be visible when NonRecursive", fs.WithMode(0o644)))
 
 	err := mount.Mount(tmpDir2.Path(), tmpDir1Mnt, "none", "bind,ro")
 	if err != nil {
@@ -284,9 +278,7 @@ func TestContainerVolumesMountedAsShared(t *testing.T) {
 	ctx := setupTest(t)
 
 	// Prepare a source directory to bind mount
-	tmpDir1 := fs.NewDir(t, "volume-source", fs.WithMode(0o755),
-		fs.WithDir("mnt1", fs.WithMode(0o755)))
-	defer tmpDir1.Remove()
+	tmpDir1 := fs.NewDir(t, "volume-source", fs.WithMode(0o755), fs.WithDir("mnt1", fs.WithMode(0o755)))
 	tmpDir1Mnt := filepath.Join(tmpDir1.Path(), "mnt1")
 
 	// Convert this directory into a shared mount point so that we do
@@ -336,16 +328,12 @@ func TestContainerVolumesMountedAsSlave(t *testing.T) {
 	ctx := testutil.StartSpan(baseContext, t)
 
 	// Prepare a source directory to bind mount
-	tmpDir1 := fs.NewDir(t, "volume-source", fs.WithMode(0o755),
-		fs.WithDir("mnt1", fs.WithMode(0o755)))
-	defer tmpDir1.Remove()
+	tmpDir1 := fs.NewDir(t, "volume-source", fs.WithMode(0o755), fs.WithDir("mnt1", fs.WithMode(0o755)))
 	tmpDir1Mnt := filepath.Join(tmpDir1.Path(), "mnt1")
 
 	// Prepare a source directory with file in it. We will bind mount this
 	// directory and see if file shows up.
-	tmpDir2 := fs.NewDir(t, "volume-source2", fs.WithMode(0o755),
-		fs.WithFile("slave-testfile", "Test", fs.WithMode(0o644)))
-	defer tmpDir2.Remove()
+	tmpDir2 := fs.NewDir(t, "volume-source2", fs.WithMode(0o755), fs.WithFile("slave-testfile", "Test", fs.WithMode(0o644)))
 
 	// Convert this directory into a shared mount point so that we do
 	// not rely on propagation properties of parent mount.

--- a/integration/container/remove_test.go
+++ b/integration/container/remove_test.go
@@ -33,7 +33,6 @@ func TestRemoveContainerWithRemovedVolume(t *testing.T) {
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
 
 	tempDir := fs.NewDir(t, "test-rm-container-with-removed-volume", fs.WithMode(0o755))
-	defer tempDir.Remove()
 
 	cID := container.Run(ctx, t, apiClient, container.WithCmd("true"), container.WithBind(tempDir.Path(), prefix+slash+"test"))
 	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "exited"))


### PR DESCRIPTION
gotest.tools v3.0.1 and up support Go's native test.Cleanup(), (see https://github.com/gotestyourself/gotest.tools/pull/180) which means that manually calling the cleanup functions in a defer is no longer needed.

Some of these could probably be replaced by Go's native `t.TempDir()`, but keeping that for a follow-up exercise.


**- A picture of a cute animal (not mandatory but encouraged)**

