### PR TITLE
integration-cli: DockerPluginSuite: use gotest.tools compare utilities

### DIFF
--- a/integration-cli/docker_cli_plugins_test.go
+++ b/integration-cli/docker_cli_plugins_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/testutil/fixtures/plugin"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
 )
 
@@ -48,21 +49,21 @@ func (ps *DockerPluginSuite) TestPluginBasicOps(c *testing.T) {
 
 	out, _, err := dockerCmdWithError("plugin", "ls")
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, plugin))
-	assert.Assert(c, strings.Contains(out, "true"))
+	assert.Check(c, is.Contains(out, plugin))
+	assert.Check(c, is.Contains(out, "true"))
 	id, _, err := dockerCmdWithError("plugin", "inspect", "-f", "{{.Id}}", plugin)
 	id = strings.TrimSpace(id)
 	assert.NilError(c, err)
 
 	out, _, err = dockerCmdWithError("plugin", "remove", plugin)
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "is enabled"))
+	assert.Check(c, is.Contains(out, "is enabled"))
 	_, _, err = dockerCmdWithError("plugin", "disable", plugin)
 	assert.NilError(c, err)
 
 	out, _, err = dockerCmdWithError("plugin", "remove", plugin)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, plugin))
+	assert.Check(c, is.Contains(out, plugin))
 	_, err = os.Stat(filepath.Join(testEnv.DaemonInfo.DockerRootDir, "plugins", id))
 	if !os.IsNotExist(err) {
 		c.Fatal(err)
@@ -76,10 +77,10 @@ func (ps *DockerPluginSuite) TestPluginForceRemove(c *testing.T) {
 	assert.NilError(c, err)
 
 	out, _, _ := dockerCmdWithError("plugin", "remove", pNameWithTag)
-	assert.Assert(c, strings.Contains(out, "is enabled"))
+	assert.Check(c, is.Contains(out, "is enabled"))
 	out, _, err = dockerCmdWithError("plugin", "remove", "--force", pNameWithTag)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, pNameWithTag))
+	assert.Check(c, is.Contains(out, pNameWithTag))
 }
 
 func (s *DockerCLIPluginsSuite) TestPluginActive(c *testing.T) {
@@ -92,7 +93,7 @@ func (s *DockerCLIPluginsSuite) TestPluginActive(c *testing.T) {
 	assert.NilError(c, err)
 
 	out, _, _ := dockerCmdWithError("plugin", "disable", pNameWithTag)
-	assert.Assert(c, strings.Contains(out, "in use"))
+	assert.Check(c, is.Contains(out, "in use"))
 	_, _, err = dockerCmdWithError("volume", "rm", "testvol1")
 	assert.NilError(c, err)
 
@@ -101,7 +102,7 @@ func (s *DockerCLIPluginsSuite) TestPluginActive(c *testing.T) {
 
 	out, _, err = dockerCmdWithError("plugin", "remove", pNameWithTag)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, pNameWithTag))
+	assert.Check(c, is.Contains(out, pNameWithTag))
 }
 
 func (s *DockerCLIPluginsSuite) TestPluginActiveNetwork(c *testing.T) {
@@ -115,18 +116,18 @@ func (s *DockerCLIPluginsSuite) TestPluginActiveNetwork(c *testing.T) {
 	nID := strings.TrimSpace(out)
 
 	out, _, _ = dockerCmdWithError("plugin", "remove", npNameWithTag)
-	assert.Assert(c, strings.Contains(out, "is in use"))
+	assert.Check(c, is.Contains(out, "is in use"))
 	_, _, err = dockerCmdWithError("network", "rm", nID)
 	assert.NilError(c, err)
 
 	out, _, _ = dockerCmdWithError("plugin", "remove", npNameWithTag)
-	assert.Assert(c, strings.Contains(out, "is enabled"))
+	assert.Check(c, is.Contains(out, "is enabled"))
 	_, _, err = dockerCmdWithError("plugin", "disable", npNameWithTag)
 	assert.NilError(c, err)
 
 	out, _, err = dockerCmdWithError("plugin", "remove", npNameWithTag)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, npNameWithTag))
