### PR TITLE
[24.0 backport] hack/make/.binary: don't use "netgo" when building Windows binaries

### DIFF
--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -51,6 +51,18 @@ source "${MAKEDIR}/.go-autogen"
 		fi
 	fi
 
+	# XXX: Disable netgo on Windows and use Window's system resolver instead.
+	#
+	# go1.19 and newer added support for netgo on Windows (https://go.dev/doc/go1.19#net),
+	# which won't ask Windows for DNS results, and hence may be ignoring
+	# custom "C:\Windows\System32\drivers\etc\hosts".
+	# See https://github.com/moby/moby/issues/45251#issuecomment-1561001817
+	# https://github.com/moby/moby/issues/45251, and
+	# https://go-review.googlesource.com/c/go/+/467335
+	if [ "$(go env GOOS)" = "windows" ]; then
+		BUILDFLAGS=("${BUILDFLAGS[@]/netgo/}")
+	fi
+
 	# only necessary for non-sandboxed invocation where TARGETPLATFORM is empty
 	PLATFORM_NAME=$TARGETPLATFORM
 	if [ -z "$PLATFORM_NAME" ]; then


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/45603
- fixes https://github.com/moby/moby/issues/45251

Starting with go1.19, the Go runtime on Windows now supports the `netgo` build- flag to use a native Go DNS resolver. Prior to that version, the build-flag only had an effect on non-Windows platforms. When using the `netgo` build-flag, the Windows's host resolver is not used, and as a result, custom entries in `etc/hosts` are ignored, which is a change in behavior from binaries compiled with older versions of the Go runtime.

From the go1.19 release notes: https://go.dev/doc/go1.19#net

> Resolver.PreferGo is now implemented on Windows and Plan 9. It previously
> only worked on Unix platforms. Combined with Dialer.Resolver and Resolver.Dial,
> it's now possible to write portable programs and be in control of all DNS name
> lookups when dialing.
>
> The net package now has initial support for the netgo build tag on Windows.
> When used, the package uses the Go DNS client (as used by Resolver.PreferGo)
> instead of asking Windows for DNS results. The upstream DNS server it discovers
> from Windows may not yet be correct with complex system network configurations,
> however.

Our Windows binaries are compiled with the "static" (`make/binary-daemon`) script, which has the `netgo` option set by default. This patch unsets the `netgo` option when cross-compiling for Windows.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

- Fix a failure to respect the `hosts` file and other components of the native DNS stack on Windows.


**- A picture of a cute animal (not mandatory but encouraged)**