### PR TITLE
Add support for custom root CAs in dev containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ junit-report.xml
 
 # top-level go.mod is not meant to be checked in
 /go.mod
+
+# ignore custom development certificates
+/hack/dockerfile/certs/*.crt

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.con
 ARG APT_MIRROR
 RUN sed -ri "s/(httpredir|deb).debian.org/${APT_MIRROR:-deb.debian.org}/g" /etc/apt/sources.list \
  && sed -ri "s/(security).debian.org/${APT_MIRROR:-security.debian.org}/g" /etc/apt/sources.list
+RUN --mount=type=bind,target=/usr/local/share/ca-certificates,source=/hack/dockerfile/certs update-ca-certificates
 ENV GO111MODULE=off
 
 FROM base AS criu

--- a/hack/dockerfile/certs/README.md
+++ b/hack/dockerfile/certs/README.md
@@ -1,0 +1,9 @@
+# Custom Root CA Certificates for Dev Containers
+
+Any files with a `.crt` extension in this directory are added as trusted root
+CA certificates in the `base` container. This is helpful if you are building
+Moby in an environment that intercepts HTTPS traffic (like some corporate
+networks) and are seeing TLS errors with the default settings.
+
+Git ignores all `.crt` files in this directory to reduce the risk of committing
+private certificates.


### PR DESCRIPTION
**- What I did**

Added support for custom root CA certificates in development containers. I'm trying to hack on Moby in a corporate environment that uses TLS decryption, so by default, the dev containers (e.g. `make shell`) failed to build due to TLS errors in the steps that use `proxy.golang.org`, `github.com`, and possibly others that hadn't gotten to yet.

**- How I did it**

Add a directory where developers can add additional root certificates. `.crt` files in this directory are added to `/usr/local/share/ca-certificates` directory with a `COPY` step in the `base` image and then added to the system by running `update-ca-certificates`.

**- How to verify it**

If you have access to an environment that uses an alternate CA, add the root certificate to the directory then build the development container. I suppose you could also run a local server with a self-signed cert and add a build step that uses `curl` to make a request against the local server.

I tested in my environment to verify that a build was successful with the right root certificate present and failed with TLS errors when I did not add the certificate. Having no additional certificates (the default state) does not cause any other build issues.

**- Description for the changelog**

Add support for custom root CAs in Moby development containers

