### PR TITLE
libnetwork: remove some outdated comments

### DIFF
--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -92,7 +92,6 @@ type sandbox struct {
 
 // These are the container configs used to customize container /etc/hosts file.
 type hostsPathConfig struct {
-	// Note(cpuguy83): The linter is drunk and says none of these fields are used while they are
 	hostName        string
 	domainName      string
 	hostsPath       string
@@ -114,7 +113,6 @@ type extraHost struct {
 
 // These are the container configs used to customize container /etc/resolv.conf file.
 type resolvConfPathConfig struct {
-	// Note(cpuguy83): The linter is drunk and says none of these fields are used while they are
 	resolvConfPath       string
 	originResolvConfPath string
 	resolvConfHashFile   string


### PR DESCRIPTION
The corresponding "nolint" comments were removed in 2f1c382a6ddb988cf968c0eac1c2c0884826e214 (https://github.com/moby/moby/pull/44089), but didn't remove these comments.


**- A picture of a cute animal (not mandatory but encouraged)**

