### PR TITLE
[24.0 backport] c8d: image history – handle dangling images

### DIFF
--- a/daemon/containerd/image_history.go
+++ b/daemon/containerd/image_history.go
@@ -90,13 +90,16 @@ func (i *ImageService) ImageHistory(ctx context.Context, name string) ([]*imaget
 			return nil, err
 		}
 
-		tags := make([]string, len(tagged))
-		for i, t := range tagged {
+		var tags []string
+		for _, t := range tagged {
+			if isDanglingImage(t) {
+				continue
+			}
 			name, err := reference.ParseNamed(t.Name)
 			if err != nil {
 				return nil, err
 			}
-			tags[i] = reference.FamiliarString(name)
+			tags = append(tags, reference.FamiliarString(name))
 		}
 		history[0].Tags = tags
 	}


### PR DESCRIPTION
backports https://github.com/moby/moby/pull/45508

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

