### PR TITLE
daemon: set containerd default snapshotter if none is configured

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -979,6 +979,11 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	}
 
 	if d.UsesSnapshotter() {
+		// FIXME(thaJeztah): implement automatic snapshotter-selection similar to graph-driver selection; see https://github.com/moby/moby/issues/44076
+		if driverName == "" {
+			driverName = containerd.DefaultSnapshotter
+		}
+
 		// Configure and validate the kernels security support. Note this is a Linux/FreeBSD
 		// operation only, so it is safe to pass *just* the runtime OS graphdriver.
 		if err := configureKernelSecuritySupport(config, driverName); err != nil {


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/43983
- upstreaming https://github.com/rumpl/moby/pull/79


This is a temporary workaround for the daemon not yet having automatic
selection of snapshotters.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

