### PR TITLE
[v2] overlay2: test for and report metacopy status

### DIFF
--- a/daemon/graphdriver/overlay2/check.go
+++ b/daemon/graphdriver/overlay2/check.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/pkg/userns"
 	"github.com/docker/docker/pkg/system"
 	"github.com/pkg/errors"
@@ -106,4 +107,75 @@ func doesSupportNativeDiff(d string) error {
 	}
 
 	return nil
+}
+
+// Forked from https://github.com/containers/storage/blob/05c69f1b2a5871d170c07dc8d2eec69c681e143b/drivers/overlay/check.go
+//
+// usingMetacopy checks if overlayfs's metacopy feature is active. When active,
+// overlayfs will only copy up metadata (as opposed to the whole file) when a
+// metadata-only operation is performed. Affected inodes will be marked with
+// the "(trusted|user).overlay.metacopy" xattr.
+//
+// The CONFIG_OVERLAY_FS_METACOPY option, the overlay.metacopy parameter, or
+// the metacopy mount option can all enable metacopy mode. For more details on
+// this feature, see filesystems/overlayfs.txt in the kernel documentation
+// tree.
+//
+// Note that the mount option should never be relevant should never come up the
+// daemon has control over all of its own mounts and presently does not request
+// metacopy. Nonetheless, a user or kernel distributor may enable metacopy, so
+// we should report in the daemon whether or not we detect its use.
+func usingMetacopy(d string) (bool, error) {
+	td, err := os.MkdirTemp(d, "metacopy-check")
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		if err := os.RemoveAll(td); err != nil {
+			logger.WithError(err).Warnf("failed to remove check directory %v", td)
+		}
+	}()
+
+	l1, l2, work, merged := filepath.Join(td, "l1"), filepath.Join(td, "l2"), filepath.Join(td, "work"), filepath.Join(td, "merged")
+	for _, dir := range []string{l1, l2, work, merged} {
+		if err := os.Mkdir(dir, 0755); err != nil {
+			return false, err
+		}
+	}
+
+	// Create empty file in l1 with 0700 permissions for metacopy test
+	if err := os.WriteFile(filepath.Join(l1, "f"), []byte{}, 0700); err != nil {
+		return false, err
+	}
+
+	opts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", l1, l2, work)
+	m := mount.Mount{
+		Type:    "overlay",
+		Source:  "overlay",
+		Options: []string{opts},
+	}
+
+	if err := m.Mount(merged); err != nil {
+		return false, errors.Wrap(err, "failed to mount overlay for metacopy check")
+	}
+	defer func() {
+		if err := mount.UnmountAll(merged, 0); err != nil {
+			logger.WithError(err).Warnf("failed to unmount check directory %v", merged)
+		}
+	}()
+
+	// Make a change that only impacts the inode, in the upperdir
+	if err := os.Chmod(filepath.Join(merged, "f"), 0600); err != nil {
+		return false, errors.Wrap(err, "error changing permissions on file for metacopy check")
+	}
+
+	// ...and check if the pulled-up copy is marked as metadata-only
+	xattr, err := system.Lgetxattr(filepath.Join(l2, "f"), "trusted.overlay.metacopy")
+	if err != nil {
+		return false, errors.Wrap(err, "metacopy flag was not set on file in the upperdir")
+	}
+	usingMetacopy := xattr != nil
+
+	logger.WithField("usingMetacopy", usingMetacopy).Debug("successfully detected metacopy status")
+	return usingMetacopy, nil
 }

--- a/daemon/graphdriver/overlayutils/overlayutils.go
+++ b/daemon/graphdriver/overlayutils/overlayutils.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/containerd/containerd/pkg/userns"
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -76,4 +77,15 @@ func SupportsOverlay(d string, checkMultipleLowers bool) error {
 		logrus.Warnf("Failed to unmount check directory %v: %v", mnt, err)
 	}
 	return nil
+}
+
+// GetOverlayXattr combines the overlay module's xattr class with the named
+// xattr -- `user` when mounted inside a user namespace, and `trusted` when
+// mounted in the 'root' namespace.
+func GetOverlayXattr(name string) string {
+	class := "trusted"
+	if userns.RunningInUserNS() {
+		class = "user"
+	}
+	return fmt.Sprintf("%s.overlay.%s", class, name)
 }


### PR DESCRIPTION
This is helpful for debugging issues with the overlay2 storage driver.

Metacopy may be enabled by CONFIG_OVERLAY_FS_METACOPY, the overlay.metacopy parameter, or the metacopy mount option. See Documentation/filesystems/overlayfs.txt in the kernel source tree for details.

Backported from containers/storage@05c69f1b2a.
