### PR TITLE
[22.06 backport] client: remove deprecated WithDialer() option

### DIFF
--- a/client/options.go
+++ b/client/options.go
@@ -44,13 +44,6 @@ func FromEnv(c *Client) error {
 	return nil
 }
 
-// WithDialer applies the dialer.DialContext to the client transport. This can be
-// used to set the Timeout and KeepAlive settings of the client.
-// Deprecated: use WithDialContext
-func WithDialer(dialer *net.Dialer) Opt {
-	return WithDialContext(dialer.DialContext)
-}
-
 // WithDialContext applies the dialer to the client transport. This can be
 // used to set the Timeout and KeepAlive settings of the client.
 func WithDialContext(dialContext func(ctx context.Context, network, addr string) (net.Conn, error)) Opt {


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44020


It was deprecated in edac92409a3b1d0cfb7f5c0e2d10b3bb71f27245, which
was part of 18.09 and up, so should be safe by now to remove this.

(cherry picked from commit e14924570c27b4d5347135fdc47378363123d974)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

