### PR TITLE
c8d: Fix resolving truncated id to a descriptor

### DIFF
--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -180,7 +180,7 @@ func (i *ImageService) resolveDescriptor(ctx context.Context, refOrID string) (o
 	if truncatedID.MatchString(refOrID) {
 		filters := []string{
 			fmt.Sprintf("name==%q", ref), // Or it could just look like one.
-			"target.digest~=" + strconv.Quote(fmt.Sprintf(`sha256:^%s[0-9a-fA-F]{%d}$`, regexp.QuoteMeta(refOrID), 64-len(refOrID))),
+			"target.digest~=" + strconv.Quote(fmt.Sprintf(`^sha256:%s[0-9a-fA-F]{%d}$`, regexp.QuoteMeta(refOrID), 64-len(refOrID))),
 		}
 		imgs, err := is.List(ctx, filters...)
 		if err != nil {


### PR DESCRIPTION
Regular expression beginning anchor was placed after `sha256:` digest prefix.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>

**- What I did**
Fixed searching an image by truncated id.

**- How I did it**
Moved the `$` anchor before `sha256:`

**- How to verify it**

```bash
$ docker pull alpine
$ docker image ls
REPOSITORY   TAG       IMAGE ID       CREATED          SIZE
alpine       latest    f271e74b17ce   2 hours ago      3.26MB
$ docker inspect f271e74
# Should inspect alpine:latest image and not error with `Error: No such object: f271e`
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

