### PR TITLE
integration: TestPingSwarmHeader(): fix incorrect ping, and cleanup

### DIFF
--- a/integration/system/ping_test.go
+++ b/integration/system/ping_test.go
@@ -66,30 +66,30 @@ func TestPingSwarmHeader(t *testing.T) {
 	ctx := context.TODO()
 
 	t.Run("before swarm init", func(t *testing.T) {
-		res, _, err := request.Get("/_ping")
+		p, err := client.Ping(ctx)
 		assert.NilError(t, err)
-		assert.Equal(t, res.StatusCode, http.StatusOK)
-		assert.Equal(t, hdr(res, "Swarm"), "inactive")
+		assert.Equal(t, p.SwarmStatus.NodeState, swarm.LocalNodeStateInactive)
+		assert.Equal(t, p.SwarmStatus.ControlAvailable, false)
 	})
 
 	_, err := client.SwarmInit(ctx, swarm.InitRequest{ListenAddr: "127.0.0.1", AdvertiseAddr: "127.0.0.1:2377"})
 	assert.NilError(t, err)
 
 	t.Run("after swarm init", func(t *testing.T) {
-		res, _, err := request.Get("/_ping", request.Host(d.Sock()))
+		p, err := client.Ping(ctx)
 		assert.NilError(t, err)
-		assert.Equal(t, res.StatusCode, http.StatusOK)
-		assert.Equal(t, hdr(res, "Swarm"), "active/manager")
+		assert.Equal(t, p.SwarmStatus.NodeState, swarm.LocalNodeStateActive)
+		assert.Equal(t, p.SwarmStatus.ControlAvailable, true)
 	})
 
 	err = client.SwarmLeave(ctx, true)
 	assert.NilError(t, err)
 
 	t.Run("after swarm leave", func(t *testing.T) {
-		res, _, err := request.Get("/_ping", request.Host(d.Sock()))
+		p, err := client.Ping(ctx)
 		assert.NilError(t, err)
-		assert.Equal(t, res.StatusCode, http.StatusOK)
-		assert.Equal(t, hdr(res, "Swarm"), "inactive")
+		assert.Equal(t, p.SwarmStatus.NodeState, swarm.LocalNodeStateInactive)
+		assert.Equal(t, p.SwarmStatus.ControlAvailable, false)
 	})
 }
 


### PR DESCRIPTION
- introduced in https://github.com/moby/moby/pull/42064

While working on https://github.com/moby/moby/pull/43657, I noticed I made a mistake in the first ping ("before swarm init"), which was not specifying the daemon's socket path and because of that testing against the main integration daemon (not the locally spun up daemon).

While fixing that, I wondered why the test didn't actually use the client for the requests (to also verify the client converted the response), so I rewrote the test to use `client.Ping()` and to verify the ping response has the expected values set.


```bash
make BIND_DIR=. TEST_FILTER=TestPingSwarmHeader DOCKER_GRAPHDRIVER=vfs test-integration
...
=== RUN   TestPingSwarmHeader
=== RUN   TestPingSwarmHeader/before_swarm_init
=== RUN   TestPingSwarmHeader/after_swarm_init
=== RUN   TestPingSwarmHeader/after_swarm_leave
--- PASS: TestPingSwarmHeader (2.75s)
    --- PASS: TestPingSwarmHeader/before_swarm_init (0.00s)
    --- PASS: TestPingSwarmHeader/after_swarm_init (0.00s)
    --- PASS: TestPingSwarmHeader/after_swarm_leave (0.00s)
PASS
```



**- A picture of a cute animal (not mandatory but encouraged)**

