### PR TITLE
client: make IsErrNotFound an alias for errdefs.IsNotFound, clean-up assertions on tests

### DIFF
--- a/client/checkpoint_create_test.go
+++ b/client/checkpoint_create_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestCheckpointCreateError(t *testing.T) {
@@ -23,9 +25,7 @@ func TestCheckpointCreateError(t *testing.T) {
 		Exit:         true,
 	})
 
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestCheckpointCreate(t *testing.T) {

--- a/client/checkpoint_delete_test.go
+++ b/client/checkpoint_delete_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestCheckpointDeleteError(t *testing.T) {
@@ -22,9 +24,7 @@ func TestCheckpointDeleteError(t *testing.T) {
 		CheckpointID: "checkpoint_id",
 	})
 
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestCheckpointDelete(t *testing.T) {

--- a/client/checkpoint_list_test.go
+++ b/client/checkpoint_list_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestCheckpointListError(t *testing.T) {
@@ -20,9 +22,7 @@ func TestCheckpointListError(t *testing.T) {
 	}
 
 	_, err := client.CheckpointList(context.Background(), "container_id", types.CheckpointListOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestCheckpointList(t *testing.T) {
@@ -63,7 +63,5 @@ func TestCheckpointListContainerNotFound(t *testing.T) {
 	}
 
 	_, err := client.CheckpointList(context.Background(), "unknown", types.CheckpointListOptions{})
-	if err == nil || !IsErrNotFound(err) {
-		t.Fatalf("expected a containerNotFound error, got %v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }

--- a/client/config_create_test.go
+++ b/client/config_create_test.go
@@ -32,9 +32,7 @@ func TestConfigCreateError(t *testing.T) {
 		client:  newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ConfigCreate(context.Background(), swarm.ConfigSpec{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestConfigCreate(t *testing.T) {

--- a/client/config_inspect_test.go
+++ b/client/config_inspect_test.go
@@ -23,9 +23,7 @@ func TestConfigInspectNotFound(t *testing.T) {
 	}
 
 	_, _, err := client.ConfigInspectWithRaw(context.Background(), "unknown")
-	if err == nil || !IsErrNotFound(err) {
-		t.Fatalf("expected a NotFoundError error, got %v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestConfigInspectWithEmptyID(t *testing.T) {
@@ -35,9 +33,7 @@ func TestConfigInspectWithEmptyID(t *testing.T) {
 		}),
 	}
 	_, _, err := client.ConfigInspectWithRaw(context.Background(), "")
-	if !IsErrNotFound(err) {
-		t.Fatalf("Expected NotFoundError, got %v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestConfigInspectUnsupported(t *testing.T) {
@@ -56,9 +52,7 @@ func TestConfigInspectError(t *testing.T) {
 	}
 
 	_, _, err := client.ConfigInspectWithRaw(context.Background(), "nothing")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestConfigInspectConfigNotFound(t *testing.T) {
@@ -68,9 +62,7 @@ func TestConfigInspectConfigNotFound(t *testing.T) {
 	}
 
 	_, _, err := client.ConfigInspectWithRaw(context.Background(), "unknown")
-	if err == nil || !IsErrNotFound(err) {
-		t.Fatalf("expected a configNotFoundError error, got %v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestConfigInspect(t *testing.T) {

--- a/client/config_list_test.go
+++ b/client/config_list_test.go
@@ -34,9 +34,7 @@ func TestConfigListError(t *testing.T) {
 	}
 
 	_, err := client.ConfigList(context.Background(), types.ConfigListOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestConfigList(t *testing.T) {

--- a/client/config_remove_test.go
+++ b/client/config_remove_test.go
@@ -30,9 +30,7 @@ func TestConfigRemoveError(t *testing.T) {
 	}
 
 	err := client.ConfigRemove(context.Background(), "config_id")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestConfigRemove(t *testing.T) {

--- a/client/config_update_test.go
+++ b/client/config_update_test.go
@@ -31,9 +31,7 @@ func TestConfigUpdateError(t *testing.T) {
 	}
 
 	err := client.ConfigUpdate(context.Background(), "config_id", swarm.Version{}, swarm.ConfigSpec{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestConfigUpdate(t *testing.T) {

--- a/client/container_commit_test.go
+++ b/client/container_commit_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestContainerCommitError(t *testing.T) {
@@ -19,9 +21,7 @@ func TestContainerCommitError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ContainerCommit(context.Background(), "nothing", types.ContainerCommitOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestContainerCommit(t *testing.T) {

--- a/client/container_copy_test.go
+++ b/client/container_copy_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestContainerStatPathError(t *testing.T) {
@@ -20,9 +22,7 @@ func TestContainerStatPathError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ContainerStatPath(context.Background(), "container_id", "path")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestContainerStatPathNotFoundError(t *testing.T) {
@@ -30,9 +30,7 @@ func TestContainerStatPathNotFoundError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusNotFound, "Not found")),
 	}
 	_, err := client.ContainerStatPath(context.Background(), "container_id", "path")
-	if !IsErrNotFound(err) {
-		t.Fatalf("expected a not found error, got %v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestContainerStatPathNoHeaderError(t *testing.T) {
@@ -100,9 +98,7 @@ func TestCopyToContainerError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	err := client.CopyToContainer(context.Background(), "container_id", "path/to/file", bytes.NewReader([]byte("")), types.CopyToContainerOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestCopyToContainerNotFoundError(t *testing.T) {
@@ -110,9 +106,7 @@ func TestCopyToContainerNotFoundError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusNotFound, "Not found")),
 	}
 	err := client.CopyToContainer(context.Background(), "container_id", "path/to/file", bytes.NewReader([]byte("")), types.CopyToContainerOptions{})
-	if !IsErrNotFound(err) {
-		t.Fatalf("expected a not found error, got %v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 // TestCopyToContainerEmptyResponse verifies that no error is returned when a
@@ -178,9 +172,7 @@ func TestCopyFromContainerError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, _, err := client.CopyFromContainer(context.Background(), "container_id", "path/to/file")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestCopyFromContainerNotFoundError(t *testing.T) {
@@ -188,9 +180,7 @@ func TestCopyFromContainerNotFoundError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusNotFound, "Not found")),
 	}
 	_, _, err := client.CopyFromContainer(context.Background(), "container_id", "path/to/file")
-	if !IsErrNotFound(err) {
-		t.Fatalf("expected a not found error, got %v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 // TestCopyFromContainerEmptyResponse verifies that no error is returned when a

--- a/client/container_create_test.go
+++ b/client/container_create_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestContainerCreateError(t *testing.T) {
@@ -19,18 +21,14 @@ func TestContainerCreateError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ContainerCreate(context.Background(), nil, nil, nil, nil, "nothing")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error while testing StatusInternalServerError, got %T", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 
 	// 404 doesn't automatically means an unknown image
 	client = &Client{
 		client: newMockClient(errorMock(http.StatusNotFound, "Server error")),
 	}
 	_, err = client.ContainerCreate(context.Background(), nil, nil, nil, nil, "nothing")
-	if err == nil || !IsErrNotFound(err) {
-		t.Fatalf("expected a Server Error while testing StatusNotFound, got %T", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestContainerCreateImageNotFound(t *testing.T) {
@@ -38,9 +36,7 @@ func TestContainerCreateImageNotFound(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusNotFound, "No such image")),
 	}
 	_, err := client.ContainerCreate(context.Background(), &container.Config{Image: "unknown_image"}, nil, nil, nil, "unknown")
-	if err == nil || !IsErrNotFound(err) {
-		t.Fatalf("expected an imageNotFound error, got %v, %T", err, err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestContainerCreateWithName(t *testing.T) {

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestContainerExecCreateError(t *testing.T) {
@@ -19,9 +21,7 @@ func TestContainerExecCreateError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ContainerExecCreate(context.Background(), "container_id", types.ExecConfig{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestContainerExecCreate(t *testing.T) {
@@ -74,9 +74,7 @@ func TestContainerExecStartError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	err := client.ContainerExecStart(context.Background(), "nothing", types.ExecStartCheck{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestContainerExecStart(t *testing.T) {
@@ -118,9 +116,7 @@ func TestContainerExecInspectError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ContainerExecInspect(context.Background(), "nothing")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestContainerExecInspect(t *testing.T) {

--- a/client/container_export_test.go
+++ b/client/container_export_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestContainerExportError(t *testing.T) {
@@ -17,9 +19,7 @@ func TestContainerExportError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ContainerExport(context.Background(), "nothing")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestContainerExport(t *testing.T) {

--- a/client/container_inspect_test.go
+++ b/client/container_inspect_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestContainerInspectError(t *testing.T) {
@@ -21,9 +23,7 @@ func TestContainerInspectError(t *testing.T) {
 	}
 
 	_, err := client.ContainerInspect(context.Background(), "nothing")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestContainerInspectContainerNotFound(t *testing.T) {
@@ -32,9 +32,7 @@ func TestContainerInspectContainerNotFound(t *testing.T) {
 	}
 
 	_, err := client.ContainerInspect(context.Background(), "unknown")
-	if err == nil || !IsErrNotFound(err) {
-		t.Fatalf("expected a containerNotFound error, got %v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestContainerInspectWithEmptyID(t *testing.T) {
@@ -44,9 +42,7 @@ func TestContainerInspectWithEmptyID(t *testing.T) {
 		}),
 	}
 	_, _, err := client.ContainerInspectWithRaw(context.Background(), "", true)
-	if !IsErrNotFound(err) {
-		t.Fatalf("Expected NotFoundError, got %v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestContainerInspect(t *testing.T) {

--- a/client/container_kill_test.go
+++ b/client/container_kill_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestContainerKillError(t *testing.T) {
@@ -17,9 +19,7 @@ func TestContainerKillError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	err := client.ContainerKill(context.Background(), "nothing", "SIGKILL")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestContainerKill(t *testing.T) {

--- a/client/container_list_test.go
+++ b/client/container_list_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestContainerListError(t *testing.T) {
@@ -20,9 +22,7 @@ func TestContainerListError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ContainerList(context.Background(), types.ContainerListOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestContainerList(t *testing.T) {

--- a/client/container_logs_test.go
+++ b/client/container_logs_test.go
@@ -23,9 +23,7 @@ func TestContainerLogsNotFoundError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusNotFound, "Not found")),
 	}
 	_, err := client.ContainerLogs(context.Background(), "container_id", types.ContainerLogsOptions{})
-	if !IsErrNotFound(err) {
-		t.Fatalf("expected a not found error, got %v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestContainerLogsError(t *testing.T) {
@@ -33,9 +31,8 @@ func TestContainerLogsError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ContainerLogs(context.Background(), "container_id", types.ContainerLogsOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
+
 	_, err = client.ContainerLogs(context.Background(), "container_id", types.ContainerLogsOptions{
 		Since: "2006-01-02TZ",
 	})

--- a/client/container_pause_test.go
+++ b/client/container_pause_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestContainerPauseError(t *testing.T) {
@@ -17,9 +19,7 @@ func TestContainerPauseError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	err := client.ContainerPause(context.Background(), "nothing")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestContainerPause(t *testing.T) {

--- a/client/container_prune_test.go
+++ b/client/container_prune_test.go
@@ -24,9 +24,7 @@ func TestContainersPruneError(t *testing.T) {
 	}
 
 	_, err := client.ContainersPrune(context.Background(), filters.Args{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestContainersPrune(t *testing.T) {

--- a/client/container_remove_test.go
+++ b/client/container_remove_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestContainerRemoveError(t *testing.T) {
@@ -19,9 +20,7 @@ func TestContainerRemoveError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	err := client.ContainerRemove(context.Background(), "container_id", types.ContainerRemoveOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestContainerRemoveNotFoundError(t *testing.T) {
@@ -29,8 +28,8 @@ func TestContainerRemoveNotFoundError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusNotFound, "no such container: container_id")),
 	}
 	err := client.ContainerRemove(context.Background(), "container_id", types.ContainerRemoveOptions{})
-	assert.ErrorContains(t, err, "no such container: container_id")
-	assert.Check(t, IsErrNotFound(err))
+	assert.Check(t, is.ErrorContains(err, "no such container: container_id"))
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestContainerRemove(t *testing.T) {

--- a/client/container_rename_test.go
+++ b/client/container_rename_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestContainerRenameError(t *testing.T) {
@@ -17,9 +19,7 @@ func TestContainerRenameError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	err := client.ContainerRename(context.Background(), "nothing", "newNothing")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestContainerRename(t *testing.T) {

--- a/client/container_resize_test.go
+++ b/client/container_resize_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestContainerResizeError(t *testing.T) {
@@ -18,9 +20,7 @@ func TestContainerResizeError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	err := client.ContainerResize(context.Background(), "container_id", types.ResizeOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestContainerExecResizeError(t *testing.T) {
@@ -28,9 +28,7 @@ func TestContainerExecResizeError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	err := client.ContainerExecResize(context.Background(), "exec_id", types.ResizeOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestContainerResize(t *testing.T) {

--- a/client/container_restart_test.go
+++ b/client/container_restart_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestContainerRestartError(t *testing.T) {
@@ -18,9 +20,7 @@ func TestContainerRestartError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	err := client.ContainerRestart(context.Background(), "nothing", container.StopOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestContainerRestart(t *testing.T) {

--- a/client/container_start_test.go
+++ b/client/container_start_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestContainerStartError(t *testing.T) {
@@ -19,9 +21,7 @@ func TestContainerStartError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	err := client.ContainerStart(context.Background(), "nothing", types.ContainerStartOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestContainerStart(t *testing.T) {

--- a/client/container_stats_test.go
+++ b/client/container_stats_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestContainerStatsError(t *testing.T) {
@@ -17,9 +19,7 @@ func TestContainerStatsError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ContainerStats(context.Background(), "nothing", false)
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestContainerStats(t *testing.T) {

--- a/client/container_stop_test.go
+++ b/client/container_stop_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestContainerStopError(t *testing.T) {
@@ -18,9 +20,7 @@ func TestContainerStopError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	err := client.ContainerStop(context.Background(), "nothing", container.StopOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestContainerStop(t *testing.T) {

--- a/client/container_top_test.go
+++ b/client/container_top_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestContainerTopError(t *testing.T) {
@@ -20,9 +22,7 @@ func TestContainerTopError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ContainerTop(context.Background(), "nothing", []string{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestContainerTop(t *testing.T) {

--- a/client/container_unpause_test.go
+++ b/client/container_unpause_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestContainerUnpauseError(t *testing.T) {
@@ -17,9 +19,7 @@ func TestContainerUnpauseError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	err := client.ContainerUnpause(context.Background(), "nothing")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestContainerUnpause(t *testing.T) {

--- a/client/container_update_test.go
+++ b/client/container_update_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestContainerUpdateError(t *testing.T) {
@@ -19,9 +21,7 @@ func TestContainerUpdateError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ContainerUpdate(context.Background(), "nothing", container.UpdateConfig{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestContainerUpdate(t *testing.T) {

--- a/client/container_wait_test.go
+++ b/client/container_wait_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestContainerWaitError(t *testing.T) {
@@ -25,9 +27,7 @@ func TestContainerWaitError(t *testing.T) {
 	case result := <-resultC:
 		t.Fatalf("expected to not get a wait result, got %d", result.StatusCode)
 	case err := <-errC:
-		if !errdefs.IsSystem(err) {
-			t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-		}
+		assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 	}
 }
 

--- a/client/disk_usage_test.go
+++ b/client/disk_usage_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestDiskUsageError(t *testing.T) {
@@ -19,9 +21,7 @@ func TestDiskUsageError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.DiskUsage(context.Background(), types.DiskUsageOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestDiskUsage(t *testing.T) {

--- a/client/distribution_inspect_test.go
+++ b/client/distribution_inspect_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -26,7 +27,5 @@ func TestDistributionInspectWithEmptyID(t *testing.T) {
 		}),
 	}
 	_, err := client.DistributionInspect(context.Background(), "", "")
-	if !IsErrNotFound(err) {
-		t.Fatalf("Expected NotFoundError, got %v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }

--- a/client/errors.go
+++ b/client/errors.go
@@ -31,20 +31,10 @@ func ErrorConnectionFailed(host string) error {
 	return errConnectionFailed{host: host}
 }
 
-// Deprecated: use the errdefs.NotFound() interface instead. Kept for backward compatibility
-type notFound interface {
-	error
-	NotFound() bool
-}
-
 // IsErrNotFound returns true if the error is a NotFound error, which is returned
-// by the API when some object is not found.
+// by the API when some object is not found. It is an alias for [errdefs.IsNotFound].
 func IsErrNotFound(err error) bool {
-	if errdefs.IsNotFound(err) {
-		return true
-	}
-	var e notFound
-	return errors.As(err, &e)
+	return errdefs.IsNotFound(err)
 }
 
 type objectNotFoundError struct {

--- a/client/events_test.go
+++ b/client/events_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestEventsErrorInOptions(t *testing.T) {
@@ -52,9 +54,7 @@ func TestEventsErrorFromServer(t *testing.T) {
 	}
 	_, errs := client.Events(context.Background(), types.EventsOptions{})
 	err := <-errs
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestEvents(t *testing.T) {

--- a/client/image_build_test.go
+++ b/client/image_build_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/errdefs"
 	units "github.com/docker/go-units"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestImageBuildError(t *testing.T) {
@@ -22,9 +24,7 @@ func TestImageBuildError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ImageBuild(context.Background(), nil, types.ImageBuildOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestImageBuild(t *testing.T) {

--- a/client/image_create_test.go
+++ b/client/image_create_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestImageCreateError(t *testing.T) {
@@ -19,9 +21,7 @@ func TestImageCreateError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ImageCreate(context.Background(), "reference", types.ImageCreateOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestImageCreate(t *testing.T) {

--- a/client/image_history_test.go
+++ b/client/image_history_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestImageHistoryError(t *testing.T) {
@@ -19,9 +21,7 @@ func TestImageHistoryError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ImageHistory(context.Background(), "nothing")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestImageHistory(t *testing.T) {

--- a/client/image_import_test.go
+++ b/client/image_import_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestImageImportError(t *testing.T) {
@@ -19,9 +21,7 @@ func TestImageImportError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ImageImport(context.Background(), types.ImageImportSource{}, "image:tag", types.ImageImportOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestImageImport(t *testing.T) {

--- a/client/image_inspect_test.go
+++ b/client/image_inspect_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestImageInspectError(t *testing.T) {
@@ -22,9 +24,7 @@ func TestImageInspectError(t *testing.T) {
 	}
 
 	_, _, err := client.ImageInspectWithRaw(context.Background(), "nothing")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestImageInspectImageNotFound(t *testing.T) {
@@ -33,9 +33,7 @@ func TestImageInspectImageNotFound(t *testing.T) {
 	}
 
 	_, _, err := client.ImageInspectWithRaw(context.Background(), "unknown")
-	if err == nil || !IsErrNotFound(err) {
-		t.Fatalf("expected an imageNotFound error, got %v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestImageInspectWithEmptyID(t *testing.T) {
@@ -45,9 +43,7 @@ func TestImageInspectWithEmptyID(t *testing.T) {
 		}),
 	}
 	_, _, err := client.ImageInspectWithRaw(context.Background(), "")
-	if !IsErrNotFound(err) {
-		t.Fatalf("Expected NotFoundError, got %v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestImageInspect(t *testing.T) {

--- a/client/image_list_test.go
+++ b/client/image_list_test.go
@@ -24,9 +24,7 @@ func TestImageListError(t *testing.T) {
 	}
 
 	_, err := client.ImageList(context.Background(), types.ImageListOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestImageList(t *testing.T) {

--- a/client/image_load_test.go
+++ b/client/image_load_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestImageLoadError(t *testing.T) {
@@ -18,9 +20,7 @@ func TestImageLoadError(t *testing.T) {
 	}
 
 	_, err := client.ImageLoad(context.Background(), nil, true)
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestImageLoad(t *testing.T) {

--- a/client/image_prune_test.go
+++ b/client/image_prune_test.go
@@ -25,9 +25,7 @@ func TestImagesPruneError(t *testing.T) {
 	}
 
 	_, err := client.ImagesPrune(context.Background(), filters.NewArgs())
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestImagesPrune(t *testing.T) {

--- a/client/image_pull_test.go
+++ b/client/image_pull_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestImagePullReferenceParseError(t *testing.T) {
@@ -32,9 +34,7 @@ func TestImagePullAnyError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ImagePull(context.Background(), "myimage", types.ImagePullOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestImagePullStatusUnauthorizedError(t *testing.T) {
@@ -42,9 +42,7 @@ func TestImagePullStatusUnauthorizedError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")),
 	}
 	_, err := client.ImagePull(context.Background(), "myimage", types.ImagePullOptions{})
-	if !errdefs.IsUnauthorized(err) {
-		t.Fatalf("expected a Unauthorized Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsUnauthorized))
 }
 
 func TestImagePullWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
@@ -72,9 +70,7 @@ func TestImagePullWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.T)
 	_, err := client.ImagePull(context.Background(), "myimage", types.ImagePullOptions{
 		PrivilegeFunc: privilegeFunc,
 	})
-	if !errdefs.IsUnauthorized(err) {
-		t.Fatalf("expected a Unauthorized Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsUnauthorized))
 }
 
 func TestImagePullWithPrivilegedFuncNoError(t *testing.T) {

--- a/client/image_push_test.go
+++ b/client/image_push_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestImagePushReferenceError(t *testing.T) {
@@ -37,9 +39,7 @@ func TestImagePushAnyError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ImagePush(context.Background(), "myimage", types.ImagePushOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestImagePushStatusUnauthorizedError(t *testing.T) {
@@ -47,9 +47,7 @@ func TestImagePushStatusUnauthorizedError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")),
 	}
 	_, err := client.ImagePush(context.Background(), "myimage", types.ImagePushOptions{})
-	if !errdefs.IsUnauthorized(err) {
-		t.Fatalf("expected a Unauthorized Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsUnauthorized))
 }
 
 func TestImagePushWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
@@ -77,9 +75,7 @@ func TestImagePushWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.T)
 	_, err := client.ImagePush(context.Background(), "myimage", types.ImagePushOptions{
 		PrivilegeFunc: privilegeFunc,
 	})
-	if !errdefs.IsUnauthorized(err) {
-		t.Fatalf("expected a Unauthorized Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsUnauthorized))
 }
 
 func TestImagePushWithPrivilegedFuncNoError(t *testing.T) {

--- a/client/image_remove_test.go
+++ b/client/image_remove_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestImageRemoveError(t *testing.T) {
@@ -21,9 +22,7 @@ func TestImageRemoveError(t *testing.T) {
 	}
 
 	_, err := client.ImageRemove(context.Background(), "image_id", types.ImageRemoveOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestImageRemoveImageNotFound(t *testing.T) {
@@ -32,8 +31,8 @@ func TestImageRemoveImageNotFound(t *testing.T) {
 	}
 
 	_, err := client.ImageRemove(context.Background(), "unknown", types.ImageRemoveOptions{})
-	assert.ErrorContains(t, err, "no such image: unknown")
-	assert.Check(t, IsErrNotFound(err))
+	assert.Check(t, is.ErrorContains(err, "no such image: unknown"))
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestImageRemove(t *testing.T) {

--- a/client/image_save_test.go
+++ b/client/image_save_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestImageSaveError(t *testing.T) {
@@ -18,9 +20,7 @@ func TestImageSaveError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ImageSave(context.Background(), []string{"nothing"})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestImageSave(t *testing.T) {

--- a/client/image_search_test.go
+++ b/client/image_search_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestImageSearchAnyError(t *testing.T) {
@@ -21,9 +23,7 @@ func TestImageSearchAnyError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ImageSearch(context.Background(), "some-image", types.ImageSearchOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestImageSearchStatusUnauthorizedError(t *testing.T) {
@@ -31,9 +31,7 @@ func TestImageSearchStatusUnauthorizedError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")),
 	}
 	_, err := client.ImageSearch(context.Background(), "some-image", types.ImageSearchOptions{})
-	if !errdefs.IsUnauthorized(err) {
-		t.Fatalf("expected a Unauthorized Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsUnauthorized))
 }
 
 func TestImageSearchWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
@@ -61,9 +59,7 @@ func TestImageSearchWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.
 	_, err := client.ImageSearch(context.Background(), "some-image", types.ImageSearchOptions{
 		PrivilegeFunc: privilegeFunc,
 	})
-	if !errdefs.IsUnauthorized(err) {
-		t.Fatalf("expected a Unauthorized Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsUnauthorized))
 }
 
 func TestImageSearchWithPrivilegedFuncNoError(t *testing.T) {

--- a/client/image_tag_test.go
+++ b/client/image_tag_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestImageTagError(t *testing.T) {
@@ -18,9 +20,7 @@ func TestImageTagError(t *testing.T) {
 	}
 
 	err := client.ImageTag(context.Background(), "image_id", "repo:tag")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 // Note: this is not testing all the InvalidReference as it's the responsibility

--- a/client/info_test.go
+++ b/client/info_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestInfoServerError(t *testing.T) {
@@ -19,9 +21,7 @@ func TestInfoServerError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.Info(context.Background())
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestInfoInvalidResponseJSONError(t *testing.T) {

--- a/client/network_connect_test.go
+++ b/client/network_connect_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestNetworkConnectError(t *testing.T) {
@@ -21,9 +23,7 @@ func TestNetworkConnectError(t *testing.T) {
 	}
 
 	err := client.NetworkConnect(context.Background(), "network_id", "container_id", nil)
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestNetworkConnectEmptyNilEndpointSettings(t *testing.T) {

--- a/client/network_create_test.go
+++ b/client/network_create_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestNetworkCreateError(t *testing.T) {
@@ -20,9 +22,7 @@ func TestNetworkCreateError(t *testing.T) {
 	}
 
 	_, err := client.NetworkCreate(context.Background(), "mynetwork", types.NetworkCreate{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestNetworkCreate(t *testing.T) {

--- a/client/network_disconnect_test.go
+++ b/client/network_disconnect_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestNetworkDisconnectError(t *testing.T) {
@@ -20,9 +22,7 @@ func TestNetworkDisconnectError(t *testing.T) {
 	}
 
 	err := client.NetworkDisconnect(context.Background(), "network_id", "container_id", false)
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestNetworkDisconnect(t *testing.T) {

--- a/client/network_inspect_test.go
+++ b/client/network_inspect_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestNetworkInspect(t *testing.T) {
@@ -69,7 +70,7 @@ func TestNetworkInspect(t *testing.T) {
 	t.Run("empty ID", func(t *testing.T) {
 		// verify that the client does not create a request if the network-ID/name is empty.
 		_, err := client.NetworkInspect(context.Background(), "", types.NetworkInspectOptions{})
-		assert.Check(t, IsErrNotFound(err))
+		assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 	})
 	t.Run("no options", func(t *testing.T) {
 		r, err := client.NetworkInspect(context.Background(), "network_id", types.NetworkInspectOptions{})
@@ -87,17 +88,17 @@ func TestNetworkInspect(t *testing.T) {
 	})
 	t.Run("global scope", func(t *testing.T) {
 		_, err := client.NetworkInspect(context.Background(), "network_id", types.NetworkInspectOptions{Scope: "global"})
-		assert.ErrorContains(t, err, "Error: No such network: network_id")
-		assert.Check(t, IsErrNotFound(err))
+		assert.Check(t, is.ErrorContains(err, "Error: No such network: network_id"))
+		assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 	})
 	t.Run("unknown network", func(t *testing.T) {
 		_, err := client.NetworkInspect(context.Background(), "unknown", types.NetworkInspectOptions{})
-		assert.ErrorContains(t, err, "Error: No such network: unknown")
-		assert.Check(t, IsErrNotFound(err))
+		assert.Check(t, is.ErrorContains(err, "Error: No such network: unknown"))
+		assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 	})
 	t.Run("server error", func(t *testing.T) {
 		// Just testing that an internal server error is converted correctly by the client
 		_, err := client.NetworkInspect(context.Background(), "test-500-response", types.NetworkInspectOptions{})
-		assert.Check(t, errdefs.IsSystem(err))
+		assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 	})
 }

--- a/client/network_list_test.go
+++ b/client/network_list_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestNetworkListError(t *testing.T) {
@@ -21,9 +23,7 @@ func TestNetworkListError(t *testing.T) {
 	}
 
 	_, err := client.NetworkList(context.Background(), types.NetworkListOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestNetworkList(t *testing.T) {

--- a/client/network_prune_test.go
+++ b/client/network_prune_test.go
@@ -24,9 +24,7 @@ func TestNetworksPruneError(t *testing.T) {
 	}
 
 	_, err := client.NetworksPrune(context.Background(), filters.NewArgs())
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestNetworksPrune(t *testing.T) {

--- a/client/network_remove_test.go
+++ b/client/network_remove_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestNetworkRemoveError(t *testing.T) {
@@ -18,9 +20,7 @@ func TestNetworkRemoveError(t *testing.T) {
 	}
 
 	err := client.NetworkRemove(context.Background(), "network_id")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestNetworkRemove(t *testing.T) {

--- a/client/node_inspect_test.go
+++ b/client/node_inspect_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestNodeInspectError(t *testing.T) {
@@ -21,9 +23,7 @@ func TestNodeInspectError(t *testing.T) {
 	}
 
 	_, _, err := client.NodeInspectWithRaw(context.Background(), "nothing")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestNodeInspectNodeNotFound(t *testing.T) {
@@ -32,9 +32,7 @@ func TestNodeInspectNodeNotFound(t *testing.T) {
 	}
 
 	_, _, err := client.NodeInspectWithRaw(context.Background(), "unknown")
-	if err == nil || !IsErrNotFound(err) {
-		t.Fatalf("expected a nodeNotFoundError error, got %v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestNodeInspectWithEmptyID(t *testing.T) {
@@ -44,9 +42,7 @@ func TestNodeInspectWithEmptyID(t *testing.T) {
 		}),
 	}
 	_, _, err := client.NodeInspectWithRaw(context.Background(), "")
-	if !IsErrNotFound(err) {
-		t.Fatalf("Expected NotFoundError, got %v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestNodeInspect(t *testing.T) {

--- a/client/node_list_test.go
+++ b/client/node_list_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestNodeListError(t *testing.T) {
@@ -22,9 +24,7 @@ func TestNodeListError(t *testing.T) {
 	}
 
 	_, err := client.NodeList(context.Background(), types.NodeListOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestNodeList(t *testing.T) {

--- a/client/node_remove_test.go
+++ b/client/node_remove_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestNodeRemoveError(t *testing.T) {
@@ -19,9 +21,7 @@ func TestNodeRemoveError(t *testing.T) {
 	}
 
 	err := client.NodeRemove(context.Background(), "node_id", types.NodeRemoveOptions{Force: false})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestNodeRemove(t *testing.T) {

--- a/client/node_update_test.go
+++ b/client/node_update_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestNodeUpdateError(t *testing.T) {
@@ -19,9 +21,7 @@ func TestNodeUpdateError(t *testing.T) {
 	}
 
 	err := client.NodeUpdate(context.Background(), "node_id", swarm.Version{}, swarm.NodeSpec{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestNodeUpdate(t *testing.T) {

--- a/client/ping_test.go
+++ b/client/ping_test.go
@@ -34,7 +34,7 @@ func TestPingFail(t *testing.T) {
 	}
 
 	ping, err := client.Ping(context.Background())
-	assert.ErrorContains(t, err, "some error with the server")
+	assert.Check(t, is.ErrorContains(err, "some error with the server"))
 	assert.Check(t, is.Equal(false, ping.Experimental))
 	assert.Check(t, is.Equal("", ping.APIVersion))
 	var si *swarm.Status
@@ -42,7 +42,7 @@ func TestPingFail(t *testing.T) {
 
 	withHeader = true
 	ping2, err := client.Ping(context.Background())
-	assert.ErrorContains(t, err, "some error with the server")
+	assert.Check(t, is.ErrorContains(err, "some error with the server"))
 	assert.Check(t, is.Equal(true, ping2.Experimental))
 	assert.Check(t, is.Equal("awesome", ping2.APIVersion))
 	assert.Check(t, is.Equal(swarm.Status{NodeState: "inactive"}, *ping2.SwarmStatus))
@@ -64,7 +64,7 @@ func TestPingWithError(t *testing.T) {
 	}
 
 	ping, err := client.Ping(context.Background())
-	assert.ErrorContains(t, err, "some error")
+	assert.Check(t, is.ErrorContains(err, "some error"))
 	assert.Check(t, is.Equal(false, ping.Experimental))
 	assert.Check(t, is.Equal("", ping.APIVersion))
 	var si *swarm.Status

--- a/client/plugin_disable_test.go
+++ b/client/plugin_disable_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestPluginDisableError(t *testing.T) {
@@ -19,9 +21,7 @@ func TestPluginDisableError(t *testing.T) {
 	}
 
 	err := client.PluginDisable(context.Background(), "plugin_name", types.PluginDisableOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestPluginDisable(t *testing.T) {

--- a/client/plugin_enable_test.go
+++ b/client/plugin_enable_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestPluginEnableError(t *testing.T) {
@@ -19,9 +21,7 @@ func TestPluginEnableError(t *testing.T) {
 	}
 
 	err := client.PluginEnable(context.Background(), "plugin_name", types.PluginEnableOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestPluginEnable(t *testing.T) {

--- a/client/plugin_inspect_test.go
+++ b/client/plugin_inspect_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestPluginInspectError(t *testing.T) {
@@ -21,9 +23,7 @@ func TestPluginInspectError(t *testing.T) {
 	}
 
 	_, _, err := client.PluginInspectWithRaw(context.Background(), "nothing")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestPluginInspectWithEmptyID(t *testing.T) {
@@ -33,9 +33,7 @@ func TestPluginInspectWithEmptyID(t *testing.T) {
 		}),
 	}
 	_, _, err := client.PluginInspectWithRaw(context.Background(), "")
-	if !IsErrNotFound(err) {
-		t.Fatalf("Expected NotFoundError, got %v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestPluginInspect(t *testing.T) {

--- a/client/plugin_list_test.go
+++ b/client/plugin_list_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestPluginListError(t *testing.T) {
@@ -21,9 +23,7 @@ func TestPluginListError(t *testing.T) {
 	}
 
 	_, err := client.PluginList(context.Background(), filters.NewArgs())
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestPluginList(t *testing.T) {

--- a/client/plugin_push_test.go
+++ b/client/plugin_push_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestPluginPushError(t *testing.T) {
@@ -19,9 +21,7 @@ func TestPluginPushError(t *testing.T) {
 	}
 
 	_, err := client.PluginPush(context.Background(), "plugin_name", "")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestPluginPush(t *testing.T) {

--- a/client/plugin_remove_test.go
+++ b/client/plugin_remove_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestPluginRemoveError(t *testing.T) {
@@ -19,9 +21,7 @@ func TestPluginRemoveError(t *testing.T) {
 	}
 
 	err := client.PluginRemove(context.Background(), "plugin_name", types.PluginRemoveOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestPluginRemove(t *testing.T) {

--- a/client/plugin_set_test.go
+++ b/client/plugin_set_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestPluginSetError(t *testing.T) {
@@ -18,9 +20,7 @@ func TestPluginSetError(t *testing.T) {
 	}
 
 	err := client.PluginSet(context.Background(), "plugin_name", []string{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestPluginSet(t *testing.T) {

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -88,9 +88,7 @@ func TestPlainTextError(t *testing.T) {
 		client: newMockClient(plainTextErrorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ContainerList(context.Background(), types.ContainerListOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestInfiniteError(t *testing.T) {

--- a/client/secret_create_test.go
+++ b/client/secret_create_test.go
@@ -32,9 +32,7 @@ func TestSecretCreateError(t *testing.T) {
 		client:  newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.SecretCreate(context.Background(), swarm.SecretSpec{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestSecretCreate(t *testing.T) {

--- a/client/secret_inspect_test.go
+++ b/client/secret_inspect_test.go
@@ -33,9 +33,7 @@ func TestSecretInspectError(t *testing.T) {
 	}
 
 	_, _, err := client.SecretInspectWithRaw(context.Background(), "nothing")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestSecretInspectSecretNotFound(t *testing.T) {
@@ -45,9 +43,7 @@ func TestSecretInspectSecretNotFound(t *testing.T) {
 	}
 
 	_, _, err := client.SecretInspectWithRaw(context.Background(), "unknown")
-	if err == nil || !IsErrNotFound(err) {
-		t.Fatalf("expected a secretNotFoundError error, got %v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestSecretInspectWithEmptyID(t *testing.T) {
@@ -57,9 +53,7 @@ func TestSecretInspectWithEmptyID(t *testing.T) {
 		}),
 	}
 	_, _, err := client.SecretInspectWithRaw(context.Background(), "")
-	if !IsErrNotFound(err) {
-		t.Fatalf("Expected NotFoundError, got %v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestSecretInspect(t *testing.T) {

--- a/client/secret_list_test.go
+++ b/client/secret_list_test.go
@@ -34,9 +34,7 @@ func TestSecretListError(t *testing.T) {
 	}
 
 	_, err := client.SecretList(context.Background(), types.SecretListOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestSecretList(t *testing.T) {

--- a/client/secret_remove_test.go
+++ b/client/secret_remove_test.go
@@ -30,9 +30,7 @@ func TestSecretRemoveError(t *testing.T) {
 	}
 
 	err := client.SecretRemove(context.Background(), "secret_id")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestSecretRemove(t *testing.T) {

--- a/client/secret_update_test.go
+++ b/client/secret_update_test.go
@@ -31,9 +31,7 @@ func TestSecretUpdateError(t *testing.T) {
 	}
 
 	err := client.SecretUpdate(context.Background(), "secret_id", swarm.Version{}, swarm.SecretSpec{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestSecretUpdate(t *testing.T) {

--- a/client/service_create_test.go
+++ b/client/service_create_test.go
@@ -25,9 +25,7 @@ func TestServiceCreateError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, types.ServiceCreateOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestServiceCreate(t *testing.T) {

--- a/client/service_inspect_test.go
+++ b/client/service_inspect_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestServiceInspectError(t *testing.T) {
@@ -22,9 +24,7 @@ func TestServiceInspectError(t *testing.T) {
 	}
 
 	_, _, err := client.ServiceInspectWithRaw(context.Background(), "nothing", types.ServiceInspectOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestServiceInspectServiceNotFound(t *testing.T) {
@@ -33,9 +33,7 @@ func TestServiceInspectServiceNotFound(t *testing.T) {
 	}
 
 	_, _, err := client.ServiceInspectWithRaw(context.Background(), "unknown", types.ServiceInspectOptions{})
-	if err == nil || !IsErrNotFound(err) {
-		t.Fatalf("expected a serviceNotFoundError error, got %v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestServiceInspectWithEmptyID(t *testing.T) {
@@ -45,9 +43,7 @@ func TestServiceInspectWithEmptyID(t *testing.T) {
 		}),
 	}
 	_, _, err := client.ServiceInspectWithRaw(context.Background(), "", types.ServiceInspectOptions{})
-	if !IsErrNotFound(err) {
-		t.Fatalf("Expected NotFoundError, got %v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestServiceInspect(t *testing.T) {

--- a/client/service_list_test.go
+++ b/client/service_list_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestServiceListError(t *testing.T) {
@@ -22,9 +24,7 @@ func TestServiceListError(t *testing.T) {
 	}
 
 	_, err := client.ServiceList(context.Background(), types.ServiceListOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestServiceList(t *testing.T) {

--- a/client/service_logs_test.go
+++ b/client/service_logs_test.go
@@ -23,9 +23,8 @@ func TestServiceLogsError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	_, err := client.ServiceLogs(context.Background(), "service_id", types.ContainerLogsOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
+
 	_, err = client.ServiceLogs(context.Background(), "service_id", types.ContainerLogsOptions{
 		Since: "2006-01-02TZ",
 	})

--- a/client/service_remove_test.go
+++ b/client/service_remove_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestServiceRemoveError(t *testing.T) {
@@ -19,9 +20,7 @@ func TestServiceRemoveError(t *testing.T) {
 	}
 
 	err := client.ServiceRemove(context.Background(), "service_id")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestServiceRemoveNotFoundError(t *testing.T) {
@@ -30,8 +29,8 @@ func TestServiceRemoveNotFoundError(t *testing.T) {
 	}
 
 	err := client.ServiceRemove(context.Background(), "service_id")
-	assert.ErrorContains(t, err, "no such service: service_id")
-	assert.Check(t, IsErrNotFound(err))
+	assert.Check(t, is.ErrorContains(err, "no such service: service_id"))
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestServiceRemove(t *testing.T) {

--- a/client/service_update_test.go
+++ b/client/service_update_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestServiceUpdateError(t *testing.T) {
@@ -20,9 +22,7 @@ func TestServiceUpdateError(t *testing.T) {
 	}
 
 	_, err := client.ServiceUpdate(context.Background(), "service_id", swarm.Version{}, swarm.ServiceSpec{}, types.ServiceUpdateOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestServiceUpdate(t *testing.T) {

--- a/client/swarm_get_unlock_key_test.go
+++ b/client/swarm_get_unlock_key_test.go
@@ -22,9 +22,7 @@ func TestSwarmGetUnlockKeyError(t *testing.T) {
 	}
 
 	_, err := client.SwarmGetUnlockKey(context.Background())
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestSwarmGetUnlockKey(t *testing.T) {

--- a/client/swarm_init_test.go
+++ b/client/swarm_init_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestSwarmInitError(t *testing.T) {
@@ -19,9 +21,7 @@ func TestSwarmInitError(t *testing.T) {
 	}
 
 	_, err := client.SwarmInit(context.Background(), swarm.InitRequest{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestSwarmInit(t *testing.T) {

--- a/client/swarm_inspect_test.go
+++ b/client/swarm_inspect_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestSwarmInspectError(t *testing.T) {
@@ -20,9 +22,7 @@ func TestSwarmInspectError(t *testing.T) {
 	}
 
 	_, err := client.SwarmInspect(context.Background())
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestSwarmInspect(t *testing.T) {

--- a/client/swarm_join_test.go
+++ b/client/swarm_join_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestSwarmJoinError(t *testing.T) {
@@ -19,9 +21,7 @@ func TestSwarmJoinError(t *testing.T) {
 	}
 
 	err := client.SwarmJoin(context.Background(), swarm.JoinRequest{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestSwarmJoin(t *testing.T) {

--- a/client/swarm_leave_test.go
+++ b/client/swarm_leave_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestSwarmLeaveError(t *testing.T) {
@@ -18,9 +20,7 @@ func TestSwarmLeaveError(t *testing.T) {
 	}
 
 	err := client.SwarmLeave(context.Background(), false)
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestSwarmLeave(t *testing.T) {

--- a/client/swarm_unlock_test.go
+++ b/client/swarm_unlock_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestSwarmUnlockError(t *testing.T) {
@@ -19,9 +21,7 @@ func TestSwarmUnlockError(t *testing.T) {
 	}
 
 	err := client.SwarmUnlock(context.Background(), swarm.UnlockRequest{UnlockKey: "SWMKEY-1-y6guTZNTwpQeTL5RhUfOsdBdXoQjiB2GADHSRJvbXeU"})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestSwarmUnlock(t *testing.T) {

--- a/client/swarm_update_test.go
+++ b/client/swarm_update_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestSwarmUpdateError(t *testing.T) {
@@ -19,9 +21,7 @@ func TestSwarmUpdateError(t *testing.T) {
 	}
 
 	err := client.SwarmUpdate(context.Background(), swarm.Version{}, swarm.Spec{}, swarm.UpdateFlags{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestSwarmUpdate(t *testing.T) {

--- a/client/task_inspect_test.go
+++ b/client/task_inspect_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestTaskInspectError(t *testing.T) {
@@ -21,9 +23,7 @@ func TestTaskInspectError(t *testing.T) {
 	}
 
 	_, _, err := client.TaskInspectWithRaw(context.Background(), "nothing")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestTaskInspectWithEmptyID(t *testing.T) {
@@ -33,9 +33,7 @@ func TestTaskInspectWithEmptyID(t *testing.T) {
 		}),
 	}
 	_, _, err := client.TaskInspectWithRaw(context.Background(), "")
-	if !IsErrNotFound(err) {
-		t.Fatalf("Expected NotFoundError, got %v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestTaskInspect(t *testing.T) {

--- a/client/task_list_test.go
+++ b/client/task_list_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestTaskListError(t *testing.T) {
@@ -22,9 +24,7 @@ func TestTaskListError(t *testing.T) {
 	}
 
 	_, err := client.TaskList(context.Background(), types.TaskListOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestTaskList(t *testing.T) {

--- a/client/volume_create_test.go
+++ b/client/volume_create_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestVolumeCreateError(t *testing.T) {
@@ -20,9 +22,7 @@ func TestVolumeCreateError(t *testing.T) {
 	}
 
 	_, err := client.VolumeCreate(context.Background(), volume.CreateOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestVolumeCreate(t *testing.T) {

--- a/client/volume_inspect_test.go
+++ b/client/volume_inspect_test.go
@@ -23,9 +23,7 @@ func TestVolumeInspectError(t *testing.T) {
 	}
 
 	_, err := client.VolumeInspect(context.Background(), "nothing")
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestVolumeInspectNotFound(t *testing.T) {
@@ -34,7 +32,7 @@ func TestVolumeInspectNotFound(t *testing.T) {
 	}
 
 	_, err := client.VolumeInspect(context.Background(), "unknown")
-	assert.Check(t, IsErrNotFound(err))
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestVolumeInspectWithEmptyID(t *testing.T) {
@@ -44,9 +42,7 @@ func TestVolumeInspectWithEmptyID(t *testing.T) {
 		}),
 	}
 	_, _, err := client.VolumeInspectWithRaw(context.Background(), "")
-	if !IsErrNotFound(err) {
-		t.Fatalf("Expected NotFoundError, got %v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestVolumeInspect(t *testing.T) {

--- a/client/volume_list_test.go
+++ b/client/volume_list_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestVolumeListError(t *testing.T) {
@@ -21,9 +23,7 @@ func TestVolumeListError(t *testing.T) {
 	}
 
 	_, err := client.VolumeList(context.Background(), volume.ListOptions{})
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestVolumeList(t *testing.T) {

--- a/client/volume_remove_test.go
+++ b/client/volume_remove_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestVolumeRemoveError(t *testing.T) {
@@ -18,9 +20,7 @@ func TestVolumeRemoveError(t *testing.T) {
 	}
 
 	err := client.VolumeRemove(context.Background(), "volume_id", false)
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestVolumeRemove(t *testing.T) {

--- a/client/volume_update_test.go
+++ b/client/volume_update_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestVolumeUpdateError(t *testing.T) {
@@ -20,10 +22,7 @@ func TestVolumeUpdateError(t *testing.T) {
 	}
 
 	err := client.VolumeUpdate(context.Background(), "", swarm.Version{}, volumetypes.UpdateOptions{})
-
-	if !errdefs.IsSystem(err) {
-		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
 func TestVolumeUpdate(t *testing.T) {

--- a/integration-cli/daemon/daemon_swarm.go
+++ b/integration-cli/daemon/daemon_swarm.go
@@ -9,7 +9,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
 )
 
@@ -68,7 +68,7 @@ func (d *Daemon) CheckPluginRunning(plugin string) func(c *testing.T) (interface
 	return func(c *testing.T) (interface{}, string) {
 		apiclient := d.NewClientT(c)
 		resp, _, err := apiclient.PluginInspectWithRaw(context.Background(), plugin)
-		if client.IsErrNotFound(err) {
+		if errdefs.IsNotFound(err) {
 			return false, fmt.Sprintf("%v", err)
 		}
 		assert.NilError(c, err)
@@ -81,7 +81,7 @@ func (d *Daemon) CheckPluginImage(plugin string) func(c *testing.T) (interface{}
 	return func(c *testing.T) (interface{}, string) {
 		apiclient := d.NewClientT(c)
 		resp, _, err := apiclient.PluginInspectWithRaw(context.Background(), plugin)
-		if client.IsErrNotFound(err) {
+		if errdefs.IsNotFound(err) {
 			return false, fmt.Sprintf("%v", err)
 		}
 		assert.NilError(c, err)

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -2153,7 +2153,7 @@ func (s *DockerAPISuite) TestContainersAPICreateMountsCreate(c *testing.T) {
 			// anonymous volumes are removed
 			default:
 				_, err := apiclient.VolumeInspect(ctx, mountPoint.Name)
-				assert.Check(c, client.IsErrNotFound(err))
+				assert.Check(c, is.ErrorType(err, errdefs.IsNotFound))
 			}
 		})
 	}

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/daemon"
 	testdaemon "github.com/docker/docker/testutil/daemon"
@@ -1042,5 +1042,5 @@ func (s *DockerSwarmSuite) TestAPINetworkInspectWithScope(c *testing.T) {
 	assert.Check(c, is.Equal(resp.ID, network.ID))
 
 	_, err = apiclient.NetworkInspect(ctx, name, types.NetworkInspectOptions{Scope: "local"})
-	assert.Check(c, client.IsErrNotFound(err))
+	assert.Check(c, is.ErrorType(err, errdefs.IsNotFound))
 }

--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -29,8 +29,8 @@ func TestCopyFromContainerPathDoesNotExist(t *testing.T) {
 	cid := container.Create(ctx, t, apiclient)
 
 	_, _, err := apiclient.CopyFromContainer(ctx, cid, "/dne")
-	assert.Check(t, client.IsErrNotFound(err))
-	assert.ErrorContains(t, err, "Could not find the file /dne in container "+cid)
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, is.ErrorContains(err, "Could not find the file /dne in container "+cid))
 }
 
 func TestCopyFromContainerPathIsNotDir(t *testing.T) {
@@ -58,8 +58,8 @@ func TestCopyToContainerPathDoesNotExist(t *testing.T) {
 	cid := container.Create(ctx, t, apiclient)
 
 	err := apiclient.CopyToContainer(ctx, cid, "/dne", nil, types.CopyToContainerOptions{})
-	assert.Check(t, client.IsErrNotFound(err))
-	assert.ErrorContains(t, err, "Could not find the file /dne in container "+cid)
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, is.ErrorContains(err, "Could not find the file /dne in container "+cid))
 }
 
 func TestCopyEmptyFile(t *testing.T) {
@@ -115,7 +115,7 @@ func TestCopyToContainerPathIsNotDir(t *testing.T) {
 		path = "c:/windows/system32/drivers/etc/hosts/"
 	}
 	err := apiclient.CopyToContainer(ctx, cid, path, nil, types.CopyToContainerOptions{})
-	assert.Assert(t, is.ErrorContains(err, "not a directory"))
+	assert.Check(t, is.ErrorContains(err, "not a directory"))
 }
 
 func TestCopyFromContainer(t *testing.T) {

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -13,7 +13,6 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/versions"
-	"github.com/docker/docker/client"
 	"github.com/docker/docker/errdefs"
 	ctr "github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/oci"
@@ -481,7 +480,7 @@ func TestCreateDifferentPlatform(t *testing.T) {
 			Variant:      img.Variant,
 		}
 		_, err := c.ContainerCreate(ctx, &containertypes.Config{Image: "busybox:latest"}, &containertypes.HostConfig{}, nil, &p, "")
-		assert.Assert(t, client.IsErrNotFound(err), err)
+		assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 	})
 	t.Run("different cpu arch", func(t *testing.T) {
 		p := ocispec.Platform{
@@ -490,7 +489,7 @@ func TestCreateDifferentPlatform(t *testing.T) {
 			Variant:      img.Variant,
 		}
 		_, err := c.ContainerCreate(ctx, &containertypes.Config{Image: "busybox:latest"}, &containertypes.HostConfig{}, nil, &p, "")
-		assert.Assert(t, client.IsErrNotFound(err), err)
+		assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 	})
 }
 

--- a/integration/internal/container/states.go
+++ b/integration/internal/container/states.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 	"gotest.tools/v3/poll"
 )
@@ -63,7 +64,7 @@ func IsRemoved(ctx context.Context, cli client.APIClient, containerID string) fu
 	return func(log poll.LogT) poll.Result {
 		inspect, err := cli.ContainerInspect(ctx, containerID)
 		if err != nil {
-			if client.IsErrNotFound(err) {
+			if errdefs.IsNotFound(err) {
 				return poll.Success()
 			}
 			return poll.Error(err)

--- a/testutil/daemon/plugin.go
+++ b/testutil/daemon/plugin.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/poll"
 )
 
@@ -33,7 +34,7 @@ func (d *Daemon) PluginIsNotRunning(t testing.TB, name string) func(poll.LogT) p
 func (d *Daemon) PluginIsNotPresent(t testing.TB, name string) func(poll.LogT) poll.Result {
 	return withClient(t, d, func(c client.APIClient, t poll.LogT) poll.Result {
 		_, _, err := c.PluginInspectWithRaw(context.Background(), name)
-		if client.IsErrNotFound(err) {
+		if errdefs.IsNotFound(err) {
 			return poll.Success()
 		}
 		if err != nil {
@@ -56,7 +57,7 @@ func (d *Daemon) PluginReferenceIs(t testing.TB, name, expectedRef string) func(
 func withPluginInspect(name string, f func(*types.Plugin, poll.LogT) poll.Result) func(client.APIClient, poll.LogT) poll.Result {
 	return func(c client.APIClient, t poll.LogT) poll.Result {
 		plugin, _, err := c.PluginInspectWithRaw(context.Background(), name)
-		if client.IsErrNotFound(err) {
+		if errdefs.IsNotFound(err) {
 			return poll.Continue("plugin %q not found", name)
 		}
 		if err != nil {

--- a/testutil/environment/clean.go
+++ b/testutil/environment/clean.go
@@ -74,7 +74,7 @@ func deleteAllContainers(t testing.TB, apiclient client.ContainerAPIClient, prot
 			Force:         true,
 			RemoveVolumes: true,
 		})
-		if err == nil || client.IsErrNotFound(err) || alreadyExists.MatchString(err.Error()) || isErrNotFoundSwarmClassic(err) {
+		if err == nil || errdefs.IsNotFound(err) || alreadyExists.MatchString(err.Error()) || isErrNotFoundSwarmClassic(err) {
 			continue
 		}
 		assert.Check(t, err, "failed to remove %s", container.ID)
@@ -115,7 +115,7 @@ func removeImage(ctx context.Context, t testing.TB, apiclient client.ImageAPICli
 	_, err := apiclient.ImageRemove(ctx, ref, types.ImageRemoveOptions{
 		Force: true,
 	})
-	if client.IsErrNotFound(err) {
+	if errdefs.IsNotFound(err) {
 		return
 	}
 	assert.Check(t, err, "failed to remove image %s", ref)


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/35069
- relates to https://github.com/docker/cli/pull/4282


None of the client will return the old error-types, so there's no need
to keep the compatibility code. We can consider deprecating this function
in favor of the errdefs equivalent this.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

