### PR TITLE
Fix TLS configuration resolution for buildkit

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -7,8 +7,10 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -59,6 +61,7 @@ import (
 	volumesservice "github.com/docker/docker/volume/service"
 	"github.com/moby/buildkit/util/resolver"
 	resolverconfig "github.com/moby/buildkit/util/resolver/config"
+	"github.com/moby/buildkit/util/tracing"
 	"github.com/moby/locker"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -159,6 +162,30 @@ func (daemon *Daemon) UsesSnapshotter() bool {
 	return false
 }
 
+// testHookHostCertsDir overrides the behavior of registryHostCertsDir if it is non-nil.
+//
+// Functions assigned to this variable are expected to return a string representing a
+// path to a directory which the process may read and list (execute), which SHOULD contain
+// some combination of readable files `ca.crt`, `client.cert`, and `client.key` compliant with
+// the behavior documented at https://docs.docker.com/engine/security/certificates/.
+var testHookHostCertsDir func(string) string
+
+// registryHostCertsDir is an alias of registry.HostCertsDir that can be overridden.
+//
+// Its behavior is identical to that of registry.HostCertsDir if and only if
+// `testHookHostCertsDir` is `nil`. Otherwise, the function assigned to
+// `testHookHostCertsDir` overrides the behavior of `registry.HostCertsDir`.
+//
+// The intent of this method is to avoid the global, mutable state that is the
+// filesystem, isolating tests from each other and from one's actual host certificate
+// configuration.
+func registryHostCertsDir(host string) string {
+	if testHookHostCertsDir != nil {
+		return testHookHostCertsDir(host)
+	}
+	return registry.HostCertsDir(host)
+}
+
 // RegistryHosts returns registry configuration in containerd resolvers format
 func (daemon *Daemon) RegistryHosts() docker.RegistryHosts {
 	var (
@@ -199,22 +226,59 @@ func (daemon *Daemon) RegistryHosts() docker.RegistryHosts {
 	}
 
 	for k, v := range m {
-		v.TLSConfigDir = []string{registry.HostCertsDir(k)}
+		v.TLSConfigDir = []string{registryHostCertsDir(k)}
 		m[k] = v
 	}
 
-	certsDir := registry.CertsDir()
-	if fis, err := os.ReadDir(certsDir); err == nil {
-		for _, fi := range fis {
-			if _, ok := m[fi.Name()]; !ok {
-				m[fi.Name()] = resolverconfig.RegistryConfig{
-					TLSConfigDir: []string{filepath.Join(certsDir, fi.Name())},
-				}
-			}
+	resolverConfig := resolver.NewRegistryConfig(m)
+	return func(host string) ([]docker.RegistryHost, error) {
+		if _, ok := m[host]; ok {
+			return resolverConfig(host)
 		}
-	}
 
-	return resolver.NewRegistryConfig(m)
+		tc := new(tls.Config)
+		err := registry.ReadCertsDirectory(tc, registryHostCertsDir(host))
+		if err != nil {
+			return resolverConfig(host)
+		}
+
+		transport := newDefaultTransport()
+		transport.TLSClientConfig = tc
+
+		return []docker.RegistryHost{{
+			Scheme: "https",
+			Client: &http.Client{
+				Transport: tracing.NewTransport(transport),
+			},
+			Host:         host,
+			Path:         "/v2",
+			Capabilities: docker.HostCapabilityPush | docker.HostCapabilityPull | docker.HostCapabilityResolve,
+		}}, nil
+	}
+}
+
+// newDefaultTransport is for pull or push client
+//
+// NOTE: For push, there must disable http2 for https because the flow control
+// will limit data transfer. The net/http package doesn't provide http2 tunable
+// settings which limits push performance.
+//
+// REF: https://github.com/golang/go/issues/14077
+// REF: https://github.com/moby/buildkit/blob/v0.11.2/util/resolver/resolver.go#L185
+func newDefaultTransport() *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 60 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          30,
+		IdleConnTimeout:       120 * time.Second,
+		MaxIdleConnsPerHost:   4,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 5 * time.Second,
+		TLSNextProto:          make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
+	}
 }
 
 func (daemon *Daemon) restore() error {

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1,18 +1,33 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork"
 	"github.com/docker/docker/pkg/idtools"
+	"github.com/docker/docker/registry"
 	volumesservice "github.com/docker/docker/volume/service"
 	"github.com/docker/go-connections/nat"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -311,5 +326,194 @@ func TestFindNetworkErrorType(t *testing.T) {
 	ok := errors.As(err, &nsn)
 	if !errdefs.IsNotFound(err) || !ok {
 		t.Error("The FindNetwork method MUST always return an error that implements the NotFound interface and is ErrNoSuchNetwork")
+	}
+}
+
+// getClientCertificate generates a client TLS certificate.
+//
+// The returned certificate shall be mostly random and only valid
+// for a very narrow time window and is only suited for test use-cases.
+func getClientCertificate(t *testing.T) (*x509.Certificate, *rsa.PrivateKey) {
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		t.Fatalf("Error generating client certificate: %v.", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName: "foo",
+		},
+		DNSNames: []string{"example.com"},
+
+		NotBefore: time.Now().Add(-time.Minute),
+		NotAfter:  time.Now().Add(time.Minute),
+
+		IsCA:     true,
+		KeyUsage: x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageClientAuth,
+			x509.ExtKeyUsageServerAuth,
+		},
+		BasicConstraintsValid: true,
+	}
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Error generating client key: %v.", err)
+	}
+	certBytes, err := x509.CreateCertificate(
+		rand.Reader,
+		template,
+		template,
+		key.Public(),
+		key,
+	)
+	if err != nil {
+		t.Fatalf("Error generating client certificate: %v.", err)
+	}
+	cert, err := x509.ParseCertificate(certBytes)
+	if err != nil {
+		t.Fatalf("Error parsing client certificate: %v.", err)
+	}
+
+	return cert, key
+}
+
+// TestRegistryHosts ensures RegistryHosts returns properly-configured registries.
+//
+// In particular, the test as-written validates the TLS configuration of the
+// returned TLS client matches the TLS configuration encoded in the certs
+// directory: https://docs.docker.com/engine/security/certificates/
+//
+// We construct a TLS configuration and a server requiring that configuration
+// and ensure that we are able to connect to it using the client in the singular
+// docker.RegistryHost returned by the RegistryHosts function for the corresponding
+// name.
+//
+// https://github.com/moby/moby/issues/38386
+func TestRegistryHosts(t *testing.T) {
+	tmp, err := os.MkdirTemp("", "certs.d.*")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory: %v.", err)
+	}
+	defer os.RemoveAll(tmp)
+
+	testHookHostCertsDir = func(host string) string {
+		// Rebase the path returned from HostCertsDir onto
+		// tmp so that this test does not have to maintain a parallel
+		// implementation of any platform-specific differences.
+		//
+		// REF: https://github.com/moby/moby/pull/44955#issuecomment-1422644089
+		return filepath.Join(
+			tmp,
+			filepath.Base(registry.HostCertsDir(host)),
+		)
+	}
+	defer func() {
+		testHookHostCertsDir = nil
+	}()
+
+	cert, key := getClientCertificate(t)
+	cp := x509.NewCertPool()
+	cp.AddCert(cert)
+
+	// Construct a test server.
+	wantStr := "Hello, Client!\n"
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, wantStr)
+	})
+	s := httptest.NewUnstartedServer(h)
+
+	// Server must ensure that the requested client certificate is presented.
+	s.TLS = &tls.Config{
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientCAs:  cp,
+	}
+	s.StartTLS()
+	defer s.Close()
+
+	// s.URL is safely constructed from URL parts and is therefore guaranteed to parse.
+	uri, _ := url.Parse(s.URL)
+
+	// Populate the host certificate configuration directory for the test server with
+	// the server's certificate as the trust pool and the generated client certificate.
+	certsDir := registryHostCertsDir(uri.Host)
+	err = os.MkdirAll(certsDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create host certificate directory: %v.", err)
+	}
+
+	certOut, err := os.Create(filepath.Join(certsDir, "client.cert"))
+	if err != nil {
+		t.Fatalf("Failed to open client.cert for writing: %v.", err)
+	}
+	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}); err != nil {
+		t.Fatalf("Failed to write data to client.cert: %v.", err)
+	}
+	if err := certOut.Close(); err != nil {
+		t.Fatalf("Error closing client.cert: %v.", err)
+	}
+
+	certOut, err = os.Create(filepath.Join(certsDir, "ca.crt"))
+	if err != nil {
+		t.Fatalf("Failed to open ca.crt for writing: %v.", err)
+	}
+	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: s.Certificate().Raw}); err != nil {
+		t.Fatalf("Failed to write data to ca.crt: %v", err)
+	}
+	if err := certOut.Close(); err != nil {
+		t.Fatalf("Error closing ca.crt: %v.", err)
+	}
+
+	keyOut, err := os.OpenFile(
+		filepath.Join(certsDir, "client.key"),
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+		0600,
+	)
+	if err != nil {
+		t.Fatalf("Failed to open client.key for writing: %v.", err)
+	}
+	privBytes, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("Unable to marshal private key: %v.", err)
+	}
+	if err := pem.Encode(keyOut, &pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}); err != nil {
+		t.Fatalf("Failed to write data to client.key: %v.", err)
+	}
+	if err := keyOut.Close(); err != nil {
+		t.Fatalf("Error closing client.key: %v.", err)
+	}
+
+	// Actual test starts here. Acquire a registry configuration for the specified host
+	// and ensure that the returned http Client has a valid TLS configuration for the server.
+	d := Daemon{
+		configStore: new(config.Config),
+	}
+	configs, err := d.RegistryHosts()(uri.Host)
+	if err != nil || len(configs) != 1 {
+		t.Errorf(
+			"Daemon{}.RegistryHosts()(%v) = %+v, %v; want one config, nil error",
+			uri.Host,
+			configs,
+			err,
+		)
+	}
+
+	rsp, err := configs[0].Client.Get(uri.String())
+	if err != nil {
+		t.Errorf(
+			"configs[0].Client.Get(uri.String()) = %+v, %v",
+			rsp,
+			err,
+		)
+	}
+	defer rsp.Body.Close()
+	got, err := io.ReadAll(rsp.Body)
+	if err != nil || !cmp.Equal(got, []byte(wantStr)) {
+		t.Errorf(
+			"io.ReadAll(rsp.Body) = %v, %v; want %v, %v",
+			got, err,
+			[]byte(wantStr), nil,
+		)
 	}
 }


