### PR TITLE
[23.0 backport] make tests less flaky

### DIFF
--- a/integration/container/daemon_linux_test.go
+++ b/integration/container/daemon_linux_test.go
@@ -141,7 +141,7 @@ func TestDaemonHostGatewayIP(t *testing.T) {
 	// Verify the IP in /etc/hosts is same as host-gateway-ip
 	d := daemon.New(t)
 	// Verify the IP in /etc/hosts is same as the default bridge's IP
-	d.StartWithBusybox(t)
+	d.StartWithBusybox(t, "--iptables=false")
 	c := d.NewClientT(t)
 	ctx := context.Background()
 	cID := container.Run(ctx, t, c,
@@ -158,7 +158,7 @@ func TestDaemonHostGatewayIP(t *testing.T) {
 	d.Stop(t)
 
 	// Verify the IP in /etc/hosts is same as host-gateway-ip
-	d.StartWithBusybox(t, "--host-gateway-ip=6.7.8.9")
+	d.StartWithBusybox(t, "--iptables=false", "--host-gateway-ip=6.7.8.9")
 	cID = container.Run(ctx, t, c,
 		container.WithExtraHost("host.docker.internal:host-gateway"),
 	)
@@ -220,7 +220,7 @@ func TestRestartDaemonWithRestartingContainer(t *testing.T) {
 	assert.NilError(t, err)
 	assert.NilError(t, os.WriteFile(configPath, configBytes, 0600))
 
-	d.Start(t)
+	d.Start(t, "--iptables=false")
 
 	ctxTimeout, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()

--- a/integration/container/daemon_test.go
+++ b/integration/container/daemon_test.go
@@ -43,7 +43,7 @@ func TestContainerKillOnDaemonStart(t *testing.T) {
 	assert.Assert(t, inspect.State.Running)
 
 	assert.NilError(t, d.Kill())
-	d.Start(t)
+	d.Start(t, "--iptables=false")
 
 	inspect, err = client.ContainerInspect(ctx, id)
 	assert.Check(t, is.Nil(err))

--- a/integration/image/import_test.go
+++ b/integration/image/import_test.go
@@ -27,7 +27,7 @@ func TestImportExtremelyLargeImageWorks(t *testing.T) {
 
 	// Spin up a new daemon, so that we can run this test in parallel (it's a slow test)
 	d := daemon.New(t)
-	d.Start(t)
+	d.Start(t, "--iptables=false")
 	defer d.Stop(t)
 
 	client := d.NewClientT(t)

--- a/pkg/plugins/client_test.go
+++ b/pkg/plugins/client_test.go
@@ -3,6 +3,7 @@ package plugins // import "github.com/docker/docker/pkg/plugins"
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,7 +14,6 @@ import (
 
 	"github.com/docker/docker/pkg/plugins/transport"
 	"github.com/docker/go-connections/tlsconfig"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -240,22 +240,39 @@ func TestClientWithRequestTimeout(t *testing.T) {
 		Timeout() bool
 	}
 
-	timeout := 1 * time.Millisecond
+	unblock := make(chan struct{})
 	testHandler := func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(timeout + 10*time.Millisecond)
+		select {
+		case <-unblock:
+		case <-r.Context().Done():
+		}
 		w.WriteHeader(http.StatusOK)
 	}
 
 	srv := httptest.NewServer(http.HandlerFunc(testHandler))
-	defer srv.Close()
+	defer func() {
+		close(unblock)
+		srv.Close()
+	}()
 
 	client := &Client{http: srv.Client(), requestFactory: &testRequestWrapper{srv}}
-	_, err := client.callWithRetry("/Plugin.Hello", nil, false, WithRequestTimeout(timeout))
-	assert.Assert(t, is.ErrorContains(err, ""), "expected error")
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := client.callWithRetry("/Plugin.Hello", nil, false, WithRequestTimeout(time.Millisecond))
+		errCh <- err
+	}()
 
-	var tErr timeoutError
-	assert.Assert(t, errors.As(err, &tErr))
-	assert.Assert(t, tErr.Timeout())
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	select {
+	case err := <-errCh:
+		var tErr timeoutError
+		if assert.Check(t, errors.As(err, &tErr), "want timeout error, got %T", err) {
+			assert.Check(t, tErr.Timeout())
+		}
+	case <-timer.C:
+		t.Fatal("client request did not time out in time")
+	}
 }
 
 type testRequestWrapper struct {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

23.0 backports of:
- #45889 
- #45891 

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

