### PR TITLE
[WIP]: Streams API

### DIFF
--- a/api/server/router/streams/backend.go
+++ b/api/server/router/streams/backend.go
@@ -1,0 +1,13 @@
+package streams
+
+import (
+	"context"
+
+	"github.com/docker/docker/api/types/streams"
+)
+
+type Backend interface {
+	Create(ctx context.Context, id string, spec streams.Spec) (*streams.Stream, error)
+	Get(ctx context.Context, id string) (*streams.Stream, error)
+	Delete(ctx context.Context, id string) error
+}

--- a/api/server/router/streams/routes.go
+++ b/api/server/router/streams/routes.go
@@ -1,0 +1,49 @@
+package streams
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/docker/docker/api/server/httputils"
+	"github.com/docker/docker/api/types/streams"
+)
+
+func (r *streamRouter) createStream(ctx context.Context, w http.ResponseWriter, req *http.Request, vars map[string]string) error {
+	if err := httputils.ParseForm(req); err != nil {
+		return err
+	}
+
+	var spec streams.Spec
+	if err := httputils.ReadJSON(req, &spec); err != nil {
+		return err
+	}
+
+	stream, err := r.backend.Create(ctx, req.Form.Get("id"), spec)
+	if err != nil {
+		return err
+	}
+	return httputils.WriteJSON(w, http.StatusCreated, stream)
+}
+
+func (r *streamRouter) getStream(ctx context.Context, w http.ResponseWriter, req *http.Request, vars map[string]string) error {
+	if err := httputils.ParseForm(req); err != nil {
+		return err
+	}
+
+	stream, err := r.backend.Get(ctx, vars["id"])
+	if err != nil {
+		return err
+	}
+	return httputils.WriteJSON(w, http.StatusOK, stream)
+}
+
+func (r *streamRouter) deleteStream(ctx context.Context, w http.ResponseWriter, req *http.Request, vars map[string]string) error {
+	if err := httputils.ParseForm(req); err != nil {
+		return err
+	}
+
+	if err := r.backend.Delete(ctx, vars["id"]); err != nil {
+		return err
+	}
+	return nil
+}

--- a/api/server/router/streams/stream.go
+++ b/api/server/router/streams/stream.go
@@ -1,0 +1,32 @@
+package streams
+
+import "github.com/docker/docker/api/server/router"
+
+type streamRouter struct {
+	backend Backend
+	routes  []router.Route
+}
+
+func (r *streamRouter) Routes() []router.Route {
+	ret := make([]router.Route, 0, len(r.routes))
+	for _, route := range r.routes {
+		ret = append(ret, route)
+	}
+	return ret
+}
+
+func (r *streamRouter) initRoutes() {
+	r.routes = []router.Route{
+		router.NewPostRoute("/streams/create", r.createStream),
+		router.NewGetRoute("/streams/{id:.*}", r.getStream),
+		router.NewDeleteRoute("/streams/{id:.*}", r.deleteStream),
+	}
+}
+
+func NewRouter(b Backend) router.Router {
+	r := &streamRouter{
+		backend: b,
+	}
+	r.initRoutes()
+	return r
+}

