### PR TITLE
api: info: don't use ad-hoc type for compatibility with old api versions

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -307,11 +307,18 @@ type Info struct {
 	ProductLicense      string               `json:",omitempty"`
 	DefaultAddressPools []NetworkAddressPool `json:",omitempty"`
 
+	// Legacy API fields for older API versions.
+	legacyFields
+
 	// Warnings contains a slice of warnings that occurred  while collecting
 	// system information. These warnings are intended to be informational
 	// messages for the user, and are not intended to be parsed / used for
 	// other purposes, as they do not have a fixed format.
 	Warnings []string
+}
+
+type legacyFields struct {
+	ExecutionDriver string `json:",omitempty"` // Deprecated: deprecated since API v1.25, but returned for older versions.
 }
 
 // KeyValue holds a key/value pair


### PR DESCRIPTION
- Add the field as a "deprecated" field in the API type.
- Don't error when failing to parse the options, but produce a warning instead, because the client won't be able to fix issues in the daemon configuration. This was unlikely to happen, as the daemon probably would fail to start with an invalid config, but just in case.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

