### PR TITLE
Prefer loading `docker-init` from an appropriate "libexec" directory

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -748,12 +747,9 @@ func WithCommonOptions(daemon *Daemon, c *container.Container) coci.SpecOpts {
 			if (c.HostConfig.Init != nil && *c.HostConfig.Init) ||
 				(c.HostConfig.Init == nil && daemon.configStore.Init) {
 				s.Process.Args = append([]string{inContainerInitPath, "--", c.Path}, c.Args...)
-				path := daemon.configStore.InitPath
-				if path == "" {
-					path, err = exec.LookPath(dconfig.DefaultInitBinary)
-					if err != nil {
-						return err
-					}
+				path, err := daemon.configStore.LookupInitPath() // this will fall back to DefaultInitBinary and return an absolute path
+				if err != nil {
+					return err
 				}
 				s.Mounts = append(s.Mounts, specs.Mount{
 					Destination: inContainerInitPath,


### PR DESCRIPTION
The `docker-init` binary is not intended to be a user-facing command, and as such it is more appropriate for it to be found in `/usr/libexec` (or similar) than in `PATH` (see the FHS, especially https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s07.html and https://refspecs.linuxfoundation.org/FHS_2.3/fhs-2.3.html#USRLIBLIBRARIESFORPROGRAMMINGANDPA).

This adjusts the logic for using that configuration option to take this into account and appropriately search for `docker-init` (or the user's configured alternative) in these directories before falling back to the existing `PATH` lookup behavior.

This behavior _used_ to exist for the old `dockerinit` binary (of a similar name and used in a similar way but for an alternative purpose), but that behavior was removed in 4357ed4a7363a1032edf93cf03232953c805184f when that older `dockerinit` was also removed.

Most of this reasoning _also_ applies to `docker-proxy` (and various `containerd-xxx` binaries such as the shims), but this change does not affect those.  It would be relatively straightforward to adapt `LookupInitPath` to be a more generic function such as `libexecLookupPath` or similar if we wanted to explore that.

See https://github.com/docker/cli/blob/14482589df194a86b2ee07df643ba3277b40df7d/cli-plugins/manager/manager_unix.go for the related path list in the CLI which loads CLI plugins from a similar set of paths (with a similar rationale - plugin binaries are not typically intended to be run directly by users but rather invoked _via_ the CLI binary).

Refs https://github.com/moby/moby/pull/19490, https://github.com/moby/moby/pull/2217, https://github.com/docker/cli/pull/1564