--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -11,16 +11,32 @@ import (
 
 // ContainerAttachConfig holds the streams to use when connecting to a container to view logs.
 type ContainerAttachConfig struct {
+	// GetStreams is mutually exclusive with Streams.
 	GetStreams func(multiplexed bool) (io.ReadCloser, io.Writer, io.Writer, error)
-	UseStdin   bool
-	UseStdout  bool
-	UseStderr  bool
+
+	// Use<stream> is mutually exclusive with Streams and should not be true if Streams is not nil.
+	UseStdin  bool
+	UseStdout bool
+	UseStderr bool
+
 	Logs       bool
 	Stream     bool
 	DetachKeys string
 	// Used to signify that streams must be multiplexed by producer as endpoint can't manage multiple streams.
 	// This is typically set by HTTP endpoint, while websocket can transport raw streams
+	// This is mutually exclusive with Streams.
 	MuxStreams bool
+
+	// Streams is an optional field that can be used to specify the stream IDs to use for attach.
+	// This is mutually exclusive with Use<stdio>, MuxStreams, and GetStreams.
+	Streams *AttachStreamConfig
+}
+
+// AttachStreamConfig holds the stream ID's that may be used to attach to a container.
+type AttachStreamConfig struct {
+	StdinID  string
+	StdoutID string
+	StderrID string
 }
 
 // PartialLogMetaData provides meta data for a partial log message. Messages

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -39,6 +39,12 @@ type ContainerAttachOptions struct {
 	Logs       bool
 }
 
+type AttachStreamConfig struct {
+	Stdin  string
+	Stdout string
+	Stderr string
+}
+
 // ContainerCommitOptions holds parameters to commit changes into a container.
 type ContainerCommitOptions struct {
 	Reference string

--- a/api/types/streams/stream.go
+++ b/api/types/streams/stream.go
@@ -1,0 +1,35 @@
+package streams
+
+type Protocol string
+
+const (
+	ProtocolPipe        Protocol = "pipe"
+	ProtocolUnixConnect Protocol = "unix-connect"
+	ProtocolTCPConnect  Protocol = "tcp-connect"
+)
+
+type PipeConfig struct {
+	Path string
+}
+
+type UnixConnectConfig struct {
+	Addr string
+}
+
+type TCPConnectConfig struct {
+	Addr string
+	Port int
+}
+
+type Stream struct {
+	ID   string
+	Spec Spec
+}
+
+type Spec struct {
+	Protocol Protocol `json:"protocol"`
+
+	PipeConfig        *PipeConfig        `json:"pipeConfig,omitempty"`
+	UnixConnectConfig *UnixConnectConfig `json:"unixConnectConfig,omitempty"`
+	TCPConnectConfig  *TCPConnectConfig  `json:"tcpConnectConfig,omitempty"`
+}

--- a/client/container_attach.go
+++ b/client/container_attach.go
@@ -57,3 +57,27 @@ func (cli *Client) ContainerAttach(ctx context.Context, container string, option
 	}
 	return cli.postHijacked(ctx, "/containers/"+container+"/attach", query, nil, headers)
 }
+
+func (cli *Client) ContainerAttachStreams(ctx context.Context, container string, options types.AttachStreamConfig) error {
+	query := url.Values{}
+	query.Set("stream", "1")
+
+	if options.Stdin != "" {
+		query.Set("stdin-stream", options.Stdin)
+	}
+
+	if options.Stdout != "" {
+		query.Set("stdout-stream", options.Stdout)
+	}
+
+	if options.Stderr != "" {
+		query.Set("stderr-stream", options.Stderr)
+	}
+
+	resp, err := cli.post(ctx, "/containers/"+container+"/attach", query, nil, nil)
+	if err != nil {
+		return err
+	}
+	defer ensureReaderClosed(resp)
+	return nil
+}

--- a/client/interface.go
+++ b/client/interface.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/api/types/streams"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/volume"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -32,6 +33,7 @@ type CommonAPIClient interface {
 	SecretAPIClient
 	SystemAPIClient
 	VolumeAPIClient
+	StreamAPIClient
 	ClientVersion() string
 	DaemonHost() string
 	HTTPClient() *http.Client
@@ -198,4 +200,10 @@ type ConfigAPIClient interface {
 	ConfigRemove(ctx context.Context, id string) error
 	ConfigInspectWithRaw(ctx context.Context, name string) (swarm.Config, []byte, error)
 	ConfigUpdate(ctx context.Context, id string, version swarm.Version, config swarm.ConfigSpec) error
+}
+
+type StreamAPIClient interface {
+	StreamCreate(ctx context.Context, name string, options streams.Spec) (streams.Stream, error)
+	StreamInspect(ctx context.Context, name string) (streams.Stream, error)
+	StreamDelete(ctx context.Context, name string) error
 }

--- a/client/interface.go
+++ b/client/interface.go
@@ -48,6 +48,7 @@ type CommonAPIClient interface {
 // ContainerAPIClient defines API client methods for the containers
 type ContainerAPIClient interface {
 	ContainerAttach(ctx context.Context, container string, options types.ContainerAttachOptions) (types.HijackedResponse, error)
+	ContainerAttachStreams(ctx context.Context, container string, options types.AttachStreamConfig) error
 	ContainerCommit(ctx context.Context, container string, options types.ContainerCommitOptions) (types.IDResponse, error)
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *specs.Platform, containerName string) (container.CreateResponse, error)
 	ContainerDiff(ctx context.Context, container string) ([]container.ContainerChangeResponseItem, error)

--- a/client/streams.go
+++ b/client/streams.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+
+	"github.com/docker/docker/api/types/streams"
+)
+
+// StreamCreate creates a stream in the daemon host.
+// A stream can be used for bi-directional communication with the daemon.
+func (c *Client) StreamCreate(ctx context.Context, id string, spec streams.Spec) (streams.Stream, error) {
+	var s streams.Stream
+	q := url.Values{}
+	q.Set("id", id)
+	resp, err := c.post(ctx, "/streams/create", q, spec, nil)
+	if err != nil {
+		return s, err
+	}
+	defer ensureReaderClosed(resp)
+
+	if err != nil {
+		return s, err
+	}
+	err = json.NewDecoder(resp.body).Decode(&s)
+	return s, err
+}
+
+// StreamInspect returns information about a stream.
+func (c *Client) StreamInspect(ctx context.Context, id string) (streams.Stream, error) {
+	var s streams.Stream
+	resp, err := c.get(ctx, "/streams/"+id, nil, nil)
+	if err != nil {
+		return s, err
+	}
+	defer ensureReaderClosed(resp)
+
+	if err != nil {
+		return s, err
+	}
+	err = json.NewDecoder(resp.body).Decode(&s)
+	return s, err
+}
+
+// StreamDelete deletes a stream.
+func (c *Client) StreamDelete(ctx context.Context, id string) error {
+	resp, err := c.delete(ctx, "/streams/"+id, nil, nil)
+	if err != nil {
+		return err
+	}
+	defer ensureReaderClosed(resp)
+
+	return nil
+}

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -27,6 +27,7 @@ import (
 	"github.com/docker/docker/api/server/router/network"
 	pluginrouter "github.com/docker/docker/api/server/router/plugin"
 	sessionrouter "github.com/docker/docker/api/server/router/session"
+	"github.com/docker/docker/api/server/router/streams"
 	swarmrouter "github.com/docker/docker/api/server/router/swarm"
 	systemrouter "github.com/docker/docker/api/server/router/system"
 	"github.com/docker/docker/api/server/router/volume"
@@ -522,6 +523,7 @@ func initRouter(opts routerOptions) {
 		swarmrouter.NewRouter(opts.cluster),
 		pluginrouter.NewRouter(opts.daemon.PluginManager()),
 		distributionrouter.NewRouter(opts.daemon.ImageService()),
+		streams.NewRouter(opts.daemon.StreamService()),
 	}
 
 	if opts.buildBackend != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -37,6 +37,7 @@ import (
 	dlogger "github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/daemon/stats"
+	"github.com/docker/docker/daemon/streams"
 	dmetadata "github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/errdefs"
@@ -124,6 +125,8 @@ type Daemon struct {
 	// It stores metadata for the content store (used for manifest caching)
 	// This needs to be closed on daemon exit
 	mdDB *bbolt.DB
+
+	streams *streams.Service
 }
 
 // StoreHosts stores the addresses the daemon is listening on
@@ -953,6 +956,11 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		return nil, err
 	}
 
+	d.streams, err = streams.NewService(ctx, filepath.Join(config.Root, "streams"), filepath.Join(d.configStore.ExecRoot, "streams"))
+	if err != nil {
+		return nil, err
+	}
+
 	// Check if Devices cgroup is mounted, it is hard requirement for container security,
 	// on Linux.
 	//
@@ -1265,6 +1273,10 @@ func (daemon *Daemon) Shutdown(ctx context.Context) error {
 		daemon.mdDB.Close()
 	}
 
+	if daemon.streams != nil {
+		daemon.streams.Close()
+	}
+
 	return daemon.cleanupMounts()
 }
 
@@ -1478,4 +1490,8 @@ func (daemon *Daemon) RawSysInfo() *sysinfo.SysInfo {
 	})
 
 	return daemon.sysInfo
+}
+
+func (daemon *Daemon) StreamService() *streams.Service {
+	return daemon.streams
 }

