### PR TITLE
set ReadHeaderTimeout to address G112: Potential Slowloris Attack (gosec)

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/docker/docker/api/server/httpstatus"
 	"github.com/docker/docker/api/server/httputils"
@@ -58,7 +59,8 @@ func (s *Server) Accept(addr string, listeners ...net.Listener) {
 	for _, listener := range listeners {
 		httpServer := &HTTPServer{
 			srv: &http.Server{
-				Addr: addr,
+				Addr:              addr,
+				ReadHeaderTimeout: 5 * time.Minute, // "G112: Potential Slowloris Attack (gosec)"; not a real concern for our use, so setting a long timeout.
 			},
 			l: listener,
 		}

--- a/libnetwork/diagnostic/server.go
+++ b/libnetwork/diagnostic/server.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/docker/docker/libnetwork/internal/caller"
 	"github.com/docker/docker/pkg/stack"
@@ -94,8 +95,9 @@ func (s *Server) EnableDiagnostic(ip string, port int) {
 
 	logrus.Infof("Starting the diagnostic server listening on %d for commands", port)
 	srv := &http.Server{
-		Addr:    net.JoinHostPort(ip, strconv.Itoa(port)),
-		Handler: s,
+		Addr:              net.JoinHostPort(ip, strconv.Itoa(port)),
+		Handler:           s,
+		ReadHeaderTimeout: 5 * time.Minute, // "G112: Potential Slowloris Attack (gosec)"; not a real concern for our use, so setting a long timeout.
 	}
 	s.srv = srv
 	s.enable = 1


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/44089

After discussing in the maintainers meeting, we concluded that Slowloris attacks are not a real risk other than potentially having some additional goroutines lingering around, so setting a long timeout to satisfy the linter, and to at least have "some" timeout.

    libnetwork/diagnostic/server.go:96:10: G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server (gosec)
        srv := &http.Server{
            Addr:    net.JoinHostPort(ip, strconv.Itoa(port)),
            Handler: s,
        }
    api/server/server.go:60:10: G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server (gosec)
                srv: &http.Server{
                    Addr: addr,
                },
    daemon/metrics_unix.go:34:13: G114: Use of net/http serve function that has no support for setting timeouts (gosec)
            if err := http.Serve(l, mux); err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
                      ^
    cmd/dockerd/metrics.go:27:13: G114: Use of net/http serve function that has no support for setting timeouts (gosec)
            if err := http.Serve(l, mux); err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
                      ^

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

