### PR TITLE
[23.0 backport] rootless: support `--ipc=host`

### DIFF
--- a/integration/container/ipcmode_linux_test.go
+++ b/integration/container/ipcmode_linux_test.go
@@ -115,7 +115,7 @@ func TestIpcModePrivate(t *testing.T) {
 // also exists on the host.
 func TestIpcModeShareable(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon)
-	skip.If(t, testEnv.IsRootless, "cannot test /dev/shm in rootless")
+	skip.If(t, testEnv.IsRootless, "no support for --ipc=shareable in rootless")
 
 	testIpcNonePrivateShareable(t, "shareable", true, true)
 }
@@ -191,7 +191,6 @@ func TestAPIIpcModeShareableAndContainer(t *testing.T) {
 func TestAPIIpcModeHost(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon)
 	skip.If(t, testEnv.IsUserNamespace)
-	skip.If(t, testEnv.IsRootless, "cannot test /dev/shm in rootless")
 
 	cfg := containertypes.Config{
 		Image: "busybox",
@@ -263,7 +262,7 @@ func testDaemonIpcPrivateShareable(t *testing.T, mustBeShared bool, arg ...strin
 // TestDaemonIpcModeShareable checks that --default-ipc-mode shareable works as intended.
 func TestDaemonIpcModeShareable(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon)
-	skip.If(t, testEnv.IsRootless, "cannot test /dev/shm in rootless")
+	skip.If(t, testEnv.IsRootless, "no support for --ipc=shareable in rootless")
 
 	testDaemonIpcPrivateShareable(t, true, "--default-ipc-mode", "shareable")
 }
@@ -277,9 +276,9 @@ func TestDaemonIpcModePrivate(t *testing.T) {
 
 // used to check if an IpcMode given in config works as intended
 func testDaemonIpcFromConfig(t *testing.T, mode string, mustExist bool) {
-	skip.If(t, testEnv.IsRootless, "cannot test /dev/shm in rootless")
 	config := `{"default-ipc-mode": "` + mode + `"}`
-	file := fs.NewFile(t, "test-daemon-ipc-config", fs.WithContent(config))
+	// WithMode is needed for rootless
+	file := fs.NewFile(t, "test-daemon-ipc-config", fs.WithContent(config), fs.WithMode(0o644))
 	defer file.Remove()
 
 	testDaemonIpcPrivateShareable(t, mustExist, "--config-file", file.Path())
@@ -295,6 +294,7 @@ func TestDaemonIpcModePrivateFromConfig(t *testing.T) {
 // TestDaemonIpcModeShareableFromConfig checks that "default-ipc-mode: shareable" config works as intended.
 func TestDaemonIpcModeShareableFromConfig(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon)
+	skip.If(t, testEnv.IsRootless, "no support for --ipc=shareable in rootless")
 
 	testDaemonIpcFromConfig(t, "shareable", true)
 }


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/44852
- fixes https://github.com/moby/moby/issues/44294

(cherry picked from commit b3c5352386c2bb6c46d0f2232bad9e84e53e8d27)


---



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

rootless: support `--ipc=host`

Fixes #44294

**- How I did it**

By bind-mounting `/dev/{shm,mqueue}` for rootless.

**- How to verify it**

```console
$ touch /dev/shm/foo
$ docker --context=rootless run --rm --ipc=host alpine ls /dev/shm
foo
```

Previously it was failing with:
```
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "mqueue" to rootfs at "/dev/mqueue": mount mqueue:/dev/mqueue (via /proc/self/fd/7), flags: 0xe: operation not permitted: unknown.
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
rootless: support `--ipc=host`

**- A picture of a cute animal (not mandatory but encouraged)**

🐧 
