### PR TITLE
logger/journald: remove journald_compat (for systemd < 209)

### DIFF
--- a/daemon/logger/journald/read_native.go
+++ b/daemon/logger/journald/read_native.go
@@ -1,5 +1,5 @@
-//go:build linux && cgo && !static_build && journald && !journald_compat
-// +build linux,cgo,!static_build,journald,!journald_compat
+//go:build linux && cgo && !static_build && journald
+// +build linux,cgo,!static_build,journald
 
 package journald // import "github.com/docker/docker/daemon/logger/journald"
 

--- a/daemon/logger/journald/read_native_compat.go
+++ b/daemon/logger/journald/read_native_compat.go
@@ -1,7 +1,0 @@
-//go:build linux && cgo && !static_build && journald && journald_compat
-// +build linux,cgo,!static_build,journald,journald_compat
-
-package journald // import "github.com/docker/docker/daemon/logger/journald"
-
-// #cgo pkg-config: libsystemd-journal
-import "C"

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -83,10 +83,8 @@ add_buildtag() {
 	[[ " $DOCKER_BUILDTAGS" == *" $1_"* ]] || DOCKER_BUILDTAGS+=" $1_$2"
 }
 
-if ${PKG_CONFIG} 'libsystemd >= 209' 2> /dev/null; then
+if ${PKG_CONFIG} 'libsystemd' 2> /dev/null; then
 	DOCKER_BUILDTAGS+=" journald"
-elif ${PKG_CONFIG} 'libsystemd-journal' 2> /dev/null; then
-	DOCKER_BUILDTAGS+=" journald journald_compat"
 fi
 
 # test whether "libdevmapper.h" is new enough to support deferred remove

--- a/hack/validate/golangci-lint
+++ b/hack/validate/golangci-lint
@@ -11,10 +11,8 @@ SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 [ -n "${TESTDEBUG}" ] && set -x
 
 # TODO find a way to share this code with hack/make.sh
-if ${PKG_CONFIG} 'libsystemd >= 209' 2> /dev/null; then
+if pkg-config 'libsystemd' 2> /dev/null; then
 	DOCKER_BUILDTAGS+=" journald"
-elif ${PKG_CONFIG} 'libsystemd-journal' 2> /dev/null; then
-	DOCKER_BUILDTAGS+=" journald journald_compat"
 fi
 
 echo -e "\n\033[0;36mINFO\033[0m Start validation with golang-ci-lint"


### PR DESCRIPTION
- depends on https://github.com/moby/moby/pull/43839
- relates to https://github.com/moby/moby/pull/43529#discussion_r925474764

This was added in 6cdc4ba6cd5178037466c50ebe03a7eb111c43b1 (https://github.com/moby/moby/pull/20617) in 2016, likely
because at the time we were still building for CentOS 6 and Ubuntu 14.04.

All currently supported distros appear to be on _at least_ 219 now, so it looks
safe to remove this;

```bash
docker run -it --rm centos:7

yum install -y systemd-devel

pkg-config 'libsystemd >= 209' && echo "OK" || echo "KO"
OK

pkg-config --print-provides 'libsystemd'
libsystemd = 219

pkg-config --print-provides 'libsystemd-journal'
libsystemd-journal = 219
```

And on a `debian:buster` (old stable)

```bash
docker run -it --rm debian:buster

apt-get update && apt-get install -y libsystemd-dev pkg-config

pkg-config 'libsystemd >= 209' && echo "OK" || echo "KO"
OK

pkg-config --print-provides 'libsystemd'
libsystemd = 241

pkg-config --print-provides 'libsystemd-journal'
Package libsystemd-journal was not found in the pkg-config search path.
Perhaps you should add the directory containing `libsystemd-journal.pc'
to the PKG_CONFIG_PATH environment variable
No package 'libsystemd-journal' found
```

OpenSUSE leap (I think that's built for s390x)

```bash
docker run -it --rm docker.io/opensuse/leap:15

zypper install -y systemd-devel

pkg-config 'libsystemd >= 209' && echo "OK" || echo "KO"
OK

pkg-config --print-provides 'libsystemd'
libsystemd = 246

pkg-config --print-provides 'libsystemd-journal'
Package libsystemd-journal was not found in the pkg-config search path.
Perhaps you should add the directory containing `libsystemd-journal.pc'
to the PKG_CONFIG_PATH environment variable
No package 'libsystemd-journal' found
```


**- A picture of a cute animal (not mandatory but encouraged)**

