### PR TITLE
[24.0 backport] contrib/busybox: Update to FRP-5007-g82accfc19

### DIFF
--- a/contrib/busybox/Dockerfile
+++ b/contrib/busybox/Dockerfile
@@ -10,10 +10,10 @@
 # To publish: Needs someone with publishing rights
 ARG WINDOWS_BASE_IMAGE=mcr.microsoft.com/windows/servercore
 ARG WINDOWS_BASE_IMAGE_TAG=ltsc2022
-ARG BUSYBOX_VERSION=FRP-3329-gcf0fa4d13
+ARG BUSYBOX_VERSION=FRP-5007-g82accfc19
 
 # Checksum taken from https://frippery.org/files/busybox/SHA256SUM
-ARG BUSYBOX_SHA256SUM=bfaeb88638e580fc522a68e69072e305308f9747563e51fa085eec60ca39a5ae
+ARG BUSYBOX_SHA256SUM=2d6fff0b2de5c034c92990d696c0d85a677b8a75931fa1ec30694fbf1f1df5c9
 
 FROM ${WINDOWS_BASE_IMAGE}:${WINDOWS_BASE_IMAGE_TAG}
 RUN mkdir C:\tmp && mkdir C:\bin

--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -24,17 +24,10 @@ import (
 func (s *DockerAPISuite) TestBuildAPIDockerFileRemote(c *testing.T) {
 	testRequires(c, NotUserNamespace)
 
-	var testD string
-	if testEnv.OSType == "windows" {
-		testD = `FROM busybox
-RUN find / -name ba*
-RUN find /tmp/`
-	} else {
-		// -xdev is required because sysfs can cause EPERM
-		testD = `FROM busybox
+	// -xdev is required because sysfs can cause EPERM
+	testD := `FROM busybox
 RUN find / -xdev -name ba*
 RUN find /tmp/`
-	}
 	server := fakestorage.New(c, "", fakecontext.WithFiles(map[string]string{"testD": testD}))
 	defer server.Close()
 


### PR DESCRIPTION
- Backport: https://github.com/moby/moby/pull/45784

(cherry picked from commit e01022318621102f6692ddc37a5b0c475dfe5ab4)


Creating symlinks with `ln` on Windows doesn't work with FRP-3329.
 
**- What I did**
- Updated Windows busybox image to use FRP-5007-g82accfc19 busybox version.
- Removed special Windows case from `TestBuildAPIDockerFileRemote` because `-xdev` is now supported.

**- How I did it**

**- How to verify it**
CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

