### PR TITLE
[24.0 backport] fix docker cp -a failing to access / in container (run `getent` with a noop stdin)

### DIFF
--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -65,6 +65,34 @@ func TestCopyToContainerPathDoesNotExist(t *testing.T) {
 func TestCopyEmptyFile(t *testing.T) {
 	defer setupTest(t)()
 
+	ctx := context.Background()
+	apiclient := testEnv.APIClient()
+	cid := container.Create(ctx, t, apiclient)
+
+	// empty content
+	dstDir, _ := makeEmptyArchive(t)
+	err := apiclient.CopyToContainer(ctx, cid, dstDir, bytes.NewReader([]byte("")), types.CopyToContainerOptions{})
+	assert.NilError(t, err)
+
+	// tar with empty file
+	dstDir, preparedArchive := makeEmptyArchive(t)
+	err = apiclient.CopyToContainer(ctx, cid, dstDir, preparedArchive, types.CopyToContainerOptions{})
+	assert.NilError(t, err)
+
+	// tar with empty file archive mode
+	dstDir, preparedArchive = makeEmptyArchive(t)
+	err = apiclient.CopyToContainer(ctx, cid, dstDir, preparedArchive, types.CopyToContainerOptions{
+		CopyUIDGID: true,
+	})
+	assert.NilError(t, err)
+
+	// copy from empty file
+	rdr, _, err := apiclient.CopyFromContainer(ctx, cid, dstDir)
+	assert.NilError(t, err)
+	defer rdr.Close()
+}
+
+func makeEmptyArchive(t *testing.T) (string, io.ReadCloser) {
 	tmpDir := t.TempDir()
 	srcPath := filepath.Join(tmpDir, "empty-file.txt")
 	err := os.WriteFile(srcPath, []byte(""), 0400)
@@ -77,30 +105,18 @@ func TestCopyEmptyFile(t *testing.T) {
 
 	srcArchive, err := archive.TarResource(srcInfo)
 	assert.NilError(t, err)
-	defer srcArchive.Close()
+	t.Cleanup(func() {
+		srcArchive.Close()
+	})
 
 	ctrPath := "/empty-file.txt"
 	dstInfo := archive.CopyInfo{Path: ctrPath}
 	dstDir, preparedArchive, err := archive.PrepareArchiveCopy(srcArchive, srcInfo, dstInfo)
 	assert.NilError(t, err)
-	defer preparedArchive.Close()
-
-	ctx := context.Background()
-	apiclient := testEnv.APIClient()
-	cid := container.Create(ctx, t, apiclient)
-
-	// empty content
-	err = apiclient.CopyToContainer(ctx, cid, dstDir, bytes.NewReader([]byte("")), types.CopyToContainerOptions{})
-	assert.NilError(t, err)
-
-	// tar with empty file
-	err = apiclient.CopyToContainer(ctx, cid, dstDir, preparedArchive, types.CopyToContainerOptions{})
-	assert.NilError(t, err)
-
-	// copy from empty file
-	rdr, _, err := apiclient.CopyFromContainer(ctx, cid, dstDir)
-	assert.NilError(t, err)
-	defer rdr.Close()
+	t.Cleanup(func() {
+		preparedArchive.Close()
+	})
+	return dstDir, preparedArchive
 }
 
 func TestCopyToContainerPathIsNotDir(t *testing.T) {

--- a/pkg/idtools/idtools_unix.go
+++ b/pkg/idtools/idtools_unix.go
@@ -167,7 +167,10 @@ func callGetent(database, key string) (io.Reader, error) {
 	if getentCmd == "" {
 		return nil, fmt.Errorf("unable to find getent command")
 	}
-	out, err := exec.Command(getentCmd, database, key).CombinedOutput()
+	command := exec.Command(getentCmd, database, key)
+	// we run getent within container filesystem, but without /dev so /dev/null is not available for exec to mock stdin
+	command.Stdin = io.NopCloser(bytes.NewReader(nil))
+	out, err := command.CombinedOutput()
 	if err != nil {
 		exitCode, errC := getExitCode(err)
 		if errC != nil {


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/45720
- fixes https://github.com/moby/moby/issues/45719

(cherry picked from commit 3cc5d62f8a653d235bd96a450fa58fee68808c0d)

---
**- What I did**
configure command to run `getent` to use a noop readCloser as stdin to prevent ENOENT failure to open `/dev/null`

**- How I did it**

**- How to verify it**
test case included

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/moby/moby/assets/132757/19e58e57-3606-4a67-895e-cd450aa97ed2)

