### PR TITLE
Makefile: update buildx to v0.8.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all binary dynbinary build cross help install manpages run shell test test-docker-py test-integration test-unit validate win
 
-BUILDX_VERSION ?= v0.6.0
+BUILDX_VERSION ?= v0.8.2
 
 ifdef USE_BUILDX
 BUILDX ?= $(shell command -v buildx)


### PR DESCRIPTION
release notes: https://github.com/docker/buildx/releases/tag/v0.8.2

Notable changes:

- Update Compose spec used by buildx bake to v1.2.1 to fix parsing ports definition
- Fix possible crash on handling progress streams from BuildKit v0.10
- Fix parsing groups in buildx bake when already loaded by a parent group


**- A picture of a cute animal (not mandatory but encouraged)**

