### PR TITLE
c8d: implement GetRepository (split GetRepository from ImageService)

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -522,7 +522,7 @@ func initRouter(opts routerOptions) {
 		sessionrouter.NewRouter(opts.sessionManager),
 		swarmrouter.NewRouter(opts.cluster),
 		pluginrouter.NewRouter(opts.daemon.PluginManager()),
-		distributionrouter.NewRouter(opts.daemon.ImageService()),
+		distributionrouter.NewRouter(opts.daemon.ImageBackend()),
 	}
 
 	if opts.buildBackend != nil {
@@ -729,7 +729,7 @@ func createAndStartCluster(cli *DaemonCli, d *daemon.Daemon) (*cluster.Cluster, 
 		Name:                   name,
 		Backend:                d,
 		VolumeBackend:          d.VolumesService(),
-		ImageBackend:           d.ImageService(),
+		ImageBackend:           d.ImageBackend(),
 		PluginBackend:          d.PluginManager(),
 		NetworkSubnetsProvider: d,
 		DefaultAdvertiseAddr:   cli.Config.SwarmDefaultAdvertiseAddr,

--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -2,14 +2,12 @@ package containerd
 
 import (
 	"context"
-	"errors"
 	"io"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/pkg/snapshotters"
 	"github.com/containerd/containerd/platforms"
-	"github.com/docker/distribution"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/errdefs"
@@ -72,9 +70,4 @@ func (i *ImageService) PullImage(ctx context.Context, image, tagOrDigest string,
 
 	_, err = i.client.Pull(ctx, ref.String(), opts...)
 	return err
-}
-
-// GetRepository returns a repository from the registry.
-func (i *ImageService) GetRepository(ctx context.Context, ref reference.Named, authConfig *registry.AuthConfig) (distribution.Repository, error) {
-	return nil, errdefs.NotImplemented(errors.New("not implemented"))
 }

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 
-	"github.com/docker/distribution"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
@@ -73,7 +72,6 @@ type ImageService interface {
 
 	// Other
 
-	GetRepository(ctx context.Context, ref reference.Named, authConfig *registry.AuthConfig) (distribution.Repository, error)
 	DistributionServices() images.DistributionServices
 	Children(id image.ID) []image.ID
 	Cleanup() error

--- a/daemon/images/image_pull.go
+++ b/daemon/images/image_pull.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/namespaces"
-	dist "github.com/docker/distribution"
 	"github.com/docker/distribution/reference"
 	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/registry"
@@ -132,16 +131,6 @@ func (i *ImageService) pullImageWithReference(ctx context.Context, ref reference
 	close(progressChan)
 	<-writesDone
 	return err
-}
-
-// GetRepository returns a repository from the registry.
-func (i *ImageService) GetRepository(ctx context.Context, ref reference.Named, authConfig *registry.AuthConfig) (dist.Repository, error) {
-	return distribution.GetRepository(ctx, ref, &distribution.ImagePullConfig{
-		Config: distribution.Config{
-			AuthConfig:      authConfig,
-			RegistryService: i.registryService,
-		},
-	})
 }
 
 func tempLease(ctx context.Context, mgr leases.Manager) (context.Context, func(context.Context) error, error) {


### PR DESCRIPTION
The GetRepository method interacts directly with the registry, and does
not depend on the snapshotter, but is used for two purposes;

For the GET /distribution/{name:.*}/json route;
https://github.com/moby/moby/blob/dd3b71d17c614f837c4bba18baed9fa2cb31f1a4/api/server/router/distribution/backend.go#L11-L15

And to satisfy the "executor.ImageBackend" interface as used by Swarm;
https://github.com/moby/moby/blob/58c027ac8ba19a3fa339c65274ea6704ccbec977/daemon/cluster/executor/backend.go#L77

This patch removes the method from the ImageService interface, and instead
implements it through an composite struct that satisfies both interfaces,
and an ImageBackend() method is added to the daemon.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

