### PR TITLE
Fix the max-concurrent-downloads and max-concurrent-uploads configs documentation

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -45,8 +45,8 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.Var(opts.NewNamedMapOpts("log-opts", conf.LogConfig.Config, nil), "log-opt", "Default log driver options for containers")
 
 	flags.StringVar(&conf.CorsHeaders, "api-cors-header", "", "Set CORS headers in the Engine API")
-	flags.IntVar(&conf.MaxConcurrentDownloads, "max-concurrent-downloads", conf.MaxConcurrentDownloads, "Set the max concurrent downloads for each pull")
-	flags.IntVar(&conf.MaxConcurrentUploads, "max-concurrent-uploads", conf.MaxConcurrentUploads, "Set the max concurrent uploads for each push")
+	flags.IntVar(&conf.MaxConcurrentDownloads, "max-concurrent-downloads", conf.MaxConcurrentDownloads, "Set the max concurrent downloads")
+	flags.IntVar(&conf.MaxConcurrentUploads, "max-concurrent-uploads", conf.MaxConcurrentUploads, "Set the max concurrent uploads")
 	flags.IntVar(&conf.MaxDownloadAttempts, "max-download-attempts", conf.MaxDownloadAttempts, "Set the max download attempts for each pull")
 	flags.IntVar(&conf.ShutdownTimeout, "shutdown-timeout", conf.ShutdownTimeout, "Set the default shutdown timeout")
 

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -24,11 +24,11 @@ import (
 const (
 	// DefaultMaxConcurrentDownloads is the default value for
 	// maximum number of downloads that
-	// may take place at a time for each pull.
+	// may take place at a time.
 	DefaultMaxConcurrentDownloads = 3
 	// DefaultMaxConcurrentUploads is the default value for
 	// maximum number of uploads that
-	// may take place at a time for each push.
+	// may take place at a time.
 	DefaultMaxConcurrentUploads = 5
 	// DefaultDownloadAttempts is the default value for
 	// maximum number of attempts that


### PR DESCRIPTION
Fixes #44346.

**- What I did**

The `max-concurrent-downloads` and `max-concurrent-uploads` limits are applied for the whole engine and not for each pull/push command, as informed on the commands docs.

This PR fixes the `max-concurrent-downloads` and `max-concurrent-uploads` command documentation.

**- How I did it**

Fixed the docs. All the investigation part is documented on #44346

**- How to verify it**

See #44346

**- Description for the changelog**

Fix the max-concurrent-downloads and max-concurrent-uploads configs documentation. The `max-concurrent-downloads` and `max-concurrent-uploads` limits are applied for the whole engine and not for each pull/push command.
