### PR TITLE
manage image inspect data in backend

### DIFF
--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -22,7 +22,7 @@ type Backend interface {
 
 type imageBackend interface {
 	ImageDelete(ctx context.Context, imageRef string, force, prune bool) ([]types.ImageDeleteResponseItem, error)
-	ImageHistory(imageName string) ([]*image.HistoryResponseItem, error)
+	ImageHistory(ctx context.Context, imageName string) ([]*image.HistoryResponseItem, error)
 	Images(ctx context.Context, opts types.ImageListOptions) ([]*types.ImageSummary, error)
 	GetImage(ctx context.Context, refOrID string, options image.GetImageOpts) (*dockerimage.Image, error)
 	TagImage(imageName, repository, tag string) (string, error)

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -321,7 +321,7 @@ func (ir *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter,
 }
 
 func (ir *imageRouter) getImagesHistory(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	history, err := ir.backend.ImageHistory(vars["name"])
+	history, err := ir.backend.ImageHistory(ctx, vars["name"])
 	if err != nil {
 		return err
 	}

--- a/api/types/image/opts.go
+++ b/api/types/image/opts.go
@@ -5,4 +5,5 @@ import specs "github.com/opencontainers/image-spec/specs-go/v1"
 // GetImageOpts holds parameters to inspect an image.
 type GetImageOpts struct {
 	Platform *specs.Platform
+	Details  bool
 }

--- a/daemon/containerd/image_history.go
+++ b/daemon/containerd/image_history.go
@@ -1,6 +1,7 @@
 package containerd
 
 import (
+	"context"
 	"errors"
 
 	imagetype "github.com/docker/docker/api/types/image"
@@ -9,6 +10,6 @@ import (
 
 // ImageHistory returns a slice of ImageHistory structures for the specified
 // image name by walking the image lineage.
-func (i *ImageService) ImageHistory(name string) ([]*imagetype.HistoryResponseItem, error) {
+func (i *ImageService) ImageHistory(ctx context.Context, name string) ([]*imagetype.HistoryResponseItem, error) {
 	return nil, errdefs.NotImplemented(errors.New("not implemented"))
 }

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -40,7 +40,7 @@ type ImageService interface {
 	TagImage(imageName, repository, tag string) (string, error)
 	TagImageWithReference(imageID image.ID, newTag reference.Named) error
 	GetImage(ctx context.Context, refOrID string, options imagetype.GetImageOpts) (*image.Image, error)
-	ImageHistory(name string) ([]*imagetype.HistoryResponseItem, error)
+	ImageHistory(ctx context.Context, name string) ([]*imagetype.HistoryResponseItem, error)
 	CommitImage(c backend.CommitConfig) (image.ID, error)
 	SquashImage(id, parent string) (string, error)
 

--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -15,6 +15,7 @@ import (
 	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
+	"github.com/docker/docker/layer"
 	"github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -148,7 +149,43 @@ func (i *ImageService) manifestMatchesPlatform(ctx context.Context, img *image.I
 }
 
 // GetImage returns an image corresponding to the image referred to by refOrID.
-func (i *ImageService) GetImage(ctx context.Context, refOrID string, options imagetypes.GetImageOpts) (retImg *image.Image, retErr error) {
+func (i *ImageService) GetImage(ctx context.Context, refOrID string, options imagetypes.GetImageOpts) (*image.Image, error) {
+	img, err := i.getImage(ctx, refOrID, options)
+	if err != nil {
+		return nil, err
+	}
+	if options.Details {
+		var size int64
+		var layerMetadata map[string]string
+		layerID := img.RootFS.ChainID()
+		if layerID != "" {
+			l, err := i.layerStore.Get(layerID)
+			if err != nil {
+				return nil, err
+			}
+			defer layer.ReleaseAndLog(i.layerStore, l)
+			size = l.Size()
+			layerMetadata, err = l.Metadata()
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		lastUpdated, err := i.imageStore.GetLastUpdated(img.ID())
+		if err != nil {
+			return nil, err
+		}
+		img.Details = &image.Details{
+			Size:        size,
+			Metadata:    layerMetadata,
+			Driver:      i.layerStore.DriverName(),
+			LastUpdated: lastUpdated,
+		}
+	}
+	return img, nil
+}
+
+func (i *ImageService) getImage(ctx context.Context, refOrID string, options imagetypes.GetImageOpts) (retImg *image.Image, retErr error) {
 	defer func() {
 		if retErr != nil || retImg == nil || options.Platform == nil {
 			return

--- a/daemon/images/image_history.go
+++ b/daemon/images/image_history.go
@@ -12,8 +12,7 @@ import (
 
 // ImageHistory returns a slice of ImageHistory structures for the specified image
 // name by walking the image lineage.
-func (i *ImageService) ImageHistory(name string) ([]*image.HistoryResponseItem, error) {
-	ctx := context.TODO()
+func (i *ImageService) ImageHistory(ctx context.Context, name string) ([]*image.HistoryResponseItem, error) {
 	start := time.Now()
 	img, err := i.GetImage(ctx, name, image.GetImageOpts{})
 	if err != nil {

--- a/image/image.go
+++ b/image/image.go
@@ -112,6 +112,17 @@ type Image struct {
 	// computedID is the ID computed from the hash of the image config.
 	// Not to be confused with the legacy V1 ID in V1Image.
 	computedID ID
+
+	// Details holds additional details about image
+	Details *Details `json:"-"`
+}
+
+// Details provides additional image data
+type Details struct {
+	Size        int64
+	Metadata    map[string]string
+	Driver      string
+	LastUpdated time.Time
 }
 
 // RawJSON returns the immutable JSON associated with the image.


### PR DESCRIPTION
- upstreaming https://github.com/rumpl/moby/pull/27
- replaces https://github.com/moby/moby/pull/44080
- closes https://github.com/moby/moby/pull/44080
- relates to https://github.com/moby/moby/pull/44621
- relates to https://github.com/moby/moby/pull/43818

### manage image inspect data in backend

This allows differentiating how the detailed data is collected between
the containerd-integration code and the existing implementation.

This PR is a subset of the changes in  https://github.com/rumpl/moby/pull/27, and only implements the changes for the existing backend. Changes for the containerd-integration variant are done in https://github.com/moby/moby/pull/44621