### PR TITLE
daemon/graphdriver/devicemapper: simplify Udev log, and update link

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/daemon/graphdriver"
-	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/pkg/devicemapper"
 	"github.com/docker/docker/pkg/dmesg"
 	"github.com/docker/docker/pkg/idtools"
@@ -1672,12 +1671,7 @@ func (devices *DeviceSet) initDevmapper(doInit bool) (retErr error) {
 
 	// https://github.com/docker/docker/issues/4036
 	if supported := devicemapper.UdevSetSyncSupport(true); !supported {
-		if dockerversion.IAmStatic == "true" {
-			logger.Error("Udev sync is not supported. This will lead to data loss and unexpected behavior. Install a dynamic binary to use devicemapper or select a different storage driver. For more information, see https://docs.docker.com/engine/reference/commandline/dockerd/#storage-driver-options")
-		} else {
-			logger.Error("Udev sync is not supported. This will lead to data loss and unexpected behavior. Install a more recent version of libdevmapper or select a different storage driver. For more information, see https://docs.docker.com/engine/reference/commandline/dockerd/#storage-driver-options")
-		}
-
+		logger.Error("Udev sync is not supported, which will lead to data loss and unexpected behavior. Make sure you have a recent version of libdevmapper installed and are running a dynamic binary, or select a different storage driver. For more information, see https://docs.docker.com/go/storage-driver/")
 		if !devices.overrideUdevSyncCheck {
 			return graphdriver.ErrNotSupported
 		}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/44546#discussion_r1059642855
- relates to https://github.com/moby/moby/pull/21730


Simplify the error message so that we don't have to distinguish between static- and non-static builds. Also update the link to the storage-driver section to use a "/go/" redirect in the docs, as the anchor link was no longer correct. Using a "/go/" redirect  makes sure the link remains functional if docs is  moving around.


**- A picture of a cute animal (not mandatory but encouraged)**

