### PR TITLE
Update `WithAPIVersionNegotiation` function documentation

### DIFF
--- a/client/options.go
+++ b/client/options.go
@@ -212,6 +212,9 @@ func WithVersionFromEnv() Opt {
 // With this option enabled, the client automatically negotiates the API version
 // to use when making requests. API version negotiation is performed on the first
 // request; subsequent requests will not re-negotiate.
+//
+// NOTE: This option is not thread safe and may cause a race condition
+// as the version is not protected by a Mutex.
 func WithAPIVersionNegotiation() Opt {
 	return func(c *Client) error {
 		c.negotiateVersion = true


### PR DESCRIPTION
The "WithAPIVersionNegotiation" option is not thread-safe and can result in race conditions. Although a pull request[1] was submitted a year ago to fix the issue, it appears that no consensus has been reached on how to resolve it. As mitigation, I recommend updating the documentation to keep end-users informed of the option behavior.

Also, I am willing to enhance the suggested solution provided there is an agreement to resolve this matter permanently.

[1] https://github.com/moby/moby/pull/43738