### PR TITLE
pkg/system: make IsAbs() platform-agnostic

### DIFF
--- a/pkg/system/filesys.go
+++ b/pkg/system/filesys.go
@@ -1,0 +1,19 @@
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// IsAbs is a platform-agnostic wrapper for filepath.IsAbs.
+//
+// On Windows, golang filepath.IsAbs does not consider a path \windows\system32
+// as absolute as it doesn't start with a drive-letter/colon combination. However,
+// in docker we need to verify things such as WORKDIR /windows/system32 in
+// a Dockerfile (which gets translated to \windows\system32 when being processed
+// by the daemon). This SHOULD be treated as absolute from a docker processing
+// perspective.
+func IsAbs(path string) bool {
+	return filepath.IsAbs(path) || strings.HasPrefix(path, string(os.PathSeparator))
+}

--- a/pkg/system/filesys_unix.go
+++ b/pkg/system/filesys_unix.go
@@ -3,10 +3,7 @@
 
 package system // import "github.com/docker/docker/pkg/system"
 
-import (
-	"os"
-	"path/filepath"
-)
+import "os"
 
 // MkdirAllWithACL is a wrapper for os.MkdirAll on unix systems.
 func MkdirAllWithACL(path string, perm os.FileMode, sddl string) error {
@@ -17,11 +14,6 @@ func MkdirAllWithACL(path string, perm os.FileMode, sddl string) error {
 // with permission specified by attribute perm for all dir created.
 func MkdirAll(path string, perm os.FileMode) error {
 	return os.MkdirAll(path, perm)
-}
-
-// IsAbs is a platform-specific wrapper for filepath.IsAbs.
-func IsAbs(path string) bool {
-	return filepath.IsAbs(path)
 }
 
 // The functions below here are wrappers for the equivalents in the os and ioutils packages.

--- a/pkg/system/filesys_windows.go
+++ b/pkg/system/filesys_windows.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -120,20 +119,6 @@ func mkdirWithACL(name string, sddl string) error {
 		return &os.PathError{Op: "mkdir", Path: name, Err: e}
 	}
 	return nil
-}
-
-// IsAbs is a platform-specific wrapper for filepath.IsAbs. On Windows,
-// golang filepath.IsAbs does not consider a path \windows\system32 as absolute
-// as it doesn't start with a drive-letter/colon combination. However, in
-// docker we need to verify things such as WORKDIR /windows/system32 in
-// a Dockerfile (which gets translated to \windows\system32 when being processed
-// by the daemon. This SHOULD be treated as absolute from a docker processing
-// perspective.
-func IsAbs(path string) bool {
-	if filepath.IsAbs(path) || strings.HasPrefix(path, string(os.PathSeparator)) {
-		return true
-	}
-	return false
 }
 
 // The origin of the functions below here are the golang OS and windows packages,


### PR DESCRIPTION
filepath.IsAbs() will short-circuit on Linux/Unix, so having a single implementation should not affect those platforms.

**- A picture of a cute animal (not mandatory but encouraged)**

