### PR TITLE
Implement cache for "FROM scratch" in classic builder

### DIFF
--- a/daemon/containerd/cache.go
+++ b/daemon/containerd/cache.go
@@ -32,20 +32,37 @@ type imageCache struct {
 func (ic *imageCache) GetCache(parentID string, cfg *container.Config) (imageID string, err error) {
 	ctx := context.TODO()
 
-	if parentID == "" {
-		// TODO handle "parentless" image cache lookups ("FROM scratch")
-		return "", nil
-	}
-
-	parent, err := ic.c.GetImage(ctx, parentID, imagetype.GetImageOpts{})
-	if err != nil {
-		return "", err
+	var parent *image.Image
+	if parentID != "" { // not "FROM scratch"
+		var err error
+		parent, err = ic.c.GetImage(ctx, parentID, imagetype.GetImageOpts{})
+		if err != nil {
+			return "", err
+		}
 	}
 
 	for _, localCachedImage := range ic.images {
 		if isMatch(localCachedImage, parent, cfg) {
 			return localCachedImage.ID().String(), nil
 		}
+	}
+
+	if parent == nil { // "FROM scratch"
+		imgs, err := ic.c.client.ImageService().List(ctx) // TODO is this right??
+		if err != nil {
+			return "", err
+		}
+		for _, img := range imgs {
+			id := img.Target.Digest.String()
+			image, err := ic.c.GetImage(ctx, id, imagetype.GetImageOpts{})
+			if err != nil {
+				return "", err
+			}
+			if isMatch(image, parent, cfg) {
+				return id, nil
+			}
+		}
+		return "", nil
 	}
 
 	children, err := ic.c.Children(ctx, parent.ID())
@@ -73,8 +90,17 @@ func (ic *imageCache) GetCache(parentID string, cfg *container.Config) (imageID 
 // a parent image with `n` history entries, a valid target must have `n+1`
 // entries and the extra entry must match the provided config
 func isMatch(target, parent *image.Image, cfg *container.Config) bool {
-	if target == nil || parent == nil || cfg == nil {
+	if target == nil || cfg == nil {
 		return false
+	}
+
+	childCreatedBy := target.History[len(target.History)-1].CreatedBy
+	if childCreatedBy != strings.Join(cfg.Cmd, " ") {
+		return false
+	}
+
+	if parent == nil { // "FROM scratch"
+		return len(target.History) == 1 && len(target.RootFS.DiffIDs) == 1
 	}
 
 	if len(target.History) != len(parent.History)+1 ||
@@ -88,6 +114,5 @@ func isMatch(target, parent *image.Image, cfg *container.Config) bool {
 		}
 	}
 
-	childCreatedBy := target.History[len(target.History)-1].CreatedBy
-	return childCreatedBy == strings.Join(cfg.Cmd, " ")
+	return true
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/moby/moby/pull/45818 (implementing the `TODO` I added), but I'm opening it as a draft for now because it's both riskier and I'm much less sure of my implementation (there are a number of places in the code we could choose to plumb down the fact that we're building `FROM scratch` and I am not sure I chose the right ones).