### PR TITLE
containerd integration: some test-fixes

### DIFF
--- a/daemon/inspect_test.go
+++ b/daemon/inspect_test.go
@@ -22,9 +22,11 @@ func TestGetInspectData(t *testing.T) {
 		linkIndex:   newLinkIndex(),
 		configStore: &config.Config{},
 	}
-
+	if d.UsesSnapshotter() {
+		t.Skip("does not apply to containerd snapshotters, which don't have RWLayer set")
+	}
 	_, err := d.getInspectData(c)
-	assert.Check(t, is.ErrorContains(err, ""))
+	assert.Check(t, is.ErrorContains(err, "RWLayer of container inspect-me is unexpectedly nil"))
 
 	c.Dead = true
 	_, err = d.getInspectData(c)

--- a/daemon/oci_linux_test.go
+++ b/daemon/oci_linux_test.go
@@ -33,6 +33,7 @@ func setupFakeDaemon(t *testing.T, c *container.Container) *Daemon {
 		configStore:   &config.Config{},
 		linkIndex:     newLinkIndex(),
 		netController: netController,
+		imageService:  &fakeImageService{},
 	}
 
 	c.Root = root
@@ -49,6 +50,14 @@ func setupFakeDaemon(t *testing.T, c *container.Container) *Daemon {
 	}
 
 	return d
+}
+
+type fakeImageService struct {
+	ImageService
+}
+
+func (i *fakeImageService) StorageDriver() string {
+	return "overlay"
 }
 
 func cleanupFakeContainer(c *container.Container) {


### PR DESCRIPTION
- taken from https://github.com/moby/moby/pull/45232

### daemon: setupFakeDaemon(): add fakeImageService
To prevent a panic happening when running tests:

    === FAIL: daemon TestTmpfsDevShmNoDupMount (0.01s)
    panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x120 pc=0x261a373]

    goroutine 134 [running]:
    testing.tRunner.func1.2({0x28baf20, 0x3ea8000})
        /usr/local/go/src/testing/testing.go:1526 +0x24e
    testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1529 +0x39f
    panic({0x28baf20, 0x3ea8000})
        /usr/local/go/src/runtime/panic.go:884 +0x213
    github.com/docker/docker/daemon.(*Daemon).createSpec(0xc0006e0000, {0x2ea5588, 0xc00012a008}, 0xc0003b5900)
        /go/src/github.com/docker/docker/daemon/oci_linux.go:1060 +0xf33
    github.com/docker/docker/daemon.TestTmpfsDevShmNoDupMount(0xc000b781a0?)
        /go/src/github.com/docker/docker/daemon/oci_linux_test.go:77 +0x20a
    testing.tRunner(0xc000b78340, 0x2c74210)
        /usr/local/go/src/testing/testing.go:1576 +0x10b
    created by testing.(*T).Run
        /usr/local/go/src/testing/testing.go:1629 +0x3ea

### daemon: skip TestGetInspectData when using containerd snapshotters
This test does not apply when running with snapshotters enabled;

    go test -v -run TestGetInspectData .
    === RUN   TestGetInspectData
        inspect_test.go:27: RWLayer of container inspect-me is unexpectedly nil
    --- FAIL: TestGetInspectData (0.00s)
    FAIL
    FAIL	github.com/docker/docker/daemon	0.049s
    FAIL
