### PR TITLE
[23.0 backport] libnet/d/windows: log EnableInternalDNS val after setting it 

### DIFF
--- a/libnetwork/drivers/windows/windows.go
+++ b/libnetwork/drivers/windows/windows.go
@@ -681,8 +681,8 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 	}
 
 	if n.driver.name == "nat" && !epOption.DisableDNS {
-		logrus.Debugf("endpointStruct.EnableInternalDNS =[%v]", endpointStruct.EnableInternalDNS)
 		endpointStruct.EnableInternalDNS = true
+		logrus.Debugf("endpointStruct.EnableInternalDNS =[%v]", endpointStruct.EnableInternalDNS)
 	}
 
 	endpointStruct.DisableICC = epOption.DisableICC


### PR DESCRIPTION
* backport of #45211 

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/557933/228842060-27c4247e-a4e8-46a7-9226-0fd10ae103df.png)