### PR TITLE
daemon: LogDaemonEventWithAttributes: don't call SystemInfo()

### DIFF
--- a/daemon/events.go
+++ b/daemon/events.go
@@ -87,14 +87,13 @@ func (daemon *Daemon) LogNetworkEventWithAttributes(nw libnetwork.Network, actio
 // LogDaemonEventWithAttributes generates an event related to the daemon itself with specific given attributes.
 func (daemon *Daemon) LogDaemonEventWithAttributes(action string, attributes map[string]string) {
 	if daemon.EventsService != nil {
-		if info := daemon.SystemInfo(); info.Name != "" {
-			attributes["name"] = info.Name
+		if name := hostName(); name != "" {
+			attributes["name"] = name
 		}
-		actor := events.Actor{
+		daemon.EventsService.Log(action, events.DaemonEventType, events.Actor{
 			ID:         daemon.id,
 			Attributes: attributes,
-		}
-		daemon.EventsService.Log(action, events.DaemonEventType, actor)
+		})
 	}
 }
 

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -42,10 +42,6 @@ func (daemon *Daemon) Reload(conf *config.Config) (err error) {
 			})
 			logrus.Infof("Reloaded configuration: %s", jsonString)
 		}
-
-		// we're unlocking here, because
-		// LogDaemonEventWithAttributes() -> SystemInfo() -> GetAllRuntimes()
-		// holds that lock too.
 		daemon.configStore.Unlock()
 		if err == nil {
 			daemon.LogDaemonEventWithAttributes("reload", attributes)


### PR DESCRIPTION
This function was calling SystemInfo() only to get the daemon's name
to add to the event that's generated.

SystemInfo() is quite heavy, and no info other than the Name was used.
The name returned is just looking up the hostname, so instead, call
`hostName()` directly.


**- A picture of a cute animal (not mandatory but encouraged)**

