### PR TITLE
`GenerateRandomName` now returns an error when `size` is over 64. Fixes #44362

### DIFF
--- a/libnetwork/netutils/utils.go
+++ b/libnetwork/netutils/utils.go
@@ -124,6 +124,9 @@ func GenerateMACFromIP(ip net.IP) net.HardwareAddr {
 // GenerateRandomName returns a new name joined with a prefix.  This size
 // specified is used to truncate the randomly generated value
 func GenerateRandomName(prefix string, size int) (string, error) {
+	if size > 64 {
+		panic("size cannot be greater than 64")
+	}
 	id := make([]byte, 32)
 	if _, err := io.ReadFull(rand.Reader, id); err != nil {
 		return "", err

--- a/libnetwork/netutils/utils.go
+++ b/libnetwork/netutils/utils.go
@@ -125,7 +125,7 @@ func GenerateMACFromIP(ip net.IP) net.HardwareAddr {
 // specified is used to truncate the randomly generated value
 func GenerateRandomName(prefix string, size int) (string, error) {
 	if size > 64 {
-		panic("size cannot be greater than 64")
+		return "", fmt.Errorf("name: size should be less or equal to 64 but was %d", size)
 	}
 	id := make([]byte, 32)
 	if _, err := io.ReadFull(rand.Reader, id); err != nil {

--- a/libnetwork/netutils/utils_linux_test.go
+++ b/libnetwork/netutils/utils_linux_test.go
@@ -202,6 +202,14 @@ func TestGenerateRandomName(t *testing.T) {
 	if name1 == name2 {
 		t.Fatalf("Expected differing values but received %s and %s", name1, name2)
 	}
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("A panic should occur with size greater than 64")
+		}
+	}()
+	GenerateRandomName("veth", 65)
 }
 
 // Test mac generation.

--- a/libnetwork/netutils/utils_linux_test.go
+++ b/libnetwork/netutils/utils_linux_test.go
@@ -204,7 +204,7 @@ func TestGenerateRandomName(t *testing.T) {
 	}
 
 	_, err = GenerateRandomName("veth", 65)
-	if err != nil {
+	if err == nil {
 		t.Fatal("An error should be returned with size greater than 64")
 	}
 }

--- a/libnetwork/netutils/utils_linux_test.go
+++ b/libnetwork/netutils/utils_linux_test.go
@@ -203,13 +203,10 @@ func TestGenerateRandomName(t *testing.T) {
 		t.Fatalf("Expected differing values but received %s and %s", name1, name2)
 	}
 
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Fatal("A panic should occur with size greater than 64")
-		}
-	}()
-	GenerateRandomName("veth", 65)
+	_, err = GenerateRandomName("veth", 65)
+	if err == nil {
+		t.Fatal("A panic should occur with size greater than 64")
+	}
 }
 
 // Test mac generation.

--- a/libnetwork/netutils/utils_linux_test.go
+++ b/libnetwork/netutils/utils_linux_test.go
@@ -204,8 +204,8 @@ func TestGenerateRandomName(t *testing.T) {
 	}
 
 	_, err = GenerateRandomName("veth", 65)
-	if err == nil {
-		t.Fatal("A panic should occur with size greater than 64")
+	if err != nil {
+		t.Fatal("An error should be returned with size greater than 64")
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Kirk Easterson <kirk.easterson@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did** Added a check for `size` to `GenerateRandomName` and added a test for it

**- How I did it** Added a check for `size` to `GenerateRandomName` 

**- How to verify it** Run the test `TestGenerateRandomName` in `libnetwork/netutils/utils_linux_test.go`. Or `TESTDIRS="./libnetwork/netutils/" make test-unit`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

`netutils.GenerateRandomName` now returns an error when the `size` argument is over 64

**- A picture of a cute animal (not mandatory but encouraged)**

![cute_animal](https://user-images.githubusercontent.com/17068532/210511051-a9ad067a-1ba9-4775-8d85-b8dbb9ed318c.jpg)
