### PR TITLE
gha: switch buildkit back to upstream for testing

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -69,11 +69,10 @@ jobs:
       -
         name: BuildKit ref
         run: |
-          # FIXME(tonistiigi) test suite needs patch moby/buildkit#3567
-          # echo "BUILDKIT_REPO=moby/buildkit" >> $GITHUB_ENV
+          echo "BUILDKIT_REPO=moby/buildkit" >> $GITHUB_ENV
+          # FIXME(thaJeztah) remove when updating BuildKit to v0.11.3
           # echo "BUILDKIT_REF=$(./hack/buildkit-ref)" >> $GITHUB_ENV
-          echo "BUILDKIT_REPO=tonistiigi/buildkit" >> $GITHUB_ENV
-          echo "BUILDKIT_REF=db67180a1a439efb1547ecf5decd4003ec8f621b" >> $GITHUB_ENV
+          echo "BUILDKIT_REF=09223a2c58d06e0333b48107be5490397d11e65a" >> $GITHUB_ENV
         working-directory: moby
       -
         name: Checkout BuildKit ${{ env.BUILDKIT_REF }}

--- a/vendor.mod
+++ b/vendor.mod
@@ -56,7 +56,7 @@ require (
 	github.com/klauspost/compress v1.15.12
 	github.com/miekg/dns v1.1.43
 	github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
-	github.com/moby/buildkit v0.11.2
+	github.com/moby/buildkit v0.11.2 // FIXME(thaJeztah): remove override from .github/workflows/buildkit.yml when updating to v0.11.3
 	github.com/moby/ipvs v1.1.0
 	github.com/moby/locker v1.0.1
 	github.com/moby/patternmatcher v0.5.0


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/44686
- https://github.com/moby/buildkit/pull/3578
- https://github.com/moby/buildkit/pull/3584



commit 043dbc05dfacfe3d8bc2e7297fa78e861c89cd85 (https://github.com/moby/moby/pull/44686) temporarily switched to a fork of BuildKit to workaround a failure in CI. These fixes have been backported to the v0.11 branch in BuildKit, so we can switch back to upstream.

We can remove this override once we update vendor.mod to BuildKit v0.11.3.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

