### PR TITLE
Use separate openrc init script for containerd

### DIFF
--- a/contrib/init/openrc/docker.initd
+++ b/contrib/init/openrc/docker.initd
@@ -17,6 +17,10 @@ rc_ulimit="${DOCKER_ULIMIT:--c unlimited -n 1048576 -u unlimited}"
 
 retry="${DOCKER_RETRY:-TERM/60/KILL/10}"
 
+depend() {
+	need containerd
+}
+
 start_pre() {
 	checkpath -f -m 0644 -o root:docker "$DOCKER_LOGFILE"
 }


### PR DESCRIPTION
The current init script spawns both a docker process **and** a containerd process. This probably confuses openrc which sometimes leads to a crashed docker service when running `/etc/init.d/docker start`.  
Gentoo Linux ships with a separate init script for containerd. By adding the dependency to the docker init script, both processes can be monitored separately by openrc.  

Probably related issue: #23628

---

Related bug for Gentoo Linux [#842567](https://bugs.gentoo.org/842567)

The current docker init file does not specify containerd as dependency. When the docker service is started, it first starts containerd itself. You can check this by
```
rc-service docker stop
rc-service containerd stop
dockerd
```
-> output that indicates that both docker and containerd are started. Htop shows containerd as child process of dockerd.

There exists a separate init script for containerd which is always there when docker is installed because app-containers/containerd (to which the file belongs) is pulled in as a dependency of docker.

When starting the containerd service before docker, the already existing process is used. You can check this by
```
rc-service docker stop
rc-service containerd start
dockerd
```
-> output that indicates that only dockerd is started. Containerd is a separate process.