### PR TITLE
[20.10 backport] daemon/graphdriver/btrfs: workaround field rename in btrfs-progs 6.1

### DIFF
--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -6,6 +6,9 @@ package btrfs // import "github.com/docker/docker/daemon/graphdriver/btrfs"
 /*
 #include <stdlib.h>
 #include <dirent.h>
+
+// keep struct field name compatible with btrfs-progs < 6.1.
+#define max_referenced max_rfer
 #include <btrfs/ioctl.h>
 #include <btrfs/ctree.h>
 
@@ -434,7 +437,7 @@ func subvolLimitQgroup(path string, size uint64) error {
 	defer closeDir(dir)
 
 	var args C.struct_btrfs_ioctl_qgroup_limit_args
-	args.lim.max_referenced = C.__u64(size)
+	args.lim.max_rfer = C.__u64(size)
 	args.lim.flags = C.BTRFS_QGROUP_LIMIT_MAX_RFER
 	_, _, errno := unix.Syscall(unix.SYS_IOCTL, getDirFd(dir), C.BTRFS_IOC_QGROUP_LIMIT,
 		uintptr(unsafe.Pointer(&args)))


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/44707

(cherry picked from commit ffbbe3d103b045c3f8ec5f74aa71b7a314fd57fe)