### PR TITLE
daemon.NewDaemon(): fix network feature detection on first start

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1726,14 +1726,14 @@ func (daemon *Daemon) setupSeccompProfile() error {
 	return nil
 }
 
-func (daemon *Daemon) loadSysInfo() {
+func getSysInfo(daemon *Daemon) *sysinfo.SysInfo {
 	var siOpts []sysinfo.Opt
 	if daemon.getCgroupDriver() == cgroupSystemdDriver {
 		if euid := os.Getenv("ROOTLESSKIT_PARENT_EUID"); euid != "" {
 			siOpts = append(siOpts, sysinfo.WithCgroup2GroupPath("/user.slice/user-"+euid+".slice"))
 		}
 	}
-	daemon.sysInfo = sysinfo.New(siOpts...)
+	return sysinfo.New(siOpts...)
 }
 
 func (daemon *Daemon) initLibcontainerd(ctx context.Context) error {

--- a/daemon/daemon_unsupported.go
+++ b/daemon/daemon_unsupported.go
@@ -13,6 +13,6 @@ const platformSupported = false
 func setupResolvConf(config *config.Config) {
 }
 
-func (daemon *Daemon) loadSysInfo() {
-	daemon.sysInfo = sysinfo.New()
+func getSysInfo(daemon *Daemon) *sysinfo.SysInfo {
+	return sysinfo.New()
 }

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -598,8 +598,8 @@ func (daemon *Daemon) loadRuntimes() error {
 
 func setupResolvConf(config *config.Config) {}
 
-func (daemon *Daemon) loadSysInfo() {
-	daemon.sysInfo = sysinfo.New()
+func getSysInfo(daemon *Daemon) *sysinfo.SysInfo {
+	return sysinfo.New()
 }
 
 func (daemon *Daemon) initLibcontainerd(ctx context.Context) error {


### PR DESCRIPTION
Commit 483aa6294b457ad4f60df91e46c0038a0e953dad (https://github.com/moby/moby/pull/43130) introduced a regression, causing spurious warnings to be shown when starting a daemon for the first time after a fresh install:

    docker info
    ...
    WARNING: IPv4 forwarding is disabled
    WARNING: bridge-nf-call-iptables is disabled
    WARNING: bridge-nf-call-ip6tables is disabled

The information shown is incorrect, as checking the corresponding options on the system, shows that these options are available:

    cat /proc/sys/net/ipv4/ip_forward
    1
    cat /proc/sys/net/bridge/bridge-nf-call-iptables
    1
    cat /proc/sys/net/bridge/bridge-nf-call-ip6tables
    1

The reason this is failing is because the daemon itself reconfigures those options during networking initialization in `configureIPForwarding()`; https://github.com/moby/moby/blob/cf4595265e7703e1e9745a30f1dd265acbc075d3/libnetwork/drivers/bridge/setup_ip_forwarding.go#L14-L25

Network initialization happens in the `daemon.restore()` function within `daemon.NewDaemon()`: https://github.com/moby/moby/blob/cf4595265e7703e1e9745a30f1dd265acbc075d3/daemon/daemon.go#L475-L478

However, 483aa6294b457ad4f60df91e46c0038a0e953dad moved detection of features earlier in the `daemon.NewDaemon()` function, and collects the system information (`d.RawSysInfo()`) before we enter `daemon.restore()`; https://github.com/moby/moby/blob/cf4595265e7703e1e9745a30f1dd265acbc075d3/daemon/daemon.go#L1008-L1011

For optimization (collecting the system information comes at a cost), those results are cached on the daemon, and will only be performed once (using a `sync.Once`).

This patch:

- introduces a `getSysInfo()` utility, which collects system information without caching the results
- uses `getSysInfo()` to collect the preliminary information needed at that  point in the daemon's lifecycle.
- moves printing warnings to the end of `daemon.NewDaemon()`, after all information  can be read correctly.


**- A picture of a cute animal (not mandatory but encouraged)**

![2825418679_024de324b4_b](https://user-images.githubusercontent.com/1804568/171895484-e382e779-6f33-49a2-accd-3f0c986325ec.jpg)
