### PR TITLE
[20.10] update containerd binary to v1.6.12 (addresses CVE-2022-23471)

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.6.11}"
+: "${CONTAINERD_VERSION:=v1.6.12}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"


### PR DESCRIPTION
The twelfth patch release for containerd 1.6 contains a fix for CVE-2022-23471.

Notable Updates

- Fix goroutine leak during Exec in CRI plugin (GHSA-2qjp-425j-52j9)

full diff: https://github.com/containerd/containerd/compare/v1.6.11...v1.6.12

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

