### PR TITLE
client: set both request.Host and request.URL.Host

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -56,6 +56,36 @@ import (
 	"github.com/pkg/errors"
 )
 
+// DummyHost is a hostname used for local communication.
+//
+// It acts as a valid formatted hostname for local connections (such as "unix://"
+// or "npipe://") which do not require a hostname. It should never be resolved,
+// but uses the special-purpose ".localhost" TLD (as defined in [RFC 2606, Section 2]
+// and [RFC 6761, Section 6.3]).
+//
+// [RFC 7230, Section 5.4] defines that an empty header must be used for such
+// cases:
+//
+//	If the authority component is missing or undefined for the target URI,
+//	then a client MUST send a Host header field with an empty field-value.
+//
+// However, [Go stdlib] enforces the semantics of HTTP(S) over TCP, does not
+// allow an empty header to be used, and requires req.URL.Scheme to be either
+// "http" or "https".
+//
+// For further details, refer to:
+//
+//   - https://github.com/docker/engine-api/issues/189
+//   - https://github.com/golang/go/issues/13624
+//   - https://github.com/golang/go/issues/61076
+//   - https://github.com/moby/moby/issues/45935
+//
+// [RFC 2606, Section 2]: https://www.rfc-editor.org/rfc/rfc2606.html#section-2
+// [RFC 6761, Section 6.3]: https://www.rfc-editor.org/rfc/rfc6761#section-6.3
+// [RFC 7230, Section 5.4]: https://datatracker.ietf.org/doc/html/rfc7230#section-5.4
+// [Go stdlib]: https://github.com/golang/go/blob/6244b1946bc2101b01955468f1be502dbadd6807/src/net/http/transport.go#L558-L569
+const DummyHost = "api.moby.localhost"
+
 // ErrRedirect is the error returned by checkRedirect when the request is non-GET.
 var ErrRedirect = errors.New("unexpected redirect in response")
 

