### PR TITLE
api: swagger: Adjust ContainerWaitResponse error as optional

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4656,7 +4656,7 @@ definitions:
     type: "object"
     x-go-name: "WaitResponse"
     title: "ContainerWaitResponse"
-    required: [StatusCode, Error]
+    required: [StatusCode]
     properties:
       StatusCode:
         description: "Exit code of the container"

--- a/api/types/container/wait_response.go
+++ b/api/types/container/wait_response.go
@@ -10,8 +10,7 @@ package container
 type WaitResponse struct {
 
 	// error
-	// Required: true
-	Error *WaitExitError `json:"Error"`
+	Error *WaitExitError `json:"Error,omitempty"`
 
 	// Exit code of the container
 	// Required: true

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -4336,7 +4336,7 @@ definitions:
     type: "object"
     x-go-name: "ContainerWaitOKBody"
     title: "ContainerWaitResponse"
-    required: [StatusCode, Error]
+    required: [StatusCode]
     properties:
       StatusCode:
         description: "Exit code of the container"

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -4461,7 +4461,7 @@ definitions:
     type: "object"
     x-go-name: "ContainerWaitOKBody"
     title: "ContainerWaitResponse"
-    required: [StatusCode, Error]
+    required: [StatusCode]
     properties:
       StatusCode:
         description: "Exit code of the container"

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -4634,7 +4634,7 @@ definitions:
     type: "object"
     x-go-name: "ContainerWaitOKBody"
     title: "ContainerWaitResponse"
-    required: [StatusCode, Error]
+    required: [StatusCode]
     properties:
       StatusCode:
         description: "Exit code of the container"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Removed the `required` API swagger flag on the `ContainerWaitResponse` type `Error` property

**- How I did it**
Amended API 1.39, 1.40, 1.41 and the future swagger for 1.42 YAML description to remove the `required` flag

**- How to verify it**
Generated types for the [Bollard](https://github.com/fussybeaver/bollard) docker client and ran integration tests on the new types.

**- Description for the changelog**
Removed the `required` field in the swagger documentation for the `ContainerWaitResponse` `Error` property. 

fixes #43655 


**- A picture of a cute animal (not mandatory but encouraged)**

