### PR TITLE
remove deprecated support for overlay(2) on backing FS without d_type (fstype=1)

### DIFF
--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -294,18 +294,6 @@ func scanPriorDrivers(root string) map[string]bool {
 	return driversMap
 }
 
-// IsInitialized checks if the driver's home-directory exists and is non-empty.
-func IsInitialized(driverHome string) bool {
-	_, err := os.Stat(driverHome)
-	if os.IsNotExist(err) {
-		return false
-	}
-	if err != nil {
-		logrus.Warnf("graphdriver.IsInitialized: stat failed: %v", err)
-	}
-	return !isEmptyDir(driverHome)
-}
-
 // isEmptyDir checks if a directory is empty. It is used to check if prior
 // storage-driver directories exist. If an error occurs, it also assumes the
 // directory is not empty (which preserves the behavior _before_ this check

--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -147,11 +147,7 @@ func Init(home string, options []string, idMap idtools.IdentityMapping) (graphdr
 		return nil, err
 	}
 	if !supportsDType {
-		if !graphdriver.IsInitialized(home) {
-			return nil, overlayutils.ErrDTypeNotSupported("overlay", backingFs)
-		}
-		// allow running without d_type only for existing setups (#27443)
-		logrus.WithField("storage-driver", "overlay").Warn(overlayutils.ErrDTypeNotSupported("overlay", backingFs))
+		return nil, overlayutils.ErrDTypeNotSupported("overlay", backingFs)
 	}
 
 	currentID := idtools.CurrentIdentity()

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -156,11 +156,7 @@ func Init(home string, options []string, idMap idtools.IdentityMapping) (graphdr
 		return nil, err
 	}
 	if !supportsDType {
-		if !graphdriver.IsInitialized(home) {
-			return nil, overlayutils.ErrDTypeNotSupported("overlay2", backingFs)
-		}
-		// allow running without d_type only for existing setups (#27443)
-		logger.Warn(overlayutils.ErrDTypeNotSupported("overlay2", backingFs))
+		return nil, overlayutils.ErrDTypeNotSupported("overlay2", backingFs)
 	}
 
 	cur := idtools.CurrentIdentity()


### PR DESCRIPTION
Support for overlay on a backing filesystem without d_type was deprecated in 0abb8dec3f730f3ad2cc9a161c97968a6bfd0631 (https://github.com/moby/moby/pull/35514, Docker 17.12), with an exception for existing installations (0a4e793a3da9ba6d20bccfb83f7c48e20a76d895, https://github.com/moby/moby/pull/35514).

That deprecation was nearly 5 years ago, and running without d_type is known to cause serious issues (so users will likely already have run into other problems).

This patch removes support for running overlay and overlay2 on these filesystems, returning the error instead of logging it.


### daemon/graphdriver: remove unused `graphdriver.IsInitialized()`

It's no longer used, and has no external consumers.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```markdown
* Remove support for overlay and overlay2 storage drivers on backing filesystems without `d_type` support [moby/moby#43472](https://github.com/moby/moby/pull/43472)
```


**- A picture of a cute animal (not mandatory but encouraged)**

