### PR TITLE
[22.06 backport] fix debian sysvinit script fails to restart docker daemon when stopped

### DIFF
--- a/contrib/init/sysvinit-debian/docker
+++ b/contrib/init/sysvinit-debian/docker
@@ -131,7 +131,7 @@ case "$1" in
 	restart)
 		check_init
 		fail_unless_root
-		docker_pid=$(cat "$DOCKER_SSD_PIDFILE" 2> /dev/null)
+		docker_pid=$(cat "$DOCKER_SSD_PIDFILE" 2> /dev/null || true)
 		[ -n "$docker_pid" ] \
 			&& ps -p $docker_pid > /dev/null 2>&1 \
 			&& $0 stop


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44131
- Fixes: #44130

