### PR TITLE
[24.0 backport] daemon: fix double-unlock in health check probe

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -160,7 +160,6 @@ func (p *cmdProbe) run(ctx context.Context, d *Daemon, cntr *container.Container
 		info.Lock()
 		defer info.Unlock()
 		if info.ExitCode == nil {
-			info.Unlock()
 			return 0, fmt.Errorf("healthcheck for container %s has no exit code", cntr.ID)
 		}
 		return *info.ExitCode, nil


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/45797

(cherry picked from commit 786c9adaa2af6fbd5a369643de897cbeca884f3f)

---

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed a doubled-up mutex unlock in the health-check probe code, which would cause a fatal error if that code path was ever executed.

**- How I did it**

**- How to verify it**
By inspection

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


