### PR TITLE
[20.10] Update uses of Image platform fields in OCI image-spec

### DIFF
--- a/builder/builder-next/exporter/writer.go
+++ b/builder/builder-next/exporter/writer.go
@@ -20,10 +20,9 @@ import (
 // )
 
 func emptyImageConfig() ([]byte, error) {
-	img := ocispec.Image{
-		Architecture: runtime.GOARCH,
-		OS:           runtime.GOOS,
-	}
+	img := ocispec.Image{}
+	img.Architecture = runtime.GOARCH
+	img.OS = runtime.GOOS
 	img.RootFS.Type = "layers"
 	img.Config.WorkingDir = "/"
 	img.Config.Env = []string{"PATH=" + system.DefaultPathEnvUnix}


### PR DESCRIPTION
- equivalent of https://github.com/moby/moby/pull/44125 on master

The OCI image spec is considering to change the Image struct and embedding the Platform type (see opencontainers/image-spec#959) in the go implementation. Moby currently uses some struct-literals to propagate the platform fields, which will break once those changes in the OCI spec are merged.

Ideally (once that change arrives) we would update the code to set the Platform information as a whole, instead of assigning related fields individually, but in some cases in the code, image platform information is only partially set (for example, OSVersion and OSFeatures are not preserved in all cases). This may be on purpose, so needs to be reviewed.

This patch keeps the current behavior (assigning only specific fields), but removes the use of struct-literals to make the code compatible with the upcoming changes in the image-spec module.

(similar to commit 3cb933db9d34ad2c75245851332df45c6ff82bf2)


