### PR TITLE
pkg/homedir: use os.UserHomeDir(), deprecate GetShortcutString(), Key()

### DIFF
--- a/pkg/homedir/homedir.go
+++ b/pkg/homedir/homedir.go
@@ -8,6 +8,8 @@ import (
 
 // Key returns the env var name for the user's home dir based on
 // the platform being run on.
+//
+// Deprecated: this function is no longer used, and will be removed in the next release.
 func Key() string {
 	return envKeyName
 }

--- a/pkg/homedir/homedir.go
+++ b/pkg/homedir/homedir.go
@@ -1,0 +1,40 @@
+package homedir
+
+import (
+	"os"
+	"os/user"
+	"runtime"
+)
+
+// Key returns the env var name for the user's home dir based on
+// the platform being run on.
+func Key() string {
+	return envKeyName
+}
+
+// Get returns the home directory of the current user with the help of
+// environment variables depending on the target operating system.
+// Returned path should be used with "path/filepath" to form new paths.
+//
+// On non-Windows platforms, it falls back to nss lookups, if the home
+// directory cannot be obtained from environment-variables.
+//
+// If linking statically with cgo enabled against glibc, ensure the
+// osusergo build tag is used.
+//
+// If needing to do nss lookups, do not disable cgo or set osusergo.
+func Get() string {
+	home, _ := os.UserHomeDir()
+	if home == "" && runtime.GOOS != "windows" {
+		if u, err := user.Current(); err == nil {
+			return u.HomeDir
+		}
+	}
+	return home
+}
+
+// GetShortcutString returns the string that is shortcut to user's home directory
+// in the native shell of the platform running on.
+func GetShortcutString() string {
+	return homeShortCut
+}

--- a/pkg/homedir/homedir.go
+++ b/pkg/homedir/homedir.go
@@ -35,6 +35,8 @@ func Get() string {
 
 // GetShortcutString returns the string that is shortcut to user's home directory
 // in the native shell of the platform running on.
+//
+// Deprecated: this function is no longer used, and will be removed in the next release.
 func GetShortcutString() string {
 	return homeShortCut
 }

--- a/pkg/homedir/homedir_test.go
+++ b/pkg/homedir/homedir_test.go
@@ -17,7 +17,7 @@ func TestGet(t *testing.T) {
 }
 
 func TestGetShortcutString(t *testing.T) {
-	shortcut := GetShortcutString()
+	shortcut := GetShortcutString() //nolint:staticcheck // ignore SA1019 (GetShortcutString is deprecated)
 	if shortcut == "" {
 		t.Fatal("returned shortcut string is empty")
 	}

--- a/pkg/homedir/homedir_unix.go
+++ b/pkg/homedir/homedir_unix.go
@@ -2,37 +2,7 @@
 
 package homedir // import "github.com/docker/docker/pkg/homedir"
 
-import (
-	"os"
-	"os/user"
+const (
+	envKeyName   = "HOME"
+	homeShortCut = "~"
 )
-
-// Key returns the env var name for the user's home dir based on
-// the platform being run on
-func Key() string {
-	return "HOME"
-}
-
-// Get returns the home directory of the current user with the help of
-// environment variables depending on the target operating system.
-// Returned path should be used with "path/filepath" to form new paths.
-//
-// If linking statically with cgo enabled against glibc, ensure the
-// osusergo build tag is used.
-//
-// If needing to do nss lookups, do not disable cgo or set osusergo.
-func Get() string {
-	home, _ := os.UserHomeDir()
-	if home == "" {
-		if u, err := user.Current(); err == nil {
-			return u.HomeDir
-		}
-	}
-	return home
-}
-
-// GetShortcutString returns the string that is shortcut to user's home directory
-// in the native shell of the platform running on.
-func GetShortcutString() string {
-	return "~"
-}

--- a/pkg/homedir/homedir_unix.go
+++ b/pkg/homedir/homedir_unix.go
@@ -22,7 +22,7 @@ func Key() string {
 //
 // If needing to do nss lookups, do not disable cgo or set osusergo.
 func Get() string {
-	home := os.Getenv(Key())
+	home, _ := os.UserHomeDir()
 	if home == "" {
 		if u, err := user.Current(); err == nil {
 			return u.HomeDir

--- a/pkg/homedir/homedir_windows.go
+++ b/pkg/homedir/homedir_windows.go
@@ -1,25 +1,6 @@
 package homedir // import "github.com/docker/docker/pkg/homedir"
 
-import (
-	"os"
+const (
+	envKeyName   = "USERPROFILE"
+	homeShortCut = "%USERPROFILE%" // be careful while using in format functions
 )
-
-// Key returns the env var name for the user's home dir based on
-// the platform being run on
-func Key() string {
-	return "USERPROFILE"
-}
-
-// Get returns the home directory of the current user with the help of
-// environment variables depending on the target operating system.
-// Returned path should be used with "path/filepath" to form new paths.
-func Get() string {
-	home, _ := os.UserHomeDir()
-	return home
-}
-
-// GetShortcutString returns the string that is shortcut to user's home directory
-// in the native shell of the platform running on.
-func GetShortcutString() string {
-	return "%USERPROFILE%" // be careful while using in format functions
-}

--- a/pkg/homedir/homedir_windows.go
+++ b/pkg/homedir/homedir_windows.go
@@ -14,7 +14,8 @@ func Key() string {
 // environment variables depending on the target operating system.
 // Returned path should be used with "path/filepath" to form new paths.
 func Get() string {
-	return os.Getenv(Key())
+	home, _ := os.UserHomeDir()
+	return home
 }
 
 // GetShortcutString returns the string that is shortcut to user's home directory


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/45812

### pkg/homedir: use os.UserHomeDir()

Use os.UserHomeDir() instead of writing our own, but keep the fallback
on Linux.

### pkg/homedir: deprecate GetShortcutString() utility

This function was last used in the pkg/mflag package, which was removed
in 14712f9ff0d20a3b64a60103608b8cc998909242, and is no longer used in
libnetwork code since https://github.com/moby/libnetwork/commit/e6de8aec2fc3cea888f620de490fc6ab83700878

relates to:

- https://github.com/moby/libnetwork/pull/2562
- https://github.com/moby/moby/pull/25354

### pkg/homedir: deprecate Key() utility

This utility was only used in tests, and internally, and no longer used since
we switch to using `os.UserHomeDir()` from stdlib.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

