### PR TITLE
opts: remove hacks for old go versions, and improve coverage

### DIFF
--- a/opts/hosts.go
+++ b/opts/hosts.go
@@ -132,13 +132,6 @@ func ParseTCPAddr(tryAddr string, defaultAddr string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	// url.Parse fails for trailing colon on IPv6 brackets on Go 1.5, but
-	// not 1.4. See https://github.com/golang/go/issues/12200 and
-	// https://github.com/golang/go/issues/6530.
-	if strings.HasSuffix(addr, "]:") {
-		addr += defaultPort
-	}
-
 	u, err := url.Parse("tcp://" + addr)
 	if err != nil {
 		return "", err

--- a/opts/hosts_test.go
+++ b/opts/hosts_test.go
@@ -7,20 +7,20 @@ import (
 )
 
 func TestParseHost(t *testing.T) {
-	invalid := []string{
-		"something with spaces",
-		"://",
-		"unknown://",
-		"tcp://:port",
-		"tcp://invalid:port",
-		"tcp://:5555/",
-		"tcp://:5555/p",
-		"tcp://0.0.0.0:5555/",
-		"tcp://0.0.0.0:5555/p",
-		"tcp://[::1]:/",
-		"tcp://[::1]:5555/",
-		"tcp://[::1]:5555/p",
-		" tcp://:5555/path ",
+	invalid := map[string]string{
+		"something with spaces": `parse "tcp://something with spaces": invalid character " " in host name`,
+		"://":                   `Invalid bind address format: ://`,
+		"unknown://":            `Invalid bind address format: unknown://`,
+		"tcp://:port":           `parse "tcp://:port": invalid port ":port" after host`,
+		"tcp://invalid:port":    `parse "tcp://invalid:port": invalid port ":port" after host`,
+		"tcp://:5555/":          `invalid bind address (:5555/): should not contain a path element`,
+		"tcp://:5555/p":         `invalid bind address (:5555/p): should not contain a path element`,
+		"tcp://0.0.0.0:5555/":   `invalid bind address (0.0.0.0:5555/): should not contain a path element`,
+		"tcp://0.0.0.0:5555/p":  `invalid bind address (0.0.0.0:5555/p): should not contain a path element`,
+		"tcp://[::1]:/":         `invalid bind address ([::1]:/): should not contain a path element`,
+		"tcp://[::1]:5555/":     `invalid bind address ([::1]:5555/): should not contain a path element`,
+		"tcp://[::1]:5555/p":    `invalid bind address ([::1]:5555/p): should not contain a path element`,
+		" tcp://:5555/path ":    `invalid bind address (:5555/path): should not contain a path element`,
 	}
 
 	valid := map[string]string{
@@ -46,11 +46,11 @@ func TestParseHost(t *testing.T) {
 		"npipe:////./pipe/foo":     "npipe:////./pipe/foo",
 	}
 
-	for _, value := range invalid {
+	for value, expectedError := range invalid {
 		t.Run(value, func(t *testing.T) {
 			_, err := ParseHost(false, false, value)
-			if err == nil {
-				t.Errorf("expected an error, got [nil]")
+			if err == nil || err.Error() != expectedError {
+				t.Errorf(`expected error "%s", got "%v"`, expectedError, err)
 			}
 		})
 	}

--- a/opts/hosts_test.go
+++ b/opts/hosts_test.go
@@ -59,9 +59,8 @@ func TestParseHost(t *testing.T) {
 
 func TestParseDockerDaemonHost(t *testing.T) {
 	invalids := map[string]string{
-
-		"tcp:a.b.c.d":                   "",
-		"tcp:a.b.c.d/path":              "",
+		"tcp:a.b.c.d":                   `parse "tcp://tcp:a.b.c.d": invalid port ":a.b.c.d" after host`,
+		"tcp:a.b.c.d/path":              `parse "tcp://tcp:a.b.c.d/path": invalid port ":a.b.c.d" after host`,
 		"udp://127.0.0.1":               "Invalid bind address format: udp://127.0.0.1",
 		"udp://127.0.0.1:2375":          "Invalid bind address format: udp://127.0.0.1:2375",
 		"tcp://unix:///run/docker.sock": "Invalid proto, expected tcp: unix:///run/docker.sock",
@@ -90,7 +89,7 @@ func TestParseDockerDaemonHost(t *testing.T) {
 		"localhost:5555":          "tcp://localhost:5555",
 	}
 	for invalidAddr, expectedError := range invalids {
-		if addr, err := parseDaemonHost(invalidAddr); err == nil || expectedError != "" && err.Error() != expectedError {
+		if addr, err := parseDaemonHost(invalidAddr); err == nil || err.Error() != expectedError {
 			t.Errorf("tcp %v address expected error %q return, got %q and addr %v", invalidAddr, expectedError, err, addr)
 		}
 	}
@@ -106,8 +105,8 @@ func TestParseTCP(t *testing.T) {
 		defaultHTTPHost = "tcp://127.0.0.1:2376"
 	)
 	invalids := map[string]string{
-		"tcp:a.b.c.d":                 "",
-		"tcp:a.b.c.d/path":            "",
+		"tcp:a.b.c.d":                 `parse "tcp://tcp:a.b.c.d": invalid port ":a.b.c.d" after host`,
+		"tcp:a.b.c.d/path":            `parse "tcp://tcp:a.b.c.d/path": invalid port ":a.b.c.d" after host`,
 		"udp://127.0.0.1":             "Invalid proto, expected tcp: udp://127.0.0.1",
 		"udp://127.0.0.1:2375":        "Invalid proto, expected tcp: udp://127.0.0.1:2375",
 		":5555/path":                  "invalid bind address (:5555/path): should not contain a path element",
@@ -132,7 +131,7 @@ func TestParseTCP(t *testing.T) {
 		"localhost:5555":         "tcp://localhost:5555",
 	}
 	for invalidAddr, expectedError := range invalids {
-		if addr, err := ParseTCPAddr(invalidAddr, defaultHTTPHost); err == nil || expectedError != "" && err.Error() != expectedError {
+		if addr, err := ParseTCPAddr(invalidAddr, defaultHTTPHost); err == nil || err.Error() != expectedError {
 			t.Errorf("tcp %v address expected error %v return, got %s and addr %v", invalidAddr, expectedError, err, addr)
 		}
 	}

--- a/opts/hosts_test.go
+++ b/opts/hosts_test.go
@@ -47,15 +47,24 @@ func TestParseHost(t *testing.T) {
 	}
 
 	for _, value := range invalid {
-		if _, err := ParseHost(false, false, value); err == nil {
-			t.Errorf("Expected an error for %v, got [nil]", value)
-		}
+		t.Run(value, func(t *testing.T) {
+			_, err := ParseHost(false, false, value)
+			if err == nil {
+				t.Errorf("expected an error, got [nil]")
+			}
+		})
 	}
 
 	for value, expected := range valid {
-		if actual, err := ParseHost(false, false, value); err != nil || actual != expected {
-			t.Errorf("Expected for %v [%v], got [%v, %v]", value, expected, actual, err)
-		}
+		t.Run(value, func(t *testing.T) {
+			actual, err := ParseHost(false, false, value)
+			if err != nil {
+				t.Errorf(`unexpected error: "%v"`, err)
+			}
+			if actual != expected {
+				t.Errorf(`expected "%s", got "%s""`, expected, actual)
+			}
+		})
 	}
 }
 
@@ -99,14 +108,26 @@ func TestParseDockerDaemonHost(t *testing.T) {
 		"unix:///run/docker.sock": "unix:///run/docker.sock",
 	}
 	for invalidAddr, expectedError := range invalids {
-		if addr, err := parseDaemonHost(invalidAddr); err == nil || err.Error() != expectedError {
-			t.Errorf("tcp %v address expected error %q return, got %q and addr %v", invalidAddr, expectedError, err, addr)
-		}
+		t.Run(invalidAddr, func(t *testing.T) {
+			addr, err := parseDaemonHost(invalidAddr)
+			if err == nil || err.Error() != expectedError {
+				t.Errorf(`expected error "%s", got "%v"`, expectedError, err)
+			}
+			if addr != "" {
+				t.Errorf(`expected addr to be empty, got "%s""`, addr)
+			}
+		})
 	}
 	for validAddr, expectedAddr := range valids {
-		if addr, err := parseDaemonHost(validAddr); err != nil || addr != expectedAddr {
-			t.Errorf("%v -> expected %v, got (%v) addr (%v)", validAddr, expectedAddr, err, addr)
-		}
+		t.Run(validAddr, func(t *testing.T) {
+			addr, err := parseDaemonHost(validAddr)
+			if err != nil {
+				t.Errorf(`unexpected error: "%v"`, err)
+			}
+			if addr != expectedAddr {
+				t.Errorf(`expected "%s", got "%s""`, expectedAddr, addr)
+			}
+		})
 	}
 }
 
@@ -146,14 +167,26 @@ func TestParseTCP(t *testing.T) {
 		"tcp://:5555":            "tcp://127.0.0.1:5555",
 	}
 	for invalidAddr, expectedError := range invalids {
-		if addr, err := ParseTCPAddr(invalidAddr, defaultHTTPHost); err == nil || err.Error() != expectedError {
-			t.Errorf("tcp %v address expected error %v return, got %s and addr %v", invalidAddr, expectedError, err, addr)
-		}
+		t.Run(invalidAddr, func(t *testing.T) {
+			addr, err := ParseTCPAddr(invalidAddr, defaultHTTPHost)
+			if err == nil || err.Error() != expectedError {
+				t.Errorf(`expected error "%s", got "%v"`, expectedError, err)
+			}
+			if addr != "" {
+				t.Errorf(`expected addr to be empty, got "%s""`, addr)
+			}
+		})
 	}
 	for validAddr, expectedAddr := range valids {
-		if addr, err := ParseTCPAddr(validAddr, defaultHTTPHost); err != nil || addr != expectedAddr {
-			t.Errorf("%v -> expected %v, got %v and addr %v", validAddr, expectedAddr, err, addr)
-		}
+		t.Run(validAddr, func(t *testing.T) {
+			addr, err := ParseTCPAddr(validAddr, defaultHTTPHost)
+			if err != nil {
+				t.Errorf(`unexpected error: "%v"`, err)
+			}
+			if addr != expectedAddr {
+				t.Errorf(`expected "%s", got "%s""`, expectedAddr, addr)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Moving some more commits out of a local branch I had (follow-up to https://github.com/moby/moby/pull/43457)

### opts: TestParseDockerDaemonHost(), TestParseTCP() remove workaround for go1.12

This was added in https://github.com/moby/moby/commit/683766613a8c1dca8f95b19ddb7e083bb3aef266, to workaround changes in error between go 1.12.8 / go 1.11.13, causing the test to fail.

We no longer test against those versions, so we can remove this workaround.

### opts: ParseTCPAddr(): remove workaround for go1.5

Current versions of Go no longer have a problem with the trailing
colon when using url.Parse() or net.SplitHostPort(), so we can remove
this workaround.

### opts: re-order test-cases and use more consistent values

Re-order some test-cases to make it easier to find if we cover all variants,
and add some missing variants.

Also change tests to not use default ports where needed, so that we are sure
the code is taking the provided value, and didn't fall back to use the defaults.

### opts: use subtests, and split checks

Some checks combined all possible comparisons in a single "assert",
making it hard to see in the output what failed (output, error?)

### opts: TestParseHost(): also check the error

This test was only validating that "an" error occurred, but failed
to check if the error was for the expected reason.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

