### PR TITLE
[23.0] update containerd binary to v1.6.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -192,7 +192,7 @@ RUN git init . && git remote add origin "https://github.com/containerd/container
 # When updating the binary version you may also need to update the vendor
 # version to pick up bug fixes or new APIs, however, usually the Go packages
 # are built from a commit from the master branch.
-ARG CONTAINERD_VERSION=v1.6.16
+ARG CONTAINERD_VERSION=v1.6.18
 RUN git fetch -q --depth 1 origin "${CONTAINERD_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS containerd-build

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -168,7 +168,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ARG GO_VERSION=1.19.5
 ARG GOTESTSUM_VERSION=v1.8.2
 ARG GOWINRES_VERSION=v0.3.0
-ARG CONTAINERD_VERSION=v1.6.16
+ARG CONTAINERD_VERSION=v1.6.18
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.6.16}"
+: "${CONTAINERD_VERSION:=v1.6.18}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"


### PR DESCRIPTION
update containerd binary to v1.6.18, which includes fixes for CVE-2023-25153 and CVE-2023-25173.

1.6.18 release notes: https://github.com/containerd/containerd/releases/tag/v1.6.18

> - Fix OCI image importer memory exhaustion (GHSA-259w-8hf6-59c2)
> - Fix supplementary groups not being set up properly (GHSA-hmfx-3pcx-653p)
> - Revert removal of /sbin/apparmor_parser check
> - Update Go to 1.19.6

full diff: https://github.com/containerd/containerd/compare/v1.6.17...v1.6.18

1.6.17 release notes: https://github.com/containerd/containerd/releases/tag/v1.6.17

> - Add network plugin metrics
> - Update mkdir permission on /etc/cni to 0755 instead of 0700
> - Export remote snapshotter label handler
> - Add support for default hosts.toml configuration

full diff: https://github.com/containerd/containerd/compare/v1.6.16...v1.6.17

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```
update containerd binary to v1.6.18, which includes fixes for CVE-2023-25153 and CVE-2023-25173.
```



**- A picture of a cute animal (not mandatory but encouraged)**

