### PR TITLE
introduce /images/json?containers=true parameter

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -228,15 +228,18 @@ func (s *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter, 
 	}
 
 	var sharedSize bool
+	var containers bool
 	if versions.GreaterThanOrEqualTo(version, "1.42") {
-		// NOTE: Support for the "shared-size" parameter was added in API 1.42.
+		// NOTE: Support for the "shared-size" and "containers" parameter was added in API 1.42.
 		sharedSize = httputils.BoolValue(r, "shared-size")
+		containers = httputils.BoolValue(r, "containers")
 	}
 
 	images, err := s.backend.Images(ctx, types.ImageListOptions{
-		All:        httputils.BoolValue(r, "all"),
-		Filters:    imageFilters,
-		SharedSize: sharedSize,
+		All:            httputils.BoolValue(r, "all"),
+		Filters:        imageFilters,
+		SharedSize:     sharedSize,
+		ContainerCount: containers,
 	})
 	if err != nil {
 		return err

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -7689,6 +7689,11 @@ paths:
           description: "Compute and show shared size as a `SharedSize` field on each image."
           type: "boolean"
           default: false
+        - name: "containers"
+          in: "query"
+          description: "Compute and show number of containers using image as a `Containers` field on each image."
+          type: "boolean"
+          default: false
         - name: "digests"
           in: "query"
           description: "Show digest information as a `RepoDigests` field on each image."

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1036,7 +1036,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	d.linkIndex = newLinkIndex()
 
 	imgSvcConfig := images.ImageServiceConfig{
-		ContainerStore:            d.containers,
+		ContainerStore:            d.containersReplica,
 		DistributionMetadataStore: distributionMetadataStore,
 		EventsService:             d.EventsService,
 		ImageStore:                imageStore,

--- a/daemon/images/image_commit.go
+++ b/daemon/images/image_commit.go
@@ -110,7 +110,10 @@ func exportContainerRw(layerStore layer.Store, id, mountLabel string) (arch io.R
 //
 // This is a temporary shim. Should be removed when builder stops using commit.
 func (i *ImageService) CommitBuildStep(c backend.CommitConfig) (image.ID, error) {
-	container := i.containers.Get(c.ContainerID)
+	container, err := i.containers.Snapshot().Get(c.ContainerID)
+	if err != nil {
+		return "", err
+	}
 	if container == nil {
 		// TODO: use typed error
 		return "", errors.Errorf("container not found: %s", c.ContainerID)

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -27,14 +27,14 @@ type containerStore interface {
 	// used by image delete
 	First(container.StoreFilter) *container.Container
 	// used by image prune, and image list
-	List() []*container.Container
+	List(filters ...container.StoreFilter) []*container.Container
 	// TODO: remove, only used for CommitBuildStep
 	Get(string) *container.Container
 }
 
 // ImageServiceConfig is the configuration used to create a new ImageService
 type ImageServiceConfig struct {
-	ContainerStore            containerStore
+	ContainerStore            container.ViewDB
 	DistributionMetadataStore metadata.Store
 	EventsService             *daemonevents.Events
 	ImageStore                image.Store
@@ -71,7 +71,7 @@ func NewImageService(config ImageServiceConfig) *ImageService {
 
 // ImageService provides a backend for image management
 type ImageService struct {
-	containers                containerStore
+	containers                container.ViewDB
 	distributionMetadataStore metadata.Store
 	downloadManager           *xfer.LayerDownloadManager
 	eventsService             *daemonevents.Events

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -21,12 +21,11 @@ keywords: "API, Docker, rcli, REST, documentation"
   was introduced in API 1.31 as part of an experimental feature, and no longer
   used since API 1.40.
   Use field `BuildCache` instead to track storage used by the builder component.
-* `POST /containers/{id}/stop` and `POST /containers/{id}/restart` now accept a
-  `signal` query parameter, which allows overriding the container's default stop-
-  signal.
-* `GET /images/json` now accepts query parameter `shared-size`. When set `true`,
-  images returned will include `SharedSize`, which provides the size on disk shared
-  with other images present on the system.
+* `GET /images/json` now accepts query parameters `containers` and `shared-size`. 
+  When `shared-size` is set `true`, images returned will include `SharedSize`,
+  which provides the size on disk shared with other images present on the system.
+  When `containers` is set `true`, images returned will include `Containers`,
+  which provides the number of containers created from this image.
 * `GET /system/df` now accepts query parameter `type`. When set,
   computes and returns data only for the specified object type.
   The parameter can be specified multiple times to select several object types.


### PR DESCRIPTION
** Make sure all your commits include a signature generated with `git commit -s` **

close https://github.com/moby/moby/issues/43244

**- What I did**
Restored the ability to list number of containers using an image with /images/json API

**- How I did it**
introduced new parameter `containers` to trigger (pre-existing) counting logic

**- How to verify it**
curl  http://localhost:2375/v1.41/images/json?containers=true | jq

**- Description for the changelog**
`GET /images/json` now accepts query parameters `containers` to count containers using each image

