### PR TITLE
all: use unix.ByteSliceToString for utsname fields

### DIFF
--- a/pkg/parsers/kernel/kernel_unix.go
+++ b/pkg/parsers/kernel/kernel_unix.go
@@ -6,9 +6,8 @@
 package kernel // import "github.com/docker/docker/pkg/parsers/kernel"
 
 import (
-	"bytes"
-
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 )
 
 // GetKernelVersion gets the current kernel version.
@@ -19,7 +18,7 @@ func GetKernelVersion() (*VersionInfo, error) {
 	}
 
 	// Remove the \x00 from the release for Atoi to parse correctly
-	return ParseRelease(string(uts.Release[:bytes.IndexByte(uts.Release[:], 0)]))
+	return ParseRelease(unix.ByteSliceToString(uts.Release[:]))
 }
 
 // CheckKernelVersion checks if current kernel is newer than (or equal to)

--- a/pkg/parsers/operatingsystem/operatingsystem_unix.go
+++ b/pkg/parsers/operatingsystem/operatingsystem_unix.go
@@ -16,7 +16,7 @@ func GetOperatingSystem() (string, error) {
 	if err := unix.Uname(utsname); err != nil {
 		return "", err
 	}
-	return string(utsname.Machine[:bytes.IndexByte(utsname.Sysname[:], 0)]), nil
+	return unix.ByteSliceToString(utsname.Machine[:]), nil
 }
 
 // GetOperatingSystemVersion gets the version of the current operating system, as a string.

--- a/pkg/platform/architecture_unix.go
+++ b/pkg/platform/architecture_unix.go
@@ -6,8 +6,6 @@
 package platform // import "github.com/docker/docker/pkg/platform"
 
 import (
-	"bytes"
-
 	"golang.org/x/sys/unix"
 )
 
@@ -17,5 +15,5 @@ func runtimeArchitecture() (string, error) {
 	if err := unix.Uname(utsname); err != nil {
 		return "", err
 	}
-	return string(utsname.Machine[:bytes.IndexByte(utsname.Machine[:], 0)]), nil
+	return unix.ByteSliceToString(utsname.Machine[:]), nil
 }

--- a/profiles/seccomp/kernel_linux.go
+++ b/profiles/seccomp/kernel_linux.go
@@ -1,7 +1,6 @@
 package seccomp
 
 import (
-	"bytes"
 	"fmt"
 	"sync"
 
@@ -22,7 +21,7 @@ func getKernelVersion() (*KernelVersion, error) {
 			return
 		}
 		// Remove the \x00 from the release for Atoi to parse correctly
-		currentKernelVersion, kernelVersionError = parseRelease(string(uts.Release[:bytes.IndexByte(uts.Release[:], 0)]))
+		currentKernelVersion, kernelVersionError = parseRelease(unix.ByteSliceToString(uts.Release[:]))
 	})
 	return currentKernelVersion, kernelVersionError
 }


### PR DESCRIPTION
This also fixes the GetOperatingSystem function in
pkg/parsers/operatingsystem which mistakenly truncated utsname.Machine
to the \0 in utsname.Sysname.

Fixes: 7aeb3efcb40c907e9d19cd75bac2ad88aaf7fa19 (#39849)
