### PR TITLE
seccomp: support riscv64

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -48,6 +48,10 @@
 			"subArchitectures": [
 				"SCMP_ARCH_S390"
 			]
+		},
+		{
+			"architecture": "SCMP_ARCH_RISCV64",
+			"subArchitectures": null
 		}
 	],
 	"syscalls": [
@@ -537,6 +541,17 @@
 				"arches": [
 					"s390",
 					"s390x"
+				]
+			}
+		},
+		{
+			"names": [
+				"riscv_flush_icache"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"arches": [
+					"riscv64"
 				]
 			}
 		},

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -38,6 +38,10 @@ func arches() []Architecture {
 			Arch:      specs.ArchS390X,
 			SubArches: []specs.Arch{specs.ArchS390},
 		},
+		{
+			Arch:      specs.ArchRISCV64,
+			SubArches: nil,
+		},
 	}
 }
 
@@ -531,6 +535,17 @@ func DefaultProfile() *Seccomp {
 			},
 			Includes: &Filter{
 				Arches: []string{"s390", "s390x"},
+			},
+		},
+		{
+			LinuxSyscall: specs.LinuxSyscall{
+				Names: []string{
+					"riscv_flush_icache",
+				},
+				Action: specs.ActAllow,
+			},
+			Includes: &Filter{
+				Arches: []string{"riscv64"},
 			},
 		},
 		{


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added riscv64 support.

Corresponds to:
- containerd/containerd#6882

**- How I did it**

Updated the seccomp profile.

Needs runc with:
- https://github.com/opencontainers/runc/pull/3446

**- How to verify it**


```console
$ uname -a
Linux lima-riscv64 5.15.0-1008-generic #8-Ubuntu SMP Wed Apr 20 07:00:28 UTC 2022 riscv64 riscv64 riscv64 GNU/Linux

$ docker info
Client:
 Context:    default
 Debug Mode: false

Server:
 Containers: 0
  Running: 0
  Paused: 0
  Stopped: 0
 Images: 2
 Server Version: library-import
 Storage Driver: overlay2
  Backing Filesystem: extfs
  Supports d_type: true
  Native Overlay Diff: true
  userxattr: false
 Logging Driver: json-file
 Cgroup Driver: systemd
 Cgroup Version: 2
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
 Swarm: inactive
 Runtimes: runc io.containerd.runc.v2 io.containerd.runtime.v1.linux
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: 
 runc version: v1.1.0-169-ge41ba42e
 init version: N/A
 Security Options:
  apparmor
  seccomp
   Profile: builtin
  cgroupns
 Kernel Version: 5.15.0-1008-generic
 Operating System: Ubuntu 22.04 LTS
 OSType: linux
 Architecture: riscv64
 CPUs: 1
 Total Memory: 1.919GiB
 Name: lima-riscv64
 ID: PKRT:2BZP:WI2W:AFSF:RJJS:VFNW:636S:5LWX:LCDH:CWKK:BKJO:JDEU
 Docker Root Dir: /var/lib/docker
 Debug Mode: false
 Registry: https://index.docker.io/v1/
 Labels:
 Experimental: false
 Insecure Registries:
  127.0.0.0/8
 Live Restore Enabled: false

WARNING: No swap limit support

$ docker run -it --rm ubuntu:22.04
root@27d3fc38e4f8:/# uname -a
Linux 27d3fc38e4f8 5.15.0-1008-generic #8-Ubuntu SMP Wed Apr 20 07:00:28 UTC 2022 riscv64 riscv64 riscv64 GNU/Linux
```

Tested on `qemu-system-riscv64 -M virt -cpu rv64` (QEMU 6.2)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
seccomp: support riscv64

**- A picture of a cute animal (not mandatory but encouraged)**
🐧 


- - -

We should update the CI to cover riscv64, but it will be a separate PR, after refactoring of the cross compilation scripts:
- https://github.com/moby/moby/pull/43529
