### PR TITLE
Skip cache lookup for "FROM scratch" in containerd

### DIFF
--- a/daemon/containerd/cache.go
+++ b/daemon/containerd/cache.go
@@ -31,6 +31,12 @@ type imageCache struct {
 
 func (ic *imageCache) GetCache(parentID string, cfg *container.Config) (imageID string, err error) {
 	ctx := context.TODO()
+
+	if parentID == "" {
+		// TODO handle "parentless" image cache lookups ("FROM scratch")
+		return "", nil
+	}
+
 	parent, err := ic.c.GetImage(ctx, parentID, imagetype.GetImageOpts{})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Ideally, this should actually do a lookup across images that have no parent, but I wasn't 100% sure how to accomplish that so I opted for the smaller change of having `FROM scratch` builds not be cached for now.

Before:

```console
$ docker build 'https://github.com/docker-library/busybox.git#dist-amd64:latest/glibc'
Sending build context to Docker daemon  1.781MB
Step 1/3 : FROM scratch
 --->
Step 2/3 : ADD busybox.tar.xz /
invalid reference format
```

After:

```console
$ docker build 'https://github.com/docker-library/busybox.git#dist-amd64:latest/glibc'
Sending build context to Docker daemon  1.711MB
Step 1/3 : FROM scratch
 ---> 
Step 2/3 : ADD busybox.tar.xz /
 ---> 75399b0f600c
Step 3/3 : CMD ["sh"]
 ---> Running in fbacee298b99
Removing intermediate container fbacee298b99
 ---> d170630036d7
Successfully built d170630036d7
```