### PR TITLE
[22.06 backport] gha: buildkit: remove "skip-integration-tests" from matrix

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -52,11 +52,11 @@ jobs:
       fail-fast: false
       matrix:
         pkg:
-          - ./client
-          - ./cmd/buildctl
-          - ./solver
-          - ./frontend
-          - ./frontend/dockerfile
+          - client
+          - cmd/buildctl
+          - solver
+          - frontend
+          - frontend/dockerfile
         typ:
           - integration
     steps:
@@ -107,6 +107,6 @@ jobs:
           CONTEXT: "."
           TEST_DOCKERD: "1"
           TEST_DOCKERD_BINARY: "./build/moby/binary-daemon/dockerd"
-          TESTPKGS: "${{ matrix.pkg }}"
+          TESTPKGS: "./${{ matrix.pkg }}"
           TESTFLAGS: "-v --parallel=1 --timeout=30m --run=//worker=dockerd$"
         working-directory: buildkit

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -59,9 +59,6 @@ jobs:
           - ./frontend/dockerfile
         typ:
           - integration
-        include:
-          - pkg: ./...
-            skip-integration-tests: 1
     steps:
       -
         name: Checkout
@@ -112,5 +109,4 @@ jobs:
           TEST_DOCKERD_BINARY: "./build/moby/binary-daemon/dockerd"
           TESTPKGS: "${{ matrix.pkg }}"
           TESTFLAGS: "-v --parallel=1 --timeout=30m --run=//worker=dockerd$"
-          SKIP_INTEGRATION_TESTS: "${{ matrix.skip-integration-tests }}"
         working-directory: buildkit


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44337