### PR TITLE
daemon: un-skip TestHealthCheckProcessKilled on Windows

### DIFF
--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -96,7 +96,6 @@ while true; do sleep 1; done
 
 // TestHealthCheckProcessKilled verifies that health-checks exec get killed on time-out.
 func TestHealthCheckProcessKilled(t *testing.T) {
-	skip.If(t, testEnv.RuntimeIsWindowsContainerd(), "FIXME: Broken on Windows + containerd combination")
 	defer setupTest(t)()
 	ctx := context.Background()
 	apiClient := testEnv.APIClient()


### PR DESCRIPTION
- alternative to / closes https://github.com/moby/moby/pull/44014

It appears that #43564 has fixed the integration test on Windows+containerd.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

