### PR TITLE
integration/TestKillContainer: Bigger timeout on Windows

### DIFF
--- a/integration/container/kill_test.go
+++ b/integration/container/kill_test.go
@@ -2,6 +2,7 @@ package container // import "github.com/docker/docker/integration/container"
 
 import (
 	"context"
+	"runtime"
 	"testing"
 	"time"
 
@@ -61,6 +62,11 @@ func TestKillContainer(t *testing.T) {
 		},
 	}
 
+	var pollOpts []poll.SettingOp
+	if runtime.GOOS == "windows" {
+		pollOpts = append(pollOpts, poll.WithTimeout(StopContainerWindowsPollTimeout))
+	}
+
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
@@ -70,7 +76,7 @@ func TestKillContainer(t *testing.T) {
 			err := client.ContainerKill(ctx, id, tc.signal)
 			assert.NilError(t, err)
 
-			poll.WaitOn(t, container.IsInState(ctx, client, id, tc.status), poll.WithDelay(100*time.Millisecond))
+			poll.WaitOn(t, container.IsInState(ctx, client, id, tc.status), pollOpts...)
 		})
 	}
 }


### PR DESCRIPTION
**- What I did**
Increased timeout for stopping killed container on Windows.
This test was flaky.

**- How I did it**

**- How to verify it**
Run TestKillContainer

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

