### PR TITLE
update docs file for windows build

### DIFF
--- a/docs/contributing/software-req-win.md
+++ b/docs/contributing/software-req-win.md
@@ -88,6 +88,8 @@ to learn about the other software that powers the Moby platform.
 Create a builder-container with the Moby source code. You can change the source
 code on your system and rebuild any time:
 
+    docker pull mcr.microsoft.com/windows/servercore:ltsc2022
+    docker image tag mcr.microsoft.com/windows/servercore:ltsc2022 microsoft/windowsservercore
     docker build -t nativebuildimage -f .\Dockerfile.windows .
     docker build -t nativebuildimage -f Dockerfile.windows -m 2GB .  # (if using Hyper-V containers)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
update docs for windows build

**- why I did it**
I try to follow the software-req-win.Md files described in the build process to do it, but an error prompt Microsoft/windowsservercore mirror does not exist, this is because Microsoft/windowsservercore mirror has been deprecated.
![image](https://github.com/moby/moby/assets/42128890/e3108afe-697f-4832-bf19-180805025469)

I found that this problem had been mentioned by some people before #43304 , but had not been solved，so I thought should modify the documentation.

**- How to verify it**
github actions uses this command to ensure a successful build
![Snipaste_2023-06-09_11-02-42](https://github.com/moby/moby/assets/42128890/1a7bda73-d6eb-4496-95e2-d9d52fad4ffb)


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/moby/moby/assets/42128890/3647b61e-da0c-4a79-acd8-ebe185888185)

