### PR TITLE
validate/vendor: always tidy

### DIFF
--- a/hack/go-mod-prepare.sh
+++ b/hack/go-mod-prepare.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 
-ROOTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+set -e
 
-cat > "${ROOTDIR}/go.mod" << EOF
+SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOTDIR="$(git -C "$SCRIPTDIR" rev-parse --show-toplevel)"
+
+set -x
+
+tee "${ROOTDIR}/go.mod" << EOF
 module github.com/docker/docker
 
 go 1.18

--- a/hack/validate/vendor
+++ b/hack/validate/vendor
@@ -24,25 +24,26 @@ validate_vendor_diff() {
 		# check if any files have changed
 		git diff --quiet HEAD -- "${vendor_files[@]}"
 	else
-		echo >&2 'No vendor changes in diff; skipping vendor check.'
+		echo >&2 'INFO: no vendor changes in diff; skipping vendor check.'
 	fi
 }
 
 validate_vendor_license() {
-	for f in $(mawk '$1 = "#" { print $2 }' 'vendor/modules.txt'); do
-		if [ -d "vendor/$f" ]; then
-			if ! echo "vendor/$f"/* | grep -qiEc '/(LICENSE|COPYING)'; then
-				echo >&2 "WARNING: could not find copyright information for $f"
-			fi
+	while IFS= read -r module; do
+		test -d "vendor/$module" || continue
+		if ! compgen -G "vendor/$module/*" | grep -qEi '/(LICENSE|COPYING)[^/]*$'; then
+			echo >&2 "WARNING: could not find copyright information for $module"
 		fi
-	done
+	done < <(awk '/^# /{ print $2 }' vendor/modules.txt)
 }
 
 if validate_vendor_tidy && validate_vendor_diff && validate_vendor_license; then
-	echo >&2 'Vendoring has been performed correctly!'
+	echo >&2 'PASS: Vendoring has been performed correctly!'
 else
 	{
-		echo 'Vendoring was not performed correctly; the following files changed during re-vendor:'
+		echo 'FAIL: Vendoring was not performed correctly!'
+		echo
+		echo 'The following files changed during re-vendor:'
 		echo
 		git diff --name-status HEAD -- "${vendor_files[@]}"
 		echo

--- a/hack/validate/vendor
+++ b/hack/validate/vendor
@@ -1,53 +1,54 @@
 #!/usr/bin/env bash
 
+set -e
+
 SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPTDIR}/.validate"
 
+tidy_files=('vendor.mod' 'vendor.sum')
+vendor_files=("${tidy_files[@]}" 'vendor/')
+
+validate_vendor_tidy() {
+	# run mod tidy
+	./hack/vendor.sh tidy
+	# check if any files have changed
+	git diff --quiet HEAD -- "${tidy_files[@]}"
+}
+
 validate_vendor_diff() {
-	IFS=$'\n'
-	check_files=('vendor.sum' 'vendor.mod' 'vendor/')
-	# shellcheck disable=SC2207
-	changed_files=($(validate_diff --diff-filter=ACMR --name-only -- "${check_files[@]}" || true))
-	unset IFS
+	mapfile -t changed_files < <(validate_diff --diff-filter=ACMR --name-only -- "${vendor_files[@]}")
 
 	if [ -n "${TEST_FORCE_VALIDATE:-}" ] || [ "${#changed_files[@]}" -gt 0 ]; then
 		# recreate vendor/
-		./hack/vendor.sh
+		./hack/vendor.sh vendor
 		# check if any files have changed
-		diffs="$(git status --porcelain -- "${check_files[@]}" 2> /dev/null)"
-		mfiles="$(echo "$diffs" | awk '/^ M / {print $2}')"
-		if [ "$diffs" ]; then
-			{
-				echo 'The result of go mod vendor differs'
-				echo
-				echo "$diffs"
-				echo
-				echo 'Please vendor your package with hack/vendor.sh.'
-				echo
-				if [ -n "$mfiles" ]; then
-					git diff -- "$mfiles"
-				fi
-			} >&2
-			false
-		else
-			echo 'Congratulations! All vendoring changes are done the right way.'
-		fi
+		git diff --quiet HEAD -- "${vendor_files[@]}"
 	else
-		echo 'No vendor changes in diff.'
+		echo >&2 'No vendor changes in diff; skipping vendor check.'
 	fi
 }
 
-# 1. make sure all the vendored packages are used
-# 2. make sure all the packages contain license information (just warning, because it can cause false-positive)
-validate_vendor_used() {
+validate_vendor_license() {
 	for f in $(mawk '$1 = "#" { print $2 }' 'vendor/modules.txt'); do
 		if [ -d "vendor/$f" ]; then
 			if ! echo "vendor/$f"/* | grep -qiEc '/(LICENSE|COPYING)'; then
-				echo "WARNING: could not find copyright information for $f"
+				echo >&2 "WARNING: could not find copyright information for $f"
 			fi
 		fi
 	done
 }
 
-validate_vendor_diff
-validate_vendor_used
+if validate_vendor_tidy && validate_vendor_diff && validate_vendor_license; then
+	echo >&2 'Vendoring has been performed correctly!'
+else
+	{
+		echo 'Vendoring was not performed correctly; the following files changed during re-vendor:'
+		echo
+		git diff --name-status HEAD -- "${vendor_files[@]}"
+		echo
+		echo 'Please revendor with hack/vendor.sh'
+		echo
+		git diff --diff-filter=M -- "${vendor_files[@]}"
+	} >&2
+	exit 1
+fi

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -1,14 +1,37 @@
 #!/usr/bin/env bash
-
-# This file is just wrapper around 'go mod vendor' tool.
+#
+# This file is just a wrapper around the 'go mod vendor' tool.
 # For updating dependencies you should change `vendor.mod` file in root of the
 # project.
 
 set -e
-set -x
 
 SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 "${SCRIPTDIR}"/go-mod-prepare.sh
 
-GO111MODULE=auto go mod tidy -modfile 'vendor.mod' -compat 1.18
-GO111MODULE=auto go mod vendor -modfile vendor.mod
+export GO111MODULE=on
+
+tidy() (
+		set -x
+		go mod tidy -modfile vendor.mod -compat 1.18
+)
+
+vendor() (
+		set -x
+		go mod vendor -modfile vendor.mod
+)
+
+help() {
+	printf "%s:\n" "$(basename "$0")"
+	echo "  - tidy: run go mod tidy"
+	echo "  - vendor: run go mod vendor"
+	echo "  - all: run tidy && vendor"
+	echo "  - help: show this help"
+}
+
+case "$1" in
+	tidy) tidy ;;
+	vendor) vendor ;;
+	""|all) tidy && vendor ;;
+	*) help ;;
+esac


### PR DESCRIPTION
**- What I did**
Prevent #44453 or similar by always running `go mod tidy` when checking vendoring.

**- How I did it**
Allow running individual steps in `hack/vendor.sh` while still using it as the exclusive wrapper for `go mod` by introducing 'subcommands'; the default behavior is identical to the previous (which is now aliased as the `all` subcommand).

Make `hack/validate/vendor` take advantage of these split steps, and refactor it to be more robust against whitespace/follow bash best practices.

**- How to verify it**
Manually; revert #44453 locally to test tidy detection, and commit a modification to a vendored file to test re-vendor detection.

**- Description for the changelog**
N/A

**- A picture of a cute animal (not mandatory but encouraged)**
![](https://cdn.discordapp.com/attachments/704333319697072231/1041724104077750373/78191E84-9FF7-4BE8-9F2D-D94EEEAA48FA.jpg)

