### PR TITLE
Dockerfile: prefer ld for building against arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -581,7 +581,7 @@ ARG PACKAGER_NAME
 ENV PREFIX=/tmp
 RUN <<EOT
   # in bullseye arm64 target does not link with lld so configure it to use ld instead
-  if xx-info is-cross && [ "$(xx-info arch)" = "arm64" ]; then
+  if [ "$(xx-info arch)" = "arm64" ]; then
     XX_CC_PREFER_LINKER=ld xx-clang --setup-target-triple
   fi
 EOT


### PR DESCRIPTION
reported by @thaJeztah when building static binary on M1, also repro on my side:

```
$ docker buildx bake
...
------                                                                                                                                                                                                                                                
 > [build 6/6] RUN --mount=type=bind,target=.     --mount=type=tmpfs,target=cli/winresources/dockerd     --mount=type=tmpfs,target=cli/winresources/docker-proxy     --mount=type=cache,target=/root/.cache/go-build,id=moby-build-linux/arm64 <<EOT (set -e...):                                                                                                                                                                                                                                           
#0 0.263                                                                                                                                                                                                                                              
#0 0.336 Removing /tmp/bundles/                                                                                                                                                                                                                       
#0 0.337                                                                                                                                                                                                                                              
#0 0.343 ---> Making bundle: binary (in /tmp/bundles/binary)
#0 0.364 Building static /tmp/bundles/binary-daemon/dockerd (linux/arm64)...
#0 24.68 # github.com/docker/docker/cmd/dockerd
#0 24.68 /usr/local/go/pkg/tool/linux_arm64/link: running aarch64-linux-gnu-clang failed: exit status 1
#0 24.68 ld.lld: error: allocatestack.c:962:(.text+0x80C): unknown relocation (313) against symbol __default_pthread_attr_lock
#0 24.68 ld.lld: error: allocatestack.c:1051:(.text+0x974): unknown relocation (313) against symbol __stack_chk_guard
#0 24.68 ld.lld: error: allocatestack.c:1067:(.text+0x9D8): unknown relocation (313) against symbol __stack_chk_guard
#0 24.68 ld.lld: error: allocatestack.c:1077:(.text+0xA60): unknown relocation (313) against symbol __xidcmd
#0 24.68 ld.lld: error: pthread_create.c:256:(.text+0x121C): unknown relocation (313) against symbol __pthread_keys
#0 24.68 ld.lld: error: pthread_create.c:379:(.text+0x13A4): unknown relocation (313) against symbol __stack_chk_guard
#0 24.68 ld.lld: error: pthread_create.c:483:(.text+0x1450): unknown relocation (313) against symbol __call_tls_dtors
#0 24.68 ld.lld: error: pthread_create.c:625:(.text+0x1728): unknown relocation (313) against symbol __stack_chk_guard
#0 24.68 ld.lld: error: pthread_create.c:634:(.text+0x1764): unknown relocation (313) against symbol __default_pthread_attr_lock
#0 24.68 ld.lld: error: pthread_create.c:635:(.text+0x177C): unknown relocation (313) against symbol __default_pthread_attr
#0 24.68 ld.lld: error: pthread_create.c:655:(.text+0x17E4): unknown relocation (313) against symbol __default_pthread_attr_lock
#0 24.68 ld.lld: error: allocatestack.c:427:(.text+0x181C): unknown relocation (313) against symbol __default_pthread_attr_lock
#0 24.68 ld.lld: error: allocatestack.c:428:(.text+0x1834): unknown relocation (313) against symbol __default_pthread_attr
#0 24.68 ld.lld: error: allocatestack.c:429:(.text+0x183C): unknown relocation (313) against symbol __default_pthread_attr_lock
#0 24.68 ld.lld: error: allocatestack.c:528:(.text+0x185C): unknown relocation (313) against symbol __static_tls_align_m1
#0 24.68 ld.lld: error: allocatestack.c:538:(.text+0x1898): unknown relocation (313) against symbol __static_tls_size
#0 24.68 ld.lld: error: allocatestack.c:525:(.text+0x18B4): unknown relocation (313) against symbol _dl_stack_flags
#0 24.68 ld.lld: error: pthread_create.c:875:(.text+0x1B7C): unknown relocation (313) against symbol __stack_chk_guard
#0 24.68 ld.lld: error: allocatestack.c:447:(.text+0x1BC8): unknown relocation (313) against symbol __static_tls_size
#0 24.68 ld.lld: error: allocatestack.c:457:(.text+0x1BDC): unknown relocation (313) against symbol __static_tls_align_m1
#0 24.68 ld.lld: error: too many errors emitted, stopping now (use -error-limit=0 to see all errors)
#0 24.68 clang: error: linker command failed with exit code 1 (use -v to see invocation)
#0 24.68 
------
```

**- What I did**

We already prefer ld for cross-building arm64 but that seems not enough as native arm64 build also has a linker issue with lld so we need to also prefer ld for native build.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

