### PR TITLE
[23.0 backport] Fix volume CreatedAt being altered on initialization

### DIFF
--- a/volume/local/local_unix.go
+++ b/volume/local/local_unix.go
@@ -164,7 +164,7 @@ func (v *localVolume) unmount() error {
 }
 
 func (v *localVolume) CreatedAt() (time.Time, error) {
-	fileInfo, err := os.Stat(v.path)
+	fileInfo, err := os.Stat(v.rootPath)
 	if err != nil {
 		return time.Time{}, err
 	}

--- a/volume/local/local_windows.go
+++ b/volume/local/local_windows.go
@@ -44,7 +44,7 @@ func (v *localVolume) postMount() error {
 }
 
 func (v *localVolume) CreatedAt() (time.Time, error) {
-	fileInfo, err := os.Stat(v.path)
+	fileInfo, err := os.Stat(v.rootPath)
 	if err != nil {
 		return time.Time{}, err
 	}


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44719
- replaces / closes https://github.com/moby/moby/pull/38276
- fixes https://github.com/moby/moby/issues/38274
- fixes https://github.com/moby/moby/issues/44364

The CreatedAt date was determined from the volume's `_data` directory (`/var/lib/docker/volumes/<volumename>/_data`). However, when initializing a volume, this directory is updated, causing the date to change.

Instead of using the `_data` directory, use its root directory, which is not updated afterwards, and should reflect the time that the volume was created.


This is basically the same as the original PR, but uses `rootPath` directly instead of manipulating the `path`.

**- Description for the changelog**
Volume's `CreatedAt` doesn't change when volume content is modified.
