### PR TITLE
[23.0 backport] builder: pass host-gateway IP as worker label

### DIFF
--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -17,6 +17,7 @@ import (
 	containerimageexp "github.com/docker/docker/builder/builder-next/exporter"
 	"github.com/docker/docker/builder/builder-next/imagerefchecker"
 	mobyworker "github.com/docker/docker/builder/builder-next/worker"
+	wlabel "github.com/docker/docker/builder/builder-next/worker/label"
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/daemon/graphdriver"
 	units "github.com/docker/go-units"
@@ -204,6 +205,7 @@ func newController(rt http.RoundTripper, opt Opt) (*control.Controller, error) {
 		Transport:         rt,
 		Layers:            layers,
 		Platforms:         archutil.SupportedPlatforms(true),
+		Labels:            getLabels(opt, nil),
 	}
 
 	wc := &worker.Controller{}
@@ -285,4 +287,12 @@ func getEntitlements(conf config.BuilderConfig) []string {
 		ents = append(ents, string(entitlements.EntitlementSecurityInsecure))
 	}
 	return ents
+}
+
+func getLabels(opt Opt, labels map[string]string) map[string]string {
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[wlabel.HostGatewayIP] = opt.DNSConfig.HostGatewayIP.String()
+	return labels
 }

--- a/builder/builder-next/worker/label/label.go
+++ b/builder/builder-next/worker/label/label.go
@@ -1,0 +1,9 @@
+package label
+
+// Pre-defined label keys similar to BuildKit ones
+// https://github.com/moby/buildkit/blob/v0.11.6/worker/label/label.go#L3-L16
+const (
+	prefix = "org.mobyproject.buildkit.worker.moby."
+
+	HostGatewayIP = prefix + "host-gateway-ip"
+)


### PR DESCRIPTION
* backport of https://github.com/moby/moby/pull/45767

Not a clean cherry-pick due to lack of containerd snapshotter support on 23.0.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>