### PR TITLE
daemon: set container.State.Restarting=true on docker restart command

### DIFF
--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -93,7 +93,7 @@ func (daemon *Daemon) killWithSignal(container *containerpkg.Container, stopSign
 	// if the container is currently restarting we do not need to send the signal
 	// to the process. Telling the monitor that it should exit on its next event
 	// loop is enough
-	if container.Restarting {
+	if container.Restarting && !container.HasBeenManuallyRestarted {
 		return nil
 	}
 

--- a/daemon/restart.go
+++ b/daemon/restart.go
@@ -52,6 +52,7 @@ func (daemon *Daemon) containerRestart(ctx context.Context, daemonCfg *configSto
 	if container.IsRunning() {
 		container.Lock()
 		container.HasBeenManuallyRestarted = true
+		container.State.Restarting = true
 		container.Unlock()
 
 		err := daemon.containerStop(ctx, container, options)

--- a/daemon/restart.go
+++ b/daemon/restart.go
@@ -31,9 +31,9 @@ func (daemon *Daemon) ContainerRestart(ctx context.Context, name string, options
 // container. When stopping, wait for the given duration in seconds to
 // gracefully stop, before forcefully terminating the container. If
 // given a negative duration, wait forever for a graceful stop.
-func (daemon *Daemon) containerRestart(ctx context.Context, daemonCfg *configStore, cnt *container.Container, options containertypes.StopOptions) error {
+func (daemon *Daemon) containerRestart(ctx context.Context, daemonCfg *configStore, ctr *container.Container, options containertypes.StopOptions) error {
 	// Determine isolation. If not specified in the hostconfig, use daemon default.
-	actualIsolation := cnt.HostConfig.Isolation
+	actualIsolation := ctr.HostConfig.Isolation
 	if containertypes.Isolation.IsDefault(actualIsolation) {
 		actualIsolation = daemon.defaultIsolation
 	}
@@ -45,32 +45,32 @@ func (daemon *Daemon) containerRestart(ctx context.Context, daemonCfg *configSto
 	// access to mount the containers filesystem inside the utility
 	// VM.
 	if !containertypes.Isolation.IsHyperV(actualIsolation) {
-		if err := daemon.Mount(cnt); err == nil {
-			defer daemon.Unmount(cnt)
+		if err := daemon.Mount(ctr); err == nil {
+			defer daemon.Unmount(ctr)
 		}
 	}
 
-	if cnt.IsRunning() {
-		cnt.Lock()
-		cnt.HasBeenManuallyRestarted = true
-		cnt.Unlock()
+	if ctr.IsRunning() {
+		ctr.Lock()
+		ctr.HasBeenManuallyRestarted = true
+		ctr.Unlock()
 
-		cnt.State.Lock()
-		cnt.State.Restarting = true
-		cnt.State.FinishedAt = time.Now().UTC()
-		cnt.State.Unlock()
+		ctr.State.Lock()
+		ctr.State.Restarting = true
+		ctr.State.FinishedAt = time.Now().UTC()
+		ctr.State.Unlock()
 
-		err := daemon.containerStop(ctx, cnt, options)
+		err := daemon.containerStop(ctx, ctr, options)
 
 		if err != nil {
 			return err
 		}
 	}
 
-	if err := daemon.containerStart(ctx, daemonCfg, cnt, "", "", true); err != nil {
+	if err := daemon.containerStart(ctx, daemonCfg, ctr, "", "", true); err != nil {
 		return err
 	}
 
-	daemon.LogContainerEvent(cnt, "restart")
+	daemon.LogContainerEvent(ctr, "restart")
 	return nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Fixes #45538

**- What I did**
- I set `container.State.Restarting=true` when the container is in restarting state.

**- How to verify it**
1. [Setup the development environment](https://github.com/moby/moby/blob/master/docs/contributing/set-up-dev-env.md)
2. Run the following commands
```
$ docker run --name test -d alpine ping localhost
34ce1163ab9a3c4ac920e4f60735977114effbaefd09424d645e965b8da2b1da
$ docker restart test &
[1] 55396
$ docker inspect test -f '{{.State.Restarting}}'
```

Previous output: `false`

Current output: `true`

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
daemon: set container.State.Restarting=true on the `docker restart` command

