### PR TITLE
Remove the registry.Service interface and use the struct

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -80,7 +80,7 @@ type Daemon struct {
 	configStore           *config.Config
 	statsCollector        *stats.Collector
 	defaultLogConfig      containertypes.LogConfig
-	registryService       registry.Service
+	registryService       *registry.Service
 	EventsService         *events.Events
 	netController         libnetwork.NetworkController
 	volumes               *volumesservice.VolumesService

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -39,7 +39,7 @@ type ImageServiceConfig struct {
 	MaxConcurrentUploads      int
 	MaxDownloadAttempts       int
 	ReferenceStore            dockerreference.Store
-	RegistryService           registry.Service
+	RegistryService           *registry.Service
 	ContentStore              content.Store
 	Leases                    leases.Manager
 	ContentNamespace          string
@@ -73,7 +73,7 @@ type ImageService struct {
 	layerStore                layer.Store
 	pruneRunning              int32
 	referenceStore            dockerreference.Store
-	registryService           registry.Service
+	registryService           *registry.Service
 	uploadManager             *xfer.LayerUploadManager
 	leases                    leases.Manager
 	content                   content.Store

--- a/distribution/config.go
+++ b/distribution/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	ProgressOutput progress.Output
 	// RegistryService is the registry service to use for TLS configuration
 	// and endpoint lookup.
-	RegistryService registrypkg.Service
+	RegistryService *registrypkg.Service
 	// ImageEventLogger notifies events for a given image
 	ImageEventLogger func(id, name, action string)
 	// MetadataStore is the storage backend for distribution-specific

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -520,7 +520,7 @@ func TestMirrorEndpointLookup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s := defaultService{config: cfg}
+	s := Service{config: cfg}
 
 	imageName, err := reference.WithName(IndexName + "/test/image")
 	if err != nil {

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -7,7 +7,7 @@ import (
 	"github.com/docker/go-connections/tlsconfig"
 )
 
-func (s *defaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, err error) {
+func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, err error) {
 	ana := s.config.allowNondistributableArtifacts(hostname)
 
 	if hostname == DefaultNamespace || hostname == IndexHostname {


### PR DESCRIPTION
**- What I did**

Removed `registry.Service` interface, it's 

**- How I did it**

Remove the interface and changed the usages until it built.

**- How to verify it**

Should build

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

