### PR TITLE
image save: make output tarball OCI compliant

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/layer"
 	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // ID is the content-addressable ID of an image.
@@ -172,6 +173,17 @@ func (img *Image) OperatingSystem() string {
 		os = runtime.GOOS
 	}
 	return os
+}
+
+// Platform generates an OCI platform from the image
+func (img *Image) Platform() ocispec.Platform {
+	return ocispec.Platform{
+		Architecture: img.Architecture,
+		OS:           img.OS,
+		OSVersion:    img.OSVersion,
+		OSFeatures:   img.OSFeatures,
+		Variant:      img.Variant,
+	}
 }
 
 // MarshalJSON serializes the image to JSON. It sorts the top-level keys so

--- a/image/tarexport/tarexport.go
+++ b/image/tarexport/tarexport.go
@@ -12,6 +12,10 @@ const (
 	legacyLayerFileName        = "layer.tar"
 	legacyConfigFileName       = "json"
 	legacyRepositoriesFileName = "repositories"
+
+	ociIndexFileName  = "index.json"
+	ociLayoutFilename = "oci-layout"
+	ociLayoutContent  = `{"imageLayoutVersion": "1.0.0"}`
 )
 
 type manifestItem struct {

--- a/image/tarexport/tarexport.go
+++ b/image/tarexport/tarexport.go
@@ -11,7 +11,6 @@ const (
 	manifestFileName           = "manifest.json"
 	legacyLayerFileName        = "layer.tar"
 	legacyConfigFileName       = "json"
-	legacyVersionFileName      = "VERSION"
 	legacyRepositoriesFileName = "repositories"
 )
 

--- a/integration/image/save_test.go
+++ b/integration/image/save_test.go
@@ -1,0 +1,242 @@
+package image
+
+import (
+	"archive/tar"
+	"context"
+	"encoding/json"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cpuguy83/tar2go"
+	"github.com/docker/docker/api/types"
+	containerapi "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/integration/internal/build"
+	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/testutil/fakecontext"
+	"github.com/opencontainers/go-digest"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/skip"
+)
+
+type imageSaveManifestEntry struct {
+	Config   string
+	RepoTags []string
+	Layers   []string
+}
+
+func tarIndexFS(t *testing.T, rdr io.Reader) fs.FS {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	f, err := os.Create(filepath.Join(dir, "image.tar"))
+	assert.NilError(t, err)
+
+	// Do not close at the end of this function otherwise the indexer won't work
+	t.Cleanup(func() { f.Close() })
+
+	_, err = io.Copy(f, rdr)
+	assert.NilError(t, err)
+
+	return tar2go.NewIndex(f).FS()
+}
+
+func TestSaveCheckTimes(t *testing.T) {
+	t.Parallel()
+
+	defer setupTest(t)()
+	client := testEnv.APIClient()
+	ctx := context.Background()
+
+	const repoName = "busybox:latest"
+	img, _, err := client.ImageInspectWithRaw(ctx, repoName)
+	assert.NilError(t, err)
+
+	rdr, err := client.ImageSave(ctx, []string{repoName})
+	assert.NilError(t, err)
+
+	tarfs := tarIndexFS(t, rdr)
+
+	dt, err := fs.ReadFile(tarfs, "manifest.json")
+	assert.NilError(t, err)
+
+	var ls []imageSaveManifestEntry
+	assert.NilError(t, json.Unmarshal(dt, &ls))
+	assert.Assert(t, cmp.Len(ls, 1))
+
+	info, err := fs.Stat(tarfs, ls[0].Config)
+	assert.NilError(t, err)
+
+	created, err := time.Parse(time.RFC3339, img.Created)
+	assert.NilError(t, err)
+
+	assert.Equal(t, created.Format(time.RFC3339), info.ModTime().Format(time.RFC3339), "expected: %s, actual: %s", created, info.ModTime())
+}
+
+func TestSaveRepoWithMultipleImages(t *testing.T) {
+	defer setupTest(t)()
+	ctx := context.Background()
+	client := testEnv.APIClient()
+
+	makeImage := func(from string, tag string) string {
+		id := container.Run(ctx, t, client, func(cfg *container.TestContainerConfig) {
+			cfg.Config.Image = from
+			cfg.Config.Cmd = []string{"true"}
+		})
+
+		chW, chErr := client.ContainerWait(ctx, id, containerapi.WaitConditionNotRunning)
+
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+
+		select {
+		case <-chW:
+		case err := <-chErr:
+			assert.NilError(t, err)
+		case <-ctx.Done():
+			t.Fatal("timeout waiting for container to exit")
+		}
+
+		res, err := client.ContainerCommit(ctx, id, types.ContainerCommitOptions{Reference: tag})
+		assert.NilError(t, err)
+
+		err = client.ContainerRemove(ctx, id, types.ContainerRemoveOptions{Force: true})
+		assert.NilError(t, err)
+
+		return res.ID
+	}
+
+	repoName := "foobar-save-multi-images-test"
+	tagFoo := repoName + ":foo"
+	tagBar := repoName + ":bar"
+
+	idFoo := makeImage("busybox:latest", tagFoo)
+	idBar := makeImage("busybox:latest", tagBar)
+
+	client.ImageRemove(ctx, repoName, types.ImageRemoveOptions{Force: true})
+
+	rdr, err := client.ImageSave(ctx, []string{repoName, "busybox:latest"})
+	assert.NilError(t, err)
+	defer rdr.Close()
+
+	tarfs := tarIndexFS(t, rdr)
+
+	dt, err := fs.ReadFile(tarfs, "manifest.json")
+	assert.NilError(t, err)
+
+	var mfstLs []imageSaveManifestEntry
+	assert.NilError(t, json.Unmarshal(dt, &mfstLs))
+
+	actual := make([]string, 0, len(mfstLs))
+	for _, m := range mfstLs {
+		actual = append(actual, strings.TrimPrefix(m.Config, "blobs/sha256/"))
+		// make sure the blob actually exists
+		_, err := fs.Stat(tarfs, m.Config)
+		assert.Check(t, cmp.Nil(err))
+	}
+
+	// make the list of expected layers
+	img, _, err := client.ImageInspectWithRaw(ctx, "busybox:latest")
+	assert.NilError(t, err)
+
+	expected := []string{img.ID, idFoo, idBar}
+
+	// prefixes are not in tar
+	for i := range expected {
+		expected[i] = digest.Digest(expected[i]).Encoded()
+	}
+
+	sort.Strings(actual)
+	sort.Strings(expected)
+	assert.Assert(t, cmp.DeepEqual(actual, expected), "archive does not contains the right layers: got %v, expected %v", actual, expected)
+}
+
+func TestSaveDirectoryPermissions(t *testing.T) {
+	skip.If(t, testEnv.OSType == "windows", "Test is looking at linux specific details")
+
+	defer setupTest(t)()
+
+	ctx := context.Background()
+	client := testEnv.APIClient()
+
+	layerEntries := []string{"opt/", "opt/a/", "opt/a/b/", "opt/a/b/c"}
+	layerEntriesAUFS := []string{"./", ".wh..wh.aufs", ".wh..wh.orph/", ".wh..wh.plnk/", "opt/", "opt/a/", "opt/a/b/", "opt/a/b/c"}
+
+	dockerfile := `FROM busybox
+RUN adduser -D user && mkdir -p /opt/a/b && chown -R user:user /opt/a
+RUN touch /opt/a/b/c && chown user:user /opt/a/b/c`
+
+	imgID := build.Do(ctx, t, client, fakecontext.New(t, t.TempDir(), fakecontext.WithDockerfile(dockerfile)))
+
+	rdr, err := client.ImageSave(ctx, []string{imgID})
+	assert.NilError(t, err)
+	defer rdr.Close()
+
+	tarfs := tarIndexFS(t, rdr)
+
+	dt, err := fs.ReadFile(tarfs, "manifest.json")
+	assert.NilError(t, err)
+
+	var mfstLs []imageSaveManifestEntry
+	assert.NilError(t, json.Unmarshal(dt, &mfstLs))
+
+	var found bool
+
+	for _, p := range mfstLs[0].Layers {
+		var entriesSansDev []string
+
+		f, err := tarfs.Open(p)
+		assert.NilError(t, err)
+
+		entries, err := listTar(f)
+		f.Close()
+		assert.NilError(t, err)
+
+		for _, e := range entries {
+			if !strings.Contains(e, "dev/") {
+				entriesSansDev = append(entriesSansDev, e)
+			}
+		}
+		assert.NilError(t, err, "encountered error while listing tar entries: %s", err)
+
+		if reflect.DeepEqual(entriesSansDev, layerEntries) || reflect.DeepEqual(entriesSansDev, layerEntriesAUFS) {
+			found = true
+			break
+		}
+	}
+
+	assert.Assert(t, found, "failed to find the layer with the right content listing")
+}
+
+func listTar(f io.Reader) ([]string, error) {
+	// If using the containerd snapshotter, the tar file may be compressed
+	dec, err := archive.DecompressStream(f)
+	if err != nil {
+		return nil, err
+	}
+	defer dec.Close()
+
+	tr := tar.NewReader(dec)
+	var entries []string
+
+	for {
+		th, err := tr.Next()
+		if err == io.EOF {
+			// end of tar archive
+			return entries, nil
+		}
+		if err != nil {
+			return entries, err
+		}
+		entries = append(entries, th.Name)
+	}
+}

--- a/vendor.mod
+++ b/vendor.mod
@@ -30,6 +30,7 @@ require (
 	github.com/containerd/fifo v1.1.0
 	github.com/containerd/typeurl/v2 v2.1.0
 	github.com/coreos/go-systemd/v22 v22.5.0
+	github.com/cpuguy83/tar2go v0.3.1
 	github.com/creack/pty v1.1.18
 	github.com/deckarep/golang-set/v2 v2.3.0
 	github.com/docker/distribution v2.8.2+incompatible

--- a/vendor.sum
+++ b/vendor.sum
@@ -468,6 +468,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/tar2go v0.3.1 h1:DMWlaIyoh9FBWR4hyfZSOEDA7z8rmCiGF1IJIzlTlR8=
+github.com/cpuguy83/tar2go v0.3.1/go.mod h1:2Ys2/Hu+iPHQRa4DjIVJ7UAaKnDhAhNACeK3A0Rr5rM=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/vendor/github.com/cpuguy83/tar2go/LICENSE.md
+++ b/vendor/github.com/cpuguy83/tar2go/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Brian Goff
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/cpuguy83/tar2go/README.md
+++ b/vendor/github.com/cpuguy83/tar2go/README.md
@@ -1,0 +1,49 @@
+# tar2go
+
+tar2go implements are go [fs.FS](https://pkg.go.dev/io/fs#FS) for tar files.
+
+Tars are not indexed so by themselves don't really have support for random access.
+When a request to open/stat a file is made tar2go will scan through the tar, indexing each entry along the way, until the file is found in the tar.
+A tar file is only ever scanned 1 time and scanning is done lazily (as needed to index the requested entry).
+
+tar2go does not support modifying a tar file, however there is support for modifying the in-memory representation of the tar which will show up in the `fs.FS`.
+You can also write a new tar file with requested modifications.
+
+### Usage
+
+```go
+  f, _ := os.Open(p)
+  defer f.Close()
+  
+  // Entrypoint into this library
+  idx := NewIndex(f)
+  
+  // Get the `fs.FS` implementation
+  goFS := idx.FS()
+  // Do stuff with your fs
+  // ...
+  
+  
+  // Add or replace a file in the index
+  _ := idx.Replace("foo", strings.NewReader("random stuff")
+  data, _ := fs.ReadFile(goFS, "foo")
+  if string(data) != "random stuff") {
+    panic("unexpected data")
+  }
+  
+  // Delete a file in the index
+  _ := idx.Replace("foo", nil)
+  if _, err := fs.ReadFile(goFS, "foo"); !errors.Is(err, fs.ErrNotExist) {
+    panic(err)
+  }
+  
+  // Create a new tar with updated content
+  // First we need to create an `io.Writer`, which is where the updated tar stream will be written to.
+  f, _ := os.CreateTemp("", "updated")
+  idx.Update(f, func(name string, rdr ReaderAtSized) (ReaderAtSized, bool, error) {
+    // Update calls this function for every file in the tar
+    // The returned `ReaderAtSized` is used instead of the content passed in (rdr).
+    // To make no changes just return the same rdr back.
+    // Return true for the bool value if the content is changed.
+  })
+```

--- a/vendor/github.com/cpuguy83/tar2go/file.go
+++ b/vendor/github.com/cpuguy83/tar2go/file.go
@@ -1,0 +1,66 @@
+package tar2go
+
+import (
+	"archive/tar"
+	"io"
+	"io/fs"
+	"time"
+)
+
+type file struct {
+	idx *indexReader
+	rdr *io.SectionReader
+}
+
+func newFile(idx *indexReader) *file {
+	return &file{idx: idx, rdr: io.NewSectionReader(idx.rdr, idx.offset, idx.size)}
+}
+
+type fileinfo struct {
+	h *tar.Header
+}
+
+func (f *fileinfo) Name() string {
+	return f.h.Name
+}
+
+func (f *fileinfo) Size() int64 {
+	return f.h.Size
+}
+
+func (f *fileinfo) Mode() fs.FileMode {
+	return fs.FileMode(f.h.Mode)
+}
+
+func (f *fileinfo) ModTime() time.Time {
+	return f.h.ModTime
+}
+
+func (f *fileinfo) IsDir() bool {
+	return f.h.Typeflag == tar.TypeDir
+}
+
+func (f *file) Close() error {
+	return nil
+}
+
+func (f *fileinfo) Sys() interface{} {
+	h := *f.h
+	return &h
+}
+
+func (f *file) Read(p []byte) (int, error) {
+	return f.rdr.Read(p)
+}
+
+func (f *file) ReadAt(p []byte, off int64) (int, error) {
+	return f.rdr.ReadAt(p, off)
+}
+
+func (f *file) Size() int64 {
+	return f.rdr.Size()
+}
+
+func (f *file) Stat() (fs.FileInfo, error) {
+	return &fileinfo{h: f.idx.hdr}, nil
+}

--- a/vendor/github.com/cpuguy83/tar2go/fs.go
+++ b/vendor/github.com/cpuguy83/tar2go/fs.go
@@ -1,0 +1,30 @@
+package tar2go
+
+import (
+	"io/fs"
+)
+
+var (
+	_ fs.FS   = &filesystem{}
+	_ fs.File = &file{}
+)
+
+type filesystem struct {
+	idx *Index
+}
+
+func (f *filesystem) Open(name string) (fs.File, error) {
+	idx, err := f.idx.indexWithLock(name)
+	if err != nil {
+		return nil, &fs.PathError{Path: name, Op: "open", Err: err}
+	}
+	return newFile(idx), nil
+}
+
+func (f *filesystem) Stat(name string) (fs.FileInfo, error) {
+	idx, err := f.idx.indexWithLock(name)
+	if err != nil {
+		return nil, &fs.PathError{Path: name, Op: "stat", Err: err}
+	}
+	return &fileinfo{h: idx.hdr}, nil
+}

--- a/vendor/github.com/cpuguy83/tar2go/index.go
+++ b/vendor/github.com/cpuguy83/tar2go/index.go
@@ -1,0 +1,190 @@
+package tar2go
+
+import (
+	"archive/tar"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"sync"
+)
+
+var (
+	// ErrDelete should be returned by an UpdaterFn when the file should be deleted.
+	ErrDelete = errors.New("delete")
+)
+
+// Index is a tar index that can be used to read files from a tar.
+type Index struct {
+	rdr *io.SectionReader
+	tar *tar.Reader
+	mu  sync.Mutex
+	idx map[string]*indexReader
+}
+
+// NewIndex creates a new Index from the passed in io.ReaderAt.
+func NewIndex(rdr io.ReaderAt) *Index {
+	ras, ok := rdr.(ReaderAtSized)
+	var size int64
+	if !ok {
+		size = 1<<63 - 1
+	} else {
+		size = ras.Size()
+	}
+	return &Index{
+		rdr: io.NewSectionReader(rdr, 0, size),
+		idx: make(map[string]*indexReader),
+	}
+}
+
+func (i *Index) indexWithLock(name string) (*indexReader, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.index(name)
+}
+
+func filterFSPrefix(name string) string {
+	if len(name) <= 1 {
+		return name
+	}
+	if name[0] == '/' {
+		return name[1:]
+	}
+	if len(name) > 2 && name[0] == '.' && name[1] == '/' {
+		return name[2:]
+	}
+	return name
+}
+
+// This function must be called with the lock held.
+func (i *Index) index(name string) (*indexReader, error) {
+	name = filterFSPrefix(name)
+	if rdr, ok := i.idx[name]; ok {
+		return rdr, nil
+	}
+
+	if i.tar == nil {
+		i.tar = tar.NewReader(i.rdr)
+	}
+
+	for {
+		hdr, err := i.tar.Next()
+		if err != nil {
+			if err == io.EOF {
+				return nil, fs.ErrNotExist
+			}
+			return nil, fmt.Errorf("error indexing tar: %w", err)
+		}
+
+		pos, err := i.rdr.Seek(0, io.SeekCurrent)
+		if err != nil {
+			return nil, fmt.Errorf("error getting file offset: %w", err)
+		}
+		rdr := &indexReader{rdr: i.rdr, offset: pos, size: hdr.Size, hdr: hdr}
+		hdrName := filterFSPrefix(hdr.Name)
+		i.idx[hdrName] = rdr
+
+		if hdrName == name {
+			return rdr, nil
+		}
+	}
+}
+
+// Reader returns an io.ReaderAt that can be used to read the entire tar.
+func (i *Index) Reader() *io.SectionReader {
+	return io.NewSectionReader(i.rdr, 0, i.rdr.Size())
+}
+
+// FS returns an fs.FS that can be used to read the files in the tar.
+func (i *Index) FS() fs.FS {
+	return &filesystem{idx: i}
+}
+
+// ReaderAtSized is an io.ReaderAt that also implements a Size method.
+type ReaderAtSized interface {
+	io.ReaderAt
+	Size() int64
+}
+
+// UpdaterFn is a function that is passed the name of the file and a ReaderAtSized
+type UpdaterFn func(string, ReaderAtSized) (ReaderAtSized, bool, error)
+
+// Replace replaces the file with the passed in name with the passed in ReaderAtSized.
+// If the passed in ReaderAtSized is nil, the file will be deleted.
+// If the file does not exist, it will be added.
+//
+// This function does not update the actual tar file, it only updates the index.
+func (i *Index) Replace(name string, rdr ReaderAtSized) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	// index may overwrite it this replacement.
+	i.index(name)
+
+	if rdr == nil {
+		delete(i.idx, name)
+		return nil
+	}
+
+	i.idx[name] = &indexReader{rdr: rdr, offset: 0, size: rdr.Size(), hdr: &tar.Header{
+		Name: name,
+		Size: rdr.Size(),
+	}}
+	return nil
+}
+
+// Update creates a new tar with the files updated by the passed in updater function.
+// The output tar is written to the passed in io.Writer
+func (i *Index) Update(w io.Writer, updater UpdaterFn) error {
+	tw := tar.NewWriter(w)
+	defer tw.Close()
+
+	rdr := i.Reader()
+	tr := tar.NewReader(rdr)
+
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return fmt.Errorf("error reading tar: %w", err)
+		}
+
+		offset, err := rdr.Seek(0, io.SeekCurrent)
+		if err != nil {
+			return fmt.Errorf("error getting file offset: %w", err)
+		}
+
+		ra, updated, err := updater(hdr.Name, io.NewSectionReader(i.rdr, offset, hdr.Size))
+		if err != nil {
+			if err == ErrDelete {
+				continue
+			}
+			return fmt.Errorf("error updating file %s: %w", hdr.Name, err)
+		}
+
+		if updated {
+			hdr.Size = ra.Size()
+		}
+
+		if err := tw.WriteHeader(hdr); err != nil {
+			return fmt.Errorf("error writing tar header: %w", err)
+		}
+
+		if _, err := io.Copy(tw, io.NewSectionReader(ra, 0, ra.Size())); err != nil {
+			return fmt.Errorf("error writing tar file: %w", err)
+		}
+	}
+}
+
+type indexReader struct {
+	rdr    io.ReaderAt
+	offset int64
+	size   int64
+	hdr    *tar.Header
+}
+
+func (r *indexReader) Reader() *io.SectionReader {
+	return io.NewSectionReader(r.rdr, r.offset, r.size)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -350,6 +350,9 @@ github.com/coreos/go-systemd/v22/activation
 github.com/coreos/go-systemd/v22/daemon
 github.com/coreos/go-systemd/v22/dbus
 github.com/coreos/go-systemd/v22/journal
+# github.com/cpuguy83/tar2go v0.3.1
+## explicit; go 1.19
+github.com/cpuguy83/tar2go
 # github.com/creack/pty v1.1.18
 ## explicit; go 1.13
 github.com/creack/pty


### PR DESCRIPTION
- Moves blobs for the tarball into the OCI compliant paths (`blobs/<alg>/<digest>`)
- Removes old `VERSION` file which has no meaning and can't be used anyway in the new format
- Adds oci-layout, oci manifest, and index files to the outputted tars

For the new files this just goes ahead and uses OCI media types (instead of old docker types) since these are new and should not break anything.

All this works because the old docker layout is dependent on the `manifest.json` file at the root of the tar which has paths to each of the blobs in the tarball. The change updates the paths in the manifest to point to the new paths.

This is the same technique used by buildkit to support both OCI tar formats as well as legacy docker ones.
