### PR TITLE
Add daemon logs for any errors in endpoint's handlerFunction and image delete, load events in DEBUG mode

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/api/server/router/debug"
 	"github.com/docker/docker/dockerversion"
 	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
 )
 
 // versionMatcher defines a variable matcher to be parsed by the router
@@ -53,7 +54,9 @@ func (s *Server) makeHTTPHandler(handler httputils.APIFunc) http.HandlerFunc {
 		if err := handlerFunc(ctx, w, r, vars); err != nil {
 			statusCode := httpstatus.FromError(err)
 			if statusCode >= 500 {
-				log.G(ctx).Errorf("Handler for %s %s returned error: %v", r.Method, r.URL.Path, err)
+				log.G(ctx).WithFields(logrus.Fields{"error": err, "method": r.Method, "path": r.URL.Path}).Error("Handler for endpoint returned error")
+			} else {
+				log.G(ctx).WithFields(logrus.Fields{"error": err, "method": r.Method, "path": r.URL.Path}).Debug("Handler for endpoint returned error")
 			}
 			makeErrorHandler(err)(w, r)
 		}

--- a/daemon/images/image_exporter.go
+++ b/daemon/images/image_exporter.go
@@ -46,5 +46,5 @@ func (i *ImageService) PerformWithBaseFS(ctx context.Context, c *container.Conta
 // ball containing images and metadata.
 func (i *ImageService) LoadImage(ctx context.Context, inTar io.ReadCloser, outStream io.Writer, quiet bool) error {
 	imageExporter := tarexport.NewTarExporter(i.imageStore, i.layerStore, i.referenceStore, i)
-	return imageExporter.Load(inTar, outStream, quiet)
+	return imageExporter.Load(ctx, inTar, outStream, quiet)
 }

--- a/image/image.go
+++ b/image/image.go
@@ -1,6 +1,7 @@
 package image // import "github.com/docker/docker/image"
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -277,7 +278,7 @@ func NewHistory(author, comment, createdBy string, isEmptyLayer bool) History {
 
 // Exporter provides interface for loading and saving images
 type Exporter interface {
-	Load(io.ReadCloser, io.Writer, bool) error
+	Load(context.Context, io.ReadCloser, io.Writer, bool) error
 	// TODO: Load(net.Context, io.ReadCloser, <- chan StatusMessage) error
 	Save([]string, io.Writer) error
 }


### PR DESCRIPTION
Fixes #45730 

**- What I did**
Added error log whenever an API returns an error in DEBUG mode
Added daemon logs for image deletion, reference removal and image removal in DEBUG mode

**- How I did it**
* Added log statements when attempting to delete image, reference. 
* Added a debug log statement in `server.go` whenever an error occurs

**- How to verify it**
* Start docker daemon in DEBUG mode
* Try to delete an image (docker rmi \<image\>)
* An image removal log will be added on successful deletion
* An error log will be added whenever an error occurs in the API

**- Description for the changelog**
These changes will make the dockerd log successful events of image removal and reference removal or conflict which occurs during the removal

