### PR TITLE
libnetwork/ipam: stop eagerly stringifying debug logs

### DIFF
--- a/libnetwork/ipam/allocator.go
+++ b/libnetwork/ipam/allocator.go
@@ -204,7 +204,7 @@ func (a *Allocator) retrieveBitmask(k SubnetKey, n *net.IPNet) (*bitseq.Handle, 
 	bm, ok := a.addresses[k]
 	a.Unlock()
 	if !ok {
-		logrus.Debugf("Retrieving bitmask (%s, %s)", k.String(), n.String())
+		logrus.Debugf("Retrieving bitmask (%s, %s)", k, n)
 		if err := a.insertBitMask(k, n); err != nil {
 			return nil, types.InternalErrorf("could not find bitmask for %s", k.String())
 		}
@@ -380,7 +380,7 @@ func (a *Allocator) ReleaseAddress(poolID string, address net.IP) error {
 		return types.InternalErrorf("could not find bitmask for %s on address %v release from pool %s: %v",
 			k.String(), address, poolID, err)
 	}
-	defer logrus.Debugf("Released address PoolID:%s, Address:%v Sequence:%s", poolID, address, bm.String())
+	defer logrus.Debugf("Released address PoolID:%s, Address:%v Sequence:%s", poolID, address, bm)
 
 	return bm.Unset(ipToUint64(h))
 }
@@ -392,7 +392,7 @@ func (a *Allocator) getAddress(nw *net.IPNet, bitmask *bitseq.Handle, prefAddres
 		base    *net.IPNet
 	)
 
-	logrus.Debugf("Request address PoolID:%v %s Serial:%v PrefAddress:%v ", nw, bitmask.String(), serial, prefAddress)
+	logrus.Debugf("Request address PoolID:%v %s Serial:%v PrefAddress:%v ", nw, bitmask, serial, prefAddress)
 	base = types.GetIPNetCopy(nw)
 
 	if bitmask.Unselected() == 0 {


### PR DESCRIPTION
The (*bitmap.Handle).String() method can be rather expensive to call. It is all the more tragic when the expensively-constructed string is immediately discarded because the log level is not high enough. Let logrus stringify the arguments to debug logs so they are only stringified when the log level is high enough.

    # Before
    ok  	github.com/docker/docker/libnetwork/ipam	10.159s
    # After
    ok  	github.com/docker/docker/libnetwork/ipam	2.484s

Signed-off-by: Cory Snider <csnider@mirantis.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

