### PR TITLE
Fix 'docker cp' mount loop

### DIFF
--- a/hack/dind
+++ b/hack/dind
@@ -37,6 +37,10 @@ if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
 		> /sys/fs/cgroup/cgroup.subtree_control
 fi
 
+# Change mount propagation to shared to make the environment more similar to a
+# modern Linux system, e.g. with SystemD as PID 1.
+mount --make-rshared /
+
 if [ $# -gt 0 ]; then
 	exec "$@"
 fi

--- a/hack/dind-systemd
+++ b/hack/dind-systemd
@@ -13,6 +13,11 @@ if [ ! -t 0 ]; then
 	exit 1
 fi
 
+# Change mount propagation to shared, which SystemD PID 1 would normally do
+# itself when started by the kernel. SystemD skips that when it detects it is
+# running in a container.
+mount --make-rshared /
+
 env > /etc/docker-entrypoint-env
 
 cat > /etc/systemd/system/docker-entrypoint.target << EOF

--- a/integration/container/mounts_linux_test.go
+++ b/integration/container/mounts_linux_test.go
@@ -391,3 +391,38 @@ func TestContainerVolumesMountedAsSlave(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// Regression test for #38995 and #43390.
+func TestContainerCopyLeaksMounts(t *testing.T) {
+	defer setupTest(t)()
+
+	bindMount := mounttypes.Mount{
+		Type:   mounttypes.TypeBind,
+		Source: "/var",
+		Target: "/hostvar",
+		BindOptions: &mounttypes.BindOptions{
+			Propagation: mounttypes.PropagationRSlave,
+		},
+	}
+
+	ctx := context.Background()
+	client := testEnv.APIClient()
+	cid := container.Run(ctx, t, client, container.WithMount(bindMount), container.WithCmd("sleep", "120s"))
+
+	getMounts := func() string {
+		t.Helper()
+		res, err := container.Exec(ctx, client, cid, []string{"cat", "/proc/self/mountinfo"})
+		assert.NilError(t, err)
+		assert.Equal(t, res.ExitCode, 0)
+		return res.Stdout()
+	}
+
+	mountsBefore := getMounts()
+
+	_, _, err := client.CopyFromContainer(ctx, cid, "/etc/passwd")
+	assert.NilError(t, err)
+
+	mountsAfter := getMounts()
+
+	assert.Equal(t, mountsBefore, mountsAfter)
+}


### PR DESCRIPTION
* Fixes #38995
* Fixes #43390
* Supersedes #38993
* Supersedes #43583

**- What I did**
* Fixed the 'docker cp' mount loop issue without resorting to `MS_UNBINDABLE` or temporary mount namespaces
* Made the issue reproducible in a DinD environment so it can be covered by a regression test

**- How I did it**
* I got the issue to reproduce in a DinD container by changing the mount propagation mode to shared, which matches the behaviour of SystemD PID 1 outside of a container.
* Force the mount propagation mode of the container rootfs (in the initial mount namespace) to private before the container starts so that any mounts under it after do not propagate anywhere.

**- How to verify it**
Check out the first commit and run the integration test to observe it failing. Repeat with the second commit to observe it passing.

**- Description for the changelog**
* Fixed `docker cp` failing with "no space left on device" when the daemon root is mounted into the container as a volume

**- A picture of a cute animal (not mandatory but encouraged)**

