### PR TITLE
api: Deprecate outdated networking fields & structs

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -318,7 +318,7 @@ type ContainerJSONBase struct {
 	SizeRootFs      *int64 `json:",omitempty"`
 }
 
-// ContainerJSON is newly used struct along with MountPoint
+// ContainerJSON represents the state and settings of a container when inspecting it.
 type ContainerJSON struct {
 	*ContainerJSONBase
 	Mounts          []MountPoint
@@ -326,7 +326,7 @@ type ContainerJSON struct {
 	NetworkSettings *NetworkSettings
 }
 
-// NetworkSettings exposes the network settings in the api
+// NetworkSettings holds the networking state of a specific container when inspecting it.
 type NetworkSettings struct {
 	NetworkSettingsBase
 	DefaultNetworkSettings // Deprecated: DefaultNetworkSettings is deprecated since API v1.21 and will be removed in a future release.
@@ -339,7 +339,7 @@ type SummaryNetworkSettings struct {
 	Networks map[string]*network.EndpointSettings
 }
 
-// NetworkSettingsBase holds networking state for a container when inspecting it.
+// NetworkSettingsBase holds the networking state of a specific container when inspecting it.
 type NetworkSettingsBase struct {
 	Bridge     string      // Bridge contains the name of the default bridge interface iff it was set through the daemon --bridge flag.
 	SandboxID  string      // SandboxID uniquely represents a container's network stack

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -328,7 +328,7 @@ type ContainerJSON struct {
 
 // NetworkSettings holds the networking state of a specific container when inspecting it.
 type NetworkSettings struct {
-	NetworkSettingsBase
+	NetworkSettingsBase    // Deprecated: NetworkSettingsBase is deprecated since API v1.21 and will be removed in a future release.
 	DefaultNetworkSettings // Deprecated: DefaultNetworkSettings is deprecated since API v1.21 and will be removed in a future release.
 	Networks               map[string]*network.EndpointSettings
 }
@@ -340,6 +340,8 @@ type SummaryNetworkSettings struct {
 }
 
 // NetworkSettingsBase holds the networking state of a specific container when inspecting it.
+//
+// Deprecated: this struct mostly contains deprecated fields and will be removed in v26.0.
 type NetworkSettingsBase struct {
 	Bridge     string      // Bridge contains the name of the default bridge interface iff it was set through the daemon --bridge flag.
 	SandboxID  string      // SandboxID uniquely represents a container's network stack

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -329,8 +329,8 @@ type ContainerJSON struct {
 // NetworkSettings exposes the network settings in the api
 type NetworkSettings struct {
 	NetworkSettingsBase
-	DefaultNetworkSettings
-	Networks map[string]*network.EndpointSettings
+	DefaultNetworkSettings // Deprecated: DefaultNetworkSettings is deprecated since API v1.21 and will be removed in a future release.
+	Networks               map[string]*network.EndpointSettings
 }
 
 // SummaryNetworkSettings provides a summary of container's networks
@@ -362,9 +362,10 @@ type NetworkSettingsBase struct {
 	SecondaryIPv6Addresses []network.Address // Deprecated: This field is never set and will be removed in a future release.
 }
 
-// DefaultNetworkSettings holds network information
-// during the 2 release deprecation period.
-// It will be removed in Docker 1.11.
+// DefaultNetworkSettings holds the networking state of the default bridge when inspecting a container.
+//
+// Deprecated: this struct is deprecated since API v1.21 and will be removed in a future release. You should look for
+// the default network in NetworkSettings.Networks instead.
 type DefaultNetworkSettings struct {
 	EndpointID          string // EndpointID uniquely represents a service endpoint in a Sandbox
 	Gateway             string // Gateway holds the gateway address for the network

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -73,14 +73,9 @@ func (daemon *Daemon) ContainerInspectCurrent(ctx context.Context, name string, 
 	mountPoints := ctr.GetMountPoints()
 	networkSettings := &types.NetworkSettings{
 		NetworkSettingsBase: types.NetworkSettingsBase{
-			Bridge:                 ctr.NetworkSettings.Bridge,
-			SandboxID:              ctr.NetworkSettings.SandboxID,
-			SandboxKey:             ctr.NetworkSettings.SandboxKey,
-			HairpinMode:            ctr.NetworkSettings.HairpinMode,
-			LinkLocalIPv6Address:   ctr.NetworkSettings.LinkLocalIPv6Address,
-			LinkLocalIPv6PrefixLen: ctr.NetworkSettings.LinkLocalIPv6PrefixLen,
-			SecondaryIPAddresses:   ctr.NetworkSettings.SecondaryIPAddresses,
-			SecondaryIPv6Addresses: ctr.NetworkSettings.SecondaryIPv6Addresses,
+			Bridge:     ctr.NetworkSettings.Bridge,
+			SandboxID:  ctr.NetworkSettings.SandboxID,
+			SandboxKey: ctr.NetworkSettings.SandboxKey,
 		},
 		DefaultNetworkSettings: daemon.getDefaultNetworkSettings(ctr.NetworkSettings.Networks),
 		Networks:               apiNetworks,
@@ -276,15 +271,10 @@ func (daemon *Daemon) ContainerExecInspect(id string) (*backend.ExecInspect, err
 func (daemon *Daemon) getBackwardsCompatibleNetworkSettings(settings *network.Settings) *v1p20.NetworkSettings {
 	result := &v1p20.NetworkSettings{
 		NetworkSettingsBase: types.NetworkSettingsBase{
-			Bridge:                 settings.Bridge,
-			SandboxID:              settings.SandboxID,
-			SandboxKey:             settings.SandboxKey,
-			HairpinMode:            settings.HairpinMode,
-			LinkLocalIPv6Address:   settings.LinkLocalIPv6Address,
-			LinkLocalIPv6PrefixLen: settings.LinkLocalIPv6PrefixLen,
-			Ports:                  settings.Ports,
-			SecondaryIPAddresses:   settings.SecondaryIPAddresses,
-			SecondaryIPv6Addresses: settings.SecondaryIPv6Addresses,
+			Bridge:     settings.Bridge,
+			SandboxID:  settings.SandboxID,
+			SandboxKey: settings.SandboxKey,
+			Ports:      settings.Ports,
 		},
 		DefaultNetworkSettings: daemon.getDefaultNetworkSettings(settings.Networks),
 	}

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -292,10 +292,10 @@ func (daemon *Daemon) getBackwardsCompatibleNetworkSettings(settings *network.Se
 	return result
 }
 
-// getDefaultNetworkSettings creates the deprecated structure that holds the information
-// about the bridge network for a container.
-func (daemon *Daemon) getDefaultNetworkSettings(networks map[string]*network.EndpointSettings) types.DefaultNetworkSettings {
-	var settings types.DefaultNetworkSettings
+// getDefaultNetworkSettings creates the struct that holds the networking state of the default bridge when inspecting a
+// container.
+func (daemon *Daemon) getDefaultNetworkSettings(networks map[string]*network.EndpointSettings) types.DefaultNetworkSettings { //nolint:staticcheck // ignore SA1019: struct is deprecated since API v1.21.
+	var settings types.DefaultNetworkSettings //nolint:staticcheck // ignore SA1019: struct is deprecated since API v1.21.
 
 	if defaultNetwork, ok := networks[networktypes.NetworkBridge]; ok && defaultNetwork.EndpointSettings != nil {
 		settings.EndpointID = defaultNetwork.EndpointID

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -72,7 +72,7 @@ func (daemon *Daemon) ContainerInspectCurrent(ctx context.Context, name string, 
 
 	mountPoints := ctr.GetMountPoints()
 	networkSettings := &types.NetworkSettings{
-		NetworkSettingsBase: types.NetworkSettingsBase{
+		NetworkSettingsBase: types.NetworkSettingsBase{ //nolint:staticcheck // ignore SA1019: NetworkSettingsBase is deprecated since v26.0.
 			Bridge:     ctr.NetworkSettings.Bridge,
 			SandboxID:  ctr.NetworkSettings.SandboxID,
 			SandboxKey: ctr.NetworkSettings.SandboxKey,
@@ -270,7 +270,7 @@ func (daemon *Daemon) ContainerExecInspect(id string) (*backend.ExecInspect, err
 
 func (daemon *Daemon) getBackwardsCompatibleNetworkSettings(settings *network.Settings) *v1p20.NetworkSettings {
 	result := &v1p20.NetworkSettings{
-		NetworkSettingsBase: types.NetworkSettingsBase{
+		NetworkSettingsBase: types.NetworkSettingsBase{ //nolint:staticcheck // ignore SA1019: NetworkSettingsBase is deprecated since v26.0.
 			Bridge:     settings.Bridge,
 			SandboxID:  settings.SandboxID,
 			SandboxKey: settings.SandboxKey,

--- a/daemon/network/settings.go
+++ b/daemon/network/settings.go
@@ -13,7 +13,7 @@ import (
 // Settings stores networking configuration and state for a specific container.
 // TODO Windows. Many of these fields can be factored out.
 type Settings struct {
-	Bridge           string
+	Bridge           string // Bridge contains the name of the default bridge interface iff it was set through the daemon --bridge flag.
 	SandboxID        string
 	SandboxKey       string
 	Networks         map[string]*EndpointSettings

--- a/daemon/network/settings.go
+++ b/daemon/network/settings.go
@@ -10,21 +10,22 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Settings stores configuration details about the daemon network config
-// TODO Windows. Many of these fields can be factored out.,
+// Settings stores networking configuration and state for a specific container.
+// TODO Windows. Many of these fields can be factored out.
 type Settings struct {
-	Bridge                 string
-	SandboxID              string
-	SandboxKey             string
-	HairpinMode            bool
-	LinkLocalIPv6Address   string
-	LinkLocalIPv6PrefixLen int
-	Networks               map[string]*EndpointSettings
-	Service                *clustertypes.ServiceConfig
-	Ports                  nat.PortMap
-	SecondaryIPAddresses   []networktypes.Address
-	SecondaryIPv6Addresses []networktypes.Address
-	HasSwarmEndpoint       bool
+	Bridge           string
+	SandboxID        string
+	SandboxKey       string
+	Networks         map[string]*EndpointSettings
+	Service          *clustertypes.ServiceConfig
+	Ports            nat.PortMap
+	HasSwarmEndpoint bool
+
+	HairpinMode            bool                   // Deprecated: this field is never set and will be removed in a future release.
+	LinkLocalIPv6Address   string                 // Deprecated: this field is never set and will be removed in a future release.
+	LinkLocalIPv6PrefixLen int                    // Deprecated: this field is never set and will be removed in a future release.
+	SecondaryIPAddresses   []networktypes.Address // Deprecated: this field has no practical use and will be removed in a future release.
+	SecondaryIPv6Addresses []networktypes.Address // Deprecated: this field has no practical use and will be removed in a future release.
 }
 
 // EndpointSettings is a package local wrapper for


### PR DESCRIPTION
**- What I did**

* Fixed the deprecation warning on `DefaultNetworkSettings` ;
* Marked `NetworkSettingsBase` as deprecated ;
* Fixed a few undescriptive comments ;

**- How to verify it**

CI is green

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://images.saymedia-content.com/.image/ar_4:3%2Cc_fill%2Ccs_srgb%2Cfl_progressive%2Cq_auto:eco%2Cw_1200/MTc3NjQ2OTc0MzIzOTkyMTcz/your-guide-to-successfully-rearing-stray-kittens.jpg)
