### PR TITLE
Reduce usage of runc/libcontainer/user package

### DIFF
--- a/builder/dockerfile/internals_linux.go
+++ b/builder/dockerfile/internals_linux.go
@@ -2,12 +2,11 @@ package dockerfile // import "github.com/docker/docker/builder/dockerfile"
 
 import (
 	"context"
-	"path/filepath"
 	"strconv"
 	"strings"
 
+	"github.com/containerd/containerd/oci"
 	"github.com/docker/docker/pkg/idtools"
-	"github.com/moby/sys/symlink"
 	lcUser "github.com/opencontainers/runc/libcontainer/user"
 	"github.com/pkg/errors"
 )
@@ -25,19 +24,11 @@ func parseChownFlag(ctx context.Context, builder *Builder, state *dispatchState,
 		userStr, grpStr = parts[0], parts[1]
 	}
 
-	passwdPath, err := symlink.FollowSymlinkInScope(filepath.Join(ctrRootPath, "etc", "passwd"), ctrRootPath)
-	if err != nil {
-		return idtools.Identity{}, errors.Wrapf(err, "can't resolve /etc/passwd path in container rootfs")
-	}
-	groupPath, err := symlink.FollowSymlinkInScope(filepath.Join(ctrRootPath, "etc", "group"), ctrRootPath)
-	if err != nil {
-		return idtools.Identity{}, errors.Wrapf(err, "can't resolve /etc/group path in container rootfs")
-	}
-	uid, err := lookupUser(userStr, passwdPath)
+	uid, err := lookupUser(ctrRootPath, userStr)
 	if err != nil {
 		return idtools.Identity{}, errors.Wrapf(err, "can't find uid for user "+userStr)
 	}
-	gid, err := lookupGroup(grpStr, groupPath)
+	gid, err := lookupGroup(ctrRootPath, grpStr)
 	if err != nil {
 		return idtools.Identity{}, errors.Wrapf(err, "can't find gid for group "+grpStr)
 	}
@@ -50,40 +41,40 @@ func parseChownFlag(ctx context.Context, builder *Builder, state *dispatchState,
 	return chownPair, nil
 }
 
