### PR TITLE
[20.10] Revert "seccomp: block socket calls to AF_VSOCK in default profile"

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -348,6 +348,7 @@
 				"signalfd4",
 				"sigprocmask",
 				"sigreturn",
+				"socket",
 				"socketcall",
 				"socketpair",
 				"splice",
@@ -414,22 +415,6 @@
 			"includes": {
 				"minKernel": "4.8"
 			},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"socket"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [
-				{
-					"index": 0,
-					"value": 40,
-					"op": "SCMP_CMP_NE"
-				}
-			],
-			"comment": "",
-			"includes": {},
 			"excludes": {}
 		},
 		{

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -343,6 +343,7 @@ func DefaultProfile() *Seccomp {
 				"signalfd4",
 				"sigprocmask",
 				"sigreturn",
+				"socket",
 				"socketcall",
 				"socketpair",
 				"splice",
@@ -401,17 +402,6 @@ func DefaultProfile() *Seccomp {
 			Action: specs.ActAllow,
 			Includes: Filter{
 				MinKernel: &KernelVersion{4, 8},
-			},
-		},
-		{
-			Names:  []string{"socket"},
-			Action: specs.ActAllow,
-			Args: []*specs.LinuxSeccompArg{
-				{
-					Index: 0,
-					Value: unix.AF_VSOCK,
-					Op:    specs.OpNotEqual,
-				},
 			},
 		},
 		{


### PR DESCRIPTION
As discussed in last week's maintainer call. Closes moby/moby#44670.

---

This reverts commit 57b229012a5b5ff97889ae44c9b6fa77ba9b3a5c.

This change, while favorable from a security standpoint, caused a
regression for users of the 20.10 branch of Moby. As such, we are
reverting it to ensure stability and compatibility for the affected
users.

However, users of AF_VSOCK in containers should recognize that this
(special) address family is not currently namespaced in any version of
the Linux kernel, and may result in unexpected behavior, like VMs
communicating directly with host hypervisors.

Future branches, including the 23.0 branch, will continue to filter
AF_VSOCK. Users who need to allow containers to communicate over the
unnamespaced AF_VSOCK will need to turn off seccomp confinement or set a
custom seccomp profile.

It is our hope that future mechanisms will make this more
ergonomic/maintainable for end users, and that future kernels will
support namespacing of AF_VSOCK.