### PR TITLE
daemon/config: fix default-network-opts in daemon.json

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -76,12 +76,13 @@ var builtinRuntimes = map[string]bool{
 // Use this to differentiate these options
 // with others like the ones in TLSOptions.
 var flatOptions = map[string]bool{
-	"cluster-store-opts": true,
-	"log-opts":           true,
-	"runtimes":           true,
-	"default-ulimits":    true,
-	"features":           true,
-	"builder":            true,
+	"cluster-store-opts":   true,
+	"default-network-opts": true,
+	"log-opts":             true,
+	"runtimes":             true,
+	"default-ulimits":      true,
+	"features":             true,
+	"builder":              true,
 }
 
 // skipValidateOptions contains configuration keys

--- a/daemon/config/config_linux_test.go
+++ b/daemon/config/config_linux_test.go
@@ -25,6 +25,11 @@ func TestGetConflictFreeConfiguration(t *testing.T) {
 			},
 			"log-opts": {
 				"tag": "test_tag"
+			},
+			"default-network-opts": {
+				"overlay": {
+					"com.docker.network.driver.mtu": "1337"
+				}
 			}
 		}`)
 
@@ -33,6 +38,7 @@ func TestGetConflictFreeConfiguration(t *testing.T) {
 	flags.BoolVarP(&debug, "debug", "D", false, "")
 	flags.Var(opts.NewNamedUlimitOpt("default-ulimits", nil), "default-ulimit", "")
 	flags.Var(opts.NewNamedMapOpts("log-opts", nil, nil), "log-opt", "")
+	flags.Var(opts.NewNamedMapMapOpts("default-network-opts", nil, nil), "default-network-opt", "")
 
 	cc, err := getConflictFreeConfiguration(configFile, flags)
 	assert.NilError(t, err)


### PR DESCRIPTION
- Fixes https://github.com/moby/moby/pull/43197#issuecomment-1494674946
- fixes https://github.com/moby/moby/issues/23938

Thank you @richardg867 for reporting the issue.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Prevent the daemon from erroring out if daemon.json contains default network options for network drivers aside from bridge. Configuring defaults for the bridge driver previously worked by coincidence because the unrelated CLI flag `‑‑bridge` exists.

**- How I did it**
Added `"default-network-opts"` to the `flatOptions` set.

**- How to verify it**
With the following configuration, the daemon starts up and newly created overlay networks have the mtu option applied by default.

```console
$ cat /etc/docker/daemon.json
{"default-network-opts": {"overlay": {"com.docker.network.driver.mtu": "1434"}}}
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
N/A; bugfix for unreleased feature

**- A picture of a cute animal (not mandatory but encouraged)**

