### PR TITLE
api/server: drop unused Config struct

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -2,7 +2,6 @@ package server // import "github.com/docker/docker/api/server"
 
 import (
 	"context"
-	"crypto/tls"
 	"net"
 	"net/http"
 	"strings"
@@ -22,30 +21,11 @@ import (
 // when a request is about to be served.
 const versionMatcher = "/v{version:[0-9.]+}"
 
-// Config provides the configuration for the API server
-type Config struct {
-	CorsHeaders string
-	Version     string
-	SocketGroup string
-	TLSConfig   *tls.Config
-	// Hosts is a list of addresses for the API to listen on.
-	Hosts []string
-}
-
 // Server contains instance details for the server
 type Server struct {
-	cfg         *Config
 	servers     []*HTTPServer
 	routers     []router.Router
 	middlewares []middleware.Middleware
-}
-
-// New returns a new instance of the server based on the specified configuration.
-// It allocates resources which will be needed for ServeAPI(ports, unix-sockets).
-func New(cfg *Config) *Server {
-	return &Server{
-		cfg: cfg,
-	}
 }
 
 // UseMiddleware appends a new middleware to the request chain.

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -13,12 +13,7 @@ import (
 )
 
 func TestMiddlewares(t *testing.T) {
-	cfg := &Config{
-		Version: "0.1omega2",
-	}
-	srv := &Server{
-		cfg: cfg,
-	}
+	srv := &Server{}
 
 	srv.UseMiddleware(middleware.NewVersionMiddleware("0.1omega2", api.DefaultVersion, api.MinVersion))
 


### PR DESCRIPTION
- Extracted from https://github.com/moby/moby/pull/43980

The `Server.cfg` field is never referenced by any code in package `"./api/server"`. `"./api/server".Config` struct values are used by `DaemonCli` code, but only to pass around configuration copied out of the daemon config within the `"./cmd/dockerd"` package. Delete the `"./api/server".Config` struct definition and refactor the `"./cmd/dockerd"` package to pull configuration directly from `cli.Config`.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

