### PR TITLE
[22.06 backport] builder/remotecontext/git: allow building on go1.18

### DIFF
--- a/builder/remotecontext/git/gitutils.go
+++ b/builder/remotecontext/git/gitutils.go
@@ -213,7 +213,7 @@ func (repo gitRepo) gitWithinDir(dir string, args ...string) ([]byte, error) {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
 	// Disable unsafe remote protocols.
-	cmd.Env = append(cmd.Environ(), "GIT_PROTOCOL_FROM_USER=0")
+	cmd.Env = append(os.Environ(), "GIT_PROTOCOL_FROM_USER=0")
 
 	if repo.isolateConfig {
 		cmd.Env = append(cmd.Env,


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44344
- relates to https://github.com/docker/docker-ce-packaging/pull/775

cmd.Environ() is new in go1.19, and not needed for this specific case. Without this, trying to use this package in code that uses go1.18 will fail;

    builder/remotecontext/git/gitutils.go:216:23: cmd.Environ undefined (type *exec.Cmd has no field or method Environ)

(cherry picked from commit 4fdc1bb1fb4bba22bc8cf8beccc37b3af284b4a7)

