### PR TITLE
Allow sharing UTS namespace of another container

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1098,7 +1098,12 @@ definitions:
               type: "string"
           UTSMode:
             type: "string"
-            description: "UTS namespace to use for the container."
+            description: |
+              Set the UTS (UNIX Time-Sharing) Namespace mode for the container. It can be
+              either:
+
+              - `"container:<name|id>"`: joins another container's UTS namespace
+              - `"host"`: use the host's UTS namespace inside the container
           UsernsMode:
             type: "string"
             description: |

--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -228,15 +228,34 @@ func (n UTSMode) IsHost() bool {
 	return n == "host"
 }
 
-// Valid indicates whether the UTS namespace is valid.
+// IsContainer indicates whether container uses another container's UTS namespace.
+func (n UTSMode) IsContainer() bool {
+	parts := strings.SplitN(string(n), ":", 2)
+	return len(parts) > 1 && parts[0] == "container"
+}
+
+// Valid indicates whether the uts mode is valid.
 func (n UTSMode) Valid() bool {
 	parts := strings.Split(string(n), ":")
 	switch mode := parts[0]; mode {
 	case "", "host":
+	case "container":
+		if len(parts) != 2 || parts[1] == "" {
+			return false
+		}
 	default:
 		return false
 	}
 	return true
+}
+
+// Container returns the name of the container whose uts namespace is going to be used.
+func (n UTSMode) Container() string {
+	parts := strings.SplitN(string(n), ":", 2)
+	if len(parts) > 1 {
+		return parts[1]
+	}
+	return ""
 }
 
 // PidMode represents the pid namespace of the container.

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -89,6 +89,15 @@ func (daemon *Daemon) getPidContainer(ctr *container.Container) (*container.Cont
 	return ctr, daemon.checkContainer(ctr, containerIsRunning, containerIsNotRestarting)
 }
 
