### PR TITLE
re-enable TestCheckpoint

### DIFF
--- a/integration/container/checkpoint_test.go
+++ b/integration/container/checkpoint_test.go
@@ -30,7 +30,6 @@ func containerExec(t *testing.T, client client.APIClient, cID string, cmd []stri
 }
 
 func TestCheckpoint(t *testing.T) {
-	t.Skip("TestCheckpoint is broken; see https://github.com/moby/moby/issues/38963")
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, !testEnv.DaemonInfo.ExperimentalBuild)
 


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/38984
- relates to https://github.com/moby/moby/issues/38963
- relates to https://github.com/moby/moby/pull/44086

Let's see if it's still broken (if we build and install CRIU for a test we don't run ... )

This reverts commit 23fec5025dacbfef7a1c497147c7c0ff0dcb729f.

**- A picture of a cute animal (not mandatory but encouraged)**

