### PR TITLE
experiment: Increase timeout for TestRunContainerWithRmFlagCannotStartContainer

### DIFF
--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -509,16 +509,18 @@ func (s *DockerCLIExecSuite) TestExecUlimits(c *testing.T) {
 
 // #15750
 func (s *DockerCLIExecSuite) TestExecStartFails(c *testing.T) {
-	// TODO Windows CI. This test should be portable. Figure out why it fails
-	// currently.
-	testRequires(c, DaemonIsLinux)
 	name := "exec-15750"
 	runSleepingContainer(c, "-d", "--name", name)
 	assert.NilError(c, waitRun(name))
 
 	out, _, err := dockerCmdWithError("exec", name, "no-such-cmd")
 	assert.ErrorContains(c, err, "", out)
-	assert.Assert(c, strings.Contains(out, "executable file not found"))
+
+	expectedMsg := "executable file not found"
+	if runtime.GOOS == "windows" {
+		expectedMsg = "The system cannot find the file specified"
+	}
+	assert.Assert(c, is.Contains(out, expectedMsg))
 }
 
 // Fix regression in https://github.com/docker/docker/pull/26461#issuecomment-250287297

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2763,11 +2763,19 @@ func (s *DockerCLIRunSuite) TestRunContainerWithRmFlagExitCodeNotEqualToZero(c *
 
 func (s *DockerCLIRunSuite) TestRunContainerWithRmFlagCannotStartContainer(c *testing.T) {
 	name := "sparkles"
-	cli.Docker(cli.Args("run", "--name", name, "--rm", "busybox", "commandNotFound")).Assert(c, icmd.Expected{
-		ExitCode: 127,
-	})
 
-	poll.WaitOn(c, containerRemoved(name))
+	for i := 0; i < 250; i++ {
+		name := fmt.Sprintf("%s_%d", name, i)
+		c.Run(name, func(c *testing.T) {
+			c.Parallel()
+
+			cli.Docker(cli.Args("run", "--name", name, "--rm", "busybox", "commandNotFound")).Assert(c, icmd.Expected{
+				ExitCode: 127,
+			})
+
+			poll.WaitOn(c, containerRemoved(name))
+		})
+	}
 }
 
 func containerRemoved(name string) poll.Check {

--- a/integration-cli/test_vars_test.go
+++ b/integration-cli/test_vars_test.go
@@ -5,7 +5,7 @@ package main
 // The Windows busybox image does not have a `top` command.
 func sleepCommandForDaemonPlatform() []string {
 	if testEnv.OSType == "windows" {
-		return []string{"sleep", "240"}
+		return []string{"sleep", "600"}
 	}
 	return []string{"top"}
 }

--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -410,18 +410,11 @@ func (ctr *container) Start(_ context.Context, _ string, withStdin bool, attachS
 	// the output through logs. We also tell HCS to always create stdin,
 	// even if it's not used - it will be closed shortly. Stderr is only
 	// created if it we're not -t.
-	var (
-		createStdErrPipe bool
-	)
-	if ctr.ociSpec.Process != nil {
-		createStdErrPipe = !ctr.ociSpec.Process.Terminal
-	}
-
 	createProcessParms := &hcsshim.ProcessConfig{
 		WorkingDirectory: ctrSpec.Cwd,
 		CreateStdInPipe:  true,
 		CreateStdOutPipe: true,
-		CreateStdErrPipe: createStdErrPipe,
+		CreateStdErrPipe: !spec.Terminal,
 	}
 	if spec.Terminal {
 		createProcessParms.EmulateConsole = true

--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -415,6 +415,7 @@ func (ctr *container) Start(_ context.Context, _ string, withStdin bool, attachS
 		CreateStdInPipe:  true,
 		CreateStdOutPipe: true,
 		CreateStdErrPipe: !spec.Terminal,
+		User:             spec.User.Username,
 	}
 	if spec.Terminal {
 		createProcessParms.EmulateConsole = true
@@ -439,8 +440,6 @@ func (ctr *container) Start(_ context.Context, _ string, withStdin bool, attachS
 		createProcessParms.CommandLine = system.EscapeArgs(spec.Args)
 	}
 	logger.Debugf("start commandLine: %s", createProcessParms.CommandLine)
-
-	createProcessParms.User = spec.User.Username
 
 	// Start the command running in the container.
 	newProcess, err := ctr.hcsContainer.CreateProcess(createProcessParms)
@@ -572,6 +571,7 @@ func (t *task) Exec(ctx context.Context, processID string, spec *specs.Process, 
 		CreateStdInPipe:  true,
 		CreateStdOutPipe: true,
 		CreateStdErrPipe: !spec.Terminal,
+		User:             spec.User.Username,
 	}
 	if spec.Terminal {
 		createProcessParms.EmulateConsole = true
@@ -596,8 +596,6 @@ func (t *task) Exec(ctx context.Context, processID string, spec *specs.Process, 
 		createProcessParms.CommandLine = system.EscapeArgs(spec.Args)
 	}
 	logger.Debugf("exec commandLine: %s", createProcessParms.CommandLine)
-
-	createProcessParms.User = spec.User.Username
 
 	// Start the command running in the container.
 	newProcess, err := hcsContainer.CreateProcess(createProcessParms)

--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -433,8 +433,11 @@ func (ctr *container) Start(_ context.Context, _ string, withStdin bool, attachS
 	// Configure the environment for the process
 	createProcessParms.Environment = setupEnvironmentVariables(spec.Env)
 
-	// Configure the CommandLine/CommandArgs
-	setCommandLineAndArgs(ctr.ociSpec.Process, createProcessParms)
+	if spec.CommandLine != "" {
+		createProcessParms.CommandLine = spec.CommandLine
+	} else {
+		createProcessParms.CommandLine = system.EscapeArgs(spec.Args)
+	}
 	logger.Debugf("start commandLine: %s", createProcessParms.CommandLine)
 
 	createProcessParms.User = spec.User.Username
@@ -524,15 +527,6 @@ func (ctr *container) Task(context.Context) (libcontainerdtypes.Task, error) {
 	return ctr.task, nil
 }
 
-// setCommandLineAndArgs configures the HCS ProcessConfig based on an OCI process spec
-func setCommandLineAndArgs(process *specs.Process, createProcessParms *hcsshim.ProcessConfig) {
-	if process.CommandLine != "" {
-		createProcessParms.CommandLine = process.CommandLine
-	} else {
-		createProcessParms.CommandLine = system.EscapeArgs(process.Args)
-	}
-}
-
 func newIOFromProcess(newProcess hcsshim.Process, terminal bool) (*cio.DirectIO, error) {
 	stdin, stdout, stderr, err := newProcess.Stdio()
 	if err != nil {
@@ -596,8 +590,11 @@ func (t *task) Exec(ctx context.Context, processID string, spec *specs.Process, 
 	// Configure the environment for the process
 	createProcessParms.Environment = setupEnvironmentVariables(spec.Env)
 
-	// Configure the CommandLine/CommandArgs
-	setCommandLineAndArgs(spec, createProcessParms)
+	if spec.CommandLine != "" {
+		createProcessParms.CommandLine = spec.CommandLine
+	} else {
+		createProcessParms.CommandLine = system.EscapeArgs(spec.Args)
+	}
 	logger.Debugf("exec commandLine: %s", createProcessParms.CommandLine)
 
 	createProcessParms.User = spec.User.Username

--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -437,7 +437,7 @@ func (ctr *container) Start(_ context.Context, _ string, withStdin bool, attachS
 	setCommandLineAndArgs(ctr.ociSpec.Process, createProcessParms)
 	logger.Debugf("start commandLine: %s", createProcessParms.CommandLine)
 
-	createProcessParms.User = ctr.ociSpec.Process.User.Username
+	createProcessParms.User = spec.User.Username
 
 	// Start the command running in the container.
 	newProcess, err := ctr.hcsContainer.CreateProcess(createProcessParms)

--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -450,7 +450,7 @@ func (ctr *container) Start(_ context.Context, _ string, withStdin bool, attachS
 		logger.WithError(err).Error("CreateProcess() failed")
 		return nil, err
 	}
-
+	pid := newProcess.Pid()
 	defer func() {
 		if retErr != nil {
 			if err := newProcess.Kill(); err != nil {
@@ -472,7 +472,6 @@ func (ctr *container) Start(_ context.Context, _ string, withStdin bool, attachS
 		hcsProcess: newProcess,
 		waitCh:     make(chan struct{}),
 	}}
-	pid := t.Pid()
 	logger.WithField("pid", pid).Debug("init process started")
 
 	// Spin up a goroutine to notify the backend and clean up resources when
@@ -500,7 +499,7 @@ func (ctr *container) Start(_ context.Context, _ string, withStdin bool, attachS
 		ei := libcontainerdtypes.EventInfo{
 			ContainerID: ctr.id,
 			ProcessID:   t.id,
-			Pid:         pid,
+			Pid:         uint32(pid),
 		}
 		ctr.client.logger.WithFields(logrus.Fields{
 			"container":  ctr.id,

--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -431,7 +431,7 @@ func (ctr *container) Start(_ context.Context, _ string, withStdin bool, attachS
 	}
 
 	// Configure the environment for the process
-	createProcessParms.Environment = setupEnvironmentVariables(ctr.ociSpec.Process.Env)
+	createProcessParms.Environment = setupEnvironmentVariables(spec.Env)
 
 	// Configure the CommandLine/CommandArgs
 	setCommandLineAndArgs(ctr.ociSpec.Process, createProcessParms)


### PR DESCRIPTION
I couldn't reproduce the flakiness on my Windows machine, but noticed that the run command itself takes a very long time to start. Maybe the removal in such case can take a long time too.
Increase timeout for this test just to test if it makes any difference.


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

