### PR TITLE
[24.0 backport] Dockerfile: use COPY --link for source code as well

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -646,4 +646,4 @@ EOT
 # > make shell
 # > SYSTEMD=true make shell
 FROM dev-base AS dev
-COPY . .
+COPY --link . .


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/45676
- follow-up to https://github.com/moby/moby/pull/45660

I missed the most important COPY in 637ca59375cdc26486e9451eea1aa6a9aac6154e (https://github.com/moby/moby/pull/45660)

Copying the source code into the dev-container does not depend on the parent layers, so can use the --link option as well.

(cherry picked from commit ff2342154b9c34925e0ddb7988b6925346d9efcb)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

