### PR TITLE
MAINTAINERS: update my email; AUTHORS,.mailmap: update with recent contributors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -144,6 +144,8 @@ Cristian Ariza <dev@cristianrz.com>
 Cristian Staretu <cristian.staretu@gmail.com>
 Cristian Staretu <cristian.staretu@gmail.com> <unclejack@users.noreply.github.com>
 Cristian Staretu <cristian.staretu@gmail.com> <unclejacksons@gmail.com>
+cui fliter <imcusg@gmail.com>
+cui fliter <imcusg@gmail.com> cuishuang <imcusg@gmail.com>
 CUI Wei <ghostplant@qq.com> cuiwei13 <cuiwei13@pku.edu.cn>
 Daehyeok Mun <daehyeok@gmail.com>
 Daehyeok Mun <daehyeok@gmail.com> <daehyeok@daehyeok-ui-MacBook-Air.local>
@@ -551,6 +553,7 @@ Sebastiaan van Stijn <github@gone.nl>
 Sebastiaan van Stijn <github@gone.nl> <moby@example.com>
 Sebastiaan van Stijn <github@gone.nl> <sebastiaan@ws-key-sebas3.dpi1.dpi>
 Sebastiaan van Stijn <github@gone.nl> <thaJeztah@users.noreply.github.com>
+Sebastian Thomschke <sebthom@users.noreply.github.com>
 Seongyeol Lim <seongyeol37@gmail.com>
 Shaun Kaasten <shaunk@gmail.com>
 Shawn Landden <shawn@churchofgit.com> <shawnlandden@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -27,6 +27,7 @@ Adam Miller <admiller@redhat.com>
 Adam Mills <adam@armills.info>
 Adam Pointer <adam.pointer@skybettingandgaming.com>
 Adam Singer <financeCoding@gmail.com>
+Adam Thornton <adam.thornton@maryville.com>
 Adam Walz <adam@adamwalz.net>
 Adam Williams <awilliams@mirantis.com>
 AdamKorcz <adam@adalogics.com>
@@ -436,7 +437,6 @@ Cristina Yenyxe Gonzalez Garcia <cristina.yenyxe@gmail.com>
 Cruceru Calin-Cristian <crucerucalincristian@gmail.com>
 cui fliter <imcusg@gmail.com>
 CUI Wei <ghostplant@qq.com>
-cuishuang <imcusg@gmail.com>
 Cuong Manh Le <cuong.manhle.vn@gmail.com>
 Cyprian Gracz <cyprian.gracz@micro-jumbo.eu>
 Cyril F <cyrilf7x@gmail.com>
@@ -679,6 +679,7 @@ Evan Allrich <evan@unguku.com>
 Evan Carmi <carmi@users.noreply.github.com>
 Evan Hazlett <ejhazlett@gmail.com>
 Evan Krall <krall@yelp.com>
+Evan Lezar <elezar@nvidia.com>
 Evan Phoenix <evan@fallingsnow.net>
 Evan Wies <evan@neomantra.net>
 Evelyn Xu <evelynhsu21@gmail.com>
@@ -986,6 +987,7 @@ Jean Rouge <rougej+github@gmail.com>
 Jean-Baptiste Barth <jeanbaptiste.barth@gmail.com>
 Jean-Baptiste Dalido <jeanbaptiste@appgratis.com>
 Jean-Christophe Berthon <huygens@berthon.eu>
+Jean-Michel Rouet <jm.rouet@gmail.com>
 Jean-Paul Calderone <exarkun@twistedmatrix.com>
 Jean-Pierre Huynh <jean-pierre.huynh@ounet.fr>
 Jean-Tiare Le Bigot <jt@yadutaf.fr>
@@ -1016,6 +1018,7 @@ Jeroen Jacobs <github@jeroenj.be>
 Jesse Dearing <jesse.dearing@gmail.com>
 Jesse Dubay <jesse@thefortytwo.net>
 Jessica Frazelle <jess@oxide.computer>
+Jeyanthinath Muthuram <jeyanthinath10@gmail.com>
 Jezeniel Zapanta <jpzapanta22@gmail.com>
 Jhon Honce <jhonce@redhat.com>
 Ji.Zhilong <zhilongji@gmail.com>
@@ -1610,6 +1613,7 @@ Noah Treuhaft <noah.treuhaft@docker.com>
 NobodyOnSE <ich@sektor.selfip.com>
 noducks <onemannoducks@gmail.com>
 Nolan Darilek <nolan@thewordnerd.info>
+Nolan Miles <nolanpmiles@gmail.com>
 Noriki Nakamura <noriki.nakamura@miraclelinux.com>
 nponeccop <andy.melnikov@gmail.com>
 Nurahmadie <nurahmadie@gmail.com>
@@ -1665,6 +1669,7 @@ Paul Lietar <paul@lietar.net>
 Paul Liljenberg <liljenberg.paul@gmail.com>
 Paul Morie <pmorie@gmail.com>
 Paul Nasrat <pnasrat@gmail.com>
+Paul Seiffert <paul.seiffert@jimdo.com>
 Paul Weaver <pauweave@cisco.com>
 Paulo Gomes <pjbgf@linux.com>
 Paulo Ribeiro <paigr.io@gmail.com>
@@ -1927,6 +1932,7 @@ Sebastiaan van Steenis <mail@superseb.nl>
 Sebastiaan van Stijn <github@gone.nl>
 Sebastian Höffner <sebastian.hoeffner@mevis.fraunhofer.de>
 Sebastian Radloff <sradloff23@gmail.com>
+Sebastian Thomschke <sebthom@users.noreply.github.com>
 Sebastien Goasguen <runseb@gmail.com>
 Senthil Kumar Selvaraj <senthil.thecoder@gmail.com>
 Senthil Kumaran <senthil@uthcode.com>
@@ -2208,6 +2214,7 @@ Vinod Kulkarni <vinod.kulkarni@gmail.com>
 Vishal Doshi <vishal.doshi@gmail.com>
 Vishnu Kannan <vishnuk@google.com>
 Vitaly Ostrosablin <vostrosablin@virtuozzo.com>
+Vitor Anjos <bartier@users.noreply.github.com>
 Vitor Monteiro <vmrmonteiro@gmail.com>
 Vivek Agarwal <me@vivek.im>
 Vivek Dasgupta <vdasgupt@redhat.com>
@@ -2360,6 +2367,7 @@ Zen Lin(Zhinan Lin) <linzhinan@huawei.com>
 Zhang Kun <zkazure@gmail.com>
 Zhang Wei <zhangwei555@huawei.com>
 Zhang Wentao <zhangwentao234@huawei.com>
+zhangguanzhang <zhangguanzhang@qq.com>
 ZhangHang <stevezhang2014@gmail.com>
 zhangxianwei <xianwei.zw@alibaba-inc.com>
 Zhenan Ye <21551168@zju.edu.cn>

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -459,7 +459,7 @@
 
 	[people.neersighted]
 	Name = "Bjorn Neergaard"
-	Email = "bneergaard@mirantis.com"
+	Email = "bjorn@neersighted.com"
 	GitHub = "neersighted"
 
 	[people.olljanat]


### PR DESCRIPTION
Follow-up to https://github.com/moby/moby/pull/45505; I neglected to update `MAINTAINERS`. Use my personal email as it will be the most stable point of contact.

Also include some updates to `.mailmap` and `AUTHORS` for recent contributors.