### PR TITLE
overlay2: remove deprecated overlay2.override_kernel_check option

### DIFF
--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -234,9 +234,6 @@ func parseOptions(options []string) (*overlayOptions, error) {
 		}
 		key = strings.ToLower(key)
 		switch key {
-		case "overlay2.override_kernel_check":
-			// TODO(thaJeztah): change this to an error, see https://github.com/docker/cli/pull/3806
-			logger.Warn("DEPRECATED: the overlay2.override_kernel_check option is ignored and will be removed in the next release. You can safely remove this option from your configuration.")
 		case "overlay2.size":
 			size, err := units.RAMInBytes(val)
 			if err != nil {


### PR DESCRIPTION
- relates to / follow-up to https://github.com/moby/moby/pull/44278
- relates to / follow-up to https://github.com/moby/moby/pull/44279


This option was deprecated in e35700eb5018ff14d91bf5e46f39e65cfe711b6f (and backported to v23.0 through 43ce8f7d24dc949949f0332e30a57dde3a1d6f82).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

