### PR TITLE
[20.10 backport]  Rename Reservation to Reservations in the open API

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3347,7 +3347,7 @@ definitions:
           Limits:
             description: "Define resources limits."
             $ref: "#/definitions/Limit"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:

--- a/docs/api/v1.25.yaml
+++ b/docs/api/v1.25.yaml
@@ -1939,7 +1939,7 @@ definitions:
                 description: "Memory limit in Bytes."
                 type: "integer"
                 format: "int64"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             properties:
               NanoCPUs:

--- a/docs/api/v1.26.yaml
+++ b/docs/api/v1.26.yaml
@@ -1944,7 +1944,7 @@ definitions:
                 description: "Memory limit in Bytes."
                 type: "integer"
                 format: "int64"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             properties:
               NanoCPUs:

--- a/docs/api/v1.27.yaml
+++ b/docs/api/v1.27.yaml
@@ -2017,7 +2017,7 @@ definitions:
                 description: "Memory limit in Bytes."
                 type: "integer"
                 format: "int64"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             properties:
               NanoCPUs:

--- a/docs/api/v1.28.yaml
+++ b/docs/api/v1.28.yaml
@@ -2059,7 +2059,7 @@ definitions:
                 description: "Memory limit in Bytes."
                 type: "integer"
                 format: "int64"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             properties:
               NanoCPUs:

--- a/docs/api/v1.29.yaml
+++ b/docs/api/v1.29.yaml
@@ -2081,7 +2081,7 @@ definitions:
                 description: "Memory limit in Bytes."
                 type: "integer"
                 format: "int64"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             properties:
               NanoCPUs:

--- a/docs/api/v1.30.yaml
+++ b/docs/api/v1.30.yaml
@@ -2242,7 +2242,7 @@ definitions:
                 description: "Memory limit in Bytes."
                 type: "integer"
                 format: "int64"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             properties:
               NanoCPUs:

--- a/docs/api/v1.31.yaml
+++ b/docs/api/v1.31.yaml
@@ -2272,7 +2272,7 @@ definitions:
                 description: "Memory limit in Bytes."
                 type: "integer"
                 format: "int64"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             properties:
               NanoCPUs:

--- a/docs/api/v1.32.yaml
+++ b/docs/api/v1.32.yaml
@@ -2726,7 +2726,7 @@ definitions:
           Limits:
             description: "Define resources limits."
             $ref: "#/definitions/ResourceObject"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:

--- a/docs/api/v1.33.yaml
+++ b/docs/api/v1.33.yaml
@@ -2731,7 +2731,7 @@ definitions:
           Limits:
             description: "Define resources limits."
             $ref: "#/definitions/ResourceObject"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:

--- a/docs/api/v1.34.yaml
+++ b/docs/api/v1.34.yaml
@@ -2742,7 +2742,7 @@ definitions:
           Limits:
             description: "Define resources limits."
             $ref: "#/definitions/ResourceObject"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:

--- a/docs/api/v1.35.yaml
+++ b/docs/api/v1.35.yaml
@@ -2724,7 +2724,7 @@ definitions:
           Limits:
             description: "Define resources limits."
             $ref: "#/definitions/ResourceObject"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:

--- a/docs/api/v1.36.yaml
+++ b/docs/api/v1.36.yaml
@@ -2737,7 +2737,7 @@ definitions:
           Limits:
             description: "Define resources limits."
             $ref: "#/definitions/ResourceObject"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:

--- a/docs/api/v1.37.yaml
+++ b/docs/api/v1.37.yaml
@@ -2740,7 +2740,7 @@ definitions:
           Limits:
             description: "Define resources limits."
             $ref: "#/definitions/ResourceObject"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:

--- a/docs/api/v1.38.yaml
+++ b/docs/api/v1.38.yaml
@@ -2794,7 +2794,7 @@ definitions:
           Limits:
             description: "Define resources limits."
             $ref: "#/definitions/ResourceObject"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -3398,7 +3398,7 @@ definitions:
           Limits:
             description: "Define resources limits."
             $ref: "#/definitions/ResourceObject"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -3514,7 +3514,7 @@ definitions:
           Limits:
             description: "Define resources limits."
             $ref: "#/definitions/ResourceObject"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -3596,7 +3596,7 @@ definitions:
           Limits:
             description: "Define resources limits."
             $ref: "#/definitions/Limit"
-          Reservation:
+          Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:


### PR DESCRIPTION
Backport of #43605

Cherry-picked commit cc3848f2b736ba8667f9cb9d502306055298453f