### PR TITLE
Jenkinsfile: Fix dev image build fox ppc64le/s390x archs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -278,8 +278,7 @@ pipeline {
                         stage("Build dev image") {
                             steps {
                                 sh '''
-                                make bundles/buildx
-                                bundles/buildx build --load --force-rm --build-arg APT_MIRROR -t docker:${GIT_COMMIT} .
+                                docker buildx build --load --force-rm --build-arg APT_MIRROR -t docker:${GIT_COMMIT} .
                                 '''
                             }
                         }
@@ -392,8 +391,7 @@ pipeline {
                         stage("Build dev image") {
                             steps {
                                 sh '''
-                                make bundles/buildx
-                                bundles/buildx build --load --force-rm --build-arg APT_MIRROR -t docker:${GIT_COMMIT} .
+                                docker buildx build --load --force-rm --build-arg APT_MIRROR -t docker:${GIT_COMMIT} .
                                 '''
                             }
                         }


### PR DESCRIPTION
- related to https://github.com/moby/moby/pull/44533

Dev image build fails for ppc64le/s390x archs: https://ci-next.docker.com/public/blue/organizations/jenkins/moby/detail/master/1681/pipeline/185#step-186-log-2

```
[2022-11-29T04:09:49.156Z] + make bundles/buildx
[2022-11-29T04:09:49.452Z] make: *** No rule to make target 'bundles/buildx'.  Stop.
script returned exit code 2
```

Didn't catch this one as Jenkins does not run on PR for these archs.