### PR TITLE
fix(volume_xfs): recreating a volume with quota skips project id assignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ thumbs.db
 
 # local repository customization
 .envrc
+# a .bashrc may be added to customize the build environment
 .bashrc
 .editorconfig
 

--- a/quota/projectquota.go
+++ b/quota/projectquota.go
@@ -319,6 +319,12 @@ func setProjectID(targetPath string, projectID uint32) error {
 	return nil
 }
 
+func (q *Control) RemoveQuota(targetPath string) {
+	q.Lock()
+	delete(q.quotas, targetPath)
+	q.Unlock()
+}
+
 // findNextProjectID - find the next project id to be used for containers
 // by scanning driver home directory to find used project ids
 func (q *Control) findNextProjectID(home string, baseID uint32) error {

--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -220,8 +220,6 @@ func (r *Root) Remove(v volume.Volume) error {
 		return err
 	}
 
-	lv.quotaCtl.RemoveQuota(realPath)
-
 	delete(r.volumes, lv.name)
 	return removePath(lv.rootPath)
 }

--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -220,6 +220,8 @@ func (r *Root) Remove(v volume.Volume) error {
 		return err
 	}
 
+	lv.quotaCtl.RemoveQuota(realPath)
+
 	delete(r.volumes, lv.name)
 	return removePath(lv.rootPath)
 }


### PR DESCRIPTION
Signed-off-by: Debdut Chakraborty <debdutdeb@outlook.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Closes #43891 

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* Remove volume path from quota state if respective volume is being deleted


**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/76006232/183312172-4fef064f-79c7-45e7-a391-1e297cd24a2b.png)
