### PR TITLE
[20.10] fix broken vanity-URL for code.cloudfoundry.org

### DIFF
--- a/hack/dockerfile/install/vndr.installer
+++ b/hack/dockerfile/install/vndr.installer
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-: "${VNDR_VERSION:=v0.1.2}"
+: "${VNDR_VERSION:=v0.1.3-0.20221229102223-87603e47e8ea}"
 
 install_vndr() {
 	echo "Install vndr version $VNDR_VERSION"

--- a/vendor.conf
+++ b/vendor.conf
@@ -158,7 +158,7 @@ github.com/hashicorp/go-memdb                       cb9a474f84cc5e41b273b20c6927
 github.com/hashicorp/go-immutable-radix             826af9ccf0feeee615d546d69b11f8e98da8c8f1 https://github.com/tonistiigi/go-immutable-radix.git
 github.com/hashicorp/golang-lru                     7f827b33c0f158ec5dfbba01bb0b14a4541fd81d # v0.5.3
 github.com/coreos/pkg                               3ac0863d7acf3bc44daf49afef8919af12f704ef # v3
-code.cloudfoundry.org/clock                         02e53af36e6c978af692887ed449b74026d76fec # v1.0.0
+code.cloudfoundry.org/clock                         02e53af36e6c978af692887ed449b74026d76fec https://github.com/cloudfoundry/clock.git # v1.0.0
 
 # prometheus
 github.com/prometheus/client_golang                 6edbbd9e560190e318cdc5b4d3e630b442858380 # v1.6.0


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/44682#issuecomment-1363479204

The vanity URL looks to be misconfigured;

    2022-12-22T00:01:12.571Z] 2022/12/22 00:01:12 unrecognized import path "code.cloudfoundry.org/clock" (https fetch: Get "https://code.cloudfoundry.org/clock?go-get=1": x509: certificate is valid for *.de.a9sapp.eu, de.a9sapp.eu, not code.cloudfoundry.org)

This patch updates vendor.conf to fetch the code directly from GitHub.


