### PR TITLE
[23.0 backport] distribution: checkSupportedMediaType: allow additional media-types

### DIFF
--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -608,14 +608,12 @@ func (p *puller) pullSchema1(ctx context.Context, ref reference.Reference, unver
 }
 
 func checkSupportedMediaType(mediaType string) error {
-	supportedMediaTypes := []string{
-		"application/vnd.oci.image.",
-		"application/vnd.docker.",
-	}
-
 	lowerMt := strings.ToLower(mediaType)
 	for _, mt := range supportedMediaTypes {
-		if strings.HasPrefix(lowerMt, mt) {
+		// The should either be an exact match, or have a valid prefix
+		// we append a "." when matching prefixes to exclude "false positives";
+		// for example, we don't want to match "application/vnd.oci.images_are_fun_yolo".
+		if lowerMt == mt || strings.HasPrefix(lowerMt, mt+".") {
 			return nil
 		}
 	}

--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -20,6 +20,22 @@ import (
 )
 
 var (
+	// supportedMediaTypes represents acceptable media-type(-prefixes)
+	// we use this list to prevent obscure errors when trying to pull
+	// OCI artifacts.
+	supportedMediaTypes = []string{
+		// valid prefixes
+		"application/vnd.oci.image",
+		"application/vnd.docker",
+
+		// these types may occur on old images, and are copied from
+		// defaultImageTypes below.
+		"application/octet-stream",
+		"application/json",
+		"text/html",
+		"",
+	}
+
 	// defaultImageTypes represents the schema2 config types for images
 	defaultImageTypes = []string{
 		schema2.MediaTypeImageConfig,


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44567
- relates to https://github.com/moby/moby/pull/44367
- relates to https://github.com/moby/moby/pull/30262

This addresses a regression introduced in 407e3a455231bcf5b1c3e18a9e682a646b6e96ab (https://github.com/moby/moby/pull/44367), which turned out to be "too strict", as there's old images that use, for example;

    docker pull python:3.5.1-alpine
    3.5.1-alpine: Pulling from library/python
    unsupported media type application/octet-stream

Before 407e3a455231bcf5b1c3e18a9e682a646b6e96ab, such mediatypes were accepted;

    docker pull python:3.5.1-alpine
    3.5.1-alpine: Pulling from library/python
    e110a4a17941: Pull complete
    30dac23631f0: Pull complete
    202fc3980a36: Pull complete
    Digest: sha256:f88925c97b9709dd6da0cb2f811726da9d724464e9be17a964c70f067d2aa64a
    Status: Downloaded newer image for python:3.5.1-alpine
    docker.io/library/python:3.5.1-alpine

This patch copies the additional media-types, using the list of types that were added in a215e15cb1fbecc3b22d4f90e15638728ac7ac78 (https://github.com/moby/moby/pull/30262), which fixed a similar issue.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
