### PR TITLE
integration: Don't env cleanup before parallel subtests

### DIFF
--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestBuildWithRemoveAndForceRemove(t *testing.T) {
-	defer setupTest(t)()
+	t.Cleanup(setupTest(t))
 
 	cases := []struct {
 		name                           string
@@ -577,7 +577,7 @@ COPY --from=intermediate C:\\stuff C:\\stuff
 func TestBuildWithEmptyDockerfile(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"), "broken in earlier versions")
 	ctx := context.TODO()
-	defer setupTest(t)()
+	t.Cleanup(setupTest(t))
 
 	tests := []struct {
 		name        string

--- a/integration/container/container_test.go
+++ b/integration/container/container_test.go
@@ -13,7 +13,7 @@ import (
 // TestContainerInvalidJSON tests that POST endpoints that expect a body return
 // the correct error when sending invalid JSON requests.
 func TestContainerInvalidJSON(t *testing.T) {
-	defer setupTest(t)()
+	t.Cleanup(setupTest(t))
 
 	// POST endpoints that accept / expect a JSON body;
 	endpoints := []string{

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestCreateFailsWhenIdentifierDoesNotExist(t *testing.T) {
-	defer setupTest(t)()
+	t.Cleanup(setupTest(t))
 	client := testEnv.APIClient()
 
 	testCases := []struct {
@@ -90,7 +90,7 @@ func TestCreateLinkToNonExistingContainer(t *testing.T) {
 }
 
 func TestCreateWithInvalidEnv(t *testing.T) {
-	defer setupTest(t)()
+	t.Cleanup(setupTest(t))
 	client := testEnv.APIClient()
 
 	testCases := []struct {
@@ -337,7 +337,7 @@ func TestCreateWithCustomReadonlyPaths(t *testing.T) {
 }
 
 func TestCreateWithInvalidHealthcheckParams(t *testing.T) {
-	defer setupTest(t)()
+	t.Cleanup(setupTest(t))
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
@@ -532,7 +532,7 @@ func TestCreatePlatformSpecificImageNoPlatform(t *testing.T) {
 func TestCreateInvalidHostConfig(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 
-	defer setupTest(t)()
+	t.Cleanup(setupTest(t))
 	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 

--- a/integration/container/devices_windows_test.go
+++ b/integration/container/devices_windows_test.go
@@ -18,7 +18,7 @@ import (
 // via HostConfig.Devices through to the implementation in hcsshim.
 func TestWindowsDevices(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "windows")
-	defer setupTest(t)()
+	t.Cleanup(setupTest(t))
 	client := testEnv.APIClient()
 	ctx := context.Background()
 

--- a/integration/container/mounts_linux_test.go
+++ b/integration/container/mounts_linux_test.go
@@ -91,7 +91,7 @@ func TestContainerNetworkMountsNoChown(t *testing.T) {
 func TestMountDaemonRoot(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon)
 
-	defer setupTest(t)()
+	t.Cleanup(setupTest(t))
 	client := testEnv.APIClient()
 	ctx := context.Background()
 	info, err := client.Info(ctx)

--- a/integration/container/stop_linux_test.go
+++ b/integration/container/stop_linux_test.go
@@ -24,7 +24,7 @@ import (
 // a timeout works as documented, i.e. in case of negative timeout
 // waiting is not limited (issue #35311).
 func TestStopContainerWithTimeout(t *testing.T) {
-	defer setupTest(t)()
+	t.Cleanup(setupTest(t))
 	client := testEnv.APIClient()
 	ctx := context.Background()
 

--- a/integration/container/stop_windows_test.go
+++ b/integration/container/stop_windows_test.go
@@ -18,7 +18,7 @@ import (
 // waiting is not limited (issue #35311).
 func TestStopContainerWithTimeout(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
-	defer setupTest(t)()
+	t.Cleanup(setupTest(t))
 	client := testEnv.APIClient()
 	ctx := context.Background()
 

--- a/integration/container/wait_test.go
+++ b/integration/container/wait_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestWaitNonBlocked(t *testing.T) {
-	defer setupTest(t)()
+	t.Cleanup(setupTest(t))
 	cli := request.NewAPIClient(t)
 
 	testCases := []struct {
@@ -59,7 +59,7 @@ func TestWaitBlocked(t *testing.T) {
 	// Windows busybox does not support trap in this way, not sleep with sub-second
 	// granularity. It will always exit 0x40010004.
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
-	defer setupTest(t)()
+	t.Cleanup(setupTest(t))
 	cli := request.NewAPIClient(t)
 
 	testCases := []struct {
@@ -104,7 +104,7 @@ func TestWaitBlocked(t *testing.T) {
 }
 
 func TestWaitConditions(t *testing.T) {
-	defer setupTest(t)()
+	t.Cleanup(setupTest(t))
 	cli := request.NewAPIClient(t)
 
 	testCases := []struct {
@@ -179,7 +179,7 @@ func TestWaitConditions(t *testing.T) {
 }
 
 func TestWaitRestartedContainer(t *testing.T) {
-	defer setupTest(t)()
+	t.Cleanup(setupTest(t))
 	cli := request.NewAPIClient(t)
 
 	testCases := []struct {

--- a/integration/network/network_test.go
+++ b/integration/network/network_test.go
@@ -67,7 +67,7 @@ func TestRunContainerWithBridgeNone(t *testing.T) {
 // TestNetworkInvalidJSON tests that POST endpoints that expect a body return
 // the correct error when sending invalid JSON requests.
 func TestNetworkInvalidJSON(t *testing.T) {
-	defer setupTest(t)()
+	t.Cleanup(setupTest(t))
 
 	// POST endpoints that accept / expect a JSON body;
 	endpoints := []string{
@@ -126,7 +126,7 @@ func TestNetworkInvalidJSON(t *testing.T) {
 // TestNetworkList verifies that /networks returns a list of networks either
 // with, or without a trailing slash (/networks/). Regression test for https://github.com/moby/moby/issues/24595
 func TestNetworkList(t *testing.T) {
-	defer setupTest(t)()
+	t.Cleanup(setupTest(t))
 
 	endpoints := []string{
 		"/networks",

--- a/integration/plugin/common/plugin_test.go
+++ b/integration/plugin/common/plugin_test.go
@@ -33,7 +33,7 @@ import (
 // TestPluginInvalidJSON tests that POST endpoints that expect a body return
 // the correct error when sending invalid JSON requests.
 func TestPluginInvalidJSON(t *testing.T) {
-	defer setupTest(t)()
+	t.Cleanup(setupTest(t))
 
 	// POST endpoints that accept / expect a JSON body;
 	endpoints := []string{

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -196,7 +196,7 @@ func TestVolumesInspect(t *testing.T) {
 // TestVolumesInvalidJSON tests that POST endpoints that expect a body return
 // the correct error when sending invalid JSON requests.
 func TestVolumesInvalidJSON(t *testing.T) {
-	defer setupTest(t)()
+	t.Cleanup(setupTest(t))
 
 	// POST endpoints that accept / expect a JSON body;
 	endpoints := []string{"/volumes/create"}


### PR DESCRIPTION
Calling function returned from setupTest (which calls testEnv.Clean) in a defer block inside a test that spawns parallel subtests caused the cleanup function to be called before any of the subtest did anything.

Consider this test:
```go
package main

import (
        "testing"
)

var Global = "test"

func TestHelloWorld(t *testing.T) {
        cleanup := func() {
                Global = ""
        }
        defer cleanup()

        t.Run("subtest", func(t *testing.T) {
                t.Parallel()
                if Global != "test" {
                        t.Fatalf("Global doesn't match: %q", Global)
                }
        })
}
```

running it fail miserably:

```bash
$ go test -v .
--- FAIL: TestHelloWorld (0.00s)
    --- FAIL: TestHelloWorld/subtest (0.00s)
        main_test.go:18: Global doesn't match: ""
FAIL
FAIL    example.com/test/asdasffsa      0.505s
FAIL

```

This is because t.Parallel blocks the subtests goroutine and waits for the parent test to exit (so that the parent test has the chance to create all the subtest goroutines).
That causes the the defer block to run before the t.Logf after t.Parallel in the subtest is executed.

Using `t.Cleanup` doesn't have this issue, as it's called only after all subtests have also finished:
```diff
-        defer cleanup()
+        t.Cleanup(cleanup)
```

```bash
$ go test -v .
ok      example.com/test/asdasffsa      0.505s
```


**- What I did**
Fixed testEnv.Clean being called before any Parallel subtest does anything meaningful.

**- How I did it**
Change the defer expressions to use `t.Cleanup` instead to call it only after all subtests have also finished.
This doesn't change all `defer setupTest(t)()`, only these which have parallel subtests.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![dduddudu](https://github.com/moby/moby/assets/5046555/ed2e76e6-324e-4499-b464-13f3e64f47f0)
