### PR TITLE
[24.0 backport] build: use daemon id as worker id for the graph driver controller

### DIFF
--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -78,6 +78,7 @@ var cacheFields = map[string]bool{
 type Opt struct {
 	SessionManager      *session.Manager
 	Root                string
+	EngineID            string
 	Dist                images.DistributionServices
 	ImageTagger         mobyexporter.ImageTagger
 	NetworkController   *libnetwork.Controller

--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -16,7 +16,6 @@ import (
 	"github.com/docker/docker/builder/builder-next/adapters/containerimage"
 	"github.com/docker/docker/builder/builder-next/adapters/localinlinecache"
 	"github.com/docker/docker/builder/builder-next/adapters/snapshot"
-	"github.com/docker/docker/builder/builder-next/exporter"
 	"github.com/docker/docker/builder/builder-next/exporter/mobyexporter"
 	"github.com/docker/docker/builder/builder-next/imagerefchecker"
 	mobyworker "github.com/docker/docker/builder/builder-next/worker"
@@ -312,7 +311,7 @@ func newGraphDriverController(ctx context.Context, rt http.RoundTripper, opt Opt
 	}
 
 	wopt := mobyworker.Opt{
-		ID:                exporter.Moby,
+		ID:                opt.EngineID,
 		ContentStore:      store,
 		CacheManager:      cm,
 		GCPolicy:          gcPolicy,

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -351,6 +351,7 @@ func newRouterOptions(ctx context.Context, config *config.Config, d *daemon.Daem
 	bk, err := buildkit.New(ctx, buildkit.Opt{
 		SessionManager:      sm,
 		Root:                filepath.Join(config.Root, "buildkit"),
+		EngineID:            d.ID(),
 		Dist:                d.DistributionServices(),
 		ImageTagger:         d.ImageService(),
 		NetworkController:   d.NetworkController(),

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -131,6 +131,11 @@ type Daemon struct {
 	mdDB *bbolt.DB
 }
 
+// ID returns the daemon id
+func (daemon *Daemon) ID() string {
+	return daemon.id
+}
+
 // StoreHosts stores the addresses the daemon is listening on
 func (daemon *Daemon) StoreHosts(hosts []string) {
 	if daemon.hosts == nil {


### PR DESCRIPTION
* backport of https://github.com/moby/moby/pull/45557 (clean)