### PR TITLE
[24.0 backport] remove remaining uses of apparmor_parser version in apparmor packages

### DIFF
--- a/contrib/apparmor/main.go
+++ b/contrib/apparmor/main.go
@@ -6,13 +6,9 @@ import (
 	"os"
 	"path"
 	"text/template"
-
-	"github.com/docker/docker/pkg/aaparser"
 )
 
-type profileData struct {
-	Version int
-}
+type profileData struct{}
 
 func main() {
 	if len(os.Args) < 2 {
@@ -21,15 +17,6 @@ func main() {
 
 	// parse the arg
 	apparmorProfilePath := os.Args[1]
-
-	version, err := aaparser.GetVersion()
-	if err != nil {
-		log.Fatal(err)
-	}
-	data := profileData{
-		Version: version,
-	}
-	fmt.Printf("apparmor_parser is of version %+v\n", data)
 
 	// parse the template
 	compiled, err := template.New("apparmor_profile").Parse(dockerProfileTemplate)
@@ -48,6 +35,7 @@ func main() {
 	}
 	defer f.Close()
 
+	data := profileData{}
 	if err := compiled.Execute(f, data); err != nil {
 		log.Fatalf("executing template failed: %v", err)
 	}

--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -149,9 +149,7 @@ profile /usr/bin/docker (attach_disconnected, complain) {
   }
   # xz works via pipes, so we do not need access to the filesystem.
   profile /usr/bin/xz (complain) {
-{{if ge .Version 209000}}
     signal (receive) peer=/usr/bin/docker,
-{{end}}
     /etc/ld.so.cache r,
     /lib/** rm,
     /usr/bin/xz rm,

--- a/pkg/aaparser/aaparser.go
+++ b/pkg/aaparser/aaparser.go
@@ -13,6 +13,8 @@ const (
 )
 
 // GetVersion returns the major and minor version of apparmor_parser.
+//
+// Deprecated: no longer used, and will be removed in the next release.
 func GetVersion() (int, error) {
 	output, err := cmd("", "--version")
 	if err != nil {

--- a/profiles/apparmor/apparmor.go
+++ b/profiles/apparmor/apparmor.go
@@ -14,10 +14,8 @@ import (
 	"github.com/docker/docker/pkg/aaparser"
 )
 
-var (
-	// profileDirectory is the file store for apparmor profiles and macros.
-	profileDirectory = "/etc/apparmor.d"
-)
+// profileDirectory is the file store for apparmor profiles and macros.
+const profileDirectory = "/etc/apparmor.d"
 
 // profileData holds information about the given profile for generation.
 type profileData struct {
@@ -29,8 +27,6 @@ type profileData struct {
 	Imports []string
 	// InnerImports defines the apparmor functions to import in the profile.
 	InnerImports []string
-	// Version is the {major, minor, patch} version of apparmor_parser as a single number.
-	Version int
 }
 
 // generateDefault creates an apparmor profile from ProfileData.
@@ -49,12 +45,6 @@ func (p *profileData) generateDefault(out io.Writer) error {
 	if macroExists("abstractions/base") {
 		p.InnerImports = append(p.InnerImports, "#include <abstractions/base>")
 	}
-
-	ver, err := aaparser.GetVersion()
-	if err != nil {
-		return err
-	}
-	p.Version = ver
 
 	return compiled.Execute(out, p)
 }


### PR DESCRIPTION
Backports:

- https://github.com/moby/moby/pull/45492
- https://github.com/moby/moby/pull/45495
- https://github.com/moby/moby/pull/45496

Relates to:

- https://github.com/moby/moby/pull/44960