### PR TITLE
[23.0 backport] daemon: fully resolve `apparmor_parser` regression

### DIFF
--- a/daemon/apparmor_default.go
+++ b/daemon/apparmor_default.go
@@ -5,23 +5,15 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"fmt"
-	"os"
-	"sync"
 
 	"github.com/containerd/containerd/pkg/apparmor"
 	aaprofile "github.com/docker/docker/profiles/apparmor"
-	"github.com/sirupsen/logrus"
 )
 
 // Define constants for native driver
 const (
 	unconfinedAppArmorProfile = "unconfined"
 	defaultAppArmorProfile    = "docker-default"
-)
-
-var (
-	checkAppArmorOnce   sync.Once
-	isAppArmorAvailable bool
 )
 
 // DefaultApparmorProfile returns the name of the default apparmor profile
@@ -33,20 +25,7 @@ func DefaultApparmorProfile() string {
 }
 
 func ensureDefaultAppArmorProfile() error {
-	checkAppArmorOnce.Do(func() {
-		if apparmor.HostSupports() {
-			// Restore the apparmor_parser check removed in containerd:
-			// https://github.com/containerd/containerd/commit/1acca8bba36e99684ee3489ea4a42609194ca6b9
-			// Fixes: https://github.com/moby/moby/issues/44900
-			if _, err := os.Stat("/sbin/apparmor_parser"); err == nil {
-				isAppArmorAvailable = true
-			} else {
-				logrus.Warn("AppArmor enabled on system but \"apparmor_parser\" binary is missing, so profile can't be loaded")
-			}
-		}
-	})
-
-	if isAppArmorAvailable {
+	if apparmor.HostSupports() {
 		loaded, err := aaprofile.IsLoaded(defaultAppArmorProfile)
 		if err != nil {
 			return fmt.Errorf("Could not check if %s AppArmor profile was loaded: %s", defaultAppArmorProfile, err)

--- a/vendor.mod
+++ b/vendor.mod
@@ -19,7 +19,7 @@ require (
 	github.com/bsphere/le_go v0.0.0-20200109081728-fc06dab2caa8
 	github.com/cloudflare/cfssl v0.0.0-20180323000720-5d63dbd981b5
 	github.com/containerd/cgroups v1.0.4
-	github.com/containerd/containerd v1.6.16
+	github.com/containerd/containerd v1.6.18
 	github.com/containerd/continuity v0.3.0
 	github.com/containerd/fifo v1.0.0
 	github.com/containerd/typeurl v1.0.2

--- a/vendor.sum
+++ b/vendor.sum
@@ -243,8 +243,8 @@ github.com/containerd/containerd v1.5.0-beta.4/go.mod h1:GmdgZd2zA2GYIBZ0w09Zvgq
 github.com/containerd/containerd v1.5.0-rc.0/go.mod h1:V/IXoMqNGgBlabz3tHD2TWDoTJseu1FGOKuoA4nNb2s=
 github.com/containerd/containerd v1.5.1/go.mod h1:0DOxVqwDy2iZvrZp2JUx/E+hS0UNTVn7dJnIOwtYR4g=
 github.com/containerd/containerd v1.5.7/go.mod h1:gyvv6+ugqY25TiXxcZC3L5yOeYgEw0QMhscqVp1AR9c=
-github.com/containerd/containerd v1.6.16 h1:0H5xH6ABsN7XTrxIAKxFpBkFCBtrZ/OSORhCpUnHjrc=
-github.com/containerd/containerd v1.6.16/go.mod h1:1RdCUu95+gc2v9t3IL+zIlpClSmew7/0YS8O5eQZrOw=
+github.com/containerd/containerd v1.6.18 h1:qZbsLvmyu+Vlty0/Ex5xc0z2YtKpIsb5n45mAMI+2Ns=
+github.com/containerd/containerd v1.6.18/go.mod h1:1RdCUu95+gc2v9t3IL+zIlpClSmew7/0YS8O5eQZrOw=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20190815185530-f2a389ac0a02/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20191127005431-f65d91d395eb/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=

--- a/vendor/github.com/containerd/containerd/Vagrantfile
+++ b/vendor/github.com/containerd/containerd/Vagrantfile
@@ -93,7 +93,7 @@ EOF
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.18.10",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.19.6",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/vendor/github.com/containerd/containerd/api/services/content/v1/content.pb.go
+++ b/vendor/github.com/containerd/containerd/api/services/content/v1/content.pb.go
@@ -299,7 +299,7 @@ type ListContentRequest struct {
 	// filters. Expanded, containers that match the following will be
 	// returned:
 	//
-	//   filters[0] or filters[1] or ... or filters[n-1] or filters[n]
+	//	filters[0] or filters[1] or ... or filters[n-1] or filters[n]
 	//
 	// If filters is zero-length or nil, all items will be returned.
 	Filters              []string `protobuf:"bytes,1,rep,name=filters,proto3" json:"filters,omitempty"`

--- a/vendor/github.com/containerd/containerd/images/archive/importer.go
+++ b/vendor/github.com/containerd/containerd/images/archive/importer.go
@@ -232,12 +232,14 @@ func ImportIndex(ctx context.Context, store content.Store, reader io.Reader, opt
 	return writeManifest(ctx, store, idx, ocispec.MediaTypeImageIndex)
 }
 
+const (
+	kib       = 1024
+	mib       = 1024 * kib
+	jsonLimit = 20 * mib
+)
+
 func onUntarJSON(r io.Reader, j interface{}) error {
-	b, err := io.ReadAll(r)
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(b, j)
+	return json.NewDecoder(io.LimitReader(r, jsonLimit)).Decode(j)
 }
 
 func onUntarBlob(ctx context.Context, r io.Reader, store content.Ingester, size int64, ref string) (digest.Digest, error) {

--- a/vendor/github.com/containerd/containerd/pkg/apparmor/apparmor.go
+++ b/vendor/github.com/containerd/containerd/pkg/apparmor/apparmor.go
@@ -16,13 +16,13 @@
 
 package apparmor
 
-// HostSupports returns true if apparmor is enabled for the host, // On non-Linux returns false
-// On Linux returns true if apparmor_parser is enabled, and if we
+// HostSupports returns true if apparmor is enabled for the host:
+//   - On Linux returns true if apparmor is enabled, apparmor_parser is
+//     present, and if we are not running docker-in-docker.
+//   - On non-Linux returns false.
 //
-//	are not running docker-in-docker.
-//
-//	It is a modified version of libcontainer/apparmor.IsEnabled(), which does not
-//	check for apparmor_parser to be present, or if we're running docker-in-docker.
+// This is derived from libcontainer/apparmor.IsEnabled(), with the addition
+// of checks for apparmor_parser to be present and docker-in-docker.
 func HostSupports() bool {
 	return hostSupports()
 }

--- a/vendor/github.com/containerd/containerd/pkg/apparmor/apparmor_linux.go
+++ b/vendor/github.com/containerd/containerd/pkg/apparmor/apparmor_linux.go
@@ -29,14 +29,16 @@ var (
 // hostSupports returns true if apparmor is enabled for the host, if
 // apparmor_parser is enabled, and if we are not running docker-in-docker.
 //
-// It is a modified version of libcontainer/apparmor.IsEnabled(), which does not
-// check for apparmor_parser to be present, or if we're running docker-in-docker.
+// This is derived from libcontainer/apparmor.IsEnabled(), with the addition
+// of checks for apparmor_parser to be present and docker-in-docker.
 func hostSupports() bool {
 	checkAppArmor.Do(func() {
 		// see https://github.com/opencontainers/runc/blob/0d49470392206f40eaab3b2190a57fe7bb3df458/libcontainer/apparmor/apparmor_linux.go
 		if _, err := os.Stat("/sys/kernel/security/apparmor"); err == nil && os.Getenv("container") == "" {
-			buf, err := os.ReadFile("/sys/module/apparmor/parameters/enabled")
-			appArmorSupported = err == nil && len(buf) > 1 && buf[0] == 'Y'
+			if _, err = os.Stat("/sbin/apparmor_parser"); err == nil {
+				buf, err := os.ReadFile("/sys/module/apparmor/parameters/enabled")
+				appArmorSupported = err == nil && len(buf) > 1 && buf[0] == 'Y'
+			}
 		}
 	})
 	return appArmorSupported

--- a/vendor/github.com/containerd/containerd/platforms/defaults_windows.go
+++ b/vendor/github.com/containerd/containerd/platforms/defaults_windows.go
@@ -46,10 +46,14 @@ type matchComparer struct {
 
 // Match matches platform with the same windows major, minor
 // and build version.
-func (m matchComparer) Match(p imagespec.Platform) bool {
-	if m.defaults.Match(p) {
-		// TODO(windows): Figure out whether OSVersion is deprecated.
-		return strings.HasPrefix(p.OSVersion, m.osVersionPrefix)
+func (m matchComparer) Match(p specs.Platform) bool {
+	match := m.defaults.Match(p)
+
+	if match && p.OS == "windows" {
+		if strings.HasPrefix(p.OSVersion, m.osVersionPrefix) {
+			return true
+		}
+		return p.OSVersion == ""
 	}
 	return false
 }

--- a/vendor/github.com/containerd/containerd/version/version.go
+++ b/vendor/github.com/containerd/containerd/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.16+unknown"
+	Version = "1.6.18+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -160,7 +160,7 @@ github.com/containerd/cgroups/v2/stats
 # github.com/containerd/console v1.0.3
 ## explicit; go 1.13
 github.com/containerd/console
-# github.com/containerd/containerd v1.6.16
+# github.com/containerd/containerd v1.6.18
 ## explicit; go 1.17
 github.com/containerd/containerd
 github.com/containerd/containerd/api/events


### PR DESCRIPTION
- Backport of https://github.com/moby/moby/pull/44982
- Reverts https://github.com/moby/moby/pull/44902
- Fixes https://github.com/moby/moby/issues/44970

**- What I did**
- vendor: github.com/containerd/containerd v1.6.18
- Revert #44902

**- How I did it**

Pull in https://github.com/containerd/containerd/pull/8087 from containerd, and drop the partial fix we made in this repository.

**- How to verify it**

We really could use some sort of binary download from our CI jobs to make the friction of manual testing easier. But for now, manually, and by reviewing the clean revert of the offending change in containerd.

**- Description for the changelog**
- Fully resolve a failure to start containers when an AppArmor-enabled kernel is present, but `apparmor_parser` is missing.
