### PR TITLE
libnetwork: Add managers for Windows drivers

### DIFF
--- a/libnetwork/drivers/windows/manager.go
+++ b/libnetwork/drivers/windows/manager.go
@@ -1,0 +1,94 @@
+//go:build windows
+// +build windows
+
+package windows
+
+import (
+	"github.com/docker/docker/libnetwork/datastore"
+	"github.com/docker/docker/libnetwork/discoverapi"
+	"github.com/docker/docker/libnetwork/driverapi"
+	"github.com/docker/docker/libnetwork/types"
+)
+
+type manager struct {
+	networkType string
+}
+
+// Register registers a new instance of the manager driver for networkType with r.
+func RegisterManager(r driverapi.Registerer, networkType string) error {
+	if !IsBuiltinLocalDriver(networkType) {
+		return types.BadRequestErrorf("Network type not supported: %s", networkType)
+	}
+	c := driverapi.Capability{
+		DataScope:         datastore.LocalScope,
+		ConnectivityScope: datastore.LocalScope,
+	}
+	return r.RegisterDriver(networkType, &manager{networkType: networkType}, c)
+}
+
+func (d *manager) NetworkAllocate(id string, option map[string]string, ipV4Data, ipV6Data []driverapi.IPAMData) (map[string]string, error) {
+	return nil, types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) NetworkFree(id string) error {
+	return types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) CreateNetwork(id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
+	return types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) EventNotify(etype driverapi.EventType, nid, tableName, key string, value []byte) {
+}
+
+func (d *manager) DecodeTableEntry(tablename string, key string, value []byte) (string, map[string]string) {
+	return "", nil
+}
+
+func (d *manager) DeleteNetwork(nid string) error {
+	return types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
+	return types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) DeleteEndpoint(nid, eid string) error {
+	return types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) EndpointOperInfo(nid, eid string) (map[string]interface{}, error) {
+	return nil, types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+	return types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) Leave(nid, eid string) error {
+	return types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) Type() string {
+	return d.networkType
+}
+
+func (d *manager) IsBuiltIn() bool {
+	return true
+}
+
+func (d *manager) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
+	return types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) DiscoverDelete(dType discoverapi.DiscoveryType, data interface{}) error {
+	return types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
+	return types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) RevokeExternalConnectivity(nid, eid string) error {
+	return types.NotImplementedErrorf("not implemented")
+}


### PR DESCRIPTION
**- What I did**
I noticed that currently we cannot use [Swarm networks with local scope drivers](https://docs.docker.com/engine/reference/commandline/network_create/#swarm-networks-with-local-scope-drivers) configuration on Windows nodes because those are not published on way swarmkit would be able to register them.

There is actually quite many default drivers for Windows in libnetwork
https://github.com/moby/moby/blob/3ba527d82af53cf752aa6ec39daac14626c41b0f/libnetwork/drivers_windows.go#L13-L19
and I didn't found even documentation for all of them so I picked `internal` , `nat` and `l2bridge` drivers to this one as all of those I can imagine real world use case (examples below).

**- How I did it**
Code is copy of Linux brmanager on all of those.

https://github.com/olljanat/swarmkit/commit/26191d64ab0b33a299b4d121910c057af2ccb412 is need to swarmkit after this is merged and moby/moby vendored to there and after that swarmkit needed to be vendored back to here.

**- How to verify it**
`nat` driver example
```powershell
docker network create `
  --config-only `
  --subnet 192.168.101.0/24 `
  --gateway 192.168.101.1 `
  -o com.docker.network.windowsshim.disable_dns=true `
  -o com.docker.network.windowsshim.disable_gatewaydns=true `
  nat-config

docker network create `
  -d nat `
  --scope swarm `
  --config-from nat-config `
  --attachable `
  --internal `
  swarm-nat

docker service create `
  --name=test `
  --network=swarm-nat `
  --publish published=8080,target=80,mode=host `
  mcr.microsoft.com/dotnet/samples:aspnetapp
```

`internal` driver works with same config but it does not implement outgoing NAT. It is also possible to turn it to L3 bridge (like default bridge on Linux works when engine flag `--ip-masq=false` is used) by enabling IP forwarding to interface it creates and the Docker node Ethernet interface (but that is not persistent so I might create another PR to add driver option for that).

Best part is that both of those works even when there is no `ingress` network at all on swarm which means that Docker will not reconfigure `Ethernet` interface to use virtual switch (which is known to causing issues because configuration get removed and re-created everytime when Docker engine reboots.

`l2bridge` can be used with very complex configurations like explained on [L2bridge Container Networking](https://techcommunity.microsoft.com/t5/networking-blog/l2bridge-container-networking/ba-p/1180923)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

