### PR TITLE
[23.0 backport] Fix insecure registries reload

### DIFF
--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -63,10 +63,10 @@ func (daemon *Daemon) Reload(conf *config.Config) (err error) {
 	if err := daemon.reloadAllowNondistributableArtifacts(conf, attributes); err != nil {
 		return err
 	}
-	if err := daemon.reloadInsecureRegistries(conf, attributes); err != nil {
+	if err := daemon.reloadRegistryMirrors(conf, attributes); err != nil {
 		return err
 	}
-	if err := daemon.reloadRegistryMirrors(conf, attributes); err != nil {
+	if err := daemon.reloadInsecureRegistries(conf, attributes); err != nil {
 		return err
 	}
 	if err := daemon.reloadLiveRestore(conf, attributes); err != nil {

--- a/daemon/reload_test.go
+++ b/daemon/reload_test.go
@@ -238,13 +238,19 @@ func TestDaemonReloadInsecureRegistries(t *testing.T) {
 		"docker3.example.com", // this will be newly added
 	}
 
+	mirrors := []string{
+		"https://mirror.test.example.com",
+	}
+
 	valuesSets := make(map[string]interface{})
 	valuesSets["insecure-registries"] = insecureRegistries
+	valuesSets["registry-mirrors"] = mirrors
 
 	newConfig := &config.Config{
 		CommonConfig: config.CommonConfig{
 			ServiceOptions: registry.ServiceOptions{
 				InsecureRegistries: insecureRegistries,
+				Mirrors:            mirrors,
 			},
 			ValuesSet: valuesSets,
 		},


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/45552


**- What I did**

Fixed a small bug where when both `insecure-registries` and `registry-mirrors` are set in `daemon.json`, when executing a daemon reload (such as with `systemctl reload docker`) the insecure registries are no longer in the daemon's loaded configuration.

**- How I did it**

Reordered the loading of the insecure registries to occur _after_ the loading of the mirrors. This matches [a newly started daemon's configuration loading order](https://github.com/miles-to-go/moby/blob/master/registry/config.go#L83).

The overwriting occurs because `loadMirrors()` creates a new map for `config.IndexConfigs`.

I added a mirror to the unit test to demonstrate this.

**- How to verify it**

Through the unit tests:
1. Apply only the first commit to `daemon/reload_test.go`
2. Run `make test-unit`
3. Apply the second commit
4. Run `make test-unit`

Independently on Linux:
1. Create a `daemon.json` that has both `insecure-registries` and `registry-mirrors`
2. Start the `dockerd` daemon
3. Verify the insecure registries are loaded with `docker info`
4. Reload the daemon (e.g. `systemctl reload docker` or `kill -s HUP <pid>`)
5.  Without this fix, `docker info` will not show the registries are loaded. With it, it will.

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**

