### PR TITLE
[20.10 backport] Jenkinsfile: add workaround for CVE-2022-24765

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
                   -v "$WORKSPACE:/workspace" \
                   -e VALIDATE_REPO=${GIT_URL} \
                   -e VALIDATE_BRANCH=${CHANGE_TARGET} \
-                  alpine sh -c 'apk add --no-cache -q bash git openssh-client && cd /workspace && hack/validate/dco'
+                  alpine sh -c 'apk add --no-cache -q bash git openssh-client && git config --system --add safe.directory /workspace && cd /workspace && hack/validate/dco'
                 '''
             }
         }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/43477#issuecomment-1097341271
- backports https://github.com/moby/moby/pull/43485

git published an advisory Yesterday, which (as a counter-measure)
requires the git repository's directory to be owned by the current
user, and otherwise produce an error:

    fatal: unsafe repository ('/workspace' is owned by someone else)
    To add an exception for this directory, call:

        git config --global --add safe.directory /workspace

The DCO check is run within a container, which is running as `root`
(to allow packages to be installed), but because of this, the user
does not match the files that are bind-mounted from the host (as they
are checked out by Jenkins, using a different user).

To work around this issue, this patch configures git to consider the
`/workspace` directory as "safe". We configure it in the `--system`
configuration so that it takes effect for "all users" inside the
container.

More details on the advisory can be found on GitHub's blog:
https://github.blog/2022-04-12-git-security-vulnerability-announced/

(cherry picked from commit efe03aa2d83383d494a86f6a3029cc02b6379024)

**- A picture of a cute animal (not mandatory but encouraged)**

