### PR TITLE
fix flaky TestRunContainerWithRmFlag tests

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2745,30 +2745,29 @@ func (s *DockerSuite) TestRunVolumesFromRestartAfterRemoved(c *testing.T) {
 
 // run container with --rm should remove container if exit code != 0
 func (s *DockerSuite) TestRunContainerWithRmFlagExitCodeNotEqualToZero(c *testing.T) {
-	existingContainers := ExistingContainerIDs(c)
 	name := "flowers"
 	cli.Docker(cli.Args("run", "--name", name, "--rm", "busybox", "ls", "/notexists")).Assert(c, icmd.Expected{
 		ExitCode: 1,
 	})
 
-	out := cli.DockerCmd(c, "ps", "-q", "-a").Combined()
-	out = RemoveOutputForExistingElements(out, existingContainers)
-	if out != "" {
-		c.Fatal("Expected not to have containers", out)
-	}
+	cli.Docker(cli.Args("container", "inspect", name)).Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Out:      "[]\n",
+		Err:      "o such container", // (N|n)o such container
+	})
 }
 
 func (s *DockerSuite) TestRunContainerWithRmFlagCannotStartContainer(c *testing.T) {
-	existingContainers := ExistingContainerIDs(c)
 	name := "sparkles"
 	cli.Docker(cli.Args("run", "--name", name, "--rm", "busybox", "commandNotFound")).Assert(c, icmd.Expected{
 		ExitCode: 127,
 	})
-	out := cli.DockerCmd(c, "ps", "-q", "-a").Combined()
-	out = RemoveOutputForExistingElements(out, existingContainers)
-	if out != "" {
-		c.Fatal("Expected not to have containers", out)
-	}
+
+	cli.Docker(cli.Args("container", "inspect", name)).Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Out:      "[]\n",
+		Err:      "o such container", // (N|n)o such container
+	})
 }
 
 func (s *DockerSuite) TestRunPIDHostWithChildIsKillable(c *testing.T) {


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/43679

This attempts to fix CI flakiness on the TestRunContainerWithRmFlagCannotStartContainer
and TestRunContainerWithRmFlagExitCodeNotEqualToZero tests.

These tests;

- get a list of all container ID's
- run a container with `--rm`
- wait for it to exit
- checks that the list of all container IDs is empty

The last step assumes that no other tests are running on the same daemon; if
another test is running, there may be other containers present (unrelated to
the test).

This patch updates the tests to use a `docker inspect` to verify the container
no longer exists afterwards.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

