### PR TITLE
[20.10] vendor: github.com/moby/libnetwork dcdf8f176d1e13ad719e913e796fb698d846de98

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-: "${LIBNETWORK_COMMIT:=0dde5c895075df6e3630e76f750a447cf63f4789}"
+: "${LIBNETWORK_COMMIT:=dcdf8f176d1e13ad719e913e796fb698d846de98}"
 
 install_proxy() {
 	case "$1" in
@@ -29,7 +29,7 @@ install_proxy_dynamic() {
 
 _install_proxy() {
 	echo "Install docker-proxy version $LIBNETWORK_COMMIT"
-	git clone https://github.com/docker/libnetwork.git "$GOPATH/src/github.com/docker/libnetwork"
+	git clone https://github.com/moby/libnetwork.git "$GOPATH/src/github.com/docker/libnetwork"
 	cd "$GOPATH/src/github.com/docker/libnetwork"
 	git checkout -q "$LIBNETWORK_COMMIT"
 	go build ${BUILD_MODE} -ldflags="$PROXY_LDFLAGS" -o ${PREFIX}/docker-proxy github.com/docker/libnetwork/cmd/proxy

--- a/vendor.conf
+++ b/vendor.conf
@@ -48,7 +48,7 @@ github.com/grpc-ecosystem/go-grpc-middleware        3c51f7f332123e8be5a157c0802a
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        0dde5c895075df6e3630e76f750a447cf63f4789
+github.com/docker/libnetwork                        dcdf8f176d1e13ad719e913e796fb698d846de98
 github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         f0300d1749da6fa982027e449ec0c7a145510c3c # v0.4.1

--- a/vendor/github.com/docker/libnetwork/README.md
+++ b/vendor/github.com/docker/libnetwork/README.md
@@ -1,3 +1,12 @@
+> **Warning**
+> libnetwork was moved to https://github.com/moby/moby/tree/master/libnetwork
+>
+> libnetwork has been merged to the main repo of Moby since Docker 22.06.
+>
+> The old libnetwork repo (https://github.com/moby/libnetwork) now only accepts PR for Docker 20.10,
+> and will be archived after the EOL of Docker 20.10.
+
+- - -
 # libnetwork - networking for containers
 
 [![Circle CI](https://circleci.com/gh/docker/libnetwork/tree/master.svg?style=svg)](https://circleci.com/gh/docker/libnetwork/tree/master) [![Coverage Status](https://coveralls.io/repos/docker/libnetwork/badge.svg)](https://coveralls.io/r/docker/libnetwork) [![GoDoc](https://godoc.org/github.com/docker/libnetwork?status.svg)](https://godoc.org/github.com/docker/libnetwork) [![Go Report Card](https://goreportcard.com/badge/github.com/docker/libnetwork)](https://goreportcard.com/report/github.com/docker/libnetwork)

--- a/vendor/github.com/docker/libnetwork/config/config.go
+++ b/vendor/github.com/docker/libnetwork/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -14,7 +13,6 @@ import (
 	"github.com/docker/libnetwork/ipamutils"
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/osl"
-	"github.com/docker/libnetwork/portallocator"
 	"github.com/sirupsen/logrus"
 )
 
@@ -237,23 +235,6 @@ func OptionExperimental(exp bool) Option {
 	return func(c *Config) {
 		logrus.Debugf("Option Experimental: %v", exp)
 		c.Daemon.Experimental = exp
-	}
-}
-
-// OptionDynamicPortRange function returns an option setter for service port allocation range
-func OptionDynamicPortRange(in string) Option {
-	return func(c *Config) {
-		start, end := 0, 0
-		if len(in) > 0 {
-			n, err := fmt.Sscanf(in, "%d-%d", &start, &end)
-			if n != 2 || err != nil {
-				logrus.Errorf("Failed to parse range string with err %v", err)
-				return
-			}
-		}
-		if err := portallocator.Get().SetPortRange(start, end); err != nil {
-			logrus.Errorf("Failed to set port range with err %v", err)
-		}
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Scott Buckfelder <buckscot@amazon.com>

Issue : [#44423](https://github.com/moby/moby/issues/44423)
fixes https://github.com/moby/moby/issues/43054

Merges in commit https://github.com/moby/libnetwork/pull/2668 which is a backport of functionality.

**Note For Reviewers** :  I also updated the _hack/dockerfile/install/proxy.installer_ file to now reference moby/libnetwork as opposed to docker/libnetwork.  I'm not terribly confident this was the correct thing to do.