### PR TITLE
[24.0 backport] libnetwork: fix sandbox restore

### DIFF
--- a/libnetwork/osl/sandbox.go
+++ b/libnetwork/osl/sandbox.go
@@ -17,6 +17,10 @@ const (
 	SandboxTypeLoadBalancer = iota
 )
 
+type Iface struct {
+	SrcName, DstPrefix string
+}
+
 // IfaceOption is a function option type to set interface options.
 type IfaceOption func(i *nwIface)
 
@@ -89,7 +93,7 @@ type Sandbox interface {
 	Destroy() error
 
 	// Restore restores the sandbox.
-	Restore(ifsopt map[string][]IfaceOption, routes []*types.StaticRoute, gw net.IP, gw6 net.IP) error
+	Restore(ifsopt map[Iface][]IfaceOption, routes []*types.StaticRoute, gw net.IP, gw6 net.IP) error
 
 	// ApplyOSTweaks applies operating system specific knobs on the sandbox.
 	ApplyOSTweaks([]SandboxType)

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -765,7 +765,7 @@ func (sb *Sandbox) restoreOslSandbox() error {
 	var routes []*types.StaticRoute
 
 	// restore osl sandbox
-	Ifaces := make(map[string][]osl.IfaceOption)
+	Ifaces := make(map[osl.Iface][]osl.IfaceOption)
 	for _, ep := range sb.endpoints {
 		ep.mu.Lock()
 		joinInfo := ep.joinInfo
@@ -790,7 +790,7 @@ func (sb *Sandbox) restoreOslSandbox() error {
 		if len(i.llAddrs) != 0 {
 			ifaceOptions = append(ifaceOptions, sb.osSbox.InterfaceOptions().LinkLocalAddresses(i.llAddrs))
 		}
-		Ifaces[i.srcName+i.dstPrefix] = ifaceOptions
+		Ifaces[osl.Iface{SrcName: i.srcName, DstPrefix: i.dstPrefix}] = ifaceOptions
 		if joinInfo != nil {
 			routes = append(routes, joinInfo.StaticRoutes...)
 		}

--- a/libnetwork/sandbox_store.go
+++ b/libnetwork/sandbox_store.go
@@ -260,7 +260,7 @@ func (c *Controller) sandboxCleanup(activeSandboxes map[string]interface{}) {
 		// reconstruct osl sandbox field
 		if !sb.config.useDefaultSandBox {
 			if err := sb.restoreOslSandbox(); err != nil {
-				logrus.Errorf("failed to populate fields for osl sandbox %s", sb.ID())
+				logrus.Errorf("failed to populate fields for osl sandbox %s: %v", sb.ID(), err)
 				continue
 			}
 		} else {


### PR DESCRIPTION
- 24.0 backport of #45654 
- Related to #45646
- Fixes #45653 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed passing the list of interfaces to restore.

**- How I did it**
By passing it as structured data.

**- How to verify it**
Live-restored containers can resolve other restored containers attached to the same networks over DNS.

`docker stats` shows nonzero NET I/O stats for restored containers.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Fixed an issue which caused container networking of live-restored containers to malfunction in various ways after restarting the daemon

**- A picture of a cute animal (not mandatory but encouraged)**

