### PR TITLE
client/list: Handle SharedSize

### DIFF
--- a/client/image_list.go
+++ b/client/image_list.go
@@ -34,6 +34,9 @@ func (cli *Client) ImageList(ctx context.Context, options types.ImageListOptions
 	if options.All {
 		query.Set("all", "1")
 	}
+	if options.SharedSize && versions.GreaterThanOrEqualTo(cli.version, "1.42") {
+		query.Set("shared-size", "1")
+	}
 
 	serverResp, err := cli.get(ctx, "/images/json", query, nil)
 	defer ensureReaderClosed(serverResp)

--- a/client/image_list_test.go
+++ b/client/image_list_test.go
@@ -7,12 +7,15 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestImageListError(t *testing.T) {
@@ -156,5 +159,43 @@ func TestImageListApiBefore125(t *testing.T) {
 	}
 	if len(images) != 2 {
 		t.Fatalf("expected 2 images, got %v", images)
+	}
+}
+
+// Checks if shared-size query parameter is set/not being set correctly
+// for /images/json.
+func TestImageListWithSharedSize(t *testing.T) {
+	t.Parallel()
+	const sharedSize = "shared-size"
+	for _, tc := range []struct {
+		name       string
+		version    string
+		options    types.ImageListOptions
+		sharedSize string // expected value for the shared-size query param, or empty if it should not be set.
+	}{
+		{name: "unset after 1.42, no options set", version: "1.42"},
+		{name: "set after 1.42, if requested", version: "1.42", options: types.ImageListOptions{SharedSize: true}, sharedSize: "1"},
+		{name: "unset before 1.42, even if requested", version: "1.41", options: types.ImageListOptions{SharedSize: true}},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var query url.Values
+			client := &Client{
+				client: newMockClient(func(req *http.Request) (*http.Response, error) {
+					query = req.URL.Query()
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader("[]")),
+					}, nil
+				}),
+				version: tc.version,
+			}
+			_, err := client.ImageList(context.Background(), tc.options)
+			assert.Check(t, err)
+			expectedSet := tc.sharedSize != ""
+			assert.Check(t, is.Equal(query.Has(sharedSize), expectedSet))
+			assert.Check(t, is.Equal(query.Get(sharedSize), tc.sharedSize))
+		})
 	}
 }


### PR DESCRIPTION
Related to:
- https://github.com/moby/moby/pull/42531

SharedSize support was introduced in API version 1.42. This field was added to the options struct, but client wasn't adjusted.

**- What I did**
Make it possible for client to call `/images/json` with SharedSize enabled.

**- How I did it**
~Pressing buttons on a keyboard.~ Made `ImageList` add `shared-size=1` to the url query when caller sets the `SharedSize` option.

**- How to verify it**
`go test -run TestImageListWithSharedSize -v`

**- Description for the changelog**
client: Respect `SharedSize` option

**- A picture of a cute animal (not mandatory but encouraged)**

