### PR TITLE
[draft] containerd integration: add support for image inspect

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -206,9 +206,8 @@ func (ir *imageRouter) getImagesByName(ctx context.Context, w http.ResponseWrite
 }
 
 func (ir *imageRouter) toImageInspect(img *image.Image) (*types.ImageInspect, error) {
-	refs := ir.referenceBackend.References(img.ID().Digest())
 	var repoTags, repoDigests []string
-	for _, ref := range refs {
+	for _, ref := range img.Details.References {
 		switch ref.(type) {
 		case reference.NamedTagged:
 			repoTags = append(repoTags, reference.FamiliarString(ref))

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -128,13 +128,8 @@ func (i *ImageService) resolveImage(ctx context.Context, refOrID string) (img co
 
 	is := i.client.ImageService()
 
-	namedRef, ok := parsed.(reference.Named)
-	if !ok {
-		digested, ok := parsed.(reference.Digested)
-		if !ok {
-			return containerdimages.Image{}, errdefs.InvalidParameter(errors.New("bad reference"))
-		}
-
+	digested, ok := parsed.(reference.Digested)
+	if ok {
 		imgs, err := is.List(ctx, fmt.Sprintf("target.digest==%s", digested.Digest()))
 		if err != nil {
 			return containerdimages.Image{}, errors.Wrap(err, "failed to lookup digest")
@@ -146,6 +141,7 @@ func (i *ImageService) resolveImage(ctx context.Context, refOrID string) (img co
 		return imgs[0], nil
 	}
 
+	namedRef := parsed.(reference.Named)
 	namedRef = reference.TagNameOnly(namedRef)
 
 	// If the identifier could be a short ID, attempt to match

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -62,12 +62,8 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 }
 
 func (i *ImageService) getImage(ctx context.Context, refOrID string, platform *ocispec.Platform) (containerd.Image, *image.Image, error) {
-	desc, err := i.ResolveImage(ctx, refOrID)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	ctrdimg, err := i.resolveImageName2(ctx, refOrID)
+	// TODO(rumpl): pass the platform
+	ctrdimg, err := i.resolveImage(ctx, refOrID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -102,7 +98,7 @@ func (i *ImageService) getImage(ctx context.Context, refOrID string, platform *o
 	}
 	return containerdImage, &image.Image{
 		V1Image: image.V1Image{
-			ID:           string(desc.Digest),
+			ID:           string(ctrdimg.Target.Digest),
 			OS:           ociimage.OS,
 			Architecture: ociimage.Architecture,
 			Config: &containertypes.Config{
@@ -119,18 +115,13 @@ func (i *ImageService) getImage(ctx context.Context, refOrID string, platform *o
 	}, nil
 }
 
-// ResolveImage searches for an image based on the given
+// resolveImage searches for an image based on the given
 // reference or identifier. Returns the descriptor of
 // the image, could be manifest list, manifest, or config.
-func (i *ImageService) ResolveImage(ctx context.Context, refOrID string) (d ocispec.Descriptor, err error) {
-	d, _, err = i.resolveImageName(ctx, refOrID)
-	return
-}
-
-func (i *ImageService) resolveImageName2(ctx context.Context, refOrID string) (img containerdimages.Image, err error) {
+func (i *ImageService) resolveImage(ctx context.Context, refOrID string) (img containerdimages.Image, err error) {
 	parsed, err := reference.ParseAnyReference(refOrID)
 	if err != nil {
-		return img, errdefs.InvalidParameter(err)
+		return containerdimages.Image{}, errdefs.InvalidParameter(err)
 	}
 
 	is := i.client.ImageService()
@@ -139,15 +130,15 @@ func (i *ImageService) resolveImageName2(ctx context.Context, refOrID string) (i
 	if !ok {
 		digested, ok := parsed.(reference.Digested)
 		if !ok {
-			return img, errdefs.InvalidParameter(errors.New("bad reference"))
+			return containerdimages.Image{}, errdefs.InvalidParameter(errors.New("bad reference"))
 		}
 
 		imgs, err := is.List(ctx, fmt.Sprintf("target.digest==%s", digested.Digest()))
 		if err != nil {
-			return img, errors.Wrap(err, "failed to lookup digest")
+			return containerdimages.Image{}, errors.Wrap(err, "failed to lookup digest")
 		}
 		if len(imgs) == 0 {
-			return img, errdefs.NotFound(errors.New("image not found with digest"))
+			return containerdimages.Image{}, errdefs.NotFound(errors.New("image not found with digest"))
 		}
 
 		return imgs[0], nil
@@ -164,11 +155,11 @@ func (i *ImageService) resolveImageName2(ctx context.Context, refOrID string) (i
 		}
 		imgs, err := is.List(ctx, filters...)
 		if err != nil {
-			return img, err
+			return containerdimages.Image{}, err
 		}
 
 		if len(imgs) == 0 {
-			return img, errdefs.NotFound(errors.New("list returned no images"))
+			return containerdimages.Image{}, errdefs.NotFound(errors.New("list returned no images"))
 		}
 		if len(imgs) > 1 {
 			digests := map[digest.Digest]struct{}{}
@@ -180,7 +171,7 @@ func (i *ImageService) resolveImageName2(ctx context.Context, refOrID string) (i
 			}
 
 			if len(digests) > 1 {
-				return img, errdefs.NotFound(errors.New("ambiguous reference"))
+				return containerdimages.Image{}, errdefs.NotFound(errors.New("ambiguous reference"))
 			}
 		}
 
@@ -193,7 +184,7 @@ func (i *ImageService) resolveImageName2(ctx context.Context, refOrID string) (i
 	if err != nil {
 		// TODO(containerd): error translation can use common function
 		if !cerrdefs.IsNotFound(err) {
-			return img, err
+			return containerdimages.Image{}, err
 		}
 		// Some clients (such as the docker 17.03 CLI used in CI) still
 		// perform string-matching to detect that the *image* wasn't found.
@@ -201,82 +192,8 @@ func (i *ImageService) resolveImageName2(ctx context.Context, refOrID string) (i
 		// Without this prefix, the CLI prints the error message, and exits.
 		//
 		// FIXME(thaJeztah): we need to fix this; if needed, gated by API version (API < X add the prefix)
-		return img, errdefs.NotFound(errors.New("No such image: " + refOrID))
+		return containerdimages.Image{}, errdefs.NotFound(errors.New("No such image: " + refOrID))
 	}
 
 	return img, nil
-}
-
-func (i *ImageService) resolveImageName(ctx context.Context, refOrID string) (ocispec.Descriptor, reference.Named, error) {
-	parsed, err := reference.ParseAnyReference(refOrID)
-	if err != nil {
-		return ocispec.Descriptor{}, nil, errdefs.InvalidParameter(err)
-	}
-
-	is := i.client.ImageService()
-
-	namedRef, ok := parsed.(reference.Named)
-	if !ok {
-		digested, ok := parsed.(reference.Digested)
-		if !ok {
-			return ocispec.Descriptor{}, nil, errdefs.InvalidParameter(errors.New("bad reference"))
-		}
-
-		imgs, err := is.List(ctx, fmt.Sprintf("target.digest==%s", digested.Digest()))
-		if err != nil {
-			return ocispec.Descriptor{}, nil, errors.Wrap(err, "failed to lookup digest")
-		}
-		if len(imgs) == 0 {
-			return ocispec.Descriptor{}, nil, errdefs.NotFound(errors.New("image not found with digest"))
-		}
-
-		return imgs[0].Target, nil, nil
-	}
-
-	namedRef = reference.TagNameOnly(namedRef)
-
-	// If the identifier could be a short ID, attempt to match
-	if shortID.MatchString(refOrID) {
-		ref := namedRef.String()
-		filters := []string{
-			fmt.Sprintf("name==%q", ref),
-			fmt.Sprintf(`target.digest~=/sha256:%s[0-9a-fA-F]{%d}/`, refOrID, 64-len(refOrID)),
-		}
-		imgs, err := is.List(ctx, filters...)
-		if err != nil {
-			return ocispec.Descriptor{}, nil, err
-		}
-
-		if len(imgs) == 0 {
-			return ocispec.Descriptor{}, nil, errdefs.NotFound(errors.New("list returned no images"))
-		}
-		if len(imgs) > 1 {
-			digests := map[digest.Digest]struct{}{}
-			for _, img := range imgs {
-				if img.Name == ref {
-					return img.Target, namedRef, nil
-				}
-				digests[img.Target.Digest] = struct{}{}
-			}
-
-			if len(digests) > 1 {
-				return ocispec.Descriptor{}, nil, errdefs.NotFound(errors.New("ambiguous reference"))
-			}
-		}
-
-		if imgs[0].Name != ref {
-			namedRef = nil
-		}
-		return imgs[0].Target, namedRef, nil
-	}
-	img, err := is.Get(ctx, namedRef.String())
-	if err != nil {
-		// TODO(containerd): error translation can use common function
-		if !cerrdefs.IsNotFound(err) {
-			return ocispec.Descriptor{}, nil, err
-		}
-		return ocispec.Descriptor{}, nil, errdefs.NotFound(errors.New("id not found"))
-	}
-
-	return img.Target, namedRef, nil
 }

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -142,7 +142,13 @@ func (i *ImageService) resolveImageName2(ctx context.Context, refOrID string) (i
 		if !cerrdefs.IsNotFound(err) {
 			return img, err
 		}
-		return img, errdefs.NotFound(errors.New("id not found"))
+		// Some clients (such as the docker 17.03 CLI used in CI) still
+		// perform string-matching to detect that the *image* wasn't found.
+		// This requires the error to be prefixed with "No such image:".
+		// Without this prefix, the CLI prints the error message, and exits.
+		//
+		// FIXME(thaJeztah): we need to fix this; if needed, gated by API version (API < X add the prefix)
+		return img, errdefs.NotFound(errors.New("No such image: " + refOrID))
 	}
 
 	return img, nil

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -2,14 +2,222 @@ package containerd
 
 import (
 	"context"
-	"errors"
+	"encoding/json"
+	"fmt"
+	"regexp"
 
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/content"
+	cerrdefs "github.com/containerd/containerd/errdefs"
+	containerdimages "github.com/containerd/containerd/images"
+	"github.com/docker/distribution/reference"
+	containertypes "github.com/docker/docker/api/types/container"
 	imagetype "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
 )
 
+var shortID = regexp.MustCompile(`^([a-f0-9]{4,64})$`)
+
 // GetImage returns an image corresponding to the image referred to by refOrID.
-func (i *ImageService) GetImage(ctx context.Context, refOrID string, options imagetype.GetImageOpts) (retImg *image.Image, retErr error) {
-	return nil, errdefs.NotImplemented(errors.New("not implemented"))
+func (i *ImageService) GetImage(ctx context.Context, refOrID string, options imagetype.GetImageOpts) (*image.Image, error) {
+	desc, err := i.ResolveImage(ctx, refOrID)
+	if err != nil {
+		return nil, err
+	}
+
+	ctrdimg, err := i.resolveImageName2(ctx, refOrID)
+	if err != nil {
+		return nil, err
+	}
+	containerdImage := containerd.NewImage(i.client, ctrdimg)
+	provider := i.client.ContentStore()
+	conf, err := ctrdimg.Config(ctx, provider, containerdImage.Platform())
+	if err != nil {
+		return nil, err
+	}
+
+	var ociimage ocispec.Image
+	imageConfigBytes, err := content.ReadBlob(ctx, containerdImage.ContentStore(), conf)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(imageConfigBytes, &ociimage); err != nil {
+		return nil, err
+	}
+
+	return &image.Image{
+		V1Image: image.V1Image{
+			ID:           string(desc.Digest),
+			OS:           ociimage.OS,
+			Architecture: ociimage.Architecture,
+			Config: &containertypes.Config{
+				Entrypoint: ociimage.Config.Entrypoint,
+				Env:        ociimage.Config.Env,
+				Cmd:        ociimage.Config.Cmd,
+				User:       ociimage.Config.User,
+				WorkingDir: ociimage.Config.WorkingDir,
+			},
+		},
+	}, nil
+}
+
+// ResolveImage searches for an image based on the given
+// reference or identifier. Returns the descriptor of
+// the image, could be manifest list, manifest, or config.
+func (i *ImageService) ResolveImage(ctx context.Context, refOrID string) (d ocispec.Descriptor, err error) {
+	d, _, err = i.resolveImageName(ctx, refOrID)
+	return
+}
+
+func (i *ImageService) resolveImageName2(ctx context.Context, refOrID string) (img containerdimages.Image, err error) {
+	parsed, err := reference.ParseAnyReference(refOrID)
+	if err != nil {
+		return img, errdefs.InvalidParameter(err)
+	}
+
+	is := i.client.ImageService()
+
+	namedRef, ok := parsed.(reference.Named)
+	if !ok {
+		digested, ok := parsed.(reference.Digested)
+		if !ok {
+			return img, errdefs.InvalidParameter(errors.New("bad reference"))
+		}
+
+		imgs, err := is.List(ctx, fmt.Sprintf("target.digest==%s", digested.Digest()))
+		if err != nil {
+			return img, errors.Wrap(err, "failed to lookup digest")
+		}
+		if len(imgs) == 0 {
+			return img, errdefs.NotFound(errors.New("image not found with digest"))
+		}
+
+		return imgs[0], nil
+	}
+
+	namedRef = reference.TagNameOnly(namedRef)
+
+	// If the identifier could be a short ID, attempt to match
+	if shortID.MatchString(refOrID) {
+		ref := namedRef.String()
+		filters := []string{
+			fmt.Sprintf("name==%q", ref),
+			fmt.Sprintf(`target.digest~=/sha256:%s[0-9a-fA-F]{%d}/`, refOrID, 64-len(refOrID)),
+		}
+		imgs, err := is.List(ctx, filters...)
+		if err != nil {
+			return img, err
+		}
+
+		if len(imgs) == 0 {
+			return img, errdefs.NotFound(errors.New("list returned no images"))
+		}
+		if len(imgs) > 1 {
+			digests := map[digest.Digest]struct{}{}
+			for _, img := range imgs {
+				if img.Name == ref {
+					return img, nil
+				}
+				digests[img.Target.Digest] = struct{}{}
+			}
+
+			if len(digests) > 1 {
+				return img, errdefs.NotFound(errors.New("ambiguous reference"))
+			}
+		}
+
+		if imgs[0].Name != ref {
+			namedRef = nil
+		}
+		return imgs[0], nil
+	}
+	img, err = is.Get(ctx, namedRef.String())
+	if err != nil {
+		// TODO(containerd): error translation can use common function
+		if !cerrdefs.IsNotFound(err) {
+			return img, err
+		}
+		return img, errdefs.NotFound(errors.New("id not found"))
+	}
+
+	return img, nil
+}
+
+func (i *ImageService) resolveImageName(ctx context.Context, refOrID string) (ocispec.Descriptor, reference.Named, error) {
+	parsed, err := reference.ParseAnyReference(refOrID)
+	if err != nil {
+		return ocispec.Descriptor{}, nil, errdefs.InvalidParameter(err)
+	}
+
+	is := i.client.ImageService()
+
+	namedRef, ok := parsed.(reference.Named)
+	if !ok {
+		digested, ok := parsed.(reference.Digested)
+		if !ok {
+			return ocispec.Descriptor{}, nil, errdefs.InvalidParameter(errors.New("bad reference"))
+		}
+
+		imgs, err := is.List(ctx, fmt.Sprintf("target.digest==%s", digested.Digest()))
+		if err != nil {
+			return ocispec.Descriptor{}, nil, errors.Wrap(err, "failed to lookup digest")
+		}
+		if len(imgs) == 0 {
+			return ocispec.Descriptor{}, nil, errdefs.NotFound(errors.New("image not found with digest"))
+		}
+
+		return imgs[0].Target, nil, nil
+	}
+
+	namedRef = reference.TagNameOnly(namedRef)
+
+	// If the identifier could be a short ID, attempt to match
+	if shortID.MatchString(refOrID) {
+		ref := namedRef.String()
+		filters := []string{
+			fmt.Sprintf("name==%q", ref),
+			fmt.Sprintf(`target.digest~=/sha256:%s[0-9a-fA-F]{%d}/`, refOrID, 64-len(refOrID)),
+		}
+		imgs, err := is.List(ctx, filters...)
+		if err != nil {
+			return ocispec.Descriptor{}, nil, err
+		}
+
+		if len(imgs) == 0 {
+			return ocispec.Descriptor{}, nil, errdefs.NotFound(errors.New("list returned no images"))
+		}
+		if len(imgs) > 1 {
+			digests := map[digest.Digest]struct{}{}
+			for _, img := range imgs {
+				if img.Name == ref {
+					return img.Target, namedRef, nil
+				}
+				digests[img.Target.Digest] = struct{}{}
+			}
+
+			if len(digests) > 1 {
+				return ocispec.Descriptor{}, nil, errdefs.NotFound(errors.New("ambiguous reference"))
+			}
+		}
+
+		if imgs[0].Name != ref {
+			namedRef = nil
+		}
+		return imgs[0].Target, namedRef, nil
+	}
+	img, err := is.Get(ctx, namedRef.String())
+	if err != nil {
+		// TODO(containerd): error translation can use common function
+		if !cerrdefs.IsNotFound(err) {
+			return ocispec.Descriptor{}, nil, err
+		}
+		return ocispec.Descriptor{}, nil, errdefs.NotFound(errors.New("id not found"))
+	}
+
+	return img.Target, namedRef, nil
 }

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containerd/containerd/content"
 	cerrdefs "github.com/containerd/containerd/errdefs"
 	containerdimages "github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
 	"github.com/docker/distribution/reference"
 	containertypes "github.com/docker/docker/api/types/container"
 	imagetype "github.com/docker/docker/api/types/image"
@@ -62,12 +63,15 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 }
 
 func (i *ImageService) getImage(ctx context.Context, refOrID string, platform *ocispec.Platform) (containerd.Image, *image.Image, error) {
-	// TODO(rumpl): pass the platform
-	ctrdimg, err := i.resolveImage(ctx, refOrID)
+	ctrdimg, err := i.resolveImage(ctx, refOrID, platform)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	containerdImage := containerd.NewImage(i.client, ctrdimg)
+	if platform != nil {
+		containerdImage = containerd.NewImageWithPlatform(i.client, ctrdimg, platforms.OnlyStrict(*platform))
+	}
 	provider := i.client.ContentStore()
 	conf, err := ctrdimg.Config(ctx, provider, containerdImage.Platform())
 	if err != nil {
@@ -120,7 +124,7 @@ func (i *ImageService) getImage(ctx context.Context, refOrID string, platform *o
 // resolveImage searches for an image based on the given
 // reference or identifier. Returns the descriptor of
 // the image, could be manifest list, manifest, or config.
-func (i *ImageService) resolveImage(ctx context.Context, refOrID string) (img containerdimages.Image, err error) {
+func (i *ImageService) resolveImage(ctx context.Context, refOrID string, platform *ocispec.Platform) (img containerdimages.Image, err error) {
 	parsed, err := reference.ParseAnyReference(refOrID)
 	if err != nil {
 		return containerdimages.Image{}, errdefs.InvalidParameter(err)
@@ -192,6 +196,20 @@ func (i *ImageService) resolveImage(ctx context.Context, refOrID string) (img co
 		// FIXME(thaJeztah): we need to fix this; if needed, gated by API version (API < X add the prefix)
 		return containerdimages.Image{}, errdefs.NotFound(errors.New("No such image: " + refOrID))
 	}
+	if platform != nil {
+		cs := i.client.ContentStore()
+		imgPlatforms, err := containerdimages.Platforms(ctx, cs, img.Target)
+		if err != nil {
+			return img, err
+		}
 
+		comparer := platforms.Only(*platform)
+		for _, p := range imgPlatforms {
+			if comparer.Match(p) {
+				return img, nil
+			}
+		}
+		return img, errdefs.NotFound(errors.Errorf("platform %s not supported", platforms.Format(*platform)))
+	}
 	return img, nil
 }

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -36,13 +36,18 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 			return nil, err
 		}
 
-		name, err := reference.ParseNamed(containerdImage.Name())
-		if err != nil {
-			return nil, err
+		tagged, err := i.client.ImageService().List(ctx, fmt.Sprintf("target.digest==%s", containerdImage.Target().Digest.String()))
+		tags := make([]reference.Named, 0, len(tagged))
+		for _, i := range tagged {
+			name, err := reference.ParseNamed(i.Name)
+			if err != nil {
+				return nil, err
+			}
+			tags = append(tags, name)
 		}
 
 		img.Details = &image.Details{
-			References:  []reference.Named{name},
+			References:  tags,
 			Size:        size,
 			Metadata:    nil,
 			Driver:      i.snapshotter,

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
+	"github.com/docker/go-connections/nat"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -37,6 +38,9 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 		}
 
 		tagged, err := i.client.ImageService().List(ctx, fmt.Sprintf("target.digest==%s", containerdImage.Target().Digest.String()))
+		if err != nil {
+			return nil, err
+		}
 		tags := make([]reference.Named, 0, len(tagged))
 		for _, i := range tagged {
 			name, err := reference.ParseNamed(i.Name)
@@ -92,17 +96,23 @@ func (i *ImageService) getImage(ctx context.Context, refOrID string, platform *o
 	for _, id := range fs {
 		rootfs.Append(layer.DiffID(id))
 	}
+	exposedPorts := make(nat.PortSet, len(ociimage.Config.ExposedPorts))
+	for k, v := range ociimage.Config.ExposedPorts {
+		exposedPorts[nat.Port(k)] = v
+	}
 	return containerdImage, &image.Image{
 		V1Image: image.V1Image{
 			ID:           string(desc.Digest),
 			OS:           ociimage.OS,
 			Architecture: ociimage.Architecture,
 			Config: &containertypes.Config{
-				Entrypoint: ociimage.Config.Entrypoint,
-				Env:        ociimage.Config.Env,
-				Cmd:        ociimage.Config.Cmd,
-				User:       ociimage.Config.User,
-				WorkingDir: ociimage.Config.WorkingDir,
+				Entrypoint:   ociimage.Config.Entrypoint,
+				Env:          ociimage.Config.Env,
+				Cmd:          ociimage.Config.Cmd,
+				User:         ociimage.Config.User,
+				WorkingDir:   ociimage.Config.WorkingDir,
+				ExposedPorts: exposedPorts,
+				Volumes:      ociimage.Config.Volumes,
 			},
 		},
 		RootFS: rootfs,

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -96,23 +96,25 @@ func (i *ImageService) getImage(ctx context.Context, refOrID string, platform *o
 	for k, v := range ociimage.Config.ExposedPorts {
 		exposedPorts[nat.Port(k)] = v
 	}
-	return containerdImage, &image.Image{
-		V1Image: image.V1Image{
-			ID:           string(ctrdimg.Target.Digest),
-			OS:           ociimage.OS,
-			Architecture: ociimage.Architecture,
-			Config: &containertypes.Config{
-				Entrypoint:   ociimage.Config.Entrypoint,
-				Env:          ociimage.Config.Env,
-				Cmd:          ociimage.Config.Cmd,
-				User:         ociimage.Config.User,
-				WorkingDir:   ociimage.Config.WorkingDir,
-				ExposedPorts: exposedPorts,
-				Volumes:      ociimage.Config.Volumes,
-			},
+
+	img := image.NewImage(image.IDFromDigest(ctrdimg.Target.Digest))
+	img.V1Image = image.V1Image{
+		ID:           string(ctrdimg.Target.Digest),
+		OS:           ociimage.OS,
+		Architecture: ociimage.Architecture,
+		Config: &containertypes.Config{
+			Entrypoint:   ociimage.Config.Entrypoint,
+			Env:          ociimage.Config.Env,
+			Cmd:          ociimage.Config.Cmd,
+			User:         ociimage.Config.User,
+			WorkingDir:   ociimage.Config.WorkingDir,
+			ExposedPorts: exposedPorts,
+			Volumes:      ociimage.Config.Volumes,
 		},
-		RootFS: rootfs,
-	}, nil
+	}
+	img.RootFS = rootfs
+
+	return containerdImage, img, nil
 }
 
 // resolveImage searches for an image based on the given

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -35,7 +35,14 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 		if err != nil {
 			return nil, err
 		}
+
+		name, err := reference.ParseNamed(containerdImage.Name())
+		if err != nil {
+			return nil, err
+		}
+
 		img.Details = &image.Details{
+			References:  []reference.Named{name},
 			Size:        size,
 			Metadata:    nil,
 			Driver:      i.snapshotter,

--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -176,6 +176,7 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 			return nil, err
 		}
 		img.Details = &image.Details{
+			References:  i.referenceStore.References(img.ID().Digest()),
 			Size:        size,
 			Metadata:    layerMetadata,
 			Driver:      i.layerStore.DriverName(),

--- a/image/image.go
+++ b/image/image.go
@@ -201,6 +201,13 @@ type ChildConfig struct {
 	Config          *container.Config
 }
 
+// NewImage creates a new image with the given ID
+func NewImage(id ID) *Image {
+	return &Image{
+		computedID: id,
+	}
+}
+
 // NewChildImage creates a new Image as a child of this image.
 func NewChildImage(img *Image, child ChildConfig, os string) *Image {
 	isEmptyLayer := layer.IsEmpty(child.DiffID)

--- a/image/image.go
+++ b/image/image.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/layer"
@@ -119,6 +120,7 @@ type Image struct {
 
 // Details provides additional image data
 type Details struct {
+	References  []reference.Named
 	Size        int64
 	Metadata    map[string]string
 	Driver      string


### PR DESCRIPTION
- alternative for https://github.com/moby/moby/pull/43818

This upstreams a set of (partial) patches:

- https://github.com/rumpl/moby/pull/8
- https://github.com/rumpl/moby/pull/122
- https://github.com/rumpl/moby/pull/27
- https://github.com/rumpl/moby/pull/55
- https://github.com/rumpl/moby/pull/68
- https://github.com/rumpl/moby/pull/88
- https://github.com/rumpl/moby/pull/114
- https://github.com/rumpl/moby/pull/90
- https://github.com/rumpl/moby/pull/93
- https://github.com/rumpl/moby/pull/98

These patches were selected by looking at the history for https://github.com/rumpl/moby/commits/dd-4.15.0/daemon/containerd/image.go, and only the relevant parts for this feature were included.

Quite a few of those are touching-up previous commits, so we should consider squashing (some of) them, but keeping them separate for now to somewhat help review.

```
p 85d6399836 add support for image inspect
p fa430d6686 Implement run using the containerd snapshotter
p d37b797d34 introduce GetImageOpts to manage image inspect data in backend
p 4543499f86 Introduce support for docker commit
p f1213b08bd Fix linting issues
p 2840f63ee6 GetImage to return image tags with details
p 75df7b7a05 list images matching digest to discover all tags
p d9b76c6682 c8d/prune: Handle filters, don't delete used
p a930139556 Add ExposedPorts and Volumes to the image returned
p 8df0a88265 Refactor resolving/getting images
p d58184802b Return the image ID on inspect
p 61ea993343 consider digest and ignore tag when both are set
p eaa810ab98 docker run --platform
p ab6918735d c8d/builder: store untagged images
p 960cff2c71 c8d/commit: Save as dangling name
p f7962b37ef Remove the call to resolveImage
p 9ac5d768c7 Handle multi-platform images when listing them
```

Also included https://github.com/rumpl/moby/pull/122

```
p a5a01b5cf7 daemon/containerd: fix compat for "docker run" with image that's not present
```