### PR TITLE
ci: enable BuildKit tests with containerd integration worker

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -47,11 +47,16 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     timeout-minutes: 120
+    env:
+      BUILDKIT_REPO: moby/buildkit
     needs:
       - build
     strategy:
       fail-fast: false
       matrix:
+        worker:
+          - dockerd
+          - dockerd-containerd
         pkg:
           - client
           - cmd/buildctl
@@ -62,6 +67,11 @@ jobs:
           - integration
     steps:
       -
+        name: Prepare
+        run: |
+          disabledFeatures="cache_backend_azblob,cache_backend_s3"
+          echo "BUILDKIT_TEST_DISABLE_FEATURES=${disabledFeatures}" >> $GITHUB_ENV
+      -
         name: Checkout
         uses: actions/checkout@v3
         with:
@@ -69,8 +79,9 @@ jobs:
       -
         name: BuildKit ref
         run: |
-          echo "BUILDKIT_REPO=moby/buildkit" >> $GITHUB_ENV
-          echo "BUILDKIT_REF=$(./hack/buildkit-ref)" >> $GITHUB_ENV
+          # FIXME(crazy-max) remove when updating BuildKit to v0.11.5
+          echo "BUILDKIT_REF=237fee9c00877d64a1c757fc5270c98b65a51abf" >> $GITHUB_ENV
+          #echo "BUILDKIT_REF=$(./hack/buildkit-ref)" >> $GITHUB_ENV
         working-directory: moby
       -
         name: Checkout BuildKit ${{ env.BUILDKIT_REF }}
@@ -107,5 +118,5 @@ jobs:
           TEST_DOCKERD: "1"
           TEST_DOCKERD_BINARY: "./build/moby/dockerd"
           TESTPKGS: "./${{ matrix.pkg }}"
-          TESTFLAGS: "-v --parallel=1 --timeout=30m --run=//worker=dockerd$"
+          TESTFLAGS: "-v --parallel=1 --timeout=30m --run=//worker=${{ matrix.worker }}$"
         working-directory: buildkit

--- a/vendor.mod
+++ b/vendor.mod
@@ -56,7 +56,7 @@ require (
 	github.com/klauspost/compress v1.16.3
 	github.com/miekg/dns v1.1.43
 	github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
-	github.com/moby/buildkit v0.11.4
+	github.com/moby/buildkit v0.11.4 // FIXME(crazy-max): remove override from .github/workflows/buildkit.yml when updating to v0.11.5
 	github.com/moby/ipvs v1.1.0
 	github.com/moby/locker v1.0.1
 	github.com/moby/patternmatcher v0.5.0


### PR DESCRIPTION
follow-up https://github.com/moby/moby/pull/44686
related to https://github.com/moby/buildkit/pull/3176

**- What I did**

Now that BuildKit 0.11 vendoring PR has been merged we can enable tests for the containerd integration worker.

**- How I did it**

**- How to verify it**

Check CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

cc @tonistiigi @rumpl @vvoland 