### PR TITLE
cmd/dockerd: fix some minor issues in Windows implementation

### DIFF
--- a/cmd/dockerd/daemon_windows.go
+++ b/cmd/dockerd/daemon_windows.go
@@ -24,7 +24,7 @@ func setDefaultUmask() error {
 }
 
 func getDaemonConfDir(root string) (string, error) {
-	return filepath.Join(root, `\config`), nil
+	return filepath.Join(root, "config"), nil
 }
 
 // preNotifyReady sends a message to the host when the API is active, but before the daemon is

--- a/cmd/dockerd/docker_windows.go
+++ b/cmd/dockerd/docker_windows.go
@@ -15,7 +15,7 @@ func runDaemon(opts *daemonOptions) error {
 	// register the service.
 	stop, runAsService, err := initService(daemonCli)
 	if err != nil {
-		logrus.Fatal(err)
+		return err
 	}
 
 	if stop {
@@ -24,7 +24,11 @@ func runDaemon(opts *daemonOptions) error {
 
 	// Windows specific settings as these are not defaulted.
 	if opts.configFile == "" {
-		opts.configFile = filepath.Join(opts.daemonConfig.Root, `config\daemon.json`)
+		configDir, err := getDaemonConfDir(opts.daemonConfig.Root)
+		if err != nil {
+			return err
+		}
+		opts.configFile = filepath.Join(configDir, "daemon.json")
 	}
 	if runAsService {
 		// If Windows SCM manages the service - no need for PID files


### PR DESCRIPTION
stumbled upon these by accident 😂  - I should probably also look at integrating some of these defaults into https://github.com/moby/moby/pull/43756, but decided to just open these separately, as that PR needs a bit more work.

-----

- properly use filepath.Join() for Windows paths
- use getDaemonConfDir() to get the path for storing daemon.json
- return error instead of logrus.Fatal(). The logrus.Fatal() was a left-over from when Cobra was not used, and appears to have been missed in commit fb83394714a9797f8ca5a08023a89560ce6c4aa3 (https://github.com/moby/moby/pull/25354), which did the conversion to Cobra.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

