### PR TITLE
[20.10 backport] update runc binary to v1.1.1

### DIFF
--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.conf accordingly
-: "${RUNC_VERSION:=v1.1.0}"
+: "${RUNC_VERSION:=v1.1.1}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.conf accordingly
-: "${RUNC_VERSION:=v1.0.3}"
+: "${RUNC_VERSION:=v1.1.0}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"


### PR DESCRIPTION
depends on:

- [x] https://github.com/containerd/containerd/pull/6770
- [ ]  a new release of containerd v1.5 so that the `containerd.io` packages and the static packages have the same version


backport of:

- backport first commit from https://github.com/moby/moby/pull/43083
- backport second commit from https://github.com/moby/moby/pull/43445



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

