### PR TITLE
builder: handle host-gateway with extra hosts

### DIFF
--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/libnetwork"
+	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/go-units"
@@ -81,6 +82,7 @@ type Opt struct {
 // Builder can build using BuildKit backend
 type Builder struct {
 	controller     *control.Controller
+	dnsconfig      config.DNSConfig
 	reqBodyHandler *reqBodyHandler
 
 	mu   sync.Mutex
@@ -97,6 +99,7 @@ func New(opt Opt) (*Builder, error) {
 	}
 	b := &Builder{
 		controller:     c,
+		dnsconfig:      opt.DNSConfig,
 		reqBodyHandler: reqHandler,
 		jobs:           map[string]*buildJob{},
 	}
@@ -311,7 +314,7 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 		return nil, errors.Errorf("network mode %q not supported by buildkit", opt.Options.NetworkMode)
 	}
 
-	extraHosts, err := toBuildkitExtraHosts(opt.Options.ExtraHosts)
+	extraHosts, err := toBuildkitExtraHosts(opt.Options.ExtraHosts, b.dnsconfig.HostGatewayIP)
 	if err != nil {
 		return nil, err
 	}
@@ -551,18 +554,28 @@ func (j *buildJob) SetUpload(ctx context.Context, rc io.ReadCloser) error {
 }
 
 // toBuildkitExtraHosts converts hosts from docker key:value format to buildkit's csv format
-func toBuildkitExtraHosts(inp []string) (string, error) {
+func toBuildkitExtraHosts(inp []string, hostGatewayIP net.IP) (string, error) {
 	if len(inp) == 0 {
 		return "", nil
 	}
 	hosts := make([]string, 0, len(inp))
 	for _, h := range inp {
-		parts := strings.Split(h, ":")
-
-		if len(parts) != 2 || parts[0] == "" || net.ParseIP(parts[1]) == nil {
+		host, ip, ok := strings.Cut(h, ":")
+		if !ok || host == "" || ip == "" {
 			return "", errors.Errorf("invalid host %s", h)
 		}
-		hosts = append(hosts, parts[0]+"="+parts[1])
+		// If the IP Address is a "host-gateway", replace this value with the
+		// IP address stored in the daemon level HostGatewayIP config variable.
+		if ip == opts.HostGatewayName {
+			gateway := hostGatewayIP.String()
+			if gateway == "" {
+				return "", fmt.Errorf("unable to derive the IP value for host-gateway")
+			}
+			ip = gateway
+		} else if net.ParseIP(ip) == nil {
+			return "", fmt.Errorf("invalid host %s", h)
+		}
+		hosts = append(hosts, host+"="+ip)
 	}
 	return strings.Join(hosts, ","), nil
 }


### PR DESCRIPTION
fixes #44525 

**- What I did**

If the IP Address is a string called `host-gateway`, replace this value with the IP address stored in the daemon level `HostGatewayIP` config variable.

This is the current behavior with the classic builder.

~Keeping in draft for now as it's still subject to discussion~.

Need changes in Buildx client: https://github.com/docker/buildx/blob/23cabd67fb1c5e7ba2e3765e91bd5cc0f0311337/build/utils.go#L41-L56 cc @tonistiigi @jedevc

**- How I did it**

**- How to verify it**

**- Description for the changelog**

handle `host-gateway` with extra hosts.

**- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>