### PR TITLE
integration-cli/daemon: remove uses of deprecated WaitRun, dockerCmdWithResult utilities

### DIFF
--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -92,14 +92,9 @@ func (d *Daemon) CheckActiveContainerCount(ctx context.Context) func(t *testing.
 	}
 }
 
-// WaitRun waits for a container to be running for 10s
-func (d *Daemon) WaitRun(contID string) error {
-	args := []string{"--host", d.Sock()}
-	return WaitInspectWithArgs(d.dockerBinary, contID, "{{.State.Running}}", "true", 10*time.Second, args...)
-}
-
 // WaitInspectWithArgs waits for the specified expression to be equals to the specified expected string in the given time.
-// Deprecated: use cli.WaitCmd instead
+//
+// Deprecated: use [cli.WaitRun] instead.
 func WaitInspectWithArgs(dockerBinary, name, expr, expected string, timeout time.Duration, arg ...string) error {
 	after := time.After(timeout)
 

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1961,7 +1961,7 @@ func (s *DockerDaemonSuite) TestExecWithUserAfterLiveRestore(c *testing.T) {
 	out, err := s.d.Cmd("run", "--init", "-d", "--name=top", "busybox", "sh", "-c", "addgroup -S testgroup && adduser -S -G testgroup test -D -s /bin/sh && touch /adduser_end && exec top")
 	assert.NilError(c, err, "Output: %s", out)
 
-	s.d.WaitRun("top")
+	cli.WaitRun(c, "top")
 
 	// Wait for shell command to be completed
 	_, err = s.d.Cmd("exec", "top", "sh", "-c", `for i in $(seq 1 5); do if [ -e /adduser_end ]; then rm -f /adduser_end && break; else sleep 1 && false; fi; done`)
@@ -1988,7 +1988,7 @@ func (s *DockerDaemonSuite) TestRemoveContainerAfterLiveRestore(c *testing.T) {
 	out, err := s.d.Cmd("run", "-d", "--name=top", "busybox", "top")
 	assert.NilError(c, err, "Output: %s", out)
 
-	s.d.WaitRun("top")
+	cli.WaitRun(c, "top")
 
 	// restart daemon.
 	s.d.Restart(c, "--live-restore")

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -100,7 +100,7 @@ func (s *DockerCLIEventSuite) TestEventsOOMDisableTrue(c *testing.T) {
 	}()
 
 	cli.WaitRun(c, "oomTrue")
-	defer dockerCmdWithResult("kill", "oomTrue")
+	defer cli.Docker(cli.Args("kill", "oomTrue"))
 	containerID := inspectField(c, "oomTrue", "Id")
 
 	testActions := map[string]chan bool{

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -327,14 +327,14 @@ func (s *DockerCLIInspectSuite) TestInspectByPrefix(c *testing.T) {
 func (s *DockerCLIInspectSuite) TestInspectStopWhenNotFound(c *testing.T) {
 	runSleepingContainer(c, "--name=busybox1", "-d")
 	runSleepingContainer(c, "--name=busybox2", "-d")
-	result := dockerCmdWithResult("inspect", "--type=container", "--format='{{.Name}}'", "busybox1", "busybox2", "missing")
+	result := cli.Docker(cli.Args("inspect", "--type=container", "--format='{{.Name}}'", "busybox1", "busybox2", "missing"))
 
 	assert.Assert(c, result.Error != nil)
 	assert.Assert(c, is.Contains(result.Stdout(), "busybox1"))
 	assert.Assert(c, is.Contains(result.Stdout(), "busybox2"))
 	assert.Assert(c, is.Contains(result.Stderr(), "Error: No such container: missing"))
 	// test inspect would not fast fail
-	result = dockerCmdWithResult("inspect", "--type=container", "--format='{{.Name}}'", "missing", "busybox1", "busybox2")
+	result = cli.Docker(cli.Args("inspect", "--type=container", "--format='{{.Name}}'", "missing", "busybox1", "busybox2"))
 
 	assert.Assert(c, result.Error != nil)
 	assert.Assert(c, is.Contains(result.Stdout(), "busybox1"))

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -298,7 +298,7 @@ func (s *DockerCLILogsSuite) TestLogsFollowGoroutinesWithStdout(c *testing.T) {
 	assert.NilError(c, err)
 
 	id := strings.TrimSpace(out)
-	assert.NilError(c, d.WaitRun(id))
+	cli.WaitRun(c, id)
 
 	client := d.NewClientT(c)
 	nroutines := waitForStableGoroutineCount(ctx, c, client)
@@ -354,7 +354,7 @@ func (s *DockerCLILogsSuite) TestLogsFollowGoroutinesNoOutput(c *testing.T) {
 	out, err := d.Cmd("run", "-d", "busybox", "/bin/sh", "-c", "while true; do sleep 2; done")
 	assert.NilError(c, err)
 	id := strings.TrimSpace(out)
-	assert.NilError(c, d.WaitRun(id))
+	cli.WaitRun(c, id)
 
 	client := d.NewClientT(c)
 	nroutines := waitForStableGoroutineCount(ctx, c, client)

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -465,7 +465,7 @@ func (s *DockerCLINetworkSuite) TestDockerNetworkInspectWithID(c *testing.T) {
 }
 
 func (s *DockerCLINetworkSuite) TestDockerInspectMultipleNetwork(c *testing.T) {
-	result := dockerCmdWithResult("network", "inspect", "host", "none")
+	result := cli.Docker(cli.Args("network", "inspect", "host", "none"))
 	result.Assert(c, icmd.Success)
 
 	var networkResources []network.Inspect
@@ -477,7 +477,7 @@ func (s *DockerCLINetworkSuite) TestDockerInspectMultipleNetwork(c *testing.T) {
 func (s *DockerCLINetworkSuite) TestDockerInspectMultipleNetworksIncludingNonexistent(c *testing.T) {
 	// non-existent network was not at the beginning of the inspect list
 	// This should print an error, return an exitCode 1 and print the host network
-	result := dockerCmdWithResult("network", "inspect", "host", "nonexistent")
+	result := cli.Docker(cli.Args("network", "inspect", "host", "nonexistent"))
 	result.Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "Error: No such network: nonexistent",
@@ -491,7 +491,7 @@ func (s *DockerCLINetworkSuite) TestDockerInspectMultipleNetworksIncludingNonexi
 
 	// Only one non-existent network to inspect
 	// Should print an error and return an exitCode, nothing else
-	result = dockerCmdWithResult("network", "inspect", "nonexistent")
+	result = cli.Docker(cli.Args("network", "inspect", "nonexistent"))
 	result.Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "Error: No such network: nonexistent",
@@ -500,7 +500,7 @@ func (s *DockerCLINetworkSuite) TestDockerInspectMultipleNetworksIncludingNonexi
 
 	// non-existent network was at the beginning of the inspect list
 	// Should not fail fast, and still print host network but print an error
-	result = dockerCmdWithResult("network", "inspect", "nonexistent", "host")
+	result = cli.Docker(cli.Args("network", "inspect", "nonexistent", "host"))
 	result.Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "Error: No such network: nonexistent",

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1134,8 +1134,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkHostModeUngracefulDaemonRestart(c 
 		assert.NilError(c, err, out)
 
 		// verify container has finished starting before killing daemon
-		err = s.d.WaitRun(cName)
-		assert.NilError(c, err)
+		cli.WaitRun(c, cName)
 	}
 
 	// Kill daemon ungracefully and restart
@@ -1144,8 +1143,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkHostModeUngracefulDaemonRestart(c 
 
 	// make sure all the containers are up and running
 	for i := 0; i < 10; i++ {
-		err := s.d.WaitRun(fmt.Sprintf("hostc-%d", i))
-		assert.NilError(c, err)
+		cli.WaitRun(c, fmt.Sprintf("hostc-%d", i))
 	}
 }
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2441,10 +2441,10 @@ func (s *DockerCLIRunSuite) TestRunTLSVerify(c *testing.T) {
 
 	// Regardless of whether we specify true or false we need to
 	// test to make sure tls is turned on if --tlsverify is specified at all
-	result := dockerCmdWithResult("--tlsverify=false", "ps")
+	result := cli.Docker(cli.Args("--tlsverify=false", "ps"))
 	result.Assert(c, icmd.Expected{ExitCode: 1, Err: "error during connect"})
 
-	result = dockerCmdWithResult("--tlsverify=true", "ps")
+	result = cli.Docker(cli.Args("--tlsverify=true", "ps"))
 	result.Assert(c, icmd.Expected{ExitCode: 1, Err: "cert"})
 }
 
@@ -3804,9 +3804,9 @@ func (s *DockerCLIRunSuite) TestRunAttachFailedNoLeak(c *testing.T) {
 	_, err := d.Cmd("run", "--rm", "busybox", "true")
 	assert.NilError(c, err)
 
-	client := d.NewClientT(c)
+	apiClient := d.NewClientT(c)
 
-	nroutines := waitForStableGoroutineCount(ctx, c, client)
+	nroutines := waitForStableGoroutineCount(ctx, c, apiClient)
 
 	out, err := d.Cmd(append([]string{"run", "-d", "--name=test", "-p", "8000:8000", "busybox"}, sleepCommandForDaemonPlatform()...)...)
 	assert.NilError(c, err, out)
@@ -3834,7 +3834,7 @@ func (s *DockerCLIRunSuite) TestRunAttachFailedNoLeak(c *testing.T) {
 	assert.NilError(c, err, out)
 
 	// NGoroutines is not updated right away, so we need to wait before failing
-	waitForGoroutines(ctx, c, client, nroutines)
+	waitForGoroutines(ctx, c, apiClient, nroutines)
 }
 
 // Test for one character directory name case (#20122)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3812,7 +3812,7 @@ func (s *DockerCLIRunSuite) TestRunAttachFailedNoLeak(c *testing.T) {
 	assert.NilError(c, err, out)
 
 	// Wait until container is fully up and running
-	assert.NilError(c, d.WaitRun("test"))
+	cli.WaitRun(c, "test")
 
 	out, err = d.Cmd("run", "--name=fail", "-p", "8000:8000", "busybox", "true")
 
@@ -3998,7 +3998,7 @@ func (s *DockerDaemonSuite) TestRunWithUlimitAndDaemonDefault(c *testing.T) {
 	name := "test-A"
 	_, err := d.Cmd("run", "--name", name, "-d", "busybox", "top")
 	assert.NilError(c, err)
-	assert.NilError(c, d.WaitRun(name))
+	cli.WaitRun(c, name)
 
 	out, err := d.Cmd("inspect", "--format", "{{.HostConfig.Ulimits}}", name)
 	assert.NilError(c, err)
@@ -4006,7 +4006,7 @@ func (s *DockerDaemonSuite) TestRunWithUlimitAndDaemonDefault(c *testing.T) {
 	name = "test-B"
 	_, err = d.Cmd("run", "--name", name, "--ulimit=nofile=42", "-d", "busybox", "top")
 	assert.NilError(c, err)
-	assert.NilError(c, d.WaitRun(name))
+	cli.WaitRun(c, name)
 
 	out, err = d.Cmd("inspect", "--format", "{{.HostConfig.Ulimits}}", name)
 	assert.NilError(c, err)

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -407,8 +407,7 @@ func (s *DockerSwarmSuite) TestSwarmContainerAttachByNetworkId(c *testing.T) {
 	out, err = d.Cmd("run", "-d", "--net", networkID, "busybox", "top")
 	assert.NilError(c, err, out)
 	cID := strings.TrimSpace(out)
-	err = d.WaitRun(cID)
-	assert.NilError(c, err)
+	cli.WaitRun(c, cID)
 
 	out, err = d.Cmd("rm", "-f", cID)
 	assert.NilError(c, err, out)

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -66,7 +66,7 @@ func (s *DockerCLIVolumeSuite) TestVolumeCLIInspectMulti(c *testing.T) {
 	cli.DockerCmd(c, "volume", "create", "test2")
 	cli.DockerCmd(c, "volume", "create", "test3")
 
-	result := dockerCmdWithResult("volume", "inspect", "--format={{ .Name }}", "test1", "test2", "doesnotexist", "test3")
+	result := cli.Docker(cli.Args("volume", "inspect", "--format={{ .Name }}", "test1", "test2", "doesnotexist", "test3"))
 	result.Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "No such volume: doesnotexist",

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -42,11 +42,6 @@ func dockerCmdWithError(args ...string) (string, int, error) {
 	return result.Combined(), result.ExitCode, result.Error
 }
 
-// Deprecated: use cli.Docker or cli.DockerCmd
-func dockerCmdWithResult(args ...string) *icmd.Result {
-	return cli.Docker(cli.Args(args...))
-}
-
 func findContainerIP(t *testing.T, id string, network string) string {
 	t.Helper()
 	out := cli.DockerCmd(t, "inspect", fmt.Sprintf("--format='{{ .NetworkSettings.Networks.%s.IPAddress }}'", network), id).Stdout()


### PR DESCRIPTION
We should probably look a bit at the replacement though; looks like the replacement;

- calls t.Fatal() by itself, instead of returning errors.
- does not use t.Helper(), which can make it more difficult to locate where errors happened.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

