### PR TITLE
api: use singleflight for /info endpoint

### DIFF
--- a/api/server/router/system/system.go
+++ b/api/server/router/system/system.go
@@ -2,7 +2,9 @@ package system // import "github.com/docker/docker/api/server/router/system"
 
 import (
 	"github.com/docker/docker/api/server/router"
+	"github.com/docker/docker/api/types"
 	buildkit "github.com/docker/docker/builder/builder-next"
+	"resenje.org/singleflight"
 )
 
 // systemRouter provides information about the Docker system overall.
@@ -13,6 +15,11 @@ type systemRouter struct {
 	routes   []router.Route
 	builder  *buildkit.Builder
 	features func() map[string]bool
+
+	// collectSystemInfo is a single-flight for the /info endpoint,
+	// unique per API version (as different API versions may return
+	// a different API response).
+	collectSystemInfo singleflight.Group[string, *types.Info]
 }
 
 // NewRouter initializes a new system router


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/45842
- [x] depends on https://github.com/moby/moby/pull/45873

Prevent potential suggestion when many concurrent requests happen on the /info endpoint. It's worth noting that with this change, requests to the endpoint while another request is still in flight will share the results, hence might be slightly incorrect (for example, the output includes SystemTime, which may now be incorrect).

Assuming that under normal circumstances, requests will still happen fast enough to not be shared, this may not be a problem, but we could decide to update specific fields to not be shared.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

