### PR TITLE
Dockerfile: remove redundant variable, and upgrade to latest 1.x stable syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3
+# syntax=docker/dockerfile:1
 
 ARG CROSS="false"
 ARG SYSTEMD="false"

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -26,10 +26,9 @@ RUN /download-frozen-image-v2.sh /build \
 # See also frozenImages in "testutil/environment/protect.go" (which needs to be updated when adding images to this list)
 
 FROM base AS dockercli
-ENV INSTALL_BINARY_NAME=dockercli
 COPY hack/dockerfile/install/install.sh ./install.sh
-COPY hack/dockerfile/install/$INSTALL_BINARY_NAME.installer ./
-RUN PREFIX=/build ./install.sh $INSTALL_BINARY_NAME
+COPY hack/dockerfile/install/dockercli.installer ./
+RUN PREFIX=/build ./install.sh dockercli
 
 # TestDockerCLIBuildSuite dependency
 FROM base AS contrib


### PR DESCRIPTION
### Dockerfile.e2e: remove redundant INSTALL_BINARY_NAME

It's only used in a single place, so may as well just hard-code it

### Dockerfile: update to latest syntax

It was pinned to the 1.3 version; removing the minor version to
make sure we're on the latest 1.x stable.