### PR TITLE
api/s/r/swarm: log backend errors at Debug level

### DIFF
--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -36,7 +36,7 @@ func (sr *swarmRouter) initCluster(ctx context.Context, w http.ResponseWriter, r
 	}
 	nodeID, err := sr.backend.Init(req)
 	if err != nil {
-		logrus.Errorf("Error initializing swarm: %v", err)
+		logrus.WithContext(ctx).WithError(err).Debug("Error initializing swarm")
 		return err
 	}
 	return httputils.WriteJSON(w, http.StatusOK, nodeID)
@@ -62,7 +62,7 @@ func (sr *swarmRouter) leaveCluster(ctx context.Context, w http.ResponseWriter, 
 func (sr *swarmRouter) inspectCluster(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	swarm, err := sr.backend.Inspect()
 	if err != nil {
-		logrus.Errorf("Error getting swarm: %v", err)
+		logrus.WithContext(ctx).WithError(err).Debug("Error getting swarm")
 		return err
 	}
 
@@ -114,7 +114,7 @@ func (sr *swarmRouter) updateCluster(ctx context.Context, w http.ResponseWriter,
 	}
 
 	if err := sr.backend.Update(version, swarm, flags); err != nil {
-		logrus.Errorf("Error configuring swarm: %v", err)
+		logrus.WithContext(ctx).WithError(err).Debug("Error configuring swarm")
 		return err
 	}
 	return nil
@@ -127,7 +127,7 @@ func (sr *swarmRouter) unlockCluster(ctx context.Context, w http.ResponseWriter,
 	}
 
 	if err := sr.backend.UnlockSwarm(req); err != nil {
-		logrus.Errorf("Error unlocking swarm: %v", err)
+		logrus.WithContext(ctx).WithError(err).Debug("Error unlocking swarm")
 		return err
 	}
 	return nil
@@ -136,7 +136,7 @@ func (sr *swarmRouter) unlockCluster(ctx context.Context, w http.ResponseWriter,
 func (sr *swarmRouter) getUnlockKey(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	unlockKey, err := sr.backend.GetUnlockKey()
 	if err != nil {
-		logrus.WithError(err).Errorf("Error retrieving swarm unlock key")
+		logrus.WithContext(ctx).WithError(err).Debug("Error retrieving swarm unlock key")
 		return err
 	}
 
@@ -168,7 +168,7 @@ func (sr *swarmRouter) getServices(ctx context.Context, w http.ResponseWriter, r
 
 	services, err := sr.backend.GetServices(basictypes.ServiceListOptions{Filters: filter, Status: status})
 	if err != nil {
-		logrus.Errorf("Error getting services: %v", err)
+		logrus.WithContext(ctx).WithError(err).Debug("Error getting services")
 		return err
 	}
 
@@ -194,7 +194,10 @@ func (sr *swarmRouter) getService(ctx context.Context, w http.ResponseWriter, r 
 
 	service, err := sr.backend.GetService(vars["id"], insertDefaults)
 	if err != nil {
-		logrus.Errorf("Error getting service %s: %v", vars["id"], err)
+		logrus.WithContext(ctx).WithFields(logrus.Fields{
+			"error":      err,
+			"service-id": vars["id"],
+		}).Debug("Error getting service")
 		return err
 	}
 
@@ -218,7 +221,10 @@ func (sr *swarmRouter) createService(ctx context.Context, w http.ResponseWriter,
 	}
 	resp, err := sr.backend.CreateService(service, encodedAuth, queryRegistry)
 	if err != nil {
-		logrus.Errorf("Error creating service %s: %v", service.Name, err)
+		logrus.WithContext(ctx).WithFields(logrus.Fields{
+			"error":        err,
+			"service-name": service.Name,
+		}).Debug("Error creating service")
 		return err
 	}
 
@@ -254,7 +260,10 @@ func (sr *swarmRouter) updateService(ctx context.Context, w http.ResponseWriter,
 
 	resp, err := sr.backend.UpdateService(vars["id"], version, service, flags, queryRegistry)
 	if err != nil {
-		logrus.Errorf("Error updating service %s: %v", vars["id"], err)
+		logrus.WithContext(ctx).WithFields(logrus.Fields{
+			"error":      err,
+			"service-id": vars["id"],
+		}).Debug("Error updating service")
 		return err
 	}
 	return httputils.WriteJSON(w, http.StatusOK, resp)
@@ -262,7 +271,10 @@ func (sr *swarmRouter) updateService(ctx context.Context, w http.ResponseWriter,
 
 func (sr *swarmRouter) removeService(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := sr.backend.RemoveService(vars["id"]); err != nil {
-		logrus.Errorf("Error removing service %s: %v", vars["id"], err)
+		logrus.WithContext(ctx).WithFields(logrus.Fields{
+			"error":      err,
+			"service-id": vars["id"],
+		}).Debug("Error removing service")
 		return err
 	}
 	return nil
@@ -303,7 +315,7 @@ func (sr *swarmRouter) getNodes(ctx context.Context, w http.ResponseWriter, r *h
 
 	nodes, err := sr.backend.GetNodes(basictypes.NodeListOptions{Filters: filter})
 	if err != nil {
-		logrus.Errorf("Error getting nodes: %v", err)
+		logrus.WithContext(ctx).WithError(err).Debug("Error getting nodes")
 		return err
 	}
 
@@ -313,7 +325,10 @@ func (sr *swarmRouter) getNodes(ctx context.Context, w http.ResponseWriter, r *h
 func (sr *swarmRouter) getNode(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	node, err := sr.backend.GetNode(vars["id"])
 	if err != nil {
-		logrus.Errorf("Error getting node %s: %v", vars["id"], err)
+		logrus.WithContext(ctx).WithFields(logrus.Fields{
+			"error":   err,
+			"node-id": vars["id"],
+		}).Debug("Error getting node")
 		return err
 	}
 
@@ -334,7 +349,10 @@ func (sr *swarmRouter) updateNode(ctx context.Context, w http.ResponseWriter, r 
 	}
 
 	if err := sr.backend.UpdateNode(vars["id"], version, node); err != nil {
-		logrus.Errorf("Error updating node %s: %v", vars["id"], err)
+		logrus.WithContext(ctx).WithFields(logrus.Fields{
+			"error":   err,
+			"node-id": vars["id"],
+		}).Debug("Error updating node")
 		return err
 	}
 	return nil
@@ -348,7 +366,10 @@ func (sr *swarmRouter) removeNode(ctx context.Context, w http.ResponseWriter, r 
 	force := httputils.BoolValue(r, "force")
 
 	if err := sr.backend.RemoveNode(vars["id"], force); err != nil {
-		logrus.Errorf("Error removing node %s: %v", vars["id"], err)
+		logrus.WithContext(ctx).WithFields(logrus.Fields{
+			"error":   err,
+			"node-id": vars["id"],
+		}).Debug("Error removing node")
 		return err
 	}
 	return nil
@@ -365,7 +386,7 @@ func (sr *swarmRouter) getTasks(ctx context.Context, w http.ResponseWriter, r *h
 
 	tasks, err := sr.backend.GetTasks(basictypes.TaskListOptions{Filters: filter})
 	if err != nil {
-		logrus.Errorf("Error getting tasks: %v", err)
+		logrus.WithContext(ctx).WithError(err).Debug("Error getting tasks")
 		return err
 	}
 
@@ -375,7 +396,10 @@ func (sr *swarmRouter) getTasks(ctx context.Context, w http.ResponseWriter, r *h
 func (sr *swarmRouter) getTask(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	task, err := sr.backend.GetTask(vars["id"])
 	if err != nil {
-		logrus.Errorf("Error getting task %s: %v", vars["id"], err)
+		logrus.WithContext(ctx).WithFields(logrus.Fields{
+			"error":   err,
+			"task-id": vars["id"],
+		}).Debug("Error getting task")
 		return err
 	}
 


### PR DESCRIPTION
- Fixes #44997

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
The errors are already returned to the client in the API response, so logging them to the daemon log is redundant. Log the errors at level Debug so as not to pollute the end-users' daemon logs with noise.

Refactor the logs to use structured fields. Add the request context to the log entry so that logrus hooks could annotate the log entries with contextual information about the API request in the hypothetical future.

**- How I did it**
Grepped for all `logrus` calls in cluster_routes.go and hand-edited them all.

**- How to verify it**
Code review?

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Errors handling Swarm API requests are now logged to the daemon log at Debug level instead of Error. These errors will continue to be returned to the client in the API request responses.

**- A picture of a cute animal (not mandatory but encouraged)**

