### PR TITLE
daemon: CreateNetwork: remove redundant error check

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -283,11 +283,7 @@ func (daemon *Daemon) CreateManagedNetwork(create clustertypes.NetworkCreateRequ
 
 // CreateNetwork creates a network with the given name, driver and other optional parameters
 func (daemon *Daemon) CreateNetwork(create types.NetworkCreateRequest) (*types.NetworkCreateResponse, error) {
-	resp, err := daemon.createNetwork(create, "", false)
-	if err != nil {
-		return nil, err
-	}
-	return resp, err
+	return daemon.createNetwork(create, "", false)
 }
 
 func (daemon *Daemon) createNetwork(create types.NetworkCreateRequest, id string, agent bool) (*types.NetworkCreateResponse, error) {


### PR DESCRIPTION
the non-exported "daemon.createNetwork" already returns nil if there's an error, so no need to check the error.


**- A picture of a cute animal (not mandatory but encouraged)**

