### PR TITLE
container: ViewDB: cleanup error-types

### DIFF
--- a/container/view.go
+++ b/container/view.go
@@ -391,7 +391,7 @@ func (v *View) transform(container *Container) *Snapshot {
 		for port, bindings := range container.NetworkSettings.Ports {
 			p, err := nat.ParsePort(port.Port())
 			if err != nil {
-				logrus.Warnf("invalid port map %+v", err)
+				logrus.WithError(err).Warn("invalid port map")
 				continue
 			}
 			if len(bindings) == 0 {
@@ -404,7 +404,7 @@ func (v *View) transform(container *Container) *Snapshot {
 			for _, binding := range bindings {
 				h, err := nat.ParsePort(binding.HostPort)
 				if err != nil {
-					logrus.Warnf("invalid host port map %+v", err)
+					logrus.WithError(err).Warn("invalid host port map")
 					continue
 				}
 				snapshot.Ports = append(snapshot.Ports, types.Port{

--- a/container/view.go
+++ b/container/view.go
@@ -100,7 +100,7 @@ type ViewDB struct {
 func NewViewDB() (*ViewDB, error) {
 	store, err := memdb.NewMemDB(schema)
 	if err != nil {
-		return nil, err
+		return nil, errdefs.System(err)
 	}
 	return &ViewDB{store: store}, nil
 }
@@ -151,7 +151,7 @@ func (db *ViewDB) withTxn(cb func(*memdb.Txn) error) error {
 	err := cb(txn)
 	if err != nil {
 		txn.Abort()
-		return err
+		return errdefs.System(err)
 	}
 	txn.Commit()
 	return nil
@@ -190,7 +190,7 @@ func (db *ViewDB) ReserveName(name, containerID string) error {
 	return db.withTxn(func(txn *memdb.Txn) error {
 		s, err := txn.First(memdbNamesTable, memdbIDIndex, name)
 		if err != nil {
-			return err
+			return errdefs.System(err)
 		}
 		if s != nil {
 			if s.(nameAssociation).containerID != containerID {
@@ -220,7 +220,7 @@ func (v *View) All() ([]Snapshot, error) {
 	var all []Snapshot
 	iter, err := v.txn.Get(memdbContainersTable, memdbIDIndex)
 	if err != nil {
-		return nil, err
+		return nil, errdefs.System(err)
 	}
 	for {
 		item := iter.Next()
@@ -237,7 +237,7 @@ func (v *View) All() ([]Snapshot, error) {
 func (v *View) Get(id string) (*Snapshot, error) {
 	s, err := v.txn.First(memdbContainersTable, memdbIDIndex, id)
 	if err != nil {
-		return nil, err
+		return nil, errdefs.System(err)
 	}
 	if s == nil {
 		return nil, errdefs.NotFound(errors.New("No such container: " + id))
@@ -268,7 +268,7 @@ func (v *View) getNames(containerID string) []string {
 func (v *View) GetID(name string) (string, error) {
 	s, err := v.txn.First(memdbNamesTable, memdbIDIndex, name)
 	if err != nil {
-		return "", err
+		return "", errdefs.System(err)
 	}
 	if s == nil {
 		return "", ErrNameNotReserved

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -48,13 +48,12 @@ func (daemon *Daemon) GetContainer(prefixOrName string) (*container.Container, e
 		return containerByName, nil
 	}
 
-	containerID, indexError := daemon.containersReplica.GetByPrefix(prefixOrName)
-	if indexError != nil {
-		// When truncindex defines an error type, use that instead
-		if indexError == container.ErrNotExist {
-			return nil, containerNotFound(prefixOrName)
+	containerID, err := daemon.containersReplica.GetByPrefix(prefixOrName)
+	if err != nil {
+		if errdefs.IsNotFound(err) {
+			return nil, err
 		}
-		return nil, errdefs.System(indexError)
+		return nil, errdefs.System(err)
 	}
 	return daemon.containers.Get(containerID), nil
 }

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -50,10 +50,7 @@ func (daemon *Daemon) GetContainer(prefixOrName string) (*container.Container, e
 
 	containerID, err := daemon.containersReplica.GetByPrefix(prefixOrName)
 	if err != nil {
-		if errdefs.IsNotFound(err) {
-			return nil, err
-		}
-		return nil, errdefs.System(err)
+		return nil, err
 	}
 	return daemon.containers.Get(containerID), nil
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -647,7 +647,7 @@ func (daemon *Daemon) parents(c *container.Container) map[string]*container.Cont
 func (daemon *Daemon) registerLink(parent, child *container.Container, alias string) error {
 	fullName := path.Join(parent.Name, alias)
 	if err := daemon.containersReplica.ReserveName(fullName, child.ID); err != nil {
-		if err == container.ErrNameReserved {
+		if errors.Is(err, container.ErrNameReserved) {
 			logrus.Warnf("error registering link for %s, to %s, as alias %s, ignoring: %v", parent.ID, child.ID, alias, err)
 			return nil
 		}

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -119,8 +119,11 @@ func (daemon *Daemon) filterByNameIDMatches(view *container.View, filter *listCo
 		// standard behavior of walking the entire container
 		// list from the daemon's in-memory store
 		all, err := view.All()
+		if err != nil {
+			return nil, err
+		}
 		sort.Sort(byCreatedDescending(all))
-		return all, err
+		return all, nil
 	}
 
 	// idSearch will determine if we limit name matching to the IDs

--- a/daemon/names.go
+++ b/daemon/names.go
@@ -64,7 +64,7 @@ func (daemon *Daemon) reserveName(id, name string) (string, error) {
 	}
 
 	if err := daemon.containersReplica.ReserveName(name, id); err != nil {
-		if err == container.ErrNameReserved {
+		if errors.Is(err, container.ErrNameReserved) {
 			id, err := daemon.containersReplica.Snapshot().GetID(name)
 			if err != nil {
 				logrus.Errorf("got unexpected error while looking up reserved name: %v", err)
@@ -90,7 +90,7 @@ func (daemon *Daemon) generateNewName(id string) (string, error) {
 		}
 
 		if err := daemon.containersReplica.ReserveName(name, id); err != nil {
-			if err == container.ErrNameReserved {
+			if errors.Is(err, container.ErrNameReserved) {
 				continue
 			}
 			return "", err


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/43624

some changes I had in a local branch while I was reviewing https://github.com/moby/moby/pull/43624 - removes some custom error-types that didn't have to be exported, and fixes some errors to prevent producing 500 "internal server errors".


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

