### PR TITLE
[22.06 backport] Revert "validation: temporarily allows changes in integration-cli"

### DIFF
--- a/hack/validate/default
+++ b/hack/validate/default
@@ -14,6 +14,6 @@ SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "${SCRIPTDIR}"/toml
 . "${SCRIPTDIR}"/changelog-well-formed
 . "${SCRIPTDIR}"/changelog-date-descending
-#. "${SCRIPTDIR}"/deprecate-integration-cli
+. "${SCRIPTDIR}"/deprecate-integration-cli
 . "${SCRIPTDIR}"/golangci-lint
 . "${SCRIPTDIR}"/shfmt


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44129

This reverts commit 7ed823ead91938e5cc8de7a42ff93a25abe73e7e.

(cherry picked from commit 9b71a46899d8c80e88c95edc972bb0101d36b1f0)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

