### PR TITLE
Fix exit-event handling for Kata runtime

### DIFF
--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -156,7 +156,7 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerdtypes.EventType, ei
 
 		daemon.LogContainerEvent(c, "oom")
 	case libcontainerdtypes.EventExit:
-		if int(ei.Pid) == c.Pid {
+		if ei.ProcessID == ei.ContainerID {
 			return daemon.handleContainerExit(c, &ei)
 		}
 

--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -461,7 +461,7 @@ func (ctr *container) Start(_ context.Context, _ string, withStdin bool, attachS
 		}
 	}()
 	t := &task{process: process{
-		id:         libcontainerdtypes.InitProcessName,
+		id:         ctr.id,
 		ctr:        ctr,
 		hcsProcess: newProcess,
 		waitCh:     make(chan struct{}),
@@ -495,7 +495,7 @@ func (ctr *container) Start(_ context.Context, _ string, withStdin bool, attachS
 	ctr.client.eventQ.Append(ctr.id, func() {
 		ei := libcontainerdtypes.EventInfo{
 			ContainerID: ctr.id,
-			ProcessID:   libcontainerdtypes.InitProcessName,
+			ProcessID:   t.id,
 			Pid:         pid,
 		}
 		ctr.client.logger.WithFields(logrus.Fields{
@@ -793,7 +793,7 @@ func (t *task) Pause(_ context.Context) error {
 	t.ctr.client.eventQ.Append(t.ctr.id, func() {
 		err := t.ctr.client.backend.ProcessEvent(t.ctr.id, libcontainerdtypes.EventPaused, libcontainerdtypes.EventInfo{
 			ContainerID: t.ctr.id,
-			ProcessID:   libcontainerdtypes.InitProcessName,
+			ProcessID:   t.id,
 		})
 		t.ctr.client.logger.WithFields(logrus.Fields{
 			"container": t.ctr.id,
@@ -834,7 +834,7 @@ func (t *task) Resume(ctx context.Context) error {
 	t.ctr.client.eventQ.Append(t.ctr.id, func() {
 		err := t.ctr.client.backend.ProcessEvent(t.ctr.id, libcontainerdtypes.EventResumed, libcontainerdtypes.EventInfo{
 			ContainerID: t.ctr.id,
-			ProcessID:   libcontainerdtypes.InitProcessName,
+			ProcessID:   t.id,
 		})
 		t.ctr.client.logger.WithFields(logrus.Fields{
 			"container": t.ctr.id,

--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -213,9 +213,9 @@ func (c *container) Start(ctx context.Context, checkpointDir string, withStdin b
 
 	t, err = c.c8dCtr.NewTask(ctx,
 		func(id string) (cio.IO, error) {
-			fifos := newFIFOSet(bundle, libcontainerdtypes.InitProcessName, withStdin, spec.Process.Terminal)
+			fifos := newFIFOSet(bundle, id, withStdin, spec.Process.Terminal)
 
-			rio, err = c.createIO(fifos, libcontainerdtypes.InitProcessName, stdinCloseSync, attachStdio)
+			rio, err = c.createIO(fifos, stdinCloseSync, attachStdio)
 			return rio, err
 		},
 		taskOpts...,
@@ -278,7 +278,7 @@ func (t *task) Exec(ctx context.Context, processID string, spec *specs.Process, 
 	}()
 
 	p, err = t.Task.Exec(ctx, processID, spec, func(id string) (cio.IO, error) {
-		rio, err = t.ctr.createIO(fifos, processID, stdinCloseSync, attachStdio)
+		rio, err = t.ctr.createIO(fifos, stdinCloseSync, attachStdio)
 		return rio, err
 	})
 	if err != nil {
@@ -489,7 +489,7 @@ func (c *container) Task(ctx context.Context) (libcontainerdtypes.Task, error) {
 
 // createIO creates the io to be used by a process
 // This needs to get a pointer to interface as upon closure the process may not have yet been registered
-func (c *container) createIO(fifos *cio.FIFOSet, processID string, stdinCloseSync chan containerd.Process, attachStdio libcontainerdtypes.StdioCallback) (cio.IO, error) {
+func (c *container) createIO(fifos *cio.FIFOSet, stdinCloseSync chan containerd.Process, attachStdio libcontainerdtypes.StdioCallback) (cio.IO, error) {
 	var (
 		io  *cio.DirectIO
 		err error

--- a/libcontainerd/types/types.go
+++ b/libcontainerd/types/types.go
@@ -99,6 +99,3 @@ type Task interface {
 
 // StdioCallback is called to connect a container or process stdio.
 type StdioCallback func(io *cio.DirectIO) (cio.IO, error)
-
-// InitProcessName is the name given to the first process of a container
-const InitProcessName = "init"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- Fixes https://github.com/kata-containers/kata-containers/issues/6154

**- What I did**
I fixed [an issue](https://dockercommunity.slack.com/archives/C04HMFX54F7/p1673634955862119) with the handling of exit events when using the Kata Containers runtime. The daemon would misinterpret an exit event for an exec as the exit event for the container itself, resulting in it prematurely closing the container FIFOs.

**- How I did it**
I modified daemon to differentiate container (task) exit events from exec (process) exit events by comparing the process ID (not to be confused with PID) to the container ID. [ContainerD guarantees that the process ID of a task is equal to the container ID.](https://github.com/containerd/containerd/blob/0b81378be65587d80f88f232e75981f2f6f58630/services/tasks/local.go#L237)

**- How to verify it**
CI. We have lots of existing integration tests which cover container and exec lifecycle.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Fixed an issue with the handling of process exit events which was causing compatibility issues with the `io.containerd.kata.v2` runtime.

**- A picture of a cute animal (not mandatory but encouraged)**

