### PR TITLE
remove pre-go1.17 build-tags

### DIFF
--- a/api/common_unix.go
+++ b/api/common_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package api // import "github.com/docker/docker/api"
 

--- a/api/types/container/hostconfig_unix.go
+++ b/api/types/container/hostconfig_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package container // import "github.com/docker/docker/api/types/container"
 

--- a/api/types/container/hostconfig_unix_test.go
+++ b/api/types/container/hostconfig_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package container
 

--- a/builder/builder-next/executor_unix.go
+++ b/builder/builder-next/executor_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package buildkit
 

--- a/builder/builder-next/worker/gc_unix.go
+++ b/builder/builder-next/worker/gc_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package worker
 

--- a/builder/builder-next/worker/gc_windows.go
+++ b/builder/builder-next/worker/gc_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package worker
 

--- a/builder/dockerfile/builder_unix.go
+++ b/builder/dockerfile/builder_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package dockerfile // import "github.com/docker/docker/builder/dockerfile"
 

--- a/builder/dockerfile/copy_unix.go
+++ b/builder/dockerfile/copy_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package dockerfile // import "github.com/docker/docker/builder/dockerfile"
 

--- a/builder/dockerfile/dispatchers_unix.go
+++ b/builder/dockerfile/dispatchers_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package dockerfile // import "github.com/docker/docker/builder/dockerfile"
 

--- a/builder/dockerfile/dispatchers_unix_test.go
+++ b/builder/dockerfile/dispatchers_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package dockerfile // import "github.com/docker/docker/builder/dockerfile"
 

--- a/builder/dockerfile/dispatchers_windows_test.go
+++ b/builder/dockerfile/dispatchers_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package dockerfile // import "github.com/docker/docker/builder/dockerfile"
 

--- a/builder/dockerfile/internals_windows_test.go
+++ b/builder/dockerfile/internals_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package dockerfile // import "github.com/docker/docker/builder/dockerfile"
 

--- a/client/client_unix.go
+++ b/client/client_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package client // import "github.com/docker/docker/client"
 

--- a/cmd/dockerd/config_unix.go
+++ b/cmd/dockerd/config_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package main
 

--- a/cmd/dockerd/config_unix_test.go
+++ b/cmd/dockerd/config_unix_test.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package main
 

--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/cmd/dockerd/daemon_unix_test.go
+++ b/cmd/dockerd/daemon_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/cmd/dockerd/docker_unix.go
+++ b/cmd/dockerd/docker_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/cmd/dockerd/service_unsupported.go
+++ b/cmd/dockerd/service_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/cmd/dockerd/trap/trap_linux_test.go
+++ b/cmd/dockerd/trap/trap_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package trap // import "github.com/docker/docker/cmd/dockerd/trap"
 

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package container // import "github.com/docker/docker/container"
 

--- a/container/mounts_unix.go
+++ b/container/mounts_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package container // import "github.com/docker/docker/container"
 

--- a/daemon/apparmor_default.go
+++ b/daemon/apparmor_default.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/apparmor_default_unsupported.go
+++ b/daemon/apparmor_default_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/archive_tarcopyoptions_unix.go
+++ b/daemon/archive_tarcopyoptions_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/archive_unix.go
+++ b/daemon/archive_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/cluster/executor/container/health_test.go
+++ b/daemon/cluster/executor/container/health_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package container // import "github.com/docker/docker/daemon/cluster/executor/container"
 

--- a/daemon/cluster/executor/container/validate_unix_test.go
+++ b/daemon/cluster/executor/container/validate_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package container // import "github.com/docker/docker/daemon/cluster/executor/container"
 

