### PR TITLE
client: Add buildkit ClientOpts

### DIFF
--- a/client/buildkit.go
+++ b/client/buildkit.go
@@ -1,0 +1,27 @@
+package client
+
+import (
+	"context"
+	"net"
+
+	"github.com/moby/buildkit/client"
+)
+
+// BuildkitClientOpts returns a list of buildkit client options which allows the
+// caller to use to create a buildkit client which will connect to the buildkit
+// API provided by the daemon.
+//
+// Example: bkclient.New(ctx, "", BuildkitClientOpts(c)...)
+func BuildkitClientOpts(c CommonAPIClient) []client.ClientOpt {
+	session := func(ctx context.Context, proto string, meta map[string][]string) (net.Conn, error) {
+		return c.DialHijack(ctx, "/session", proto, meta)
+	}
+	grpc := func(ctx context.Context, _ string) (net.Conn, error) {
+		return c.DialHijack(ctx, "/grpc", "h2c", nil)
+	}
+
+	return []client.ClientOpt{
+		client.WithSessionDialer(session),
+		client.WithContextDialer(grpc),
+	}
+}


### PR DESCRIPTION

**- What I did**

This adds a function to the client package which can be used to create a buildkit client from our moby client.

**- How to verify it**

Example:

```go
package main

import (
  "context"

  "github.com/moby/moby/client"
  bkclient "github.com/moby/buildkit/client"
)

func main() {
  c := client.NewWithOpts()
  bc, _ := bkclient.New(context.Background(), ""
    client.BuildkitClientOpts(c),
  )
  // ...
}
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

client: Add helper to create a buildkit client from the moby client

**- A picture of a cute animal (not mandatory but encouraged)**

![IMG_0902](https://user-images.githubusercontent.com/799078/227374393-f867cfb5-dd0d-405a-9ff6-cf3520c13f01.jpeg)
