### PR TITLE
[23.0 backport] daemon: set docker0 subpool as the IPAM pool

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1000,6 +1000,9 @@ func initBridgeDriver(controller libnetwork.NetworkController, config *config.Co
 		}
 
 		ipamV4Conf.SubPool = fCIDR.String()
+		if ipamV4Conf.PreferredPool == "" {
+			ipamV4Conf.PreferredPool = fCIDR.String()
+		}
 	}
 
 	if config.BridgeConfig.DefaultGatewayIPv4 != nil {

--- a/integration/daemon/daemon_test.go
+++ b/integration/daemon/daemon_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/icmd"
 	"gotest.tools/v3/skip"
 )
 
@@ -415,4 +416,31 @@ func testLiveRestoreVolumeReferences(t *testing.T) {
 		runTest(t, "on-failure")
 		runTest(t, "no")
 	})
+}
+
+func TestDaemonDefaultBridgeWithFixedCidrButNoBip(t *testing.T) {
+	skip.If(t, runtime.GOOS == "windows")
+
+	bridgeName := "ext-bridge1"
+	d := daemon.New(t, daemon.WithEnvVars("DOCKER_TEST_CREATE_DEFAULT_BRIDGE="+bridgeName))
+	defer func() {
+		d.Stop(t)
+		d.Cleanup(t)
+	}()
+
+	defer func() {
+		// No need to clean up when running this test in rootless mode, as the
+		// interface is deleted when the daemon is stopped and the netns
+		// reclaimed by the kernel.
+		if !testEnv.IsRootless() {
+			deleteInterface(t, bridgeName)
+		}
+	}()
+	d.StartWithBusybox(t, "--bridge", bridgeName, "--fixed-cidr", "192.168.130.0/24")
+}
+
+func deleteInterface(t *testing.T, ifName string) {
+	icmd.RunCommand("ip", "link", "delete", ifName).Assert(t, icmd.Success)
+	icmd.RunCommand("iptables", "-t", "nat", "--flush").Assert(t, icmd.Success)
+	icmd.RunCommand("iptables", "--flush").Assert(t, icmd.Success)
 }

--- a/libnetwork/drivers/bridge/setup_device.go
+++ b/libnetwork/drivers/bridge/setup_device.go
@@ -16,8 +16,14 @@ import (
 // SetupDevice create a new bridge interface/
 func setupDevice(config *networkConfiguration, i *bridgeInterface) error {
 	// We only attempt to create the bridge when the requested device name is
-	// the default one.
-	if config.BridgeName != DefaultBridgeName && config.DefaultBridge {
+	// the default one. The default bridge name can be overridden with the
+	// DOCKER_TEST_CREATE_DEFAULT_BRIDGE env var. It should be used only for
+	// test purpose.
+	var defaultBridgeName string
+	if defaultBridgeName = os.Getenv("DOCKER_TEST_CREATE_DEFAULT_BRIDGE"); defaultBridgeName == "" {
+		defaultBridgeName = DefaultBridgeName
+	}
+	if config.BridgeName != defaultBridgeName && config.DefaultBridge {
 		return NonDefaultBridgeExistError(config.BridgeName)
 	}
 


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/45356

Backport:

- https://github.com/moby/moby/pull/45366

Note that the original commit incriminated by the message of the cherry-picked commit is not present in branch `23.0`. However it's been cherry-picked too, by the following PR (commit 063d3a6):

- https://github.com/moby/moby/pull/45246

**- Description for the changelog**

Fix a regression introduced in v23.0.4 where dockerd would refuse to start if the `fixed-cidr` config parameter is provided but not `bip`.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://static.nationalgeographic.fr/files/styles/image_3200/public/04_slothlove_flower.jpg?w=710&h=473)
