### PR TITLE
pkg/archive: make CanonicalTarNameForPath an alias for filepath.ToSlash

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -555,10 +555,17 @@ func newTarAppender(idMapping idtools.IdentityMapping, writer io.Writer, chownOp
 	}
 }
 
-// canonicalTarName provides a platform-independent and consistent posix-style
+// CanonicalTarNameForPath canonicalizes relativePath to a POSIX-style path using
+// forward slashes. It is an alias for filepath.ToSlash, which is a no-op on
+// Linux and Unix.
+func CanonicalTarNameForPath(relativePath string) string {
+	return filepath.ToSlash(relativePath)
+}
+
+// canonicalTarName provides a platform-independent and consistent POSIX-style
 // path for files and directories to be archived regardless of the platform.
 func canonicalTarName(name string, isDir bool) string {
-	name = CanonicalTarNameForPath(name)
+	name = filepath.ToSlash(name)
 
 	// suffix with '/' for directories
 	if isDir && !strings.HasSuffix(name, "/") {

--- a/pkg/archive/archive_unix.go
+++ b/pkg/archive/archive_unix.go
@@ -35,16 +35,8 @@ func getWalkRoot(srcPath string, include string) string {
 	return strings.TrimSuffix(srcPath, string(filepath.Separator)) + string(filepath.Separator) + include
 }
 
-// CanonicalTarNameForPath returns platform-specific filepath
-// to canonical posix-style path for tar archival. p is relative
-// path.
-func CanonicalTarNameForPath(p string) string {
-	return p // already unix-style
-}
-
 // chmodTarEntry is used to adjust the file permissions used in tar header based
 // on the platform the archival is done.
-
 func chmodTarEntry(perm os.FileMode) os.FileMode {
 	return perm // noop for unix as golang APIs provide perm bits correctly
 }

--- a/pkg/archive/archive_unix_test.go
+++ b/pkg/archive/archive_unix_test.go
@@ -23,19 +23,6 @@ import (
 	"gotest.tools/v3/skip"
 )
 
-func TestCanonicalTarNameForPath(t *testing.T) {
-	cases := []struct{ in, expected string }{
-		{"foo", "foo"},
-		{"foo/bar", "foo/bar"},
-		{"foo/dir/", "foo/dir/"},
-	}
-	for _, v := range cases {
-		if CanonicalTarNameForPath(v.in) != v.expected {
-			t.Fatalf("wrong canonical tar name. expected:%s got:%s", v.expected, CanonicalTarNameForPath(v.in))
-		}
-	}
-}
-
 func TestCanonicalTarName(t *testing.T) {
 	cases := []struct {
 		in       string

--- a/pkg/archive/archive_windows.go
+++ b/pkg/archive/archive_windows.go
@@ -21,13 +21,6 @@ func getWalkRoot(srcPath string, include string) string {
 	return filepath.Join(srcPath, include)
 }
 
-// CanonicalTarNameForPath returns platform-specific filepath
-// to canonical posix-style path for tar archival. p is relative
-// path.
-func CanonicalTarNameForPath(p string) string {
-	return filepath.ToSlash(p)
-}
-
 // chmodTarEntry is used to adjust the file permissions used in tar header based
 // on the platform the archival is done.
 func chmodTarEntry(perm os.FileMode) os.FileMode {

--- a/pkg/archive/archive_windows_test.go
+++ b/pkg/archive/archive_windows_test.go
@@ -33,21 +33,6 @@ func TestCopyFileWithInvalidDest(t *testing.T) {
 	}
 }
 
-func TestCanonicalTarNameForPath(t *testing.T) {
-	cases := []struct {
-		in, expected string
-	}{
-		{"foo", "foo"},
-		{"foo/bar", "foo/bar"},
-		{`foo\bar`, "foo/bar"},
-	}
-	for _, v := range cases {
-		if CanonicalTarNameForPath(v.in) != v.expected {
-			t.Fatalf("wrong canonical tar name. expected:%s got:%s", v.expected, CanonicalTarNameForPath(v.in))
-		}
-	}
-}
-
 func TestCanonicalTarName(t *testing.T) {
 	cases := []struct {
 		in       string


### PR DESCRIPTION
### pkg/archive: make CanonicalTarNameForPath and alias for filepath.ToSlash

filepath.ToSlash is already a no-op on non-Windows platforms, so there's no
need to provide multiple implementations.

We could consider deprecating this function, but it's used in the CLI, and
perhaps it's still useful to have a canonical location to perform this normalization.


### pkg/archive: remove tests for CanonicalTarNameForPath

Now that CanonicalTarNameForPath is an alias for filepath.ToSlash, they were
mostly redundant, and only testing Go's stdlib. Coverage for filepath.ToSlash is
provided through TestCanonicalTarName, which does a superset of CanonicalTarNameForPath,
