### PR TITLE
Silence GRPC logs unless our log level is debug

### DIFF
--- a/cmd/dockerd/docker.go
+++ b/cmd/dockerd/docker.go
@@ -87,6 +87,7 @@ func main() {
 	_, stdout, stderr := term.StdStreams()
 
 	initLogging(stdout, stderr)
+	configureGRPCLog()
 
 	onError := func(err error) {
 		fmt.Fprintf(stderr, "%s\n", err)

--- a/cmd/dockerd/grpclog.go
+++ b/cmd/dockerd/grpclog.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/grpclog"
+)
+
+// grpc's default logger is *very* noisy and uses "info" and even "warn" level logging for mostly useless messages.
+// This function configures the grpc logger to step down the severity of all messages.
+//
+// info => trace
+// warn => debug
+// error => warn
+func configureGRPCLog() {
+	l := logrus.WithField("library", "grpc")
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(l.WriterLevel(logrus.TraceLevel), l.WriterLevel(logrus.DebugLevel), l.WriterLevel(logrus.WarnLevel)))
+}


### PR DESCRIPTION
GRPC is logging a *lot* of garbage at info level.
This configures the GRPC logger such that it is only giving us logs when at debug level and also adds a log field indicating where the logs are coming from.

containerd is still currently spewing these same log messages and needs a separate update.

Without this change `docker build` is extremely noisy in the daemon logs.