### PR DESCRIPTION
The resolver in `daemon.(*Daemon).RegistryHosts()` returned `docker.RegistryHost` structs with clients that were not able to authenticate with registries requiring client TLS certificates.

This patch adds a unit test for that functionality, verifying that the `http.Client` in the returned `docker.RegistryHost` is able to perform a TLS Handshake with a mutually-authenticated TLS server after parsing the TLS configuration from the corresponding host certificate directory in a manner consistent with the actual behavior of the `docker image pull` command and the documented behavior for verifying repository clients with certificates [1]. The host certificate directory is constructed in the course of the test.

Additionally, a fix is included in `daemon/daemon.go`, replacing the lines that previously offloaded TLS configuration resolution to the buildkit package for all registries having associated TLS configuration directories with logic that uses the `registry.ReadCertsDirectory` method used elsewhere in this repository for certificate resolution.

It appears to my reading that there is some subtle difference between the TLS configuration resolution in the `registry` package of this repository and that in the `util/resolver` package of the buildkit repository, and that does still leave me with some concerns because the solution I have implemented does not cover every case: TLS configurations for explicitly-declared insecure registries and mirrors of `docker.io` are still resolved by buildkit's resolver, which demonstrably did not work for the general case of secure registries covered by this patch. I suspect there may still be a bug lurking in Buildkit's implementation of the TLS configuration resolution behavior.

