### PR TITLE
fix authorization request by using right client certificate on master branch - fixes #45327

### DIFF
--- a/distribution/config.go
+++ b/distribution/config.go
@@ -81,6 +81,7 @@ type RegistryResolver interface {
 	LookupPushEndpoints(hostname string) (endpoints []registrypkg.APIEndpoint, err error)
 	LookupPullEndpoints(hostname string) (endpoints []registrypkg.APIEndpoint, err error)
 	ResolveRepository(name reference.Named) (*registrypkg.RepositoryInfo, error)
+	IsInsecureRegistry(indexName string) bool
 }
 
 // ImageConfigStore handles storing and getting image configurations

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -77,7 +77,7 @@ type puller struct {
 
 func (p *puller) pull(ctx context.Context, ref reference.Named) (err error) {
 	// TODO(tiborvass): was ReceiveTimeout
-	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
+	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, p.config.RegistryService, "pull")
 	if err != nil {
 		logrus.Warnf("Error getting v2 registry: %v", err)
 		return err

--- a/distribution/pull_v2_test.go
+++ b/distribution/pull_v2_test.go
@@ -357,7 +357,7 @@ func testNewPuller(t *testing.T, rawurl string) *puller {
 	}
 
 	p := newPuller(endpoint, repoInfo, imagePullConfig, nil)
-	p.repo, err = newRepository(context.Background(), p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
+	p.repo, err = newRepository(context.Background(), p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, p.config.RegistryService, "pull")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -74,7 +74,7 @@ type pushState struct {
 func (p *pusher) push(ctx context.Context) (err error) {
 	p.pushState.remoteLayers = make(map[layer.DiffID]distribution.Descriptor)
 
-	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "push", "pull")
+	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, p.config.RegistryService, "push", "pull")
 	p.pushState.hasAuthInfo = p.config.AuthConfig.RegistryToken != "" || (p.config.AuthConfig.Username != "" && p.config.AuthConfig.Password != "")
 	if err != nil {
 		logrus.Debugf("Error getting v2 registry: %v", err)

--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -126,9 +126,11 @@ func newRepository(
 
 		var newAuthTransport = authTransport
 		if len(realmHost) > 0 && registryResolver != nil {
+			//trying to load a new TLS config for the auth challenge
 			tlsConfig, err := registry.NewTLSConfig(realmHost, !registryResolver.IsInsecureRegistry(realmHost))
 			logrus.Debugf("Loading TLS config for host %s", realmHost)
 			if err != nil {
+				//if no TLS config was found for the auth challenge, keep the previous TLS config
 				logrus.Warnf("TLS config not found for host %s", realmHost)
 			} else {
 				logrus.Debugf("TLS config was found for host %s", realmHost)

--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -125,6 +125,7 @@ func newRepository(
 		}
 
 		var newAuthTransport = authTransport
+		//TODO: Support multiple challenges for loading TLS configs
 		if len(realmHost) > 0 && registryResolver != nil {
 			//trying to load a new TLS config for the auth challenge
 			tlsConfig, err := registry.NewTLSConfig(realmHost, !registryResolver.IsInsecureRegistry(realmHost))

--- a/distribution/registry_unit_test.go
+++ b/distribution/registry_unit_test.go
@@ -69,7 +69,7 @@ func testTokenPassThru(t *testing.T, ts *httptest.Server) {
 	}
 	p := newPuller(endpoint, repoInfo, imagePullConfig, nil)
 	ctx := context.Background()
-	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
+	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, p.config.RegistryService, "pull")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/distribution/repository.go
+++ b/distribution/repository.go
@@ -25,7 +25,7 @@ func GetRepository(ctx context.Context, ref reference.Named, config *ImagePullCo
 	}
 
 	for _, endpoint := range endpoints {
-		repository, lastError = newRepository(ctx, repoInfo, endpoint, nil, config.AuthConfig, "pull")
+		repository, lastError = newRepository(ctx, repoInfo, endpoint, nil, config.AuthConfig, config.RegistryService, "pull")
 		if lastError == nil {
 			break
 		}

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -215,7 +215,9 @@ func PingV2Registry(endpoint *url.URL, transport http.RoundTripper) (challenge.M
 		return nil, "", err
 	}
 
-	if len(challenges) == 1 {
+	challengesCount := len(challenges)
+
+	if challengesCount == 1 {
 		realm, ok := challenges[0].Parameters["realm"]
 		if ok {
 			realmURL, err := url.Parse(realm)
@@ -223,6 +225,9 @@ func PingV2Registry(endpoint *url.URL, transport http.RoundTripper) (challenge.M
 				return challengeManager, realmURL.Host, nil
 			}
 		}
+	} else if challengesCount > 1 {
+		//TODO: Support multiple challenges for loading TLS configs
+		logrus.Warnf("Multiple challenges are not yet supported for loading TLS configs")
 	}
 
 	return challengeManager, "", nil

--- a/registry/endpoint_test.go
+++ b/registry/endpoint_test.go
@@ -65,7 +65,7 @@ func TestValidateEndpoint(t *testing.T) {
 
 	testEndpoint := v1Endpoint{
 		URL:    testServerURL,
-		client: httpClient(newTransport(nil)),
+		client: httpClient(NewTransport(nil)),
 	}
 
 	if err = validateEndpoint(&testEndpoint); err != nil {

--- a/registry/endpoint_v1.go
+++ b/registry/endpoint_v1.go
@@ -36,7 +36,7 @@ type v1Endpoint struct {
 // newV1Endpoint parses the given address to return a registry endpoint.
 // TODO: remove. This is only used by search.
 func newV1Endpoint(index *registry.IndexInfo, headers http.Header) (*v1Endpoint, error) {
-	tlsConfig, err := newTLSConfig(index.Name, index.Secure)
+	tlsConfig, err := NewTLSConfig(index.Name, index.Secure)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func newV1EndpointFromStr(address string, tlsConfig *tls.Config, headers http.He
 	}
 
 	// TODO(tiborvass): make sure a ConnectTimeout transport is used
-	tr := newTransport(tlsConfig)
+	tr := NewTransport(tlsConfig)
 
 	return &v1Endpoint{
 		IsSecure: tlsConfig == nil || !tlsConfig.InsecureSkipVerify,

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -21,7 +21,7 @@ func HostCertsDir(hostname string) string {
 }
 
 // newTLSConfig constructs a client TLS configuration based on server defaults
-func newTLSConfig(hostname string, isSecure bool) (*tls.Config, error) {
+func NewTLSConfig(hostname string, isSecure bool) (*tls.Config, error) {
 	// PreferredServerCipherSuites should have no effect
 	tlsConfig := tlsconfig.ServerDefault()
 
@@ -159,7 +159,7 @@ func addRequiredHeadersToRedirectedRequests(req *http.Request, via []*http.Reque
 
 // newTransport returns a new HTTP transport. If tlsConfig is nil, it uses the
 // default TLS configuration.
-func newTransport(tlsConfig *tls.Config) *http.Transport {
+func NewTransport(tlsConfig *tls.Config) *http.Transport {
 	if tlsConfig == nil {
 		tlsConfig = tlsconfig.ServerDefault()
 	}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -22,7 +22,7 @@ func spawnTestRegistrySession(t *testing.T) *session {
 		t.Fatal(err)
 	}
 	userAgent := "docker test client"
-	var tr http.RoundTripper = debugTransport{newTransport(nil), t.Log}
+	var tr http.RoundTripper = debugTransport{NewTransport(nil), t.Log}
 	tr = transport.NewTransport(newAuthTransport(tr, authConfig, false), Headers(userAgent, nil)...)
 	client := httpClient(tr)
 

--- a/registry/search.go
+++ b/registry/search.go
@@ -117,7 +117,7 @@ func (s *Service) searchUnfiltered(ctx context.Context, term string, limit int, 
 
 		// TODO(thaJeztah); is there a reason not to include other headers here? (originally added in 19d48f0b8ba59eea9f2cac4ad1c7977712a6b7ac)
 		modifiers := Headers(headers.Get("User-Agent"), nil)
-		v2Client, err := v2AuthHTTPClient(endpoint.URL, endpoint.client.Transport, modifiers, creds, scopes)
+		v2Client, err := v2AuthHTTPClient(endpoint.URL, endpoint.client.Transport, modifiers, creds, scopes, s)
 		if err != nil {
 			return nil, err
 		}

--- a/registry/service.go
+++ b/registry/service.go
@@ -14,6 +14,7 @@ import (
 )
 
 // Service is a registry service. It tracks configuration data such as a list
+// defaultService is a registry service. It tracks configuration data such as a list
 // of mirrors.
 type Service struct {
 	config *serviceConfig
@@ -87,7 +88,7 @@ func (s *Service) Auth(ctx context.Context, authConfig *registry.AuthConfig, use
 	}
 
 	for _, endpoint := range endpoints {
-		status, token, err = loginV2(authConfig, endpoint, userAgent)
+		status, token, err = loginV2(authConfig, endpoint, userAgent, s)
 		if err == nil {
 			return
 		}

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -19,7 +19,7 @@ func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, e
 			if err != nil {
 				return nil, invalidParam(err)
 			}
-			mirrorTLSConfig, err := newTLSConfig(mirrorURL.Host, s.config.isSecureIndex(mirrorURL.Host))
+			mirrorTLSConfig, err := NewTLSConfig(mirrorURL.Host, s.config.isSecureIndex(mirrorURL.Host))
 			if err != nil {
 				return nil, err
 			}
@@ -44,7 +44,7 @@ func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, e
 		return endpoints, nil
 	}
 
-	tlsConfig, err := newTLSConfig(hostname, s.config.isSecureIndex(hostname))
+	tlsConfig, err := NewTLSConfig(hostname, s.config.isSecureIndex(hostname))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- What I did
I changed the tls config in the transport object if a token request must be sent to a token provider

- How I did it

- How to verify it
Configure a docker registry under a reverse proxy needing a client certificate authentication
Configure a token provider under a reverse proxy needing a client certificate authentication that is different with the registry
Set the client.cert and client.key files in /etc/docked/certs.d/<registry.domain>
Set the client.cert and client.key files in /etc/docked/certs.d/<token_provider.domain>
Try to login onto the registry with "docker login <registry.domain>" command
Test to push and pull images with the registry

- Description for the changelog
Fix docker daemon for using the right client certificate for authorization token request when the client certificate to user with the token provider is different from the client certificate to use with docker registry. Concerns "docker login", "docker push" and "docker pull" commands.

fixes #45327 

Reference to PR #45400  on branch 23.0
Reference to PR #45401  on branch 20.10
