### PR TITLE
Remove reference to "requireRegistryMatch"

### DIFF
--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -636,8 +636,8 @@ func getMaxMountAndExistenceCheckAttempts(layer PushLayer) (maxMountAttempts, ma
 }
 
 // getRepositoryMountCandidates returns an array of v2 metadata items belonging to the given registry. The
-// array is sorted from youngest to oldest. If requireRegistryMatch is true, the resulting array will contain
-// only metadata entries having registry part of SourceRepository matching the part of repoInfo.
+// array is sorted from youngest to oldest. The resulting array will contain only metadata entries having
+// registry part of SourceRepository matching the part of repoInfo.
 func getRepositoryMountCandidates(
 	repoInfo reference.Named,
 	hmacKey []byte,


### PR DESCRIPTION
This option appears to never have actually existed in the merged implementation. 😄