### PR TITLE
Close DecompressStream after layer is downloaded

### DIFF
--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -344,6 +344,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				d.err = fmt.Errorf("could not get decompression stream: %v", err)
 				return
 			}
+			defer inflatedLayerData.Close()
 
 			var src distribution.Descriptor
 			if fs, ok := descriptor.(distribution.Describable); ok {


### PR DESCRIPTION
**- What I did**

Added a deferred `Close()` call to the DecompressStream used to download a layer. This was likely leaking resources.

**- How I did it**

Noticed this while working on a Moby fork I help to maintain.

**- How to verify it**

I can't think of any simple way to test this change, but it should be clear that we ought to close a `ReadCloser`. FWIW, I ran unit tests and the non-CLI integration tests and nothing is broken after the change.

(Also, there is similar code in `image/tarexport/load.go`, which does close the DecompressStream.)

**- Description for the changelog**

Avoid resource leak by closing the DecompressStream after layer is downloaded

**- A picture of a cute animal (not mandatory but encouraged)**

```
             . --- .
           /        \
          |  O  _  O |
          |  ./   \. |
          /  `-._.-'  \
        .' /         \ `.
    .-~.-~/           \~-.~-.
.-~ ~    |             |    ~ ~-.
`- .     |             |     . -'
     ~ - |             | - ~
         \             /
       ___\           /___
       ~;_  >- . . -<  _i~
          `'         `'
```

