### PR TITLE
[23.0 backport] apparmor: Check if apparmor_parser is available

### DIFF
--- a/daemon/apparmor_default.go
+++ b/daemon/apparmor_default.go
@@ -5,15 +5,23 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"fmt"
+	"os"
+	"sync"
 
 	"github.com/containerd/containerd/pkg/apparmor"
 	aaprofile "github.com/docker/docker/profiles/apparmor"
+	"github.com/sirupsen/logrus"
 )
 
 // Define constants for native driver
 const (
 	unconfinedAppArmorProfile = "unconfined"
 	defaultAppArmorProfile    = "docker-default"
+)
+
+var (
+	checkAppArmorOnce   sync.Once
+	isAppArmorAvailable bool
 )
 
 // DefaultApparmorProfile returns the name of the default apparmor profile
@@ -25,7 +33,20 @@ func DefaultApparmorProfile() string {
 }
 
 func ensureDefaultAppArmorProfile() error {
-	if apparmor.HostSupports() {
+	checkAppArmorOnce.Do(func() {
+		if apparmor.HostSupports() {
+			// Restore the apparmor_parser check removed in containerd:
+			// https://github.com/containerd/containerd/commit/1acca8bba36e99684ee3489ea4a42609194ca6b9
+			// Fixes: https://github.com/moby/moby/issues/44900
+			if _, err := os.Stat("/sbin/apparmor_parser"); err == nil {
+				isAppArmorAvailable = true
+			} else {
+				logrus.Warn("AppArmor enabled on system but \"apparmor_parser\" binary is missing, so profile can't be loaded")
+			}
+		}
+	})
+
+	if isAppArmorAvailable {
 		loaded, err := aaprofile.IsLoaded(defaultAppArmorProfile)
 		if err != nil {
 			return fmt.Errorf("Could not check if %s AppArmor profile was loaded: %s", defaultAppArmorProfile, err)


### PR DESCRIPTION
- backports: https://github.com/moby/moby/pull/44902
- fixes: https://github.com/moby/moby/issues/44900
- related to: https://github.com/moby/moby/pull/42276


`hostSupports` doesn't check if the apparmor_parser is available. It's possible in some environments that the apparmor will be enabled but the tool to load the profile is not available which will cause the ensureDefaultAppArmorProfile to fail completely.

This patch checks if the apparmor_parser is available. Otherwise the function returns early, but still logs a warning to the daemon log.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>
(cherry picked from commit ab3fa46502381293b7dc5526c296e7e598d1983b)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

