### PR TITLE
ci(windows): upload test reports with logs

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -178,10 +178,10 @@ jobs:
           flags: unit
       -
         name: Upload reports
-        if: matrix.os == 'windows-2022'
+        if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: unit-reports
+          name: ${{ matrix.os }}-unit-reports
           path: ${{ env.GOPATH }}\src\github.com\docker\docker\bundles\*
 
   integration-test:
@@ -223,6 +223,7 @@ jobs:
       -
         name: Init
         run: |
+          New-Item -ItemType "directory" -Path "bundles"
           If ("${{ matrix.os }}" -eq "windows-2019") {
             echo "WINDOWS_BASE_IMAGE_TAG=${{ env.WINDOWS_BASE_TAG_2019 }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           } ElseIf ("${{ matrix.os }}" -eq "windows-2022") {
@@ -348,11 +349,16 @@ jobs:
       -
         name: Test CLI
         run: |
-          & gotestsum --format=standard-verbose --packages="./integration-cli/..." -- `
-            "-coverprofile" "./bundles/coverage-report-int-cli-tests.txt" `
-            "-covermode" "atomic" `
-            "-tags" "autogen" `
-            "-test.timeout" "200m"
+          & gotestsum `
+            --format=standard-verbose `
+            --jsonfile="./bundles/go-test-report-int-cli-tests.json" `
+            --junitfile="./bundles/junit-report-int-cli-tests.xml" `
+            --packages="./integration-cli/..." `
+            -- `
+              "-coverprofile" "./bundles/coverage-report-int-cli-tests.txt" `
+              "-covermode" "atomic" `
+              "-tags" "autogen" `
+              "-test.timeout" "200m"
         env:
           DOCKER_HOST: npipe:////./pipe/docker_engine
           GO111MODULE: "off"
@@ -366,13 +372,6 @@ jobs:
           directory: bundles
           env_vars: RUNNER_OS
           flags: integration,${{ matrix.runtime }}
-      -
-        name: Upload reports
-        if: matrix.os == 'windows-2022'
-        uses: actions/upload-artifact@v3
-        with:
-          name: integration-reports-${{ matrix.runtime }}
-          path: ${{ env.GOPATH }}\src\github.com\docker\docker\bundles\*
       -
         name: Docker info
         run: |
@@ -390,6 +389,7 @@ jobs:
         name: Containerd logs
         if: always() && matrix.runtime == 'containerd'
         run: |
+          Copy-Item "$env:TEMP\ctn.log" -Destination ".\bundles\containerd.log"
           Get-Content "$env:TEMP\ctn.log" | Out-Host
       -
         name: Stop daemon
@@ -408,4 +408,11 @@ jobs:
             -FilterHashtable @{ProviderName= "docker"; LogName = "application"} |
               Select-Object -Property TimeCreated, @{N='Detailed Message'; E={$_.Message}} |
               Sort-Object @{Expression="TimeCreated";Descending=$false} |
-              Select-Object -ExpandProperty 'Detailed Message'
+              Select-Object -ExpandProperty 'Detailed Message' | Tee-Object -file ".\bundles\daemon.log"
+      -
+        name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.os }}-integration-reports-${{ matrix.runtime }}
+          path: ${{ env.GOPATH }}\src\github.com\docker\docker\bundles\*


### PR DESCRIPTION
As discussed with @thaJeztah, before disabling Windows nodes on Jenkins we need to keep logs in uploaded reports.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>