### PR TITLE
api:  postContainersStop, postContainersRestart  remove redundant validation

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -226,12 +226,7 @@ func (s *containerRouter) postContainersStop(ctx context.Context, w http.Respons
 		version = httputils.VersionFromContext(ctx)
 	)
 	if versions.GreaterThanOrEqualTo(version, "1.42") {
-		if sig := r.Form.Get("signal"); sig != "" {
-			if _, err := signal.ParseSignal(sig); err != nil {
-				return errdefs.InvalidParameter(err)
-			}
-			options.Signal = sig
-		}
+		options.Signal = r.Form.Get("signal")
 	}
 	if tmpSeconds := r.Form.Get("t"); tmpSeconds != "" {
 		valSeconds, err := strconv.Atoi(tmpSeconds)
@@ -294,12 +289,7 @@ func (s *containerRouter) postContainersRestart(ctx context.Context, w http.Resp
 		version = httputils.VersionFromContext(ctx)
 	)
 	if versions.GreaterThanOrEqualTo(version, "1.42") {
-		if sig := r.Form.Get("signal"); sig != "" {
-			if _, err := signal.ParseSignal(sig); err != nil {
-				return errdefs.InvalidParameter(err)
-			}
-			options.Signal = sig
-		}
+		options.Signal = r.Form.Get("signal")
 	}
 	if tmpSeconds := r.Form.Get("t"); tmpSeconds != "" {
 		valSeconds, err := strconv.Atoi(tmpSeconds)


### PR DESCRIPTION
Both of these pass the signal to  daemon.containerStop(), which already validates
the signal; https://github.com/moby/moby/blob/2ed904cad7055847796433cc56ef1d1de0da868c/daemon/stop.go#L48-L52

**- A picture of a cute animal (not mandatory but encouraged)**

