### PR TITLE
Annotate some swagger documented types as int64

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -771,11 +771,13 @@ definitions:
           The time to wait between checks in nanoseconds. It should be 0 or at
           least 1000000 (1 ms). 0 means inherit.
         type: "integer"
+        format: "int64"
       Timeout:
         description: |
           The time to wait before considering the check to have hung. It should
           be 0 or at least 1000000 (1 ms). 0 means inherit.
         type: "integer"
+        format: "int64"
       Retries:
         description: |
           The number of consecutive failures needed to consider a container as
@@ -787,6 +789,7 @@ definitions:
           health-retries countdown in nanoseconds. It should be 0 or at least
           1000000 (1 ms). 0 means inherit.
         type: "integer"
+        format: "int64"
 
   Health:
     description: |
@@ -1625,7 +1628,7 @@ definitions:
           List of image names/tags in the local image cache that reference this
           image.
 
-          Multiple image tags can refer to the same imagem and this list may be
+          Multiple image tags can refer to the same image, and this list may be
           empty if no tags reference the image, in which case the image is
           "untagged", in which case it can still be referenced by its ID.
         type: "array"
@@ -1826,7 +1829,7 @@ definitions:
           List of image names/tags in the local image cache that reference this
           image.
 
-          Multiple image tags can refer to the same imagem and this list may be
+          Multiple image tags can refer to the same image, and this list may be
           empty if no tags reference the image, in which case the image is
           "untagged", in which case it can still be referenced by its ID.
         type: "array"
@@ -1876,6 +1879,7 @@ definitions:
           This size is not calculated by default. `-1` indicates that the value
           has not been set / calculated.
         type: "integer"
+        format: "int64"
         x-nullable: false
         example: 1239828
       VirtualSize:
@@ -2023,6 +2027,7 @@ definitions:
         properties:
           Size:
             type: "integer"
+            format: "int64"
             default: -1
             description: |
               Amount of disk space used by the volume (in bytes). This information
@@ -2032,6 +2037,7 @@ definitions:
             x-nullable: false
           RefCount:
             type: "integer"
+            format: "int64"
             default: -1
             description: |
               The number of containers referencing this volume. This field
@@ -4655,6 +4661,7 @@ definitions:
       StatusCode:
         description: "Exit code of the container"
         type: "integer"
+        format: "int64"
         x-nullable: false
       Error:
         $ref: "#/definitions/ContainerWaitExitError"

