### PR TITLE
docs/api: version-history: also mention /system/df for VirtualSize

### DIFF
--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -27,9 +27,9 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `GET /images/json` no longer includes hardcoded `<none>:<none>` and
   `<none>@<none>` in `RepoTags` and`RepoDigests` for untagged images.
   In such cases, empty arrays will be produced instead.
-* The `VirtualSize` field in the `GET /images/{name}/json` and `GET /images//json`
-  responses is deprecated and will no longer be included in API v1.44. Use the
-  `Size` field instead, which contains the same information.
+* The `VirtualSize` field in the `GET /images/{name}/json`, `GET /images/json`,
+  and `GET /system/df` responses is deprecated and will no longer be included
+  in API v1.44. Use the `Size` field instead, which contains the same information.
 * `GET /info` now includes `no-new-privileges` in the `SecurityOptions` string
   list when this option is enabled globally. This change is not versioned, and
   affects all API versions if the daemon has this patch.


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/45346
- relates to https://github.com/moby/moby/pull/45469

Commit 1261fe69a3586bb102182aa885197822419c768c (https://github.com/moby/moby/pull/45346) deprecated the VirtualSize field, but forgot to mention that it's also included in the /system/df endpoint.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

