### PR TITLE
[24.0 backport] c8d: Use reference counting while mounting a snapshot

### DIFF
--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/container"
 	daemonevents "github.com/docker/docker/daemon/events"
 	"github.com/docker/docker/daemon/images"
+	"github.com/docker/docker/daemon/snapshotter"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
@@ -35,6 +36,7 @@ type ImageService struct {
 	registryService RegistryConfigProvider
 	eventsService   *daemonevents.Events
 	pruneRunning    atomic.Bool
+	refCountMounter snapshotter.Mounter
 }
 
 type RegistryHostsProvider interface {
@@ -47,12 +49,13 @@ type RegistryConfigProvider interface {
 }
 
 type ImageServiceConfig struct {
-	Client        *containerd.Client
-	Containers    container.Store
-	Snapshotter   string
-	HostsProvider RegistryHostsProvider
-	Registry      RegistryConfigProvider
-	EventsService *daemonevents.Events
+	Client          *containerd.Client
+	Containers      container.Store
+	Snapshotter     string
+	HostsProvider   RegistryHostsProvider
+	Registry        RegistryConfigProvider
+	EventsService   *daemonevents.Events
+	RefCountMounter snapshotter.Mounter
 }
 
 // NewService creates a new ImageService.
@@ -64,6 +67,7 @@ func NewService(config ImageServiceConfig) *ImageService {
 		registryHosts:   config.HostsProvider,
 		registryService: config.Registry,
 		eventsService:   config.EventsService,
+		refCountMounter: config.RefCountMounter,
 	}
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -40,6 +40,7 @@ import (
 	"github.com/docker/docker/daemon/images"
 	dlogger "github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/network"
+	"github.com/docker/docker/daemon/snapshotter"
 	"github.com/docker/docker/daemon/stats"
 	"github.com/docker/docker/distribution"
 	dmetadata "github.com/docker/docker/distribution/metadata"
@@ -1023,12 +1024,13 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 			return nil, err
 		}
 		d.imageService = ctrd.NewService(ctrd.ImageServiceConfig{
-			Client:        d.containerdCli,
-			Containers:    d.containers,
-			Snapshotter:   driverName,
-			HostsProvider: d,
-			Registry:      d.registryService,
-			EventsService: d.EventsService,
+			Client:          d.containerdCli,
+			Containers:      d.containers,
+			Snapshotter:     driverName,
+			HostsProvider:   d,
+			Registry:        d.registryService,
+			EventsService:   d.EventsService,
+			RefCountMounter: snapshotter.NewMounter(config.Root, driverName, idMapping),
 		})
 	} else {
 		layerStore, err := layer.NewStoreFromOptions(layer.StoreOptions{

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1394,19 +1394,13 @@ func (daemon *Daemon) registerLinks(container *container.Container, hostConfig *
 // conditionalMountOnStart is a platform specific helper function during the
 // container start to call mount.
 func (daemon *Daemon) conditionalMountOnStart(container *container.Container) error {
-	if !daemon.UsesSnapshotter() {
-		return daemon.Mount(container)
-	}
-	return nil
+	return daemon.Mount(container)
 }
 
 // conditionalUnmountOnCleanup is a platform specific helper function called
 // during the cleanup of a container to unmount.
 func (daemon *Daemon) conditionalUnmountOnCleanup(container *container.Container) error {
-	if !daemon.UsesSnapshotter() {
-		return daemon.Unmount(container)
-	}
-	return nil
+	return daemon.Unmount(container)
 }
 
 // setDefaultIsolation determines the default isolation mode for the

--- a/daemon/snapshotter/mount.go
+++ b/daemon/snapshotter/mount.go
@@ -1,0 +1,141 @@
+package snapshotter
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/containerd/containerd/mount"
+	"github.com/docker/docker/daemon/graphdriver"
+	"github.com/docker/docker/pkg/idtools"
+	"github.com/moby/locker"
+	"github.com/sirupsen/logrus"
+)
+
+const mountsDir = "rootfs"
+
+// List of known filesystems that can't be re-mounted or have shared layers
+var refCountedFileSystems = []string{"overlayfs", "zfs", "fuse-overlayfs"}
+
+// Mounter handles mounting/unmounting things coming in from a snapshotter
+// with optional reference counting if needed by the filesystem
+type Mounter interface {
+	// Mount mounts the rootfs for a container and returns the mount point
+	Mount(mounts []mount.Mount, containerID string) (string, error)
+	// Unmount unmounts the container rootfs
+	Unmount(target string) error
+}
+
+// inSlice tests whether a string is contained in a slice of strings or not.
+// Comparison is case sensitive
+func inSlice(slice []string, s string) bool {
+	for _, ss := range slice {
+		if s == ss {
+			return true
+		}
+	}
+	return false
+}
+
+// NewMounter creates a new mounter for the provided snapshotter
+func NewMounter(home string, snapshotter string, idMap idtools.IdentityMapping) Mounter {
+	if inSlice(refCountedFileSystems, snapshotter) {
+		return &refCountMounter{
+			home:        home,
+			snapshotter: snapshotter,
+			rc:          graphdriver.NewRefCounter(checker()),
+			locker:      locker.New(),
+			idMap:       idMap,
+		}
+	}
+
+	return mounter{
+		home:        home,
+		snapshotter: snapshotter,
+		idMap:       idMap,
+	}
+}
+
+type refCountMounter struct {
+	home        string
+	snapshotter string
+	rc          *graphdriver.RefCounter
+	locker      *locker.Locker
+	idMap       idtools.IdentityMapping
+}
+
+func (m *refCountMounter) Mount(mounts []mount.Mount, containerID string) (target string, retErr error) {
+	target = filepath.Join(m.home, mountsDir, m.snapshotter, containerID)
+
+	_, err := os.Stat(target)
+	if err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+
+	if count := m.rc.Increment(target); count > 1 {
+		return target, nil
+	}
+
+	m.locker.Lock(target)
+	defer m.locker.Unlock(target)
+
+	defer func() {
+		if retErr != nil {
+			if c := m.rc.Decrement(target); c <= 0 {
+				if mntErr := unmount(target); mntErr != nil {
+					logrus.Errorf("error unmounting %s: %v", target, mntErr)
+				}
+				if rmErr := os.Remove(target); rmErr != nil && !os.IsNotExist(rmErr) {
+					logrus.Debugf("Failed to remove %s: %v: %v", target, rmErr, err)
+				}
+			}
+		}
+	}()
+
+	root := m.idMap.RootPair()
+	if err := idtools.MkdirAllAndChown(target, 0700, root); err != nil {
+		return "", err
+	}
+
+	return target, mount.All(mounts, target)
+}
+
+func (m *refCountMounter) Unmount(target string) error {
+	if count := m.rc.Decrement(target); count > 0 {
+		return nil
+	}
+
+	m.locker.Lock(target)
+	defer m.locker.Unlock(target)
+
+	if err := unmount(target); err != nil {
+		logrus.Debugf("Failed to unmount %s: %v", target, err)
+	}
+
+	if err := os.Remove(target); err != nil {
+		logrus.WithError(err).WithField("dir", target).Error("failed to remove mount temp dir")
+	}
+
+	return nil
+}
+
+type mounter struct {
+	home        string
+	snapshotter string
+	idMap       idtools.IdentityMapping
+}
+
+func (m mounter) Mount(mounts []mount.Mount, containerID string) (string, error) {
+	target := filepath.Join(m.home, mountsDir, m.snapshotter, containerID)
+
+	root := m.idMap.RootPair()
+	if err := idtools.MkdirAndChown(target, 0700, root); err != nil {
+		return "", err
+	}
+
+	return target, mount.All(mounts, target)
+}
+
+func (m mounter) Unmount(target string) error {
+	return unmount(target)
+
+}

--- a/daemon/snapshotter/mount_default.go
+++ b/daemon/snapshotter/mount_default.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package snapshotter
+
+import (
+	"github.com/containerd/containerd/mount"
+	"github.com/docker/docker/daemon/graphdriver"
+	"golang.org/x/sys/unix"
+)
+
+func checker() graphdriver.Checker {
+	return graphdriver.NewDefaultChecker()
+}
+
+func unmount(target string) error {
+	return mount.Unmount(target, unix.MNT_DETACH)
+}

--- a/daemon/snapshotter/mount_windows.go
+++ b/daemon/snapshotter/mount_windows.go
@@ -1,0 +1,18 @@
+package snapshotter
+
+import "github.com/containerd/containerd/mount"
+
+type winChecker struct {
+}
+
+func (c *winChecker) IsMounted(path string) bool {
+	return false
+}
+
+func checker() *winChecker {
+	return &winChecker{}
+}
+
+func unmount(target string) error {
+	return mount.Unmount(target, 0)
+}

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -5,7 +5,6 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/containerd/containerd"
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
@@ -178,13 +177,7 @@ func (daemon *Daemon) containerStart(ctx context.Context, container *container.C
 		return err
 	}
 
-	newContainerOpts := []containerd.NewContainerOpts{}
-	if daemon.UsesSnapshotter() {
-		newContainerOpts = append(newContainerOpts, containerd.WithSnapshotter(container.Driver))
-		newContainerOpts = append(newContainerOpts, containerd.WithSnapshot(container.ID))
-	}
-
-	ctr, err := libcontainerd.ReplaceContainer(ctx, daemon.containerd, container.ID, spec, shim, createOptions, newContainerOpts...)
+	ctr, err := libcontainerd.ReplaceContainer(ctx, daemon.containerd, container.ID, spec, shim, createOptions)
 	if err != nil {
 		return setExitCodeFromError(container.SetExitCode, err)
 	}


### PR DESCRIPTION
- Backport of https://github.com/moby/moby/pull/45698
- :warning: Slight conflict due to a lack of https://github.com/moby/moby/pull/43980
- fixes https://github.com/moby/moby/issues/46074

---

**- What I did**

Some snapshotters (like overlayfs or zfs) can't mount the same directories twice. For example if the same directroy is used as an upper directory in two mounts the kernel will output this warning:

    overlayfs: upperdir is in-use as upperdir/workdir of another mount, accessing files from both mounts will result in undefined behavior.

And indeed accessing the files from both mounts will result in an "No such file or directory" error.

This change introduces reference counts for the mounts, if a directory is already mounted the mount interface will only increment the mount counter and return the mount target effectively making sure that the filesystem doesn't end up in an undefined behavior.

This PR replaces #45383

**- How I did it**

Created a `refCountMounter` that makes sure things aren't mounted twice.

**- How to verify it**

You can use this script:

```bash
set -ex

pp () {
  read -s -k '?Press any key to continue.'
}

ID=$(docker run --name cp-test -d nginx)

docker exec $ID mount | wc -l

cat > test <<EOF
Hello cpa
EOF

docker cp test $ID:/test

docker exec $ID touch /etc/default/test-file

docker exec $ID touch /etc/default/test-file1

docker exec $ID mount | wc -l

docker stop $ID

# pp

docker cp test $ID:/test2
docker cp test $ID:/test2
docker cp test $ID:/test2
docker cp test $ID:/test2
docker cp test $ID:/test2
docker cp test $ID:/test2

docker rm cp-test
```

_Note_: Using this script you will see the kernel warning you that upperdir or workdir is already in-use by another mount. This is because unmounting happens async (MNT_DETACH is used, [more info here](https://github.com/moby/moby/pull/42349#issuecomment-841363359)), this happens during the last block of `docker cp` commands. This happens because cp does two calls:

* First call: `HEAD /v1.43/containers/<containerID>/archive?path=<patHh`
* Second call: `PUT /v1.43/containers/<containerID>/archive?noOverwriteDirNonDir=true&path=<path>`

The daemon calls Mount/Unmount for both of these calls, between the first Unmount and the second Mount the kernel didn't have the time to finish unmounting. 

In this case this warning can be safely ignored. The same warning can be seen with graph drivers when running the script above.

**- Description for the changelog**

```
Fixed `docker cp` with the containerd integration
```


**- A picture of a cute animal (not mandatory but encouraged)**
![IMG_2869](https://github.com/moby/moby/assets/99933/77702f8e-7415-44dc-9c55-90048600d3f8)

