### PR TITLE
ci(test): validate job matrix

### DIFF
--- a/.github/workflows/.dco.yml
+++ b/.github/workflows/.dco.yml
@@ -1,0 +1,48 @@
+# reusable workflow
+name: .dco
+
+# TODO: hide reusable workflow from the UI. Tracked in https://github.com/community/community/discussions/12025
+
+on:
+  workflow_call:
+
+env:
+  ALPINE_VERSION: 3.16
+
+jobs:
+  run:
+    runs-on: ubuntu-20.04
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        name: Dump context
+        uses: actions/github-script@v6
+        with:
+          script: |
+            console.log(JSON.stringify(context, null, 2));
+      -
+        name: Get base ref
+        id: base-ref
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            if (/^refs\/pull\//.test(context.ref) && context.payload?.pull_request?.base?.ref != undefined) {
+              return context.payload.pull_request.base.ref;
+            }
+            return context.ref.replace(/^refs\/heads\//g, '');
+      -
+        name: Validate
+        run: |
+          docker run --rm \
+            -v "$(pwd):/workspace" \
+            -e VALIDATE_REPO \
+            -e VALIDATE_BRANCH \
+            alpine:${{ env.ALPINE_VERSION }} sh -c 'apk add --no-cache -q bash git openssh-client && git config --system --add safe.directory /workspace && cd /workspace && hack/validate/dco'
+        env:
+          VALIDATE_REPO: ${{ github.server_url }}/${{ github.repository }}.git
+          VALIDATE_BRANCH: ${{ steps.base-ref.outputs.result }}

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -1,6 +1,8 @@
 # reusable workflow
 name: .windows
 
+# TODO: hide reusable workflow from the UI. Tracked in https://github.com/community/community/discussions/12025
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -16,8 +16,13 @@ env:
   BUNDLES_OUTPUT: ./bundles
 
 jobs:
+  validate-dco:
+    uses: ./.github/workflows/.dco.yml
+
   build:
     runs-on: ubuntu-20.04
+    needs:
+      - validate-dco
     steps:
       -
         name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,13 @@ env:
   BUNDLES_OUTPUT: ./bundles
 
 jobs:
+  validate-dco:
+    uses: ./.github/workflows/.dco.yml
+
   build:
     runs-on: ubuntu-20.04
+    needs:
+      - validate-dco
     strategy:
       fail-fast: false
       matrix:
@@ -54,6 +59,8 @@ jobs:
 
   cross:
     runs-on: ubuntu-20.04
+    needs:
+      - validate-dco
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,10 +55,75 @@ jobs:
             *.cache-to=type=gha,scope=dev${{ matrix.mode }},mode=max
             *.output=type=cacheonly
 
+  validate:
+    runs-on: ubuntu-20.04
+    needs:
+      - build-dev
+    strategy:
+      fail-fast: true
+      matrix:
+        script:
+          - dco
+          - default-seccomp
+          - pkg-imports
+          - yamllint
+          - swagger
+          - swagger-gen
+          - toml
+          - changelog-well-formed
+          - changelog-date-descending
+          - golangci-lint
+          - shfmt
+          - vendor
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        name: Dump context
+        uses: actions/github-script@v6
+        with:
+          script: |
+            console.log(JSON.stringify(context, null, 2));
+      -
+        name: Get base ref
+        id: base-ref
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            if (/^refs\/pull\//.test(context.ref) && context.payload?.pull_request?.base?.ref != undefined) {
+              return context.payload.pull_request.base.ref;
+            }
+            return context.ref.replace(/^refs\/heads\//g, '');
+      -
+        name: Set up runner
+        uses: ./.github/actions/setup-runner
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Build dev image
+        uses: docker/bake-action@v2
+        with:
+          targets: dev
+          set: |
+            dev.cache-from=type=gha,scope=dev
+      -
+        name: Validate
+        run: |
+          make -o build validate-${{ matrix.script }}
+        env:
+          VALIDATE_REPO: ${{ github.server_url }}/${{ github.repository }}.git
+          VALIDATE_BRANCH: ${{ steps.base-ref.outputs.result }}
+
   unit:
     runs-on: ubuntu-20.04
     needs:
       - build-dev
+      - validate
     steps:
       -
         name: Checkout
@@ -108,6 +173,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
       - build-dev
+      - validate
     steps:
       -
         name: Checkout
@@ -155,6 +221,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
       - build-dev
+      - validate
     steps:
       -
         name: Checkout
@@ -183,6 +250,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs:
       - build-dev
+      - validate
     strategy:
       fail-fast: false
       matrix:
@@ -299,6 +367,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
       - build-dev
+      - validate
       - integration-cli-prepare
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,13 @@ env:
   DOCKER_GRAPHDRIVER: overlay2
 
 jobs:
+  validate-dco:
+    uses: ./.github/workflows/.dco.yml
+
   build-dev:
     runs-on: ubuntu-20.04
+    needs:
+      - validate-dco
     strategy:
       fail-fast: false
       matrix:
@@ -92,23 +97,6 @@ jobs:
         with:
           fetch-depth: 0
       -
-        name: Dump context
-        uses: actions/github-script@v6
-        with:
-          script: |
-            console.log(JSON.stringify(context, null, 2));
-      -
-        name: Get base ref
-        id: base-ref
-        uses: actions/github-script@v6
-        with:
-          result-encoding: string
-          script: |
-            if (/^refs\/pull\//.test(context.ref) && context.payload?.pull_request?.base?.ref != undefined) {
-              return context.payload.pull_request.base.ref;
-            }
-            return context.ref.replace(/^refs\/heads\//g, '');
-      -
         name: Set up runner
         uses: ./.github/actions/setup-runner
       -
@@ -125,15 +113,11 @@ jobs:
         name: Validate
         run: |
           make -o build validate-${{ matrix.script }}
-        env:
-          VALIDATE_REPO: ${{ github.server_url }}/${{ github.repository }}.git
-          VALIDATE_BRANCH: ${{ steps.base-ref.outputs.result }}
 
   unit:
     runs-on: ubuntu-20.04
     needs:
       - build-dev
-      - validate
     steps:
       -
         name: Checkout
@@ -183,7 +167,6 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
       - build-dev
-      - validate
     steps:
       -
         name: Checkout
@@ -231,7 +214,6 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
       - build-dev
-      - validate
     steps:
       -
         name: Checkout
@@ -260,7 +242,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs:
       - build-dev
-      - validate
     strategy:
       fail-fast: false
       matrix:
@@ -343,6 +324,8 @@ jobs:
 
   integration-cli-prepare:
     runs-on: ubuntu-20.04
+    needs:
+      - validate-dco
     outputs:
       matrix: ${{ steps.tests.outputs.matrix }}
     steps:
@@ -377,7 +360,6 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
       - build-dev
-      - validate
       - integration-cli-prepare
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,26 +55,36 @@ jobs:
             *.cache-to=type=gha,scope=dev${{ matrix.mode }},mode=max
             *.output=type=cacheonly
 
+  validate-prepare:
+    runs-on: ubuntu-20.04
+    needs:
+      - validate-dco
+    outputs:
+      matrix: ${{ steps.scripts.outputs.matrix }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Create matrix
+        id: scripts
+        run: |
+          scripts=$(jq -ncR '[inputs]' <<< "$(ls -I .validate -I all -I default -I dco -I golangci-lint.yml -I yamllint.yaml -A ./hack/validate/)")
+          echo "::set-output name=matrix::$scripts"
+      -
+        name: Show matrix
+        run: |
+          echo ${{ steps.scripts.outputs.matrix }}
+
   validate:
     runs-on: ubuntu-20.04
     needs:
+      - validate-prepare
       - build-dev
     strategy:
       fail-fast: true
       matrix:
-        script:
-          - dco
-          - default-seccomp
-          - pkg-imports
-          - yamllint
-          - swagger
-          - swagger-gen
-          - toml
-          - changelog-well-formed
-          - changelog-date-descending
-          - golangci-lint
-          - shfmt
-          - vendor
+        script: ${{ fromJson(needs.validate-prepare.outputs.matrix) }}
     steps:
       -
         name: Checkout

--- a/.github/workflows/windows-2019.yml
+++ b/.github/workflows/windows-2019.yml
@@ -10,7 +10,12 @@ on:
   workflow_dispatch:
 
 jobs:
+  validate-dco:
+    uses: ./.github/workflows/.dco.yml
+
   run:
+    needs:
+      - validate-dco
     uses: ./.github/workflows/.windows.yml
     with:
       os: windows-2019

--- a/.github/workflows/windows-2022.yml
+++ b/.github/workflows/windows-2022.yml
@@ -13,7 +13,12 @@ on:
   pull_request:
 
 jobs:
+  validate-dco:
+    uses: ./.github/workflows/.dco.yml
+
   run:
+    needs:
+      - validate-dco
     uses: ./.github/workflows/.windows.yml
     with:
       os: windows-2022

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all binary dynbinary build cross help install manpages run shell test test-docker-py test-integration test-unit validate win
+.PHONY: all binary dynbinary build cross help install manpages run shell test test-docker-py test-integration test-unit validate validate-% win
 
 BUILDX_VERSION ?= v0.9.1
 
@@ -246,6 +246,9 @@ test-unit: build ## run the unit tests
 
 validate: build ## validate DCO, Seccomp profile generation, gofmt,\n./pkg/ isolation, golint, tests, tomls, go vet and vendor
 	$(DOCKER_RUN_DOCKER) hack/validate/all
+
+validate-%: build ## validate specific check
+	$(DOCKER_RUN_DOCKER) hack/validate/$*
 
 win: build ## cross build the binary for windows
 	$(DOCKER_RUN_DOCKER) DOCKER_CROSSPLATFORMS=windows/amd64 hack/make.sh cross


### PR DESCRIPTION
follow-up https://github.com/moby/moby/pull/44078#discussion_r960888199

**- What I did**

adds `validate` job matrix in `test` workflow that will trigger checks in place in the Jenkinsfile atm. `fail-fast` is enabled so if one of them fails workflow will be cancelled right away and also other jobs in this workflow depends on the `validate` job to save some compute.

last commit adds a `dco` reusable workflow that will be used by our workflows so we save more compute as suggested by @neersighted.

In a follow-up we can remove validation in Jenkinsfile like https://github.com/moby/moby/pull/44078

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>