### PR TITLE
libnet/overlay: clean up iptables rules on network delete

### DIFF
--- a/libnetwork/drivers/overlay/ov_network.go
+++ b/libnetwork/drivers/overlay/ov_network.go
@@ -216,6 +216,25 @@ func (d *driver) DeleteNetwork(nid string) error {
 	doPeerFlush = true
 	delete(d.networks, nid)
 
+	if n.secure {
+		for _, s := range n.subnets {
+			if err := programMangle(s.vni, false); err != nil {
+				logrus.WithFields(logrus.Fields{
+					logrus.ErrorKey: err,
+					"network_id":    n.id,
+					"subnet":        s.subnetIP,
+				}).Warn("Failed to clean up iptables rules during overlay network deletion")
+			}
+			if err := programInput(s.vni, false); err != nil {
+				logrus.WithFields(logrus.Fields{
+					logrus.ErrorKey: err,
+					"network_id":    n.id,
+					"subnet":        s.subnetIP,
+				}).Warn("Failed to clean up iptables rules during overlay network deletion")
+			}
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**- What I did**

This is a follow-up of #44965 (see [this comment](https://github.com/moby/moby/pull/44965#discussion_r1154957099)).

Remove iptables rules configured for secure overlay networks when a network is deleted. Prior to this commit, only CreateNetwork() was taking care of removing stale iptables rules.

If one of the iptables rule can't be removed, the erorr is logged but it doesn't prevent network deletion.

**- How to verify it**

```console
$ docker network create --driver overlay  --opt encrypted testnet
$ docker service create --name test1 --network testnet alpine:latest /bin/sleep infinity
$ iptables -t mangle -nvL
# Show 1 rule
$ docker service rm test1
$ docker network rm test1
$ iptables -t mangle -nvL
# Show 0 rules
```

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/557933/232347650-d9925cb6-23a5-48f5-8bf8-a2484b96d230.png)
