### PR TITLE
hack: name for target ARM architecture not specified

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -551,6 +551,7 @@ ARG TARGETPLATFORM
 RUN --mount=type=cache,sharing=locked,id=moby-build-aptlib,target=/var/lib/apt \
     --mount=type=cache,sharing=locked,id=moby-build-aptcache,target=/var/cache/apt \
         xx-apt-get install --no-install-recommends -y \
+            dpkg-dev \
             gcc \
             libapparmor-dev \
             libc6-dev \
@@ -579,7 +580,7 @@ RUN --mount=type=bind,target=. \
   set -e
   target=$([ "$DOCKER_STATIC" = "1" ] && echo "binary" || echo "dynbinary")
   xx-go --wrap
-  ./hack/make.sh $target
+  PKG_CONFIG=$(xx-go env PKG_CONFIG) ./hack/make.sh $target
   xx-verify $([ "$DOCKER_STATIC" = "1" ] && echo "--static") /tmp/bundles/${target}-daemon/dockerd$([ "$(xx-info os)" = "windows" ] && echo ".exe")
   xx-verify $([ "$DOCKER_STATIC" = "1" ] && echo "--static") /tmp/bundles/${target}-daemon/docker-proxy$([ "$(xx-info os)" = "windows" ] && echo ".exe")
   mkdir /build

--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -16,59 +16,22 @@ source "${MAKEDIR}/.go-autogen"
 (
 	export GOGC=${DOCKER_BUILD_GOGC:-1000}
 
-	# for non-sandboxed invocation
-	if ! command -v xx-go > /dev/null 2>&1; then
-		if [ "$(go env GOOS)/$(go env GOARCH)" != "$(go env GOHOSTOS)/$(go env GOHOSTARCH)" ]; then
-			# must be cross-compiling!
-			case "$(go env GOOS)/$(go env GOARCH)" in
-				windows/amd64)
-					export CC="${CC:-x86_64-w64-mingw32-gcc}"
-					export CGO_ENABLED=1
-					;;
-				linux/arm)
-					case "${GOARM}" in
-						5)
-							export CC="${CC:-arm-linux-gnueabi-gcc}"
-							export CGO_ENABLED=1
-							export CGO_CFLAGS="-march=armv5t"
-							export CGO_CXXFLAGS="-march=armv5t"
-							;;
-						6)
-							export CC="${CC:-arm-linux-gnueabi-gcc}"
-							export CGO_ENABLED=1
-							export CGO_CFLAGS="-march=armv6"
-							export CGO_CXXFLAGS="-march=armv6"
-							;;
-						7)
-							export CC="${CC:-arm-linux-gnueabihf-gcc}"
-							export CGO_ENABLED=1
-							export CGO_CFLAGS="-march=armv7-a"
-							export CGO_CXXFLAGS="-march=armv7-a"
-							;;
-						*)
-							export CC="${CC:-arm-linux-gnueabihf-gcc}"
-							export CGO_ENABLED=1
-							;;
-					esac
-					;;
-				linux/arm64)
-					export CC="${CC:-aarch64-linux-gnu-gcc}"
-					export CGO_ENABLED=1
-					;;
-				linux/amd64)
-					export CC="${CC:-x86_64-linux-gnu-gcc}"
-					export CGO_ENABLED=1
-					;;
-				linux/ppc64le)
-					export CC="${CC:-powerpc64le-linux-gnu-gcc}"
-					export CGO_ENABLED=1
-					;;
-				linux/s390x)
-					export CC="${CC:-s390x-linux-gnu-gcc}"
-					export CGO_ENABLED=1
-					;;
-			esac
-		fi
+	if [ "$(go env GOOS)/$(go env GOARCH)" = "linux/arm" ]; then
+		# specify name of the target ARM architecture
+		case "$(go env GOARM)" in
+			5)
+				export CGO_CFLAGS="-march=armv5t"
+				export CGO_CXXFLAGS="-march=armv5t"
+				;;
+			6)
+				export CGO_CFLAGS="-march=armv6"
+				export CGO_CXXFLAGS="-march=armv6"
+				;;
+			7)
+				export CGO_CFLAGS="-march=armv7-a"
+				export CGO_CXXFLAGS="-march=armv7-a"
+				;;
+		esac
 	fi
 
 	# -buildmode=pie is not supported on Windows arm64 and Linux mips*, ppc64be

--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -90,7 +90,7 @@ source "${MAKEDIR}/.go-autogen"
 	if [ -z "$PLATFORM_NAME" ]; then
 		PLATFORM_NAME="$(go env GOOS)/$(go env GOARCH)"
 		if [ -n "$(go env GOARM)" ]; then
-			PLATFORM_NAME+="/$(go env GOARM)"
+			PLATFORM_NAME+="/v$(go env GOARM)"
 		elif [ -n "$(go env GOAMD64)" ] && [ "$(go env GOAMD64)" != "v1" ]; then
 			PLATFORM_NAME+="/$(go env GOAMD64)"
 		fi


### PR DESCRIPTION
**- What I did**

Build currently doesn't set the right name for target ARM architecture through switches in `CGO_CFLAGS` and `CGO_CXXFLAGS` when doing cross-compilation. This was previously fixed in https://github.com/moby/moby/pull/43474

Also following changes for cross-compilation in https://github.com/moby/moby/pull/44546, we forgot to remove the toolchain configuration that is not used anymore as `xx` already sets correct cc/cxx envs already.

I was also looking at `go env` output while debugging and I found out `make.sh` overwrites `PKG_CONFIG` if not defined and set it to `pkg-config`. This is "problematic" when a build is invoked using `xx` in our Dockerfile because it already sets `PKG_CONFIG` to the right value in go environments depending on the target architecture: https://github.com/tonistiigi/xx/blob/8015613cccc2d3b689bf8189ec3604c4e4c94c34/base/xx-go#L75-L78. Last commit ensures we set the right value in our Dockerfile.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

