### PR TITLE
client: ImageSearch(): don't send limit if none was specified

### DIFF
--- a/client/image_search.go
+++ b/client/image_search.go
@@ -3,8 +3,8 @@ package client // import "github.com/docker/docker/client"
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/url"
+	"strconv"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -18,7 +18,9 @@ func (cli *Client) ImageSearch(ctx context.Context, term string, options types.I
 	var results []registry.SearchResult
 	query := url.Values{}
 	query.Set("term", term)
-	query.Set("limit", fmt.Sprintf("%d", options.Limit))
+	if options.Limit > 0 {
+		query.Set("limit", strconv.Itoa(options.Limit))
+	}
 
 	if options.Filters.Len() > 0 {
 		filterJSON, err := filters.ToJSON(options.Filters)


### PR DESCRIPTION

- (slightly) related to https://github.com/moby/moby/pull/43312
- related to https://github.com/docker/cli/pull/3471

The API defines a default limit for searches, but when removing the
default from the cli, the client still sends "0" as a limit, which
is not allowed by existing versions of the API:

    docker search --limit=0 busybox
    Error response from daemon: Limit 0 is outside the range of [1, 100]

This patch changes the client so that no limit is sent if none was set ("0"),
allowing the daemon to use its (or the registry's) default.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

