### PR TITLE
builder/remotecontext: remove mimeTypes struct, use consts

### DIFF
--- a/builder/remotecontext/detect.go
+++ b/builder/remotecontext/detect.go
@@ -102,7 +102,7 @@ func newURLRemote(url string, dockerfilePath string, progressReader func(in io.R
 	defer content.Close()
 
 	switch contentType {
-	case mimeTypes.TextPlain:
+	case mimeTypeTextPlain:
 		res, err := parser.Parse(progressReader(content))
 		return nil, res, errdefs.InvalidParameter(err)
 	default:

--- a/builder/remotecontext/mimetype.go
+++ b/builder/remotecontext/mimetype.go
@@ -5,11 +5,11 @@ import (
 	"net/http"
 )
 
-// mimeTypes stores the MIME content type.
-var mimeTypes = struct {
-	TextPlain   string
-	OctetStream string
-}{"text/plain", "application/octet-stream"}
+// MIME content types.
+const (
+	mimeTypeTextPlain   = "text/plain"
+	mimeTypeOctetStream = "application/octet-stream"
+)
 
 // detectContentType returns a best guess representation of the MIME
 // content type for the bytes at c.  The value detected by
@@ -17,11 +17,10 @@ var mimeTypes = struct {
 // application/octet-stream when a better guess cannot be made. The
 // result of this detection is then run through mime.ParseMediaType()
 // which separates the actual MIME string from any parameters.
-func detectContentType(c []byte) (string, map[string]string, error) {
-	ct := http.DetectContentType(c)
-	contentType, args, err := mime.ParseMediaType(ct)
+func detectContentType(c []byte) (string, error) {
+	contentType, _, err := mime.ParseMediaType(http.DetectContentType(c))
 	if err != nil {
-		return "", nil, err
+		return "", err
 	}
-	return contentType, args, nil
+	return contentType, nil
 }

--- a/builder/remotecontext/mimetype_test.go
+++ b/builder/remotecontext/mimetype_test.go
@@ -10,7 +10,7 @@ import (
 func TestDetectContentType(t *testing.T) {
 	input := []byte("That is just a plain text")
 
-	contentType, _, err := detectContentType(input)
+	contentType, err := detectContentType(input)
 	assert.NilError(t, err)
-	assert.Check(t, is.Equal("text/plain", contentType))
+	assert.Check(t, is.Equal(mimeTypeTextPlain, contentType))
 }

--- a/builder/remotecontext/remote.go
+++ b/builder/remotecontext/remote.go
@@ -105,8 +105,8 @@ func inspectResponse(ct string, r io.Reader, clen int64) (string, io.Reader, err
 	// content type for files without an extension (e.g. 'Dockerfile')
 	// so if we receive this value we better check for text content
 	contentType := ct
-	if len(ct) == 0 || ct == mimeTypes.OctetStream {
-		contentType, _, err = detectContentType(preamble)
+	if len(ct) == 0 || ct == mimeTypeOctetStream {
+		contentType, err = detectContentType(preamble)
 		if err != nil {
 			return contentType, bodyReader, err
 		}

--- a/builder/remotecontext/remote_test.go
+++ b/builder/remotecontext/remote_test.go
@@ -189,7 +189,7 @@ func TestDownloadRemote(t *testing.T) {
 	contentType, content, err := downloadRemote(remoteURL)
 	assert.NilError(t, err)
 
-	assert.Check(t, is.Equal(mimeTypes.TextPlain, contentType))
+	assert.Check(t, is.Equal(mimeTypeTextPlain, contentType))
 	raw, err := io.ReadAll(content)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(dockerfileContents, string(raw)))


### PR DESCRIPTION
This struct was never modified; let's just use consts for these.

Also remove the args return from detectContentType(), as it was not used anywhere.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

