### PR TITLE
daemon/config: remove unused CommonConfig.Context

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -144,22 +144,21 @@ type DNSConfig struct {
 // It includes json tags to deserialize configuration from a file
 // using the same names that the flags in the command line use.
 type CommonConfig struct {
-	AuthorizationPlugins  []string            `json:"authorization-plugins,omitempty"` // AuthorizationPlugins holds list of authorization plugins
-	AutoRestart           bool                `json:"-"`
-	Context               map[string][]string `json:"-"`
-	DisableBridge         bool                `json:"-"`
-	ExecOptions           []string            `json:"exec-opts,omitempty"`
-	GraphDriver           string              `json:"storage-driver,omitempty"`
-	GraphOptions          []string            `json:"storage-opts,omitempty"`
-	Labels                []string            `json:"labels,omitempty"`
-	Mtu                   int                 `json:"mtu,omitempty"`
-	NetworkDiagnosticPort int                 `json:"network-diagnostic-port,omitempty"`
-	Pidfile               string              `json:"pidfile,omitempty"`
-	RawLogs               bool                `json:"raw-logs,omitempty"`
-	Root                  string              `json:"data-root,omitempty"`
-	ExecRoot              string              `json:"exec-root,omitempty"`
-	SocketGroup           string              `json:"group,omitempty"`
-	CorsHeaders           string              `json:"api-cors-header,omitempty"`
+	AuthorizationPlugins  []string `json:"authorization-plugins,omitempty"` // AuthorizationPlugins holds list of authorization plugins
+	AutoRestart           bool     `json:"-"`
+	DisableBridge         bool     `json:"-"`
+	ExecOptions           []string `json:"exec-opts,omitempty"`
+	GraphDriver           string   `json:"storage-driver,omitempty"`
+	GraphOptions          []string `json:"storage-opts,omitempty"`
+	Labels                []string `json:"labels,omitempty"`
+	Mtu                   int      `json:"mtu,omitempty"`
+	NetworkDiagnosticPort int      `json:"network-diagnostic-port,omitempty"`
+	Pidfile               string   `json:"pidfile,omitempty"`
+	RawLogs               bool     `json:"raw-logs,omitempty"`
+	Root                  string   `json:"data-root,omitempty"`
+	ExecRoot              string   `json:"exec-root,omitempty"`
+	SocketGroup           string   `json:"group,omitempty"`
+	CorsHeaders           string   `json:"api-cors-header,omitempty"`
 
 	// Proxies holds the proxies that are configured for the daemon.
 	Proxies `json:"proxies"`


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/5448

This field was added in f0e6e135a8d733af173bf0b8732c704c9ec716d7 (https://github.com/moby/moby/pull/5448), and from that change I suspect it was intended to store the default SELinux mount-labels to be set on containers.

However, it was never used, so let's remove it.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

