### PR TITLE
[20.10 backport] update containerd binary to v1.6.7, runc to v1.3.1

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.6.6}"
+: "${CONTAINERD_VERSION:=v1.6.7}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.conf accordingly
-: "${RUNC_VERSION:=v1.1.2}"
+: "${RUNC_VERSION:=v1.1.3}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"


### PR DESCRIPTION
backport of:

- https://github.com/moby/moby/pull/43708
- https://github.com/moby/moby/pull/43917