### PR TITLE
correct nullability documentation for ImageSummary

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1838,7 +1838,7 @@ definitions:
           empty if no tags reference the image, in which case the image is
           "untagged", in which case it can still be referenced by its ID.
         type: "array"
-        x-nullable: false
+        x-nullable: true
         items:
           type: "string"
         example:
@@ -1856,7 +1856,7 @@ definitions:
           from a registry, or if the image was pushed to a registry, which is when
           the manifest is generated and its digest calculated.
         type: "array"
-        x-nullable: false
+        x-nullable: true
         items:
           type: "string"
         example:
@@ -1905,7 +1905,7 @@ definitions:
       Labels:
         description: "User-defined key/value metadata."
         type: "object"
-        x-nullable: false
+        x-nullable: true
         additionalProperties:
           type: "string"
         example:


### PR DESCRIPTION
**- What I did**

Looked for the API request produced by image-listing, and flagged three properties which I'm seeing as null in production code as `x-nullable: true` (they were all marked x-nullable: false which appears to be a lie)

**- How I did it**

With vim!

**- How to verify it**

As far as I can tell this is not an unusual circumstance and has been documented since at least #29157, so it's been this way for like 6 years now. You should be able to find many examples on your local if you have `jq` and `curl` installed:

```shell
curl --unix-socket /var/run/docker.sock -H 'Content-Type: application/json' http://localhost/images/json | jq 'map(select(.Labels and .RepoDigests and .RepoTags | not))'
```

**- Description for the changelog**
add documentation for ImageSummary nulls

**- A picture of a cute animal (not mandatory but encouraged)**

![cat which does not exist](https://d2ph5fj80uercy.cloudfront.net/04/cat2329.jpg)