### PR TITLE
ci: define timeout for jobs

### DIFF
--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -105,6 +105,7 @@ jobs:
 
   unit-test:
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 120
     env:
       GOPATH: ${{ github.workspace }}\go
       GOBIN: ${{ github.workspace }}\go\bin
@@ -239,6 +240,7 @@ jobs:
 
   integration-test:
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 120
     needs:
       - build
       - integration-test-prepare

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -45,9 +45,10 @@ jobs:
           retention-days: 1
 
   test:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 120
     needs:
       - build
-    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,6 +117,7 @@ jobs:
 
   unit:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120
     needs:
       - build-dev
     steps:
@@ -192,6 +193,7 @@ jobs:
 
   docker-py:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120
     needs:
       - build-dev
     steps:
@@ -239,6 +241,7 @@ jobs:
 
   integration-flaky:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120
     needs:
       - build-dev
     steps:
@@ -267,6 +270,7 @@ jobs:
 
   integration:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
     needs:
       - build-dev
     strategy:
@@ -411,6 +415,7 @@ jobs:
 
   integration-cli:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120
     needs:
       - build-dev
       - integration-cli-prepare


### PR DESCRIPTION
I see some jobs hang and timeout after 6h ([default value](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes)) since few days. This PR set `timeout-minutes` to `120`. Unfortunately we can't (yet) set a global timeout for a workflow: https://github.com/orgs/community/discussions/10690

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>