### PR TITLE
registry: remove dependency on rootlesskit, add `SetCertsDir()`

### DIFF
--- a/cmd/dockerd/config_windows.go
+++ b/cmd/dockerd/config_windows.go
@@ -33,3 +33,7 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.StringVarP(&conf.SocketGroup, "group", "G", "", "Users or groups that can access the named pipe")
 	return nil
 }
+
+// configureCertsDir configures registry.CertsDir() depending on if the daemon
+// is running in rootless mode or not. On Windows, it is a no-op.
+func configureCertsDir() {}

--- a/cmd/dockerd/docker.go
+++ b/cmd/dockerd/docker.go
@@ -45,6 +45,7 @@ func newDaemonCommand() (*cobra.Command, error) {
 		return nil, err
 	}
 	flags.StringVar(&opts.configFile, "config-file", defaultDaemonConfigFile, "Daemon configuration file")
+	configureCertsDir()
 	opts.InstallFlags(flags)
 	if err := installConfigFlags(opts.daemonConfig, flags); err != nil {
 		return nil, err

--- a/registry/config.go
+++ b/registry/config.go
@@ -59,7 +59,25 @@ var (
 
 	// for mocking in unit tests
 	lookupIP = net.LookupIP
+
+	// certsDir is used to override defaultCertsDir.
+	certsDir string
 )
+
+// SetCertsDir allows the default certs directory to be changed. This function
+// is used at daemon startup to set the correct location when running in
+// rootless mode.
+func SetCertsDir(path string) {
+	certsDir = path
+}
+
+// CertsDir is the directory where certificates are stored.
+func CertsDir() string {
+	if certsDir != "" {
+		return certsDir
+	}
+	return defaultCertsDir
+}
 
 // newServiceConfig returns a new instance of ServiceConfig
 func newServiceConfig(options ServiceOptions) (*serviceConfig, error) {

--- a/registry/config_unix.go
+++ b/registry/config_unix.go
@@ -3,25 +3,10 @@
 
 package registry // import "github.com/docker/docker/registry"
 
-import (
-	"path/filepath"
-
-	"github.com/docker/docker/pkg/homedir"
-	"github.com/docker/docker/rootless"
-)
-
-// CertsDir is the directory where certificates are stored
-func CertsDir() string {
-	d := "/etc/docker/certs.d"
-
-	if rootless.RunningWithRootlessKit() {
-		configHome, err := homedir.GetConfigHome()
-		if err == nil {
-			d = filepath.Join(configHome, "docker/certs.d")
-		}
-	}
-	return d
-}
+// defaultCertsDir is the platform-specific default directory where certificates
+// are stored. On Linux, it may be overridden through certsDir, for example, when
+// running in rootless mode.
+const defaultCertsDir = "/etc/docker/certs.d"
 
 // cleanPath is used to ensure that a directory name is valid on the target
 // platform. It will be passed in something *similar* to a URL such as

--- a/registry/config_windows.go
+++ b/registry/config_windows.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 )
 
-// CertsDir is the directory where certificates are stored
-func CertsDir() string {
-	return os.Getenv("programdata") + `\docker\certs.d`
-}
+// defaultCertsDir is the platform-specific default directory where certificates
+// are stored. On Linux, it may be overridden through certsDir, for example, when
+// running in rootless mode.
+var defaultCertsDir = os.Getenv("programdata") + `\docker\certs.d`
 
 // cleanPath is used to ensure that a directory name is valid on the target
 // platform. It will be passed in something *similar* to a URL such as


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/42330
- relates to https://github.com/docker/cli/pull/3486 https://github.com/docker/cli/pull/3486#discussion_r835121443 

The registry package contained code to automatically set the CertsDir() path, based on wether or not the daemon was running in rootlessmode. In doing so, it made use of the `pkg/rootless.RunningWithRootlessKit()` utility.

A recent change in de6732a403af49a18c754bb9de0abf18ad48e3c8 (https://github.com/moby/moby/pull/42330) added additional functionality in the `pkg/rootless` package, introducing a dependency on `github.com/rootless-containers/rootlesskit`. Unfortunately, the extra dependency also made its way into the docker cli, which also uses the registry package.

This patch introduces a new `SetCertsDir()` function, which allows the default certs-directory to be overridden, and updates the daemon to configure this location during startup.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

