### PR TITLE
api/server: fix stray import in container_routes.go

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -19,7 +19,6 @@ import (
 	containerpkg "github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/ioutils"
-	"github.com/moby/sys/signal"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"


### PR DESCRIPTION
This import was left behind due to some PR's being merged, both
affecting the imports that were used;

- https://github.com/moby/moby/pull/43552
- https://github.com/moby/moby/pull/43563


**- A picture of a cute animal (not mandatory but encouraged)**

