### PR TITLE
volumes/local: remove legacy migration code, and some cleanups

### DIFF
--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -71,7 +71,7 @@ func New(scope string, rootIdentity idtools.Identity) (*Root, error) {
 			continue
 		}
 
-		name := filepath.Base(d.Name())
+		name := d.Name()
 		v := &localVolume{
 			driverName: r.Name(),
 			name:       name,

--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -21,11 +21,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// VolumeDataPathName is the name of the directory where the volume data is stored.
-// It uses a very distinctive name to avoid collisions migrating data between
-// Docker versions.
 const (
-	VolumeDataPathName = "_data"
+	// volumeDataPathName is the name of the directory where the volume data is stored.
+	// It uses a very distinctive name to avoid collisions migrating data between
+	// Docker versions.
+	volumeDataPathName = "_data"
 	volumesPathName    = "volumes"
 )
 
@@ -127,7 +127,7 @@ func (r *Root) List() ([]volume.Volume, error) {
 
 // DataPath returns the constructed path of this volume.
 func (r *Root) DataPath(volumeName string) string {
-	return filepath.Join(r.path, volumeName, VolumeDataPathName)
+	return filepath.Join(r.path, volumeName, volumeDataPathName)
 }
 
 // Name returns the name of Root, defined in the volume package in the DefaultDriverName constant.

--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -54,7 +54,6 @@ func New(scope string, rootIdentity idtools.Identity) (*Root, error) {
 	}
 
 	r := &Root{
-		scope:        scope,
 		path:         rootDirectory,
 		volumes:      make(map[string]*localVolume),
 		rootIdentity: rootIdentity,
@@ -107,7 +106,6 @@ func New(scope string, rootIdentity idtools.Identity) (*Root, error) {
 // commands to create/remove dirs within its provided scope.
 type Root struct {
 	m            sync.Mutex
-	scope        string
 	path         string
 	quotaCtl     *quota.Control
 	volumes      map[string]*localVolume
@@ -224,8 +222,8 @@ func (r *Root) Remove(v volume.Volume) error {
 		realPath = filepath.Dir(lv.path)
 	}
 
-	if !r.scopedPath(realPath) {
-		return errdefs.System(errors.Errorf("Unable to remove a directory outside of the local volume root %s: %s", r.scope, realPath))
+	if realPath == r.path || !strings.HasPrefix(realPath, r.path) {
+		return errdefs.System(errors.Errorf("unable to remove a directory outside of the local volume root %s: %s", r.path, realPath))
 	}
 
 	if err := removePath(realPath); err != nil {

--- a/volume/local/local_unix.go
+++ b/volume/local/local_unix.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -46,15 +45,6 @@ type optsConfig struct {
 
 func (o *optsConfig) String() string {
 	return fmt.Sprintf("type='%s' device='%s' o='%s' size='%d'", o.MountType, o.MountDevice, o.MountOpts, o.Quota.Size)
-}
-
-// scopedPath verifies that the path where the volume is located
-// is under Docker's root and the valid local paths.
-func (r *Root) scopedPath(realPath string) bool {
-	if strings.HasPrefix(realPath, filepath.Join(r.scope, volumesPathName)) && realPath != filepath.Join(r.scope, volumesPathName) {
-		return true
-	}
-	return false
 }
 
 func setOpts(v *localVolume, opts map[string]string) error {

--- a/volume/local/local_unix.go
+++ b/volume/local/local_unix.go
@@ -24,8 +24,6 @@ import (
 )
 
 var (
-	oldVfsDir = filepath.Join("vfs", "dir")
-
 	validOpts = map[string]struct{}{
 		"type":   {}, // specify the filesystem type for mount, e.g. nfs
 		"o":      {}, // generic mount options
@@ -53,16 +51,9 @@ func (o *optsConfig) String() string {
 // scopedPath verifies that the path where the volume is located
 // is under Docker's root and the valid local paths.
 func (r *Root) scopedPath(realPath string) bool {
-	// Volumes path for Docker version >= 1.7
 	if strings.HasPrefix(realPath, filepath.Join(r.scope, volumesPathName)) && realPath != filepath.Join(r.scope, volumesPathName) {
 		return true
 	}
-
-	// Volumes path for Docker version < 1.7
-	if strings.HasPrefix(realPath, filepath.Join(r.scope, oldVfsDir)) {
-		return true
-	}
-
 	return false
 }
 

--- a/volume/local/local_windows.go
+++ b/volume/local/local_windows.go
@@ -5,8 +5,6 @@ package local // import "github.com/docker/docker/volume/local"
 
 import (
 	"os"
-	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 
@@ -15,15 +13,6 @@ import (
 )
 
 type optsConfig struct{}
-
-// scopedPath verifies that the path where the volume is located
-// is under Docker's root and the valid local paths.
-func (r *Root) scopedPath(realPath string) bool {
-	if strings.HasPrefix(realPath, filepath.Join(r.scope, volumesPathName)) && realPath != filepath.Join(r.scope, volumesPathName) {
-		return true
-	}
-	return false
-}
 
 func setOpts(v *localVolume, opts map[string]string) error {
 	if len(opts) > 0 {


### PR DESCRIPTION
This is part of a branch that I had locally (and recalled I had after Today's maintainers meeting)

More to come, including some (potential) bugs on Windows


### volume/local: remove hack for downgrading docker 1.7 to 1.6

This was added in bd9814f0db9c8a087e42b66eabb8413bf1b2ab66 (https://github.com/moby/moby/pull/13699) to support downgrading
docker 1.7 to 1.6.

The related migration code was removed in 0023abbad34282762d5bd17302776d2a8521fffc (https://github.com/moby/moby/pull/36637)
(Docker 18.05), which was also the last consumer of VolumeDataPathName outside
of the package, so that const can be un-exported.

### volume/local: remove redundant Root.scopedPath(), Root.scope

Now that there's no differentiation between Linux and Windows
for this check, we can remove the two implementations and move
the code inline as it's only used in a single location and moving
it inline makes it more transparent on what's being checked.

As part of this change, the now unused "scope" field is also removed.


### volume/local.New(): remove some intermediate variables

### volume/local.New(): remove redundant filepath.Base()

FileInfo.Name() returns the base name, so no need to remove path information.

**- A picture of a cute animal (not mandatory but encouraged)**

