### PR TITLE
testutil: remove unused TEST_OSTYPE env-var, and remove Execution.OSType field

### DIFF
--- a/integration-cli/cli/cli.go
+++ b/integration-cli/cli/cli.go
@@ -107,7 +107,7 @@ func Docker(cmd icmd.Cmd, cmdOperators ...CmdOperator) *icmd.Result {
 // validateArgs is a checker to ensure tests are not running commands which are
 // not supported on platforms. Specifically on Windows this is 'busybox top'.
 func validateArgs(args ...string) error {
-	if testEnv.OSType != "windows" {
+	if testEnv.DaemonInfo.OSType != "windows" {
 		return nil
 	}
 	foundBusybox := -1

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -987,7 +987,7 @@ func (s *DockerAPISuite) TestContainerAPIWait(c *testing.T) {
 	name := "test-api-wait"
 
 	sleepCmd := "/bin/sleep"
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		sleepCmd = "sleep"
 	}
 	dockerCmd(c, "run", "--name", name, "busybox", sleepCmd, "2")
@@ -1194,7 +1194,7 @@ func (s *DockerAPISuite) TestContainerAPIDeleteRemoveVolume(c *testing.T) {
 	testRequires(c, testEnv.IsLocalDaemon)
 
 	vol := "/testvolume"
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		vol = `c:\testvolume`
 	}
 
@@ -1972,7 +1972,7 @@ func (s *DockerAPISuite) TestContainersAPICreateMountsCreate(c *testing.T) {
 	var (
 		testImg string
 	)
-	if testEnv.OSType != "windows" {
+	if testEnv.DaemonInfo.OSType != "windows" {
 		testImg = "test-mount-config"
 		buildImageSuccessfully(c, testImg, build.WithDockerfile(`
 	FROM busybox
@@ -2073,7 +2073,7 @@ func (s *DockerAPISuite) TestContainersAPICreateMountsCreate(c *testing.T) {
 		}
 	}
 
-	if testEnv.OSType != "windows" { // Windows does not support volume populate
+	if testEnv.DaemonInfo.OSType != "windows" { // Windows does not support volume populate
 		cases = append(cases, []testCase{
 			{
 				spec:     mount.Mount{Type: "volume", Target: destPath, VolumeOptions: &mount.VolumeOptions{NoCopy: true}},

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -78,7 +78,7 @@ func (s *DockerAPISuite) TestAPIImagesDelete(c *testing.T) {
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
-	if testEnv.OSType != "windows" {
+	if testEnv.DaemonInfo.OSType != "windows" {
 		testRequires(c, Network)
 	}
 	name := "test-api-images-delete"
@@ -102,7 +102,7 @@ func (s *DockerAPISuite) TestAPIImagesHistory(c *testing.T) {
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
-	if testEnv.OSType != "windows" {
+	if testEnv.DaemonInfo.OSType != "windows" {
 		testRequires(c, Network)
 	}
 	name := "test-api-images-history"

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -27,7 +27,7 @@ func (s *DockerAPISuite) TestInspectAPIContainerResponse(c *testing.T) {
 
 	var cases []acase
 
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		cases = []acase{
 			{"v1.25", append(keysBase, "Mounts")},
 		}

--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -42,7 +42,7 @@ func (s *DockerAPISuite) TestAPIStatsNoStreamGetCpu(c *testing.T) {
 
 	var cpuPercent = 0.0
 
-	if testEnv.OSType != "windows" {
+	if testEnv.DaemonInfo.OSType != "windows" {
 		cpuDelta := float64(v.CPUStats.CPUUsage.TotalUsage - v.PreCPUStats.CPUUsage.TotalUsage)
 		systemDelta := float64(v.CPUStats.SystemUsage - v.PreCPUStats.SystemUsage)
 		cpuPercent = (cpuDelta / systemDelta) * float64(len(v.CPUStats.CPUUsage.PercpuUsage)) * 100.0
@@ -109,7 +109,7 @@ func (s *DockerAPISuite) TestAPIStatsNetworkStats(c *testing.T) {
 
 	// Retrieve the container address
 	net := "bridge"
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		net = "nat"
 	}
 	contIP := findContainerIP(c, id, net)
@@ -157,7 +157,7 @@ func (s *DockerAPISuite) TestAPIStatsNetworkStats(c *testing.T) {
 	// On Linux, account for ARP.
 	expRxPkts := preRxPackets + uint64(numPings)
 	expTxPkts := preTxPackets + uint64(numPings)
-	if testEnv.OSType != "windows" {
+	if testEnv.DaemonInfo.OSType != "windows" {
 		expRxPkts++
 		expTxPkts++
 	}

--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -40,13 +40,13 @@ func (s *DockerAPISuite) TestAPIGetEnabledCORS(c *testing.T) {
 	body.Close()
 	// TODO: @runcom incomplete tests, why old integration tests had this headers
 	// and here none of the headers below are in the response?
-	//c.Log(res.Header)
-	//assert.Equal(c, res.Header.Get("Access-Control-Allow-Origin"), "*")
-	//assert.Equal(c, res.Header.Get("Access-Control-Allow-Headers"), "Origin, X-Requested-With, Content-Type, Accept, X-Registry-Auth")
+	// c.Log(res.Header)
+	// assert.Equal(c, res.Header.Get("Access-Control-Allow-Origin"), "*")
+	// assert.Equal(c, res.Header.Get("Access-Control-Allow-Headers"), "Origin, X-Requested-With, Content-Type, Accept, X-Registry-Auth")
 }
 
 func (s *DockerAPISuite) TestAPIClientVersionOldNotSupported(c *testing.T) {
-	if testEnv.OSType != runtime.GOOS {
+	if testEnv.DaemonInfo.OSType != runtime.GOOS {
 		c.Skip("Daemon platform doesn't match test platform")
 	}
 	if api.MinVersion == api.DefaultVersion {

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -52,7 +52,7 @@ func (s *DockerCLIBuildSuite) TestBuildJSONEmptyRun(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildShCmdJSONEntrypoint(c *testing.T) {
 	name := "testbuildshcmdjsonentrypoint"
 	expected := "/bin/sh -c echo test"
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		expected = "cmd /S /C echo test"
 	}
 
@@ -90,7 +90,7 @@ func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementVolume(c *testing.T
 
 	var volumePath string
 
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		volumePath = "c:/quux"
 	} else {
 		volumePath = "/quux"
@@ -145,7 +145,7 @@ func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementWorkdir(c *testing.
 	res := inspectFieldJSON(c, name, "Config.WorkingDir")
 
 	expected := `"/work"`
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		expected = `"C:\\work"`
 	}
 	if res != expected {
@@ -1298,7 +1298,7 @@ func (s *DockerCLIBuildSuite) TestBuildRelativeWorkdir(c *testing.T) {
 		expectedFinal string
 	)
 
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		expected1 = `C:/`
 		expected2 = `C:/test1`
 		expected3 = `C:/test2`
@@ -1377,7 +1377,7 @@ func (s *DockerCLIBuildSuite) TestBuildWorkdirWithEnvVariables(c *testing.T) {
 	name := "testbuildworkdirwithenvvariables"
 
 	var expected string
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		expected = `C:\test1\test2`
 	} else {
 		expected = `/test1/test2`
@@ -1399,7 +1399,7 @@ func (s *DockerCLIBuildSuite) TestBuildRelativeCopy(c *testing.T) {
 	testRequires(c, NotUserNamespace)
 
 	var expected string
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		expected = `C:/test1/test2`
 	} else {
 		expected = `/test1/test2`
@@ -2230,7 +2230,7 @@ func (s *DockerCLIBuildSuite) TestBuildOnBuild(c *testing.T) {
 // gh #2446
 func (s *DockerCLIBuildSuite) TestBuildAddToSymlinkDest(c *testing.T) {
 	makeLink := `ln -s /foo /bar`
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		makeLink = `mklink /D C:\bar C:\foo`
 	}
 	name := "testbuildaddtosymlinkdest"
@@ -3186,7 +3186,7 @@ func (s *DockerCLIBuildSuite) TestBuildCmdShDashC(c *testing.T) {
 
 	res := inspectFieldJSON(c, name, "Config.Cmd")
 	expected := `["/bin/sh","-c","echo cmd"]`
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		expected = `["cmd /S /C echo cmd"]`
 	}
 	if res != expected {
@@ -3258,7 +3258,7 @@ func (s *DockerCLIBuildSuite) TestBuildEntrypointCanBeOverriddenByChildInspect(c
 		expected = `["/bin/sh","-c","echo quux"]`
 	)
 
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		expected = `["cmd /S /C echo quux"]`
 	}
 
@@ -3328,7 +3328,7 @@ func (s *DockerCLIBuildSuite) TestBuildVerboseOut(c *testing.T) {
 	name := "testbuildverboseout"
 	expected := "\n123\n"
 
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		expected = "\n123\r\n"
 	}
 
@@ -3344,7 +3344,7 @@ func (s *DockerCLIBuildSuite) TestBuildWithTabs(c *testing.T) {
 	res := inspectFieldJSON(c, name, "ContainerConfig.Cmd")
 	expected1 := `["/bin/sh","-c","echo\tone\t\ttwo"]`
 	expected2 := `["/bin/sh","-c","echo\u0009one\u0009\u0009two"]` // syntactically equivalent, and what Go 1.3 generates
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		expected1 = `["cmd /S /C echo\tone\t\ttwo"]`
 		expected2 = `["cmd /S /C echo\u0009one\u0009\u0009two"]` // syntactically equivalent, and what Go 1.3 generates
 	}
@@ -3542,7 +3542,7 @@ func (s *DockerCLIBuildSuite) TestBuildStderr(c *testing.T) {
 	result.Assert(c, icmd.Success)
 
 	// Windows to non-Windows should have a security warning
-	if runtime.GOOS == "windows" && testEnv.OSType != "windows" && !strings.Contains(result.Stdout(), "SECURITY WARNING:") {
+	if runtime.GOOS == "windows" && testEnv.DaemonInfo.OSType != "windows" && !strings.Contains(result.Stdout(), "SECURITY WARNING:") {
 		c.Fatalf("Stdout contains unexpected output: %q", result.Stdout())
 	}
 
@@ -3659,7 +3659,7 @@ func (s *DockerCLIBuildSuite) TestBuildVolumesRetainContents(c *testing.T) {
 		volName  = "/foo"
 	)
 
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		volName = "C:/foo"
 	}
 
@@ -3842,7 +3842,7 @@ RUN echo "  \
 
 	expected := "\n    foo  \n"
 	// Windows uses the builtin echo, which preserves quotes
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		expected = "\"    foo  \""
 	}
 
@@ -3876,7 +3876,7 @@ func (s *DockerCLIBuildSuite) TestBuildMissingArgs(c *testing.T) {
 		"INSERT":     {},
 	}
 
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		skipCmds = map[string]struct{}{
 			"CMD":        {},
 			"RUN":        {},
@@ -4008,7 +4008,7 @@ func (s *DockerCLIBuildSuite) TestBuildRUNErrMsg(c *testing.T) {
 	name := "testbuildbadrunerrmsg"
 	shell := "/bin/sh -c"
 	exitCode := 127
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		shell = "cmd /S /C"
 		// architectural - Windows has to start the container to determine the exe is bad, Linux does not
 		exitCode = 1
@@ -4027,7 +4027,7 @@ func (s *DockerCLIBuildSuite) TestBuildRUNErrMsg(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildNullStringInAddCopyVolume(c *testing.T) {
 	name := "testbuildnullstringinaddcopyvolume"
 	volName := "nullvolume"
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		volName = `C:\\nullvolume`
 	}
 
@@ -4067,7 +4067,7 @@ func (s *DockerCLIBuildSuite) TestBuildBuildTimeArg(c *testing.T) {
 	envKey := "foo"
 	envVal := "bar"
 	var dockerfile string
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		// Bugs in Windows busybox port - use the default base image and native cmd stuff
 		dockerfile = fmt.Sprintf(`FROM `+minimalBaseImage()+`
 			ARG %s
@@ -4678,7 +4678,7 @@ func (s *DockerCLIBuildSuite) TestBuildMultiStageUnusedArg(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildNoNamedVolume(c *testing.T) {
 	volName := "testname:/foo"
 
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		volName = "testname:C:\\foo"
 	}
 	dockerCmd(c, "run", "-v", volName, "busybox", "sh", "-c", "touch /foo/oops")
@@ -6105,7 +6105,7 @@ CMD echo foo
 
 	out, _ := dockerCmd(c, "inspect", "--format", "{{ json .Config.Cmd }}", "build2")
 	expected := `["/bin/sh","-c","echo foo"]`
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		expected = `["/bin/sh -c echo foo"]`
 	}
 	assert.Equal(c, strings.TrimSpace(out), expected)

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -137,7 +137,7 @@ func (s *DockerCLICommitSuite) TestCommitChange(c *testing.T) {
 	expectedEnv := "[DEBUG=true test=1 PATH=/foo]"
 	// bug fixed in 1.36, add min APi >= 1.36 requirement
 	// PR record https://github.com/moby/moby/pull/35582
-	if versions.GreaterThan(testEnv.DaemonAPIVersion(), "1.35") && testEnv.OSType != "windows" {
+	if versions.GreaterThan(testEnv.DaemonAPIVersion(), "1.35") && testEnv.DaemonInfo.OSType != "windows" {
 		// The ordering here is due to `PATH` being overridden from the container's
 		// ENV.  On windows, the container doesn't have a `PATH` ENV variable so
 		// the ordering is the same as the cli.

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -201,7 +201,7 @@ func (s *DockerCLICreateSuite) TestCreateLabelFromImage(c *testing.T) {
 func (s *DockerCLICreateSuite) TestCreateHostnameWithNumber(c *testing.T) {
 	image := "busybox"
 	// Busybox on Windows does not implement hostname command
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		image = testEnv.PlatformDefaults.BaseImage
 	}
 	out, _ := dockerCmd(c, "run", "-h", "web.0", image, "hostname")
@@ -284,7 +284,7 @@ func (s *DockerCLICreateSuite) TestCreateWithWorkdir(c *testing.T) {
 
 	dockerCmd(c, "create", "--name", name, "-w", dir, "busybox")
 	// Windows does not create the workdir until the container is started
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		dockerCmd(c, "start", name)
 		if testEnv.DaemonInfo.Isolation.IsHyperV() {
 			// Hyper-V isolated containers do not allow file-operations on a

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -657,7 +657,7 @@ func (s *DockerCLIEventSuite) TestEventsContainerRestart(c *testing.T) {
 
 	// wait until test2 is auto removed.
 	waitTime := 10 * time.Second
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		// Windows takes longer...
 		waitTime = 90 * time.Second
 	}

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -46,7 +46,7 @@ func (s *DockerCLIInfoSuite) TestInfoEnsureSucceeds(c *testing.T) {
 		"Live Restore Enabled:",
 	}
 
-	if testEnv.OSType == "linux" {
+	if testEnv.DaemonInfo.OSType == "linux" {
 		stringsToCheck = append(stringsToCheck, "Init Binary:", "Security Options:", "containerd version:", "runc version:", "init version:")
 	}
 

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -72,7 +72,7 @@ func (s *DockerCLIInspectSuite) TestInspectStatus(c *testing.T) {
 
 	// Windows does not support pause/unpause on Windows Server Containers.
 	// (RS1 does for Hyper-V Containers, but production CI is not setup for that)
-	if testEnv.OSType != "windows" {
+	if testEnv.DaemonInfo.OSType != "windows" {
 		dockerCmd(c, "pause", out)
 		inspectOut = inspectField(c, out, "State.Status")
 		assert.Equal(c, inspectOut, "paused")
@@ -174,7 +174,7 @@ func (s *DockerCLIInspectSuite) TestInspectContainerFilterInt(c *testing.T) {
 func (s *DockerCLIInspectSuite) TestInspectBindMountPoint(c *testing.T) {
 	modifier := ",z"
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		modifier = ""
 		// Linux creates the host directory if it doesn't exist. Windows does not.
 		os.Mkdir(`c:\data`, os.ModeDir)
@@ -197,7 +197,7 @@ func (s *DockerCLIInspectSuite) TestInspectBindMountPoint(c *testing.T) {
 	assert.Equal(c, m.Driver, "")
 	assert.Equal(c, m.Source, prefix+slash+"data")
 	assert.Equal(c, m.Destination, prefix+slash+"data")
-	if testEnv.OSType != "windows" { // Windows does not set mode
+	if testEnv.DaemonInfo.OSType != "windows" { // Windows does not set mode
 		assert.Equal(c, m.Mode, "ro"+modifier)
 	}
 	assert.Equal(c, m.RW, false)

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -223,7 +223,7 @@ func (s *DockerCLIPsSuite) TestPsListContainersFilterStatus(c *testing.T) {
 		Err:      err,
 	})
 	// Windows doesn't support pausing of containers
-	if testEnv.OSType != "windows" {
+	if testEnv.DaemonInfo.OSType != "windows" {
 		// pause running container
 		out = cli.DockerCmd(c, "run", "-itd", "busybox").Combined()
 		pausedID := strings.TrimSpace(out)

--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -299,7 +299,7 @@ func (s *DockerCLIRestartSuite) TestRestartContainerwithRestartPolicy(c *testing
 	id1 := strings.TrimSpace(out1)
 	id2 := strings.TrimSpace(out2)
 	waitTimeout := 15 * time.Second
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		waitTimeout = 150 * time.Second
 	}
 	err := waitInspect(id1, "{{ .State.Restarting }} {{ .State.Running }}", "false false", waitTimeout)

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -77,7 +77,7 @@ func (s *DockerCLIRmiSuite) TestRmiImgIDMultipleTag(c *testing.T) {
 
 	// Wait for it to exit as cannot commit a running container on Windows, and
 	// it will take a few seconds to exit
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		cli.WaitExited(c, containerID, 60*time.Second)
 	}
 
@@ -118,7 +118,7 @@ func (s *DockerCLIRmiSuite) TestRmiImgIDForce(c *testing.T) {
 
 	// Wait for it to exit as cannot commit a running container on Windows, and
 	// it will take a few seconds to exit
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		cli.WaitExited(c, containerID, 60*time.Second)
 	}
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -82,7 +82,7 @@ func (s *DockerCLIRunSuite) TestRunLeakyFileDescriptors(c *testing.T) {
 // this will fail when Internet access is unavailable
 func (s *DockerCLIRunSuite) TestRunLookupGoogleDNS(c *testing.T) {
 	testRequires(c, Network, NotArm)
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		// nslookup isn't present in Windows busybox. Is built-in. Further,
 		// nslookup isn't present in nanoserver. Hence just use PowerShell...
 		dockerCmd(c, "run", testEnv.PlatformDefaults.BaseImage, "powershell", "Resolve-DNSName", "google.com")
@@ -146,7 +146,7 @@ func (s *DockerCLIRunSuite) TestRunDetachedContainerIDPrinting(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunWorkingDirectory(c *testing.T) {
 	dir := "/root"
 	image := "busybox"
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		dir = `C:/Windows`
 	}
 
@@ -169,7 +169,7 @@ func (s *DockerCLIRunSuite) TestRunWorkingDirectory(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunWithoutNetworking(c *testing.T) {
 	count := "-c"
 	image := "busybox"
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		count = "-n"
 		image = testEnv.PlatformDefaults.BaseImage
 	}
@@ -360,7 +360,7 @@ func (s *DockerCLIRunSuite) TestRunWithVolumesFromExited(c *testing.T) {
 	)
 
 	// Create a file in a volume
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		out, exitCode = dockerCmd(c, "run", "--name", "test-data", "--volume", `c:\some\dir`, testEnv.PlatformDefaults.BaseImage, "cmd", "/c", `echo hello > c:\some\dir\file`)
 	} else {
 		out, exitCode = dockerCmd(c, "run", "--name", "test-data", "--volume", "/some/dir", "busybox", "touch", "/some/dir/file")
@@ -370,7 +370,7 @@ func (s *DockerCLIRunSuite) TestRunWithVolumesFromExited(c *testing.T) {
 	}
 
 	// Read the file from another container using --volumes-from to access the volume in the second container
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		out, exitCode = dockerCmd(c, "run", "--volumes-from", "test-data", testEnv.PlatformDefaults.BaseImage, "cmd", "/c", `type c:\some\dir\file`)
 	} else {
 		out, exitCode = dockerCmd(c, "run", "--volumes-from", "test-data", "busybox", "cat", "/some/dir/file")
@@ -402,7 +402,7 @@ func (s *DockerCLIRunSuite) TestRunCreateVolumesInSymlinkDir(c *testing.T) {
 	// In the case of Windows to Windows CI, if the machine is setup so that
 	// the temp directory is not the C: drive, this test is invalid and will
 	// not work.
-	if testEnv.OSType == "windows" && strings.ToLower(dir[:1]) != "c" {
+	if testEnv.DaemonInfo.OSType == "windows" && strings.ToLower(dir[:1]) != "c" {
 		c.Skip("Requires TEMP to point to C: drive")
 	}
 
@@ -412,7 +412,7 @@ func (s *DockerCLIRunSuite) TestRunCreateVolumesInSymlinkDir(c *testing.T) {
 	}
 	f.Close()
 
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		dockerFile = fmt.Sprintf("FROM %s\nRUN mkdir %s\nRUN mklink /D c:\\test %s", testEnv.PlatformDefaults.BaseImage, dir, dir)
 		containerPath = `c:\test\test`
 		cmd = "tasklist"
@@ -437,7 +437,7 @@ func (s *DockerCLIRunSuite) TestRunCreateVolumesInSymlinkDir2(c *testing.T) {
 	testRequires(c, testEnv.IsLocalDaemon, DaemonIsLinux)
 	name := "test-volume-symlink2"
 
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		dockerFile = fmt.Sprintf("FROM %s\nRUN mkdir c:\\%s\nRUN mklink /D c:\\test c:\\%s", testEnv.PlatformDefaults.BaseImage, name, name)
 		containerPath = `c:\test\test`
 		cmd = "tasklist"
@@ -461,7 +461,7 @@ func (s *DockerCLIRunSuite) TestRunVolumesFromInReadonlyModeFails(c *testing.T) 
 		volumeDir string
 		fileInVol string
 	)
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		volumeDir = `c:/test` // Forward-slash as using busybox
 		fileInVol = `c:/test/file`
 	} else {
@@ -482,7 +482,7 @@ func (s *DockerCLIRunSuite) TestRunVolumesFromInReadWriteMode(c *testing.T) {
 		volumeDir string
 		fileInVol string
 	)
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		volumeDir = `c:/test` // Forward-slash as using busybox
 		fileInVol = `c:/test/file`
 	} else {
@@ -503,7 +503,7 @@ func (s *DockerCLIRunSuite) TestRunVolumesFromInReadWriteMode(c *testing.T) {
 func (s *DockerCLIRunSuite) TestVolumesFromGetsProperMode(c *testing.T) {
 	testRequires(c, testEnv.IsLocalDaemon)
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
-	hostpath := RandomTmpDirPath("test", testEnv.OSType)
+	hostpath := RandomTmpDirPath("test", testEnv.DaemonInfo.OSType)
 	if err := os.MkdirAll(hostpath, 0755); err != nil {
 		c.Fatalf("Failed to create %s: %q", hostpath, err)
 	}
@@ -526,11 +526,11 @@ func (s *DockerCLIRunSuite) TestVolumesFromGetsProperMode(c *testing.T) {
 
 // Test for GH#10618
 func (s *DockerCLIRunSuite) TestRunNoDupVolumes(c *testing.T) {
-	path1 := RandomTmpDirPath("test1", testEnv.OSType)
-	path2 := RandomTmpDirPath("test2", testEnv.OSType)
+	path1 := RandomTmpDirPath("test1", testEnv.DaemonInfo.OSType)
+	path2 := RandomTmpDirPath("test2", testEnv.DaemonInfo.OSType)
 
 	someplace := ":/someplace"
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		// Windows requires that the source directory exists before calling HCS
 		testRequires(c, testEnv.IsLocalDaemon)
 		someplace = `:c:\someplace`
@@ -579,7 +579,7 @@ func (s *DockerCLIRunSuite) TestRunNoDupVolumes(c *testing.T) {
 // Test for #1351
 func (s *DockerCLIRunSuite) TestRunApplyVolumesFromBeforeVolumes(c *testing.T) {
 	prefix := ""
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		prefix = `c:`
 	}
 	dockerCmd(c, "run", "--name", "parent", "-v", prefix+"/test", "busybox", "touch", prefix+"/test/foo")
@@ -588,7 +588,7 @@ func (s *DockerCLIRunSuite) TestRunApplyVolumesFromBeforeVolumes(c *testing.T) {
 
 func (s *DockerCLIRunSuite) TestRunMultipleVolumesFrom(c *testing.T) {
 	prefix := ""
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		prefix = `c:`
 	}
 	dockerCmd(c, "run", "--name", "parent1", "-v", prefix+"/test", "busybox", "touch", prefix+"/test/foo")
@@ -618,7 +618,7 @@ func (s *DockerCLIRunSuite) TestRunVerifyContainerID(c *testing.T) {
 // Test that creating a container with a volume doesn't crash. Regression test for #995.
 func (s *DockerCLIRunSuite) TestRunCreateVolume(c *testing.T) {
 	prefix := ""
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		prefix = `c:`
 	}
 	dockerCmd(c, "run", "-v", prefix+"/var/lib/data", "busybox", "true")
@@ -675,7 +675,7 @@ func (s *DockerCLIRunSuite) TestRunVolumesFromSymlinkPath(c *testing.T) {
 		RUN ln -s home /foo
 		VOLUME ["/foo/bar"]`
 
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		prefix = `c:`
 		dfContents = `FROM ` + testEnv.PlatformDefaults.BaseImage + `
 	    RUN mkdir c:\home
@@ -721,7 +721,7 @@ func (s *DockerCLIRunSuite) TestRunExitCode(c *testing.T) {
 
 func (s *DockerCLIRunSuite) TestRunUserDefaults(c *testing.T) {
 	expected := "uid=0(root) gid=0(root)"
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		expected = "uid=0(root) gid=0(root) groups=0(root)"
 	}
 	out, _ := dockerCmd(c, "run", "busybox", "id")
@@ -927,7 +927,7 @@ func (s *DockerCLIRunSuite) TestRunEnvironmentOverride(c *testing.T) {
 }
 
 func (s *DockerCLIRunSuite) TestRunContainerNetwork(c *testing.T) {
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		// Windows busybox does not have ping. Use built in ping instead.
 		dockerCmd(c, "run", testEnv.PlatformDefaults.BaseImage, "ping", "-n", "1", "127.0.0.1")
 	} else {
@@ -1227,7 +1227,7 @@ func (s *DockerCLIRunSuite) TestRunModeHostname(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunRootWorkdir(c *testing.T) {
 	out, _ := dockerCmd(c, "run", "--workdir", "/", "busybox", "pwd")
 	expected := "/\n"
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		expected = "C:" + expected
 	}
 	if out != expected {
@@ -1236,7 +1236,7 @@ func (s *DockerCLIRunSuite) TestRunRootWorkdir(c *testing.T) {
 }
 
 func (s *DockerCLIRunSuite) TestRunAllowBindMountingRoot(c *testing.T) {
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		// Windows busybox will fail with Permission Denied on items such as pagefile.sys
 		dockerCmd(c, "run", "-v", `c:\:c:\host`, testEnv.PlatformDefaults.BaseImage, "cmd", "-c", "dir", `c:\host`)
 	} else {
@@ -1247,7 +1247,7 @@ func (s *DockerCLIRunSuite) TestRunAllowBindMountingRoot(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunDisallowBindMountingRootToRoot(c *testing.T) {
 	mount := "/:/"
 	targetDir := "/host"
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		mount = `c:\:c\`
 		targetDir = "c:/host" // Forward slash as using busybox
 	}
@@ -1708,7 +1708,7 @@ func (s *DockerCLIRunSuite) TestRunCleanupCmdOnEntrypoint(c *testing.T) {
 	}
 	out = strings.TrimSpace(out)
 	expected := "root"
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		if strings.Contains(testEnv.PlatformDefaults.BaseImage, "servercore") {
 			expected = `user manager\containeradministrator`
 		} else {
@@ -1724,7 +1724,7 @@ func (s *DockerCLIRunSuite) TestRunCleanupCmdOnEntrypoint(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunWorkdirExistsAndIsFile(c *testing.T) {
 	existingFile := "/bin/cat"
 	expected := "not a directory"
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		existingFile = `\windows\system32\ntdll.dll`
 		expected = `The directory name is invalid.`
 	}
@@ -1740,7 +1740,7 @@ func (s *DockerCLIRunSuite) TestRunExitOnStdinClose(c *testing.T) {
 
 	meow := "/bin/cat"
 	delay := 60
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		meow = "cat"
 	}
 	runCmd := exec.Command(dockerBinary, "run", "--name", name, "-i", "busybox", meow)
@@ -1883,7 +1883,7 @@ func (s *DockerCLIRunSuite) TestRunEntrypoint(c *testing.T) {
 
 func (s *DockerCLIRunSuite) TestRunBindMounts(c *testing.T) {
 	testRequires(c, testEnv.IsLocalDaemon)
-	if testEnv.OSType == "linux" {
+	if testEnv.DaemonInfo.OSType == "linux" {
 		testRequires(c, DaemonIsLinux, NotUserNamespace)
 	}
 
@@ -1904,7 +1904,7 @@ func (s *DockerCLIRunSuite) TestRunBindMounts(c *testing.T) {
 	}
 
 	// test writing to bind mount
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		dockerCmd(c, "run", "-v", fmt.Sprintf(`%s:c:\tmp:rw`, tmpDir), "busybox", "touch", "c:/tmp/holla")
 	} else {
 		dockerCmd(c, "run", "-v", fmt.Sprintf("%s:/tmp:rw", tmpDir), "busybox", "touch", "/tmp/holla")
@@ -1919,7 +1919,7 @@ func (s *DockerCLIRunSuite) TestRunBindMounts(c *testing.T) {
 	}
 
 	// Windows does not (and likely never will) support mounting a single file
-	if testEnv.OSType != "windows" {
+	if testEnv.DaemonInfo.OSType != "windows" {
 		// test mount a file
 		dockerCmd(c, "run", "-v", fmt.Sprintf("%s/holla:/tmp/holla:rw", tmpDir), "busybox", "sh", "-c", "echo -n 'yotta' > /tmp/holla")
 		content := readFile(path.Join(tmpDir, "holla"), c) // Will fail if the file doesn't exist
@@ -1988,7 +1988,7 @@ func (s *DockerCLIRunSuite) TestRunSetMacAddress(c *testing.T) {
 	skip.If(c, RuntimeIsWindowsContainerd(), "FIXME: Broken on Windows + containerd combination")
 	mac := "12:34:56:78:9a:bc"
 	var out string
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		out, _ = dockerCmd(c, "run", "-i", "--rm", fmt.Sprintf("--mac-address=%s", mac), "busybox", "sh", "-c", "ipconfig /all | grep 'Physical Address' | awk '{print $12}'")
 		mac = strings.ReplaceAll(strings.ToUpper(mac), ":", "-") // To Windows-style MACs
 	} else {
@@ -2184,7 +2184,7 @@ func (s *DockerCLIRunSuite) TestVolumesNoCopyData(c *testing.T) {
 		c.Fatalf("Data was copied on volumes-from but shouldn't be:\n%q", out)
 	}
 
-	tmpDir := RandomTmpDirPath("docker_test_bind_mount_copy_data", testEnv.OSType)
+	tmpDir := RandomTmpDirPath("docker_test_bind_mount_copy_data", testEnv.DaemonInfo.OSType)
 	if out, _, err := dockerCmdWithError("run", "-v", tmpDir+":/foo", "dataimage", "ls", "-lh", "/foo/bar"); err == nil || !strings.Contains(out, "No such file or directory") {
 		c.Fatalf("Data was copied on bind mount but shouldn't be:\n%q", out)
 	}
@@ -2536,7 +2536,7 @@ func (s *DockerCLIRunSuite) TestRunNonLocalMacAddress(c *testing.T) {
 	args := []string{"run", "--mac-address", addr}
 	expected := addr
 
-	if testEnv.OSType != "windows" {
+	if testEnv.DaemonInfo.OSType != "windows" {
 		args = append(args, "busybox", "ifconfig")
 	} else {
 		args = append(args, testEnv.PlatformDefaults.BaseImage, "ipconfig", "/all")
@@ -2632,7 +2632,7 @@ func (s *DockerCLIRunSuite) TestRunSetDefaultRestartPolicy(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunRestartMaxRetries(c *testing.T) {
 	out, _ := dockerCmd(c, "run", "-d", "--restart=on-failure:3", "busybox", "false")
 	timeout := 10 * time.Second
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		timeout = 120 * time.Second
 	}
 
@@ -3003,7 +3003,7 @@ func (s *DockerCLIRunSuite) TestVolumeFromMixedRWOptions(c *testing.T) {
 	dockerCmd(c, "run", "--volumes-from", "parent:ro", "--name", "test-volumes-1", "busybox", "true")
 	dockerCmd(c, "run", "--volumes-from", "parent:rw", "--name", "test-volumes-2", "busybox", "true")
 
-	if testEnv.OSType != "windows" {
+	if testEnv.DaemonInfo.OSType != "windows" {
 		mRO, err := inspectMountPoint("test-volumes-1", prefix+slash+"test")
 		assert.NilError(c, err, "failed to inspect mount point")
 		if mRO.RW {
@@ -3394,7 +3394,7 @@ func (s *DockerCLIRunSuite) TestRunLoopbackOnlyExistsWhenNetworkingDisabled(c *t
 
 // Issue #4681
 func (s *DockerCLIRunSuite) TestRunLoopbackWhenNetworkDisabled(c *testing.T) {
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		dockerCmd(c, "run", "--net=none", testEnv.PlatformDefaults.BaseImage, "ping", "-n", "1", "127.0.0.1")
 	} else {
 		dockerCmd(c, "run", "--net=none", "busybox", "ping", "-c", "1", "127.0.0.1")
@@ -3660,7 +3660,7 @@ func (s *DockerCLIRunSuite) TestRunNonExistingCmd(c *testing.T) {
 // as that's when the check is made (and yes, by its design...)
 func (s *DockerCLIRunSuite) TestCmdCannotBeInvoked(c *testing.T) {
 	expected := 126
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		expected = 127
 	}
 	name := "testCmdCannotBeInvoked"

--- a/integration-cli/docker_cli_top_test.go
+++ b/integration-cli/docker_cli_top_test.go
@@ -25,7 +25,7 @@ func (s *DockerCLITopSuite) TestTopMultipleArgs(c *testing.T) {
 	cleanedContainerID := strings.TrimSpace(out)
 
 	var expected icmd.Expected
-	switch testEnv.OSType {
+	switch testEnv.DaemonInfo.OSType {
 	case "windows":
 		expected = icmd.Expected{ExitCode: 1, Err: "Windows does not support arguments to top"}
 	default:
@@ -46,7 +46,7 @@ func (s *DockerCLITopSuite) TestTopNonPrivileged(c *testing.T) {
 	// Windows will list the name of the launched executable which in this case is busybox.exe, without the parameters.
 	// Linux will display the command executed in the container
 	var lookingFor string
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		lookingFor = "busybox.exe"
 	} else {
 		lookingFor = "top"

--- a/integration-cli/docker_deprecated_api_v124_test.go
+++ b/integration-cli/docker_deprecated_api_v124_test.go
@@ -41,7 +41,7 @@ func (s *DockerAPISuite) TestDeprecatedContainerAPIStartVolumeBinds(c *testing.T
 	// TODO Windows CI: Investigate further why this fails on Windows to Windows CI.
 	testRequires(c, DaemonIsLinux)
 	path := "/foo"
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		path = `c:\foo`
 	}
 	name := "testing"
@@ -54,7 +54,7 @@ func (s *DockerAPISuite) TestDeprecatedContainerAPIStartVolumeBinds(c *testing.T
 	assert.NilError(c, err)
 	assert.Equal(c, res.StatusCode, http.StatusCreated)
 
-	bindPath := RandomTmpDirPath("test", testEnv.OSType)
+	bindPath := RandomTmpDirPath("test", testEnv.DaemonInfo.OSType)
 	config = map[string]interface{}{
 		"Binds": []string{bindPath + ":" + path},
 	}
@@ -81,8 +81,8 @@ func (s *DockerAPISuite) TestDeprecatedContainerAPIStartDupVolumeBinds(c *testin
 	assert.NilError(c, err)
 	assert.Equal(c, res.StatusCode, http.StatusCreated)
 
-	bindPath1 := RandomTmpDirPath("test1", testEnv.OSType)
-	bindPath2 := RandomTmpDirPath("test2", testEnv.OSType)
+	bindPath1 := RandomTmpDirPath("test1", testEnv.DaemonInfo.OSType)
+	bindPath2 := RandomTmpDirPath("test2", testEnv.DaemonInfo.OSType)
 
 	config = map[string]interface{}{
 		"Binds": []string{bindPath1 + ":/tmp", bindPath2 + ":/tmp"},

--- a/integration-cli/fixtures_linux_daemon_test.go
+++ b/integration-cli/fixtures_linux_daemon_test.go
@@ -23,7 +23,7 @@ func ensureSyscallTest(c *testing.T) {
 
 	// if no match, must build in docker, which is significantly slower
 	// (slower mostly because of the vfs graphdriver)
-	if testEnv.OSType != runtime.GOOS {
+	if testEnv.DaemonInfo.OSType != runtime.GOOS {
 		ensureSyscallTestBuild(c)
 		return
 	}
@@ -86,7 +86,7 @@ func ensureNNPTest(c *testing.T) {
 
 	// if no match, must build in docker, which is significantly slower
 	// (slower mostly because of the vfs graphdriver)
-	if testEnv.OSType != runtime.GOOS {
+	if testEnv.DaemonInfo.OSType != runtime.GOOS {
 		ensureNNPTestBuild(c)
 		return
 	}

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -24,11 +24,11 @@ func ArchitectureIsNot(arch string) bool {
 }
 
 func DaemonIsWindows() bool {
-	return testEnv.OSType == "windows"
+	return testEnv.DaemonInfo.OSType == "windows"
 }
 
 func DaemonIsLinux() bool {
-	return testEnv.OSType == "linux"
+	return testEnv.DaemonInfo.OSType == "linux"
 }
 
 func MinimumAPIVersion(version string) func() bool {
@@ -153,7 +153,7 @@ func UserNamespaceInKernel() bool {
 }
 
 func IsPausable() bool {
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		return testEnv.DaemonInfo.Isolation.IsHyperV()
 	}
 	return true

--- a/integration-cli/test_vars_test.go
+++ b/integration-cli/test_vars_test.go
@@ -4,7 +4,7 @@ package main
 // the command is for a sleeping container based on the daemon platform.
 // The Windows busybox image does not have a `top` command.
 func sleepCommandForDaemonPlatform() []string {
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		return []string{"sleep", "240"}
 	}
 	return []string{"top"}

--- a/integration-cli/utils_test.go
+++ b/integration-cli/utils_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getPrefixAndSlashFromDaemonPlatform() (prefix, slash string) {
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		return "c:", `\`
 	}
 	return "", "/"

--- a/integration/container/cdi_test.go
+++ b/integration/container/cdi_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestCreateWithCDIDevices(t *testing.T) {
-	skip.If(t, testEnv.OSType != "linux", "CDI devices are only supported on Linux")
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux", "CDI devices are only supported on Linux")
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run cdi tests with a remote daemon")
 
 	cwd, err := os.Getwd()

--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -42,7 +42,7 @@ func TestCopyFromContainerPathIsNotDir(t *testing.T) {
 
 	path := "/etc/passwd/"
 	expected := "not a directory"
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		path = "c:/windows/system32/drivers/etc/hosts/"
 		expected = "The filename, directory name, or volume label syntax is incorrect."
 	}
@@ -127,7 +127,7 @@ func TestCopyToContainerPathIsNotDir(t *testing.T) {
 	cid := container.Create(ctx, t, apiclient)
 
 	path := "/etc/passwd/"
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		path = "c:/windows/system32/drivers/etc/hosts/"
 	}
 	err := apiclient.CopyToContainer(ctx, cid, path, nil, types.CopyToContainerOptions{})

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -514,7 +514,7 @@ func TestCreatePlatformSpecificImageNoPlatform(t *testing.T) {
 	defer setupTest(t)()
 
 	skip.If(t, testEnv.DaemonInfo.Architecture == "arm", "test only makes sense to run on non-arm systems")
-	skip.If(t, testEnv.OSType != "linux", "test image is only available on linux")
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux", "test image is only available on linux")
 	cli := testEnv.APIClient()
 
 	_, err := cli.ContainerCreate(

--- a/integration/container/diff_test.go
+++ b/integration/container/diff_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestDiff(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows", "FIXME")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	client := testEnv.APIClient()
 	ctx := context.Background()
@@ -28,7 +28,7 @@ func TestDiff(t *testing.T) {
 		{Kind: containertypes.ChangeAdd, Path: "/foo"},
 		{Kind: containertypes.ChangeAdd, Path: "/foo/bar"},
 	}
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(60*time.Second))
 		expected = []containertypes.FilesystemChange{
 			{Kind: containertypes.ChangeModify, Path: "Files/foo"},

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -119,7 +119,7 @@ func TestExec(t *testing.T) {
 	out := string(r)
 	assert.NilError(t, err)
 	expected := "PWD=/tmp"
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		expected = "PWD=C:/tmp"
 	}
 	assert.Assert(t, is.Contains(out, expected), "exec command not running in expected /tmp working directory")
@@ -128,7 +128,7 @@ func TestExec(t *testing.T) {
 
 func TestExecUser(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.39"), "broken in earlier versions")
-	skip.If(t, testEnv.OSType == "windows", "FIXME. Probably needs to wait for container to be in running state.")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME. Probably needs to wait for container to be in running state.")
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := testEnv.APIClient()

--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -18,7 +18,7 @@ import (
 // TestHealthCheckWorkdir verifies that health-checks inherit the containers'
 // working-dir.
 func TestHealthCheckWorkdir(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows", "FIXME")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := testEnv.APIClient()
@@ -37,7 +37,7 @@ func TestHealthCheckWorkdir(t *testing.T) {
 // GitHub #37263
 // Do not stop healthchecks just because we sent a signal to the container
 func TestHealthKillContainer(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows", "Windows only supports SIGKILL and SIGTERM? See https://github.com/moby/moby/issues/39574")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "Windows only supports SIGKILL and SIGTERM? See https://github.com/moby/moby/issues/39574")
 	defer setupTest(t)()
 
 	ctx := context.Background()

--- a/integration/container/kill_test.go
+++ b/integration/container/kill_test.go
@@ -70,7 +70,7 @@ func TestKillContainer(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
-			skip.If(t, testEnv.OSType == tc.skipOs, "Windows does not support SIGWINCH")
+			skip.If(t, testEnv.DaemonInfo.OSType == tc.skipOs, "Windows does not support SIGWINCH")
 			ctx := context.Background()
 			id := container.Run(ctx, t, client)
 			err := client.ContainerKill(ctx, id, tc.signal)
@@ -82,7 +82,7 @@ func TestKillContainer(t *testing.T) {
 }
 
 func TestKillWithStopSignalAndRestartPolicies(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows", "Windows only supports 1.25 or later")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "Windows only supports 1.25 or later")
 	defer setupTest(t)()
 	client := testEnv.APIClient()
 
@@ -121,7 +121,7 @@ func TestKillWithStopSignalAndRestartPolicies(t *testing.T) {
 }
 
 func TestKillStoppedContainer(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows", "Windows only supports 1.25 or later")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "Windows only supports 1.25 or later")
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := testEnv.APIClient()
@@ -132,7 +132,7 @@ func TestKillStoppedContainer(t *testing.T) {
 }
 
 func TestKillStoppedContainerAPIPre120(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows", "Windows only supports 1.25 or later")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "Windows only supports 1.25 or later")
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := request.NewAPIClient(t, client.WithVersion("1.19"))
@@ -143,7 +143,7 @@ func TestKillStoppedContainerAPIPre120(t *testing.T) {
 
 func TestKillDifferentUserContainer(t *testing.T) {
 	// TODO Windows: Windows does not yet support -u (Feb 2016).
-	skip.If(t, testEnv.OSType == "windows", "User containers (container.Config.User) are not yet supported on %q platform", testEnv.OSType)
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "User containers (container.Config.User) are not yet supported on %q platform", testEnv.DaemonInfo.OSType)
 
 	defer setupTest(t)()
 	ctx := context.Background()

--- a/integration/container/logs_test.go
+++ b/integration/container/logs_test.go
@@ -125,7 +125,7 @@ func testLogs(t *testing.T, logDriver string) {
 	}
 
 	pollTimeout := time.Second * 10
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		pollTimeout = StopContainerWindowsPollTimeout
 	}
 
@@ -160,7 +160,7 @@ func testLogs(t *testing.T, logDriver string) {
 
 			stdoutStr := stdout.String()
 
-			if tty && testEnv.OSType == "windows" {
+			if tty && testEnv.DaemonInfo.OSType == "windows" {
 				stdoutStr = stripEscapeCodes(t, stdoutStr)
 
 				// Special case for Windows Server 2019

--- a/integration/container/nat_test.go
+++ b/integration/container/nat_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestNetworkNat(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows", "FIXME")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	skip.If(t, testEnv.IsRemoteDaemon)
 
 	defer setupTest(t)()
@@ -57,7 +57,7 @@ func TestNetworkLocalhostTCPNat(t *testing.T) {
 
 func TestNetworkLoopbackNat(t *testing.T) {
 	skip.If(t, testEnv.GitHubActions, "FIXME: https://github.com/moby/moby/issues/41561")
-	skip.If(t, testEnv.OSType == "windows", "FIXME")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	skip.If(t, testEnv.IsRemoteDaemon)
 
 	defer setupTest(t)()

--- a/integration/container/remove_test.go
+++ b/integration/container/remove_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func getPrefixAndSlashFromDaemonPlatform() (prefix, slash string) {
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		return "c:", `\`
 	}
 	return "", "/"

--- a/integration/container/rename_test.go
+++ b/integration/container/rename_test.go
@@ -23,7 +23,7 @@ import (
 // This checks that "rename" updates source container correctly and doesn't set it to null.
 func TestRenameLinkedContainer(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.32"), "broken in earlier versions")
-	skip.If(t, testEnv.OSType == "windows", "FIXME")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := testEnv.APIClient()
@@ -151,7 +151,7 @@ func TestRenameAnonymousContainer(t *testing.T) {
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	count := "-c"
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		count = "-n"
 	}
 	cID = container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
@@ -190,7 +190,7 @@ func TestRenameContainerWithSameName(t *testing.T) {
 // container could still reference to the container that is renamed.
 func TestRenameContainerWithLinkedContainer(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon)
-	skip.If(t, testEnv.OSType == "windows", "FIXME")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 
 	defer setupTest(t)()
 	ctx := context.Background()

--- a/integration/container/stop_windows_test.go
+++ b/integration/container/stop_windows_test.go
@@ -17,7 +17,7 @@ import (
 // a timeout works as documented, i.e. in case of negative timeout
 // waiting is not limited (issue #35311).
 func TestStopContainerWithTimeout(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	defer setupTest(t)()
 	client := testEnv.APIClient()
 	ctx := context.Background()

--- a/integration/container/update_test.go
+++ b/integration/container/update_test.go
@@ -33,7 +33,7 @@ func TestUpdateRestartPolicy(t *testing.T) {
 	assert.NilError(t, err)
 
 	timeout := 60 * time.Second
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		timeout = 180 * time.Second
 	}
 

--- a/integration/image/import_test.go
+++ b/integration/image/import_test.go
@@ -22,7 +22,7 @@ import (
 func TestImportExtremelyLargeImageWorks(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
 	skip.If(t, runtime.GOARCH == "arm64", "effective test will be time out")
-	skip.If(t, testEnv.OSType == "windows", "TODO enable on windows")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "TODO enable on windows")
 	t.Parallel()
 
 	// Spin up a new daemon, so that we can run this test in parallel (it's a slow test)
@@ -51,7 +51,7 @@ func TestImportExtremelyLargeImageWorks(t *testing.T) {
 }
 
 func TestImportWithCustomPlatform(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows", "TODO enable on windows")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "TODO enable on windows")
 
 	defer setupTest(t)()
 	client := testEnv.APIClient()

--- a/integration/image/inspect_test.go
+++ b/integration/image/inspect_test.go
@@ -13,7 +13,7 @@ import (
 
 // Regression test for: https://github.com/moby/moby/issues/45556
 func TestImageInspectEmptyTagsAndDigests(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows", "build-empty-images is not called on Windows")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "build-empty-images is not called on Windows")
 	defer setupTest(t)()
 
 	client := testEnv.APIClient()

--- a/integration/image/pull_test.go
+++ b/integration/image/pull_test.go
@@ -115,7 +115,7 @@ func createTestImage(ctx context.Context, t testing.TB, store content.Store) oci
 // verifies with the remote that the digest exists in that repo.
 func TestImagePullStoredfDigestForOtherRepo(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
-	skip.If(t, testEnv.OSType == "windows", "We don't run a test registry on Windows")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "We don't run a test registry on Windows")
 	skip.If(t, testEnv.IsRootless, "Rootless has a different view of localhost (needed for test registry access)")
 	defer setupTest(t)()
 

--- a/integration/image/save_test.go
+++ b/integration/image/save_test.go
@@ -161,7 +161,7 @@ func TestSaveRepoWithMultipleImages(t *testing.T) {
 }
 
 func TestSaveDirectoryPermissions(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows", "Test is looking at linux specific details")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "Test is looking at linux specific details")
 
 	defer setupTest(t)()
 

--- a/integration/network/delete_test.go
+++ b/integration/network/delete_test.go
@@ -65,7 +65,7 @@ func TestNetworkCreateDelete(t *testing.T) {
 // ID is removed, and not the network with the given name.
 func TestDockerNetworkDeletePreferID(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.34"), "broken in earlier versions")
-	skip.If(t, testEnv.OSType == "windows",
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows",
 		"FIXME. Windows doesn't run DinD and uses networks shared between control daemon and daemon under test")
 	defer setupTest(t)()
 	client := testEnv.APIClient()

--- a/integration/network/inspect_test.go
+++ b/integration/network/inspect_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestInspectNetwork(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows", "FIXME")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	skip.If(t, testEnv.IsRootless, "rootless mode doesn't support Swarm-mode")
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)

--- a/integration/network/network_test.go
+++ b/integration/network/network_test.go
@@ -153,7 +153,7 @@ func TestNetworkList(t *testing.T) {
 }
 
 func TestHostIPv4BridgeLabel(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, testEnv.IsRemoteDaemon)
 	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
 	d := daemon.New(t)
@@ -179,7 +179,7 @@ func TestHostIPv4BridgeLabel(t *testing.T) {
 }
 
 func TestDefaultNetworkOpts(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, testEnv.IsRemoteDaemon)
 	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
 

--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -27,7 +27,7 @@ func delInterface(t *testing.T, ifName string) {
 }
 
 func TestDaemonRestartWithLiveRestore(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, testEnv.IsRemoteDaemon)
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.38"), "skip test from new feature")
 	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
@@ -56,7 +56,7 @@ func TestDaemonRestartWithLiveRestore(t *testing.T) {
 }
 
 func TestDaemonDefaultNetworkPools(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	// Remove docker0 bridge and the start daemon defining the predefined address pools
 	skip.If(t, testEnv.IsRemoteDaemon)
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.38"), "skip test from new feature")
@@ -99,7 +99,7 @@ func TestDaemonDefaultNetworkPools(t *testing.T) {
 }
 
 func TestDaemonRestartWithExistingNetwork(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, testEnv.IsRemoteDaemon)
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.38"), "skip test from new feature")
 	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
@@ -133,7 +133,7 @@ func TestDaemonRestartWithExistingNetwork(t *testing.T) {
 }
 
 func TestDaemonRestartWithExistingNetworkWithDefaultPoolRange(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, testEnv.IsRemoteDaemon)
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.38"), "skip test from new feature")
 	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
@@ -184,7 +184,7 @@ func TestDaemonRestartWithExistingNetworkWithDefaultPoolRange(t *testing.T) {
 }
 
 func TestDaemonWithBipAndDefaultNetworkPool(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, testEnv.IsRemoteDaemon)
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.38"), "skip test from new feature")
 	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
@@ -209,7 +209,7 @@ func TestDaemonWithBipAndDefaultNetworkPool(t *testing.T) {
 }
 
 func TestServiceWithPredefinedNetwork(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, testEnv.IsRootless, "rootless mode doesn't support Swarm-mode")
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)
@@ -242,7 +242,7 @@ func TestServiceRemoveKeepsIngressNetwork(t *testing.T) {
 	t.Skip("FLAKY_TEST")
 	skip.If(t, testEnv.IsRootless, "rootless mode doesn't support Swarm-mode")
 
-	skip.If(t, testEnv.OSType == "windows")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)
 	defer d.Stop(t)
@@ -330,7 +330,7 @@ func noServices(ctx context.Context, client client.ServiceAPIClient) func(log po
 }
 
 func TestServiceWithDataPathPortInit(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"), "DataPathPort was added in API v1.40")
 	skip.If(t, testEnv.IsRootless, "rootless mode doesn't support Swarm-mode")
 	defer setupTest(t)()
@@ -398,7 +398,7 @@ func TestServiceWithDataPathPortInit(t *testing.T) {
 }
 
 func TestServiceWithDefaultAddressPoolInit(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, testEnv.IsRootless, "rootless mode doesn't support Swarm-mode")
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv,

--- a/integration/plugin/common/plugin_test.go
+++ b/integration/plugin/common/plugin_test.go
@@ -90,7 +90,7 @@ func TestPluginInvalidJSON(t *testing.T) {
 
 func TestPluginInstall(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
-	skip.If(t, testEnv.OSType == "windows")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, testEnv.IsRootless, "rootless mode has different view of localhost")
 
 	ctx := context.Background()
@@ -199,7 +199,7 @@ func TestPluginInstall(t *testing.T) {
 func TestPluginsWithRuntimes(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
 	skip.If(t, testEnv.IsRootless, "Test not supported on rootless due to buggy daemon setup in rootless mode due to daemon restart")
-	skip.If(t, testEnv.OSType == "windows")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 
 	dir, err := os.MkdirTemp("", t.Name())
 	assert.NilError(t, err)
@@ -261,7 +261,7 @@ func TestPluginsWithRuntimes(t *testing.T) {
 
 func TestPluginBackCompatMediaTypes(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
-	skip.If(t, testEnv.OSType == "windows")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, testEnv.IsRootless, "Rootless has a different view of localhost (needed for test registry access)")
 
 	defer setupTest(t)()

--- a/integration/session/session_test.go
+++ b/integration/session/session_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestSessionCreate(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows", "FIXME")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.39"), "experimental in older versions")
 
 	defer setupTest(t)()
@@ -33,7 +33,7 @@ func TestSessionCreate(t *testing.T) {
 }
 
 func TestSessionCreateWithBadUpgrade(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows", "FIXME")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.39"), "experimental in older versions")
 
 	defer setupTest(t)()

--- a/integration/system/disk_usage_test.go
+++ b/integration/system/disk_usage_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestDiskUsage(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows") // d.Start fails on Windows with `protocol not available`
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows") // d.Start fails on Windows with `protocol not available`
 
 	t.Parallel()
 

--- a/integration/system/event_test.go
+++ b/integration/system/event_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestEventsExecDie(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.36"), "broken in earlier versions")
-	skip.If(t, testEnv.OSType == "windows", "FIXME. Suspect may need to wait until container is running before exec")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME. Suspect may need to wait until container is running before exec")
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := testEnv.APIClient()
@@ -77,7 +77,7 @@ func TestEventsExecDie(t *testing.T) {
 // backward compatibility so old `JSONMessage` could still be used.
 // This test verifies that backward compatibility maintains.
 func TestEventsBackwardsCompatible(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows", "Windows doesn't support back-compat messages")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "Windows doesn't support back-compat messages")
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := testEnv.APIClient()
@@ -128,7 +128,7 @@ func TestEventsBackwardsCompatible(t *testing.T) {
 // TestEventsVolumeCreate verifies that volume create events are only fired
 // once: when creating the volume, and not when attaching to a container.
 func TestEventsVolumeCreate(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows", "FIXME: Windows doesn't trigger the events? Could be a race")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME: Windows doesn't trigger the events? Could be a race")
 
 	defer setupTest(t)()
 	ctx, cancel := context.WithCancel(context.Background())

--- a/integration/system/version_test.go
+++ b/integration/system/version_test.go
@@ -19,5 +19,5 @@ func TestVersion(t *testing.T) {
 	assert.Check(t, version.Version != "")
 	assert.Check(t, version.MinAPIVersion != "")
 	assert.Check(t, is.Equal(testEnv.DaemonInfo.ExperimentalBuild, version.Experimental))
-	assert.Check(t, is.Equal(testEnv.OSType, version.Os))
+	assert.Check(t, is.Equal(testEnv.DaemonInfo.OSType, version.Os))
 }

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -32,7 +32,7 @@ func TestVolumesCreateAndList(t *testing.T) {
 
 	name := t.Name()
 	// Windows file system is case insensitive
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		name = strings.ToLower(name)
 	}
 	vol, err := client.VolumeCreate(ctx, volume.CreateOptions{
@@ -112,7 +112,7 @@ func TestVolumesRemove(t *testing.T) {
 // Regression test for https://github.com/docker/cli/issues/4082
 func TestVolumesRemoveSwarmEnabled(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
-	skip.If(t, testEnv.OSType == "windows", "TODO enable on windows")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "TODO enable on windows")
 	t.Parallel()
 	defer setupTest(t)()
 
@@ -249,7 +249,7 @@ func TestVolumesInvalidJSON(t *testing.T) {
 }
 
 func getPrefixAndSlashFromDaemonPlatform() (prefix, slash string) {
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		return "c:", `\`
 	}
 	return "", "/"
@@ -311,7 +311,7 @@ func TestVolumePruneAnonFromImage(t *testing.T) {
 	client := testEnv.APIClient()
 
 	volDest := "/foo"
-	if testEnv.OSType == "windows" {
+	if testEnv.DaemonInfo.OSType == "windows" {
 		volDest = `c:\\foo`
 	}
 

--- a/testutil/environment/clean.go
+++ b/testutil/environment/clean.go
@@ -21,7 +21,7 @@ func (e *Execution) Clean(t testing.TB) {
 	t.Helper()
 	apiClient := e.APIClient()
 
-	platform := e.OSType
+	platform := e.DaemonInfo.OSType
 	if (platform != "windows") || (platform == "windows" && e.DaemonInfo.Isolation == "hyperv") {
 		unpauseAllContainers(t, apiClient)
 	}

--- a/testutil/environment/clean.go
+++ b/testutil/environment/clean.go
@@ -19,18 +19,18 @@ import (
 // depend on each others.
 func (e *Execution) Clean(t testing.TB) {
 	t.Helper()
-	client := e.APIClient()
+	apiClient := e.APIClient()
 
 	platform := e.OSType
 	if (platform != "windows") || (platform == "windows" && e.DaemonInfo.Isolation == "hyperv") {
-		unpauseAllContainers(t, client)
+		unpauseAllContainers(t, apiClient)
 	}
-	deleteAllContainers(t, client, e.protectedElements.containers)
-	deleteAllImages(t, client, e.protectedElements.images)
-	deleteAllVolumes(t, client, e.protectedElements.volumes)
-	deleteAllNetworks(t, client, platform, e.protectedElements.networks)
+	deleteAllContainers(t, apiClient, e.protectedElements.containers)
+	deleteAllImages(t, apiClient, e.protectedElements.images)
+	deleteAllVolumes(t, apiClient, e.protectedElements.volumes)
+	deleteAllNetworks(t, apiClient, platform, e.protectedElements.networks)
 	if platform == "linux" {
-		deleteAllPlugins(t, client, e.protectedElements.plugins)
+		deleteAllPlugins(t, apiClient, e.protectedElements.plugins)
 	}
 }
 

--- a/testutil/environment/environment.go
+++ b/testutil/environment/environment.go
@@ -50,31 +50,20 @@ func FromClient(c *client.Client) (*Execution, error) {
 		return nil, errors.Wrapf(err, "failed to get info from daemon")
 	}
 
-	osType := getOSType(info)
-
 	return &Execution{
 		client:            c,
 		DaemonInfo:        info,
-		OSType:            osType,
-		PlatformDefaults:  getPlatformDefaults(info, osType),
+		OSType:            info.OSType,
+		PlatformDefaults:  getPlatformDefaults(info),
 		protectedElements: newProtectedElements(),
 	}, nil
 }
 
-func getOSType(info types.Info) string {
-	// Docker EE does not set the OSType so allow the user to override this value.
-	userOsType := os.Getenv("TEST_OSTYPE")
-	if userOsType != "" {
-		return userOsType
-	}
-	return info.OSType
-}
-
-func getPlatformDefaults(info types.Info, osType string) PlatformDefaults {
+func getPlatformDefaults(info types.Info) PlatformDefaults {
 	volumesPath := filepath.Join(info.DockerRootDir, "volumes")
 	containersPath := filepath.Join(info.DockerRootDir, "containers")
 
-	switch osType {
+	switch info.OSType {
 	case "linux":
 		return PlatformDefaults{
 			BaseImage:            "scratch",
@@ -96,12 +85,12 @@ func getPlatformDefaults(info types.Info, osType string) PlatformDefaults {
 			ContainerStoragePath: filepath.FromSlash(containersPath),
 		}
 	default:
-		panic(fmt.Sprintf("unknown OSType for daemon: %s", osType))
+		panic(fmt.Sprintf("unknown OSType for daemon: %s", info.OSType))
 	}
 }
 
 // Make sure in context of daemon, not the local platform. Note we can't
-// use filepath.FromSlash or ToSlash here as they are a no-op on Unix.
+// use filepath.ToSlash here as that is a no-op on Unix.
 func toSlash(path string) string {
 	return strings.ReplaceAll(path, `\`, `/`)
 }

--- a/testutil/environment/environment.go
+++ b/testutil/environment/environment.go
@@ -21,7 +21,6 @@ import (
 type Execution struct {
 	client            client.APIClient
 	DaemonInfo        types.Info
-	OSType            string
 	PlatformDefaults  PlatformDefaults
 	protectedElements protectedElements
 }
@@ -53,7 +52,6 @@ func FromClient(c *client.Client) (*Execution, error) {
 	return &Execution{
 		client:            c,
 		DaemonInfo:        info,
-		OSType:            info.OSType,
 		PlatformDefaults:  getPlatformDefaults(info),
 		protectedElements: newProtectedElements(),
 	}, nil
@@ -208,7 +206,7 @@ func (e *Execution) HasExistingImage(t testing.TB, reference string) bool {
 // EnsureFrozenImagesLinux loads frozen test images into the daemon
 // if they aren't already loaded
 func EnsureFrozenImagesLinux(testEnv *Execution) error {
-	if testEnv.OSType == "linux" {
+	if testEnv.DaemonInfo.OSType == "linux" {
 		err := load.FrozenImagesLinux(testEnv.APIClient(), frozenImages...)
 		if err != nil {
 			return errors.Wrap(err, "error loading frozen images")

--- a/testutil/environment/protect.go
+++ b/testutil/environment/protect.go
@@ -40,7 +40,7 @@ func ProtectAll(t testing.TB, testEnv *Execution) {
 	ProtectImages(t, testEnv)
 	ProtectNetworks(t, testEnv)
 	ProtectVolumes(t, testEnv)
-	if testEnv.OSType == "linux" {
+	if testEnv.DaemonInfo.OSType == "linux" {
 		ProtectPlugins(t, testEnv)
 	}
 }
@@ -91,7 +91,7 @@ func ProtectImages(t testing.TB, testEnv *Execution) {
 	t.Helper()
 	images := getExistingImages(t, testEnv)
 
-	if testEnv.OSType == "linux" {
+	if testEnv.DaemonInfo.OSType == "linux" {
 		images = append(images, frozenImages...)
 	}
 	testEnv.ProtectImage(t, images...)

--- a/testutil/fakestorage/fixtures.go
+++ b/testutil/fakestorage/fixtures.go
@@ -35,7 +35,7 @@ func ensureHTTPServerImage(t testing.TB) {
 	}
 	defer os.RemoveAll(tmp)
 
-	goos := testEnv.OSType
+	goos := testEnv.DaemonInfo.OSType
 	if goos == "" {
 		goos = "linux"
 	}


### PR DESCRIPTION
- relates to / reverts https://github.com/moby/moby/pull/34907

### testutil/environment: rename var that collided with import

### testutil/environment: remove unused TEST_OSTYPE env-var

This env-var was added in f0e5b3d7d89c0c87d001faa18bc60fd1b4531901 (https://github.com/moby/moby/pull/34907) to account for older versions of the engine (Docker EE LTS versions), which did not yet provide the OSType field in Docker info.

### testutil/environment: remove Execution.OSType field

This field was added in f0e5b3d7d89c0c87d001faa18bc60fd1b4531901 to account for older versions of the engine (Docker EE LTS versions), which did not yet provide the OSType field in Docker info, and had to be manually set using the TEST_OSTYPE env-var.

This patch removes the field in favor of the equivalent in DaemonInfo. It's more verbose, but also less ambiguous what information we're using (i.e., the platform the daemon is running on, not the local platform).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

