### PR TITLE
[DNM] hack: keep sockets out of the bundles directory

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -147,21 +147,21 @@ main() {
 
 	if [ -z "${KEEPBUNDLE-}" ]; then
 		echo "Removing ${bundle_dir}/"
-		rm -rf "${bundle_dir}"/*
+		rm -rf "${bundle_dir:?}"/*
 		echo
 	fi
 	mkdir -p "${bundle_dir}"
 
 	if [ $# -lt 1 ]; then
-		bundles=(${DEFAULT_BUNDLES[@]})
+		bundles=("${DEFAULT_BUNDLES[@]}")
 	else
-		bundles=($@)
+		bundles=("$@")
 	fi
-	for bundle in ${bundles[@]}; do
 		export DEST="${bundle_dir}/$(basename "$bundle")"
+	for bundle in "${bundles[@]}"; do
 		# Cygdrive paths don't play well with go build -o.
 		if [[ "$(uname -s)" == CYGWIN* ]]; then
-			export DEST="$(cygpath -mw "$DEST")"
+			DEST="$(cygpath -mw "$DEST")"
 		fi
 		mkdir -p "$DEST"
 		ABS_DEST="$(cd "$DEST" && pwd -P)"

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -157,14 +157,18 @@ main() {
 	else
 		bundles=("$@")
 	fi
-		export DEST="${bundle_dir}/$(basename "$bundle")"
 	for bundle in "${bundles[@]}"; do
+		DEST="${bundle_dir}/$(basename "$bundle")"
 		# Cygdrive paths don't play well with go build -o.
 		if [[ "$(uname -s)" == CYGWIN* ]]; then
 			DEST="$(cygpath -mw "$DEST")"
 		fi
 		mkdir -p "$DEST"
+		export DEST
+
 		ABS_DEST="$(cd "$DEST" && pwd -P)"
+		export ABS_DEST
+
 		bundle "$bundle"
 		echo
 	done

--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -74,6 +74,9 @@ if [ -f "/sys/fs/cgroup/cgroup.controllers" ]; then
 	fi
 fi
 
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
 if [ -n "$DOCKER_ROOTLESS" ]; then
 	if [ -z "$TEST_SKIP_INTEGRATION_CLI" ]; then
 		echo >&2 '# DOCKER_ROOTLESS requires TEST_SKIP_INTEGRATION_CLI to be set'
@@ -83,7 +86,7 @@ if [ -n "$DOCKER_ROOTLESS" ]; then
 	uid=$(id -u $user)
 	# shellcheck disable=SC2174
 	mkdir -p -m 700 "/tmp/docker-${uid}"
-	chown "$user" "/tmp/docker-${uid}"
+	chown -R "$user" "/tmp/docker-${uid}" "$tmp_dir"
 	chmod -R o+w "$DEST"
 	dockerd="sudo -u $user -E -E XDG_RUNTIME_DIR=/tmp/docker-${uid} -E HOME=/home/${user} -E PATH=$PATH -- dockerd-rootless.sh"
 fi
@@ -100,8 +103,7 @@ if [ -z "$DOCKER_TEST_HOST" ]; then
 		)
 	fi
 
-	# "pwd" tricks to make sure $DEST is an absolute path, not a relative one
-	export DOCKER_HOST="unix://$(cd "$DEST" && pwd)/docker.sock"
+	export DOCKER_HOST="unix://${tmp_dir}/docker.sock"
 	(
 		echo "Starting dockerd"
 		[ -n "$TESTDEBUG" ] && set -x
@@ -109,11 +111,11 @@ if [ -z "$DOCKER_TEST_HOST" ]; then
 			${dockerd} --debug \
 			--host "$DOCKER_HOST" \
 			--storage-driver "$DOCKER_GRAPHDRIVER" \
-			--pidfile "$DEST/docker.pid" \
+			--pidfile "${DEST}/docker.pid" \
 			--userland-proxy="$DOCKER_USERLANDPROXY" \
 			${storage_params} \
 			${extra_params} \
-			&> "$DEST/docker.log"
+			&> "${DEST}/docker.log"
 	) &
 else
 	export DOCKER_HOST="$DOCKER_TEST_HOST"

--- a/hack/make/.integration-daemon-stop
+++ b/hack/make/.integration-daemon-stop
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ ! "$(go env GOOS)" = 'windows' ]; then
-	for pidFile in $(find "$DEST" -name docker.pid); do
+	while IFS= read -r pidFile; do
 		pid=$(
 			[ -n "$TESTDEBUG" ] && set -x
 			cat "$pidFile"
@@ -17,7 +17,7 @@ if [ ! "$(go env GOOS)" = 'windows' ]; then
 		if [ -d "$root" ]; then
 			umount "$root" || true
 		fi
-	done
+	done < <(find "$DEST" -name docker.pid)
 
 	if [ -z "$DOCKER_TEST_HOST" ]; then
 		# Stop apparmor if it is enabled


### PR DESCRIPTION
**- What I did**
Move sockets out of the `bundles/` directory so that integration tests can run under Docker Desktop on macOS with virtiofs enabled.

**- How I did it**

A little bit of a kludge -- we make a new temporary directory and `chown` it if we're in rootless mode. This isn't great, but the script as a whole needs cleanup, and it's simpler to add this now and clean it later, instead of reviewing a refactor along with this behavior change.

**- How to verify it**
`make test-integration` should fail in new and exciting ways under DD for macOS, related to the tests themselves instead of starting the daemon.
