### PR TITLE
ci: add concurrency check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: ci
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,5 +1,9 @@
 name: windows
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
add concurrency check in our workflows to ensure that only a single workflow using the same concurrency group will run at a time. it allows to reduce job build queue in our pipeline (we are limited to 20 concurrent jobs atm with the [Free plan](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits)).

more info: https://docs.github.com/en/actions/using-jobs/using-concurrency

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>