### PR TITLE
api/server/backend/build: sanitizeRepoAndTags() check for digest

### DIFF
--- a/api/server/backend/build/tag.go
+++ b/api/server/backend/build/tag.go
@@ -21,14 +21,10 @@ func tagImages(ic ImageComponent, stdout io.Writer, imageID image.ID, repoAndTag
 }
 
 // sanitizeRepoAndTags parses the raw "t" parameter received from the client
-// to a slice of repoAndTag.
-// It also validates each repoName and tag.
-func sanitizeRepoAndTags(names []string) ([]reference.Named, error) {
-	var (
-		repoAndTags []reference.Named
-		// This map is used for deduplicating the "-t" parameter.
-		uniqNames = make(map[string]struct{})
-	)
+// to a slice of repoAndTag. It removes duplicates, and validates each name
+// to not contain a digest.
+func sanitizeRepoAndTags(names []string) (repoAndTags []reference.Named, err error) {
+	uniqNames := map[string]struct{}{}
 	for _, repo := range names {
 		if repo == "" {
 			continue
@@ -39,14 +35,12 @@ func sanitizeRepoAndTags(names []string) ([]reference.Named, error) {
 			return nil, err
 		}
 
-		if _, isCanonical := ref.(reference.Canonical); isCanonical {
+		if _, ok := ref.(reference.Digested); ok {
 			return nil, errors.New("build tag cannot contain a digest")
 		}
 
 		ref = reference.TagNameOnly(ref)
-
 		nameWithTag := ref.String()
-
 		if _, exists := uniqNames[nameWithTag]; !exists {
 			uniqNames[nameWithTag] = struct{}{}
 			repoAndTags = append(repoAndTags, ref)


### PR DESCRIPTION
The reference.ParseNormalizedNamed() utility already returns a Named reference, but we're interested in wether the digest has a digest, so check for that.


**- A picture of a cute animal (not mandatory but encouraged)**

