### PR TITLE
[23.0 backport] Use the image service instead of the reference store for tagging

### DIFF
--- a/api/server/backend/build/backend.go
+++ b/api/server/backend/build/backend.go
@@ -92,7 +92,7 @@ func (b *Backend) Build(ctx context.Context, config backend.BuildConfig) (string
 		stdout := config.ProgressWriter.StdoutFormatter
 		fmt.Fprintf(stdout, "Successfully built %s\n", stringid.TruncateID(imageID))
 	}
-	if imageID != "" {
+	if imageID != "" && !useBuildKit {
 		err = tagger.TagImages(image.ID(imageID))
 	}
 	return imageID, err

--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/builder"
+	containerimageexp "github.com/docker/docker/builder/builder-next/exporter"
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/libnetwork"
@@ -70,6 +71,7 @@ type Opt struct {
 	Root                string
 	Dist                images.DistributionServices
 	NetworkController   libnetwork.NetworkController
+	ImageTagger         containerimageexp.ImageTagger
 	DefaultCgroupParent string
 	RegistryHosts       docker.RegistryHosts
 	BuilderConfig       config.BuilderConfig

--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -159,9 +159,9 @@ func newController(rt http.RoundTripper, opt Opt) (*control.Controller, error) {
 	}
 
 	exp, err := containerimageexp.New(containerimageexp.Opt{
-		ImageStore:     dist.ImageStore,
-		ReferenceStore: dist.ReferenceStore,
-		Differ:         differ,
+		ImageStore:  dist.ImageStore,
+		Differ:      differ,
+		ImageTagger: opt.ImageTagger,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -295,6 +295,7 @@ func newRouterOptions(config *config.Config, d *daemon.Daemon) (routerOptions, e
 		SessionManager:      sm,
 		Root:                filepath.Join(config.Root, "buildkit"),
 		Dist:                d.DistributionServices(),
+		ImageTagger:         d.ImageService(),
 		NetworkController:   d.NetworkController(),
 		DefaultCgroupParent: cgroupParent,
 		RegistryHosts:       d.RegistryHosts(),


### PR DESCRIPTION
* backport of #45404

**- What I did**

Changed the way `mobyexporter` tags an image, it used to use the reference store which doesn't send image events, we now use the image service to tag the new image. This makes sure we send the "tag" event when an image is built with `buildx`.

Note: this was a long standing issue when building an image with buildx but it only came up now because buildx is the default builder since 23.0

**- How I did it**

**- How to verify it**
