### PR TITLE
graphdriver/overlay2: usingMetacopy ENOTSUP is non-fatal

### DIFF
--- a/daemon/graphdriver/overlay2/check.go
+++ b/daemon/graphdriver/overlay2/check.go
@@ -188,6 +188,11 @@ func usingMetacopy(d string) (bool, error) {
 	// ...and check if the pulled-up copy is marked as metadata-only
 	xattr, err := system.Lgetxattr(filepath.Join(l2, "f"), overlayutils.GetOverlayXattr("metacopy"))
 	if err != nil {
+		// ENOTSUP signifies the FS does not support either xattrs or metacopy. In either case,
+		// it is not a fatal error, and we should report metacopy as unused.
+		if errors.Is(err, unix.ENOTSUP) {
+			return false, nil
+		}
 		return false, errors.Wrap(err, "metacopy flag was not set on file in the upperdir")
 	}
 	usingMetacopy := xattr != nil


### PR DESCRIPTION
- Closes https://github.com/moby/moby/issues/44911

**- What I did**
Change `usesMetacopy` in `overlay2`'s `check.go` to return false/no error on a `ENOTSUP` in lgetxattr(2).

**- How to verify it**
By reading kernel documentation, more or less. ENOTSUP does not indicate that something went wrong, but that either the xattr in question, or xattr as a whole, are not supported by the filesystem.

**- Description for the changelog**
- Fix the `overlay2` storage driver failing in a check for metacopy status instead of backing FS compatibility on incompatible backing filesystems.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/1049222/216600188-9f691f4c-89dd-4470-93aa-2ee3688d5bc2.png)
