### PR TITLE
builder/remotecontext: deprecate CachableSource, NewCachableSource

### DIFF
--- a/builder/remotecontext/tarsum.go
+++ b/builder/remotecontext/tarsum.go
@@ -15,7 +15,9 @@ type hashed interface {
 	Digest() digest.Digest
 }
 
-// CachableSource is a source that contains cache records for its contents
+// CachableSource is a source that contains cache records for its contents.
+//
+// Deprecated: this type was used for the experimental "stream" support for the classic builder, which is no longer supported.
 type CachableSource struct {
 	mu   sync.Mutex
 	root string
@@ -23,7 +25,9 @@ type CachableSource struct {
 	txn  *iradix.Txn
 }
 
-// NewCachableSource creates new CachableSource
+// NewCachableSource creates new CachableSource.
+//
+// Deprecated: this type was used for the experimental "stream" support for the classic builder, which is no longer supported.
 func NewCachableSource(root string) *CachableSource {
 	ts := &CachableSource{
 		tree: iradix.New(),


### PR DESCRIPTION
This type (as well as TarsumBackup), was used for the experimental --stream support for the classic builder. This feature was removed in commit 6ca3ec88ae9e1435abbed665ec598c00058659da (https://github.com/moby/moby/pull/39983), which also removed uses of the CachableSource type.

As far as I could find, there's no external consumers of these types, but let's deprecated it, to give potential users a heads-up that it will be removed.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

