### PR TITLE
windows: daemon: allow pulling/running of newer images under Hyper-V.

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -78,8 +78,9 @@ func (daemon *Daemon) containerCreate(ctx context.Context, daemonCfg *configStor
 		return containertypes.CreateResponse{Warnings: warnings}, errdefs.InvalidParameter(err)
 	}
 
+	var img *image.Image
 	if opts.params.Platform == nil && opts.params.Config.Image != "" {
-		img, err := daemon.imageService.GetImage(ctx, opts.params.Config.Image, imagetypes.GetImageOpts{Platform: opts.params.Platform})
+		img, err = daemon.imageService.GetImage(ctx, opts.params.Config.Image, imagetypes.GetImageOpts{Platform: opts.params.Platform})
 		if err != nil {
 			return containertypes.CreateResponse{}, err
 		}
@@ -106,6 +107,11 @@ func (daemon *Daemon) containerCreate(ctx context.Context, daemonCfg *configStor
 		opts.params.HostConfig = &containertypes.HostConfig{}
 	}
 	err = daemon.adaptContainerSettings(&daemonCfg.Config, opts.params.HostConfig, opts.params.AdjustCPUShares)
+	if err != nil {
+		return containertypes.CreateResponse{Warnings: warnings}, errdefs.InvalidParameter(err)
+	}
+
+	err = daemon.checkImageIsolationCompatiblity(opts.params.HostConfig, img)
 	if err != nil {
 		return containertypes.CreateResponse{Warnings: warnings}, errdefs.InvalidParameter(err)
 	}

--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -12,6 +12,7 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 	mounttypes "github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/image"
 	"github.com/docker/docker/oci"
 	volumeopts "github.com/docker/docker/volume/service/opts"
 	"github.com/opencontainers/selinux/go-selinux/label"
@@ -90,5 +91,12 @@ func (daemon *Daemon) populateVolumes(c *container.Container) error {
 			return err
 		}
 	}
+	return nil
+}
+
+// checkImageIsolationCompatiblity checks whether the provided image is compatible
+// with the host config's isolation settings.
+// This is currently only used for determining image compatiblity on Windows.
+func (daemon *Daemon) checkImageIsolationCompatiblity(hostConfig *containertypes.HostConfig, img *image.Image) error {
 	return nil
 }

--- a/daemon/create_windows.go
+++ b/daemon/create_windows.go
@@ -3,11 +3,16 @@ package daemon // import "github.com/docker/docker/daemon"
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
+	"github.com/Microsoft/hcsshim/osversion"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/image"
 	volumemounts "github.com/docker/docker/volume/mounts"
 	volumeopts "github.com/docker/docker/volume/service/opts"
+	"github.com/sirupsen/logrus"
 )
 
 // createContainerOSSpecificSettings performs host-OS specific container create functionality
@@ -73,4 +78,67 @@ func (daemon *Daemon) createContainerOSSpecificSettings(container *container.Con
 		container.AddMountPointWithVolume(mp.Destination, &volumeWrapper{v: v, s: daemon.volumes}, mp.RW)
 	}
 	return nil
+}
+
+// checkImageIsolationCompatiblity checks whether the provided image is compatible
+// with the host config's isolation settings.
+func (daemon *Daemon) checkImageIsolationCompatiblity(hostConfig *containertypes.HostConfig, img *image.Image) error {
+	hostOSV := osversion.Get()
+	isHyperV := hostConfig.Isolation.IsHyperV()
+	// fallback on default daemon isolation if none was explicitly provided:
+	if hostConfig.Isolation.IsDefault() {
+		isHyperV = daemon.defaultIsolation.IsHyperV()
+	}
+	return checkImageCompatibilityForHostIsolation(hostOSV, img.OSVersion, isHyperV)
+}
+
+// checkImageCompatibilityForHostIsolation checks whether the provided `imageOSVersion`
+// should be able to run on the provided host OS version given Hyper-V isolation.
+// Its contained logic can be distilled into:
+// - if imageOS == hostOS => can run under any isolation mode
+// - if imageOS < hostOS => must be run under Hyper-V
+// - if imageOS > hostOS => can be run under Hyper-V only on an RS5 (1809+) host
+// Please see the below:
+// https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility?tabs=windows-server-2016%2Cwindows-10#windows-server-host-os-compatibility
+func checkImageCompatibilityForHostIsolation(hostOSV osversion.OSVersion, imageOSVersion string, isHyperV bool) error {
+	var err error
+	var imageOSBuildU64 uint64
+	splitImageOSVersion := strings.Split(imageOSVersion, ".") // eg 10.0.16299.nnnn
+	if len(splitImageOSVersion) >= 3 {
+		if imageOSBuildU64, err = strconv.ParseUint(splitImageOSVersion[2], 10, 16); err == nil {
+			logrus.Debugf("parsed Windows build number %d from image OS version %s", imageOSBuildU64, imageOSVersion)
+		} else {
+			return fmt.Errorf("failed to ParseUint() Windows image build %q from image version %q: %s", splitImageOSVersion[2], imageOSVersion, err)
+		}
+	} else {
+		return fmt.Errorf("failed to split and parse Windows image version %q (was expecting format like '10.0.16299.nnnn')", imageOSVersion)
+	}
+	truncatedImageOSVersion := fmt.Sprintf("%s.%s.%s", splitImageOSVersion[0], splitImageOSVersion[1], splitImageOSVersion[2])
+
+	imageOSBuild := uint16(imageOSBuildU64)
+	if imageOSBuild == hostOSV.Build {
+		// same image version should run on identically-versioned host regardless of isolation:
+		logrus.Debugf("image version %s is trivially compatible with host version %s", truncatedImageOSVersion, hostOSV.ToString())
+		return nil
+	} else if imageOSBuild < hostOSV.Build {
+		// images older than the host must be run under Hyper-V:
+		if isHyperV {
+			logrus.Debugf("older image version %s is compatible with host version %s under Hyper-V", truncatedImageOSVersion, hostOSV.ToString())
+			return nil
+		} else {
+			return fmt.Errorf("an older Windows version %s-based image can only be run on a %s host using Hyper-V isolation", truncatedImageOSVersion, hostOSV.ToString())
+		}
+	} else {
+		// images newer than the host can only run if the host is RS5 and is using Hyper-V:
+		if hostOSV.Build < osversion.RS5 {
+			return fmt.Errorf("a Windows version %s-based image is incompatible with a %s host", truncatedImageOSVersion, hostOSV.ToString())
+		} else {
+			if isHyperV {
+				logrus.Debugf("newer Windows image version %s is compatible with host version %s under Hyper-V", truncatedImageOSVersion, hostOSV.ToString())
+				return nil
+			} else {
+				return fmt.Errorf("a newer Windows version %s-based image can only be run on a %s host using Hyper-V isolation", truncatedImageOSVersion, hostOSV.ToString())
+			}
+		}
+	}
 }

