### PR TITLE
Allow for xattr copy failure for vfs

### DIFF
--- a/daemon/graphdriver/copy/copy.go
+++ b/daemon/graphdriver/copy/copy.go
@@ -116,7 +116,7 @@ type dirMtimeInfo struct {
 //
 // The copyOpaqueXattrs controls if "trusted.overlay.opaque" xattrs are copied.
 // Passing false disables copying "trusted.overlay.opaque" xattrs.
-func DirCopy(srcDir, dstDir string, copyMode Mode, copyOpaqueXattrs bool) error {
+func DirCopy(srcDir, dstDir string, copyMode Mode, copyOpaqueXattrs bool, allowXattrFailure bool) error {
 	copyWithFileRange := true
 	copyWithFileClone := true
 
@@ -210,7 +210,9 @@ func DirCopy(srcDir, dstDir string, copyMode Mode, copyOpaqueXattrs bool) error 
 		}
 
 		if err := copyXattr(srcPath, dstPath, "security.capability"); err != nil {
-			return err
+			if !allowXattrFailure {
+				return err
+			}
 		}
 
 		if copyOpaqueXattrs {

--- a/daemon/graphdriver/copy/copy_test.go
+++ b/daemon/graphdriver/copy/copy_test.go
@@ -40,7 +40,7 @@ func TestCopyDir(t *testing.T) {
 	assert.NilError(t, err)
 	defer os.RemoveAll(dstDir)
 
-	assert.Check(t, DirCopy(srcDir, dstDir, Content, false))
+	assert.Check(t, DirCopy(srcDir, dstDir, Content, false, true))
 	assert.NilError(t, filepath.Walk(srcDir, func(srcPath string, f os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -146,7 +146,7 @@ func TestCopyHardlink(t *testing.T) {
 	assert.NilError(t, os.WriteFile(srcFile1, []byte{}, 0777))
 	assert.NilError(t, os.Link(srcFile1, srcFile2))
 
-	assert.Check(t, DirCopy(srcDir, dstDir, Content, false))
+	assert.Check(t, DirCopy(srcDir, dstDir, Content, false, true))
 
 	assert.NilError(t, unix.Stat(srcFile1, &srcFile1FileInfo))
 	assert.NilError(t, unix.Stat(srcFile2, &srcFile2FileInfo))

--- a/daemon/graphdriver/vfs/copy_linux.go
+++ b/daemon/graphdriver/vfs/copy_linux.go
@@ -3,5 +3,5 @@ package vfs // import "github.com/docker/docker/daemon/graphdriver/vfs"
 import "github.com/docker/docker/daemon/graphdriver/copy"
 
 func dirCopy(srcDir, dstDir string) error {
-	return copy.DirCopy(srcDir, dstDir, copy.Content, false)
+	return copy.DirCopy(srcDir, dstDir, copy.Content, false, true)
 }


### PR DESCRIPTION
vfs is declared to work with any filesystem, but after https://github.com/moby/moby/commit/31f654a704f61768828d5950a13f30bb493d1239 it's no longer working with NFS.

As the extended attribute support depends on filesystem and if we do copy it in vfs and do not allow failure, that would essentially mean that vfs does NOT support all filesystems but only those that support xattr.

So we should just try to copy security.capabilities and allow for failure. In this way, vfs come back to the state of being able to run on any filesystem as declared in https://docs.docker.com/storage/storagedriver/select-storage-driver/.

Fixes https://github.com/moby/moby/issues/45417

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

