### PR TITLE
[24.0 backport] libnetwork/osl: restore the right thread's netns

### DIFF
--- a/libnetwork/resolver_test.go
+++ b/libnetwork/resolver_test.go
@@ -494,6 +494,13 @@ func TestProxyNXDOMAIN(t *testing.T) {
 		<-serveDone
 	}()
 
+	// This test, by virtue of running a server and client in different
+	// not-locked-to-thread goroutines, happens to be a good canary for
+	// whether we are leaking unlocked OS threads set to the wrong network
+	// namespace. Make a best-effort attempt to detect that situation so we
+	// are not left chasing ghosts next time.
+	testutils.AssertSocketSameNetNS(t, srv.PacketConn.(*net.UDPConn))
+
 	srvAddr := srv.PacketConn.LocalAddr().(*net.UDPAddr)
 	rsv := NewResolver("", true, noopDNSBackend{})
 	rsv.SetExtServers([]extDNSEntry{

--- a/libnetwork/testutils/sanity_linux.go
+++ b/libnetwork/testutils/sanity_linux.go
@@ -1,0 +1,43 @@
+package testutils
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+
+	"github.com/vishvananda/netns"
+	"golang.org/x/sys/unix"
+	"gotest.tools/v3/assert"
+)
+
+// AssertSocketSameNetNS makes a best-effort attempt to assert that conn is in
+// the same network namespace as the current goroutine's thread.
+func AssertSocketSameNetNS(t testing.TB, conn syscall.Conn) {
+	t.Helper()
+
+	sc, err := conn.SyscallConn()
+	assert.NilError(t, err)
+	sc.Control(func(fd uintptr) {
+		srvnsfd, err := unix.IoctlRetInt(int(fd), unix.SIOCGSKNS)
+		if err != nil {
+			if errors.Is(err, unix.EPERM) {
+				t.Log("Cannot determine socket's network namespace. Do we have CAP_NET_ADMIN?")
+				return
+			}
+			if errors.Is(err, unix.ENOSYS) {
+				t.Log("Cannot query socket's network namespace due to missing kernel support.")
+				return
+			}
+			t.Fatal(err)
+		}
+		srvns := netns.NsHandle(srvnsfd)
+		defer srvns.Close()
+
+		curns, err := netns.Get()
+		assert.NilError(t, err)
+		defer curns.Close()
+		if !srvns.Equal(curns) {
+			t.Fatalf("Socket is in network namespace %s, but test goroutine is in %s", srvns, curns)
+		}
+	})
+}

--- a/libnetwork/testutils/sanity_notlinux.go
+++ b/libnetwork/testutils/sanity_notlinux.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package testutils
+
+import (
+	"syscall"
+	"testing"
+)
+
+// AssertSocketSameNetNS is a no-op on platforms other than Linux.
+func AssertSocketSameNetNS(t testing.TB, conn syscall.Conn) {}


### PR DESCRIPTION
- 24.0 backport of #45586 
- Fixes #45583

**- What I did**
- Fixed `panic: Log in goroutine after TestReplySERVFAIL/ProxyDNS=true has completed` flakes by no longer touching global logrus state
- Resolved the root cause of flakiness in `TestProxyNXDOMAIN` by fixing `osl.setIPv6` to capture and restore the locked-to thread's original network namespace instead of "restoring" it to the netns of the calling goroutine's thread
- Added a canary check to `TestProxyNXDOMAIN` which can diagnose this situation if it happens again

**- How to verify it**
Throw it at CI and see what sticks

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Fixed a correctness issue in libnetwork which is believed to only impact tests

**- A picture of a cute animal (not mandatory but encouraged)**
