### PR TITLE
contrib/check-config: move xt_bpf check to overlay section

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -220,7 +220,6 @@ check_flags \
 	VETH BRIDGE BRIDGE_NETFILTER \
 	IP_NF_FILTER IP_NF_TARGET_MASQUERADE \
 	NETFILTER_XT_MATCH_ADDRTYPE \
-	NETFILTER_XT_MATCH_BPF \
 	NETFILTER_XT_MATCH_CONNTRACK \
 	NETFILTER_XT_MATCH_IPVS \
 	NETFILTER_XT_MARK \
@@ -352,7 +351,7 @@ echo "  - \"$(wrap_color 'overlay' blue)\":"
 check_flags VXLAN BRIDGE_VLAN_FILTERING | sed 's/^/    /'
 echo '      Optional (for encrypted networks):'
 check_flags CRYPTO CRYPTO_AEAD CRYPTO_GCM CRYPTO_SEQIV CRYPTO_GHASH \
-	XFRM XFRM_USER XFRM_ALGO INET_ESP | sed 's/^/      /'
+	XFRM XFRM_USER XFRM_ALGO INET_ESP NETFILTER_XT_MATCH_BPF | sed 's/^/      /'
 if [ "$kernelMajor" -lt 5 ] || [ "$kernelMajor" -eq 5 -a "$kernelMinor" -le 3 ]; then
 	check_flags INET_XFRM_MODE_TRANSPORT | sed 's/^/      /'
 fi


### PR DESCRIPTION
- Follow-up to: https://github.com/moby/moby/pull/45694

I overlooked the existing section for the `overlay` driver in the last PR; this change makes the specific need for `xt_bpf` much more evident to users while also making it clear that lacking this functionality does not prevent the daemon from being otherwise functional.