### PR TITLE
c8d: Send an event when an image is tagged or deleted

### DIFF
--- a/daemon/containerd/image_delete.go
+++ b/daemon/containerd/image_delete.go
@@ -45,7 +45,7 @@ import (
 // TODO(thaJeztah): implement ImageDelete "force" options; see https://github.com/moby/moby/issues/43850
 // TODO(thaJeztah): implement ImageDelete "prune" options; see https://github.com/moby/moby/issues/43849
 // TODO(thaJeztah): add support for image delete using image (short)ID; see https://github.com/moby/moby/issues/43854
-// TODO(thaJeztah): mage delete should send image "untag" events and prometheus counters; see https://github.com/moby/moby/issues/43855
+// TODO(thaJeztah): image delete should send prometheus counters; see https://github.com/moby/moby/issues/45268
 func (i *ImageService) ImageDelete(ctx context.Context, imageRef string, force, prune bool) ([]types.ImageDeleteResponseItem, error) {
 	parsedRef, err := reference.ParseNormalizedNamed(imageRef)
 	if err != nil {
@@ -53,10 +53,19 @@ func (i *ImageService) ImageDelete(ctx context.Context, imageRef string, force, 
 	}
 	ref := reference.TagNameOnly(parsedRef)
 
+	desc, err := i.resolveDescriptor(ctx, imageRef)
+	if err != nil {
+		return nil, err
+	}
+
+	imgID := string(desc.Digest)
 	err = i.client.ImageService().Delete(ctx, ref.String(), images.SynchronousDelete())
 	if err != nil {
 		return nil, err
 	}
+
+	i.LogImageEvent(imgID, imgID, "untag")
+	i.LogImageEvent(imgID, imgID, "delete")
 
 	return []types.ImageDeleteResponseItem{{Untagged: reference.FamiliarString(parsedRef)}}, nil
 }


### PR DESCRIPTION
**- What I did**

Added image events when images are tagged or deleted. 

Note: the delete is not completely done, we don't send the `untag` event, only the `delete` one.

References #43855

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
