### PR TITLE
[23.0 backport] ci: fix branch filter pattern in buildkit workflow

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches:
       - 'master'
-      - '[0-9]+.[0-9]{2}'
+      - '[0-9]+.[0-9]+'
   pull_request:
 
 env:


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/44950

(cherry picked from commit 80f8432b52101da0d9dde948a414288778043bd3)

---

**- What I did**

BuildKit tests were not running when merged to a release branch. Looks like an oversight in https://github.com/moby/moby/pull/44158.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


