### PR TITLE
hack: check if cross-compiling before setting ARM target name

### DIFF
--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -16,22 +16,25 @@ source "${MAKEDIR}/.go-autogen"
 (
 	export GOGC=${DOCKER_BUILD_GOGC:-1000}
 
-	if [ "$(go env GOOS)/$(go env GOARCH)" = "linux/arm" ]; then
-		# specify name of the target ARM architecture
-		case "$(go env GOARM)" in
-			5)
-				export CGO_CFLAGS="-march=armv5t"
-				export CGO_CXXFLAGS="-march=armv5t"
-				;;
-			6)
-				export CGO_CFLAGS="-march=armv6"
-				export CGO_CXXFLAGS="-march=armv6"
-				;;
-			7)
-				export CGO_CFLAGS="-march=armv7-a"
-				export CGO_CXXFLAGS="-march=armv7-a"
-				;;
-		esac
+	if [ "$(go env GOOS)/$(go env GOARCH)" != "$(go env GOHOSTOS)/$(go env GOHOSTARCH)" ]; then
+		# must be cross-compiling!
+		if [ "$(go env GOOS)/$(go env GOARCH)" = "linux/arm" ]; then
+			# specify name of the target ARM architecture
+			case "$(go env GOARM)" in
+				5)
+					export CGO_CFLAGS="-march=armv5t"
+					export CGO_CXXFLAGS="-march=armv5t"
+					;;
+				6)
+					export CGO_CFLAGS="-march=armv6"
+					export CGO_CXXFLAGS="-march=armv6"
+					;;
+				7)
+					export CGO_CFLAGS="-march=armv7-a"
+					export CGO_CXXFLAGS="-march=armv7-a"
+					;;
+			esac
+		fi
 	fi
 
 	# -buildmode=pie is not supported on Windows arm64 and Linux mips*, ppc64be


### PR DESCRIPTION
reported by @thaJeztah

**- What I did**

Fixing name of target ARM architecture in https://github.com/moby/moby/pull/44812 breaks packaging release on https://github.com/docker/docker-ce-packaging. See https://ci-next.docker.com/public/blue/organizations/jenkins/docker-ce-packaging/detail/PR-832/3/pipeline#step-1137-log-374:

```
---> Making bundle: dynbinary (in bundles/dynbinary)
Building dynamic bundles/dynbinary-daemon/dockerd (linux/arm/v6)...
# runtime/cgo
cc1: error: '-mfloat-abi=hard': selected architecture lacks an FPU
```

Starting with gcc-11, Debian's armhf compiler no longer builds with a default `-mfpu=` option. Instead it enables the FPU via an extension to the `-march` flag (`--with-arch=armv7-a+fp`). Build explicitly passes its own `-march=armv7-a` setting, which overrides the `+fp` default, so we end up with no FPU.

We could just set `-march=armv7-a+fp` in https://github.com/moby/moby/blob/95e207933d02d1ebadec4b9cfb791f6e3cffd51b/hack/make/.binary#L31-L32

But golang image to build armhf looks to be an armel one with `GOARM=6`: https://github.com/docker-library/golang/blob/9a135136dcd3d56a39e1f40c5b264938eac0c7ee/1.19/buster/Dockerfile#L36-L39 so it still fails with the same error.

We can't set `-march=armv6+fp` as it's not supported by gcc-7 on focal: https://ci-next.docker.com/public/blue/organizations/jenkins/docker-ce-packaging/detail/PR-833/2/pipeline/711/#step-854-log-370

```
---> Making bundle: dynbinary (in bundles/dynbinary)

Building dynamic bundles/dynbinary-daemon/dockerd (linux/arm/v6)...
# runtime/cgo
gcc: error: unrecognized argument in option '-march=armv6+fp'
gcc: note: valid arguments to '-march=' are: armv2 armv2a armv3 armv3m armv4 armv4t armv5 armv5e armv5t armv5te armv5tej armv6 armv6-m armv6j armv6k armv6kz armv6s-m armv6t2 armv6z armv6zk armv7 armv7-a armv7-m armv7-r armv7e-m armv7ve armv8-a armv8-a+crc armv8-m.base armv8-m.main armv8-m.main+dsp armv8.1-a armv8.2-a armv8.2-a+dotprod armv8.2-a+fp16 armv8.2-a+fp16+dotprod iwmmxt iwmmxt2 native; did you mean 'armv6'?
```

So in the meantime bring back the cross-compilation check. Maybe in the future we could also use clang to build packages.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

cc @tianon @tonistiigi @corhere @vvoland 