### PR TITLE
builder-next/prune: Handle `until` filter timestamps

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8226,7 +8226,7 @@ paths:
 
             Available filters:
 
-            - `until=<duration>`: duration relative to daemon's time, during which build cache was not used, in Go's duration format (e.g., '24h')
+            - `until=<timestamp>` remove cache older than `<timestamp>`. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon's local time.
             - `id=<id>`
             - `parent=<id>`
             - `type=<string>`

--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
+	timetypes "github.com/docker/docker/api/types/time"
 	"github.com/docker/docker/builder"
 	mobyexporter "github.com/docker/docker/builder/builder-next/exporter"
 	"github.com/docker/docker/builder/builder-next/exporter/overrides"
@@ -626,11 +627,16 @@ func toBuildkitPruneInfo(opts types.BuildCachePruneOptions) (client.PruneInfo, e
 	case 0:
 		// nothing to do
 	case 1:
-		var err error
-		until, err = time.ParseDuration(untilValues[0])
+		ts, err := timetypes.GetTimestamp(untilValues[0], time.Now())
 		if err != nil {
-			return client.PruneInfo{}, errors.Wrapf(err, "%q filter expects a duration (e.g., '24h')", filterKey)
+			return client.PruneInfo{}, errors.Wrapf(err, "%q filter expects a duration (e.g., '24h') or a timestamp", filterKey)
 		}
+		seconds, nanoseconds, err := timetypes.ParseTimestamps(ts, 0)
+		if err != nil {
+			return client.PruneInfo{}, errors.Wrapf(err, "failed to parse timestamp %s", ts)
+		}
+
+		until = time.Since(time.Unix(seconds, nanoseconds))
 	default:
 		return client.PruneInfo{}, errMultipleFilterValues{}
 	}

--- a/daemon/prune.go
+++ b/daemon/prune.go
@@ -2,7 +2,6 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"strconv"
 	"sync/atomic"
@@ -230,15 +229,15 @@ func getUntilFromPruneFilters(pruneFilters filters.Args) (time.Time, error) {
 	}
 	untilFilters := pruneFilters.Get("until")
 	if len(untilFilters) > 1 {
-		return until, fmt.Errorf("more than one until filter specified")
+		return until, errdefs.InvalidParameter(errors.New("more than one until filter specified"))
 	}
 	ts, err := timetypes.GetTimestamp(untilFilters[0], time.Now())
 	if err != nil {
-		return until, err
+		return until, errdefs.InvalidParameter(err)
 	}
 	seconds, nanoseconds, err := timetypes.ParseTimestamps(ts, 0)
 	if err != nil {
-		return until, err
+		return until, errdefs.InvalidParameter(err)
 	}
 	until = time.Unix(seconds, nanoseconds)
 	return until, nil


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/40253
- supersedes https://github.com/moby/moby/pull/40254

Fixes `docker system prune --filter until=<timestamp>`.
`docker system prune` claims to support "until" filter for timestamps, but it doesn't work because builder "until" filter only supports duration.
Use the same filter parsing logic and then convert the timestamp to a relative "keep-duration" supported by buildkit.

Also, fixed untyped errors returned when filter isn't a valid value:
```
DEBU[2023-04-07T11:27:28.111736050Z] FIXME: Got an API for which error does not match any expected type!!!: parsing time "202dfsfddf3-04-08" as "2006-01-02": cannot parse "202dfsfddf3-04-08" as "2006"  error_type="*time.ParseError" module=api
ERRO[2023-04-07T11:27:28.111806259Z] Handler for POST /v1.41/containers/prune returned error: parsing time "202dfsfddf3-04-08" as "2006-01-02": cannot parse "202dfsfddf3-04-08" as "2006"
```

**- How to verify it**
<details>
<summary>Spoiler</summary>

```bash
# Before
$ docker system prune --filter until=2023-04-07
WARNING! This will remove:
  - all stopped containers
  - all networks not used by at least one container
  - all dangling images
  - all dangling build cache

  Items to be pruned will be filtered with:
  - until=2023-04-07

Are you sure you want to continue? [y/N] y
Error response from daemon: failed to prune build cache: "until" filter expects a duration (e.g., '24h'): time: unknown unit "-" in duration "2023-04-07"

# After
$ echo 'FROM alpine' | docker buildx build -q -t asdf -
sha256:c41833b44d910632b415cd89a9cdaa4d62c9725dc56c99a7ddadafd6719960f9

$ docker rmi asdf
Untagged: asdf:latest
Deleted: sha256:13fdf3c19db4214ef2013388e22461ec089d6c8fd6d1c84fe8ba31680aff19b0

# prune until start of today (excluding last build)
$ docker system prune --filter until=2023-04-07
WARNING! This will remove:
  - all stopped containers
  - all networks not used by at least one container
  - all dangling images
  - all dangling build cache

  Items to be pruned will be filtered with:
  - until=2023-04-07

Are you sure you want to continue? [y/N] y
Total reclaimed space: 0B

# prune until next day (including last build)
$ docker system prune --filter until=2023-04-08
WARNING! This will remove:
  - all stopped containers
  - all networks not used by at least one container
  - all dangling images
  - all dangling build cache

  Items to be pruned will be filtered with:
  - until=2023-04-08

Are you sure you want to continue? [y/N] y
Deleted build cache objects:
np1jrw1al2rfmu6cmr7tsnbbh
o0cl7w0jcsruz9dnwkr2epf9l
4wtlnw56cddubj3tqka67o4z2

Total reclaimed space: 12B
```

</details>

**- Description for the changelog**



**- A picture of a cute animal (not mandatory but encouraged)**
![dudubox](https://user-images.githubusercontent.com/5046555/230604593-6da242a9-9700-41d7-a298-f732f826665b.jpg)
