### PR TITLE
client: remove deprecated WithDialer() option

### DIFF
--- a/client/options.go
+++ b/client/options.go
@@ -44,13 +44,6 @@ func FromEnv(c *Client) error {
 	return nil
 }
 
-// WithDialer applies the dialer.DialContext to the client transport. This can be
-// used to set the Timeout and KeepAlive settings of the client.
-// Deprecated: use WithDialContext
-func WithDialer(dialer *net.Dialer) Opt {
-	return WithDialContext(dialer.DialContext)
-}
-
 // WithDialContext applies the dialer to the client transport. This can be
 // used to set the Timeout and KeepAlive settings of the client.
 func WithDialContext(dialContext func(ctx context.Context, network, addr string) (net.Conn, error)) Opt {


### PR DESCRIPTION
It was deprecated in edac92409a3b1d0cfb7f5c0e2d10b3bb71f27245 (https://github.com/moby/moby/pull/36630), which was part of 18.09 and up, so should be safe by now to remove this.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

