### PR TITLE
Fix nil pointer dereference when attempting to log DNS errors

### DIFF
--- a/libnetwork/resolver.go
+++ b/libnetwork/resolver.go
@@ -398,7 +398,7 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 	}
 
 	if err != nil {
-		logrus.WithError(err).Errorf("[resolver] failed to handle query: %s (%s) from %s", queryName, dns.TypeToString[queryType], extConn.LocalAddr().String())
+		logrus.WithError(err).Errorf("[resolver] failed to handle query: %s (%s)", queryName, dns.TypeToString[queryType])
 		return
 	}
 


### PR DESCRIPTION
- Forward port of https://github.com/moby/moby/pull/44980

This PR was originally accepted on 23.0, but we decided after the fact that taking it on master would have been preferable.

PTAL @er0k