### PR TITLE
[23.0 backport] Add GetLibHome stub for non-linux OS

### DIFF
--- a/pkg/homedir/homedir_others.go
+++ b/pkg/homedir/homedir_others.go
@@ -26,3 +26,8 @@ func GetDataHome() (string, error) {
 func GetConfigHome() (string, error) {
 	return "", errors.New("homedir.GetConfigHome() is not supported on this system")
 }
+
+// GetLibHome is unsupported on non-linux system.
+func GetLibHome() (string, error) {
+	return "", errors.New("homedir.GetLibHome() is not supported on this system")
+}


### PR DESCRIPTION
- backports https://github.com/moby/moby/pull/44835
- fixes https://github.com/moby/moby/issues/44830


(cherry picked from commit ff14f8ef1621dc314c95219d37135613c378fca0)


