### PR TITLE
graphdriver/btrfs: needs kernel headers >= 4.12, not >= 4.7

### DIFF
--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -8,6 +8,12 @@ package btrfs // import "github.com/docker/docker/daemon/graphdriver/btrfs"
 #include <stdio.h>
 #include <dirent.h>
 
+#include <linux/version.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,12,0)
+    #error "Headers from kernel >= 4.12 are required to build with Btrfs support."
+    #error "HINT: Set 'DOCKER_BUILDTAGS=exclude_graphdriver_btrfs' to build without Btrfs."
+#endif
+
 #include <linux/btrfs.h>
 #include <linux/btrfs_tree.h>
 

--- a/project/PACKAGERS.md
+++ b/project/PACKAGERS.md
@@ -139,7 +139,7 @@ by having support for them in the kernel or userspace. A few examples include:
 
 * AUFS graph driver (requires AUFS patches/support enabled in the kernel, and at
   least the "auplink" utility from aufs-tools)
-* BTRFS graph driver (requires suitable kernel headers: `linux/btrfs.h` and `linux/btrfs_tree.h`, present in 4.7+; and BTRFS support enabled in the kernel)
+* BTRFS graph driver (requires suitable kernel headers: `linux/btrfs.h` and `linux/btrfs_tree.h`, present in 4.12+; and BTRFS support enabled in the kernel)
 * ZFS graph driver (requires userspace zfs-utils and a corresponding kernel module)
 * Libseccomp to allow running seccomp profiles with containers
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Follow-up to
- https://github.com/moby/moby/pull/44761

Updated `project/PACKAGERS.md` to clarify that the minimum requirement is 4.12, not 4.7.

The 4.7 kernel tree has https://github.com/torvalds/linux/blob/v4.7/include/uapi/linux/btrfs_tree.h but it was not installed to `/usr/include/linux/btrfs_tree.h` until kernel 4.12: https://github.com/torvalds/linux/commit/fcc8487d477a3452a1d0ccbdd4c5e0e1e3cb8bed

Also added a `LINUX_VERSION_CODE` check in `daemon/graphdriver/btrfs/btrfs.go`


**- How to verify it**

Build this Dockerfile with `LINUX_VERSION=4.12` and `LINUX_VERSION=4.7`. 
The latter one fails with `linux/btrfs_tree.h: No such file or directory`.

```dockerfile
ARG GOLANG_VERSION=1.19
ARG LINUX_VERSION=4.12
# 2023-01-07
ARG MOBY_VERSION=6834304febca3c0610d1061bd9612ee99020df34

FROM golang:${GOLANG_VERSION}
ARG LINUX_VERSION
RUN curl -sSL -O "https://mirrors.edge.kernel.org/pub/linux/kernel/v$(echo ${LINUX_VERSION} | cut -d. -f1).x/linux-${LINUX_VERSION}.tar.gz"
RUN tar Cxzf / "linux-${LINUX_VERSION}.tar.gz" && \
  cd "/linux-${LINUX_VERSION}" && \
  make headers_install INSTALL_HDR_PATH=/usr2 && \
  for f in /usr2/include/*; do rm -rf "/usr/include/$(basename ${f})"; done && \
  cp -a /usr2/include /usr

RUN mkdir -p /go/src/github.com/docker && \
  git clone https://github.com/moby/moby.git /go/src/github.com/docker/docker
WORKDIR /go/src/github.com/docker/docker
ARG MOBY_VERSION
RUN git checkout "${MOBY_VERSION}"
ENV GO111MODULE=off
RUN go build ./daemon/graphdriver/btrfs
```

**- A picture of a cute animal (not mandatory but encouraged)**
🐧 
