### PR TITLE
integration-cli: Enable TestGetContainersAttachWebsocket for Windows

### DIFF
--- a/integration-cli/docker_api_attach_test.go
+++ b/integration-cli/docker_api_attach_test.go
@@ -23,8 +23,7 @@ import (
 )
 
 func (s *DockerAPISuite) TestGetContainersAttachWebsocket(c *testing.T) {
-	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-dit", "busybox", "cat")
+	out, _ := dockerCmd(c, "run", "-di", "busybox", "cat")
 
 	rwc, err := request.SockConn(10*time.Second, request.DaemonHost())
 	assert.NilError(c, err)


### PR DESCRIPTION
**- What I did**
I have been trying to figure out why `TestExecWithCloseStdin` test hangs forever in Windows + containerd combination and as part of it find out that there is other good attach tests which are not currently enabled on Windows. So this PR enables `TestGetContainersAttachWebsocket`

**- How I did it**
Disabled TTY because `is.DeepEqual` looks to be comparing hex decimals and which does not work even without containerd on Windows because of different encoding/etc 

For record error before disabling TTY was (or that looks to be from my test where message was "hello+r
```
=== RUN   TestDockerAPISuite/TestGetContainersAttachWebsocket
    docker_api_attach_test.go:73: assertion failed: 
        --- actual
        +++ expected
          []uint8{
        -       0x1b, 0x5b, 0x32, 0x4a, 0x1b, // -|.[2J.|
        +       0x68, 0x65, 0x6c, 0x6c, 0x6f, // +|hello|
          }
        : Websocket didn't return the expected data
```

For the record. I did also investigate `TestPostContainersAttach` but there even non-TTY tests looks to be problematic because those tests contains line breaks which does not end up to actual.

**- How to verify it**
Should be good if CI passes on all combinations.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