--- a/daemon/streams/service.go
+++ b/daemon/streams/service.go
@@ -1,0 +1,126 @@
+package streams
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	router "github.com/docker/docker/api/server/router/streams"
+	"github.com/docker/docker/api/types/streams"
+	"github.com/docker/docker/daemon/names"
+	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/pkg/stringid"
+	"github.com/opencontainers/go-digest"
+	"go.etcd.io/bbolt"
+)
+
+var _ router.Backend = (*Service)(nil)
+
+type Service struct {
+	store    *Store
+	execRoot string
+}
+
+func NewService(ctx context.Context, root, execRoot string) (*Service, error) {
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return nil, fmt.Errorf("could not create streams root dir: %w", err)
+	}
+	if err := os.MkdirAll(execRoot, 0o700); err != nil {
+		return nil, fmt.Errorf("could not create streams exec root dir: %w", err)
+	}
+	dbpath := filepath.Join(root, "streams.db")
+
+	timeout := 10 * time.Second
+
+	if deadline, ok := ctx.Deadline(); ok {
+		timeout = deadline.Sub(time.Now())
+	}
+
+	db, err := bbolt.Open(dbpath, 0600, &bbolt.Options{Timeout: timeout})
+	if err != nil {
+		return nil, fmt.Errorf("could not create streams k/v store: %w", err)
+	}
+	return &Service{store: NewStore(db), execRoot: execRoot}, nil
+}
+
+func (s *Service) Create(ctx context.Context, id string, spec streams.Spec) (*streams.Stream, error) {
+	if id == "" {
+		id = stringid.GenerateRandomID()
+	}
+
+	if !names.RestrictedNamePattern.MatchString(id) {
+		return nil, errdefs.InvalidParameter(fmt.Errorf("invalid stream ID: id must match pattern %q", names.RestrictedNameChars))
+	}
+
+	if spec.Protocol == "" {
+		spec.Protocol = streams.ProtocolPipe
+	}
+
+	if spec.Protocol == streams.ProtocolPipe && (spec.PipeConfig == nil || spec.PipeConfig.Path == "") {
+		key := digest.FromBytes([]byte(id))
+		spec.PipeConfig = &streams.PipeConfig{Path: filepath.Join(s.execRoot, key.Encoded())}
+	}
+
+	if err := Validate(spec); err != nil {
+		return nil, err
+	}
+
+	stream := streams.Stream{ID: id, Spec: spec}
+	if err := s.store.Create(stream); err != nil {
+		return nil, err
+	}
+	return &stream, nil
+}
+
+func (s *Service) Get(ctx context.Context, id string) (*streams.Stream, error) {
+	return s.store.Get(id)
+}
+
+func (s *Service) Delete(ctx context.Context, id string) error {
+	return s.store.Delete(id)
+}
+
+func Validate(spec streams.Spec) error {
+	switch spec.Protocol {
+	case streams.ProtocolPipe:
+		if spec.TCPConnectConfig != nil {
+			return errdefs.InvalidParameter(errors.New("tcp connect config must not be set for pipe protocol"))
+		}
+		if spec.UnixConnectConfig != nil {
+			return errdefs.InvalidParameter(errors.New("unix connect config must not be set for pipe protocol"))
+		}
+		if spec.PipeConfig == nil || spec.PipeConfig.Path == "" {
+			return errdefs.InvalidParameter(errors.New("missing pipe config"))
+		}
+	case streams.ProtocolTCPConnect:
+		if spec.PipeConfig != nil {
+			return errdefs.InvalidParameter(errors.New("pipe config must not be set for tcp connect protocol"))
+		}
+		if spec.UnixConnectConfig != nil {
+			return errdefs.InvalidParameter(errors.New("unix connect config must not be set for tcp connect protocol"))
+		}
+		if spec.TCPConnectConfig == nil {
+			return errdefs.InvalidParameter(errors.New("missing tcp connect config"))
+		}
+	case streams.ProtocolUnixConnect:
+		if spec.PipeConfig != nil {
+			return errdefs.InvalidParameter(errors.New("pipe config must not be set for unix connect protocol"))
+		}
+		if spec.TCPConnectConfig != nil {
+			return errdefs.InvalidParameter(errors.New("tcp connect config must not be set for unix connect protocol"))
+		}
+		if spec.UnixConnectConfig == nil {
+			return errdefs.InvalidParameter(errors.New("missing unix connect config"))
+		}
+	default:
+		return errdefs.InvalidParameter(errors.New("unknown protocol"))
+	}
+	return nil
+}
+
+func (s *Service) Close() error {
+	return s.store.Close()
+}

--- a/daemon/streams/store.go
+++ b/daemon/streams/store.go
@@ -1,0 +1,104 @@
+package streams
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/api/types/streams"
+	"github.com/docker/docker/errdefs"
+	"github.com/opencontainers/go-digest"
+	"go.etcd.io/bbolt"
+)
+
+var (
+	bucketName  = []byte("streams")
+	errNotFound = errdefs.NotFound(errors.New("stream not found"))
+)
+
+func NewStore(db *bbolt.DB) *Store {
+	return &Store{db: db}
+}
+
+type Store struct {
+	db  *bbolt.DB
+	dir string
+}
+
+func (s *Store) Create(stream streams.Stream) error {
+	if stream.ID == "" {
+		return errdefs.InvalidParameter(errors.New("stream ID cannot be empty"))
+	}
+
+	data, err := json.Marshal(stream)
+	if err != nil {
+		return errdefs.System(err)
+	}
+
+	id := []byte(stream.ID)
+	err = s.db.Update(func(tx *bbolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists(bucketName)
+		if err != nil {
+			if errors.Is(err, bbolt.ErrBucketNameRequired) {
+				return errdefs.InvalidParameter(err)
+			}
+			return errdefs.System(err)
+		}
+		if bucket.Get(id) != nil {
+			return errdefs.Conflict(fmt.Errorf("stream already exists: %s", stream.ID))
+		}
+		return bucket.Put(id, data)
+	})
+	return err
+}
+
+func (s *Store) Get(key string) (*streams.Stream, error) {
+	k := []byte(key)
+
+	var v []byte
+
+	err := s.db.View(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket(bucketName)
+		if bucket == nil {
+			return errNotFound
+		}
+		v = bucket.Get(k)
+		return nil
+	})
+	if err != nil {
+		return nil, errdefs.System(err)
+	}
+
+	if v == nil {
+		return nil, errNotFound
+	}
+
+	var stream streams.Stream
+	if err := json.Unmarshal(v, &stream); err != nil {
+		return nil, errdefs.System(err)
+	}
+
+	return &stream, nil
+}
+
+func (s *Store) Delete(key string) error {
+	k := []byte(key)
+	return s.db.Update(func(tx *bbolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists(bucketName)
+		if err != nil {
+			return err
+		}
+
+		dgst := digest.FromBytes(k)
+		if err := os.Remove(filepath.Join(s.dir, dgst.String())); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return errdefs.System(err)
+		}
+		return bucket.Delete(k)
+	})
+}
+
+func (s *Store) Close() error {
+	return s.db.Close()
+}

--- a/daemon/streams/store_test.go
+++ b/daemon/streams/store_test.go
@@ -1,0 +1,30 @@
+package streams
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types/streams"
+	"go.etcd.io/bbolt"
+	"gotest.tools/v3/assert"
+)
+
+func TestStore(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := bbolt.Open(filepath.Join(dir, "db"), 0600, &bbolt.Options{Timeout: 10 * time.Second})
+	assert.NilError(t, err)
+	defer db.Close()
+
+	s := NewStore(db)
+	defer s.Close()
+
+	id := "foo"
+	err = s.Create(streams.Stream{ID: id})
+	assert.NilError(t, err)
+
+	stream, err := s.Get(id)
+	assert.NilError(t, err)
+	assert.Equal(t, stream.ID, id)
+}

--- a/daemon/streams/stream.go
+++ b/daemon/streams/stream.go
@@ -1,24 +1,47 @@
 package streams
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
 	"strconv"
 
 	"github.com/docker/docker/api/types/streams"
