### PR TITLE
[20.10 backport] Merge fixes to pkg/system to support FreeBSD's mknod

### DIFF
--- a/pkg/system/mknod.go
+++ b/pkg/system/mknod.go
@@ -7,12 +7,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// Mknod creates a filesystem node (file, device special file or named pipe) named path
-// with attributes specified by mode and dev.
-func Mknod(path string, mode uint32, dev int) error {
-	return unix.Mknod(path, mode, dev)
-}
-
 // Mkdev is used to build the value of linux devices (in /dev/) which specifies major
 // and minor number of the newly created device special file.
 // Linux device nodes are a bit weird due to backwards compat with 16 bit device nodes.

--- a/pkg/system/mknod_freebsd.go
+++ b/pkg/system/mknod_freebsd.go
@@ -1,0 +1,14 @@
+//go:build freebsd
+// +build freebsd
+
+package system // import "github.com/docker/docker/pkg/system"
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// Mknod creates a filesystem node (file, device special file or named pipe) named path
+// with attributes specified by mode and dev.
+func Mknod(path string, mode uint32, dev int) error {
+	return unix.Mknod(path, mode, uint64(dev))
+}

--- a/pkg/system/mknod_linux.go
+++ b/pkg/system/mknod_linux.go
@@ -1,0 +1,11 @@
+package system // import "github.com/docker/docker/pkg/system"
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// Mknod creates a filesystem node (file, device special file or named pipe) named path
+// with attributes specified by mode and dev.
+func Mknod(path string, mode uint32, dev int) error {
+	return unix.Mknod(path, mode, dev)
+}

--- a/pkg/system/mknod_unix.go
+++ b/pkg/system/mknod_unix.go
@@ -1,3 +1,6 @@
+//go:build !freebsd && !windows
+// +build !freebsd,!windows
+
 package system // import "github.com/docker/docker/pkg/system"
 
 import (


### PR DESCRIPTION
backports:

- https://github.com/moby/moby/pull/42866
- https://github.com/moby/moby/pull/43087

This allows projects that depend on pkg/system's implementation of mknod such as github.com/openshift/imagebuilder and github.com/containers/buildah to build on FreeBSD.