### PR TITLE
[22.06 backport] registry: allow "allow-nondistributable-artifacts" for Docker Hub

### DIFF
--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -8,6 +8,8 @@ import (
 )
 
 func (s *defaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, err error) {
+	ana := s.config.allowNondistributableArtifacts(hostname)
+
 	if hostname == DefaultNamespace || hostname == IndexHostname {
 		for _, mirror := range s.config.Mirrors {
 			if !strings.HasPrefix(mirror, "http://") && !strings.HasPrefix(mirror, "https://") {
@@ -35,6 +37,8 @@ func (s *defaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndp
 			Official:     true,
 			TrimHostname: true,
 			TLSConfig:    tlsconfig.ServerDefault(),
+
+			AllowNondistributableArtifacts: ana,
 		})
 
 		return endpoints, nil
@@ -45,7 +49,6 @@ func (s *defaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndp
 		return nil, err
 	}
 
-	ana := s.config.allowNondistributableArtifacts(hostname)
 	endpoints = []APIEndpoint{
 		{
 			URL: &url.URL{


### PR DESCRIPTION
Cherry-pick of https://github.com/moby/moby/pull/44305

> Previously, Docker Hub was excluded when configuring "allow-nondistributable-artifacts". With the updated policy announced by Microsoft, we can remove this restriction; https://techcommunity.microsoft.com/t5/containers/announcing-windows-container-base-image-redistribution-rights/ba-p/3645201
> 
> There are plans to deprecated support for foreign layers altogether in the OCI, and we should consider to make this option the default, but as that requires deprecating the option (and possibly keeping an "opt-out" option), we can look at that separately.

(cherry picked from commit 30e5333ce3e11654fe343b8765bb719aa7b1ca0c)