### PR TITLE
Add LoongArch64 support in seccomp

### DIFF
--- a/daemon/pkg/oci/fixtures/default.json
+++ b/daemon/pkg/oci/fixtures/default.json
@@ -47,6 +47,10 @@
 			"subArchitectures": [
 				"SCMP_ARCH_S390"
 			]
+		},
+		{
+			"architecture": "SCMP_ARCH_LOONGARCH64",
+			"subArchitectures": null
 		}
 	],
 	"syscalls": [

--- a/vendor/github.com/moby/profiles/seccomp/default.json
+++ b/vendor/github.com/moby/profiles/seccomp/default.json
@@ -52,6 +52,10 @@
 		{
 			"architecture": "SCMP_ARCH_RISCV64",
 			"subArchitectures": null
+		},
+		{
+			"architecture": "SCMP_ARCH_LOONGARCH64",
+			"subArchitectures": null
 		}
 	],
 	"syscalls": [

--- a/vendor/github.com/moby/profiles/seccomp/default_linux.go
+++ b/vendor/github.com/moby/profiles/seccomp/default_linux.go
@@ -39,6 +39,10 @@ func arches() []Architecture {
 			Arch:      specs.ArchRISCV64,
 			SubArches: nil,
 		},
+		{
+			Arch:      specs.ArchLOONGARCH64,
+			SubArches: nil,
+		},
 	}
 }
 

--- a/vendor/github.com/moby/profiles/seccomp/seccomp_linux.go
+++ b/vendor/github.com/moby/profiles/seccomp/seccomp_linux.go
@@ -42,6 +42,7 @@ var nativeToSeccomp = map[string]specs.Arch{
 	"riscv64":     specs.ArchRISCV64,
 	"s390":        specs.ArchS390,
 	"s390x":       specs.ArchS390X,
+	"loong64":     specs.ArchLOONGARCH64,
 }
 
 // GOARCH => libseccomp string
@@ -61,6 +62,7 @@ var goToNative = map[string]string{
 	"riscv64":     "riscv64",
 	"s390":        "s390",
 	"s390x":       "s390x",
+	"loong64":     "loong64",
 }
 
 // inSlice tests whether a string is contained in a slice of strings or not.


### PR DESCRIPTION
The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.

Documentations:
ISA:
https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
ABI:
https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
More docs can be found at:
https://loongson.github.io/LoongArch-Documentation/README-EN.html