### PR TITLE
[23.0 backport] Fix loop-closure bugs in tests

### DIFF
--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -389,6 +389,7 @@ func TestMaxDownloadAttempts(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			layerStore := &mockLayerStore{make(map[layer.ChainID]*mockLayer)}

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -379,7 +379,7 @@ func TestMaxDownloadAttempts(t *testing.T) {
 			name:                "max-attempts=5, fail at 6th attempt",
 			simulateRetries:     6,
 			maxDownloadAttempts: 5,
-			expectedErr:         "simulating download attempt 5/6",
+			expectedErr:         "simulating download attempt 6/6",
 		},
 		{
 			name:                "max-attempts=0, fail after 1 attempt",

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -90,6 +90,7 @@ func TestBuildWithRemoveAndForceRemove(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 	for _, c := range cases {
+		c := c
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 			dockerfile := []byte(c.dockerfile)


### PR DESCRIPTION
- 23.0 backport of #45005

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed loop-variable capture bugs flagged by golangci-lint v1.51 and updated `"./distribution/xfer".TestMaxDownloadAttempts` so it passes again.

**- How I did it**
As backporting 97921915a801dd82b1f5a70e0a69353539c1e3ae would change the behaviour of the daemon in a patch release and it is not a regression from v20.10, I updated the test to assert that the `--max-download-attempts` off-by-one error is present, effectively turning the bug into a feature on v23.

**- How to verify it**
Tests pass, and golangci-lint v1.51.1 does not complain about any loop-closure bugs.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
N/A: no user-visible changes

**- A picture of a cute animal (not mandatory but encouraged)**

