### PR TITLE
vendor.mod: remove outdated comment about replaced module

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -117,7 +117,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/btree v1.1.2 // indirect
-	github.com/google/certificate-transparency-go v1.1.4 // indirect; replaced; see "replace" section at the bottom of this file for the actual version.
+	github.com/google/certificate-transparency-go v1.1.4 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.1.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.4.0 // indirect


### PR DESCRIPTION
The replace was removed in 64f9ea1cf5179718e11a89412341f3eb4781cab9, but I forgot to remove the comment.


**- A picture of a cute animal (not mandatory but encouraged)**