+	"github.com/docker/docker/pkg/ioutils"
 )
 
-func Open(s *streams.Stream) (io.ReadCloser, io.WriteCloser, error) {
+func Open(ctx context.Context, s *streams.Stream) (io.ReadCloser, io.WriteCloser, error) {
 	switch s.Spec.Protocol {
 	case streams.ProtocolPipe:
 		return openPipe(s.Spec.PipeConfig.Path)
 	case streams.ProtocolUnixConnect:
-		conn, err := net.Dial("unix", s.Spec.UnixConnectConfig.Addr)
-		return conn, conn, err
+		var d net.Dialer
+		conn, err := d.DialContext(ctx, "unix", s.Spec.UnixConnectConfig.Addr)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		uc := conn.(*net.UnixConn)
+		r := ioutils.NewReadCloserWrapper(uc, uc.CloseRead)
+		w := ioutils.NewWriteCloserWrapper(uc, uc.CloseWrite)
+
+		return r, w, nil
 	case streams.ProtocolTCPConnect:
-		conn, err := net.Dial("tcp", s.Spec.TCPConnectConfig.Addr+":"+strconv.Itoa(s.Spec.TCPConnectConfig.Port))
-		return conn, conn, err
+		var d net.Dialer
+		conn, err := d.DialContext(ctx, "tcp", s.Spec.TCPConnectConfig.Addr+":"+strconv.Itoa(s.Spec.TCPConnectConfig.Port))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		tc := conn.(*net.TCPConn)
+		if err := tc.SetKeepAlive(true); err != nil {
+			return nil, nil, err
+		}
+		r := ioutils.NewReadCloserWrapper(tc, tc.CloseRead)
+		w := ioutils.NewWriteCloserWrapper(tc, tc.CloseWrite)
+
+		return r, w, err
 	}
 	return nil, nil, fmt.Errorf("unknown protocol")
 }

--- a/daemon/streams/stream.go
+++ b/daemon/streams/stream.go
@@ -1,0 +1,24 @@
+package streams
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+
+	"github.com/docker/docker/api/types/streams"
+)
+
+func Open(s *streams.Stream) (io.ReadCloser, io.WriteCloser, error) {
+	switch s.Spec.Protocol {
+	case streams.ProtocolPipe:
+		return openPipe(s.Spec.PipeConfig.Path)
+	case streams.ProtocolUnixConnect:
+		conn, err := net.Dial("unix", s.Spec.UnixConnectConfig.Addr)
+		return conn, conn, err
+	case streams.ProtocolTCPConnect:
+		conn, err := net.Dial("tcp", s.Spec.TCPConnectConfig.Addr+":"+strconv.Itoa(s.Spec.TCPConnectConfig.Port))
+		return conn, conn, err
+	}
+	return nil, nil, fmt.Errorf("unknown protocol")
+}

--- a/daemon/streams/stream_linux.go
+++ b/daemon/streams/stream_linux.go
@@ -1,0 +1,13 @@
+package streams
+
+import (
+	"io"
+	"os"
+
+	"github.com/cpuguy83/pipes"
+)
+
+func openPipe(path string) (io.ReadCloser, io.WriteCloser, error) {
+	flags := os.O_RDWR | os.O_CREATE
+	return pipes.OpenFifo(path, flags, 0o660)
+}

--- a/daemon/streams/stream_windows.go
+++ b/daemon/streams/stream_windows.go
@@ -1,0 +1,23 @@
+package streams
+
+import (
+	"io"
+
+	"github.com/Microsoft/go-winio"
+)
+
+func openPipe(path string) (io.ReadCloser, io.WriteCloser, error) {
+	// Open the pipe twice so we can close one side without closing the other.
+
+	r, err := winio.DialPipe(path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	w, err := winio.DialPipe(path, nil)
+	if err != nil {
+		r.Close()
+		return nil, nil, err
+	}
+	return r, w, nil
+}

--- a/errdefs/is.go
+++ b/errdefs/is.go
@@ -23,9 +23,15 @@ func getImplementer(err error) error {
 		return err
 	case causer:
 		return getImplementer(e.Cause())
+	case unwrapper:
+		return getImplementer(e.Unwrap())
 	default:
 		return err
 	}
+}
+
+type unwrapper interface {
+	Unwrap() error
 }
 
 // IsNotFound returns if the passed in error is an ErrNotFound

