### PR TITLE
Fix minor swagger spec type differences

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4307,6 +4307,9 @@ definitions:
               - "updating"
               - "paused"
               - "completed"
+              - "rollback_started"
+              - "rollback_paused"
+              - "rollback_completed"
           StartedAt:
             type: "string"
             format: "dateTime"
@@ -4595,6 +4598,16 @@ definitions:
       Spec:
         $ref: "#/definitions/SecretSpec"
 
+  SecretCreateResponse:
+    description: "Contains the information returned to a client on the creation of a new secret."
+    type: "object"
+    required: ["ID"]
+    properties:
+      ID:
+        description: "The id of the newly created secret"
+        type: "string"
+        x-nullable: false
+
   ConfigSpec:
     type: "object"
     properties:
@@ -4634,6 +4647,16 @@ definitions:
         format: "dateTime"
       Spec:
         $ref: "#/definitions/ConfigSpec"
+
+  ConfigCreateResponse:
+    description: "Contains the information returned to a client on the creation of a new config."
+    type: "object"
+    required: ["ID"]
+    properties:
+      ID:
+        description: "The id of the newly created config"
+        type: "string"
+        x-nullable: false
 
   ContainerState:
     description: |
@@ -11738,7 +11761,7 @@ paths:
         201:
           description: "no error"
           schema:
-            $ref: "#/definitions/IdResponse"
+            $ref: "#/definitions/SecretCreateResponse"
         409:
           description: "name conflicts with an existing object"
           schema:
@@ -11945,7 +11968,7 @@ paths:
         201:
           description: "no error"
           schema:
-            $ref: "#/definitions/IdResponse"
+            $ref: "#/definitions/ConfigCreateResponse"
         409:
           description: "name conflicts with an existing object"
           schema:

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -737,7 +737,7 @@ type NetworksPruneReport struct {
 // on the creation of a new secret.
 type SecretCreateResponse struct {
 	// ID is the id of the created secret.
-	ID string
+	ID string `json:"ID"`
 }
 
 // SecretListOptions holds parameters to list secrets
@@ -749,7 +749,7 @@ type SecretListOptions struct {
 // on the creation of a new config.
 type ConfigCreateResponse struct {
 	// ID is the id of the created config.
-	ID string
+	ID string `json:"ID"`
 }
 
 // ConfigListOptions holds parameters to list configs


### PR DESCRIPTION
no issue
- Update IDResponse to use the correct casing for ID
- Add missing UpdateStatus enum values

**- What I did**

Made a couple of small fixes to the swagger.yaml spec. I've been auto-generating a Typescript client for Docker Swarm in a project I've been working on, and noticed these type differences when debugging an issue.

**- How I did it**

Via the github.dev web editor 😛 (not sure this applies since it's a docs change)

**- How to verify it**

Not 100% sure on this - looking at other spots in the API code it appears that IdResponse is used in a few places. The place I noticed the type difference is in the `/secrets/create` and `/configs/create` API responses - but looking at the code those endpoints don't actually return an IDResponse struct, they return specific structs for those endpoints.

Given that endpoints other than secrets/configs use IdResponse directly, it might make more sense to update the spec instead to have `/secrets/create` and `/configs/create` return their own types (rather than having them incorrectly noted as returning IdResponse). Modifying IdResponse directly technically fixes the type differences, but also may cause the response structure to change in the other API endpoints that _are_ using IdResponse directly. Happy to change this approach if it's needed, though if breaking changes in JSON field cases are allowed, it might make sense to remove the endpoint-specific types used by secrets/configs in favor of actually using the IdResponse struct (hopefully that makes sense 😅)

Regarding the UpdateStatus missing enum values, I'm not entirely sure why the diff exists - from the looks of it the swagger.yaml isn't autogenerating the UpdateStatus enums, so it could just be a case of a missed update.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Update IdResponse and UpdateStatus definitions in Swagger to match implementation.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/moby/moby/assets/5167581/dca36c8f-11b7-492a-9d54-730fc14b7ee2)

