### PR TITLE
libnetwork: Remove iptables nat rule when hairpin is disabled

### DIFF
--- a/libnetwork/drivers/bridge/setup_ip_tables.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables.go
@@ -244,11 +244,10 @@ func setupIPTablesInternal(hostIP net.IP, bridgeIface string, addr *net.IPNet, i
 		}
 	}
 
-	// In hairpin mode, masquerade traffic from localhost
-	if hairpin {
-		if err := programChainRule(ipVersion, hpNatRule, "MASQ LOCAL HOST", enable); err != nil {
-			return err
-		}
+	// In hairpin mode, masquerade traffic from localhost. If hairpin is disabled or if we're tearing down
+	// that bridge, make sure the iptables rule isn't lying around.
+	if err := programChainRule(ipVersion, hpNatRule, "MASQ LOCAL HOST", enable && hairpin); err != nil {
+		return err
 	}
 
 	// Set Inter Container Communication.


### PR DESCRIPTION
When userland-proxy is turned off and on again, the iptables nat rule
doing hairpinning isn't properly removed. This fix makes sure this nat
rule is removed whenever the bridge is torn down or hairpinning is
disabled (through setting userland-proxy to true).

Unlike for ip masquerading and ICC, the `programChainRule()` call
setting up the "MASQ LOCAL HOST" rule has to be called unconditionally
because the hairpin parameter isn't restored from the driver store, but
always comes from the driver config.

For the "SKIP DNAT" rule, things are a bit different: this rule is
always deleted by `removeIPChains()` when the bridge driver is
initialized.

Fixes #44721.

Side note: I'm not super happy with this fix. It does its job but there're now 3 ways iptables rules created by `setupIPTablesInternal` are torn down. There might be a better way to do that, but this probably won't be possible until libnetwork got cleaned up and iptables rules are managed in a better way.

**- How to verify it**

Turning `userland-proxy` off and on again, and then running `iptables -t nat -nvL`. There should be no rule looking like `-A POSTROUTING -o docker0 -m addrtype --src-type LOCAL -j MASQUERADE`.