### PR TITLE
docs: add 401 to possible status codes of /auth

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8726,6 +8726,10 @@ paths:
               IdentityToken: "9cbaf023786cd7..."
         204:
           description: "No error"
+        401:
+          description: "Auth error"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         500:
           description: "Server error"
           schema:


### PR DESCRIPTION
PR adds the missing 401 as currently 401 is returned by `/auth`:

```sh
➜  moby git:(master) ✗ curl -v --unix-socket /var/run/docker.sock -d '{"username":"123","password":"456","serveraddress":"https://index.docker.io/v1/"}' 'http://localhost/auth'
*   Trying /var/run/docker.sock:0...
* Connected to localhost (/Users/<redacted>/.docker/run/docker.sock) port 80 (#0)
> POST /auth HTTP/1.1
> Host: localhost
> User-Agent: curl/7.79.1
> Accept: */*
> Content-Length: 81
> Content-Type: application/x-www-form-urlencoded
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 401 Unauthorized
< Api-Version: 1.41
< Content-Type: application/json
< Date: Wed, 07 Dec 2022 01:58:02 GMT
< Docker-Experimental: false
< Ostype: linux
< Server: Docker/20.10.21 (linux)
< Transfer-Encoding: chunked
<
{"message":"Get \"https://registry-1.docker.io/v2/\": unauthorized: incorrect username or password"}
* Connection #0 to host localhost left intact
```

Signed-off-by: Hsing-Yu (David) Chen <davidhsingyuchen@gmail.com>