### PR TITLE
[20.10 backport] integration: download busybox-w32 from GitHub Release

### DIFF
--- a/contrib/busybox/Dockerfile
+++ b/contrib/busybox/Dockerfile
@@ -19,7 +19,7 @@ FROM ${WINDOWS_BASE_IMAGE}:${WINDOWS_BASE_IMAGE_TAG}
 RUN mkdir C:\tmp && mkdir C:\bin
 ARG BUSYBOX_VERSION
 ARG BUSYBOX_SHA256SUM
-ADD https://frippery.org/files/busybox/busybox-w32-${BUSYBOX_VERSION}.exe /bin/busybox.exe
+ADD https://github.com/moby/busybox/releases/download/${BUSYBOX_VERSION}/busybox-w32-${BUSYBOX_VERSION}.exe /bin/busybox.exe
 RUN powershell \
     if ((Get-FileHash -Path /bin/busybox.exe -Algorithm SHA256).Hash -ne $Env:BUSYBOX_SHA256SUM) { \
         Throw \"Checksum validation failed\" \


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44299
- fixes https://github.com/moby/moby/issues/44298

(cherry picked from commit 4f1d1422deb1a8cf43a3b39c7eb65581aedb6013)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
