### PR TITLE
build: force unlazy of refs by calling extract

### DIFF
--- a/builder/builder-next/exporter/export.go
+++ b/builder/builder-next/exporter/export.go
@@ -160,6 +160,10 @@ func (e *imageExporterInstance) Export(ctx context.Context, inp exporter.Source,
 			return nil, layersDone(err)
 		}
 
+		if err := ref.Extract(ctx, nil); err != nil {
+			return nil, err
+		}
+
 		diffIDs, err := e.opt.Differ.EnsureLayer(ctx, ref.ID())
 		if err != nil {
 			return nil, layersDone(err)

--- a/builder/builder-next/worker/worker.go
+++ b/builder/builder-next/worker/worker.go
@@ -228,7 +228,7 @@ func (w *Worker) Exporter(name string, sm *session.Manager) (exporter.Exporter, 
 }
 
 // GetRemote returns a remote snapshot reference for a local one
-func (w *Worker) GetRemote(ctx context.Context, ref cache.ImmutableRef, createIfNeeded bool, _ compression.Type, _ session.Group) (*solver.Remote, error) {
+func (w *Worker) GetRemote(ctx context.Context, ref cache.ImmutableRef, createIfNeeded bool, _ compression.Type, s session.Group) (*solver.Remote, error) {
 	var diffIDs []layer.DiffID
 	var err error
 	if !createIfNeeded {
@@ -238,6 +238,9 @@ func (w *Worker) GetRemote(ctx context.Context, ref cache.ImmutableRef, createIf
 		}
 	} else {
 		if err := ref.Finalize(ctx); err != nil {
+			return nil, err
+		}
+		if err := ref.Extract(ctx, s); err != nil {
 			return nil, err
 		}
 		diffIDs, err = w.Layers.EnsureLayer(ctx, ref.ID())


### PR DESCRIPTION
fixes #43742 

cherry picked from https://github.com/sipsma/moby/commit/ab819190efd66dde0224c7fbcb54de9f8f19fbc2

keeping in draft for now as we have to also add an integration test for it.