### PR TITLE
[22.06 backport] Remove the OS check when creating a container

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -16,7 +16,6 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/idtools"
-	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/runconfig"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/selinux/go-selinux"
@@ -124,9 +123,6 @@ func (daemon *Daemon) create(opts createOpts) (retC *container.Container, retErr
 			return nil, err
 		}
 		os = img.OperatingSystem()
-		if !system.IsOSSupported(os) {
-			return nil, system.ErrNotSupportedOperatingSystem
-		}
 		imgID = img.ID()
 	} else if isWindows {
 		os = "linux" // 'scratch' case.


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44181

Now that we can pass any custom containerd shim to dockerd there is need for this check. Without this it becomes possible to use wasm shims for example with images that have "wasi" as the OS.

(cherry picked from commit 1a3d8019d1ddb82e8a6b437a8eccf2d22cbc8b5d)

**- A picture of a cute animal (not mandatory but encouraged)**

