### PR TITLE
fix authorization request by using right client certificate on branch 20.10 - fixes #45327

### DIFF
--- a/daemon/images/image_pull.go
+++ b/daemon/images/image_pull.go
@@ -163,7 +163,7 @@ func (i *ImageService) GetRepository(ctx context.Context, ref reference.Named, a
 			continue
 		}
 
-		repository, confirmedV2, lastError = distribution.NewV2Repository(ctx, repoInfo, endpoint, nil, authConfig, "pull")
+		repository, confirmedV2, lastError = distribution.NewV2Repository(ctx, repoInfo, endpoint, nil, authConfig, i.registryService, "pull")
 		if lastError == nil && confirmedV2 {
 			break
 		}

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -69,7 +69,7 @@ type v2Puller struct {
 
 func (p *v2Puller) Pull(ctx context.Context, ref reference.Named, platform *specs.Platform) (err error) {
 	// TODO(tiborvass): was ReceiveTimeout
-	p.repo, p.confirmedV2, err = NewV2Repository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
+	p.repo, p.confirmedV2, err = NewV2Repository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, p.config.RegistryService, "pull")
 	if err != nil {
 		logrus.Warnf("Error getting v2 registry: %v", err)
 		return err

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -62,7 +62,7 @@ type pushState struct {
 func (p *v2Pusher) Push(ctx context.Context) (err error) {
 	p.pushState.remoteLayers = make(map[layer.DiffID]distribution.Descriptor)
 
-	p.repo, p.pushState.confirmedV2, err = NewV2Repository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "push", "pull")
+	p.repo, p.pushState.confirmedV2, err = NewV2Repository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, p.config.RegistryService, "push", "pull")
 	p.pushState.hasAuthInfo = p.config.AuthConfig.RegistryToken != "" || (p.config.AuthConfig.Username != "" && p.config.AuthConfig.Password != "")
 	if err != nil {
 		logrus.Debugf("Error getting v2 registry: %v", err)

--- a/registry/endpoint_v1.go
+++ b/registry/endpoint_v1.go
@@ -23,7 +23,7 @@ type V1Endpoint struct {
 
 // NewV1Endpoint parses the given address to return a registry endpoint.
 func NewV1Endpoint(index *registrytypes.IndexInfo, userAgent string, metaHeaders http.Header) (*V1Endpoint, error) {
-	tlsConfig, err := newTLSConfig(index.Name, index.Secure)
+	tlsConfig, err := NewTLSConfig(index.Name, index.Secure)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -32,7 +32,7 @@ func HostCertsDir(hostname string) (string, error) {
 	return hostDir, nil
 }
 
-func newTLSConfig(hostname string, isSecure bool) (*tls.Config, error) {
+func NewTLSConfig(hostname string, isSecure bool) (*tls.Config, error) {
 	// PreferredServerCipherSuites should have no effect
 	tlsConfig := tlsconfig.ServerDefault()
 

--- a/vendor/github.com/docker/distribution/registry/client/auth/challenge/authchallenge.go
+++ b/vendor/github.com/docker/distribution/registry/client/auth/challenge/authchallenge.go
@@ -35,6 +35,8 @@ type Manager interface {
 	// response was authorized, any challenges for the
 	// endpoint will be cleared.
 	AddResponse(resp *http.Response) error
+
+	GetHost() string
 }
 
 // NewSimpleManager returns an instance of
@@ -84,6 +86,24 @@ func (m *simpleManager) AddResponse(resp *http.Response) error {
 	defer m.Unlock()
 	m.Challenges[urlCopy.String()] = challenges
 	return nil
+}
+
+func (m *simpleManager) GetHost() string {
+	if len(m.Challenges) == 1 {
+		for _, challenges := range m.Challenges {
+			if len(challenges) == 1 {
+				realm, ok := challenges[0].Parameters["realm"]
+				if ok {
+					realmURL, err := url.Parse(realm)
+					if err == nil {
+						return realmURL.Host
+					}
+				}
+			}
+		}
+	}
+
+	return ""
 }
 
 // Octet types from RFC 2616.


### PR DESCRIPTION
- What I did
I changed the tls config in the transport object if a token request must be sent to a token provider

- How I did it

- How to verify it
Configure a docker registry under a reverse proxy needing a client certificate authentication
Configure a token provider under a reverse proxy needing a client certificate authentication that is different with the registry
Set the client.cert and client.key files in /etc/docked/certs.d/<registry.domain>
Set the client.cert and client.key files in /etc/docked/certs.d/<token_provider.domain>
Try to login onto the registry with "docker login <registry.domain>" command
Test to push and pull images with the registry

- Description for the changelog
Fix docker daemon for using the right client certificate for authorization token request when the client certificate to user with the token provider is different from the client certificate to use with docker registry. Concerns "docker login", "docker push" and "docker pull" commands.
fixes #45327