### PR TITLE
libnetwork: support encrypted overlay networks on systems without xt_u32 kernel module

### DIFF
--- a/libnetwork/drivers/overlay/bpf.go
+++ b/libnetwork/drivers/overlay/bpf.go
@@ -1,0 +1,47 @@
+package overlay
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/net/bpf"
+)
+
+// vniMatchBPF returns a BPF program suitable for passing to the iptables bpf
+// match which matches on the VXAN Network ID of encapsulated packets. The
+// program assumes that it will be used in a rule which only matches UDP
+// datagrams.
+func vniMatchBPF(vni uint32) []bpf.RawInstruction {
+	asm, err := bpf.Assemble([]bpf.Instruction{
+		bpf.LoadMemShift{Off: 0},                                    // ldx 4*([0] & 0xf) ; Load length of IPv4 header into X
+		bpf.LoadIndirect{Off: 12, Size: 4},                          // ld [x + 12]       ; Load VXLAN ID (UDP header + 4 bytes) into A
+		bpf.ALUOpConstant{Op: bpf.ALUOpAnd, Val: 0xffffff00},        // and #0xffffff00   ; VXLAN ID is in top 24 bits
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: vni << 8, SkipTrue: 1}, // jeq ($vni << 8), match
+		bpf.RetConstant{Val: 0},                                     // ret #0
+		bpf.RetConstant{Val: ^uint32(0)},                            // match: ret #-1
+	})
+	// bpf.Assemble() only errors if an instruction is invalid. As the only variable
+	// part of the program is an instruction value for which the entire range is
+	// valid, whether the program can be successfully assembled is independent of
+	// the input. Given that the only recourse is to fix this function and
+	// recompile, there's little value in bubbling the error up to the caller.
+	if err != nil {
+		panic(err)
+	}
+	return asm
+}
+
+// marshalXTBPF marshals a BPF program into the "decimal" byte code format
+// which is suitable for passing to the [iptables bpf match].
+//
+//	iptables -m bpf --bytecode
+//
+// [iptables bpf match]: https://ipset.netfilter.org/iptables-extensions.man.html#lbAH
+func marshalXTBPF(prog []bpf.RawInstruction) string { //nolint:unused
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d", len(prog))
+	for _, ins := range prog {
+		fmt.Fprintf(&b, ",%d %d %d %d", ins.Op, ins.Jt, ins.Jf, ins.K)
+	}
+	return b.String()
+}

--- a/libnetwork/drivers/overlay/bpf_test.go
+++ b/libnetwork/drivers/overlay/bpf_test.go
@@ -1,0 +1,14 @@
+package overlay
+
+import (
+	"testing"
+)
+
+func FuzzVNIMatchBPFDoesNotPanic(f *testing.F) {
+	for _, seed := range []uint32{0, 1, 42, 0xfffffe, 0xffffff, 0xfffffffe, 0xffffffff} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, vni uint32) {
+		_ = vniMatchBPF(vni)
+	})
+}

--- a/libnetwork/drivers/overlay/encryption.go
+++ b/libnetwork/drivers/overlay/encryption.go
@@ -22,8 +22,36 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+/*
+Encrypted overlay networks use IPsec in transport mode to encrypt and
+authenticate the VXLAN UDP datagrams. This driver implements a bespoke control
+plane which negotiates the security parameters for each peer-to-peer tunnel.
+
+IPsec Terminology
+
+ - ESP: IPSec Encapsulating Security Payload
+ - SPI: Security Parameter Index
+ - ICV: Integrity Check Value
+ - SA: Security Association https://en.wikipedia.org/wiki/IPsec#Security_association
+
+
+Developer documentation for Linux IPsec is rather sparse online. The following
+slide deck provides a decent overview.
+https://libreswan.org/wiki/images/e/e0/Netdev-0x12-ipsec-flow.pdf
+
+The Linux IPsec stack is part of XFRM, the netlink packet transformation
+interface.
+https://man7.org/linux/man-pages/man8/ip-xfrm.8.html
+*/
+
 const (
-	r            = 0xD0C4E3
+	// Value used to mark outgoing packets which should have our IPsec
+	// processing applied. It is also used as a label to identify XFRM
+	// states (Security Associations) and policies (Security Policies)
+	// programmed by us so we know which ones we can clean up without
+	// disrupting other VPN connections on the system.
+	mark = 0xD0C4E3
+
 	pktExpansion = 26 // SPI(4) + SeqN(4) + IV(8) + PadLength(1) + NextHeader(1) + ICV(8)
 )
 
