### PR TITLE
[22.06 backport] Jenkinsfile: use Ubuntu 20.04 for DCO stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
                 beforeAgent true
                 expression { params.dco }
             }
-            agent { label 'amd64 && ubuntu-1804 && overlay2' }
+            agent { label 'arm64 && ubuntu-2004' }
             steps {
                 sh '''
                 docker run --rm \


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/42941

Also switching to use arm64, as all amd64 stages have moved to GitHub actions, so using arm64 allows the same machine to be used for tests after the DCO check completed.

(cherry picked from commit 419c47a80af9a0423f05592ddf7e8151cfb1eb0b)


