### PR TITLE
libnetwork/drivers/ipvlan: fix missing IpvlanFlag field in config JSON

### DIFF
--- a/libnetwork/drivers/ipvlan/ipvlan_store.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_store.go
@@ -154,6 +154,7 @@ func (config *configuration) MarshalJSON() ([]byte, error) {
 	nMap["Mtu"] = config.Mtu
 	nMap["Parent"] = config.Parent
 	nMap["IpvlanMode"] = config.IpvlanMode
+	nMap["IpvlanFlag"] = config.IpvlanFlag
 	nMap["Internal"] = config.Internal
 	nMap["CreatedSubIface"] = config.CreatedSlaveLink
 	if len(config.Ipv4Subnets) > 0 {
@@ -187,6 +188,7 @@ func (config *configuration) UnmarshalJSON(b []byte) error {
 	config.Mtu = int(nMap["Mtu"].(float64))
 	config.Parent = nMap["Parent"].(string)
 	config.IpvlanMode = nMap["IpvlanMode"].(string)
+	config.IpvlanFlag = nMap["IpvlanFlag"].(string)
 	config.Internal = nMap["Internal"].(bool)
 	config.CreatedSlaveLink = nMap["CreatedSubIface"].(bool)
 	if v, ok := nMap["Ipv4Subnets"]; ok {


### PR DESCRIPTION
Containers with `ipvlan` networks refuse to start and report `Unsupported  ipvlan flag: unknown ipvlan flag:` when connecting containers to network.

The root cause is I missed `IpvlanFlag` field in `MarshalJSON`/`UnmarshalJSON` in my previous PR #42542 . The network state is lost across dockerd restart.

Existing `ipvlan` networks should be recreated to ensure a proper `IpvlanFlag` field was written to disk.

This patch should be backported to 22.06 as well.