### PR TITLE
[22.06 backport] Fix containerd task deletion after failed start

### DIFF
--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -245,7 +245,9 @@ func (c *client) Start(ctx context.Context, id, checkpointDir string, withStdin 
 	close(stdinCloseSync)
 
 	if err := t.Start(ctx); err != nil {
-		if _, err := t.Delete(ctx); err != nil {
+		// Only Stopped tasks can be deleted. Created tasks have to be
+		// killed first, to transition them to Stopped.
+		if _, err := t.Delete(ctx, containerd.WithProcessKill); err != nil {
 			c.logger.WithError(err).WithField("container", id).
 				Error("failed to delete task after fail start")
 		}


### PR DESCRIPTION
- Backport of #44399

Deleting a containerd task whose status is Created fails with a "precondition failed" error. This is because (aside from Windows) a process is spawned when the task is created, and deleting the task while the process is running would leak the process if it was allowed. libcontainerd mistakenly tries to clean up from a failed start by deleting the created task, which will always fail with the aforementioned error. Change it to pass the `WithProcessKill` delete option so the cleanup has a chance to succeed.