### PR TITLE
[22.06 backport] update gotestsum to v1.8.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -210,7 +210,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
      && /build/golangci-lint --version
 
 FROM base AS gotestsum
-ARG GOTESTSUM_VERSION=v1.8.1
+ARG GOTESTSUM_VERSION=v1.8.2
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
         GOBIN=/build/ GO111MODULE=on go install "gotest.tools/gotestsum@${GOTESTSUM_VERSION}" \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -166,7 +166,7 @@ FROM microsoft/windowsservercore
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG GO_VERSION=1.19.3
-ARG GOTESTSUM_VERSION=v1.8.1
+ARG GOTESTSUM_VERSION=v1.8.2
 ARG GOWINRES_VERSION=v0.2.3
 ARG CONTAINERD_VERSION=v1.6.10
 


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44485

release notes: https://github.com/gotestyourself/gotestsum/releases/tag/v1.8.2

- Show shuffle seed
- Update tests, and cleanup formats
- Update dependencies
- Test against go1.19, remove go1.15
- Add project name to junit.xml output
- Adding in support for s390x and ppc64le

full diff: https://github.com/gotestyourself/gotestsum/compare/v1.8.1...v1.8.2

(cherry picked from commit 882ddf4b1616dfb6eef054556d25efbacfe62101)

