### PR TITLE
Allow empty body in `POST /commit` again

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -44,7 +44,7 @@ func (s *containerRouter) postCommit(ctx context.Context, w http.ResponseWriter,
 	}
 
 	config, _, _, err := s.decoder.DecodeConfig(r.Body)
-	if err != nil && err != io.EOF { // Do not fail if body is empty.
+	if err != nil && !errors.Is(err, io.EOF) { // Do not fail if body is empty.
 		return err
 	}
 
@@ -486,6 +486,9 @@ func (s *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 
 	config, hostConfig, networkingConfig, err := s.decoder.DecodeConfig(r.Body)
 	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return errdefs.InvalidParameter(errors.New("invalid JSON: got EOF while reading request body"))
+		}
 		return err
 	}
 	version := httputils.VersionFromContext(ctx)

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -77,10 +77,7 @@ func decodeContainerConfig(src io.Reader, si *sysinfo.SysInfo) (*container.Confi
 func loadJSON(src io.Reader, out interface{}) error {
 	dec := json.NewDecoder(src)
 	if err := dec.Decode(&out); err != nil {
-		if err == io.EOF {
-			return validationError("invalid JSON: got EOF while reading request body")
-		}
-		return validationError("invalid JSON: " + err.Error())
+		return invalidJSONError{Err: err}
 	}
 	if dec.More() {
 		return validationError("unexpected content after JSON")

--- a/runconfig/errors.go
+++ b/runconfig/errors.go
@@ -40,3 +40,17 @@ func (e validationError) Error() string {
 }
 
 func (e validationError) InvalidParameter() {}
+
+type invalidJSONError struct {
+	Err error
+}
+
+func (e invalidJSONError) Error() string {
+	return "invalid JSON: " + e.Err.Error()
+}
+
+func (e invalidJSONError) Unwrap() error {
+	return e.Err
+}
+
+func (e invalidJSONError) InvalidParameter() {}


### PR DESCRIPTION
- Fixes #45543

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed a regression in the `POST /commit` API endpoint which made it an error to not include a JSON body in the request. This regression went unnoticed because a bug in the client caused it to always send a request body of
```json
null
```
when `options.Config == nil`.

**- How I did it**
I changed `runconfig.loadJSON` to return an error which wraps the error from the JSON decoder so that the caller can once again test whether the error is `io.EOF`.

I modified the client to treat typed-nil request objects the same as untyped nil: a signal that the request should not have a body. This may be a controversial change as it will break client compatibility with buggy daemons, though I feel it is necessary for the long-term health of the project. The regression snuck in because the quirks of the client let it go unnoticed; making the client less quirky forces us to not become dependent on those quirks. (I also want to see what else a full CI run with this client change reveals.)

**- How to verify it**
Existing integration tests fail after the first commit, and pass after the second.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Fixed a regression in `POST /commit` which made it an error to make a request with no body.

**- A picture of a cute animal (not mandatory but encouraged)**

