### PR TITLE
Wrap the image inspect error to a "not found"

### DIFF
--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -152,7 +152,7 @@ func (i *ImageService) manifestMatchesPlatform(ctx context.Context, img *image.I
 func (i *ImageService) GetImage(ctx context.Context, refOrID string, options imagetypes.GetImageOpts) (*image.Image, error) {
 	img, err := i.getImage(ctx, refOrID, options)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "no such image: %s", refOrID)
 	}
 	if options.Details {
 		var size int64


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

The commit https://github.com/moby/moby/pull/43680/commits/b4ffe3a9fb9d25abb1690c506e7a2cb59249c107 removed the LookupImage function but while doing that we lost the "no such image" part of the error.

This change brings this back

**- How I did it**

By bringing back the `error.Wrap` code that was in the [LookupImage code](https://github.com/moby/moby/pull/43680/commits/b4ffe3a9fb9d25abb1690c506e7a2cb59249c107#diff-137f57e765ed41886f1f25085f7876e22b7ebaa06ebea01f2512f3037be164c1L18)

**- How to verify it**

Call `docker image inspect 46331D942d63` (take an existing image id and uppercase any chararcter) and you should see this error:

```
[]
Error response from daemon: no such image: 46331D942d63: invalid reference format: repository name must be lowercase
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

