### PR TITLE
docker-rootless-setuptools.sh: improve readability of messages

### DIFF
--- a/contrib/dockerd-rootless-setuptool.sh
+++ b/contrib/dockerd-rootless-setuptool.sh
@@ -390,18 +390,18 @@ cmd_entrypoint_install() {
 		cli_ctx_create "${CLI_CONTEXT}" "unix://${XDG_RUNTIME_DIR}/docker.sock" "Rootless mode"
 	fi
 
-	INFO "Use CLI context \"${CLI_CONTEXT}\""
+	INFO "Using CLI context \"${CLI_CONTEXT}\""
 	cli_ctx_use "${CLI_CONTEXT}"
 
 	echo
-	INFO "Make sure the following environment variables are set (or add them to ~/.bashrc):"
-	echo
+	INFO "Make sure the following environment variable(s) are set (or add them to ~/.bashrc):"
 	if [ -n "$XDG_RUNTIME_DIR_CREATED" ]; then
 		echo "# WARNING: systemd not found. You have to remove XDG_RUNTIME_DIR manually on every logout."
 		echo "export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}"
 	fi
 	echo "export PATH=${BIN}:\$PATH"
-	echo "Some applications may require the following environment variable too:"
+	echo
+	INFO "Some applications may require the following environment variable too:"
 	echo "export DOCKER_HOST=unix://${XDG_RUNTIME_DIR}/docker.sock"
 	echo
 
@@ -433,7 +433,7 @@ cmd_entrypoint_uninstall() {
 	unset DOCKER_HOST
 	unset DOCKER_CONTEXT
 	cli_ctx_use "default"
-	INFO 'Configured CLI use the "default" context.'
+	INFO 'Configured CLI to use the "default" context.'
 	INFO
 	INFO 'Make sure to unset or update the environment PATH, DOCKER_HOST, and DOCKER_CONTEXT environment variables if you have added them to `~/.bashrc`.'
 	INFO "This uninstallation tool does NOT remove Docker binaries and data."


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
`docker-rootless-setuptools.sh`: improve readability of messages

**- How I did it**
See the code

**- How to verify it**

Before:
```console
$ docker-rootless-setuptool.sh install
...
[INFO] Use CLI context "rootless"
Current context is now "rootless"

[INFO] Make sure the following environment variables are set (or add them to ~/.bashrc):

export PATH=/usr/local/bin:$PATH
Some applications may require the following environment variable too:
export DOCKER_HOST=unix:///run/user/1001/docker.sock
```

After:
```console
$ docker-rootless-setuptool.sh install
...
[INFO] Using CLI context "rootless"
Current context is now "rootless"

[INFO] Make sure the following environment variable(s) are set (or add them to ~/.bashrc):
export PATH=/usr/local/bin:$PATH

[INFO] Some applications may require the following environment variable too:
export DOCKER_HOST=unix:///run/user/1001/docker.sock
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
docker-rootless-setuptools.sh: improve readability of messages

**- A picture of a cute animal (not mandatory but encouraged)**
:penguin:
