### PR TITLE
Dockerfile: Make it easier to use ctr in shell container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -460,6 +460,8 @@ COPY --from=containerutil /build/ /usr/local/bin/
 COPY --from=crun          /build/ /usr/local/bin/
 COPY hack/dockerfile/etc/docker/  /etc/docker/
 ENV PATH=/usr/local/cli:$PATH
+ENV CONTAINERD_ADDRESS=/run/docker/containerd/containerd.sock
+ENV CONTAINERD_NAMESPACE=moby
 WORKDIR /go/src/github.com/docker/docker
 VOLUME /var/lib/docker
 VOLUME /home/unprivilegeduser/.local/share/docker


### PR DESCRIPTION
**- What I did**
Running `ctr` in `make shell` doesn't work by default - one has to invoke it via `ctr --address /run/docker/containerd/containerd.sock -n moby` or set the CONTAINERD_{ADDRESS,NAMESPACE} environment variables to be able to just use `ctr`.

Considering ephemeral nature of these containers it's cumbersome to do it every time manually - this commit sets the variables to the default containerd socket address and makes it much easier to use ctr.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>

**- How to verify it**
Before:
```bash
root@a8efcf765514:/go/src/github.com/docker/docker# ctr image ls
ctr: failed to dial "/run/containerd/containerd.sock": context deadline exceeded: connection error: desc = "transport: error while dialing: dial unix:///run/containerd/containerd.sock: timeout"

root@a8efcf765514:/go/src/github.com/docker/docker# ctr --address /run/docker/containerd/containerd.sock -n moby image ls
REF                             TYPE                                                      DIGEST                                                                  SIZE    PLATFORMS                                                                                LABELS
docker.io/library/alpine:latest application/vnd.docker.distribution.manifest.list.v2+json sha256:f271e74b17ced29b915d351685fd4644785c6d1559dd1f2d4189a5e851ef753a 3.1 MiB linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x -

```

After:
```bash
root@a8efcf765514:/go/src/github.com/docker/docker# ctr image ls
REF                             TYPE                                                      DIGEST                                                                  SIZE    PLATFORMS                                                                                LABELS
docker.io/library/alpine:latest application/vnd.docker.distribution.manifest.list.v2+json sha256:f271e74b17ced29b915d351685fd4644785c6d1559dd1f2d4189a5e851ef753a 3.1 MiB linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x -

```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

