### PR TITLE
Builder: some improvements on cleaning up containers

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -62,8 +62,6 @@ type ExecBackend interface {
 	ContainerCreateIgnoreImagesArgsEscaped(ctx context.Context, config backend.ContainerCreateConfig) (container.CreateResponse, error)
 	// ContainerRm removes a container specified by `id`.
 	ContainerRm(name string, config *backend.ContainerRmConfig) error
-	// ContainerKill stops the container execution abruptly.
-	ContainerKill(containerID string, sig string) error
 	// ContainerStart starts a new container
 	ContainerStart(ctx context.Context, containerID string, hostConfig *container.HostConfig, checkpoint string, checkpointDir string) error
 	// ContainerWait stops processing until the given container is stopped.

--- a/builder/dockerfile/containerbackend.go
+++ b/builder/dockerfile/containerbackend.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/builder"
 	containerpkg "github.com/docker/docker/container"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/pkg/errors"
 )
@@ -128,9 +129,9 @@ func (e *statusCodeError) StatusCode() int {
 // RemoveAll containers managed by this container manager
 func (c *containerManager) RemoveAll(stdout io.Writer) {
 	for containerID := range c.tmpContainers {
-		if err := c.backend.ContainerRm(containerID, &backend.ContainerRmConfig{ForceRemove: true, RemoveVolume: true}); err != nil {
+		if err := c.backend.ContainerRm(containerID, &backend.ContainerRmConfig{ForceRemove: true, RemoveVolume: true}); err != nil && !errdefs.IsNotFound(err) {
 			_, _ = fmt.Fprintf(stdout, "Removing intermediate container %s: %v\n", stringid.TruncateID(containerID), err)
-			return
+			continue
 		}
 		delete(c.tmpContainers, containerID)
 		_, _ = fmt.Fprintf(stdout, " ---> Removed intermediate container %s\n", stringid.TruncateID(containerID))

--- a/builder/dockerfile/containerbackend.go
+++ b/builder/dockerfile/containerbackend.go
@@ -61,8 +61,7 @@ func (c *containerManager) Run(ctx context.Context, cID string, stdout, stderr i
 	go func() {
 		select {
 		case <-ctx.Done():
-			log.G(ctx).Debugln("Build cancelled, killing and removing container:", cID)
-			c.backend.ContainerKill(cID, "")
+			log.G(ctx).Debugln("Build cancelled, removing container:", cID)
 			err = c.backend.ContainerRm(cID, &backend.ContainerRmConfig{ForceRemove: true, RemoveVolume: true})
 			if err != nil {
 				_, _ = fmt.Fprintf(stdout, "Removing container %s: %v\n", stringid.TruncateID(cID), err)

--- a/builder/dockerfile/mockbackend_test.go
+++ b/builder/dockerfile/mockbackend_test.go
@@ -45,10 +45,6 @@ func (m *MockBackend) CommitBuildStep(ctx context.Context, c backend.CommitConfi
 	return "", nil
 }
 
-func (m *MockBackend) ContainerKill(containerID string, sig string) error {
-	return nil
-}
-
 func (m *MockBackend) ContainerStart(ctx context.Context, containerID string, hostConfig *container.HostConfig, checkpoint string, checkpointDir string) error {
 	return nil
 }


### PR DESCRIPTION
Some changes I had in stashed in a branch that I was working on; see individual commits for details.

### builder/dockerfile: remove containerManager.removeContainer()

This was just a very thin wrapper for backend.ContainerRm(), and the error it returned was not handled, so moving this code inline.

Moving it inline also allows differentiating the error message to distinguish the "removing all intermediate containers" from "removing container" (when cancelling a build).

### builder/dockerfile: rename variable that collided with imported package

### builder/dockerfile: containerManager.RemoveAll() prevent partial cleanup

Prevent cleanup from terminating early when failing to remove a container;

- continue trying to remove remaining containers
- ignore errors due to containers that were not found

### builder: remove redundant ExecBackend.ContainerKill()

The `ExecBackend.ContainerKill()` function was called before removing a build-container.

This function is backed by `daemon.ContainerKill()` which, if no signal is passed, performed a `daemon.Kill()`, using `SIGKILL` as signal. However, the `ExecBackend.ContainerRm()` (backed by `daemonContainerRm()`), which is called after this, is executed with the `ForceRemove` option set, which calls `daemon.cleanupContainer()` with `ForceRemove` set, which also results in `daemon.Kill()` being called:
https://github.com/moby/moby/blob/1a0c15abbb69105be7dab74335f7c9f6bb6f2efa/daemon/delete.go#L84-L95

This makes the `ExecBackend.ContainerKill()` redundant, so removing this from the interface.

While looking at this code, one (possible) race-condition was found in `daemon.cleanupContainer()`, where `daemon.Kill()` could return a `errdefs.Conflict` if the container was already stopped. An extra check was added for this case to prevent `daemon.cleanupContainer()` from terminating early.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

