### PR TITLE
daemon/containerd: containerConfigToOciImageConfig: add ArgsEscaped

### DIFF
--- a/daemon/containerd/image_import.go
+++ b/daemon/containerd/image_import.go
@@ -383,14 +383,15 @@ func storeJson(ctx context.Context, cs content.Ingester, mt string, obj interfac
 
 func containerConfigToOciImageConfig(cfg *container.Config) ocispec.ImageConfig {
 	ociCfg := ocispec.ImageConfig{
-		User:       cfg.User,
-		Env:        cfg.Env,
-		Entrypoint: cfg.Entrypoint,
-		Cmd:        cfg.Cmd,
-		Volumes:    cfg.Volumes,
-		WorkingDir: cfg.WorkingDir,
-		Labels:     cfg.Labels,
-		StopSignal: cfg.StopSignal,
+		User:        cfg.User,
+		Env:         cfg.Env,
+		Entrypoint:  cfg.Entrypoint,
+		Cmd:         cfg.Cmd,
+		Volumes:     cfg.Volumes,
+		WorkingDir:  cfg.WorkingDir,
+		Labels:      cfg.Labels,
+		StopSignal:  cfg.StopSignal,
+		ArgsEscaped: cfg.ArgsEscaped,
 	}
 	for k, v := range cfg.ExposedPorts {
 		ociCfg.ExposedPorts[string(k)] = v


### PR DESCRIPTION
- relates to https://github.com/opencontainers/image-spec/pull/892


The OCI image-spec now also provides ArgsEscaped for backward compatibility with the option used by Docker.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

