### PR TITLE
fix typo (cluser -> cluster)

### DIFF
--- a/libnetwork/cmd/ssd/README.md
+++ b/libnetwork/cmd/ssd/README.md
@@ -5,7 +5,7 @@ ssd is a troubleshooting utility for Docker swarm networks.
 ### control-plane and datapath consistency check on a node
 ssd checks for the consistency between docker network control-plane (from the docker daemon in-memory state) and kernel data path programming. Currently the tool checks only for the consistency of the Load balancer (implemented using IPVS).
 
-In a three node swarm cluser ssd status for a overlay network `ov2` which has three services running, each replicated to 3 instances.
+In a three node swarm cluster ssd status for a overlay network `ov2` which has three services running, each replicated to 3 instances.
 
 ````bash
 vagrant@net-1:~/code/go/src/github.com/docker/docker-e2e/tests$ docker run -v /var/run/docker.sock:/var/run/docker.sock -v /var/run/docker/netns:/var/run/docker/netns --privileged --net=host sanimej/ssd ov2

--- a/libnetwork/networkdb/networkdb_test.go
+++ b/libnetwork/networkdb/networkdb_test.go
@@ -55,7 +55,7 @@ func createNetworkDBInstances(t *testing.T, num int, namePrefix string, conf *Co
 		// Check that the cluster is properly created
 		for i := 0; i < num; i++ {
 			if num != len(dbs[i].ClusterPeers()) {
-				return poll.Continue("%s:Waiting for cluser peers to be established", dbs[i].config.Hostname)
+				return poll.Continue("%s:Waiting for cluster peers to be established", dbs[i].config.Hostname)
 			}
 		}
 		return poll.Success()


### PR DESCRIPTION
saw this in a failure on a flaky test