### PR TITLE
c8d: align "Size" and "VirtualSize" for images

### DIFF
--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -195,10 +195,11 @@ func (i *ImageService) GetContainerLayerSize(ctx context.Context, containerID st
 	}
 
 	chainIDs := identity.ChainIDs(img.RootFS.DiffIDs)
-	virtualSize, err := computeVirtualSize(chainIDs, snapshotSizeFn)
+	snapShotSize, err := computeSnapshotSize(chainIDs, snapshotSizeFn)
 	if err != nil {
 		return 0, 0, err
 	}
 
-	return usage.Size, usage.Size + virtualSize, nil
+	// TODO(thaJeztah): include content-store size for the image (similar to "GET /images/json")
+	return usage.Size, usage.Size + snapShotSize, nil
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/45346
- fixes https://github.com/moby/moby/issues/43862


In versions of Docker before v1.10, this field was calculated from the image itself and all of its parent images. Images are now stored self-contained, and no longer use a parent-chain, making this field an equivalent of the Size field.

For the containerd integration, the Size should be the sum of the image's compressed / packaged and unpacked (snapshots) layers.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

