### PR TITLE
Fix argv quoting bugs in dockerd-rootless.sh

### DIFF
--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -107,7 +107,7 @@ if [ -z "$_DOCKERD_ROOTLESS_CHILD" ]; then
 		--copy-up=/etc --copy-up=/run \
 		--propagation=rslave \
 		$DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS \
-		$0 $@
+		"$0" "$@"
 else
 	[ "$_DOCKERD_ROOTLESS_CHILD" = 1 ]
 	# remove the symlinks for the existing files in the parent namespace if any,
@@ -130,6 +130,5 @@ else
 		mount --rbind ${realpath_etc_ssl} /etc/ssl
 	fi
 
-	# shellcheck disable=SC2086
-	exec $dockerd "$@"
+	exec "$dockerd" "$@"
 fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Fix a bug if `$0` contains a space
- Fix a bug if `$DOCKERD` contains a space
- Fix a bug if `$@` contains an empty string argument, or any argument contains a space

**- How I did it**

I added doublequotes to make sure the arguments are passed as opaque strings instead of being processed by the shell.

The same bug was already fixed in line 134 in #43275.

**- How to verify it**

```
contrib/dockerd-rootless.sh --data-root "$PWD/../data/docker" --exec-root "$PWD/run" -H "unix://$PWD/run/docker.sock" --group ''
```

This should start up correctly (empty string means the docker socket shouldn't be chgrp'd). The command currently exits with an error due to invalid arguments.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Use `"$@"` instead of `$@` in `docker-rootless.sh` when passing arguments to dockerd

**- A picture of a cute animal (not mandatory but encouraged)**

![2023-04-13-dockerd-rootless-patch](https://user-images.githubusercontent.com/7763184/231789952-0e6aa1c3-7168-4067-9432-37dfbfa627b1.png)
