### PR TITLE
[23.0 backport] Silence GRPC logs unless our log level is debug

### DIFF
--- a/cmd/dockerd/docker.go
+++ b/cmd/dockerd/docker.go
@@ -88,6 +88,7 @@ func main() {
 	_, stdout, stderr := term.StdStreams()
 
 	initLogging(stdout, stderr)
+	configureGRPCLog()
 
 	onError := func(err error) {
 		fmt.Fprintf(stderr, "%s\n", err)

--- a/cmd/dockerd/grpclog.go
+++ b/cmd/dockerd/grpclog.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/grpclog"
+)
+
+// grpc's default logger is *very* noisy and uses "info" and even "warn" level logging for mostly useless messages.
+// This function configures the grpc logger to step down the severity of all messages.
+//
+// info => trace
+// warn => debug
+// error => warn
+func configureGRPCLog() {
+	l := logrus.WithField("library", "grpc")
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(l.WriterLevel(logrus.TraceLevel), l.WriterLevel(logrus.DebugLevel), l.WriterLevel(logrus.WarnLevel)))
+}


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/45187

GRPC is logging a *lot* of garbage at info level.
This configures the GRPC logger such that it is only giving us logs when at debug level and also adds a log field indicating where the logs are coming from.

containerd is still currently spewing these same log messages and needs a separate update.

Without this change `docker build` is extremely noisy in the daemon logs.


(cherry picked from commit c7ccc68b15fc0fc8c2a8683170e6d61e3381e358)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

