### PR TITLE
Fix attach goroutine/fd leak when no I/O is ready

### DIFF
--- a/api/server/router/container/notify_linux.go
+++ b/api/server/router/container/notify_linux.go
@@ -1,0 +1,54 @@
+package container
+
+import (
+	"context"
+	"net"
+	"syscall"
+
+	"github.com/containerd/log"
+	"github.com/docker/docker/internal/unix_noeintr"
+	"golang.org/x/sys/unix"
+)
+
+func notifyClosed(ctx context.Context, conn net.Conn, notify func()) {
+	sc, ok := conn.(syscall.Conn)
+	if !ok {
+		log.G(ctx).Debug("notifyClosed: conn does not support close notifications")
+		return
+	}
+
+	rc, err := sc.SyscallConn()
+	if err != nil {
+		log.G(ctx).WithError(err).Warn("notifyClosed: failed get raw conn for close notifications")
+		return
+	}
+
+	epFd, err := unix_noeintr.EpollCreate()
+	if err != nil {
+		log.G(ctx).WithError(err).Warn("notifyClosed: failed to create epoll fd")
+		return
+	}
+	defer unix.Close(epFd)
+
+	err = rc.Control(func(fd uintptr) {
+		err := unix_noeintr.EpollCtl(epFd, unix.EPOLL_CTL_ADD, int(fd), &unix.EpollEvent{
+			Events: unix.EPOLLHUP,
+			Fd:     int32(fd),
+		})
+		if err != nil {
+			log.G(ctx).WithError(err).Warn("notifyClosed: failed to register fd for close notifications")
+			return
+		}
+
+		events := make([]unix.EpollEvent, 1)
+		if _, err := unix_noeintr.EpollWait(epFd, events, -1); err != nil {
+			log.G(ctx).WithError(err).Warn("notifyClosed: failed to wait for close notifications")
+			return
+		}
+		notify()
+	})
+	if err != nil {
+		log.G(ctx).WithError(err).Warn("notifyClosed: failed to register for close notifications")
+		return
+	}
+}

--- a/api/server/router/container/notify_unsupported.go
+++ b/api/server/router/container/notify_unsupported.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package container
+
+import (
+	"context"
+	"net"
+)
+
+func notifyClosed(ctx context.Context, conn net.Conn, notify func()) {}

