### PR TITLE
cmd/dockerd: move code for managed containerd to unix-only files

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -169,12 +169,13 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	waitForContainerdShutdown, err := cli.initContainerd(ctx)
 	if err != nil {
+		cancel()
 		return err
 	}
 	defer waitForContainerdShutdown()
+	defer cancel()
 
 	stopc := make(chan bool)
 	defer close(stopc)

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -39,7 +39,6 @@ import (
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/daemon/listeners"
 	"github.com/docker/docker/dockerversion"
-	"github.com/docker/docker/libcontainerd/supervisor"
 	dopts "github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/authorization"
 	"github.com/docker/docker/pkg/homedir"
@@ -170,15 +169,12 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	waitForContainerDShutdown, err := cli.initContainerD(ctx)
-	if waitForContainerDShutdown != nil {
-		defer waitForContainerDShutdown(10 * time.Second)
-	}
+	defer cancel()
+	waitForContainerdShutdown, err := cli.initContainerd(ctx)
 	if err != nil {
-		cancel()
 		return err
 	}
-	defer cancel()
+	defer waitForContainerdShutdown()
 
 	stopc := make(chan bool)
 	defer close(stopc)
@@ -593,25 +589,6 @@ func (cli *DaemonCli) initMiddlewares(s *apiserver.Server, cfg *apiserver.Config
 	cli.Config.AuthzMiddleware = cli.authzMiddleware
 	s.UseMiddleware(cli.authzMiddleware)
 	return nil
-}
-
-func (cli *DaemonCli) getContainerdDaemonOpts() ([]supervisor.DaemonOpt, error) {
-	opts, err := cli.getPlatformContainerdDaemonOpts()
-	if err != nil {
-		return nil, err
-	}
-
-	if cli.Config.Debug {
-		opts = append(opts, supervisor.WithLogLevel("debug"))
-	} else if cli.Config.LogLevel != "" {
-		opts = append(opts, supervisor.WithLogLevel(cli.Config.LogLevel))
-	}
-
-	if !cli.Config.CriContainerd {
-		opts = append(opts, supervisor.WithPlugin("cri", nil))
-	}
-
-	return opts, nil
 }
 
 func newAPIServerConfig(config *config.Config) (*apiserver.Config, error) {

--- a/cmd/dockerd/daemon_windows.go
+++ b/cmd/dockerd/daemon_windows.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/docker/docker/daemon/config"
-	"github.com/docker/docker/libcontainerd/supervisor"
 	"github.com/docker/docker/pkg/system"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
@@ -57,10 +55,6 @@ func notifyShutdown(err error) {
 	}
 }
 
-func (cli *DaemonCli) getPlatformContainerdDaemonOpts() ([]supervisor.DaemonOpt, error) {
-	return nil, nil
-}
-
 // setupConfigReloadTrap configures a Win32 event to reload the configuration.
 func (cli *DaemonCli) setupConfigReloadTrap() {
 	go func() {
@@ -93,9 +87,9 @@ func newCgroupParent(config *config.Config) string {
 	return ""
 }
 
-func (cli *DaemonCli) initContainerD(_ context.Context) (func(time.Duration) error, error) {
+func (cli *DaemonCli) initContainerd(_ context.Context) (func(), error) {
 	system.InitContainerdRuntime(cli.Config.ContainerdAddr)
-	return nil, nil
+	return func() {}, nil
 }
 
 func validateCPURealtimeOptions(_ *config.Config) error {


### PR DESCRIPTION
Starting containerd as managed child-process is only used on Linux,
so we can move this code to linux-specific files.

This also refactors the DaemonCLI.initContainerd();

- return early if we're expecting a system-containerd
- handle WaitTimeout() errors by logging them
- move creation of options inline, now that we no longer
  need platform-specific abstractions.

**- A picture of a cute animal (not mandatory but encouraged)**

