### PR TITLE
integration-cli: Add t.Helper() to the cli test helper functions

### DIFF
--- a/integration-cli/cli/cli.go
+++ b/integration-cli/cli/cli.go
@@ -32,22 +32,26 @@ func DockerCmd(t testing.TB, args ...string) *icmd.Result {
 
 // BuildCmd executes the specified docker build command and expect a success
 func BuildCmd(t testing.TB, name string, cmdOperators ...CmdOperator) *icmd.Result {
+	t.Helper()
 	return Docker(Args("build", "-t", name), cmdOperators...).Assert(t, icmd.Success)
 }
 
 // InspectCmd executes the specified docker inspect command and expect a success
 func InspectCmd(t testing.TB, name string, cmdOperators ...CmdOperator) *icmd.Result {
+	t.Helper()
 	return Docker(Args("inspect", name), cmdOperators...).Assert(t, icmd.Success)
 }
 
 // WaitRun will wait for the specified container to be running, maximum 5 seconds.
 func WaitRun(t testing.TB, name string, cmdOperators ...CmdOperator) {
+	t.Helper()
 	waitForInspectResult(t, name, "{{.State.Running}}", "true", 5*time.Second, cmdOperators...)
 }
 
 // WaitExited will wait for the specified container to state exit, subject
 // to a maximum time limit in seconds supplied by the caller
 func WaitExited(t testing.TB, name string, timeout time.Duration, cmdOperators ...CmdOperator) {
+	t.Helper()
 	waitForInspectResult(t, name, "{{.State.Status}}", "exited", timeout, cmdOperators...)
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added `t.Helper()` calls to cli helper functions, making it easier to find where the error comes from in some of the cli integration tests.

**- How I did it**

...

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

