### PR TITLE
daemon: replaced exported errors with errdefs

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -16,11 +16,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ErrExtractPointNotDirectory is used to convey that the operation to extract
-// a tar archive to a directory in a container has failed because the specified
-// path does not refer to a directory.
-var ErrExtractPointNotDirectory = errors.New("extraction point is not a directory")
-
 // ContainerCopy performs a deprecated operation of archiving the resource at
 // the specified path in the container identified by the given name.
 func (daemon *Daemon) ContainerCopy(name string, res string) (io.ReadCloser, error) {
@@ -97,7 +92,7 @@ func (daemon *Daemon) ContainerArchivePath(name string, path string) (content io
 // ContainerExtractToDir extracts the given archive to the specified location
 // in the filesystem of the container identified by the given name. The given
 // path must be of a directory in the container. If it is not, the error will
-// be ErrExtractPointNotDirectory. If noOverwriteDirNonDir is true then it will
+// be an errdefs.InvalidParameter. If noOverwriteDirNonDir is true then it will
 // be an error if unpacking the given content would cause an existing directory
 // to be replaced with a non-directory and vice versa.
 func (daemon *Daemon) ContainerExtractToDir(name, path string, copyUIDGID, noOverwriteDirNonDir bool, content io.Reader) error {
@@ -239,7 +234,7 @@ func (daemon *Daemon) containerArchivePath(container *container.Container, path 
 
 // containerExtractToDir extracts the given tar archive to the specified location in the
 // filesystem of this container. The given path must be of a directory in the
-// container. If it is not, the error will be ErrExtractPointNotDirectory. If
+// container. If it is not, the error will be an errdefs.InvalidParameter. If
 // noOverwriteDirNonDir is true then it will be an error if unpacking the
 // given content would cause an existing directory to be replaced with a non-
 // directory and vice versa.
@@ -288,7 +283,7 @@ func (daemon *Daemon) containerExtractToDir(container *container.Container, path
 	}
 
 	if !stat.IsDir() {
-		return ErrExtractPointNotDirectory
+		return errdefs.InvalidParameter(errors.New("extraction point is not a directory"))
 	}
 
 	// Need to check if the path is in a volume. If it is, it cannot be in a

--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -326,7 +326,7 @@ func (daemon *Daemon) containerExtractToDir(container *container.Container, path
 	}
 
 	if !toVolume && container.HostConfig.ReadonlyRootfs {
-		return ErrRootFSReadOnly
+		return errdefs.InvalidParameter(errors.New("container rootfs is marked read-only"))
 	}
 
 	options := daemon.defaultTarCopyOptions(noOverwriteDirNonDir)

--- a/daemon/archive_unix.go
+++ b/daemon/archive_unix.go
@@ -5,7 +5,9 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/errdefs"
 	volumemounts "github.com/docker/docker/volume/mounts"
+	"github.com/pkg/errors"
 )
 
 // checkIfPathIsInAVolume checks if the path is in a volume. If it is, it
@@ -19,7 +21,7 @@ func checkIfPathIsInAVolume(container *container.Container, absPath string) (boo
 			if mnt.RW {
 				break
 			}
-			return false, ErrVolumeReadonly
+			return false, errdefs.InvalidParameter(errors.New("mounted volume is marked read-only"))
 		}
 	}
 	return toVolume, nil

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -26,10 +26,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// ErrRootFSReadOnly is returned when a container
-// rootfs is marked readonly.
-var ErrRootFSReadOnly = errors.New("container rootfs is marked read-only")
-
 func (daemon *Daemon) getDNSSearchSettings(container *container.Container) []string {
 	if len(container.HostConfig.DNSSearch) > 0 {
 		return container.HostConfig.DNSSearch

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -26,12 +26,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var (
-	// ErrRootFSReadOnly is returned when a container
-	// rootfs is marked readonly.
-	ErrRootFSReadOnly = errors.New("container rootfs is marked read-only")
-	getPortMapInfo    = getSandboxPortMapInfo
-)
+// ErrRootFSReadOnly is returned when a container
+// rootfs is marked readonly.
+var ErrRootFSReadOnly = errors.New("container rootfs is marked read-only")
 
 func (daemon *Daemon) getDNSSearchSettings(container *container.Container) []string {
 	if len(container.HostConfig.DNSSearch) > 0 {

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -886,7 +886,7 @@ func buildCreateEndpointOptions(c *container.Container, n libnetwork.Network, ep
 	}
 
 	// Port-mapping rules belong to the container & applicable only to non-internal networks
-	portmaps := getSandboxPortMapInfo(sb)
+	portmaps := getPortMapInfo(sb)
 	if n.Info().Internal() || len(portmaps) > 0 {
 		return createOptions, nil
 	}
@@ -960,8 +960,8 @@ func buildCreateEndpointOptions(c *container.Container, n libnetwork.Network, ep
 	return createOptions, nil
 }
 
-// getSandboxPortMapInfo retrieves the current port-mapping programmed for the given sandbox
-func getSandboxPortMapInfo(sb libnetwork.Sandbox) nat.PortMap {
+// getPortMapInfo retrieves the current port-mapping programmed for the given sandbox
+func getPortMapInfo(sb libnetwork.Sandbox) nat.PortMap {
 	pm := nat.PortMap{}
 	if sb == nil {
 		return pm

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -21,12 +21,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var (
-	// ErrVolumeReadonly is used to signal an error when trying to copy data into
-	// a volume mount that is not writable.
-	ErrVolumeReadonly = errors.New("mounted volume is marked read-only")
-)
-
 type mounts []container.Mount
 
 // Len returns the number of mounts. Used in sorting.

--- a/integration-cli/docker_cli_cp_to_container_test.go
+++ b/integration-cli/docker_cli_cp_to_container_test.go
@@ -411,9 +411,7 @@ func (s *DockerCLICpSuite) TestCpToErrReadOnlyRootfs(c *testing.T) {
 	dstPath := containerCpPath(containerID, "/root/shouldNotExist")
 
 	err := runDockerCp(c, srcPath, dstPath)
-	assert.ErrorContains(c, err, "")
-
-	assert.Assert(c, isCpCannotCopyReadOnly(err), "expected ErrContainerRootfsReadonly error, but got %T: %s", err, err)
+	assert.ErrorContains(c, err, "marked read-only")
 	assert.NilError(c, containerStartOutputEquals(c, containerID, ""), "dstPath should not have existed")
 }
 
@@ -436,8 +434,7 @@ func (s *DockerCLICpSuite) TestCpToErrReadOnlyVolume(c *testing.T) {
 	dstPath := containerCpPath(containerID, "/vol_ro/shouldNotExist")
 
 	err := runDockerCp(c, srcPath, dstPath)
-	assert.ErrorContains(c, err, "")
+	assert.ErrorContains(c, err, "marked read-only")
 
-	assert.Assert(c, isCpCannotCopyReadOnly(err), "expected ErrVolumeReadonly error, but got %T: %s", err, err)
 	assert.NilError(c, containerStartOutputEquals(c, containerID, ""), "dstPath should not have existed")
 }

--- a/integration-cli/docker_cli_cp_utils_test.go
+++ b/integration-cli/docker_cli_cp_utils_test.go
@@ -232,10 +232,6 @@ func isCpCannotCopyDir(err error) bool {
 	return strings.Contains(err.Error(), archive.ErrCannotCopyDir.Error())
 }
 
-func isCpCannotCopyReadOnly(err error) bool {
-	return strings.Contains(err.Error(), "marked read-only")
-}
-
 func fileContentEquals(c *testing.T, filename, contents string) error {
 	c.Helper()
 


### PR DESCRIPTION
This removes some exported errors that were added in https://github.com/moby/moby/pull/13171, but not actually used as sentinel errors. As there was no special handling for these errors (and returning the error through the API would lose its type either way), this pull request replaces them with an `errdefs.InvalidParameter` so that the API can return a proper status code for them.

### daemon: replace ErrRootFSReadOnly with errdefs

It was only used in a single location, and the ErrRootFSReadOnly was not checked
for, or used as a sentinel error.

This error was introduced in c32dde5baadc8c472666ef9d5cead13ab6de28ea, originally
named `ErrContainerRootfsReadonly`. It was never used as a sentinel error, but
from that commit, it looks like it was added as a package variable to mirror
the coding style of already existing errors defined at the package level.

This patch removes the exported variable, and replaces the error with an
errdefs.InvalidParameter(), so that the API also returns the correct (400)
status code.


### daemon: replace ErrVolumeReadonly with errdefs

It was only used in a single location, and the ErrVolumeReadonly was not checked
for, or used as a sentinel error.

This error was introduced in c32dde5baadc8c472666ef9d5cead13ab6de28ea. It was
never used as a sentinel error, but from that commit, it looks like it was added
as a package variable to mirror already existing errors defined at the package
level.

This patch removes the exported variable, and replaces the error with an
errdefs.InvalidParameter(), so that the API also returns the correct (400)
status code.

### daemon: replace ErrExtractPointNotDirectory with errdefs

It was only used in a single location, and the ErrExtractPointNotDirectory was
not checked for, or used as a sentinel error.

This error was introduced in c32dde5baadc8c472666ef9d5cead13ab6de28ea. It was
never used as a sentinel error, but from that commit, it looks like it was added
as a package variable to mirror already existing errors defined at the package
level.

This patch removes the exported variable, and replaces the error with an
errdefs.InvalidParameter(), so that the API also returns the correct (400)
status code.