### PR TITLE
libnetwork: minor cleanup related to GenerateRandomName

### DIFF
--- a/libnetwork/drivers/bridge/bridge.go
+++ b/libnetwork/drivers/bridge/bridge.go
@@ -30,7 +30,7 @@ import (
 const (
 	networkType                = "bridge"
 	vethPrefix                 = "veth"
-	vethLen                    = 7
+	vethLen                    = len(vethPrefix) + 7
 	defaultContainerVethPrefix = "eth"
 	maxAllocatePortAttempts    = 10
 )

--- a/libnetwork/drivers/ipvlan/ipvlan.go
+++ b/libnetwork/drivers/ipvlan/ipvlan.go
@@ -14,9 +14,9 @@ import (
 )
 
 const (
-	vethLen             = 7
 	containerVethPrefix = "eth"
 	vethPrefix          = "veth"
+	vethLen             = len(vethPrefix) + 7
 
 	driverName    = "ipvlan"      // driver type name
 	parentOpt     = "parent"      // parent interface -o parent

--- a/libnetwork/drivers/macvlan/macvlan.go
+++ b/libnetwork/drivers/macvlan/macvlan.go
@@ -14,9 +14,9 @@ import (
 )
 
 const (
-	vethLen             = 7
 	containerVethPrefix = "eth"
 	vethPrefix          = "veth"
+	vethLen             = len(vethPrefix) + 7
 	driverName          = "macvlan"      // driver type name
 	modePrivate         = "private"      // macvlan mode private
 	modeVepa            = "vepa"         // macvlan mode vepa

--- a/libnetwork/drivers/overlay/overlay.go
+++ b/libnetwork/drivers/overlay/overlay.go
@@ -25,7 +25,7 @@ import (
 const (
 	networkType  = "overlay"
 	vethPrefix   = "veth"
-	vethLen      = 7
+	vethLen      = len(vethPrefix) + 7
 	vxlanIDStart = 256
 	vxlanIDEnd   = (1 << 24) - 1
 	vxlanEncap   = 50

--- a/libnetwork/drivers/windows/overlay/overlay_windows.go
+++ b/libnetwork/drivers/windows/overlay/overlay_windows.go
@@ -17,10 +17,7 @@ import (
 )
 
 const (
-	networkType  = "overlay"
-	vethPrefix   = "veth"
-	vethLen      = 7
-	secureOption = "encrypted"
+	networkType = "overlay"
 )
 
 type driver struct {

--- a/libnetwork/netutils/utils.go
+++ b/libnetwork/netutils/utils.go
@@ -121,14 +121,21 @@ func GenerateMACFromIP(ip net.IP) net.HardwareAddr {
 	return genMAC(ip)
 }
 
-// GenerateRandomName returns a new name joined with a prefix.  This size
-// specified is used to truncate the randomly generated value
-func GenerateRandomName(prefix string, size int) (string, error) {
-	id := make([]byte, 32)
-	if _, err := io.ReadFull(rand.Reader, id); err != nil {
+// GenerateRandomName returns a string of the specified length, created by joining the prefix to random hex characters.
+// The length must be strictly larger than len(prefix), or an error will be returned.
+func GenerateRandomName(prefix string, length int) (string, error) {
+	if length <= len(prefix) {
+		return "", fmt.Errorf("invalid length %d for prefix %s", length, prefix)
+	}
+
+	// We add 1 here as integer division will round down, and we want to round up.
+	b := make([]byte, (length-len(prefix)+1)/2)
+	if _, err := io.ReadFull(rand.Reader, b); err != nil {
 		return "", err
 	}
-	return prefix + hex.EncodeToString(id)[:size], nil
+
+	// By taking a slice here, we ensure that the string is always the correct length.
+	return (prefix + hex.EncodeToString(b))[:length], nil
 }
 
 // ReverseIP accepts a V4 or V6 IP string in the canonical form and returns a reversed IP in

--- a/libnetwork/netutils/utils_linux.go
+++ b/libnetwork/netutils/utils_linux.go
@@ -8,7 +8,6 @@ package netutils
 import (
 	"net"
 	"os"
-	"strings"
 
 	"github.com/docker/docker/libnetwork/ipamutils"
 	"github.com/docker/docker/libnetwork/ns"
@@ -49,11 +48,11 @@ func GenerateIfaceName(nlh *netlink.Handle, prefix string, len int) (string, err
 	for i := 0; i < 3; i++ {
 		name, err := GenerateRandomName(prefix, len)
 		if err != nil {
-			continue
+			return "", err
 		}
 		_, err = linkByName(name)
 		if err != nil {
-			if strings.Contains(err.Error(), "not found") {
+			if errors.As(err, &netlink.LinkNotFoundError{}) {
 				return name, nil
 			}
 			return "", err


### PR DESCRIPTION
- Alternative to #44743
- Fixes #44362

**- What I did**
Moderate cleanup in areas related to libnetwork/netutils, especially GenerateRandomName; consult commit messages for details.

**- How to verify it**
Unit tests, and commit-wise review. The changes are minimal and focused on the immediate areas related to GenerateRandomName

**- Description for the changelog**
N/A

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/1049222/213894046-4cd454be-4095-4904-b33d-8133af5b6f96.png)
