### PR TITLE
pkg/directory: remove unused MoveToSubdir() utility, and some refactoring

### DIFF
--- a/pkg/directory/directory.go
+++ b/pkg/directory/directory.go
@@ -1,6 +1,7 @@
 package directory // import "github.com/docker/docker/pkg/directory"
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 )
@@ -21,4 +22,9 @@ func MoveToSubdir(oldpath, subdir string) error {
 		}
 	}
 	return nil
+}
+
+// Size walks a directory tree and returns its total size in bytes.
+func Size(ctx context.Context, dir string) (int64, error) {
+	return calcSize(ctx, dir)
 }

--- a/pkg/directory/directory.go
+++ b/pkg/directory/directory.go
@@ -1,28 +1,6 @@
 package directory // import "github.com/docker/docker/pkg/directory"
 
-import (
-	"context"
-	"os"
-	"path/filepath"
-)
-
-// MoveToSubdir moves all contents of a directory to a subdirectory underneath the original path
-func MoveToSubdir(oldpath, subdir string) error {
-	infos, err := os.ReadDir(oldpath)
-	if err != nil {
-		return err
-	}
-	for _, info := range infos {
-		if info.Name() != subdir {
-			oldName := filepath.Join(oldpath, info.Name())
-			newName := filepath.Join(oldpath, subdir, info.Name())
-			if err := os.Rename(oldName, newName); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
+import "context"
 
 // Size walks a directory tree and returns its total size in bytes.
 func Size(ctx context.Context, dir string) (int64, error) {

--- a/pkg/directory/directory_test.go
+++ b/pkg/directory/directory_test.go
@@ -3,9 +3,6 @@ package directory // import "github.com/docker/docker/pkg/directory"
 import (
 	"context"
 	"os"
-	"path/filepath"
-	"reflect"
-	"sort"
 	"testing"
 )
 
@@ -141,51 +138,6 @@ func TestSizeFileAndNestedDirectoryNonempty(t *testing.T) {
 	var size int64
 	if size, _ = Size(context.Background(), dir); size != 12 {
 		t.Fatalf("directory with 6-byte file and nested directory with 6-byte file has size: %d", size)
-	}
-}
-
-// Test migration of directory to a subdir underneath itself
-func TestMoveToSubdir(t *testing.T) {
-	var outerDir, subDir string
-	var err error
-
-	if outerDir, err = os.MkdirTemp(os.TempDir(), "TestMoveToSubdir"); err != nil {
-		t.Fatalf("failed to create directory: %v", err)
-	}
-
-	if subDir, err = os.MkdirTemp(outerDir, "testSub"); err != nil {
-		t.Fatalf("failed to create subdirectory: %v", err)
-	}
-
-	// write 4 temp files in the outer dir to get moved
-	filesList := []string{"a", "b", "c", "d"}
-	for _, fName := range filesList {
-		if file, err := os.Create(filepath.Join(outerDir, fName)); err != nil {
-			t.Fatalf("couldn't create temp file %q: %v", fName, err)
-		} else {
-			file.WriteString(fName)
-			file.Close()
-		}
-	}
-
-	if err = MoveToSubdir(outerDir, filepath.Base(subDir)); err != nil {
-		t.Fatalf("Error during migration of content to subdirectory: %v", err)
-	}
-	// validate that the files were moved to the subdirectory
-	infos, err := os.ReadDir(subDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(infos) != 4 {
-		t.Fatalf("Should be four files in the subdir after the migration: actual length: %d", len(infos))
-	}
-	var results []string
-	for _, info := range infos {
-		results = append(results, info.Name())
-	}
-	sort.Strings(results)
-	if !reflect.DeepEqual(filesList, results) {
-		t.Fatalf("Results after migration do not equal list of files: expected: %v, got: %v", filesList, results)
 	}
 }
 

--- a/pkg/directory/directory_unix.go
+++ b/pkg/directory/directory_unix.go
@@ -10,14 +10,15 @@ import (
 	"syscall"
 )
 
-// Size walks a directory tree and returns its total size in bytes.
-func Size(ctx context.Context, dir string) (size int64, err error) {
+// calcSize walks a directory tree and returns its total size in bytes.
+func calcSize(ctx context.Context, dir string) (int64, error) {
+	var size int64
 	data := make(map[uint64]struct{})
-	err = filepath.Walk(dir, func(d string, fileInfo os.FileInfo, err error) error {
+	err := filepath.Walk(dir, func(d string, fileInfo os.FileInfo, err error) error {
 		if err != nil {
-			// if dir does not exist, Size() returns the error.
 			// if dir/x disappeared while walking, Size() ignores dir/x.
-			if os.IsNotExist(err) && d != dir {
+			// if dir does not exist, Size() returns the error.
+			if d != dir && os.IsNotExist(err) {
 				return nil
 			}
 			return err
@@ -51,5 +52,5 @@ func Size(ctx context.Context, dir string) (size int64, err error) {
 
 		return nil
 	})
-	return
+	return size, err
 }

--- a/pkg/directory/directory_windows.go
+++ b/pkg/directory/directory_windows.go
@@ -6,13 +6,14 @@ import (
 	"path/filepath"
 )
 
-// Size walks a directory tree and returns its total size in bytes.
-func Size(ctx context.Context, dir string) (size int64, err error) {
-	err = filepath.Walk(dir, func(d string, fileInfo os.FileInfo, err error) error {
+// calcSize walks a directory tree and returns its total calcSize in bytes.
+func calcSize(ctx context.Context, dir string) (int64, error) {
+	var size int64
+	err := filepath.Walk(dir, func(d string, fileInfo os.FileInfo, err error) error {
 		if err != nil {
-			// if dir does not exist, Size() returns the error.
 			// if dir/x disappeared while walking, Size() ignores dir/x.
-			if os.IsNotExist(err) && d != dir {
+			// if dir does not exist, Size() returns the error.
+			if d != dir && os.IsNotExist(err) {
 				return nil
 			}
 			return err
@@ -38,5 +39,5 @@ func Size(ctx context.Context, dir string) (size int64, err error) {
 
 		return nil
 	})
-	return
+	return size, err
 }


### PR DESCRIPTION
### pkg/directory: minor refactor of Size()

- separate exported function from implementation, to allow for GoDoc to be maintained in a single location.
- don't use named return variables (no "bare" return, and potentially shadowing variables)
- reverse the `os.IsNotExist(err) && d != dir` condition, putting  the "lighter" `d != dir` first.


### pkg/directory: remove unused MoveToSubdir() utility

This utility was added in 442b45628ee12ebd8e8bd08497896d5fa8eec4bd (https://github.com/moby/moby/pull/12648) as part of user-namespaces, and first used in 44e1023a93a0107d63d5400695cbbc6da498a425 to set up the daemon root, and move the existing content;
https://github.com/docker/docker/blob/44e1023a93a0107d63d5400695cbbc6da498a425/daemon/daemon_experimental.go#L68-L71

A later iteration no longer _moved_ the existing root directory, and removed the use of `directory.MoveToSubdir()` e8532023f20498e6eb1ce5c079dc8a09aeae3061 (https://github.com/moby/moby/pull/19093)

It looks like there's no external consumers of this utility, so we should be save to remove it.


**- A picture of a cute animal (not mandatory but encouraged)**

