### PR TITLE
when created, workdir is owned by user, not root

### DIFF
--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -40,7 +40,17 @@ func (daemon *Daemon) createContainerVolumesOS(ctx context.Context, ctr *contain
 	}
 	defer daemon.Unmount(ctr)
 
-	if err := ctr.SetupWorkingDirectory(daemon.idMapping.RootPair()); err != nil {
+	// The working directory, when created, is owned by the container's
+	// user, so that it is writable when running with a non-root USER.
+	usr, err := getUser(ctr, config.User)
+	if err != nil {
+		return err
+	}
+	uid, gid, err := daemon.idMapping.ToHost(int(usr.UID), int(usr.GID))
+	if err != nil {
+		return err
+	}
+	if err := ctr.SetupWorkingDirectory(uid, gid); err != nil {
 		return err
 	}
 

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -838,3 +838,43 @@ func TestContainerdContainerImageInfo(t *testing.T) {
 		assert.Equal(t, ctr.Image, "")
 	}
 }
+
+// Make sure that the working directory, when created by the daemon, is
+// owned by the container's user so that it is writable.
+// https://github.com/docker/cli/issues/3464
+func TestCreateWorkingDirForUser(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "Windows does not set up the working directory at create time")
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	id := testContainer.Create(ctx, t, apiClient,
+		testContainer.WithWorkingDir("/foo"),
+		testContainer.WithUser("1000:1000"),
+		testContainer.WithCmd("touch", "/foo/bar"),
+	)
+
+	defer func() {
+		_, err := apiClient.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
+		assert.NilError(t, err)
+	}()
+
+	wait := apiClient.ContainerWait(ctx, id, client.ContainerWaitOptions{Condition: container.WaitConditionNextExit})
+	_, err := apiClient.ContainerStart(ctx, id, client.ContainerStartOptions{})
+	assert.NilError(t, err)
+
+	timeout := time.NewTimer(30 * time.Second)
+	defer timeout.Stop()
+
+	select {
+	case <-timeout.C:
+		t.Fatal("timeout waiting for container to exit")
+	case status := <-wait.Result:
+		var errMsg string
+		if status.Error != nil {
+			errMsg = status.Error.Message
+		}
+		assert.Equal(t, int(status.StatusCode), 0, errMsg)
+	case err := <-wait.Error:
+		assert.NilError(t, err)
+	}
+}


### PR DESCRIPTION
closes https://github.com/docker/cli/issues/3464

**- What I did**
If not present on image filesystem, and created on purpose, working directory is owned by container's USER, not root

**- How I did it**
get user from container.Config and use this `Identity` to setup working directory

**- How to verify it**
docker run -w /foo alpine touch /foo/bar

**- Description for the changelog**
working directory, if created, is owned by container's USER

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/132757/165753483-77d1a51a-dade-47d5-82cb-7fbddaa0f38d.png)

