### PR TITLE
pkg/parsers/operatingsystem: fix stray import

### DIFF
--- a/pkg/parsers/operatingsystem/operatingsystem_unix.go
+++ b/pkg/parsers/operatingsystem/operatingsystem_unix.go
@@ -4,7 +4,6 @@
 package operatingsystem // import "github.com/docker/docker/pkg/parsers/operatingsystem"
 
 import (
-	"bytes"
 	"errors"
 
 	"golang.org/x/sys/unix"


### PR DESCRIPTION
This was caught by goimports;

    goimports -w $(find . -type f -name '*.go'| grep -v "/vendor/")

CI doesn't run on these platforms, so didn't catch it.

