### PR TITLE
[22.06 backport] update containerd binary to v1.6.9

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -168,7 +168,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ARG GO_VERSION=1.19.2
 ARG GOTESTSUM_VERSION=v1.8.1
 ARG GOWINRES_VERSION=v0.2.3
-ARG CONTAINERD_VERSION=v1.6.8
+ARG CONTAINERD_VERSION=v1.6.9
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.6.8}"
+: "${CONTAINERD_VERSION:=v1.6.9}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44351

release notes: https://github.com/containerd/containerd/releases/tag/v1.6.9

full diff: containerd/containerd@v1.6.8...v1.6.9

(cherry picked from commit ac79a02ace2d8432eafca4364b4c55a55aba5172)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

