### PR TITLE
daemon: remove some legacy fallbacks, and small refactor

### DIFF
--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -81,7 +81,6 @@ func (i *ImageService) Cleanup() error {
 // GraphDriverName returns the name of the graph drvier
 // moved from Daemon.GraphDriverName, used by:
 // - newContainer
-// - to report an error in Daemon.Mount(container)
 func (i *ImageService) GraphDriverName() string {
 	return ""
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -239,10 +239,6 @@ func (daemon *Daemon) restore() error {
 				log.WithError(err).Error("failed to load container")
 				return
 			}
-			if !system.IsOSSupported(c.OS) {
-				log.Errorf("failed to load container: %s (%q)", system.ErrNotSupportedOperatingSystem, c.OS)
-				return
-			}
 			// Ignore the container if it does not support the current driver being used by the graph
 			if (c.Driver == "" && daemon.graphDriver == "aufs") || c.Driver == daemon.graphDriver {
 				rwlayer, err := daemon.imageService.GetLayerByID(c.ID)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1273,8 +1273,8 @@ func (daemon *Daemon) Mount(container *container.Container) error {
 		// on non-Windows operating systems.
 		if runtime.GOOS != "windows" {
 			daemon.Unmount(container)
-			return fmt.Errorf("Error: driver %s is returning inconsistent paths for container %s ('%s' then '%s')",
-				daemon.imageService.GraphDriverName(), container.ID, container.BaseFS, dir)
+			return fmt.Errorf("driver %s is returning inconsistent paths for container %s ('%s' then '%s')",
+				container.Driver, container.ID, container.BaseFS, dir)
 		}
 	}
 	container.BaseFS = dir // TODO: combine these fields

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -175,7 +175,6 @@ func (i *ImageService) Cleanup() error {
 // GraphDriverName returns the name of the graph drvier
 // moved from Daemon.GraphDriverName, used by:
 // - newContainer
-// - to report an error in Daemon.Mount(container)
 func (i *ImageService) GraphDriverName() string {
 	return i.layerStore.DriverName()
 }


### PR DESCRIPTION
### daemon: restore(): remove platform-check (was used for LCOW)

This was added in https://github.com/moby/moby/commit/0cba7740d41369eee33b671f26276325580bc07b (https://github.com/moby/moby/pull/34859), as part of the LCOW implementation. LCOW support has been removed, so we can remove this check.

### daemon: restore(): remove fallback for legacy containers

The check was accounting for old containers that did not have a storage-driver set in their config, and was added in https://github.com/moby/moby/commit/4908d7f81db91f4a28be152ec0cacb0cf711b403 (https://github.com/moby/moby/pull/2609) for docker v0.7.0-rc6 - nearly 9 Years ago, so very likely nobody is still depending on this ;-)

### daemon: Mount(): use container's driver information for error-message

Use the information stored as part of the container for the error-message, instead of querying the current storage driver from the daemon.