### PR TITLE
[20.10 backport] distribution: Error when pulling OCI artifacts

### DIFF
--- a/distribution/errors.go
+++ b/distribution/errors.go
@@ -87,6 +87,19 @@ func (e notFoundError) Cause() error {
 	return e.cause
 }
 
+// unsupportedMediaTypeError is an error issued when attempted
+// to pull unsupported content.
+type unsupportedMediaTypeError struct {
+	MediaType string
+}
+
+func (e unsupportedMediaTypeError) InvalidParameter() {}
+
+// Error returns the error string for unsupportedMediaTypeError.
+func (e unsupportedMediaTypeError) Error() string {
+	return "unsupported media type " + e.MediaType
+}
+
 // TranslatePullError is used to convert an error from a registry pull
 // operation to an error representing the entire pull operation. Any error
 // information which is not used by the returned error gets output to
@@ -150,6 +163,8 @@ func continueOnError(err error, mirrorEndpoint bool) bool {
 		// Failures from a mirror endpoint should result in fallback to the
 		// canonical repo.
 		return mirrorEndpoint
+	case unsupportedMediaTypeError:
+		return false
 	case error:
 		return !strings.Contains(err.Error(), strings.ToLower(syscall.ESRCH.Error()))
 	}
@@ -179,7 +194,7 @@ func retryOnError(err error) error {
 			return xfer.DoNotRetry{Err: v.Err}
 		}
 		return retryOnError(v.Err)
-	case *client.UnexpectedHTTPResponseError:
+	case *client.UnexpectedHTTPResponseError, unsupportedMediaTypeError:
 		return xfer.DoNotRetry{Err: err}
 	case error:
 		if err == distribution.ErrBlobUnknown {


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44367

Currently an attempt to pull a reference which resolves to an OCI artifact (Helm chart for example), results in a bit unrelated error message `invalid rootfs in image configuration`.

This provides a more meaningful error in case a user attempts to download a media type which isn't image related.

(cherry picked from commit 407e3a455231bcf5b1c3e18a9e682a646b6e96ab)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

