### PR TITLE
builder: Alias `image` to `moby` exporter

### DIFF
--- a/builder/builder-next/exporter/overrides/wrapper.go
+++ b/builder/builder-next/exporter/overrides/wrapper.go
@@ -30,11 +30,13 @@ func (e *imageExporterMobyWrapper) Resolve(ctx context.Context, exporterAttrs ma
 	if exporterAttrs == nil {
 		exporterAttrs = make(map[string]string)
 	}
-	reposAndTags, err := SanitizeRepoAndTags(strings.Split(exporterAttrs[keyImageName], ","))
-	if err != nil {
-		return nil, err
+	if name, ok := exporterAttrs[keyImageName]; ok && name != "*" {
+		reposAndTags, err := SanitizeRepoAndTags(strings.Split(name, ","))
+		if err != nil {
+			return nil, err
+		}
+		exporterAttrs[keyImageName] = strings.Join(reposAndTags, ",")
 	}
-	exporterAttrs[keyImageName] = strings.Join(reposAndTags, ",")
 	exporterAttrs[keyUnpack] = "true"
 	if _, has := exporterAttrs[keyDanglingPrefix]; !has {
 		exporterAttrs[keyDanglingPrefix] = "moby-dangling"

--- a/builder/builder-next/worker/containerdworker.go
+++ b/builder/builder-next/worker/containerdworker.go
@@ -28,7 +28,7 @@ func NewContainerdWorker(ctx context.Context, wo base.WorkerOpt) (*ContainerdWor
 // Exporter returns exporter by name
 func (w *ContainerdWorker) Exporter(name string, sm *session.Manager) (exporter.Exporter, error) {
 	switch name {
-	case mobyexporter.Moby:
+	case mobyexporter.Moby, client.ExporterImage:
 		exp, err := w.Worker.Exporter(client.ExporterImage, sm)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Moby exporter is a wrapper for the `image` exporter that modifies the
request attributes on the fly to make it work correctly with the engine.

Before this, if user explicitly asks for the `image` exporter, it would
completely bypass the special handling it needs. For example it wouldn't
create an image if the user didn't provide a tag.

This makes the `image` exporter being handled the same way as `moby.

**- What I did**
- Alias `image` to `moby` exporter

**- How I did it**

**- How to verify it**

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**

