### PR TITLE
use filepath.WalkDir instead of filepath.Walk

### DIFF
--- a/builder/dockerfile/copy.go
+++ b/builder/dockerfile/copy.go
@@ -258,7 +258,7 @@ func (o *copier) storeInPathCache(im *imageMount, path string, hash string) {
 func (o *copier) copyWithWildcards(origPath string) ([]copyInfo, error) {
 	root := o.source.Root()
 	var copyInfos []copyInfo
-	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	if err := filepath.WalkDir(root, func(path string, _ os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -316,7 +316,7 @@ func walkSource(source builder.Source, origPath string) ([]string, error) {
 	}
 	// Must be a dir
 	var subfiles []string
-	err = filepath.Walk(fp, func(path string, info os.FileInfo, err error) error {
+	err = filepath.WalkDir(fp, func(path string, _ os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/builder/dockerfile/copy_unix.go
+++ b/builder/dockerfile/copy_unix.go
@@ -26,7 +26,7 @@ func fixPermissions(source, destination string, identity idtools.Identity, overr
 
 	// We Walk on the source rather than on the destination because we don't
 	// want to change permissions on things we haven't created or modified.
-	return filepath.Walk(source, func(fullpath string, _ os.FileInfo, _ error) error {
+	return filepath.WalkDir(source, func(fullpath string, _ os.DirEntry, _ error) error {
 		// Do not alter the walk root iff. it existed before, as it doesn't fall under
 		// the domain of "things we should chown".
 		if skipChownRoot && source == fullpath {

--- a/builder/remotecontext/tarsum.go
+++ b/builder/remotecontext/tarsum.go
@@ -66,7 +66,7 @@ func (cs *CachableSource) Scan() error {
 		return err
 	}
 	txn := iradix.New().Txn()
-	err = filepath.Walk(cs.root, func(path string, info os.FileInfo, err error) error {
+	err = filepath.WalkDir(cs.root, func(path string, _ os.DirEntry, err error) error {
 		if err != nil {
 			return errors.Wrapf(err, "failed to walk %s", path)
 		}

--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -269,7 +269,7 @@ func subvolDelete(dirpath, name string, quotaEnabled bool) error {
 	var args C.struct_btrfs_ioctl_vol_args
 
 	// walk the btrfs subvolumes
-	walkSubvolumes := func(p string, f os.FileInfo, err error) error {
+	walkSubVolumes := func(p string, f os.DirEntry, err error) error {
 		if err != nil {
 			if os.IsNotExist(err) && p != fullPath {
 				// missing most likely because the path was a subvolume that got removed in the previous iteration
@@ -293,7 +293,7 @@ func subvolDelete(dirpath, name string, quotaEnabled bool) error {
 		}
 		return nil
 	}
-	if err := filepath.Walk(path.Join(dirpath, name), walkSubvolumes); err != nil {
+	if err := filepath.WalkDir(path.Join(dirpath, name), walkSubVolumes); err != nil {
 		return fmt.Errorf("Recursively walking subvolumes for %s failed: %v", dirpath, err)
 	}
 

--- a/libnetwork/drivers/overlay/ov_network.go
+++ b/libnetwork/drivers/overlay/ov_network.go
@@ -414,24 +414,24 @@ func (n *network) destroySandbox() {
 }
 
 func populateVNITbl() {
-	filepath.Walk(filepath.Dir(osl.GenerateKey("walk")),
+	filepath.WalkDir(filepath.Dir(osl.GenerateKey("walk")),
 		// NOTE(cpuguy83): The linter picked up on the fact that this walk function was not using this error argument
 		// That seems wrong... however I'm not familiar with this code or if that error matters
-		func(path string, info os.FileInfo, _ error) error {
+		func(path string, _ os.DirEntry, _ error) error {
 			_, fname := filepath.Split(path)
 
 			if len(strings.Split(fname, "-")) <= 1 {
 				return nil
 			}
 
-			ns, err := netns.GetFromPath(path)
+			n, err := netns.GetFromPath(path)
 			if err != nil {
 				logrus.Errorf("Could not open namespace path %s during vni population: %v", path, err)
 				return nil
 			}
-			defer ns.Close()
+			defer n.Close()
 
-			nlh, err := netlink.NewHandleAt(ns, unix.NETLINK_ROUTE)
+			nlh, err := netlink.NewHandleAt(n, unix.NETLINK_ROUTE)
 			if err != nil {
 				logrus.Errorf("Could not open netlink handle during vni population for ns %s: %v", path, err)
 				return nil
@@ -681,8 +681,8 @@ func (n *network) initSubnetSandbox(s *subnet, restore bool) error {
 }
 
 func (n *network) cleanupStaleSandboxes() {
-	filepath.Walk(filepath.Dir(osl.GenerateKey("walk")),
-		func(path string, info os.FileInfo, err error) error {
+	filepath.WalkDir(filepath.Dir(osl.GenerateKey("walk")),
+		func(path string, _ os.DirEntry, _ error) error {
 			_, fname := filepath.Split(path)
 
 			pList := strings.Split(fname, "-")

--- a/oci/devices_linux.go
+++ b/oci/devices_linux.go
@@ -45,7 +45,7 @@ func DevicesFromPath(pathOnHost, pathInContainer, cgroupPermissions string) (dev
 		if src, e := os.Stat(resolvedPathOnHost); e == nil && src.IsDir() {
 			// mount the internal devices recursively
 			// TODO check if additional errors should be handled or logged
-			_ = filepath.Walk(resolvedPathOnHost, func(dpath string, f os.FileInfo, _ error) error {
+			_ = filepath.WalkDir(resolvedPathOnHost, func(dpath string, f os.DirEntry, _ error) error {
 				childDevice, e := coci.DeviceFromPath(dpath)
 				if e != nil {
 					// ignore the device

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -904,7 +904,7 @@ func TarWithOptions(srcPath string, options *TarOptions) (io.ReadCloser, error) 
 			)
 
 			walkRoot := getWalkRoot(srcPath, include)
-			filepath.Walk(walkRoot, func(filePath string, f os.FileInfo, err error) error {
+			filepath.WalkDir(walkRoot, func(filePath string, f os.DirEntry, err error) error {
 				if err != nil {
 					logrus.Errorf("Tar: Can't stat file %s to tar: %s", srcPath, err)
 					return nil

--- a/pkg/archive/changes_other.go
+++ b/pkg/archive/changes_other.go
@@ -41,7 +41,7 @@ func collectFileInfoForChanges(oldDir, newDir string) (*FileInfo, *FileInfo, err
 func collectFileInfo(sourceDir string) (*FileInfo, error) {
 	root := newRootFileInfo()
 
-	err := filepath.Walk(sourceDir, func(path string, f os.FileInfo, err error) error {
+	err := filepath.WalkDir(sourceDir, func(path string, _ os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/pkg/archive/copy_unix_test.go
+++ b/pkg/archive/copy_unix_test.go
@@ -101,7 +101,8 @@ func dirContentsEqual(t *testing.T, newDir, oldDir string) (err error) {
 }
 
 func logDirContents(t *testing.T, dirPath string) {
-	logWalkedPaths := filepath.WalkFunc(func(path string, info os.FileInfo, err error) error {
+	t.Logf("logging directory contents: %q", dirPath)
+	err := filepath.WalkDir(dirPath, func(path string, info os.DirEntry, err error) error {
 		if err != nil {
 			t.Errorf("stat error for path %q: %s", path, err)
 			return nil
@@ -115,10 +116,6 @@ func logDirContents(t *testing.T, dirPath string) {
 
 		return nil
 	})
-
-	t.Logf("logging directory contents: %q", dirPath)
-
-	err := filepath.Walk(dirPath, logWalkedPaths)
 	assert.NilError(t, err)
 }
 

--- a/pkg/archive/diff.go
+++ b/pkg/archive/diff.go
@@ -121,7 +121,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				if err != nil {
 					return 0, err
 				}
-				err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+				err = filepath.WalkDir(dir, func(path string, info os.DirEntry, err error) error {
 					if err != nil {
 						if os.IsNotExist(err) {
 							err = nil // parent was deleted
@@ -132,8 +132,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 						return nil
 					}
 					if _, exists := unpackedPaths[path]; !exists {
-						err := os.RemoveAll(path)
-						return err
+						return os.RemoveAll(path)
 					}
 					return nil
 				})

--- a/pkg/archive/utils_test.go
+++ b/pkg/archive/utils_test.go
@@ -139,7 +139,7 @@ func testBreakout(untarFn string, tmpdir string, headers []*tar.Header) error {
 	// Since victim/hello was generated with time.Now(), it is safe to assume
 	// that any file whose content matches exactly victim/hello, managed somehow
 	// to access victim/hello.
-	return filepath.Walk(dest, func(path string, info os.FileInfo, err error) error {
+	return filepath.WalkDir(dest, func(path string, info os.DirEntry, err error) error {
 		if info.IsDir() {
 			if err != nil {
 				// skip directory if error

--- a/testutil/daemon/daemon_linux.go
+++ b/testutil/daemon/daemon_linux.go
@@ -18,8 +18,7 @@ func cleanupNetworkNamespace(t testing.TB, d *Daemon) {
 	// daemon instance and has no chance of getting
 	// cleaned up when a new daemon is instantiated with a
 	// new exec root.
-	netnsPath := filepath.Join(d.execRoot, "netns")
-	filepath.Walk(netnsPath, func(path string, info os.FileInfo, err error) error {
+	filepath.WalkDir(filepath.Join(d.execRoot, "netns"), func(path string, _ os.DirEntry, _ error) error {
 		if err := unix.Unmount(path, unix.MNT_DETACH); err != nil && err != unix.EINVAL && err != unix.ENOENT {
 			t.Logf("[%s] unmount of %s failed: %v", d.id, path, err)
 		}


### PR DESCRIPTION
WalkDir is more performant as it doesn't perform an os.Lstat on every visited
file or directory.
