### PR TITLE
api/server/router/grpc: fix some nits in NewRouter()

### DIFF
--- a/api/server/router/grpc/grpc.go
+++ b/api/server/router/grpc/grpc.go
@@ -15,12 +15,12 @@ type grpcRouter struct {
 
 // NewRouter initializes a new grpc http router
 func NewRouter(backends ...Backend) router.Router {
-	opts := []grpc.ServerOption{grpc.UnaryInterceptor(grpcerrors.UnaryServerInterceptor), grpc.StreamInterceptor(grpcerrors.StreamServerInterceptor)}
-	server := grpc.NewServer(opts...)
-
 	r := &grpcRouter{
-		h2Server:   &http2.Server{},
-		grpcServer: server,
+		h2Server: &http2.Server{},
+		grpcServer: grpc.NewServer(
+			grpc.UnaryInterceptor(grpcerrors.UnaryServerInterceptor),
+			grpc.StreamInterceptor(grpcerrors.StreamServerInterceptor),
+		),
 	}
 	for _, b := range backends {
 		b.RegisterGRPC(r.grpcServer)
@@ -30,12 +30,12 @@ func NewRouter(backends ...Backend) router.Router {
 }
 
 // Routes returns the available routers to the session controller
-func (r *grpcRouter) Routes() []router.Route {
-	return r.routes
+func (gr *grpcRouter) Routes() []router.Route {
+	return gr.routes
 }
 
-func (r *grpcRouter) initRoutes() {
-	r.routes = []router.Route{
-		router.NewPostRoute("/grpc", r.serveGRPC),
+func (gr *grpcRouter) initRoutes() {
+	gr.routes = []router.Route{
+		router.NewPostRoute("/grpc", gr.serveGRPC),
 	}
 }


### PR DESCRIPTION
These were changes I drafted when reviewing 7c731e02a980666e262c68d4995f5643b6ffae30 (https://github.com/moby/moby/pull/42329), and had these stashed in my local git;

- rename receiver to prevent "unconsistent receiver name" warnings
- make NewRouter() slightly more idiomatic, and wrap the options, to make them easier to read.


**- A picture of a cute animal (not mandatory but encouraged)**

