### PR TITLE
Add manifest tag header to each request in push/pull

### DIFF
--- a/distribution/manifest_headers.go
+++ b/distribution/manifest_headers.go
@@ -1,0 +1,70 @@
+package distribution
+
+import (
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/distribution/registry/client/transport"
+	"github.com/sirupsen/logrus"
+	"net/http"
+)
+
+const dockerManifestTagHeader = "Docker-Manifest-Tag"
+
+// distributionRepositoryWithManifestInfo is a distribution.Repository implementation wrapper which keeps track on the
+// manifest information (specifically the tag) being pushed / pulled. It also acts as transport.RequestModifier to
+// modify requests, adding a header with the manifest tag.
+type distributionRepositoryWithManifestInfo struct {
+	distribution.Repository
+	manifestInfo struct {
+		tag string
+	}
+}
+
+var _ distribution.Repository = (*distributionRepositoryWithManifestInfo)(nil)
+var _ transport.RequestModifier = (*distributionRepositoryWithManifestInfo)(nil)
+
+func (r *distributionRepositoryWithManifestInfo) ModifyRequest(req *http.Request) error {
+	logrus.Tracef("distributionRepositoryWithManifestInfo.ModifyRequest: %s %s", req.Method, req.URL)
+	info := r.manifestInfo
+	if info.tag != "" {
+		logrus.Tracef("distributionRepositoryWithManifestInfo: Setting manifest tag header - %s: %s", dockerManifestTagHeader, info.tag)
+		req.Header.Set(dockerManifestTagHeader, info.tag)
+	}
+	return nil
+}
+
+// update the manifest info kept by this instance according to the given named ref.
+func (r *distributionRepositoryWithManifestInfo) update(ref reference.Named) {
+	if tagged, ok := ref.(reference.Tagged); ok {
+		r.manifestInfo.tag = tagged.Tag()
+		logrus.Tracef("distributionRepositoryWithManifestInfo: updated tag='%s' (from ref: %#v)", tagged.Tag(), ref)
+	}
+}
+
+// updateRepoWithManifestInfo safely calls distributionRepositoryWithManifestInfo.update if repo is a
+// distributionRepositoryWithManifestInfo
+func updateRepoWithManifestInfo(repo distribution.Repository, ref reference.Named) {
+	if r, ok := repo.(*distributionRepositoryWithManifestInfo); ok {
+		r.update(ref)
+	}
+}
+
+// metaHeadersWithManifestTagHeader returns a copy of the given meta headers map the 'Docker-Manifest-Tag' header with
+// the tag value if the given ref is tagged, otherwise returns the original map.
+func metaHeadersWithManifestTagHeader(metaHeaders map[string][]string, ref reference.Named) map[string][]string {
+	tag, tagged := ref.(reference.NamedTagged)
+	if !tagged || len(tag.Tag()) == 0 {
+		logrus.Debugf("metaHeadersWithManifestTagHeader: ref is not tagged: %#v; skip adding metadata tag header", ref)
+		return metaHeaders
+	}
+	// Copy the meta headers from the config
+	newMetaHeaders := make(map[string][]string, len(metaHeaders))
+	for k, v := range metaHeaders {
+		newMetaHeaders[k] = v
+	}
+
+	logrus.Debugf("metaHeadersWithManifestTagHeader: Setting meta header: %s: %s", dockerManifestTagHeader, tag.Tag())
+	newMetaHeaders[dockerManifestTagHeader] = []string{tag.Tag()}
+
+	return newMetaHeaders
+}

