### PR TITLE
[24.0 backport] c8d/list: Show layerless images

### DIFF
--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -525,9 +525,12 @@ func getManifestPlatform(ctx context.Context, store content.Provider, manifestDe
 	return platforms.Normalize(platform), nil
 }
 
-// isImageManifest returns true if the manifest has any layer that is a known image layer.
+// isImageManifest returns true if the manifest has no layers or any of its layers is a known image layer.
 // Some manifests use the image media type for compatibility, even if they are not a real image.
 func isImageManifest(mfst v1.Manifest) bool {
+	if len(mfst.Layers) == 0 {
+		return true
+	}
 	for _, l := range mfst.Layers {
 		if images.IsLayerType(l.MediaType) {
 			return true


### PR DESCRIPTION
- Backports: https://github.com/moby/moby/pull/45587

**- What I did**
Fix layerless images not being shown in `docker images`:

**- How I did it**
Add exception to `isImageManifest`.

**- How to verify it**

```bash
$ echo 'FROM scratch' | docker build -t chacha -
[+] Building 0.0s (3/3) FINISHED
 => [internal] load .dockerignore                                                                                                                       0.0s
 => => transferring context: 2B                                                                                                                         0.0s
 => [internal] load build definition from Dockerfile                                                                                                    0.0s
 => => transferring dockerfile: 87B                                                                                                                     0.0s
 => exporting to image                                                                                                                                  0.0s
 => => exporting layers                                                                                                                                 0.0s
 => => exporting manifest sha256:a63cf1e09745cbbaca7f82e8447379ff3f1834421711ae386c31468d5510e97c                                                       0.0s
 => => exporting config sha256:63c7db7133a831861b7ec181985a11cbbc29e1c0d4119865095825ecd755f004                                                         0.0s
 => => naming to docker.io/library/chacha:latest                                                                                                        0.0s
$ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
chacha              latest              a63cf1e09745        1 second ago        604B
$ dd-ctr image ls
REF TYPE DIGEST SIZE PLATFORMS LABELS
REF                             TYPE                                                 DIGEST                                                                  SIZE    PLATFORMS   LABELS
docker.io/library/chacha:latest application/vnd.docker.distribution.manifest.v2+json sha256:a63cf1e09745cbbaca7f82e8447379ff3f1834421711ae386c31468d5510e97c 548.0 B linux/arm64 -
```

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- Description for the changelog**
- Fix layerless images not being shown in `docker images` output with containerd snapshotter enabled


**- A picture of a cute animal (not mandatory but encouraged)**

