### PR TITLE
use consistent alias for gotest.tools/v3/assert/cmp

### DIFF
--- a/daemon/images/store_test.go
+++ b/daemon/images/store_test.go
@@ -17,7 +17,7 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.etcd.io/bbolt"
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/assert/cmp"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func setupTestStores(t *testing.T) (context.Context, content.Store, *imageStoreWithLease, func(t *testing.T)) {
@@ -75,24 +75,24 @@ func TestImageDelete(t *testing.T) {
 
 		ls, err := images.leases.List(ctx)
 		assert.NilError(t, err)
-		assert.Check(t, cmp.Equal(len(ls), 1), ls)
+		assert.Check(t, is.Equal(len(ls), 1), ls)
 
 		_, err = images.Delete(id)
 		assert.NilError(t, err)
 
 		ls, err = images.leases.List(ctx)
 		assert.NilError(t, err)
-		assert.Check(t, cmp.Equal(len(ls), 0), ls)
+		assert.Check(t, is.Equal(len(ls), 0), ls)
 	})
 }
 
 func TestContentStoreForPull(t *testing.T) {
-	ctx, cs, is, cleanup := setupTestStores(t)
+	ctx, cs, imgStore, cleanup := setupTestStores(t)
 	defer cleanup(t)
 
 	csP := &contentStoreForPull{
 		ContentStore: cs,
-		leases:       is.leases,
+		leases:       imgStore.leases,
 	}
 
 	data := []byte(`{}`)
@@ -112,12 +112,12 @@ func TestContentStoreForPull(t *testing.T) {
 	assert.NilError(t, err)
 
 	assert.Equal(t, len(csP.digested), 1)
-	assert.Check(t, cmp.Equal(csP.digested[0], desc.Digest))
+	assert.Check(t, is.Equal(csP.digested[0], desc.Digest))
 
 	// Test already exists
 	csP.digested = nil
 	_, err = csP.Writer(ctx, content.WithRef(t.Name()), content.WithDescriptor(desc))
 	assert.Check(t, c8derrdefs.IsAlreadyExists(err))
 	assert.Equal(t, len(csP.digested), 1)
-	assert.Check(t, cmp.Equal(csP.digested[0], desc.Digest))
+	assert.Check(t, is.Equal(csP.digested[0], desc.Digest))
 }

--- a/daemon/logger/loggerutils/cache/log_cache_test.go
+++ b/daemon/logger/loggerutils/cache/log_cache_test.go
@@ -1,16 +1,14 @@
 package cache
 
 import (
+	"bytes"
 	"context"
 	"testing"
-
 	"time"
-
-	"bytes"
 
 	"github.com/docker/docker/daemon/logger"
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/assert/cmp"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 type fakeLogger struct {
@@ -75,7 +73,7 @@ func TestLog(t *testing.T) {
 		case <-ctx.Done():
 			t.Fatal("timed out waiting for messages... this is probably a test implementation error")
 		case msg = <-cacher.messages:
-			assert.Assert(t, cmp.DeepEqual(msg, m))
+			assert.Assert(t, is.DeepEqual(msg, m))
 		}
 	}
 }

--- a/daemon/logger/loggerutils/sharedtemp_test.go
+++ b/daemon/logger/loggerutils/sharedtemp_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/assert/cmp"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestSharedTempFileConverter(t *testing.T) {
@@ -33,9 +33,9 @@ func TestSharedTempFileConverter(t *testing.T) {
 			t.Logf("Iteration %v", i)
 
 			rdr := convertPath(t, uut, name)
-			assert.Check(t, cmp.Equal("HELLO, WORLD!", readAll(t, rdr)))
+			assert.Check(t, is.Equal("HELLO, WORLD!", readAll(t, rdr)))
 			assert.Check(t, rdr.Close())
-			assert.Check(t, cmp.Equal(fs.ErrClosed, rdr.Close()), "closing an already-closed reader should return an error")
+			assert.Check(t, is.Equal(fs.ErrClosed, rdr.Close()), "closing an already-closed reader should return an error")
 		}
 
 		assert.NilError(t, os.Remove(name))
