### PR TITLE
[20.10 backport] Only check if route overlaps routes with scope: LINK

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-: "${LIBNETWORK_COMMIT:=64b7a4574d1426139437d20e81c0b6d391130ec8}"
+: "${LIBNETWORK_COMMIT:=339b972b464ee3d401b5788b2af9e31d09d6b7da}"
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -47,7 +47,7 @@ github.com/grpc-ecosystem/go-grpc-middleware        3c51f7f332123e8be5a157c0802a
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        64b7a4574d1426139437d20e81c0b6d391130ec8
+github.com/docker/libnetwork                        339b972b464ee3d401b5788b2af9e31d09d6b7da
 github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/netutils/utils_linux.go
+++ b/vendor/github.com/docker/libnetwork/netutils/utils_linux.go
@@ -31,7 +31,7 @@ func CheckRouteOverlaps(toCheck *net.IPNet) error {
 		return err
 	}
 	for _, network := range networks {
-		if network.Dst != nil && NetworkOverlaps(toCheck, network.Dst) {
+		if network.Dst != nil && network.Scope == netlink.SCOPE_LINK && NetworkOverlaps(toCheck, network.Dst) {
 			return ErrNetworkOverlaps
 		}
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Backport this PR https://github.com/moby/moby/pull/42598 to be able to use Docker with VPN services in current major version of Docker.

closes https://github.com/moby/moby/issues/41525
partially addresses https://github.com/moby/moby/issues/33925
According to original PR.

Signed-off-by: Mikael Svensson <mikael.svensson@nasdaq.com>

**- What I did**
Backport https://github.com/moby/moby/pull/42598 to 20.10.x
**- How I did it**
Used the change from above PR. I did not however find the test setup that main branch had. Did not add the test change because of that.
**- How to verify it**
I have not been able to verify it in 20.10.x branch

**- Description for the changelog**
https://github.com/moby/moby/issues/41525 Only check if route overlaps routes with scope LINK. Fixes problems with some VPN clients.

