### PR TITLE
ignorefiles: cleanup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,4 @@
 .git
-.go-pkg-cache
-.gopath
-bundles
+bundles/
 cli/winresources/**/winres.json
 cli/winresources/**/*.syso
-vendor/pkg

--- a/.gitignore
+++ b/.gitignore
@@ -1,27 +1,30 @@
-# Docker project generated files to ignore
-#  if you want to ignore files created by your editor/tools,
-#  please consider a global .gitignore https://help.github.com/articles/ignoring-files
-*.exe
-*.exe~
-*.gz
+# If you want to ignore files created by your editor/tools, please consider a
+# [global .gitignore](https://help.github.com/articles/ignoring-files).
+
+*~
+*.bak
 *.orig
-test.main
 .*.swp
 .DS_Store
-# a .bashrc may be added to customize the build environment
+thumbs.db
+
+# local repository customization
+.envrc
 .bashrc
 .editorconfig
-.gopath/
-.go-pkg-cache/
-bundles/
-cli/winresources/**/winres.json
-cli/winresources/**/*.syso
-cmd/dockerd/dockerd
-contrib/builder/rpm/*/changelog
-vendor/pkg/
-go-test-report.json
-profile.out
-junit-report.xml
 
 # top-level go.mod is not meant to be checked in
 /go.mod
+# build artifacts
+bundles/
+cli/winresources/*/*.syso
+cli/winresources/*/winres.json
+contrib/builder/rpm/*/changelog
+
+# ci artifacts
+*.exe
+*.gz
+go-test-report.json
+junit-report.xml
+profile.out
+test.main


### PR DESCRIPTION
**- What I did**
Clean up .gitignore based on current tooling/usage of the project.

`.gopath` has been removed; however, I believe that power users who prefer a GOPATH (vs. go mod) based IDE integration are better served by a GOPATH outside the project tree; local ignores can still be established in `.git/info/exclude` as well.
