### PR TITLE
api: search: deprecate is_automated field, and is-automated filter

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8601,28 +8601,36 @@ paths:
                 is_official:
                   type: "boolean"
                 is_automated:
+                  description: |
+                    Whether this repository has automated builds enabled.
+
+                    <p><br /></p>
+
+                    > **Deprecated**: This field is deprecated and will always
+                    > be "false" in future.
                   type: "boolean"
+                  example: false
                 name:
                   type: "string"
                 star_count:
                   type: "integer"
           examples:
             application/json:
-              - description: ""
-                is_official: false
+              - description: "A minimal Docker image based on Alpine Linux with a complete package index and only 5 MB in size!"
+                is_official: true
                 is_automated: false
-                name: "wma55/u1210sshd"
-                star_count: 0
-              - description: ""
-                is_official: false
+                name: "alpine"
+                star_count: 10093
+              - description: "Busybox base image."
+                is_official: true
                 is_automated: false
-                name: "jdswinbank/sshd"
-                star_count: 0
-              - description: ""
-                is_official: false
+                name: "Busybox base image."
+                star_count: 3037
+              - description: "The PostgreSQL object-relational database system provides reliability and data integrity."
+                is_official: true
                 is_automated: false
-                name: "vgauthier/sshd"
-                star_count: 0
+                name: "postgres"
+                star_count: 12408
         500:
           description: "Server error"
           schema:
@@ -8642,9 +8650,13 @@ paths:
           description: |
             A JSON encoded value of the filters (a `map[string][]string`) to process on the images list. Available filters:
 
-            - `is-automated=(true|false)`
+            - `is-automated=(true|false)` (deprecated, see below)
             - `is-official=(true|false)`
             - `stars=<number>` Matches images that has at least 'number' stars.
+
+            The `is-automated` filter is deprecated. The `is_automated` field has
+            been deprecated by Docker Hub's search API. Consequently, searching
+            for `is-automated=true` will yield no results.
           type: "string"
       tags: ["Image"]
   /images/prune:

