### PR TITLE
[22.06 backport] pkg/parsers/operatingsystem: fix stray import

### DIFF
--- a/pkg/parsers/operatingsystem/operatingsystem_unix.go
+++ b/pkg/parsers/operatingsystem/operatingsystem_unix.go
@@ -4,7 +4,6 @@
 package operatingsystem // import "github.com/docker/docker/pkg/parsers/operatingsystem"
 
 import (
-	"bytes"
 	"errors"
 
 	"golang.org/x/sys/unix"


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/43785 

This was caught by goimports;

    goimports -w $(find . -type f -name '*.go'| grep -v "/vendor/")

CI doesn't run on these platforms, so didn't catch it.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit e4e819b49c4d7ca55e53d135f7ffdbf40ca7887c)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

