### PR TITLE
daemon/config: ignore UTF-8 BOM in config JSON

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -410,14 +410,14 @@ func getConflictFreeConfiguration(configFile string, flags *pflag.FlagSet) (*Con
 		return nil, err
 	}
 
-	var config Config
-
 	// Strip the UTF-8 BOM if present ([RFC 8259] allows JSON implementations to optionally strip the BOM for
 	// interoperability; do so here as Notepad on older versions of Windows Server insists on a BOM).
 	// [RFC 8259]: https://tools.ietf.org/html/rfc8259#section-8.1
 	b = bytes.TrimPrefix(b, []byte("\xef\xbb\xbf"))
-
+	// Trim whitespace so that an empty config can be detected for an early return.
 	b = bytes.TrimSpace(b)
+
+	var config Config
 	if len(b) == 0 {
 		return &config, nil // early return on empty config
 	}

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -412,10 +412,14 @@ func getConflictFreeConfiguration(configFile string, flags *pflag.FlagSet) (*Con
 
 	var config Config
 
+	// Strip the UTF-8 BOM if present ([RFC 8259] allows JSON implementations to optionally strip the BOM for
+	// interoperability; do so here as Notepad on older versions of Windows Server insists on a BOM).
+	// [RFC 8259]: https://tools.ietf.org/html/rfc8259#section-8.1
+	b = bytes.TrimPrefix(b, []byte("\xef\xbb\xbf"))
+
 	b = bytes.TrimSpace(b)
 	if len(b) == 0 {
-		// empty config file
-		return &config, nil
+		return &config, nil // early return on empty config
 	}
 
 	if flags != nil {

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -2,6 +2,7 @@ package config // import "github.com/docker/docker/daemon/config"
 
 import (
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -33,6 +34,20 @@ func TestDaemonBrokenConfiguration(t *testing.T) {
 
 	_, err = MergeDaemonConfigurations(&Config{}, nil, configFile)
 	assert.ErrorContains(t, err, `invalid character ' ' in literal true`)
+}
+
+// TestDaemonConfigurationWithBOM ensures that the UTF-8 byte order mark is ignored when reading the configuration file.
+func TestDaemonConfigurationWithBOM(t *testing.T) {
+	configFile := filepath.Join(t.TempDir(), "daemon.json")
+
+	f, err := os.Create(configFile)
+	assert.NilError(t, err)
+
+	f.Write([]byte("\xef\xbb\xbf{\"debug\": true}"))
+	f.Close()
+
+	_, err = MergeDaemonConfigurations(&Config{}, nil, configFile)
+	assert.NilError(t, err)
 }
 
 func TestFindConfigurationConflicts(t *testing.T) {


### PR DESCRIPTION
**- What I did**
Strip a BOM when present in the config JSON.

[RFC 8259] allows for JSON implementations to optionally ignore a BOM when it helps with interoperability; do so in Moby as Notepad (the only text editor available out of the box in many versions of Windows server) insists on writing UTF-8 with a BOM.

  [RFC 8259]: https://tools.ietf.org/html/rfc8259#section-8.1

**- How I did it**
`bytes.TrimPrefix`

**- How to verify it**
Unit tests.

**- Description for the changelog**
* Moby now accepts config JSON files with a UTF-8 byte order mark present.

**- A picture of a cute animal (not mandatory but encouraged)**
![beardy](https://i.redd.it/zam79ldo73z91.jpg)
