### PR TITLE
[20.10 backport] update containerd binary to v1.6.6

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.6.5}"
+: "${CONTAINERD_VERSION:=v1.6.6}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/43700

Welcome to the v1.6.6 release of containerd!

The sixth patch release for containerd 1.6 includes a fix for
[CVE-2022-31030](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-31030).

Notable Updates

- Fix ExecSync handler to cap console output size ([GHSA-5ffw-gxpp-mxpf](https://github.com/containerd/containerd/security/advisories/GHSA-5ffw-gxpp-mxpf))

full diff: https://github.com/containerd/containerd/compare/v1.6.5...v1.6.6

(cherry picked from commit a7e3182757ca20217032cdf5bc04e61e528c2dfa)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

