### PR TITLE
Add no-new-privileges to SecurityOptions returned by /info

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5243,7 +5243,8 @@ definitions:
       SecurityOptions:
         description: |
           List of security features that are enabled on the daemon, such as
-          apparmor, seccomp, SELinux, user-namespaces (userns), and rootless.
+          apparmor, seccomp, SELinux, user-namespaces (userns), rootless and
+          no-new-privileges.
 
           Additional configuration options for each security feature may
           be present, and are included as a comma-separated list of key/value

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -170,6 +170,9 @@ func (daemon *Daemon) fillSecurityOptions(v *types.Info, sysInfo *sysinfo.SysInf
 	if daemon.cgroupNamespacesEnabled(sysInfo) {
 		securityOptions = append(securityOptions, "name=cgroupns")
 	}
+	if daemon.noNewPrivileges() {
+		securityOptions = append(securityOptions, "name=no-new-privileges")
+	}
 
 	v.SecurityOptions = securityOptions
 }

--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -366,3 +366,7 @@ func (daemon *Daemon) cgroupNamespacesEnabled(sysInfo *sysinfo.SysInfo) bool {
 func (daemon *Daemon) Rootless() bool {
 	return daemon.configStore.Rootless
 }
+
+func (daemon *Daemon) noNewPrivileges() bool {
+	return daemon.configStore.NoNewPrivileges
+}

--- a/daemon/info_windows.go
+++ b/daemon/info_windows.go
@@ -22,3 +22,7 @@ func (daemon *Daemon) cgroupNamespacesEnabled(sysInfo *sysinfo.SysInfo) bool {
 func (daemon *Daemon) Rootless() bool {
 	return false
 }
+
+func (daemon *Daemon) noNewPrivileges() bool {
+	return false
+}

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -23,6 +23,9 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `GET /images/json` no longer includes hardcoded `<none>:<none>` and
   `<none>@<none>` in `RepoTags` and`RepoDigests` for untagged images.
   In such cases, empty arrays will be produced instead.
+* `GET /info` now includes `no-new-privileges` in the `SecurityOptions` string
+  list when this option is enabled globally. This change is not versioned, and
+  affects all API versions if the daemon has this patch.
 
 ## v1.42 API changes
 


### PR DESCRIPTION
**- What I did**

Add no-new-privileges to SecurityOptions returned by /info

Partially fixes #45311.

**- How to verify it**

```
$ docker info 2>/dev/null | grep -A 4 "Security Options"
Security Options:
 seccomp
  Profile: builtin
 cgroupns
 no-new-privileges
```

**- Description for the changelog**

- The API now indicates no-new-privileges is globally enabled.


