### PR TITLE
builder-next: Set moby exporter as default

### DIFF
--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -355,11 +355,7 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 	exporterName := ""
 	exporterAttrs := map[string]string{}
 	if len(opt.Options.Outputs) == 0 {
-		if b.useSnapshotter {
-			exporterName = client.ExporterImage
-		} else {
-			exporterName = exporter.Moby
-		}
+		exporterName = exporter.Moby
 	} else {
 		// cacheonly is a special type for triggering skipping all exporters
 		if opt.Options.Outputs[0].Type != "cacheonly" {


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/45665

Building via `ImageBuild` without exporter set made it use the `image` exporter by default, which didn't go through the same special handling as `moby` (setting `unpack` to true, sanitizing names, setting dangling image prefix).

**- What I did**
- Use `moby` exporter by default in the `ImageBuild`.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
containerd integration: Fix images built with `ImageBuild` endpoint not created in Docker


**- A picture of a cute animal (not mandatory but encouraged)**

