### PR TITLE
c8d: commit: generateCommitImageConfig: don't merge image config

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -53,16 +53,14 @@ func (s *containerRouter) postCommit(ctx context.Context, w http.ResponseWriter,
 		return errdefs.InvalidParameter(err)
 	}
 
-	commitCfg := &backend.CreateImageConfig{
+	imgID, err := s.backend.CreateImageFromContainer(ctx, r.Form.Get("container"), &backend.CreateImageConfig{
 		Pause:   pause,
 		Tag:     ref,
 		Author:  r.Form.Get("author"),
 		Comment: r.Form.Get("comment"),
 		Config:  config,
 		Changes: r.Form["changes"],
-	}
-
-	imgID, err := s.backend.CreateImageFromContainer(ctx, r.Form.Get("container"), commitCfg)
+	})
 	if err != nil {
 		return err
 	}

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -132,13 +132,11 @@ func (daemon *Daemon) CreateImageFromContainer(ctx context.Context, name string,
 	}
 
 	if container.IsDead() {
-		err := fmt.Errorf("You cannot commit container %s which is Dead", container.ID)
-		return "", errdefs.Conflict(err)
+		return "", errdefs.Conflict(fmt.Errorf("You cannot commit container %s which is Dead", container.ID))
 	}
 
 	if container.IsRemovalInProgress() {
-		err := fmt.Errorf("You cannot commit container %s which is being removed", container.ID)
-		return "", errdefs.Conflict(err)
+		return "", errdefs.Conflict(fmt.Errorf("You cannot commit container %s which is being removed", container.ID))
 	}
 
 	if c.Pause && !container.IsPaused() {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/45322
- relates to https://github.com/moby/moby/pull/45322#discussion_r1168830490


daemon.CreateImageFromContainer() already constructs a new config by taking the image config, applying custom options (`docker commit --change ..`) (if any), and merging those with the containers' configuration, so there is no need to merge options again.

https://github.com/moby/moby/blob/e22758bfb2d615f67512336f121c677d099b3269/daemon/commit.go#L152-L158

This patch removes the merge logic from generateCommitImageConfig, and removes the unused arguments and error-return.


**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

