### PR TITLE
configure stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,23 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 120
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 10
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - kind/feature
+  - kind/enhancement
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: true
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false
+# Limit to only `issues` or `pulls`
+only: issues


### PR DESCRIPTION
**- What I did**
Added configuration for [stale bot](https://github.com/apps/stale) so that old issues without recent activity get closed.

With 4k open issues, we hardly can offer efficient triage, so using stale bot can help focus on active topics - we did the same on docker/compose. Bot is configured to exclude feature requests so that we can keep them alive for future investigation, or close those after review by an explicit decision.

note: Will require an admin on moby organization to install https://github.com/apps/stale