### PR TITLE
panic() instead of logrus.Fatal() in init funcs

### DIFF
--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -120,10 +120,10 @@ type byTimestamp []wrappedEvent
 // init registers the awslogs driver
 func init() {
 	if err := logger.RegisterLogDriver(name, New); err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 	if err := logger.RegisterLogOptValidator(name, ValidateLogOpt); err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 }
 

--- a/daemon/logger/etwlogs/etwlogs_windows.go
+++ b/daemon/logger/etwlogs/etwlogs_windows.go
@@ -48,7 +48,7 @@ var mu sync.Mutex
 func init() {
 	providerHandle = windows.InvalidHandle
 	if err := logger.RegisterLogDriver(name, New); err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 }
 

--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -62,10 +62,10 @@ const (
 
 func init() {
 	if err := logger.RegisterLogDriver(name, New); err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 	if err := logger.RegisterLogOptValidator(name, ValidateLogOpt); err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 }
 

--- a/daemon/logger/gcplogs/gcplogging.go
+++ b/daemon/logger/gcplogs/gcplogging.go
@@ -43,13 +43,12 @@ var (
 )
 
 func init() {
-
 	if err := logger.RegisterLogDriver(name, New); err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 
 	if err := logger.RegisterLogOptValidator(name, ValidateLogOpts); err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 }
 

--- a/daemon/logger/gelf/gelf.go
+++ b/daemon/logger/gelf/gelf.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Graylog2/go-gelf/gelf"
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/logger/loggerutils"
-	"github.com/sirupsen/logrus"
 )
 
 const name = "gelf"
@@ -28,10 +27,10 @@ type gelfLogger struct {
 
 func init() {
 	if err := logger.RegisterLogDriver(name, New); err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 	if err := logger.RegisterLogOptValidator(name, ValidateLogOpt); err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 }
 

--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -14,7 +14,6 @@ import (
 	"github.com/coreos/go-systemd/v22/journal"
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/logger/loggerutils"
-	"github.com/sirupsen/logrus"
 )
 
 const name = "journald"
@@ -27,10 +26,10 @@ type journald struct {
 
 func init() {
 	if err := logger.RegisterLogDriver(name, New); err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 	if err := logger.RegisterLogOptValidator(name, validateLogOpt); err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 }
 

--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -15,7 +15,6 @@ import (
 	"github.com/docker/docker/daemon/logger/loggerutils"
 	units "github.com/docker/go-units"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 // Name is the name of the file that the jsonlogger logs to.
@@ -32,10 +31,10 @@ type JSONFileLogger struct {
 
 func init() {
 	if err := logger.RegisterLogDriver(Name, New); err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 	if err := logger.RegisterLogOptValidator(Name, ValidateLogOpt); err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 }
 

--- a/daemon/logger/local/local.go
+++ b/daemon/logger/local/local.go
@@ -14,7 +14,6 @@ import (
 	"github.com/docker/docker/errdefs"
 	units "github.com/docker/go-units"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -49,10 +48,10 @@ func ValidateLogOpt(cfg map[string]string) error {
 
 func init() {
 	if err := logger.RegisterLogDriver(Name, New); err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 	if err := logger.RegisterLogOptValidator(Name, ValidateLogOpt); err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 }
 

--- a/daemon/logger/logentries/logentries.go
+++ b/daemon/logger/logentries/logentries.go
@@ -29,10 +29,10 @@ const (
 
 func init() {
 	if err := logger.RegisterLogDriver(name, New); err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 	if err := logger.RegisterLogOptValidator(name, ValidateLogOpt); err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 }
 

--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -142,10 +142,10 @@ const (
 
 func init() {
 	if err := logger.RegisterLogDriver(driverName, New); err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 	if err := logger.RegisterLogOptValidator(driverName, ValidateLogOpt); err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 }
 

--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -16,7 +16,6 @@ import (
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/logger/loggerutils"
 	"github.com/docker/go-connections/tlsconfig"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -54,10 +53,10 @@ type syslogger struct {
 
 func init() {
 	if err := logger.RegisterLogDriver(name, New); err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 	if err := logger.RegisterLogOptValidator(name, ValidateLogOpt); err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 }
 

--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -54,8 +54,7 @@ func init() {
 
 	testEnv, err = environment.New()
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		panic(err)
 	}
 }
 

--- a/libnetwork/ipamutils/utils.go
+++ b/libnetwork/ipamutils/utils.go
@@ -34,13 +34,11 @@ type NetworkToSplit struct {
 func init() {
 	var err error
 	if PredefinedGlobalScopeDefaultNetworks, err = splitNetworks(globalScopeDefaultNetworks); err != nil {
-		//we are going to panic in case of error as we should never get into this state
-		panic("InitAddressPools failed to initialize the global scope default address pool")
+		panic("failed to initialize the global scope default address pool: " + err.Error())
 	}
 
 	if PredefinedLocalScopeDefaultNetworks, err = splitNetworks(localScopeDefaultNetworks); err != nil {
-		//we are going to panic in case of error as we should never get into this state
-		panic("InitAddressPools failed to initialize the local scope default address pool")
+		panic("failed to initialize the local scope default address pool: " + err.Error())
 	}
 }
 

--- a/pkg/chrootarchive/init_windows.go
+++ b/pkg/chrootarchive/init_windows.go
@@ -1,4 +1,0 @@
-package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
-
-func init() {
-}


### PR DESCRIPTION

Some packages were using `logrus.Fatal()` in init functions (which logs the error,
and (by default) calls `os.Exit(1)` after logging).

Given that logrus formatting and outputs have not yet been configured during the
initialization stage, it does not provide much benefits over a plain `panic()`.

This patch replaces some instances of `logrus.Fatal()` with `panic()`, which has
the added benefits of not introducing logrus as a dependency in some of these
packages, and also produces a stacktrace, which could help locating the problem
in the unlikely event an `init()` fails.

Before this change, an error would look like:

    $ dockerd
    FATA[0000] something bad happened

After this change, the same error looks like:

    $ dockerd
    panic: something bad happened

    goroutine 1 [running]:
      github.com/docker/docker/daemon/logger/awslogs.init.0()
        /go/src/github.com/docker/docker/daemon/logger/awslogs/cloudwatchlogs.go:128 +0x89

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

