### PR TITLE
[24.0 backport] fix: `docker pull` with platform checks wrong image tag

### DIFF
--- a/daemon/images/image_pull.go
+++ b/daemon/images/image_pull.go
@@ -63,7 +63,7 @@ func (i *ImageService) PullImage(ctx context.Context, image, tag string, platfor
 		// we allow the image to have a non-matching architecture. The code
 		// below checks for this situation, and returns a warning to the client,
 		// as well as logging it to the daemon logs.
-		img, err := i.GetImage(ctx, image, imagetypes.GetImageOpts{Platform: platform})
+		img, err := i.GetImage(ctx, ref.String(), imagetypes.GetImageOpts{Platform: platform})
 
 		// Note that this is a special case where GetImage returns both an image
 		// and an error: https://github.com/docker/docker/blob/v20.10.7/daemon/images/image.go#L175-L183


### PR DESCRIPTION
- backports: https://github.com/moby/moby/pull/45561
- closes https://github.com/moby/moby/issues/45558
- (this might also close) https://github.com/docker/cli/issues/4295
- closes https://github.com/docker/cli/issues/4312

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/moby/moby/assets/70572044/232e4457-ff9b-4ce8-9767-116d141d4526)

