### PR TITLE
libcontainerd/client: Fix checkpoint not being set

### DIFF
--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -145,7 +145,7 @@ func (c *client) NewContainer(ctx context.Context, id string, ociSpec *specs.Spe
 // Start create and start a task for the specified containerd id
 func (c *container) Start(ctx context.Context, checkpointDir string, withStdin bool, attachStdio libcontainerdtypes.StdioCallback) (libcontainerdtypes.Task, error) {
 	var (
-		cp             *types.Descriptor
+		checkpoint     *types.Descriptor
 		t              containerd.Task
 		rio            cio.IO
 		stdinCloseSync = make(chan containerd.Process, 1)
@@ -155,15 +155,15 @@ func (c *container) Start(ctx context.Context, checkpointDir string, withStdin b
 		// write checkpoint to the content store
 		tar := archive.Diff(ctx, "", checkpointDir)
 		var err error
-		cp, err = c.client.writeContent(ctx, images.MediaTypeContainerd1Checkpoint, checkpointDir, tar)
+		checkpoint, err = c.client.writeContent(ctx, images.MediaTypeContainerd1Checkpoint, checkpointDir, tar)
 		// remove the checkpoint when we're done
 		defer func() {
-			if cp != nil {
-				err := c.client.client.ContentStore().Delete(ctx, cp.Digest)
+			if checkpoint != nil {
+				err := c.client.client.ContentStore().Delete(ctx, checkpoint.Digest)
 				if err != nil {
 					c.client.logger.WithError(err).WithFields(logrus.Fields{
 						"ref":    checkpointDir,
-						"digest": cp.Digest,
+						"digest": checkpoint.Digest,
 					}).Warnf("failed to delete temporary checkpoint entry")
 				}
 			}
@@ -193,7 +193,7 @@ func (c *container) Start(ctx context.Context, checkpointDir string, withStdin b
 
 	taskOpts := []containerd.NewTaskOpts{
 		func(_ context.Context, _ *containerd.Client, info *containerd.TaskInfo) error {
-			info.Checkpoint = cp
+			info.Checkpoint = checkpoint
 			return nil
 		},
 	}

--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -154,7 +154,8 @@ func (c *container) Start(ctx context.Context, checkpointDir string, withStdin b
 	if checkpointDir != "" {
 		// write checkpoint to the content store
 		tar := archive.Diff(ctx, "", checkpointDir)
-		cp, err := c.client.writeContent(ctx, images.MediaTypeContainerd1Checkpoint, checkpointDir, tar)
+		var err error
+		cp, err = c.client.writeContent(ctx, images.MediaTypeContainerd1Checkpoint, checkpointDir, tar)
 		// remove the checkpoint when we're done
 		defer func() {
 			if cp != nil {


### PR DESCRIPTION
- Related to: https://github.com/moby/moby/pull/43564

**- What I did**
`cp` variable is used later to populate the `info.Checkpoint` field option used by Task creation:
https://github.com/moby/moby/blob/a48f19157ad560fcb39e3b10fa0d6c331558998c/libcontainerd/remote/client.go#L193-L198

Previous changes mistakenly changed assignment of the `cp` variable to declaration of a new variable that's scoped only to the if block.


**- How I did it**
- Restore the old assignment behavior.
- Make variable name longer (2 letter variable gives impression of single-scope).

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

