### PR TITLE
Allow STOPSIGNAL instruction in commit change

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -35,6 +35,7 @@ var validCommitCommands = map[string]bool{
 	"expose":      true,
 	"label":       true,
 	"onbuild":     true,
+	"stopsignal":  true,
 	"user":        true,
 	"volume":      true,
 	"workdir":     true,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add `stopsignal` in `validCommitCommands` for `commit` command.

**- How I did it**
- `docker commit` command requests `CreateImageFromContainer` function. https://github.com/moby/moby/blob/a583434ebc5fb98bab6f693475e89e4d3a6703be/daemon/commit.go#L119
- This function calls `dockerfile.BuildFromConfig` function
https://github.com/moby/moby/blob/a583434ebc5fb98bab6f693475e89e4d3a6703be/daemon/commit.go#L149
- `validCommitCommands` is used to rejected unsupported instructions in `dockerfile.BuildFromConfig`
https://github.com/moby/moby/blob/a583434ebc5fb98bab6f693475e89e4d3a6703be/builder/dockerfile/builder.go#L339
- Back to `CreateImageFromContainer` function, `merge` function already support StopSIgnal
https://github.com/moby/moby/blob/a583434ebc5fb98bab6f693475e89e4d3a6703be/daemon/commit.go#L110

**- How to verify it**
Commit a new image with following command: `docker commit xxxx -c "STOPSIGNAL SIGRTMIN+3"`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Allow STOPSIGNAL instruction in commit changes

**- A picture of a cute animal (not mandatory but encouraged)**
![dolphin](https://user-images.githubusercontent.com/109060/158026289-6bd7da7f-6a7e-45af-995b-c6bfea1d4d4b.jpg)