### PR TITLE
api: swagger: fix invalid example value (API v1.39-v1.41)

### DIFF
--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -8228,7 +8228,7 @@ paths:
               BuildCache:
                 -
                   ID: "hw53o5aio51xtltp5xjp8v7fx"
-                  Parent: """
+                  Parent: ""
                   Type: "regular"
                   Description: "pulled from docker.io/library/debian@sha256:234cb88d3020898631af0ccbbcca9a66ae7306ecd30c9720690858c1b007d2a0"
                   InUse: false

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -8559,7 +8559,7 @@ paths:
               BuildCache:
                 -
                   ID: "hw53o5aio51xtltp5xjp8v7fx"
-                  Parent: """
+                  Parent: ""
                   Type: "regular"
                   Description: "pulled from docker.io/library/debian@sha256:234cb88d3020898631af0ccbbcca9a66ae7306ecd30c9720690858c1b007d2a0"
                   InUse: false

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -8772,7 +8772,7 @@ paths:
               BuildCache:
                 -
                   ID: "hw53o5aio51xtltp5xjp8v7fx"
-                  Parent: """
+                  Parent: ""
                   Type: "regular"
                   Description: "pulled from docker.io/library/debian@sha256:234cb88d3020898631af0ccbbcca9a66ae7306ecd30c9720690858c1b007d2a0"
                   InUse: false


### PR DESCRIPTION
This was introduced in 43956c1bfc7abc5eb06b59fe7f6a6b37e5062fc1 (https://github.com/moby/moby/pull/43631)


**- A picture of a cute animal (not mandatory but encouraged)**

