### PR TITLE
[23.0 backport] pkg/fileutils: GetTotalUsedFds: reduce allocations 

### DIFF
--- a/pkg/fileutils/fileutils_linux.go
+++ b/pkg/fileutils/fileutils_linux.go
@@ -6,12 +6,27 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 )
 
 // GetTotalUsedFds Returns the number of used File Descriptors by
 // reading it via /proc filesystem.
 func GetTotalUsedFds() int {
 	name := fmt.Sprintf("/proc/%d/fd", os.Getpid())
+
+	// Fast-path for Linux 6.2 (since [f1f1f2569901ec5b9d425f2e91c09a0e320768f3]).
+	// From the [Linux docs]:
+	//
+	// "The number of open files for the process is stored in 'size' member of
+	// stat() output for /proc/<pid>/fd for fast access."
+	//
+	// [Linux docs]: https://docs.kernel.org/filesystems/proc.html#proc-pid-fd-list-of-symlinks-to-open-files:
+	// [f1f1f2569901ec5b9d425f2e91c09a0e320768f3]: https://github.com/torvalds/linux/commit/f1f1f2569901ec5b9d425f2e91c09a0e320768f3
+	var stat unix.Stat_t
+	if err := unix.Stat(name, &stat); err == nil && stat.Size > 0 {
+		return int(stat.Size)
+	}
+
 	f, err := os.Open(name)
 	if err != nil {
 		logrus.WithError(err).Error("Error listing file descriptors")
@@ -30,5 +45,7 @@ func GetTotalUsedFds() int {
 			return -1
 		}
 	}
+	// Note that the slow path has 1 more file-descriptor, due to the open
+	// file-handle for /proc/<pid>/fd during the calculation.
 	return fdCount
 }

--- a/pkg/fileutils/fileutils_linux.go
+++ b/pkg/fileutils/fileutils_linux.go
@@ -2,6 +2,7 @@ package fileutils
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -10,10 +11,24 @@ import (
 // GetTotalUsedFds Returns the number of used File Descriptors by
 // reading it via /proc filesystem.
 func GetTotalUsedFds() int {
-	if fds, err := os.ReadDir(fmt.Sprintf("/proc/%d/fd", os.Getpid())); err != nil {
-		logrus.Errorf("Error opening /proc/%d/fd: %s", os.Getpid(), err)
-	} else {
-		return len(fds)
+	name := fmt.Sprintf("/proc/%d/fd", os.Getpid())
+	f, err := os.Open(name)
+	if err != nil {
+		logrus.WithError(err).Error("Error listing file descriptors")
+		return -1
 	}
-	return -1
+	defer f.Close()
+
+	var fdCount int
+	for {
+		names, err := f.Readdirnames(100)
+		fdCount += len(names)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			logrus.WithError(err).Error("Error listing file descriptors")
+			return -1
+		}
+	}
+	return fdCount
 }

--- a/pkg/fileutils/fileutils_linux.go
+++ b/pkg/fileutils/fileutils_linux.go
@@ -1,7 +1,4 @@
-//go:build linux || freebsd
-// +build linux freebsd
-
-package fileutils // import "github.com/docker/docker/pkg/fileutils"
+package fileutils
 
 import (
 	"fmt"

--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -216,3 +216,10 @@ func TestCreateIfNotExistsFile(t *testing.T) {
 		t.Fatalf("Should have been a file, seems it's not")
 	}
 }
+
+func BenchmarkGetTotalUsedFds(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = GetTotalUsedFds()
+	}
+}


### PR DESCRIPTION
- Backport of https://github.com/moby/moby/pull/45848

> **Warning**
> Slight conflicts due to a lack of:
> * https://github.com/moby/moby/pull/45799
> * https://github.com/moby/moby/pull/45475

---

- relates to https://github.com/moby/moby/issues/45842

### pkg/fileutils: GetTotalUsedFds(): don't pretend to support FreeBSD

Commit 8d56108ffb4e334600377c4bb4471eecec7b825c moved this function from
the generic (no build-tags) fileutils.go to a unix file, adding "freebsd"
to the build-tags.

This likely was a wrong assumption (as other files had freebsd build-tags).
FreeBSD's procfs does not mention `/proc/<pid>/fd` in the manpage, and
we don't test FreeBSD in CI, so let's drop it, and make this a Linux-only
file.

While updating also dropping the import-tag, as we're planning to move
this file internal to the daemon.


### pkg/fileutils: add BenchmarkGetTotalUsedFds

    go test -bench ^BenchmarkGetTotalUsedFds$ -run ^$ ./pkg/fileutils/
    goos: linux
    goarch: arm64
    pkg: github.com/docker/docker/pkg/fileutils
    BenchmarkGetTotalUsedFds-5   	  149272	      7896 ns/op	     945 B/op	      20 allocs/op

### pkg/fileutils: GetTotalUsedFds: reduce allocations

Use File.Readdirnames instead of os.ReadDir, as we're only interested in
the number of files, and results don't have to be sorted.

Before:

    BenchmarkGetTotalUsedFds-5            149272              7896 ns/op             945 B/op         20 allocs/op

After:

    BenchmarkGetTotalUsedFds-5            153517              7644 ns/op             408 B/op         10 allocs/op


### pkg/fileutils: GetTotalUsedFds(): use fast-path for Kernel 6.2 and up

Linux 6.2 and up (commit [f1f1f2569901ec5b9d425f2e91c09a0e320768f3][1])
provides a fast path for the number of open files for the process.

From the [Linux docs][2]:

> The number of open files for the process is stored in 'size' member of
> `stat()` output for /proc/<pid>/fd for fast access.

[1]: https://github.com/torvalds/linux/commit/f1f1f2569901ec5b9d425f2e91c09a0e320768f3
[2]: https://docs.kernel.org/filesystems/proc.html#proc-pid-fd-list-of-symlinks-to-open-files

This patch adds a fast-path for Kernels that support this, and falls back
to the slow path if the Size fields is zero.

Comparing on a Fedora 38 (kernel 6.2.9-300.fc38.x86_64):

Before/After:

    go test -bench ^BenchmarkGetTotalUsedFds$ -run ^$ ./pkg/fileutils/
    BenchmarkGetTotalUsedFds        57264     18595 ns/op     408 B/op      10 allocs/op
    BenchmarkGetTotalUsedFds       370392      3271 ns/op      40 B/op       3 allocs/op

Note that the slow path has 1 more file-descriptor, due to the open
file-handle for /proc/<pid>/fd during the calculation.

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

