### PR TITLE
container: remove Store interface, use concrete type

### DIFF
--- a/container/memory_store.go
+++ b/container/memory_store.go
@@ -4,60 +4,60 @@ import (
 	"sync"
 )
 
-// memoryStore implements a Store in memory.
-type memoryStore struct {
-	s map[string]*Container
-	sync.RWMutex
+// MemoryStore implements a Store in memory.
+type MemoryStore struct {
+	s  map[string]*Container
+	mu sync.RWMutex
 }
 
 // NewMemoryStore initializes a new memory store.
-func NewMemoryStore() Store {
-	return &memoryStore{
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{
 		s: make(map[string]*Container),
 	}
 }
 
 // Add appends a new container to the memory store.
 // It overrides the id if it existed before.
-func (c *memoryStore) Add(id string, cont *Container) {
-	c.Lock()
+func (c *MemoryStore) Add(id string, cont *Container) {
+	c.mu.Lock()
 	c.s[id] = cont
-	c.Unlock()
+	c.mu.Unlock()
 }
 
 // Get returns a container from the store by id.
-func (c *memoryStore) Get(id string) *Container {
+func (c *MemoryStore) Get(id string) *Container {
 	var res *Container
-	c.RLock()
+	c.mu.RLock()
 	res = c.s[id]
-	c.RUnlock()
+	c.mu.RUnlock()
 	return res
 }
 
 // Delete removes a container from the store by id.
-func (c *memoryStore) Delete(id string) {
-	c.Lock()
+func (c *MemoryStore) Delete(id string) {
+	c.mu.Lock()
 	delete(c.s, id)
-	c.Unlock()
+	c.mu.Unlock()
 }
 
 // List returns a sorted list of containers from the store.
 // The containers are ordered by creation date.
-func (c *memoryStore) List() []*Container {
+func (c *MemoryStore) List() []*Container {
 	containers := History(c.all())
 	containers.sort()
 	return containers
 }
 
 // Size returns the number of containers in the store.
-func (c *memoryStore) Size() int {
-	c.RLock()
-	defer c.RUnlock()
+func (c *MemoryStore) Size() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	return len(c.s)
 }
 
 // First returns the first container found in the store by a given filter.
-func (c *memoryStore) First(filter StoreFilter) *Container {
+func (c *MemoryStore) First(filter StoreFilter) *Container {
 	for _, cont := range c.all() {
 		if filter(cont) {
 			return cont
@@ -69,7 +69,7 @@ func (c *memoryStore) First(filter StoreFilter) *Container {
 // ApplyAll calls the reducer function with every container in the store.
 // This operation is asynchronous in the memory store.
 // NOTE: Modifications to the store MUST NOT be done by the StoreReducer.
-func (c *memoryStore) ApplyAll(apply StoreReducer) {
+func (c *MemoryStore) ApplyAll(apply StoreReducer) {
 	wg := new(sync.WaitGroup)
 	for _, cont := range c.all() {
 		wg.Add(1)
@@ -82,14 +82,12 @@ func (c *memoryStore) ApplyAll(apply StoreReducer) {
 	wg.Wait()
 }
 
-func (c *memoryStore) all() []*Container {
-	c.RLock()
+func (c *MemoryStore) all() []*Container {
+	c.mu.RLock()
 	containers := make([]*Container, 0, len(c.s))
 	for _, cont := range c.s {
 		containers = append(containers, cont)
 	}
-	c.RUnlock()
+	c.mu.RUnlock()
 	return containers
 }
-
-var _ Store = &memoryStore{}

--- a/container/memory_store_test.go
+++ b/container/memory_store_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestNewMemoryStore(t *testing.T) {
 	s := NewMemoryStore()
-	m, ok := s.(*memoryStore)
+	m, ok := s.(*MemoryStore)
 	if !ok {
 		t.Fatalf("store is not a memory store %v", s)
 	}

--- a/container/store.go
+++ b/container/store.go
@@ -7,22 +7,3 @@ type StoreFilter func(*Container) bool
 // StoreReducer defines a function to
 // manipulate containers in the store
 type StoreReducer func(*Container)
-
-// Store defines an interface that
-// any container store must implement.
-type Store interface {
-	// Add appends a new container to the store.
-	Add(string, *Container)
-	// Get returns a container from the store by the identifier it was stored with.
-	Get(string) *Container
-	// Delete removes a container from the store by the identifier it was stored with.
-	Delete(string)
-	// List returns a list of containers from the store.
-	List() []*Container
-	// Size returns the number of containers in the store.
-	Size() int
-	// First returns the first container found in the store by a given filter.
-	First(StoreFilter) *Container
-	// ApplyAll calls the reducer function with every container in the store.
-	ApplyAll(StoreReducer)
-}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -97,7 +97,7 @@ type configStore struct {
 type Daemon struct {
 	id                    string
 	repository            string
-	containers            container.Store
+	containers            *container.MemoryStore
 	containersReplica     *container.ViewDB
 	execCommands          *container.ExecStore
 	imageService          ImageService


### PR DESCRIPTION
This interface was introduced in 3c82fad44112dc73861f325bbecd68b9922b0ad3 (https://github.com/moby/moby/pull/19383). At the time, there only was a single implementation, and that's still the case six Years later, so let's drop the abstraction and use a concrete type.


**- A picture of a cute animal (not mandatory but encouraged)**

