### PR TITLE
[20.10 backport] daemon: kill exec process on ctx cancel

### DIFF
--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -2,6 +2,7 @@ package container // import "github.com/docker/docker/integration/container"
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -91,6 +92,42 @@ while true; do sleep 1; done
 	ctxPoll, cancel = context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	poll.WaitOn(t, pollForHealthStatus(ctxPoll, client, id, "healthy"), poll.WithDelay(100*time.Millisecond))
+}
+
+// TestHealthCheckProcessKilled verifies that health-checks exec get killed on time-out.
+func TestHealthCheckProcessKilled(t *testing.T) {
+	// FIXME: Broken on Windows + containerd combination
+	defer setupTest(t)()
+	ctx := context.Background()
+	apiClient := testEnv.APIClient()
+
+	cID := container.Run(ctx, t, apiClient, func(c *container.TestContainerConfig) {
+		c.Config.Healthcheck = &containertypes.HealthConfig{
+			Test:     []string{"CMD", "sh", "-c", "sleep 60"},
+			Interval: 100 * time.Millisecond,
+			Timeout:  50 * time.Millisecond,
+			Retries:  1,
+		}
+	})
+	poll.WaitOn(t, pollForHealthCheckLog(ctx, apiClient, cID, "Health check exceeded timeout (50ms)"))
+}
+
+func pollForHealthCheckLog(ctx context.Context, client client.APIClient, containerID string, expected string) func(log poll.LogT) poll.Result {
+	return func(log poll.LogT) poll.Result {
+		inspect, err := client.ContainerInspect(ctx, containerID)
+		if err != nil {
+			return poll.Error(err)
+		}
+		healthChecksTotal := len(inspect.State.Health.Log)
+		if healthChecksTotal > 0 {
+			output := inspect.State.Health.Log[healthChecksTotal-1].Output
+			if output == expected {
+				return poll.Success()
+			}
+			return poll.Error(fmt.Errorf("expected %q, got %q", expected, output))
+		}
+		return poll.Continue("waiting for container healthcheck logs")
+	}
 }
 
 func pollForHealthStatus(ctx context.Context, client client.APIClient, containerID string, healthStatus string) func(log poll.LogT) poll.Result {


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/43739
- fixes https://github.com/moby/moby/issues/43737

Terminating the exec process when the context is canceled has been
broken since Docker v17.11 so nobody has been able to depend upon that
behaviour in five years of releases. We are thus free from backwards-
compatibility constraints.

conflicts:

- minor conflict in daemon/exec.go, as 2ec2b65e45ca6ae28480c6da49aaf06fda1a091f
  is not in the 20.10 branch, so had to cast the signal to an int.
- minor conflict in daemon/health.go, where a comment was updated, which was
  added in bdc6473d2de1eca6fe5d0c2e59c9411a463281cc, which is not in the
  20.10 branch
- remove the skip.If() from TestHealthCheckProcessKilled, as the 20.10 branch
  is not testing on Windows with containerd (and the RuntimeIsWindowsContainerd
  does not exist), but kept a "FIXME" comment.

(cherry picked from commit 4b84a3321723a849295d5cbf7342ec36077f9179)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

