### PR TITLE
API: omit deprecated VirtualSize field for API v1.44 and up

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -263,6 +263,10 @@ func (ir *imageRouter) getImagesByName(ctx context.Context, w http.ResponseWrite
 		return err
 	}
 
+	version := httputils.VersionFromContext(ctx)
+	if versions.LessThan(version, "1.44") {
+		imageInspect.VirtualSize = imageInspect.Size //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.44.
+	}
 	return httputils.WriteJSON(w, http.StatusOK, imageInspect)
 }
 
@@ -299,7 +303,6 @@ func (ir *imageRouter) toImageInspect(img *image.Image) (*types.ImageInspect, er
 		Os:              img.OperatingSystem(),
 		OsVersion:       img.OSVersion,
 		Size:            img.Details.Size,
-		VirtualSize:     img.Details.Size, //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.44.
 		GraphDriver: types.GraphDriverData{
 			Name: img.Details.Driver,
 			Data: img.Details.Metadata,
@@ -357,6 +360,7 @@ func (ir *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter,
 	}
 
 	useNone := versions.LessThan(version, "1.43")
+	withVirtualSize := versions.LessThan(version, "1.44")
 	for _, img := range images {
 		if useNone {
 			if len(img.RepoTags) == 0 && len(img.RepoDigests) == 0 {
@@ -370,6 +374,9 @@ func (ir *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter,
 			if img.RepoDigests == nil {
 				img.RepoDigests = []string{}
 			}
+		}
+		if withVirtualSize {
+			img.VirtualSize = img.Size //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.44.
 		}
 	}
 

--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -185,6 +185,11 @@ func (s *systemRouter) getDiskUsage(ctx context.Context, w http.ResponseWriter, 
 			b.Parent = "" //nolint:staticcheck // ignore SA1019 (Parent field is deprecated)
 		}
 	}
+	if versions.LessThan(version, "1.44") {
+		for _, b := range systemDiskUsage.Images {
+			b.VirtualSize = b.Size //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.44.
+		}
+	}
 
 	du := types.DiskUsage{
 		BuildCache:  buildCache,

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1781,13 +1781,7 @@ definitions:
         description: |
           Total size of the image including all layers it is composed of.
 
-          In versions of Docker before v1.10, this field was calculated from
-          the image itself and all of its parent images. Images are now stored
-          self-contained, and no longer use a parent-chain, making this field
-          an equivalent of the Size field.
-
-          > **Deprecated**: this field is kept for backward compatibility, but
-          > will be removed in API v1.44.
+          Deprecated: this field is omitted in API v1.44, but kept for backward compatibility. Use Size instead.
         type: "integer"
         format: "int64"
         example: 1239828
@@ -1925,12 +1919,7 @@ definitions:
         description: |-
           Total size of the image including all layers it is composed of.
 
-          In versions of Docker before v1.10, this field was calculated from
-          the image itself and all of its parent images. Images are now stored
-          self-contained, and no longer use a parent-chain, making this field
-          an equivalent of the Size field.
-
-          Deprecated: this field is kept for backward compatibility, and will be removed in API v1.44.
+          Deprecated: this field is omitted in API v1.44, but kept for backward compatibility. Use Size instead.
         type: "integer"
         format: "int64"
         example: 172064416
@@ -9066,7 +9055,6 @@ paths:
                   Created: 1466724217
                   Size: 1092588
                   SharedSize: 0
-                  VirtualSize: 1092588
                   Labels: {}
                   Containers: 1
               Containers:

--- a/api/types/image_summary.go
+++ b/api/types/image_summary.go
@@ -84,11 +84,6 @@ type ImageSummary struct {
 
 	// Total size of the image including all layers it is composed of.
 	//
-	// In versions of Docker before v1.10, this field was calculated from
-	// the image itself and all of its parent images. Images are now stored
-	// self-contained, and no longer use a parent-chain, making this field
-	// an equivalent of the Size field.
-	//
-	// Deprecated: this field is kept for backward compatibility, and will be removed in API v1.44.
+	// Deprecated: this field is omitted in API v1.44, but kept for backward compatibility. Use Size instead.
 	VirtualSize int64 `json:"VirtualSize,omitempty"`
 }

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -118,12 +118,7 @@ type ImageInspect struct {
 	// VirtualSize is the total size of the image including all layers it is
 	// composed of.
 	//
-	// In versions of Docker before v1.10, this field was calculated from
-	// the image itself and all of its parent images. Docker v1.10 and up
-	// store images self-contained, and no longer use a parent-chain, making
-	// this field an equivalent of the Size field.
-	//
-	// Deprecated: Unused in API 1.43 and up, but kept for backward compatibility with older API versions.
+	// Deprecated: this field is omitted in API v1.44, but kept for backward compatibility. Use Size instead.
 	VirtualSize int64 `json:"VirtualSize,omitempty"`
 
 	// GraphDriver holds information about the storage driver used to store the

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -250,7 +250,6 @@ func (i *ImageService) singlePlatformImage(ctx context.Context, contentStore con
 		RepoDigests: repoDigests,
 		RepoTags:    repoTags,
 		Size:        totalSize,
-		VirtualSize: totalSize, //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.44.
 		// -1 indicates that the value has not been set (avoids ambiguity
 		// between 0 (default) and "not set". We cannot use a pointer (nil)
 		// for this, as the JSON representation uses "omitempty", which would

--- a/daemon/images/image_list.go
+++ b/daemon/images/image_list.go
@@ -257,11 +257,10 @@ func (i *ImageService) Images(ctx context.Context, opts types.ImageListOptions) 
 
 func newImageSummary(image *image.Image, size int64) *types.ImageSummary {
 	summary := &types.ImageSummary{
-		ParentID:    image.Parent.String(),
-		ID:          image.ID().String(),
-		Created:     image.Created.Unix(),
-		Size:        size,
-		VirtualSize: size, //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.44.
+		ParentID: image.Parent.String(),
+		ID:       image.ID().String(),
+		Created:  image.Created.Unix(),
+		Size:     size,
 		// -1 indicates that the value has not been set (avoids ambiguity
 		// between 0 (default) and "not set". We cannot use a pointer (nil)
 		// for this, as the JSON representation uses "omitempty", which would

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -17,6 +17,10 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.44](https://docs.docker.com/engine/api/v1.44/) documentation
 
+* The `VirtualSize` field in the `GET /images/{name}/json`, `GET /images/json`,
+  and `GET /system/df` responses is now omitted. Use the `Size` field instead,
+  which contains the same information.
+
 ## v1.43 API changes
 
 [Docker Engine API v1.43](https://docs.docker.com/engine/api/v1.43/) documentation

--- a/integration/system/disk_usage_test.go
+++ b/integration/system/disk_usage_test.go
@@ -57,11 +57,10 @@ func TestDiskUsage(t *testing.T) {
 					LayersSize: du.LayersSize,
 					Images: []*types.ImageSummary{
 						{
-							Created:     du.Images[0].Created,
-							ID:          du.Images[0].ID,
-							RepoTags:    []string{"busybox:latest"},
-							Size:        du.LayersSize,
-							VirtualSize: du.LayersSize, //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.44.
+							Created:  du.Images[0].Created,
+							ID:       du.Images[0].ID,
+							RepoTags: []string{"busybox:latest"},
+							Size:     du.LayersSize,
 						},
 					},
 					Containers: []*types.Container{},


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/45346
- [x] depends on https://github.com/moby/moby/pull/45467
- [x] depends on https://github.com/moby/moby/pull/45468


This field is deprecated since 1261fe69a3586bb102182aa885197822419c768c,
and will now be omitted on API v1.44 and up for the `GET /images/json`
and `GET /images/{id}/json` endpoints.

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

