### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -189,7 +188,7 @@ func TestNewClientWithOpsFromEnvSetsDefaultVersion(t *testing.T) {
 	assert.Check(t, is.Equal(client.ClientVersion(), api.DefaultVersion))
 
 	const expected = "1.22"
-	_ = os.Setenv("DOCKER_API_VERSION", expected)
+	t.Setenv("DOCKER_API_VERSION", expected)
 	client, err = NewClientWithOpts(FromEnv)
 	if err != nil {
 		t.Fatal(err)

--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -1654,8 +1654,7 @@ func BenchmarkUnwrapEvents(b *testing.B) {
 
 func TestNewAWSLogsClientCredentialEndpointDetect(t *testing.T) {
 	// required for the cloudwatchlogs client
-	os.Setenv("AWS_REGION", "us-west-2")
-	defer os.Unsetenv("AWS_REGION")
+	t.Setenv("AWS_REGION", "us-west-2")
 
 	credsResp := `{
 		"AccessKeyId" :    "test-access-key-id",
@@ -1694,17 +1693,13 @@ func TestNewAWSLogsClientCredentialEndpointDetect(t *testing.T) {
 
 func TestNewAWSLogsClientCredentialEnvironmentVariable(t *testing.T) {
 	// required for the cloudwatchlogs client
-	os.Setenv("AWS_REGION", "us-west-2")
-	defer os.Unsetenv("AWS_REGION")
+	t.Setenv("AWS_REGION", "us-west-2")
 
 	expectedAccessKeyID := "test-access-key-id"
 	expectedSecretAccessKey := "test-secret-access-key"
 
-	os.Setenv("AWS_ACCESS_KEY_ID", expectedAccessKeyID)
-	defer os.Unsetenv("AWS_ACCESS_KEY_ID")
-
-	os.Setenv("AWS_SECRET_ACCESS_KEY", expectedSecretAccessKey)
-	defer os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+	t.Setenv("AWS_ACCESS_KEY_ID", expectedAccessKeyID)
+	t.Setenv("AWS_SECRET_ACCESS_KEY", expectedSecretAccessKey)
 
 	info := logger.Info{
 		Config: map[string]string{},
@@ -1724,8 +1719,7 @@ func TestNewAWSLogsClientCredentialEnvironmentVariable(t *testing.T) {
 
 func TestNewAWSLogsClientCredentialSharedFile(t *testing.T) {
 	// required for the cloudwatchlogs client
-	os.Setenv("AWS_REGION", "us-west-2")
-	defer os.Unsetenv("AWS_REGION")
+	t.Setenv("AWS_REGION", "us-west-2")
 
 	expectedAccessKeyID := "test-access-key-id"
 	expectedSecretAccessKey := "test-secret-access-key"
@@ -1750,8 +1744,7 @@ func TestNewAWSLogsClientCredentialSharedFile(t *testing.T) {
 	os.Unsetenv("AWS_ACCESS_KEY_ID")
 	os.Unsetenv("AWS_SECRET_ACCESS_KEY")
 
-	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", tmpfile.Name())
-	defer os.Unsetenv("AWS_SHARED_CREDENTIALS_FILE")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", tmpfile.Name())
 
 	info := logger.Info{
 		Config: map[string]string{},

--- a/daemon/logger/splunk/splunk_test.go
+++ b/daemon/logger/splunk/splunk_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"runtime"
 	"testing"
 	"time"
@@ -807,9 +806,7 @@ func TestRawFormatWithoutTag(t *testing.T) {
 // Verify that we will send messages in batches with default batching parameters,
 // but change frequency to be sure that numOfRequests will match expected 17 requests
 func TestBatching(t *testing.T) {
-	if err := os.Setenv(envVarPostMessagesFrequency, "10h"); err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv(envVarPostMessagesFrequency, "10h")
 
 	hec := NewHTTPEventCollectorMock(t)
 
@@ -865,17 +862,11 @@ func TestBatching(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	if err := os.Setenv(envVarPostMessagesFrequency, ""); err != nil {
-		t.Fatal(err)
-	}
 }
 
 // Verify that test is using time to fire events not rare than specified frequency
 func TestFrequency(t *testing.T) {
-	if err := os.Setenv(envVarPostMessagesFrequency, "5ms"); err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv(envVarPostMessagesFrequency, "5ms")
 
 	hec := NewHTTPEventCollectorMock(t)
 
@@ -938,30 +929,15 @@ func TestFrequency(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	if err := os.Setenv(envVarPostMessagesFrequency, ""); err != nil {
-		t.Fatal(err)
-	}
 }
 
 // Simulate behavior similar to first version of Splunk Logging Driver, when we were sending one message
 // per request
 func TestOneMessagePerRequest(t *testing.T) {
-	if err := os.Setenv(envVarPostMessagesFrequency, "10h"); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Setenv(envVarPostMessagesBatchSize, "1"); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Setenv(envVarBufferMaximum, "1"); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Setenv(envVarStreamChannelSize, "0"); err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv(envVarPostMessagesFrequency, "10h")
+	t.Setenv(envVarPostMessagesBatchSize, "1")
+	t.Setenv(envVarBufferMaximum, "1")
+	t.Setenv(envVarStreamChannelSize, "0")
 
 	hec := NewHTTPEventCollectorMock(t)
 
@@ -1015,22 +991,6 @@ func TestOneMessagePerRequest(t *testing.T) {
 
 	err = hec.Close()
 	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Setenv(envVarPostMessagesFrequency, ""); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Setenv(envVarPostMessagesBatchSize, ""); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Setenv(envVarBufferMaximum, ""); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Setenv(envVarStreamChannelSize, ""); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1136,17 +1096,9 @@ func TestSkipVerify(t *testing.T) {
 
 // Verify logic for when we filled whole buffer
 func TestBufferMaximum(t *testing.T) {
-	if err := os.Setenv(envVarPostMessagesBatchSize, "2"); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Setenv(envVarBufferMaximum, "10"); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Setenv(envVarStreamChannelSize, "0"); err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv(envVarPostMessagesBatchSize, "2")
+	t.Setenv(envVarBufferMaximum, "10")
+	t.Setenv(envVarStreamChannelSize, "0")
 
 	hec := NewHTTPEventCollectorMock(t)
 	hec.simulateErr(true)
@@ -1209,33 +1161,13 @@ func TestBufferMaximum(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	if err := os.Setenv(envVarPostMessagesBatchSize, ""); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Setenv(envVarBufferMaximum, ""); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Setenv(envVarStreamChannelSize, ""); err != nil {
-		t.Fatal(err)
-	}
 }
 
 // Verify that we are not blocking close when HEC is down for the whole time
 func TestServerAlwaysDown(t *testing.T) {
-	if err := os.Setenv(envVarPostMessagesBatchSize, "2"); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Setenv(envVarBufferMaximum, "4"); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Setenv(envVarStreamChannelSize, "0"); err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv(envVarPostMessagesBatchSize, "2")
+	t.Setenv(envVarBufferMaximum, "4")
+	t.Setenv(envVarStreamChannelSize, "0")
 
 	hec := NewHTTPEventCollectorMock(t)
 	hec.simulateServerError = true
@@ -1279,18 +1211,6 @@ func TestServerAlwaysDown(t *testing.T) {
 
 	err = hec.Close()
 	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Setenv(envVarPostMessagesBatchSize, ""); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Setenv(envVarBufferMaximum, ""); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Setenv(envVarStreamChannelSize, ""); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5009,16 +5009,14 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestBuildFromAuthenticatedRegistry(c *
 }
 
 func (s *DockerRegistryAuthHtpasswdSuite) TestBuildWithExternalAuth(c *testing.T) {
-	osPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", osPath)
-
 	workingDir, err := os.Getwd()
 	assert.NilError(c, err)
 	absolute, err := filepath.Abs(filepath.Join(workingDir, "fixtures", "auth"))
 	assert.NilError(c, err)
-	testPath := fmt.Sprintf("%s%c%s", osPath, filepath.ListSeparator, absolute)
 
-	os.Setenv("PATH", testPath)
+	osPath := os.Getenv("PATH")
+	testPath := fmt.Sprintf("%s%c%s", osPath, filepath.ListSeparator, absolute)
+	c.Setenv("PATH", testPath)
 
 	repoName := fmt.Sprintf("%v/dockercli/busybox:authtest", privateRegistryURL)
 

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1693,12 +1693,7 @@ func (s *DockerDaemonSuite) TestDaemonStartWithDefaultTLSHost(c *testing.T) {
 		"--tlskey", "fixtures/https/server-key.pem")
 
 	// The client with --tlsverify should also use default host localhost:2376
-	tmpHost := os.Getenv("DOCKER_HOST")
-	defer func() {
-		os.Setenv("DOCKER_HOST", tmpHost)
-	}()
-
-	os.Setenv("DOCKER_HOST", "")
+	c.Setenv("DOCKER_HOST", "")
 
 	out, _ := dockerCmd(
 		c,

--- a/integration-cli/docker_cli_logout_test.go
+++ b/integration-cli/docker_cli_logout_test.go
@@ -15,16 +15,14 @@ import (
 func (s *DockerRegistryAuthHtpasswdSuite) TestLogoutWithExternalAuth(c *testing.T) {
 	s.d.StartWithBusybox(c)
 
-	osPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", osPath)
-
 	workingDir, err := os.Getwd()
 	assert.NilError(c, err)
 	absolute, err := filepath.Abs(filepath.Join(workingDir, "fixtures", "auth"))
 	assert.NilError(c, err)
-	testPath := fmt.Sprintf("%s%c%s", osPath, filepath.ListSeparator, absolute)
 
-	os.Setenv("PATH", testPath)
+	osPath := os.Getenv("PATH")
+	testPath := fmt.Sprintf("%s%c%s", osPath, filepath.ListSeparator, absolute)
+	c.Setenv("PATH", testPath)
 
 	repoName := fmt.Sprintf("%v/dockercli/busybox:authtest", privateRegistryURL)
 
@@ -65,16 +63,14 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestLogoutWithExternalAuth(c *testing.
 
 // #23100
 func (s *DockerRegistryAuthHtpasswdSuite) TestLogoutWithWrongHostnamesStored(c *testing.T) {
-	osPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", osPath)
-
 	workingDir, err := os.Getwd()
 	assert.NilError(c, err)
 	absolute, err := filepath.Abs(filepath.Join(workingDir, "fixtures", "auth"))
 	assert.NilError(c, err)
-	testPath := fmt.Sprintf("%s%c%s", osPath, filepath.ListSeparator, absolute)
 
-	os.Setenv("PATH", testPath)
+	osPath := os.Getenv("PATH")
+	testPath := fmt.Sprintf("%s%c%s", osPath, filepath.ListSeparator, absolute)
+	c.Setenv("PATH", testPath)
 
 	cmd := exec.Command("docker-credential-shell-test", "store")
 	stdin := bytes.NewReader([]byte(fmt.Sprintf(`{"ServerURL": "https://%s", "Username": "%s", "Secret": "%s"}`, privateRegistryURL, s.reg.Username(), s.reg.Password())))

--- a/integration-cli/docker_cli_pull_local_test.go
+++ b/integration-cli/docker_cli_pull_local_test.go
@@ -367,16 +367,14 @@ func (s *DockerRegistrySuite) TestPullManifestList(c *testing.T) {
 
 // #23100
 func (s *DockerRegistryAuthHtpasswdSuite) TestPullWithExternalAuthLoginWithScheme(c *testing.T) {
-	osPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", osPath)
-
 	workingDir, err := os.Getwd()
 	assert.NilError(c, err)
 	absolute, err := filepath.Abs(filepath.Join(workingDir, "fixtures", "auth"))
 	assert.NilError(c, err)
-	testPath := fmt.Sprintf("%s%c%s", osPath, filepath.ListSeparator, absolute)
 
-	os.Setenv("PATH", testPath)
+	osPath := os.Getenv("PATH")
+	testPath := fmt.Sprintf("%s%c%s", osPath, filepath.ListSeparator, absolute)
+	c.Setenv("PATH", testPath)
 
 	repoName := fmt.Sprintf("%v/dockercli/busybox:authtest", privateRegistryURL)
 
@@ -411,16 +409,14 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestPullWithExternalAuthLoginWithSchem
 }
 
 func (s *DockerRegistryAuthHtpasswdSuite) TestPullWithExternalAuth(c *testing.T) {
-	osPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", osPath)
-
 	workingDir, err := os.Getwd()
 	assert.NilError(c, err)
 	absolute, err := filepath.Abs(filepath.Join(workingDir, "fixtures", "auth"))
 	assert.NilError(c, err)
-	testPath := fmt.Sprintf("%s%c%s", osPath, filepath.ListSeparator, absolute)
 
-	os.Setenv("PATH", testPath)
+	osPath := os.Getenv("PATH")
+	testPath := fmt.Sprintf("%s%c%s", osPath, filepath.ListSeparator, absolute)
+	c.Setenv("PATH", testPath)
 
 	repoName := fmt.Sprintf("%v/dockercli/busybox:authtest", privateRegistryURL)
 

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -243,8 +243,6 @@ func (s *DockerSuite) TestRunAttachDetachFromConfig(c *testing.T) {
 	keyA := []byte{97}
 
 	// Setup config
-	homeKey := homedir.Key()
-	homeVal := homedir.Get()
 	tmpDir, err := os.MkdirTemp("", "fake-home")
 	assert.NilError(c, err)
 	defer os.RemoveAll(tmpDir)
@@ -253,8 +251,7 @@ func (s *DockerSuite) TestRunAttachDetachFromConfig(c *testing.T) {
 	os.Mkdir(dotDocker, 0600)
 	tmpCfg := filepath.Join(dotDocker, "config.json")
 
-	defer func() { os.Setenv(homeKey, homeVal) }()
-	os.Setenv(homeKey, tmpDir)
+	c.Setenv(homedir.Key(), tmpDir)
 
 	data := `{
 		"detachKeys": "ctrl-a,a"
@@ -326,8 +323,6 @@ func (s *DockerSuite) TestRunAttachDetachKeysOverrideConfig(c *testing.T) {
 	keyA := []byte{97}
 
 	// Setup config
-	homeKey := homedir.Key()
-	homeVal := homedir.Get()
 	tmpDir, err := os.MkdirTemp("", "fake-home")
 	assert.NilError(c, err)
 	defer os.RemoveAll(tmpDir)
@@ -336,8 +331,7 @@ func (s *DockerSuite) TestRunAttachDetachKeysOverrideConfig(c *testing.T) {
 	os.Mkdir(dotDocker, 0600)
 	tmpCfg := filepath.Join(dotDocker, "config.json")
 
-	defer func() { os.Setenv(homeKey, homeVal) }()
-	os.Setenv(homeKey, tmpDir)
+	c.Setenv(homedir.Key(), tmpDir)
 
 	data := `{
 		"detachKeys": "ctrl-e,e"

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -1372,8 +1372,7 @@ func TestDisablePigz(t *testing.T) {
 		t.Log("Test will not check full path when Pigz not installed")
 	}
 
-	os.Setenv("MOBY_DISABLE_PIGZ", "true")
-	defer os.Unsetenv("MOBY_DISABLE_PIGZ")
+	t.Setenv("MOBY_DISABLE_PIGZ", "true")
 
 	r := testDecompressStream(t, "gz", "gzip -f")
 	// For the bufio pool

--- a/pkg/jsonmessage/jsonmessage_test.go
+++ b/pkg/jsonmessage/jsonmessage_test.go
@@ -3,7 +3,6 @@ package jsonmessage // import "github.com/docker/docker/pkg/jsonmessage"
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -268,8 +267,7 @@ func TestDisplayJSONMessagesStream(t *testing.T) {
 
 	// Use $TERM which is unlikely to exist, forcing DisplayJSONMessageStream to
 	// (hopefully) use &noTermInfo.
-	origTerm := os.Getenv("TERM")
-	os.Setenv("TERM", "xyzzy-non-existent-terminfo")
+	t.Setenv("TERM", "xyzzy-non-existent-terminfo")
 
 	for jsonMessage, expectedMessages := range messages {
 		data := bytes.NewBuffer([]byte{})
@@ -294,6 +292,4 @@ func TestDisplayJSONMessagesStream(t *testing.T) {
 			t.Fatalf("\nExpected %q\n     got %q", expectedMessages[1], data.String())
 		}
 	}
-	os.Setenv("TERM", origTerm)
-
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
A testing cleanup.

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.Setenv

**- How I did it**

Search for usages of `os.Setenv` in `*_test.go` using GoLand, and replace them with `t.Setenv` accordingly.

**- How to verify it**

All tests should continue to pass, except those that are already failing before this PR.

**- Description for the changelog**
```
test: use `T.SetEnv` to set env vars in tests
```

**- A picture of a cute animal (not mandatory but encouraged)**