### PR TITLE
libnetwork/overlay:fix sandbox deadlock

### DIFF
--- a/libnetwork/drivers/overlay/ov_network.go
+++ b/libnetwork/drivers/overlay/ov_network.go
@@ -319,7 +319,7 @@ func (n *network) joinSandbox(s *subnet, restore bool, incJoinCount bool) error 
 	defer func() {
 		n.Unlock()
 		if doInitPeerDB {
-			n.driver.initSandboxPeerDB(n.id)
+			go n.driver.initSandboxPeerDB(n.id)
 		}
 	}()
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

This PR updates #42842, but I don't have rights to their repo. @dojci, I've had some conversations with a maintainer, and moving to a goroutine instead should finally get this merged. Want to pull it in?

> We are using docker swarm with overlay network driver in the environment where stacks are very often updated. There was a problem several times a week when the docker daemon unexpectedly hangs forever, the docker daemon was unable to process update commands like remove and deploy stacks/services as well as container operations. The only thing that helped was the force-killing docker daemon and start it again. This problem often happens when we want to redeploy stack/service. When the docker gets stuck, the service from the given stack always remains in the Remove state forever. It is very difficult to reproduce this problem and we didn't find a reliable way to trigger this deadlock issue. We could only wait for it to happen spontaneously (2-4 times a week).

**- What I did**
 I changed the way how the peerInit operation is called from joinSandbox() to avoid deadlock.
 
**- How I did it**
Spooling `initSandboxPeerDB` off into a goroutine so if it needs to write back to `peerOpCh`, we do not have the same goroutine both producing and consuming, deadlocking the channel.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Operations performed on overlay network sandboxes are handled by
dispatching operations send through a channel. This allows for
asynchronous operations to be performed which, since they are
not called from within another function, are able to operate in
an idempotent manner with a known/measurable starting state from
which an identical series of iterative actions can be performed.

However, it was possible in some cases for an operation dispatched
from this channel to write a message back to the channel in the
case of joining a network when a sufficient volume of sandboxes
were operated on.

A goroutine which is simultaneously reading and writing to an
unbuffered channel can deadlock if it sends a message to a channel
then waits for it to be consumed and completed, since the only
available goroutine is more or less "talking to itself". In order
to break this deadlock, in the observed race, a goroutine is now
created to send the message to the channel.
