### PR TITLE
docs: document more buildx targets

### DIFF
--- a/docs/contributing/ctn-build.md
+++ b/docs/contributing/ctn-build.md
@@ -25,4 +25,21 @@ docker buildx bake binary-cross
 
 # build binaries for a specific platform
 docker buildx bake --set *.platform=linux/arm64
+
+# build "complete" binaries (including containerd, runc, vpnkit, etc.)
+docker buildx bake all
+
+# build "complete" binaries for all supported platforms
+docker buildx bake all-cross
+
+# build non-runnable image wrapping "complete" binaries
+# useful for use with undock and sharing via a registry
+docker buildx bake bin-image
+
+# build non-runnable image wrapping "complete" binaries, with custom tag
+docker buildx bake bin-image --set "*.tags=foo/moby-bin:latest"
+
+# build non-runnable image wrapping "complete" binaries for all supported platforms
+# multi-platform images must be directly pushed to a registry
+docker buildx bake bin-image-cross --set "*.tags=foo/moby-bin:latest" --push
 ```


### PR DESCRIPTION
**- What I did**
Document more of the `buildx bake` targets introduced in the repo.

**- A picture of a cute animal (not mandatory but encouraged)**
![](https://media.discordapp.net/attachments/237010660347609088/1121827674579554325/20230622_104621.jpg?width=555&height=740)