### PR TITLE
container: split security options to a SecurityOptions struct

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -79,9 +79,7 @@ type Container struct {
 	Name            string
 	Driver          string
 	OS              string
-	// MountLabel contains the options for the 'mount' command
-	MountLabel               string
-	ProcessLabel             string
+
 	RestartCount             int
 	HasBeenStartedBefore     bool
 	HasBeenManuallyStopped   bool // used for unless-stopped restart policy
@@ -99,18 +97,25 @@ type Container struct {
 	attachContext  *attachContext
 
 	// Fields here are specific to Unix platforms
-	AppArmorProfile string
-	HostnamePath    string
-	HostsPath       string
-	ShmPath         string
-	ResolvConfPath  string
-	SeccompProfile  string
-	NoNewPrivileges bool
+	SecurityOptions
+	HostnamePath   string
+	HostsPath      string
+	ShmPath        string
+	ResolvConfPath string
 
 	// Fields here are specific to Windows
 	NetworkSharedContainerID string            `json:"-"`
 	SharedEndpointList       []string          `json:"-"`
 	LocalLogCacheMeta        localLogCacheMeta `json:",omitempty"`
+}
+
+type SecurityOptions struct {
+	// MountLabel contains the options for the "mount" command.
+	MountLabel      string
+	ProcessLabel    string
+	AppArmorProfile string
+	SeccompProfile  string
+	NoNewPrivileges bool
 }
 
 type localLogCacheMeta struct {

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -209,7 +209,7 @@ func (daemon *Daemon) generateHostname(id string, config *containertypes.Config)
 func (daemon *Daemon) setSecurityOptions(container *container.Container, hostConfig *containertypes.HostConfig) error {
 	container.Lock()
 	defer container.Unlock()
-	return daemon.parseSecurityOpt(container, hostConfig)
+	return daemon.parseSecurityOpt(&container.SecurityOptions, hostConfig)
 }
 
 func (daemon *Daemon) setHostConfig(container *container.Container, hostConfig *containertypes.HostConfig) error {

--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -15,7 +15,7 @@ func (daemon *Daemon) saveAppArmorConfig(container *container.Container) error {
 		return nil // if apparmor is disabled there is nothing to do here.
 	}
 
-	if err := parseSecurityOpt(container, container.HostConfig); err != nil {
+	if err := parseSecurityOpt(&container.SecurityOptions, container.HostConfig); err != nil {
 		return errdefs.InvalidParameter(err)
 	}
 

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -190,12 +190,12 @@ func getBlkioWeightDevices(config containertypes.Resources) ([]specs.LinuxWeight
 	return blkioWeightDevices, nil
 }
 
-func (daemon *Daemon) parseSecurityOpt(container *container.Container, hostConfig *containertypes.HostConfig) error {
-	container.NoNewPrivileges = daemon.configStore.NoNewPrivileges
-	return parseSecurityOpt(container, hostConfig)
+func (daemon *Daemon) parseSecurityOpt(securityOptions *container.SecurityOptions, hostConfig *containertypes.HostConfig) error {
+	securityOptions.NoNewPrivileges = daemon.configStore.NoNewPrivileges
+	return parseSecurityOpt(securityOptions, hostConfig)
 }
 
-func parseSecurityOpt(container *container.Container, config *containertypes.HostConfig) error {
+func parseSecurityOpt(securityOptions *container.SecurityOptions, config *containertypes.HostConfig) error {
 	var (
 		labelOpts []string
 		err       error
@@ -203,7 +203,7 @@ func parseSecurityOpt(container *container.Container, config *containertypes.Hos
 
 	for _, opt := range config.SecurityOpt {
 		if opt == "no-new-privileges" {
-			container.NoNewPrivileges = true
+			securityOptions.NoNewPrivileges = true
 			continue
 		}
 		if opt == "disable" {
@@ -227,21 +227,21 @@ func parseSecurityOpt(container *container.Container, config *containertypes.Hos
 		case "label":
 			labelOpts = append(labelOpts, v)
 		case "apparmor":
-			container.AppArmorProfile = v
+			securityOptions.AppArmorProfile = v
 		case "seccomp":
-			container.SeccompProfile = v
+			securityOptions.SeccompProfile = v
 		case "no-new-privileges":
 			noNewPrivileges, err := strconv.ParseBool(v)
 			if err != nil {
 				return fmt.Errorf("invalid --security-opt 2: %q", opt)
 			}
-			container.NoNewPrivileges = noNewPrivileges
+			securityOptions.NoNewPrivileges = noNewPrivileges
 		default:
 			return fmt.Errorf("invalid --security-opt 2: %q", opt)
 		}
 	}
 
-	container.ProcessLabel, container.MountLabel, err = label.InitLabels(labelOpts)
+	securityOptions.ProcessLabel, securityOptions.MountLabel, err = label.InitLabels(labelOpts)
 	return err
 }
 

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -55,7 +55,7 @@ func getPluginExecRoot(cfg *config.Config) string {
 	return filepath.Join(cfg.Root, "plugins")
 }
 
-func (daemon *Daemon) parseSecurityOpt(container *container.Container, hostConfig *containertypes.HostConfig) error {
+func (daemon *Daemon) parseSecurityOpt(securityOptions *container.SecurityOptions, hostConfig *containertypes.HostConfig) error {
 	return nil
 }
 

--- a/daemon/exec_linux_test.go
+++ b/daemon/exec_linux_test.go
@@ -74,7 +74,7 @@ func TestExecSetPlatformOptAppArmor(t *testing.T) {
 			}
 			t.Run(doc, func(t *testing.T) {
 				c := &container.Container{
-					AppArmorProfile: tc.appArmorProfile,
+					SecurityOptions: container.SecurityOptions{AppArmorProfile: tc.appArmorProfile},
 					HostConfig: &containertypes.HostConfig{
 						Privileged: tc.privileged,
 					},

--- a/daemon/seccomp_linux_test.go
+++ b/daemon/seccomp_linux_test.go
@@ -31,7 +31,7 @@ func TestWithSeccomp(t *testing.T) {
 				sysInfo: &sysinfo.SysInfo{Seccomp: true},
 			},
 			c: &container.Container{
-				SeccompProfile: dconfig.SeccompProfileUnconfined,
+				SecurityOptions: container.SecurityOptions{SeccompProfile: dconfig.SeccompProfileUnconfined},
 				HostConfig: &containertypes.HostConfig{
 					Privileged: false,
 				},
@@ -45,7 +45,7 @@ func TestWithSeccomp(t *testing.T) {
 				sysInfo: &sysinfo.SysInfo{Seccomp: true},
 			},
 			c: &container.Container{
-				SeccompProfile: "{ \"defaultAction\": \"SCMP_ACT_LOG\" }",
+				SecurityOptions: container.SecurityOptions{SeccompProfile: `{"defaultAction": "SCMP_ACT_LOG"}`},
 				HostConfig: &containertypes.HostConfig{
 					Privileged: true,
 				},
@@ -59,7 +59,7 @@ func TestWithSeccomp(t *testing.T) {
 				sysInfo: &sysinfo.SysInfo{Seccomp: true},
 			},
 			c: &container.Container{
-				SeccompProfile: "",
+				SecurityOptions: container.SecurityOptions{SeccompProfile: ""},
 				HostConfig: &containertypes.HostConfig{
 					Privileged: true,
 				},
@@ -71,10 +71,10 @@ func TestWithSeccomp(t *testing.T) {
 			comment: "privileged container w/ daemon profile runs unconfined",
 			daemon: &Daemon{
 				sysInfo:        &sysinfo.SysInfo{Seccomp: true},
-				seccompProfile: []byte("{ \"defaultAction\": \"SCMP_ACT_ERRNO\" }"),
+				seccompProfile: []byte(`{"defaultAction": "SCMP_ACT_ERRNO"}`),
 			},
 			c: &container.Container{
-				SeccompProfile: "",
+				SecurityOptions: container.SecurityOptions{SeccompProfile: ""},
 				HostConfig: &containertypes.HostConfig{
 					Privileged: true,
 				},
@@ -88,7 +88,7 @@ func TestWithSeccomp(t *testing.T) {
 				sysInfo: &sysinfo.SysInfo{Seccomp: false},
 			},
 			c: &container.Container{
-				SeccompProfile: "{ \"defaultAction\": \"SCMP_ACT_ERRNO\" }",
+				SecurityOptions: container.SecurityOptions{SeccompProfile: `{"defaultAction": "SCMP_ACT_ERRNO"}`},
 				HostConfig: &containertypes.HostConfig{
 					Privileged: false,
 				},
@@ -103,7 +103,7 @@ func TestWithSeccomp(t *testing.T) {
 				sysInfo: &sysinfo.SysInfo{Seccomp: true},
 			},
 			c: &container.Container{
-				SeccompProfile: "",
+				SecurityOptions: container.SecurityOptions{SeccompProfile: ""},
 				HostConfig: &containertypes.HostConfig{
 					Privileged: false,
 				},
@@ -122,7 +122,7 @@ func TestWithSeccomp(t *testing.T) {
 				sysInfo: &sysinfo.SysInfo{Seccomp: true},
 			},
 			c: &container.Container{
-				SeccompProfile: "{ \"defaultAction\": \"SCMP_ACT_ERRNO\" }",
+				SecurityOptions: container.SecurityOptions{SeccompProfile: `{"defaultAction": "SCMP_ACT_ERRNO"}`},
 				HostConfig: &containertypes.HostConfig{
 					Privileged: false,
 				},
@@ -141,10 +141,10 @@ func TestWithSeccomp(t *testing.T) {
 			comment: "load daemon's profile",
 			daemon: &Daemon{
 				sysInfo:        &sysinfo.SysInfo{Seccomp: true},
-				seccompProfile: []byte("{ \"defaultAction\": \"SCMP_ACT_ERRNO\" }"),
+				seccompProfile: []byte(`{"defaultAction": "SCMP_ACT_ERRNO"}`),
 			},
 			c: &container.Container{
-				SeccompProfile: "",
+				SecurityOptions: container.SecurityOptions{SeccompProfile: ""},
 				HostConfig: &containertypes.HostConfig{
 					Privileged: false,
 				},
@@ -163,10 +163,10 @@ func TestWithSeccomp(t *testing.T) {
 			comment: "load prioritise container profile over daemon's",
 			daemon: &Daemon{
 				sysInfo:        &sysinfo.SysInfo{Seccomp: true},
-				seccompProfile: []byte("{ \"defaultAction\": \"SCMP_ACT_ERRNO\" }"),
+				seccompProfile: []byte(`{"defaultAction": "SCMP_ACT_ERRNO"}`),
 			},
 			c: &container.Container{
-				SeccompProfile: "{ \"defaultAction\": \"SCMP_ACT_LOG\" }",
+				SecurityOptions: container.SecurityOptions{SeccompProfile: `{"defaultAction": "SCMP_ACT_LOG"}`},
 				HostConfig: &containertypes.HostConfig{
 					Privileged: false,
 				},


### PR DESCRIPTION
some changes I had lying around locally (may still need some finishing up), but recalled I had them when I looked at

- https://github.com/moby/moby/pull/45320



- Split these options to a separate struct, so that we can handle them in isolation.
- Change some tests to use subtests, and improve coverage

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

