### PR TITLE
windows: libcontainer: prefer bundled containerd.exe

### DIFF
--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -305,7 +305,7 @@ jobs:
           }
       -
         name: Starting containerd
-        if: matrix.runtime == 'containerd'
+        if: matrix.runtime == 'containerd' && matrix.os == 'windows-2019'
         run: |
           Write-Host "Generating config"
           & "${{ env.BIN_OUT }}\containerd.exe" config default | Out-File "$env:TEMP\ctn.toml" -Encoding ascii
@@ -328,8 +328,12 @@ jobs:
         name: Starting test daemon
         run: |
           Write-Host "Creating service"
-          If ("${{ matrix.runtime }}" -eq "containerd") {
+          If ("${{ matrix.runtime }}" -eq "containerd" -and "${{ matrix.os }}" -eq "windows-2019") {
             $runtimeArg="--containerd=\\.\pipe\containerd-containerd"
+            echo "DOCKER_WINDOWS_CONTAINERD_RUNTIME=1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          }
+          If ("${{ matrix.runtime }}" -eq "containerd" -and "${{ matrix.os }}" -eq "windows-2022") {
+            $runtimeArg="--default-runtime=io.containerd.runhcs.v1"
             echo "DOCKER_WINDOWS_CONTAINERD_RUNTIME=1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           }
           New-Item -ItemType Directory "$env:TEMP\moby-root" -ErrorAction SilentlyContinue | Out-Null
@@ -364,6 +368,11 @@ jobs:
             Start-Sleep -Seconds 1
           }
           Write-Host "Test daemon started and replied!"
+          If ("${{ matrix.runtime }}" -eq "containerd") {
+            If (-not (Get-Process -Name containerd -ErrorAction:SilentlyContinue)) {
+              Throw "containerd process is not running"
+            }
+          }
         env:
           DOCKER_HOST: npipe:////./pipe/docker_engine
       -
@@ -428,14 +437,14 @@ jobs:
           DOCKER_HOST: npipe:////./pipe/docker_engine
       -
         name: Stop containerd
-        if: always() && matrix.runtime == 'containerd'
+        if: always() && matrix.runtime == 'containerd' && matrix.os == 'windows-2019'
         run: |
           $ErrorActionPreference = "SilentlyContinue"
           Stop-Service -Force -Name containerd
           $ErrorActionPreference = "Stop"
       -
         name: Containerd logs
-        if: always() && matrix.runtime == 'containerd'
+        if: always() && matrix.runtime == 'containerd' && matrix.os == 'windows-2019'
         run: |
           Copy-Item "$env:TEMP\ctn.log" -Destination ".\bundles\containerd.log"
           Get-Content "$env:TEMP\ctn.log" | Out-Host

--- a/cmd/dockerd/daemon_windows.go
+++ b/cmd/dockerd/daemon_windows.go
@@ -59,7 +59,14 @@ func notifyShutdown(err error) {
 }
 
 func (cli *DaemonCli) getPlatformContainerdDaemonOpts() ([]supervisor.DaemonOpt, error) {
-	return nil, nil
+	opts := []supervisor.DaemonOpt{
+		// On Windows, it first checks if a containerd binary is found in the same
+		// directory as the dockerd binary. If found, this binary takes precedence
+		// over containerd binaries installed in $PATH.
+		supervisor.WithDetectLocalBinary(),
+	}
+
+	return opts, nil
 }
 
 // setupConfigReloadTrap configures a Win32 event to reload the configuration.

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -63,11 +63,6 @@ const (
 	SeccompProfileUnconfined = "unconfined"
 )
 
-var builtinRuntimes = map[string]bool{
-	StockRuntimeName:   true,
-	LinuxV2RuntimeName: true,
-}
-
 // flatOptions contains configuration keys
 // that MUST NOT be parsed as deep structures.
 // Use this to differentiate these options

--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -31,6 +31,11 @@ const (
 	StockRuntimeName = "runc"
 )
 
+var builtinRuntimes = map[string]bool{
+	StockRuntimeName:   true,
+	LinuxV2RuntimeName: true,
+}
+
 // BridgeConfig stores all the bridge driver specific
 // configuration.
 type BridgeConfig struct {

--- a/daemon/config/config_windows.go
+++ b/daemon/config/config_windows.go
@@ -12,7 +12,15 @@ const (
 	// default value. On Windows keep this empty so the value is auto-detected
 	// based on other options.
 	StockRuntimeName = ""
+
+	WindowsV1RuntimeName = "com.docker.hcsshim.v1"
+	WindowsV2RuntimeName = "io.containerd.runhcs.v1"
 )
+
+var builtinRuntimes = map[string]bool{
+	WindowsV1RuntimeName: true,
+	WindowsV2RuntimeName: true,
+}
 
 // BridgeConfig stores all the bridge driver specific
 // configuration.

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -42,9 +42,6 @@ const (
 	windowsMaxCPUShares  = 10000
 	windowsMinCPUPercent = 1
 	windowsMaxCPUPercent = 100
-
-	windowsV1RuntimeName = "com.docker.hcsshim.v1"
-	windowsV2RuntimeName = "io.containerd.runhcs.v1"
 )
 
 // Windows containers are much larger than Linux containers and each of them
@@ -639,14 +636,14 @@ func (daemon *Daemon) initLibcontainerd(ctx context.Context) error {
 	rt := daemon.configStore.GetDefaultRuntimeName()
 	if rt == "" {
 		if daemon.configStore.ContainerdAddr == "" {
-			rt = windowsV1RuntimeName
+			rt = config.WindowsV1RuntimeName
 		} else {
-			rt = windowsV2RuntimeName
+			rt = config.WindowsV2RuntimeName
 		}
 	}
 
 	switch rt {
-	case windowsV1RuntimeName:
+	case config.WindowsV1RuntimeName:
 		daemon.containerd, err = local.NewClient(
 			ctx,
 			daemon.containerdCli,
@@ -654,7 +651,7 @@ func (daemon *Daemon) initLibcontainerd(ctx context.Context) error {
 			daemon.configStore.ContainerdNamespace,
 			daemon,
 		)
-	case windowsV2RuntimeName:
+	case config.WindowsV2RuntimeName:
 		if daemon.configStore.ContainerdAddr == "" {
 			return fmt.Errorf("cannot use the specified runtime %q without containerd", rt)
 		}

--- a/daemon/start_windows.go
+++ b/daemon/start_windows.go
@@ -3,13 +3,14 @@ package daemon // import "github.com/docker/docker/daemon"
 import (
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/pkg/system"
 )
 
 func (daemon *Daemon) getLibcontainerdCreateOptions(_ *container.Container) (string, interface{}, error) {
 	if system.ContainerdRuntimeSupported() {
 		opts := &options.Options{}
-		return "io.containerd.runhcs.v1", opts, nil
+		return config.WindowsV2RuntimeName, opts, nil
 	}
 	return "", nil, nil
 }

--- a/libcontainerd/supervisor/remote_daemon.go
+++ b/libcontainerd/supervisor/remote_daemon.go
@@ -36,9 +36,13 @@ type remote struct {
 	// file is saved.
 	configFile string
 
-	daemonPid int
-	pidFile   string
-	logger    *logrus.Entry
+	// daemonPath is the binary to execute, and can be either a basename (to use
+	// a binary installed in the system's $PATH), or the full path to the binary
+	// to use.
+	daemonPath string
+	daemonPid  int
+	pidFile    string
+	logger     *logrus.Entry
 
 	daemonWaitCh  chan struct{}
 	daemonStartCh chan error
@@ -73,6 +77,7 @@ func Start(ctx context.Context, rootDir, stateDir string, opts ...DaemonOpt) (Da
 			State:   filepath.Join(stateDir, "daemon"),
 		},
 		configFile:    filepath.Join(stateDir, configFile),
+		daemonPath:    binaryName,
 		daemonPid:     -1,
 		pidFile:       filepath.Join(stateDir, pidFile),
 		logger:        logrus.WithField("module", "libcontainerd"),
@@ -159,7 +164,8 @@ func (r *remote) startContainerd() error {
 		args = append(args, "--log-level", r.logLevel)
 	}
 
-	cmd := exec.Command(binaryName, args...)
+	r.logger.WithField("binary", r.daemonPath).Debug("starting containerd binary")
+	cmd := exec.Command(r.daemonPath, args...)
 	// redirect containerd logs to docker logs
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/libcontainerd/supervisor/remote_daemon.go
+++ b/libcontainerd/supervisor/remote_daemon.go
@@ -26,7 +26,6 @@ const (
 	shutdownTimeout         = 15 * time.Second
 	startupTimeout          = 15 * time.Second
 	configFile              = "containerd.toml"
-	binaryName              = "containerd"
 	pidFile                 = "containerd.pid"
 )
 

--- a/libcontainerd/supervisor/remote_daemon_linux.go
+++ b/libcontainerd/supervisor/remote_daemon_linux.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	binaryName    = "containerd"
 	sockFile      = "containerd.sock"
 	debugSockFile = "containerd-debug.sock"
 )

--- a/libcontainerd/supervisor/remote_daemon_options.go
+++ b/libcontainerd/supervisor/remote_daemon_options.go
@@ -1,4 +1,10 @@
 package supervisor // import "github.com/docker/docker/libcontainerd/supervisor"
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
 
 // WithLogLevel defines which log level to start containerd with.
 func WithLogLevel(lvl string) DaemonOpt {
@@ -17,6 +23,33 @@ func WithLogLevel(lvl string) DaemonOpt {
 func WithCRIDisabled() DaemonOpt {
 	return func(r *remote) error {
 		r.DisabledPlugins = append(r.DisabledPlugins, "io.containerd.grpc.v1.cri")
+		return nil
+	}
+}
+
+// WithDetectLocalBinary checks if a containerd binary is present in the same
+// directory as the dockerd binary, and overrides the path of the containerd
+// binary to start if found. If no binary is found, no changes are made.
+func WithDetectLocalBinary() DaemonOpt {
+	return func(r *remote) error {
+		dockerdPath, err := os.Executable()
+		if err != nil {
+			return errors.Wrap(err, "looking up binary path")
+		}
+
+		localBinary := filepath.Join(filepath.Dir(dockerdPath), binaryName)
+		fi, err := os.Stat(localBinary)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return err
+			}
+			return nil
+		}
+		if fi.IsDir() {
+			return errors.Errorf("local containerd path found (%s), but is a directory", localBinary)
+		}
+		r.daemonPath = localBinary
+		r.logger.WithError(err).WithField("binary", localBinary).Debug("failed to look up local containerd binary; using default binary")
 		return nil
 	}
 }

--- a/libcontainerd/supervisor/remote_daemon_windows.go
+++ b/libcontainerd/supervisor/remote_daemon_windows.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	grpcPipeName  = `\\.\pipe\containerd-containerd`
-	debugPipeName = `\\.\pipe\containerd-debug`
+	binaryName    = "containerd.exe"
+	grpcPipeName  = `\\.\pipe\docker-containerd`
+	debugPipeName = `\\.\pipe\docker-containerd-debug`
 )
 
 func (r *remote) setDefaults() {


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/43893

This removes the bit I commented on in https://github.com/moby/moby/pull/43893#discussion_r942865350

> I'm a bit on the fence on this part. I can see pros (install them together and be sure we're not running some other version), but also "cons"; as I wrote on [#43892 (comment)](https://github.com/moby/moby/issues/43892#issuecomment-1202321040), we're looking at decoupling the docker and containerd packages more, and perhaps we should consider to be flexible as well on "how" someone installed containerd (which could be through some other package).
> 
> TL;DR it's not a "yes" or "no", but perhaps it's good to move this part of the PR to a separate PR and discuss it separately (I _think_ this PR would still work without this change, so moving it separate would prevent it from being blocked pending that discussion)

-----

Prefer a containerd binary that's installed next to the dockerd
binary. This prevents running a containerd executable that was installed through
other means instead of the bundled one, in cases where the docker is installed
using the static binaries.

Also see this MicroSoft blog-post about this approach;
https://devblogs.microsoft.com/oldnewthing/20110620-00/?p=10393

This patch impements a WithDetectLocalBinary() DaemonOpt, which is set by
default on Windows (we can consider using the same on other platforms).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

