### PR TITLE
[20.10 backport] docs: api: /containers/{id}/attach/ws: remove unsupported query-args < v1.42

### DIFF
--- a/docs/api/v1.18.md
+++ b/docs/api/v1.18.md
@@ -1013,12 +1013,6 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
 -   **stream** – 1/True/true or 0/False/false, return stream.
         Default `false`.
--   **stdin** – 1/True/true or 0/False/false, if `stream=true`, attach
-        to `stdin`. Default `false`.
--   **stdout** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stdout` log, if `stream=true`, attach to `stdout`. Default `false`.
--   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
 **Status codes**:
 

--- a/docs/api/v1.19.md
+++ b/docs/api/v1.19.md
@@ -1050,12 +1050,6 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
 -   **stream** – 1/True/true or 0/False/false, return stream.
         Default `false`.
--   **stdin** – 1/True/true or 0/False/false, if `stream=true`, attach
-        to `stdin`. Default `false`.
--   **stdout** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stdout` log, if `stream=true`, attach to `stdout`. Default `false`.
--   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
 **Status codes**:
 

--- a/docs/api/v1.20.md
+++ b/docs/api/v1.20.md
@@ -1059,12 +1059,6 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
 -   **stream** – 1/True/true or 0/False/false, return stream.
         Default `false`.
--   **stdin** – 1/True/true or 0/False/false, if `stream=true`, attach
-        to `stdin`. Default `false`.
--   **stdout** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stdout` log, if `stream=true`, attach to `stdout`. Default `false`.
--   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
 **Status codes**:
 

--- a/docs/api/v1.21.md
+++ b/docs/api/v1.21.md
@@ -1140,12 +1140,6 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
 -   **stream** – 1/True/true or 0/False/false, return stream.
         Default `false`.
--   **stdin** – 1/True/true or 0/False/false, if `stream=true`, attach
-        to `stdin`. Default `false`.
--   **stdout** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stdout` log, if `stream=true`, attach to `stdout`. Default `false`.
--   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
 **Status codes**:
 

--- a/docs/api/v1.22.md
+++ b/docs/api/v1.22.md
@@ -1320,12 +1320,6 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
 -   **stream** – 1/True/true or 0/False/false, return stream.
         Default `false`.
--   **stdin** – 1/True/true or 0/False/false, if `stream=true`, attach
-        to `stdin`. Default `false`.
--   **stdout** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stdout` log, if `stream=true`, attach to `stdout`. Default `false`.
--   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
 **Status codes**:
 

--- a/docs/api/v1.23.md
+++ b/docs/api/v1.23.md
@@ -1354,12 +1354,6 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
 -   **stream** – 1/True/true or 0/False/false, return stream.
         Default `false`.
--   **stdin** – 1/True/true or 0/False/false, if `stream=true`, attach
-        to `stdin`. Default `false`.
--   **stdout** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stdout` log, if `stream=true`, attach to `stdout`. Default `false`.
--   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
 **Status codes**:
 

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -1400,12 +1400,6 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
 -   **stream** – 1/True/true or 0/False/false, return stream.
         Default `false`.
--   **stdin** – 1/True/true or 0/False/false, if `stream=true`, attach
-        to `stdin`. Default `false`.
--   **stdout** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stdout` log, if `stream=true`, attach to `stdout`. Default `false`.
--   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
-        `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
 **Status codes**:
 

--- a/docs/api/v1.25.yaml
+++ b/docs/api/v1.25.yaml
@@ -3984,21 +3984,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.26.yaml
+++ b/docs/api/v1.26.yaml
@@ -3989,21 +3989,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.27.yaml
+++ b/docs/api/v1.27.yaml
@@ -4057,21 +4057,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.28.yaml
+++ b/docs/api/v1.28.yaml
@@ -4149,21 +4149,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.29.yaml
+++ b/docs/api/v1.29.yaml
@@ -4183,21 +4183,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.30.yaml
+++ b/docs/api/v1.30.yaml
@@ -4401,21 +4401,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.31.yaml
+++ b/docs/api/v1.31.yaml
@@ -4471,21 +4471,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.32.yaml
+++ b/docs/api/v1.32.yaml
@@ -5711,21 +5711,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.33.yaml
+++ b/docs/api/v1.33.yaml
@@ -5716,21 +5716,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.34.yaml
+++ b/docs/api/v1.34.yaml
@@ -5745,21 +5745,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.35.yaml
+++ b/docs/api/v1.35.yaml
@@ -5732,21 +5732,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.36.yaml
+++ b/docs/api/v1.36.yaml
@@ -5754,21 +5754,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.37.yaml
+++ b/docs/api/v1.37.yaml
@@ -5781,21 +5781,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.38.yaml
+++ b/docs/api/v1.38.yaml
@@ -5842,21 +5842,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -6762,21 +6762,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -7068,21 +7068,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -7249,21 +7249,6 @@ paths:
           description: "Return stream"
           type: "boolean"
           default: false
-        - name: "stdin"
-          in: "query"
-          description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
-        - name: "stdout"
-          in: "query"
-          description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
-        - name: "stderr"
-          in: "query"
-          description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:


### PR DESCRIPTION
- partial (only second commit) backport of https://github.com/moby/moby/pull/43609
- relates to https://github.com/moby/moby/pull/43322
- relates to https://github.com/moby/moby/issues/43272

These query-args were documented, but not actually supported until
ea6760138c35c607a0b51ad041051374d8304e68 (https://github.com/moby/moby/pull/43322) (API v1.42).

This removes them from the documentation, as these arguments were ignored (and defaulted to `true` (enabled))

(cherry picked from commit a5a77979dda121929a6de10d6419a0695d83f511)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

