### PR TITLE
Revert "Temporarily skip DCO check"

### DIFF
--- a/.github/workflows/.dco.yml
+++ b/.github/workflows/.dco.yml
@@ -35,14 +35,14 @@ jobs:
               return context.payload.pull_request.base.ref;
             }
             return context.ref.replace(/^refs\/heads\//g, '');
-#      -
-#        name: Validate
-#        run: |
-#          docker run --rm \
-#            -v "$(pwd):/workspace" \
-#            -e VALIDATE_REPO \
-#            -e VALIDATE_BRANCH \
-#            alpine:${{ env.ALPINE_VERSION }} sh -c 'apk add --no-cache -q bash git openssh-client && git config --system --add safe.directory /workspace && cd /workspace && hack/validate/dco'
-#        env:
-#          VALIDATE_REPO: ${{ github.server_url }}/${{ github.repository }}.git
-#          VALIDATE_BRANCH: ${{ steps.base-ref.outputs.result }}
+      -
+        name: Validate
+        run: |
+          docker run --rm \
+            -v "$(pwd):/workspace" \
+            -e VALIDATE_REPO \
+            -e VALIDATE_BRANCH \
+            alpine:${{ env.ALPINE_VERSION }} sh -c 'apk add --no-cache -q bash git openssh-client && git config --system --add safe.directory /workspace && cd /workspace && hack/validate/dco'
+        env:
+          VALIDATE_REPO: ${{ github.server_url }}/${{ github.repository }}.git
+          VALIDATE_BRANCH: ${{ steps.base-ref.outputs.result }}


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/45817

re-enable the DCO check, which was temporarily disabled to migrate old commits from github.com/docker/libkv

This reverts commit 7d7225fae657a18f8f384273a2313a288d84a021.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

