### PR TITLE
[23.0 backport] Wait longer for exit events on Windows

### DIFF
--- a/integration/container/wait_test.go
+++ b/integration/container/wait_test.go
@@ -145,7 +145,7 @@ func TestWaitConditions(t *testing.T) {
 				opts = append(opts, container.WithAutoRemove)
 			}
 			containerID := container.Run(ctx, t, cli, opts...)
-			poll.WaitOn(t, container.IsInState(ctx, cli, containerID, "running"), poll.WithTimeout(30*time.Second), poll.WithDelay(100*time.Millisecond))
+			poll.WaitOn(t, container.IsInState(ctx, cli, containerID, "running"), poll.WithTimeout(75*time.Second), poll.WithDelay(100*time.Millisecond))
 
 			waitResC, errC := cli.ContainerWait(ctx, containerID, tc.waitCond)
 			select {


### PR DESCRIPTION
- 23.0 backport of https://github.com/moby/moby/pull/44893

The latest version of containerd-shim-runhcs-v1 (v0.10.0-rc.4) pulled in with the bump to ContainerD v1.7.0-rc.3 had several changes to make it more robust, which had the side effect of increasing the worst-case amount of time it takes for a container to exit in the worst case. Notably, the total timeout for shutting down a task increased from 30 seconds to 60! Increase the timeouts hardcoded in the daemon and integration tests so that they don't give up too soon.


(cherry picked from commit d634ae9b600743187309c97b53116ec6041e530f)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

