### PR TITLE
containerd integration: Handle nil container.ImageManifest

### DIFF
--- a/daemon/containerd/image_changes.go
+++ b/daemon/containerd/image_changes.go
@@ -17,7 +17,12 @@ import (
 func (i *ImageService) Changes(ctx context.Context, container *container.Container) ([]archive.Change, error) {
 	cs := i.client.ContentStore()
 
-	imageManifestBytes, err := content.ReadBlob(ctx, cs, *container.ImageManifest)
+	imageManifest, err := getContainerImageManifest(container)
+	if err != nil {
+		return nil, err
+	}
+
+	imageManifestBytes, err := content.ReadBlob(ctx, cs, imageManifest)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/containerd/image_commit.go
+++ b/daemon/containerd/image_commit.go
@@ -40,7 +40,12 @@ func (i *ImageService) CommitImage(ctx context.Context, cc backend.CommitConfig)
 	container := i.containers.Get(cc.ContainerID)
 	cs := i.client.ContentStore()
 
-	imageManifestBytes, err := content.ReadBlob(ctx, cs, *container.ImageManifest)
+	imageManifest, err := getContainerImageManifest(container)
+	if err != nil {
+		return "", err
+	}
+
+	imageManifestBytes, err := content.ReadBlob(ctx, cs, imageManifest)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
**- What I did**
Fix panic when processing containers created under fork containerd integration (this field was added in the upstream and didn't exist in fork).

This fixes a panic when upgrading from DD 4.18 to 4.19 if the user had created a containers with the containerd image store integration enabled. This is because the fork didn't have the `ImageManifest` which was introduced only in the upstream, so it wasn't set and is now nil.


**- How I did it**
See commit.

**- How to verify it**
fork 4.18 -> upstream 4.19 can be simulated by changing https://github.com/moby/moby/blob/a343ed13e556ec97a26bd5fc34b069a64f86f16b/daemon/create.go#L183 to set `ImageManifest` to nil and creating some containers with nil `ImageManifest`.
Alternatively setting `ImageManifest` to nil directly in the container config directly in `/var/lib/docker/containers/.../config.v2.json`  and restarting the daemon.

Run: `system df`, `commit` and `diff`. 


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