-func lookupUser(userStr, filepath string) (int, error) {
+func lookupUser(root, userStr string) (int, error) {
 	// if the string is actually a uid integer, parse to int and return
 	// as we don't need to translate with the help of files
 	uid, err := strconv.Atoi(userStr)
 	if err == nil {
 		return uid, nil
 	}
-	users, err := lcUser.ParsePasswdFileFilter(filepath, func(u lcUser.User) bool {
+	user, err := oci.UserFromPath(root, func(u lcUser.User) bool {
 		return u.Name == userStr
 	})
 	if err != nil {
+		if errors.Is(err, oci.ErrNoUsersFound) {
+			return 0, errors.New("no such user: " + userStr)
+		}
 		return 0, err
 	}
-	if len(users) == 0 {
-		return 0, errors.New("no such user: " + userStr)
-	}
-	return users[0].Uid, nil
+	return user.Uid, nil
 }
 
-func lookupGroup(groupStr, filepath string) (int, error) {
+func lookupGroup(root, groupStr string) (int, error) {
 	// if the string is actually a gid integer, parse to int and return
 	// as we don't need to translate with the help of files
 	gid, err := strconv.Atoi(groupStr)
 	if err == nil {
 		return gid, nil
 	}
-	groups, err := lcUser.ParseGroupFileFilter(filepath, func(g lcUser.Group) bool {
+	group, err := oci.GIDFromPath(root, func(g lcUser.Group) bool {
 		return g.Name == groupStr
 	})
 	if err != nil {
+		if errors.Is(err, oci.ErrNoGroupsFound) {
+			return 0, errors.New("no such group: " + groupStr)
+		}
 		return 0, err
 	}
-	if len(groups) == 0 {
-		return 0, errors.New("no such group: " + groupStr)
-	}
-	return groups[0].Gid, nil
+	return int(group), nil
 }

--- a/daemon/archive_tarcopyoptions_unix.go
+++ b/daemon/archive_tarcopyoptions_unix.go
@@ -4,6 +4,10 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"fmt"
+	"os/user"
+	"strconv"
+
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/idtools"
@@ -14,12 +18,21 @@ func (daemon *Daemon) tarCopyOptions(container *container.Container, noOverwrite
 		return daemon.defaultTarCopyOptions(noOverwriteDirNonDir), nil
 	}
 
-	user, err := idtools.LookupUser(container.Config.User)
+	user, err := user.Lookup(container.Config.User)
 	if err != nil {
 		return nil, err
 	}
 
-	identity := idtools.Identity{UID: user.Uid, GID: user.Gid}
+	uid, err := strconv.Atoi(user.Uid)
+	if err != nil {
+		// Should always be numeric on POSIX systems.
+		panic(fmt.Errorf("uid is not numeric: %w", err))
+	}
+	gid, err := strconv.Atoi(user.Gid)
+	if err != nil {
+		panic(fmt.Errorf("gid is not numeric: %w", err))
+	}
+	identity := idtools.Identity{UID: uid, GID: gid}
 
 	return &archive.TarOptions{
 		NoOverwriteDirNonDir: noOverwriteDirNonDir,

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
@@ -1102,7 +1103,7 @@ func parseRemappedRoot(usergrp string) (string, string, error) {
 	if uid, err := strconv.ParseInt(idparts[0], 10, 32); err == nil {
 		// must be a uid; take it as valid
 		userID = int(uid)
-		luser, err := idtools.LookupUID(userID)
+		luser, err := user.LookupId(strconv.Itoa(userID))
 		if err != nil {
 			return "", "", fmt.Errorf("Uid %d has no entry in /etc/passwd: %v", userID, err)
 		}
@@ -1110,7 +1111,7 @@ func parseRemappedRoot(usergrp string) (string, string, error) {
 		if len(idparts) == 1 {
 			// if the uid was numeric and no gid was specified, take the uid as the gid
 			groupID = userID
-			lgrp, err := idtools.LookupGID(groupID)
+			lgrp, err := user.LookupGroupId(strconv.Itoa(groupID))
 			if err != nil {
 				return "", "", fmt.Errorf("Gid %d has no entry in /etc/group: %v", groupID, err)
 			}
@@ -1123,7 +1124,7 @@ func parseRemappedRoot(usergrp string) (string, string, error) {
 		if lookupName == defaultIDSpecifier {
 			lookupName = defaultRemappedID
 		}
-		luser, err := idtools.LookupUser(lookupName)
+		luser, err := user.Lookup(lookupName)
 		if err != nil && idparts[0] != defaultIDSpecifier {
 			// error if the name requested isn't the special "dockremap" ID
 			return "", "", fmt.Errorf("Error during uid lookup for %q: %v", lookupName, err)
@@ -1140,7 +1141,7 @@ func parseRemappedRoot(usergrp string) (string, string, error) {
 		username = luser.Name
 		if len(idparts) == 1 {
 			// we only have a string username, and no group specified; look up gid from username as group
-			group, err := idtools.LookupGroup(lookupName)
+			group, err := user.LookupGroup(lookupName)
 			if err != nil {
 				return "", "", fmt.Errorf("Error during gid lookup for %q: %v", lookupName, err)
 			}
@@ -1154,14 +1155,14 @@ func parseRemappedRoot(usergrp string) (string, string, error) {
 		if gid, err := strconv.ParseInt(idparts[1], 10, 32); err == nil {
 			// must be a gid, take it as valid
 			groupID = int(gid)
-			lgrp, err := idtools.LookupGID(groupID)
+			lgrp, err := user.LookupGroupId(strconv.Itoa(groupID))
 			if err != nil {
 				return "", "", fmt.Errorf("Gid %d has no entry in /etc/passwd: %v", groupID, err)
 			}
 			groupname = lgrp.Name
 		} else {
 			// not a number; attempt a lookup
-			if _, err := idtools.LookupGroup(idparts[1]); err != nil {
+			if _, err := user.LookupGroup(idparts[1]); err != nil {
 				return "", "", fmt.Errorf("Error during groupname lookup for %q: %v", idparts[1], err)
 			}
 			groupname = idparts[1]

--- a/daemon/listeners/group_unix.go
+++ b/daemon/listeners/group_unix.go
@@ -5,21 +5,26 @@ package listeners // import "github.com/docker/docker/daemon/listeners"
 
 import (
 	"fmt"
+	"os/user"
 	"strconv"
-
-	"github.com/docker/docker/pkg/idtools"
 )
 
 const defaultSocketGroup = "docker"
 
 func lookupGID(name string) (int, error) {
-	group, err := idtools.LookupGroup(name)
-	if err == nil {
-		return group.Gid, nil
-	}
-	gid, err := strconv.Atoi(name)
-	if err == nil {
+	group, err := user.LookupGroup(name)
+	if err != nil {
+		gid, err := strconv.Atoi(name)
+		if err != nil {
+			return -1, fmt.Errorf("group %s not found", name)
+		}
 		return gid, nil
 	}
-	return -1, fmt.Errorf("group %s not found", name)
+	gid, err := strconv.Atoi(group.Gid)
+	if err != nil {
+		// group.Gid is documented to always be numeric on POSIX
+		// systems.
+		panic(fmt.Errorf("gid is not numeric: %w", err))
+	}
+	return gid, nil
 }

--- a/pkg/idtools/idtools_unix_test.go
+++ b/pkg/idtools/idtools_unix_test.go
@@ -435,43 +435,6 @@ func TestNewIDMappings(t *testing.T) {
 	assert.Check(t, err, "Unable to access %s directory with user UID:%d and GID:%d:\n%s", dirName, rootUID, rootGID, string(out))
 }
 
-func TestLookupUserAndGroup(t *testing.T) {
-	RequiresRoot(t)
-	uid, gid, err := AddNamespaceRangesUser(tempUser)
-	assert.Check(t, err)
-	defer delUser(t, tempUser)
-
-	fetchedUser, err := LookupUser(tempUser)
-	assert.Check(t, err)
-
-	fetchedUserByID, err := LookupUID(uid)
-	assert.Check(t, err)
-	assert.Check(t, is.DeepEqual(fetchedUserByID, fetchedUser))
-
-	fetchedGroup, err := LookupGroup(tempUser)
-	assert.Check(t, err)
-
-	fetchedGroupByID, err := LookupGID(gid)
-	assert.Check(t, err)
-	assert.Check(t, is.DeepEqual(fetchedGroupByID, fetchedGroup))
-}
-
-func TestLookupUserAndGroupThatDoesNotExist(t *testing.T) {
-	fakeUser := "fakeuser"
-	_, err := LookupUser(fakeUser)
-	assert.Check(t, is.Error(err, "getent unable to find entry \""+fakeUser+"\" in passwd database"))
-
-	_, err = LookupUID(-1)
-	assert.Check(t, is.ErrorContains(err, ""))
-
-	fakeGroup := "fakegroup"
-	_, err = LookupGroup(fakeGroup)
-	assert.Check(t, is.Error(err, "getent unable to find entry \""+fakeGroup+"\" in group database"))
-
-	_, err = LookupGID(-1)
-	assert.Check(t, is.ErrorContains(err, ""))
-}
-
 // TestMkdirIsNotDir checks that mkdirAs() function (used by MkdirAll...)
 // returns a correct error in case a directory which it is about to create
 // already exists but is a file (rather than a directory).


### PR DESCRIPTION
Partially addresses #42452.

**- What I did**
Replaced most uses of package github.com/opencontainers/runc/libcontainer/user with stable alternatives.

**- How I did it**
Substituted the idtools user and group lookup functions with native ones in package os/user. Substituted the in-container user and group lookup functions with the newly-exported utilities in containerd.

I left the uses of libcontainer in daemon/oci_linux.go alone as the code which uses it can be replaced with containerd's [WithUser](https://pkg.go.dev/github.com/containerd/containerd/oci#WithUser) and [WithAdditionalGIDs](https://pkg.go.dev/github.com/containerd/containerd/oci#WithAdditionalGIDs) SpecOpts after #38043 is complete.

**- How to verify it**
TODO

**- Description for the changelog**
* Static builds no longer support resolving host user and group names in non-file databases.

**- A picture of a cute animal (not mandatory but encouraged)**

