### PR TITLE
libcontainerd: Upgrade to typeurl/v2

### DIFF
--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -23,7 +23,7 @@ import (
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/images"
 	v2runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
-	"github.com/containerd/typeurl"
+	"github.com/containerd/typeurl/v2"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libcontainerd/queue"
 	libcontainerdtypes "github.com/docker/docker/libcontainerd/types"

--- a/vendor.mod
+++ b/vendor.mod
@@ -28,7 +28,7 @@ require (
 	github.com/containerd/containerd v1.6.19
 	github.com/containerd/continuity v0.3.0
 	github.com/containerd/fifo v1.1.0
-	github.com/containerd/typeurl v1.0.2
+	github.com/containerd/typeurl/v2 v2.1.0
 	github.com/coreos/go-systemd/v22 v22.4.0
 	github.com/creack/pty v1.1.11
 	github.com/deckarep/golang-set v0.0.0-20141123011944-ef32fa3046d9
@@ -121,6 +121,7 @@ require (
 	github.com/containerd/nydus-snapshotter v0.3.1 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.13.0 // indirect
 	github.com/containerd/ttrpc v1.1.0 // indirect
+	github.com/containerd/typeurl v1.0.2 // indirect
 	github.com/containernetworking/cni v1.1.1 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect

--- a/vendor.sum
+++ b/vendor.sum
@@ -423,6 +423,8 @@ github.com/containerd/typeurl v0.0.0-20190911142611-5eb25027c9fd/go.mod h1:GeKYz
 github.com/containerd/typeurl v1.0.1/go.mod h1:TB1hUtrpaiO88KEK56ijojHS1+NeF0izUACaJW2mdXg=
 github.com/containerd/typeurl v1.0.2 h1:Chlt8zIieDbzQFzXzAeBEF92KhExuE4p9p92/QmY7aY=
 github.com/containerd/typeurl v1.0.2/go.mod h1:9trJWW2sRlGub4wZJRTW83VtbOLS6hwcDZXTn6oPz9s=
+github.com/containerd/typeurl/v2 v2.1.0 h1:yNAhJvbNEANt7ck48IlEGOxP7YAp6LLpGn5jZACDNIE=
+github.com/containerd/typeurl/v2 v2.1.0/go.mod h1:IDp2JFvbwZ31H8dQbEIY7sDl2L3o3HZj1hsSQlywkQ0=
 github.com/containerd/zfs v0.0.0-20200918131355-0a33824f23a2/go.mod h1:8IgZOBdv8fAgXddBT4dBXJPtxyRsejFIpXoklgxgEjw=
 github.com/containerd/zfs v0.0.0-20210301145711-11e8f1707f62/go.mod h1:A9zfAbMlQwE+/is6hi0Xw8ktpL+6glmqZYtevJgaB8Y=
 github.com/containerd/zfs v0.0.0-20210315114300-dde8f0fda960/go.mod h1:m+m51S1DvAP6r3FcmYCp54bQ34pyOwTieQDNRIRHsFY=

--- a/vendor/github.com/containerd/typeurl/v2/.gitignore
+++ b/vendor/github.com/containerd/typeurl/v2/.gitignore
@@ -1,0 +1,2 @@
+*.test
+coverage.txt

--- a/vendor/github.com/containerd/typeurl/v2/LICENSE
+++ b/vendor/github.com/containerd/typeurl/v2/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright The containerd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/containerd/typeurl/v2/README.md
+++ b/vendor/github.com/containerd/typeurl/v2/README.md
@@ -1,0 +1,20 @@
+# typeurl
+
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/containerd/typeurl)](https://pkg.go.dev/github.com/containerd/typeurl)
+[![Build Status](https://github.com/containerd/typeurl/workflows/CI/badge.svg)](https://github.com/containerd/typeurl/actions?query=workflow%3ACI)
+[![codecov](https://codecov.io/gh/containerd/typeurl/branch/master/graph/badge.svg)](https://codecov.io/gh/containerd/typeurl)
+[![Go Report Card](https://goreportcard.com/badge/github.com/containerd/typeurl)](https://goreportcard.com/report/github.com/containerd/typeurl)
+
+A Go package for managing the registration, marshaling, and unmarshaling of encoded types.
+
+This package helps when types are sent over a ttrpc/GRPC API and marshaled as a protobuf [Any](https://pkg.go.dev/google.golang.org/protobuf@v1.27.1/types/known/anypb#Any)
+
+## Project details
+
+**typeurl** is a containerd sub-project, licensed under the [Apache 2.0 license](./LICENSE).
+As a containerd sub-project, you will find the:
+ * [Project governance](https://github.com/containerd/project/blob/master/GOVERNANCE.md),
+ * [Maintainers](https://github.com/containerd/project/blob/master/MAINTAINERS),
+ * and [Contributing guidelines](https://github.com/containerd/project/blob/master/CONTRIBUTING.md)
+
+information in our [`containerd/project`](https://github.com/containerd/project) repository.

--- a/vendor/github.com/containerd/typeurl/v2/doc.go
+++ b/vendor/github.com/containerd/typeurl/v2/doc.go
@@ -1,0 +1,83 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package typeurl
+
+// Package typeurl assists with managing the registration, marshaling, and
+// unmarshaling of types encoded as protobuf.Any.
+//
+// A protobuf.Any is a proto message that can contain any arbitrary data. It
+// consists of two components, a TypeUrl and a Value, and its proto definition
+// looks like this:
+//
+//   message Any {
+//     string type_url = 1;
+//     bytes value = 2;
+//   }
+//
+// The TypeUrl is used to distinguish the contents from other proto.Any
+// messages. This typeurl library manages these URLs to enable automagic
+// marshaling and unmarshaling of the contents.
+//
+// For example, consider this go struct:
+//
+//   type Foo struct {
+//     Field1 string
+//     Field2 string
+//   }
+//
+// To use typeurl, types must first be registered. This is typically done in
+// the init function
+//
+//   func init() {
+//      typeurl.Register(&Foo{}, "Foo")
+//   }
+//
+// This will register the type Foo with the url path "Foo". The arguments to
+// Register are variadic, and are used to construct a url path. Consider this
+// example, from the github.com/containerd/containerd/client package:
+//
+//   func init() {
+//     const prefix = "types.containerd.io"
+//     // register TypeUrls for commonly marshaled external types
+//     major := strconv.Itoa(specs.VersionMajor)
+//     typeurl.Register(&specs.Spec{}, prefix, "opencontainers/runtime-spec", major, "Spec")
+//     // this function has more Register calls, which are elided.
+//   }
+//
+// This registers several types under a more complex url, which ends up mapping
+// to `types.containerd.io/opencontainers/runtime-spec/1/Spec` (or some other
+// value for major).
+//
+// Once a type is registered, it can be marshaled to a proto.Any message simply
+// by calling `MarshalAny`, like this:
+//
+//   foo := &Foo{Field1: "value1", Field2: "value2"}
+//   anyFoo, err := typeurl.MarshalAny(foo)
+//
+// MarshalAny will resolve the correct URL for the type. If the type in
+// question implements the proto.Message interface, then it will be marshaled
+// as a proto message. Otherwise, it will be marshaled as json. This means that
+// typeurl will work on any arbitrary data, whether or not it has a proto
+// definition, as long as it can be serialized to json.
+//
+// To unmarshal, the process is simply inverse:
+//
+//   iface, err := typeurl.UnmarshalAny(anyFoo)
+//   foo := iface.(*Foo)
+//
+// The correct type is automatically chosen from the type registry, and the
+// returned interface can be cast straight to that type.

--- a/vendor/github.com/containerd/typeurl/v2/types.go
+++ b/vendor/github.com/containerd/typeurl/v2/types.go
@@ -1,0 +1,273 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package typeurl
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path"
+	"reflect"
+	"sync"
+
+	gogoproto "github.com/gogo/protobuf/proto"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+var (
+	mu       sync.RWMutex
+	registry = make(map[reflect.Type]string)
+)
+
+// Definitions of common error types used throughout typeurl.
+//
+// These error types are used with errors.Wrap and errors.Wrapf to add context
+// to an error.
+//
+// To detect an error class, use errors.Is() functions to tell whether an
+// error is of this type.
+
+var (
+	ErrNotFound = errors.New("not found")
+)
+
+// Any contains an arbitrary protcol buffer message along with its type.
+//
+// While there is google.golang.org/protobuf/types/known/anypb.Any,
+// we'd like to have our own to hide the underlying protocol buffer
+// implementations from containerd clients.
+//
+// https://developers.google.com/protocol-buffers/docs/proto3#any
+type Any interface {
+	// GetTypeUrl returns a URL/resource name that uniquely identifies
+	// the type of the serialized protocol buffer message.
+	GetTypeUrl() string
+
+	// GetValue returns a valid serialized protocol buffer of the type that
+	// GetTypeUrl() indicates.
+	GetValue() []byte
+}
+
+type anyType struct {
+	typeURL string
+	value   []byte
+}
+
+func (a *anyType) GetTypeUrl() string {
+	if a == nil {
+		return ""
+	}
+	return a.typeURL
+}
+
+func (a *anyType) GetValue() []byte {
+	if a == nil {
+		return nil
+	}
+	return a.value
+}
+
+// Register a type with a base URL for JSON marshaling. When the MarshalAny and
+// UnmarshalAny functions are called they will treat the Any type value as JSON.
+// To use protocol buffers for handling the Any value the proto.Register
+// function should be used instead of this function.
+func Register(v interface{}, args ...string) {
+	var (
+		t = tryDereference(v)
+		p = path.Join(args...)
+	)
+	mu.Lock()
+	defer mu.Unlock()
+	if et, ok := registry[t]; ok {
+		if et != p {
+			panic(fmt.Errorf("type registered with alternate path %q != %q", et, p))
+		}
+		return
+	}
+	registry[t] = p
+}
+
+// TypeURL returns the type url for a registered type.
+func TypeURL(v interface{}) (string, error) {
+	mu.RLock()
+	u, ok := registry[tryDereference(v)]
+	mu.RUnlock()
+	if !ok {
+		switch t := v.(type) {
+		case proto.Message:
+			return string(t.ProtoReflect().Descriptor().FullName()), nil
+		case gogoproto.Message:
+			return gogoproto.MessageName(t), nil
+		default:
+			return "", fmt.Errorf("type %s: %w", reflect.TypeOf(v), ErrNotFound)
+		}
+	}
+	return u, nil
+}
+
+// Is returns true if the type of the Any is the same as v.
+func Is(any Any, v interface{}) bool {
+	// call to check that v is a pointer
+	tryDereference(v)
+	url, err := TypeURL(v)
+	if err != nil {
+		return false
+	}
+	return any.GetTypeUrl() == url
+}
+
+// MarshalAny marshals the value v into an any with the correct TypeUrl.
+// If the provided object is already a proto.Any message, then it will be
+// returned verbatim. If it is of type proto.Message, it will be marshaled as a
+// protocol buffer. Otherwise, the object will be marshaled to json.
+func MarshalAny(v interface{}) (Any, error) {
+	var marshal func(v interface{}) ([]byte, error)
+	switch t := v.(type) {
+	case Any:
+		// avoid reserializing the type if we have an any.
+		return t, nil
+	case proto.Message:
+		marshal = func(v interface{}) ([]byte, error) {
+			return proto.Marshal(t)
+		}
+	case gogoproto.Message:
+		marshal = func(v interface{}) ([]byte, error) {
+			return gogoproto.Marshal(t)
+		}
+	default:
+		marshal = json.Marshal
+	}
+
+	url, err := TypeURL(v)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return &anyType{
+		typeURL: url,
+		value:   data,
+	}, nil
+}
+
+// UnmarshalAny unmarshals the any type into a concrete type.
+func UnmarshalAny(any Any) (interface{}, error) {
+	return UnmarshalByTypeURL(any.GetTypeUrl(), any.GetValue())
+}
+
+// UnmarshalByTypeURL unmarshals the given type and value to into a concrete type.
+func UnmarshalByTypeURL(typeURL string, value []byte) (interface{}, error) {
+	return unmarshal(typeURL, value, nil)
+}
+
+// UnmarshalTo unmarshals the any type into a concrete type passed in the out
+// argument. It is identical to UnmarshalAny, but lets clients provide a
+// destination type through the out argument.
+func UnmarshalTo(any Any, out interface{}) error {
+	return UnmarshalToByTypeURL(any.GetTypeUrl(), any.GetValue(), out)
+}
+
+// UnmarshalToByTypeURL unmarshals the given type and value into a concrete type passed
+// in the out argument. It is identical to UnmarshalByTypeURL, but lets clients
+// provide a destination type through the out argument.
+func UnmarshalToByTypeURL(typeURL string, value []byte, out interface{}) error {
+	_, err := unmarshal(typeURL, value, out)
+	return err
+}
+
+func unmarshal(typeURL string, value []byte, v interface{}) (interface{}, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	t, err := getTypeByUrl(typeURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if v == nil {
+		v = reflect.New(t.t).Interface()
+	} else {
+		// Validate interface type provided by client
+		vURL, err := TypeURL(v)
+		if err != nil {
+			return nil, err
+		}
+		if typeURL != vURL {
+			return nil, fmt.Errorf("can't unmarshal type %q to output %q", typeURL, vURL)
+		}
+	}
+
+	if t.isProto {
+		switch t := v.(type) {
+		case proto.Message:
+			err = proto.Unmarshal(value, t)
+		case gogoproto.Message:
+			err = gogoproto.Unmarshal(value, t)
+		}
+	} else {
+		err = json.Unmarshal(value, v)
+	}
+
+	return v, err
+}
+
+type urlType struct {
+	t       reflect.Type
+	isProto bool
+}
+
+func getTypeByUrl(url string) (urlType, error) {
+	mu.RLock()
+	for t, u := range registry {
+		if u == url {
+			mu.RUnlock()
+			return urlType{
+				t: t,
+			}, nil
+		}
+	}
+	mu.RUnlock()
+	// fallback to proto registry
+	t := gogoproto.MessageType(url)
+	if t != nil {
+		return urlType{
+			// get the underlying Elem because proto returns a pointer to the type
+			t:       t.Elem(),
+			isProto: true,
+		}, nil
+	}
+	mt, err := protoregistry.GlobalTypes.FindMessageByURL(url)
+	if err != nil {
+		return urlType{}, fmt.Errorf("type with url %s: %w", url, ErrNotFound)
+	}
+	empty := mt.New().Interface()
+	return urlType{t: reflect.TypeOf(empty).Elem(), isProto: true}, nil
+}
+
+func tryDereference(v interface{}) reflect.Type {
+	t := reflect.TypeOf(v)
+	if t.Kind() == reflect.Ptr {
+		// require check of pointer but dereference to register
+		return t.Elem()
+	}
+	panic("v is not a pointer to a type")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -323,6 +323,9 @@ github.com/containerd/ttrpc
 # github.com/containerd/typeurl v1.0.2
 ## explicit; go 1.13
 github.com/containerd/typeurl
+# github.com/containerd/typeurl/v2 v2.1.0
+## explicit; go 1.13
+github.com/containerd/typeurl/v2
 # github.com/containernetworking/cni v1.1.1
 ## explicit; go 1.14
 github.com/containernetworking/cni/libcni


### PR DESCRIPTION
Preemptively upgrade the typeurl to v2, to avoid compilation errors once we upgrade to containerd v1.7.
v1.7 migrated off `gogo/protobuf` and changed the protobuf Any to one that's not supported by the vendored `typeurl.UnmarshalAny`, which is used for example here:
https://github.com/moby/moby/blob/7aa36717bb4602df6b5ab89d186881229ef060bc/libcontainerd/remote/client.go#L332

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

