### PR TITLE
[22.06 backport] logger/journald: fix SA4011: ineffective break statement

### DIFF
--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -227,6 +227,7 @@ func (s *journald) followJournal(logWatcher *logger.LogWatcher, j *C.sd_journal,
 
 	waitTimeout := C.uint64_t(250000) // 0.25s
 
+LOOP:
 	for {
 		status := C.sd_journal_wait(j, waitTimeout)
 		if status < 0 {
@@ -235,7 +236,7 @@ func (s *journald) followJournal(logWatcher *logger.LogWatcher, j *C.sd_journal,
 		}
 		select {
 		case <-logWatcher.WatchConsumerGone():
-			break // won't be able to write anything anymore
+			break LOOP // won't be able to write anything anymore
 		case <-s.closed:
 			// container is gone, drain journal
 		default:


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/43839

This was introduced in 906b979b888cf9111a4a2583640e509d28395670, which changed
a `goto` to a `break`, but afaics, the intent was still to break out of the loop.
(linter didn't catch this before because it didn't have the right build-tag set)

    daemon/logger/journald/read.go:238:4: SA4011: ineffective break statement. Did you mean to break out of the outer loop? (staticcheck)
                break // won't be able to write anything anymore
                ^

(cherry picked from commit 75577fe7a8d9f21442b00df90c8ac33ebea2ac67)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

