### PR TITLE
api: add "Listeners" field to /info, to help discover how the API is exposed

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -452,6 +452,9 @@ are not part of the underlying image's Config, and deprecated:
   may take no effect, depending on the kernel version and OCI runtime in use.
 * `GET /containers/{id}/json` now omits the `KernelMemory` and `KernelMemoryTCP`
   if they are not set.
+* `GET /info` now returns a `Listeners` property, containing a list of addresses
+  on which the API is listening. This change is not versioned, and affects all
+  API versions if the daemon has this patch.
 * `GET /info` now omits the `KernelMemory` and `KernelMemoryTCP` if they are not
   supported by the host or host's configuration (if cgroups v2 are in use).
 * `GET /_ping` and `HEAD /_ping` now return `Builder-Version` by default.

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -7294,6 +7294,10 @@ definitions:
           $ref: "#/definitions/DeviceInfo"
       NRI:
         $ref: "#/definitions/NRIInfo"
+      Listeners:
+        type: "array"
+        items:
+          $ref: "#/definitions/ListenerInfo"
       Warnings:
         description: |
           List of warnings / informational messages about missing features, or
@@ -7622,6 +7626,24 @@ definitions:
         description: "Actual commit ID of external tool."
         type: "string"
         example: "cfb82a876ecc11b5ca0977d1733adbe58599088a"
+
+  ListenerInfo:
+    description: |
+      ListenerInfo provides information about an address that the API is listening on.
+    type: "object"
+    properties:
+      Address:
+        description: |
+          Address is the address that the daemon API is listening on.
+        type: "string"
+        example: "unix:///var/run/docker.sock"
+      Insecure:
+        description: |
+          Insecure indicates if the address is insecure, which could be either
+          if the daemon is configured without TLS client verification, or if
+          TLS verify is disabled.
+        type: "boolean"
+        example: false
 
   SwarmInfo:
     description: |

