### PR TITLE
[24.0 backport] client: define a "dummy" hostname to use for local connections

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -56,6 +56,36 @@ import (
 	"github.com/pkg/errors"
 )
 
+// DummyHost is a hostname used for local communication.
+//
+// It acts as a valid formatted hostname for local connections (such as "unix://"
+// or "npipe://") which do not require a hostname. It should never be resolved,
+// but uses the special-purpose ".localhost" TLD (as defined in [RFC 2606, Section 2]
+// and [RFC 6761, Section 6.3]).
+//
+// [RFC 7230, Section 5.4] defines that an empty header must be used for such
+// cases:
+//
+//	If the authority component is missing or undefined for the target URI,
+//	then a client MUST send a Host header field with an empty field-value.
+//
+// However, [Go stdlib] enforces the semantics of HTTP(S) over TCP, does not
+// allow an empty header to be used, and requires req.URL.Scheme to be either
+// "http" or "https".
+//
+// For further details, refer to:
+//
+//   - https://github.com/docker/engine-api/issues/189
+//   - https://github.com/golang/go/issues/13624
+//   - https://github.com/golang/go/issues/61076
+//   - https://github.com/moby/moby/issues/45935
+//
+// [RFC 2606, Section 2]: https://www.rfc-editor.org/rfc/rfc2606.html#section-2
+// [RFC 6761, Section 6.3]: https://www.rfc-editor.org/rfc/rfc6761#section-6.3
+// [RFC 7230, Section 5.4]: https://datatracker.ietf.org/doc/html/rfc7230#section-5.4
+// [Go stdlib]: https://github.com/golang/go/blob/6244b1946bc2101b01955468f1be502dbadd6807/src/net/http/transport.go#L558-L569
+const DummyHost = "api.moby.localhost"
+
 // ErrRedirect is the error returned by checkRedirect when the request is non-GET.
 var ErrRedirect = errors.New("unexpected redirect in response")
 

