### PR TITLE
builder: pass host-gateway IP as worker label

### DIFF
--- a/builder/builder-next/worker/label/label.go
+++ b/builder/builder-next/worker/label/label.go
@@ -1,0 +1,9 @@
+package label
+
+// Pre-defined label keys similar to BuildKit ones
+// https://github.com/moby/buildkit/blob/v0.11.6/worker/label/label.go#L3-L16
+const (
+	prefix = "org.mobyproject.buildkit.worker.moby."
+
+	HostGatewayIP = prefix + "host-gateway-ip"
+)


### PR DESCRIPTION
related to https://github.com/docker/buildx/issues/1832

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

We missed a case when parsing extra hosts from the dockerfile frontend so the build fails.

**- How I did it**

To handle this case we need to set a dedicated worker label that contains the host gateway IP so clients like Buildx can just set the proper host:ip when parsing extra hosts that contain the special string "host-gateway". See https://github.com/docker/buildx/pull/1894

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

