### PR TITLE
[backport 20.10] TestDaemonRestartKillContainers: Fix races

### DIFF
--- a/integration/container/restart_test.go
+++ b/integration/container/restart_test.go
@@ -58,11 +58,10 @@ func TestDaemonRestartKillContainers(t *testing.T) {
 					d.Stop(t)
 				},
 			} {
+				tc := tc
+				liveRestoreEnabled := liveRestoreEnabled
+				stopDaemon := stopDaemon
 				t.Run(fmt.Sprintf("live-restore=%v/%s/%s", liveRestoreEnabled, tc.desc, fnName), func(t *testing.T) {
-					c := tc
-					liveRestoreEnabled := liveRestoreEnabled
-					stopDaemon := stopDaemon
-
 					t.Parallel()
 
 					d := daemon.New(t)
@@ -77,11 +76,11 @@ func TestDaemonRestartKillContainers(t *testing.T) {
 					defer d.Stop(t)
 					ctx := context.Background()
 
-					resp, err := client.ContainerCreate(ctx, c.config, c.hostConfig, nil, nil, "")
+					resp, err := client.ContainerCreate(ctx, tc.config, tc.hostConfig, nil, nil, "")
 					assert.NilError(t, err)
 					defer client.ContainerRemove(ctx, resp.ID, types.ContainerRemoveOptions{Force: true})
 
-					if c.xStart {
+					if tc.xStart {
 						err = client.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{})
 						assert.NilError(t, err)
 					}
@@ -89,9 +88,9 @@ func TestDaemonRestartKillContainers(t *testing.T) {
 					stopDaemon(t, d)
 					d.Start(t, args...)
 
-					expected := c.xRunning
+					expected := tc.xRunning
 					if liveRestoreEnabled {
-						expected = c.xRunningLiveRestore
+						expected = tc.xRunningLiveRestore
 					}
 
 					var running bool

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -380,32 +380,32 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 	}
 
 	d.args = append(d.args, providedArgs...)
-	d.cmd = exec.Command(dockerdBinary, d.args...)
-	d.cmd.Env = append(os.Environ(), "DOCKER_SERVICE_PREFER_OFFLINE_IMAGE=1")
-	d.cmd.Stdout = out
-	d.cmd.Stderr = out
+	cmd := exec.Command(dockerdBinary, d.args...)
+	cmd.Env = append(os.Environ(), "DOCKER_SERVICE_PREFER_OFFLINE_IMAGE=1")
+	cmd.Stdout = out
+	cmd.Stderr = out
 	d.logFile = out
 	if d.rootlessUser != nil {
 		// sudo requires this for propagating signals
-		setsid(d.cmd)
+		setsid(cmd)
 	}
 
-	if err := d.cmd.Start(); err != nil {
+	if err := cmd.Start(); err != nil {
 		return errors.Wrapf(err, "[%s] could not start daemon container", d.id)
 	}
 
 	wait := make(chan error, 1)
+	d.cmd = cmd
+	d.Wait = wait
 
 	go func() {
-		ret := d.cmd.Wait()
+		ret := cmd.Wait()
 		d.log.Logf("[%s] exiting daemon", d.id)
 		// If we send before logging, we might accidentally log _after_ the test is done.
 		// As of Go 1.12, this incurs a panic instead of silently being dropped.
 		wait <- ret
 		close(wait)
 	}()
-
-	d.Wait = wait
 
 	clientConfig, err := d.getClientConfig()
 	if err != nil {


### PR DESCRIPTION
- Cherrypick: https://github.com/moby/moby/pull/45168

## TestDaemonRestartKillContainers: Fix loop capture

TestDaemonRestartKillContainers test was always executing the last case (`container created should not be restarted`) because the iterated variables were not copied correctly.
Capture iterated values by value correctly.

## StartWithLogFile: Fix d.cmd race 
Use `exec.Command` created by this function instead of obtaining it from daemon struct. This prevents a race condition where `daemon.Kill` is called before the goroutine has the chance to call `cmd.Wait`.

Detected by `-race`:
```
WARNING: DATA RACE
Write at 0x00c00071c048 by goroutine 40:
  github.com/docker/docker/testutil/daemon.(*Daemon).Kill.func1()
      /go/src/github.com/docker/docker/testutil/daemon/daemon.go:497 +0x88
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:476 +0x32
  github.com/docker/docker/integration/container.TestDaemonRestartKillContainers.func1()
      /go/src/github.com/docker/docker/integration/container/restart_test.go:72 +0x31
  github.com/docker/docker/integration/container.TestDaemonRestartKillContainers.func3()
      /go/src/github.com/docker/docker/integration/container/restart_test.go:111 +0x6b8
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1629 +0x47

Previous read at 0x00c00071c048 by goroutine 50:
  github.com/docker/docker/testutil/daemon.(*Daemon).StartWithLogFile.func1()
      /go/src/github.com/docker/docker/testutil/daemon/daemon.go:413 +0x46
```


**- How to verify it**
```bash
make  BUILDFLAGS='-race'  TEST_FILTER='TestDaemonRestartKillContainers'  test-integration
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/5046555/225363824-b4d744ca-0f11-40df-aae0-aa5feabc3532.png)

