### PR TITLE
update runc binary to v1.1.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -280,7 +280,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged. When updating RUNC_VERSION,
 # consider updating runc in vendor.mod accordingly.
-ARG RUNC_VERSION=v1.1.4
+ARG RUNC_VERSION=v1.1.5
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=v1.1.4}"
+: "${RUNC_VERSION:=v1.1.5}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"


### PR DESCRIPTION
release notes: https://github.com/opencontainers/runc/releases/tag/v1.1.5
diff: https://github.com/opencontainers/runc/compare/v1.1.4...v1.1.5

This is the fifth patch release in the 1.1.z series of runc, which fixes three CVEs found in runc.

* CVE-2023-25809 is a vulnerability involving rootless containers where (under specific configurations), the container would have write access to the /sys/fs/cgroup/user.slice/... cgroup hierarchy. No other hierarchies on the host were affected. This vulnerability was discovered by Akihiro Suda. <https://github.com/opencontainers/runc/security/advisories/GHSA-m8cg-xc2p-r3fc>

* CVE-2023-27561 was a regression which effectively re-introduced CVE-2019-19921. This bug was present from v1.0.0-rc95 to v1.1.4. This regression was discovered by @Beuc. <https://github.com/advisories/GHSA-vpvm-3wq2-2wvm>

* CVE-2023-28642 is a variant of CVE-2023-27561 and was fixed by the same patch. This variant of the above vulnerability was reported by Lei Wang. <https://github.com/opencontainers/runc/security/advisories/GHSA-g2j6-57v7-gm8c>

In addition, the following other fixes are included in this release:

* Fix the inability to use `/dev/null` when inside a container.
* Fix changing the ownership of host's `/dev/null` caused by fd redirection
  (a regression in 1.1.1).
* Fix rare runc exec/enter unshare error on older kernels, including
  CentOS < 7.7.
* nsexec: Check for errors in `write_log()`.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

