### PR TITLE
distribution: match manifest list resolution with containerd

### DIFF
--- a/distribution/pull_v2_unix.go
+++ b/distribution/pull_v2_unix.go
@@ -24,14 +24,25 @@ func filterManifests(manifests []manifestlist.ManifestDescriptor, p specs.Platfo
 	m := platforms.Only(p)
 	var matches []manifestlist.ManifestDescriptor
 	for _, desc := range manifests {
-		if m.Match(toOCIPlatform(desc.Platform)) {
+		descP := toOCIPlatform(desc.Platform)
+		if descP == nil || m.Match(*descP) {
 			matches = append(matches, desc)
-			logrus.Debugf("found match for %s with media type %s, digest %s", platforms.Format(p), desc.MediaType, desc.Digest.String())
+			if descP != nil {
+				logrus.Debugf("found match for %s with media type %s, digest %s", platforms.Format(p), desc.MediaType, desc.Digest.String())
+			}
 		}
 	}
 
 	sort.SliceStable(matches, func(i, j int) bool {
-		return m.Less(toOCIPlatform(matches[i].Platform), toOCIPlatform(matches[j].Platform))
+		p1 := toOCIPlatform(matches[i].Platform)
+		if p1 == nil {
+			return false
+		}
+		p2 := toOCIPlatform(matches[j].Platform)
+		if p2 == nil {
+			return true
+		}
+		return m.Less(*p1, *p2)
 	})
 
 	// deprecated: backwards compatibility with older versions that didn't compare variant


### PR DESCRIPTION
There are slight differences on how Docker and containerd find a specific image config/rootfs for running a container from a multi-platform image index.

Containerd logic for these edge cases seems to be according to spec https://github.com/opencontainers/image-spec although some cases are a bit vague there.

This PR matches Docker logic with what containerd is doing. With containerd storage integration, the Moby implementation will be replaced with containerd's anyway in the next release and this would be the future behavior. With this PR we can move to correct logic sooner and avoid behavior changes with containerd integration.

There is also a discussion going on at OCI Reference Types working group https://github.com/opencontainers/wg-reference-types/issues/50 that may choose to use nested Image indexes as a way to attach signatures to images. As nested indexes are currently handled differently in Moby we should get to matching implementation sooner to avoid breakage.

Changes:
- Manifest list is allowed to contain manifest lists.

> Also, implementations SHOULD support the following media types:
> application/vnd.oci.image.index.v1+json (nested index)
> https://github.com/opencontainers/image-spec/blob/main/image-index.md

- Unknown mediatype inside manifest list is skipped instead of causing an error

> An encountered mediaType that is unknown to the implementation MUST be ignored.
> https://github.com/opencontainers/image-spec/blob/main/image-index.md

- Platform in descriptor is optional

> This OPTIONAL property describes the minimum runtime requirements of the image. 
> https://github.com/opencontainers/image-spec/blob/main/image-index.md


The algorithm for finding the best match is as follows:
- From the image index all descriptors matching the minimum platform requirements are filtered out
- Matched descriptors are sorted from most specific to least specific (arm/v7 is more specific than arm/v6 is more specific than "")
- If matched descriptor points to the image manifest it is returned
- If it points to an unknown object it is skipped
- If it points to another image index then the same algorithm is performed there. If no matches were in the inner manifest list then the descriptor is skipped.


OCI mediatypes and Docker mediatypes work the same way. Obviously, the specs are slightly different but the intention in here is to replicate containerd's behavior not to redefine new behavior for the loosely defined areas.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>


