### PR TITLE
missing windows arm64 arch detection

### DIFF
--- a/pkg/platform/architecture_windows.go
+++ b/pkg/platform/architecture_windows.go
@@ -30,10 +30,11 @@ type systeminfo struct {
 
 // Constants
 const (
-	ProcessorArchitecture64   = 9 // PROCESSOR_ARCHITECTURE_AMD64
-	ProcessorArchitectureIA64 = 6 // PROCESSOR_ARCHITECTURE_IA64
-	ProcessorArchitecture32   = 0 // PROCESSOR_ARCHITECTURE_INTEL
-	ProcessorArchitectureArm  = 5 // PROCESSOR_ARCHITECTURE_ARM
+	ProcessorArchitecture64    = 9  // PROCESSOR_ARCHITECTURE_AMD64
+	ProcessorArchitectureIA64  = 6  // PROCESSOR_ARCHITECTURE_IA64
+	ProcessorArchitecture32    = 0  // PROCESSOR_ARCHITECTURE_INTEL
+	ProcessorArchitectureArm   = 5  // PROCESSOR_ARCHITECTURE_ARM
+	ProcessorArchitectureArm64 = 12 // PROCESSOR_ARCHITECTURE_ARM64
 )
 
 // runtimeArchitecture gets the name of the current architecture (x86, x86_64, …)
@@ -47,8 +48,10 @@ func runtimeArchitecture() (string, error) {
 		return "i686", nil
 	case ProcessorArchitectureArm:
 		return "arm", nil
+	case ProcessorArchitectureArm64:
+		return "arm64", nil
 	default:
-		return "", fmt.Errorf("Unknown processor architecture")
+		return "", fmt.Errorf("unknown processor architecture %+v", sysinfo.wProcessorArchitecture)
 	}
 }
 


### PR DESCRIPTION
encountered this issue in https://github.com/moby/moby/pull/43431#issuecomment-1093408301

**- What I did**

fix windows arm64 arch detection:

```
time="2022-04-09T12:22:20-07:00" level=error msg="Could not read system architecture info: Unknown processor architecture"
time="2022-04-09T12:22:20.960012400-07:00" level=info msg="Starting up"
time="2022-04-09T12:22:20.964046500-07:00" level=info msg="Windows default isolation mode: hyperv"
```

**- How to verify it**

```console
$ DOCKER_CROSSPLATFORMS=windows/arm64 hack/make.sh cross
```

On a Windows arm64 capable system:

```console
> dockerd-dev.exe --debug
time="2022-04-09T12:22:20.960012400-07:00" level=info msg="Starting up"
...
```

**- Description for the changelog**

fix windows arm64 arch detection

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>