@@ -67,15 +67,15 @@ func TestSharedTempFileConverter(t *testing.T) {
 
 		rb1 := convertPath(t, uut, bpath) // Same path, different file.
 		ra2 := convertPath(t, uut, apath) // New path, old file.
-		assert.Check(t, cmp.Equal(2, conversions), "expected only one conversion per unique file")
+		assert.Check(t, is.Equal(2, conversions), "expected only one conversion per unique file")
 
 		// Interleave reading and closing to shake out ref-counting bugs:
 		// closing one reader shouldn't affect any other open readers.
-		assert.Check(t, cmp.Equal("FILE A", readAll(t, ra1)))
+		assert.Check(t, is.Equal("FILE A", readAll(t, ra1)))
 		assert.NilError(t, ra1.Close())
-		assert.Check(t, cmp.Equal("FILE A", readAll(t, ra2)))
+		assert.Check(t, is.Equal("FILE A", readAll(t, ra2)))
 		assert.NilError(t, ra2.Close())
-		assert.Check(t, cmp.Equal("FILE B", readAll(t, rb1)))
+		assert.Check(t, is.Equal("FILE B", readAll(t, rb1)))
 		assert.NilError(t, rb1.Close())
 
 		assert.NilError(t, os.Remove(apath))
@@ -120,7 +120,7 @@ func TestSharedTempFileConverter(t *testing.T) {
 				t.Logf("goroutine %v: enter", i)
 				defer t.Logf("goroutine %v: exit", i)
 				f := convertPath(t, uut, name)
-				assert.Check(t, cmp.Equal("HI THERE", readAll(t, f)), "in goroutine %v", i)
+				assert.Check(t, is.Equal("HI THERE", readAll(t, f)), "in goroutine %v", i)
 				closers <- f
 			}()
 		}
@@ -138,12 +138,12 @@ func TestSharedTempFileConverter(t *testing.T) {
 		f := convertPath(t, uut, name)
 		closers <- f
 		close(closers)
-		assert.Check(t, cmp.Equal("HI THERE", readAll(t, f)), "after all goroutines returned")
+		assert.Check(t, is.Equal("HI THERE", readAll(t, f)), "after all goroutines returned")
 		for c := range closers {
 			assert.Check(t, c.Close())
 		}
 
-		assert.Check(t, cmp.Equal(int32(1), conversions))
+		assert.Check(t, is.Equal(int32(1), conversions))
 
 		assert.NilError(t, os.Remove(name))
 		checkDirEmpty(t, dir)
@@ -197,7 +197,7 @@ func TestSharedTempFileConverter(t *testing.T) {
 		fakeErr = nil
 		f, err := uut.Do(src)
 		assert.Check(t, err)
-		assert.Check(t, cmp.Equal("HI THERE", readAll(t, f)))
+		assert.Check(t, is.Equal("HI THERE", readAll(t, f)))
 		assert.Check(t, f.Close())
 
 		// Files pending delete continue to show up in directory
@@ -241,7 +241,7 @@ func checkDirEmpty(t *testing.T, path string) {
 	t.Helper()
 	ls, err := os.ReadDir(path)
 	assert.NilError(t, err)
-	assert.Check(t, cmp.Len(ls, 0), "directory should be free of temp files")
+	assert.Check(t, is.Len(ls, 0), "directory should be free of temp files")
 }
 
 func copyTransform(f func(string) string) func(dst io.WriteSeeker, src io.ReadSeeker) error {


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/43800#discussion_r929877771

Make sure we use the same alias everywhere for easier finding,
and to prevent accidentally introducing duplicate imports with
different aliases for the same package.


**- A picture of a cute animal (not mandatory but encouraged)**

