### PR TITLE
daemon: fix restoring container with missing task

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -447,6 +447,8 @@ func (daemon *Daemon) restore(cfg *configStore) error {
 					if es != nil {
 						ces.ExitCode = int(es.ExitCode())
 						ces.ExitedAt = es.ExitTime()
+					} else {
+						ces.ExitCode = 255
 					}
 					c.SetStopped(&ces)
 					daemon.Cleanup(c)


### PR DESCRIPTION
- Fixes #45788 
- Relates to #43564

Before 4bafaa00aa810dd17fde13e563def08f96fffc31, if the daemon was killed while a container was running and the container shim is killed before the daemon is restarted, such as if the host system is hard-rebooted, the daemon would restore the container to the stopped state and set the exit code to 255. The aforementioned commit introduced a regression where the container's exit code would instead be set to 0. Fix the regression so that the exit code is once against set to 255 on restore.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
- CI: new regression tests

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Fixed an issue where a container would be marked as exited successfully rather than failed if the system is hard-rebooted while the container is running

**- A picture of a cute animal (not mandatory but encouraged)**

