### PR TITLE
[24.0 backport] containerd: add c8d version and storage-driver to User-Agent

### DIFF
--- a/daemon/containerd/resolver.go
+++ b/daemon/containerd/resolver.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
+	"github.com/containerd/containerd/version"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/dockerversion"
+	"github.com/docker/docker/pkg/useragent"
 	"github.com/docker/docker/registry"
 	"github.com/sirupsen/logrus"
 )
@@ -20,7 +22,7 @@ func (i *ImageService) newResolverFromAuthConfig(ctx context.Context, authConfig
 
 	hosts := hostsWrapper(hostsFn, authConfig, i.registryService)
 	headers := http.Header{}
-	headers.Set("User-Agent", dockerversion.DockerUserAgent(ctx))
+	headers.Set("User-Agent", dockerversion.DockerUserAgent(ctx, useragent.VersionInfo{Name: "containerd-client", Version: version.Version}, useragent.VersionInfo{Name: "storage-driver", Version: i.snapshotter}))
 
 	return docker.NewResolver(docker.ResolverOptions{
 		Hosts:   hosts,

--- a/dockerversion/useragent.go
+++ b/dockerversion/useragent.go
@@ -69,8 +69,10 @@ func getUserAgentFromContext(ctx context.Context) string {
 	return upstreamUA
 }
 
+const charsToEscape = `();\`
+
 // escapeStr returns s with every rune in charsToEscape escaped by a backslash
-func escapeStr(s string, charsToEscape string) string {
+func escapeStr(s string) string {
 	var ret string
 	for _, currRune := range s {
 		appended := false
@@ -93,7 +95,5 @@ func escapeStr(s string, charsToEscape string) string {
 //
 //	$dockerUA UpstreamClient($upstreamUA)
 func insertUpstreamUserAgent(upstreamUA string, dockerUA string) string {
-	charsToEscape := `();\`
-	upstreamUAEscaped := escapeStr(upstreamUA, charsToEscape)
-	return fmt.Sprintf("%s UpstreamClient(%s)", dockerUA, upstreamUAEscaped)
+	return fmt.Sprintf("%s UpstreamClient(%s)", dockerUA, escapeStr(upstreamUA))
 }

--- a/dockerversion/useragent.go
+++ b/dockerversion/useragent.go
@@ -17,8 +17,8 @@ type UAStringKey struct{}
 // In accordance with RFC 7231 (5.5.3) is of the form:
 //
 //	[docker client's UA] UpstreamClient([upstream client's UA])
-func DockerUserAgent(ctx context.Context) string {
-	ua := getDaemonUserAgent()
+func DockerUserAgent(ctx context.Context, extraVersions ...useragent.VersionInfo) string {
+	ua := useragent.AppendVersions(getDaemonUserAgent(), extraVersions...)
 	if upstreamUA := getUpstreamUserAgent(ctx); upstreamUA != "" {
 		ua += " " + upstreamUA
 	}

--- a/dockerversion/useragent_test.go
+++ b/dockerversion/useragent_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/docker/docker/pkg/useragent"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -15,10 +16,23 @@ func TestDockerUserAgent(t *testing.T) {
 		assert.Check(t, is.Equal(ua, expected))
 	})
 
+	t.Run("daemon user-agent custom metadata", func(t *testing.T) {
+		ua := DockerUserAgent(context.TODO(), useragent.VersionInfo{Name: "hello", Version: "world"}, useragent.VersionInfo{Name: "foo", Version: "bar"})
+		expected := getDaemonUserAgent() + ` hello/world foo/bar`
+		assert.Check(t, is.Equal(ua, expected))
+	})
+
 	t.Run("daemon user-agent with upstream", func(t *testing.T) {
 		ctx := context.WithValue(context.TODO(), UAStringKey{}, "Magic-Client/1.2.3 (linux)")
 		ua := DockerUserAgent(ctx)
 		expected := getDaemonUserAgent() + ` UpstreamClient(Magic-Client/1.2.3 \(linux\))`
+		assert.Check(t, is.Equal(ua, expected))
+	})
+
+	t.Run("daemon user-agent with upstream and custom metadata", func(t *testing.T) {
+		ctx := context.WithValue(context.TODO(), UAStringKey{}, "Magic-Client/1.2.3 (linux)")
+		ua := DockerUserAgent(ctx, useragent.VersionInfo{Name: "hello", Version: "world"}, useragent.VersionInfo{Name: "foo", Version: "bar"})
+		expected := getDaemonUserAgent() + ` hello/world foo/bar UpstreamClient(Magic-Client/1.2.3 \(linux\))`
 		assert.Check(t, is.Equal(ua, expected))
 	})
 }

--- a/dockerversion/useragent_test.go
+++ b/dockerversion/useragent_test.go
@@ -1,0 +1,24 @@
+package dockerversion
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestDockerUserAgent(t *testing.T) {
+	t.Run("daemon user-agent", func(t *testing.T) {
+		ua := DockerUserAgent(context.TODO())
+		expected := getDaemonUserAgent()
+		assert.Check(t, is.Equal(ua, expected))
+	})
+
+	t.Run("daemon user-agent with upstream", func(t *testing.T) {
+		ctx := context.WithValue(context.TODO(), UAStringKey{}, "Magic-Client/1.2.3 (linux)")
+		ua := DockerUserAgent(ctx)
+		expected := getDaemonUserAgent() + ` UpstreamClient(Magic-Client/1.2.3 \(linux\))`
+		assert.Check(t, is.Equal(ua, expected))
+	})
+}


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/45670
- follow-up to https://github.com/moby/moby/pull/45669
- fixes https://github.com/moby/moby/issues/44828


### dockerversion: add a basic unit-test


### dockerversion: simplify escapeStr()

Use a const for the characters to escape, instead of implementing
this as a generic escaping function.

### dockerversion: remove insertUpstreamUserAgent()

It was not really "inserting" anything, just formatting and appending.
Simplify this by changing this in to a `getUpstreamUserAgent()` function
which returns the upstream User-Agent (if any) into a `UpstreamClient()`.


### dockerversion: DockerUserAgent(): allow custom versions to be passed

Allow additional metadata to be passed as part of the generated User-Agent.



### containerd: add c8d version and storage-driver to User-Agent

With this patch, the user-agent has information about the containerd-client
version and the storage-driver that's used when using the containerd-integration;

    time="2023-06-01T11:27:07.959822887Z" level=info msg="listening on [::]:5000" go.version=go1.19.9 instance.id=53590f34-096a-4fd1-9c58-d3b8eb7e5092 service=registry version=2.8.2
    ...
    172.18.0.1 - - [01/Jun/2023:11:30:12 +0000] "HEAD /v2/multifoo/blobs/sha256:c7ec7661263e5e597156f2281d97b160b91af56fa1fd2cc045061c7adac4babd HTTP/1.1" 404 157 "" "docker/dev go/go1.20.4 git-commit/8d67d0c1a8 kernel/5.15.49-linuxkit-pr os/linux arch/arm64 containerd-client/1.6.21+unknown storage-driver/overlayfs UpstreamClient(Docker-Client/24.0.2 \\(linux\\))"



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

