### PR TITLE
Disable chrootarchive.init() on Windows

### DIFF
--- a/pkg/chrootarchive/archive.go
+++ b/pkg/chrootarchive/archive.go
@@ -3,21 +3,12 @@ package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
 import (
 	"fmt"
 	"io"
-	"net"
 	"os"
-	"os/user"
 	"path/filepath"
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/idtools"
 )
-
-func init() {
-	// initialize nss libraries in Glibc so that the dynamic libraries are loaded in the host
-	// environment not in the chroot from untrusted files.
-	_, _ = user.Lookup("docker")
-	_, _ = net.LookupHost("localhost")
-}
 
 // NewArchiver returns a new Archiver which uses chrootarchive.Untar
 func NewArchiver(idMapping idtools.IdentityMapping) *archive.Archiver {

--- a/pkg/chrootarchive/archive_unix.go
+++ b/pkg/chrootarchive/archive_unix.go
@@ -5,12 +5,21 @@ package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
 
 import (
 	"io"
+	"net"
+	"os/user"
 	"path/filepath"
 	"strings"
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/pkg/errors"
 )
+
+func init() {
+	// initialize nss libraries in Glibc so that the dynamic libraries are loaded in the host
+	// environment not in the chroot from untrusted files.
+	_, _ = user.Lookup("docker")
+	_, _ = net.LookupHost("localhost")
+}
 
 func invokeUnpack(decompressedArchive io.Reader, dest string, options *archive.TarOptions, root string) error {
 	relDest, err := resolvePathInChroot(root, dest)


### PR DESCRIPTION
Any package that simply imports ```pkg/chrootarchive``` will panic on Windows Nano Server, due to missing ```netapi32.dll```. While docker itself is not meant to run on Nano Server, binaries that may import this package and run on Nano server, will fail even if they don't really use any of the functionality in this package while running on Nano.

I stumbled across this while trying to create a ```reexec``` helper in ```buildkit``` that is meant to run inside a container. 

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>

**- What I did**

Added a condition that skips running the ```init()``` function in ```archive.go```.

**- How to verify it**

Create a small program that imports this package and run it on Nano server. Without this patch, the result is a panic when trying to load ```netapi32.dll``` (needed by ```user.Lookup()```)

**- Description for the changelog**

Disables user.Lookup() and net.LookupHost() in the init() function on Windows.
