### PR TITLE
Add minimal workflow permissions

### DIFF
--- a/.github/workflows/.dco.yml
+++ b/.github/workflows/.dco.yml
@@ -6,6 +6,9 @@ name: .dco
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 env:
   ALPINE_VERSION: 3.16
 

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -14,6 +14,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 env:
   GO_VERSION: "1.20.4"
   GOTESTLIST_VERSION: v0.3.1

--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -14,6 +14,9 @@ on:
       - 'v*'
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   PLATFORM: Moby Engine
   PRODUCT: Moby

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -12,6 +12,9 @@ on:
       - '[0-9]+.[0-9]+'
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   DESTDIR: ./build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
       - 'v*'
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   DESTDIR: ./build
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,9 @@ on:
       - 'v*'
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   GO_VERSION: "1.20.4"
   GOTESTLIST_VERSION: v0.3.1

--- a/.github/workflows/windows-2019.yml
+++ b/.github/workflows/windows-2019.yml
@@ -9,6 +9,9 @@ on:
     - cron: '0 10 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate-dco:
     uses: ./.github/workflows/.dco.yml

--- a/.github/workflows/windows-2022.yml
+++ b/.github/workflows/windows-2022.yml
@@ -12,6 +12,9 @@ on:
       - '[0-9]+.[0-9]+'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate-dco:
     uses: ./.github/workflows/.dco.yml


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixes #45575.

**- How I did it**
Added read-only token permissions to all GitHub workflows.

**- How to verify it**
Ensure all workflows now have the following block at the top-level (before the `jobs:` block):

```yml
permissions:
  contents: read
```

**- Description for the changelog**
Added read-only token permissions to all GitHub workflows to improve the project's supply-chain security.


**- A picture of a cute animal (not mandatory but encouraged)**
A twofer!

![20221120_145741](https://github.com/moby/moby/assets/15221358/1085e544-ed5b-45a3-b818-de96c559a955)

