### PR TITLE
[23.0 backport] Check iptables options before looking for ip6tables binary

### DIFF
--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -89,19 +89,32 @@ func (e ChainError) Error() string {
 	return fmt.Sprintf("Error iptables %s: %s", e.Chain, string(e.Output))
 }
 
-func probe() {
+func detectIptables() {
 	path, err := exec.LookPath("iptables")
 	if err != nil {
-		logrus.Warnf("Failed to find iptables: %v", err)
+		logrus.WithError(err).Warnf("failed to find iptables")
 		return
 	}
-	if out, err := exec.Command(path, "--wait", "-t", "nat", "-L", "-n").CombinedOutput(); err != nil {
-		logrus.Warnf("Running iptables --wait -t nat -L -n failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
+	iptablesPath = path
+
+	if out, err := exec.Command(path, "--wait", "-L", "-n").CombinedOutput(); err != nil {
+		logrus.WithError(err).Infof("unable to detect if iptables supports xlock: 'iptables --wait -L -n': `%s`", strings.TrimSpace(string(out)))
+	} else {
+		supportsXlock = true
 	}
-	_, err = exec.LookPath("ip6tables")
+
+	mj, mn, mc, err := GetVersion()
 	if err != nil {
-		logrus.Warnf("Failed to find ip6tables: %v", err)
-		return
+		logrus.Warnf("Failed to read iptables version: %v", err)
+	} else {
+		supportsCOpt = supportsCOption(mj, mn, mc)
+	}
+
+	path, err = exec.LookPath("ip6tables")
+	if err != nil {
+		logrus.WithError(err).Warnf("unable to find ip6tables")
+	} else {
+		ip6tablesPath = path
 	}
 }
 
@@ -113,35 +126,11 @@ func initFirewalld() {
 		return
 	}
 	if err := FirewalldInit(); err != nil {
-		logrus.Debugf("Fail to initialize firewalld: %v, using raw iptables instead", err)
-	}
-}
-
-func detectIptables() {
-	path, err := exec.LookPath("iptables")
-	if err != nil {
-		return
-	}
-	iptablesPath = path
-
-	supportsXlock = exec.Command(iptablesPath, "--wait", "-L", "-n").Run() == nil
-	mj, mn, mc, err := GetVersion()
-	if err != nil {
-		logrus.Warnf("Failed to read iptables version: %v", err)
-		return
-	}
-	supportsCOpt = supportsCOption(mj, mn, mc)
-
-	path, err = exec.LookPath("ip6tables")
-	if err != nil {
-		return
-	} else {
-		ip6tablesPath = path
+		logrus.WithError(err).Debugf("unable to initialize firewalld; using raw iptables instead")
 	}
 }
 
 func initDependencies() {
-	probe()
 	initFirewalld()
 	detectIptables()
 }
@@ -554,6 +543,9 @@ func (iptable IPTable) raw(args ...string) ([]byte, error) {
 	path := iptablesPath
 	commandName := "iptables"
 	if iptable.Version == IPv6 {
+		if ip6tablesPath == "" {
+			return nil, fmt.Errorf("ip6tables is missing")
+		}
 		path = ip6tablesPath
 		commandName = "ip6tables"
 	}

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -123,11 +123,7 @@ func detectIptables() {
 		return
 	}
 	iptablesPath = path
-	path, err = exec.LookPath("ip6tables")
-	if err != nil {
-		return
-	}
-	ip6tablesPath = path
+
 	supportsXlock = exec.Command(iptablesPath, "--wait", "-L", "-n").Run() == nil
 	mj, mn, mc, err := GetVersion()
 	if err != nil {
@@ -135,6 +131,13 @@ func detectIptables() {
 		return
 	}
 	supportsCOpt = supportsCOption(mj, mn, mc)
+
+	path, err = exec.LookPath("ip6tables")
+	if err != nil {
+		return
+	} else {
+		ip6tablesPath = path
+	}
 }
 
 func initDependencies() {

--- a/libnetwork/iptables/iptables_test.go
+++ b/libnetwork/iptables/iptables_test.go
@@ -287,44 +287,15 @@ func TestExistsRaw(t *testing.T) {
 		if err != nil {
 			t.Fatalf("i=%d, err: %v", i, err)
 		}
-		if !iptable.existsRaw(Filter, testChain1, r.rule...) {
+		if !iptable.exists(true, Filter, testChain1, r.rule...) {
 			t.Fatalf("Failed to detect rule. i=%d", i)
 		}
 		// Truncate the rule
 		trg := r.rule[len(r.rule)-1]
 		trg = trg[:len(trg)-2]
 		r.rule[len(r.rule)-1] = trg
-		if iptable.existsRaw(Filter, testChain1, r.rule...) {
+		if iptable.exists(true, Filter, testChain1, r.rule...) {
 			t.Fatalf("Invalid detection. i=%d", i)
-		}
-	}
-}
-
-func TestGetVersion(t *testing.T) {
-	mj, mn, mc := parseVersionNumbers("iptables v1.4.19.1-alpha")
-	if mj != 1 || mn != 4 || mc != 19 {
-		t.Fatal("Failed to parse version numbers")
-	}
-}
-
-func TestSupportsCOption(t *testing.T) {
-	input := []struct {
-		mj int
-		mn int
-		mc int
-		ok bool
-	}{
-		{1, 4, 11, true},
-		{1, 4, 12, true},
-		{1, 5, 0, true},
-		{0, 4, 11, false},
-		{0, 5, 12, false},
-		{1, 3, 12, false},
-		{1, 4, 10, false},
-	}
-	for ind, inp := range input {
-		if inp.ok != supportsCOption(inp.mj, inp.mn, inp.mc) {
-			t.Fatalf("Incorrect check: %d", ind)
 		}
 	}
 }


### PR DESCRIPTION
backports:

- https://github.com/moby/moby/pull/43384
- fixes https://github.com/moby/moby/issues/42696
- https://github.com/moby/moby/pull/43060
- fixes https://github.com/moby/moby/issues/42127


⚠️ I had a merge conflict in the second commit of https://github.com/moby/moby/pull/43060, as https://github.com/moby/moby/pull/43793 was back ported to 23.0 (through https://github.com/moby/moby/pull/43813), and it looks like git was smart enough to apply af7236f85a3477b37518aed7eb8dbc8e2b595d59 on the master branch (without rebase), but applying the same on the 23.0 branch cause a conflict, and would remove the patch from https://github.com/moby/moby/pull/43813