### PR TITLE
integration: download busybox-w32 from GitHub Release

### DIFF
--- a/contrib/busybox/Dockerfile
+++ b/contrib/busybox/Dockerfile
@@ -19,7 +19,7 @@ FROM ${WINDOWS_BASE_IMAGE}:${WINDOWS_BASE_IMAGE_TAG}
 RUN mkdir C:\tmp && mkdir C:\bin
 ARG BUSYBOX_VERSION
 ARG BUSYBOX_SHA256SUM
-ADD https://frippery.org/files/busybox/busybox-w32-${BUSYBOX_VERSION}.exe /bin/busybox.exe
+ADD https://github.com/moby/busybox/releases/download/${BUSYBOX_VERSION}/busybox-w32-${BUSYBOX_VERSION}.exe /bin/busybox.exe
 RUN powershell \
     if ((Get-FileHash -Path /bin/busybox.exe -Algorithm SHA256).Hash -ne $Env:BUSYBOX_SHA256SUM) { \
         Throw \"Checksum validation failed\" \


### PR DESCRIPTION
fixes #44298

**- What I did**

Download busybox-w32 through ~a docker image~ GitHub Release to avoid making too much requests to https://frippery.org/files/busybox.

**- How I did it**

Published GitHub Release with busybox-w32 binaries: https://github.com/moby/busybox/releases/tag/FRP-3329-gcf0fa4d13

Didn't updated to latest `FRP-4716-g31467ddfc` as it seems there are some issues with it: #44000

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>