### PR TITLE
api/types/filters: Args: use pointer receiver and update tests

### DIFF
--- a/api/types/filters/parse.go
+++ b/api/types/filters/parse.go
@@ -125,6 +125,9 @@ func (args Args) Get(key string) []string {
 
 // Add a new value to the set of values
 func (args Args) Add(key, value string) {
+	if args.fields == nil {
+		args.fields = map[string]map[string]bool{}
+	}
 	if _, ok := args.fields[key]; ok {
 		args.fields[key][value] = true
 	} else {

--- a/api/types/filters/parse_test.go
+++ b/api/types/filters/parse_test.go
@@ -21,15 +21,27 @@ func TestMarshalJSON(t *testing.T) {
 	assert.Check(t, err)
 	const expected = `{"created":{"today":true},"image.name":{"*untu":true,"ubuntu*":true}}`
 	assert.Check(t, is.Equal(string(s), expected))
+
+	s, err = json.Marshal(&Args{fields: map[string]map[string]bool{
+		"created":    {"today": true},
+		"image.name": {"*untu": true, "ubuntu*": true},
+	}})
+	assert.Check(t, err)
+	assert.Check(t, is.Equal(string(s), expected))
+
+	s, err = json.Marshal(&a)
+	assert.Check(t, err)
+	assert.Check(t, is.Equal(string(s), expected))
 }
 
 func TestMarshalJSONWithEmpty(t *testing.T) {
-	s, err := json.Marshal(NewArgs())
+	a := NewArgs()
+	s, err := json.Marshal(&a)
 	assert.Check(t, err)
 	const expected = `{}`
 	assert.Check(t, is.Equal(string(s), expected))
 
-	s, err = json.Marshal(Args{})
+	s, err = json.Marshal(&Args{})
 	assert.Check(t, err)
 	assert.Check(t, is.Equal(string(s), expected))
 }

--- a/api/types/filters/parse_test.go
+++ b/api/types/filters/parse_test.go
@@ -28,6 +28,10 @@ func TestMarshalJSONWithEmpty(t *testing.T) {
 	assert.Check(t, err)
 	const expected = `{}`
 	assert.Check(t, is.Equal(string(s), expected))
+
+	s, err = json.Marshal(Args{})
+	assert.Check(t, err)
+	assert.Check(t, is.Equal(string(s), expected))
 }
 
 func TestToJSON(t *testing.T) {

--- a/daemon/config/builder_test.go
+++ b/daemon/config/builder_test.go
@@ -29,10 +29,8 @@ func TestBuilderGC(t *testing.T) {
 	cfg, err := MergeDaemonConfigurations(&Config{}, nil, configFile)
 	assert.NilError(t, err)
 	assert.Assert(t, cfg.Builder.GC.Enabled)
-	f1 := filters.NewArgs()
-	f1.Add("unused-for", "2200h")
-	f2 := filters.NewArgs()
-	f2.Add("unused-for", "3300h")
+	f1 := filters.NewArgs(filters.Arg("unused-for", "2200h"))
+	f2 := filters.NewArgs(filters.Arg("unused-for", "3300h"))
 	expectedPolicy := []BuilderGCRule{
 		{ReservedSpace: "10GB", Filter: BuilderGCFilter(f1)},
 		{ReservedSpace: "50GB", Filter: BuilderGCFilter(f2)}, /* parsed from deprecated form */
@@ -73,8 +71,10 @@ func TestBuilderGC_DeprecatedKeepStorage(t *testing.T) {
 	}
 	assert.DeepEqual(t, cfg.Builder.GC.Policy, expectedPolicy, cmp.AllowUnexported(BuilderGCFilter{}))
 	// double check to please the skeptics
-	assert.Assert(t, filters.Args(cfg.Builder.GC.Policy[0].Filter).UniqueExactMatch("unused-for", "2200h"))
-	assert.Assert(t, filters.Args(cfg.Builder.GC.Policy[1].Filter).UniqueExactMatch("unused-for", "3300h"))
+	f3 := filters.Args(cfg.Builder.GC.Policy[0].Filter)
+	assert.Assert(t, f3.UniqueExactMatch("unused-for", "2200h"))
+	f4 := filters.Args(cfg.Builder.GC.Policy[1].Filter)
+	assert.Assert(t, f4.UniqueExactMatch("unused-for", "3300h"))
 }
 
 // TestBuilderGCFilterUnmarshal is a regression test for https://github.com/moby/moby/issues/44361,

--- a/volume/service/convert.go
+++ b/volume/service/convert.go
@@ -132,7 +132,7 @@ func filtersToBy(filter filters.Args, acceptedFilters map[string]bool) (By, erro
 	return by, nil
 }
 
-func withPrune(filter filters.Args) error {
+func withPrune(filter *filters.Args) error {
 	all := filter.Get("all")
 	switch {
 	case len(all) > 1:

--- a/volume/service/convert_test.go
+++ b/volume/service/convert_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestFilterWithPrune(t *testing.T) {
 	f := filters.NewArgs()
-	assert.NilError(t, withPrune(f))
+	assert.NilError(t, withPrune(&f))
 	assert.Check(t, is.Len(f.Get("label"), 1))
 	assert.Check(t, f.Match("label", AnonymousLabel))
 
@@ -18,7 +18,7 @@ func TestFilterWithPrune(t *testing.T) {
 		filters.Arg("label", "foo=bar"),
 		filters.Arg("label", "bar=baz"),
 	)
-	assert.NilError(t, withPrune(f))
+	assert.NilError(t, withPrune(&f))
 
 	assert.Check(t, is.Len(f.Get("label"), 3))
 	assert.Check(t, f.Match("label", AnonymousLabel))
@@ -29,7 +29,7 @@ func TestFilterWithPrune(t *testing.T) {
 		filters.Arg("label", "foo=bar"),
 		filters.Arg("all", "1"),
 	)
-	assert.NilError(t, withPrune(f))
+	assert.NilError(t, withPrune(&f))
 
 	assert.Check(t, is.Len(f.Get("label"), 1))
 	assert.Check(t, f.Match("label", "foo=bar"))
@@ -38,27 +38,27 @@ func TestFilterWithPrune(t *testing.T) {
 		filters.Arg("label", "foo=bar"),
 		filters.Arg("all", "true"),
 	)
-	assert.NilError(t, withPrune(f))
+	assert.NilError(t, withPrune(&f))
 
 	assert.Check(t, is.Len(f.Get("label"), 1))
 	assert.Check(t, f.Match("label", "foo=bar"))
 
 	f = filters.NewArgs(filters.Arg("all", "0"))
-	assert.NilError(t, withPrune(f))
+	assert.NilError(t, withPrune(&f))
 	assert.Check(t, is.Len(f.Get("label"), 1))
 	assert.Check(t, f.Match("label", AnonymousLabel))
 
 	f = filters.NewArgs(filters.Arg("all", "false"))
-	assert.NilError(t, withPrune(f))
+	assert.NilError(t, withPrune(&f))
 	assert.Check(t, is.Len(f.Get("label"), 1))
 	assert.Check(t, f.Match("label", AnonymousLabel))
 
 	f = filters.NewArgs(filters.Arg("all", ""))
-	assert.ErrorContains(t, withPrune(f), "invalid filter 'all'")
+	assert.ErrorContains(t, withPrune(&f), "invalid filter 'all'")
 
 	f = filters.NewArgs(
 		filters.Arg("all", "1"),
 		filters.Arg("all", "0"),
 	)
-	assert.ErrorContains(t, withPrune(f), "invalid filter 'all")
+	assert.ErrorContains(t, withPrune(&f), "invalid filter 'all")
 }

--- a/volume/service/service.go
+++ b/volume/service/service.go
@@ -215,7 +215,7 @@ func (s *VolumesService) Prune(ctx context.Context, filter filters.Args) (*volum
 	}
 	defer s.pruneRunning.Store(false)
 
-	if err := withPrune(filter); err != nil {
+	if err := withPrune(&filter); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Use a pointer receiver, to make it easier to use this type without having to call `filter.NewArgs()`


**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

