### PR TITLE
Make `*client.Client` safe for concurrent use

### DIFF
--- a/client/build_prune.go
+++ b/client/build_prune.go
@@ -13,7 +13,11 @@ import (
 
 // BuildCachePrune requests the daemon to delete unused cache data
 func (cli *Client) BuildCachePrune(ctx context.Context, opts types.BuildCachePruneOptions) (*types.BuildCachePruneReport, error) {
-	if err := cli.NewVersionError("1.31", "build prune"); err != nil {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := versioned.NewVersionError("1.31", "build prune"); err != nil {
 		return nil, err
 	}
 
@@ -30,7 +34,7 @@ func (cli *Client) BuildCachePrune(ctx context.Context, opts types.BuildCachePru
 	}
 	query.Set("filters", filters)
 
-	serverResp, err := cli.post(ctx, "/build/prune", query, nil, nil)
+	serverResp, err := versioned.post(ctx, "/build/prune", query, nil, nil)
 	defer ensureReaderClosed(serverResp)
 
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -59,8 +59,15 @@ import (
 // ErrRedirect is the error returned by checkRedirect when the request is non-GET.
 var ErrRedirect = errors.New("unexpected redirect in response")
 
-// Client is the API client that performs all operations
-// against a docker server.
+type versionNegotiation struct {
+	// The version of the server to talk to.
+	version string
+	// Whether API version negotiation took place.
+	negotiated bool
+}
+
+// Client is the API client that performs all operations against a docker
+// server. Clients are safe for concurrent use by multiple goroutines.
 type Client struct {
 	// scheme sets the scheme for the client
 	scheme string
@@ -75,7 +82,7 @@ type Client struct {
 	// client used to send and receive http requests.
 	client *http.Client
 	// version of the server to talk to.
-	version string
+	version chan versionNegotiation
 	// custom http headers configured by users.
 	customHTTPHeaders map[string]string
 	// manualOverride is set to true when the version was set by users.
@@ -86,9 +93,6 @@ type Client struct {
 	// performed on the first request, after which negotiated is set to "true"
 	// so that subsequent requests do not re-negotiate.
 	negotiateVersion bool
-
-	// negotiated indicates that API version negotiation took place
-	negotiated bool
 }
 
 // CheckRedirect specifies the policy for dealing with redirect responses:
@@ -134,11 +138,12 @@ func NewClientWithOpts(ops ...Opt) (*Client, error) {
 	}
 	c := &Client{
 		host:    DefaultDockerHost,
-		version: api.DefaultVersion,
 		client:  client,
 		proto:   defaultProto,
 		addr:    defaultAddr,
+		version: make(chan versionNegotiation, 1),
 	}
+	c.version <- versionNegotiation{version: api.DefaultVersion}
 
 	for _, op := range ops {
 		if err := op(c); err != nil {
@@ -186,23 +191,23 @@ func (cli *Client) Close() error {
 
 // getAPIPath returns the versioned request path to call the api.
 // It appends the query parameters to the path if they are not empty.
-func (cli *Client) getAPIPath(ctx context.Context, p string, query url.Values) string {
+func (cli versionedClient) getAPIPath(p string, query url.Values) string {
 	var apiPath string
-	if cli.negotiateVersion && !cli.negotiated {
-		cli.NegotiateAPIVersion(ctx)
-	}
 	if cli.version != "" {
 		v := strings.TrimPrefix(cli.version, "v")
-		apiPath = path.Join(cli.basePath, "/v"+v, p)
+		apiPath = path.Join(cli.cli.basePath, "/v"+v, p)
 	} else {
-		apiPath = path.Join(cli.basePath, p)
+		apiPath = path.Join(cli.cli.basePath, p)
 	}
 	return (&url.URL{Path: apiPath, RawQuery: query.Encode()}).String()
 }
 
 // ClientVersion returns the API version used by this client.
 func (cli *Client) ClientVersion() string {
-	return cli.version
+	v := <-cli.version
+	ver := v.version
+	cli.version <- v
+	return ver
 }
 
 // NegotiateAPIVersion queries the API and updates the version to match the API
@@ -222,9 +227,25 @@ func (cli *Client) ClientVersion() string {
 // added (1.24).
 func (cli *Client) NegotiateAPIVersion(ctx context.Context) {
 	if !cli.manualOverride {
-		ping, _ := cli.Ping(ctx)
-		cli.negotiateAPIVersionPing(ping)
+		_ = cli.negotiateAPIVersion(ctx, true /* force renegotiation */)
 	}
+}
+
+func (cli *Client) negotiateAPIVersion(ctx context.Context, force bool) string {
+	var state versionNegotiation
+	select {
+	case <-ctx.Done():
+		return ""
+	case state = <-cli.version:
+	}
+
+	if !cli.negotiateVersion || (state.negotiated && !force) {
+		cli.version <- state
+		return state.version
+	}
+
+	ping, _ := cli.Ping(ctx)
+	return cli.negotiateAPIVersionPing(state, ping)
 }
 
 // NegotiateAPIVersionPing downgrades the client's API version to match the
@@ -242,33 +263,35 @@ func (cli *Client) NegotiateAPIVersion(ctx context.Context) {
 // added (1.24).
 func (cli *Client) NegotiateAPIVersionPing(pingResponse types.Ping) {
 	if !cli.manualOverride {
-		cli.negotiateAPIVersionPing(pingResponse)
+		cli.negotiateAPIVersionPing(<-cli.version, pingResponse)
 	}
 }
 
 // negotiateAPIVersionPing queries the API and updates the version to match the
 // API version from the ping response.
-func (cli *Client) negotiateAPIVersionPing(pingResponse types.Ping) {
+func (cli *Client) negotiateAPIVersionPing(state versionNegotiation, pingResponse types.Ping) string {
 	// default to the latest version before versioning headers existed
 	if pingResponse.APIVersion == "" {
 		pingResponse.APIVersion = "1.24"
 	}
 
 	// if the client is not initialized with a version, start with the latest supported version
-	if cli.version == "" {
-		cli.version = api.DefaultVersion
+	if state.version == "" {
+		state.version = api.DefaultVersion
 	}
 
 	// if server version is lower than the client version, downgrade
-	if versions.LessThan(pingResponse.APIVersion, cli.version) {
-		cli.version = pingResponse.APIVersion
+	if versions.LessThan(pingResponse.APIVersion, state.version) {
+		state.version = pingResponse.APIVersion
 	}
 
 	// Store the results, so that automatic API version negotiation (if enabled)
 	// won't be performed on the next request.
 	if cli.negotiateVersion {
-		cli.negotiated = true
+		state.negotiated = true
 	}
+	cli.version <- state
+	return state.version
 }
 
 // DaemonHost returns the host address used by the client

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -131,7 +131,9 @@ func TestGetAPIPath(t *testing.T) {
 			WithHost("tcp://localhost:2375"),
 		)
 		assert.NilError(t, err)
-		actual := client.getAPIPath(ctx, tc.path, tc.query)
+		versioned, err := client.versioned(ctx)
+		assert.NilError(t, err)
+		actual := versioned.getAPIPath(tc.path, tc.query)
 		assert.Check(t, is.Equal(actual, tc.expected))
 	}
 }
@@ -206,7 +208,8 @@ func TestNegotiateAPIVersionEmpty(t *testing.T) {
 	assert.NilError(t, err)
 
 	// set our version to something new
-	client.version = "1.25"
+	<-client.version
+	client.version <- versionNegotiation{version: "1.25"}
 
 	// if no version from server, expect the earliest
 	// version before APIVersion was implemented

--- a/client/config_create.go
+++ b/client/config_create.go
@@ -11,10 +11,14 @@ import (
 // ConfigCreate creates a new config.
 func (cli *Client) ConfigCreate(ctx context.Context, config swarm.ConfigSpec) (types.ConfigCreateResponse, error) {
 	var response types.ConfigCreateResponse
-	if err := cli.NewVersionError("1.30", "config create"); err != nil {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
 		return response, err
 	}
-	resp, err := cli.post(ctx, "/configs/create", nil, config, nil)
+	if err := versioned.NewVersionError("1.30", "config create"); err != nil {
+		return response, err
+	}
+	resp, err := versioned.post(ctx, "/configs/create", nil, config, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
 		return response, err

--- a/client/config_inspect.go
+++ b/client/config_inspect.go
@@ -14,10 +14,14 @@ func (cli *Client) ConfigInspectWithRaw(ctx context.Context, id string) (swarm.C
 	if id == "" {
 		return swarm.Config{}, nil, objectNotFoundError{object: "config", id: id}
 	}
-	if err := cli.NewVersionError("1.30", "config inspect"); err != nil {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
 		return swarm.Config{}, nil, err
 	}
-	resp, err := cli.get(ctx, "/configs/"+id, nil, nil)
+	if err := versioned.NewVersionError("1.30", "config inspect"); err != nil {
+		return swarm.Config{}, nil, err
+	}
+	resp, err := versioned.get(ctx, "/configs/"+id, nil, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
 		return swarm.Config{}, nil, err

--- a/client/config_inspect_test.go
+++ b/client/config_inspect_test.go
@@ -18,56 +18,58 @@ import (
 )
 
 func TestConfigInspectNotFound(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusNotFound, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusNotFound, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	_, _, err := client.ConfigInspectWithRaw(context.Background(), "unknown")
+	_, _, err = client.ConfigInspectWithRaw(context.Background(), "unknown")
 	if err == nil || !IsErrNotFound(err) {
 		t.Fatalf("expected a NotFoundError error, got %v", err)
 	}
 }
 
 func TestConfigInspectWithEmptyID(t *testing.T) {
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			return nil, errors.New("should not make request")
-		}),
-	}
-	_, _, err := client.ConfigInspectWithRaw(context.Background(), "")
+		})),
+	)
+	assert.NilError(t, err)
+	_, _, err = client.ConfigInspectWithRaw(context.Background(), "")
 	if !IsErrNotFound(err) {
 		t.Fatalf("Expected NotFoundError, got %v", err)
 	}
 }
 
 func TestConfigInspectUnsupported(t *testing.T) {
-	client := &Client{
-		version: "1.29",
-		client:  &http.Client{},
-	}
-	_, _, err := client.ConfigInspectWithRaw(context.Background(), "nothing")
+	client, err := NewClientWithOpts(WithVersion("1.29"))
+	assert.NilError(t, err)
+	_, _, err = client.ConfigInspectWithRaw(context.Background(), "nothing")
 	assert.Check(t, is.Error(err, `"config inspect" requires API version 1.30, but the Docker daemon API version is 1.29`))
 }
 
 func TestConfigInspectError(t *testing.T) {
-	client := &Client{
-		version: "1.30",
-		client:  newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithVersion("1.30"),
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	_, _, err := client.ConfigInspectWithRaw(context.Background(), "nothing")
+	_, _, err = client.ConfigInspectWithRaw(context.Background(), "nothing")
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestConfigInspectConfigNotFound(t *testing.T) {
-	client := &Client{
-		version: "1.30",
-		client:  newMockClient(errorMock(http.StatusNotFound, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithVersion("1.30"),
+		WithHTTPClient(newMockClient(errorMock(http.StatusNotFound, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	_, _, err := client.ConfigInspectWithRaw(context.Background(), "unknown")
+	_, _, err = client.ConfigInspectWithRaw(context.Background(), "unknown")
 	if err == nil || !IsErrNotFound(err) {
 		t.Fatalf("expected a configNotFoundError error, got %v", err)
 	}
@@ -75,9 +77,9 @@ func TestConfigInspectConfigNotFound(t *testing.T) {
 
 func TestConfigInspect(t *testing.T) {
 	expectedURL := "/v1.30/configs/config_id"
-	client := &Client{
-		version: "1.30",
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithVersion("1.30"),
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -91,8 +93,9 @@ func TestConfigInspect(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader(content)),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
 	configInspect, _, err := client.ConfigInspectWithRaw(context.Background(), "config_id")
 	if err != nil {

--- a/client/config_list.go
+++ b/client/config_list.go
@@ -12,7 +12,11 @@ import (
 
 // ConfigList returns the list of configs.
 func (cli *Client) ConfigList(ctx context.Context, options types.ConfigListOptions) ([]swarm.Config, error) {
-	if err := cli.NewVersionError("1.30", "config list"); err != nil {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := versioned.NewVersionError("1.30", "config list"); err != nil {
 		return nil, err
 	}
 	query := url.Values{}
@@ -26,7 +30,7 @@ func (cli *Client) ConfigList(ctx context.Context, options types.ConfigListOptio
 		query.Set("filters", filterJSON)
 	}
 
-	resp, err := cli.get(ctx, "/configs", query, nil)
+	resp, err := versioned.get(ctx, "/configs", query, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
 		return nil, err

--- a/client/config_list_test.go
+++ b/client/config_list_test.go
@@ -19,21 +19,22 @@ import (
 )
 
 func TestConfigListUnsupported(t *testing.T) {
-	client := &Client{
-		version: "1.29",
-		client:  &http.Client{},
-	}
-	_, err := client.ConfigList(context.Background(), types.ConfigListOptions{})
+	client, err := NewClientWithOpts(
+		WithVersion("1.29"),
+	)
+	assert.NilError(t, err)
+	_, err = client.ConfigList(context.Background(), types.ConfigListOptions{})
 	assert.Check(t, is.Error(err, `"config list" requires API version 1.30, but the Docker daemon API version is 1.29`))
 }
 
 func TestConfigListError(t *testing.T) {
-	client := &Client{
-		version: "1.30",
-		client:  newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithVersion("1.30"),
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	_, err := client.ConfigList(context.Background(), types.ConfigListOptions{})
+	_, err = client.ConfigList(context.Background(), types.ConfigListOptions{})
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
@@ -66,9 +67,9 @@ func TestConfigList(t *testing.T) {
 		},
 	}
 	for _, listCase := range listCases {
-		client := &Client{
-			version: "1.30",
-			client: newMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := NewClientWithOpts(
+			WithVersion("1.30"),
+			WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 				if !strings.HasPrefix(req.URL.Path, expectedURL) {
 					return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 				}
@@ -94,8 +95,9 @@ func TestConfigList(t *testing.T) {
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader(content)),
 				}, nil
-			}),
-		}
+			})),
+		)
+		assert.NilError(t, err)
 
 		configs, err := client.ConfigList(context.Background(), listCase.options)
 		if err != nil {

--- a/client/config_remove.go
+++ b/client/config_remove.go
@@ -4,10 +4,14 @@ import "context"
 
 // ConfigRemove removes a config.
 func (cli *Client) ConfigRemove(ctx context.Context, id string) error {
-	if err := cli.NewVersionError("1.30", "config remove"); err != nil {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
 		return err
 	}
-	resp, err := cli.delete(ctx, "/configs/"+id, nil, nil)
+	if err := versioned.NewVersionError("1.30", "config remove"); err != nil {
+		return err
+	}
+	resp, err := versioned.delete(ctx, "/configs/"+id, nil, nil)
 	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/config_update.go
+++ b/client/config_update.go
@@ -9,12 +9,16 @@ import (
 
 // ConfigUpdate attempts to update a config
 func (cli *Client) ConfigUpdate(ctx context.Context, id string, version swarm.Version, config swarm.ConfigSpec) error {
-	if err := cli.NewVersionError("1.30", "config update"); err != nil {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return err
+	}
+	if err := versioned.NewVersionError("1.30", "config update"); err != nil {
 		return err
 	}
 	query := url.Values{}
 	query.Set("version", version.String())
-	resp, err := cli.post(ctx, "/configs/"+id+"/update", query, config, nil)
+	resp, err := versioned.post(ctx, "/configs/"+id+"/update", query, config, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_create_test.go
+++ b/client/container_create_test.go
@@ -10,23 +10,28 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestContainerCreateError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	_, err := client.ContainerCreate(context.Background(), nil, nil, nil, nil, "nothing")
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
+	_, err = client.ContainerCreate(context.Background(), nil, nil, nil, nil, "nothing")
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error while testing StatusInternalServerError, got %T", err)
 	}
 
 	// 404 doesn't automatically means an unknown image
-	client = &Client{
-		client: newMockClient(errorMock(http.StatusNotFound, "Server error")),
-	}
+	client, err = NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusNotFound, "Server error"))),
+	)
+	assert.NilError(t, err)
+
 	_, err = client.ContainerCreate(context.Background(), nil, nil, nil, nil, "nothing")
 	if err == nil || !IsErrNotFound(err) {
 		t.Fatalf("expected a Server Error while testing StatusNotFound, got %T", err)
@@ -34,19 +39,20 @@ func TestContainerCreateError(t *testing.T) {
 }
 
 func TestContainerCreateImageNotFound(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusNotFound, "No such image")),
-	}
-	_, err := client.ContainerCreate(context.Background(), &container.Config{Image: "unknown_image"}, nil, nil, nil, "unknown")
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusNotFound, "No such image"))),
+	)
+	assert.NilError(t, err)
+	_, err = client.ContainerCreate(context.Background(), &container.Config{Image: "unknown_image"}, nil, nil, nil, "unknown")
 	if err == nil || !IsErrNotFound(err) {
 		t.Fatalf("expected an imageNotFound error, got %v, %T", err, err)
 	}
 }
 
 func TestContainerCreateWithName(t *testing.T) {
-	expectedURL := "/containers/create"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	expectedURL := "/v" + api.DefaultVersion + "/containers/create"
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -64,8 +70,9 @@ func TestContainerCreateWithName(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader(b)),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
 	r, err := client.ContainerCreate(context.Background(), nil, nil, nil, nil, "container_name")
 	if err != nil {
@@ -102,17 +109,19 @@ func TestContainerCreateAutoRemove(t *testing.T) {
 		}
 	}
 
-	client := &Client{
-		client:  newMockClient(autoRemoveValidator(false)),
-		version: "1.24",
-	}
-	if _, err := client.ContainerCreate(context.Background(), nil, &container.HostConfig{AutoRemove: true}, nil, nil, ""); err != nil {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(autoRemoveValidator(false))),
+		WithVersion("1.24"),
+	)
+	assert.NilError(t, err)
+	if _, err = client.ContainerCreate(context.Background(), nil, &container.HostConfig{AutoRemove: true}, nil, nil, ""); err != nil {
 		t.Fatal(err)
 	}
-	client = &Client{
-		client:  newMockClient(autoRemoveValidator(true)),
-		version: "1.25",
-	}
+	client, err = NewClientWithOpts(
+		WithHTTPClient(newMockClient(autoRemoveValidator(true))),
+		WithVersion("1.25"),
+	)
+	assert.NilError(t, err)
 	if _, err := client.ContainerCreate(context.Background(), nil, &container.HostConfig{AutoRemove: true}, nil, nil, ""); err != nil {
 		t.Fatal(err)
 	}

--- a/client/container_diff_test.go
+++ b/client/container_diff_test.go
@@ -10,24 +10,27 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestContainerDiffError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	_, err := client.ContainerDiff(context.Background(), "nothing")
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
+	_, err = client.ContainerDiff(context.Background(), "nothing")
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestContainerDiff(t *testing.T) {
-	expectedURL := "/containers/container_id/changes"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	expectedURL := "/v" + api.DefaultVersion + "/containers/container_id/changes"
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -48,8 +51,9 @@ func TestContainerDiff(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader(b)),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
 	changes, err := client.ContainerDiff(context.Background(), "container_id")
 	if err != nil {

--- a/client/container_exec.go
+++ b/client/container_exec.go
@@ -11,11 +11,15 @@ import (
 func (cli *Client) ContainerExecCreate(ctx context.Context, container string, config types.ExecConfig) (types.IDResponse, error) {
 	var response types.IDResponse
 
-	if err := cli.NewVersionError("1.25", "env"); len(config.Env) != 0 && err != nil {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return response, err
+	}
+	if err := versioned.NewVersionError("1.25", "env"); len(config.Env) != 0 && err != nil {
 		return response, err
 	}
 
-	resp, err := cli.post(ctx, "/containers/"+container+"/exec", nil, config, nil)
+	resp, err := versioned.post(ctx, "/containers/"+container+"/exec", nil, config, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
 		return response, err

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -10,24 +10,27 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestContainerExecCreateError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	_, err := client.ContainerExecCreate(context.Background(), "container_id", types.ExecConfig{})
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
+	_, err = client.ContainerExecCreate(context.Background(), "container_id", types.ExecConfig{})
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestContainerExecCreate(t *testing.T) {
-	expectedURL := "/containers/container_id/exec"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	expectedURL := "/v" + api.DefaultVersion + "/containers/container_id/exec"
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -55,8 +58,9 @@ func TestContainerExecCreate(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader(b)),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
 	r, err := client.ContainerExecCreate(context.Background(), "container_id", types.ExecConfig{
 		User: "user",
@@ -70,19 +74,20 @@ func TestContainerExecCreate(t *testing.T) {
 }
 
 func TestContainerExecStartError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	err := client.ContainerExecStart(context.Background(), "nothing", types.ExecStartCheck{})
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
+	err = client.ContainerExecStart(context.Background(), "nothing", types.ExecStartCheck{})
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestContainerExecStart(t *testing.T) {
-	expectedURL := "/exec/exec_id/start"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	expectedURL := "/v" + api.DefaultVersion + "/exec/exec_id/start"
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -101,10 +106,11 @@ func TestContainerExecStart(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
-	err := client.ContainerExecStart(context.Background(), "exec_id", types.ExecStartCheck{
+	err = client.ContainerExecStart(context.Background(), "exec_id", types.ExecStartCheck{
 		Detach: true,
 		Tty:    false,
 	})
@@ -114,19 +120,20 @@ func TestContainerExecStart(t *testing.T) {
 }
 
 func TestContainerExecInspectError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	_, err := client.ContainerExecInspect(context.Background(), "nothing")
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
+	_, err = client.ContainerExecInspect(context.Background(), "nothing")
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestContainerExecInspect(t *testing.T) {
-	expectedURL := "/exec/exec_id/json"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	expectedURL := "/v" + api.DefaultVersion + "/exec/exec_id/json"
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -141,8 +148,9 @@ func TestContainerExecInspect(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader(b)),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
 	inspect, err := client.ContainerExecInspect(context.Background(), "exec_id")
 	if err != nil {

--- a/client/container_export_test.go
+++ b/client/container_export_test.go
@@ -9,23 +9,26 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestContainerExportError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	_, err := client.ContainerExport(context.Background(), "nothing")
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
+	_, err = client.ContainerExport(context.Background(), "nothing")
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestContainerExport(t *testing.T) {
-	expectedURL := "/containers/container_id/export"
-	client := &Client{
-		client: newMockClient(func(r *http.Request) (*http.Response, error) {
+	expectedURL := "/v" + api.DefaultVersion + "/containers/container_id/export"
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(r *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(r.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, r.URL)
 			}
@@ -34,8 +37,9 @@ func TestContainerExport(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader([]byte("response"))),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 	body, err := client.ContainerExport(context.Background(), "container_id")
 	if err != nil {
 		t.Fatal(err)

--- a/client/container_kill_test.go
+++ b/client/container_kill_test.go
@@ -9,23 +9,26 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestContainerKillError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	err := client.ContainerKill(context.Background(), "nothing", "SIGKILL")
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
+	err = client.ContainerKill(context.Background(), "nothing", "SIGKILL")
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestContainerKill(t *testing.T) {
-	expectedURL := "/containers/container_id/kill"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	expectedURL := "/v" + api.DefaultVersion + "/containers/container_id/kill"
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -37,10 +40,11 @@ func TestContainerKill(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
-	err := client.ContainerKill(context.Background(), "container_id", "SIGKILL")
+	err = client.ContainerKill(context.Background(), "container_id", "SIGKILL")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/container_list.go
+++ b/client/container_list.go
@@ -12,6 +12,11 @@ import (
 
 // ContainerList returns the list of containers in the docker host.
 func (cli *Client) ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	query := url.Values{}
 
 	if options.All {
@@ -36,7 +41,7 @@ func (cli *Client) ContainerList(ctx context.Context, options types.ContainerLis
 
 	if options.Filters.Len() > 0 {
 		//nolint:staticcheck // ignore SA1019 for old code
-		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filters)
+		filterJSON, err := filters.ToParamWithVersion(versioned.version, options.Filters)
 
 		if err != nil {
 			return nil, err
@@ -45,7 +50,7 @@ func (cli *Client) ContainerList(ctx context.Context, options types.ContainerLis
 		query.Set("filters", filterJSON)
 	}
 
-	resp, err := cli.get(ctx, "/containers/json", query, nil)
+	resp, err := versioned.get(ctx, "/containers/json", query, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
 		return nil, err

--- a/client/container_pause_test.go
+++ b/client/container_pause_test.go
@@ -9,23 +9,26 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestContainerPauseError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	err := client.ContainerPause(context.Background(), "nothing")
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
+	err = client.ContainerPause(context.Background(), "nothing")
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestContainerPause(t *testing.T) {
-	expectedURL := "/containers/container_id/pause"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	expectedURL := "/v" + api.DefaultVersion + "/containers/container_id/pause"
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -33,9 +36,10 @@ func TestContainerPause(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 			}, nil
-		}),
-	}
-	err := client.ContainerPause(context.Background(), "container_id")
+		})),
+	)
+	assert.NilError(t, err)
+	err = client.ContainerPause(context.Background(), "container_id")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/container_prune.go
+++ b/client/container_prune.go
@@ -13,7 +13,11 @@ import (
 func (cli *Client) ContainersPrune(ctx context.Context, pruneFilters filters.Args) (types.ContainersPruneReport, error) {
 	var report types.ContainersPruneReport
 
-	if err := cli.NewVersionError("1.25", "container prune"); err != nil {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return report, err
+	}
+	if err := versioned.NewVersionError("1.25", "container prune"); err != nil {
 		return report, err
 	}
 
@@ -22,7 +26,7 @@ func (cli *Client) ContainersPrune(ctx context.Context, pruneFilters filters.Arg
 		return report, err
 	}
 
-	serverResp, err := cli.post(ctx, "/containers/prune", query, nil, nil)
+	serverResp, err := versioned.post(ctx, "/containers/prune", query, nil, nil)
 	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return report, err

--- a/client/container_prune_test.go
+++ b/client/container_prune_test.go
@@ -18,14 +18,15 @@ import (
 )
 
 func TestContainersPruneError(t *testing.T) {
-	client := &Client{
-		client:  newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-		version: "1.25",
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+		WithVersion("1.25"),
+	)
+	assert.NilError(t, err)
 
 	filters := filters.NewArgs()
 
-	_, err := client.ContainersPrune(context.Background(), filters)
+	_, err = client.ContainersPrune(context.Background(), filters)
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
@@ -95,8 +96,8 @@ func TestContainersPrune(t *testing.T) {
 		},
 	}
 	for _, listCase := range listCases {
-		client := &Client{
-			client: newMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := NewClientWithOpts(
+			WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 				if !strings.HasPrefix(req.URL.Path, expectedURL) {
 					return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 				}
@@ -116,9 +117,10 @@ func TestContainersPrune(t *testing.T) {
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader(content)),
 				}, nil
-			}),
-			version: "1.25",
-		}
+			})),
+			WithVersion("1.25"),
+		)
+		assert.NilError(t, err)
 
 		report, err := client.ContainersPrune(context.Background(), listCase.filters)
 		assert.Check(t, err)

--- a/client/container_remove_test.go
+++ b/client/container_remove_test.go
@@ -9,34 +9,37 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
 )
 
 func TestContainerRemoveError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	err := client.ContainerRemove(context.Background(), "container_id", types.ContainerRemoveOptions{})
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
+	err = client.ContainerRemove(context.Background(), "container_id", types.ContainerRemoveOptions{})
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestContainerRemoveNotFoundError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusNotFound, "no such container: container_id")),
-	}
-	err := client.ContainerRemove(context.Background(), "container_id", types.ContainerRemoveOptions{})
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusNotFound, "no such container: container_id"))),
+	)
+	assert.NilError(t, err)
+	err = client.ContainerRemove(context.Background(), "container_id", types.ContainerRemoveOptions{})
 	assert.ErrorContains(t, err, "no such container: container_id")
 	assert.Check(t, IsErrNotFound(err))
 }
 
 func TestContainerRemove(t *testing.T) {
-	expectedURL := "/containers/container_id"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	expectedURL := "/v" + api.DefaultVersion + "/containers/container_id"
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -57,10 +60,11 @@ func TestContainerRemove(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
-	err := client.ContainerRemove(context.Background(), "container_id", types.ContainerRemoveOptions{
+	err = client.ContainerRemove(context.Background(), "container_id", types.ContainerRemoveOptions{
 		RemoveVolumes: true,
 		Force:         true,
 	})

--- a/client/container_resize_test.go
+++ b/client/container_resize_test.go
@@ -9,36 +9,41 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestContainerResizeError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	err := client.ContainerResize(context.Background(), "container_id", types.ResizeOptions{})
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
+	err = client.ContainerResize(context.Background(), "container_id", types.ResizeOptions{})
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestContainerExecResizeError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	err := client.ContainerExecResize(context.Background(), "exec_id", types.ResizeOptions{})
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
+	err = client.ContainerExecResize(context.Background(), "exec_id", types.ResizeOptions{})
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestContainerResize(t *testing.T) {
-	client := &Client{
-		client: newMockClient(resizeTransport("/containers/container_id/resize")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(resizeTransport("/v" + api.DefaultVersion + "/containers/container_id/resize"))),
+	)
+	assert.NilError(t, err)
 
-	err := client.ContainerResize(context.Background(), "container_id", types.ResizeOptions{
+	err = client.ContainerResize(context.Background(), "container_id", types.ResizeOptions{
 		Height: 500,
 		Width:  600,
 	})
@@ -48,11 +53,12 @@ func TestContainerResize(t *testing.T) {
 }
 
 func TestContainerExecResize(t *testing.T) {
-	client := &Client{
-		client: newMockClient(resizeTransport("/exec/exec_id/resize")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(resizeTransport("/v" + api.DefaultVersion + "/exec/exec_id/resize"))),
+	)
+	assert.NilError(t, err)
 
-	err := client.ContainerExecResize(context.Background(), "exec_id", types.ResizeOptions{
+	err = client.ContainerExecResize(context.Background(), "exec_id", types.ResizeOptions{
 		Height: 500,
 		Width:  600,
 	})

--- a/client/container_restart.go
+++ b/client/container_restart.go
@@ -13,14 +13,18 @@ import (
 // It makes the daemon wait for the container to be up again for
 // a specific amount of time, given the timeout.
 func (cli *Client) ContainerRestart(ctx context.Context, containerID string, options container.StopOptions) error {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return err
+	}
 	query := url.Values{}
 	if options.Timeout != nil {
 		query.Set("t", strconv.Itoa(*options.Timeout))
 	}
-	if options.Signal != "" && versions.GreaterThanOrEqualTo(cli.version, "1.42") {
+	if options.Signal != "" && versions.GreaterThanOrEqualTo(versioned.version, "1.42") {
 		query.Set("signal", options.Signal)
 	}
-	resp, err := cli.post(ctx, "/containers/"+containerID+"/restart", query, nil, nil)
+	resp, err := versioned.post(ctx, "/containers/"+containerID+"/restart", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_stop.go
+++ b/client/container_stop.go
@@ -17,14 +17,18 @@ import (
 // otherwise the engine default. A negative timeout value can be specified,
 // meaning no timeout, i.e. no forceful termination is performed.
 func (cli *Client) ContainerStop(ctx context.Context, containerID string, options container.StopOptions) error {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return err
+	}
 	query := url.Values{}
 	if options.Timeout != nil {
 		query.Set("t", strconv.Itoa(*options.Timeout))
 	}
-	if options.Signal != "" && versions.GreaterThanOrEqualTo(cli.version, "1.42") {
+	if options.Signal != "" && versions.GreaterThanOrEqualTo(versioned.version, "1.42") {
 		query.Set("signal", options.Signal)
 	}
-	resp, err := cli.post(ctx, "/containers/"+containerID+"/stop", query, nil, nil)
+	resp, err := versioned.post(ctx, "/containers/"+containerID+"/stop", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_stop_test.go
+++ b/client/container_stop_test.go
@@ -11,13 +11,15 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestContainerStopError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	err := client.ContainerStop(context.Background(), "nothing", container.StopOptions{})
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
+	err = client.ContainerStop(context.Background(), "nothing", container.StopOptions{})
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
@@ -25,8 +27,8 @@ func TestContainerStopError(t *testing.T) {
 
 func TestContainerStop(t *testing.T) {
 	const expectedURL = "/v1.42/containers/container_id/stop"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -42,11 +44,12 @@ func TestContainerStop(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 			}, nil
-		}),
-		version: "1.42",
-	}
+		})),
+		WithVersion("1.42"),
+	)
+	assert.NilError(t, err)
 	timeout := 100
-	err := client.ContainerStop(context.Background(), "container_id", container.StopOptions{
+	err = client.ContainerStop(context.Background(), "container_id", container.StopOptions{
 		Signal:  "SIGKILL",
 		Timeout: &timeout,
 	})

--- a/client/container_top_test.go
+++ b/client/container_top_test.go
@@ -11,30 +11,33 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestContainerTopError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	_, err := client.ContainerTop(context.Background(), "nothing", []string{})
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
+	_, err = client.ContainerTop(context.Background(), "nothing", []string{})
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestContainerTop(t *testing.T) {
-	expectedURL := "/containers/container_id/top"
+	expectedURL := "/v" + api.DefaultVersion + "/containers/container_id/top"
 	expectedProcesses := [][]string{
 		{"p1", "p2"},
 		{"p3"},
 	}
 	expectedTitles := []string{"title1", "title2"}
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -59,8 +62,9 @@ func TestContainerTop(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader(b)),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
 	processList, err := client.ContainerTop(context.Background(), "container_id", []string{"arg1", "arg2"})
 	if err != nil {

--- a/client/container_unpause_test.go
+++ b/client/container_unpause_test.go
@@ -9,23 +9,26 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestContainerUnpauseError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	err := client.ContainerUnpause(context.Background(), "nothing")
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
+	err = client.ContainerUnpause(context.Background(), "nothing")
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestContainerUnpause(t *testing.T) {
-	expectedURL := "/containers/container_id/unpause"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	expectedURL := "/v" + api.DefaultVersion + "/containers/container_id/unpause"
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -33,9 +36,10 @@ func TestContainerUnpause(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 			}, nil
-		}),
-	}
-	err := client.ContainerUnpause(context.Background(), "container_id")
+		})),
+	)
+	assert.NilError(t, err)
+	err = client.ContainerUnpause(context.Background(), "container_id")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/container_update_test.go
+++ b/client/container_update_test.go
@@ -10,25 +10,28 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestContainerUpdateError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	_, err := client.ContainerUpdate(context.Background(), "nothing", container.UpdateConfig{})
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
+	_, err = client.ContainerUpdate(context.Background(), "nothing", container.UpdateConfig{})
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestContainerUpdate(t *testing.T) {
-	expectedURL := "/containers/container_id/update"
+	expectedURL := "/v" + api.DefaultVersion + "/containers/container_id/update"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -42,10 +45,11 @@ func TestContainerUpdate(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader(b)),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
-	_, err := client.ContainerUpdate(context.Background(), "container_id", container.UpdateConfig{
+	_, err = client.ContainerUpdate(context.Background(), "container_id", container.UpdateConfig{
 		Resources: container.Resources{
 			CPUPeriod: 1,
 		},

--- a/client/container_wait_test.go
+++ b/client/container_wait_test.go
@@ -12,14 +12,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestContainerWaitError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
 	resultC, errC := client.ContainerWait(context.Background(), "nothing", "")
 	select {
 	case result := <-resultC:
@@ -32,9 +35,9 @@ func TestContainerWaitError(t *testing.T) {
 }
 
 func TestContainerWait(t *testing.T) {
-	expectedURL := "/containers/container_id/wait"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	expectedURL := "/v" + api.DefaultVersion + "/containers/container_id/wait"
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -48,8 +51,9 @@ func TestContainerWait(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader(b)),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
 	resultC, errC := client.ContainerWait(context.Background(), "container_id", "")
 	select {

--- a/client/disk_usage_test.go
+++ b/client/disk_usage_test.go
@@ -10,24 +10,27 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestDiskUsageError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	_, err := client.DiskUsage(context.Background(), types.DiskUsageOptions{})
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
+	_, err = client.DiskUsage(context.Background(), types.DiskUsageOptions{})
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestDiskUsage(t *testing.T) {
-	expectedURL := "/system/df"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	expectedURL := "/v" + api.DefaultVersion + "/system/df"
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -48,9 +51,10 @@ func TestDiskUsage(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader(b)),
 			}, nil
-		}),
-	}
-	if _, err := client.DiskUsage(context.Background(), types.DiskUsageOptions{}); err != nil {
+		})),
+	)
+	assert.NilError(t, err)
+	if _, err = client.DiskUsage(context.Background(), types.DiskUsageOptions{}); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/client/distribution_inspect.go
+++ b/client/distribution_inspect.go
@@ -16,7 +16,11 @@ func (cli *Client) DistributionInspect(ctx context.Context, image, encodedRegist
 		return distributionInspect, objectNotFoundError{object: "distribution", id: image}
 	}
 
-	if err := cli.NewVersionError("1.30", "distribution inspect"); err != nil {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return distributionInspect, err
+	}
+	if err := versioned.NewVersionError("1.30", "distribution inspect"); err != nil {
 		return distributionInspect, err
 	}
 	var headers map[string][]string
@@ -27,7 +31,7 @@ func (cli *Client) DistributionInspect(ctx context.Context, image, encodedRegist
 		}
 	}
 
-	resp, err := cli.get(ctx, "/distribution/"+image+"/json", url.Values{}, headers)
+	resp, err := versioned.get(ctx, "/distribution/"+image+"/json", url.Values{}, headers)
 	defer ensureReaderClosed(resp)
 	if err != nil {
 		return distributionInspect, err

--- a/client/distribution_inspect_test.go
+++ b/client/distribution_inspect_test.go
@@ -11,21 +11,22 @@ import (
 )
 
 func TestDistributionInspectUnsupported(t *testing.T) {
-	client := &Client{
-		version: "1.29",
-		client:  &http.Client{},
-	}
-	_, err := client.DistributionInspect(context.Background(), "foobar:1.0", "")
+	client, err := NewClientWithOpts(
+		WithVersion("1.29"),
+	)
+	assert.NilError(t, err)
+	_, err = client.DistributionInspect(context.Background(), "foobar:1.0", "")
 	assert.Check(t, is.Error(err, `"distribution inspect" requires API version 1.30, but the Docker daemon API version is 1.29`))
 }
 
 func TestDistributionInspectWithEmptyID(t *testing.T) {
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			return nil, errors.New("should not make request")
-		}),
-	}
-	_, err := client.DistributionInspect(context.Background(), "", "")
+		})),
+	)
+	assert.NilError(t, err)
+	_, err = client.DistributionInspect(context.Background(), "", "")
 	if !IsErrNotFound(err) {
 		t.Fatalf("Expected NotFoundError, got %v", err)
 	}

--- a/client/errors.go
+++ b/client/errors.go
@@ -116,7 +116,7 @@ func IsErrNotImplemented(err error) bool {
 
 // NewVersionError returns an error if the APIVersion required
 // if less than the current supported version
-func (cli *Client) NewVersionError(APIrequired, feature string) error {
+func (cli versionedClient) NewVersionError(APIrequired, feature string) error {
 	if cli.version != "" && versions.LessThan(cli.version, APIrequired) {
 		return fmt.Errorf("%q requires API version %s, but the Docker daemon API version is %s", feature, APIrequired, cli.version)
 	}

--- a/client/events.go
+++ b/client/events.go
@@ -25,14 +25,20 @@ func (cli *Client) Events(ctx context.Context, options types.EventsOptions) (<-c
 	go func() {
 		defer close(errs)
 
-		query, err := buildEventsQueryParams(cli.version, options)
+		versioned, err := cli.versioned(ctx)
+		if err != nil {
+			close(started)
+			errs <- err
+			return
+		}
+		query, err := buildEventsQueryParams(versioned.version, options)
 		if err != nil {
 			close(started)
 			errs <- err
 			return
 		}
 
-		resp, err := cli.get(ctx, "/events", query, nil)
+		resp, err := versioned.get(ctx, "/events", query, nil)
 		if err != nil {
 			close(started)
 			errs <- err

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -18,7 +18,11 @@ import (
 // The Body in the response implements an io.ReadCloser and it's up to the caller to
 // close it.
 func (cli *Client) ImageBuild(ctx context.Context, buildContext io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error) {
-	query, err := cli.imageBuildOptionsToQuery(options)
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return types.ImageBuildResponse{}, err
+	}
+	query, err := versioned.imageBuildOptionsToQuery(options)
 	if err != nil {
 		return types.ImageBuildResponse{}, err
 	}
@@ -32,7 +36,7 @@ func (cli *Client) ImageBuild(ctx context.Context, buildContext io.Reader, optio
 
 	headers.Set("Content-Type", "application/x-tar")
 
-	serverResp, err := cli.postRaw(ctx, "/build", query, buildContext, headers)
+	serverResp, err := versioned.postRaw(ctx, "/build", query, buildContext, headers)
 	if err != nil {
 		return types.ImageBuildResponse{}, err
 	}
@@ -45,7 +49,7 @@ func (cli *Client) ImageBuild(ctx context.Context, buildContext io.Reader, optio
 	}, nil
 }
 
-func (cli *Client) imageBuildOptionsToQuery(options types.ImageBuildOptions) (url.Values, error) {
+func (cli versionedClient) imageBuildOptionsToQuery(options types.ImageBuildOptions) (url.Values, error) {
 	query := url.Values{
 		"t":           options.Tags,
 		"securityopt": options.SecurityOpt,

--- a/client/image_import_test.go
+++ b/client/image_import_test.go
@@ -10,24 +10,27 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestImageImportError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	_, err := client.ImageImport(context.Background(), types.ImageImportSource{}, "image:tag", types.ImageImportOptions{})
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
+	_, err = client.ImageImport(context.Background(), types.ImageImportSource{}, "image:tag", types.ImageImportOptions{})
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestImageImport(t *testing.T) {
-	expectedURL := "/images/create"
-	client := &Client{
-		client: newMockClient(func(r *http.Request) (*http.Response, error) {
+	expectedURL := "/v" + api.DefaultVersion + "/images/create"
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(r *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(r.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, r.URL)
 			}
@@ -58,8 +61,9 @@ func TestImageImport(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader([]byte("response"))),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 	importResponse, err := client.ImageImport(context.Background(), types.ImageImportSource{
 		Source:     strings.NewReader("source"),
 		SourceName: "image_source",

--- a/client/image_prune.go
+++ b/client/image_prune.go
@@ -13,7 +13,11 @@ import (
 func (cli *Client) ImagesPrune(ctx context.Context, pruneFilters filters.Args) (types.ImagesPruneReport, error) {
 	var report types.ImagesPruneReport
 
-	if err := cli.NewVersionError("1.25", "image prune"); err != nil {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return report, err
+	}
+	if err := versioned.NewVersionError("1.25", "image prune"); err != nil {
 		return report, err
 	}
 
@@ -22,7 +26,7 @@ func (cli *Client) ImagesPrune(ctx context.Context, pruneFilters filters.Args) (
 		return report, err
 	}
 
-	serverResp, err := cli.post(ctx, "/images/prune", query, nil, nil)
+	serverResp, err := versioned.post(ctx, "/images/prune", query, nil, nil)
 	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return report, err

--- a/client/network_create_test.go
+++ b/client/network_create_test.go
@@ -10,26 +10,29 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestNetworkCreateError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	_, err := client.NetworkCreate(context.Background(), "mynetwork", types.NetworkCreate{})
+	_, err = client.NetworkCreate(context.Background(), "mynetwork", types.NetworkCreate{})
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestNetworkCreate(t *testing.T) {
-	expectedURL := "/networks/create"
+	expectedURL := "/v" + api.DefaultVersion + "/networks/create"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -49,8 +52,9 @@ func TestNetworkCreate(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader(content)),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
 	networkResponse, err := client.NetworkCreate(context.Background(), "mynetwork", types.NetworkCreate{
 		CheckDuplicate: true,

--- a/client/network_disconnect_test.go
+++ b/client/network_disconnect_test.go
@@ -10,26 +10,29 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestNetworkDisconnectError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	err := client.NetworkDisconnect(context.Background(), "network_id", "container_id", false)
+	err = client.NetworkDisconnect(context.Background(), "network_id", "container_id", false)
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestNetworkDisconnect(t *testing.T) {
-	expectedURL := "/networks/network_id/disconnect"
+	expectedURL := "/v" + api.DefaultVersion + "/networks/network_id/disconnect"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -55,10 +58,11 @@ func TestNetworkDisconnect(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
-	err := client.NetworkDisconnect(context.Background(), "network_id", "container_id", true)
+	err = client.NetworkDisconnect(context.Background(), "network_id", "container_id", true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/network_list.go
+++ b/client/network_list.go
@@ -11,10 +11,14 @@ import (
 
 // NetworkList returns the list of networks configured in the docker host.
 func (cli *Client) NetworkList(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error) {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return nil, err
+	}
 	query := url.Values{}
 	if options.Filters.Len() > 0 {
 		//nolint:staticcheck // ignore SA1019 for old code
-		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filters)
+		filterJSON, err := filters.ToParamWithVersion(versioned.version, options.Filters)
 		if err != nil {
 			return nil, err
 		}
@@ -22,7 +26,7 @@ func (cli *Client) NetworkList(ctx context.Context, options types.NetworkListOpt
 		query.Set("filters", filterJSON)
 	}
 	var networkResources []types.NetworkResource
-	resp, err := cli.get(ctx, "/networks", query, nil)
+	resp, err := versioned.get(ctx, "/networks", query, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
 		return networkResources, err

--- a/client/network_prune.go
+++ b/client/network_prune.go
@@ -13,7 +13,11 @@ import (
 func (cli *Client) NetworksPrune(ctx context.Context, pruneFilters filters.Args) (types.NetworksPruneReport, error) {
 	var report types.NetworksPruneReport
 
-	if err := cli.NewVersionError("1.25", "network prune"); err != nil {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return report, err
+	}
+	if err := versioned.NewVersionError("1.25", "network prune"); err != nil {
 		return report, err
 	}
 
@@ -22,7 +26,7 @@ func (cli *Client) NetworksPrune(ctx context.Context, pruneFilters filters.Args)
 		return report, err
 	}
 
-	serverResp, err := cli.post(ctx, "/networks/prune", query, nil, nil)
+	serverResp, err := versioned.post(ctx, "/networks/prune", query, nil, nil)
 	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return report, err

--- a/client/network_remove_test.go
+++ b/client/network_remove_test.go
@@ -9,25 +9,28 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestNetworkRemoveError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	err := client.NetworkRemove(context.Background(), "network_id")
+	err = client.NetworkRemove(context.Background(), "network_id")
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestNetworkRemove(t *testing.T) {
-	expectedURL := "/networks/network_id"
+	expectedURL := "/v" + api.DefaultVersion + "/networks/network_id"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -38,10 +41,11 @@ func TestNetworkRemove(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader([]byte("body"))),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
-	err := client.NetworkRemove(context.Background(), "network_id")
+	err = client.NetworkRemove(context.Background(), "network_id")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/node_list_test.go
+++ b/client/node_list_test.go
@@ -10,25 +10,28 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestNodeListError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	_, err := client.NodeList(context.Background(), types.NodeListOptions{})
+	_, err = client.NodeList(context.Background(), types.NodeListOptions{})
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestNodeList(t *testing.T) {
-	expectedURL := "/nodes"
+	expectedURL := "/v" + api.DefaultVersion + "/nodes"
 
 	filters := filters.NewArgs()
 	filters.Add("label", "label1")
@@ -54,8 +57,8 @@ func TestNodeList(t *testing.T) {
 		},
 	}
 	for _, listCase := range listCases {
-		client := &Client{
-			client: newMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := NewClientWithOpts(
+			WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 				if !strings.HasPrefix(req.URL.Path, expectedURL) {
 					return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 				}
@@ -81,8 +84,9 @@ func TestNodeList(t *testing.T) {
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader(content)),
 				}, nil
-			}),
-		}
+			})),
+		)
+		assert.NilError(t, err)
 
 		nodes, err := client.NodeList(context.Background(), listCase.options)
 		if err != nil {

--- a/client/options.go
+++ b/client/options.go
@@ -189,8 +189,10 @@ func WithTLSClientConfigFromEnv() Opt {
 func WithVersion(version string) Opt {
 	return func(c *Client) error {
 		if version != "" {
-			c.version = version
+			v := <-c.version
+			v.version = version
 			c.manualOverride = true
+			c.version <- v
 		}
 		return nil
 	}

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -40,7 +40,7 @@ func TestOptionWithVersionFromEnv(t *testing.T) {
 	c, err := NewClientWithOpts(WithVersionFromEnv())
 	assert.NilError(t, err)
 	assert.Check(t, c.client != nil)
-	assert.Equal(t, c.version, api.DefaultVersion)
+	assert.Equal(t, (<-c.version).version, api.DefaultVersion)
 	assert.Equal(t, c.manualOverride, false)
 
 	t.Setenv("DOCKER_API_VERSION", "2.9999")
@@ -48,6 +48,6 @@ func TestOptionWithVersionFromEnv(t *testing.T) {
 	c, err = NewClientWithOpts(WithVersionFromEnv())
 	assert.NilError(t, err)
 	assert.Check(t, c.client != nil)
-	assert.Equal(t, c.version, "2.9999")
+	assert.Equal(t, (<-c.version).version, "2.9999")
 	assert.Equal(t, c.manualOverride, true)
 }

--- a/client/ping.go
+++ b/client/ping.go
@@ -3,12 +3,10 @@ package client // import "github.com/docker/docker/client"
 import (
 	"context"
 	"net/http"
-	"path"
 	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/errdefs"
 )
 
 // Ping pings the server and returns the value of the "Docker-Experimental",
@@ -16,60 +14,49 @@ import (
 // a HEAD request on the endpoint, but falls back to GET if HEAD is not supported
 // by the daemon.
 func (cli *Client) Ping(ctx context.Context) (types.Ping, error) {
-	var ping types.Ping
+	// Ping requests are used during API version negotiation, so we want to
+	// hit the non-versioned /_ping endpoint, not /v1.xx/_ping
+	unversioned := versionedClient{cli: cli, version: ""}
+	serverResp, err := unversioned.head(ctx, "/_ping", nil, nil)
+	ensureReaderClosed(serverResp) // We're only interested in the headers.
+	switch serverResp.statusCode {
+	case http.StatusOK, http.StatusInternalServerError:
+		// Server handled the request, so parse the response
+		return parsePingResponse(serverResp.header), err
+	}
+	// We only want to fall back to GET if the daemon is reachable but does
+	// not support HEAD /_ping requests. The client converts status codes
+	// outside of the 2xx and 3xx ranges into different kinds of errors,
+	// which makes it awkward and error-prone to differentiate "errors
+	// returned by the daemon" from "errors making the request" by testing
+	// only the error value. There is an easy tell, however:
+	// serverResp.statusCode is set to a positive value iff the HTTP client
+	// successfully received and parsed the server response, therefore in
+	// such cases any returned error must be an error returned by the
+	// daemon.
+	if err != nil && serverResp.statusCode <= 0 {
+		return types.Ping{}, err
+	}
 
-	// Using cli.buildRequest() + cli.doRequest() instead of cli.sendRequest()
-	// because ping requests are used during API version negotiation, so we want
-	// to hit the non-versioned /_ping endpoint, not /v1.xx/_ping
-	req, err := cli.buildRequest(http.MethodHead, path.Join(cli.basePath, "/_ping"), nil, nil)
-	if err != nil {
-		return ping, err
-	}
-	serverResp, err := cli.doRequest(ctx, req)
-	if err == nil {
-		defer ensureReaderClosed(serverResp)
-		switch serverResp.statusCode {
-		case http.StatusOK, http.StatusInternalServerError:
-			// Server handled the request, so parse the response
-			return parsePingResponse(cli, serverResp)
-		}
-	} else if IsErrConnectionFailed(err) {
-		return ping, err
-	}
-
-	req, err = cli.buildRequest(http.MethodGet, path.Join(cli.basePath, "/_ping"), nil, nil)
-	if err != nil {
-		return ping, err
-	}
-	serverResp, err = cli.doRequest(ctx, req)
-	defer ensureReaderClosed(serverResp)
-	if err != nil {
-		return ping, err
-	}
-	return parsePingResponse(cli, serverResp)
+	serverResp, err = unversioned.get(ctx, "/_ping", nil, nil)
+	ensureReaderClosed(serverResp)
+	return parsePingResponse(serverResp.header), err
 }
 
-func parsePingResponse(cli *Client, resp serverResponse) (types.Ping, error) {
-	var ping types.Ping
-	if resp.header == nil {
-		err := cli.checkResponseErr(resp)
-		return ping, errdefs.FromStatusCode(err, resp.statusCode)
-	}
-	ping.APIVersion = resp.header.Get("API-Version")
-	ping.OSType = resp.header.Get("OSType")
-	if resp.header.Get("Docker-Experimental") == "true" {
-		ping.Experimental = true
-	}
-	if bv := resp.header.Get("Builder-Version"); bv != "" {
-		ping.BuilderVersion = types.BuilderVersion(bv)
-	}
-	if si := resp.header.Get("Swarm"); si != "" {
+func parsePingResponse(header http.Header) types.Ping {
+	var swarmStatus *swarm.Status
+	if si := header.Get("Swarm"); si != "" {
 		parts := strings.SplitN(si, "/", 2)
-		ping.SwarmStatus = &swarm.Status{
+		swarmStatus = &swarm.Status{
 			NodeState:        swarm.LocalNodeState(parts[0]),
 			ControlAvailable: len(parts) == 2 && parts[1] == "manager",
 		}
 	}
-	err := cli.checkResponseErr(resp)
-	return ping, errdefs.FromStatusCode(err, resp.statusCode)
+	return types.Ping{
+		APIVersion:     header.Get("API-Version"),
+		OSType:         header.Get("OSType"),
+		Experimental:   header.Get("Docker-Experimental") == "true",
+		BuilderVersion: types.BuilderVersion(header.Get("Builder-Version")),
+		SwarmStatus:    swarmStatus,
+	}
 }

--- a/client/ping_test.go
+++ b/client/ping_test.go
@@ -56,23 +56,14 @@ func TestPingFail(t *testing.T) {
 func TestPingWithError(t *testing.T) {
 	client, err := NewClientWithOpts(
 		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
-			resp := &http.Response{StatusCode: http.StatusInternalServerError}
-			resp.Header = http.Header{}
-			resp.Header.Set("API-Version", "awesome")
-			resp.Header.Set("Docker-Experimental", "true")
-			resp.Header.Set("Swarm", "active/manager")
-			resp.Body = io.NopCloser(strings.NewReader("some error with the server"))
-			return resp, errors.New("some error")
+			return nil, errors.New("some error")
 		})),
 	)
 	assert.NilError(t, err)
 
 	ping, err := client.Ping(context.Background())
 	assert.ErrorContains(t, err, "some error")
-	assert.Check(t, is.Equal(false, ping.Experimental))
-	assert.Check(t, is.Equal("", ping.APIVersion))
-	var si *swarm.Status
-	assert.Check(t, is.Equal(si, ping.SwarmStatus))
+	assert.Check(t, is.DeepEqual(ping, types.Ping{}))
 }
 
 // TestPingSuccess tests that we are able to get the expected API headers/ping

--- a/client/ping_test.go
+++ b/client/ping_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -19,8 +20,8 @@ import (
 // panics.
 func TestPingFail(t *testing.T) {
 	var withHeader bool
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			resp := &http.Response{StatusCode: http.StatusInternalServerError}
 			if withHeader {
 				resp.Header = http.Header{}
@@ -30,29 +31,31 @@ func TestPingFail(t *testing.T) {
 			}
 			resp.Body = io.NopCloser(strings.NewReader("some error with the server"))
 			return resp, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
+	var want types.Ping
 	ping, err := client.Ping(context.Background())
 	assert.ErrorContains(t, err, "some error with the server")
-	assert.Check(t, is.Equal(false, ping.Experimental))
-	assert.Check(t, is.Equal("", ping.APIVersion))
-	var si *swarm.Status
-	assert.Check(t, is.Equal(si, ping.SwarmStatus))
+	assert.Check(t, is.DeepEqual(ping, want))
 
 	withHeader = true
 	ping2, err := client.Ping(context.Background())
 	assert.ErrorContains(t, err, "some error with the server")
-	assert.Check(t, is.Equal(true, ping2.Experimental))
-	assert.Check(t, is.Equal("awesome", ping2.APIVersion))
-	assert.Check(t, is.Equal(swarm.Status{NodeState: "inactive"}, *ping2.SwarmStatus))
+	want = types.Ping{
+		Experimental: true,
+		APIVersion:   "awesome",
+		SwarmStatus:  &swarm.Status{NodeState: "inactive"},
+	}
+	assert.Check(t, is.DeepEqual(ping2, want))
 }
 
 // TestPingWithError tests the case where there is a protocol error in the ping.
 // This test is mostly just testing that there are no panics in this code path.
 func TestPingWithError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			resp := &http.Response{StatusCode: http.StatusInternalServerError}
 			resp.Header = http.Header{}
 			resp.Header.Set("API-Version", "awesome")
@@ -60,8 +63,9 @@ func TestPingWithError(t *testing.T) {
 			resp.Header.Set("Swarm", "active/manager")
 			resp.Body = io.NopCloser(strings.NewReader("some error with the server"))
 			return resp, errors.New("some error")
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
 	ping, err := client.Ping(context.Background())
 	assert.ErrorContains(t, err, "some error")
@@ -74,8 +78,8 @@ func TestPingWithError(t *testing.T) {
 // TestPingSuccess tests that we are able to get the expected API headers/ping
 // details on success.
 func TestPingSuccess(t *testing.T) {
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			resp := &http.Response{StatusCode: http.StatusOK}
 			resp.Header = http.Header{}
 			resp.Header.Set("API-Version", "awesome")
@@ -83,8 +87,9 @@ func TestPingSuccess(t *testing.T) {
 			resp.Header.Set("Swarm", "active/manager")
 			resp.Body = io.NopCloser(strings.NewReader("OK"))
 			return resp, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 	ping, err := client.Ping(context.Background())
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(true, ping.Experimental))
@@ -120,8 +125,8 @@ func TestPingHeadFallback(t *testing.T) {
 		tc := tc
 		t.Run(http.StatusText(tc.status), func(t *testing.T) {
 			var reqs []string
-			client := &Client{
-				client: newMockClient(func(req *http.Request) (*http.Response, error) {
+			client, err := NewClientWithOpts(
+				WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 					reqs = append(reqs, req.Method)
 					resp := &http.Response{StatusCode: http.StatusOK}
 					if req.Method == http.MethodHead {
@@ -130,8 +135,9 @@ func TestPingHeadFallback(t *testing.T) {
 					resp.Header = http.Header{}
 					resp.Header.Add("API-Version", strings.Join(reqs, ", "))
 					return resp, nil
-				}),
-			}
+				})),
+			)
+			assert.NilError(t, err)
 			ping, _ := client.Ping(context.Background())
 			assert.Check(t, is.Equal(ping.APIVersion, tc.expected))
 		})

--- a/client/plugin_disable_test.go
+++ b/client/plugin_disable_test.go
@@ -9,26 +9,29 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestPluginDisableError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	err := client.PluginDisable(context.Background(), "plugin_name", types.PluginDisableOptions{})
+	err = client.PluginDisable(context.Background(), "plugin_name", types.PluginDisableOptions{})
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestPluginDisable(t *testing.T) {
-	expectedURL := "/plugins/plugin_name/disable"
+	expectedURL := "/v" + api.DefaultVersion + "/plugins/plugin_name/disable"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -39,10 +42,11 @@ func TestPluginDisable(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
-	err := client.PluginDisable(context.Background(), "plugin_name", types.PluginDisableOptions{})
+	err = client.PluginDisable(context.Background(), "plugin_name", types.PluginDisableOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/plugin_inspect_test.go
+++ b/client/plugin_inspect_test.go
@@ -10,38 +10,42 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
+	"gotest.tools/v3/assert"
 )
 
 func TestPluginInspectError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	_, _, err := client.PluginInspectWithRaw(context.Background(), "nothing")
+	_, _, err = client.PluginInspectWithRaw(context.Background(), "nothing")
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestPluginInspectWithEmptyID(t *testing.T) {
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			return nil, errors.New("should not make request")
-		}),
-	}
-	_, _, err := client.PluginInspectWithRaw(context.Background(), "")
+		})),
+	)
+	assert.NilError(t, err)
+	_, _, err = client.PluginInspectWithRaw(context.Background(), "")
 	if !IsErrNotFound(err) {
 		t.Fatalf("Expected NotFoundError, got %v", err)
 	}
 }
 
 func TestPluginInspect(t *testing.T) {
-	expectedURL := "/plugins/plugin_name"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	expectedURL := "/v" + api.DefaultVersion + "/plugins/plugin_name"
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -55,8 +59,9 @@ func TestPluginInspect(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader(content)),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
 	pluginInspect, _, err := client.PluginInspectWithRaw(context.Background(), "plugin_name")
 	if err != nil {

--- a/client/plugin_list.go
+++ b/client/plugin_list.go
@@ -14,15 +14,19 @@ func (cli *Client) PluginList(ctx context.Context, filter filters.Args) (types.P
 	var plugins types.PluginsListResponse
 	query := url.Values{}
 
+	req, err := cli.versioned(ctx)
+	if err != nil {
+		return plugins, err
+	}
 	if filter.Len() > 0 {
 		//nolint:staticcheck // ignore SA1019 for old code
-		filterJSON, err := filters.ToParamWithVersion(cli.version, filter)
+		filterJSON, err := filters.ToParamWithVersion(req.version, filter)
 		if err != nil {
 			return plugins, err
 		}
 		query.Set("filters", filterJSON)
 	}
-	resp, err := cli.get(ctx, "/plugins", query, nil)
+	resp, err := req.get(ctx, "/plugins", query, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
 		return plugins, err

--- a/client/plugin_remove_test.go
+++ b/client/plugin_remove_test.go
@@ -9,26 +9,29 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestPluginRemoveError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	err := client.PluginRemove(context.Background(), "plugin_name", types.PluginRemoveOptions{})
+	err = client.PluginRemove(context.Background(), "plugin_name", types.PluginRemoveOptions{})
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestPluginRemove(t *testing.T) {
-	expectedURL := "/plugins/plugin_name"
+	expectedURL := "/v" + api.DefaultVersion + "/plugins/plugin_name"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -39,10 +42,11 @@ func TestPluginRemove(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
-	err := client.PluginRemove(context.Background(), "plugin_name", types.PluginRemoveOptions{})
+	err = client.PluginRemove(context.Background(), "plugin_name", types.PluginRemoveOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/plugin_set_test.go
+++ b/client/plugin_set_test.go
@@ -9,25 +9,28 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestPluginSetError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	err := client.PluginSet(context.Background(), "plugin_name", []string{})
+	err = client.PluginSet(context.Background(), "plugin_name", []string{})
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestPluginSet(t *testing.T) {
-	expectedURL := "/plugins/plugin_name/set"
+	expectedURL := "/v" + api.DefaultVersion + "/plugins/plugin_name/set"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -38,10 +41,11 @@ func TestPluginSet(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
-	err := client.PluginSet(context.Background(), "plugin_name", []string{"arg1"})
+	err = client.PluginSet(context.Background(), "plugin_name", []string{"arg1"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/plugin_upgrade.go
+++ b/client/plugin_upgrade.go
@@ -12,7 +12,11 @@ import (
 
 // PluginUpgrade upgrades a plugin
 func (cli *Client) PluginUpgrade(ctx context.Context, name string, options types.PluginInstallOptions) (rc io.ReadCloser, err error) {
-	if err := cli.NewVersionError("1.26", "plugin upgrade"); err != nil {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := versioned.NewVersionError("1.26", "plugin upgrade"); err != nil {
 		return nil, err
 	}
 	query := url.Values{}
@@ -21,19 +25,19 @@ func (cli *Client) PluginUpgrade(ctx context.Context, name string, options types
 	}
 	query.Set("remote", options.RemoteRef)
 
-	privileges, err := cli.checkPluginPermissions(ctx, query, options)
+	privileges, err := versioned.checkPluginPermissions(ctx, query, options)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := cli.tryPluginUpgrade(ctx, query, privileges, name, options.RegistryAuth)
+	resp, err := versioned.tryPluginUpgrade(ctx, query, privileges, name, options.RegistryAuth)
 	if err != nil {
 		return nil, err
 	}
 	return resp.body, nil
 }
 
-func (cli *Client) tryPluginUpgrade(ctx context.Context, query url.Values, privileges types.PluginPrivileges, name, registryAuth string) (serverResponse, error) {
+func (cli versionedClient) tryPluginUpgrade(ctx context.Context, query url.Values, privileges types.PluginPrivileges, name, registryAuth string) (serverResponse, error) {
 	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
 	return cli.post(ctx, "/plugins/"+name+"/upgrade", query, privileges, headers)
 }

--- a/client/request.go
+++ b/client/request.go
@@ -42,8 +42,8 @@ type versionedClient struct {
 // request to ensure that the same version is consistently used, even if the
 // client's configured version is concurrently modified.
 func (cli *Client) versioned(ctx context.Context) (versionedClient, error) {
-	ver := cli.negotiateAPIVersion(ctx, false)
-	return versionedClient{cli: cli, version: ver}, ctx.Err()
+	ver, err := cli.negotiateAPIVersion(ctx, false)
+	return versionedClient{cli: cli, version: ver}, err
 }
 
 // head sends an HTTP HEAD request to the docker API.

--- a/client/secret_create.go
+++ b/client/secret_create.go
@@ -11,10 +11,14 @@ import (
 // SecretCreate creates a new secret.
 func (cli *Client) SecretCreate(ctx context.Context, secret swarm.SecretSpec) (types.SecretCreateResponse, error) {
 	var response types.SecretCreateResponse
-	if err := cli.NewVersionError("1.25", "secret create"); err != nil {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
 		return response, err
 	}
-	resp, err := cli.post(ctx, "/secrets/create", nil, secret, nil)
+	if err := versioned.NewVersionError("1.25", "secret create"); err != nil {
+		return response, err
+	}
+	resp, err := versioned.post(ctx, "/secrets/create", nil, secret, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
 		return response, err

--- a/client/secret_inspect.go
+++ b/client/secret_inspect.go
@@ -11,13 +11,17 @@ import (
 
 // SecretInspectWithRaw returns the secret information with raw data
 func (cli *Client) SecretInspectWithRaw(ctx context.Context, id string) (swarm.Secret, []byte, error) {
-	if err := cli.NewVersionError("1.25", "secret inspect"); err != nil {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return swarm.Secret{}, nil, err
+	}
+	if err := versioned.NewVersionError("1.25", "secret inspect"); err != nil {
 		return swarm.Secret{}, nil, err
 	}
 	if id == "" {
 		return swarm.Secret{}, nil, objectNotFoundError{object: "secret", id: id}
 	}
-	resp, err := cli.get(ctx, "/secrets/"+id, nil, nil)
+	resp, err := versioned.get(ctx, "/secrets/"+id, nil, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
 		return swarm.Secret{}, nil, err

--- a/client/secret_inspect_test.go
+++ b/client/secret_inspect_test.go
@@ -18,45 +18,48 @@ import (
 )
 
 func TestSecretInspectUnsupported(t *testing.T) {
-	client := &Client{
-		version: "1.24",
-		client:  &http.Client{},
-	}
-	_, _, err := client.SecretInspectWithRaw(context.Background(), "nothing")
+	client, err := NewClientWithOpts(
+		WithVersion("1.24"),
+	)
+	assert.NilError(t, err)
+	_, _, err = client.SecretInspectWithRaw(context.Background(), "nothing")
 	assert.Check(t, is.Error(err, `"secret inspect" requires API version 1.25, but the Docker daemon API version is 1.24`))
 }
 
 func TestSecretInspectError(t *testing.T) {
-	client := &Client{
-		version: "1.25",
-		client:  newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithVersion("1.25"),
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	_, _, err := client.SecretInspectWithRaw(context.Background(), "nothing")
+	_, _, err = client.SecretInspectWithRaw(context.Background(), "nothing")
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestSecretInspectSecretNotFound(t *testing.T) {
-	client := &Client{
-		version: "1.25",
-		client:  newMockClient(errorMock(http.StatusNotFound, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithVersion("1.25"),
+		WithHTTPClient(newMockClient(errorMock(http.StatusNotFound, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	_, _, err := client.SecretInspectWithRaw(context.Background(), "unknown")
+	_, _, err = client.SecretInspectWithRaw(context.Background(), "unknown")
 	if err == nil || !IsErrNotFound(err) {
 		t.Fatalf("expected a secretNotFoundError error, got %v", err)
 	}
 }
 
 func TestSecretInspectWithEmptyID(t *testing.T) {
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			return nil, errors.New("should not make request")
-		}),
-	}
-	_, _, err := client.SecretInspectWithRaw(context.Background(), "")
+		})),
+	)
+	assert.NilError(t, err)
+	_, _, err = client.SecretInspectWithRaw(context.Background(), "")
 	if !IsErrNotFound(err) {
 		t.Fatalf("Expected NotFoundError, got %v", err)
 	}
@@ -64,9 +67,9 @@ func TestSecretInspectWithEmptyID(t *testing.T) {
 
 func TestSecretInspect(t *testing.T) {
 	expectedURL := "/v1.25/secrets/secret_id"
-	client := &Client{
-		version: "1.25",
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithVersion("1.25"),
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -80,8 +83,9 @@ func TestSecretInspect(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader(content)),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
 	secretInspect, _, err := client.SecretInspectWithRaw(context.Background(), "secret_id")
 	if err != nil {

--- a/client/secret_list.go
+++ b/client/secret_list.go
@@ -12,7 +12,11 @@ import (
 
 // SecretList returns the list of secrets.
 func (cli *Client) SecretList(ctx context.Context, options types.SecretListOptions) ([]swarm.Secret, error) {
-	if err := cli.NewVersionError("1.25", "secret list"); err != nil {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := versioned.NewVersionError("1.25", "secret list"); err != nil {
 		return nil, err
 	}
 	query := url.Values{}
@@ -26,7 +30,7 @@ func (cli *Client) SecretList(ctx context.Context, options types.SecretListOptio
 		query.Set("filters", filterJSON)
 	}
 
-	resp, err := cli.get(ctx, "/secrets", query, nil)
+	resp, err := versioned.get(ctx, "/secrets", query, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
 		return nil, err

--- a/client/secret_remove.go
+++ b/client/secret_remove.go
@@ -4,10 +4,14 @@ import "context"
 
 // SecretRemove removes a secret.
 func (cli *Client) SecretRemove(ctx context.Context, id string) error {
-	if err := cli.NewVersionError("1.25", "secret remove"); err != nil {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
 		return err
 	}
-	resp, err := cli.delete(ctx, "/secrets/"+id, nil, nil)
+	if err := versioned.NewVersionError("1.25", "secret remove"); err != nil {
+		return err
+	}
+	resp, err := versioned.delete(ctx, "/secrets/"+id, nil, nil)
 	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/secret_update.go
+++ b/client/secret_update.go
@@ -9,12 +9,16 @@ import (
 
 // SecretUpdate attempts to update a secret.
 func (cli *Client) SecretUpdate(ctx context.Context, id string, version swarm.Version, secret swarm.SecretSpec) error {
-	if err := cli.NewVersionError("1.25", "secret update"); err != nil {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return err
+	}
+	if err := versioned.NewVersionError("1.25", "secret update"); err != nil {
 		return err
 	}
 	query := url.Values{}
 	query.Set("version", version.String())
-	resp, err := cli.post(ctx, "/secrets/"+id+"/update", query, secret, nil)
+	resp, err := versioned.post(ctx, "/secrets/"+id+"/update", query, secret, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/service_create.go
+++ b/client/service_create.go
@@ -16,8 +16,12 @@ import (
 // ServiceCreate creates a new service.
 func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options types.ServiceCreateOptions) (types.ServiceCreateResponse, error) {
 	var response types.ServiceCreateResponse
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return response, err
+	}
 	headers := map[string][]string{
-		"version": {cli.version},
+		"version": {versioned.version},
 	}
 
 	if options.EncodedRegistryAuth != "" {
@@ -52,7 +56,7 @@ func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec,
 		}
 	}
 
-	resp, err := cli.post(ctx, "/services/create", nil, service, headers)
+	resp, err := versioned.post(ctx, "/services/create", nil, service, headers)
 	defer ensureReaderClosed(resp)
 	if err != nil {
 		return response, err

--- a/client/service_inspect_test.go
+++ b/client/service_inspect_test.go
@@ -10,50 +10,55 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
+	"gotest.tools/v3/assert"
 )
 
 func TestServiceInspectError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	_, _, err := client.ServiceInspectWithRaw(context.Background(), "nothing", types.ServiceInspectOptions{})
+	_, _, err = client.ServiceInspectWithRaw(context.Background(), "nothing", types.ServiceInspectOptions{})
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestServiceInspectServiceNotFound(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusNotFound, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusNotFound, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	_, _, err := client.ServiceInspectWithRaw(context.Background(), "unknown", types.ServiceInspectOptions{})
+	_, _, err = client.ServiceInspectWithRaw(context.Background(), "unknown", types.ServiceInspectOptions{})
 	if err == nil || !IsErrNotFound(err) {
 		t.Fatalf("expected a serviceNotFoundError error, got %v", err)
 	}
 }
 
 func TestServiceInspectWithEmptyID(t *testing.T) {
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			return nil, errors.New("should not make request")
-		}),
-	}
-	_, _, err := client.ServiceInspectWithRaw(context.Background(), "", types.ServiceInspectOptions{})
+		})),
+	)
+	assert.NilError(t, err)
+	_, _, err = client.ServiceInspectWithRaw(context.Background(), "", types.ServiceInspectOptions{})
 	if !IsErrNotFound(err) {
 		t.Fatalf("Expected NotFoundError, got %v", err)
 	}
 }
 
 func TestServiceInspect(t *testing.T) {
-	expectedURL := "/services/service_id"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	expectedURL := "/v" + api.DefaultVersion + "/services/service_id"
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -67,8 +72,9 @@ func TestServiceInspect(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader(content)),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
 	serviceInspect, _, err := client.ServiceInspectWithRaw(context.Background(), "service_id", types.ServiceInspectOptions{})
 	if err != nil {

--- a/client/service_remove_test.go
+++ b/client/service_remove_test.go
@@ -9,36 +9,39 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
 )
 
 func TestServiceRemoveError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	err := client.ServiceRemove(context.Background(), "service_id")
+	err = client.ServiceRemove(context.Background(), "service_id")
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestServiceRemoveNotFoundError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusNotFound, "no such service: service_id")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusNotFound, "no such service: service_id"))),
+	)
+	assert.NilError(t, err)
 
-	err := client.ServiceRemove(context.Background(), "service_id")
+	err = client.ServiceRemove(context.Background(), "service_id")
 	assert.ErrorContains(t, err, "no such service: service_id")
 	assert.Check(t, IsErrNotFound(err))
 }
 
 func TestServiceRemove(t *testing.T) {
-	expectedURL := "/services/service_id"
+	expectedURL := "/v" + api.DefaultVersion + "/services/service_id"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -49,10 +52,11 @@ func TestServiceRemove(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader([]byte("body"))),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
-	err := client.ServiceRemove(context.Background(), "service_id")
+	err = client.ServiceRemove(context.Background(), "service_id")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/service_update.go
+++ b/client/service_update.go
@@ -18,8 +18,12 @@ func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version 
 		response = types.ServiceUpdateResponse{}
 	)
 
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return response, err
+	}
 	headers := map[string][]string{
-		"version": {cli.version},
+		"version": {versioned.version},
 	}
 
 	if options.EncodedRegistryAuth != "" {
@@ -59,7 +63,7 @@ func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version 
 		}
 	}
 
-	resp, err := cli.post(ctx, "/services/"+serviceID+"/update", query, service, headers)
+	resp, err := versioned.post(ctx, "/services/"+serviceID+"/update", query, service, headers)
 	defer ensureReaderClosed(resp)
 	if err != nil {
 		return response, err

--- a/client/swarm_init_test.go
+++ b/client/swarm_init_test.go
@@ -9,26 +9,29 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestSwarmInitError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	_, err := client.SwarmInit(context.Background(), swarm.InitRequest{})
+	_, err = client.SwarmInit(context.Background(), swarm.InitRequest{})
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestSwarmInit(t *testing.T) {
-	expectedURL := "/swarm/init"
+	expectedURL := "/v" + api.DefaultVersion + "/swarm/init"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -39,8 +42,9 @@ func TestSwarmInit(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader([]byte(`"body"`))),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
 	resp, err := client.SwarmInit(context.Background(), swarm.InitRequest{
 		ListenAddr: "0.0.0.0:2377",

--- a/client/swarm_join_test.go
+++ b/client/swarm_join_test.go
@@ -9,26 +9,29 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestSwarmJoinError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	err := client.SwarmJoin(context.Background(), swarm.JoinRequest{})
+	err = client.SwarmJoin(context.Background(), swarm.JoinRequest{})
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestSwarmJoin(t *testing.T) {
-	expectedURL := "/swarm/join"
+	expectedURL := "/v" + api.DefaultVersion + "/swarm/join"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -39,10 +42,11 @@ func TestSwarmJoin(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
-	err := client.SwarmJoin(context.Background(), swarm.JoinRequest{
+	err = client.SwarmJoin(context.Background(), swarm.JoinRequest{
 		ListenAddr: "0.0.0.0:2377",
 	})
 	if err != nil {

--- a/client/swarm_update_test.go
+++ b/client/swarm_update_test.go
@@ -9,26 +9,29 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestSwarmUpdateError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	err := client.SwarmUpdate(context.Background(), swarm.Version{}, swarm.Spec{}, swarm.UpdateFlags{})
+	err = client.SwarmUpdate(context.Background(), swarm.Version{}, swarm.Spec{}, swarm.UpdateFlags{})
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestSwarmUpdate(t *testing.T) {
-	expectedURL := "/swarm/update"
+	expectedURL := "/v" + api.DefaultVersion + "/swarm/update"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -39,10 +42,11 @@ func TestSwarmUpdate(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
-	err := client.SwarmUpdate(context.Background(), swarm.Version{}, swarm.Spec{}, swarm.UpdateFlags{})
+	err = client.SwarmUpdate(context.Background(), swarm.Version{}, swarm.Spec{}, swarm.UpdateFlags{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/volume_inspect_test.go
+++ b/client/volume_inspect_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
@@ -18,47 +19,50 @@ import (
 )
 
 func TestVolumeInspectError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	_, err := client.VolumeInspect(context.Background(), "nothing")
+	_, err = client.VolumeInspect(context.Background(), "nothing")
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestVolumeInspectNotFound(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusNotFound, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusNotFound, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	_, err := client.VolumeInspect(context.Background(), "unknown")
+	_, err = client.VolumeInspect(context.Background(), "unknown")
 	assert.Check(t, IsErrNotFound(err))
 }
 
 func TestVolumeInspectWithEmptyID(t *testing.T) {
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			return nil, errors.New("should not make request")
-		}),
-	}
-	_, _, err := client.VolumeInspectWithRaw(context.Background(), "")
+		})),
+	)
+	assert.NilError(t, err)
+	_, _, err = client.VolumeInspectWithRaw(context.Background(), "")
 	if !IsErrNotFound(err) {
 		t.Fatalf("Expected NotFoundError, got %v", err)
 	}
 }
 
 func TestVolumeInspect(t *testing.T) {
-	expectedURL := "/volumes/volume_id"
+	expectedURL := "/v" + api.DefaultVersion + "/volumes/volume_id"
 	expected := volume.Volume{
 		Name:       "name",
 		Driver:     "driver",
 		Mountpoint: "mountpoint",
 	}
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -73,8 +77,9 @@ func TestVolumeInspect(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader(content)),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
 	vol, err := client.VolumeInspect(context.Background(), "volume_id")
 	assert.NilError(t, err)

--- a/client/volume_list.go
+++ b/client/volume_list.go
@@ -14,15 +14,19 @@ func (cli *Client) VolumeList(ctx context.Context, filter filters.Args) (volume.
 	var volumes volume.ListResponse
 	query := url.Values{}
 
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return volumes, err
+	}
 	if filter.Len() > 0 {
 		//nolint:staticcheck // ignore SA1019 for old code
-		filterJSON, err := filters.ToParamWithVersion(cli.version, filter)
+		filterJSON, err := filters.ToParamWithVersion(versioned.version, filter)
 		if err != nil {
 			return volumes, err
 		}
 		query.Set("filters", filterJSON)
 	}
-	resp, err := cli.get(ctx, "/volumes", query, nil)
+	resp, err := versioned.get(ctx, "/volumes", query, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
 		return volumes, err

--- a/client/volume_list_test.go
+++ b/client/volume_list_test.go
@@ -10,24 +10,27 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestVolumeListError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	_, err := client.VolumeList(context.Background(), filters.NewArgs())
+	_, err = client.VolumeList(context.Background(), filters.NewArgs())
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestVolumeList(t *testing.T) {
-	expectedURL := "/volumes"
+	expectedURL := "/v" + api.DefaultVersion + "/volumes"
 
 	noDanglingFilters := filters.NewArgs()
 	noDanglingFilters.Add("dangling", "false")
@@ -59,8 +62,8 @@ func TestVolumeList(t *testing.T) {
 	}
 
 	for _, listCase := range listCases {
-		client := &Client{
-			client: newMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := NewClientWithOpts(
+			WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 				if !strings.HasPrefix(req.URL.Path, expectedURL) {
 					return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 				}
@@ -84,8 +87,9 @@ func TestVolumeList(t *testing.T) {
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader(content)),
 				}, nil
-			}),
-		}
+			})),
+		)
+		assert.NilError(t, err)
 
 		volumeResponse, err := client.VolumeList(context.Background(), listCase.filters)
 		if err != nil {

--- a/client/volume_prune.go
+++ b/client/volume_prune.go
@@ -13,7 +13,11 @@ import (
 func (cli *Client) VolumesPrune(ctx context.Context, pruneFilters filters.Args) (types.VolumesPruneReport, error) {
 	var report types.VolumesPruneReport
 
-	if err := cli.NewVersionError("1.25", "volume prune"); err != nil {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return report, err
+	}
+	if err := versioned.NewVersionError("1.25", "volume prune"); err != nil {
 		return report, err
 	}
 
@@ -22,7 +26,7 @@ func (cli *Client) VolumesPrune(ctx context.Context, pruneFilters filters.Args) 
 		return report, err
 	}
 
-	serverResp, err := cli.post(ctx, "/volumes/prune", query, nil, nil)
+	serverResp, err := versioned.post(ctx, "/volumes/prune", query, nil, nil)
 	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return report, err

--- a/client/volume_remove.go
+++ b/client/volume_remove.go
@@ -9,13 +9,17 @@ import (
 
 // VolumeRemove removes a volume from the docker host.
 func (cli *Client) VolumeRemove(ctx context.Context, volumeID string, force bool) error {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return err
+	}
 	query := url.Values{}
-	if versions.GreaterThanOrEqualTo(cli.version, "1.25") {
+	if versions.GreaterThanOrEqualTo(versioned.version, "1.25") {
 		if force {
 			query.Set("force", "1")
 		}
 	}
-	resp, err := cli.delete(ctx, "/volumes/"+volumeID, query, nil)
+	resp, err := versioned.delete(ctx, "/volumes/"+volumeID, query, nil)
 	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/volume_remove_test.go
+++ b/client/volume_remove_test.go
@@ -9,25 +9,28 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
 )
 
 func TestVolumeRemoveError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(errorMock(http.StatusInternalServerError, "Server error"))),
+	)
+	assert.NilError(t, err)
 
-	err := client.VolumeRemove(context.Background(), "volume_id", false)
+	err = client.VolumeRemove(context.Background(), "volume_id", false)
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
 }
 
 func TestVolumeRemove(t *testing.T) {
-	expectedURL := "/volumes/volume_id"
+	expectedURL := "/v" + api.DefaultVersion + "/volumes/volume_id"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -38,10 +41,11 @@ func TestVolumeRemove(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader([]byte("body"))),
 			}, nil
-		}),
-	}
+		})),
+	)
+	assert.NilError(t, err)
 
-	err := client.VolumeRemove(context.Background(), "volume_id", false)
+	err = client.VolumeRemove(context.Background(), "volume_id", false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/volume_update.go
+++ b/client/volume_update.go
@@ -11,14 +11,18 @@ import (
 // VolumeUpdate updates a volume. This only works for Cluster Volumes, and
 // only some fields can be updated.
 func (cli *Client) VolumeUpdate(ctx context.Context, volumeID string, version swarm.Version, options volume.UpdateOptions) error {
-	if err := cli.NewVersionError("1.42", "volume update"); err != nil {
+	versioned, err := cli.versioned(ctx)
+	if err != nil {
+		return err
+	}
+	if err := versioned.NewVersionError("1.42", "volume update"); err != nil {
 		return err
 	}
 
 	query := url.Values{}
 	query.Set("version", version.String())
 
-	resp, err := cli.put(ctx, "/volumes/"+volumeID, query, options, nil)
+	resp, err := versioned.put(ctx, "/volumes/"+volumeID, query, options, nil)
 	ensureReaderClosed(resp)
 	return err
 }


### PR DESCRIPTION
* Fixes #43729
* Closes #42379 

**- What I did**
* Added concurrency control and synchronization to version negotiation to eliminate data races and duplicate pings
* Modified how versioning is handled in the client so that changing the client's API version is atomic: each request will use the same API version to construct and validate the request, process the response and handle errors, even if the client API version is changed mid-request
* Updated all the client unit tests to construct clients using the exported `NewClientWithOpts` constructor instead of a struct literal
* Modified version negotiation to disregard the negotiation attempt and try negotiating again on the next API call instead of falling back to v1.24 if the ping request fails due to network conditions or the request context is canceled mid-ping

**- How I did it**
Way too much tedious and repetitive semi-manual editing.

**- How to verify it**
New tests to exercise concurrent client usage for the race detector and to verify the new negotiation retry behaviour.

**- Description for the changelog**
* `*client.Client` instances can now safely be used concurrently by multiple goroutines in all cases. Older client versions are not safe for concurrent use when the `WithAPIVersionNegotation` option is used.
* The `WithAPIVersionNegotiation` option for `*client.Client` has been made more robust. API version negotiation will now be retried if the first attempt timed out or could not be completed due to network conditions.

**- A picture of a cute animal (not mandatory but encouraged)**

