### PR TITLE
integration-cli: don't use pkg/homedir in test

### DIFF
--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -21,7 +22,6 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
-	"github.com/docker/docker/pkg/homedir"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/sysinfo"
 	"github.com/moby/sys/mount"
@@ -250,7 +250,11 @@ func (s *DockerCLIRunSuite) TestRunAttachDetachFromConfig(c *testing.T) {
 	os.Mkdir(dotDocker, 0600)
 	tmpCfg := filepath.Join(dotDocker, "config.json")
 
-	c.Setenv(homedir.Key(), tmpDir)
+	if runtime.GOOS == "windows" {
+		c.Setenv("USERPROFILE", tmpDir)
+	} else {
+		c.Setenv("HOME", tmpDir)
+	}
 
 	data := `{
 		"detachKeys": "ctrl-a,a"
@@ -330,7 +334,11 @@ func (s *DockerCLIRunSuite) TestRunAttachDetachKeysOverrideConfig(c *testing.T) 
 	os.Mkdir(dotDocker, 0600)
 	tmpCfg := filepath.Join(dotDocker, "config.json")
 
-	c.Setenv(homedir.Key(), tmpDir)
+	if runtime.GOOS == "windows" {
+		c.Setenv("USERPROFILE", tmpDir)
+	} else {
+		c.Setenv("HOME", tmpDir)
+	}
 
 	data := `{
 		"detachKeys": "ctrl-e,e"


### PR DESCRIPTION
I'm considering deprecating the "Key()" utility, as it was only used in tests.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

