### PR TITLE
contrib: make dockerd-rootless-setuptool.sh more robust

### DIFF
--- a/contrib/dockerd-rootless-setuptool.sh
+++ b/contrib/dockerd-rootless-setuptool.sh
@@ -354,24 +354,24 @@ install_nonsystemd() {
 
 cli_ctx_exists() {
 	name="$1"
-	"${BIN}/docker" context inspect -f "{{.Name}}" "${name}" > /dev/null 2>&1
+	"${BIN}/docker" --context=default context inspect -f "{{.Name}}" "${name}" > /dev/null 2>&1
 }
 
 cli_ctx_create() {
 	name="$1"
 	host="$2"
 	description="$3"
-	"${BIN}/docker" context create "${name}" --docker "host=${host}" --description "${description}" > /dev/null
+	"${BIN}/docker" --context=default context create "${name}" --docker "host=${host}" --description "${description}" > /dev/null
 }
 
 cli_ctx_use() {
 	name="$1"
-	"${BIN}/docker" context use "${name}" > /dev/null
+	"${BIN}/docker" --context=default context use "${name}" > /dev/null
 }
 
 cli_ctx_rm() {
 	name="$1"
-	"${BIN}/docker" context rm -f "${name}" > /dev/null
+	"${BIN}/docker" --context=default context rm -f "${name}" > /dev/null
 }
 
 # CLI subcommand: "install"
@@ -430,7 +430,12 @@ cmd_entrypoint_uninstall() {
 		cli_ctx_rm "${CLI_CONTEXT}"
 		INFO "Deleted CLI context \"${CLI_CONTEXT}\""
 	fi
-
+	unset DOCKER_HOST
+	unset DOCKER_CONTEXT
+	cli_ctx_use "default"
+	INFO 'Configured CLI use the "default" context.'
+	INFO
+	INFO 'Make sure to unset or update the environment PATH, DOCKER_HOST, and DOCKER_CONTEXT environment variables if you have added them to `~/.bashrc`.'
 	INFO "This uninstallation tool does NOT remove Docker binaries and data."
 	INFO "To remove data, run: \`$BIN/rootlesskit rm -rf $HOME/.local/share/docker\`"
 }


### PR DESCRIPTION
- relates to https://github.com/docker/docker.github.io/pull/14727

The `docker` CLI currently doesn't handle situations where the current context (as defined in `~/.docker/config.json`) is invalid or doesn't exist. As loading (and checking) the context happens during initialization of the CLI, this prevents `docker context` commands from being used, which makes it complicated to fix the situation. For example, running `docker context use <correct context>` would fail, which makes it not possible to update the `~/.docker/config.json`, unless doing so manually.

For example, given the following `~/.docker/config.json`:

```json
{
        "currentContext": "nosuchcontext"
}
```

All of the commands below fail:

```bash
docker context inspect rootless
Current context "nosuchcontext" is not found on the file system, please check your config file at /Users/thajeztah/.docker/config.json

docker context rm --force rootless
Current context "nosuchcontext" is not found on the file system, please check your config file at /Users/thajeztah/.docker/config.json

docker context use default
Current context "nosuchcontext" is not found on the file system, please check your config file at /Users/thajeztah/.docker/config.json
```

While these things should be fixed, this patch updates the script to switch the context using the `--context` flag; this flag is taken into account when initializing the CLI, so that having an invalid context configured won't block `docker context` commands from being executed. Given that all `context` commands are local operations, "any" context can be used (it doesn't need to make a connection with the daemon).

With this patch, those commands can now be run (and won't fail for the wrong reason);

```bash
 docker --context=default context inspect -f "{{.Name}}" rootless
rootless

docker --context=default context inspect -f "{{.Name}}" rootless-doesnt-exist
context "rootless-doesnt-exist" does not exist
```

One other issue may also cause things to fail during uninstall; trying to remove a context that doesn't exist will fail (even with the `-f` / `--force` option set);

```bash
docker --context=default context rm blablabla
Error: context "blablabla": not found
```

While this is "ok" in most circumstances, it also means that (potentially) the current context is not reset to "default", so this patch adds an explicit `docker context use`, as well as unsetting the `DOCKER_HOST` and `DOCKER_CONTEXT` environment variables.

**- A picture of a cute animal (not mandatory but encouraged)**

