### PR TITLE
Add swarm service and stack name to journald logger output fields.

### DIFF
--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -81,6 +81,18 @@ func New(info logger.Info) (logger.Logger, error) {
 	for k, v := range extraAttrs {
 		vars[k] = v
 	}
+	if info.ContainerLabels["com.docker.stack.namespace"] != "" {
+		vars["SWARM_STACK"] = info.ContainerLabels["com.docker.stack.namespace"]
+	}
+	if info.ContainerLabels["com.docker.swarm.service.name"] != "" {
+		vars["SWARM_SERVICE"] = info.ContainerLabels["com.docker.swarm.service.name"]
+	}
+	if info.ContainerLabels["com.docker.compose.project"] != "" {
+		vars["COMPOSE_PROJECT"] = info.ContainerLabels["com.docker.compose.project"]
+	}
+	if info.ContainerLabels["com.docker.compose.service"] != "" {
+		vars["COMPOSE_SERVICE"] = info.ContainerLabels["com.docker.compose.service"]
+	}
 	return &journald{vars: vars, readers: make(map[*logger.LogWatcher]struct{})}, nil
 }
 


### PR DESCRIPTION
**- What I did**
I noticed the [loki logging dirver](https://grafana.com/docs/loki/latest/clients/docker-driver/) includes `swarm_service`, `swarm_stack` fields for containers that belong to such. These are useful but I want to use the journald logger. Added these two fields in the ~same way the loki logging driver does.

**- How I did it**
Modified journald logger code with a text editor.

**- How to verify it**
Tests pass. Also, I built and tested locally by starting an image as a stack and as a plain container then tailing journal:

```
cat >docker-compose.yml <<EOF
version: '3'
services:
  nginx:
    image: nginx:latest
    ports:
      - "8081:80"
    logging:
      driver: journald
EOF
docker pull nginx
docker stack deploy --compose-file docker-compose.yml nginx
docker run -d --rm -p 8081:80 nginx 
curl 127.0.0.1:8080 127.0.0.1:8081
```

**- Description for the changelog**
Add swarm service and stack name to journald logger output fields.

**- A picture of a cute animal (not mandatory but encouraged)**

![bobbit worm](https://i.redd.it/pjfshq6llno21.png)
