### PR TITLE
[24.0 backport] Fix npe in exec resize when exec errored

### DIFF
--- a/daemon/resize.go
+++ b/daemon/resize.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"strconv"
 	"time"
+
+	"github.com/docker/docker/errdefs"
 )
 
 // ContainerResize changes the size of the TTY of the process running
@@ -48,6 +50,10 @@ func (daemon *Daemon) ContainerExecResize(name string, height, width int) error 
 
 	select {
 	case <-ec.Started:
+		// An error may have occurred, so ec.Process may be nil.
+		if ec.Process == nil {
+			return errdefs.InvalidParameter(errors.New("exec process is not started"))
+		}
 		return ec.Process.Resize(context.Background(), uint32(width), uint32(height))
 	case <-timeout.C:
 		return errors.New("timeout waiting for exec session ready")


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/45641


In cases where an exec start failed the exec process will be nil even though the channel to signal that the exec started was closed.

Ideally ExecConfig would get a nice refactor to handle this case better (ie. it's not started so don't close that channel). This is a minimal fix to prevent NPE. Luckilly this would only get called by a client and only the http request goroutine gets the panic (http lib recovers the panic).


(cherry picked from commit 487ea813163903df78e5449b9c9b1cc02cef6ae2)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

