### PR TITLE
pkg/namesgenerator: Add IsRandomName to identify generated names

### DIFF
--- a/pkg/namesgenerator/names-generator.go
+++ b/pkg/namesgenerator/names-generator.go
@@ -12,8 +12,11 @@
 package namesgenerator // import "github.com/docker/docker/pkg/namesgenerator"
 
 import (
+	"fmt"
 	"math/rand"
+	"regexp"
 	"strconv"
+	"strings"
 )
 
 var (
@@ -857,4 +860,14 @@ begin:
 		name += strconv.Itoa(rand.Intn(10)) //nolint:gosec // G404: Use of weak random number generator (math/rand instead of crypto/rand)
 	}
 	return name
+}
+
+func IsRandomName(name string) bool {
+	if strings.HasPrefix(name, "boring_wozniak") {
+		return false
+	}
+	leftParts := strings.Join(left[:], "|")
+	rightParts := strings.Join(right[:], "|")
+	re := regexp.MustCompile(fmt.Sprintf("^(%s)_(%s)[0-9]?$", leftParts, rightParts))
+	return re.FindString(name) != ""
 }

--- a/pkg/namesgenerator/names-generator_test.go
+++ b/pkg/namesgenerator/names-generator_test.go
@@ -25,6 +25,18 @@ func TestNameRetries(t *testing.T) {
 	}
 }
 
+func TestIsRandomName(t *testing.T) {
+	name := GetRandomName(0)
+	if !IsRandomName(name) {
+		t.Fatalf("Generated name %s is not detected", name)
+	}
+
+	name = GetRandomName(1)
+	if !IsRandomName(name) {
+		t.Fatalf("Generated name %s is not detected", name)
+	}
+}
+
 func BenchmarkGetRandomName(b *testing.B) {
 	b.ReportAllocs()
 	var out string


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### Motivation

As a lab sysadmin I often find lots of discarded containers lingering around our servers. There are some prominent traits like bearing an auto-generated name, created X months ago and exited (0) X months ago, in addition to having an untagged image. Since people often forget to add `--rm` when creating containers, as well as leftover containers from failed `docker build`s, I have to clean them up periodically.

While the container status (image tag, creation/exit times) can be fetched from the Docker API, there's no authoritative information whether a container has a human-specified or auto-generated name. So at present I grab `names-generator.go` and add my own code to utilize the arrays (see [my Makefile](https://github.com/iBug/goGadgets/blob/9377f59e1a0447e7003c771b8a6c31dcc7271ab4/docker-autogenerated-names/Makefile)). It'd be nice if the official package exports an API for this task, which is the point of this PR.

Ideally, the `left` and `right` arrays are exported as well, but an `IsRandomName` satisfies my needs for now.

### What I did

This PR adds `func IsRandomName(string) bool` to identify if a given name is (possibly) auto-generated.

### How I did it

It uses a regular expression to match the name, explicitly skipping an excluded name (`boring_wozniak`).

### How to verify it

See the addition of `func TestIsRandomName(*testing.T)`.

### Description for the changelog

```
pkg/namesgenerator: Add IsRandomName to identify generated names
```

### A picture of a cute animal (not mandatory but encouraged)

Meh.