### PR TITLE
libnetwork: Clean up sysfs-based operations

### DIFF
--- a/libnetwork/drivers/overlay/ov_network.go
+++ b/libnetwork/drivers/overlay/ov_network.go
@@ -124,6 +124,8 @@ func setDefaultVlan() {
 	}
 
 	brName := os.Args[2]
+	// IFLA_BR_VLAN_DEFAULT_PVID was added in Linux v4.4 (see torvalds/linux@0f963b7), so we can't use netlink for
+	// setting this until Docker drops support for CentOS/RHEL 7 (kernel 3.10, eol date: 2024-06-30).
 	path := filepath.Join("/sys/class/net", brName, "bridge/default_pvid")
 	data := []byte{'0', '\n'}
 

--- a/libnetwork/osl/interface_linux.go
+++ b/libnetwork/osl/interface_linux.go
@@ -3,7 +3,6 @@ package osl
 import (
 	"fmt"
 	"net"
-	"regexp"
 	"sync"
 	"syscall"
 	"time"
@@ -416,30 +415,6 @@ func setInterfaceRoutes(nlh *netlink.Handle, iface netlink.Link, i *nwIface) err
 		}
 	}
 	return nil
-}
-
-// In older kernels (like the one in Centos 6.6 distro) sysctl does not have netns support. Therefore
-// we cannot gather the statistics from /sys/class/net/<dev>/statistics/<counter> files. Per-netns stats
-// are naturally found in /proc/net/dev in kernels which support netns (ifconfig relies on that).
-const (
-	base = "[ ]*%s:([ ]+[0-9]+){16}"
-)
-
-func scanInterfaceStats(data, ifName string, i *types.InterfaceStatistics) error {
-	var (
-		bktStr string
-		bkt    uint64
-	)
-
-	regex := fmt.Sprintf(base, ifName)
-	re := regexp.MustCompile(regex)
-	line := re.FindString(data)
-
-	_, err := fmt.Sscanf(line, "%s %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d",
-		&bktStr, &i.RxBytes, &i.RxPackets, &i.RxErrors, &i.RxDropped, &bkt, &bkt, &bkt,
-		&bkt, &i.TxBytes, &i.TxPackets, &i.TxErrors, &i.TxDropped, &bkt, &bkt, &bkt, &bkt)
-
-	return err
 }
 
 func checkRouteConflict(nlh *netlink.Handle, address *net.IPNet, family int) error {

--- a/libnetwork/osl/sandbox_linux_test.go
+++ b/libnetwork/osl/sandbox_linux_test.go
@@ -158,32 +158,6 @@ func verifyCleanup(t *testing.T, s Sandbox, wait bool) {
 	}
 }
 
-func TestScanStatistics(t *testing.T) {
-	data :=
-		"Inter-|   Receive                                                |  Transmit\n" +
-			"	face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed\n" +
-			"  eth0:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0\n" +
-			" wlan0: 7787685   11141    0    0    0     0          0         0  1681390    7220    0    0    0     0       0          0\n" +
-			"    lo:  783782    1853    0    0    0     0          0         0   783782    1853    0    0    0     0       0          0\n" +
-			"lxcbr0:       0       0    0    0    0     0          0         0     9006      61    0    0    0     0       0          0\n"
-
-	i := &types.InterfaceStatistics{}
-
-	if err := scanInterfaceStats(data, "wlan0", i); err != nil {
-		t.Fatal(err)
-	}
-	if i.TxBytes != 1681390 || i.TxPackets != 7220 || i.RxBytes != 7787685 || i.RxPackets != 11141 {
-		t.Fatalf("Error scanning the statistics")
-	}
-
-	if err := scanInterfaceStats(data, "lxcbr0", i); err != nil {
-		t.Fatal(err)
-	}
-	if i.TxBytes != 9006 || i.TxPackets != 61 || i.RxBytes != 0 || i.RxPackets != 0 {
-		t.Fatalf("Error scanning the statistics")
-	}
-}
-
 func TestDisableIPv6DAD(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
 


### PR DESCRIPTION
- The oldest kernel version currently supported is v3.10. Bridge parameters can be set through netlink since v3.8 (see torvalds/linux@25c71c7). As such, we don't need to fallback to sysfs to set hairpin mode.
- `scanInterfaceStats()` is never called, so no need to keep it alive.
- Document why `default_pvid` is set through sysfs
