### PR TITLE
[23.0 backport] daemon: registerName(): don't reserve name twice

### DIFF
--- a/daemon/names.go
+++ b/daemon/names.go
@@ -26,11 +26,12 @@ func (daemon *Daemon) registerName(container *container.Container) error {
 		return err
 	}
 	if container.Name == "" {
-		name, err := daemon.generateNewName(container.ID)
+		name, err := daemon.generateAndReserveName(container.ID)
 		if err != nil {
 			return err
 		}
 		container.Name = name
+		return nil
 	}
 	return daemon.containersReplica.ReserveName(container.Name, container.ID)
 }
@@ -42,7 +43,7 @@ func (daemon *Daemon) generateIDAndName(name string) (string, string, error) {
 	)
 
 	if name == "" {
-		if name, err = daemon.generateNewName(id); err != nil {
+		if name, err = daemon.generateAndReserveName(id); err != nil {
 			return "", "", err
 		}
 		return id, name, nil
@@ -81,7 +82,7 @@ func (daemon *Daemon) releaseName(name string) {
 	daemon.containersReplica.ReleaseName(name)
 }
 
-func (daemon *Daemon) generateNewName(id string) (string, error) {
+func (daemon *Daemon) generateAndReserveName(id string) (string, error) {
 	var name string
 	for i := 0; i < 6; i++ {
 		name = namesgenerator.GetRandomName(i)


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/45736

daemon.generateNewName() already reserves the generated name, but its name did not indicate it did. The daemon.registerName() assumed that the generated name still had to be reserved, which could mean it would try to reserve the same name again.

This patch renames daemon.generateNewName to daemon.generateAndReserveName to make it clearer what it does, and updates registerName() to return early if it successfully generated (and registered) the container name.


(cherry picked from commit 3ba67ee214927b681a560ba4d2a4ac7f3a993ad9)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

