### PR TITLE
c8d: image history – handle dangling images

### DIFF
--- a/daemon/containerd/image_history.go
+++ b/daemon/containerd/image_history.go
@@ -90,13 +90,16 @@ func (i *ImageService) ImageHistory(ctx context.Context, name string) ([]*imaget
 			return nil, err
 		}
 
-		tags := make([]string, len(tagged))
-		for i, t := range tagged {
+		var tags []string
+		for _, t := range tagged {
+			if isDanglingImage(t) {
+				continue
+			}
 			name, err := reference.ParseNamed(t.Name)
 			if err != nil {
 				return nil, err
 			}
-			tags[i] = reference.FamiliarString(name)
+			tags = append(tags, reference.FamiliarString(name))
 		}
 		history[0].Tags = tags
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

closes #45506 

**- What I did**

Skip dangling references when parsing tags for the `docker history` response.

**- How I did it**

**- How to verify it**
```bash

root@15c840d410df:/go/src/github.com/docker/docker# docker images
REPOSITORY   TAG       IMAGE ID       CREATED        SIZE
alpine       latest    02bb6f428431   14 hours ago   12.7MB
<none>       <none>    aaae57b15401   14 hours ago   12.7MB

root@15c840d410df:/go/src/github.com/docker/docker# docker history alpine
IMAGE          CREATED        CREATED BY                                      SIZE      COMMENT
02bb6f428431   11 hours ago   /bin/sh -c #(nop)  CMD ["/bin/sh"]              0B
<missing>      11 hours ago   /bin/sh -c #(nop) ADD file:df7fccc3453b6ec14…   9.37MB

root@15c840d410df:/go/src/github.com/docker/docker# docker history aaae57
IMAGE          CREATED        CREATED BY                                      SIZE      COMMENT
aaae57b15401   10 hours ago   /bin/sh -c #(nop) ADD file:ed22a8e68ac4a4172…   12.3kB
<missing>      10 hours ago   /bin/sh -c echo "bork" > hello.txt              4.1kB
<missing>      11 hours ago   /bin/sh -c #(nop)  CMD ["/bin/sh"]              0B
<missing>      11 hours ago   /bin/sh -c #(nop) ADD file:df7fccc3453b6ec14…   9.37MB
```

```bash
root@15c840d410df:/go/src/github.com/docker/docker# curl --unix-socket /var/run/docker.sock http://v1.43/images/aaae57/history | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   705  100   705    0     0  58750      0 --:--:-- --:--:-- --:--:-- 58750
[
  {
    "Comment": "",
    "Created": 1683676685,
    "CreatedBy": "/bin/sh -c #(nop) ADD file:ed22a8e68ac4a417266f8f8ecaae7cabd1f9d9b38247d73909fb9ff0febf5f55 in /go.mod ",
    "Id": "sha256:aaae57b1540137425512d81c0f133dad2444ea6484117c5ba50c16326e226c80",
    "Size": 12288,
    "Tags": null
  },
  {
    "Comment": "",
    "Created": 1683676685,
    "CreatedBy": "/bin/sh -c echo \"bork\" > hello.txt",
    "Id": "<missing>",
    "Size": 4096,
    "Tags": null
  },
  {
    "Comment": "",
    "Created": 1683673868,
    "CreatedBy": "/bin/sh -c #(nop)  CMD [\"/bin/sh\"]",
    "Id": "<missing>",
    "Size": 0,
    "Tags": null
  },
  {
    "Comment": "",
    "Created": 1683673868,
    "CreatedBy": "/bin/sh -c #(nop) ADD file:df7fccc3453b6ec1401d27a1295b0882a83e731fde8f23db9d3f687a2b6b4e70 in / ",
    "Id": "<missing>",
    "Size": 9371648,
    "Tags": null
  }
]
root@15c840d410df:/go/src/github.com/docker/docker# curl --unix-socket /var/run/docker.sock http://v1.43/images/alpine/history | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   394  100   394    0     0  49250      0 --:--:-- --:--:-- --:--:-- 49250
[
  {
    "Comment": "",
    "Created": 1683673868,
    "CreatedBy": "/bin/sh -c #(nop)  CMD [\"/bin/sh\"]",
    "Id": "sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11",
    "Size": 0,
    "Tags": [
      "alpine:latest"
    ]
  },
  {
    "Comment": "",
    "Created": 1683673868,
    "CreatedBy": "/bin/sh -c #(nop) ADD file:df7fccc3453b6ec1401d27a1295b0882a83e731fde8f23db9d3f687a2b6b4e70 in / ",
    "Id": "<missing>",
    "Size": 9371648,
    "Tags": null
  }
]
root@15c840d410df:/go/src/github.com/docker/docker#
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/moby/moby/assets/70572044/33bbc5a5-95a2-41c0-90ef-464ab5c0dd5b)
