### PR TITLE
libnetwork: fix resolver restore w/ chatty 'iptables -C'

### DIFF
--- a/libnetwork/resolver_unix.go
+++ b/libnetwork/resolver_unix.go
@@ -37,8 +37,7 @@ func (r *Resolver) setupIPTable() error {
 		iptable := iptables.GetIptable(iptables.IPv4)
 
 		// insert outputChain and postroutingchain
-		err := iptable.RawCombinedOutputNative("-t", "nat", "-C", "OUTPUT", "-d", resolverIP, "-j", outputChain)
-		if err == nil {
+		if iptable.ExistsNative("nat", "OUTPUT", "-d", resolverIP, "-j", outputChain) {
 			if err := iptable.RawCombinedOutputNative("-t", "nat", "-F", outputChain); err != nil {
 				setupErr = err
 				return
@@ -54,8 +53,7 @@ func (r *Resolver) setupIPTable() error {
 			}
 		}
 
-		err = iptable.RawCombinedOutputNative("-t", "nat", "-C", "POSTROUTING", "-d", resolverIP, "-j", postroutingChain)
-		if err == nil {
+		if iptable.ExistsNative("nat", "POSTROUTING", "-d", resolverIP, "-j", postroutingChain) {
 			if err := iptable.RawCombinedOutputNative("-t", "nat", "-F", postroutingChain); err != nil {
 				setupErr = err
 				return


### PR DESCRIPTION
- Fixes #45646

`Resolver.setupIPTable()` checks whether it needs to flush or create the user chains used for NATing container DNS requests by testing for the existence of the rules which jump to said user chains. Unfortunately it does so using the `IPTable.RawCombinedOutputNative()` method, which returns a non-nil error if the iptables command returns any output even if the command exits with a zero status code. While that is fine with iptables-legacy as it prints no output if the rule exists, iptables-nft v1.8.7 prints some information about the rule. Consequently, `Resolver.setupIPTable()` would incorrectly think that the rule does not exist during container restore and attempt to create it. This happened work work by coincidence before 8f5a9a741b70852bc6c9d675c6e0c4944022b467 because the failure to create the already-existing table would be ignored and the new NAT rules would be inserted before the stale rules left in the table from when the container was last started/restored. Now that failing to create the table is treated as a fatal error, the incompatibility with iptables-nft is no longer hidden.

Switch to using `IPTable.ExistsNative()` to test for the existence of the jump rules as it correctly only checks the iptables command's exit status without regard for whether it outputs anything.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

- Fixed an issue which prevented DNS resolution from working in live-restored containers on systems using iptables-nft

**- A picture of a cute animal (not mandatory but encouraged)**

