### PR TITLE
[20.10 backport] Fix for Windows port conflict with published ports in host mode for overlay.

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-: "${LIBNETWORK_COMMIT:=339b972b464ee3d401b5788b2af9e31d09d6b7da}"
+: "${LIBNETWORK_COMMIT:=2dab5620d4462865c6151e573b3e7fa5d3b8458b}"
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -47,7 +47,7 @@ github.com/grpc-ecosystem/go-grpc-middleware        3c51f7f332123e8be5a157c0802a
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        339b972b464ee3d401b5788b2af9e31d09d6b7da
+github.com/docker/libnetwork                        2dab5620d4462865c6151e573b3e7fa5d3b8458b
 github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,5 @@
 github.com/Azure/go-ansiterm                        d6e3b3328b783f23731bc4d058875b0371ff8109
-github.com/Microsoft/hcsshim                        64a2b71405dacf76c95600f4c756a991ad09cf7c # moby branch
+github.com/Microsoft/hcsshim                        a11a2c44e8a4aa9d66314b1d759ef582df5ab5e8 # moby branch
 github.com/Microsoft/go-winio                       7e149e8c70409f36773c1b2cf3447a7ab7697368 # v0.4.20
 github.com/docker/libtrust                          9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/golang/gddo                              72a348e765d293ed6d1ded7b699591f14d6cd921

--- a/vendor/github.com/Microsoft/hcsshim/internal/hns/hnspolicy.go
+++ b/vendor/github.com/Microsoft/hcsshim/internal/hns/hnspolicy.go
@@ -21,10 +21,11 @@ const (
 )
 
 type NatPolicy struct {
-	Type         PolicyType `json:"Type"`
-	Protocol     string
-	InternalPort uint16
-	ExternalPort uint16
+	Type                 PolicyType `json:"Type"`
+	Protocol             string
+	InternalPort         uint16
+	ExternalPort         uint16
+	ExternalPortReserved bool       `json:",omitempty"`
 }
 
 type QosPolicy struct {

--- a/vendor/github.com/docker/libnetwork/drivers/windows/windows.go
+++ b/vendor/github.com/docker/libnetwork/drivers/windows/windows.go
@@ -493,10 +493,11 @@ func ConvertPortBindings(portBindings []types.PortBinding) ([]json.RawMessage, e
 		}
 
 		encodedPolicy, err := json.Marshal(hcsshim.NatPolicy{
-			Type:         "NAT",
-			ExternalPort: elem.HostPort,
-			InternalPort: elem.Port,
-			Protocol:     elem.Proto.String(),
+			Type:                 "NAT",
+			ExternalPort:         elem.HostPort,
+			InternalPort:         elem.Port,
+			Protocol:             elem.Proto.String(),
+			ExternalPortReserved: true,
 		})
 
 		if err != nil {

--- a/vendor/github.com/docker/libnetwork/vendor.conf
+++ b/vendor/github.com/docker/libnetwork/vendor.conf
@@ -2,7 +2,7 @@ github.com/Azure/go-ansiterm                        d6e3b3328b783f23731bc4d05887
 github.com/BurntSushi/toml                          3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
 github.com/containerd/cgroups                       318312a373405e5e91134d8063d04d59768a1bff
 github.com/Microsoft/go-winio                       6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
-github.com/Microsoft/hcsshim                        9dcb42f100215f8d375b4a9265e5bba009217a85 # moby branch
+github.com/Microsoft/hcsshim                        a11a2c44e8a4aa9d66314b1d759ef582df5ab5e8 # moby branch
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/coreos/etcd                              d57e8b8d97adfc4a6c224fe116714bf1a1f3beb9 # v3.3.12


### PR DESCRIPTION
Backporting: https://github.com/moby/moby/pull/43634

Vendoring libnetwork for moby/libnetwork#2658
Full libnetwork diff: 
https://github.com/moby/libnetwork/compare/339b972b464ee3d401b5788b2af9e31d09d6b7da...2dab5620d4462865c6151e573b3e7fa5d3b8458b

Vendoring moby branch hcsshim for https://github.com/microsoft/hcsshim/pull/1371
Full hcsshim diff: https://github.com/microsoft/hcsshim/compare/64a2b71405dacf76c95600f4c756a991ad09cf7c...a11a2c44e8a4aa9d66314b1d759ef582df5ab5e8

