### PR TITLE
[22.06 backport] Update uses of Image platform fields in OCI image-spec

### DIFF
--- a/builder/builder-next/exporter/writer.go
+++ b/builder/builder-next/exporter/writer.go
@@ -22,11 +22,10 @@ import (
 
 func emptyImageConfig() ([]byte, error) {
 	pl := platforms.Normalize(platforms.DefaultSpec())
-	img := ocispec.Image{
-		Architecture: pl.Architecture,
-		OS:           pl.OS,
-		Variant:      pl.Variant,
-	}
+	img := ocispec.Image{}
+	img.Architecture = pl.Architecture
+	img.OS = pl.OS
+	img.Variant = pl.Variant
 	img.RootFS.Type = "layers"
 	img.Config.WorkingDir = "/"
 	img.Config.Env = []string{"PATH=" + system.DefaultPathEnv(pl.OS)}


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44125

The OCI image spec is considering to change the Image struct and embedding the Platform type (see opencontainers/image-spec#959) in the go implementation. Moby currently uses some struct-literals to propagate the platform fields, which will break once those changes in the OCI spec are merged.

Ideally (once that change arrives) we would update the code to set the Platform information as a whole, instead of assigning related fields individually, but in some cases in the code, image platform information is only partially set (for example, OSVersion and OSFeatures are not preserved in all cases). This may be on purpose, so needs to be reviewed.

This patch keeps the current behavior (assigning only specific fields), but removes the use of struct-literals to make the code compatible with the upcoming changes in the image-spec module.

(cherry picked from commit 3cb933db9d34ad2c75245851332df45c6ff82bf2)

