### PR TITLE
Swagger API docs for Commit container object field 'id' should be pascalcase not uppercase

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5573,7 +5573,7 @@ definitions:
       or `runC`.
     type: "object"
     properties:
-      ID:
+      Id:
         description: "Actual commit ID of external tool."
         type: "string"
         example: "cfb82a876ecc11b5ca0977d1733adbe58599088a"

--- a/docs/api/v1.43.yaml
+++ b/docs/api/v1.43.yaml
@@ -5574,7 +5574,7 @@ definitions:
       or `runC`.
     type: "object"
     properties:
-      ID:
+      Id:
         description: "Actual commit ID of external tool."
         type: "string"
         example: "cfb82a876ecc11b5ca0977d1733adbe58599088a"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Renamed the field Commit `id` in the 1.43 swagger docs and the api doc to pascalcase.

**- How I did it**
Modified the 1.43 swagger doc and the future 1.44 YAML specification.

**- How to verify it**
Generated types for the [Bollard](https://github.com/fussybeaver/bollard) docker client and ran integration tests on the new types.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Modified the Commit `id` field in the swagger docs to align with docker output. Fixes #45761 

**- A picture of a cute animal (not mandatory but encouraged)**

