### PR TITLE
[23.0 backport] Disable chrootarchive.init() on Windows

### DIFF
--- a/pkg/chrootarchive/archive.go
+++ b/pkg/chrootarchive/archive.go
@@ -3,21 +3,12 @@ package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
 import (
 	"fmt"
 	"io"
-	"net"
 	"os"
-	"os/user"
 	"path/filepath"
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/idtools"
 )
-
-func init() {
-	// initialize nss libraries in Glibc so that the dynamic libraries are loaded in the host
-	// environment not in the chroot from untrusted files.
-	_, _ = user.Lookup("docker")
-	_, _ = net.LookupHost("localhost")
-}
 
 // NewArchiver returns a new Archiver which uses chrootarchive.Untar
 func NewArchiver(idMapping idtools.IdentityMapping) *archive.Archiver {

--- a/pkg/chrootarchive/archive_unix.go
+++ b/pkg/chrootarchive/archive_unix.go
@@ -9,7 +9,9 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"os"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -18,6 +20,13 @@ import (
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/pkg/errors"
 )
+
+func init() {
+	// initialize nss libraries in Glibc so that the dynamic libraries are loaded in the host
+	// environment not in the chroot from untrusted files.
+	_, _ = user.Lookup("docker")
+	_, _ = net.LookupHost("localhost")
+}
 
 // untar is the entry-point for docker-untar on re-exec. This is not used on
 // Windows as it does not support chroot, hence no point sandboxing through


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44847

Minor conflict in `pkg/chrootarchive/archive_unix.go` due to adjacent line changes.


Disables user.Lookup() and net.LookupHost() in the init() function on Windows.

Any package that simply imports pkg/chrootarchive will panic on Windows Nano Server, due to missing netapi32.dll. While docker itself is not meant to run on Nano Server, binaries that may import this package and run on Nano server, will fail even if they don't really use any of the functionality in this package while running on Nano.

Conflicts:
    pkg/chrootarchive/archive_unix.go

(cherry picked from commit f49c88f1c429d9dd1459c08fc718cea6e2cb323c)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

