### PR TITLE
ci: print Windows daemon event log timestamps

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -472,9 +472,9 @@ jobs:
         run: |
           Get-WinEvent -ea SilentlyContinue `
             -FilterHashtable @{ProviderName= "docker"; LogName = "application"} |
-              Select-Object -Property TimeCreated, @{N='Detailed Message'; E={$_.Message}} |
               Sort-Object @{Expression="TimeCreated";Descending=$false} |
-              Select-Object -ExpandProperty 'Detailed Message' | Tee-Object -file ".\bundles\daemon.log"
+              ForEach-Object {"$($_.TimeCreated.ToUniversalTime().ToString("o")) [$($_.LevelDisplayName)] $($_.Message)"} |
+              Tee-Object -file ".\bundles\daemon.log"
       -
         name: Upload reports
         if: always()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added timestamps and the log level to the daemon log entries scraped from the Windows event log so they can be correlated with containerd and integration test logs.

**- How I did it**
⚡ Power ⚡ Shell ⚡ 

**- How to verify it**
Run the workflow and [inspect the output manually.](https://github.com/moby/moby/runs/7979686086?check_suite_focus=true#step:21:24)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
N/A

**- A picture of a cute animal (not mandatory but encouraged)**

