### PR TITLE
[chore] clean up reexec.Init() calls

### DIFF
--- a/builder/dockerfile/evaluator_test.go
+++ b/builder/dockerfile/evaluator_test.go
@@ -21,8 +21,11 @@ type dispatchTestCase struct {
 	files               map[string]string
 }
 
-func init() {
-	reexec.Init()
+func TestMain(m *testing.M) {
+	if reexec.Init() {
+		return
+	}
+	os.Exit(m.Run())
 }
 
 func TestDispatch(t *testing.T) {

--- a/builder/remotecontext/tarsum_test.go
+++ b/builder/remotecontext/tarsum_test.go
@@ -17,8 +17,11 @@ const (
 	contents = "contents test"
 )
 
-func init() {
-	reexec.Init()
+func TestMain(m *testing.M) {
+	if reexec.Init() {
+		return
+	}
+	os.Exit(m.Run())
 }
 
 func TestCloseRootDirectory(t *testing.T) {

--- a/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs_test.go
+++ b/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/daemon/graphdriver/graphtest"
 	"github.com/docker/docker/pkg/archive"
-	"github.com/docker/docker/pkg/reexec"
 )
 
 func init() {
@@ -17,8 +16,6 @@ func init() {
 	// errors or hangs to be debugged directly from the test process.
 	untar = archive.UntarUncompressed
 	graphdriver.ApplyUncompressedLayer = archive.ApplyUncompressedLayer
-
-	reexec.Init()
 }
 
 // This avoids creating a new driver for each test if all tests are run

--- a/daemon/graphdriver/overlay2/overlay_test.go
+++ b/daemon/graphdriver/overlay2/overlay_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/daemon/graphdriver/graphtest"
 	"github.com/docker/docker/pkg/archive"
-	"github.com/docker/docker/pkg/reexec"
 )
 
 func init() {
@@ -18,8 +17,6 @@ func init() {
 	// errors or hangs to be debugged directly from the test process.
 	untar = archive.UntarUncompressed
 	graphdriver.ApplyUncompressedLayer = archive.ApplyUncompressedLayer
-
-	reexec.Init()
 }
 
 func skipIfNaive(t *testing.T) {

--- a/daemon/graphdriver/vfs/vfs_test.go
+++ b/daemon/graphdriver/vfs/vfs_test.go
@@ -7,13 +7,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/daemon/graphdriver/graphtest"
-
-	"github.com/docker/docker/pkg/reexec"
 )
-
-func init() {
-	reexec.Init()
-}
 
 // This avoids creating a new driver for each test if all tests are run
 // Make sure to put new tests between TestVfsSetup and TestVfsTeardown

--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/integration-cli/environment"
 	"github.com/docker/docker/internal/test/suite"
-	"github.com/docker/docker/pkg/reexec"
 	testdaemon "github.com/docker/docker/testutil/daemon"
 	ienv "github.com/docker/docker/testutil/environment"
 	"github.com/docker/docker/testutil/fakestorage"
@@ -49,8 +48,6 @@ var (
 
 func init() {
 	var err error
-
-	reexec.Init() // This is required for external graphdriver tests
 
 	testEnv, err = environment.New()
 	if err != nil {

--- a/integration/plugin/common/main_test.go
+++ b/integration/plugin/common/main_test.go
@@ -5,16 +5,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/docker/docker/pkg/reexec"
 	"github.com/docker/docker/testutil/environment"
 )
 
 var testEnv *environment.Execution
 
 func TestMain(m *testing.M) {
-	if reexec.Init() {
-		return
-	}
 	var err error
 	testEnv, err = environment.New()
 	if err != nil {

--- a/integration/plugin/graphdriver/main_test.go
+++ b/integration/plugin/graphdriver/main_test.go
@@ -5,17 +5,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/docker/docker/pkg/reexec"
 	"github.com/docker/docker/testutil/environment"
 )
 
 var (
 	testEnv *environment.Execution
 )
-
-func init() {
-	reexec.Init() // This is required for external graphdriver tests
-}
 
 func TestMain(m *testing.M) {
 	var err error

--- a/libnetwork/cmd/readme_test/readme.go
+++ b/libnetwork/cmd/readme_test/readme.go
@@ -8,14 +8,9 @@ import (
 	"github.com/docker/docker/libnetwork/config"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/options"
-	"github.com/docker/docker/pkg/reexec"
 )
 
 func main() {
-	if reexec.Init() {
-		return
-	}
-
 	// Select and configure the network driver
 	networkType := "bridge"
 

--- a/libnetwork/drivers/bridge/port_mapping_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_test.go
@@ -4,22 +4,13 @@
 package bridge
 
 import (
-	"os"
 	"testing"
 
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/ns"
 	"github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/libnetwork/types"
-	"github.com/docker/docker/pkg/reexec"
 )
-
-func TestMain(m *testing.M) {
-	if reexec.Init() {
-		return
-	}
-	os.Exit(m.Run())
-}
 
 func TestPortMappingConfig(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()

--- a/libnetwork/libnetwork_test.go
+++ b/libnetwork/libnetwork_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/docker/docker/libnetwork"
@@ -23,19 +22,9 @@ import (
 	"github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/docker/docker/pkg/plugins"
-	"github.com/docker/docker/pkg/reexec"
-	"github.com/sirupsen/logrus"
 )
 
 func TestMain(m *testing.M) {
-	if runtime.GOOS == "windows" {
-		logrus.Info("Test suite does not currently support windows")
-		os.Exit(0)
-	}
-	if reexec.Init() {
-		return
-	}
-
 	// Cleanup local datastore file
 	_ = os.Remove(datastore.DefaultScope("").Client.Address)
 

--- a/libnetwork/osl/sandbox_linux_test.go
+++ b/libnetwork/osl/sandbox_linux_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/docker/docker/libnetwork/ns"
 	"github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/libnetwork/types"
-	"github.com/docker/docker/pkg/reexec"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
 	"github.com/vishvananda/netns"
@@ -380,13 +379,6 @@ func TestLiveRestore(t *testing.T) {
 	if err := setInterfaceIP(nlh, linkA, iface); err == nil {
 		t.Fatalf("Expected route conflict error, but succeeded for IPV4 ")
 	}
-}
-
-func TestMain(m *testing.M) {
-	if reexec.Init() {
-		return
-	}
-	os.Exit(m.Run())
 }
 
 func TestSandboxCreate(t *testing.T) {

--- a/pkg/chrootarchive/archive_test.go
+++ b/pkg/chrootarchive/archive_test.go
@@ -14,13 +14,8 @@ import (
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/idtools"
-	"github.com/docker/docker/pkg/reexec"
 	"gotest.tools/v3/skip"
 )
-
-func init() {
-	reexec.Init()
-}
 
 var chrootArchiver = NewArchiver(idtools.IdentityMapping{})
 


### PR DESCRIPTION
Now that most uses of reexec have been replaced with non-reexec solutions, most of the `reexec.Init()` calls peppered throughout the test suites are unnecessary. Furthermore, most of the `reexec.Init()` calls in test code neglects to check the return value to determine whether to exit, which would result in the reexec'ed subprocesses proceeding to run
the tests, which would reexec another subprocess which would proceed to run the tests, recursively. (That would explain why every reexec callback used to unconditionally call `os.Exit()` instead of returning...)

Remove unneeded `reexec.Init()` calls from test and example code which no longer needs it, and fix the `reexec.Init()` calls which are not inert to exit after a reexec callback is invoked.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
CI ✅ 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