@@ -33,7 +61,9 @@ const (
 	bidir
 )
 
-var spMark = netlink.XfrmMark{Value: uint32(r), Mask: 0xffffffff}
+// Mark value for matching packets which should have our IPsec security policy
+// applied.
+var spMark = netlink.XfrmMark{Value: mark, Mask: 0xffffffff}
 
 type key struct {
 	value []byte
@@ -47,6 +77,9 @@ func (k *key) String() string {
 	return ""
 }
 
+// Security Parameter Indices for the IPsec flows between local node and a
+// remote peer, which identify the Security Associations (XFRM states) to be
+// applied when encrypting and decrypting packets.
 type spi struct {
 	forward int
 	reverse int
@@ -204,7 +237,7 @@ func programMangle(vni uint32, add bool) (err error) {
 	var (
 		p      = strconv.FormatUint(uint64(overlayutils.VXLANUDPPort()), 10)
 		c      = fmt.Sprintf("0>>22&0x3C@12&0xFFFFFF00=%d", int(vni)<<8)
-		m      = strconv.FormatUint(uint64(r), 10)
+		m      = strconv.FormatUint(mark, 10)
 		chain  = "OUTPUT"
 		rule   = []string{"-p", "udp", "--dport", p, "-m", "u32", "--u32", c, "-j", "MARK", "--set-mark", m}
 		a      = "-A"
@@ -251,10 +284,12 @@ func programInput(vni uint32, add bool) (err error) {
 		msg = "remove"
 	}
 
+	// Accept incoming VXLAN datagrams for the VNI which were subjected to IPSec processing.
 	if err := iptable.ProgramRule(iptables.Filter, chain, action, accept); err != nil {
 		logrus.Errorf("could not %s input rule: %v. Please do it manually.", msg, err)
 	}
 
+	// Drop incoming VXLAN datagrams for the VNI which were received in cleartext.
 	if err := iptable.ProgramRule(iptables.Filter, chain, action, block); err != nil {
 		logrus.Errorf("could not %s input rule: %v. Please do it manually.", msg, err)
 	}
@@ -280,7 +315,7 @@ func programSA(localIP, remoteIP net.IP, spi *spi, k *key, dir int, add bool) (f
 			Proto: netlink.XFRM_PROTO_ESP,
 			Spi:   spi.reverse,
 			Mode:  netlink.XFRM_MODE_TRANSPORT,
-			Reqid: r,
+			Reqid: mark,
 		}
 		if add {
 			rSA.Aead = buildAeadAlgo(k, spi.reverse)
@@ -306,7 +341,7 @@ func programSA(localIP, remoteIP net.IP, spi *spi, k *key, dir int, add bool) (f
 			Proto: netlink.XFRM_PROTO_ESP,
 			Spi:   spi.forward,
 			Mode:  netlink.XFRM_MODE_TRANSPORT,
-			Reqid: r,
+			Reqid: mark,
 		}
 		if add {
 			fSA.Aead = buildAeadAlgo(k, spi.forward)
@@ -355,7 +390,7 @@ func programSP(fSA *netlink.XfrmState, rSA *netlink.XfrmState, add bool) error {
 				Proto: netlink.XFRM_PROTO_ESP,
 				Mode:  netlink.XFRM_MODE_TRANSPORT,
 				Spi:   fSA.Spi,
-				Reqid: r,
+				Reqid: mark,
 			},
 		},
 	}
@@ -569,7 +604,7 @@ func updateNodeKey(lIP, aIP, rIP net.IP, idxs []*spi, curKeys []*key, newIdx, pr
 					Proto: netlink.XFRM_PROTO_ESP,
 					Mode:  netlink.XFRM_MODE_TRANSPORT,
 					Spi:   fSA2.Spi,
-					Reqid: r,
+					Reqid: mark,
 				},
 			},
 		}
@@ -638,7 +673,7 @@ func clearEncryptionStates() {
 	}
 	for _, sa := range saList {
 		sa := sa
-		if sa.Reqid == r {
+		if sa.Reqid == mark {
 			if err := nlh.XfrmStateDel(&sa); err != nil {
 				logrus.Warnf("Failed to delete stale SA %s: %v", sa, err)
 				continue

--- a/libnetwork/drivers/overlay/encryption_bpf.go
+++ b/libnetwork/drivers/overlay/encryption_bpf.go
@@ -1,0 +1,20 @@
+//go:build libnetwork_overlay_bpf
+// +build libnetwork_overlay_bpf
+
+package overlay
+
+import (
+	"strconv"
+)
+
+// matchVXLAN returns an iptables rule fragment which matches VXLAN datagrams
+// with the given destination port and VXLAN Network ID utilizing the xt_u32
+// netfilter kernel module. The returned slice's backing array is guaranteed not
+// to alias any other slice's.
+func matchVXLAN(port, vni uint32) []string {
+	dport := strconv.FormatUint(uint64(port), 10)
+	vniMatch := marshalXTBPF(vniMatchBPF(vni))
+
+	// https://ipset.netfilter.org/iptables-extensions.man.html#lbAH
+	return []string{"-p", "udp", "--dport", dport, "-m", "bpf", "--bytecode", vniMatch}
+}

--- a/libnetwork/drivers/overlay/encryption_u32.go
+++ b/libnetwork/drivers/overlay/encryption_u32.go
@@ -1,3 +1,6 @@
+//go:build !libnetwork_overlay_bpf
+// +build !libnetwork_overlay_bpf
+
 package overlay
 
 import (

--- a/libnetwork/drivers/overlay/encryption_u32.go
+++ b/libnetwork/drivers/overlay/encryption_u32.go
@@ -1,0 +1,30 @@
+package overlay
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// matchVXLAN returns an iptables rule fragment which matches VXLAN datagrams
+// with the given destination port and VXLAN Network ID utilizing the xt_u32
+// netfilter kernel module. The returned slice's backing array is guaranteed not
+// to alias any other slice's.
+func matchVXLAN(port, vni uint32) []string {
+	dport := strconv.FormatUint(uint64(port), 10)
+
+	// The u32 expression language is documented in iptables-extensions(8).
+	// https://ipset.netfilter.org/iptables-extensions.man.html#lbCK
+	//
+	// 0>>22&0x3C                ; Compute number of octets in IPv4 header
+	//           @               ; Make this the new offset into the packet
+	//                           ; (jump to start of UDP header)
+	//            12&0xFFFFFF00  ; Read 32-bit value at offset 12 and mask off the bottom octet
+	//                         = ; Test whether the value is equal to a constant
+	//
+	// A UDP header is eight octets long so offset 12 from the start of the
+	// UDP header is four octets into the payload: the VNI field of the
+	// VXLAN header.
+	vniMatch := fmt.Sprintf("0>>22&0x3C@12&0xFFFFFF00=%d", int(vni)<<8)
+
+	return []string{"-p", "udp", "--dport", dport, "-m", "u32", "--u32", vniMatch}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
The `xt_u32` kernel module provides the xtables `u32` match, which allows firewall rules to be written which match on the contents of the raw packet. The libnetwork overlay network driver creates firewall rules using `u32` matches to match the VXLAN ID (VNI) of VXLAN datagrams so that the rules are selectively applied only to packets associated with VXLANs for the overlay networks managed by the driver. RHEL/CentOS 8 no longer ship the `xt_u32` kernel module by default, and RHEL/CentOS 9 do not build it at all.

**- What I did**
I added an alternative implementation of the iptables rules to the overlay driver which does not depend on the `xt_u32` kernel module. It can be selected at compile-time using the `libnetwork_overlay_bpf` build tag.

**- How I did it**
I wrote a BPF filter which is a drop-in replacement for the `u32` expression and used that filter with the `xt_bpf` kernel module to match using the filter in the iptables rules.

**- How to verify it**
Spin up a Swarm cluster with at least two nodes, at least one of which is v23.0.1 (to test back-compatibility). Create an encrypted overlay network, start a container on each node attached to the network, and verify that processes on one node's container can connect to processes listening in the other node's container.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

