### PR TITLE
c8d: Better handling of partially filled `AuthConfig`

### DIFF
--- a/daemon/containerd/resolver.go
+++ b/daemon/containerd/resolver.go
@@ -51,7 +51,7 @@ func hostsWrapper(hostsFn docker.RegistryHosts, authConfig *registrytypes.AuthCo
 
 func authorizationCredsFromAuthConfig(authConfig registrytypes.AuthConfig) docker.AuthorizerOpt {
 	cfgHost := registry.ConvertToHostname(authConfig.ServerAddress)
-	if cfgHost == registry.IndexHostname {
+	if cfgHost == "" || cfgHost == registry.IndexHostname {
 		cfgHost = registry.DefaultRegistryHost
 	}
 


### PR DESCRIPTION
### c8d/authorizer: Default to docker.io

When the `ServerAddress` in the `AuthConfig` provided by the client is empty, default to the default registry (registry-1.docker.io).

This makes the behaviour the same as with the containerd image store integration disabled.

https://github.com/moby/moby/blob/e58c267d66cd9c8fc89c582047b22158c9d44db8/registry/service.go#L67-L69

This fixes an issue where Docker Desktop users couldn't pull private images when using credentials provided by the Docker Desktop credential helper (without `docker login`).

### c8d: Don't create authorizer for empty AuthConfig
- Fixes: https://github.com/moby/moby/issues/45397

Don't create an authorizer just to return empty credentials and log warning about registry host not matching the (empty) host from auth config.


**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

