### PR TITLE
api/server/backend/build: remove Tagger and NewTagger

### DIFF
--- a/api/server/backend/build/backend.go
+++ b/api/server/backend/build/backend.go
@@ -54,7 +54,7 @@ func (b *Backend) Build(ctx context.Context, config backend.BuildConfig) (string
 	options := config.Options
 	useBuildKit := options.Version == types.BuilderBuildKit
 
-	tagger, err := NewTagger(b.imageComponent, config.ProgressWriter.StdoutFormatter, options.Tags)
+	tags, err := sanitizeRepoAndTags(options.Tags)
 	if err != nil {
 		return "", err
 	}
@@ -93,7 +93,7 @@ func (b *Backend) Build(ctx context.Context, config backend.BuildConfig) (string
 		fmt.Fprintf(stdout, "Successfully built %s\n", stringid.TruncateID(imageID))
 	}
 	if imageID != "" {
-		err = tagger.TagImages(image.ID(imageID))
+		err = tagImages(b.imageComponent, config.ProgressWriter.StdoutFormatter, image.ID(imageID), tags)
 	}
 	return imageID, err
 }

--- a/api/server/backend/build/tag.go
+++ b/api/server/backend/build/tag.go
@@ -9,34 +9,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Tagger is responsible for tagging an image created by a builder
-type Tagger struct {
-	imageComponent ImageComponent
-	stdout         io.Writer
-	repoAndTags    []reference.Named
-}
-
-// NewTagger returns a new Tagger for tagging the images of a build.
-// If any of the names are invalid tags an error is returned.
-func NewTagger(backend ImageComponent, stdout io.Writer, names []string) (*Tagger, error) {
-	reposAndTags, err := sanitizeRepoAndTags(names)
-	if err != nil {
-		return nil, err
-	}
-	return &Tagger{
-		imageComponent: backend,
-		stdout:         stdout,
-		repoAndTags:    reposAndTags,
-	}, nil
-}
-
-// TagImages creates image tags for the imageID
-func (bt *Tagger) TagImages(imageID image.ID) error {
-	for _, rt := range bt.repoAndTags {
-		if err := bt.imageComponent.TagImageWithReference(imageID, rt); err != nil {
+// tagImages creates image tags for the imageID.
+func tagImages(ic ImageComponent, stdout io.Writer, imageID image.ID, repoAndTags []reference.Named) error {
+	for _, rt := range repoAndTags {
+		if err := ic.TagImageWithReference(imageID, rt); err != nil {
 			return err
 		}
-		fmt.Fprintf(bt.stdout, "Successfully tagged %s\n", reference.FamiliarString(rt))
+		_, _ = fmt.Fprintln(stdout, "Successfully tagged", reference.FamiliarString(rt))
 	}
 	return nil
 }


### PR DESCRIPTION
The Tagger was introduced in 0296797f0f39477d675128c93c1646b3186937ee (https://github.com/moby/moby/pull/32610), as part of a refactor, but was never used outside of the package itself. The commit also didn't explain why this was changed into a Type with a constructor, as all the constructor appears to be used for is to sanitize and validate the tags.

This patch removes the `Tagger` struct and its constructor, and instead just uses a function to do the same.



**- A picture of a cute animal (not mandatory but encouraged)**

