### PR TITLE
daemon/config: rename CommonTLSOptions, and remove RootDeprecated field

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -62,9 +62,6 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 
 	// Deprecated flags / options
 
-	//nolint:staticcheck // TODO(thaJeztah): remove in next release.
-	flags.StringVarP(&conf.RootDeprecated, "graph", "g", conf.RootDeprecated, "Root of the Docker runtime")
-	_ = flags.MarkDeprecated("graph", "Use --data-root instead")
 	flags.BoolVarP(&conf.AutoRestart, "restart", "r", true, "--restart on the daemon has been deprecated in favor of --restart policies on docker run")
 	_ = flags.MarkDeprecated("restart", "Please use a restart policy on docker run")
 

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -405,13 +405,13 @@ func loadDaemonCliConfig(opts *daemonOptions) (*config.Config, error) {
 	}
 
 	if opts.TLSOptions != nil {
-		conf.CommonTLSOptions = config.CommonTLSOptions{
+		conf.TLSOptions = config.TLSOptions{
 			CAFile:   opts.TLSOptions.CAFile,
 			CertFile: opts.TLSOptions.CertFile,
 			KeyFile:  opts.TLSOptions.KeyFile,
 		}
 	} else {
-		conf.CommonTLSOptions = config.CommonTLSOptions{}
+		conf.TLSOptions = config.TLSOptions{}
 	}
 
 	if opts.configFile != "" {
@@ -609,9 +609,9 @@ func newAPIServerConfig(config *config.Config) (*apiserver.Config, error) {
 			clientAuth = tls.RequireAndVerifyClientCert
 		}
 		tlsConfig, err = tlsconfig.Server(tlsconfig.Options{
-			CAFile:             config.CommonTLSOptions.CAFile,
-			CertFile:           config.CommonTLSOptions.CertFile,
-			KeyFile:            config.CommonTLSOptions.KeyFile,
+			CAFile:             config.TLSOptions.CAFile,
+			CertFile:           config.TLSOptions.CertFile,
+			KeyFile:            config.TLSOptions.KeyFile,
 			ExclusiveRootPools: true,
 			ClientAuth:         clientAuth,
 		})

--- a/cmd/dockerd/daemon_test.go
+++ b/cmd/dockerd/daemon_test.go
@@ -48,7 +48,7 @@ func TestLoadDaemonCliConfigWithTLS(t *testing.T) {
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
 	assert.Assert(t, loadedConfig != nil)
-	assert.Check(t, is.Equal("/tmp/ca.pem", loadedConfig.CommonTLSOptions.CAFile))
+	assert.Check(t, is.Equal("/tmp/ca.pem", loadedConfig.TLSOptions.CAFile))
 }
 
 func TestLoadDaemonCliConfigWithConflicts(t *testing.T) {
@@ -164,7 +164,7 @@ func TestLoadDaemonConfigWithEmbeddedOptions(t *testing.T) {
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
 	assert.Assert(t, loadedConfig != nil)
-	assert.Check(t, is.Equal("/etc/certs/ca.pem", loadedConfig.CommonTLSOptions.CAFile))
+	assert.Check(t, is.Equal("/etc/certs/ca.pem", loadedConfig.TLSOptions.CAFile))
 	assert.Check(t, is.Equal("syslog", loadedConfig.LogConfig.Type))
 }
 

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -159,7 +159,6 @@ type CommonConfig struct {
 	NetworkDiagnosticPort int                       `json:"network-diagnostic-port,omitempty"`
 	Pidfile               string                    `json:"pidfile,omitempty"`
 	RawLogs               bool                      `json:"raw-logs,omitempty"`
-	RootDeprecated        string                    `json:"graph,omitempty"` // Deprecated: use Root instead. TODO(thaJeztah): remove in next release.
 	Root                  string                    `json:"data-root,omitempty"`
 	ExecRoot              string                    `json:"exec-root,omitempty"`
 	SocketGroup           string                    `json:"group,omitempty"`
@@ -558,11 +557,6 @@ func findConfigurationConflicts(config map[string]interface{}, flags *pflag.Flag
 // such as config.DNS, config.Labels, config.DNSSearch,
 // as well as config.MaxConcurrentDownloads, config.MaxConcurrentUploads and config.MaxDownloadAttempts.
 func Validate(config *Config) error {
-	//nolint:staticcheck // TODO(thaJeztah): remove in next release.
-	if config.RootDeprecated != "" {
-		return errors.New(`the "graph" config file option is deprecated; use "data-root" instead`)
-	}
-
 	// validate log-level
 	if config.LogLevel != "" {
 		if _, err := logrus.ParseLevel(config.LogLevel); err != nil {

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -71,7 +71,7 @@ var builtinRuntimes = map[string]bool{
 // flatOptions contains configuration keys
 // that MUST NOT be parsed as deep structures.
 // Use this to differentiate these options
-// with others like the ones in CommonTLSOptions.
+// with others like the ones in TLSOptions.
 var flatOptions = map[string]bool{
 	"cluster-store-opts": true,
 	"log-opts":           true,
@@ -124,10 +124,10 @@ type NetworkConfig struct {
 	NetworkControlPlaneMTU int `json:"network-control-plane-mtu,omitempty"`
 }
 
-// CommonTLSOptions defines TLS configuration for the daemon server.
+// TLSOptions defines TLS configuration for the daemon server.
 // It includes json tags to deserialize configuration from a file
 // using the same names that the flags in the command line use.
-type CommonTLSOptions struct {
+type TLSOptions struct {
 	CAFile   string `json:"tlscacert,omitempty"`
 	CertFile string `json:"tlscert,omitempty"`
 	KeyFile  string `json:"tlskey,omitempty"`
@@ -196,7 +196,7 @@ type CommonConfig struct {
 
 	// Embedded structs that allow config
 	// deserialization without the full struct.
-	CommonTLSOptions
+	TLSOptions
 
 	// SwarmDefaultAdvertiseAddr is the default host/IP or network interface
 	// to use if a wildcard address is specified in the ListenAddr value


### PR DESCRIPTION
### daemon/config: rename CommonTLSOptions to TLSOptions

This type was added in 677a6b3506107468ed8c00331991afd9176fa0b9 (https://github.com/moby/moby/pull/18587), and named
"common", because at the time, the "docker" and "dockerd" (daemon) code
were still in the same repository, and shared this type. Renaming it, now
that's no longer the case.

As there are no external consumers of this type, I'm not adding an alias.

### daemon/config: remove deprecated RootDeprecated field

Since b58de39ca78a42e01f4e0d80c53ed11f8357be83 (https://github.com/moby/moby/pull/43981), this option was now only used
to produce a fatal error when starting the daemon. That change is in the 23.0
release, so we can remove it from the master branch.
