### PR TITLE
[backport 24.0] c8d/pull: Use same progress action as distribution

### DIFF
--- a/daemon/containerd/progress.go
+++ b/daemon/containerd/progress.go
@@ -152,7 +152,7 @@ func (p pullProgress) UpdateProgress(ctx context.Context, ongoing *jobs, out pro
 		} else if p.ShowExists {
 			out.WriteProgress(progress.Progress{
 				ID:         stringid.TruncateID(j.Digest.Encoded()),
-				Action:     "Exists",
+				Action:     "Already exists",
 				HideCounts: true,
 				LastUpdate: true,
 			})


### PR DESCRIPTION
- Backport: https://github.com/moby/moby/pull/45601
- Related to: https://github.com/docker/compose/pull/10611

Docker with containerd integration emits "Exists" progress action when a layer of the currently pulled image already exists. This is different from the non-c8d Docker which emits "Already exists".

This makes both implementations consistent by emitting backwards compatible "Already exists" action.

(cherry picked from commit a7bc65fbd83b367bf827d8fbbef220b2a8e6f406)

**- How to verify it**
```bash
# Before
$ docker pull ubuntu:22.04
dfd64a3b4296: Exists
6f8fe7bff0be: Exists
3f5ef9003cef: Exists
docker.io/library/ubuntu:22.04

# After
$ docker pull ubuntu:22.04
dfd64a3b4296: Already exists
6f8fe7bff0be: Already exists
3f5ef9003cef: Already exists
docker.io/library/ubuntu:22.04
```

**- Description for the changelog**
containerd integration: Make pull emit `Already exists` progress

**- A picture of a cute animal (not mandatory but encouraged)**

