### PR TITLE
[22.06 backport] vendor: github.com/docker/go-units v0.5.0

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -30,7 +30,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c
 	github.com/docker/go-metrics v0.0.1
-	github.com/docker/go-units v0.4.0
+	github.com/docker/go-units v0.5.0
 	github.com/docker/libkv v0.2.2-0.20211217103745-e480589147e3
 	github.com/docker/libtrust v0.0.0-20150526203908-9cbd2a1374f4
 	github.com/fluent/fluent-logger-golang v1.9.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -374,8 +374,9 @@ github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c/go.mod h1:Uw6Uezg
 github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916/go.mod h1:/u0gXw0Gay3ceNrsHubL3BtdOL2fHf93USgMTe0W5dI=
 github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQV8=
 github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
-github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
+github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/libkv v0.2.2-0.20211217103745-e480589147e3 h1:q6MhOaE4xsrl6cAiFYrazobNFSQN6ckhD6Et9zYbcrU=
 github.com/docker/libkv v0.2.2-0.20211217103745-e480589147e3/go.mod h1:r5hEwHwW8dr0TFBYGCarMNbrQOiwL1xoqDYZ/JqoTK0=
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=

--- a/vendor/github.com/docker/go-units/size.go
+++ b/vendor/github.com/docker/go-units/size.go
@@ -2,7 +2,6 @@ package units
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 )
@@ -26,16 +25,17 @@ const (
 	PiB = 1024 * TiB
 )
 
-type unitMap map[string]int64
+type unitMap map[byte]int64
 
 var (
-	decimalMap = unitMap{"k": KB, "m": MB, "g": GB, "t": TB, "p": PB}
-	binaryMap  = unitMap{"k": KiB, "m": MiB, "g": GiB, "t": TiB, "p": PiB}
-	sizeRegex  = regexp.MustCompile(`^(\d+(\.\d+)*) ?([kKmMgGtTpP])?[iI]?[bB]?$`)
+	decimalMap = unitMap{'k': KB, 'm': MB, 'g': GB, 't': TB, 'p': PB}
+	binaryMap  = unitMap{'k': KiB, 'm': MiB, 'g': GiB, 't': TiB, 'p': PiB}
 )
 
-var decimapAbbrs = []string{"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}
-var binaryAbbrs = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"}
+var (
+	decimapAbbrs = []string{"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}
+	binaryAbbrs  = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"}
+)
 
 func getSizeAndUnit(size float64, base float64, _map []string) (float64, string) {
 	i := 0
@@ -89,20 +89,66 @@ func RAMInBytes(size string) (int64, error) {
 
 // Parses the human-readable size string into the amount it represents.
 func parseSize(sizeStr string, uMap unitMap) (int64, error) {
-	matches := sizeRegex.FindStringSubmatch(sizeStr)
-	if len(matches) != 4 {
+	// TODO: rewrite to use strings.Cut if there's a space
+	// once Go < 1.18 is deprecated.
+	sep := strings.LastIndexAny(sizeStr, "01234567890. ")
+	if sep == -1 {
+		// There should be at least a digit.
 		return -1, fmt.Errorf("invalid size: '%s'", sizeStr)
 	}
+	var num, sfx string
+	if sizeStr[sep] != ' ' {
+		num = sizeStr[:sep+1]
+		sfx = sizeStr[sep+1:]
+	} else {
+		// Omit the space separator.
+		num = sizeStr[:sep]
+		sfx = sizeStr[sep+1:]
+	}
 
-	size, err := strconv.ParseFloat(matches[1], 64)
+	size, err := strconv.ParseFloat(num, 64)
 	if err != nil {
 		return -1, err
 	}
+	// Backward compatibility: reject negative sizes.
+	if size < 0 {
+		return -1, fmt.Errorf("invalid size: '%s'", sizeStr)
+	}
 
-	unitPrefix := strings.ToLower(matches[3])
-	if mul, ok := uMap[unitPrefix]; ok {
+	if len(sfx) == 0 {
+		return int64(size), nil
+	}
+
+	// Process the suffix.
+
+	if len(sfx) > 3 { // Too long.
+		goto badSuffix
+	}
+	sfx = strings.ToLower(sfx)
+	// Trivial case: b suffix.
+	if sfx[0] == 'b' {
+		if len(sfx) > 1 { // no extra characters allowed after b.
+			goto badSuffix
+		}
+		return int64(size), nil
+	}
+	// A suffix from the map.
+	if mul, ok := uMap[sfx[0]]; ok {
 		size *= float64(mul)
+	} else {
+		goto badSuffix
+	}
+
+	// The suffix may have extra "b" or "ib" (e.g. KiB or MB).
+	switch {
+	case len(sfx) == 2 && sfx[1] != 'b':
+		goto badSuffix
+	case len(sfx) == 3 && sfx[1:] != "ib":
+		goto badSuffix
 	}
 
 	return int64(size), nil
+
+badSuffix:
+	return -1, fmt.Errorf("invalid suffix: '%s'", sfx)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -302,7 +302,7 @@ github.com/docker/go-events
 # github.com/docker/go-metrics v0.0.1
 ## explicit; go 1.11
 github.com/docker/go-metrics
-# github.com/docker/go-units v0.4.0
+# github.com/docker/go-units v0.5.0
 ## explicit
 github.com/docker/go-units
 # github.com/docker/libkv v0.2.2-0.20211217103745-e480589147e3


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44072

full diff: https://github.com/docker/go-units/compare/v0.4.0...v0.5.0

(cherry picked from commit 13f99eb65f5b96b58f9791495fb4a579c6b0afb1)


**- A picture of a cute animal (not mandatory but encouraged)**

