### PR TITLE
[20.10 backport] vendor: moby/term, Azure/go-ansiterm for golang.org/x/sys/windows compatibility

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,4 +1,4 @@
-github.com/Azure/go-ansiterm                        d6e3b3328b783f23731bc4d058875b0371ff8109
+github.com/Azure/go-ansiterm                        d185dfc1b5a126116ea5a19e148e29d16b4574c9
 github.com/Microsoft/hcsshim                        a11a2c44e8a4aa9d66314b1d759ef582df5ab5e8 # moby branch
 github.com/Microsoft/go-winio                       7e149e8c70409f36773c1b2cf3447a7ab7697368 # v0.4.20
 github.com/docker/libtrust                          9cbd2a1374f46905c68a4eb3694a130610adc62a
@@ -7,7 +7,7 @@ github.com/google/uuid                              0cd6bf5da1e1c83f8b45653022c7
 github.com/gorilla/mux                              98cb6bf42e086f6af920b965c38cacc07402d51b # v1.8.0
 github.com/Microsoft/opengcs                        a10967154e143a36014584a6f664344e3bb0aa64
 github.com/moby/locker                              281af2d563954745bea9d1487c965f24d30742fe # v1.0.1
-github.com/moby/term                                bea5bbe245bf407372d477f1361d2ff042d2f556
+github.com/moby/term                                3f7ff695adc6a35abc925370dd0a4dafb48ec64d
 
 # Note that this dependency uses submodules, providing the github.com/moby/sys/mount,
 # github.com/moby/sys/mountinfo, and github.com/moby/sys/symlink modules. Our vendoring

--- a/vendor/github.com/Azure/go-ansiterm/go.mod
+++ b/vendor/github.com/Azure/go-ansiterm/go.mod
@@ -1,0 +1,5 @@
+module github.com/Azure/go-ansiterm
+
+go 1.16
+
+require golang.org/x/sys v0.0.0-20210616094352-59db8d763f22

--- a/vendor/github.com/Azure/go-ansiterm/winterm/ansi.go
+++ b/vendor/github.com/Azure/go-ansiterm/winterm/ansi.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/Azure/go-ansiterm"
+	windows "golang.org/x/sys/windows"
 )
 
 // Windows keyboard constants
@@ -162,15 +163,28 @@ func ensureInRange(n int16, min int16, max int16) int16 {
 
 func GetStdFile(nFile int) (*os.File, uintptr) {
 	var file *os.File
-	switch nFile {
-	case syscall.STD_INPUT_HANDLE:
+
+	// syscall uses negative numbers
+	// windows package uses very big uint32
+	// Keep these switches split so we don't have to convert ints too much.
+	switch uint32(nFile) {
+	case windows.STD_INPUT_HANDLE:
 		file = os.Stdin
-	case syscall.STD_OUTPUT_HANDLE:
+	case windows.STD_OUTPUT_HANDLE:
 		file = os.Stdout
-	case syscall.STD_ERROR_HANDLE:
+	case windows.STD_ERROR_HANDLE:
 		file = os.Stderr
 	default:
-		panic(fmt.Errorf("Invalid standard handle identifier: %v", nFile))
+		switch nFile {
+		case syscall.STD_INPUT_HANDLE:
+			file = os.Stdin
+		case syscall.STD_OUTPUT_HANDLE:
+			file = os.Stdout
+		case syscall.STD_ERROR_HANDLE:
+			file = os.Stderr
+		default:
+			panic(fmt.Errorf("Invalid standard handle identifier: %v", nFile))
+		}
 	}
 
 	fd, err := syscall.GetStdHandle(nFile)

--- a/vendor/github.com/moby/term/go.mod
+++ b/vendor/github.com/moby/term/go.mod
@@ -3,10 +3,10 @@ module github.com/moby/term
 go 1.13
 
 require (
-	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1
 	github.com/creack/pty v1.1.11
 	github.com/google/go-cmp v0.4.0
 	github.com/pkg/errors v0.9.1 // indirect
-	golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a
+	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22
 	gotest.tools/v3 v3.0.2
 )

--- a/vendor/github.com/moby/term/windows/console.go
+++ b/vendor/github.com/moby/term/windows/console.go
@@ -29,7 +29,7 @@ func GetHandleInfo(in interface{}) (uintptr, bool) {
 
 // IsConsole returns true if the given file descriptor is a Windows Console.
 // The code assumes that GetConsoleMode will return an error for file descriptors that are not a console.
-// Deprecated: use golang.org/x/sys/windows.GetConsoleMode() or golang.org/x/crypto/ssh/terminal.IsTerminal()
+// Deprecated: use golang.org/x/sys/windows.GetConsoleMode() or golang.org/x/term.IsTerminal()
 var IsConsole = isConsole
 
 func isConsole(fd uintptr) bool {


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/42508

----

- winterm: GetStdFile(): Added compatibility with "golang.org/x/sys/windows"
- winterm: fix GetStdFile() falltrough
- update deprecation message to refer to the correct replacement
- add go.mod
- Fix int overflow
- Convert int to string using rune()

full diff:

- https://github.com/moby/term/compare/bea5bbe245bf407372d477f1361d2ff042d2f556...3f7ff695adc6a35abc925370dd0a4dafb48ec64d
- https://github.com/Azure/go-ansiterm/compare/d6e3b3328b783f23731bc4d058875b0371ff8109...d185dfc1b5a126116ea5a19e148e29d16b4574c9

(cherry picked from commit af1e74555aec5858a59573df3a920d108cec30d4)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```markdown
- Fix an `Invalid standard handle identifie` panic when  registering the docker daemon as a service from a legacy CLI on Windows.
```


**- A picture of a cute animal (not mandatory but encouraged)**

