### PR TITLE
[RFC] libnetwork/iptables: preserve existing forward rules instead of re-creation

### DIFF
--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -641,16 +641,11 @@ func (iptable IPTable) EnsureJumpRule(fromChain, toChain string) error {
 		args  = []string{"-j", toChain}
 	)
 
-	if iptable.Exists(table, fromChain, args...) {
-		err := iptable.RawCombinedOutput(append([]string{"-D", fromChain}, args...)...)
+	if !iptable.Exists(table, fromChain, args...) {
+		err := iptable.RawCombinedOutput(append([]string{"-I", fromChain}, args...)...)
 		if err != nil {
-			return fmt.Errorf("unable to remove jump to %s rule in %s chain: %s", toChain, fromChain, err.Error())
+			return fmt.Errorf("unable to insert jump to %s rule in %s chain: %s", toChain, fromChain, err.Error())
 		}
-	}
-
-	err := iptable.RawCombinedOutput(append([]string{"-I", fromChain}, args...)...)
-	if err != nil {
-		return fmt.Errorf("unable to insert jump to %s rule in %s chain: %s", toChain, fromChain, err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
Forwarding to `DOCKER-USER` chain is racy, because it is always re-created:

    time="2022-05-11T20:03:03.915890496Z" level=debug msg="/usr/sbin/iptables, [--wait -D FORWARD -j DOCKER-USER]"
    time="2022-05-11T20:03:04.051254185Z" level=debug msg="/usr/sbin/iptables, [--wait -I FORWARD -j DOCKER-USER]"

This is not very convenient since if you are using `DOCKER-USER` chain
to limit network between containers, for a short period of time rules
from `DOCKER-USER` will not be applied.

So replace -D/-I with -C/-I, seems that there should not be any issues
with this, although note that, **after this change rules will not
re-queued at the beginning of the FORWARD chain**.

P.S. I've also tried to overcome this issue with creating separate
chain, but since docker users -I, my chain will goes after docker rules
and it will not receive any packets.