### PR TITLE
[20.10] vendor: github.com/moby/buildkit 3a1eeca59a9263613d996ead67d53a4b7d45723d (v0.8 branch)

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -33,7 +33,7 @@ github.com/imdario/mergo                            1afb36080aec31e0d1528973ebe6
 golang.org/x/sync                                   cd5d95a43a6e21273425c7ae415d3df9ea832eeb
 
 # buildkit
-github.com/moby/buildkit                            bc07b2b81b1c6a62d29981ac564b16a15ce2bfa7 # v0.8.3-4-gbc07b2b8
+github.com/moby/buildkit                            3a1eeca59a9263613d996ead67d53a4b7d45723d # v0.8.3-29-g3a1eeca5
 github.com/tonistiigi/fsutil                        0834f99b7b85462efb69b4f571a4fa3ca7da5ac9
 github.com/tonistiigi/units                         6950e57a87eaf136bbe44ef2ec8e75b9e3569de2
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746

--- a/vendor/github.com/moby/buildkit/README.md
+++ b/vendor/github.com/moby/buildkit/README.md
@@ -189,7 +189,7 @@ buildctl build \
 buildctl build \
     --frontend gateway.v0 \
     --opt source=docker/dockerfile \
-    --opt context=git://github.com/moby/moby \
+    --opt context=https://github.com/moby/moby.git \
     --opt build-arg:APT_MIRROR=cdn-fastly.deb.debian.org
 ```
 

--- a/vendor/github.com/moby/buildkit/api/services/control/generate.go
+++ b/vendor/github.com/moby/buildkit/api/services/control/generate.go
@@ -1,3 +1,3 @@
-package moby_buildkit_v1 //nolint:golint
+package moby_buildkit_v1 //nolint:revive
 
 //go:generate protoc -I=. -I=../../../vendor/ -I=../../../../../../ --gogo_out=plugins=grpc:. control.proto

--- a/vendor/github.com/moby/buildkit/api/types/generate.go
+++ b/vendor/github.com/moby/buildkit/api/types/generate.go
@@ -1,3 +1,3 @@
-package moby_buildkit_v1_types //nolint:golint
+package moby_buildkit_v1_types //nolint:revive
 
 //go:generate protoc -I=. -I=../../vendor/ -I=../../../../../ --gogo_out=plugins=grpc:. worker.proto

--- a/vendor/github.com/moby/buildkit/cache/contenthash/filehash_unix.go
+++ b/vendor/github.com/moby/buildkit/cache/contenthash/filehash_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package contenthash

--- a/vendor/github.com/moby/buildkit/cache/contenthash/filehash_windows.go
+++ b/vendor/github.com/moby/buildkit/cache/contenthash/filehash_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package contenthash

--- a/vendor/github.com/moby/buildkit/cache/remotecache/registry/registry.go
+++ b/vendor/github.com/moby/buildkit/cache/remotecache/registry/registry.go
@@ -12,7 +12,6 @@ import (
 	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/resolver"
 	digest "github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
@@ -93,11 +92,11 @@ func (dsl *withDistributionSourceLabel) SetDistributionSourceLabel(ctx context.C
 	if err != nil {
 		return err
 	}
-	_, err = hf(ctx, ocispec.Descriptor{Digest: dgst})
+	_, err = hf(ctx, specs.Descriptor{Digest: dgst})
 	return err
 }
 
-func (dsl *withDistributionSourceLabel) SetDistributionSourceAnnotation(desc ocispec.Descriptor) ocispec.Descriptor {
+func (dsl *withDistributionSourceLabel) SetDistributionSourceAnnotation(desc specs.Descriptor) specs.Descriptor {
 	if desc.Annotations == nil {
 		desc.Annotations = map[string]string{}
 	}

--- a/vendor/github.com/moby/buildkit/client/client_unix.go
+++ b/vendor/github.com/moby/buildkit/client/client_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package client

--- a/vendor/github.com/moby/buildkit/cmd/buildkitd/config/gcpolicy_unix.go
+++ b/vendor/github.com/moby/buildkit/cmd/buildkitd/config/gcpolicy_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package config

--- a/vendor/github.com/moby/buildkit/cmd/buildkitd/config/gcpolicy_windows.go
+++ b/vendor/github.com/moby/buildkit/cmd/buildkitd/config/gcpolicy_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package config

--- a/vendor/github.com/moby/buildkit/executor/oci/spec_unix.go
+++ b/vendor/github.com/moby/buildkit/executor/oci/spec_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package oci

--- a/vendor/github.com/moby/buildkit/executor/oci/spec_windows.go
+++ b/vendor/github.com/moby/buildkit/executor/oci/spec_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package oci

--- a/vendor/github.com/moby/buildkit/executor/runcexecutor/executor_common.go
+++ b/vendor/github.com/moby/buildkit/executor/runcexecutor/executor_common.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package runcexecutor

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert_norunnetwork.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert_norunnetwork.go
@@ -1,3 +1,4 @@
+//go:build !dfrunnetwork
 // +build !dfrunnetwork
 
 package dockerfile2llb

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert_norunsecurity.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert_norunsecurity.go
@@ -1,3 +1,4 @@
+//go:build !dfrunsecurity
 // +build !dfrunsecurity
 
 package dockerfile2llb

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert_runnetwork.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert_runnetwork.go
@@ -1,3 +1,4 @@
+//go:build dfrunnetwork
 // +build dfrunnetwork
 
 package dockerfile2llb

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert_runsecurity.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert_runsecurity.go
@@ -1,3 +1,4 @@
+//go:build dfrunsecurity
 // +build dfrunsecurity
 
 package dockerfile2llb

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands_runnetwork.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands_runnetwork.go
@@ -1,3 +1,4 @@
+//go:build dfrunnetwork
 // +build dfrunnetwork
 
 package instructions

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands_runsecurity.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands_runsecurity.go
@@ -1,3 +1,4 @@
+//go:build dfrunsecurity
 // +build dfrunsecurity
 
 package instructions

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/errors_unix.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/errors_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package instructions

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/parse.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/parse.go
@@ -648,7 +648,7 @@ func errExactlyOneArgument(command string) error {
 }
 
 func errNoDestinationArgument(command string) error {
-	return errors.Errorf("%s requires at least two arguments, but only one was provided. Destination could not be determined.", command)
+	return errors.Errorf("%s requires at least two arguments, but only one was provided. Destination could not be determined", command)
 }
 
 func errBlankCommandNames(command string) error {

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/shell/equal_env_unix.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/shell/equal_env_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package shell

--- a/vendor/github.com/moby/buildkit/frontend/gateway/pb/caps.go
+++ b/vendor/github.com/moby/buildkit/frontend/gateway/pb/caps.go
@@ -1,4 +1,4 @@
-package moby_buildkit_v1_frontend //nolint:golint
+package moby_buildkit_v1_frontend //nolint:revive
 
 import "github.com/moby/buildkit/util/apicaps"
 

--- a/vendor/github.com/moby/buildkit/frontend/gateway/pb/generate.go
+++ b/vendor/github.com/moby/buildkit/frontend/gateway/pb/generate.go
@@ -1,3 +1,3 @@
-package moby_buildkit_v1_frontend //nolint:golint
+package moby_buildkit_v1_frontend //nolint:revive
 
 //go:generate protoc -I=. -I=../../../vendor/ -I=../../../../../../ --gogo_out=plugins=grpc:. gateway.proto

--- a/vendor/github.com/moby/buildkit/go.mod
+++ b/vendor/github.com/moby/buildkit/go.mod
@@ -9,8 +9,7 @@ require (
 	github.com/Microsoft/hcsshim v0.8.10
 	github.com/codahale/hdrhistogram v0.0.0-20160425231609-f8ad88b59a58 // indirect
 	github.com/containerd/console v1.0.1
-	// containerd: the actual version is replaced in replace()
-	github.com/containerd/containerd v1.4.1-0.20201117152358-0edc412565dc
+	github.com/containerd/containerd v1.4.1-0.20201117152358-0edc412565dc // the actual version is replaced in replace()
 	github.com/containerd/continuity v0.0.0-20200710164510-efbc4488d8fe
 	github.com/containerd/go-cni v1.0.1
 	github.com/containerd/go-runc v0.0.0-20201020171139-16b287bc67d0
@@ -64,7 +63,7 @@ require (
 	golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
-	golang.org/x/sys v0.0.0-20201013081832-0aaa2718063a
+	golang.org/x/sys v0.0.0-20210507161434-a76c4d0a0096
 	golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1
 	// genproto: the actual version is replaced in replace()
 	google.golang.org/genproto v0.0.0-20200527145253-8367513e4ece
@@ -72,11 +71,16 @@ require (
 )
 
 replace (
-	// containerd: Forked from 0edc412565dcc6e3d6125ff9e4b009ad4b89c638 (20201117) with:
+	// containerd: vendoring from the docker/20.10 branch in https://github.com/moby/containerd
+	//
+	// Forked from 0edc412565dcc6e3d6125ff9e4b009ad4b89c638 (20201117) with:
+	// - `images: validate document type before unmarshal`   (eb9ba7ed8d46d48fb22362f9d91fff6fb837e37e)
+	// - `schema1: reject ambiguous documents`               (70c88f507579277ab7af23b06666e3b57d4b4f2d)
+	// - `Fix the Inheritable capability defaults`           (6906b57c721f9114377ceb069662b196876915c0)
 	// - `Adjust overlay tests to expect "index=off"`        (#4719, for ease of cherry-picking #5076)
 	// - `overlay: support "userxattr" option (kernel 5.11)` (#5076)
 	// - `docker: avoid concurrent map access panic`         (#4855)
-	github.com/containerd/containerd => github.com/AkihiroSuda/containerd v1.1.1-0.20210312044057-48f85a131bb8
+	github.com/containerd/containerd => github.com/moby/containerd v0.0.0-20220901192706-96c5ae04b678
 	// protobuf: corresponds to containerd
 	github.com/golang/protobuf => github.com/golang/protobuf v1.3.5
 	github.com/hashicorp/go-immutable-radix => github.com/tonistiigi/go-immutable-radix v0.0.0-20170803185627-826af9ccf0fe

--- a/vendor/github.com/moby/buildkit/snapshot/localmounter_unix.go
+++ b/vendor/github.com/moby/buildkit/snapshot/localmounter_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package snapshot

--- a/vendor/github.com/moby/buildkit/solver/errdefs/solve.go
+++ b/vendor/github.com/moby/buildkit/solver/errdefs/solve.go
@@ -14,7 +14,7 @@ func init() {
 	typeurl.Register((*Solve)(nil), "github.com/moby/buildkit", "errdefs.Solve+json")
 }
 
-//nolint:golint
+//nolint:revive
 type IsSolve_Subject isSolve_Subject
 
 // SolveError will be returned when an error is encountered during a solve that

--- a/vendor/github.com/moby/buildkit/solver/llbsolver/file/user_nolinux.go
+++ b/vendor/github.com/moby/buildkit/solver/llbsolver/file/user_nolinux.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package file

--- a/vendor/github.com/moby/buildkit/source/git/gitsource_unix.go
+++ b/vendor/github.com/moby/buildkit/source/git/gitsource_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package git

--- a/vendor/github.com/moby/buildkit/source/git/gitsource_windows.go
+++ b/vendor/github.com/moby/buildkit/source/git/gitsource_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package git

--- a/vendor/github.com/moby/buildkit/source/git/redact_credentials_go114.go
+++ b/vendor/github.com/moby/buildkit/source/git/redact_credentials_go114.go
@@ -1,0 +1,31 @@
+//go:build !go1.15
+// +build !go1.15
+
+package git
+
+import "net/url"
+
+// redactCredentials takes a URL and redacts a password from it.
+// e.g. "https://user:password@github.com/user/private-repo-failure.git" will be changed to
+// "https://user:xxxxx@github.com/user/private-repo-failure.git"
+func redactCredentials(s string) string {
+	u, err := url.Parse(s)
+	if err != nil {
+		return s // string is not a URL, just return it
+	}
+
+	return urlRedacted(u)
+}
+
+// urlRedacted comes from go's url.Redacted() which isn't available on go < 1.15
+func urlRedacted(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+
+	ru := *u
+	if _, has := ru.User.Password(); has {
+		ru.User = url.UserPassword(ru.User.Username(), "xxxxx")
+	}
+	return ru.String()
+}

--- a/vendor/github.com/moby/buildkit/util/apicaps/pb/generate.go
+++ b/vendor/github.com/moby/buildkit/util/apicaps/pb/generate.go
@@ -1,3 +1,3 @@
-package moby_buildkit_v1_apicaps //nolint:golint
+package moby_buildkit_v1_apicaps //nolint:revive
 
 //go:generate protoc -I=. -I=../../../vendor/ -I=../../../../../../ --gogo_out=plugins=grpc:. caps.proto

--- a/vendor/github.com/moby/buildkit/util/appdefaults/appdefaults_unix.go
+++ b/vendor/github.com/moby/buildkit/util/appdefaults/appdefaults_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package appdefaults

--- a/vendor/github.com/moby/buildkit/util/archutil/386_binary.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/386_binary.go
@@ -1,3 +1,4 @@
+//go:build !386
 // +build !386
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/archutil/386_check.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/386_check.go
@@ -1,3 +1,4 @@
+//go:build !386
 // +build !386
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/archutil/386_check_386.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/386_check_386.go
@@ -1,3 +1,4 @@
+//go:build 386
 // +build 386
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/archutil/amd64_binary.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/amd64_binary.go
@@ -1,3 +1,4 @@
+//go:build !amd64
 // +build !amd64
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/archutil/amd64_check.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/amd64_check.go
@@ -1,3 +1,4 @@
+//go:build !amd64
 // +build !amd64
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/archutil/amd64_check_amd64.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/amd64_check_amd64.go
@@ -1,3 +1,4 @@
+//go:build amd64
 // +build amd64
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/archutil/arm64_binary.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/arm64_binary.go
@@ -1,3 +1,4 @@
+//go:build !arm64
 // +build !arm64
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/archutil/arm64_check.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/arm64_check.go
@@ -1,3 +1,4 @@
+//go:build !arm64
 // +build !arm64
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/archutil/arm64_check_arm64.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/arm64_check_arm64.go
@@ -1,3 +1,4 @@
+//go:build arm64
 // +build arm64
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/archutil/arm_binary.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/arm_binary.go
@@ -1,3 +1,4 @@
+//go:build !arm
 // +build !arm
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/archutil/arm_check.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/arm_check.go
@@ -1,3 +1,4 @@
+//go:build !arm
 // +build !arm
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/archutil/arm_check_arm.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/arm_check_arm.go
@@ -1,3 +1,4 @@
+//go:build arm
 // +build arm
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/archutil/check_unix.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/check_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/archutil/check_windows.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/check_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/archutil/ppc64le_binary.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/ppc64le_binary.go
@@ -1,3 +1,4 @@
+//go:build !ppc64le
 // +build !ppc64le
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/archutil/ppc64le_check.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/ppc64le_check.go
@@ -1,3 +1,4 @@
+//go:build !ppc64le
 // +build !ppc64le
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/archutil/ppc64le_check_ppc64le.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/ppc64le_check_ppc64le.go
@@ -1,3 +1,4 @@
+//go:build ppc64le
 // +build ppc64le
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/archutil/riscv64_binary.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/riscv64_binary.go
@@ -1,3 +1,4 @@
+//go:build !riscv64
 // +build !riscv64
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/archutil/riscv64_check.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/riscv64_check.go
@@ -1,3 +1,4 @@
+//go:build !riscv64
 // +build !riscv64
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/archutil/riscv64_check_riscv64.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/riscv64_check_riscv64.go
@@ -1,3 +1,4 @@
+//go:build riscv64
 // +build riscv64
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/archutil/s390x_binary.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/s390x_binary.go
@@ -1,3 +1,4 @@
+//go:build !s390x
 // +build !s390x
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/archutil/s390x_check.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/s390x_check.go
@@ -1,3 +1,4 @@
+//go:build !s390x
 // +build !s390x
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/archutil/s390x_check_s390x.go
+++ b/vendor/github.com/moby/buildkit/util/archutil/s390x_check_s390x.go
@@ -1,3 +1,4 @@
+//go:build s390x
 // +build s390x
 
 package archutil

--- a/vendor/github.com/moby/buildkit/util/entitlements/security/security_linux.go
+++ b/vendor/github.com/moby/buildkit/util/entitlements/security/security_linux.go
@@ -154,7 +154,7 @@ func getFreeLoopID() (int, error) {
 	}
 	defer fd.Close()
 
-	const _LOOP_CTL_GET_FREE = 0x4C82 //nolint:golint
+	const _LOOP_CTL_GET_FREE = 0x4C82 //nolint:revive
 	r1, _, uerr := unix.Syscall(unix.SYS_IOCTL, fd.Fd(), _LOOP_CTL_GET_FREE, 0)
 	if uerr == 0 {
 		return int(r1), nil

--- a/vendor/github.com/moby/buildkit/util/network/host.go
+++ b/vendor/github.com/moby/buildkit/util/network/host.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package network

--- a/vendor/github.com/moby/buildkit/util/rootless/specconv/specconv_nonlinux.go
+++ b/vendor/github.com/moby/buildkit/util/rootless/specconv/specconv_nonlinux.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package specconv

--- a/vendor/github.com/moby/buildkit/util/system/path_unix.go
+++ b/vendor/github.com/moby/buildkit/util/system/path_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package system

--- a/vendor/github.com/moby/buildkit/util/system/path_windows.go
+++ b/vendor/github.com/moby/buildkit/util/system/path_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package system

--- a/vendor/github.com/moby/buildkit/util/system/seccomp_linux.go
+++ b/vendor/github.com/moby/buildkit/util/system/seccomp_linux.go
@@ -1,3 +1,4 @@
+//go:build linux && seccomp
 // +build linux,seccomp
 
 package system

--- a/vendor/github.com/moby/buildkit/util/system/seccomp_nolinux.go
+++ b/vendor/github.com/moby/buildkit/util/system/seccomp_nolinux.go
@@ -1,3 +1,4 @@
+//go:build !linux && seccomp
 // +build !linux,seccomp
 
 package system

--- a/vendor/github.com/moby/buildkit/util/system/seccomp_noseccomp.go
+++ b/vendor/github.com/moby/buildkit/util/system/seccomp_noseccomp.go
@@ -1,3 +1,4 @@
+//go:build !seccomp
 // +build !seccomp
 
 package system

--- a/vendor/github.com/moby/buildkit/util/winlayers/differ.go
+++ b/vendor/github.com/moby/buildkit/util/winlayers/differ.go
@@ -108,8 +108,7 @@ func (s *winDiffer) Compare(ctx context.Context, lower, upper []mount.Mount, opt
 				if err != nil {
 					return errors.Wrap(err, "failed to get compressed stream")
 				}
-				var w io.Writer = io.MultiWriter(compressed, dgstr.Hash())
-				w, discard, done := makeWindowsLayer(w)
+				w, discard, done := makeWindowsLayer(io.MultiWriter(compressed, dgstr.Hash()))
 				err = archive.WriteDiff(ctx, w, lowerRoot, upperRoot)
 				if err != nil {
 					discard(err)


### PR DESCRIPTION
- update to go1.18 https://github.com/moby/buildkit/pull/3079
- metadata: hold lock on storageitem update  https://github.com/moby/buildkit/pull/3076
- cache: avoid concurrent maps write on prune https://github.com/moby/buildkit/pull/3087
    - fixes https://github.com/moby/buildkit/issues/2157
    - fixes https://github.com/moby/buildkit/issues/2061
- update containerd to latest of docker-20.10 branch https://github.com/moby/buildkit/pull/3076
    - fixes https://github.com/moby/buildkit/issues/2111
    - fixes https://github.com/containerd/containerd/issues/4795

full diff: https://github.com/moby/buildkit/compare/bc07b2b81b1c6a62d29981ac564b16a15ce2bfa7...3a1eeca59a9263613d996ead67d53a4b7d45723d

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

