### PR TITLE
[23.0 backport] integration-cli: Enable TestExecStartFails on Windows

### DIFF
--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -509,16 +509,18 @@ func (s *DockerCLIExecSuite) TestExecUlimits(c *testing.T) {
 
 // #15750
 func (s *DockerCLIExecSuite) TestExecStartFails(c *testing.T) {
-	// TODO Windows CI. This test should be portable. Figure out why it fails
-	// currently.
-	testRequires(c, DaemonIsLinux)
 	name := "exec-15750"
 	runSleepingContainer(c, "-d", "--name", name)
 	assert.NilError(c, waitRun(name))
 
 	out, _, err := dockerCmdWithError("exec", name, "no-such-cmd")
 	assert.ErrorContains(c, err, "", out)
-	assert.Assert(c, strings.Contains(out, "executable file not found"))
+
+	expectedMsg := "executable file not found"
+	if DaemonIsWindows() {
+		expectedMsg = "The system cannot find the file specified"
+	}
+	assert.Assert(c, is.Contains(out, expectedMsg))
 }
 
 // Fix regression in https://github.com/docker/docker/pull/26461#issuecomment-250287297


### PR DESCRIPTION
- Cherry-pick: https://github.com/moby/moby/pull/45186

**- What I did**
Enabled `TestExecStartFails` test for Windows daemon.

**- How I did it**
Adjusted the expected error message.

**- How to verify it**
CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

