### PR TITLE
pkg/idtools: remove execCmd() utility

### DIFF
--- a/pkg/idtools/idtools_unix.go
+++ b/pkg/idtools/idtools_unix.go
@@ -167,7 +167,7 @@ func callGetent(database, key string) (io.Reader, error) {
 	if getentCmd == "" {
 		return nil, fmt.Errorf("unable to find getent command")
 	}
-	out, err := execCmd(getentCmd, database, key)
+	out, err := exec.Command(getentCmd, database, key).CombinedOutput()
 	if err != nil {
 		exitCode, errC := getExitCode(err)
 		if errC != nil {

--- a/pkg/idtools/idtools_unix_test.go
+++ b/pkg/idtools/idtools_unix_test.go
@@ -328,8 +328,8 @@ func compareTrees(left, right map[string]node) error {
 }
 
 func delUser(t *testing.T, name string) {
-	_, err := execCmd("userdel", name)
-	assert.Check(t, err)
+	out, err := exec.Command("userdel", name).CombinedOutput()
+	assert.Check(t, err, out)
 }
 
 func TestParseSubidFileWithNewlinesAndComments(t *testing.T) {

--- a/pkg/idtools/utils_unix.go
+++ b/pkg/idtools/utils_unix.go
@@ -25,8 +25,3 @@ func resolveBinary(binname string) (string, error) {
 	}
 	return "", fmt.Errorf("Binary %q does not resolve to a binary of that name in $PATH (%q)", binname, resolvedPath)
 }
-
-func execCmd(cmd string, arg ...string) ([]byte, error) {
-	execCmd := exec.Command(cmd, arg...)
-	return execCmd.CombinedOutput()
-}


### PR DESCRIPTION
The `execCmd()` utility was a basic wrapper around `exec.Command()`. Inlining it makes the code more transparent.

**- A picture of a cute animal (not mandatory but encouraged)**