--- a/api/types/registry/registry.go
+++ b/api/types/registry/registry.go
@@ -92,7 +92,9 @@ type SearchResult struct {
 	IsOfficial bool `json:"is_official"`
 	// Name is the name of the repository
 	Name string `json:"name"`
-	// IsAutomated indicates whether the result is automated
+	// IsAutomated indicates whether the result is automated.
+	//
+	// Deprecated: the "is_automated" field is deprecated and will always be "false" in the future.
 	IsAutomated bool `json:"is_automated"`
 	// Description is a textual description of the repository
 	Description string `json:"description"`

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -20,6 +20,14 @@ keywords: "API, Docker, rcli, REST, documentation"
 * The `VirtualSize` field in the `GET /images/{name}/json`, `GET /images/json`,
   and `GET /system/df` responses is now omitted. Use the `Size` field instead,
   which contains the same information.
+* Deprecated: The `is_automated` field in the `GET /images/search` response has
+  been deprecated and will always be set to false in the future because Docker
+  Hub is deprecating the `is_automated` field in its search API. The deprecation
+  is_ not versioned, and applies to all API versions.
+* Deprecated: The `is-automated` filter for the `GET /images/search` endpoint.
+  The `is_automated` field has been deprecated by Docker Hub's search API.
+  Consequently, searching for `is-automated=true` will yield no results. The
+  deprecation is not versioned, and applies to all API versions.
 * Read-only bind mounts are now made recursively read-only on kernel >= 5.12
   with runtimes which support the feature.
   `POST /containers/create`, `GET /containers/{id}/json`, and `GET /containers/json` now supports

--- a/registry/search.go
+++ b/registry/search.go
@@ -16,7 +16,7 @@ import (
 )
 
 var acceptedSearchFilterTags = map[string]bool{
-	"is-automated": true,
+	"is-automated": true, // Deprecated: the "is_automated" field is deprecated and will always be false in the future.
 	"is-official":  true,
 	"stars":        true,
 }
@@ -28,6 +28,7 @@ func (s *Service) Search(ctx context.Context, searchFilters filters.Args, term s
 		return nil, err
 	}
 
+	// TODO(thaJeztah): the "is-automated" field is deprecated; reset the field for the next release (v26.0.0). Return early when using "is-automated=true", and ignore "is-automated=false".
 	isAutomated, err := searchFilters.GetBoolOrDefault("is-automated", false)
 	if err != nil {
 		return nil, err
@@ -51,6 +52,7 @@ func (s *Service) Search(ctx context.Context, searchFilters filters.Args, term s
 		}
 	}
 
+	// TODO(thaJeztah): the "is-automated" field is deprecated. Reset the field for the next release (v26.0.0) if any "true" values are present.
 	unfilteredResult, err := s.searchUnfiltered(ctx, term, limit, authConfig, headers)
 	if err != nil {
 		return nil, err
@@ -59,7 +61,7 @@ func (s *Service) Search(ctx context.Context, searchFilters filters.Args, term s
 	filteredResults := []registry.SearchResult{}
 	for _, result := range unfilteredResult.Results {
 		if searchFilters.Contains("is-automated") {
-			if isAutomated != result.IsAutomated {
+			if isAutomated != result.IsAutomated { //nolint:staticcheck // ignore SA1019 for old API versions.
 				continue
 			}
 		}

--- a/registry/search_test.go
+++ b/registry/search_test.go
@@ -134,14 +134,14 @@ func TestSearch(t *testing.T) {
 				{
 					Name:        "name",
 					Description: "description",
-					IsAutomated: true,
+					IsAutomated: true, //nolint:staticcheck // ignore SA1019 (field is deprecated).
 				},
 			},
 			expectedResults: []registry.SearchResult{
 				{
 					Name:        "name",
 					Description: "description",
-					IsAutomated: true,
+					IsAutomated: true, //nolint:staticcheck // ignore SA1019 (field is deprecated).
 				},
 			},
 		},
@@ -152,7 +152,7 @@ func TestSearch(t *testing.T) {
 				{
 					Name:        "name",
 					Description: "description",
-					IsAutomated: true,
+					IsAutomated: true, //nolint:staticcheck // ignore SA1019 (field is deprecated).
 				},
 			},
 			expectedResults: []registry.SearchResult{},
@@ -164,14 +164,12 @@ func TestSearch(t *testing.T) {
 				{
 					Name:        "name",
 					Description: "description",
-					IsAutomated: false,
 				},
 			},
 			expectedResults: []registry.SearchResult{
 				{
 					Name:        "name",
 					Description: "description",
-					IsAutomated: false,
 				},
 			},
 		},
@@ -300,28 +298,27 @@ func TestSearch(t *testing.T) {
 					Description: "description0",
 					StarCount:   0,
 					IsOfficial:  true,
-					IsAutomated: true,
+					IsAutomated: true, //nolint:staticcheck // ignore SA1019 (field is deprecated).
 				},
 				{
 					Name:        "name1",
 					Description: "description1",
 					StarCount:   1,
 					IsOfficial:  false,
-					IsAutomated: true,
+					IsAutomated: true, //nolint:staticcheck // ignore SA1019 (field is deprecated).
 				},
 				{
 					Name:        "name2",
 					Description: "description2",
 					StarCount:   1,
 					IsOfficial:  true,
-					IsAutomated: false,
 				},
 				{
 					Name:        "name3",
 					Description: "description3",
 					StarCount:   2,
 					IsOfficial:  true,
-					IsAutomated: true,
+					IsAutomated: true, //nolint:staticcheck // ignore SA1019 (field is deprecated).
 				},
 			},
 			expectedResults: []registry.SearchResult{
@@ -330,7 +327,7 @@ func TestSearch(t *testing.T) {
 					Description: "description3",
 					StarCount:   2,
 					IsOfficial:  true,
-					IsAutomated: true,
+					IsAutomated: true, //nolint:staticcheck // ignore SA1019 (field is deprecated).
 				},
 			},
 		},


### PR DESCRIPTION
- related: https://github.com/docker/cli/pull/4413

### api: search: deprecate is_automated field, and is-automated filter


The is-automated field is being deprecated by Docker Hub's search API, and will always be set to "false" in future.

This patch deprecates the field and related filter for the Engine's API. In future, the `is-automated` filter will not yield any results when searching for `is-automated=true`, and will be ignored when searching for `is-automated=false`.

Given that this field is deprecated by an external API, the deprecation will not be versioned, and will apply to any API version.
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
api: search: deprecate "is_automated" field, and "is-automated" filter
```

**- A picture of a cute animal (not mandatory but encouraged)**

