### PR TITLE
daemon/linux: Set console size on creation

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"runtime"
 	"strconv"
 
 	"github.com/containerd/containerd/platforms"
@@ -515,6 +516,11 @@ func (s *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 	if hostConfig != nil && versions.GreaterThanOrEqualTo(version, "1.42") {
 		// Ignore KernelMemory removed in API 1.42.
 		hostConfig.KernelMemory = 0
+	}
+
+	if hostConfig != nil && runtime.GOOS == "linux" && versions.LessThan(version, "1.42") {
+		// ConsoleSize is not respected by Linux daemon before API 1.42
+		hostConfig.ConsoleSize = [2]uint{0, 0}
 	}
 
 	var platform *specs.Platform

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -955,6 +955,15 @@ definitions:
             type: "array"
             items:
               $ref: "#/definitions/Mount"
+          ConsoleSize:
+            type: "array"
+            description: |
+              Initial console size, as an `[height, width]` array.
+            minItems: 2
+            maxItems: 2
+            items:
+              type: "integer"
+              minimum: 0
 
           # Applicable to UNIX platforms
           CapAdd:
@@ -1119,15 +1128,6 @@ definitions:
             type: "string"
             description: "Runtime to use with this container."
           # Applicable to Windows
-          ConsoleSize:
-            type: "array"
-            description: |
-              Initial console size, as an `[height, width]` array. (Windows only)
-            minItems: 2
-            maxItems: 2
-            items:
-              type: "integer"
-              minimum: 0
           Isolation:
             type: "string"
             description: |

--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -417,6 +417,7 @@ type HostConfig struct {
 	AutoRemove      bool          // Automatically remove container when it exits
 	VolumeDriver    string        // Name of the volume driver used to mount volumes
 	VolumesFrom     []string      // List of volumes to take from other container
+	ConsoleSize     [2]uint       // Initial console size (height,width)
 
 	// Applicable to UNIX platforms
 	CapAdd          strslice.StrSlice // List of kernel capabilities to add to the container
@@ -445,8 +446,7 @@ type HostConfig struct {
 	Runtime         string            `json:",omitempty"` // Runtime to use with this container
 
 	// Applicable to Windows
-	ConsoleSize [2]uint   // Initial console size (height,width)
-	Isolation   Isolation // Isolation technology of the container (e.g. default, hyperv)
+	Isolation Isolation // Isolation technology of the container (e.g. default, hyperv)
 
 	// Contains container's resources (cgroups, ulimits)
 	Resources

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -1023,7 +1023,9 @@ func (daemon *Daemon) createSpec(c *container.Container) (retSpec *specs.Spec, e
 	if c.NoNewPrivileges {
 		opts = append(opts, coci.WithNoNewPrivileges)
 	}
-
+	if c.Config.Tty {
+		opts = append(opts, WithConsoleSize(c))
+	}
 	// Set the masked and readonly paths with regard to the host config options if they are set.
 	if c.HostConfig.MaskedPaths != nil {
 		opts = append(opts, coci.WithMaskedPaths(c.HostConfig.MaskedPaths))

--- a/daemon/oci_opts.go
+++ b/daemon/oci_opts.go
@@ -1,0 +1,23 @@
+package daemon
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/containers"
+	coci "github.com/containerd/containerd/oci"
+	"github.com/docker/docker/container"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// WithConsoleSize sets the initial console size
+func WithConsoleSize(c *container.Container) coci.SpecOpts {
+	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
+		if c.HostConfig.ConsoleSize[0] > 0 || c.HostConfig.ConsoleSize[1] > 0 {
+			s.Process.ConsoleSize = &specs.Box{
+				Height: c.HostConfig.ConsoleSize[0],
+				Width:  c.HostConfig.ConsoleSize[1],
+			}
+		}
+		return nil
+	}
+}

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -94,6 +94,9 @@ keywords: "API, Docker, rcli, REST, documentation"
   actually supported. API versions before v1.42 continue to ignore these parameters
   and default to attaching to all streams. To preserve the pre-v1.42 behavior,
   set all three query parameters (`?stdin=1,stdout=1,stderr=1`).
+* `POST /containers/create` on Linux now respects the `HostConfig.ConsoleSize` property.
+  Container is immediately created with the desired terminal size and clients no longer
+  need to set the desired size on their own.
 
 ## v1.41 API changes
 

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -227,3 +227,10 @@ func WithIsolation(isolation containertypes.Isolation) func(*TestContainerConfig
 		c.HostConfig.Isolation = isolation
 	}
 }
+
+// WithConsoleSize sets the initial console size of the container
+func WithConsoleSize(width, height uint) func(*TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.HostConfig.ConsoleSize = [2]uint{height, width}
+	}
+}


### PR DESCRIPTION
**- What I did**
On Linux the daemon was not respecting the HostConfig.ConsoleSize property and relied on cli initializing the tty size after the container was created. This caused a delay between container creation and the tty actually being resized.

So for example:
`docker run -it --rm ubuntu sh -c 'tput cols; tput lines'`
would print the default tty size

but:
`docker run -it --rm ubuntu sh -c 'sleep 1; tput cols; tput lines'`
would print the expected size

This is also a small change to the api description, because HostConfig.ConsoleSize is no longer Windows-only

Relates to
[cli#3554](https://github.com/docker/cli/issues/3554)
[cli#3572](https://github.com/docker/cli/pull/3572#issuecomment-1112069795)

**- How I did it**
Apply the HostConfig.ConsoleSize to the Spec just like the Windows code does.

**- How to verify it**
Terminal size should be changed immediately when starting container, can verify by resizing the terminal window from default 80x24 and checking if running the below prints the expected size:
`docker run -it --rm ubuntu sh -c 'tput cols; tput lines'`

**- Description for the changelog**
Container's tty size is set immediately on creation

**- A picture of a cute animal (not mandatory but encouraged)**
![cute Duduś](https://user-images.githubusercontent.com/5046555/168241647-661b98b6-2e17-4b99-a4aa-a685c13593b0.jpg)

