### PR TITLE
c8d/list: Initialize capacity instead of length

### DIFF
--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -61,7 +61,7 @@ func (i *ImageService) Images(ctx context.Context, opts types.ImageListOptions) 
 		layers    map[digest.Digest]int
 	)
 	if opts.SharedSize {
-		root = make([]*[]digest.Digest, len(imgs))
+		root = make([]*[]digest.Digest, 0, len(imgs))
 		layers = make(map[digest.Digest]int)
 	}
 	for n, img := range imgs {


### PR DESCRIPTION
The slice which stores chain ids used for computing shared size was mistakenly initialized with the length set instead of the capacity. This caused a panic when iterating over it later and dereferncing nil pointer from empty items.

**- What I did**
Fix panic when calling `images/json?shared-size=1`

**- How I did it**

**- How to verify it**
```bash
$ docker pull alpine
$ curl --unix-socket /var/run/docker.sock http://localhost/images/json?shared-size=1
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

