### PR TITLE
[22.06 backport] update containerd binary to v1.6.8

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -166,7 +166,7 @@ FROM microsoft/windowsservercore
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG GO_VERSION=1.18.5
-ARG CONTAINERD_VERSION=v1.6.7
+ARG CONTAINERD_VERSION=v1.6.8
 ARG GOTESTSUM_VERSION=v1.8.1
 ARG GOWINRES_VERSION=v0.2.3
 

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.6.7}"
+: "${CONTAINERD_VERSION:=v1.6.8}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44040

release notes: https://github.com/containerd/containerd/releases/tag/v1.6.8

full diff: https://github.com/containerd/containerd/compare/v1.6.7...v1.6.8

(cherry picked from commit d52ffce38f0f8361c3ca6000344a5a14d77608f2)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

