### PR TITLE
integration-cli: debug TestPushToCentralRegistryUnauthorized

### DIFF
--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -232,8 +232,8 @@ func (s *DockerCLIPushSuite) TestPushToCentralRegistryUnauthorized(c *testing.T)
 	const imgRepo = "test/busybox"
 	cli.DockerCmd(c, "tag", "busybox", imgRepo)
 	out, _, err := dockerCmdWithError("push", imgRepo)
-	assert.ErrorContains(c, err, "", out)
-	assert.Assert(c, !strings.Contains(out, "Retrying"))
+	assert.Check(c, is.ErrorContains(err, ""), out)
+	assert.Check(c, !strings.Contains(out, "Retrying"), out)
 }
 
 func getTestTokenService(status int, body string, retries int) *httptest.Server {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/44234#issuecomment-1524073416
- relates to https://github.com/moby/moby/pull/45403#issuecomment-1523243828


Seeing some test-failures, which could be due to changes on Docker Hub

    === Failed
    === FAIL: github.com/docker/docker/integration-cli TestDockerCLIPushSuite/TestPushToCentralRegistryUnauthorized (51.08s)
        docker_cli_push_test.go:229: assertion failed: strings.Contains(out, "Retrying") is true

    === FAIL: github.com/docker/docker/integration-cli TestDockerCLIPushSuite (101.49s)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

