### PR TITLE
libnetwork: eliminate almost all reexecs

### DIFF
--- a/libnetwork/network_windows.go
+++ b/libnetwork/network_windows.go
@@ -50,7 +50,7 @@ func (n *network) startResolver() {
 		for _, subnet := range hnsresponse.Subnets {
 			if subnet.GatewayAddress != "" {
 				for i := 0; i < 3; i++ {
-					resolver := NewResolver(subnet.GatewayAddress, false, "", n)
+					resolver := NewResolver(subnet.GatewayAddress, false, n)
 					logrus.Debugf("Binding a resolver on network %s gateway %s", n.Name(), subnet.GatewayAddress)
 					executeInCompartment(hnsresponse.DNSServerCompartment, resolver.SetupFunc(53))
 

--- a/libnetwork/resolver.go
+++ b/libnetwork/resolver.go
@@ -90,7 +90,6 @@ type resolver struct {
 	queryLock     sync.Mutex
 	listenAddress string
 	proxyDNS      bool
-	resolverKey   string
 	startCh       chan struct{}
 }
 
@@ -99,12 +98,11 @@ func init() {
 }
 
 // NewResolver creates a new instance of the Resolver
-func NewResolver(address string, proxyDNS bool, resolverKey string, backend DNSBackend) Resolver {
+func NewResolver(address string, proxyDNS bool, backend DNSBackend) Resolver {
 	return &resolver{
 		backend:       backend,
 		proxyDNS:      proxyDNS,
 		listenAddress: address,
-		resolverKey:   resolverKey,
 		err:           fmt.Errorf("setup not done yet"),
 		startCh:       make(chan struct{}, 1),
 	}

--- a/libnetwork/resolver_test.go
+++ b/libnetwork/resolver_test.go
@@ -122,7 +122,7 @@ func TestDNSIPQuery(t *testing.T) {
 
 	w := new(tstwriter)
 	// the unit tests right now will focus on non-proxyed DNS requests
-	r := NewResolver(resolverIPSandbox, false, sb.Key(), sb.(*sandbox))
+	r := NewResolver(resolverIPSandbox, false, sb.(*sandbox))
 
 	// test name1's IP is resolved correctly with the default A type query
 	// Also make sure DNS lookups are case insensitive
@@ -266,7 +266,7 @@ func TestDNSProxyServFail(t *testing.T) {
 	t.Log("DNS Server can be reached")
 
 	w := new(tstwriter)
-	r := NewResolver(resolverIPSandbox, true, sb.Key(), sb.(*sandbox))
+	r := NewResolver(resolverIPSandbox, true, sb.(*sandbox))
 	q := new(dns.Msg)
 	q.SetQuestion("name1.", dns.TypeA)
 

--- a/libnetwork/resolver_unix.go
+++ b/libnetwork/resolver_unix.go
@@ -4,21 +4,11 @@
 package libnetwork
 
 import (
-	"fmt"
 	"net"
-	"os"
-	"os/exec"
-	"runtime"
 
 	"github.com/docker/docker/libnetwork/iptables"
-	"github.com/docker/docker/pkg/reexec"
 	"github.com/sirupsen/logrus"
-	"github.com/vishvananda/netns"
 )
-
-func init() {
-	reexec.Register("setup-resolver", reexecSetupResolver)
-}
 
 const (
 	// outputChain used for docker embed dns
@@ -27,79 +17,46 @@ const (
 	postroutingchain = "DOCKER_POSTROUTING"
 )
 
-func reexecSetupResolver() {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
-	if len(os.Args) < 4 {
-		logrus.Error("invalid number of arguments..")
-		os.Exit(1)
-	}
-
-	resolverIP, ipPort, _ := net.SplitHostPort(os.Args[2])
-	_, tcpPort, _ := net.SplitHostPort(os.Args[3])
-	rules := [][]string{
-		{"-t", "nat", "-I", outputChain, "-d", resolverIP, "-p", "udp", "--dport", dnsPort, "-j", "DNAT", "--to-destination", os.Args[2]},
-		{"-t", "nat", "-I", postroutingchain, "-s", resolverIP, "-p", "udp", "--sport", ipPort, "-j", "SNAT", "--to-source", ":" + dnsPort},
-		{"-t", "nat", "-I", outputChain, "-d", resolverIP, "-p", "tcp", "--dport", dnsPort, "-j", "DNAT", "--to-destination", os.Args[3]},
-		{"-t", "nat", "-I", postroutingchain, "-s", resolverIP, "-p", "tcp", "--sport", tcpPort, "-j", "SNAT", "--to-source", ":" + dnsPort},
-	}
-
-	f, err := os.OpenFile(os.Args[1], os.O_RDONLY, 0)
-	if err != nil {
-		logrus.Errorf("failed get network namespace %q: %v", os.Args[1], err)
-		os.Exit(2)
-	}
-	defer f.Close() //nolint:gosec
-
-	nsFD := f.Fd()
-	if err = netns.Set(netns.NsHandle(nsFD)); err != nil {
-		logrus.Errorf("setting into container net ns %v failed, %v", os.Args[1], err)
-		os.Exit(3)
-	}
-
-	// TODO IPv6 support
-	iptable := iptables.GetIptable(iptables.IPv4)
-
-	// insert outputChain and postroutingchain
-	err = iptable.RawCombinedOutputNative("-t", "nat", "-C", "OUTPUT", "-d", resolverIP, "-j", outputChain)
-	if err == nil {
-		iptable.RawCombinedOutputNative("-t", "nat", "-F", outputChain)
-	} else {
-		iptable.RawCombinedOutputNative("-t", "nat", "-N", outputChain)
-		iptable.RawCombinedOutputNative("-t", "nat", "-I", "OUTPUT", "-d", resolverIP, "-j", outputChain)
-	}
-
-	err = iptable.RawCombinedOutputNative("-t", "nat", "-C", "POSTROUTING", "-d", resolverIP, "-j", postroutingchain)
-	if err == nil {
-		iptable.RawCombinedOutputNative("-t", "nat", "-F", postroutingchain)
-	} else {
-		iptable.RawCombinedOutputNative("-t", "nat", "-N", postroutingchain)
-		iptable.RawCombinedOutputNative("-t", "nat", "-I", "POSTROUTING", "-d", resolverIP, "-j", postroutingchain)
-	}
-
-	for _, rule := range rules {
-		if iptable.RawCombinedOutputNative(rule...) != nil {
-			logrus.Errorf("set up rule failed, %v", rule)
-		}
-	}
-}
-
 func (r *resolver) setupIPTable() error {
 	if r.err != nil {
 		return r.err
 	}
 	laddr := r.conn.LocalAddr().String()
 	ltcpaddr := r.tcpListen.Addr().String()
+	resolverIP, ipPort, _ := net.SplitHostPort(laddr)
+	_, tcpPort, _ := net.SplitHostPort(ltcpaddr)
+	rules := [][]string{
+		{"-t", "nat", "-I", outputChain, "-d", resolverIP, "-p", "udp", "--dport", dnsPort, "-j", "DNAT", "--to-destination", laddr},
+		{"-t", "nat", "-I", postroutingchain, "-s", resolverIP, "-p", "udp", "--sport", ipPort, "-j", "SNAT", "--to-source", ":" + dnsPort},
+		{"-t", "nat", "-I", outputChain, "-d", resolverIP, "-p", "tcp", "--dport", dnsPort, "-j", "DNAT", "--to-destination", ltcpaddr},
+		{"-t", "nat", "-I", postroutingchain, "-s", resolverIP, "-p", "tcp", "--sport", tcpPort, "-j", "SNAT", "--to-source", ":" + dnsPort},
+	}
 
-	cmd := &exec.Cmd{
-		Path:   reexec.Self(),
-		Args:   append([]string{"setup-resolver"}, r.resolverKey, laddr, ltcpaddr),
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
-	}
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("reexec failed: %v", err)
-	}
-	return nil
+	return r.backend.ExecFunc(func() {
+		// TODO IPv6 support
+		iptable := iptables.GetIptable(iptables.IPv4)
+
+		// insert outputChain and postroutingchain
+		err := iptable.RawCombinedOutputNative("-t", "nat", "-C", "OUTPUT", "-d", resolverIP, "-j", outputChain)
+		if err == nil {
+			iptable.RawCombinedOutputNative("-t", "nat", "-F", outputChain)
+		} else {
+			iptable.RawCombinedOutputNative("-t", "nat", "-N", outputChain)
+			iptable.RawCombinedOutputNative("-t", "nat", "-I", "OUTPUT", "-d", resolverIP, "-j", outputChain)
+		}
+
+		err = iptable.RawCombinedOutputNative("-t", "nat", "-C", "POSTROUTING", "-d", resolverIP, "-j", postroutingchain)
+		if err == nil {
+			iptable.RawCombinedOutputNative("-t", "nat", "-F", postroutingchain)
+		} else {
+			iptable.RawCombinedOutputNative("-t", "nat", "-N", postroutingchain)
+			iptable.RawCombinedOutputNative("-t", "nat", "-I", "POSTROUTING", "-d", resolverIP, "-j", postroutingchain)
+		}
+
+		for _, rule := range rules {
+			if iptable.RawCombinedOutputNative(rule...) != nil {
+				logrus.Errorf("set up rule failed, %v", rule)
+			}
+		}
+	})
 }

--- a/libnetwork/sandbox_dns_unix.go
+++ b/libnetwork/sandbox_dns_unix.go
@@ -27,7 +27,7 @@ const (
 func (sb *sandbox) startResolver(restore bool) {
 	sb.resolverOnce.Do(func() {
 		var err error
-		sb.resolver = NewResolver(resolverIPSandbox, true, sb.Key(), sb)
+		sb.resolver = NewResolver(resolverIPSandbox, true, sb)
 		defer func() {
 			if err != nil {
 				sb.resolver = nil


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Excised every reexec in libnetwork aside from the one called from an OCI prestart hook.
* Work to drop the OCI hook is happening in #44385

**- How I did it**
`runtime.LockOSThread()` + setns.

**- How to verify it**
CI.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
N/A. Refactoring.

**- A picture of a cute animal (not mandatory but encouraged)**

