### PR TITLE
use /proc/thread-self for mounting network namespace

### DIFF
--- a/libnetwork/osl/namespace_linux.go
+++ b/libnetwork/osl/namespace_linux.go
@@ -300,7 +300,7 @@ func createNetworkNamespace(path string, osCreate bool) error {
 	}
 
 	do := func() error {
-		return mountNetworkNamespace(fmt.Sprintf("/proc/self/task/%d/ns/net", unix.Gettid()), path)
+		return mountNetworkNamespace("/proc/thread-self/ns/net", path)
 	}
 	if osCreate {
 		return unshare.Go(unix.CLONE_NEWNET, do, nil)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- fixes #45681 

**- What I did**

Fixes an issue where `--net=host` runs would fail if Docker is run within a sysbox container.

**- How I did it**

`--net=host` mounts the network namespace without using `unshare`, but the code uses a call to `unix.Gettid()` for the thread ID, builds the `/proc` path from it, then issues the syscall.  Without `unshare` code on the same goroutine can be run on different OS threads, and it appears the syscall is run on a different thread and fails.

We can simplify and fix the logic by using `/proc/thread-self` instead of querying for the threadID.

**- How to verify it**

c.f. repro steps in #45681 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fixed an issue where `--net=host` would fail in restricted environments, for example sysbox

**- A picture of a cute animal (not mandatory but encouraged)**

![IMG_1673](https://github.com/moby/moby/assets/5375600/2004b943-ae94-4737-bd75-8d7c828fffab)
