### PR TITLE
Revert "libnetwork: Support IPv6 in arrangeUserFilterRule()"

### DIFF
--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -1247,23 +1247,3 @@ func (c *Controller) iptablesEnabled() bool {
 	}
 	return enabled
 }
-
-func (c *controller) ip6tablesEnabled() bool {
-	c.Lock()
-	defer c.Unlock()
-
-	if c.cfg == nil {
-		return false
-	}
-	// parse map cfg["bridge"]["generic"]["EnableIP6Table"]
-	cfgBridge, ok := c.cfg.DriverCfg["bridge"].(map[string]interface{})
-	if !ok {
-		return false
-	}
-	cfgGeneric, ok := cfgBridge[netlabel.GenericData].(options.Generic)
-	if !ok {
-		return false
-	}
-	enabled, _ := cfgGeneric["EnableIP6Tables"].(bool)
-	return enabled
-}

--- a/libnetwork/firewall_linux.go
+++ b/libnetwork/firewall_linux.go
@@ -21,40 +21,24 @@ func setupArrangeUserFilterRule(c *Controller) {
 // IPTableForwarding is disabled, because it contains rules configured by user that
 // are beyond docker engine's control.
 func arrangeUserFilterRule() {
-	if ctrl == nil {
+	if ctrl == nil || !ctrl.iptablesEnabled() {
+		return
+	}
+	// TODO IPv6 support
+	iptable := iptables.GetIptable(iptables.IPv4)
+	_, err := iptable.NewChain(userChain, iptables.Filter, false)
+	if err != nil {
+		logrus.Warnf("Failed to create %s chain: %v", userChain, err)
 		return
 	}
 
-	conds := []struct {
-		ipVer iptables.IPVersion
-		cond  bool
-	}{
-		{ipVer: iptables.IPv4, cond: ctrl.iptablesEnabled()},
-		{ipVer: iptables.IPv6, cond: ctrl.ip6tablesEnabled()},
+	if err = iptable.AddReturnRule(userChain); err != nil {
+		logrus.Warnf("Failed to add the RETURN rule for %s: %v", userChain, err)
+		return
 	}
 
-	for _, ipVerCond := range conds {
-		cond := ipVerCond.cond
-		if !cond {
-			continue
-		}
-
-		ipVer := ipVerCond.ipVer
-		iptable := iptables.GetIptable(ipVer)
-		_, err := iptable.NewChain(userChain, iptables.Filter, false)
-		if err != nil {
-			logrus.WithError(err).Warnf("Failed to create %s %v chain", userChain, ipVer)
-			return
-		}
-
-		if err = iptable.AddReturnRule(userChain); err != nil {
-			logrus.WithError(err).Warnf("Failed to add the RETURN rule for %s %v", userChain, ipVer)
-			return
-		}
-
-		err = iptable.EnsureJumpRule("FORWARD", userChain)
-		if err != nil {
-			logrus.WithError(err).Warnf("Failed to ensure the jump rule for %s %v", userChain, ipVer)
-		}
+	err = iptable.EnsureJumpRule("FORWARD", userChain)
+	if err != nil {
+		logrus.Warnf("Failed to ensure the jump rule for %s: %v", userChain, err)
 	}
 }


### PR DESCRIPTION
- Reverts moby#44706

This reverts commit 2d397beb0068ebf42f7196e243f33842544693d5.

moby#44706 and moby#44805 were both merged, and both refactored the same file. The combination broke the build, and was not detected in CI as only the combination of the two, applied to the same parent commit, caused the failure.

moby#44706 should be carried forward, based on the current master, in order to resolve this conflict.
