### PR TITLE
client: defaultHTTPClient() accept URL

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -167,7 +167,10 @@ func NewClientWithOpts(ops ...Opt) (*Client, error) {
 
 func defaultHTTPClient(hostURL *url.URL) (*http.Client, error) {
 	transport := &http.Transport{}
-	_ = sockets.ConfigureTransport(transport, hostURL.Scheme, hostURL.Host)
+	err := sockets.ConfigureTransport(transport, hostURL.Scheme, hostURL.Host)
+	if err != nil {
+		return nil, err
+	}
 	return &http.Client{
 		Transport:     transport,
 		CheckRedirect: CheckRedirect,

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -165,6 +165,14 @@ func TestParseHostURL(t *testing.T) {
 			host:     "tcp://localhost:2476/path",
 			expected: &url.URL{Scheme: "tcp", Host: "localhost:2476", Path: "/path"},
 		},
+		{
+			host:     "unix:///var/run/docker.sock",
+			expected: &url.URL{Scheme: "unix", Host: "/var/run/docker.sock"},
+		},
+		{
+			host:     "npipe:////./pipe/docker_engine",
+			expected: &url.URL{Scheme: "npipe", Host: "//./pipe/docker_engine"},
+		},
 	}
 
 	for _, testcase := range testcases {

--- a/client/client_unix.go
+++ b/client/client_unix.go
@@ -6,6 +6,3 @@ package client // import "github.com/docker/docker/client"
 // DefaultDockerHost defines OS-specific default host if the DOCKER_HOST
 // (EnvOverrideHost) environment variable is unset or empty.
 const DefaultDockerHost = "unix:///var/run/docker.sock"
-
-const defaultProto = "unix"
-const defaultAddr = "/var/run/docker.sock"

--- a/client/client_windows.go
+++ b/client/client_windows.go
@@ -3,6 +3,3 @@ package client // import "github.com/docker/docker/client"
 // DefaultDockerHost defines OS-specific default host if the DOCKER_HOST
 // (EnvOverrideHost) environment variable is unset or empty.
 const DefaultDockerHost = "npipe:////./pipe/docker_engine"
-
-const defaultProto = "npipe"
-const defaultAddr = "//./pipe/docker_engine"


### PR DESCRIPTION
looks like I never pushed this branch, so let's do so 😂 

### client: defaultHTTPClient() accept URL

We're parsing the URL either way, so may just as well use the result.

### client: defaultHTTPClient(): don't ignore transport errors

This function was suppressing errors coming from ConfigureTransport, with the
assumption that it will only be used with the Default configuration, and only return
errors for invalid / unsupported schemes (e.g., using "npipe" on a Linux environment);
https://github.com/moby/moby/blob/d109e429dd69bbfc2b575c11e66cbd98364a860b/vendor/github.com/docker/go-connections/sockets/sockets_unix.go#L27-L29

Those errors won't happen when the default is passed, so this is mostly theoretical.
Let's return the error instead (which should always be nil), just to be on the save
side, and to make sure that any other use of this function will return errors that
occurred, which may also be when parsing proxy environment variables;
https://github.com/moby/moby/blob/d109e429dd69bbfc2b575c11e66cbd98364a860b/vendor/github.com/docker/go-connections/sockets/sockets.go#L29



**- A picture of a cute animal (not mandatory but encouraged)**

