### PR TITLE
libnetwork: remove dead / unused code from datastore and kvstore

### DIFF
--- a/libnetwork/agent.go
+++ b/libnetwork/agent.go
@@ -312,9 +312,9 @@ func (c *Controller) agentInit(listenAddr, bindAddrOrInterface, advertiseAddr, d
 	c.DiagnosticServer.RegisterHandler(nDB, networkdb.NetDbPaths2Func)
 
 	var cancelList []func()
-	ch, cancel := nDB.Watch(libnetworkEPTable, "", "")
+	ch, cancel := nDB.Watch(libnetworkEPTable, "")
 	cancelList = append(cancelList, cancel)
-	nodeCh, cancel := nDB.Watch(networkdb.NodeTable, "", "")
+	nodeCh, cancel := nDB.Watch(networkdb.NodeTable, "")
 	cancelList = append(cancelList, cancel)
 
 	c.mu.Lock()
@@ -783,7 +783,7 @@ func (n *network) addDriverWatches() {
 		return
 	}
 	for _, table := range n.driverTables {
-		ch, cancel := agent.networkDB.Watch(table.name, n.ID(), "")
+		ch, cancel := agent.networkDB.Watch(table.name, n.ID())
 		agent.Lock()
 		agent.driverCancelFuncs[n.ID()] = append(agent.driverCancelFuncs[n.ID()], cancel)
 		agent.Unlock()

--- a/libnetwork/cmd/networkdb-test/dummyclient/dummyClient.go
+++ b/libnetwork/cmd/networkdb-test/dummyclient/dummyClient.go
@@ -45,7 +45,7 @@ func watchTable(ctx interface{}, w http.ResponseWriter, r *http.Request) {
 
 	nDB, ok := ctx.(*networkdb.NetworkDB)
 	if ok {
-		ch, cancel := nDB.Watch(tableName, "", "")
+		ch, cancel := nDB.Watch(tableName, "")
 		clientWatchTable[tableName] = tableHandler{cancelWatch: cancel, entries: make(map[string]string)}
 		go handleTableEvents(tableName, ch)
 

--- a/libnetwork/config/config.go
+++ b/libnetwork/config/config.go
@@ -7,7 +7,6 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/docker/docker/libnetwork/cluster"
 	"github.com/docker/docker/libnetwork/datastore"
-	store "github.com/docker/docker/libnetwork/internal/kvstore"
 	"github.com/docker/docker/libnetwork/ipamutils"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/osl"
@@ -139,30 +138,6 @@ func OptionNetworkControlPlaneMTU(exp int) Option {
 // IsValidName validates configuration objects supported by libnetwork
 func IsValidName(name string) bool {
 	return strings.TrimSpace(name) != ""
-}
-
-// OptionLocalKVProvider function returns an option setter for kvstore provider
-func OptionLocalKVProvider(provider string) Option {
-	return func(c *Config) {
-		log.G(context.TODO()).Debugf("Option OptionLocalKVProvider: %s", provider)
-		c.Scope.Client.Provider = strings.TrimSpace(provider)
-	}
-}
-
-// OptionLocalKVProviderURL function returns an option setter for kvstore url
-func OptionLocalKVProviderURL(url string) Option {
-	return func(c *Config) {
-		log.G(context.TODO()).Debugf("Option OptionLocalKVProviderURL: %s", url)
-		c.Scope.Client.Address = strings.TrimSpace(url)
-	}
-}
-
-// OptionLocalKVProviderConfig function returns an option setter for kvstore config
-func OptionLocalKVProviderConfig(config *store.Config) Option {
-	return func(c *Config) {
-		log.G(context.TODO()).Debugf("Option OptionLocalKVProviderConfig: %v", config)
-		c.Scope.Client.Config = config
-	}
 }
 
 // OptionActiveSandboxes function returns an option setter for passing the sandboxes

--- a/libnetwork/datastore/cache.go
+++ b/libnetwork/datastore/cache.go
@@ -138,7 +138,7 @@ func (c *cache) del(kvObject KVObject, atomic bool) error {
 	return nil
 }
 
-func (c *cache) get(key string, kvObject KVObject) error {
+func (c *cache) get(kvObject KVObject) error {
 	kmap, err := c.kmap(kvObject)
 	if err != nil {
 		return err

--- a/libnetwork/datastore/datastore.go
+++ b/libnetwork/datastore/datastore.go
@@ -41,10 +41,10 @@ var (
 )
 
 type datastore struct {
+	mu    sync.Mutex
 	scope string
 	store store.Store
 	cache *cache
-	sync.Mutex
 }
 
 // KVObject is Key/Value interface used by objects to be part of the DataStore
@@ -254,8 +254,8 @@ func (ds *datastore) PutObjectAtomic(kvObject KVObject) error {
 		pair     *store.KVPair
 		err      error
 	)
-	ds.Lock()
-	defer ds.Unlock()
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
 
 	if kvObject == nil {
 		return types.BadRequestErrorf("invalid KV Object : nil")
@@ -299,8 +299,8 @@ add_cache:
 
 // GetObject returns a record matching the key
 func (ds *datastore) GetObject(key string, o KVObject) error {
-	ds.Lock()
-	defer ds.Unlock()
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
 
 	if ds.cache != nil {
 		return ds.cache.get(o)
@@ -333,8 +333,8 @@ func (ds *datastore) ensureParent(parent string) error {
 }
 
 func (ds *datastore) List(key string, kvObject KVObject) ([]KVObject, error) {
-	ds.Lock()
-	defer ds.Unlock()
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
 
 	if ds.cache != nil {
 		return ds.cache.list(kvObject)
@@ -388,8 +388,8 @@ func (ds *datastore) iterateKVPairsFromStore(key string, kvObject KVObject, call
 }
 
 func (ds *datastore) Map(key string, kvObject KVObject) (map[string]KVObject, error) {
-	ds.Lock()
-	defer ds.Unlock()
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
 
 	kvol := make(map[string]KVObject)
 	cb := func(key string, val KVObject) {
@@ -405,8 +405,8 @@ func (ds *datastore) Map(key string, kvObject KVObject) (map[string]KVObject, er
 
 // DeleteObjectAtomic performs atomic delete on a record
 func (ds *datastore) DeleteObjectAtomic(kvObject KVObject) error {
-	ds.Lock()
-	defer ds.Unlock()
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
 
 	if kvObject == nil {
 		return types.BadRequestErrorf("invalid KV Object : nil")

--- a/libnetwork/datastore/datastore.go
+++ b/libnetwork/datastore/datastore.go
@@ -20,8 +20,6 @@ type DataStore interface {
 	PutObjectAtomic(kvObject KVObject) error
 	// DeleteObjectAtomic performs an atomic delete operation
 	DeleteObjectAtomic(kvObject KVObject) error
-	// DeleteTree deletes a record
-	DeleteTree(kvObject KVObject) error
 	// List returns of a list of KVObjects belonging to the parent
 	// key. The caller must pass a KVObject of the same type as
 	// the objects that need to be listed
@@ -436,23 +434,4 @@ del_cache:
 	}
 
 	return nil
-}
-
-// DeleteTree unconditionally deletes a record from the store
-func (ds *datastore) DeleteTree(kvObject KVObject) error {
-	ds.Lock()
-	defer ds.Unlock()
-
-	// cleanup the cache first
-	if ds.cache != nil {
-		// If persistent store is skipped, sequencing needs to
-		// happen in cache.
-		ds.cache.del(kvObject, kvObject.Skip())
-	}
-
-	if kvObject.Skip() {
-		return nil
-	}
-
-	return ds.store.DeleteTree(Key(kvObject.KeyPrefix()...))
 }

--- a/libnetwork/datastore/datastore.go
+++ b/libnetwork/datastore/datastore.go
@@ -54,11 +54,10 @@ var (
 )
 
 type datastore struct {
-	scope      string
-	store      store.Store
-	cache      *cache
-	watchCh    chan struct{}
-	sequential bool
+	scope   string
+	store   store.Store
+	cache   *cache
+	watchCh chan struct{}
 	sync.Mutex
 }
 
@@ -207,7 +206,7 @@ func newClient(kv string, addr string, config *store.Config) (DataStore, error) 
 		return nil, err
 	}
 
-	ds := &datastore{scope: LocalScope, store: s, watchCh: make(chan struct{}), sequential: true}
+	ds := &datastore{scope: LocalScope, store: s, watchCh: make(chan struct{})}
 	ds.cache = newCache(ds)
 
 	return ds, nil
@@ -346,10 +345,8 @@ func (ds *datastore) PutObjectAtomic(kvObject KVObject) error {
 		pair     *store.KVPair
 		err      error
 	)
-	if ds.sequential {
-		ds.Lock()
-		defer ds.Unlock()
-	}
+	ds.Lock()
+	defer ds.Unlock()
 
 	if kvObject == nil {
 		return types.BadRequestErrorf("invalid KV Object : nil")
@@ -393,10 +390,8 @@ add_cache:
 
 // PutObject adds a new Record based on an object into the datastore
 func (ds *datastore) PutObject(kvObject KVObject) error {
-	if ds.sequential {
-		ds.Lock()
-		defer ds.Unlock()
-	}
+	ds.Lock()
+	defer ds.Unlock()
 
 	if kvObject == nil {
 		return types.BadRequestErrorf("invalid KV Object : nil")
@@ -431,10 +426,8 @@ func (ds *datastore) putObjectWithKey(kvObject KVObject, key ...string) error {
 
 // GetObject returns a record matching the key
 func (ds *datastore) GetObject(key string, o KVObject) error {
-	if ds.sequential {
-		ds.Lock()
-		defer ds.Unlock()
-	}
+	ds.Lock()
+	defer ds.Unlock()
 
 	if ds.cache != nil {
 		return ds.cache.get(key, o)
@@ -467,10 +460,8 @@ func (ds *datastore) ensureParent(parent string) error {
 }
 
 func (ds *datastore) List(key string, kvObject KVObject) ([]KVObject, error) {
-	if ds.sequential {
-		ds.Lock()
-		defer ds.Unlock()
-	}
+	ds.Lock()
+	defer ds.Unlock()
 
 	if ds.cache != nil {
 		return ds.cache.list(kvObject)
@@ -524,10 +515,8 @@ func (ds *datastore) iterateKVPairsFromStore(key string, kvObject KVObject, call
 }
 
 func (ds *datastore) Map(key string, kvObject KVObject) (map[string]KVObject, error) {
-	if ds.sequential {
-		ds.Lock()
-		defer ds.Unlock()
-	}
+	ds.Lock()
+	defer ds.Unlock()
 
 	kvol := make(map[string]KVObject)
 	cb := func(key string, val KVObject) {
@@ -543,10 +532,8 @@ func (ds *datastore) Map(key string, kvObject KVObject) (map[string]KVObject, er
 
 // DeleteObject unconditionally deletes a record from the store
 func (ds *datastore) DeleteObject(kvObject KVObject) error {
-	if ds.sequential {
-		ds.Lock()
-		defer ds.Unlock()
-	}
+	ds.Lock()
+	defer ds.Unlock()
 
 	// cleanup the cache first
 	if ds.cache != nil {
@@ -564,10 +551,8 @@ func (ds *datastore) DeleteObject(kvObject KVObject) error {
 
 // DeleteObjectAtomic performs atomic delete on a record
 func (ds *datastore) DeleteObjectAtomic(kvObject KVObject) error {
-	if ds.sequential {
-		ds.Lock()
-		defer ds.Unlock()
-	}
+	ds.Lock()
+	defer ds.Unlock()
 
 	if kvObject == nil {
 		return types.BadRequestErrorf("invalid KV Object : nil")
@@ -599,10 +584,8 @@ del_cache:
 
 // DeleteTree unconditionally deletes a record from the store
 func (ds *datastore) DeleteTree(kvObject KVObject) error {
-	if ds.sequential {
-		ds.Lock()
-		defer ds.Unlock()
-	}
+	ds.Lock()
+	defer ds.Unlock()
 
 	// cleanup the cache first
 	if ds.cache != nil {

--- a/libnetwork/datastore/datastore.go
+++ b/libnetwork/datastore/datastore.go
@@ -590,7 +590,7 @@ func (ds *datastore) DeleteObjectAtomic(kvObject KVObject) error {
 		goto del_cache
 	}
 
-	if _, err := ds.store.AtomicDelete(Key(kvObject.Key()...), previous); err != nil {
+	if err := ds.store.AtomicDelete(Key(kvObject.Key()...), previous); err != nil {
 		if err == store.ErrKeyExists {
 			return ErrKeyModified
 		}

--- a/libnetwork/datastore/datastore.go
+++ b/libnetwork/datastore/datastore.go
@@ -382,7 +382,7 @@ func (ds *datastore) PutObjectAtomic(kvObject KVObject) error {
 		previous = nil
 	}
 
-	_, pair, err = ds.store.AtomicPut(Key(kvObject.Key()...), kvObjValue, previous, nil)
+	_, pair, err = ds.store.AtomicPut(Key(kvObject.Key()...), kvObjValue, previous)
 	if err != nil {
 		if err == store.ErrKeyExists {
 			return ErrKeyModified
@@ -437,7 +437,7 @@ func (ds *datastore) putObjectWithKey(kvObject KVObject, key ...string) error {
 	if kvObjValue == nil {
 		return types.BadRequestErrorf("invalid KV Object with a nil Value for key %s", Key(kvObject.Key()...))
 	}
-	return ds.store.Put(Key(key...), kvObjValue, nil)
+	return ds.store.Put(Key(key...), kvObjValue)
 }
 
 // GetObject returns a record matching the key
@@ -474,7 +474,7 @@ func (ds *datastore) ensureParent(parent string) error {
 	if exists {
 		return nil
 	}
-	return ds.store.Put(parent, []byte{}, &store.WriteOptions{IsDir: true})
+	return ds.store.Put(parent, []byte{})
 }
 
 func (ds *datastore) List(key string, kvObject KVObject) ([]KVObject, error) {

--- a/libnetwork/datastore/datastore.go
+++ b/libnetwork/datastore/datastore.go
@@ -382,7 +382,7 @@ func (ds *datastore) PutObjectAtomic(kvObject KVObject) error {
 		previous = nil
 	}
 
-	_, pair, err = ds.store.AtomicPut(Key(kvObject.Key()...), kvObjValue, previous)
+	pair, err = ds.store.AtomicPut(Key(kvObject.Key()...), kvObjValue, previous)
 	if err != nil {
 		if err == store.ErrKeyExists {
 			return ErrKeyModified

--- a/libnetwork/datastore/datastore.go
+++ b/libnetwork/datastore/datastore.go
@@ -430,7 +430,7 @@ func (ds *datastore) GetObject(key string, o KVObject) error {
 	defer ds.Unlock()
 
 	if ds.cache != nil {
-		return ds.cache.get(key, o)
+		return ds.cache.get(o)
 	}
 
 	kvPair, err := ds.store.Get(key)

--- a/libnetwork/datastore/datastore_test.go
+++ b/libnetwork/datastore/datastore_test.go
@@ -51,7 +51,7 @@ func TestInvalidDataStore(t *testing.T) {
 func TestKVObjectFlatKey(t *testing.T) {
 	store := NewTestDataStore()
 	expected := dummyKVObject("1000", true)
-	err := store.PutObject(expected)
+	err := store.PutObjectAtomic(expected)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/datastore/mock_store.go
+++ b/libnetwork/datastore/mock_store.go
@@ -48,12 +48,6 @@ func (s *MockStore) Put(key string, value []byte) error {
 	return nil
 }
 
-// Delete a value at "key"
-func (s *MockStore) Delete(key string) error {
-	delete(s.db, key)
-	return nil
-}
-
 // Exists checks that the key exists inside the store
 func (s *MockStore) Exists(key string) (bool, error) {
 	_, ok := s.db[key]
@@ -95,7 +89,8 @@ func (s *MockStore) AtomicDelete(key string, previous *store.KVPair) error {
 	if mData != nil && mData.Index != previous.LastIndex {
 		return types.BadRequestErrorf("atomic delete failed due to mismatched Index")
 	}
-	return s.Delete(key)
+	delete(s.db, key)
+	return nil
 }
 
 // Close closes the client connection

--- a/libnetwork/datastore/mock_store.go
+++ b/libnetwork/datastore/mock_store.go
@@ -65,11 +65,6 @@ func (s *MockStore) List(prefix string) ([]*store.KVPair, error) {
 	return nil, ErrNotImplemented
 }
 
-// Watch a single key for modifications
-func (s *MockStore) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
-	return nil, ErrNotImplemented
-}
-
 // AtomicPut put a value at "key" if the key has not been
 // modified in the meantime, throws an error if this is the case
 func (s *MockStore) AtomicPut(key string, newValue []byte, previous *store.KVPair) (*store.KVPair, error) {

--- a/libnetwork/datastore/mock_store.go
+++ b/libnetwork/datastore/mock_store.go
@@ -101,12 +101,12 @@ func (s *MockStore) AtomicPut(key string, newValue []byte, previous *store.KVPai
 
 // AtomicDelete deletes a value at "key" if the key has not
 // been modified in the meantime, throws an error if this is the case
-func (s *MockStore) AtomicDelete(key string, previous *store.KVPair) (bool, error) {
+func (s *MockStore) AtomicDelete(key string, previous *store.KVPair) error {
 	mData := s.db[key]
 	if mData != nil && mData.Index != previous.LastIndex {
-		return false, types.BadRequestErrorf("atomic delete failed due to mismatched Index")
+		return types.BadRequestErrorf("atomic delete failed due to mismatched Index")
 	}
-	return true, s.Delete(key)
+	return s.Delete(key)
 }
 
 // Close closes the client connection

--- a/libnetwork/datastore/mock_store.go
+++ b/libnetwork/datastore/mock_store.go
@@ -38,7 +38,7 @@ func (s *MockStore) Get(key string) (*store.KVPair, error) {
 }
 
 // Put a value at "key"
-func (s *MockStore) Put(key string, value []byte, options *store.WriteOptions) error {
+func (s *MockStore) Put(key string, value []byte) error {
 	mData := s.db[key]
 	if mData == nil {
 		mData = &MockData{value, 0}
@@ -78,7 +78,7 @@ func (s *MockStore) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVP
 
 // AtomicPut put a value at "key" if the key has not been
 // modified in the meantime, throws an error if this is the case
-func (s *MockStore) AtomicPut(key string, newValue []byte, previous *store.KVPair, options *store.WriteOptions) (bool, *store.KVPair, error) {
+func (s *MockStore) AtomicPut(key string, newValue []byte, previous *store.KVPair) (bool, *store.KVPair, error) {
 	mData := s.db[key]
 
 	if previous == nil {
@@ -93,7 +93,7 @@ func (s *MockStore) AtomicPut(key string, newValue []byte, previous *store.KVPai
 			return false, nil, types.BadRequestErrorf("atomic put failed due to mismatched Index")
 		} // Else OK.
 	}
-	err := s.Put(key, newValue, nil)
+	err := s.Put(key, newValue)
 	if err != nil {
 		return false, nil, err
 	}

--- a/libnetwork/datastore/mock_store.go
+++ b/libnetwork/datastore/mock_store.go
@@ -65,12 +65,6 @@ func (s *MockStore) List(prefix string) ([]*store.KVPair, error) {
 	return nil, ErrNotImplemented
 }
 
-// DeleteTree deletes a range of values at "directory"
-func (s *MockStore) DeleteTree(prefix string) error {
-	delete(s.db, prefix)
-	return nil
-}
-
 // Watch a single key for modifications
 func (s *MockStore) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
 	return nil, ErrNotImplemented

--- a/libnetwork/datastore/mock_store.go
+++ b/libnetwork/datastore/mock_store.go
@@ -76,16 +76,6 @@ func (s *MockStore) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVP
 	return nil, ErrNotImplemented
 }
 
-// WatchTree triggers a watch on a range of values at "directory"
-func (s *MockStore) WatchTree(prefix string, stopCh <-chan struct{}) (<-chan []*store.KVPair, error) {
-	return nil, ErrNotImplemented
-}
-
-// NewLock exposed
-func (s *MockStore) NewLock(key string, options *store.LockOptions) (store.Locker, error) {
-	return nil, ErrNotImplemented
-}
-
 // AtomicPut put a value at "key" if the key has not been
 // modified in the meantime, throws an error if this is the case
 func (s *MockStore) AtomicPut(key string, newValue []byte, previous *store.KVPair, options *store.WriteOptions) (bool, *store.KVPair, error) {

--- a/libnetwork/internal/kvstore/boltdb/boltdb.go
+++ b/libnetwork/internal/kvstore/boltdb/boltdb.go
@@ -178,26 +178,6 @@ func (b *BoltDB) Put(key string, value []byte) error {
 	})
 }
 
-// Delete the value for the given key.
-func (b *BoltDB) Delete(key string) error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	db, err := b.getDBhandle()
-	if err != nil {
-		return err
-	}
-	defer b.releaseDBhandle()
-
-	return db.Update(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(b.boltBucket)
-		if bucket == nil {
-			return store.ErrKeyNotFound
-		}
-		return bucket.Delete([]byte(key))
-	})
-}
-
 // Exists checks if the key exists inside the store
 func (b *BoltDB) Exists(key string) (bool, error) {
 	b.mu.Lock()

--- a/libnetwork/internal/kvstore/boltdb/boltdb.go
+++ b/libnetwork/internal/kvstore/boltdb/boltdb.go
@@ -369,8 +369,3 @@ func (b *BoltDB) Close() {
 		b.client.Close()
 	}
 }
-
-// Watch has to implemented at the library level since its not supported by BoltDB
-func (b *BoltDB) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
-	return nil, store.ErrCallNotSupported
-}

--- a/libnetwork/internal/kvstore/boltdb/boltdb.go
+++ b/libnetwork/internal/kvstore/boltdb/boltdb.go
@@ -370,38 +370,6 @@ func (b *BoltDB) Close() {
 	}
 }
 
-// DeleteTree deletes a range of keys with a given prefix
-func (b *BoltDB) DeleteTree(keyPrefix string) error {
-	var (
-		db  *bolt.DB
-		err error
-	)
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	if db, err = b.getDBhandle(); err != nil {
-		return err
-	}
-	defer b.releaseDBhandle()
-
-	err = db.Update(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(b.boltBucket)
-		if bucket == nil {
-			return store.ErrKeyNotFound
-		}
-
-		cursor := bucket.Cursor()
-		prefix := []byte(keyPrefix)
-
-		for key, _ := cursor.Seek(prefix); bytes.HasPrefix(key, prefix); key, _ = cursor.Next() {
-			_ = bucket.Delete(key)
-		}
-		return nil
-	})
-
-	return err
-}
-
 // Watch has to implemented at the library level since its not supported by BoltDB
 func (b *BoltDB) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
 	return nil, store.ErrCallNotSupported

--- a/libnetwork/internal/kvstore/boltdb/boltdb.go
+++ b/libnetwork/internal/kvstore/boltdb/boltdb.go
@@ -456,17 +456,7 @@ func (b *BoltDB) DeleteTree(keyPrefix string) error {
 	return err
 }
 
-// NewLock has to implemented at the library level since its not supported by BoltDB
-func (b *BoltDB) NewLock(key string, options *store.LockOptions) (store.Locker, error) {
-	return nil, store.ErrCallNotSupported
-}
-
 // Watch has to implemented at the library level since its not supported by BoltDB
 func (b *BoltDB) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
-	return nil, store.ErrCallNotSupported
-}
-
-// WatchTree has to implemented at the library level since its not supported by BoltDB
-func (b *BoltDB) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*store.KVPair, error) {
 	return nil, store.ErrCallNotSupported
 }

--- a/libnetwork/internal/kvstore/boltdb/boltdb.go
+++ b/libnetwork/internal/kvstore/boltdb/boltdb.go
@@ -22,9 +22,7 @@ var (
 	ErrBoltBucketOptionMissing = errors.New("boltBucket config option missing")
 )
 
-const (
-	filePerm os.FileMode = 0644
-)
+const filePerm = 0o644
 
 // BoltDB type implements the Store interface
 type BoltDB struct {
@@ -54,13 +52,6 @@ func Register() {
 
 // New opens a new BoltDB connection to the specified path and bucket
 func New(endpoints []string, options *store.Config) (store.Store, error) {
-	var (
-		db          *bolt.DB
-		err         error
-		boltOptions *bolt.Options
-		timeout     = transientTimeout
-	)
-
 	if len(endpoints) > 1 {
 		return nil, ErrMultipleEndpointsUnsupported
 	}
@@ -70,18 +61,22 @@ func New(endpoints []string, options *store.Config) (store.Store, error) {
 	}
 
 	dir, _ := filepath.Split(endpoints[0])
-	if err = os.MkdirAll(dir, 0750); err != nil {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return nil, err
 	}
 
+	var db *bolt.DB
 	if options.PersistConnection {
-		boltOptions = &bolt.Options{Timeout: options.ConnectionTimeout}
-		db, err = bolt.Open(endpoints[0], filePerm, boltOptions)
+		var err error
+		db, err = bolt.Open(endpoints[0], filePerm, &bolt.Options{
+			Timeout: options.ConnectionTimeout,
+		})
 		if err != nil {
 			return nil, err
 		}
 	}
 
+	timeout := transientTimeout
 	if options.ConnectionTimeout != 0 {
 		timeout = options.ConnectionTimeout
 	}
@@ -103,18 +98,13 @@ func (b *BoltDB) reset() {
 }
 
 func (b *BoltDB) getDBhandle() (*bolt.DB, error) {
-	var (
-		db  *bolt.DB
-		err error
-	)
 	if !b.PersistConnection {
-		boltOptions := &bolt.Options{Timeout: b.timeout}
-		if db, err = bolt.Open(b.path, filePerm, boltOptions); err != nil {
+		db, err := bolt.Open(b.path, filePerm, &bolt.Options{Timeout: b.timeout})
+		if err != nil {
 			return nil, err
 		}
 		b.client = db
 	}
-
 	return b.client, nil
 }
 
@@ -127,19 +117,16 @@ func (b *BoltDB) releaseDBhandle() {
 // Get the value at "key". BoltDB doesn't provide an inbuilt last modified index with every kv pair. Its implemented by
 // by a atomic counter maintained by the libkv and appened to the value passed by the client.
 func (b *BoltDB) Get(key string) (*store.KVPair, error) {
-	var (
-		val []byte
-		db  *bolt.DB
-		err error
-	)
 	b.Lock()
 	defer b.Unlock()
 
-	if db, err = b.getDBhandle(); err != nil {
+	db, err := b.getDBhandle()
+	if err != nil {
 		return nil, err
 	}
 	defer b.releaseDBhandle()
 
+	var val []byte
 	err = db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(b.boltBucket)
 		if bucket == nil {
@@ -163,100 +150,78 @@ func (b *BoltDB) Get(key string) (*store.KVPair, error) {
 	dbIndex := binary.LittleEndian.Uint64(val[:libkvmetadatalen])
 	val = val[libkvmetadatalen:]
 
-	return &store.KVPair{Key: key, Value: val, LastIndex: (dbIndex)}, nil
+	return &store.KVPair{Key: key, Value: val, LastIndex: dbIndex}, nil
 }
 
 // Put the key, value pair. index number metadata is prepended to the value
 func (b *BoltDB) Put(key string, value []byte) error {
-	var (
-		dbIndex uint64
-		db      *bolt.DB
-		err     error
-	)
 	b.Lock()
 	defer b.Unlock()
 
-	dbval := make([]byte, libkvmetadatalen)
-
-	if db, err = b.getDBhandle(); err != nil {
+	db, err := b.getDBhandle()
+	if err != nil {
 		return err
 	}
 	defer b.releaseDBhandle()
 
-	err = db.Update(func(tx *bolt.Tx) error {
+	return db.Update(func(tx *bolt.Tx) error {
 		bucket, err := tx.CreateBucketIfNotExists(b.boltBucket)
 		if err != nil {
 			return err
 		}
 
-		dbIndex = atomic.AddUint64(&b.dbIndex, 1)
+		dbIndex := atomic.AddUint64(&b.dbIndex, 1)
+		dbval := make([]byte, libkvmetadatalen)
 		binary.LittleEndian.PutUint64(dbval, dbIndex)
 		dbval = append(dbval, value...)
 
-		err = bucket.Put([]byte(key), dbval)
-		if err != nil {
-			return err
-		}
-		return nil
+		return bucket.Put([]byte(key), dbval)
 	})
-	return err
 }
 
 // Delete the value for the given key.
 func (b *BoltDB) Delete(key string) error {
-	var (
-		db  *bolt.DB
-		err error
-	)
 	b.Lock()
 	defer b.Unlock()
 
-	if db, err = b.getDBhandle(); err != nil {
+	db, err := b.getDBhandle()
+	if err != nil {
 		return err
 	}
 	defer b.releaseDBhandle()
 
-	err = db.Update(func(tx *bolt.Tx) error {
+	return db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(b.boltBucket)
 		if bucket == nil {
 			return store.ErrKeyNotFound
 		}
-		err := bucket.Delete([]byte(key))
-		return err
+		return bucket.Delete([]byte(key))
 	})
-	return err
 }
 
 // Exists checks if the key exists inside the store
 func (b *BoltDB) Exists(key string) (bool, error) {
-	var (
-		val []byte
-		db  *bolt.DB
-		err error
-	)
 	b.Lock()
 	defer b.Unlock()
 
-	if db, err = b.getDBhandle(); err != nil {
+	db, err := b.getDBhandle()
+	if err != nil {
 		return false, err
 	}
 	defer b.releaseDBhandle()
 
+	var exists bool
 	err = db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(b.boltBucket)
 		if bucket == nil {
 			return store.ErrKeyNotFound
 		}
 
-		val = bucket.Get([]byte(key))
-
+		exists = len(bucket.Get([]byte(key))) > 0
 		return nil
 	})
 
-	if len(val) == 0 {
-		return false, err
-	}
-	return true, err
+	return exists, err
 }
 
 // List returns the range of keys starting with the passed in prefix
@@ -342,29 +307,24 @@ func (b *BoltDB) AtomicDelete(key string, previous *store.KVPair) error {
 // AtomicPut puts a value at "key" if the key has not been
 // modified since the last Put, throws an error if this is the case
 func (b *BoltDB) AtomicPut(key string, value []byte, previous *store.KVPair) (*store.KVPair, error) {
-	var (
-		val     []byte
-		dbIndex uint64
-		db      *bolt.DB
-		err     error
-	)
 	b.Lock()
 	defer b.Unlock()
 
-	dbval := make([]byte, libkvmetadatalen)
-
-	if db, err = b.getDBhandle(); err != nil {
+	db, err := b.getDBhandle()
+	if err != nil {
 		return nil, err
 	}
 	defer b.releaseDBhandle()
 
+	var dbIndex uint64
+	dbval := make([]byte, libkvmetadatalen)
 	err = db.Update(func(tx *bolt.Tx) error {
-		var err error
 		bucket := tx.Bucket(b.boltBucket)
 		if bucket == nil {
 			if previous != nil {
 				return store.ErrKeyNotFound
 			}
+			var err error
 			bucket, err = tx.CreateBucket(b.boltBucket)
 			if err != nil {
 				return err
@@ -372,7 +332,7 @@ func (b *BoltDB) AtomicPut(key string, value []byte, previous *store.KVPair) (*s
 		}
 		// AtomicPut is equivalent to Put if previous is nil and the Ky
 		// doesn't exist in the DB.
-		val = bucket.Get([]byte(key))
+		val := bucket.Get([]byte(key))
 		if previous == nil && len(val) != 0 {
 			return store.ErrKeyExists
 		}
@@ -388,7 +348,7 @@ func (b *BoltDB) AtomicPut(key string, value []byte, previous *store.KVPair) (*s
 		dbIndex = atomic.AddUint64(&b.dbIndex, 1)
 		binary.LittleEndian.PutUint64(dbval, b.dbIndex)
 		dbval = append(dbval, value...)
-		return (bucket.Put([]byte(key), dbval))
+		return bucket.Put([]byte(key), dbval)
 	})
 	if err != nil {
 		return nil, err

--- a/libnetwork/internal/kvstore/boltdb/boltdb.go
+++ b/libnetwork/internal/kvstore/boltdb/boltdb.go
@@ -350,7 +350,7 @@ func (b *BoltDB) AtomicDelete(key string, previous *store.KVPair) (bool, error) 
 
 // AtomicPut puts a value at "key" if the key has not been
 // modified since the last Put, throws an error if this is the case
-func (b *BoltDB) AtomicPut(key string, value []byte, previous *store.KVPair) (bool, *store.KVPair, error) {
+func (b *BoltDB) AtomicPut(key string, value []byte, previous *store.KVPair) (*store.KVPair, error) {
 	var (
 		val     []byte
 		dbIndex uint64
@@ -363,7 +363,7 @@ func (b *BoltDB) AtomicPut(key string, value []byte, previous *store.KVPair) (bo
 	dbval := make([]byte, libkvmetadatalen)
 
 	if db, err = b.getDBhandle(); err != nil {
-		return false, nil, err
+		return nil, err
 	}
 	defer b.releaseDBhandle()
 
@@ -400,16 +400,9 @@ func (b *BoltDB) AtomicPut(key string, value []byte, previous *store.KVPair) (bo
 		return (bucket.Put([]byte(key), dbval))
 	})
 	if err != nil {
-		return false, nil, err
+		return nil, err
 	}
-
-	updated := &store.KVPair{
-		Key:       key,
-		Value:     value,
-		LastIndex: dbIndex,
-	}
-
-	return true, updated, nil
+	return &store.KVPair{Key: key, Value: value, LastIndex: dbIndex}, nil
 }
 
 // Close the db connection to the BoltDB

--- a/libnetwork/internal/kvstore/boltdb/boltdb.go
+++ b/libnetwork/internal/kvstore/boltdb/boltdb.go
@@ -167,7 +167,7 @@ func (b *BoltDB) Get(key string) (*store.KVPair, error) {
 }
 
 // Put the key, value pair. index number metadata is prepended to the value
-func (b *BoltDB) Put(key string, value []byte, opts *store.WriteOptions) error {
+func (b *BoltDB) Put(key string, value []byte) error {
 	var (
 		dbIndex uint64
 		db      *bolt.DB
@@ -350,7 +350,7 @@ func (b *BoltDB) AtomicDelete(key string, previous *store.KVPair) (bool, error) 
 
 // AtomicPut puts a value at "key" if the key has not been
 // modified since the last Put, throws an error if this is the case
-func (b *BoltDB) AtomicPut(key string, value []byte, previous *store.KVPair, options *store.WriteOptions) (bool, *store.KVPair, error) {
+func (b *BoltDB) AtomicPut(key string, value []byte, previous *store.KVPair) (bool, *store.KVPair, error) {
 	var (
 		val     []byte
 		dbIndex uint64

--- a/libnetwork/internal/kvstore/boltdb/boltdb.go
+++ b/libnetwork/internal/kvstore/boltdb/boltdb.go
@@ -139,12 +139,11 @@ func (b *BoltDB) Get(key string) (*store.KVPair, error) {
 
 		return nil
 	})
-
-	if len(val) == 0 {
-		return nil, store.ErrKeyNotFound
-	}
 	if err != nil {
 		return nil, err
+	}
+	if len(val) == 0 {
+		return nil, store.ErrKeyNotFound
 	}
 
 	dbIndex := binary.LittleEndian.Uint64(val[:libkvmetadatalen])

--- a/libnetwork/internal/kvstore/boltdb/boltdb.go
+++ b/libnetwork/internal/kvstore/boltdb/boltdb.go
@@ -220,8 +220,13 @@ func (b *BoltDB) Exists(key string) (bool, error) {
 		exists = len(bucket.Get([]byte(key))) > 0
 		return nil
 	})
-
-	return exists, err
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		return false, store.ErrKeyNotFound
+	}
+	return true, nil
 }
 
 // List returns the range of keys starting with the passed in prefix

--- a/libnetwork/internal/kvstore/kvstore.go
+++ b/libnetwork/internal/kvstore/kvstore.go
@@ -64,7 +64,7 @@ type Store interface {
 	AtomicPut(key string, value []byte, previous *KVPair) (*KVPair, error)
 
 	// AtomicDelete performs an atomic delete of a single value.
-	AtomicDelete(key string, previous *KVPair) (bool, error)
+	AtomicDelete(key string, previous *KVPair) error
 
 	// Close the store connection
 	Close()

--- a/libnetwork/internal/kvstore/kvstore.go
+++ b/libnetwork/internal/kvstore/kvstore.go
@@ -53,15 +53,6 @@ type Store interface {
 	// Watch for changes on a key
 	Watch(key string, stopCh <-chan struct{}) (<-chan *KVPair, error)
 
-	// WatchTree watches for changes on child nodes under
-	// a given directory
-	WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*KVPair, error)
-
-	// NewLock creates a lock for a given key.
-	// The returned Locker is not held and must be acquired
-	// with `.Lock`. The Value is optional.
-	NewLock(key string, options *LockOptions) (Locker, error)
-
 	// List the content of a given prefix
 	List(directory string) ([]*KVPair, error)
 
@@ -90,18 +81,4 @@ type KVPair struct {
 type WriteOptions struct {
 	IsDir bool
 	TTL   time.Duration
-}
-
-// LockOptions contains optional request parameters
-type LockOptions struct {
-	Value     []byte        // Optional, value to associate with the lock
-	TTL       time.Duration // Optional, expiration ttl associated with the lock
-	RenewLock chan struct{} // Optional, chan used to control and stop the session ttl renewal for the lock
-}
-
-// Locker provides locking mechanism on top of the store.
-// Similar to `sync.Lock` except it may return errors.
-type Locker interface {
-	Lock(stopChan chan struct{}) (<-chan struct{}, error)
-	Unlock() error
 }

--- a/libnetwork/internal/kvstore/kvstore.go
+++ b/libnetwork/internal/kvstore/kvstore.go
@@ -1,7 +1,6 @@
 package kvstore
 
 import (
-	"crypto/tls"
 	"errors"
 	"time"
 )
@@ -29,21 +28,9 @@ var (
 
 // Config contains the options for a storage client
 type Config struct {
-	ClientTLS         *ClientTLSConfig
-	TLS               *tls.Config
 	ConnectionTimeout time.Duration
 	Bucket            string
 	PersistConnection bool
-	Username          string
-	Password          string
-}
-
-// ClientTLSConfig contains data for a Client TLS configuration in the form
-// the etcd client wants it.  Eventually we'll adapt it for ZK and Consul.
-type ClientTLSConfig struct {
-	CertFile   string
-	KeyFile    string
-	CACertFile string
 }
 
 // Store represents the backend K/V storage

--- a/libnetwork/internal/kvstore/kvstore.go
+++ b/libnetwork/internal/kvstore/kvstore.go
@@ -56,9 +56,6 @@ type Store interface {
 	// List the content of a given prefix
 	List(directory string) ([]*KVPair, error)
 
-	// DeleteTree deletes a range of keys under a given directory
-	DeleteTree(directory string) error
-
 	// AtomicPut performs an atomic CAS operation on a single value.
 	// Pass previous = nil to create a new key.
 	AtomicPut(key string, value []byte, previous *KVPair) (*KVPair, error)

--- a/libnetwork/internal/kvstore/kvstore.go
+++ b/libnetwork/internal/kvstore/kvstore.go
@@ -42,9 +42,6 @@ type Store interface {
 	// Get a value given its key
 	Get(key string) (*KVPair, error)
 
-	// Delete the value at the specified key
-	Delete(key string) error
-
 	// Exists verifies if a Key exists in the store.
 	Exists(key string) (bool, error)
 

--- a/libnetwork/internal/kvstore/kvstore.go
+++ b/libnetwork/internal/kvstore/kvstore.go
@@ -47,7 +47,7 @@ type Store interface {
 	// Delete the value at the specified key
 	Delete(key string) error
 
-	// Verify if a Key exists in the store
+	// Exists verifies if a Key exists in the store.
 	Exists(key string) (bool, error)
 
 	// Watch for changes on a key
@@ -68,11 +68,11 @@ type Store interface {
 	// DeleteTree deletes a range of keys under a given directory
 	DeleteTree(directory string) error
 
-	// Atomic CAS operation on a single value.
+	// AtomicPut performs an atomic CAS operation on a single value.
 	// Pass previous = nil to create a new key.
 	AtomicPut(key string, value []byte, previous *KVPair, options *WriteOptions) (bool, *KVPair, error)
 
-	// Atomic delete of a single value
+	// AtomicDelete performs an atomic delete of a single value.
 	AtomicDelete(key string, previous *KVPair) (bool, error)
 
 	// Close the store connection

--- a/libnetwork/internal/kvstore/kvstore.go
+++ b/libnetwork/internal/kvstore/kvstore.go
@@ -61,7 +61,7 @@ type Store interface {
 
 	// AtomicPut performs an atomic CAS operation on a single value.
 	// Pass previous = nil to create a new key.
-	AtomicPut(key string, value []byte, previous *KVPair) (bool, *KVPair, error)
+	AtomicPut(key string, value []byte, previous *KVPair) (*KVPair, error)
 
 	// AtomicDelete performs an atomic delete of a single value.
 	AtomicDelete(key string, previous *KVPair) (bool, error)

--- a/libnetwork/internal/kvstore/kvstore.go
+++ b/libnetwork/internal/kvstore/kvstore.go
@@ -39,7 +39,7 @@ type Config struct {
 // backend for libkv
 type Store interface {
 	// Put a value at the specified key
-	Put(key string, value []byte, options *WriteOptions) error
+	Put(key string, value []byte) error
 
 	// Get a value given its key
 	Get(key string) (*KVPair, error)
@@ -61,7 +61,7 @@ type Store interface {
 
 	// AtomicPut performs an atomic CAS operation on a single value.
 	// Pass previous = nil to create a new key.
-	AtomicPut(key string, value []byte, previous *KVPair, options *WriteOptions) (bool, *KVPair, error)
+	AtomicPut(key string, value []byte, previous *KVPair) (bool, *KVPair, error)
 
 	// AtomicDelete performs an atomic delete of a single value.
 	AtomicDelete(key string, previous *KVPair) (bool, error)
@@ -75,10 +75,4 @@ type KVPair struct {
 	Key       string
 	Value     []byte
 	LastIndex uint64
-}
-
-// WriteOptions contains optional request parameters
-type WriteOptions struct {
-	IsDir bool
-	TTL   time.Duration
 }

--- a/libnetwork/internal/kvstore/kvstore.go
+++ b/libnetwork/internal/kvstore/kvstore.go
@@ -14,8 +14,6 @@ const BOLTDB Backend = "boltdb"
 var (
 	// ErrBackendNotSupported is thrown when the backend k/v store is not supported by libkv
 	ErrBackendNotSupported = errors.New("Backend storage not supported yet, please choose one of")
-	// ErrCallNotSupported is thrown when a method is not implemented/supported by the current backend
-	ErrCallNotSupported = errors.New("The current call is not supported with this backend")
 	// ErrKeyModified is thrown during an atomic operation if the index does not match the one in the store
 	ErrKeyModified = errors.New("Unable to complete atomic operation, key modified")
 	// ErrKeyNotFound is thrown when the key is not found in the store during a Get operation
@@ -49,9 +47,6 @@ type Store interface {
 
 	// Exists verifies if a Key exists in the store.
 	Exists(key string) (bool, error)
-
-	// Watch for changes on a key
-	Watch(key string, stopCh <-chan struct{}) (<-chan *KVPair, error)
 
 	// List the content of a given prefix
 	List(directory string) ([]*KVPair, error)

--- a/libnetwork/libnetwork_test.go
+++ b/libnetwork/libnetwork_test.go
@@ -32,15 +32,13 @@ func TestMain(m *testing.M) {
 
 func newController(t *testing.T) *libnetwork.Controller {
 	t.Helper()
-	genericOption := map[string]interface{}{
-		netlabel.GenericData: options.Generic{
-			"EnableIPForwarding": true,
-		},
-	}
-
 	c, err := libnetwork.New(
 		libnetwork.OptionBoltdbWithRandomDBFile(t),
-		config.OptionDriverConfig(bridgeNetType, genericOption),
+		config.OptionDriverConfig(bridgeNetType, map[string]interface{}{
+			netlabel.GenericData: options.Generic{
+				"EnableIPForwarding": true,
+			},
+		}),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -56,9 +54,7 @@ func createTestNetwork(c *libnetwork.Controller, networkType, networkName string
 }
 
 func getEmptyGenericOption() map[string]interface{} {
-	genericOption := make(map[string]interface{})
-	genericOption[netlabel.GenericData] = map[string]string{}
-	return genericOption
+	return map[string]interface{}{netlabel.GenericData: map[string]string{}}
 }
 
 func getPortMapping() []types.PortBinding {

--- a/libnetwork/networkdb/networkdb_test.go
+++ b/libnetwork/networkdb/networkdb_test.go
@@ -368,7 +368,7 @@ func TestNetworkDBWatch(t *testing.T) {
 	err = dbs[1].JoinNetwork("network1")
 	assert.NilError(t, err)
 
-	ch, cancel := dbs[1].Watch("", "", "")
+	ch, cancel := dbs[1].Watch("", "")
 
 	err = dbs[0].CreateEntry("test_table", "network1", "test_key", []byte("test_value"))
 	assert.NilError(t, err)

--- a/libnetwork/networkdb/watch.go
+++ b/libnetwork/networkdb/watch.go
@@ -39,14 +39,14 @@ type UpdateEvent event
 type DeleteEvent event
 
 // Watch creates a watcher with filters for a particular table or
-// network or key or any combination of the tuple. If any of the
+// network or any combination of the tuple. If any of the
 // filter is an empty string it acts as a wildcard for that
 // field. Watch returns a channel of events, where the events will be
 // sent.
-func (nDB *NetworkDB) Watch(tname, nid, key string) (*events.Channel, func()) {
+func (nDB *NetworkDB) Watch(tname, nid string) (*events.Channel, func()) {
 	var matcher events.Matcher
 
-	if tname != "" || nid != "" || key != "" {
+	if tname != "" || nid != "" {
 		matcher = events.MatcherFunc(func(ev events.Event) bool {
 			var evt event
 			switch ev := ev.(type) {
@@ -63,10 +63,6 @@ func (nDB *NetworkDB) Watch(tname, nid, key string) (*events.Channel, func()) {
 			}
 
 			if nid != "" && evt.NetworkID != nid {
-				return false
-			}
-
-			if key != "" && evt.Key != key {
 				return false
 			}
 

--- a/libnetwork/store_linux_test.go
+++ b/libnetwork/store_linux_test.go
@@ -17,12 +17,12 @@ func TestBoltdbBackend(t *testing.T) {
 }
 
 func TestNoPersist(t *testing.T) {
-	ctrl, err := New(OptionBoltdbWithRandomDBFile(t))
+	testController, err := New(OptionBoltdbWithRandomDBFile(t))
 	if err != nil {
 		t.Fatalf("Error new controller: %v", err)
 	}
-	defer ctrl.Stop()
-	nw, err := ctrl.NewNetwork("host", "host", "", NetworkOptionPersist(false))
+	defer testController.Stop()
+	nw, err := testController.NewNetwork("host", "host", "", NetworkOptionPersist(false))
 	if err != nil {
 		t.Fatalf("Error creating default \"host\" network: %v", err)
 	}
@@ -30,12 +30,12 @@ func TestNoPersist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating endpoint: %v", err)
 	}
-	store := ctrl.getStore().KVStore()
-	if exists, _ := store.Exists(datastore.Key(datastore.NetworkKeyPrefix, nw.ID())); exists {
+	kvStore := testController.getStore().KVStore()
+	if exists, _ := kvStore.Exists(datastore.Key(datastore.NetworkKeyPrefix, nw.ID())); exists {
 		t.Fatalf("Network with persist=false should not be stored in KV Store")
 	}
-	if exists, _ := store.Exists(datastore.Key([]string{datastore.EndpointKeyPrefix, nw.ID(), ep.ID()}...)); exists {
+	if exists, _ := kvStore.Exists(datastore.Key([]string{datastore.EndpointKeyPrefix, nw.ID(), ep.ID()}...)); exists {
 		t.Fatalf("Endpoint in Network with persist=false should not be stored in KV Store")
 	}
-	store.Close()
+	kvStore.Close()
 }

--- a/libnetwork/store_linux_test.go
+++ b/libnetwork/store_linux_test.go
@@ -2,6 +2,7 @@ package libnetwork
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/docker/docker/libnetwork/datastore"
@@ -11,9 +12,10 @@ import (
 func TestBoltdbBackend(t *testing.T) {
 	defer os.Remove(datastore.DefaultScope("").Client.Address)
 	testLocalBackend(t, "", "", nil)
-	defer os.Remove("/tmp/boltdb.db")
-	config := &store.Config{Bucket: "testBackend"}
-	testLocalBackend(t, "boltdb", "/tmp/boltdb.db", config)
+	tmpPath := filepath.Join(t.TempDir(), "boltdb.db")
+	testLocalBackend(t, "boltdb", tmpPath, &store.Config{
+		Bucket: "testBackend",
+	})
 }
 
 func TestNoPersist(t *testing.T) {

--- a/libnetwork/store_test.go
+++ b/libnetwork/store_test.go
@@ -3,6 +3,7 @@ package libnetwork
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker/libnetwork/config"
@@ -14,9 +15,9 @@ import (
 
 func testLocalBackend(t *testing.T, provider, url string, storeConfig *store.Config) {
 	cfgOptions := []config.Option{}
-	cfgOptions = append(cfgOptions, config.OptionLocalKVProvider(provider))
-	cfgOptions = append(cfgOptions, config.OptionLocalKVProviderURL(url))
-	cfgOptions = append(cfgOptions, config.OptionLocalKVProviderConfig(storeConfig))
+	cfgOptions = append(cfgOptions, optionLocalKVProvider(provider))
+	cfgOptions = append(cfgOptions, optionLocalKVProviderURL(url))
+	cfgOptions = append(cfgOptions, optionLocalKVProviderConfig(storeConfig))
 
 	driverOptions := options.Generic{}
 	genericOption := make(map[string]interface{})
@@ -65,9 +66,30 @@ func OptionBoltdbWithRandomDBFile(t *testing.T) config.Option {
 	}
 
 	return func(c *config.Config) {
-		config.OptionLocalKVProvider("boltdb")(c)
-		config.OptionLocalKVProviderURL(tmp)(c)
-		config.OptionLocalKVProviderConfig(&store.Config{Bucket: "testBackend"})(c)
+		optionLocalKVProvider("boltdb")(c)
+		optionLocalKVProviderURL(tmp)(c)
+		optionLocalKVProviderConfig(&store.Config{Bucket: "testBackend"})(c)
+	}
+}
+
+// optionLocalKVProvider function returns an option setter for kvstore provider
+func optionLocalKVProvider(provider string) config.Option {
+	return func(c *config.Config) {
+		c.Scope.Client.Provider = strings.TrimSpace(provider)
+	}
+}
+
+// optionLocalKVProviderURL function returns an option setter for kvstore url
+func optionLocalKVProviderURL(url string) config.Option {
+	return func(c *config.Config) {
+		c.Scope.Client.Address = strings.TrimSpace(url)
+	}
+}
+
+// optionLocalKVProviderConfig function returns an option setter for kvstore config
+func optionLocalKVProviderConfig(cfg *store.Config) config.Option {
+	return func(c *config.Config) {
+		c.Scope.Client.Config = cfg
 	}
 }
 

--- a/libnetwork/store_test.go
+++ b/libnetwork/store_test.go
@@ -23,12 +23,12 @@ func testLocalBackend(t *testing.T, provider, url string, storeConfig *store.Con
 	genericOption[netlabel.GenericData] = driverOptions
 	cfgOptions = append(cfgOptions, config.OptionDriverConfig("host", genericOption))
 
-	ctrl, err := New(cfgOptions...)
+	testController, err := New(cfgOptions...)
 	if err != nil {
 		t.Fatalf("Error new controller: %v", err)
 	}
-	defer ctrl.Stop()
-	nw, err := ctrl.NewNetwork("host", "host", "")
+	defer testController.Stop()
+	nw, err := testController.NewNetwork("host", "host", "")
 	if err != nil {
 		t.Fatalf("Error creating default \"host\" network: %v", err)
 	}
@@ -36,22 +36,22 @@ func testLocalBackend(t *testing.T, provider, url string, storeConfig *store.Con
 	if err != nil {
 		t.Fatalf("Error creating endpoint: %v", err)
 	}
-	store := ctrl.getStore().KVStore()
-	if exists, err := store.Exists(datastore.Key(datastore.NetworkKeyPrefix, nw.ID())); !exists || err != nil {
+	kvStore := testController.getStore().KVStore()
+	if exists, err := kvStore.Exists(datastore.Key(datastore.NetworkKeyPrefix, nw.ID())); !exists || err != nil {
 		t.Fatalf("Network key should have been created.")
 	}
-	if exists, err := store.Exists(datastore.Key([]string{datastore.EndpointKeyPrefix, nw.ID(), ep.ID()}...)); !exists || err != nil {
+	if exists, err := kvStore.Exists(datastore.Key([]string{datastore.EndpointKeyPrefix, nw.ID(), ep.ID()}...)); !exists || err != nil {
 		t.Fatalf("Endpoint key should have been created.")
 	}
-	store.Close()
+	kvStore.Close()
 
 	// test restore of local store
-	ctrl, err = New(cfgOptions...)
+	testController, err = New(cfgOptions...)
 	if err != nil {
 		t.Fatalf("Error creating controller: %v", err)
 	}
-	defer ctrl.Stop()
-	if _, err = ctrl.NetworkByID(nw.ID()); err != nil {
+	defer testController.Stop()
+	if _, err = testController.NetworkByID(nw.ID()); err != nil {
 		t.Fatalf("Error getting network %v", err)
 	}
 }


### PR DESCRIPTION
### libnetwork/internal/kvstore: remove unused Config options

The only remaining kvstore is BoltDB, which doesn't use TLS connections
or authentication, so we can remove these options.

### libnetwork/internal/kvstore: fix some linting issues

### libnetwork/internal/kvstore: remove unused WatchTree and NewLock methods

These were not used, and not implemented by the BoltDB store.

### libnetwork/internal/kvstore: remove unused WriteOptions

The WriteOptions struct was only used to set the "IsDir" option. This option
was added in https://github.com/docker/libkv/commit/d635a8e32b67f1ac511b7fcc15d524dedb9f549b (https://github.com/docker/libkv/pull/75)
and was only supported by the etcd libkv store.

The BoltDB store does not support this option, making the WriteOptions
struct fully redundant.

### libnetwork/internal/kvstore: AtomicPut(): remove unused "created" return

This boolean was not used anywhere, so we can remove it.

### libnetwork/internal/kvstore: AtomicDelete(): remove unused "deleted" return

This boolean was not used anywhere, so we can remove it. Also cleaning up
the implementation a bit.

### libnetwork/internal/kvstore/boltdb: minor cleanup/refactor

Make the code slightly more idiomatic; remove some "var" declarations,
remove some intermediate variables and redundant error-checks, and remove
the filePerm const.


### libnetwork/internal/kvstore/boltdb: BoltDB.Exists(): fix error handling

This function could potentially return "true" even if an error was returned.

### libnetwork/internal/kvstore/boltdb: BoltDB.Get(): don't shadow error

Don't shadow the original error if we got one.


### libnetwork/internal/kvstore/boltdb: BoltDB.List(): minor cleanup

cleanup the code to be slightly more idiomatic

### libnetwork/internal/kvstore/boltdb: un-export Mutex

Keep the mutex internal to BoltDB.

### libnetwork/datastore: remove unused datastore.Active()

The value was set, and updated, but never used.

### libnetwork/datastore: remove redundant datastore.sequential

The sequential field determined whether a lock was needed when storing
and retrieving data. This field was always set to true, with the exception
of NewTestDataStore() in the tests.

This field was added in https://github.com/moby/libnetwork/commit/a18e2f9965b0d772ed2b552bb4e26ea43bf90c95 (https://github.com/moby/libnetwork/pull/1206)
to make locking optional for non-local scoped stores. Such stores are no
longer used, so we can remove this field.

### libnetwork/datastore: remove Watch(), Watchable(), RestartWatch()

The `store.Watch()` was only used in `Controller.processEndpointCreate()`,
and skipped if the store was not "watchable" (`store.Watchable()`).

Whether a store is watchable depends on the store's datastore.scope;
local stores are not watchable;

    func (ds *datastore) Watchable() bool {
        return ds.scope != LocalScope
    }

datastore is only initialized in two locations, and both locations set the
scope field to LocalScope:

datastore.newClient() (also called by datastore.NewDataStore()):
https://github.com/moby/moby/blob/3e4c9d90cf6a796334519f0de12ff09608d7abbe/libnetwork/datastore/datastore.go#L213

datastore.NewTestDataStore() (used in tests);
https://github.com/moby/moby/blob/3e4c9d90cf6a796334519f0de12ff09608d7abbe/libnetwork/datastore/datastore_test.go#L14-L17

Furthermore, the backing BoltDB kvstore does not implement the Watch()
method;

https://github.com/moby/moby/blob/3e4c9d90cf6a796334519f0de12ff09608d7abbe/libnetwork/internal/kvstore/boltdb/boltdb.go#L464-L467

Based on the above;

- our datastore is never Watchable()
- so datastore.Watch() is never used

This patch removes the Watchable(), Watch(), and RestartWatch() functions,
as well as the code handling watching.

### libnetwork/internal/kvstore: remove unused Watch() method

The BoltDB store is not Watchable, and the Watch function was never used,
so we can remove it.

### libnetwork/networkdb: NetworkDB.Watch(): remove unused "key" argument

This function was implemented in https://github.com/moby/libnetwork/commit/dd4950f36d0a568791ead9398ddd175451ae36fa
which added a "key" field, but that field was never used anywhere, and
still appears unused.

### libnetwork/datastore: cache.get(): remove unused "key" argument

### libnetwork: rename vars that shadowed with pkg vars and imports

### libnetwork/config: remove options that were only used in tests

The OptionLocalKVProvider, OptionLocalKVProviderURL, and OptionLocalKVProviderConfig
options were only used in tests, so un-export them, and move them to the
test-files.

### libnetwork: inline store config options

### libnetwork: TestBoltdbBackend(): use t.TempDir()

### libnetwork/datastore: remove unused DeleteTree() method


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

