### PR TITLE
[20.10 backport] Fix AppArmor profile docker-default /proc/sys rule

### DIFF
--- a/profiles/apparmor/template.go
+++ b/profiles/apparmor/template.go
@@ -35,7 +35,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**
-  deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,
+  deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9/]*}/** w,
   deny @{PROC}/sys/[^k]** w,  # deny /proc/sys except /proc/sys/k* (effectively /proc/sys/kernel)
   deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm* in /proc/sys/kernel/
   deny @{PROC}/sysrq-trigger rwklx,


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/39792