### PR TITLE
[23.0] vendor: update buildkit to latest v0.10

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -49,7 +49,7 @@ require (
 	github.com/klauspost/compress v1.15.12
 	github.com/miekg/dns v1.1.43
 	github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
-	github.com/moby/buildkit v0.10.7-0.20230206124303-b8fdb4b78da0
+	github.com/moby/buildkit v0.10.7-0.20230208155512-4f0ee09c40e2
 	github.com/moby/ipvs v1.1.0
 	github.com/moby/locker v1.0.1
 	github.com/moby/patternmatcher v0.5.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -728,8 +728,8 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
-github.com/moby/buildkit v0.10.7-0.20230206124303-b8fdb4b78da0 h1:ms/fLL8YkmjZQ7/o+QZ2aOjhvY7m3pVilzwwuSaEqaw=
-github.com/moby/buildkit v0.10.7-0.20230206124303-b8fdb4b78da0/go.mod h1:tQuuyTWtOb9D+RE425cwOCUkX0/oZ+5iBZ+uWpWQ9bU=
+github.com/moby/buildkit v0.10.7-0.20230208155512-4f0ee09c40e2 h1:TF8U8vLWgBk9YtxrGqIpHx7/T+qQksNfqmMVGm/16/w=
+github.com/moby/buildkit v0.10.7-0.20230208155512-4f0ee09c40e2/go.mod h1:tQuuyTWtOb9D+RE425cwOCUkX0/oZ+5iBZ+uWpWQ9bU=
 github.com/moby/ipvs v1.1.0 h1:ONN4pGaZQgAx+1Scz5RvWV4Q7Gb+mvfRh3NsPS+1XQQ=
 github.com/moby/ipvs v1.1.0/go.mod h1:4VJMWuf098bsUMmZEiD4Tjk/O7mOn3l1PTD3s4OoYAs=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=

--- a/vendor/github.com/moby/buildkit/cache/metadata.go
+++ b/vendor/github.com/moby/buildkit/cache/metadata.go
@@ -251,7 +251,11 @@ func (md *cacheMetadata) queueMediaType(str string) error {
 }
 
 func (md *cacheMetadata) getSnapshotID() string {
-	return md.GetString(keySnapshot)
+	sid := md.GetString(keySnapshot)
+	if sid == "" {
+		return md.ID()
+	}
+	return sid
 }
 
 func (md *cacheMetadata) queueSnapshotID(str string) error {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -486,7 +486,7 @@ github.com/mistifyio/go-zfs
 # github.com/mitchellh/hashstructure/v2 v2.0.2
 ## explicit; go 1.14
 github.com/mitchellh/hashstructure/v2
-# github.com/moby/buildkit v0.10.7-0.20230206124303-b8fdb4b78da0
+# github.com/moby/buildkit v0.10.7-0.20230208155512-4f0ee09c40e2
 ## explicit; go 1.17
 github.com/moby/buildkit/api/services/control
 github.com/moby/buildkit/api/types


### PR DESCRIPTION
Brings in https://github.com/moby/buildkit/pull/3595

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
