### PR TITLE
pkg/idtools: remove CanAccess(), and move to daemon

### DIFF
--- a/pkg/idtools/idtools_unix.go
+++ b/pkg/idtools/idtools_unix.go
@@ -59,17 +59,15 @@ func mkdirAs(path string, mode os.FileMode, owner Identity, mkAll, chownExisting
 			if dirPath == "/" {
 				break
 			}
-			if _, err := os.Stat(dirPath); err != nil && os.IsNotExist(err) {
+			if _, err = os.Stat(dirPath); err != nil && os.IsNotExist(err) {
 				paths = append(paths, dirPath)
 			}
 		}
-		if err := os.MkdirAll(path, mode); err != nil {
+		if err = os.MkdirAll(path, mode); err != nil {
 			return err
 		}
-	} else {
-		if err := os.Mkdir(path, mode); err != nil && !os.IsExist(err) {
-			return err
-		}
+	} else if err = os.Mkdir(path, mode); err != nil {
+		return err
 	}
 	// even if it existed, we will chown the requested path + any subpaths that
 	// didn't exist when we called MkdirAll

--- a/pkg/idtools/idtools_unix.go
+++ b/pkg/idtools/idtools_unix.go
@@ -79,30 +79,6 @@ func mkdirAs(path string, mode os.FileMode, owner Identity, mkAll, chownExisting
 	return nil
 }
 
-// CanAccess takes a valid (existing) directory and a uid, gid pair and determines
-// if that uid, gid pair has access (execute bit) to the directory
-func CanAccess(path string, pair Identity) bool {
-	statInfo, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-	perms := statInfo.Mode().Perm()
-	if perms&0o001 == 0o001 {
-		// world access
-		return true
-	}
-	ssi := statInfo.Sys().(*syscall.Stat_t)
-	if ssi.Uid == uint32(pair.UID) && (perms&0o100 == 0o100) {
-		// owner access.
-		return true
-	}
-	if ssi.Gid == uint32(pair.GID) && (perms&0o010 == 0o010) {
-		// group access.
-		return true
-	}
-	return false
-}
-
 // LookupUser uses traditional local system files lookup (from libcontainer/user) on a username,
 // followed by a call to `getent` for supporting host configured non-files passwd and group dbs
 func LookupUser(name string) (user.User, error) {


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/44254
- relates to / closes https://github.com/moby/moby/issues/43724

The implementation of CanAccess() is very rudimentary, and should
not be used for anything other than a basic check (and maybe not
even for that). It's only used in a single location in the daemon,
so move it there, and un-export it to not encourage others to use
it out of context.