### PR TITLE
api: synchronize api/swagger.yaml with docs/api/v1.43.yaml

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -976,6 +976,13 @@ definitions:
             items:
               type: "integer"
               minimum: 0
+          Annotations:
+            type: "object"
+            description: |
+              Arbitrary non-identifying metadata attached to container and
+              provided to the runtime when the container is started.
+            additionalProperties:
+              type: "string"
 
           # Applicable to UNIX platforms
           CapAdd:
@@ -1122,6 +1129,7 @@ definitions:
               remapping option is enabled.
           ShmSize:
             type: "integer"
+            format: "int64"
             description: |
               Size of `/dev/shm` in bytes. If omitted, the system uses 64MB.
             minimum: 0

--- a/docs/api/v1.43.yaml
+++ b/docs/api/v1.43.yaml
@@ -1618,6 +1618,34 @@ definitions:
           "WorkDir": "/var/lib/docker/overlay2/ef749362d13333e65fc95c572eb525abbe0052e16e086cb64bc3b98ae9aa6d74/work"
         }
 
+  FilesystemChange:
+    description: |
+      Change in the container's filesystem.
+    type: "object"
+    required: [Path, Kind]
+    properties:
+      Path:
+        description: |
+          Path to file or directory that has changed.
+        type: "string"
+        x-nullable: false
+      Kind:
+        $ref: "#/definitions/ChangeType"
+
+  ChangeType:
+    description: |
+      Kind of change
+
+      Can be one of:
+
+      - `0`: Modified ("C")
+      - `1`: Added ("A")
+      - `2`: Deleted ("D")
+    type: "integer"
+    format: "uint8"
+    enum: [0, 1, 2]
+    x-nullable: false
+
   ImageInspect:
     description: |
       Information about an image in the local image cache.
@@ -1754,15 +1782,14 @@ definitions:
           Total size of the image including all layers it is composed of.
 
           In versions of Docker before v1.10, this field was calculated from
-          the image itself and all of its parent images. Docker v1.10 and up
-          store images self-contained, and no longer use a parent-chain, making
-          this field an equivalent of the Size field.
+          the image itself and all of its parent images. Images are now stored
+          self-contained, and no longer use a parent-chain, making this field
+          an equivalent of the Size field.
 
-          This field is kept for backward compatibility, but may be removed in
-          a future version of the API.
+          > **Deprecated**: this field is kept for backward compatibility, but
+          > will be removed in API v1.44.
         type: "integer"
         format: "int64"
-        x-nullable: false
         example: 1239828
       GraphDriver:
         $ref: "#/definitions/GraphDriverData"
@@ -1810,7 +1837,6 @@ definitions:
       - Created
       - Size
       - SharedSize
-      - VirtualSize
       - Labels
       - Containers
     properties:
@@ -1896,19 +1922,17 @@ definitions:
         x-nullable: false
         example: 1239828
       VirtualSize:
-        description: |
+        description: |-
           Total size of the image including all layers it is composed of.
 
           In versions of Docker before v1.10, this field was calculated from
-          the image itself and all of its parent images. Docker v1.10 and up
-          store images self-contained, and no longer use a parent-chain, making
-          this field an equivalent of the Size field.
+          the image itself and all of its parent images. Images are now stored
+          self-contained, and no longer use a parent-chain, making this field
+          an equivalent of the Size field.
 
-          This field is kept for backward compatibility, but may be removed in
-          a future version of the API.
+          Deprecated: this field is kept for backward compatibility, and will be removed in API v1.44.
         type: "integer"
         format: "int64"
-        x-nullable: false
         example: 172064416
       Labels:
         description: "User-defined key/value metadata."
@@ -4660,7 +4684,8 @@ definitions:
         example: false
       OOMKilled:
         description: |
-          Whether this container has been killed because it ran out of memory.
+          Whether a process within this container has been killed because it ran
+          out of memory since the container was last started.
         type: "boolean"
         example: false
       Dead:
@@ -5250,7 +5275,8 @@ definitions:
       SecurityOptions:
         description: |
           List of security features that are enabled on the daemon, such as
-          apparmor, seccomp, SELinux, user-namespaces (userns), and rootless.
+          apparmor, seccomp, SELinux, user-namespaces (userns), rootless and
+          no-new-privileges.
 
           Additional configuration options for each security feature may
           be present, and are included as a comma-separated list of key/value
@@ -6883,9 +6909,9 @@ paths:
         Returns which files in a container's filesystem have been added, deleted,
         or modified. The `Kind` of modification can be one of:
 
-        - `0`: Modified
-        - `1`: Added
-        - `2`: Deleted
+        - `0`: Modified ("C")
+        - `1`: Added ("A")
+        - `2`: Deleted ("D")
       operationId: "ContainerChanges"
       produces: ["application/json"]
       responses:
@@ -6894,22 +6920,7 @@ paths:
           schema:
             type: "array"
             items:
-              type: "object"
-              x-go-name: "ContainerChangeResponseItem"
-              title: "ContainerChangeResponseItem"
-              description: "change item in response to ContainerChanges operation"
-              required: [Path, Kind]
-              properties:
-                Path:
-                  description: "Path to file that has changed"
-                  type: "string"
-                  x-nullable: false
-                Kind:
-                  description: "Kind of change"
-                  type: "integer"
-                  format: "uint8"
-                  enum: [0, 1, 2]
-                  x-nullable: false
+              $ref: "#/definitions/FilesystemChange"
           examples:
             application/json:
               - Path: "/dev"
@@ -8236,7 +8247,7 @@ paths:
 
             Available filters:
 
-            - `until=<duration>`: duration relative to daemon's time, during which build cache was not used, in Go's duration format (e.g., '24h')
+            - `until=<timestamp>` remove cache older than `<timestamp>`. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon's local time.
             - `id=<id>`
             - `parent=<id>`
             - `type=<string>`


### PR DESCRIPTION
- forward-port changes from 0ffaa6c7858f0a5d85318efda43a2d20a684eae2 to api/swagger.yaml (v1.44-dev) (https://github.com/moby/moby/pull/45025)
- backports the changes to v1.43;
  - Update container OOMKilled flag immediately 57d2d6ef621cc126ca904e8fc98fbacbd345790a (https://github.com/moby/moby/pull/43564)
  - Add no-new-privileges to SecurityOptions returned by /info eb7738221c3b6a6a1c1f46e4f38357473feddfc4 (https://github.com/moby/moby/pull/45320)
  - API: deprecate VirtualSize field for /images/json and /images/{id}/json 1261fe69a3586bb102182aa885197822419c768c (https://github.com/moby/moby/pull/45346)
  - api/types/container: create type for changes endpoint dbb48e4b29e124aef6716ee8ad6856bf696235ca (https://github.com/moby/moby/pull/45353)
  - builder-next/prune: Handle "until" filter timestamps 54a125f67703ab51ed8a004b625439dfafa7aa6c (https://github.com/moby/moby/pull/45294)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

