### PR TITLE
Dockerfile: use TARGETPLATFORM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,13 @@ ARG DEBIAN_FRONTEND=noninteractive
 # cross compilation helper
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 
+# dummy stage to make sure the image is built for deps that don't support some
+# architectures
+FROM --platform=$BUILDPLATFORM busybox AS build-dummy
+RUN mkdir -p /build
+FROM scratch AS binary-dummy
+COPY --from=build-dummy /build /build
+
 # base
 FROM --platform=$BUILDPLATFORM ${GOLANG_IMAGE} AS base
 COPY --from=xx / /

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ARG VPNKIT_VERSION=0.5.0
 ARG CROSS="false"
 ARG SYSTEMD="false"
 ARG DEBIAN_FRONTEND=noninteractive
+ARG DOCKER_STATIC=1
 
 # cross compilation helper
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx

--- a/Dockerfile
+++ b/Dockerfile
@@ -451,6 +451,31 @@ FROM djs55/vpnkit:${VPNKIT_VERSION} AS vpnkit-linux-arm64
 FROM vpnkit-linux-${TARGETARCH} AS vpnkit-linux
 FROM vpnkit-${TARGETOS} AS vpnkit
 
+# containerutility
+FROM base AS containerutil-src
+WORKDIR /usr/src/containerutil
+RUN git init . && git remote add origin "https://github.com/docker-archive/windows-container-utility.git"
+ARG CONTAINERUTILITY_VERSION=aa1ba87e99b68e0113bd27ec26c60b88f9d4ccd9
+RUN git fetch -q --depth 1 origin "${CONTAINERUTILITY_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
+
+FROM base AS containerutil-build
+WORKDIR /usr/src/containerutil
+ARG TARGETPLATFORM
+RUN xx-apt-get install -y --no-install-recommends gcc g++ libc6-dev
+RUN --mount=from=containerutil-src,src=/usr/src/containerutil,rw \
+    --mount=type=cache,target=/root/.cache/go-build,id=containerutil-build-$TARGETPLATFORM <<EOT
+  set -e
+  CC="$(xx-info)-gcc" CXX="$(xx-info)-g++" make
+  xx-verify --static containerutility.exe
+  mkdir /build
+  mv containerutility.exe /build/
+EOT
+
+FROM binary-dummy AS containerutil-linux
+FROM containerutil-build AS containerutil-windows-amd64
+FROM containerutil-windows-${TARGETARCH} AS containerutil-windows
+FROM containerutil-${TARGETOS} AS containerutil
+
 # TODO: Some of this is only really needed for testing, it would be nice to split this up
 FROM runtime-dev AS dev-systemd-false
 ARG DEBIAN_FRONTEND
@@ -524,6 +549,7 @@ COPY --from=runc          /build/ /usr/local/bin/
 COPY --from=containerd    /build/ /usr/local/bin/
 COPY --from=rootlesskit   /build/ /usr/local/bin/
 COPY --from=vpnkit        /       /usr/local/bin/
+COPY --from=containerutil /build/ /usr/local/bin/
 COPY --from=crun          /build/ /usr/local/bin/
 COPY hack/dockerfile/etc/docker/  /etc/docker/
 ENV PATH=/usr/local/cli:$PATH
@@ -571,6 +597,7 @@ COPY --from=runc          /build/ /usr/local/bin/
 COPY --from=containerd    /build/ /usr/local/bin/
 COPY --from=rootlesskit   /build/ /usr/local/bin/
 COPY --from=vpnkit        /       /usr/local/bin/
+COPY --from=containerutil /build/ /usr/local/bin/
 COPY --from=gowinres      /build/ /usr/local/bin/
 WORKDIR /go/src/github.com/docker/docker
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,6 +1,9 @@
 variable "BUNDLES_OUTPUT" {
   default = "./bundles"
 }
+variable "DOCKER_STATIC" {
+  default = "1"
+}
 variable "DOCKER_CROSSPLATFORMS" {
   default = ""
 }
@@ -9,6 +12,7 @@ target "_common" {
   args = {
     BUILDKIT_CONTEXT_KEEP_GIT_DIR = 1
     APT_MIRROR = "cdn-fastly.deb.debian.org"
+    DOCKER_STATIC = DOCKER_STATIC
   }
 }
 


### PR DESCRIPTION
follow-up https://github.com/moby/moby/pull/43529

Prepare next follow-ups to properly handle cross compilation using `TARGETPLATFORM` global arg.

This will optimize build for each components as it doesn't depend anymore on `dev-base` stage with hardcoded `linux/amd64` platform which installs cross packages for all platforms for cross compilation:

https://github.com/moby/moby/blob/d6d0e4c9427eb0d5632daa398a716c103eb0bdd2/Dockerfile#L133-L149

In follow-up remove `CROSS` and `DOCKER_CROSSPLATFORMS` arg and cross stages in Dockerfile. It also needs changes in hack scripts.

cc @rumpl @vvoland @thaJeztah