### PR TITLE
pkg/sysinfo: move MemInfo and ReadMemInfo to a separate package

### DIFF
--- a/daemon/info.go
+++ b/daemon/info.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/pkg/fileutils"
+	"github.com/docker/docker/pkg/meminfo"
 	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/parsers/operatingsystem"
 	"github.com/docker/docker/pkg/platform"
@@ -249,11 +250,11 @@ func kernelVersion() string {
 	return kernelVersion
 }
 
-func memInfo() *sysinfo.Memory {
-	memInfo, err := sysinfo.ReadMemInfo()
+func memInfo() *meminfo.Memory {
+	memInfo, err := meminfo.Read()
 	if err != nil {
 		logrus.Errorf("Could not read system memory info: %v", err)
-		memInfo = &sysinfo.Memory{}
+		memInfo = &meminfo.Memory{}
 	}
 	return memInfo
 }

--- a/daemon/stats_collector.go
+++ b/daemon/stats_collector.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/daemon/stats"
-	"github.com/docker/docker/pkg/sysinfo"
+	"github.com/docker/docker/pkg/meminfo"
 )
 
 // newStatsCollector returns a new statsCollector that collections
@@ -15,7 +15,7 @@ import (
 func (daemon *Daemon) newStatsCollector(interval time.Duration) *stats.Collector {
 	// FIXME(vdemeester) move this elsewhere
 	if runtime.GOOS == "linux" {
-		meminfo, err := sysinfo.ReadMemInfo()
+		meminfo, err := meminfo.Read()
 		if err == nil && meminfo.MemTotal > 0 {
 			daemon.machineMemory = uint64(meminfo.MemTotal)
 		}

--- a/pkg/meminfo/meminfo.go
+++ b/pkg/meminfo/meminfo.go
@@ -1,9 +1,11 @@
-package sysinfo
+// Package meminfo provides utilites to retrieve memory statistics of
+// the host system.
+package meminfo
 
-// ReadMemInfo retrieves memory statistics of the host system and returns a
+// Read retrieves memory statistics of the host system and returns a
 // Memory type. It is only supported on Linux and Windows, and returns an
 // error on other platforms.
-func ReadMemInfo() (*Memory, error) {
+func Read() (*Memory, error) {
 	return readMemInfo()
 }
 

--- a/pkg/meminfo/meminfo_linux.go
+++ b/pkg/meminfo/meminfo_linux.go
@@ -1,4 +1,4 @@
-package sysinfo
+package meminfo
 
 import (
 	"bufio"

--- a/pkg/meminfo/meminfo_unix_test.go
+++ b/pkg/meminfo/meminfo_unix_test.go
@@ -1,7 +1,7 @@
 //go:build linux || freebsd
 // +build linux freebsd
 
-package sysinfo
+package meminfo
 
 import (
 	"strings"

--- a/pkg/meminfo/meminfo_unsupported.go
+++ b/pkg/meminfo/meminfo_unsupported.go
@@ -1,7 +1,7 @@
 //go:build !linux && !windows
 // +build !linux,!windows
 
-package sysinfo
+package meminfo
 
 import "errors"
 

--- a/pkg/meminfo/meminfo_windows.go
+++ b/pkg/meminfo/meminfo_windows.go
@@ -1,4 +1,4 @@
-package sysinfo
+package meminfo
 
 import (
 	"unsafe"
@@ -26,7 +26,7 @@ type memorystatusex struct {
 	ullAvailExtendedVirtual uint64
 }
 
-// ReadMemInfo retrieves memory statistics of the host system and returns a
+// readMemInfo retrieves memory statistics of the host system and returns a
 // Memory type.
 func readMemInfo() (*Memory, error) {
 	msi := &memorystatusex{

--- a/pkg/system/meminfo_deprecated.go
+++ b/pkg/system/meminfo_deprecated.go
@@ -1,16 +1,16 @@
 package system
 
-import "github.com/docker/docker/pkg/sysinfo"
+import "github.com/docker/docker/pkg/meminfo"
 
 // MemInfo contains memory statistics of the host system.
 //
-// Deprecated: use [sysinfo.Memory].
-type MemInfo = sysinfo.Memory
+// Deprecated: use [meminfo.Memory].
+type MemInfo = meminfo.Memory
 
 // ReadMemInfo retrieves memory statistics of the host system and returns a
 // MemInfo type.
 //
-// Deprecated: use [sysinfo.ReadMemInfo].
-func ReadMemInfo() (*sysinfo.Memory, error) {
-	return sysinfo.ReadMemInfo()
+// Deprecated: use [meminfo.Read].
+func ReadMemInfo() (*meminfo.Memory, error) {
+	return meminfo.Read()
 }


### PR DESCRIPTION
Commit 6a516acb2e720b7a01d27c7df9cfe9857c013308 (https://github.com/moby/moby/pull/44663) moved the MemInfo type and ReadMemInfo() function into the pkg/sysinfo package. In an attempt to assist consumers of these to migrate to the new location, an alias was added.

Unfortunately, the side effect of this alias is that pkg/system now depends on pkg/sysinfo, which means that consumers of this (such as docker/cli) now get all (indirect) dependencies of that package as dependency, which includes many dependencies that should only be needed for the daemon / runtime;

- github.com/cilium/ebpf
- github.com/containerd/cgroups
- github.com/coreos/go-systemd/v22
- github.com/godbus/dbus/v5
- github.com/moby/sys/mountinfo
- github.com/opencontainers/runtime-spec

This patch moves the MemInfo related code to its own package. As the previous move
was not yet part of a release, we're not adding new aliases in pkg/sysinfo.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

