### PR TITLE
integration: Add logs tests

### DIFF
--- a/daemon/logger/local/read_test.go
+++ b/daemon/logger/local/read_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 func TestDecode(t *testing.T) {
-	marshal := makeMarshaller()
+	buf := make([]byte, 0)
 
-	buf, err := marshal(&logger.Message{Line: []byte("hello")})
+	err := marshal(&logger.Message{Line: []byte("hello")}, &buf)
 	assert.NilError(t, err)
 
 	for i := 0; i < len(buf); i++ {

--- a/daemon/logger/logger.go
+++ b/daemon/logger/logger.go
@@ -131,6 +131,3 @@ type Capability struct {
 	// Determines if a log driver can read back logs
 	ReadLogs bool
 }
-
-// MarshalFunc is a func that marshals a message into an arbitrary format
-type MarshalFunc func(*Message) ([]byte, error)

--- a/integration/container/logs_test.go
+++ b/integration/container/logs_test.go
@@ -1,14 +1,17 @@
 package container // import "github.com/docker/docker/integration/container"
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/pkg/stdcopy"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
 
@@ -31,4 +34,136 @@ func TestLogsFollowTailEmpty(t *testing.T) {
 
 	_, err = stdcopy.StdCopy(io.Discard, io.Discard, logs)
 	assert.Check(t, err)
+}
+
+// Containers without the Tty have their stdout and stderr muxed
+// into one stream with stdcopy
+func TestLogsMuxed(t *testing.T) {
+	defer setupTest(t)()
+	client := testEnv.APIClient()
+	ctx := context.Background()
+
+	testCases := []struct {
+		desc        string
+		logOps      types.ContainerLogsOptions
+		expectedOut string
+		expectedErr string
+	}{
+		{
+			desc: "stdout and stderr",
+			logOps: types.ContainerLogsOptions{
+				ShowStdout: true,
+				ShowStderr: true,
+			},
+			expectedOut: "this is fine",
+			expectedErr: "accidents happen",
+		},
+		{
+			desc: "only stdout",
+			logOps: types.ContainerLogsOptions{
+				ShowStdout: true,
+				ShowStderr: false,
+			},
+			expectedOut: "this is fine",
+			expectedErr: "",
+		},
+		{
+			desc: "only stderr",
+			logOps: types.ContainerLogsOptions{
+				ShowStdout: false,
+				ShowStderr: true,
+			},
+			expectedOut: "",
+			expectedErr: "accidents happen",
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			id := container.Run(ctx, t, client,
+				container.WithTty(false), // Stream is muxed when not TTY
+				container.WithCmd("sh", "-c", "echo -n this is fine; echo -n accidents happen >&2"),
+			)
+			defer client.ContainerRemove(ctx, id, types.ContainerRemoveOptions{Force: true})
+
+			poll.WaitOn(t, container.IsStopped(ctx, client, id), poll.WithDelay(time.Millisecond*100))
+
+			logs, err := client.ContainerLogs(ctx, id, tC.logOps)
+			if logs != nil {
+				defer logs.Close()
+			}
+			assert.NilError(t, err)
+
+			stderr := new(bytes.Buffer)
+			stdout := new(bytes.Buffer)
+
+			_, err = stdcopy.StdCopy(stdout, stderr, logs)
+			assert.NilError(t, err)
+			assert.Equal(t, stdout.String(), tC.expectedOut)
+			assert.Equal(t, stderr.String(), tC.expectedErr)
+		})
+	}
+
+}
+
+// Containers with tty have their stdout and stderr both redirected to one output stream
+// This makes all the logs saved as they were printed to stdout
+func TestLogsNotMuxed(t *testing.T) {
+	defer setupTest(t)()
+	client := testEnv.APIClient()
+	ctx := context.Background()
+
+	testCases := []struct {
+		desc           string
+		logOps         types.ContainerLogsOptions
+		expectedOutput string
+	}{
+		{
+			desc: "stdout and stderr",
+			logOps: types.ContainerLogsOptions{
+				ShowStdout: true,
+				ShowStderr: true,
+			},
+			expectedOutput: "this is fineaccidents happen",
+		},
+		{
+			desc: "only stdout",
+			logOps: types.ContainerLogsOptions{
+				ShowStdout: true,
+				ShowStderr: false,
+			},
+			expectedOutput: "this is fineaccidents happen",
+		},
+		{
+			desc: "only stderr",
+			logOps: types.ContainerLogsOptions{
+				ShowStdout: false,
+				ShowStderr: true,
+			},
+			expectedOutput: "",
+		},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			id := container.Run(ctx, t, client,
+				container.WithTty(true), // Stream is only stdout when TTY
+				container.WithCmd("sh", "-c", "echo -n this is fine; echo -n accidents happen >&2"),
+			)
+			defer client.ContainerRemove(ctx, id, types.ContainerRemoveOptions{Force: true})
+
+			poll.WaitOn(t, container.IsStopped(ctx, client, id), poll.WithDelay(time.Millisecond*100))
+
+			logs, err := client.ContainerLogs(ctx, id, tC.logOps)
+			if logs != nil {
+				defer logs.Close()
+			}
+			assert.Check(t, err)
+
+			out := new(bytes.Buffer)
+
+			_, err = io.Copy(out, logs)
+			assert.NilError(t, err)
+			assert.Equal(t, out.String(), tC.expectedOutput)
+		})
+	}
 }


### PR DESCRIPTION
Added integration tests for ContainerLogs.

Each test handle a distinct case of ContainerLogs output.
- Muxed stream, when container is started without tty
- Single stream, when container is started with tty

**- How to verify it**
```make BIND_DIR=. TEST_FILTER='TestLogs' test-integration```

**- A picture of a cute animal (not mandatory but encouraged)**
