### PR TITLE
c8d: Implement Children by comparing diff ids

### DIFF
--- a/daemon/containerd/image_children.go
+++ b/daemon/containerd/image_children.go
@@ -15,9 +15,7 @@ import (
 // Children returns a slice of image ID which rootfs is a superset of the
 // rootfs of the given image ID, excluding images with exactly the same rootfs.
 // Called from list.go to filter containers.
-func (i *ImageService) Children(id image.ID) []image.ID {
-	ctx := context.TODO()
-
+func (i *ImageService) Children(ctx context.Context, id image.ID) []image.ID {
 	target, err := i.resolveDescriptor(ctx, id.String())
 	if err != nil {
 		logrus.WithError(err).Error("failed to get parent image")

--- a/daemon/containerd/image_children.go
+++ b/daemon/containerd/image_children.go
@@ -1,0 +1,129 @@
+package containerd
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/content"
+	cerrdefs "github.com/containerd/containerd/errdefs"
+	containerdimages "github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
+	"github.com/docker/docker/image"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
+)
+
+// Children returns a slice of image ID which rootfs is a superset of the
+// rootfs of the given image ID, excluding images with exactly the same rootfs.
+// Called from list.go to filter containers.
+func (i *ImageService) Children(id image.ID) []image.ID {
+	ctx := context.TODO()
+
+	target, err := i.resolveDescriptor(ctx, id.String())
+	if err != nil {
+		logrus.WithError(err).Error("failed to get parent image")
+		return []image.ID{}
+	}
+
+	is := i.client.ImageService()
+	cs := i.client.ContentStore()
+
+	log := logrus.WithField("id", id)
+
+	allPlatforms, err := containerdimages.Platforms(ctx, cs, target)
+	if err != nil {
+		log.WithError(err).Error("failed to list supported platorms of image")
+		return []image.ID{}
+	}
+
+	parentRootFS := []ocispec.RootFS{}
+	for _, platform := range allPlatforms {
+		rootfs, err := platformRootfs(ctx, cs, target, platform)
+		if err != nil {
+			continue
+		}
+
+		parentRootFS = append(parentRootFS, rootfs)
+	}
+
+	imgs, err := is.List(ctx)
+	if err != nil {
+		log.WithError(err).Error("failed to list all images")
+		return []image.ID{}
+	}
+
+	children := []image.ID{}
+	for _, img := range imgs {
+	nextImage:
+		for _, platform := range allPlatforms {
+			rootfs, err := platformRootfs(ctx, cs, img.Target, platform)
+			if err != nil {
+				continue
+			}
+
+			for _, parentRoot := range parentRootFS {
+				if isRootfsChildOf(rootfs, parentRoot) {
+					children = append(children, image.ID(img.Target.Digest))
+					break nextImage
+				}
+			}
+		}
+
+	}
+
+	return children
+}
+
+// platformRootfs returns a rootfs for a specified platform.
+func platformRootfs(ctx context.Context, store content.Store, desc ocispec.Descriptor, platform ocispec.Platform) (ocispec.RootFS, error) {
+	empty := ocispec.RootFS{}
+
+	log := logrus.WithField("desc", desc.Digest).WithField("platform", platforms.Format(platform))
+	configDesc, err := containerdimages.Config(ctx, store, desc, platforms.OnlyStrict(platform))
+	if err != nil {
+		if !cerrdefs.IsNotFound(err) {
+			log.WithError(err).Warning("failed to get parent image config")
+		}
+		return empty, err
+	}
+
+	log = log.WithField("configDesc", configDesc)
+	diffs, err := containerdimages.RootFS(ctx, store, configDesc)
+	if err != nil {
+		if !cerrdefs.IsNotFound(err) {
+			log.WithError(err).Warning("failed to get parent image rootfs")
+		}
+		return empty, err
+	}
+
+	return ocispec.RootFS{
+		Type:    "layers",
+		DiffIDs: diffs,
+	}, nil
+}
+
+// isRootfsChildOf checks if all layers from parent rootfs are child's first layers
+// and child has at least one more layer (to make it not commutative).
+// Example:
+// A with layers [X, Y],
+// B with layers [X, Y, Z]
+// C with layers [Y, Z]
+//
+// Only isRootfsChildOf(B, A) is true.
+// Which means that B is considered a children of A. B and C has no children.
+// See more examples in TestIsRootfsChildOf.
+func isRootfsChildOf(child ocispec.RootFS, parent ocispec.RootFS) bool {
+	childLen := len(child.DiffIDs)
+	parentLen := len(parent.DiffIDs)
+
+	if childLen <= parentLen {
+		return false
+	}
+
+	for i := 0; i < parentLen; i++ {
+		if child.DiffIDs[i] != parent.DiffIDs[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/daemon/containerd/image_children_test.go
+++ b/daemon/containerd/image_children_test.go
@@ -1,0 +1,55 @@
+package containerd
+
+import (
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestIsRootfsChildOf(t *testing.T) {
+	// Each unique letter is one distinct DiffID
+	ab := toRootfs("AB")
+	abc := toRootfs("ABC")
+	abd := toRootfs("ABD")
+	xyz := toRootfs("XYZ")
+	xyzab := toRootfs("XYZAB")
+
+	for _, tc := range []struct {
+		name   string
+		parent ocispec.RootFS
+		child  ocispec.RootFS
+		out    bool
+	}{
+		{parent: ab, child: abc, out: true, name: "one additional layer"},
+		{parent: xyz, child: xyzab, out: true, name: "two additional layers"},
+		{parent: xyz, child: xyz, out: false, name: "parent is not a child of itself"},
+		{parent: abc, child: abd, out: false, name: "sibling"},
+		{parent: abc, child: xyz, out: false, name: "completely different rootfs, but same length"},
+		{parent: abc, child: ab, out: false, name: "child can't be shorter than parent"},
+		{parent: ab, child: xyzab, out: false, name: "parent layers appended"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			out := isRootfsChildOf(tc.child, tc.parent)
+
+			assert.Check(t, is.Equal(out, tc.out))
+		})
+	}
+}
+
+func toRootfs(values string) ocispec.RootFS {
+	dgsts := []digest.Digest{}
+
+	for _, v := range values {
+		vd := digest.FromString(string(v))
+		dgsts = append(dgsts, vd)
+	}
+
+	return ocispec.RootFS{
+		Type:    "layers",
+		DiffIDs: dgsts,
+	}
+}

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -76,13 +76,6 @@ func (i *ImageService) CountImages() int {
 	return len(imgs)
 }
 
-// Children returns the children image.IDs for a parent image.
-// called from list.go to filter containers
-// TODO: refactor to expose an ancestry for image.ID?
-func (i *ImageService) Children(id image.ID) []image.ID {
-	panic("not implemented")
-}
-
 // CreateLayer creates a filesystem layer for a container.
 // called from create.go
 // TODO: accept an opt struct instead of container?

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -75,7 +75,7 @@ type ImageService interface {
 
 	GetRepository(ctx context.Context, ref reference.Named, authConfig *registry.AuthConfig) (distribution.Repository, error)
 	DistributionServices() images.DistributionServices
-	Children(id image.ID) []image.ID
+	Children(ctx context.Context, id image.ID) []image.ID
 	Cleanup() error
 	StorageDriver() string
 	UpdateConfig(maxDownloads, maxUploads int)

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -109,7 +109,7 @@ func (i *ImageService) CountImages() int {
 // Children returns the children image.IDs for a parent image.
 // called from list.go to filter containers
 // TODO: refactor to expose an ancestry for image.ID?
-func (i *ImageService) Children(id image.ID) []image.ID {
+func (i *ImageService) Children(_ context.Context, id image.ID) []image.ID {
 	return i.imageStore.Children(id)
 }
 

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -328,7 +328,7 @@ func (daemon *Daemon) foldFilter(ctx context.Context, view *container.View, conf
 				return nil
 			}
 			// Then walk down the graph and put the imageIds in imagesFilter
-			populateImageFilterByParents(imagesFilter, img.ID(), daemon.imageService.Children)
+			populateImageFilterByParents(ctx, imagesFilter, img.ID(), daemon.imageService.Children)
 			return nil
 		})
 	}
@@ -594,10 +594,10 @@ func (daemon *Daemon) refreshImage(ctx context.Context, s *container.Snapshot, f
 	return &c, nil
 }
 
-func populateImageFilterByParents(ancestorMap map[image.ID]bool, imageID image.ID, getChildren func(image.ID) []image.ID) {
+func populateImageFilterByParents(ctx context.Context, ancestorMap map[image.ID]bool, imageID image.ID, getChildren func(context.Context, image.ID) []image.ID) {
 	if !ancestorMap[imageID] {
-		for _, id := range getChildren(imageID) {
-			populateImageFilterByParents(ancestorMap, id, getChildren)
+		for _, id := range getChildren(ctx, imageID) {
+			populateImageFilterByParents(ctx, ancestorMap, id, getChildren)
 		}
 		ancestorMap[imageID] = true
 	}


### PR DESCRIPTION
- Upstreams: https://github.com/rumpl/moby/pull/115

Implement Children method for containerd image store which makes the `ancestor` filter work for `docker ps`. 

Checking if image is a children of other image is implemented by comparing their rootfs diffids because containerd image store doesn't have a concept of image parentship like the graphdriver store. The child is expected to have more layers than the parent and should start with all parent layers.


**- How to verify it**

```bash
$ docker run -it alpine
/ # apk add fish
...
OK: 22 MiB in 24 packages

$ docker commit 8b1ea669e23e alpine-plus-fish
sha256:776b08f8a0cb27796cced75fcbe783bce0f2cbb0a91c38faadea44b519509c29

$ docker create alpine-plus-fish
c8e1caffdbbabdd3d67dbb9768d67a66ef98d26004eb4e10d7a880dd5da0870a

$ docker create busybox
7276114c22057a45964c93fcada3e23d2856e9021f1fdcc4959d410b8dce8eab

$ docker ps -a
CONTAINER ID   IMAGE              COMMAND     CREATED              STATUS                     PORTS     NAMES
7276114c2205   busybox            "sh"        About a minute ago   Created                              angry_kare
c8e1caffdbba   alpine-plus-fish   "/bin/sh"   2 minutes ago        Created                              brave_mcnulty
8b1ea669e23e   alpine             "/bin/sh"   2 minutes ago        Exited (0) 2 minutes ago             nifty_kilby

$ docker ps -a --filter ancestor=busybox
CONTAINER ID   IMAGE     COMMAND   CREATED         STATUS    PORTS     NAMES
7276114c2205   busybox   "sh"      2 minutes ago   Created             angry_kare
$ docker ps -a --filter ancestor=alpine-plus-fish
CONTAINER ID   IMAGE              COMMAND     CREATED         STATUS    PORTS     NAMES
c8e1caffdbba   alpine-plus-fish   "/bin/sh"   2 minutes ago   Created             brave_mcnulty
$ docker ps -a --filter ancestor=alpine
CONTAINER ID   IMAGE              COMMAND     CREATED         STATUS                     PORTS     NAMES
c8e1caffdbba   alpine-plus-fish   "/bin/sh"   2 minutes ago   Created                              brave_mcnulty
8b1ea669e23e   alpine             "/bin/sh"   3 minutes ago   Exited (0) 2 minutes ago             nifty_kilby

```

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

