### PR TITLE
Fix missing Topology in NodeCSIInfo

### DIFF
--- a/daemon/cluster/convert/node.go
+++ b/daemon/cluster/convert/node.go
@@ -58,13 +58,20 @@ func NodeFromGRPC(n swarmapi.Node) types.Node {
 		}
 		for _, csi := range n.Description.CSIInfo {
 			if csi != nil {
+				convertedInfo := types.NodeCSIInfo{
+					PluginName:        csi.PluginName,
+					NodeID:            csi.NodeID,
+					MaxVolumesPerNode: csi.MaxVolumesPerNode,
+				}
+
+				if csi.AccessibleTopology != nil {
+					convertedInfo.AccessibleTopology = &types.Topology{
+						Segments: csi.AccessibleTopology.Segments,
+					}
+				}
+
 				node.Description.CSIInfo = append(
-					node.Description.CSIInfo,
-					types.NodeCSIInfo{
-						PluginName:        csi.PluginName,
-						NodeID:            csi.NodeID,
-						MaxVolumesPerNode: csi.MaxVolumesPerNode,
-					},
+					node.Description.CSIInfo, convertedInfo,
 				)
 			}
 		}

--- a/daemon/cluster/convert/node_test.go
+++ b/daemon/cluster/convert/node_test.go
@@ -1,0 +1,60 @@
+package convert
+
+import (
+	"testing"
+
+	types "github.com/docker/docker/api/types/swarm"
+	swarmapi "github.com/moby/swarmkit/v2/api"
+	"gotest.tools/v3/assert"
+)
+
+// TestNodeCSIInfoFromGRPC tests that conversion of the NodeCSIInfo from the
+// gRPC to the Docker types is correct.
+func TestNodeCSIInfoFromGRPC(t *testing.T) {
+	node := &swarmapi.Node{
+		ID: "someID",
+		Description: &swarmapi.NodeDescription{
+			CSIInfo: []*swarmapi.NodeCSIInfo{
+				&swarmapi.NodeCSIInfo{
+					PluginName:        "plugin1",
+					NodeID:            "p1n1",
+					MaxVolumesPerNode: 1,
+				},
+				&swarmapi.NodeCSIInfo{
+					PluginName:        "plugin2",
+					NodeID:            "p2n1",
+					MaxVolumesPerNode: 2,
+					AccessibleTopology: &swarmapi.Topology{
+						Segments: map[string]string{
+							"a": "1",
+							"b": "2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expected := []types.NodeCSIInfo{
+		{
+			PluginName:        "plugin1",
+			NodeID:            "p1n1",
+			MaxVolumesPerNode: 1,
+		},
+		{
+			PluginName:        "plugin2",
+			NodeID:            "p2n1",
+			MaxVolumesPerNode: 2,
+			AccessibleTopology: &types.Topology{
+				Segments: map[string]string{
+					"a": "1",
+					"b": "2",
+				},
+			},
+		},
+	}
+
+	actual := NodeFromGRPC(*node)
+
+	assert.DeepEqual(t, actual.Description.CSIInfo, expected)
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added code to `daemon/cluster/convert` to include the Topology in the NodeCSIInfo from the gRPC. Apparently in the past, I'd forgotten it.

Discovered this in the course of debugging other CSI issues.

**- How I did it**

A map is a map. Just convert the crap. Please clap.

**- How to verify it**

I wrote tests because I am a good contributor with attention to detail who does not often misspell "receive".