### PR TITLE
daemon/config: move MTU to BridgeConfig, and warn when using on Windows

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"runtime"
+
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/registry"
@@ -28,7 +30,16 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.BoolVar(&conf.CriContainerd, "cri-containerd", false, "start containerd with cri")
 
 	flags.Var(opts.NewNamedMapMapOpts("default-network-opts", conf.DefaultNetworkOpts, nil), "default-network-opt", "Default network options")
-	flags.IntVar(&conf.Mtu, "mtu", conf.Mtu, "Set the containers network MTU")
+	flags.IntVar(&conf.Mtu, "mtu", conf.Mtu, `Set the MTU for the default "bridge" network`)
+	if runtime.GOOS == "windows" {
+		// The mtu option is not used on Windows, but it has been available since
+		// "forever" (and always silently ignored). We hide the flag for now,
+		// to discourage using it (and print a warning if it's set), but not
+		// "hard-deprecating" it, to not break users, and in case it will be
+		// supported on Windows in future.
+		flags.MarkHidden("mtu")
+	}
+
 	flags.IntVar(&conf.NetworkControlPlaneMTU, "network-control-plane-mtu", conf.NetworkControlPlaneMTU, "Network Control plane MTU")
 	flags.IntVar(&conf.NetworkDiagnosticPort, "network-diagnostic-port", 0, "TCP port number of the network diagnostic server")
 	_ = flags.MarkHidden("network-diagnostic-port")

--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -30,7 +30,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.BoolVar(&conf.CriContainerd, "cri-containerd", false, "start containerd with cri")
 
 	flags.Var(opts.NewNamedMapMapOpts("default-network-opts", conf.DefaultNetworkOpts, nil), "default-network-opt", "Default network options")
