### PR TITLE
libnetwork/netutils: drop ElectInterfaceAddresses

### DIFF
--- a/libnetwork/netutils/utils_freebsd.go
+++ b/libnetwork/netutils/utils_freebsd.go
@@ -6,16 +6,6 @@ import (
 	"github.com/docker/docker/libnetwork/types"
 )
 
-// ElectInterfaceAddresses looks for an interface on the OS with the specified name
-// and returns returns all its IPv4 and IPv6 addresses in CIDR notation.
-// If a failure in retrieving the addresses or no IPv4 address is found, an error is returned.
-// If the interface does not exist, it chooses from a predefined
-// list the first IPv4 address which does not conflict with other
-// interfaces on the system.
-func ElectInterfaceAddresses(name string) ([]*net.IPNet, []*net.IPNet, error) {
-	return nil, nil, types.NotImplementedErrorf("not supported on freebsd")
-}
-
 // FindAvailableNetwork returns a network from the passed list which does not
 // overlap with existing interfaces in the system
 func FindAvailableNetwork(list []*net.IPNet) (*net.IPNet, error) {

--- a/libnetwork/netutils/utils_windows.go
+++ b/libnetwork/netutils/utils_windows.go
@@ -2,19 +2,7 @@ package netutils
 
 import (
 	"net"
-
-	"github.com/docker/docker/libnetwork/types"
 )
-
-// ElectInterfaceAddresses looks for an interface on the OS with the specified name
-// and returns returns all its IPv4 and IPv6 addresses in CIDR notation.
-// If a failure in retrieving the addresses or no IPv4 address is found, an error is returned.
-// If the interface does not exist, it chooses from a predefined
-// list the first IPv4 address which does not conflict with other
-// interfaces on the system.
-func ElectInterfaceAddresses(name string) ([]*net.IPNet, []*net.IPNet, error) {
-	return nil, nil, types.NotImplementedErrorf("not supported on windows")
-}
 
 // FindAvailableNetwork returns a network from the passed list which does not
 // overlap with existing interfaces in the system


### PR DESCRIPTION
This is a follow-up of [48ad9e1](https://github.com/moby/moby/commit/48ad9e19e479ae25b1ff4b8a419131d319205192). This commit removed the function ElectInterfaceAddresses from utils_linux.go but not their FreeBSD & Windows counterpart. As these functions are never called, they can be safely removed.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://compote.slate.com/images/73f0857e-2a1a-4fea-b97a-bd4c241c01f5.jpg)