### PR TITLE
libnetwork/iptables: some cleanups and refactoring

### DIFF
--- a/libnetwork/drivers/bridge/setup_bridgenetfiltering.go
+++ b/libnetwork/drivers/bridge/setup_bridgenetfiltering.go
@@ -24,11 +24,11 @@ const (
 
 // getIPVersion gets the IP version in use ( [ipv4], [ipv6] or [ipv4 and ipv6] )
 func getIPVersion(config *networkConfiguration) ipVersion {
-	ipVersion := ipv4
+	ipVer := ipv4
 	if config.AddressIPv6 != nil || config.EnableIPv6 {
-		ipVersion |= ipv6
+		ipVer |= ipv6
 	}
-	return ipVersion
+	return ipVer
 }
 
 func setupBridgeNetFiltering(config *networkConfiguration, i *bridgeInterface) error {

--- a/libnetwork/drivers/bridge/setup_ip_tables.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables.go
@@ -226,38 +226,37 @@ func setupIPTablesInternal(hostIP net.IP, bridgeIface string, addr *net.IPNet, i
 	natRule := iptRule{table: iptables.Nat, chain: "POSTROUTING", preArgs: []string{"-t", "nat"}, args: natArgs}
 	hpNatRule := iptRule{table: iptables.Nat, chain: "POSTROUTING", preArgs: []string{"-t", "nat"}, args: hpNatArgs}
 
-	ipVersion := iptables.IPv4
-
+	ipVer := iptables.IPv4
 	if addr.IP.To4() == nil {
-		ipVersion = iptables.IPv6
+		ipVer = iptables.IPv6
 	}
 
 	// Set NAT.
 	if ipmasq {
-		if err := programChainRule(ipVersion, natRule, "NAT", enable); err != nil {
+		if err := programChainRule(ipVer, natRule, "NAT", enable); err != nil {
 			return err
 		}
 	}
 
 	if ipmasq && !hairpin {
-		if err := programChainRule(ipVersion, skipDNAT, "SKIP DNAT", enable); err != nil {
+		if err := programChainRule(ipVer, skipDNAT, "SKIP DNAT", enable); err != nil {
 			return err
 		}
 	}
 
 	// In hairpin mode, masquerade traffic from localhost. If hairpin is disabled or if we're tearing down
 	// that bridge, make sure the iptables rule isn't lying around.
-	if err := programChainRule(ipVersion, hpNatRule, "MASQ LOCAL HOST", enable && hairpin); err != nil {
+	if err := programChainRule(ipVer, hpNatRule, "MASQ LOCAL HOST", enable && hairpin); err != nil {
 		return err
 	}
 
 	// Set Inter Container Communication.
-	if err := setIcc(ipVersion, bridgeIface, icc, enable); err != nil {
+	if err := setIcc(ipVer, bridgeIface, icc, enable); err != nil {
 		return err
 	}
 
 	// Set Accept on all non-intercontainer outgoing packets.
-	return programChainRule(ipVersion, outRule, "ACCEPT NON_ICC OUTGOING", enable)
+	return programChainRule(ipVer, outRule, "ACCEPT NON_ICC OUTGOING", enable)
 }
 
 func programChainRule(version iptables.IPVersion, rule iptRule, ruleDescr string, insert bool) error {

--- a/libnetwork/drivers/bridge/setup_ip_tables.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables.go
@@ -17,6 +17,7 @@ import (
 // DockerChain: DOCKER iptable chain name
 const (
 	DockerChain = "DOCKER"
+
 	// Isolation between bridge networks is achieved in two stages by means
 	// of the following two chains in the filter table. The first chain matches
 	// on the source interface being a bridge network's bridge and the
@@ -26,6 +27,7 @@ const (
 	// bridge. A positive match identifies a packet originated from one bridge
 	// network's bridge destined to another bridge network's bridge and will
 	// result in the packet being dropped. No match returns to the parent chain.
+
 	IsolationChain1 = "DOCKER-ISOLATION-STAGE-1"
 	IsolationChain2 = "DOCKER-ISOLATION-STAGE-2"
 )
@@ -382,11 +384,11 @@ func removeIPChains(version iptables.IPVersion) {
 
 	// Remove chains
 	for _, chainInfo := range []iptables.ChainInfo{
-		{Name: DockerChain, Table: iptables.Nat, IPTable: ipt},
-		{Name: DockerChain, Table: iptables.Filter, IPTable: ipt},
-		{Name: IsolationChain1, Table: iptables.Filter, IPTable: ipt},
-		{Name: IsolationChain2, Table: iptables.Filter, IPTable: ipt},
-		{Name: oldIsolationChain, Table: iptables.Filter, IPTable: ipt},
+		{Name: DockerChain, Table: iptables.Nat, IPVersion: version},
+		{Name: DockerChain, Table: iptables.Filter, IPVersion: version},
+		{Name: IsolationChain1, Table: iptables.Filter, IPVersion: version},
+		{Name: IsolationChain2, Table: iptables.Filter, IPVersion: version},
+		{Name: oldIsolationChain, Table: iptables.Filter, IPVersion: version},
 	} {
 		if err := chainInfo.Remove(); err != nil {
 			log.G(context.TODO()).Warnf("Failed to remove existing iptables entries in table %s chain %s : %v", chainInfo.Table, chainInfo.Name, err)

--- a/libnetwork/iptables/firewalld.go
+++ b/libnetwork/iptables/firewalld.go
@@ -20,8 +20,6 @@ const (
 	Iptables IPV = "ipv4"
 	// IP6Tables point to ipv6 table
 	IP6Tables IPV = "ipv6"
-	// Ebtables point to bridge table
-	Ebtables IPV = "eb"
 )
 
 const (

--- a/libnetwork/iptables/firewalld.go
+++ b/libnetwork/iptables/firewalld.go
@@ -177,14 +177,12 @@ func OnReloaded(callback func()) {
 
 // Call some remote method to see whether the service is actually running.
 func checkRunning() bool {
-	var zone string
-	var err error
-
-	if connection != nil {
-		err = connection.sysObj.Call(dbusInterface+".getDefaultZone", 0).Store(&zone)
-		return err == nil
+	if connection == nil {
+		return false
 	}
-	return false
+	var zone string
+	err := connection.sysObj.Call(dbusInterface+".getDefaultZone", 0).Store(&zone)
+	return err == nil
 }
 
 // Passthrough method simply passes args through to iptables/ip6tables

--- a/libnetwork/iptables/firewalld.go
+++ b/libnetwork/iptables/firewalld.go
@@ -114,10 +114,12 @@ func newConnection() (*Conn, error) {
 
 func signalHandler() {
 	for signal := range connection.signal {
-		if strings.Contains(signal.Name, "NameOwnerChanged") {
+		switch {
+		case strings.Contains(signal.Name, "NameOwnerChanged"):
 			firewalldRunning = checkRunning()
 			dbusConnectionChanged(signal.Body)
-		} else if strings.Contains(signal.Name, "Reloaded") {
+
+		case strings.Contains(signal.Name, "Reloaded"):
 			reloaded()
 		}
 	}

--- a/libnetwork/iptables/firewalld_test.go
+++ b/libnetwork/iptables/firewalld_test.go
@@ -75,6 +75,9 @@ func TestReloaded(t *testing.T) {
 }
 
 func TestPassthrough(t *testing.T) {
+	if !firewalldRunning {
+		t.Skip("firewalld is not running")
+	}
 	rule1 := []string{
 		"-i", "lo",
 		"-p", "udp",
@@ -82,14 +85,11 @@ func TestPassthrough(t *testing.T) {
 		"-j", "ACCEPT",
 	}
 
-	iptable := GetIptable(IPv4)
-	if firewalldRunning {
-		_, err := Passthrough(Iptables, append([]string{"-A"}, rule1...)...)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !iptable.Exists(Filter, "INPUT", rule1...) {
-			t.Fatal("rule1 does not exist")
-		}
+	_, err := Passthrough(Iptables, append([]string{"-A"}, rule1...)...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !GetIptable(IPv4).Exists(Filter, "INPUT", rule1...) {
+		t.Fatal("rule1 does not exist")
 	}
 }

--- a/libnetwork/iptables/firewalld_test.go
+++ b/libnetwork/iptables/firewalld_test.go
@@ -19,15 +19,11 @@ func TestFirewalldInit(t *testing.T) {
 }
 
 func TestReloaded(t *testing.T) {
-	var err error
-	var fwdChain *ChainInfo
-
 	iptable := GetIptable(IPv4)
-	fwdChain, err = iptable.NewChain("FWD", Filter, false)
+	fwdChain, err := iptable.NewChain("FWD", Filter, false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	bridgeName := "lo"
 
 	err = iptable.ProgramChain(fwdChain, bridgeName, false, true)
 	if err != nil {
@@ -38,8 +34,8 @@ func TestReloaded(t *testing.T) {
 	// copy-pasted from iptables_test:TestLink
 	ip1 := net.ParseIP("192.168.1.1")
 	ip2 := net.ParseIP("192.168.1.2")
-	port := 1234
-	proto := "tcp"
+	const port = 1234
+	const proto = "tcp"
 
 	err = fwdChain.Link(Append, ip1, ip2, port, proto, bridgeName)
 	if err != nil {

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -450,19 +450,19 @@ func (iptable IPTable) ExistsNative(table Table, chain string, rule ...string) b
 }
 
 func (iptable IPTable) exists(native bool, table Table, chain string, rule ...string) bool {
+	if err := initCheck(); err != nil {
+		// The exists() signature does not allow us to return an error, but at least
+		// we can skip the (likely invalid) exec invocation.
+		return false
+	}
+
 	f := iptable.Raw
 	if native {
 		f = iptable.raw
 	}
 
-	if string(table) == "" {
+	if table == "" {
 		table = Filter
-	}
-
-	if err := initCheck(); err != nil {
-		// The exists() signature does not allow us to return an error, but at least
-		// we can skip the (likely invalid) exec invocation.
-		return false
 	}
 
 	// if exit status is 0 then return true, the rule exists

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -275,13 +275,13 @@ func (iptable IPTable) ProgramChain(c *ChainInfo, bridgeName string, hairpinMode
 
 // RemoveExistingChain removes existing chain from the table.
 func (iptable IPTable) RemoveExistingChain(name string, table Table) error {
+	if table == "" {
+		table = Filter
+	}
 	c := &ChainInfo{
 		Name:    name,
 		Table:   table,
 		IPTable: iptable,
-	}
-	if string(c.Table) == "" {
-		c.Table = Filter
 	}
 	return c.Remove()
 }

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -581,7 +581,7 @@ func (iptable IPTable) AddReturnRule(chain string) error {
 
 	err := iptable.RawCombinedOutput("-A", chain, "-j", "RETURN")
 	if err != nil {
-		return fmt.Errorf("unable to add return rule in %s chain: %s", chain, err.Error())
+		return fmt.Errorf("unable to add return rule in %s chain: %v", chain, err)
 	}
 
 	return nil
@@ -592,13 +592,13 @@ func (iptable IPTable) EnsureJumpRule(fromChain, toChain string) error {
 	if iptable.Exists(Filter, fromChain, "-j", toChain) {
 		err := iptable.RawCombinedOutput("-D", fromChain, "-j", toChain)
 		if err != nil {
-			return fmt.Errorf("unable to remove jump to %s rule in %s chain: %s", toChain, fromChain, err.Error())
+			return fmt.Errorf("unable to remove jump to %s rule in %s chain: %v", toChain, fromChain, err)
 		}
 	}
 
 	err := iptable.RawCombinedOutput("-I", fromChain, "-j", toChain)
 	if err != nil {
-		return fmt.Errorf("unable to insert jump to %s rule in %s chain: %s", toChain, fromChain, err.Error())
+		return fmt.Errorf("unable to insert jump to %s rule in %s chain: %v", toChain, fromChain, err)
 	}
 
 	return nil

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -83,7 +83,7 @@ type ChainError struct {
 }
 
 func (e ChainError) Error() string {
-	return fmt.Sprintf("Error iptables %s: %s", e.Chain, string(e.Output))
+	return fmt.Sprintf("error iptables %s: %s", e.Chain, string(e.Output))
 }
 
 func detectIptables() {
@@ -173,7 +173,7 @@ func (iptable IPTable) LoopbackByVersion() string {
 // ProgramChain is used to add rules to a chain
 func (iptable IPTable) ProgramChain(c *ChainInfo, bridgeName string, hairpinMode, enable bool) error {
 	if c.Name == "" {
-		return errors.New("Could not program chain, missing chain name")
+		return errors.New("could not program chain, missing chain name")
 	}
 
 	// Either add or remove the interface from the firewalld zone
@@ -198,11 +198,11 @@ func (iptable IPTable) ProgramChain(c *ChainInfo, bridgeName string, hairpinMode
 		}
 		if !iptable.Exists(Nat, "PREROUTING", preroute...) && enable {
 			if err := c.Prerouting(Append, preroute...); err != nil {
-				return fmt.Errorf("Failed to inject %s in PREROUTING chain: %s", c.Name, err)
+				return fmt.Errorf("failed to inject %s in PREROUTING chain: %s", c.Name, err)
 			}
 		} else if iptable.Exists(Nat, "PREROUTING", preroute...) && !enable {
 			if err := c.Prerouting(Delete, preroute...); err != nil {
-				return fmt.Errorf("Failed to remove %s in PREROUTING chain: %s", c.Name, err)
+				return fmt.Errorf("failed to remove %s in PREROUTING chain: %s", c.Name, err)
 			}
 		}
 		output := []string{
@@ -215,17 +215,16 @@ func (iptable IPTable) ProgramChain(c *ChainInfo, bridgeName string, hairpinMode
 		}
 		if !iptable.Exists(Nat, "OUTPUT", output...) && enable {
 			if err := c.Output(Append, output...); err != nil {
-				return fmt.Errorf("Failed to inject %s in OUTPUT chain: %s", c.Name, err)
+				return fmt.Errorf("failed to inject %s in OUTPUT chain: %s", c.Name, err)
 			}
 		} else if iptable.Exists(Nat, "OUTPUT", output...) && !enable {
 			if err := c.Output(Delete, output...); err != nil {
-				return fmt.Errorf("Failed to inject %s in OUTPUT chain: %s", c.Name, err)
+				return fmt.Errorf("failed to inject %s in OUTPUT chain: %s", c.Name, err)
 			}
 		}
 	case Filter:
 		if bridgeName == "" {
-			return fmt.Errorf("Could not program chain %s/%s, missing bridge name",
-				c.Table, c.Name)
+			return fmt.Errorf("could not program chain %s/%s, missing bridge name", c.Table, c.Name)
 		}
 		link := []string{
 			"-o", bridgeName,
@@ -236,14 +235,14 @@ func (iptable IPTable) ProgramChain(c *ChainInfo, bridgeName string, hairpinMode
 			if output, err := iptable.Raw(insert...); err != nil {
 				return err
 			} else if len(output) != 0 {
-				return fmt.Errorf("Could not create linking rule to %s/%s: %s", c.Table, c.Name, output)
+				return fmt.Errorf("could not create linking rule to %s/%s: %s", c.Table, c.Name, output)
 			}
 		} else if iptable.Exists(Filter, "FORWARD", link...) && !enable {
 			del := append([]string{string(Delete), "FORWARD"}, link...)
 			if output, err := iptable.Raw(del...); err != nil {
 				return err
 			} else if len(output) != 0 {
-				return fmt.Errorf("Could not delete linking rule from %s/%s: %s", c.Table, c.Name, output)
+				return fmt.Errorf("could not delete linking rule from %s/%s: %s", c.Table, c.Name, output)
 			}
 		}
 		establish := []string{
@@ -257,14 +256,14 @@ func (iptable IPTable) ProgramChain(c *ChainInfo, bridgeName string, hairpinMode
 			if output, err := iptable.Raw(insert...); err != nil {
 				return err
 			} else if len(output) != 0 {
-				return fmt.Errorf("Could not create establish rule to %s: %s", c.Table, output)
+				return fmt.Errorf("could not create establish rule to %s: %s", c.Table, output)
 			}
 		} else if iptable.Exists(Filter, "FORWARD", establish...) && !enable {
 			del := append([]string{string(Delete), "FORWARD"}, establish...)
 			if output, err := iptable.Raw(del...); err != nil {
 				return err
 			} else if len(output) != 0 {
-				return fmt.Errorf("Could not delete establish rule from %s: %s", c.Table, output)
+				return fmt.Errorf("could not delete establish rule from %s: %s", c.Table, output)
 			}
 		}
 	}

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -577,16 +577,11 @@ func (iptable IPTable) SetDefaultPolicy(table Table, chain string, policy Policy
 
 // AddReturnRule adds a return rule for the chain in the filter table
 func (iptable IPTable) AddReturnRule(chain string) error {
-	var (
-		table = Filter
-		args  = []string{"-j", "RETURN"}
-	)
-
-	if iptable.Exists(table, chain, args...) {
+	if iptable.Exists(Filter, chain, "-j", "RETURN") {
 		return nil
 	}
 
-	err := iptable.RawCombinedOutput(append([]string{"-A", chain}, args...)...)
+	err := iptable.RawCombinedOutput("-A", chain, "-j", "RETURN")
 	if err != nil {
 		return fmt.Errorf("unable to add return rule in %s chain: %s", chain, err.Error())
 	}
@@ -596,19 +591,14 @@ func (iptable IPTable) AddReturnRule(chain string) error {
 
 // EnsureJumpRule ensures the jump rule is on top
 func (iptable IPTable) EnsureJumpRule(fromChain, toChain string) error {
-	var (
-		table = Filter
-		args  = []string{"-j", toChain}
-	)
-
-	if iptable.Exists(table, fromChain, args...) {
-		err := iptable.RawCombinedOutput(append([]string{"-D", fromChain}, args...)...)
+	if iptable.Exists(Filter, fromChain, "-j", toChain) {
+		err := iptable.RawCombinedOutput("-D", fromChain, "-j", toChain)
 		if err != nil {
 			return fmt.Errorf("unable to remove jump to %s rule in %s chain: %s", toChain, fromChain, err.Error())
 		}
 	}
 
-	err := iptable.RawCombinedOutput(append([]string{"-I", fromChain}, args...)...)
+	err := iptable.RawCombinedOutput("-I", fromChain, "-j", toChain)
 	if err != nil {
 		return fmt.Errorf("unable to insert jump to %s rule in %s chain: %s", toChain, fromChain, err.Error())
 	}

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -60,9 +60,7 @@ var (
 	xLockWaitMsg  = "Another app is currently holding the xtables lock"
 	// used to lock iptables commands if xtables lock is not supported
 	bestEffortLock sync.Mutex
-	// ErrIptablesNotFound is returned when the rule is not found.
-	ErrIptablesNotFound = errors.New("Iptables not found")
-	initOnce            sync.Once
+	initOnce       sync.Once
 )
 
 // IPTable defines struct with IPVersion
@@ -133,7 +131,7 @@ func initCheck() error {
 	initOnce.Do(initDependencies)
 
 	if iptablesPath == "" {
-		return ErrIptablesNotFound
+		return errors.New("iptables not found")
 	}
 	return nil
 }

--- a/libnetwork/iptables/iptables_test.go
+++ b/libnetwork/iptables/iptables_test.go
@@ -252,8 +252,8 @@ func TestCleanup(t *testing.T) {
 }
 
 func TestExistsRaw(t *testing.T) {
-	testChain1 := "ABCD"
-	testChain2 := "EFGH"
+	const testChain1 = "ABCD"
+	const testChain2 = "EFGH"
 
 	iptable := GetIptable(IPv4)
 


### PR DESCRIPTION
### libnetwork/iptables: inline some args

Just inline the args if they're not dynamically constructed.

### libnetwork/iptables: IPTable.NewChain() minor cleanups

- validate input variables before constructing the ChainInfo
- only construct the ChainInfo if things were successful

### libnetwork/iptables: don't use err.Error() if not needed

### libnetwork/iptables: IPTable.exists(): return early on error

Also remove a redundant string cast for the Table value.

### libnetwork/iptables: IPTable.RemoveExistingChain() slight refactor

### libnetwork/iptables: ChainInfo.Output(): explicitly suppress errors

### libnetwork/iptables: ChainInfo: don't pass whole IPTable as value

It only needed the IPVersion, so let's pass that instead.

### libnetwork/drivers/bridge: rename vars that collided with type


### libnetwork/iptables: TestPassthrough(): skip without firewalld

The test was not doing anything without firewalld running, but did
not skip either.


### libnetwork/iptables: TestReloaded(): minor cleanup

- remove local bridgeName variable that shadowed the const, but
  used the same value
- remove some redundant `var` declarations, and changed fixed
  values to a const

### libnetwork/iptables: remove unused Ebtables const

This const was added in 8301dcc6d702a97feeb968ee79ae381fd8a4997a, before
being moved to libnetwork, and moved back, but it was never used.

### libnetwork/iptables: checkRunning(): use early return

Remove redundant variable declarations, and use an early return instead.

### libnetwork/iptables: merge Conn.initConnection into newConnection

initConnection was effectively just part of the constructor; ot was not
used elsewhere. Merge the two functions to simplify things a bit.


### libnetwork/iptables: signalHandler(): use s switch

It felt ever-so-slightly more readable than if/else if/(else if...)


### libnetwork/drivers/bridge: minor cleanups for iptables funcs

setupBridgeNetFiltering:
- Indicate that the bridgeInterface argument is unused (but it's needed
  to satisfy the signature).
- Return instead of nullifying the err. Still not great, but I thought it
  was very slightly more logical thing to do.

checkBridgeNetFiltering:
- Remove unused argument, and scope ipVerName to the branch where it's
  used.

### libnetwork/iptables: remove ErrIptablesNotFound

looks like this error was added in 1cbdaebaa1c2326e57945333420d25d6f77011d5,
and later moved to libnetwork in https://github.com/moby/libnetwork/commit/44c96449c2aafbb22487086ad94ff865f9ee855a
which also updated the description to something that doesn't match what
it means.

In either case, this error was never used as a special / sentinel error,
so we can just use a regular error return.

While at it, I also lower-cased the error-message; it's not string-matched
anywhere, so we can update it to make linters more happy.

### libnetwork/iptables: errors should not be capitalized

None of these errors were string-matched anywhere, so let's change them
to be non-capitalized, as they should.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

