### PR TITLE
[DO NOT MERGE] Test if pivot_root can be used from a user ns

### DIFF
--- a/pkg/chrootarchive/chroot_linux.go
+++ b/pkg/chrootarchive/chroot_linux.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/containerd/containerd/pkg/userns"
 	"github.com/moby/sys/mount"
 	"github.com/moby/sys/mountinfo"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -19,9 +19,12 @@ import (
 // This is similar to how libcontainer sets up a container's rootfs
 func chroot(path string) (err error) {
 	// if the engine is running in a user namespace we need to use actual chroot
-	if userns.RunningInUserNS() {
-		return realChroot(path)
-	}
+	// if userns.RunningInUserNS() {
+	//	return realChroot(path)
+	// }
+	status, err := os.ReadFile("/proc/thread-self/status")
+	logrus.WithError(err).WithField("path", path).Infof("chrootarchive: /proc/thread-self/status: -=-=-=-\n%s\n=-=-=-=", status)
+
 	if err := unix.Unshare(unix.CLONE_NEWNS); err != nil {
 		return fmt.Errorf("Error creating mount namespace before pivot: %v", err)
 	}


### PR DESCRIPTION
It didn't work in 2016 when user namespace support was first implemented, but the manpages indicate that it should be possible. Let's throw it at CI and see what happens. (I can't get rootless tests to run locally...)

Signed-off-by: Cory Snider <csnider@mirantis.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

