### PR TITLE
libcontainerd/supervisor: refactoring and cleanup in preparation of custom containerd.toml

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -167,7 +167,7 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	waitForContainerDShutdown, err := cli.initContainerD(ctx)
+	waitForContainerDShutdown, err := cli.initContainerd(ctx)
 	if waitForContainerDShutdown != nil {
 		defer waitForContainerDShutdown(10 * time.Second)
 	}

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -589,13 +589,13 @@ func (cli *DaemonCli) getContainerdDaemonOpts() ([]supervisor.DaemonOpt, error) 
 		return nil, err
 	}
 
-	if cli.Config.Debug {
+	if cli.Debug {
 		opts = append(opts, supervisor.WithLogLevel("debug"))
-	} else if cli.Config.LogLevel != "" {
-		opts = append(opts, supervisor.WithLogLevel(cli.Config.LogLevel))
+	} else {
+		opts = append(opts, supervisor.WithLogLevel(cli.LogLevel))
 	}
 
-	if !cli.Config.CriContainerd {
+	if !cli.CriContainerd {
 		// CRI support in the managed daemon is currently opt-in.
 		//
 		// It's disabled by default, originally because it was listening on

--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -140,7 +140,7 @@ func (cli *DaemonCli) initContainerD(ctx context.Context) (func(time.Duration) e
 			return nil, errors.Wrap(err, "could not determine whether the system containerd is running")
 		}
 		if !ok {
-			logrus.Debug("Containerd not running, starting daemon managed containerd")
+			logrus.Info("containerd not running, starting managed containerd")
 			opts, err := cli.getContainerdDaemonOpts()
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to generate containerd options")
@@ -150,7 +150,6 @@ func (cli *DaemonCli) initContainerD(ctx context.Context) (func(time.Duration) e
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to start containerd")
 			}
-			logrus.Debug("Started daemon managed containerd")
 			cli.Config.ContainerdAddr = r.Address()
 
 			// Try to wait for containerd to shutdown

--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -62,6 +62,9 @@ func getDaemonConfDir(_ string) (string, error) {
 
 func (cli *DaemonCli) getPlatformContainerdDaemonOpts() ([]supervisor.DaemonOpt, error) {
 	opts := []supervisor.DaemonOpt{
+		// TODO(thaJeztah) change this to use /proc/self/oom_score_adj instead,
+		// which would allow us to set the correct score even if dockerd's score
+		// was set through other means (such as systemd or "manually").
 		supervisor.WithOOMScore(cli.Config.OOMScoreAdjust),
 	}
 

--- a/cmd/dockerd/daemon_windows.go
+++ b/cmd/dockerd/daemon_windows.go
@@ -93,8 +93,8 @@ func newCgroupParent(config *config.Config) string {
 	return ""
 }
 
-func (cli *DaemonCli) initContainerD(_ context.Context) (func(time.Duration) error, error) {
-	system.InitContainerdRuntime(cli.Config.ContainerdAddr)
+func (cli *DaemonCli) initContainerd(_ context.Context) (func(time.Duration) error, error) {
+	system.InitContainerdRuntime(cli.ContainerdAddr)
 	return nil, nil
 }
 

--- a/libcontainerd/supervisor/remote_daemon.go
+++ b/libcontainerd/supervisor/remote_daemon.go
@@ -39,7 +39,6 @@ type remote struct {
 	daemonStartCh chan error
 	daemonStopCh  chan struct{}
 
-	rootDir  string
 	stateDir string
 }
 
@@ -55,7 +54,6 @@ type DaemonOpt func(c *remote) error
 // Start starts a containerd daemon and monitors it
 func Start(ctx context.Context, rootDir, stateDir string, opts ...DaemonOpt) (Daemon, error) {
 	r := &remote{
-		rootDir:  rootDir,
 		stateDir: stateDir,
 		Config: config.Config{
 			Version: 2,

--- a/libcontainerd/supervisor/remote_daemon.go
+++ b/libcontainerd/supervisor/remote_daemon.go
@@ -48,6 +48,10 @@ type remote struct {
 
 	// oomScore adjusts the OOM score for the containerd process.
 	oomScore int
+
+	// logLevel overrides the containerd logging-level through the --log-level
+	// command-line option.
+	logLevel string
 }
 
 // Daemon represents a running containerd daemon
@@ -180,8 +184,8 @@ func (r *remote) startContainerd() error {
 
 	args := []string{"--config", configFile}
 
-	if r.Debug.Level != "" {
-		args = append(args, "--log-level", r.Debug.Level)
+	if r.logLevel != "" {
+		args = append(args, "--log-level", r.logLevel)
 	}
 
 	cmd := exec.Command(binaryName, args...)

--- a/libcontainerd/supervisor/remote_daemon.go
+++ b/libcontainerd/supervisor/remote_daemon.go
@@ -161,8 +161,7 @@ func (r *remote) startContainerd() error {
 
 	if pid != -1 {
 		r.daemonPid = pid
-		logrus.WithField("pid", pid).
-			Infof("libcontainerd: %s is still running", binaryName)
+		r.logger.WithField("pid", pid).Infof("%s is still running", binaryName)
 		return nil
 	}
 
@@ -210,8 +209,7 @@ func (r *remote) startContainerd() error {
 		return errors.Wrap(err, "libcontainerd: failed to save daemon pid to disk")
 	}
 
-	logrus.WithField("pid", r.daemonPid).
-		Infof("libcontainerd: started new %s process", binaryName)
+	r.logger.WithField("pid", r.daemonPid).Infof("started new %s process", binaryName)
 
 	return nil
 }
@@ -285,7 +283,7 @@ func (r *remote) monitorDaemon(ctx context.Context) {
 				delay = 100 * time.Millisecond
 				continue
 			}
-			logrus.WithField("address", r.GRPC.Address).Debug("Created containerd monitoring client")
+			r.logger.WithField("address", r.GRPC.Address).Debug("created containerd monitoring client")
 		}
 
 		if client != nil {

--- a/libcontainerd/supervisor/remote_daemon.go
+++ b/libcontainerd/supervisor/remote_daemon.go
@@ -225,7 +225,7 @@ func (r *remote) startContainerd() error {
 		return errors.Wrap(err, "libcontainerd: failed to save daemon pid to disk")
 	}
 
-	r.logger.WithField("pid", r.daemonPid).Infof("started new %s process", binaryName)
+	r.logger.WithField("pid", r.daemonPid).WithField("address", r.Address()).Infof("started new %s process", binaryName)
 
 	return nil
 }

--- a/libcontainerd/supervisor/remote_daemon.go
+++ b/libcontainerd/supervisor/remote_daemon.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/containerd/containerd"
@@ -31,7 +30,6 @@ const (
 )
 
 type remote struct {
-	sync.RWMutex
 	config.Config
 
 	daemonPid int

--- a/libcontainerd/supervisor/remote_daemon_linux.go
+++ b/libcontainerd/supervisor/remote_daemon_linux.go
@@ -55,5 +55,5 @@ func (r *remote) killDaemon() {
 }
 
 func (r *remote) platformCleanup() {
-	os.Remove(filepath.Join(r.stateDir, sockFile))
+	_ = os.Remove(r.Address())
 }

--- a/libcontainerd/supervisor/remote_daemon_options.go
+++ b/libcontainerd/supervisor/remote_daemon_options.go
@@ -1,10 +1,14 @@
 package supervisor // import "github.com/docker/docker/libcontainerd/supervisor"
 
-// WithLogLevel defines which log level to starts containerd with.
-// This only makes sense if WithStartDaemon() was set to true.
+// WithLogLevel defines which log level to start containerd with.
 func WithLogLevel(lvl string) DaemonOpt {
 	return func(r *remote) error {
-		r.Debug.Level = lvl
+		if lvl == "info" {
+			// both dockerd and containerd default log-level is "info",
+			// so don't pass the default.
+			lvl = ""
+		}
+		r.logLevel = lvl
 		return nil
 	}
 }

--- a/libcontainerd/supervisor/remote_daemon_options_linux.go
+++ b/libcontainerd/supervisor/remote_daemon_options_linux.go
@@ -3,7 +3,7 @@ package supervisor // import "github.com/docker/docker/libcontainerd/supervisor"
 // WithOOMScore defines the oom_score_adj to set for the containerd process.
 func WithOOMScore(score int) DaemonOpt {
 	return func(r *remote) error {
-		r.OOMScore = score
+		r.oomScore = score
 		return nil
 	}
 }


### PR DESCRIPTION
### libcontainerd/supervisor: remove unused RWMutex

This RWMutex was added in https://github.com/moby/moby/commit/9c4570a958df42d1ad19364b1a8da55b891d850a (https://github.com/moby/moby/pull/20662), and used in the `remote.Client()` method. Commit https://github.com/moby/moby/commit/dd2e19ebd58cd8896d79b4b8db61144b93717b33 (https://github.com/moby/moby/pull/37149) split the code for client and daemon, but did not remove the mutex.

### libcontainerd/supervisor: remove unused remote.rootDir

### libcontainerd/supervisor: platformCleanup(): use canonical socket address

Consider Address() (Config.GRPC.Addres) to be the source of truth for the location of the containerd socket.

### libcontainerd/supervisor: use correct logger

Don't call logrus directly, but use the logger that was set.

### libcontainerd/supervisor: make supervisor adjust OOM score for containerd

Containerd, like dockerd has a OOMScore configuration option to adjust its own OOM score. In dockerd, this option was added when default installations were not yet running the daemon as a systemd unit, which made it more complicated to set the score, and adding a daemon option was convenient.

A binary adjusting its own score has been frowned upon, as it's more logical to make that the responsibility of the process manager _starting_ the daemon, which is what we did for dockerd in 21578530d7291f2e7bc0b90ace2f058df753a443 (https://github.com/moby/moby/pull/42373).

There have been discussions on deprecating the daemon flag for dockerd, and similar discussions have been happening for containerd.

This patch changes how we set the OOM score for the containerd child process, and to have dockerd (supervisor) set the OOM score, as it's acting as process manager in this case (performing a role similar to systemd otherwise).

With this patch, the score is still adjusted as usual, but not written to the containerd configuration file;

    dockerd --oom-score-adjust=-123
    cat /proc/$(pidof containerd)/oom_score_adj
    -123

As a follow-up, we may consider to adjust the containerd OOM score based on the daemon's own score instead of on the `cli.OOMScoreAdjust` configuration so that we will also adjust the score in situations where dockerd's OOM score was set through other ways (systemd or manually adjusting the cgroup). A TODO was added for this.


### libcontainerd/supervisor: store location of pidFile

Adding a remote.pidFile to store the location instead of re-constructing its location each time. Also performing a small refactor to use `strconv.Itoa` instead of `fmt.Sprintf`.

### libcontainerd/supervisor: store location of config-file

Adding a remote.configFile to store the location instead of re-constructing its location each time. Also fixing a minor inconsistency in the error formats.

### libcontainerd/supervisor: don't write log-level to config file

The `--log-level` flag overrides whatever is in the containerd configuration file;
https://github.com/containerd/containerd/blob/f033f6ff85ce397202ee69de22b4e3a4bf4093f5/cmd/containerd/command/main.go#L339-L352

Given that we set that flag when we start the containerd binary, there is no need to write it both to the generated config-file and pass it as flag.

This patch also slightly changes the behavior; as both dockerd and containerd use "info" as default log-level, don't set the log-level if it's the default.

### cmd/dockerd: initContainerD(): clean-up some logs

Change the log-level for messages about starting the managed containerd instance to be the same as for the main API. And remove a redundant debug-log.

With this patch:

    dockerd
    INFO[2022-08-11T11:46:32.573299176Z] Starting up
    INFO[2022-08-11T11:46:32.574304409Z] containerd not running, starting managed containerd
    INFO[2022-08-11T11:46:32.575289181Z] started new containerd process                address=/var/run/docker/containerd/containerd.sock module=libcontainerd pid=5370

### cmd/dockerd: initContainerd() use early return

- return early if we're expecting a system-containerd
- rename `initContainerD` to `initContainerd` ':)
- remove .Config to reduce verbosity

**- A picture of a cute animal (not mandatory but encouraged)**
