### PR TITLE
[23.0 backport] vendor: update dependencies for fluentd

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -134,7 +134,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/phayes/permbits v0.0.0-20190612203442-39d7c581d2ee // indirect
-	github.com/philhofer/fwd v1.0.0 // indirect
+	github.com/philhofer/fwd v1.1.2 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect

--- a/vendor.mod
+++ b/vendor.mod
@@ -140,7 +140,7 @@ require (
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/rexray/gocsi v1.2.2 // indirect
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
-	github.com/tinylib/msgp v1.1.0 // indirect
+	github.com/tinylib/msgp v1.1.6 // indirect
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.6 // indirect
 	go.etcd.io/etcd/pkg/v3 v3.5.6 // indirect

--- a/vendor.sum
+++ b/vendor.sum
@@ -914,8 +914,8 @@ github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/phayes/permbits v0.0.0-20190612203442-39d7c581d2ee h1:P6U24L02WMfj9ymZTxl7CxS73JC99x3ukk+DBkgQGQs=
 github.com/phayes/permbits v0.0.0-20190612203442-39d7c581d2ee/go.mod h1:3uODdxMgOaPYeWU7RzZLxVtJHZ/x1f/iHkBZuKJDzuY=
-github.com/philhofer/fwd v1.0.0 h1:UbZqGr5Y38ApvM/V/jEljVxwocdweyH+vmYvRPBnbqQ=
-github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
+github.com/philhofer/fwd v1.1.2 h1:bnDivRJ1EWPjUIRXV5KfORO897HTbpFAQddBdE8t7Gw=
+github.com/philhofer/fwd v1.1.2/go.mod h1:qkPdfjR2SIEbspLqpe1tO4n5yICnr2DY7mqEx2tUTP0=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/vendor.sum
+++ b/vendor.sum
@@ -914,6 +914,7 @@ github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/phayes/permbits v0.0.0-20190612203442-39d7c581d2ee h1:P6U24L02WMfj9ymZTxl7CxS73JC99x3ukk+DBkgQGQs=
 github.com/phayes/permbits v0.0.0-20190612203442-39d7c581d2ee/go.mod h1:3uODdxMgOaPYeWU7RzZLxVtJHZ/x1f/iHkBZuKJDzuY=
+github.com/philhofer/fwd v1.1.1/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/philhofer/fwd v1.1.2 h1:bnDivRJ1EWPjUIRXV5KfORO897HTbpFAQddBdE8t7Gw=
 github.com/philhofer/fwd v1.1.2/go.mod h1:qkPdfjR2SIEbspLqpe1tO4n5yICnr2DY7mqEx2tUTP0=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -1054,8 +1055,8 @@ github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ
 github.com/tchap/go-patricia v2.3.0+incompatible h1:GkY4dP3cEfEASBPPkWd+AmjYxhmDkqO9/zg7R0lSQRs=
 github.com/tchap/go-patricia v2.3.0+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/thecodeteam/gosync v0.1.0/go.mod h1:43QHsngcnWc8GE1aCmi7PEypslflHjCzXFleuWKEb00=
-github.com/tinylib/msgp v1.1.0 h1:9fQd+ICuRIu/ue4vxJZu6/LzxN0HwMds2nq/0cFvxHU=
-github.com/tinylib/msgp v1.1.0/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
+github.com/tinylib/msgp v1.1.6 h1:i+SbKraHhnrf9M5MYmvQhFnbLhAXSDWF8WWsuyRdocw=
+github.com/tinylib/msgp v1.1.6/go.mod h1:75BAfg2hauQhs3qedfdDZmWAPcFMAvJE5b9rGOMufyw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -1570,6 +1571,7 @@ golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
 golang.org/x/tools v0.0.0-20200916195026-c9a70fc28ce3/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
+golang.org/x/tools v0.0.0-20201022035929-9cf592e881e9/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=

--- a/vendor/github.com/philhofer/fwd/README.md
+++ b/vendor/github.com/philhofer/fwd/README.md
@@ -1,17 +1,25 @@
 
 # fwd
-    import "github.com/philhofer/fwd"
 
-The `fwd` package provides a buffered reader
+[![Go Reference](https://pkg.go.dev/badge/github.com/philhofer/fwd.svg)](https://pkg.go.dev/github.com/philhofer/fwd)
+
+
+`import "github.com/philhofer/fwd"`
+
+* [Overview](#pkg-overview)
+* [Index](#pkg-index)
+
+## <a name="pkg-overview">Overview</a>
+Package fwd provides a buffered reader
 and writer. Each has methods that help improve
 the encoding/decoding performance of some binary
 protocols.
 
-The `fwd.Writer` and `fwd.Reader` type provide similar
+The `Writer` and `Reader` type provide similar
 functionality to their counterparts in `bufio`, plus
 a few extra utility methods that simplify read-ahead
 and write-ahead. I wrote this package to improve serialization
-performance for <a href="http://github.com/tinylib/msgp">http://github.com/tinylib/msgp</a>,
+performance for [github.com/tinylib/msgp](https://github.com/tinylib/msgp),
 where it provided about a 2x speedup over `bufio` for certain
 workloads. However, care must be taken to understand the semantics of the
 extra methods provided by this package, as they allow
@@ -39,7 +47,37 @@ to write directly to the end of the buffer.
 
 
 
-## Constants
+## <a name="pkg-index">Index</a>
+* [Constants](#pkg-constants)
+* [type Reader](#Reader)
+  * [func NewReader(r io.Reader) *Reader](#NewReader)
+  * [func NewReaderBuf(r io.Reader, buf []byte) *Reader](#NewReaderBuf)
+  * [func NewReaderSize(r io.Reader, n int) *Reader](#NewReaderSize)
+  * [func (r *Reader) BufferSize() int](#Reader.BufferSize)
+  * [func (r *Reader) Buffered() int](#Reader.Buffered)
+  * [func (r *Reader) Next(n int) ([]byte, error)](#Reader.Next)
+  * [func (r *Reader) Peek(n int) ([]byte, error)](#Reader.Peek)
+  * [func (r *Reader) Read(b []byte) (int, error)](#Reader.Read)
+  * [func (r *Reader) ReadByte() (byte, error)](#Reader.ReadByte)
+  * [func (r *Reader) ReadFull(b []byte) (int, error)](#Reader.ReadFull)
+  * [func (r *Reader) Reset(rd io.Reader)](#Reader.Reset)
+  * [func (r *Reader) Skip(n int) (int, error)](#Reader.Skip)
+  * [func (r *Reader) WriteTo(w io.Writer) (int64, error)](#Reader.WriteTo)
+* [type Writer](#Writer)
+  * [func NewWriter(w io.Writer) *Writer](#NewWriter)
+  * [func NewWriterBuf(w io.Writer, buf []byte) *Writer](#NewWriterBuf)
+  * [func NewWriterSize(w io.Writer, n int) *Writer](#NewWriterSize)
+  * [func (w *Writer) BufferSize() int](#Writer.BufferSize)
+  * [func (w *Writer) Buffered() int](#Writer.Buffered)
+  * [func (w *Writer) Flush() error](#Writer.Flush)
+  * [func (w *Writer) Next(n int) ([]byte, error)](#Writer.Next)
+  * [func (w *Writer) ReadFrom(r io.Reader) (int64, error)](#Writer.ReadFrom)
+  * [func (w *Writer) Write(p []byte) (int, error)](#Writer.Write)
+  * [func (w *Writer) WriteByte(b byte) error](#Writer.WriteByte)
+  * [func (w *Writer) WriteString(s string) (int, error)](#Writer.WriteString)
+
+
+## <a name="pkg-constants">Constants</a>
 ``` go
 const (
     // DefaultReaderSize is the default size of the read buffer
@@ -121,7 +159,7 @@ and the reader position will not be incremented.
 
 
 
-### func (\*Reader) Peek
+### <a name="Reader.Peek">func</a> (\*Reader) Peek
 ``` go
 func (r *Reader) Peek(n int) ([]byte, error)
 ```
@@ -134,23 +172,23 @@ io.ErrUnexpectedEOF.
 
 
 
-### func (\*Reader) Read
+### <a name="Reader.Read">func</a> (\*Reader) Read
 ``` go
 func (r *Reader) Read(b []byte) (int, error)
 ```
-Read implements `io.Reader`
+Read implements `io.Reader`.
 
 
 
-### func (\*Reader) ReadByte
+### <a name="Reader.ReadByte">func</a> (\*Reader) ReadByte
 ``` go
 func (r *Reader) ReadByte() (byte, error)
 ```
-ReadByte implements `io.ByteReader`
+ReadByte implements `io.ByteReader`.
 
 
 
-### func (\*Reader) ReadFull
+### <a name="Reader.ReadFull">func</a> (\*Reader) ReadFull
 ``` go
 func (r *Reader) ReadFull(b []byte) (int, error)
 ```
@@ -161,7 +199,7 @@ EOF is considered an unexpected error.
 
 
 
-### func (\*Reader) Reset
+### <a name="Reader.Reset">func</a> (\*Reader) Reset
 ``` go
 func (r *Reader) Reset(rd io.Reader)
 ```
@@ -170,7 +208,7 @@ and the read buffer.
 
 
 
-### func (\*Reader) Skip
+### <a name="Reader.Skip">func</a> (\*Reader) Skip
 ``` go
 func (r *Reader) Skip(n int) (int, error)
 ```
@@ -182,27 +220,30 @@ that method will be used to skip forward.
 
 If the reader encounters
 an EOF before skipping 'n' bytes, it
-returns io.ErrUnexpectedEOF. If the
-underlying reader implements io.Seeker, then
+returns `io.ErrUnexpectedEOF`. If the
+underlying reader implements `io.Seeker`, then
 those rules apply instead. (Many implementations
 will not return `io.EOF` until the next call
-to Read.)
+to Read).
 
 
 
-### func (\*Reader) WriteTo
+
+### <a name="Reader.WriteTo">func</a> (\*Reader) WriteTo
 ``` go
 func (r *Reader) WriteTo(w io.Writer) (int64, error)
 ```
-WriteTo implements `io.WriterTo`
+WriteTo implements `io.WriterTo`.
 
 
 
-## type Writer
+
+## <a name="Writer">type</a> Writer
 ``` go
 type Writer struct {
     // contains filtered or unexported fields
 }
+
 ```
 Writer is a buffered writer
 
@@ -212,9 +253,7 @@ Writer is a buffered writer
 
 
 
-
-
-### func NewWriter
+### <a name="NewWriter">func</a> NewWriter
 ``` go
 func NewWriter(w io.Writer) *Writer
 ```
@@ -223,18 +262,24 @@ that writes to 'w' and has a buffer
 that is `DefaultWriterSize` bytes.
 
 
-### func NewWriterSize
+### <a name="NewWriterBuf">func</a> NewWriterBuf
 ``` go
-func NewWriterSize(w io.Writer, size int) *Writer
+func NewWriterBuf(w io.Writer, buf []byte) *Writer
 ```
-NewWriterSize returns a new writer
-that writes to 'w' and has a buffer
-that is 'size' bytes.
+NewWriterBuf returns a new writer
+that writes to 'w' and has 'buf' as a buffer.
+'buf' is not used when has smaller capacity than 18,
+custom buffer is allocated instead.
 
 
+### <a name="NewWriterSize">func</a> NewWriterSize
+``` go
+func NewWriterSize(w io.Writer, n int) *Writer
+```
+NewWriterSize returns a new writer that
+writes to 'w' and has a buffer size 'n'.
 
-
-### func (\*Writer) BufferSize
+### <a name="Writer.BufferSize">func</a> (\*Writer) BufferSize
 ``` go
 func (w *Writer) BufferSize() int
 ```
@@ -242,7 +287,7 @@ BufferSize returns the maximum size of the buffer.
 
 
 
-### func (\*Writer) Buffered
+### <a name="Writer.Buffered">func</a> (\*Writer) Buffered
 ``` go
 func (w *Writer) Buffered() int
 ```
@@ -251,7 +296,7 @@ in the reader.
 
 
 
-### func (\*Writer) Flush
+### <a name="Writer.Flush">func</a> (\*Writer) Flush
 ``` go
 func (w *Writer) Flush() error
 ```
@@ -260,7 +305,7 @@ to the underlying writer.
 
 
 
-### func (\*Writer) Next
+### <a name="Writer.Next">func</a> (\*Writer) Next
 ``` go
 func (w *Writer) Next(n int) ([]byte, error)
 ```
@@ -273,7 +318,7 @@ the size of the returned buffer.
 
 
 
-### func (\*Writer) ReadFrom
+### <a name="Writer.ReadFrom">func</a> (\*Writer) ReadFrom
 ``` go
 func (w *Writer) ReadFrom(r io.Reader) (int64, error)
 ```
@@ -281,7 +326,7 @@ ReadFrom implements `io.ReaderFrom`
 
 
 
-### func (\*Writer) Write
+### <a name="Writer.Write">func</a> (\*Writer) Write
 ``` go
 func (w *Writer) Write(p []byte) (int, error)
 ```
@@ -289,7 +334,7 @@ Write implements `io.Writer`
 
 
 
-### func (\*Writer) WriteByte
+### <a name="Writer.WriteByte">func</a> (\*Writer) WriteByte
 ``` go
 func (w *Writer) WriteByte(b byte) error
 ```
@@ -297,7 +342,7 @@ WriteByte implements `io.ByteWriter`
 
 
 
-### func (\*Writer) WriteString
+### <a name="Writer.WriteString">func</a> (\*Writer) WriteString
 ``` go
 func (w *Writer) WriteString(s string) (int, error)
 ```
@@ -310,6 +355,5 @@ WriteString is analogous to Write, but it takes a string.
 
 
 
-
 - - -
-Generated by [godoc2md](http://godoc.org/github.com/davecheney/godoc2md)
+Generated by [godoc2md](https://github.com/davecheney/godoc2md)

--- a/vendor/github.com/philhofer/fwd/writer.go
+++ b/vendor/github.com/philhofer/fwd/writer.go
@@ -29,16 +29,28 @@ func NewWriter(w io.Writer) *Writer {
 	}
 }
 
-// NewWriterSize returns a new writer
-// that writes to 'w' and has a buffer
-// that is 'size' bytes.
-func NewWriterSize(w io.Writer, size int) *Writer {
-	if wr, ok := w.(*Writer); ok && cap(wr.buf) >= size {
+// NewWriterSize returns a new writer that
+// writes to 'w' and has a buffer size 'n'.
+func NewWriterSize(w io.Writer, n int) *Writer {
+	if wr, ok := w.(*Writer); ok && cap(wr.buf) >= n {
 		return wr
 	}
+	buf := make([]byte, 0, max(n, minWriterSize))
+	return NewWriterBuf(w, buf)
+}
+
+// NewWriterBuf returns a new writer
+// that writes to 'w' and has 'buf' as a buffer.
+// 'buf' is not used when has smaller capacity than 18,
+// custom buffer is allocated instead.
+func NewWriterBuf(w io.Writer, buf []byte) *Writer {
+	if cap(buf) < minWriterSize {
+		buf = make([]byte, 0, minWriterSize)
+	}
+	buf = buf[:0]
 	return &Writer{
 		w:   w,
-		buf: make([]byte, 0, max(size, minWriterSize)),
+		buf: buf,
 	}
 }
 

--- a/vendor/github.com/philhofer/fwd/writer_appengine.go
+++ b/vendor/github.com/philhofer/fwd/writer_appengine.go
@@ -1,3 +1,4 @@
+//go:build appengine
 // +build appengine
 
 package fwd

--- a/vendor/github.com/philhofer/fwd/writer_tinygo.go
+++ b/vendor/github.com/philhofer/fwd/writer_tinygo.go
@@ -1,0 +1,19 @@
+//go:build tinygo
+// +build tinygo
+
+package fwd
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// unsafe cast string as []byte
+func unsafestr(b string) []byte {
+	l := uintptr(len(b))
+	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+		Len:  l,
+		Cap:  l,
+		Data: (*reflect.StringHeader)(unsafe.Pointer(&b)).Data,
+	}))
+}

--- a/vendor/github.com/philhofer/fwd/writer_unsafe.go
+++ b/vendor/github.com/philhofer/fwd/writer_unsafe.go
@@ -1,4 +1,5 @@
-// +build !appengine
+//go:build !appengine && !tinygo
+// +build !appengine,!tinygo
 
 package fwd
 
@@ -8,11 +9,12 @@ import (
 )
 
 // unsafe cast string as []byte
-func unsafestr(b string) []byte {
-	l := len(b)
-	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-		Len:  l,
-		Cap:  l,
-		Data: (*reflect.StringHeader)(unsafe.Pointer(&b)).Data,
-	}))
+func unsafestr(s string) []byte {
+	var b []byte
+	sHdr := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	bHdr := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	bHdr.Data = sHdr.Data
+	bHdr.Len = sHdr.Len
+	bHdr.Cap = sHdr.Len
+	return b
 }

--- a/vendor/github.com/tinylib/msgp/msgp/errors.go
+++ b/vendor/github.com/tinylib/msgp/msgp/errors.go
@@ -123,6 +123,9 @@ func (e errWrapped) Resumable() bool {
 	return resumableDefault
 }
 
+// Unwrap returns the cause.
+func (e errWrapped) Unwrap() error { return e.cause }
+
 type errShort struct{}
 
 func (e errShort) Error() string   { return "msgp: too few bytes left to read object" }

--- a/vendor/github.com/tinylib/msgp/msgp/extension.go
+++ b/vendor/github.com/tinylib/msgp/msgp/extension.go
@@ -474,8 +474,8 @@ func AppendExtension(b []byte, e Extension) ([]byte, error) {
 // and returns any remaining bytes.
 // Possible errors:
 // - ErrShortBytes ('b' not long enough)
-// - ExtensionTypeErorr{} (wire type not the same as e.Type())
-// - TypeErorr{} (next object not an extension)
+// - ExtensionTypeError{} (wire type not the same as e.Type())
+// - TypeError{} (next object not an extension)
 // - InvalidPrefixError
 // - An umarshal error returned from e.UnmarshalBinary
 func ReadExtensionBytes(b []byte, e Extension) ([]byte, error) {

--- a/vendor/github.com/tinylib/msgp/msgp/read.go
+++ b/vendor/github.com/tinylib/msgp/msgp/read.go
@@ -126,6 +126,11 @@ func NewReaderSize(r io.Reader, sz int) *Reader {
 	return &Reader{R: fwd.NewReaderSize(r, sz)}
 }
 
+// NewReaderBuf returns a *Reader with a provided buffer.
+func NewReaderBuf(r io.Reader, buf []byte) *Reader {
+	return &Reader{R: fwd.NewReaderBuf(r, buf)}
+}
+
 // Reader wraps an io.Reader and provides
 // methods to read MessagePack-encoded values
 // from it. Readers are buffered.

--- a/vendor/github.com/tinylib/msgp/msgp/unsafe.go
+++ b/vendor/github.com/tinylib/msgp/msgp/unsafe.go
@@ -3,7 +3,6 @@
 package msgp
 
 import (
-	"reflect"
 	"unsafe"
 )
 
@@ -24,18 +23,14 @@ const (
 // THIS IS EVIL CODE.
 // YOU HAVE BEEN WARNED.
 func UnsafeString(b []byte) string {
-	sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	return *(*string)(unsafe.Pointer(&reflect.StringHeader{Data: sh.Data, Len: sh.Len}))
+	return *(*string)(unsafe.Pointer(&b))
 }
 
 // UnsafeBytes returns the string as a byte slice
-// THIS SHOULD ONLY BE USED BY THE CODE GENERATOR.
-// THIS IS EVIL CODE.
-// YOU HAVE BEEN WARNED.
+//
+// Deprecated:
+// Since this code is no longer used by the code generator,
+// UnsafeBytes(s) is precisely equivalent to []byte(s)
 func UnsafeBytes(s string) []byte {
-	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-		Len:  len(s),
-		Cap:  len(s),
-		Data: (*(*reflect.StringHeader)(unsafe.Pointer(&s))).Data,
-	}))
+	return []byte(s)
 }

--- a/vendor/github.com/tinylib/msgp/msgp/write.go
+++ b/vendor/github.com/tinylib/msgp/msgp/write.go
@@ -10,6 +10,11 @@ import (
 	"time"
 )
 
+const (
+	// min buffer size for the writer
+	minWriterSize = 18
+)
+
 // Sizer is an interface implemented
 // by types that can estimate their
 // size when MessagePack encoded.
@@ -120,16 +125,27 @@ func NewWriter(w io.Writer) *Writer {
 
 // NewWriterSize returns a writer with a custom buffer size.
 func NewWriterSize(w io.Writer, sz int) *Writer {
-	// we must be able to require() 18
+	// we must be able to require() 'minWriterSize'
 	// contiguous bytes, so that is the
 	// practical minimum buffer size
-	if sz < 18 {
-		sz = 18
+	if sz < minWriterSize {
+		sz = minWriterSize
 	}
+	buf := make([]byte, sz)
+	return NewWriterBuf(w, buf)
+}
 
+// NewWriterBuf returns a writer with a provided buffer.
+// 'buf' is not used when the capacity is smaller than 18,
+// custom buffer is allocated instead.
+func NewWriterBuf(w io.Writer, buf []byte) *Writer {
+	if cap(buf) < minWriterSize {
+		buf = make([]byte, minWriterSize)
+	}
+	buf = buf[:cap(buf)]
 	return &Writer{
 		w:   w,
-		buf: make([]byte, sz),
+		buf: buf,
 	}
 }
 

--- a/vendor/github.com/tinylib/msgp/msgp/write_bytes.go
+++ b/vendor/github.com/tinylib/msgp/msgp/write_bytes.go
@@ -193,6 +193,26 @@ func AppendBytes(b []byte, bts []byte) []byte {
 	return o[:n+copy(o[n:], bts)]
 }
 
+// AppendBytesHeader appends an 'bin' header with
+// the given size to the slice.
+func AppendBytesHeader(b []byte, sz uint32) []byte {
+	var o []byte
+	var n int
+	switch {
+	case sz <= math.MaxUint8:
+		o, n = ensure(b, 2)
+		prefixu8(o[n:], mbin8, uint8(sz))
+		return o
+	case sz <= math.MaxUint16:
+		o, n = ensure(b, 3)
+		prefixu16(o[n:], mbin16, uint16(sz))
+		return o
+	}
+	o, n = ensure(b, 5)
+	prefixu32(o[n:], mbin32, sz)
+	return o
+}
+
 // AppendBool appends a bool to the slice
 func AppendBool(b []byte, t bool) []byte {
 	if t {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -734,8 +734,8 @@ github.com/opencontainers/selinux/pkg/pwalkdir
 github.com/pelletier/go-toml
 # github.com/phayes/permbits v0.0.0-20190612203442-39d7c581d2ee
 ## explicit
-# github.com/philhofer/fwd v1.0.0
-## explicit
+# github.com/philhofer/fwd v1.1.2
+## explicit; go 1.15
 github.com/philhofer/fwd
 # github.com/pkg/errors v0.9.1
 ## explicit

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -780,8 +780,8 @@ github.com/spf13/pflag
 # github.com/tchap/go-patricia v2.3.0+incompatible
 ## explicit
 github.com/tchap/go-patricia/patricia
-# github.com/tinylib/msgp v1.1.0
-## explicit
+# github.com/tinylib/msgp v1.1.6
+## explicit; go 1.14
 github.com/tinylib/msgp/msgp
 # github.com/tonistiigi/fsutil v0.0.0-20220315205639-9ed612626da3
 ## explicit; go 1.13


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44625

### vendor: github.com/philhofer/fwd v1.1.2

This is an (indirect) dependency of github.com/fluent/fluent-logger-golang,
which currently does not provide a go.mod, but tests against the latest
versions of its dependencies.

Updating this dependency to the latest version.

full diff: https://github.com/philhofer/fwd/compare/v1.0.0...v1.1.2


### vendor: github.com/tinylib/msgp v1.1.6

This is a dependency of github.com/fluent/fluent-logger-golang, which
currently does not provide a go.mod, but tests against the latest
versions of its dependencies.

Updating this dependency to the latest version.

Notable changes:

- all: implement omitempty
- fix: JSON encoder may produce invalid utf-8 when provided invalid utf-8 message pack string.
- added Unwrap method to errWrapped plus tests; switched travis to go 1.14
- CopyToJSON: fix bitSize for floats
- Add Reader/Writer constructors with custom buffer
- Add missing bin header functions
- msgp/unsafe: bring code in line with unsafe guidelines
- msgp/msgp: fix ReadMapKeyZC (fix "Fail to decode string encoded as bin type")

full diff: https://github.com/tinylib/msgp/compare/v1.1.0...v1.1.6
