### PR TITLE
[22.06 backport] registry: session: remove unused id

### DIFF
--- a/registry/session.go
+++ b/registry/session.go
@@ -16,7 +16,6 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/jsonmessage"
-	"github.com/docker/docker/pkg/stringid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -25,7 +24,6 @@ import (
 type session struct {
 	indexEndpoint *v1Endpoint
 	client        *http.Client
-	id            string
 }
 
 type authTransport struct {
@@ -180,7 +178,6 @@ func newSession(client *http.Client, endpoint *v1Endpoint) *session {
 	return &session{
 		client:        client,
 		indexEndpoint: endpoint,
-		id:            stringid.GenerateRandomID(),
 	}
 }
 


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44548

This removes the dependency on github.com/docker/docker/pkg/stringid

(cherry picked from commit a44f547343299d609d6840306851102a0c78b70e)


**- A picture of a cute animal (not mandatory but encouraged)**

