### PR TITLE
contrib: update Windows busybox to FRP-4716-g31467ddfc

### DIFF
--- a/contrib/busybox/Dockerfile
+++ b/contrib/busybox/Dockerfile
@@ -10,10 +10,10 @@
 # To publish: Needs someone with publishing rights
 ARG WINDOWS_BASE_IMAGE=mcr.microsoft.com/windows/servercore
 ARG WINDOWS_BASE_IMAGE_TAG=ltsc2019
-ARG BUSYBOX_VERSION=FRP-3329-gcf0fa4d13
+ARG BUSYBOX_VERSION=FRP-4716-g31467ddfc
 
 # Checksum taken from https://frippery.org/files/busybox/SHA256SUM
-ARG BUSYBOX_SHA256SUM=bfaeb88638e580fc522a68e69072e305308f9747563e51fa085eec60ca39a5ae
+ARG BUSYBOX_SHA256SUM=b4fd02bb938f97e59a0242da6a7763104d9cd344f96427af178940271b22ed5c
 
 FROM ${WINDOWS_BASE_IMAGE}:${WINDOWS_BASE_IMAGE_TAG}
 RUN mkdir C:\tmp && mkdir C:\bin


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/43739

Release notes, and some possible highlights, since last update of our Dockerfile:

- https://frippery.org/busybox/release-notes/FRP-4716.html
    - adds `jn` applet 
- https://frippery.org/busybox/release-notes/FRP-4621.html
- https://frippery.org/busybox/release-notes/FRP-4487.html
    - If the user tries to exit from an interactive shell when some background 
      Jobs are still running the shell will prevent them from doing so. Previously
      the shell would just hang because the console host refused to shut down while
      background jobs were still attached. Now the user has the option to terminate
      the background jobs from the command line or by other means.
    - BusyBox ash now supports the bash-like ERR trap. (As a reminder, in
      busybox-w32 the trap builtin accepts signal names but never handles them.
      It only handles ERR and EXIT traps.) 
- https://frippery.org/busybox/release-notes/FRP-4264.html
    - adds `sync` applet
- https://frippery.org/busybox/release-notes/FRP-3902.html
    - lists some improvements in ANSI escaping
    - adds `bc`, `nproc`, `free`, and `uptime` applets
- https://frippery.org/busybox/release-notes/FRP-3812.html
- https://frippery.org/busybox/release-notes/FRP-3578.html
    - The command busybox --install -u has been added to create links to applets
      in the four Unix-style binary directories listed above. However, this
      shouldn't normally be necessary.
- https://frippery.org/busybox/release-notes/FRP-3532.html
    - The ls command now treats files with the 'hidden' attribute as if their names started with a dot
    - `chattr` and `lsatt` applets
- https://frippery.org/busybox/release-notes/FRP-3466.html
    - `inotifyd` applet added
    - By default busybox-w32 uses the Windows console API to emulate terminal
      escape sequences. These control things like cursor movement and text
      colours. The new Windows terminal program and many alternative terminal
      programs provide direct support for escape sequences. The shell variable
      BB_SKIP_ANSI_EMULATION allows the default behaviour of busybox-w32 to be
      changed.
- https://frippery.org/busybox/release-notes/FRP-3445.html
    - `httpd`, `time` applets added
