### PR TITLE
[20.10 backport] hack/make: Don't add -buildmode=pie with -race

### DIFF
--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -70,14 +70,17 @@ hash_files() {
 		esac
 	fi
 
-	# -buildmode=pie is not supported on Windows and Linux on mips and riscv64.
-	case "$(go env GOOS)/$(go env GOARCH)" in
-		windows/* | linux/mips* | linux/riscv*) ;;
+	# -buildmode=pie not supported when -race is enabled
+	if [[ " $BUILDFLAGS " != *" -race "* ]]; then
+		# -buildmode=pie is not supported on Windows and Linux on mips and riscv64.
+		case "$(go env GOOS)/$(go env GOARCH)" in
+			windows/* | linux/mips* | linux/riscv*) ;;
 
-		*)
-			BUILDFLAGS+=("-buildmode=pie")
-			;;
-	esac
+			*)
+				BUILDFLAGS+=("-buildmode=pie")
+				;;
+		esac
+	fi
 
 	echo "Building: $DEST/$BINARY_FULLNAME"
 	echo "GOOS=\"${GOOS}\" GOARCH=\"${GOARCH}\" GOARM=\"${GOARM}\""


### PR DESCRIPTION
Backport of:
- https://github.com/moby/moby/pull/44748

This wasn't a clean cherry-pick due lack of https://github.com/moby/moby/pull/44546.

**- What I did**
Don't add `-buildmode=pie` when BUILDFLAGS has `-race` flag.

**- How to verify it**
`make TEST_FILTER='TestLogsFollowGoroutinesWithStdout'  BUILDFLAGS='-race'  test-integration`
should run TestLogsFollowGoroutinesWithStdout integration test with race detector instead of failing with: `-buildmode=pie not supported when -race is enabled`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
