### PR TITLE
Forward-port patches of 20.10.20 to master

### DIFF
--- a/builder/remotecontext/git.go
+++ b/builder/remotecontext/git.go
@@ -11,7 +11,7 @@ import (
 
 // MakeGitContext returns a Context from gitURL that is cloned in a temporary directory.
 func MakeGitContext(gitURL string) (builder.Source, error) {
-	root, err := git.Clone(gitURL)
+	root, err := git.Clone(gitURL, git.WithIsolatedConfig(true))
 	if err != nil {
 		return nil, err
 	}

--- a/builder/remotecontext/git/gitutils.go
+++ b/builder/remotecontext/git/gitutils.go
@@ -192,8 +192,14 @@ func checkoutGit(root, ref, subdir string) (string, error) {
 }
 
 func gitWithinDir(dir string, args ...string) ([]byte, error) {
+	args = append([]string{"-c", "protocol.file.allow=never"}, args...) // Block sneaky repositories from using repos from the filesystem as submodules.
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
+	cmd.Env = append(cmd.Env,
+		"GIT_PROTOCOL_FROM_USER=0", // Disable unsafe remote protocols.
+		"GIT_CONFIG_NOSYSTEM=1",    // Disable reading from system gitconfig.
+		"HOME=/dev/null",           // Disable reading from user gitconfig.
+	)
 	return cmd.CombinedOutput()
 }
 

--- a/builder/remotecontext/git/gitutils.go
+++ b/builder/remotecontext/git/gitutils.go
@@ -192,12 +192,9 @@ func checkoutGit(root, ref, subdir string) (string, error) {
 }
 
 func gitWithinDir(dir string, args ...string) ([]byte, error) {
-	a := []string{"--work-tree", dir, "--git-dir", filepath.Join(dir, ".git")}
-	return git(append(a, args...)...)
-}
-
-func git(args ...string) ([]byte, error) {
-	return exec.Command("git", args...).CombinedOutput()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	return cmd.CombinedOutput()
 }
 
 // isGitTransport returns true if the provided str is a git transport by inspecting

--- a/builder/remotecontext/git/gitutils_test.go
+++ b/builder/remotecontext/git/gitutils_test.go
@@ -170,9 +170,7 @@ func gitGetConfig(name string) string {
 }
 
 func TestCheckoutGit(t *testing.T) {
-	root, err := os.MkdirTemp("", "docker-build-git-checkout")
-	assert.NilError(t, err)
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	autocrlf := gitGetConfig("core.autocrlf")
 	if !(autocrlf == "true" || autocrlf == "false" ||
@@ -184,88 +182,57 @@ func TestCheckoutGit(t *testing.T) {
 		eol = "\r\n"
 	}
 
+	must := func(out []byte, err error) {
+		t.Helper()
+		if len(out) > 0 {
+			t.Logf("%s", out)
+		}
+		assert.NilError(t, err)
+	}
+
 	gitDir := filepath.Join(root, "repo")
-	_, err = git("init", gitDir)
-	assert.NilError(t, err)
-
-	_, err = gitWithinDir(gitDir, "config", "user.email", "test@docker.com")
-	assert.NilError(t, err)
-
-	_, err = gitWithinDir(gitDir, "config", "user.name", "Docker test")
-	assert.NilError(t, err)
-
-	err = os.WriteFile(filepath.Join(gitDir, "Dockerfile"), []byte("FROM scratch"), 0644)
-	assert.NilError(t, err)
+	must(git("-c", "init.defaultBranch=master", "init", gitDir))
+	must(gitWithinDir(gitDir, "config", "user.email", "test@docker.com"))
+	must(gitWithinDir(gitDir, "config", "user.name", "Docker test"))
+	assert.NilError(t, os.WriteFile(filepath.Join(gitDir, "Dockerfile"), []byte("FROM scratch"), 0644))
 
 	subDir := filepath.Join(gitDir, "subdir")
 	assert.NilError(t, os.Mkdir(subDir, 0755))
-
-	err = os.WriteFile(filepath.Join(subDir, "Dockerfile"), []byte("FROM scratch\nEXPOSE 5000"), 0644)
-	assert.NilError(t, err)
+	assert.NilError(t, os.WriteFile(filepath.Join(subDir, "Dockerfile"), []byte("FROM scratch\nEXPOSE 5000"), 0644))
 
 	if runtime.GOOS != "windows" {
-		if err = os.Symlink("../subdir", filepath.Join(gitDir, "parentlink")); err != nil {
-			t.Fatal(err)
-		}
-
-		if err = os.Symlink("/subdir", filepath.Join(gitDir, "absolutelink")); err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, os.Symlink("../subdir", filepath.Join(gitDir, "parentlink")))
+		assert.NilError(t, os.Symlink("/subdir", filepath.Join(gitDir, "absolutelink")))
 	}
 
-	_, err = gitWithinDir(gitDir, "add", "-A")
-	assert.NilError(t, err)
+	must(gitWithinDir(gitDir, "add", "-A"))
+	must(gitWithinDir(gitDir, "commit", "-am", "First commit"))
+	must(gitWithinDir(gitDir, "checkout", "-b", "test"))
 
-	_, err = gitWithinDir(gitDir, "commit", "-am", "First commit")
-	assert.NilError(t, err)
+	assert.NilError(t, os.WriteFile(filepath.Join(gitDir, "Dockerfile"), []byte("FROM scratch\nEXPOSE 3000"), 0644))
+	assert.NilError(t, os.WriteFile(filepath.Join(subDir, "Dockerfile"), []byte("FROM busybox\nEXPOSE 5000"), 0644))
 
-	_, err = gitWithinDir(gitDir, "checkout", "-b", "test")
-	assert.NilError(t, err)
-
-	err = os.WriteFile(filepath.Join(gitDir, "Dockerfile"), []byte("FROM scratch\nEXPOSE 3000"), 0644)
-	assert.NilError(t, err)
-
-	err = os.WriteFile(filepath.Join(subDir, "Dockerfile"), []byte("FROM busybox\nEXPOSE 5000"), 0644)
-	assert.NilError(t, err)
-
-	_, err = gitWithinDir(gitDir, "add", "-A")
-	assert.NilError(t, err)
-
-	_, err = gitWithinDir(gitDir, "commit", "-am", "Branch commit")
-	assert.NilError(t, err)
-
-	_, err = gitWithinDir(gitDir, "checkout", "master")
-	assert.NilError(t, err)
+	must(gitWithinDir(gitDir, "add", "-A"))
+	must(gitWithinDir(gitDir, "commit", "-am", "Branch commit"))
+	must(gitWithinDir(gitDir, "checkout", "master"))
 
 	// set up submodule
 	subrepoDir := filepath.Join(root, "subrepo")
-	_, err = git("init", subrepoDir)
-	assert.NilError(t, err)
+	must(git("-c", "init.defaultBranch=master", "init", subrepoDir))
+	must(gitWithinDir(subrepoDir, "config", "user.email", "test@docker.com"))
+	must(gitWithinDir(subrepoDir, "config", "user.name", "Docker test"))
 
-	_, err = gitWithinDir(subrepoDir, "config", "user.email", "test@docker.com")
-	assert.NilError(t, err)
+	assert.NilError(t, os.WriteFile(filepath.Join(subrepoDir, "subfile"), []byte("subcontents"), 0644))
 
-	_, err = gitWithinDir(subrepoDir, "config", "user.name", "Docker test")
-	assert.NilError(t, err)
-
-	err = os.WriteFile(filepath.Join(subrepoDir, "subfile"), []byte("subcontents"), 0644)
-	assert.NilError(t, err)
-
-	_, err = gitWithinDir(subrepoDir, "add", "-A")
-	assert.NilError(t, err)
-
-	_, err = gitWithinDir(subrepoDir, "commit", "-am", "Subrepo initial")
-	assert.NilError(t, err)
+	must(gitWithinDir(subrepoDir, "add", "-A"))
+	must(gitWithinDir(subrepoDir, "commit", "-am", "Subrepo initial"))
 
 	cmd := exec.Command("git", "submodule", "add", subrepoDir, "sub") // this command doesn't work with --work-tree
 	cmd.Dir = gitDir
-	assert.NilError(t, cmd.Run())
+	must(cmd.CombinedOutput())
 
-	_, err = gitWithinDir(gitDir, "add", "-A")
-	assert.NilError(t, err)
-
-	_, err = gitWithinDir(gitDir, "commit", "-am", "With submodule")
-	assert.NilError(t, err)
+	must(gitWithinDir(gitDir, "add", "-A"))
+	must(gitWithinDir(gitDir, "commit", "-am", "With submodule"))
 
 	type singleCase struct {
 		frag      string
@@ -299,28 +266,30 @@ func TestCheckoutGit(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		ref, subdir := getRefAndSubdir(c.frag)
-		r, err := cloneGitRepo(gitRepo{remote: gitDir, ref: ref, subdir: subdir})
+		t.Run(c.frag, func(t *testing.T) {
+			ref, subdir := getRefAndSubdir(c.frag)
+			r, err := cloneGitRepo(gitRepo{remote: gitDir, ref: ref, subdir: subdir})
 
-		if c.fail {
-			assert.Check(t, is.ErrorContains(err, ""))
-			continue
-		}
-		assert.NilError(t, err)
-		defer os.RemoveAll(r)
-		if c.submodule {
-			b, err := os.ReadFile(filepath.Join(r, "sub/subfile"))
+			if c.fail {
+				assert.Check(t, is.ErrorContains(err, ""))
+				return
+			}
 			assert.NilError(t, err)
-			assert.Check(t, is.Equal("subcontents", string(b)))
-		} else {
-			_, err := os.Stat(filepath.Join(r, "sub/subfile"))
-			assert.Assert(t, is.ErrorContains(err, ""))
-			assert.Assert(t, os.IsNotExist(err))
-		}
+			defer os.RemoveAll(r)
+			if c.submodule {
+				b, err := os.ReadFile(filepath.Join(r, "sub/subfile"))
+				assert.NilError(t, err)
+				assert.Check(t, is.Equal("subcontents", string(b)))
+			} else {
+				_, err := os.Stat(filepath.Join(r, "sub/subfile"))
+				assert.Assert(t, is.ErrorContains(err, ""))
+				assert.Assert(t, os.IsNotExist(err))
+			}
 
-		b, err := os.ReadFile(filepath.Join(r, "Dockerfile"))
-		assert.NilError(t, err)
-		assert.Check(t, is.Equal(c.exp, string(b)))
+			b, err := os.ReadFile(filepath.Join(r, "Dockerfile"))
+			assert.NilError(t, err)
+			assert.Check(t, is.Equal(c.exp, string(b)))
+		})
 	}
 }
 

--- a/builder/remotecontext/git/gitutils_test.go
+++ b/builder/remotecontext/git/gitutils_test.go
@@ -162,7 +162,7 @@ func TestCloneArgsGit(t *testing.T) {
 }
 
 func gitGetConfig(name string) string {
-	b, err := gitWithinDir("", "config", "--get", name)
+	b, err := gitRepo{}.gitWithinDir("", "config", "--get", name)
 	if err != nil {
 		// since we are interested in empty or non empty string,
 		// we can safely ignore the err here.
@@ -236,9 +236,9 @@ func TestCheckoutGit(t *testing.T) {
 	}
 
 	gitDir := filepath.Join(root, "repo")
-	must(gitWithinDir(root, "-c", "init.defaultBranch=master", "init", gitDir))
-	must(gitWithinDir(gitDir, "config", "user.email", "test@docker.com"))
-	must(gitWithinDir(gitDir, "config", "user.name", "Docker test"))
+	must(gitRepo{}.gitWithinDir(root, "-c", "init.defaultBranch=master", "init", gitDir))
+	must(gitRepo{}.gitWithinDir(gitDir, "config", "user.email", "test@docker.com"))
+	must(gitRepo{}.gitWithinDir(gitDir, "config", "user.name", "Docker test"))
 	assert.NilError(t, os.WriteFile(filepath.Join(gitDir, "Dockerfile"), []byte("FROM scratch"), 0644))
 
 	subDir := filepath.Join(gitDir, "subdir")
@@ -250,31 +250,31 @@ func TestCheckoutGit(t *testing.T) {
 		assert.NilError(t, os.Symlink("/subdir", filepath.Join(gitDir, "absolutelink")))
 	}
 
-	must(gitWithinDir(gitDir, "add", "-A"))
-	must(gitWithinDir(gitDir, "commit", "-am", "First commit"))
-	must(gitWithinDir(gitDir, "checkout", "-b", "test"))
+	must(gitRepo{}.gitWithinDir(gitDir, "add", "-A"))
+	must(gitRepo{}.gitWithinDir(gitDir, "commit", "-am", "First commit"))
+	must(gitRepo{}.gitWithinDir(gitDir, "checkout", "-b", "test"))
 
 	assert.NilError(t, os.WriteFile(filepath.Join(gitDir, "Dockerfile"), []byte("FROM scratch\nEXPOSE 3000"), 0644))
 	assert.NilError(t, os.WriteFile(filepath.Join(subDir, "Dockerfile"), []byte("FROM busybox\nEXPOSE 5000"), 0644))
 
-	must(gitWithinDir(gitDir, "add", "-A"))
-	must(gitWithinDir(gitDir, "commit", "-am", "Branch commit"))
-	must(gitWithinDir(gitDir, "checkout", "master"))
+	must(gitRepo{}.gitWithinDir(gitDir, "add", "-A"))
+	must(gitRepo{}.gitWithinDir(gitDir, "commit", "-am", "Branch commit"))
+	must(gitRepo{}.gitWithinDir(gitDir, "checkout", "master"))
 
 	// set up submodule
 	subrepoDir := filepath.Join(root, "subrepo")
-	must(gitWithinDir(root, "-c", "init.defaultBranch=master", "init", subrepoDir))
-	must(gitWithinDir(subrepoDir, "config", "user.email", "test@docker.com"))
-	must(gitWithinDir(subrepoDir, "config", "user.name", "Docker test"))
+	must(gitRepo{}.gitWithinDir(root, "-c", "init.defaultBranch=master", "init", subrepoDir))
+	must(gitRepo{}.gitWithinDir(subrepoDir, "config", "user.email", "test@docker.com"))
+	must(gitRepo{}.gitWithinDir(subrepoDir, "config", "user.name", "Docker test"))
 
 	assert.NilError(t, os.WriteFile(filepath.Join(subrepoDir, "subfile"), []byte("subcontents"), 0644))
 
-	must(gitWithinDir(subrepoDir, "add", "-A"))
-	must(gitWithinDir(subrepoDir, "commit", "-am", "Subrepo initial"))
+	must(gitRepo{}.gitWithinDir(subrepoDir, "add", "-A"))
+	must(gitRepo{}.gitWithinDir(subrepoDir, "commit", "-am", "Subrepo initial"))
 
-	must(gitWithinDir(gitDir, "submodule", "add", server.URL+"/subrepo", "sub"))
-	must(gitWithinDir(gitDir, "add", "-A"))
-	must(gitWithinDir(gitDir, "commit", "-am", "With submodule"))
+	must(gitRepo{}.gitWithinDir(gitDir, "submodule", "add", server.URL+"/subrepo", "sub"))
+	must(gitRepo{}.gitWithinDir(gitDir, "add", "-A"))
+	must(gitRepo{}.gitWithinDir(gitDir, "commit", "-am", "With submodule"))
 
 	type singleCase struct {
 		frag      string
@@ -311,7 +311,7 @@ func TestCheckoutGit(t *testing.T) {
 		t.Run(c.frag, func(t *testing.T) {
 			currentSubtest = t
 			ref, subdir := getRefAndSubdir(c.frag)
-			r, err := cloneGitRepo(gitRepo{remote: server.URL + "/repo", ref: ref, subdir: subdir})
+			r, err := gitRepo{remote: server.URL + "/repo", ref: ref, subdir: subdir}.clone()
 
 			if c.fail {
 				assert.Check(t, is.ErrorContains(err, ""))

--- a/distribution/manifest_test.go
+++ b/distribution/manifest_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/distribution/manifest/ocischema"
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
+	"github.com/docker/distribution/reference"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -37,6 +38,11 @@ func (m *mockManifestGetter) Get(ctx context.Context, dgst digest.Digest, option
 		return nil, distribution.ErrManifestUnknown{Tag: dgst.String()}
 	}
 	return manifest, nil
+}
+
+func (m *mockManifestGetter) Exists(ctx context.Context, dgst digest.Digest) (bool, error) {
+	_, ok := m.manifests[dgst]
+	return ok, nil
 }
 
 type memoryLabelStore struct {
@@ -76,7 +82,9 @@ func (s *memoryLabelStore) Update(dgst digest.Digest, update map[string]string) 
 	for k, v := range update {
 		labels[k] = v
 	}
-
+	if s.labels == nil {
+		s.labels = map[digest.Digest]map[string]string{}
+	}
 	s.labels[dgst] = labels
 
 	return labels, nil
@@ -125,7 +133,7 @@ func TestManifestStore(t *testing.T) {
 	assert.NilError(t, err)
 	dgst := digest.Canonical.FromBytes(serialized)
 
-	setupTest := func(t *testing.T) (specs.Descriptor, *mockManifestGetter, *manifestStore, content.Store, func(*testing.T)) {
+	setupTest := func(t *testing.T) (reference.Named, specs.Descriptor, *mockManifestGetter, *manifestStore, content.Store, func(*testing.T)) {
 		root, err := os.MkdirTemp("", strings.ReplaceAll(t.Name(), "/", "_"))
 		assert.NilError(t, err)
 		defer func() {
@@ -141,7 +149,10 @@ func TestManifestStore(t *testing.T) {
 		store := &manifestStore{local: cs, remote: mg}
 		desc := specs.Descriptor{Digest: dgst, MediaType: specs.MediaTypeImageManifest, Size: int64(len(serialized))}
 
-		return desc, mg, store, cs, func(t *testing.T) {
+		ref, err := reference.Parse("foo/bar")
+		assert.NilError(t, err)
+
+		return ref.(reference.Named), desc, mg, store, cs, func(t *testing.T) {
 			assert.Check(t, os.RemoveAll(root))
 		}
 	}
@@ -181,22 +192,22 @@ func TestManifestStore(t *testing.T) {
 	}
 
 	t.Run("no remote or local", func(t *testing.T) {
-		desc, _, store, cs, teardown := setupTest(t)
+		ref, desc, _, store, cs, teardown := setupTest(t)
 		defer teardown(t)
 
-		_, err = store.Get(ctx, desc)
+		_, err = store.Get(ctx, desc, ref)
 		checkIngest(t, cs, desc)
 		// This error is what our digest getter returns when it doesn't know about the manifest
 		assert.Error(t, err, distribution.ErrManifestUnknown{Tag: dgst.String()}.Error())
 	})
 
 	t.Run("no local cache", func(t *testing.T) {
-		desc, mg, store, cs, teardown := setupTest(t)
+		ref, desc, mg, store, cs, teardown := setupTest(t)
 		defer teardown(t)
 
 		mg.manifests[desc.Digest] = m
 
-		m2, err := store.Get(ctx, desc)
+		m2, err := store.Get(ctx, desc, ref)
 		checkIngest(t, cs, desc)
 		assert.NilError(t, err)
 		assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
@@ -206,23 +217,34 @@ func TestManifestStore(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, cmp.Equal(i.Digest, desc.Digest))
 
+		distKey, distSource := makeDistributionSourceLabel(ref)
+		assert.Check(t, hasDistributionSource(i.Labels[distKey], distSource))
+
 		// Now check again, this should not hit the remote
-		m2, err = store.Get(ctx, desc)
+		m2, err = store.Get(ctx, desc, ref)
 		checkIngest(t, cs, desc)
 		assert.NilError(t, err)
 		assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
 		assert.Check(t, cmp.Equal(mg.gets, 1))
+
+		t.Run("digested", func(t *testing.T) {
+			ref, err := reference.WithDigest(ref, desc.Digest)
+			assert.NilError(t, err)
+
+			_, err = store.Get(ctx, desc, ref)
+			assert.NilError(t, err)
+		})
 	})
 
 	t.Run("with local cache", func(t *testing.T) {
-		desc, mg, store, cs, teardown := setupTest(t)
+		ref, desc, mg, store, cs, teardown := setupTest(t)
 		defer teardown(t)
 
 		// first add the manifest to the coontent store
 		writeManifest(t, cs, desc)
 
 		// now do the get
-		m2, err := store.Get(ctx, desc)
+		m2, err := store.Get(ctx, desc, ref)
 		checkIngest(t, cs, desc)
 		assert.NilError(t, err)
 		assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
@@ -236,13 +258,13 @@ func TestManifestStore(t *testing.T) {
 	// This is for the case of pull by digest where we don't know the media type of the manifest until it's actually pulled.
 	t.Run("unknown media type", func(t *testing.T) {
 		t.Run("no cache", func(t *testing.T) {
-			desc, mg, store, cs, teardown := setupTest(t)
+			ref, desc, mg, store, cs, teardown := setupTest(t)
 			defer teardown(t)
 
 			mg.manifests[desc.Digest] = m
 			desc.MediaType = ""
 
-			m2, err := store.Get(ctx, desc)
+			m2, err := store.Get(ctx, desc, ref)
 			checkIngest(t, cs, desc)
 			assert.NilError(t, err)
 			assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
@@ -251,13 +273,13 @@ func TestManifestStore(t *testing.T) {
 
 		t.Run("with cache", func(t *testing.T) {
 			t.Run("cached manifest has media type", func(t *testing.T) {
-				desc, mg, store, cs, teardown := setupTest(t)
+				ref, desc, mg, store, cs, teardown := setupTest(t)
 				defer teardown(t)
 
 				writeManifest(t, cs, desc)
 				desc.MediaType = ""
 
-				m2, err := store.Get(ctx, desc)
+				m2, err := store.Get(ctx, desc, ref)
 				checkIngest(t, cs, desc)
 				assert.NilError(t, err)
 				assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
@@ -265,13 +287,13 @@ func TestManifestStore(t *testing.T) {
 			})
 
 			t.Run("cached manifest has no media type", func(t *testing.T) {
-				desc, mg, store, cs, teardown := setupTest(t)
+				ref, desc, mg, store, cs, teardown := setupTest(t)
 				defer teardown(t)
 
 				desc.MediaType = ""
 				writeManifest(t, cs, desc)
 
-				m2, err := store.Get(ctx, desc)
+				m2, err := store.Get(ctx, desc, ref)
 				checkIngest(t, cs, desc)
 				assert.NilError(t, err)
 				assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
@@ -286,14 +308,14 @@ func TestManifestStore(t *testing.T) {
 	// Also makes sure the ingests are aborted.
 	t.Run("error persisting manifest", func(t *testing.T) {
 		t.Run("error on writer", func(t *testing.T) {
-			desc, mg, store, cs, teardown := setupTest(t)
+			ref, desc, mg, store, cs, teardown := setupTest(t)
 			defer teardown(t)
 			mg.manifests[desc.Digest] = m
 
 			csW := &testingContentStoreWrapper{ContentStore: store.local, errorOnWriter: errors.New("random error")}
 			store.local = csW
 
-			m2, err := store.Get(ctx, desc)
+			m2, err := store.Get(ctx, desc, ref)
 			checkIngest(t, cs, desc)
 			assert.NilError(t, err)
 			assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
@@ -305,14 +327,14 @@ func TestManifestStore(t *testing.T) {
 		})
 
 		t.Run("error on commit", func(t *testing.T) {
-			desc, mg, store, cs, teardown := setupTest(t)
+			ref, desc, mg, store, cs, teardown := setupTest(t)
 			defer teardown(t)
 			mg.manifests[desc.Digest] = m
 
 			csW := &testingContentStoreWrapper{ContentStore: store.local, errorOnCommit: errors.New("random error")}
 			store.local = csW
 
-			m2, err := store.Get(ctx, desc)
+			m2, err := store.Get(ctx, desc, ref)
 			checkIngest(t, cs, desc)
 			assert.NilError(t, err)
 			assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -385,7 +385,8 @@ func (p *puller) pullTag(ctx context.Context, ref reference.Named, platform *spe
 		Digest:    dgst,
 		Size:      size,
 	}
-	manifest, err := p.manifestStore.Get(ctx, desc)
+
+	manifest, err := p.manifestStore.Get(ctx, desc, ref)
 	if err != nil {
 		if isTagged && isNotFound(errors.Cause(err)) {
 			logrus.WithField("ref", ref).WithError(err).Debug("Falling back to pull manifest by tag")
@@ -843,7 +844,7 @@ func (p *puller) pullManifestList(ctx context.Context, ref reference.Named, mfst
 			Size:      match.Size,
 			MediaType: match.MediaType,
 		}
-		manifest, err := p.manifestStore.Get(ctx, desc)
+		manifest, err := p.manifestStore.Get(ctx, desc, ref)
 		if err != nil {
 			return "", "", err
 		}

--- a/integration/image/pull_test.go
+++ b/integration/image/pull_test.go
@@ -2,11 +2,25 @@ package image
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
 	"testing"
 
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/content/local"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/testutil/registry"
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/skip"
 )
@@ -21,4 +35,126 @@ func TestImagePullPlatformInvalid(t *testing.T) {
 	assert.Assert(t, err != nil)
 	assert.ErrorContains(t, err, "unknown operating system or architecture")
 	assert.Assert(t, errdefs.IsInvalidParameter(err))
+}
+
+func createTestImage(ctx context.Context, t testing.TB, store content.Store) imagespec.Descriptor {
+	w, err := store.Writer(ctx, content.WithRef("layer"))
+	assert.NilError(t, err)
+	defer w.Close()
+
+	// Empty layer with just a root dir
+	const layer = `./0000775000000000000000000000000014201045023007702 5ustar  rootroot`
+
+	_, err = w.Write([]byte(layer))
+	assert.NilError(t, err)
+
+	err = w.Commit(ctx, int64(len(layer)), digest.FromBytes([]byte(layer)))
+	assert.NilError(t, err)
+
+	layerDigest := w.Digest()
+	w.Close()
+
+	platform := platforms.DefaultSpec()
+
+	img := imagespec.Image{
+		Architecture: platform.Architecture,
+		OS:           platform.OS,
+		RootFS:       imagespec.RootFS{Type: "layers", DiffIDs: []digest.Digest{layerDigest}},
+		Config:       imagespec.ImageConfig{WorkingDir: "/"},
+	}
+	imgJSON, err := json.Marshal(img)
+	assert.NilError(t, err)
+
+	w, err = store.Writer(ctx, content.WithRef("config"))
+	assert.NilError(t, err)
+	defer w.Close()
+	_, err = w.Write(imgJSON)
+	assert.NilError(t, err)
+	assert.NilError(t, w.Commit(ctx, int64(len(imgJSON)), digest.FromBytes(imgJSON)))
+
+	configDigest := w.Digest()
+	w.Close()
+
+	info, err := store.Info(ctx, layerDigest)
+	assert.NilError(t, err)
+
+	manifest := imagespec.Manifest{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2,
+		},
+		MediaType: images.MediaTypeDockerSchema2Manifest,
+		Config: imagespec.Descriptor{
+			MediaType: images.MediaTypeDockerSchema2Config,
+			Digest:    configDigest,
+			Size:      int64(len(imgJSON)),
+		},
+		Layers: []imagespec.Descriptor{{
+			MediaType: images.MediaTypeDockerSchema2Layer,
+			Digest:    layerDigest,
+			Size:      info.Size,
+		}},
+	}
+
+	manifestJSON, err := json.Marshal(manifest)
+	assert.NilError(t, err)
+
+	w, err = store.Writer(ctx, content.WithRef("manifest"))
+	assert.NilError(t, err)
+	defer w.Close()
+	_, err = w.Write(manifestJSON)
+	assert.NilError(t, err)
+	assert.NilError(t, w.Commit(ctx, int64(len(manifestJSON)), digest.FromBytes(manifestJSON)))
+
+	manifestDigest := w.Digest()
+	w.Close()
+
+	return imagespec.Descriptor{
+		MediaType: images.MediaTypeDockerSchema2Manifest,
+		Digest:    manifestDigest,
+		Size:      int64(len(manifestJSON)),
+	}
+}
+
+// Make sure that pulling by an already cached digest but for a different ref (that should not have that digest)
+//  verifies with the remote that the digest exists in that repo.
+func TestImagePullStoredfDigestForOtherRepo(t *testing.T) {
+	defer setupTest(t)()
+
+	reg := registry.NewV2(t, registry.WithStdout(os.Stdout), registry.WithStderr(os.Stderr))
+	defer reg.Close()
+	reg.WaitReady(t)
+
+	ctx := context.Background()
+
+	// First create an image and upload it to our local registry
+	// Then we'll download it so that we can make sure the content is available in dockerd's manifest cache.
+	// Then we'll try to pull the same digest but with a different repo name.
+
+	dir := t.TempDir()
+	store, err := local.NewStore(dir)
+	assert.NilError(t, err)
+
+	desc := createTestImage(ctx, t, store)
+
+	remote := path.Join(registry.DefaultURL, "test:latest")
+
+	c8dClient, err := containerd.New("", containerd.WithServices(containerd.WithContentStore(store)))
+	assert.NilError(t, err)
+
+	c8dClient.Push(ctx, remote, desc)
+	assert.NilError(t, err)
+
+	client := testEnv.APIClient()
+	rdr, err := client.ImagePull(ctx, remote, types.ImagePullOptions{})
+	assert.NilError(t, err)
+	defer rdr.Close()
+	io.Copy(ioutil.Discard, rdr)
+
+	// Now, pull a totally different repo with a the same digest
+	rdr, err = client.ImagePull(ctx, path.Join(registry.DefaultURL, "other:image@"+desc.Digest.String()), types.ImagePullOptions{})
+	if rdr != nil {
+		rdr.Close()
+	}
+	assert.Assert(t, err != nil, "Expected error, got none: %v", err)
+	assert.Assert(t, errdefs.IsNotFound(err), err)
 }


### PR DESCRIPTION
cherry-pick of https://github.com/moby/moby/compare/v20.10.19...v20.10.20 (except for BuildKit, which is done in https://github.com/moby/moby/pull/44320)


- conflicts in the first commit (in test files) due to `io/ioutil` -> `io` changes
- conflicts in the last commit, due to https://github.com/moby/moby/commit/9adad264d2bf17bee8ec7b8a29d7112b3f503771 (https://github.com/moby/moby/pull/43675), which is not in 20.10 <-- please double check the last commit 👍 