### PR TITLE
Dockerfile: Separate cli follow-up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -469,8 +469,6 @@ ENV CONTAINERD_NAMESPACE=moby
 WORKDIR /go/src/github.com/docker/docker
 VOLUME /var/lib/docker
 VOLUME /home/unprivilegeduser/.local/share/docker
-COPY --link --from=dockercli             /build/ /usr/local/cli
-COPY --link --from=dockercli-integration /build/ /usr/local/cli-integration
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 ENTRYPOINT ["hack/dind"]
 
@@ -551,6 +549,8 @@ RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,target=/var/lib/apt \
             libsecret-1-dev \
             libsystemd-dev \
             libudev-dev
+COPY --link --from=dockercli             /build/ /usr/local/cli
+COPY --link --from=dockercli-integration /build/ /usr/local/cli-integration
 
 FROM base AS build
 COPY --from=gowinres /build/ /usr/local/bin/

--- a/hack/dockerfile/cli.sh
+++ b/hack/dockerfile/cli.sh
@@ -13,7 +13,7 @@ if curl --head --silent --fail "${DOWNLOAD_URL}" 1> /dev/null 2>&1; then
 	mv docker/docker "${outdir}/docker"
 else
 	git init -q .
-	git remote remove origin || true
+	git remote remove origin 2> /dev/null || true
 	git remote add origin "${repository}"
 	git fetch -q --depth 1 origin "${version}" +refs/tags/*:refs/tags/*
 	git checkout -fq "${version}"


### PR DESCRIPTION
- Follow up to: https://github.com/moby/moby/pull/45358

A few small changes I didn't manage to push in time before the #45358 got merged 😄 🥷 

### hack/cli.sh: Quiet origin remove
Don't show `error: No such remote: 'origin'` error when building for the first time and the cached git repository doesn't a remote yet.

### Dockerfile: Move dockercli to base-dev

Avoids invalidation of dev-systemd-true and dev-base when changing the CLI version/repository.
This saves around 30s on my machine.