### PR TITLE
c8d/list: Support dangling filter

### DIFF
--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -18,7 +18,7 @@ import (
 )
 
 var acceptedImageFilterTags = map[string]bool{
-	"dangling":  false, // TODO(thaJeztah): implement "dangling" filter: see https://github.com/moby/moby/issues/43846
+	"dangling":  true,
 	"label":     true,
 	"before":    true,
 	"since":     true,
@@ -256,6 +256,17 @@ func (i *ImageService) setupFilters(ctx context.Context, imageFilters filters.Ar
 			return imageFilters.MatchKVList("label", image.Labels)
 		})
 	}
+
+	if imageFilters.Contains("dangling") {
+		danglingValue, err := imageFilters.GetBoolOrDefault("dangling", false)
+		if err != nil {
+			return nil, err
+		}
+		fltrs = append(fltrs, func(image images.Image) bool {
+			return danglingValue == isDanglingImage(image)
+		})
+	}
+
 	return func(image images.Image) bool {
 		for _, filter := range fltrs {
 			if !filter(image) {


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/43846
- Upstreams: https://github.com/rumpl/moby/pull/128

**- What I did**
Implemented `dangling` filter for c8d image store

**- How I did it**

**- How to verify it**
```bash
$ docker images
REPOSITORY   TAG       IMAGE ID       CREATED          SIZE
myimage      latest    69665d02cb32   1 second ago     3.27MB
<none>       <none>    7b3ccabffc97   1 second ago     2.01MB

$ docker images -f 'dangling=true'
REPOSITORY   TAG       IMAGE ID       CREATED         SIZE
<none>       <none>    7b3ccabffc97   6 seconds ago   2.01MB

$ docker images -f 'dangling=false'
REPOSITORY   TAG       IMAGE ID       CREATED          SIZE
myimage      latest    69665d02cb32   8 seconds ago    3.27MB

```

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

