### PR TITLE
builder-next: disable mergeop and diffop

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -70,6 +70,9 @@ jobs:
         name: Prepare
         run: |
           disabledFeatures="cache_backend_azblob,cache_backend_s3"
+          if [ "${{ matrix.worker }}" = "dockerd" ]; then
+            disabledFeatures="${disabledFeatures},merge_diff"
+          fi
           echo "BUILDKIT_TEST_DISABLE_FEATURES=${disabledFeatures}" >> $GITHUB_ENV
       -
         name: Checkout

--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -49,6 +49,9 @@ import (
 	"github.com/pkg/errors"
 	"go.etcd.io/bbolt"
 	bolt "go.etcd.io/bbolt"
+
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/apicaps"
 )
 
 func newController(ctx context.Context, rt http.RoundTripper, opt Opt) (*control.Controller, error) {
@@ -164,6 +167,18 @@ func newGraphDriverController(ctx context.Context, rt http.RoundTripper, opt Opt
 
 	dist := opt.Dist
 	root := opt.Root
+
+	pb.Caps.Init(apicaps.Cap{
+		ID:                pb.CapMergeOp,
+		Enabled:           false,
+		DisabledReasonMsg: "only enabled with containerd image store backend",
+	})
+
+	pb.Caps.Init(apicaps.Cap{
+		ID:                pb.CapDiffOp,
+		Enabled:           false,
+		DisabledReasonMsg: "only enabled with containerd image store backend",
+	})
 
 	var driver graphdriver.Driver
 	if ls, ok := dist.LayerStore.(interface {


### PR DESCRIPTION
- Rebase of #45112 onto master
- Addresses #45111

Temporarily disable Merge/Diff until there is a proper solution to #45111. Dockerfiles will detect the missing capability for `COPY --link` and fall back to the behavior in 20.10.