### PR TITLE
libnetwork: devirtualize package `internal/setmatrix`

### DIFF
--- a/libnetwork/drivers/overlay/peerdb.go
+++ b/libnetwork/drivers/overlay/peerdb.go
@@ -63,7 +63,7 @@ func (p *peerEntryDB) UnMarshalDB() peerEntry {
 
 type peerMap struct {
 	// set of peerEntry, note they have to be objects and not pointers to maintain the proper equality checks
-	mp setmatrix.SetMatrix
+	mp *setmatrix.SetMatrix
 	sync.Mutex
 }
 

--- a/libnetwork/internal/setmatrix/setmatrix.go
+++ b/libnetwork/internal/setmatrix/setmatrix.go
@@ -35,7 +35,7 @@ type SetMatrix interface {
 type setMatrix struct {
 	matrix map[string]mapset.Set
 
-	sync.Mutex
+	mu sync.Mutex
 }
 
 // NewSetMatrix creates a new set matrix object
@@ -50,8 +50,8 @@ func (s *setMatrix) init() {
 }
 
 func (s *setMatrix) Get(key string) ([]interface{}, bool) {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	set, ok := s.matrix[key]
 	if !ok {
 		return nil, ok
@@ -60,8 +60,8 @@ func (s *setMatrix) Get(key string) ([]interface{}, bool) {
 }
 
 func (s *setMatrix) Contains(key string, value interface{}) (bool, bool) {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	set, ok := s.matrix[key]
 	if !ok {
 		return false, ok
@@ -70,8 +70,8 @@ func (s *setMatrix) Contains(key string, value interface{}) (bool, bool) {
 }
 
 func (s *setMatrix) Insert(key string, value interface{}) (bool, int) {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	set, ok := s.matrix[key]
 	if !ok {
 		s.matrix[key] = mapset.NewSet()
@@ -83,8 +83,8 @@ func (s *setMatrix) Insert(key string, value interface{}) (bool, int) {
 }
 
 func (s *setMatrix) Remove(key string, value interface{}) (bool, int) {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	set, ok := s.matrix[key]
 	if !ok {
 		return false, 0
@@ -104,8 +104,8 @@ func (s *setMatrix) Remove(key string, value interface{}) (bool, int) {
 }
 
 func (s *setMatrix) Cardinality(key string) (int, bool) {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	set, ok := s.matrix[key]
 	if !ok {
 		return 0, ok
@@ -115,8 +115,8 @@ func (s *setMatrix) Cardinality(key string) (int, bool) {
 }
 
 func (s *setMatrix) String(key string) (string, bool) {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	set, ok := s.matrix[key]
 	if !ok {
 		return "", ok
@@ -125,8 +125,8 @@ func (s *setMatrix) String(key string) (string, bool) {
 }
 
 func (s *setMatrix) Keys() []string {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	keys := make([]string, 0, len(s.matrix))
 	for k := range s.matrix {
 		keys = append(keys, k)

--- a/libnetwork/internal/setmatrix/setmatrix_test.go
+++ b/libnetwork/internal/setmatrix/setmatrix_test.go
@@ -135,7 +135,7 @@ func TestSetSerialInsertDelete(t *testing.T) {
 	}
 }
 
-func insertDeleteRotuine(ctx context.Context, endCh chan int, s SetMatrix, key, value string) {
+func insertDeleteRotuine(ctx context.Context, endCh chan int, s *SetMatrix, key, value string) {
 	for {
 		select {
 		case <-ctx.Done():

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -105,9 +105,9 @@ type svcMapEntry struct {
 }
 
 type svcInfo struct {
-	svcMap     setmatrix.SetMatrix
-	svcIPv6Map setmatrix.SetMatrix
-	ipMap      setmatrix.SetMatrix
+	svcMap     *setmatrix.SetMatrix
+	svcIPv6Map *setmatrix.SetMatrix
+	ipMap      *setmatrix.SetMatrix
 	service    map[string][]servicePorts
 }
 
@@ -1362,7 +1362,7 @@ func (n *network) updateSvcRecord(ep *Endpoint, localEps []*Endpoint, isAdd bool
 	}
 }
 
-func addIPToName(ipMap setmatrix.SetMatrix, name, serviceID string, ip net.IP) {
+func addIPToName(ipMap *setmatrix.SetMatrix, name, serviceID string, ip net.IP) {
 	reverseIP := netutils.ReverseIP(ip.String())
 	ipMap.Insert(reverseIP, ipInfo{
 		name:      name,
@@ -1370,7 +1370,7 @@ func addIPToName(ipMap setmatrix.SetMatrix, name, serviceID string, ip net.IP) {
 	})
 }
 
-func delIPToName(ipMap setmatrix.SetMatrix, name, serviceID string, ip net.IP) {
+func delIPToName(ipMap *setmatrix.SetMatrix, name, serviceID string, ip net.IP) {
 	reverseIP := netutils.ReverseIP(ip.String())
 	ipMap.Remove(reverseIP, ipInfo{
 		name:      name,
@@ -1378,7 +1378,7 @@ func delIPToName(ipMap setmatrix.SetMatrix, name, serviceID string, ip net.IP) {
 	})
 }
 
-func addNameToIP(svcMap setmatrix.SetMatrix, name, serviceID string, epIP net.IP) {
+func addNameToIP(svcMap *setmatrix.SetMatrix, name, serviceID string, epIP net.IP) {
 	// Since DNS name resolution is case-insensitive, Use the lower-case form
 	// of the name as the key into svcMap
 	lowerCaseName := strings.ToLower(name)
@@ -1388,7 +1388,7 @@ func addNameToIP(svcMap setmatrix.SetMatrix, name, serviceID string, epIP net.IP
 	})
 }
 
-func delNameToIP(svcMap setmatrix.SetMatrix, name, serviceID string, epIP net.IP) {
+func delNameToIP(svcMap *setmatrix.SetMatrix, name, serviceID string, epIP net.IP) {
 	lowerCaseName := strings.ToLower(name)
 	svcMap.Remove(lowerCaseName, svcMapEntry{
 		ip:        epIP.String(),

--- a/libnetwork/service.go
+++ b/libnetwork/service.go
@@ -54,7 +54,7 @@ type service struct {
 	// associated with it. At stable state the endpoint ID expected is 1
 	// but during transition and service change it is possible to have
 	// temporary more than 1
-	ipToEndpoint setmatrix.SetMatrix
+	ipToEndpoint *setmatrix.SetMatrix
 
 	deleted bool
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Deleted the unnecessary interface `setmatrix.SetMatrix`.

**- How I did it**
I renamed the `setmatrix.setMatrix` struct type to `setmatrix.SetMatrix`.

**- How to verify it**
CI.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