--- a/distribution/manifest_headers_test.go
+++ b/distribution/manifest_headers_test.go
@@ -1,0 +1,81 @@
+package distribution
+
+import (
+	"github.com/docker/distribution/reference"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDistributionRepositoryWithManifestInfo_ModifyRequest(t *testing.T) {
+	assertExpectedHeaders := func(t *testing.T, req *http.Request, tag string) {
+		var expectedTags []string = nil
+		if tag != "" {
+			expectedTags = []string{tag}
+		}
+		tagValues := req.Header.Values("Docker-Manifest-Tag")
+		assert.Check(t, cmp.DeepEqual(expectedTags, tagValues), "manifest tag values in header not as expected")
+	}
+
+	repo := &distributionRepositoryWithManifestInfo{}
+	newRequest := func() *http.Request { return httptest.NewRequest(http.MethodGet, "https://www.example.com", nil) }
+	refName, _ := reference.WithName("foo")
+	refWithTag1, _ := reference.WithTag(refName, "1.0")
+
+	t.Run("initial values", func(t *testing.T) {
+		req := newRequest()
+		err := repo.ModifyRequest(req)
+		assert.NilError(t, err)
+		assertExpectedHeaders(t, req, "")
+	})
+
+	t.Run("update ref tag", func(t *testing.T) {
+		req := newRequest()
+		updateRepoWithManifestInfo(repo, refWithTag1)
+		err := repo.ModifyRequest(req)
+		assert.NilError(t, err)
+		assertExpectedHeaders(t, req, "1.0")
+	})
+}
+
+func TestMetaHeadersWithManifestTagHeader(t *testing.T) {
+	namedRef, _ := reference.WithName("foo")
+	taggedRef, _ := reference.WithTag(namedRef, "1.0")
+	var metaHeaders map[string][]string
+
+	t.Run("nil meta headers map, ref not tagged", func(t *testing.T) {
+		result := metaHeadersWithManifestTagHeader(metaHeaders, namedRef)
+		// Original not changed
+		assert.Check(t, metaHeaders == nil)
+		// Result is the same as original
+		assert.DeepEqual(t, metaHeaders, result)
+	})
+
+	t.Run("nil meta headers map, tagged ref", func(t *testing.T) {
+		result := metaHeadersWithManifestTagHeader(metaHeaders, taggedRef)
+		// Original not changed
+		assert.Check(t, metaHeaders == nil)
+		// Result includes the added header
+		assert.DeepEqual(t, result, map[string][]string{"Docker-Manifest-Tag": {"1.0"}})
+	})
+
+	metaHeaders = map[string][]string{"foo": {"1"}, "bar": {"2", "3"}}
+
+	t.Run("non-empty meta headers map, ref not tagged", func(t *testing.T) {
+		result := metaHeadersWithManifestTagHeader(metaHeaders, namedRef)
+		// Original not changed
+		assert.DeepEqual(t, metaHeaders, map[string][]string{"foo": {"1"}, "bar": {"2", "3"}})
+		// Result is the same as original
+		assert.DeepEqual(t, metaHeaders, result)
+	})
+
+	t.Run("non-empty meta headers map, tagged ref", func(t *testing.T) {
+		result := metaHeadersWithManifestTagHeader(metaHeaders, taggedRef)
+		// Original not changed
+		assert.DeepEqual(t, metaHeaders, map[string][]string{"foo": {"1"}, "bar": {"2", "3"}})
+		// Result is the same as original, plus the additional header
+		assert.DeepEqual(t, result, map[string][]string{"foo": {"1"}, "bar": {"2", "3"}, "Docker-Manifest-Tag": {"1.0"}})
+	})
+}

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -76,7 +76,8 @@ type puller struct {
 
 func (p *puller) pull(ctx context.Context, ref reference.Named) (err error) {
 	// TODO(tiborvass): was ReceiveTimeout
-	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
+	metaHeaders := metaHeadersWithManifestTagHeader(p.config.MetaHeaders, ref)
+	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, metaHeaders, p.config.AuthConfig, "pull")
 	if err != nil {
 		logrus.Warnf("Error getting v2 registry: %v", err)
 		return err
@@ -373,6 +374,7 @@ func (p *puller) pullTag(ctx context.Context, ref reference.Named, platform *spe
 	} else {
 		return false, fmt.Errorf("internal error: reference has neither a tag nor a digest: %s", reference.FamiliarString(ref))
 	}
+	updateRepoWithManifestInfo(p.repo, ref)
 
 	ctx = log.WithLogger(ctx, logrus.WithFields(
 		logrus.Fields{

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -73,7 +73,8 @@ type pushState struct {
 func (p *pusher) push(ctx context.Context) (err error) {
 	p.pushState.remoteLayers = make(map[layer.DiffID]distribution.Descriptor)
 
-	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "push", "pull")
+	metaHeaders := metaHeadersWithManifestTagHeader(p.config.MetaHeaders, p.ref)
+	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, metaHeaders, p.config.AuthConfig, "push", "pull")
 	p.pushState.hasAuthInfo = p.config.AuthConfig.RegistryToken != "" || (p.config.AuthConfig.Username != "" && p.config.AuthConfig.Password != "")
 	if err != nil {
 		logrus.Debugf("Error getting v2 registry: %v", err)
@@ -125,6 +126,7 @@ func (p *pusher) pushRepository(ctx context.Context) (err error) {
 
 func (p *pusher) pushTag(ctx context.Context, ref reference.NamedTagged, id digest.Digest) error {
 	logrus.Debugf("Pushing repository: %s", reference.FamiliarString(ref))
+	updateRepoWithManifestInfo(p.repo, ref)
 
 	imgConfig, err := p.config.ImageStore.Get(ctx, id)
 	if err != nil {

--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -81,7 +81,13 @@ func newRepository(
 		DisableKeepAlives: true,
 	}
 
+	// Using distributionRepositoryWithManifestInfo as a wrapper for the distribution.Repository, to add the manifest
+	// tag header to all requests during push/pull. This implementation assumes the repository instance returned by this
+	// function is used for a single push/pull at a time (not in concurrent)
+	distRepo := &distributionRepositoryWithManifestInfo{}
+
 	modifiers := registry.Headers(dockerversion.DockerUserAgent(ctx), metaHeaders)
+	modifiers = append(modifiers, distRepo)
 	authTransport := transport.NewTransport(base, modifiers...)
 
 	challengeManager, err := registry.PingV2Registry(endpoint.URL, authTransport)
@@ -128,13 +134,14 @@ func newRepository(
 		}
 	}
 
-	repo, err = client.NewRepository(repoNameRef, endpoint.URL.String(), tr)
+	distRepo.Repository, err = client.NewRepository(repoNameRef, endpoint.URL.String(), tr)
 	if err != nil {
 		err = fallbackError{
 			err:         err,
 			transportOK: true,
 		}
 	}
+	repo = distRepo
 	return
 }
 


### PR DESCRIPTION
Signed-off-by: Yinon Avraham <yinona@jfrog.com>

**- What I did**

Added the `Docker-Manifest-Tag` header to all requests in the push / pull operations.
This header includes the tag value of the image being pushed / pulled. 
The header is not added when the reference is not tagged, e.g. when an image is pulled by digest.

*Note-* This header was suggested to the Distribution SPEC in [this PR](https://github.com/opencontainers/distribution-spec/pull/358)

**- How I did it**

1. Try to get the tag from the reference being pushed / pulled and add it as an additional meta header. This way the header is added as part of the `GET /v2/` request. 
2. Add the header for each tag being pushed / pulled. This is very important when a named reference without a tag is pushed. Then all local tags of that reference are being pushed, one by one, and each needs to have a header with its own tag.

The implementation is based on `distributionRepositoryWithManifestInfo` which is a wrapper of the `distribution.Repository` and keeps track of the tag currently being handled. This wrapper is also a `transport.RequestModifier` which is used to add the manifest tag header to each request.

**- How to verify it**

New unit tests were added to verify the functionality of the added struct and functions.
The integration can be tested by push to / pull from a registry and tracking the request headers being sent - either by debugging the requests on the registry side, or by putting a proxy in the middle.

**- Description for the changelog**

Implement the 

**- A picture of a cute animal (not mandatory but encouraged)**

none