### PR TITLE
ci(bin-image): fix meta step

### DIFF
--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -34,27 +34,6 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       -
-        name: Create platforms matrix
-        id: platforms
-        run: |
-          echo "matrix=$(docker buildx bake bin-image-cross --print | jq -cr '.target."bin-image-cross".platforms')" >>${GITHUB_OUTPUT}
-
-  build:
-    runs-on: ubuntu-20.04
-    needs:
-      - validate-dco
-      - prepare
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: ${{ fromJson(needs.prepare.outputs.platforms) }}
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      -
         name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -76,6 +55,45 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
       -
+        name: Rename meta bake definition file
+        run: |
+          mv "${{ steps.meta.outputs.bake-file }}" "/tmp/bake-meta.json"
+      -
+        name: Upload meta bake definition
+        uses: actions/upload-artifact@v3
+        with:
+          name: bake-meta
+          path: /tmp/bake-meta.json
+          if-no-files-found: error
+          retention-days: 1
+      -
+        name: Create platforms matrix
+        id: platforms
+        run: |
+          echo "matrix=$(docker buildx bake bin-image-cross --print | jq -cr '.target."bin-image-cross".platforms')" >>${GITHUB_OUTPUT}
+
+  build:
+    runs-on: ubuntu-20.04
+    needs:
+      - validate-dco
+      - prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJson(needs.prepare.outputs.platforms) }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        name: Download meta bake definition
+        uses: actions/download-artifact@v3
+        with:
+          name: bake-meta
+          path: /tmp
+      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       -
@@ -95,7 +113,7 @@ jobs:
         with:
           files: |
             ./docker-bake.hcl
-            ${{ steps.meta.outputs.bake-file }}
+            /tmp/bake-meta.json
           targets: bin-image
           set: |
             *.platform=${{ matrix.platform }}
@@ -115,18 +133,6 @@ jobs:
         with:
           name: digests
           path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-      -
-        name: Rename meta bake definition file
-        run: |
-          mv "${{ steps.meta.outputs.bake-file }}" "/tmp/bake-meta.json"
-      -
-        name: Upload meta bake definition
-        uses: actions/upload-artifact@v3
-        with:
-          name: bake-meta
-          path: /tmp/bake-meta.json
           if-no-files-found: error
           retention-days: 1
 
@@ -162,10 +168,10 @@ jobs:
         working-directory: /tmp/digests
         run: |
           set -x
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map("-t " + .) | join(" ")' /tmp/bake.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map("-t " + .) | join(" ")' /tmp/bake-meta.json) \
             $(printf '${{ env.MOBYBIN_REPO_SLUG }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
           set -x
-          docker buildx imagetools inspect ${{ env.MOBYBIN_REPO_SLUG }}:$(jq -cr '.target."docker-metadata-action".args.DOCKER_META_VERSION' /tmp/bake.json)
+          docker buildx imagetools inspect ${{ env.MOBYBIN_REPO_SLUG }}:$(jq -cr '.target."docker-metadata-action".args.DOCKER_META_VERSION' /tmp/bake-meta.json)

--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -106,7 +106,7 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           mkdir -p /tmp/digests
-          digest="${{ fromJSON(steps.bake.outputs.metadata).image['containerimage.digest'] }}"
+          digest="${{ fromJSON(steps.bake.outputs.metadata)['bin-image']['containerimage.digest'] }}"
           touch "/tmp/digests/${digest#sha256:}"
       -
         name: Upload digest


### PR DESCRIPTION
follow-up https://github.com/moby/moby/pull/45930

**- What I did**

Got another issue with previous fix where digest from metadata build result output was empty because of a typo on target name: https://github.com/moby/moby/actions/runs/5524595417/jobs/10077121927#step:8:3

Also needed to fix the meta step and bake meta file in merge job. We can't upload the same file in a matrix so we have to generate metadata in prepare job instead.

**- How I did it**

**- How to verify it**

To be sure it works I triggered the workflow on my fork: https://github.com/crazy-max/moby/actions/runs/5524785463

![image](https://github.com/moby/moby/assets/1951866/dba15dc7-f38f-4220-97ef-3e9d8c63349b)
> https://hub.docker.com/r/crazymax/moby-bin/tags?page=1&ordering=last_updated

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

