### PR TITLE
profiles/apparmor: remove use of aaparser.GetVersion()

### DIFF
--- a/profiles/apparmor/apparmor.go
+++ b/profiles/apparmor/apparmor.go
@@ -14,10 +14,8 @@ import (
 	"github.com/docker/docker/pkg/aaparser"
 )
 
-var (
-	// profileDirectory is the file store for apparmor profiles and macros.
-	profileDirectory = "/etc/apparmor.d"
-)
+// profileDirectory is the file store for apparmor profiles and macros.
+const profileDirectory = "/etc/apparmor.d"
 
 // profileData holds information about the given profile for generation.
 type profileData struct {
@@ -29,8 +27,6 @@ type profileData struct {
 	Imports []string
 	// InnerImports defines the apparmor functions to import in the profile.
 	InnerImports []string
-	// Version is the {major, minor, patch} version of apparmor_parser as a single number.
-	Version int
 }
 
 // generateDefault creates an apparmor profile from ProfileData.
@@ -49,12 +45,6 @@ func (p *profileData) generateDefault(out io.Writer) error {
 	if macroExists("abstractions/base") {
 		p.InnerImports = append(p.InnerImports, "#include <abstractions/base>")
 	}
-
-	ver, err := aaparser.GetVersion()
-	if err != nil {
-		return err
-	}
-	p.Version = ver
 
 	return compiled.Execute(out, p)
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/44960

commit 7008a514493a83a1342f30afca6726ffea14f50f (https://github.com/moby/moby/pull/44960) removed version-conditional rules from the template, so we no longer need the apparmor_parser Version.

This patch removes the call to `aaparser.GetVersion()`

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

