### PR TITLE
libcontainerd/supervisor: add support for custom containerd.toml config

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -778,6 +778,7 @@ func (cli *DaemonCli) getContainerdDaemonOpts() ([]supervisor.DaemonOpt, error) 
 		opts = append(opts, supervisor.WithCRIDisabled())
 	}
 
+	opts = append(opts, supervisor.WithPlatformDefaults())
 	return opts, nil
 }
 

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -778,7 +778,7 @@ func (cli *DaemonCli) getContainerdDaemonOpts() ([]supervisor.DaemonOpt, error) 
 		opts = append(opts, supervisor.WithCRIDisabled())
 	}
 
-	opts = append(opts, supervisor.WithPlatformDefaults())
+	opts = append(opts, supervisor.WithPlatformDefaults(filepath.Join(cli.Root, "containerd")))
 	return opts, nil
 }
 

--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -138,7 +138,7 @@ func (cli *DaemonCli) initContainerd(ctx context.Context) (func(time.Duration) e
 		return nil, errors.Wrap(err, "failed to generate containerd options")
 	}
 
-	r, err := supervisor.Start(ctx, filepath.Join(cli.Root, "containerd"), filepath.Join(cli.ExecRoot, "containerd"), opts...)
+	r, err := supervisor.Start(ctx, filepath.Join(cli.ExecRoot, "containerd"), opts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start containerd")
 	}

--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -133,9 +133,36 @@ func (cli *DaemonCli) initContainerd(ctx context.Context) (func(time.Duration) e
 	}
 
 	log.G(ctx).Info("containerd not running, starting managed containerd")
-	opts, err := cli.getContainerdDaemonOpts()
+	var opts []supervisor.DaemonOpt
+
+	configFile, ok, err := getCustomConfigFile()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate containerd options")
+		return nil, err
+	}
+	if ok {
+		// detected a custom containerd.toml config file with an address.
+		log.G(ctx).Infof("using pre-existing containerd configuration file: %s", configFile)
+
+		opts = append(opts,
+			// We currently hard-code this to be relative to dockerd's exec-root
+			// (e.g., /var/run/docker/containerd.pid on linux). Unlike the managed
+			// config below, we don't use the "containerd" subdirectory so that
+			// we don't have to create this subdirectory.
+			supervisor.WithPIDFile(filepath.Join(cli.ExecRoot, supervisor.PIDFile)),
+			supervisor.WithCustomConfigFile(configFile),
+			supervisor.WithLogLevel(cli.LogLevel),
+		)
+		if cli.Debug {
+			opts = append(opts, supervisor.WithLogLevel("debug"))
+		}
+	} else {
+		// no existing configuration file found; set our own configuration.
+		// this configuration will be written to a temporary containerd.toml
+		// when the containerd instance is started.
+		opts, err = cli.getContainerdDaemonOpts()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to generate containerd options")
+		}
 	}
 
 	r, err := supervisor.Start(ctx, filepath.Join(cli.ExecRoot, "containerd"), opts...)
@@ -146,4 +173,30 @@ func (cli *DaemonCli) initContainerd(ctx context.Context) (func(time.Duration) e
 
 	// Try to wait for containerd to shutdown
 	return r.WaitTimeout, nil
+}
+
+// getCustomConfigFile checks if a custom containerd.toml configuration file is
+// present in the daemon's default config directory. If found, it checks if the
+// file is "valid" (contains an address for the containerd GRPC socket), and
+// otherwise returns an error.
+//
+// Note that the daemon allows setting a custom location for the config-file,
+// but not the config-directory. This means that with a custom "config-file",
+// the containerd.toml and daemon.json may be in different locations. We should
+// consider to either follow the same directory automatically, or to add a
+// "--config-dir" option on the daemon, possibly deprecating the "--config-file"
+// option.
+func getCustomConfigFile() (fileName string, found bool, err error) {
+	// TODO(thaJeztah) getDefaultDaemonConfigDir is not implemented / does not return a path on Windows
+	// TODO(thaJeztah) consider making the daemon config-directory configurable.
+	configDir, err := getDefaultDaemonConfigDir()
+	if err != nil {
+		return "", false, err
+	}
+	configFile := filepath.Join(configDir, supervisor.ConfigFile)
+	_, err = supervisor.LoadConfigFile(configFile)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return "", false, err
+	}
+	return configFile, err == nil, nil
 }

