### PR TITLE
[24.0 backport] docs: api: remove outdated information from ServerVersion

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5162,12 +5162,8 @@ definitions:
       ServerVersion:
         description: |
           Version string of the daemon.
-
-          > **Note**: the [standalone Swarm API](https://docs.docker.com/swarm/swarm-api/)
-          > returns the Swarm version instead of the daemon  version, for example
-          > `swarm/1.2.8`.
         type: "string"
-        example: "17.06.0-ce"
+        example: "24.0.2"
       Runtimes:
         description: |
           List of [OCI compliant](https://github.com/opencontainers/runtime-spec)

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -5100,12 +5100,8 @@ definitions:
       ServerVersion:
         description: |
           Version string of the daemon.
-
-          > **Note**: the [standalone Swarm API](https://docs.docker.com/swarm/swarm-api/)
-          > returns the Swarm version instead of the daemon  version, for example
-          > `swarm/1.2.8`.
         type: "string"
-        example: "17.06.0-ce"
+        example: "20.10.25"
       ClusterStore:
         description: |
           URL of the distributed storage backend.

--- a/docs/api/v1.42.yaml
+++ b/docs/api/v1.42.yaml
@@ -5130,12 +5130,8 @@ definitions:
       ServerVersion:
         description: |
           Version string of the daemon.
-
-          > **Note**: the [standalone Swarm API](https://docs.docker.com/swarm/swarm-api/)
-          > returns the Swarm version instead of the daemon  version, for example
-          > `swarm/1.2.8`.
         type: "string"
-        example: "17.06.0-ce"
+        example: "23.0.0"
       Runtimes:
         description: |
           List of [OCI compliant](https://github.com/opencontainers/runtime-spec)

--- a/docs/api/v1.43.yaml
+++ b/docs/api/v1.43.yaml
@@ -5162,12 +5162,8 @@ definitions:
       ServerVersion:
         description: |
           Version string of the daemon.
-
-          > **Note**: the [standalone Swarm API](https://docs.docker.com/swarm/swarm-api/)
-          > returns the Swarm version instead of the daemon  version, for example
-          > `swarm/1.2.8`.
         type: "string"
-        example: "17.06.0-ce"
+        example: "24.0.2"
       Runtimes:
         description: |
           List of [OCI compliant](https://github.com/opencontainers/runtime-spec)


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/45866


docs: api: remove outdated information from ServerVersion

This field's documentation was still referring to the Swarm V1 API, which
is deprecated, and the link redirects to SwarmKit.


**- A picture of a cute animal (not mandatory but encouraged)**

