### PR TITLE
Jenkinsfile: allow all ppc64le / s390x stages through checkbox

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -663,8 +663,11 @@ pipeline {
                 stage('s390x integration-cli') {
                     when {
                         beforeAgent true
-                        not { changeRequest() }
-                        expression { params.s390x }
+                        // Skip this stage on PRs unless the checkbox is selected
+                        anyOf {
+                            not { changeRequest() }
+                            expression { params.s390x }
+                        }
                     }
                     agent { label 's390x-ubuntu-2004' }
 
@@ -865,8 +868,11 @@ pipeline {
                 stage('ppc64le integration-cli') {
                     when {
                         beforeAgent true
-                        not { changeRequest() }
-                        expression { params.ppc64le }
+                        // Skip this stage on PRs unless the checkbox is selected
+                        anyOf {
+                            not { changeRequest() }
+                            expression { params.ppc64le }
+                        }
                     }
                     agent { label 'ppc64le-ubuntu-1604' }
                     // ppc64le machines run on Docker 18.06, and buildkit has some


### PR DESCRIPTION
Previously, the ppc64ls and s390x stages only ran on non-PR commits, but the unit-tests and integration/xx tests could be enabled with a checkbox.

This patch changes the Jenkinsfile to also allow the integration-cli tests to be run on pull requests if the checkbox is enabled.

**- A picture of a cute animal (not mandatory but encouraged)**

