### PR TITLE
image: deprecate IDFromDigest(), and some minor fixes/cleanup

### DIFF
--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -49,7 +49,7 @@ type manifest struct {
 func (i *ImageService) manifestMatchesPlatform(ctx context.Context, img *image.Image, platform specs.Platform) (bool, error) {
 	logger := logrus.WithField("image", img.ID).WithField("desiredPlatform", platforms.Format(platform))
 
-	ls, leaseErr := i.leases.ListResources(ctx, leases.Lease{ID: imageKey(img.ID().Digest())})
+	ls, leaseErr := i.leases.ListResources(ctx, leases.Lease{ID: imageKey(img.ID().String())})
 	if leaseErr != nil {
 		logger.WithError(leaseErr).Error("Error looking up image leases")
 		return false, leaseErr

--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -230,17 +230,15 @@ func (i *ImageService) getImage(ctx context.Context, refOrID string, options ima
 		if !ok {
 			return nil, ErrImageDoesNotExist{ref}
 		}
-		id := image.IDFromDigest(digested.Digest())
-		if img, err := i.imageStore.Get(id); err == nil {
+		if img, err := i.imageStore.Get(image.ID(digested.Digest())); err == nil {
 			return img, nil
 		}
 		return nil, ErrImageDoesNotExist{ref}
 	}
 
-	if digest, err := i.referenceStore.Get(namedRef); err == nil {
+	if dgst, err := i.referenceStore.Get(namedRef); err == nil {
 		// Search the image stores to get the operating system, defaulting to host OS.
-		id := image.IDFromDigest(digest)
-		if img, err := i.imageStore.Get(id); err == nil {
+		if img, err := i.imageStore.Get(image.ID(dgst)); err == nil {
 			return img, nil
 		}
 	}

--- a/daemon/images/image_list.go
+++ b/daemon/images/image_list.go
@@ -2,6 +2,7 @@ package images // import "github.com/docker/docker/daemon/images"
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -132,7 +133,7 @@ func (i *ImageService) Images(ctx context.Context, opts types.ImageListOptions) 
 			if err != nil {
 				// The layer may have been deleted between the call to `Map()` or
 				// `Heads()` and the call to `Get()`, so we just ignore this error
-				if err == layer.ErrLayerDoesNotExist {
+				if errors.Is(err, layer.ErrLayerDoesNotExist) {
 					continue
 				}
 				return nil, err

--- a/daemon/images/store_test.go
+++ b/daemon/images/store_test.go
@@ -68,7 +68,7 @@ func TestImageDelete(t *testing.T) {
 		assert.NilError(t, err)
 		defer images.Delete(id)
 
-		leaseID := imageKey(digest.Digest(id))
+		leaseID := imageKey(id.String())
 		_, err = images.leases.Create(ctx, leases.WithID(leaseID))
 		assert.NilError(t, err)
 		defer images.leases.Delete(ctx, leases.Lease{ID: leaseID})

--- a/daemon/list_test.go
+++ b/daemon/list_test.go
@@ -37,7 +37,7 @@ func setupContainerWithName(t *testing.T, name string, daemon *Daemon) *containe
 	t.Helper()
 	var (
 		id              = uuid.New().String()
-		computedImageID = digest.FromString(id)
+		computedImageID = image.ID(digest.FromString(id))
 		cRoot           = filepath.Join(root, id)
 	)
 	if err := os.MkdirAll(cRoot, 0755); err != nil {
@@ -54,7 +54,7 @@ func setupContainerWithName(t *testing.T, name string, daemon *Daemon) *containe
 	c.HostConfig = &containertypes.HostConfig{}
 
 	// these are for passing the refreshImage reducer
-	c.ImageID = image.IDFromDigest(computedImageID)
+	c.ImageID = computedImageID
 	c.Config = &containertypes.Config{
 		Image: computedImageID.String(),
 	}

--- a/distribution/config.go
+++ b/distribution/config.go
@@ -118,7 +118,7 @@ func (s *imageConfigStore) Put(_ context.Context, c []byte) (digest.Digest, erro
 }
 
 func (s *imageConfigStore) Get(_ context.Context, d digest.Digest) ([]byte, error) {
-	img, err := s.Store.Get(image.IDFromDigest(d))
+	img, err := s.Store.Get(image.ID(d))
 	if err != nil {
 		return nil, err
 	}

--- a/image/image.go
+++ b/image/image.go
@@ -28,6 +28,8 @@ func (id ID) Digest() digest.Digest {
 }
 
 // IDFromDigest creates an ID from a digest
+//
+// Deprecated: cast to an ID using ID(digest).
 func IDFromDigest(digest digest.Digest) ID {
 	return ID(digest)
 }

--- a/image/store.go
+++ b/image/store.go
@@ -88,7 +88,7 @@ func (is *store) restore() error {
 			}
 			l, err = is.lss.Get(chainID)
 			if err != nil {
-				if err == layer.ErrLayerDoesNotExist {
+				if errors.Is(err, layer.ErrLayerDoesNotExist) {
 					logrus.WithFields(f{"chainID": chainID, "os": img.OperatingSystem(), "err": err}).Error("not restoring image")
 					return nil
 				}

--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -94,8 +94,7 @@ func (l *tarexporter) parseNames(names []string) (desc map[image.ID]*imageDescri
 		if !ok {
 			// Check if digest ID reference
 			if digested, ok := ref.(reference.Digested); ok {
-				id := image.IDFromDigest(digested.Digest())
-				if err := addAssoc(id, nil); err != nil {
+				if err := addAssoc(image.ID(digested.Digest()), nil); err != nil {
 					return nil, err
 				}
 				continue
@@ -116,7 +115,7 @@ func (l *tarexporter) parseNames(names []string) (desc map[image.ID]*imageDescri
 		if reference.IsNameOnly(namedRef) {
 			assocs := l.rs.ReferencesByName(namedRef)
 			for _, assoc := range assocs {
-				if err := addAssoc(image.IDFromDigest(assoc.ID), assoc.Ref); err != nil {
+				if err := addAssoc(image.ID(assoc.ID), assoc.Ref); err != nil {
 					return nil, err
 				}
 			}
@@ -135,7 +134,7 @@ func (l *tarexporter) parseNames(names []string) (desc map[image.ID]*imageDescri
 		if err != nil {
 			return nil, err
 		}
-		if err := addAssoc(image.IDFromDigest(id), namedRef); err != nil {
+		if err := addAssoc(image.ID(id), namedRef); err != nil {
 			return nil, err
 		}
 	}

--- a/layer/layer_test.go
+++ b/layer/layer_test.go
@@ -2,6 +2,7 @@ package layer // import "github.com/docker/docker/layer"
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -397,7 +398,7 @@ func TestStoreRestore(t *testing.T) {
 	// Create again with same name, should return error
 	if _, err := ls2.CreateRWLayer("some-mount_name", layer3b.ChainID(), nil); err == nil {
 		t.Fatal("Expected error creating mount with same name")
-	} else if err != ErrMountNameConflict {
+	} else if !errors.Is(err, ErrMountNameConflict) {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Having this function hides what it's doing, which is just to type-cast to an image.ID (which is a digest). Using a cast is more transparent, so deprecating this function in favor of a regular typecast.

I'm looking at potentially making this type a straight alias for digest.Digest (and possibly sunsetting it)