+func (daemon *Daemon) getUtsContainer(ctr *container.Container) (*container.Container, error) {
+	containerID := ctr.HostConfig.UTSMode.Container()
+	ctr, err := daemon.GetContainer(containerID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot join UTS of a non running container: %s", containerID)
+	}
+	return ctr, daemon.checkContainer(ctr, containerIsRunning, containerIsNotRestarting)
+}
+
 func containerIsRunning(c *container.Container) error {
 	if !c.IsRunning() {
 		return errdefs.Conflict(errors.Errorf("container %s is not running", c.ID))

--- a/integration/container/utsmode_linux_test.go
+++ b/integration/container/utsmode_linux_test.go
@@ -1,0 +1,124 @@
+package container // import "github.com/docker/docker/integration/container"
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	containerTypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/runconfig"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/poll"
+	"gotest.tools/v3/skip"
+)
+
+func TestUtsHost(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.IsRemoteDaemon())
+
+	hostUts, err := os.Readlink("/proc/1/ns/uts")
+	assert.NilError(t, err)
+
+	defer setupTest(t)()
+	client := testEnv.APIClient()
+	ctx := context.Background()
+
+	cID := container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
+		c.HostConfig.UTSMode = "host"
+	})
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	cUts := container.GetContainerNS(ctx, t, client, cID, "uts")
+	assert.Assert(t, hostUts == cUts)
+
+	cID = container.Run(ctx, t, client)
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	cUts = container.GetContainerNS(ctx, t, client, cID, "uts")
+	assert.Assert(t, hostUts != cUts)
+}
+
+func TestUtsContainerNotExists(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.IsRemoteDaemon())
+
+	defer setupTest(t)()
+	client := testEnv.APIClient()
+	ctx := context.Background()
+
+	cID := container.Create(ctx, t, client, func(c *container.TestContainerConfig) {
+		c.HostConfig.UTSMode = "container:non_existent"
+	})
+
+	err := client.ContainerStart(ctx, cID, types.ContainerStartOptions{})
+	assert.Check(t, is.ErrorContains(err, "non_existent"))
+}
+
+func TestUtsContainerNotRunning(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.IsRemoteDaemon())
+
+	defer setupTest(t)()
+	client := testEnv.APIClient()
+	ctx := context.Background()
+
+	// create parent container
+	parentID := container.Create(ctx, t, client)
+
+	cID := container.Create(ctx, t, client, func(c *container.TestContainerConfig) {
+		c.HostConfig.UTSMode = containerTypes.UTSMode("container:" + parentID)
+	})
+	err := client.ContainerStart(ctx, cID, types.ContainerStartOptions{})
+	assert.Check(t, is.ErrorContains(err, "is not running"))
+}
+
+func TestUtsContainer(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.IsRemoteDaemon())
+
+	defer setupTest(t)()
+	client := testEnv.APIClient()
+	ctx := context.Background()
+
+	parentID := container.Run(ctx, t, client)
+	poll.WaitOn(t, container.IsInState(ctx, client, parentID, "running"), poll.WithDelay(100*time.Millisecond))
+	parentUts := container.GetContainerNS(ctx, t, client, parentID, "uts")
+
+	cID := container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
+		c.HostConfig.UTSMode = containerTypes.UTSMode("container:" + parentID)
+	})
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	cUts := container.GetContainerNS(ctx, t, client, cID, "uts")
+	assert.Assert(t, parentUts == cUts)
+}
+
+func TestUtsArgumentsConflict(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.IsRemoteDaemon())
+
+	defer setupTest(t)()
+	client := testEnv.APIClient()
+	ctx := context.Background()
+
+	container.CreateExpectingErr(ctx, t, client, runconfig.ErrConflictUTSHostname.Error(), func(c *container.TestContainerConfig) {
+		c.Config.Hostname = "abcd1234"
+		c.HostConfig.UTSMode = "container:efgh5678"
+	})
+
+	container.CreateExpectingErr(ctx, t, client, runconfig.ErrConflictUTSDomainname.Error(), func(c *container.TestContainerConfig) {
+		c.Config.Domainname = "abcd1234"
+		c.HostConfig.UTSMode = "container:efgh5678"
+	})
+
+	container.CreateExpectingErr(ctx, t, client, runconfig.ErrConflictUTSHostname.Error(), func(c *container.TestContainerConfig) {
+		c.Config.Hostname = "abcd1234"
+		c.HostConfig.UTSMode = "host"
+	})
+
+	container.CreateExpectingErr(ctx, t, client, runconfig.ErrConflictUTSDomainname.Error(), func(c *container.TestContainerConfig) {
+		c.Config.Domainname = "abcd1234"
+		c.HostConfig.UTSMode = "host"
+	})
+}

--- a/runconfig/errors.go
+++ b/runconfig/errors.go
@@ -31,6 +31,8 @@ const (
 	ErrUnsupportedNetworkAndAlias validationError = "network-scoped alias is supported only for containers in user defined networks"
 	// ErrConflictUTSHostname conflict between the hostname and the UTS mode
 	ErrConflictUTSHostname validationError = "conflicting options: hostname and the UTS mode"
+	// ErrConflictUTSDomainname conflict between the domainname and the UTS mode
+	ErrConflictUTSDomainname validationError = "conflicting options: domainname and the UTS mode"
 )
 
 type validationError string

