### PR TITLE
daemon: let shim binary of runtime configurable

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5484,6 +5484,16 @@ definitions:
         items:
           type: "string"
         example: ["--debug", "--systemd-cgroup=false"]
+      shim:
+        description: |
+          Specify the containerd shim v2 name or binary when invoked.
+        type: "object"
+        properties:
+          binary:
+            description: |
+              A containerd shim v2 name or the absolute path of the binary.
+            type: "string"
+            example: "io.containerd.kata.v2"
 
   Commit:
     description: |

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -654,18 +654,19 @@ type Checkpoint struct {
 
 // Runtime describes an OCI runtime
 type Runtime struct {
-	Path string   `json:"path"`
+	Path string   `json:"path,omitempty"`
 	Args []string `json:"runtimeArgs,omitempty"`
 
-	// This is exposed here only for internal use
-	// It is not currently supported to specify custom shim configs
-	Shim *ShimConfig `json:"-"`
+	Shim *ShimConfig `json:"shim,omitempty"`
 }
 
 // ShimConfig is used by runtime to configure containerd shims
 type ShimConfig struct {
-	Binary string
-	Opts   interface{}
+	Binary string `json:"binary"`
+
+	// This is exposed here only for internal use
+	// It is not currently supported to specify custom shim options
+	Opts interface{} `json:"-"`
 }
 
 // DiskUsageObject represents an object type used for disk usage query filtering.

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -17,6 +17,7 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.42](https://docs.docker.com/engine/api/v1.42/) documentation
 
+* `GET /info` now returns a shim's binary field that identifies shim's name or binary.
 * Removed the `BuilderSize` field on the `GET /system/df` endpoint. This field
   was introduced in API 1.31 as part of an experimental feature, and no longer
   used since API 1.40.


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Let users configure shim's binary for additional runtimes

**- How I did it**
Set json tag of the golang struct definition.

**- How to verify it**

Edit daemon.json.
```json
{
  "default-runtime": "runc",
  "runtimes": {
    "kata": {
      "shim": {
        "binary": " io.containerd.kata.v2"
      }
    }
  }
}
```
and then run `docker run --net none --runtime kata -it alpine:3.15 sh`.
Note: you need Kata Containers shim has been installed.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
daemon: let shim binary of runtime configurable

**- A picture of a cute animal (not mandatory but encouraged)**
