### PR TITLE
info: add Features field to show feature-configuration

### DIFF
--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -97,6 +97,9 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 	if versions.GreaterThanOrEqualTo(version, "1.42") {
 		info.KernelMemory = false
 	}
+	if versions.LessThan(version, "1.43") {
+		info.Features = nil
+	}
 	return httputils.WriteJSON(w, http.StatusOK, info)
 }
 

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4848,6 +4848,20 @@ definitions:
         example: "/var/lib/docker"
       Plugins:
         $ref: "#/definitions/PluginsInfo"
+      Features:
+        description: |
+          Features contains the list of features indicating what features are
+          enabled or disabled in the daemon configuration. The field contains
+          a list of strings, formatted as `<feature-name>=<enabled|disabled>`.
+          
+          If a certain feature doesn't appear in this list then it's unset
+          (i.e. neither true nor false).
+        type: "array"
+        items:
+          type: "string"
+        example:
+          - "containerd-snapshotter=enabled"
+          - "other-feature=disabled"
       MemoryLimit:
         description: "Indicates if the host has memory limit support enabled."
         type: "boolean"

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -248,16 +248,23 @@ type Commit struct {
 // Info contains response of Engine API:
 // GET "/info"
 type Info struct {
-	ID                 string
-	Containers         int
-	ContainersRunning  int
-	ContainersPaused   int
-	ContainersStopped  int
-	Images             int
-	Driver             string
-	DriverStatus       [][2]string
-	SystemStatus       [][2]string `json:",omitempty"` // SystemStatus is only propagated by the Swarm standalone API
-	Plugins            PluginsInfo
+	ID                string
+	Containers        int
+	ContainersRunning int
+	ContainersPaused  int
+	ContainersStopped int
+	Images            int
+	Driver            string
+	DriverStatus      [][2]string
+	SystemStatus      [][2]string `json:",omitempty"` // SystemStatus is only propagated by the Swarm standalone API
+	Plugins           PluginsInfo
+	// Features contains the list of features indicating what features are
+	// enabled or disabled in the daemon configuration. The field contains
+	// a list of strings, formatted as `<feature-name>=<enabled|disabled>`.
+	//
+	// If a certain feature doesn't appear in this list then it's unset
+	// (i.e. neither true nor false).
+	Features           []string `json:"Features,omitempty"`
 	MemoryLimit        bool
 	SwapLimit          bool
 	KernelMemory       bool `json:",omitempty"` // Deprecated: kernel 5.4 deprecated kmem.limit_in_bytes

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -62,6 +63,7 @@ func (daemon *Daemon) SystemInfo() *types.Info {
 	}
 
 	daemon.fillContainerStates(v)
+	daemon.fillFeaturesInfo(v)
 	daemon.fillDebugInfo(v)
 	daemon.fillAPIInfo(v)
 	// Retrieve platform specific info
@@ -195,6 +197,22 @@ func (daemon *Daemon) fillDebugInfo(v *types.Info) {
 	v.NFd = fileutils.GetTotalUsedFds()
 	v.NGoroutines = runtime.NumGoroutine()
 	v.NEventsListener = daemon.EventsService.SubscribersCount()
+}
+
+// fillFeaturesInfo propagates the Features list with features that have been
+// enabled.
+func (daemon *Daemon) fillFeaturesInfo(v *types.Info) {
+	for feature, enabled := range daemon.configStore.Features {
+		if v.Features == nil {
+			v.Features = []string{}
+		}
+		if enabled {
+			v.Features = append(v.Features, feature+"=enabled")
+		} else {
+			v.Features = append(v.Features, feature+"=disabled")
+		}
+	}
+	sort.Strings(v.Features)
 }
 
 func (daemon *Daemon) fillAPIInfo(v *types.Info) {

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -17,7 +17,8 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.43](https://docs.docker.com/engine/api/v1.43/) documentation
 
-* TODO add API changes for v1.43 here when they arrive.
+* `GET /info` now includes a `Features` property, containing a list of features
+  that have been enabled or disabled in the daemon configuration.
 
 ## v1.42 API changes
 


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/43735
- relates to https://github.com/rumpl/moby/pull/31

This adds a new Features field for API v1.43 and up, which contains the current
configuration of features that have been either enabled or disabled in the daemon
configuration.

With this patch:

```bash
mkdir -p /etc/docker
echo '{"features":{"containerd-snapshotter":true}}' > /etc/docker/daemon.json
dockerd &

curl -s  --unix-socket /var/run/docker.sock http://localhost/info | jq .Features
[
  "containerd-snapshotter=enabled"
]
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

