### PR TITLE
ci: push bin image to Docker Hub

### DIFF
--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -15,6 +15,7 @@ on:
   pull_request:
 
 env:
+  MOBYBIN_REPO_SLUG: moby/moby-bin
   PLATFORM: Moby Engine
   PRODUCT: Moby
   DEFAULT_PRODUCT_LICENSE: Moby
@@ -37,12 +38,29 @@ jobs:
         id: platforms
         run: |
           echo "matrix=$(docker buildx bake bin-image-cross --print | jq -cr '.target."bin-image-cross".platforms')" >>${GITHUB_OUTPUT}
+
+  build:
+    runs-on: ubuntu-20.04
+    needs:
+      - validate-dco
+      - prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJson(needs.prepare.outputs.platforms) }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       -
         name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: moby-bin
+          images: |
+            ${{ env.MOBYBIN_REPO_SLUG }}
           ### versioning strategy
           ## push semver tag v23.0.0
           # moby/moby-bin:23.0.0
@@ -69,28 +87,11 @@ jobs:
           path: /tmp/bake-meta.json
           if-no-files-found: error
           retention-days: 1
-
-  build:
-    runs-on: ubuntu-20.04
-    needs:
-      - validate-dco
-      - prepare
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: ${{ fromJson(needs.prepare.outputs.platforms) }}
-    steps:
       -
-        name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      -
-        name: Download meta bake definition
-        uses: actions/download-artifact@v3
-        with:
-          name: bake-meta
-          path: /tmp
+        name: Remove tags from meta bake definition
+        run: |
+          # we just want labels being set in this job
+          jq -r 'del(.target."docker-metadata-action".tags)' "/tmp/bake-meta.json" > "${{ steps.meta.outputs.bake-file }}"
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -98,13 +99,77 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
+        name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_MOBYBIN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_MOBYBIN_TOKEN }}
+      -
         name: Build
-        uses: docker/bake-action@v2
+        id: bake
+        uses: docker/bake-action@v3
         with:
           files: |
             ./docker-bake.hcl
-            /tmp/bake-meta.json
+            ${{ steps.meta.outputs.bake-file }}
           targets: bin-image
           set: |
             *.platform=${{ matrix.platform }}
-            *.output=type=cacheonly
+            *.output=type=image,name=${{ env.MOBYBIN_REPO_SLUG }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+      -
+        name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ fromJSON(steps.bake.outputs.metadata).image['containerimage.digest'] }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      -
+        name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-20.04
+    if: github.event_name != 'pull_request'
+    needs:
+      - build
+    steps:
+      -
+        name: Download meta bake definition
+        uses: actions/download-artifact@v3
+        with:
+          name: bake-meta
+          path: /tmp
+      -
+        name: Download digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_MOBYBIN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_MOBYBIN_TOKEN }}
+      -
+        name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          set -x
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map("-t " + .) | join(" ")' /tmp/bake.json) \
+            $(printf '${{ env.MOBYBIN_REPO_SLUG }}@sha256:%s ' *)
+      -
+        name: Inspect image
+        run: |
+          set -x
+          docker buildx imagetools inspect ${{ env.MOBYBIN_REPO_SLUG }}:$(jq -cr '.target."docker-metadata-action".args.DOCKER_META_VERSION' /tmp/bake.json)


### PR DESCRIPTION
follow-up https://github.com/moby/moby/pull/45519

**- What I did**

Update bin-image workflow to push the bin image to Docker Hub

