### PR TITLE
container: remove ViewDB and View interfaces, use concrete types

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -193,7 +193,7 @@ func (container *Container) toDisk() (*Container, error) {
 
 // CheckpointTo makes the Container's current state visible to queries, and persists state.
 // Callers must hold a Container lock.
-func (container *Container) CheckpointTo(store ViewDB) error {
+func (container *Container) CheckpointTo(store *ViewDB) error {
 	deepCopy, err := container.toDisk()
 	if err != nil {
 		return err

--- a/container/view_test.go
+++ b/container/view_test.go
@@ -373,7 +373,7 @@ func TestTruncIndex(t *testing.T) {
 	}
 }
 
-func assertIndexGet(t *testing.T, snapshot ViewDB, input, expectedResult string, expectError bool) {
+func assertIndexGet(t *testing.T, snapshot *ViewDB, input, expectedResult string, expectError bool) {
 	if result, err := snapshot.GetByPrefix(input); err != nil && !expectError {
 		t.Fatalf("Unexpected error getting '%s': %s", input, err)
 	} else if err == nil && expectError {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -73,7 +73,7 @@ type Daemon struct {
 	id                    string
 	repository            string
 	containers            container.Store
-	containersReplica     container.ViewDB
+	containersReplica     *container.ViewDB
 	execCommands          *container.ExecStore
 	imageService          ImageService
 	configStore           *config.Config

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -110,7 +110,7 @@ func (daemon *Daemon) Containers(config *types.ContainerListOptions) ([]*types.C
 	return daemon.reduceContainers(config, daemon.refreshImage)
 }
 
-func (daemon *Daemon) filterByNameIDMatches(view container.View, filter *listContext) ([]container.Snapshot, error) {
+func (daemon *Daemon) filterByNameIDMatches(view *container.View, filter *listContext) ([]container.Snapshot, error) {
 	idSearch := false
 	names := filter.filters.Get("name")
 	ids := filter.filters.Get("id")
@@ -243,7 +243,7 @@ func (daemon *Daemon) reducePsContainer(container *container.Snapshot, filter *l
 }
 
 // foldFilter generates the container filter based on the user's filtering options.
-func (daemon *Daemon) foldFilter(view container.View, config *types.ContainerListOptions) (*listContext, error) {
+func (daemon *Daemon) foldFilter(view *container.View, config *types.ContainerListOptions) (*listContext, error) {
 	ctx := context.TODO()
 	psFilters := config.Filters
 
@@ -363,7 +363,7 @@ func (daemon *Daemon) foldFilter(view container.View, config *types.ContainerLis
 	}, nil
 }
 
-func idOrNameFilter(view container.View, value string) (*container.Snapshot, error) {
+func idOrNameFilter(view *container.View, value string) (*container.Snapshot, error) {
 	filter, err := view.Get(value)
 	switch err.(type) {
 	case container.NoSuchContainerError:


### PR DESCRIPTION
- (slightly) related to https://github.com/moby/moby/pull/43787
- related to https://github.com/moby/moby/pull/31273

These interfaces were added in aacddda89df05b88a6d15fb33c42864760385ab2 (https://github.com/moby/moby/pull/31273), with no clear motivation, other than "Also hide ViewDB behind an interface".

This patch removes the interface in favor of using a concrete implementation; There's currently only one implementation of this interface, and if we would decide to change to an alternative implementation, we could define relevant interfaces on the receiver side.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

