### PR TITLE
d/g/overlayutils: improve SupportsOverlay checks

### DIFF
--- a/daemon/graphdriver/overlayutils/overlayutils.go
+++ b/daemon/graphdriver/overlayutils/overlayutils.go
@@ -4,7 +4,9 @@
 package overlayutils // import "github.com/docker/docker/daemon/graphdriver/overlayutils"
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,6 +16,7 @@ import (
 	"github.com/containerd/containerd/pkg/userns"
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/opencontainers/selinux/go-selinux"
+	"golang.org/x/sys/unix"
 )
 
 // ErrDTypeNotSupported denotes that the backing filesystem doesn't support d_type.
@@ -37,8 +40,12 @@ const (
 )
 
 // SupportsOverlay determines whether the kernel supports overlayfs (meeting our needs) by performing an actual mount.
+// Before the mount, we also check for basic vfs functionality that overlay depends on, but may not check before
+// creating a mount, e.g. the RENAME_EXCHANGE, RENAME_NOREPLACE, RENAME_WHITEOUT, and flags in renameat2(2).
 //
 // checkMultipleLowers tests for multiple lowerdir support, which is needed for overlay2.
+//
+// [renameat2(2)]: https://linux.die.net/man/2/renameat
 func SupportsOverlay(d string, checkMultipleLowers bool) error {
 	// We can't solely rely on selinux.GetEnabled() to detect whether SELinux is enabled, as [RootlessKit] does not
 	// mount /sys/fs/selinux for us. _DOCKERD_ROOTLESS_SELINUX is set in the dockerd-rootless.sh wrapper script instead.
@@ -66,6 +73,43 @@ func SupportsOverlay(d string, checkMultipleLowers bool) error {
 		if err := os.Mkdir(dir, 0o755); err != nil {
 			return err
 		}
+	}
+
+	// Create files, each holding their own path, which will be used for subsequent testing.
+	f1, f2 := filepath.Join(l1, "f1"), filepath.Join(l1, "f2")
+	for _, file := range []string{f1, f2} {
+		if err := os.WriteFile(file, []byte(file), 0o644); err != nil {
+			return err
+		}
+	}
+
+	// RENAME_EXCHANGE will cause an atomic swap of f1 and f2. Create two files, each with their own paths as their
+	// contents.
+	err = unix.Renameat2(0, f1, 0, f2, unix.RENAME_EXCHANGE)
+	if err != nil {
+		return err
+	}
+	// The contents of f1 should now be the path to f2, and vice versa.
+	content, err := os.ReadFile(f1)
+	if !bytes.Equal(content, []byte(f2)) || err != nil {
+		return fmt.Errorf("RENAME_EXCHANGE of %v and %v failed: %w", f1, f2, err)
+	}
+
+	// RENAME_NOREPLACE should cause an error since f2 already exists.
+	err = unix.Renameat2(0, f1, 0, f2, unix.RENAME_NOREPLACE)
+	if !errors.Is(err, unix.EEXIST) {
+		return fmt.Errorf("RENAME_NOREPLACE of %v to %v should have failed with EEXIST, but got %w", f1, f2, err)
+	}
+
+	// RENAME_WHITEOUT will move f3 to f4, leaving a whiteout file behind. This is used internally by overlayfs, but is
+	// not validated before a mount is attempted, as some use cases may not break. Ours will.
+	f3, f4 := filepath.Join(l1, "f3"), filepath.Join(l1, "f4")
+	if err := os.WriteFile(f3, []byte{}, 0o700); err != nil {
+		return err
+	}
+	err = unix.Renameat2(0, f3, 0, f4, unix.RENAME_WHITEOUT)
+	if err != nil {
+		return fmt.Errorf("RENAME_WHITEOUT of %v to %v failed: %w", f3, f4, err)
 	}
 
 	lowers := l1


### PR DESCRIPTION
- Fixes https://github.com/moby/moby/issues/45884
- Relates to https://github.com/moby/moby/issues/42333
- Relates to https://github.com/moby/moby/issues/41230
- Relates to https://github.com/rootless-containers/rootlesskit/issues/94

**- What I did**
Adjust the logic in `SupportsOverlay`, to both check for SELinux support more holistically, and to check the underlying filesystem for support for vfs operations required by overlayfs in some cases, but that don't prevent a mount.

This prevents recent versions of OpenZFS that don't truly support overlayfs from being selected for use.

**- How I did it**

Reading the kernel source/experimentally.

**- How to verify it**

TODO

**- Description for the changelog**
TODO

**- A picture of a cute animal (not mandatory but encouraged)**
