### PR TITLE
introduce Containerd-snapshotter feature flag

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -146,6 +146,16 @@ func (daemon *Daemon) Features() *map[string]bool {
 	return &daemon.configStore.Features
 }
 
+// usesSnapshotter returns true if feature flag to use containerd snapshotter is enabled
+func (daemon *Daemon) usesSnapshotter() bool {
+	if daemon.configStore.Features != nil {
+		if b, ok := daemon.configStore.Features["containerd-snapshotter"]; ok {
+			return b
+		}
+	}
+	return false
+}
+
 // RegistryHosts returns registry configuration in containerd resolvers format
 func (daemon *Daemon) RegistryHosts() docker.RegistryHosts {
 	var (


### PR DESCRIPTION
**- What I did**
introduce Containerd-snapshotter feature flag

**- How I did it**
added support for `Containerd-snapshotter`feature flag
introduced `usesSnapshotter` for usability in code
illustration in oci_linux for some obvious places where moby enforce a mounted rootFS, while migration to containerd will rely on an active snapshot

**- How to verify it**
no impact as this is just basic skaffolding to bootstrap containerd image store migration work. Enabling this new feature flag is expected to just break until some concrete development takes place.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/132757/174965821-ce18177b-6111-439e-9d29-8136803b94cf.png)

