### PR TITLE
ci: reduce cache throttling limits

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -35,9 +35,6 @@ jobs:
         uses: docker/bake-action@v2
         with:
           targets: binary
-          set: |
-            *.cache-from=type=gha,scope=buildkit-build-binary
-            *.cache-to=type=gha,scope=buildkit-build-binary
       -
         name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,6 @@ jobs:
         uses: docker/bake-action@v1
         with:
           targets: ${{ matrix.target }}
-          set: |
-            *.cache-from=type=gha,scope=build-${{ matrix.target }}
-            *.cache-to=type=gha,scope=build-${{ matrix.target }}
       -
         name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -93,9 +90,6 @@ jobs:
         uses: docker/bake-action@v1
         with:
           targets: cross
-          set: |
-            *.cache-from=type=gha,scope=cross-${{ env.PLATFORM_PAIR }}
-            *.cache-to=type=gha,scope=cross-${{ env.PLATFORM_PAIR }}
         env:
           DOCKER_CROSSPLATFORMS: ${{ matrix.platform }}
       -


### PR DESCRIPTION
follow-up https://github.com/moby/moby/pull/44168#issuecomment-1253972032

**- What I did**

While waiting for a solution with throttling limits issue using GitHub Cache API, remove caching for `build` targets which should fix our issue.

**- How I did it**

I choose this target because that's the one that generates most requests when exporting cache (11 scoped cache in `ci` workflow and 1 in `buildkit` workflow). Ofc build time will be increased (~50s cached vs ~6m uncached) for these workflows but overall build time will be unchanged as `test` workflow takes longer than `ci` or `buildkit` workflows anyway.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

