### PR TITLE
ci: fix bin-image workflow

### DIFF
--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -30,6 +30,12 @@ jobs:
       - validate-dco
     steps:
       -
+        # FIXME: remove when we implement build distribution across runners for each platform
+        name: Free up disk space
+        run: |
+          #sudo du -h -S / | sort -rh
+          sudo rm -rf /opt/hostedtoolcache /usr/local/lib/android/sdk /usr/share/dotnet
+      -
         name: Checkout
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
**- What I did**

Related to https://github.com/moby/moby/actions/runs/5014814026/jobs/8989563591#step:6:13158

```
#147 3.762 Building static /tmp/bundles/binary-daemon/dockerd (linux/arm/v6)...
#147 798.5 # github.com/docker/docker/cmd/dockerd
#147 798.5 /usr/local/go/pkg/tool/linux_amd64/link: running arm-linux-gnueabi-clang failed: exit status 1
#147 798.5 ld.lld: error: failed to open $WORK/b001/exe/a.out: No space left on device
#147 798.5 clang: error: linker command failed with exit code 1 (use -v to see invocation)
#147 798.5 
```

It seems public runner specs have changed recently with lower available disk space.

**- How I did it**

In the meantime let's just remove the android sdk, hosted tool cache and dotnet we don't need for this workflow to fix this issue. Will open a follow-up to implement build distribution for each platform on a dedicated runner. The pipeline will also be faster.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

