### PR TITLE
integration: don't use pkg/system MkNod/mkDev

### DIFF
--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/docker/docker/integration/internal/container"
 	net "github.com/docker/docker/integration/internal/network"
 	"github.com/docker/docker/pkg/stdcopy"
-	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/testutil/daemon"
 	"golang.org/x/sys/unix"
 	"gotest.tools/v3/assert"
@@ -155,7 +154,7 @@ func TestPrivilegedHostDevices(t *testing.T) {
 	)
 
 	// Create Null devices.
-	if err := system.Mknod(devTest, unix.S_IFCHR|0o600, int(system.Mkdev(1, 3))); err != nil {
+	if err := unix.Mknod(devTest, unix.S_IFCHR|0o600, int(unix.Mkdev(1, 3))); err != nil {
 		t.Fatal(err)
 	}
 	defer os.Remove(devTest)
@@ -163,7 +162,7 @@ func TestPrivilegedHostDevices(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(filepath.Dir(devRootOnlyTest))
-	if err := system.Mknod(devRootOnlyTest, unix.S_IFCHR|0o600, int(system.Mkdev(1, 3))); err != nil {
+	if err := unix.Mknod(devRootOnlyTest, unix.S_IFCHR|0o600, int(unix.Mkdev(1, 3))); err != nil {
 		t.Fatal(err)
 	}
 	defer os.Remove(devRootOnlyTest)


### PR DESCRIPTION
These tests are Linux-only, so we don't need the wrapper.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

