### PR TITLE
[23.0 backport] libnetwork: check DNS loopback with user DNS opts

### DIFF
--- a/libnetwork/sandbox_dns_unix.go
+++ b/libnetwork/sandbox_dns_unix.go
@@ -263,7 +263,7 @@ func (sb *sandbox) setupDNS() error {
 		// After building the resolv.conf from the user config save the
 		// external resolvers in the sandbox. Note that --dns 127.0.0.x
 		// config refers to the loopback in the container namespace
-		sb.setExternalResolvers(newRC.Content, resolvconf.IPv4, false)
+		sb.setExternalResolvers(newRC.Content, resolvconf.IPv4, len(sb.config.dnsList) == 0)
 	} else {
 		// If the host resolv.conf file has 127.0.0.x container should
 		// use the host resolver for queries. This is supported by the


### PR DESCRIPTION
- Backport of #44976 to 23.0
- Fixes https://github.com/docker/for-linux/issues/1404
- Closes #43705

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
DNS servers in the loopback address range should always be resolved in the host network namespace when the servers are configured by reading from the host's /etc/resolv.conf. The daemon mistakenly conflated the presence of DNS options (`docker run --dns-opt`) with user-supplied DNS servers, treating the list of servers loaded from the host as a user- supplied list and attempting to resolve in the container's network namespace. Correct this oversight so that loopback DNS servers are only resolved in the container's network namespace when the user provides the DNS server list, irrespective of other DNS configuration.

**- How I did it**
Should be self-explanatory.

**- How to verify it**
Run a daemon on a host with DNS resolved by systemd-resolved or some other configuration with loopback-to-localhost DNS resolution. Run a container attached to a user-defined network with some `--dns-opt` flag and verify that DNS resolves within the container.

```console
$ docker network create br1
006efd576eab62b9503e3d0a8ea642836a01c052c83531e955dd25b7e29fd470
$ docker run --rm --network br1 --dns-opt attempts:1 alpine nslookup google.com
Server:		127.0.0.11
Address:	127.0.0.11:53

Non-authoritative answer:
Name:	google.com
Address: 142.251.41.78

Non-authoritative answer:
Name:	google.com
Address: 2607:f8b0:400b:804::200e
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Fixed an issue which would cause DNS resolution to fail inside containers attached to user-defined networks when the container is created using the `--dns-opt` or `--dns-search` flags and systemd-resolved is used for DNS resolution on the host.

**- A picture of a cute animal (not mandatory but encouraged)**

