### PR TITLE
builder: Isolate Git from local system

### DIFF
--- a/builder/remotecontext/git.go
+++ b/builder/remotecontext/git.go
@@ -11,7 +11,7 @@ import (
 
 // MakeGitContext returns a Context from gitURL that is cloned in a temporary directory.
 func MakeGitContext(gitURL string) (builder.Source, error) {
-	root, err := git.Clone(gitURL)
+	root, err := git.Clone(gitURL, git.WithIsolatedConfig(true))
 	if err != nil {
 		return nil, err
 	}

--- a/builder/remotecontext/git/gitutils.go
+++ b/builder/remotecontext/git/gitutils.go
@@ -192,8 +192,14 @@ func checkoutGit(root, ref, subdir string) (string, error) {
 }
 
 func gitWithinDir(dir string, args ...string) ([]byte, error) {
+	args = append([]string{"-c", "protocol.file.allow=never"}, args...) // Block sneaky repositories from using repos from the filesystem as submodules.
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
+	cmd.Env = append(cmd.Env,
+		"GIT_PROTOCOL_FROM_USER=0", // Disable unsafe remote protocols.
+		"GIT_CONFIG_NOSYSTEM=1",    // Disable reading from system gitconfig.
+		"HOME=/dev/null",           // Disable reading from user gitconfig.
+	)
 	return cmd.CombinedOutput()
 }
 

--- a/builder/remotecontext/git/gitutils.go
+++ b/builder/remotecontext/git/gitutils.go
@@ -212,7 +212,7 @@ func (repo gitRepo) gitWithinDir(dir string, args ...string) ([]byte, error) {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
 	// Disable unsafe remote protocols.
-	cmd.Env = append(cmd.Env, "GIT_PROTOCOL_FROM_USER=0")
+	cmd.Env = append(cmd.Environ(), "GIT_PROTOCOL_FROM_USER=0")
 
 	if repo.isolateConfig {
 		cmd.Env = append(cmd.Env,

--- a/builder/remotecontext/git/gitutils.go
+++ b/builder/remotecontext/git/gitutils.go
@@ -20,6 +20,7 @@ type gitRepo struct {
 	isolateConfig bool
 }
 
+// CloneOption changes the behaviour of Clone().
 type CloneOption func(*gitRepo)
 
 // WithIsolatedConfig disables reading the user or system gitconfig files when

--- a/builder/remotecontext/git/gitutils.go
+++ b/builder/remotecontext/git/gitutils.go
@@ -192,12 +192,9 @@ func checkoutGit(root, ref, subdir string) (string, error) {
 }
 
 func gitWithinDir(dir string, args ...string) ([]byte, error) {
-	a := []string{"--work-tree", dir, "--git-dir", filepath.Join(dir, ".git")}
-	return git(append(a, args...)...)
-}
-
-func git(args ...string) ([]byte, error) {
-	return exec.Command("git", args...).CombinedOutput()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	return cmd.CombinedOutput()
 }
 
 // isGitTransport returns true if the provided str is a git transport by inspecting

--- a/builder/remotecontext/git/gitutils_test.go
+++ b/builder/remotecontext/git/gitutils_test.go
@@ -170,9 +170,7 @@ func gitGetConfig(name string) string {
 }
 
 func TestCheckoutGit(t *testing.T) {
-	root, err := os.MkdirTemp("", "docker-build-git-checkout")
-	assert.NilError(t, err)
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	autocrlf := gitGetConfig("core.autocrlf")
 	if !(autocrlf == "true" || autocrlf == "false" ||
@@ -184,88 +182,57 @@ func TestCheckoutGit(t *testing.T) {
 		eol = "\r\n"
 	}
 
+	must := func(out []byte, err error) {
+		t.Helper()
+		if len(out) > 0 {
+			t.Logf("%s", out)
+		}
+		assert.NilError(t, err)
+	}
+
 	gitDir := filepath.Join(root, "repo")
-	_, err = git("init", gitDir)
-	assert.NilError(t, err)
-
-	_, err = gitWithinDir(gitDir, "config", "user.email", "test@docker.com")
-	assert.NilError(t, err)
-
-	_, err = gitWithinDir(gitDir, "config", "user.name", "Docker test")
-	assert.NilError(t, err)
-
-	err = os.WriteFile(filepath.Join(gitDir, "Dockerfile"), []byte("FROM scratch"), 0644)
-	assert.NilError(t, err)
+	must(git("-c", "init.defaultBranch=master", "init", gitDir))
+	must(gitWithinDir(gitDir, "config", "user.email", "test@docker.com"))
+	must(gitWithinDir(gitDir, "config", "user.name", "Docker test"))
+	assert.NilError(t, os.WriteFile(filepath.Join(gitDir, "Dockerfile"), []byte("FROM scratch"), 0644))
 
 	subDir := filepath.Join(gitDir, "subdir")
 	assert.NilError(t, os.Mkdir(subDir, 0755))
-
-	err = os.WriteFile(filepath.Join(subDir, "Dockerfile"), []byte("FROM scratch\nEXPOSE 5000"), 0644)
-	assert.NilError(t, err)
+	assert.NilError(t, os.WriteFile(filepath.Join(subDir, "Dockerfile"), []byte("FROM scratch\nEXPOSE 5000"), 0644))
 
 	if runtime.GOOS != "windows" {
-		if err = os.Symlink("../subdir", filepath.Join(gitDir, "parentlink")); err != nil {
-			t.Fatal(err)
-		}
-
-		if err = os.Symlink("/subdir", filepath.Join(gitDir, "absolutelink")); err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, os.Symlink("../subdir", filepath.Join(gitDir, "parentlink")))
+		assert.NilError(t, os.Symlink("/subdir", filepath.Join(gitDir, "absolutelink")))
 	}
 
-	_, err = gitWithinDir(gitDir, "add", "-A")
-	assert.NilError(t, err)
+	must(gitWithinDir(gitDir, "add", "-A"))
+	must(gitWithinDir(gitDir, "commit", "-am", "First commit"))
+	must(gitWithinDir(gitDir, "checkout", "-b", "test"))
 
-	_, err = gitWithinDir(gitDir, "commit", "-am", "First commit")
-	assert.NilError(t, err)
+	assert.NilError(t, os.WriteFile(filepath.Join(gitDir, "Dockerfile"), []byte("FROM scratch\nEXPOSE 3000"), 0644))
+	assert.NilError(t, os.WriteFile(filepath.Join(subDir, "Dockerfile"), []byte("FROM busybox\nEXPOSE 5000"), 0644))
 
-	_, err = gitWithinDir(gitDir, "checkout", "-b", "test")
-	assert.NilError(t, err)
-
-	err = os.WriteFile(filepath.Join(gitDir, "Dockerfile"), []byte("FROM scratch\nEXPOSE 3000"), 0644)
-	assert.NilError(t, err)
-
-	err = os.WriteFile(filepath.Join(subDir, "Dockerfile"), []byte("FROM busybox\nEXPOSE 5000"), 0644)
-	assert.NilError(t, err)
-
-	_, err = gitWithinDir(gitDir, "add", "-A")
-	assert.NilError(t, err)
-
-	_, err = gitWithinDir(gitDir, "commit", "-am", "Branch commit")
-	assert.NilError(t, err)
-
-	_, err = gitWithinDir(gitDir, "checkout", "master")
-	assert.NilError(t, err)
+	must(gitWithinDir(gitDir, "add", "-A"))
+	must(gitWithinDir(gitDir, "commit", "-am", "Branch commit"))
+	must(gitWithinDir(gitDir, "checkout", "master"))
 
 	// set up submodule
 	subrepoDir := filepath.Join(root, "subrepo")
-	_, err = git("init", subrepoDir)
-	assert.NilError(t, err)
+	must(git("-c", "init.defaultBranch=master", "init", subrepoDir))
+	must(gitWithinDir(subrepoDir, "config", "user.email", "test@docker.com"))
+	must(gitWithinDir(subrepoDir, "config", "user.name", "Docker test"))
 
-	_, err = gitWithinDir(subrepoDir, "config", "user.email", "test@docker.com")
-	assert.NilError(t, err)
+	assert.NilError(t, os.WriteFile(filepath.Join(subrepoDir, "subfile"), []byte("subcontents"), 0644))
 
-	_, err = gitWithinDir(subrepoDir, "config", "user.name", "Docker test")
-	assert.NilError(t, err)
-
-	err = os.WriteFile(filepath.Join(subrepoDir, "subfile"), []byte("subcontents"), 0644)
-	assert.NilError(t, err)
-
-	_, err = gitWithinDir(subrepoDir, "add", "-A")
-	assert.NilError(t, err)
-
-	_, err = gitWithinDir(subrepoDir, "commit", "-am", "Subrepo initial")
-	assert.NilError(t, err)
+	must(gitWithinDir(subrepoDir, "add", "-A"))
+	must(gitWithinDir(subrepoDir, "commit", "-am", "Subrepo initial"))
 
 	cmd := exec.Command("git", "submodule", "add", subrepoDir, "sub") // this command doesn't work with --work-tree
 	cmd.Dir = gitDir
-	assert.NilError(t, cmd.Run())
+	must(cmd.CombinedOutput())
 
-	_, err = gitWithinDir(gitDir, "add", "-A")
-	assert.NilError(t, err)
-
-	_, err = gitWithinDir(gitDir, "commit", "-am", "With submodule")
-	assert.NilError(t, err)
+	must(gitWithinDir(gitDir, "add", "-A"))
+	must(gitWithinDir(gitDir, "commit", "-am", "With submodule"))
 
 	type singleCase struct {
 		frag      string
@@ -299,28 +266,30 @@ func TestCheckoutGit(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		ref, subdir := getRefAndSubdir(c.frag)
-		r, err := cloneGitRepo(gitRepo{remote: gitDir, ref: ref, subdir: subdir})
+		t.Run(c.frag, func(t *testing.T) {
+			ref, subdir := getRefAndSubdir(c.frag)
+			r, err := cloneGitRepo(gitRepo{remote: gitDir, ref: ref, subdir: subdir})
 
-		if c.fail {
-			assert.Check(t, is.ErrorContains(err, ""))
-			continue
-		}
-		assert.NilError(t, err)
-		defer os.RemoveAll(r)
-		if c.submodule {
-			b, err := os.ReadFile(filepath.Join(r, "sub/subfile"))
+			if c.fail {
+				assert.Check(t, is.ErrorContains(err, ""))
+				return
+			}
 			assert.NilError(t, err)
-			assert.Check(t, is.Equal("subcontents", string(b)))
-		} else {
-			_, err := os.Stat(filepath.Join(r, "sub/subfile"))
-			assert.Assert(t, is.ErrorContains(err, ""))
-			assert.Assert(t, os.IsNotExist(err))
-		}
+			defer os.RemoveAll(r)
+			if c.submodule {
+				b, err := os.ReadFile(filepath.Join(r, "sub/subfile"))
+				assert.NilError(t, err)
+				assert.Check(t, is.Equal("subcontents", string(b)))
+			} else {
+				_, err := os.Stat(filepath.Join(r, "sub/subfile"))
+				assert.Assert(t, is.ErrorContains(err, ""))
+				assert.Assert(t, os.IsNotExist(err))
+			}
 
-		b, err := os.ReadFile(filepath.Join(r, "Dockerfile"))
-		assert.NilError(t, err)
-		assert.Check(t, is.Equal(c.exp, string(b)))
+			b, err := os.ReadFile(filepath.Join(r, "Dockerfile"))
+			assert.NilError(t, err)
+			assert.Check(t, is.Equal(c.exp, string(b)))
+		})
 	}
 }
 

--- a/builder/remotecontext/git/gitutils_test.go
+++ b/builder/remotecontext/git/gitutils_test.go
@@ -162,7 +162,7 @@ func TestCloneArgsGit(t *testing.T) {
 }
 
 func gitGetConfig(name string) string {
-	b, err := gitWithinDir("", "config", "--get", name)
+	b, err := gitRepo{}.gitWithinDir("", "config", "--get", name)
 	if err != nil {
 		// since we are interested in empty or non empty string,
 		// we can safely ignore the err here.
@@ -236,9 +236,9 @@ func TestCheckoutGit(t *testing.T) {
 	}
 
 	gitDir := filepath.Join(root, "repo")
-	must(gitWithinDir(root, "-c", "init.defaultBranch=master", "init", gitDir))
-	must(gitWithinDir(gitDir, "config", "user.email", "test@docker.com"))
-	must(gitWithinDir(gitDir, "config", "user.name", "Docker test"))
+	must(gitRepo{}.gitWithinDir(root, "-c", "init.defaultBranch=master", "init", gitDir))
+	must(gitRepo{}.gitWithinDir(gitDir, "config", "user.email", "test@docker.com"))
+	must(gitRepo{}.gitWithinDir(gitDir, "config", "user.name", "Docker test"))
 	assert.NilError(t, os.WriteFile(filepath.Join(gitDir, "Dockerfile"), []byte("FROM scratch"), 0644))
 
 	subDir := filepath.Join(gitDir, "subdir")
@@ -250,31 +250,31 @@ func TestCheckoutGit(t *testing.T) {
 		assert.NilError(t, os.Symlink("/subdir", filepath.Join(gitDir, "absolutelink")))
 	}
 
-	must(gitWithinDir(gitDir, "add", "-A"))
-	must(gitWithinDir(gitDir, "commit", "-am", "First commit"))
-	must(gitWithinDir(gitDir, "checkout", "-b", "test"))
+	must(gitRepo{}.gitWithinDir(gitDir, "add", "-A"))
+	must(gitRepo{}.gitWithinDir(gitDir, "commit", "-am", "First commit"))
+	must(gitRepo{}.gitWithinDir(gitDir, "checkout", "-b", "test"))
 
 	assert.NilError(t, os.WriteFile(filepath.Join(gitDir, "Dockerfile"), []byte("FROM scratch\nEXPOSE 3000"), 0644))
 	assert.NilError(t, os.WriteFile(filepath.Join(subDir, "Dockerfile"), []byte("FROM busybox\nEXPOSE 5000"), 0644))
 
-	must(gitWithinDir(gitDir, "add", "-A"))
-	must(gitWithinDir(gitDir, "commit", "-am", "Branch commit"))
-	must(gitWithinDir(gitDir, "checkout", "master"))
+	must(gitRepo{}.gitWithinDir(gitDir, "add", "-A"))
+	must(gitRepo{}.gitWithinDir(gitDir, "commit", "-am", "Branch commit"))
+	must(gitRepo{}.gitWithinDir(gitDir, "checkout", "master"))
 
 	// set up submodule
 	subrepoDir := filepath.Join(root, "subrepo")
-	must(gitWithinDir(root, "-c", "init.defaultBranch=master", "init", subrepoDir))
-	must(gitWithinDir(subrepoDir, "config", "user.email", "test@docker.com"))
-	must(gitWithinDir(subrepoDir, "config", "user.name", "Docker test"))
+	must(gitRepo{}.gitWithinDir(root, "-c", "init.defaultBranch=master", "init", subrepoDir))
+	must(gitRepo{}.gitWithinDir(subrepoDir, "config", "user.email", "test@docker.com"))
+	must(gitRepo{}.gitWithinDir(subrepoDir, "config", "user.name", "Docker test"))
 
 	assert.NilError(t, os.WriteFile(filepath.Join(subrepoDir, "subfile"), []byte("subcontents"), 0644))
 
-	must(gitWithinDir(subrepoDir, "add", "-A"))
-	must(gitWithinDir(subrepoDir, "commit", "-am", "Subrepo initial"))
+	must(gitRepo{}.gitWithinDir(subrepoDir, "add", "-A"))
+	must(gitRepo{}.gitWithinDir(subrepoDir, "commit", "-am", "Subrepo initial"))
 
-	must(gitWithinDir(gitDir, "submodule", "add", server.URL+"/subrepo", "sub"))
-	must(gitWithinDir(gitDir, "add", "-A"))
-	must(gitWithinDir(gitDir, "commit", "-am", "With submodule"))
+	must(gitRepo{}.gitWithinDir(gitDir, "submodule", "add", server.URL+"/subrepo", "sub"))
+	must(gitRepo{}.gitWithinDir(gitDir, "add", "-A"))
+	must(gitRepo{}.gitWithinDir(gitDir, "commit", "-am", "With submodule"))
 
 	type singleCase struct {
 		frag      string
@@ -311,7 +311,7 @@ func TestCheckoutGit(t *testing.T) {
 		t.Run(c.frag, func(t *testing.T) {
 			currentSubtest = t
 			ref, subdir := getRefAndSubdir(c.frag)
-			r, err := cloneGitRepo(gitRepo{remote: server.URL + "/repo", ref: ref, subdir: subdir})
+			r, err := gitRepo{remote: server.URL + "/repo", ref: ref, subdir: subdir}.clone()
 
 			if c.fail {
 				assert.Check(t, is.ErrorContains(err, ""))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Changed how git is invoked by builder to stop it from reading configuration from the host system and to block it from cloning submodules off the local filesystem. It is no longer possible for a specially-crafted remote repository to clone a repository on the local filesystem into the build context.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* Added mitigation for https://github.com/git/git/security/advisories/GHSA-3wp6-j8xr-qw85 (CVE-2022-39253)

**- A picture of a cute animal (not mandatory but encouraged)**

