### PR TITLE
Dockerfile: make cli stages more resilient against unclean termination

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -255,9 +255,11 @@ COPY hack/dockerfile/cli.sh /download-or-build-cli.sh
 ARG DOCKERCLI_REPOSITORY
 ARG DOCKERCLI_VERSION
 ARG TARGETPLATFORM
-RUN --mount=type=cache,id=dockercli-git-$TARGETPLATFORM,target=./.git \
+RUN --mount=type=cache,id=dockercli-git-$TARGETPLATFORM,sharing=locked,target=./.git \
     --mount=type=cache,target=/root/.cache/go-build,id=dockercli-build-$TARGETPLATFORM \
-    /download-or-build-cli.sh ${DOCKERCLI_VERSION} ${DOCKERCLI_REPOSITORY} /build
+        rm -f ./.git/*.lock \
+     && /download-or-build-cli.sh ${DOCKERCLI_VERSION} ${DOCKERCLI_REPOSITORY} /build \
+     && /build/docker --version
 
 FROM base AS dockercli-integration
 WORKDIR /go/src/github.com/docker/cli
@@ -265,9 +267,11 @@ COPY hack/dockerfile/cli.sh /download-or-build-cli.sh
 ARG DOCKERCLI_INTEGRATION_REPOSITORY
 ARG DOCKERCLI_INTEGRATION_VERSION
 ARG TARGETPLATFORM
-RUN --mount=type=cache,id=dockercli-integration-git-$TARGETPLATFORM,target=./.git \
+RUN --mount=type=cache,id=dockercli-integration-git-$TARGETPLATFORM,sharing=locked,target=./.git \
     --mount=type=cache,target=/root/.cache/go-build,id=dockercli-integration-build-$TARGETPLATFORM \
-    /download-or-build-cli.sh ${DOCKERCLI_INTEGRATION_VERSION} ${DOCKERCLI_INTEGRATION_REPOSITORY} /build
+        rm -f ./.git/*.lock \
+     && /download-or-build-cli.sh ${DOCKERCLI_INTEGRATION_VERSION} ${DOCKERCLI_INTEGRATION_REPOSITORY} /build \
+     && /build/docker --version
 
 # runc
 FROM base AS runc-src


### PR DESCRIPTION
- relates to https://github.com/moby/buildkit/issues/3955

The Dockerfile in this repository performs many stages in parallel. If any of those stages fails to build (which could be due to networking congestion), other stages are also (forcibly?) terminated, which can cause an unclean shutdown.

In some case, this can cause `git` to be terminated, leaving a `.lock` file behind in the cache mount. Retrying the build now will fail, and the only workaround is to clean the build-cache (which causes many stages to be built again, potentially triggering the problem again).

     > [dockercli-integration 3/3] RUN --mount=type=cache,id=dockercli-integration-git-linux/arm64/v8,target=./.git     --mount=type=cache,target=/root/.cache/go-build,id=dockercli-integration-build-linux/arm64/v8     /download-or-build-cli.sh v17.06.2-ce https://github.com/docker/cli.git /build:
    #0 1.575 fatal: Unable to create '/go/src/github.com/docker/cli/.git/shallow.lock': File exists.
    #0 1.575
    #0 1.575 Another git process seems to be running in this repository, e.g.
    #0 1.575 an editor opened by 'git commit'. Please make sure all processes
    #0 1.575 are terminated then try again. If it still fails, a git process
    #0 1.575 may have crashed in this repository earlier:
    #0 1.575 remove the file manually to continue.

This patch:

- Updates the Dockerfile to remove `.lock` files (`shallow.lock`, `index.lock`) that may have been left behind from previous builds. I put this code in the Dockerfile itself (not the script), as the script may be used in other situations outside of the Dockerfile (for which we cannot guarantee no other git session is active).
- Adds a `docker --version` step to the stage; this is mostly to verify the build was successful (and to be consistent with other stages).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

