### PR TITLE
44151: update docker network disconnect on not attached network error with container name

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -920,7 +920,8 @@ func (daemon *Daemon) disconnectFromNetwork(container *container.Container, n li
 	}
 
 	if ep == nil {
-		return fmt.Errorf("container %s is not connected to network %s", container.ID, n.Name())
+		containerName := strings.TrimPrefix(container.Name, "/")
+		return fmt.Errorf("container %s is not connected to network %s", containerName, n.Name())
 	}
 
 	if err := ep.Leave(sbox); err != nil {


### PR DESCRIPTION


Signed-off-by: Datta Kumbhar <dattakumbhar2804@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #44151 "

Please provide the following information:
-->

**- What I did**
disconnect network disconnect command on not attached  network,  update with container name
**- How I did it**
Update daemon/container_operations.go with “container %s is not connected to network %s", container.Name, n.Name()"

**- How to verify it**
docker network create net11
docker run -d -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 -p 3306 mariadb:10.8.4
Lets container id start with faad0301bd40eea137bf727f461c141655c52136fe3181df1055a45117f762cf
Connect network to container
docker network connect net11 fa
Conect existing network
docker network connect net11 fa
Gives below error with container name
Error response from daemon: endpoint with name affectionate_cartwright already exists in network net11
Disconnect network
docker network disconnect net11 fa
Try to disconnect again same
docker network disconnect net11 fa

Get error which is expected however container id is seen so should be container name as connect
Error response from daemon: container affectionate_cartwright is not connected to network net11

**- Description for the changelog**
<!--
Changed docker network disconnect net11 fa on not attached network , update error message to container.Name
-->


