### PR TITLE
libnetwork: reduce usage of shared mutable state in ipamutils

### DIFF
--- a/libnetwork/drivers_ipam.go
+++ b/libnetwork/drivers_ipam.go
@@ -10,7 +10,12 @@ import (
 )
 
 func initIPAMDrivers(r *drvregistry.DrvRegistry, lDs, gDs interface{}, addressPool []*ipamutils.NetworkToSplit) error {
-	builtinIpam.SetDefaultIPAddressPool(addressPool)
+	// TODO: pass address pools as arguments to builtinIpam.Init instead of
+	// indirectly through global mutable state. Swarmkit references that
+	// function so changing its signature breaks the build.
+	if err := builtinIpam.SetDefaultIPAddressPool(addressPool); err != nil {
+		return err
+	}
 	for _, fn := range [](func(ipamapi.Callback, interface{}, interface{}) error){
 		builtinIpam.Init,
 		remoteIpam.Init,

--- a/libnetwork/ipam/allocator.go
+++ b/libnetwork/ipam/allocator.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/discoverapi"
 	"github.com/docker/docker/libnetwork/ipamapi"
-	"github.com/docker/docker/libnetwork/ipamutils"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/sirupsen/logrus"
 )
@@ -38,14 +37,14 @@ type Allocator struct {
 }
 
 // NewAllocator returns an instance of libnetwork ipam
-func NewAllocator(lcDs, glDs datastore.DataStore) (*Allocator, error) {
+func NewAllocator(lcDs, glDs datastore.DataStore, lcAs, glAs []*net.IPNet) (*Allocator, error) {
 	a := &Allocator{}
 
 	// Load predefined subnet pools
 
 	a.predefined = map[string][]*net.IPNet{
-		localAddressSpace:  ipamutils.GetLocalScopeDefaultNetworks(),
-		globalAddressSpace: ipamutils.GetGlobalScopeDefaultNetworks(),
+		localAddressSpace:  lcAs,
+		globalAddressSpace: glAs,
 	}
 
 	// Initialize asIndices map

--- a/libnetwork/ipam/allocator_test.go
+++ b/libnetwork/ipam/allocator_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/libnetwork/bitseq"
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/ipamapi"
+	"github.com/docker/docker/libnetwork/ipamutils"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/store/boltdb"
@@ -61,7 +62,7 @@ func getAllocator(store bool) (*Allocator, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewAllocator(ds, nil)
+	return NewAllocator(ds, nil, ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
 }
 
 func TestInt2IP2IntConversion(t *testing.T) {
@@ -1287,7 +1288,7 @@ func testAllocateRandomDeallocate(t *testing.T, pool, subPool string, num int, s
 	ds, err := randomLocalStore(store)
 	assert.NilError(t, err)
 
-	a, err := NewAllocator(ds, nil)
+	a, err := NewAllocator(ds, nil, ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1355,7 +1356,7 @@ func TestRetrieveFromStore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	a, err := NewAllocator(ds, nil)
+	a, err := NewAllocator(ds, nil, ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1370,7 +1371,7 @@ func TestRetrieveFromStore(t *testing.T) {
 	}
 
 	// Restore
-	a1, err := NewAllocator(ds, nil)
+	a1, err := NewAllocator(ds, nil, ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1392,7 +1393,7 @@ func TestRetrieveFromStore(t *testing.T) {
 	}
 
 	// Restore
-	a2, err := NewAllocator(ds, nil)
+	a2, err := NewAllocator(ds, nil, ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1409,7 +1410,7 @@ func TestRetrieveFromStore(t *testing.T) {
 	}
 
 	// Restore
-	a3, err := NewAllocator(ds, nil)
+	a3, err := NewAllocator(ds, nil, ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1426,7 +1427,7 @@ func TestRetrieveFromStore(t *testing.T) {
 	}
 
 	// Restore
-	a4, err := NewAllocator(ds, nil)
+	a4, err := NewAllocator(ds, nil, ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/ipams/builtin/builtin.go
+++ b/libnetwork/ipams/builtin/builtin.go
@@ -1,0 +1,62 @@
+package builtin
+
+import (
+	"errors"
+	"net"
+
+	"github.com/docker/docker/libnetwork/datastore"
+	"github.com/docker/docker/libnetwork/ipam"
+	"github.com/docker/docker/libnetwork/ipamapi"
+	"github.com/docker/docker/libnetwork/ipamutils"
+)
+
+var (
+	// defaultAddressPool Stores user configured subnet list
+	defaultAddressPool []*net.IPNet
+)
+
+// initBuiltin registers the built-in ipam service with libnetwork
+func initBuiltin(ic ipamapi.Callback, l, g interface{}) error {
+	var (
+		ok                bool
+		localDs, globalDs datastore.DataStore
+	)
+
+	if l != nil {
+		if localDs, ok = l.(datastore.DataStore); !ok {
+			return errors.New("incorrect local datastore passed to built-in ipam init")
+		}
+	}
+
+	if g != nil {
+		if globalDs, ok = g.(datastore.DataStore); !ok {
+			return errors.New("incorrect global datastore passed to built-in ipam init")
+		}
+	}
+
+	var localAddressPool []*net.IPNet
+	if len(defaultAddressPool) > 0 {
+		localAddressPool = append([]*net.IPNet(nil), defaultAddressPool...)
+	} else {
+		localAddressPool = ipamutils.GetLocalScopeDefaultNetworks()
+	}
+
+	a, err := ipam.NewAllocator(localDs, globalDs, localAddressPool, ipamutils.GetGlobalScopeDefaultNetworks())
+	if err != nil {
+		return err
+	}
+
+	cps := &ipamapi.Capability{RequiresRequestReplay: true}
+
+	return ic.RegisterIpamDriverWithCapabilities(ipamapi.DefaultIPAM, a, cps)
+}
+
+// SetDefaultIPAddressPool stores default address pool.
+func SetDefaultIPAddressPool(addressPool []*ipamutils.NetworkToSplit) error {
+	nets, err := ipamutils.SplitNetworks(addressPool)
+	if err != nil {
+		return err
+	}
+	defaultAddressPool = nets
+	return nil
+}

--- a/libnetwork/ipams/builtin/builtin_unix.go
+++ b/libnetwork/ipams/builtin/builtin_unix.go
@@ -3,60 +3,9 @@
 
 package builtin
 
-import (
-	"errors"
-
-	"github.com/docker/docker/libnetwork/datastore"
-	"github.com/docker/docker/libnetwork/ipam"
-	"github.com/docker/docker/libnetwork/ipamapi"
-	"github.com/docker/docker/libnetwork/ipamutils"
-)
-
-var (
-	// defaultAddressPool Stores user configured subnet list
-	defaultAddressPool []*ipamutils.NetworkToSplit
-)
+import "github.com/docker/docker/libnetwork/ipamapi"
 
 // Init registers the built-in ipam service with libnetwork
 func Init(ic ipamapi.Callback, l, g interface{}) error {
-	var (
-		ok                bool
-		localDs, globalDs datastore.DataStore
-	)
-
-	if l != nil {
-		if localDs, ok = l.(datastore.DataStore); !ok {
-			return errors.New("incorrect local datastore passed to built-in ipam init")
-		}
-	}
-
-	if g != nil {
-		if globalDs, ok = g.(datastore.DataStore); !ok {
-			return errors.New("incorrect global datastore passed to built-in ipam init")
-		}
-	}
-
-	err := ipamutils.ConfigLocalScopeDefaultNetworks(GetDefaultIPAddressPool())
-	if err != nil {
-		return err
-	}
-
-	a, err := ipam.NewAllocator(localDs, globalDs)
-	if err != nil {
-		return err
-	}
-
-	cps := &ipamapi.Capability{RequiresRequestReplay: true}
-
-	return ic.RegisterIpamDriverWithCapabilities(ipamapi.DefaultIPAM, a, cps)
-}
-
-// SetDefaultIPAddressPool stores default address pool.
-func SetDefaultIPAddressPool(addressPool []*ipamutils.NetworkToSplit) {
-	defaultAddressPool = addressPool
-}
-
-// GetDefaultIPAddressPool returns default address pool.
-func GetDefaultIPAddressPool() []*ipamutils.NetworkToSplit {
-	return defaultAddressPool
+	return initBuiltin(ic, l, g)
 }

--- a/libnetwork/ipams/builtin/builtin_windows.go
+++ b/libnetwork/ipams/builtin/builtin_windows.go
@@ -4,70 +4,18 @@
 package builtin
 
 import (
-	"errors"
-
-	"github.com/docker/docker/libnetwork/datastore"
-	"github.com/docker/docker/libnetwork/ipam"
 	"github.com/docker/docker/libnetwork/ipamapi"
-	"github.com/docker/docker/libnetwork/ipamutils"
-
-	windowsipam "github.com/docker/docker/libnetwork/ipams/windowsipam"
+	"github.com/docker/docker/libnetwork/ipams/windowsipam"
 )
-
-var (
-	// defaultAddressPool Stores user configured subnet list
-	defaultAddressPool []*ipamutils.NetworkToSplit
-)
-
-// InitDockerDefault registers the built-in ipam service with libnetwork
-func InitDockerDefault(ic ipamapi.Callback, l, g interface{}) error {
-	var (
-		ok                bool
-		localDs, globalDs datastore.DataStore
-	)
-
-	if l != nil {
-		if localDs, ok = l.(datastore.DataStore); !ok {
-			return errors.New("incorrect local datastore passed to built-in ipam init")
-		}
-	}
-
-	if g != nil {
-		if globalDs, ok = g.(datastore.DataStore); !ok {
-			return errors.New("incorrect global datastore passed to built-in ipam init")
-		}
-	}
-
-	ipamutils.ConfigLocalScopeDefaultNetworks(nil)
-
-	a, err := ipam.NewAllocator(localDs, globalDs)
-	if err != nil {
-		return err
-	}
-
-	cps := &ipamapi.Capability{RequiresRequestReplay: true}
-
-	return ic.RegisterIpamDriverWithCapabilities(ipamapi.DefaultIPAM, a, cps)
-}
 
 // Init registers the built-in ipam service with libnetwork
 func Init(ic ipamapi.Callback, l, g interface{}) error {
 	initFunc := windowsipam.GetInit(windowsipam.DefaultIPAM)
 
-	err := InitDockerDefault(ic, l, g)
+	err := initBuiltin(ic, l, g)
 	if err != nil {
 		return err
 	}
 
 	return initFunc(ic, l, g)
-}
-
-// SetDefaultIPAddressPool stores default address pool .
-func SetDefaultIPAddressPool(addressPool []*ipamutils.NetworkToSplit) {
-	defaultAddressPool = addressPool
-}
-
-// GetDefaultIPAddressPool returns default address pool .
-func GetDefaultIPAddressPool() []*ipamutils.NetworkToSplit {
-	return defaultAddressPool
 }

--- a/libnetwork/ipamutils/utils.go
+++ b/libnetwork/ipamutils/utils.go
@@ -33,11 +33,11 @@ type NetworkToSplit struct {
 
 func init() {
 	var err error
-	if PredefinedGlobalScopeDefaultNetworks, err = splitNetworks(globalScopeDefaultNetworks); err != nil {
+	if PredefinedGlobalScopeDefaultNetworks, err = SplitNetworks(globalScopeDefaultNetworks); err != nil {
 		panic("failed to initialize the global scope default address pool: " + err.Error())
 	}
 
-	if PredefinedLocalScopeDefaultNetworks, err = splitNetworks(localScopeDefaultNetworks); err != nil {
+	if PredefinedLocalScopeDefaultNetworks, err = SplitNetworks(localScopeDefaultNetworks); err != nil {
 		panic("failed to initialize the local scope default address pool: " + err.Error())
 	}
 }
@@ -46,7 +46,7 @@ func init() {
 func configDefaultNetworks(defaultAddressPool []*NetworkToSplit, result *[]*net.IPNet) error {
 	mutex.Lock()
 	defer mutex.Unlock()
-	defaultNetworks, err := splitNetworks(defaultAddressPool)
+	defaultNetworks, err := SplitNetworks(defaultAddressPool)
 	if err != nil {
 		return err
 	}
@@ -86,8 +86,8 @@ func ConfigLocalScopeDefaultNetworks(defaultAddressPool []*NetworkToSplit) error
 	return configDefaultNetworks(defaultAddressPool, &PredefinedLocalScopeDefaultNetworks)
 }
 
-// splitNetworks takes a slice of networks, split them accordingly and returns them
-func splitNetworks(list []*NetworkToSplit) ([]*net.IPNet, error) {
+// SplitNetworks takes a slice of networks, split them accordingly and returns them
+func SplitNetworks(list []*NetworkToSplit) ([]*net.IPNet, error) {
 	localPools := make([]*net.IPNet, 0, len(list))
 
 	for _, p := range list {

--- a/libnetwork/ipamutils/utils_test.go
+++ b/libnetwork/ipamutils/utils_test.go
@@ -44,13 +44,13 @@ func initGlobalScopeNetworks() []*net.IPNet {
 }
 
 func TestDefaultNetwork(t *testing.T) {
-	for _, nw := range PredefinedGlobalScopeDefaultNetworks {
+	for _, nw := range GetGlobalScopeDefaultNetworks() {
 		if ones, bits := nw.Mask.Size(); bits != 32 || ones != 24 {
 			t.Fatalf("Unexpected size for network in granular list: %v", nw)
 		}
 	}
 
-	for _, nw := range PredefinedLocalScopeDefaultNetworks {
+	for _, nw := range GetLocalScopeDefaultNetworks() {
 		if ones, bits := nw.Mask.Size(); bits != 32 || (ones != 20 && ones != 16) {
 			t.Fatalf("Unexpected size for network in broad list: %v", nw)
 		}
@@ -61,7 +61,7 @@ func TestDefaultNetwork(t *testing.T) {
 	for _, v := range originalBroadNets {
 		m[v.String()] = true
 	}
-	for _, nw := range PredefinedLocalScopeDefaultNetworks {
+	for _, nw := range GetLocalScopeDefaultNetworks() {
 		_, ok := m[nw.String()]
 		assert.Check(t, ok)
 		delete(m, nw.String())
@@ -75,7 +75,7 @@ func TestDefaultNetwork(t *testing.T) {
 	for _, v := range originalGranularNets {
 		m[v.String()] = true
 	}
-	for _, nw := range PredefinedGlobalScopeDefaultNetworks {
+	for _, nw := range GetGlobalScopeDefaultNetworks() {
 		_, ok := m[nw.String()]
 		assert.Check(t, ok)
 		delete(m, nw.String())
@@ -93,25 +93,11 @@ func TestConfigGlobalScopeDefaultNetworks(t *testing.T) {
 	for _, v := range originalGlobalScopeNetworks {
 		m[v.String()] = true
 	}
-	for _, nw := range PredefinedGlobalScopeDefaultNetworks {
+	for _, nw := range GetGlobalScopeDefaultNetworks() {
 		_, ok := m[nw.String()]
 		assert.Check(t, ok)
 		delete(m, nw.String())
 	}
 
 	assert.Check(t, is.Len(m, 0))
-}
-
-func TestInitAddressPools(t *testing.T) {
-	err := ConfigLocalScopeDefaultNetworks([]*NetworkToSplit{{"172.80.0.0/16", 24}, {"172.90.0.0/16", 24}})
-	assert.NilError(t, err)
-
-	// Check for Random IPAddresses in PredefinedLocalScopeDefaultNetworks  ex: first , last and middle
-	assert.Check(t, is.Len(PredefinedLocalScopeDefaultNetworks, 512), "Failed to find PredefinedLocalScopeDefaultNetworks")
-	assert.Check(t, is.Equal(PredefinedLocalScopeDefaultNetworks[0].String(), "172.80.0.0/24"))
-	assert.Check(t, is.Equal(PredefinedLocalScopeDefaultNetworks[127].String(), "172.80.127.0/24"))
-	assert.Check(t, is.Equal(PredefinedLocalScopeDefaultNetworks[255].String(), "172.80.255.0/24"))
-	assert.Check(t, is.Equal(PredefinedLocalScopeDefaultNetworks[256].String(), "172.90.0.0/24"))
-	assert.Check(t, is.Equal(PredefinedLocalScopeDefaultNetworks[383].String(), "172.90.127.0/24"))
-	assert.Check(t, is.Equal(PredefinedLocalScopeDefaultNetworks[511].String(), "172.90.255.0/24"))
 }

--- a/libnetwork/netutils/utils_linux_test.go
+++ b/libnetwork/netutils/utils_linux_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"net"
-	"sort"
 	"strings"
 	"testing"
 
@@ -297,66 +296,6 @@ func TestNetworkRequest(t *testing.T) {
 	}
 	if !types.CompareIPNet(exp, nw) {
 		t.Fatalf("expected %s. got %s", exp, nw)
-	}
-}
-
-func TestElectInterfaceAddressMultipleAddresses(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
-
-	nws := []string{"172.101.202.254/16", "172.102.202.254/16"}
-	createInterface(t, "test", nws...)
-
-	ipv4NwList, ipv6NwList, err := ElectInterfaceAddresses("test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(ipv4NwList) == 0 {
-		t.Fatal("unexpected empty ipv4 network addresses")
-	}
-
-	if len(ipv6NwList) == 0 {
-		t.Fatal("unexpected empty ipv6 network addresses")
-	}
-
-	nwList := []string{}
-	for _, ipv4Nw := range ipv4NwList {
-		nwList = append(nwList, ipv4Nw.String())
-	}
-	sort.Strings(nws)
-	sort.Strings(nwList)
-
-	if len(nws) != len(nwList) {
-		t.Fatalf("expected %v. got %v", nws, nwList)
-	}
-	for i, nw := range nws {
-		if nw != nwList[i] {
-			t.Fatalf("expected %v. got %v", nw, nwList[i])
-		}
-	}
-}
-
-func TestElectInterfaceAddress(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
-
-	nws := "172.101.202.254/16"
-	createInterface(t, "test", nws)
-
-	ipv4Nw, ipv6Nw, err := ElectInterfaceAddresses("test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(ipv4Nw) == 0 {
-		t.Fatal("unexpected empty ipv4 network addresses")
-	}
-
-	if len(ipv6Nw) == 0 {
-		t.Fatal("unexpected empty ipv6 network addresses")
-	}
-
-	if nws != ipv4Nw[0].String() {
-		t.Fatalf("expected %s. got %s", nws, ipv4Nw[0])
 	}
 }
 

--- a/libnetwork/netutils/utils_linux_test.go
+++ b/libnetwork/netutils/utils_linux_test.go
@@ -249,13 +249,13 @@ func TestUtilGenerateRandomMAC(t *testing.T) {
 func TestNetworkRequest(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
 
-	nw, err := FindAvailableNetwork(ipamutils.PredefinedLocalScopeDefaultNetworks)
+	nw, err := FindAvailableNetwork(ipamutils.GetLocalScopeDefaultNetworks())
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	var found bool
-	for _, exp := range ipamutils.PredefinedLocalScopeDefaultNetworks {
+	for _, exp := range ipamutils.GetLocalScopeDefaultNetworks() {
 		if types.CompareIPNet(exp, nw) {
 			found = true
 			break
@@ -266,13 +266,13 @@ func TestNetworkRequest(t *testing.T) {
 		t.Fatalf("Found unexpected broad network %s", nw)
 	}
 
-	nw, err = FindAvailableNetwork(ipamutils.PredefinedGlobalScopeDefaultNetworks)
+	nw, err = FindAvailableNetwork(ipamutils.GetGlobalScopeDefaultNetworks())
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	found = false
-	for _, exp := range ipamutils.PredefinedGlobalScopeDefaultNetworks {
+	for _, exp := range ipamutils.GetGlobalScopeDefaultNetworks() {
 		if types.CompareIPNet(exp, nw) {
 			found = true
 			break
@@ -290,7 +290,7 @@ func TestNetworkRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	nw, err = FindAvailableNetwork(ipamutils.PredefinedLocalScopeDefaultNetworks)
+	nw, err = FindAvailableNetwork(ipamutils.GetLocalScopeDefaultNetworks())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Reduced the scope of the shared mutable state in package `"./libnetwork/ipamutils"` down to only the bits which require Swarmkit changes to modify.

**- How I did it**
I deleted the function `"./libnetwork/netutils".ElectInterfaceAddresses` which references the mutable state in ipamutils. I determined that the one non-test reference to that function did not actually need the behaviour which is implemented using the shared mutable state. When the interface doesn't exist, the function would pick an available IP network from `ipamutils.PredefinedLocalScopeDefaultNetworks`. This is the same list of networks which the `builtin` IPAM driver allocates from, and by extension, the list of networks which libnetwork allocates from when creating a new libnetwork network without the preferred-subnet option set in its IPAM config.

I eliminated the implicit configuration of `ipam.Allocator` from the `ipamutils` state by refactoring it to require the predefined address spaces be passed into the constructor. The IPAM driver initializer still has to pull the global address space from the `ipamutils` state to support Swarmkit, but it's still an improvement over the status quo. This refactor allows the local-scope default address space list in `ipamutils` to be made immutable!

**- How to verify it**
CI?

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
N/A; refactoring without any end-user visible changes (hopefully)

**- A picture of a cute animal (not mandatory but encouraged)**

