### PR TITLE
daemon: capture output of killed health checks

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -136,9 +136,16 @@ func (p *cmdProbe) run(ctx context.Context, d *Daemon, cntr *container.Container
 		// Wait for probe to exit (it might take some time to call containerd to kill
 		// the process and we don't want dying probes to pile up).
 		<-execErr
+
+		var msg string
+		if out := output.String(); len(out) > 0 {
+			msg = fmt.Sprintf("Health check exceeded timeout (%v): %s", probeTimeout, out)
+		} else {
+			msg = fmt.Sprintf("Health check exceeded timeout (%v)", probeTimeout)
+		}
 		return &types.HealthcheckResult{
 			ExitCode: -1,
-			Output:   fmt.Sprintf("Health check exceeded timeout (%v)", probeTimeout),
+			Output:   msg,
 			End:      time.Now(),
 		}, nil
 	case err := <-execErr:

--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -103,13 +103,13 @@ func TestHealthCheckProcessKilled(t *testing.T) {
 
 	cID := container.Run(ctx, t, apiClient, func(c *container.TestContainerConfig) {
 		c.Config.Healthcheck = &containertypes.HealthConfig{
-			Test:     []string{"CMD", "sh", "-c", "sleep 60"},
+			Test:     []string{"CMD", "sh", "-c", `echo "logs logs logs"; sleep 60`},
 			Interval: 100 * time.Millisecond,
 			Timeout:  50 * time.Millisecond,
 			Retries:  1,
 		}
 	})
-	poll.WaitOn(t, pollForHealthCheckLog(ctx, apiClient, cID, "Health check exceeded timeout (50ms)"))
+	poll.WaitOn(t, pollForHealthCheckLog(ctx, apiClient, cID, "Health check exceeded timeout (50ms): logs logs logs\n"))
 }
 
 func pollForHealthCheckLog(ctx context.Context, client client.APIClient, containerID string, expected string) func(log poll.LogT) poll.Result {


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/43739

Add an integration test to verify that health checks are killed on timeout and that the output is captured.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

