### PR TITLE
pkg/sysinfo: remove libcontainer dependency

### DIFF
--- a/pkg/sysinfo/cgroup2_linux.go
+++ b/pkg/sysinfo/cgroup2_linux.go
@@ -5,9 +5,9 @@ import (
 	"path"
 	"strings"
 
+	"github.com/containerd/cgroups"
 	cgroupsV2 "github.com/containerd/cgroups/v2"
 	"github.com/containerd/containerd/pkg/userns"
-	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/sirupsen/logrus"
 )
 


### PR DESCRIPTION
**- What I did**
Addressed part of #42452. The only remaining place where package github.com/opencontainers/runc/libcontainer/cgroups is used within Moby is
https://github.com/moby/moby/blob/327699c313f51f8062cf3affcb3746f56f3689c6/daemon/oci_linux.go#L821-L843

**- How I did it**
Reimplemented `GetCgroupMounts` in terms of the github.com/containerd/cgroups and github.com/moby/sys/mountinfo packages. I recursively inlined the libcontainer implementation into the `findCgroupMountpoints` function and refactored the resulting code, deleting dead branches and simplifying what remained.

**- How to verify it**
Are existing integration tests sufficient?

**- Description for the changelog**
N/A

**- A picture of a cute animal (not mandatory but encouraged)**

