### PR TITLE
client: ContainerKill(): don't send signal query-param if none was set

### DIFF
--- a/client/container_kill.go
+++ b/client/container_kill.go
@@ -8,7 +8,9 @@ import (
 // ContainerKill terminates the container process but does not remove the container from the docker host.
 func (cli *Client) ContainerKill(ctx context.Context, containerID, signal string) error {
 	query := url.Values{}
-	query.Set("signal", signal)
+	if signal != "" {
+		query.Set("signal", signal)
+	}
 
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/kill", query, nil, nil)
 	ensureReaderClosed(resp)


### PR DESCRIPTION
Just a small clean-up (there's more endpoints to do this for, but I was working on changes in this area on the CLI when I noticed we were setting this query-parameter unconditionally.


**- A picture of a cute animal (not mandatory but encouraged)**

