### PR TITLE
[24.0 backport] Skip cache lookup for "FROM scratch" in containerd

### DIFF
--- a/daemon/containerd/cache.go
+++ b/daemon/containerd/cache.go
@@ -31,6 +31,12 @@ type imageCache struct {
 
 func (ic *imageCache) GetCache(parentID string, cfg *container.Config) (imageID string, err error) {
 	ctx := context.TODO()
+
+	if parentID == "" {
+		// TODO handle "parentless" image cache lookups ("FROM scratch")
+		return "", nil
+	}
+
 	parent, err := ic.c.GetImage(ctx, parentID, imagetype.GetImageOpts{})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/45818

Ideally, this should actually do a lookup across images that have no parent, but I wasn't 100% sure how to accomplish that so I opted for the smaller change of having `FROM scratch` builds not be cached for now.


(cherry picked from commit 1741771b672b2418b4df2b2c6c0d4410ba12e65f)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

