### PR TITLE
Remove the OS check when creating a container

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -18,7 +18,6 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/idtools"
-	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/runconfig"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/selinux/go-selinux"
@@ -132,9 +131,6 @@ func (daemon *Daemon) create(opts createOpts) (retC *container.Container, retErr
 			return nil, err
 		}
 		os = img.OperatingSystem()
-		if !system.IsOSSupported(os) {
-			return nil, system.ErrNotSupportedOperatingSystem
-		}
 		imgID = img.ID()
 	} else if isWindows {
 		os = "linux" // 'scratch' case.


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Removed the OS check when creating a container

Now that we can pass any custom containerd shim to dockerd there is need for this check. Without this it becomes possible to use wasm shims for example with images that have "wasi" as the OS.

In a followup we could add a configuration to set the default runtime by OS so that people can run a wasm image without needing to define a runtime on `docker run`.

**- How I did it**

**- How to verify it**

Run [this image](https://github.com/deislabs/runwasi/blob/main/Makefile#L25) with the `containerd-shim-wasmtime-v1` runtime.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/191789586-89700722-7718-453a-b47d-0c0d4dba3188.png)

