### PR TITLE
daemon: use initialized config struct in more tests

### DIFF
--- a/cmd/dockerd/daemon_test.go
+++ b/cmd/dockerd/daemon_test.go
@@ -12,12 +12,13 @@ import (
 )
 
 func defaultOptions(t *testing.T, configFile string) *daemonOptions {
-	opts := newDaemonOptions(&config.Config{})
+	cfg, err := config.New()
+	assert.NilError(t, err)
+	opts := newDaemonOptions(cfg)
 	opts.flags = &pflag.FlagSet{}
 	opts.installFlags(opts.flags)
-	if err := installConfigFlags(opts.daemonConfig, opts.flags); err != nil {
-		t.Fatal(err)
-	}
+	err = installConfigFlags(opts.daemonConfig, opts.flags)
+	assert.NilError(t, err)
 	defaultDaemonConfigFile, err := getDefaultDaemonConfigFile()
 	assert.NilError(t, err)
 	opts.flags.StringVar(&opts.configFile, "config-file", defaultDaemonConfigFile, "")

--- a/daemon/config/config_linux_test.go
+++ b/daemon/config/config_linux_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/opts"
 	units "github.com/docker/go-units"
+	"github.com/imdario/mergo"
 	"github.com/spf13/pflag"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -112,7 +113,8 @@ func TestDaemonConfigurationMergeShmSize(t *testing.T) {
 	file := fs.NewFile(t, "docker-config", fs.WithContent(data))
 	defer file.Remove()
 
-	c := &Config{}
+	c, err := New()
+	assert.NilError(t, err)
 
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	shmSize := opts.MemBytes(DefaultShmSize)
@@ -156,7 +158,10 @@ func TestUnixValidateConfigurationErrors(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
-			err := Validate(tc.config)
+			cfg, err := New()
+			assert.NilError(t, err)
+			assert.Check(t, mergo.Merge(cfg, tc.config, mergo.WithOverride))
+			err = Validate(cfg)
 			assert.ErrorContains(t, err, tc.expectedErr)
 		})
 	}


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/43756
- extracting more bits from https://github.com/moby/moby/pull/43703


Makes sure that tests use a config struct that's more representative to how it's used in the code.