### PR TITLE
Dockerfile/shell: Install buildx cli plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ARG XX_VERSION=1.1.2
 
 ARG VPNKIT_VERSION=0.5.0
 ARG DOCKERCLI_VERSION=v17.06.2-ce
+ARG BUILDX_VERSION=0.10.2
 
 ARG SYSTEMD="false"
 ARG DEBIAN_FRONTEND=noninteractive
@@ -438,6 +439,7 @@ FROM binary-dummy AS containerutil-linux
 FROM containerutil-build AS containerutil-windows-amd64
 FROM containerutil-windows-${TARGETARCH} AS containerutil-windows
 FROM containerutil-${TARGETOS} AS containerutil
+FROM docker/buildx-bin:${BUILDX_VERSION} as buildx
 
 FROM base AS dev-systemd-false
 COPY --from=dockercli     /build/ /usr/local/cli
@@ -458,6 +460,7 @@ COPY --from=rootlesskit   /build/ /usr/local/bin/
 COPY --from=vpnkit        /       /usr/local/bin/
 COPY --from=containerutil /build/ /usr/local/bin/
 COPY --from=crun          /build/ /usr/local/bin/
+COPY --from=buildx        /buildx /usr/local/libexec/docker/cli-plugins/docker-buildx
 COPY hack/dockerfile/etc/docker/  /etc/docker/
 ENV PATH=/usr/local/cli:$PATH
 ENV CONTAINERD_ADDRESS=/run/docker/containerd/containerd.sock


### PR DESCRIPTION
Installs the buildx cli plugin in the container shell by default. Previously user had to manually download the buildx binary to use buildkit.

Note: The default cli in shell is v17.06 (🧓🏻), so you still need to provide a more recent cli that's actually able to use the buildx plugin:
```bash
make DOCKER_BUILD_ARGS='--build-arg=DOCKERCLI_VERSION=v20.10.23' shell
```
or
```bash
make DOCKER_CLI_PATH=<your custom build cli binary> shell
```

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>

**- What I did** 
Made buildx available by default in dev shell container.

**- How I did it**
Install buildx binary from `docker/buildx-bin` image.

**- How to verify it**
```bash
$ make DOCKER_BUILD_ARGS='--build-arg=DOCKERCLI_VERSION=v20.10.23' shell
...
root@58a62b814982:/go/src/github.com/docker/docker# docker buildx version
github.com/docker/buildx v0.10.2 00ed17df6d20f3ca4553d45789264cdb78506e5f

```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

