### PR TITLE
volume: mask password in cifs mount error messages

### DIFF
--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -366,3 +366,15 @@ func getAddress(opts string) string {
 	}
 	return ""
 }
+
+// getPassword finds out a password from options
+func getPassword(opts string) string {
+	optsList := strings.Split(opts, ",")
+	for i := 0; i < len(optsList); i++ {
+		if strings.HasPrefix(optsList[i], "password=") {
+			passwd := strings.SplitN(optsList[i], "=", 2)[1]
+			return passwd
+		}
+	}
+	return ""
+}

--- a/volume/local/local_test.go
+++ b/volume/local/local_test.go
@@ -29,6 +29,25 @@ func TestGetAddress(t *testing.T) {
 
 }
 
+func TestGetPassword(t *testing.T) {
+	cases := map[string]string{
+		"password=secret":                       "secret",
+		" ":                                     "",
+		"password=":                             "",
+		"password=Tr0ub4dor&3":                  "Tr0ub4dor&3",
+		"password=correcthorsebatterystaple":    "correcthorsebatterystaple",
+		"username=moby,password=secret":         "secret",
+		"username=moby,password=secret,addr=11": "secret",
+		"username=moby,addr=11":                 "",
+	}
+	for optsstring, success := range cases {
+		v := getPassword(optsstring)
+		if v != success {
+			t.Errorf("Test case failed for %s actual: %s expected : %s", optsstring, v, success)
+		}
+	}
+}
+
 func TestRemove(t *testing.T) {
 	skip.If(t, runtime.GOOS == "windows", "FIXME: investigate why this test fails on CI")
 	rootDir, err := os.MkdirTemp("", "local-volume-test")

--- a/volume/local/local_unix.go
+++ b/volume/local/local_unix.go
@@ -143,6 +143,11 @@ func (v *localVolume) mount() error {
 		}
 	}
 	err := mount.Mount(v.opts.MountDevice, v.path, v.opts.MountType, mountOpts)
+	if err != nil {
+		if password := getPassword(v.opts.MountOpts); password != "" {
+			err = errors.New(strings.Replace(err.Error(), "password="+password, "password=********", 1))
+		}
+	}
 	return errors.Wrap(err, "failed to mount local volume")
 }
 


### PR DESCRIPTION
In managed environment (such as Nomad clusters), users are not always
supposed to see credentials used to mount volumes.
However, if errors occur (most commonly, misspelled mount paths), the
error messages will output the full mount command -- which might contain
a username and a password in the case of CIFS mounts.

This PR detects password=... when error messages are wrapped and masks
them with ********.

Closes https://github.com/fsouza/go-dockerclient/issues/905.
Closes https://github.com/hashicorp/nomad/issues/12296.
Closes https://github.com/moby/moby/issues/43596.

Signed-off-by: Sebastian Höffner <sebastian.hoeffner@mevis.fraunhofer.de>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
In the error handler for cifs mounts, `password=...` will be masked with `********` in user facing error messages.

**- How I did it**
- Added `func getPassword(opts string) string` in line with `getAddr` (could potentially be refactored into something such as `func getOption(opt string, opts string) string`)
- Added unit tests for getPassword
- Replaced `password=[detectedPassword]` with `password=********`

**- How to verify it**
Was:
```console
$ docker volume create --driver local --opt type=cifs --opt "o=username=shoeffner,password=supersecretpassword,iocharset=utf8,file_mode=0777,dir_mode=0777" --opt device=//192.168.1.2/Public cifstest
$ docker run --rm -it -v cifstest:/themnt busybox bash
docker: Error response from daemon: error while mounting volume '/var/lib/docker/volumes/cifstest/_data': failed to mount local volume: mount //192.168.1.2/Public:/var/lib/docker/volumes/cifstest/_data, data: username=shoeffner,password=supersecretpassword,iocharset=utf8,file_mode=0777,dir_mode=0777: permission denied.
```
Is:
```console
$ docker volume create --driver local --opt type=cifs --opt "o=username=shoeffner,password=supersecretpassword,iocharset=utf8,file_mode=0777,dir_mode=0777" --opt device=//192.168.1.2/Public cifstest
$ docker run --rm -it -v cifstest:/themnt busybox bash
docker: Error response from daemon: error while mounting volume '/var/lib/docker/volumes/cifstest/_data': failed to mount local volume: mount //192.168.1.2/Public:/var/lib/docker/volumes/cifstest/_data, data: username=shoeffner,password=********,iocharset=utf8,file_mode=0777,dir_mode=0777: permission denied.
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Passwords in user facing error messages for CIFS mounts are masked.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/1836815/168321285-b249cf28-c2bc-467f-a321-f90cde684fa8.png)
https://www.pexels.com/photo/cold-nature-cute-ice-52509/