### PR TITLE
WIP: update buildkit adapters to support hardlink merges.

### DIFF
--- a/daemon/graphdriver/fsdiff.go
+++ b/daemon/graphdriver/fsdiff.go
@@ -4,10 +4,12 @@ import (
 	"io"
 	"time"
 
+	ctdmount "github.com/containerd/containerd/mount"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/ioutils"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -169,4 +171,18 @@ func (gdw *NaiveDiffDriver) DiffSize(id, parent string) (size int64, err error) 
 	defer driver.Put(id)
 
 	return archive.ChangesSize(layerFs.Path(), changes), nil
+}
+
+func (gdw *NaiveDiffDriver) GetDirectMounts(id, mountLabel string) ([]ctdmount.Mount, error) {
+	if gdw, ok := gdw.ProtoDriver.(DirectMountDriver); ok {
+		return gdw.GetDirectMounts(id, mountLabel)
+	}
+	return nil, errors.New("driver does not support GetDirectMounts")
+}
+
+func (gdw *NaiveDiffDriver) PutDirectMounts(id string) error {
+	if gdw, ok := gdw.ProtoDriver.(DirectMountDriver); ok {
+		return gdw.PutDirectMounts(id)
+	}
+	return errors.New("driver does not support PutDirectMounts")
 }


### PR DESCRIPTION
BuildKit's mergeop implementation relies on inspecting mount options in
order to implement the optimization where merged directories are created
using hardlinks from source files instead of copies. This is needed in
the overlay case to ensure that hardlinks are made from underlying
lowerdirs rather than from already mounted overlays.

The main difficulty is that the graphdriver model creates mounts for
callers and then just expects that they bind mount that somewhere, which
is a significant deviation from the containerd model BuildKit uses where
mount options are returned and callers are expected to mount those
themselves.

This update is a quite ugly but solves the problem by bolting on methods
to the relevant graphdriver implementations that enable retrieving mount
options directly instead of having the mounts be made on the callers
behalf.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

---

Ref: #43415

cc @tonistiigi @crazy-max 

Rebased and did some minor cleanups (though overall the change is still quite ugly). This worked last time I tried, but when I was just trying to test again using the buildkit integ tests I was getting failures with the error `failed to compute cache key: unlazy requires an applier`. Is that a known issue? It seems unrelated to my exact change here, but not sure. Haven't dug in yet.

Either way, let me know if the change here is worth cleaning up more. Like I said in the commit message, it's quite ugly. Open to suggestions on other approaches (though I am limited in the time I can spend on this so updates may take a while).