### PR TITLE
Add implementation of wildcard DNS lookup for container aliases

### DIFF
--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -2001,7 +2001,13 @@ func (n *network) ResolveName(req string, ipType int) ([]net.IP, bool) {
 				strings.HasSuffix(req, strings.TrimPrefix(key, "*"))) {
 			selectedKey = key
 			ok = true
-			ipSet, _ = sr.svcMap.Get(selectedKey)
+			var found bool
+			ipSet, found = sr.svcMap.Get(selectedKey)
+			if !found {
+				logrus.Errorf("svcMap changed unexpectedly looking for key %s", key)
+				continue
+			}
+
 			break
 		}
 	}


### PR DESCRIPTION
Fixes #43442

**- What I did**

Add implementation of wildcard DNS lookup for container aliases

**- How I did it**

`ResolveName` function is updated to perform both exact match for service name to request, and also wildcard match, i.e. entries starting `*.`, strip the `*` and check if the remainder is a _suffix_ of the request. There is an [RFC](https://datatracker.ietf.org/doc/html/rfc4592) clarifying how this should work, I _think_ this implementation complies. 

I welcome suggestions for faster implementation. I am slightly concerned that I have swapped a map lookup to a loop, which could have a negative performance impact for large numbers of containers.

**- How to verify it**

Unit test is added. Manual verification can be performed: 
```
docker network create foonetwork
docker run --network foonetwork '--network-alias=*.foo.local' -d nginx
docker run --network foonetwork alpine wget -O - http://my.foo.local
... expect HTML output from nginx ...
```

**- Description for the changelog**

Add support for wildcard aliases with --network-alias argument/

**- A picture of a cute animal (not mandatory but encouraged)**

https://c.files.bbci.co.uk/7853/production/_115230803_i61pmw-q.jpg
