### PR TITLE
libnetwork: Skip setIPv6 if unavailable

### DIFF
--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -11,12 +11,12 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/docker/docker/libnetwork"
 	"github.com/docker/docker/libnetwork/ipamapi"
 	"github.com/docker/docker/libnetwork/netlabel"
+	"github.com/docker/docker/libnetwork/netutils"
 	"github.com/docker/docker/libnetwork/options"
 	"github.com/docker/docker/libnetwork/osl"
 	"github.com/docker/docker/libnetwork/testutils"
@@ -1123,34 +1123,12 @@ func TestBridge(t *testing.T) {
 		t.Fatalf("Unexpected format for port mapping in endpoint operational data")
 	}
 	expectedLen := 10
-	if !isV6Listenable() {
+	if !netutils.IsV6Listenable() {
 		expectedLen = 5
 	}
 	if len(pm) != expectedLen {
 		t.Fatalf("Incomplete data for port mapping in endpoint operational data: %d", len(pm))
 	}
-}
-
-var (
-	v6ListenableCached bool
-	v6ListenableOnce   sync.Once
-)
-
-// This is copied from the bridge driver package b/c the bridge driver is not platform agnostic.
-func isV6Listenable() bool {
-	v6ListenableOnce.Do(func() {
-		ln, err := net.Listen("tcp6", "[::1]:0")
-		if err != nil {
-			// When the kernel was booted with `ipv6.disable=1`,
-			// we get err "listen tcp6 [::1]:0: socket: address family not supported by protocol"
-			// https://github.com/moby/moby/issues/42288
-			logrus.Debugf("port_mapping: v6Listenable=false (%v)", err)
-		} else {
-			v6ListenableCached = true
-			ln.Close()
-		}
-	})
-	return v6ListenableCached
 }
 
 func TestParallel3(t *testing.T) {

--- a/libnetwork/osl/namespace_linux.go
+++ b/libnetwork/osl/namespace_linux.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/docker/docker/libnetwork/netutils"
 	"github.com/docker/docker/libnetwork/ns"
 	"github.com/docker/docker/libnetwork/osl/kernel"
 	"github.com/docker/docker/libnetwork/types"
@@ -667,6 +668,10 @@ func reexecSetIPv6() {
 }
 
 func setIPv6(path, iface string, enable bool) error {
+	if !netutils.IsV6Listenable() {
+		return nil
+	}
+
 	cmd := &exec.Cmd{
 		Path:   reexec.Self(),
 		Args:   append([]string{"set-ipv6"}, path, iface, strconv.FormatBool(enable)),


### PR DESCRIPTION
**- What I did**
Update libnetwork/osl to skip calls to setIPv6 if IPv6 is disabled in the linux kernel

fixes #34995

**- How I did it**
Refactored IsV6Listenable to libnetwork/netutils

**- How to verify it**
Create a container on a Linux host where IPv6 is disabled via kernel boot option

**- Description for the changelog**
Fix spurious logging of IPv6 messages when IPv6 is disabled


**- A picture of a cute animal (not mandatory but encouraged)**

![Kitty](https://lh3.googleusercontent.com/85Dr_A_nIRIX4dEg4qqE5Fk5OfcTwHNwIbZ0ZW0KbDYt13be1h2126n2cH6DB4twmBnyD6xnxxx50wxAGEznEQEZqegZ_28G9UhuSwK02Lzq7ZB-pKcOz1WHrSQGPmsyZqocnPEiMQ=w284-h378-no)