### PR TITLE
api: swagger: add IPAMConfig on IPAM

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2035,11 +2035,23 @@ definitions:
           ```
         type: "array"
         items:
-          type: "object"
-          additionalProperties:
-            type: "string"
+          $ref: "#/definitions/IPAMConfig"
       Options:
         description: "Driver-specific options, specified as a map."
+        type: "object"
+        additionalProperties:
+          type: "string"
+
+  IPAMConfig:
+    type: "object"
+    properties:
+      Subnet:
+        type: "string"
+      IPRange:
+        type: "string"
+      Gateway:
+        type: "string"
+      AuxiliaryAddresses:
         type: "object"
         additionalProperties:
           type: "string"

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -2035,11 +2035,23 @@ definitions:
           ```
         type: "array"
         items:
-          type: "object"
-          additionalProperties:
-            type: "string"
+          $ref: "#/definitions/IPAMConfig"
       Options:
         description: "Driver-specific options, specified as a map."
+        type: "object"
+        additionalProperties:
+          type: "string"
+
+  IPAMConfig:
+    type: "object"
+    properties:
+      Subnet:
+        type: "string"
+      IPRange:
+        type: "string"
+      Gateway:
+        type: "string"
+      AuxiliaryAddresses:
         type: "object"
         additionalProperties:
           type: "string"


### PR DESCRIPTION
Signed-off-by: Niel Drummond <niel@drummond.lu>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
fixes #43292 
ref: https://github.com/fussybeaver/bollard/issues/201

**- What I did**
Changed the swagger documentation signature for the `IPAM` `Config` field from an array of strings, to a new `IPAMConfig` type.

**- How I did it**
Amended the YAML documentation for version 1.41.

**- How to verify it**
I used a swagger generator on the new type to verify the yaml and new type are created. Testing executed with the newly generated codebase by the original issue owner. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Changed swagger documentation IPAM config from array to IPAMConfig type

**- A picture of a cute animal (not mandatory but encouraged)**

