### PR TITLE
libnetwork/ipam: refactor all the things

### DIFF
--- a/libnetwork/ipam/allocator.go
+++ b/libnetwork/ipam/allocator.go
@@ -89,8 +89,7 @@ retry:
 		return "", nil, nil, err
 	}
 
-	insert, err := aSpace.updatePoolDBOnAdd(*k, nw, ipr, pdf)
-	if err != nil {
+	if err := aSpace.allocateSubnet(*k, nw, ipr, pdf); err != nil {
 		if _, ok := err.(types.MaskableError); ok {
 			logrus.Debugf("Retrying predefined pool search: %v", err)
 			goto retry
@@ -98,7 +97,7 @@ retry:
 		return "", nil, nil, err
 	}
 
-	return k.String(), nw, nil, insert()
+	return k.String(), nw, nil, nil
 }
 
 // ReleasePool releases the address pool identified by the passed id
@@ -114,7 +113,7 @@ func (a *Allocator) ReleasePool(poolID string) error {
 		return err
 	}
 
-	return aSpace.updatePoolDBOnRemoval(k)
+	return aSpace.releaseSubnet(k)
 }
 
 // Given the address space, returns the local or global PoolConfig based on whether the

--- a/libnetwork/ipam/parallel_test.go
+++ b/libnetwork/ipam/parallel_test.go
@@ -41,16 +41,11 @@ func newTestContext(t *testing.T, mask int, options map[string]string) *testCont
 	if err != nil {
 		t.Fatal(err)
 	}
-	a.addrSpaces["giallo"] = &addrSpace{
-		alloc:   a.addrSpaces[localAddressSpace].alloc,
-		subnets: map[SubnetKey]*PoolData{},
-	}
-
 	network := fmt.Sprintf("192.168.100.0/%d", mask)
 	// total ips 2^(32-mask) - 2 (network and broadcast)
 	totalIps := 1<<uint(32-mask) - 2
 
