### PR TITLE
libnetwork: Always use an IPv4 to (re)create default bridge

### DIFF
--- a/libnetwork/drivers/bridge/bridge_test.go
+++ b/libnetwork/drivers/bridge/bridge_test.go
@@ -170,7 +170,10 @@ func compareBindings(a, b []types.PortBinding) bool {
 
 func getIPv4Data(t *testing.T, iface string) []driverapi.IPAMData {
 	ipd := driverapi.IPAMData{AddressSpace: "full"}
-	nw, err := netutils.FindAvailableNetwork(ipamutils.GetLocalScopeDefaultNetworks())
+	nw, err := netutils.FindAvailableNetwork(ipamutils.GetLocalScopeDefaultNetworks(), func(nw *net.IPNet) bool {
+		_, maskSize := nw.Mask.Size()
+		return maskSize == 32
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/netutils/utils_freebsd.go
+++ b/libnetwork/netutils/utils_freebsd.go
@@ -18,6 +18,6 @@ func ElectInterfaceAddresses(name string) ([]*net.IPNet, []*net.IPNet, error) {
 
 // FindAvailableNetwork returns a network from the passed list which does not
 // overlap with existing interfaces in the system
-func FindAvailableNetwork(list []*net.IPNet) (*net.IPNet, error) {
+func FindAvailableNetwork(list []*net.IPNet, filter func(*net.IPNet) bool) (*net.IPNet, error) {
 	return nil, types.NotImplementedErrorf("not supported on freebsd")
 }

--- a/libnetwork/netutils/utils_linux.go
+++ b/libnetwork/netutils/utils_linux.go
@@ -62,7 +62,7 @@ func GenerateIfaceName(nlh *netlink.Handle, prefix string, len int) (string, err
 
 // FindAvailableNetwork returns a network from the passed list which does not
 // overlap with existing interfaces in the system
-func FindAvailableNetwork(list []*net.IPNet) (*net.IPNet, error) {
+func FindAvailableNetwork(list []*net.IPNet, filter func(*net.IPNet) bool) (*net.IPNet, error) {
 	// We don't check for an error here, because we don't really care if we
 	// can't read /etc/resolv.conf. So instead we skip the append if resolvConf
 	// is nil. It either doesn't exist, or we can't read it for some reason.
@@ -71,6 +71,9 @@ func FindAvailableNetwork(list []*net.IPNet) (*net.IPNet, error) {
 		nameservers = resolvconf.GetNameserversAsCIDR(rc)
 	}
 	for _, nw := range list {
+		if !filter(nw) {
+			continue
+		}
 		if err := CheckNameserverOverlaps(nameservers, nw); err == nil {
 			if err := CheckRouteOverlaps(nw); err == nil {
 				return nw, nil

--- a/libnetwork/netutils/utils_windows.go
+++ b/libnetwork/netutils/utils_windows.go
@@ -20,6 +20,6 @@ func ElectInterfaceAddresses(name string) ([]*net.IPNet, []*net.IPNet, error) {
 // overlap with existing interfaces in the system
 //
 // TODO : Use appropriate windows APIs to identify non-overlapping subnets
-func FindAvailableNetwork(list []*net.IPNet) (*net.IPNet, error) {
+func FindAvailableNetwork(list []*net.IPNet, filter func(*net.IPNet) bool) (*net.IPNet, error) {
 	return nil, nil
 }


### PR DESCRIPTION
When (re)creating the default bridge, libnetwork tries to find the first available network from the default local pool by calling `netutils.FindAvailableNetwork()`. It assumes there's only IPv4 in default-address-pools, and thus end up trying to assign an IPv6 before it's enabled on the bridge (eg. disable_ipv6 sysctl == 1). In such case, the daemon will fail to start and the following message will be logged:

> failed to start daemon: Error initializing network controller: Error creating default "bridge" network: failed to add IPv4 address fc00:1337:1337::1/8

To prevent such mix up `FindAvailableNetwork()` now takes an ipVer parameter and checks if subnets it iterates over are matching ipVer param.

This issue is already fixed by the refactoring done in #43033. But unlike #43033 this PR should be backported to v20.10/v23.0 imho.

Fixes #44220.

**- How to verify it**

Using the following `daemon.json` dockerd should not fail to start:

```json
{
  "default-address-pools": [
    {
      "base": "fc00:1337:1337::0/64",
      "size": 80
    },
    {
      "base": "172.16.0.0/12",
      "size": 24
    }
  ]
}
```
