### PR TITLE
seccomp: allow "bpf", "perf_event_open", gated by CAP_BPF, CAP_PERFMON

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -790,6 +790,28 @@
 					"CAP_SYSLOG"
 				]
 			}
+		},
+		{
+			"names": [
+				"bpf"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"caps": [
+					"CAP_BPF"
+				]
+			}
+		},
+		{
+			"names": [
+				"perf_event_open"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"caps": [
+					"CAP_PERFMON"
+				]
+			}
 		}
 	]
 }

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -777,6 +777,28 @@ func DefaultProfile() *Seccomp {
 				Caps: []string{"CAP_SYSLOG"},
 			},
 		},
+		{
+			LinuxSyscall: specs.LinuxSyscall{
+				Names: []string{
+					"bpf",
+				},
+				Action: specs.ActAllow,
+			},
+			Includes: &Filter{
+				Caps: []string{"CAP_BPF"},
+			},
+		},
+		{
+			LinuxSyscall: specs.LinuxSyscall{
+				Names: []string{
+					"perf_event_open",
+				},
+				Action: specs.ActAllow,
+			},
+			Includes: &Filter{
+				Caps: []string{"CAP_PERFMON"},
+			},
+		},
 	}
 
 	errnoRet := uint(unix.EPERM)


### PR DESCRIPTION
Update the profile to make use of CAP_BPF and CAP_PERFMON capabilities. Prior to
kernel 5.8, bpf and perf_event_open required CAP_SYS_ADMIN. This change enables
finer control of the privilege setting, thus allowing us to run certain system
tracing tools with minimal privileges.

Based on the original patch from Henry Wang @henry118 in the containerd repository (https://github.com/containerd/containerd/pull/7301).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

