### PR TITLE
Dockerfile: don't install delve on ppc64le, s390x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -154,10 +154,19 @@ FROM base AS delve
 # attaching debugger to it.
 #
 ARG DELVE_VERSION=v1.8.1
+# Delve on Linux is currently only supported on amd64 and arm64;
+# https://github.com/go-delve/delve/blob/v1.8.1/pkg/proc/native/support_sentinel.go#L1-L6
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-        GOBIN=/build/ GO111MODULE=on go install "github.com/go-delve/delve/cmd/dlv@${DELVE_VERSION}" \
-     && /build/dlv --help
+        case $(dpkg --print-architecture) in \
+            amd64|arm64) \
+                GOBIN=/build/ GO111MODULE=on go install "github.com/go-delve/delve/cmd/dlv@${DELVE_VERSION}" \
+                && /build/dlv --help \
+                ;; \
+            *) \
+                mkdir -p /build/ \
+                ;; \
+        esac
 
 FROM base AS tomll
 # GOTOML_VERSION specifies the version of the tomll binary to build and install


### PR DESCRIPTION
Delve on Linux is currently only supported on amd64 and arm64;
https://github.com/go-delve/delve/blob/v1.8.1/pkg/proc/native/support_sentinel.go#L1-L6

On ppc64le and s390x, trying to install and run it, caused the
build to fail:

    RUN --mount=type=cache,target=/root/.cache/go-build     --mount=type=cache,target=/go/pkg/mod         GOBIN=/build/ GO111MODULE=on go install "github.com/go-delve/delve/cmd/dlv@v1.8.1"      && /build/dlv --help:

    pkg/mod/github.com/go-delve/delve@v1.8.1/service/debugger/debugger.go:28:2: found packages native (dump_linux.go) and your_operating_system_and_architecture_combination_is_not_supported_by_delve (support_sentinel.go) in /go/pkg/mod/github.com/go-delve/delve@v1.8.1/pkg/proc/native
    Error: failed to solve: executor failed running [/bin/sh -c GOBIN=/build/ GO111MODULE=on go install "github.com/go-delve/delve/cmd/dlv@${DELVE_VERSION}"      && /build/dlv --help]: exit code: 1


**- A picture of a cute animal (not mandatory but encouraged)**

