### PR TITLE
[20.10 backport] Jenkinsfile: use Ubuntu 20.04

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,7 @@ pipeline {
                         beforeAgent true
                         expression { params.unit_validate }
                     }
-                    agent { label 'amd64 && ubuntu-1804 && overlay2' }
+                    agent { label 'amd64 && ubuntu-2004 && overlay2' }
                     environment {
                         // On master ("non-pull-request"), force running some validation checks (vendor, swagger),
                         // even if no files were changed. This allows catching problems caused by pull-requests
@@ -249,7 +249,7 @@ pipeline {
                         beforeAgent true
                         expression { params.amd64 }
                     }
-                    agent { label 'amd64 && ubuntu-1804 && overlay2' }
+                    agent { label 'amd64 && ubuntu-2004 && overlay2' }
 
                     stages {
                         stage("Print info") {
@@ -378,7 +378,7 @@ pipeline {
                         beforeAgent true
                         expression { params.rootless }
                     }
-                    agent { label 'amd64 && ubuntu-1804 && overlay2' }
+                    agent { label 'amd64 && ubuntu-2004 && overlay2' }
                     stages {
                         stage("Print info") {
                             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ pipeline {
                 beforeAgent true
                 expression { params.dco }
             }
-            agent { label 'amd64 && ubuntu-1804 && overlay2' }
+            agent { label 'arm64 && ubuntu-2004' }
             steps {
                 sh '''
                 docker run --rm \


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/42941

Also switching to use arm64, as all amd64 stages have moved to GitHub actions, so using arm64 allows the same machine to be used for tests after the DCO check completed.


(cherry picked from commit 419c47a80af9a0423f05592ddf7e8151cfb1eb0b)


**- A picture of a cute animal (not mandatory but encouraged)**

