### PR TITLE
[22.06 backport] libnetwork/drivers/ipvlan: fix missing IpvlanFlag field in config JSON

### DIFF
--- a/libnetwork/drivers/ipvlan/ipvlan_store.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_store.go
@@ -159,6 +159,7 @@ func (config *configuration) MarshalJSON() ([]byte, error) {
 	nMap["Mtu"] = config.Mtu
 	nMap["Parent"] = config.Parent
 	nMap["IpvlanMode"] = config.IpvlanMode
+	nMap["IpvlanFlag"] = config.IpvlanFlag
 	nMap["Internal"] = config.Internal
 	nMap["CreatedSubIface"] = config.CreatedSlaveLink
 	if len(config.Ipv4Subnets) > 0 {
@@ -192,6 +193,7 @@ func (config *configuration) UnmarshalJSON(b []byte) error {
 	config.Mtu = int(nMap["Mtu"].(float64))
 	config.Parent = nMap["Parent"].(string)
 	config.IpvlanMode = nMap["IpvlanMode"].(string)
+	config.IpvlanFlag = nMap["IpvlanFlag"].(string)
 	config.Internal = nMap["Internal"].(bool)
 	config.CreatedSlaveLink = nMap["CreatedSubIface"].(bool)
 	if v, ok := nMap["Ipv4Subnets"]; ok {


### PR DESCRIPTION
- introduced in / fixes https://github.com/moby/moby/pull/42542
- backport of https://github.com/moby/moby/pull/44026

(cherry picked from commit 549d24b437b87fe27e49ed0bf8c11832b4565cab)


**- A picture of a cute animal (not mandatory but encouraged)**

