### PR TITLE
Move GetLayerFolders away from the image service

### DIFF
--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -138,11 +138,6 @@ func (i *ImageService) UpdateConfig(maxDownloads, maxUploads int) {
 	panic("not implemented")
 }
 
-// GetLayerFolders returns the layer folders from an image RootFS.
-func (i *ImageService) GetLayerFolders(img *image.Image, rwLayer layer.RWLayer) ([]string, error) {
-	return nil, errdefs.NotImplemented(errors.New("not implemented"))
-}
-
 // GetContainerLayerSize returns the real size & virtual size of the container.
 func (i *ImageService) GetContainerLayerSize(ctx context.Context, containerID string) (int64, int64, error) {
 	ctr := i.containers.Get(containerID)

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -61,10 +61,6 @@ type ImageService interface {
 	Mount(ctx context.Context, container *container.Container) error
 	Unmount(ctx context.Context, container *container.Container) error
 
-	// Windows specific
-
-	GetLayerFolders(img *image.Image, rwLayer layer.RWLayer) ([]string, error)
-
 	// Build
 
 	MakeImageCache(ctx context.Context, cacheFrom []string) (builder.ImageCache, error)

--- a/daemon/images/image_unix.go
+++ b/daemon/images/image_unix.go
@@ -6,16 +6,8 @@ package images // import "github.com/docker/docker/daemon/images"
 import (
 	"context"
 
-	"github.com/docker/docker/image"
-	"github.com/docker/docker/layer"
 	"github.com/sirupsen/logrus"
 )
-
-// GetLayerFolders returns the layer folders from an image RootFS
-func (i *ImageService) GetLayerFolders(img *image.Image, rwLayer layer.RWLayer) ([]string, error) {
-	// Windows specific
-	panic("not implemented")
-}
 
 // GetContainerLayerSize returns the real size & virtual size of the container.
 func (i *ImageService) GetContainerLayerSize(ctx context.Context, containerID string) (int64, int64, error) {

--- a/daemon/images/image_windows.go
+++ b/daemon/images/image_windows.go
@@ -2,42 +2,10 @@ package images
 
 import (
 	"context"
-
-	"github.com/docker/docker/image"
-	"github.com/docker/docker/layer"
-	"github.com/docker/docker/pkg/system"
-	"github.com/pkg/errors"
 )
 
 // GetContainerLayerSize returns real size & virtual size
 func (i *ImageService) GetContainerLayerSize(ctx context.Context, containerID string) (int64, int64, error) {
 	// TODO Windows
 	return 0, 0, nil
-}
-
-// GetLayerFolders returns the layer folders from an image RootFS
-func (i *ImageService) GetLayerFolders(img *image.Image, rwLayer layer.RWLayer) ([]string, error) {
-	folders := []string{}
-	max := len(img.RootFS.DiffIDs)
-	for index := 1; index <= max; index++ {
-		// FIXME: why does this mutate the RootFS?
-		img.RootFS.DiffIDs = img.RootFS.DiffIDs[:index]
-		if !system.IsOSSupported(img.OperatingSystem()) {
-			return nil, errors.Wrapf(system.ErrNotSupportedOperatingSystem, "cannot get layerpath for ImageID %s", img.RootFS.ChainID())
-		}
-		layerPath, err := layer.GetLayerPath(i.layerStore, img.RootFS.ChainID())
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get layer path from graphdriver %s for ImageID %s", i.layerStore, img.RootFS.ChainID())
-		}
-		// Reverse order, expecting parent first
-		folders = append([]string{layerPath}, folders...)
-	}
-	if rwLayer == nil {
-		return nil, errors.New("RWLayer is unexpectedly nil")
-	}
-	m, err := rwLayer.Metadata()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get layer metadata")
-	}
-	return append(folders, m["dir"]), nil
 }


### PR DESCRIPTION
**- What I did**

Moved `GetLayerFolders` away from the image service.

This method is windows specific and is only used in oci_windows.go. There is really no need for it to be in the image service. This change moves this method closer to where it's used.

**- How I did it**

* moved the function to oci_windows.go
* removed the method from the image service interface

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

