### PR TITLE
api/server: remove "Logging" from config

### DIFF
--- a/api/server/middleware.go
+++ b/api/server/middleware.go
@@ -16,7 +16,7 @@ func (s *Server) handlerWithGlobalMiddlewares(handler httputils.APIFunc) httputi
 		next = m.WrapHandler(next)
 	}
 
-	if s.cfg.Logging && logrus.GetLevel() == logrus.DebugLevel {
+	if logrus.GetLevel() == logrus.DebugLevel {
 		next = middleware.DebugRequestMiddleware(next)
 	}
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -23,7 +23,6 @@ const versionMatcher = "/v{version:[0-9.]+}"
 
 // Config provides the configuration for the API server
 type Config struct {
-	Logging     bool
 	CorsHeaders string
 	Version     string
 	SocketGroup string

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -569,7 +569,6 @@ func (cli *DaemonCli) getContainerdDaemonOpts() ([]supervisor.DaemonOpt, error) 
 
 func newAPIServerConfig(cli *DaemonCli) (*apiserver.Config, error) {
 	serverConfig := &apiserver.Config{
-		Logging:     true,
 		SocketGroup: cli.Config.SocketGroup,
 		Version:     dockerversion.Version,
 		CorsHeaders: cli.Config.CorsHeaders,


### PR DESCRIPTION
The Logging boolean was unconditionally set to true and ignored in all locations,
except for enabling the debugging middleware, which was also gated by the active
logrus logging level.

While it could make sense to have a Loglevel option configured on the API server,
we don't have this currently, and to make that actually useful, that config would
need to be tollerated by all locations that produce logs (which isn't the case
either).

Looking at the history of this option; a boolean to disable logging was originally
added in commit c423a790d629b13c2eb1bc553beb3f61e30b3888 (https://github.com/moby/moby/pull/432), which hard-coded it to
"disabled" in a test, and "enabled" for the API server outside of tests (before
that commit, logging was always enabled).

02ddaad5d985186eed94dea4105a57fa21ba24db (https://github.com/moby/moby/pull/2673) and 5c42b2b5122c1db08d229c258da26869b4d4d9cc (https://github.com/moby/moby/pull/2673)
changed the hard-coded values to be configurable through a `Logging` env-var (env-
vars were used _internally_ at the time to pass on options), which later became
a configuration struct in a0bf80fe0372196812a9cb295f209c08f8037601 (https://github.com/moby/moby/pull/12486).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

