### PR TITLE
daemon/config: use strings.Cut(), fix panic in BuilderGCFilter

### DIFF
--- a/daemon/config/builder.go
+++ b/daemon/config/builder.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"encoding/json"
-	"fmt"
 	"sort"
 	"strings"
 
@@ -28,7 +27,7 @@ func (x *BuilderGCFilter) MarshalJSON() ([]byte, error) {
 	for _, k := range keys {
 		values := f.Get(k)
 		for _, v := range values {
-			arr = append(arr, fmt.Sprintf("%s=%s", k, v))
+			arr = append(arr, k+"="+v)
 		}
 	}
 	return json.Marshal(arr)
@@ -45,9 +44,9 @@ func (x *BuilderGCFilter) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	for _, s := range arr {
-		fields := strings.SplitN(s, "=", 2)
-		name := strings.ToLower(strings.TrimSpace(fields[0]))
-		value := strings.TrimSpace(fields[1])
+		name, value, _ := strings.Cut(s, "=")
+		name = strings.ToLower(strings.TrimSpace(name))
+		value = strings.TrimSpace(value)
 		f.Add(name, value)
 	}
 	*x = BuilderGCFilter(f)

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -313,13 +313,13 @@ func New() (*Config, error) {
 func GetConflictFreeLabels(labels []string) ([]string, error) {
 	labelMap := map[string]string{}
 	for _, label := range labels {
-		stringSlice := strings.SplitN(label, "=", 2)
-		if len(stringSlice) > 1 {
+		key, val, ok := strings.Cut(label, "=")
+		if ok {
 			// If there is a conflict we will return an error
-			if v, ok := labelMap[stringSlice[0]]; ok && v != stringSlice[1] {
-				return nil, errors.Errorf("conflict labels for %s=%s and %s=%s", stringSlice[0], stringSlice[1], stringSlice[0], v)
+			if v, ok := labelMap[key]; ok && v != val {
+				return nil, errors.Errorf("conflict labels for %s=%s and %s=%s", key, val, key, v)
 			}
-			labelMap[stringSlice[0]] = stringSlice[1]
+			labelMap[key] = val
 		}
 	}
 


### PR DESCRIPTION
splitting this out of a branch I had which replaces strings.Split(N) calls.

- fixes https://github.com/moby/moby/issues/44361