### PR TITLE
daemon: getPluginExecRoot(): pass config

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -903,13 +903,13 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 			}
 			rt = *rtPtr
 		}
-		return pluginexec.New(ctx, getPluginExecRoot(config.Root), pluginCli, config.ContainerdPluginNamespace, m, rt)
+		return pluginexec.New(ctx, getPluginExecRoot(config), pluginCli, config.ContainerdPluginNamespace, m, rt)
 	}
 
 	// Plugin system initialization should happen before restore. Do not change order.
 	d.pluginManager, err = plugin.NewManager(plugin.ManagerConfig{
 		Root:               filepath.Join(config.Root, "plugins"),
-		ExecRoot:           getPluginExecRoot(config.Root),
+		ExecRoot:           getPluginExecRoot(config),
 		Store:              d.PluginStore,
 		CreateExecutor:     createPluginExec,
 		RegistryService:    registryService,

--- a/daemon/daemon_linux.go
+++ b/daemon/daemon_linux.go
@@ -20,7 +20,7 @@ import (
 // instead of deriving path from daemon's exec-root. This is because
 // plugin socket files are created here and they cannot exceed max
 // path length of 108 bytes.
-func getPluginExecRoot(root string) string {
+func getPluginExecRoot(_ *config.Config) string {
 	return "/run/docker/plugins"
 }
 

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -55,8 +55,8 @@ func adjustParallelLimit(n int, limit int) int {
 }
 
 // Windows has no concept of an execution state directory. So use config.Root here.
-func getPluginExecRoot(root string) string {
-	return filepath.Join(root, "plugins")
+func getPluginExecRoot(cfg *config.Config) string {
+	return filepath.Join(cfg.Root, "plugins")
 }
 
 func (daemon *Daemon) parseSecurityOpt(container *container.Container, hostConfig *containertypes.HostConfig) error {


### PR DESCRIPTION
Had this stashed in another branch, but wasn't really related to those changes, so lets move it separate

This makes it more transparent that it's unused for Linux, and we don't pass "root", which has no relation with the path on Linux.

