### PR TITLE
libnet: add idm.NewWithNoStore

### DIFF
--- a/libnetwork/drivers/overlay/ovmanager/ovmanager.go
+++ b/libnetwork/drivers/overlay/ovmanager/ovmanager.go
@@ -65,7 +65,7 @@ func Register(r driverapi.DriverCallback, config map[string]interface{}) error {
 		config:   config,
 	}
 
-	d.vxlanIdm, err = idm.New(nil, "vxlan-id", 0, vxlanIDEnd)
+	d.vxlanIdm, err = idm.NewWithNoStore("vxlan-id", 0, vxlanIDEnd)
 	if err != nil {
 		return fmt.Errorf("failed to initialize vxlan id manager: %v", err)
 	}

--- a/libnetwork/drivers/overlay/ovmanager/ovmanager_test.go
+++ b/libnetwork/drivers/overlay/ovmanager/ovmanager_test.go
@@ -19,7 +19,7 @@ func newDriver(t *testing.T) *driver {
 		networks: networkTable{},
 	}
 
-	vxlanIdm, err := idm.New(nil, "vxlan-id", vxlanIDStart, vxlanIDEnd)
+	vxlanIdm, err := idm.NewWithNoStore("vxlan-id", vxlanIDStart, vxlanIDEnd)
 	assert.NilError(t, err)
 
 	d.vxlanIdm = vxlanIdm

--- a/libnetwork/idm/idm.go
+++ b/libnetwork/idm/idm.go
@@ -33,6 +33,11 @@ func New(ds datastore.DataStore, id string, start, end uint64) (*Idm, error) {
 	return &Idm{start: start, end: end, handle: h}, nil
 }
 
+// NewWithNoStore returns an instance of id manager for a [start,end] set of numerical ids
+func NewWithNoStore(id string, start, end uint64) (*Idm, error) {
+	return New(nil, id, start, end)
+}
+
 // GetID returns the first available id in the set
 func (i *Idm) GetID(serial bool) (uint64, error) {
 	if i.handle == nil {

--- a/libnetwork/idm/idm_test.go
+++ b/libnetwork/idm/idm_test.go
@@ -5,17 +5,17 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	_, err := New(nil, "", 0, 1)
+	_, err := NewWithNoStore("", 0, 1)
 	if err == nil {
 		t.Fatal("Expected failure, but succeeded")
 	}
 
-	_, err = New(nil, "myset", 1<<10, 0)
+	_, err = NewWithNoStore("myset", 1<<10, 0)
 	if err == nil {
 		t.Fatal("Expected failure, but succeeded")
 	}
 
-	i, err := New(nil, "myset", 0, 10)
+	i, err := NewWithNoStore("myset", 0, 10)
 	if err != nil {
 		t.Fatalf("Unexpected failure: %v", err)
 	}
@@ -31,7 +31,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestAllocate(t *testing.T) {
-	i, err := New(nil, "myids", 50, 52)
+	i, err := NewWithNoStore("myids", 50, 52)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func TestUninitialized(t *testing.T) {
 }
 
 func TestAllocateInRange(t *testing.T) {
-	i, err := New(nil, "myset", 5, 10)
+	i, err := NewWithNoStore("myset", 5, 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,7 +203,7 @@ func TestAllocateInRange(t *testing.T) {
 
 	// New larger set
 	ul := uint64((1 << 24) - 1)
-	i, err = New(nil, "newset", 0, ul)
+	i, err = NewWithNoStore("newset", 0, ul)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -234,7 +234,7 @@ func TestAllocateInRange(t *testing.T) {
 }
 
 func TestAllocateSerial(t *testing.T) {
-	i, err := New(nil, "myids", 50, 55)
+	i, err := NewWithNoStore("myids", 50, 55)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**- What I did**

Related to:

- #45348
- moby/swarmkit#3130

Add a new idm constructor named `NewWithNoStore`. This new idm constructor is temporarily added to make it possible to change swarmkit without hitting the dependency cycle that requires moby/swarmkit#3130 to revendor a fork of moby/moby. Once swarmkit uses this new constructor, we'll be able to change idm.New() to match idm.NewWithNoStore().

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://img.freepik.com/photos-premium/tapir-amerique-du-sud-espece-tapirus-terrestris_313877-7.jpg?w=370)