### PR TITLE
update runc binary to v1.1.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -280,7 +280,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged. When updating RUNC_VERSION,
 # consider updating runc in vendor.mod accordingly.
-ARG RUNC_VERSION=v1.1.5
+ARG RUNC_VERSION=v1.1.6
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=v1.1.5}"
+: "${RUNC_VERSION:=v1.1.6}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"


### PR DESCRIPTION
release notes: https://github.com/opencontainers/runc/releases/tag/v1.1.6
full diff: https://github.com/opencontainers/runc/compare/v1.1.5...v1.1.6

This is the sixth patch release in the 1.1.z series of runc, which fixes a series of cgroup-related issues.

Note that this release can no longer be built from sources using Go 1.16. Using a latest maintained Go 1.20.x or Go 1.19.x release is recommended. Go 1.17 can still be used.

- systemd cgroup v1 and v2 drivers were deliberately ignoring UnitExist error from systemd while trying to create a systemd unit, which in some scenarios may result in a container not being added to the proper systemd unit and cgroup.
- systemd cgroup v2 driver was incorrectly translating cpuset range from spec's resources.cpu.cpus to systemd unit property (AllowedCPUs) in case of more than 8 CPUs, resulting in the wrong AllowedCPUs setting.
- systemd cgroup v1 driver was prefixing container's cgroup path with the path of PID 1 cgroup, resulting in inability to place PID 1 in a non-root cgroup.
- runc run/start may return "permission denied" error when starting a rootless container when the file to be executed does not have executable bit set for the user, not taking the CAP_DAC_OVERRIDE capability into account. This is a regression in runc 1.1.4, as well as in Go 1.20 and 1.20.1
- cgroup v1 drivers are now aware of misc controller.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

