### PR TITLE
Remove long-deprecated "arm" fallback

### DIFF
--- a/distribution/pull_v2_unix.go
+++ b/distribution/pull_v2_unix.go
@@ -45,17 +45,6 @@ func filterManifests(manifests []manifestlist.ManifestDescriptor, p specs.Platfo
 		return m.Less(*p1, *p2)
 	})
 
-	// deprecated: backwards compatibility with older versions that didn't compare variant
-	if len(matches) == 0 && p.Architecture == "arm" {
-		p = platforms.Normalize(p)
-		for _, desc := range manifests {
-			if desc.Platform.OS == p.OS && desc.Platform.Architecture == p.Architecture {
-				matches = append(matches, desc)
-				logrus.Debugf("found deprecated partial match for %s with media type %s, digest %s", platforms.Format(p), desc.MediaType, desc.Digest.String())
-			}
-		}
-	}
-
 	return matches
 }
 


### PR DESCRIPTION
This fallback is used when we filter the manifest list by the user-provided platform and find no matches such that we match the previous Docker behavior (before it supported variant matching).  This has been deprecated long enough that I think it's time we finally stop supporting this weird fallback, especially since it makes for buggy behavior like `docker pull --platform linux/arm/v5 alpine:3.16` leading to a `linux/arm/v6` image being pulled (I specified a variant, every manifest list entry specifies a variant, so clearly the only behavior I as a user could reasonably expect is an error that `linux/arm/v5` is not supported, but instead I get an explicitly incompatible image despite doing everything I as a user can to prevent that situation).