### PR TITLE
[23.0 backport] Upgrade containerd/fifo to v1.1.0

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -21,7 +21,7 @@ require (
 	github.com/containerd/cgroups v1.0.4
 	github.com/containerd/containerd v1.6.18
 	github.com/containerd/continuity v0.3.0
-	github.com/containerd/fifo v1.0.0
+	github.com/containerd/fifo v1.1.0
 	github.com/containerd/typeurl v1.0.2
 	github.com/coreos/go-systemd/v22 v22.4.0
 	github.com/creack/pty v1.1.11

--- a/vendor.sum
+++ b/vendor.sum
@@ -259,8 +259,9 @@ github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448/go.mod h1:ODA38xgv
 github.com/containerd/fifo v0.0.0-20200410184934-f15a3290365b/go.mod h1:jPQ2IAeZRCYxpS/Cm1495vGFww6ecHmMk1YJH2Q5ln0=
 github.com/containerd/fifo v0.0.0-20201026212402-0724c46b320c/go.mod h1:jPQ2IAeZRCYxpS/Cm1495vGFww6ecHmMk1YJH2Q5ln0=
 github.com/containerd/fifo v0.0.0-20210316144830-115abcc95a1d/go.mod h1:ocF/ME1SX5b1AOlWi9r677YJmCPSwwWnQ9O123vzpE4=
-github.com/containerd/fifo v1.0.0 h1:6PirWBr9/L7GDamKr+XM0IeUFXu5mf3M/BPpH9gaLBU=
 github.com/containerd/fifo v1.0.0/go.mod h1:ocF/ME1SX5b1AOlWi9r677YJmCPSwwWnQ9O123vzpE4=
+github.com/containerd/fifo v1.1.0 h1:4I2mbh5stb1u6ycIABlBw9zgtlK8viPI9QkQNRQEEmY=
+github.com/containerd/fifo v1.1.0/go.mod h1:bmC4NWMbXlt2EZ0Hc7Fx7QzTFxgPID13eH0Qu+MAb2o=
 github.com/containerd/go-cni v1.0.1/go.mod h1:+vUpYxKvAF72G9i1WoDOiPGRtQpqsNW/ZHtSlv++smU=
 github.com/containerd/go-cni v1.0.2/go.mod h1:nrNABBHzu0ZwCug9Ije8hL2xBCYh/pjfMb1aZGrrohk=
 github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3/go.mod h1:IV7qH3hrUgRmyYrtgEeGWJfWbgcHL9CSRruz2Vqcph0=

--- a/vendor/github.com/containerd/fifo/.golangci.yml
+++ b/vendor/github.com/containerd/fifo/.golangci.yml
@@ -1,18 +1,34 @@
 linters:
   enable:
-    - structcheck
-    - varcheck
-    - staticcheck
-    - unconvert
+    - exportloopref # Checks for pointers to enclosing loop variables
     - gofmt
     - goimports
-    - golint
+    - gosec
     - ineffassign
-    - vet
-    - unused
     - misspell
+    - nolintlint
+    - revive
+    - staticcheck
+    - tenv # Detects using os.Setenv instead of t.Setenv since Go 1.17
+    - unconvert
+    - unused
+    - vet
+    - dupword # Checks for duplicate words in the source code
   disable:
     - errcheck
+
+linters-settings:
+  gosec:
+    # The following issues surfaced when `gosec` linter
+    # was enabled. They are temporarily excluded to unblock
+    # the existing workflow, but still to be addressed by
+    # future works.
+    excludes:
+      - G204
+      - G305
+      - G306
+      - G402
+      - G404
 
 run:
   timeout: 3m

--- a/vendor/github.com/containerd/fifo/fifo.go
+++ b/vendor/github.com/containerd/fifo/fifo.go
@@ -1,4 +1,4 @@
-// +build !windows
+//go:build !windows
 
 /*
    Copyright The containerd Authors.
@@ -20,13 +20,13 @@ package fifo
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"runtime"
 	"sync"
 	"syscall"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
@@ -48,12 +48,12 @@ var leakCheckWg *sync.WaitGroup
 func OpenFifoDup2(ctx context.Context, fn string, flag int, perm os.FileMode, fd int) (io.ReadWriteCloser, error) {
 	f, err := openFifo(ctx, fn, flag, perm)
 	if err != nil {
-		return nil, errors.Wrap(err, "fifo error")
+		return nil, fmt.Errorf("fifo error: %w", err)
 	}
 
 	if err := unix.Dup2(int(f.file.Fd()), fd); err != nil {
 		_ = f.Close()
-		return nil, errors.Wrap(err, "dup2 error")
+		return nil, fmt.Errorf("dup2 error: %w", err)
 	}
 
 	return f, nil
@@ -62,22 +62,28 @@ func OpenFifoDup2(ctx context.Context, fn string, flag int, perm os.FileMode, fd
 // OpenFifo opens a fifo. Returns io.ReadWriteCloser.
 // Context can be used to cancel this function until open(2) has not returned.
 // Accepted flags:
-// - syscall.O_CREAT - create new fifo if one doesn't exist
-// - syscall.O_RDONLY - open fifo only from reader side
-// - syscall.O_WRONLY - open fifo only from writer side
-// - syscall.O_RDWR - open fifo from both sides, never block on syscall level
-// - syscall.O_NONBLOCK - return io.ReadWriteCloser even if other side of the
+//   - syscall.O_CREAT - create new fifo if one doesn't exist
+//   - syscall.O_RDONLY - open fifo only from reader side
+//   - syscall.O_WRONLY - open fifo only from writer side
+//   - syscall.O_RDWR - open fifo from both sides, never block on syscall level
+//   - syscall.O_NONBLOCK - return io.ReadWriteCloser even if other side of the
 //     fifo isn't open. read/write will be connected after the actual fifo is
 //     open or after fifo is closed.
 func OpenFifo(ctx context.Context, fn string, flag int, perm os.FileMode) (io.ReadWriteCloser, error) {
-	return openFifo(ctx, fn, flag, perm)
+	fifo, err := openFifo(ctx, fn, flag, perm)
+	if fifo == nil {
+		// Do not return a non-nil ReadWriteCloser((*fifo)(nil)) value
+		// as that can confuse callers.
+		return nil, err
+	}
+	return fifo, err
 }
 
 func openFifo(ctx context.Context, fn string, flag int, perm os.FileMode) (*fifo, error) {
 	if _, err := os.Stat(fn); err != nil {
 		if os.IsNotExist(err) && flag&syscall.O_CREAT != 0 {
 			if err := syscall.Mkfifo(fn, uint32(perm&os.ModePerm)); err != nil && !os.IsExist(err) {
-				return nil, errors.Wrapf(err, "error creating fifo %v", fn)
+				return nil, fmt.Errorf("error creating fifo %v: %w", fn, err)
 			}
 		} else {
 			return nil, err
@@ -138,7 +144,7 @@ func openFifo(ctx context.Context, fn string, flag int, perm os.FileMode) (*fifo
 				case <-ctx.Done():
 					err = ctx.Err()
 				default:
-					err = errors.Errorf("fifo %v was closed before opening", h.Name())
+					err = fmt.Errorf("fifo %v was closed before opening", h.Name())
 				}
 				if file != nil {
 					file.Close()
@@ -206,6 +212,10 @@ func (f *fifo) Write(b []byte) (int, error) {
 // before open(2) has returned and fifo was never opened.
 func (f *fifo) Close() (retErr error) {
 	for {
+		if f == nil {
+			return
+		}
+
 		select {
 		case <-f.closed:
 			f.handle.Close()

--- a/vendor/github.com/containerd/fifo/handle_nolinux.go
+++ b/vendor/github.com/containerd/fifo/handle_nolinux.go
@@ -1,4 +1,4 @@
-// +build !linux,!windows
+//go:build !linux && !windows
 
 /*
    Copyright The containerd Authors.
@@ -19,9 +19,8 @@
 package fifo
 
 import (
+	"fmt"
 	"syscall"
-
-	"github.com/pkg/errors"
 )
 
 type handle struct {
@@ -33,13 +32,13 @@ type handle struct {
 func getHandle(fn string) (*handle, error) {
 	var stat syscall.Stat_t
 	if err := syscall.Stat(fn, &stat); err != nil {
-		return nil, errors.Wrapf(err, "failed to stat %v", fn)
+		return nil, fmt.Errorf("failed to stat %v: %w", fn, err)
 	}
 
 	h := &handle{
 		fn:  fn,
-		dev: uint64(stat.Dev), //nolint: unconvert
-		ino: uint64(stat.Ino), //nolint: unconvert
+		dev: uint64(stat.Dev), //nolint:unconvert,nolintlint
+		ino: uint64(stat.Ino), //nolint:unconvert,nolintlint
 	}
 
 	return h, nil
@@ -48,10 +47,10 @@ func getHandle(fn string) (*handle, error) {
 func (h *handle) Path() (string, error) {
 	var stat syscall.Stat_t
 	if err := syscall.Stat(h.fn, &stat); err != nil {
-		return "", errors.Wrapf(err, "path %v could not be statted", h.fn)
+		return "", fmt.Errorf("path %v could not be statted: %w", h.fn, err)
 	}
-	if uint64(stat.Dev) != h.dev || uint64(stat.Ino) != h.ino { //nolint: unconvert
-		return "", errors.Errorf("failed to verify handle %v/%v %v/%v for %v", stat.Dev, h.dev, stat.Ino, h.ino, h.fn)
+	if uint64(stat.Dev) != h.dev || uint64(stat.Ino) != h.ino { //nolint:unconvert,nolintlint
+		return "", fmt.Errorf("failed to verify handle %v/%v %v/%v for %v", stat.Dev, h.dev, stat.Ino, h.ino, h.fn)
 	}
 	return h.fn, nil
 }

--- a/vendor/github.com/containerd/fifo/raw.go
+++ b/vendor/github.com/containerd/fifo/raw.go
@@ -1,4 +1,4 @@
-// +build !windows
+//go:build !windows
 
 /*
    Copyright The containerd Authors.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -247,8 +247,8 @@ github.com/containerd/continuity/driver
 github.com/containerd/continuity/fs
 github.com/containerd/continuity/pathdriver
 github.com/containerd/continuity/sysx
-# github.com/containerd/fifo v1.0.0
-## explicit; go 1.13
+# github.com/containerd/fifo v1.1.0
+## explicit; go 1.18
 github.com/containerd/fifo
 # github.com/containerd/go-runc v1.0.0
 ## explicit; go 1.13


### PR DESCRIPTION
- v23.0 backport of #45049 
- Fixes https://github.com/docker/for-linux/issues/1186
- Fixes https://github.com/moby/moby/issues/45002

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Upgraded containerd/fifo to a tagged version containing https://github.com/containerd/fifo/pull/47

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Fixed an issue with the daemon crashing on startup during container restore

**- A picture of a cute animal (not mandatory but encouraged)**