+	assert.Check(c, is.Contains(out, npNameWithTag))
 }
 
 func (ps *DockerPluginSuite) TestPluginInstallDisable(c *testing.T) {
@@ -134,26 +135,26 @@ func (ps *DockerPluginSuite) TestPluginInstallDisable(c *testing.T) {
 
 	out, _, err := dockerCmdWithError("plugin", "install", "--grant-all-permissions", "--disable", pName)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), pName))
+	assert.Check(c, is.Contains(out, pName))
 	out, _, err = dockerCmdWithError("plugin", "ls")
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, "false"))
+	assert.Check(c, is.Contains(out, "false"))
 	out, _, err = dockerCmdWithError("plugin", "enable", pName)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), pName))
+	assert.Check(c, is.Contains(out, pName))
 	out, _, err = dockerCmdWithError("plugin", "disable", pName)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), pName))
+	assert.Check(c, is.Contains(out, pName))
 	out, _, err = dockerCmdWithError("plugin", "remove", pName)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), pName))
+	assert.Check(c, is.Contains(out, pName))
 }
 
 func (s *DockerCLIPluginsSuite) TestPluginInstallDisableVolumeLs(c *testing.T) {
 	testRequires(c, DaemonIsLinux, IsAmd64, Network)
 	out, _, err := dockerCmdWithError("plugin", "install", "--grant-all-permissions", "--disable", pName)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), pName))
+	assert.Check(c, is.Contains(out, pName))
 	dockerCmd(c, "volume", "ls")
 }
 
@@ -183,25 +184,25 @@ func (ps *DockerPluginSuite) TestPluginSet(c *testing.T) {
 	assert.Assert(c, err == nil, "failed to create test plugin")
 
 	env, _ := dockerCmd(c, "plugin", "inspect", "-f", "{{.Settings.Env}}", name)
-	assert.Equal(c, strings.TrimSpace(env), "[DEBUG=0]")
+	assert.Check(c, is.Equal(strings.TrimSpace(env), "[DEBUG=0]"))
 
 	dockerCmd(c, "plugin", "set", name, "DEBUG=1")
 
 	env, _ = dockerCmd(c, "plugin", "inspect", "-f", "{{.Settings.Env}}", name)
-	assert.Equal(c, strings.TrimSpace(env), "[DEBUG=1]")
+	assert.Check(c, is.Equal(strings.TrimSpace(env), "[DEBUG=1]"))
 
 	env, _ = dockerCmd(c, "plugin", "inspect", "-f", "{{with $mount := index .Settings.Mounts 0}}{{$mount.Source}}{{end}}", name)
-	assert.Assert(c, strings.Contains(strings.TrimSpace(env), mntSrc))
+	assert.Check(c, is.Contains(env, mntSrc))
 	dockerCmd(c, "plugin", "set", name, "pmount1.source=bar")
 
 	env, _ = dockerCmd(c, "plugin", "inspect", "-f", "{{with $mount := index .Settings.Mounts 0}}{{$mount.Source}}{{end}}", name)
-	assert.Assert(c, strings.Contains(strings.TrimSpace(env), "bar"))
+	assert.Check(c, is.Contains(env, "bar"))
 	out, _, err := dockerCmdWithError("plugin", "set", name, "pmount2.source=bar2")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "Plugin config has no mount source"))
+	assert.Check(c, is.Contains(out, "Plugin config has no mount source"))
 	out, _, err = dockerCmdWithError("plugin", "set", name, "pdev2.path=/dev/bar2")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "Plugin config has no device path"))
