### PR TITLE
pkg/plugins: don't share plugin server between tests and t.Parallel()

### DIFF
--- a/pkg/plugins/client_test.go
+++ b/pkg/plugins/client_test.go
@@ -18,21 +18,15 @@ import (
 	is "gotest.tools/v3/assert/cmp"
 )
 
-var (
-	mux    *http.ServeMux
-	server *httptest.Server
-)
-
-func setupRemotePluginServer() string {
+func setupRemotePluginServer(t *testing.T) (mux *http.ServeMux, addr string) {
+	t.Helper()
 	mux = http.NewServeMux()
-	server = httptest.NewServer(mux)
-	return server.URL
-}
-
-func teardownRemotePluginServer() {
-	if server != nil {
+	server := httptest.NewServer(mux)
+	t.Logf("started remote plugin server listening on: %s", server.URL)
+	t.Cleanup(func() {
 		server.Close()
-	}
+	})
+	return mux, server.URL
 }
 
 func TestFailedConnection(t *testing.T) {
@@ -44,8 +38,7 @@ func TestFailedConnection(t *testing.T) {
 }
 
 func TestFailOnce(t *testing.T) {
-	addr := setupRemotePluginServer()
-	defer teardownRemotePluginServer()
+	mux, addr := setupRemotePluginServer(t)
 
 	failed := false
 	mux.HandleFunc("/Test.FailOnce", func(w http.ResponseWriter, r *http.Request) {
@@ -64,8 +57,7 @@ func TestFailOnce(t *testing.T) {
 }
 
 func TestEchoInputOutput(t *testing.T) {
-	addr := setupRemotePluginServer()
-	defer teardownRemotePluginServer()
+	mux, addr := setupRemotePluginServer(t)
 
 	m := Manifest{[]string{"VolumeDriver", "NetworkDriver"}}
 
@@ -157,8 +149,7 @@ func TestClientScheme(t *testing.T) {
 }
 
 func TestNewClientWithTimeout(t *testing.T) {
-	addr := setupRemotePluginServer()
-	defer teardownRemotePluginServer()
+	mux, addr := setupRemotePluginServer(t)
 
 	m := Manifest{[]string{"VolumeDriver", "NetworkDriver"}}
 
@@ -178,8 +169,7 @@ func TestNewClientWithTimeout(t *testing.T) {
 }
 
 func TestClientStream(t *testing.T) {
-	addr := setupRemotePluginServer()
-	defer teardownRemotePluginServer()
+	mux, addr := setupRemotePluginServer(t)
 
 	m := Manifest{[]string{"VolumeDriver", "NetworkDriver"}}
 	var output Manifest
@@ -208,8 +198,7 @@ func TestClientStream(t *testing.T) {
 }
 
 func TestClientSendFile(t *testing.T) {
-	addr := setupRemotePluginServer()
-	defer teardownRemotePluginServer()
+	mux, addr := setupRemotePluginServer(t)
 
 	m := Manifest{[]string{"VolumeDriver", "NetworkDriver"}}
 	var output Manifest

--- a/pkg/plugins/client_test.go
+++ b/pkg/plugins/client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -30,6 +31,7 @@ func setupRemotePluginServer(t *testing.T) (mux *http.ServeMux, addr string) {
 }
 
 func TestFailedConnection(t *testing.T) {
+	t.Parallel()
 	c, _ := NewClient("tcp://127.0.0.1:1", &tlsconfig.Options{InsecureSkipVerify: true})
 	_, err := c.callWithRetry("Service.Method", nil, false)
 	if err == nil {
@@ -38,13 +40,14 @@ func TestFailedConnection(t *testing.T) {
 }
 
 func TestFailOnce(t *testing.T) {
+	t.Parallel()
 	mux, addr := setupRemotePluginServer(t)
 
 	failed := false
 	mux.HandleFunc("/Test.FailOnce", func(w http.ResponseWriter, r *http.Request) {
 		if !failed {
 			failed = true
-			panic("Plugin not ready")
+			panic("Plugin not ready (intentional panic for test)")
 		}
 	})
 
@@ -57,6 +60,7 @@ func TestFailOnce(t *testing.T) {
 }
 
 func TestEchoInputOutput(t *testing.T) {
+	t.Parallel()
 	mux, addr := setupRemotePluginServer(t)
 
 	m := Manifest{[]string{"VolumeDriver", "NetworkDriver"}}
@@ -87,47 +91,56 @@ func TestEchoInputOutput(t *testing.T) {
 }
 
 func TestBackoff(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		retries    int
 		expTimeOff time.Duration
 	}{
-		{0, time.Duration(1)},
-		{1, time.Duration(2)},
-		{2, time.Duration(4)},
-		{4, time.Duration(16)},
-		{6, time.Duration(30)},
-		{10, time.Duration(30)},
+		{expTimeOff: time.Duration(1)},
+		{retries: 1, expTimeOff: time.Duration(2)},
+		{retries: 2, expTimeOff: time.Duration(4)},
+		{retries: 4, expTimeOff: time.Duration(16)},
+		{retries: 6, expTimeOff: time.Duration(30)},
+		{retries: 10, expTimeOff: time.Duration(30)},
 	}
 
-	for _, c := range cases {
-		s := c.expTimeOff * time.Second
-		if d := backoff(c.retries); d != s {
-			t.Fatalf("Retry %v, expected %v, was %v\n", c.retries, s, d)
-		}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(fmt.Sprintf("retries: %v", tc.retries), func(t *testing.T) {
+			s := tc.expTimeOff * time.Second
+			if d := backoff(tc.retries); d != s {
+				t.Fatalf("Retry %v, expected %v, was %v\n", tc.retries, s, d)
+			}
+		})
 	}
 }
 
 func TestAbortRetry(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		timeOff  time.Duration
 		expAbort bool
 	}{
-		{time.Duration(1), false},
-		{time.Duration(2), false},
-		{time.Duration(10), false},
-		{time.Duration(30), true},
-		{time.Duration(40), true},
+		{timeOff: time.Duration(1)},
+		{timeOff: time.Duration(2)},
+		{timeOff: time.Duration(10)},
+		{timeOff: time.Duration(30), expAbort: true},
+		{timeOff: time.Duration(40), expAbort: true},
 	}
 
-	for _, c := range cases {
-		s := c.timeOff * time.Second
-		if a := abort(time.Now(), s); a != c.expAbort {
-			t.Fatalf("Duration %v, expected %v, was %v\n", c.timeOff, s, a)
-		}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(fmt.Sprintf("duration: %v", tc.timeOff), func(t *testing.T) {
+			s := tc.timeOff * time.Second
+			if a := abort(time.Now(), s); a != tc.expAbort {
+				t.Fatalf("Duration %v, expected %v, was %v\n", tc.timeOff, s, a)
+			}
+		})
 	}
 }
 
 func TestClientScheme(t *testing.T) {
+	t.Parallel()
 	cases := map[string]string{
 		"tcp://127.0.0.1:8080":          "http",
 		"unix:///usr/local/plugins/foo": "http",
@@ -138,7 +151,7 @@ func TestClientScheme(t *testing.T) {
 	for addr, scheme := range cases {
 		u, err := url.Parse(addr)
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 		s := httpScheme(u)
 
@@ -149,6 +162,7 @@ func TestClientScheme(t *testing.T) {
 }
 
 func TestNewClientWithTimeout(t *testing.T) {
+	t.Parallel()
 	mux, addr := setupRemotePluginServer(t)
 
 	m := Manifest{[]string{"VolumeDriver", "NetworkDriver"}}
@@ -169,6 +183,7 @@ func TestNewClientWithTimeout(t *testing.T) {
 }
 
 func TestClientStream(t *testing.T) {
+	t.Parallel()
 	mux, addr := setupRemotePluginServer(t)
 
 	m := Manifest{[]string{"VolumeDriver", "NetworkDriver"}}
@@ -198,6 +213,7 @@ func TestClientStream(t *testing.T) {
 }
 
 func TestClientSendFile(t *testing.T) {
+	t.Parallel()
 	mux, addr := setupRemotePluginServer(t)
 
 	m := Manifest{[]string{"VolumeDriver", "NetworkDriver"}}
@@ -225,6 +241,7 @@ func TestClientSendFile(t *testing.T) {
 }
 
 func TestClientWithRequestTimeout(t *testing.T) {
+	t.Parallel()
 	type timeoutError interface {
 		Timeout() bool
 	}

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -25,6 +25,7 @@ const (
 
 // regression test for deadlock in handlers
 func TestPluginAddHandler(t *testing.T) {
+	t.Parallel()
 	// make a plugin which is pre-activated
 	p := &Plugin{activateWait: sync.NewCond(&sync.Mutex{})}
 	p.Manifest = &Manifest{Implements: []string{"bananas"}}
@@ -36,6 +37,7 @@ func TestPluginAddHandler(t *testing.T) {
 }
 
 func TestPluginWaitBadPlugin(t *testing.T) {
+	t.Parallel()
 	p := &Plugin{activateWait: sync.NewCond(&sync.Mutex{})}
 	p.activateErr = errors.New("some junk happened")
 	testActive(t, p)
@@ -57,6 +59,7 @@ func testActive(t *testing.T, p *Plugin) {
 }
 
 func TestGet(t *testing.T) {
+	t.Parallel()
 	p := &Plugin{name: fruitPlugin, activateWait: sync.NewCond(&sync.Mutex{})}
 	p.Manifest = &Manifest{Implements: []string{fruitImplements}}
 	storage.plugins[fruitPlugin] = p
@@ -85,6 +88,7 @@ func TestGet(t *testing.T) {
 }
 
 func TestPluginWithNoManifest(t *testing.T) {
+	t.Parallel()
 	mux, addr := setupRemotePluginServer(t)
 
 	m := Manifest{[]string{fruitImplements}}
@@ -122,6 +126,7 @@ func TestPluginWithNoManifest(t *testing.T) {
 }
 
 func TestGetAll(t *testing.T) {
+	t.Parallel()
 	tmpdir, unregister, r := Setup(t)
 	defer unregister()
 

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -85,8 +85,7 @@ func TestGet(t *testing.T) {
 }
 
 func TestPluginWithNoManifest(t *testing.T) {
-	addr := setupRemotePluginServer()
-	defer teardownRemotePluginServer()
+	mux, addr := setupRemotePluginServer(t)
 
 	m := Manifest{[]string{fruitImplements}}
 	var buf bytes.Buffer


### PR DESCRIPTION
### pkg/plugins: don't share plugin server between tests

Refactor setupRemotePluginServer() to be a helper, and to spin up a test-
server for each test instead of sharing the same instance between tests.

This allows the tests to be run in parallel without stepping on each-other's
toes (tearing down the server).


### pkg/plugins: run tests with t.Parallel()

Some tests are testing timeouts and take a long time to run. Run the tests
in parallel, so that the test-suite takes shorter to run.

Before:

    ok  github.com/docker/docker/pkg/plugins	34.013s

After:

    ok  github.com/docker/docker/pkg/plugins	17.945s

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

