### PR TITLE
fix cross compilation for arm platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,60 @@ jobs:
             *.cache-from=type=gha,scope=build-${{ matrix.target }}
             *.cache-to=type=gha,scope=build-${{ matrix.target }}
       -
-        name: Upload build artifacts
+        name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.target }}
-          path: ${{ env.BUNDLES_OUTPUT }}/${{ matrix.target }}-daemon/*
+          path: ${{ env.BUNDLES_OUTPUT }}
+          if-no-files-found: error
+          retention-days: 7
+
+  cross:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm/v5
+          - linux/arm/v6
+          - linux/arm/v7
+          - linux/arm64
+          - linux/ppc64le
+          - linux/s390x
+          - windows/amd64
+          - windows/arm64
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+          mkdir -p autogen
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Build
+        uses: docker/bake-action@v1
+        with:
+          targets: cross
+          set: |
+            *.cache-from=type=gha,scope=cross-${{ env.PLATFORM_PAIR }}
+            *.cache-to=type=gha,scope=cross-${{ env.PLATFORM_PAIR }}
+        env:
+          DOCKER_CROSSPLATFORMS: ${{ matrix.platform }}
+      -
+        name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: cross-${{ env.PLATFORM_PAIR }}
+          path: ${{ env.BUNDLES_OUTPUT }}
           if-no-files-found: error
           retention-days: 7
 
@@ -92,7 +141,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
-        name: Download build artifacts
+        name: Download binary artifacts
         uses: actions/download-artifact@v3
         with:
           name: binary
@@ -111,7 +160,7 @@ jobs:
         env:
           CONTEXT: "."
           TEST_DOCKERD: "1"
-          TEST_DOCKERD_BINARY: "./build/moby/dockerd"
+          TEST_DOCKERD_BINARY: "./build/moby/binary-daemon/dockerd"
           TESTPKGS: "${{ matrix.pkg }}"
           TESTFLAGS: "-v --parallel=1 --timeout=30m --run=//worker=dockerd$"
           SKIP_INTEGRATION_TESTS: "${{ matrix.skip-integration-tests }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
           name: ${{ matrix.target }}
           path: ${{ env.BUNDLES_OUTPUT }}/${{ matrix.target }}-daemon/*
           if-no-files-found: error
+          retention-days: 7
 
   test-buildkit:
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
             *.cache-to=type=gha,scope=build-${{ matrix.target }}
       -
         name: Upload build artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.target }}
           path: ${{ env.BUNDLES_OUTPUT }}/${{ matrix.target }}-daemon/*
@@ -92,7 +92,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
       -
         name: Download build artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: binary
           path: ./buildkit/build/moby/

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,10 +1,14 @@
 variable "BUNDLES_OUTPUT" {
   default = "./bundles"
 }
+variable "DOCKER_CROSSPLATFORMS" {
+  default = ""
+}
 
 target "_common" {
   args = {
     BUILDKIT_CONTEXT_KEEP_GIT_DIR = 1
+    APT_MIRROR = "cdn-fastly.deb.debian.org"
   }
 }
 
@@ -21,4 +25,13 @@ target "binary" {
 target "dynbinary" {
   inherits = ["binary"]
   target = "dynbinary"
+}
+
+target "cross" {
+  inherits = ["binary"]
+  args = {
+    CROSS = "true"
+    DOCKER_CROSSPLATFORMS = DOCKER_CROSSPLATFORMS
+  }
+  target = "cross"
 }

--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -47,11 +47,25 @@ hash_files() {
 				;;
 			linux/arm)
 				case "${GOARM}" in
-					5 | "")
+					5)
 						export CC="${CC:-arm-linux-gnueabi-gcc}"
 						export CGO_ENABLED=1
+						export CGO_CFLAGS="-march=armv5t"
+						export CGO_CXXFLAGS="-march=armv5t"
+						;;
+					6)
+						export CC="${CC:-arm-linux-gnueabi-gcc}"
+						export CGO_ENABLED=1
+						export CGO_CFLAGS="-march=armv6"
+						export CGO_CXXFLAGS="-march=armv6"
 						;;
 					7)
+						export CC="${CC:-arm-linux-gnueabihf-gcc}"
+						export CGO_ENABLED=1
+						export CGO_CFLAGS="-march=armv7-a"
+						export CGO_CXXFLAGS="-march=armv7-a"
+						;;
+					*)
 						export CC="${CC:-arm-linux-gnueabihf-gcc}"
 						export CGO_ENABLED=1
 						;;


### PR DESCRIPTION
follow-up https://github.com/docker/docker-ce-packaging/pull/665#issuecomment-1081864970

cross compilation is currently broken against some arm platforms:

```
#43 0.132 
#43 0.138 ---> Making bundle: cross (in /build/bundles/cross)
#43 0.139 Cross building: /build/bundles/cross/linux/arm/v6
#43 0.182 Building: /build/bundles/cross/linux/arm/v6-daemon/dockerd-0.0.0-20220329083112-174e51c
#43 0.182 GOOS="linux" GOARCH="arm" GOARM="6"
#43 76.80 # github.com/docker/docker/cmd/dockerd
#43 76.80 loadinternal: cannot find runtime/cgo
#43 76.80 /usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
#43 76.80 gcc: error: unrecognized command-line option '-marm'; did you mean '-mabm'?
```

**- What I did**

fix cross compilation for arm platforms by setting correct switches for `CGO_CFLAGS` and `CGO_CXXFLAGS` flags.

also adds a GitHub Action job to check cross targets work, which is not currently done in Jenkins.

**- How to verify it**

```console
$ mkdir -p autogen # workaround that will be fixed by https://github.com/moby/moby/pull/43431
$ DOCKER_CROSSPLATFORMS="linux/arm/v7 linux/arm/v6 linux/arm/v5" docker buildx bake cross
```

**- Description for the changelog**

fix cross compilation for arm platforms

___

in a follow-up we should switch to [xx](https://github.com/tonistiigi/xx/).

cc @thaJeztah 