### PR TITLE
Dockerfile: remove hardcoded platforms for vpnkit stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -289,13 +289,18 @@ RUN --mount=type=tmpfs,target=/tmp/crun-build \
     ./configure --bindir=/build && \
     make -j install
 
-FROM --platform=amd64 djs55/vpnkit:${VPNKIT_VERSION} AS vpnkit-amd64
-
-FROM --platform=arm64 djs55/vpnkit:${VPNKIT_VERSION} AS vpnkit-arm64
-
-FROM scratch AS vpnkit
-COPY --from=vpnkit-amd64 /vpnkit /build/vpnkit.x86_64
-COPY --from=vpnkit-arm64 /vpnkit /build/vpnkit.aarch64
+# vpnkit
+# use dummy scratch stage to avoid build to fail for unsupported platforms
+FROM scratch AS vpnkit-windows
+FROM scratch AS vpnkit-linux-386
+FROM scratch AS vpnkit-linux-arm
+FROM scratch AS vpnkit-linux-ppc64le
+FROM scratch AS vpnkit-linux-riscv64
+FROM scratch AS vpnkit-linux-s390x
+FROM djs55/vpnkit:${VPNKIT_VERSION} AS vpnkit-linux-amd64
+FROM djs55/vpnkit:${VPNKIT_VERSION} AS vpnkit-linux-arm64
+FROM vpnkit-linux-${TARGETARCH} AS vpnkit-linux
+FROM vpnkit-${TARGETOS} AS vpnkit
 
 # TODO: Some of this is only really needed for testing, it would be nice to split this up
 FROM runtime-dev AS dev-systemd-false
@@ -369,7 +374,7 @@ COPY --from=shfmt         /build/ /usr/local/bin/
 COPY --from=runc          /build/ /usr/local/bin/
 COPY --from=containerd    /build/ /usr/local/bin/
 COPY --from=rootlesskit   /build/ /usr/local/bin/
-COPY --from=vpnkit        /build/ /usr/local/bin/
+COPY --from=vpnkit        /       /usr/local/bin/
 COPY --from=crun          /build/ /usr/local/bin/
 COPY hack/dockerfile/etc/docker/  /etc/docker/
 ENV PATH=/usr/local/cli:$PATH
@@ -416,7 +421,7 @@ COPY --from=tini          /build/ /usr/local/bin/
 COPY --from=runc          /build/ /usr/local/bin/
 COPY --from=containerd    /build/ /usr/local/bin/
 COPY --from=rootlesskit   /build/ /usr/local/bin/
-COPY --from=vpnkit        /build/ /usr/local/bin/
+COPY --from=vpnkit        /       /usr/local/bin/
 COPY --from=gowinres      /build/ /usr/local/bin/
 WORKDIR /go/src/github.com/docker/docker
 

--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -79,7 +79,6 @@ if [ -n "$DOCKER_ROOTLESS" ]; then
 		echo >&2 '# DOCKER_ROOTLESS requires TEST_SKIP_INTEGRATION_CLI to be set'
 		exit 1
 	fi
-	ln -sf "$(command -v vpnkit."$(uname -m)")" /usr/local/bin/vpnkit
 	user="unprivilegeduser"
 	uid=$(id -u $user)
 	# shellcheck disable=SC2174

--- a/hack/make/binary-daemon
+++ b/hack/make/binary-daemon
@@ -17,10 +17,10 @@ copy_binaries() {
 	for file in containerd containerd-shim-runc-v2 ctr runc docker-init rootlesskit rootlesskit-docker-proxy dockerd-rootless.sh dockerd-rootless-setuptool.sh; do
 		cp -f "$(command -v "$file")" "$dir/"
 	done
-
-	# vpnkit is available for x86_64 and aarch64
-	if command -v "vpnkit.$(uname -m)" 2>&1 > /dev/null; then
-		cp -f "$(command -v "vpnkit.$(uname -m)")" "$dir/vpnkit"
+	# vpnkit might not be available for the target platform, see vpnkit stage in
+	# the Dockerfile for more information.
+	if command -v vpnkit > /dev/null 2>&1; then
+		cp -f "$(command -v vpnkit)" "$dir/"
 	fi
 }
 


### PR DESCRIPTION
As discussed, start splitting https://github.com/moby/moby/pull/43529 into several PRs to ease peer review.

___

Current Dockerfile downloads vpnkit for both linux/amd64 and linux/arm64 platforms even if target platform does not match. This change will download vpnkit only if target platform matches.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>