### PR TITLE
libnetwork/drivers: remove unused "config" parameters and fields

### DIFF
--- a/libnetwork/drivers/bridge/bridge.go
+++ b/libnetwork/drivers/bridge/bridge.go
@@ -174,12 +174,10 @@ func Register(r driverapi.Registerer, config map[string]interface{}) error {
 	if err := d.configure(config); err != nil {
 		return err
 	}
-
-	c := driverapi.Capability{
+	return r.RegisterDriver(networkType, d, driverapi.Capability{
 		DataScope:         datastore.LocalScope,
 		ConnectivityScope: datastore.LocalScope,
-	}
-	return r.RegisterDriver(networkType, d, c)
+	})
 }
 
 // Validate performs a static validation on the network configuration parameters.

--- a/libnetwork/drivers/bridge/brmanager/brmanager.go
+++ b/libnetwork/drivers/bridge/brmanager/brmanager.go
@@ -20,11 +20,10 @@ func Init(dc driverapi.DriverCallback, _ map[string]interface{}) error {
 
 // Register registers a new instance of the bridge manager driver with r.
 func Register(r driverapi.Registerer, _ map[string]interface{}) error {
-	c := driverapi.Capability{
+	return r.RegisterDriver(networkType, &driver{}, driverapi.Capability{
 		DataScope:         datastore.LocalScope,
 		ConnectivityScope: datastore.LocalScope,
-	}
-	return r.RegisterDriver(networkType, &driver{}, c)
+	})
 }
 
 func (d *driver) NetworkAllocate(id string, option map[string]string, ipV4Data, ipV6Data []driverapi.IPAMData) (map[string]string, error) {

--- a/libnetwork/drivers/bridge/brmanager/brmanager.go
+++ b/libnetwork/drivers/bridge/brmanager/brmanager.go
@@ -14,12 +14,12 @@ type driver struct{}
 // Init registers a new instance of bridge manager driver.
 //
 // Deprecated: use [Register].
-func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
-	return Register(dc, config)
+func Init(dc driverapi.DriverCallback, _ map[string]interface{}) error {
+	return Register(dc, nil)
 }
 
 // Register registers a new instance of the bridge manager driver with r.
-func Register(r driverapi.Registerer, config map[string]interface{}) error {
+func Register(r driverapi.Registerer, _ map[string]interface{}) error {
 	c := driverapi.Capability{
 		DataScope:         datastore.LocalScope,
 		ConnectivityScope: datastore.LocalScope,

--- a/libnetwork/drivers/host/host.go
+++ b/libnetwork/drivers/host/host.go
@@ -24,11 +24,10 @@ func Init(dc driverapi.DriverCallback, _ map[string]interface{}) error {
 }
 
 func Register(r driverapi.Registerer, _ map[string]interface{}) error {
-	c := driverapi.Capability{
+	return r.RegisterDriver(networkType, &driver{}, driverapi.Capability{
 		DataScope:         datastore.LocalScope,
 		ConnectivityScope: datastore.LocalScope,
-	}
-	return r.RegisterDriver(networkType, &driver{}, c)
+	})
 }
 
 func (d *driver) NetworkAllocate(id string, option map[string]string, ipV4Data, ipV6Data []driverapi.IPAMData) (map[string]string, error) {

--- a/libnetwork/drivers/host/host.go
+++ b/libnetwork/drivers/host/host.go
@@ -19,11 +19,11 @@ type driver struct {
 // Init registers a new instance of host driver.
 //
 // Deprecated: use [Register].
-func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
-	return Register(dc, config)
+func Init(dc driverapi.DriverCallback, _ map[string]interface{}) error {
+	return Register(dc, nil)
 }
 
-func Register(r driverapi.Registerer, config map[string]interface{}) error {
+func Register(r driverapi.Registerer, _ map[string]interface{}) error {
 	c := driverapi.Capability{
 		DataScope:         datastore.LocalScope,
 		ConnectivityScope: datastore.LocalScope,

--- a/libnetwork/drivers/ipvlan/ipvlan.go
+++ b/libnetwork/drivers/ipvlan/ipvlan.go
@@ -64,18 +64,16 @@ type network struct {
 
 // Register initializes and registers the libnetwork ipvlan driver.
 func Register(r driverapi.Registerer, config map[string]interface{}) error {
-	c := driverapi.Capability{
-		DataScope:         datastore.LocalScope,
-		ConnectivityScope: datastore.GlobalScope,
-	}
 	d := &driver{
 		networks: networkTable{},
 	}
 	if err := d.initStore(config); err != nil {
 		return err
 	}
-
-	return r.RegisterDriver(driverName, d, c)
+	return r.RegisterDriver(driverName, d, driverapi.Capability{
+		DataScope:         datastore.LocalScope,
+		ConnectivityScope: datastore.GlobalScope,
+	})
 }
 
 func (d *driver) NetworkAllocate(id string, option map[string]string, ipV4Data, ipV6Data []driverapi.IPAMData) (map[string]string, error) {

--- a/libnetwork/drivers/ipvlan/ivmanager/ivmanager.go
+++ b/libnetwork/drivers/ipvlan/ivmanager/ivmanager.go
@@ -14,12 +14,12 @@ type driver struct{}
 // Init registers a new instance of the ipvlan manager driver.
 //
 // Deprecated: use [Register].
-func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
-	return Register(dc, config)
+func Init(dc driverapi.DriverCallback, _ map[string]interface{}) error {
+	return Register(dc, nil)
 }
 
 // Register registers a new instance of the ipvlan manager driver.
-func Register(r driverapi.Registerer, config map[string]interface{}) error {
+func Register(r driverapi.Registerer, _ map[string]interface{}) error {
 	c := driverapi.Capability{
 		DataScope:         datastore.LocalScope,
 		ConnectivityScope: datastore.GlobalScope,

--- a/libnetwork/drivers/ipvlan/ivmanager/ivmanager.go
+++ b/libnetwork/drivers/ipvlan/ivmanager/ivmanager.go
@@ -20,11 +20,10 @@ func Init(dc driverapi.DriverCallback, _ map[string]interface{}) error {
 
 // Register registers a new instance of the ipvlan manager driver.
 func Register(r driverapi.Registerer, _ map[string]interface{}) error {
-	c := driverapi.Capability{
+	return r.RegisterDriver(networkType, &driver{}, driverapi.Capability{
 		DataScope:         datastore.LocalScope,
 		ConnectivityScope: datastore.GlobalScope,
-	}
-	return r.RegisterDriver(networkType, &driver{}, c)
+	})
 }
 
 func (d *driver) NetworkAllocate(id string, option map[string]string, ipV4Data, ipV6Data []driverapi.IPAMData) (map[string]string, error) {

--- a/libnetwork/drivers/macvlan/macvlan.go
+++ b/libnetwork/drivers/macvlan/macvlan.go
@@ -58,18 +58,16 @@ type network struct {
 
 // Register initializes and registers the libnetwork macvlan driver
 func Register(r driverapi.Registerer, config map[string]interface{}) error {
-	c := driverapi.Capability{
-		DataScope:         datastore.LocalScope,
-		ConnectivityScope: datastore.GlobalScope,
-	}
 	d := &driver{
 		networks: networkTable{},
 	}
 	if err := d.initStore(config); err != nil {
 		return err
 	}
-
-	return r.RegisterDriver(driverName, d, c)
+	return r.RegisterDriver(driverName, d, driverapi.Capability{
+		DataScope:         datastore.LocalScope,
+		ConnectivityScope: datastore.GlobalScope,
+	})
 }
 
 func (d *driver) NetworkAllocate(id string, option map[string]string, ipV4Data, ipV6Data []driverapi.IPAMData) (map[string]string, error) {

--- a/libnetwork/drivers/macvlan/mvmanager/mvmanager.go
+++ b/libnetwork/drivers/macvlan/mvmanager/mvmanager.go
@@ -20,11 +20,10 @@ func Init(dc driverapi.DriverCallback, _ map[string]interface{}) error {
 
 // Register registers a new instance of the macvlan manager driver.
 func Register(r driverapi.Registerer, _ map[string]interface{}) error {
-	c := driverapi.Capability{
+	return r.RegisterDriver(networkType, &driver{}, driverapi.Capability{
 		DataScope:         datastore.LocalScope,
 		ConnectivityScope: datastore.GlobalScope,
-	}
-	return r.RegisterDriver(networkType, &driver{}, c)
+	})
 }
 
 func (d *driver) NetworkAllocate(id string, option map[string]string, ipV4Data, ipV6Data []driverapi.IPAMData) (map[string]string, error) {

--- a/libnetwork/drivers/macvlan/mvmanager/mvmanager.go
+++ b/libnetwork/drivers/macvlan/mvmanager/mvmanager.go
@@ -14,12 +14,12 @@ type driver struct{}
 // Init registers a new instance of the macvlan manager driver.
 //
 // Deprecated: use [Register].
-func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
-	return Register(dc, config)
+func Init(dc driverapi.DriverCallback, _ map[string]interface{}) error {
+	return Register(dc, nil)
 }
 
 // Register registers a new instance of the macvlan manager driver.
-func Register(r driverapi.Registerer, config map[string]interface{}) error {
+func Register(r driverapi.Registerer, _ map[string]interface{}) error {
 	c := driverapi.Capability{
 		DataScope:         datastore.LocalScope,
 		ConnectivityScope: datastore.GlobalScope,

--- a/libnetwork/drivers/null/null.go
+++ b/libnetwork/drivers/null/null.go
@@ -18,10 +18,9 @@ type driver struct {
 
 // Register registers a new instance of the null driver.
 func Register(r driverapi.Registerer, _ map[string]interface{}) error {
-	c := driverapi.Capability{
+	return r.RegisterDriver(networkType, &driver{}, driverapi.Capability{
 		DataScope: datastore.LocalScope,
-	}
-	return r.RegisterDriver(networkType, &driver{}, c)
+	})
 }
 
 func (d *driver) NetworkAllocate(id string, option map[string]string, ipV4Data, ipV6Data []driverapi.IPAMData) (map[string]string, error) {

--- a/libnetwork/drivers/null/null.go
+++ b/libnetwork/drivers/null/null.go
@@ -17,7 +17,7 @@ type driver struct {
 }
 
 // Register registers a new instance of the null driver.
-func Register(r driverapi.Registerer, config map[string]interface{}) error {
+func Register(r driverapi.Registerer, _ map[string]interface{}) error {
 	c := driverapi.Capability{
 		DataScope: datastore.LocalScope,
 	}

--- a/libnetwork/drivers/overlay/overlay.go
+++ b/libnetwork/drivers/overlay/overlay.go
@@ -39,10 +39,6 @@ type driver struct {
 
 // Register registers a new instance of the overlay driver.
 func Register(r driverapi.Registerer, config map[string]interface{}) error {
-	c := driverapi.Capability{
-		DataScope:         datastore.GlobalScope,
-		ConnectivityScope: datastore.GlobalScope,
-	}
 	d := &driver{
 		networks: networkTable{},
 		peerDb: peerNetworkMap{
@@ -51,8 +47,10 @@ func Register(r driverapi.Registerer, config map[string]interface{}) error {
 		secMap: &encrMap{nodes: map[string][]*spi{}},
 		config: config,
 	}
-
-	return r.RegisterDriver(networkType, d, c)
+	return r.RegisterDriver(networkType, d, driverapi.Capability{
+		DataScope:         datastore.GlobalScope,
+		ConnectivityScope: datastore.GlobalScope,
+	})
 }
 
 func (d *driver) configure() error {

--- a/libnetwork/drivers/overlay/ovmanager/ovmanager.go
+++ b/libnetwork/drivers/overlay/ovmanager/ovmanager.go
@@ -52,7 +52,7 @@ func Init(dc driverapi.DriverCallback, _ map[string]interface{}) error {
 }
 
 // Register registers a new instance of the overlay driver.
-func Register(r driverapi.DriverCallback, _ map[string]interface{}) error {
+func Register(r driverapi.Registerer, _ map[string]interface{}) error {
 	var err error
 	c := driverapi.Capability{
 		DataScope:         datastore.GlobalScope,

--- a/libnetwork/drivers/overlay/ovmanager/ovmanager.go
+++ b/libnetwork/drivers/overlay/ovmanager/ovmanager.go
@@ -54,11 +54,6 @@ func Init(dc driverapi.DriverCallback, _ map[string]interface{}) error {
 // Register registers a new instance of the overlay driver.
 func Register(r driverapi.Registerer, _ map[string]interface{}) error {
 	var err error
-	c := driverapi.Capability{
-		DataScope:         datastore.GlobalScope,
-		ConnectivityScope: datastore.GlobalScope,
-	}
-
 	d := &driver{
 		networks: networkTable{},
 	}
@@ -68,7 +63,10 @@ func Register(r driverapi.Registerer, _ map[string]interface{}) error {
 		return fmt.Errorf("failed to initialize vxlan id manager: %v", err)
 	}
 
-	return r.RegisterDriver(networkType, d, c)
+	return r.RegisterDriver(networkType, d, driverapi.Capability{
+		DataScope:         datastore.GlobalScope,
+		ConnectivityScope: datastore.GlobalScope,
+	})
 }
 
 func (d *driver) NetworkAllocate(id string, option map[string]string, ipV4Data, ipV6Data []driverapi.IPAMData) (map[string]string, error) {

--- a/libnetwork/drivers/overlay/ovmanager/ovmanager.go
+++ b/libnetwork/drivers/overlay/ovmanager/ovmanager.go
@@ -26,7 +26,6 @@ const (
 type networkTable map[string]*network
 
 type driver struct {
-	config   map[string]interface{}
 	networks networkTable
 	vxlanIdm *idm.Idm
 	sync.Mutex
@@ -48,12 +47,12 @@ type network struct {
 // Init registers a new instance of the overlay driver.
 //
 // Deprecated: use [Register].
-func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
-	return Register(dc, config)
+func Init(dc driverapi.DriverCallback, _ map[string]interface{}) error {
+	return Register(dc, nil)
 }
 
 // Register registers a new instance of the overlay driver.
-func Register(r driverapi.DriverCallback, config map[string]interface{}) error {
+func Register(r driverapi.DriverCallback, _ map[string]interface{}) error {
 	var err error
 	c := driverapi.Capability{
 		DataScope:         datastore.GlobalScope,
@@ -62,7 +61,6 @@ func Register(r driverapi.DriverCallback, config map[string]interface{}) error {
 
 	d := &driver{
 		networks: networkTable{},
-		config:   config,
 	}
 
 	d.vxlanIdm, err = idm.New(nil, "vxlan-id", 0, vxlanIDEnd)

--- a/libnetwork/drivers/remote/driver.go
+++ b/libnetwork/drivers/remote/driver.go
@@ -33,7 +33,7 @@ func newDriver(name string, client *plugins.Client) driverapi.Driver {
 // plugin is activated.
 //
 // Deprecated: use [Register].
-func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
+func Init(dc driverapi.DriverCallback, _ map[string]interface{}) error {
 	return Register(dc, dc.GetPluginGetter())
 }
 

--- a/libnetwork/drivers/windows/overlay/overlay_windows.go
+++ b/libnetwork/drivers/windows/overlay/overlay_windows.go
@@ -21,13 +21,12 @@ const (
 )
 
 type driver struct {
-	config   map[string]interface{}
 	networks networkTable
 	sync.Mutex
 }
 
 // Register registers a new instance of the overlay driver.
-func Register(r driverapi.Registerer, config map[string]interface{}) error {
+func Register(r driverapi.Registerer, _ map[string]interface{}) error {
 	c := driverapi.Capability{
 		DataScope:         datastore.GlobalScope,
 		ConnectivityScope: datastore.GlobalScope,
@@ -35,7 +34,6 @@ func Register(r driverapi.Registerer, config map[string]interface{}) error {
 
 	d := &driver{
 		networks: networkTable{},
-		config:   config,
 	}
 
 	d.restoreHNSNetworks()
@@ -64,7 +62,7 @@ func (d *driver) restoreHNSNetworks() error {
 		// We assume that any network will be recreated on daemon restart
 		// and therefore don't restore hns endpoints for now
 		//
-		//n.restoreNetworkEndpoints()
+		// n.restoreNetworkEndpoints()
 	}
 
 	return nil

--- a/libnetwork/drivers/windows/overlay/overlay_windows.go
+++ b/libnetwork/drivers/windows/overlay/overlay_windows.go
@@ -27,18 +27,16 @@ type driver struct {
 
 // Register registers a new instance of the overlay driver.
 func Register(r driverapi.Registerer, _ map[string]interface{}) error {
-	c := driverapi.Capability{
-		DataScope:         datastore.GlobalScope,
-		ConnectivityScope: datastore.GlobalScope,
-	}
-
 	d := &driver{
 		networks: networkTable{},
 	}
 
 	d.restoreHNSNetworks()
 
-	return r.RegisterDriver(networkType, d, c)
+	return r.RegisterDriver(networkType, d, driverapi.Capability{
+		DataScope:         datastore.GlobalScope,
+		ConnectivityScope: datastore.GlobalScope,
+	})
 }
 
 func (d *driver) restoreHNSNetworks() error {


### PR DESCRIPTION
### libnetwork/drivers: remove unused "config" parameters and fields

### libnetwork/drivers/overlay: Register does not require DriverCallback

This function was not using the DriverCallback interface, and only
required the Registerer interface.

### libnetwork/drivers: inline capabilities options

Remove the intermediate variable, and move the option closer to where it's used, as in some cases we created the variable, but could return with an error before it was used.


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

