### PR TITLE
pkg/ioutils: some cleanups in tests

### DIFF
--- a/pkg/ioutils/buffer_test.go
+++ b/pkg/ioutils/buffer_test.go
@@ -17,7 +17,7 @@ func TestFixedBufferCap(t *testing.T) {
 func TestFixedBufferLen(t *testing.T) {
 	buf := &fixedBuffer{buf: make([]byte, 0, 10)}
 
-	buf.Write([]byte("hello"))
+	_, _ = buf.Write([]byte("hello"))
 	l := buf.Len()
 	if l != 5 {
 		t.Fatalf("expected buffer length to be 5 bytes, got %d", l)
@@ -31,7 +31,7 @@ func TestFixedBufferLen(t *testing.T) {
 
 	// read 5 bytes
 	b := make([]byte, 5)
-	buf.Read(b)
+	_, _ = buf.Read(b)
 
 	l = buf.Len()
 	if l != 5 {
@@ -61,8 +61,8 @@ func TestFixedBufferLen(t *testing.T) {
 func TestFixedBufferString(t *testing.T) {
 	buf := &fixedBuffer{buf: make([]byte, 0, 10)}
 
-	buf.Write([]byte("hello"))
-	buf.Write([]byte("world"))
+	_, _ = buf.Write([]byte("hello"))
+	_, _ = buf.Write([]byte("world"))
 
 	out := buf.String()
 	if out != "helloworld" {
@@ -71,7 +71,7 @@ func TestFixedBufferString(t *testing.T) {
 
 	// read 5 bytes
 	b := make([]byte, 5)
-	buf.Read(b)
+	_, _ = buf.Read(b)
 
 	// test that fixedBuffer.String() only returns the part that hasn't been read
 	out = buf.String()

--- a/pkg/ioutils/fswriters_test.go
+++ b/pkg/ioutils/fswriters_test.go
@@ -18,11 +18,7 @@ func init() {
 }
 
 func TestAtomicWriteToFile(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "atomic-writers-test")
-	if err != nil {
-		t.Fatalf("Error when creating temporary directory: %s", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	expected := []byte("barbaz")
 	if err := AtomicWriteFile(filepath.Join(tmpDir, "foo"), expected, testMode); err != nil {
@@ -48,11 +44,7 @@ func TestAtomicWriteToFile(t *testing.T) {
 }
 
 func TestAtomicWriteSetCommit(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "atomic-writerset-test")
-	if err != nil {
-		t.Fatalf("Error when creating temporary directory: %s", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	if err := os.Mkdir(filepath.Join(tmpDir, "tmp"), 0o700); err != nil {
 		t.Fatalf("Error creating tmp directory: %s", err)
@@ -96,11 +88,7 @@ func TestAtomicWriteSetCommit(t *testing.T) {
 }
 
 func TestAtomicWriteSetCancel(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "atomic-writerset-test")
-	if err != nil {
-		t.Fatalf("Error when creating temporary directory: %s", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	if err := os.Mkdir(filepath.Join(tmpDir, "tmp"), 0o700); err != nil {
 		t.Fatalf("Error creating tmp directory: %s", err)

--- a/pkg/ioutils/readers_test.go
+++ b/pkg/ioutils/readers_test.go
@@ -2,59 +2,61 @@ package ioutils // import "github.com/docker/docker/pkg/ioutils"
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
 	"strings"
 	"testing"
+	"testing/iotest"
 	"time"
-
-	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
 )
 
-// Implement io.Reader
-type errorReader struct{}
-
-func (r *errorReader) Read(p []byte) (int, error) {
-	return 0, fmt.Errorf("error reader always fail")
-}
-
 func TestReadCloserWrapperClose(t *testing.T) {
-	reader := strings.NewReader("A string reader")
-	wrapper := NewReadCloserWrapper(reader, func() error {
-		return fmt.Errorf("This will be called when closing")
+	const text = "hello world"
+	testErr := errors.New("this will be called when closing")
+	wrapper := NewReadCloserWrapper(strings.NewReader(text), func() error {
+		return testErr
 	})
-	err := wrapper.Close()
-	if err == nil || !strings.Contains(err.Error(), "This will be called when closing") {
-		t.Fatalf("readCloserWrapper should have call the anonymous func and thus, fail.")
+
+	buf, err := io.ReadAll(wrapper)
+	if err != nil {
+		t.Errorf("io.ReadAll(wrapper) err = %v", err)
+	}
+	if string(buf) != text {
+		t.Errorf("expected %v, got: %v", text, string(buf))
+	}
+	err = wrapper.Close()
+	if !errors.Is(err, testErr) {
+		// readCloserWrapper should have called the anonymous func and thus, fail
+		t.Errorf("expected %v, got: %v", testErr, err)
 	}
 }
 
 func TestReaderErrWrapperReadOnError(t *testing.T) {
 	called := false
-	reader := &errorReader{}
-	wrapper := NewReaderErrWrapper(reader, func() {
+	expectedErr := errors.New("error reader always fail")
+	wrapper := NewReaderErrWrapper(iotest.ErrReader(expectedErr), func() {
 		called = true
 	})
 	_, err := wrapper.Read([]byte{})
-	assert.Check(t, is.Error(err, "error reader always fail"))
+	if !errors.Is(err, expectedErr) {
+		t.Errorf("expected %v, got: %v", expectedErr, err)
+	}
 	if !called {
-		t.Fatalf("readErrWrapper should have call the anonymous function on failure")
+		t.Fatalf("readErrWrapper should have called the anonymous function on failure")
 	}
 }
 
 func TestReaderErrWrapperRead(t *testing.T) {
-	reader := strings.NewReader("a string reader.")
-	wrapper := NewReaderErrWrapper(reader, func() {
+	const text = "hello world"
+	wrapper := NewReaderErrWrapper(strings.NewReader(text), func() {
 		t.Fatalf("readErrWrapper should not have called the anonymous function")
 	})
-	// Read 20 byte (should be ok with the string above)
-	num, err := wrapper.Read(make([]byte, 20))
+	num, err := wrapper.Read(make([]byte, len(text)+10))
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
-	if num != 16 {
-		t.Fatalf("readerErrWrapper should have read 16 byte, but read %d", num)
+	if expected := len(text); num != expected {
+		t.Errorf("readerErrWrapper should have read %d byte, but read %d", expected, num)
 	}
 }
 
@@ -70,10 +72,10 @@ func (p *perpetualReader) Read(buf []byte) (n int, err error) {
 func TestCancelReadCloser(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	cancelReadCloser := NewCancelReadCloser(ctx, io.NopCloser(&perpetualReader{}))
+	crc := NewCancelReadCloser(ctx, io.NopCloser(&perpetualReader{}))
 	for {
 		var buf [128]byte
-		_, err := cancelReadCloser.Read(buf[:])
+		_, err := crc.Read(buf[:])
 		if err == context.DeadlineExceeded {
 			break
 		} else if err != nil {

--- a/pkg/ioutils/writers_test.go
+++ b/pkg/ioutils/writers_test.go
@@ -51,8 +51,8 @@ func TestWriteCounter(t *testing.T) {
 	var buffer bytes.Buffer
 	wc := NewWriteCounter(&buffer)
 
-	reader1.WriteTo(wc)
-	reader2.WriteTo(wc)
+	_, _ = reader1.WriteTo(wc)
+	_, _ = reader2.WriteTo(wc)
 
 	if wc.Count != totalLength {
 		t.Errorf("Wrong count: %d vs. %d", wc.Count, totalLength)


### PR DESCRIPTION
- remove gotest.tools dependency as it was only used in one test, and only for a trivial check
- use t.TempDir()
- rename vars that collided with package types
- don't use un-keyed structs
- explicitly ignore some errors to please linters


**- A picture of a cute animal (not mandatory but encouraged)**

