### PR TITLE
daemon: separate daemon ID from trust-key, and disable generating

### DIFF
--- a/daemon/id.go
+++ b/daemon/id.go
@@ -1,0 +1,61 @@
+package daemon // import "github.com/docker/docker/daemon"
+
+import (
+	"os"
+
+	"github.com/docker/docker/pkg/ioutils"
+	"github.com/docker/libtrust"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// loadOrCreateID loads the engine's ID from idPath, or generates a new ID
+// if it doesn't exist. It returns the ID, and any error that occurred when
+// saving the file.
+//
+// Note that this function expects the daemon's root directory to already have
+// been created with the right permissions and ownership (usually this would
+// be done by daemon.CreateDaemonRoot().
+func loadOrCreateID(idPath string) (string, error) {
+	var id string
+	idb, err := os.ReadFile(idPath)
+	if os.IsNotExist(err) {
+		id = uuid.New().String()
+		if err := ioutils.AtomicWriteFile(idPath, []byte(id), os.FileMode(0600)); err != nil {
+			return "", errors.Wrap(err, "error saving ID file")
+		}
+	} else if err != nil {
+		return "", errors.Wrapf(err, "error loading ID file %s", idPath)
+	} else {
+		id = string(idb)
+	}
+	return id, nil
+}
+
+// migrateTrustKeyID migrates the daemon ID of existing installations. It returns
+// an error when a trust-key was found, but we failed to read it, or failed to
+// complete the migration.
+//
+// We migrate the ID so that engines don't get a new ID generated on upgrades,
+// which may be unexpected (and users may be using the ID for various purposes).
+func migrateTrustKeyID(deprecatedTrustKeyPath, idPath string) error {
+	if _, err := os.Stat(idPath); err == nil {
+		// engine ID file already exists; no migration needed
+		return nil
+	}
+	trustKey, err := libtrust.LoadKeyFile(deprecatedTrustKeyPath)
+	if err != nil {
+		if err == libtrust.ErrKeyFileDoesNotExist {
+			// no existing trust-key found; no migration needed
+			return nil
+		}
+		return err
+	}
+	id := trustKey.PublicKey().KeyID()
+	if err := ioutils.AtomicWriteFile(idPath, []byte(id), os.FileMode(0600)); err != nil {
+		return errors.Wrap(err, "error saving ID file")
+	}
+	logrus.Info("successfully migrated engine ID")
+	return nil
+}

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -559,6 +559,7 @@ func (s *DockerDaemonSuite) TestDaemonAllocatesListeningPort(c *testing.T) {
 func (s *DockerDaemonSuite) TestDaemonKeyGeneration(c *testing.T) {
 	// TODO: skip or update for Windows daemon
 	os.Remove("/etc/docker/key.json")
+	c.Setenv("DOCKER_ALLOW_SCHEMA1_PUSH_DONOTUSE", "1")
 	s.d.Start(c)
 	s.d.Stop(c)
 
@@ -1212,6 +1213,7 @@ func (s *DockerDaemonSuite) TestDaemonWithWrongkey(c *testing.T) {
 	}
 
 	os.Remove("/etc/docker/key.json")
+	c.Setenv("DOCKER_ALLOW_SCHEMA1_PUSH_DONOTUSE", "1")
 	s.d.Start(c)
 	s.d.Stop(c)
 

--- a/integration/daemon/daemon_test.go
+++ b/integration/daemon/daemon_test.go
@@ -22,6 +22,11 @@ import (
 	"gotest.tools/v3/skip"
 )
 
+const (
+	libtrustKey   = `{"crv":"P-256","d":"dm28PH4Z4EbyUN8L0bPonAciAQa1QJmmyYd876mnypY","kid":"WTJ3:YSIP:CE2E:G6KJ:PSBD:YX2Y:WEYD:M64G:NU2V:XPZV:H2CR:VLUB","kty":"EC","x":"Mh5-JINSjaa_EZdXDttri255Z5fbCEOTQIZjAcScFTk","y":"eUyuAjfxevb07hCCpvi4Zi334Dy4GDWQvEToGEX4exQ"}`
+	libtrustKeyID = "WTJ3:YSIP:CE2E:G6KJ:PSBD:YX2Y:WEYD:M64G:NU2V:XPZV:H2CR:VLUB"
+)
+
 func TestConfigDaemonLibtrustID(t *testing.T) {
 	skip.If(t, runtime.GOOS == "windows")
 
@@ -29,16 +34,53 @@ func TestConfigDaemonLibtrustID(t *testing.T) {
 	defer d.Stop(t)
 
 	trustKey := filepath.Join(d.RootDir(), "key.json")
-	err := os.WriteFile(trustKey, []byte(`{"crv":"P-256","d":"dm28PH4Z4EbyUN8L0bPonAciAQa1QJmmyYd876mnypY","kid":"WTJ3:YSIP:CE2E:G6KJ:PSBD:YX2Y:WEYD:M64G:NU2V:XPZV:H2CR:VLUB","kty":"EC","x":"Mh5-JINSjaa_EZdXDttri255Z5fbCEOTQIZjAcScFTk","y":"eUyuAjfxevb07hCCpvi4Zi334Dy4GDWQvEToGEX4exQ"}`), 0644)
+	err := os.WriteFile(trustKey, []byte(libtrustKey), 0644)
 	assert.NilError(t, err)
 
-	config := filepath.Join(d.RootDir(), "daemon.json")
-	err = os.WriteFile(config, []byte(`{"deprecated-key-path": "`+trustKey+`"}`), 0644)
+	cfg := filepath.Join(d.RootDir(), "daemon.json")
+	err = os.WriteFile(cfg, []byte(`{"deprecated-key-path": "`+trustKey+`"}`), 0644)
 	assert.NilError(t, err)
 
-	d.Start(t, "--config-file", config)
+	d.Start(t, "--config-file", cfg)
 	info := d.Info(t)
-	assert.Equal(t, info.ID, "WTJ3:YSIP:CE2E:G6KJ:PSBD:YX2Y:WEYD:M64G:NU2V:XPZV:H2CR:VLUB")
+	assert.Equal(t, info.ID, libtrustKeyID)
+}
+
+func TestConfigDaemonID(t *testing.T) {
+	skip.If(t, runtime.GOOS == "windows")
+
+	d := daemon.New(t)
+	defer d.Stop(t)
+
+	trustKey := filepath.Join(d.RootDir(), "key.json")
+	err := os.WriteFile(trustKey, []byte(libtrustKey), 0644)
+	assert.NilError(t, err)
+
+	cfg := filepath.Join(d.RootDir(), "daemon.json")
+	err = os.WriteFile(cfg, []byte(`{"deprecated-key-path": "`+trustKey+`"}`), 0644)
+	assert.NilError(t, err)
+
+	// Verify that on an installation with a trust-key present, the ID matches
+	// the trust-key ID, and that the ID has been migrated to the engine-id file.
+	d.Start(t, "--config-file", cfg, "--iptables=false")
+	info := d.Info(t)
+	assert.Equal(t, info.ID, libtrustKeyID)
+
+	idFile := filepath.Join(d.RootDir(), "engine-id")
+	id, err := os.ReadFile(idFile)
+	assert.NilError(t, err)
+	assert.Equal(t, string(id), libtrustKeyID)
+	d.Stop(t)
+
+	// Verify that (if present) the engine-id file takes precedence
+	const engineID = "this-is-the-engine-id"
+	err = os.WriteFile(idFile, []byte(engineID), 0600)
+	assert.NilError(t, err)
+
+	d.Start(t, "--config-file", cfg, "--iptables=false")
+	info = d.Info(t)
+	assert.Equal(t, info.ID, engineID)
+	d.Stop(t)
 }
 
 func TestDaemonConfigValidation(t *testing.T) {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/42300

## daemon: separate daemon ID from trust-key

This change is in preparation of deprecating support for old manifests.
Currently the daemon's ID is based on the trust-key ID, which will be
removed once we fully deprecate support for old manifests (the trust
key is currently only used in tests).

This patch:

- looks if a trust-key is present; if so, it migrates the trust-key
  ID to the new "engine-id" file within the daemon's root.
- if no trust-key is present (so in case it's a "fresh" install), we
  generate a UUID instead and use that as ID.

The migration is to prevent engines from getting a new ID on upgrades;
while we don't provide any guarantees on the engine's ID, users may
expect the ID to be "stable" (not change) between upgrades.

A test has been added, which can be ran with;

    make DOCKER_GRAPHDRIVER=vfs TEST_FILTER='TestConfigDaemonID' test-integration


## daemon: only create trust-key if DOCKER_ALLOW_SCHEMA1_PUSH_DONOTUSE is set

The libtrust trust-key is only used for pushing legacy image manifests;
pushing these images has been deprecated, and we only need to be able
to push them in our CI.

This patch disables generating the trust-key (and related paths) unless
the DOCKER_ALLOW_SCHEMA1_PUSH_DONOTUSE env-var is set (which we do in
our CI).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

