### PR TITLE
vendor: github.com/moby/term v0.0.0-20221120202655-abb19827d345

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -62,7 +62,7 @@ require (
 	github.com/moby/sys/sequential v0.5.0
 	github.com/moby/sys/signal v0.7.0
 	github.com/moby/sys/symlink v0.2.0
-	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6
+	github.com/moby/term v0.0.0-20221120202655-abb19827d345
 	github.com/morikuni/aec v1.0.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.3-0.20220303224323-02efb9a75ee1

--- a/vendor.sum
+++ b/vendor.sum
@@ -783,8 +783,8 @@ github.com/moby/sys/symlink v0.2.0 h1:tk1rOM+Ljp0nFmfOIBtlV3rTDlWOwFRhjEeAhZB0nZ
 github.com/moby/sys/symlink v0.2.0/go.mod h1:7uZVF2dqJjG/NsClqul95CqKOBRQyYSNnJ6BMgR/gFs=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
 github.com/moby/term v0.0.0-20210610120745-9d4ed1856297/go.mod h1:vgPCkQMyxTZ7IDy8SXRufE172gr8+K/JE/7hHFxHW3A=
-github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 h1:dcztxKSvZ4Id8iPpHERQBbIJfabdt4wUm5qy3wOL2Zc=
-github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6/go.mod h1:E2VnQOmVuvZB6UYnnDB0qG5Nq/1tD9acaOpo6xmt0Kw=
+github.com/moby/term v0.0.0-20221120202655-abb19827d345 h1:J9c53/kxIH+2nTKBEfZYFMlhghtHpIHSXpm5VRGHSnU=
+github.com/moby/term v0.0.0-20221120202655-abb19827d345/go.mod h1:15ce4BGCFxt7I5NQKT+HV0yEDxmf6fSysfEDiVo3zFM=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=

--- a/vendor/github.com/moby/term/tc.go
+++ b/vendor/github.com/moby/term/tc.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package term

--- a/vendor/github.com/moby/term/term.go
+++ b/vendor/github.com/moby/term/term.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 // Package term provides structures and helper functions to work with
@@ -14,10 +15,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var (
-	// ErrInvalidState is returned if the state of the terminal is invalid.
-	ErrInvalidState = errors.New("Invalid terminal state")
-)
+// ErrInvalidState is returned if the state of the terminal is invalid.
+var ErrInvalidState = errors.New("Invalid terminal state")
 
 // State represents the state of the terminal.
 type State struct {

--- a/vendor/github.com/moby/term/term_windows.go
+++ b/vendor/github.com/moby/term/term_windows.go
@@ -66,10 +66,6 @@ func StdStreams() (stdIn io.ReadCloser, stdOut, stdErr io.Writer) {
 		}
 	}
 
-	// Temporarily use STD_INPUT_HANDLE, STD_OUTPUT_HANDLE and
-	// STD_ERROR_HANDLE from syscall rather than x/sys/windows as long as
-	// go-ansiterm hasn't switch to x/sys/windows.
-	// TODO: switch back to x/sys/windows once go-ansiterm has switched
 	if emulateStdin {
 		h := uint32(windows.STD_INPUT_HANDLE)
 		stdIn = windowsconsole.NewAnsiReader(int(h))

--- a/vendor/github.com/moby/term/termios.go
+++ b/vendor/github.com/moby/term/termios.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package term

--- a/vendor/github.com/moby/term/termios_bsd.go
+++ b/vendor/github.com/moby/term/termios_bsd.go
@@ -1,3 +1,4 @@
+//go:build darwin || freebsd || openbsd || netbsd
 // +build darwin freebsd openbsd netbsd
 
 package term

--- a/vendor/github.com/moby/term/termios_nonbsd.go
+++ b/vendor/github.com/moby/term/termios_nonbsd.go
@@ -1,4 +1,5 @@
-//+build !darwin,!freebsd,!netbsd,!openbsd,!windows
+//go:build !darwin && !freebsd && !netbsd && !openbsd && !windows
+// +build !darwin,!freebsd,!netbsd,!openbsd,!windows
 
 package term
 

--- a/vendor/github.com/moby/term/windows/ansi_reader.go
+++ b/vendor/github.com/moby/term/windows/ansi_reader.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package windowsconsole
@@ -190,7 +191,6 @@ func keyToString(keyEvent *winterm.KEY_EVENT_RECORD, escapeSequence []byte) stri
 		// <Ctrl>-S  Suspends printing on the screen (does not stop the program).
 		// <Ctrl>-U  Deletes all characters on the current line. Also called the KILL key.
 		// <Ctrl>-E  Quits current command and creates a core
-
 	}
 
 	// <Alt>+Key generates ESC N Key

--- a/vendor/github.com/moby/term/windows/ansi_writer.go
+++ b/vendor/github.com/moby/term/windows/ansi_writer.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package windowsconsole

--- a/vendor/github.com/moby/term/windows/console.go
+++ b/vendor/github.com/moby/term/windows/console.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package windowsconsole

--- a/vendor/github.com/moby/term/winsize.go
+++ b/vendor/github.com/moby/term/winsize.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package term

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -683,8 +683,8 @@ github.com/moby/sys/signal
 # github.com/moby/sys/symlink v0.2.0
 ## explicit; go 1.16
 github.com/moby/sys/symlink
-# github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6
-## explicit; go 1.13
+# github.com/moby/term v0.0.0-20221120202655-abb19827d345
+## explicit; go 1.18
 github.com/moby/term
 github.com/moby/term/windows
 # github.com/morikuni/aec v1.0.0


### PR DESCRIPTION
no significant changes in vendored code, other than updating build-tags for go1.17, but removes some dependencies from the module, which can help with future updates;

full diff: https://github.com/moby/term/compare/3f7ff695adc6...abb19827d345664b1f8d301092abf7c33bd7461e


**- A picture of a cute animal (not mandatory but encouraged)**

