### PR TITLE
c8d/builder: Store untagged images as dangling

### DIFF
--- a/builder/builder-next/exporter/overrides/wrapper.go
+++ b/builder/builder-next/exporter/overrides/wrapper.go
@@ -10,8 +10,9 @@ import (
 // TODO(vvoland): Use buildkit consts once they're public
 // https://github.com/moby/buildkit/pull/3694
 const (
-	keyImageName = "name"
-	keyUnpack    = "unpack"
+	keyImageName      = "name"
+	keyUnpack         = "unpack"
+	keyDanglingPrefix = "dangling-name-prefix"
 )
 
 // Wraps the containerimage exporter's Resolve method to apply moby-specific
@@ -35,6 +36,9 @@ func (e *imageExporterMobyWrapper) Resolve(ctx context.Context, exporterAttrs ma
 	}
 	exporterAttrs[keyImageName] = strings.Join(reposAndTags, ",")
 	exporterAttrs[keyUnpack] = "true"
+	if _, has := exporterAttrs[keyDanglingPrefix]; !has {
+		exporterAttrs[keyDanglingPrefix] = "moby-dangling"
+	}
 
 	return e.exp.Resolve(ctx, exporterAttrs)
 }

--- a/builder/builder-next/exporter/overrides/wrapper.go
+++ b/builder/builder-next/exporter/overrides/wrapper.go
@@ -7,6 +7,13 @@ import (
 	"github.com/moby/buildkit/exporter"
 )
 
+// TODO(vvoland): Use buildkit consts once they're public
+// https://github.com/moby/buildkit/pull/3694
+const (
+	keyImageName = "name"
+	keyUnpack    = "unpack"
+)
+
 // Wraps the containerimage exporter's Resolve method to apply moby-specific
 // overrides to the exporter attributes.
 type imageExporterMobyWrapper struct {
@@ -22,12 +29,12 @@ func (e *imageExporterMobyWrapper) Resolve(ctx context.Context, exporterAttrs ma
 	if exporterAttrs == nil {
 		exporterAttrs = make(map[string]string)
 	}
-	reposAndTags, err := SanitizeRepoAndTags(strings.Split(exporterAttrs["name"], ","))
+	reposAndTags, err := SanitizeRepoAndTags(strings.Split(exporterAttrs[keyImageName], ","))
 	if err != nil {
 		return nil, err
 	}
-	exporterAttrs["name"] = strings.Join(reposAndTags, ",")
-	exporterAttrs["unpack"] = "true"
+	exporterAttrs[keyImageName] = strings.Join(reposAndTags, ",")
+	exporterAttrs[keyUnpack] = "true"
 
 	return e.exp.Resolve(ctx, exporterAttrs)
 }


### PR DESCRIPTION
- Upstreams: https://github.com/rumpl/moby/pull/100

Set buildkit `dangling-name-prefix` attribute to `moby-dangling` which makes it create an containerd image even when user didn't provide any name for the new image.

**- How to verify it**
Before
```bash
$ echo 'FROM alpine' | docker buildx build -
[+] Building 1.9s (5/5) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                  0.0s
 => => transferring dockerfile: 49B                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                       0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                      1.8s
 => [1/1] FROM docker.io/library/alpine@sha256:69665d02cb32192e52e07644d76bc6f25abeb5410edc1c7a81a10ba3f0efb90a                                       0.0s
 => => resolve docker.io/library/alpine@sha256:69665d02cb32192e52e07644d76bc6f25abeb5410edc1c7a81a10ba3f0efb90a                                       0.0s
 => exporting to image                                                                                                                                0.0s
 => => exporting layers                                                                                                                               0.0s
 => => exporting manifest sha256:e713f6240884609e976dd9d955de377ab272d2b5da3bb81cf3e0cc06fe92a2d5                                                     0.0s
 => => exporting config sha256:95f03905f1ed7ba6e36ab6c28bfd9c27ae83c6c9305fb852bfb3c26b4c8edf89                                                       0.0s
 => => exporting attestation manifest sha256:44dc56e9eac9c3cd67fe9eabbbf85f11b0c0fc48733b7cff122af217f9cb3ffd                                         0.0s
 => => exporting manifest list sha256:b92a27782e00e9cb67d8ae8d1cd467f59a971f24236caac5d4a8af17622791c8                                                0.0s

$ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE

$ docker tag b92a27782e00e9cb67d8ae8d1cd467f59a971f24236caac5d4a8af17622791c8 myimage
Error response from daemon: No such image: sha256:b92a27782e00e9cb67d8ae8d1cd467f59a971f24236caac5d4a8af17622791c8

```

After
```bash
$ echo 'FROM alpine' | /usr/libexec/docker/cli-plugins/docker-buildx build -
[+] Building 2.7s (5/5) FINISHED
 => [internal] load .dockerignore                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                       0.0s
 => [internal] load build definition from Dockerfile                                                                                                  0.0s
 => => transferring dockerfile: 49B                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                      2.2s
 => [1/1] FROM docker.io/library/alpine@sha256:69665d02cb32192e52e07644d76bc6f25abeb5410edc1c7a81a10ba3f0efb90a                                       0.3s
 => => resolve docker.io/library/alpine@sha256:69665d02cb32192e52e07644d76bc6f25abeb5410edc1c7a81a10ba3f0efb90a                                       0.0s
 => => sha256:af6eaf76a39c2d3e7e0b8a0420486e3df33c4027d696c076a99a3d0ac09026af 3.26MB / 3.26MB                                                        0.3s
 => exporting to image                                                                                                                                0.4s
 => => exporting layers                                                                                                                               0.0s
 => => exporting manifest sha256:e713f6240884609e976dd9d955de377ab272d2b5da3bb81cf3e0cc06fe92a2d5                                                     0.0s
 => => exporting config sha256:95f03905f1ed7ba6e36ab6c28bfd9c27ae83c6c9305fb852bfb3c26b4c8edf89                                                       0.0s
 => => exporting attestation manifest sha256:534cfefe885504f808b82ecc659590a2230c9110da1c14f22edaeb14f881d6f2                                         0.0s
 => => exporting manifest list sha256:bd46afaeedb5ebfea682fb55d3d3a0d2fe7b91127f0ef9899b3c010739241e58                                                0.0s
 => => naming to moby-dangling@sha256:bd46afaeedb5ebfea682fb55d3d3a0d2fe7b91127f0ef9899b3c010739241e58                                                0.0s
 => => unpacking to moby-dangling@sha256:bd46afaeedb5ebfea682fb55d3d3a0d2fe7b91127f0ef9899b3c010739241e58                                             0.4s

$ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
<none>              <none>              bd46afaeedb5        4 seconds ago       3.26MB

$ docker tag bd46afaeedb5ebfea682fb55d3d3a0d2fe7b91127f0ef9899b3c010739241e58 myimage
$ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
myimage             latest              bd46afaeedb5        1 second ago        3.26MB

```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

