### PR TITLE
api: swagger: add errorDetail to CreateImageInfo

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2343,6 +2343,8 @@ definitions:
         type: "string"
       error:
         type: "string"
+      errorDetail:
+        $ref: "#/definitions/ErrorDetail"
       status:
         type: "string"
       progress:

--- a/docs/api/v1.42.yaml
+++ b/docs/api/v1.42.yaml
@@ -2343,6 +2343,8 @@ definitions:
         type: "string"
       error:
         type: "string"
+      errorDetail:
+        $ref: "#/definitions/ErrorDetail"
       status:
         type: "string"
       progress:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

fixes #44059 

**- What I did**

Added an `errorDetail` field to the `CreateImageInfo` swagger v1.42 API

**- How I did it**

Amended API 1.42 and the future swagger for 1.43 YAML description

**- How to verify it**

Not able to reproduce, as yet.

**- Description for the changelog**

Added an `errorDetail` field to the `CreateImageInfo` swagger documentation.


**- A picture of a cute animal (not mandatory but encouraged)**

