### PR TITLE
daemon/logger: Driver-scope buffer pools, bigger buffers

### DIFF
--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -20,12 +20,18 @@ import (
 // Name is the name of the file that the jsonlogger logs to.
 const Name = "json-file"
 
+// Every buffer will have to store the same constant json structure with the message
+// len(`{"log":"","stream:"stdout","time":"2000-01-01T00:00:00.000000000Z"}\n`) = 68.
+// So let's start with a buffer bigger than this.
+const initialBufSize = 128
+
+var buffersPool = sync.Pool{New: func() interface{} { return bytes.NewBuffer(make([]byte, 0, initialBufSize)) }}
+
 // JSONFileLogger is Logger implementation for default Docker logging.
 type JSONFileLogger struct {
-	writer      *loggerutils.LogFile
-	tag         string // tag values requested by the user to log
-	extra       json.RawMessage
-	buffersPool sync.Pool
+	writer *loggerutils.LogFile
+	tag    string // tag values requested by the user to log
+	extra  json.RawMessage
 }
 
 func init() {
@@ -104,28 +110,18 @@ func New(info logger.Info) (logger.Logger, error) {
 	}
 
 	return &JSONFileLogger{
-		writer:      writer,
-		tag:         tag,
-		extra:       extra,
-		buffersPool: makePool(),
+		writer: writer,
+		tag:    tag,
+		extra:  extra,
 	}, nil
-}
-
-func makePool() sync.Pool {
-	// Every buffer will have to store the same constant json structure and the message
-	// len(`{"log":"","stream:"stdout","time":"2000-01-01T00:00:00.000000000Z"}\n`) = 68
-	// So let's start with a buffer bigger than this
-	const initialBufSize = 128
-
-	return sync.Pool{New: func() interface{} { return bytes.NewBuffer(make([]byte, 0, initialBufSize)) }}
 }
 
 // Log converts logger.Message to jsonlog.JSONLog and serializes it to file.
 func (l *JSONFileLogger) Log(msg *logger.Message) error {
 	defer logger.PutMessage(msg)
-	buf := l.buffersPool.Get().(*bytes.Buffer)
+	buf := buffersPool.Get().(*bytes.Buffer)
 	buf.Reset()
-	defer l.buffersPool.Put(buf)
+	defer buffersPool.Put(buf)
 
 	if err := marshalMessage(msg, l.extra, buf); err != nil {
 		return err

--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -118,16 +118,19 @@ func New(info logger.Info) (logger.Logger, error) {
 
 // Log converts logger.Message to jsonlog.JSONLog and serializes it to file.
 func (l *JSONFileLogger) Log(msg *logger.Message) error {
-	defer logger.PutMessage(msg)
 	buf := buffersPool.Get().(*bytes.Buffer)
 	buf.Reset()
 	defer buffersPool.Put(buf)
 
-	if err := marshalMessage(msg, l.extra, buf); err != nil {
+	timestamp := msg.Timestamp
+	err := marshalMessage(msg, l.extra, buf)
+	logger.PutMessage(msg)
+
+	if err != nil {
 		return err
 	}
 
-	return l.writer.WriteLogEntry(msg.Timestamp, buf.Bytes())
+	return l.writer.WriteLogEntry(timestamp, buf.Bytes())
 }
 
 func marshalMessage(msg *logger.Message, extra json.RawMessage, buf *bytes.Buffer) error {

--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -23,7 +23,7 @@ const Name = "json-file"
 // Every buffer will have to store the same constant json structure with the message
 // len(`{"log":"","stream:"stdout","time":"2000-01-01T00:00:00.000000000Z"}\n`) = 68.
 // So let's start with a buffer bigger than this.
-const initialBufSize = 128
+const initialBufSize = 256
 
 var buffersPool = sync.Pool{New: func() interface{} { return bytes.NewBuffer(make([]byte, 0, initialBufSize)) }}
 

--- a/daemon/logger/local/local.go
+++ b/daemon/logger/local/local.go
@@ -3,6 +3,7 @@ package local // import "github.com/docker/docker/daemon/logger/local"
 import (
 	"encoding/binary"
 	"io"
+	"math/bits"
 	"strconv"
 	"sync"
 	"time"
@@ -110,7 +111,11 @@ func marshal(m *logger.Message, buffer *[]byte) error {
 
 	buf := *buffer
 	if writeLen > cap(buf) {
-		buf = make([]byte, writeLen)
+		// If we already need to reallocate the buffer, make it larger to be more reusable.
+		// Round to the next power of two.
+		capacity := 1 << (bits.Len(uint(writeLen)) + 1)
+
+		buf = make([]byte, writeLen, capacity)
 	} else {
 		buf = buf[:writeLen]
 	}

--- a/daemon/logger/local/local.go
+++ b/daemon/logger/local/local.go
@@ -147,15 +147,17 @@ func (d *driver) Name() string {
 }
 
 func (d *driver) Log(msg *logger.Message) error {
-	defer logger.PutMessage(msg)
 	buf := buffersPool.Get().(*[]byte)
 	defer buffersPool.Put(buf)
 
+	timestamp := msg.Timestamp
 	err := marshal(msg, buf)
+	logger.PutMessage(msg)
+
 	if err != nil {
 		return errors.Wrap(err, "error marshalling logger.Message")
 	}
-	return d.logfile.WriteLogEntry(msg.Timestamp, *buf)
+	return d.logfile.WriteLogEntry(timestamp, *buf)
 }
 
 func (d *driver) Close() error {


### PR DESCRIPTION
Follow up to:
- https://github.com/moby/moby/pull/43650

Addressed review comments from @corhere - thank you!

**- What I did**
- Moved the pools to be global inside the driver, instead of individual per each logger instance
- Increased initial buffer size
- Moved the PutMessage from defer to the line after message is marshalled.

**- A picture of a cute animal (not mandatory but encouraged)**

