### PR TITLE
fixing consistent aliases for OCI spec imports

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -21,7 +21,7 @@ import (
 	containerpkg "github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/ioutils"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/websocket"
@@ -566,7 +566,7 @@ func (s *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 		hostConfig.Annotations = nil
 	}
 
-	var platform *specs.Platform
+	var platform *ocispec.Platform
 	if versions.GreaterThanOrEqualTo(version, "1.41") {
 		if v := r.Form.Get("platform"); v != "" {
 			p, err := platforms.Parse(v)

--- a/api/server/router/distribution/distribution_routes.go
+++ b/api/server/router/distribution/distribution_routes.go
@@ -12,7 +12,7 @@ import (
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/errdefs"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -61,7 +61,7 @@ func (s *distributionRouter) getDistributionInfo(ctx context.Context, w http.Res
 		if err != nil {
 			return err
 		}
-		distributionInspect.Descriptor = v1.Descriptor{
+		distributionInspect.Descriptor = ocispec.Descriptor{
 			MediaType: descriptor.MediaType,
 			Digest:    descriptor.Digest,
 			Size:      descriptor.Size,
@@ -107,7 +107,7 @@ func (s *distributionRouter) getDistributionInfo(ctx context.Context, w http.Res
 	switch mnfstObj := mnfst.(type) {
 	case *manifestlist.DeserializedManifestList:
 		for _, m := range mnfstObj.Manifests {
-			distributionInspect.Platforms = append(distributionInspect.Platforms, v1.Platform{
+			distributionInspect.Platforms = append(distributionInspect.Platforms, ocispec.Platform{
 				Architecture: m.Platform.Architecture,
 				OS:           m.Platform.OS,
 				OSVersion:    m.Platform.OSVersion,
@@ -117,7 +117,7 @@ func (s *distributionRouter) getDistributionInfo(ctx context.Context, w http.Res
 		}
 	case *schema2.DeserializedManifest:
 		configJSON, err := blobsrvc.Get(ctx, mnfstObj.Config.Digest)
-		var platform v1.Platform
+		var platform ocispec.Platform
 		if err == nil {
 			err := json.Unmarshal(configJSON, &platform)
 			if err == nil && (platform.OS != "" || platform.Architecture != "") {
@@ -125,7 +125,7 @@ func (s *distributionRouter) getDistributionInfo(ctx context.Context, w http.Res
 			}
 		}
 	case *schema1.SignedManifest:
-		platform := v1.Platform{
+		platform := ocispec.Platform{
 			Architecture: mnfstObj.Architecture,
 			OS:           "linux",
 		}

--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/registry"
 	dockerimage "github.com/docker/docker/image"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // Backend is all the methods that need to be implemented
@@ -32,12 +32,12 @@ type imageBackend interface {
 
 type importExportBackend interface {
 	LoadImage(ctx context.Context, inTar io.ReadCloser, outStream io.Writer, quiet bool) error
-	ImportImage(ctx context.Context, ref reference.Named, platform *specs.Platform, msg string, layerReader io.Reader, changes []string) (dockerimage.ID, error)
+	ImportImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, msg string, layerReader io.Reader, changes []string) (dockerimage.ID, error)
 	ExportImage(ctx context.Context, names []string, outStream io.Writer) error
 }
 
 type registryBackend interface {
-	PullImage(ctx context.Context, image, tag string, platform *specs.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
+	PullImage(ctx context.Context, image, tag string, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
 	PushImage(ctx context.Context, ref reference.Named, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
 }
 

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -24,7 +24,7 @@ import (
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -41,7 +41,7 @@ func (ir *imageRouter) postImagesCreate(ctx context.Context, w http.ResponseWrit
 		comment     = r.Form.Get("message")
 		progressErr error
 		output      = ioutils.NewWriteFlusher(w)
-		platform    *specs.Platform
+		platform    *ocispec.Platform
 	)
 	defer output.Close()
 

--- a/api/types/backend/build.go
+++ b/api/types/backend/build.go
@@ -6,7 +6,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/pkg/streamformatter"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // PullOption defines different modes for accessing images
@@ -42,5 +42,5 @@ type GetImageAndLayerOptions struct {
 	PullOption PullOption
 	AuthConfig map[string]registry.AuthConfig
 	Output     io.Writer
-	Platform   *specs.Platform
+	Platform   *ocispec.Platform
 }

--- a/api/types/configs.go
+++ b/api/types/configs.go
@@ -3,7 +3,7 @@ package types // import "github.com/docker/docker/api/types"
 import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // configs holds structs used for internal communication between the
@@ -16,7 +16,7 @@ type ContainerCreateConfig struct {
 	Config           *container.Config
 	HostConfig       *container.HostConfig
 	NetworkingConfig *network.NetworkingConfig
-	Platform         *specs.Platform
+	Platform         *ocispec.Platform
 	AdjustCPUShares  bool
 }
 

--- a/api/types/image/opts.go
+++ b/api/types/image/opts.go
@@ -1,9 +1,9 @@
 package image
 
-import specs "github.com/opencontainers/image-spec/specs-go/v1"
+import ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 // GetImageOpts holds parameters to inspect an image.
 type GetImageOpts struct {
-	Platform *specs.Platform
+	Platform *ocispec.Platform
 	Details  bool
 }

--- a/api/types/registry/registry.go
+++ b/api/types/registry/registry.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net"
 
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // ServiceConfig stores daemon registry services configuration.
@@ -113,8 +113,8 @@ type SearchResults struct {
 type DistributionInspect struct {
 	// Descriptor contains information about the manifest, including
 	// the content addressable digest
-	Descriptor v1.Descriptor
+	Descriptor ocispec.Descriptor
 	// Platforms contains the list of platforms supported by the image,
 	// obtained by parsing the manifest
-	Platforms []v1.Platform
+	Platforms []ocispec.Platform
 }

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -21,7 +21,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/moby/buildkit/frontend/dockerfile/shell"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/syncmap"
@@ -125,7 +125,7 @@ type Builder struct {
 	pathCache        pathCache
 	containerManager *containerManager
 	imageProber      ImageProber
-	platform         *specs.Platform
+	platform         *ocispec.Platform
 }
 
 // newBuilder creates a new Dockerfile builder from an optional dockerfile and a Options.

--- a/builder/dockerfile/copy.go
+++ b/builder/dockerfile/copy.go
@@ -24,7 +24,7 @@ import (
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/pkg/system"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -74,7 +74,7 @@ type copier struct {
 	source      builder.Source
 	pathCache   pathCache
 	download    sourceDownloader
-	platform    *specs.Platform
+	platform    *ocispec.Platform
 	// for cleanup. TODO: having copier.cleanup() is error prone and hard to
 	// follow. Code calling performCopy should manage the lifecycle of its params.
 	// Copier should take override source as input, not imageMount.
@@ -86,7 +86,7 @@ func copierFromDispatchRequest(req dispatchRequest, download sourceDownloader, i
 	platform := req.builder.platform
 	if platform == nil {
 		// May be nil if not explicitly set in API/dockerfile
-		platform = &specs.Platform{}
+		platform = &ocispec.Platform{}
 	}
 	if platform.OS == "" {
 		// Default to the dispatch requests operating system if not explicit in API/dockerfile

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -28,7 +28,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/moby/buildkit/frontend/dockerfile/shell"
 	"github.com/moby/sys/signal"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -158,7 +158,7 @@ func initializeStage(ctx context.Context, d dispatchRequest, cmd *instructions.S
 		return err
 	}
 
-	var platform *specs.Platform
+	var platform *ocispec.Platform
 	if v := cmd.Platform; v != "" {
 		v, err := d.getExpandedString(d.shlex, v)
 		if err != nil {
@@ -232,7 +232,7 @@ func (d *dispatchRequest) getExpandedString(shlex *shell.Lex, str string) (strin
 	return name, nil
 }
 
-func (d *dispatchRequest) getImageOrStage(ctx context.Context, name string, platform *specs.Platform) (builder.Image, error) {
+func (d *dispatchRequest) getImageOrStage(ctx context.Context, name string, platform *ocispec.Platform) (builder.Image, error) {
 	var localOnly bool
 	if im, ok := d.stages.getByName(name); ok {
 		name = im.Image
@@ -266,7 +266,7 @@ func (d *dispatchRequest) getImageOrStage(ctx context.Context, name string, plat
 	return imageMount.Image(), nil
 }
 
-func (d *dispatchRequest) getFromImage(ctx context.Context, shlex *shell.Lex, basename string, platform *specs.Platform) (builder.Image, error) {
+func (d *dispatchRequest) getFromImage(ctx context.Context, shlex *shell.Lex, basename string, platform *ocispec.Platform) (builder.Image, error) {
 	name, err := d.getExpandedString(shlex, basename)
 	if err != nil {
 		return nil, err

--- a/builder/dockerfile/imagecontext.go
+++ b/builder/dockerfile/imagecontext.go
@@ -8,12 +8,12 @@ import (
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/builder"
 	dockerimage "github.com/docker/docker/image"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
-type getAndMountFunc func(context.Context, string, bool, *specs.Platform) (builder.Image, builder.ROLayer, error)
+type getAndMountFunc func(context.Context, string, bool, *ocispec.Platform) (builder.Image, builder.ROLayer, error)
 
 // imageSources mounts images and provides a cache for mounted images. It tracks
 // all images so they can be unmounted at the end of the build.
@@ -24,7 +24,7 @@ type imageSources struct {
 }
 
 func newImageSources(options builderOptions) *imageSources {
-	getAndMount := func(ctx context.Context, idOrRef string, localOnly bool, platform *specs.Platform) (builder.Image, builder.ROLayer, error) {
+	getAndMount := func(ctx context.Context, idOrRef string, localOnly bool, platform *ocispec.Platform) (builder.Image, builder.ROLayer, error) {
 		pullOption := backend.PullOptionNoPull
 		if !localOnly {
 			if options.Options.PullParent {
@@ -47,7 +47,7 @@ func newImageSources(options builderOptions) *imageSources {
 	}
 }
 
-func (m *imageSources) Get(ctx context.Context, idOrRef string, localOnly bool, platform *specs.Platform) (*imageMount, error) {
+func (m *imageSources) Get(ctx context.Context, idOrRef string, localOnly bool, platform *ocispec.Platform) (*imageMount, error) {
 	if im, ok := m.byImageID[idOrRef]; ok {
 		return im, nil
 	}
@@ -71,7 +71,7 @@ func (m *imageSources) Unmount() (retErr error) {
 	return
 }
 
-func (m *imageSources) Add(im *imageMount, platform *specs.Platform) {
+func (m *imageSources) Add(im *imageMount, platform *ocispec.Platform) {
 	switch im.image {
 	case nil:
 		// Set the platform for scratch images

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -19,7 +19,7 @@ import (
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/go-connections/nat"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -74,7 +74,7 @@ func (b *Builder) exportImage(state *dispatchState, layer builder.RWLayer, paren
 		return errors.Errorf("unexpected image type")
 	}
 
-	platform := &specs.Platform{
+	platform := &ocispec.Platform{
 		OS:           parentImage.OS,
 		Architecture: parentImage.Architecture,
 		Variant:      parentImage.Variant,

--- a/client/container_create.go
+++ b/client/container_create.go
@@ -9,7 +9,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/versions"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type configWrapper struct {
@@ -20,7 +20,7 @@ type configWrapper struct {
 
 // ContainerCreate creates a new container based on the given configuration.
 // It can be associated with a name, but it's not mandatory.
-func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *specs.Platform, containerName string) (container.CreateResponse, error) {
+func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
 	var response container.CreateResponse
 
 	if err := cli.NewVersionError("1.25", "stop timeout"); config != nil && config.StopTimeout != nil && err != nil {
@@ -75,7 +75,7 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 // Similar to containerd's platforms.Format(), but does allow components to be
 // omitted (e.g. pass "architecture" only, without "os":
 // https://github.com/containerd/containerd/blob/v1.5.2/platforms/platforms.go#L243-L263
-func formatPlatform(platform *specs.Platform) string {
+func formatPlatform(platform *ocispec.Platform) string {
 	if platform == nil {
 		return ""
 	}

--- a/client/interface.go
+++ b/client/interface.go
@@ -15,7 +15,7 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/volume"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // CommonAPIClient is the common methods between stable and experimental versions of APIClient.
@@ -47,7 +47,7 @@ type CommonAPIClient interface {
 type ContainerAPIClient interface {
 	ContainerAttach(ctx context.Context, container string, options types.ContainerAttachOptions) (types.HijackedResponse, error)
 	ContainerCommit(ctx context.Context, container string, options types.ContainerCommitOptions) (types.IDResponse, error)
-	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *specs.Platform, containerName string) (container.CreateResponse, error)
+	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
 	ContainerDiff(ctx context.Context, container string) ([]container.FilesystemChange, error)
 	ContainerExecAttach(ctx context.Context, execID string, config types.ExecStartCheck) (types.HijackedResponse, error)
 	ContainerExecCreate(ctx context.Context, container string, config types.ExecConfig) (types.IDResponse, error)

--- a/client/service_create_test.go
+++ b/client/service_create_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
 	"github.com/opencontainers/go-digest"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -91,10 +91,10 @@ func TestServiceCreateCompatiblePlatforms(t *testing.T) {
 				}, nil
 			} else if strings.HasPrefix(req.URL.Path, "/v1.30/distribution/") {
 				b, err := json.Marshal(registrytypes.DistributionInspect{
-					Descriptor: v1.Descriptor{
+					Descriptor: ocispec.Descriptor{
 						Digest: "sha256:c0537ff6a5218ef531ece93d4984efc99bbf3f7497c0a7726c88e2bb7584dc96",
 					},
-					Platforms: []v1.Platform{
+					Platforms: []ocispec.Platform{
 						{
 							Architecture: "amd64",
 							OS:           "linux",
@@ -171,7 +171,7 @@ func TestServiceCreateDigestPinning(t *testing.T) {
 			} else if strings.HasPrefix(req.URL.Path, "/v1.30/distribution/") {
 				// resolvable images
 				b, err := json.Marshal(registrytypes.DistributionInspect{
-					Descriptor: v1.Descriptor{
+					Descriptor: ocispec.Descriptor{
 						Digest: digest.Digest(dgst),
 					},
 				})

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -27,7 +27,7 @@ import (
 	"github.com/docker/docker/plugin"
 	volumeopts "github.com/docker/docker/volume/service/opts"
 	"github.com/moby/swarmkit/v2/agent/exec"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // Backend defines the executor component for a swarm agent.
@@ -75,7 +75,7 @@ type VolumeBackend interface {
 
 // ImageBackend is used by an executor to perform image operations
 type ImageBackend interface {
-	PullImage(ctx context.Context, image, tag string, platform *specs.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
+	PullImage(ctx context.Context, image, tag string, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
 	GetRepository(context.Context, reference.Named, *registry.AuthConfig) (distribution.Repository, error)
 	GetImage(ctx context.Context, refOrID string, options opts.GetImageOpts) (*image.Image, error)
 }

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -19,7 +19,7 @@ import (
 	"github.com/moby/buildkit/util/attestation"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -87,7 +87,7 @@ func (i *ImageService) Images(ctx context.Context, opts types.ImageListOptions) 
 			continue
 		}
 
-		err := images.Walk(ctx, images.HandlerFunc(func(ctx context.Context, desc v1.Descriptor) ([]v1.Descriptor, error) {
+		err := images.Walk(ctx, images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 			if images.IsIndexType(desc.MediaType) {
 				return images.Children(ctx, contentStore, desc)
 			}
@@ -418,7 +418,7 @@ func setupLabelFilter(store content.Store, fltrs filters.Args) (func(image image
 		// processing more content (otherwise it will run for all children).
 		// It will be returned once a matching config is found.
 		errFoundConfig := errors.New("success, found matching config")
-		err := images.Dispatch(ctx, presentChildrenHandler(store, images.HandlerFunc(func(ctx context.Context, desc v1.Descriptor) (subdescs []v1.Descriptor, err error) {
+		err := images.Dispatch(ctx, presentChildrenHandler(store, images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) (subdescs []ocispec.Descriptor, err error) {
 			if !images.IsConfigType(desc.MediaType) {
 				return nil, nil
 			}
@@ -511,8 +511,8 @@ func computeSharedSize(chainIDs []digest.Digest, layers map[digest.Digest]int, s
 
 // getManifestPlatform returns a platform specified by the manifest descriptor
 // or reads it from its config.
-func getManifestPlatform(ctx context.Context, store content.Provider, manifestDesc, configDesc v1.Descriptor) (v1.Platform, error) {
-	var platform v1.Platform
+func getManifestPlatform(ctx context.Context, store content.Provider, manifestDesc, configDesc ocispec.Descriptor) (ocispec.Platform, error) {
+	var platform ocispec.Platform
 	if manifestDesc.Platform != nil {
 		platform = *manifestDesc.Platform
 	} else {
@@ -527,7 +527,7 @@ func getManifestPlatform(ctx context.Context, store content.Provider, manifestDe
 
 // isImageManifest returns true if the manifest has any layer that is a known image layer.
 // Some manifests use the image media type for compatibility, even if they are not a real image.
-func isImageManifest(mfst v1.Manifest) bool {
+func isImageManifest(mfst ocispec.Manifest) bool {
 	for _, l := range mfst.Layers {
 		if images.IsLayerType(l.MediaType) {
 			return true
@@ -537,7 +537,7 @@ func isImageManifest(mfst v1.Manifest) bool {
 }
 
 // readConfig reads content pointed by the descriptor and unmarshals it into a specified output.
-func readConfig(ctx context.Context, store content.Provider, desc v1.Descriptor, out interface{}) error {
+func readConfig(ctx context.Context, store content.Provider, desc ocispec.Descriptor, out interface{}) error {
 	data, err := content.ReadBlob(ctx, store, desc)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read config content")

--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -14,13 +14,13 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/opencontainers/go-digest"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 )
 
 // PullImage initiates a pull operation. image is the repository name to pull, and
 // tagOrDigest may be either empty, or indicate a specific tag or digest to pull.
-func (i *ImageService) PullImage(ctx context.Context, image, tagOrDigest string, platform *specs.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error {
+func (i *ImageService) PullImage(ctx context.Context, image, tagOrDigest string, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error {
 	var opts []containerd.RemoteOpt
 	if platform != nil {
 		opts = append(opts, containerd.WithPlatform(platforms.Format(*platform)))
@@ -49,7 +49,7 @@ func (i *ImageService) PullImage(ctx context.Context, image, tagOrDigest string,
 	opts = append(opts, containerd.WithResolver(resolver))
 
 	jobs := newJobs()
-	h := images.HandlerFunc(func(ctx context.Context, desc specs.Descriptor) ([]specs.Descriptor, error) {
+	h := images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 		if desc.MediaType != images.MediaTypeDockerSchema1Manifest {
 			jobs.Add(desc)
 		}

--- a/daemon/containerd/image_snapshot.go
+++ b/daemon/containerd/image_snapshot.go
@@ -7,11 +7,11 @@ import (
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/platforms"
 	"github.com/opencontainers/image-spec/identity"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // PrepareSnapshot prepares a snapshot from a parent image for a container
-func (i *ImageService) PrepareSnapshot(ctx context.Context, id string, parentImage string, platform *v1.Platform) error {
+func (i *ImageService) PrepareSnapshot(ctx context.Context, id string, parentImage string, platform *ocispec.Platform) error {
 	desc, err := i.resolveDescriptor(ctx, parentImage)
 	if err != nil {
 		return err

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -19,7 +19,7 @@ import (
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/runconfig"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -74,7 +74,7 @@ func (daemon *Daemon) containerCreate(ctx context.Context, opts createOpts) (con
 		}
 		if img != nil {
 			p := maximumSpec()
-			imgPlat := v1.Platform{
+			imgPlat := ocispec.Platform{
 				OS:           img.OS,
 				Architecture: img.Architecture,
 				Variant:      img.Variant,
@@ -117,7 +117,7 @@ func (daemon *Daemon) create(ctx context.Context, opts createOpts) (retC *contai
 	var (
 		ctr         *container.Container
 		img         *image.Image
-		imgManifest *v1.Descriptor
+		imgManifest *ocispec.Descriptor
 		imgID       image.ID
 		err         error
 		os          = runtime.GOOS
@@ -345,7 +345,7 @@ func verifyNetworkingConfig(nwConfig *networktypes.NetworkingConfig) error {
 }
 
 // maximumSpec returns the distribution platform with maximum compatibility for the current node.
-func maximumSpec() v1.Platform {
+func maximumSpec() ocispec.Platform {
 	p := platforms.DefaultSpec()
 	if p.Architecture == "amd64" {
 		p.Variant = archvariant.AMD64Variant()

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -16,7 +16,7 @@ import (
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/archive"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // ImageService is a temporary interface to assist in the migration to the
@@ -25,7 +25,7 @@ import (
 type ImageService interface {
 	// Images
 
-	PullImage(ctx context.Context, name, tag string, platform *v1.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
+	PullImage(ctx context.Context, name, tag string, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
 	PushImage(ctx context.Context, ref reference.Named, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
 	CreateImage(config []byte, parent string) (builder.Image, error)
 	ImageDelete(ctx context.Context, imageRef string, force, prune bool) ([]types.ImageDeleteResponseItem, error)
@@ -36,7 +36,7 @@ type ImageService interface {
 	LogImageEvent(imageID, refName, action string)
 	CountImages() int
 	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*types.ImagesPruneReport, error)
-	ImportImage(ctx context.Context, ref reference.Named, platform *v1.Platform, msg string, layerReader io.Reader, changes []string) (image.ID, error)
+	ImportImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, msg string, layerReader io.Reader, changes []string) (image.ID, error)
 	TagImage(ctx context.Context, imageID image.ID, newTag reference.Named) error
 	GetImage(ctx context.Context, refOrID string, options imagetype.GetImageOpts) (*image.Image, error)
 	ImageHistory(ctx context.Context, name string) ([]*imagetype.HistoryResponseItem, error)
@@ -45,8 +45,8 @@ type ImageService interface {
 
 	// Containerd related methods
 
-	PrepareSnapshot(ctx context.Context, id string, image string, platform *v1.Platform) error
-	GetImageManifest(ctx context.Context, refOrID string, options imagetype.GetImageOpts) (*v1.Descriptor, error)
+	PrepareSnapshot(ctx context.Context, id string, image string, platform *ocispec.Platform) error
+	GetImageManifest(ctx context.Context, refOrID string, options imagetype.GetImageOpts) (*ocispec.Descriptor, error)
 
 	// Layers
 

--- a/daemon/images/image_builder.go
+++ b/daemon/images/image_builder.go
@@ -19,7 +19,7 @@ import (
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/system"
 	registrypkg "github.com/docker/docker/registry"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -144,7 +144,7 @@ func newROLayerForImage(img *image.Image, layerStore layer.Store) (builder.ROLay
 }
 
 // TODO: could this use the regular daemon PullImage ?
-func (i *ImageService) pullForBuilder(ctx context.Context, name string, authConfigs map[string]registry.AuthConfig, output io.Writer, platform *specs.Platform) (*image.Image, error) {
+func (i *ImageService) pullForBuilder(ctx context.Context, name string, authConfigs map[string]registry.AuthConfig, output io.Writer, platform *ocispec.Platform) (*image.Image, error) {
 	ref, err := reference.ParseNormalizedNamed(name)
 	if err != nil {
 		return nil, err
@@ -169,7 +169,7 @@ func (i *ImageService) pullForBuilder(ctx context.Context, name string, authConf
 
 	img, err := i.GetImage(ctx, name, imagetypes.GetImageOpts{Platform: platform})
 	if errdefs.IsNotFound(err) && img != nil && platform != nil {
-		imgPlat := specs.Platform{
+		imgPlat := ocispec.Platform{
 			OS:           img.OS,
 			Architecture: img.BaseImgArch(),
 			Variant:      img.BaseImgVariant(),

--- a/daemon/images/image_import.go
+++ b/daemon/images/image_import.go
@@ -16,7 +16,7 @@ import (
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/system"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // ImportImage imports an image, getting the archived layer data from layerReader.
@@ -26,7 +26,7 @@ import (
 // If the platform is nil, the default host platform is used.
 // Message is used as the image's history comment.
 // Image configuration is derived from the dockerfile instructions in changes.
-func (i *ImageService) ImportImage(ctx context.Context, newRef reference.Named, platform *specs.Platform, msg string, layerReader io.Reader, changes []string) (image.ID, error) {
+func (i *ImageService) ImportImage(ctx context.Context, newRef reference.Named, platform *ocispec.Platform, msg string, layerReader io.Reader, changes []string) (image.ID, error) {
 	if platform == nil {
 		def := platforms.DefaultSpec()
 		platform = &def

--- a/daemon/images/image_pull.go
+++ b/daemon/images/image_pull.go
@@ -17,14 +17,14 @@ import (
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/opencontainers/go-digest"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
 // PullImage initiates a pull operation. image is the repository name to pull, and
 // tag may be either empty, or indicate a specific tag to pull.
-func (i *ImageService) PullImage(ctx context.Context, image, tag string, platform *specs.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error {
+func (i *ImageService) PullImage(ctx context.Context, image, tag string, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error {
 	start := time.Now()
 	// Special case: "pull -a" may send an image name with a
 	// trailing :. This is ugly, but let's not break API
@@ -79,7 +79,7 @@ func (i *ImageService) PullImage(ctx context.Context, image, tag string, platfor
 	return nil
 }
 
-func (i *ImageService) pullImageWithReference(ctx context.Context, ref reference.Named, platform *specs.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error {
+func (i *ImageService) pullImageWithReference(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error {
 	// Include a buffer so that slow client connections don't affect
 	// transfer performance.
 	progressChan := make(chan progress.Progress, 100)

--- a/daemon/images/images_test.go
+++ b/daemon/images/images_test.go
@@ -3,30 +3,30 @@ package images
 import (
 	"testing"
 
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 )
 
 func TestOnlyPlatformWithFallback(t *testing.T) {
-	p := specs.Platform{
+	p := ocispec.Platform{
 		OS:           "linux",
 		Architecture: "arm",
 		Variant:      "v8",
 	}
 
 	// Check no variant
-	assert.Assert(t, OnlyPlatformWithFallback(p).Match(specs.Platform{
+	assert.Assert(t, OnlyPlatformWithFallback(p).Match(ocispec.Platform{
 		OS:           p.OS,
 		Architecture: p.Architecture,
 	}))
 	// check with variant
-	assert.Assert(t, OnlyPlatformWithFallback(p).Match(specs.Platform{
+	assert.Assert(t, OnlyPlatformWithFallback(p).Match(ocispec.Platform{
 		OS:           p.OS,
 		Architecture: p.Architecture,
 		Variant:      p.Variant,
 	}))
 	// Make sure non-matches are false.
-	assert.Assert(t, !OnlyPlatformWithFallback(p).Match(specs.Platform{
+	assert.Assert(t, !OnlyPlatformWithFallback(p).Match(ocispec.Platform{
 		OS:           p.OS,
 		Architecture: "amd64",
 	}))

--- a/daemon/images/store_test.go
+++ b/daemon/images/store_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/docker/docker/image"
 	"github.com/opencontainers/go-digest"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.etcd.io/bbolt"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -96,7 +96,7 @@ func TestContentStoreForPull(t *testing.T) {
 	}
 
 	data := []byte(`{}`)
-	desc := v1.Descriptor{
+	desc := ocispec.Descriptor{
 		Digest: digest.Canonical.FromBytes(data),
 		Size:   int64(len(data)),
 	}

--- a/distribution/config.go
+++ b/distribution/config.go
@@ -19,7 +19,7 @@ import (
 	refstore "github.com/docker/docker/reference"
 	registrypkg "github.com/docker/docker/registry"
 	"github.com/opencontainers/go-digest"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -60,7 +60,7 @@ type ImagePullConfig struct {
 	// types is used.
 	Schema2Types []string
 	// Platform is the requested platform of the image being pulled
-	Platform *specs.Platform
+	Platform *ocispec.Platform
 }
 
 // ImagePushConfig stores push configuration.
@@ -141,7 +141,7 @@ func rootFSFromConfig(c []byte) (*image.RootFS, error) {
 	return unmarshalledConfig.RootFS, nil
 }
 
-func platformFromConfig(c []byte) (*specs.Platform, error) {
+func platformFromConfig(c []byte) (*ocispec.Platform, error) {
 	var unmarshalledConfig image.Image
 	if err := json.Unmarshal(c, &unmarshalledConfig); err != nil {
 		return nil, err
@@ -154,7 +154,7 @@ func platformFromConfig(c []byte) (*specs.Platform, error) {
 	if !system.IsOSSupported(os) {
 		return nil, errors.Wrapf(system.ErrNotSupportedOperatingSystem, "image operating system %q cannot be used on this platform", os)
 	}
-	return &specs.Platform{
+	return &ocispec.Platform{
 		OS:           os,
 		Architecture: unmarshalledConfig.Architecture,
 		Variant:      unmarshalledConfig.Variant,

--- a/distribution/manifest_test.go
+++ b/distribution/manifest_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/opencontainers/go-digest"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
@@ -128,12 +128,12 @@ func (w *testingContentWriterWrapper) Commit(ctx context.Context, size int64, dg
 }
 
 func TestManifestStore(t *testing.T) {
-	ociManifest := &specs.Manifest{}
+	ociManifest := &ocispec.Manifest{}
 	serialized, err := json.Marshal(ociManifest)
 	assert.NilError(t, err)
 	dgst := digest.Canonical.FromBytes(serialized)
 
-	setupTest := func(t *testing.T) (reference.Named, specs.Descriptor, *mockManifestGetter, *manifestStore, content.Store, func(*testing.T)) {
+	setupTest := func(t *testing.T) (reference.Named, ocispec.Descriptor, *mockManifestGetter, *manifestStore, content.Store, func(*testing.T)) {
 		root, err := os.MkdirTemp("", strings.ReplaceAll(t.Name(), "/", "_"))
 		assert.NilError(t, err)
 		defer func() {
@@ -147,7 +147,7 @@ func TestManifestStore(t *testing.T) {
 
 		mg := &mockManifestGetter{manifests: make(map[digest.Digest]distribution.Manifest)}
 		store := &manifestStore{local: cs, remote: mg}
-		desc := specs.Descriptor{Digest: dgst, MediaType: specs.MediaTypeImageManifest, Size: int64(len(serialized))}
+		desc := ocispec.Descriptor{Digest: dgst, MediaType: ocispec.MediaTypeImageManifest, Size: int64(len(serialized))}
 
 		ref, err := reference.Parse("foo/bar")
 		assert.NilError(t, err)
@@ -159,10 +159,10 @@ func TestManifestStore(t *testing.T) {
 
 	ctx := context.Background()
 
-	m, _, err := distribution.UnmarshalManifest(specs.MediaTypeImageManifest, serialized)
+	m, _, err := distribution.UnmarshalManifest(ocispec.MediaTypeImageManifest, serialized)
 	assert.NilError(t, err)
 
-	writeManifest := func(t *testing.T, cs ContentStore, desc specs.Descriptor, opts ...content.Opt) {
+	writeManifest := func(t *testing.T, cs ContentStore, desc ocispec.Descriptor, opts ...content.Opt) {
 		ingestKey := remotes.MakeRefKey(ctx, desc)
 		w, err := cs.Writer(ctx, content.WithDescriptor(desc), content.WithRef(ingestKey))
 		assert.NilError(t, err)
@@ -185,7 +185,7 @@ func TestManifestStore(t *testing.T) {
 	}
 
 	// All tests should end up with no active ingest
-	checkIngest := func(t *testing.T, cs content.Store, desc specs.Descriptor) {
+	checkIngest := func(t *testing.T, cs content.Store, desc ocispec.Descriptor) {
 		ingestKey := remotes.MakeRefKey(ctx, desc)
 		_, err := cs.Status(ctx, ingestKey)
 		assert.Check(t, cerrdefs.IsNotFound(err), err)
@@ -354,9 +354,9 @@ func TestDetectManifestBlobMediaType(t *testing.T) {
 	}
 	cases := map[string]testCase{
 		"mediaType is set":   {[]byte(`{"mediaType": "bananas"}`), "bananas"},
-		"oci manifest":       {[]byte(`{"config": {}}`), specs.MediaTypeImageManifest},
+		"oci manifest":       {[]byte(`{"config": {}}`), ocispec.MediaTypeImageManifest},
 		"schema1":            {[]byte(`{"fsLayers": []}`), schema1.MediaTypeManifest},
-		"oci index fallback": {[]byte(`{}`), specs.MediaTypeImageIndex},
+		"oci index fallback": {[]byte(`{}`), ocispec.MediaTypeImageIndex},
 		// Make sure we prefer mediaType
 		"mediaType and config set":   {[]byte(`{"mediaType": "bananas", "config": {}}`), "bananas"},
 		"mediaType and fsLayers set": {[]byte(`{"mediaType": "bananas", "fsLayers": []}`), "bananas"},
@@ -394,7 +394,7 @@ func TestDetectManifestBlobMediaTypeInvalid(t *testing.T) {
 			`media-type: "application/vnd.docker.distribution.manifest.v2+json" should not have "manifests" or "fsLayers"`,
 		},
 		"oci manifest mediaType with manifests": {
-			[]byte(`{"mediaType": "` + specs.MediaTypeImageManifest + `","manifests":[]}`),
+			[]byte(`{"mediaType": "` + ocispec.MediaTypeImageManifest + `","manifests":[]}`),
 			`media-type: "application/vnd.oci.image.manifest.v1+json" should not have "manifests" or "fsLayers"`,
 		},
 		"manifest list mediaType with fsLayers": {
@@ -402,11 +402,11 @@ func TestDetectManifestBlobMediaTypeInvalid(t *testing.T) {
 			`media-type: "application/vnd.docker.distribution.manifest.list.v2+json" should not have "config", "layers", or "fsLayers"`,
 		},
 		"index mediaType with layers": {
-			[]byte(`{"mediaType": "` + specs.MediaTypeImageIndex + `","layers":[]}`),
+			[]byte(`{"mediaType": "` + ocispec.MediaTypeImageIndex + `","layers":[]}`),
 			`media-type: "application/vnd.oci.image.index.v1+json" should not have "config", "layers", or "fsLayers"`,
 		},
 		"index mediaType with config": {
-			[]byte(`{"mediaType": "` + specs.MediaTypeImageIndex + `","config":{}}`),
+			[]byte(`{"mediaType": "` + ocispec.MediaTypeImageIndex + `","config":{}}`),
 			`media-type: "application/vnd.oci.image.index.v1+json" should not have "config", "layers", or "fsLayers"`,
 		},
 		"config and manifests": {

--- a/distribution/pull_v2_test.go
+++ b/distribution/pull_v2_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/registry"
 	"github.com/opencontainers/go-digest"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -194,7 +194,7 @@ func TestValidateManifest(t *testing.T) {
 }
 
 func TestFormatPlatform(t *testing.T) {
-	var platform specs.Platform
+	var platform ocispec.Platform
 	var result = formatPlatform(platform)
 	if strings.HasPrefix(result, "unknown") {
 		t.Fatal("expected formatPlatform to show a known platform")

--- a/distribution/pull_v2_unix.go
+++ b/distribution/pull_v2_unix.go
@@ -10,7 +10,7 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/manifestlist"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 )
 
@@ -19,7 +19,7 @@ func (ld *layerDescriptor) open(ctx context.Context) (distribution.ReadSeekClose
 	return blobs.Open(ctx, ld.digest)
 }
 
-func filterManifests(manifests []manifestlist.ManifestDescriptor, p specs.Platform) []manifestlist.ManifestDescriptor {
+func filterManifests(manifests []manifestlist.ManifestDescriptor, p ocispec.Platform) []manifestlist.ManifestDescriptor {
 	p = platforms.Normalize(withDefault(p))
 	m := platforms.Only(p)
 	var matches []manifestlist.ManifestDescriptor
@@ -53,7 +53,7 @@ func checkImageCompatibility(imageOS, imageOSVersion string) error {
 	return nil
 }
 
-func withDefault(p specs.Platform) specs.Platform {
+func withDefault(p ocispec.Platform) ocispec.Platform {
 	def := maximumSpec()
 	if p.OS == "" {
 		p.OS = def.OS
@@ -65,7 +65,7 @@ func withDefault(p specs.Platform) specs.Platform {
 	return p
 }
 
-func formatPlatform(platform specs.Platform) string {
+func formatPlatform(platform ocispec.Platform) string {
 	if platform.OS == "" {
 		platform = platforms.DefaultSpec()
 	}

--- a/distribution/pull_v2_windows.go
+++ b/distribution/pull_v2_windows.go
@@ -18,7 +18,7 @@ import (
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/pkg/system"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 )
 
@@ -65,7 +65,7 @@ func (ld *layerDescriptor) open(ctx context.Context) (distribution.ReadSeekClose
 	return rsc, err
 }
 
-func filterManifests(manifests []manifestlist.ManifestDescriptor, p specs.Platform) []manifestlist.ManifestDescriptor {
+func filterManifests(manifests []manifestlist.ManifestDescriptor, p ocispec.Platform) []manifestlist.ManifestDescriptor {
 	version := osversion.Get()
 	osVersion := fmt.Sprintf("%d.%d.%d", version.MajorVersion, version.MinorVersion, version.Build)
 	logrus.Debugf("will prefer Windows entries with version %s", osVersion)
@@ -139,7 +139,7 @@ func checkImageCompatibility(imageOS, imageOSVersion string) error {
 	return nil
 }
 
-func formatPlatform(platform specs.Platform) string {
+func formatPlatform(platform ocispec.Platform) string {
 	if platform.OS == "" {
 		platform = platforms.DefaultSpec()
 	}

--- a/hack/validate/golangci-lint.yml
+++ b/hack/validate/golangci-lint.yml
@@ -34,6 +34,8 @@ linters-settings:
       # own errdefs package (or vice-versa).
       - pkg: github.com/containerd/containerd/errdefs
         alias: cerrdefs
+      - pkg: github.com/opencontainers/image-spec/specs-go/v1
+        alias: ocispec
 
   govet:
     check-shadowing: false

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/docker/docker/errdefs"
 	ctr "github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/oci"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/poll"
@@ -475,7 +475,7 @@ func TestCreateDifferentPlatform(t *testing.T) {
 	assert.Assert(t, img.Architecture != "")
 
 	t.Run("different os", func(t *testing.T) {
-		p := specs.Platform{
+		p := ocispec.Platform{
 			OS:           img.Os + "DifferentOS",
 			Architecture: img.Architecture,
 			Variant:      img.Variant,
@@ -484,7 +484,7 @@ func TestCreateDifferentPlatform(t *testing.T) {
 		assert.Assert(t, client.IsErrNotFound(err), err)
 	})
 	t.Run("different cpu arch", func(t *testing.T) {
-		p := specs.Platform{
+		p := ocispec.Platform{
 			OS:           img.Os,
 			Architecture: img.Architecture + "DifferentArch",
 			Variant:      img.Variant,

--- a/integration/image/pull_test.go
+++ b/integration/image/pull_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/docker/docker/testutil/registry"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/skip"
 )
@@ -36,7 +36,7 @@ func TestImagePullPlatformInvalid(t *testing.T) {
 	assert.Assert(t, errdefs.IsInvalidParameter(err))
 }
 
-func createTestImage(ctx context.Context, t testing.TB, store content.Store) imagespec.Descriptor {
+func createTestImage(ctx context.Context, t testing.TB, store content.Store) ocispec.Descriptor {
 	w, err := store.Writer(ctx, content.WithRef("layer"))
 	assert.NilError(t, err)
 	defer w.Close()
@@ -55,11 +55,11 @@ func createTestImage(ctx context.Context, t testing.TB, store content.Store) ima
 
 	platform := platforms.DefaultSpec()
 
-	img := imagespec.Image{
+	img := ocispec.Image{
 		Architecture: platform.Architecture,
 		OS:           platform.OS,
-		RootFS:       imagespec.RootFS{Type: "layers", DiffIDs: []digest.Digest{layerDigest}},
-		Config:       imagespec.ImageConfig{WorkingDir: "/"},
+		RootFS:       ocispec.RootFS{Type: "layers", DiffIDs: []digest.Digest{layerDigest}},
+		Config:       ocispec.ImageConfig{WorkingDir: "/"},
 	}
 	imgJSON, err := json.Marshal(img)
 	assert.NilError(t, err)
@@ -77,17 +77,17 @@ func createTestImage(ctx context.Context, t testing.TB, store content.Store) ima
 	info, err := store.Info(ctx, layerDigest)
 	assert.NilError(t, err)
 
-	manifest := imagespec.Manifest{
+	manifest := ocispec.Manifest{
 		Versioned: specs.Versioned{
 			SchemaVersion: 2,
 		},
 		MediaType: images.MediaTypeDockerSchema2Manifest,
-		Config: imagespec.Descriptor{
+		Config: ocispec.Descriptor{
 			MediaType: images.MediaTypeDockerSchema2Config,
 			Digest:    configDigest,
 			Size:      int64(len(imgJSON)),
 		},
-		Layers: []imagespec.Descriptor{{
+		Layers: []ocispec.Descriptor{{
 			MediaType: images.MediaTypeDockerSchema2Layer,
 			Digest:    layerDigest,
 			Size:      info.Size,
@@ -107,7 +107,7 @@ func createTestImage(ctx context.Context, t testing.TB, store content.Store) ima
 	manifestDigest := w.Digest()
 	w.Close()
 
-	return imagespec.Descriptor{
+	return ocispec.Descriptor{
 		MediaType: images.MediaTypeDockerSchema2Manifest,
 		Digest:    manifestDigest,
 		Size:      int64(len(manifestJSON)),

--- a/integration/internal/container/container.go
+++ b/integration/internal/container/container.go
@@ -9,7 +9,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 )
 
@@ -20,7 +20,7 @@ type TestContainerConfig struct {
 	Config           *container.Config
 	HostConfig       *container.HostConfig
 	NetworkingConfig *network.NetworkingConfig
-	Platform         *specs.Platform
+	Platform         *ocispec.Platform
 }
 
 // create creates a container with the specified options

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -8,7 +8,7 @@ import (
 	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/go-connections/nat"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // WithName sets the name of the container
@@ -204,7 +204,7 @@ func WithExtraHost(extraHost string) func(*TestContainerConfig) {
 }
 
 // WithPlatform specifies the desired platform the image should have.
-func WithPlatform(p *specs.Platform) func(*TestContainerConfig) {
+func WithPlatform(p *ocispec.Platform) func(*TestContainerConfig) {
 	return func(c *TestContainerConfig) {
 		c.Platform = p
 	}

--- a/integration/plugin/common/plugin_test.go
+++ b/integration/plugin/common/plugin_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/docker/docker/testutil/fixtures/plugin"
 	"github.com/docker/docker/testutil/registry"
 	"github.com/docker/docker/testutil/request"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
@@ -306,7 +306,7 @@ func TestPluginBackCompatMediaTypes(t *testing.T) {
 	assert.NilError(t, err)
 	defer rdr.Close()
 
-	var m v1.Manifest
+	var m ocispec.Manifest
 	assert.NilError(t, json.NewDecoder(rdr).Decode(&m))
 	assert.Check(t, is.Equal(m.MediaType, images.MediaTypeDockerSchema2Manifest))
 	assert.Check(t, is.Len(m.Layers, 1))

--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -29,7 +29,7 @@ import (
 	libcontainerdtypes "github.com/docker/docker/libcontainerd/types"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/hashicorp/go-multierror"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -439,12 +439,12 @@ func (t *task) CreateCheckpoint(ctx context.Context, checkpointDir string, exit 
 	if err != nil {
 		return errdefs.System(errors.Wrapf(err, "failed to retrieve checkpoint data"))
 	}
-	var index v1.Index
+	var index ocispec.Index
 	if err := json.Unmarshal(b, &index); err != nil {
 		return errdefs.System(errors.Wrapf(err, "failed to decode checkpoint data"))
 	}
 
-	var cpDesc *v1.Descriptor
+	var cpDesc *ocispec.Descriptor
 	for _, m := range index.Manifests {
 		m := m
 		if m.MediaType == images.MediaTypeContainerd1Checkpoint {

--- a/plugin/manager_linux.go
+++ b/plugin/manager_linux.go
@@ -18,7 +18,7 @@ import (
 	v2 "github.com/docker/docker/plugin/v2"
 	"github.com/moby/sys/mount"
 	"github.com/opencontainers/go-digest"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -267,7 +267,7 @@ func (pm *Manager) upgradePlugin(p *v2.Plugin, configDigest, manifestDigest dige
 }
 
 func (pm *Manager) setupNewPlugin(configDigest digest.Digest, privileges *types.PluginPrivileges) (types.PluginConfig, error) {
-	configRA, err := pm.blobStore.ReaderAt(context.TODO(), specs.Descriptor{Digest: configDigest})
+	configRA, err := pm.blobStore.ReaderAt(context.TODO(), ocispec.Descriptor{Digest: configDigest})
 	if err != nil {
 		return types.PluginConfig{}, err
 	}


### PR DESCRIPTION
fix : #45194 

**- What I did**

 changed the aliases to a common alias `ocispec`