### PR TITLE
[20.10] vendor: update containerd to latest of docker-20.10 branch

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -132,7 +132,7 @@ github.com/googleapis/gax-go                        bd5b16380fd03dc758d11cef74ba
 google.golang.org/genproto                          3f1135a288c9a07e340ae8ba4cc6c7065a3160e8
 
 # containerd
-github.com/containerd/containerd                    7cfa023d95d37076d5ab035003d4839f4b6ba791 https://github.com/moby/containerd.git # master (v1.5.0-dev) + patch for CVE-2021-41190 and CVE-2022-24769
+github.com/containerd/containerd                    96c5ae04b6784e180aaeee50fba715ac448ddb0d https://github.com/moby/containerd.git # docker-20.10 branch
 github.com/containerd/fifo                          0724c46b320cf96bb172a0550c19a4b1fca4dacb
 github.com/containerd/continuity                    5ad51c7aca47b8e742f5e6e7dc841d50f5f6affd # v0.3.0
 github.com/containerd/cgroups                       b9de8a2212026c07cec67baf3323f1fc0121e048 # v1.0.1 

--- a/vendor/github.com/containerd/containerd/remotes/docker/resolver.go
+++ b/vendor/github.com/containerd/containerd/remotes/docker/resolver.go
@@ -521,7 +521,10 @@ func (r *request) do(ctx context.Context) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header = r.header
+	req.Header = http.Header{} // headers need to be copied to avoid concurrent map access
+	for k, v := range r.header {
+		req.Header[k] = v
+	}
 	if r.body != nil {
 		body, err := r.body()
 		if err != nil {


### PR DESCRIPTION
- depends on https://github.com/moby/containerd/pull/2
- fixes https://github.com/containerd/containerd/issues/4795
- fixes https://github.com/moby/buildkit/issues/1867
- fixes https://github.com/moby/buildkit/issues/1983

Backports:

- https://github.com/containerd/containerd/pull/4719
- https://github.com/containerd/containerd/pull/5076
- https://github.com/containerd/containerd/pull/4855



This brings the containerd vendoring up-to-date with the latest changes from
the docker-20.10 branch in our fork (https://github.com/moby/containerd). This
adds some fixes that were included in another fork that was used in the BuildKit
repository, which have now been ported to our fork as well.

Relevant changes:

- docker: avoid concurrent map access panic
- overlay: support "userxattr" option (kernel 5.11) (does not affect vendored code)

full diff: https://github.com/moby/containerd/compare/7cfa023d95d37076d5ab035003d4839f4b6ba791...96c5ae04b6784e180aaeee50fba715ac448ddb0d


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

