### PR TITLE
pkg: replace some README's with GoDoc package descriptions

### DIFF
--- a/pkg/archive/README.md
+++ b/pkg/archive/README.md
@@ -1,1 +1,0 @@
-This code provides helper functions for dealing with archive files.

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -1,3 +1,4 @@
+// Package archive provides helper functions for dealing with archive files.
 package archive // import "github.com/docker/docker/pkg/archive"
 
 import (

--- a/pkg/reexec/README.md
+++ b/pkg/reexec/README.md
@@ -1,5 +1,0 @@
-# reexec
-
-The `reexec` package facilitates the busybox style reexec of the docker binary that we require because 
-of the forking limitations of using Go.  Handlers can be registered with a name and the argv 0 of 
-the exec of the binary will be used to find and execute custom init paths.

--- a/pkg/reexec/reexec.go
+++ b/pkg/reexec/reexec.go
@@ -1,3 +1,7 @@
+// Package reexec facilitates the busybox style reexec of the docker binary that
+// we require because of the forking limitations of using Go.  Handlers can be
+// registered with a name and the argv 0 of the exec of the binary will be used
+// to find and execute custom init paths.
 package reexec // import "github.com/docker/docker/pkg/reexec"
 
 import (

--- a/pkg/stringid/README.md
+++ b/pkg/stringid/README.md
@@ -1,1 +1,0 @@
-This package provides helper functions for dealing with string identifiers

--- a/pkg/sysinfo/README.md
+++ b/pkg/sysinfo/README.md
@@ -1,1 +1,0 @@
-SysInfo stores information about which features a kernel supports.

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -1,3 +1,4 @@
+// Package sysinfo stores information about which features a kernel supports.
 package sysinfo // import "github.com/docker/docker/pkg/sysinfo"
 
 import "github.com/docker/docker/pkg/parsers"


### PR DESCRIPTION
In preparation of adding more linters (quite some other packages to do, but I had these ones lingering around).