--- a/runconfig/hostconfig_unix.go
+++ b/runconfig/hostconfig_unix.go
@@ -30,8 +30,11 @@ func validateNetMode(c *container.Config, hc *container.HostConfig) error {
 	if err != nil {
 		return err
 	}
-	if hc.UTSMode.IsHost() && c.Hostname != "" {
+	if (hc.UTSMode.IsHost() || hc.UTSMode.IsContainer()) && c.Hostname != "" {
 		return ErrConflictUTSHostname
+	}
+	if (hc.UTSMode.IsHost() || hc.UTSMode.IsContainer()) && c.Domainname != "" {
+		return ErrConflictUTSDomainname
 	}
 	if hc.NetworkMode.IsHost() && len(hc.Links) > 0 {
 		return ErrConflictHostNetworkAndLinks


### PR DESCRIPTION
Signed-off-by: Grant Millar <rid@cylo.io>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Allow sharing of the UTS namespace of another container using `--uts container:<name|id>`

**- How I did it**
- Updated `api/types/container/host_config.go` to allow for checking the parent container
- Added the getUtsContainer function to `daemon/container_operations_unix.go`
- Added the namespace logic to `daemon/oci_linux.go`

**- How to verify it**
```
# docker run -d --rm \
--name foo_sandbox \
--cgroup-parent pod_foo.slice \
--ipc 'shareable' \
alpine sleep infinity

# docker run -d --rm \
--name app \
--cgroup-parent pod_foo.slice \
--network container:foo_sandbox \
--ipc container:foo_sandbox \
--uts container:foo_sandbox \
kennethreitz/httpbin

# lsns | grep -E 'sleep|httpbin'
4026533142 mnt         1 963921 root             sleep infinity
4026533143 uts         3 963921 root             sleep infinity
4026533144 ipc         3 963921 root             sleep infinity
4026533145 pid         1 963921 root             sleep infinity
4026533147 net         3 963921 root             sleep infinity
4026533203 cgroup      1 963921 root             sleep infinity
4026533205 mnt         2 964606 root             /usr/bin/python3 /usr/local/bin/gunicorn -b 0.0.0.0:80 httpbin:app -k gevent
4026533206 pid         2 964606 root             /usr/bin/python3 /usr/local/bin/gunicorn -b 0.0.0.0:80 httpbin:app -k gevent
4026533207 cgroup      2 964606 root             /usr/bin/python3 /usr/local/bin/gunicorn -b 0.0.0.0:80 httpbin:app -k gevent

# ls -l /proc/963921/ns
total 0
lrwxrwxrwx 1 root root 0 Mar  8 12:59 cgroup -> 'cgroup:[4026533203]'
lrwxrwxrwx 1 root root 0 Mar  8 12:58 ipc -> 'ipc:[4026533144]'
lrwxrwxrwx 1 root root 0 Mar  8 12:59 mnt -> 'mnt:[4026533142]'
lrwxrwxrwx 1 root root 0 Mar  8 12:58 net -> 'net:[4026533147]'
lrwxrwxrwx 1 root root 0 Mar  8 12:59 pid -> 'pid:[4026533145]'
lrwxrwxrwx 1 root root 0 Mar  8 13:00 pid_for_children -> 'pid:[4026533145]'
lrwxrwxrwx 1 root root 0 Mar  8 12:59 user -> 'user:[4026531837]'
lrwxrwxrwx 1 root root 0 Mar  8 12:58 uts -> 'uts:[4026533143]'

# ls -l /proc/964606/ns
total 0
lrwxrwxrwx 1 root root 0 Mar  8 12:59 cgroup -> 'cgroup:[4026533207]'
lrwxrwxrwx 1 root root 0 Mar  8 12:59 ipc -> 'ipc:[4026533144]'
lrwxrwxrwx 1 root root 0 Mar  8 12:59 mnt -> 'mnt:[4026533205]'
lrwxrwxrwx 1 root root 0 Mar  8 12:59 net -> 'net:[4026533147]'
lrwxrwxrwx 1 root root 0 Mar  8 12:59 pid -> 'pid:[4026533206]'
lrwxrwxrwx 1 root root 0 Mar  8 13:01 pid_for_children -> 'pid:[4026533206]'
lrwxrwxrwx 1 root root 0 Mar  8 12:59 user -> 'user:[4026531837]'
lrwxrwxrwx 1 root root 0 Mar  8 12:59 uts -> 'uts:[4026533143]'

# docker exec foo_sandbox hostname
223bae70638b

# docker exec app hostname
223bae70638b
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Allow sharing UTS namespace of another container

**- A picture of a cute animal (not mandatory but encouraged)**
🐤

This will also require changes to the CLI to support the new functionality which I will submit a PR for shortly, the PR for the CLI will require vendoring from the API as it requires changes to `host_config` interfaces.
