### PR TITLE
c8d: Fix returning errors from snapshotter.Prepare

### DIFF
--- a/daemon/containerd/image_snapshot.go
+++ b/daemon/containerd/image_snapshot.go
@@ -51,9 +51,6 @@ func (i *ImageService) PrepareSnapshot(ctx context.Context, id string, parentIma
 	}
 
 	s := i.client.SnapshotService(i.StorageDriver())
-	if _, err := s.Prepare(ctx, id, parent); err == nil {
-		return err
-	}
-
-	return nil
+	_, err = s.Prepare(ctx, id, parent)
+	return err
 }


### PR DESCRIPTION
- introduced in https://github.com/moby/moby/commit/0137446248d7f8a0834dd3a093b539c1d7cca957 https://github.com/moby/moby/pull/44804


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed returning errors from snapshotter.Prepare.

In the case of an error when calling snapshotter.Prepare we would return nil. This change fixes that and returns the error from Prepare all the time.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

