### PR TITLE
golangci-lint: enable nolintlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,7 @@ linters:
     - misspell                  # Detects commonly misspelled English words in comments.
     - nakedret                  # Detects uses of naked returns.
     - nilnesserr                # Detects returning nil errors. It combines the features of nilness and nilerr,
+    - nolintlint                # Reports ill-formed or insufficient nolint directives.
     - nosprintfhostport         # Detects misuse of Sprintf to construct a host with port in a URL.
     - reassign                  # Detects reassigning a top-level variable in another package.
     - revive                    # Metalinter; drop-in replacement for golint.


### PR DESCRIPTION
learned about this linter through https://github.com/docker/compose/pull/9738

This linter checks for redundant or incorrect "nolint" comments;
https://github.com/ashanbrown/nolintlint

**- A picture of a cute animal (not mandatory but encouraged)**

