### PR TITLE
[23.0 backport] integration-cli: Fix hanging TestLogsFollowGoroutines*

### DIFF
--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -290,9 +290,17 @@ func (s *DockerCLILogsSuite) TestLogsFollowGoroutinesWithStdout(c *testing.T) {
 	assert.NilError(c, err)
 	cmd := exec.Command(dockerBinary, "logs", "-f", id)
 	r, w := io.Pipe()
+	defer r.Close()
+	defer w.Close()
+
 	cmd.Stdout = w
 	assert.NilError(c, cmd.Start())
-	go cmd.Wait()
+	defer cmd.Process.Kill()
+
+	finished := make(chan error)
+	go func() {
+		finished <- cmd.Wait()
+	}()
 
 	// Make sure pipe is written to
 	chErr := make(chan error)
@@ -300,11 +308,15 @@ func (s *DockerCLILogsSuite) TestLogsFollowGoroutinesWithStdout(c *testing.T) {
 		b := make([]byte, 1)
 		_, err := r.Read(b)
 		chErr <- err
+		r.Close()
 	}()
+
+	// Check read from pipe succeeded
 	assert.NilError(c, <-chErr)
+
 	assert.NilError(c, cmd.Process.Kill())
-	r.Close()
-	cmd.Wait()
+	<-finished
+
 	// NGoroutines is not updated right away, so we need to wait before failing
 	assert.NilError(c, waitForGoroutines(nroutines))
 }
@@ -318,10 +330,16 @@ func (s *DockerCLILogsSuite) TestLogsFollowGoroutinesNoOutput(c *testing.T) {
 	assert.NilError(c, err)
 	cmd := exec.Command(dockerBinary, "logs", "-f", id)
 	assert.NilError(c, cmd.Start())
-	go cmd.Wait()
+
+	finished := make(chan error)
+	go func() {
+		finished <- cmd.Wait()
+	}()
+
 	time.Sleep(200 * time.Millisecond)
 	assert.NilError(c, cmd.Process.Kill())
-	cmd.Wait()
+
+	<-finished
 
 	// NGoroutines is not updated right away, so we need to wait before failing
 	assert.NilError(c, waitForGoroutines(nroutines))


### PR DESCRIPTION
- Fix: https://github.com/moby/moby/issues/44747
- Backport: https://github.com/moby/moby/pull/44749

**- What I did**
Fix TestLogsFollowGoroutinesWithStdout and TestLogsFollowGoroutinesNoOutput hanging randomly

**- How I did it**
cmd.Wait is called twice from different goroutines which can cause the test to hang completely. Fix by calling Wait only once and sending its return value over a channel.

In `TestLogsFollowGoroutinesWithStdout` also added additional closes and process kills to ensure that we don't leak anything in case test returns early because of failed test assertion.


**- How to verify it**
```bash
make TEST_FILTER='.*TestLogsFollowGoroutine.*' TESTFLAGS='-test.count 10000 '  test-integration
```

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

