### PR TITLE
[22.06 backport] fix various linting issues in preparation of golangci-lint update

### DIFF
--- a/contrib/httpserver/server.go
+++ b/contrib/httpserver/server.go
@@ -8,5 +8,5 @@ import (
 func main() {
 	fs := http.FileServer(http.Dir("/static"))
 	http.Handle("/", fs)
-	log.Panic(http.ListenAndServe(":80", nil))
+	log.Panic(http.ListenAndServe(":80", nil)) // #nosec G114 -- Ignoring for test-code: G114: Use of net/http serve function that has no support for setting timeouts (gosec)
 }

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -542,7 +542,7 @@ func (s *DockerDaemonSuite) TestDaemonAllocatesListeningPort(c *testing.T) {
 
 	cmdArgs := make([]string, 0, len(listeningPorts)*2)
 	for _, l := range listeningPorts {
-		cmdArgs = append(cmdArgs, "--tls=false", "--host", fmt.Sprintf("tcp://%s:%s", l.daemon, l.port))
+		cmdArgs = append(cmdArgs, "--tls=false", "--host", "tcp://"+net.JoinHostPort(l.daemon, l.port))
 	}
 
 	s.d.StartWithBusybox(c, cmdArgs...)

--- a/integration/plugin/logging/cmd/close_on_start/main.go
+++ b/integration/plugin/logging/cmd/close_on_start/main.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"time"
 )
 
 type start struct {
@@ -40,8 +41,9 @@ func main() {
 		fmt.Fprintln(w, `{}`)
 	})
 	server := http.Server{
-		Addr:    l.Addr().String(),
-		Handler: mux,
+		Addr:              l.Addr().String(),
+		Handler:           mux,
+		ReadHeaderTimeout: 2 * time.Second, // This server is not for production code; picked an arbitrary timeout to statisfy gosec (G112: Potential Slowloris Attack)
 	}
 
 	server.Serve(l)

--- a/integration/plugin/logging/cmd/discard/main.go
+++ b/integration/plugin/logging/cmd/discard/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net"
 	"net/http"
+	"time"
 )
 
 func main() {
@@ -15,8 +16,9 @@ func main() {
 	handle(mux)
 
 	server := http.Server{
-		Addr:    l.Addr().String(),
-		Handler: mux,
+		Addr:              l.Addr().String(),
+		Handler:           mux,
+		ReadHeaderTimeout: 2 * time.Second, // This server is not for production code; picked an arbitrary timeout to statisfy gosec (G112: Potential Slowloris Attack)
 	}
 	server.Serve(l)
 }

--- a/integration/plugin/logging/cmd/dummy/main.go
+++ b/integration/plugin/logging/cmd/dummy/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net"
 	"net/http"
+	"time"
 )
 
 func main() {
@@ -12,8 +13,9 @@ func main() {
 	}
 
 	server := http.Server{
-		Addr:    l.Addr().String(),
-		Handler: http.NewServeMux(),
+		Addr:              l.Addr().String(),
+		Handler:           http.NewServeMux(),
+		ReadHeaderTimeout: 2 * time.Second, // This server is not for production code; picked an arbitrary timeout to statisfy gosec (G112: Potential Slowloris Attack)
 	}
 	server.Serve(l)
 }

--- a/integration/plugin/volumes/cmd/dummy/main.go
+++ b/integration/plugin/volumes/cmd/dummy/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net"
 	"net/http"
+	"time"
 )
 
 func main() {
@@ -12,8 +13,9 @@ func main() {
 	}
 
 	server := http.Server{
-		Addr:    l.Addr().String(),
-		Handler: http.NewServeMux(),
+		Addr:              l.Addr().String(),
+		Handler:           http.NewServeMux(),
+		ReadHeaderTimeout: 2 * time.Second, // This server is not for production code; picked an arbitrary timeout to statisfy gosec (G112: Potential Slowloris Attack)
 	}
 	server.Serve(l)
 }

--- a/libnetwork/diagnostic/server.go
+++ b/libnetwork/diagnostic/server.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"strconv"
 	"sync"
 	"sync/atomic"
 
