### PR TITLE
[23.0] Fix nil pointer dereference when attempting to log DNS errors

### DIFF
--- a/libnetwork/resolver.go
+++ b/libnetwork/resolver.go
@@ -396,7 +396,7 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 	}
 
 	if err != nil {
-		logrus.WithError(err).Errorf("[resolver] failed to handle query: %s (%s) from %s", queryName, dns.TypeToString[queryType], extConn.LocalAddr().String())
+		logrus.WithError(err).Errorf("[resolver] failed to handle query: %s (%s)", queryName, dns.TypeToString[queryType])
 		return
 	}
 


### PR DESCRIPTION

fixes #44979 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This makes sure `dockerd` won't panic and crash from a nil pointer dereference when it sees an invalid DNS query.

**- How I did it**

If the resolver encounters an error before it attempts to forward the request to external DNS, do not try to log information about the external connection, because at this point `extConn` is `nil`

**- How to verify it**

:monocle_face: 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix nil pointer dereference when attempting to log DNS errors

**- A picture of a cute animal (not mandatory but encouraged)**
![ok](https://er0k.org/tmp/hamandcheese.jpg)