### PR TITLE
containerd integration: handle multi-platform images

### DIFF
--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -4,11 +4,16 @@ import (
 	"context"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/content"
+	cerrdefs "github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/images"
+	cplatforms "github.com/containerd/containerd/platforms"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 )
 
@@ -37,7 +42,7 @@ func (i *ImageService) Images(ctx context.Context, opts types.ImageListOptions) 
 		return nil, err
 	}
 
-	imgs, err := i.client.ListImages(ctx)
+	imgs, err := i.client.ImageService().List(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -66,79 +71,35 @@ func (i *ImageService) Images(ctx context.Context, opts types.ImageListOptions) 
 		layers = make(map[digest.Digest]int)
 	}
 
-	for n, img := range imgs {
+	contentStore := i.client.ContentStore()
+	for _, img := range imgs {
 		if !filter(img) {
 			continue
 		}
 
-		diffIDs, err := img.RootFS(ctx)
-		if err != nil {
-			return nil, err
-		}
-		chainIDs := identity.ChainIDs(diffIDs)
-		if opts.SharedSize {
-			root[n] = &chainIDs
-			for _, id := range chainIDs {
-				layers[id] = layers[id] + 1
-			}
-		}
-
-		size, err := img.Size(ctx)
+		platforms, err := images.Platforms(ctx, contentStore, img.Target)
 		if err != nil {
 			return nil, err
 		}
 
-		virtualSize, err := computeVirtualSize(chainIDs, snapshotSizeFn)
-		if err != nil {
-			return nil, err
-		}
-
-		var repoTags, repoDigests []string
-		rawImg := img.Metadata()
-		target := rawImg.Target.Digest
-
-		logger := logrus.WithFields(logrus.Fields{
-			"name":   img.Name(),
-			"digest": target,
-		})
-
-		ref, err := reference.ParseNamed(rawImg.Name)
-		if err != nil {
-			// If the image has unexpected name format (not a Named reference or a dangling image)
-			// add the offending name to RepoTags but also log an error to make it clear to the
-			// administrator that this is unexpected.
-			// TODO: Reconsider when containerd is more strict on image names, see:
-			//       https://github.com/containerd/containerd/issues/7986
-			if !isDanglingImage(rawImg) {
-				logger.WithError(err).Error("failed to parse image name as reference")
-				repoTags = append(repoTags, img.Name())
-			}
-		} else {
-			repoTags = append(repoTags, reference.TagNameOnly(ref).String())
-
-			digested, err := reference.WithDigest(reference.TrimNamed(ref), target)
+		for _, platform := range platforms {
+			image, chainIDs, err := i.singlePlatformImage(ctx, contentStore, img, platform)
 			if err != nil {
-				logger.WithError(err).Error("failed to create digested reference")
-			} else {
-				repoDigests = append(repoDigests, digested.String())
+				return nil, err
+			}
+			if image == nil {
+				continue
+			}
+
+			summaries = append(summaries, image)
+
+			if opts.SharedSize {
+				root = append(root, &chainIDs)
+				for _, id := range chainIDs {
+					layers[id] = layers[id] + 1
+				}
 			}
 		}
-
-		summaries = append(summaries, &types.ImageSummary{
-			ParentID:    "",
-			ID:          target.String(),
-			Created:     rawImg.CreatedAt.Unix(),
-			RepoDigests: repoDigests,
-			RepoTags:    repoTags,
-			Size:        size,
-			VirtualSize: virtualSize,
-			// -1 indicates that the value has not been set (avoids ambiguity
-			// between 0 (default) and "not set". We cannot use a pointer (nil)
-			// for this, as the JSON representation uses "omitempty", which would
-			// consider both "0" and "nil" to be "empty".
-			SharedSize: -1,
-			Containers: -1,
-		})
 	}
 
 	if opts.SharedSize {
@@ -154,7 +115,98 @@ func (i *ImageService) Images(ctx context.Context, opts types.ImageListOptions) 
 	return summaries, nil
 }
 
-type imageFilterFunc func(image containerd.Image) bool
+func (i *ImageService) singlePlatformImage(ctx context.Context, contentStore content.Store, img images.Image, platform v1.Platform) (*types.ImageSummary, []digest.Digest, error) {
+	platformMatcher := cplatforms.OnlyStrict(platform)
+	available, _, _, missing, err := images.Check(ctx, contentStore, img.Target, platformMatcher)
+	if !available || err != nil || len(missing) > 0 {
+		return nil, nil, nil
+	}
+
+	image := containerd.NewImageWithPlatform(i.client, img, platformMatcher)
+
+	diffIDs, err := image.RootFS(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	chainIDs := identity.ChainIDs(diffIDs)
+
+	size, err := image.Size(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	snapshotter := i.client.SnapshotService(i.snapshotter)
+	sizeCache := make(map[digest.Digest]int64)
+
+	snapshotSizeFn := func(d digest.Digest) (int64, error) {
+		if s, ok := sizeCache[d]; ok {
+			return s, nil
+		}
+		usage, err := snapshotter.Usage(ctx, d.String())
+		if err != nil {
+			if cerrdefs.IsNotFound(err) {
+				return 0, nil
+			}
+			return 0, err
+		}
+		sizeCache[d] = usage.Size
+		return usage.Size, nil
+	}
+	virtualSize, err := computeVirtualSize(chainIDs, snapshotSizeFn)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var repoTags, repoDigests []string
+	rawImg := image.Metadata()
+	target := rawImg.Target.Digest
+
+	logger := logrus.WithFields(logrus.Fields{
+		"name":   rawImg.Name,
+		"digest": target,
+	})
+
+	ref, err := reference.ParseNamed(rawImg.Name)
+	if err != nil {
+		// If the image has unexpected name format (not a Named reference or a dangling image)
+		// add the offending name to RepoTags but also log an error to make it clear to the
+		// administrator that this is unexpected.
+		// TODO: Reconsider when containerd is more strict on image names, see:
+		//       https://github.com/containerd/containerd/issues/7986
+		if !isDanglingImage(rawImg) {
+			logger.WithError(err).Error("failed to parse image name as reference")
+			repoTags = append(repoTags, rawImg.Name)
+		}
+	} else {
+		repoTags = append(repoTags, reference.TagNameOnly(ref).String())
+
+		digested, err := reference.WithDigest(reference.TrimNamed(ref), target)
+		if err != nil {
+			logger.WithError(err).Error("failed to create digested reference")
+		} else {
+			repoDigests = append(repoDigests, digested.String())
+		}
+	}
+
+	summary := &types.ImageSummary{
+		ParentID:    "",
+		ID:          target.String(),
+		Created:     rawImg.CreatedAt.Unix(),
+		RepoDigests: repoDigests,
+		RepoTags:    repoTags,
+		Size:        size,
+		VirtualSize: virtualSize,
+		// -1 indicates that the value has not been set (avoids ambiguity
+		// between 0 (default) and "not set". We cannot use a pointer (nil)
+		// for this, as the JSON representation uses "omitempty", which would
+		// consider both "0" and "nil" to be "empty".
+		SharedSize: -1,
+		Containers: -1,
+	}
+
+	return summary, chainIDs, nil
+}
+
+type imageFilterFunc func(image images.Image) bool
 
 // setupFilters constructs an imageFilterFunc from the given imageFilters.
 //
@@ -169,8 +221,8 @@ func (i *ImageService) setupFilters(ctx context.Context, imageFilters filters.Ar
 		img, err := i.client.GetImage(ctx, ref.String())
 		if img != nil {
 			t := img.Metadata().CreatedAt
-			fltrs = append(fltrs, func(image containerd.Image) bool {
-				created := image.Metadata().CreatedAt
+			fltrs = append(fltrs, func(image images.Image) bool {
+				created := image.CreatedAt
 				return created.Equal(t) || created.After(t)
 			})
 		}
@@ -188,8 +240,8 @@ func (i *ImageService) setupFilters(ctx context.Context, imageFilters filters.Ar
 		img, err := i.client.GetImage(ctx, ref.String())
 		if img != nil {
 			t := img.Metadata().CreatedAt
-			fltrs = append(fltrs, func(image containerd.Image) bool {
-				created := image.Metadata().CreatedAt
+			fltrs = append(fltrs, func(image images.Image) bool {
+				created := image.CreatedAt
 				return created.Equal(t) || created.Before(t)
 			})
 		}
@@ -200,11 +252,11 @@ func (i *ImageService) setupFilters(ctx context.Context, imageFilters filters.Ar
 	}
 
 	if imageFilters.Contains("label") {
-		fltrs = append(fltrs, func(image containerd.Image) bool {
-			return imageFilters.MatchKVList("label", image.Labels())
+		fltrs = append(fltrs, func(image images.Image) bool {
+			return imageFilters.MatchKVList("label", image.Labels)
 		})
 	}
-	return func(image containerd.Image) bool {
+	return func(image images.Image) bool {
 		for _, filter := range fltrs {
 			if !filter(image) {
 				return false


### PR DESCRIPTION
Signed-off-by: Laura Brehm <laurabrehm@hey.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix listing images with containerd store

Upstreams:
- https://github.com/rumpl/moby/pull/113
- https://github.com/rumpl/moby/pull/126

**- How I did it**

Multiple entries are returned for each platform of an image (more discussion here: https://github.com/rumpl/moby/pull/113) – which isn't fantastic, but is better than the current state where listing images is broken.

**- How to verify it**

- `docker pull --platform=linux/amd64 alpine:latest`
- `docker images` (verify it doesn't break)
- `docker pull --platform=[another platform] alpine:latest`
- `docker images` (verify another entry is returned)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

<img width="491" alt="image" src="https://user-images.githubusercontent.com/70572044/218497498-ae606a32-2521-4855-8be5-bed94b3f680a.png">
