### PR TITLE
[22.06 backport] ci: fix broken workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,8 @@ jobs:
         name: BuildKit ref
         run: |
           ./hack/go-mod-prepare.sh
-# FIXME(thaJeztah) temporarily overriding version to use for tests; see https://github.com/moby/moby/pull/44028#issuecomment-1225964929
-#          echo "BUILDKIT_REF=$(./hack/buildkit-ref)" >> $GITHUB_ENV
+          # FIXME(thaJeztah) temporarily overriding version to use for tests; see https://github.com/moby/moby/pull/44028#issuecomment-1225964929
+          # echo "BUILDKIT_REF=$(./hack/buildkit-ref)" >> $GITHUB_ENV
           echo "BUILDKIT_REF=8e2d9b9006caadb74c1745608889a37ba139acc1" >> $GITHUB_ENV
         working-directory: moby
       -


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44045
- introduced in https://github.com/moby/moby/pull/44029

(cherry picked from commit 8e8d9a36500fb07fa9d1b68539756b9a93d3509e)

