### PR TITLE
integration: disable iptables in parallel tests

### DIFF
--- a/integration/container/daemon_linux_test.go
+++ b/integration/container/daemon_linux_test.go
@@ -140,7 +140,7 @@ func TestDaemonHostGatewayIP(t *testing.T) {
 	// Verify the IP in /etc/hosts is same as host-gateway-ip
 	d := daemon.New(t)
 	// Verify the IP in /etc/hosts is same as the default bridge's IP
-	d.StartWithBusybox(t)
+	d.StartWithBusybox(t, "--iptables=false")
 	c := d.NewClientT(t)
 	ctx := context.Background()
 	cID := container.Run(ctx, t, c,
@@ -157,7 +157,7 @@ func TestDaemonHostGatewayIP(t *testing.T) {
 	d.Stop(t)
 
 	// Verify the IP in /etc/hosts is same as host-gateway-ip
-	d.StartWithBusybox(t, "--host-gateway-ip=6.7.8.9")
+	d.StartWithBusybox(t, "--iptables=false", "--host-gateway-ip=6.7.8.9")
 	cID = container.Run(ctx, t, c,
 		container.WithExtraHost("host.docker.internal:host-gateway"),
 	)
@@ -208,7 +208,7 @@ func TestRestartDaemonWithRestartingContainer(t *testing.T) {
 		c.HasBeenStartedBefore = true
 	})
 
-	d.Start(t)
+	d.Start(t, "--iptables=false")
 
 	ctxTimeout, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
@@ -256,7 +256,7 @@ func TestHardRestartWhenContainerIsRunning(t *testing.T) {
 		})
 	}
 
-	d.Start(t)
+	d.Start(t, "--iptables=false")
 
 	t.Run("RestartPolicy=none", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)

--- a/integration/container/daemon_test.go
+++ b/integration/container/daemon_test.go
@@ -43,7 +43,7 @@ func TestContainerKillOnDaemonStart(t *testing.T) {
 	assert.Assert(t, inspect.State.Running)
 
 	assert.NilError(t, d.Kill())
-	d.Start(t)
+	d.Start(t, "--iptables=false")
 
 	inspect, err = client.ContainerInspect(ctx, id)
 	assert.Check(t, is.Nil(err))

--- a/integration/image/import_test.go
+++ b/integration/image/import_test.go
@@ -27,7 +27,7 @@ func TestImportExtremelyLargeImageWorks(t *testing.T) {
 
 	// Spin up a new daemon, so that we can run this test in parallel (it's a slow test)
 	d := daemon.New(t)
-	d.Start(t)
+	d.Start(t, "--iptables=false")
 	defer d.Stop(t)
 
 	client := d.NewClientT(t)


### PR DESCRIPTION
Multiple daemons starting/running concurrently can collide with each other when editing iptables rules. Most integration tests which opt into parallelism and start daemons work around this problem by starting the daemon with the `--iptables=false option`. However, some of the tests neglect to pass the option when starting or restarting the daemon, resulting in those tests being flaky.

Audit the integration tests which call `t.Parallel()` and `(*Daemon).Stop()` and add `--iptables=false` arguments where needed.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

