### PR TITLE
[20.10 backport] update runc binary to v1.1.2

### DIFF
--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.conf accordingly
-: "${RUNC_VERSION:=v1.1.1}"
+: "${RUNC_VERSION:=v1.1.2}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"


### PR DESCRIPTION
- backport of (only binary changes)  https://github.com/moby/moby/pull/43588
- relates to https://github.com/containerd/containerd/pull/6934
- relates to https://github.com/containerd/containerd/pull/6936

This is the second patch release of the runc 1.1 release branch. It
fixes CVE-2022-29162, a minor security issue (which appears to not be
exploitable) related to process capabilities.

This is a similar bug to the ones found and fixed in Docker and
containerd recently (CVE-2022-24769).

- A bug was found in runc where runc exec --cap executed processes with
  non-empty inheritable Linux process capabilities, creating an atypical Linux
  environment. For more information, see GHSA-f3fp-gc8g-vw66 and CVE-2022-29162.
- runc spec no longer sets any inheritable capabilities in the created
  example OCI spec (config.json) file.