### PR TITLE
[23.0 backport] Go 1.20 enablement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -223,8 +223,7 @@ FROM binary-dummy AS containerd-windows
 FROM containerd-${TARGETOS} AS containerd
 
 FROM base AS golangci_lint
-# FIXME: when updating golangci-lint, remove the temporary "nolint" in https://github.com/moby/moby/blob/7860686a8df15eea9def9e6189c6f9eca031bb6f/libnetwork/networkdb/cluster.go#L246
-ARG GOLANGCI_LINT_VERSION=v1.49.0
+ARG GOLANGCI_LINT_VERSION=v1.51.2
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
         GOBIN=/build/ GO111MODULE=on go install "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}" \

--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -1428,7 +1428,7 @@ func TestCollectBatchWithDuplicateTimestamps(t *testing.T) {
 	for i := 0; i < times; i++ {
 		line := fmt.Sprintf("%d", i)
 		if i%2 == 0 {
-			timestamp.Add(1 * time.Nanosecond)
+			timestamp = timestamp.Add(1 * time.Nanosecond)
 		}
 		stream.Log(&logger.Message{
 			Line:      []byte(line),

--- a/libnetwork/bitseq/sequence_test.go
+++ b/libnetwork/bitseq/sequence_test.go
@@ -891,10 +891,10 @@ func TestRandomAllocateDeallocate(t *testing.T) {
 	}
 
 	seed := time.Now().Unix()
-	rand.Seed(seed)
+	rng := rand.New(rand.NewSource(seed))
 
 	// Allocate all bits using a random pattern
-	pattern := rand.Perm(numBits)
+	pattern := rng.Perm(numBits)
 	for _, bit := range pattern {
 		err := hnd.Set(uint64(bit))
 		if err != nil {
@@ -909,7 +909,7 @@ func TestRandomAllocateDeallocate(t *testing.T) {
 	}
 
 	// Deallocate all bits using a random pattern
-	pattern = rand.Perm(numBits)
+	pattern = rng.Perm(numBits)
 	for _, bit := range pattern {
 		err := hnd.Unset(uint64(bit))
 		if err != nil {
@@ -959,10 +959,10 @@ func TestAllocateRandomDeallocate(t *testing.T) {
 	}
 
 	seed := time.Now().Unix()
-	rand.Seed(seed)
+	rng := rand.New(rand.NewSource(seed))
 
 	// Deallocate half of the allocated bits following a random pattern
-	pattern := rand.Perm(numBits / 2)
+	pattern := rng.Perm(numBits / 2)
 	for i := 0; i < numBits/4; i++ {
 		bit := pattern[i]
 		err := hnd.Unset(uint64(bit))
@@ -1025,10 +1025,10 @@ func TestAllocateRandomDeallocateSerialize(t *testing.T) {
 	}
 
 	seed := time.Now().Unix()
-	rand.Seed(seed)
+	rng := rand.New(rand.NewSource(seed))
 
 	// Deallocate half of the allocated bits following a random pattern
-	pattern := rand.Perm(numBits / 2)
+	pattern := rng.Perm(numBits / 2)
 	for i := 0; i < numBits/4; i++ {
 		bit := pattern[i]
 		err := hnd.Unset(uint64(bit))
@@ -1269,10 +1269,10 @@ func testSetRollover(t *testing.T, serial bool) {
 	}
 
 	seed := time.Now().Unix()
-	rand.Seed(seed)
+	rng := rand.New(rand.NewSource(seed))
 
 	// Deallocate half of the allocated bits following a random pattern
-	pattern := rand.Perm(numBits / 2)
+	pattern := rng.Perm(numBits / 2)
 	for i := 0; i < numBits/4; i++ {
 		bit := pattern[i]
 		err := hnd.Unset(uint64(bit))

--- a/libnetwork/ipam/allocator_test.go
+++ b/libnetwork/ipam/allocator_test.go
@@ -1317,10 +1317,10 @@ func testAllocateRandomDeallocate(t *testing.T, pool, subPool string, num int, s
 	}
 
 	seed := time.Now().Unix()
-	rand.Seed(seed)
+	rng := rand.New(rand.NewSource(seed))
 
 	// Deallocate half of the allocated addresses following a random pattern
-	pattern := rand.Perm(num)
+	pattern := rng.Perm(num)
 	for i := 0; i < num/2; i++ {
 		idx := pattern[i]
 		ip := indices[idx]
@@ -1553,6 +1553,10 @@ func TestRequestReleaseAddressDuplicate(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	seed := time.Now().Unix()
+	t.Logf("Random seed: %v", seed)
+	rng := rand.New(rand.NewSource(seed))
+
 	group := new(errgroup.Group)
 	for err == nil {
 		var c *net.IPNet
@@ -1562,7 +1566,7 @@ func TestRequestReleaseAddressDuplicate(t *testing.T) {
 			l.Unlock()
 			allocatedIPs = append(allocatedIPs, c)
 			if len(allocatedIPs) > 500 {
-				i := rand.Intn(len(allocatedIPs) - 1)
+				i := rng.Intn(len(allocatedIPs) - 1)
 				ip := allocatedIPs[i]
 				group.Go(func() error {
 					if err = a.ReleaseAddress(poolID, ip.IP); err != nil {

--- a/libnetwork/networkdb/cluster.go
+++ b/libnetwork/networkdb/cluster.go
@@ -717,7 +717,7 @@ func randomOffset(n int) int {
 		return 0
 	}
 
-	val, err := rand.Int(rand.Reader, big.NewInt(int64(n))) // #nosec G404 -- False positive; see https://github.com/securego/gosec/issues/862
+	val, err := rand.Int(rand.Reader, big.NewInt(int64(n)))
 	if err != nil {
 		logrus.Errorf("Failed to get a random offset: %v", err)
 		return 0

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -711,7 +711,7 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 			}
 		}
 
-	case tar.TypeReg, tar.TypeRegA:
+	case tar.TypeReg:
 		// Source is regular file. We use sequential file access to avoid depleting
 		// the standby list on Windows. On Linux, this equates to a regular os.OpenFile.
 		file, err := sequential.OpenFile(path, os.O_CREATE|os.O_WRONLY, hdrInfo.Mode())


### PR DESCRIPTION
23.0 backports of:
- [x] #45004 
- [x] ~#45005~ (backported separately in #45062)
- [x] #45006 
- [x] #45007
- [x] #45063

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

