### PR TITLE
ci(buildkit): match moby go version for buildkit tests

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -13,6 +13,7 @@ on:
   pull_request:
 
 env:
+  GO_VERSION: "1.20.5"
   DESTDIR: ./build
 
 jobs:

--- a/vendor.mod
+++ b/vendor.mod
@@ -60,7 +60,7 @@ require (
 	github.com/miekg/dns v1.1.43
 	github.com/mistifyio/go-zfs/v3 v3.0.1
 	github.com/mitchellh/copystructure v1.2.0
-	github.com/moby/buildkit v0.11.7-0.20230525183624-798ad6b0ce9f
+	github.com/moby/buildkit v0.11.7-0.20230712171151-0a15675913b7 // v0.11
 	github.com/moby/ipvs v1.1.0
 	github.com/moby/locker v1.0.1
 	github.com/moby/patternmatcher v0.5.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -1054,8 +1054,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mndrix/tap-go v0.0.0-20171203230836-629fa407e90b/go.mod h1:pzzDgJWZ34fGzaAZGFW22KVZDfyrYW+QABMrWnJBnSs=
 github.com/moby/buildkit v0.8.1/go.mod h1:/kyU1hKy/aYCuP39GZA9MaKioovHku57N6cqlKZIaiQ=
-github.com/moby/buildkit v0.11.7-0.20230525183624-798ad6b0ce9f h1:9wobL03Y6U8azuDLUqYblbUdVU9jpjqecDdW7w4wZtI=
-github.com/moby/buildkit v0.11.7-0.20230525183624-798ad6b0ce9f/go.mod h1:GCqKfHhz+pddzfgaR7WmHVEE3nKKZMMDPpK8mh3ZLv4=
+github.com/moby/buildkit v0.11.7-0.20230712171151-0a15675913b7 h1:9gjbrmALOUAJCqWL4RTwydPUiepMnkc3BNbBFiFiBeU=
+github.com/moby/buildkit v0.11.7-0.20230712171151-0a15675913b7/go.mod h1:GCqKfHhz+pddzfgaR7WmHVEE3nKKZMMDPpK8mh3ZLv4=
 github.com/moby/ipvs v1.1.0 h1:ONN4pGaZQgAx+1Scz5RvWV4Q7Gb+mvfRh3NsPS+1XQQ=
 github.com/moby/ipvs v1.1.0/go.mod h1:4VJMWuf098bsUMmZEiD4Tjk/O7mOn3l1PTD3s4OoYAs=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -618,7 +618,7 @@ github.com/mitchellh/hashstructure/v2
 # github.com/mitchellh/reflectwalk v1.0.2
 ## explicit
 github.com/mitchellh/reflectwalk
-# github.com/moby/buildkit v0.11.7-0.20230525183624-798ad6b0ce9f
+# github.com/moby/buildkit v0.11.7-0.20230712171151-0a15675913b7
 ## explicit; go 1.18
 github.com/moby/buildkit/api/services/control
 github.com/moby/buildkit/api/types


### PR DESCRIPTION
follow-up
* https://github.com/moby/buildkit/pull/4018
* https://github.com/moby/buildkit/pull/4019

related to
* https://github.com/moby/moby/pull/45932#issuecomment-1632069512
* https://github.com/moby/moby/issues/45935

**- What I did**

BuildKit integration tests image always pulls latest Go 1.20: https://github.com/moby/buildkit/blob/ca5d5bff71976d99d3ae6bb55dae7e4dd017c22d/Dockerfile#L19

With latest Go 1.20.6 we see failed tests in buildkit workflow (https://github.com/moby/moby/pull/45932#issuecomment-1632069512) related to https://github.com/moby/moby/issues/45935

Let's pin go version for buildkit tests matching the one in this repo.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

