### PR TITLE
[20.10] Bump swarmkit for change to max config size

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -144,7 +144,7 @@ github.com/gogo/googleapis                          01e0f9cca9b92166042241267ee2
 github.com/cilium/ebpf                              1c8d4c9ef7759622653a1d319284a44652333b28
 
 # cluster
-github.com/docker/swarmkit                          286f4575a2d2853c1574e1be10eb1a2450692dfc # bump_20.10
+github.com/docker/swarmkit                          cf1e0f8d95ee37ea1f9a5f8a54c73c1e0fa58a54 # bump_20.10
 github.com/gogo/protobuf                            5628607bb4c51c3157aacc3a50f0ab707582b805 # v1.3.1
 github.com/golang/protobuf                          84668698ea25b64748563aa20726db66a6b8d299 # v1.3.5
 github.com/cloudflare/cfssl                         5d63dbd981b5c408effbb58c442d54761ff94fbd # 1.3.2

--- a/vendor/github.com/docker/swarmkit/manager/controlapi/config.go
+++ b/vendor/github.com/docker/swarmkit/manager/controlapi/config.go
@@ -15,7 +15,7 @@ import (
 )
 
 // MaxConfigSize is the maximum byte length of the `Config.Spec.Data` field.
-const MaxConfigSize = 500 * 1024 // 500KB
+const MaxConfigSize = 1000 * 1024 // 500KB
 
 // assumes spec is not nil
 func configFromConfigSpec(spec *api.ConfigSpec) *api.Config {


### PR DESCRIPTION
**- What I did**
Bump Swarmkit version to pick up PR [3055](https://github.com/docker/swarmkit/pull/3055) to increase max size of a config.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

