### PR TITLE
[20.10 backport] update containerd binary to v1.6.4

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.6.3}"
+: "${CONTAINERD_VERSION:=v1.6.4}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/43560

Notable Updates

- Update go-cni to fix teardown regression
- Fix broken SELinux relabeling for Kubernetes volume mounts

full diff: https://github.com/containerd/containerd/compare/v1.6.3...v1.6.4

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit 6e376e32d85ab3faad4095c561b8ab8030fbce15)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

