### PR TITLE
pkg/fileutils: ReadSymlinkedDirectory: preserve underlying error, and improve test-coverage

### DIFF
--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -34,18 +34,16 @@ func CopyFile(src, dst string) (int64, error) {
 
 // ReadSymlinkedDirectory returns the target directory of a symlink.
 // The target of the symbolic link may not be a file.
-func ReadSymlinkedDirectory(path string) (string, error) {
-	var realPath string
-	var err error
+func ReadSymlinkedDirectory(path string) (realPath string, err error) {
 	if realPath, err = filepath.Abs(path); err != nil {
-		return "", fmt.Errorf("unable to get absolute path for %s: %s", path, err)
+		return "", fmt.Errorf("unable to get absolute path for %s: %w", path, err)
 	}
 	if realPath, err = filepath.EvalSymlinks(realPath); err != nil {
-		return "", fmt.Errorf("failed to canonicalise path for %s: %s", path, err)
+		return "", fmt.Errorf("failed to canonicalise path for %s: %w", path, err)
 	}
 	realPathInfo, err := os.Stat(realPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to stat target '%s' of '%s': %s", realPath, path, err)
+		return "", fmt.Errorf("failed to stat target '%s' of '%s': %w", realPath, path, err)
 	}
 	if !realPathInfo.Mode().IsDir() {
 		return "", fmt.Errorf("canonical path points to a file '%s'", realPath)

--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -160,6 +160,9 @@ func TestReadSymlinkedDirectoryNonExistingSymlink(t *testing.T) {
 	if err == nil {
 		t.Errorf("error expected for non-existing symlink")
 	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("Expected an os.ErrNotExist, got: %v", err)
+	}
 	if symLinkedPath != "" {
 		t.Fatalf("expected empty path, but '%s' was returned", symLinkedPath)
 	}


### PR DESCRIPTION
### pkg/fileutils: ReadSymlinkedDirectory: preserve underlying error

We were discarding the underlying error, which made it impossible for
callers to detect (e.g.) an os.ErrNotExist.

### pkg/fileutils: improve tests

- use t.TempDir() to make sure we're testing from a clean state
- improve checks for errors to have the correct error-type where possible
