### PR TITLE
Stop subprocesses from getting unexpectedly killed

### DIFF
--- a/daemon/graphdriver/overlay2/mount.go
+++ b/daemon/graphdriver/overlay2/mount.go
@@ -50,6 +50,13 @@ func mountFrom(dir, device, target, mType string, flags uintptr, label string) e
 	output := bytes.NewBuffer(nil)
 	cmd.Stdout = output
 	cmd.Stderr = output
+
+	// reexec.Command() sets cmd.SysProcAttr.Pdeathsig on Linux, which
+	// causes the started process to be signaled when the creating OS thread
+	// dies. Ensure that the reexec is not prematurely signaled. See
+	// https://go.dev/issue/27505 for more information.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	if err := cmd.Start(); err != nil {
 		w.Close()
 		return fmt.Errorf("mountfrom error on re-exec cmd: %v", err)

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -404,6 +404,7 @@ func waitUntilFlushedImpl(s *journald) error {
 	go func() {
 		defer close(flushed)
 		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
 
 		var (
 			j   *sdjournal.Journal

--- a/pkg/reexec/command_linux.go
+++ b/pkg/reexec/command_linux.go
@@ -17,6 +17,11 @@ func Self() string {
 // SysProcAttr.Pdeathsig to SIGTERM.
 // This will use the in-memory version (/proc/self/exe) of the current binary,
 // it is thus safe to delete or replace the on-disk binary (os.Args[0]).
+//
+// As SysProcAttr.Pdeathsig is set, the signal will be sent to the process when
+// the OS thread which created the process dies. It is the caller's
+// responsibility to ensure that the creating thread is not terminated
+// prematurely. See https://go.dev/issue/27505 for more details.
 func Command(args ...string) *exec.Cmd {
 	return &exec.Cmd{
 		Path: Self(),


### PR DESCRIPTION
The behaviour of `(syscall.SysProcAttr).Pdeathsig` on Linux has some surprising behaviour, as detailed in https://github.com/golang/go/issues/27505. The parent death signal is sent to the child process when the creating _thread_ dies, which in a Go program is going to be an arbitrary thread taken from the goroutine thread pool and recycled for other goroutines to execute on. A goroutine can cause the thread it is running on to exit by wiring itself to the thread with `runtime.LockOSThread()` and returning. Letting the creating thread become available for other goroutines risks having that thread terminated arbitrarily, and the child process with it.

While the problem can in theory be worked around by ensuring that no goroutine returns while wired to a thread, this is not practical. Unpaired `runtime.LockOSThread()` calls could be tucked away in third-party modules, and mistakes happen in first-party code. And there are legitimate use-cases for terminating threads early, which [heavily overlap with the use-cases for `pkg/reexec`](https://www.weave.works/blog/linux-namespaces-golang-followup), which makes it impractical to ban. The only viable solution is to arrange for the threads which are parents of subprocesses started with `Pdeathsig` to not be eligible for other goroutines to execute on them while the subprocess is alive.

**- What I did**
* Audited all calls to `runtime.LockOSThread()` in non-vendor code in the daemon process to ensure they had matching `runtime.UnlockOSThread()` calls. Unmatched calls in reexec functions were left alone.
* Ensured that the threads which create subprocesses with `Pdeathsig` could not be terminated before the subprocess or the daemon process exited, whichever comes first.

**- How I did it**
* `runtime.LockOSThread()` is both the problem and solution

**- How to verify it**
* CI 🟢 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* Resolved an issue which could potentially cause daemon-managed containerd or certain utility subprocesses from being prematurely killed on Linux

**- A picture of a cute animal (not mandatory but encouraged)**

