### PR TITLE
bridge: also flush conntrack entries when setting up endpoints

### DIFF
--- a/libnetwork/drivers/bridge/bridge.go
+++ b/libnetwork/drivers/bridge/bridge.go
@@ -1352,6 +1352,11 @@ func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string
 		}
 	}()
 
+	// Clean the connection tracker state of the host for the
+	// specific endpoint. This is needed because some flows may be
+	// bound to the local proxy and won't bre redirect to the new endpoints.
+	clearEndpointConnections(d.nlh, endpoint)
+
 	if err = d.storeUpdate(endpoint); err != nil {
 		return fmt.Errorf("failed to update bridge endpoint %.7s to store: %v", endpoint.id, err)
 	}


### PR DESCRIPTION
**- What I did**

- addresses issue #8795 still reported by some people.

**- How I did it**

- Clear conntrack after configuring network endpoints for the bridge driver

There is a race condition between the local proxy and iptables rule
setting. When we have a lot of UDP traffic, the kernel will create
conntrack entries to the local proxy and will ignore the iptables
rules set after that.

Related to PR #32505.

**- How to verify it**

That's the hard point as this is a race condition. You need to have a lot of UDP packets for them to reach the local proxy before iptables rules are set.

**- Description for the changelog**

Fix UDP traffic in containers not working after the container is restarted on sustained traffic
