### PR TITLE
Dockerfile: use clang to build dockerd/docker-proxy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -502,3 +502,55 @@ jobs:
         name: Create summary
         run: |
           teststat -markdown $(find /tmp/reports -type f -name '*.json' -print0 | xargs -0) >> $GITHUB_STEP_SUMMARY
+
+  prepare-smoke:
+    runs-on: ubuntu-20.04
+    needs:
+      - validate-dco
+    outputs:
+      matrix: ${{ steps.platforms.outputs.matrix }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Create matrix
+        id: platforms
+        run: |
+          matrix="$(docker buildx bake binary-smoketest --print | jq -cr '.target."binary-smoketest".platforms')"
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+      -
+        name: Show matrix
+        run: |
+          echo ${{ steps.platforms.outputs.matrix }}
+
+  smoke:
+    runs-on: ubuntu-20.04
+    needs:
+      - prepare-smoke
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJson(needs.prepare-smoke.outputs.matrix) }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Test
+        uses: docker/bake-action@v2
+        with:
+          targets: binary-smoketest
+          set: |
+            *.platform=${{ matrix.platform }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -547,6 +547,12 @@ WORKDIR /go/src/github.com/docker/docker
 ENV GO111MODULE=off
 ENV CGO_ENABLED=1
 ARG DEBIAN_FRONTEND
+RUN --mount=type=cache,sharing=locked,id=moby-build-aptlib,target=/var/lib/apt \
+    --mount=type=cache,sharing=locked,id=moby-build-aptcache,target=/var/cache/apt \
+        apt-get update && apt-get install --no-install-recommends -y \
+            clang \
+            lld \
+            llvm
 ARG TARGETPLATFORM
 RUN --mount=type=cache,sharing=locked,id=moby-build-aptlib,target=/var/lib/apt \
     --mount=type=cache,sharing=locked,id=moby-build-aptcache,target=/var/cache/apt \
@@ -573,6 +579,12 @@ ARG PACKAGER_NAME
 # PREFIX overrides DEST dir in make.sh script otherwise it fails because of
 # read only mount in current work dir
 ENV PREFIX=/tmp
+RUN <<EOT
+  # in bullseye arm64 target does not link with lld so configure it to use ld instead
+  if xx-info is-cross && [ "$(xx-info arch)" = "arm64" ]; then
+    XX_CC_PREFER_LINKER=ld xx-clang --setup-target-triple
+  fi
+EOT
 RUN --mount=type=bind,target=. \
     --mount=type=tmpfs,target=cli/winresources/dockerd \
     --mount=type=tmpfs,target=cli/winresources/docker-proxy \

--- a/Dockerfile
+++ b/Dockerfile
@@ -619,6 +619,20 @@ COPY --from=containerutil /build/ /
 COPY --from=vpnkit        /       /
 COPY --from=build         /build  /
 
+# smoke tests
+# usage:
+# > docker buildx bake binary-smoketest
+FROM --platform=$TARGETPLATFORM base AS smoketest
+WORKDIR /usr/local/bin
+COPY --from=build /build .
+RUN <<EOT
+  set -ex
+  file dockerd
+  dockerd --version
+  file docker-proxy
+  docker-proxy --version
+EOT
+
 # usage:
 # > make shell
 # > SYSTEMD=true make shell

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -124,6 +124,20 @@ target "binary-cross" {
   inherits = ["binary", "_platforms"]
 }
 
+target "binary-smoketest" {
+  inherits = ["_common"]
+  target = "smoketest"
+  output = ["type=cacheonly"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm/v6",
+    "linux/arm/v7",
+    "linux/arm64",
+    "linux/ppc64le",
+    "linux/s390x"
+  ]
+}
+
 #
 # same as binary but with extra tools as well (containerd, runc, ...)
 #


### PR DESCRIPTION
follow-up https://github.com/moby/moby/pull/44812 and https://github.com/moby/moby/pull/43529

**- What I did**

Atm static binaries for dockerd are broken on armhf and armel (32-bit):

```
$ cat /proc/cpuinfo 
processor       : 0
model name      : ARMv7 Processor rev 3 (v7l)
BogoMIPS        : 108.00
Features        : half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm crc32 
CPU implementer : 0x41
CPU architecture: 7
CPU variant     : 0x0
CPU part        : 0xd08
CPU revision    : 3

processor       : 1
...

Hardware        : BCM2711
Revision        : c03111
Serial          : 10000000d198f4cb
Model           : Raspberry Pi 4 Model B Rev 1.1

$ uname -a
Linux rasp4 5.15.32-v7l+ #1538 SMP Thu Mar 31 19:39:41 BST 2022 armv7l GNU/Linux

$ ./dockerd --version
Illegal instruction
```

```
(gdb) run
Starting program: /home/foo/dockerd 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/arm-linux-gnueabihf/libthread_db.so.1".

Program received signal SIGILL, Illegal instruction.
0x018cd968 in memcpy_ifunc ()
(gdb) bt
#0  0x018cd968 in memcpy_ifunc ()
#1  0x018b89da in __libc_start_main ()
#2  0x000103ec in _start ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
(gdb) disassemble
Dump of assembler code for function memcpy_ifunc:
   0x018cd95c <+0>:     lsls    r3, r0, #19
   0x018cd95e <+2>:     bmi.n   0x18cd966 <memcpy_ifunc+10>
   0x018cd960 <+4>:     ldr     r0, [pc, #8]    ; (0x18cd96c <memcpy_ifunc+16>)
   0x018cd962 <+6>:     add     r0, pc
   0x018cd964 <+8>:     bx      lr
   0x018cd966 <+10>:    ldr     r0, [pc, #8]    ; (0x18cd970 <memcpy_ifunc+20>)
=> 0x018cd968 <+12>:    add     r0, pc
   0x018cd96a <+14>:    bx      lr
   0x018cd96c <+16>:    andeq   r0, r0, r10, asr r6
   0x018cd970 <+20>:    andeq   r0, r0, r4, asr r1
End of assembler dump.
```

It seems to be an issue with GCC as building using clang solves this issue:

```
$ ./dockerd --version
Docker version dev, build HEAD
```

```
$ docker info
Client:
 Context:    default
 Debug Mode: false
 Plugins:
  app: Docker App (Docker Inc., v0.9.1-beta3)
  buildx: Docker Buildx (Docker Inc., v0.8.2-docker)

Server:
 Containers: 4
  Running: 4
  Paused: 0
  Stopped: 0
 Images: 29
 Server Version: dev
 Storage Driver: overlay2
  Backing Filesystem: extfs
  Supports d_type: true
  Using metacopy: false
  Native Overlay Diff: true
  userxattr: false
 Logging Driver: json-file
 Cgroup Driver: systemd
 Cgroup Version: 2
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
 Swarm: inactive
 Runtimes: io.containerd.runc.v2 runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: 212e8b6fa2f44b9c21b2798135fc6fb7c53efc16
 runc version: v1.1.1-0-g52de29d
 init version: de40ad0
 Security Options:
  seccomp
   Profile: builtin
  cgroupns
 Kernel Version: 5.15.32-v7l+
 Operating System: Raspbian GNU/Linux 11 (bullseye)
 OSType: linux
 Architecture: armv7l
 CPUs: 4
 Total Memory: 3.749GiB
 Name: dns2
 ID: 9fb1c1f4-43ac-4f0e-85ae-c32b5edd899d
 Docker Root Dir: /var/lib/docker
 Debug Mode: false
 Registry: https://index.docker.io/v1/
 Labels:
 Experimental: false
 Insecure Registries:
  127.0.0.0/8
 Live Restore Enabled: false
```

**- How I did it**

~Set `CGO_ENABLED=0` for static build in the Dockerfile. Maybe we should disable CGO only for armel/armhf archs?~

Build dockerd and docker-proxy using clang and also adds extra instruction to prefer ld for cross-compiling arm64 in bullseye otherwise it doesn't link.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