+	assert.Check(c, is.Contains(out, "Plugin config has no device path"))
 }
 
 func (ps *DockerPluginSuite) TestPluginInstallArgs(c *testing.T) {
@@ -214,9 +215,9 @@ func (ps *DockerPluginSuite) TestPluginInstallArgs(c *testing.T) {
 	})
 
 	out, _ := dockerCmd(c, "plugin", "install", "--grant-all-permissions", "--disable", pName, "DEBUG=1")
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), pName))
+	assert.Check(c, is.Contains(out, pName))
 	env, _ := dockerCmd(c, "plugin", "inspect", "-f", "{{.Settings.Env}}", pName)
-	assert.Equal(c, strings.TrimSpace(env), "[DEBUG=1]")
+	assert.Check(c, is.Equal(strings.TrimSpace(env), "[DEBUG=1]"))
 }
 
 func (ps *DockerPluginSuite) TestPluginInstallImage(c *testing.T) {
@@ -231,7 +232,7 @@ func (ps *DockerPluginSuite) TestPluginInstallImage(c *testing.T) {
 
 	out, _, err := dockerCmdWithError("plugin", "install", repoName)
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, `Encountered remote "application/vnd.docker.container.image.v1+json"(image) when fetching`))
+	assert.Check(c, is.Contains(out, `Encountered remote "application/vnd.docker.container.image.v1+json"(image) when fetching`))
 }
 
 func (ps *DockerPluginSuite) TestPluginEnableDisableNegative(c *testing.T) {
@@ -239,16 +240,16 @@ func (ps *DockerPluginSuite) TestPluginEnableDisableNegative(c *testing.T) {
 
 	out, _, err := dockerCmdWithError("plugin", "install", "--grant-all-permissions", pName)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), pName))
+	assert.Check(c, is.Contains(out, pName))
 	out, _, err = dockerCmdWithError("plugin", "enable", pName)
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), "already enabled"))
+	assert.Check(c, is.Contains(out, "already enabled"))
 	_, _, err = dockerCmdWithError("plugin", "disable", pName)
 	assert.NilError(c, err)
 
 	out, _, err = dockerCmdWithError("plugin", "disable", pName)
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), "already disabled"))
+	assert.Check(c, is.Contains(out, "already disabled"))
 	_, _, err = dockerCmdWithError("plugin", "remove", pName)
 	assert.NilError(c, err)
 }
@@ -268,16 +269,16 @@ func (ps *DockerPluginSuite) TestPluginCreate(c *testing.T) {
 
 	out, _, err := dockerCmdWithError("plugin", "create", name, temp)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, name))
+	assert.Check(c, is.Contains(out, name))
 	out, _, err = dockerCmdWithError("plugin", "ls")
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, name))
+	assert.Check(c, is.Contains(out, name))
 	out, _, err = dockerCmdWithError("plugin", "create", name, temp)
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "already exist"))
+	assert.Check(c, is.Contains(out, "already exist"))
 	out, _, err = dockerCmdWithError("plugin", "ls")
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, name))
+	assert.Check(c, is.Contains(out, name))
 	// The output will consists of one HEADER line and one line of foo/bar-driver
 	assert.Equal(c, len(strings.Split(strings.TrimSpace(out), "\n")), 2)
 }
@@ -290,8 +291,8 @@ func (ps *DockerPluginSuite) TestPluginInspect(c *testing.T) {
 
 	out, _, err := dockerCmdWithError("plugin", "ls")
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, pNameWithTag))
-	assert.Assert(c, strings.Contains(out, "true"))
+	assert.Check(c, is.Contains(out, pNameWithTag))
+	assert.Check(c, is.Contains(out, "true"))
 	// Find the ID first
 	out, _, err = dockerCmdWithError("plugin", "inspect", "-f", "{{.Id}}", pNameWithTag)
 	assert.NilError(c, err)
