### PR TITLE
[23.0 backport] Dockerfile: prefer ld for building against arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -583,7 +583,7 @@ ARG PACKAGER_NAME
 ENV PREFIX=/tmp
 RUN <<EOT
   # in bullseye arm64 target does not link with lld so configure it to use ld instead
-  if xx-info is-cross && [ "$(xx-info arch)" = "arm64" ]; then
+  if [ "$(xx-info arch)" = "arm64" ]; then
     XX_CC_PREFER_LINKER=ld xx-clang --setup-target-triple
   fi
 EOT


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/44854

We already prefer ld for cross-building arm64 but that seems not enough as native arm64 build also has a linker issue with lld so we need to also prefer ld for native arm64 build.

(cherry picked from commit d2d6ef431f9d2180784dfeea7788900a27066f4a)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

