### PR TITLE
daemon: remove driver-warnings for overlay without d_type, and devicemapper

### DIFF
--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -273,14 +273,6 @@ func (daemon *Daemon) fillRootlessVersion(v *types.Version) {
 
 func fillDriverWarnings(v *types.Info) {
 	for _, pair := range v.DriverStatus {
-		if pair[0] == "Data loop file" {
-			msg := fmt.Sprintf("WARNING: %s: usage of loopback devices is "+
-				"strongly discouraged for production use.\n         "+
-				"Use `--storage-opt dm.thinpooldev` to specify a custom block storage device.", v.Driver)
-
-			v.Warnings = append(v.Warnings, msg)
-			continue
-		}
 		if pair[0] == "Extended file attributes" && pair[1] == "best-effort" {
 			msg := fmt.Sprintf("WARNING: %s: extended file attributes from container images "+
 				"will be silently discarded if the backing filesystem does not support them.\n"+

--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -281,18 +281,6 @@ func fillDriverWarnings(v *types.Info) {
 			v.Warnings = append(v.Warnings, msg)
 			continue
 		}
-		if pair[0] == "Supports d_type" && pair[1] == "false" {
-			backingFs := getBackingFs(v)
-
-			msg := fmt.Sprintf("WARNING: %s: the backing %s filesystem is formatted without d_type support, which leads to incorrect behavior.\n", v.Driver, backingFs)
-			if backingFs == "xfs" {
-				msg += "         Reformat the filesystem with ftype=1 to enable d_type support.\n"
-			}
-			msg += "         Running without d_type support will not be supported in future releases."
-
-			v.Warnings = append(v.Warnings, msg)
-			continue
-		}
 		if pair[0] == "Extended file attributes" && pair[1] == "best-effort" {
 			msg := fmt.Sprintf("WARNING: %s: extended file attributes from container images "+
 				"will be silently discarded if the backing filesystem does not support them.\n"+
@@ -303,15 +291,6 @@ func fillDriverWarnings(v *types.Info) {
 			continue
 		}
 	}
-}
-
-func getBackingFs(v *types.Info) string {
-	for _, pair := range v.DriverStatus {
-		if pair[0] == "Backing Filesystem" {
-			return pair[1]
-		}
-	}
-	return ""
 }
 
 // parseInitVersion parses a Tini version string, and extracts the "version"


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/35514
- relates to https://github.com/moby/moby/pull/43637


### daemon: remove warning for overlay/overlay2 without d_type

commit 0abb8dec3f730f3ad2cc9a161c97968a6bfd0631 (https://github.com/moby/moby/pull/35514) removed support for running overlay/overlay2 on top of a backing filesystem without d_type support, and  turned it into a fatal error when starting the daemon, so there's no need to generate warnings for this situation.


### daemon: remove fillDriverWarnings()

commit dc11d2a2d8e1df0a90ce289f5dd06cad38193073 (https://github.com/moby/moby/pull/43637) removed the devicemapper storage-driver, which was the last remaining driver needing this function, so we can remove it.