### PR TITLE
Fix containerd task deletion after failed start

### DIFF
--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -233,7 +233,9 @@ func (c *container) Start(ctx context.Context, checkpointDir string, withStdin b
 	stdinCloseSync <- t
 
 	if err := t.Start(ctx); err != nil {
-		if _, err := t.Delete(ctx); err != nil {
+		// Only Stopped tasks can be deleted. Created tasks have to be
+		// killed first, to transition them to Stopped.
+		if _, err := t.Delete(ctx, containerd.WithProcessKill); err != nil {
 			c.client.logger.WithError(err).WithField("container", c.c8dCtr.ID()).
 				Error("failed to delete task after fail start")
 		}

--- a/plugin/executor/containerd/containerd.go
+++ b/plugin/executor/containerd/containerd.go
@@ -60,7 +60,7 @@ type c8dPlugin struct {
 // deleteTaskAndContainer deletes plugin task and then plugin container from containerd
 func (p c8dPlugin) deleteTaskAndContainer(ctx context.Context) {
 	if p.tsk != nil {
-		if _, err := p.tsk.Delete(ctx); err != nil && !errdefs.IsNotFound(err) {
+		if err := p.tsk.ForceDelete(ctx); err != nil && !errdefs.IsNotFound(err) {
 			p.log.WithError(err).Error("failed to delete plugin task from containerd")
 		}
 	}


### PR DESCRIPTION
Deleting a containerd task whose status is Created fails with a "precondition failed" error. This is because (aside from Windows) a process is spawned when the task is created, and deleting the task while the process is running would leak the process if it was allowed. libcontainerd and the containerd plugin executor mistakenly try to clean up from a failed start by deleting the created task, which will always fail with the aforementined error. Change them to pass the `WithProcessKill` delete option so the cleanup has a chance to succeed.

**- How to verify it**
Break container start in a way which allows `container.NewTask` to succeed but `task.Start` to fail in a way which does not also kill the container process, such as by breaking the `libnetwork-setkey` prestart hook. Try to run a container and verify that no container processes are leaked.

**- Description for the changelog**
- Fix a situation where, in rare circumstances, cleaning up a failed attempt to start a container could result in a leaked process.

**- A picture of a cute animal (not mandatory but encouraged)**

