### PR TITLE
Dockerfile: configure code dir as "safe" directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -490,6 +490,9 @@ RUN ln -sfv /go/src/github.com/docker/docker/.bashrc ~/.bashrc
 RUN echo "source /usr/share/bash-completion/bash_completion" >> /etc/bash.bashrc
 RUN ln -s /usr/local/completion/bash/docker /etc/bash_completion.d/docker
 RUN ldconfig
+# Set dev environment as safe git directory to prevent "dubious ownership" errors
+# when bind-mounting the source into the dev-container. See https://github.com/moby/moby/pull/44930
+RUN git config --global --add safe.directory $GOPATH/src/github.com/docker/docker
 # This should only install packages that are specifically needed for the dev environment and nothing else
 # Do you really need to add another package here? Can it be done in a different build stage?
 RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,target=/var/lib/apt \


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/44929#issuecomment-1418907922
- may be related to https://github.com/actions/runner-images/issues/6775


CI is failing when bind-mounting source from the host into the dev-container;

    fatal: detected dubious ownership in repository at '/go/src/github.com/docker/docker'
    To add an exception for this directory, call:

        git config --global --add safe.directory /go/src/github.com/docker/docker

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

