### PR TITLE
seccomp: add name_to_handle_at to allowlist

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -237,6 +237,7 @@
 				"munlock",
 				"munlockall",
 				"munmap",
+				"name_to_handle_at",
 				"nanosleep",
 				"newfstatat",
 				"_newselect",

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -229,6 +229,7 @@ func DefaultProfile() *Seccomp {
 					"munlock",
 					"munlockall",
 					"munmap",
+					"name_to_handle_at",
 					"nanosleep",
 					"newfstatat",
 					"_newselect",


### PR DESCRIPTION
- Follow-up to https://github.com/moby/moby/pull/45766#discussion_r1244845677

Looks like I forgot how modern seccomp profiles are constructed; this follow-up finishes the migration of `name_to_handle_at(2)` to allowed-by-default.