### PR TITLE
hack/test/unit: allow one to exclude extra directories when running unit tests

### DIFF
--- a/hack/test/unit
+++ b/hack/test/unit
@@ -10,13 +10,17 @@
 #
 #   TESTDIRS='./pkg/term' hack/test/unit
 #
+# EXCLUDE_PATHS - run tests but excluding directories. Ex:
+#
+#   EXCLUDE_PATHS='daemon/graphdriver/aufs' hack/test/unit
+
 set -eux -o pipefail
 
 BUILDFLAGS=(-tags 'netgo libdm_no_deferred_remove journald')
 TESTFLAGS+=" -test.timeout=${TIMEOUT:-5m}"
 TESTDIRS="${TESTDIRS:-./...}"
-exclude_paths='/vendor/|/integration'
-pkg_list=$(go list $TESTDIRS | grep -vE "($exclude_paths)")
+EXCLUDE_PATHS="/vendor/|/integration${EXCLUDE_PATHS:-}"
+pkg_list=$(go list $TESTDIRS | grep -vE "($EXCLUDE_PATHS)")
 
 base_pkg_list=$(echo "${pkg_list}" | grep --fixed-strings -v "/libnetwork" || :)
 libnetwork_pkg_list=$(echo "${pkg_list}" | grep --fixed-strings "/libnetwork" || :)


### PR DESCRIPTION
**- What I did**
Allow one to exclude more directories when running unit tests.

**- How I did it**
Changed `hack/test/unit` to accept the environment variable `exclude_paths` with more test directories to be excluded.

**- How to verify it**
Run the script skipping some tests, such as `exclude_paths='|/daemon/graphdriver/aufs' ./hack/test/unit`. Tests from the mentioned directory won't be executed.

**- Description for the changelog**
hack/test/unit: allow one to exclude extra directories when running unit tests.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/moby/moby/assets/2944544/ce0cea4b-89a8-4b76-84f0-78886387d90e)

