### PR TITLE
[23.0 backport] Fix exit-event handling for Kata runtime

### DIFF
--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -148,7 +148,7 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerdtypes.EventType, ei
 
 		daemon.LogContainerEvent(c, "oom")
 	case libcontainerdtypes.EventExit:
-		if int(ei.Pid) == c.Pid {
+		if ei.ProcessID == libcontainerdtypes.InitProcessName {
 			return daemon.handleContainerExit(c, &ei)
 		}
 

--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -674,7 +674,7 @@ func (c *client) processEvent(ctx context.Context, et libcontainerdtypes.EventTy
 			}).Error("failed to process event")
 		}
 
-		if et == libcontainerdtypes.EventExit && ei.ProcessID != ei.ContainerID {
+		if et == libcontainerdtypes.EventExit && ei.ProcessID != libcontainerdtypes.InitProcessName {
 			p, err := c.getProcess(ctx, ei.ContainerID, ei.ProcessID)
 			if err != nil {
 
@@ -822,6 +822,9 @@ func (c *client) processEventStream(ctx context.Context, ns string) {
 					Pid:         t.Pid,
 					ExitCode:    t.ExitStatus,
 					ExitedAt:    t.ExitedAt,
+				}
+				if t.ID == t.ContainerID {
+					ei.ProcessID = libcontainerdtypes.InitProcessName
 				}
 			case *apievents.TaskOOM:
 				et = libcontainerdtypes.EventOOM


### PR DESCRIPTION
- Fixes https://github.com/kata-containers/kata-containers/issues/6154
- 23.0 backport of #44888

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed exit event handling in a pre-#43564 world.

**- How I did it**
Without cherry-picking.

**- How to verify it**
Start a container with the `io.containerd.kata.v2` runtime and exec a command in it. Verify the container is still running according to `docker ps` after the exec exits.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Fixed an issue with the handling of process exit events which was causing compatibility issues with the `io.containerd.kata.v2` runtime.

**- A picture of a cute animal (not mandatory but encouraged)**

