### PR TITLE
[22.06 backport] distribution: Error when pulling OCI artifacts

### DIFF
--- a/distribution/errors.go
+++ b/distribution/errors.go
@@ -63,6 +63,19 @@ func (e notFoundError) Cause() error {
 	return e.cause
 }
 
+// unsupportedMediaTypeError is an error issued when attempted
+// to pull unsupported content.
+type unsupportedMediaTypeError struct {
+	MediaType string
+}
+
+func (e unsupportedMediaTypeError) InvalidParameter() {}
+
+// Error returns the error string for unsupportedMediaTypeError.
+func (e unsupportedMediaTypeError) Error() string {
+	return "unsupported media type " + e.MediaType
+}
+
 // translatePullError is used to convert an error from a registry pull
 // operation to an error representing the entire pull operation. Any error
 // information which is not used by the returned error gets output to
@@ -124,6 +137,8 @@ func continueOnError(err error, mirrorEndpoint bool) bool {
 		// Failures from a mirror endpoint should result in fallback to the
 		// canonical repo.
 		return mirrorEndpoint
+	case unsupportedMediaTypeError:
+		return false
 	case error:
 		return !strings.Contains(err.Error(), strings.ToLower(syscall.ESRCH.Error()))
 	}
@@ -153,7 +168,7 @@ func retryOnError(err error) error {
 			return xfer.DoNotRetry{Err: v.Err}
 		}
 		return retryOnError(v.Err)
-	case *client.UnexpectedHTTPResponseError:
+	case *client.UnexpectedHTTPResponseError, unsupportedMediaTypeError:
 		return xfer.DoNotRetry{Err: err}
 	case error:
 		if err == distribution.ErrBlobUnknown {


### PR DESCRIPTION
Backport:
- https://github.com/moby/moby/pull/44367

Currently an attempt to pull a reference which resolves to an OCI artifact (Helm chart for example), results in a bit unrelated error message `invalid rootfs in image configuration`.

This provides a more meaningful error in case a user attempts to download a media type which isn't image related.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