--- a/integration/container/attach_test.go
+++ b/integration/container/attach_test.go
@@ -1,13 +1,24 @@
 package container // import "github.com/docker/docker/integration/container"
 
 import (
+	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/cpuguy83/pipes"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/api/types/streams"
+	"github.com/docker/docker/pkg/stringid"
+	"golang.org/x/sys/unix"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+
+	intctr "github.com/docker/docker/integration/internal/container"
 )
 
 func TestAttachWithTTY(t *testing.T) {
@@ -47,4 +58,127 @@ func testAttach(t *testing.T, tty bool, expected string) {
 	mediaType, ok := attach.MediaType()
 	assert.Check(t, ok)
 	assert.Check(t, mediaType == expected)
+}
+
+func openFifo(t *testing.T, p string, flag int, perm os.FileMode) <-chan pipes.OpenFifoResult {
+	t.Helper()
+
+	waiter, err := pipes.AsyncOpenFifo(p, flag, perm)
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		select {
+		case res := <-waiter:
+			assert.Check(t, cmp.Nil(res.Err))
+			if res.W != nil {
+				res.W.Close()
+			}
+			if res.R != nil {
+				res.R.Close()
+			}
+		default:
+		}
+	})
+	return waiter
+}
+
+func TestAttachStreams(t *testing.T) {
+	defer setupTest(t)()
+	client := testEnv.APIClient()
+	defer client.Close()
+
+	dir := t.TempDir()
+	stdinP := filepath.Join(dir, "stdin")
+	stdoutP := filepath.Join(dir, "stdout")
+	stderrP := filepath.Join(dir, "stderr")
+
+	stdinWaiter := openFifo(t, stdinP, unix.O_WRONLY|unix.O_CREAT, 0600)
+	stdoutWaiter := openFifo(t, stdoutP, unix.O_RDONLY|unix.O_CREAT, 0600)
+	stderrWaiter := openFifo(t, stderrP, unix.O_RDONLY|unix.O_CREAT, 0600)
+
+	ctx := context.Background()
+
+	stdinID := stringid.GenerateRandomID()
+	resp, err := client.StreamCreate(ctx, stdinID, streams.Spec{
+		Protocol: streams.ProtocolPipe,
+		PipeConfig: &streams.PipeConfig{
+			Path: stdinP,
+		},
+	})
+	assert.NilError(t, err)
+	defer client.StreamDelete(ctx, resp.ID)
+
+	stdoutID := stringid.GenerateRandomID()
+	resp, err = client.StreamCreate(ctx, stdoutID, streams.Spec{
+		Protocol: streams.ProtocolPipe,
+		PipeConfig: &streams.PipeConfig{
+			Path: stdoutP,
+		},
+	})
+	assert.NilError(t, err)
+	defer client.StreamDelete(ctx, resp.ID)
+
+	stderrID := stringid.GenerateRandomID()
+	resp, err = client.StreamCreate(ctx, stderrID, streams.Spec{
+		Protocol: streams.ProtocolPipe,
+		PipeConfig: &streams.PipeConfig{
+			Path: stderrP,
+		},
+	})
+	assert.NilError(t, err)
+	defer client.StreamDelete(ctx, resp.ID)
+
+	id := intctr.Run(ctx, t, client, func(cfg *intctr.TestContainerConfig) {
+		cfg.Config.OpenStdin = true
+		cfg.Config.AttachStdin = true
+		cfg.Config.AttachStdout = true
+		cfg.Config.AttachStderr = true
+		cfg.Config.Cmd = []string{"cat", "-"}
+	})
+
+	chErr := make(chan error, 1)
+	go func() {
+		err = client.ContainerAttachStreams(ctx, id, types.AttachStreamConfig{
+			Stdin:  stdinID,
+			Stdout: stdoutID,
+			Stderr: stderrID,
+		})
+		chErr <- err
+	}()
+
+	waitForPipe := func(waiter <-chan pipes.OpenFifoResult) pipes.OpenFifoResult {
+		t.Helper()
+		timer := time.NewTimer(30 * time.Second)
+		defer timer.Stop()
+
+		select {
+		case res := <-waiter:
+			assert.NilError(t, res.Err)
+			return res
+		case err := <-chErr:
+			assert.NilError(t, err, "attach failed")
+		case <-timer.C:
+			t.Fatal("timed out waiting for pipe to open")
+		}
+		panic("unreachable")
+	}
+
+	stdin := waitForPipe(stdinWaiter)
+	defer stdin.W.Close()
+
+	stdout := waitForPipe(stdoutWaiter)
+	defer stdout.R.Close()
+
+	stderr := waitForPipe(stderrWaiter)
+	defer stderr.R.Close()
+
+	payload := []byte("hello\n")
+	_, err = stdin.W.Write(payload)
+	assert.NilError(t, err)
+	stdin.W.Close()
+
+	buf := make([]byte, len(payload))
+	// n, err := io.ReadFull(stdout.R, buf)
+	n, err := stdout.R.Read(buf)
+	assert.NilError(t, err)
+	assert.Assert(t, bytes.Equal(payload[:n], buf))
 }

--- a/integration/internal/container/container.go
+++ b/integration/internal/container/container.go
@@ -51,6 +51,10 @@ func Create(ctx context.Context, t *testing.T, client client.APIClient, ops ...f
 	c, err := create(ctx, t, client, ops...)
 	assert.NilError(t, err)
 
+	t.Cleanup(func() {
+		client.ContainerRemove(ctx, c.ID, types.ContainerRemoveOptions{Force: true, RemoveVolumes: true})
+	})
+
 	return c.ID
 }
 

