### PR TITLE
pkg/archive: remove backward compat hack for go < 1.9

### DIFF
--- a/builder/remotecontext/tarsum_test.go
+++ b/builder/remotecontext/tarsum_test.go
@@ -60,7 +60,7 @@ func TestHashFile(t *testing.T) {
 		t.Fatalf("Hash returned empty sum")
 	}
 
-	expected := "1149ab94af7be6cc1da1335e398f24ee1cf4926b720044d229969dfc248ae7ec"
+	expected := "55dfeb344351ab27f59aa60ebb0ed12025a2f2f4677bf77d26ea7a671274a9ca"
 
 	if actual := sum; expected != actual {
 		t.Fatalf("invalid checksum. expected %s, got %s", expected, actual)
@@ -97,7 +97,7 @@ func TestHashSubdir(t *testing.T) {
 		t.Fatalf("Hash returned empty sum")
 	}
 
-	expected := "d7f8d6353dee4816f9134f4156bf6a9d470fdadfb5d89213721f7e86744a4e69"
+	expected := "74a3326b8e766ce63a8e5232f22e9dd895be647fb3ca7d337e5e0a9b3da8ef28"
 
 	if actual := sum; expected != actual {
 		t.Fatalf("invalid checksum. expected %s, got %s", expected, actual)

--- a/pkg/archive/archive_windows.go
+++ b/pkg/archive/archive_windows.go
@@ -31,14 +31,8 @@ func CanonicalTarNameForPath(p string) string {
 // chmodTarEntry is used to adjust the file permissions used in tar header based
 // on the platform the archival is done.
 func chmodTarEntry(perm os.FileMode) os.FileMode {
-	// perm &= 0755 // this 0-ed out tar flags (like link, regular file, directory marker etc.)
-	permPart := perm & os.ModePerm
-	noPermPart := perm &^ os.ModePerm
-	// Add the x bit: make everything +x from windows
-	permPart |= 0111
-	permPart &= 0755
-
-	return noPermPart | permPart
+	// Add the x bit: make everything +x on Windows
+	return perm | 0111
 }
 
 func setHeaderForSpecialDevice(hdr *tar.Header, name string, stat interface{}) (err error) {

--- a/pkg/archive/archive_windows.go
+++ b/pkg/archive/archive_windows.go
@@ -31,8 +31,11 @@ func CanonicalTarNameForPath(p string) string {
 // chmodTarEntry is used to adjust the file permissions used in tar header based
 // on the platform the archival is done.
 func chmodTarEntry(perm os.FileMode) os.FileMode {
+	// Remove group- and world-writable bits.
+	perm &= 0o755
+
 	// Add the x bit: make everything +x on Windows
-	return perm | 0111
+	return perm | 0o111
 }
 
 func setHeaderForSpecialDevice(hdr *tar.Header, name string, stat interface{}) (err error) {

--- a/pkg/archive/archive_windows_test.go
+++ b/pkg/archive/archive_windows_test.go
@@ -71,12 +71,10 @@ func TestChmodTarEntry(t *testing.T) {
 		in, expected os.FileMode
 	}{
 		{0000, 0111},
-		{0777, 0755},
+		{0777, 0777},
 		{0644, 0755},
 		{0755, 0755},
 		{0444, 0555},
-		{0755 | os.ModeDir, 0755 | os.ModeDir},
-		{0755 | os.ModeSymlink, 0755 | os.ModeSymlink},
 	}
 	for _, v := range cases {
 		if out := chmodTarEntry(v.in); out != v.expected {

--- a/pkg/archive/archive_windows_test.go
+++ b/pkg/archive/archive_windows_test.go
@@ -71,7 +71,7 @@ func TestChmodTarEntry(t *testing.T) {
 		in, expected os.FileMode
 	}{
 		{0000, 0111},
-		{0777, 0777},
+		{0777, 0755},
 		{0644, 0755},
 		{0755, 0755},
 		{0444, 0555},


### PR DESCRIPTION
- reverts https://github.com/moby/moby/pull/33935
- reverts https://github.com/moby/moby/pull/32959
- relates to https://github.com/moby/moby/pull/11148
- relates to https://github.com/moby/buildkit/pull/152


The fillGo18FileTypeBits func was added in 1a451d9a7bb9cd7d437b42d4e73b0560fbf84348 (https://github.com/moby/moby/pull/33935)
to keep the tar headers consistent with headers created with go1.8 and older.

go1.8 and older incorrectly preserved all file-mode bits, including file-type,
instead of stripping those bits and only preserving the _permission_ bits, as
defined in;

- the GNU tar spec: https://www.gnu.org/software/tar/manual/html_node/Standard.html
- and POSIX: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/tar.h.html

We decided at the time to copy the "wrong" behavior to prevent a cache-bust and
to keep the archives identical, however:

- It's not matching the standards, which causes differences between our tar
  implementation and the standard tar implementations, as well as implementations
  in other languages, such as Python (see docker/compose#883).
- BuildKit does not implement this hack.
- We don't _need_ this extra information (as it's already preserved in the
  type header; https://pkg.go.dev/archive/tar#pkg-constants

In short; let's remove this hack.

This reverts commit 1a451d9a7bb9cd7d437b42d4e73b0560fbf84348.
This reverts commit 41eb61d5c2a44c745b11ada948034fd3bcc42db5.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

