### PR TITLE
Avoid iptables lock error for endpoint port mapping

### DIFF
--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -124,10 +124,9 @@ func detectIptables() {
 	}
 	iptablesPath = path
 	path, err = exec.LookPath("ip6tables")
-	if err != nil {
-		return
+	if err == nil {
+		ip6tablesPath = path
 	}
-	ip6tablesPath = path
 	supportsXlock = exec.Command(iptablesPath, "--wait", "-L", "-n").Run() == nil
 	mj, mn, mc, err := GetVersion()
 	if err != nil {

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -489,6 +489,11 @@ func (iptable IPTable) exists(native bool, table Table, chain string, rule ...st
 func (iptable IPTable) existsRaw(table Table, chain string, rule ...string) bool {
 	path := iptablesPath
 	if iptable.Version == IPv6 {
+		// The existsRaw() signature does not allow us to return an error, but at least
+		// we can skip the invalid exec invocation.
+		if ip6tablesPath == "" {
+			return false
+		}
 		path = ip6tablesPath
 	}
 
@@ -557,6 +562,9 @@ func (iptable IPTable) raw(args ...string) ([]byte, error) {
 	path := iptablesPath
 	commandName := "iptables"
 	if iptable.Version == IPv6 {
+		if ip6tablesPath == "" {
+			return nil, fmt.Errorf("ip6tables not found")
+		}
 		path = ip6tablesPath
 		commandName = "ip6tables"
 	}


### PR DESCRIPTION
Fixes: #44331 Run failure due to iptables xtables lock contention

On Ubuntu Focal the iptables implementation returns immediately with an
error if the xtables lock is held.  This is a change in behavior that
has exposed a latent issue in Docker's implementation.

After moving to Focal hosts in our CI environment, contention on the
iptables xtable lock is leading to the following error message (these
failures are easy to trigger and frequent):

```
  Error response from daemon: driver failed programming
  external connectivity on endpoint foo
  (4ee313e3bf3f375e70c3ee5d00b9000523cb80e5fb29b9ccff565913c74ab6ec):
  (iptables failed: iptables -t nat -A POSTROUTING -p tcp -s 172.16.128.7
  -d 172.16.128.7 --dport 8081 -j MASQUERADE: Another app is currently
  holding the xtables lock. Perhaps you want to use the -w option?
```

The source of that error message is endpoint.sbJoin in
libnetwork/endpoint.go.  It calls:

```
  endpoint.sbJoin
   driver.ProgramExternalConnectivity (libnetwork/drivers/bridge/bridge.go)
    bridgeNetwork.allocatePorts
     bridgeNetwork.allocatePortsInternal
      bridgeNetwork.allocatePort
       PortMapper.MapRange
        PortMapper.AppendForwardingTableEntry
         PortMapper.Forward
          ChainInfo.Forward
           iptable.ProgramRule
            iptable.Exist
             iptable.exists
              iptable.existsRaw
```

`iptable.raw` calls iptables with `--wait` if supported, but
`iptable.existsRaw` does not.  The invocation of iptables in `existsRaw`
has not changed since 2017, but the OS behavior has.  In Ubuntu 20.04
(Focal) the call to `iptables -S` will fail immediately if the lock is
held by another process, this is not the case in earlier (Bionic) or
later (Jammy) releases.

This patch adds the `--wait` option to this invocation of iptable (or
if that is not supported the `bestEffortLock` is used) when listing
existing rules.

Signed-off-by: Robert C Jennings <rcj4747@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Addressed the iptables lock contention

**- How I did it**
Added the same handling for `iptable.existsRaw` as is found in `iptable.raw`; specifically yhis patch adds the `--wait` option to this invocation of iptable (or if that is not supported the `bestEffortLock` is used) when listing existing rules.

**- How to verify it**
~~On Ubuntu 20.04 (Bionic) you can explicitly take the lock with `flock /run/xtables.lock sleep 60&` and run a container with port mappings.~~  (edit: running flock will block the other iptables calls which wait for the lock, you need contention and timing to recreate)

**- Description for the changelog**
Wait for iptables lock when listing existing rules with bridge networks

