### PR TITLE
cmd/dockerd: use x/sys Service.SetRecoveryActions(), and update restart delay

### DIFF
--- a/cmd/dockerd/service_windows.go
+++ b/cmd/dockerd/service_windows.go
@@ -189,8 +189,8 @@ func registerService() error {
 
 	err = s.SetRecoveryActions(
 		[]mgr.RecoveryAction{
-			{Type: mgr.ServiceRestart, Delay: 60 * time.Second},
-			{Type: mgr.ServiceRestart, Delay: 60 * time.Second},
+			{Type: mgr.ServiceRestart, Delay: 15 * time.Second},
+			{Type: mgr.ServiceRestart, Delay: 15 * time.Second},
 			{Type: mgr.NoAction},
 		},
 		uint32(24*time.Hour/time.Second),

--- a/cmd/dockerd/service_windows.go
+++ b/cmd/dockerd/service_windows.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"time"
-	"unsafe"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
@@ -188,35 +187,14 @@ func registerService() error {
 	}
 	defer s.Close()
 
-	// See http://stackoverflow.com/questions/35151052/how-do-i-configure-failure-actions-of-a-windows-service-written-in-go
-	const (
-		scActionNone       = 0
-		scActionRestart    = 1
-		scActionReboot     = 2
-		scActionRunCommand = 3
-
-		serviceConfigFailureActions = 2
+	err = s.SetRecoveryActions(
+		[]mgr.RecoveryAction{
+			{Type: mgr.ServiceRestart, Delay: 60 * time.Second},
+			{Type: mgr.ServiceRestart, Delay: 60 * time.Second},
+			{Type: mgr.NoAction},
+		},
+		uint32(24*time.Hour/time.Second),
 	)
-
-	type serviceFailureActions struct {
-		ResetPeriod  uint32
-		RebootMsg    *uint16
-		Command      *uint16
-		ActionsCount uint32
-		Actions      uintptr
-	}
-
-	type scAction struct {
-		Type  uint32
-		Delay uint32
-	}
-	t := []scAction{
-		{Type: scActionRestart, Delay: uint32(60 * time.Second / time.Millisecond)},
-		{Type: scActionRestart, Delay: uint32(60 * time.Second / time.Millisecond)},
-		{Type: scActionNone},
-	}
-	lpInfo := serviceFailureActions{ResetPeriod: uint32(24 * time.Hour / time.Second), ActionsCount: uint32(3), Actions: uintptr(unsafe.Pointer(&t[0]))}
-	err = windows.ChangeServiceConfig2(s.Handle, serviceConfigFailureActions, (*byte)(unsafe.Pointer(&lpInfo)))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/7512
- relates to https://github.com/containerd/containerd/pull/3313

### cmd/dockerd: use golang.org/x/sys Service.SetRecoveryActions()

Looks like this is the equivalent of the local implementation.

### Change restart delay for Windows service to 15s

Previously we waited for 60 seconds after the service faults to restart
it. However, there isn't much benefit to waiting this long. We expect
15 seconds to be a more reasonable delay.

(same as https://github.com/containerd/containerd/pull/3313)