### PR TITLE
Present a better error for "unmanifested" Windows builds

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -191,8 +191,11 @@ func verifyDaemonSettings(config *config.Config) error {
 func checkSystem() error {
 	// Validate the OS version. Note that dockerd.exe must be manifested for this
 	// call to return the correct version.
-	if osversion.Get().MajorVersion < 10 || osversion.Build() < osversion.RS5 {
-		return fmt.Errorf("this version of Windows does not support the docker daemon (Windows build %d or higher is required)", osversion.RS5)
+	if osver := osversion.Get(); osver.MajorVersion < 10 || osver.Build < osversion.RS5 {
+		if osver.Build == 9200 { // TODO implement a proper check / constant for this build number? https://github.com/microsoft/hcsshim/issues/1080#issuecomment-1281601474
+			return fmt.Errorf("this build is not 'manifested', which breaks many Windows APIs (see https://github.com/golang/go/issues/44466 for a list of some)")
+		}
+		return fmt.Errorf("this version of Windows (%s) does not support the docker daemon (Windows build %d or higher is required)", osver.ToString(), osversion.RS5)
 	}
 
 	vmcompute := windows.NewLazySystemDLL("vmcompute.dll")


### PR DESCRIPTION
Currently, unmanifested builds will complain that your Windows version is "too old" even if it's a very recent insider build of Windows 11, which is very misleading.

This also adds the detected Windows version to the original error message to make cases like this more obvious (where I would've clearly seen that it's detecting my Windows `MajorVersion` as 6).

See also https://github.com/microsoft/hcsshim/issues/1080, especially https://github.com/microsoft/hcsshim/issues/1080#issuecomment-1281601474.