### PR TITLE
c8d: Send event when an image is imported

### DIFF
--- a/daemon/containerd/image_exporter.go
+++ b/daemon/containerd/image_exporter.go
@@ -102,8 +102,6 @@ func (i *ImageService) ExportImage(ctx context.Context, names []string, outStrea
 // LoadImage uploads a set of images into the repository. This is the
 // complement of ExportImage.  The input stream is an uncompressed tar
 // ball containing images and metadata.
-//
-// TODO(thaJeztah): produce JSON stream progress response and image events; see https://github.com/moby/moby/issues/43910
 func (i *ImageService) LoadImage(ctx context.Context, inTar io.ReadCloser, outStream io.Writer, quiet bool) error {
 	// TODO(vvoland): Allow user to pass platform
 	platform := cplatforms.All
@@ -153,7 +151,9 @@ func (i *ImageService) LoadImage(ctx context.Context, inTar io.ReadCloser, outSt
 		}
 
 		fmt.Fprintf(progress, "Loaded image: %s\n", name)
+		i.LogImageEvent(img.Target.Digest.String(), img.Target.Digest.String(), "load")
 	}
+
 	return nil
 }
 

--- a/daemon/containerd/image_import.go
+++ b/daemon/containerd/image_import.go
@@ -146,6 +146,8 @@ func (i *ImageService) ImportImage(ctx context.Context, ref reference.Named, pla
 	err = i.unpackImage(ctx, img, *platform)
 	if err != nil {
 		logger.WithError(err).Debug("failed to unpack image")
+	} else {
+		i.LogImageEvent(id.String(), id.String(), "import")
 	}
 
 	return id, err


### PR DESCRIPTION
**- What I did**

Added image events for `docker save` and `docker load`

Fixes #43910

**- How I did it**

By calling the events service

**- How to verify it**

Running `docker events` in one terminal and loading/saving images in another.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