--- a/client/hijack.go
+++ b/client/hijack.go
@@ -64,7 +64,11 @@ func fallbackDial(proto, addr string, tlsConfig *tls.Config) (net.Conn, error) {
 }
 
 func (cli *Client) setupHijackConn(ctx context.Context, req *http.Request, proto string) (net.Conn, string, error) {
-	req.Host = cli.addr
+	req.URL.Host = cli.addr
+	if cli.proto == "unix" || cli.proto == "npipe" {
+		// Override host header for non-tcp connections.
+		req.Host = DummyHost
+	}
 	req.Header.Set("Connection", "Upgrade")
 	req.Header.Set("Upgrade", proto)
 

--- a/client/request.go
+++ b/client/request.go
@@ -96,15 +96,13 @@ func (cli *Client) buildRequest(method, path string, body io.Reader, headers hea
 		return nil, err
 	}
 	req = cli.addHeaders(req, headers)
+	req.URL.Scheme = cli.scheme
+	req.URL.Host = cli.addr
 
 	if cli.proto == "unix" || cli.proto == "npipe" {
-		// For local communications, it doesn't matter what the host is. We just
-		// need a valid and meaningful host name. (See #189)
-		req.Host = "docker"
+		// Override host header for non-tcp connections.
+		req.Host = DummyHost
 	}
-
-	req.URL.Host = cli.addr
-	req.URL.Scheme = cli.scheme
 
 	if expectedPayload && req.Header.Get("Content-Type") == "" {
 		req.Header.Set("Content-Type", "text/plain")

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -28,24 +28,24 @@ func TestSetHostHeader(t *testing.T) {
 		expectedURLHost string
 	}{
 		{
-			"unix:///var/run/docker.sock",
-			"docker",
-			"/var/run/docker.sock",
+			host:            "unix:///var/run/docker.sock",
+			expectedHost:    "docker",
+			expectedURLHost: "/var/run/docker.sock",
 		},
 		{
-			"npipe:////./pipe/docker_engine",
-			"docker",
-			"//./pipe/docker_engine",
+			host:            "npipe:////./pipe/docker_engine",
+			expectedHost:    "docker",
+			expectedURLHost: "//./pipe/docker_engine",
 		},
 		{
-			"tcp://0.0.0.0:4243",
-			"",
-			"0.0.0.0:4243",
+			host:            "tcp://0.0.0.0:4243",
+			expectedHost:    "",
+			expectedURLHost: "0.0.0.0:4243",
 		},
 		{
-			"tcp://localhost:4243",
-			"",
-			"localhost:4243",
+			host:            "tcp://localhost:4243",
+			expectedHost:    "",
+			expectedURLHost: "localhost:4243",
 		},
 	}
 

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -29,12 +29,12 @@ func TestSetHostHeader(t *testing.T) {
 	}{
 		{
 			host:            "unix:///var/run/docker.sock",
-			expectedHost:    "docker",
+			expectedHost:    DummyHost,
 			expectedURLHost: "/var/run/docker.sock",
 		},
 		{
 			host:            "npipe:////./pipe/docker_engine",
-			expectedHost:    "docker",
+			expectedHost:    DummyHost,
 			expectedURLHost: "//./pipe/docker_engine",
 		},
 		{

--- a/integration-cli/docker_api_attach_test.go
+++ b/integration-cli/docker_api_attach_test.go
@@ -236,6 +236,11 @@ func requestHijack(method, endpoint string, data io.Reader, ct, daemon string, m
 	req.URL.Scheme = "http"
 	req.URL.Host = hostURL.Host
 
+	if hostURL.Scheme == "unix" || hostURL.Scheme == "npipe" {
+		// Override host header for non-tcp connections.
+		req.Host = client.DummyHost
+	}
+
 	for _, opt := range modifiers {
 		opt(req)
 	}

--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -18,6 +18,12 @@ import (
 
 const (
 	defaultTimeOut = 30
+
+	// dummyHost is a hostname used for local communication.
+	//
+	// For local communications (npipe://, unix://), the hostname is not used,
+	// but we need valid and meaningful hostname.
+	dummyHost = "plugin.moby.localhost"
 )
 
 func newTransport(addr string, tlsConfig *tlsconfig.Options) (transport.Transport, error) {
@@ -44,8 +50,12 @@ func newTransport(addr string, tlsConfig *tlsconfig.Options) (transport.Transpor
 		return nil, err
 	}
 	scheme := httpScheme(u)
-
-	return transport.NewHTTPTransport(tr, scheme, socket), nil
+	hostName := u.Host
+	if hostName == "" || u.Scheme == "unix" || u.Scheme == "npipe" {
+		// Override host header for non-tcp connections.
+		hostName = dummyHost
+	}
+	return transport.NewHTTPTransport(tr, scheme, hostName), nil
 }
 
 // NewClient creates a new plugin client (http).

--- a/testutil/request/request.go
+++ b/testutil/request/request.go
@@ -125,6 +125,11 @@ func newRequest(endpoint string, opts *Options) (*http.Request, error) {
 	}
 	req.URL.Host = hostURL.Host
 
+	if hostURL.Scheme == "unix" || hostURL.Scheme == "npipe" {
+		// Override host header for non-tcp connections.
+		req.Host = client.DummyHost
+	}
+
 	for _, config := range opts.requestModifiers {
 		if err := config(req); err != nil {
 			return nil, err


### PR DESCRIPTION
ℹ️ Minor conflict in a code comment, which was added in https://github.com/moby/moby/commit/a6048fc792468df982f6635981a138ad226304a8, and is not part of this branch.

-----


- backport of https://github.com/moby/moby/pull/45942
- fixes https://github.com/moby/moby/issues/45935
- relates to https://github.com/moby/moby/pull/45941


For local communications (npipe://, unix://), the hostname is not used, but we need valid and meaningful hostname.

The current code used the client's `addr` as hostname in some cases, which could contain the path for the unix-socket (`/var/run/docker.sock`), which gets rejected by go1.20.6 and go1.19.11 because of a security fix for [CVE-2023-29406 ][1], which was implemented in  https://go.dev/issue/60374.

Prior versions go Go would clean the host header, and strip slashes in the process, but go1.20.6 and go1.19.11 no longer do, and reject the host header.

This patch introduces a `DummyHost` const, and uses this dummy host for cases where we don't need an actual hostname.

Before this patch (using go1.20.6):

    make GO_VERSION=1.20.6 TEST_FILTER=TestAttach test-integration
    === RUN   TestAttachWithTTY
        attach_test.go:46: assertion failed: error is not nil: http: invalid Host header
    --- FAIL: TestAttachWithTTY (0.11s)
    === RUN   TestAttachWithoutTTy
        attach_test.go:46: assertion failed: error is not nil: http: invalid Host header
    --- FAIL: TestAttachWithoutTTy (0.02s)
    FAIL

With this patch applied:

    make GO_VERSION=1.20.6 TEST_FILTER=TestAttach test-integration
    INFO: Testing against a local daemon
    === RUN   TestAttachWithTTY
    --- PASS: TestAttachWithTTY (0.12s)
    === RUN   TestAttachWithoutTTy
    --- PASS: TestAttachWithoutTTy (0.02s)
    PASS

[1]: https://github.com/advisories/GHSA-f8f7-69v5-w4vx

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


