### PR TITLE
[23.0 backport] api/server: allow empty body for POST /commit again

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -44,7 +44,7 @@ func (s *containerRouter) postCommit(ctx context.Context, w http.ResponseWriter,
 	}
 
 	config, _, _, err := s.decoder.DecodeConfig(r.Body)
-	if err != nil && err != io.EOF { // Do not fail if body is empty.
+	if err != nil && !errors.Is(err, io.EOF) { // Do not fail if body is empty.
 		return err
 	}
 
@@ -484,6 +484,9 @@ func (s *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 
 	config, hostConfig, networkingConfig, err := s.decoder.DecodeConfig(r.Body)
 	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return errdefs.InvalidParameter(errors.New("invalid JSON: got EOF while reading request body"))
+		}
 		return err
 	}
 	version := httputils.VersionFromContext(ctx)

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -77,10 +77,7 @@ func decodeContainerConfig(src io.Reader, si *sysinfo.SysInfo) (*container.Confi
 func loadJSON(src io.Reader, out interface{}) error {
 	dec := json.NewDecoder(src)
 	if err := dec.Decode(&out); err != nil {
-		if err == io.EOF {
-			return validationError("invalid JSON: got EOF while reading request body")
-		}
-		return validationError("invalid JSON: " + err.Error())
+		return invalidJSONError{Err: err}
 	}
 	if dec.More() {
 		return validationError("unexpected content after JSON")

--- a/runconfig/errors.go
+++ b/runconfig/errors.go
@@ -40,3 +40,17 @@ func (e validationError) Error() string {
 }
 
 func (e validationError) InvalidParameter() {}
+
+type invalidJSONError struct {
+	Err error
+}
+
+func (e invalidJSONError) Error() string {
+	return "invalid JSON: " + e.Err.Error()
+}
+
+func (e invalidJSONError) Unwrap() error {
+	return e.Err
+}
+
+func (e invalidJSONError) InvalidParameter() {}


### PR DESCRIPTION
- 23.0 backport of #45550 (without the client changes)

The error returned by DecodeConfig was changed in
b6d58d749c6d671f0dc19a88b948b772272e145d and caused this to regress. Allow empty request bodies for this endpoint once again.


(cherry picked from commit 967c7bc5d35107964c5eb5e6bf0d7416558a681b)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

