### PR TITLE
[23.0 backport] Fix argument quoting bugs in dockerd-rootless.sh

### DIFF
--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -107,7 +107,7 @@ if [ -z "$_DOCKERD_ROOTLESS_CHILD" ]; then
 		--copy-up=/etc --copy-up=/run \
 		--propagation=rslave \
 		$DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS \
-		$0 $@
+		"$0" "$@"
 else
 	[ "$_DOCKERD_ROOTLESS_CHILD" = 1 ]
 	# remove the symlinks for the existing files in the parent namespace if any,
@@ -130,6 +130,5 @@ else
 		mount --rbind ${realpath_etc_ssl} /etc/ssl
 	fi
 
-	# shellcheck disable=SC2086
-	exec $dockerd "$@"
+	exec "$dockerd" "$@"
 fi


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/45325

(cherry picked from commit 7fe0f738388be2a51caa5262a6a862efdf4b6759)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

