### PR TITLE
[22.06 backport] hack: remove obsolete sources for go-autogen

### DIFF
--- a/hack/make/.go-autogen
+++ b/hack/make/.go-autogen
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-source hack/dockerfile/install/runc.installer
-source hack/dockerfile/install/tini.installer
-source hack/dockerfile/install/containerd.installer
-
 LDFLAGS="${LDFLAGS} \
 	-X \"github.com/docker/docker/dockerversion.Version=${VERSION}\" \
 	-X \"github.com/docker/docker/dockerversion.GitCommit=${GITCOMMIT}\" \


### PR DESCRIPTION
* backport of #44494

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>
(cherry picked from commit 40069797efc18fd070299accb32fb840e8366c0c)