--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -30,7 +30,7 @@ type ContainerRmConfig struct {
 
 // ContainerAttachConfig holds the streams to use when connecting to a container to view logs.
 type ContainerAttachConfig struct {
-	GetStreams func(multiplexed bool) (io.ReadCloser, io.Writer, io.Writer, error)
+	GetStreams func(multiplexed bool, cancel func()) (io.ReadCloser, io.Writer, io.Writer, error)
 	UseStdin   bool
 	UseStdout  bool
 	UseStderr  bool

--- a/container/stream/attach_test.go
+++ b/container/stream/attach_test.go
@@ -1,0 +1,102 @@
+package stream
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+// Make sure when there is no I/O on a stream that the goroutines do not get blcoked after the container exits.
+func TestAttachNoIO(t *testing.T) {
+	t.Run("stdin only", func(t *testing.T) {
+		stdinR, _ := io.Pipe()
+		defer stdinR.Close()
+		testStreamCopy(t, stdinR, nil, nil)
+	})
+
+	t.Run("stdout only", func(t *testing.T) {
+		_, w := io.Pipe()
+		defer w.Close()
+		testStreamCopy(t, nil, w, nil)
+	})
+
+	t.Run("stderr only", func(t *testing.T) {
+		_, w := io.Pipe()
+		defer w.Close()
+		testStreamCopy(t, nil, nil, w)
+	})
+
+	t.Run("stdout+stderr", func(t *testing.T) {
+		_, stdoutW := io.Pipe()
+		defer stdoutW.Close()
+		_, stderrW := io.Pipe()
+		defer stderrW.Close()
+
+		testStreamCopy(t, nil, stdoutW, stderrW)
+	})
+
+	t.Run("stdin+stdout", func(t *testing.T) {
+		stdin, _ := io.Pipe()
+		defer stdin.Close()
+		_, stdout := io.Pipe()
+		defer stdout.Close()
+
+		testStreamCopy(t, stdin, stdout, nil)
+	})
+
+	t.Run("stdin+stderr", func(t *testing.T) {
+		stdin, _ := io.Pipe()
+		defer stdin.Close()
+		_, stderr := io.Pipe()
+		defer stderr.Close()
+
+		testStreamCopy(t, stdin, nil, stderr)
+	})
+
+	t.Run("stdin+stdout+stderr", func(t *testing.T) {
+		stdinR, _ := io.Pipe()
+		defer stdinR.Close()
+		stdoutR, stdoutW := io.Pipe()
+		defer stdoutR.Close()
+		stderrR, stderrW := io.Pipe()
+		defer stderrR.Close()
+		testStreamCopy(t, stdinR, stdoutW, stderrW)
+	})
+}
+
+func testStreamCopy(t *testing.T, stdin io.ReadCloser, stdout, stderr io.WriteCloser) {
+	cfg := AttachConfig{
+		UseStdin:  stdin != nil,
+		UseStdout: stdout != nil,
+		UseStderr: stderr != nil,
+		Stdin:     stdin,
+		Stdout:    stdout,
+		Stderr:    stderr,
+	}
+
+	sc := NewConfig()
+	sc.AttachStreams(&cfg)
+	defer sc.CloseStreams()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	chErr := sc.CopyStreams(ctx, &cfg)
+
+	select {
+	case err := <-chErr:
+		assert.NilError(t, err)
+	default:
+	}
+
+	cancel()
+
+	select {
+	case err := <-chErr:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for CopyStreams to exit")
+	}
+}

--- a/container/stream/attach_test.go
+++ b/container/stream/attach_test.go
@@ -9,7 +9,7 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-// Make sure when there is no I/O on a stream that the goroutines do not get blcoked after the container exits.
+// Make sure when there is no I/O on a stream that the goroutines do not get blocked after the container exits.
 func TestAttachNoIO(t *testing.T) {
 	t.Run("stdin only", func(t *testing.T) {
 		stdinR, _ := io.Pipe()

--- a/integration/container/attach_test.go
+++ b/integration/container/attach_test.go
@@ -2,13 +2,18 @@ package container // import "github.com/docker/docker/integration/container"
 
 import (
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
+	systemutil "github.com/docker/docker/integration/internal/system"
 	"github.com/docker/docker/testutil"
+	"github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/poll"
+	"gotest.tools/v3/skip"
 )
 
 func TestAttach(t *testing.T) {
@@ -58,4 +63,59 @@ func TestAttach(t *testing.T) {
 			assert.Check(t, is.Equal(mediaType, tc.expectedMediaType))
 		})
 	}
+}
+
+// Regression test for #37182
+func TestAttachDisconnectLeak(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux", "Bug still exists on Windows")
+	t.Parallel()
+
+	ctx := testutil.StartSpan(baseContext, t)
+
+	// Use a new daemon to make sure stuff from other tests isn't affecting the
+	// goroutine count.
+	d := daemon.New(t)
+	defer d.Cleanup(t)
+
+	d.StartWithBusybox(ctx, t, "--iptables=false")
+
+	client := d.NewClientT(t)
+
+	resp, err := client.ContainerCreate(ctx,
+		&container.Config{
+			Image: "busybox",
+			Cmd:   []string{"/bin/sh", "-c", "while true; usleep 100000; done"},
+		},
+		&container.HostConfig{},
+		&network.NetworkingConfig{},
+		nil,
+		"",
+	)
+	assert.NilError(t, err)
+	cID := resp.ID
+	defer client.ContainerRemove(ctx, cID, container.RemoveOptions{
+		Force: true,
+	})
+
+	nGoroutines := systemutil.WaitForStableGoroutineCount(ctx, t, client)
+
+	attach, err := client.ContainerAttach(ctx, cID, container.AttachOptions{
+		Stdout: true,
+	})
+	assert.NilError(t, err)
+	defer attach.Close()
+
+	poll.WaitOn(t, func(_ poll.LogT) poll.Result {
+		count := systemutil.WaitForStableGoroutineCount(ctx, t, client)
+		if count > nGoroutines {
+			return poll.Success()
+		}
+		return poll.Continue("waiting for goroutines to increase from %d, current: %d", nGoroutines, count)
+	},
+		poll.WithTimeout(time.Minute),
+	)
+
+	attach.Close()
+
+	poll.WaitOn(t, systemutil.CheckGoroutineCount(ctx, client, nGoroutines), poll.WithTimeout(time.Minute))
 }

--- a/integration/internal/system/goroutines.go
+++ b/integration/internal/system/goroutines.go
@@ -1,0 +1,78 @@
+package system
+
+import (
+	"context"
+	"time"
+
+	"github.com/docker/docker/client"
+	"gotest.tools/v3/poll"
+)
+
+// WaitForStableGoroutineCount polls the daemon Info API and returns the reported goroutine count
+// after multiple calls return the same number.
+func WaitForStableGoroutineCount(ctx context.Context, t poll.TestingT, apiClient client.SystemAPIClient, opts ...poll.SettingOp) int {
+	var out int
+	// Use a longish delay to make sure the goroutine count is actually stable.
+	defaults := []poll.SettingOp{poll.WithTimeout(time.Minute), poll.WithDelay(time.Second)}
+	opts = append(defaults, opts...)
+
+	poll.WaitOn(t, StableGoroutineCount(ctx, apiClient, &out), opts...)
+	return out
+}
+
+// StableGoroutineCount is a [poll.Check] that polls the daemon info API until the goroutine count is the same for 3 iterations.
+func StableGoroutineCount(ctx context.Context, apiClient client.SystemAPIClient, count *int) poll.Check {
+	var (
+		numStable int
+		nRoutines int
+	)
+
+	return func(t poll.LogT) poll.Result {
+		n, err := getGoroutineNumber(ctx, apiClient)
+		if err != nil {
+			return poll.Error(err)
+		}
+
+		last := nRoutines
+
+		if nRoutines == n {
+			numStable++
+		} else {
+			numStable = 0
+			nRoutines = n
+		}
+
+		if numStable > 3 {
+			*count = n
+			return poll.Success()
+		}
+		return poll.Continue("goroutine count is not stable: last %d, current %d, stable iters: %d", last, n, numStable)
+	}
+}
+
+// CheckGoroutineCount returns a [poll.Check] that polls the daemon info API until the expected number of goroutines is hit.
+func CheckGoroutineCount(ctx context.Context, apiClient client.SystemAPIClient, expected int) poll.Check {
+	first := true
+	return func(t poll.LogT) poll.Result {
+		n, err := getGoroutineNumber(ctx, apiClient)
+		if err != nil {
+			return poll.Error(err)
+		}
+		if n > expected {
+			if first {
+				t.Log("Waiting for goroutines to stabilize")
+				first = false
+			}
+			return poll.Continue("exepcted %d goroutines, got %d", expected, n)
+		}
+		return poll.Success()
+	}
+}
+
+func getGoroutineNumber(ctx context.Context, apiClient client.SystemAPIClient) (int, error) {
+	info, err := apiClient.Info(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return info.NGoroutines, nil
+}

--- a/internal/unix_noeintr/epoll_linux.go
+++ b/internal/unix_noeintr/epoll_linux.go
@@ -1,0 +1,37 @@
+package unix_noeintr
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+func EpollCreate() (int, error) {
+	for {
+		fd, err := unix.EpollCreate1(unix.EPOLL_CLOEXEC)
+		if errors.Is(err, unix.EINTR) {
+			continue
+		}
+		return fd, err
+	}
+}
+
+func EpollCtl(epFd int, op int, fd int, event *unix.EpollEvent) error {
+	for {
+		err := unix.EpollCtl(epFd, op, fd, event)
+		if errors.Is(err, unix.EINTR) {
+			continue
+		}
+		return err
+	}
+}
+
+func EpollWait(epFd int, events []unix.EpollEvent, msec int) (int, error) {
+	for {
+		n, err := unix.EpollWait(epFd, events, msec)
+		if errors.Is(err, unix.EINTR) {
+			continue
+		}
+		return n, err
+	}
+}


### PR DESCRIPTION
When only stdin is attached the goroutine can only ever exit if:

1. The container pipe is closed while trying to write to it
2. The client closes the stdin read pipe

This is because `io.Copy` does a read on the read side then a write to the write side.
If reading from the client's stdin pipe blocks, the goroutine will never get notified that the container pipe is closed.

Another similar case is when the client disconnects but `io.Copy` is blocking waiting for data from the container's stdout/stderr streams.
This is significantly trickier to resolve.
The 2nd commit fixes this for Linux only.

- Fixes #37182

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
fix a goroutine and file-descriptor leak on container attach
```

**- A picture of a cute animal (not mandatory but encouraged)**
