### PR TITLE
[RFC] libcontainerd/supervisor: use containerd's defaults

### DIFF
--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -138,7 +138,7 @@ func (cli *DaemonCli) initContainerd(ctx context.Context) (func(time.Duration) e
 		return nil, errors.Wrap(err, "failed to generate containerd options")
 	}
 
-	r, err := supervisor.Start(ctx, filepath.Join(cli.Root, "containerd"), filepath.Join(cli.ExecRoot, "containerd"), opts...)
+	r, err := supervisor.Start(ctx, filepath.Join(cli.ExecRoot, "containerd"), opts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start containerd")
 	}

--- a/libcontainerd/supervisor/remote_daemon_linux.go
+++ b/libcontainerd/supervisor/remote_daemon_linux.go
@@ -2,33 +2,11 @@ package supervisor // import "github.com/docker/docker/libcontainerd/supervisor"
 
 import (
 	"os"
-	"path/filepath"
 	"syscall"
 	"time"
 
-	"github.com/containerd/containerd/defaults"
 	"github.com/docker/docker/pkg/process"
 )
-
-const (
-	sockFile      = "containerd.sock"
-	debugSockFile = "containerd-debug.sock"
-)
-
-func (r *remote) setDefaults() {
-	if r.GRPC.Address == "" {
-		r.GRPC.Address = filepath.Join(r.stateDir, sockFile)
-	}
-	if r.GRPC.MaxRecvMsgSize == 0 {
-		r.GRPC.MaxRecvMsgSize = defaults.DefaultMaxRecvMsgSize
-	}
-	if r.GRPC.MaxSendMsgSize == 0 {
-		r.GRPC.MaxSendMsgSize = defaults.DefaultMaxSendMsgSize
-	}
-	if r.Debug.Address == "" {
-		r.Debug.Address = filepath.Join(r.stateDir, debugSockFile)
-	}
-}
 
 func (r *remote) stopDaemon() {
 	// Ask the daemon to quit

--- a/libcontainerd/supervisor/remote_daemon_windows.go
+++ b/libcontainerd/supervisor/remote_daemon_windows.go
@@ -6,20 +6,6 @@ import (
 	"github.com/docker/docker/pkg/process"
 )
 
-const (
-	grpcPipeName  = `\\.\pipe\containerd-containerd`
-	debugPipeName = `\\.\pipe\containerd-debug`
-)
-
-func (r *remote) setDefaults() {
-	if r.GRPC.Address == "" {
-		r.GRPC.Address = grpcPipeName
-	}
-	if r.Debug.Address == "" {
-		r.Debug.Address = debugPipeName
-	}
-}
-
 func (r *remote) stopDaemon() {
 	p, err := os.FindProcess(r.daemonPid)
 	if err != nil {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/43946
- relates to https://github.com/moby/moby/pull/43945 (https://github.com/moby/moby/pull/43945#issuecomment-1211871117)

When starting a managed containerd instance, we currently configure the instance
to use alternative runtime and storage locations, and alternative paths for the
socket (for Windows, we used the same named pipes).

The reason for this was that we didn't want to conflict with an already running
containerd service when manually starting dockerd. As we currently only use
containerd as runtime (but not for image management), this works well, as all
(most) information in containerd is considered ephemeral, and we re-create
containers when starting the daemon.

However, with work being in progress on using containerd also for image management,
containerd's storage can no longer be considered ephemeral, and using the
alternative configuration will limit the ability to (temporarily) start
dockerd manually for debugging, i.e.;

```bash
systemctr stop containerd docker
dockerd --debug
```

When using containerd for image storage, the above will now start a containerd
instance with a different storage location as the one that was running as
(systemd) service, and does not contain the images and snapshots that are
expected.

This patch changes the managed containerd configuration to use most of containerd's
default settings, with the exception of the CRI plugin being disabled by default
on the managed instance (which can be enabled using the `--cri-containerd` flag).

The daemon will still detect if an instance of containerd is already running, so
that in situations where the `docker` service was stopped, but the `containerd`
service is still running, the already running `containerd` service to be used
(assuming it's using the default location).

To be discussed
-------------------------

This patch currently does not contain any migration code, so no content is migrated
from the "old" location to the new; as most (all?) data we add to containerd is
ephemeral (except for manifests we store?) we may not have to do any migration,
but we should look if anything is needed.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

