### PR TITLE
hack: restore copy_binaries func

### DIFF
--- a/hack/make/binary-daemon
+++ b/hack/make/binary-daemon
@@ -1,6 +1,29 @@
 #!/usr/bin/env bash
 set -e
 
+copy_binaries() {
+	local dir="${1:?}"
+
+	# Add nested executables to bundle dir so we have complete set of
+	# them available, but only if the native OS/ARCH is the same as the
+	# OS/ARCH of the build target
+	if [ "$(go env GOOS)/$(go env GOARCH)" != "$(go env GOHOSTOS)/$(go env GOHOSTARCH)" ]; then
+		return
+	fi
+	if [ ! -x /usr/local/bin/runc ]; then
+		return
+	fi
+	echo "Copying nested executables into $dir"
+	for file in containerd containerd-shim-runc-v2 ctr runc docker-init rootlesskit rootlesskit-docker-proxy dockerd-rootless.sh dockerd-rootless-setuptool.sh; do
+		cp -f "$(command -v "$file")" "$dir/"
+	done
+	# vpnkit might not be available for the target platform, see vpnkit stage in
+	# the Dockerfile for more information.
+	if command -v vpnkit > /dev/null 2>&1; then
+		cp -f "$(command -v vpnkit)" "$dir/"
+	fi
+}
+
 [ -z "$KEEPDEST" ] && rm -rf "$DEST"
 
 (
@@ -8,4 +31,5 @@ set -e
 	GO_PACKAGE='github.com/docker/docker/cmd/dockerd'
 	BINARY_NAME='dockerd'
 	source "${MAKEDIR}/.binary"
+	copy_binaries "$DEST"
 )


### PR DESCRIPTION
reported on community slack https://dockercommunity.slack.com/archives/C50QFMRC2/p1672827713572689

**- What I did**

`copy_binaries` func has been removed in https://github.com/moby/moby/pull/44546 (https://github.com/moby/moby/commit/8086f4012330d1c1058e07fc4e5e4522dd432c20#diff-04ff962b93ae3db9d1620183ecb03b37c366b4fa3cf189cf5ec2b646c44d432f) but is still useful for the dev environment.

cc @akerouanton

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

