### PR TITLE
restore behaviour of allocator.insertBitMask which returned a fully used up set.

### DIFF
--- a/libnetwork/ipam/allocator.go
+++ b/libnetwork/ipam/allocator.go
@@ -348,6 +348,11 @@ func (a *Allocator) insertBitMask(key SubnetKey, pool *net.IPNet) error {
 		return err
 	}
 
+	// /32 "subnets" dont exist
+	if ipVer == v4 && numAddresses == 1 {
+		h.Set(0)
+	}
+
 	// Pre-reserve the network address on IPv4 networks large
 	// enough to have one (i.e., anything bigger than a /31.
 	if !(ipVer == v4 && numAddresses <= 2) {


### PR DESCRIPTION
- relates to / introduced in https://github.com/moby/moby/pull/42626
- Required for moby/swarmkit https://github.com/moby/swarmkit/issues/3081/ https://github.com/moby/swarmkit/issues/3083

Signed-off-by: Martin Braun <braun@neuroforge.de>

**- What I did**

Restored old behaviour of insertBitMask for calls with 1.1.1.1/32

**- How I did it**

see https://github.com/moby/swarmkit/pull/3083

**- How to verify it**

...

**- Description for the changelog**

Restored old behaviour of insertBitMask for calls with 1.1.1.1/32 in libnetworkd

