### PR TITLE
c8d: Don't remount if the container is already running

### DIFF
--- a/daemon/containerd/mount.go
+++ b/daemon/containerd/mount.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/containerd/containerd/mount"
 	"github.com/docker/docker/container"
 	"github.com/sirupsen/logrus"
 )
+
+const rootfsMountSuffix = "_rootfs-mount"
 
 // Mount mounts the container filesystem in a temporary location, use defer imageService.Unmount
 // to unmount the filesystem when calling this
@@ -19,15 +22,21 @@ func (i *ImageService) Mount(ctx context.Context, container *container.Container
 		return err
 	}
 
-	// The temporary location will be under /var/lib/docker/... because
-	// we set the `TMPDIR`
-	root, err := os.MkdirTemp("", fmt.Sprintf("%s_rootfs-mount", container.ID))
-	if err != nil {
-		return fmt.Errorf("failed to create temp dir: %w", err)
-	}
+	root := ""
+	if container.State != nil && !container.State.Running && container.Pid == 0 {
+		// The temporary location will be under /var/lib/docker/... because
+		// we set the `TMPDIR`
+		var err error
+		root, err = os.MkdirTemp("", container.ID+rootfsMountSuffix)
+		if err != nil {
+			return fmt.Errorf("failed to create temp dir: %w", err)
+		}
 
-	if err := mount.All(mounts, root); err != nil {
-		return fmt.Errorf("failed to mount %s: %w", root, err)
+		if err := mount.All(mounts, root); err != nil {
+			return fmt.Errorf("failed to mount %s: %w", root, err)
+		}
+	} else {
+		root = fmt.Sprintf("/proc/%d/root", container.Pid)
 	}
 
 	container.BaseFS = root
@@ -38,12 +47,14 @@ func (i *ImageService) Mount(ctx context.Context, container *container.Container
 func (i *ImageService) Unmount(ctx context.Context, container *container.Container) error {
 	root := container.BaseFS
 
-	if err := mount.UnmountAll(root, 0); err != nil {
-		return fmt.Errorf("failed to unmount %s: %w", root, err)
-	}
+	if strings.HasSuffix(root, rootfsMountSuffix) {
+		if err := mount.UnmountAll(root, 0); err != nil {
+			return fmt.Errorf("failed to unmount %s: %w", root, err)
+		}
 
-	if err := os.Remove(root); err != nil {
-		logrus.WithError(err).WithField("dir", root).Error("failed to remove mount temp dir")
+		if err := os.Remove(root); err != nil {
+			logrus.WithError(err).WithField("dir", root).Error("failed to remove mount temp dir")
+		}
 	}
 
 	container.BaseFS = ""

--- a/daemon/containerfs_linux.go
+++ b/daemon/containerfs_linux.go
@@ -77,6 +77,9 @@ func (daemon *Daemon) openContainerFS(container *container.Container) (_ *contai
 	done := make(chan error)
 	err = unshare.Go(unix.CLONE_NEWNS,
 		func() error {
+			if container.State != nil && container.State.Running && container.Pid != 0 {
+				return mounttree.SwitchRoot(container.BaseFS)
+			}
 			if err := mount.MakeRSlave("/"); err != nil {
 				return err
 			}


### PR DESCRIPTION
**- What I did**

Opening this PR to start a discussion more than wanting this code to be merged. The code works but maybe someone has a better idea for this case. @AkihiroSuda @thaJeztah @vvoland 

The `openContainerFS` would need some more work, I'm not sure we need to unmount volumes here: https://github.com/moby/moby/blob/master/daemon/containerfs_linux.go#L69, they are unmounted in the finalizer of the struct

This change fixes double-mounting when running an exec or a cp on a running container with the containerd integration enabled. Sharing layers with overlayfs results in an undefined state and things start to randomly break with a "No such file or directory" error.

Graph drivers use reference counting and only mount things once, we can't do this with containerd because we don't know where it mounted the container rootfs. Instead of reference counting we return the `/proc/<pid>/root` directory for exec and/or cp to read from.


**- How I did it**

Checking the container state and setting the container basefs to `/proc/<pid>/root` if the container is running.

**- How to verify it**

You can use this script:

```bash
set -x

ID=$(docker run -d nginx)

docker exec $ID mount | wc -l

cat > test <<EOF
Hello cp
EOF

docker cp test $ID:/test

docker exec $ID touch /etc/default/test-file

docker exec $ID mount | wc -l

docker stop $ID

docker cp test $ID:/test2

docker start $ID

docker exec $ID mount | wc -l

docker exec $ID cat /test
docker exec $ID cat /test2

docker stop $ID
docker rm $ID
```

With current `master` branch the output is:

```
./cp.sh 
++ docker run -d nginx
+ ID=88d265e718b3adf0cc9e4c52e1bb363c95a27c91096ac9f1097927eb0772e0a9
+ docker exec 88d265e718b3adf0cc9e4c52e1bb363c95a27c91096ac9f1097927eb0772e0a9 mount
+ wc -l
24
+ cat
+ docker cp test 88d265e718b3adf0cc9e4c52e1bb363c95a27c91096ac9f1097927eb0772e0a9:/test
Successfully copied 2.05kB to 88d265e718b3adf0cc9e4c52e1bb363c95a27c91096ac9f1097927eb0772e0a9:/test
+ docker exec 88d265e718b3adf0cc9e4c52e1bb363c95a27c91096ac9f1097927eb0772e0a9 touch /etc/default/test-file
touch: cannot touch '/etc/default/test-file': No such file or directory
+ docker exec 88d265e718b3adf0cc9e4c52e1bb363c95a27c91096ac9f1097927eb0772e0a9 mount
+ wc -l
24
+ docker stop 88d265e718b3adf0cc9e4c52e1bb363c95a27c91096ac9f1097927eb0772e0a9
88d265e718b3adf0cc9e4c52e1bb363c95a27c91096ac9f1097927eb0772e0a9
+ docker cp test 88d265e718b3adf0cc9e4c52e1bb363c95a27c91096ac9f1097927eb0772e0a9:/test2
Successfully copied 2.05kB to 88d265e718b3adf0cc9e4c52e1bb363c95a27c91096ac9f1097927eb0772e0a9:/test2
+ docker start 88d265e718b3adf0cc9e4c52e1bb363c95a27c91096ac9f1097927eb0772e0a9
88d265e718b3adf0cc9e4c52e1bb363c95a27c91096ac9f1097927eb0772e0a9
+ docker exec 88d265e718b3adf0cc9e4c52e1bb363c95a27c91096ac9f1097927eb0772e0a9 mount
+ wc -l
24
+ docker exec 88d265e718b3adf0cc9e4c52e1bb363c95a27c91096ac9f1097927eb0772e0a9 cat /test
Hello cp
+ docker exec 88d265e718b3adf0cc9e4c52e1bb363c95a27c91096ac9f1097927eb0772e0a9 cat /test2
Hello cp
+ docker stop 88d265e718b3adf0cc9e4c52e1bb363c95a27c91096ac9f1097927eb0772e0a9
88d265e718b3adf0cc9e4c52e1bb363c95a27c91096ac9f1097927eb0772e0a9
+ docker rm 88d265e718b3adf0cc9e4c52e1bb363c95a27c91096ac9f1097927eb0772e0a9
88d265e718b3adf0cc9e4c52e1bb363c95a27c91096ac9f1097927eb0772e0a9
```

Notice the line `touch: cannot touch '/etc/default/test-file': No such file or directory`, the rootfs  is in an undefined state...


With this change the error goes away:

```
$ ./cp.sh
++ docker run -d nginx
+ ID=7e1d0a21f5a743e7b3769bfff16705db6e3c306ba6c79427db7a637a7670ec89
+ docker exec 7e1d0a21f5a743e7b3769bfff16705db6e3c306ba6c79427db7a637a7670ec89 mount
+ wc -l
24
+ cat
+ docker cp test 7e1d0a21f5a743e7b3769bfff16705db6e3c306ba6c79427db7a637a7670ec89:/test
Successfully copied 2.05kB to 7e1d0a21f5a743e7b3769bfff16705db6e3c306ba6c79427db7a637a7670ec89:/test
+ docker exec 7e1d0a21f5a743e7b3769bfff16705db6e3c306ba6c79427db7a637a7670ec89 touch /etc/default/test-file
+ docker exec 7e1d0a21f5a743e7b3769bfff16705db6e3c306ba6c79427db7a637a7670ec89 mount
+ wc -l
24
+ docker stop 7e1d0a21f5a743e7b3769bfff16705db6e3c306ba6c79427db7a637a7670ec89
7e1d0a21f5a743e7b3769bfff16705db6e3c306ba6c79427db7a637a7670ec89
+ docker cp test 7e1d0a21f5a743e7b3769bfff16705db6e3c306ba6c79427db7a637a7670ec89:/test2
Successfully copied 2.05kB to 7e1d0a21f5a743e7b3769bfff16705db6e3c306ba6c79427db7a637a7670ec89:/test2
+ docker start 7e1d0a21f5a743e7b3769bfff16705db6e3c306ba6c79427db7a637a7670ec89
7e1d0a21f5a743e7b3769bfff16705db6e3c306ba6c79427db7a637a7670ec89
+ docker exec 7e1d0a21f5a743e7b3769bfff16705db6e3c306ba6c79427db7a637a7670ec89 mount
+ wc -l
24
+ docker exec 7e1d0a21f5a743e7b3769bfff16705db6e3c306ba6c79427db7a637a7670ec89 cat /test
Hello cp
+ docker exec 7e1d0a21f5a743e7b3769bfff16705db6e3c306ba6c79427db7a637a7670ec89 cat /test2
Hello cp
+ docker stop 7e1d0a21f5a743e7b3769bfff16705db6e3c306ba6c79427db7a637a7670ec89
7e1d0a21f5a743e7b3769bfff16705db6e3c306ba6c79427db7a637a7670ec89
+ docker rm 7e1d0a21f5a743e7b3769bfff16705db6e3c306ba6c79427db7a637a7670ec89
7e1d0a21f5a743e7b3769bfff16705db6e3c306ba6c79427db7a637a7670ec89
```

You can also look at `sudo dmesg -w` in parallel, there shouldn't be any overlayfs warnings after this change.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

