### PR TITLE
prefer Errorf for errors with parameters

### DIFF
--- a/api/types/filters/parse.go
+++ b/api/types/filters/parse.go
@@ -262,7 +262,7 @@ func (invalidFilter) InvalidParameter() {}
 func (args Args) Validate(accepted map[string]bool) error {
 	for name := range args.fields {
 		if !accepted[name] {
-			return invalidFilter{errors.New("invalid filter '" + name + "'")}
+			return invalidFilter{errors.Errorf("invalid filter '%s'", name)}
 		}
 	}
 	return nil

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -721,7 +721,7 @@ func sysctlExists(s string) bool {
 func WithCommonOptions(daemon *Daemon, c *container.Container) coci.SpecOpts {
 	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
 		if c.BaseFS == nil && !daemon.UsesSnapshotter() {
-			return errors.New("populateCommonSpec: BaseFS of container " + c.ID + " is unexpectedly nil")
+			return errors.Errorf("populateCommonSpec: BaseFS of container %s is unexpectedly nil", c.ID)
 		}
 		linkedEnv, err := daemon.setupLinkedContainers(c)
 		if err != nil {

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -236,7 +236,7 @@ func (daemon *Daemon) createSpecWindowsFields(c *container.Container, s *specs.S
 	s.Root.Readonly = false // Windows does not support a read-only root filesystem
 	if !isHyperV {
 		if c.BaseFS == nil {
-			return errors.New("createSpecWindowsFields: BaseFS of container " + c.ID + " is unexpectedly nil")
+			return errors.Errorf("createSpecWindowsFields: BaseFS of container %s is unexpectedly nil", c.ID)
 		}
 
 		s.Root.Path = c.BaseFS.Path() // This is not set for Hyper-V containers

--- a/pkg/archive/copy.go
+++ b/pkg/archive/copy.go
@@ -2,13 +2,13 @@ package archive // import "github.com/docker/docker/pkg/archive"
 
 import (
 	"archive/tar"
-	"errors"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/docker/docker/pkg/system"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -186,7 +186,7 @@ func CopyInfoDestinationPath(path string) (info CopyInfo, err error) {
 	for n := 0; err == nil && stat.Mode()&os.ModeSymlink != 0; n++ {
 		if n > maxSymlinkIter {
 			// Don't follow symlinks more than this arbitrary number of times.
-			return CopyInfo{}, errors.New("too many symlinks in " + originalPath)
+			return CopyInfo{}, errors.Errorf("too many symlinks in %s", originalPath)
 		}
 
 		// The path is a symbolic link. We need to evaluate it so that the

--- a/pkg/parsers/kernel/kernel.go
+++ b/pkg/parsers/kernel/kernel.go
@@ -6,8 +6,9 @@
 package kernel // import "github.com/docker/docker/pkg/parsers/kernel"
 
 import (
-	"errors"
 	"fmt"
+
+	"github.com/pkg/errors"
 )
 
 // VersionInfo holds information about the kernel.
@@ -57,7 +58,7 @@ func ParseRelease(release string) (*VersionInfo, error) {
 	// make sure we got all the version numbers.
 	parsed, _ = fmt.Sscanf(release, "%d.%d%s", &kernel, &major, &partial)
 	if parsed < 2 {
-		return nil, errors.New("Can't parse kernel version " + release)
+		return nil, errors.Errorf("Can't parse kernel version %s", release)
 	}
 
 	// sometimes we have 3.12.25-gentoo, but sometimes we just have 3.12-1-amd64


### PR DESCRIPTION
**- What I did**
used pkg/errors so we can rely on errors.Errorf to format error message, passing parameters
