### PR TITLE
distribution: remove v1 leftovers, and refactor to reduce public api/interface

### DIFF
--- a/daemon/images/image_pull.go
+++ b/daemon/images/image_pull.go
@@ -133,35 +133,12 @@ func (i *ImageService) pullImageWithReference(ctx context.Context, ref reference
 
 // GetRepository returns a repository from the registry.
 func (i *ImageService) GetRepository(ctx context.Context, ref reference.Named, authConfig *types.AuthConfig) (dist.Repository, error) {
-	// get repository info
-	repoInfo, err := i.registryService.ResolveRepository(ref)
-	if err != nil {
-		return nil, errdefs.InvalidParameter(err)
-	}
-	// makes sure name is not empty or `scratch`
-	if err := distribution.ValidateRepoName(repoInfo.Name); err != nil {
-		return nil, errdefs.InvalidParameter(err)
-	}
-
-	// get endpoints
-	endpoints, err := i.registryService.LookupPullEndpoints(reference.Domain(repoInfo.Name))
-	if err != nil {
-		return nil, err
-	}
-
-	// retrieve repository
-	var (
-		repository dist.Repository
-		lastError  error
-	)
-
-	for _, endpoint := range endpoints {
-		repository, lastError = distribution.NewV2Repository(ctx, repoInfo, endpoint, nil, authConfig, "pull")
-		if lastError == nil {
-			break
-		}
-	}
-	return repository, lastError
+	return distribution.GetRepository(ctx, ref, &distribution.ImagePullConfig{
+		Config: distribution.Config{
+			AuthConfig:      authConfig,
+			RegistryService: i.registryService,
+		},
+	})
 }
 
 func tempLease(ctx context.Context, mgr leases.Manager) (context.Context, func(context.Context) error, error) {

--- a/daemon/images/image_pull.go
+++ b/daemon/images/image_pull.go
@@ -122,7 +122,6 @@ func (i *ImageService) pullImageWithReference(ctx context.Context, ref reference
 			ReferenceStore:   i.referenceStore,
 		},
 		DownloadManager: i.downloadManager,
-		Schema2Types:    distribution.ImageTypes,
 		Platform:        platform,
 	}
 

--- a/distribution/config.go
+++ b/distribution/config.go
@@ -57,8 +57,9 @@ type ImagePullConfig struct {
 
 	// DownloadManager manages concurrent pulls.
 	DownloadManager *xfer.LayerDownloadManager
-	// Schema2Types is the valid schema2 configuration types allowed
-	// by the pull operation.
+	// Schema2Types is an optional list of valid schema2 configuration types
+	// allowed by the pull operation. If omitted, the default list of accepted
+	// types is used.
 	Schema2Types []string
 	// Platform is the requested platform of the image being pulled
 	Platform *specs.Platform

--- a/distribution/config.go
+++ b/distribution/config.go
@@ -87,8 +87,6 @@ type ImagePushConfig struct {
 type ImageConfigStore interface {
 	Put(context.Context, []byte) (digest.Digest, error)
 	Get(context.Context, digest.Digest) ([]byte, error)
-	RootFSFromConfig([]byte) (*image.RootFS, error)
-	PlatformFromConfig([]byte) (*specs.Platform, error)
 }
 
 // PushLayerProvider provides layers to be pushed by ChainID.
@@ -133,7 +131,7 @@ func (s *imageConfigStore) Get(_ context.Context, d digest.Digest) ([]byte, erro
 	return img.RawJSON(), nil
 }
 
-func (s *imageConfigStore) RootFSFromConfig(c []byte) (*image.RootFS, error) {
+func rootFSFromConfig(c []byte) (*image.RootFS, error) {
 	var unmarshalledConfig image.Image
 	if err := json.Unmarshal(c, &unmarshalledConfig); err != nil {
 		return nil, err
@@ -141,7 +139,7 @@ func (s *imageConfigStore) RootFSFromConfig(c []byte) (*image.RootFS, error) {
 	return unmarshalledConfig.RootFS, nil
 }
 
-func (s *imageConfigStore) PlatformFromConfig(c []byte) (*specs.Platform, error) {
+func platformFromConfig(c []byte) (*specs.Platform, error) {
 	var unmarshalledConfig image.Image
 	if err := json.Unmarshal(c, &unmarshalledConfig); err != nil {
 		return nil, err
@@ -154,7 +152,12 @@ func (s *imageConfigStore) PlatformFromConfig(c []byte) (*specs.Platform, error)
 	if !system.IsOSSupported(os) {
 		return nil, errors.Wrapf(system.ErrNotSupportedOperatingSystem, "image operating system %q cannot be used on this platform", os)
 	}
-	return &specs.Platform{OS: os, Architecture: unmarshalledConfig.Architecture, Variant: unmarshalledConfig.Variant, OSVersion: unmarshalledConfig.OSVersion}, nil
+	return &specs.Platform{
+		OS:           os,
+		Architecture: unmarshalledConfig.Architecture,
+		Variant:      unmarshalledConfig.Variant,
+		OSVersion:    unmarshalledConfig.OSVersion,
+	}, nil
 }
 
 type storeLayerProvider struct {

--- a/distribution/errors_test.go
+++ b/distribution/errors_test.go
@@ -18,15 +18,13 @@ var alwaysContinue = []error{
 	errUnexpected,
 	// nested
 	errcode.Errors{errUnexpected},
-	ErrNoSupport{Err: errUnexpected},
 }
 
 var continueFromMirrorEndpoint = []error{
-	ImageConfigPullError{},
+	imageConfigPullError{},
 	errcode.Error{},
 	// nested
 	errcode.Errors{errcode.Error{}},
-	ErrNoSupport{Err: errcode.Error{}},
 }
 
 var neverContinue = []error{

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -38,7 +38,7 @@ func Pull(ctx context.Context, ref reference.Named, config *ImagePullConfig, loc
 	}
 
 	// makes sure name is not `scratch`
-	if err := ValidateRepoName(repoInfo.Name); err != nil {
+	if err := validateRepoName(repoInfo.Name); err != nil {
 		return err
 	}
 
@@ -112,8 +112,8 @@ func writeStatus(requestedTag string, out progress.Output, layersDownloaded bool
 	}
 }
 
-// ValidateRepoName validates the name of a repository.
-func ValidateRepoName(name reference.Named) error {
+// validateRepoName validates the name of a repository.
+func validateRepoName(name reference.Named) error {
 	if reference.FamiliarName(name) == api.NoBaseImageSpecifier {
 		return errors.WithStack(reservedNameError(api.NoBaseImageSpecifier))
 	}

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -6,27 +6,11 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api"
-	"github.com/docker/docker/distribution/metadata"
-	"github.com/docker/docker/pkg/progress"
 	refstore "github.com/docker/docker/reference"
-	"github.com/docker/docker/registry"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
-
-// newPuller returns a puller to pull from a v2 registry.
-func newPuller(endpoint registry.APIEndpoint, repoInfo *registry.RepositoryInfo, config *ImagePullConfig, local ContentStore) *puller {
-	return &puller{
-		metadataService: metadata.NewV2MetadataService(config.MetadataStore),
-		endpoint:        endpoint,
-		config:          config,
-		repoInfo:        repoInfo,
-		manifestStore: &manifestStore{
-			local: local,
-		},
-	}
-}
 
 // Pull initiates a pull operation. image is the repository name to pull, and
 // tag may be either empty, or indicate a specific tag to pull.
@@ -98,18 +82,6 @@ func Pull(ctx context.Context, ref reference.Named, config *ImagePullConfig, loc
 	}
 
 	return translatePullError(lastErr, ref)
-}
-
-// writeStatus writes a status message to out. If layersDownloaded is true, the
-// status message indicates that a newer image was downloaded. Otherwise, it
-// indicates that the image is up to date. requestedTag is the tag the message
-// will refer to.
-func writeStatus(requestedTag string, out progress.Output, layersDownloaded bool) {
-	if layersDownloaded {
-		progress.Message(out, "", "Status: Downloaded newer image for "+requestedTag)
-	} else {
-		progress.Message(out, "", "Status: Image is up to date for "+requestedTag)
-	}
 }
 
 // validateRepoName validates the name of a repository.

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -41,14 +41,14 @@ var (
 	errRootFSInvalid  = errors.New("invalid rootfs in image configuration")
 )
 
-// ImageConfigPullError is an error pulling the image config blob
+// imageConfigPullError is an error pulling the image config blob
 // (only applies to schema2).
-type ImageConfigPullError struct {
+type imageConfigPullError struct {
 	Err error
 }
 
-// Error returns the error string for ImageConfigPullError.
-func (e ImageConfigPullError) Error() string {
+// Error returns the error string for imageConfigPullError.
+func (e imageConfigPullError) Error() string {
 	return "error pulling image configuration: " + e.Err.Error()
 }
 
@@ -619,7 +619,7 @@ func (p *v2Puller) pullSchema2Layers(ctx context.Context, target distribution.De
 	go func() {
 		configJSON, err := p.pullSchema2Config(ctx, target.Digest)
 		if err != nil {
-			configErrChan <- ImageConfigPullError{Err: err}
+			configErrChan <- imageConfigPullError{Err: err}
 			cancel()
 			return
 		}

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -647,7 +647,7 @@ func (p *puller) pullSchema2Layers(ctx context.Context, target distribution.Desc
 	// check to block Windows images being pulled on Linux is implemented, it
 	// may be necessary to perform the same type of serialisation.
 	if runtime.GOOS == "windows" {
-		configJSON, configRootFS, configPlatform, err = receiveConfig(p.config.ImageStore, configChan, configErrChan)
+		configJSON, configRootFS, configPlatform, err = receiveConfig(configChan, configErrChan)
 		if err != nil {
 			return "", err
 		}
@@ -708,7 +708,7 @@ func (p *puller) pullSchema2Layers(ctx context.Context, target distribution.Desc
 	}
 
 	if configJSON == nil {
-		configJSON, configRootFS, _, err = receiveConfig(p.config.ImageStore, configChan, configErrChan)
+		configJSON, configRootFS, _, err = receiveConfig(configChan, configErrChan)
 		if err == nil && configRootFS == nil {
 			err = errRootFSInvalid
 		}
@@ -773,14 +773,14 @@ func (p *puller) pullOCI(ctx context.Context, ref reference.Named, mfst *ocische
 	return id, manifestDigest, err
 }
 
-func receiveConfig(s ImageConfigStore, configChan <-chan []byte, errChan <-chan error) ([]byte, *image.RootFS, *specs.Platform, error) {
+func receiveConfig(configChan <-chan []byte, errChan <-chan error) ([]byte, *image.RootFS, *specs.Platform, error) {
 	select {
 	case configJSON := <-configChan:
-		rootfs, err := s.RootFSFromConfig(configJSON)
+		rootfs, err := rootFSFromConfig(configJSON)
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		platform, err := s.PlatformFromConfig(configJSON)
+		platform, err := platformFromConfig(configJSON)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -63,7 +63,7 @@ type puller struct {
 
 func (p *puller) pull(ctx context.Context, ref reference.Named) (err error) {
 	// TODO(tiborvass): was ReceiveTimeout
-	p.repo, err = NewV2Repository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
+	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
 	if err != nil {
 		logrus.Warnf("Error getting v2 registry: %v", err)
 		return err

--- a/distribution/pull_v2_test.go
+++ b/distribution/pull_v2_test.go
@@ -356,7 +356,6 @@ func testNewPuller(t *testing.T, rawurl string) *v2Puller {
 				RegistryToken: secretRegistryToken,
 			},
 		},
-		Schema2Types: ImageTypes,
 	}
 
 	puller, err := newPuller(endpoint, repoInfo, imagePullConfig, nil)

--- a/distribution/pull_v2_test.go
+++ b/distribution/pull_v2_test.go
@@ -322,7 +322,7 @@ func TestPullSchema2Config(t *testing.T) {
 	}
 }
 
-func testNewPuller(t *testing.T, rawurl string) *v2Puller {
+func testNewPuller(t *testing.T, rawurl string) *puller {
 	t.Helper()
 
 	uri, err := url.Parse(rawurl)
@@ -358,12 +358,7 @@ func testNewPuller(t *testing.T, rawurl string) *v2Puller {
 		},
 	}
 
-	puller, err := newPuller(endpoint, repoInfo, imagePullConfig, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	p := puller.(*v2Puller)
-
+	p := newPuller(endpoint, repoInfo, imagePullConfig, nil)
 	p.repo, err = NewV2Repository(context.Background(), p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
 	if err != nil {
 		t.Fatal(err)

--- a/distribution/pull_v2_test.go
+++ b/distribution/pull_v2_test.go
@@ -359,7 +359,7 @@ func testNewPuller(t *testing.T, rawurl string) *puller {
 	}
 
 	p := newPuller(endpoint, repoInfo, imagePullConfig, nil)
-	p.repo, err = NewV2Repository(context.Background(), p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
+	p.repo, err = newRepository(context.Background(), p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/distribution/pull_v2_unix.go
+++ b/distribution/pull_v2_unix.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (ld *v2LayerDescriptor) open(ctx context.Context) (distribution.ReadSeekCloser, error) {
+func (ld *layerDescriptor) open(ctx context.Context) (distribution.ReadSeekCloser, error) {
 	blobs := ld.repo.Blobs(ctx)
 	return blobs.Open(ctx, ld.digest)
 }

--- a/distribution/pull_v2_windows.go
+++ b/distribution/pull_v2_windows.go
@@ -22,16 +22,16 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var _ distribution.Describable = &v2LayerDescriptor{}
+var _ distribution.Describable = &layerDescriptor{}
 
-func (ld *v2LayerDescriptor) Descriptor() distribution.Descriptor {
+func (ld *layerDescriptor) Descriptor() distribution.Descriptor {
 	if ld.src.MediaType == schema2.MediaTypeForeignLayer && len(ld.src.URLs) > 0 {
 		return ld.src
 	}
 	return distribution.Descriptor{}
 }
 
-func (ld *v2LayerDescriptor) open(ctx context.Context) (distribution.ReadSeekCloser, error) {
+func (ld *layerDescriptor) open(ctx context.Context) (distribution.ReadSeekCloser, error) {
 	blobs := ld.repo.Blobs(ctx)
 	rsc, err := blobs.Open(ctx, ld.digest)
 

--- a/distribution/push.go
+++ b/distribution/push.go
@@ -14,58 +14,40 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Pusher is an interface that abstracts pushing for different API versions.
-type Pusher interface {
-	// Push tries to push the image configured at the creation of Pusher.
-	// Push returns an error if any, as well as a boolean that determines whether to retry Push on the next configured endpoint.
-	//
-	// TODO(tiborvass): have Push() take a reference to repository + tag, so that the pusher itself is repository-agnostic.
-	Push(ctx context.Context) error
-}
-
 const compressionBufSize = 32768
 
-// NewPusher creates a new Pusher interface that will push to either a v1 or v2
-// registry. The endpoint argument contains a Version field that determines
-// whether a v1 or v2 pusher will be created. The other parameters are passed
-// through to the underlying pusher implementation for use during the actual
-// push operation.
-func NewPusher(ref reference.Named, endpoint registry.APIEndpoint, repoInfo *registry.RepositoryInfo, imagePushConfig *ImagePushConfig) (Pusher, error) {
-	switch endpoint.Version {
-	case registry.APIVersion2:
-		return &v2Pusher{
-			v2MetadataService: metadata.NewV2MetadataService(imagePushConfig.MetadataStore),
-			ref:               ref,
-			endpoint:          endpoint,
-			repoInfo:          repoInfo,
-			config:            imagePushConfig,
-		}, nil
-	case registry.APIVersion1:
-		return nil, fmt.Errorf("protocol version %d no longer supported. Please contact admins of registry %s", endpoint.Version, endpoint.URL)
+// newPusher creates a new pusher for pushing to a v2 registry.
+// The parameters are passed through to the underlying pusher implementation for
+// use during the actual push operation.
+func newPusher(ref reference.Named, endpoint registry.APIEndpoint, repoInfo *registry.RepositoryInfo, config *ImagePushConfig) *pusher {
+	return &pusher{
+		metadataService: metadata.NewV2MetadataService(config.MetadataStore),
+		ref:             ref,
+		endpoint:        endpoint,
+		repoInfo:        repoInfo,
+		config:          config,
 	}
-	return nil, fmt.Errorf("unknown version %d for registry %s", endpoint.Version, endpoint.URL)
 }
 
-// Push initiates a push operation on ref.
-// ref is the specific variant of the image to be pushed.
-// If no tag is provided, all tags will be pushed.
-func Push(ctx context.Context, ref reference.Named, imagePushConfig *ImagePushConfig) error {
+// Push initiates a push operation on ref. ref is the specific variant of the
+// image to push. If no tag is provided, all tags are pushed.
+func Push(ctx context.Context, ref reference.Named, config *ImagePushConfig) error {
 	// FIXME: Allow to interrupt current push when new push of same image is done.
 
 	// Resolve the Repository name from fqn to RepositoryInfo
-	repoInfo, err := imagePushConfig.RegistryService.ResolveRepository(ref)
+	repoInfo, err := config.RegistryService.ResolveRepository(ref)
 	if err != nil {
 		return err
 	}
 
-	endpoints, err := imagePushConfig.RegistryService.LookupPushEndpoints(reference.Domain(repoInfo.Name))
+	endpoints, err := config.RegistryService.LookupPushEndpoints(reference.Domain(repoInfo.Name))
 	if err != nil {
 		return err
 	}
 
-	progress.Messagef(imagePushConfig.ProgressOutput, "", "The push refers to repository [%s]", repoInfo.Name.Name())
+	progress.Messagef(config.ProgressOutput, "", "The push refers to repository [%s]", repoInfo.Name.Name())
 
-	associations := imagePushConfig.ReferenceStore.ReferencesByName(repoInfo.Name)
+	associations := config.ReferenceStore.ReferencesByName(repoInfo.Name)
 	if len(associations) == 0 {
 		return fmt.Errorf("An image does not exist locally with the tag: %s", reference.FamiliarName(repoInfo.Name))
 	}
@@ -87,14 +69,9 @@ func Push(ctx context.Context, ref reference.Named, imagePushConfig *ImagePushCo
 			}
 		}
 
-		logrus.Debugf("Trying to push %s to %s %s", repoInfo.Name.Name(), endpoint.URL, endpoint.Version)
+		logrus.Debugf("Trying to push %s to %s", repoInfo.Name.Name(), endpoint.URL)
 
-		pusher, err := NewPusher(ref, endpoint, repoInfo, imagePushConfig)
-		if err != nil {
-			lastErr = err
-			continue
-		}
-		if err := pusher.Push(ctx); err != nil {
+		if err := newPusher(ref, endpoint, repoInfo, config).push(ctx); err != nil {
 			// Was this push cancelled? If so, don't try to fall
 			// back.
 			select {
@@ -115,7 +92,7 @@ func Push(ctx context.Context, ref reference.Named, imagePushConfig *ImagePushCo
 			return err
 		}
 
-		imagePushConfig.ImageEventLogger(reference.FamiliarString(ref), reference.FamiliarName(repoInfo.Name), "push")
+		config.ImageEventLogger(reference.FamiliarString(ref), reference.FamiliarName(repoInfo.Name), "push")
 		return nil
 	}
 

--- a/distribution/push.go
+++ b/distribution/push.go
@@ -8,26 +8,11 @@ import (
 	"io"
 
 	"github.com/docker/distribution/reference"
-	"github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/pkg/progress"
-	"github.com/docker/docker/registry"
 	"github.com/sirupsen/logrus"
 )
 
 const compressionBufSize = 32768
-
-// newPusher creates a new pusher for pushing to a v2 registry.
-// The parameters are passed through to the underlying pusher implementation for
-// use during the actual push operation.
-func newPusher(ref reference.Named, endpoint registry.APIEndpoint, repoInfo *registry.RepositoryInfo, config *ImagePushConfig) *pusher {
-	return &pusher{
-		metadataService: metadata.NewV2MetadataService(config.MetadataStore),
-		ref:             ref,
-		endpoint:        endpoint,
-		repoInfo:        repoInfo,
-		config:          config,
-	}
-}
 
 // Push initiates a push operation on ref. ref is the specific variant of the
 // image to push. If no tag is provided, all tags are pushed.

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -118,7 +118,7 @@ func (p *pusher) pushTag(ctx context.Context, ref reference.NamedTagged, id dige
 		return fmt.Errorf("could not find image from tag %s: %v", reference.FamiliarString(ref), err)
 	}
 
-	rootfs, err := p.config.ImageStore.RootFSFromConfig(imgConfig)
+	rootfs, err := rootFSFromConfig(imgConfig)
 	if err != nil {
 		return fmt.Errorf("unable to get rootfs for image %s: %s", reference.FamiliarString(ref), err)
 	}

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -60,7 +60,7 @@ type pushState struct {
 func (p *pusher) push(ctx context.Context) (err error) {
 	p.pushState.remoteLayers = make(map[layer.DiffID]distribution.Descriptor)
 
-	p.repo, err = NewV2Repository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "push", "pull")
+	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "push", "pull")
 	p.pushState.hasAuthInfo = p.config.AuthConfig.RegistryToken != "" || (p.config.AuthConfig.Username != "" && p.config.AuthConfig.Password != "")
 	if err != nil {
 		logrus.Debugf("Error getting v2 registry: %v", err)

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -34,6 +34,19 @@ const (
 	middleLayerMaximumSize = 10 * (1 << 20)  // 10MB
 )
 
+// newPusher creates a new pusher for pushing to a v2 registry.
+// The parameters are passed through to the underlying pusher implementation for
+// use during the actual push operation.
+func newPusher(ref reference.Named, endpoint registry.APIEndpoint, repoInfo *registry.RepositoryInfo, config *ImagePushConfig) *pusher {
+	return &pusher{
+		metadataService: metadata.NewV2MetadataService(config.MetadataStore),
+		ref:             ref,
+		endpoint:        endpoint,
+		repoInfo:        repoInfo,
+		config:          config,
+	}
+}
+
 type pusher struct {
 	metadataService metadata.V2MetadataService
 	ref             reference.Named

--- a/distribution/push_v2_test.go
+++ b/distribution/push_v2_test.go
@@ -395,16 +395,16 @@ func TestLayerAlreadyExists(t *testing.T) {
 		}
 		ctx := context.Background()
 		ms := &mockV2MetadataService{}
-		pd := &v2PushDescriptor{
+		pd := &pushDescriptor{
 			hmacKey:  []byte(tc.hmacKey),
 			repoInfo: repoInfo,
 			layer: &storeLayer{
 				Layer: layer.EmptyLayer,
 			},
-			repo:              repo,
-			v2MetadataService: ms,
-			pushState:         &pushState{remoteLayers: make(map[layer.DiffID]distribution.Descriptor)},
-			checkedDigests:    make(map[digest.Digest]struct{}),
+			repo:            repo,
+			metadataService: ms,
+			pushState:       &pushState{remoteLayers: make(map[layer.DiffID]distribution.Descriptor)},
+			checkedDigests:  make(map[digest.Digest]struct{}),
 		}
 
 		desc, exists, err := pd.layerAlreadyExists(ctx, &progressSink{t}, layer.EmptyLayer.DiffID(), tc.checkOtherRepositories, tc.maxExistenceChecks, tc.metadata)
@@ -522,7 +522,7 @@ func TestWhenEmptyAuthConfig(t *testing.T) {
 		}
 		imagePushConfig.ReferenceStore = &mockReferenceStore{}
 		repoInfo, _ := reference.ParseNormalizedNamed("xujihui1985/test.img")
-		pusher := &v2Pusher{
+		pusher := &pusher{
 			config: imagePushConfig,
 			repoInfo: &registry.RepositoryInfo{
 				Name: repoInfo,
@@ -536,7 +536,7 @@ func TestWhenEmptyAuthConfig(t *testing.T) {
 				TrimHostname: true,
 			},
 		}
-		pusher.Push(context.Background())
+		pusher.push(context.Background())
 		if pusher.pushState.hasAuthInfo != authInfo.expected {
 			t.Errorf("hasAuthInfo does not match expected: %t != %t", authInfo.expected, pusher.pushState.hasAuthInfo)
 		}
@@ -598,14 +598,14 @@ func TestPushRegistryWhenAuthInfoEmpty(t *testing.T) {
 			requests: []string{},
 		},
 	}
-	pd := &v2PushDescriptor{
+	pd := &pushDescriptor{
 		hmacKey:  []byte("abcd"),
 		repoInfo: repoInfo,
 		layer: &storeLayer{
 			Layer: layer.EmptyLayer,
 		},
-		repo:              repo,
-		v2MetadataService: ms,
+		repo:            repo,
+		metadataService: ms,
 		pushState: &pushState{
 			remoteLayers: make(map[layer.DiffID]distribution.Descriptor),
 			hasAuthInfo:  false,

--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -19,35 +19,36 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// ImageTypes represents the schema2 config types for images
-var ImageTypes = []string{
-	schema2.MediaTypeImageConfig,
-	ocispec.MediaTypeImageConfig,
-	// Handle unexpected values from https://github.com/docker/distribution/issues/1621
-	// (see also https://github.com/docker/docker/issues/22378,
-	// https://github.com/docker/docker/issues/30083)
-	"application/octet-stream",
-	"application/json",
-	"text/html",
-	// Treat defaulted values as images, newer types cannot be implied
-	"",
-}
+var (
+	// defaultImageTypes represents the schema2 config types for images
+	defaultImageTypes = []string{
+		schema2.MediaTypeImageConfig,
+		ocispec.MediaTypeImageConfig,
+		// Handle unexpected values from https://github.com/docker/distribution/issues/1621
+		// (see also https://github.com/docker/docker/issues/22378,
+		// https://github.com/docker/docker/issues/30083)
+		"application/octet-stream",
+		"application/json",
+		"text/html",
+		// Treat defaulted values as images, newer types cannot be implied
+		"",
+	}
 
-// PluginTypes represents the schema2 config types for plugins
-var PluginTypes = []string{
-	schema2.MediaTypePluginConfig,
-}
+	// pluginTypes represents the schema2 config types for plugins
+	pluginTypes = []string{
+		schema2.MediaTypePluginConfig,
+	}
 
-var mediaTypeClasses map[string]string
+	mediaTypeClasses map[string]string
+)
 
 func init() {
-	// initialize media type classes with all know types for
-	// plugin
+	// initialize media type classes with all know types for images and plugins.
 	mediaTypeClasses = map[string]string{}
-	for _, t := range ImageTypes {
+	for _, t := range defaultImageTypes {
 		mediaTypeClasses[t] = "image"
 	}
-	for _, t := range PluginTypes {
+	for _, t := range pluginTypes {
 		mediaTypeClasses[t] = "plugin"
 	}
 }

--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -53,10 +53,10 @@ func init() {
 	}
 }
 
-// NewV2Repository returns a repository (v2 only). It creates an HTTP transport
+// newRepository returns a repository (v2 only). It creates an HTTP transport
 // providing timeout settings and authentication support, and also verifies the
 // remote API version.
-func NewV2Repository(
+func newRepository(
 	ctx context.Context, repoInfo *registry.RepositoryInfo, endpoint registry.APIEndpoint,
 	metaHeaders http.Header, authConfig *types.AuthConfig, actions ...string,
 ) (repo distribution.Repository, err error) {

--- a/distribution/registry_unit_test.go
+++ b/distribution/registry_unit_test.go
@@ -67,7 +67,6 @@ func testTokenPassThru(t *testing.T, ts *httptest.Server) {
 				RegistryToken: secretRegistryToken,
 			},
 		},
-		Schema2Types: ImageTypes,
 	}
 	puller, err := newPuller(endpoint, repoInfo, imagePullConfig, nil)
 	if err != nil {

--- a/distribution/registry_unit_test.go
+++ b/distribution/registry_unit_test.go
@@ -70,7 +70,7 @@ func testTokenPassThru(t *testing.T, ts *httptest.Server) {
 	}
 	p := newPuller(endpoint, repoInfo, imagePullConfig, nil)
 	ctx := context.Background()
-	p.repo, err = NewV2Repository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
+	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/distribution/registry_unit_test.go
+++ b/distribution/registry_unit_test.go
@@ -68,11 +68,7 @@ func testTokenPassThru(t *testing.T, ts *httptest.Server) {
 			},
 		},
 	}
-	puller, err := newPuller(endpoint, repoInfo, imagePullConfig, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	p := puller.(*v2Puller)
+	p := newPuller(endpoint, repoInfo, imagePullConfig, nil)
 	ctx := context.Background()
 	p.repo, err = NewV2Repository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
 	if err != nil {
@@ -82,7 +78,7 @@ func testTokenPassThru(t *testing.T, ts *httptest.Server) {
 	logrus.Debug("About to pull")
 	// We expect it to fail, since we haven't mock'd the full registry exchange in our handler above
 	tag, _ := reference.WithTag(n, "tag_goes_here")
-	_ = p.pullV2Repository(ctx, tag)
+	_ = p.pullRepository(ctx, tag)
 }
 
 func TestTokenPassThru(t *testing.T) {

--- a/distribution/repository.go
+++ b/distribution/repository.go
@@ -1,0 +1,34 @@
+package distribution
+
+import (
+	"context"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/errdefs"
+)
+
+// GetRepository returns a repository from the registry.
+func GetRepository(ctx context.Context, ref reference.Named, config *ImagePullConfig) (repository distribution.Repository, lastError error) {
+	repoInfo, err := config.RegistryService.ResolveRepository(ref)
+	if err != nil {
+		return nil, errdefs.InvalidParameter(err)
+	}
+	// makes sure name is not empty or `scratch`
+	if err := validateRepoName(repoInfo.Name); err != nil {
+		return nil, errdefs.InvalidParameter(err)
+	}
+
+	endpoints, err := config.RegistryService.LookupPullEndpoints(reference.Domain(repoInfo.Name))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, endpoint := range endpoints {
+		repository, lastError = newRepository(ctx, repoInfo, endpoint, nil, config.AuthConfig, "pull")
+		if lastError == nil {
+			break
+		}
+	}
+	return repository, lastError
+}


### PR DESCRIPTION
I think I wanted to push this after https://github.com/moby/moby/pull/43298 was merged, but let me clean up some of my local branches (I may have stashed more after this). I'll update the description here later.

Before:

<img width="1447" alt="Screenshot 2022-03-12 at 00 32 46" src="https://user-images.githubusercontent.com/1804568/157988408-2ed00ba5-8273-4689-86bf-68fd87c8adfa.png">


After:

<img width="936" alt="Screenshot 2022-03-12 at 00 31 51" src="https://user-images.githubusercontent.com/1804568/157988469-e827b649-9956-4443-bb2a-46d88414459e.png">
