### PR TITLE
[20.10 backport] seccomp: block socket calls to AF_VSOCK in default profile

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -348,7 +348,6 @@
 				"signalfd4",
 				"sigprocmask",
 				"sigreturn",
-				"socket",
 				"socketcall",
 				"socketpair",
 				"splice",
@@ -415,6 +414,22 @@
 			"includes": {
 				"minKernel": "4.8"
 			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 40,
+					"op": "SCMP_CMP_NE"
+				}
+			],
+			"comment": "",
+			"includes": {},
 			"excludes": {}
 		},
 		{

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -343,7 +343,6 @@ func DefaultProfile() *Seccomp {
 				"signalfd4",
 				"sigprocmask",
 				"sigreturn",
-				"socket",
 				"socketcall",
 				"socketpair",
 				"splice",
@@ -402,6 +401,17 @@ func DefaultProfile() *Seccomp {
 			Action: specs.ActAllow,
 			Includes: Filter{
 				MinKernel: &KernelVersion{4, 8},
+			},
+		},
+		{
+			Names:  []string{"socket"},
+			Action: specs.ActAllow,
+			Args: []*specs.LinuxSeccompArg{
+				{
+					Index: 0,
+					Value: unix.AF_VSOCK,
+					Op:    specs.OpNotEqual,
+				},
 			},
 		},
 		{


### PR DESCRIPTION
backport:

- https://github.com/moby/moby/pull/44562

related:

- relates to https://github.com/moby/moby/pull/29076#commitcomment-21831387
- relates to https://github.com/moby/moby/commit/dcf2632945b87acedeea989a5aa36c084a20ae88
- relates to https://github.com/containerd/containerd/pull/7510
- relates to https://github.com/containerd/containerd/issues/7442


This syncs the seccomp-profile with the latest changes in containerd's profile, applying the same changes as https://github.com/containerd/containerd/commit/17a93240359b406c78e5f08a20013f759ea230bf

Some background from the associated ticket:

> We want to use vsock for guest-host communication on KubeVirt
> (https://github.com/kubevirt/kubevirt). In KubeVirt we run VMs in pods.
>
> However since anyone can just connect from any pod to any VM with the
> default seccomp settings, we cannot limit connection attempts to our
> privileged node-agent.
>
> ### Describe the solution you'd like
> We want to deny the `socket` syscall for the `AF_VSOCK` family by default.
>
> I see in [1] and [2] that AF_VSOCK was actually already blocked for some
> time, but that got reverted since some architectures support the `socketcall`
> syscall which can't be restricted properly. However we are mostly interested
> in `arm64` and `amd64` where limiting `socket` would probably be enough.
>
> ### Additional context
> I know that in theory we could use our own seccomp profiles, but we would want
> to provide security for as many users as possible which use KubeVirt, and there
> it would be very helpful if this protection could be added by being part of the
> DefaultRuntime profile to easily ensure that it is active for all pods [3].
>
> Impact on existing workloads: It is unlikely that this will disturb any existing
> workload, becuase VSOCK is almost exclusively used for host-guest commmunication.
> However if someone would still use it: Privileged pods would still be able to
> use `socket` for `AF_VSOCK`, custom seccomp policies could be applied too.
> Further it was already blocked for quite some time and the blockade got lifted
> due to reasons not related to AF_VSOCK.
>
> The PR in KubeVirt which adds VSOCK support for additional context: [4]
>
> [1]: https://github.com/moby/moby/pull/29076#commitcomment-21831387
> [2]: https://github.com/moby/moby/commit/dcf2632945b87acedeea989a5aa36c084a20ae88
> [3]: https://kubernetes.io/docs/tutorials/security/seccomp/#enable-the-use-of-runtimedefault-as-the-default-seccomp-profile-for-all-workloads
> [4]: https://github.com/kubevirt/kubevirt/pull/8546

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
- seccomp: AF_VSOCK is not blocked by default in the default profile
```

**- A picture of a cute animal (not mandatory but encouraged)**


