### PR TITLE
client: container ps: don't set "limit" if none was set

### DIFF
--- a/client/container_list.go
+++ b/client/container_list.go
@@ -18,7 +18,7 @@ func (cli *Client) ContainerList(ctx context.Context, options types.ContainerLis
 		query.Set("all", "1")
 	}
 
-	if options.Limit != -1 {
+	if options.Limit > 0 {
 		query.Set("limit", strconv.Itoa(options.Limit))
 	}
 

--- a/client/container_list_test.go
+++ b/client/container_list_test.go
@@ -39,8 +39,8 @@ func TestContainerList(t *testing.T) {
 				return nil, fmt.Errorf("all not set in URL query properly. Expected '1', got %s", all)
 			}
 			limit := query.Get("limit")
-			if limit != "0" {
-				return nil, fmt.Errorf("limit should have not be present in query. Expected '0', got %s", limit)
+			if limit != "" {
+				return nil, fmt.Errorf("limit should have not be present in query, got %s", limit)
 			}
 			since := query.Get("since")
 			if since != "container" {
@@ -48,7 +48,7 @@ func TestContainerList(t *testing.T) {
 			}
 			before := query.Get("before")
 			if before != "" {
-				return nil, fmt.Errorf("before should have not be present in query, go %s", before)
+				return nil, fmt.Errorf("before should have not be present in query, got %s", before)
 			}
 			size := query.Get("size")
 			if size != "1" {


### PR DESCRIPTION
both -1 and 0 are accepted as "no limit", so don't send the limit option if no limit was set.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

