### PR TITLE
Fix incorrect use of loop variables in parallel tests.

### DIFF
--- a/daemon/logger/loggerutils/logfile_test.go
+++ b/daemon/logger/loggerutils/logfile_test.go
@@ -66,8 +66,8 @@ func TestTailFiles(t *testing.T) {
 			started := make(chan struct{})
 			fwd := newForwarder(config)
 			go func() {
-				close(started)
 				tailFiles(files, watcher, dec, tailReader, config.Tail, fwd)
+				close(started)
 			}()
 			<-started
 		})

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -379,7 +379,7 @@ func TestMaxDownloadAttempts(t *testing.T) {
 			name:                "max-attempts=5, fail at 6th attempt",
 			simulateRetries:     6,
 			maxDownloadAttempts: 5,
-			expectedErr:         "simulating download attempt 5/6",
+			expectedErr:         "simulating download attempt 6/6",
 		},
 		{
 			name:                "max-attempts=0, fail after 1 attempt",
@@ -389,6 +389,7 @@ func TestMaxDownloadAttempts(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
+		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			layerStore := &mockLayerStore{make(map[layer.ChainID]*mockLayer)}

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -90,6 +90,7 @@ func TestBuildWithRemoveAndForceRemove(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 	for _, c := range cases {
+		c := c // capture range variable
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 			dockerfile := []byte(c.dockerfile)


### PR DESCRIPTION
**- What I did**
This commit fixes occurrences of loop variables being captured by
reference in parallel tests. With very high probability, only the last
test case will actually be exercised. To work around this problem, we
create a local copy of the range variable before the parallel test, as
advised by the Go documentation at:

https://pkg.go.dev/testing#hdr-Subtests_and_Sub_benchmarks

**- How I did it**
Issues were found automatically using the `loopvarcapture` linter.

**- How to verify it**
Running the tests changed here and verifying that they now actually run each test declared.