### PR TITLE
[23.0 backport] build: use daemon id as worker id for the graph driver controller

### DIFF
--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -69,6 +69,7 @@ var cacheFields = map[string]bool{
 type Opt struct {
 	SessionManager      *session.Manager
 	Root                string
+	EngineID            string
 	Dist                images.DistributionServices
 	NetworkController   libnetwork.NetworkController
 	ImageTagger         containerimageexp.ImageTagger

--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -191,7 +191,7 @@ func newController(rt http.RoundTripper, opt Opt) (*control.Controller, error) {
 	}
 
 	wopt := mobyworker.Opt{
-		ID:                "moby",
+		ID:                opt.EngineID,
 		ContentStore:      store,
 		CacheManager:      cm,
 		GCPolicy:          gcPolicy,

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -294,6 +294,7 @@ func newRouterOptions(config *config.Config, d *daemon.Daemon) (routerOptions, e
 	bk, err := buildkit.New(buildkit.Opt{
 		SessionManager:      sm,
 		Root:                filepath.Join(config.Root, "buildkit"),
+		EngineID:            d.ID(),
 		Dist:                d.DistributionServices(),
 		ImageTagger:         d.ImageService(),
 		NetworkController:   d.NetworkController(),

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -127,6 +127,11 @@ type Daemon struct {
 	mdDB *bbolt.DB
 }
 
+// ID returns the daemon id
+func (daemon *Daemon) ID() string {
+	return daemon.id
+}
+
 // StoreHosts stores the addresses the daemon is listening on
 func (daemon *Daemon) StoreHosts(hosts []string) {
 	if daemon.hosts == nil {


### PR DESCRIPTION
* backport of https://github.com/moby/moby/pull/45557

not a clean cherry pick due to containerd snapshotter impl.