### PR TITLE
archive: improve path splitting logic

### DIFF
--- a/daemon/archive_unix.go
+++ b/daemon/archive_unix.go
@@ -66,13 +66,13 @@ func (daemon *Daemon) containerArchivePath(container *container.Container, path 
 		return nil, nil, err
 	}
 
-	sourceDir, sourceBase := absPath, "."
-	if stat.Mode&os.ModeDir == 0 { // not dir
-		sourceDir, sourceBase = filepath.Split(absPath)
+	var opts *archive.TarOptions
+	if stat.Mode&os.ModeSymlink != 0 {
+		_, sourceBase := filepath.Split(absPath)
+		opts = archive.TarResourceRebaseOpts(sourceBase, filepath.Base(absPath))
 	}
-	opts := archive.TarResourceRebaseOpts(sourceBase, filepath.Base(absPath))
 
-	tb, err := archive.NewTarballer(sourceDir, opts)
+	tb, err := archive.NewTarballer(absPath, opts)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
This is a follow up from https://github.com/moby/moby/pull/39357/files#r293629119 (merge commit fb5fe241b5931c7031fc4aa2ad4ca61159888df1)

Signed-off-by: Tibor Vass <teabee89@gmail.com>

Carry of #39385 (old diff: https://github.com/moby/moby/compare/384c782721...9e1d1f4137338381a3955e425e2d6513a6e6649e)

Feel free to close this if this is not wanted anymore.