### PR TITLE
Wait longer for exit events on Windows

### DIFF
--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -146,7 +146,12 @@ func (daemon *Daemon) Kill(container *containerpkg.Container) error {
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	waitTimeout := 10 * time.Second
+	if runtime.GOOS == "windows" {
+		waitTimeout = 75 * time.Second // runhcs can be sloooooow.
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), waitTimeout)
 	defer cancel()
 
 	status := <-container.Wait(ctx, containerpkg.WaitConditionNotRunning)
@@ -154,7 +159,7 @@ func (daemon *Daemon) Kill(container *containerpkg.Container) error {
 		return nil
 	}
 
-	logrus.WithError(status.Err()).WithField("container", container.ID).Error("Container failed to exit within 10 seconds of kill - trying direct SIGKILL")
+	logrus.WithError(status.Err()).WithField("container", container.ID).Errorf("Container failed to exit within %v of kill - trying direct SIGKILL", waitTimeout)
 
 	if err := killProcessDirectly(container); err != nil {
 		if errors.As(err, &errNoSuchProcess{}) {

--- a/integration/container/wait_test.go
+++ b/integration/container/wait_test.go
@@ -170,7 +170,7 @@ func TestWaitConditions(t *testing.T) {
 				assert.NilError(t, err)
 			case waitRes := <-waitResC:
 				assert.Check(t, is.Equal(int64(99), waitRes.StatusCode))
-			case <-time.After(15 * time.Second):
+			case <-time.After(75 * time.Second):
 				info, _ := cli.ContainerInspect(ctx, containerID)
 				t.Fatalf("Timed out waiting for container exit code (status = %q)", info.State.Status)
 			}


### PR DESCRIPTION
The latest version of containerd-shim-runhcs-v1 (v0.10.0-rc.4) pulled in with the bump to ContainerD v1.7.0-rc.3 (https://github.com/moby/moby/pull/44880) had several changes to make it more robust, which had the side effect of increasing the worst-case amount of time it takes for a container to exit in the worst case. Notably, the total timeout for shutting down a task increased from 30 seconds to 60! Increase the timeouts hardcoded in the daemon and integration tests so that they don't give up too soon.

Signed-off-by: Cory Snider <csnider@mirantis.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

