### PR TITLE
hack: remove -installsuffix build flag

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -110,11 +110,7 @@ fi
 
 LDFLAGS_STATIC=''
 EXTLDFLAGS_STATIC='-static'
-# ORIG_BUILDFLAGS is necessary for the cross target which cannot always build
-# with options like -race.
-ORIG_BUILDFLAGS=(-tags "netgo osusergo static_build $DOCKER_BUILDTAGS")
-
-BUILDFLAGS=(${BUILDFLAGS} "${ORIG_BUILDFLAGS[@]}")
+BUILDFLAGS=(${BUILDFLAGS} -tags "netgo osusergo static_build $DOCKER_BUILDTAGS")
 
 LDFLAGS_STATIC_DOCKER="
 	$LDFLAGS_STATIC

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -108,14 +108,8 @@ if [ -z "$DOCKER_DEBUG" ]; then
 	LDFLAGS='-w'
 fi
 
-LDFLAGS_STATIC=''
-EXTLDFLAGS_STATIC='-static'
 BUILDFLAGS=(${BUILDFLAGS} -tags "netgo osusergo static_build $DOCKER_BUILDTAGS")
-
-LDFLAGS_STATIC_DOCKER="
-	$LDFLAGS_STATIC
-	-extldflags \"$EXTLDFLAGS_STATIC\"
-"
+LDFLAGS_STATIC="-extldflags -static"
 
 if [ "$(uname -s)" = 'FreeBSD' ]; then
 	# Tell cgo the compiler is Clang, not GCC

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -112,8 +112,7 @@ LDFLAGS_STATIC=''
 EXTLDFLAGS_STATIC='-static'
 # ORIG_BUILDFLAGS is necessary for the cross target which cannot always build
 # with options like -race.
-ORIG_BUILDFLAGS=(-tags "netgo osusergo static_build $DOCKER_BUILDTAGS" -installsuffix netgo)
-# see https://github.com/golang/go/issues/9369#issuecomment-69864440 for why -installsuffix is necessary here
+ORIG_BUILDFLAGS=(-tags "netgo osusergo static_build $DOCKER_BUILDTAGS")
 
 BUILDFLAGS=(${BUILDFLAGS} "${ORIG_BUILDFLAGS[@]}")
 

--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -60,15 +60,10 @@ source "${MAKEDIR}/.go-autogen"
 	fi
 
 	echo "Building $([ "$DOCKER_STATIC" = "1" ] && echo "static" || echo "dynamic") $DEST/$BINARY_FULLNAME ($PLATFORM_NAME)..."
-	go build \
-		-o "$DEST/$BINARY_FULLNAME" \
-		"${BUILDFLAGS[@]}" \
-		-ldflags "
-		$LDFLAGS
-		$LDFLAGS_STATIC
-		$DOCKER_LDFLAGS
-	" \
-		${GO_PACKAGE}
+	if [ -n "$DOCKER_DEBUG" ]; then
+		set -x
+	fi
+	go build -o "$DEST/$BINARY_FULLNAME" "${BUILDFLAGS[@]}" -ldflags "$LDFLAGS $LDFLAGS_STATIC $DOCKER_LDFLAGS" ${GO_PACKAGE}
 )
 
 echo "Created binary: $DEST/$BINARY_FULLNAME"

--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -65,7 +65,7 @@ source "${MAKEDIR}/.go-autogen"
 		"${BUILDFLAGS[@]}" \
 		-ldflags "
 		$LDFLAGS
-		$LDFLAGS_STATIC_DOCKER
+		$LDFLAGS_STATIC
 		$DOCKER_LDFLAGS
 	" \
 		${GO_PACKAGE}

--- a/hack/make/.go-autogen
+++ b/hack/make/.go-autogen
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 
 LDFLAGS="${LDFLAGS} \
-	-X \"github.com/docker/docker/dockerversion.Version=${VERSION}\" \
-	-X \"github.com/docker/docker/dockerversion.GitCommit=${GITCOMMIT}\" \
-	-X \"github.com/docker/docker/dockerversion.BuildTime=${BUILDTIME}\" \
-	-X \"github.com/docker/docker/dockerversion.PlatformName=${PLATFORM}\" \
-	-X \"github.com/docker/docker/dockerversion.ProductName=${PRODUCT}\" \
-	-X \"github.com/docker/docker/dockerversion.DefaultProductLicense=${DEFAULT_PRODUCT_LICENSE}\" \
-"
+-X \"github.com/docker/docker/dockerversion.Version=${VERSION}\" \
+-X \"github.com/docker/docker/dockerversion.GitCommit=${GITCOMMIT}\" \
+-X \"github.com/docker/docker/dockerversion.BuildTime=${BUILDTIME}\" \
+-X \"github.com/docker/docker/dockerversion.PlatformName=${PLATFORM}\" \
+-X \"github.com/docker/docker/dockerversion.ProductName=${PRODUCT}\" \
+-X \"github.com/docker/docker/dockerversion.DefaultProductLicense=${DEFAULT_PRODUCT_LICENSE}\" "
 
 # Compile the Windows resources into the sources
 if [ "$(go env GOOS)" = "windows" ]; then

--- a/hack/make/dynbinary-daemon
+++ b/hack/make/dynbinary-daemon
@@ -4,7 +4,7 @@ set -e
 [ -z "$KEEPDEST" ] && rm -rf "$DEST"
 
 (
-	export LDFLAGS_STATIC_DOCKER=''
+	export LDFLAGS_STATIC=''
 	export BUILDFLAGS=("${BUILDFLAGS[@]/netgo /}")        # disable netgo, since we don't need it for a dynamic binary
 	export BUILDFLAGS=("${BUILDFLAGS[@]/osusergo /}")     # ditto for osusergo
 	export BUILDFLAGS=("${BUILDFLAGS[@]/static_build /}") # we're not building a "static" binary here

--- a/hack/make/dynbinary-proxy
+++ b/hack/make/dynbinary-proxy
@@ -3,7 +3,7 @@
 set -e
 
 (
-	export LDFLAGS_STATIC_DOCKER=''
+	export LDFLAGS_STATIC=''
 	export BUILDFLAGS=("${BUILDFLAGS[@]/netgo /}")        # disable netgo, since we don't need it for a dynamic binary
 	export BUILDFLAGS=("${BUILDFLAGS[@]/osusergo /}")     # ditto for osusergo
 	export BUILDFLAGS=("${BUILDFLAGS[@]/static_build /}") # we're not building a "static" binary here


### PR DESCRIPTION
follow-up https://github.com/moby/moby/pull/44546#discussion_r1054961381

**- What I did**

`-installsuffix netgo` has been added in https://github.com/moby/moby/pull/10155 to work around a bug with "go build" but not required anymore since go 1.5: https://github.com/golang/go/commit/4dab6d01f12591f256d36b32cd6480ef679458f1

Also took the opportunity to:
* remove `ORIG_BUILDFLAGS` var that was used for the cross target but has been removed
in https://github.com/moby/moby/pull/44546 so not necessary anymore
* cleanup unnecessary vars in `make.sh` script
* display build cmd when `DOCKER_DEBUG` is set (had to remove extra tabs and new lines to avoid a clunky output)

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

