### PR TITLE
[23.0 backport] gha: update buildkit to fix integration tests

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           # FIXME(thaJeztah) temporarily overriding version to use for tests; remove with the next release of buildkit
           # echo "BUILDKIT_REF=$(./hack/buildkit-ref)" >> $GITHUB_ENV
-          echo "BUILDKIT_REF=0bfcd83e6db95e6c6877ee6e5224b994cea62ba1" >> $GITHUB_ENV
+          echo "BUILDKIT_REF=d77361423c88cc2a0d19e285ec3599022e92571f" >> $GITHUB_ENV
         working-directory: moby
       -
         name: Checkout BuildKit ${{ env.BUILDKIT_REF }}


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44701
- relates to https://github.com/moby/buildkit/pull/3437


full diff: https://github.com/moby/buildkit/compare/0bfcd83e6db95e6c6877ee6e5224b994cea62ba1...d77361423c88cc2a0d19e285ec3599022e92571f

(cherry picked from commit c42b304f626ce6b25f8c17e656a5aebffeff0b34)


**- A picture of a cute animal (not mandatory but encouraged)**

