### PR TITLE
[22.06] libnetwork: skip firewalld management for rootless

### DIFF
--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/docker/docker/rootless"
 	"github.com/sirupsen/logrus"
 )
 
@@ -105,6 +106,12 @@ func probe() {
 }
 
 func initFirewalld() {
+	// When running with RootlessKit, firewalld is running as the root outside our network namespace
+	// https://github.com/moby/moby/issues/43781
+	if rootless.RunningWithRootlessKit() {
+		logrus.Info("skipping firewalld management for rootless mode")
+		return
+	}
 	if err := FirewalldInit(); err != nil {
 		logrus.Debugf("Fail to initialize firewalld: %v, using raw iptables instead", err)
 	}


### PR DESCRIPTION
Cherry-pick https://github.com/moby/moby/pull/43793 (clean)

> **- What I did** Fix:
> 
> * [No networking in rootless docker with firewalld #43781](https://github.com/moby/moby/issues/43781)
> 
> **- How I did it**
> 
> Skip firewalld management when running with RootlessKit
> 
> **- How to verify it**
> 
> ```
> sudo systemctl enable firewalld
> dockerd-rootless-setuptool.sh install -f
> docker --context=rootless run --rm alpine sh -euxc 'apk add neofetch && neofetch'
> ```
> 
> **- Description for the changelog**
> 
> libnetwork: skip firewalld management for rootless
> 
> **- A picture of a cute animal (not mandatory but encouraged)** 🐧

