### PR TITLE
daemon: set docker0 subpool as the IPAM pool

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -997,6 +997,9 @@ func initBridgeDriver(controller *libnetwork.Controller, config *config.Config) 
 		}
 
 		ipamV4Conf.SubPool = fCIDR.String()
+		if ipamV4Conf.PreferredPool == "" {
+			ipamV4Conf.PreferredPool = fCIDR.String()
+		}
 	}
 
 	if config.BridgeConfig.DefaultGatewayIPv4 != nil {

--- a/integration/daemon/daemon_test.go
+++ b/integration/daemon/daemon_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/icmd"
 	"gotest.tools/v3/skip"
 )
 
@@ -399,4 +400,31 @@ func testLiveRestoreVolumeReferences(t *testing.T) {
 		runTest(t, "on-failure")
 		runTest(t, "no")
 	})
+}
+
+func TestDaemonDefaultBridgeWithFixedCidrButNoBip(t *testing.T) {
+	skip.If(t, runtime.GOOS == "windows")
+
+	bridgeName := "ext-bridge1"
+	d := daemon.New(t, daemon.WithEnvVars("DOCKER_TEST_CREATE_DEFAULT_BRIDGE="+bridgeName))
+	defer func() {
+		d.Stop(t)
+		d.Cleanup(t)
+	}()
+
+	defer func() {
+		// No need to clean up when running this test in rootless mode, as the
+		// interface is deleted when the daemon is stopped and the netns
+		// reclaimed by the kernel.
+		if !testEnv.IsRootless() {
+			deleteInterface(t, bridgeName)
+		}
+	}()
+	d.StartWithBusybox(t, "--bridge", bridgeName, "--fixed-cidr", "192.168.130.0/24")
+}
+
+func deleteInterface(t *testing.T, ifName string) {
+	icmd.RunCommand("ip", "link", "delete", ifName).Assert(t, icmd.Success)
+	icmd.RunCommand("iptables", "-t", "nat", "--flush").Assert(t, icmd.Success)
+	icmd.RunCommand("iptables", "--flush").Assert(t, icmd.Success)
 }

--- a/libnetwork/drivers/bridge/setup_device.go
+++ b/libnetwork/drivers/bridge/setup_device.go
@@ -16,8 +16,14 @@ import (
 // SetupDevice create a new bridge interface/
 func setupDevice(config *networkConfiguration, i *bridgeInterface) error {
 	// We only attempt to create the bridge when the requested device name is
-	// the default one.
-	if config.BridgeName != DefaultBridgeName && config.DefaultBridge {
+	// the default one. The default bridge name can be overridden with the
+	// DOCKER_TEST_CREATE_DEFAULT_BRIDGE env var. It should be used only for
+	// test purpose.
+	var defaultBridgeName string
+	if defaultBridgeName = os.Getenv("DOCKER_TEST_CREATE_DEFAULT_BRIDGE"); defaultBridgeName == "" {
+		defaultBridgeName = DefaultBridgeName
+	}
+	if config.BridgeName != defaultBridgeName && config.DefaultBridge {
 		return NonDefaultBridgeExistError(config.BridgeName)
 	}
 


### PR DESCRIPTION
**- What I did**

Fix a regression introduced by:

- https://github.com/moby/moby/pull/44827

Since cc19eba (backported to v23.0.4), the PreferredPool for docker0 is set only when the user provides the bip config parameter or when the default bridge already exist. That means, if a user provides the fixed-cidr parameter on a fresh install or reboot their computer/server without bip set, dockerd throw the following error when it starts:

> failed to start daemon: Error initializing network controller: Error creating default "bridge" network: failed to parse pool request for address space "LocalDefault" pool "" subpool "100.64.0.0/26": Invalid Address SubPool

I added a new integration test to `integration-cli` to make sure we won't re-introduce this regression.

Closes #45356.

**- How to verify it**

Execute the daemon with the config provided in the original issue reporting this regression. And check if CI is green.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://media.istockphoto.com/id/1068395160/fr/photo/paresse-au-costa-rica.jpg?s=612x612&w=0&k=20&c=3cUYydcbLs95LQ4fZO9FSDoAhPh7W-SCLYecwCczgXg=)