### PR TITLE
build: use daemon id as worker id for the graph driver controller

### DIFF
--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -78,6 +78,7 @@ var cacheFields = map[string]bool{
 type Opt struct {
 	SessionManager      *session.Manager
 	Root                string
+	EngineID            string
 	Dist                images.DistributionServices
 	ImageTagger         mobyexporter.ImageTagger
 	NetworkController   *libnetwork.Controller

--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -16,7 +16,6 @@ import (
 	"github.com/docker/docker/builder/builder-next/adapters/containerimage"
 	"github.com/docker/docker/builder/builder-next/adapters/localinlinecache"
 	"github.com/docker/docker/builder/builder-next/adapters/snapshot"
-	"github.com/docker/docker/builder/builder-next/exporter"
 	"github.com/docker/docker/builder/builder-next/exporter/mobyexporter"
 	"github.com/docker/docker/builder/builder-next/imagerefchecker"
 	mobyworker "github.com/docker/docker/builder/builder-next/worker"
@@ -312,7 +311,7 @@ func newGraphDriverController(ctx context.Context, rt http.RoundTripper, opt Opt
 	}
 
 	wopt := mobyworker.Opt{
-		ID:                exporter.Moby,
+		ID:                opt.EngineID,
 		ContentStore:      store,
 		CacheManager:      cm,
 		GCPolicy:          gcPolicy,

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -351,6 +351,7 @@ func newRouterOptions(ctx context.Context, config *config.Config, d *daemon.Daem
 	bk, err := buildkit.New(ctx, buildkit.Opt{
 		SessionManager:      sm,
 		Root:                filepath.Join(config.Root, "buildkit"),
+		EngineID:            d.ID(),
 		Dist:                d.DistributionServices(),
 		ImageTagger:         d.ImageService(),
 		NetworkController:   d.NetworkController(),

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -131,6 +131,11 @@ type Daemon struct {
 	mdDB *bbolt.DB
 }
 
+// ID returns the daemon id
+func (daemon *Daemon) ID() string {
+	return daemon.id
+}
+
 // StoreHosts stores the addresses the daemon is listening on
 func (daemon *Daemon) StoreHosts(hosts []string) {
 	if daemon.hosts == nil {


### PR DESCRIPTION
**- What I did**

Current worker ID for the graph driver controller is static but should be generated like we do with the snapshotter controller:
* https://github.com/moby/moby/blob/2ea5c1af57ea484e37a196fc18a1b547e87fd03a/builder/builder-next/controller.go#L84
* https://github.com/moby/moby/blob/2ea5c1af57ea484e37a196fc18a1b547e87fd03a/vendor/github.com/moby/buildkit/worker/containerd/containerd.go#L51-L54

**- How I did it**

Use the daemon ID as worker ID for the graph driver controller.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

___

Not related to this change but looking at https://github.com/moby/moby/blob/2ea5c1af57ea484e37a196fc18a1b547e87fd03a/vendor/github.com/moby/buildkit/worker/containerd/containerd.go#L50

https://github.com/containerd/containerd/issues/1862, we could make some changes for the containerd worker on BuildKit to use the UUID provided by containerd: https://github.com/containerd/containerd/pull/3474 (cc @tonistiigi @jedevc)