### PR TITLE
libnet: Return proper error when overlay network can't be created

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -9900,7 +9900,9 @@ paths:
               Id: "22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30"
               Warning: ""
         403:
-          description: "operation not supported for pre-defined networks"
+          description: |
+            Forbidden operation. This happens when trying to create a network named after a pre-defined network,
+            or when trying to create an overlay network on a daemon which is not part of a Swarm cluster.
           schema:
             $ref: "#/definitions/ErrorResponse"
         404:

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -293,6 +293,16 @@ func (daemon *Daemon) createNetwork(cfg *config.Config, create types.NetworkCrea
 		return nil, PredefinedNetworkError(create.Name)
 	}
 
+	c := daemon.netController
+	driver := create.Driver
+	if driver == "" {
+		driver = c.Config().DefaultDriver
+	}
+
+	if driver == "overlay" && !daemon.cluster.IsManager() && !agent {
+		return nil, errors.New(`This node is not a swarm manager. Use "docker swarm init" or "docker swarm join" to connect this node to swarm and try again.`)
+	}
+
 	var warning string
 	nw, err := daemon.GetNetworkByName(create.Name)
 	if err != nil {
@@ -309,12 +319,6 @@ func (daemon *Daemon) createNetwork(cfg *config.Config, create types.NetworkCrea
 			}
 		}
 		warning = fmt.Sprintf("Network with name %s (id : %s) already exists", nw.Name(), nw.ID())
-	}
-
-	c := daemon.netController
-	driver := create.Driver
-	if driver == "" {
-		driver = c.Config().DefaultDriver
 	}
 
 	networkOptions := make(map[string]string)
@@ -375,10 +379,6 @@ func (daemon *Daemon) createNetwork(cfg *config.Config, create types.NetworkCrea
 
 	n, err := c.NewNetwork(driver, create.Name, id, nwOptions...)
 	if err != nil {
-		if errors.Is(err, libnetwork.ErrDataStoreNotInitialized) {
-			//nolint: revive
-			return nil, errors.New(`This node is not a swarm manager. Use "docker swarm init" or "docker swarm join" to connect this node to swarm and try again.`)
-		}
 		return nil, err
 	}
 

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -300,7 +300,7 @@ func (daemon *Daemon) createNetwork(cfg *config.Config, create types.NetworkCrea
 	}
 
 	if driver == "overlay" && !daemon.cluster.IsManager() && !agent {
-		return nil, errors.New(`This node is not a swarm manager. Use "docker swarm init" or "docker swarm join" to connect this node to swarm and try again.`)
+		return nil, errdefs.Forbidden(errors.New(`This node is not a swarm manager. Use "docker swarm init" or "docker swarm join" to connect this node to swarm and try again.`))
 	}
 
 	var warning string


### PR DESCRIPTION
related:

- https://github.com/moby/moby/pull/44875
- https://github.com/moby/moby/pull/44965

**- What I did**

##### 1st commit: `libnet: Return proper error when overlay network can't be created`

Commit https://github.com/moby/moby/commit/befff0e13f68d39fed40e9f81bafc25042e944da (https://github.com/moby/moby/pull/44875) inadvertendly disabled the error returned when trying to create an overlay network on a node which is not part of a Swarm cluster.

Since commit https://github.com/moby/moby/commit/e3708a89ccf5c88273660b2409e2ea1197530b0b (https://github.com/moby/moby/pull/44965) the overlay netdriver returns the error: `no VNI provided`.

This commit reinstates the original error message by checking if the node is a manager before calling libnetwork's `controller.NewNetwork()`.

##### 2nd commit: `libnet: Return a 403 when overlay network isn't allowed`

With this change, the API will now return a 403 instead of a 500 when trying to create an overlay network on a non-manager node.

**- How to verify it**

```
$ docker network create --driver overlay testnet
Error response from daemon: This node is not a swarm manager. Use "docker swarm init" or "docker swarm join" to connect this node to swarm and try again.
```

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://media.australian.museum/media/dd/images/parma_wallaby2.0206795.width-800.c4ac33a.jpg)