### PR TITLE
api: swagger: add missing "force" query arg on plugin disable

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -9737,6 +9737,12 @@ paths:
             default if omitted.
           required: true
           type: "string"
+        - name: "force"
+          in: "query"
+          description: |
+            Force disable a plugin even if still in use.
+          required: false
+          type: "boolean"
       tags: ["Plugin"]
   /plugins/{name}/upgrade:
     post:


### PR DESCRIPTION
This has been around for a long time - since v17.04 (API v1.28)
but was never documented.

It allows removing a plugin even if it's still in use.

Q for maintainers: what branches should I cherry-pick this back to?

Internal ticket: [ENGDOCS-876](https://docker.atlassian.net/browse/ENGDOCS-876)