### PR TITLE
libnetwork: replace some unnecessary interfaces with their concrete types

### DIFF
--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -69,7 +69,7 @@ type Opt struct {
 	SessionManager      *session.Manager
 	Root                string
 	Dist                images.DistributionServices
-	NetworkController   libnetwork.NetworkController
+	NetworkController   *libnetwork.Controller
 	DefaultCgroupParent string
 	RegistryHosts       docker.RegistryHosts
 	BuilderConfig       config.BuilderConfig

--- a/builder/builder-next/executor_unix.go
+++ b/builder/builder-next/executor_unix.go
@@ -83,7 +83,7 @@ func (p *bridgeProvider) New() (network.Namespace, error) {
 }
 
 type lnInterface struct {
-	ep  libnetwork.Endpoint
+	ep  *libnetwork.Endpoint
 	sbx *libnetwork.Sandbox
 	sync.Once
 	err      error

--- a/builder/builder-next/executor_unix.go
+++ b/builder/builder-next/executor_unix.go
@@ -84,7 +84,7 @@ func (p *bridgeProvider) New() (network.Namespace, error) {
 
 type lnInterface struct {
 	ep  libnetwork.Endpoint
-	sbx libnetwork.Sandbox
+	sbx *libnetwork.Sandbox
 	sync.Once
 	err      error
 	ready    chan struct{}

--- a/builder/builder-next/executor_windows.go
+++ b/builder/builder-next/executor_windows.go
@@ -11,7 +11,7 @@ import (
 	"github.com/moby/buildkit/executor/oci"
 )
 
-func newExecutor(_, _ string, _ libnetwork.NetworkController, _ *oci.DNSConfig, _ bool, _ idtools.IdentityMapping, _ string) (executor.Executor, error) {
+func newExecutor(_, _ string, _ *libnetwork.Controller, _ *oci.DNSConfig, _ bool, _ idtools.IdentityMapping, _ string) (executor.Executor, error) {
 	return &winExecutor{}, nil
 }
 

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -291,7 +291,7 @@ func (daemon *Daemon) updateNetworkSettings(container *container.Container, n li
 	return nil
 }
 
-func (daemon *Daemon) updateEndpointNetworkSettings(container *container.Container, n libnetwork.Network, ep libnetwork.Endpoint) error {
+func (daemon *Daemon) updateEndpointNetworkSettings(container *container.Container, n libnetwork.Network, ep *libnetwork.Endpoint) error {
 	if err := buildEndpointInfo(container.NetworkSettings, n, ep); err != nil {
 		return err
 	}
@@ -834,7 +834,7 @@ func (daemon *Daemon) connectToNetwork(container *container.Container, idOrName 
 	return nil
 }
 
-func updateJoinInfo(networkSettings *network.Settings, n libnetwork.Network, ep libnetwork.Endpoint) error {
+func updateJoinInfo(networkSettings *network.Settings, n libnetwork.Network, ep *libnetwork.Endpoint) error {
 	if ep == nil {
 		return errors.New("invalid enppoint whhile building portmap info")
 	}
@@ -881,11 +881,11 @@ func (daemon *Daemon) ForceEndpointDelete(name string, networkName string) error
 
 func (daemon *Daemon) disconnectFromNetwork(container *container.Container, n libnetwork.Network, force bool) error {
 	var (
-		ep   libnetwork.Endpoint
+		ep   *libnetwork.Endpoint
 		sbox *libnetwork.Sandbox
 	)
 
-	s := func(current libnetwork.Endpoint) bool {
+	s := func(current *libnetwork.Endpoint) bool {
 		epInfo := current.Info()
 		if epInfo == nil {
 			return false

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -602,9 +602,9 @@ func (daemon *Daemon) allocateNetwork(container *container.Container) (retErr er
 	return nil
 }
 
-func (daemon *Daemon) getNetworkSandbox(container *container.Container) libnetwork.Sandbox {
-	var sb libnetwork.Sandbox
-	daemon.netController.WalkSandboxes(func(s libnetwork.Sandbox) bool {
+func (daemon *Daemon) getNetworkSandbox(container *container.Container) *libnetwork.Sandbox {
+	var sb *libnetwork.Sandbox
+	daemon.netController.WalkSandboxes(func(s *libnetwork.Sandbox) bool {
 		if s.ContainerID() == container.ID {
 			sb = s
 			return true
@@ -882,7 +882,7 @@ func (daemon *Daemon) ForceEndpointDelete(name string, networkName string) error
 func (daemon *Daemon) disconnectFromNetwork(container *container.Container, n libnetwork.Network, force bool) error {
 	var (
 		ep   libnetwork.Endpoint
-		sbox libnetwork.Sandbox
+		sbox *libnetwork.Sandbox
 	)
 
 	s := func(current libnetwork.Endpoint) bool {
@@ -1164,7 +1164,7 @@ func getNetworkID(name string, endpointSettings *networktypes.EndpointSettings) 
 }
 
 // updateSandboxNetworkSettings updates the sandbox ID and Key.
-func updateSandboxNetworkSettings(c *container.Container, sb libnetwork.Sandbox) error {
+func updateSandboxNetworkSettings(c *container.Container, sb *libnetwork.Sandbox) error {
 	c.NetworkSettings.SandboxID = sb.ID()
 	c.NetworkSettings.SandboxKey = sb.Key()
 	return nil

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -83,7 +83,7 @@ type Daemon struct {
 	defaultLogConfig      containertypes.LogConfig
 	registryService       registry.Service
 	EventsService         *events.Events
-	netController         libnetwork.NetworkController
+	netController         *libnetwork.Controller
 	volumes               *volumesservice.VolumesService
 	root                  string
 	sysInfoOnce           sync.Once

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -864,7 +864,7 @@ func (daemon *Daemon) initNetworkController(activeSandboxes map[string]interface
 	return nil
 }
 
-func configureNetworking(controller libnetwork.NetworkController, conf *config.Config) error {
+func configureNetworking(controller *libnetwork.Controller, conf *config.Config) error {
 	// Initialize default network on "null"
 	if n, _ := controller.NetworkByName("none"); n == nil {
 		if _, err := controller.NewNetwork("null", "none", "", libnetwork.NetworkOptionPersist(true)); err != nil {
@@ -902,7 +902,7 @@ func configureNetworking(controller libnetwork.NetworkController, conf *config.C
 }
 
 // setHostGatewayIP sets cfg.HostGatewayIP to the default bridge's IP if it is empty.
-func setHostGatewayIP(controller libnetwork.NetworkController, config *config.Config) {
+func setHostGatewayIP(controller *libnetwork.Controller, config *config.Config) {
 	if config.HostGatewayIP != nil {
 		return
 	}
@@ -930,7 +930,7 @@ func driverOptions(config *config.Config) nwconfig.Option {
 	})
 }
 
-func initBridgeDriver(controller libnetwork.NetworkController, config *config.Config) error {
+func initBridgeDriver(controller *libnetwork.Controller, config *config.Config) error {
 	bridgeName := bridge.DefaultBridgeName
 	if config.BridgeConfig.Iface != "" {
 		bridgeName = config.BridgeConfig.Iface

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -409,7 +409,7 @@ func (daemon *Daemon) initNetworkController(activeSandboxes map[string]interface
 	return nil
 }
 
-func initBridgeDriver(controller libnetwork.NetworkController, config *config.Config) error {
+func initBridgeDriver(controller *libnetwork.Controller, config *config.Config) error {
 	if _, err := controller.NetworkByName(runconfig.DefaultDaemonNetworkMode().NetworkName()); err == nil {
 		return nil
 	}

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -782,7 +782,7 @@ func (daemon *Daemon) clearAttachableNetworks() {
 }
 
 // buildCreateEndpointOptions builds endpoint options from a given network.
-func buildCreateEndpointOptions(c *container.Container, n libnetwork.Network, epConfig *network.EndpointSettings, sb libnetwork.Sandbox, daemonDNS []string) ([]libnetwork.EndpointOption, error) {
+func buildCreateEndpointOptions(c *container.Container, n libnetwork.Network, epConfig *network.EndpointSettings, sb *libnetwork.Sandbox, daemonDNS []string) ([]libnetwork.EndpointOption, error) {
 	var (
 		bindings      = make(nat.PortMap)
 		pbList        []networktypes.PortBinding
@@ -954,7 +954,7 @@ func buildCreateEndpointOptions(c *container.Container, n libnetwork.Network, ep
 }
 
 // getPortMapInfo retrieves the current port-mapping programmed for the given sandbox
-func getPortMapInfo(sb libnetwork.Sandbox) nat.PortMap {
+func getPortMapInfo(sb *libnetwork.Sandbox) nat.PortMap {
 	pm := nat.PortMap{}
 	if sb == nil {
 		return pm

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -50,7 +50,7 @@ func (daemon *Daemon) NetworkControllerEnabled() bool {
 }
 
 // NetworkController returns the network controller created by the daemon.
-func (daemon *Daemon) NetworkController() libnetwork.NetworkController {
+func (daemon *Daemon) NetworkController() *libnetwork.Controller {
 	return daemon.netController
 }
 

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -969,7 +969,7 @@ func getPortMapInfo(sb *libnetwork.Sandbox) nat.PortMap {
 	return pm
 }
 
-func getEndpointPortMapInfo(ep libnetwork.Endpoint) (nat.PortMap, error) {
+func getEndpointPortMapInfo(ep *libnetwork.Endpoint) (nat.PortMap, error) {
 	pm := nat.PortMap{}
 	driverInfo, err := ep.DriverInfo()
 	if err != nil {
@@ -1013,7 +1013,7 @@ func getEndpointPortMapInfo(ep libnetwork.Endpoint) (nat.PortMap, error) {
 }
 
 // buildEndpointInfo sets endpoint-related fields on container.NetworkSettings based on the provided network and endpoint.
-func buildEndpointInfo(networkSettings *internalnetwork.Settings, n libnetwork.Network, ep libnetwork.Endpoint) error {
+func buildEndpointInfo(networkSettings *internalnetwork.Settings, n libnetwork.Network, ep *libnetwork.Endpoint) error {
 	if ep == nil {
 		return errors.New("endpoint cannot be nil")
 	}

--- a/daemon/network_windows.go
+++ b/daemon/network_windows.go
@@ -7,7 +7,7 @@ import (
 )
 
 // getEndpointInNetwork returns the container's endpoint to the provided network.
-func getEndpointInNetwork(name string, n libnetwork.Network) (libnetwork.Endpoint, error) {
+func getEndpointInNetwork(name string, n libnetwork.Network) (*libnetwork.Endpoint, error) {
 	endpointName := strings.TrimPrefix(name, "/")
 	return n.EndpointByName(endpointName)
 }

--- a/daemon/rename.go
+++ b/daemon/rename.go
@@ -16,7 +16,7 @@ import (
 func (daemon *Daemon) ContainerRename(oldName, newName string) error {
 	var (
 		sid string
-		sb  libnetwork.Sandbox
+		sb  *libnetwork.Sandbox
 	)
 
 	if oldName == "" || newName == "" {

--- a/libnetwork/agent.go
+++ b/libnetwork/agent.go
@@ -551,7 +551,7 @@ func (n *network) leaveCluster() error {
 	return agent.networkDB.LeaveNetwork(n.ID())
 }
 
-func (ep *endpoint) addDriverInfoToCluster() error {
+func (ep *Endpoint) addDriverInfoToCluster() error {
 	n := ep.getNetwork()
 	if !n.isClusterEligible() {
 		return nil
@@ -573,7 +573,7 @@ func (ep *endpoint) addDriverInfoToCluster() error {
 	return nil
 }
 
-func (ep *endpoint) deleteDriverInfoFromCluster() error {
+func (ep *Endpoint) deleteDriverInfoFromCluster() error {
 	n := ep.getNetwork()
 	if !n.isClusterEligible() {
 		return nil
@@ -595,7 +595,7 @@ func (ep *endpoint) deleteDriverInfoFromCluster() error {
 	return nil
 }
 
-func (ep *endpoint) addServiceInfoToCluster(sb *Sandbox) error {
+func (ep *Endpoint) addServiceInfoToCluster(sb *Sandbox) error {
 	if ep.isAnonymous() && len(ep.myAliases) == 0 || ep.Iface() == nil || ep.Iface().Address() == nil {
 		return nil
 	}
@@ -677,7 +677,7 @@ func (ep *endpoint) addServiceInfoToCluster(sb *Sandbox) error {
 	return nil
 }
 
-func (ep *endpoint) deleteServiceInfoFromCluster(sb *Sandbox, fullRemove bool, method string) error {
+func (ep *Endpoint) deleteServiceInfoFromCluster(sb *Sandbox, fullRemove bool, method string) error {
 	if ep.isAnonymous() && len(ep.myAliases) == 0 {
 		return nil
 	}
@@ -742,7 +742,7 @@ func (ep *endpoint) deleteServiceInfoFromCluster(sb *Sandbox, fullRemove bool, m
 	return nil
 }
 
-func disableServiceInNetworkDB(a *agent, n *network, ep *endpoint) {
+func disableServiceInNetworkDB(a *agent, n *network, ep *Endpoint) {
 	var epRec EndpointRecord
 
 	logrus.Debugf("disableServiceInNetworkDB for %s %s", ep.svcName, ep.ID())

--- a/libnetwork/agent.go
+++ b/libnetwork/agent.go
@@ -97,7 +97,7 @@ func resolveAddr(addrOrInterface string) (string, error) {
 	return addr.String(), nil
 }
 
-func (c *controller) handleKeyChange(keys []*types.EncryptionKey) error {
+func (c *Controller) handleKeyChange(keys []*types.EncryptionKey) error {
 	drvEnc := discoverapi.DriverEncryptionUpdate{}
 
 	a := c.getAgent()
@@ -201,7 +201,7 @@ func (c *controller) handleKeyChange(keys []*types.EncryptionKey) error {
 	return nil
 }
 
-func (c *controller) agentSetup(clusterProvider cluster.Provider) error {
+func (c *Controller) agentSetup(clusterProvider cluster.Provider) error {
 	agent := c.getAgent()
 
 	// If the agent is already present there is no need to try to initialize it again
@@ -248,7 +248,7 @@ func (c *controller) agentSetup(clusterProvider cluster.Provider) error {
 
 // For a given subsystem getKeys sorts the keys by lamport time and returns
 // slice of keys and lamport time which can used as a unique tag for the keys
-func (c *controller) getKeys(subsys string) ([][]byte, []uint64) {
+func (c *Controller) getKeys(subsys string) ([][]byte, []uint64) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -270,7 +270,7 @@ func (c *controller) getKeys(subsys string) ([][]byte, []uint64) {
 
 // getPrimaryKeyTag returns the primary key for a given subsystem from the
 // list of sorted key and the associated tag
-func (c *controller) getPrimaryKeyTag(subsys string) ([]byte, uint64, error) {
+func (c *Controller) getPrimaryKeyTag(subsys string) ([]byte, uint64, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	sort.Sort(ByTime(c.keys))
@@ -283,7 +283,7 @@ func (c *controller) getPrimaryKeyTag(subsys string) ([]byte, uint64, error) {
 	return keys[1].Key, keys[1].LamportTime, nil
 }
 
-func (c *controller) agentInit(listenAddr, bindAddrOrInterface, advertiseAddr, dataPathAddr string) error {
+func (c *Controller) agentInit(listenAddr, bindAddrOrInterface, advertiseAddr, dataPathAddr string) error {
 	bindAddr, err := resolveAddr(bindAddrOrInterface)
 	if err != nil {
 		return err
@@ -348,7 +348,7 @@ func (c *controller) agentInit(listenAddr, bindAddrOrInterface, advertiseAddr, d
 	return nil
 }
 
-func (c *controller) agentJoin(remoteAddrList []string) error {
+func (c *Controller) agentJoin(remoteAddrList []string) error {
 	agent := c.getAgent()
 	if agent == nil {
 		return nil
@@ -356,7 +356,7 @@ func (c *controller) agentJoin(remoteAddrList []string) error {
 	return agent.networkDB.Join(remoteAddrList)
 }
 
-func (c *controller) agentDriverNotify(d driverapi.Driver) {
+func (c *Controller) agentDriverNotify(d driverapi.Driver) {
 	agent := c.getAgent()
 	if agent == nil {
 		return
@@ -380,7 +380,7 @@ func (c *controller) agentDriverNotify(d driverapi.Driver) {
 	}
 }
 
-func (c *controller) agentClose() {
+func (c *Controller) agentClose() {
 	// Acquire current agent instance and reset its pointer
 	// then run closing functions
 	c.mu.Lock()
@@ -827,7 +827,7 @@ func (n *network) cancelDriverWatches() {
 	}
 }
 
-func (c *controller) handleTableEvents(ch *events.Channel, fn func(events.Event)) {
+func (c *Controller) handleTableEvents(ch *events.Channel, fn func(events.Event)) {
 	for {
 		select {
 		case ev := <-ch.C:
@@ -873,7 +873,7 @@ func (n *network) handleDriverTableEvent(ev events.Event) {
 	d.EventNotify(etype, n.ID(), tname, key, value)
 }
 
-func (c *controller) handleNodeTableEvent(ev events.Event) {
+func (c *Controller) handleNodeTableEvent(ev events.Event) {
 	var (
 		value    []byte
 		isAdd    bool
@@ -897,7 +897,7 @@ func (c *controller) handleNodeTableEvent(ev events.Event) {
 	c.processNodeDiscovery([]net.IP{nodeAddr.Addr}, isAdd)
 }
 
-func (c *controller) handleEpTableEvent(ev events.Event) {
+func (c *Controller) handleEpTableEvent(ev events.Event) {
 	var (
 		nid   string
 		eid   string

--- a/libnetwork/agent.go
+++ b/libnetwork/agent.go
@@ -595,7 +595,7 @@ func (ep *endpoint) deleteDriverInfoFromCluster() error {
 	return nil
 }
 
-func (ep *endpoint) addServiceInfoToCluster(sb *sandbox) error {
+func (ep *endpoint) addServiceInfoToCluster(sb *Sandbox) error {
 	if ep.isAnonymous() && len(ep.myAliases) == 0 || ep.Iface() == nil || ep.Iface().Address() == nil {
 		return nil
 	}
@@ -605,8 +605,8 @@ func (ep *endpoint) addServiceInfoToCluster(sb *sandbox) error {
 		return nil
 	}
 
-	sb.Service.Lock()
-	defer sb.Service.Unlock()
+	sb.service.Lock()
+	defer sb.service.Unlock()
 	logrus.Debugf("addServiceInfoToCluster START for %s %s", ep.svcName, ep.ID())
 
 	// Check that the endpoint is still present on the sandbox before adding it to the service discovery.
@@ -677,7 +677,7 @@ func (ep *endpoint) addServiceInfoToCluster(sb *sandbox) error {
 	return nil
 }
 
-func (ep *endpoint) deleteServiceInfoFromCluster(sb *sandbox, fullRemove bool, method string) error {
+func (ep *endpoint) deleteServiceInfoFromCluster(sb *Sandbox, fullRemove bool, method string) error {
 	if ep.isAnonymous() && len(ep.myAliases) == 0 {
 		return nil
 	}
@@ -687,8 +687,8 @@ func (ep *endpoint) deleteServiceInfoFromCluster(sb *sandbox, fullRemove bool, m
 		return nil
 	}
 
-	sb.Service.Lock()
-	defer sb.Service.Unlock()
+	sb.service.Lock()
+	defer sb.service.Unlock()
 	logrus.Debugf("deleteServiceInfoFromCluster from %s START for %s %s", method, ep.svcName, ep.ID())
 
 	// Avoid a race w/ with a container that aborts preemptively.  This would

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -90,8 +90,8 @@ type Controller struct {
 	cfg              *config.Config
 	stores           []datastore.DataStore
 	extKeyListener   net.Listener
-	watchCh          chan *endpoint
-	unWatchCh        chan *endpoint
+	watchCh          chan *Endpoint
+	unWatchCh        chan *Endpoint
 	svcRecords       map[string]svcInfo
 	nmap             map[string]*netWatch
 	serviceBindings  map[serviceKey]*service
@@ -959,7 +959,7 @@ func (c *Controller) NewSandbox(containerID string, options ...SandboxOption) (*
 		sb = &Sandbox{
 			id:                 sandboxID,
 			containerID:        containerID,
-			endpoints:          []*endpoint{},
+			endpoints:          []*Endpoint{},
 			epPriority:         map[string]int{},
 			populatedEndpoints: map[string]struct{}{},
 			config:             containerConfig{},

--- a/libnetwork/default_gateway.go
+++ b/libnetwork/default_gateway.go
@@ -29,7 +29,7 @@ var procGwNetwork = make(chan (bool), 1)
    - its deleted when an endpoint with GW joins the container
 */
 
-func (sb *sandbox) setupDefaultGW() error {
+func (sb *Sandbox) setupDefaultGW() error {
 	// check if the container already has a GW endpoint
 	if ep := sb.getEndpointInGWNetwork(); ep != nil {
 		return nil
@@ -94,7 +94,7 @@ func (sb *sandbox) setupDefaultGW() error {
 }
 
 // If present, detach and remove the endpoint connecting the sandbox to the default gw network.
-func (sb *sandbox) clearDefaultGW() error {
+func (sb *Sandbox) clearDefaultGW() error {
 	var ep *endpoint
 
 	if ep = sb.getEndpointInGWNetwork(); ep == nil {
@@ -113,7 +113,7 @@ func (sb *sandbox) clearDefaultGW() error {
 // on the endpoints to which it is connected. It does not account
 // for the default gateway network endpoint.
 
-func (sb *sandbox) needDefaultGW() bool {
+func (sb *Sandbox) needDefaultGW() bool {
 	var needGW bool
 
 	for _, ep := range sb.getConnectedEndpoints() {
@@ -145,7 +145,7 @@ func (sb *sandbox) needDefaultGW() bool {
 	return needGW
 }
 
-func (sb *sandbox) getEndpointInGWNetwork() *endpoint {
+func (sb *Sandbox) getEndpointInGWNetwork() *endpoint {
 	for _, ep := range sb.getConnectedEndpoints() {
 		if ep.getNetwork().name == libnGWNetwork && strings.HasPrefix(ep.Name(), "gateway_") {
 			return ep
@@ -175,7 +175,7 @@ func (c *Controller) defaultGwNetwork() (Network, error) {
 }
 
 // Returns the endpoint which is providing external connectivity to the sandbox
-func (sb *sandbox) getGatewayEndpoint() *endpoint {
+func (sb *Sandbox) getGatewayEndpoint() *endpoint {
 	for _, ep := range sb.getConnectedEndpoints() {
 		if ep.getNetwork().Type() == "null" || ep.getNetwork().Type() == "host" {
 			continue

--- a/libnetwork/default_gateway.go
+++ b/libnetwork/default_gateway.go
@@ -163,7 +163,7 @@ func (ep *endpoint) endpointInGWNetwork() bool {
 
 // Looks for the default gw network and creates it if not there.
 // Parallel executions are serialized.
-func (c *controller) defaultGwNetwork() (Network, error) {
+func (c *Controller) defaultGwNetwork() (Network, error) {
 	procGwNetwork <- true
 	defer func() { <-procGwNetwork }()
 

--- a/libnetwork/default_gateway.go
+++ b/libnetwork/default_gateway.go
@@ -84,9 +84,7 @@ func (sb *Sandbox) setupDefaultGW() error {
 		}
 	}()
 
-	epLocal := newEp.(*endpoint)
-
-	if err = epLocal.sbJoin(sb); err != nil {
+	if err = newEp.sbJoin(sb); err != nil {
 		return fmt.Errorf("container %s: endpoint join on GW Network failed: %v", sb.containerID, err)
 	}
 
@@ -95,7 +93,7 @@ func (sb *Sandbox) setupDefaultGW() error {
 
 // If present, detach and remove the endpoint connecting the sandbox to the default gw network.
 func (sb *Sandbox) clearDefaultGW() error {
-	var ep *endpoint
+	var ep *Endpoint
 
 	if ep = sb.getEndpointInGWNetwork(); ep == nil {
 		return nil
@@ -116,7 +114,7 @@ func (sb *Sandbox) clearDefaultGW() error {
 func (sb *Sandbox) needDefaultGW() bool {
 	var needGW bool
 
-	for _, ep := range sb.getConnectedEndpoints() {
+	for _, ep := range sb.Endpoints() {
 		if ep.endpointInGWNetwork() {
 			continue
 		}
@@ -145,8 +143,8 @@ func (sb *Sandbox) needDefaultGW() bool {
 	return needGW
 }
 
-func (sb *Sandbox) getEndpointInGWNetwork() *endpoint {
-	for _, ep := range sb.getConnectedEndpoints() {
+func (sb *Sandbox) getEndpointInGWNetwork() *Endpoint {
+	for _, ep := range sb.Endpoints() {
 		if ep.getNetwork().name == libnGWNetwork && strings.HasPrefix(ep.Name(), "gateway_") {
 			return ep
 		}
@@ -154,7 +152,7 @@ func (sb *Sandbox) getEndpointInGWNetwork() *endpoint {
 	return nil
 }
 
-func (ep *endpoint) endpointInGWNetwork() bool {
+func (ep *Endpoint) endpointInGWNetwork() bool {
 	if ep.getNetwork().name == libnGWNetwork && strings.HasPrefix(ep.Name(), "gateway_") {
 		return true
 	}
@@ -175,8 +173,8 @@ func (c *Controller) defaultGwNetwork() (Network, error) {
 }
 
 // Returns the endpoint which is providing external connectivity to the sandbox
-func (sb *Sandbox) getGatewayEndpoint() *endpoint {
-	for _, ep := range sb.getConnectedEndpoints() {
+func (sb *Sandbox) getGatewayEndpoint() *Endpoint {
+	for _, ep := range sb.Endpoints() {
 		if ep.getNetwork().Type() == "null" || ep.getNetwork().Type() == "host" {
 			continue
 		}

--- a/libnetwork/default_gateway_freebsd.go
+++ b/libnetwork/default_gateway_freebsd.go
@@ -8,6 +8,6 @@ func getPlatformOption() EndpointOption {
 	return nil
 }
 
-func (c *controller) createGWNetwork() (Network, error) {
+func (c *Controller) createGWNetwork() (Network, error) {
 	return nil, types.NotImplementedErrorf("default gateway functionality is not implemented in freebsd")
 }

--- a/libnetwork/default_gateway_linux.go
+++ b/libnetwork/default_gateway_linux.go
@@ -13,7 +13,7 @@ func getPlatformOption() EndpointOption {
 	return nil
 }
 
-func (c *controller) createGWNetwork() (Network, error) {
+func (c *Controller) createGWNetwork() (Network, error) {
 	netOption := map[string]string{
 		bridge.BridgeName:         libnGWNetwork,
 		bridge.EnableICC:          strconv.FormatBool(false),

--- a/libnetwork/default_gateway_windows.go
+++ b/libnetwork/default_gateway_windows.go
@@ -17,6 +17,6 @@ func getPlatformOption() EndpointOption {
 	return EndpointOptionGeneric(epOption)
 }
 
-func (c *controller) createGWNetwork() (Network, error) {
+func (c *Controller) createGWNetwork() (Network, error) {
 	return nil, types.NotImplementedErrorf("default gateway functionality is not implemented in windows")
 }

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -1173,7 +1173,7 @@ func (ep *endpoint) releaseAddress() {
 	}
 }
 
-func (c *controller) cleanupLocalEndpoints() {
+func (c *Controller) cleanupLocalEndpoints() {
 	// Get used endpoints
 	eps := make(map[string]interface{})
 	for _, sb := range c.sandboxes {

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -14,40 +14,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Endpoint represents a logical connection between a network and a sandbox.
-type Endpoint interface {
-	// A system generated id for this endpoint.
-	ID() string
-
-	// Name returns the name of this endpoint.
-	Name() string
-
-	// Network returns the name of the network to which this endpoint is attached.
-	Network() string
-
-	// Join joins the sandbox to the endpoint and populates into the sandbox
-	// the network resources allocated for the endpoint.
-	Join(sandbox *Sandbox, options ...EndpointOption) error
-
-	// Leave detaches the network resources populated in the sandbox.
-	Leave(sandbox *Sandbox, options ...EndpointOption) error
-
-	// Return certain operational data belonging to this endpoint
-	Info() EndpointInfo
-
-	// DriverInfo returns a collection of driver operational data related to this endpoint retrieved from the driver
-	DriverInfo() (map[string]interface{}, error)
-
-	// Delete and detaches this endpoint from the network.
-	Delete(force bool) error
-}
-
 // EndpointOption is an option setter function type used to pass various options to Network
 // and Endpoint interfaces methods. The various setter functions of type EndpointOption are
 // provided by libnetwork, they look like <Create|Join|Leave>Option[...](...)
-type EndpointOption func(ep *endpoint)
+type EndpointOption func(ep *Endpoint)
 
-type endpoint struct {
+// Endpoint represents a logical connection between a network and a sandbox.
+type Endpoint struct {
 	name              string
 	id                string
 	network           *network
@@ -75,7 +48,7 @@ type endpoint struct {
 	mu                sync.Mutex
 }
 
-func (ep *endpoint) MarshalJSON() ([]byte, error) {
+func (ep *Endpoint) MarshalJSON() ([]byte, error) {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
@@ -102,7 +75,7 @@ func (ep *endpoint) MarshalJSON() ([]byte, error) {
 	return json.Marshal(epMap)
 }
 
-func (ep *endpoint) UnmarshalJSON(b []byte) (err error) {
+func (ep *Endpoint) UnmarshalJSON(b []byte) (err error) {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
@@ -221,15 +194,15 @@ func (ep *endpoint) UnmarshalJSON(b []byte) (err error) {
 	return nil
 }
 
-func (ep *endpoint) New() datastore.KVObject {
-	return &endpoint{network: ep.getNetwork()}
+func (ep *Endpoint) New() datastore.KVObject {
+	return &Endpoint{network: ep.getNetwork()}
 }
 
-func (ep *endpoint) CopyTo(o datastore.KVObject) error {
+func (ep *Endpoint) CopyTo(o datastore.KVObject) error {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
-	dstEp := o.(*endpoint)
+	dstEp := o.(*Endpoint)
 	dstEp.name = ep.name
 	dstEp.id = ep.id
 	dstEp.sandboxID = ep.sandboxID
@@ -276,28 +249,31 @@ func (ep *endpoint) CopyTo(o datastore.KVObject) error {
 	return nil
 }
 
-func (ep *endpoint) ID() string {
+// ID returns the system-generated id for this endpoint.
+func (ep *Endpoint) ID() string {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
 	return ep.id
 }
 
-func (ep *endpoint) Name() string {
+// Name returns the name of this endpoint.
+func (ep *Endpoint) Name() string {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
 	return ep.name
 }
 
-func (ep *endpoint) MyAliases() []string {
+func (ep *Endpoint) MyAliases() []string {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
 	return ep.myAliases
 }
 
-func (ep *endpoint) Network() string {
+// Network returns the name of the network to which this endpoint is attached.
+func (ep *Endpoint) Network() string {
 	if ep.network == nil {
 		return ""
 	}
@@ -305,41 +281,41 @@ func (ep *endpoint) Network() string {
 	return ep.network.name
 }
 
-func (ep *endpoint) isAnonymous() bool {
+func (ep *Endpoint) isAnonymous() bool {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 	return ep.anonymous
 }
 
 // isServiceEnabled check if service is enabled on the endpoint
-func (ep *endpoint) isServiceEnabled() bool {
+func (ep *Endpoint) isServiceEnabled() bool {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 	return ep.serviceEnabled
 }
 
 // enableService sets service enabled on the endpoint
-func (ep *endpoint) enableService() {
+func (ep *Endpoint) enableService() {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 	ep.serviceEnabled = true
 }
 
 // disableService disables service on the endpoint
-func (ep *endpoint) disableService() {
+func (ep *Endpoint) disableService() {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 	ep.serviceEnabled = false
 }
 
-func (ep *endpoint) needResolver() bool {
+func (ep *Endpoint) needResolver() bool {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 	return !ep.disableResolution
 }
 
 // endpoint Key structure : endpoint/network-id/endpoint-id
-func (ep *endpoint) Key() []string {
+func (ep *Endpoint) Key() []string {
 	if ep.network == nil {
 		return nil
 	}
@@ -347,7 +323,7 @@ func (ep *endpoint) Key() []string {
 	return []string{datastore.EndpointKeyPrefix, ep.network.id, ep.id}
 }
 
-func (ep *endpoint) KeyPrefix() []string {
+func (ep *Endpoint) KeyPrefix() []string {
 	if ep.network == nil {
 		return nil
 	}
@@ -355,7 +331,7 @@ func (ep *endpoint) KeyPrefix() []string {
 	return []string{datastore.EndpointKeyPrefix, ep.network.id}
 }
 
-func (ep *endpoint) Value() []byte {
+func (ep *Endpoint) Value() []byte {
 	b, err := json.Marshal(ep)
 	if err != nil {
 		return nil
@@ -363,34 +339,34 @@ func (ep *endpoint) Value() []byte {
 	return b
 }
 
-func (ep *endpoint) SetValue(value []byte) error {
+func (ep *Endpoint) SetValue(value []byte) error {
 	return json.Unmarshal(value, ep)
 }
 
-func (ep *endpoint) Index() uint64 {
+func (ep *Endpoint) Index() uint64 {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 	return ep.dbIndex
 }
 
-func (ep *endpoint) SetIndex(index uint64) {
+func (ep *Endpoint) SetIndex(index uint64) {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 	ep.dbIndex = index
 	ep.dbExists = true
 }
 
-func (ep *endpoint) Exists() bool {
+func (ep *Endpoint) Exists() bool {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 	return ep.dbExists
 }
 
-func (ep *endpoint) Skip() bool {
+func (ep *Endpoint) Skip() bool {
 	return ep.getNetwork().Skip()
 }
 
-func (ep *endpoint) processOptions(options ...EndpointOption) {
+func (ep *Endpoint) processOptions(options ...EndpointOption) {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
@@ -401,14 +377,14 @@ func (ep *endpoint) processOptions(options ...EndpointOption) {
 	}
 }
 
-func (ep *endpoint) getNetwork() *network {
+func (ep *Endpoint) getNetwork() *network {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
 	return ep.network
 }
 
-func (ep *endpoint) getNetworkFromStore() (*network, error) {
+func (ep *Endpoint) getNetworkFromStore() (*network, error) {
 	if ep.network == nil {
 		return nil, fmt.Errorf("invalid network object in endpoint %s", ep.Name())
 	}
@@ -416,7 +392,9 @@ func (ep *endpoint) getNetworkFromStore() (*network, error) {
 	return ep.network.getController().getNetworkFromStore(ep.network.id)
 }
 
-func (ep *endpoint) Join(sb *Sandbox, options ...EndpointOption) error {
+// Join joins the sandbox to the endpoint and populates into the sandbox
+// the network resources allocated for the endpoint.
+func (ep *Endpoint) Join(sb *Sandbox, options ...EndpointOption) error {
 	if sb == nil || sb.ID() == "" || sb.Key() == "" {
 		return types.BadRequestErrorf("invalid Sandbox passed to endpoint join: %v", sb)
 	}
@@ -427,7 +405,7 @@ func (ep *endpoint) Join(sb *Sandbox, options ...EndpointOption) error {
 	return ep.sbJoin(sb, options...)
 }
 
-func (ep *endpoint) sbJoin(sb *Sandbox, options ...EndpointOption) (err error) {
+func (ep *Endpoint) sbJoin(sb *Sandbox, options ...EndpointOption) (err error) {
 	n, err := ep.getNetworkFromStore()
 	if err != nil {
 		return fmt.Errorf("failed to get network from store during join: %v", err)
@@ -586,7 +564,7 @@ func (ep *endpoint) sbJoin(sb *Sandbox, options ...EndpointOption) (err error) {
 	return nil
 }
 
-func (ep *endpoint) rename(name string) error {
+func (ep *Endpoint) rename(name string) error {
 	var (
 		err      error
 		netWatch *netWatch
@@ -669,14 +647,15 @@ func (ep *endpoint) rename(name string) error {
 	return err
 }
 
-func (ep *endpoint) hasInterface(iName string) bool {
+func (ep *Endpoint) hasInterface(iName string) bool {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
 	return ep.iface != nil && ep.iface.srcName == iName
 }
 
-func (ep *endpoint) Leave(sb *Sandbox, options ...EndpointOption) error {
+// Leave detaches the network resources populated in the sandbox.
+func (ep *Endpoint) Leave(sb *Sandbox, options ...EndpointOption) error {
 	if sb == nil || sb.ID() == "" || sb.Key() == "" {
 		return types.BadRequestErrorf("invalid Sandbox passed to endpoint leave: %v", sb)
 	}
@@ -687,7 +666,7 @@ func (ep *endpoint) Leave(sb *Sandbox, options ...EndpointOption) error {
 	return ep.sbLeave(sb, false, options...)
 }
 
-func (ep *endpoint) sbLeave(sb *Sandbox, force bool, options ...EndpointOption) error {
+func (ep *Endpoint) sbLeave(sb *Sandbox, force bool, options ...EndpointOption) error {
 	n, err := ep.getNetworkFromStore()
 	if err != nil {
 		return fmt.Errorf("failed to get network from store during leave: %v", err)
@@ -795,7 +774,8 @@ func (ep *endpoint) sbLeave(sb *Sandbox, force bool, options ...EndpointOption) 
 	return nil
 }
 
-func (ep *endpoint) Delete(force bool) error {
+// Delete deletes and detaches this endpoint from the network.
+func (ep *Endpoint) Delete(force bool) error {
 	var err error
 	n, err := ep.getNetworkFromStore()
 	if err != nil {
@@ -853,7 +833,7 @@ func (ep *endpoint) Delete(force bool) error {
 	return nil
 }
 
-func (ep *endpoint) deleteEndpoint(force bool) error {
+func (ep *Endpoint) deleteEndpoint(force bool) error {
 	ep.mu.Lock()
 	n := ep.network
 	name := ep.name
@@ -882,7 +862,7 @@ func (ep *endpoint) deleteEndpoint(force bool) error {
 	return nil
 }
 
-func (ep *endpoint) getSandbox() (*Sandbox, bool) {
+func (ep *Endpoint) getSandbox() (*Sandbox, bool) {
 	c := ep.network.getController()
 	ep.mu.Lock()
 	sid := ep.sandboxID
@@ -895,7 +875,7 @@ func (ep *endpoint) getSandbox() (*Sandbox, bool) {
 	return ps, ok
 }
 
-func (ep *endpoint) getFirstInterfaceIPv4Address() net.IP {
+func (ep *Endpoint) getFirstInterfaceIPv4Address() net.IP {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
@@ -906,7 +886,7 @@ func (ep *endpoint) getFirstInterfaceIPv4Address() net.IP {
 	return nil
 }
 
-func (ep *endpoint) getFirstInterfaceIPv6Address() net.IP {
+func (ep *Endpoint) getFirstInterfaceIPv6Address() net.IP {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
@@ -920,7 +900,7 @@ func (ep *endpoint) getFirstInterfaceIPv6Address() net.IP {
 // EndpointOptionGeneric function returns an option setter for a Generic option defined
 // in a Dictionary of Key-Value pair
 func EndpointOptionGeneric(generic map[string]interface{}) EndpointOption {
-	return func(ep *endpoint) {
+	return func(ep *Endpoint) {
 		for k, v := range generic {
 			ep.generic[k] = v
 		}
@@ -934,7 +914,7 @@ var (
 
 // CreateOptionIpam function returns an option setter for the ipam configuration for this endpoint
 func CreateOptionIpam(ipV4, ipV6 net.IP, llIPs []net.IP, ipamOptions map[string]string) EndpointOption {
-	return func(ep *endpoint) {
+	return func(ep *Endpoint) {
 		ep.prefAddress = ipV4
 		ep.prefAddressV6 = ipV6
 		if len(llIPs) != 0 {
@@ -953,7 +933,7 @@ func CreateOptionIpam(ipV4, ipV6 net.IP, llIPs []net.IP, ipamOptions map[string]
 // CreateOptionExposedPorts function returns an option setter for the container exposed
 // ports option to be passed to network.CreateEndpoint() method.
 func CreateOptionExposedPorts(exposedPorts []types.TransportPort) EndpointOption {
-	return func(ep *endpoint) {
+	return func(ep *Endpoint) {
 		// Defensive copy
 		eps := make([]types.TransportPort, len(exposedPorts))
 		copy(eps, exposedPorts)
@@ -966,7 +946,7 @@ func CreateOptionExposedPorts(exposedPorts []types.TransportPort) EndpointOption
 // CreateOptionPortMapping function returns an option setter for the mapping
 // ports option to be passed to network.CreateEndpoint() method.
 func CreateOptionPortMapping(portBindings []types.PortBinding) EndpointOption {
-	return func(ep *endpoint) {
+	return func(ep *Endpoint) {
 		// Store a copy of the bindings as generic data to pass to the driver
 		pbs := make([]types.PortBinding, len(portBindings))
 		copy(pbs, portBindings)
@@ -977,7 +957,7 @@ func CreateOptionPortMapping(portBindings []types.PortBinding) EndpointOption {
 // CreateOptionDNS function returns an option setter for dns entry option to
 // be passed to container Create method.
 func CreateOptionDNS(dns []string) EndpointOption {
-	return func(ep *endpoint) {
+	return func(ep *Endpoint) {
 		ep.generic[netlabel.DNSServers] = dns
 	}
 }
@@ -985,7 +965,7 @@ func CreateOptionDNS(dns []string) EndpointOption {
 // CreateOptionAnonymous function returns an option setter for setting
 // this endpoint as anonymous
 func CreateOptionAnonymous() EndpointOption {
-	return func(ep *endpoint) {
+	return func(ep *Endpoint) {
 		ep.anonymous = true
 	}
 }
@@ -993,14 +973,14 @@ func CreateOptionAnonymous() EndpointOption {
 // CreateOptionDisableResolution function returns an option setter to indicate
 // this endpoint doesn't want embedded DNS server functionality
 func CreateOptionDisableResolution() EndpointOption {
-	return func(ep *endpoint) {
+	return func(ep *Endpoint) {
 		ep.disableResolution = true
 	}
 }
 
 // CreateOptionAlias function returns an option setter for setting endpoint alias
 func CreateOptionAlias(name string, alias string) EndpointOption {
-	return func(ep *endpoint) {
+	return func(ep *Endpoint) {
 		if ep.aliases == nil {
 			ep.aliases = make(map[string]string)
 		}
@@ -1010,7 +990,7 @@ func CreateOptionAlias(name string, alias string) EndpointOption {
 
 // CreateOptionService function returns an option setter for setting service binding configuration
 func CreateOptionService(name, id string, vip net.IP, ingressPorts []*PortConfig, aliases []string) EndpointOption {
-	return func(ep *endpoint) {
+	return func(ep *Endpoint) {
 		ep.svcName = name
 		ep.svcID = id
 		ep.virtualIP = vip
@@ -1021,14 +1001,14 @@ func CreateOptionService(name, id string, vip net.IP, ingressPorts []*PortConfig
 
 // CreateOptionMyAlias function returns an option setter for setting endpoint's self alias
 func CreateOptionMyAlias(alias string) EndpointOption {
-	return func(ep *endpoint) {
+	return func(ep *Endpoint) {
 		ep.myAliases = append(ep.myAliases, alias)
 	}
 }
 
 // CreateOptionLoadBalancer function returns an option setter for denoting the endpoint is a load balancer for a network
 func CreateOptionLoadBalancer() EndpointOption {
-	return func(ep *endpoint) {
+	return func(ep *Endpoint) {
 		ep.loadBalancer = true
 	}
 }
@@ -1036,7 +1016,7 @@ func CreateOptionLoadBalancer() EndpointOption {
 // JoinOptionPriority function returns an option setter for priority option to
 // be passed to the endpoint.Join() method.
 func JoinOptionPriority(prio int) EndpointOption {
-	return func(ep *endpoint) {
+	return func(ep *Endpoint) {
 		// ep lock already acquired
 		c := ep.network.getController()
 		c.mu.Lock()
@@ -1050,11 +1030,11 @@ func JoinOptionPriority(prio int) EndpointOption {
 	}
 }
 
-func (ep *endpoint) DataScope() string {
+func (ep *Endpoint) DataScope() string {
 	return ep.getNetwork().DataScope()
 }
 
-func (ep *endpoint) assignAddress(ipam ipamapi.Ipam, assignIPv4, assignIPv6 bool) error {
+func (ep *Endpoint) assignAddress(ipam ipamapi.Ipam, assignIPv4, assignIPv6 bool) error {
 	var err error
 
 	n := ep.getNetwork()
@@ -1077,7 +1057,7 @@ func (ep *endpoint) assignAddress(ipam ipamapi.Ipam, assignIPv4, assignIPv6 bool
 	return err
 }
 
-func (ep *endpoint) assignAddressVersion(ipVer int, ipam ipamapi.Ipam) error {
+func (ep *Endpoint) assignAddressVersion(ipVer int, ipam ipamapi.Ipam) error {
 	var (
 		poolID  *string
 		address **net.IPNet
@@ -1136,7 +1116,7 @@ func (ep *endpoint) assignAddressVersion(ipVer int, ipam ipamapi.Ipam) error {
 	return fmt.Errorf("no available IPv%d addresses on this network's address pools: %s (%s)", ipVer, n.Name(), n.ID())
 }
 
-func (ep *endpoint) releaseAddress() {
+func (ep *Endpoint) releaseAddress() {
 	n := ep.getNetwork()
 	if n.hasSpecialDriver() {
 		return

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -616,9 +616,9 @@ func (ep *endpoint) rename(name string) error {
 			return types.InternalErrorf("Could not delete service state for endpoint %s from cluster on rename: %v", ep.Name(), err)
 		}
 	} else {
-		c.Lock()
+		c.mu.Lock()
 		netWatch, ok = c.nmap[n.ID()]
-		c.Unlock()
+		c.mu.Unlock()
 		if !ok {
 			return fmt.Errorf("watch null for network %q", n.Name())
 		}
@@ -898,9 +898,9 @@ func (ep *endpoint) getSandbox() (*sandbox, bool) {
 	sid := ep.sandboxID
 	ep.Unlock()
 
-	c.Lock()
+	c.mu.Lock()
 	ps, ok := c.sandboxes[sid]
-	c.Unlock()
+	c.mu.Unlock()
 
 	return ps, ok
 }
@@ -1049,9 +1049,9 @@ func JoinOptionPriority(prio int) EndpointOption {
 	return func(ep *endpoint) {
 		// ep lock already acquired
 		c := ep.network.getController()
-		c.Lock()
+		c.mu.Lock()
 		sb, ok := c.sandboxes[ep.sandboxID]
-		c.Unlock()
+		c.mu.Unlock()
 		if !ok {
 			logrus.Errorf("Could not set endpoint priority value during Join to endpoint %s: No sandbox id present in endpoint", ep.id)
 			return

--- a/libnetwork/endpoint_info.go
+++ b/libnetwork/endpoint_info.go
@@ -187,7 +187,8 @@ type tableEntry struct {
 	value     []byte
 }
 
-func (ep *endpoint) Info() EndpointInfo {
+// Info returns certain operational data belonging to this endpoint.
+func (ep *Endpoint) Info() EndpointInfo {
 	if ep.sandboxID != "" {
 		return ep
 	}
@@ -211,7 +212,7 @@ func (ep *endpoint) Info() EndpointInfo {
 	return sb.getEndpoint(ep.ID())
 }
 
-func (ep *endpoint) Iface() InterfaceInfo {
+func (ep *Endpoint) Iface() InterfaceInfo {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
@@ -222,7 +223,7 @@ func (ep *endpoint) Iface() InterfaceInfo {
 	return nil
 }
 
-func (ep *endpoint) Interface() driverapi.InterfaceInfo {
+func (ep *Endpoint) Interface() driverapi.InterfaceInfo {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
@@ -288,7 +289,7 @@ func (epi *endpointInterface) SetNames(srcName string, dstPrefix string) error {
 	return nil
 }
 
-func (ep *endpoint) InterfaceName() driverapi.InterfaceNameInfo {
+func (ep *Endpoint) InterfaceName() driverapi.InterfaceNameInfo {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
@@ -299,7 +300,7 @@ func (ep *endpoint) InterfaceName() driverapi.InterfaceNameInfo {
 	return nil
 }
 
-func (ep *endpoint) AddStaticRoute(destination *net.IPNet, routeType int, nextHop net.IP) error {
+func (ep *Endpoint) AddStaticRoute(destination *net.IPNet, routeType int, nextHop net.IP) error {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
@@ -315,7 +316,7 @@ func (ep *endpoint) AddStaticRoute(destination *net.IPNet, routeType int, nextHo
 	return nil
 }
 
-func (ep *endpoint) AddTableEntry(tableName, key string, value []byte) error {
+func (ep *Endpoint) AddTableEntry(tableName, key string, value []byte) error {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
@@ -328,7 +329,7 @@ func (ep *endpoint) AddTableEntry(tableName, key string, value []byte) error {
 	return nil
 }
 
-func (ep *endpoint) Sandbox() *Sandbox {
+func (ep *Endpoint) Sandbox() *Sandbox {
 	cnt, ok := ep.getSandbox()
 	if !ok {
 		return nil
@@ -336,13 +337,13 @@ func (ep *endpoint) Sandbox() *Sandbox {
 	return cnt
 }
 
-func (ep *endpoint) LoadBalancer() bool {
+func (ep *Endpoint) LoadBalancer() bool {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 	return ep.loadBalancer
 }
 
-func (ep *endpoint) StaticRoutes() []*types.StaticRoute {
+func (ep *Endpoint) StaticRoutes() []*types.StaticRoute {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
@@ -353,7 +354,7 @@ func (ep *endpoint) StaticRoutes() []*types.StaticRoute {
 	return ep.joinInfo.StaticRoutes
 }
 
-func (ep *endpoint) Gateway() net.IP {
+func (ep *Endpoint) Gateway() net.IP {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
@@ -364,7 +365,7 @@ func (ep *endpoint) Gateway() net.IP {
 	return types.GetIPCopy(ep.joinInfo.gw)
 }
 
-func (ep *endpoint) GatewayIPv6() net.IP {
+func (ep *Endpoint) GatewayIPv6() net.IP {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
@@ -375,7 +376,7 @@ func (ep *endpoint) GatewayIPv6() net.IP {
 	return types.GetIPCopy(ep.joinInfo.gw6)
 }
 
-func (ep *endpoint) SetGateway(gw net.IP) error {
+func (ep *Endpoint) SetGateway(gw net.IP) error {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
@@ -383,7 +384,7 @@ func (ep *endpoint) SetGateway(gw net.IP) error {
 	return nil
 }
 
-func (ep *endpoint) SetGatewayIPv6(gw6 net.IP) error {
+func (ep *Endpoint) SetGatewayIPv6(gw6 net.IP) error {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
@@ -391,7 +392,7 @@ func (ep *endpoint) SetGatewayIPv6(gw6 net.IP) error {
 	return nil
 }
 
-func (ep *endpoint) retrieveFromStore() (*endpoint, error) {
+func (ep *Endpoint) retrieveFromStore() (*Endpoint, error) {
 	n, err := ep.getNetworkFromStore()
 	if err != nil {
 		return nil, fmt.Errorf("could not find network in store to get latest endpoint %s: %v", ep.Name(), err)
@@ -399,7 +400,7 @@ func (ep *endpoint) retrieveFromStore() (*endpoint, error) {
 	return n.getEndpointFromStore(ep.ID())
 }
 
-func (ep *endpoint) DisableGatewayService() {
+func (ep *Endpoint) DisableGatewayService() {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 

--- a/libnetwork/endpoint_info.go
+++ b/libnetwork/endpoint_info.go
@@ -30,7 +30,7 @@ type EndpointInfo interface {
 	StaticRoutes() []*types.StaticRoute
 
 	// Sandbox returns the attached sandbox if there, nil otherwise.
-	Sandbox() Sandbox
+	Sandbox() *Sandbox
 
 	// LoadBalancer returns whether the endpoint is the load balancer endpoint for the network.
 	LoadBalancer() bool
@@ -328,7 +328,7 @@ func (ep *endpoint) AddTableEntry(tableName, key string, value []byte) error {
 	return nil
 }
 
-func (ep *endpoint) Sandbox() Sandbox {
+func (ep *endpoint) Sandbox() *Sandbox {
 	cnt, ok := ep.getSandbox()
 	if !ok {
 		return nil

--- a/libnetwork/endpoint_info.go
+++ b/libnetwork/endpoint_info.go
@@ -212,8 +212,8 @@ func (ep *endpoint) Info() EndpointInfo {
 }
 
 func (ep *endpoint) Iface() InterfaceInfo {
-	ep.Lock()
-	defer ep.Unlock()
+	ep.mu.Lock()
+	defer ep.mu.Unlock()
 
 	if ep.iface != nil {
 		return ep.iface
@@ -223,8 +223,8 @@ func (ep *endpoint) Iface() InterfaceInfo {
 }
 
 func (ep *endpoint) Interface() driverapi.InterfaceInfo {
-	ep.Lock()
-	defer ep.Unlock()
+	ep.mu.Lock()
+	defer ep.mu.Unlock()
 
 	if ep.iface != nil {
 		return ep.iface
@@ -289,8 +289,8 @@ func (epi *endpointInterface) SetNames(srcName string, dstPrefix string) error {
 }
 
 func (ep *endpoint) InterfaceName() driverapi.InterfaceNameInfo {
-	ep.Lock()
-	defer ep.Unlock()
+	ep.mu.Lock()
+	defer ep.mu.Unlock()
 
 	if ep.iface != nil {
 		return ep.iface
@@ -300,8 +300,8 @@ func (ep *endpoint) InterfaceName() driverapi.InterfaceNameInfo {
 }
 
 func (ep *endpoint) AddStaticRoute(destination *net.IPNet, routeType int, nextHop net.IP) error {
-	ep.Lock()
-	defer ep.Unlock()
+	ep.mu.Lock()
+	defer ep.mu.Unlock()
 
 	r := types.StaticRoute{Destination: destination, RouteType: routeType, NextHop: nextHop}
 
@@ -316,8 +316,8 @@ func (ep *endpoint) AddStaticRoute(destination *net.IPNet, routeType int, nextHo
 }
 
 func (ep *endpoint) AddTableEntry(tableName, key string, value []byte) error {
-	ep.Lock()
-	defer ep.Unlock()
+	ep.mu.Lock()
+	defer ep.mu.Unlock()
 
 	ep.joinInfo.driverTableEntries = append(ep.joinInfo.driverTableEntries, &tableEntry{
 		tableName: tableName,
@@ -337,14 +337,14 @@ func (ep *endpoint) Sandbox() *Sandbox {
 }
 
 func (ep *endpoint) LoadBalancer() bool {
-	ep.Lock()
-	defer ep.Unlock()
+	ep.mu.Lock()
+	defer ep.mu.Unlock()
 	return ep.loadBalancer
 }
 
 func (ep *endpoint) StaticRoutes() []*types.StaticRoute {
-	ep.Lock()
-	defer ep.Unlock()
+	ep.mu.Lock()
+	defer ep.mu.Unlock()
 
 	if ep.joinInfo == nil {
 		return nil
@@ -354,8 +354,8 @@ func (ep *endpoint) StaticRoutes() []*types.StaticRoute {
 }
 
 func (ep *endpoint) Gateway() net.IP {
-	ep.Lock()
-	defer ep.Unlock()
+	ep.mu.Lock()
+	defer ep.mu.Unlock()
 
 	if ep.joinInfo == nil {
 		return net.IP{}
@@ -365,8 +365,8 @@ func (ep *endpoint) Gateway() net.IP {
 }
 
 func (ep *endpoint) GatewayIPv6() net.IP {
-	ep.Lock()
-	defer ep.Unlock()
+	ep.mu.Lock()
+	defer ep.mu.Unlock()
 
 	if ep.joinInfo == nil {
 		return net.IP{}
@@ -376,16 +376,16 @@ func (ep *endpoint) GatewayIPv6() net.IP {
 }
 
 func (ep *endpoint) SetGateway(gw net.IP) error {
-	ep.Lock()
-	defer ep.Unlock()
+	ep.mu.Lock()
+	defer ep.mu.Unlock()
 
 	ep.joinInfo.gw = types.GetIPCopy(gw)
 	return nil
 }
 
 func (ep *endpoint) SetGatewayIPv6(gw6 net.IP) error {
-	ep.Lock()
-	defer ep.Unlock()
+	ep.mu.Lock()
+	defer ep.mu.Unlock()
 
 	ep.joinInfo.gw6 = types.GetIPCopy(gw6)
 	return nil
@@ -400,8 +400,8 @@ func (ep *endpoint) retrieveFromStore() (*endpoint, error) {
 }
 
 func (ep *endpoint) DisableGatewayService() {
-	ep.Lock()
-	defer ep.Unlock()
+	ep.mu.Lock()
+	defer ep.mu.Unlock()
 
 	ep.joinInfo.disableGatewayService = true
 }

--- a/libnetwork/endpoint_info_unix.go
+++ b/libnetwork/endpoint_info_unix.go
@@ -5,7 +5,8 @@ package libnetwork
 
 import "fmt"
 
-func (ep *endpoint) DriverInfo() (map[string]interface{}, error) {
+// DriverInfo returns a collection of driver operational data related to this endpoint retrieved from the driver.
+func (ep *Endpoint) DriverInfo() (map[string]interface{}, error) {
 	ep, err := ep.retrieveFromStore()
 	if err != nil {
 		return nil, err

--- a/libnetwork/endpoint_info_windows.go
+++ b/libnetwork/endpoint_info_windows.go
@@ -5,7 +5,8 @@ package libnetwork
 
 import "fmt"
 
-func (ep *endpoint) DriverInfo() (map[string]interface{}, error) {
+// DriverInfo returns a collection of driver operational data related to this endpoint retrieved from the driver.
+func (ep *Endpoint) DriverInfo() (map[string]interface{}, error) {
 	ep, err := ep.retrieveFromStore()
 	if err != nil {
 		return nil, err

--- a/libnetwork/endpoint_test.go
+++ b/libnetwork/endpoint_test.go
@@ -30,8 +30,7 @@ fe90::2	somehost.example.com somehost
 		[]*IpamConf{{PreferredPool: "fe90::/64", Gateway: "fe90::1"}},
 		nil)}
 
-	c, nws := getTestEnv(t, opts)
-	ctrlr := c.(*controller)
+	ctrlr, nws := getTestEnv(t, opts)
 
 	hostsFile, err := os.CreateTemp("", "")
 	if err != nil {

--- a/libnetwork/firewall_linux.go
+++ b/libnetwork/firewall_linux.go
@@ -7,9 +7,9 @@ import (
 
 const userChain = "DOCKER-USER"
 
-var ctrl *controller
+var ctrl *Controller
 
-func setupArrangeUserFilterRule(c *controller) {
+func setupArrangeUserFilterRule(c *Controller) {
 	ctrl = c
 	iptables.OnReloaded(arrangeUserFilterRule)
 }

--- a/libnetwork/firewall_linux_test.go
+++ b/libnetwork/firewall_linux_test.go
@@ -51,10 +51,9 @@ func TestUserChain(t *testing.T) {
 			defer testutils.SetupTestOSContext(t)()
 			defer resetIptables(t)
 
-			nc, err := New()
+			c, err := New()
 			assert.NilError(t, err)
-			defer nc.Stop()
-			c := nc.(*controller)
+			defer c.Stop()
 			c.cfg.DriverCfg["bridge"] = map[string]interface{}{
 				netlabel.GenericData: options.Generic{
 					"EnableIPTables": tc.iptables,

--- a/libnetwork/firewall_others.go
+++ b/libnetwork/firewall_others.go
@@ -3,5 +3,5 @@
 
 package libnetwork
 
-func setupArrangeUserFilterRule(c *controller) {}
+func setupArrangeUserFilterRule(c *Controller) {}
 func arrangeUserFilterRule()                   {}

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -188,7 +188,7 @@ func TestEndpointMarshalling(t *testing.T) {
 		lla = append(lla, ll)
 	}
 
-	e := &endpoint{
+	e := &Endpoint{
 		name:      "Bau",
 		id:        "efghijklmno",
 		sandboxID: "ambarabaciccicocco",
@@ -213,7 +213,7 @@ func TestEndpointMarshalling(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ee := &endpoint{}
+	ee := &Endpoint{}
 	err = json.Unmarshal(b, ee)
 	if err != nil {
 		t.Fatal(err)

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -320,7 +320,7 @@ func TestAuxAddresses(t *testing.T) {
 	}
 	defer c.Stop()
 
-	n := &network{ipamType: ipamapi.DefaultIPAM, networkType: "bridge", ctrlr: c.(*controller)}
+	n := &network{ipamType: ipamapi.DefaultIPAM, networkType: "bridge", ctrlr: c}
 
 	input := []struct {
 		masterPool   string
@@ -421,7 +421,7 @@ func TestSRVServiceQuery(t *testing.T) {
 	sr.service["web.swarm"] = append(sr.service["web.swarm"], httpPort)
 	sr.service["web.swarm"] = append(sr.service["web.swarm"], extHTTPPort)
 
-	c.(*controller).svcRecords[n.ID()] = sr
+	c.svcRecords[n.ID()] = sr
 
 	_, ip := ep.Info().Sandbox().ResolveService("_http._tcp.web.swarm")
 
@@ -576,9 +576,7 @@ func TestIpamReleaseOnNetDriverFailures(t *testing.T) {
 	}
 	defer c.Stop()
 
-	cc := c.(*controller)
-
-	if err := cc.drvRegistry.AddDriver(badDriverName, badDriverInit, nil); err != nil {
+	if err := c.drvRegistry.AddDriver(badDriverName, badDriverInit, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -852,7 +852,7 @@ type parallelTester struct {
 
 func (pt parallelTester) Do(t *testing.T, thrNumber int) error {
 	var (
-		ep  libnetwork.Endpoint
+		ep  *libnetwork.Endpoint
 		sb  *libnetwork.Sandbox
 		err error
 	)

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -282,7 +282,7 @@ func TestEndpointJoin(t *testing.T) {
 		t.Fatalf("Unexpected error type returned: %T", err)
 	}
 
-	fsbx := &fakeSandbox{}
+	fsbx := &libnetwork.Sandbox{}
 	if err = ep1.Join(fsbx); err == nil {
 		t.Fatalf("Expected to fail join with invalid Sandbox")
 	}
@@ -853,7 +853,7 @@ type parallelTester struct {
 func (pt parallelTester) Do(t *testing.T, thrNumber int) error {
 	var (
 		ep  libnetwork.Endpoint
-		sb  libnetwork.Sandbox
+		sb  *libnetwork.Sandbox
 		err error
 	)
 
@@ -944,7 +944,7 @@ func TestParallel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sboxes := make([]libnetwork.Sandbox, numThreads)
+	sboxes := make([]*libnetwork.Sandbox, numThreads)
 	if sboxes[first-1], err = controller.NewSandbox(fmt.Sprintf("%drace", first), libnetwork.OptionUseDefaultSandbox()); err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -30,7 +30,7 @@ const (
 	bridgeNetType = "bridge"
 )
 
-func makeTesthostNetwork(t *testing.T, c libnetwork.NetworkController) libnetwork.Network {
+func makeTesthostNetwork(t *testing.T, c *libnetwork.Controller) libnetwork.Network {
 	t.Helper()
 	n, err := createTestNetwork(c, "host", "testhost", options.Generic{}, nil, nil)
 	if err != nil {
@@ -845,7 +845,7 @@ func TestResolvConf(t *testing.T) {
 
 type parallelTester struct {
 	osctx      *testutils.OSContext
-	controller libnetwork.NetworkController
+	controller *libnetwork.Controller
 	net1, net2 libnetwork.Network
 	iterCnt    int
 }

--- a/libnetwork/libnetwork_test.go
+++ b/libnetwork/libnetwork_test.go
@@ -6,7 +6,6 @@ package libnetwork_test
 import (
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -830,68 +829,6 @@ func TestNetworkQuery(t *testing.T) {
 
 const containerID = "valid_c"
 
-type fakeSandbox struct{}
-
-func (f *fakeSandbox) ID() string {
-	return "fake sandbox"
-}
-
-func (f *fakeSandbox) ContainerID() string {
-	return ""
-}
-
-func (f *fakeSandbox) Key() string {
-	return "fake key"
-}
-
-func (f *fakeSandbox) Labels() map[string]interface{} {
-	return nil
-}
-
-func (f *fakeSandbox) Statistics() (map[string]*types.InterfaceStatistics, error) {
-	return nil, nil
-}
-
-func (f *fakeSandbox) Refresh(opts ...libnetwork.SandboxOption) error {
-	return nil
-}
-
-func (f *fakeSandbox) Delete() error {
-	return nil
-}
-
-func (f *fakeSandbox) Rename(name string) error {
-	return nil
-}
-
-func (f *fakeSandbox) SetKey(key string) error {
-	return nil
-}
-
-func (f *fakeSandbox) ResolveName(name string, ipType int) ([]net.IP, bool) {
-	return nil, false
-}
-
-func (f *fakeSandbox) ResolveIP(ip string) string {
-	return ""
-}
-
-func (f *fakeSandbox) ResolveService(name string) ([]*net.SRV, []net.IP) {
-	return nil, nil
-}
-
-func (f *fakeSandbox) Endpoints() []libnetwork.Endpoint {
-	return nil
-}
-
-func (f *fakeSandbox) EnableService() error {
-	return nil
-}
-
-func (f *fakeSandbox) DisableService() error {
-	return nil
-}
-
 func TestEndpointDeleteWithActiveContainer(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
 	controller := newController(t)
@@ -1159,7 +1096,7 @@ func TestContainerInvalidLeave(t *testing.T) {
 		t.Fatalf("Unexpected error type returned: %T. Desc: %s", err, err.Error())
 	}
 
-	fsbx := &fakeSandbox{}
+	fsbx := &libnetwork.Sandbox{}
 	if err = ep.Leave(fsbx); err == nil {
 		t.Fatalf("Expected to fail leave with invalid Sandbox")
 	}

--- a/libnetwork/libnetwork_test.go
+++ b/libnetwork/libnetwork_test.go
@@ -43,7 +43,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func newController(t *testing.T) libnetwork.NetworkController {
+func newController(t *testing.T) *libnetwork.Controller {
 	t.Helper()
 	genericOption := map[string]interface{}{
 		netlabel.GenericData: options.Generic{
@@ -62,7 +62,7 @@ func newController(t *testing.T) libnetwork.NetworkController {
 	return c
 }
 
-func createTestNetwork(c libnetwork.NetworkController, networkType, networkName string, netOption options.Generic, ipamV4Configs, ipamV6Configs []*libnetwork.IpamConf) (libnetwork.Network, error) {
+func createTestNetwork(c *libnetwork.Controller, networkType, networkName string, netOption options.Generic, ipamV4Configs, ipamV6Configs []*libnetwork.IpamConf) (libnetwork.Network, error) {
 	return c.NewNetwork(networkType, networkName, "",
 		libnetwork.NetworkOptionGeneric(netOption),
 		libnetwork.NetworkOptionIpam(ipamapi.DefaultIPAM, "", ipamV4Configs, ipamV6Configs, nil))

--- a/libnetwork/libnetwork_test.go
+++ b/libnetwork/libnetwork_test.go
@@ -520,8 +520,8 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 
 	// Test Endpoint Walk method
 	var epName string
-	var epWanted libnetwork.Endpoint
-	wlk := func(ep libnetwork.Endpoint) bool {
+	var epWanted *libnetwork.Endpoint
+	wlk := func(ep *libnetwork.Endpoint) bool {
 		if ep.Name() == epName {
 			epWanted = ep
 			return true

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -200,7 +200,7 @@ func (i *IpamInfo) UnmarshalJSON(data []byte) error {
 }
 
 type network struct {
-	ctrlr            *controller
+	ctrlr            *Controller
 	name             string
 	networkType      string
 	id               string
@@ -1517,7 +1517,7 @@ func (n *network) getSvcRecords(ep *endpoint) []etchosts.Record {
 	return recs
 }
 
-func (n *network) getController() *controller {
+func (n *network) getController() *Controller {
 	n.Lock()
 	defer n.Unlock()
 	return n.ctrlr
@@ -2139,7 +2139,7 @@ func (n *network) NdotsSet() bool {
 }
 
 // config-only network is looked up by name
-func (c *controller) getConfigNetwork(name string) (*network, error) {
+func (c *Controller) getConfigNetwork(name string) (*network, error) {
 	var n Network
 
 	s := func(current Network) bool {

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1413,8 +1413,8 @@ func (n *network) addSvcRecords(eID, name, serviceID string, epIP, epIPv6 net.IP
 	logrus.Debugf("%s (%.7s).addSvcRecords(%s, %s, %s, %t) %s sid:%s", eID, networkID, name, epIP, epIPv6, ipMapUpdate, method, serviceID)
 
 	c := n.getController()
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	sr, ok := c.svcRecords[networkID]
 	if !ok {
@@ -1449,8 +1449,8 @@ func (n *network) deleteSvcRecords(eID, name, serviceID string, epIP net.IP, epI
 	logrus.Debugf("%s (%.7s).deleteSvcRecords(%s, %s, %s, %t) %s sid:%s ", eID, networkID, name, epIP, epIPv6, ipMapUpdate, method, serviceID)
 
 	c := n.getController()
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	sr, ok := c.svcRecords[networkID]
 	if !ok {
@@ -1484,8 +1484,8 @@ func (n *network) getSvcRecords(ep *endpoint) []etchosts.Record {
 
 	epName := ep.Name()
 
-	n.ctrlr.Lock()
-	defer n.ctrlr.Unlock()
+	n.ctrlr.mu.Lock()
+	defer n.ctrlr.mu.Unlock()
 	sr, ok := n.ctrlr.svcRecords[n.id]
 	if !ok || sr.svcMap == nil {
 		return nil
@@ -1980,8 +1980,8 @@ func (n *network) ResolveName(req string, ipType int) ([]net.IP, bool) {
 
 	c := n.getController()
 	networkID := n.ID()
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	sr, ok := c.svcRecords[networkID]
 
 	if !ok {
@@ -2022,8 +2022,8 @@ func (n *network) ResolveName(req string, ipType int) ([]net.IP, bool) {
 func (n *network) HandleQueryResp(name string, ip net.IP) {
 	networkID := n.ID()
 	c := n.getController()
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	sr, ok := c.svcRecords[networkID]
 
 	if !ok {
@@ -2042,8 +2042,8 @@ func (n *network) HandleQueryResp(name string, ip net.IP) {
 func (n *network) ResolveIP(ip string) string {
 	networkID := n.ID()
 	c := n.getController()
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	sr, ok := c.svcRecords[networkID]
 
 	if !ok {
@@ -2096,8 +2096,8 @@ func (n *network) ResolveService(name string) ([]*net.SRV, []net.IP) {
 	svcName := strings.Join(parts[2:], ".")
 
 	networkID := n.ID()
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	sr, ok := c.svcRecords[networkID]
 
 	if !ok {

--- a/libnetwork/resolver_test.go
+++ b/libnetwork/resolver_test.go
@@ -122,7 +122,7 @@ func TestDNSIPQuery(t *testing.T) {
 
 	w := new(tstwriter)
 	// the unit tests right now will focus on non-proxyed DNS requests
-	r := NewResolver(resolverIPSandbox, false, sb.(*sandbox))
+	r := NewResolver(resolverIPSandbox, false, sb)
 
 	// test name1's IP is resolved correctly with the default A type query
 	// Also make sure DNS lookups are case insensitive
@@ -266,7 +266,7 @@ func TestDNSProxyServFail(t *testing.T) {
 	t.Log("DNS Server can be reached")
 
 	w := new(tstwriter)
-	r := NewResolver(resolverIPSandbox, true, sb.(*sandbox))
+	r := NewResolver(resolverIPSandbox, true, sb)
 	q := new(dns.Msg)
 	q.SetQuestion("name1.", dns.TypeA)
 

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -69,7 +69,7 @@ type sandbox struct {
 	config             containerConfig
 	extDNS             []extDNSEntry
 	osSbox             osl.Sandbox
-	controller         *controller
+	controller         *Controller
 	resolver           Resolver
 	resolverOnce       sync.Once
 	endpoints          []*endpoint

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -253,12 +253,12 @@ func (sb *sandbox) delete(force bool) error {
 		logrus.Warnf("Failed to delete sandbox %s from store: %v", sb.ID(), err)
 	}
 
-	c.Lock()
+	c.mu.Lock()
 	if sb.ingress {
 		c.ingressSandbox = nil
 	}
 	delete(c.sandboxes, sb.ID())
-	c.Unlock()
+	c.mu.Unlock()
 
 	return nil
 }

--- a/libnetwork/sandbox_dns_windows.go
+++ b/libnetwork/sandbox_dns_windows.go
@@ -9,30 +9,30 @@ import (
 
 // Stub implementations for DNS related functions
 
-func (sb *sandbox) startResolver(bool) {}
+func (sb *Sandbox) startResolver(bool) {}
 
-func (sb *sandbox) setupResolutionFiles() error {
+func (sb *Sandbox) setupResolutionFiles() error {
 	return nil
 }
 
-func (sb *sandbox) restorePath() {}
+func (sb *Sandbox) restorePath() {}
 
-func (sb *sandbox) updateHostsFile(ifaceIP []string) error {
+func (sb *Sandbox) updateHostsFile(ifaceIP []string) error {
 	return nil
 }
 
-func (sb *sandbox) addHostsEntries(recs []etchosts.Record) {}
+func (sb *Sandbox) addHostsEntries(recs []etchosts.Record) {}
 
-func (sb *sandbox) deleteHostsEntries(recs []etchosts.Record) {}
+func (sb *Sandbox) deleteHostsEntries(recs []etchosts.Record) {}
 
-func (sb *sandbox) updateDNS(ipv6Enabled bool) error {
+func (sb *Sandbox) updateDNS(ipv6Enabled bool) error {
 	return nil
 }
 
-func (sb *sandbox) setupDNS() error {
+func (sb *Sandbox) setupDNS() error {
 	return nil
 }
 
-func (sb *sandbox) rebuildDNS() error {
+func (sb *Sandbox) rebuildDNS() error {
 	return nil
 }

--- a/libnetwork/sandbox_externalkey_unix.go
+++ b/libnetwork/sandbox_externalkey_unix.go
@@ -178,7 +178,7 @@ func (c *Controller) processExternalKey(conn net.Conn) error {
 		return err
 	}
 
-	var sandbox Sandbox
+	var sandbox *Sandbox
 	search := SandboxContainerWalker(&sandbox, s.ContainerID)
 	c.WalkSandboxes(search)
 	if sandbox == nil {

--- a/libnetwork/sandbox_externalkey_unix.go
+++ b/libnetwork/sandbox_externalkey_unix.go
@@ -112,7 +112,7 @@ func processReturn(r io.Reader) error {
 	return nil
 }
 
-func (c *controller) startExternalKeyListener() error {
+func (c *Controller) startExternalKeyListener() error {
 	execRoot := defaultExecRoot
 	if v := c.Config().ExecRoot; v != "" {
 		execRoot = v
@@ -139,7 +139,7 @@ func (c *controller) startExternalKeyListener() error {
 	return nil
 }
 
-func (c *controller) acceptClientConnections(sock string, l net.Listener) {
+func (c *Controller) acceptClientConnections(sock string, l net.Listener) {
 	for {
 		conn, err := l.Accept()
 		if err != nil {
@@ -167,7 +167,7 @@ func (c *controller) acceptClientConnections(sock string, l net.Listener) {
 	}
 }
 
-func (c *controller) processExternalKey(conn net.Conn) error {
+func (c *Controller) processExternalKey(conn net.Conn) error {
 	buf := make([]byte, 1280)
 	nr, err := conn.Read(buf)
 	if err != nil {
@@ -188,6 +188,6 @@ func (c *controller) processExternalKey(conn net.Conn) error {
 	return sandbox.SetKey(s.Key)
 }
 
-func (c *controller) stopExternalKeyListener() {
+func (c *Controller) stopExternalKeyListener() {
 	c.extKeyListener.Close()
 }

--- a/libnetwork/sandbox_externalkey_unix.go
+++ b/libnetwork/sandbox_externalkey_unix.go
@@ -131,9 +131,9 @@ func (c *controller) startExternalKeyListener() error {
 		l.Close()
 		return err
 	}
-	c.Lock()
+	c.mu.Lock()
 	c.extKeyListener = l
-	c.Unlock()
+	c.mu.Unlock()
 
 	go c.acceptClientConnections(uds, l)
 	return nil

--- a/libnetwork/sandbox_externalkey_windows.go
+++ b/libnetwork/sandbox_externalkey_windows.go
@@ -31,16 +31,16 @@ func processReturn(r io.Reader) error {
 }
 
 // no-op on non linux systems
-func (c *controller) startExternalKeyListener() error {
+func (c *Controller) startExternalKeyListener() error {
 	return nil
 }
 
-func (c *controller) acceptClientConnections(sock string, l net.Listener) {
+func (c *Controller) acceptClientConnections(sock string, l net.Listener) {
 }
 
-func (c *controller) processExternalKey(conn net.Conn) error {
+func (c *Controller) processExternalKey(conn net.Conn) error {
 	return types.NotImplementedErrorf("processExternalKey isn't supported on non linux systems")
 }
 
-func (c *controller) stopExternalKeyListener() {
+func (c *Controller) stopExternalKeyListener() {
 }

--- a/libnetwork/sandbox_store.go
+++ b/libnetwork/sandbox_store.go
@@ -147,7 +147,7 @@ func (sb *Sandbox) storeUpdate() error {
 
 retry:
 	sbs.Eps = nil
-	for _, ep := range sb.getConnectedEndpoints() {
+	for _, ep := range sb.Endpoints() {
 		// If the endpoint is not persisted then do not add it to
 		// the sandbox checkpoint
 		if ep.Skip() {
@@ -211,7 +211,7 @@ func (c *Controller) sandboxCleanup(activeSandboxes map[string]interface{}) {
 			id:                 sbs.ID,
 			controller:         sbs.c,
 			containerID:        sbs.Cid,
-			endpoints:          []*endpoint{},
+			endpoints:          []*Endpoint{},
 			populatedEndpoints: map[string]struct{}{},
 			dbIndex:            sbs.dbIndex,
 			isStub:             true,
@@ -251,16 +251,16 @@ func (c *Controller) sandboxCleanup(activeSandboxes map[string]interface{}) {
 
 		for _, eps := range sbs.Eps {
 			n, err := c.getNetworkFromStore(eps.Nid)
-			var ep *endpoint
+			var ep *Endpoint
 			if err != nil {
 				logrus.Errorf("getNetworkFromStore for nid %s failed while trying to build sandbox for cleanup: %v", eps.Nid, err)
 				n = &network{id: eps.Nid, ctrlr: c, drvOnce: &sync.Once{}, persist: true}
-				ep = &endpoint{id: eps.Eid, network: n, sandboxID: sbs.ID}
+				ep = &Endpoint{id: eps.Eid, network: n, sandboxID: sbs.ID}
 			} else {
 				ep, err = n.getEndpointFromStore(eps.Eid)
 				if err != nil {
 					logrus.Errorf("getEndpointFromStore for eid %s failed while trying to build sandbox for cleanup: %v", eps.Eid, err)
-					ep = &endpoint{id: eps.Eid, network: n, sandboxID: sbs.ID}
+					ep = &Endpoint{id: eps.Eid, network: n, sandboxID: sbs.ID}
 				}
 			}
 			if _, ok := activeSandboxes[sb.ID()]; ok && err != nil {

--- a/libnetwork/sandbox_store.go
+++ b/libnetwork/sandbox_store.go
@@ -55,12 +55,11 @@ func (sbs *sbState) SetValue(value []byte) error {
 }
 
 func (sbs *sbState) Index() uint64 {
-	sbi, err := sbs.c.SandboxByID(sbs.ID)
+	sb, err := sbs.c.SandboxByID(sbs.ID)
 	if err != nil {
 		return sbs.dbIndex
 	}
 
-	sb := sbi.(*sandbox)
 	maxIndex := sb.dbIndex
 	if sbs.dbIndex > maxIndex {
 		maxIndex = sbs.dbIndex
@@ -73,12 +72,11 @@ func (sbs *sbState) SetIndex(index uint64) {
 	sbs.dbIndex = index
 	sbs.dbExists = true
 
-	sbi, err := sbs.c.SandboxByID(sbs.ID)
+	sb, err := sbs.c.SandboxByID(sbs.ID)
 	if err != nil {
 		return
 	}
 
-	sb := sbi.(*sandbox)
 	sb.dbIndex = index
 	sb.dbExists = true
 }
@@ -88,12 +86,11 @@ func (sbs *sbState) Exists() bool {
 		return sbs.dbExists
 	}
 
-	sbi, err := sbs.c.SandboxByID(sbs.ID)
+	sb, err := sbs.c.SandboxByID(sbs.ID)
 	if err != nil {
 		return false
 	}
 
-	sb := sbi.(*sandbox)
 	return sb.dbExists
 }
 
@@ -135,7 +132,7 @@ func (sbs *sbState) DataScope() string {
 	return datastore.LocalScope
 }
 
-func (sb *sandbox) storeUpdate() error {
+func (sb *Sandbox) storeUpdate() error {
 	sbs := &sbState{
 		c:          sb.controller,
 		ID:         sb.id,
@@ -177,7 +174,7 @@ retry:
 	return err
 }
 
-func (sb *sandbox) storeDelete() error {
+func (sb *Sandbox) storeDelete() error {
 	sbs := &sbState{
 		c:        sb.controller,
 		ID:       sb.id,
@@ -210,7 +207,7 @@ func (c *Controller) sandboxCleanup(activeSandboxes map[string]interface{}) {
 	for _, kvo := range kvol {
 		sbs := kvo.(*sbState)
 
-		sb := &sandbox{
+		sb := &Sandbox{
 			id:                 sbs.ID,
 			controller:         sbs.c,
 			containerID:        sbs.Cid,

--- a/libnetwork/sandbox_store.go
+++ b/libnetwork/sandbox_store.go
@@ -248,9 +248,9 @@ func (c *controller) sandboxCleanup(activeSandboxes map[string]interface{}) {
 			continue
 		}
 
-		c.Lock()
+		c.mu.Lock()
 		c.sandboxes[sb.id] = sb
-		c.Unlock()
+		c.mu.Unlock()
 
 		for _, eps := range sbs.Eps {
 			n, err := c.getNetworkFromStore(eps.Nid)

--- a/libnetwork/sandbox_store.go
+++ b/libnetwork/sandbox_store.go
@@ -21,7 +21,7 @@ type epState struct {
 type sbState struct {
 	ID         string
 	Cid        string
-	c          *controller
+	c          *Controller
 	dbIndex    uint64
 	dbExists   bool
 	Eps        []epState
@@ -189,7 +189,7 @@ func (sb *sandbox) storeDelete() error {
 	return sb.controller.deleteFromStore(sbs)
 }
 
-func (c *controller) sandboxCleanup(activeSandboxes map[string]interface{}) {
+func (c *Controller) sandboxCleanup(activeSandboxes map[string]interface{}) {
 	store := c.getStore(datastore.LocalScope)
 	if store == nil {
 		logrus.Error("Could not find local scope store while trying to cleanup sandboxes")

--- a/libnetwork/sandbox_test.go
+++ b/libnetwork/sandbox_test.go
@@ -14,7 +14,7 @@ import (
 	"gotest.tools/v3/skip"
 )
 
-func getTestEnv(t *testing.T, opts ...[]NetworkOption) (NetworkController, []Network) {
+func getTestEnv(t *testing.T, opts ...[]NetworkOption) (*Controller, []Network) {
 	skip.If(t, runtime.GOOS == "windows", "test only works on linux")
 
 	netType := "bridge"
@@ -61,8 +61,7 @@ func getTestEnv(t *testing.T, opts ...[]NetworkOption) (NetworkController, []Net
 }
 
 func TestSandboxAddEmpty(t *testing.T) {
-	c, _ := getTestEnv(t)
-	ctrlr := c.(*controller)
+	ctrlr, _ := getTestEnv(t)
 
 	sbx, err := ctrlr.NewSandbox("sandbox0")
 	if err != nil {
@@ -90,8 +89,7 @@ func TestSandboxAddMultiPrio(t *testing.T) {
 		{},
 	}
 
-	c, nws := getTestEnv(t, opts...)
-	ctrlr := c.(*controller)
+	ctrlr, nws := getTestEnv(t, opts...)
 
 	sbx, err := ctrlr.NewSandbox("sandbox1")
 	if err != nil {
@@ -176,9 +174,7 @@ func TestSandboxAddSamePrio(t *testing.T) {
 		{NetworkOptionInternalNetwork()},
 	}
 
-	c, nws := getTestEnv(t, opts...)
-
-	ctrlr := c.(*controller)
+	ctrlr, nws := getTestEnv(t, opts...)
 
 	sbx, err := ctrlr.NewSandbox("sandbox1")
 	if err != nil {

--- a/libnetwork/service_common.go
+++ b/libnetwork/service_common.go
@@ -12,7 +12,7 @@ import (
 
 const maxSetStringLen = 350
 
-func (c *controller) addEndpointNameResolution(svcName, svcID, nID, eID, containerName string, vip net.IP, serviceAliases, taskAliases []string, ip net.IP, addService bool, method string) error {
+func (c *Controller) addEndpointNameResolution(svcName, svcID, nID, eID, containerName string, vip net.IP, serviceAliases, taskAliases []string, ip net.IP, addService bool, method string) error {
 	n, err := c.NetworkByID(nID)
 	if err != nil {
 		return err
@@ -55,7 +55,7 @@ func (c *controller) addEndpointNameResolution(svcName, svcID, nID, eID, contain
 	return nil
 }
 
-func (c *controller) addContainerNameResolution(nID, eID, containerName string, taskAliases []string, ip net.IP, method string) error {
+func (c *Controller) addContainerNameResolution(nID, eID, containerName string, taskAliases []string, ip net.IP, method string) error {
 	n, err := c.NetworkByID(nID)
 	if err != nil {
 		return err
@@ -73,7 +73,7 @@ func (c *controller) addContainerNameResolution(nID, eID, containerName string, 
 	return nil
 }
 
-func (c *controller) deleteEndpointNameResolution(svcName, svcID, nID, eID, containerName string, vip net.IP, serviceAliases, taskAliases []string, ip net.IP, rmService, multipleEntries bool, method string) error {
+func (c *Controller) deleteEndpointNameResolution(svcName, svcID, nID, eID, containerName string, vip net.IP, serviceAliases, taskAliases []string, ip net.IP, rmService, multipleEntries bool, method string) error {
 	n, err := c.NetworkByID(nID)
 	if err != nil {
 		return err
@@ -119,7 +119,7 @@ func (c *controller) deleteEndpointNameResolution(svcName, svcID, nID, eID, cont
 	return nil
 }
 
-func (c *controller) delContainerNameResolution(nID, eID, containerName string, taskAliases []string, ip net.IP, method string) error {
+func (c *Controller) delContainerNameResolution(nID, eID, containerName string, taskAliases []string, ip net.IP, method string) error {
 	n, err := c.NetworkByID(nID)
 	if err != nil {
 		return err
@@ -148,7 +148,7 @@ func newService(name string, id string, ingressPorts []*PortConfig, serviceAlias
 	}
 }
 
-func (c *controller) getLBIndex(sid, nid string, ingressPorts []*PortConfig) int {
+func (c *Controller) getLBIndex(sid, nid string, ingressPorts []*PortConfig) int {
 	skey := serviceKey{
 		id:    sid,
 		ports: portConfigs(ingressPorts).String(),
@@ -169,7 +169,7 @@ func (c *controller) getLBIndex(sid, nid string, ingressPorts []*PortConfig) int
 }
 
 // cleanupServiceDiscovery when the network is being deleted, erase all the associated service discovery records
-func (c *controller) cleanupServiceDiscovery(cleanupNID string) {
+func (c *Controller) cleanupServiceDiscovery(cleanupNID string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if cleanupNID == "" {
@@ -181,7 +181,7 @@ func (c *controller) cleanupServiceDiscovery(cleanupNID string) {
 	delete(c.svcRecords, cleanupNID)
 }
 
-func (c *controller) cleanupServiceBindings(cleanupNID string) {
+func (c *Controller) cleanupServiceBindings(cleanupNID string) {
 	var cleanupFuncs []func()
 
 	logrus.Debugf("cleanupServiceBindings for %s", cleanupNID)
@@ -215,7 +215,7 @@ func (c *controller) cleanupServiceBindings(cleanupNID string) {
 	}
 }
 
-func makeServiceCleanupFunc(c *controller, s *service, nID, eID string, vip net.IP, ip net.IP) func() {
+func makeServiceCleanupFunc(c *Controller, s *service, nID, eID string, vip net.IP, ip net.IP) func() {
 	// ContainerName and taskAliases are not available here, this is still fine because the Service discovery
 	// cleanup already happened before. The only thing that rmServiceBinding is still doing here a part from the Load
 	// Balancer bookeeping, is to keep consistent the mapping of endpoint to IP.
@@ -226,7 +226,7 @@ func makeServiceCleanupFunc(c *controller, s *service, nID, eID string, vip net.
 	}
 }
 
-func (c *controller) addServiceBinding(svcName, svcID, nID, eID, containerName string, vip net.IP, ingressPorts []*PortConfig, serviceAliases, taskAliases []string, ip net.IP, method string) error {
+func (c *Controller) addServiceBinding(svcName, svcID, nID, eID, containerName string, vip net.IP, ingressPorts []*PortConfig, serviceAliases, taskAliases []string, ip net.IP, method string) error {
 	var addService bool
 
 	// Failure to lock the network ID on add can result in racing
@@ -313,7 +313,7 @@ func (c *controller) addServiceBinding(svcName, svcID, nID, eID, containerName s
 	return nil
 }
 
-func (c *controller) rmServiceBinding(svcName, svcID, nID, eID, containerName string, vip net.IP, ingressPorts []*PortConfig, serviceAliases []string, taskAliases []string, ip net.IP, method string, deleteSvcRecords bool, fullRemove bool) error {
+func (c *Controller) rmServiceBinding(svcName, svcID, nID, eID, containerName string, vip net.IP, ingressPorts []*PortConfig, serviceAliases []string, taskAliases []string, ip net.IP, method string, deleteSvcRecords bool, fullRemove bool) error {
 	var rmService bool
 
 	skey := serviceKey{

--- a/libnetwork/service_common_test.go
+++ b/libnetwork/service_common_test.go
@@ -39,21 +39,21 @@ func TestCleanupServiceDiscovery(t *testing.T) {
 	n2.(*network).addSvcRecords("N2ep1", "service_test", "serviceID1", net.ParseIP("192.168.1.1"), net.IP{}, true, "test")
 	n2.(*network).addSvcRecords("N2ep2", "service_test", "serviceID2", net.ParseIP("192.168.1.2"), net.IP{}, true, "test")
 
-	if len(c.(*controller).svcRecords) != 2 {
-		t.Fatalf("Service record not added correctly:%v", c.(*controller).svcRecords)
+	if len(c.svcRecords) != 2 {
+		t.Fatalf("Service record not added correctly:%v", c.svcRecords)
 	}
 
 	// cleanup net1
-	c.(*controller).cleanupServiceDiscovery(n1.ID())
+	c.cleanupServiceDiscovery(n1.ID())
 
-	if len(c.(*controller).svcRecords) != 1 {
-		t.Fatalf("Service record not cleaned correctly:%v", c.(*controller).svcRecords)
+	if len(c.svcRecords) != 1 {
+		t.Fatalf("Service record not cleaned correctly:%v", c.svcRecords)
 	}
 
-	c.(*controller).cleanupServiceDiscovery("")
+	c.cleanupServiceDiscovery("")
 
-	if len(c.(*controller).svcRecords) != 0 {
-		t.Fatalf("Service record not cleaned correctly:%v", c.(*controller).svcRecords)
+	if len(c.svcRecords) != 0 {
+		t.Fatalf("Service record not cleaned correctly:%v", c.svcRecords)
 	}
 }
 
@@ -63,7 +63,7 @@ func TestDNSOptions(t *testing.T) {
 	c, err := New()
 	assert.NilError(t, err)
 
-	sb, err := c.(*controller).NewSandbox("cnt1", nil)
+	sb, err := c.NewSandbox("cnt1", nil)
 	assert.NilError(t, err)
 
 	cleanup := func(s Sandbox) {
@@ -102,7 +102,7 @@ func TestDNSOptions(t *testing.T) {
 	assert.Check(t, is.Len(dnsOptionsList, 1))
 	assert.Check(t, is.Equal("ndots:5", dnsOptionsList[0]))
 
-	sb2, err := c.(*controller).NewSandbox("cnt2", nil)
+	sb2, err := c.NewSandbox("cnt2", nil)
 	assert.NilError(t, err)
 	defer cleanup(sb2)
 	sb2.(*sandbox).startResolver(false)

--- a/libnetwork/service_common_test.go
+++ b/libnetwork/service_common_test.go
@@ -66,37 +66,37 @@ func TestDNSOptions(t *testing.T) {
 	sb, err := c.NewSandbox("cnt1", nil)
 	assert.NilError(t, err)
 
-	cleanup := func(s Sandbox) {
+	cleanup := func(s *Sandbox) {
 		if err := s.Delete(); err != nil {
 			t.Error(err)
 		}
 	}
 
 	defer cleanup(sb)
-	sb.(*sandbox).startResolver(false)
+	sb.startResolver(false)
 
-	err = sb.(*sandbox).setupDNS()
+	err = sb.setupDNS()
 	assert.NilError(t, err)
-	err = sb.(*sandbox).rebuildDNS()
+	err = sb.rebuildDNS()
 	assert.NilError(t, err)
-	currRC, err := resolvconf.GetSpecific(sb.(*sandbox).config.resolvConfPath)
+	currRC, err := resolvconf.GetSpecific(sb.config.resolvConfPath)
 	assert.NilError(t, err)
 	dnsOptionsList := resolvconf.GetOptions(currRC.Content)
 	assert.Check(t, is.Len(dnsOptionsList, 1))
 	assert.Check(t, is.Equal("ndots:0", dnsOptionsList[0]))
 
-	sb.(*sandbox).config.dnsOptionsList = []string{"ndots:5"}
-	err = sb.(*sandbox).setupDNS()
+	sb.config.dnsOptionsList = []string{"ndots:5"}
+	err = sb.setupDNS()
 	assert.NilError(t, err)
-	currRC, err = resolvconf.GetSpecific(sb.(*sandbox).config.resolvConfPath)
+	currRC, err = resolvconf.GetSpecific(sb.config.resolvConfPath)
 	assert.NilError(t, err)
 	dnsOptionsList = resolvconf.GetOptions(currRC.Content)
 	assert.Check(t, is.Len(dnsOptionsList, 1))
 	assert.Check(t, is.Equal("ndots:5", dnsOptionsList[0]))
 
-	err = sb.(*sandbox).rebuildDNS()
+	err = sb.rebuildDNS()
 	assert.NilError(t, err)
-	currRC, err = resolvconf.GetSpecific(sb.(*sandbox).config.resolvConfPath)
+	currRC, err = resolvconf.GetSpecific(sb.config.resolvConfPath)
 	assert.NilError(t, err)
 	dnsOptionsList = resolvconf.GetOptions(currRC.Content)
 	assert.Check(t, is.Len(dnsOptionsList, 1))
@@ -105,28 +105,28 @@ func TestDNSOptions(t *testing.T) {
 	sb2, err := c.NewSandbox("cnt2", nil)
 	assert.NilError(t, err)
 	defer cleanup(sb2)
-	sb2.(*sandbox).startResolver(false)
+	sb2.startResolver(false)
 
-	sb2.(*sandbox).config.dnsOptionsList = []string{"ndots:0"}
-	err = sb2.(*sandbox).setupDNS()
+	sb2.config.dnsOptionsList = []string{"ndots:0"}
+	err = sb2.setupDNS()
 	assert.NilError(t, err)
-	err = sb2.(*sandbox).rebuildDNS()
+	err = sb2.rebuildDNS()
 	assert.NilError(t, err)
-	currRC, err = resolvconf.GetSpecific(sb2.(*sandbox).config.resolvConfPath)
+	currRC, err = resolvconf.GetSpecific(sb2.config.resolvConfPath)
 	assert.NilError(t, err)
 	dnsOptionsList = resolvconf.GetOptions(currRC.Content)
 	assert.Check(t, is.Len(dnsOptionsList, 1))
 	assert.Check(t, is.Equal("ndots:0", dnsOptionsList[0]))
 
-	sb2.(*sandbox).config.dnsOptionsList = []string{"ndots:foobar"}
-	err = sb2.(*sandbox).setupDNS()
+	sb2.config.dnsOptionsList = []string{"ndots:foobar"}
+	err = sb2.setupDNS()
 	assert.NilError(t, err)
-	err = sb2.(*sandbox).rebuildDNS()
+	err = sb2.rebuildDNS()
 	assert.Error(t, err, "invalid number for ndots option: foobar")
 
-	sb2.(*sandbox).config.dnsOptionsList = []string{"ndots:-1"}
-	err = sb2.(*sandbox).setupDNS()
+	sb2.config.dnsOptionsList = []string{"ndots:-1"}
+	err = sb2.setupDNS()
 	assert.NilError(t, err)
-	err = sb2.(*sandbox).rebuildDNS()
+	err = sb2.rebuildDNS()
 	assert.Error(t, err, "invalid number for ndots option: -1")
 }

--- a/libnetwork/service_linux.go
+++ b/libnetwork/service_linux.go
@@ -21,7 +21,7 @@ import (
 
 // Populate all loadbalancers on the network that the passed endpoint
 // belongs to, into this sandbox.
-func (sb *sandbox) populateLoadBalancers(ep *endpoint) {
+func (sb *Sandbox) populateLoadBalancers(ep *endpoint) {
 	// This is an interface less endpoint. Nothing to do.
 	if ep.Iface() == nil {
 		return
@@ -37,7 +37,7 @@ func (sb *sandbox) populateLoadBalancers(ep *endpoint) {
 	}
 }
 
-func (n *network) findLBEndpointSandbox() (*endpoint, *sandbox, error) {
+func (n *network) findLBEndpointSandbox() (*endpoint, *Sandbox, error) {
 	// TODO: get endpoint from store?  See EndpointInfo()
 	var ep *endpoint
 	// Find this node's LB sandbox endpoint:  there should be exactly one
@@ -66,7 +66,7 @@ func (n *network) findLBEndpointSandbox() (*endpoint, *sandbox, error) {
 // Searches the OS sandbox for the name of the endpoint interface
 // within the sandbox.   This is required for adding/removing IP
 // aliases to the interface.
-func findIfaceDstName(sb *sandbox, ep *endpoint) string {
+func findIfaceDstName(sb *Sandbox, ep *endpoint) string {
 	srcName := ep.Iface().SrcName()
 	for _, i := range sb.osSbox.Info().Interfaces() {
 		if i.SrcName() == srcName {
@@ -532,7 +532,7 @@ func plumbProxy(iPort *PortConfig, isDelete bool) error {
 
 // configureFWMark configures the sandbox firewall to mark vip destined packets
 // with the firewall mark fwMark.
-func (sb *sandbox) configureFWMark(vip net.IP, fwMark uint32, ingressPorts []*PortConfig, eIP *net.IPNet, isDelete bool, lbMode string) error {
+func (sb *Sandbox) configureFWMark(vip net.IP, fwMark uint32, ingressPorts []*PortConfig, eIP *net.IPNet, isDelete bool, lbMode string) error {
 	// TODO IPv6 support
 	iptable := iptables.GetIptable(iptables.IPv4)
 
@@ -585,7 +585,7 @@ func (sb *sandbox) configureFWMark(vip net.IP, fwMark uint32, ingressPorts []*Po
 	return innerErr
 }
 
-func (sb *sandbox) addRedirectRules(eIP *net.IPNet, ingressPorts []*PortConfig) error {
+func (sb *Sandbox) addRedirectRules(eIP *net.IPNet, ingressPorts []*PortConfig) error {
 	// TODO IPv6 support
 	iptable := iptables.GetIptable(iptables.IPv4)
 	ipAddr := eIP.IP.String()

--- a/libnetwork/service_linux.go
+++ b/libnetwork/service_linux.go
@@ -21,7 +21,7 @@ import (
 
 // Populate all loadbalancers on the network that the passed endpoint
 // belongs to, into this sandbox.
-func (sb *Sandbox) populateLoadBalancers(ep *endpoint) {
+func (sb *Sandbox) populateLoadBalancers(ep *Endpoint) {
 	// This is an interface less endpoint. Nothing to do.
 	if ep.Iface() == nil {
 		return
@@ -37,14 +37,14 @@ func (sb *Sandbox) populateLoadBalancers(ep *endpoint) {
 	}
 }
 
-func (n *network) findLBEndpointSandbox() (*endpoint, *Sandbox, error) {
+func (n *network) findLBEndpointSandbox() (*Endpoint, *Sandbox, error) {
 	// TODO: get endpoint from store?  See EndpointInfo()
-	var ep *endpoint
+	var ep *Endpoint
 	// Find this node's LB sandbox endpoint:  there should be exactly one
 	for _, e := range n.Endpoints() {
 		epi := e.Info()
 		if epi != nil && epi.LoadBalancer() {
-			ep = e.(*endpoint)
+			ep = e
 			break
 		}
 	}
@@ -66,7 +66,7 @@ func (n *network) findLBEndpointSandbox() (*endpoint, *Sandbox, error) {
 // Searches the OS sandbox for the name of the endpoint interface
 // within the sandbox.   This is required for adding/removing IP
 // aliases to the interface.
-func findIfaceDstName(sb *Sandbox, ep *endpoint) string {
+func findIfaceDstName(sb *Sandbox, ep *Endpoint) string {
 	srcName := ep.Iface().SrcName()
 	for _, i := range sb.osSbox.Info().Interfaces() {
 		if i.SrcName() == srcName {

--- a/libnetwork/service_unsupported.go
+++ b/libnetwork/service_unsupported.go
@@ -8,14 +8,14 @@ import (
 	"net"
 )
 
-func (c *controller) cleanupServiceBindings(nid string) {
+func (c *Controller) cleanupServiceBindings(nid string) {
 }
 
-func (c *controller) addServiceBinding(name, sid, nid, eid string, vip net.IP, ingressPorts []*PortConfig, aliases []string, ip net.IP) error {
+func (c *Controller) addServiceBinding(name, sid, nid, eid string, vip net.IP, ingressPorts []*PortConfig, aliases []string, ip net.IP) error {
 	return fmt.Errorf("not supported")
 }
 
-func (c *controller) rmServiceBinding(name, sid, nid, eid string, vip net.IP, ingressPorts []*PortConfig, aliases []string, ip net.IP) error {
+func (c *Controller) rmServiceBinding(name, sid, nid, eid string, vip net.IP, ingressPorts []*PortConfig, aliases []string, ip net.IP) error {
 	return fmt.Errorf("not supported")
 }
 

--- a/libnetwork/service_windows.go
+++ b/libnetwork/service_windows.go
@@ -161,7 +161,7 @@ func numEnabledBackends(lb *loadBalancer) int {
 	return nEnabled
 }
 
-func (sb *sandbox) populateLoadBalancers(ep *endpoint) {
+func (sb *Sandbox) populateLoadBalancers(ep *endpoint) {
 }
 
 func arrangeIngressFilterRule() {

--- a/libnetwork/service_windows.go
+++ b/libnetwork/service_windows.go
@@ -161,7 +161,7 @@ func numEnabledBackends(lb *loadBalancer) int {
 	return nEnabled
 }
 
-func (sb *Sandbox) populateLoadBalancers(ep *endpoint) {
+func (sb *Sandbox) populateLoadBalancers(ep *Endpoint) {
 }
 
 func arrangeIngressFilterRule() {

--- a/libnetwork/store.go
+++ b/libnetwork/store.go
@@ -138,7 +138,7 @@ func (c *Controller) getNetworksFromStore() []*network {
 
 		for _, kvo := range kvol {
 			n := kvo.(*network)
-			n.Lock()
+			n.mu.Lock()
 			n.ctrlr = c
 			ec := &endpointCnt{n: n}
 			// Trim the leading & trailing "/" to make it consistent across all stores
@@ -150,7 +150,7 @@ func (c *Controller) getNetworksFromStore() []*network {
 			if n.scope == "" {
 				n.scope = store.Scope()
 			}
-			n.Unlock()
+			n.mu.Unlock()
 			nl = append(nl, n)
 		}
 	}

--- a/libnetwork/store_linux_test.go
+++ b/libnetwork/store_linux_test.go
@@ -30,7 +30,7 @@ func TestNoPersist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating endpoint: %v", err)
 	}
-	store := ctrl.(*controller).getStore(datastore.LocalScope).KVStore()
+	store := ctrl.getStore(datastore.LocalScope).KVStore()
 	if exists, _ := store.Exists(datastore.Key(datastore.NetworkKeyPrefix, nw.ID())); exists {
 		t.Fatalf("Network with persist=false should not be stored in KV Store")
 	}

--- a/libnetwork/store_test.go
+++ b/libnetwork/store_test.go
@@ -36,7 +36,7 @@ func testLocalBackend(t *testing.T, provider, url string, storeConfig *store.Con
 	if err != nil {
 		t.Fatalf("Error creating endpoint: %v", err)
 	}
-	store := ctrl.(*controller).getStore(datastore.LocalScope).KVStore()
+	store := ctrl.getStore(datastore.LocalScope).KVStore()
 	if exists, err := store.Exists(datastore.Key(datastore.NetworkKeyPrefix, nw.ID())); !exists || err != nil {
 		t.Fatalf("Network key should have been created.")
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Replaced some unnecessary interfaces in libnetwork with their underlying concrete types. In many cases no other type which implemented the interface could be used as libnetwork code would type-assert that the interface value boxed the unexported concrete type!

Changed embedded mutexes to unexported fields so the concrete types would no longer implement the `sync.Locker` interface.

While the `Network` interface is another tempting candidate for devirtualization, I have decided not to refactor it yet as I believe that keeping it an interface could help with refactoring away some of the warts of libnetwork's implementation. It might be possible to get rid of the [overlay](https://github.com/moby/libnetwork/pull/2270/commits/0c76756a844b21d5496753e1f58cf0a1a215f808) and [bridge](https://github.com/moby/moby/commit/fcb70a0e864b7da1e0f2ab10d9666bfddd4e7b19) driver hacks by having each network driver provide its own `Network` implementation, or something to that effect.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

