### PR TITLE
[20.10 backport] testing: temporarily pin docker-py tests to use "bullseye"

### DIFF
--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -9,6 +9,12 @@ source hack/make/.integration-test-helpers
 #: exit status 128
 : "${DOCKER_PY_COMMIT:=4.4.1}"
 
+# The version (and variant) of the python image to use for the tests;
+# see https://github.com/docker/docker-py/blob/5.0.3/tests/Dockerfile#L1C5-L3
+#
+# TODO remove once https://github.com/docker/docker-py/pull/3145 is merged.
+: "${PYTHON_VERSION:=3.7-bullseye}"
+
 # custom options to pass py.test
 #
 # This option can be used to temporarily skip flaky tests (using the `--deselect`
@@ -48,7 +54,7 @@ source hack/make/.integration-test-helpers
 			[ -z "${TESTDEBUG}" ] && build_opts="--quiet"
 			[ -f /.dockerenv ] || build_opts="${build_opts} --network=host"
 			# shellcheck disable=SC2086
-			exec docker build ${build_opts} -t "${docker_py_image}" -f tests/Dockerfile "https://github.com/docker/docker-py.git#${DOCKER_PY_COMMIT}"
+			exec docker build ${build_opts} --build-arg PYTHON_VERSION="${PYTHON_VERSION}" -t "${docker_py_image}" -f tests/Dockerfile "https://github.com/docker/docker-py.git#${DOCKER_PY_COMMIT}"
 		)
 	fi
 


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/45769
- related https://github.com/docker/docker-py/pull/3145


The official Python images on Docker Hub switched to debian bookworm, which is now the current stable version of Debian.

However, the location of the apt repository config file changed, which causes the Dockerfile build to fail;

    Loaded image: emptyfs:latest
    Loaded image ID: sha256:0df1207206e5288f4a989a2f13d1f5b3c4e70467702c1d5d21dfc9f002b7bd43
    INFO: Building docker-sdk-python3:5.0.3...
    tests/Dockerfile:6
    --------------------
       5 |     ARG APT_MIRROR
       6 | >>> RUN sed -ri "s/(httpredir|deb).debian.org/${APT_MIRROR:-deb.debian.org}/g" /etc/apt/sources.list \
       7 | >>>     && sed -ri "s/(security).debian.org/${APT_MIRROR:-security.debian.org}/g" /etc/apt/sources.list
       8 |
    --------------------
    ERROR: failed to solve: process "/bin/sh -c sed -ri \"s/(httpredir|deb).debian.org/${APT_MIRROR:-deb.debian.org}/g\" /etc/apt/sources.list     && sed -ri \"s/(security).debian.org/${APT_MIRROR:-security.debian.org}/g\" /etc/apt/sources.list" did not complete successfully: exit code: 2

This needs to be fixed in docker-py, but in the meantime, we can pin to the bullseye variant.


(cherry picked from commit 19d860fa9dd25f09cca979830d3a4ccaeb680529)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

