### PR TITLE
[23.0 backport] libnet/d/ipvlan: gracefully migrate from older dbs

### DIFF
--- a/libnetwork/drivers/ipvlan/ipvlan_store.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_store.go
@@ -193,7 +193,12 @@ func (config *configuration) UnmarshalJSON(b []byte) error {
 	config.Mtu = int(nMap["Mtu"].(float64))
 	config.Parent = nMap["Parent"].(string)
 	config.IpvlanMode = nMap["IpvlanMode"].(string)
-	config.IpvlanFlag = nMap["IpvlanFlag"].(string)
+	if v, ok := nMap["IpvlanFlag"]; ok {
+		config.IpvlanFlag = v.(string)
+	} else {
+		// Migrate config from an older daemon which did not have the flag configurable.
+		config.IpvlanFlag = flagBridge
+	}
 	config.Internal = nMap["Internal"].(bool)
 	config.CreatedSlaveLink = nMap["CreatedSubIface"].(bool)
 	if v, ok := nMap["Ipv4Subnets"]; ok {


### PR DESCRIPTION
- v23.0 backport of #44935 
- Fixes #44925

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
IPVLAN networks created on Moby v20.10 do not have the IpvlanFlag configuration value persisted in the libnetwork database as that config value did not exist before v23.0.0. Gracefully migrate configurations on unmarshal to prevent type-assertion panics at daemon start after upgrade.

**- How I did it**

**- How to verify it**
1. Create an IPVLAN network with Moby v20.10.x
2. Upgrade dockerd, or copy `/var/lib/docker/network/files/local-kv.db` into an upgraded installation
3. Start the upgraded daemon and inspect the aforementioned network

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Fixed an issue which prevented the daemon from starting upon upgrade from v20.10 or earlier when an IPVLAN network is configured.

**- A picture of a cute animal (not mandatory but encouraged)**

