### PR TITLE
Fix libnetwork `TestParallel` tests

### DIFF
--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -1046,7 +1046,9 @@ func runParallelTests(t *testing.T, thrNumber int) {
 			<-thrdone
 		}
 
-		testns.Close()
+		if testns != origins {
+			testns.Close()
+		}
 		if err := net2.Delete(); err != nil {
 			t.Fatal(err)
 		}

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -36,6 +36,23 @@ var (
 	testns  = netns.None()
 )
 
+var createTesthostNetworkOnce sync.Once
+
+func getTesthostNetwork(t *testing.T) libnetwork.Network {
+	t.Helper()
+	createTesthostNetworkOnce.Do(func() {
+		_, err := createTestNetwork("host", "testhost", options.Generic{}, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	n, err := controller.NetworkByName("testhost")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
 func createGlobalInstance(t *testing.T) {
 	var err error
 	defer close(start)
@@ -60,11 +77,7 @@ func createGlobalInstance(t *testing.T) {
 		},
 	}
 
-	net1, err := controller.NetworkByName("testhost")
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	net1 := getTesthostNetwork(t)
 	net2, err := createTestNetwork("bridge", "network2", netOption, nil, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -124,11 +137,7 @@ func TestHost(t *testing.T) {
 		}
 	}()
 
-	network, err := createTestNetwork("host", "testhost", options.Generic{}, nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	network := getTesthostNetwork(t)
 	ep1, err := network.CreateEndpoint("testep1")
 	if err != nil {
 		t.Fatal(err)
@@ -708,11 +717,7 @@ func TestResolvConfHost(t *testing.T) {
 		}
 	}()
 
-	n, err := controller.NetworkByName("testhost")
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	n := getTesthostNetwork(t)
 	ep1, err := n.CreateEndpoint("ep1", libnetwork.CreateOptionDisableResolution())
 	if err != nil {
 		t.Fatal(err)
@@ -991,10 +996,7 @@ func runParallelTests(t *testing.T, thrNumber int) {
 		}
 	}()
 
-	net1, err := controller.NetworkByName("testhost")
-	if err != nil {
-		t.Fatal(err)
-	}
+	net1 := getTesthostNetwork(t)
 	if net1 == nil {
 		t.Fatal("Could not find testhost")
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I fixed [running the libnetwork unit tests outside of CI.](https://github.com/moby/moby/pull/44356#discussion_r1013815245)
```console
# make BIND_DIR=. TESTFLAGS='-v' TESTDIRS='github.com/docker/docker/libnetwork'  test-unit
...
=== FAIL: libnetwork TestParallel1 (2.51s)
    libnetwork_linux_test.go:988: Error restoring the current thread's netns: bad file descriptor
```

Additionally, I fixed running the `TestParallel` tests in isolation.

**- How I did it**
I stopped the test from closing the handle to the original network namespace, or from depending on `TestHost` to create the `"testhost"` network.

**- How to verify it**
```console
# make TESTDIRS='github.com/docker/docker/libnetwork'  test-unit
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
N/A: unit tests

**- A picture of a cute animal (not mandatory but encouraged)**

