### PR TITLE
client: remove deprecated error-utilities

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -58,29 +58,12 @@ func (e objectNotFoundError) Error() string {
 	return fmt.Sprintf("Error: No such %s: %s", e.object, e.id)
 }
 
-// IsErrUnauthorized returns true if the error is caused
-// when a remote registry authentication fails
-//
-// Deprecated: use errdefs.IsUnauthorized
-func IsErrUnauthorized(err error) bool {
-	return errdefs.IsUnauthorized(err)
-}
-
 type pluginPermissionDenied struct {
 	name string
 }
 
 func (e pluginPermissionDenied) Error() string {
 	return "Permission denied while installing plugin " + e.name
-}
-
-// IsErrNotImplemented returns true if the error is a NotImplemented error.
-// This is returned by the API when a requested feature has not been
-// implemented.
-//
-// Deprecated: use errdefs.IsNotImplemented
-func IsErrNotImplemented(err error) bool {
-	return errdefs.IsNotImplemented(err)
 }
 
 // NewVersionError returns an error if the APIVersion required

--- a/client/errors.go
+++ b/client/errors.go
@@ -58,14 +58,6 @@ func (e objectNotFoundError) Error() string {
 	return fmt.Sprintf("Error: No such %s: %s", e.object, e.id)
 }
 
-type pluginPermissionDenied struct {
-	name string
-}
-
-func (e pluginPermissionDenied) Error() string {
-	return "Permission denied while installing plugin " + e.name
-}
-
 // NewVersionError returns an error if the APIVersion required
 // if less than the current supported version
 func (cli *Client) NewVersionError(APIrequired, feature string) error {

--- a/client/plugin_install.go
+++ b/client/plugin_install.go
@@ -107,7 +107,7 @@ func (cli *Client) checkPluginPermissions(ctx context.Context, query url.Values,
 			return nil, err
 		}
 		if !accept {
-			return nil, pluginPermissionDenied{options.RemoteRef}
+			return nil, errors.Errorf("permission denied while installing plugin %s", options.RemoteRef)
 		}
 	}
 	return privileges, nil


### PR DESCRIPTION
### client: remove deprecated IsErrUnauthorized, IsErrNotImplemented

These were deprecated in https://github.com/moby/moby/commit/ee230d8fdda6a1901c2adc394b5fb8471ec7aa51 (https://github.com/moby/moby/pull/43789),
which is in the 22.06 branch, so we can safely remove it from
master to have them removed in the release after that.

### client: remove redundant pluginPermissionDenied

It was only used in a single location, and only a "convenience" type,
not used to detect a specific error.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

