### PR TITLE
[23.0 backport] Work around missing rename support when the backing filesystem is overlayfs

### DIFF
--- a/daemon/runtime_unix.go
+++ b/daemon/runtime_unix.go
@@ -69,7 +69,9 @@ func (daemon *Daemon) initRuntimes(runtimes map[string]types.Runtime) (err error
 		}
 
 		if err = os.Rename(runtimeDir, runtimeDir+"-old"); err != nil {
-			return
+			if err = os.RemoveAll(runtimeDir); err != nil {
+				return
+			}
 		}
 		if err = os.Rename(tmpDir, runtimeDir); err != nil {
 			err = errors.Wrap(err, "failed to setup runtimes dir, new containers may not start")


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/43225

---

**Intro**

Raspberry Pi allows to start system under overlayfs.

Docker is successfully fallbacks to `fuse-overlay` but not starting
because of the `Error starting daemon: rename /var/lib/docker/runtimes /var/lib/docker/runtimes-old: invalid cross-device link` error.
It's happening because `rename` is not supported by overlayfs.
After manually removing directory `runtimes` docker starts and works successfully.

relates to https://github.com/moby/moby/issues/25409#issuecomment-239756567
`docker` in this case is `userspace`

**- What I did**
Remove `runtimes` directory in case renaming failed.

**- How I did it**
On `os.rename` error try to remove `runtimes` directory .

**- How to verify it**
Run a docker under the overlayfs as backing FS.

1. Add `RUN mkdir -p "/docker/runtimes"` right after `FROM dev-systemd-${SYSTEMD} AS dev` in `Dockerfile`
2. Run `make BIND_DIR=. shell`
3. Execute `wget -O /usr/local/bin/fuse-overlayfs https://github.com/containers/fuse-overlayfs/releases/download/v1.8.2/fuse-overlayfs-x86_64`
4. Execute `chmod +x /usr/local/bin/fuse-overlayfs`
5. Execute `hack/make.sh binary install-binary`
6. Execute `dockerd --data-root /docker`

Without the fix docker is failing with `failed to start daemon: rename /docker/runtimes /docker/runtimes-old: invalid cross-device link` with the fix `dockerd` starts fine.

**- Description for the changelog**
Remove `runtimes` directory on startup in case renaming to `runtimes-old` failed

**- A picture of a cute animal (not mandatory but encouraged)**

closes https://github.com/docker/for-linux/issues/230