@@ -301,29 +302,29 @@ func (ps *DockerPluginSuite) TestPluginInspect(c *testing.T) {
 	// Long form
 	out, _, err = dockerCmdWithError("plugin", "inspect", "-f", "{{.Id}}", id)
 	assert.NilError(c, err)
-	assert.Equal(c, strings.TrimSpace(out), id)
+	assert.Check(c, is.Equal(strings.TrimSpace(out), id))
 
 	// Short form
 	out, _, err = dockerCmdWithError("plugin", "inspect", "-f", "{{.Id}}", id[:5])
 	assert.NilError(c, err)
-	assert.Equal(c, strings.TrimSpace(out), id)
+	assert.Check(c, is.Equal(strings.TrimSpace(out), id))
 
 	// Name with tag form
 	out, _, err = dockerCmdWithError("plugin", "inspect", "-f", "{{.Id}}", pNameWithTag)
 	assert.NilError(c, err)
-	assert.Equal(c, strings.TrimSpace(out), id)
+	assert.Check(c, is.Equal(strings.TrimSpace(out), id))
 
 	// Name without tag form
 	out, _, err = dockerCmdWithError("plugin", "inspect", "-f", "{{.Id}}", ps.getPluginRepo())
 	assert.NilError(c, err)
-	assert.Equal(c, strings.TrimSpace(out), id)
+	assert.Check(c, is.Equal(strings.TrimSpace(out), id))
 
 	_, _, err = dockerCmdWithError("plugin", "disable", pNameWithTag)
 	assert.NilError(c, err)
 
 	out, _, err = dockerCmdWithError("plugin", "remove", pNameWithTag)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, pNameWithTag))
+	assert.Check(c, is.Contains(out, pNameWithTag))
 	// After remove nothing should be found
 	_, _, err = dockerCmdWithError("plugin", "inspect", "-f", "{{.Id}}", id[:5])
 	assert.ErrorContains(c, err, "")
@@ -336,7 +337,7 @@ func (s *DockerCLIPluginsSuite) TestPluginInspectOnWindows(c *testing.T) {
 
 	out, _, err := dockerCmdWithError("plugin", "inspect", "foobar")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "plugins are not supported on this platform"))
+	assert.Check(c, is.Contains(out, "plugins are not supported on this platform"))
 	assert.ErrorContains(c, err, "plugins are not supported on this platform")
 }
 
@@ -361,30 +362,30 @@ func (ps *DockerPluginSuite) TestPluginIDPrefix(c *testing.T) {
 	// List current state
 	out, _, err := dockerCmdWithError("plugin", "ls")
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, name))
-	assert.Assert(c, strings.Contains(out, "false"))
+	assert.Check(c, is.Contains(out, name))
+	assert.Check(c, is.Contains(out, "false"))
 	env, _ := dockerCmd(c, "plugin", "inspect", "-f", "{{.Settings.Env}}", id[:5])
-	assert.Equal(c, strings.TrimSpace(env), "[DEBUG=0]")
+	assert.Check(c, is.Equal(strings.TrimSpace(env), "[DEBUG=0]"))
 
 	dockerCmd(c, "plugin", "set", id[:5], "DEBUG=1")
 
 	env, _ = dockerCmd(c, "plugin", "inspect", "-f", "{{.Settings.Env}}", id[:5])
-	assert.Equal(c, strings.TrimSpace(env), "[DEBUG=1]")
+	assert.Check(c, is.Equal(strings.TrimSpace(env), "[DEBUG=1]"))
 
 	// Enable
 	_, _, err = dockerCmdWithError("plugin", "enable", id[:5])
 	assert.NilError(c, err)
 	out, _, err = dockerCmdWithError("plugin", "ls")
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, name))
-	assert.Assert(c, strings.Contains(out, "true"))
+	assert.Check(c, is.Contains(out, name))
+	assert.Check(c, is.Contains(out, "true"))
 	// Disable
 	_, _, err = dockerCmdWithError("plugin", "disable", id[:5])
 	assert.NilError(c, err)
 	out, _, err = dockerCmdWithError("plugin", "ls")
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, name))
-	assert.Assert(c, strings.Contains(out, "false"))
+	assert.Check(c, is.Contains(out, name))
+	assert.Check(c, is.Contains(out, "false"))
 	// Remove
 	_, _, err = dockerCmdWithError("plugin", "remove", id[:5])
 	assert.NilError(c, err)
