### PR TITLE
API: fix documentation for containers/{id}/attach/ws

### DIFF
--- a/docs/api/v1.18.md
+++ b/docs/api/v1.18.md
@@ -1013,12 +1013,6 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
 -   **stream** – 1/True/true or 0/False/false, return stream.
         Default `false`.
--   **stdin** – 1/True/true or 0/False/false, if `stream=true`, attach
-        to `stdin`. Default `false`.
--   **stdout** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stdout` log, if `stream=true`, attach to `stdout`. Default `false`.
--   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
 **Status codes**:
 

--- a/docs/api/v1.19.md
+++ b/docs/api/v1.19.md
@@ -1050,12 +1050,6 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
 -   **stream** – 1/True/true or 0/False/false, return stream.
         Default `false`.
--   **stdin** – 1/True/true or 0/False/false, if `stream=true`, attach
-        to `stdin`. Default `false`.
--   **stdout** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stdout` log, if `stream=true`, attach to `stdout`. Default `false`.
--   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
 **Status codes**:
 

--- a/docs/api/v1.20.md
+++ b/docs/api/v1.20.md
@@ -1059,12 +1059,6 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
 -   **stream** – 1/True/true or 0/False/false, return stream.
         Default `false`.
--   **stdin** – 1/True/true or 0/False/false, if `stream=true`, attach
-        to `stdin`. Default `false`.
--   **stdout** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stdout` log, if `stream=true`, attach to `stdout`. Default `false`.
--   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
 **Status codes**:
 

--- a/docs/api/v1.21.md
+++ b/docs/api/v1.21.md
@@ -1140,12 +1140,6 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
 -   **stream** – 1/True/true or 0/False/false, return stream.
         Default `false`.
--   **stdin** – 1/True/true or 0/False/false, if `stream=true`, attach
-        to `stdin`. Default `false`.
--   **stdout** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stdout` log, if `stream=true`, attach to `stdout`. Default `false`.
--   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
 **Status codes**:
 

--- a/docs/api/v1.22.md
+++ b/docs/api/v1.22.md
@@ -1320,12 +1320,6 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
 -   **stream** – 1/True/true or 0/False/false, return stream.
         Default `false`.
--   **stdin** – 1/True/true or 0/False/false, if `stream=true`, attach
-        to `stdin`. Default `false`.
--   **stdout** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stdout` log, if `stream=true`, attach to `stdout`. Default `false`.
--   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
 **Status codes**:
 

--- a/docs/api/v1.23.md
+++ b/docs/api/v1.23.md
@@ -1354,12 +1354,6 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
 -   **stream** – 1/True/true or 0/False/false, return stream.
         Default `false`.
--   **stdin** – 1/True/true or 0/False/false, if `stream=true`, attach
-        to `stdin`. Default `false`.
--   **stdout** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stdout` log, if `stream=true`, attach to `stdout`. Default `false`.
--   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
 **Status codes**:
 

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -1400,12 +1400,6 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
 -   **stream** – 1/True/true or 0/False/false, return stream.
         Default `false`.
--   **stdin** – 1/True/true or 0/False/false, if `stream=true`, attach
-        to `stdin`. Default `false`.
--   **stdout** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stdout` log, if `stream=true`, attach to `stdout`. Default `false`.
--   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
 **Status codes**:
 

--- a/docs/api/v1.25.yaml
+++ b/docs/api/v1.25.yaml
@@ -3984,21 +3984,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.26.yaml
+++ b/docs/api/v1.26.yaml
@@ -3989,21 +3989,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.27.yaml
+++ b/docs/api/v1.27.yaml
@@ -4057,21 +4057,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.28.yaml
+++ b/docs/api/v1.28.yaml
@@ -4149,21 +4149,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.29.yaml
+++ b/docs/api/v1.29.yaml
@@ -4183,21 +4183,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.30.yaml
+++ b/docs/api/v1.30.yaml
@@ -4409,21 +4409,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.31.yaml
+++ b/docs/api/v1.31.yaml
@@ -4479,21 +4479,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.32.yaml
+++ b/docs/api/v1.32.yaml
@@ -5719,21 +5719,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.33.yaml
+++ b/docs/api/v1.33.yaml
@@ -5724,21 +5724,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.34.yaml
+++ b/docs/api/v1.34.yaml
@@ -5753,21 +5753,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.35.yaml
+++ b/docs/api/v1.35.yaml
@@ -5740,21 +5740,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.36.yaml
+++ b/docs/api/v1.36.yaml
@@ -5762,21 +5762,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.37.yaml
+++ b/docs/api/v1.37.yaml
@@ -5789,21 +5789,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.38.yaml
+++ b/docs/api/v1.38.yaml
@@ -5850,21 +5850,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -6866,21 +6866,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -7172,21 +7172,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -7353,21 +7353,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -87,8 +87,13 @@ keywords: "API, Docker, rcli, REST, documentation"
 * The `Volume` type, as returned by `Added new `ClusterVolume` fields 
 * Added a new `PUT /volumes{name}` endpoint to update cluster volumes (CNI).
   Cluster volumes are only supported if the daemon is a Swarm manager.
-* `/containers/{name}/attach/ws` endpoint only attach to configured streams
-  according to `stdin`, `stdout` and `stderr` parameters.
+* `GET /containers/{name}/attach/ws` endpoint now accepts `stdin`, `stdout` and
+  `stderr` query parameters to only attach to configured streams.
+
+  NOTE: These parameters were documented before in older API versions, but not
+  actually supported. API versions before v1.42 continue to ignore these parameters
+  and default to attaching to all streams. To preserve the pre-v1.42 behavior,
+  set all three query parameters (`?stdin=1,stdout=1,stderr=1`).
 
 ## v1.41 API changes
 


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/43322
- relates to https://github.com/moby/moby/issues/43272

### docs: api: add note about websocket attach streams

Slightly make the change in API v1.42 more visible, and add a snippet about what users should do to preserve the pre-v1.41 behavior.

### docs: api: /containers/{id}/attach/ws: remove unsupported query-args < v1.42

These query-args were documented, but not actually supported until https://github.com/moby/moby/commit/ea6760138c35c607a0b51ad041051374d8304e68 (https://github.com/moby/moby/pull/43322) (API v1.42).

This removes them from the documentation, as these arguments were ignored (and defaulted to `true` (enabled))


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