1: https://docs.docker.com/engine/security/certificates/

Resolves #38386

Signed-off-by: Peter <peter@psanders.me>

**- What I did**

Change the TLS configuration resolution with the Buildkit builder to (more closely) match the TLS configuration resolution behavior used elsewhere, e.g., in the `docker pull` command.

**- How I did it**

When a registry is not listed as a `docker.io` mirror or an `insecure-registry`, the `(*daemon.Daemon).RegistryHosts` method defaults to using the TLS configuration resolution methods in the `registry` module instead of adding them to the map used to construct the Buildkit `docker.RegistryHosts` resolver. I will note that I'm not entirely convinced that there is not still a bug lurking in that section of the Buildkit repository, but I was not able to identify it. If such a bug in buildkit exists then it would still affect insecure registries or `docker.io` mirrors that perform client TLS authentication.

**- How to verify it**

A unit test was written in which I construct a mutually-authenticated TLS server, resolve the `docker.RegistryHost` configuration, and ensure that the returned `http.Client` is able to connect. This test failed before I started changing the logic contained in `daemon/daemon.go`, and now passes.

A proper end-to-end verification would involve actually setting up a mutually-authenticated TLS registry and attempting to connect via the workflow described in the referenced issue: #38386

**- Description for the changelog**

Fix repository TLS configuration resolution for the buildkit builder

