### PR TITLE
[23.0 backport] errdefs: FromStatusCode() don't log "FIXME" debug message

### DIFF
--- a/errdefs/http_helpers.go
+++ b/errdefs/http_helpers.go
@@ -2,14 +2,12 @@ package errdefs // import "github.com/docker/docker/errdefs"
 
 import (
 	"net/http"
-
-	"github.com/sirupsen/logrus"
 )
 
 // FromStatusCode creates an errdef error, based on the provided HTTP status-code
 func FromStatusCode(err error, statusCode int) error {
 	if err == nil {
-		return err
+		return nil
 	}
 	switch statusCode {
 	case http.StatusNotFound:
@@ -33,11 +31,6 @@ func FromStatusCode(err error, statusCode int) error {
 			err = System(err)
 		}
 	default:
-		logrus.WithError(err).WithFields(logrus.Fields{
-			"module":      "api",
-			"status_code": statusCode,
-		}).Debug("FIXME: Got an status-code for which error does not match any expected type!!!")
-
 		switch {
 		case statusCode >= 200 && statusCode < 400:
 			// it's a client error


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44678
- fixes https://github.com/moby/moby/issues/38877#issuecomment-1359329062
- relates to https://github.com/moby/moby/pull/38689

This utility is used by the client, which cannot do anything about errors received from the API. In situations where no API connection was possible, for example, if the client has no permissions to connect to the socket, the request would have a "-1" status-code;
https://github.com/moby/moby/blob/3e39ec60dab859f70577ea8561fe5bda5236749e/client/request.go#L133-L134

In this case, a client with "debug" enabled, would print _and_ log a confusing error message:

    DEBU[0000] FIXME: Got an status-code for which error does not match any expected type!!!  error="Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Post \"http://%2Fvar%2Frun%2Fdocker.sock/v1.24/build?buildargs=%7B%7D&cachefrom=%5B%5D&cgroupparent=&cpuperiod=0&cpuquota=0&cpusetcpus=&cpusetmems=&cpushares=0&dockerfile=Dockerfile.repro&labels=%7B%7D&memory=0&memswap=0&networkmode=default&rm=1&shmsize=0&t=repro&target=&ulimits=null&version=1\": dial unix /var/run/docker.sock: connect: permission denied" module=api status_code=-1
    Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Post "http://%2Fvar%2Frun%2Fdocker.sock/v1.24/build?buildargs=%7B%7D&cachefrom=%5B%5D&cgroupparent=&cpuperiod=0&cpuquota=0&cpusetcpus=&cpusetmems=&cpushares=0&dockerfile=Dockerfile.repro&labels=%7B%7D&memory=0&memswap=0&networkmode=default&rm=1&shmsize=0&t=repro&target=&ulimits=null&version=1": dial unix /var/run/docker.sock: connect: permission denied

In the above; `DEBU` logs the error (including the "FIXME"), and the second line is the error message printed.

This was a mistake on my side when I added the `FromStatusCode` utility. I implemented that to be the counterpart to `FromError`, but in doing so also copied over the logging (see 1af30c50ca0ad81e2839ff4f2c5e70413f021d52). That log-message is only intended to be logged on the daemon side, for situations where we return an error without a proper errdefs (which would result in an 500 "internal server error" to be returned by the API).

This patch removes the debug log, and a minor cleanup to explicitly return "nil" if we didn't get an error in the first place.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
Remove unneeded "FIXME" debug logs printed by the client
```


**- A picture of a cute animal (not mandatory but encouraged)**



