### PR TITLE
Fix force-remove for cluster volumes

### DIFF
--- a/api/server/router/volume/volume_routes_test.go
+++ b/api/server/router/volume/volume_routes_test.go
@@ -574,6 +574,7 @@ func TestVolumeRemoveSwarmForce(t *testing.T) {
 
 	assert.NilError(t, err)
 	assert.Equal(t, len(b.volumes), 0)
+	assert.Equal(t, len(c.volumes), 0)
 }
 
 type fakeVolumeBackend struct {
@@ -616,9 +617,16 @@ func (b *fakeVolumeBackend) Create(_ context.Context, name, driverName string, _
 	return v, nil
 }
 
-func (b *fakeVolumeBackend) Remove(_ context.Context, name string, _ ...opts.RemoveOption) error {
+func (b *fakeVolumeBackend) Remove(_ context.Context, name string, o ...opts.RemoveOption) error {
+	removeOpts := &opts.RemoveConfig{}
+	for _, opt := range o {
+		opt(removeOpts)
+	}
+
 	if v, ok := b.volumes[name]; !ok {
-		return errdefs.NotFound(fmt.Errorf("volume %s not found", name))
+		if !removeOpts.PurgeOnError {
+			return errdefs.NotFound(fmt.Errorf("volume %s not found", name))
+		}
 	} else if v.Name == "inuse" {
 		return errdefs.Conflict(fmt.Errorf("volume in use"))
 	}


### PR DESCRIPTION
Signed-off-by: Drew Erny <derny@mirantis.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixes force remove functionality for Swarm Cluster Volumes

**- How I did it**

Previously, the code assumed that attempting to force remove a local volume that did not exist would return a Not Found error. This is not the case; force-remove always returns no error. To correctly force-remove volumes, we must force locally and then send a force remove to Swarm.