### PR TITLE
[23.0 backport] ci(buildkit): update buildkit ref to fix issue with alpine image

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -72,7 +72,7 @@ jobs:
           ./hack/go-mod-prepare.sh
           # FIXME(thaJeztah) temporarily overriding version to use for tests; remove with the next release of buildkit
           # echo "BUILDKIT_REF=$(./hack/buildkit-ref)" >> $GITHUB_ENV
-          echo "BUILDKIT_REF=4febae4f874bd8ef52dec30e988c8fe0bc96b3b9" >> $GITHUB_ENV
+          echo "BUILDKIT_REF=0bfcd83e6db95e6c6877ee6e5224b994cea62ba1" >> $GITHUB_ENV
         working-directory: moby
       -
         name: Checkout BuildKit ${{ env.BUILDKIT_REF }}


### PR DESCRIPTION
* backport of https://github.com/moby/moby/pull/44571

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>
(cherry picked from commit 381fa4afcae723de811b1bd1c330a5ad4a8d5952)