### PR TITLE
ci(bin-image): don't set tags when pushing by digest

### DIFF
--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -76,23 +76,6 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
       -
-        name: Rename meta bake definition file
-        run: |
-          mv "${{ steps.meta.outputs.bake-file }}" "/tmp/bake-meta.json"
-      -
-        name: Upload meta bake definition
-        uses: actions/upload-artifact@v3
-        with:
-          name: bake-meta
-          path: /tmp/bake-meta.json
-          if-no-files-found: error
-          retention-days: 1
-      -
-        name: Remove tags from meta bake definition
-        run: |
-          # we just want labels being set in this job
-          jq -r 'del(.target."docker-metadata-action".tags)' "/tmp/bake-meta.json" > "${{ steps.meta.outputs.bake-file }}"
-      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       -
@@ -117,6 +100,7 @@ jobs:
           set: |
             *.platform=${{ matrix.platform }}
             *.output=type=image,name=${{ env.MOBYBIN_REPO_SLUG }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+            *.tags=
       -
         name: Export digest
         if: github.event_name != 'pull_request'
@@ -131,6 +115,18 @@ jobs:
         with:
           name: digests
           path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+      -
+        name: Rename meta bake definition file
+        run: |
+          mv "${{ steps.meta.outputs.bake-file }}" "/tmp/bake-meta.json"
+      -
+        name: Upload meta bake definition
+        uses: actions/upload-artifact@v3
+        with:
+          name: bake-meta
+          path: /tmp/bake-meta.json
           if-no-files-found: error
           retention-days: 1
 


### PR DESCRIPTION
follow-up https://github.com/moby/moby/pull/44740

**- What I did**

https://github.com/moby/moby/actions/runs/5523198400/jobs/10073797998#step:10:2961

```
#65 exporting to image
#65 exporting layers
#65 exporting layers 4.4s done
#65 exporting manifest sha256:f225c20202190ce50bd8e3c2f7466d847c1ab4e7620a8943b983c66d5a1daf3c done
#65 exporting config sha256:0d1da44af12ad680d8cff460d0207480728dd077716fd6367caed9d0e74fec82 done
#65 exporting attestation manifest sha256:a31ffac99ced8143782bc9b4ba81a990a0f6c21e906d7334f8114273a67868d7
#65 exporting attestation manifest sha256:a31ffac99ced8143782bc9b4ba81a990a0f6c21e906d7334f8114273a67868d7 done
#65 exporting manifest list sha256:adde00d7a67dee6df6a204aeaf7ec795b895c985ef5c4956a0eccef0e959bc3a done
#65 ERROR: failed to push moby-bin:local: can't push tagged ref docker.io/library/moby-bin:local by digest
```

We can't push tagged ref by digest obviously but forgot we also fallback to `moby-bin:local` tag in our bake definition: https://github.com/moby/moby/blob/080844b9b32415d04ae39df8ef744ceb65dce52d/docker-bake.hcl#L64

**- How I did it**

Just setting `--set "*.tags="` fixes this issue.

**- How to verify it**

```
$ docker buildx bake bin-image --set "*.tags=" --print
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

