### PR TITLE
Fix grammar in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Moby is an open project guided by strong principles, aiming to be modular, flexi
 It is open to the community to help set its direction.
 
 - Modular: the project includes lots of components that have well-defined functions and APIs that work together.
-- Batteries included but swappable: Moby includes enough components to build fully featured container system, but its modular architecture ensures that most of the components can be swapped by different implementations.
+- Batteries included but swappable: Moby includes enough components to build fully featured container systems, but its modular architecture ensures that most of the components can be swapped by different implementations.
 - Usable security: Moby provides secure defaults without compromising usability.
 - Developer focused: The APIs are intended to be functional and useful to build powerful tools.
 They are not necessarily intended as end user tools but as components aimed at developers.


### PR DESCRIPTION
Not sure how I never noticed this before. Correction to the grammar in one sentence. Arguably due to the `but`, the sentence could read better starting "Not only does Moby include enough....", or changing `but` to `and` instead as another option. However, I didn't get the greatest score in English growing up 😇.

(Cough.... brushing off my very rusty git skills, I'm sure I've probably messed up CF vs CR/LF or similar....)

Signed-off-by: John Howard <john@lowenna.com>