### PR TITLE
Revert "validation: temporarily allows changes in integration-cli"

### DIFF
--- a/hack/validate/default
+++ b/hack/validate/default
@@ -14,6 +14,6 @@ SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "${SCRIPTDIR}"/toml
 . "${SCRIPTDIR}"/changelog-well-formed
 . "${SCRIPTDIR}"/changelog-date-descending
-#. "${SCRIPTDIR}"/deprecate-integration-cli
+. "${SCRIPTDIR}"/deprecate-integration-cli
 . "${SCRIPTDIR}"/golangci-lint
 . "${SCRIPTDIR}"/shfmt


### PR DESCRIPTION
This reverts commit 7ed823ead91938e5cc8de7a42ff93a25abe73e7e, which was added in https://github.com/moby/moby/pull/43682, and meant to be temporary 😅  