--- a/api/types/system/info.go
+++ b/api/types/system/info.go
@@ -71,7 +71,8 @@ type Info struct {
 	SecurityOptions     []string
 	ProductLicense      string               `json:",omitempty"`
 	DefaultAddressPools []NetworkAddressPool `json:",omitempty"`
-	FirewallBackend     *FirewallInfo        `json:"FirewallBackend,omitempty"`
+	Listeners           []ListenerInfo
+	FirewallBackend     *FirewallInfo `json:"FirewallBackend,omitempty"`
 	CDISpecDirs         []string
 	DiscoveredDevices   []DeviceInfo `json:",omitempty"`
 	NRI                 *NRIInfo     `json:",omitempty"`

--- a/api/types/system/system.go
+++ b/api/types/system/system.go
@@ -1,0 +1,11 @@
+package system // import "github.com/docker/docker/api/types/system"
+
+// ListenerInfo provides information about an address that the API is listening on.
+type ListenerInfo struct {
+	// Address is the address that the daemon API is listening on.
+	Address string
+	// Insecure indicates if the address is insecure, which could be either
+	// if the daemon is configured without TLS client verification, or if
+	// TLS verify is disabled.
+	Insecure bool
+}

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"runtime"
 	"strconv"
@@ -266,21 +267,32 @@ func (daemon *Daemon) fillAPIInfo(v *system.Info, cfg *config.Config) {
          to the 'Docker daemon attack surface' section in the documentation for
          more information: https://docs.docker.com/go/attack-surface/`
 
+	v.Listeners = make([]system.ListenerInfo, 0, len(cfg.Hosts))
 	for _, host := range cfg.Hosts {
 		// cnf.Hosts is normalized during startup, so should always have a scheme/proto
-		proto, addr, _ := strings.Cut(host, "://")
-		if proto != "tcp" {
+		addr, err := url.Parse(host)
+		if err != nil {
+			v.Warnings = append(v.Warnings, fmt.Sprintf("WARNING: Unable to parse host: %s", host))
+			continue
+		}
+		if addr.Scheme != "tcp" {
+			v.Listeners = append(v.Listeners, system.ListenerInfo{Address: addr.String()})
 			continue
 		}
 		const removal = "In future versions this will be a hard failure preventing the daemon from starting! Learn more at: https://docs.docker.com/go/api-security/"
 		if cfg.TLS == nil || !*cfg.TLS {
+			addr.Scheme = "http"
 			v.Warnings = append(v.Warnings, fmt.Sprintf("[DEPRECATION NOTICE]: API is accessible on http://%s without encryption.%s\n%s", addr, warn, removal))
+			v.Listeners = append(v.Listeners, system.ListenerInfo{Address: addr.String(), Insecure: true})
 			continue
 		}
+		addr.Scheme = "https"
 		if cfg.TLSVerify == nil || !*cfg.TLSVerify {
 			v.Warnings = append(v.Warnings, fmt.Sprintf("[DEPRECATION NOTICE]: API is accessible on https://%s without TLS client verification.%s\n%s", addr, warn, removal))
+			v.Listeners = append(v.Listeners, system.ListenerInfo{Address: addr.String(), Insecure: true})
 			continue
 		}
+		v.Listeners = append(v.Listeners, system.ListenerInfo{Address: addr.String()})
 	}
 }
 

--- a/integration/system/info_test.go
+++ b/integration/system/info_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/moby/moby/api/types/registry"
+	"github.com/moby/moby/api/types/system"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/internal/testutil"
 	"github.com/moby/moby/v2/internal/testutil/daemon"
@@ -122,6 +123,23 @@ func TestInfoInsecureRegistries(t *testing.T) {
 	assert.Assert(t, is.Contains(cidrs, "127.0.0.0/8"))
 	assert.DeepEqual(t, *info.RegistryConfig.IndexConfigs["docker.io"], registry.IndexInfo{Name: "docker.io", Mirrors: []string{}, Secure: true, Official: true})
 	assert.DeepEqual(t, *info.RegistryConfig.IndexConfigs[registryHost], registry.IndexInfo{Name: registryHost, Mirrors: []string{}, Secure: false, Official: false})
+}
+
+func TestInfoListeners(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME: test starts daemon with -H unix://.....")
+
+	d := daemon.New(t)
+	d.Start(t, "-H=127.0.0.1:5732", "-H=[::1]:5733")
+	defer d.Stop(t)
+
+	info := d.Info(t)
+	expected := []system.ListenerInfo{
+		{Address: d.Sock(), Insecure: false},
+		{Address: "http://127.0.0.1:5732", Insecure: true},
+		{Address: "http://[::1]:5733", Insecure: true},
+	}
+	assert.DeepEqual(t, info.Listeners, expected)
 }
 
 func TestInfoRegistryMirrors(t *testing.T) {


### PR DESCRIPTION
- related: https://github.com/moby/moby/issues/26253

The daemon can be configured to listen on multiple endpoints, which can make
it difficult to discover how the API is exposed (e.g. if the daemon is listening
both on `/var/run/docker.sock` and through tcp).

This patch adds a `Listeners` field to the `/info` response, listing on what
addresses (and/or sockets) the API is exposed on to make it more discoverable.

Currently only API listeners are included, but as a follow-up, we can include
other listeners (metrics socket, SwarmKit control and data-plane).

With this patch:

```bash
dockerd

curl -s --unix-socket /var/run/docker.sock http://localhost/info | jq .Hosts
[
  {
    "Address": "unix:///var/run/docker.sock",
    "Insecure": false
  }
]

dockerd -H localhost:2375 -H unix:///var/run/docker.sock

curl -s --unix-socket /var/run/docker.sock http://localhost/info | jq .Hosts
[
  {
    "Address": "http://localhost:2375",
    "Insecure": true
  },
  {
    "Address": "unix:///var/run/docker.sock",
    "Insecure": false
  }
]
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
The `GET /info` API endpoint now returns a `Listeners` property, containing a list of addresses on which the API is listening.
```

**- A picture of a cute animal (not mandatory but encouraged)**

