### PR TITLE
libnetwork: stop passing config to drivers which ignore the config argument

### DIFF
--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -110,11 +110,6 @@ type Controller struct {
 	mu               sync.Mutex
 }
 
-type initializer struct {
-	fn    func(driverapi.Registerer, map[string]interface{}) error
-	ntype string
-}
-
 // New creates a new instance of network controller.
 func New(cfgOptions ...config.Option) (*Controller, error) {
 	c := &Controller{
@@ -141,10 +136,8 @@ func New(cfgOptions ...config.Option) (*Controller, error) {
 		return nil, err
 	}
 
-	for _, i := range getInitializers() {
-		if err := i.fn(&c.drvRegistry, c.makeDriverConfig(i.ntype)); err != nil {
-			return nil, err
-		}
+	if err := registerNetworkDrivers(&c.drvRegistry, c.makeDriverConfig); err != nil {
+		return nil, err
 	}
 
 	if err := initIPAMDrivers(&c.ipamRegistry, c.cfg.PluginGetter, c.cfg.DefaultAddressPool); err != nil {

--- a/libnetwork/drivers/bridge/bridge.go
+++ b/libnetwork/drivers/bridge/bridge.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	networkType                = "bridge"
+	NetworkType                = "bridge"
 	vethPrefix                 = "veth"
 	vethLen                    = len(vethPrefix) + 7
 	defaultContainerVethPrefix = "eth"
@@ -174,7 +174,7 @@ func Register(r driverapi.Registerer, config map[string]interface{}) error {
 	if err := d.configure(config); err != nil {
 		return err
 	}
-	return r.RegisterDriver(networkType, d, driverapi.Capability{
+	return r.RegisterDriver(NetworkType, d, driverapi.Capability{
 		DataScope:         datastore.LocalScope,
 		ConnectivityScope: datastore.LocalScope,
 	})
@@ -1433,7 +1433,7 @@ func (d *driver) link(network *bridgeNetwork, endpoint *bridgeEndpoint, enable b
 }
 
 func (d *driver) Type() string {
-	return networkType
+	return NetworkType
 }
 
 func (d *driver) IsBuiltIn() bool {

--- a/libnetwork/drivers/bridge/brmanager/brmanager.go
+++ b/libnetwork/drivers/bridge/brmanager/brmanager.go
@@ -15,11 +15,11 @@ type driver struct{}
 //
 // Deprecated: use [Register].
 func Init(dc driverapi.DriverCallback, _ map[string]interface{}) error {
-	return Register(dc, nil)
+	return Register(dc)
 }
 
 // Register registers a new instance of the bridge manager driver with r.
-func Register(r driverapi.Registerer, _ map[string]interface{}) error {
+func Register(r driverapi.Registerer) error {
 	return r.RegisterDriver(networkType, &driver{}, driverapi.Capability{
 		DataScope:         datastore.LocalScope,
 		ConnectivityScope: datastore.LocalScope,

--- a/libnetwork/drivers/host/host.go
+++ b/libnetwork/drivers/host/host.go
@@ -9,7 +9,7 @@ import (
 	"github.com/docker/docker/libnetwork/types"
 )
 
-const networkType = "host"
+const NetworkType = "host"
 
 type driver struct {
 	network string
@@ -24,7 +24,7 @@ func Init(dc driverapi.DriverCallback, _ map[string]interface{}) error {
 }
 
 func Register(r driverapi.Registerer, _ map[string]interface{}) error {
-	return r.RegisterDriver(networkType, &driver{}, driverapi.Capability{
+	return r.RegisterDriver(NetworkType, &driver{}, driverapi.Capability{
 		DataScope:         datastore.LocalScope,
 		ConnectivityScope: datastore.LocalScope,
 	})
@@ -50,7 +50,7 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 	defer d.Unlock()
 
 	if d.network != "" {
-		return types.ForbiddenErrorf("only one instance of \"%s\" network is allowed", networkType)
+		return types.ForbiddenErrorf("only one instance of \"%s\" network is allowed", NetworkType)
 	}
 
 	d.network = id
@@ -59,7 +59,7 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 }
 
 func (d *driver) DeleteNetwork(nid string) error {
-	return types.ForbiddenErrorf("network of type \"%s\" cannot be deleted", networkType)
+	return types.ForbiddenErrorf("network of type \"%s\" cannot be deleted", NetworkType)
 }
 
 func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
@@ -93,7 +93,7 @@ func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
 }
 
 func (d *driver) Type() string {
-	return networkType
+	return NetworkType
 }
 
 func (d *driver) IsBuiltIn() bool {

--- a/libnetwork/drivers/host/host.go
+++ b/libnetwork/drivers/host/host.go
@@ -20,10 +20,10 @@ type driver struct {
 //
 // Deprecated: use [Register].
 func Init(dc driverapi.DriverCallback, _ map[string]interface{}) error {
-	return Register(dc, nil)
+	return Register(dc)
 }
 
-func Register(r driverapi.Registerer, _ map[string]interface{}) error {
+func Register(r driverapi.Registerer) error {
 	return r.RegisterDriver(NetworkType, &driver{}, driverapi.Capability{
 		DataScope:         datastore.LocalScope,
 		ConnectivityScope: datastore.LocalScope,

--- a/libnetwork/drivers/host/host_test.go
+++ b/libnetwork/drivers/host/host_test.go
@@ -9,7 +9,7 @@ import (
 func TestDriver(t *testing.T) {
 	d := &driver{}
 
-	if d.Type() != networkType {
+	if d.Type() != NetworkType {
 		t.Fatal("Unexpected network type returned by driver")
 	}
 

--- a/libnetwork/drivers/ipvlan/ipvlan.go
+++ b/libnetwork/drivers/ipvlan/ipvlan.go
@@ -18,7 +18,7 @@ const (
 	vethPrefix          = "veth"
 	vethLen             = len(vethPrefix) + 7
 
-	driverName    = "ipvlan"      // driver type name
+	NetworkType   = "ipvlan"      // driver type name
 	parentOpt     = "parent"      // parent interface -o parent
 	driverModeOpt = "ipvlan_mode" // mode -o ipvlan_mode
 	driverFlagOpt = "ipvlan_flag" // flag -o ipvlan_flag
@@ -70,7 +70,7 @@ func Register(r driverapi.Registerer, config map[string]interface{}) error {
 	if err := d.initStore(config); err != nil {
 		return err
 	}
-	return r.RegisterDriver(driverName, d, driverapi.Capability{
+	return r.RegisterDriver(NetworkType, d, driverapi.Capability{
 		DataScope:         datastore.LocalScope,
 		ConnectivityScope: datastore.GlobalScope,
 	})
@@ -89,7 +89,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 }
 
 func (d *driver) Type() string {
-	return driverName
+	return NetworkType
 }
 
 func (d *driver) IsBuiltIn() bool {

--- a/libnetwork/drivers/ipvlan/ivmanager/ivmanager.go
+++ b/libnetwork/drivers/ipvlan/ivmanager/ivmanager.go
@@ -15,11 +15,11 @@ type driver struct{}
 //
 // Deprecated: use [Register].
 func Init(dc driverapi.DriverCallback, _ map[string]interface{}) error {
-	return Register(dc, nil)
+	return Register(dc)
 }
 
 // Register registers a new instance of the ipvlan manager driver.
-func Register(r driverapi.Registerer, _ map[string]interface{}) error {
+func Register(r driverapi.Registerer) error {
 	return r.RegisterDriver(networkType, &driver{}, driverapi.Capability{
 		DataScope:         datastore.LocalScope,
 		ConnectivityScope: datastore.GlobalScope,

--- a/libnetwork/drivers/macvlan/macvlan.go
+++ b/libnetwork/drivers/macvlan/macvlan.go
@@ -17,7 +17,7 @@ const (
 	containerVethPrefix = "eth"
 	vethPrefix          = "veth"
 	vethLen             = len(vethPrefix) + 7
-	driverName          = "macvlan"      // driver type name
+	NetworkType         = "macvlan"      // driver type name
 	modePrivate         = "private"      // macvlan mode private
 	modeVepa            = "vepa"         // macvlan mode vepa
 	modeBridge          = "bridge"       // macvlan mode bridge
@@ -64,7 +64,7 @@ func Register(r driverapi.Registerer, config map[string]interface{}) error {
 	if err := d.initStore(config); err != nil {
 		return err
 	}
-	return r.RegisterDriver(driverName, d, driverapi.Capability{
+	return r.RegisterDriver(NetworkType, d, driverapi.Capability{
 		DataScope:         datastore.LocalScope,
 		ConnectivityScope: datastore.GlobalScope,
 	})
@@ -83,7 +83,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 }
 
 func (d *driver) Type() string {
-	return driverName
+	return NetworkType
 }
 
 func (d *driver) IsBuiltIn() bool {

--- a/libnetwork/drivers/macvlan/mvmanager/mvmanager.go
+++ b/libnetwork/drivers/macvlan/mvmanager/mvmanager.go
@@ -15,11 +15,11 @@ type driver struct{}
 //
 // Deprecated: use [Register].
 func Init(dc driverapi.DriverCallback, _ map[string]interface{}) error {
-	return Register(dc, nil)
+	return Register(dc)
 }
 
 // Register registers a new instance of the macvlan manager driver.
-func Register(r driverapi.Registerer, _ map[string]interface{}) error {
+func Register(r driverapi.Registerer) error {
 	return r.RegisterDriver(networkType, &driver{}, driverapi.Capability{
 		DataScope:         datastore.LocalScope,
 		ConnectivityScope: datastore.GlobalScope,

--- a/libnetwork/drivers/null/null.go
+++ b/libnetwork/drivers/null/null.go
@@ -17,7 +17,7 @@ type driver struct {
 }
 
 // Register registers a new instance of the null driver.
-func Register(r driverapi.Registerer, _ map[string]interface{}) error {
+func Register(r driverapi.Registerer) error {
 	return r.RegisterDriver(NetworkType, &driver{}, driverapi.Capability{
 		DataScope: datastore.LocalScope,
 	})

--- a/libnetwork/drivers/null/null.go
+++ b/libnetwork/drivers/null/null.go
@@ -9,7 +9,7 @@ import (
 	"github.com/docker/docker/libnetwork/types"
 )
 
-const networkType = "null"
+const NetworkType = "null"
 
 type driver struct {
 	network string
@@ -18,7 +18,7 @@ type driver struct {
 
 // Register registers a new instance of the null driver.
 func Register(r driverapi.Registerer, _ map[string]interface{}) error {
-	return r.RegisterDriver(networkType, &driver{}, driverapi.Capability{
+	return r.RegisterDriver(NetworkType, &driver{}, driverapi.Capability{
 		DataScope: datastore.LocalScope,
 	})
 }
@@ -43,7 +43,7 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 	defer d.Unlock()
 
 	if d.network != "" {
-		return types.ForbiddenErrorf("only one instance of \"%s\" network is allowed", networkType)
+		return types.ForbiddenErrorf("only one instance of \"%s\" network is allowed", NetworkType)
 	}
 
 	d.network = id
@@ -52,7 +52,7 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 }
 
 func (d *driver) DeleteNetwork(nid string) error {
-	return types.ForbiddenErrorf("network of type \"%s\" cannot be deleted", networkType)
+	return types.ForbiddenErrorf("network of type \"%s\" cannot be deleted", NetworkType)
 }
 
 func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
@@ -86,7 +86,7 @@ func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
 }
 
 func (d *driver) Type() string {
-	return networkType
+	return NetworkType
 }
 
 func (d *driver) IsBuiltIn() bool {

--- a/libnetwork/drivers/null/null_test.go
+++ b/libnetwork/drivers/null/null_test.go
@@ -9,7 +9,7 @@ import (
 func TestDriver(t *testing.T) {
 	d := &driver{}
 
-	if d.Type() != networkType {
+	if d.Type() != NetworkType {
 		t.Fatalf("Unexpected network type returned by driver")
 	}
 

--- a/libnetwork/drivers/overlay/overlay.go
+++ b/libnetwork/drivers/overlay/overlay.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	networkType  = "overlay"
+	NetworkType  = "overlay"
 	vethPrefix   = "veth"
 	vethLen      = len(vethPrefix) + 7
 	vxlanEncap   = 50
@@ -47,7 +47,7 @@ func Register(r driverapi.Registerer, config map[string]interface{}) error {
 		secMap: &encrMap{nodes: map[string][]*spi{}},
 		config: config,
 	}
-	return r.RegisterDriver(networkType, d, driverapi.Capability{
+	return r.RegisterDriver(NetworkType, d, driverapi.Capability{
 		DataScope:         datastore.GlobalScope,
 		ConnectivityScope: datastore.GlobalScope,
 	})
@@ -61,7 +61,7 @@ func (d *driver) configure() error {
 }
 
 func (d *driver) Type() string {
-	return networkType
+	return NetworkType
 }
 
 func (d *driver) IsBuiltIn() bool {

--- a/libnetwork/drivers/overlay/ovmanager/ovmanager.go
+++ b/libnetwork/drivers/overlay/ovmanager/ovmanager.go
@@ -50,11 +50,11 @@ type network struct {
 //
 // Deprecated: use [Register].
 func Init(dc driverapi.DriverCallback, _ map[string]interface{}) error {
-	return Register(dc, nil)
+	return Register(dc)
 }
 
 // Register registers a new instance of the overlay driver.
-func Register(r driverapi.Registerer, _ map[string]interface{}) error {
+func Register(r driverapi.Registerer) error {
 	return r.RegisterDriver(networkType, newDriver(), driverapi.Capability{
 		DataScope:         datastore.GlobalScope,
 		ConnectivityScope: datastore.GlobalScope,

--- a/libnetwork/drivers/windows/overlay/overlay_windows.go
+++ b/libnetwork/drivers/windows/overlay/overlay_windows.go
@@ -26,7 +26,7 @@ type driver struct {
 }
 
 // Register registers a new instance of the overlay driver.
-func Register(r driverapi.Registerer, _ map[string]interface{}) error {
+func Register(r driverapi.Registerer) error {
 	d := &driver{
 		networks: networkTable{},
 	}

--- a/libnetwork/drivers/windows/overlay/overlay_windows.go
+++ b/libnetwork/drivers/windows/overlay/overlay_windows.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	networkType = "overlay"
+	NetworkType = "overlay"
 )
 
 type driver struct {
@@ -33,7 +33,7 @@ func Register(r driverapi.Registerer, _ map[string]interface{}) error {
 
 	d.restoreHNSNetworks()
 
-	return r.RegisterDriver(networkType, d, driverapi.Capability{
+	return r.RegisterDriver(NetworkType, d, driverapi.Capability{
 		DataScope:         datastore.GlobalScope,
 		ConnectivityScope: datastore.GlobalScope,
 	})
@@ -48,7 +48,7 @@ func (d *driver) restoreHNSNetworks() error {
 	}
 
 	for _, v := range hnsresponse {
-		if v.Type != networkType {
+		if v.Type != NetworkType {
 			continue
 		}
 
@@ -105,7 +105,7 @@ func (d *driver) convertToOverlayNetwork(v *hcsshim.HNSNetwork) *network {
 }
 
 func (d *driver) Type() string {
-	return networkType
+	return NetworkType
 }
 
 func (d *driver) IsBuiltIn() bool {

--- a/libnetwork/drivers_freebsd.go
+++ b/libnetwork/drivers_freebsd.go
@@ -4,8 +4,6 @@ import (
 	"github.com/docker/docker/libnetwork/drivers/null"
 )
 
-func getInitializers() []initializer {
-	return []initializer{
-		{null.Register, "null"},
-	}
+func registerNetworkDrivers(r driverapi.Registerer, driverConfig func(string) map[string]interface{}) error {
+	return null.Register(r, driverConfig(null.NetworkType))
 }

--- a/libnetwork/drivers_freebsd.go
+++ b/libnetwork/drivers_freebsd.go
@@ -5,5 +5,5 @@ import (
 )
 
 func registerNetworkDrivers(r driverapi.Registerer, driverConfig func(string) map[string]interface{}) error {
-	return null.Register(r, driverConfig(null.NetworkType))
+	return null.Register(r)
 }

--- a/libnetwork/drivers_linux.go
+++ b/libnetwork/drivers_linux.go
@@ -1,6 +1,9 @@
 package libnetwork
 
 import (
+	"fmt"
+
+	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/drivers/bridge"
 	"github.com/docker/docker/libnetwork/drivers/host"
 	"github.com/docker/docker/libnetwork/drivers/ipvlan"
@@ -9,14 +12,22 @@ import (
 	"github.com/docker/docker/libnetwork/drivers/overlay"
 )
 
-func getInitializers() []initializer {
-	in := []initializer{
-		{bridge.Register, "bridge"},
-		{host.Register, "host"},
-		{ipvlan.Register, "ipvlan"},
-		{macvlan.Register, "macvlan"},
-		{null.Register, "null"},
-		{overlay.Register, "overlay"},
+func registerNetworkDrivers(r driverapi.Registerer, driverConfig func(string) map[string]interface{}) error {
+	for _, nr := range []struct {
+		ntype    string
+		register func(driverapi.Registerer, map[string]interface{}) error
+	}{
+		{ntype: bridge.NetworkType, register: bridge.Register},
+		{ntype: host.NetworkType, register: host.Register},
+		{ntype: ipvlan.NetworkType, register: ipvlan.Register},
+		{ntype: macvlan.NetworkType, register: macvlan.Register},
+		{ntype: null.NetworkType, register: null.Register},
+		{ntype: overlay.NetworkType, register: overlay.Register},
+	} {
+		if err := nr.register(r, driverConfig(nr.ntype)); err != nil {
+			return fmt.Errorf("failed to register %q driver: %w", nr.ntype, err)
+		}
 	}
-	return in
+
+	return nil
 }

--- a/libnetwork/drivers_unsupported.go
+++ b/libnetwork/drivers_unsupported.go
@@ -2,6 +2,6 @@
 
 package libnetwork
 
-func getInitializers() []initializer {
+func registerNetworkDrivers(r driverapi.Registerer, driverConfig func(string) map[string]interface{}) error {
 	return nil
 }

--- a/libnetwork/drivers_windows.go
+++ b/libnetwork/drivers_windows.go
@@ -12,12 +12,12 @@ import (
 func registerNetworkDrivers(r driverapi.Registerer, driverConfig func(string) map[string]interface{}) error {
 	for _, nr := range []struct {
 		ntype    string
-		register func(driverapi.Registerer, map[string]interface{}) error
+		register func(driverapi.Registerer) error
 	}{
 		{ntype: null.NetworkType, register: null.Register},
 		{ntype: overlay.NetworkType, register: overlay.Register},
 	} {
-		if err := nr.register(r, driverConfig(nr.ntype)); err != nil {
+		if err := nr.register(r); err != nil {
 			return fmt.Errorf("failed to register %q driver: %w", nr.ntype, err)
 		}
 	}

--- a/libnetwork/drivers_windows.go
+++ b/libnetwork/drivers_windows.go
@@ -1,21 +1,26 @@
 package libnetwork
 
 import (
+	"fmt"
+
+	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/drivers/null"
 	"github.com/docker/docker/libnetwork/drivers/windows"
 	"github.com/docker/docker/libnetwork/drivers/windows/overlay"
 )
 
-func getInitializers() []initializer {
-	return []initializer{
-		{null.Register, "null"},
-		{overlay.Register, "overlay"},
-		{windows.GetInit("transparent"), "transparent"},
-		{windows.GetInit("l2bridge"), "l2bridge"},
-		{windows.GetInit("l2tunnel"), "l2tunnel"},
-		{windows.GetInit("nat"), "nat"},
-		{windows.GetInit("internal"), "internal"},
-		{windows.GetInit("private"), "private"},
-		{windows.GetInit("ics"), "ics"},
+func registerNetworkDrivers(r driverapi.Registerer, driverConfig func(string) map[string]interface{}) error {
+	for _, nr := range []struct {
+		ntype    string
+		register func(driverapi.Registerer, map[string]interface{}) error
+	}{
+		{ntype: null.NetworkType, register: null.Register},
+		{ntype: overlay.NetworkType, register: overlay.Register},
+	} {
+		if err := nr.register(r, driverConfig(nr.ntype)); err != nil {
+			return fmt.Errorf("failed to register %q driver: %w", nr.ntype, err)
+		}
 	}
+
+	return windows.RegisterBuiltinLocalDrivers(r, driverConfig)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- Relates to https://github.com/moby/swarmkit/pull/3138

**- What I did**
Removed the config argument from the network driver `Register` functions which ignore the argument value.

**- How I did it**
By refactoring how the libnetwork controller registers network drivers so that the driver registration functions are abstracted away from the controller and therefore no longer need to conform to a single common interface.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

