### PR TITLE
d/graphdriver/copy: support src fs w/o xattr support

### DIFF
--- a/daemon/graphdriver/copy/copy.go
+++ b/daemon/graphdriver/copy/copy.go
@@ -5,6 +5,7 @@ package copy // import "github.com/docker/docker/daemon/graphdriver/copy"
 
 import (
 	"container/list"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -90,6 +91,11 @@ func legacyCopy(srcFile io.Reader, dstFile io.Writer) error {
 func copyXattr(srcPath, dstPath, attr string) error {
 	data, err := system.Lgetxattr(srcPath, attr)
 	if err != nil {
+		if errors.Is(err, syscall.EOPNOTSUPP) {
+			// Task failed successfully: there is no xattr to copy
+			// if the source filesystem doesn't support xattrs.
+			return nil
+		}
 		return err
 	}
 	if data != nil {


### PR DESCRIPTION
- Fixes #45417
- Closes #45420

Treat copying extended attributes from a source filesystem which does not support extended attributes as a no-op, same as if the file did not possess the extended attribute. Only fail copying extended attributes if the source file has the attribute and the destination filesystem does not support xattrs.

cc @ChenQi1989

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

