### PR TITLE
pkg/plugins: make unit test less time sensitive

### DIFF
--- a/pkg/plugins/client_test.go
+++ b/pkg/plugins/client_test.go
@@ -3,6 +3,7 @@ package plugins // import "github.com/docker/docker/pkg/plugins"
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,7 +14,6 @@ import (
 
 	"github.com/docker/docker/pkg/plugins/transport"
 	"github.com/docker/go-connections/tlsconfig"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -240,22 +240,39 @@ func TestClientWithRequestTimeout(t *testing.T) {
 		Timeout() bool
 	}
 
-	timeout := 1 * time.Millisecond
+	unblock := make(chan struct{})
 	testHandler := func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(timeout + 10*time.Millisecond)
+		select {
+		case <-unblock:
+		case <-r.Context().Done():
+		}
 		w.WriteHeader(http.StatusOK)
 	}
 
 	srv := httptest.NewServer(http.HandlerFunc(testHandler))
-	defer srv.Close()
+	defer func() {
+		close(unblock)
+		srv.Close()
+	}()
 
 	client := &Client{http: srv.Client(), requestFactory: &testRequestWrapper{srv}}
-	_, err := client.callWithRetry("/Plugin.Hello", nil, false, WithRequestTimeout(timeout))
-	assert.Assert(t, is.ErrorContains(err, ""), "expected error")
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := client.callWithRetry("/Plugin.Hello", nil, false, WithRequestTimeout(time.Millisecond))
+		errCh <- err
+	}()
 
-	var tErr timeoutError
-	assert.Assert(t, errors.As(err, &tErr))
-	assert.Assert(t, tErr.Timeout())
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	select {
+	case err := <-errCh:
+		var tErr timeoutError
+		if assert.Check(t, errors.As(err, &tErr), "want timeout error, got %T", err) {
+			assert.Check(t, tErr.Timeout())
+		}
+	case <-timer.C:
+		t.Fatal("client request did not time out in time")
+	}
 }
 
 type testRequestWrapper struct {


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/38587

TestClientWithRequestTimeout has been observed to flake in CI. The timing in the test is quite tight, only giving the client a 10ms window to time out, which could potentially be missed if the host is under load and the goroutine scheduling is unlucky. Give the client a full five seconds of grace to time out before failing the test.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

