### PR TITLE
  Dockerfile: variant support in frozen-images stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,9 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
         && git checkout -q "$GO_SWAGGER_COMMIT" \
         && go build -o /build/swagger github.com/go-swagger/go-swagger/cmd/swagger
 
+# frozen-images
+# See also frozenImages in "testutil/environment/protect.go" (which needs to
+# be updated when adding images to this list)
 FROM debian:${BASE_DEBIAN_DISTRO} AS frozen-images
 ARG DEBIAN_FRONTEND
 RUN --mount=type=cache,sharing=locked,id=moby-frozen-images-aptlib,target=/var/lib/apt \
@@ -85,13 +88,13 @@ RUN --mount=type=cache,sharing=locked,id=moby-frozen-images-aptlib,target=/var/l
 # Get useful and necessary Hub images so we can "docker load" locally instead of pulling
 COPY contrib/download-frozen-image-v2.sh /
 ARG TARGETARCH
+ARG TARGETVARIANT
 RUN /download-frozen-image-v2.sh /build \
         busybox:latest@sha256:95cf004f559831017cdf4628aaf1bb30133677be8702a8c5f2994629f637a209 \
         busybox:glibc@sha256:1f81263701cddf6402afe9f33fca0266d9fff379e59b1748f33d3072da71ee85 \
         debian:bullseye-slim@sha256:dacf278785a4daa9de07596ec739dbc07131e189942772210709c5c0777e8437 \
         hello-world:latest@sha256:d58e752213a51785838f9eed2b7a498ffa1cb3aa7f946dda11af39286c3db9a9 \
         arm32v7/hello-world:latest@sha256:50b8560ad574c779908da71f7ce370c0a2471c098d44d1c8f6b513c5a55eeeb1
-# See also frozenImages in "testutil/environment/protect.go" (which needs to be updated when adding images to this list)
 
 FROM base AS cross-false
 

--- a/contrib/download-frozen-image-v2.sh
+++ b/contrib/download-frozen-image-v2.sh
@@ -261,6 +261,10 @@ get_target_arch() {
 	echo amd64
 }
 
+get_target_variant() {
+	echo "${TARGETVARIANT:-}"
+}
+
 while [ $# -gt 0 ]; do
 	imageTag="$1"
 	shift
@@ -311,11 +315,13 @@ while [ $# -gt 0 ]; do
 
 					found=""
 					targetArch="$(get_target_arch)"
+					targetVariant="$(get_target_variant)"
 					# parse first level multi-arch manifest
 					for i in "${!layers[@]}"; do
 						layerMeta="${layers[$i]}"
 						maniArch="$(echo "$layerMeta" | jq --raw-output '.platform.architecture')"
-						if [ "$maniArch" = "${targetArch}" ]; then
+						maniVariant="$(echo "$layerMeta" | jq --raw-output '.platform.variant')"
+						if [[ "$maniArch" = "${targetArch}" ]] && [[ -z "${targetVariant}" || "$maniVariant" = "${targetVariant}" ]]; then
 							digest="$(echo "$layerMeta" | jq --raw-output '.digest')"
 							# get second level single manifest
 							submanifestJson="$(
@@ -332,7 +338,7 @@ while [ $# -gt 0 ]; do
 						fi
 					done
 					if [ -z "$found" ]; then
-						echo >&2 "error: manifest for $maniArch is not found"
+						echo >&2 "error: manifest for ${targetArch}${targetVariant:+/${targetVariant}} is not found"
 						exit 1
 					fi
 					;;


### PR DESCRIPTION
closes #44005
related #43529
~needs #44034 (for testing)~

**- What I did**

using `TARGETVARIANT` in frozen-images stage implies changes in `download-frozen-image-v2.sh` script to add support for variants so we are able to build against more platforms.

looking at others issues in this repo, this script seems to be used outside the Dockerfile. I didn't  check this case. If it's relevant to also check that then I think using scopeo in the Dockerfile is a better alternative: https://github.com/moby/moby/pull/44005

**- How I did it**

**- How to verify it**

```
$ docker buildx build --platform linux/arm/v7 --target frozen-images .
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

