### PR TITLE
c8d/prune: Remove gc.ref labels from configs of deleted images 

### DIFF
--- a/daemon/containerd/image_prune.go
+++ b/daemon/containerd/image_prune.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/errdefs"
 	"github.com/hashicorp/go-multierror"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -108,23 +109,37 @@ func (i *ImageService) pruneUnused(ctx context.Context, filterFunc imageFilterFu
 
 	logrus.WithField("images", imagesToPrune).Debug("pruning")
 
+	possiblyDeletedConfigs := map[digest.Digest]struct{}{}
+
+	// Workaround for https://github.com/moby/buildkit/issues/3797
+	defer func() {
+		if err := i.unleaseSnapshotsFromDeletedConfigs(context.Background(), possiblyDeletedConfigs); err != nil {
+			errs = multierror.Append(errs, err)
+		}
+	}()
+
 	for _, img := range imagesToPrune {
 		blobs := []ocispec.Descriptor{}
 
-		err = containerdimages.Walk(ctx, presentChildrenHandler(store, containerdimages.HandlerFunc(
-			func(_ context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-				blobs = append(blobs, desc)
-				return nil, nil
-			})),
-			img.Target)
-
+		err := i.walkPresentChildren(ctx, img.Target, func(_ context.Context, desc ocispec.Descriptor) {
+			blobs = append(blobs, desc)
+			if containerdimages.IsConfigType(desc.MediaType) {
+				possiblyDeletedConfigs[desc.Digest] = struct{}{}
+			}
+		})
 		if err != nil {
 			errs = multierror.Append(errs, err)
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return &report, errs
+			}
 			continue
 		}
 		err = is.Delete(ctx, img.Name, containerdimages.SynchronousDelete())
 		if err != nil && !cerrdefs.IsNotFound(err) {
 			errs = multierror.Append(errs, err)
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return &report, errs
+			}
 			continue
 		}
 
@@ -148,5 +163,65 @@ func (i *ImageService) pruneUnused(ctx context.Context, filterFunc imageFilterFu
 			}
 		}
 	}
+
 	return &report, errs
+}
+
+// unleaseSnapshotsFromDeletedConfigs removes gc.ref.snapshot content label from configs that are not
+// referenced by any of the existing images.
+// This is a temporary solution to the rootfs snapshot not being deleted when there's a buildkit history
+// item referencing an image config.
+func (i *ImageService) unleaseSnapshotsFromDeletedConfigs(ctx context.Context, possiblyDeletedConfigs map[digest.Digest]struct{}) error {
+	is := i.client.ImageService()
+	store := i.client.ContentStore()
+
+	all, err := is.List(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to list images during snapshot lease removal")
+	}
+
+	var errs error
+	for _, img := range all {
+		err := i.walkPresentChildren(ctx, img.Target, func(_ context.Context, desc ocispec.Descriptor) {
+			if containerdimages.IsConfigType(desc.MediaType) {
+				delete(possiblyDeletedConfigs, desc.Digest)
+			}
+		})
+		if err != nil {
+			errs = multierror.Append(errs, err)
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return errs
+			}
+			continue
+		}
+	}
+
+	// At this point, all configs that are used by any image has been removed from the slice
+	for cfgDigest := range possiblyDeletedConfigs {
+		info, err := store.Info(ctx, cfgDigest)
+		if err != nil {
+			if cerrdefs.IsNotFound(err) {
+				logrus.WithField("config", cfgDigest).Debug("config already gone")
+			} else {
+				errs = multierror.Append(errs, err)
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					return errs
+				}
+			}
+			continue
+		}
+
+		label := "containerd.io/gc.ref.snapshot." + i.StorageDriver()
+
+		delete(info.Labels, label)
+		_, err = store.Update(ctx, info, "labels."+label)
+		if err != nil {
+			errs = multierror.Append(errs, errors.Wrapf(err, "failed to remove gc.ref.snapshot label from %s", cfgDigest))
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return errs
+			}
+		}
+	}
+
+	return errs
 }

