### PR TITLE
profiles/apparmor, contrib/apparmor: remove version-conditionals from template

### DIFF
--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -20,11 +20,9 @@ profile /usr/bin/docker (attach_disconnected, complain) {
 
   umount,
   pivot_root,
-{{if ge .Version 209000}}
   signal (receive) peer=@{profile_name},
   signal (receive) peer=unconfined,
   signal (send),
-{{end}}
   network,
   capability,
   owner /** rw,
@@ -47,12 +45,10 @@ profile /usr/bin/docker (attach_disconnected, complain) {
   /etc/ld.so.cache r,
   /etc/passwd r,
 
-{{if ge .Version 209000}}
   ptrace peer=@{profile_name},
   ptrace (read) peer=docker-default,
   deny ptrace (trace) peer=docker-default,
   deny ptrace peer=/usr/bin/docker///bin/ps,
-{{end}}
 
   /usr/lib/** rm,
   /lib/** rm,
@@ -73,11 +69,9 @@ profile /usr/bin/docker (attach_disconnected, complain) {
   /sbin/zfs rCx,
   /sbin/apparmor_parser rCx,
 
-{{if ge .Version 209000}}
   # Transitions
   change_profile -> docker-*,
   change_profile -> unconfined,
-{{end}}
 
   profile /bin/cat (complain) {
     /etc/ld.so.cache r,
@@ -99,10 +93,8 @@ profile /usr/bin/docker (attach_disconnected, complain) {
     /dev/null rw,
     /bin/ps mr,
 
-{{if ge .Version 209000}}
     # We don't need ptrace so we'll deny and ignore the error.
     deny ptrace (read, trace),
-{{end}}
 
     # Quiet dac_override denials
     deny capability dac_override,
@@ -120,15 +112,11 @@ profile /usr/bin/docker (attach_disconnected, complain) {
     /proc/tty/drivers r,
   }
   profile /sbin/iptables (complain) {
-{{if ge .Version 209000}}
     signal (receive) peer=/usr/bin/docker,
-{{end}}
     capability net_admin,
   }
   profile /sbin/auplink flags=(attach_disconnected, complain) {
-{{if ge .Version 209000}}
     signal (receive) peer=/usr/bin/docker,
-{{end}}
     capability sys_admin,
     capability dac_override,
 
@@ -147,9 +135,7 @@ profile /usr/bin/docker (attach_disconnected, complain) {
     /proc/[0-9]*/mounts rw,
   }
   profile /sbin/modprobe /bin/kmod (complain) {
-{{if ge .Version 209000}}
     signal (receive) peer=/usr/bin/docker,
-{{end}}
     capability sys_module,
     /etc/ld.so.cache r,
     /lib/** rm,

--- a/profiles/apparmor/template.go
+++ b/profiles/apparmor/template.go
@@ -24,14 +24,12 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   capability,
   file,
   umount,
-{{if ge .Version 208096}}
   # Host (privileged) processes may send signals to container processes.
   signal (receive) peer=unconfined,
   # dockerd may send signals to container processes (for "docker kill").
   signal (receive) peer={{.DaemonProfile}},
   # Container processes may send signals amongst themselves.
   signal (send,receive) peer={{.Name}},
-{{end}}
 
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**
@@ -51,9 +49,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   deny /sys/firmware/** rwklx,
   deny /sys/kernel/security/** rwklx,
 
-{{if ge .Version 208095}}
   # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
   ptrace (trace,read,tracedby,readby) peer={{.Name}},
-{{end}}
 }
 `


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/44902#issuecomment-1419368714

These conditions were added in 8cf89245f5b5f9abb066f599cb69bfe0202bae5d (https://github.com/moby/moby/pull/17002)
to account for old versions of debian/ubuntu (apparmor_parser < 2.8.95)
that lacked some options;

> This allows us to use the apparmor profile we have in contrib/apparmor/
> and solves the problems where certain functions are not apparent on older
> versions of apparmor_parser on debian/ubuntu.

Those patches were from 2015/2016, and all currently supported distro
versions should now have more current versions than that. Looking at the
oldest supported versions;

Ubuntu 18.04 "Bionic":

    apparmor_parser --version
    AppArmor parser version 2.12
    Copyright (C) 1999-2008 Novell Inc.
    Copyright 2009-2012 Canonical Ltd.

Debian 10 "Buster"

    apparmor_parser --version
    AppArmor parser version 2.13.2
    Copyright (C) 1999-2008 Novell Inc.
    Copyright 2009-2018 Canonical Ltd.

This patch removes the conditionals.



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

