### PR TITLE
[23.0 backport] hack/make: Don't add -buildmode=pie with -race

### DIFF
--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -74,12 +74,15 @@ source "${MAKEDIR}/.go-autogen"
 	# -buildmode=pie is not supported on Windows arm64 and Linux mips*, ppc64be
 	# https://github.com/golang/go/blob/go1.19.4/src/cmd/internal/sys/supported.go#L125-L132
 	if ! [ "$DOCKER_STATIC" = "1" ]; then
-		case "$(go env GOOS)/$(go env GOARCH)" in
-			windows/arm64 | linux/mips* | linux/ppc64) ;;
-			*)
-				BUILDFLAGS+=("-buildmode=pie")
-				;;
-		esac
+		# -buildmode=pie not supported when -race is enabled
+		if [[ " $BUILDFLAGS " != *" -race "* ]]; then
+			case "$(go env GOOS)/$(go env GOARCH)" in
+				windows/arm64 | linux/mips* | linux/ppc64) ;;
+				*)
+					BUILDFLAGS+=("-buildmode=pie")
+					;;
+			esac
+		fi
 	fi
 
 	# only necessary for non-sandboxed invocation where TARGETPLATFORM is empty


### PR DESCRIPTION
Backport of:
- https://github.com/moby/moby/pull/44748

**- What I did**
Don't add `-buildmode=pie` when BUILDFLAGS has `-race` flag.

**- How to verify it**
`make TEST_FILTER='TestLogsFollowGoroutinesWithStdout'  BUILDFLAGS='-race'  test-integration`
should run TestLogsFollowGoroutinesWithStdout integration test with race detector instead of failing with: `-buildmode=pie not supported when -race is enabled`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
