### PR TITLE
ci: github action workflow for windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -101,3 +101,67 @@ jobs:
           path: ${{ env.BIN_OUT }}/*
           if-no-files-found: error
           retention-days: 2
+
+  unit-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-2019
+          - windows-2022
+    env:
+      GOPATH: ${{ github.workspace }}\go
+      GOBIN: ${{ github.workspace }}\go\bin
+    defaults:
+      run:
+        working-directory: ${{ env.GOPATH }}/src/github.com/docker/docker
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: ${{ env.GOPATH }}/src/github.com/docker/docker
+      -
+        name: Env
+        run: |
+          Get-ChildItem Env: | Out-String
+      -
+        name: Init
+        run: |
+          New-Item -ItemType "directory" -Path "${{ github.workspace }}\go-build"
+          New-Item -ItemType "directory" -Path "${{ github.workspace }}\go\pkg\mod"
+          If ("${{ matrix.os }}" -eq "windows-2019") {
+            echo "WINDOWS_BASE_IMAGE_TAG=${{ env.WINDOWS_BASE_TAG_2019 }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          } ElseIf ("${{ matrix.os }}" -eq "windows-2022") {
+            echo "WINDOWS_BASE_IMAGE_TAG=${{ env.WINDOWS_BASE_TAG_2022 }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          }
+      -
+        name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~\AppData\Local\go-build
+            ~\go\pkg\mod
+            ${{ github.workspace }}\go-build
+            ${{ env.GOPATH }}\pkg\mod
+          key: ${{ matrix.os }}-${{ github.job }}-${{ hashFiles('**/vendor.sum') }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ github.job }}-
+      -
+        name: Docker info
+        run: |
+          docker info
+      -
+        name: Build base image
+        run: |
+          docker pull ${{ env.WINDOWS_BASE_IMAGE }}:${{ env.WINDOWS_BASE_IMAGE_TAG }}
+          docker tag ${{ env.WINDOWS_BASE_IMAGE }}:${{ env.WINDOWS_BASE_IMAGE_TAG }} microsoft/windowsservercore
+          docker build --build-arg GO_VERSION -t ${{ env.TEST_IMAGE_NAME }} -f Dockerfile.windows .
+      -
+        name: Test
+        run: |
+          & docker run --name ${{ env.TEST_CTN_NAME }} -e "DOCKER_GITCOMMIT=${{ github.sha }}" `
+              -v "${{ github.workspace }}\go-build:C:\Users\ContainerAdministrator\AppData\Local\go-build" `
+              -v "${{ github.workspace }}\go\pkg\mod:C:\gopath\pkg\mod" `
+              ${{ env.TEST_IMAGE_NAME }} hack\make.ps1 -TestUnit

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -165,3 +165,210 @@ jobs:
               -v "${{ github.workspace }}\go-build:C:\Users\ContainerAdministrator\AppData\Local\go-build" `
               -v "${{ github.workspace }}\go\pkg\mod:C:\gopath\pkg\mod" `
               ${{ env.TEST_IMAGE_NAME }} hack\make.ps1 -TestUnit
+
+  integration-test:
+    runs-on: ${{ matrix.os }}
+    needs:
+      - build
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-2019
+          - windows-2022
+        runtime:
+          - builtin
+          - containerd
+    env:
+      GOPATH: ${{ github.workspace }}\go
+      GOBIN: ${{ github.workspace }}\go\bin
+      BIN_OUT: ${{ github.workspace }}\out
+    defaults:
+      run:
+        working-directory: ${{ env.GOPATH }}/src/github.com/docker/docker
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: ${{ env.GOPATH }}/src/github.com/docker/docker
+      -
+        name: Env
+        run: |
+          Get-ChildItem Env: | Out-String
+      -
+        name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-${{ matrix.os }}
+          path: ${{ env.BIN_OUT }}
+      -
+        name: Init
+        run: |
+          If ("${{ matrix.os }}" -eq "windows-2019") {
+            echo "WINDOWS_BASE_IMAGE_TAG=${{ env.WINDOWS_BASE_TAG_2019 }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          } ElseIf ("${{ matrix.os }}" -eq "windows-2022") {
+            echo "WINDOWS_BASE_IMAGE_TAG=${{ env.WINDOWS_BASE_TAG_2022 }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          }
+          Write-Output "${{ env.BIN_OUT }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      -
+        # removes docker service that is currently installed on the runner. we
+        # could use Uninstall-Package but not yet available on Windows runners.
+        # more info: https://github.com/actions/virtual-environments/blob/d3a5bad25f3b4326c5666bab0011ac7f1beec95e/images/win/scripts/Installers/Install-Docker.ps1#L11
+        name: Removing current daemon
+        run: |
+          if (Get-Service docker -ErrorAction SilentlyContinue) {
+            $dockerVersion = (docker version -f "{{.Server.Version}}")
+            Write-Host "Current installed Docker version: $dockerVersion"
+            # remove service
+            Stop-Service -Force -Name docker
+            Remove-Service -Name docker
+            # removes event log entry. we could use "Remove-EventLog -LogName -Source docker"
+            # but this cmd is only available since windows-2022
+            $ErrorActionPreference = "SilentlyContinue"
+            & reg delete "HKLM\SYSTEM\CurrentControlSet\Services\EventLog\Application\docker" /f 2>&1 | Out-Null
+            $ErrorActionPreference = "Stop"
+            Write-Host "Service removed"
+          }
+      -
+        name: Starting containerd
+        if: matrix.runtime == 'containerd'
+        run: |
+          Write-Host "Generating config"
+          & "${{ env.BIN_OUT }}\containerd.exe" config default | Out-File "$env:TEMP\ctn.toml" -Encoding ascii
+          Write-Host "Creating service"
+          New-Item -ItemType Directory "$env:TEMP\ctn-root" -ErrorAction SilentlyContinue | Out-Null
+          New-Item -ItemType Directory "$env:TEMP\ctn-state" -ErrorAction SilentlyContinue | Out-Null
+          Start-Process -Wait "${{ env.BIN_OUT }}\containerd.exe" `
+            -ArgumentList "--log-level=debug", `
+              "--config=$env:TEMP\ctn.toml", `
+              "--address=\\.\pipe\containerd-containerd", `
+              "--root=$env:TEMP\ctn-root", `
+              "--state=$env:TEMP\ctn-state", `
+              "--log-file=$env:TEMP\ctn.log", `
+              "--register-service"
+          Write-Host "Starting service"
+          Start-Service -Name containerd
+          Start-Sleep -Seconds 5
+          Write-Host "Service started successfully!"
+      -
+        name: Starting test daemon
+        run: |
+          Write-Host "Creating service"
+          If ("${{ matrix.runtime }}" -eq "containerd") {
+            $runtimeArg="--containerd=\\.\pipe\containerd-containerd"
+            echo "DOCKER_WINDOWS_CONTAINERD_RUNTIME=1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          }
+          New-Item -ItemType Directory "$env:TEMP\moby-root" -ErrorAction SilentlyContinue | Out-Null
+          New-Item -ItemType Directory "$env:TEMP\moby-exec" -ErrorAction SilentlyContinue | Out-Null
+          Start-Process -Wait -NoNewWindow "${{ env.BIN_OUT }}\dockerd" `
+            -ArgumentList $runtimeArg, "--debug", `
+              "--host=npipe:////./pipe/docker_engine", `
+              "--data-root=$env:TEMP\moby-root", `
+              "--exec-root=$env:TEMP\moby-exec", `
+              "--pidfile=$env:TEMP\docker.pid", `
+              "--register-service"
+          Write-Host "Starting service"
+          Start-Service -Name docker
+          Write-Host "Service started successfully!"
+      -
+        name: Waiting for test daemon to start
+        run: |
+          $tries=20
+          Write-Host "Waiting for the test daemon to start..."
+          While ($true) {
+            $ErrorActionPreference = "SilentlyContinue"
+            & "${{ env.BIN_OUT }}\docker" version
+            $ErrorActionPreference = "Stop"
+            If ($LastExitCode -eq 0) {
+              break
+            }
+            $tries--
+            If ($tries -le 0) {
+              Throw "Failed to get a response from the daemon"
+            }
+            Write-Host -NoNewline "."
+            Start-Sleep -Seconds 1
+          }
+          Write-Host "Test daemon started and replied!"
+        env:
+          DOCKER_HOST: npipe:////./pipe/docker_engine
+      -
+        name: Docker info
+        run: |
+          & "${{ env.BIN_OUT }}\docker" info
+        env:
+          DOCKER_HOST: npipe:////./pipe/docker_engine
+      -
+        name: Building contrib/busybox
+        run: |
+          & "${{ env.BIN_OUT }}\docker" build -t busybox `
+            --build-arg WINDOWS_BASE_IMAGE `
+            --build-arg WINDOWS_BASE_IMAGE_TAG `
+            .\contrib\busybox\
+        env:
+          DOCKER_HOST: npipe:////./pipe/docker_engine
+      -
+        name: List images
+        run: |
+          & "${{ env.BIN_OUT }}\docker" images
+        env:
+          DOCKER_HOST: npipe:////./pipe/docker_engine
+      -
+        name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      -
+        name: Test API
+        run: |
+          .\hack\make.ps1 -TestIntegration
+        env:
+          DOCKER_HOST: npipe:////./pipe/docker_engine
+          GO111MODULE: "off"
+          TEST_CLIENT_BINARY: ${{ env.BIN_OUT }}\docker
+      -
+        name: Test CLI
+        run: |
+          gotestsum --format=standard-verbose -- "-tags" "autogen" "-test.timeout" "200m"
+        working-directory: ${{ env.GOPATH }}/src/github.com/docker/docker/integration-cli
+        env:
+          DOCKER_HOST: npipe:////./pipe/docker_engine
+          GO111MODULE: "off"
+          TEST_CLIENT_BINARY: ${{ env.BIN_OUT }}\docker
+      -
+        name: Docker info
+        run: |
+          & "${{ env.BIN_OUT }}\docker" info
+        env:
+          DOCKER_HOST: npipe:////./pipe/docker_engine
+      -
+        name: Stop containerd
+        if: always() && matrix.runtime == 'containerd'
+        run: |
+          $ErrorActionPreference = "SilentlyContinue"
+          Stop-Service -Force -Name containerd
+          $ErrorActionPreference = "Stop"
+      -
+        name: Containerd logs
+        if: always() && matrix.runtime == 'containerd'
+        run: |
+          Get-Content "$env:TEMP\ctn.log" | Out-Host
+      -
+        name: Stop daemon
+        if: always()
+        run: |
+          $ErrorActionPreference = "SilentlyContinue"
+          Stop-Service -Force -Name docker
+          $ErrorActionPreference = "Stop"
+      -
+        # as the daemon is registered as a service we have to check the event
+        # logs against the docker provider.
+        name: Daemon event logs
+        if: always()
+        run: |
+          Get-WinEvent -ea SilentlyContinue `
+            -FilterHashtable @{ProviderName= "docker"; LogName = "application"} |
+              Select-Object -Property TimeCreated, @{N='Detailed Message'; E={$_.Message}} |
+              Sort-Object @{Expression="TimeCreated";Descending=$false} |
+              Select-Object -ExpandProperty 'Detailed Message'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,103 @@
+name: windows
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+      - '[0-9]+.[0-9]{2}'
+    tags:
+      - 'v*'
+  pull_request:
+
+env:
+  GO_VERSION: 1.18.2
+  WINDOWS_BASE_IMAGE: mcr.microsoft.com/windows/servercore
+  WINDOWS_BASE_TAG_2019: ltsc2019
+  WINDOWS_BASE_TAG_2022: ltsc2022
+  TEST_IMAGE_NAME: moby:test
+  TEST_CTN_NAME: moby
+  DOCKER_BUILDKIT: 0
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-2019
+          - windows-2022
+    env:
+      GOPATH: ${{ github.workspace }}\go
+      GOBIN: ${{ github.workspace }}\go\bin
+      BIN_OUT: ${{ github.workspace }}\out
+    defaults:
+      run:
+        working-directory: ${{ env.GOPATH }}/src/github.com/docker/docker
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: ${{ env.GOPATH }}/src/github.com/docker/docker
+      -
+        name: Env
+        run: |
+          Get-ChildItem Env: | Out-String
+      -
+        name: Init
+        run: |
+          New-Item -ItemType "directory" -Path "${{ github.workspace }}\go-build"
+          New-Item -ItemType "directory" -Path "${{ github.workspace }}\go\pkg\mod"
+          If ("${{ matrix.os }}" -eq "windows-2019") {
+            echo "WINDOWS_BASE_IMAGE_TAG=${{ env.WINDOWS_BASE_TAG_2019 }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          } ElseIf ("${{ matrix.os }}" -eq "windows-2022") {
+            echo "WINDOWS_BASE_IMAGE_TAG=${{ env.WINDOWS_BASE_TAG_2022 }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          }
+      -
+        name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~\AppData\Local\go-build
+            ~\go\pkg\mod
+            ${{ github.workspace }}\go-build
+            ${{ env.GOPATH }}\pkg\mod
+          key: ${{ matrix.os }}-${{ github.job }}-${{ hashFiles('**/vendor.sum') }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ github.job }}-
+      -
+        name: Docker info
+        run: |
+          docker info
+      -
+        name: Build base image
+        run: |
+          docker pull ${{ env.WINDOWS_BASE_IMAGE }}:${{ env.WINDOWS_BASE_IMAGE_TAG }}
+          docker tag ${{ env.WINDOWS_BASE_IMAGE }}:${{ env.WINDOWS_BASE_IMAGE_TAG }} microsoft/windowsservercore
+          docker build --build-arg GO_VERSION -t ${{ env.TEST_IMAGE_NAME }} -f Dockerfile.windows .
+      -
+        name: Build binaries
+        run: |
+          & docker run --name ${{ env.TEST_CTN_NAME }} -e "DOCKER_GITCOMMIT=${{ github.sha }}" `
+              -v "${{ github.workspace }}\go-build:C:\Users\ContainerAdministrator\AppData\Local\go-build" `
+              -v "${{ github.workspace }}\go\pkg\mod:C:\gopath\pkg\mod" `
+              ${{ env.TEST_IMAGE_NAME }} hack\make.ps1 -Daemon -Client
+      -
+        name: Copy artifacts
+        run: |
+          New-Item -ItemType "directory" -Path "${{ env.BIN_OUT }}"
+          docker cp "${{ env.TEST_CTN_NAME }}`:c`:\gopath\src\github.com\docker\docker\bundles\docker.exe" ${{ env.BIN_OUT }}\
+          docker cp "${{ env.TEST_CTN_NAME }}`:c`:\gopath\src\github.com\docker\docker\bundles\dockerd.exe" ${{ env.BIN_OUT }}\
+          docker cp "${{ env.TEST_CTN_NAME }}`:c`:\gopath\bin\gotestsum.exe" ${{ env.BIN_OUT }}\
+          docker cp "${{ env.TEST_CTN_NAME }}`:c`:\containerd\bin\containerd.exe" ${{ env.BIN_OUT }}\
+          docker cp "${{ env.TEST_CTN_NAME }}`:c`:\containerd\bin\containerd-shim-runhcs-v1.exe" ${{ env.BIN_OUT }}\
+      -
+        name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-${{ matrix.os }}
+          path: ${{ env.BIN_OUT }}/*
+          if-no-files-found: error
+          retention-days: 2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -131,6 +131,7 @@ jobs:
         run: |
           New-Item -ItemType "directory" -Path "${{ github.workspace }}\go-build"
           New-Item -ItemType "directory" -Path "${{ github.workspace }}\go\pkg\mod"
+          New-Item -ItemType "directory" -Path "bundles"
           If ("${{ matrix.os }}" -eq "windows-2019") {
             echo "WINDOWS_BASE_IMAGE_TAG=${{ env.WINDOWS_BASE_TAG_2019 }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           } ElseIf ("${{ matrix.os }}" -eq "windows-2022") {
@@ -162,9 +163,26 @@ jobs:
         name: Test
         run: |
           & docker run --name ${{ env.TEST_CTN_NAME }} -e "DOCKER_GITCOMMIT=${{ github.sha }}" `
-              -v "${{ github.workspace }}\go-build:C:\Users\ContainerAdministrator\AppData\Local\go-build" `
-              -v "${{ github.workspace }}\go\pkg\mod:C:\gopath\pkg\mod" `
-              ${{ env.TEST_IMAGE_NAME }} hack\make.ps1 -TestUnit
+            -v "${{ github.workspace }}\go-build:C:\Users\ContainerAdministrator\AppData\Local\go-build" `
+            -v "${{ github.workspace }}\go\pkg\mod:C:\gopath\pkg\mod" `
+            -v "${{ env.GOPATH }}\src\github.com\docker\docker\bundles:C:\gopath\src\github.com\docker\docker\bundles" `
+            ${{ env.TEST_IMAGE_NAME }} hack\make.ps1 -TestUnit
+      -
+        name: Send to Codecov
+        if: matrix.os == 'windows-2022'
+        uses: codecov/codecov-action@v3
+        with:
+          working-directory: ${{ env.GOPATH }}\src\github.com\docker\docker
+          directory: bundles
+          env_vars: RUNNER_OS
+          flags: unit
+      -
+        name: Upload reports
+        if: matrix.os == 'windows-2022'
+        uses: actions/upload-artifact@v3
+        with:
+          name: unit-reports
+          path: ${{ env.GOPATH }}\src\github.com\docker\docker\bundles\*
 
   integration-test:
     runs-on: ${{ matrix.os }}
@@ -330,12 +348,31 @@ jobs:
       -
         name: Test CLI
         run: |
-          gotestsum --format=standard-verbose -- "-tags" "autogen" "-test.timeout" "200m"
-        working-directory: ${{ env.GOPATH }}/src/github.com/docker/docker/integration-cli
+          & gotestsum --format=standard-verbose --packages="./integration-cli/..." -- `
+            "-coverprofile" "./bundles/coverage-report-int-cli-tests.txt" `
+            "-covermode" "atomic" `
+            "-tags" "autogen" `
+            "-test.timeout" "200m"
         env:
           DOCKER_HOST: npipe:////./pipe/docker_engine
           GO111MODULE: "off"
           TEST_CLIENT_BINARY: ${{ env.BIN_OUT }}\docker
+      -
+        name: Send to Codecov
+        if: matrix.os == 'windows-2022'
+        uses: codecov/codecov-action@v3
+        with:
+          working-directory: ${{ env.GOPATH }}\src\github.com\docker\docker
+          directory: bundles
+          env_vars: RUNNER_OS
+          flags: integration,${{ matrix.runtime }}
+      -
+        name: Upload reports
+        if: matrix.os == 'windows-2022'
+        uses: actions/upload-artifact@v3
+        with:
+          name: integration-reports-${{ matrix.runtime }}
+          path: ${{ env.GOPATH }}\src\github.com\docker\docker\bundles\*
       -
         name: Docker info
         run: |

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,8 @@
-comment:
-  layout: header, changes, diff, sunburst
+comment: false
+
+github_checks:
+  annotations: false
+
 coverage:
   status:
     patch:
@@ -13,5 +16,6 @@ coverage:
         target: auto
         threshold: "15%"
     changes: false
+
 ignore:
-  - "vendor/*"
+  - "vendor/**/*"

--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -328,7 +328,10 @@ Function Run-UnitTests() {
     $pkgList = $pkgList | Select-String -NotMatch "github.com/docker/docker/integration"
     $pkgList = $pkgList -replace "`r`n", " "
 
-    $goTestArg = "--format=standard-verbose --jsonfile=bundles\go-test-report-unit-tests.json --junitfile=bundles\junit-report-unit-tests.xml -- " + $raceParm + " -cover -ldflags -w -a """ + "-test.timeout=10m" + """ $pkgList"
+    $jsonFilePath = $bundlesDir + "\go-test-report-unit-tests.json"
+    $xmlFilePath = $bundlesDir + "\junit-report-unit-tests.xml"
+    $coverageFilePath = $bundlesDir + "\coverage-report-unit-tests.txt"
+    $goTestArg = "--format=standard-verbose --jsonfile=$jsonFilePath --junitfile=$xmlFilePath -- " + $raceParm + " -coverprofile=$coverageFilePath -covermode=atomic -ldflags -w -a """ + "-test.timeout=10m" + """ $pkgList"
     Write-Host "INFO: Invoking unit tests run with $GOTESTSUM_LOCATION\gotestsum.exe $goTestArg"
     $pinfo = New-Object System.Diagnostics.ProcessStartInfo
     $pinfo.FileName = "$GOTESTSUM_LOCATION\gotestsum.exe"
@@ -364,13 +367,14 @@ Function Run-IntegrationTests() {
         }
         $jsonFilePath = $bundlesDir + "\go-test-report-int-tests-$normDir" + ".json"
         $xmlFilePath = $bundlesDir + "\junit-report-int-tests-$normDir" + ".xml"
+        $coverageFilePath = $bundlesDir + "\coverage-report-int-tests-$normDir" + ".txt"
         Set-Location $dir
         Write-Host "Running $($PWD.Path)"
         $pinfo = New-Object System.Diagnostics.ProcessStartInfo
         $pinfo.FileName = "gotestsum.exe"
         $pinfo.WorkingDirectory = "$($PWD.Path)"
         $pinfo.UseShellExecute = $false
-        $pinfo.Arguments = "--format=standard-verbose --jsonfile=$jsonFilePath --junitfile=$xmlFilePath -- -test.timeout=60m $env:INTEGRATION_TESTFLAGS"
+        $pinfo.Arguments = "--format=standard-verbose --jsonfile=$jsonFilePath --junitfile=$xmlFilePath -- -coverprofile=$coverageFilePath -covermode=atomic -test.timeout=60m $env:INTEGRATION_TESTFLAGS"
         $p = New-Object System.Diagnostics.Process
         $p.StartInfo = $pinfo
         $p.Start() | Out-Null

--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -11,6 +11,7 @@ import (
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/poll"
+	"gotest.tools/v3/skip"
 )
 
 func (s *DockerSuite) TestRestartStoppedContainer(c *testing.T) {
@@ -171,6 +172,7 @@ func (s *DockerSuite) TestRestartContainerSuccess(c *testing.T) {
 	// such that it assumes there is a host process to kill. In Hyper-V
 	// containers, the process is inside the utility VM, not on the host.
 	if DaemonIsWindows() {
+		skip.If(c, testEnv.GitHubActions())
 		testRequires(c, testEnv.DaemonInfo.Isolation.IsProcess)
 	}
 
@@ -247,7 +249,7 @@ func (s *DockerSuite) TestRestartPolicyAfterRestart(c *testing.T) {
 	// such that it assumes there is a host process to kill. In Hyper-V
 	// containers, the process is inside the utility VM, not on the host.
 	if DaemonIsWindows() {
-		testRequires(c, testEnv.DaemonInfo.Isolation.IsProcess)
+		testRequires(c, testEnv.DaemonInfo.Isolation.IsProcess, testEnv.NotGitHubActions)
 	}
 
 	out := runSleepingContainer(c, "-d", "--restart=always")

--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -249,7 +249,8 @@ func (s *DockerSuite) TestRestartPolicyAfterRestart(c *testing.T) {
 	// such that it assumes there is a host process to kill. In Hyper-V
 	// containers, the process is inside the utility VM, not on the host.
 	if DaemonIsWindows() {
-		testRequires(c, testEnv.DaemonInfo.Isolation.IsProcess, testEnv.NotGitHubActions)
+		skip.If(c, testEnv.GitHubActions())
+		testRequires(c, testEnv.DaemonInfo.Isolation.IsProcess)
 	}
 
 	out := runSleepingContainer(c, "-d", "--restart=always")

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4151,6 +4151,9 @@ func (s *DockerSuite) TestRunEmptyEnv(c *testing.T) {
 
 // #28658
 func (s *DockerSuite) TestSlowStdinClosing(c *testing.T) {
+	if DaemonIsWindows() {
+		skip.If(c, testEnv.GitHubActions())
+	}
 	const repeat = 3 // regression happened 50% of the time
 	for i := 0; i < repeat; i++ {
 		c.Run(strconv.Itoa(i), func(c *testing.T) {

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -186,14 +186,8 @@ func (s *DockerSuite) TestStartAttachWithRename(c *testing.T) {
 }
 
 func (s *DockerSuite) TestStartReturnCorrectExitCode(c *testing.T) {
-	dockerCmd(c, "create", "--restart=on-failure:2", "--name", "withRestart", "busybox", "sh", "-c", "exit 11")
-	dockerCmd(c, "create", "--rm", "--name", "withRm", "busybox", "sh", "-c", "exit 12")
-
-	out, exitCode, err := dockerCmdWithError("start", "-a", "withRestart")
-	assert.ErrorContains(c, err, "")
-	assert.Equal(c, exitCode, 11, fmt.Sprintf("out: %s", out))
-
-	out, exitCode, err = dockerCmdWithError("start", "-a", "withRm")
-	assert.ErrorContains(c, err, "")
-	assert.Equal(c, exitCode, 12, fmt.Sprintf("out: %s", out))
+	cli.DockerCmd(c, "create", "--restart=on-failure:2", "--name", "withRestart", "busybox", "sh", "-c", "exit 11")
+	cli.DockerCmd(c, "create", "--rm", "--name", "withRm", "busybox", "sh", "-c", "exit 12")
+	cli.Docker(cli.Args("start", "-a", "withRestart")).Assert(c, icmd.Expected{ExitCode: 11})
+	cli.Docker(cli.Args("start", "-a", "withRm")).Assert(c, icmd.Expected{ExitCode: 12})
 }

--- a/testutil/environment/environment.go
+++ b/testutil/environment/environment.go
@@ -221,3 +221,8 @@ func EnsureFrozenImagesLinux(testEnv *Execution) error {
 	}
 	return nil
 }
+
+// GitHubActions is true if test is executed on a GitHub Runner.
+func (e *Execution) GitHubActions() bool {
+	return os.Getenv("GITHUB_ACTIONS") == "true"
+}


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/1951866/162825243-4c5e4a96-25fd-409e-9e03-a3e19391a43f.png)

**- What I did**

Adds a `windows` workflow for GitHub Actions that would do the same job as Jenkins but fragmented to leverage a bit of caching and compute. There is also:

* a build step
* daemon runs as a service so we can check if logging event is working (see last step in the workflow for the `integration-test` job) and we are also close to the user experience.
* use named pipe to expose docker daemon instead of tcp
* containerd runtime also tested against `windows-2019`
* containerd now runs as a service and logs are available

~Scripting is embedded in the workflow for now but planned to move it in a dedicated `.ps1` file. I have not changed the [`hack/ci/windows.ps1`](https://github.com/moby/moby/blob/master/hack/ci/windows.ps1) file on purpose to not disturb the current pipeline and also to be able to test side by side the behavior of Jenkins/GHA.~

Build time is a bit longer:

~1h40 with gha: https://github.com/moby/moby/actions/runs/2154295292
~1h30 with jenkins: https://ci-next.docker.com/public/blue/organizations/jenkins/moby/detail/PR-43475/3/pipeline/283

Not too bad as the hardware on Jenkins is "twice" better:

Jenkins: https://ci-next.docker.com/public/blue/organizations/jenkins/moby/detail/PR-43475/3/pipeline/264#step-266-log-31

```
CPUs: 4
Total Memory: 32GiB
```

GHA: https://github.com/moby/moby/runs/5988331677?check_suite_focus=true#step:10:36

```
CPUs: 2
Total Memory: 7GiB
```

We could split in a follow-up the cli integration tests using a dedicated matrix to reduce build time like we do in BuildKit.

Encountered some tests that failed:

### `TestSlowStdinClosing` (containerd runtime)

Already reported: https://github.com/moby/moby/issues/43012

```
=== FAIL: github.com/docker/docker/integration-cli TestDockerSuite/TestSlowStdinClosing/0 (0.80s)
    docker_cli_run_test.go:4165: D:\a\moby\moby\out\docker.exe: Error response from daemon: failed to create shim task: open \\.\pipe\containerd-991a0ea5a6da06d3ad7260d8e7017fe0760dcf1662544fd587ea608e8450a254-init-stdin: The system cannot find the file specified.: not found.
        
    docker_cli_run_test.go:4174: assertion failed: error is not nil: exit status 127
        --- FAIL: TestDockerSuite/TestSlowStdinClosing/0 (0.80s)

=== FAIL: github.com/docker/docker/integration-cli TestDockerSuite/TestSlowStdinClosing/1 (1.04s)
    docker_cli_run_test.go:4165: D:\a\moby\moby\out\docker.exe: Error response from daemon: failed to create shim task: open \\.\pipe\containerd-65b589a5c9e54e01a4de12c0dae2311bb308d0986998673871385a33bfd11560-init-stdin: The system cannot find the file specified.: not found.
        
    docker_cli_run_test.go:4174: assertion failed: error is not nil: exit status 127
        --- FAIL: TestDockerSuite/TestSlowStdinClosing/1 (1.04s)

=== FAIL: github.com/docker/docker/integration-cli TestDockerSuite/TestSlowStdinClosing/2 (0.79s)
    docker_cli_run_test.go:4165: D:\a\moby\moby\out\docker.exe: Error response from daemon: failed to create shim task: open \\.\pipe\containerd-b328648d14a71422c3b957ddb223b952a4ef987a0e02746ce8de04d20f2eea1b-init-stdin: The system cannot find the file specified.: not found.
        
    docker_cli_run_test.go:4174: assertion failed: error is not nil: exit status 127
        --- FAIL: TestDockerSuite/TestSlowStdinClosing/2 (0.79s)

=== FAIL: github.com/docker/docker/integration-cli TestDockerSuite/TestSlowStdinClosing (2.65s)
    --- FAIL: TestDockerSuite/TestSlowStdinClosing (2.65s)
```

Now that containerd logs are shown in GHA:

```
2022-04-11T21:57:51.4096464Z debug: Calling POST /v1.30/containers/991a0ea5a6da06d3ad7260d8e7017fe0760dcf1662544fd587ea608e8450a254/attach?stderr=1&stdin=1&stdout=1&stream=1
2022-04-11T21:57:51.4096570Z debug: attach: stdin: begin
2022-04-11T21:57:51.4096676Z debug: attach: stdout: begin
2022-04-11T21:57:51.4096763Z debug: attach: stderr: begin
2022-04-11T21:57:51.4097045Z debug: Calling POST /v1.30/containers/991a0ea5a6da06d3ad7260d8e7017fe0760dcf1662544fd587ea608e8450a254/wait?condition=removed
2022-04-11T21:57:51.4097297Z debug: Calling POST /v1.30/containers/991a0ea5a6da06d3ad7260d8e7017fe0760dcf1662544fd587ea608e8450a254/start
2022-04-11T21:57:51.4097562Z debug: WindowsGraphDriver Get() id 991a0ea5a6da06d3ad7260d8e7017fe0760dcf1662544fd587ea608e8450a254 mountLabel 
2022-04-11T21:57:51.4098071Z debug: Calling proc (1) [spanID=3fd90fd300d29243 traceID=4b1e401782d9015e9d9ffab4fc199d26]
2022-04-11T21:57:51.4098277Z debug: Calling proc (2) [traceID=4b1e401782d9015e9d9ffab4fc199d26 spanID=3fd90fd300d29243]
2022-04-11T21:57:51.4098844Z debug: container mounted via layerStore: &{\\?\Volume{94bf3478-b3ab-4632-b15f-7d1ece26f62e} 0x3a09100 0x3a09100} [container=991a0ea5a6da06d3ad7260d8e7017fe0760dcf1662544fd587ea608e8450a254]
2022-04-11T21:57:51.4098993Z debug: RequestAddress(172.24.144.0/20, <nil>, map[])
2022-04-11T21:57:51.4099290Z debug: Assigning addresses for endpoint priceless_lumiere's interface on network nat
2022-04-11T21:57:51.4099467Z debug: endpointStruct.EnableInternalDNS =[false]
2022-04-11T21:57:51.4099824Z debug: [POST]=>[/endpoints/] Request : {"VirtualNetwork":"40472233-959E-46CE-B5C4-334FE808616A","EnableInternalDNS":true}
2022-04-11T21:57:51.4101745Z debug: Network Response : {"ID":"fdd2853f-68cb-4451-8e09-f95b7a5ff944","Name":"Ethernet","Version":55834574851,"AdditionalParams":{},"Resources":{"AdditionalParams":{},"AllocationOrder":0,"CompartmentOperationTime":0,"Flags":0,"Health":{"LastErrorCode":0,"LastUpdateTime":132941877457137836},"ID":"07D566C1-9323-4BAB-B0CB-F748D010B888","PortOperationTime":0,"State":1,"SwitchOperationTime":0,"VfpOperationTime":0,"parentId":"F5C402EB-75F5-474E-9259-96A6ABBF4F51"},"State":1,"VirtualNetwork":"40472233-959e-46ce-b5c4-334fe808616a","VirtualNetworkName":"nat","MacAddress":"00-15-5D-D0-34-C9","EnableInternalDNS":true,"IPAddress":"172.24.147.17","PrefixLength":20,"GatewayAddress":"172.24.144.1","IPSubnetId":"3dcc69b3-0fa9-431f-800d-ddb4f3bc78a0","DNSServerList":"172.24.144.1,168.63.129.16","DNSSuffix":"sfvjqs5o01lenmfktyycba1lhh.cx.internal.cloudapp.net","SharedContainers":[]}
2022-04-11T21:57:51.4102062Z debug: Assigning addresses for endpoint priceless_lumiere's interface on network nat
2022-04-11T21:57:51.4102320Z debug: [GET]=>[/endpoints/fdd2853f-68cb-4451-8e09-f95b7a5ff944] Request : 
2022-04-11T21:57:51.4104288Z debug: Network Response : {"ID":"fdd2853f-68cb-4451-8e09-f95b7a5ff944","Name":"Ethernet","Version":55834574851,"AdditionalParams":{},"Resources":{"AdditionalParams":{},"AllocationOrder":0,"CompartmentOperationTime":0,"Flags":0,"Health":{"LastErrorCode":0,"LastUpdateTime":132941877457137836},"ID":"07D566C1-9323-4BAB-B0CB-F748D010B888","PortOperationTime":0,"State":1,"SwitchOperationTime":0,"VfpOperationTime":0,"parentId":"F5C402EB-75F5-474E-9259-96A6ABBF4F51"},"State":1,"VirtualNetwork":"40472233-959e-46ce-b5c4-334fe808616a","VirtualNetworkName":"nat","MacAddress":"00-15-5D-D0-34-C9","EnableInternalDNS":true,"IPAddress":"172.24.147.17","PrefixLength":20,"GatewayAddress":"172.24.144.1","IPSubnetId":"3dcc69b3-0fa9-431f-800d-ddb4f3bc78a0","DNSServerList":"172.24.144.1,168.63.129.16","DNSSuffix":"sfvjqs5o01lenmfktyycba1lhh.cx.internal.cloudapp.net","SharedContainers":[]}
2022-04-11T21:57:51.4104566Z debug: [GET]=>[/endpoints/fdd2853f-68cb-4451-8e09-f95b7a5ff944] Request : 
2022-04-11T21:57:51.4106511Z debug: Network Response : {"ID":"fdd2853f-68cb-4451-8e09-f95b7a5ff944","Name":"Ethernet","Version":55834574851,"AdditionalParams":{},"Resources":{"AdditionalParams":{},"AllocationOrder":0,"CompartmentOperationTime":0,"Flags":0,"Health":{"LastErrorCode":0,"LastUpdateTime":132941877457137836},"ID":"07D566C1-9323-4BAB-B0CB-F748D010B888","PortOperationTime":0,"State":1,"SwitchOperationTime":0,"VfpOperationTime":0,"parentId":"F5C402EB-75F5-474E-9259-96A6ABBF4F51"},"State":1,"VirtualNetwork":"40472233-959e-46ce-b5c4-334fe808616a","VirtualNetworkName":"nat","MacAddress":"00-15-5D-D0-34-C9","EnableInternalDNS":true,"IPAddress":"172.24.147.17","PrefixLength":20,"GatewayAddress":"172.24.144.1","IPSubnetId":"3dcc69b3-0fa9-431f-800d-ddb4f3bc78a0","DNSServerList":"172.24.144.1,168.63.129.16","DNSSuffix":"sfvjqs5o01lenmfktyycba1lhh.cx.internal.cloudapp.net","SharedContainers":[]}
2022-04-11T21:57:51.4106815Z debug: Programming external connectivity on endpoint priceless_lumiere (47317ab517691814d63ebd52db38745b75a7e9904055206162a445b0508d38e1)
2022-04-11T21:57:51.4107365Z debug: EnableService 991a0ea5a6da06d3ad7260d8e7017fe0760dcf1662544fd587ea608e8450a254 START
2022-04-11T21:57:51.4107595Z debug: EnableService 991a0ea5a6da06d3ad7260d8e7017fe0760dcf1662544fd587ea608e8450a254 DONE
2022-04-11T21:57:51.4112176Z debug: Generated spec: {"ociVersion":"1.0.2-dev","process":{"user":{"uid":0,"gid":0},"args":["cat"],"cwd":"C:\\"},"root":{"path":"\\\\?\\Volume{94bf3478-b3ab-4632-b15f-7d1ece26f62e}\\"},"hostname":"991a0ea5a6da","windows":{"layerFolders":["C:\\Users\\runneradmin\\AppData\\Local\\Temp\\moby-root\\windowsfilter\\06eca824015c405b5ff226d92b60620f5270ff7cd372f36e21a84fc4e6d26931","C:\\Users\\runneradmin\\AppData\\Local\\Temp\\moby-root\\windowsfilter\\a155fe780ecb40972bd0a466409c18153a5b7dcc3843e98dd4f109ea0b9bd3b3","C:\\Users\\runneradmin\\AppData\\Local\\Temp\\moby-root\\windowsfilter\\76d824896c8c6ad237fc5331ea7babe34ccb505ddaeb47c6d0073a75ed662883","C:\\Users\\runneradmin\\AppData\\Local\\Temp\\moby-root\\windowsfilter\\dc7b34aab55da4dfda8306cc1840de6f146a453c28d5f7c23d405fba9100a782","C:\\Users\\runneradmin\\AppData\\Local\\Temp\\moby-root\\windowsfilter\\8b337301899ab5611ff1ca64ec18f62418c53a9e26cea72b62957568d0961075","C:\\Users\\runneradmin\\AppData\\Local\\Temp\\moby-root\\windowsfilter\\6bd1bd73e4dee8a234d5017cc0b08a23dd315fe58494ed44816815cfd867d448","C:\\Users\\runneradmin\\AppData\\Local\\Temp\\moby-root\\windowsfilter\\1a0419d9ef6071bfd0459cad520e4c075ee908a91d6b7e255ac942f247842c5e","C:\\Users\\runneradmin\\AppData\\Local\\Temp\\moby-root\\windowsfilter\\783852746fc8e7e5947248a091d601b1b9bea8722459bff95e67a9b979816818","C:\\Users\\runneradmin\\AppData\\Local\\Temp\\moby-root\\windowsfilter\\0bf0708af2a7556c8842b19419e2350be0b4e1e3cd722a9c3dade28675a56c00","C:\\Users\\runneradmin\\AppData\\Local\\Temp\\moby-root\\windowsfilter\\e7c0ede728d344c256cea593e93d85c96f27c8117b18f0e5abe99d22d25d7a51","C:\\Users\\runneradmin\\AppData\\Local\\Temp\\moby-root\\windowsfilter\\991a0ea5a6da06d3ad7260d8e7017fe0760dcf1662544fd587ea608e8450a254"],"ignoreFlushesDuringBoot":true,"network":{"endpointList":["fdd2853f-68cb-4451-8e09-f95b7a5ff944"],"allowUnqualifiedDNSQuery":true}}}
2022-04-11T21:57:51.4112892Z debug: bundle dir created [namespace=moby bundle=C:\Users\RUNNER~1\AppData\Local\Temp\moby-exec\containerd\991a0ea5a6da06d3ad7260d8e7017fe0760dcf1662544fd587ea608e8450a254 root=\\?\Volume{94bf3478-b3ab-4632-b15f-7d1ece26f62e}\ module=libcontainerd]
2022-04-11T21:57:51.4113427Z debug: listen [module=libcontainerd namespace=moby stdin=\\.\pipe\containerd-991a0ea5a6da06d3ad7260d8e7017fe0760dcf1662544fd587ea608e8450a254-init-stdin]
2022-04-11T21:57:51.4113963Z debug: listen [module=libcontainerd namespace=moby stdout=\\.\pipe\containerd-991a0ea5a6da06d3ad7260d8e7017fe0760dcf1662544fd587ea608e8450a254-init-stdout]
2022-04-11T21:57:51.4114492Z debug: listen [module=libcontainerd namespace=moby stderr=\\.\pipe\containerd-991a0ea5a6da06d3ad7260d8e7017fe0760dcf1662544fd587ea608e8450a254-init-stderr]
2022-04-11T21:57:51.4115022Z debug: accept [module=libcontainerd namespace=moby stdout=\\.\pipe\containerd-991a0ea5a6da06d3ad7260d8e7017fe0760dcf1662544fd587ea608e8450a254-init-stdout]
2022-04-11T21:57:51.4115583Z debug: accept [module=libcontainerd namespace=moby stdin=\\.\pipe\containerd-991a0ea5a6da06d3ad7260d8e7017fe0760dcf1662544fd587ea608e8450a254-init-stdin]
2022-04-11T21:57:51.4116103Z debug: accept [module=libcontainerd namespace=moby stderr=\\.\pipe\containerd-991a0ea5a6da06d3ad7260d8e7017fe0760dcf1662544fd587ea608e8450a254-init-stderr]
2022-04-11T21:57:51.4116228Z debug: Closing buffered stdin pipe
2022-04-11T21:57:51.4116331Z debug: attach: stdin: end
2022-04-11T21:57:51.4116471Z stream copy error: use of closed network connection
2022-04-11T21:57:51.4116616Z stream copy error: use of closed network connection
2022-04-11T21:57:51.4116718Z debug: attach: stdout: end
2022-04-11T21:57:51.4116822Z debug: attach: stderr: end
2022-04-11T21:57:51.4117229Z debug: attach done
2022-04-11T21:57:51.4117522Z debug: Revoking external connectivity on endpoint priceless_lumiere (47317ab517691814d63ebd52db38745b75a7e9904055206162a445b0508d38e1)
2022-04-11T21:57:51.4117800Z debug: [GET]=>[/endpoints/fdd2853f-68cb-4451-8e09-f95b7a5ff944] Request : 
2022-04-11T21:57:51.4119727Z debug: Network Response : {"ID":"fdd2853f-68cb-4451-8e09-f95b7a5ff944","Name":"Ethernet","Version":55834574851,"AdditionalParams":{},"Resources":{"AdditionalParams":{},"AllocationOrder":0,"CompartmentOperationTime":0,"Flags":0,"Health":{"LastErrorCode":0,"LastUpdateTime":132941877457137836},"ID":"07D566C1-9323-4BAB-B0CB-F748D010B888","PortOperationTime":0,"State":1,"SwitchOperationTime":0,"VfpOperationTime":0,"parentId":"F5C402EB-75F5-474E-9259-96A6ABBF4F51"},"State":1,"VirtualNetwork":"40472233-959e-46ce-b5c4-334fe808616a","VirtualNetworkName":"nat","MacAddress":"00-15-5D-D0-34-C9","EnableInternalDNS":true,"IPAddress":"172.24.147.17","PrefixLength":20,"GatewayAddress":"172.24.144.1","IPSubnetId":"3dcc69b3-0fa9-431f-800d-ddb4f3bc78a0","DNSServerList":"172.24.144.1,168.63.129.16","DNSSuffix":"sfvjqs5o01lenmfktyycba1lhh.cx.internal.cloudapp.net","SharedContainers":[]}
2022-04-11T21:57:51.4120004Z debug: [GET]=>[/endpoints/fdd2853f-68cb-4451-8e09-f95b7a5ff944] Request : 
2022-04-11T21:57:51.4121955Z debug: Network Response : {"ID":"fdd2853f-68cb-4451-8e09-f95b7a5ff944","Name":"Ethernet","Version":55834574851,"AdditionalParams":{},"Resources":{"AdditionalParams":{},"AllocationOrder":0,"CompartmentOperationTime":0,"Flags":0,"Health":{"LastErrorCode":0,"LastUpdateTime":132941877457137836},"ID":"07D566C1-9323-4BAB-B0CB-F748D010B888","PortOperationTime":0,"State":1,"SwitchOperationTime":0,"VfpOperationTime":0,"parentId":"F5C402EB-75F5-474E-9259-96A6ABBF4F51"},"State":1,"VirtualNetwork":"40472233-959e-46ce-b5c4-334fe808616a","VirtualNetworkName":"nat","MacAddress":"00-15-5D-D0-34-C9","EnableInternalDNS":true,"IPAddress":"172.24.147.17","PrefixLength":20,"GatewayAddress":"172.24.144.1","IPSubnetId":"3dcc69b3-0fa9-431f-800d-ddb4f3bc78a0","DNSServerList":"172.24.144.1,168.63.129.16","DNSSuffix":"sfvjqs5o01lenmfktyycba1lhh.cx.internal.cloudapp.net","SharedContainers":[]}
2022-04-11T21:57:51.4122244Z debug: [DELETE]=>[/endpoints/fdd2853f-68cb-4451-8e09-f95b7a5ff944] Request : 
2022-04-11T21:57:51.4122381Z debug: ReleaseAddress(172.24.144.0/20, 172.24.147.17)
2022-04-11T21:57:51.4122680Z debug: Releasing addresses for endpoint priceless_lumiere's interface on network nat
2022-04-11T21:57:51.4122934Z debug: WindowsGraphDriver Put() id 991a0ea5a6da06d3ad7260d8e7017fe0760dcf1662544fd587ea608e8450a254
2022-04-11T21:57:51.4123215Z 991a0ea5a6da06d3ad7260d8e7017fe0760dcf1662544fd587ea608e8450a254 cleanup: failed to delete container from containerd: no such container
```

Looks like a race condition:

```
...
2022-04-11T21:57:51.4116228Z debug: Closing buffered stdin pipe
2022-04-11T21:57:51.4116331Z debug: attach: stdin: end
2022-04-11T21:57:51.4116471Z stream copy error: use of closed network connection
2022-04-11T21:57:51.4116616Z stream copy error: use of closed network connection
2022-04-11T21:57:51.4116718Z debug: attach: stdout: end
2022-04-11T21:57:51.4116822Z debug: attach: stderr: end
2022-04-11T21:57:51.4117229Z debug: attach done
...
2022-04-11T21:57:51.4123215Z 991a0ea5a6da06d3ad7260d8e7017fe0760dcf1662544fd587ea608e8450a254 cleanup: failed to delete container from containerd: no such container
```

Seems to be also linked to https://github.com/moby/moby/issues/33710

### `TestRestartContainerSuccess`, `TestRestartPolicyAfterRestart`

```
=== Failed
=== FAIL: github.com/docker/docker/integration-cli TestDockerSuite/TestRestartContainerSuccess (4.51s)
    docker_cli_restart_test.go:191: assertion failed: error is not nil: DuplicateHandle: Access is denied.
    --- FAIL: TestDockerSuite/TestRestartContainerSuccess (4.51s)

=== FAIL: github.com/docker/docker/integration-cli TestDockerSuite/TestRestartPolicyAfterRestart (7.20s)
    docker_cli_restart_test.go:271: assertion failed: error is not nil: DuplicateHandle: Access is denied.
    --- FAIL: TestDockerSuite/TestRestartPolicyAfterRestart (7.20s)
```

Repro everytime on GitHub Runners so might be linked to the OS configuration (maybe HyperV). Skipping the test for now.


**- Description for the changelog**

Adds github action workflow for windows

cc @corhere @thaJeztah