### PR TITLE
Mitigate the impact of slow exec starts on health checks

### DIFF
--- a/daemon/metrics.go
+++ b/daemon/metrics.go
@@ -37,6 +37,7 @@ var (
 
 	healthChecksCounter       = metricsNS.NewCounter("health_checks", "The total number of health checks")
 	healthChecksFailedCounter = metricsNS.NewCounter("health_checks_failed", "The total number of failed health checks")
+	healthCheckStartDuration  = metricsNS.NewTimer("health_check_start_duration", "The number of seconds it takes to prepare to run health checks")
 
 	stateCtr = newStateCounter(metricsNS, metricsNS.NewDesc("container_states", "The count of containers in various states", metrics.Unit("containers"), "state"))
 )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- Relates to #33933

**- What I did**
While investigating a report of slow `docker exec`s and failing health checks on heavily-loaded systems, I instrumented `dockerd` with OpenTelemetry tracing (https://github.com/corhere/moby/tree/otel-trace) and captured traces with tens of health-checked containers running concurrently. I was surprised to find that—on my machine and setup—the `containerd.services.tasks.v1.Tasks/Start` RPC could take upwards of a full second to complete with ~50 health-checked containers.

```sh
for i in {0..50}; do
  docker run -d --name healthstress${i} \
  --health-cmd true --health-interval 1s --health-timeout 5s \
  alpine sleep infinity
done
```

![Screenshot of Jaeger UI showing a trace of a health check](https://user-images.githubusercontent.com/274527/163066201-b008f8f6-2e9d-4667-9f4d-41758a13f3ab.png)

The timeout for a container health check starts the moment `dockerd` starts setting up the exec for the probe command. Consequently, the time it takes to setup the command execution, including all containerd RPCs, takes away from the time the probe command has to run to completion. I have yet to determine the root cause of the latency, but in the meantime I have attempted to mitigate the worst impacts by not counting it against the probe command's timeout.

**- How I did it**
I moved the the probe-timeout timer into the probe implementation, and started the timer only once the probe command has started up.

**- How to verify it**
Test that container health checks and timeouts continue to function as before.
```sh
# Should be unhealthy
docker run --health-cmd "sleep 5" --health-interval 1s --health-timeout 2s -d --name healthtest -d alpine sleep infinity
# Should be healthy
docker run --health-cmd true --health-interval 1s --health-timeout 2s -d --name healthtest -d alpine sleep infinity
```

[Configure `dockerd` to expose the metrics server](https://docs.docker.com/config/daemon/prometheus/), make an HTTP request against it (`curl localhost:9323/metrics`) and check that the newly-added `engine_daemon_health_check_start_duration_seconds` histogram metric is returned.

**- Description for the changelog**
- Health check timeout now applies only to the duration that the health-check command is running. The time it takes to start the command no longer counts against the timeout.

**- A picture of a cute animal (not mandatory but encouraged)**
<img src="https://github.com/jaegertracing/artwork/raw/master/PNG/Jaeger_Logo_Final_PANTONE.png" width="50%" height="50%">
