### PR TITLE
Rename Reservation to Reservations in the open API

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3699,7 +3699,7 @@ definitions:
           Limits:
             description: "Define resources limits."
             $ref: "#/definitions/Limit"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:

--- a/docs/api/v1.25.yaml
+++ b/docs/api/v1.25.yaml
@@ -1939,7 +1939,7 @@ definitions:
                 description: "Memory limit in Bytes."
                 type: "integer"
                 format: "int64"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             properties:
               NanoCPUs:

--- a/docs/api/v1.26.yaml
+++ b/docs/api/v1.26.yaml
@@ -1944,7 +1944,7 @@ definitions:
                 description: "Memory limit in Bytes."
                 type: "integer"
                 format: "int64"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             properties:
               NanoCPUs:

--- a/docs/api/v1.27.yaml
+++ b/docs/api/v1.27.yaml
@@ -2017,7 +2017,7 @@ definitions:
                 description: "Memory limit in Bytes."
                 type: "integer"
                 format: "int64"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             properties:
               NanoCPUs:

--- a/docs/api/v1.28.yaml
+++ b/docs/api/v1.28.yaml
@@ -2059,7 +2059,7 @@ definitions:
                 description: "Memory limit in Bytes."
                 type: "integer"
                 format: "int64"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             properties:
               NanoCPUs:

--- a/docs/api/v1.29.yaml
+++ b/docs/api/v1.29.yaml
@@ -2081,7 +2081,7 @@ definitions:
                 description: "Memory limit in Bytes."
                 type: "integer"
                 format: "int64"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             properties:
               NanoCPUs:

--- a/docs/api/v1.30.yaml
+++ b/docs/api/v1.30.yaml
@@ -2250,7 +2250,7 @@ definitions:
                 description: "Memory limit in Bytes."
                 type: "integer"
                 format: "int64"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             properties:
               NanoCPUs:

--- a/docs/api/v1.31.yaml
+++ b/docs/api/v1.31.yaml
@@ -2280,7 +2280,7 @@ definitions:
                 description: "Memory limit in Bytes."
                 type: "integer"
                 format: "int64"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             properties:
               NanoCPUs:

--- a/docs/api/v1.32.yaml
+++ b/docs/api/v1.32.yaml
@@ -2734,7 +2734,7 @@ definitions:
           Limits:
             description: "Define resources limits."
             $ref: "#/definitions/ResourceObject"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:

--- a/docs/api/v1.33.yaml
+++ b/docs/api/v1.33.yaml
@@ -2739,7 +2739,7 @@ definitions:
           Limits:
             description: "Define resources limits."
             $ref: "#/definitions/ResourceObject"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:

--- a/docs/api/v1.34.yaml
+++ b/docs/api/v1.34.yaml
@@ -2750,7 +2750,7 @@ definitions:
           Limits:
             description: "Define resources limits."
             $ref: "#/definitions/ResourceObject"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:

--- a/docs/api/v1.35.yaml
+++ b/docs/api/v1.35.yaml
@@ -2732,7 +2732,7 @@ definitions:
           Limits:
             description: "Define resources limits."
             $ref: "#/definitions/ResourceObject"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:

--- a/docs/api/v1.36.yaml
+++ b/docs/api/v1.36.yaml
@@ -2745,7 +2745,7 @@ definitions:
           Limits:
             description: "Define resources limits."
             $ref: "#/definitions/ResourceObject"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:

--- a/docs/api/v1.37.yaml
+++ b/docs/api/v1.37.yaml
@@ -2748,7 +2748,7 @@ definitions:
           Limits:
             description: "Define resources limits."
             $ref: "#/definitions/ResourceObject"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:

--- a/docs/api/v1.38.yaml
+++ b/docs/api/v1.38.yaml
@@ -2802,7 +2802,7 @@ definitions:
           Limits:
             description: "Define resources limits."
             $ref: "#/definitions/ResourceObject"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -3502,7 +3502,7 @@ definitions:
           Limits:
             description: "Define resources limits."
             $ref: "#/definitions/ResourceObject"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -3618,7 +3618,7 @@ definitions:
           Limits:
             description: "Define resources limits."
             $ref: "#/definitions/ResourceObject"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -3700,7 +3700,7 @@ definitions:
           Limits:
             description: "Define resources limits."
             $ref: "#/definitions/Limit"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:


### PR DESCRIPTION
- fixes https://github.com/docker/cli/issues/3611
- addresses https://github.com/moby/moby/issues/33327


The correct name for this property is, and always was "Reservations"

**- What I did**

Renamed Reservation to Reservations in the open API, this property was always named [Reservations](https://github.com/moby/moby/blob/master/api/types/swarm/task.go#L142)

This is an issue that was open in the [cli](https://github.com/docker/cli/issues/3611).

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

