### PR TITLE
Add Albin Kerouanton (@akerouanton) as maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -24,6 +24,7 @@
 	# subsystem maintainers accountable. If ownership is unclear, they are the de facto owners.
 
 		people = [
+			"akerouanton",
 			"akihirosuda",
 			"anusha",
 			"coolljt0725",
@@ -63,7 +64,6 @@
 	# - close an issue or pull request when it's inappropriate or off-topic
 
 		people = [
-		    "akerouanton",
 			"alexellis",
 			"andrewhsu",
 			"bsousaa",


### PR DESCRIPTION
Albin is currently a curator, has been contributing for various years prior to that, and has taken on the daunting task to work on Moby's networking stack.

Albin would be a great addition to our list of maintainers and to allow him to perform his work in these areas in a more official capacity.

I nominated Albin as maintainer, and votes passed, so opening a PR to make it official.


**- A picture of a cute animal (not mandatory but encouraged)**

![squirrel-nut-cute-animal-nature-grass-1920x1280](https://github.com/moby/moby/assets/1804568/f4cfde0c-17d2-4c1c-8e18-9f94b84d4cbc)
