### PR TITLE
hack: remove version from binaries, and remove symlinks

### DIFF
--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -8,7 +8,6 @@ binary_extension() {
 	fi
 }
 
-BINARY_NAME="$BINARY_SHORT_NAME-$VERSION"
 BINARY_EXTENSION="$(binary_extension)"
 BINARY_FULLNAME="$BINARY_NAME$BINARY_EXTENSION"
 
@@ -116,6 +115,4 @@ hash_files() {
 )
 
 echo "Created binary: $DEST/$BINARY_FULLNAME"
-ln -sf "$BINARY_FULLNAME" "$DEST/$BINARY_SHORT_NAME$BINARY_EXTENSION"
-
 hash_files "$DEST/$BINARY_FULLNAME"

--- a/hack/make/.mkwinres
+++ b/hack/make/.mkwinres
@@ -16,7 +16,7 @@ VERSION_QUAD=$(printf "%s" "$VERSION" | sed -re 's/^([0-9.]*).*$/\1/' | sed -re 
 # Microsoft Windows Version Information and an icon using go-winres.
 # https://docs.microsoft.com/en-us/windows/win32/menurc/stringfileinfo-block
 # https://github.com/tc-hib/go-winres#json-format
-cat > "./cli/winresources/${BINARY_SHORT_NAME}/winres.json" << EOL
+cat > "./cli/winresources/${BINARY_NAME}/winres.json" << EOL
 {
   "RT_GROUP_ICON": {
     "#1": {
@@ -76,10 +76,10 @@ cat > "./cli/winresources/${BINARY_SHORT_NAME}/winres.json" << EOL
 EOL
 (
 	set -x
-	cat "./cli/winresources/${BINARY_SHORT_NAME}/winres.json"
+	cat "./cli/winresources/${BINARY_NAME}/winres.json"
 )
 
 # Create winresources package stub if removed while using tmpfs in Dockerfile
-if [ ! -f "./cli/winresources/${BINARY_SHORT_NAME}/winresources.go" ]; then
-	echo "package winresources" > "./cli/winresources/${BINARY_SHORT_NAME}/winresources.go"
+if [ ! -f "./cli/winresources/${BINARY_NAME}/winresources.go" ]; then
+	echo "package winresources" > "./cli/winresources/${BINARY_NAME}/winresources.go"
 fi

--- a/hack/make/binary-daemon
+++ b/hack/make/binary-daemon
@@ -34,7 +34,7 @@ copy_binaries() {
 
 (
 	GO_PACKAGE='github.com/docker/docker/cmd/dockerd'
-	BINARY_SHORT_NAME='dockerd'
+	BINARY_NAME='dockerd'
 
 	source "${MAKEDIR}/.binary"
 	copy_binaries "$DEST" 'hash'

--- a/hack/make/binary-proxy
+++ b/hack/make/binary-proxy
@@ -6,7 +6,7 @@ set -e
 	export CGO_ENABLED=0
 
 	GO_PACKAGE='github.com/docker/docker/cmd/docker-proxy'
-	BINARY_SHORT_NAME='docker-proxy'
+	BINARY_NAME='docker-proxy'
 
 	source "${MAKEDIR}/.binary"
 )

--- a/hack/make/cross
+++ b/hack/make/cross
@@ -2,7 +2,7 @@
 set -e
 
 # if we have our linux/amd64 version compiled, let's symlink it in
-if [ -x "${DEST}/../binary-daemon/dockerd-${VERSION}" ]; then
+if [ -x "${DEST}/../binary-daemon/dockerd" ]; then
 	arch=$(go env GOHOSTARCH)
 	mkdir -p "$DEST/linux/${arch}"
 	(

--- a/hack/make/dynbinary-daemon
+++ b/hack/make/dynbinary-daemon
@@ -11,6 +11,6 @@ set -e
 	export BUILDFLAGS=("${BUILDFLAGS[@]/static_build /}") # we're not building a "static" binary here
 
 	GO_PACKAGE='github.com/docker/docker/cmd/dockerd'
-	BINARY_SHORT_NAME='dockerd'
+	BINARY_NAME='dockerd'
 	source "${MAKEDIR}/.binary"
 )

--- a/hack/make/dynbinary-proxy
+++ b/hack/make/dynbinary-proxy
@@ -10,6 +10,6 @@ set -e
 	export BUILDFLAGS=("${BUILDFLAGS[@]/static_build /}") # we're not building a "static" binary here
 
 	GO_PACKAGE='github.com/docker/docker/cmd/docker-proxy'
-	BINARY_SHORT_NAME='docker-proxy'
+	BINARY_NAME='docker-proxy'
 	source "${MAKEDIR}/.binary"
 )


### PR DESCRIPTION
There may have been some historic reason for doing this, but I couldn't find
a practical use for building the (some) binaries with a version (default: "dev")
included, only to use a symlink to refer to the actual binary.

This patch removes the "${VERSION}" from the binary names in bundles, and
removes the code that created symlinks for them.

Before this patch:

```bash
rm -rf ./bundles
docker buildx build --build-arg VERSION=22.06.0-beta.1 --output ./bundles --target binary .

tree bundles
bundles
└── binary-daemon
    ├── containerd
    ├── containerd-shim-runc-v2
    ├── containerd-shim-runc-v2.md5
    ├── containerd-shim-runc-v2.sha256
    ├── containerd.md5
    ├── containerd.sha256
    ├── ctr
    ├── ctr.md5
    ├── ctr.sha256
    ├── docker-init
    ├── docker-init.md5
    ├── docker-init.sha256
    ├── docker-proxy -> docker-proxy-22.06.0-beta.1
    ├── docker-proxy-22.06.0-beta.1
    ├── docker-proxy-22.06.0-beta.1.md5
    ├── docker-proxy-22.06.0-beta.1.sha256
    ├── dockerd -> dockerd-22.06.0-beta.1
    ├── dockerd-22.06.0-beta.1
    ├── dockerd-22.06.0-beta.1.md5
    ├── dockerd-22.06.0-beta.1.sha256
    ├── dockerd-rootless-setuptool.sh
    ├── dockerd-rootless-setuptool.sh.md5
    ├── dockerd-rootless-setuptool.sh.sha256
    ├── dockerd-rootless.sh
    ├── dockerd-rootless.sh.md5
    ├── dockerd-rootless.sh.sha256
    ├── rootlesskit
    ├── rootlesskit-docker-proxy
    ├── rootlesskit-docker-proxy.md5
    ├── rootlesskit-docker-proxy.sha256
    ├── rootlesskit.md5
    ├── rootlesskit.sha256
    ├── runc
    ├── runc.md5
    ├── runc.sha256
    ├── vpnkit
    ├── vpnkit.md5
    └── vpnkit.sha256

1 directory, 38 files
```

After this patch:

```bash
rm -rf ./bundles
docker buildx build --build-arg VERSION=22.06.0-beta.1 --output ./bundles --target binary .

tree bundles
bundles
└── binary-daemon
    ├── containerd
    ├── containerd-shim-runc-v2
    ├── containerd-shim-runc-v2.md5
    ├── containerd-shim-runc-v2.sha256
    ├── containerd.md5
    ├── containerd.sha256
    ├── ctr
    ├── ctr.md5
    ├── ctr.sha256
    ├── docker-init
    ├── docker-init.md5
    ├── docker-init.sha256
    ├── docker-proxy
    ├── docker-proxy.md5
    ├── docker-proxy.sha256
    ├── dockerd
    ├── dockerd-rootless-setuptool.sh
    ├── dockerd-rootless-setuptool.sh.md5
    ├── dockerd-rootless-setuptool.sh.sha256
    ├── dockerd-rootless.sh
    ├── dockerd-rootless.sh.md5
    ├── dockerd-rootless.sh.sha256
    ├── dockerd.md5
    ├── dockerd.sha256
    ├── rootlesskit
    ├── rootlesskit-docker-proxy
    ├── rootlesskit-docker-proxy.md5
    ├── rootlesskit-docker-proxy.sha256
    ├── rootlesskit.md5
    ├── rootlesskit.sha256
    ├── runc
    ├── runc.md5
    ├── runc.sha256
    ├── vpnkit
    ├── vpnkit.md5
    └── vpnkit.sha256

1 directory, 36 files
```



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

