### PR TITLE
distribution: fix matching amd64 variants

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -22,6 +22,7 @@ import (
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	archvariant "github.com/tonistiigi/go-archvariant"
 )
 
 type createOpts struct {
@@ -68,7 +69,7 @@ func (daemon *Daemon) containerCreate(opts createOpts) (containertypes.Container
 
 	if opts.params.Platform == nil && opts.params.Config.Image != "" {
 		if img, _ := daemon.imageService.GetImage(opts.params.Config.Image, opts.params.Platform); img != nil {
-			p := platforms.DefaultSpec()
+			p := maximumSpec()
 			imgPlat := v1.Platform{
 				OS:           img.OS,
 				Architecture: img.Architecture,
@@ -318,4 +319,13 @@ func verifyNetworkingConfig(nwConfig *networktypes.NetworkingConfig) error {
 		}
 	}
 	return nil
+}
+
+// maximumSpec returns the distribution platform with maximum compatibility for the current node.
+func maximumSpec() v1.Platform {
+	p := platforms.DefaultSpec()
+	if p.Architecture == "amd64" {
+		p.Variant = archvariant.AMD64Variant()
+	}
+	return p
 }

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -33,6 +33,7 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	archvariant "github.com/tonistiigi/go-archvariant"
 )
 
 var (
@@ -1026,4 +1027,13 @@ func toOCIPlatform(p manifestlist.PlatformSpec) specs.Platform {
 		OSFeatures:   p.OSFeatures,
 		OSVersion:    p.OSVersion,
 	}
+}
+
+// maximumSpec returns the distribution platform with maximum compatibility for the current node.
+func maximumSpec() specs.Platform {
+	p := platforms.DefaultSpec()
+	if p.Architecture == "amd64" {
+		p.Variant = archvariant.AMD64Variant()
+	}
+	return p
 }

--- a/distribution/pull_v2_unix.go
+++ b/distribution/pull_v2_unix.go
@@ -54,7 +54,7 @@ func checkImageCompatibility(imageOS, imageOSVersion string) error {
 }
 
 func withDefault(p specs.Platform) specs.Platform {
-	def := platforms.DefaultSpec()
+	def := maximumSpec()
 	if p.OS == "" {
 		p.OS = def.OS
 	}

--- a/distribution/pull_v2_unix.go
+++ b/distribution/pull_v2_unix.go
@@ -5,6 +5,7 @@ package distribution // import "github.com/docker/docker/distribution"
 
 import (
 	"context"
+	"sort"
 
 	"github.com/containerd/containerd/platforms"
 	"github.com/docker/distribution"
@@ -20,7 +21,7 @@ func (ld *v2LayerDescriptor) open(ctx context.Context) (distribution.ReadSeekClo
 
 func filterManifests(manifests []manifestlist.ManifestDescriptor, p specs.Platform) []manifestlist.ManifestDescriptor {
 	p = platforms.Normalize(withDefault(p))
-	m := platforms.NewMatcher(p)
+	m := platforms.Only(p)
 	var matches []manifestlist.ManifestDescriptor
 	for _, desc := range manifests {
 		if m.Match(toOCIPlatform(desc.Platform)) {
@@ -28,6 +29,10 @@ func filterManifests(manifests []manifestlist.ManifestDescriptor, p specs.Platfo
 			logrus.Debugf("found match for %s with media type %s, digest %s", platforms.Format(p), desc.MediaType, desc.Digest.String())
 		}
 	}
+
+	sort.SliceStable(matches, func(i, j int) bool {
+		return m.Less(toOCIPlatform(matches[i].Platform), toOCIPlatform(matches[j].Platform))
+	})
 
 	// deprecated: backwards compatibility with older versions that didn't compare variant
 	if len(matches) == 0 && p.Architecture == "arm" {

--- a/vendor.mod
+++ b/vendor.mod
@@ -74,6 +74,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/tchap/go-patricia v2.3.0+incompatible
 	github.com/tonistiigi/fsutil v0.0.0-20220115021204-b19f7f9cb274
+	github.com/tonistiigi/go-archvariant v1.0.0
 	github.com/vbatts/tar-split v0.11.2
 	github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5
 	github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f
@@ -137,7 +138,6 @@ require (
 	github.com/rexray/gocsi v1.2.2 // indirect
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
 	github.com/tinylib/msgp v1.1.0 // indirect
-	github.com/tonistiigi/go-archvariant v1.0.0 // indirect
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.2 // indirect


### PR DESCRIPTION
These commits correct the support for pulling images with custom amd64 variants https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels that are used by the latest Go, GCC, LLVM etc.

The first commit matches variant comparison to containerd.

Second commit ensures that when no specific platform is set then the variant with maximum compatibility with the current system is used. Warning is also fixed so that it doesn't show up when variants are compatible.

Note that builder part default platform is intentionally not updated as `linux/amd64` (implicit v1) remains default there. When building new images default is to build v1 - maximum compatibility with the rest of the systems. When pulling default is to pull image with maximum compatibility for the current system.

You can use these images to test the behavior https://hub.docker.com/r/tonistiigi/test/tags?page=1&name=amd64