### PR TITLE
Prevent containers from being included in List API before they are registered

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -233,7 +233,7 @@ func (daemon *Daemon) setHostConfig(container *container.Container, hostConfig *
 
 	runconfig.SetDefaultNetModeIfBlank(hostConfig)
 	container.HostConfig = hostConfig
-	return container.CheckpointTo(daemon.containersReplica)
+	return nil
 }
 
 // verifyContainerSettings performs validation of the hostconfig and config

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -56,7 +56,18 @@ func (daemon *Daemon) GetContainer(prefixOrName string) (*container.Container, e
 		}
 		return nil, errdefs.System(indexError)
 	}
-	return daemon.containers.Get(containerID), nil
+	ctr := daemon.containers.Get(containerID)
+	if ctr == nil {
+		// Updates to the daemon.containersReplica ViewDB are not atomic
+		// or consistent w.r.t. the live daemon.containers Store so
+		// while reaching this code path may be indicative of a bug,
+		// it is not _necessarily_ the case.
+		logrus.WithField("prefixOrName", prefixOrName).
+			WithField("id", containerID).
+			Debugf("daemon.GetContainer: container is known to daemon.containersReplica but not daemon.containers")
+		return nil, containerNotFound(prefixOrName)
+	}
+	return ctr, nil
 }
 
 // checkContainer make sure the specified container validates the specified conditions

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1336,7 +1336,8 @@ func getUnmountOnShutdownPath(config *config.Config) string {
 	return filepath.Join(config.ExecRoot, "unmount-on-shutdown")
 }
 
-// registerLinks writes the links to a file.
+// registerLinks registers network links between container and other containers
+// with the daemon using the specification in hostConfig.
 func (daemon *Daemon) registerLinks(container *container.Container, hostConfig *containertypes.HostConfig) error {
 	if hostConfig == nil || hostConfig.NetworkMode.IsUserDefined() {
 		return nil
@@ -1380,10 +1381,7 @@ func (daemon *Daemon) registerLinks(container *container.Container, hostConfig *
 		}
 	}
 
-	// After we load all the links into the daemon
-	// set them to nil on the hostconfig
-	_, err := container.WriteHostConfig()
-	return err
+	return nil
 }
 
 // conditionalMountOnStart is a platform specific helper function during the

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -68,9 +68,9 @@ func (daemon *Daemon) ContainerStart(ctx context.Context, name string, hostConfi
 				// if user has change the network mode on starting, clean up the
 				// old networks. It is a deprecated feature and has been removed in Docker 1.12
 				ctr.NetworkSettings.Networks = nil
-				if err := ctr.CheckpointTo(daemon.containersReplica); err != nil {
-					return errdefs.System(err)
-				}
+			}
+			if err := ctr.CheckpointTo(daemon.containersReplica); err != nil {
+				return errdefs.System(err)
 			}
 			ctr.InitDNSHostConfig()
 		}


### PR DESCRIPTION
- Fixes #44512 

**- What I did**
- Resolved a bug where containers were being included in the List Containers API response before they finished being created
- Resolved a bug where calling Container APIs with the ID of a container in the process of being created would result in a nil-pointer dereference panic

**- How I did it**
See commit descriptions for details.

**- How to verify it**
Patch the daemon to widen the race window and try to reproduce the issue, as described in https://github.com/moby/moby/issues/44512#issuecomment-1344717192

**- Description for the changelog**
- Resolved an issue where the List Containers API would return containers in the process of being created

**- A picture of a cute animal (not mandatory but encouraged)**