![image](https://user-images.githubusercontent.com/1951866/210321635-c667d660-644b-4061-bf1c-0da458a555f3.png)
> https://hub.docker.com/r/crazymax/moby-bin/tags

```
$ undock --rm-dist --all crazymax/moby-bin:latest ./moby-bin
...
$ tree -nh ./moby-bin/
[4.0K]  ./moby-bin/
├── [4.0K]  linux_amd64
│   ├── [ 37M]  containerd
│   ├── [8.1M]  containerd-shim-runc-v2
│   ├── [ 18M]  ctr
│   ├── [748K]  docker-init
│   ├── [1.9M]  docker-proxy
│   ├── [ 62M]  dockerd
│   ├── [ 14K]  dockerd-rootless-setuptool.sh
│   ├── [5.1K]  dockerd-rootless.sh
│   ├── [ 11M]  rootlesskit
│   ├── [6.9M]  rootlesskit-docker-proxy
│   ├── [ 14M]  runc
│   └── [ 32M]  vpnkit
├── [4.0K]  linux_arm64
│   ├── [ 36M]  containerd
│   ├── [7.9M]  containerd-shim-runc-v2
│   ├── [ 17M]  ctr
│   ├── [527K]  docker-init
│   ├── [2.0M]  docker-proxy
│   ├── [ 59M]  dockerd
│   ├── [ 14K]  dockerd-rootless-setuptool.sh
│   ├── [5.1K]  dockerd-rootless.sh
│   ├── [ 10M]  rootlesskit
│   ├── [6.6M]  rootlesskit-docker-proxy
│   ├── [ 13M]  runc
│   └── [ 38M]  vpnkit
├── [4.0K]  linux_armv5
│   ├── [ 35M]  containerd
│   ├── [7.8M]  containerd-shim-runc-v2
│   ├── [ 17M]  ctr
│   ├── [484K]  docker-init
│   ├── [1.9M]  docker-proxy
│   ├── [ 57M]  dockerd
│   ├── [ 14K]  dockerd-rootless-setuptool.sh
│   ├── [5.1K]  dockerd-rootless.sh
│   ├── [ 10M]  rootlesskit
│   ├── [6.8M]  rootlesskit-docker-proxy
│   └── [ 13M]  runc
├── [4.0K]  linux_armv6
│   ├── [ 35M]  containerd
│   ├── [7.8M]  containerd-shim-runc-v2
│   ├── [ 17M]  ctr
│   ├── [484K]  docker-init
│   ├── [1.9M]  docker-proxy
│   ├── [ 57M]  dockerd
│   ├── [ 14K]  dockerd-rootless-setuptool.sh
│   ├── [5.1K]  dockerd-rootless.sh
│   ├── [ 10M]  rootlesskit
│   ├── [6.8M]  rootlesskit-docker-proxy
│   └── [ 13M]  runc
├── [4.0K]  linux_armv7
│   ├── [ 35M]  containerd
│   ├── [7.8M]  containerd-shim-runc-v2
│   ├── [ 17M]  ctr
│   ├── [364K]  docker-init
│   ├── [1.9M]  docker-proxy
│   ├── [ 57M]  dockerd
│   ├── [ 14K]  dockerd-rootless-setuptool.sh
│   ├── [5.1K]  dockerd-rootless.sh
│   ├── [ 10M]  rootlesskit
│   ├── [6.8M]  rootlesskit-docker-proxy
│   └── [ 12M]  runc
├── [4.0K]  linux_ppc64le
│   ├── [ 36M]  containerd
│   ├── [8.0M]  containerd-shim-runc-v2
│   ├── [ 18M]  ctr
│   ├── [843K]  docker-init
│   ├── [1.9M]  docker-proxy
│   ├── [ 60M]  dockerd
│   ├── [ 14K]  dockerd-rootless-setuptool.sh
│   ├── [5.1K]  dockerd-rootless.sh
│   ├── [ 10M]  rootlesskit
│   ├── [6.7M]  rootlesskit-docker-proxy
│   └── [ 13M]  runc
├── [4.0K]  linux_s390x
│   ├── [ 39M]  containerd
│   ├── [8.6M]  containerd-shim-runc-v2
│   ├── [ 19M]  ctr
│   ├── [615K]  docker-init
│   ├── [2.0M]  docker-proxy
│   ├── [ 64M]  dockerd
│   ├── [ 14K]  dockerd-rootless-setuptool.sh
│   ├── [5.1K]  dockerd-rootless.sh
│   ├── [ 11M]  rootlesskit
│   ├── [7.1M]  rootlesskit-docker-proxy
│   └── [ 14M]  runc
└── [4.0K]  windows_amd64
    ├── [103K]  containerutility.exe
    ├── [2.1M]  docker-proxy.exe
    └── [ 57M]  dockerd.exe

8 directories, 82 files
```

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

cc @rumpl @vvoland