### PR TITLE
[24.0 backport] c8d: mark stargz as requiring reference-counted mounts

### DIFF
--- a/daemon/snapshotter/mount.go
+++ b/daemon/snapshotter/mount.go
@@ -14,7 +14,7 @@ import (
 const mountsDir = "rootfs"
 
 // List of known filesystems that can't be re-mounted or have shared layers
-var refCountedFileSystems = []string{"overlayfs", "zfs", "fuse-overlayfs"}
+var refCountedFileSystems = []string{"fuse-overlayfs", "overlayfs", "stargz", "zfs"}
 
 // Mounter handles mounting/unmounting things coming in from a snapshotter
 // with optional reference counting if needed by the filesystem


### PR DESCRIPTION
- Backport of https://github.com/moby/moby/pull/45781
- Stacked on https://github.com/moby/moby/pull/45780

**- What I did**

The stargz snapshotter cannot be re-mounted, so the reference-counted path must be used.

**- How to verify it**

`docker cp` with the stargz snapshotter.
