### PR TITLE
[20.10 backport] Update some tests for supplementary group permissions

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -775,7 +775,7 @@ func (s *DockerSuite) TestRunUserByIDZero(c *testing.T) {
 	if err != nil {
 		c.Fatal(err, out)
 	}
-	if !strings.Contains(out, "uid=0(root) gid=0(root) groups=10(wheel)") {
+	if !strings.Contains(out, "uid=0(root) gid=0(root) groups=0(root),10(wheel)") {
 		c.Fatalf("expected daemon user got %s", out)
 	}
 }
@@ -1075,7 +1075,7 @@ func (s *DockerSuite) TestRunGroupAdd(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "--group-add=audio", "--group-add=staff", "--group-add=777", "busybox", "sh", "-c", "id")
 
-	groupsList := "uid=0(root) gid=0(root) groups=10(wheel),29(audio),50(staff),777"
+	groupsList := "uid=0(root) gid=0(root) groups=0(root),10(wheel),29(audio),50(staff),777"
 	if actual := strings.Trim(out, "\r\n"); actual != groupsList {
 		c.Fatalf("expected output %s received %s", groupsList, actual)
 	}

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -315,7 +315,7 @@ func (s *DockerSwarmSuite) TestSwarmServiceWithGroup(c *testing.T) {
 
 	out, err = d.Cmd("exec", container, "id")
 	assert.NilError(c, err, out)
-	assert.Equal(c, strings.TrimSpace(out), "uid=0(root) gid=0(root) groups=10(wheel),29(audio),50(staff),777")
+	assert.Equal(c, strings.TrimSpace(out), "uid=0(root) gid=0(root) groups=0(root),10(wheel),29(audio),50(staff),777")
 }
 
 func (s *DockerSwarmSuite) TestSwarmContainerAutoStart(c *testing.T) {


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44119

Update tests checking for groups to adjust for new policy updated in de7af816e76a7fd3fbf06bffa6832959289fba32, which caused those tests to fail:

    === FAIL: amd64.integration-cli TestDockerSwarmSuite/TestSwarmServiceWithGroup (1.94s)
    docker_cli_swarm_test.go:311: assertion failed: uid=0(root) gid=0(root) groups=0(root),10(wheel),29(audio),50(staff),777 (string) != uid=0(root) gid=0(root) groups=10(wheel),29(audio),50(staff),777
(string)
    --- FAIL: TestDockerSwarmSuite/TestSwarmServiceWithGroup (1.94s)

    === FAIL: amd64.integration-cli TestDockerCLIRunSuite/TestRunGroupAdd (0.41s)
    docker_cli_run_test.go:1091: expected output uid=0(root) gid=0(root) groups=10(wheel),29(audio),50(staff),777 received uid=0(root) gid=0(root) groups=0(root),10(wheel),29(audio),50(staff),777
    --- FAIL: TestDockerCLIRunSuite/TestRunGroupAdd (0.41s)

    === FAIL: amd64.integration-cli TestDockerCLIRunSuite/TestRunUserByIDZero (0.41s)
    docker_cli_run_test.go:790: expected daemon user got uid=0(root) gid=0(root) groups=0(root),10(wheel)
    --- FAIL: TestDockerCLIRunSuite/TestRunUserByIDZero (0.41s)

    === FAIL: amd64.integration-cli TestDockerCLIRunSuite (195.70s)

(cherry picked from commit c7e77dba7ff1e512d702dc434d8d2bb956d80f47)


