### PR TITLE
hack: don't generate checksums for individual binaries

### DIFF
--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -13,27 +13,6 @@ BINARY_FULLNAME="$BINARY_NAME$BINARY_EXTENSION"
 
 source "${MAKEDIR}/.go-autogen"
 
-hash_files() {
-	while [ $# -gt 0 ]; do
-		f="$1"
-		shift
-		dir="$(dirname "$f")"
-		base="$(basename "$f")"
-		for hashAlgo in md5 sha256; do
-			if command -v "${hashAlgo}sum" &> /dev/null; then
-				(
-					# subshell and cd so that we get output files like:
-					#   $HASH docker-$VERSION
-					# instead of:
-					#   $HASH /go/src/github.com/.../$VERSION/binary/docker-$VERSION
-					cd "$dir"
-					"${hashAlgo}sum" "$base" > "$base.$hashAlgo"
-				)
-			fi
-		done
-	done
-}
-
 (
 	export GOGC=${DOCKER_BUILD_GOGC:-1000}
 
@@ -115,4 +94,3 @@ hash_files() {
 )
 
 echo "Created binary: $DEST/$BINARY_FULLNAME"
-hash_files "$DEST/$BINARY_FULLNAME"

--- a/hack/make/binary-daemon
+++ b/hack/make/binary-daemon
@@ -3,7 +3,7 @@ set -e
 
 copy_binaries() {
 	local dir="$1"
-	local hash="$2"
+
 	# Add nested executables to bundle dir so we have complete set of
 	# them available, but only if the native OS/ARCH is the same as the
 	# OS/ARCH of the build target
@@ -16,17 +16,11 @@ copy_binaries() {
 	echo "Copying nested executables into $dir"
 	for file in containerd containerd-shim-runc-v2 ctr runc docker-init rootlesskit rootlesskit-docker-proxy dockerd-rootless.sh dockerd-rootless-setuptool.sh; do
 		cp -f "$(command -v "$file")" "$dir/"
-		if [ "$hash" = "hash" ]; then
-			hash_files "$dir/$file"
-		fi
 	done
 
 	# vpnkit is available for x86_64 and aarch64
 	if command -v "vpnkit.$(uname -m)" 2>&1 > /dev/null; then
 		cp -f "$(command -v "vpnkit.$(uname -m)")" "$dir/vpnkit"
-		if [ "$hash" = "hash" ]; then
-			hash_files "$dir/vpnkit"
-		fi
 	fi
 }
 
@@ -37,5 +31,5 @@ copy_binaries() {
 	BINARY_NAME='dockerd'
 
 	source "${MAKEDIR}/.binary"
-	copy_binaries "$DEST" 'hash'
+	copy_binaries "$DEST"
 )


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/43762

(kept it separate for visibility, and in case there's objections against this change)

The script to build (static)binaries also generated checksums for all binaries
and scripts included. These checksums were not used, and not included when
releasing packages (which are a `tar.gz` for which a separate checksum would
be generated).

Removing these checksums, as they're unused, and complicated using these
artifacts for packagers (who would have to exclude them after building).

Before this:

```bash
rm -rf ./bundles
docker buildx build --build-arg VERSION=22.06.0-beta.1 --output ./bundles --target binary .

tree bundles
bundles
└── binary-daemon
    ├── containerd
    ├── containerd-shim-runc-v2
    ├── containerd-shim-runc-v2.md5
    ├── containerd-shim-runc-v2.sha256
    ├── containerd.md5
    ├── containerd.sha256
    ├── ctr
    ├── ctr.md5
    ├── ctr.sha256
    ├── docker-init
    ├── docker-init.md5
    ├── docker-init.sha256
    ├── docker-proxy
    ├── docker-proxy.md5
    ├── docker-proxy.sha256
    ├── dockerd
    ├── dockerd-rootless-setuptool.sh
    ├── dockerd-rootless-setuptool.sh.md5
    ├── dockerd-rootless-setuptool.sh.sha256
    ├── dockerd-rootless.sh
    ├── dockerd-rootless.sh.md5
    ├── dockerd-rootless.sh.sha256
    ├── dockerd.md5
    ├── dockerd.sha256
    ├── rootlesskit
    ├── rootlesskit-docker-proxy
    ├── rootlesskit-docker-proxy.md5
    ├── rootlesskit-docker-proxy.sha256
    ├── rootlesskit.md5
    ├── rootlesskit.sha256
    ├── runc
    ├── runc.md5
    ├── runc.sha256
    ├── vpnkit
    ├── vpnkit.md5
    └── vpnkit.sha256

1 directory, 36 files
```


After this:

```bash
rm -rf ./bundles
docker buildx build --build-arg VERSION=22.06.0-beta.1 --output ./bundles --target binary .

tree bundles
bundles
└── binary-daemon
    ├── containerd
    ├── containerd-shim-runc-v2
    ├── ctr
    ├── docker-init
    ├── docker-proxy
    ├── dockerd
    ├── dockerd-rootless-setuptool.sh
    ├── dockerd-rootless.sh
    ├── rootlesskit
    ├── rootlesskit-docker-proxy
    ├── runc
    └── vpnkit

1 directory, 12 files
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

