### PR TITLE
c8d/list: Fix `label` (and add `label!`) filter

### DIFF
--- a/daemon/containerd/handlers.go
+++ b/daemon/containerd/handlers.go
@@ -1,0 +1,37 @@
+package containerd
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/content"
+	cerrdefs "github.com/containerd/containerd/errdefs"
+	containerdimages "github.com/containerd/containerd/images"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// presentChildrenHandler is a handler wrapper which traverses all children
+// descriptors that are present in the store and calls specified handler.
+func presentChildrenHandler(store content.Store, h containerdimages.HandlerFunc) containerdimages.HandlerFunc {
+	return func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		_, err := store.Info(ctx, desc.Digest)
+		if err != nil {
+			if cerrdefs.IsNotFound(err) {
+				return nil, nil
+			}
+			return nil, err
+		}
+
+		children, err := h(ctx, desc)
+		if err != nil {
+			return nil, err
+		}
+
+		c, err := containerdimages.Children(ctx, store, desc)
+		if err != nil {
+			return nil, err
+		}
+		children = append(children, c...)
+
+		return children, nil
+	}
+}


### PR DESCRIPTION
- Depends on: https://github.com/moby/moby/pull/45269
- Alternative to: https://github.com/moby/moby/pull/45288

Fixes the  `label` filter which compared labels of the  containerd Image object instead of the labels from the image config.
Multi-platform images have multiple configurations - in this case the image will match the filter as long as **any** of the config's labels match the filter.

I tried to use the containerd filter syntax, but it can't really do the `label!=key` which filters images that DON'T have the label `key`. The code is here: https://github.com/moby/moby/pull/45288 - posting it just for posterity, maybe at some point containerd gets that ability or we contribute it and we'll be able use it instead (if we want).

**- What I did**

**- How I did it**

**- How to verify it**
```bash
$ docker images
REPOSITORY   TAG       IMAGE ID       CREATED             SIZE
busybox      latest    b5d6fe071263   About an hour ago   2.01MB
ubuntu       20.04     24a0df437301   About an hour ago   26MB
ubuntu       22.04     67211c14fa74   About an hour ago   27.4MB

$ docker inspect busybox -f '{{.Config.Labels}}'
map[]
$ docker inspect ubuntu:22.04 -f '{{.Config.Labels}}'
map[org.opencontainers.image.ref.name:ubuntu org.opencontainers.image.version:22.04]
$ docker inspect ubuntu:20.04 -f '{{.Config.Labels}}'
map[org.opencontainers.image.ref.name:ubuntu org.opencontainers.image.version:20.04]



$ docker images --filter label=org.opencontainers.image.ref.name # images with this label (any value)
REPOSITORY   TAG       IMAGE ID       CREATED             SIZE
ubuntu       20.04     24a0df437301   About an hour ago   26MB
ubuntu       22.04     67211c14fa74   About an hour ago   27.4MB

$ docker images --filter label=org.opencontainers.image.ref.name=ubuntu # images with exact value of this label
REPOSITORY   TAG       IMAGE ID       CREATED             SIZE
ubuntu       20.04     24a0df437301   About an hour ago   26MB
ubuntu       22.04     67211c14fa74   About an hour ago   27.4MB

$ docker images --filter label=org.opencontainers.image.version=22.04 # images with exact value of this label
REPOSITORY   TAG       IMAGE ID       CREATED             SIZE
ubuntu       22.04     67211c14fa74   About an hour ago   27.4MB

$ docker images --filter label!=org.opencontainers.image.version # images without this label
REPOSITORY   TAG       IMAGE ID       CREATED             SIZE
busybox      latest    b5d6fe071263   About an hour ago   2.01MB

$ docker images --filter label=org.opencontainers.image.version!=22.04 # images with value other than
REPOSITORY   TAG       IMAGE ID       CREATED             SIZE
busybox      latest    b5d6fe071263   About an hour ago   2.01MB
ubuntu       20.04     24a0df437301   About an hour ago   26MB

$ docker images --filter label=org.opencontainers.image.version!=22.04 # images with value other than
REPOSITORY   TAG       IMAGE ID       CREATED       SIZE
ubuntu       20.04     24a0df437301   2 hours ago   26MB

$ docker images --filter label!=org.opencontainers.image.version!=22.04 # images with value not other than (aka sceptic's way to check equality)
REPOSITORY   TAG       IMAGE ID       CREATED       SIZE
ubuntu       22.04     67211c14fa74   2 hours ago   27.4MB


```

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

