### PR TITLE
Remove errant "runtime.GOARCH" from debug message

### DIFF
--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -830,7 +830,7 @@ func (p *puller) pullManifestList(ctx context.Context, ref reference.Named, mfst
 	if pp != nil {
 		platform = *pp
 	}
-	logrus.Debugf("%s resolved to a manifestList object with %d entries; looking for a %s/%s match", ref, len(mfstList.Manifests), platforms.Format(platform), runtime.GOARCH)
+	logrus.Debugf("%s resolved to a manifestList object with %d entries; looking for a %s match", ref, len(mfstList.Manifests), platforms.Format(platform))
 
 	manifestMatches := filterManifests(mfstList.Manifests, platform)
 


### PR DESCRIPTION
This debug message already includes a full platform string, so this ends up being something like `linux/arm/v7/amd64` in the end result.

> `DEBU[2022-11-01T22:11:13.017477155Z] docker.io/library/alpine:3.16 resolved to a manifestList object with 7 entries; looking for a linux/arm/v5/amd64 match `