### PR TITLE
Introduce `://` syntax for Windows Devices in DeviceMapping.PathOnHost

### DIFF
--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -254,7 +254,7 @@ func (daemon *Daemon) createSpecWindowsFields(c *container.Container, s *specs.S
 		return err
 	}
 
-	devices, err := setupWindowsDevices(c.HostConfig.Devices, isHyperV)
+	devices, err := setupWindowsDevices(c.HostConfig.Devices)
 	if err != nil {
 		return err
 	}
@@ -452,13 +452,9 @@ func readCredentialSpecFile(id, root, location string) (string, error) {
 	return string(bcontents[:]), nil
 }
 
-func setupWindowsDevices(devices []containertypes.DeviceMapping, isHyperV bool) (specDevices []specs.WindowsDevice, err error) {
+func setupWindowsDevices(devices []containertypes.DeviceMapping) (specDevices []specs.WindowsDevice, err error) {
 	if len(devices) == 0 {
 		return
-	}
-
-	if isHyperV {
-		return nil, errors.New("device assignment is not supported for HyperV containers")
 	}
 
 	for _, deviceMapping := range devices {

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -458,12 +458,17 @@ func setupWindowsDevices(devices []containertypes.DeviceMapping) (specDevices []
 	}
 
 	for _, deviceMapping := range devices {
-		srcParts := strings.SplitN(deviceMapping.PathOnHost, "/", 2)
-		if len(srcParts) != 2 {
-			return nil, errors.New("invalid device assignment path")
+		devicePath := deviceMapping.PathOnHost
+		if strings.HasPrefix(devicePath, "class/") {
+			devicePath = strings.Replace(devicePath, "class/", "class://", 1)
 		}
-		if srcParts[0] != "class" {
-			return nil, errors.Errorf("invalid device assignment type: '%s' should be 'class'", srcParts[0])
+
+		srcParts := strings.SplitN(devicePath, "://", 2)
+		if len(srcParts) != 2 {
+			return nil, errors.Errorf("invalid device assignment path: '%s', must be 'class/ID' or 'IDType://ID'", deviceMapping.PathOnHost)
+		}
+		if srcParts[0] == "" {
+			return nil, errors.Errorf("invalid device assignment path: '%s', IDType cannot be empty", deviceMapping.PathOnHost)
 		}
 		wd := specs.WindowsDevice{
 			ID:     srcParts[1],

--- a/daemon/oci_windows_test.go
+++ b/daemon/oci_windows_test.go
@@ -322,36 +322,68 @@ func TestSetupWindowsDevices(t *testing.T) {
 	t.Run("it fails if any devices are blank", func(t *testing.T) {
 		devices, err := setupWindowsDevices([]containertypes.DeviceMapping{{PathOnHost: "class/anything"}, {PathOnHost: ""}})
 		assert.ErrorContains(t, err, "invalid device assignment path")
+		assert.ErrorContains(t, err, "''")
 		assert.Equal(t, len(devices), 0)
 	})
 
-	t.Run("it fails if all devices do not contain '/'", func(t *testing.T) {
+	t.Run("it fails if all devices do not contain '/' or '://'", func(t *testing.T) {
 		devices, err := setupWindowsDevices([]containertypes.DeviceMapping{{PathOnHost: "anything"}, {PathOnHost: "goes"}})
 		assert.ErrorContains(t, err, "invalid device assignment path")
+		assert.ErrorContains(t, err, "'anything'")
 		assert.Equal(t, len(devices), 0)
 	})
 
-	t.Run("it fails if any devices do not contain '/'", func(t *testing.T) {
+	t.Run("it fails if any devices do not contain '/' or '://'", func(t *testing.T) {
 		devices, err := setupWindowsDevices([]containertypes.DeviceMapping{{PathOnHost: "class/anything"}, {PathOnHost: "goes"}})
 		assert.ErrorContains(t, err, "invalid device assignment path")
+		assert.ErrorContains(t, err, "'goes'")
 		assert.Equal(t, len(devices), 0)
 	})
 
-	t.Run("it fails if all devices do not have IDType 'class'", func(t *testing.T) {
+	t.Run("it fails if all '/'-separated devices do not have IDType 'class'", func(t *testing.T) {
 		devices, err := setupWindowsDevices([]containertypes.DeviceMapping{{PathOnHost: "klass/anything"}, {PathOnHost: "klass/goes"}})
-		assert.ErrorContains(t, err, "invalid device assignment type: 'klass' should be 'class'")
+		assert.ErrorContains(t, err, "invalid device assignment path")
+		assert.ErrorContains(t, err, "'klass/anything'")
 		assert.Equal(t, len(devices), 0)
 	})
 
-	t.Run("it fails if any devices do not have IDType 'class'", func(t *testing.T) {
+	t.Run("it fails if any '/'-separated devices do not have IDType 'class'", func(t *testing.T) {
 		devices, err := setupWindowsDevices([]containertypes.DeviceMapping{{PathOnHost: "class/anything"}, {PathOnHost: "klass/goes"}})
-		assert.ErrorContains(t, err, "invalid device assignment type: 'klass' should be 'class'")
+		assert.ErrorContains(t, err, "invalid device assignment path")
+		assert.ErrorContains(t, err, "'klass/goes'")
 		assert.Equal(t, len(devices), 0)
 	})
 
-	t.Run("it creates devices if all devices have IDType 'class'", func(t *testing.T) {
+	t.Run("it fails if any '://'-separated devices have IDType ''", func(t *testing.T) {
+		devices, err := setupWindowsDevices([]containertypes.DeviceMapping{{PathOnHost: "class/anything"}, {PathOnHost: "://goes"}})
+		assert.ErrorContains(t, err, "invalid device assignment path")
+		assert.ErrorContains(t, err, "'://goes'")
+		assert.Equal(t, len(devices), 0)
+	})
+
+	t.Run("it creates devices if all '/'-separated devices have IDType 'class'", func(t *testing.T) {
 		devices, err := setupWindowsDevices([]containertypes.DeviceMapping{{PathOnHost: "class/anything"}, {PathOnHost: "class/goes"}})
 		expectedDevices := []specs.WindowsDevice{{IDType: "class", ID: "anything"}, {IDType: "class", ID: "goes"}}
+		assert.NilError(t, err)
+		assert.Equal(t, len(devices), len(expectedDevices))
+		for i := range expectedDevices {
+			assert.Equal(t, devices[i], expectedDevices[i])
+		}
+	})
+
+	t.Run("it creates devices if all '://'-separated devices have non-blank IDType", func(t *testing.T) {
+		devices, err := setupWindowsDevices([]containertypes.DeviceMapping{{PathOnHost: "class://anything"}, {PathOnHost: "klass://goes"}})
+		expectedDevices := []specs.WindowsDevice{{IDType: "class", ID: "anything"}, {IDType: "klass", ID: "goes"}}
+		assert.NilError(t, err)
+		assert.Equal(t, len(devices), len(expectedDevices))
+		for i := range expectedDevices {
+			assert.Equal(t, devices[i], expectedDevices[i])
+		}
+	})
+
+	t.Run("it creates devices when given a mix of '/'-separated and '://'-separated devices", func(t *testing.T) {
+		devices, err := setupWindowsDevices([]containertypes.DeviceMapping{{PathOnHost: "class/anything"}, {PathOnHost: "klass://goes"}})
+		expectedDevices := []specs.WindowsDevice{{IDType: "class", ID: "anything"}, {IDType: "klass", ID: "goes"}}
 		assert.NilError(t, err)
 		assert.Equal(t, len(devices), len(expectedDevices))
 		for i := range expectedDevices {

--- a/daemon/oci_windows_test.go
+++ b/daemon/oci_windows_test.go
@@ -313,56 +313,44 @@ func setRegistryOpenKeyFunc(t *testing.T, key *dummyRegistryKey, err ...error) f
 }
 
 func TestSetupWindowsDevices(t *testing.T) {
-	t.Run("it does nothing if there are no devices and HyperV is disabled", func(t *testing.T) {
-		devices, err := setupWindowsDevices(nil, false)
+	t.Run("it does nothing if there are no devices", func(t *testing.T) {
+		devices, err := setupWindowsDevices(nil)
 		assert.NilError(t, err)
 		assert.Equal(t, len(devices), 0)
 	})
 
-	t.Run("it does nothing if there are no devices and HyperV is enabled", func(t *testing.T) {
-		devices, err := setupWindowsDevices(nil, true)
-		assert.NilError(t, err)
-		assert.Equal(t, len(devices), 0)
-	})
-
-	t.Run("it fails if there are devices and HyperV is enabled", func(t *testing.T) {
-		devices, err := setupWindowsDevices([]containertypes.DeviceMapping{{PathOnHost: "anything"}}, true)
-		assert.ErrorContains(t, err, "device assignment is not supported for HyperV containers")
-		assert.Equal(t, len(devices), 0)
-	})
-
-	t.Run("it fails if any devices are blank and HyperV is disabled", func(t *testing.T) {
-		devices, err := setupWindowsDevices([]containertypes.DeviceMapping{{PathOnHost: "class/anything"}, {PathOnHost: ""}}, false)
+	t.Run("it fails if any devices are blank", func(t *testing.T) {
+		devices, err := setupWindowsDevices([]containertypes.DeviceMapping{{PathOnHost: "class/anything"}, {PathOnHost: ""}})
 		assert.ErrorContains(t, err, "invalid device assignment path")
 		assert.Equal(t, len(devices), 0)
 	})
 
-	t.Run("it fails if all devices do not contain '/' and HyperV is disabled", func(t *testing.T) {
-		devices, err := setupWindowsDevices([]containertypes.DeviceMapping{{PathOnHost: "anything"}, {PathOnHost: "goes"}}, false)
+	t.Run("it fails if all devices do not contain '/'", func(t *testing.T) {
+		devices, err := setupWindowsDevices([]containertypes.DeviceMapping{{PathOnHost: "anything"}, {PathOnHost: "goes"}})
 		assert.ErrorContains(t, err, "invalid device assignment path")
 		assert.Equal(t, len(devices), 0)
 	})
 
-	t.Run("it fails if any devices do not contain '/' and HyperV is disabled", func(t *testing.T) {
-		devices, err := setupWindowsDevices([]containertypes.DeviceMapping{{PathOnHost: "class/anything"}, {PathOnHost: "goes"}}, false)
+	t.Run("it fails if any devices do not contain '/'", func(t *testing.T) {
+		devices, err := setupWindowsDevices([]containertypes.DeviceMapping{{PathOnHost: "class/anything"}, {PathOnHost: "goes"}})
 		assert.ErrorContains(t, err, "invalid device assignment path")
 		assert.Equal(t, len(devices), 0)
 	})
 
-	t.Run("it fails if all devices do not have IDType 'class' and HyperV is disabled", func(t *testing.T) {
-		devices, err := setupWindowsDevices([]containertypes.DeviceMapping{{PathOnHost: "klass/anything"}, {PathOnHost: "klass/goes"}}, false)
+	t.Run("it fails if all devices do not have IDType 'class'", func(t *testing.T) {
+		devices, err := setupWindowsDevices([]containertypes.DeviceMapping{{PathOnHost: "klass/anything"}, {PathOnHost: "klass/goes"}})
 		assert.ErrorContains(t, err, "invalid device assignment type: 'klass' should be 'class'")
 		assert.Equal(t, len(devices), 0)
 	})
 
-	t.Run("it fails if any devices do not have IDType 'class' and HyperV is disabled", func(t *testing.T) {
-		devices, err := setupWindowsDevices([]containertypes.DeviceMapping{{PathOnHost: "class/anything"}, {PathOnHost: "klass/goes"}}, false)
+	t.Run("it fails if any devices do not have IDType 'class'", func(t *testing.T) {
+		devices, err := setupWindowsDevices([]containertypes.DeviceMapping{{PathOnHost: "class/anything"}, {PathOnHost: "klass/goes"}})
 		assert.ErrorContains(t, err, "invalid device assignment type: 'klass' should be 'class'")
 		assert.Equal(t, len(devices), 0)
 	})
 
-	t.Run("it creates devices if all devices have IDType 'class' and HyperV is disabled", func(t *testing.T) {
-		devices, err := setupWindowsDevices([]containertypes.DeviceMapping{{PathOnHost: "class/anything"}, {PathOnHost: "class/goes"}}, false)
+	t.Run("it creates devices if all devices have IDType 'class'", func(t *testing.T) {
+		devices, err := setupWindowsDevices([]containertypes.DeviceMapping{{PathOnHost: "class/anything"}, {PathOnHost: "class/goes"}})
 		expectedDevices := []specs.WindowsDevice{{IDType: "class", ID: "anything"}, {IDType: "class", ID: "goes"}}
 		assert.NilError(t, err)
 		assert.Equal(t, len(devices), len(expectedDevices))

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -65,6 +65,11 @@ keywords: "API, Docker, rcli, REST, documentation"
     - "locked"
     - "active/worker"
     - "active/manager"
+* `POST /containers/create` for Windows containers now accepts a new syntax in
+  `HostConfig.Resources.Devices.PathOnHost`. As well as the existing `class/<GUID>`
+  syntax, `<IDType>://<ID>` is now recognised. Support for specific `<IDType>` values
+  depends on the underlying implementation and Windows version. This change is not
+  versioned, and affects all API versions if the daemon has this patch.
 
 ## v1.41 API changes
 

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -540,7 +540,7 @@ func (s *DockerSuite) TestPsListContainersFilterCreated(c *testing.T) {
 	// filter containers by 'create' - note, no -a needed
 	out, _ = dockerCmd(c, "ps", "-q", "-f", "status=created")
 	containerOut := strings.TrimSpace(out)
-	assert.Assert(c, strings.HasPrefix(cID, containerOut))
+	assert.Assert(c, strings.Contains(containerOut, shortCID), "Should have seen '%s' in ps output:\n%s", shortCID, out)
 }
 
 // Test for GitHub issue #12595

--- a/integration/container/devices_windows_test.go
+++ b/integration/container/devices_windows_test.go
@@ -50,12 +50,10 @@ func TestWindowsDevices(t *testing.T) {
 			expectedStdout: "/Windows/System32/HostDriverStore/FileRepository",
 		},
 		{
-			doc:                         "process/vpci-class-guid://5B45201D-F2F2-4F3B-85BB-30FF1F953599 mounted",
-			devices:                     []string{"vpci-class-guid://5B45201D-F2F2-4F3B-85BB-30FF1F953599"},
-			isolation:                   containertypes.IsolationProcess,
-			expectedStartFailure:        !testEnv.RuntimeIsWindowsContainerd(),
-			expectedStartFailureMessage: "device assignment of type 'vpci-class-guid' is not supported",
-			expectedStdout:              "/Windows/System32/HostDriverStore/FileRepository",
+			doc:            "process/vpci-class-guid://5B45201D-F2F2-4F3B-85BB-30FF1F953599 mounted",
+			devices:        []string{"vpci-class-guid://5B45201D-F2F2-4F3B-85BB-30FF1F953599"},
+			isolation:      containertypes.IsolationProcess,
+			expectedStdout: "/Windows/System32/HostDriverStore/FileRepository",
 		},
 		{
 			doc:              "hyperv/no device mounted",

--- a/integration/container/devices_windows_test.go
+++ b/integration/container/devices_windows_test.go
@@ -44,6 +44,20 @@ func TestWindowsDevices(t *testing.T) {
 			expectedStdout: "/Windows/System32/HostDriverStore/FileRepository",
 		},
 		{
+			doc:            "process/class://5B45201D-F2F2-4F3B-85BB-30FF1F953599 mounted",
+			devices:        []string{"class://5B45201D-F2F2-4F3B-85BB-30FF1F953599"},
+			isolation:      containertypes.IsolationProcess,
+			expectedStdout: "/Windows/System32/HostDriverStore/FileRepository",
+		},
+		{
+			doc:                         "process/vpci-class-guid://5B45201D-F2F2-4F3B-85BB-30FF1F953599 mounted",
+			devices:                     []string{"vpci-class-guid://5B45201D-F2F2-4F3B-85BB-30FF1F953599"},
+			isolation:                   containertypes.IsolationProcess,
+			expectedStartFailure:        !testEnv.RuntimeIsWindowsContainerd(),
+			expectedStartFailureMessage: "device assignment of type 'vpci-class-guid' is not supported",
+			expectedStdout:              "/Windows/System32/HostDriverStore/FileRepository",
+		},
+		{
 			doc:              "hyperv/no device mounted",
 			isolation:        containertypes.IsolationHyperV,
 			expectedExitCode: 1,
@@ -51,6 +65,22 @@ func TestWindowsDevices(t *testing.T) {
 		{
 			doc:                         "hyperv/class/5B45201D-F2F2-4F3B-85BB-30FF1F953599 mounted",
 			devices:                     []string{"class/5B45201D-F2F2-4F3B-85BB-30FF1F953599"},
+			isolation:                   containertypes.IsolationHyperV,
+			expectedStartFailure:        !testEnv.RuntimeIsWindowsContainerd(),
+			expectedStartFailureMessage: "device assignment is not supported for HyperV containers",
+			expectedStdout:              "/Windows/System32/HostDriverStore/FileRepository",
+		},
+		{
+			doc:                         "hyperv/class://5B45201D-F2F2-4F3B-85BB-30FF1F953599 mounted",
+			devices:                     []string{"class://5B45201D-F2F2-4F3B-85BB-30FF1F953599"},
+			isolation:                   containertypes.IsolationHyperV,
+			expectedStartFailure:        !testEnv.RuntimeIsWindowsContainerd(),
+			expectedStartFailureMessage: "device assignment is not supported for HyperV containers",
+			expectedStdout:              "/Windows/System32/HostDriverStore/FileRepository",
+		},
+		{
+			doc:                         "hyperv/vpci-class-guid://5B45201D-F2F2-4F3B-85BB-30FF1F953599 mounted",
+			devices:                     []string{"vpci-class-guid://5B45201D-F2F2-4F3B-85BB-30FF1F953599"},
 			isolation:                   containertypes.IsolationHyperV,
 			expectedStartFailure:        !testEnv.RuntimeIsWindowsContainerd(),
 			expectedStartFailureMessage: "device assignment is not supported for HyperV containers",

--- a/integration/container/devices_windows_test.go
+++ b/integration/container/devices_windows_test.go
@@ -1,0 +1,67 @@
+package container // import "github.com/docker/docker/integration/container"
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	containertypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/integration/internal/container"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/poll"
+	"gotest.tools/v3/skip"
+)
+
+// TestWindowsDevices that Windows Devices are correctly propagated
+// via HostConfig.Devices through to the implementation in hcsshim.
+func TestWindowsDevices(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType != "windows")
+	defer setupTest(t)()
+	client := testEnv.APIClient()
+	ctx := context.Background()
+
+	testData := []struct {
+		doc              string
+		devices          []string
+		expectedExitCode int
+		expectedStdout   string
+		expectedStderr   string
+	}{
+		{
+			doc:              "no device mounted",
+			expectedExitCode: 1,
+		},
+		{
+			doc:            "class/5B45201D-F2F2-4F3B-85BB-30FF1F953599 mounted",
+			devices:        []string{"class/5B45201D-F2F2-4F3B-85BB-30FF1F953599"},
+			expectedStdout: "/Windows/System32/HostDriverStore/FileRepository",
+		},
+	}
+
+	for _, d := range testData {
+		d := d
+		t.Run(d.doc, func(t *testing.T) {
+			t.Parallel()
+			deviceOptions := []func(*container.TestContainerConfig){container.WithIsolation(containertypes.IsolationProcess)}
+			for _, deviceName := range d.devices {
+				deviceOptions = append(deviceOptions, container.WithWindowsDevice(deviceName))
+			}
+			id := container.Run(ctx, t, client, deviceOptions...)
+
+			poll.WaitOn(t, container.IsInState(ctx, client, id, "running"), poll.WithDelay(100*time.Millisecond))
+
+			// /Windows/System32/HostDriverStore is mounted from the host when class GUID 5B45201D-F2F2-4F3B-85BB-30FF1F953599
+			// is mounted. See `C:\windows\System32\containers\devices.def` on a Windows host for (slightly more) details.
+			res, err := container.Exec(ctx, client, id, []string{"sh", "-c",
+				"ls -d /Windows/System32/HostDriverStore/* | grep /Windows/System32/HostDriverStore/FileRepository"})
+			assert.NilError(t, err)
+			assert.Equal(t, d.expectedExitCode, res.ExitCode)
+			if d.expectedExitCode == 0 {
+				assert.Equal(t, d.expectedStdout, strings.TrimSpace(res.Stdout()))
+				assert.Equal(t, d.expectedStderr, strings.TrimSpace(res.Stderr()))
+			}
+
+		})
+	}
+}

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -213,3 +213,17 @@ func WithPlatform(p *specs.Platform) func(*TestContainerConfig) {
 		c.Platform = p
 	}
 }
+
+// WithWindowsDevice specifies a Windows Device, ala `--device` on the CLI
+func WithWindowsDevice(device string) func(*TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.HostConfig.Devices = append(c.HostConfig.Devices, containertypes.DeviceMapping{PathOnHost: device})
+	}
+}
+
+// WithIsolation specifies the isolation technology to apply to the container
+func WithIsolation(isolation containertypes.Isolation) func(*TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.HostConfig.Isolation = isolation
+	}
+}

--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -313,8 +313,8 @@ func (c *client) createWindows(id string, spec *specs.Spec, runtimeOptions inter
 		}
 		for _, d := range spec.Windows.Devices {
 			// Per https://github.com/microsoft/hcsshim/blob/v0.9.2/internal/uvm/virtual_device.go#L17-L18,
-			// this represents an Interface Class GUID.
-			if d.IDType != "class" {
+			// these represent an Interface Class GUID.
+			if d.IDType != "class" && d.IDType != "vpci-class-guid" {
 				return errors.Errorf("device assignment of type '%s' is not supported", d.IDType)
 			}
 			configuration.AssignedDevices = append(configuration.AssignedDevices, hcsshim.AssignedDevice{InterfaceClassGUID: d.ID})

--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -312,6 +312,11 @@ func (c *client) createWindows(id string, spec *specs.Spec, runtimeOptions inter
 			return errors.New("device assignment is not supported for HyperV containers")
 		}
 		for _, d := range spec.Windows.Devices {
+			// Per https://github.com/microsoft/hcsshim/blob/v0.9.2/internal/uvm/virtual_device.go#L17-L18,
+			// this represents an Interface Class GUID.
+			if d.IDType != "class" {
+				return errors.Errorf("device assignment of type '%s' is not supported", d.IDType)
+			}
 			configuration.AssignedDevices = append(configuration.AssignedDevices, hcsshim.AssignedDevice{InterfaceClassGUID: d.ID})
 		}
 	}


### PR DESCRIPTION
**- What I did**

Introduced a new Windows Device string syntax for the `--devices` and the `api.types.container.DeviceMapping.PathOnHost`.

The syntax is `IDType://ID`, reflecting an evolution and generalisation of the existing `class/ID` syntax. The latter remains supported specifically for `class/X`: `IDType/ID` for other `IDType`s is not implemented to avoid future parsing ambiguity.

This syntax will function with both the `--device` parameter from https://github.com/docker/cli, and also when fed from Kubernetes (or other CRI client) via https://github.com/Mirantis/cri-dockerd, or [dockershim](https://kubernetes.io/blog/2022/02/17/dockershim-faq/) where supported. Kubernetes and CRI are both currently agnostic about this format, passing the strings down from user-controlled APIs unchanged.

~~`DeviceMapping` no long accepts-and-ignores values in the `PathInContainer` or `CgroupPermissions` fields for Windows Devices.~~ (This will be a separate to-be-created PR, as this was a more-impactful change than I realised)

For reference, containerd has just [implemented the same syntax](https://github.com/containerd/containerd/pull/6618) for both CRI and the `ctr` CLI, to be part of the 1.7 release series. When [a more-specific CRI type is implemented for Windows Devices](https://github.com/kubernetes/kubernetes/issues/97739), then cri-dockerd (or other CRI implementation) will be responsible for packing the required data into this format for consumption by the daemon.

Windows Devices are no-longer limited to Process Isolation mode, as there are IDTypes that are also supported for HyperV Isolation, and I don't think it's desirable to repeat the mapping of which IDTypes work with which Isolation mode here.

**Note**: Due to limitations of the HCS v1 API used when not using the containerd backend:
* IDTypes other than `class` or `vpci-class-guid` are not supported without the containerd backend.
* Assigning devices to HyperV-isolated containers is not supported without the containerd backend.

Because these depend on the backend in-use, they are reported as failures from the backend via `ContainerStart` when not supported. Previously, `ContainerCreate` rejected both of these cases unconditionally, so these restrictions are looser than they were before this change.

Practically, these limitations from using the HCS v1 API won't matter, since Windows Server 2019 and earlier do not support the other IDType mappings, even if using the HCS v2 API via containerd, and Windows Server 2022 and later is intended to default to using the containerd backend and the HCS v2 API in Docker 21.xx. The only other Windows Server product not already end-of-life is SAC 20H2, [which does support the newer ID types](https://github.com/kubernetes/kubernetes/issues/97739#issuecomment-767981773). That product, the final Windows Server SAC release, reaches end-of-life in August 2022.

**- How I did it**

Changed the code that split `DeviceMapping{PathOnHost: "class/X"}` into `WindowsDevice{IDType:"class", ID: "X"}` to also split `DeviceMapping{PathOnHost: "W://X"}` into `WindowsDevice{IDType:"W", ID: "X"}`

**- How to verify it**

Unit test coverage for the parser.

Integration tests covering `class/5B45201D-F2F2-4F3B-85BB-30FF1F953599`, `class://5B45201D-F2F2-4F3B-85BB-30FF1F953599` and `vpci-class-guid://5B45201D-F2F2-4F3B-85BB-30FF1F953599` for both Process Isolation and HyperV isolation, supported by both containerd and HCS v1-based backends, where possible.

*Note*: Integration tests were having issues with HyperV isolation, so they have been skipped except for the early-failure case. It turns out we currently have no integration tests for HyperV isolation running on CI. This is possibly a nested-VM issue on the CI side, so it may vary by build-host config. I saw one pass for the skipped tests on an RS5 node.

Manually test exactly like the existing `--device` CLI flag on Windows, except using `class://` where you would currently use `class/`, e.g. `class/5B45201D-F2F2-4F3B-85BB-30FF1F953599` and `class://5B45201D-F2F2-4F3B-85BB-30FF1F953599` should produce identical results.

hcshim defines [a bunch of other possible IDTypes](https://github.com/microsoft/hcsshim/blob/v0.9.2/internal/uvm/virtual_device.go#L14-L21), but platform support and use-cases will vary, so I can't really advise on how to test them. And we don't deal with them here anyway, they go on opaquely down to hcshim to be handled.

**- Description for the changelog**

Windows Devices described by string, e.g. `--devices` in the CLI, now support the syntax `IDType://ID` as well as `class/ID`. Supported IDTypes depend on the active backend and other parameters of the container being created.

**- A picture of a cute animal (not mandatory but encouraged)**

[![Baby Animal](https://static.wikia.nocookie.net/muppet/images/d/dc/Character.babyanimal.jpg)](https://muppet.fandom.com/wiki/Muppet_Babies_(puppets)?file=Character.babyanimal.jpg)