### PR TITLE
[23.0 backport] builder-next: temporarily disable mergeop and diffop

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -106,5 +106,6 @@ jobs:
           TEST_DOCKERD: "1"
           TEST_DOCKERD_BINARY: "./build/moby/dockerd"
           TESTPKGS: "./${{ matrix.pkg }}"
-          TESTFLAGS: "-v --parallel=1 --timeout=30m --run=//worker=dockerd$"
+          # Diff/MergeOp tests are skipped
+          TESTFLAGS: "-v --parallel=1 --timeout=30m --run=/^Test([^DM]|.[^ie]|..[^fr]|...[^fg])/worker=dockerd$"
         working-directory: buildkit

--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -39,6 +39,9 @@ import (
 	"github.com/moby/buildkit/worker"
 	"github.com/pkg/errors"
 	bolt "go.etcd.io/bbolt"
+
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/apicaps"
 )
 
 func newController(rt http.RoundTripper, opt Opt) (*control.Controller, error) {
@@ -48,6 +51,18 @@ func newController(rt http.RoundTripper, opt Opt) (*control.Controller, error) {
 
 	dist := opt.Dist
 	root := opt.Root
+
+	pb.Caps.Init(apicaps.Cap{
+		ID:                pb.CapMergeOp,
+		Enabled:           false,
+		DisabledReasonMsg: "only enabled with containerd image store backend",
+	})
+
+	pb.Caps.Init(apicaps.Cap{
+		ID:                pb.CapDiffOp,
+		Enabled:           false,
+		DisabledReasonMsg: "only enabled with containerd image store backend",
+	})
 
 	var driver graphdriver.Driver
 	if ls, ok := dist.LayerStore.(interface {


### PR DESCRIPTION
- (Partial, synthetic) backport of https://github.com/moby/moby/pull/45153
- Addresses #45111

Temporarily disable Merge/Diff until there is a proper solution to #45111 . Dockerfiles will detect the missing capability for `COPY --link` and fall back to the behavior in 20.10.

---

Changed to be a backport of a change to master for workflow reasons by @neersighted.