### PR TITLE
api/import: Don't set default comment 

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -123,7 +123,7 @@ func (ir *imageRouter) postImagesCreate(ctx context.Context, w http.ResponseWrit
 		var id image.ID
 		id, progressErr = ir.backend.ImportImage(ctx, ref, platform, comment, layerReader, r.Form["changes"])
 
-		if progressErr == nil {
+		if id != "" {
 			output.Write(streamformatter.FormatStatus("", id.String()))
 		}
 	}

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -93,10 +93,6 @@ func (ir *imageRouter) postImagesCreate(ctx context.Context, w http.ResponseWrit
 			}
 		}
 
-		if len(comment) == 0 {
-			comment = "Imported from " + src
-		}
-
 		var layerReader io.ReadCloser
 		defer r.Body.Close()
 		if src == "-" {

--- a/daemon/images/image_import.go
+++ b/daemon/images/image_import.go
@@ -26,6 +26,8 @@ import (
 // If the platform is nil, the default host platform is used.
 // Message is used as the image's history comment.
 // Image configuration is derived from the dockerfile instructions in changes.
+// Function can return both an error and valid image ID if the image was
+// imported successfully but tagging it to a newRef reference failed.
 func (i *ImageService) ImportImage(ctx context.Context, newRef reference.Named, platform *specs.Platform, msg string, layerReader io.Reader, changes []string) (image.ID, error) {
 	if platform == nil {
 		def := platforms.DefaultSpec()
@@ -78,13 +80,13 @@ func (i *ImageService) ImportImage(ctx context.Context, newRef reference.Named, 
 	if err != nil {
 		return "", err
 	}
+	defer i.LogImageEvent(id.String(), id.String(), "import")
 
 	if newRef != nil {
 		if err := i.TagImageWithReference(id, newRef); err != nil {
-			return "", err
+			return id, err
 		}
 	}
 
-	i.LogImageEvent(id.String(), id.String(), "import")
 	return id, nil
 }


### PR DESCRIPTION
- Follow up: https://github.com/moby/moby/pull/44628

**- What I did**
Removed the default comment set on imported image "Imported from -".
It isn't very helpful and is another thing that impacts the image digest.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
Import images no longer have a default comment.

**- A picture of a cute animal (not mandatory but encouraged)**

