### PR TITLE
[22.06 backport] client: errors: remove dead code

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -40,11 +40,11 @@ type notFound interface {
 // IsErrNotFound returns true if the error is a NotFound error, which is returned
 // by the API when some object is not found.
 func IsErrNotFound(err error) bool {
-	var e notFound
-	if errors.As(err, &e) {
+	if errdefs.IsNotFound(err) {
 		return true
 	}
-	return errdefs.IsNotFound(err)
+	var e notFound
+	return errors.As(err, &e)
 }
 
 type objectNotFoundError struct {
@@ -58,22 +58,11 @@ func (e objectNotFoundError) Error() string {
 	return fmt.Sprintf("Error: No such %s: %s", e.object, e.id)
 }
 
-// unauthorizedError represents an authorization error in a remote registry.
-type unauthorizedError struct {
-	cause error
-}
-
-// Error returns a string representation of an unauthorizedError
-func (u unauthorizedError) Error() string {
-	return u.cause.Error()
-}
-
 // IsErrUnauthorized returns true if the error is caused
 // when a remote registry authentication fails
+//
+// Deprecated: use errdefs.IsUnauthorized
 func IsErrUnauthorized(err error) bool {
-	if _, ok := err.(unauthorizedError); ok {
-		return ok
-	}
 	return errdefs.IsUnauthorized(err)
 }
 
@@ -85,32 +74,12 @@ func (e pluginPermissionDenied) Error() string {
 	return "Permission denied while installing plugin " + e.name
 }
 
-// IsErrPluginPermissionDenied returns true if the error is caused
-// when a user denies a plugin's permissions
-func IsErrPluginPermissionDenied(err error) bool {
-	_, ok := err.(pluginPermissionDenied)
-	return ok
-}
-
-type notImplementedError struct {
-	message string
-}
-
-func (e notImplementedError) Error() string {
-	return e.message
-}
-
-func (e notImplementedError) NotImplemented() bool {
-	return true
-}
-
 // IsErrNotImplemented returns true if the error is a NotImplemented error.
 // This is returned by the API when a requested feature has not been
 // implemented.
+//
+// Deprecated: use errdefs.IsNotImplemented
 func IsErrNotImplemented(err error) bool {
-	if _, ok := err.(notImplementedError); ok {
-		return ok
-	}
 	return errdefs.IsNotImplemented(err)
 }
 

--- a/testutil/environment/clean.go
+++ b/testutil/environment/clean.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
 )
 
@@ -164,7 +165,7 @@ func deleteAllPlugins(t testing.TB, c client.PluginAPIClient, protectedPlugins m
 	t.Helper()
 	plugins, err := c.PluginList(context.Background(), filters.Args{})
 	// Docker EE does not allow cluster-wide plugin management.
-	if client.IsErrNotImplemented(err) {
+	if errdefs.IsNotImplemented(err) {
 		return
 	}
 	assert.Check(t, err, "failed to list plugins")

--- a/testutil/environment/protect.go
+++ b/testutil/environment/protect.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	dclient "github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
 )
 
@@ -180,7 +180,7 @@ func getExistingPlugins(t testing.TB, testEnv *Execution) []string {
 	client := testEnv.APIClient()
 	pluginList, err := client.PluginList(context.Background(), filters.Args{})
 	// Docker EE does not allow cluster-wide plugin management.
-	if dclient.IsErrNotImplemented(err) {
+	if errdefs.IsNotImplemented(err) {
 		return []string{}
 	}
 	assert.NilError(t, err, "failed to list plugins")


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/43789

- Update IsErrNotFound() to check for the current type before falling back to
  detecting the deprecated type.
- Remove unauthorizedError and notImplementedError types, which were not used.
- IsErrPluginPermissionDenied() was added in 7c36a1af031b510cd990cf488ee5998a3efb450f,
  but not used at the time, and still appears to be unused.
- Deprecate IsErrUnauthorized in favor of errdefs.IsUnauthorized()
- Deprecate IsErrNotImplemented in favor of errdefs,IsNotImplemented()

(cherry picked from commit ee230d8fdda6a1901c2adc394b5fb8471ec7aa51)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

