### PR TITLE
[20.10] vendor: github.com/docker/distribution v2.8.1

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -78,7 +78,7 @@ github.com/modern-go/concurrent                     bacd9c7ef1dd9b15be4a9909b8ac
 github.com/modern-go/reflect2                       94122c33edd36123c84d5368cfb2b69df93a0ec8 # v1.0.1
 
 # get graph and distribution packages
-github.com/docker/distribution                      dcf66392d606f50bf3a9286dcb4bdcdfb7c0e83a # v2.8.0
+github.com/docker/distribution                      b5ca020cfbe998e5af3457fda087444cf5116496 # v2.8.1
 github.com/vbatts/tar-split                         620714a4c508c880ac1bdda9c8370a2b19af1a55 # v0.11.1
 github.com/opencontainers/go-digest                 ea51bea511f75cfa3ef6098cc253c5c3609b037a # v1.0.0
 


### PR DESCRIPTION
equivalent of b92af14a1c47368b8cf1c52e303adf6e11cebc3b (https://github.com/moby/moby/pull/43352), for 20.10.x

no changes to code we use, but the v2.8.0 module was borked

full diff: https://github.com/docker/distribution/compare/v2.8.0...v2.8.1


**- A picture of a cute animal (not mandatory but encouraged)**

