### PR TITLE
Support Zstandard archive compression

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -293,6 +293,13 @@ func CompressStream(dest io.Writer, compression Compression) (io.WriteCloser, er
 		// archive/bzip2 does not support writing, and there is no xz support at all
 		// However, this is not a problem as docker only currently generates gzipped tars
 		return nil, fmt.Errorf("Unsupported compression format %s", (&compression).Extension())
+	case Zstd:
+		zstdWriter, err := zstd.NewWriter(dest)
+		if err != nil {
+			return nil, err
+		}
+		writeBufWrapper := p.NewWriteCloserWrapper(buf, zstdWriter)
+		return writeBufWrapper, nil
 	default:
 		return nil, fmt.Errorf("Unsupported compression format %s", (&compression).Extension())
 	}

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -747,6 +747,7 @@ func TestTarUntar(t *testing.T) {
 	for _, c := range []Compression{
 		Uncompressed,
 		Gzip,
+		Zstd,
 	} {
 		changes, err := tarUntar(t, origin, &TarOptions{
 			Compression:     c,


### PR DESCRIPTION
**- What I did**

Added a `Zstd` case in `CompressStream`.

**- How I did it**

I used `zstd.Encoder` (similarly to how `zstd.Decoder` is used in `DecompressStream`).

**- How to verify it**

`TestTarUntar` tests Zstandard archive compression/decompression.

**- Description for the changelog**