### PR TITLE
containerd-integration: prefer error over panic where possible

### DIFF
--- a/daemon/changes.go
+++ b/daemon/changes.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/archive"
 )
 
@@ -19,6 +20,9 @@ func (daemon *Daemon) ContainerChanges(name string) ([]archive.Change, error) {
 		return nil, errors.New("Windows does not support diff of a running container")
 	}
 
+	if daemon.UsesSnapshotter() {
+		return nil, errdefs.NotImplemented(errors.New("not implemented"))
+	}
 	container.Lock()
 	defer container.Unlock()
 	if container.RWLayer == nil {

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -2,12 +2,14 @@ package containerd
 
 import (
 	"context"
+	"errors"
 
 	imagetype "github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 )
 
 // GetImage returns an image corresponding to the image referred to by refOrID.
 func (i *ImageService) GetImage(ctx context.Context, refOrID string, options imagetype.GetImageOpts) (retImg *image.Image, retErr error) {
-	panic("not implemented")
+	return nil, errdefs.NotImplemented(errors.New("not implemented"))
 }

--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -2,21 +2,23 @@ package containerd
 
 import (
 	"context"
+	"errors"
 
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/builder"
+	"github.com/docker/docker/errdefs"
 )
 
 // GetImageAndReleasableLayer returns an image and releaseable layer for a
 // reference or ID. Every call to GetImageAndReleasableLayer MUST call
 // releasableLayer.Release() to prevent leaking of layers.
 func (i *ImageService) GetImageAndReleasableLayer(ctx context.Context, refOrID string, opts backend.GetImageAndLayerOptions) (builder.Image, builder.ROLayer, error) {
-	panic("not implemented")
+	return nil, nil, errdefs.NotImplemented(errors.New("not implemented"))
 }
 
 // CreateImage creates a new image by adding a config and ID to the image store.
 // This is similar to LoadImage() except that it receives JSON encoded bytes of
 // an image instead of a tar archive.
 func (i *ImageService) CreateImage(config []byte, parent string) (builder.Image, error) {
-	panic("not implemented")
+	return nil, errdefs.NotImplemented(errors.New("not implemented"))
 }

--- a/daemon/containerd/image_commit.go
+++ b/daemon/containerd/image_commit.go
@@ -1,13 +1,16 @@
 package containerd
 
 import (
+	"errors"
+
 	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 )
 
 // CommitImage creates a new image from a commit config.
 func (i *ImageService) CommitImage(c backend.CommitConfig) (image.ID, error) {
-	panic("not implemented")
+	return "", errdefs.NotImplemented(errors.New("not implemented"))
 }
 
 // CommitBuildStep is used by the builder to create an image for each step in
@@ -20,5 +23,5 @@ func (i *ImageService) CommitImage(c backend.CommitConfig) (image.ID, error) {
 //
 // This is a temporary shim. Should be removed when builder stops using commit.
 func (i *ImageService) CommitBuildStep(c backend.CommitConfig) (image.ID, error) {
-	panic("not implemented")
+	return "", errdefs.NotImplemented(errors.New("not implemented"))
 }

--- a/daemon/containerd/image_history.go
+++ b/daemon/containerd/image_history.go
@@ -1,9 +1,14 @@
 package containerd
 
-import imagetype "github.com/docker/docker/api/types/image"
+import (
+	"errors"
+
+	imagetype "github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/errdefs"
+)
 
 // ImageHistory returns a slice of ImageHistory structures for the specified
 // image name by walking the image lineage.
 func (i *ImageService) ImageHistory(name string) ([]*imagetype.HistoryResponseItem, error) {
-	panic("not implemented")
+	return nil, errdefs.NotImplemented(errors.New("not implemented"))
 }

--- a/daemon/containerd/image_import.go
+++ b/daemon/containerd/image_import.go
@@ -1,8 +1,10 @@
 package containerd
 
 import (
+	"errors"
 	"io"
 
+	"github.com/docker/docker/errdefs"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -11,5 +13,5 @@ import (
 // written to outStream. Repository and tag names can optionally be given in
 // the repo and tag arguments, respectively.
 func (i *ImageService) ImportImage(src string, repository string, platform *specs.Platform, tag string, msg string, inConfig io.ReadCloser, outStream io.Writer, changes []string) error {
-	panic("not implemented")
+	return errdefs.NotImplemented(errors.New("not implemented"))
 }

--- a/daemon/containerd/image_prune.go
+++ b/daemon/containerd/image_prune.go
@@ -2,12 +2,14 @@ package containerd
 
 import (
 	"context"
+	"errors"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/errdefs"
 )
 
 // ImagesPrune removes unused images
 func (i *ImageService) ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*types.ImagesPruneReport, error) {
-	panic("not implemented")
+	return nil, errdefs.NotImplemented(errors.New("not implemented"))
 }

--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -2,6 +2,7 @@ package containerd
 
 import (
 	"context"
+	"errors"
 	"io"
 
 	"github.com/containerd/containerd"
@@ -50,5 +51,5 @@ func (i *ImageService) PullImage(ctx context.Context, image, tagOrDigest string,
 
 // GetRepository returns a repository from the registry.
 func (i *ImageService) GetRepository(ctx context.Context, ref reference.Named, authConfig *registry.AuthConfig) (distribution.Repository, error) {
-	panic("not implemented")
+	return nil, errdefs.NotImplemented(errors.New("not implemented"))
 }

--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -2,12 +2,14 @@ package containerd
 
 import (
 	"context"
+	"errors"
 	"io"
 
 	"github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/errdefs"
 )
 
 // PushImage initiates a push operation on the repository named localName.
 func (i *ImageService) PushImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error {
-	panic("not implemented")
+	return errdefs.NotImplemented(errors.New("not implemented"))
 }

--- a/daemon/containerd/image_search.go
+++ b/daemon/containerd/image_search.go
@@ -2,9 +2,11 @@ package containerd
 
 import (
 	"context"
+	"errors"
 
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/errdefs"
 )
 
 // SearchRegistryForImages queries the registry for images matching
@@ -13,5 +15,5 @@ import (
 // TODO: this could be implemented in a registry service instead of the image
 // service.
 func (i *ImageService) SearchRegistryForImages(ctx context.Context, searchFilters filters.Args, term string, limit int, authConfig *registry.AuthConfig, metaHeaders map[string][]string) (*registry.SearchResults, error) {
-	panic("not implemented")
+	return nil, errdefs.NotImplemented(errors.New("not implemented"))
 }

--- a/daemon/containerd/image_squash.go
+++ b/daemon/containerd/image_squash.go
@@ -1,5 +1,11 @@
 package containerd
 
+import (
+	"errors"
+
+	"github.com/docker/docker/errdefs"
+)
+
 // SquashImage creates a new image with the diff of the specified image and
 // the specified parent. This new image contains only the layers from its
 // parent + 1 extra layer which contains the diff of all the layers in between.
@@ -7,5 +13,5 @@ package containerd
 // image with the diff of all the specified image's layers merged into a new
 // layer that has no parents.
 func (i *ImageService) SquashImage(id, parent string) (string, error) {
-	panic("not implemented")
+	return "", errdefs.NotImplemented(errors.New("not implemented"))
 }

--- a/daemon/containerd/image_tag.go
+++ b/daemon/containerd/image_tag.go
@@ -1,17 +1,20 @@
 package containerd
 
 import (
+	"errors"
+
 	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 )
 
 // TagImage creates the tag specified by newTag, pointing to the image named
 // imageName (alternatively, imageName can also be an image ID).
 func (i *ImageService) TagImage(imageName, repository, tag string) (string, error) {
-	panic("not implemented")
+	return "", errdefs.NotImplemented(errors.New("not implemented"))
 }
 
 // TagImageWithReference adds the given reference to the image ID provided.
 func (i *ImageService) TagImageWithReference(imageID image.ID, newTag reference.Named) error {
-	panic("not implemented")
+	return errdefs.NotImplemented(errors.New("not implemented"))
 }

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -2,12 +2,14 @@ package containerd
 
 import (
 	"context"
+	"errors"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/plugin"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/images"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 )
@@ -53,13 +55,13 @@ func (i *ImageService) Children(id image.ID) []image.ID {
 // called from create.go
 // TODO: accept an opt struct instead of container?
 func (i *ImageService) CreateLayer(container *container.Container, initFunc layer.MountInit) (layer.RWLayer, error) {
-	panic("not implemented")
+	return nil, errdefs.NotImplemented(errdefs.NotImplemented(errors.New("not implemented")))
 }
 
 // GetLayerByID returns a layer by ID
 // called from daemon.go Daemon.restore(), and Daemon.containerExport().
 func (i *ImageService) GetLayerByID(cid string) (layer.RWLayer, error) {
-	panic("not implemented")
+	return nil, errdefs.NotImplemented(errors.New("not implemented"))
 }
 
 // LayerStoreStatus returns the status for each layer store
@@ -75,7 +77,7 @@ func (i *ImageService) LayerStoreStatus() [][2]string {
 // called from daemon.go Daemon.Shutdown(), and Daemon.Cleanup() (cleanup is actually continerCleanup)
 // TODO: needs to be refactored to Unmount (see callers), or removed and replaced with GetLayerByID
 func (i *ImageService) GetLayerMountID(cid string) (string, error) {
-	panic("not implemented")
+	return "", errdefs.NotImplemented(errors.New("not implemented"))
 }
 
 // Cleanup resources before the process is shutdown.
@@ -93,18 +95,18 @@ func (i *ImageService) StorageDriver() string {
 // ReleaseLayer releases a layer allowing it to be removed
 // called from delete.go Daemon.cleanupContainer(), and Daemon.containerExport()
 func (i *ImageService) ReleaseLayer(rwlayer layer.RWLayer) error {
-	panic("not implemented")
+	return errdefs.NotImplemented(errors.New("not implemented"))
 }
 
 // LayerDiskUsage returns the number of bytes used by layer stores
 // called from disk_usage.go
 func (i *ImageService) LayerDiskUsage(ctx context.Context) (int64, error) {
-	panic("not implemented")
+	return 0, errdefs.NotImplemented(errors.New("not implemented"))
 }
 
 // ImageDiskUsage returns information about image data disk usage.
 func (i *ImageService) ImageDiskUsage(ctx context.Context) ([]*types.ImageSummary, error) {
-	panic("not implemented")
+	return nil, errdefs.NotImplemented(errors.New("not implemented"))
 }
 
 // UpdateConfig values
@@ -116,7 +118,7 @@ func (i *ImageService) UpdateConfig(maxDownloads, maxUploads int) {
 
 // GetLayerFolders returns the layer folders from an image RootFS.
 func (i *ImageService) GetLayerFolders(img *image.Image, rwLayer layer.RWLayer) ([]string, error) {
-	panic("not implemented")
+	return nil, errdefs.NotImplemented(errors.New("not implemented"))
 }
 
 // GetContainerLayerSize returns the real size & virtual size of the container.


### PR DESCRIPTION
- upstreaming (variant of) https://github.com/rumpl/moby/pull/53

- prefer error over panic where possible
- ContainerChanges is not implemented by snapshotter-based ImageService

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

