### PR TITLE
Add support for devices in swarm

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -682,6 +682,11 @@ definitions:
           (Windows only).
         type: "integer"
         format: "int64"
+      Devices:
+        description: "A list of devices to add to the container."
+        type: "array"
+        items:
+          $ref: "#/definitions/DeviceMapping"
 
   Limit:
     description: |

--- a/api/types/swarm/container.go
+++ b/api/types/swarm/container.go
@@ -68,13 +68,14 @@ type ContainerSpec struct {
 	// The format of extra hosts on swarmkit is specified in:
 	// http://man7.org/linux/man-pages/man5/hosts.5.html
 	//    IP_address canonical_hostname [aliases...]
-	Hosts          []string            `json:",omitempty"`
-	DNSConfig      *DNSConfig          `json:",omitempty"`
-	Secrets        []*SecretReference  `json:",omitempty"`
-	Configs        []*ConfigReference  `json:",omitempty"`
-	Isolation      container.Isolation `json:",omitempty"`
-	Sysctls        map[string]string   `json:",omitempty"`
-	CapabilityAdd  []string            `json:",omitempty"`
-	CapabilityDrop []string            `json:",omitempty"`
-	Ulimits        []*units.Ulimit     `json:",omitempty"`
+	Hosts          []string                  `json:",omitempty"`
+	DNSConfig      *DNSConfig                `json:",omitempty"`
+	Secrets        []*SecretReference        `json:",omitempty"`
+	Configs        []*ConfigReference        `json:",omitempty"`
+	Isolation      container.Isolation       `json:",omitempty"`
+	Sysctls        map[string]string         `json:",omitempty"`
+	CapabilityAdd  []string                  `json:",omitempty"`
+	CapabilityDrop []string                  `json:",omitempty"`
+	Ulimits        []*units.Ulimit           `json:",omitempty"`
+	Devices        []container.DeviceMapping `json:",omitempty"`
 }

--- a/daemon/cluster/convert/container.go
+++ b/daemon/cluster/convert/container.go
@@ -41,6 +41,7 @@ func containerSpecFromGRPC(c *swarmapi.ContainerSpec) *types.ContainerSpec {
 		CapabilityAdd:  c.CapabilityAdd,
 		CapabilityDrop: c.CapabilityDrop,
 		Ulimits:        ulimitsFromGRPC(c.Ulimits),
+		Devices:        devicesFromGRPC(c.Devices),
 	}
 
 	if c.DNSConfig != nil {
@@ -269,6 +270,7 @@ func containerToGRPC(c *types.ContainerSpec) (*swarmapi.ContainerSpec, error) {
 		CapabilityAdd:  c.CapabilityAdd,
 		CapabilityDrop: c.CapabilityDrop,
 		Ulimits:        ulimitsToGRPC(c.Ulimits),
+		Devices:        devicesToGRPC(c.Devices),
 	}
 
 	if c.DNSConfig != nil {
@@ -500,4 +502,32 @@ func ulimitsToGRPC(u []*units.Ulimit) []*swarmapi.ContainerSpec_Ulimit {
 	}
 
 	return ulimits
+}
+
+func devicesFromGRPC(d []*swarmapi.ContainerSpec_DeviceMapping) []container.DeviceMapping {
+	devices := make([]container.DeviceMapping, len(d))
+
+	for i, device := range d {
+		devices[i] = container.DeviceMapping{
+			PathOnHost:        device.PathOnHost,
+			PathInContainer:   device.PathInContainer,
+			CgroupPermissions: device.CgroupPermissions,
+		}
+	}
+
+	return devices
+}
+
+func devicesToGRPC(d []container.DeviceMapping) []*swarmapi.ContainerSpec_DeviceMapping {
+	devices := make([]*swarmapi.ContainerSpec_DeviceMapping, len(d))
+
+	for i, device := range d {
+		devices[i] = &swarmapi.ContainerSpec_DeviceMapping{
+			PathOnHost:        device.PathOnHost,
+			PathInContainer:   device.PathInContainer,
+			CgroupPermissions: device.CgroupPermissions,
+		}
+	}
+
+	return devices
 }

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -479,6 +479,15 @@ func (c *containerConfig) resources() enginecontainer.Resources {
 		}
 	}
 
+	resources.Devices = make([]enginecontainer.DeviceMapping, len(c.spec().Devices))
+	for i, device := range c.spec().Devices {
+		resources.Devices[i] = enginecontainer.DeviceMapping{
+			PathOnHost:        device.PathOnHost,
+			PathInContainer:   device.PathInContainer,
+			CgroupPermissions: device.CgroupPermissions,
+		}
+	}
+
 	// If no limits are specified let the engine use its defaults.
 	//
 	// TODO(aluzzardi): We might want to set some limits anyway otherwise


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This is for:
- moby/swarmkit#1244
- moby/swarmkit#2682, though this PR series takes a much simpler approach.
- moby/moby#24865

This simply plumbs devices through everything such that swarm can specify the devices field.

**- How I did it**

Largely based on:

- moby/swarmkit#2967
- moby/moby#41284
- docker/cli#2712

But, plumbing devices instead of ulimits.

This needs https://github.com/moby/swarmkit/pull/3106.

**- How to test it**

Still working on this; I'm finding it pretty difficult to get all of the pieces set up.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add support for devices in swarm mode.