### PR TITLE
[23.0 backport] seccomp: always allow name_to_handle_at(2)

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -237,6 +237,7 @@
 				"munlock",
 				"munlockall",
 				"munmap",
+				"name_to_handle_at",
 				"nanosleep",
 				"newfstatat",
 				"_newselect",

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -601,7 +601,6 @@
 				"mount",
 				"mount_setattr",
 				"move_mount",
-				"name_to_handle_at",
 				"open_tree",
 				"perf_event_open",
 				"quotactl",

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -229,6 +229,7 @@ func DefaultProfile() *Seccomp {
 					"munlock",
 					"munlockall",
 					"munmap",
+					"name_to_handle_at",
 					"nanosleep",
 					"newfstatat",
 					"_newselect",

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -592,7 +592,6 @@ func DefaultProfile() *Seccomp {
 					"mount",
 					"mount_setattr",
 					"move_mount",
-					"name_to_handle_at",
 					"open_tree",
 					"perf_event_open",
 					"quotactl",


### PR DESCRIPTION
- Backport of https://github.com/moby/moby/pull/45766 and https://github.com/moby/moby/pull/45837

---

closes #45518

Hi there, this is my first PR here, so please feel free to point me out if anything is wrong with this contribution. I looked the #45518 issue and I believe this could be a fix.

**- What I did**
Removed the function from the filtered syscalls as `name_to_handle_at(2)` is in fact innocuous and safe

**- How I did it**
@neersighted help at [comment](https://github.com/moby/moby/pull/45766#pullrequestreview-1493908145)

**- How to verify it**
N/A

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Remove name_to_handle_at(2) from filtered syscalls


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/moby/moby/assets/18057391/a8a3b84f-ccb9-40cf-a22c-512713efd790)

