### PR TITLE
Fail unpacking images with xattrs to filesystems without xattr support

### DIFF
--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -16,6 +16,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	xattrsStorageOpt         = "vfs.xattrs"
+	bestEffortXattrsOptValue = "i_want_broken_containers"
+)
+
 var (
 	// CopyDir defines the copy method to use.
 	CopyDir = dirCopy
@@ -51,7 +56,11 @@ func Init(home string, options []string, idMap idtools.IdentityMapping) (graphdr
 		return nil, quota.ErrQuotaNotSupported
 	}
 
-	return graphdriver.NewNaiveDiffDriver(d, d.idMapping), nil
+	return &graphdriver.NaiveDiffDriver{
+		ProtoDriver:      d,
+		IDMap:            d.idMapping,
+		BestEffortXattrs: d.bestEffortXattrs,
+	}, nil
 }
 
 // Driver holds information about the driver, home directory of the driver.
@@ -60,16 +69,24 @@ func Init(home string, options []string, idMap idtools.IdentityMapping) (graphdr
 // Driver must be wrapped in NaiveDiffDriver to be used as a graphdriver.Driver
 type Driver struct {
 	driverQuota
-	home      string
-	idMapping idtools.IdentityMapping
+	home             string
+	idMapping        idtools.IdentityMapping
+	bestEffortXattrs bool
 }
 
 func (d *Driver) String() string {
 	return "vfs"
 }
 
-// Status is used for implementing the graphdriver.ProtoDriver interface. VFS does not currently have any status information.
+// Status is used for implementing the graphdriver.ProtoDriver interface.
 func (d *Driver) Status() [][2]string {
+	if d.bestEffortXattrs {
+		return [][2]string{
+			// These strings are looked for in daemon/info_unix.go:fillDriverWarnings()
+			// because plumbing is hard and temporary is forever. Forgive me.
+			{"Extended file attributes", "best-effort"},
+		}
+	}
 	return nil
 }
 
@@ -98,6 +115,11 @@ func (d *Driver) parseOptions(options []string) error {
 			if err = d.setQuotaOpt(uint64(size)); err != nil {
 				return errdefs.InvalidParameter(errors.Wrap(err, "failed to set option size for vfs"))
 			}
+		case xattrsStorageOpt:
+			if val != bestEffortXattrsOptValue {
+				return errdefs.InvalidParameter(errors.Errorf("do not set the " + xattrsStorageOpt + " option unless you are willing to accept the consequences"))
+			}
+			d.bestEffortXattrs = true
 		default:
 			return errdefs.InvalidParameter(errors.Errorf("unknown option %s for vfs", key))
 		}

--- a/daemon/graphdriver/vfs/vfs_test.go
+++ b/daemon/graphdriver/vfs/vfs_test.go
@@ -4,8 +4,19 @@
 package vfs // import "github.com/docker/docker/daemon/graphdriver/vfs"
 
 import (
+	"archive/tar"
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
 	"testing"
 
+	"github.com/moby/sys/mount"
+	"gotest.tools/v3/assert"
+
+	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/daemon/graphdriver/graphtest"
 )
 
@@ -33,4 +44,72 @@ func TestVfsSetQuota(t *testing.T) {
 
 func TestVfsTeardown(t *testing.T) {
 	graphtest.PutDriver(t)
+}
+
+func TestXattrUnsupportedByBackingFS(t *testing.T) {
+	rootdir := t.TempDir()
+	// The ramfs filesystem is unconditionally compiled into the kernel,
+	// and does not support extended attributes.
+	err := mount.Mount("ramfs", rootdir, "ramfs", "")
+	if errors.Is(err, syscall.EPERM) {
+		t.Skip("test requires the ability to mount a filesystem")
+	}
+	assert.NilError(t, err)
+	defer mount.Unmount(rootdir)
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	const (
+		filename = "test.txt"
+		content  = "hello world\n"
+	)
+	assert.NilError(t, tw.WriteHeader(&tar.Header{
+		Name: filename,
+		Mode: 0o644,
+		Size: int64(len(content)),
+		PAXRecords: map[string]string{
+			"SCHILY.xattr.user.test": "helloxattr",
+		},
+	}))
+	_, err = io.WriteString(tw, content)
+	assert.NilError(t, err)
+	assert.NilError(t, tw.Close())
+	testlayer := buf.Bytes()
+
+	for _, tt := range []struct {
+		name        string
+		opts        []string
+		expectErrIs error
+	}{
+		{
+			name:        "Default",
+			expectErrIs: syscall.EOPNOTSUPP,
+		},
+		{
+			name: "xattrs=i_want_broken_containers",
+			opts: []string{"xattrs=i_want_broken_containers"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			subdir := filepath.Join(rootdir, tt.name)
+			assert.NilError(t, os.Mkdir(subdir, 0o755))
+			d, err := graphdriver.GetDriver("vfs", nil,
+				graphdriver.Options{DriverOptions: tt.opts, Root: subdir})
+			assert.NilError(t, err)
+			defer d.Cleanup()
+
+			assert.NilError(t, d.Create("test", "", nil))
+			_, err = d.ApplyDiff("test", "", bytes.NewReader(testlayer))
+			assert.ErrorIs(t, err, tt.expectErrIs)
+
+			if err == nil {
+				path, err := d.Get("test", "")
+				assert.NilError(t, err)
+				defer d.Put("test")
+				actual, err := os.ReadFile(filepath.Join(path, filename))
+				assert.NilError(t, err)
+				assert.Equal(t, string(actual), content)
+			}
+		})
+	}
 }

--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -293,6 +293,15 @@ func fillDriverWarnings(v *types.Info) {
 			v.Warnings = append(v.Warnings, msg)
 			continue
 		}
+		if pair[0] == "Extended file attributes" && pair[1] == "best-effort" {
+			msg := fmt.Sprintf("WARNING: %s: extended file attributes from container images "+
+				"will be silently discarded if the backing filesystem does not support them.\n"+
+				"         CONTAINERS MAY MALFUNCTION IF EXTENDED ATTRIBUTES ARE MISSING.\n"+
+				"         This is an UNSUPPORTABLE configuration for which no bug reports will be accepted.\n", v.Driver)
+
+			v.Warnings = append(v.Warnings, msg)
+			continue
+		}
 	}
 }
 

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -70,6 +70,12 @@ type (
 		// replaced with the matching name from this map.
 		RebaseNames map[string]string
 		InUserNS    bool
+		// Allow unpacking to succeed in spite of failures to set extended
+		// attributes on the unpacked files due to the destination filesystem
+		// not supporting them or a lack of permissions. Extended attributes
+		// were probably in the archive for a reason, so set this option at
+		// your own peril.
+		BestEffortXattrs bool
 	}
 )
 
