### PR TITLE
client: TestNewClientWithOpsFromEnv(): use sub-tests

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -85,23 +85,26 @@ func TestNewClientWithOpsFromEnv(t *testing.T) {
 		},
 	}
 
-	defer env.PatchAll(t, nil)()
+	env.PatchAll(t, nil)
 	for _, tc := range testcases {
-		env.PatchAll(t, tc.envs)
-		client, err := NewClientWithOpts(FromEnv)
-		if tc.expectedError != "" {
-			assert.Check(t, is.Error(err, tc.expectedError), tc.doc)
-		} else {
-			assert.Check(t, err, tc.doc)
-			assert.Check(t, is.Equal(client.ClientVersion(), tc.expectedVersion), tc.doc)
-		}
+		tc := tc
+		t.Run(tc.doc, func(t *testing.T) {
+			env.PatchAll(t, tc.envs)
+			client, err := NewClientWithOpts(FromEnv)
+			if tc.expectedError != "" {
+				assert.Check(t, is.Error(err, tc.expectedError))
+			} else {
+				assert.Check(t, err)
+				assert.Check(t, is.Equal(client.ClientVersion(), tc.expectedVersion))
+			}
 
-		if tc.envs["DOCKER_TLS_VERIFY"] != "" {
-			// pedantic checking that this is handled correctly
-			tr := client.client.Transport.(*http.Transport)
-			assert.Assert(t, tr.TLSClientConfig != nil, tc.doc)
-			assert.Check(t, is.Equal(tr.TLSClientConfig.InsecureSkipVerify, false), tc.doc)
-		}
+			if tc.envs["DOCKER_TLS_VERIFY"] != "" {
+				// pedantic checking that this is handled correctly
+				tr := client.client.Transport.(*http.Transport)
+				assert.Assert(t, tr.TLSClientConfig != nil)
+				assert.Check(t, is.Equal(tr.TLSClientConfig.InsecureSkipVerify, false))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Had this stashed as part of some other changes, so thought I'd push as a PR; with this patch:

    === RUN   TestNewClientWithOpsFromEnv/invalid_cert_path
    === RUN   TestNewClientWithOpsFromEnv/default_api_version_with_cert_path
    === RUN   TestNewClientWithOpsFromEnv/default_api_version_with_cert_path_and_tls_verify
    === RUN   TestNewClientWithOpsFromEnv/default_api_version_with_cert_path_and_host
    === RUN   TestNewClientWithOpsFromEnv/invalid_docker_host
    === RUN   TestNewClientWithOpsFromEnv/invalid_docker_host,_with_good_format
    === RUN   TestNewClientWithOpsFromEnv/override_api_version
    --- PASS: TestNewClientWithOpsFromEnv (0.00s)
        --- PASS: TestNewClientWithOpsFromEnv/default_api_version (0.00s)
        --- PASS: TestNewClientWithOpsFromEnv/invalid_cert_path (0.00s)
        --- PASS: TestNewClientWithOpsFromEnv/default_api_version_with_cert_path (0.00s)
        --- PASS: TestNewClientWithOpsFromEnv/default_api_version_with_cert_path_and_tls_verify (0.00s)
        --- PASS: TestNewClientWithOpsFromEnv/default_api_version_with_cert_path_and_host (0.00s)
        --- PASS: TestNewClientWithOpsFromEnv/invalid_docker_host (0.00s)
        --- PASS: TestNewClientWithOpsFromEnv/invalid_docker_host,_with_good_format (0.00s)
        --- PASS: TestNewClientWithOpsFromEnv/override_api_version (0.00s)
PASS

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

