### PR TITLE
[20.10] integration/daemon: fix missing import

### DIFF
--- a/integration/daemon/daemon_test.go
+++ b/integration/daemon/daemon_test.go
@@ -2,6 +2,7 @@ package daemon // import "github.com/docker/docker/integration/daemon"
 
 import (
 	"context"
+	"os"
 	"runtime"
 	"testing"
 


### PR DESCRIPTION
- related / introduced in https://github.com/moby/moby/pull/45913
- related https://github.com/moby/moby/pull/45972#issuecomment-1636478290

commit 44152f6fb66da0ade1aa226f0b66ebbaa43d54b1 (https://github.com/moby/moby/pull/45913) backported a change that added `os.TempDir()` to a test, but that import was not yet in this file in the 20.10 branch.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

