### PR TITLE
[23.0 backport] libnet/networkdb: fix nil-dereference panic in test

### DIFF
--- a/libnetwork/networkdb/networkdb_test.go
+++ b/libnetwork/networkdb/networkdb_test.go
@@ -109,7 +109,10 @@ func (db *NetworkDB) verifyNetworkExistence(t *testing.T, node string, id string
 		nn, nnok := db.networks[node]
 		if nnok {
 			n, ok := nn[id]
-			leaving := n.leaving
+			var leaving bool
+			if ok {
+				leaving = n.leaving
+			}
 			db.RUnlock()
 			if present && ok {
 				return


### PR DESCRIPTION
- 23.0 backport of #45070

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

