### PR TITLE
Dockerfile: Update shfmt to 3.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -237,7 +237,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
      && /build/gotestsum --version
 
 FROM base AS shfmt
-ARG SHFMT_VERSION=v3.0.2
+ARG SHFMT_VERSION=v3.6.0
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
         GOBIN=/build/ GO111MODULE=on go install "mvdan.cc/sh/v3/cmd/shfmt@${SHFMT_VERSION}" \

--- a/contrib/dockerize-disk.sh
+++ b/contrib/dockerize-disk.sh
@@ -103,8 +103,8 @@ cat > $builddir/result/$new_image_id/json <<- EOS
 EOS
 
 if [ -n "$docker_base_image" ]; then
- image_id=$(docker inspect -f "{{.Id}}" "$docker_base_image")
- echo ", \"parent\": \"$image_id\"" >> $builddir/result/$new_image_id/json
+	image_id=$(docker inspect -f "{{.Id}}" "$docker_base_image")
+	echo ", \"parent\": \"$image_id\"" >> $builddir/result/$new_image_id/json
 fi
 
 echo "}" >> $builddir/result/$new_image_id/json


### PR DESCRIPTION
**- What I did**
Updated shfmt to 3.6.0
Fixed inconsistent indendation in `contrib/dockerize-disk.sh` which wasn't detected by older version.

**- How I did it**

**- How to verify it**
CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

