### PR TITLE
registry/search: pass User-Agent through headers

### DIFF
--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -42,5 +42,5 @@ type registryBackend interface {
 }
 
 type Searcher interface {
-	Search(ctx context.Context, searchFilters filters.Args, term string, limit int, authConfig *registry.AuthConfig, metaHeaders map[string][]string) ([]registry.SearchResult, error)
+	Search(ctx context.Context, searchFilters filters.Args, term string, limit int, authConfig *registry.AuthConfig, headers map[string][]string) ([]registry.SearchResult, error)
 }

--- a/registry/endpoint_test.go
+++ b/registry/endpoint_test.go
@@ -20,7 +20,7 @@ func TestEndpointParse(t *testing.T) {
 		{"http://0.0.0.0:5000/v0/", "http://0.0.0.0:5000/v0/v1/"},
 	}
 	for _, td := range testData {
-		e, err := newV1EndpointFromStr(td.str, nil, "", nil)
+		e, err := newV1EndpointFromStr(td.str, nil, nil)
 		if err != nil {
 			t.Errorf("%q: %s", td.str, err)
 		}
@@ -39,7 +39,7 @@ func TestEndpointParseInvalid(t *testing.T) {
 		"http://0.0.0.0:5000/v2/",
 	}
 	for _, td := range testData {
-		e, err := newV1EndpointFromStr(td, nil, "", nil)
+		e, err := newV1EndpointFromStr(td, nil, nil)
 		if err == nil {
 			t.Errorf("expected error parsing %q: parsed as %q", td, e)
 		}

--- a/registry/endpoint_v1.go
+++ b/registry/endpoint_v1.go
@@ -35,13 +35,13 @@ type v1Endpoint struct {
 
 // newV1Endpoint parses the given address to return a registry endpoint.
 // TODO: remove. This is only used by search.
-func newV1Endpoint(index *registry.IndexInfo, userAgent string, metaHeaders http.Header) (*v1Endpoint, error) {
+func newV1Endpoint(index *registry.IndexInfo, headers http.Header) (*v1Endpoint, error) {
 	tlsConfig, err := newTLSConfig(index.Name, index.Secure)
 	if err != nil {
 		return nil, err
 	}
 
-	endpoint, err := newV1EndpointFromStr(GetAuthConfigKey(index), tlsConfig, userAgent, metaHeaders)
+	endpoint, err := newV1EndpointFromStr(GetAuthConfigKey(index), tlsConfig, headers)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func trimV1Address(address string) (string, error) {
 	return address, nil
 }
 
-func newV1EndpointFromStr(address string, tlsConfig *tls.Config, userAgent string, metaHeaders http.Header) (*v1Endpoint, error) {
+func newV1EndpointFromStr(address string, tlsConfig *tls.Config, headers http.Header) (*v1Endpoint, error) {
 	if !strings.HasPrefix(address, "http://") && !strings.HasPrefix(address, "https://") {
 		address = "https://" + address
 	}
@@ -121,7 +121,7 @@ func newV1EndpointFromStr(address string, tlsConfig *tls.Config, userAgent strin
 	return &v1Endpoint{
 		IsSecure: tlsConfig == nil || !tlsConfig.InsecureSkipVerify,
 		URL:      uri,
-		client:   httpClient(transport.NewTransport(tr, Headers(userAgent, metaHeaders)...)),
+		client:   httpClient(transport.NewTransport(tr, Headers("", headers)...)),
 	}, nil
 }
 

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -17,7 +17,7 @@ import (
 
 func spawnTestRegistrySession(t *testing.T) *session {
 	authConfig := &registry.AuthConfig{}
-	endpoint, err := newV1Endpoint(makeIndex("/v1/"), "", nil)
+	endpoint, err := newV1Endpoint(makeIndex("/v1/"), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func spawnTestRegistrySession(t *testing.T) *session {
 func TestPingRegistryEndpoint(t *testing.T) {
 	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 	testPing := func(index *registry.IndexInfo, expectedStandalone bool, assertMessage string) {
-		ep, err := newV1Endpoint(index, "", nil)
+		ep, err := newV1Endpoint(index, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -69,7 +69,7 @@ func TestEndpoint(t *testing.T) {
 	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 	// Simple wrapper to fail test if err != nil
 	expandEndpoint := func(index *registry.IndexInfo) *v1Endpoint {
-		endpoint, err := newV1Endpoint(index, "", nil)
+		endpoint, err := newV1Endpoint(index, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -78,14 +78,14 @@ func TestEndpoint(t *testing.T) {
 
 	assertInsecureIndex := func(index *registry.IndexInfo) {
 		index.Secure = true
-		_, err := newV1Endpoint(index, "", nil)
+		_, err := newV1Endpoint(index, nil)
 		assert.ErrorContains(t, err, "insecure-registry", index.Name+": Expected insecure-registry  error for insecure index")
 		index.Secure = false
 	}
 
 	assertSecureIndex := func(index *registry.IndexInfo) {
 		index.Secure = true
-		_, err := newV1Endpoint(index, "", nil)
+		_, err := newV1Endpoint(index, nil)
 		assert.ErrorContains(t, err, "certificate signed by unknown authority", index.Name+": Expected cert error for secure index")
 		index.Secure = false
 	}
@@ -132,7 +132,7 @@ func TestEndpoint(t *testing.T) {
 	}
 	for _, address := range badEndpoints {
 		index.Name = address
-		_, err := newV1Endpoint(index, "", nil)
+		_, err := newV1Endpoint(index, nil)
 		assert.Check(t, err != nil, "Expected error while expanding bad endpoint: %s", address)
 	}
 }


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/4010
- relates to https://github.com/moby/moby/pull/45086 / https://github.com/moby/moby/pull/45086#discussion_r1137154374


Commit 3991faf4640a46412a8af000ede78fc5cba76d0a (https://github.com/moby/moby/pull/45086) moved search into the registry package, which also made the `dockerversion` package a dependency for registry, which brings additional (indirect) dependencies, such as `pkg/parsers/kernel`, and `golang.org/x/sys/windows/registry`.

Client code, such as used in docker/cli may depend on the `registry` package, but should not depend on those additional dependencies.

This patch moves setting the userAgent to the API router, and instead of passing it as a separate argument, includes it into the "headers".

As these headers now not only contain the `X-Meta-...` headers, the variables were renamed accordingly.


**- A picture of a cute animal (not mandatory but encouraged)**

