### PR TITLE
[22.06 backport] client: disable deprecated NewClient() and NewEnvClient()

### DIFF
--- a/client/client_deprecated.go
+++ b/client/client_deprecated.go
@@ -9,15 +9,51 @@ import "net/http"
 // It won't send any version information if the version number is empty. It is
 // highly recommended that you set a version or your client may break if the
 // server is upgraded.
+//
+// This function is deprecated, and is no longer functional.
+//
+// If you're using this function, replace it with the code below to get
+// the equivalent (non-deprecated) code to initialize a client with a
+// fixed API version:
+//
+//    client.NewClientWithOpts(
+//        WithHost(host),
+//        WithVersion(version),
+//        WithHTTPClient(client),
+//        WithHTTPHeaders(httpHeaders),
+//    )
+//
+// We recommend to enable API version negotiation, so that the client
+// automatically negotiates the API version to use when connecting with the
+// daemon. To enable API version negotiation, use the WithAPIVersionNegotiation()
+// option instead of WithVersion(version):
+//
+//    client.NewClientWithOpts(
+//        WithHost(host),
+//        WithAPIVersionNegotiation(),
+//        WithHTTPClient(client),
+//        WithHTTPHeaders(httpHeaders),
+//    )
+//
 // Deprecated: use NewClientWithOpts
-func NewClient(host string, version string, client *http.Client, httpHeaders map[string]string) (*Client, error) {
-	return NewClientWithOpts(WithHost(host), WithVersion(version), WithHTTPClient(client), WithHTTPHeaders(httpHeaders))
-}
+func NewClient(host string, version string, client *http.Client, httpHeaders map[string]string) {}
 
 // NewEnvClient initializes a new API client based on environment variables.
 // See FromEnv for a list of support environment variables.
 //
-// Deprecated: use NewClientWithOpts(FromEnv)
-func NewEnvClient() (*Client, error) {
-	return NewClientWithOpts(FromEnv)
-}
+// This function is deprecated, and is no longer functional.
+//
+// If you're using this function, replace it with the code below to get
+// the equivalent (non-deprecated) code:
+//
+//    client.NewClientWithOpts(FromEnv)
+//
+// We recommend to enable API version negotiation, so that the client
+// automatically negotiates the API version to use when connecting with the
+// daemon. To enable API version negotiation, add the WithAPIVersionNegotiation()
+// option:
+//
+//    client.NewClientWithOpts(FromEnv, WithAPIVersionNegotiation())
+//
+// Deprecated: use NewClientWithOpts
+func NewEnvClient() {}


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44019

The `NewClient()` and `NewEnvClient()` functions were deprecated in 18.03 in
commit 772edd020cc784913973387b00c4d0c526a10a26 (https://github.com/moby/moby/pull/36140), but they continued to be functional.

Searching public repositories on GitHub shows that there's quite some projects
that haven't updated their code to use the replacements.

This patch updates both functions to become non-functional (to enforce a compilation
failure), but extend the function's documentaiton with instructions on migrating to
their non-deprecated alternatives. This should hopefully assist projects to migrate
their code.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
