### PR TITLE
[22.06 backport] client: ignore kernel-memory on API >= 1.42

### DIFF
--- a/client/container_create.go
+++ b/client/container_create.go
@@ -26,21 +26,23 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 	if err := cli.NewVersionError("1.25", "stop timeout"); config != nil && config.StopTimeout != nil && err != nil {
 		return response, err
 	}
-
-	clientVersion := cli.ClientVersion()
-
-	// When using API 1.24 and under, the client is responsible for removing the container
-	if hostConfig != nil && versions.LessThan(clientVersion, "1.25") {
-		hostConfig.AutoRemove = false
-	}
-
-	// When using API under 1.42, the Linux daemon doesn't respect the ConsoleSize
-	if hostConfig != nil && platform != nil && platform.OS == "linux" && versions.LessThan(clientVersion, "1.42") {
-		hostConfig.ConsoleSize = [2]uint{0, 0}
-	}
-
 	if err := cli.NewVersionError("1.41", "specify container image platform"); platform != nil && err != nil {
 		return response, err
+	}
+
+	if hostConfig != nil {
+		if versions.LessThan(cli.ClientVersion(), "1.25") {
+			// When using API 1.24 and under, the client is responsible for removing the container
+			hostConfig.AutoRemove = false
+		}
+		if versions.GreaterThanOrEqualTo(cli.ClientVersion(), "1.42") || versions.LessThan(cli.ClientVersion(), "1.40") {
+			// KernelMemory was added in API 1.40, and deprecated in API 1.42
+			hostConfig.KernelMemory = 0
+		}
+		if platform != nil && platform.OS == "linux" && versions.LessThan(cli.ClientVersion(), "1.42") {
+			// When using API under 1.42, the Linux daemon doesn't respect the ConsoleSize
+			hostConfig.ConsoleSize = [2]uint{0, 0}
+		}
 	}
 
 	query := url.Values{}


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44138
- relates to https://github.com/moby/moby/pull/43214
- relates to https://github.com/docker/cli/pull/3542


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

