### PR TITLE
fix unclosed file-handles in tests

### DIFF
--- a/daemon/graphdriver/driver_test.go
+++ b/daemon/graphdriver/driver_test.go
@@ -28,8 +28,9 @@ func TestIsEmptyDir(t *testing.T) {
 	d = filepath.Join(tmp, "dir-with-empty-file")
 	err = os.Mkdir(d, 0755)
 	assert.NilError(t, err)
-	_, err = os.CreateTemp(d, "file")
+	f, err := os.CreateTemp(d, "file")
 	assert.NilError(t, err)
+	defer f.Close()
 	empty = isEmptyDir(d)
 	assert.Check(t, !empty)
 }

--- a/daemon/trustkey_test.go
+++ b/daemon/trustkey_test.go
@@ -18,6 +18,7 @@ func TestLoadOrCreateTrustKeyInvalidKeyFile(t *testing.T) {
 
 	tmpKeyFile, err := os.CreateTemp(tmpKeyFolderPath, "keyfile")
 	assert.NilError(t, err)
+	defer tmpKeyFile.Close()
 
 	_, err = loadOrCreateTrustKey(tmpKeyFile.Name())
 	assert.Check(t, is.ErrorContains(err, "Error loading key file"))

--- a/pkg/directory/directory_test.go
+++ b/pkg/directory/directory_test.go
@@ -35,6 +35,7 @@ func TestSizeEmptyFile(t *testing.T) {
 	if file, err = os.CreateTemp(dir, "file"); err != nil {
 		t.Fatalf("failed to create file: %s", err)
 	}
+	defer file.Close()
 
 	var size int64
 	if size, _ = Size(context.Background(), file.Name()); size != 0 {
@@ -54,6 +55,7 @@ func TestSizeNonemptyFile(t *testing.T) {
 	if file, err = os.CreateTemp(dir, "file"); err != nil {
 		t.Fatalf("failed to create file: %s", err)
 	}
+	defer file.Close()
 
 	d := []byte{97, 98, 99, 100, 101}
 	file.Write(d)
@@ -96,6 +98,7 @@ func TestSizeFileAndNestedDirectoryEmpty(t *testing.T) {
 	if file, err = os.CreateTemp(dir, "file"); err != nil {
 		t.Fatalf("failed to create file: %s", err)
 	}
+	defer file.Close()
 
 	d := []byte{100, 111, 99, 107, 101, 114}
 	file.Write(d)
@@ -121,6 +124,7 @@ func TestSizeFileAndNestedDirectoryNonempty(t *testing.T) {
 	if file, err = os.CreateTemp(dir, "file"); err != nil {
 		t.Fatalf("failed to create file: %s", err)
 	}
+	defer file.Close()
 
 	data := []byte{100, 111, 99, 107, 101, 114}
 	file.Write(data)
@@ -129,6 +133,7 @@ func TestSizeFileAndNestedDirectoryNonempty(t *testing.T) {
 	if nestedFile, err = os.CreateTemp(dirNested, "file"); err != nil {
 		t.Fatalf("failed to create file in nested directory: %s", err)
 	}
+	defer nestedFile.Close()
 
 	nestedData := []byte{100, 111, 99, 107, 101, 114}
 	nestedFile.Write(nestedData)

--- a/volume/service/db_test.go
+++ b/volume/service/db_test.go
@@ -22,6 +22,7 @@ func TestSetGetMeta(t *testing.T) {
 	assert.NilError(t, err)
 
 	store := &VolumeStore{db: db}
+	defer store.Shutdown()
 
 	_, err = store.getMeta("test")
 	assert.Assert(t, is.ErrorContains(err, ""))

--- a/volume/service/restore_test.go
+++ b/volume/service/restore_test.go
@@ -40,6 +40,7 @@ func TestRestore(t *testing.T) {
 
 	s, err = NewStore(dir, drivers)
 	assert.NilError(t, err)
+	defer s.Shutdown()
 
 	v, err := s.Get(ctx, "test1")
 	assert.NilError(t, err)

--- a/volume/service/store_test.go
+++ b/volume/service/store_test.go
@@ -121,6 +121,7 @@ func TestList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer s.Shutdown()
 	ls, _, err = s.Find(ctx, nil)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/43346

Found these while working on https://github.com/moby/moby/pull/43346, and while our current tests don't show these errors (we likely ignore failures in most cases), it's possible these could be causing some issues (specifically on Windows). So let's extract this commit from the other PR.

(There may be more issues like this that I didn't find yet)

These seemed to prevent cleaning up directories;

On arm64:

    === RUN   TestSysctlOverride
        testing.go:1090: TempDir RemoveAll cleanup: unlinkat /tmp/TestSysctlOverride2860094781/001/mounts/shm: device or resource busy
    --- FAIL: TestSysctlOverride (0.00s)

On Windows:

    === Failed
    === FAIL: github.com/docker/docker/daemon TestLoadOrCreateTrustKeyInvalidKeyFile (0.00s)
        testing.go:1090: TempDir RemoveAll cleanup: remove C:\Users\CONTAI~1\AppData\Local\Temp\TestLoadOrCreateTrustKeyInvalidKeyFile2014634395\001\keyfile4156691647: The process cannot access the file because it is being used by another process.

    === FAIL: github.com/docker/docker/daemon/graphdriver TestIsEmptyDir (0.01s)
        testing.go:1090: TempDir RemoveAll cleanup: remove C:\Users\CONTAI~1\AppData\Local\Temp\TestIsEmptyDir1962964337\001\dir-with-empty-file\file2523853824: The process cannot access the file because it is being used by another process.

    === FAIL: github.com/docker/docker/pkg/directory TestSizeEmptyFile (0.00s)
        testing.go:1090: TempDir RemoveAll cleanup: remove C:\Users\CONTAI~1\AppData\Local\Temp\TestSizeEmptyFile1562416712\001\file16507846: The process cannot access the file because it is being used by another process.

    === FAIL: github.com/docker/docker/pkg/directory TestSizeNonemptyFile (0.00s)
        testing.go:1090: TempDir RemoveAll cleanup: remove C:\Users\CONTAI~1\AppData\Local\Temp\TestSizeNonemptyFile1240832785\001\file3265662846: The process cannot access the file because it is being used by another process.

    === FAIL: github.com/docker/docker/pkg/directory TestSizeFileAndNestedDirectoryEmpty (0.00s)
        testing.go:1090: TempDir RemoveAll cleanup: remove C:\Users\CONTAI~1\AppData\Local\Temp\TestSizeFileAndNestedDirectoryEmpty2163416550\001\file3715413181: The process cannot access the file because it is being used by another process.

    === FAIL: github.com/docker/docker/pkg/directory TestSizeFileAndNestedDirectoryNonempty (0.00s)
        testing.go:1090: TempDir RemoveAll cleanup: remove C:\Users\CONTAI~1\AppData\Local\Temp\TestSizeFileAndNestedDirectoryNonempty878205470\001\file3280422273: The process cannot access the file because it is being used by another process.

    === FAIL: github.com/docker/docker/volume/service TestSetGetMeta (0.01s)
        testing.go:1090: TempDir RemoveAll cleanup: remove C:\Users\CONTAI~1\AppData\Local\Temp\TestSetGetMeta3332268057\001\db: The process cannot access the file because it is being used by another process.

    === FAIL: github.com/docker/docker/volume/service TestList (0.03s)
        testing.go:1090: TempDir RemoveAll cleanup: remove C:\Users\CONTAI~1\AppData\Local\Temp\TestList2846947953\001\volumes\metadata.db: The process cannot access the file because it is being used by another process.

    === FAIL: github.com/docker/docker/volume/service TestRestore (0.02s)
        testing.go:1090: TempDir RemoveAll cleanup: remove C:\Users\CONTAI~1\AppData\Local\Temp\TestRestore3368254142\001\volumes\metadata.db: The process cannot access the file because it is being used by another process.

    === FAIL: github.com/docker/docker/daemon/graphdriver TestIsEmptyDir (0.00s)
        testing.go:1090: TempDir RemoveAll cleanup: remove C:\Users\CONTAI~1\AppData\Local\Temp\TestIsEmptyDir2823795693\001\dir-with-empty-file\file2625561089: The process cannot access the file because it is being used by another process.

    === FAIL: github.com/docker/docker/pkg/directory TestSizeFileAndNestedDirectoryNonempty (0.00s)
        testing.go:1090: TempDir RemoveAll cleanup: remove C:\Users\CONTAI~1\AppData\Local\Temp\TestSizeFileAndNestedDirectoryNonempty4246252950\001\nested3442260313\file21164327: The process cannot access the file because it is being used by another process.



**- A picture of a cute animal (not mandatory but encouraged)**

