### PR TITLE
layer: NewStoreFromOptions(): include driver-name in error message

### DIFF
--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -62,6 +62,9 @@ func NewStoreFromOptions(options StoreOptions) (Store, error) {
 		ExperimentalEnabled: options.ExperimentalEnabled,
 	})
 	if err != nil {
+		if options.GraphDriver != "" {
+			return nil, fmt.Errorf("error initializing graphdriver: %v: %s", err, options.GraphDriver)
+		}
 		return nil, fmt.Errorf("error initializing graphdriver: %v", err)
 	}
 	logrus.Debugf("Initialized graph driver %s", driver)


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/15651#issuecomment-1410780071


When reading through some bug reports, I noticed that the error-message for unsupported storage drivers is not very informative, as it does not include the actual storage driver. Some of these errors are used as sentinel errors internally, so improving the error returned by graphdriver.New() may need some additional work, but this patch makes a start by including the name of the graphdriver (if set) in the error-message.

Before this patch:

    dockerd --storage-driver=foobar
    ...
    failed to start daemon: error initializing graphdriver: driver not supported

With this patch:

    dockerd --storage-driver=foobar
    ...
    failed to start daemon: error initializing graphdriver: driver not supported: foobar

It's worth noting that there may be code "in the wild" that perform string- matching on this error (e.g. [balena][1]), which is why I included the name as a separate "component" in the output, to allow matching parts of the error. 

[1]: https://github.com/balena-io-modules/balena-preload/blob/3d5c77a4668b688dd21e9d7aec7c333943680adb/lib/preload.ts#L34-L35

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

