### PR TITLE
[22.06 backport] fix formatting of "nolint" tags for go1.19

### DIFF
--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -558,7 +558,7 @@ func (c *client) CreateCheckpoint(ctx context.Context, containerID, checkpointDi
 	for _, m := range index.Manifests {
 		m := m
 		if m.MediaType == images.MediaTypeContainerd1Checkpoint {
-			cpDesc = &m // nolint:gosec
+			cpDesc = &m //nolint:gosec
 			break
 		}
 	}

--- a/libnetwork/cmd/networkdb-test/dummyclient/dummyClient.go
+++ b/libnetwork/cmd/networkdb-test/dummyclient/dummyClient.go
@@ -29,11 +29,11 @@ type tableHandler struct {
 var clientWatchTable = map[string]tableHandler{}
 
 func watchTable(ctx interface{}, w http.ResponseWriter, r *http.Request) {
-	r.ParseForm() // nolint:errcheck
+	r.ParseForm() //nolint:errcheck
 	diagnostic.DebugHTTPForm(r)
 	if len(r.Form["tname"]) < 1 {
 		rsp := diagnostic.WrongCommand(missingParameter, fmt.Sprintf("%s?tname=table_name", r.URL.Path))
-		diagnostic.HTTPReply(w, rsp, &diagnostic.JSONOutput{}) // nolint:errcheck
+		diagnostic.HTTPReply(w, rsp, &diagnostic.JSONOutput{}) //nolint:errcheck
 		return
 	}
 
@@ -54,11 +54,11 @@ func watchTable(ctx interface{}, w http.ResponseWriter, r *http.Request) {
 }
 
 func watchTableEntries(ctx interface{}, w http.ResponseWriter, r *http.Request) {
-	r.ParseForm() // nolint:errcheck
+	r.ParseForm() //nolint:errcheck
 	diagnostic.DebugHTTPForm(r)
 	if len(r.Form["tname"]) < 1 {
 		rsp := diagnostic.WrongCommand(missingParameter, fmt.Sprintf("%s?tname=table_name", r.URL.Path))
-		diagnostic.HTTPReply(w, rsp, &diagnostic.JSONOutput{}) // nolint:errcheck
+		diagnostic.HTTPReply(w, rsp, &diagnostic.JSONOutput{}) //nolint:errcheck
 		return
 	}
 

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -623,7 +623,7 @@ func (c *controller) NewNetwork(networkType, name string, id string, options ...
 
 	if id != "" {
 		c.networkLocker.Lock(id)
-		defer c.networkLocker.Unlock(id) // nolint:errcheck
+		defer c.networkLocker.Unlock(id) //nolint:errcheck
 
 		if _, err = c.NetworkByID(id); err == nil {
 			return nil, NetworkNameError(id)
@@ -734,7 +734,7 @@ func (c *controller) NewNetwork(networkType, name string, id string, options ...
 
 	err = c.addNetwork(network)
 	if err != nil {
-		if _, ok := err.(types.MaskableError); ok { // nolint:gosimple
+		if _, ok := err.(types.MaskableError); ok { //nolint:gosimple
 			// This error can be ignored and set this boolean
 			// value to skip a refcount increment for configOnly networks
 			skipCfgEpCount = true

--- a/libnetwork/diagnostic/server.go
+++ b/libnetwork/diagnostic/server.go
@@ -108,7 +108,7 @@ func (s *Server) DisableDiagnostic() {
 	s.Lock()
 	defer s.Unlock()
 
-	s.srv.Shutdown(context.Background()) // nolint:errcheck
+	s.srv.Shutdown(context.Background()) //nolint:errcheck
 	s.srv = nil
 	s.enable = 0
 	logrus.Info("Disabling the diagnostic server")
@@ -122,7 +122,7 @@ func (s *Server) IsDiagnosticEnabled() bool {
 }
 
 func notImplemented(ctx interface{}, w http.ResponseWriter, r *http.Request) {
-	r.ParseForm() // nolint:errcheck
+	r.ParseForm() //nolint:errcheck
 	_, json := ParseHTTPFormOptions(r)
 	rsp := WrongCommand("not implemented", fmt.Sprintf("URL path: %s no method implemented check /help\n", r.URL.Path))
 
@@ -130,11 +130,11 @@ func notImplemented(ctx interface{}, w http.ResponseWriter, r *http.Request) {
 	log := logrus.WithFields(logrus.Fields{"component": "diagnostic", "remoteIP": r.RemoteAddr, "method": caller.Name(0), "url": r.URL.String()})
 	log.Info("command not implemented done")
 
-	HTTPReply(w, rsp, json) // nolint:errcheck
+	HTTPReply(w, rsp, json) //nolint:errcheck
 }
 
 func help(ctx interface{}, w http.ResponseWriter, r *http.Request) {
-	r.ParseForm() // nolint:errcheck
+	r.ParseForm() //nolint:errcheck
 	_, json := ParseHTTPFormOptions(r)
 
 	// audit logs
@@ -147,22 +147,22 @@ func help(ctx interface{}, w http.ResponseWriter, r *http.Request) {
 		for path := range n.registeredHanders {
 			result += fmt.Sprintf("%s\n", path)
 		}
-		HTTPReply(w, CommandSucceed(&StringCmd{Info: result}), json) // nolint:errcheck
+		HTTPReply(w, CommandSucceed(&StringCmd{Info: result}), json) //nolint:errcheck
 	}
 }
 
 func ready(ctx interface{}, w http.ResponseWriter, r *http.Request) {
-	r.ParseForm() // nolint:errcheck
+	r.ParseForm() //nolint:errcheck
 	_, json := ParseHTTPFormOptions(r)
 
 	// audit logs
 	log := logrus.WithFields(logrus.Fields{"component": "diagnostic", "remoteIP": r.RemoteAddr, "method": caller.Name(0), "url": r.URL.String()})
 	log.Info("ready done")
-	HTTPReply(w, CommandSucceed(&StringCmd{Info: "OK"}), json) // nolint:errcheck
+	HTTPReply(w, CommandSucceed(&StringCmd{Info: "OK"}), json) //nolint:errcheck
 }
 
 func stackTrace(ctx interface{}, w http.ResponseWriter, r *http.Request) {
-	r.ParseForm() // nolint:errcheck
+	r.ParseForm() //nolint:errcheck
 	_, json := ParseHTTPFormOptions(r)
 
 	// audit logs
@@ -172,10 +172,10 @@ func stackTrace(ctx interface{}, w http.ResponseWriter, r *http.Request) {
 	path, err := stack.DumpToFile("/tmp/")
 	if err != nil {
 		log.WithError(err).Error("failed to write goroutines dump")
-		HTTPReply(w, FailCommand(err), json) // nolint:errcheck
+		HTTPReply(w, FailCommand(err), json) //nolint:errcheck
 	} else {
 		log.Info("stack trace done")
-		HTTPReply(w, CommandSucceed(&StringCmd{Info: fmt.Sprintf("goroutine stacks written to %s", path)}), json) // nolint:errcheck
+		HTTPReply(w, CommandSucceed(&StringCmd{Info: fmt.Sprintf("goroutine stacks written to %s", path)}), json) //nolint:errcheck
 	}
 }
 

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -120,18 +120,18 @@ func (ep *endpoint) UnmarshalJSON(b []byte) (err error) {
 	// If anyone ever comes here and figures out one way or another if we can/should be checking these errors and it turns out we can't... then please document *why*
 
 	ib, _ := json.Marshal(epMap["ep_iface"])
-	json.Unmarshal(ib, &ep.iface) // nolint:errcheck
+	json.Unmarshal(ib, &ep.iface) //nolint:errcheck
 
 	jb, _ := json.Marshal(epMap["joinInfo"])
-	json.Unmarshal(jb, &ep.joinInfo) // nolint:errcheck
+	json.Unmarshal(jb, &ep.joinInfo) //nolint:errcheck
 
 	tb, _ := json.Marshal(epMap["exposed_ports"])
 	var tPorts []types.TransportPort
-	json.Unmarshal(tb, &tPorts) // nolint:errcheck
+	json.Unmarshal(tb, &tPorts) //nolint:errcheck
 	ep.exposedPorts = tPorts
 
 	cb, _ := json.Marshal(epMap["sandbox"])
-	json.Unmarshal(cb, &ep.sandboxID) // nolint:errcheck
+	json.Unmarshal(cb, &ep.sandboxID) //nolint:errcheck
 
 	if v, ok := epMap["generic"]; ok {
 		ep.generic = v.(map[string]interface{})
@@ -207,17 +207,17 @@ func (ep *endpoint) UnmarshalJSON(b []byte) (err error) {
 
 	sal, _ := json.Marshal(epMap["svcAliases"])
 	var svcAliases []string
-	json.Unmarshal(sal, &svcAliases) // nolint:errcheck
+	json.Unmarshal(sal, &svcAliases) //nolint:errcheck
 	ep.svcAliases = svcAliases
 
 	pc, _ := json.Marshal(epMap["ingressPorts"])
 	var ingressPorts []*PortConfig
-	json.Unmarshal(pc, &ingressPorts) // nolint:errcheck
+	json.Unmarshal(pc, &ingressPorts) //nolint:errcheck
 	ep.ingressPorts = ingressPorts
 
 	ma, _ := json.Marshal(epMap["myAliases"])
 	var myAliases []string
-	json.Unmarshal(ma, &myAliases) // nolint:errcheck
+	json.Unmarshal(ma, &myAliases) //nolint:errcheck
 	ep.myAliases = myAliases
 	return nil
 }

--- a/libnetwork/endpoint_info.go
+++ b/libnetwork/endpoint_info.go
@@ -137,7 +137,7 @@ func (epi *endpointInterface) UnmarshalJSON(b []byte) error {
 	var routes []string
 
 	// TODO(cpuguy83): linter noticed we don't check the error here... no idea why but it seems like it could introduce problems if we start checking
-	json.Unmarshal(rb, &routes) // nolint:errcheck
+	json.Unmarshal(rb, &routes) //nolint:errcheck
 
 	epi.routes = make([]*net.IPNet, 0)
 	for _, route := range routes {
@@ -444,7 +444,7 @@ func (epj *endpointJoinInfo) UnmarshalJSON(b []byte) error {
 		// This is why I'm not adding the error check.
 		//
 		// In any case for posterity please if you figure this out document it or check the error
-		json.Unmarshal(tb, &tStaticRoute) // nolint:errcheck
+		json.Unmarshal(tb, &tStaticRoute) //nolint:errcheck
 	}
 	var StaticRoutes []*types.StaticRoute
 	for _, r := range tStaticRoute {

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -630,7 +630,7 @@ func TestIpamReleaseOnNetDriverFailures(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ep.Delete(false) // nolint:errcheck
+	defer ep.Delete(false) //nolint:errcheck
 
 	expectedIP, _ := types.ParseCIDR("10.35.0.1/16")
 	if !types.CompareIPNet(ep.Info().Iface().Address(), expectedIP) {

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -993,7 +993,7 @@ func (n *network) delete(force bool, rmLBEndpoint bool) error {
 	n.Unlock()
 
 	c.networkLocker.Lock(id)
-	defer c.networkLocker.Unlock(id) // nolint:errcheck
+	defer c.networkLocker.Unlock(id) //nolint:errcheck
 
 	n, err := c.getNetworkFromStore(id)
 	if err != nil {
@@ -1027,7 +1027,7 @@ func (n *network) delete(force bool, rmLBEndpoint bool) error {
 			// continue deletion when force is true even on error
 			logrus.Warnf("Error deleting load balancer sandbox: %v", err)
 		}
-		//Reload the network from the store to update the epcnt.
+		// Reload the network from the store to update the epcnt.
 		n, err = c.getNetworkFromStore(id)
 		if err != nil {
 			return &UnknownNetworkError{name: name, id: id}
@@ -1165,7 +1165,7 @@ func (n *network) CreateEndpoint(name string, options ...EndpointOption) (Endpoi
 	}
 
 	n.ctrlr.networkLocker.Lock(n.id)
-	defer n.ctrlr.networkLocker.Unlock(n.id) // nolint:errcheck
+	defer n.ctrlr.networkLocker.Unlock(n.id) //nolint:errcheck
 
 	return n.createEndpoint(name, options...)
 

--- a/libnetwork/options/options_test.go
+++ b/libnetwork/options/options_test.go
@@ -84,7 +84,7 @@ func TestGenerateMissingField(t *testing.T) {
 }
 
 func TestFieldCannotBeSet(t *testing.T) {
-	type Model struct{ foo int } // nolint:structcheck
+	type Model struct{ foo int } //nolint:structcheck
 	_, err := GenerateFromModel(Generic{"foo": "bar"}, Model{})
 
 	if _, ok := err.(CannotSetFieldError); !ok {

--- a/libnetwork/resolver.go
+++ b/libnetwork/resolver.go
@@ -64,7 +64,7 @@ const (
 	ptrIPv4domain   = ".in-addr.arpa."
 	ptrIPv6domain   = ".ip6.arpa."
 	respTTL         = 600
-	maxExtDNS       = 3 //max number of external servers to try
+	maxExtDNS       = 3 // max number of external servers to try
 	extIOTimeout    = 4 * time.Second
 	defaultRespSize = 512
 	maxConcurrent   = 1024
@@ -177,10 +177,10 @@ func (r *resolver) Stop() {
 	defer func() { <-r.startCh }()
 
 	if r.server != nil {
-		r.server.Shutdown() // nolint:errcheck
+		r.server.Shutdown() //nolint:errcheck
 	}
 	if r.tcpServer != nil {
-		r.tcpServer.Shutdown() // nolint:errcheck
+		r.tcpServer.Shutdown() //nolint:errcheck
 	}
 	r.conn = nil
 	r.tcpServer = nil
@@ -214,7 +214,7 @@ func setCommonFlags(msg *dns.Msg) {
 
 func shuffleAddr(addr []net.IP) []net.IP {
 	for i := len(addr) - 1; i > 0; i-- {
-		r := rand.Intn(i + 1) // nolint:gosec // gosec complains about the use of rand here. It should be fine.
+		r := rand.Intn(i + 1) //nolint:gosec // gosec complains about the use of rand here. It should be fine.
 		addr[i], addr[r] = addr[r], addr[i]
 	}
 	return addr

--- a/libnetwork/resolver_test.go
+++ b/libnetwork/resolver_test.go
@@ -252,7 +252,7 @@ func TestDNSProxyServFail(t *testing.T) {
 		srvErrCh <- server.ListenAndServe()
 	}()
 	defer func() {
-		server.Shutdown() // nolint:errcheck
+		server.Shutdown() //nolint:errcheck
 		if err := <-srvErrCh; err != nil {
 			t.Error(err)
 		}

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -93,12 +93,12 @@ type sandbox struct {
 // These are the container configs used to customize container /etc/hosts file.
 type hostsPathConfig struct {
 	// Note(cpuguy83): The linter is drunk and says none of these fields are used while they are
-	hostName        string         // nolint:structcheck
-	domainName      string         // nolint:structcheck
-	hostsPath       string         // nolint:structcheck
-	originHostsPath string         // nolint:structcheck
-	extraHosts      []extraHost    // nolint:structcheck
-	parentUpdates   []parentUpdate // nolint:structcheck
+	hostName        string         //nolint:structcheck
+	domainName      string         //nolint:structcheck
+	hostsPath       string         //nolint:structcheck
+	originHostsPath string         //nolint:structcheck
+	extraHosts      []extraHost    //nolint:structcheck
+	parentUpdates   []parentUpdate //nolint:structcheck
 }
 
 type parentUpdate struct {
@@ -115,12 +115,12 @@ type extraHost struct {
 // These are the container configs used to customize container /etc/resolv.conf file.
 type resolvConfPathConfig struct {
 	// Note(cpuguy83): The linter is drunk and says none of these fields are used while they are
-	resolvConfPath       string   // nolint:structcheck
-	originResolvConfPath string   // nolint:structcheck
-	resolvConfHashFile   string   // nolint:structcheck
-	dnsList              []string // nolint:structcheck
-	dnsSearchList        []string // nolint:structcheck
-	dnsOptionsList       []string // nolint:structcheck
+	resolvConfPath       string   //nolint:structcheck
+	originResolvConfPath string   //nolint:structcheck
+	resolvConfHashFile   string   //nolint:structcheck
+	dnsList              []string //nolint:structcheck
+	dnsSearchList        []string //nolint:structcheck
+	dnsOptionsList       []string //nolint:structcheck
 }
 
 type containerConfig struct {
@@ -412,8 +412,8 @@ func (sb *sandbox) updateGateway(ep *endpoint) error {
 	if osSbox == nil {
 		return nil
 	}
-	osSbox.UnsetGateway()     // nolint:errcheck
-	osSbox.UnsetGatewayIPv6() // nolint:errcheck
+	osSbox.UnsetGateway()     //nolint:errcheck
+	osSbox.UnsetGatewayIPv6() //nolint:errcheck
 
 	if ep == nil {
 		return nil

--- a/libnetwork/service_common.go
+++ b/libnetwork/service_common.go
@@ -235,7 +235,7 @@ func (c *controller) addServiceBinding(svcName, svcID, nID, eID, containerName s
 	// state in the c.serviceBindings map and it's sub-maps. Also,
 	// always lock network ID before services to avoid deadlock.
 	c.networkLocker.Lock(nID)
-	defer c.networkLocker.Unlock(nID) // nolint:errcheck
+	defer c.networkLocker.Unlock(nID) //nolint:errcheck
 
 	n, err := c.NetworkByID(nID)
 	if err != nil {

--- a/pkg/devicemapper/devmapper.go
+++ b/pkg/devicemapper/devmapper.go
@@ -15,7 +15,8 @@ import (
 )
 
 // Same as DM_DEVICE_* enum values from libdevmapper.h
-// nolint: deadcode,unused,varcheck
+//
+//nolint:deadcode,unused,varcheck
 const (
 	deviceCreate TaskType = iota
 	deviceReload

--- a/volume/drivers/extpoint.go
+++ b/volume/drivers/extpoint.go
@@ -21,7 +21,8 @@ const extName = "VolumeDriver"
 // volumeDriver defines the available functions that volume plugins must implement.
 // This interface is only defined to generate the proxy objects.
 // It's not intended to be public or reused.
-// nolint: deadcode,unused,varcheck
+//
+//nolint:deadcode,unused,varcheck
 type volumeDriver interface {
 	// Create a volume with the given name
 	Create(name string, opts map[string]string) (err error)


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/43804

The correct formatting for machine-readable comments is;

    //<some alphanumeric identifier>:<options>[,<option>...][ // comment]

Which basically means:

- MUST NOT have a space before `<identifier>` (e.g. `nolint`)
- Identified MUST be alphanumeric
- MUST be followed by a colon
- MUST be followed by at least one `<option>`
- Optionally additional `<options>` (comma-separated)
- Optionally followed by a comment

Any other format will not be considered a machine-readable comment by `gofmt`,
and thus formatted as a regular comment. Note that this also means that a
`//nolint` (without anything after it) is considered invalid, same for `//#nosec`
(starts with a `#`).

(cherry picked from commit 4f0834668696c981ef56ee77dc7af05bf3d0dbf9)


