### PR TITLE
add PID file to the docker.service

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -10,7 +10,8 @@ Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+# explicitly set the PID file path to be aligned with PIDFile option in this file 
+ExecStart=/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock --pidfile /var/run/docker.pid
 ExecReload=/bin/kill -s HUP $MAINPID
 TimeoutStartSec=0
 RestartSec=2
@@ -25,6 +26,9 @@ StartLimitBurst=3
 # Both the old, and new name are accepted by systemd 230 and up, so using the old name to make
 # this option work for either version of systemd.
 StartLimitInterval=60s
+
+# Ensure to cleanup pid file when the daemon stops
+PIDFile=/var/run/docker.pid
 
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Add PID file to the docker.service.

**- How I did it**
```
# systemctl daemon-reload
# systemctl stop docker
# echo "1" > /var/run/docker.pid
# systemctl start docker
Job for docker.service failed because the control process exited with error code.
See "systemctl status docker.service" and "journalctl -xe" for details.
```

https://github.com/moby/moby/blob/master/pkg/pidfile/pidfile.go#L35

**- How to verify it**
Manually verified the systemd service start, stop and restart.


**- Description for the changelog**
add PID file to the docker.service

**- A picture of a cute animal (not mandatory but encouraged)**

