### PR TITLE
pkg/idtools: remove deprecated NewIdentityMapping, UIDS() and GIDS()

### DIFF
--- a/pkg/idtools/idtools.go
+++ b/pkg/idtools/idtools.go
@@ -162,20 +162,6 @@ func (i IdentityMapping) Empty() bool {
 	return len(i.UIDMaps) == 0 && len(i.GIDMaps) == 0
 }
 
-// UIDs returns the mapping for UID.
-//
-// Deprecated: reference the UIDMaps field directly.
-func (i IdentityMapping) UIDs() []IDMap {
-	return i.UIDMaps
-}
-
-// GIDs returns the mapping for GID.
-//
-// Deprecated: reference the GIDMaps field directly.
-func (i IdentityMapping) GIDs() []IDMap {
-	return i.GIDMaps
-}
-
 func createIDMap(subidRanges ranges) []IDMap {
 	idMap := []IDMap{}
 

--- a/pkg/idtools/idtools_unix.go
+++ b/pkg/idtools/idtools_unix.go
@@ -237,19 +237,6 @@ func setPermissions(p string, mode os.FileMode, uid, gid int, stat *system.StatT
 	return os.Chown(p, uid, gid)
 }
 
-// NewIdentityMapping takes a requested username and
-// using the data from /etc/sub{uid,gid} ranges, creates the
-// proper uid and gid remapping ranges for that user/group pair
-//
-// Deprecated: Use LoadIdentityMapping.
-func NewIdentityMapping(name string) (*IdentityMapping, error) {
-	m, err := LoadIdentityMapping(name)
-	if err != nil {
-		return nil, err
-	}
-	return &m, err
-}
-
 // LoadIdentityMapping takes a requested username and
 // using the data from /etc/sub{uid,gid} ranges, creates the
 // proper uid and gid remapping ranges for that user/group pair


### PR DESCRIPTION
These were deprecated in 098a44c07f38a14147a57feffa31b551a47f3c73  (https://github.com/moby/moby/pull/43366, which is in the 22.06 branch, and no longer in use since e05f614267213c93bd941d8a8980a0265a2e4634 (https://github.com/moby/moby/pull/43922) so we can remove them from the master branch.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

