### PR TITLE
pkg/pidfile: windows: replace magic consts for golang.org/x/sys consts

### DIFF
--- a/pkg/pidfile/pidfile_windows.go
+++ b/pkg/pidfile/pidfile_windows.go
@@ -11,7 +11,7 @@ func processExists(pid int) bool {
 	}
 	var c uint32
 	err = windows.GetExitCodeProcess(h, &c)
-	windows.Close(h)
+	_ = windows.CloseHandle(h)
 	if err != nil {
 		// From the GetExitCodeProcess function (processthreadsapi.h) API docs:
 		// https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getexitcodeprocess

--- a/pkg/pidfile/pidfile_windows.go
+++ b/pkg/pidfile/pidfile_windows.go
@@ -4,14 +4,8 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-const (
-	processQueryLimitedInformation = 0x1000
-
-	stillActive = 259
-)
-
 func processExists(pid int) bool {
-	h, err := windows.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
 	if err != nil {
 		return false
 	}
@@ -19,7 +13,18 @@ func processExists(pid int) bool {
 	err = windows.GetExitCodeProcess(h, &c)
 	windows.Close(h)
 	if err != nil {
-		return c == stillActive
+		// From the GetExitCodeProcess function (processthreadsapi.h) API docs:
+		// https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getexitcodeprocess
+		//
+		// The GetExitCodeProcess function returns a valid error code defined by the
+		// application only after the thread terminates. Therefore, an application should
+		// not use STILL_ACTIVE (259) as an error code (STILL_ACTIVE is a macro for
+		// STATUS_PENDING (minwinbase.h)). If a thread returns STILL_ACTIVE (259) as
+		// an error code, then applications that test for that value could interpret it
+		// to mean that the thread is still running, and continue to test for the
+		// completion of the thread after the thread has terminated, which could put
+		// the application into an infinite loop.
+		return c == uint32(windows.STATUS_PENDING)
 	}
 	return true
 }


### PR DESCRIPTION
- related: https://github.com/golang/sys/pull/139

### pkg/pidfile: windows: replace magic consts for golang.org/x/sys consts

These consts were defined locally, but are now defined in golang.org/x/sys, so
we can use those.

Also added some documentation about how this function works, taking the description
from the GetExitCodeProcess function (processthreadsapi.h) API reference:
https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getexitcodeprocess

> The GetExitCodeProcess function returns a valid error code defined by the
> application only after the thread terminates. Therefore, an application should
> not use `STILL_ACTIVE` (259) as an error code (`STILL_ACTIVE` is a macro for
> `STATUS_PENDING` (minwinbase.h)). If a thread returns `STILL_ACTIVE` (259) as
> an error code, then applications that test for that value could interpret it
> to mean that the thread is still running, and continue to test for the
> completion of the thread after the thread has terminated, which could put
> the application into an infinite loop.

### pkg/pidfile: replace uses of windows.Close() with windows.CloseHandle()

Since https://golang.org/cl/4600042, Close is a straight wrapper of CloseHandle.
