### PR TITLE
profiles: seccomp: allow clock_settime64 when CAP_SYS_TIME is added

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -743,7 +743,8 @@
 			"names": [
 				"settimeofday",
 				"stime",
-				"clock_settime"
+				"clock_settime",
+				"clock_settime64"
 			],
 			"action": "SCMP_ACT_ALLOW",
 			"includes": {

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -731,6 +731,7 @@ func DefaultProfile() *Seccomp {
 					"settimeofday",
 					"stime",
 					"clock_settime",
+					"clock_settime64",
 				},
 				Action: specs.ActAllow,
 			},


### PR DESCRIPTION
closes #43774

**- What I did**

Allow clock_settime64 syscall with `--cap-add SYS_TIME`