### PR TITLE
filters: Reduce duplication of bool filter parsing and invalidFilter error

### DIFF
--- a/api/types/filters/errors.go
+++ b/api/types/filters/errors.go
@@ -1,0 +1,37 @@
+package filters
+
+import "fmt"
+
+// invalidFilter indicates that the provided filter or its value is invalid
+type invalidFilter struct {
+	Filter string
+	Value  []string
+}
+
+func (e invalidFilter) Error() string {
+	msg := "invalid filter"
+	if e.Filter != "" {
+		msg += " '" + e.Filter
+		if e.Value != nil {
+			msg = fmt.Sprintf("%s=%s", msg, e.Value)
+		}
+		msg += "'"
+	}
+	return msg
+}
+
+// InvalidParameter marks this error as ErrInvalidParameter
+func (e invalidFilter) InvalidParameter() {}
+
+// unreachableCode is an error indicating that the code path was not expected to be reached.
+type unreachableCode struct {
+	Filter string
+	Value  []string
+}
+
+// System marks this error as ErrSystem
+func (e unreachableCode) System() {}
+
+func (e unreachableCode) Error() string {
+	return fmt.Sprintf("unreachable code reached for filter: %q with values: %s", e.Filter, e.Value)
+}

--- a/api/types/filters/parse_test.go
+++ b/api/types/filters/parse_test.go
@@ -3,6 +3,7 @@ package filters // import "github.com/docker/docker/api/types/filters"
 import (
 	"encoding/json"
 	"errors"
+	"sort"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -417,4 +418,119 @@ func TestClone(t *testing.T) {
 	f2 := f.Clone()
 	f2.Add("baz", "qux")
 	assert.Check(t, is.Len(f.Get("baz"), 0))
+}
+
+func TestGetBoolOrDefault(t *testing.T) {
+	for _, tC := range []struct {
+		name          string
+		args          map[string][]string
+		defValue      bool
+		expectedErr   error
+		expectedValue bool
+	}{
+		{
+			name: "single true",
+			args: map[string][]string{
+				"dangling": {"true"},
+			},
+			defValue:      false,
+			expectedErr:   nil,
+			expectedValue: true,
+		},
+		{
+			name: "single false",
+			args: map[string][]string{
+				"dangling": {"false"},
+			},
+			defValue:      true,
+			expectedErr:   nil,
+			expectedValue: false,
+		},
+		{
+			name: "single bad value",
+			args: map[string][]string{
+				"dangling": {"potato"},
+			},
+			defValue:      true,
+			expectedErr:   invalidFilter{Filter: "dangling", Value: []string{"potato"}},
+			expectedValue: true,
+		},
+		{
+			name: "two bad values",
+			args: map[string][]string{
+				"dangling": {"banana", "potato"},
+			},
+			defValue:      true,
+			expectedErr:   invalidFilter{Filter: "dangling", Value: []string{"banana", "potato"}},
+			expectedValue: true,
+		},
+		{
+			name: "two conflicting values",
+			args: map[string][]string{
+				"dangling": {"false", "true"},
+			},
+			defValue:      false,
+			expectedErr:   invalidFilter{Filter: "dangling", Value: []string{"false", "true"}},
+			expectedValue: false,
+		},
+		{
+			name: "multiple conflicting values",
+			args: map[string][]string{
+				"dangling": {"false", "true", "1"},
+			},
+			defValue:      true,
+			expectedErr:   invalidFilter{Filter: "dangling", Value: []string{"false", "true", "1"}},
+			expectedValue: true,
+		},
+		{
+			name: "1 means true",
+			args: map[string][]string{
+				"dangling": {"1"},
+			},
+			defValue:      false,
+			expectedErr:   nil,
+			expectedValue: true,
+		},
+		{
+			name: "0 means false",
+			args: map[string][]string{
+				"dangling": {"0"},
+			},
+			defValue:      true,
+			expectedErr:   nil,
+			expectedValue: false,
+		},
+	} {
+		tC := tC
+		t.Run(tC.name, func(t *testing.T) {
+			a := NewArgs()
+
+			for key, values := range tC.args {
+				for _, value := range values {
+					a.Add(key, value)
+				}
+			}
+
+			value, err := a.GetBoolOrDefault("dangling", tC.defValue)
+
+			if tC.expectedErr == nil {
+				assert.Check(t, is.Nil(err))
+			} else {
+				assert.Check(t, is.ErrorType(err, tC.expectedErr))
+
+				// Check if error is the same.
+				expected := tC.expectedErr.(invalidFilter)
+				actual := err.(invalidFilter)
+
+				assert.Check(t, is.Equal(expected.Filter, actual.Filter))
+
+				sort.Strings(expected.Value)
+				sort.Strings(actual.Value)
+				assert.Check(t, is.DeepEqual(expected.Value, actual.Value))
+			}
+
+			assert.Check(t, is.Equal(tC.expectedValue, value))
+		})
+	}
+
 }

--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -109,21 +109,6 @@ func (e containerFileNotFound) Error() string {
 
 func (containerFileNotFound) NotFound() {}
 
-type invalidFilter struct {
-	filter string
-	value  interface{}
-}
-
-func (e invalidFilter) Error() string {
-	msg := "invalid filter '" + e.filter
-	if e.value != nil {
-		msg += fmt.Sprintf("=%s", e.value)
-	}
-	return msg + "'"
-}
-
-func (e invalidFilter) InvalidParameter() {}
-
 type startInvalidConfigError string
 
 func (e startInvalidConfigError) Error() string {

--- a/daemon/images/image_list.go
+++ b/daemon/images/image_list.go
@@ -38,18 +38,13 @@ func (i *ImageService) Images(ctx context.Context, opts types.ImageListOptions) 
 		return nil, err
 	}
 
-	var danglingOnly bool
-	if opts.Filters.Contains("dangling") {
-		if opts.Filters.ExactMatch("dangling", "true") {
-			danglingOnly = true
-		} else if !opts.Filters.ExactMatch("dangling", "false") {
-			return nil, invalidFilter{"dangling", opts.Filters.Get("dangling")}
-		}
+	danglingOnly, err := opts.Filters.GetBoolOrDefault("dangling", false)
+	if err != nil {
+		return nil, err
 	}
 
 	var (
 		beforeFilter, sinceFilter time.Time
-		err                       error
 	)
 	err = opts.Filters.WalkValues("before", func(value string) error {
 		img, err := i.GetImage(ctx, value, imagetypes.GetImageOpts{})

--- a/daemon/images/image_prune.go
+++ b/daemon/images/image_prune.go
@@ -46,13 +46,9 @@ func (i *ImageService) ImagesPrune(ctx context.Context, pruneFilters filters.Arg
 
 	rep := &types.ImagesPruneReport{}
 
-	danglingOnly := true
-	if pruneFilters.Contains("dangling") {
-		if pruneFilters.ExactMatch("dangling", "false") || pruneFilters.ExactMatch("dangling", "0") {
-			danglingOnly = false
-		} else if !pruneFilters.ExactMatch("dangling", "true") && !pruneFilters.ExactMatch("dangling", "1") {
-			return nil, invalidFilter{"dangling", pruneFilters.Get("dangling")}
-		}
+	danglingOnly, err := pruneFilters.GetBoolOrDefault("dangling", true)
+	if err != nil {
+		return nil, err
 	}
 
 	until, err := getUntilFromPruneFilters(pruneFilters)

--- a/daemon/images/locals.go
+++ b/daemon/images/locals.go
@@ -1,25 +1,8 @@
 package images // import "github.com/docker/docker/daemon/images"
 
 import (
-	"fmt"
-
 	metrics "github.com/docker/go-metrics"
 )
-
-type invalidFilter struct {
-	filter string
-	value  interface{}
-}
-
-func (e invalidFilter) Error() string {
-	msg := "invalid filter '" + e.filter
-	if e.value != nil {
-		msg += fmt.Sprintf("=%s", e.value)
-	}
-	return msg + "'"
-}
-
-func (e invalidFilter) InvalidParameter() {}
 
 var imageActions metrics.LabeledTimer
 

--- a/plugin/backend_linux.go
+++ b/plugin/backend_linux.go
@@ -318,12 +318,15 @@ func (pm *Manager) List(pluginFilters filters.Args) ([]types.Plugin, error) {
 	enabledOnly := false
 	disabledOnly := false
 	if pluginFilters.Contains("enabled") {
-		if pluginFilters.ExactMatch("enabled", "true") {
+		enabledFilter, err := pluginFilters.GetBoolOrDefault("enabled", false)
+		if err != nil {
+			return nil, err
+		}
+
+		if enabledFilter {
 			enabledOnly = true
-		} else if pluginFilters.ExactMatch("enabled", "false") {
-			disabledOnly = true
 		} else {
-			return nil, invalidFilter{"enabled", pluginFilters.Get("enabled")}
+			disabledOnly = true
 		}
 	}
 

--- a/plugin/errors.go
+++ b/plugin/errors.go
@@ -26,21 +26,6 @@ func (name errDisabled) Error() string {
 
 func (name errDisabled) Conflict() {}
 
-type invalidFilter struct {
-	filter string
-	value  []string
-}
-
-func (e invalidFilter) Error() string {
-	msg := "invalid filter '" + e.filter
-	if len(e.value) > 0 {
-		msg += fmt.Sprintf("=%s", e.value)
-	}
-	return msg + "'"
-}
-
-func (invalidFilter) InvalidParameter() {}
-
 type inUseError string
 
 func (e inUseError) Error() string {

--- a/volume/service/convert.go
+++ b/volume/service/convert.go
@@ -114,11 +114,9 @@ func filtersToBy(filter filters.Args, acceptedFilters map[string]bool) (By, erro
 	bys = append(bys, byLabelFilter(filter))
 
 	if filter.Contains("dangling") {
-		var dangling bool
-		if filter.ExactMatch("dangling", "true") || filter.ExactMatch("dangling", "1") {
-			dangling = true
-		} else if !filter.ExactMatch("dangling", "false") && !filter.ExactMatch("dangling", "0") {
-			return nil, invalidFilter{"dangling", filter.Get("dangling")}
+		dangling, err := filter.GetBoolOrDefault("dangling", false)
+		if err != nil {
+			return nil, err
 		}
 		bys = append(bys, ByReferenced(!dangling))
 	}
@@ -138,7 +136,7 @@ func withPrune(filter filters.Args) error {
 	all := filter.Get("all")
 	switch {
 	case len(all) > 1:
-		return invalidFilter{"all", all}
+		return errdefs.InvalidParameter(fmt.Errorf("invalid filter 'all=%s': only one value is expected", all))
 	case len(all) == 1:
 		ok, err := strconv.ParseBool(all[0])
 		if err != nil {

--- a/volume/service/errors.go
+++ b/volume/service/errors.go
@@ -1,7 +1,6 @@
 package service // import "github.com/docker/docker/volume/service"
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -94,18 +93,3 @@ func isErr(err error, expected error) bool {
 	}
 	return err == expected
 }
-
-type invalidFilter struct {
-	filter string
-	value  interface{}
-}
-
-func (e invalidFilter) Error() string {
-	msg := "invalid filter '" + e.filter
-	if e.value != nil {
-		msg += fmt.Sprintf("=%s", e.value)
-	}
-	return msg + "'"
-}
-
-func (e invalidFilter) InvalidParameter() {}


### PR DESCRIPTION
When working on images prune for containerd branch I noticed that the logic for parsing the filter value as boolean is duplicated in multiple places and each package has its own invalidFilter type which basically does the same thing.

**- What I did**
- Removed all duplicated invalidFilter types
- Replaced repeated pattern of parsing boolean filter with the usage of `GetBoolOrDefault`

**- How to verify it**
CI, lint, tests

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

