### PR TITLE
use consistent alias for containerd's errdefs package, and validate in CI

### DIFF
--- a/api/server/httpstatus/status.go
+++ b/api/server/httpstatus/status.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	containerderrors "github.com/containerd/containerd/errdefs"
+	cerrdefs "github.com/containerd/containerd/errdefs"
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/docker/errdefs"
 	"github.com/sirupsen/logrus"
@@ -132,17 +132,17 @@ func statusCodeFromDistributionError(err error) int {
 // consumed directly (not through gRPC)
 func statusCodeFromContainerdError(err error) int {
 	switch {
-	case containerderrors.IsInvalidArgument(err):
+	case cerrdefs.IsInvalidArgument(err):
 		return http.StatusBadRequest
-	case containerderrors.IsNotFound(err):
+	case cerrdefs.IsNotFound(err):
 		return http.StatusNotFound
-	case containerderrors.IsAlreadyExists(err):
+	case cerrdefs.IsAlreadyExists(err):
 		return http.StatusConflict
-	case containerderrors.IsFailedPrecondition(err):
+	case cerrdefs.IsFailedPrecondition(err):
 		return http.StatusPreconditionFailed
-	case containerderrors.IsUnavailable(err):
+	case cerrdefs.IsUnavailable(err):
 		return http.StatusServiceUnavailable
-	case containerderrors.IsNotImplemented(err):
+	case cerrdefs.IsNotImplemented(err):
 		return http.StatusNotImplemented
 	default:
 		return http.StatusInternalServerError

--- a/builder/builder-next/adapters/containerimage/pull.go
+++ b/builder/builder-next/adapters/containerimage/pull.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/content"
-	containerderrors "github.com/containerd/containerd/errdefs"
+	cerrdefs "github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/gc"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/leases"
@@ -712,7 +712,7 @@ func showProgress(ctx context.Context, ongoing *jobs, cs content.Store, pw progr
 			if !j.done {
 				info, err := cs.Info(context.TODO(), j.Digest)
 				if err != nil {
-					if containerderrors.IsNotFound(err) {
+					if cerrdefs.IsNotFound(err) {
 						// _ = pw.Write(j.Digest.String(), progress.Status{
 						// 	Action: "waiting",
 						// })

--- a/builder/builder-next/adapters/snapshot/snapshot.go
+++ b/builder/builder-next/adapters/snapshot/snapshot.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/containerd/containerd/errdefs"
+	cerrdefs "github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshots"
@@ -204,7 +204,7 @@ func (s *snapshotter) getGraphDriverID(key string) (string, bool) {
 	if err := s.db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(key))
 		if b == nil {
-			return errors.Wrapf(errdefs.ErrNotFound, "key %s", key)
+			return errors.Wrapf(cerrdefs.ErrNotFound, "key %s", key)
 		}
 		v := b.Get(keyCommitted)
 		if v != nil {
@@ -248,7 +248,7 @@ func (s *snapshotter) Stat(ctx context.Context, key string) (snapshots.Info, err
 	if err := s.db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(id))
 		if b == nil && l == nil {
-			return errors.Wrapf(errdefs.ErrNotFound, "snapshot %s", id)
+			return errors.Wrapf(cerrdefs.ErrNotFound, "snapshot %s", id)
 		}
 		inf.Name = key
 		if b != nil {

--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -7,7 +7,7 @@ import (
 	"io"
 
 	"github.com/containerd/containerd/content"
-	c8derrdefs "github.com/containerd/containerd/errdefs"
+	cerrdefs "github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/platforms"
@@ -83,7 +83,7 @@ func (i *ImageService) manifestMatchesPlatform(ctx context.Context, img *image.I
 
 		ra, err := i.content.ReaderAt(ctx, specs.Descriptor{Digest: digest.Digest(r.ID)})
 		if err != nil {
-			if c8derrdefs.IsNotFound(err) {
+			if cerrdefs.IsNotFound(err) {
 				continue
 			}
 			logger.WithError(err).Error("Error looking up referenced manifest list for image")

--- a/daemon/images/store_test.go
+++ b/daemon/images/store_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/content/local"
-	c8derrdefs "github.com/containerd/containerd/errdefs"
+	cerrdefs "github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/metadata"
 	"github.com/containerd/containerd/namespaces"
@@ -117,7 +117,7 @@ func TestContentStoreForPull(t *testing.T) {
 	// Test already exists
 	csP.digested = nil
 	_, err = csP.Writer(ctx, content.WithRef(t.Name()), content.WithDescriptor(desc))
-	assert.Check(t, c8derrdefs.IsAlreadyExists(err))
+	assert.Check(t, cerrdefs.IsAlreadyExists(err))
 	assert.Equal(t, len(csP.digested), 1)
 	assert.Check(t, is.Equal(csP.digested[0], desc.Digest))
 }

--- a/distribution/manifest.go
+++ b/distribution/manifest.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/errdefs"
+	cerrdefs "github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/remotes"
 	"github.com/docker/distribution"
@@ -124,7 +124,7 @@ func (m *manifestStore) getLocal(ctx context.Context, desc specs.Descriptor, ref
 			}
 
 			if !exists {
-				return nil, errors.Wrapf(errdefs.ErrNotFound, "manifest %v not found", desc.Digest)
+				return nil, errors.Wrapf(cerrdefs.ErrNotFound, "manifest %v not found", desc.Digest)
 			}
 
 		}
@@ -180,7 +180,7 @@ func (m *manifestStore) Get(ctx context.Context, desc specs.Descriptor, ref refe
 		// here. We may not even have the content locally, and this is fine, but
 		// if we do we should determine that.
 		mt, err := m.getMediaType(ctx, desc)
-		if err != nil && !errdefs.IsNotFound(err) {
+		if err != nil && !cerrdefs.IsNotFound(err) {
 			l.WithError(err).Warn("Error looking up media type of content")
 		}
 		desc.MediaType = mt
@@ -193,7 +193,7 @@ func (m *manifestStore) Get(ctx context.Context, desc specs.Descriptor, ref refe
 	// ref count on the content.
 	w, err := m.local.Writer(ctx, content.WithDescriptor(desc), content.WithRef(key))
 	if err != nil {
-		if errdefs.IsAlreadyExists(err) {
+		if cerrdefs.IsAlreadyExists(err) {
 			var manifest distribution.Manifest
 			if manifest, err = m.getLocal(ctx, desc, ref); err == nil {
 				return manifest, nil

--- a/distribution/manifest_test.go
+++ b/distribution/manifest_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/content/local"
-	"github.com/containerd/containerd/errdefs"
+	cerrdefs "github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/remotes"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/manifestlist"
@@ -188,7 +188,7 @@ func TestManifestStore(t *testing.T) {
 	checkIngest := func(t *testing.T, cs content.Store, desc specs.Descriptor) {
 		ingestKey := remotes.MakeRefKey(ctx, desc)
 		_, err := cs.Status(ctx, ingestKey)
-		assert.Check(t, errdefs.IsNotFound(err), err)
+		assert.Check(t, cerrdefs.IsNotFound(err), err)
 	}
 
 	t.Run("no remote or local", func(t *testing.T) {
@@ -323,7 +323,7 @@ func TestManifestStore(t *testing.T) {
 
 			_, err = cs.Info(ctx, desc.Digest)
 			// Nothing here since we couldn't persist
-			assert.Check(t, errdefs.IsNotFound(err), err)
+			assert.Check(t, cerrdefs.IsNotFound(err), err)
 		})
 
 		t.Run("error on commit", func(t *testing.T) {
@@ -342,7 +342,7 @@ func TestManifestStore(t *testing.T) {
 
 			_, err = cs.Info(ctx, desc.Digest)
 			// Nothing here since we couldn't persist
-			assert.Check(t, errdefs.IsNotFound(err), err)
+			assert.Check(t, cerrdefs.IsNotFound(err), err)
 		})
 	})
 }

--- a/hack/validate/golangci-lint.yml
+++ b/hack/validate/golangci-lint.yml
@@ -5,6 +5,7 @@ linters:
     - gosec
     - gosimple
     - govet
+    - importas
     - ineffassign
     - misspell
     - revive
@@ -24,6 +25,16 @@ linters:
       - docs
 
 linters-settings:
+  importas:
+    # Do not allow unaliased imports of aliased packages.
+    no-unaliased: true
+
+    alias:
+      # Enforce alias to prevent it accidentally being used instead of our
+      # own errdefs package (or vice-versa).
+      - pkg: github.com/containerd/containerd/errdefs
+        alias: cerrdefs
+
   govet:
     check-shadowing: false
   depguard:

--- a/integration/container/pause_test.go
+++ b/integration/container/pause_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	containerderrdefs "github.com/containerd/containerd/errdefs"
+	cerrdefs "github.com/containerd/containerd/errdefs"
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
@@ -64,7 +64,7 @@ func TestPauseFailsOnWindowsServerContainers(t *testing.T) {
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	err := client.ContainerPause(ctx, cID)
-	assert.Check(t, is.ErrorContains(err, containerderrdefs.ErrNotImplemented.Error()))
+	assert.Check(t, is.ErrorContains(err, cerrdefs.ErrNotImplemented.Error()))
 }
 
 func TestPauseStopPausedContainer(t *testing.T) {

--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -18,8 +18,7 @@ import (
 	"github.com/Microsoft/hcsshim"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
-	containerderrdefs "github.com/containerd/containerd/errdefs"
-
+	cerrdefs "github.com/containerd/containerd/errdefs"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libcontainerd/queue"
 	libcontainerdtypes "github.com/docker/docker/libcontainerd/types"
@@ -397,7 +396,7 @@ func (ctr *container) Start(_ context.Context, _ string, withStdin bool, attachS
 	case ctr.ociSpec == nil:
 		return nil, errors.WithStack(errdefs.NotImplemented(errors.New("a restored container cannot be started")))
 	case ctr.task != nil:
-		return nil, errors.WithStack(errdefs.NotModified(containerderrdefs.ErrAlreadyExists))
+		return nil, errors.WithStack(errdefs.NotModified(cerrdefs.ErrAlreadyExists))
 	}
 
 	logger := ctr.client.logger.WithField("container", ctr.id)
@@ -520,7 +519,7 @@ func (ctr *container) Task(context.Context) (libcontainerdtypes.Task, error) {
 	ctr.mu.Lock()
 	defer ctr.mu.Unlock()
 	if ctr.task == nil {
-		return nil, errdefs.NotFound(containerderrdefs.ErrNotFound)
+		return nil, errdefs.NotFound(cerrdefs.ErrNotFound)
 	}
 	return ctr.task, nil
 }
@@ -772,7 +771,7 @@ func (p *process) CloseStdin(context.Context) error {
 // Pause handles pause requests for containers
 func (t *task) Pause(_ context.Context) error {
 	if t.ctr.ociSpec.Windows.HyperV == nil {
-		return containerderrdefs.ErrNotImplemented
+		return cerrdefs.ErrNotImplemented
 	}
 
 	t.ctr.mu.Lock()
@@ -908,7 +907,7 @@ func (c *client) LoadContainer(ctx context.Context, id string) (libcontainerdtyp
 // re-attach isn't possible (see LoadContainer), a NotFound error is
 // unconditionally returned to allow restore to make progress.
 func (*container) AttachTask(context.Context, libcontainerdtypes.StdioCallback) (libcontainerdtypes.Task, error) {
-	return nil, errdefs.NotFound(containerderrdefs.ErrNotImplemented)
+	return nil, errdefs.NotFound(cerrdefs.ErrNotImplemented)
 }
 
 // Pids returns a list of process IDs running in a container. It is not

--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -19,7 +19,7 @@ import (
 	"github.com/containerd/containerd/archive"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/content"
-	containerderrors "github.com/containerd/containerd/errdefs"
+	cerrdefs "github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/images"
 	v2runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
@@ -127,7 +127,7 @@ func (c *client) NewContainer(ctx context.Context, id string, ociSpec *specs.Spe
 
 	ctr, err := c.client.NewContainer(ctx, id, opts...)
 	if err != nil {
-		if containerderrors.IsAlreadyExists(err) {
+		if cerrdefs.IsAlreadyExists(err) {
 			return nil, errors.WithStack(errdefs.Conflict(errors.New("id already in use")))
 		}
 		return nil, wrapError(err)
@@ -285,7 +285,7 @@ func (t *task) Exec(ctx context.Context, processID string, spec *specs.Process, 
 	})
 	if err != nil {
 		close(stdinCloseSync)
-		if containerderrors.IsAlreadyExists(err) {
+		if cerrdefs.IsAlreadyExists(err) {
 			return nil, errors.WithStack(errdefs.Conflict(errors.New("id already in use")))
 		}
 		return nil, wrapError(err)
@@ -473,7 +473,7 @@ func (t *task) CreateCheckpoint(ctx context.Context, checkpointDir string, exit 
 func (c *client) LoadContainer(ctx context.Context, id string) (libcontainerdtypes.Container, error) {
 	ctr, err := c.client.LoadContainer(ctx, id)
 	if err != nil {
-		if containerderrors.IsNotFound(err) {
+		if cerrdefs.IsNotFound(err) {
 			return nil, errors.WithStack(errdefs.NotFound(errors.New("no such container")))
 		}
 		return nil, wrapError(err)
@@ -758,7 +758,7 @@ func wrapError(err error) error {
 	switch {
 	case err == nil:
 		return nil
-	case containerderrors.IsNotFound(err):
+	case cerrdefs.IsNotFound(err):
 		return errdefs.NotFound(err)
 	}
 

--- a/plugin/fetch_linux.go
+++ b/plugin/fetch_linux.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/content"
-	c8derrdefs "github.com/containerd/containerd/errdefs"
+	cerrdefs "github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
@@ -248,7 +248,7 @@ func withFetchProgress(cs content.Store, out progress.Output, ref reference.Name
 
 				s, err := cs.Status(ctx, key)
 				if err != nil {
-					if !c8derrdefs.IsNotFound(err) {
+					if !cerrdefs.IsNotFound(err) {
 						logrus.WithError(err).WithField("layerDigest", desc.Digest.String()).Error("Error looking up status of plugin layer pull")
 						progress.Update(out, id, err.Error())
 						return


### PR DESCRIPTION
### use consistent alias for containerd's errdefs package

The signatures of functions in containerd's errdefs packages are very
similar to those in our own, and it's easy to accidentally use the wrong
package.

This patch uses a consistent alias for all occurrences of this import.

### golangci-lint: enable importas linter to force consistent aliases

This enforces the github.com/containerd/containerd/errdefs package to
be aliased as "cerrdefs". Any other alias (or no alias used) results
in a linting failure:

    integration/container/pause_test.go:9:2: import "github.com/containerd/containerd/errdefs" imported as "c8derrdefs" but must be "cerrdefs" according to config (importas)
        c8derrdefs "github.com/containerd/containerd/errdefs"
        ^


**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