--- a/vendor.mod
+++ b/vendor.mod
@@ -124,6 +124,7 @@ require (
 	github.com/containerd/ttrpc v1.1.0 // indirect
 	github.com/containerd/typeurl v1.0.2 // indirect
 	github.com/containernetworking/cni v1.1.1 // indirect
+	github.com/cpuguy83/pipes v0.1.1
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect

--- a/vendor.sum
+++ b/vendor.sum
@@ -469,6 +469,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/pipes v0.1.1 h1:xUQ5u2xfMaqxWd8J9VSmltU45PA1azfizlg4QF8ssV0=
+github.com/cpuguy83/pipes v0.1.1/go.mod h1:ZwnWkqeVtjPomMTJejcl/gvHvMmpRlMmb3gDV6+Ff/c=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=

--- a/vendor/github.com/cpuguy83/pipes/README.md
+++ b/vendor/github.com/cpuguy83/pipes/README.md
@@ -1,0 +1,57 @@
+# Pipes
+
+A library to work with OS pipes which takes advantage of OS-level optimizations.
+
+## Why pipes?
+
+The idea behind this library is to enable copying between different file
+descriptors without the normal overhead of `read(bytes) && write(bytes)`, which
+is 2 system calls and 2 copies between userspace and kernel space.
+
+In the implementation here we use the splice(2) system call to move bytes from
+the read side to the write side. This means there is only 1 system call to
+perform and no data copied into userspace. In many cases there is no copying
+even in kernel space as the pointer to the data is just shifted between the two
+fd's.
+
+The important thing to note here is that the only benefit that this library
+brings is if you are copying between to another file descriptor (such as, but
+not limited to, a regular file or a tcp socket).
+
+### Benchmarks
+
+This compares against using io.Copy directly on the underlying *os.File vs the
+optimized ReadFrom implementation here.
+
+A note about these benchmarks, as it turns out it is pretty difficult to test
+throughput accurately. For instance the tests currently just dumbly drain data
+out of the pipe with `io.Copy(ioutil.Discard, pipe)` while the benchmark is in
+progress so we can test how write speed. This can in and of itself be a
+bottleneck. However, the benchmarks do let us compare throughput across
+different implementations with the same bottlenecks.
+
+```
+benchmark                                  old ns/op     new ns/op     delta
+BenchmarkReadFrom/regular_file/16K-4       32933         16940         -48.56%
+BenchmarkReadFrom/regular_file/32K-4       43407         24365         -43.87%
+BenchmarkReadFrom/regular_file/64K-4       65497         39097         -40.31%
+BenchmarkReadFrom/regular_file/128K-4      102643        61719         -39.87%
+BenchmarkReadFrom/regular_file/256K-4      172160        99404         -42.26%
+BenchmarkReadFrom/regular_file/512K-4      299951        178221        -40.58%
+BenchmarkReadFrom/regular_file/1MB-4       552199        322710        -41.56%
+BenchmarkReadFrom/regular_file/10MB-4      5256567       3632938       -30.89%
+BenchmarkReadFrom/regular_file/100MB-4     54652792      35899298      -34.31%
+BenchmarkReadFrom/regular_file/1GB-4       552312826     383047329     -30.65%
+
+benchmark                                  old MB/s     new MB/s     speedup
+BenchmarkReadFrom/regular_file/16K-4       497.49       967.17       1.94x
+BenchmarkReadFrom/regular_file/32K-4       754.89       1344.89      1.78x
+BenchmarkReadFrom/regular_file/64K-4       1000.60      1676.24      1.68x
+BenchmarkReadFrom/regular_file/128K-4      1276.96      2123.68      1.66x
+BenchmarkReadFrom/regular_file/256K-4      1522.67      2637.17      1.73x
+BenchmarkReadFrom/regular_file/512K-4      1747.91      2941.78      1.68x
+BenchmarkReadFrom/regular_file/1MB-4       1898.91      3249.28      1.71x
+BenchmarkReadFrom/regular_file/10MB-4      1994.79      2886.30      1.45x
+BenchmarkReadFrom/regular_file/100MB-4     1918.61      2920.88      1.52x
+BenchmarkReadFrom/regular_file/1GB-4       1944.08      2803.16      1.44x
+```

--- a/vendor/github.com/cpuguy83/pipes/copier_linux.go
+++ b/vendor/github.com/cpuguy83/pipes/copier_linux.go
@@ -1,0 +1,299 @@
+package pipes
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func NewCopier(ctx context.Context, r *PipeReader, writers ...*PipeWriter) (*Copier, error) {
+	ls := make([]syscall.RawConn, 0, len(writers))
+	for _, w := range writers {
+		wrc, err := w.SyscallConn()
+		if err != nil {
+			return nil, err
+		}
+		ls = append(ls, wrc)
+	}
+
+	rwc, err := r.SyscallConn()
+	if err != nil {
+		return nil, err
+	}
+
+	var buf [2]int
+	if err := unix.Pipe2(buf[:], unix.O_NONBLOCK|unix.O_CLOEXEC); err != nil {
+		return nil, fmt.Errorf("error creating pipe buffer: %w", err)
+	}
+
+	c := &Copier{
+		r:       rwc,
+		writers: ls,
+		buf:     buf,
+	}
+
+	c.cond = sync.NewCond(&c.mu)
+
+	go c.run(ctx)
+
+	return c, nil
+}
+
+type Copier struct {
+	r       syscall.RawConn
+	writers []syscall.RawConn
+
+	mu        sync.Mutex
+	cond      *sync.Cond
+	pending   []syscall.RawConn
+	closedErr error
+
+	buf [2]int
+
+	// This is used for teseting purposes
+	_lastErr error
+}
+
+func (c *Copier) run(ctx context.Context) {
+	defer func() {
+		unix.Close(c.buf[0])
+		unix.Close(c.buf[1])
+	}()
+
+	for {
+		if err := c.wait(ctx); err != nil {
+			return
+		}
+
+		c.doCopy(ctx)
+	}
+}
+
+func (c *Copier) setClosedErr(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err == nil || c.closedErr != nil {
+		return
+	}
+
+	c.closedErr = err
+}
+
+func (c *Copier) Add(w *PipeWriter) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.closedErr; err != nil {
+		return err
+	}
+
+	wrc, err := w.SyscallConn()
+	if err != nil {
+		return err
+	}
+
+	c.pending = append(c.pending, wrc)
+	c.cond.Signal()
+
+	return nil
+}
+
+func (c *Copier) lastErr() error {
+	c.mu.Lock()
+	err := c._lastErr
+	c.mu.Unlock()
+	return err
+}
+
+func (c *Copier) shouldWait(ctx context.Context) bool {
+	return len(c.writers) == 0 && len(c.pending) == 0 && c.closedErr == nil && ctx.Err() == nil
+}
+
+func (c *Copier) wait(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for c.shouldWait(ctx) {
+		c.cond.Wait()
+	}
+
+	if c.closedErr != nil {
+		return c.closedErr
+	}
+
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	if len(c.pending) > 0 {
+		c.writers = append(c.writers, c.pending...)
+		c.pending = c.pending[:0]
+	}
+	return nil
+}
+
+func (c *Copier) doCopy(ctx context.Context) {
+	if ctx.Err() != nil {
+		c.setClosedErr(ctx.Err())
+		return
+	}
+
+	var (
+		evict []int
+	)
+
+	err := c.r.Read(func(rfd uintptr) bool {
+		if err := c.wait(ctx); err != nil {
+			return true
+		}
+
+		var (
+			spliced bool
+		)
+
+		total, err := splice(int(rfd), c.buf[1], 0)
+		if err != nil && err != unix.EAGAIN {
+			c.setClosedErr(err)
+			return true
+		}
+
+		if total == 0 {
+			if err == unix.EAGAIN {
+				return false
+			}
+			if err == nil {
+				c.setClosedErr(io.EOF)
+				return true
+			}
+		}
+
+		for i, wrc := range c.writers {
+			if ctx.Err() != nil {
+				c.setClosedErr(ctx.Err())
+				return true
+			}
+
+			if i == len(c.writers)-1 {
+				n, err := c.doSplice(uintptr(c.buf[0]), wrc, total)
+				if (err != nil && err != unix.EAGAIN) || (total > 0 && n < total) {
+					c.mu.Lock()
+					c._lastErr = err
+					c.mu.Unlock()
+					evict = append(evict, i)
+				}
+			} else {
+				n, err := c.doTee(uintptr(c.buf[0]), wrc, total)
+				if err != nil || (total > 0 && n < total) {
+					if err != unix.EAGAIN && total > 0 && n < total {
+						c.mu.Lock()
+						c._lastErr = err
+						c.mu.Unlock()
+						evict = append(evict, i)
+						continue
+					}
+				}
+				if total == 0 {
+					total = n
+				}
+			}
+		}
+
+		// We only splice on the last writer
+		// If for some reason we couldn't do that then we need to drain that data
+		// from the buffer.
+		if !spliced && total > 0 {
+			buf := make([]byte, 32*1024)
+			nn := total
+			for nn > 0 {
+				if int64(len(buf)) > nn {
+					buf = buf[:nn]
+				}
+				n, err := unix.Read(c.buf[0], buf)
+				if n > 0 {
+					nn -= int64(n)
+				}
+				if err != nil {
+					if err != unix.EAGAIN {
+						c.setClosedErr(err)
+					}
+					return true
+				}
+			}
+		}
+
+		return true
+	})
+
+	for n, i := range evict {
+		c.writers = append(c.writers[:i-n], c.writers[i-n+1:]...)
+	}
+
+	if err != nil {
+		c.setClosedErr(err)
+	}
+}
+
+// Copier calls doSplice when it is copying to the last (or only) writer.
+//
+// When `total` is 0, this should be the *only* writer.
+// In such a case we only want to splice until EAGAIN (or some fatal error).
+//
+// When `total` is greater than zero we need to keep trying until either
+// we have written `total` bytes OR some fatal error (*not* EGAIN).
+func (c *Copier) doSplice(rfd uintptr, wrc syscall.RawConn, total int64) (int64, error) {
+	var (
+		written   int64
+		spliceErr error
+	)
+
+	writeErr := wrc.Write(func(wfd uintptr) bool {
+		n, err := splice(int(rfd), int(wfd), total-written)
+		if n > 0 {
+			written += n
+		}
+		spliceErr = err
+
+		if n == 0 && spliceErr == nil {
+			spliceErr = io.EOF
+		}
+
+		return true
+	})
+	if writeErr != nil {
+		return written, writeErr
+	}
+	return written, spliceErr
+}
+
+func (c *Copier) doTee(rfd uintptr, wrc syscall.RawConn, total int64) (int64, error) {
+	var (
+		written int64
+		teeErr  error
+	)
+
+	writeErr := wrc.Write(func(wfd uintptr) bool {
+		n, err := tee(int(rfd), int(wfd), total-written)
+		if n > 0 {
+			written += n
+		}
+		teeErr = err
+
+		if n == 0 {
+			if err == nil {
+				teeErr = io.EOF
+			}
+		}
+
+		return true
+	})
+
+	if writeErr != nil {
+		return written, writeErr
+	}
+	return written, teeErr
+}

