### PR TITLE
api/types/swarm: Version: implement stringer interface

### DIFF
--- a/api/types/swarm/common.go
+++ b/api/types/swarm/common.go
@@ -1,10 +1,18 @@
 package swarm // import "github.com/docker/docker/api/types/swarm"
 
-import "time"
+import (
+	"strconv"
+	"time"
+)
 
 // Version represents the internal object version.
 type Version struct {
 	Index uint64 `json:",omitempty"`
+}
+
+// String implements fmt.Stringer interface.
+func (v Version) String() string {
+	return strconv.FormatUint(v.Index, 10)
 }
 
 // Meta is a base object inherited by most of the other once.

--- a/client/config_update.go
+++ b/client/config_update.go
@@ -3,7 +3,6 @@ package client // import "github.com/docker/docker/client"
 import (
 	"context"
 	"net/url"
-	"strconv"
 
 	"github.com/docker/docker/api/types/swarm"
 )
@@ -14,7 +13,7 @@ func (cli *Client) ConfigUpdate(ctx context.Context, id string, version swarm.Ve
 		return err
 	}
 	query := url.Values{}
-	query.Set("version", strconv.FormatUint(version.Index, 10))
+	query.Set("version", version.String())
 	resp, err := cli.post(ctx, "/configs/"+id+"/update", query, config, nil)
 	ensureReaderClosed(resp)
 	return err

--- a/client/node_update.go
+++ b/client/node_update.go
@@ -3,7 +3,6 @@ package client // import "github.com/docker/docker/client"
 import (
 	"context"
 	"net/url"
-	"strconv"
 
 	"github.com/docker/docker/api/types/swarm"
 )
@@ -11,7 +10,7 @@ import (
 // NodeUpdate updates a Node.
 func (cli *Client) NodeUpdate(ctx context.Context, nodeID string, version swarm.Version, node swarm.NodeSpec) error {
 	query := url.Values{}
-	query.Set("version", strconv.FormatUint(version.Index, 10))
+	query.Set("version", version.String())
 	resp, err := cli.post(ctx, "/nodes/"+nodeID+"/update", query, node, nil)
 	ensureReaderClosed(resp)
 	return err

--- a/client/secret_update.go
+++ b/client/secret_update.go
@@ -3,7 +3,6 @@ package client // import "github.com/docker/docker/client"
 import (
 	"context"
 	"net/url"
-	"strconv"
 
 	"github.com/docker/docker/api/types/swarm"
 )
@@ -14,7 +13,7 @@ func (cli *Client) SecretUpdate(ctx context.Context, id string, version swarm.Ve
 		return err
 	}
 	query := url.Values{}
-	query.Set("version", strconv.FormatUint(version.Index, 10))
+	query.Set("version", version.String())
 	resp, err := cli.post(ctx, "/secrets/"+id+"/update", query, secret, nil)
 	ensureReaderClosed(resp)
 	return err

--- a/client/service_update.go
+++ b/client/service_update.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/url"
-	"strconv"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
@@ -35,7 +34,7 @@ func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version 
 		query.Set("rollback", options.Rollback)
 	}
 
-	query.Set("version", strconv.FormatUint(version.Index, 10))
+	query.Set("version", version.String())
 
 	if err := validateServiceSpec(service); err != nil {
 		return response, err

--- a/client/swarm_update.go
+++ b/client/swarm_update.go
@@ -2,7 +2,6 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"strconv"
 
@@ -12,10 +11,10 @@ import (
 // SwarmUpdate updates the swarm.
 func (cli *Client) SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec, flags swarm.UpdateFlags) error {
 	query := url.Values{}
-	query.Set("version", strconv.FormatUint(version.Index, 10))
-	query.Set("rotateWorkerToken", fmt.Sprintf("%v", flags.RotateWorkerToken))
-	query.Set("rotateManagerToken", fmt.Sprintf("%v", flags.RotateManagerToken))
-	query.Set("rotateManagerUnlockKey", fmt.Sprintf("%v", flags.RotateManagerUnlockKey))
+	query.Set("version", version.String())
+	query.Set("rotateWorkerToken", strconv.FormatBool(flags.RotateWorkerToken))
+	query.Set("rotateManagerToken", strconv.FormatBool(flags.RotateManagerToken))
+	query.Set("rotateManagerUnlockKey", strconv.FormatBool(flags.RotateManagerUnlockKey))
 	resp, err := cli.post(ctx, "/swarm/update", query, swarm, nil)
 	ensureReaderClosed(resp)
 	return err

--- a/client/volume_update.go
+++ b/client/volume_update.go
@@ -3,7 +3,6 @@ package client // import "github.com/docker/docker/client"
 import (
 	"context"
 	"net/url"
-	"strconv"
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/volume"
@@ -17,7 +16,7 @@ func (cli *Client) VolumeUpdate(ctx context.Context, volumeID string, version sw
 	}
 
 	query := url.Values{}
-	query.Set("version", strconv.FormatUint(version.Index, 10))
+	query.Set("version", version.String())
 
 	resp, err := cli.put(ctx, "/volumes/"+volumeID, query, options, nil)
 	ensureReaderClosed(resp)


### PR DESCRIPTION
noticed this while reviewing https://github.com/moby/moby/pull/41982 (depending on which one gets merged first, we can update the new uses added in that PR)

Adds a `String()` function to make the code a bit more DRY.

**- A picture of a cute animal (not mandatory but encouraged)**