--- a/daemon/create_windows_test.go
+++ b/daemon/create_windows_test.go
@@ -1,0 +1,88 @@
+package daemon
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Microsoft/hcsshim/osversion"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestCheckImageCompatibilityForHostIsolation(t *testing.T) {
+	testCases := []struct {
+		hostBuildNo    uint16
+		imageBuildNo   uint16
+		isHyperV       bool
+		expectedErrMsg string
+	}{
+		// coincinding build numbers are valid regardless of isolation:
+		{
+			hostBuildNo:    osversion.RS1,
+			imageBuildNo:   osversion.RS1,
+			isHyperV:       false,
+			expectedErrMsg: "",
+		},
+		{
+			hostBuildNo:    osversion.RS1,
+			imageBuildNo:   osversion.RS1,
+			isHyperV:       true,
+			expectedErrMsg: "",
+		},
+		// images older than the host must be run using Hyper-V:
+		{
+			hostBuildNo:    osversion.RS2,
+			imageBuildNo:   osversion.RS1,
+			isHyperV:       false,
+			expectedErrMsg: "an older Windows version .*-based image can only be run on a .* host using Hyper-V isolation",
+		},
+		{
+			hostBuildNo:    osversion.RS2,
+			imageBuildNo:   osversion.RS1,
+			isHyperV:       true,
+			expectedErrMsg: "",
+		},
+		// images newer than the host can not run prior to host version RS5:
+		{
+			hostBuildNo:    osversion.RS4,
+			imageBuildNo:   osversion.RS5,
+			isHyperV:       false,
+			expectedErrMsg: "a Windows version .*-based image is incompatible with a .* host",
+		},
+		{
+			hostBuildNo:    osversion.RS4,
+			imageBuildNo:   osversion.RS5,
+			isHyperV:       true,
+			expectedErrMsg: "a Windows version .*-based image is incompatible with a .* host",
+		},
+		// images newer than an RS5+ host can only run using Hyper-V:
+		{
+			hostBuildNo:    osversion.RS5,
+			imageBuildNo:   osversion.V21H2Server, // ltsc2022
+			isHyperV:       false,
+			expectedErrMsg: "a newer Windows version .*-based image can only be run on a .* host using Hyper-V isolation",
+		},
+		{
+			hostBuildNo:    osversion.RS5,
+			imageBuildNo:   osversion.V21H2Server,
+			isHyperV:       true,
+			expectedErrMsg: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		hostVersion := osversion.OSVersion{
+			Version:      0,
+			MajorVersion: 0,
+			MinorVersion: 0,
+			Build:        testCase.hostBuildNo,
+		}
+		imageOSVersion := fmt.Sprintf("10.0.%d", testCase.imageBuildNo)
+		err := checkImageCompatibilityForHostIsolation(hostVersion, imageOSVersion, testCase.isHyperV)
+		if testCase.expectedErrMsg == "" {
+			assert.NilError(t, err)
+		} else {
+			assert.Check(t, is.Regexp(testCase.expectedErrMsg, err.Error()))
+		}
+	}
+}


### PR DESCRIPTION
Following the addition of Hyper-V isolation, it should be possible for Windows hosts to run container images with older/newer OS versions given a Windows host with the RS5 updates and above.

This patch includes the following changes:
- [distribution/pull_v2] enable pulling images newer than the host on RS5+
- [daemon/create] add version checks which prevent running newer/older unless using Hyper-V isolation

Previously, pulling a Windows image with a newer OS version than the host was prevented by moby#36327, whose behavior is preserved on pre-RS5 hosts.

Signed-off-by: Nashwan Azhari <nazhari@cloudbasesolutions.com>