### PR TITLE
hack: allow pkg/ to import internal/ packages

### DIFF
--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -269,6 +269,7 @@ Function Validate-PkgImports($headCommit, $upstreamCommit) {
         # Filter out what we are looking for
         $imports = @() + $imports -NotMatch "^github.com/docker/docker/pkg/" `
                                   -NotMatch "^github.com/docker/docker/vendor" `
+                                  -NotMatch "^github.com/docker/docker/internal" `
                                   -Match "^github.com/docker/docker" `
                                   -Replace "`n", ""
         $imports | ForEach-Object{ $badFiles+="$file imports $_`n" }

--- a/hack/validate/pkg-imports
+++ b/hack/validate/pkg-imports
@@ -17,7 +17,12 @@ for f in "${files[@]}"; do
 		continue
 	fi
 	IFS=$'\n'
-	badImports=($(go list -e -f '{{ join .Deps "\n" }}' "$f" | sort -u | grep -vE '^github.com/docker/docker/pkg/' | grep -vE '^github.com/docker/docker/vendor' | grep -E '^github.com/docker/docker' || true))
+	badImports=($(go list -e -f '{{ join .Deps "\n" }}' "$f" | sort -u \
+		| grep -vE '^github.com/docker/docker/pkg/' \
+		| grep -vE '^github.com/docker/docker/vendor' \
+		| grep -vE '^github.com/docker/docker/internal' \
+		| grep -E '^github.com/docker/docker' \
+		|| true))
 	unset IFS
 
 	for import in "${badImports[@]}"; do


### PR DESCRIPTION
The pkg-imports validation prevents reusable library packages from depending on the whole daemon, accidentally or intentionally. The allowlist is overly restrictive as it also prevents us from reusing code in both `pkg/` and `daemon/` unless that code is also made into a reusable library package under `pkg/`. Allow `pkg/` packages to import `internal/` packages which do not transitively depend on disallowed packages.
