### PR TITLE
fix authorization request by using right client certificate on branch 23.0 - fixes #45327 

### DIFF
--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -77,7 +77,7 @@ type puller struct {
 
 func (p *puller) pull(ctx context.Context, ref reference.Named) (err error) {
 	// TODO(tiborvass): was ReceiveTimeout
-	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
+	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, p.config.RegistryService, "pull")
 	if err != nil {
 		logrus.Warnf("Error getting v2 registry: %v", err)
 		return err

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -74,7 +74,7 @@ type pushState struct {
 func (p *pusher) push(ctx context.Context) (err error) {
 	p.pushState.remoteLayers = make(map[layer.DiffID]distribution.Descriptor)
 
-	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "push", "pull")
+	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, p.config.RegistryService, "push", "pull")
 	p.pushState.hasAuthInfo = p.config.AuthConfig.RegistryToken != "" || (p.config.AuthConfig.Username != "" && p.config.AuthConfig.Password != "")
 	if err != nil {
 		logrus.Debugf("Error getting v2 registry: %v", err)

--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/registry"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -74,7 +75,8 @@ func init() {
 // remote API version.
 func newRepository(
 	ctx context.Context, repoInfo *registry.RepositoryInfo, endpoint registry.APIEndpoint,
-	metaHeaders http.Header, authConfig *types.AuthConfig, actions ...string,
+	metaHeaders http.Header, authConfig *types.AuthConfig, registryService registry.Service,
+	actions ...string,
 ) (repo distribution.Repository, err error) {
 	repoName := repoInfo.Name.Name()
 	// If endpoint does not support CanonicalName, use the RemoteName instead
@@ -123,9 +125,23 @@ func newRepository(
 			Class:      repoInfo.Class,
 		}
 
+		hostname := challengeManager.GetHost()
+
+		var newAuthTransport = authTransport
+		if len(hostname) > 0 {
+			tlsConfig, err := registry.NewTLSConfig(hostname, registryService.IsSecureIndex(hostname))
+			logrus.Debugf("Loading TLS config for host %s", hostname)
+			if err != nil {
+				logrus.Errorf("TLS config not found for host %s", hostname)
+			} else {
+				logrus.Debugf("TLS config was found for host %s", hostname)
+				newAuthTransport = transport.NewTransport(registry.NewTransport(tlsConfig), modifiers...)
+			}
+		}
+
 		creds := registry.NewStaticCredentialStore(authConfig)
 		tokenHandlerOptions := auth.TokenHandlerOptions{
-			Transport:   authTransport,
+			Transport:   newAuthTransport,
 			Credentials: creds,
 			Scopes:      []auth.Scope{scope},
 			ClientID:    registry.AuthClientID,

--- a/distribution/repository.go
+++ b/distribution/repository.go
@@ -25,7 +25,7 @@ func GetRepository(ctx context.Context, ref reference.Named, config *ImagePullCo
 	}
 
 	for _, endpoint := range endpoints {
-		repository, lastError = newRepository(ctx, repoInfo, endpoint, nil, config.AuthConfig, "pull")
+		repository, lastError = newRepository(ctx, repoInfo, endpoint, nil, config.AuthConfig, config.RegistryService, "pull")
 		if lastError == nil {
 			break
 		}

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -66,18 +66,18 @@ func (scs staticCredentialStore) SetRefreshToken(*url.URL, string, string) {
 // loginV2 tries to login to the v2 registry server. The given registry
 // endpoint will be pinged to get authorization challenges. These challenges
 // will be used to authenticate against the registry to validate credentials.
-func loginV2(authConfig *types.AuthConfig, endpoint APIEndpoint, userAgent string) (string, string, error) {
+func loginV2(authConfig *types.AuthConfig, endpoint APIEndpoint, userAgent string, s *defaultService) (string, string, error) {
 	var (
 		endpointStr          = strings.TrimRight(endpoint.URL.String(), "/") + "/v2/"
 		modifiers            = Headers(userAgent, nil)
-		authTransport        = transport.NewTransport(newTransport(endpoint.TLSConfig), modifiers...)
+		authTransport        = transport.NewTransport(NewTransport(endpoint.TLSConfig), modifiers...)
 		credentialAuthConfig = *authConfig
 		creds                = loginCredentialStore{authConfig: &credentialAuthConfig}
 	)
 
 	logrus.Debugf("attempting v2 login to registry endpoint %s", endpointStr)
 
-	loginClient, err := v2AuthHTTPClient(endpoint.URL, authTransport, modifiers, creds, nil)
+	loginClient, err := v2AuthHTTPClient(endpoint.URL, authTransport, modifiers, creds, nil, s)
 	if err != nil {
 		return "", "", err
 	}
@@ -102,14 +102,28 @@ func loginV2(authConfig *types.AuthConfig, endpoint APIEndpoint, userAgent strin
 	return "", "", errors.Errorf("login attempt to %s failed with status: %d %s", endpointStr, resp.StatusCode, http.StatusText(resp.StatusCode))
 }
 
-func v2AuthHTTPClient(endpoint *url.URL, authTransport http.RoundTripper, modifiers []transport.RequestModifier, creds auth.CredentialStore, scopes []auth.Scope) (*http.Client, error) {
+func v2AuthHTTPClient(endpoint *url.URL, authTransport http.RoundTripper, modifiers []transport.RequestModifier, creds auth.CredentialStore, scopes []auth.Scope, s *defaultService) (*http.Client, error) {
 	challengeManager, err := PingV2Registry(endpoint, authTransport)
 	if err != nil {
 		return nil, err
 	}
 
+	hostname := challengeManager.GetHost()
+
+	var newAuthTransport = authTransport
+	if len(hostname) > 0 {
+		tlsConfig, err := NewTLSConfig(hostname, s.config.isSecureIndex(hostname))
+		logrus.Debugf("Loading TLS config for host %s", hostname)
+		if err != nil {
+			logrus.Errorf("TLS config not found for host %s", hostname)
+		} else {
+			logrus.Debugf("TLS config was found for host %s", hostname)
+			newAuthTransport = transport.NewTransport(NewTransport(tlsConfig), modifiers...)
+		}
+	}
+
 	tokenHandlerOptions := auth.TokenHandlerOptions{
-		Transport:     authTransport,
+		Transport:     newAuthTransport,
 		Credentials:   creds,
 		OfflineAccess: true,
 		ClientID:      AuthClientID,

--- a/registry/endpoint_v1.go
+++ b/registry/endpoint_v1.go
@@ -36,7 +36,7 @@ type v1Endpoint struct {
 // newV1Endpoint parses the given address to return a registry endpoint.
 // TODO: remove. This is only used by search.
 func newV1Endpoint(index *registry.IndexInfo, userAgent string, metaHeaders http.Header) (*v1Endpoint, error) {
-	tlsConfig, err := newTLSConfig(index.Name, index.Secure)
+	tlsConfig, err := NewTLSConfig(index.Name, index.Secure)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func newV1EndpointFromStr(address string, tlsConfig *tls.Config, userAgent strin
 	}
 
 	// TODO(tiborvass): make sure a ConnectTimeout transport is used
-	tr := newTransport(tlsConfig)
+	tr := NewTransport(tlsConfig)
 
 	return &v1Endpoint{
 		IsSecure: tlsConfig == nil || !tlsConfig.InsecureSkipVerify,

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -21,7 +21,7 @@ func HostCertsDir(hostname string) string {
 }
 
 // newTLSConfig constructs a client TLS configuration based on server defaults
-func newTLSConfig(hostname string, isSecure bool) (*tls.Config, error) {
+func NewTLSConfig(hostname string, isSecure bool) (*tls.Config, error) {
 	// PreferredServerCipherSuites should have no effect
 	tlsConfig := tlsconfig.ServerDefault()
 
@@ -159,7 +159,7 @@ func addRequiredHeadersToRedirectedRequests(req *http.Request, via []*http.Reque
 
 // newTransport returns a new HTTP transport. If tlsConfig is nil, it uses the
 // default TLS configuration.
-func newTransport(tlsConfig *tls.Config) *http.Transport {
+func NewTransport(tlsConfig *tls.Config) *http.Transport {
 	if tlsConfig == nil {
 		tlsConfig = tlsconfig.ServerDefault()
 	}

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -19,7 +19,7 @@ func (s *defaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndp
 			if err != nil {
 				return nil, invalidParam(err)
 			}
-			mirrorTLSConfig, err := newTLSConfig(mirrorURL.Host, s.config.isSecureIndex(mirrorURL.Host))
+			mirrorTLSConfig, err := NewTLSConfig(mirrorURL.Host, s.config.isSecureIndex(mirrorURL.Host))
 			if err != nil {
 				return nil, err
 			}
@@ -44,7 +44,7 @@ func (s *defaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndp
 		return endpoints, nil
 	}
 
-	tlsConfig, err := newTLSConfig(hostname, s.config.isSecureIndex(hostname))
+	tlsConfig, err := NewTLSConfig(hostname, s.config.isSecureIndex(hostname))
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/docker/distribution/registry/client/auth/challenge/authchallenge.go
+++ b/vendor/github.com/docker/distribution/registry/client/auth/challenge/authchallenge.go
@@ -35,6 +35,8 @@ type Manager interface {
 	// response was authorized, any challenges for the
 	// endpoint will be cleared.
 	AddResponse(resp *http.Response) error
+
+	GetHost() string
 }
 
 // NewSimpleManager returns an instance of
@@ -84,6 +86,24 @@ func (m *simpleManager) AddResponse(resp *http.Response) error {
 	defer m.Unlock()
 	m.Challenges[urlCopy.String()] = challenges
 	return nil
+}
+
+func (m *simpleManager) GetHost() string {
+	if len(m.Challenges) == 1 {
+		for _, challenges := range m.Challenges {
+			if len(challenges) == 1 {
+				realm, ok := challenges[0].Parameters["realm"]
+				if ok {
+					realmURL, err := url.Parse(realm)
+					if err == nil {
+						return realmURL.Host
+					}
+				}
+			}
+		}
+	}
+
+	return ""
 }
 
 // Octet types from RFC 2616.


### PR DESCRIPTION
**- What I did**
I changed the tls config in the transport object if a token request must be sent to a token provider

**- How I did it**

**- How to verify it**
Configure a docker registry under a reverse proxy needing a client certificate authentication
Configure a token provider under a reverse proxy needing a client certificate authentication that is different with the registry
Set the client.cert and client.key files in /etc/docked/certs.d/<registry.domain> 
Set the client.cert and client.key files in /etc/docked/certs.d/<token_provider.domain> 
Try to login onto the registry with "docker login <registry.domain>" command
Test to push and pull images with the registry

**- Description for the changelog**
Fix docker daemon for using the right client certificate for authorization token request when the client certificate to user with the token provider is different from the client certificate to use with docker registry. Concerns "docker login", "docker push" and "docker pull" commands.
fixes #45327 
