### PR TITLE
Respect Latest option in ContainerList

### DIFF
--- a/client/container_list.go
+++ b/client/container_list.go
@@ -18,6 +18,10 @@ func (cli *Client) ContainerList(ctx context.Context, options types.ContainerLis
 		query.Set("all", "1")
 	}
 
+	if options.Latest {
+		query.Set("latest", "1")
+	}
+
 	if options.Limit > 0 {
 		query.Set("limit", strconv.Itoa(options.Limit))
 	}

--- a/client/container_list.go
+++ b/client/container_list.go
@@ -19,7 +19,7 @@ func (cli *Client) ContainerList(ctx context.Context, options types.ContainerLis
 	}
 
 	if options.Latest {
-		query.Set("latest", "1")
+		query.Set("limit", "1")
 	}
 
 	if options.Limit > 0 {


### PR DESCRIPTION
**- What I did**
Set the latest value in the docker client query.

**- How to verify it**
Previously ContainerList requests with the Latest flag set would still return all containers. After this change, only the latest container is returned.

**- Description for the changelog**
The `Latest` option which is exported is not used in the ContainerList query. This change fixes that by setting the appropriate value when users set the latest flag.

