### PR TITLE
Update dockerd to support JSON logging format

### DIFF
--- a/cmd/dockerd/daemon_test.go
+++ b/cmd/dockerd/daemon_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	"github.com/containerd/containerd/log"
 	"github.com/docker/docker/daemon/config"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
@@ -153,6 +154,26 @@ func TestLoadDaemonCliConfigWithLogLevel(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, loadedConfig != nil)
 	assert.Check(t, is.Equal("warn", loadedConfig.LogLevel))
+}
+
+func TestLoadDaemonCliConfigWithLogFormat(t *testing.T) {
+	tempFile := fs.NewFile(t, "config", fs.WithContent(`{"log-format": "json"}`))
+	defer tempFile.Remove()
+
+	opts := defaultOptions(t, tempFile.Path())
+	loadedConfig, err := loadDaemonCliConfig(opts)
+	assert.NilError(t, err)
+	assert.Assert(t, loadedConfig != nil)
+	assert.Check(t, is.Equal(log.JSONFormat, loadedConfig.LogFormat))
+}
+
+func TestLoadDaemonCliConfigWithInvalidLogFormat(t *testing.T) {
+	tempFile := fs.NewFile(t, "config", fs.WithContent(`{"log-format": "foo"}`))
+	defer tempFile.Remove()
+
+	opts := defaultOptions(t, tempFile.Path())
+	_, err := loadDaemonCliConfig(opts)
+	assert.Check(t, is.ErrorContains(err, "invalid log format: foo"))
 }
 
 func TestLoadDaemonConfigWithEmbeddedOptions(t *testing.T) {

--- a/cmd/dockerd/options.go
+++ b/cmd/dockerd/options.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/containerd/containerd/log"
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/homedir"
@@ -72,6 +74,7 @@ type daemonOptions struct {
 	Debug        bool
 	Hosts        []string
 	LogLevel     string
+	LogFormat    string
 	TLS          bool
 	TLSVerify    bool
 	TLSOptions   *tlsconfig.Options
@@ -104,6 +107,8 @@ func (o *daemonOptions) installFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&o.Debug, "debug", "D", false, "Enable debug mode")
 	flags.BoolVar(&o.Validate, "validate", false, "Validate daemon configuration and exit")
 	flags.StringVarP(&o.LogLevel, "log-level", "l", "info", `Set the logging level ("debug"|"info"|"warn"|"error"|"fatal")`)
+	flags.StringVar(&o.LogFormat, "log-format", log.TextFormat,
+		fmt.Sprintf(`Set the logging format ("%s"|"%s")`, log.TextFormat, log.JSONFormat))
 	flags.BoolVar(&o.TLS, FlagTLS, DefaultTLSValue, "Use TLS; implied by --tlsverify")
 	flags.BoolVar(&o.TLSVerify, FlagTLSVerify, dockerTLSVerify || DefaultTLSValue, "Use TLS and verify the remote")
 

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -187,6 +187,7 @@ type CommonConfig struct {
 	Debug     bool     `json:"debug,omitempty"`
 	Hosts     []string `json:"hosts,omitempty"`
 	LogLevel  string   `json:"log-level,omitempty"`
+	LogFormat string   `json:"log-format,omitempty"`
 	TLS       *bool    `json:"tls,omitempty"`
 	TLSVerify *bool    `json:"tlsverify,omitempty"`
 
@@ -591,6 +592,16 @@ func Validate(config *Config) error {
 	if config.LogLevel != "" {
 		if _, err := logrus.ParseLevel(config.LogLevel); err != nil {
 			return errors.Errorf("invalid logging level: %s", config.LogLevel)
+		}
+	}
+
+	// validate log-format
+	if logFormat := config.LogFormat; logFormat != "" {
+		switch logFormat {
+		case log.TextFormat, log.JSONFormat:
+			// These are valid
+		default:
+			return errors.Errorf("invalid log format: %s", logFormat)
 		}
 	}
 

--- a/libcontainerd/supervisor/remote_daemon_options.go
+++ b/libcontainerd/supervisor/remote_daemon_options.go
@@ -13,6 +13,15 @@ func WithLogLevel(lvl string) DaemonOpt {
 	}
 }
 
+// WithLogFormat defines the containerd log format.
+// This only makes sense if WithStartDaemon() was set to true.
+func WithLogFormat(format string) DaemonOpt {
+	return func(r *remote) error {
+		r.Debug.Format = format
+		return nil
+	}
+}
+
 // WithCRIDisabled disables the CRI plugin.
 func WithCRIDisabled() DaemonOpt {
 	return func(r *remote) error {


### PR DESCRIPTION
**- What I did**
Update docker to support a `--log-format` option, which accepts either `text` (default) or `json`. Propagate the log format to containerd as well, to ensure that everything will be logged consistently.

Fixes #44940.

**- How I did it**
Added a new CLI flag `--log-format` which accepts `text` (default) or `json`. Propagate log format to containerd so that all daemon output uses consistent formatting.

**- How to verify it**
Run dockerd with `--log-format=json` and `--log-format=text` (or leaving the option unset) to verify both encoding formats. This should set consistent log formats for both dockerd and containerd.

**- Description for the changelog**
Add a `--log-format` option to dockerd to allow logging in text (default) or JSON format.

**- A picture of a cute animal (not mandatory but encouraged)**

