### PR TITLE
Push image faster by using pigz to compress

### DIFF
--- a/distribution/push.go
+++ b/distribution/push.go
@@ -101,6 +101,29 @@ func Push(ctx context.Context, ref reference.Named, config *ImagePushConfig) err
 // before it releases any resources connected with the reader that was
 // passed in.
 func compress(in io.Reader) (io.ReadCloser, chan struct{}) {
+	var usePigz bool
+	noPigzEnv := os.Getenv("MOBY_DISABLE_PIGZ")
+	if noPigzEnv == "" {
+		usePigz = true
+	} else {
+		noPigz, err := strconv.ParseBool(noPigzEnv)
+		if err != nil {
+			logrus.WithError(err).Warn("invalid value in MOBY_DISABLE_PIGZ env var")
+		}
+		usePigz = !noPigz
+	}
+
+	if usePigz {
+		pigzPath, err := exec.LookPath("pigz")
+		if err != nil {
+			logrus.Debugf("pigz binary not found, falling back to go gzip library")
+		} else {
+			return pigzCompress(ctx, in, pigzPath)
+		}
+	} else {
+		logrus.Debugf("Use of pigz is disabled due to MOBY_DISABLE_PIGZ=%s", noPigzEnv)
+	}
+
 	compressionDone := make(chan struct{})
 
 	pipeReader, pipeWriter := io.Pipe()
@@ -125,4 +148,33 @@ func compress(in io.Reader) (io.ReadCloser, chan struct{}) {
 	}()
 
 	return pipeReader, compressionDone
+}
+
+func pigzCompress(ctx context.Context, in io.Reader, pigzPath string) (io.ReadCloser, chan struct{}) {
+	cmd := exec.CommandContext(ctx, pigzPath, "-c")
+
+	cmd.Stdin = in
+	pipeR, pipeW := io.Pipe()
+	cmd.Stdout = pipeW
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+
+	done := make(chan struct{})
+
+	if err := cmd.Start(); err != nil {
+		fmt.Errorf("could not get compression stream: %v", err)
+		close(done)
+		return nil, done
+	}
+
+	go func() {
+		if err := cmd.Wait(); err != nil {
+			pipeW.CloseWithError(fmt.Errorf("%s: %s", err, errBuf.String()))
+		} else {
+			pipeW.Close()
+		}
+		close(done)
+	}()
+
+	return pipeR, done
 }

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -469,7 +469,7 @@ func (pd *pushDescriptor) uploadUsingSession(
 
 	switch m := pd.layer.MediaType(); m {
 	case schema2.MediaTypeUncompressedLayer:
-		compressedReader, compressionDone := compress(reader)
+		compressedReader, compressionDone := compress(ctx, reader)
 		defer func(closer io.Closer) {
 			closer.Close()
 			<-compressionDone


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
The gzip compression used in the docker push has poor performance. I changed it to using pigz for compression. 
I noticed that docker used pigz to decompress the pull image for better performance (https://github.com/moby/moby/pull/35697), so I think the performance of docker push can be improved in the same way.

**- How I did it**
Similar to https://github.com/moby/moby/pull/35697, this change switches to trying to use pigz for gzip compression. If it isn't available, it'll fall back to the default. This code path can also be disabled by environment variable.

**- How to verify it**
Performance improvement verification: after the manual push test of some images (from 19.2 MB to 28.2 GB) , the time consumed by pushing images is reduced by 47.9%~74.7%. In fact, I have noticed that some issues have discussed and verified the performance improvement brought by this.
Correctness verification: There are existing tests for this codepath to ensure correctness of this implementation.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Push image faster by using pigz to compress

