### PR TITLE
Revert "Updated outdated docker contributing guidelines link"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ anybody starts working on it.
 We are always thrilled to receive pull requests. We do our best to process them
 quickly. If your pull request is not accepted on the first try,
 don't get discouraged! Our contributor's guide explains [the review process we
-use for simple changes](https://docs.docker.com/contribute/overview/).
+use for simple changes](https://docs.docker.com/opensource/workflow/make-a-contribution/).
 
 ### Design and cleanup proposals
 


### PR DESCRIPTION
- Reverts https://github.com/moby/moby/pull/44744

This reverts commit 1fdfd459959c580fe6c5906a7a63b57a7ad6396e.

Unfortunately, I did not catch that this link is actually entirely unrelated to contributing to Moby projects during review (in fact, it only relates to docs.docker.com).

Given it is misleading and makes an effort to restore these links to working condition harder, I am going to back it out for now. At least the fully broken link will prompt the intrepid contributor to consult web.archive.org instead of being baffled by the unrelated content.

Anyone interested in trying to repair the docs to a working state is encouraged to reach out; I'll be trying to do some work here myself, and I can also connect you to other interested contributors.

cc @KirkEasterson 