### PR TITLE
bin-image bake target

### DIFF
--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -1,0 +1,72 @@
+name: bin-image
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+      - '[0-9]+.[0-9]+'
+    tags:
+      - 'v*'
+  pull_request:
+
+env:
+  PLATFORM: Moby Engine
+  PRODUCT: Moby
+  DEFAULT_PRODUCT_LICENSE: Moby
+  PACKAGER_NAME: Moby
+
+jobs:
+  validate-dco:
+    uses: ./.github/workflows/.dco.yml
+
+  build:
+    runs-on: ubuntu-20.04
+    needs:
+      - validate-dco
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: moby-bin
+          ### versioning strategy
+          ## push semver tag v23.0.0
+          # moby/moby-bin:23.0.0
+          # moby/moby-bin:latest
+          ## push semver prelease tag v23.0.0-beta.1
+          # moby/moby-bin:23.0.0-beta.1
+          ## push on master
+          # moby/moby-bin:master
+          ## push on 23.0 branch
+          # moby/moby-bin:23.0
+          tags: |
+            type=semver,pattern={{version}}
+            type=ref,event=branch
+            type=ref,event=pr
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Build
+        uses: docker/bake-action@v2
+        with:
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          targets: bin-image-cross
+          set: |
+            *.output=type=cacheonly

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -59,6 +59,11 @@ variable "GITHUB_SHA" {
   default = ""
 }
 
+# Special target: https://github.com/docker/metadata-action#bake-definition
+target "docker-metadata-action" {
+  tags = ["moby-bin:local"]
+}
+
 # Defines the output folder
 variable "DESTDIR" {
   default = ""
@@ -157,8 +162,7 @@ target "all-cross" {
 #
 
 target "bin-image" {
-  inherits = ["all"]
-  tags = ["moby-bin:local"]
+  inherits = ["all", "docker-metadata-action"]
   output = ["type=docker"]
 }
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -153,6 +153,30 @@ target "all-cross" {
 }
 
 #
+# bin image
+#
+
+target "bin-image" {
+  inherits = ["all"]
+  tags = ["moby-bin:local"]
+  output = ["type=docker"]
+}
+
+target "bin-image-cross" {
+  inherits = ["bin-image"]
+  output = ["type=image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm/v6",
+    "linux/arm/v7",
+    "linux/arm64",
+    "linux/ppc64le",
+    "linux/s390x",
+    "windows/amd64"
+  ]
+}
+
+#
 # dev
 #
 


### PR DESCRIPTION
follow-up https://github.com/moby/moby/pull/44740#pullrequestreview-1422002811

**- What I did**

Add `bin-image` and `bin-image-cross` bake targets to build and load a non-runnable image containing bundles.

Also adds a workflow that will just build this target for sanity check. In follow-up we could then update the workflow to login to the registry and push this image.

**- How I did it**

**- How to verify it**

```bash
# load moby-bin:local image to docker
$ docker buildx bake bin-image
# push multi-platform image to craymax/moby-bin:latest
$ docker buildx bake bin-image-cross --set *.tags=crazymax/moby-bin:latest --push
```

https://explore.ggcr.dev/?image=crazymax/moby-bin:latest

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

