### PR TITLE
c8d: add image history

### DIFF
--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -68,6 +68,21 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 		exposedPorts[nat.Port(k)] = v
 	}
 
+	var imgHistory []image.History
+	for _, h := range ociimage.History {
+		var created time.Time
+		if h.Created != nil {
+			created = *h.Created
+		}
+		imgHistory = append(imgHistory, image.History{
+			Created:    created,
+			Author:     h.Author,
+			CreatedBy:  h.CreatedBy,
+			Comment:    h.Comment,
+			EmptyLayer: h.EmptyLayer,
+		})
+	}
+
 	img := image.NewImage(image.ID(desc.Digest))
 	img.V1Image = image.V1Image{
 		ID:           string(desc.Digest),
@@ -87,6 +102,7 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 	}
 
 	img.RootFS = rootfs
+	img.History = imgHistory
 
 	if options.Details {
 		lastUpdated := time.Unix(0, 0)

--- a/daemon/containerd/image_commit.go
+++ b/daemon/containerd/image_commit.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/containerd/containerd/content"
@@ -143,7 +144,7 @@ func generateCommitImageConfig(baseConfig ocispec.Image, diffID digest.Digest, o
 		},
 		History: append(baseConfig.History, ocispec.History{
 			Created:    &createdTime,
-			CreatedBy:  "", // FIXME(ndeloof) ?
+			CreatedBy:  strings.Join(opts.ContainerConfig.Cmd, " "),
 			Author:     opts.Author,
 			Comment:    opts.Comment,
 			EmptyLayer: diffID == "",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- *`daemon/containerd/GetImage()`*: include image history from fetched containerd store image
- *`daemon/containerd/CommitImage()`*: include `CreatedBy` when writing image history to store

I extracted this out from #45322 since it's a smaller change/separately useful and for easier reviewing. This is needed there so we can rely on image history for cache checks.

**- How I did it**

**- How to verify it**

- `docker commit [...]`
- `docker history [...]`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/moby/moby/assets/70572044/b44e76d7-7d43-4f91-b392-8b25bc31bc14)

