### PR TITLE
libnetwork: clean up inDelete network atomically

### DIFF
--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1061,9 +1061,6 @@ func (n *network) delete(force bool, rmLBEndpoint bool) error {
 	}
 
 	n.ipamRelease()
-	if err = c.updateToStore(n); err != nil {
-		logrus.Warnf("Failed to update store after ipam release for network %s (%s): %v", n.Name(), n.ID(), err)
-	}
 
 	// We are about to delete the network. Leave the gossip
 	// cluster for the network to stop all incoming network


### PR DESCRIPTION
- Fixes #45057 

The `(*network).ipamRelease` function nils out the network's IPAM info fields, putting the network struct into an inconsistent state. The network-restore startup code panics if it tries to restore a network from a struct which has fewer IPAM config entries than IPAM info entries. Therefore `(*network).delete` contains a critical section: by persisting the network to the store after `ipamRelease()`, the datastore will contain an inconsistent network until the deletion operation completes and finishes deleting the network from the datastore. If for any reason the deletion operation is interrupted between `ipamRelease()` and `deleteFromStore()`, the daemon will crash on startup when it tries to restore the network.

Updating the datastore after releasing the network's IPAM pools may have served a purpose in the past, when a global datastore was used for intra-cluster communication and the IPAM allocator had persistent global state, but nowadays there is no global datastore and the IPAM allocator has no persistent state whatsoever. Remove the vestigial datastore update as it is no longer necessary and only serves to cause problems. If the network deletion is interrupted before the network is deleted from the datastore, the deletion will resume during the next daemon startup, including releasing the IPAM pools.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
Race a network delete with shutting down the daemon. Verify that the daemon starts back up without panicking.

```console
$ docker network create foo
$ docker network rm foo & sleep 0.01; pkill -TERM dockerd
```

You will have hit the race window if the `docker network rm` command logs an error indicative of the daemon shutting down before the API request completes, such as
```
error during connect: Delete http://%2Fvar%2Frun%2Fdocker.sock/v1.30/networks/foo: EOF
```
and on next startup, the daemon logs an INFO message `Removing stale network foo`.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Fixed an issue which could corrupt the daemon state, crashing on next start if the daemon is terminated while a container network is being deleted

**- A picture of a cute animal (not mandatory but encouraged)**

