### PR TITLE
daemon: complete the "--graph" / "-g" deprecation

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -65,10 +65,9 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 
 	// Deprecated flags / options
 
-	// "--graph" is "soft-deprecated" in favor of "data-root". This flag was added
-	// before Docker 1.0, so won't be removed, only hidden, to discourage its usage.
-	flags.StringVarP(&conf.Root, "graph", "g", conf.Root, "Root of the Docker runtime")
-	_ = flags.MarkHidden("graph")
+	//nolint:staticcheck // TODO(thaJeztah): remove in next release.
+	flags.StringVarP(&conf.RootDeprecated, "graph", "g", conf.RootDeprecated, "Root of the Docker runtime")
+	_ = flags.MarkDeprecated("graph", "Use --data-root instead")
 	flags.BoolVarP(&conf.AutoRestart, "restart", "r", true, "--restart on the daemon has been deprecated in favor of --restart policies on docker run")
 	_ = flags.MarkDeprecated("restart", "Please use a restart policy on docker run")
 

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -397,9 +397,6 @@ func loadDaemonCliConfig(opts *daemonOptions) (*config.Config, error) {
 	conf.Hosts = opts.Hosts
 	conf.LogLevel = opts.LogLevel
 
-	if flags.Changed("graph") && flags.Changed("data-root") {
-		return nil, errors.New(`cannot specify both "--graph" and "--data-root" option`)
-	}
 	if flags.Changed(FlagTLS) {
 		conf.TLS = &opts.TLS
 	}
@@ -448,10 +445,6 @@ func loadDaemonCliConfig(opts *daemonOptions) (*config.Config, error) {
 
 	if err := config.Validate(conf); err != nil {
 		return nil, err
-	}
-
-	if flags.Changed("graph") {
-		logrus.Warnf(`The "-g / --graph" flag is deprecated. Please use "--data-root" instead`)
 	}
 
 	// Check if duplicate label-keys with different values are found

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -157,7 +157,7 @@ type CommonConfig struct {
 	NetworkDiagnosticPort int                       `json:"network-diagnostic-port,omitempty"`
 	Pidfile               string                    `json:"pidfile,omitempty"`
 	RawLogs               bool                      `json:"raw-logs,omitempty"`
-	RootDeprecated        string                    `json:"graph,omitempty"`
+	RootDeprecated        string                    `json:"graph,omitempty"` // Deprecated: use Root instead. TODO(thaJeztah): remove in next release.
 	Root                  string                    `json:"data-root,omitempty"`
 	ExecRoot              string                    `json:"exec-root,omitempty"`
 	SocketGroup           string                    `json:"group,omitempty"`
@@ -472,16 +472,6 @@ func getConflictFreeConfiguration(configFile string, flags *pflag.FlagSet) (*Con
 		return nil, err
 	}
 
-	if config.RootDeprecated != "" {
-		logrus.Warn(`The "graph" config file option is deprecated. Please use "data-root" instead.`)
-
-		if config.Root != "" {
-			return nil, errors.New(`cannot specify both "graph" and "data-root" config file options`)
-		}
-
-		config.Root = config.RootDeprecated
-	}
-
 	return &config, nil
 }
 
@@ -572,6 +562,11 @@ func findConfigurationConflicts(config map[string]interface{}, flags *pflag.Flag
 // such as config.DNS, config.Labels, config.DNSSearch,
 // as well as config.MaxConcurrentDownloads, config.MaxConcurrentUploads and config.MaxDownloadAttempts.
 func Validate(config *Config) error {
+	//nolint:staticcheck // TODO(thaJeztah): remove in next release.
+	if config.RootDeprecated != "" {
+		return errors.New(`the "graph" config file option is deprecated; use "data-root" instead`)
+	}
+
 	// validate log-level
 	if config.LogLevel != "" {
 		if _, err := logrus.ParseLevel(config.LogLevel); err != nil {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/28696
- related https://github.com/docker/cli/pull/3739


The `-g` / `--graph` options were soft deprecated in favor of `--data-root` in
261ef1fa27c4dfefa5f686b0a4ef354a43040e58 (https://github.com/moby/moby/pull/28696) (v17.05.0) and at the time considered
to not be removed https://github.com/moby/moby/pull/28696#issuecomment-268630617. However, with the move towards containerd snapshotters, having
these options around adds additional complexity to handle fallbacks for deprecated
(and hidden) flags, so completing the deprecation.

With this patch:

    dockerd --graph=/var/lib/docker --validate
    Flag --graph has been deprecated, Use --data-root instead
    unable to configure the Docker daemon with file /etc/docker/daemon.json: merged configuration validation from file and command line flags failed: the "graph" config file option is deprecated; use "data-root" instead

    mkdir -p /etc/docker
    echo '{"graph":"/var/lib/docker"}' > /etc/docker/daemon.json

    dockerd --validate
    unable to configure the Docker daemon with file /etc/docker/daemon.json: merged configuration validation from file and command line flags failed: the "graph" config file option is deprecated; use "data-root" instead

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

