### PR TITLE
pkg/directory: Size(): add back type-casts to account for platform differences

### DIFF
--- a/pkg/directory/directory_unix.go
+++ b/pkg/directory/directory_unix.go
@@ -40,12 +40,12 @@ func Size(ctx context.Context, dir string) (size int64, err error) {
 
 		// Check inode to handle hard links correctly
 		inode := fileInfo.Sys().(*syscall.Stat_t).Ino
-		// inode is not a uint64 on all platforms. Cast it to avoid issues.
-		if _, exists := data[inode]; exists {
+		//nolint:unconvert // inode is not an uint64 on all platforms.
+		if _, exists := data[uint64(inode)]; exists {
 			return nil
 		}
-		// inode is not a uint64 on all platforms. Cast it to avoid issues.
-		data[inode] = struct{}{}
+
+		data[uint64(inode)] = struct{}{} //nolint:unconvert // inode is not an uint64 on all platforms.
 
 		size += s
 


### PR DESCRIPTION
I noticed the comment above this code, but didn't see a corresponding type-cast. Looking at this file's history, I found that these were removed as part of 2f5f0af3fdb7e9ee607a0e178dbe2af6e10cccf4 (https://github.com/moby/moby/pull/34625), which looks to have overlooked some deliberate type-casts.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

