### PR TITLE
daemon: registerName(): don't reserve name twice

### DIFF
--- a/daemon/names.go
+++ b/daemon/names.go
@@ -26,11 +26,12 @@ func (daemon *Daemon) registerName(container *container.Container) error {
 		return err
 	}
 	if container.Name == "" {
-		name, err := daemon.generateNewName(container.ID)
+		name, err := daemon.generateAndReserveName(container.ID)
 		if err != nil {
 			return err
 		}
 		container.Name = name
+		return nil
 	}
 	return daemon.containersReplica.ReserveName(container.Name, container.ID)
 }
@@ -42,7 +43,7 @@ func (daemon *Daemon) generateIDAndName(name string) (string, string, error) {
 	)
 
 	if name == "" {
-		if name, err = daemon.generateNewName(id); err != nil {
+		if name, err = daemon.generateAndReserveName(id); err != nil {
 			return "", "", err
 		}
 		return id, name, nil
@@ -81,7 +82,7 @@ func (daemon *Daemon) releaseName(name string) {
 	daemon.containersReplica.ReleaseName(name)
 }
 
-func (daemon *Daemon) generateNewName(id string) (string, error) {
+func (daemon *Daemon) generateAndReserveName(id string) (string, error) {
 	var name string
 	for i := 0; i < 6; i++ {
 		name = namesgenerator.GetRandomName(i)


### PR DESCRIPTION
daemon.generateNewName() already reserves the generated name, but its name did not indicate it did. The daemon.registerName() assumed that the generated name still had to be reserved, which could mean it would try to reserve the same name again.

This patch renames daemon.generateNewName to daemon.generateAndReserveName to make it clearer what it does, and updates registerName() to return early if it successfully generated (and registered) the container name.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

