### PR TITLE
[20.10 backport] Fix file capabilities dropping in Dockerfile

### DIFF
--- a/daemon/graphdriver/copy/copy.go
+++ b/daemon/graphdriver/copy/copy.go
@@ -110,11 +110,13 @@ type dirMtimeInfo struct {
 	stat    *syscall.Stat_t
 }
 
-// DirCopy copies or hardlinks the contents of one directory to another,
-// properly handling xattrs, and soft links
+// DirCopy copies or hardlinks the contents of one directory to another, properly
+// handling soft links, "security.capability" and (optionally) "trusted.overlay.opaque"
+// xattrs.
 //
-// Copying xattrs can be opted out of by passing false for copyXattrs.
-func DirCopy(srcDir, dstDir string, copyMode Mode, copyXattrs bool) error {
+// The copyOpaqueXattrs controls if "trusted.overlay.opaque" xattrs are copied.
+// Passing false disables copying "trusted.overlay.opaque" xattrs.
+func DirCopy(srcDir, dstDir string, copyMode Mode, copyOpaqueXattrs bool) error {
 	copyWithFileRange := true
 	copyWithFileClone := true
 
@@ -207,7 +209,11 @@ func DirCopy(srcDir, dstDir string, copyMode Mode, copyXattrs bool) error {
 			return err
 		}
 
-		if copyXattrs {
+		if err := copyXattr(srcPath, dstPath, "security.capability"); err != nil {
+			return err
+		}
+
+		if copyOpaqueXattrs {
 			if err := doCopyXattrs(srcPath, dstPath); err != nil {
 				return err
 			}
@@ -256,10 +262,6 @@ func DirCopy(srcDir, dstDir string, copyMode Mode, copyXattrs bool) error {
 }
 
 func doCopyXattrs(srcPath, dstPath string) error {
-	if err := copyXattr(srcPath, dstPath, "security.capability"); err != nil {
-		return err
-	}
-
 	// We need to copy this attribute if it appears in an overlay upper layer, as
 	// this function is used to copy those. It is set by overlay if a directory
 	// is removed and then re-created and should not inherit anything from the


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/42934
- fixes https://github.com/moby/moby/issues/42655


doCopyXattrs() never reached due to copyXattrs boolean being false, as
a result file capabilities not being copied.

moved copyXattr() out of doCopyXattrs()

(cherry picked from commit 31f654a704f61768828d5950a13f30bb493d1239)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fixed issue of file capabilities dropping when moving to next command in Dockerfile during image building.



**- A picture of a cute animal (not mandatory but encouraged)**
