### PR TITLE
daemon: handle EISDIR error from runtime

### DIFF
--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -160,6 +160,17 @@ func setExitCodeFromError(setExitCode func(exitStatus), err error) error {
 		return startInvalidConfigError(errDesc)
 	}
 
+	// Go 1.20 changed the error for attempting to execute a directory from
+	// syscall.EACCESS to syscall.EISDIR. Unfortunately docker/cli checks
+	// whether the error message contains syscall.EACCESS.Error() to
+	// determine whether to exit with code 126 or 125, so we have little
+	// choice but to fudge the error string.
+	if contains(errDesc, syscall.EISDIR.Error()) {
+		errDesc += ": " + syscall.EACCES.Error()
+		setExitCode(exitEaccess)
+		return startInvalidConfigError(errDesc)
+	}
+
 	// attempted to mount a file onto a directory, or a directory onto a file, maybe from user specified bind mounts
 	if contains(errDesc, syscall.ENOTDIR.Error()) {
 		errDesc += ": Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type"


### PR DESCRIPTION
Go 1.20 made a change to the behaviour of package "os/exec" which was not mentioned in the release notes:
https://github.com/golang/go/commit/2b8f21409480931b45c983853a78dc7984ed634e Attempts to execute a directory now return `syscall.EISDIR` instead of `syscall.EACCESS`. Check for `EISDIR` errors from the runtime and fudge the returned error message to maintain compatibility with existing versions of docker/cli when using a version of runc compiled with Go 1.20+.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

