### PR TITLE
libcontainerd: Fix racy error override

### DIFF
--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -516,7 +516,7 @@ func (c *container) createIO(fifos *cio.FIFOSet, stdinCloseSync chan containerd.
 					if !ok {
 						return
 					}
-					err = p.CloseIO(context.Background(), containerd.WithStdinCloser)
+					err := p.CloseIO(context.Background(), containerd.WithStdinCloser)
 					if err != nil && strings.Contains(err.Error(), "transport is closing") {
 						err = nil
 					}


### PR DESCRIPTION
Related to:
- https://github.com/moby/moby/pull/43564

Previous change removed declaration of the new error variable in the
subroutine scope and turned this statement into overriding an error from
the upper scope.


This results in a data race:
<details>
<summary> SHOW ME </summary>

```
==================
WARNING: DATA RACE
Read at 0x00c000929aa0 by goroutine 43:
  github.com/docker/docker/libcontainerd/supervisor.(*remote).monitorDaemon()
      /go/src/github.com/docker/docker/libcontainerd/supervisor/remote_daemon.go:318 +0x744
  github.com/docker/docker/libcontainerd/supervisor.Start.func1()
      /go/src/github.com/docker/docker/libcontainerd/supervisor/remote_daemon.go:95 +0x4c

Previous write at 0x00c000929aa0 by goroutine 45:
  github.com/docker/docker/libcontainerd/supervisor.(*remote).startContainerd.func1()
      /go/src/github.com/docker/docker/libcontainerd/supervisor/remote_daemon.go:193 +0xb8

Goroutine 43 (running) created at:
  github.com/docker/docker/libcontainerd/supervisor.Start()
      /go/src/github.com/docker/docker/libcontainerd/supervisor/remote_daemon.go:95 +0x578
  main.(*DaemonCli).initContainerd()
      /go/src/github.com/docker/docker/cmd/dockerd/daemon_unix.go:153 +0x244
  main.(*DaemonCli).start()
      /go/src/github.com/docker/docker/cmd/dockerd/daemon.go:170 +0x72c
  main.runDaemon()
      /go/src/github.com/docker/docker/cmd/dockerd/docker_unix.go:14 +0xd4
  main.newDaemonCommand.func1()
      /go/src/github.com/docker/docker/cmd/dockerd/docker.go:37 +0xd8
  github.com/docker/docker/vendor/github.com/spf13/cobra.(*Command).execute()
      /go/src/github.com/docker/docker/vendor/github.com/spf13/cobra/command.go:916 +0x7c8
  github.com/docker/docker/vendor/github.com/spf13/cobra.(*Command).ExecuteC()
      /go/src/github.com/docker/docker/vendor/github.com/spf13/cobra/command.go:1044 +0x480
  github.com/docker/docker/vendor/github.com/spf13/cobra.(*Command).Execute()
      /go/src/github.com/docker/docker/vendor/github.com/spf13/cobra/command.go:968 +0x288
  main.main()
      /go/src/github.com/docker/docker/cmd/dockerd/docker.go:102 +0x28c

Goroutine 45 (running) created at:
  github.com/docker/docker/libcontainerd/supervisor.(*remote).startContainerd()
      /go/src/github.com/docker/docker/libcontainerd/supervisor/remote_daemon.go:177 +0x798
  github.com/docker/docker/libcontainerd/supervisor.(*remote).monitorDaemon()
      /go/src/github.com/docker/docker/libcontainerd/supervisor/remote_daemon.go:286 +0x274
  github.com/docker/docker/libcontainerd/supervisor.Start.func1()
      /go/src/github.com/docker/docker/libcontainerd/supervisor/remote_daemon.go:95 +0x4c
==================
```

</details>

See the previous code for reference:
https://github.com/moby/moby/blob/57d2d6ef621cc126ca904e8fc98fbacbd345790a/libcontainerd/remote/client.go#L630-L646

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

