### PR TITLE
Set BuildKit version and revision at build time

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -82,7 +82,8 @@ jobs:
       -
         name: BuildKit ref
         run: |
-          echo "BUILDKIT_REF=$(./hack/buildkit-ref)" >> $GITHUB_ENV
+          . hack/buildkit-ref
+          echo "BUILDKIT_REF=$BUILDKIT_REF" >> $GITHUB_ENV
         working-directory: moby
       -
         name: Checkout BuildKit ${{ env.BUILDKIT_REF }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -584,12 +584,13 @@ ARG PACKAGER_NAME
 # read only mount in current work dir
 ENV PREFIX=/tmp
 RUN <<EOT
+  set -e
   # in bullseye arm64 target does not link with lld so configure it to use ld instead
   if [ "$(xx-info arch)" = "arm64" ]; then
     XX_CC_PREFER_LINKER=ld xx-clang --setup-target-triple
   fi
 EOT
-RUN --mount=type=bind,target=. \
+RUN --mount=type=bind,target=.,rw \
     --mount=type=tmpfs,target=cli/winresources/dockerd \
     --mount=type=tmpfs,target=cli/winresources/docker-proxy \
     --mount=type=cache,target=/root/.cache/go-build,id=moby-build-$TARGETPLATFORM <<EOT

--- a/builder/builder-next/worker/worker.go
+++ b/builder/builder-next/worker/worker.go
@@ -49,8 +49,16 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
+var (
+	// buildkitVersion holds the version number. Filled in at linking time.
+	buildkitVersion = "v0.0.0+unknown"
+	// buildkitRevision holds the VCS revision. Filled in at linking time.
+	buildkitRevision = ""
+)
+
 func init() {
-	version.Version = "v0.11.0-rc3"
+	version.Version = buildkitVersion
+	version.Revision = buildkitRevision
 }
 
 const labelCreatedAt = "buildkit/createdat"

--- a/hack/buildkit-ref
+++ b/hack/buildkit-ref
@@ -1,21 +1,36 @@
 #!/usr/bin/env bash
-# This script returns the current BuildKit ref being used in moby.
+# This script returns the current BuildKit version and revision being used in moby.
 
 : "${BUILDKIT_REPO=moby/buildkit}"
 : "${BUILDKIT_REF=}"
 
-if [ -n "$BUILDKIT_REF" ]; then
-	echo "$BUILDKIT_REF"
-	exit 0
-fi
+: "${BUILDKIT_VERSION=}"
+: "${BUILDKIT_REVISION=}"
 
-# get buildkit version from vendor.mod
-BUILDKIT_REF=$(./hack/with-go-mod.sh go list -mod=mod -modfile=vendor.mod -u -m -f '{{.Version}}' "github.com/${BUILDKIT_REPO}")
+if [ -z "$BUILDKIT_REF" ]; then
+	# get buildkit version from vendor.mod if not set
+	BUILDKIT_REF=$(./hack/with-go-mod.sh go list -mod=mod -modfile=vendor.mod -u -m -f '{{.Version}}' "github.com/${BUILDKIT_REPO}")
+fi
 if [[ "${BUILDKIT_REF}" == *-*-* ]]; then
 	# if pseudo-version, figure out just the uncommon sha (https://github.com/golang/go/issues/34745)
 	BUILDKIT_REF=$(echo "${BUILDKIT_REF}" | awk -F"-" '{print $NF}' | awk 'BEGIN{FIELDWIDTHS="7"} {print $1}')
-	# use github api to return full sha to be able to use it as ref
-	BUILDKIT_REF=$(curl -s "https://api.github.com/repos/${BUILDKIT_REPO}/commits/${BUILDKIT_REF}" | jq -r .sha)
+	# use GitHub API to return full sha to be able to use it as ref
+	BUILDKIT_REF=$(curl -s "https://api.github.com/repos/${BUILDKIT_REPO}/commits/${BUILDKIT_REF}" | sed -nE '$!{:a;N;$!ba;s/\n//g;s/"sha":[^"]*"([^"]*)"/\n\1\nSHA/g};/^[^\n]*\nSHA/P;D' | head -n 1)
 fi
+export BUILDKIT_REF
 
-echo "$BUILDKIT_REF"
+repoDir=$(mktemp -d -t buildkit-repo.XXXXXXXXXX)
+trap 'rm -rf "${repoDir}"' EXIT
+
+(
+	cd "$repoDir" || exit
+	git init -q .
+	git remote add origin "https://github.com/${BUILDKIT_REPO}.git"
+	git fetch -q origin "${BUILDKIT_REF}" +refs/tags/*:refs/tags/*
+	git checkout -q FETCH_HEAD
+	git describe --match 'v[0-9]*' --dirty='.m' --always --tags > .bkversion
+	git rev-parse HEAD > .bkrevision
+)
+
+export "BUILDKIT_VERSION=$(cat "$repoDir"/.bkversion)"
+export "BUILDKIT_REVISION=$(cat "$repoDir"/.bkrevision)"

--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -62,6 +62,15 @@ source "${MAKEDIR}/.go-autogen"
 		fi
 	fi
 
+	# Set buildkit version and revision
+	. hack/buildkit-ref
+	if [ -n "$BUILDKIT_VERSION" ]; then
+		LDFLAGS="${LDFLAGS} -X \"github.com/docker/docker/builder/builder-next/worker.buildkitVersion=${BUILDKIT_VERSION}\" "
+		if [ -n "$BUILDKIT_REVISION" ]; then
+			LDFLAGS="${LDFLAGS} -X \"github.com/docker/docker/builder/builder-next/worker.buildkitRevision=${BUILDKIT_REVISION}\" "
+		fi
+	fi
+
 	echo "Building $([ "$DOCKER_STATIC" = "1" ] && echo "static" || echo "dynamic") $DEST/$BINARY_FULLNAME ($PLATFORM_NAME)..."
 	if [ -n "$DOCKER_DEBUG" ]; then
 		set -x

--- a/hack/with-go-mod.sh
+++ b/hack/with-go-mod.sh
@@ -9,7 +9,7 @@
 set -e
 
 SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOTDIR="$(git -C "$SCRIPTDIR" rev-parse --show-toplevel)"
+ROOTDIR="${SCRIPTDIR}/.."
 
 if test -e "${ROOTDIR}/go.mod"; then
 	{
@@ -18,13 +18,7 @@ if test -e "${ROOTDIR}/go.mod"; then
 		echo "${scriptname}: WARN: Using your go.mod instead of our generated version -- this may misbehave!"
 	} >&2
 else
-	set -x
-
-	tee "${ROOTDIR}/go.mod" >&2 <<- EOF
-		module github.com/docker/docker
-
-		go 1.19
-	EOF
+	printf '%s\n\n%s' 'module github.com/docker/docker' 'go 1.19' > "${ROOTDIR}/go.mod"
 	trap 'rm -f "${ROOTDIR}/go.mod"' EXIT
 fi
 


### PR DESCRIPTION
follow-up https://github.com/moby/moby/pull/44686#discussion_r1094416821

**- What I did**

We should set the BuildKit version and revision at build time so we make sure we are aligned with the expected vendoring.

Also needs to remove the dependency on git in `with-go-mod.sh` script as we ignore `.git` folder in `.dockerignore`, otherwise it fails. And needs to make bind mount writable for the `go.mod` file as well.

**- How I did it**

Use go mod tooling and ldflags to set BuildKit version at build time.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

