### PR TITLE
[22.06 backport] gha: update buildkit to v0.10.5-6-ge27c8e24 to skip some tests

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -72,9 +72,9 @@ jobs:
         name: BuildKit ref
         run: |
           ./hack/go-mod-prepare.sh
-          # FIXME(thaJeztah) temporarily overriding version to use for tests; see https://github.com/moby/moby/pull/44028#issuecomment-1225964929
+          # FIXME(thaJeztah) temporarily overriding version to use for tests; remove with the next release of buildkit
           # echo "BUILDKIT_REF=$(./hack/buildkit-ref)" >> $GITHUB_ENV
-          echo "BUILDKIT_REF=8e2d9b9006caadb74c1745608889a37ba139acc1" >> $GITHUB_ENV
+          echo "BUILDKIT_REF=e27c8e24bb9ee92a170567b8b597201925ae9b8a" >> $GITHUB_ENV
         working-directory: moby
       -
         name: Checkout BuildKit ${{ env.BUILDKIT_REF }}


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44336

full diff: https://github.com/moby/buildkit/compare/v0.10.5...v0.10.5-6-ge27c8e24

(cherry picked from commit 16b74f287e3f38c5bb795c472a55aed8bb6b1ece)

