### PR TITLE
introduce CreateMountpoint for parity between binds and mounts

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -380,6 +380,10 @@ definitions:
             description: "Disable recursive bind mount."
             type: "boolean"
             default: false
+          CreateMountpoint:
+            description: "Create mount point on host if missing"
+            type: "boolean"
+            default: false
       VolumeOptions:
         description: "Optional configuration for the `volume` type."
         type: "object"

--- a/api/types/mount/mount.go
+++ b/api/types/mount/mount.go
@@ -82,8 +82,9 @@ const (
 
 // BindOptions defines options specific to mounts of type "bind".
 type BindOptions struct {
-	Propagation  Propagation `json:",omitempty"`
-	NonRecursive bool        `json:",omitempty"`
+	Propagation      Propagation `json:",omitempty"`
+	NonRecursive     bool        `json:",omitempty"`
+	CreateMountpoint bool        `json:",omitempty"`
 }
 
 // VolumeOptions represents the options for a mount of type volume.

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -216,7 +216,7 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 			}
 		}
 
-		if mp.Type == mounttypes.TypeBind {
+		if mp.Type == mounttypes.TypeBind && (cfg.BindOptions == nil || !cfg.BindOptions.CreateMountpoint) {
 			mp.SkipMountpointCreation = true
 		}
 

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -97,6 +97,10 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `POST /containers/create` on Linux now respects the `HostConfig.ConsoleSize` property.
   Container is immediately created with the desired terminal size and clients no longer
   need to set the desired size on their own.
+* `POST /containers/create` allow to set `CreateMountpoint` for host path to be
+  created if missing. This brings parity with `Binds`
+* `POST /containers/create` rejects request if BindOptions|VolumeOptions|TmpfsOptions
+  is set with a non-matching mount Type.
 
 ## v1.41 API changes
 


### PR DESCRIPTION
closes https://github.com/moby/moby/issues/43483

**- What I did**
introduce `CreateMountpoint` to offer parity between `binds` and `mounts` APIs

My long terms goal is to fully translate `binds` API to `mounts` in `container_routes` so we only have to support `mounts` within the engine backend

**- How I did it**
Introduced Mount.BindOptions.CreateMountPoint

**- How to verify it**

**- Description for the changelog**
- Introduced Mount.BindOptions.CreateMountPoint on POST /containers/create

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/132757/163155959-e24b85e5-beae-4131-899a-7a581973279a.png)

