### PR TITLE
[23.0 backport] libnetwork: improve logs for DNS failures

### DIFF
--- a/libnetwork/resolver.go
+++ b/libnetwork/resolver.go
@@ -502,7 +502,7 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 			// client can retry over TCP
 			if err != nil && (resp == nil || !resp.Truncated) {
 				r.forwardQueryEnd()
-				logrus.WithError(err).Debugf("[resolver] failed to read from DNS server")
+				logrus.WithError(err).Warnf("[resolver] failed to read from DNS server: %s, query: %s", extConn.RemoteAddr().String(), query.Question[0].String())
 				continue
 			}
 			r.forwardQueryEnd()


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44667
- fixes https://github.com/moby/moby/issues/44610

libnetwork: fix function call

(cherry picked from commit 0787ea8b26999d4b60a995d129c6461f440b0441)


**- A picture of a cute animal (not mandatory but encouraged)**

