### PR TITLE
ImageService: rename GraphDriverName to StorageDriver, remove daemon.graphdriver

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -154,7 +154,7 @@ func (daemon *Daemon) newContainer(name string, operatingSystem string, config *
 	base.ImageID = imgID
 	base.NetworkSettings = &network.Settings{IsAnonymousEndpoint: noExplicitName}
 	base.Name = name
-	base.Driver = daemon.imageService.GraphDriverName()
+	base.Driver = daemon.imageService.StorageDriver()
 	base.OS = operatingSystem
 	return base, err
 }

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -78,10 +78,9 @@ func (i *ImageService) Cleanup() error {
 	return nil
 }
 
-// GraphDriverName returns the name of the graph drvier
-// moved from Daemon.GraphDriverName, used by:
-// - newContainer
-func (i *ImageService) GraphDriverName() string {
+// StorageDriver returns the name of the default storage-driver (snapshotter)
+// used by the ImageService.
+func (i *ImageService) StorageDriver() string {
 	return ""
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -89,7 +89,6 @@ type Daemon struct {
 	sysInfo               *sysinfo.SysInfo
 	shutdown              bool
 	idMapping             idtools.IdentityMapping
-	graphDriver           string        // TODO: move graphDriver field to an InfoService
 	PluginStore           *plugin.Store // TODO: remove
 	pluginManager         *plugin.Manager
 	linkIndex             *linkIndex
@@ -239,7 +238,7 @@ func (daemon *Daemon) restore() error {
 				log.WithError(err).Error("failed to load container")
 				return
 			}
-			if c.Driver != daemon.graphDriver {
+			if c.Driver != daemon.imageService.StorageDriver() {
 				// Ignore the container if it wasn't created with the current storage-driver
 				log.Debugf("not restoring container because it was created with another storage driver (%s)", c.Driver)
 				return
@@ -834,18 +833,19 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		}
 	}
 
+	var graphDriver string
 	if isWindows {
 		// On Windows we don't support the environment variable, or a user supplied graphdriver
-		d.graphDriver = "windowsfilter"
+		graphDriver = "windowsfilter"
 	} else {
 		// Unix platforms however run a single graphdriver for all containers, and it can
 		// be set through an environment variable, a daemon start parameter, or chosen through
 		// initialization of the layerstore through driver priority order for example.
 		if drv := os.Getenv("DOCKER_DRIVER"); drv != "" {
-			d.graphDriver = drv
+			graphDriver = drv
 			logrus.Infof("Setting the storage driver from the $DOCKER_DRIVER environment variable (%s)", drv)
 		} else {
-			d.graphDriver = config.GraphDriver // May still be empty. Layerstore init determines instead.
+			graphDriver = config.GraphDriver // May still be empty. Layerstore init determines instead.
 		}
 	}
 
@@ -941,7 +941,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	layerStore, err := layer.NewStoreFromOptions(layer.StoreOptions{
 		Root:                      config.Root,
 		MetadataStorePathTemplate: filepath.Join(config.Root, "image", "%s", "layerdb"),
-		GraphDriver:               d.graphDriver,
+		GraphDriver:               graphDriver,
 		GraphDriverOptions:        config.GraphOptions,
 		IDMapping:                 idMapping,
 		PluginGetter:              d.PluginStore,
@@ -951,16 +951,13 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		return nil, err
 	}
 
-	// As layerstore initialization may set the driver
-	d.graphDriver = layerStore.DriverName()
-
 	// Configure and validate the kernels security support. Note this is a Linux/FreeBSD
 	// operation only, so it is safe to pass *just* the runtime OS graphdriver.
-	if err := configureKernelSecuritySupport(config, d.graphDriver); err != nil {
+	if err := configureKernelSecuritySupport(config, layerStore.DriverName()); err != nil {
 		return nil, err
 	}
 
-	imageRoot := filepath.Join(config.Root, "image", d.graphDriver)
+	imageRoot := filepath.Join(config.Root, "image", layerStore.DriverName())
 
 	d.volumes, err = volumesservice.NewVolumeService(config.Root, d.PluginStore, rootIDs, d)
 	if err != nil {
@@ -1125,7 +1122,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	logrus.WithFields(logrus.Fields{
 		"version":     dockerversion.Version,
 		"commit":      dockerversion.GitCommit,
-		"graphdriver": d.graphDriver,
+		"graphdriver": d.ImageService().StorageDriver(),
 	}).Info("Docker daemon")
 
 	return d, nil

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -72,6 +72,6 @@ type ImageService interface {
 	DistributionServices() images.DistributionServices
 	Children(id image.ID) []image.ID
 	Cleanup() error
-	GraphDriverName() string
+	StorageDriver() string
 	UpdateConfig(maxDownloads, maxUploads int)
 }

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -172,10 +172,8 @@ func (i *ImageService) Cleanup() error {
 	return nil
 }
 
-// GraphDriverName returns the name of the graph drvier
-// moved from Daemon.GraphDriverName, used by:
-// - newContainer
-func (i *ImageService) GraphDriverName() string {
+// StorageDriver returns the name of the storage driver used by the ImageService.
+func (i *ImageService) StorageDriver() string {
 	return i.layerStore.DriverName()
 }
 

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -120,17 +120,17 @@ func (daemon *Daemon) SystemVersion() types.Version {
 }
 
 func (daemon *Daemon) fillDriverInfo(v *types.Info) {
+	v.Driver = daemon.imageService.StorageDriver()
+	v.DriverStatus = daemon.imageService.LayerStoreStatus()
+
 	const warnMsg = `
 WARNING: The %s storage-driver is deprecated, and will be removed in a future release.
          Refer to the documentation for more information: https://docs.docker.com/go/storage-driver/`
 
-	switch daemon.graphDriver {
+	switch v.Driver {
 	case "aufs", "devicemapper", "overlay":
-		v.Warnings = append(v.Warnings, fmt.Sprintf(warnMsg, daemon.graphDriver))
+		v.Warnings = append(v.Warnings, fmt.Sprintf(warnMsg, v.Driver))
 	}
-
-	v.Driver = daemon.graphDriver
-	v.DriverStatus = daemon.imageService.LayerStoreStatus()
 
 	fillDriverWarnings(v)
 }


### PR DESCRIPTION
### ImageService: rename GraphDriverName to StorageDriver

Make the function name more generic, as it's no longer used only for graphdrivers but also for snapshotters.

### daemon: info: fillDriverInfo() get driver-name from ImageService

Make the ImageService the source of truth for the storage-driver that's used.

### daemon: remove daemon.graphdriver

It was only used as an intermediate variable to store what's returned
by layerstore.DriverName() / ImageService.StorageDriver()


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

