### PR TITLE
Deprecate dockerd api-cors-header parameter

### DIFF
--- a/api/server/middleware/cors.go
+++ b/api/server/middleware/cors.go
@@ -10,11 +10,15 @@ import (
 
 // CORSMiddleware injects CORS headers to each request
 // when it's configured.
+//
+// Deprecated: CORS headers should not be set on the API. This feature will be removed in the next release.
 type CORSMiddleware struct {
 	defaultHeaders string
 }
 
 // NewCORSMiddleware creates a new CORSMiddleware with default headers.
+//
+// Deprecated: CORS headers should not be set on the API. This feature will be removed in the next release.
 func NewCORSMiddleware(d string) CORSMiddleware {
 	return CORSMiddleware{defaultHeaders: d}
 }

--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -53,7 +53,6 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.StringVar(&conf.LogConfig.Type, "log-driver", "json-file", "Default driver for container logs")
 	flags.Var(opts.NewNamedMapOpts("log-opts", conf.LogConfig.Config, nil), "log-opt", "Default log driver options for containers")
 
-	flags.StringVar(&conf.CorsHeaders, "api-cors-header", "", "Set CORS headers in the Engine API")
 	flags.IntVar(&conf.MaxConcurrentDownloads, "max-concurrent-downloads", conf.MaxConcurrentDownloads, "Set the max concurrent downloads")
 	flags.IntVar(&conf.MaxConcurrentUploads, "max-concurrent-uploads", conf.MaxConcurrentUploads, "Set the max concurrent uploads")
 	flags.IntVar(&conf.MaxDownloadAttempts, "max-download-attempts", conf.MaxDownloadAttempts, "Set the max download attempts for each pull")
@@ -76,6 +75,8 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 
 	// Deprecated flags / options
 
+	flags.StringVar(&conf.CorsHeaders, "api-cors-header", "", "Set CORS headers in the Engine API; deprecated, and will be removed in the next release")
+	_ = flags.MarkDeprecated("api-cors-header", "accessing Docker API through a browser is insecure; use a reverse proxy if you need CORS headers")
 	flags.BoolVarP(&conf.AutoRestart, "restart", "r", true, "--restart on the daemon has been deprecated in favor of --restart policies on docker run")
 	_ = flags.MarkDeprecated("restart", "Please use a restart policy on docker run")
 

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -729,8 +729,9 @@ func initMiddlewares(s *apiserver.Server, cfg *config.Config, pluginStore plugin
 	}
 	s.UseMiddleware(*vm)
 
-	if cfg.CorsHeaders != "" {
-		c := middleware.NewCORSMiddleware(cfg.CorsHeaders)
+	if cfg.CorsHeaders != "" && os.Getenv("DOCKERD_DEPRECATED_CORS_HEADER") != "" {
+		logrus.Warnf(`DEPRECATED: The "api-cors-header" config parameter and the dockerd "--api-cors-header" option will be removed in the next release. Use a reverse proxy if you need CORS headers.`)
+		c := middleware.NewCORSMiddleware(cfg.CorsHeaders) //nolint:staticcheck // ignore SA1019 (NewCORSMiddleware is deprecated); will be removed in the next release.
 		s.UseMiddleware(c)
 	}
 

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -160,7 +160,7 @@ type CommonConfig struct {
 	Root                  string   `json:"data-root,omitempty"`
 	ExecRoot              string   `json:"exec-root,omitempty"`
 	SocketGroup           string   `json:"group,omitempty"`
-	CorsHeaders           string   `json:"api-cors-header,omitempty"`
+	CorsHeaders           string   `json:"api-cors-header,omitempty"` // Deprecated: CORS headers should not be set on the API. This feature will be removed in the next release.
 
 	// Proxies holds the proxies that are configured for the daemon.
 	Proxies `json:"proxies"`

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -235,6 +235,10 @@ func (daemon *Daemon) fillAPIInfo(v *system.Info, cfg *config.Config) {
          to the 'Docker daemon attack surface' section in the documentation for
          more information: https://docs.docker.com/go/attack-surface/`
 
+	if cfg.CorsHeaders != "" {
+		v.Warnings = append(v.Warnings, `DEPRECATED: The "api-cors-header" config parameter and the dockerd "--api-cors-header" option will be removed in the next release. Use a reverse proxy if you need CORS headers.`)
+	}
+
 	for _, host := range cfg.Hosts {
 		// cnf.Hosts is normalized during startup, so should always have a scheme/proto
 		proto, addr, _ := strings.Cut(host, "://")


### PR DESCRIPTION
CORS headers were originally added by 6d5bdff.

These headers could be set without any Authz plugin enabled beforehand, making this feature quite dangerous.

This commit marks the daemon flag `api-cors-header` as deprecated and requires the env var `DOCKERD_DEPRECATED_CORS_HEADER` to be set. When enabled, the daemon will write a deprecation warning to the logs and the endpoint `GET /info` will return the same deprecation warning.

**- Description for the changelog**

```markdown changelog
Deprecate the daemon flag `--api-cors-header` and the corresponding daemon.json config param. These will be removed in the next major release.
```
