### PR TITLE
Fix TLS configuration resolution for buildkit

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -7,8 +7,10 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -59,6 +61,7 @@ import (
 	volumesservice "github.com/docker/docker/volume/service"
 	"github.com/moby/buildkit/util/resolver"
 	resolverconfig "github.com/moby/buildkit/util/resolver/config"
+	"github.com/moby/buildkit/util/tracing"
 	"github.com/moby/locker"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -159,6 +162,30 @@ func (daemon *Daemon) UsesSnapshotter() bool {
 	return false
 }
 
+// testHookHostCertsDir overrides the behavior of registryHostCertsDir if it is non-nil.
+//
+// Functions assigned to this variable are expected to return a string representing a
+// path to a directory which the process may read and list (execute), which SHOULD contain
+// some combination of readable files `ca.crt`, `client.cert`, and `client.key` compliant with
+// the behavior documented at https://docs.docker.com/engine/security/certificates/.
+var testHookHostCertsDir func(string) string
+
+// registryHostCertsDir is an alias of registry.HostCertsDir that can be overridden.
+//
+// Its behavior is identical to that of registry.HostCertsDir if and only if
+// `testHookHostCertsDir` is `nil`. Otherwise, the function assigned to
+// `testHookHostCertsDir` overrides the behavior of `registry.HostCertsDir`.
+//
+// The intent of this method is to avoid the global, mutable state that is the
+// filesystem, isolating tests from each other and from one's actual host certificate
+// configuration.
+func registryHostCertsDir(host string) string {
+	if testHookHostCertsDir != nil {
+		return testHookHostCertsDir(host)
+	}
+	return registry.HostCertsDir(host)
+}
+
 // RegistryHosts returns registry configuration in containerd resolvers format
 func (daemon *Daemon) RegistryHosts() docker.RegistryHosts {
 	var (
@@ -199,22 +226,59 @@ func (daemon *Daemon) RegistryHosts() docker.RegistryHosts {
 	}
 
 	for k, v := range m {
-		v.TLSConfigDir = []string{registry.HostCertsDir(k)}
+		v.TLSConfigDir = []string{registryHostCertsDir(k)}
 		m[k] = v
 	}
 
-	certsDir := registry.CertsDir()
-	if fis, err := os.ReadDir(certsDir); err == nil {
-		for _, fi := range fis {
-			if _, ok := m[fi.Name()]; !ok {
-				m[fi.Name()] = resolverconfig.RegistryConfig{
-					TLSConfigDir: []string{filepath.Join(certsDir, fi.Name())},
-				}
-			}
+	resolverConfig := resolver.NewRegistryConfig(m)
+	return func(host string) ([]docker.RegistryHost, error) {
+		if _, ok := m[host]; ok {
+			return resolverConfig(host)
 		}
-	}
 
-	return resolver.NewRegistryConfig(m)
+		tc := new(tls.Config)
+		err := registry.ReadCertsDirectory(tc, registryHostCertsDir(host))
+		if err != nil {
+			return resolverConfig(host)
+		}
+
+		transport := newDefaultTransport()
+		transport.TLSClientConfig = tc
+
+		return []docker.RegistryHost{{
+			Scheme: "https",
+			Client: &http.Client{
+				Transport: tracing.NewTransport(transport),
+			},
+			Host:         host,
+			Path:         "/v2",
+			Capabilities: docker.HostCapabilityPush | docker.HostCapabilityPull | docker.HostCapabilityResolve,
+		}}, nil
+	}
+}
+
+// newDefaultTransport is for pull or push client
+//
+// NOTE: For push, there must disable http2 for https because the flow control
+// will limit data transfer. The net/http package doesn't provide http2 tunable
+// settings which limits push performance.
+//
+// REF: https://github.com/golang/go/issues/14077
+// REF: https://github.com/moby/buildkit/blob/v0.11.2/util/resolver/resolver.go#L185
+func newDefaultTransport() *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 60 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          30,
+		IdleConnTimeout:       120 * time.Second,
+		MaxIdleConnsPerHost:   4,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 5 * time.Second,
+		TLSNextProto:          make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
+	}
 }
 
 func (daemon *Daemon) restore() error {


### PR DESCRIPTION
The resolver in `daemon.(*Daemon).RegistryHosts()` returned `docker.RegistryHost` structs with clients that were not able to authenticate with registries requiring client TLS certificates.

This patch adds a unit test for that functionality, verifying that the `http.Client` in the returned `docker.RegistryHost` is able to perform a TLS Handshake with a mutually-authenticated TLS server after parsing the TLS configuration from the corresponding host certificate directory in a manner consistent with the actual behavior of the `docker image pull` command and the documented behavior for verifying repository clients with certificates [1]. The host certificate directory is constructed in the course of the test.

Additionally, a fix is included in `daemon/daemon.go`, replacing the lines that previously offloaded TLS configuration resolution to the buildkit package for all registries having associated TLS configuration directories with logic that uses the `registry.ReadCertsDirectory` method used elsewhere in this repository for certificate resolution.

It appears to my reading that there is some subtle difference between the TLS configuration resolution in the `registry` package of this repository and that in the `util/resolver` package of the buildkit repository, and that does still leave me with some concerns because the solution I have implemented does not cover every case: TLS configurations for explicitly-declared insecure registries and mirrors of `docker.io` are still resolved by buildkit's resolver, which demonstrably did not work for the general case of secure registries covered by this patch. I suspect there may still be a bug lurking in Buildkit's implementation of the TLS configuration resolution behavior.

1: https://docs.docker.com/engine/security/certificates/

Resolves #38386

Signed-off-by: Peter <peter@psanders.me>

**- What I did**

Change the TLS configuration resolution with the Buildkit builder to (more closely) match the TLS configuration resolution behavior used elsewhere, e.g., in the `docker pull` command.

**- How I did it**

When a registry is not listed as a `docker.io` mirror or an `insecure-registry`, the `(*daemon.Daemon).RegistryHosts` method defaults to using the TLS configuration resolution methods in the `registry` module instead of adding them to the map used to construct the Buildkit `docker.RegistryHosts` resolver. I will note that I'm not entirely convinced that there is not still a bug lurking in that section of the Buildkit repository, but I was not able to identify it.

**- How to verify it**

A unit test was written in which I construct a mutually-authenticated TLS server, resolve the `docker.RegistryHost` configuration, and ensure that the returned `http.Client` is able to connect. This test failed before I started changing the logic contained in `daemon/daemon.go`, and now passes.

**- Description for the changelog**

Fix repository TLS configuration resolution for the buildkit builder

