### PR TITLE
[22.06 backport] docs: swagger: update description for default builder version

### DIFF
--- a/docs/api/v1.42.yaml
+++ b/docs/api/v1.42.yaml
@@ -8786,7 +8786,17 @@ paths:
               description: "Max API Version the server supports"
             Builder-Version:
               type: "string"
-              description: "Default version of docker image builder"
+              description: |
+                Default version of docker image builder
+
+                The default on Linux is version "2" (BuildKit), but the daemon
+                can be configured to recommend version "1" (classic Builder).
+                Windows does not yet support BuildKit for native Windows images,
+                and uses "1" (classic builder) as a default.
+
+                This value is a recommendation as advertised by the daemon, and
+                it is up to the client to choose which builder to use.
+              default: "2"
             Docker-Experimental:
               type: "boolean"
               description: "If the server is running with experimental mode enabled"


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44244
- relates to https://github.com/moby/moby/pull/43657

Commit 7b153b9e28b53779215de209736310f9266b3f2f updated the main swagger file, but didn't update the v1.42 version used for the documentation as it wasn't created yet at the time.

(cherry picked from commit 271243d382edd02ca26768ca286b003a979e1b22)


**- A picture of a cute animal (not mandatory but encouraged)**

