### PR TITLE
registry: minor fixes and cleanups in search code

### DIFF
--- a/registry/config.go
+++ b/registry/config.go
@@ -439,10 +439,5 @@ func ParseRepositoryInfo(reposName reference.Named) (*RepositoryInfo, error) {
 // for that.
 func ParseSearchIndexInfo(reposName string) (*registry.IndexInfo, error) {
 	indexName, _ := splitReposSearchTerm(reposName)
-
-	indexInfo, err := newIndexInfo(emptyServiceConfig, indexName)
-	if err != nil {
-		return nil, err
-	}
-	return indexInfo, nil
+	return newIndexInfo(emptyServiceConfig, indexName)
 }

--- a/registry/session.go
+++ b/registry/session.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -208,10 +209,14 @@ func (r *session) searchRepositories(term string, limit int) (*registry.SearchRe
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		return nil, errdefs.Unknown(&jsonmessage.JSONError{
-			Message: fmt.Sprintf("Unexpected status code %d", res.StatusCode),
+			Message: "Unexpected status code " + strconv.Itoa(res.StatusCode),
 			Code:    res.StatusCode,
 		})
 	}
-	result := new(registry.SearchResults)
-	return result, errors.Wrap(json.NewDecoder(res.Body).Decode(result), "error decoding registry search results")
+	result := &registry.SearchResults{}
+	err = json.NewDecoder(res.Body).Decode(result)
+	if err != nil {
+		return nil, errdefs.System(errors.Wrap(err, "error decoding registry search results"))
+	}
+	return result, nil
 }

--- a/registry/session.go
+++ b/registry/session.go
@@ -192,8 +192,8 @@ func (r *session) searchRepositories(term string, limit int) (*registry.SearchRe
 	if limit < 1 || limit > 100 {
 		return nil, invalidParamf("limit %d is outside the range of [1, 100]", limit)
 	}
-	log.G(context.TODO()).Debugf("Index server: %s", r.indexEndpoint)
 	u := r.indexEndpoint.String() + "search?q=" + url.QueryEscape(term) + "&n=" + url.QueryEscape(fmt.Sprintf("%d", limit))
+	log.G(context.TODO()).WithField("url", u).Debug("searchRepositories")
 
 	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {


### PR DESCRIPTION
### registry: ParseSearchIndexInfo: remove redundant error-handling

### registry: session.searchRepositories(): log actual search URL

### registry: session.searchRepositories(): return typed error, and small cleanup

- return a errdefs.System if we fail to decode the registry's response
- use strconv.Itoa instead of fmt.Sprintf




**- A picture of a cute animal (not mandatory but encouraged)**

