### PR TITLE
daemon/config: move proxy settings to "proxies" struct within daemon.json

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -160,7 +160,9 @@ type CommonConfig struct {
 	ExecRoot              string                    `json:"exec-root,omitempty"`
 	SocketGroup           string                    `json:"group,omitempty"`
 	CorsHeaders           string                    `json:"api-cors-header,omitempty"`
-	ProxyConfig
+
+	// Proxies holds the proxies that are configured for the daemon.
+	Proxies `json:"proxies"`
 
 	// TrustKeyPath is used to generate the daemon ID and for signing schema 1 manifests
 	// when pushing to a registry which does not support schema 2. This field is marked as
@@ -271,8 +273,8 @@ type CommonConfig struct {
 	DefaultRuntime string `json:"default-runtime,omitempty"`
 }
 
-// ProxyConfig holds the proxy-configuration for the daemon.
-type ProxyConfig struct {
+// Proxies holds the proxies that are configured for the daemon.
+type Proxies struct {
 	HTTPProxy  string `json:"http-proxy,omitempty"`
 	HTTPSProxy string `json:"https-proxy,omitempty"`
 	NoProxy    string `json:"no-proxy,omitempty"`

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -30,10 +30,10 @@ func (daemon *Daemon) Reload(conf *config.Config) (err error) {
 		if err == nil {
 			jsonString, _ := json.Marshal(&struct {
 				*config.Config
-				config.ProxyConfig
+				config.Proxies `json:"proxies"`
 			}{
 				Config: daemon.configStore,
-				ProxyConfig: config.ProxyConfig{
+				Proxies: config.Proxies{
 					HTTPProxy:  config.MaskCredentials(daemon.configStore.HTTPProxy),
 					HTTPSProxy: config.MaskCredentials(daemon.configStore.HTTPSProxy),
 					NoProxy:    config.MaskCredentials(daemon.configStore.NoProxy),

--- a/integration/daemon/daemon_test.go
+++ b/integration/daemon/daemon_test.go
@@ -253,7 +253,7 @@ func TestDaemonProxy(t *testing.T) {
 		ctx := context.Background()
 
 		configFile := filepath.Join(d.RootDir(), "daemon.json")
-		configJSON := fmt.Sprintf(`{"http-proxy":%[1]q, "https-proxy": %[1]q, "no-proxy": "example.com"}`, proxyServer.URL)
+		configJSON := fmt.Sprintf(`{"proxies":{"http-proxy":%[1]q, "https-proxy": %[1]q, "no-proxy": "example.com"}}`, proxyServer.URL)
 		assert.NilError(t, os.WriteFile(configFile, []byte(configJSON), 0644))
 
 		d.Start(t, "--config-file", configFile)
@@ -293,7 +293,7 @@ func TestDaemonProxy(t *testing.T) {
 		d := daemon.New(t)
 
 		configFile := filepath.Join(d.RootDir(), "daemon.json")
-		configJSON := fmt.Sprintf(`{"http-proxy":%[1]q, "https-proxy": %[1]q, "no-proxy": "example.com"}`, proxyRawURL)
+		configJSON := fmt.Sprintf(`{"proxies":{"http-proxy":%[1]q, "https-proxy": %[1]q, "no-proxy": "example.com"}}`, proxyRawURL)
 		assert.NilError(t, os.WriteFile(configFile, []byte(configJSON), 0644))
 
 		err := d.StartWithError("--http-proxy", proxyRawURL, "--https-proxy", proxyRawURL, "--no-proxy", "example.com", "--config-file", configFile, "--validate")


### PR DESCRIPTION
### daemon/config: move proxy settings to "proxies" struct within daemon.json

This is a follow-up to 427c7cc5f86364466c7173e8ca59b97c3876471d (https://github.com/moby/moby/pull/42835), which added proxy-configuration options ("http-proxy", "https-proxy", "no-proxy") to the dockerd cli and in `daemon.json`.

While working on documentation changes for this feature, I realised that those options won't be "next" to each-other when formatting the daemon.json JSON, for example using `jq` (which sorts the fields alphabetically). As it's possible that additional proxy configuration options are added in future, I considered that grouping these options in a struct within the JSON may help setting these options, as well as discovering related options.

This patch introduces a "proxies" field in the JSON, which includes the "http-proxy", "https-proxy", "no-proxy" options.

Conflict detection continues to work as before; with this patch applied:

```bash
cat /etc/docker/config.json
{
  "proxies": {
    "http-proxy": "http-config",
    "https-proxy": "https-config",
    "no-proxy": "no-proxy-config"
  }
}

dockerd --http-proxy=http-flag --https-proxy=https-flag --no-proxy=no-proxy-flag --validate

unable to configure the Docker daemon with file /etc/docker/daemon.json:
the following directives are specified both as a flag and in the configuration file:
http-proxy: (from flag: http-flag, from file: http-config),
https-proxy: (from flag: https-flag, from file: https-config),
no-proxy: (from flag: no-proxy-flag, from file: no-proxy-config)
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

