### PR TITLE
c8d/list: Fix Repo(Digests|Tags) for untagged images

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -337,6 +337,13 @@ func (ir *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter,
 		return err
 	}
 
+	for _, img := range images {
+		if len(img.RepoTags) == 0 && len(img.RepoDigests) == 0 {
+			img.RepoTags = append(img.RepoTags, "<none>:<none>")
+			img.RepoDigests = append(img.RepoDigests, "<none>@<none>")
+		}
+	}
+
 	return httputils.WriteJSON(w, http.StatusOK, images)
 }
 

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
+	"github.com/sirupsen/logrus"
 )
 
 var acceptedImageFilterTags = map[string]bool{
@@ -64,6 +65,7 @@ func (i *ImageService) Images(ctx context.Context, opts types.ImageListOptions) 
 		root = make([]*[]digest.Digest, len(imgs))
 		layers = make(map[digest.Digest]int)
 	}
+
 	for n, img := range imgs {
 		if !filter(img) {
 			continue
@@ -91,12 +93,43 @@ func (i *ImageService) Images(ctx context.Context, opts types.ImageListOptions) 
 			return nil, err
 		}
 
+		var repoTags, repoDigests []string
+		rawImg := img.Metadata()
+		target := rawImg.Target.Digest
+
+		logger := logrus.WithFields(logrus.Fields{
+			"name":   img.Name(),
+			"digest": target,
+		})
+
+		ref, err := reference.ParseNamed(rawImg.Name)
+		if err != nil {
+			// If the image has unexpected name format (not a Named reference or a dangling image)
+			// add the offending name to RepoTags but also log an error to make it clear to the
+			// administrator that this is unexpected.
+			// TODO: Reconsider when containerd is more strict on image names, see:
+			//       https://github.com/containerd/containerd/issues/7986
+			if !isDanglingImage(rawImg) {
+				logger.WithError(err).Error("failed to parse image name as reference")
+				repoTags = append(repoTags, img.Name())
+			}
+		} else {
+			repoTags = append(repoTags, reference.TagNameOnly(ref).String())
+
+			digested, err := reference.WithDigest(reference.TrimNamed(ref), target)
+			if err != nil {
+				logger.WithError(err).Error("failed to create digested reference")
+			} else {
+				repoDigests = append(repoDigests, digested.String())
+			}
+		}
+
 		summaries = append(summaries, &types.ImageSummary{
 			ParentID:    "",
-			ID:          img.Target().Digest.String(),
-			Created:     img.Metadata().CreatedAt.Unix(),
-			RepoDigests: []string{img.Name() + "@" + img.Target().Digest.String()}, // "hello-world@sha256:bfea6278a0a267fad2634554f4f0c6f31981eea41c553fdf5a83e95a41d40c38"},
-			RepoTags:    []string{img.Name()},
+			ID:          target.String(),
+			Created:     rawImg.CreatedAt.Unix(),
+			RepoDigests: repoDigests,
+			RepoTags:    repoTags,
 			Size:        size,
 			VirtualSize: virtualSize,
 			// -1 indicates that the value has not been set (avoids ambiguity

--- a/daemon/containerd/soft_delete.go
+++ b/daemon/containerd/soft_delete.go
@@ -59,3 +59,7 @@ func (i *ImageService) softImageDelete(ctx context.Context, img containerdimages
 func danglingImageName(digest digest.Digest) string {
 	return "moby-dangling@" + digest.String()
 }
+
+func isDanglingImage(image containerdimages.Image) bool {
+	return image.Name == danglingImageName(image.Target.Digest)
+}

--- a/daemon/images/image_list.go
+++ b/daemon/images/image_list.go
@@ -178,8 +178,6 @@ func (i *ImageService) Images(ctx context.Context, opts types.ImageListOptions) 
 				if opts.Filters.Contains("reference") { // skip images with no references if filtering by reference
 					continue
 				}
-				summary.RepoDigests = []string{"<none>@<none>"}
-				summary.RepoTags = []string{"<none>:<none>"}
 			} else {
 				continue
 			}


### PR DESCRIPTION
Upstreams:
- https://github.com/rumpl/moby/pull/126

Make images without tag show correctly in the `docker image ls` output.


Before:
```bash
$ docker pull docker.io/library/busybox@sha256:7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c
$ docker image ls
REPOSITORY   TAG       IMAGE ID       CREATED          SIZE
$
```

After:
```bash
$ docker pull docker.io/library/busybox@sha256:7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c
$ docker image ls
REPOSITORY   TAG       IMAGE ID       CREATED          SIZE
busybox      <none>    7b3ccabffc97   1 second ago     2.01MB
$
```


Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