--- a/client/hijack.go
+++ b/client/hijack.go
@@ -67,6 +67,7 @@ func (cli *Client) setupHijackConn(ctx context.Context, req *http.Request, proto
 	if cli.proto == "unix" || cli.proto == "npipe" {
 		// For local communications, it doesn't matter what the host is.
 		req.URL.Host = DummyHost
+		req.Host = DummyHost
 	}
 	req.Header.Set("Connection", "Upgrade")
 	req.Header.Set("Upgrade", proto)

--- a/client/hijack.go
+++ b/client/hijack.go
@@ -64,7 +64,10 @@ func fallbackDial(proto, addr string, tlsConfig *tls.Config) (net.Conn, error) {
 }
 
 func (cli *Client) setupHijackConn(ctx context.Context, req *http.Request, proto string) (net.Conn, string, error) {
-	req.Host = cli.addr
+	if cli.proto == "unix" || cli.proto == "npipe" {
+		// For local communications, it doesn't matter what the host is.
+		req.URL.Host = DummyHost
+	}
 	req.Header.Set("Connection", "Upgrade")
 	req.Header.Set("Upgrade", proto)
 

--- a/client/request.go
+++ b/client/request.go
@@ -106,6 +106,7 @@ func (cli *Client) buildRequest(method, path string, body io.Reader, headers htt
 	if cli.proto == "unix" || cli.proto == "npipe" {
 		// For local communications, it doesn't matter what the host is.
 		req.URL.Host = DummyHost
+		req.Host = DummyHost
 	} else {
 		req.URL.Host = cli.addr
 	}

--- a/client/request.go
+++ b/client/request.go
@@ -104,15 +104,12 @@ func (cli *Client) buildRequest(method, path string, body io.Reader, headers htt
 	req = cli.addHeaders(req, headers)
 
 	if cli.proto == "unix" || cli.proto == "npipe" {
-		// For local communications, it doesn't matter what the host is. We just
-		// need a valid and meaningful host name. For details, see:
-		//
-		// - https://github.com/docker/engine-api/issues/189
-		// - https://github.com/golang/go/issues/13624
-		req.Host = "docker"
+		// For local communications, it doesn't matter what the host is.
+		req.URL.Host = DummyHost
+	} else {
+		req.URL.Host = cli.addr
 	}
 
-	req.URL.Host = cli.addr
 	req.URL.Scheme = cli.scheme
 
 	if body != nil && req.Header.Get("Content-Type") == "" {

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -29,10 +29,12 @@ func TestSetHostHeader(t *testing.T) {
 	}{
 		{
 			host:            "unix:///var/run/docker.sock",
+			expectedHost:    DummyHost,
 			expectedURLHost: DummyHost,
 		},
 		{
 			host:            "npipe:////./pipe/docker_engine",
+			expectedHost:    DummyHost,
 			expectedURLHost: DummyHost,
 		},
 		{

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -28,24 +28,20 @@ func TestSetHostHeader(t *testing.T) {
 		expectedURLHost string
 	}{
 		{
-			"unix:///var/run/docker.sock",
-			"docker",
-			"/var/run/docker.sock",
+			host:            "unix:///var/run/docker.sock",
+			expectedURLHost: DummyHost,
 		},
 		{
-			"npipe:////./pipe/docker_engine",
-			"docker",
-			"//./pipe/docker_engine",
+			host:            "npipe:////./pipe/docker_engine",
+			expectedURLHost: DummyHost,
 		},
 		{
-			"tcp://0.0.0.0:4243",
-			"",
-			"0.0.0.0:4243",
+			host:            "tcp://0.0.0.0:4243",
+			expectedURLHost: "0.0.0.0:4243",
 		},
 		{
-			"tcp://localhost:4243",
-			"",
-			"localhost:4243",
+			host:            "tcp://localhost:4243",
+			expectedURLHost: "localhost:4243",
 		},
 	}
 

--- a/integration-cli/docker_api_attach_test.go
+++ b/integration-cli/docker_api_attach_test.go
@@ -234,7 +234,14 @@ func requestHijack(method, endpoint string, data io.Reader, ct, daemon string, m
 		return nil, nil, errors.Wrap(err, "could not create new request")
 	}
 	req.URL.Scheme = "http"
-	req.URL.Host = hostURL.Host
+
+	// FIXME(thaJeztah): this should really be done by client.ParseHostURL
+	if hostURL.Scheme == "unix" || hostURL.Scheme == "npipe" {
+		// For local communications, it doesn't matter what the host is.
+		req.URL.Host = client.DummyHost
+	} else {
+		req.URL.Host = hostURL.Host
+	}
 
 	for _, opt := range modifiers {
 		opt(req)

--- a/integration-cli/docker_api_attach_test.go
+++ b/integration-cli/docker_api_attach_test.go
@@ -239,6 +239,7 @@ func requestHijack(method, endpoint string, data io.Reader, ct, daemon string, m
 	if hostURL.Scheme == "unix" || hostURL.Scheme == "npipe" {
 		// For local communications, it doesn't matter what the host is.
 		req.URL.Host = client.DummyHost
+		req.Host = client.DummyHost
 	} else {
 		req.URL.Host = hostURL.Host
 	}

--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -18,6 +18,12 @@ import (
 
 const (
 	defaultTimeOut = 30
+
+	// dummyHost is a hostname used for local communication.
+	//
+	// For local communications (npipe://, unix://), the hostname is not used,
+	// but we need valid and meaningful hostname.
+	dummyHost = "plugin.moby.localhost"
 )
 
 func newTransport(addr string, tlsConfig *tlsconfig.Options) (transport.Transport, error) {
@@ -44,8 +50,12 @@ func newTransport(addr string, tlsConfig *tlsconfig.Options) (transport.Transpor
 		return nil, err
 	}
 	scheme := httpScheme(u)
-
-	return transport.NewHTTPTransport(tr, scheme, socket), nil
+	hostName := u.Host
+	if hostName == "" || u.Scheme == "unix" || u.Scheme == "npipe" {
+		// For local communications, it doesn't matter what the host is.
+		hostName = dummyHost
+	}
+	return transport.NewHTTPTransport(tr, scheme, hostName), nil
 }
 
 // NewClient creates a new plugin client (http).

--- a/testutil/request/request.go
+++ b/testutil/request/request.go
@@ -123,8 +123,13 @@ func newRequest(endpoint string, opts *Options) (*http.Request, error) {
 	} else {
 		req.URL.Scheme = "http"
 	}
-	req.URL.Host = hostURL.Host
-
+	// FIXME(thaJeztah): this should really be done by client.ParseHostURL
+	if hostURL.Scheme == "unix" || hostURL.Scheme == "npipe" {
+		// For local communications, it doesn't matter what the host is.
+		req.URL.Host = client.DummyHost
+	} else {
+		req.URL.Host = hostURL.Host
+	}
 	for _, config := range opts.requestModifiers {
 		if err := config(req); err != nil {
 			return nil, err

--- a/testutil/request/request.go
+++ b/testutil/request/request.go
@@ -127,6 +127,7 @@ func newRequest(endpoint string, opts *Options) (*http.Request, error) {
 	if hostURL.Scheme == "unix" || hostURL.Scheme == "npipe" {
 		// For local communications, it doesn't matter what the host is.
 		req.URL.Host = client.DummyHost
+		req.Host = client.DummyHost
 	} else {
 		req.URL.Host = hostURL.Host
 	}


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/45942

Originally, code would be setting `request.host`, but it doesn't appear to be needed, so I left it out of the PR above, but maybe there's something I'm overlooking 😓 


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

