### PR TITLE
[20.10 backport] vendor: github.com/containerd/console v1.0.2

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -135,8 +135,8 @@ google.golang.org/genproto                          3f1135a288c9a07e340ae8ba4cc6
 github.com/containerd/containerd                    96c5ae04b6784e180aaeee50fba715ac448ddb0d https://github.com/moby/containerd.git # docker-20.10 branch
 github.com/containerd/fifo                          0724c46b320cf96bb172a0550c19a4b1fca4dacb
 github.com/containerd/continuity                    5ad51c7aca47b8e742f5e6e7dc841d50f5f6affd # v0.3.0
-github.com/containerd/cgroups                       b9de8a2212026c07cec67baf3323f1fc0121e048 # v1.0.1 
-github.com/containerd/console                       5d7e1412f07b502a01029ea20e20e0d2be31fa7c # v1.0.1
+github.com/containerd/cgroups                       b9de8a2212026c07cec67baf3323f1fc0121e048 # v1.0.1
+github.com/containerd/console                       2f1e3d2b6afd18e8b2077816c711205a0b4d8769 # v1.0.2
 github.com/containerd/go-runc                       16b287bc67d069a60fa48db15f330b790b74365b
 github.com/containerd/typeurl                       cd3ce7159eae562a4f60ceff37dada11a939d247 # v1.0.1
 github.com/containerd/ttrpc                         bfba540dc45464586c106b1f31c8547933c1eb41 # v1.0.2

--- a/vendor/github.com/containerd/console/README.md
+++ b/vendor/github.com/containerd/console/README.md
@@ -1,6 +1,8 @@
 # console
 
