### PR TITLE
Add Kevin Alvarez ("crazy-max") to curators

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -63,6 +63,7 @@
 			"alexellis",
 			"andrewhsu",
 			"bsousaa",
+			"crazy-max",
 			"fntlnz",
 			"gianarb",
 			"ndeloof",
@@ -334,6 +335,11 @@
 	Name = "Brian Goff"
 	Email = "cpuguy83@gmail.com"
 	GitHub = "cpuguy83"
+
+	[people.crazy-max]
+	Name = "Kevin Alvarez"
+	Email = "contact@crazymax.dev"
+	GitHub = "crazy-max"
 
 	[people.crosbymichael]
 	Name = "Michael Crosby"


### PR DESCRIPTION
Kevin has been doing a lot of work helping modernize our CI, and helping with BuildKit-related changes. Being our "resident GitHub actions expert", I think it make sense to add him to the maintainers list as a curator (for starters), to grant him permissions on the repository.

Perhaps we should nominate him to become a maintainer (with a focus on his area of expertise) :)


**- A picture of a cute animal (not mandatory but encouraged)**

![15funny1](https://user-images.githubusercontent.com/1804568/205940418-6db5b89d-c6f0-4144-9920-53b9320964cf.jpeg)

Photograph: [Arthur Telle Thiemann/Comedy Wildlife Photography Awards 2020](https://www.rediff.com/news/report/pix-these-funny-animals-are-just-what-we-need-right-now/20200915.htm)