### PR TITLE
c8d: use the container's configured snapshotter where possible

### DIFF
--- a/daemon/containerd/image_changes.go
+++ b/daemon/containerd/image_changes.go
@@ -40,7 +40,7 @@ func (i *ImageService) Changes(ctx context.Context, container *container.Contain
 		return nil, err
 	}
 
-	snapshotter := i.client.SnapshotService(i.snapshotter)
+	snapshotter := i.client.SnapshotService(container.Driver)
 
 	diffIDs := image.RootFS.DiffIDs
 	parent, err := snapshotter.View(ctx, rnd.String(), identity.ChainID(diffIDs).String())

--- a/daemon/containerd/image_commit.go
+++ b/daemon/containerd/image_commit.go
@@ -61,7 +61,7 @@ func (i *ImageService) CommitImage(ctx context.Context, cc backend.CommitConfig)
 
 	var (
 		differ = i.client.DiffService()
-		sn     = i.client.SnapshotService(i.snapshotter)
+		sn     = i.client.SnapshotService(container.Driver)
 	)
 
 	// Don't gc me and clean the dirty data after 1 hour!
@@ -87,7 +87,7 @@ func (i *ImageService) CommitImage(ctx context.Context, cc backend.CommitConfig)
 	}
 
 	layers := append(manifest.Layers, diffLayerDesc)
-	commitManifestDesc, err := writeContentsForImage(ctx, i.snapshotter, cs, imageConfig, layers)
+	commitManifestDesc, err := writeContentsForImage(ctx, container.Driver, cs, imageConfig, layers)
 	if err != nil {
 		return "", err
 	}

--- a/daemon/containerd/image_exporter.go
+++ b/daemon/containerd/image_exporter.go
@@ -22,7 +22,7 @@ import (
 )
 
 func (i *ImageService) PerformWithBaseFS(ctx context.Context, c *container.Container, fn func(root string) error) error {
-	snapshotter := i.client.SnapshotService(i.snapshotter)
+	snapshotter := i.client.SnapshotService(c.Driver)
 	mounts, err := snapshotter.Mounts(ctx, c.ID)
 	if err != nil {
 		return err

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -50,6 +50,7 @@ func (i *ImageService) Images(ctx context.Context, opts types.ImageListOptions) 
 		return nil, err
 	}
 
+	// TODO(thaJeztah): do we need to take multiple snapshotters into account? See https://github.com/moby/moby/issues/45273
 	snapshotter := i.client.SnapshotService(i.snapshotter)
 	sizeCache := make(map[digest.Digest]int64)
 	snapshotSizeFn := func(d digest.Digest) (int64, error) {
@@ -177,6 +178,8 @@ func (i *ImageService) singlePlatformImage(ctx context.Context, contentStore con
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO(thaJeztah): do we need to take multiple snapshotters into account? See https://github.com/moby/moby/issues/45273
 	snapshotter := i.client.SnapshotService(i.snapshotter)
 	sizeCache := make(map[digest.Digest]int64)
 

--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -62,6 +62,7 @@ func (i *ImageService) PullImage(ctx context.Context, image, tagOrDigest string,
 	defer finishProgress()
 
 	opts = append(opts, containerd.WithPullUnpack)
+	// TODO(thaJeztah): we may have to pass the snapshotter to use if the pull is part of a "docker run" (container create -> pull image if missing). See https://github.com/moby/moby/issues/45273
 	opts = append(opts, containerd.WithPullSnapshotter(i.snapshotter))
 
 	// AppendInfoHandlerWrapper will annotate the image with basic information like manifest and layer digests as labels;

--- a/daemon/containerd/mount.go
+++ b/daemon/containerd/mount.go
@@ -13,7 +13,7 @@ import (
 // Mount mounts the container filesystem in a temporary location, use defer imageService.Unmount
 // to unmount the filesystem when calling this
 func (i *ImageService) Mount(ctx context.Context, container *container.Container) error {
-	snapshotter := i.client.SnapshotService(i.snapshotter)
+	snapshotter := i.client.SnapshotService(container.Driver)
 	mounts, err := snapshotter.Mounts(ctx, container.ID)
 	if err != nil {
 		return err

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -128,6 +128,7 @@ func (i *ImageService) ReleaseLayer(rwlayer layer.RWLayer) error {
 // called from disk_usage.go
 func (i *ImageService) LayerDiskUsage(ctx context.Context) (int64, error) {
 	var allLayersSize int64
+	// TODO(thaJeztah): do we need to take multiple snapshotters into account? See https://github.com/moby/moby/issues/45273
 	snapshotter := i.client.SnapshotService(i.snapshotter)
 	snapshotter.Walk(ctx, func(ctx context.Context, info snapshots.Info) error {
 		usage, err := snapshotter.Usage(ctx, info.Name)
@@ -179,7 +180,7 @@ func (i *ImageService) GetContainerLayerSize(ctx context.Context, containerID st
 		return 0, 0, err
 	}
 
-	snapshotter := i.client.SnapshotService(i.snapshotter)
+	snapshotter := i.client.SnapshotService(ctr.Driver)
 	usage, err := snapshotter.Usage(ctx, containerID)
 	if err != nil {
 		return 0, 0, err


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/45273
- relates to https://github.com/moby/moby/pull/44964#discussion_r1146197741

While we currently do not provide an option to specify the snapshotter to use for individual containers (we may want to add this option in future), currently it already is possible to configure the snapshotter in the daemon configuration, which could (likely) cause issues when changing and restarting the daemon.

This patch updates some code-paths that have the container available to use the snapshotter that's configured for the container (instead of the default snapshotter configured).

There are still code-paths to be looked into, and a tracking ticket as well as some TODO's were added for those.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

