### PR TITLE
pkg/system: move memory-info types to pkg/systeminfo, and minor refactor

### DIFF
--- a/daemon/info.go
+++ b/daemon/info.go
@@ -18,7 +18,6 @@ import (
 	"github.com/docker/docker/pkg/parsers/operatingsystem"
 	"github.com/docker/docker/pkg/platform"
 	"github.com/docker/docker/pkg/sysinfo"
-	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/registry"
 	metrics "github.com/docker/go-metrics"
 	"github.com/opencontainers/selinux/go-selinux"
@@ -252,11 +251,11 @@ func kernelVersion() string {
 	return kernelVersion
 }
 
-func memInfo() *system.MemInfo {
-	memInfo, err := system.ReadMemInfo()
+func memInfo() *sysinfo.Memory {
+	memInfo, err := sysinfo.ReadMemInfo()
 	if err != nil {
 		logrus.Errorf("Could not read system memory info: %v", err)
-		memInfo = &system.MemInfo{}
+		memInfo = &sysinfo.Memory{}
 	}
 	return memInfo
 }

--- a/daemon/stats_collector.go
+++ b/daemon/stats_collector.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/daemon/stats"
-	"github.com/docker/docker/pkg/system"
+	"github.com/docker/docker/pkg/sysinfo"
 )
 
 // newStatsCollector returns a new statsCollector that collections
@@ -15,7 +15,7 @@ import (
 func (daemon *Daemon) newStatsCollector(interval time.Duration) *stats.Collector {
 	// FIXME(vdemeester) move this elsewhere
 	if runtime.GOOS == "linux" {
-		meminfo, err := system.ReadMemInfo()
+		meminfo, err := sysinfo.ReadMemInfo()
 		if err == nil && meminfo.MemTotal > 0 {
 			daemon.machineMemory = uint64(meminfo.MemTotal)
 		}

--- a/pkg/sysinfo/meminfo.go
+++ b/pkg/sysinfo/meminfo.go
@@ -1,5 +1,12 @@
 package sysinfo
 
+// ReadMemInfo retrieves memory statistics of the host system and returns a
+// Memory type. It is only supported on Linux and Windows, and returns an
+// error on other platforms.
+func ReadMemInfo() (*Memory, error) {
+	return readMemInfo()
+}
+
 // Memory contains memory statistics of the host system.
 type Memory struct {
 	// Total usable RAM (i.e. physical RAM minus a few reserved bits and the

--- a/pkg/sysinfo/meminfo.go
+++ b/pkg/sysinfo/meminfo.go
@@ -1,7 +1,7 @@
-package system // import "github.com/docker/docker/pkg/system"
+package sysinfo
 
-// MemInfo contains memory statistics of the host system.
-type MemInfo struct {
+// Memory contains memory statistics of the host system.
+type Memory struct {
 	// Total usable RAM (i.e. physical RAM minus a few reserved bits and the
 	// kernel binary code).
 	MemTotal int64

--- a/pkg/sysinfo/meminfo_linux.go
+++ b/pkg/sysinfo/meminfo_linux.go
@@ -1,4 +1,4 @@
-package system // import "github.com/docker/docker/pkg/system"
+package sysinfo
 
 import (
 	"bufio"
@@ -9,8 +9,8 @@ import (
 )
 
 // ReadMemInfo retrieves memory statistics of the host system and returns a
-// MemInfo type.
-func ReadMemInfo() (*MemInfo, error) {
+// Memory type.
+func ReadMemInfo() (*Memory, error) {
 	file, err := os.Open("/proc/meminfo")
 	if err != nil {
 		return nil, err
@@ -20,10 +20,10 @@ func ReadMemInfo() (*MemInfo, error) {
 }
 
 // parseMemInfo parses the /proc/meminfo file into
-// a MemInfo object given an io.Reader to the file.
+// a Memory object given an io.Reader to the file.
 // Throws error if there are problems reading from the file
-func parseMemInfo(reader io.Reader) (*MemInfo, error) {
-	meminfo := &MemInfo{}
+func parseMemInfo(reader io.Reader) (*Memory, error) {
+	meminfo := &Memory{}
 	scanner := bufio.NewScanner(reader)
 	memAvailable := int64(-1)
 	for scanner.Scan() {

--- a/pkg/sysinfo/meminfo_linux.go
+++ b/pkg/sysinfo/meminfo_linux.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 )
 
-// ReadMemInfo retrieves memory statistics of the host system and returns a
+// readMemInfo retrieves memory statistics of the host system and returns a
 // Memory type.
-func ReadMemInfo() (*Memory, error) {
+func readMemInfo() (*Memory, error) {
 	file, err := os.Open("/proc/meminfo")
 	if err != nil {
 		return nil, err

--- a/pkg/sysinfo/meminfo_unix_test.go
+++ b/pkg/sysinfo/meminfo_unix_test.go
@@ -6,8 +6,6 @@ package sysinfo
 import (
 	"strings"
 	"testing"
-
-	units "github.com/docker/go-units"
 )
 
 // TestMemInfo tests parseMemInfo with a static meminfo string
@@ -23,20 +21,23 @@ func TestMemInfo(t *testing.T) {
 	Malformed3:    2 MB
 	Malformed4:    X kB
 	`
+
+	const KiB = 1024
+
 	meminfo, err := parseMemInfo(strings.NewReader(input))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if meminfo.MemTotal != 1*units.KiB {
+	if meminfo.MemTotal != 1*KiB {
 		t.Fatalf("Unexpected MemTotal: %d", meminfo.MemTotal)
 	}
-	if meminfo.MemFree != 3*units.KiB {
+	if meminfo.MemFree != 3*KiB {
 		t.Fatalf("Unexpected MemFree: %d", meminfo.MemFree)
 	}
-	if meminfo.SwapTotal != 4*units.KiB {
+	if meminfo.SwapTotal != 4*KiB {
 		t.Fatalf("Unexpected SwapTotal: %d", meminfo.SwapTotal)
 	}
-	if meminfo.SwapFree != 5*units.KiB {
+	if meminfo.SwapFree != 5*KiB {
 		t.Fatalf("Unexpected SwapFree: %d", meminfo.SwapFree)
 	}
 }

--- a/pkg/sysinfo/meminfo_unix_test.go
+++ b/pkg/sysinfo/meminfo_unix_test.go
@@ -1,7 +1,7 @@
 //go:build linux || freebsd
 // +build linux freebsd
 
-package system // import "github.com/docker/docker/pkg/system"
+package sysinfo
 
 import (
 	"strings"

--- a/pkg/sysinfo/meminfo_unsupported.go
+++ b/pkg/sysinfo/meminfo_unsupported.go
@@ -1,0 +1,11 @@
+//go:build !linux && !windows
+// +build !linux,!windows
+
+package sysinfo
+
+import "errors"
+
+// ReadMemInfo is not supported on platforms other than linux and windows.
+func ReadMemInfo() (*Memory, error) {
+	return nil, errors.New("platform and architecture is not supported")
+}

--- a/pkg/sysinfo/meminfo_unsupported.go
+++ b/pkg/sysinfo/meminfo_unsupported.go
@@ -5,7 +5,7 @@ package sysinfo
 
 import "errors"
 
-// ReadMemInfo is not supported on platforms other than linux and windows.
-func ReadMemInfo() (*Memory, error) {
+// readMemInfo is not supported on platforms other than linux and windows.
+func readMemInfo() (*Memory, error) {
 	return nil, errors.New("platform and architecture is not supported")
 }

--- a/pkg/sysinfo/meminfo_windows.go
+++ b/pkg/sysinfo/meminfo_windows.go
@@ -1,4 +1,4 @@
-package system // import "github.com/docker/docker/pkg/system"
+package sysinfo
 
 import (
 	"unsafe"
@@ -27,16 +27,16 @@ type memorystatusex struct {
 }
 
 // ReadMemInfo retrieves memory statistics of the host system and returns a
-// MemInfo type.
-func ReadMemInfo() (*MemInfo, error) {
+// Memory type.
+func ReadMemInfo() (*Memory, error) {
 	msi := &memorystatusex{
 		dwLength: 64,
 	}
 	r1, _, _ := procGlobalMemoryStatusEx.Call(uintptr(unsafe.Pointer(msi)))
 	if r1 == 0 {
-		return &MemInfo{}, nil
+		return &Memory{}, nil
 	}
-	return &MemInfo{
+	return &Memory{
 		MemTotal:  int64(msi.ullTotalPhys),
 		MemFree:   int64(msi.ullAvailPhys),
 		SwapTotal: int64(msi.ullTotalPageFile),

--- a/pkg/sysinfo/meminfo_windows.go
+++ b/pkg/sysinfo/meminfo_windows.go
@@ -28,7 +28,7 @@ type memorystatusex struct {
 
 // ReadMemInfo retrieves memory statistics of the host system and returns a
 // Memory type.
-func ReadMemInfo() (*Memory, error) {
+func readMemInfo() (*Memory, error) {
 	msi := &memorystatusex{
 		dwLength: 64,
 	}

--- a/pkg/sysinfo/numcpu.go
+++ b/pkg/sysinfo/numcpu.go
@@ -1,13 +1,15 @@
-//go:build !linux && !windows
-// +build !linux,!windows
-
 package sysinfo // import "github.com/docker/docker/pkg/sysinfo"
 
 import (
 	"runtime"
 )
 
-// NumCPU returns the number of CPUs
+// NumCPU returns the number of CPUs. On Linux and Windows, it returns
+// the number of CPUs which are currently online. On other platforms,
+// it's the equivalent of [runtime.NumCPU].
 func NumCPU() int {
+	if ncpu := numCPU(); ncpu > 0 {
+		return ncpu
+	}
 	return runtime.NumCPU()
 }

--- a/pkg/sysinfo/numcpu_linux.go
+++ b/pkg/sysinfo/numcpu_linux.go
@@ -1,8 +1,6 @@
 package sysinfo // import "github.com/docker/docker/pkg/sysinfo"
 
 import (
-	"runtime"
-
 	"golang.org/x/sys/unix"
 )
 
@@ -22,12 +20,4 @@ func numCPU() int {
 	}
 
 	return mask.Count()
-}
-
-// NumCPU returns the number of CPUs which are currently online
-func NumCPU() int {
-	if ncpu := numCPU(); ncpu > 0 {
-		return ncpu
-	}
-	return runtime.NumCPU()
 }

--- a/pkg/sysinfo/numcpu_other.go
+++ b/pkg/sysinfo/numcpu_other.go
@@ -1,0 +1,9 @@
+//go:build !linux && !windows
+// +build !linux,!windows
+
+package sysinfo
+
+func numCPU() int {
+	// not implemented
+	return 0
+}

--- a/pkg/sysinfo/numcpu_windows.go
+++ b/pkg/sysinfo/numcpu_windows.go
@@ -1,7 +1,6 @@
 package sysinfo // import "github.com/docker/docker/pkg/sysinfo"
 
 import (
-	"runtime"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -34,12 +33,4 @@ func numCPU() int {
 	// For every available thread a bit is set in the mask.
 	ncpu := int(popcnt(uint64(mask)))
 	return ncpu
-}
-
-// NumCPU returns the number of CPUs which are currently online
-func NumCPU() int {
-	if ncpu := numCPU(); ncpu > 0 {
-		return ncpu
-	}
-	return runtime.NumCPU()
 }

--- a/pkg/system/meminfo_deprecated.go
+++ b/pkg/system/meminfo_deprecated.go
@@ -1,0 +1,16 @@
+package system
+
+import "github.com/docker/docker/pkg/sysinfo"
+
+// MemInfo contains memory statistics of the host system.
+//
+// Deprecated: use [sysinfo.Memory].
+type MemInfo = sysinfo.Memory
+
+// ReadMemInfo retrieves memory statistics of the host system and returns a
+// MemInfo type.
+//
+// Deprecated: use [sysinfo.ReadMemInfo].
+func ReadMemInfo() (*sysinfo.Memory, error) {
+	return sysinfo.ReadMemInfo()
+}

--- a/pkg/system/meminfo_unsupported.go
+++ b/pkg/system/meminfo_unsupported.go
@@ -1,9 +1,0 @@
-//go:build !linux && !windows
-// +build !linux,!windows
-
-package system // import "github.com/docker/docker/pkg/system"
-
-// ReadMemInfo is not supported on platforms other than linux and windows.
-func ReadMemInfo() (*MemInfo, error) {
-	return nil, ErrNotSupportedPlatform
-}


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/44275

### pkg/sysinfo: unify NumCPU implementation

Use a single exported implementation, so that we can maintain the
GoDoc string in one place, and use non-exported functions for the
actual implementation (which were already in place).

### pkg/system: move memory-info types to pkg/systeminfo

These types and functions are more closely related to the functionality
provided by pkg/systeminfo, and used in conjunction with the other functions
in that package, so moving them there.

### pkg/sysinfo: remove github.com/docker/go-units dependency

It was only used in a test, and only for a single const; define
it locally.

### pkg/sysinfo: unify ReadMemInfo implementation

Use a single exported implementation, so that we can maintain the
GoDoc string in one place, and use non-exported functions for the
actual implementation.