-[![Build Status](https://travis-ci.org/containerd/console.svg?branch=master)](https://travis-ci.org/containerd/console)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/containerd/console)](https://pkg.go.dev/github.com/containerd/console)
+[![Build Status](https://github.com/containerd/console/workflows/CI/badge.svg)](https://github.com/containerd/console/actions?query=workflow%3ACI)
+[![Go Report Card](https://goreportcard.com/badge/github.com/containerd/console)](https://goreportcard.com/report/github.com/containerd/console)
 
 Golang package for dealing with consoles.  Light on deps and a simple API.
 

--- a/vendor/github.com/containerd/console/console_unix.go
+++ b/vendor/github.com/containerd/console/console_unix.go
@@ -19,8 +19,6 @@
 package console
 
 import (
-	"os"
-
 	"golang.org/x/sys/unix"
 )
 
@@ -28,7 +26,7 @@ import (
 // The master is returned as the first console and a string
 // with the path to the pty slave is returned as the second
 func NewPty() (Console, string, error) {
-	f, err := os.OpenFile("/dev/ptmx", unix.O_RDWR|unix.O_NOCTTY|unix.O_CLOEXEC, 0)
+	f, err := openpt()
 	if err != nil {
 		return nil, "", err
 	}

--- a/vendor/github.com/containerd/console/go.mod
+++ b/vendor/github.com/containerd/console/go.mod
@@ -4,5 +4,5 @@ go 1.13
 
 require (
 	github.com/pkg/errors v0.9.1
-	golang.org/x/sys v0.0.0-20200916030750-2334cc1a136f
+	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
 )

--- a/vendor/github.com/containerd/console/pty_freebsd_cgo.go
+++ b/vendor/github.com/containerd/console/pty_freebsd_cgo.go
@@ -1,0 +1,45 @@
+// +build freebsd,cgo
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package console
+
+import (
+	"fmt"
+	"os"
+)
+
+/*
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+*/
+import "C"
+
+// openpt allocates a new pseudo-terminal and establishes a connection with its
+// control device.
+func openpt() (*os.File, error) {
+	fd, err := C.posix_openpt(C.O_RDWR)
+	if err != nil {
+		return nil, fmt.Errorf("posix_openpt: %w", err)
+	}
+	if _, err := C.grantpt(fd); err != nil {
+		C.close(fd)
+		return nil, fmt.Errorf("grantpt: %w", err)
+	}
+	return os.NewFile(uintptr(fd), ""), nil
+}

--- a/vendor/github.com/containerd/console/pty_freebsd_nocgo.go
+++ b/vendor/github.com/containerd/console/pty_freebsd_nocgo.go
@@ -1,0 +1,36 @@
+// +build freebsd,!cgo
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package console
+
+import (
+	"os"
+)
+
+//
+// Implementing the functions below requires cgo support.  Non-cgo stubs
+// versions are defined below to enable cross-compilation of source code
+// that depends on these functions, but the resultant cross-compiled
+// binaries cannot actually be used.  If the stub function(s) below are
+// actually invoked they will display an error message and cause the
+// calling process to exit.
+//
+
+func openpt() (*os.File, error) {
+	panic("openpt() support requires cgo.")
+}

--- a/vendor/github.com/containerd/console/pty_unix.go
+++ b/vendor/github.com/containerd/console/pty_unix.go
@@ -1,0 +1,30 @@
+// +build darwin linux netbsd openbsd solaris
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package console
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// openpt allocates a new pseudo-terminal by opening the /dev/ptmx device
+func openpt() (*os.File, error) {
+	return os.OpenFile("/dev/ptmx", unix.O_RDWR|unix.O_NOCTTY|unix.O_CLOEXEC, 0)
+}

--- a/vendor/github.com/containerd/console/tc_freebsd_cgo.go
+++ b/vendor/github.com/containerd/console/tc_freebsd_cgo.go
@@ -1,3 +1,5 @@
+// +build freebsd,cgo
+
 /*
    Copyright The containerd Authors.
 
@@ -19,33 +21,37 @@ package console
 import (
 	"fmt"
 	"os"
-	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
 
+/*
+#include <stdlib.h>
+#include <unistd.h>
+*/
+import "C"
+
 const (
-	cmdTcGet = unix.TCGETS
-	cmdTcSet = unix.TCSETS
+	cmdTcGet = unix.TIOCGETA
+	cmdTcSet = unix.TIOCSETA
 )
 
 // unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
 // unlockpt should be called before opening the slave side of a pty.
 func unlockpt(f *os.File) error {
-	var u int32
-	// XXX do not use unix.IoctlSetPointerInt here, see commit dbd69c59b81.
-	if _, _, err := unix.Syscall(unix.SYS_IOCTL, f.Fd(), unix.TIOCSPTLCK, uintptr(unsafe.Pointer(&u))); err != 0 {
-		return err
+	fd := C.int(f.Fd())
+	if _, err := C.unlockpt(fd); err != nil {
+		C.close(fd)
+		return fmt.Errorf("unlockpt: %w", err)
 	}
 	return nil
 }
 
 // ptsname retrieves the name of the first available pts for the given master.
 func ptsname(f *os.File) (string, error) {
-	var u uint32
-	// XXX do not use unix.IoctlGetInt here, see commit dbd69c59b81.
-	if _, _, err := unix.Syscall(unix.SYS_IOCTL, f.Fd(), unix.TIOCGPTN, uintptr(unsafe.Pointer(&u))); err != 0 {
+	n, err := unix.IoctlGetInt(int(f.Fd()), unix.TIOCGPTN)
+	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("/dev/pts/%d", u), nil
+	return fmt.Sprintf("/dev/pts/%d", n), nil
 }

--- a/vendor/github.com/containerd/console/tc_freebsd_nocgo.go
+++ b/vendor/github.com/containerd/console/tc_freebsd_nocgo.go
@@ -1,3 +1,5 @@
+// +build freebsd,!cgo
+
 /*
    Copyright The containerd Authors.
 
@@ -28,11 +30,19 @@ const (
 	cmdTcSet = unix.TIOCSETA
 )
 
+//
+// Implementing the functions below requires cgo support.  Non-cgo stubs
+// versions are defined below to enable cross-compilation of source code
+// that depends on these functions, but the resultant cross-compiled
+// binaries cannot actually be used.  If the stub function(s) below are
+// actually invoked they will display an error message and cause the
+// calling process to exit.
+//
+
 // unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
 // unlockpt should be called before opening the slave side of a pty.
-// This does not exist on FreeBSD, it does not allocate controlling terminals on open
 func unlockpt(f *os.File) error {
-	return nil
+	panic("unlockpt() support requires cgo.")
 }
 
 // ptsname retrieves the name of the first available pts for the given master.


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/42284

Contains fix for s390x and support for FreeBSD

full diff: https://github.com/containerd/console/compare/v1.0.1...v1.0.2

(cherry picked from commit 948e201c1c23c13c8f0c1b94faf4c2bc968826d1)


