### PR TITLE
pkg/rootless: remove GetRootlessKitClient, and move to daemon

### DIFF
--- a/pkg/rootless/rootless.go
+++ b/pkg/rootless/rootless.go
@@ -1,12 +1,6 @@
 package rootless // import "github.com/docker/docker/pkg/rootless"
 
-import (
-	"os"
-	"path/filepath"
-
-	"github.com/pkg/errors"
-	"github.com/rootless-containers/rootlesskit/pkg/api/client"
-)
+import "os"
 
 // RootlessKitDockerProxyBinary is the binary name of rootlesskit-docker-proxy
 const RootlessKitDockerProxyBinary = "rootlesskit-docker-proxy"
@@ -14,14 +8,4 @@ const RootlessKitDockerProxyBinary = "rootlesskit-docker-proxy"
 // RunningWithRootlessKit returns true if running under RootlessKit namespaces.
 func RunningWithRootlessKit() bool {
 	return os.Getenv("ROOTLESSKIT_STATE_DIR") != ""
-}
-
-// GetRootlessKitClient returns RootlessKit client
-func GetRootlessKitClient() (client.Client, error) {
-	stateDir := os.Getenv("ROOTLESSKIT_STATE_DIR")
-	if stateDir == "" {
-		return nil, errors.New("environment variable `ROOTLESSKIT_STATE_DIR` is not set")
-	}
-	apiSock := filepath.Join(stateDir, "api.sock")
-	return client.New(apiSock)
 }


### PR DESCRIPTION
This utility was only used in a single location (as part of `docker info`), but the `pkg/rootless` package is imported in various locations, causing rootlesskit to be a dependency for consumers of that package.

Move GetRootlessKitClient to the daemon code, which is the only location it was used.


**- A picture of a cute animal (not mandatory but encouraged)**

