### PR TITLE
namesgenerator: remove Valentina Tereshkova

### DIFF
--- a/pkg/namesgenerator/names-generator.go
+++ b/pkg/namesgenerator/names-generator.go
@@ -769,9 +769,6 @@ var (
 		// Helen Brooke Taussig - American cardiologist and founder of the field of paediatric cardiology. https://en.wikipedia.org/wiki/Helen_B._Taussig
 		"taussig",
 
-		// Valentina Tereshkova is a Russian engineer, cosmonaut and politician. She was the first woman to fly to space in 1963. In 2013, at the age of 76, she offered to go on a one-way mission to Mars. https://en.wikipedia.org/wiki/Valentina_Tereshkova
-		"tereshkova",
-
 		// Nikola Tesla invented the AC electric system and every gadget ever used by a James Bond villain. https://en.wikipedia.org/wiki/Nikola_Tesla
 		"tesla",
 


### PR DESCRIPTION
- addresses https://github.com/moby/moby/discussions/43851

While the name generator has been frozen for new additions in 624b3cfbe8dc2abfa7 (https://github.com/moby/moby/pull/43210), this person has become controversial. Our intent is for this list to be inclusive and non-controversial.

This patch removes the name from the list.

