### PR TITLE
update containerd binary to v1.6.5

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -166,7 +166,7 @@ FROM microsoft/windowsservercore
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG GO_VERSION=1.18.3
-ARG CONTAINERD_VERSION=1.6.4
+ARG CONTAINERD_VERSION=1.6.5
 ARG GOTESTSUM_VERSION=v1.8.1
 ARG GOWINRES_VERSION=v0.2.3
 

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.6.4}"
+: "${CONTAINERD_VERSION:=v1.6.5}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/43588

Welcome to the v1.6.5 release of containerd!

The fifth patch release for containerd 1.6 includes a few fixes and updated
version of runc.

Notable Updates

- Fix for older CNI plugins not reporting version
- Fix mount path handling for CRI plugin on Windows

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

