### PR TITLE
registry: acquire mutex in IsInsecureRegistry

### DIFF
--- a/registry/service.go
+++ b/registry/service.go
@@ -237,5 +237,7 @@ func (s *defaultService) LookupPushEndpoints(hostname string) (endpoints []APIEn
 // IsInsecureRegistry returns true if the registry at given host is configured as
 // insecure registry.
 func (s *defaultService) IsInsecureRegistry(host string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return !s.config.isSecureIndex(host)
 }


### PR DESCRIPTION
- Follow-up to #44756

The mutex needs to be held when accessing `s.config` to prevent data races.