### PR TITLE
ci: fix broken workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,8 @@ jobs:
         name: BuildKit ref
         run: |
           ./hack/go-mod-prepare.sh
-# FIXME(thaJeztah) temporarily overriding version to use for tests; see https://github.com/moby/moby/pull/44028#issuecomment-1225964929
-#          echo "BUILDKIT_REF=$(./hack/buildkit-ref)" >> $GITHUB_ENV
+          # FIXME(thaJeztah) temporarily overriding version to use for tests; see https://github.com/moby/moby/pull/44028#issuecomment-1225964929
+          # echo "BUILDKIT_REF=$(./hack/buildkit-ref)" >> $GITHUB_ENV
           echo "BUILDKIT_REF=8e2d9b9006caadb74c1745608889a37ba139acc1" >> $GITHUB_ENV
         working-directory: moby
       -


### PR DESCRIPTION
`ci` workflow is malformed (yaml syntax error) and is not triggered anymore since https://github.com/moby/moby/actions/runs/2929193959

![image](https://user-images.githubusercontent.com/1951866/186804159-8fd29b9c-6375-4008-ae60-b14281a31ba5.png)

looks to be the comment added in https://github.com/moby/moby/pull/44028: https://github.com/moby/moby/pull/44028/commits/6217f8001e25b945aebe0059133013b419503cdd

to avoid this in the future, I think we should require some checks in this workflow.

cc @thaJeztah 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>