@@ -422,7 +423,7 @@ description: test plugin
 enabled: false`, id, name)
 
 	out, _ = dockerCmd(c, "--config", config, "plugin", "ls", "--no-trunc")
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), expectedOutput))
+	assert.Check(c, is.Contains(out, expectedOutput))
 }
 
 func (s *DockerCLIPluginsSuite) TestPluginUpgrade(c *testing.T) {
@@ -436,7 +437,7 @@ func (s *DockerCLIPluginsSuite) TestPluginUpgrade(c *testing.T) {
 
 	out, _, err := dockerCmdWithError("plugin", "upgrade", "--grant-all-permissions", plugin, pluginV2)
 	assert.ErrorContains(c, err, "", out)
-	assert.Assert(c, strings.Contains(out, "disabled before upgrading"))
+	assert.Check(c, is.Contains(out, "disabled before upgrading"))
 	out, _ = dockerCmd(c, "plugin", "inspect", "--format={{.ID}}", plugin)
 	id := strings.TrimSpace(out)
 
@@ -474,5 +475,5 @@ func (s *DockerCLIPluginsSuite) TestPluginMetricsCollector(c *testing.T) {
 	b, err := io.ReadAll(resp.Body)
 	assert.NilError(c, err)
 	// check that a known metric is there... don't expect this metric to change over time.. probably safe
-	assert.Assert(c, strings.Contains(string(b), "container_actions"))
+	assert.Check(c, is.Contains(string(b), "container_actions"))
 }


### PR DESCRIPTION
- effectively, first commit from https://github.com/moby/moby/pull/41559
- relates to https://github.com/moby/moby/pull/41533#issuecomment-709966198
- relates to https://github.com/moby/moby/issues/43996


Some of these tests are failing (but not enabled in CI), but the current output doesn't provide any details on the failure, so this patch is just to improve the test output to allow debugging the actual failure.

Before this, tests would fail like:

    make BIND_DIR=. TEST_FILTER=TestPluginInstallImage test-integration
    ...
    === FAIL: amd64.integration-cli TestDockerPluginSuite/TestPluginInstallImage (15.22s)
        docker_cli_plugins_test.go:220: assertion failed: expression is false: strings.Contains(out, `Encountered remote "application/vnd.docker.container.image.v1+json"(image) when fetching`)
        --- FAIL: TestDockerPluginSuite/TestPluginInstallImage (15.22s)

With this patch, tests provide more useful output:

```
    make BIND_DIR=. TEST_FILTER=TestPluginInstallImage test-integration
    ...
    === FAIL: amd64.integration-cli TestDockerPluginSuite/TestPluginInstallImage (1.15s)
    time="2022-10-18T10:21:22Z" level=warning msg="reference for unknown type: application/vnd.docker.plugin.v1+json"
    time="2022-10-18T10:21:22Z" level=warning msg="reference for unknown type: application/vnd.docker.plugin.v1+json" digest="sha256:bee151d3fef5c1f787e7846efe4fa42b25a02db4e7543e54e8c679cf19d78598"
mediatype=application/vnd.docker.plugin.v1+json size=522
    time="2022-10-18T10:21:22Z" level=warning msg="reference for unknown type: application/vnd.docker.plugin.v1+json"
    time="2022-10-18T10:21:22Z" level=warning msg="reference for unknown type: application/vnd.docker.plugin.v1+json" digest="sha256:bee151d3fef5c1f787e7846efe4fa42b25a02db4e7543e54e8c679cf19d78598"
mediatype=application/vnd.docker.plugin.v1+json size=522
        docker_cli_plugins_test.go:221: assertion failed: string "Error response from daemon: application/vnd.docker.distribution.manifest.v1+prettyjws not supported\n" does not contain "Encountered remote
\"application/vnd.docker.container.image.v1+json\"(image) when fetching"
        --- FAIL: TestDockerPluginSuite/TestPluginInstallImage (1.15s)
```

**- A picture of a cute animal (not mandatory but encouraged)**

