### PR TITLE
TestLogs: Increase stop check poll timeout on Windows 

### DIFF
--- a/integration/container/logs_test.go
+++ b/integration/container/logs_test.go
@@ -126,8 +126,7 @@ func testLogs(t *testing.T, logDriver string) {
 
 	pollTimeout := time.Second * 10
 	if testEnv.OSType == "windows" {
-		// hcs can take longer than 10s to stop a container.
-		pollTimeout = time.Second * 75
+		pollTimeout = StopContainerWindowsPollTimeout
 	}
 
 	for _, tC := range testCases {

--- a/integration/container/stop_test.go
+++ b/integration/container/stop_test.go
@@ -11,6 +11,9 @@ import (
 	"gotest.tools/v3/poll"
 )
 
+// hcs can sometimes take a long time to stop container.
+const StopContainerWindowsPollTimeout = 75 * time.Second
+
 func TestStopContainerWithRestartPolicyAlways(t *testing.T) {
 	defer setupTest(t)()
 	client := testEnv.APIClient()

--- a/integration/container/wait_test.go
+++ b/integration/container/wait_test.go
@@ -170,7 +170,7 @@ func TestWaitConditions(t *testing.T) {
 				assert.NilError(t, err)
 			case waitRes := <-waitResC:
 				assert.Check(t, is.Equal(int64(99), waitRes.StatusCode))
-			case <-time.After(75 * time.Second):
+			case <-time.After(StopContainerWindowsPollTimeout):
 				info, _ := cli.ContainerInspect(ctx, containerID)
 				t.Fatalf("Timed out waiting for container exit code (status = %q)", info.State.Status)
 			}


### PR DESCRIPTION
Stopping container on Windows can sometimes take longer than 10s which
caused this test to be flaky.

```
=== Failed
=== FAIL: github.com/docker/docker/integration/container TestLogs/driver_local/without_tty/stdout_and_stderr (19.77s)
    logs_test.go:139: timeout hit after 10s: waiting for container to be stopped

=== FAIL: github.com/docker/docker/integration/container TestLogs/driver_local (0.02s)

=== FAIL: github.com/docker/docker/integration/container TestLogs (43.43s)
```

**- What I did**
Fix TestLogs flakiness.

**- How I did it**
Increase the timeout to 60s when running this test on Windows.

**- How to verify it**
Check CI

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**

