### PR TITLE
Minor tooling (hack/) improvements

### DIFF
--- a/docs/contributing/test.md
+++ b/docs/contributing/test.md
@@ -141,8 +141,7 @@ Try this now.
 
 ## Run unit tests
 
-We use golang standard [testing](https://golang.org/pkg/testing/)
-package or [gocheck](https://labix.org/gocheck) for our unit tests.
+We use the golang standard [testing](https://golang.org/pkg/testing/) package.
 
 You can use the `TESTDIRS` environment variable to run unit tests for
 a single package.
@@ -168,19 +167,20 @@ $ TESTDIRS='github.com/docker/docker/opts' TESTFLAGS='-test.run ^TestValidateIPA
 
 ## Run integration tests
 
-We use [gocheck](https://labix.org/gocheck) for our integration-cli tests.
-You can use the `TESTFLAGS` environment variable to run a single test. The
-flag's value is passed as arguments to the `go test` command. For example, from
-your local host you can run the `TestBuild` test with this command:
+We use the golang standard [testing](https://golang.org/pkg/testing/) package
+for our integration tests as well. You can use the `TEST_FILTER` environment
+variable to run a subset of tests. The filter value is a regular expression
+passed to the `go test -test.run` command. For example, from your local host
+you can run the `TestBuild`-prefixed tests with this command:
 
 ```bash
-$ TESTFLAGS='-test.run TestDockerSuite/TestBuild*' make test-integration
+$ TEST_FILTER='TestBuild' make test-integration
 ```
 
 To run the same test inside your Docker development container, you do this:
 
 ```bash
-# TESTFLAGS='-test.run TestDockerSuite/TestBuild*' hack/make.sh binary test-integration
+# TEST_FILTER='TestBuild' hack/make.sh binary test-integration
 ```
 
 ## Test the Windows binary against a Linux daemon

--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -79,14 +79,22 @@ if [ -n "$DOCKER_ROOTLESS" ]; then
 		echo >&2 '# DOCKER_ROOTLESS requires TEST_SKIP_INTEGRATION_CLI to be set'
 		exit 1
 	fi
-	ln -sf "$(command -v vpnkit."$(uname -m)")" /usr/local/bin/vpnkit
+
 	user="unprivilegeduser"
 	uid=$(id -u $user)
-	# shellcheck disable=SC2174
-	mkdir -p -m 700 "/tmp/docker-${uid}"
-	chown "$user" "/tmp/docker-${uid}"
+
+	ln -sf "$(command -v vpnkit."$(uname -m)")" /usr/local/bin/vpnkit
 	chmod -R o+w "$DEST"
-	dockerd="sudo -u $user -E -E XDG_RUNTIME_DIR=/tmp/docker-${uid} -E HOME=/home/${user} -E PATH=$PATH -- dockerd-rootless.sh"
+
+	HOST_DIR="/tmp/docker-${uid}"
+	mkdir -p "$HOST_DIR"
+	chmod 700 "$HOST_DIR"
+	chown "$user" "$HOST_DIR"
+
+	dockerd="sudo -u $user -E -E XDG_RUNTIME_DIR=${HOST_DIR} -E HOME=/home/${user} -E PATH=$PATH -- dockerd-rootless.sh"
+else
+	HOST_DIR=$(mktemp -d)
+	trap 'rm -rf -- "$HOST_DIR"' EXIT
 fi
 
 if [ -z "$DOCKER_TEST_HOST" ]; then
@@ -101,8 +109,7 @@ if [ -z "$DOCKER_TEST_HOST" ]; then
 		)
 	fi
 
-	# "pwd" tricks to make sure $DEST is an absolute path, not a relative one
-	export DOCKER_HOST="unix://$(cd "$DEST" && pwd)/docker.sock"
+	export DOCKER_HOST="unix://$HOST_DIR/docker.sock"
 	(
 		echo "Starting dockerd"
 		[ -n "$TESTDEBUG" ] && set -x

--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -17,12 +17,6 @@ if ! command -v "$TEST_CLIENT_BINARY" &> /dev/null; then
 	false
 fi
 
-# This is a temporary hack for split-binary mode. It can be removed once
-# https://github.com/docker/docker/pull/22134 is merged into docker master
-if [ "$(go env GOOS)" = 'windows' ]; then
-	return
-fi
-
 if [ -z "$DOCKER_TEST_HOST" ]; then
 	if docker version &> /dev/null; then
 		echo >&2 'skipping daemon start, since daemon appears to be already started'

--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 #
-# For integration-cli test, we use [gocheck](https://labix.org/gocheck), if you want
-# to run certain tests on your local host, you should run with command:
+# If you want to run only certain tests, you should run with $TEST_FILTER set:
 #
-#     TESTFLAGS='-test.run TestDockerSuite/TestBuild*' ./hack/make.sh binary test-integration
+#     TEST_FILTER='TestBuild' ./hack/make.sh binary test-integration
 #
 
 if [ -z "${MAKEDIR}" ]; then


### PR DESCRIPTION
**- What I did**

This is a small grab-bag of tooling improvements:

* document use of $TEST_FILTER: this modernizes some of the test docs to better reflect the state of the codebase
* place integration test socket in $TMPDIR: allows for the daemon to start when the repo is not checked out onto a fully featured filesystem

This PR previously contained a commit which was made obsolete by #43275, which solved the issue in a different way:

* fix run when DOCKER_ROOTLESS=1: fix a quoting issue that prevents using `DOCKER_ROOTLESS=1 hack/make.sh run`