--- a/daemon/cluster/executor/container/validate_windows_test.go
+++ b/daemon/cluster/executor/container/validate_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package container // import "github.com/docker/docker/daemon/cluster/executor/container"
 import (

--- a/daemon/cluster/listen_addr_others.go
+++ b/daemon/cluster/listen_addr_others.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package cluster // import "github.com/docker/docker/daemon/cluster"
 

--- a/daemon/configs_unsupported.go
+++ b/daemon/configs_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !windows
-// +build !linux,!windows
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/container_unix_test.go
+++ b/daemon/container_unix_test.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package daemon
 

--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/daemon_linux_test.go
+++ b/daemon/daemon_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/daemon_unix_test.go
+++ b/daemon/daemon_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/daemon_unsupported.go
+++ b/daemon/daemon_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !freebsd && !windows
-// +build !linux,!freebsd,!windows
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/daemon_windows_test.go
+++ b/daemon/daemon_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/debugtrap_unix.go
+++ b/daemon/debugtrap_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/debugtrap_unsupported.go
+++ b/daemon/debugtrap_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !darwin && !freebsd && !windows
-// +build !linux,!darwin,!freebsd,!windows
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/exec_linux_test.go
+++ b/daemon/exec_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package daemon
 

--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package btrfs // import "github.com/docker/docker/daemon/graphdriver/btrfs"
 

--- a/daemon/graphdriver/btrfs/btrfs_test.go
+++ b/daemon/graphdriver/btrfs/btrfs_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package btrfs // import "github.com/docker/docker/daemon/graphdriver/btrfs"
 

--- a/daemon/graphdriver/btrfs/dummy_unsupported.go
+++ b/daemon/graphdriver/btrfs/dummy_unsupported.go
@@ -1,4 +1,3 @@
 //go:build !linux || !cgo
-// +build !linux !cgo
 
 package btrfs // import "github.com/docker/docker/daemon/graphdriver/btrfs"

--- a/daemon/graphdriver/driver_unsupported.go
+++ b/daemon/graphdriver/driver_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !windows && !freebsd
-// +build !linux,!windows,!freebsd
 
 package graphdriver // import "github.com/docker/docker/daemon/graphdriver"
 

--- a/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs.go
+++ b/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package fuseoverlayfs // import "github.com/docker/docker/daemon/graphdriver/fuse-overlayfs"
 

--- a/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs_test.go
+++ b/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package fuseoverlayfs // import "github.com/docker/docker/daemon/graphdriver/fuse-overlayfs"
 

--- a/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs_unsupported.go
+++ b/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs_unsupported.go
@@ -1,4 +1,3 @@
 //go:build !linux
-// +build !linux
 
 package fuseoverlayfs // import "github.com/docker/docker/daemon/graphdriver/fuse-overlayfs"

--- a/daemon/graphdriver/graphtest/graphbench_unix.go
+++ b/daemon/graphdriver/graphtest/graphbench_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package graphtest // import "github.com/docker/docker/daemon/graphdriver/graphtest"
 

--- a/daemon/graphdriver/graphtest/graphtest_unix.go
+++ b/daemon/graphdriver/graphtest/graphtest_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package graphtest // import "github.com/docker/docker/daemon/graphdriver/graphtest"
 

--- a/daemon/graphdriver/graphtest/testutil_unix.go
+++ b/daemon/graphdriver/graphtest/testutil_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package graphtest // import "github.com/docker/docker/daemon/graphdriver/graphtest"
 

--- a/daemon/graphdriver/overlay2/check.go
+++ b/daemon/graphdriver/overlay2/check.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package overlay2 // import "github.com/docker/docker/daemon/graphdriver/overlay2"
 

--- a/daemon/graphdriver/overlay2/mount.go
+++ b/daemon/graphdriver/overlay2/mount.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package overlay2 // import "github.com/docker/docker/daemon/graphdriver/overlay2"
 

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package overlay2 // import "github.com/docker/docker/daemon/graphdriver/overlay2"
 

--- a/daemon/graphdriver/overlay2/overlay_test.go
+++ b/daemon/graphdriver/overlay2/overlay_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package overlay2 // import "github.com/docker/docker/daemon/graphdriver/overlay2"
 

--- a/daemon/graphdriver/overlay2/overlay_unsupported.go
+++ b/daemon/graphdriver/overlay2/overlay_unsupported.go
@@ -1,4 +1,3 @@
 //go:build !linux
-// +build !linux
 
 package overlay2 // import "github.com/docker/docker/daemon/graphdriver/overlay2"

--- a/daemon/graphdriver/register/register_btrfs.go
+++ b/daemon/graphdriver/register/register_btrfs.go
@@ -1,5 +1,4 @@
 //go:build !exclude_graphdriver_btrfs && linux
-// +build !exclude_graphdriver_btrfs,linux
 
 package register // import "github.com/docker/docker/daemon/graphdriver/register"
 

--- a/daemon/graphdriver/register/register_fuseoverlayfs.go
+++ b/daemon/graphdriver/register/register_fuseoverlayfs.go
@@ -1,5 +1,4 @@
 //go:build !exclude_graphdriver_fuseoverlayfs && linux
-// +build !exclude_graphdriver_fuseoverlayfs,linux
 
 package register // import "github.com/docker/docker/daemon/graphdriver/register"
 

--- a/daemon/graphdriver/register/register_overlay2.go
+++ b/daemon/graphdriver/register/register_overlay2.go
@@ -1,5 +1,4 @@
 //go:build !exclude_graphdriver_overlay2 && linux
-// +build !exclude_graphdriver_overlay2,linux
 
 package register // import "github.com/docker/docker/daemon/graphdriver/register"
 

--- a/daemon/graphdriver/register/register_zfs.go
+++ b/daemon/graphdriver/register/register_zfs.go
@@ -1,5 +1,4 @@
 //go:build (!exclude_graphdriver_zfs && linux) || (!exclude_graphdriver_zfs && freebsd)
-// +build !exclude_graphdriver_zfs,linux !exclude_graphdriver_zfs,freebsd
 
 package register // import "github.com/docker/docker/daemon/graphdriver/register"
 

--- a/daemon/graphdriver/vfs/copy_unsupported.go
+++ b/daemon/graphdriver/vfs/copy_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package vfs // import "github.com/docker/docker/daemon/graphdriver/vfs"
 

--- a/daemon/graphdriver/vfs/quota_unsupported.go
+++ b/daemon/graphdriver/vfs/quota_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package vfs // import "github.com/docker/docker/daemon/graphdriver/vfs"
 

--- a/daemon/graphdriver/vfs/vfs_test.go
+++ b/daemon/graphdriver/vfs/vfs_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package vfs // import "github.com/docker/docker/daemon/graphdriver/vfs"
 

--- a/daemon/graphdriver/zfs/zfs.go
+++ b/daemon/graphdriver/zfs/zfs.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package zfs // import "github.com/docker/docker/daemon/graphdriver/zfs"
 

--- a/daemon/graphdriver/zfs/zfs_test.go
+++ b/daemon/graphdriver/zfs/zfs_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package zfs // import "github.com/docker/docker/daemon/graphdriver/zfs"
 

--- a/daemon/graphdriver/zfs/zfs_unsupported.go
+++ b/daemon/graphdriver/zfs/zfs_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !freebsd
-// +build !linux,!freebsd
 
 package zfs // import "github.com/docker/docker/daemon/graphdriver/zfs"
 

--- a/daemon/images/image_unix.go
+++ b/daemon/images/image_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package images // import "github.com/docker/docker/daemon/images"
 

--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/info_unix_test.go
+++ b/daemon/info_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/keys.go
+++ b/daemon/keys.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/keys_unsupported.go
+++ b/daemon/keys_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/list_unix.go
+++ b/daemon/list_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/listeners/group_unix.go
+++ b/daemon/listeners/group_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package listeners // import "github.com/docker/docker/daemon/listeners"
 

--- a/daemon/logger/gelf/gelf_test.go
+++ b/daemon/logger/gelf/gelf_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package gelf // import "github.com/docker/docker/daemon/logger/gelf"
 

--- a/daemon/logger/journald/internal/sdjournal/sdjournal.go
+++ b/daemon/logger/journald/internal/sdjournal/sdjournal.go
@@ -1,5 +1,4 @@
 //go:build linux && cgo && !static_build && journald
-// +build linux,cgo,!static_build,journald
 
 package sdjournal // import "github.com/docker/docker/daemon/logger/journald/internal/sdjournal"
 

--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package journald // import "github.com/docker/docker/daemon/logger/journald"
 

--- a/daemon/logger/journald/journald_test.go
+++ b/daemon/logger/journald/journald_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package journald // import "github.com/docker/docker/daemon/logger/journald"
 

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -1,5 +1,4 @@
 //go:build linux && cgo && !static_build && journald
-// +build linux,cgo,!static_build,journald
 
 package journald // import "github.com/docker/docker/daemon/logger/journald"
 

--- a/daemon/logger/journald/read_test.go
+++ b/daemon/logger/journald/read_test.go
@@ -1,5 +1,4 @@
 //go:build linux && cgo && !static_build && journald
-// +build linux,cgo,!static_build,journald
 
 package journald // import "github.com/docker/docker/daemon/logger/journald"
 

--- a/daemon/logger/loggerutils/file_unix.go
+++ b/daemon/logger/loggerutils/file_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package loggerutils
 

--- a/daemon/logger/loggerutils/logfile_race_test.go
+++ b/daemon/logger/loggerutils/logfile_race_test.go
@@ -1,5 +1,4 @@
 //go:build race
-// +build race
 
 package loggerutils // import "github.com/docker/docker/daemon/logger/loggerutils"
 

--- a/daemon/logger/plugin_unix.go
+++ b/daemon/logger/plugin_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package logger // import "github.com/docker/docker/daemon/logger"
 

--- a/daemon/logger/plugin_unsupported.go
+++ b/daemon/logger/plugin_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !freebsd
-// +build !linux,!freebsd
 
 package logger // import "github.com/docker/docker/daemon/logger"
 

--- a/daemon/metrics_unix.go
+++ b/daemon/metrics_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/metrics_unsupported.go
+++ b/daemon/metrics_unsupported.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/network/filter_test.go
+++ b/daemon/network/filter_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package network // import "github.com/docker/docker/daemon/network"
 

--- a/daemon/reload_unix.go
+++ b/daemon/reload_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/resize_test.go
+++ b/daemon/resize_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package daemon
 

--- a/daemon/runtime_unix.go
+++ b/daemon/runtime_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package daemon
 

--- a/daemon/runtime_unix_test.go
+++ b/daemon/runtime_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package daemon
 

--- a/daemon/seccomp_unsupported.go
+++ b/daemon/seccomp_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/secrets_unsupported.go
+++ b/daemon/secrets_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !windows
-// +build !linux,!windows
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/start_unix.go
+++ b/daemon/start_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/stats/collector_unix.go
+++ b/daemon/stats/collector_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package stats // import "github.com/docker/docker/daemon/stats"
 

--- a/daemon/stats_unix.go
+++ b/daemon/stats_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/top_unix.go
+++ b/daemon/top_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/top_unix_test.go
+++ b/daemon/top_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/distribution/pull_v2_unix.go
+++ b/distribution/pull_v2_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package distribution // import "github.com/docker/docker/distribution"
 

--- a/integration-cli/docker_api_build_windows_test.go
+++ b/integration-cli/docker_api_build_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package main
 

--- a/integration-cli/docker_api_containers_unix_test.go
+++ b/integration-cli/docker_api_containers_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/docker_api_containers_windows_test.go
+++ b/integration-cli/docker_api_containers_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package main
 

--- a/integration-cli/docker_api_swarm_node_test.go
+++ b/integration-cli/docker_api_swarm_node_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/docker_api_swarm_service_test.go
+++ b/integration-cli/docker_api_swarm_service_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/docker_cli_attach_unix_test.go
+++ b/integration-cli/docker_cli_attach_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/docker_cli_build_unix_test.go
+++ b/integration-cli/docker_cli_build_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/docker_cli_cp_to_container_unix_test.go
+++ b/integration-cli/docker_cli_cp_to_container_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/docker_cli_daemon_plugins_test.go
+++ b/integration-cli/docker_cli_daemon_plugins_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package main
 

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package main
 

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/docker_cli_exec_unix_test.go
+++ b/integration-cli/docker_cli_exec_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/docker_cli_info_unix_test.go
+++ b/integration-cli/docker_cli_info_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/docker_cli_prune_unix_test.go
+++ b/integration-cli/docker_cli_prune_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/docker_cli_save_load_unix_test.go
+++ b/integration-cli/docker_cli_save_load_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/docker_cli_service_create_test.go
+++ b/integration-cli/docker_cli_service_create_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/docker_cli_service_health_test.go
+++ b/integration-cli/docker_cli_service_health_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/docker_cli_service_logs_test.go
+++ b/integration-cli/docker_cli_service_logs_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/docker_cli_service_scale_test.go
+++ b/integration-cli/docker_cli_service_scale_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/docker_cli_swarm_unix_test.go
+++ b/integration-cli/docker_cli_swarm_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/docker_cli_update_unix_test.go
+++ b/integration-cli/docker_cli_update_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/docker_cli_userns_test.go
+++ b/integration-cli/docker_cli_userns_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/docker_deprecated_api_v124_unix_test.go
+++ b/integration-cli/docker_deprecated_api_v124_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/requirements_unix_test.go
+++ b/integration-cli/requirements_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/test_vars_unix_test.go
+++ b/integration-cli/test_vars_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration-cli/test_vars_windows_test.go
+++ b/integration-cli/test_vars_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package main
 

--- a/integration-cli/utils_unix_test.go
+++ b/integration-cli/utils_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/integration/image/remove_unix_test.go
+++ b/integration/image/remove_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package image // import "github.com/docker/docker/integration/image"
 

--- a/integration/internal/requirement/requirement_windows.go
+++ b/integration/internal/requirement/requirement_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package requirement // import "github.com/docker/docker/integration/internal/requirement"
 

--- a/integration/network/helpers.go
+++ b/integration/network/helpers.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package network
 

--- a/integration/network/ipvlan/ipvlan_test.go
+++ b/integration/network/ipvlan/ipvlan_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package ipvlan // import "github.com/docker/docker/integration/network/ipvlan"
 

--- a/integration/network/ipvlan/main_test.go
+++ b/integration/network/ipvlan/main_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package ipvlan // import "github.com/docker/docker/integration/network/ipvlan"
 

--- a/integration/network/macvlan/macvlan_test.go
+++ b/integration/network/macvlan/macvlan_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package macvlan // import "github.com/docker/docker/integration/network/macvlan"
 

--- a/integration/network/macvlan/main_test.go
+++ b/integration/network/macvlan/main_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package macvlan // import "github.com/docker/docker/integration/network/macvlan"
 

--- a/integration/plugin/authz/authz_plugin_test.go
+++ b/integration/plugin/authz/authz_plugin_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package authz // import "github.com/docker/docker/integration/plugin/authz"
 

--- a/integration/plugin/authz/authz_plugin_v2_test.go
+++ b/integration/plugin/authz/authz_plugin_v2_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package authz // import "github.com/docker/docker/integration/plugin/authz"
 

--- a/integration/plugin/authz/main_test.go
+++ b/integration/plugin/authz/main_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package authz // import "github.com/docker/docker/integration/plugin/authz"
 

--- a/integration/plugin/logging/validation_test.go
+++ b/integration/plugin/logging/validation_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package logging
 

--- a/integration/system/info_linux_test.go
+++ b/integration/system/info_linux_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package system // import "github.com/docker/docker/integration/system"
 

--- a/layer/layer_unix.go
+++ b/layer/layer_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd || darwin || openbsd
-// +build linux freebsd darwin openbsd
 
 package layer // import "github.com/docker/docker/layer"
 

--- a/layer/layer_unix_test.go
+++ b/layer/layer_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package layer // import "github.com/docker/docker/layer"
 

--- a/libnetwork/drivers/bridge/bridge.go
+++ b/libnetwork/drivers/bridge/bridge.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/bridge_store.go
+++ b/libnetwork/drivers/bridge/bridge_store.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/bridge_test.go
+++ b/libnetwork/drivers/bridge/bridge_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/errors.go
+++ b/libnetwork/drivers/bridge/errors.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/interface.go
+++ b/libnetwork/drivers/bridge/interface.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/interface_test.go
+++ b/libnetwork/drivers/bridge/interface_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/link.go
+++ b/libnetwork/drivers/bridge/link.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/link_test.go
+++ b/libnetwork/drivers/bridge/link_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/network_test.go
+++ b/libnetwork/drivers/bridge/network_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/port_mapping.go
+++ b/libnetwork/drivers/bridge/port_mapping.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/port_mapping_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/setup.go
+++ b/libnetwork/drivers/bridge/setup.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/setup_bridgenetfiltering.go
+++ b/libnetwork/drivers/bridge/setup_bridgenetfiltering.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/setup_bridgenetfiltering_test.go
+++ b/libnetwork/drivers/bridge/setup_bridgenetfiltering_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/setup_device.go
+++ b/libnetwork/drivers/bridge/setup_device.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/setup_device_test.go
+++ b/libnetwork/drivers/bridge/setup_device_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/setup_firewalld.go
+++ b/libnetwork/drivers/bridge/setup_firewalld.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/setup_ip_forwarding.go
+++ b/libnetwork/drivers/bridge/setup_ip_forwarding.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/setup_ip_forwarding_test.go
+++ b/libnetwork/drivers/bridge/setup_ip_forwarding_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/setup_ip_tables.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/setup_ip_tables_test.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/setup_ipv4.go
+++ b/libnetwork/drivers/bridge/setup_ipv4.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/setup_ipv4_test.go
+++ b/libnetwork/drivers/bridge/setup_ipv4_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/setup_ipv6.go
+++ b/libnetwork/drivers/bridge/setup_ipv6.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/setup_ipv6_test.go
+++ b/libnetwork/drivers/bridge/setup_ipv6_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/setup_verify.go
+++ b/libnetwork/drivers/bridge/setup_verify.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/bridge/setup_verify_test.go
+++ b/libnetwork/drivers/bridge/setup_verify_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package bridge
 

--- a/libnetwork/drivers/overlay/encryption.go
+++ b/libnetwork/drivers/overlay/encryption.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package overlay
 

--- a/libnetwork/drivers/overlay/joinleave.go
+++ b/libnetwork/drivers/overlay/joinleave.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package overlay
 

--- a/libnetwork/drivers/overlay/ostweaks_unsupported.go
+++ b/libnetwork/drivers/overlay/ostweaks_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package overlay
 

--- a/libnetwork/drivers/overlay/ov_endpoint.go
+++ b/libnetwork/drivers/overlay/ov_endpoint.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package overlay
 

--- a/libnetwork/drivers/overlay/ov_network.go
+++ b/libnetwork/drivers/overlay/ov_network.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package overlay
 

--- a/libnetwork/drivers/overlay/ov_utils.go
+++ b/libnetwork/drivers/overlay/ov_utils.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package overlay
 

--- a/libnetwork/drivers/overlay/overlay.go
+++ b/libnetwork/drivers/overlay/overlay.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package overlay
 

--- a/libnetwork/drivers/overlay/overlay_test.go
+++ b/libnetwork/drivers/overlay/overlay_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package overlay
 

--- a/libnetwork/drivers/overlay/peerdb.go
+++ b/libnetwork/drivers/overlay/peerdb.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package overlay
 

--- a/libnetwork/drivers/overlay/peerdb_test.go
+++ b/libnetwork/drivers/overlay/peerdb_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package overlay
 

--- a/libnetwork/drivers/windows/port_mapping.go
+++ b/libnetwork/drivers/windows/port_mapping.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package windows
 

--- a/libnetwork/drivers/windows/windows.go
+++ b/libnetwork/drivers/windows/windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // Shim for the Host Network Service (HNS) to manage networking for
 // Windows Server containers and Hyper-V containers. This module

--- a/libnetwork/drivers/windows/windows_store.go
+++ b/libnetwork/drivers/windows/windows_store.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package windows
 

--- a/libnetwork/drivers/windows/windows_test.go
+++ b/libnetwork/drivers/windows/windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package windows
 

--- a/libnetwork/drivers_unsupported.go
+++ b/libnetwork/drivers_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !freebsd && !linux && !windows
-// +build !freebsd,!linux,!windows
 
 package libnetwork
 

--- a/libnetwork/endpoint_info_unix.go
+++ b/libnetwork/endpoint_info_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package libnetwork
 

--- a/libnetwork/endpoint_info_windows.go
+++ b/libnetwork/endpoint_info_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package libnetwork
 

--- a/libnetwork/endpoint_test.go
+++ b/libnetwork/endpoint_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package libnetwork
 

--- a/libnetwork/firewall_others.go
+++ b/libnetwork/firewall_others.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package libnetwork
 

--- a/libnetwork/ipams/builtin/builtin_unix.go
+++ b/libnetwork/ipams/builtin/builtin_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd || darwin
-// +build linux freebsd darwin
 
 package builtin
 

--- a/libnetwork/ipams/builtin/builtin_windows.go
+++ b/libnetwork/ipams/builtin/builtin_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package builtin
 

--- a/libnetwork/libnetwork_test.go
+++ b/libnetwork/libnetwork_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package libnetwork_test
 

--- a/libnetwork/libnetwork_unix_test.go
+++ b/libnetwork/libnetwork_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package libnetwork_test
 

--- a/libnetwork/netutils/utils_linux.go
+++ b/libnetwork/netutils/utils_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Network utility functions.
 

--- a/libnetwork/network_unix.go
+++ b/libnetwork/network_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package libnetwork
 

--- a/libnetwork/network_windows.go
+++ b/libnetwork/network_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package libnetwork
 

--- a/libnetwork/osl/interface_unsupported.go
+++ b/libnetwork/osl/interface_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package osl
 

--- a/libnetwork/osl/kernel/knobs_unsupported.go
+++ b/libnetwork/osl/kernel/knobs_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package kernel
 

--- a/libnetwork/osl/namespace_unsupported.go
+++ b/libnetwork/osl/namespace_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !windows && !freebsd
-// +build !linux,!windows,!freebsd
 
 package osl
 

--- a/libnetwork/osl/neigh_unsupported.go
+++ b/libnetwork/osl/neigh_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package osl
 

--- a/libnetwork/osl/sandbox_unsupported.go
+++ b/libnetwork/osl/sandbox_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !windows && !freebsd
-// +build !linux,!windows,!freebsd
 
 package osl
 

--- a/libnetwork/osl/sandbox_unsupported_test.go
+++ b/libnetwork/osl/sandbox_unsupported_test.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package osl
 

--- a/libnetwork/portallocator/portallocator_unix.go
+++ b/libnetwork/portallocator/portallocator_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package portallocator
 

--- a/libnetwork/resolvconf/resolvconf_unix_test.go
+++ b/libnetwork/resolvconf/resolvconf_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package resolvconf
 

--- a/libnetwork/resolver_unix.go
+++ b/libnetwork/resolver_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package libnetwork
 

--- a/libnetwork/resolver_windows.go
+++ b/libnetwork/resolver_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package libnetwork
 

--- a/libnetwork/sandbox_dns_unix.go
+++ b/libnetwork/sandbox_dns_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package libnetwork
 

--- a/libnetwork/sandbox_dns_windows.go
+++ b/libnetwork/sandbox_dns_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package libnetwork
 

--- a/libnetwork/sandbox_externalkey_unix.go
+++ b/libnetwork/sandbox_externalkey_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package libnetwork
 

--- a/libnetwork/sandbox_externalkey_unsupported.go
+++ b/libnetwork/sandbox_externalkey_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !freebsd
-// +build !linux,!freebsd
 
 package libnetwork
 

--- a/libnetwork/service_common.go
+++ b/libnetwork/service_common.go
@@ -1,5 +1,4 @@
 //go:build linux || windows
-// +build linux windows
 
 package libnetwork
 

--- a/libnetwork/service_unsupported.go
+++ b/libnetwork/service_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !windows
-// +build !linux,!windows
 
 package libnetwork
 

--- a/libnetwork/testutils/context_unix.go
+++ b/libnetwork/testutils/context_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package testutils
 

--- a/oci/caps/utils_other.go
+++ b/oci/caps/utils_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package caps // import "github.com/docker/docker/oci/caps"
 

--- a/oci/seccomp_test.go
+++ b/oci/seccomp_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package oci
 

--- a/opts/hosts_unix.go
+++ b/opts/hosts_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package opts // import "github.com/docker/docker/opts"
 

--- a/pkg/archive/archive_other.go
+++ b/pkg/archive/archive_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package archive // import "github.com/docker/docker/pkg/archive"
 

--- a/pkg/archive/archive_unix.go
+++ b/pkg/archive/archive_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package archive // import "github.com/docker/docker/pkg/archive"
 

--- a/pkg/archive/archive_unix_test.go
+++ b/pkg/archive/archive_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package archive // import "github.com/docker/docker/pkg/archive"
 

--- a/pkg/archive/archive_windows_test.go
+++ b/pkg/archive/archive_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package archive // import "github.com/docker/docker/pkg/archive"
 

--- a/pkg/archive/changes_other.go
+++ b/pkg/archive/changes_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package archive // import "github.com/docker/docker/pkg/archive"
 

--- a/pkg/archive/changes_unix.go
+++ b/pkg/archive/changes_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package archive // import "github.com/docker/docker/pkg/archive"
 

--- a/pkg/archive/copy_unix.go
+++ b/pkg/archive/copy_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package archive // import "github.com/docker/docker/pkg/archive"
 

--- a/pkg/archive/copy_unix_test.go
+++ b/pkg/archive/copy_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // TODO Windows: Some of these tests may be salvageable and portable to Windows.
 

--- a/pkg/archive/diff_unix.go
+++ b/pkg/archive/diff_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package archive
 

--- a/pkg/archive/example_changes.go
+++ b/pkg/archive/example_changes.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 // Simple tool to create an archive stream from an old and new directory
 //

--- a/pkg/archive/path_unix.go
+++ b/pkg/archive/path_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package archive
 

--- a/pkg/archive/time_unsupported.go
+++ b/pkg/archive/time_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package archive // import "github.com/docker/docker/pkg/archive"
 

--- a/pkg/authorization/authz_unix_test.go
+++ b/pkg/authorization/authz_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // TODO Windows: This uses a Unix socket for testing. This might be possible
 // to port to Windows using a named pipe instead.

--- a/pkg/authorization/middleware_unix_test.go
+++ b/pkg/authorization/middleware_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package authorization // import "github.com/docker/docker/pkg/authorization"
 

--- a/pkg/chrootarchive/archive_unix.go
+++ b/pkg/chrootarchive/archive_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
 

--- a/pkg/chrootarchive/archive_unix_test.go
+++ b/pkg/chrootarchive/archive_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package chrootarchive
 

--- a/pkg/chrootarchive/diff_unix.go
+++ b/pkg/chrootarchive/diff_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
 

--- a/pkg/containerfs/containerfs_unix.go
+++ b/pkg/containerfs/containerfs_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package containerfs // import "github.com/docker/docker/pkg/containerfs"
 

--- a/pkg/containerfs/rm.go
+++ b/pkg/containerfs/rm.go
@@ -1,5 +1,4 @@
 //go:build !darwin && !windows
-// +build !darwin,!windows
 
 package containerfs // import "github.com/docker/docker/pkg/containerfs"
 

--- a/pkg/containerfs/rm_nodarwin_test.go
+++ b/pkg/containerfs/rm_nodarwin_test.go
@@ -1,5 +1,4 @@
 //go:build !darwin
-// +build !darwin
 
 package containerfs // import "github.com/docker/docker/pkg/containerfs"
 

--- a/pkg/containerfs/rm_test.go
+++ b/pkg/containerfs/rm_test.go
@@ -1,5 +1,4 @@
 //go:build !darwin && !windows
-// +build !darwin,!windows
 
 package containerfs // import "github.com/docker/docker/pkg/containerfs"
 

--- a/pkg/directory/directory_unix.go
+++ b/pkg/directory/directory_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd || darwin
-// +build linux freebsd darwin
 
 package directory // import "github.com/docker/docker/pkg/directory"
 

--- a/pkg/fileutils/fileutils_unix.go
+++ b/pkg/fileutils/fileutils_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package fileutils // import "github.com/docker/docker/pkg/fileutils"
 

--- a/pkg/homedir/homedir_others.go
+++ b/pkg/homedir/homedir_others.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package homedir // import "github.com/docker/docker/pkg/homedir"
 

--- a/pkg/homedir/homedir_unix.go
+++ b/pkg/homedir/homedir_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package homedir // import "github.com/docker/docker/pkg/homedir"
 

--- a/pkg/idtools/idtools_unix.go
+++ b/pkg/idtools/idtools_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package idtools // import "github.com/docker/docker/pkg/idtools"
 

--- a/pkg/idtools/idtools_unix_test.go
+++ b/pkg/idtools/idtools_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package idtools // import "github.com/docker/docker/pkg/idtools"
 

--- a/pkg/idtools/usergroupadd_unsupported.go
+++ b/pkg/idtools/usergroupadd_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package idtools // import "github.com/docker/docker/pkg/idtools"
 

--- a/pkg/idtools/utils_unix.go
+++ b/pkg/idtools/utils_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package idtools // import "github.com/docker/docker/pkg/idtools"
 

--- a/pkg/meminfo/meminfo_unix_test.go
+++ b/pkg/meminfo/meminfo_unix_test.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package meminfo
 

--- a/pkg/meminfo/meminfo_unsupported.go
+++ b/pkg/meminfo/meminfo_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !windows
-// +build !linux,!windows
 
 package meminfo
 

--- a/pkg/parsers/kernel/kernel.go
+++ b/pkg/parsers/kernel/kernel.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // Package kernel provides helper function to get, parse and compare kernel
 // versions for different platforms.

--- a/pkg/parsers/kernel/kernel_darwin.go
+++ b/pkg/parsers/kernel/kernel_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 // Package kernel provides helper function to get, parse and compare kernel
 // versions for different platforms.

--- a/pkg/parsers/kernel/kernel_unix.go
+++ b/pkg/parsers/kernel/kernel_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd || openbsd
-// +build linux freebsd openbsd
 
 package kernel // import "github.com/docker/docker/pkg/parsers/kernel"
 

--- a/pkg/parsers/kernel/kernel_unix_test.go
+++ b/pkg/parsers/kernel/kernel_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package kernel // import "github.com/docker/docker/pkg/parsers/kernel"
 

--- a/pkg/parsers/kernel/uname_unsupported.go
+++ b/pkg/parsers/kernel/uname_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package kernel // import "github.com/docker/docker/pkg/parsers/kernel"
 

--- a/pkg/parsers/operatingsystem/operatingsystem_linux_test.go
+++ b/pkg/parsers/operatingsystem/operatingsystem_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package operatingsystem // import "github.com/docker/docker/pkg/parsers/operatingsystem"
 

--- a/pkg/parsers/operatingsystem/operatingsystem_unix.go
+++ b/pkg/parsers/operatingsystem/operatingsystem_unix.go
@@ -1,5 +1,4 @@
 //go:build freebsd || darwin
-// +build freebsd darwin
 
 package operatingsystem // import "github.com/docker/docker/pkg/parsers/operatingsystem"
 

--- a/pkg/platform/platform_unix.go
+++ b/pkg/platform/platform_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package platform // import "github.com/docker/docker/pkg/platform"
 

--- a/pkg/plugins/discovery_unix.go
+++ b/pkg/plugins/discovery_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package plugins // import "github.com/docker/docker/pkg/plugins"
 import (

--- a/pkg/plugins/discovery_unix_test.go
+++ b/pkg/plugins/discovery_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package plugins // import "github.com/docker/docker/pkg/plugins"
 

--- a/pkg/plugins/plugins_unix.go
+++ b/pkg/plugins/plugins_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package plugins // import "github.com/docker/docker/pkg/plugins"
 

--- a/pkg/process/process_unix.go
+++ b/pkg/process/process_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package process
 

--- a/pkg/reexec/command_unix.go
+++ b/pkg/reexec/command_unix.go
@@ -1,5 +1,4 @@
 //go:build freebsd || darwin
-// +build freebsd darwin
 
 package reexec // import "github.com/docker/docker/pkg/reexec"
 

--- a/pkg/reexec/command_unsupported.go
+++ b/pkg/reexec/command_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !windows && !freebsd && !darwin
-// +build !linux,!windows,!freebsd,!darwin
 
 package reexec // import "github.com/docker/docker/pkg/reexec"
 

--- a/pkg/sysinfo/numcpu_other.go
+++ b/pkg/sysinfo/numcpu_other.go
@@ -1,5 +1,4 @@
 //go:build !linux && !windows
-// +build !linux,!windows
 
 package sysinfo
 

--- a/pkg/sysinfo/sysinfo_other.go
+++ b/pkg/sysinfo/sysinfo_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package sysinfo // import "github.com/docker/docker/pkg/sysinfo"
 

--- a/pkg/system/chtimes_nowindows.go
+++ b/pkg/system/chtimes_nowindows.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package system // import "github.com/docker/docker/pkg/system"
 

--- a/pkg/system/chtimes_windows_test.go
+++ b/pkg/system/chtimes_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package system // import "github.com/docker/docker/pkg/system"
 

--- a/pkg/system/filesys_unix.go
+++ b/pkg/system/filesys_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package system // import "github.com/docker/docker/pkg/system"
 

--- a/pkg/system/lstat_unix.go
+++ b/pkg/system/lstat_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package system // import "github.com/docker/docker/pkg/system"
 

--- a/pkg/system/lstat_unix_test.go
+++ b/pkg/system/lstat_unix_test.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package system // import "github.com/docker/docker/pkg/system"
 

--- a/pkg/system/mknod.go
+++ b/pkg/system/mknod.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package system // import "github.com/docker/docker/pkg/system"
 

--- a/pkg/system/mknod_freebsd.go
+++ b/pkg/system/mknod_freebsd.go
@@ -1,5 +1,4 @@
 //go:build freebsd
-// +build freebsd
 
 package system // import "github.com/docker/docker/pkg/system"
 

--- a/pkg/system/mknod_unix.go
+++ b/pkg/system/mknod_unix.go
@@ -1,5 +1,4 @@
 //go:build !freebsd && !windows
-// +build !freebsd,!windows
 
 package system // import "github.com/docker/docker/pkg/system"
 

--- a/pkg/system/stat_bsd.go
+++ b/pkg/system/stat_bsd.go
@@ -1,5 +1,4 @@
 //go:build freebsd || netbsd
-// +build freebsd netbsd
 
 package system // import "github.com/docker/docker/pkg/system"
 

--- a/pkg/system/stat_unix.go
+++ b/pkg/system/stat_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package system // import "github.com/docker/docker/pkg/system"
 

--- a/pkg/system/stat_unix_test.go
+++ b/pkg/system/stat_unix_test.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package system // import "github.com/docker/docker/pkg/system"
 

--- a/pkg/system/utimes_unix.go
+++ b/pkg/system/utimes_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package system // import "github.com/docker/docker/pkg/system"
 

--- a/pkg/system/utimes_unix_test.go
+++ b/pkg/system/utimes_unix_test.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package system // import "github.com/docker/docker/pkg/system"
 

--- a/pkg/system/utimes_unsupported.go
+++ b/pkg/system/utimes_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !freebsd
-// +build !linux,!freebsd
 
 package system // import "github.com/docker/docker/pkg/system"
 

--- a/pkg/system/xattrs_unsupported.go
+++ b/pkg/system/xattrs_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package system // import "github.com/docker/docker/pkg/system"
 

--- a/plugin/backend_unsupported.go
+++ b/plugin/backend_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package plugin // import "github.com/docker/docker/plugin"
 

--- a/plugin/v2/plugin_unsupported.go
+++ b/plugin/v2/plugin_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package v2 // import "github.com/docker/docker/plugin/v2"
 

--- a/profiles/seccomp/generate.go
+++ b/profiles/seccomp/generate.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/profiles/seccomp/seccomp_test.go
+++ b/profiles/seccomp/seccomp_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package seccomp // import "github.com/docker/docker/profiles/seccomp"
 

--- a/quota/projectquota.go
+++ b/quota/projectquota.go
@@ -1,5 +1,4 @@
 //go:build linux && !exclude_disk_quota && cgo
-// +build linux,!exclude_disk_quota,cgo
 
 //
 // projectquota.go - implements XFS project quota controls

--- a/quota/projectquota_test.go
+++ b/quota/projectquota_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package quota // import "github.com/docker/docker/quota"
 

--- a/quota/projectquota_unsupported.go
+++ b/quota/projectquota_unsupported.go
@@ -1,5 +1,4 @@
 //go:build (linux && exclude_disk_quota) || (linux && !cgo) || !linux
-// +build linux,exclude_disk_quota linux,!cgo !linux
 
 package quota // import "github.com/docker/docker/quota"
 

--- a/quota/testhelpers.go
+++ b/quota/testhelpers.go
@@ -1,5 +1,4 @@
 //go:build linux && !exclude_disk_quota && cgo
-// +build linux,!exclude_disk_quota,cgo
 
 package quota // import "github.com/docker/docker/quota"
 

--- a/registry/config_unix.go
+++ b/registry/config_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package registry // import "github.com/docker/docker/registry"
 

--- a/runconfig/config_unix.go
+++ b/runconfig/config_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package runconfig // import "github.com/docker/docker/runconfig"
 

--- a/runconfig/hostconfig_test.go
+++ b/runconfig/hostconfig_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package runconfig // import "github.com/docker/docker/runconfig"
 

--- a/runconfig/hostconfig_unix.go
+++ b/runconfig/hostconfig_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package runconfig // import "github.com/docker/docker/runconfig"
 

--- a/runconfig/hostconfig_windows_test.go
+++ b/runconfig/hostconfig_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package runconfig // import "github.com/docker/docker/runconfig"
 

--- a/testutil/daemon/daemon_freebsd.go
+++ b/testutil/daemon/daemon_freebsd.go
@@ -1,5 +1,4 @@
 //go:build freebsd
-// +build freebsd
 
 package daemon // import "github.com/docker/docker/testutil/daemon"
 

--- a/testutil/daemon/daemon_unix.go
+++ b/testutil/daemon/daemon_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package daemon // import "github.com/docker/docker/testutil/daemon"
 

--- a/testutil/request/npipe.go
+++ b/testutil/request/npipe.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package request
 

--- a/volume/local/local_linux_test.go
+++ b/volume/local/local_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package local // import "github.com/docker/docker/volume/local"
 

--- a/volume/local/local_unix.go
+++ b/volume/local/local_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 // Package local provides the default implementation for volumes. It
 // is used to mount data volume containers and directories local to

--- a/volume/mounts/validate_unix_test.go
+++ b/volume/mounts/validate_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package mounts // import "github.com/docker/docker/volume/mounts"
 

--- a/volume/mounts/volume_unix.go
+++ b/volume/mounts/volume_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd || darwin
-// +build linux freebsd darwin
 
 package mounts // import "github.com/docker/docker/volume/mounts"
 

--- a/volume/service/default_driver.go
+++ b/volume/service/default_driver.go
@@ -1,5 +1,4 @@
 //go:build linux || windows
-// +build linux windows
 
 package service // import "github.com/docker/docker/volume/service"
 import (

--- a/volume/service/default_driver_stubs.go
+++ b/volume/service/default_driver_stubs.go
@@ -1,5 +1,4 @@
 //go:build !linux && !windows
-// +build !linux,!windows
 
 package service // import "github.com/docker/docker/volume/service"
 

--- a/volume/service/store_unix.go
+++ b/volume/service/store_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd || darwin
-// +build linux freebsd darwin
 
 package service // import "github.com/docker/docker/volume/service"
 


### PR DESCRIPTION
Removed pre-go1.17 build-tags with go fix;

    go mod init
    go fix -mod=readonly ./...
    rm go.mod

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

