### PR TITLE
Correct the condition based on the previous commit as the current one allows any network on cloud to ping without adhering to any security protocols

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -777,7 +777,7 @@ func WithCommonOptions(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		// joining an existing namespace, only if we create a new net namespace.
 		if c.HostConfig.NetworkMode.IsPrivate() {
 			// We cannot set up ping socket support in a user namespace
-			userNS := daemon.configStore.RemappedRoot != "" && c.HostConfig.UsernsMode.IsPrivate()
+			userNS := daemon.configStore.RemappedRoot != "" || c.HostConfig.UsernsMode.IsPrivate()
 			if !userNS && !userns.RunningInUserNS() && sysctlExists("net.ipv4.ping_group_range") {
 				// allow unprivileged ICMP echo sockets without CAP_NET_RAW
 				s.Linux.Sysctl["net.ipv4.ping_group_range"] = "0 2147483647"

--- a/daemon/oci_linux_test.go
+++ b/daemon/oci_linux_test.go
@@ -131,7 +131,7 @@ func TestSysctlOverride(t *testing.T) {
 		assert.Equal(t, s.Linux.Sysctl["net.ipv4.ip_unprivileged_port_start"], "0")
 	}
 	if sysctlExists("net.ipv4.ping_group_range") {
-		assert.Equal(t, s.Linux.Sysctl["net.ipv4.ping_group_range"], "0 2147483647")
+		assert.Equal(t, s.Linux.Sysctl["net.ipv4.ping_group_range"], "1 0")
 	}
 
 	// Set an explicit sysctl.


### PR DESCRIPTION
Correct the condition based on the previous commit as the current one allows any network on cloud to ping without adhering to any security protocols

Fixes: https://github.com/moby/moby/issues/44984

**- What I did**

Correct the condition to allow the ICMP packets only when the daemon is run under not private namespace. Looks like the change has been not carried properly.

**- How I did it**

Debug logs

**- How to verify it**

2. Create apparmor policy for no network access 
```
cat > /tmp/no_network <<EOF
#include <tunables/global>

profile no-network flags=(attach_disconnected,mediate_deleted) {
  #include <abstractions/base>
  network inet tcp,
  network inet udp,
  network inet icmp,

  deny network raw,
  deny network packet,
  file,
  mount,
}
EOF

``` 
3. Load the profile in AppArmor /sbin/apparmor_parser --replace --write-cache /tmp/no_network
4. Create a Dockerfile with Ubuntu 22.04 and ping capabilities
```
cat > Dockerfile <<EOF
FROM ubuntu:22.04
RUN apt-get update && apt install -y iputils-ping
EOF
```
5. Create a docker image using `docker build -t ubuntu-ping .`
6. Run a container with the policy `docker run --rm -i --security-opt apparmor=no-network ubuntu-test:latest ping -c3 localhost`

Results:

`ping: socket: Permission denied`

**- Description for the changelog**

Fix the issue related to  to ping without adhering to any security profile from apparmor.

**- A picture of a cute animal (not mandatory but encouraged)**


