### PR TITLE
chore: fix linguist for Dockerfile

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
+Dockerfile* linguist-language=Dockerfile
 vendor.mod linguist-language=Go-Module
 vendor.sum linguist-language=Go-Checksums


### PR DESCRIPTION
**- What I did**

Fix Dockerfile detection in the repository using linguist git attribute.

Or we could also rename them (e.g., `Dockerfile.e2e` to `e2e.Dockerfile`)

**- How to verify it**

Current: https://github.com/moby/moby/blob/master/Dockerfile.e2e

![image](https://user-images.githubusercontent.com/1951866/165442168-0a097cb2-dac1-4953-90e6-b28b11487d53.png)

After: https://github.com/crazy-max/moby/blob/gitattr-dockerfile/Dockerfile.e2e

![image](https://user-images.githubusercontent.com/1951866/165442215-b5cea8f4-a1a7-49ee-9cf8-d837ff99503c.png)

**- Description for the changelog**

Fix Dockerfile detection in the repository using linguist git attribute