### PR TITLE
pkg/system: MkdirAllWithACL(): remove "perm" argument

### DIFF
--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -37,7 +37,7 @@ func (daemon *Daemon) setupConfigDir(ctr *container.Container) (setupErr error) 
 	log.G(context.TODO()).Debugf("configs: setting up config dir: %s", localPath)
 
 	// create local config root
-	if err := system.MkdirAllWithACL(localPath, 0, system.SddlAdministratorsLocalSystem); err != nil {
+	if err := system.MkdirAllWithACL(localPath, system.SddlAdministratorsLocalSystem); err != nil {
 		return errors.Wrap(err, "error creating config dir")
 	}
 
@@ -112,7 +112,7 @@ func (daemon *Daemon) setupSecretDir(ctr *container.Container) (setupErr error) 
 	log.G(context.TODO()).Debugf("secrets: setting up secret dir: %s", localMountPath)
 
 	// create local secret root
-	if err := system.MkdirAllWithACL(localMountPath, 0, system.SddlAdministratorsLocalSystem); err != nil {
+	if err := system.MkdirAllWithACL(localMountPath, system.SddlAdministratorsLocalSystem); err != nil {
 		return errors.Wrap(err, "error creating secret local directory")
 	}
 

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -469,7 +469,7 @@ func setupRemappedRoot(config *config.Config) (idtools.IdentityMapping, error) {
 func setupDaemonRoot(config *config.Config, rootDir string, rootIdentity idtools.Identity) error {
 	config.Root = rootDir
 	// Create the root directory if it doesn't exists
-	if err := system.MkdirAllWithACL(config.Root, 0, system.SddlAdministratorsLocalSystem); err != nil {
+	if err := system.MkdirAllWithACL(config.Root, system.SddlAdministratorsLocalSystem); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/system/filesys_windows.go
+++ b/pkg/system/filesys_windows.go
@@ -15,7 +15,7 @@ const SddlAdministratorsLocalSystem = "D:P(A;OICI;GA;;;BA)(A;OICI;GA;;;SY)"
 // MkdirAllWithACL is a custom version of os.MkdirAll modified for use on Windows
 // so that it is both volume path aware, and can create a directory with
 // an appropriate SDDL defined ACL.
-func MkdirAllWithACL(path string, _ os.FileMode, sddl string) error {
+func MkdirAllWithACL(path string, sddl string) error {
 	sa, err := makeSecurityAttributes(sddl)
 	if err != nil {
 		return &os.PathError{Op: "mkdirall", Path: path, Err: err}


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/44302

This function doesn't match the signature of os.MkdirAll(), and
permissions are a no-op on Windows (in this case, the sddl mostly
takes it place), so dropping the argument to not give the impression
that perms have an effect.