### PR TITLE
c8d: images/json return image manifests

### DIFF
--- a/daemon/containerd/image_manifest.go
+++ b/daemon/containerd/image_manifest.go
@@ -51,7 +51,7 @@ func (i *ImageService) walkImageManifests(ctx context.Context, img containerdima
 type ImageManifest struct {
 	containerd.Image
 
-	// Parent of the manifest (index/manifest list)
+	// The manifest this image points to
 	RealTarget ocispec.Descriptor
 
 	manifest *ocispec.Manifest
@@ -62,13 +62,12 @@ func (i *ImageService) NewImageManifest(ctx context.Context, img containerdimage
 		return nil, errNotManifest
 	}
 
-	parent := img.Target
 	img.Target = manifestDesc
 
 	c8dImg := containerd.NewImageWithPlatform(i.client, img, cplatforms.All)
 	return &ImageManifest{
 		Image:      c8dImg,
-		RealTarget: parent,
+		RealTarget: manifestDesc,
 	}, nil
 }
 


### PR DESCRIPTION
**- What I did**

Changed the way we return multi-platform images, we used to return the same name/id for each platform of an image. The ID used to be the ID of the index. With this change we now return the ID of each manifest. Also changed it so that we can inspect etc. an image by its manifest ID.

Before:
```console
$ docker images
REPOSITORY   TAG       IMAGE ID       CREATED        SIZE
nginx        latest    08bc36ad5247   30 hours ago   272MB
nginx        latest    08bc36ad5247   30 hours ago   274MB
```

After:

```console
$ docker images
REPOSITORY   TAG       IMAGE ID       CREATED        SIZE
nginx        latest    1bb5c4b86cb7   30 hours ago   272MB
nginx        latest    b02b0565e769   30 hours ago   274MB
```

**- How I did it**

* stored the manifest in the ImageManifest struct (we used to store the parent index)
* added a (slow) way to search for an image by its manifest ID

Note: this is slow and gets slower as the number of the images increases, but for now it works, we will have to find a better way to find an image manifest by digest, either by adding metadata to the image we pull/build or by contributing a change to containerd. The ideal would be for containerd to have an API that does what we need.

**- How to verify it**

Pull multiple platforms of the same image and list them:

```console
$ docker pull --platform linux/arm64 nginx
$ docker pull --platform linux/amd64 nginx
```

And then list them.

**- Description for the changelog**
containerd image store: `docker images` now show the ID of the image a specific platform instead of the ID of the manifest list


**- A picture of a cute animal (not mandatory but encouraged)**

