### PR TITLE
c8d/inspect: Add digested reference to details

### DIFF
--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -25,6 +25,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -98,7 +99,9 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 		if err != nil {
 			return nil, err
 		}
-		tags := make([]reference.Named, 0, len(tagged))
+
+		// Each image will result in 2 references (named and digested).
+		refs := make([]reference.Named, 0, len(tagged)*2)
 		for _, i := range tagged {
 			if i.UpdatedAt.After(lastUpdated) {
 				lastUpdated = i.UpdatedAt
@@ -107,11 +110,21 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 			if err != nil {
 				return nil, err
 			}
-			tags = append(tags, name)
+			refs = append(refs, name)
+
+			digested, err := reference.WithDigest(reference.TrimNamed(name), desc.Digest)
+			if err != nil {
+				// This could only happen if digest is invalid, but considering that
+				// we get it from the Descriptor it's highly unlikely.
+				// Log error just in case.
+				logrus.WithError(err).Error("failed to create digested reference")
+				continue
+			}
+			refs = append(refs, digested)
 		}
 
 		img.Details = &image.Details{
-			References:  tags,
+			References:  refs,
 			Size:        size,
 			Metadata:    nil,
 			Driver:      i.snapshotter,


### PR DESCRIPTION
**- What I did**
Fixed `RepoDigests` value being `null` in inspect output.

**- How I did it**

**- How to verify it**

Setup
```bash
$ docker pull alpine
$ docker tag alpine myimage
$ docker images
REPOSITORY   TAG       IMAGE ID       CREATED         SIZE
alpine       latest    69665d02cb32   4 seconds ago   3.27MB
myimage      latest    69665d02cb32   1 second ago    3.27MB
```

Before
```json
$ docker inspect alpine
[
    {
        "Id": "sha256:69665d02cb32192e52e07644d76bc6f25abeb5410edc1c7a81a10ba3f0efb90a",
        "RepoTags": [
            "alpine:latest",
            "myimage:latest"
        ],
        "RepoDigests": null,
...
```

After
```json
$ docker inspect alpine
[
    {
        "Id": "sha256:69665d02cb32192e52e07644d76bc6f25abeb5410edc1c7a81a10ba3f0efb90a",
        "RepoTags": [
            "alpine:latest",
            "myimage:latest"
        ],
        "RepoDigests": [
            "alpine@sha256:69665d02cb32192e52e07644d76bc6f25abeb5410edc1c7a81a10ba3f0efb90a",
            "myimage@sha256:69665d02cb32192e52e07644d76bc6f25abeb5410edc1c7a81a10ba3f0efb90a"
        ],
...
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/5046555/223697081-e340724b-ab25-48b0-aa5a-dda9f05148fe.png)

