### PR TITLE
[20.10 backport] skip TestImagePullStoredfDigestForOtherRepo() on Windows and rootless

### DIFF
--- a/integration/image/pull_test.go
+++ b/integration/image/pull_test.go
@@ -118,6 +118,9 @@ func createTestImage(ctx context.Context, t testing.TB, store content.Store) ima
 // Make sure that pulling by an already cached digest but for a different ref (that should not have that digest)
 //  verifies with the remote that the digest exists in that repo.
 func TestImagePullStoredfDigestForOtherRepo(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+	skip.If(t, testEnv.OSType == "windows", "We don't run a test registry on Windows")
+	skip.If(t, testEnv.IsRootless, "Rootless has a different view of localhost (needed for test registry access)")
 	defer setupTest(t)()
 
 	reg := registry.NewV2(t, registry.WithStdout(os.Stdout), registry.WithStderr(os.Stderr))


### PR DESCRIPTION
- taken from https://github.com/moby/moby/pull/44327


- On Windows, we don't build and run a local  test registry (we're not running docker-in-docker), so we need to skip this test.
- On rootless, networking doesn't support this (currently)

(cherry picked from commit 4f43cb660a905983252c2162e7ca694dd3a415f1)


