### PR TITLE
Fix health check timeout test on Windows+containerd

### DIFF
--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -28,6 +28,11 @@ func (daemon *Daemon) setStateCounter(c *container.Container) {
 func (daemon *Daemon) handleContainerExit(c *container.Container, e *libcontainerdtypes.EventInfo) error {
 	var exitStatus container.ExitStatus
 	c.Lock()
+
+	// Health checks will be automatically restarted if/when the
+	// container is started again.
+	daemon.stopHealthchecks(c)
+
 	tsk, ok := c.Task()
 	if ok {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -72,9 +77,6 @@ func (daemon *Daemon) handleContainerExit(c *container.Container, e *libcontaine
 		restart = false
 	}
 
-	// cancel healthcheck here, they will be automatically
-	// restarted if/when the container is started again
-	daemon.stopHealthchecks(c)
 	attributes := map[string]string{
 		"exitCode": strconv.Itoa(exitStatus.ExitCode),
 	}

--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -96,7 +96,6 @@ while true; do sleep 1; done
 
 // TestHealthCheckProcessKilled verifies that health-checks exec get killed on time-out.
 func TestHealthCheckProcessKilled(t *testing.T) {
-	skip.If(t, testEnv.RuntimeIsWindowsContainerd(), "FIXME: Broken on Windows + containerd combination")
 	defer setupTest(t)()
 	ctx := context.Background()
 	apiClient := testEnv.APIClient()


### PR DESCRIPTION
- supersedes / closes https://github.com/moby/moby/pull/44044

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Unskipped `TestHealthCheckProcessKilled` on Windows.
- Optimized container teardown by stopping health checks as early as possible, instead of after waiting on IO.

**- How I did it**
#43564 appears to have incidentally fixed whatever was causing that test to fail on Windows+containerd as that test now passes. Stopping health checks immediately after the task has exited was thought to also help, but #44044 has shown that such a change is not strictly necessary. We think it's a good idea to make that change anyway, as an optimization.

**- How to verify it**
🟢 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
N/A

**- A picture of a cute animal (not mandatory but encouraged)**

