### PR TITLE
minor rootless fix-ups

### DIFF
--- a/cmd/dockerd/config_unix.go
+++ b/cmd/dockerd/config_unix.go
@@ -52,11 +52,6 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 		if err != nil {
 			return errors.Wrapf(err, "running with RootlessKit, but %s not installed", rootless.RootlessKitDockerProxyBinary)
 		}
-
-		configHome, err := homedir.GetConfigHome()
-		if err == nil {
-			registry.SetCertsDir(filepath.Join(configHome, "docker/certs.d"))
-		}
 	}
 	flags.StringVar(&conf.BridgeConfig.UserlandProxyPath, "userland-proxy-path", defaultUserlandProxyPath, "Path to the userland proxy binary")
 	flags.StringVar(&conf.CgroupParent, "cgroup-parent", "", "Set parent cgroup for all containers")

--- a/rootless/rootless.go
+++ b/rootless/rootless.go
@@ -3,29 +3,17 @@ package rootless // import "github.com/docker/docker/rootless"
 import (
 	"os"
 	"path/filepath"
-	"sync"
 
 	"github.com/pkg/errors"
 	"github.com/rootless-containers/rootlesskit/pkg/api/client"
 )
 
-const (
-	// RootlessKitDockerProxyBinary is the binary name of rootlesskit-docker-proxy
-	RootlessKitDockerProxyBinary = "rootlesskit-docker-proxy"
-)
-
-var (
-	runningWithRootlessKit     bool
-	runningWithRootlessKitOnce sync.Once
-)
+// RootlessKitDockerProxyBinary is the binary name of rootlesskit-docker-proxy
+const RootlessKitDockerProxyBinary = "rootlesskit-docker-proxy"
 
 // RunningWithRootlessKit returns true if running under RootlessKit namespaces.
 func RunningWithRootlessKit() bool {
-	runningWithRootlessKitOnce.Do(func() {
-		u := os.Getenv("ROOTLESSKIT_STATE_DIR")
-		runningWithRootlessKit = u != ""
-	})
-	return runningWithRootlessKit
+	return os.Getenv("ROOTLESSKIT_STATE_DIR") != ""
 }
 
 // GetRootlessKitClient returns RootlessKit client


### PR DESCRIPTION
### rootless: remove redundant sync.Once

This was added in https://github.com/moby/moby/commit/ec87479b7e2bf6f1b5bcc657a377c6e6a847574f (https://github.com/moby/moby/pull/38050), but it's unclear why a `sync.Once` was used just for reading an environment-variable. The related PR had a lot of review comments, so perhaps an earlier implementation used something more heavy-weight, or it was just overlooked.

### cmd/dockerd: don't call `registry.SetCertsDir()` twice

This was introduced in https://github.com/moby/moby/commit/85572cac14168f9dc3fc3d9daa5eae1ba00eddf4, where I probably forgot to remove this code from an earlier iteration (I decided that having an explicit an explicit `configureCertsDir()` function call for this would make it more transparent that we're re-configuring a default).


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

