### PR TITLE
fix: the logic of the protocol in loadListeners

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -663,7 +663,7 @@ func loadListeners(cli *DaemonCli, serverConfig *apiserver.Config) ([]string, er
 	for i := 0; i < len(serverConfig.Hosts); i++ {
 		protoAddr := serverConfig.Hosts[i]
 		proto, addr, ok := strings.Cut(protoAddr, "://")
-		if !ok || addr == "" {
+		if !ok || (proto != "fd" && addr == "") {
 			return nil, fmt.Errorf("bad format %s, expected PROTO://ADDR", protoAddr)
 		}
 


### PR DESCRIPTION
Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Here introduced a judgment in  https://github.com/moby/moby/commit/5008409b5cebe36690f653b71f171cf4e1ce114c


This will result in the following error.

```
➜  moby sudo /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock                                                                                                                       
INFO[2023-01-15T00:56:52.640211255+08:00] Starting up                                  
WARN[2023-01-15T00:56:52.640525792+08:00] Running experimental build                          
failed to load listeners: bad format fd://, expected PROTO://ADDR
```

The configuration `fd://` is the default configuration for docker.service.
we shouldn't break it
https://github.com/moby/moby/blob/master/contrib/init/systemd/docker.service#LL13C31-L13C36

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

