### PR TITLE
libnetwork: fix deprecation comment, and replace uses of deprecated IP consts

### DIFF
--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/libnetwork/ipamapi"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/netutils"
+	"github.com/docker/docker/libnetwork/resolvconf"
 	"github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/libnetwork/types"
 	"gotest.tools/v3/skip"
@@ -491,7 +492,7 @@ func TestServiceVIPReuse(t *testing.T) {
 
 	ipToResolve := netutils.ReverseIP("192.168.0.1")
 
-	ipList, _ := n.(*network).ResolveName("service_test", types.IPv4)
+	ipList, _ := n.(*network).ResolveName("service_test", resolvconf.IPv4)
 	if len(ipList) == 0 {
 		t.Fatal("There must be the VIP")
 	}
@@ -511,7 +512,7 @@ func TestServiceVIPReuse(t *testing.T) {
 
 	// Delete service record for one of the services, the IP should remain because one service is still associated with it
 	n.(*network).deleteSvcRecords("ep1", "service_test", "serviceID1", net.ParseIP("192.168.0.1"), net.IP{}, true, "test")
-	ipList, _ = n.(*network).ResolveName("service_test", types.IPv4)
+	ipList, _ = n.(*network).ResolveName("service_test", resolvconf.IPv4)
 	if len(ipList) == 0 {
 		t.Fatal("There must be the VIP")
 	}
@@ -531,7 +532,7 @@ func TestServiceVIPReuse(t *testing.T) {
 
 	// Delete again the service using the previous service ID, nothing should happen
 	n.(*network).deleteSvcRecords("ep2", "service_test", "serviceID1", net.ParseIP("192.168.0.1"), net.IP{}, true, "test")
-	ipList, _ = n.(*network).ResolveName("service_test", types.IPv4)
+	ipList, _ = n.(*network).ResolveName("service_test", resolvconf.IPv4)
 	if len(ipList) == 0 {
 		t.Fatal("There must be the VIP")
 	}
@@ -551,7 +552,7 @@ func TestServiceVIPReuse(t *testing.T) {
 
 	// Delete now using the second service ID, now all the entries should be gone
 	n.(*network).deleteSvcRecords("ep2", "service_test", "serviceID2", net.ParseIP("192.168.0.1"), net.IP{}, true, "test")
-	ipList, _ = n.(*network).ResolveName("service_test", types.IPv4)
+	ipList, _ = n.(*network).ResolveName("service_test", resolvconf.IPv4)
 	if len(ipList) != 0 {
 		t.Fatal("All the VIPs should be gone now")
 	}

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/docker/libnetwork/netutils"
 	"github.com/docker/docker/libnetwork/networkdb"
 	"github.com/docker/docker/libnetwork/options"
+	"github.com/docker/docker/libnetwork/resolvconf"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/sirupsen/logrus"
@@ -1985,7 +1986,7 @@ func (n *network) ResolveName(req string, ipType int) ([]net.IP, bool) {
 	req = strings.ToLower(req)
 	ipSet, ok := sr.svcMap.Get(req)
 
-	if ipType == types.IPv6 {
+	if ipType == resolvconf.IPv6 {
 		// If the name resolved to v4 address then its a valid name in
 		// the docker network domain. If the network is not v6 enabled
 		// set ipv6Miss to filter the DNS query from going to external

--- a/libnetwork/resolver.go
+++ b/libnetwork/resolver.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/docker/docker/libnetwork/types"
+	"github.com/docker/docker/libnetwork/resolvconf"
 	"github.com/miekg/dns"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
@@ -224,8 +224,8 @@ func createRespMsg(query *dns.Msg) *dns.Msg {
 
 func (r *Resolver) handleMXQuery(query *dns.Msg) (*dns.Msg, error) {
 	name := query.Question[0].Name
-	addrv4, _ := r.backend.ResolveName(name, types.IPv4)
-	addrv6, _ := r.backend.ResolveName(name, types.IPv6)
+	addrv4, _ := r.backend.ResolveName(name, resolvconf.IPv4)
+	addrv6, _ := r.backend.ResolveName(name, resolvconf.IPv6)
 
 	if addrv4 == nil && addrv6 == nil {
 		return nil, nil
@@ -263,7 +263,7 @@ func (r *Resolver) handleIPQuery(query *dns.Msg, ipType int) (*dns.Msg, error) {
 	if len(addr) > 1 {
 		addr = shuffleAddr(addr)
 	}
-	if ipType == types.IPv4 {
+	if ipType == resolvconf.IPv4 {
 		for _, ip := range addr {
 			rr := new(dns.A)
 			rr.Hdr = dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: respTTL}
@@ -355,9 +355,9 @@ func (r *Resolver) serveDNS(w dns.ResponseWriter, query *dns.Msg) {
 
 	switch queryType {
 	case dns.TypeA:
-		resp, err = r.handleIPQuery(query, types.IPv4)
+		resp, err = r.handleIPQuery(query, resolvconf.IPv4)
 	case dns.TypeAAAA:
-		resp, err = r.handleIPQuery(query, types.IPv6)
+		resp, err = r.handleIPQuery(query, resolvconf.IPv6)
 	case dns.TypeMX:
 		resp, err = r.handleMXQuery(query)
 	case dns.TypePTR:

--- a/libnetwork/types/types.go
+++ b/libnetwork/types/types.go
@@ -11,7 +11,8 @@ import (
 	"github.com/ishidawataru/sctp"
 )
 
-// constants for the IP address type
+// constants for the IP address type.
+//
 // Deprecated: use the consts defined in github.com/docker/docker/libnetwork/resolvconf
 const (
 	IP = iota // IPv4 and IPv6


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

