### PR TITLE
[24.0 backport] libnetwork/d/overlay: support encryption on any port

### DIFF
--- a/libnetwork/drivers/overlay/encryption.go
+++ b/libnetwork/drivers/overlay/encryption.go
@@ -375,8 +375,8 @@ func programSP(fSA *netlink.XfrmState, rSA *netlink.XfrmState, add bool) error {
 		Src:     &net.IPNet{IP: s, Mask: fullMask},
 		Dst:     &net.IPNet{IP: d, Mask: fullMask},
 		Dir:     netlink.XFRM_DIR_OUT,
-		Proto:   17,
-		DstPort: 4789,
+		Proto:   syscall.IPPROTO_UDP,
+		DstPort: int(overlayutils.VXLANUDPPort()),
 		Mark:    &spMark,
 		Tmpls: []netlink.XfrmPolicyTmpl{
 			{
@@ -589,8 +589,8 @@ func updateNodeKey(lIP, aIP, rIP net.IP, idxs []*spi, curKeys []*key, newIdx, pr
 			Src:     &net.IPNet{IP: s, Mask: fullMask},
 			Dst:     &net.IPNet{IP: d, Mask: fullMask},
 			Dir:     netlink.XFRM_DIR_OUT,
-			Proto:   17,
-			DstPort: 4789,
+			Proto:   syscall.IPPROTO_UDP,
+			DstPort: int(overlayutils.VXLANUDPPort()),
 			Mark:    &spMark,
 			Tmpls: []netlink.XfrmPolicyTmpl{
 				{


### PR DESCRIPTION
- 24.0 backport of #45636
- Fixes #45635 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
While the VXLAN interface and the iptables rules to mark outgoing VXLAN packets for encryption are configured to use the Swarm data path port, the XFRM policies for actually applying the encryption are hardcoded to match packets with destination port 4789/udp. Consequently, encrypted overlay networks do not pass traffic when the Swarm is configured with any other data path port: encryption is not applied to the outgoing VXLAN packets and the destination host drops the received cleartext packets. Use the configured data path port instead of hardcoding port 4789 in the XFRM policies.

We are not considering this to be a security issue as affected overlay networks are functionally non-operational. The only traffic which would be visible on the host network in cleartext would be simplex transmissions (ICMP echo requests, DNS queries, TCP SYN, etc.) shouting into the void, which the addressed recipient would never receive and thus never reply to.

**- How I did it**
Trivially.

**- How to verify it**
Initialize a swarm with a `--data-path-port` other than 4789. Create an encrypted overlay network, run containers on different nodes attached to the network, and verify that the containers can communicate with each other.

Run tcpdump on one of the nodes with the filter `udp port $DATA_PATH_PORT or esp` and verify that only IPSec ESP traffic is observed when the aforementioned containers are communicating, and not any cleartext UDP traffic.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Fix an issue which prevented encrypted overlay networks from functioning when the Swarm data path port is not set to 4789.

**- A picture of a cute animal (not mandatory but encouraged)**

