### PR TITLE
[22.06 backport] ci(actions): migrate to file-based commands

### DIFF
--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -231,7 +231,7 @@ jobs:
           # Also prepend ./... to the matrix. This is a special case to run "Test integration" step exclusively.
           matrix="$(gotestlist -d ${{ env.ITG_CLI_MATRIX_SIZE }} ./...)"
           matrix="$(echo "$matrix" | jq -c '. |= ["./..."] + .')"
-          echo "::set-output name=matrix::$matrix"
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
       -
         name: Show matrix
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,10 @@ jobs:
           fetch-depth: 0
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       -
         name: Build
-        uses: docker/bake-action@v1
+        uses: docker/bake-action@v2
         with:
           targets: ${{ matrix.target }}
       -
@@ -84,17 +84,17 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       -
         name: Build
-        uses: docker/bake-action@v1
+        uses: docker/bake-action@v2
         with:
           targets: cross
         env:
           DOCKER_CROSSPLATFORMS: ${{ matrix.platform }}
       -
         name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: cross-${{ env.PLATFORM_PAIR }}
           path: ${{ env.BUNDLES_OUTPUT }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
         id: scripts
         run: |
           scripts=$(jq -ncR '[inputs]' <<< "$(ls -I .validate -I all -I default -I dco -I golangci-lint.yml -I yamllint.yaml -A ./hack/validate/)")
-          echo "::set-output name=matrix::$scripts"
+          echo "matrix=$scripts" >> $GITHUB_OUTPUT
       -
         name: Show matrix
         run: |
@@ -403,7 +403,7 @@ jobs:
           # Also prepend ./... to the matrix. This is a special case to run "Test integration" step exclusively.
           matrix="$(gotestlist -d ${{ env.ITG_CLI_MATRIX_SIZE }} ./...)"
           matrix="$(echo "$matrix" | jq -c '. |= ["./..."] + .')"
-          echo "::set-output name=matrix::$matrix"
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
       -
         name: Show matrix
         run: |


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44444

**- What I did**
Use the new `$GITHUB_STATE` and `$GITHUB_OUTPUT` file-based command systems instead of the deprecated commands on stdout.

Likewise, bump versions in Linux actions CI to pick up new releases of actions with the same fix.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
