### PR TITLE
fix: `docker pull` with platform checks wrong image tag

### DIFF
--- a/daemon/images/image_pull.go
+++ b/daemon/images/image_pull.go
@@ -63,7 +63,7 @@ func (i *ImageService) PullImage(ctx context.Context, image, tag string, platfor
 		// we allow the image to have a non-matching architecture. The code
 		// below checks for this situation, and returns a warning to the client,
 		// as well as logging it to the daemon logs.
-		img, err := i.GetImage(ctx, image, imagetypes.GetImageOpts{Platform: platform})
+		img, err := i.GetImage(ctx, ref.String(), imagetypes.GetImageOpts{Platform: platform})
 
 		// Note that this is a special case where GetImage returns both an image
 		// and an error: https://github.com/docker/docker/blob/v20.10.7/daemon/images/image.go#L175-L183


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Related**

- closes https://github.com/moby/moby/issues/45558
- (this might also close) https://github.com/docker/cli/issues/4295
- closes https://github.com/docker/cli/issues/4312

**- What I did**

Fix a bug where, if a user pulls an image with a tag != `latest` and a specific platform, we return an NotFound error for the wrong (`latest`) tag. see: https://github.com/moby/moby/issues/45558

This bug was introduced in https://github.com/moby/moby/commit/779a5b3029473c6bb61c2d08a43e0a8d68a73d7f in the changes to `daemon/images/image_pull.go`, when we started returning the error from the call to `GetImage` after the pull. 

We started doing this call – in https://github.com/moby/moby/commit/424c0eb3c09d373aaa9c72d81bb1c557d2e0f2e1 – if pulling with a specified platform, to check if the platform of the pulled image matches the requested platform (for cases with single-arch images). However, when we call `GetImage` we're not passing the image tag, only name, so `GetImage` assumes `latest` which breaks when the user has requested a different tag.

**- How I did it**

**- How to verify it**

- `docker pull --platform amd64 quay.io/ansible/docker-test-containers:hello-world `

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

`fix error when pulling an image for a specific platform when tag != "latest"`

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/moby/moby/assets/70572044/232e4457-ff9b-4ce8-9767-116d141d4526)
