### PR TITLE
hack/install: Update docker-cli source, add missing platforms

### DIFF
--- a/hack/dockerfile/install/dockercli.installer
+++ b/hack/dockerfile/install/dockercli.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 : ${DOCKERCLI_CHANNEL:=stable}
-: ${DOCKERCLI_VERSION:=17.06.2-ce}
+: ${DOCKERCLI_VERSION:=18.06.3-ce}
 
 install_dockercli() {
 	echo "Install docker/cli version $DOCKERCLI_VERSION from $DOCKERCLI_CHANNEL"

--- a/hack/dockerfile/install/dockercli.installer
+++ b/hack/dockerfile/install/dockercli.installer
@@ -7,17 +7,23 @@ install_dockercli() {
 	echo "Install docker/cli version $DOCKERCLI_VERSION from $DOCKERCLI_CHANNEL"
 
 	arch=$(uname -m)
-	# No official release of these platforms
-	if [ "$arch" != "x86_64" ] && [ "$arch" != "s390x" ] && [ "$arch" != "armhf" ]; then
-		build_dockercli
-		return
-	fi
+	case $arch in
+		# These platforms have official binaries builds
+		"x86_64" | "armhf" | "armel" | "aarch64" | "s390x" | "ppc64le")
+			base_url=https://download.docker.com/linux/static
 
-	url=https://download.docker.com/linux/static
-	curl -Ls "${url}/${DOCKERCLI_CHANNEL}/${arch}/docker-${DOCKERCLI_VERSION}.tgz" | tar -xz docker/docker
-	mkdir -p "${PREFIX}"
-	mv docker/docker "${PREFIX}/"
-	rmdir docker
+			url="${base_url}/${DOCKERCLI_CHANNEL}/${arch}/docker-${DOCKERCLI_VERSION}.tgz"
+			if curl -Ls "$url" | tar -xz docker/docker; then
+				mkdir -p "${PREFIX}"
+				mv docker/docker "${PREFIX}/"
+				rmdir docker
+				return
+			fi
+			;;
+	esac
+
+	# Fallback to build
+	build_dockercli
 }
 
 build_dockercli() {

--- a/hack/dockerfile/install/dockercli.installer
+++ b/hack/dockerfile/install/dockercli.installer
@@ -21,10 +21,10 @@ install_dockercli() {
 }
 
 build_dockercli() {
-	git clone https://github.com/docker/docker-ce "$GOPATH/tmp/docker-ce"
-	cd "$GOPATH/tmp/docker-ce"
-	git checkout -q "v$DOCKERCLI_VERSION"
 	mkdir -p "$GOPATH/src/github.com/docker"
-	mv components/cli "$GOPATH/src/github.com/docker/cli"
+	cd "$GOPATH/src/github.com/docker"
+	git clone https://github.com/docker/cli
+	cd cli
+	git checkout -q "v$DOCKERCLI_VERSION"
 	go build ${GO_BUILDMODE} -o "${PREFIX}/docker" "github.com/docker/cli/cmd/docker"
 }


### PR DESCRIPTION
Since the docker-ce repo is deprecated, change the source repository used for building the cli to docker/cli.
The cli will also be built from source, if the binary download fails.
Add platforms which binaries are available on the download.docker.com, but are missing in the installer.
Also, added a fallback to building the cli from source when the binary download fails. 

**- A picture of a cute animal (not mandatory but encouraged)**

![turtle](https://user-images.githubusercontent.com/5046555/192825797-9e28ff8d-3d3b-4c7d-b8ea-ac184f6547f0.jpg)
