### PR TITLE
[23.0] update containerd binary to v1.6.12 (addresses CVE-2022-23471)

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -168,7 +168,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ARG GO_VERSION=1.19.4
 ARG GOTESTSUM_VERSION=v1.8.2
 ARG GOWINRES_VERSION=v0.3.0
-ARG CONTAINERD_VERSION=v1.6.11
+ARG CONTAINERD_VERSION=v1.6.12
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.6.11}"
+: "${CONTAINERD_VERSION:=v1.6.12}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"


### PR DESCRIPTION
The twelfth patch release for containerd 1.6 contains a fix for CVE-2022-23471.

Notable Updates

- Fix goroutine leak during Exec in CRI plugin (GHSA-2qjp-425j-52j9)

full diff: https://github.com/containerd/containerd/compare/v1.6.11...v1.6.12

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