--- a/daemon/containerd/image_prune.go
+++ b/daemon/containerd/image_prune.go
@@ -79,7 +79,11 @@ func (i *ImageService) pruneUnused(ctx context.Context, filterFunc imageFilterFu
 	// Apply filters
 	for name, img := range imagesToPrune {
 		filteredOut := !filterFunc(img)
-		logrus.WithField("image", name).WithField("filteredOut", filteredOut).Debug("filtering image")
+		logrus.WithFields(logrus.Fields{
+			"image":       name,
+			"filteredOut": filteredOut,
+		}).Debug("filtering image")
+
 		if filteredOut {
 			delete(imagesToPrune, name)
 		}
@@ -107,8 +111,6 @@ func (i *ImageService) pruneUnused(ctx context.Context, filterFunc imageFilterFu
 		}
 	}
 
-	logrus.WithField("images", imagesToPrune).Debug("pruning")
-
 	possiblyDeletedConfigs := map[digest.Digest]struct{}{}
 
 	// Workaround for https://github.com/moby/buildkit/issues/3797
@@ -119,6 +121,8 @@ func (i *ImageService) pruneUnused(ctx context.Context, filterFunc imageFilterFu
 	}()
 
 	for _, img := range imagesToPrune {
+		logrus.WithField("image", img).Debug("pruning image")
+
 		blobs := []ocispec.Descriptor{}
 
 		err := i.walkPresentChildren(ctx, img.Target, func(_ context.Context, desc ocispec.Descriptor) {


### PR DESCRIPTION
- Follow up to: https://github.com/moby/moby/pull/45270

Temporary workaround for: https://github.com/moby/buildkit/issues/3797

**- What I did**
Fixed snapshots of unpacked images not being deleted

**- How I did it**
Manually remove gc.ref labels from configs which are not referenced by any image.

**- How to verify it**


<details>

<summary>docker rmi</summary>

```bash
$ echo 'FROM ubuntu' | docker build -qt asdf -
docker buildx psha256:2c810c8982bab60cb661704546104727f97a31f3ad8c451e1d2e212216ceff12

$ docker buildx prune -a
WARNING! This will remove all build cache. Are you sure you want to continue? [y/N] y
ID                                              RECLAIMABLE     SIZE            LAST ACCESSED
2s5mcpdcorpvthkdfoniedjot*                      true            8.192kB         1 second ago
i82yyjvqh889nd1ua3u9iwdq8*                      true    4.096kB         1 second ago
jgghwgr5rzotfa5rzsuwa2r1o                       true    27.35MB         1 second ago
Total:  27.36MB

$ ctr snapshot ls
KEY                                                                     PARENT KIND
sha256:874b048c963ab55b06939c39d59303fb975d323822a4ea48a02ac8dc635ea371        Committed

$ docker rmi asdf
Untagged: asdf

$ ctr snapshot ls
KEY PARENT KIND
```

</details>




<details>

<summary>docker image prune</summary>

```bash
$ echo 'FROM ubuntu' | docker build -qt asdf -
sha256:8b15904a219973abd67d9ed69902053e8e07cd81ee10a88d5d93f1722cabaa13

$ docker buildx prune -a
WARNING! This will remove all build cache. Are you sure you want to continue? [y/N] y
ID                                              RECLAIMABLE     SIZE            LAST ACCESSED
y92vqiqt18vuscz15q43ee0f9*                      true            4.096kB         3 seconds ago
7e2ymvv65rtif3vabl1dt45j3*                      true    8.192kB         3 seconds ago
tymibv3erhje6pm3ucm0czln5                       true    27.35MB         3 seconds ago
Total:  27.36MB

$ ctr snapshot ls
KEY                                                                     PARENT KIND
sha256:874b048c963ab55b06939c39d59303fb975d323822a4ea48a02ac8dc635ea371        Committed

$ docker image prune -a
WARNING! This will remove all images without at least one container associated to them.
Are you sure you want to continue? [y/N] y
Deleted Images:
untagged: docker.io/library/asdf:latest

Total reclaimed space: 0B

$ ctr snapshot ls
KEY PARENT KIND
```
</details>




**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

