### PR TITLE
Validate digest in repo for pull by digest

### DIFF
--- a/distribution/manifest_test.go
+++ b/distribution/manifest_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/distribution/manifest/ocischema"
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
+	"github.com/docker/distribution/reference"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -37,6 +38,11 @@ func (m *mockManifestGetter) Get(ctx context.Context, dgst digest.Digest, option
 		return nil, distribution.ErrManifestUnknown{Tag: dgst.String()}
 	}
 	return manifest, nil
+}
+
+func (m *mockManifestGetter) Exists(ctx context.Context, dgst digest.Digest) (bool, error) {
+	_, ok := m.manifests[dgst]
+	return ok, nil
 }
 
 type memoryLabelStore struct {
@@ -76,7 +82,9 @@ func (s *memoryLabelStore) Update(dgst digest.Digest, update map[string]string) 
 	for k, v := range update {
 		labels[k] = v
 	}
-
+	if s.labels == nil {
+		s.labels = map[digest.Digest]map[string]string{}
+	}
 	s.labels[dgst] = labels
 
 	return labels, nil
@@ -125,7 +133,7 @@ func TestManifestStore(t *testing.T) {
 	assert.NilError(t, err)
 	dgst := digest.Canonical.FromBytes(serialized)
 
-	setupTest := func(t *testing.T) (specs.Descriptor, *mockManifestGetter, *manifestStore, content.Store, func(*testing.T)) {
+	setupTest := func(t *testing.T) (reference.Named, specs.Descriptor, *mockManifestGetter, *manifestStore, content.Store, func(*testing.T)) {
 		root, err := os.MkdirTemp("", strings.ReplaceAll(t.Name(), "/", "_"))
 		assert.NilError(t, err)
 		defer func() {
@@ -141,7 +149,10 @@ func TestManifestStore(t *testing.T) {
 		store := &manifestStore{local: cs, remote: mg}
 		desc := specs.Descriptor{Digest: dgst, MediaType: specs.MediaTypeImageManifest, Size: int64(len(serialized))}
 
-		return desc, mg, store, cs, func(t *testing.T) {
+		ref, err := reference.Parse("foo/bar")
+		assert.NilError(t, err)
+
+		return ref.(reference.Named), desc, mg, store, cs, func(t *testing.T) {
 			assert.Check(t, os.RemoveAll(root))
 		}
 	}
@@ -181,22 +192,22 @@ func TestManifestStore(t *testing.T) {
 	}
 
 	t.Run("no remote or local", func(t *testing.T) {
-		desc, _, store, cs, teardown := setupTest(t)
+		ref, desc, _, store, cs, teardown := setupTest(t)
 		defer teardown(t)
 
-		_, err = store.Get(ctx, desc)
+		_, err = store.Get(ctx, desc, ref)
 		checkIngest(t, cs, desc)
 		// This error is what our digest getter returns when it doesn't know about the manifest
 		assert.Error(t, err, distribution.ErrManifestUnknown{Tag: dgst.String()}.Error())
 	})
 
 	t.Run("no local cache", func(t *testing.T) {
-		desc, mg, store, cs, teardown := setupTest(t)
+		ref, desc, mg, store, cs, teardown := setupTest(t)
 		defer teardown(t)
 
 		mg.manifests[desc.Digest] = m
 
-		m2, err := store.Get(ctx, desc)
+		m2, err := store.Get(ctx, desc, ref)
 		checkIngest(t, cs, desc)
 		assert.NilError(t, err)
 		assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
@@ -206,23 +217,34 @@ func TestManifestStore(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, cmp.Equal(i.Digest, desc.Digest))
 
+		distKey, distSource := makeDistributionSourceLabel(ref)
+		assert.Check(t, hasDistributionSource(i.Labels[distKey], distSource))
+
 		// Now check again, this should not hit the remote
-		m2, err = store.Get(ctx, desc)
+		m2, err = store.Get(ctx, desc, ref)
 		checkIngest(t, cs, desc)
 		assert.NilError(t, err)
 		assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
 		assert.Check(t, cmp.Equal(mg.gets, 1))
+
+		t.Run("digested", func(t *testing.T) {
+			ref, err := reference.WithDigest(ref, desc.Digest)
+			assert.NilError(t, err)
+
+			_, err = store.Get(ctx, desc, ref)
+			assert.NilError(t, err)
+		})
 	})
 
 	t.Run("with local cache", func(t *testing.T) {
-		desc, mg, store, cs, teardown := setupTest(t)
+		ref, desc, mg, store, cs, teardown := setupTest(t)
 		defer teardown(t)
 
 		// first add the manifest to the coontent store
 		writeManifest(t, cs, desc)
 
 		// now do the get
-		m2, err := store.Get(ctx, desc)
+		m2, err := store.Get(ctx, desc, ref)
 		checkIngest(t, cs, desc)
 		assert.NilError(t, err)
 		assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
@@ -236,13 +258,13 @@ func TestManifestStore(t *testing.T) {
 	// This is for the case of pull by digest where we don't know the media type of the manifest until it's actually pulled.
 	t.Run("unknown media type", func(t *testing.T) {
 		t.Run("no cache", func(t *testing.T) {
-			desc, mg, store, cs, teardown := setupTest(t)
+			ref, desc, mg, store, cs, teardown := setupTest(t)
 			defer teardown(t)
 
 			mg.manifests[desc.Digest] = m
 			desc.MediaType = ""
 
-			m2, err := store.Get(ctx, desc)
+			m2, err := store.Get(ctx, desc, ref)
 			checkIngest(t, cs, desc)
 			assert.NilError(t, err)
 			assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
@@ -251,13 +273,13 @@ func TestManifestStore(t *testing.T) {
 
 		t.Run("with cache", func(t *testing.T) {
 			t.Run("cached manifest has media type", func(t *testing.T) {
-				desc, mg, store, cs, teardown := setupTest(t)
+				ref, desc, mg, store, cs, teardown := setupTest(t)
 				defer teardown(t)
 
 				writeManifest(t, cs, desc)
 				desc.MediaType = ""
 
-				m2, err := store.Get(ctx, desc)
+				m2, err := store.Get(ctx, desc, ref)
 				checkIngest(t, cs, desc)
 				assert.NilError(t, err)
 				assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
@@ -265,13 +287,13 @@ func TestManifestStore(t *testing.T) {
 			})
 
 			t.Run("cached manifest has no media type", func(t *testing.T) {
-				desc, mg, store, cs, teardown := setupTest(t)
+				ref, desc, mg, store, cs, teardown := setupTest(t)
 				defer teardown(t)
 
 				desc.MediaType = ""
 				writeManifest(t, cs, desc)
 
-				m2, err := store.Get(ctx, desc)
+				m2, err := store.Get(ctx, desc, ref)
 				checkIngest(t, cs, desc)
 				assert.NilError(t, err)
 				assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
@@ -286,14 +308,14 @@ func TestManifestStore(t *testing.T) {
 	// Also makes sure the ingests are aborted.
 	t.Run("error persisting manifest", func(t *testing.T) {
 		t.Run("error on writer", func(t *testing.T) {
-			desc, mg, store, cs, teardown := setupTest(t)
+			ref, desc, mg, store, cs, teardown := setupTest(t)
 			defer teardown(t)
 			mg.manifests[desc.Digest] = m
 
 			csW := &testingContentStoreWrapper{ContentStore: store.local, errorOnWriter: errors.New("random error")}
 			store.local = csW
 
-			m2, err := store.Get(ctx, desc)
+			m2, err := store.Get(ctx, desc, ref)
 			checkIngest(t, cs, desc)
 			assert.NilError(t, err)
 			assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
@@ -305,14 +327,14 @@ func TestManifestStore(t *testing.T) {
 		})
 
 		t.Run("error on commit", func(t *testing.T) {
-			desc, mg, store, cs, teardown := setupTest(t)
+			ref, desc, mg, store, cs, teardown := setupTest(t)
 			defer teardown(t)
 			mg.manifests[desc.Digest] = m
 
 			csW := &testingContentStoreWrapper{ContentStore: store.local, errorOnCommit: errors.New("random error")}
 			store.local = csW
 
-			m2, err := store.Get(ctx, desc)
+			m2, err := store.Get(ctx, desc, ref)
 			checkIngest(t, cs, desc)
 			assert.NilError(t, err)
 			assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -385,7 +385,8 @@ func (p *puller) pullTag(ctx context.Context, ref reference.Named, platform *spe
 		Digest:    dgst,
 		Size:      size,
 	}
-	manifest, err := p.manifestStore.Get(ctx, desc)
+
+	manifest, err := p.manifestStore.Get(ctx, desc, ref)
 	if err != nil {
 		if isTagged && isNotFound(errors.Cause(err)) {
 			logrus.WithField("ref", ref).WithError(err).Debug("Falling back to pull manifest by tag")
@@ -843,7 +844,7 @@ func (p *puller) pullManifestList(ctx context.Context, ref reference.Named, mfst
 			Size:      match.Size,
 			MediaType: match.MediaType,
 		}
-		manifest, err := p.manifestStore.Get(ctx, desc)
+		manifest, err := p.manifestStore.Get(ctx, desc, ref)
 		if err != nil {
 			return "", "", err
 		}

--- a/integration/image/pull_test.go
+++ b/integration/image/pull_test.go
@@ -117,6 +117,9 @@ func createTestImage(ctx context.Context, t testing.TB, store content.Store) ima
 // Make sure that pulling by an already cached digest but for a different ref (that should not have that digest)
 // verifies with the remote that the digest exists in that repo.
 func TestImagePullStoredfDigestForOtherRepo(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+	skip.If(t, testEnv.OSType == "windows", "We don't run a test registry on Windows")
+	skip.If(t, testEnv.IsRootless, "Rootless has a different view of localhost (needed for test registry access)")
 	defer setupTest(t)()
 
 	reg := registry.NewV2(t, registry.WithStdout(os.Stdout), registry.WithStderr(os.Stderr))

--- a/integration/image/pull_test.go
+++ b/integration/image/pull_test.go
@@ -2,11 +2,24 @@ package image
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path"
 	"testing"
 
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/content/local"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/testutil/registry"
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/skip"
 )
@@ -21,4 +34,126 @@ func TestImagePullPlatformInvalid(t *testing.T) {
 	assert.Assert(t, err != nil)
 	assert.ErrorContains(t, err, "unknown operating system or architecture")
 	assert.Assert(t, errdefs.IsInvalidParameter(err))
+}
+
+func createTestImage(ctx context.Context, t testing.TB, store content.Store) imagespec.Descriptor {
+	w, err := store.Writer(ctx, content.WithRef("layer"))
+	assert.NilError(t, err)
+	defer w.Close()
+
+	// Empty layer with just a root dir
+	const layer = `./0000775000000000000000000000000014201045023007702 5ustar  rootroot`
+
+	_, err = w.Write([]byte(layer))
+	assert.NilError(t, err)
+
+	err = w.Commit(ctx, int64(len(layer)), digest.FromBytes([]byte(layer)))
+	assert.NilError(t, err)
+
+	layerDigest := w.Digest()
+	w.Close()
+
+	platform := platforms.DefaultSpec()
+
+	img := imagespec.Image{
+		Architecture: platform.Architecture,
+		OS:           platform.OS,
+		RootFS:       imagespec.RootFS{Type: "layers", DiffIDs: []digest.Digest{layerDigest}},
+		Config:       imagespec.ImageConfig{WorkingDir: "/"},
+	}
+	imgJSON, err := json.Marshal(img)
+	assert.NilError(t, err)
+
+	w, err = store.Writer(ctx, content.WithRef("config"))
+	assert.NilError(t, err)
+	defer w.Close()
+	_, err = w.Write(imgJSON)
+	assert.NilError(t, err)
+	assert.NilError(t, w.Commit(ctx, int64(len(imgJSON)), digest.FromBytes(imgJSON)))
+
+	configDigest := w.Digest()
+	w.Close()
+
+	info, err := store.Info(ctx, layerDigest)
+	assert.NilError(t, err)
+
+	manifest := imagespec.Manifest{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2,
+		},
+		MediaType: images.MediaTypeDockerSchema2Manifest,
+		Config: imagespec.Descriptor{
+			MediaType: images.MediaTypeDockerSchema2Config,
+			Digest:    configDigest,
+			Size:      int64(len(imgJSON)),
+		},
+		Layers: []imagespec.Descriptor{{
+			MediaType: images.MediaTypeDockerSchema2Layer,
+			Digest:    layerDigest,
+			Size:      info.Size,
+		}},
+	}
+
+	manifestJSON, err := json.Marshal(manifest)
+	assert.NilError(t, err)
+
+	w, err = store.Writer(ctx, content.WithRef("manifest"))
+	assert.NilError(t, err)
+	defer w.Close()
+	_, err = w.Write(manifestJSON)
+	assert.NilError(t, err)
+	assert.NilError(t, w.Commit(ctx, int64(len(manifestJSON)), digest.FromBytes(manifestJSON)))
+
+	manifestDigest := w.Digest()
+	w.Close()
+
+	return imagespec.Descriptor{
+		MediaType: images.MediaTypeDockerSchema2Manifest,
+		Digest:    manifestDigest,
+		Size:      int64(len(manifestJSON)),
+	}
+}
+
+// Make sure that pulling by an already cached digest but for a different ref (that should not have that digest)
+// verifies with the remote that the digest exists in that repo.
+func TestImagePullStoredfDigestForOtherRepo(t *testing.T) {
+	defer setupTest(t)()
+
+	reg := registry.NewV2(t, registry.WithStdout(os.Stdout), registry.WithStderr(os.Stderr))
+	defer reg.Close()
+	reg.WaitReady(t)
+
+	ctx := context.Background()
+
+	// First create an image and upload it to our local registry
+	// Then we'll download it so that we can make sure the content is available in dockerd's manifest cache.
+	// Then we'll try to pull the same digest but with a different repo name.
+
+	dir := t.TempDir()
+	store, err := local.NewStore(dir)
+	assert.NilError(t, err)
+
+	desc := createTestImage(ctx, t, store)
+
+	remote := path.Join(registry.DefaultURL, "test:latest")
+
+	c8dClient, err := containerd.New("", containerd.WithServices(containerd.WithContentStore(store)))
+	assert.NilError(t, err)
+
+	c8dClient.Push(ctx, remote, desc)
+	assert.NilError(t, err)
+
+	client := testEnv.APIClient()
+	rdr, err := client.ImagePull(ctx, remote, types.ImagePullOptions{})
+	assert.NilError(t, err)
+	defer rdr.Close()
+	io.Copy(io.Discard, rdr)
+
+	// Now, pull a totally different repo with a the same digest
+	rdr, err = client.ImagePull(ctx, path.Join(registry.DefaultURL, "other:image@"+desc.Digest.String()), types.ImagePullOptions{})
+	if rdr != nil {
+		rdr.Close()
+	}
+	assert.Assert(t, err != nil, "Expected error, got none: %v", err)
+	assert.Assert(t, errdefs.IsNotFound(err), err)
 }

--- a/testutil/registry/ops.go
+++ b/testutil/registry/ops.go
@@ -1,5 +1,7 @@
 package registry
 
+import "io"
+
 // Schema1 sets the registry to serve v1 api
 func Schema1(c *Config) {
 	c.schema1 = true
@@ -22,5 +24,19 @@ func Token(tokenURL string) func(*Config) {
 func URL(registryURL string) func(*Config) {
 	return func(c *Config) {
 		c.registryURL = registryURL
+	}
+}
+
+// WithStdout sets the stdout of the registry command to the passed in writer.
+func WithStdout(w io.Writer) func(c *Config) {
+	return func(c *Config) {
+		c.stdout = w
+	}
+}
+
+// WithStderr sets the stdout of the registry command to the passed in writer.
+func WithStderr(w io.Writer) func(c *Config) {
+	return func(c *Config) {
+		c.stderr = w
 	}
 }


### PR DESCRIPTION
Upstreaming the patch for [GHSA-vjgr-4595-fc6r](https://github.com/moby/moby/security/advisories/GHSA-vjgr-4595-fc6r) to master.

This is a rebase and squash of https://github.com/moby/moby-ghsa-vjgr-4595-fc6r/pull/3


This is accomplished by storing the distribution source in the content labels. If the distribution source is not found then we check to the registry to see if the digest exists in the repo, if it does exist then the puller will use it.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