--- a/api/types/image_summary.go
+++ b/api/types/image_summary.go
@@ -61,7 +61,7 @@ type ImageSummary struct {
 	// List of image names/tags in the local image cache that reference this
 	// image.
 	//
-	// Multiple image tags can refer to the same imagem and this list may be
+	// Multiple image tags can refer to the same image, and this list may be
 	// empty if no tags reference the image, in which case the image is
 	// "untagged", in which case it can still be referenced by its ID.
 	//

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -48,7 +48,7 @@ type ImageInspect struct {
 	// RepoTags is a list of image names/tags in the local image cache that
 	// reference this image.
 	//
-	// Multiple image tags can refer to the same imagem and this list may be
+	// Multiple image tags can refer to the same image, and this list may be
 	// empty if no tags reference the image, in which case the image is
 	// "untagged", in which case it can still be referenced by its ID.
 	RepoTags []string

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -773,11 +773,13 @@ definitions:
           The time to wait between checks in nanoseconds. It should be 0 or at
           least 1000000 (1 ms). 0 means inherit.
         type: "integer"
+        format: "int64"
       Timeout:
         description: |
           The time to wait before considering the check to have hung. It should
           be 0 or at least 1000000 (1 ms). 0 means inherit.
         type: "integer"
+        format: "int64"
       Retries:
         description: |
           The number of consecutive failures needed to consider a container as
@@ -789,6 +791,7 @@ definitions:
           health-retries countdown in nanoseconds. It should be 0 or at least
           1000000 (1 ms). 0 means inherit.
         type: "integer"
+        format: "int64"
 
   Health:
     description: |
@@ -1107,6 +1110,7 @@ definitions:
               remapping option is enabled.
           ShmSize:
             type: "integer"
+            format: "int64"
             description: |
               Size of `/dev/shm` in bytes. If omitted, the system uses 64MB.
             minimum: 0
@@ -1627,7 +1631,7 @@ definitions:
           List of image names/tags in the local image cache that reference this
           image.
 
-          Multiple image tags can refer to the same imagem and this list may be
+          Multiple image tags can refer to the same image, and this list may be
           empty if no tags reference the image, in which case the image is
           "untagged", in which case it can still be referenced by its ID.
         type: "array"
@@ -1828,7 +1832,7 @@ definitions:
           List of image names/tags in the local image cache that reference this
           image.
 
-          Multiple image tags can refer to the same imagem and this list may be
+          Multiple image tags can refer to the same image, and this list may be
           empty if no tags reference the image, in which case the image is
           "untagged", in which case it can still be referenced by its ID.
         type: "array"
@@ -1878,6 +1882,7 @@ definitions:
           This size is not calculated by default. `-1` indicates that the value
           has not been set / calculated.
         type: "integer"
+        format: "int64"
         x-nullable: false
         example: 1239828
       VirtualSize:
@@ -2022,6 +2027,7 @@ definitions:
         properties:
           Size:
             type: "integer"
+            format: "int64"
             default: -1
             description: |
               Amount of disk space used by the volume (in bytes). This information
@@ -2031,6 +2037,7 @@ definitions:
             x-nullable: false
           RefCount:
             type: "integer"
+            format: "int64"
             default: -1
             description: |
               The number of containers referencing this volume. This field
@@ -4632,6 +4639,7 @@ definitions:
       StatusCode:
         description: "Exit code of the container"
         type: "integer"
+        format: "int64"
         x-nullable: false
       Error:
         $ref: "#/definitions/ContainerWaitExitError"


### PR DESCRIPTION
Using the swagger.yaml to generate api models will create incompatible field types. Some inconsistencies had already been mentioned at #39131. I've added more fixes from real life experience, some only occurring on Windows.

Closes #39131

Signed-off-by: Tobias Gesellchen <tobias@gesellix.de>

**- What I did**

The following types documented in api/swagger.yaml and docs/api/v1.41.yaml have been adjusted to match the types in the Golang model:

- [container.HealthConfig.Interval](https://github.com/moby/moby/blob/8abb84c7342a19009d777ef3d871c0b2a5c032a5/api/types/container/config.go#L46-L48
)
- [container.HealthConfig.Timeout](https://github.com/moby/moby/blob/8abb84c7342a19009d777ef3d871c0b2a5c032a5/api/types/container/config.go#L46-L48
)
- [container.HealthConfig.StartPeriod](https://github.com/moby/moby/blob/8abb84c7342a19009d777ef3d871c0b2a5c032a5/api/types/container/config.go#L46-L48
)
- [container.WaitResponse.StatusCode](https://github.com/gesellix/moby/blob/8abb84c7342a19009d777ef3d871c0b2a5c032a5/api/types/container/wait_response.go#L18)
- [types.ImageSummary.SharedSize](https://github.com/moby/moby/blob/8abb84c7342a19009d777ef3d871c0b2a5c032a5/api/types/image_summary.go#L78)
- [volume.UsageData.Size](https://github.com/moby/moby/blob/8abb84c7342a19009d777ef3d871c0b2a5c032a5/api/types/volume/volume.go#L62-L74)
- [volume.UsageData.RefCount](https://github.com/moby/moby/blob/8abb84c7342a19009d777ef3d871c0b2a5c032a5/api/types/volume/volume.go#L62-L74)

**- How I did it**

Changed the swagger.yaml and v1.41.yaml, compared with moby's Golang types (didn't check any older api versions).

**- How to verify it**

See the list above, with each entry linking to the Golang source for easier comparison.

**- Description for the changelog**

Annotate some Swagger documented types as int64, matching the Golang types.

**- A picture of a cute animal (not mandatory but encouraged)**

![ladybug](https://user-images.githubusercontent.com/432791/169714561-593d93dd-b6c5-47a3-be74-2aa7a3861bc1.jpg)