--- a/vendor/github.com/cpuguy83/pipes/pipes_linux.go
+++ b/vendor/github.com/cpuguy83/pipes/pipes_linux.go
@@ -1,0 +1,200 @@
+package pipes
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// New creates a pipe with a read and a write end.
+// Writes on one end are met with reads on the other.
+//
+// This uses pipe2(2) to create the pipe.
+func New() (*PipeReader, *PipeWriter, error) {
+	var p [2]int
+	if err := unix.Pipe2(p[:], unix.O_CLOEXEC|unix.O_NONBLOCK); err != nil {
+		return nil, nil, err
+	}
+	pr := &PipeReader{fd: os.NewFile(uintptr(p[0]), "read")}
+	pw := &PipeWriter{fd: os.NewFile(uintptr(p[1]), "write")}
+	return pr, pw, nil
+}
+
+// Open opens a fifo in read only mode
+// It *does not* block when opening.
+// This should have smiliar semantics to os.Open, except this is for a fifo.
+//
+// See OpenFifo more more granular control.
+func Open(p string) (*PipeReader, error) {
+	pr, _, err := OpenFifo(p, os.O_RDONLY, 0)
+	return pr, err
+}
+
+// Create opens the fifo with RDWR mode. If the fifo does not exist it will
+// create it with 0666 (before umask) permissions.
+//
+// This should have similar semnatics to os.Create, except for fifos.
+func Create(p string) (*PipeReader, *PipeWriter, error) {
+	return OpenFifo(p, os.O_RDWR|os.O_CREATE, 0666)
+}
+
+// OpenFifoResult is used by AsyncOpenFifo to send the results of OpenFifo to a
+// caller.
+type OpenFifoResult struct {
+	R   *PipeReader
+	W   *PipeWriter
+	Err error
+}
+
+// AsyncOpenFifo opens the fifo in a goroutine and sends the result on a channel.
+// This is usefull, for instance, if you want to open in write-only mode and the
+// read side is not yet open.
+//
+// Note that this will create the fifo *before* returning *if* you have passed os.O_CREATE.
+func AsyncOpenFifo(p string, flag int, mode os.FileMode) (<-chan OpenFifoResult, error) {
+	if err := mkFifo(p, flag, mode); err != nil {
+		return nil, err
+	}
+
+	ch := make(chan OpenFifoResult, 1)
+	go func() {
+		pr, pw, err := OpenFifo(p, flag, mode)
+		ch <- OpenFifoResult{R: pr, W: pw, Err: err}
+	}()
+	return ch, nil
+}
+
+func mkFifo(p string, flag int, mode os.FileMode) error {
+	if flag&os.O_CREATE == 0 {
+		// nothing to do
+		return nil
+	}
+
+	if _, err := os.Stat(p); !os.IsNotExist(err) {
+		return err
+	}
+	return unix.Mkfifo(p, uint32(mode.Perm()))
+}
+
+// OpenFifo opens a fifo from the provided path.
+// The fifo is always opened in non-blocking mode.
+//
+// If flag includes os.O_CREATE this will create the fifo.
+// The mode parameter should be used to set fifo permissions.
+//
+// Note, according to Linux fifo semantics, this will block if you are trying
+// to open as os.O_WRONLY and nothing has the fifo opened in read-mode. To
+// ensure a non-blocking experience, use os.O_RDWR.
+// You can open once with RDWR, then open again with O_WRONLY to get around
+// this semantic.
+//
+// If no open mode is specified (RDWR, RDONLY, WRONLY), then RDWR is used.
+func OpenFifo(p string, flag int, mode os.FileMode) (pr *PipeReader, pw *PipeWriter, _ error) {
+	if flag&os.O_RDWR == 0 && flag&os.O_RDONLY == 0 && flag&os.O_WRONLY == 0 {
+		flag |= os.O_RDWR
+	}
+
+	if err := mkFifo(p, flag, mode); err != nil {
+		return nil, nil, err
+	}
+
+	flag &= ^os.O_CREATE
+
+	f, err := os.OpenFile(p, flag, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var maybeDup bool
+	if flag&os.O_RDONLY != 0 || flag&os.O_RDWR != 0 {
+		maybeDup = true
+		pr = &PipeReader{fd: f}
+	}
+	if flag&os.O_WRONLY != 0 || flag&os.O_RDWR != 0 {
+		if maybeDup {
+			// we need to dup the file descriptor so we can have two
+			// file descriptors open to the same fifo.
+			// This is because the underlying file descriptor is shared
+			// between the two ends of the fifo.
+
+			rc, err := f.SyscallConn()
+			if err != nil {
+				return nil, nil, err
+			}
+
+			var (
+				dupErr error
+				nfd    int
+			)
+			err = rc.Control(func(fd uintptr) {
+				nfd, dupErr = unix.Dup(int(fd))
+			})
+			if err == nil && dupErr != nil {
+				dupErr = os.NewSyscallError("dup", dupErr)
+			}
+			if err != nil {
+				return nil, nil, err
+			}
+
+			f = os.NewFile(uintptr(nfd), p)
+
+		}
+		pw = &PipeWriter{fd: f}
+	}
+	return pr, pw, nil
+}
+
+func splice(rfd, wfd int, remain int64) (copied int64, spliceErr error) {
+	noEnd := remain == 0
+	if noEnd {
+		remain = 1 << 62
+	}
+
+	spliceOpts := unix.SPLICE_F_MOVE | unix.SPLICE_F_NONBLOCK | unix.SPLICE_F_MORE
+
+	for remain > 0 {
+		n, err := unix.Splice(rfd, nil, wfd, nil, int(remain), spliceOpts)
+		if n > 0 {
+			copied += int64(n)
+			if !noEnd {
+				remain -= int64(n)
+			}
+		}
+
+		spliceErr = err
+
+		if err != nil {
+			if err == unix.EINTR {
+				continue
+			}
+			return
+		}
+
+		if n == 0 {
+			// EOF
+			return
+		}
+	}
+
+	return
+}
+
+func tee(rfd, wfd int, do int64) (copied int64, teeErr error) {
+	if do == 0 {
+		do = 1 << 62
+	}
+
+	// Note, this is not using SPLICE_F_NONBLOCK otherwise we'll end up getting in
+	// a situation where we copied less than desired due to non-blocking writes,
+	// but then with tee we can't try again because the reader side has not
+	// advanced at all.
+	for {
+		n, err := unix.Tee(rfd, wfd, int(do), unix.SPLICE_F_MOVE)
+		if err == unix.EINTR {
+			continue
+		}
+		if n > 0 || err != nil {
+			return n, err
+		}
+	}
+}

--- a/vendor/github.com/cpuguy83/pipes/read.go
+++ b/vendor/github.com/cpuguy83/pipes/read.go
@@ -1,0 +1,22 @@
+package pipes
+
+import (
+	"os"
+	"syscall"
+)
+
+type PipeReader struct {
+	fd *os.File
+}
+
+func (r *PipeReader) Read(p []byte) (int, error) {
+	return r.fd.Read(p)
+}
+
+func (r *PipeReader) Close() error {
+	return r.fd.Close()
+}
+
+func (r *PipeReader) SyscallConn() (syscall.RawConn, error) {
+	return r.fd.SyscallConn()
+}

--- a/vendor/github.com/cpuguy83/pipes/read_linux.go
+++ b/vendor/github.com/cpuguy83/pipes/read_linux.go
@@ -1,0 +1,61 @@
+package pipes
+
+import (
+	"io"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func (r *PipeReader) WriteTo(w io.Writer) (int64, error) {
+	if wc, ok := w.(syscall.Conn); ok {
+		if raw, err := wc.SyscallConn(); err == nil {
+			handled, n, err := r.writeTo(raw)
+			if handled || err == nil {
+				return n, err
+			}
+		}
+	}
+
+	return io.Copy(w, r.fd)
+}
+
+func (r *PipeReader) writeTo(w syscall.RawConn) (bool, int64, error) {
+	rc, err := r.SyscallConn()
+	if err != nil {
+		return false, 0, err
+	}
+
+	var (
+		copied    int64
+		readErr   error
+		spliceErr error
+	)
+
+	// Beceause the writer may not be pollable we need to call `Read` first (which we know is pollable).
+	err = rc.Read(func(rfd uintptr) bool {
+		readErr = w.Write(func(wfd uintptr) bool {
+			var n int64
+			n, spliceErr = splice(int(rfd), int(wfd), 0)
+			if n > 0 {
+				copied += n
+			}
+			return true
+		})
+
+		if readErr != nil {
+			return true
+		}
+		return spliceErr != unix.EAGAIN
+	})
+
+	if err != nil {
+		return copied > 0, copied, err
+	}
+
+	if readErr != nil {
+		return copied > 0, copied, readErr
+	}
+
+	return copied > 0, copied, err
+}

--- a/vendor/github.com/cpuguy83/pipes/write.go
+++ b/vendor/github.com/cpuguy83/pipes/write.go
@@ -1,0 +1,22 @@
+package pipes
+
+import (
+	"os"
+	"syscall"
+)
+
+type PipeWriter struct {
+	fd *os.File
+}
+
+func (w *PipeWriter) Write(p []byte) (int, error) {
+	return w.fd.Write(p)
+}
+
+func (w *PipeWriter) Close() error {
+	return w.fd.Close()
+}
+
+func (w *PipeWriter) SyscallConn() (syscall.RawConn, error) {
+	return w.fd.SyscallConn()
+}

--- a/vendor/github.com/cpuguy83/pipes/write_linux.go
+++ b/vendor/github.com/cpuguy83/pipes/write_linux.go
@@ -1,0 +1,86 @@
+package pipes
+
+import (
+	"io"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// ReadFrom implements io.ReaderFrom for the pipe writer. It tries to use
+// splice(2) to splice data from the passed in reader to the pipe. If the
+// reader does not support splicing then it falls back to normal io.Copy
+// semantics.
+func (w *PipeWriter) ReadFrom(r io.Reader) (int64, error) {
+	var (
+		remain int64 = 0
+		rr           = r
+	)
+
+	if lr, ok := r.(*io.LimitedReader); ok {
+		rr = lr.R
+		remain = lr.N
+		if remain == 0 {
+			return 0, nil
+		}
+	}
+
+	if rc, ok := rr.(syscall.Conn); ok {
+		if raw, err := rc.SyscallConn(); err == nil {
+			handled, n, err := w.readFrom(raw, remain)
+			if handled || err == nil {
+				return n, err
+			}
+		}
+	}
+
+	return io.Copy(w.fd, r)
+}
+
+func (w *PipeWriter) readFrom(rc syscall.RawConn, remain int64) (bool, int64, error) {
+	// TODO: Maybe cache this
+	wc, err := w.fd.SyscallConn()
+	if err != nil {
+		return false, 0, err
+	}
+
+	var (
+		copied    int64
+		readErr   error
+		noEnd     = remain == 0
+		spliceErr error
+	)
+
+	// Beceause the reader may not be pollable we need to call `Write` first (which we know is pollable).
+	err = wc.Write(func(wfd uintptr) bool {
+		readErr = rc.Read(func(rfd uintptr) bool {
+			var n int64
+			n, spliceErr = splice(int(rfd), int(wfd), remain)
+			if n > 0 {
+				copied += n
+				if !noEnd {
+					remain -= n
+				}
+			}
+			return true
+		})
+
+		if readErr != nil {
+			return true
+		}
+		if remain == 0 && !noEnd {
+			return true
+		}
+		return spliceErr != unix.EAGAIN
+	})
+
+	if err != nil {
+		return copied > 0, copied, err
+	}
+
+	if readErr != nil {
+		return copied > 0, copied, readErr
+	}
+
+	return copied > 0, copied, err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -349,6 +349,9 @@ github.com/coreos/go-systemd/v22/activation
 github.com/coreos/go-systemd/v22/daemon
 github.com/coreos/go-systemd/v22/dbus
 github.com/coreos/go-systemd/v22/journal
+# github.com/cpuguy83/pipes v0.1.1
+## explicit; go 1.16
+github.com/cpuguy83/pipes
 # github.com/creack/pty v1.1.11
 ## explicit; go 1.13
 github.com/creack/pty


### PR DESCRIPTION
Posting for feedback as to the design.

Streams is a new API that allows clients to register bi-directional streams with dockerd.
A couple of concrete scenarios where this could be beneficial:

1. Client->container port forwarding - e.g. a client has a service it wants to expose to a container.
2. Attaching to container stdio - there is an implementation of this in the 2nd commit. Enables attaches without dealing with HTTP connection hijacking or requiring stream multiplexing.

Other potential uses:
1. Plugin registration/communication channel
2. Backchannel to an external buildkit daemon to enable dockerd to efficiently pass off builds to (e.g.) newer buildkit daemons.