### PR TITLE
[20.10] builder: fix running git commands on Windows

### DIFF
--- a/builder/remotecontext/git/gitutils.go
+++ b/builder/remotecontext/git/gitutils.go
@@ -21,6 +21,7 @@ type gitRepo struct {
 	isolateConfig bool
 }
 
+// CloneOption changes the behaviour of Clone().
 type CloneOption func(*gitRepo)
 
 // WithIsolatedConfig disables reading the user or system gitconfig files when

--- a/builder/remotecontext/git/gitutils.go
+++ b/builder/remotecontext/git/gitutils.go
@@ -213,7 +213,7 @@ func (repo gitRepo) gitWithinDir(dir string, args ...string) ([]byte, error) {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
 	// Disable unsafe remote protocols.
-	cmd.Env = append(cmd.Env, "GIT_PROTOCOL_FROM_USER=0")
+	cmd.Env = append(os.Environ(), "GIT_PROTOCOL_FROM_USER=0")
 
 	if repo.isolateConfig {
 		cmd.Env = append(cmd.Env,


### PR DESCRIPTION
Setting cmd.Env overrides the default of passing through the parent process' environment, which works out fine most of the time, except when it doesn't. For whatever reason, leaving out all the environment causes git-for-windows sh.exe subprocesses to enter an infinite loop of access violations during Cygwin initialization in certain environments (specifically, our very own dev container image).

Signed-off-by: Cory Snider <csnider@mirantis.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

