### PR TITLE
Added timeout to validate job in github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,7 @@ jobs:
 
   validate:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120
     needs:
       - validate-prepare
       - build-dev


### PR DESCRIPTION
- addresses #45233 

Please provide the following information:
-->

**- What I did**
Added a timeout for 2 hours `validate` job in github actions workflow 

**- How I did it**
Added timeout in file `.github/workflows/test.yml`

**- How to verify it**

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/37235937/231180350-9321d376-f7db-4788-981c-849c79ab0bdd.png)