@@ -666,7 +672,19 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 	return nil
 }
 
-func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, Lchown bool, chownOpts *idtools.Identity, inUserns bool) error {
+func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, opts *TarOptions) error {
+	var (
+		Lchown                     = true
+		inUserns, bestEffortXattrs bool
+		chownOpts                  *idtools.Identity
+	)
+	if opts != nil {
+		Lchown = !opts.NoLchown
+		inUserns = opts.InUserNS
+		chownOpts = opts.ChownOpts
+		bestEffortXattrs = opts.BestEffortXattrs
+	}
+
 	// hdr.Mode is in linux format, which we can use for sycalls,
 	// but for os.Foo() calls we need the mode converted to os.FileMode,
 	// so use hdrInfo.Mode() (they differ for e.g. setuid bits)
@@ -760,11 +778,7 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 	var xattrErrs []string
 	for key, value := range hdr.Xattrs {
 		if err := system.Lsetxattr(path, key, []byte(value), 0); err != nil {
-			if errors.Is(err, syscall.ENOTSUP) || errors.Is(err, syscall.EPERM) {
-				// We ignore errors here because not all graphdrivers support
-				// xattrs *cough* old versions of AUFS *cough*. However only
-				// ENOTSUP should be emitted in that case, otherwise we still
-				// bail.
+			if bestEffortXattrs && errors.Is(err, syscall.ENOTSUP) || errors.Is(err, syscall.EPERM) {
 				// EPERM occurs if modifying xattrs is not allowed. This can
 				// happen when running in userns with restrictions (ChromeOS).
 				xattrErrs = append(xattrErrs, err.Error())
@@ -1158,7 +1172,7 @@ loop:
 			}
 		}
 
-		if err := createTarFile(path, dest, hdr, trBuf, !options.NoLchown, options.ChownOpts, options.InUserNS); err != nil {
+		if err := createTarFile(path, dest, hdr, trBuf, options); err != nil {
 			return err
 		}
 

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -863,7 +863,7 @@ func TestTypeXGlobalHeaderDoesNotFail(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpDir)
-	err = createTarFile(filepath.Join(tmpDir, "pax_global_header"), tmpDir, &hdr, nil, true, nil, false)
+	err = createTarFile(filepath.Join(tmpDir, "pax_global_header"), tmpDir, &hdr, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/archive/diff.go
+++ b/pkg/archive/diff.go
@@ -92,7 +92,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 					}
 					defer os.RemoveAll(aufsTempdir)
 				}
-				if err := createTarFile(filepath.Join(aufsTempdir, basename), dest, hdr, tr, true, nil, options.InUserNS); err != nil {
+				if err := createTarFile(filepath.Join(aufsTempdir, basename), dest, hdr, tr, options); err != nil {
 					return 0, err
 				}
 			}
@@ -183,7 +183,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				return 0, err
 			}
 
-			if err := createTarFile(path, dest, srcHdr, srcData, !options.NoLchown, nil, options.InUserNS); err != nil {
+			if err := createTarFile(path, dest, srcHdr, srcData, options); err != nil {
 				return 0, err
 			}
 

--- a/pkg/system/xattrs_linux.go
+++ b/pkg/system/xattrs_linux.go
@@ -1,11 +1,19 @@
 package system // import "github.com/docker/docker/pkg/system"
 
-import "golang.org/x/sys/unix"
+import (
+	"io/fs"
+
+	"golang.org/x/sys/unix"
+)
 
 // Lgetxattr retrieves the value of the extended attribute identified by attr
 // and associated with the given path in the file system.
 // It will returns a nil slice and nil error if the xattr is not set.
 func Lgetxattr(path string, attr string) ([]byte, error) {
+	pathErr := func(err error) ([]byte, error) {
+		return nil, &fs.PathError{Op: "lgetxattr", Path: path, Err: err}
+	}
+
 	// Start with a 128 length byte array
 	dest := make([]byte, 128)
 	sz, errno := unix.Lgetxattr(path, attr, dest)
@@ -14,7 +22,7 @@ func Lgetxattr(path string, attr string) ([]byte, error) {
 		// Buffer too small, use zero-sized buffer to get the actual size
 		sz, errno = unix.Lgetxattr(path, attr, []byte{})
 		if errno != nil {
-			return nil, errno
+			return pathErr(errno)
 		}
 		dest = make([]byte, sz)
 		sz, errno = unix.Lgetxattr(path, attr, dest)
@@ -24,7 +32,7 @@ func Lgetxattr(path string, attr string) ([]byte, error) {
 	case errno == unix.ENODATA:
 		return nil, nil
 	case errno != nil:
-		return nil, errno
+		return pathErr(errno)
 	}
 
 	return dest[:sz], nil
@@ -33,5 +41,9 @@ func Lgetxattr(path string, attr string) ([]byte, error) {
 // Lsetxattr sets the value of the extended attribute identified by attr
 // and associated with the given path in the file system.
 func Lsetxattr(path string, attr string, data []byte, flags int) error {
-	return unix.Lsetxattr(path, attr, data, flags)
+	err := unix.Lsetxattr(path, attr, data, flags)
+	if err != nil {
+		return &fs.PathError{Op: "lsetxattr", Path: path, Err: err}
+	}
+	return nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Following up https://github.com/moby/moby/pull/45420#issuecomment-1535047278, I made it a fatal error to untar a file with extended attributes to a destination which does not support extended attributes. I added an escape hatch to the `vfs` graph driver to allow users to opt back into the old, broken behaviour.

**- How I did it**
I made ignoring `EPERM` and `ENOTSUPP` errors from `lsetxattr` when extracting a file from a tarball conditional on a new `BestEffortXattrs` flag in `archive.TarOptions` and plumbed the flag through to the `vfs` driver. I added a new storage option `vfs.xattrs=i_want_broken_containers` to the driver to set the flag. A warning is logged at daemon startup and in `docker info` output if this storage option is enabled.

**- How to verify it**
With the new unit test

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Unpacking layers containing files with extended attributes onto a filesystem which does not support extended attributes will now fail. Previously, the extended attributes would be discarded if they could not be set, which could potentially result in containers malfunctioning. Most storage drivers already require the backing filesystem to support extended attributes so this change should have no impact on most users. The `vfs` driver is a notable exception; the previous behaviour can be restored by configuring it with `--storage-opt vfs.xattrs=i_want_broken_containers`. Enabling this storage option is highly discouraged and bug reports submitted against a daemon with this option set will be summarily closed without comment.

**- A picture of a cute animal (not mandatory but encouraged)**

