### PR TITLE
ci: simple gha workflow to build docker daemon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: ci
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+      - '[0-9]+.[0-9]{2}'
+    tags:
+      - 'v*'
+  pull_request:
+
+env:
+  BUNDLES_OUTPUT: ./bundles
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - binary
+          - dynbinary
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Build
+        uses: docker/bake-action@v1
+        with:
+          targets: ${{ matrix.target }}
+      -
+        name: Upload build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.target }}
+          path: ${{ env.BUNDLES_OUTPUT }}/${{ matrix.target }}-daemon/*
+          if-no-files-found: error

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,24 @@
+variable "BUNDLES_OUTPUT" {
+  default = "./bundles"
+}
+
+target "_common" {
+  args = {
+    BUILDKIT_CONTEXT_KEEP_GIT_DIR = 1
+  }
+}
+
+group "default" {
+  targets = ["binary"]
+}
+
+target "binary" {
+  inherits = ["_common"]
+  target = "binary"
+  output = [BUNDLES_OUTPUT]
+}
+
+target "dynbinary" {
+  inherits = ["binary"]
+  target = "dynbinary"
+}


### PR DESCRIPTION
Simple workflow to build `binary` and `dynbinary` targets. It's mainly to initialize a first workflow in this repo so integration tests for BuildKit can be triggered with built-in docker daemon in https://github.com/moby/moby/pull/43239 when rebased (https://github.com/moby/moby/pull/43239/commits/4476f0ed55e31d85009e5b62a1f89e190a021cc6)

**- What I did**

Simple workflow to build `binary` and `dynbinary` targets with a bake definition.

**- How I did it**

**- How to verify it**

```console
docker buildx bake binary
```

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>