### PR TITLE
project: Add label kind/regression

### DIFF
--- a/project/ISSUE-TRIAGE.md
+++ b/project/ISSUE-TRIAGE.md
@@ -42,7 +42,8 @@ have:
 | Kind             | Description                                                                                                                     |
 |------------------|---------------------------------------------------------------------------------------------------------------------------------|
 | kind/bug         | Bugs are bugs. The cause may or may not be known at triage time so debugging should be taken account into the time estimate.    |
-| kind/enhancement | Enhancements are not bugs or new features but can drastically improve usability or performance of a project component.           |
+| kind/regression  | Regression is an issue which is known not to exist previously and breaks things which are expected to work.                     |
+| kind/enhancement | Enhancements are not bugs or new features but can drastically improve usability or performance of a project component.          |
 | kind/feature     | Functionality or other elements that the project does not currently support.  Features are new and shiny.                       |
 | kind/question    | Contains a user or contributor question requiring a response.                                                                   |
 


### PR DESCRIPTION
Regressions typically are bugs too but they break existing workflows which users rely on. Fixing them is usually more important so this would allow to give such issues better visibility.


**- A picture of a cute animal (not mandatory but encouraged)**
![jezyk](https://user-images.githubusercontent.com/5046555/176686661-0f53e10a-7f65-4b07-98e2-78b19e71f350.jpg)

