### PR TITLE
[24.0 backport] builder: pass host-gateway IP as worker label

### DIFF
--- a/builder/builder-next/worker/label/label.go
+++ b/builder/builder-next/worker/label/label.go
@@ -1,0 +1,9 @@
+package label
+
+// Pre-defined label keys similar to BuildKit ones
+// https://github.com/moby/buildkit/blob/v0.11.6/worker/label/label.go#L3-L16
+const (
+	prefix = "org.mobyproject.buildkit.worker.moby."
+
+	HostGatewayIP = prefix + "host-gateway-ip"
+)


### PR DESCRIPTION
* backport of https://github.com/moby/moby/pull/45767

(cherry picked from commit 21e50b89c92666589780eba6f83ad0851d8e9235)

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>