### PR TITLE
[24.0 backport] daemon: handleContainerExit(): add execDuration in attributes

### DIFF
--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -78,7 +78,8 @@ func (daemon *Daemon) handleContainerExit(c *container.Container, e *libcontaine
 	}
 
 	attributes := map[string]string{
-		"exitCode": strconv.Itoa(exitStatus.ExitCode),
+		"exitCode":     strconv.Itoa(exitStatus.ExitCode),
+		"execDuration": strconv.Itoa(int(execDuration.Seconds())),
 	}
 	daemon.Cleanup(c)
 


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/45488

Add `execDuration` field to the event attributes map. This is useful for tracking how long the container ran.


(cherry picked from commit 2ad37e183255e1abf9ca0d06b672338973a04d7b)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

