### PR TITLE
Sort unconsumed build arguments before usage

### DIFF
--- a/builder/dockerfile/buildargs.go
+++ b/builder/dockerfile/buildargs.go
@@ -3,6 +3,7 @@ package dockerfile // import "github.com/docker/docker/builder/dockerfile"
 import (
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/docker/docker/runconfig/opts"
 )
@@ -80,6 +81,7 @@ func (b *BuildArgs) WarnOnUnusedBuildArgs(out io.Writer) {
 		}
 	}
 	if len(leftoverArgs) > 0 {
+		sort.Strings(leftoverArgs)
 		fmt.Fprintf(out, "[Warning] One or more build-args %v were not consumed\n", leftoverArgs)
 	}
 }


### PR DESCRIPTION
Golang map iteration order is not guaranteed, so in some cases the built slice has it's output of order as well. This means that testing for exact warning messages in docker build output would result in random test failures, making it more annoying for end-users to test against this functionality.

For an example, see https://github.com/dokku/dokku/actions/runs/5498446963/jobs/10019973537?pr=6018 - the dokku project tests against build output to ensure build args aren't consumed but the docker build succeeds 

---

**- What I did**

I sorted the strings.

**- How I did it**

```go
sort.Strings()
```

**- How to verify it**

Run a build with unconsumed build arguments

**- Description for the changelog**

```
Sort unconsumed build arguments before display in build output
```

**- A picture of a cute animal (not mandatory but encouraged)**

![2014-08-31 14 29 49](https://github.com/moby/moby/assets/65675/b2b0b092-e382-49bc-9cf0-17c1e474c676)
