### PR TITLE
ci(test): report summary output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ on:
 env:
   GO_VERSION: 1.19.1
   GOTESTLIST_VERSION: v0.2.0
+  TESTSTAT_VERSION: v0.1.3
   ITG_CLI_MATRIX_SIZE: 6
   BUILDX: docker buildx
   USE_BUILDX: 1
@@ -103,6 +104,32 @@ jobs:
         with:
           name: unit-reports
           path: /tmp/reports/*
+
+  unit-report:
+    runs-on: ubuntu-20.04
+    if: always()
+    needs:
+      - unit
+    steps:
+      -
+        name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      -
+        name: Download reports
+        uses: actions/download-artifact@v3
+        with:
+          name: unit-reports
+          path: /tmp/reports
+      -
+        name: Install teststat
+        run: |
+          go install github.com/vearutop/teststat@${{ env.TESTSTAT_VERSION }}
+      -
+        name: Create summary
+        run: |
+          teststat -markdown $(find /tmp/reports -type f -name '*.json' -print0 | xargs -0) >> $GITHUB_STEP_SUMMARY
 
   docker-py:
     runs-on: ubuntu-20.04
@@ -263,6 +290,32 @@ jobs:
           name: integration-reports
           path: /tmp/reports/*
 
+  integration-report:
+    runs-on: ubuntu-20.04
+    if: always()
+    needs:
+      - integration
+    steps:
+      -
+        name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      -
+        name: Download reports
+        uses: actions/download-artifact@v3
+        with:
+          name: integration-reports
+          path: /tmp/reports
+      -
+        name: Install teststat
+        run: |
+          go install github.com/vearutop/teststat@${{ env.TESTSTAT_VERSION }}
+      -
+        name: Create summary
+        run: |
+          teststat -markdown $(find /tmp/reports -type f -name '*.json' -print0 | xargs -0) >> $GITHUB_STEP_SUMMARY
+
   integration-cli-prepare:
     runs-on: ubuntu-20.04
     outputs:
@@ -359,3 +412,29 @@ jobs:
         with:
           name: integration-cli-reports
           path: /tmp/reports/*
+
+  integration-cli-report:
+    runs-on: ubuntu-20.04
+    if: always()
+    needs:
+      - integration-cli
+    steps:
+      -
+        name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      -
+        name: Download reports
+        uses: actions/download-artifact@v3
+        with:
+          name: integration-cli-reports
+          path: /tmp/reports
+      -
+        name: Install teststat
+        run: |
+          go install github.com/vearutop/teststat@${{ env.TESTSTAT_VERSION }}
+      -
+        name: Create summary
+        run: |
+          teststat -markdown $(find /tmp/reports -type f -name '*.json' -print0 | xargs -0) >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Adds test summary output to `test` workflow like #43682 for the `windows` one.

Preview: https://github.com/crazy-max/moby/actions/runs/3024033979#summary-8275095789

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>