### PR TITLE
c8d/tag: Don't create a separate error variable

### DIFF
--- a/daemon/containerd/image_tag.go
+++ b/daemon/containerd/image_tag.go
@@ -25,8 +25,8 @@ func (i *ImageService) TagImage(ctx context.Context, imageID image.ID, newTag re
 	}
 
 	is := i.client.ImageService()
-	_, createErr := is.Create(ctx, newImg)
-	if createErr != nil {
+	_, err = is.Create(ctx, newImg)
+	if err != nil {
 		if !cerrdefs.IsAlreadyExists(err) {
 			return errdefs.System(errors.Wrapf(err, "failed to create image with name %s and target %s", newImg.Name, newImg.Target.Digest.String()))
 		}


### PR DESCRIPTION
Follow up to:
- https://github.com/moby/moby/pull/44781

Checking if the image creation failed due to IsAlreadyExists didn't use the error from ImageService.Create.
Error from ImageService.Create was stored in a separate variable and later IsAlreadyExists checked the standard `err` variable instead of the `createErr`.
As a separate image create error variable is no longer needed (it was introduced in some later changes to the original PR), just remove it and assign it to err variable to fix the check.



**- What I did**
Fixed wrong variable being passed to IsAlreadyExists
**- How I did it**
Removed separate variable, just use `err`
**- How to verify it**
```bash
$ docker pull alpine
$ docker pull busybox
$ docker tag alpine myimage
$ docker tag busybox myimage # should be able to override the myimage
$ docker images
REPOSITORY   TAG       IMAGE ID       CREATED          SIZE
alpine       latest    69665d02cb32   12 minutes ago    3.27MB
busybox      latest    7b3ccabffc97   12 minutes ago   2.01MB
myimage      latest    7b3ccabffc97   12 minutes ago   2.01MB

```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
🤦🏻 
