### PR TITLE
api/server: delete Wait method

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -77,9 +77,8 @@ func (s *Server) Close() {
 	}
 }
 
-// serveAPI loops through all initialized servers and spawns goroutine
-// with Serve method for each. It sets createMux() as Handler also.
-func (s *Server) serveAPI() error {
+// Serve starts listening for inbound requests.
+func (s *Server) Serve() error {
 	var chErrors = make(chan error, len(s.servers))
 	for _, srv := range s.servers {
 		srv.srv.Handler = s.createMux()
@@ -193,16 +192,4 @@ func (s *Server) createMux() *mux.Router {
 	m.MethodNotAllowedHandler = notFoundHandler
 
 	return m
-}
-
-// Wait blocks the server goroutine until it exits.
-// It sends an error message if there is any error during
-// the API execution.
-func (s *Server) Wait(waitChan chan error) {
-	if err := s.serveAPI(); err != nil {
-		logrus.Errorf("ServeAPI error: %v", err)
-		waitChan <- err
-		return
-	}
-	waitChan <- nil
 }

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -239,18 +239,16 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 
 	cli.setupConfigReloadTrap()
 
-	// The serve API routine never exits unless an error occurs
-	// We need to start it as a goroutine and wait on it so
-	// daemon doesn't exit
-	serveAPIWait := make(chan error)
-	go cli.api.Wait(serveAPIWait)
-
 	// after the daemon is done setting up we can notify systemd api
 	notifyReady()
 
-	// Daemon is fully initialized and handling API traffic
-	// Wait for serve API to complete
-	errAPI := <-serveAPIWait
+	// Daemon is fully initialized. Start handling API traffic
+	// and wait for serve API to complete.
+	errAPI := cli.api.Serve()
+	if errAPI != nil {
+		logrus.WithError(errAPI).Error("ServeAPI error")
+	}
+
 	c.Cleanup()
 
 	// notify systemd that we're shutting down


### PR DESCRIPTION
It's surprising that the method to begin serving requests is named `Wait`. And it is unidiomatic: it is a synchronous call, but it sends its return value to the channel passed in as an argument instead of just returning the value. And ultimately it is just a trivial wrapper around `serveAPI`. Export the `ServeAPI` method instead so callers can decide how to call and synchronize around it.

Call `ServeAPI` synchronously on the main goroutine in `cmd/dockerd`. The goroutine and channel which the `Wait()` API demanded are superfluous after all. The `notifyReady()` call was always concurrent and asynchronous with respect to serving the API (its implementation spawns a goroutine) so it makes no difference whether it is called before `ServeAPI()` or after `go ServeAPI()`.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