-	flags.IntVar(&conf.Mtu, "mtu", conf.Mtu, `Set the MTU for the default "bridge" network`)
+	flags.IntVar(&conf.MTU, "mtu", conf.MTU, `Set the MTU for the default "bridge" network`)
 	if runtime.GOOS == "windows" {
 		// The mtu option is not used on Windows, but it has been available since
 		// "forever" (and always silently ignored). We hide the flag for now,

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -151,7 +151,6 @@ type CommonConfig struct {
 	GraphDriver           string   `json:"storage-driver,omitempty"`
 	GraphOptions          []string `json:"storage-opts,omitempty"`
 	Labels                []string `json:"labels,omitempty"`
-	Mtu                   int      `json:"mtu,omitempty"`
 	NetworkDiagnosticPort int      `json:"network-diagnostic-port,omitempty"`
 	Pidfile               string   `json:"pidfile,omitempty"`
 	RawLogs               bool     `json:"raw-logs,omitempty"`
@@ -280,7 +279,7 @@ func New() (*Config, error) {
 			MaxConcurrentDownloads: DefaultMaxConcurrentDownloads,
 			MaxConcurrentUploads:   DefaultMaxConcurrentUploads,
 			MaxDownloadAttempts:    DefaultDownloadAttempts,
-			Mtu:                    DefaultNetworkMtu,
+			BridgeConfig:           BridgeConfig{MTU: DefaultNetworkMtu},
 			NetworkConfig: NetworkConfig{
 				NetworkControlPlaneMTU: DefaultNetworkMtu,
 				DefaultNetworkOpts:     make(map[string]map[string]string),
@@ -615,8 +614,8 @@ func Validate(config *Config) error {
 	}
 
 	// TODO(thaJeztah) Validations below should not accept "0" to be valid; see Validate() for a more in-depth description of this problem
-	if config.Mtu < 0 {
-		return errors.Errorf("invalid default MTU: %d", config.Mtu)
+	if config.MTU < 0 {
+		return errors.Errorf("invalid default MTU: %d", config.MTU)
 	}
 	if config.MaxConcurrentDownloads < 0 {
 		return errors.Errorf("invalid max concurrent downloads: %d", config.MaxConcurrentDownloads)

--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -37,6 +37,7 @@ type BridgeConfig struct {
 	commonBridgeConfig
 
 	// Fields below here are platform specific.
+	MTU                         int    `json:"mtu,omitempty"`
 	DefaultIP                   net.IP `json:"ip,omitempty"`
 	IP                          string `json:"bip,omitempty"`
 	DefaultGatewayIPv4          net.IP `json:"default-gateway,omitempty"`

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -286,7 +286,7 @@ func TestValidateConfigurationErrors(t *testing.T) {
 			name: "negative MTU",
 			config: &Config{
 				CommonConfig: CommonConfig{
-					Mtu: -10,
+					BridgeConfig: BridgeConfig{MTU: -10},
 				},
 			},
 			expectedErr: "invalid default MTU: -10",
@@ -440,10 +440,10 @@ func TestValidateConfiguration(t *testing.T) {
 		},
 		{
 			name:  "with mtu",
-			field: "Mtu",
+			field: "MTU",
 			config: &Config{
 				CommonConfig: CommonConfig{
-					Mtu: 1234,
+					BridgeConfig: BridgeConfig{MTU: 1234},
 				},
 			},
 		},

--- a/daemon/config/config_windows.go
+++ b/daemon/config/config_windows.go
@@ -19,6 +19,10 @@ const (
 // configuration.
 type BridgeConfig struct {
 	commonBridgeConfig
+
+	// MTU is not actually used on Windows, but the --mtu option has always
+	// been there on Windows (but ignored).
+	MTU int `json:"mtu,omitempty"`
 }
 
 // Config defines the configuration of a docker daemon.
@@ -48,7 +52,7 @@ func (conf *Config) IsSwarmCompatible() error {
 
 // ValidatePlatformConfig checks if any platform-specific configuration settings are invalid.
 func (conf *Config) ValidatePlatformConfig() error {
-	if conf.Mtu != 0 && conf.Mtu != DefaultNetworkMtu {
+	if conf.MTU != 0 && conf.MTU != DefaultNetworkMtu {
 		log.G(context.TODO()).Warn(`WARNING: MTU for the default network is not configurable on Windows, and this option will be ignored.`)
 	}
 	return nil

--- a/daemon/config/config_windows.go
+++ b/daemon/config/config_windows.go
@@ -1,8 +1,11 @@
 package config // import "github.com/docker/docker/daemon/config"
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+
+	"github.com/containerd/containerd/log"
 )
 
 const (
@@ -45,6 +48,9 @@ func (conf *Config) IsSwarmCompatible() error {
 
 // ValidatePlatformConfig checks if any platform-specific configuration settings are invalid.
 func (conf *Config) ValidatePlatformConfig() error {
+	if conf.Mtu != 0 && conf.Mtu != DefaultNetworkMtu {
+		log.G(context.TODO()).Warn(`WARNING: MTU for the default network is not configurable on Windows, and this option will be ignored.`)
+	}
 	return nil
 }
 

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -930,7 +930,7 @@ func initBridgeDriver(controller *libnetwork.Controller, config *config.Config) 
 	netOption := map[string]string{
 		bridge.BridgeName:         bridgeName,
 		bridge.DefaultBridge:      strconv.FormatBool(true),
-		netlabel.DriverMTU:        strconv.Itoa(config.Mtu),
+		netlabel.DriverMTU:        strconv.Itoa(config.MTU),
 		bridge.EnableIPMasquerade: strconv.FormatBool(config.BridgeConfig.EnableIPMasq),
 		bridge.EnableICC:          strconv.FormatBool(config.BridgeConfig.InterContainerCommunication),
 	}

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -397,7 +397,7 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 
 	if !daemonCfg.DisableBridge {
 		// Initialize default driver "bridge"
-		if err := initBridgeDriver(daemon.netController, daemonCfg); err != nil {
+		if err := initBridgeDriver(daemon.netController, daemonCfg.BridgeConfig); err != nil {
 			return err
 		}
 	}
@@ -405,7 +405,7 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 	return nil
 }
 
-func initBridgeDriver(controller *libnetwork.Controller, config *config.Config) error {
+func initBridgeDriver(controller *libnetwork.Controller, config config.BridgeConfig) error {
 	if _, err := controller.NetworkByName(runconfig.DefaultDaemonNetworkMode().NetworkName()); err == nil {
 		return nil
 	}
@@ -417,8 +417,8 @@ func initBridgeDriver(controller *libnetwork.Controller, config *config.Config) 
 	var ipamOption libnetwork.NetworkOption
 	var subnetPrefix string
 
-	if config.BridgeConfig.FixedCIDR != "" {
-		subnetPrefix = config.BridgeConfig.FixedCIDR
+	if config.FixedCIDR != "" {
+		subnetPrefix = config.FixedCIDR
 	}
 
 	if subnetPrefix != "" {


### PR DESCRIPTION
### dockerd: "--mtu": update description, hide on Windows and warn if set

The --mtu option is only used for the default "bridge" network on Linux.
On Windows, the flag is available, but ignored. As this option has been
available for a long time, and was always silently ignored, deprecating
or removing it would be a breaking change (and perhaps it's possible to
support it in future).

This patch:

- hides the option on Windows binaries
- logs a warning if the option is set to any non-zero value other than
  the default on a Windows binary

### daemon/config: move MTU to BridgeConfig

This option is only used for the default bridge network; let's move the
field to that struct to make it clearer what it's used for.

### daemon: initBridgeDriver(): pass BridgeConfig, instead of daemon config

Now that the MTU field was moved, this function only needs the BridgeConfig,
which contains all options for the default "bridge" network.



**- A picture of a cute animal (not mandatory but encouraged)**

