### PR TITLE
api: POST /containers/{id}/wait: fix validation for "condition" parameter

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -346,6 +346,8 @@ func (s *containerRouter) postContainersWait(ctx context.Context, w http.Respons
 		}
 		if v := r.Form.Get("condition"); v != "" {
 			switch container.WaitCondition(v) {
+			case container.WaitConditionNotRunning:
+				waitCondition = containerpkg.WaitConditionNotRunning
 			case container.WaitConditionNextExit:
 				waitCondition = containerpkg.WaitConditionNextExit
 			case container.WaitConditionRemoved:


### PR DESCRIPTION
commit 737e8c6ab81842d61d86df3efec5f505b5484d4c (https://github.com/moby/moby/pull/43235) added validation for the wait condition parameter, however, the default ("not-running") option was not part of the list of valid options, resulting in a regression if the default value was explicitly passed;

    docker scan --accept-license --version
    Error response from daemon: invalid condition: "not-running"

This patch adds the missing option, and adds a test to verify.

With this patch;

    make BIND_DIR=. DOCKER_GRAPHDRIVER=vfs TEST_FILTER=TestWaitConditions test-integration
    ...
    --- PASS: TestWaitConditions (0.04s)
    --- PASS: TestWaitConditions/removed (1.79s)
    --- PASS: TestWaitConditions/default (1.91s)
    --- PASS: TestWaitConditions/next-exit (1.97s)
    --- PASS: TestWaitConditions/not-running (1.99s)
    PASS



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

