### PR TITLE
[22.06 backport] fix (whitespace) formatting in preparation of enabling more linters

### DIFF
--- a/api/server/middleware/version.go
+++ b/api/server/middleware/version.go
@@ -61,5 +61,4 @@ func (v VersionMiddleware) WrapHandler(handler func(ctx context.Context, w http.
 		ctx = context.WithValue(ctx, httputils.APIVersionKey{}, apiVersion)
 		return handler(ctx, w, r, vars)
 	}
-
 }

--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -238,7 +238,6 @@ func (br *buildRouter) postBuild(ctx context.Context, w http.ResponseWriter, r *
 	defer func() { _ = output.Close() }()
 
 	errf := func(err error) error {
-
 		if httputils.BoolValue(r, "q") && notVerboseBuffer.Len() > 0 {
 			_, _ = output.Write(notVerboseBuffer.Bytes())
 		}

--- a/api/server/router/swarm/helpers_test.go
+++ b/api/server/router/swarm/helpers_test.go
@@ -115,5 +115,4 @@ func TestAdjustForAPIVersion(t *testing.T) {
 	if len(spec.TaskTemplate.ContainerSpec.Ulimits) != 0 {
 		t.Error("Ulimits were not stripped from spec")
 	}
-
 }

--- a/api/types/strslice/strslice_test.go
+++ b/api/types/strslice/strslice_test.go
@@ -33,17 +33,16 @@ func TestStrSliceUnmarshalJSON(t *testing.T) {
 		"[]":                      {},
 		`["/bin/sh","-c","echo"]`: {"/bin/sh", "-c", "echo"},
 	}
-	for json, expectedParts := range parts {
+	for input, expected := range parts {
 		strs := StrSlice{"default", "values"}
-		if err := strs.UnmarshalJSON([]byte(json)); err != nil {
+		if err := strs.UnmarshalJSON([]byte(input)); err != nil {
 			t.Fatal(err)
 		}
 
 		actualParts := []string(strs)
-		if !reflect.DeepEqual(actualParts, expectedParts) {
-			t.Fatalf("%#v: expected %v, got %v", json, expectedParts, actualParts)
+		if !reflect.DeepEqual(actualParts, expected) {
+			t.Fatalf("%#v: expected %v, got %v", input, expected, actualParts)
 		}
-
 	}
 }
 

--- a/builder/builder-next/adapters/containerimage/pull.go
+++ b/builder/builder-next/adapters/containerimage/pull.go
@@ -177,7 +177,7 @@ func (is *Source) Resolve(ctx context.Context, id source.Identifier, sm *session
 	p := &puller{
 		src: imageIdentifier,
 		is:  is,
-		//resolver: is.getResolver(is.RegistryHosts, imageIdentifier.Reference.String(), sm, g),
+		// resolver: is.getResolver(is.RegistryHosts, imageIdentifier.Reference.String(), sm, g),
 		platform: platform,
 		sm:       sm,
 	}
@@ -439,7 +439,6 @@ func (p *puller) Snapshot(ctx context.Context, g session.Group) (cache.Immutable
 		// TODO: Optimize to do dispatch and integrate pulling with download manager,
 		// leverage existing blob mapping and layer storage
 	} else {
-
 		// TODO: need a wrapper snapshot interface that combines content
 		// and snapshots as 1) buildkit shouldn't have a dependency on contentstore
 		// or 2) cachemanager should manage the contentstore

--- a/builder/builder-next/adapters/localinlinecache/inlinecache.go
+++ b/builder/builder-next/adapters/localinlinecache/inlinecache.go
@@ -24,7 +24,6 @@ import (
 
 // ResolveCacheImporterFunc returns a resolver function for local inline cache
 func ResolveCacheImporterFunc(sm *session.Manager, resolverFunc docker.RegistryHosts, cs content.Store, rs reference.Store, is imagestore.Store) remotecache.ResolveCacheImporterFunc {
-
 	upstream := registryremotecache.ResolveCacheImporterFunc(sm, cs, resolverFunc)
 
 	return func(ctx context.Context, group session.Group, attrs map[string]string) (remotecache.Importer, specs.Descriptor, error) {

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -295,7 +295,6 @@ func (b *Builder) dispatchDockerfileWithCancellation(parseResult []instructions.
 			}
 			dispatchRequest.state.updateRunConfig()
 			fmt.Fprintf(b.Stdout, " ---> %s\n", stringid.TruncateID(dispatchRequest.state.imageID))
-
 		}
 		if err := emitImageID(b.Aux, dispatchRequest.state); err != nil {
 			return nil, err

--- a/builder/dockerfile/copy.go
+++ b/builder/dockerfile/copy.go
@@ -105,7 +105,6 @@ func copierFromDispatchRequest(req dispatchRequest, download sourceDownloader, i
 		imageSource: imageSource,
 		platform:    platform,
 	}
-
 }
 
 func (o *copier) createCopyInstruction(sourcesAndDest instructions.SourcesAndDest, cmdName string) (copyInstruction, error) {

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -64,7 +64,6 @@ func dispatchEnv(d dispatchRequest, c *instructions.EnvCommand) error {
 //
 // Sets the maintainer metadata.
 func dispatchMaintainer(d dispatchRequest, c *instructions.MaintainerCommand) error {
-
 	d.state.maintainer = c.Maintainer
 	return d.builder.commit(d.state, "MAINTAINER "+c.Maintainer)
 }
@@ -557,7 +556,6 @@ func dispatchVolume(d dispatchRequest, c *instructions.VolumeCommand) error {
 //
 // Set the signal that will be used to kill the container.
 func dispatchStopSignal(d dispatchRequest, c *instructions.StopSignalCommand) error {
-
 	_, err := signal.ParseSignal(c.Signal)
 	if err != nil {
 		return errdefs.InvalidParameter(err)

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -284,7 +284,6 @@ func TestHealthcheckNone(t *testing.T) {
 }
 
 func TestHealthcheckCmd(t *testing.T) {
-
 	b := newBuilderWithMockBackend()
 	sb := newDispatchRequest(b, '`', nil, NewBuildArgs(make(map[string]*string)), newStagesBuildResults())
 	expectedTest := []string{"CMD-SHELL", "curl -f http://localhost/ || exit 1"}

--- a/builder/dockerfile/internals_test.go
+++ b/builder/dockerfile/internals_test.go
@@ -140,7 +140,6 @@ func TestCopyRunConfig(t *testing.T) {
 		// Assert the original was not modified
 		assert.Check(t, runConfig != runConfigCopy, testcase.doc)
 	}
-
 }
 
 func fullMutableRunConfig() *container.Config {

--- a/builder/remotecontext/detect_test.go
+++ b/builder/remotecontext/detect_test.go
@@ -72,7 +72,6 @@ func TestProcessShouldRemoveDockerfileDockerignore(t *testing.T) {
 	executeProcess(t, contextDir)
 
 	checkDirectory(t, contextDir, []string{shouldStayFilename})
-
 }
 
 func TestProcessNoDockerignore(t *testing.T) {
@@ -85,7 +84,6 @@ func TestProcessNoDockerignore(t *testing.T) {
 	executeProcess(t, contextDir)
 
 	checkDirectory(t, contextDir, []string{shouldStayFilename, builder.DefaultDockerfileName})
-
 }
 
 func TestProcessShouldLeaveAllFiles(t *testing.T) {
@@ -99,7 +97,6 @@ func TestProcessShouldLeaveAllFiles(t *testing.T) {
 	executeProcess(t, contextDir)
 
 	checkDirectory(t, contextDir, []string{shouldStayFilename, builder.DefaultDockerfileName, dockerignoreFilename})
-
 }
 
 // TODO: remove after moving to a separate pkg

--- a/client/events.go
+++ b/client/events.go
@@ -17,7 +17,6 @@ import (
 // be sent over the error channel. If an error is sent all processing will be stopped. It's up
 // to the caller to reopen the stream in the event of an error by reinvoking this method.
 func (cli *Client) Events(ctx context.Context, options types.EventsOptions) (<-chan events.Message, <-chan error) {
-
 	messages := make(chan events.Message)
 	errs := make(chan error, 1)
 

--- a/client/events_test.go
+++ b/client/events_test.go
@@ -58,7 +58,6 @@ func TestEventsErrorFromServer(t *testing.T) {
 }
 
 func TestEvents(t *testing.T) {
-
 	expectedURL := "/events"
 
 	filters := filters.NewArgs()

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -323,7 +323,6 @@ func newRouterOptions(config *config.Config, d *daemon.Daemon) (routerOptions, e
 
 func (cli *DaemonCli) reloadConfig() {
 	reload := func(c *config.Config) {
-
 		// Revalidate and reload the authorization plugins
 		if err := validateAuthzPlugins(c.AuthorizationPlugins, cli.d.PluginStore); err != nil {
 			logrus.Fatalf("Error validating authorization plugin: %v", err)

--- a/cmd/dockerd/trap/trap_linux_test.go
+++ b/cmd/dockerd/trap/trap_linux_test.go
@@ -62,5 +62,4 @@ func TestTrap(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/daemon/cluster/convert/container.go
+++ b/daemon/cluster/convert/container.go
@@ -222,7 +222,6 @@ func configReferencesToGRPC(sr []*types.ConfigReference) ([]*swarmapi.ConfigRefe
 func configReferencesFromGRPC(sr []*swarmapi.ConfigReference) []*types.ConfigReference {
 	refs := make([]*types.ConfigReference, 0, len(sr))
 	for _, s := range sr {
-
 		r := &types.ConfigReference{
 			ConfigID:   s.ConfigID,
 			ConfigName: s.ConfigName,

--- a/daemon/cluster/convert/network.go
+++ b/daemon/cluster/convert/network.go
@@ -120,7 +120,6 @@ func endpointFromGRPC(e *swarmapi.Endpoint) types.Endpoint {
 				NetworkID: v.NetworkID,
 				Addr:      v.Addr})
 		}
-
 	}
 
 	return endpoint

--- a/daemon/cluster/convert/service.go
+++ b/daemon/cluster/convert/service.go
@@ -96,7 +96,6 @@ func serviceSpecFromGRPC(spec *swarmapi.ServiceSpec) (*types.ServiceSpec, error)
 	for _, n := range spec.Networks {
 		netConfig := types.NetworkAttachmentConfig{Target: n.Target, Aliases: n.Aliases, DriverOpts: n.DriverAttachmentOpts}
 		serviceNetworks = append(serviceNetworks, netConfig)
-
 	}
 
 	taskTemplate, err := taskSpecFromGRPC(spec.Task)
@@ -169,7 +168,6 @@ func ServiceSpecToGRPC(s types.ServiceSpec) (swarmapi.ServiceSpec, error) {
 	for _, n := range s.TaskTemplate.Networks {
 		netConfig := &swarmapi.NetworkAttachmentConfig{Target: n.Target, Aliases: n.Aliases, DriverAttachmentOpts: n.DriverOpts}
 		taskNetworks = append(taskNetworks, netConfig)
-
 	}
 
 	spec := swarmapi.ServiceSpec{
@@ -473,7 +471,6 @@ func resourcesToGRPC(res *types.ResourceRequirements) *swarmapi.ResourceRequirem
 				MemoryBytes: res.Reservations.MemoryBytes,
 				Generic:     GenericResourcesToGRPC(res.Reservations.GenericResources),
 			}
-
 		}
 	}
 	return reqs
@@ -536,7 +533,6 @@ func restartPolicyToGRPC(p *types.RestartPolicy) (*swarmapi.RestartPolicy, error
 		}
 		if p.MaxAttempts != nil {
 			rp.MaxAttempts = *p.MaxAttempts
-
 		}
 	}
 	return rp, nil

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -455,7 +455,6 @@ func (c *containerAdapter) createVolumes(ctx context.Context) error {
 			// It returns an error if the driver name is different - that is a valid error
 			return err
 		}
-
 	}
 
 	return nil

--- a/daemon/cluster/executor/container/health_test.go
+++ b/daemon/cluster/executor/container/health_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestHealthStates(t *testing.T) {
-
 	// set up environment: events, task, container ....
 	e := events.New()
 	_, l, _ := e.Subscribe()

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -247,14 +247,11 @@ func (c *Cluster) CreateService(s types.ServiceSpec, encodedAuth string, queryRe
 					logrus.Warnf("unable to pin image %s to digest: %s", ctnr.Image, err.Error())
 					// warning in the client response should be concise
 					resp.Warnings = append(resp.Warnings, digestWarning(ctnr.Image))
-
 				} else if ctnr.Image != digestImage {
 					logrus.Debugf("pinning image %s by digest: %s", ctnr.Image, digestImage)
 					ctnr.Image = digestImage
-
 				} else {
 					logrus.Debugf("creating service using supplied digest reference %s", ctnr.Image)
-
 				}
 
 				// Replace the context with a fresh one.
@@ -286,7 +283,6 @@ func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec typ
 	var resp *apitypes.ServiceUpdateResponse
 
 	err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
-
 		err := c.populateNetworkID(ctx, state.controlClient, &spec)
 		if err != nil {
 			return err

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -562,7 +562,6 @@ func (daemon *Daemon) allocateNetwork(container *container.Container) (retErr er
 		if err := daemon.connectToNetwork(container, defaultNetName, nConf.EndpointSettings, updateSettings); err != nil {
 			return err
 		}
-
 	}
 
 	// the intermediate map is necessary because "connectToNetwork" modifies "container.NetworkSettings.Networks"
@@ -601,7 +600,6 @@ func (daemon *Daemon) allocateNetwork(container *container.Container) (retErr er
 				}
 			}()
 		}
-
 	}
 
 	if _, err := container.WriteHostConfig(); err != nil {

--- a/daemon/daemon_linux_test.go
+++ b/daemon/daemon_linux_test.go
@@ -342,5 +342,4 @@ func TestRootMountCleanup(t *testing.T) {
 		checkMounted(t, cfg.Root, false)
 		assert.Assert(t, d.cleanupMounts())
 	})
-
 }

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -558,7 +558,6 @@ func verifyPlatformContainerResources(resources *containertypes.Resources, sysIn
 	if len(resources.BlkioDeviceWriteBps) > 0 && !sysInfo.BlkioWriteBpsDevice {
 		warnings = append(warnings, "Your kernel does not support BPS Block I/O write limit or the cgroup is not mounted. Block I/O BPS write limit discarded.")
 		resources.BlkioDeviceWriteBps = []*pblkiodev.ThrottleDevice{}
-
 	}
 	if len(resources.BlkioDeviceReadIOps) > 0 && !sysInfo.BlkioReadIOpsDevice {
 		warnings = append(warnings, "Your kernel does not support IOPS Block read limit or the cgroup is not mounted. Block I/O IOPS read limit discarded.")
@@ -1090,7 +1089,6 @@ func setupInitLayer(idMapping idtools.IdentityMapping) func(containerfs.Containe
 //
 // If names are used, they are verified to exist in passwd/group
 func parseRemappedRoot(usergrp string) (string, string, error) {
-
 	var (
 		userID, groupID     int
 		username, groupname string

--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -237,7 +237,6 @@ func (a *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 // Create three folders for each id
 // mnt, layers, and diff
 func (a *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
-
 	if opts != nil && len(opts.StorageOpt) != 0 {
 		return fmt.Errorf("--storage-opt is not supported for aufs")
 	}

--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -51,7 +51,6 @@ type btrfsOptions struct {
 // Init returns a new BTRFS driver.
 // An error is returned if BTRFS is not supported.
 func Init(home string, options []string, idMap idtools.IdentityMapping) (graphdriver.Driver, error) {
-
 	// Perform feature detection on /var/lib/docker/btrfs if it's an existing directory.
 	// This covers situations where /var/lib/docker/btrfs is a mount, and on a different
 	// filesystem than /var/lib/docker.

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -647,7 +647,6 @@ func (devices *DeviceSet) migrateOldMetaData() error {
 		if err := os.Rename(devices.oldMetadataFile(), devices.oldMetadataFile()+".migrated"); err != nil {
 			return err
 		}
-
 	}
 
 	return nil
@@ -1148,7 +1147,6 @@ func (devices *DeviceSet) setupVerifyBaseImageUUIDFS(baseInfo *devInfo) error {
 }
 
 func (devices *DeviceSet) checkGrowBaseDeviceFS(info *devInfo) error {
-
 	if !userBaseSize {
 		return nil
 	}
@@ -1622,7 +1620,6 @@ func (devices *DeviceSet) loadThinPoolLoopBackInfo() error {
 			devices.dataDevice = dataLoopDevice
 			devices.dataLoopFile = datafilename
 		}
-
 	}
 
 	// metadata device has not been passed in. So there should be a
@@ -1643,7 +1640,6 @@ func (devices *DeviceSet) loadThinPoolLoopBackInfo() error {
 }
 
 func (devices *DeviceSet) enableDeferredRemovalDeletion() error {
-
 	// If user asked for deferred removal then check both libdm library
 	// and kernel driver support deferred removal otherwise error out.
 	if enableDeferredRemoval {
@@ -1946,7 +1942,6 @@ func (devices *DeviceSet) AddDevice(hash, baseHash string, storageOpt map[string
 }
 
 func (devices *DeviceSet) parseStorageOpt(storageOpt map[string]string) (uint64, error) {
-
 	// Read size to change the block device size per container.
 	for key, val := range storageOpt {
 		key := strings.ToLower(key)

--- a/daemon/graphdriver/graphtest/graphbench_unix.go
+++ b/daemon/graphdriver/graphtest/graphbench_unix.go
@@ -175,10 +175,10 @@ func DriverBenchDiffApplyN(b *testing.B, fileCount int, drivername string, drive
 		// suppressing "SA9003: empty branch (staticcheck)" instead of commenting-out/removing
 		// these lines because removing/commenting these lines causes a ripple effect
 		// of changes, and there's still a to-do below
-		//nolint:staticcheck
+		//nolint:staticcheck,revive
 		if applyDiffSize != diffSize {
 			// TODO: enforce this
-			//b.Fatalf("Apply diff size different, got %d, expected %s", applyDiffSize, diffSize)
+			// b.Fatalf("Apply diff size different, got %d, expected %s", applyDiffSize, diffSize)
 		}
 		if err := checkManyFiles(driver, diff, fileCount, 6); err != nil {
 			b.Fatal(err)
@@ -247,7 +247,6 @@ func DriverBenchDeepLayerRead(b *testing.B, layerCount int, drivername string, d
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-
 		// Read content
 		c, err := contdriver.ReadFile(root, root.Join(root.Path(), "testfile.txt"))
 		if err != nil {

--- a/daemon/graphdriver/graphtest/testutil.go
+++ b/daemon/graphdriver/graphtest/testutil.go
@@ -278,7 +278,6 @@ func addManyLayers(drv graphdriver.Driver, baseLayer string, count int) (string,
 		}
 
 		lastLayer = nextLayer
-
 	}
 	return lastLayer, nil
 }

--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -246,7 +246,6 @@ func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 // Create is used to create the upper, lower, and merge directories required for overlay fs for a given id.
 // The parent filesystem is used to configure these directories for the overlay.
 func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) (retErr error) {
-
 	if opts != nil && len(opts.StorageOpt) != 0 {
 		return fmt.Errorf("--storage-opt is not supported for overlay")
 	}

--- a/daemon/graphdriver/zfs/zfs.go
+++ b/daemon/graphdriver/zfs/zfs.go
@@ -379,7 +379,6 @@ func (d *Driver) Get(id, mountLabel string) (_ containerfs.ContainerFS, retErr e
 				if rmErr := unix.Rmdir(mountpoint); rmErr != nil && !os.IsNotExist(rmErr) {
 					logrus.WithField("storage-driver", "zfs").Debugf("Failed to remove %s: %v", id, rmErr)
 				}
-
 			}
 		}
 	}()

--- a/daemon/images/image_delete.go
+++ b/daemon/images/image_delete.go
@@ -132,7 +132,6 @@ func (i *ImageService) ImageDelete(imageRef string, force, prune bool) ([]types.
 						records = append(records, untaggedRecord)
 					} else {
 						remainingRefs = append(remainingRefs, repoRef)
-
 					}
 				}
 				repoRefs = remainingRefs

--- a/daemon/images/image_search.go
+++ b/daemon/images/image_search.go
@@ -24,7 +24,6 @@ var acceptedSearchFilterTags = map[string]bool{
 func (i *ImageService) SearchRegistryForImages(ctx context.Context, searchFilters filters.Args, term string, limit int,
 	authConfig *types.AuthConfig,
 	headers map[string][]string) (*registrytypes.SearchResults, error) {
-
 	if err := searchFilters.Validate(acceptedSearchFilterTags); err != nil {
 		return nil, err
 	}

--- a/daemon/images/images.go
+++ b/daemon/images/images.go
@@ -160,7 +160,6 @@ func (i *ImageService) Images(_ context.Context, opts types.ImageListOptions) ([
 		}
 		if summary.RepoDigests == nil && summary.RepoTags == nil {
 			if opts.All || len(i.imageStore.Children(id)) == 0 {
-
 				if opts.Filters.Contains("dangling") && !danglingOnly {
 					// dangling=false case, so dangling image is not needed
 					continue

--- a/daemon/images/store.go
+++ b/daemon/images/store.go
@@ -129,7 +129,6 @@ func (c *contentStoreForPull) Writer(ctx context.Context, opts ...content.Writer
 				if err := o(&cfg); err != nil {
 					return nil, err
 				}
-
 			}
 			c.addDigested(cfg.Desc.Digest)
 		}

--- a/daemon/logger/adapter_test.go
+++ b/daemon/logger/adapter_test.go
@@ -47,7 +47,6 @@ func (l *mockLoggingPlugin) StartLogging(file string, info Info) error {
 
 				l.c.Broadcast()
 				return
-
 			}
 
 			l.c.L.Lock()
@@ -55,7 +54,6 @@ func (l *mockLoggingPlugin) StartLogging(file string, info Info) error {
 			l.c.L.Unlock()
 			l.c.Broadcast()
 		}
-
 	}()
 	return nil
 }
@@ -172,7 +170,6 @@ func TestAdapterReadLogs(t *testing.T) {
 		assert.Check(t, !ok, "expected message channel to be closed")
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for message channel to close")
-
 	}
 	lw.ConsumerGone()
 

--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -661,7 +661,6 @@ func TestCollectBatchTicker(t *testing.T) {
 	assert.Equal(t, logline+" 3", aws.StringValue(argument.LogEvents[0].Message))
 
 	stream.Close()
-
 }
 
 func TestCollectBatchMultilinePattern(t *testing.T) {

--- a/daemon/logger/loggertest/logreader.go
+++ b/daemon/logger/loggertest/logreader.go
@@ -48,7 +48,6 @@ func makeTestMessages() []*logger.Message {
 		{Source: "stderr", Timestamp: time.Now().Add(-1 * 10 * time.Minute), Line: []byte("a really long message " + strings.Repeat("a", 4096))},
 		{Source: "stderr", Timestamp: time.Now().Add(-1 * 10 * time.Minute), Line: []byte("just one more message")},
 	}
-
 }
 
 func (tr Reader) testTail(t *testing.T, live bool) {

--- a/daemon/logger/loggerutils/sharedtemp.go
+++ b/daemon/logger/loggerutils/sharedtemp.go
@@ -138,7 +138,6 @@ func (c *sharedTempFileConverter) openExisting(st stfcState, id stfID, v sharedT
 
 	res := <-wait
 	return res.fr, res.err
-
 }
 
 func (c *sharedTempFileConverter) convert(f *os.File) (converted *os.File, size int64, err error) {

--- a/daemon/logger/loggerutils/sharedtemp_test.go
+++ b/daemon/logger/loggerutils/sharedtemp_test.go
@@ -207,7 +207,6 @@ func TestSharedTempFileConverter(t *testing.T) {
 		assert.Check(t, src.Close())
 		assert.NilError(t, os.Remove(name))
 		checkDirEmpty(t, dir)
-
 	})
 }
 

--- a/daemon/logger/ring_test.go
+++ b/daemon/logger/ring_test.go
@@ -142,7 +142,6 @@ func TestRingDrain(t *testing.T) {
 	if len(ls) != 0 {
 		t.Fatalf("expected 0 messages on 2nd drain: %v", ls)
 	}
-
 }
 
 type nopLogger struct{}

--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -265,5 +265,4 @@ func parseLogFormat(logFormat, proto string) (syslog.Formatter, syslog.Framer, e
 	default:
 		return nil, nil, errors.New("Invalid syslog format")
 	}
-
 }

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -815,7 +815,6 @@ func buildCreateEndpointOptions(c *container.Container, n libnetwork.Network, ep
 					return nil, errors.Errorf("Invalid link-local IP address: %s", ipam.LinkLocalIPs)
 				}
 				ipList = append(ipList, linkip)
-
 			}
 
 			if ip = net.ParseIP(ipam.IPv4Address); ip == nil && ipam.IPv4Address != "" {
@@ -828,7 +827,6 @@ func buildCreateEndpointOptions(c *container.Container, n libnetwork.Network, ep
 
 			createOptions = append(createOptions,
 				libnetwork.CreateOptionIpam(ip, ip6, ipList, nil))
-
 		}
 
 		for _, alias := range epConfig.Aliases {
@@ -882,7 +880,6 @@ func buildCreateEndpointOptions(c *container.Container, n libnetwork.Network, ep
 
 			createOptions = append(createOptions, libnetwork.EndpointOptionGeneric(genericOption))
 		}
-
 	}
 
 	// Port-mapping rules belong to the container & applicable only to non-internal networks

--- a/daemon/network/filter_test.go
+++ b/daemon/network/filter_test.go
@@ -173,7 +173,6 @@ func TestFilterNetworks(t *testing.T) {
 			if testCase.err != "" {
 				if err == nil {
 					t.Fatalf("expect error '%s', got no error", testCase.err)
-
 				} else if !strings.Contains(err.Error(), testCase.err) {
 					t.Fatalf("expect error '%s', got '%s'", testCase.err, err)
 				}

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -706,7 +706,6 @@ func WithMounts(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		}
 
 		return nil
-
 	}
 }
 

--- a/daemon/reload_test.go
+++ b/daemon/reload_test.go
@@ -404,5 +404,4 @@ func TestDaemonReloadNetworkDiagnosticPort(t *testing.T) {
 	if !daemon.netController.IsDiagnosticEnabled() {
 		t.Fatalf("diagnostic should be enable")
 	}
-
 }

--- a/daemon/restart.go
+++ b/daemon/restart.go
@@ -24,7 +24,6 @@ func (daemon *Daemon) ContainerRestart(ctx context.Context, name string, options
 		return fmt.Errorf("Cannot restart container %s: %v", name, err)
 	}
 	return nil
-
 }
 
 // containerRestart attempts to gracefully stop and then start the

--- a/daemon/seccomp_linux_test.go
+++ b/daemon/seccomp_linux_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestWithSeccomp(t *testing.T) {
-
 	type expected struct {
 		daemon  *Daemon
 		c       *container.Container

--- a/distribution/manifest_test.go
+++ b/distribution/manifest_test.go
@@ -171,7 +171,6 @@ func TestManifestStore(t *testing.T) {
 
 		err = w.Commit(ctx, desc.Size, desc.Digest, opts...)
 		assert.NilError(t, err)
-
 	}
 
 	// All tests should end up with no active ingest
@@ -348,7 +347,6 @@ func TestDetectManifestBlobMediaType(t *testing.T) {
 			assert.Equal(t, mt, tc.expected)
 		})
 	}
-
 }
 
 func TestDetectManifestBlobMediaTypeInvalid(t *testing.T) {
@@ -418,5 +416,4 @@ func TestDetectManifestBlobMediaTypeInvalid(t *testing.T) {
 			assert.Equal(t, mt, "")
 		})
 	}
-
 }

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -313,7 +313,6 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 						d.err = errors.New("download cancelled during retry delay")
 						return
 					}
-
 				}
 			}
 

--- a/image/fs_test.go
+++ b/image/fs_test.go
@@ -78,7 +78,6 @@ func TestFSInvalidRoot(t *testing.T) {
 
 		os.RemoveAll(root)
 	}
-
 }
 
 func TestFSMetadataGetSet(t *testing.T) {

--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -138,7 +138,6 @@ func (l *tarexporter) parseNames(names []string) (desc map[image.ID]*imageDescri
 		if err := addAssoc(image.IDFromDigest(id), namedRef); err != nil {
 			return nil, err
 		}
-
 	}
 	return imgDescr, nil
 }

--- a/integration-cli/docker_api_attach_test.go
+++ b/integration-cli/docker_api_attach_test.go
@@ -225,7 +225,6 @@ func (s *DockerAPISuite) TestPostContainersAttach(c *testing.T) {
 // , contenttype, …), if receive a successful "101 Switching Protocols" response return
 // a `io.WriteCloser` and `bufio.Reader`
 func requestHijack(method, endpoint string, data io.Reader, ct, daemon string, modifiers ...func(*http.Request)) (io.WriteCloser, *bufio.Reader, error) {
-
 	hostURL, err := client.ParseHostURL(daemon)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "parse daemon host error")

--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -427,7 +427,6 @@ func (s *DockerAPISuite) TestBuildChownOnCopy(c *testing.T) {
 }
 
 func (s *DockerAPISuite) TestBuildCopyCacheOnFileChange(c *testing.T) {
-
 	dockerfile := `FROM busybox
 COPY file /file`
 
@@ -468,7 +467,6 @@ COPY file /file`
 }
 
 func (s *DockerAPISuite) TestBuildAddCacheOnFileChange(c *testing.T) {
-
 	dockerfile := `FROM busybox
 ADD file /file`
 

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -545,7 +545,6 @@ func (s *DockerAPISuite) TestContainerAPICreate(c *testing.T) {
 }
 
 func (s *DockerAPISuite) TestContainerAPICreateEmptyConfig(c *testing.T) {
-
 	cli, err := client.NewClientWithOpts(client.FromEnv)
 	assert.NilError(c, err)
 	defer cli.Close()
@@ -1070,7 +1069,6 @@ func (s *DockerAPISuite) TestContainerAPICopyResourcePathEmptyPre124(c *testing.
 	b, err := request.ReadBody(body)
 	assert.NilError(c, err)
 	assert.Assert(c, is.Regexp("^Path cannot be empty\n$", string(b)))
-
 }
 
 func (s *DockerAPISuite) TestContainerAPICopyResourcePathNotFoundPre124(c *testing.T) {
@@ -1092,7 +1090,6 @@ func (s *DockerAPISuite) TestContainerAPICopyResourcePathNotFoundPre124(c *testi
 	b, err := request.ReadBody(body)
 	assert.NilError(c, err)
 	assert.Assert(c, is.Regexp("^Could not find the file /notexist in container "+name+"\n$", string(b)))
-
 }
 
 func (s *DockerAPISuite) TestContainerAPICopyContainerNotFoundPr124(c *testing.T) {
@@ -1230,7 +1227,6 @@ func (s *DockerAPISuite) TestContainerAPIDeleteRemoveVolume(c *testing.T) {
 
 // Regression test for https://github.com/docker/docker/issues/6231
 func (s *DockerAPISuite) TestContainerAPIChunkedEncoding(c *testing.T) {
-
 	config := map[string]interface{}{
 		"Image":     "busybox",
 		"Cmd":       append([]string{"/bin/sh", "-c"}, sleepCommandForDaemonPlatform()...),
@@ -1920,7 +1916,6 @@ func (s *DockerAPISuite) TestContainersAPICreateMountsValidation(c *testing.T) {
 				msg: "Source must not be specified",
 			},
 		}...)
-
 	}
 	apiClient, err := client.NewClientWithOpts(client.FromEnv)
 	assert.NilError(c, err)
@@ -2148,7 +2143,6 @@ func (s *DockerAPISuite) TestContainersAPICreateMountsCreate(c *testing.T) {
 			assert.NilError(c, err)
 
 			switch {
-
 			// Named volumes still exist after the container is removed
 			case x.spec.Type == "volume" && len(x.spec.Source) > 0:
 				_, err := apiclient.VolumeInspect(ctx, mountPoint.Name)

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -147,7 +147,6 @@ func (s *DockerAPISuite) TestAPIImagesImportBadSrc(c *testing.T) {
 		assert.Equal(c, res.StatusCode, te.statusExp)
 		assert.Equal(c, res.Header.Get("Content-Type"), "application/json")
 	}
-
 }
 
 // #14846

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -31,7 +31,6 @@ func (s *DockerAPISuite) TestInspectAPIContainerResponse(c *testing.T) {
 		cases = []acase{
 			{"v1.25", append(keysBase, "Mounts")},
 		}
-
 	} else {
 		cases = []acase{
 			{"v1.20", append(keysBase, "Mounts")},
@@ -51,7 +50,7 @@ func (s *DockerAPISuite) TestInspectAPIContainerResponse(c *testing.T) {
 			assert.Check(c, ok, "%s does not exist in response for version %s", key, cs.version)
 		}
 
-		//Issue #6830: type not properly converted to JSON/back
+		// Issue #6830: type not properly converted to JSON/back
 		_, ok := inspectJSON["Path"].(bool)
 		assert.Assert(c, !ok, "Path of `true` should not be converted to boolean `true` via JSON marshalling")
 	}

--- a/integration-cli/docker_api_swarm_node_test.go
+++ b/integration-cli/docker_api_swarm_node_test.go
@@ -125,5 +125,4 @@ func (s *DockerSwarmSuite) TestAPISwarmNodeDrainPause(c *testing.T) {
 	d1.UpdateService(c, d1.GetService(c, id), setInstances(instances))
 	poll.WaitOn(c, pollCheck(c, d1.CheckActiveContainerCount, checker.Equals(instances-d2ContainerCount)), poll.WithTimeout(defaultReconciliationTimeout))
 	poll.WaitOn(c, pollCheck(c, d2.CheckActiveContainerCount, checker.Equals(d2ContainerCount)), poll.WithTimeout(defaultReconciliationTimeout))
-
 }

--- a/integration-cli/docker_api_swarm_service_test.go
+++ b/integration-cli/docker_api_swarm_service_test.go
@@ -120,7 +120,6 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesMultipleAgents(c *testing.T) {
 	instances = 5
 	d1.UpdateService(c, d1.GetService(c, id), setInstances(instances))
 	poll.WaitOn(c, pollCheck(c, reducedCheck(sumAsIntegers, d1.CheckActiveContainerCount, d3.CheckActiveContainerCount), checker.Equals(instances)), poll.WithTimeout(defaultReconciliationTimeout))
-
 }
 
 func (s *DockerSwarmSuite) TestAPISwarmServicesCreateGlobal(c *testing.T) {
@@ -193,7 +192,6 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesUpdate(c *testing.T) {
 
 	// 2nd batch
 	poll.WaitOn(c, pollCheck(c, daemons[0].CheckRunningTaskImages, checker.DeepEquals(map[string]int{image1: instances})), poll.WithTimeout(defaultReconciliationTimeout))
-
 }
 
 func (s *DockerSwarmSuite) TestAPISwarmServicesUpdateStartFirst(c *testing.T) {
@@ -294,7 +292,6 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesUpdateStartFirst(c *testing.T) {
 
 	// 2nd batch
 	poll.WaitOn(c, pollCheck(c, d.CheckRunningTaskImages, checker.DeepEquals(map[string]int{image1: instances})), poll.WithTimeout(defaultReconciliationTimeout))
-
 }
 
 func (s *DockerSwarmSuite) TestAPISwarmServicesFailedUpdate(c *testing.T) {
@@ -333,7 +330,6 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesFailedUpdate(c *testing.T) {
 	assert.NilError(c, err, out)
 
 	poll.WaitOn(c, pollCheck(c, daemons[0].CheckRunningTaskImages, checker.DeepEquals(map[string]int{image1: instances})), poll.WithTimeout(defaultReconciliationTimeout))
-
 }
 
 func (s *DockerSwarmSuite) TestAPISwarmServiceConstraintRole(c *testing.T) {

--- a/integration-cli/docker_cli_attach_unix_test.go
+++ b/integration-cli/docker_cli_attach_unix_test.go
@@ -56,7 +56,6 @@ func (s *DockerCLIAttachSuite) TestAttachClosedOnContainerStop(c *testing.T) {
 	case <-time.After(attachWait):
 		c.Fatal("timed out without attach returning")
 	}
-
 }
 
 func (s *DockerCLIAttachSuite) TestAttachAfterDetach(c *testing.T) {

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -108,7 +108,6 @@ func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementVolume(c *testing.T
 	if _, ok := volumes[volumePath]; !ok {
 		c.Fatal("Volume " + volumePath + " from environment not in Config.Volumes on image")
 	}
-
 }
 
 func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementExpose(c *testing.T) {
@@ -133,7 +132,6 @@ func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementExpose(c *testing.T
 			c.Fatalf("Exposed port %d from environment not in Config.ExposedPorts on image", p)
 		}
 	}
-
 }
 
 func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementWorkdir(c *testing.T) {
@@ -240,7 +238,6 @@ func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementEnv(c *testing.T) {
 	if envCount != 4 {
 		c.Fatalf("Didn't find all env vars - only saw %d\n%s", envCount, envResult)
 	}
-
 }
 
 func (s *DockerCLIBuildSuite) TestBuildHandleEscapesInVolume(c *testing.T) {
@@ -308,7 +305,6 @@ func (s *DockerCLIBuildSuite) TestBuildOnBuildLowercase(c *testing.T) {
 	if strings.Contains(result.Combined(), "ONBUILD ONBUILD") {
 		c.Fatalf("Got an ONBUILD ONBUILD error with no error: got %s", result.Combined())
 	}
-
 }
 
 func (s *DockerCLIBuildSuite) TestBuildEnvEscapes(c *testing.T) {
@@ -325,7 +321,6 @@ func (s *DockerCLIBuildSuite) TestBuildEnvEscapes(c *testing.T) {
 	if strings.TrimSpace(out) != "$" {
 		c.Fatalf("Env TEST was not overwritten with bar when foo was supplied to dockerfile: was %q", strings.TrimSpace(out))
 	}
-
 }
 
 func (s *DockerCLIBuildSuite) TestBuildEnvOverwrite(c *testing.T) {
@@ -342,7 +337,6 @@ func (s *DockerCLIBuildSuite) TestBuildEnvOverwrite(c *testing.T) {
 	if strings.TrimSpace(out) != "bar" {
 		c.Fatalf("Env TEST was not overwritten with bar when foo was supplied to dockerfile: was %q", strings.TrimSpace(out))
 	}
-
 }
 
 // FIXME(vdemeester) why we disabled cache here ?
@@ -377,7 +371,6 @@ ONBUILD ENTRYPOINT ["echo"]`))
 	if !regexp.MustCompile(`(?m)^hello world`).MatchString(out) {
 		c.Fatal("got malformed output from onbuild", out)
 	}
-
 }
 
 func (s *DockerCLIBuildSuite) TestBuildCacheAdd(c *testing.T) {
@@ -447,7 +440,6 @@ ADD %s/file /`
 	if out == out2 {
 		c.Fatalf("MTime didn't change:\nOrigin:%s\nNew:%s", out, out2)
 	}
-
 }
 
 // Regression for https://github.com/docker/docker/pull/27805
@@ -682,7 +674,6 @@ func (s *DockerCLIBuildSuite) TestBuildCopyWildcard(c *testing.T) {
 	if id1 != id2 {
 		c.Fatal("didn't use the cache")
 	}
-
 }
 
 func (s *DockerCLIBuildSuite) TestBuildCopyWildcardInName(c *testing.T) {
@@ -728,7 +719,6 @@ func (s *DockerCLIBuildSuite) TestBuildCopyWildcardCache(c *testing.T) {
 	if id1 != id2 {
 		c.Fatal("didn't use the cache")
 	}
-
 }
 
 func (s *DockerCLIBuildSuite) TestBuildAddSingleFileToNonExistingDir(c *testing.T) {
@@ -1012,7 +1002,6 @@ func (s *DockerCLIBuildSuite) TestBuildAddBadLinks(c *testing.T) {
 	if _, err := os.Stat(nonExistingFile); err == nil || !os.IsNotExist(err) {
 		c.Fatalf("%s shouldn't have been written and it shouldn't exist", nonExistingFile)
 	}
-
 }
 
 func (s *DockerCLIBuildSuite) TestBuildAddBadLinksVolume(c *testing.T) {
@@ -1053,7 +1042,6 @@ func (s *DockerCLIBuildSuite) TestBuildAddBadLinksVolume(c *testing.T) {
 	if _, err := os.Stat(nonExistingFile); err == nil || !os.IsNotExist(err) {
 		c.Fatalf("%s shouldn't have been written and it shouldn't exist", nonExistingFile)
 	}
-
 }
 
 // Issue #5270 - ensure we throw a better error than "unexpected EOF"
@@ -1131,7 +1119,6 @@ func (s *DockerCLIBuildSuite) TestBuildWithInaccessibleFilesInContext(c *testing
 		if !strings.Contains(result.Combined(), "error checking context") {
 			c.Fatalf("output should've contained the string: error checking context\ngot:%s", result.Combined())
 		}
-
 	}
 	{
 		name := "testlinksok"
@@ -1195,7 +1182,6 @@ func (s *DockerCLIBuildSuite) TestBuildForceRm(c *testing.T) {
 	if containerCountBefore != containerCountAfter {
 		c.Fatalf("--force-rm shouldn't have left containers behind")
 	}
-
 }
 
 func (s *DockerCLIBuildSuite) TestBuildRm(c *testing.T) {
@@ -1273,7 +1259,6 @@ func (s *DockerCLIBuildSuite) TestBuildWithVolumes(c *testing.T) {
 	if !equal {
 		c.Fatalf("Volumes %s, expected %s", result, expected)
 	}
-
 }
 
 func (s *DockerCLIBuildSuite) TestBuildMaintainer(c *testing.T) {
@@ -1540,7 +1525,6 @@ func (s *DockerCLIBuildSuite) TestBuildContextCleanup(c *testing.T) {
 	if err = compareDirectoryEntries(entries, entriesFinal); err != nil {
 		c.Fatalf("context should have been deleted, but wasn't")
 	}
-
 }
 
 func (s *DockerCLIBuildSuite) TestBuildContextCleanupFailedBuild(c *testing.T) {
@@ -1564,7 +1548,6 @@ func (s *DockerCLIBuildSuite) TestBuildContextCleanupFailedBuild(c *testing.T) {
 	if err = compareDirectoryEntries(entries, entriesFinal); err != nil {
 		c.Fatalf("context should have been deleted, but wasn't")
 	}
-
 }
 
 // compareDirectoryEntries compares two sets of DirEntry (usually taken from a directory)
@@ -1724,7 +1707,6 @@ func (s *DockerCLIBuildSuite) TestBuildEmptyEntrypoint(c *testing.T) {
 	if res != expected {
 		c.Fatalf("Entrypoint %s, expected %s", res, expected)
 	}
-
 }
 
 func (s *DockerCLIBuildSuite) TestBuildEntrypoint(c *testing.T) {
@@ -1738,7 +1720,6 @@ func (s *DockerCLIBuildSuite) TestBuildEntrypoint(c *testing.T) {
 	if res != expected {
 		c.Fatalf("Entrypoint %s, expected %s", res, expected)
 	}
-
 }
 
 // #6445 ensure ONBUILD triggers aren't committed to grandchildren
@@ -2174,7 +2155,6 @@ func (s *DockerCLIBuildSuite) TestBuildWithVolumeOwnership(c *testing.T) {
 	if expected := "daemon   daemon"; !strings.Contains(out, expected) {
 		c.Fatalf("expected %s received %s", expected, out)
 	}
-
 }
 
 // testing #1405 - config.Cmd does not get cleaned up if
@@ -2282,7 +2262,6 @@ docker.com>"
 	if res != "\"Docker IO <io@docker.com>\"" {
 		c.Fatalf("Parsed string did not match the escaped string. Got: %q", res)
 	}
-
 }
 
 func (s *DockerCLIBuildSuite) TestBuildVerifyIntString(c *testing.T) {
@@ -2297,7 +2276,6 @@ func (s *DockerCLIBuildSuite) TestBuildVerifyIntString(c *testing.T) {
 	if !strings.Contains(out, "\"123\"") {
 		c.Fatalf("Output does not contain the int as a string:\n%s", out)
 	}
-
 }
 
 func (s *DockerCLIBuildSuite) TestBuildDockerignore(c *testing.T) {
@@ -3215,7 +3193,6 @@ func (s *DockerCLIBuildSuite) TestBuildCmdShDashC(c *testing.T) {
 	if res != expected {
 		c.Fatalf("Expected value %s not in Config.Cmd: %s", expected, res)
 	}
-
 }
 
 func (s *DockerCLIBuildSuite) TestBuildCmdSpaces(c *testing.T) {
@@ -3426,7 +3403,6 @@ func (s *DockerCLIBuildSuite) TestBuildLabelsCache(c *testing.T) {
 	if id1 == id2 {
 		c.Fatalf("Build 6 should have worked & NOT used the cache(%s,%s)", id1, id2)
 	}
-
 }
 
 // FIXME(vdemeester) port to docker/cli e2e tests (api tests should test suppressOutput option though)
@@ -3477,7 +3453,6 @@ func (s *DockerCLIBuildSuite) TestBuildNotVerboseSuccess(c *testing.T) {
 			c.Fatalf("Test %s expected stderr to be empty, but it is [%#v]", te.Name, result.Stderr())
 		}
 	}
-
 }
 
 // FIXME(vdemeester) migrate to docker/cli tests
@@ -3702,7 +3677,6 @@ CMD cat /foo/file`),
 	if out != expected {
 		c.Fatalf("expected file contents for /foo/file to be %q but received %q", expected, out)
 	}
-
 }
 
 func (s *DockerCLIBuildSuite) TestBuildFromMixedcaseDockerfile(c *testing.T) {
@@ -3752,7 +3726,6 @@ RUN find /tmp/`}))
 		!strings.Contains(result.Combined(), "/tmp/Dockerfile") {
 		c.Fatalf("Missing proper output: %s", result.Combined())
 	}
-
 }
 
 // FIXME(vdemeester) should migrate to docker/cli tests
@@ -3778,7 +3751,6 @@ RUN sh -c "find /tmp/" # sh -c is needed on Windows to use the correct find`)
 		!strings.Contains(result.Combined(), "/tmp/Dockerfile") {
 		c.Fatalf("Missing proper output: %s", result.Combined())
 	}
-
 }
 
 func (s *DockerCLIBuildSuite) TestBuildFromOfficialNames(c *testing.T) {
@@ -3859,7 +3831,6 @@ func (s *DockerCLIBuildSuite) TestBuildSpaces(c *testing.T) {
 	if strings.ReplaceAll(e1, " ", "") != strings.ReplaceAll(e2, " ", "") {
 		c.Fatalf("Build 4's error wasn't the same as build 1's\n1:%s\n4:%s", result1.Error, result2.Error)
 	}
-
 }
 
 func (s *DockerCLIBuildSuite) TestBuildSpacesWithQuotes(c *testing.T) {
@@ -3937,7 +3908,6 @@ func (s *DockerCLIBuildSuite) TestBuildMissingArgs(c *testing.T) {
 			Err:      cmd + " requires",
 		})
 	}
-
 }
 
 func (s *DockerCLIBuildSuite) TestBuildEmptyScratch(c *testing.T) {
@@ -4109,7 +4079,6 @@ func (s *DockerCLIBuildSuite) TestBuildBuildTimeArg(c *testing.T) {
 			ARG %s
 			RUN echo $%s
 			CMD echo $%s`, envKey, envKey, envKey)
-
 	}
 	buildImage(imgName,
 		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
@@ -4846,7 +4815,6 @@ func (s *DockerCLIBuildSuite) TestBuildFollowSymlinkToDir(c *testing.T) {
 	assert.Assert(c, !strings.Contains(result.Combined(), "Using cache"))
 	out = cli.DockerCmd(c, "run", "--rm", name, "cat", "abc", "def").Combined()
 	assert.Assert(c, cmp.Regexp("^barbax$", out))
-
 }
 
 // TestBuildSymlinkBasename tests that target file gets basename from symlink,
@@ -4869,7 +4837,6 @@ func (s *DockerCLIBuildSuite) TestBuildSymlinkBasename(c *testing.T) {
 
 	out := cli.DockerCmd(c, "run", "--rm", name, "cat", "asymlink").Combined()
 	assert.Assert(c, cmp.Regexp("^bar$", out))
-
 }
 
 // #17827
@@ -5374,7 +5341,6 @@ func (s *DockerCLIBuildSuite) TestBuildCmdShellArgsEscaped(c *testing.T) {
 	if res != `["ipconfig"]` {
 		c.Fatalf("CMD incorrect in Config.Cmd: got %v", res)
 	}
-
 }
 
 // Test case for #24912.
@@ -5614,7 +5580,6 @@ func (s *DockerCLIBuildSuite) TestBuildWithExtraHostInvalidFormat(c *testing.T) 
 			ExitCode: 125,
 		})
 	}
-
 }
 
 func (s *DockerCLIBuildSuite) TestBuildMultiStageCopyFromSyntax(c *testing.T) {

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -237,7 +237,6 @@ func (s *DockerRegistrySuite) TestListImagesWithoutDigests(c *testing.T) {
 }
 
 func (s *DockerRegistrySuite) TestListImagesWithDigests(c *testing.T) {
-
 	// setup image1
 	digest1, err := setupImageWithTag(c, "tag1")
 	assert.NilError(c, err, "error setting up image")
@@ -330,7 +329,7 @@ func (s *DockerRegistrySuite) TestListDanglingImagesWithDigests(c *testing.T) {
 	assert.Assert(c, re1.MatchString(out), "expected %q: %s", re1.String(), out)
 	// setup image2
 	digest2, err := setupImageWithTag(c, "dangle2")
-	//error setting up image
+	// error setting up image
 	assert.NilError(c, err)
 	imageReference2 := fmt.Sprintf("%s@%s", repoName, digest2)
 	c.Logf("imageReference2 = %s", imageReference2)

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -61,7 +61,6 @@ func (s *DockerCLICreateSuite) TestCreateArgs(c *testing.T) {
 	if len(cont.Args) != len(expected) || b {
 		c.Fatalf("Unexpected args. Expected %v, received: %v", expected, cont.Args)
 	}
-
 }
 
 // Make sure we can grow the container's rootfs at creation time.
@@ -135,9 +134,7 @@ func (s *DockerCLICreateSuite) TestCreateWithPortRange(c *testing.T) {
 	for k, v := range cont.HostConfig.PortBindings {
 		assert.Equal(c, len(v), 1, fmt.Sprintf("Expected 1 ports binding, for the port  %s but found %s", k, v))
 		assert.Equal(c, k.Port(), v[0].HostPort, fmt.Sprintf("Expected host port %s to match published port %s", k.Port(), v[0].HostPort))
-
 	}
-
 }
 
 func (s *DockerCLICreateSuite) TestCreateWithLargePortRange(c *testing.T) {
@@ -165,7 +162,6 @@ func (s *DockerCLICreateSuite) TestCreateWithLargePortRange(c *testing.T) {
 		assert.Equal(c, len(v), 1)
 		assert.Equal(c, k.Port(), v[0].HostPort, fmt.Sprintf("Expected host port %s to match published port %s", k.Port(), v[0].HostPort))
 	}
-
 }
 
 // "test123" should be printed by docker create + start
@@ -194,7 +190,6 @@ func (s *DockerCLICreateSuite) TestCreateVolumesCreated(c *testing.T) {
 	if err != nil {
 		c.Fatalf("Error statting volume host path: %q", err)
 	}
-
 }
 
 func (s *DockerCLICreateSuite) TestCreateLabels(c *testing.T) {

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -172,7 +172,6 @@ func (s *DockerDaemonSuite) TestDaemonRestartUnlessStopped(c *testing.T) {
 
 	// both running
 	testRun(map[string]bool{"top1": true, "top2": true, "exit": true}, "After second daemon restart: ")
-
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartOnFailure(c *testing.T) {
@@ -979,7 +978,6 @@ func (s *DockerDaemonSuite) TestDaemonLinksIpTablesRulesWhenLinkAndUnlink(c *tes
 }
 
 func (s *DockerDaemonSuite) TestDaemonUlimitDefaults(c *testing.T) {
-
 	s.d.StartWithBusybox(c, "--default-ulimit", "nofile=42:42", "--default-ulimit", "nproc=1024:1024")
 
 	out, err := s.d.Cmd("run", "--ulimit", "nproc=2048", "--name=test", "busybox", "/bin/sh", "-c", "echo $(ulimit -n); echo $(ulimit -u)")
@@ -1992,7 +1990,6 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithKilledRunningContainer(t *testi
 	if out != "143" {
 		t.Fatalf("Expected exit code '%s' got '%s' for container '%s'\n", "143", out, cid)
 	}
-
 }
 
 // os.Kill should kill daemon ungracefully, leaving behind live containers.

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -117,7 +117,6 @@ func (s *DockerCLIEventSuite) TestEventsContainerEventsAttrSort(c *testing.T) {
 		if matches["eventType"] == "container" && matches["action"] == "create" {
 			matchedEvents++
 			assert.Check(c, strings.Contains(out, "(image=busybox, name=container-events-test)"), "Event attributes not sorted")
-
 		} else if matches["eventType"] == "container" && matches["action"] == "start" {
 			matchedEvents++
 			assert.Check(c, strings.Contains(out, "(image=busybox, name=container-events-test)"), "Event attributes not sorted")

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -391,7 +391,6 @@ func (s *DockerCLIEventSuite) TestEventsFilterNetworkID(c *testing.T) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonEvents(c *testing.T) {
-
 	// daemon config file
 	configFilePath := "test.json"
 	defer os.Remove(configFilePath)
@@ -439,7 +438,6 @@ func (s *DockerDaemonSuite) TestDaemonEvents(c *testing.T) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonEventsWithFilters(c *testing.T) {
-
 	// daemon config file
 	configFilePath := "test.json"
 	defer os.Remove(configFilePath)

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -76,7 +76,6 @@ func (s *DockerCLIExecSuite) TestExecInteractive(c *testing.T) {
 	case <-time.After(1 * time.Second):
 		c.Fatal("docker exec failed to exit on stdin close")
 	}
-
 }
 
 func (s *DockerCLIExecSuite) TestExecAfterContainerRestart(c *testing.T) {

--- a/integration-cli/docker_cli_health_test.go
+++ b/integration-cli/docker_cli_health_test.go
@@ -152,7 +152,6 @@ func (s *DockerCLIHealthSuite) TestHealth(c *testing.T) {
 	out, _ = dockerCmd(c, "inspect",
 		"--format={{.Config.Healthcheck.Test}}", imageName)
 	assert.Equal(c, out, "[CMD cat /my status]\n")
-
 }
 
 // GitHub #33021
@@ -175,5 +174,4 @@ ENTRYPOINT /bin/sh -c "sleep 600"`))
 	// Start
 	dockerCmd(c, "start", name)
 	waitForHealthStatus(c, name, "starting", "healthy")
-
 }

--- a/integration-cli/docker_cli_history_test.go
+++ b/integration-cli/docker_cli_history_test.go
@@ -65,7 +65,6 @@ LABEL label.Z="Z"`))
 		actualValue := actualValues[i]
 		assert.Assert(c, strings.Contains(actualValue, echoValue))
 	}
-
 }
 
 func (s *DockerCLIHistorySuite) TestHistoryExistentImage(c *testing.T) {

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -86,7 +86,6 @@ func (s *DockerCLIInspectSuite) TestInspectStatus(c *testing.T) {
 	dockerCmd(c, "stop", out)
 	inspectOut = inspectField(c, out, "State.Status")
 	assert.Equal(c, inspectOut, "exited")
-
 }
 
 func (s *DockerCLIInspectSuite) TestInspectTypeFlagContainer(c *testing.T) {
@@ -143,7 +142,7 @@ func (s *DockerCLIInspectSuite) TestInspectImageFilterInt(c *testing.T) {
 	size, err := strconv.Atoi(out)
 	assert.Assert(c, err == nil, "failed to inspect size of the image: %s, %v", out, err)
 
-	//now see if the size turns out to be the same
+	// now see if the size turns out to be the same
 	formatStr := fmt.Sprintf("--format={{eq .Size %d}}", size)
 	out, _ = dockerCmd(c, "inspect", formatStr, imageTest)
 	result, err := strconv.ParseBool(strings.TrimSuffix(out, "\n"))
@@ -165,7 +164,7 @@ func (s *DockerCLIInspectSuite) TestInspectContainerFilterInt(c *testing.T) {
 	exitCode, err := strconv.Atoi(out)
 	assert.Assert(c, err == nil, "failed to inspect exitcode of the container: %s, %v", out, err)
 
-	//now get the exit code to verify
+	// now get the exit code to verify
 	formatStr := fmt.Sprintf("--format={{eq .State.ExitCode %d}}", exitCode)
 	out, _ = dockerCmd(c, "inspect", formatStr, id)
 	inspectResult, err := strconv.ParseBool(strings.TrimSuffix(out, "\n"))

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -100,7 +100,6 @@ func (s *DockerCLILinksSuite) TestLinksPingLinkedContainersAfterRename(c *testin
 	dockerCmd(c, "run", "--rm", "--link", "container_new:alias1", "--link", "container2:alias2", "busybox", "sh", "-c", "ping -c 1 alias1 -W 1 && ping -c 1 alias2 -W 1")
 	dockerCmd(c, "kill", idA)
 	dockerCmd(c, "kill", idB)
-
 }
 
 func (s *DockerCLILinksSuite) TestLinksInspectLinksStarted(c *testing.T) {
@@ -147,7 +146,6 @@ func (s *DockerCLILinksSuite) TestLinksNotStartedParentNotFail(c *testing.T) {
 	dockerCmd(c, "create", "--name=first", "busybox", "top")
 	dockerCmd(c, "create", "--name=second", "--link=first:first", "busybox", "top")
 	dockerCmd(c, "start", "first")
-
 }
 
 func (s *DockerCLILinksSuite) TestLinksHostsFilesInject(c *testing.T) {

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -56,7 +56,6 @@ func (s *DockerNetworkSuite) SetUpSuite(c *testing.T) {
 }
 
 func setupRemoteNetworkDrivers(c *testing.T, mux *http.ServeMux, url, netDrv, ipamDrv string) {
-
 	mux.HandleFunc("/Plugin.Activate", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
 		fmt.Fprintf(w, `{"Implements": ["%s", "%s"]}`, driverapi.NetworkPluginEndpointType, ipamapi.PluginEndpointType)
@@ -759,7 +758,6 @@ func (s *DockerNetworkSuite) TestDockerNetworkDriverOptions(c *testing.T) {
 	assert.Equal(c, opts["opt2"], "drv2")
 	dockerCmd(c, "network", "rm", "testopt")
 	assertNwNotAvailable(c, "testopt")
-
 }
 
 func (s *DockerNetworkSuite) TestDockerPluginV2NetworkDriver(c *testing.T) {
@@ -782,7 +780,6 @@ func (s *DockerNetworkSuite) TestDockerPluginV2NetworkDriver(c *testing.T) {
 	assertNwIsAvailable(c, "v2net")
 	dockerCmd(c, "network", "rm", "v2net")
 	assertNwNotAvailable(c, "v2net")
-
 }
 
 func (s *DockerDaemonSuite) TestDockerNetworkNoDiscoveryDefaultBridgeNetwork(c *testing.T) {

--- a/integration-cli/docker_cli_prune_unix_test.go
+++ b/integration-cli/docker_cli_prune_unix_test.go
@@ -38,7 +38,6 @@ func pruneNetworkAndVerify(c *testing.T, d *daemon.Daemon, kept, pruned []string
 			assert.NilError(c, err)
 			return out, ""
 		}, checker.Contains(s)), poll.WithTimeout(defaultReconciliationTimeout))
-
 	}
 
 	for _, s := range pruned {

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -130,7 +130,6 @@ func (s *DockerCLIPsSuite) TestPsListContainersBase(c *testing.T) {
 
 	out, _ = dockerCmd(c, "ps", "-f", "since="+firstID, "-f", "before="+fourthID, "-n=1")
 	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, fmt.Sprintf("SINCE filter, BEFORE filter, LIMIT: Container list is not in the correct order: \n%s", out))
-
 }
 
 func assertContainerList(out string, expected []string) bool {
@@ -602,7 +601,6 @@ func (s *DockerCLIPsSuite) TestPsImageIDAfterUpdate(c *testing.T) {
 		f := strings.Fields(line)
 		assert.Equal(c, f[1], originalImageID)
 	}
-
 }
 
 func (s *DockerCLIPsSuite) TestPsNotShowPortsOfStoppedContainer(c *testing.T) {

--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -120,7 +120,6 @@ func (s *DockerHubPullSuite) TestPullNonExistingImage(c *testing.T) {
 			assert.Assert(c, !strings.Contains(record.out, "unauthorized"), `message should not contain "unauthorized"`)
 		}
 	}
-
 }
 
 // TestPullFromCentralRegistryImplicitRefParts pulls an image from the central registry and verifies

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -63,13 +63,11 @@ func (s *DockerCLIRmiSuite) TestRmiTag(c *testing.T) {
 	{
 		imagesAfter, _ := dockerCmd(c, "images", "-a")
 		assert.Equal(c, strings.Count(imagesAfter, "\n"), strings.Count(imagesBefore, "\n")+1, fmt.Sprintf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter))
-
 	}
 	dockerCmd(c, "rmi", "utest:tag1")
 	{
 		imagesAfter, _ := dockerCmd(c, "images", "-a")
 		assert.Equal(c, strings.Count(imagesAfter, "\n"), strings.Count(imagesBefore, "\n"), fmt.Sprintf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter))
-
 	}
 }
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -89,7 +89,6 @@ func (s *DockerCLIRunSuite) TestRunLookupGoogleDNS(c *testing.T) {
 	} else {
 		dockerCmd(c, "run", "busybox", "nslookup", "google.com")
 	}
-
 }
 
 // the exit code should be 0
@@ -355,7 +354,6 @@ func (s *DockerCLIRunSuite) TestRunWithDaemonFlags(c *testing.T) {
 
 // Regression test for #4979
 func (s *DockerCLIRunSuite) TestRunWithVolumesFromExited(c *testing.T) {
-
 	var (
 		out      string
 		exitCode int

--- a/integration-cli/docker_cli_service_health_test.go
+++ b/integration-cli/docker_cli_service_health_test.go
@@ -137,5 +137,4 @@ func (s *DockerSwarmSuite) TestServiceHealthStart(c *testing.T) {
 		task = d.GetTask(c, task.ID)
 		return task.Status.State, ""
 	}, checker.Equals(swarm.TaskStateRunning)), poll.WithTimeout(defaultReconciliationTimeout))
-
 }

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -615,7 +615,6 @@ const globalNetworkPlugin = "global-network-plugin"
 const globalIPAMPlugin = "global-ipam-plugin"
 
 func setupRemoteGlobalNetworkPlugin(c *testing.T, mux *http.ServeMux, url, netDrv, ipamDrv string) {
-
 	mux.HandleFunc("/Plugin.Activate", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
 		fmt.Fprintf(w, `{"Implements": ["%s", "%s"]}`, driverapi.NetworkPluginEndpointType, ipamapi.PluginEndpointType)
@@ -923,7 +922,6 @@ func (s *DockerSwarmSuite) TestSwarmServiceNetworkUpdate(c *testing.T) {
 	result.Assert(c, icmd.Success)
 
 	poll.WaitOn(c, pollCheck(c, d.CheckRunningTaskNetworks, checker.DeepEquals(map[string]int{barNetwork: 1, bazNetwork: 1})), poll.WithTimeout(defaultReconciliationTimeout))
-
 }
 
 func (s *DockerSwarmSuite) TestDNSConfig(c *testing.T) {

--- a/integration-cli/docker_cli_swarm_unix_test.go
+++ b/integration-cli/docker_cli_swarm_unix_test.go
@@ -104,5 +104,4 @@ func (s *DockerSwarmSuite) TestSwarmNetworkPluginV2(c *testing.T) {
 	assert.NilError(c, err)
 
 	poll.WaitOn(c, pollCheck(c, d1.CheckRunningTaskImages, checker.DeepEquals(map[string]int{image: 1})), poll.WithTimeout(defaultReconciliationTimeout))
-
 }

--- a/integration/config/config_test.go
+++ b/integration/config/config_test.go
@@ -109,7 +109,6 @@ func TestConfigList(t *testing.T) {
 		})
 		assert.NilError(t, err)
 		assert.Check(t, is.DeepEqual(configNamesFromList(entries), tc.expected))
-
 	}
 }
 

--- a/integration/container/daemon_linux_test.go
+++ b/integration/container/daemon_linux_test.go
@@ -169,7 +169,6 @@ func TestDaemonHostGatewayIP(t *testing.T) {
 	assert.Check(t, is.Contains(res.Stdout(), "6.7.8.9"))
 	c.ContainerRemove(ctx, cID, types.ContainerRemoveOptions{Force: true})
 	d.Stop(t)
-
 }
 
 // TestRestartDaemonWithRestartingContainer simulates a case where a container is in "restarting" state when

--- a/integration/container/logs_test.go
+++ b/integration/container/logs_test.go
@@ -170,7 +170,6 @@ func testLogs(t *testing.T, logDriver string) {
 					}
 					return
 				}
-
 			}
 
 			assert.DeepEqual(t, stdoutStr, tC.expectedOut)

--- a/integration/container/restart_test.go
+++ b/integration/container/restart_test.go
@@ -122,7 +122,6 @@ func TestDaemonRestartKillContainers(t *testing.T) {
 							break
 						}
 						time.Sleep(2 * time.Second)
-
 					}
 					assert.Equal(t, expected, running, "got unexpected running state, expected %v, got: %v", expected, running)
 
@@ -209,5 +208,4 @@ func TestContainerWithAutoRemoveCanBeRestarted(t *testing.T) {
 			poll.WaitOn(t, testContainer.IsRemoved(ctx, cli, cID))
 		})
 	}
-
 }

--- a/integration/container/wait_test.go
+++ b/integration/container/wait_test.go
@@ -221,5 +221,4 @@ func TestWaitRestartedContainer(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/integration/internal/requirement/requirement_linux.go
+++ b/integration/internal/requirement/requirement_linux.go
@@ -37,5 +37,4 @@ func Overlay2Supported(kernelVersion string) bool {
 	}
 	requiredV := kernel.VersionInfo{Kernel: 4}
 	return kernel.CompareKernelVersion(*daemonV, requiredV) > -1
-
 }

--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -96,7 +96,6 @@ func TestDaemonDefaultNetworkPools(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, out.IPAM.Config[0].Subnet, "175.33.1.0/24")
 	delInterface(t, defaultNetworkBridge)
-
 }
 
 func TestDaemonRestartWithExistingNetwork(t *testing.T) {
@@ -454,5 +453,4 @@ func TestServiceWithDefaultAddressPoolInit(t *testing.T) {
 	assert.NilError(t, err)
 	err = d.SwarmLeave(t, true)
 	assert.NilError(t, err)
-
 }

--- a/integration/plugin/logging/read_test.go
+++ b/integration/plugin/logging/read_test.go
@@ -88,5 +88,4 @@ func TestReadPluginNoRead(t *testing.T) {
 			assert.Assert(t, strings.TrimSpace(buf.String()) == "hello world", buf.Bytes())
 		})
 	}
-
 }

--- a/integration/secret/secret_test.go
+++ b/integration/secret/secret_test.go
@@ -109,7 +109,6 @@ func TestSecretList(t *testing.T) {
 		})
 		assert.NilError(t, err)
 		assert.Check(t, is.DeepEqual(secretNamesFromList(entries), tc.expected))
-
 	}
 }
 

--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -398,7 +398,6 @@ func TestCreateServiceSysctls(t *testing.T) {
 	// net.ipv4.ip_nonlocal_bind is, we can verify that setting the sysctl
 	// options works
 	for _, expected := range []string{"0", "1"} {
-
 		// store the map we're going to be using everywhere.
 		expectedSysctls := map[string]string{"net.ipv4.ip_nonlocal_bind": expected}
 

--- a/integration/service/list_test.go
+++ b/integration/service/list_test.go
@@ -104,5 +104,4 @@ func TestServiceListWithStatuses(t *testing.T) {
 		assert.Check(t, is.Equal(service.ServiceStatus.DesiredTasks, replicas))
 		assert.Check(t, is.Equal(service.ServiceStatus.RunningTasks, replicas))
 	}
-
 }

--- a/integration/system/event_test.go
+++ b/integration/system/event_test.go
@@ -71,7 +71,6 @@ func TestEventsExecDie(t *testing.T) {
 	case <-time.After(time.Second * 3):
 		t.Fatal("timeout hit")
 	}
-
 }
 
 // Test case for #18888: Events messages have been switched from generic

--- a/layer/layer_unix_test.go
+++ b/layer/layer_unix_test.go
@@ -63,5 +63,4 @@ func TestLayerSize(t *testing.T) {
 	if expected := len(content1) + len(content2); int(layer2Size) != expected {
 		t.Fatalf("Unexpected size %d, expected %d", layer2Size, expected)
 	}
-
 }

--- a/oci/devices_linux.go
+++ b/oci/devices_linux.go
@@ -55,10 +55,8 @@ func DevicesFromPath(pathOnHost, pathInContainer, cgroupPermissions string) (dev
 	// if the device is not a device node
 	// try to see if it's a directory holding many devices
 	if err == devices.ErrNotADevice {
-
 		// check if it is a directory
 		if src, e := os.Stat(resolvedPathOnHost); e == nil && src.IsDir() {
-
 			// mount the internal devices recursively
 			// TODO check if additional errors should be handled or logged
 			_ = filepath.Walk(resolvedPathOnHost, func(dpath string, f os.FileInfo, _ error) error {

--- a/opts/address_pools_test.go
+++ b/opts/address_pools_test.go
@@ -16,5 +16,4 @@ func TestAddressPoolOpt(t *testing.T) {
 	if err := poolopt.Set(invalidAddresspoolString); err == nil {
 		t.Fatal(err)
 	}
-
 }

--- a/opts/opts_test.go
+++ b/opts/opts_test.go
@@ -29,7 +29,6 @@ func TestValidateIPAddress(t *testing.T) {
 	if ret, err := ValidateIPAddress(`random invalid string`); err == nil || ret != "" {
 		t.Fatalf("ValidateIPAddress(`random invalid string`) got %s %s", ret, err)
 	}
-
 }
 
 func TestMapOpts(t *testing.T) {
@@ -89,7 +88,6 @@ func TestListOptsWithoutValidator(t *testing.T) {
 	if len(mapListOpts) != 1 {
 		t.Errorf("Expected [map[bar:{}]], got [%v]", mapListOpts)
 	}
-
 }
 
 func TestListOptsWithValidator(t *testing.T) {
@@ -264,7 +262,6 @@ func TestValidateLabel(t *testing.T) {
 				assert.Check(t, is.Equal(result, testCase.expectedResult))
 			}
 		})
-
 	}
 }
 

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -395,7 +395,6 @@ func ReplaceFileTarWrapper(inputTarStream io.ReadCloser, mods map[string]TarModi
 		}
 
 		pipeWriter.Close()
-
 	}()
 	return pipeReader
 }
@@ -802,7 +801,6 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 			}
 			return err
 		}
-
 	}
 
 	if len(errors) > 0 {

--- a/pkg/archive/archive_linux_test.go
+++ b/pkg/archive/archive_linux_test.go
@@ -61,7 +61,6 @@ func checkOpaqueness(t *testing.T, path string, opaque string) {
 	if string(xattrOpaque) != opaque {
 		t.Fatalf("Unexpected opaque value: %q, expected %q", string(xattrOpaque), opaque)
 	}
-
 }
 
 func checkOverlayWhiteout(t *testing.T, path string) {

--- a/pkg/archive/changes.go
+++ b/pkg/archive/changes.go
@@ -246,7 +246,6 @@ func (info *FileInfo) path() string {
 }
 
 func (info *FileInfo) addChanges(oldInfo *FileInfo, changes *[]Change) {
-
 	sizeAtEntry := len(*changes)
 
 	if oldInfo == nil {
@@ -319,7 +318,6 @@ func (info *FileInfo) addChanges(oldInfo *FileInfo, changes *[]Change) {
 		copy((*changes)[sizeAtEntry+1:], (*changes)[sizeAtEntry:])
 		(*changes)[sizeAtEntry] = change
 	}
-
 }
 
 // Changes add changes to file information.

--- a/pkg/archive/changes_posix_test.go
+++ b/pkg/archive/changes_posix_test.go
@@ -102,7 +102,6 @@ func TestHardLinkOrder(t *testing.T) {
 			t.Errorf("headers - %q expected linkname %q; but got %q", hdrs[i].Name, hdrs[i].Linkname, hdrsRev[i].Linkname)
 		}
 	}
-
 }
 
 type tarHeaders []tar.Header

--- a/pkg/archive/copy.go
+++ b/pkg/archive/copy.go
@@ -303,7 +303,6 @@ func PrepareArchiveCopy(srcContent io.Reader, srcInfo, dstInfo CopyInfo) (dstDir
 		}
 		return dstDir, RebaseArchiveEntries(srcContent, srcBase, dstBase), nil
 	}
-
 }
 
 // RebaseArchiveEntries rewrites the given srcContent archive replacing

--- a/pkg/archive/copy_unix_test.go
+++ b/pkg/archive/copy_unix_test.go
@@ -372,7 +372,6 @@ func TestCopyCaseB(t *testing.T) {
 	if err != ErrDirNotExists {
 		t.Fatalf("expected ErrDirNotExists error, but got %T: %s", err, err)
 	}
-
 }
 
 // C. SRC specifies a file and DST exists as a file.

--- a/pkg/archive/diff_test.go
+++ b/pkg/archive/diff_test.go
@@ -308,7 +308,6 @@ func TestApplyLayerWhiteouts(t *testing.T) {
 			t.Fatalf("invalid files for layer %d: expected %q, got %q", i, tc.expected, paths)
 		}
 	}
-
 }
 
 func makeTestLayer(paths []string) (rc io.ReadCloser, err error) {

--- a/pkg/authorization/api_test.go
+++ b/pkg/authorization/api_test.go
@@ -68,9 +68,6 @@ func TestPeerCertificateMarshalJSON(t *testing.T) {
 			assert.Assert(t, is.Nil(err))
 			assert.Equal(t, "Earth", pcObj.Subject.Country[0])
 			assert.Equal(t, true, pcObj.IsCA)
-
 		})
-
 	}
-
 }

--- a/pkg/authorization/middleware_test.go
+++ b/pkg/authorization/middleware_test.go
@@ -43,7 +43,6 @@ func TestNewResponseModifier(t *testing.T) {
 	if recorder.Header().Get("H1") != "V1" {
 		t.Fatalf("Header value must exists %s", recorder.Header().Get("H1"))
 	}
-
 }
 
 func setAuthzPlugins(m *Middleware, plugins []Plugin) {

--- a/pkg/authorization/middleware_unix_test.go
+++ b/pkg/authorization/middleware_unix_test.go
@@ -50,7 +50,6 @@ func TestMiddlewareWrapHandler(t *testing.T) {
 		if err := mdHandler(ctx, resp, req, map[string]string{}); err == nil {
 			assert.Assert(t, is.ErrorContains(err, ""))
 		}
-
 	})
 
 	t.Run("Positive Test Case :", func(t *testing.T) {
@@ -61,7 +60,5 @@ func TestMiddlewareWrapHandler(t *testing.T) {
 		if err := mdHandler(ctx, resp, req, map[string]string{}); err != nil {
 			assert.NilError(t, err)
 		}
-
 	})
-
 }

--- a/pkg/authorization/response.go
+++ b/pkg/authorization/response.go
@@ -67,9 +67,8 @@ func (rm *responseModifier) Hijacked() bool {
 	return rm.hijacked
 }
 
-// WriterHeader stores the http status code
+// WriteHeader stores the http status code
 func (rm *responseModifier) WriteHeader(s int) {
-
 	// Use original request if hijacked
 	if rm.hijacked {
 		rm.rw.WriteHeader(s)
@@ -81,7 +80,6 @@ func (rm *responseModifier) WriteHeader(s int) {
 
 // Header returns the internal http header
 func (rm *responseModifier) Header() http.Header {
-
 	// Use original header if hijacked
 	if rm.hijacked {
 		return rm.rw.Header()
@@ -143,7 +141,6 @@ func (rm *responseModifier) RawHeaders() ([]byte, error) {
 
 // Hijack returns the internal connection of the wrapped http.ResponseWriter
 func (rm *responseModifier) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-
 	rm.hijacked = true
 	rm.FlushAll()
 

--- a/pkg/devicemapper/devmapper.go
+++ b/pkg/devicemapper/devmapper.go
@@ -237,12 +237,8 @@ func (t *Task) getDriverVersion() (string, error) {
 	return res, nil
 }
 
-func (t *Task) getNextTarget(next unsafe.Pointer) (nextPtr unsafe.Pointer, start uint64,
-	length uint64, targetType string, params string) {
-
-	return DmGetNextTarget(t.unmanaged, next, &start, &length,
-			&targetType, &params),
-		start, length, targetType, params
+func (t *Task) getNextTarget(next unsafe.Pointer) (nextPtr unsafe.Pointer, start uint64, length uint64, targetType string, params string) {
+	return DmGetNextTarget(t.unmanaged, next, &start, &length, &targetType, &params), start, length, targetType, params
 }
 
 // UdevWait waits for any processes that are waiting for udev to complete the specified cookie.
@@ -396,7 +392,6 @@ func CancelDeferredRemove(deviceName string) error {
 			return ErrEnxio
 		}
 		return fmt.Errorf("devicemapper: Error running CancelDeferredRemove %s", err)
-
 	}
 	return nil
 }
@@ -680,7 +675,6 @@ func CreateDevice(poolName string, deviceID int) error {
 		}
 
 		return fmt.Errorf("devicemapper: Error running CreateDevice %s", err)
-
 	}
 	return nil
 }

--- a/pkg/devicemapper/devmapper_wrapper.go
+++ b/pkg/devicemapper/devmapper_wrapper.go
@@ -132,9 +132,7 @@ func dmTaskSetAddNodeFct(task *cdmTask, addNode AddNodeType) int {
 	return int(C.dm_task_set_add_node((*C.struct_dm_task)(task), C.dm_add_node_t(addNode)))
 }
 
-func dmTaskAddTargetFct(task *cdmTask,
-	start, size uint64, ttype, params string) int {
-
+func dmTaskAddTargetFct(task *cdmTask, start, size uint64, ttype, params string) int {
 	Cttype := C.CString(ttype)
 	defer free(Cttype)
 

--- a/pkg/directory/directory.go
+++ b/pkg/directory/directory.go
@@ -7,7 +7,6 @@ import (
 
 // MoveToSubdir moves all contents of a directory to a subdirectory underneath the original path
 func MoveToSubdir(oldpath, subdir string) error {
-
 	infos, err := os.ReadDir(oldpath)
 	if err != nil {
 		return err

--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -19,7 +19,6 @@ func TestCopyFileWithInvalidSrc(t *testing.T) {
 	if bytes != 0 {
 		t.Fatal("Should have written 0 bytes")
 	}
-
 }
 
 // CopyFile with invalid dest
@@ -37,7 +36,6 @@ func TestCopyFileWithInvalidDest(t *testing.T) {
 	if bytes != 0 {
 		t.Fatal("Should have written 0 bytes")
 	}
-
 }
 
 // CopyFile with same src and dest
@@ -492,7 +490,6 @@ func TestMatches(t *testing.T) {
 			check(pm, test.text, test.pass, desc)
 		}
 	})
-
 }
 
 func TestCleanPatterns(t *testing.T) {

--- a/pkg/idtools/idtools_unix.go
+++ b/pkg/idtools/idtools_unix.go
@@ -213,7 +213,6 @@ func callGetent(database, key string) (io.Reader, error) {
 		default:
 			return nil, err
 		}
-
 	}
 	return bytes.NewReader(out), nil
 }

--- a/pkg/idtools/usergroupadd_linux.go
+++ b/pkg/idtools/usergroupadd_linux.go
@@ -88,7 +88,6 @@ func addUser(name string) error {
 }
 
 func createSubordinateRanges(name string) error {
-
 	// first, we should verify that ranges weren't automatically created
 	// by the distro tooling
 	ranges, err := parseSubuid(name)

--- a/pkg/ioutils/bytespipe_test.go
+++ b/pkg/ioutils/bytespipe_test.go
@@ -119,7 +119,6 @@ func TestBytesPipeWriteRandomChunks(t *testing.T) {
 		if expected != actual {
 			t.Fatalf("BytesPipe returned invalid data. Expected checksum %v, got %v", expected, actual)
 		}
-
 	}
 }
 

--- a/pkg/ioutils/fswriters_test.go
+++ b/pkg/ioutils/fswriters_test.go
@@ -95,7 +95,6 @@ func TestAtomicWriteSetCommit(t *testing.T) {
 	if expected := testMode; st.Mode() != expected {
 		t.Fatalf("Mode mismatched, expected %o, got %o", expected, st.Mode())
 	}
-
 }
 
 func TestAtomicWriteSetCancel(t *testing.T) {

--- a/pkg/ioutils/writers_test.go
+++ b/pkg/ioutils/writers_test.go
@@ -27,7 +27,6 @@ func TestNopWriteCloser(t *testing.T) {
 	if err := wrapper.Close(); err != nil {
 		t.Fatal("NopWriteCloser always return nil on Close.")
 	}
-
 }
 
 func TestNopWriter(t *testing.T) {

--- a/pkg/loopback/attach_loopback.go
+++ b/pkg/loopback/attach_loopback.go
@@ -94,7 +94,6 @@ func openNextAvailableLoopback(index int, sparseFile *os.File) (loopFile *os.Fil
 // AttachLoopDevice attaches the given sparse file to the next
 // available loopback device. It returns an opened *os.File.
 func AttachLoopDevice(sparseName string) (loop *os.File, err error) {
-
 	// Try to retrieve the next available loopback device via syscall.
 	// If it fails, we discard error and start looping for a
 	// loopback from index 0.

--- a/pkg/namesgenerator/names-generator_test.go
+++ b/pkg/namesgenerator/names-generator_test.go
@@ -23,7 +23,6 @@ func TestNameRetries(t *testing.T) {
 	if !strings.ContainsAny(name, "0123456789") {
 		t.Fatalf("Generated name doesn't contain a number")
 	}
-
 }
 
 func BenchmarkGetRandomName(b *testing.B) {

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -151,7 +151,6 @@ func (p *Plugin) runHandlers() {
 		p.handlersRun = true
 	}
 	handlers.RUnlock()
-
 }
 
 // activated returns if the plugin has already been activated.

--- a/pkg/sysinfo/sysinfo_linux_test.go
+++ b/pkg/sysinfo/sysinfo_linux_test.go
@@ -33,7 +33,6 @@ func TestReadProcBool(t *testing.T) {
 	if readProcBool(path.Join(tmpDir, "no-exist")) {
 		t.Fatal("should be false for non-existent entry")
 	}
-
 }
 
 func TestCgroupEnabled(t *testing.T) {

--- a/pkg/system/meminfo_linux.go
+++ b/pkg/system/meminfo_linux.go
@@ -55,7 +55,6 @@ func parseMemInfo(reader io.Reader) (*MemInfo, error) {
 		case "SwapFree:":
 			meminfo.SwapFree = bytes
 		}
-
 	}
 	if memAvailable != -1 {
 		meminfo.MemFree = memAvailable

--- a/pkg/system/path.go
+++ b/pkg/system/path.go
@@ -13,7 +13,6 @@ func DefaultPathEnv(os string) string {
 		return ""
 	}
 	return defaultUnixPathEnv
-
 }
 
 // PathVerifier defines the subset of a PathDriver that CheckSystemDriveAndRemoveDriveLetter

--- a/pkg/tailfile/tailfile.go
+++ b/pkg/tailfile/tailfile.go
@@ -216,6 +216,5 @@ func (s *scanner) Scan(ctx context.Context) bool {
 			// It's much simpler and cleaner to just re-read `len(delimiter)-1` bytes again.
 			s.pos += int64(len(s.delim)) - 1
 		}
-
 	}
 }

--- a/pkg/tarsum/fileinfosums_test.go
+++ b/pkg/tarsum/fileinfosums_test.go
@@ -58,5 +58,4 @@ func TestSortFileInfoSums(t *testing.T) {
 	if fis.GetFile("noPresent") != nil {
 		t.Error("Should have return nil if name not found.")
 	}
-
 }

--- a/pkg/tarsum/tarsum_test.go
+++ b/pkg/tarsum/tarsum_test.go
@@ -196,7 +196,6 @@ func TestNewTarSumForLabelInvalid(t *testing.T) {
 }
 
 func TestNewTarSumForLabel(t *testing.T) {
-
 	layer := testLayers[0]
 
 	reader, err := os.Open(layer.filename)
@@ -292,7 +291,6 @@ func TestTarSumsReadSize(t *testing.T) {
 	layer := testLayers[0]
 
 	for i := 0; i < 5; i++ {
-
 		reader, err := os.Open(layer.filename)
 		if err != nil {
 			t.Fatal(err)
@@ -515,7 +513,6 @@ func TestIteration(t *testing.T) {
 			t.Errorf("expected sum: %q, got: %q", htest.expectedSum, s)
 		}
 	}
-
 }
 
 func renderSumForHeader(v Version, h *tar.Header, data []byte) (string, error) {

--- a/plugin/backend_linux.go
+++ b/plugin/backend_linux.go
@@ -370,7 +370,6 @@ func (pm *Manager) Push(ctx context.Context, name string, metaHeader http.Header
 
 	pusher, err := resolver.Pusher(ctx, ref.String())
 	if err != nil {
-
 		return errors.Wrap(err, "error creating plugin pusher")
 	}
 

--- a/plugin/manager_linux.go
+++ b/plugin/manager_linux.go
@@ -112,7 +112,6 @@ func (pm *Manager) pluginPostStart(p *v2.Plugin, c *controller) error {
 			shutdownPlugin(p, c.exitChan, pm.executor)
 			return err
 		}
-
 	}
 	pm.config.Store.SetState(p, true)
 	pm.config.Store.CallHandler(p)

--- a/plugin/v2/settable_test.go
+++ b/plugin/v2/settable_test.go
@@ -38,7 +38,6 @@ func TestNewSettable(t *testing.T) {
 		if s.value != c.value {
 			t.Fatalf("expected value to be %q, got %q", c.value, s.value)
 		}
-
 	}
 }
 

--- a/registry/config_test.go
+++ b/registry/config_test.go
@@ -352,9 +352,7 @@ func TestValidateIndexName(t *testing.T) {
 		if assert.Check(t, err) {
 			assert.Check(t, is.Equal(testCase.expect, result))
 		}
-
 	}
-
 }
 
 func TestValidateIndexNameWithError(t *testing.T) {

--- a/runconfig/config_test.go
+++ b/runconfig/config_test.go
@@ -21,7 +21,6 @@ type f struct {
 }
 
 func TestDecodeContainerConfig(t *testing.T) {
-
 	var (
 		fixtures []f
 		image    string
@@ -73,7 +72,6 @@ func TestDecodeContainerConfig(t *testing.T) {
 // to the daemon in the hostConfig structure. Note this is platform specific
 // as to what level of container isolation is supported.
 func TestDecodeContainerConfigIsolation(t *testing.T) {
-
 	// An Invalid isolation level
 	if _, _, _, err := callDecodeContainerConfigIsolation("invalid"); err != nil {
 		if !strings.Contains(err.Error(), `Invalid isolation: "invalid"`) {

--- a/testutil/daemon/plugin.go
+++ b/testutil/daemon/plugin.go
@@ -64,7 +64,6 @@ func withPluginInspect(name string, f func(*types.Plugin, poll.LogT) poll.Result
 		}
 		return f(plugin, t)
 	}
-
 }
 
 func withClient(t testing.TB, d *Daemon, f func(client.APIClient, poll.LogT) poll.Result) func(poll.LogT) poll.Result {

--- a/testutil/fakecontext/context.go
+++ b/testutil/fakecontext/context.go
@@ -96,7 +96,6 @@ func (f *Fake) addFile(file string, content []byte) error {
 		}
 	}
 	return os.WriteFile(fp, content, 0644)
-
 }
 
 // Delete a file at a path

--- a/testutil/fixtures/load/frozen.go
+++ b/testutil/fixtures/load/frozen.go
@@ -154,7 +154,6 @@ func pullTagAndRemove(ctx context.Context, client client.APIClient, ref string, 
 	}
 	_, err = client.ImageRemove(ctx, ref, types.ImageRemoveOptions{})
 	return errors.Wrapf(err, "failed to remove %s", ref)
-
 }
 
 func readFrozenImageList(dockerfilePath string, images []string) (map[string]string, error) {

--- a/volume/local/local_test.go
+++ b/volume/local/local_test.go
@@ -26,7 +26,6 @@ func TestGetAddress(t *testing.T) {
 			t.Errorf("Test case failed for %s actual: %s expected : %s", name, v, success)
 		}
 	}
-
 }
 
 func TestGetPassword(t *testing.T) {

--- a/volume/local/local_unix.go
+++ b/volume/local/local_unix.go
@@ -143,10 +143,7 @@ func (v *localVolume) postMount() error {
 	}
 	if v.opts.Quota.Size > 0 {
 		if v.quotaCtl != nil {
-			err := v.quotaCtl.SetQuota(v.path, v.opts.Quota)
-			if err != nil {
-				return err
-			}
+			return v.quotaCtl.SetQuota(v.path, v.opts.Quota)
 		} else {
 			return errors.New("size quota requested for volume but no quota support")
 		}

--- a/volume/mounts/parser_test.go
+++ b/volume/mounts/parser_test.go
@@ -87,5 +87,4 @@ func TestParseMountSpec(t *testing.T) {
 			t.Errorf("Expected mount copy data to match. Expected: '%v', Actual: '%v'", c.expected.CopyData, mp.CopyData)
 		}
 	}
-
 }

--- a/volume/mounts/windows_parser.go
+++ b/volume/mounts/windows_parser.go
@@ -128,7 +128,6 @@ func (p *windowsParser) splitRawSpec(raw string, splitRegexp *regexp.Regexp) ([]
 			exists, isDir, _ := p.fi.fileInfo(matchgroups["destination"])
 			if exists && !isDir {
 				return nil, fmt.Errorf("file '%s' cannot be mapped. Only directories can be mapped on this platform", matchgroups["destination"])
-
 			}
 		}
 	}

--- a/volume/service/service_test.go
+++ b/volume/service/service_test.go
@@ -45,7 +45,6 @@ func TestServiceCreate(t *testing.T) {
 	assert.NilError(t, err)
 	_, err = service.Create(ctx, "v1", "d2")
 	assert.NilError(t, err)
-
 }
 
 func TestServiceList(t *testing.T) {


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44211