### PR TITLE
codecov: disable patch status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,10 +5,7 @@ github_checks:
 
 coverage:
   status:
-    patch:
-      default:
-        target: 50%
-        only_pulls: true
+    patch: false
     # project will give us the diff in the total code coverage between a commit
     # and its parent
     project:


### PR DESCRIPTION
CodeCov has been very hit-and-miss recently; it looks like we
may need some additional settings to make it compare with the
correct parent commit (perhaps it doesn't work well with rebasing),

**- A picture of a cute animal (not mandatory but encouraged)**

