### PR TITLE
[20.10 backport] vendor: update tar-split to v0.11.2

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -79,7 +79,7 @@ github.com/modern-go/reflect2                       94122c33edd36123c84d5368cfb2
 
 # get graph and distribution packages
 github.com/docker/distribution                      b5ca020cfbe998e5af3457fda087444cf5116496 # v2.8.1
-github.com/vbatts/tar-split                         620714a4c508c880ac1bdda9c8370a2b19af1a55 # v0.11.1
+github.com/vbatts/tar-split                         80a436fd6164c557b131f7c59ed69bd81af69761 # v0.11.2
 github.com/opencontainers/go-digest                 ea51bea511f75cfa3ef6098cc253c5c3609b037a # v1.0.0
 
 # get go-zfs packages

--- a/vendor/github.com/vbatts/tar-split/go.mod
+++ b/vendor/github.com/vbatts/tar-split/go.mod
@@ -1,0 +1,8 @@
+module github.com/vbatts/tar-split
+
+go 1.15
+
+require (
+	github.com/sirupsen/logrus v1.7.0
+	github.com/urfave/cli v1.22.4
+)

--- a/vendor/github.com/vbatts/tar-split/tar/storage/getter.go
+++ b/vendor/github.com/vbatts/tar-split/tar/storage/getter.go
@@ -92,11 +92,12 @@ func NewDiscardFilePutter() FilePutter {
 }
 
 type bitBucketFilePutter struct {
+	buffer [32 * 1024]byte // 32 kB is the buffer size currently used by io.Copy, as of August 2021.
 }
 
 func (bbfp *bitBucketFilePutter) Put(name string, r io.Reader) (int64, []byte, error) {
 	c := crc64.New(CRCTable)
-	i, err := io.Copy(c, r)
+	i, err := io.CopyBuffer(c, r, bbfp.buffer[:])
 	return i, c.Sum(nil), err
 }
 


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/42780
- brings in https://github.com/vbatts/tar-split/pull/54
- relates to https://github.com/moby/moby/issues/44074


(cherry picked from commit 21faae85ee8ecb4730e97083dd8605ae9534227e)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

