### PR TITLE
Allow dest writer to exceed frame size in `stdcopy`

### DIFF
--- a/pkg/stdcopy/stdcopy.go
+++ b/pkg/stdcopy/stdcopy.go
@@ -177,7 +177,7 @@ func StdCopy(dstout, dsterr io.Writer, src io.Reader) (written int64, err error)
 		}
 
 		// If the frame has not been fully written: error
-		if nw != frameSize {
+		if nw < frameSize {
 			return 0, io.ErrShortWrite
 		}
 		written += int64(nw)


### PR DESCRIPTION
**- What I did**

I've updated the check in `StdCopy` which checks the amount of data written against the frame size, to only return an `io.ErrShortWrite` error if the amount of data written is less than the frame size.

**- How I did it**

I'm added a new test case with a custom writer which emulates more data being written than what is passed to it. From this I expect that when this happens, it does not return a "short write" error.

**- How to verify it**

The tests in the `stdcopy` package can be run to verify.

Closes #45377 
