### PR TITLE
[24.0 backport] api/inspect: Fix nil RepoTags and RepoDigests

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -282,6 +282,14 @@ func (ir *imageRouter) toImageInspect(img *image.Image) (*types.ImageInspect, er
 		comment = img.History[len(img.History)-1].Comment
 	}
 
+	// Make sure we output empty arrays instead of nil.
+	if repoTags == nil {
+		repoTags = []string{}
+	}
+	if repoDigests == nil {
+		repoDigests = []string{}
+	}
+
 	return &types.ImageInspect{
 		ID:              img.ID().String(),
 		RepoTags:        repoTags,


### PR DESCRIPTION
- Backport: https://github.com/moby/moby/pull/45563

#43883 removed the variable initialization to empty arrays which silently changed the API and made it return `nil` RepoTags and RepoDigests instead of empty arrays.

https://github.com/moby/moby/commit/acd0aa7d382cc3bb87d542adf6845bd14d57d53a#diff-2d8d96f6fa256de94f3737c8631e99d897efb15ec869f465f8cfcb8962e70be0R208-R210

(cherry picked from commit 1be26e9f0cb954773616585abb25a1227866b79c)

**- What I did**
Make RepoTags and RepoDigests empty arrays instead of nil.

**- How I did it**
Set RepoTags/RepoDigests to empty array if it's nil. 

**- How to verify it**
```bash
# Before
$  docker inspect ead3e795a244 | head -n5
[
    {
        "Id": "sha256:ead3e795a244cfa86bff5eda3d7ce08a910b976453132b63a503546c80bfee13",
        "RepoTags": null,
        "RepoDigests": null,

# After
$  docker inspect ead3e795a244 | head -n5
[
    {
        "Id": "sha256:ead3e795a244cfa86bff5eda3d7ce08a910b976453132b63a503546c80bfee13",
        "RepoTags": [],
        "RepoDigests": [],

```

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**
