### PR TITLE
registry: session: remove unused id

### DIFF
--- a/registry/session.go
+++ b/registry/session.go
@@ -15,7 +15,6 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/jsonmessage"
-	"github.com/docker/docker/pkg/stringid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -24,7 +23,6 @@ import (
 type session struct {
 	indexEndpoint *v1Endpoint
 	client        *http.Client
-	id            string
 }
 
 type authTransport struct {
@@ -179,7 +177,6 @@ func newSession(client *http.Client, endpoint *v1Endpoint) *session {
 	return &session{
 		client:        client,
 		indexEndpoint: endpoint,
-		id:            stringid.GenerateRandomID(),
 	}
 }
 


### PR DESCRIPTION
This removes the dependency on github.com/docker/docker/pkg/stringid

**- A picture of a cute animal (not mandatory but encouraged)**

