### PR TITLE
registry: remove more dead code

### DIFF
--- a/registry/auth.go
+++ b/registry/auth.go
@@ -63,14 +63,6 @@ func (scs staticCredentialStore) RefreshToken(*url.URL, string) string {
 func (scs staticCredentialStore) SetRefreshToken(*url.URL, string, string) {
 }
 
-type fallbackError struct {
-	err error
-}
-
-func (err fallbackError) Error() string {
-	return err.err.Error()
-}
-
 // loginV2 tries to login to the v2 registry server. The given registry
 // endpoint will be pinged to get authorization challenges. These challenges
 // will be used to authenticate against the registry to validate credentials.

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -24,7 +24,7 @@ func spawnTestRegistrySession(t *testing.T) *session {
 	}
 	userAgent := "docker test client"
 	var tr http.RoundTripper = debugTransport{newTransport(nil), t.Log}
-	tr = transport.NewTransport(AuthTransport(tr, authConfig, false), Headers(userAgent, nil)...)
+	tr = transport.NewTransport(newAuthTransport(tr, authConfig, false), Headers(userAgent, nil)...)
 	client := httpClient(tr)
 
 	if err := authorizeClient(client, authConfig, endpoint); err != nil {

--- a/registry/service.go
+++ b/registry/service.go
@@ -29,7 +29,6 @@ type Service interface {
 	ResolveRepository(name reference.Named) (*RepositoryInfo, error)
 	Search(ctx context.Context, term string, limit int, authConfig *types.AuthConfig, userAgent string, headers map[string][]string) (*registry.SearchResults, error)
 	ServiceConfig() *registry.ServiceConfig
-	TLSConfig(hostname string) (*tls.Config, error)
 	LoadAllowNondistributableArtifacts([]string) error
 	LoadMirrors([]string) error
 	LoadInsecureRegistries([]string) error
@@ -219,15 +218,6 @@ type APIEndpoint struct {
 	Official                       bool
 	TrimHostname                   bool
 	TLSConfig                      *tls.Config
-}
-
-// TLSConfig constructs a client TLS configuration based on server defaults
-func (s *defaultService) TLSConfig(hostname string) (*tls.Config, error) {
-	s.mu.RLock()
-	secure := s.config.isSecureIndex(hostname)
-	s.mu.RUnlock()
-
-	return newTLSConfig(hostname, secure)
 }
 
 // LookupPullEndpoints creates a list of v2 endpoints to try to pull from, in order of preference.

--- a/registry/service.go
+++ b/registry/service.go
@@ -175,23 +175,16 @@ func (s *defaultService) Search(ctx context.Context, term string, limit int, aut
 		modifiers := Headers(userAgent, nil)
 		v2Client, err := v2AuthHTTPClient(endpoint.URL, endpoint.client.Transport, modifiers, creds, scopes)
 		if err != nil {
-			if fErr, ok := err.(fallbackError); ok {
-				logrus.WithError(fErr.err).Error("cannot use identity token for search, v2 auth not supported")
-			} else {
-				return nil, err
-			}
-		} else {
-			// Copy non transport http client features
-			v2Client.Timeout = endpoint.client.Timeout
-			v2Client.CheckRedirect = endpoint.client.CheckRedirect
-			v2Client.Jar = endpoint.client.Jar
-
-			logrus.Debugf("using v2 client for search to %s", endpoint.URL)
-			client = v2Client
+			return nil, err
 		}
-	}
+		// Copy non transport http client features
+		v2Client.Timeout = endpoint.client.Timeout
+		v2Client.CheckRedirect = endpoint.client.CheckRedirect
+		v2Client.Jar = endpoint.client.Jar
 
-	if client == nil {
+		logrus.Debugf("using v2 client for search to %s", endpoint.URL)
+		client = v2Client
+	} else {
 		client = endpoint.client
 		if err := authorizeClient(client, authConfig, endpoint); err != nil {
 			return nil, err

--- a/registry/session.go
+++ b/registry/session.go
@@ -39,7 +39,7 @@ type authTransport struct {
 	modReq map[*http.Request]*http.Request // original -> modified
 }
 
-// AuthTransport handles the auth layer when communicating with a v1 registry (private or official)
+// newAuthTransport handles the auth layer when communicating with a v1 registry (private or official)
 //
 // For private v1 registries, set alwaysSetBasicAuth to true.
 //
@@ -52,7 +52,7 @@ type authTransport struct {
 // If the server sends a token without the client having requested it, it is ignored.
 //
 // This RoundTripper also has a CancelRequest method important for correct timeout handling.
-func AuthTransport(base http.RoundTripper, authConfig *types.AuthConfig, alwaysSetBasicAuth bool) http.RoundTripper {
+func newAuthTransport(base http.RoundTripper, authConfig *types.AuthConfig, alwaysSetBasicAuth bool) *authTransport {
 	if base == nil {
 		base = http.DefaultTransport
 	}
@@ -165,7 +165,7 @@ func authorizeClient(client *http.Client, authConfig *types.AuthConfig, endpoint
 
 	// Annotate the transport unconditionally so that v2 can
 	// properly fallback on v1 when an image is not found.
-	client.Transport = AuthTransport(client.Transport, authConfig, alwaysSetBasicAuth)
+	client.Transport = newAuthTransport(client.Transport, authConfig, alwaysSetBasicAuth)
 
 	jar, err := cookiejar.New(nil)
 	if err != nil {


### PR DESCRIPTION
- follow up to https://github.com/moby/moby/pull/43298

- registry: remove unused `Service.TLSConfig()`
- registry: un-export AuthTransport() - It's only used internally for v1 search
- registry: remove unused fallbackError - nothing was emitting this error.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