@@ -91,7 +93,10 @@ func (s *Server) EnableDiagnostic(ip string, port int) {
 	}
 
 	logrus.Infof("Starting the diagnostic server listening on %d for commands", port)
-	srv := &http.Server{Addr: fmt.Sprintf("%s:%d", ip, port), Handler: s}
+	srv := &http.Server{
+		Addr:    net.JoinHostPort(ip, strconv.Itoa(port)),
+		Handler: s,
+	}
 	s.srv = srv
 	s.enable = 1
 	go func(n *Server) {

--- a/libnetwork/networkdb/cluster.go
+++ b/libnetwork/networkdb/cluster.go
@@ -718,7 +718,7 @@ func randomOffset(n int) int {
 		return 0
 	}
 
-	val, err := rand.Int(rand.Reader, big.NewInt(int64(n)))
+	val, err := rand.Int(rand.Reader, big.NewInt(int64(n))) // #nosec G404 -- False positive; see https://github.com/securego/gosec/issues/862
 	if err != nil {
 		logrus.Errorf("Failed to get a random offset: %v", err)
 		return 0

--- a/opts/hosts_test.go
+++ b/opts/hosts_test.go
@@ -32,7 +32,7 @@ func TestParseHost(t *testing.T) {
 		"tcp://host:":              fmt.Sprintf("tcp://host:%d", DefaultHTTPPort),
 		"tcp://":                   DefaultTCPHost,
 		"tcp://:":                  DefaultTCPHost,
-		"tcp://:5555":              fmt.Sprintf("tcp://%s:5555", DefaultHTTPHost),
+		"tcp://:5555":              fmt.Sprintf("tcp://%s:5555", DefaultHTTPHost), //nolint:nosprintfhostport // sprintf is more readable for this case.
 		"tcp://[::1]":              fmt.Sprintf(`tcp://[::1]:%d`, DefaultHTTPPort),
 		"tcp://[::1]:":             fmt.Sprintf(`tcp://[::1]:%d`, DefaultHTTPPort),
 		"tcp://[::1]:5555":         `tcp://[::1]:5555`,
@@ -88,7 +88,7 @@ func TestParseDockerDaemonHost(t *testing.T) {
 	}
 	valids := map[string]string{
 		":":                       DefaultTCPHost,
-		":5555":                   fmt.Sprintf("tcp://%s:5555", DefaultHTTPHost),
+		":5555":                   fmt.Sprintf("tcp://%s:5555", DefaultHTTPHost), //nolint:nosprintfhostport // sprintf is more readable for this case.
 		"0.0.0.1:":                fmt.Sprintf("tcp://0.0.0.1:%d", DefaultHTTPPort),
 		"0.0.0.1:5555":            "tcp://0.0.0.1:5555",
 		"[::1]":                   fmt.Sprintf("tcp://[::1]:%d", DefaultHTTPPort),

--- a/testutil/fixtures/plugin/basic/basic.go
+++ b/testutil/fixtures/plugin/basic/basic.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 func main() {
@@ -23,8 +24,9 @@ func main() {
 
 	mux := http.NewServeMux()
 	server := http.Server{
-		Addr:    l.Addr().String(),
-		Handler: http.NewServeMux(),
+		Addr:              l.Addr().String(),
+		Handler:           http.NewServeMux(),
+		ReadHeaderTimeout: 2 * time.Second, // This server is not for production code; picked an arbitrary timeout to statisfy gosec (G112: Potential Slowloris Attack)
 	}
 	mux.HandleFunc("/Plugin.Activate", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1.1+json")

--- a/volume/testutils/testutils.go
+++ b/volume/testutils/testutils.go
@@ -167,7 +167,7 @@ func MakeFakePlugin(d volume.Driver, l net.Listener) (plugingetter.CompatPlugin,
 		w.Write([]byte("{}"))
 	})
 
-	go http.Serve(l, mux)
+	go http.Serve(l, mux) // #nosec G114 -- Ignoring for test-code: G114: Use of net/http serve function that has no support for setting timeouts (gosec)
 	return &fakePlugin{client: c, name: d.Name()}, nil
 }
 


### PR DESCRIPTION
See individual commits for details

- relates to https://github.com/moby/moby/pull/44089
- backport of https://github.com/moby/moby/pull/44090
 