### PR TITLE
update containerd binary to v1.6.4

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -166,7 +166,7 @@ FROM microsoft/windowsservercore
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG GO_VERSION=1.18.1
-ARG CONTAINERD_VERSION=1.6.3
+ARG CONTAINERD_VERSION=1.6.4
 ARG GOTESTSUM_VERSION=v1.7.0
 ARG GOWINRES_VERSION=v0.2.3
 

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.6.3}"
+: "${CONTAINERD_VERSION:=v1.6.4}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"


### PR DESCRIPTION
Notable Updates

- Update go-cni to fix teardown regression
- Fix broken SELinux relabeling for Kubernetes volume mounts

full diff: https://github.com/containerd/containerd/compare/v1.6.3...v1.6.4


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

