### PR TITLE
[20.10 backport] registry: allow "allow-nondistributable-artifacts" for Docker Hub

### DIFF
--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -9,6 +9,9 @@ import (
 
 func (s *DefaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, err error) {
 	tlsConfig := tlsconfig.ServerDefault()
+
+	ana := allowNondistributableArtifacts(s.config, hostname)
+
 	if hostname == DefaultNamespace || hostname == IndexHostname {
 		for _, mirror := range s.config.Mirrors {
 			if !strings.HasPrefix(mirror, "http://") && !strings.HasPrefix(mirror, "https://") {
@@ -36,12 +39,12 @@ func (s *DefaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndp
 			Official:     true,
 			TrimHostname: true,
 			TLSConfig:    tlsConfig,
+
+			AllowNondistributableArtifacts: ana,
 		})
 
 		return endpoints, nil
 	}
-
-	ana := allowNondistributableArtifacts(s.config, hostname)
 
 	tlsConfig, err = s.tlsConfig(hostname)
 	if err != nil {


### PR DESCRIPTION
Cherry-pick of https://github.com/moby/moby/pull/44305

> Previously, Docker Hub was excluded when configuring "allow-nondistributable-artifacts". With the updated policy announced by Microsoft, we can remove this restriction; https://techcommunity.microsoft.com/t5/containers/announcing-windows-container-base-image-redistribution-rights/ba-p/3645201
> 
> There are plans to deprecated support for foreign layers altogether in the OCI, and we should consider to make this option the default, but as that requires deprecating the option (and possibly keeping an "opt-out" option), we can look at that separately.

(cherry picked from commit 30e5333ce3e11654fe343b8765bb719aa7b1ca0c)