### PR TITLE
api: Remove <none> in Repo(Tags|Digests) for >= 1.43

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -338,9 +338,18 @@ func (ir *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter,
 	}
 
 	for _, img := range images {
-		if len(img.RepoTags) == 0 && len(img.RepoDigests) == 0 {
-			img.RepoTags = append(img.RepoTags, "<none>:<none>")
-			img.RepoDigests = append(img.RepoDigests, "<none>@<none>")
+		if versions.LessThan(version, "1.43") {
+			if len(img.RepoTags) == 0 && len(img.RepoDigests) == 0 {
+				img.RepoTags = append(img.RepoTags, "<none>:<none>")
+				img.RepoDigests = append(img.RepoDigests, "<none>@<none>")
+			}
+		} else {
+			if img.RepoTags == nil {
+				img.RepoTags = []string{}
+			}
+			if img.RepoDigests == nil {
+				img.RepoDigests = []string{}
+			}
 		}
 	}
 

--- a/daemon/images/image_prune.go
+++ b/daemon/images/image_prune.go
@@ -109,7 +109,7 @@ deleteImagesLoop:
 					}
 				}
 
-				// Only delete if it's untagged (i.e. repo:<none>)
+				// Only delete if it has no references which is a valid NamedTagged.
 				shouldDelete = !hasTag
 			}
 

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -20,6 +20,9 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `POST /containers/create` now accepts `Annotations` as part of `HostConfig`.
   Can be used to attach arbitrary metadata to the container, which will also be
   passed to the runtime when the container is started.
+* `GET /images/json` no longer includes hardcoded `<none>:<none>` and
+  `<none>@<none>` in `RepoTags` and`RepoDigests` for untagged images.
+  In such cases, empty arrays will be produced instead.
 
 ## v1.42 API changes
 

--- a/testutil/environment/protect.go
+++ b/testutil/environment/protect.go
@@ -118,6 +118,9 @@ func getExistingImages(t testing.TB, testEnv *Execution) []string {
 func tagsFromImageSummary(image types.ImageSummary) []string {
 	var result []string
 	for _, tag := range image.RepoTags {
+		// Starting from API 1.43 no longer outputs the hardcoded <none>
+		// strings. But since the tests might be ran against a remote
+		// daemon/pre 1.43 CLI we must still be able to handle it.
 		if tag != "<none>:<none>" {
 			result = append(result, tag)
 		}


### PR DESCRIPTION
- Follow up to: https://github.com/moby/moby/pull/44840

**- What I did**
Deprecate `<none>:<none>` and `<none>@<none>` magic strings included in `RepoTags` and `RepoDigests`.
Produce an empty arrays instead and leave the presentation of untagged/dangling images up to the client.

**- Description for the changelog**
- `GET /images/json` no longer includes hardcoded `<none>:<none>` and`<none>@<none>` in `RepoTags` and`RepoDigests` for untagged images. In such cases, empty arrays will be produced instead.


**- A picture of a cute animal (not mandatory but encouraged)**

