### PR TITLE
minor error and logging improvements

### DIFF
--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -739,11 +739,13 @@ func (ls *layerStore) assembleTarTo(graphID string, metadata io.ReadCloser, size
 func (ls *layerStore) Cleanup() error {
 	orphanLayers, err := ls.store.getOrphan()
 	if err != nil {
-		logrus.Errorf("Cannot get orphan layers: %v", err)
+		logrus.WithError(err).Error("cannot get orphan layers")
 	}
-	logrus.Debugf("found %v orphan layers", len(orphanLayers))
+	if len(orphanLayers) > 0 {
+		logrus.Debugf("found %v orphan layers", len(orphanLayers))
+	}
 	for _, orphan := range orphanLayers {
-		logrus.Debugf("removing orphan layer, chain ID: %v , cache ID: %v", orphan.chainID, orphan.cacheID)
+		logrus.WithField("cache-id", orphan.cacheID).Debugf("removing orphan layer, chain ID: %v", orphan.chainID)
 		err = ls.driver.Remove(orphan.cacheID)
 		if err != nil && !os.IsNotExist(err) {
 			logrus.WithError(err).WithField("cache-id", orphan.cacheID).Error("cannot remove orphan layer")

--- a/volume/service/store.go
+++ b/volume/service/store.go
@@ -95,9 +95,10 @@ func NewStore(rootPath string, drivers *drivers.Store, opts ...StoreOpt) (*Volum
 		}
 
 		var err error
-		vs.db, err = bolt.Open(filepath.Join(volPath, "metadata.db"), 0600, &bolt.Options{Timeout: 1 * time.Second})
+		dbPath := filepath.Join(volPath, "metadata.db")
+		vs.db, err = bolt.Open(dbPath, 0600, &bolt.Options{Timeout: 1 * time.Second})
 		if err != nil {
-			return nil, errors.Wrap(err, "error while opening volume store metadata database")
+			return nil, errors.Wrapf(err, "error while opening volume store metadata database (%s)", dbPath)
 		}
 
 		// initialize volumes bucket


### PR DESCRIPTION
extracting this from https://github.com/moby/moby/pull/43703

### volumes/service: NewStore: add more context to error

Adding some more context to errors to debug a failure in TestDaemonEvents

    === RUN   TestDockerDaemonSuite/TestDaemonEvents
    docker_cli_events_unix_test.go:399: [dd34383dd9b63] failed to start daemon with arguments [--data-root /go/src/github.com/docker/docker/bundles/test-integration/TestDockerDaemonSuite/TestDaemonEvents/dd34383dd9b63/root --exec-root /tmp/dxr/dd34383dd9b63 --pidfile /go/src/github.com/docker/docker/bundles/test-integration/TestDockerDaemonSuite/TestDaemonEvents/dd34383dd9b63/docker.pid --userland-proxy=true --containerd-namespace dd34383dd9b63 --containerd-plugins-namespace dd34383dd9b63p --containerd /var/run/docker/containerd/containerd.sock --host unix:///tmp/docker-integration/dd34383dd9b63.sock --debug --storage-driver overlay2 --config-file=test.json] : [dd34383dd9b63] daemon exited during startup: exit status 1
    check_test.go:307: [dd34383dd9b63] daemon is not started
    --- FAIL: TestDockerDaemonSuite/TestDaemonEvents (1.59s)

The daemon logs for that failure did not mention what file it had trouble with;


```
failed to start daemon: error while opening volume store metadata database: timeout
```


### layer: layerstore.Cleanup(): improve some logging

Improve consistency for the logs, and remove a redundant log:

    time="2022-06-07T15:37:24.418470152Z" level=debug msg="found 0 orphan layers"
