### PR TITLE
Dockerfile: add crun to dev image

### DIFF
--- a/hack/dockerfile/etc/docker/daemon.json
+++ b/hack/dockerfile/etc/docker/daemon.json
@@ -1,0 +1,7 @@
+{
+	"runtimes": {
+		"crun": {
+			"path": "/usr/local/bin/crun"
+		}
+	}
+}


### PR DESCRIPTION
**- What I did**
Installed crun into the dev image so that it can be selected as the OCI runtime when starting containers inside the dev shell. Having crun installed is also a prerequisite for running integration tests with crun as the runtime. (Due to the parallelism limitations of Jenkins pipelines, matrix-testing against crun probably won't happen until the Linux integration tests are ported to GitHub Actions.)

**- How I did it**
- Installed crun into the dev image, compiled from source for ease of switching versions and testing out prereleases
- Added daemon.json `runtime` configuration for crun to the dev image

The crun build took around 30 seconds to complete on my machine. Given that it's built in its own stage which will only be invalidated when the crun version or base image is changed, I figure it isn't worth the effort to set up `ccache` or similar.

**- How to verify it**
```console
$ make shell
# hack/make.sh dynbinary
# ./bundles/dynbinary-daemon/dockerd-dev &
# docker run --rm --runtime=crun hello-world
```

**- Description for the changelog**
N/A: developer-facing changes only

**- A picture of a cute animal (not mandatory but encouraged)**
![My kittehs](https://user-images.githubusercontent.com/274527/173155154-54df5d41-9960-4889-a90f-28a063adf8f3.jpg)

