### PR TITLE
daemon/config: fix TestReloadDefaultConfigNotExist if file exists

### DIFF
--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -446,10 +446,10 @@ func TestReloadSetConfigFileNotExist(t *testing.T) {
 func TestReloadDefaultConfigNotExist(t *testing.T) {
 	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 	reloaded := false
-	configFile := "/etc/docker/daemon.json"
+	defaultConfigFile := "/tmp/blabla/not/exists/daemon.json"
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	flags.String("config-file", configFile, "")
-	err := Reload(configFile, flags, func(c *Config) {
+	flags.String("config-file", defaultConfigFile, "")
+	err := Reload(defaultConfigFile, flags, func(c *Config) {
 		reloaded = true
 	})
 	assert.Check(t, err)


### PR DESCRIPTION
The TestReloadDefaultConfigNotExist() test assumed it was running in a clean
environment, in which the `/etc/docker/daemon.json` file doesn't exist, and
would fail if that was not the case..

This patch updates the test to override the default location to a a non-existing
path, to allow running the test in an environment where `/etc/docker/daemon.json`
is present.

**- A picture of a cute animal (not mandatory but encouraged)**

