### PR TITLE
[22.06 backport] daemon/graphdriver/overlay2: remove deprecated overrideKernelCheck

### DIFF
--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -85,8 +85,7 @@ const (
 )
 
 type overlayOptions struct {
-	overrideKernelCheck bool
-	quota               quota.Quota
+	quota quota.Quota
 }
 
 // Driver contains information about the home directory and the list of active
@@ -236,10 +235,8 @@ func parseOptions(options []string) (*overlayOptions, error) {
 		key = strings.ToLower(key)
 		switch key {
 		case "overlay2.override_kernel_check":
-			o.overrideKernelCheck, err = strconv.ParseBool(val)
-			if err != nil {
-				return nil, err
-			}
+			// TODO(thaJeztah): change this to an error, see https://github.com/docker/cli/pull/3806
+			logger.Warn("DEPRECATED: the overlay2.override_kernel_check option is ignored and will be removed in the next release. You can safely remove this option from your configuration.")
 		case "overlay2.size":
 			size, err := units.RAMInBytes(val)
 			if err != nil {

--- a/integration/plugin/graphdriver/external_test.go
+++ b/integration/plugin/graphdriver/external_test.go
@@ -433,7 +433,7 @@ func TestGraphdriverPluginV2(t *testing.T) {
 
 	// restart the daemon with the plugin set as the storage driver
 	d.Stop(t)
-	d.StartWithBusybox(t, "-s", plugin, "--storage-opt", "overlay2.override_kernel_check=1")
+	d.StartWithBusybox(t, "-s", plugin)
 
 	testGraphDriver(ctx, t, client, plugin, nil)
 }


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44278
- relates to https://github.com/moby/moby/pull/35527
- relates to https://github.com/moby/moby/pull/40210
- relates to https://github.com/moby/moby/pull/40462
- relates to https://github.com/docker/cli/pull/3806


### daemon/graphdriver/overlay2: remove deprecated overrideKernelCheck

Commit 955c1f881ac94af19c99f0f7d5635e6a574789f2 (Docker v17.12.0) replaced detection of support for multiple lowerdirs (as required by overlay2) to not depend on the kernel version. The `overlay2.override_kernel_check` was still used to print a warning that older kernel versions may not have full support.

After this, commit e226aea280efdc18f887e853b5eefd763b602937 (Docker v20.10.0, backported to v19.03.7) removed uses of the `overlay2.override_kernel_check` option altogether, but we were still parsing it.

This patch changes the `parseOptions()` function to not parse the option, printing a deprecation warning instead. We should change this to be an error, but the  `overlay2.override_kernel_check` option was not deprecated in the documentation, so keeping it around for one more release.

### integration/plugin: remove deprecated overlay2.override_kernel_check

It's no longer used since e226aea280efdc18f887e853b5eefd763b602937

### daemon/graphdriver/overlay: remove overlayOptions type

The overlay driver does not have any options, and as it's deprecated, no options will be added.
