### PR TITLE
[22.06 backport] update github.com/tc-hib/go-winres v0.3.0 to fix schema version in manifest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -183,7 +183,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM base AS gowinres
 # GOWINRES_VERSION defines go-winres tool version
-ARG GOWINRES_VERSION=v0.2.3
+ARG GOWINRES_VERSION=v0.3.0
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
         GOBIN=/build/ GO111MODULE=on go install "github.com/tc-hib/go-winres@${GOWINRES_VERSION}" \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -167,7 +167,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ARG GO_VERSION=1.19.3
 ARG GOTESTSUM_VERSION=v1.8.2
-ARG GOWINRES_VERSION=v0.2.3
+ARG GOWINRES_VERSION=v0.3.0
 ARG CONTAINERD_VERSION=v1.6.10
 
 # Environment variable notes:


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44486

- Fix xml schema version in manifest
- Provide more verbose error on failed git tag resolution

full diffs:

- https://github.com/tc-hib/go-winres/compare/v0.2.3...v0.3.0
- https://github.com/tc-hib/winres/compare/v0.1.5...v0.1.6

(cherry picked from commit ca807edac0d6a91997c4cfb39394084510ad5741)

