### PR TITLE
Fixed clashing embedded DNS with `systemd-resolved`

### DIFF
--- a/libnetwork/sandbox_dns_unix.go
+++ b/libnetwork/sandbox_dns_unix.go
@@ -178,7 +178,7 @@ func (sb *sandbox) setExternalResolvers(content []byte, addrType int, checkLoopb
 			IPStr:        ip,
 			HostLoopback: hostLoopback || isSystemdResolvedIPv4Loopback(ip),
 		})
-		logrus.Infof("Added external resolver IP: %s, HostLoopback: %t", ip, hostLoopback)
+		logrus.Debugf("Added external resolver IP: %s, HostLoopback: %t", ip, hostLoopback)
 	}
 }
 
@@ -194,10 +194,12 @@ func isIPv4Loopback(ipAddress string) bool {
 	return false
 }
 
+// Considering systemd-resolved DNSStubListener addresses 127.0.0.53 and 127.0.0.54
+// as external
 func isSystemdResolvedIPv4Loopback(ipAddress string) bool {
 	if ip := net.ParseIP(ipAddress); ip != nil {
 		if ip4 := ip.To4(); ip4 != nil {
-			return ip4[0] == 127 && ip4[3] == 53
+			return ip4.Equal(net.IPv4(127, 0, 0, 53)) || ip4.Equal(net.IPv4(127, 0, 0, 54))
 		}
 	}
 	return false

--- a/libnetwork/sandbox_dns_unix.go
+++ b/libnetwork/sandbox_dns_unix.go
@@ -176,8 +176,9 @@ func (sb *sandbox) setExternalResolvers(content []byte, addrType int, checkLoopb
 		}
 		sb.extDNS = append(sb.extDNS, extDNSEntry{
 			IPStr:        ip,
-			HostLoopback: hostLoopback,
+			HostLoopback: hostLoopback || isSystemdResolvedIPv4Loopback(ip),
 		})
+		logrus.Infof("Added external resolver IP: %s, HostLoopback: %t", ip, hostLoopback)
 	}
 }
 
@@ -188,6 +189,15 @@ func isIPv4Loopback(ipAddress string) bool {
 	if ip := net.ParseIP(ipAddress); ip != nil {
 		if ip4 := ip.To4(); ip4 != nil {
 			return ip4[0] == 127
+		}
+	}
+	return false
+}
+
+func isSystemdResolvedIPv4Loopback(ipAddress string) bool {
+	if ip := net.ParseIP(ipAddress); ip != nil {
+		if ip4 := ip.To4(); ip4 != nil {
+			return ip4[0] == 127 && ip4[3] == 53
 		}
 	}
 	return false


### PR DESCRIPTION
This fixes a bug with DNS resolving in some Linux environments given we specified some DNS options.

`systemd-resolved` has DNS with IP: 127.0.0.53:
```
$ cat /etc/resolv.conf 
# This file is managed by man:systemd-resolved(8). Do not edit.
#
# This is a dynamic resolv.conf file for connecting local clients to the
# internal DNS stub resolver of systemd-resolved. This file lists all
# configured search domains.
#
# Run "resolvectl status" to see details about the uplink DNS servers
# currently in use.
#
# Third party programs should typically not access this file directly, but only
# through the symlink at /etc/resolv.conf. To manage man:resolv.conf(5) in a
# different way, replace this symlink by a static file or a different symlink.
#
# See man:systemd-resolved.service(8) for details about the supported modes of
# operation for /etc/resolv.conf.

nameserver 127.0.0.53
options edns0 trust-ad
search local
```

Docker fails to redirect DNS queries to that address given we touched some other DNS options and `/etc/resolv.conf` file was rebuilt.

Fixes docker/for-linux#1404