### PR TITLE
libcontainerd/remote: clean-up logs in client code

### DIFF
--- a/daemon/internal/libcontainerd/remote/client.go
+++ b/daemon/internal/libcontainerd/remote/client.go
@@ -614,14 +614,18 @@ func (c *client) processEventStream(ctx context.Context, ns string) {
 			if err != nil {
 				errStatus, ok := status.FromError(err)
 				if !ok || errStatus.Code() != codes.Canceled {
-					c.logger.WithError(err).Error("Failed to get event")
-					c.logger.Info("Waiting for containerd to be ready to restart event processing")
+					c.logger.WithError(err).Error("failed to get event")
+					c.logger.Info("waiting for containerd to be ready to restart event processing")
 					if c.waitServe(ctx) {
 						go c.processEventStream(ctx, ns)
 						return
 					}
 				}
-				c.logger.WithError(ctx.Err()).Info("stopping event stream following graceful shutdown")
+				if err := ctx.Err(); err != nil {
+					c.logger.WithError(err).Info("stopping event stream following graceful shutdown")
+				} else {
+					c.logger.Info("stopping event stream following graceful shutdown")
+				}
 			}
 			return
 		case ev := <-eventStream:


### PR DESCRIPTION
This one was bothering me for some time, as it was unconditionally setting the "WithError()", it would log `error="<nil>"` in many cases;

    time="2021-05-05T13:22:48.940144505Z" level=info msg="stopping event stream following graceful shutdown" error="<nil>" module=libcontainerd namespace=d4e2b9702b8e7

While at it, also changing other logs to be lowercase for consistency.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