-	pid, _, _, err := a.RequestPool("giallo", network, "", nil, false)
+	pid, _, _, err := a.RequestPool(localAddressSpace, network, "", nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/ipam/structures.go
+++ b/libnetwork/ipam/structures.go
@@ -29,6 +29,11 @@ type PoolData struct {
 type addrSpace struct {
 	subnets map[SubnetKey]*PoolData
 	alloc   *Allocator
+
+	// Predefined pool for the address space
+	predefined           []*net.IPNet
+	predefinedStartIndex int
+
 	sync.Mutex
 }
 

--- a/libnetwork/ipam/utils.go
+++ b/libnetwork/ipam/utils.go
@@ -1,75 +1,48 @@
 package ipam
 
 import (
-	"fmt"
 	"net"
+	"net/netip"
 
-	"github.com/docker/docker/libnetwork/types"
+	"github.com/docker/docker/libnetwork/ipbits"
 )
 
-type ipVersion int
-
-const (
-	v4 = 4
-	v6 = 6
-)
-
-func getAddressRange(nw, masterNw *net.IPNet) (*AddressRange, error) {
-	lIP, e := types.GetHostPartIP(nw.IP, masterNw.Mask)
-	if e != nil {
-		return nil, fmt.Errorf("failed to compute range's lowest ip address: %v", e)
+func toIPNet(p netip.Prefix) *net.IPNet {
+	if !p.IsValid() {
+		return nil
 	}
-	bIP, e := types.GetBroadcastIP(nw.IP, nw.Mask)
-	if e != nil {
-		return nil, fmt.Errorf("failed to compute range's broadcast ip address: %v", e)
-	}
-	hIP, e := types.GetHostPartIP(bIP, masterNw.Mask)
-	if e != nil {
-		return nil, fmt.Errorf("failed to compute range's highest ip address: %v", e)
-	}
-	return &AddressRange{nw, ipToUint64(types.GetMinimalIP(lIP)), ipToUint64(types.GetMinimalIP(hIP))}, nil
-}
-
-// It generates the ip address in the passed subnet specified by
-// the passed host address ordinal
-func generateAddress(ordinal uint64, network *net.IPNet) net.IP {
-	var address [16]byte
-
-	// Get network portion of IP
-	if getAddressVersion(network.IP) == v4 {
-		copy(address[:], network.IP.To4())
-	} else {
-		copy(address[:], network.IP)
-	}
-
-	end := len(network.Mask)
-	addIntToIP(address[:end], ordinal)
-
-	return net.IP(address[:end])
-}
-
-func getAddressVersion(ip net.IP) ipVersion {
-	if ip.To4() == nil {
-		return v6
-	}
-	return v4
-}
-
-// Adds the ordinal IP to the current array
-// 192.168.0.0 + 53 => 192.168.0.53
-func addIntToIP(array []byte, ordinal uint64) {
-	for i := len(array) - 1; i >= 0; i-- {
-		array[i] |= (byte)(ordinal & 0xff)
-		ordinal >>= 8
+	return &net.IPNet{
+		IP:   p.Addr().AsSlice(),
+		Mask: net.CIDRMask(p.Bits(), p.Addr().BitLen()),
 	}
 }
 
-// Convert an ordinal to the respective IP address
-func ipToUint64(ip []byte) (value uint64) {
-	cip := types.GetMinimalIP(ip)
-	for i := 0; i < len(cip); i++ {
-		j := len(cip) - 1 - i
-		value += uint64(cip[i]) << uint(j*8)
+func toPrefix(n *net.IPNet) (netip.Prefix, bool) {
+	if ll := len(n.Mask); ll != net.IPv4len && ll != net.IPv6len {
+		return netip.Prefix{}, false
 	}
-	return value
+
+	addr, ok := netip.AddrFromSlice(n.IP)
+	if !ok {
+		return netip.Prefix{}, false
+	}
+
+	ones, bits := n.Mask.Size()
+	if ones == 0 && bits == 0 {
+		return netip.Prefix{}, false
+	}
+
+	return netip.PrefixFrom(addr.Unmap(), ones), true
+}
+
+func hostID(addr netip.Addr, bits uint) uint64 {
+	return ipbits.Field(addr, bits, uint(addr.BitLen()))
+}
+
+// subnetRange returns the amount to add to network.Addr() in order to yield the
+// first and last addresses in subnet, respectively.
+func subnetRange(network, subnet netip.Prefix) (start, end uint64) {
+	start = hostID(subnet.Addr(), uint(network.Bits()))
+	end = start + (1 << uint64(subnet.Addr().BitLen()-subnet.Bits())) - 1
+	return start, end
 }

--- a/libnetwork/ipam/utils.go
+++ b/libnetwork/ipam/utils.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/docker/docker/libnetwork/ipamapi"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -15,11 +14,7 @@ const (
 	v6 = 6
 )
 
-func getAddressRange(pool string, masterNw *net.IPNet) (*AddressRange, error) {
-	ip, nw, err := net.ParseCIDR(pool)
-	if err != nil {
-		return nil, ipamapi.ErrInvalidSubPool
-	}
+func getAddressRange(nw, masterNw *net.IPNet) (*AddressRange, error) {
 	lIP, e := types.GetHostPartIP(nw.IP, masterNw.Mask)
 	if e != nil {
 		return nil, fmt.Errorf("failed to compute range's lowest ip address: %v", e)
@@ -32,7 +27,6 @@ func getAddressRange(pool string, masterNw *net.IPNet) (*AddressRange, error) {
 	if e != nil {
 		return nil, fmt.Errorf("failed to compute range's highest ip address: %v", e)
 	}
-	nw.IP = ip
 	return &AddressRange{nw, ipToUint64(types.GetMinimalIP(lIP)), ipToUint64(types.GetMinimalIP(hIP))}, nil
 }
 

--- a/libnetwork/ipbits/ipbits.go
+++ b/libnetwork/ipbits/ipbits.go
@@ -1,0 +1,41 @@
+// Package ipbits contains utilities for manipulating [netip.Addr] values as
+// numbers or bitfields.
+package ipbits
+
+import (
+	"encoding/binary"
+	"net/netip"
+)
+
+// Add returns ip + (x << shift).
+func Add(ip netip.Addr, x uint64, shift uint) netip.Addr {
+	if ip.Is4() {
+		a := ip.As4()
+		addr := binary.BigEndian.Uint32(a[:])
+		addr += uint32(x) << shift
+		binary.BigEndian.PutUint32(a[:], addr)
+		return netip.AddrFrom4(a)
+	} else {
+		a := ip.As16()
+		addr := uint128From16(a)
+		addr = addr.add(uint128From(x).lsh(shift))
+		addr.fill16(&a)
+		return netip.AddrFrom16(a)
+	}
+}
+
+// Field returns the value of the bitfield [u, v] in ip as an integer,
+// where bit 0 is the most-significant bit of ip.
+//
+// The result is undefined if u > v, if v-u > 64, or if u or v is larger than
+// ip.BitLen().
+func Field(ip netip.Addr, u, v uint) uint64 {
+	if ip.Is4() {
+		mask := ^uint32(0) >> u
+		a := ip.As4()
+		return uint64((binary.BigEndian.Uint32(a[:]) & mask) >> (32 - v))
+	} else {
+		mask := uint128From(0).not().rsh(u)
+		return uint128From16(ip.As16()).and(mask).rsh(128 - v).uint64()
+	}
+}

--- a/libnetwork/ipbits/ipbits_test.go
+++ b/libnetwork/ipbits/ipbits_test.go
@@ -1,0 +1,70 @@
+package ipbits
+
+import (
+	"net/netip"
+	"testing"
+)
+
+func TestAdd(t *testing.T) {
+	tests := []struct {
+		in    netip.Addr
+		x     uint64
+		shift uint
+		want  netip.Addr
+	}{
+		{netip.MustParseAddr("10.0.0.1"), 0, 0, netip.MustParseAddr("10.0.0.1")},
+		{netip.MustParseAddr("10.0.0.1"), 41, 0, netip.MustParseAddr("10.0.0.42")},
+		{netip.MustParseAddr("10.0.0.1"), 42, 16, netip.MustParseAddr("10.42.0.1")},
+		{netip.MustParseAddr("10.0.0.1"), 1, 7, netip.MustParseAddr("10.0.0.129")},
+		{netip.MustParseAddr("10.0.0.1"), 1, 24, netip.MustParseAddr("11.0.0.1")},
+		{netip.MustParseAddr("2001::1"), 0, 0, netip.MustParseAddr("2001::1")},
+		{netip.MustParseAddr("2001::1"), 0x41, 0, netip.MustParseAddr("2001::42")},
+		{netip.MustParseAddr("2001::1"), 1, 7, netip.MustParseAddr("2001::81")},
+		{netip.MustParseAddr("2001::1"), 0xcafe, 96, netip.MustParseAddr("2001:cafe::1")},
+		{netip.MustParseAddr("2001::1"), 1, 112, netip.MustParseAddr("2002::1")},
+	}
+
+	for _, tt := range tests {
+		if got := Add(tt.in, tt.x, tt.shift); tt.want != got {
+			t.Errorf("%v + (%v << %v) = %v; want %v", tt.in, tt.x, tt.shift, got, tt.want)
+		}
+	}
+}
+
+func BenchmarkAdd(b *testing.B) {
+	do := func(b *testing.B, addr netip.Addr) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = Add(addr, uint64(i), 0)
+		}
+	}
+
+	b.Run("IPv4", func(b *testing.B) { do(b, netip.IPv4Unspecified()) })
+	b.Run("IPv6", func(b *testing.B) { do(b, netip.IPv6Unspecified()) })
+}
+
+func TestField(t *testing.T) {
+	tests := []struct {
+		in   netip.Addr
+		u, v uint
+		want uint64
+	}{
+		{netip.MustParseAddr("1.2.3.4"), 0, 8, 1},
+		{netip.MustParseAddr("1.2.3.4"), 8, 16, 2},
+		{netip.MustParseAddr("1.2.3.4"), 16, 24, 3},
+		{netip.MustParseAddr("1.2.3.4"), 24, 32, 4},
+		{netip.MustParseAddr("1.2.3.4"), 0, 32, 0x01020304},
+		{netip.MustParseAddr("1.2.3.4"), 0, 28, 0x102030},
+		{netip.MustParseAddr("1234:5678:9abc:def0::7654:3210"), 0, 8, 0x12},
+		{netip.MustParseAddr("1234:5678:9abc:def0::7654:3210"), 8, 16, 0x34},
+		{netip.MustParseAddr("1234:5678:9abc:def0::7654:3210"), 16, 24, 0x56},
+		{netip.MustParseAddr("1234:5678:9abc:def0::7654:3210"), 64, 128, 0x76543210},
+		{netip.MustParseAddr("1234:5678:9abc:def0:beef::7654:3210"), 48, 80, 0xdef0beef},
+	}
+
+	for _, tt := range tests {
+		if got := Field(tt.in, tt.u, tt.v); got != tt.want {
+			t.Errorf("Field(%v, %v, %v) = %v (0x%[4]x); want %v (0x%[5]x)", tt.in, tt.u, tt.v, got, tt.want)
+		}
+	}
+}

--- a/libnetwork/ipbits/uint128.go
+++ b/libnetwork/ipbits/uint128.go
@@ -1,0 +1,62 @@
+package ipbits
+
+import (
+	"encoding/binary"
+	"math/bits"
+)
+
+type uint128 struct{ hi, lo uint64 }
+
+func uint128From16(b [16]byte) uint128 {
+	return uint128{
+		hi: binary.BigEndian.Uint64(b[:8]),
+		lo: binary.BigEndian.Uint64(b[8:]),
+	}
+}
+
+func uint128From(x uint64) uint128 {
+	return uint128{lo: x}
+}
+
+func (x uint128) add(y uint128) uint128 {
+	lo, carry := bits.Add64(x.lo, y.lo, 0)
+	hi, _ := bits.Add64(x.hi, y.hi, carry)
+	return uint128{hi: hi, lo: lo}
+}
+
+func (x uint128) lsh(n uint) uint128 {
+	if n > 64 {
+		return uint128{hi: x.lo << (n - 64)}
+	}
+	return uint128{
+		hi: x.hi<<n | x.lo>>(64-n),
+		lo: x.lo << n,
+	}
+}
+
+func (x uint128) rsh(n uint) uint128 {
+	if n > 64 {
+		return uint128{lo: x.hi >> (n - 64)}
+	}
+	return uint128{
+		hi: x.hi >> n,
+		lo: x.lo>>n | x.hi<<(64-n),
+	}
+}
+
+func (x uint128) and(y uint128) uint128 {
+	return uint128{hi: x.hi & y.hi, lo: x.lo & y.lo}
+}
+
+func (x uint128) not() uint128 {
+	return uint128{hi: ^x.hi, lo: ^x.lo}
+}
+
+func (x uint128) fill16(a *[16]byte) {
+	binary.BigEndian.PutUint64(a[:8], x.hi)
+	binary.BigEndian.PutUint64(a[8:], x.lo)
+}
+
+func (x uint128) uint64() uint64 {
+	return x.lo
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Simplified the implementation of package ipam by:
  - removing the affordances for half-baked and otherwise unused functionality,
  - overhauling the internal data model without datastore concerns, and
  - moving code around to better follow the Single Responsibility Principle.
- Migrated the implementation to use `net/netip` types internally, with thoughtfully-designed address manipulation utilities

I took great care to keep the behaviour as close to that of the original code as possible, including the not-so-great error messages.

**- How I did it**
128-bit arithmetic and lots of iterative refactoring.

I avoided rearranging functions within—or moving them across—source files for ease of review. I recommend using the split view when reviewing.

**- How to verify it**
The existing unit tests are fairly comprehensive, and have done a good job of catching mistakes during development.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
N/A; refactor with no significant user-visible differences

**- A picture of a cute animal (not mandatory but encouraged)**

