### PR TITLE
daemon/logger: remove uses of pkg/urlutil, fix fluentd validation and parsing

### DIFF
--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -285,12 +285,12 @@ func parseAddress(address string) (*location, error) {
 	}
 
 	switch addr.Scheme {
-	case "unix", "unixgram":
+	case "unix":
 		if strings.TrimLeft(addr.Path, "/") == "" {
 			return nil, errors.New("path is empty")
 		}
 		return &location{protocol: addr.Scheme, path: addr.Path}, nil
-	case "tcp", "tcp+tls", "udp":
+	case "tcp", "tls":
 		// continue processing below
 	default:
 		return nil, errors.Errorf("unsupported scheme: '%s'", addr.Scheme)

--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -172,7 +172,7 @@ func parseConfig(cfg map[string]string) (fluent.Config, error) {
 
 	loc, err := parseAddress(cfg[addressKey])
 	if err != nil {
-		return config, err
+		return config, errors.Wrapf(err, "invalid fluentd-address (%s)", cfg[addressKey])
 	}
 
 	bufferLimit := defaultBufferLimit
@@ -278,11 +278,10 @@ func parseAddress(address string) (*location, error) {
 	}
 
 	protocol := defaultProtocol
-	givenAddress := address
 	if urlutil.IsTransportURL(address) {
 		addr, err := url.Parse(address)
 		if err != nil {
-			return nil, errors.Wrapf(err, "invalid fluentd-address %s", givenAddress)
+			return nil, err
 		}
 		// unix and unixgram socket
 		if addr.Scheme == "unix" || addr.Scheme == "unixgram" {
@@ -301,7 +300,7 @@ func parseAddress(address string) (*location, error) {
 	host, port, err := net.SplitHostPort(address)
 	if err != nil {
 		if !strings.Contains(err.Error(), "missing port in address") {
-			return nil, errors.Wrapf(err, "invalid fluentd-address %s", givenAddress)
+			return nil, err
 		}
 		return &location{
 			protocol: protocol,
@@ -313,7 +312,7 @@ func parseAddress(address string) (*location, error) {
 
 	portnum, err := strconv.Atoi(port)
 	if err != nil {
-		return nil, errors.Wrapf(err, "invalid fluentd-address %s", givenAddress)
+		return nil, err
 	}
 	return &location{
 		protocol: protocol,

--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -280,22 +280,22 @@ func parseAddress(address string) (*location, error) {
 	protocol := defaultProtocol
 	givenAddress := address
 	if urlutil.IsTransportURL(address) {
-		url, err := url.Parse(address)
+		addr, err := url.Parse(address)
 		if err != nil {
 			return nil, errors.Wrapf(err, "invalid fluentd-address %s", givenAddress)
 		}
 		// unix and unixgram socket
-		if url.Scheme == "unix" || url.Scheme == "unixgram" {
+		if addr.Scheme == "unix" || addr.Scheme == "unixgram" {
 			return &location{
-				protocol: url.Scheme,
+				protocol: addr.Scheme,
 				host:     "",
 				port:     0,
-				path:     url.Path,
+				path:     addr.Path,
 			}, nil
 		}
 		// tcp|udp
-		protocol = url.Scheme
-		address = url.Host
+		protocol = addr.Scheme
+		address = addr.Host
 	}
 
 	host, port, err := net.SplitHostPort(address)

--- a/daemon/logger/fluentd/fluentd_test.go
+++ b/daemon/logger/fluentd/fluentd_test.go
@@ -102,7 +102,7 @@ func TestValidateLogOptAddress(t *testing.T) {
 		},
 		{
 			addr:        "corrupted:c",
-			expectedErr: "invalid syntax",
+			expectedErr: "invalid port",
 		},
 		{
 			addr:        "tcp://example.com:port",
@@ -111,6 +111,10 @@ func TestValidateLogOptAddress(t *testing.T) {
 		{
 			addr:        "tcp://example.com:-1",
 			expectedErr: "invalid port",
+		},
+		{
+			addr:        "unix://",
+			expectedErr: "path is empty",
 		},
 		{
 			addr: "unix:///some/socket.sock",
@@ -136,6 +140,10 @@ func TestValidateLogOptAddress(t *testing.T) {
 			address := tc.addr + path
 			t.Run(address, func(t *testing.T) {
 				err := ValidateLogOpt(map[string]string{addressKey: address})
+				if path != "" {
+					assert.ErrorContains(t, err, "should not contain a path element")
+					return
+				}
 				if tc.expectedErr != "" {
 					assert.ErrorContains(t, err, tc.expectedErr)
 					return

--- a/daemon/logger/fluentd/fluentd_test.go
+++ b/daemon/logger/fluentd/fluentd_test.go
@@ -2,6 +2,7 @@ package fluentd // import "github.com/docker/docker/daemon/logger/fluentd"
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"gotest.tools/v3/assert"
 )
 
@@ -20,5 +21,130 @@ func TestValidateLogOptReconnectInterval(t *testing.T) {
 			err := ValidateLogOpt(map[string]string{asyncReconnectIntervalKey: v})
 			assert.NilError(t, err)
 		})
+	}
+}
+
+func TestValidateLogOptAddress(t *testing.T) {
+
+	// paths to try
+	paths := []string{"/", "/some-path"}
+
+	tests := []struct {
+		addr        string
+		paths       []string // paths to append to addr, should be an error for tcp/udp
+		expected    location
+		expectedErr string
+	}{
+		{
+			addr: "",
+			expected: location{
+				protocol: defaultProtocol,
+				host:     defaultHost,
+				port:     defaultPort,
+			},
+		},
+		{
+			addr:  "192.168.1.1",
+			paths: paths,
+			expected: location{
+				port:     defaultPort,
+				protocol: defaultProtocol,
+			},
+		},
+		{
+			addr:  "[::1]",
+			paths: paths,
+			expected: location{
+				port:     defaultPort,
+				protocol: defaultProtocol,
+			},
+		},
+		{
+			addr:  "example.com",
+			paths: paths,
+			expected: location{
+				port:     defaultPort,
+				protocol: defaultProtocol,
+			},
+		},
+		{
+			addr:  "tcp://",
+			paths: paths,
+			expected: location{
+				protocol: "tcp",
+				port:     defaultPort,
+			},
+		},
+		{
+			addr:  "tcp://example.com",
+			paths: paths,
+			expected: location{
+				protocol: "tcp",
+				port:     defaultPort,
+			},
+		},
+		{
+			addr:  "tcp://example.com:65535",
+			paths: paths,
+			expected: location{
+				protocol: "tcp",
+				host:     "example.com",
+				port:     65535,
+			},
+		},
+		{
+			addr:        "://",
+			expectedErr: "invalid syntax",
+		},
+		{
+			addr:        "something://",
+			expectedErr: "invalid syntax",
+		},
+		{
+			addr:        "corrupted:c",
+			expectedErr: "invalid syntax",
+		},
+		{
+			addr:        "tcp://example.com:port",
+			expectedErr: "invalid port",
+		},
+		{
+			addr:        "tcp://example.com:-1",
+			expectedErr: "invalid port",
+		},
+		{
+			addr: "unix:///some/socket.sock",
+			expected: location{
+				protocol: "unix",
+				path:     "/some/socket.sock",
+			},
+		},
+		{
+			addr: "unix:///some/socket.sock:80", // unusual, but technically valid
+			expected: location{
+				protocol: "unix",
+				path:     "/some/socket.sock:80",
+			},
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		if len(tc.paths) == 0 {
+			tc.paths = []string{""}
+		}
+		for _, path := range tc.paths {
+			address := tc.addr + path
+			t.Run(address, func(t *testing.T) {
+				err := ValidateLogOpt(map[string]string{addressKey: address})
+				if tc.expectedErr != "" {
+					assert.ErrorContains(t, err, tc.expectedErr)
+					return
+				}
+
+				assert.NilError(t, err)
+				addr, _ := parseAddress(address)
+				assert.DeepEqual(t, tc.expected, *addr, cmp.AllowUnexported(location{}))
+			})
+		}
 	}
 }

--- a/daemon/logger/fluentd/fluentd_test.go
+++ b/daemon/logger/fluentd/fluentd_test.go
@@ -96,12 +96,42 @@ func TestValidateLogOptAddress(t *testing.T) {
 			},
 		},
 		{
+			addr:  "tls://",
+			paths: paths,
+			expected: location{
+				protocol: "tls",
+				host:     defaultHost,
+				port:     defaultPort,
+			},
+		},
+		{
+			addr:  "tls://example.com",
+			ports: validPorts,
+			paths: paths,
+			expected: location{
+				protocol: "tls",
+				host:     "example.com",
+			},
+		},
+		{
 			addr:        "://",
 			expectedErr: "missing protocol scheme",
 		},
 		{
 			addr:        "something://",
 			expectedErr: "unsupported scheme: 'something'",
+		},
+		{
+			addr:        "udp://",
+			expectedErr: "unsupported scheme: 'udp'",
+		},
+		{
+			addr:        "unixgram://",
+			expectedErr: "unsupported scheme: 'unixgram'",
+		},
+		{
+			addr:        "tcp+tls://",
+			expectedErr: "unsupported scheme: 'tcp+tls'",
 		},
 		{
 			addr:        "corrupted:c",

--- a/daemon/logger/gelf/gelf.go
+++ b/daemon/logger/gelf/gelf.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Graylog2/go-gelf/gelf"
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/logger/loggerutils"
-	"github.com/docker/docker/pkg/urlutil"
 	"github.com/sirupsen/logrus"
 )
 
@@ -251,23 +250,18 @@ func parseAddress(address string) (*url.URL, error) {
 	if address == "" {
 		return nil, fmt.Errorf("gelf-address is a required parameter")
 	}
-	if !urlutil.IsTransportURL(address) {
-		return nil, fmt.Errorf("gelf-address should be in form proto://address, got %v", address)
-	}
-	url, err := url.Parse(address)
+	addr, err := url.Parse(address)
 	if err != nil {
 		return nil, err
 	}
 
-	// we support only udp
-	if url.Scheme != "udp" && url.Scheme != "tcp" {
+	if addr.Scheme != "udp" && addr.Scheme != "tcp" {
 		return nil, fmt.Errorf("gelf: endpoint needs to be TCP or UDP")
 	}
 
-	// get host and port
-	if _, _, err = net.SplitHostPort(url.Host); err != nil {
+	if _, _, err = net.SplitHostPort(addr.Host); err != nil {
 		return nil, fmt.Errorf("gelf: please provide gelf-address as proto://host:port")
 	}
 
-	return url, nil
+	return addr, nil
 }

--- a/daemon/logger/gelf/gelf_test.go
+++ b/daemon/logger/gelf/gelf_test.go
@@ -223,12 +223,12 @@ func TestNewTCP(t *testing.T) {
 		ContainerID: "12345678901234567890",
 	}
 
-	logger, err := New(info)
+	gelfLogger, err := New(info)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = logger.Close()
+	err = gelfLogger.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -250,12 +250,12 @@ func TestNewUDP(t *testing.T) {
 		ContainerID: "12345678901234567890",
 	}
 
-	logger, err := New(info)
+	gelfLogger, err := New(info)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = logger.Close()
+	err = gelfLogger.Close()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -22,7 +22,6 @@ import (
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/logger/loggerutils"
 	"github.com/docker/docker/pkg/pools"
-	"github.com/docker/docker/pkg/urlutil"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 )
@@ -607,8 +606,8 @@ func parseURL(info logger.Info) (*url.URL, error) {
 		return nil, fmt.Errorf("%s: failed to parse %s as url value in %s", driverName, splunkURLStr, splunkURLKey)
 	}
 
-	if !urlutil.IsURL(splunkURLStr) ||
-		!splunkURL.IsAbs() ||
+	if !splunkURL.IsAbs() ||
+		(splunkURL.Scheme != "http" && splunkURL.Scheme != "https") ||
 		(splunkURL.Path != "" && splunkURL.Path != "/") ||
 		splunkURL.RawQuery != "" ||
 		splunkURL.Fragment != "" {

--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -13,10 +13,8 @@ import (
 	"time"
 
 	syslog "github.com/RackSec/srslog"
-
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/logger/loggerutils"
-	"github.com/docker/docker/pkg/urlutil"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/sirupsen/logrus"
 )
@@ -24,6 +22,7 @@ import (
 const (
 	name        = "syslog"
 	secureProto = "tcp+tls"
+	defaultPort = "514"
 )
 
 var facilities = map[string]syslog.Priority{
@@ -157,32 +156,32 @@ func parseAddress(address string) (string, string, error) {
 	if address == "" {
 		return "", "", nil
 	}
-	if !urlutil.IsTransportURL(address) {
-		return "", "", fmt.Errorf("syslog-address should be in form proto://address, got %v", address)
-	}
-	url, err := url.Parse(address)
+	addr, err := url.Parse(address)
 	if err != nil {
 		return "", "", err
 	}
 
 	// unix and unixgram socket validation
-	if url.Scheme == "unix" || url.Scheme == "unixgram" {
-		if _, err := os.Stat(url.Path); err != nil {
+	if addr.Scheme == "unix" || addr.Scheme == "unixgram" {
+		if _, err := os.Stat(addr.Path); err != nil {
 			return "", "", err
 		}
-		return url.Scheme, url.Path, nil
+		return addr.Scheme, addr.Path, nil
+	}
+	if addr.Scheme != "udp" && addr.Scheme != "tcp" && addr.Scheme != secureProto {
+		return "", "", fmt.Errorf("unsupported scheme: '%s'", addr.Scheme)
 	}
 
 	// here we process tcp|udp
-	host := url.Host
+	host := addr.Host
 	if _, _, err := net.SplitHostPort(host); err != nil {
 		if !strings.Contains(err.Error(), "missing port in address") {
 			return "", "", err
 		}
-		host = host + ":514"
+		host = net.JoinHostPort(host, defaultPort)
 	}
 
-	return url.Scheme, host, nil
+	return addr.Scheme, host, nil
 }
 
 // ValidateLogOpt looks for syslog specific log options

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1672,14 +1672,6 @@ func (s *DockerDaemonSuite) TestDaemonRestartLocalVolumes(c *testing.T) {
 }
 
 // FIXME(vdemeester) should be a unit test
-func (s *DockerDaemonSuite) TestDaemonCorruptedLogDriverAddress(c *testing.T) {
-	d := daemon.New(c, dockerBinary, dockerdBinary, testdaemon.WithEnvironment(testEnv.Execution))
-	assert.Assert(c, d.StartWithError("--log-driver=syslog", "--log-opt", "syslog-address=corrupted:42") != nil)
-	expected := "syslog-address should be in form proto://address"
-	icmd.RunCommand("grep", expected, d.LogFileName()).Assert(c, icmd.Success)
-}
-
-// FIXME(vdemeester) should be a unit test
 func (s *DockerDaemonSuite) TestDaemonCorruptedFluentdAddress(c *testing.T) {
 	d := daemon.New(c, dockerBinary, dockerdBinary, testdaemon.WithEnvironment(testEnv.Execution))
 	assert.Assert(c, d.StartWithError("--log-driver=fluentd", "--log-opt", "fluentd-address=corrupted:c") != nil)

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1671,14 +1671,6 @@ func (s *DockerDaemonSuite) TestDaemonRestartLocalVolumes(c *testing.T) {
 	assert.NilError(c, err, out)
 }
 
-// FIXME(vdemeester) should be a unit test
-func (s *DockerDaemonSuite) TestDaemonCorruptedFluentdAddress(c *testing.T) {
-	d := daemon.New(c, dockerBinary, dockerdBinary, testdaemon.WithEnvironment(testEnv.Execution))
-	assert.Assert(c, d.StartWithError("--log-driver=fluentd", "--log-opt", "fluentd-address=corrupted:c") != nil)
-	expected := "invalid fluentd-address corrupted:c: "
-	icmd.RunCommand("grep", expected, d.LogFileName()).Assert(c, icmd.Success)
-}
-
 // FIXME(vdemeester) Use a new daemon instance instead of the Suite one
 func (s *DockerDaemonSuite) TestDaemonStartWithoutHost(c *testing.T) {
 	s.d.UseDefaultHost = true


### PR DESCRIPTION
### daemon/logger/gelf: remove uses of pkg/urlutil.IsTransportURL()

pkg/urlutil (despite its poorly chosen name) is not really intended as a generic utility to handle URLs, and should only be used by the builder to handle (remote) build contexts.

This patch:

- removes a redundant use of urlutil.IsTransportURL(); code further below already checked if the given scheme (protocol) was supported.
- renames some variables that collided with imported packages.

### daemon/logger/splunk: remove uses of pkg/urlutil.IsURL()

pkg/urlutil (despite its poorly chosen name) is not really intended as a generic utility to handle URLs, and should only be used by the builder to handle (remote) build contexts.

This patch removes the use of urlutil.IsURL(), in favor of just checking if the provided scheme (protocol) is supported.

### daemon/logger/syslog: remove uses of pkg/urlutil.IsTransportURL()

pkg/urlutil (despite its poorly chosen name) is not really intended as a generic utility to handle URLs, and should only be used by the builder to handle (remote) build contexts.

This patch:

- removes a redundant use of urlutil.IsTransportURL(); instead adding some code to check if the given scheme (protocol) is supported.
- define a `defaultPort` const for the default port.
- use `net.JoinHostPort()` instead of string concatenating, to account for possible issues with IPv6 addresses.
- renames a variable that collided with an imported package.


### daemon/logger/fluentd: add coverage for ValidateLogOpt(), parseAddress()

This exposed a bug where host is ignored on some valid cases (to be fixed).

### daemon/logger/fluentd: rename var that collided with import

### daemon/logger/fluentd: make error-handling less DRY

### daemon/logger/fluentd: validate path element

fix some missing validation: the driver was silently ignoring path elements in some cases, and expecting a host (not an URL), and for unix sockets did not validate if a path was specified.

For the latter case, we should have a fix in the upstream driver, as it uses an empty path as default path for the socket (`defaultSocketPath`), and performs no validation.

### daemon/logger/fluentd: fix missing host, remove urlutil.IsTransportURL()

pkg/urlutil (despite its poorly chosen name) is not really intended as a generic utility to handle URLs, and should only be used by the builder to handle (remote) build contexts.

This patch:

- fix some cases where the host was ignored for valid addresses.
- removes a redundant use of urlutil.IsTransportURL(); instead adding code to check if the given scheme (protocol) is supported.
- improve port validation for out of range ports.
- fix some missing validation: the driver was silently ignoring path elements, but expected a host (not an URL)

### daemon/logger/fluentd: remove udp, tcp+tls, unixgram, add tls scheme

unix and unixgram were added in cb176c848e0731f77fa48b4e1a90ae74d1f2deae (https://github.com/moby/moby/pull/26088), but at the time, the driver only supported "tcp" and "unix": see [vendor/src/github.com/fluent/fluent-logger-golang/fluent/fluent.go#L243-L2610](https://github.com/moby/moby/blob/cb176c848e0731f77fa48b4e1a90ae74d1f2deae/vendor/src/github.com/fluent/fluent-logger-golang/fluent/fluent.go#L243-L2610)

support for tls was added in github.com/fluent/fluent-logger-golang v1.8.0, which was vendored in e24d61b7efac787ff3d5176d994608937a057522 (https://github.com/moby/moby/pull/42979).

the list of currently supported schemes by the driver is: tcp, tls and unix: see [vendor/github.com/fluent/fluent-logger-golang/fluent/fluent.go#L435-L463](https://github.com/moby/moby/blob/5179299b98a37ac2ba6eb8aefe8bf211f33f7dcc/vendor/github.com/fluent/fluent-logger-golang/fluent/fluent.go#L435-L463)
