### PR TITLE
hack: use Git-free ROOTDIR

### DIFF
--- a/hack/generate-authors.sh
+++ b/hack/generate-authors.sh
@@ -3,7 +3,7 @@
 set -e
 
 SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOTDIR="$(git -C "$SCRIPTDIR" rev-parse --show-toplevel)"
+ROOTDIR="$(cd "${SCRIPTDIR}/.." && pwd)"
 
 set -x
 

--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -74,19 +74,11 @@ source "${MAKEDIR}/.go-autogen"
 		fi
 	fi
 
-	# This is a workaround to have buildinfo with deps embedded in the binary. We
-	# need to create a go.mod file before building with -modfile=vendor.mod,
-	# otherwise it fails with: "-modfile cannot be used to set the module root directory."
-	if [ ! -f "go.mod" ]; then
-		printf '%s\n\n%s' 'module github.com/docker/docker' 'go 1.19' > "go.mod"
-		trap 'rm -f go.mod' EXIT
-	fi
-
 	echo "Building $([ "$DOCKER_STATIC" = "1" ] && echo "static" || echo "dynamic") $DEST/$BINARY_FULLNAME ($PLATFORM_NAME)..."
 	if [ -n "$DOCKER_DEBUG" ]; then
 		set -x
 	fi
-	GO111MODULE=on go build -mod=vendor -modfile=vendor.mod -o "$DEST/$BINARY_FULLNAME" "${BUILDFLAGS[@]}" -ldflags "$LDFLAGS $LDFLAGS_STATIC $DOCKER_LDFLAGS" ${GO_PACKAGE}
+	./hack/with-go-mod.sh go build -mod=vendor -modfile=vendor.mod -o "$DEST/$BINARY_FULLNAME" "${BUILDFLAGS[@]}" -ldflags "$LDFLAGS $LDFLAGS_STATIC $DOCKER_LDFLAGS" "$GO_PACKAGE"
 )
 
 echo "Created binary: $DEST/$BINARY_FULLNAME"

--- a/hack/validate/no-module
+++ b/hack/validate/no-module
@@ -3,7 +3,7 @@
 # Check that no one is trying to commit a go.mod.
 
 SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOTDIR="$(git -C "$SCRIPTDIR" rev-parse --show-toplevel)"
+ROOTDIR="$(cd "${SCRIPTDIR}/../.." && pwd)"
 
 if test -e "${ROOTDIR}/go.mod"; then
 	{

--- a/hack/with-go-mod.sh
+++ b/hack/with-go-mod.sh
@@ -9,7 +9,7 @@
 set -e
 
 SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOTDIR="$(git -C "$SCRIPTDIR" rev-parse --show-toplevel)"
+ROOTDIR="$(cd "${SCRIPTDIR}/.." && pwd)"
 
 if test -e "${ROOTDIR}/go.mod"; then
 	{


### PR DESCRIPTION
**- What I did**
Don't use Git to find the repository root as it won't work inside the build environment.
This allows us to use `with-go-mod.sh` during build and will make updating the `go 1.xx` line easier to manage.

**- A picture of a cute animal (not mandatory but encouraged)**
![](https://media.discordapp.net/attachments/704333319697072231/1128319736598495252/20230711_153934.jpg?width=1072&height=804)