### PR TITLE
update runc binary to v1.1.3

### DIFF
--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=v1.1.2}"
+: "${RUNC_VERSION:=v1.1.3}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"


### PR DESCRIPTION
keeping in draft for now, as containerd has not yet done a release with this (to keep the `.deb` / `.rpm` packages in sync with the static binaries)

full diff: https://github.com/opencontainers/runc/compare/v1.1.2...v1.1.3

This is the third release of the 1.1.z series of runc, and contains
various minor improvements and bugfixes.

- Our seccomp `-ENOSYS` stub now correctly handles multiplexed syscalls on
  s390 and s390x. This solves the issue where syscalls the host kernel did not
  support would return `-EPERM` despite the existence of the `-ENOSYS` stub
  code (this was due to how s390x does syscall multiplexing).
- Retry on dbus disconnect logic in libcontainer/cgroups/systemd now works as
  intended; this fix does not affect runc binary itself but is important for
  libcontainer users such as Kubernetes.
- Inability to compile with recent clang due to an issue with duplicate
  constants in libseccomp-golang.
- When using systemd cgroup driver, skip adding device paths that don't exist,
  to stop systemd from emitting warnings about those paths.
- Socket activation was failing when more than 3 sockets were used.
- Various CI fixes.
- Allow to bind mount `/proc/sys/kernel/ns_last_pid` to inside container.
- runc static binaries are now linked against libseccomp v2.5.4.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

