### PR TITLE
API: bump version to 1.43

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -3,7 +3,7 @@ package api // import "github.com/docker/docker/api"
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of Current REST API
-	DefaultVersion = "1.42"
+	DefaultVersion = "1.43"
 
 	// NoBaseImageSpecifier is the symbol used by the FROM
 	// command to specify that no base image is to be used.

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -19,10 +19,10 @@ produces:
 consumes:
   - "application/json"
   - "text/plain"
-basePath: "/v1.42"
+basePath: "/v1.43"
 info:
   title: "Docker Engine API"
-  version: "1.42"
+  version: "1.43"
   x-logo:
     url: "https://docs.docker.com/images/logo-docker-main.png"
   description: |
@@ -55,8 +55,8 @@ info:
     the URL is not supported by the daemon, a HTTP `400 Bad Request` error message
     is returned.
 
-    If you omit the version-prefix, the current version of the API (v1.42) is used.
-    For example, calling `/info` is the same as calling `/v1.42/info`. Using the
+    If you omit the version-prefix, the current version of the API (v1.43) is used.
+    For example, calling `/info` is the same as calling `/v1.43/info`. Using the
     API without a version-prefix is deprecated and will be removed in a future release.
 
     Engine releases in the near future should support this version of the API,

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -13,6 +13,12 @@ keywords: "API, Docker, rcli, REST, documentation"
      will be rejected.
 -->
 
+## v1.43 API changes
+
+[Docker Engine API v1.43](https://docs.docker.com/engine/api/v1.43/) documentation
+
+* TODO add API changes for v1.43 here when they arrive.
+
 ## v1.42 API changes
 
 [Docker Engine API v1.42](https://docs.docker.com/engine/api/v1.42/) documentation


### PR DESCRIPTION
- related: https://github.com/moby/moby/pull/43795

The 22.06 branch was created, so changes in master/main should now be targeting the next version of the API (1.43).


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

