### PR TITLE
[20.10] Backport sysctl performance tuning in libnetwork sandboxes

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-: "${LIBNETWORK_COMMIT:=2dab5620d4462865c6151e573b3e7fa5d3b8458b}"
+: "${LIBNETWORK_COMMIT:=f6ccccb1c082a432c2a5814aaedaca56af33d9ea}"
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -47,7 +47,7 @@ github.com/grpc-ecosystem/go-grpc-middleware        3c51f7f332123e8be5a157c0802a
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        2dab5620d4462865c6151e573b3e7fa5d3b8458b
+github.com/docker/libnetwork                        f6ccccb1c082a432c2a5814aaedaca56af33d9ea
 github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/controller.go
+++ b/vendor/github.com/docker/libnetwork/controller.go
@@ -1175,6 +1175,14 @@ func (c *controller) NewSandbox(containerID string, options ...SandboxOption) (S
 
 	if sb.osSbox != nil {
 		// Apply operating specific knobs on the load balancer sandbox
+		err := sb.osSbox.InvokeFunc(func() {
+			sb.osSbox.ApplyOSTweaks(sb.oslTypes)
+		})
+
+		if err != nil {
+			logrus.Errorf("Failed to apply performance tuning sysctls to the sandbox: %v", err)
+		}
+		// Keep this just so performance is not changed
 		sb.osSbox.ApplyOSTweaks(sb.oslTypes)
 	}
 

--- a/vendor/github.com/docker/libnetwork/service_linux.go
+++ b/vendor/github.com/docker/libnetwork/service_linux.go
@@ -169,6 +169,10 @@ func (n *network) addLBBackend(ip net.IP, lb *loadBalancer) {
 	if err := i.NewDestination(s, d); err != nil && err != syscall.EEXIST {
 		logrus.Errorf("Failed to create real server %s for vip %s fwmark %d in sbox %.7s (%.7s): %v", ip, lb.vip, lb.fwMark, sb.ID(), sb.ContainerID(), err)
 	}
+
+	// Ensure that kernel tweaks are applied in case this is the first time
+	// we've initialized ip_vs
+	sb.osSbox.ApplyOSTweaks(sb.oslTypes)
 }
 
 // Remove loadbalancer backend the load balancing endpoint for this


### PR DESCRIPTION
Backports #43146 and #43670 to 20.10 by pulling in moby/libnetwork#2659.

libnetwork diff: [moby/libnetwork@2dab562..f6ccccb](https://github.com/moby/libnetwork/compare/2dab5620d4462865c6151e573b3e7fa5d3b8458b..f6ccccb1c082a432c2a5814aaedaca56af33d9ea)

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/1049222/171724904-5788de70-5412-4c51-b500-d114dcc9ab74.png)

