### PR TITLE
pkg/aaparser: deprecate GetVersion, as it's no longer used

### DIFF
--- a/pkg/aaparser/aaparser.go
+++ b/pkg/aaparser/aaparser.go
@@ -13,6 +13,8 @@ const (
 )
 
 // GetVersion returns the major and minor version of apparmor_parser.
+//
+// Deprecated: no longer used, and will be removed in the next release.
 func GetVersion() (int, error) {
 	output, err := cmd("", "--version")
 	if err != nil {


### PR DESCRIPTION
relates to / depends on:

- [x] https://github.com/moby/moby/pull/44960
- [x] https://github.com/moby/moby/pull/45492
- [x] https://github.com/moby/moby/pull/45495

Our templates no longer contain version-specific rules, so this function is no longer used. This patch deprecates it.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

