### PR TITLE
[20.10 backport] grpc: make sure typed errors handler is installed 

### DIFF
--- a/api/server/router/grpc/grpc.go
+++ b/api/server/router/grpc/grpc.go
@@ -2,6 +2,7 @@ package grpc // import "github.com/docker/docker/api/server/router/grpc"
 
 import (
 	"github.com/docker/docker/api/server/router"
+	"github.com/moby/buildkit/util/grpcerrors"
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 )
@@ -14,9 +15,12 @@ type grpcRouter struct {
 
 // NewRouter initializes a new grpc http router
 func NewRouter(backends ...Backend) router.Router {
+	opts := []grpc.ServerOption{grpc.UnaryInterceptor(grpcerrors.UnaryServerInterceptor), grpc.StreamInterceptor(grpcerrors.StreamServerInterceptor)}
+	server := grpc.NewServer(opts...)
+
 	r := &grpcRouter{
 		h2Server:   &http2.Server{},
-		grpcServer: grpc.NewServer(),
+		grpcServer: server,
 	}
 	for _, b := range backends {
 		b.RegisterGRPC(r.grpcServer)

--- a/api/server/router/grpc/grpc.go
+++ b/api/server/router/grpc/grpc.go
@@ -15,12 +15,12 @@ type grpcRouter struct {
 
 // NewRouter initializes a new grpc http router
 func NewRouter(backends ...Backend) router.Router {
-	opts := []grpc.ServerOption{grpc.UnaryInterceptor(grpcerrors.UnaryServerInterceptor), grpc.StreamInterceptor(grpcerrors.StreamServerInterceptor)}
-	server := grpc.NewServer(opts...)
-
 	r := &grpcRouter{
-		h2Server:   &http2.Server{},
-		grpcServer: server,
+		h2Server: &http2.Server{},
+		grpcServer: grpc.NewServer(
+			grpc.UnaryInterceptor(grpcerrors.UnaryServerInterceptor),
+			grpc.StreamInterceptor(grpcerrors.StreamServerInterceptor),
+		),
 	}
 	for _, b := range backends {
 		b.RegisterGRPC(r.grpcServer)
@@ -30,12 +30,12 @@ func NewRouter(backends ...Backend) router.Router {
 }
 
 // Routes returns the available routers to the session controller
-func (r *grpcRouter) Routes() []router.Route {
-	return r.routes
+func (gr *grpcRouter) Routes() []router.Route {
+	return gr.routes
 }
 
-func (r *grpcRouter) initRoutes() {
-	r.routes = []router.Route{
-		router.NewPostRoute("/grpc", r.serveGRPC),
+func (gr *grpcRouter) initRoutes() {
+	gr.routes = []router.Route{
+		router.NewPostRoute("/grpc", gr.serveGRPC),
 	}
 }


### PR DESCRIPTION
Backport of:

- #42329
- #43471