### PR TITLE
Use the image service instead of the reference store for tagging

### DIFF
--- a/api/server/backend/build/backend.go
+++ b/api/server/backend/build/backend.go
@@ -92,7 +92,7 @@ func (b *Backend) Build(ctx context.Context, config backend.BuildConfig) (string
 		stdout := config.ProgressWriter.StdoutFormatter
 		fmt.Fprintf(stdout, "Successfully built %s\n", stringid.TruncateID(imageID))
 	}
-	if imageID != "" {
+	if imageID != "" && !useBuildKit {
 		err = tagImages(ctx, b.imageComponent, config.ProgressWriter.StdoutFormatter, image.ID(imageID), tags)
 	}
 	return imageID, err

--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -16,7 +16,8 @@ import (
 	"github.com/docker/docker/api/types/backend"
 	timetypes "github.com/docker/docker/api/types/time"
 	"github.com/docker/docker/builder"
-	mobyexporter "github.com/docker/docker/builder/builder-next/exporter"
+	"github.com/docker/docker/builder/builder-next/exporter"
+	"github.com/docker/docker/builder/builder-next/exporter/mobyexporter"
 	"github.com/docker/docker/builder/builder-next/exporter/overrides"
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/daemon/images"
@@ -78,6 +79,7 @@ type Opt struct {
 	SessionManager      *session.Manager
 	Root                string
 	Dist                images.DistributionServices
+	ImageTagger         mobyexporter.ImageTagger
 	NetworkController   *libnetwork.Controller
 	DefaultCgroupParent string
 	RegistryHosts       docker.RegistryHosts
@@ -355,7 +357,7 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 		if b.useSnapshotter {
 			exporterName = client.ExporterImage
 		} else {
-			exporterName = mobyexporter.Moby
+			exporterName = exporter.Moby
 		}
 	} else {
 		// cacheonly is a special type for triggering skipping all exporters
@@ -365,7 +367,7 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 		}
 	}
 
-	if (exporterName == client.ExporterImage || exporterName == mobyexporter.Moby) && len(opt.Options.Tags) > 0 {
+	if (exporterName == client.ExporterImage || exporterName == exporter.Moby) && len(opt.Options.Tags) > 0 {
 		nameAttr, err := overrides.SanitizeRepoAndTags(opt.Options.Tags)
 		if err != nil {
 			return nil, err
@@ -408,7 +410,7 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 		if err != nil {
 			return err
 		}
-		if exporterName != mobyexporter.Moby && exporterName != client.ExporterImage {
+		if exporterName != exporter.Moby && exporterName != client.ExporterImage {
 			return nil
 		}
 		id, ok := resp.ExporterResponse["containerimage.digest"]

--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -275,9 +275,9 @@ func newGraphDriverController(ctx context.Context, rt http.RoundTripper, opt Opt
 	}
 
 	exp, err := mobyexporter.New(mobyexporter.Opt{
-		ImageStore:     dist.ImageStore,
-		ReferenceStore: dist.ReferenceStore,
-		Differ:         differ,
+		ImageStore:  dist.ImageStore,
+		Differ:      differ,
+		ImageTagger: opt.ImageTagger,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -297,6 +297,7 @@ func newRouterOptions(ctx context.Context, config *config.Config, d *daemon.Daem
 		SessionManager:      sm,
 		Root:                filepath.Join(config.Root, "buildkit"),
 		Dist:                d.DistributionServices(),
+		ImageTagger:         d.ImageService(),
 		NetworkController:   d.NetworkController(),
 		DefaultCgroupParent: cgroupParent,
 		RegistryHosts:       d.RegistryHosts(),


### PR DESCRIPTION
**- What I did**

Changed the way `mobyexporter` tags an image, it used to use the reference store which doesn't send image events, we now use the image service to tag the new image. This makes sure we send the "tag" event when an image is built with `buildx`.

Note: this was a long standing issue when building an image with buildx but it only came up now because buildx is the default builder since 23.0

**- How I did it**

**- How to verify it**

Run `docker events` and build an image using buildx, you should see the "tag" event.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

