### PR TITLE
Support recursively read-only (RRO) mounts

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -388,6 +388,16 @@ definitions:
             description: "Create mount point on host if missing"
             type: "boolean"
             default: false
+          ReadOnlyNonRecursive:
+            description: |
+               Make the mount non-recursively read-only, but still leave the mount recursive
+               (unless NonRecursive is set to true in conjunction).
+            type: "boolean"
+            default: false
+          ReadOnlyForceRecursive:
+            description: "Raise an error if the mount cannot be made recursively read-only."
+            type: "boolean"
+            default: false
       VolumeOptions:
         description: "Optional configuration for the `volume` type."
         type: "object"

--- a/api/types/mount/mount.go
+++ b/api/types/mount/mount.go
@@ -29,7 +29,7 @@ type Mount struct {
 	// Source is not supported for tmpfs (must be an empty value)
 	Source      string      `json:",omitempty"`
 	Target      string      `json:",omitempty"`
-	ReadOnly    bool        `json:",omitempty"`
+	ReadOnly    bool        `json:",omitempty"` // attempts recursive read-only if possible
 	Consistency Consistency `json:",omitempty"`
 
 	BindOptions    *BindOptions    `json:",omitempty"`
@@ -85,6 +85,11 @@ type BindOptions struct {
 	Propagation      Propagation `json:",omitempty"`
 	NonRecursive     bool        `json:",omitempty"`
 	CreateMountpoint bool        `json:",omitempty"`
+	// ReadOnlyNonRecursive makes the mount non-recursively read-only, but still leaves the mount recursive
+	// (unless NonRecursive is set to true in conjunction).
+	ReadOnlyNonRecursive bool `json:",omitempty"`
+	// ReadOnlyForceRecursive raises an error if the mount cannot be made recursively read-only.
+	ReadOnlyForceRecursive bool `json:",omitempty"`
 }
 
 // VolumeOptions represents the options for a mount of type volume.

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/go-connections/nat"
+	"github.com/opencontainers/runtime-spec/specs-go/features"
 )
 
 const (
@@ -658,7 +659,8 @@ type Runtime struct {
 	Options map[string]interface{} `json:"options,omitempty"`
 
 	// This is exposed here only for internal use
-	ShimConfig *ShimConfig `json:"-"`
+	ShimConfig *ShimConfig        `json:"-"`
+	Features   *features.Features `json:"-"`
 }
 
 // ShimConfig is used by runtime to configure containerd shims

--- a/container/mounts_unix.go
+++ b/container/mounts_unix.go
@@ -4,10 +4,12 @@ package container // import "github.com/docker/docker/container"
 
 // Mount contains information for a mount operation.
 type Mount struct {
-	Source       string `json:"source"`
-	Destination  string `json:"destination"`
-	Writable     bool   `json:"writable"`
-	Data         string `json:"data"`
-	Propagation  string `json:"mountpropagation"`
-	NonRecursive bool   `json:"nonrecursive"`
+	Source                 string `json:"source"`
+	Destination            string `json:"destination"`
+	Writable               bool   `json:"writable"`
+	Data                   string `json:"data"`
+	Propagation            string `json:"mountpropagation"`
+	NonRecursive           bool   `json:"nonrecursive"`
+	ReadOnlyNonRecursive   bool   `json:"readonlynonrecursive"`
+	ReadOnlyForceRecursive bool   `json:"readonlyforcerecursive"`
 }

--- a/daemon/daemon_unsupported.go
+++ b/daemon/daemon_unsupported.go
@@ -17,3 +17,7 @@ func setupResolvConf(_ *interface{}) {}
 func getSysInfo(_ *Daemon) *sysinfo.SysInfo {
 	return sysinfo.New()
 }
+
+func (daemon *Daemon) supportsRecursivelyReadOnly(_ string) error {
+	return nil
+}

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -604,3 +604,7 @@ func (daemon *Daemon) initLibcontainerd(ctx context.Context) error {
 
 	return err
 }
+
+func (daemon *Daemon) supportsRecursivelyReadOnly(_ string) error {
+	return nil
+}

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -20,6 +20,10 @@ keywords: "API, Docker, rcli, REST, documentation"
 * The `VirtualSize` field in the `GET /images/{name}/json`, `GET /images/json`,
   and `GET /system/df` responses is now omitted. Use the `Size` field instead,
   which contains the same information.
+* Read-only bind mounts are now made recursively read-only on kernel >= 5.12
+  with runtimes which support the feature.
+  `POST /containers/create`, `GET /containers/{id}/json`, and `GET /containers/json` now supports
+  `BindOptions.ReadOnlyNonRecursive` and `BindOptions.ReadOnlyForceRecursive` to customize the behavior.
 
 ## v1.43 API changes
 

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -94,6 +94,13 @@ func WithBind(src, target string) func(*TestContainerConfig) {
 	}
 }
 
+// WithBindRaw sets the bind mount of the container
+func WithBindRaw(s string) func(*TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.HostConfig.Binds = append(c.HostConfig.Binds, s)
+	}
+}
+
 // WithTmpfs sets a target path in the container to a tmpfs, with optional options
 // (separated with a colon).
 func WithTmpfs(targetAndOpts string) func(config *TestContainerConfig) {

--- a/volume/mounts/parser.go
+++ b/volume/mounts/parser.go
@@ -13,8 +13,11 @@ var ErrVolumeTargetIsRoot = errors.New("invalid specification: destination can't
 
 // read-write modes
 var rwModes = map[string]bool{
-	"rw": true,
-	"ro": true,
+	"rw":                 true,
+	"ro":                 true, // attempts recursive read-only if possible
+	"ro-non-recursive":   true, // makes the mount non-recursively read-only, but still leaves the mount recursive
+	"ro-force-recursive": true, // raises an error if the mount cannot be made recursively read-only
+	"rro":                true, // alias for ro-force-recursive
 }
 
 // Parser represents a platform specific parser for mount expressions


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
- Fixes #44978
- Fixes docker/for-linux#788
- Fixes https://github.com/moby/moby/issues/23499



**- What I did**

Added the support for recursively read-only (RRO) mounts.

`docker run -v /foo:/foo:ro` is now recursively read-only on kernel >= 5.12.
Automatically falls back to the legacy non-recursively read-only mount mode on kernel < 5.12.

~Use `ro-non-recursive` to disable RRO.
Use `ro-force-recursive` or `rro` to explicitly enable RRO. (Fails on kernel < 5.12)~
(**EDIT**: the CLI options are being changed in https://github.com/moby/moby/pull/46037 and https://github.com/docker/cli/pull/4316 )

It is highly recommended to use RRO in conjunction with `rprivate` propagation.

**- How I did it**

By using OCI mount option "rro", which is implemented by calling `mount_setattr(2)` with  `AT_RECURSIVE` and `MOUNT_ATTR_RDONLY`.

**- How to verify it**

Run `docker run -v /mnt:/mnt:ro,rprivate` on kernel >= 5.12, and make sure `/mnt/recursive-mount-dir` is read-only.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Support recursively read-only (RRO) mounts

**- A picture of a cute animal (not mandatory but encouraged)**
:penguin:
