### PR TITLE
Migrate away from things deprecated in Go 1.20

### DIFF
--- a/libnetwork/bitmap/sequence_test.go
+++ b/libnetwork/bitmap/sequence_test.go
@@ -827,10 +827,10 @@ func TestRandomAllocateDeallocate(t *testing.T) {
 	hnd := New(uint64(numBits))
 
 	seed := time.Now().Unix()
-	rand.Seed(seed)
+	rng := rand.New(rand.NewSource(seed))
 
 	// Allocate all bits using a random pattern
-	pattern := rand.Perm(numBits)
+	pattern := rng.Perm(numBits)
 	for _, bit := range pattern {
 		err := hnd.Set(uint64(bit))
 		if err != nil {
@@ -845,7 +845,7 @@ func TestRandomAllocateDeallocate(t *testing.T) {
 	}
 
 	// Deallocate all bits using a random pattern
-	pattern = rand.Perm(numBits)
+	pattern = rng.Perm(numBits)
 	for _, bit := range pattern {
 		err := hnd.Unset(uint64(bit))
 		if err != nil {
@@ -882,10 +882,10 @@ func TestAllocateRandomDeallocate(t *testing.T) {
 	}
 
 	seed := time.Now().Unix()
-	rand.Seed(seed)
+	rng := rand.New(rand.NewSource(seed))
 
 	// Deallocate half of the allocated bits following a random pattern
-	pattern := rand.Perm(numBits / 2)
+	pattern := rng.Perm(numBits / 2)
 	for i := 0; i < numBits/4; i++ {
 		bit := pattern[i]
 		err := hnd.Unset(uint64(bit))
@@ -936,10 +936,10 @@ func TestAllocateRandomDeallocateSerialize(t *testing.T) {
 	}
 
 	seed := time.Now().Unix()
-	rand.Seed(seed)
+	rng := rand.New(rand.NewSource(seed))
 
 	// Deallocate half of the allocated bits following a random pattern
-	pattern := rand.Perm(numBits / 2)
+	pattern := rng.Perm(numBits / 2)
 	for i := 0; i < numBits/4; i++ {
 		bit := pattern[i]
 		err := hnd.Unset(uint64(bit))
@@ -981,10 +981,10 @@ func testSetRollover(t *testing.T, serial bool) {
 	}
 
 	seed := time.Now().Unix()
-	rand.Seed(seed)
+	rng := rand.New(rand.NewSource(seed))
 
 	// Deallocate half of the allocated bits following a random pattern
-	pattern := rand.Perm(numBits / 2)
+	pattern := rng.Perm(numBits / 2)
 	for i := 0; i < numBits/4; i++ {
 		bit := pattern[i]
 		err := hnd.Unset(uint64(bit))

--- a/libnetwork/ipam/allocator_test.go
+++ b/libnetwork/ipam/allocator_test.go
@@ -1126,10 +1126,10 @@ func testAllocateRandomDeallocate(t *testing.T, pool, subPool string, num int, s
 	}
 
 	seed := time.Now().Unix()
-	rand.Seed(seed)
+	rng := rand.New(rand.NewSource(seed))
 
 	// Deallocate half of the allocated addresses following a random pattern
-	pattern := rand.Perm(num)
+	pattern := rng.Perm(num)
 	for i := 0; i < num/2; i++ {
 		idx := pattern[i]
 		ip := indices[idx]
@@ -1247,6 +1247,10 @@ func TestRequestReleaseAddressDuplicate(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	seed := time.Now().Unix()
+	t.Logf("Random seed: %v", seed)
+	rng := rand.New(rand.NewSource(seed))
+
 	group := new(errgroup.Group)
 	for err == nil {
 		var c *net.IPNet
@@ -1256,7 +1260,7 @@ func TestRequestReleaseAddressDuplicate(t *testing.T) {
 			l.Unlock()
 			allocatedIPs = append(allocatedIPs, c)
 			if len(allocatedIPs) > 500 {
-				i := rand.Intn(len(allocatedIPs) - 1)
+				i := rng.Intn(len(allocatedIPs) - 1)
 				ip := allocatedIPs[i]
 				group.Go(func() error {
 					if err = a.ReleaseAddress(poolID, ip.IP); err != nil {

--- a/libnetwork/resolver.go
+++ b/libnetwork/resolver.go
@@ -93,10 +93,6 @@ type resolver struct {
 	startCh       chan struct{}
 }
 
-func init() {
-	rand.Seed(time.Now().Unix())
-}
-
 // NewResolver creates a new instance of the Resolver
 func NewResolver(address string, proxyDNS bool, backend DNSBackend) Resolver {
 	return &resolver{
@@ -210,9 +206,17 @@ func setCommonFlags(msg *dns.Msg) {
 	msg.RecursionAvailable = true
 }
 
+//nolint:gosec // The RNG is not used in a security-sensitive context.
+var (
+	shuffleRNG   = rand.New(rand.NewSource(time.Now().Unix()))
+	shuffleRNGMu sync.Mutex
+)
+
 func shuffleAddr(addr []net.IP) []net.IP {
+	shuffleRNGMu.Lock()
+	defer shuffleRNGMu.Unlock()
 	for i := len(addr) - 1; i > 0; i-- {
-		r := rand.Intn(i + 1) //nolint:gosec // gosec complains about the use of rand here. It should be fine.
+		r := shuffleRNG.Intn(i + 1) //nolint:gosec // gosec complains about the use of rand here. It should be fine.
 		addr[i], addr[r] = addr[r], addr[i]
 	}
 	return addr

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -682,7 +682,7 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 			}
 		}
 
-	case tar.TypeReg, tar.TypeRegA:
+	case tar.TypeReg:
 		// Source is regular file. We use sequential file access to avoid depleting
 		// the standby list on Windows. On Linux, this equates to a regular os.OpenFile.
 		file, err := sequential.OpenFile(path, os.O_CREATE|os.O_WRONLY, hdrInfo.Mode())


### PR DESCRIPTION
"math/rand".Seed
  - Migrate to using local RNG instances.

"archive/tar".TypeRegA
  - The deprecated constant `tar.TypeRegA` is the same value as `tar.TypeReg` and so is not needed at all.
