### PR TITLE
libnetwork/d/o/ovmanager: switch to using bitmap package directly

### DIFF
--- a/libnetwork/bitmap/sequence.go
+++ b/libnetwork/bitmap/sequence.go
@@ -47,7 +47,7 @@ type Bitmap struct {
 	noCopy noCopy
 }
 
-// NewHandle returns a new Bitmap n bits long.
+// NewHandle returns a new Bitmap of ordinals in the interval [0, n).
 func New(n uint64) *Bitmap {
 	return &Bitmap{
 		bits:       n,
@@ -176,7 +176,7 @@ func (s *sequence) fromByteArray(data []byte) error {
 	return nil
 }
 
-// SetAnyInRange sets the first unset bit in the range [start, end) and returns
+// SetAnyInRange sets the first unset bit in the range [start, end] and returns
 // the ordinal of the set bit.
 //
 // When serial=true, the bitmap is scanned starting from the ordinal following

--- a/libnetwork/drivers/overlay/ovmanager/ovmanager_test.go
+++ b/libnetwork/drivers/overlay/ovmanager/ovmanager_test.go
@@ -7,24 +7,11 @@ import (
 	"testing"
 
 	"github.com/docker/docker/libnetwork/driverapi"
-	"github.com/docker/docker/libnetwork/idm"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/types"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
-
-func newDriver(t *testing.T) *driver {
-	d := &driver{
-		networks: networkTable{},
-	}
-
-	vxlanIdm, err := idm.New(nil, "vxlan-id", vxlanIDStart, vxlanIDEnd)
-	assert.NilError(t, err)
-
-	d.vxlanIdm = vxlanIdm
-	return d
-}
 
 func parseCIDR(t *testing.T, ipnet string) *net.IPNet {
 	subnet, err := types.ParseCIDR(ipnet)
@@ -33,7 +20,7 @@ func parseCIDR(t *testing.T, ipnet string) *net.IPNet {
 }
 
 func TestNetworkAllocateFree(t *testing.T) {
-	d := newDriver(t)
+	d := newDriver()
 
 	ipamData := []driverapi.IPAMData{
 		{
@@ -56,7 +43,7 @@ func TestNetworkAllocateFree(t *testing.T) {
 }
 
 func TestNetworkAllocateUserDefinedVNIs(t *testing.T) {
-	d := newDriver(t)
+	d := newDriver()
 
 	ipamData := []driverapi.IPAMData{
 		{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Substituted `idm.Idm` with `bitmap.Bitmap`.

**- How I did it**
By cleaning up locking and using the ovmanager driver's mutex to guard against concurrent access to the bitmap.

**- How to verify it**
By visual inspection?

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