--- a/libcontainerd/supervisor/remote_daemon.go
+++ b/libcontainerd/supervisor/remote_daemon.go
@@ -90,7 +90,6 @@ func Start(ctx context.Context, rootDir, stateDir string, opts ...DaemonOpt) (Da
 			return nil, err
 		}
 	}
-	r.setDefaults()
 
 	if err := system.MkdirAll(stateDir, 0o700); err != nil {
 		return nil, err

--- a/libcontainerd/supervisor/remote_daemon.go
+++ b/libcontainerd/supervisor/remote_daemon.go
@@ -69,14 +69,9 @@ type Daemon interface {
 type DaemonOpt func(c *remote) error
 
 // Start starts a containerd daemon and monitors it
-func Start(ctx context.Context, rootDir, stateDir string, opts ...DaemonOpt) (Daemon, error) {
+func Start(ctx context.Context, stateDir string, opts ...DaemonOpt) (Daemon, error) {
 	r := &remote{
-		stateDir: stateDir,
-		Config: config.Config{
-			Version: 2,
-			Root:    filepath.Join(rootDir, "daemon"),
-			State:   filepath.Join(stateDir, "daemon"),
-		},
+		stateDir:      stateDir,
 		configFile:    filepath.Join(stateDir, configFile),
 		daemonPid:     -1,
 		pidFile:       filepath.Join(stateDir, pidFile),

--- a/libcontainerd/supervisor/remote_daemon.go
+++ b/libcontainerd/supervisor/remote_daemon.go
@@ -25,13 +25,16 @@ import (
 )
 
 const (
+	// PIDFile is the name of the PID file used when starting a managed
+	// containerd instance.
+	PIDFile = "containerd.pid"
+
 	maxConnectionRetryCount = 3
 	healthCheckTimeout      = 3 * time.Second
 	shutdownTimeout         = 15 * time.Second
 	startupTimeout          = 15 * time.Second
 	configFile              = "containerd.toml"
 	binaryName              = "containerd"
-	pidFile                 = "containerd.pid"
 )
 
 type remote struct {
@@ -74,7 +77,7 @@ func Start(ctx context.Context, stateDir string, opts ...DaemonOpt) (Daemon, err
 		stateDir:      stateDir,
 		configFile:    filepath.Join(stateDir, configFile),
 		daemonPid:     -1,
-		pidFile:       filepath.Join(stateDir, pidFile),
+		pidFile:       filepath.Join(stateDir, PIDFile),
 		logger:        log.G(ctx).WithField("module", "libcontainerd"),
 		daemonStartCh: make(chan error, 1),
 		daemonStopCh:  make(chan struct{}),

--- a/libcontainerd/supervisor/remote_daemon_linux.go
+++ b/libcontainerd/supervisor/remote_daemon_linux.go
@@ -2,33 +2,11 @@ package supervisor // import "github.com/docker/docker/libcontainerd/supervisor"
 
 import (
 	"os"
-	"path/filepath"
 	"syscall"
 	"time"
 
-	"github.com/containerd/containerd/defaults"
 	"github.com/docker/docker/pkg/process"
 )
-
-const (
-	sockFile      = "containerd.sock"
-	debugSockFile = "containerd-debug.sock"
-)
-
-func (r *remote) setDefaults() {
-	if r.GRPC.Address == "" {
-		r.GRPC.Address = filepath.Join(r.stateDir, sockFile)
-	}
-	if r.GRPC.MaxRecvMsgSize == 0 {
-		r.GRPC.MaxRecvMsgSize = defaults.DefaultMaxRecvMsgSize
-	}
-	if r.GRPC.MaxSendMsgSize == 0 {
-		r.GRPC.MaxSendMsgSize = defaults.DefaultMaxSendMsgSize
-	}
-	if r.Debug.Address == "" {
-		r.Debug.Address = filepath.Join(r.stateDir, debugSockFile)
-	}
-}
 
 func (r *remote) stopDaemon() {
 	// Ask the daemon to quit

--- a/libcontainerd/supervisor/remote_daemon_options.go
+++ b/libcontainerd/supervisor/remote_daemon_options.go
@@ -4,6 +4,21 @@ import (
 	"github.com/containerd/log"
 )
 
+// WithCustomConfigFile configures the supervisor to use a custom containerd.toml
+// configuration file instead of producing a generated config.
+func WithCustomConfigFile(fileName string) DaemonOpt {
+	return func(r *remote) error {
+		conf, err := LoadConfigFile(fileName)
+		if err != nil {
+			return err
+		}
+		r.Config = *conf
+		r.configFile = fileName
+		r.managedConfig = false
+		return nil
+	}
+}
+
 // WithLogLevel defines which log level to start containerd with.
 func WithLogLevel(lvl string) DaemonOpt {
 	return func(r *remote) error {

--- a/libcontainerd/supervisor/remote_daemon_options.go
+++ b/libcontainerd/supervisor/remote_daemon_options.go
@@ -33,3 +33,8 @@ func WithCRIDisabled() DaemonOpt {
 		return nil
 	}
 }
+
+// WithPlatformDefaults sets the default options for the platform.
+func WithPlatformDefaults() DaemonOpt {
+	return withPlatformDefaults()
+}

--- a/libcontainerd/supervisor/remote_daemon_options.go
+++ b/libcontainerd/supervisor/remote_daemon_options.go
@@ -35,6 +35,6 @@ func WithCRIDisabled() DaemonOpt {
 }
 
 // WithPlatformDefaults sets the default options for the platform.
-func WithPlatformDefaults() DaemonOpt {
-	return withPlatformDefaults()
+func WithPlatformDefaults(rootDir string) DaemonOpt {
+	return withPlatformDefaults(rootDir)
 }

--- a/libcontainerd/supervisor/remote_daemon_options.go
+++ b/libcontainerd/supervisor/remote_daemon_options.go
@@ -34,6 +34,15 @@ func WithCRIDisabled() DaemonOpt {
 	}
 }
 
+// WithPIDFile overrides the default location of the PID-file that's used by
+// the supervisor.
+func WithPIDFile(fileName string) DaemonOpt {
+	return func(r *remote) error {
+		r.pidFile = fileName
+		return nil
+	}
+}
+
 // WithPlatformDefaults sets the default options for the platform.
 func WithPlatformDefaults(rootDir string) DaemonOpt {
 	return withPlatformDefaults(rootDir)

--- a/libcontainerd/supervisor/remote_daemon_options_linux.go
+++ b/libcontainerd/supervisor/remote_daemon_options_linux.go
@@ -3,6 +3,7 @@ import (
 	"path/filepath"
 
 	"github.com/containerd/containerd/defaults"
+	"github.com/containerd/containerd/services/server/config"
 )
 
 const (
@@ -11,8 +12,13 @@ const (
 )
 
 // withPlatformDefaults sets the default options for the platform.
-func withPlatformDefaults() DaemonOpt {
+func withPlatformDefaults(rootDir string) DaemonOpt {
 	return func(r *remote) error {
+		r.Config = config.Config{
+			Version: 2,
+			Root:    filepath.Join(rootDir, "daemon"),
+			State:   filepath.Join(r.stateDir, "daemon"),
+		}
 		if r.GRPC.Address == "" {
 			r.GRPC.Address = filepath.Join(r.stateDir, sockFile)
 		}

--- a/libcontainerd/supervisor/remote_daemon_options_linux.go
+++ b/libcontainerd/supervisor/remote_daemon_options_linux.go
@@ -1,0 +1,30 @@
+package supervisor // import "github.com/docker/docker/libcontainerd/supervisor"
+import (
+	"path/filepath"
+
+	"github.com/containerd/containerd/defaults"
+)
+
+const (
+	sockFile      = "containerd.sock"
+	debugSockFile = "containerd-debug.sock"
+)
+
+// withPlatformDefaults sets the default options for the platform.
+func withPlatformDefaults() DaemonOpt {
+	return func(r *remote) error {
+		if r.GRPC.Address == "" {
+			r.GRPC.Address = filepath.Join(r.stateDir, sockFile)
+		}
+		if r.GRPC.MaxRecvMsgSize == 0 {
+			r.GRPC.MaxRecvMsgSize = defaults.DefaultMaxRecvMsgSize
+		}
+		if r.GRPC.MaxSendMsgSize == 0 {
+			r.GRPC.MaxSendMsgSize = defaults.DefaultMaxSendMsgSize
+		}
+		if r.Debug.Address == "" {
+			r.Debug.Address = filepath.Join(r.stateDir, debugSockFile)
+		}
+		return nil
+	}
+}

--- a/libcontainerd/supervisor/remote_daemon_options_linux.go
+++ b/libcontainerd/supervisor/remote_daemon_options_linux.go
@@ -14,6 +14,12 @@ const (
 // withPlatformDefaults sets the default options for the platform.
 func withPlatformDefaults(rootDir string) DaemonOpt {
 	return func(r *remote) error {
+		if r.managedConfig {
+			// custom configuration file is in use.
+			return nil
+		}
+		r.managedConfig = true
+		r.configFile = filepath.Join(r.stateDir, ConfigFile)
 		r.Config = config.Config{
 			Version: 2,
 			Root:    filepath.Join(rootDir, "daemon"),

--- a/libcontainerd/supervisor/remote_daemon_options_windows.go
+++ b/libcontainerd/supervisor/remote_daemon_options_windows.go
@@ -1,0 +1,27 @@
+package supervisor // import "github.com/docker/docker/libcontainerd/supervisor"
+
+import "github.com/containerd/containerd/defaults"
+
+const (
+	grpcPipeName  = `\\.\pipe\containerd-containerd`
+	debugPipeName = `\\.\pipe\containerd-debug`
+)
+
+// withPlatformDefaults sets the default options for the platform.
+func withPlatformDefaults() DaemonOpt {
+	return func(r *remote) error {
+		if r.GRPC.Address == "" {
+			r.GRPC.Address = grpcPipeName
+		}
+		if r.GRPC.MaxRecvMsgSize == 0 {
+			r.GRPC.MaxRecvMsgSize = defaults.DefaultMaxRecvMsgSize
+		}
+		if r.GRPC.MaxSendMsgSize == 0 {
+			r.GRPC.MaxSendMsgSize = defaults.DefaultMaxSendMsgSize
+		}
+		if r.Debug.Address == "" {
+			r.Debug.Address = debugPipeName
+		}
+		return nil
+	}
+}

--- a/libcontainerd/supervisor/remote_daemon_options_windows.go
+++ b/libcontainerd/supervisor/remote_daemon_options_windows.go
@@ -14,6 +14,12 @@ const (
 // withPlatformDefaults sets the default options for the platform.
 func withPlatformDefaults(rootDir string) DaemonOpt {
 	return func(r *remote) error {
+		if r.managedConfig {
+			// custom configuration file is in use.
+			return nil
+		}
+		r.managedConfig = true
+		r.configFile = filepath.Join(r.stateDir, ConfigFile)
 		r.Config = config.Config{
 			Version: 2,
 			Root:    filepath.Join(rootDir, "daemon"),

--- a/libcontainerd/supervisor/remote_daemon_options_windows.go
+++ b/libcontainerd/supervisor/remote_daemon_options_windows.go
@@ -1,6 +1,10 @@
 package supervisor // import "github.com/docker/docker/libcontainerd/supervisor"
+import (
+	"path/filepath"
 
-import "github.com/containerd/containerd/defaults"
+	"github.com/containerd/containerd/defaults"
+	"github.com/containerd/containerd/services/server/config"
+)
 
 const (
 	grpcPipeName  = `\\.\pipe\containerd-containerd`
@@ -8,8 +12,13 @@ const (
 )
 
 // withPlatformDefaults sets the default options for the platform.
-func withPlatformDefaults() DaemonOpt {
+func withPlatformDefaults(rootDir string) DaemonOpt {
 	return func(r *remote) error {
+		r.Config = config.Config{
+			Version: 2,
+			Root:    filepath.Join(rootDir, "daemon"),
+			State:   filepath.Join(r.stateDir, "daemon"),
+		}
 		if r.GRPC.Address == "" {
 			r.GRPC.Address = grpcPipeName
 		}

--- a/libcontainerd/supervisor/remote_daemon_windows.go
+++ b/libcontainerd/supervisor/remote_daemon_windows.go
@@ -3,29 +3,8 @@ package supervisor // import "github.com/docker/docker/libcontainerd/supervisor"
 import (
 	"os"
 
-	"github.com/containerd/containerd/defaults"
 	"github.com/docker/docker/pkg/process"
 )
-
-const (
-	grpcPipeName  = `\\.\pipe\containerd-containerd`
-	debugPipeName = `\\.\pipe\containerd-debug`
-)
-
-func (r *remote) setDefaults() {
-	if r.GRPC.Address == "" {
-		r.GRPC.Address = grpcPipeName
-	}
-	if r.GRPC.MaxRecvMsgSize == 0 {
-		r.GRPC.MaxRecvMsgSize = defaults.DefaultMaxRecvMsgSize
-	}
-	if r.GRPC.MaxSendMsgSize == 0 {
-		r.GRPC.MaxSendMsgSize = defaults.DefaultMaxSendMsgSize
-	}
-	if r.Debug.Address == "" {
-		r.Debug.Address = debugPipeName
-	}
-}
 
 func (r *remote) stopDaemon() {
 	p, err := os.FindProcess(r.daemonPid)

--- a/libcontainerd/supervisor/remote_daemon_windows.go
+++ b/libcontainerd/supervisor/remote_daemon_windows.go
@@ -3,6 +3,7 @@ package supervisor // import "github.com/docker/docker/libcontainerd/supervisor"
 import (
 	"os"
 
+	"github.com/containerd/containerd/defaults"
 	"github.com/docker/docker/pkg/process"
 )
 
@@ -14,6 +15,12 @@ const (
 func (r *remote) setDefaults() {
 	if r.GRPC.Address == "" {
 		r.GRPC.Address = grpcPipeName
+	}
+	if r.GRPC.MaxRecvMsgSize == 0 {
+		r.GRPC.MaxRecvMsgSize = defaults.DefaultMaxRecvMsgSize
+	}
+	if r.GRPC.MaxSendMsgSize == 0 {
+		r.GRPC.MaxSendMsgSize = defaults.DefaultMaxSendMsgSize
 	}
 	if r.Debug.Address == "" {
 		r.Debug.Address = debugPipeName


### PR DESCRIPTION
- follow-up to / depends on https://github.com/moby/moby/pull/43945 (only the last commit is new)


## Add support for custom containerd.toml config

When starting containerd as a child process of dockerd, we currently generate
a containerd.toml configuration file with the bare minimum of options we need;

- GRPC Socket address (/var/run/docker/containerd/containerd.sock)
- Root directory (/var/lib/docker/containerd/daemon)
- Exec State directory (/var/run/docker/containerd/daemon)
- Debug socket location (/var/run/docker/containerd/containerd-debug.sock)
- GRPC MaxRecvMsgSize, MaxSendMsgSize
- Disabled plugins (cri is disabled by default)
- OOMScore

While this is convenient, containerd provides many configuration options, which
cannot currently be configured through dockerd. Adding daemon options for all of
those options would be hard to maintain, and not something we want to implement.

This patch adds support for a user-provided containerd.toml configuration file
to use instead of the automatically generated configuration file. With this patch
the startup looks like this;

1. if `--containerd` is set, the daemon expects containerd to be a running
   service. No managed instance is started, and the daemon will attempt to
   connect to the given address.
2. The daemon will attempt to _detect_ if containerd is running as a service at
   `/run/containerd/containerd.sock`, or `$XDG_RUNTIME_DIR/containerd/containerd.sock`
   (when running in rootless mode).
3. The daemon checks if a `/etc/docker/containerd.toml` file is present and
   contains a GRPC Socket address. If so, it starts containerd with the given
   configuration file, and connects using the socket specified in it.
4. The daemon generates a containerd config file, and saves it in a temporary
   location; `/var/run/docker/containerd/containerd.toml` (default), or
   `$XDG_RUNTIME_DIR/containerd/containerd.toml` (rootless)

Notes/Caveats:
----------------------------------------

There's a couple of caveats worth mentioning;

- The daemon performs no validation of the configuration file, other than to
  verify that a GRPC address is present. It is up to the user to set the correct
  configuration options; including specifying the correct location when running
  dockerd in rootless mode.
- containerd's default configuration uses the same location for the socket as
  a containerd instance that's running as a (systemd) service. This can cause
  issues in some situations;
  - if the socket is not cleaned up when containerd exits, the daemon will fail
    to start, as it assumes containerd is already running as a service.
  - if dockerd is started _before_ a containerd service is started, the socket
    will conflict (potentially blocking the containerd service from being
    started).

We can consider producing a warning for the second case, or decide to refuse
the configuration (but that would likely be too restrictive).

How to test this feature
----------------------------------------

Create the `/etc/docker` configuration directory if it doesn't exist, and create
a valid `containerd.toml` file in it (the example below uses containerd's default
configuration);

```bash
mkdir -p /etc/docker
containerd config default > /etc/docker/containerd.toml
```

Start the daemon and verify that it picks up the configuration;

```
dockerd --debug

INFO[2022-08-10T15:30:42.266201214Z] Starting up
INFO[2022-08-10T15:30:42.267341643Z] containerd not running, starting managed containerd
INFO[2022-08-10T15:30:42.311542635Z] using pre-existing containerd configuration file: /etc/docker/containerd.toml
INFO[2022-08-10T15:30:42.313421457Z] libcontainerd: started new containerd process  pid=8542
INFO[2022-08-10T15:30:42.313501681Z] [core] original dial target is: "unix:///run/containerd/containerd.sock"  module=grpc
INFO[2022-08-10T15:30:42.313727993Z] [core] parsed dial target is: {Scheme:unix Authority: Endpoint:run/containerd/containerd.sock URL:{Scheme:unix Opaque: User: Host: Path:/run/containerd/containerd.sock RawPath: ForceQuery:false RawQuery: Fragment: RawFragment:}}  module=grpc
INFO[2022-08-10T15:30:42.313775044Z] [core] Channel authority set to "localhost"   module=grpc
INFO[2022-08-10T15:30:42.313851206Z] [core] ccResolverWrapper: sending update to cc: {[{/run/containerd/containerd.sock  0xc00003a3f0 <nil> 0 <nil>}] <nil> <nil>}  module=grpc
INFO[2022-08-10T15:30:42.313860948Z] [core] ClientConn switching balancer to "pick_first"  module=grpc
INFO[2022-08-10T15:30:42.313865563Z] [core] Channel switches to new LB policy "pick_first"  module=grpc
INFO[2022-08-10T15:30:42.313979933Z] [core] Subchannel Connectivity change to CONNECTING  module=grpc
INFO[2022-08-10T15:30:42.314101917Z] [core] Subchannel picks a new address "/run/containerd/containerd.sock" to connect  module=grpc
INFO[2022-08-10T15:30:42.314260534Z] [core] Channel Connectivity change to CONNECTING  module=grpc
INFO[2022-08-10T15:30:42.352557205Z] starting containerd                           revision=0197261a30bf81f1ee8e6a4dd2dea0ef95d67ccb version=v1.6.7
...
INFO[2022-08-10T15:30:43.358542169Z] API listen on /var/run/docker.sock
```

Once running, verify that containerd is started with the expected configuration
file and logging level (debug in this case);

```bash
ps auxf
...
root      1147  2.2  1.3 1422952 56236 pts/0   Sl+  16:08   0:00 dockerd --debug
root      1154  1.3  0.8 1407144 33952 ?       Ssl  16:08   0:00  \_ containerd --config /etc/docker/containerd.toml --log-level debug
```

Unlike docker's own configuration for a managed containerd instance, containerd's
default configuration uses `/var/lib/containerd` for data, and `/run/containerd/`
as runtime directory;

```bash
tree /var/lib/containerd
/var/lib/containerd
|-- io.containerd.content.v1.content
|   `-- ingest
|-- io.containerd.metadata.v1.bolt
|   `-- meta.db
|-- io.containerd.runtime.v1.linux
|-- io.containerd.runtime.v2.task
|   `-- moby
|       `-- f3061cb7133927a8bb43279a7e437cd895d210a6a73dff55d94ea358e735f153
|-- io.containerd.snapshotter.v1.btrfs
|-- io.containerd.snapshotter.v1.native
|   `-- snapshots
|-- io.containerd.snapshotter.v1.overlayfs
|   `-- snapshots
`-- tmpmounts

13 directories, 1 file
```

```bash
tree /run/containerd/
/run/containerd/
|-- containerd.sock
|-- containerd.sock.ttrpc
|-- io.containerd.runtime.v1.linux
|-- io.containerd.runtime.v2.task
|   `-- moby
|       `-- f3061cb7133927a8bb43279a7e437cd895d210a6a73dff55d94ea358e735f153
|           |-- address
|           |-- config.json
|           |-- init.pid
|           |-- log
|           |-- log.json
|           |-- options.json
|           |-- rootfs
|           |-- runtime
|           |-- shim-binary-path
|           `-- work -> /var/lib/containerd/io.containerd.runtime.v2.task/moby/f3061cb7133927a8bb43279a7e437cd895d210a6a73dff55d94ea358e735f153
`-- s
    `-- 77e1863a75ec4e750b1471bc638859398f17065e321e50b3a42ccef16bdc1a64

7 directories, 11 files
```




**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

