### PR TITLE
Improve "List Images" API filter behaviour

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -7997,25 +7997,50 @@ paths:
         - name: "filters"
           in: "query"
           description: |
-            A JSON encoded value of the filters (a `map[string][]string`) to
-            process on the images list.
+            The criteria which images must match to be included in the list,
+            encoded as a JSON object of the form
+            ```json
+            {
+              "predicate1": {
+                "value1": true,
+                "value2": true,
+                ...
+              },
+              "predicate2": {
+                "value3": true,
+                "value4": true,
+                ...
+              },
+              ...
+            }
+            ```
+
+            For example:
+
+            ```json
+            {
+              "before": {"alpine:3.16": true},
+              "dangling": {"true": true},
+              "label": {"foo": true, "bar=baz": true},
+              "reference": {"alpine:3.*": true, "debian": true, "ubuntu@sha256:*7fff": true,
+            }
+            ```
 
             Available filters:
 
-            - `before`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
-            - `dangling=true`
-            - `label=key` or `label="key=value"` of an image label
-            - `reference`=(`<image-name>[:<tag>]`)
-            - `since`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
+            predicate   | values                                            | description
+            ------------|---------------------------------------------------|----------------------------------------------------------------
+            `before`    | `<repo>[:<tag>]`, `<image id>` or `<repo@digest>` | List only images which were created before the referenced image
+            `since`     | `<repo>[:<tag>]`, `<image id>` or `<repo@digest>` | List only images which were created after the referenced image
+            `dangling`  | `true` or `false`                                 | List only dangling images (images with no children and no tags) or exclude any dangling images, respectively
+            `label`     | `<key>` or `<key>=<value>`                        | List only images which have all of the given labels
+            `reference` | `<repo>[:<tag>]` or `<repo@digest>`               | List images which have any reference that matches any of the given patterns. [Go `path.Match`](https://pkg.go.dev/path#Match) syntax is supported.
+
           type: "string"
+          format: "json"
         - name: "shared-size"
           in: "query"
           description: "Compute and show shared size as a `SharedSize` field on each image."
-          type: "boolean"
-          default: false
-        - name: "digests"
-          in: "query"
-          description: "Show digest information as a `RepoDigests` field on each image."
           type: "boolean"
           default: false
       tags: ["Image"]

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8030,8 +8030,8 @@ paths:
 
             predicate   | values                                            | description
             ------------|---------------------------------------------------|----------------------------------------------------------------
-            `before`    | `<repo>[:<tag>]`, `<image id>` or `<repo@digest>` | List only images which were created before the referenced image
-            `since`     | `<repo>[:<tag>]`, `<image id>` or `<repo@digest>` | List only images which were created after the referenced image
+            `before`    | `<repo>[:<tag>]`, `<image id>` or `<repo@digest>` | List only images which were created before the oldest of the referenced images
+            `since`     | `<repo>[:<tag>]`, `<image id>` or `<repo@digest>` | List only images which were created after the newest of the referenced images
             `dangling`  | `true` or `false`                                 | List only dangling images (images with no children and no tags) or exclude any dangling images, respectively
             `label`     | `<key>` or `<key>=<value>`                        | List only images which have all of the given labels
             `reference` | `<repo>[:<tag>]` or `<repo@digest>`               | List images which have any reference that matches any of the given patterns. [Go `path.Match`](https://pkg.go.dev/path#Match) syntax is supported.

--- a/daemon/images/image_list.go
+++ b/daemon/images/image_list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
@@ -45,20 +46,36 @@ func (i *ImageService) Images(_ context.Context, opts types.ImageListOptions) ([
 	}
 
 	var (
-		beforeFilter, sinceFilter *image.Image
+		beforeFilter, sinceFilter time.Time
 		err                       error
 	)
 	err = opts.Filters.WalkValues("before", func(value string) error {
-		beforeFilter, err = i.GetImage(value, nil)
-		return err
+		img, err := i.GetImage(value, nil)
+		if err != nil {
+			return err
+		}
+		// Resolve multiple values to the oldest image,
+		// equivalent to ANDing all the values together.
+		if beforeFilter.IsZero() || beforeFilter.After(img.Created) {
+			beforeFilter = img.Created
+		}
+		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	err = opts.Filters.WalkValues("since", func(value string) error {
-		sinceFilter, err = i.GetImage(value, nil)
-		return err
+		img, err := i.GetImage(value, nil)
+		if err != nil {
+			return err
+		}
+		// Resolve multiple values to the newest image,
+		// equivalent to ANDing all the values together.
+		if sinceFilter.Before(img.Created) {
+			sinceFilter = img.Created
+		}
+		return nil
 	})
 	if err != nil {
 		return nil, err
@@ -77,16 +94,11 @@ func (i *ImageService) Images(_ context.Context, opts types.ImageListOptions) ([
 		allContainers []*container.Container
 	)
 	for id, img := range selectedImages {
-		if beforeFilter != nil {
-			if img.Created.Equal(beforeFilter.Created) || img.Created.After(beforeFilter.Created) {
-				continue
-			}
+		if !beforeFilter.IsZero() && !img.Created.Before(beforeFilter) {
+			continue
 		}
-
-		if sinceFilter != nil {
-			if img.Created.Equal(sinceFilter.Created) || img.Created.Before(sinceFilter.Created) {
-				continue
-			}
+		if !sinceFilter.IsZero() && !img.Created.After(sinceFilter) {
+			continue
 		}
 
 		if opts.Filters.Contains("label") {

--- a/integration/image/list_test.go
+++ b/integration/image/list_test.go
@@ -44,10 +44,10 @@ func TestImagesFilterMultiReference(t *testing.T) {
 	images, err := client.ImageList(ctx, options)
 	assert.NilError(t, err)
 
-	assert.Check(t, is.Equal(len(images[0].RepoTags), 3))
-	for _, repoTag := range images[0].RepoTags {
-		if repoTag != repoTags[0] && repoTag != repoTags[1] && repoTag != repoTags[2] {
-			t.Errorf("list images doesn't match any repoTag we expected, repoTag: %s", repoTag)
-		}
+	for _, img := range images {
+		t.Logf("Image ID = %v, RepoTags = %+v", img.ID, img.RepoTags)
+	}
+	for _, tag := range filter.Get("reference") {
+		assert.Check(t, is.Contains(images[0].RepoTags, tag))
 	}
 }


### PR DESCRIPTION
- Fixes #43830 
- Closes #43895 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Modified and codified the behaviour of the Image List API when the `filters` parameter is set. Now the API can be used to answer the question "given an image reference, what are all the other references which point to the same image?"

```console
$ docker image ls --digests alpine:latest
REPOSITORY          TAG                 DIGEST                                                                    IMAGE ID            CREATED             SIZE
alpine              3.16                sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad   9c6f07244728        29 hours ago        5.54MB
alpine              3.16.2              sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad   9c6f07244728        29 hours ago        5.54MB
alpine              latest              sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad   9c6f07244728        29 hours ago        5.54MB
$ docker image ls alpine@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
alpine              3.16                9c6f07244728        29 hours ago        5.54MB
alpine              3.16.2              9c6f07244728        29 hours ago        5.54MB
alpine              latest              9c6f07244728        29 hours ago        5.54MB
```

**- How I did it**
<img src="https://media3.giphy.com/media/13GIgrGdslD9oQ/giphy.gif?cid=ecf05e4769c43fdkvjlnotrgca2t9739bfuusn9mivbea6bd&rid=giphy.gif&ct=g">

**- How to verify it**
Test automation (TODO after design review)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- The "List Images" API no longer filters digests and tags from the returned image summaries when a `reference` filter predicate is specified. All known tag and digest references to an image are unconditionally returned in the summary for images which match the filter conditions.
- When multiple image references are listed as values for the `before` or `after` filter predicates, the "List Images" API will now consistently filter images by the oldest or newest referenced image, respectively.

**- A picture of a cute animal (not mandatory but encouraged)**

