### PR TITLE
libnetwork: remove redundant init(), remove dead code, and fix stubs / build-tags

### DIFF
--- a/libnetwork/drivers/overlay/overlayutils/utils.go
+++ b/libnetwork/drivers/overlay/overlayutils/utils.go
@@ -8,14 +8,10 @@ import (
 
 var (
 	mutex        sync.RWMutex
-	vxlanUDPPort uint32
+	vxlanUDPPort = defaultVXLANUDPPort
 )
 
-const defaultVXLANUDPPort = 4789
-
-func init() {
-	vxlanUDPPort = defaultVXLANUDPPort
-}
+const defaultVXLANUDPPort uint32 = 4789
 
 // ConfigVXLANUDPPort configures the VXLAN UDP port (data path port) number.
 // If no port is set, the default (4789) is returned. Valid port numbers are

--- a/libnetwork/drivers_unsupported.go
+++ b/libnetwork/drivers_unsupported.go
@@ -1,0 +1,8 @@
+//go:build !freebsd && !linux && !windows
+// +build !freebsd,!linux,!windows
+
+package libnetwork
+
+func getInitializers() []initializer {
+	return nil
+}

--- a/libnetwork/osl/interface_freebsd.go
+++ b/libnetwork/osl/interface_freebsd.go
@@ -1,4 +1,0 @@
-package osl
-
-// IfaceOption is a function option type to set interface options
-type IfaceOption func()

--- a/libnetwork/osl/interface_linux.go
+++ b/libnetwork/osl/interface_linux.go
@@ -14,9 +14,6 @@ import (
 	"github.com/vishvananda/netns"
 )
 
-// IfaceOption is a function option type to set interface options
-type IfaceOption func(i *nwIface)
-
 type nwIface struct {
 	srcName     string
 	dstName     string

--- a/libnetwork/osl/interface_unsupported.go
+++ b/libnetwork/osl/interface_unsupported.go
@@ -1,0 +1,6 @@
+//go:build !linux
+// +build !linux
+
+package osl
+
+type nwIface struct{}

--- a/libnetwork/osl/interface_windows.go
+++ b/libnetwork/osl/interface_windows.go
@@ -1,4 +1,0 @@
-package osl
-
-// IfaceOption is a function option type to set interface options
-type IfaceOption func()

--- a/libnetwork/osl/namespace_linux.go
+++ b/libnetwork/osl/namespace_linux.go
@@ -600,29 +600,29 @@ func (n *networkNamespace) checkLoV6() {
 }
 
 func setIPv6(nspath, iface string, enable bool) error {
-	origns, err := netns.Get()
+	origNS, err := netns.Get()
 	if err != nil {
 		return fmt.Errorf("failed to get current network namespace: %w", err)
 	}
-	defer origns.Close()
+	defer origNS.Close()
 
-	ns, err := netns.GetFromPath(nspath)
+	namespace, err := netns.GetFromPath(nspath)
 	if err != nil {
 		return fmt.Errorf("failed get network namespace %q: %w", nspath, err)
 	}
-	defer ns.Close()
+	defer namespace.Close()
 
 	errCh := make(chan error, 1)
 	go func() {
 		defer close(errCh)
 
 		runtime.LockOSThread()
-		if err = netns.Set(ns); err != nil {
+		if err = netns.Set(namespace); err != nil {
 			errCh <- fmt.Errorf("setting into container netns %q failed: %w", nspath, err)
 			return
 		}
 		defer func() {
-			if err := netns.Set(origns); err != nil {
+			if err := netns.Set(origNS); err != nil {
 				logrus.WithError(err).Error("libnetwork: restoring thread network namespace failed")
 				// The error is only fatal for the current thread. Keep this
 				// goroutine locked to the thread to make the runtime replace it

--- a/libnetwork/osl/neigh_freebsd.go
+++ b/libnetwork/osl/neigh_freebsd.go
@@ -1,4 +1,0 @@
-package osl
-
-// NeighOption is a function option type to set neighbor options
-type NeighOption func()

--- a/libnetwork/osl/neigh_linux.go
+++ b/libnetwork/osl/neigh_linux.go
@@ -20,9 +20,6 @@ func (n NeighborSearchError) Error() string {
 	return fmt.Sprintf("Search neighbor failed for IP %v, mac %v, present in db:%t", n.ip, n.mac, n.present)
 }
 
-// NeighOption is a function option type to set interface options
-type NeighOption func(nh *neigh)
-
 type neigh struct {
 	dstIP    net.IP
 	dstMac   net.HardwareAddr

--- a/libnetwork/osl/neigh_unsupported.go
+++ b/libnetwork/osl/neigh_unsupported.go
@@ -1,0 +1,6 @@
+//go:build !linux
+// +build !linux
+
+package osl
+
+type neigh struct{}

--- a/libnetwork/osl/neigh_windows.go
+++ b/libnetwork/osl/neigh_windows.go
@@ -1,4 +1,0 @@
-package osl
-
-// NeighOption is a function option type to set neighbor options
-type NeighOption func()

--- a/libnetwork/osl/sandbox.go
+++ b/libnetwork/osl/sandbox.go
@@ -20,6 +20,9 @@ const (
 // IfaceOption is a function option type to set interface options.
 type IfaceOption func(i *nwIface)
 
+// NeighOption is a function option type to set neighbor options.
+type NeighOption func(nh *neigh)
+
 // Sandbox represents a network sandbox, identified by a specific key.  It
 // holds a list of Interfaces, routes etc, and more can be added dynamically.
 type Sandbox interface {

--- a/libnetwork/osl/sandbox.go
+++ b/libnetwork/osl/sandbox.go
@@ -17,6 +17,9 @@ const (
 	SandboxTypeLoadBalancer = iota
 )
 
+// IfaceOption is a function option type to set interface options.
+type IfaceOption func(i *nwIface)
+
 // Sandbox represents a network sandbox, identified by a specific key.  It
 // holds a list of Interfaces, routes etc, and more can be added dynamically.
 type Sandbox interface {

--- a/libnetwork/service_unsupported.go
+++ b/libnetwork/service_unsupported.go
@@ -4,23 +4,22 @@
 package libnetwork
 
 import (
-	"fmt"
+	"errors"
 	"net"
 )
 
-func (c *Controller) cleanupServiceBindings(nid string) {
-}
+func (c *Controller) cleanupServiceDiscovery(cleanupNID string) {}
+
+func (c *Controller) cleanupServiceBindings(nid string) {}
 
 func (c *Controller) addServiceBinding(name, sid, nid, eid string, vip net.IP, ingressPorts []*PortConfig, aliases []string, ip net.IP) error {
-	return fmt.Errorf("not supported")
+	return errors.New("not supported")
 }
 
 func (c *Controller) rmServiceBinding(name, sid, nid, eid string, vip net.IP, ingressPorts []*PortConfig, aliases []string, ip net.IP) error {
-	return fmt.Errorf("not supported")
+	return errors.New("not supported")
 }
 
-func (sb *sandbox) populateLoadBalancers(ep *endpoint) {
-}
+func (sb *Sandbox) populateLoadBalancers(*Endpoint) {}
 
-func arrangeIngressFilterRule() {
-}
+func arrangeIngressFilterRule() {}


### PR DESCRIPTION
- relates to / some bits extracted from https://github.com/moby/moby/pull/43506


### libnetwork: overlayutils: remove redundant init()

### libnetwork: fix stubs

- sandbox, endpoint changed in https://github.com/moby/moby/commit/c71555f03042ca531e24f6368d7e8c128774926f (https://github.com/moby/moby/pull/44805), but  missed updating the stubs.
- add missing stub for `Controller.cleanupServiceDiscovery()`
- While at it also doing some minor (formatting) changes.

### libnetwork: add missing stub for getInitializers()

### libnetwork: remove dead code on Windows

These methods are only called on unix.

### libnetwork/osl: rename var that collided with import

Also renaming another var for consistency ':-)

### libnetwork/osl: unify stubs for IfaceOption

Use the same signature for all platforms, but stub the nwIface type.

### libnetwork/osl: unify stubs for NeighOption

Use the same signature for all platforms, but stub the neigh type.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

