### PR TITLE
client: CopyToContainer(), CopyFromContainer(): remove status-code handling

### DIFF
--- a/client/container_copy.go
+++ b/client/container_copy.go
@@ -50,11 +50,6 @@ func (cli *Client) CopyToContainer(ctx context.Context, containerID, dstPath str
 		return err
 	}
 
-	// TODO this code converts non-error status-codes (e.g., "204 No Content") into an error; verify if this is the desired behavior
-	if response.statusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code from daemon: %d", response.statusCode)
-	}
-
 	return nil
 }
 
@@ -68,11 +63,6 @@ func (cli *Client) CopyFromContainer(ctx context.Context, containerID, srcPath s
 	response, err := cli.get(ctx, apiPath, query, nil)
 	if err != nil {
 		return nil, types.ContainerPathStat{}, err
-	}
-
-	// TODO this code converts non-error status-codes (e.g., "204 No Content") into an error; verify if this is the desired behavior
-	if response.statusCode != http.StatusOK {
-		return nil, types.ContainerPathStat{}, fmt.Errorf("unexpected status code from daemon: %d", response.statusCode)
 	}
 
 	// In order to get the copy behavior right, we need to know information

--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -2,15 +2,18 @@ package container // import "github.com/docker/docker/integration/container"
 
 import (
 	"archive/tar"
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/testutil/fakecontext"
 	"gotest.tools/v3/assert"
@@ -57,6 +60,47 @@ func TestCopyToContainerPathDoesNotExist(t *testing.T) {
 	err := apiclient.CopyToContainer(ctx, cid, "/dne", nil, types.CopyToContainerOptions{})
 	assert.Check(t, client.IsErrNotFound(err))
 	assert.ErrorContains(t, err, "Could not find the file /dne in container "+cid)
+}
+
+func TestCopyEmptyFile(t *testing.T) {
+	defer setupTest(t)()
+
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "empty-file.txt")
+	err := os.WriteFile(srcPath, []byte(""), 0400)
+	assert.NilError(t, err)
+
+	// TODO(thaJeztah) Add utilities to the client to make steps below less complicated.
+	// Code below is taken from copyToContainer() in docker/cli.
+	srcInfo, err := archive.CopyInfoSourcePath(srcPath, false)
+	assert.NilError(t, err)
+
+	srcArchive, err := archive.TarResource(srcInfo)
+	assert.NilError(t, err)
+	defer srcArchive.Close()
+
+	ctrPath := "/empty-file.txt"
+	dstInfo := archive.CopyInfo{Path: ctrPath}
+	dstDir, preparedArchive, err := archive.PrepareArchiveCopy(srcArchive, srcInfo, dstInfo)
+	assert.NilError(t, err)
+	defer preparedArchive.Close()
+
+	ctx := context.Background()
+	apiclient := testEnv.APIClient()
+	cid := container.Create(ctx, t, apiclient)
+
+	// empty content
+	err = apiclient.CopyToContainer(ctx, cid, dstDir, bytes.NewReader([]byte("")), types.CopyToContainerOptions{})
+	assert.NilError(t, err)
+
+	// tar with empty file
+	err = apiclient.CopyToContainer(ctx, cid, dstDir, preparedArchive, types.CopyToContainerOptions{})
+	assert.NilError(t, err)
+
+	// copy from empty file
+	rdr, _, err := apiclient.CopyFromContainer(ctx, cid, dstDir)
+	assert.NilError(t, err)
+	defer rdr.Close()
 }
 
 func TestCopyToContainerPathIsNotDir(t *testing.T) {


### PR DESCRIPTION
This was added in 93c3e6c91ec5eb4202b86b44b011d06f5e048dab (https://github.com/moby/moby/pull/13171), at which time only some [basic handling of non-succesful status codes was present](https://github.com/moby/moby/blob/93c3e6c91ec5eb4202b86b44b011d06f5e048dab/api/client/utils.go#L112-L121)

Given that since 38e6d474affe08230043fa36fa02f623c2ab2661 (https://github.com/moby/moby/pull/38689) non-successful status-codes are already handled, and a 204 ("no content") status should not be an error, this special case should no longer be needed.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

