### PR TITLE
hack: remove obsolete sources for go-autogen

### DIFF
--- a/hack/make/.go-autogen
+++ b/hack/make/.go-autogen
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-source hack/dockerfile/install/runc.installer
-source hack/dockerfile/install/tini.installer
-source hack/dockerfile/install/containerd.installer
-
 LDFLAGS="${LDFLAGS} \
 	-X \"github.com/docker/docker/dockerversion.Version=${VERSION}\" \
 	-X \"github.com/docker/docker/dockerversion.GitCommit=${GITCOMMIT}\" \


### PR DESCRIPTION
follow-up #43529 

This change was introduced in https://github.com/moby/moby/pull/36336 and is not required anymore.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>