### PR TITLE
imageService: Rename ExportImage, LoadImage, SaveImage

### DIFF
--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -32,7 +32,7 @@ type imageBackend interface {
 
 type importExportBackend interface {
 	LoadImages(ctx context.Context, inTar io.ReadCloser, outStream io.Writer, quiet bool) error
-	ImportImage(ctx context.Context, ref reference.Named, platform *specs.Platform, msg string, layerReader io.Reader, changes []string) (dockerimage.ID, error)
+	ImportImageRootFS(ctx context.Context, ref reference.Named, platform *specs.Platform, msg string, layerReader io.Reader, changes []string) (dockerimage.ID, error)
 	SaveImages(ctx context.Context, names []string, outStream io.Writer) error
 }
 

--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -31,9 +31,9 @@ type imageBackend interface {
 }
 
 type importExportBackend interface {
-	LoadImage(ctx context.Context, inTar io.ReadCloser, outStream io.Writer, quiet bool) error
+	LoadImages(ctx context.Context, inTar io.ReadCloser, outStream io.Writer, quiet bool) error
 	ImportImage(ctx context.Context, ref reference.Named, platform *specs.Platform, msg string, layerReader io.Reader, changes []string) (dockerimage.ID, error)
-	SaveImage(ctx context.Context, names []string, outStream io.Writer) error
+	SaveImages(ctx context.Context, names []string, outStream io.Writer) error
 }
 
 type registryBackend interface {

--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -33,7 +33,7 @@ type imageBackend interface {
 type importExportBackend interface {
 	LoadImage(ctx context.Context, inTar io.ReadCloser, outStream io.Writer, quiet bool) error
 	ImportImage(ctx context.Context, ref reference.Named, platform *specs.Platform, msg string, layerReader io.Reader, changes []string) (dockerimage.ID, error)
-	ExportImage(ctx context.Context, names []string, outStream io.Writer) error
+	SaveImage(ctx context.Context, names []string, outStream io.Writer) error
 }
 
 type registryBackend interface {

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -121,7 +121,7 @@ func (ir *imageRouter) postImagesCreate(ctx context.Context, w http.ResponseWrit
 		}
 
 		var id image.ID
-		id, progressErr = ir.backend.ImportImage(ctx, ref, platform, comment, layerReader, r.Form["changes"])
+		id, progressErr = ir.backend.ImportImageRootFS(ctx, ref, platform, comment, layerReader, r.Form["changes"])
 
 		if progressErr == nil {
 			output.Write(streamformatter.FormatStatus("", id.String()))

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -194,7 +194,7 @@ func (ir *imageRouter) getImagesGet(ctx context.Context, w http.ResponseWriter, 
 		names = r.Form["names"]
 	}
 
-	if err := ir.backend.SaveImage(ctx, names, output); err != nil {
+	if err := ir.backend.SaveImages(ctx, names, output); err != nil {
 		if !output.Flushed() {
 			return err
 		}
@@ -213,7 +213,7 @@ func (ir *imageRouter) postImagesLoad(ctx context.Context, w http.ResponseWriter
 
 	output := ioutils.NewWriteFlusher(w)
 	defer output.Close()
-	if err := ir.backend.LoadImage(ctx, r.Body, output, quiet); err != nil {
+	if err := ir.backend.LoadImages(ctx, r.Body, output, quiet); err != nil {
 		_, _ = output.Write(streamformatter.FormatError(err))
 	}
 	return nil

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -194,7 +194,7 @@ func (ir *imageRouter) getImagesGet(ctx context.Context, w http.ResponseWriter, 
 		names = r.Form["names"]
 	}
 
-	if err := ir.backend.ExportImage(ctx, names, output); err != nil {
+	if err := ir.backend.SaveImage(ctx, names, output); err != nil {
 		if !output.Flushed() {
 			return err
 		}

--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -17,7 +17,7 @@ func (i *ImageService) GetImageAndReleasableLayer(ctx context.Context, refOrID s
 }
 
 // CreateImage creates a new image by adding a config and ID to the image store.
-// This is similar to LoadImage() except that it receives JSON encoded bytes of
+// This is similar to LoadImages() except that it receives JSON encoded bytes of
 // an image instead of a tar archive.
 func (i *ImageService) CreateImage(config []byte, parent string) (builder.Image, error) {
 	return nil, errdefs.NotImplemented(errors.New("not implemented"))

--- a/daemon/containerd/image_exporter.go
+++ b/daemon/containerd/image_exporter.go
@@ -12,14 +12,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// ExportImage exports a list of images to the given output stream. The
+// SaveImage exports a list of images to the given output stream. The
 // exported images are archived into a tar when written to the output
 // stream. All images with the given tag and all versions containing
 // the same tag are exported. names is the set of tags to export, and
 // outStream is the writer which the images are written to.
 //
 // TODO(thaJeztah): produce JSON stream progress response and image events; see https://github.com/moby/moby/issues/43910
-func (i *ImageService) ExportImage(ctx context.Context, names []string, outStream io.Writer) error {
+func (i *ImageService) SaveImage(ctx context.Context, names []string, outStream io.Writer) error {
 	opts := []archive.ExportOpt{
 		archive.WithPlatform(platforms.Ordered(platforms.DefaultSpec())),
 		archive.WithSkipNonDistributableBlobs(),
@@ -36,7 +36,7 @@ func (i *ImageService) ExportImage(ctx context.Context, names []string, outStrea
 }
 
 // LoadImage uploads a set of images into the repository. This is the
-// complement of ExportImage.  The input stream is an uncompressed tar
+// complement of SaveImage.  The input stream is an uncompressed tar
 // ball containing images and metadata.
 //
 // TODO(thaJeztah): produce JSON stream progress response and image events; see https://github.com/moby/moby/issues/43910

--- a/daemon/containerd/image_exporter.go
+++ b/daemon/containerd/image_exporter.go
@@ -12,14 +12,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// SaveImage exports a list of images to the given output stream. The
+// SaveImages exports a list of images to the given output stream. The
 // exported images are archived into a tar when written to the output
 // stream. All images with the given tag and all versions containing
 // the same tag are exported. names is the set of tags to export, and
 // outStream is the writer which the images are written to.
 //
 // TODO(thaJeztah): produce JSON stream progress response and image events; see https://github.com/moby/moby/issues/43910
-func (i *ImageService) SaveImage(ctx context.Context, names []string, outStream io.Writer) error {
+func (i *ImageService) SaveImages(ctx context.Context, names []string, outStream io.Writer) error {
 	opts := []archive.ExportOpt{
 		archive.WithPlatform(platforms.Ordered(platforms.DefaultSpec())),
 		archive.WithSkipNonDistributableBlobs(),
@@ -35,12 +35,12 @@ func (i *ImageService) SaveImage(ctx context.Context, names []string, outStream 
 	return i.client.Export(ctx, outStream, opts...)
 }
 
-// LoadImage uploads a set of images into the repository. This is the
-// complement of SaveImage.  The input stream is an uncompressed tar
+// LoadImages uploads a set of images into the repository. This is the
+// complement of SaveImages.  The input stream is an uncompressed tar
 // ball containing images and metadata.
 //
 // TODO(thaJeztah): produce JSON stream progress response and image events; see https://github.com/moby/moby/issues/43910
-func (i *ImageService) LoadImage(ctx context.Context, inTar io.ReadCloser, outStream io.Writer, quiet bool) error {
+func (i *ImageService) LoadImages(ctx context.Context, inTar io.ReadCloser, outStream io.Writer, quiet bool) error {
 	platform := platforms.All
 	imgs, err := i.client.Import(ctx, inTar, containerd.WithImportPlatform(platform))
 

--- a/daemon/containerd/image_import.go
+++ b/daemon/containerd/image_import.go
@@ -28,14 +28,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// ImportImage imports an image, getting the archived layer data from layerReader.
+// ImportImageRootFS imports an image, getting the archived layer data from layerReader.
 // Layer archive is imported as-is if the compression is gzip or zstd.
 // Uncompressed, xz and bzip2 archives are recompressed into gzip.
 // The image is tagged with the given reference.
 // If the platform is nil, the default host platform is used.
 // The message is used as the history comment.
 // Image configuration is derived from the dockerfile instructions in changes.
-func (i *ImageService) ImportImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, msg string, layerReader io.Reader, changes []string) (image.ID, error) {
+func (i *ImageService) ImportImageRootFS(ctx context.Context, ref reference.Named, platform *ocispec.Platform, msg string, layerReader io.Reader, changes []string) (image.ID, error) {
 	refString := ""
 	if ref != nil {
 		refString = ref.String()

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -29,7 +29,7 @@ type ImageService interface {
 	PushImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
 	CreateImage(config []byte, parent string) (builder.Image, error)
 	ImageDelete(ctx context.Context, imageRef string, force, prune bool) ([]types.ImageDeleteResponseItem, error)
-	ExportImage(ctx context.Context, names []string, outStream io.Writer) error
+	SaveImage(ctx context.Context, names []string, outStream io.Writer) error
 	LoadImage(ctx context.Context, inTar io.ReadCloser, outStream io.Writer, quiet bool) error
 	Images(ctx context.Context, opts types.ImageListOptions) ([]*types.ImageSummary, error)
 	LogImageEvent(imageID, refName, action string)

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -29,8 +29,8 @@ type ImageService interface {
 	PushImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
 	CreateImage(config []byte, parent string) (builder.Image, error)
 	ImageDelete(ctx context.Context, imageRef string, force, prune bool) ([]types.ImageDeleteResponseItem, error)
-	SaveImage(ctx context.Context, names []string, outStream io.Writer) error
-	LoadImage(ctx context.Context, inTar io.ReadCloser, outStream io.Writer, quiet bool) error
+	SaveImages(ctx context.Context, names []string, outStream io.Writer) error
+	LoadImages(ctx context.Context, inTar io.ReadCloser, outStream io.Writer, quiet bool) error
 	Images(ctx context.Context, opts types.ImageListOptions) ([]*types.ImageSummary, error)
 	LogImageEvent(imageID, refName, action string)
 	LogImageEventWithAttributes(imageID, refName, action string, attributes map[string]string)

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -36,7 +36,7 @@ type ImageService interface {
 	LogImageEventWithAttributes(imageID, refName, action string, attributes map[string]string)
 	CountImages() int
 	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*types.ImagesPruneReport, error)
-	ImportImage(ctx context.Context, ref reference.Named, platform *v1.Platform, msg string, layerReader io.Reader, changes []string) (image.ID, error)
+	ImportImageRootFS(ctx context.Context, ref reference.Named, platform *v1.Platform, msg string, layerReader io.Reader, changes []string) (image.ID, error)
 	TagImage(imageName, repository, tag string) (string, error)
 	TagImageWithReference(imageID image.ID, newTag reference.Named) error
 	GetImage(ctx context.Context, refOrID string, options imagetype.GetImageOpts) (*image.Image, error)

--- a/daemon/images/image_builder.go
+++ b/daemon/images/image_builder.go
@@ -239,7 +239,7 @@ func (i *ImageService) GetImageAndReleasableLayer(ctx context.Context, refOrID s
 }
 
 // CreateImage creates a new image by adding a config and ID to the image store.
-// This is similar to LoadImage() except that it receives JSON encoded bytes of
+// This is similar to LoadImages() except that it receives JSON encoded bytes of
 // an image instead of a tar archive.
 func (i *ImageService) CreateImage(config []byte, parent string) (builder.Image, error) {
 	id, err := i.imageStore.Create(config)

--- a/daemon/images/image_exporter.go
+++ b/daemon/images/image_exporter.go
@@ -7,18 +7,18 @@ import (
 	"github.com/docker/docker/image/tarexport"
 )
 
-// ExportImage exports a list of images to the given output stream. The
+// SaveImage exports a list of images to the given output stream. The
 // exported images are archived into a tar when written to the output
 // stream. All images with the given tag and all versions containing
 // the same tag are exported. names is the set of tags to export, and
 // outStream is the writer which the images are written to.
-func (i *ImageService) ExportImage(ctx context.Context, names []string, outStream io.Writer) error {
+func (i *ImageService) SaveImage(ctx context.Context, names []string, outStream io.Writer) error {
 	imageExporter := tarexport.NewTarExporter(i.imageStore, i.layerStore, i.referenceStore, i)
 	return imageExporter.Save(names, outStream)
 }
 
 // LoadImage uploads a set of images into the repository. This is the
-// complement of ExportImage.  The input stream is an uncompressed tar
+// complement of SaveImage.  The input stream is an uncompressed tar
 // ball containing images and metadata.
 func (i *ImageService) LoadImage(ctx context.Context, inTar io.ReadCloser, outStream io.Writer, quiet bool) error {
 	imageExporter := tarexport.NewTarExporter(i.imageStore, i.layerStore, i.referenceStore, i)

--- a/daemon/images/image_exporter.go
+++ b/daemon/images/image_exporter.go
@@ -7,20 +7,20 @@ import (
 	"github.com/docker/docker/image/tarexport"
 )
 
-// SaveImage exports a list of images to the given output stream. The
+// SaveImages exports a list of images to the given output stream. The
 // exported images are archived into a tar when written to the output
 // stream. All images with the given tag and all versions containing
 // the same tag are exported. names is the set of tags to export, and
 // outStream is the writer which the images are written to.
-func (i *ImageService) SaveImage(ctx context.Context, names []string, outStream io.Writer) error {
+func (i *ImageService) SaveImages(ctx context.Context, names []string, outStream io.Writer) error {
 	imageExporter := tarexport.NewTarExporter(i.imageStore, i.layerStore, i.referenceStore, i)
 	return imageExporter.Save(names, outStream)
 }
 
-// LoadImage uploads a set of images into the repository. This is the
-// complement of SaveImage.  The input stream is an uncompressed tar
+// LoadImages uploads a set of images into the repository. This is the
+// complement of SaveImages.  The input stream is an uncompressed tar
 // ball containing images and metadata.
-func (i *ImageService) LoadImage(ctx context.Context, inTar io.ReadCloser, outStream io.Writer, quiet bool) error {
+func (i *ImageService) LoadImages(ctx context.Context, inTar io.ReadCloser, outStream io.Writer, quiet bool) error {
 	imageExporter := tarexport.NewTarExporter(i.imageStore, i.layerStore, i.referenceStore, i)
 	return imageExporter.Load(inTar, outStream, quiet)
 }

--- a/daemon/images/image_import.go
+++ b/daemon/images/image_import.go
@@ -19,14 +19,14 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// ImportImage imports an image, getting the archived layer data from layerReader.
+// ImportImageRootFS imports an image, getting the archived layer data from layerReader.
 // Uncompressed layer archive is passed to the layerStore and handled by the
 // underlying graph driver.
 // Image is tagged with the given reference.
 // If the platform is nil, the default host platform is used.
 // Message is used as the image's history comment.
 // Image configuration is derived from the dockerfile instructions in changes.
-func (i *ImageService) ImportImage(ctx context.Context, newRef reference.Named, platform *specs.Platform, msg string, layerReader io.Reader, changes []string) (image.ID, error) {
+func (i *ImageService) ImportImageRootFS(ctx context.Context, newRef reference.Named, platform *specs.Platform, msg string, layerReader io.Reader, changes []string) (image.ID, error) {
 	if platform == nil {
 		def := platforms.DefaultSpec()
 		platform = &def


### PR DESCRIPTION
**- What I did**

- Renamed `ExportImage` to `SaveImage` so it matches the cli operation. Previously `docker save` ended up in daemon's `ExportImage` which is easily confused with `docker export`.
Note: `docker export` doesn't have a corresponding function in the `ImageService` interface yet. I'll prepare a follow-up for that, it will also allow to share common bits with future containerd implementation.

- Renamed `LoadImage` to `LoadImages` and `SaveImage` to `SaveImages` because these functions can import more than one image.

- Renamed `ImportImage` to `ImportImageRootFS` to be clear that we are importing an image from rootfs only.


**- How I did it**
with vim

**- How to verify it**
Check if build didn't break

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

