### PR TITLE
use example.com for tests and examples

### DIFF
--- a/builder/dockerfile/evaluator_test.go
+++ b/builder/dockerfile/evaluator_test.go
@@ -87,7 +87,7 @@ func TestDispatch(t *testing.T) {
 		{
 			name: "COPY url",
 			cmd: &instructions.CopyCommand{SourcesAndDest: instructions.SourcesAndDest{
-				SourcePaths: []string{"https://index.docker.io/robots.txt"},
+				SourcePaths: []string{"https://example.com/index.html"},
 				DestPath:    "/",
 			}},
 			expectedError: "source can't be a URL for COPY",

--- a/libnetwork/README.md
+++ b/libnetwork/README.md
@@ -63,7 +63,7 @@ func main() {
 	// NewSandbox accepts Variadic optional arguments which libnetwork can use.
 	sbx, err := controller.NewSandbox("container1",
 		libnetwork.OptionHostname("test"),
-		libnetwork.OptionDomainname("docker.io"))
+		libnetwork.OptionDomainname("example.com"))
 	if err != nil {
 		log.Fatalf("controller.NewSandbox: %s", err)
 	}

--- a/libnetwork/cmd/readme_test/readme.go
+++ b/libnetwork/cmd/readme_test/readme.go
@@ -48,7 +48,7 @@ func main() {
 	// NewSandbox accepts Variadic optional arguments which libnetwork can use.
 	sbx, err := controller.NewSandbox("container1",
 		libnetwork.OptionHostname("test"),
-		libnetwork.OptionDomainname("docker.io"))
+		libnetwork.OptionDomainname("example.com"))
 	if err != nil {
 		log.Fatalf("controller.NewSandbox: %s", err)
 	}

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -33,7 +33,7 @@ create network namespaces and allocate interfaces for containers to use.
 	// NewSandbox accepts Variadic optional arguments which libnetwork can use.
 	sbx, err := controller.NewSandbox("container1",
 		libnetwork.OptionHostname("test"),
-		libnetwork.OptionDomainname("docker.io"))
+		libnetwork.OptionDomainname("example.com"))
 
 	// A sandbox can join the endpoint via the join api.
 	err = ep.Join(sbx)

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -45,7 +45,7 @@ func TestHost(t *testing.T) {
 
 	sbx1, err := controller.NewSandbox("host_c1",
 		libnetwork.OptionHostname("test1"),
-		libnetwork.OptionDomainname("docker.io"),
+		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionExtraHost("web", "192.168.0.1"),
 		libnetwork.OptionUseDefaultSandbox())
 	if err != nil {
@@ -59,7 +59,7 @@ func TestHost(t *testing.T) {
 
 	sbx2, err := controller.NewSandbox("host_c2",
 		libnetwork.OptionHostname("test2"),
-		libnetwork.OptionDomainname("docker.io"),
+		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionExtraHost("web", "192.168.0.1"),
 		libnetwork.OptionUseDefaultSandbox())
 	if err != nil {
@@ -109,7 +109,7 @@ func TestHost(t *testing.T) {
 	// Try to create another host endpoint and join/leave that.
 	cnt3, err := controller.NewSandbox("host_c3",
 		libnetwork.OptionHostname("test3"),
-		libnetwork.OptionDomainname("docker.io"),
+		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionExtraHost("web", "192.168.0.1"),
 		libnetwork.OptionUseDefaultSandbox())
 	if err != nil {
@@ -292,7 +292,7 @@ func TestEndpointJoin(t *testing.T) {
 
 	sb, err := controller.NewSandbox(containerID,
 		libnetwork.OptionHostname("test"),
-		libnetwork.OptionDomainname("docker.io"),
+		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionExtraHost("web", "192.168.0.1"))
 	if err != nil {
 		t.Fatal(err)
@@ -446,7 +446,7 @@ func externalKeyTest(t *testing.T, reexec bool) {
 
 	cnt, err := controller.NewSandbox(containerID,
 		libnetwork.OptionHostname("test"),
-		libnetwork.OptionDomainname("docker.io"),
+		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionUseExternalKey(),
 		libnetwork.OptionExtraHost("web", "192.168.0.1"))
 	defer func() {

--- a/libnetwork/libnetwork_test.go
+++ b/libnetwork/libnetwork_test.go
@@ -95,7 +95,7 @@ func TestNull(t *testing.T) {
 
 	cnt, err := controller.NewSandbox("null_container",
 		libnetwork.OptionHostname("test"),
-		libnetwork.OptionDomainname("docker.io"),
+		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionExtraHost("web", "192.168.0.1"))
 	if err != nil {
 		t.Fatal(err)
@@ -937,7 +937,7 @@ func TestEndpointDeleteWithActiveContainer(t *testing.T) {
 
 	cnt, err := controller.NewSandbox(containerID,
 		libnetwork.OptionHostname("test"),
-		libnetwork.OptionDomainname("docker.io"),
+		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionExtraHost("web", "192.168.0.1"))
 	defer func() {
 		if err := cnt.Delete(); err != nil {
@@ -996,7 +996,7 @@ func TestEndpointMultipleJoins(t *testing.T) {
 
 	sbx1, err := controller.NewSandbox(containerID,
 		libnetwork.OptionHostname("test"),
-		libnetwork.OptionDomainname("docker.io"),
+		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionExtraHost("web", "192.168.0.1"),
 	)
 	if err != nil {
@@ -1133,7 +1133,7 @@ func TestContainerInvalidLeave(t *testing.T) {
 
 	cnt, err := controller.NewSandbox(containerID,
 		libnetwork.OptionHostname("test"),
-		libnetwork.OptionDomainname("docker.io"),
+		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionExtraHost("web", "192.168.0.1"))
 	if err != nil {
 		t.Fatal(err)
@@ -1198,7 +1198,7 @@ func TestEndpointUpdateParent(t *testing.T) {
 
 	sbx1, err := controller.NewSandbox(containerID,
 		libnetwork.OptionHostname("test"),
-		libnetwork.OptionDomainname("docker.io"),
+		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionExtraHost("web", "192.168.0.1"))
 	if err != nil {
 		t.Fatal(err)
@@ -1211,7 +1211,7 @@ func TestEndpointUpdateParent(t *testing.T) {
 
 	sbx2, err := controller.NewSandbox("c2",
 		libnetwork.OptionHostname("test2"),
-		libnetwork.OptionDomainname("docker.io"),
+		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionHostsPath("/var/lib/docker/test_network/container2/hosts"),
 		libnetwork.OptionExtraHost("web", "192.168.0.2"))
 	if err != nil {


### PR DESCRIPTION
Trying to remove the "docker.io" domain from locations where it's not relevant.
In these cases, this domain was used as a "random" domain for testing or example
purposes.


**- A picture of a cute animal (not mandatory but encouraged)**

