### PR TITLE
c8d: The authorizer needs to be set even if AuthConfig is empty

### DIFF
--- a/daemon/containerd/resolver.go
+++ b/daemon/containerd/resolver.go
@@ -27,10 +27,7 @@ func (i *ImageService) newResolverFromAuthConfig(authConfig *registrytypes.AuthC
 func hostsWrapper(hostsFn docker.RegistryHosts, optAuthConfig *registrytypes.AuthConfig, regService RegistryConfigProvider) docker.RegistryHosts {
 	var authorizer docker.Authorizer
 	if optAuthConfig != nil {
-		auth := *optAuthConfig
-		if auth != (registrytypes.AuthConfig{}) {
-			authorizer = docker.NewDockerAuthorizer(authorizationCredsFromAuthConfig(auth))
-		}
+		authorizer = docker.NewDockerAuthorizer(authorizationCredsFromAuthConfig(*optAuthConfig))
 	}
 
 	return func(n string) ([]docker.RegistryHost, error) {


### PR DESCRIPTION
**- What I did**

Without the authorizer pulling will fail if the user is not logged-in. 

Fixes #45529

Relates to #45517

**- How I did it**

We now only check if the auth config is nil (it actually never is), we don't check if it's empty.

**- How to verify it**

```console
$ docker logout
$ docker pull hello-world
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

