### PR TITLE
[20.10 backport] api: can marshal and unmarshal when args.fields is empty

### DIFF
--- a/api/types/filters/parse.go
+++ b/api/types/filters/parse.go
@@ -48,7 +48,7 @@ func (args Args) Keys() []string {
 // MarshalJSON returns a JSON byte representation of the Args
 func (args Args) MarshalJSON() ([]byte, error) {
 	if len(args.fields) == 0 {
-		return []byte{}, nil
+		return []byte("{}"), nil
 	}
 	return json.Marshal(args.fields)
 }
@@ -106,9 +106,6 @@ func FromJSON(p string) (Args, error) {
 
 // UnmarshalJSON populates the Args from JSON encode bytes
 func (args Args) UnmarshalJSON(raw []byte) error {
-	if len(raw) == 0 {
-		return nil
-	}
 	return json.Unmarshal(raw, &args.fields)
 }
 

--- a/api/types/filters/parse_test.go
+++ b/api/types/filters/parse_test.go
@@ -1,12 +1,33 @@
 package filters // import "github.com/docker/docker/api/types/filters"
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
+
+func TestMarshalJSON(t *testing.T) {
+	fields := map[string]map[string]bool{
+		"created":    {"today": true},
+		"image.name": {"ubuntu*": true, "*untu": true},
+	}
+	a := Args{fields: fields}
+
+	_, err := a.MarshalJSON()
+	if err != nil {
+		t.Errorf("failed to marshal the filters: %s", err)
+	}
+}
+
+func TestMarshalJSONWithEmpty(t *testing.T) {
+	_, err := json.Marshal(NewArgs())
+	if err != nil {
+		t.Errorf("failed to marshal the filters: %s", err)
+	}
+}
 
 func TestToJSON(t *testing.T) {
 	fields := map[string]map[string]bool{


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44668

fixes: #44269 
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Can marshal and unmarshal when args.fields is empty.
**- How I did it**
When marshal, use `make(map[string]map[string]bool, 0)` instead of  return `byte[]{}`.
When unmarshal, remove the case of `len(raw) == 0`
**- How to verify it**
I wrote tests.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

