### PR TITLE
Extract ImageService interface from the image service

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -79,7 +79,7 @@ type Daemon struct {
 	containers            container.Store
 	containersReplica     container.ViewDB
 	execCommands          *exec.Store
-	imageService          *images.ImageService
+	imageService          ImageService
 	configStore           *config.Config
 	statsCollector        *stats.Collector
 	defaultLogConfig      containertypes.LogConfig
@@ -1473,7 +1473,7 @@ func (daemon *Daemon) IdentityMapping() idtools.IdentityMapping {
 }
 
 // ImageService returns the Daemon's ImageService
-func (daemon *Daemon) ImageService() *images.ImageService {
+func (daemon *Daemon) ImageService() ImageService {
 	return daemon.imageService
 }
 
@@ -1481,7 +1481,7 @@ func (daemon *Daemon) ImageService() *images.ImageService {
 func (daemon *Daemon) BuilderBackend() builder.Backend {
 	return struct {
 		*Daemon
-		*images.ImageService
+		ImageService
 	}{daemon, daemon.imageService}
 }
 

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -1,0 +1,78 @@
+package daemon
+
+import (
+	"context"
+	"io"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/api/types/filters"
+	imagetype "github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/builder"
+	"github.com/docker/docker/container"
+	"github.com/docker/docker/daemon/images"
+	"github.com/docker/docker/image"
+	"github.com/docker/docker/layer"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// ImageService is a temporary interface to assist in the migration to the
+// containerd image-store. This interface should not be considered stable,
+// and may change over time.
+type ImageService interface {
+	// Images
+
+	PullImage(ctx context.Context, image, tag string, platform *v1.Platform, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error
+	PushImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error
+	CreateImage(config []byte, parent string) (builder.Image, error)
+	ImageDelete(imageRef string, force, prune bool) ([]types.ImageDeleteResponseItem, error)
+	ExportImage(names []string, outStream io.Writer) error
+	LoadImage(inTar io.ReadCloser, outStream io.Writer, quiet bool) error
+	Images(ctx context.Context, opts types.ImageListOptions) ([]*types.ImageSummary, error)
+	LogImageEvent(imageID, refName, action string)
+	LogImageEventWithAttributes(imageID, refName, action string, attributes map[string]string)
+	CountImages() int
+	ImageDiskUsage(ctx context.Context) ([]*types.ImageSummary, error)
+	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*types.ImagesPruneReport, error)
+	ImportImage(src string, repository string, platform *v1.Platform, tag string, msg string, inConfig io.ReadCloser, outStream io.Writer, changes []string) error
+	TagImage(imageName, repository, tag string) (string, error)
+	TagImageWithReference(imageID image.ID, newTag reference.Named) error
+	GetImage(refOrID string, platform *v1.Platform) (retImg *image.Image, retErr error)
+	ImageHistory(name string) ([]*imagetype.HistoryResponseItem, error)
+	CommitImage(c backend.CommitConfig) (image.ID, error)
+	SquashImage(id, parent string) (string, error)
+
+	// Layers
+
+	GetImageAndReleasableLayer(ctx context.Context, refOrID string, opts backend.GetImageAndLayerOptions) (builder.Image, builder.ROLayer, error)
+	CreateLayer(container *container.Container, initFunc layer.MountInit) (layer.RWLayer, error)
+	GetLayerByID(cid string) (layer.RWLayer, error)
+	LayerStoreStatus() [][2]string
+	GetLayerMountID(cid string) (string, error)
+	ReleaseLayer(rwlayer layer.RWLayer) error
+	LayerDiskUsage(ctx context.Context) (int64, error)
+	GetContainerLayerSize(containerID string) (int64, int64)
+
+	// Windows specific
+
+	GetLayerFolders(img *image.Image, rwLayer layer.RWLayer) ([]string, error)
+
+	// Build
+
+	MakeImageCache(sourceRefs []string) builder.ImageCache
+	CommitBuildStep(c backend.CommitConfig) (image.ID, error)
+
+	// Other
+
+	GetRepository(ctx context.Context, ref reference.Named, authConfig *types.AuthConfig) (distribution.Repository, error)
+	Map() map[image.ID]*image.Image
+	SearchRegistryForImages(ctx context.Context, searchFilters filters.Args, term string, limit int, authConfig *types.AuthConfig, headers map[string][]string) (*registry.SearchResults, error)
+	DistributionServices() images.DistributionServices
+	Children(id image.ID) []image.ID
+	Cleanup() error
+	GraphDriverName() string
+	UpdateConfig(maxDownloads, maxUploads int)
+}

--- a/daemon/images/image_unix.go
+++ b/daemon/images/image_unix.go
@@ -4,8 +4,16 @@
 package images // import "github.com/docker/docker/daemon/images"
 
 import (
+	"github.com/docker/docker/image"
+	"github.com/docker/docker/layer"
 	"github.com/sirupsen/logrus"
 )
+
+// GetLayerFolders returns the layer folders from an image RootFS
+func (i *ImageService) GetLayerFolders(img *image.Image, rwLayer layer.RWLayer) ([]string, error) {
+	// Windows specific
+	panic("not implemented")
+}
 
 // GetContainerLayerSize returns the real size & virtual size of the container.
 func (i *ImageService) GetContainerLayerSize(containerID string) (int64, int64) {


### PR DESCRIPTION
**- What I did**

Extracted the `ImageService` interface form the image service. The daemon now uses this interface rather than the image service struct directly.

This will help us split the image service more easily, it does too many things. This interface will also be useful for the containerd store migration.

**- How I did it**

With goland.

**- How to verify it**

The project should build.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/176178678-7bf21f9f-8a07-4765-8204-4bb72bbf6703.png)
