### PR TITLE
libnetwork/options: remove unused NewGeneric, and use map[string]any

### DIFF
--- a/libnetwork/options/options.go
+++ b/libnetwork/options/options.go
@@ -42,12 +42,7 @@ func (e TypeMismatchError) Error() string {
 }
 
 // Generic is a basic type to store arbitrary settings.
-type Generic map[string]interface{}
-
-// NewGeneric returns a new Generic instance.
-func NewGeneric() Generic {
-	return make(Generic)
-}
+type Generic map[string]any
 
 // GenerateFromModel takes the generic options, and tries to build a new
 // instance of the model's type by matching keys from the generic options to

--- a/libnetwork/options/options_test.go
+++ b/libnetwork/options/options_test.go
@@ -7,10 +7,11 @@ import (
 )
 
 func TestGenerate(t *testing.T) {
-	gen := NewGeneric()
-	gen["Int"] = 1
-	gen["Rune"] = 'b'
-	gen["Float64"] = 2.0
+	gen := Generic{
+		"Int":     1,
+		"Rune":    'b',
+		"Float64": 2.0,
+	}
 
 	type Model struct {
 		Int     int
@@ -39,10 +40,11 @@ func TestGenerate(t *testing.T) {
 }
 
 func TestGeneratePtr(t *testing.T) {
-	gen := NewGeneric()
-	gen["Int"] = 1
-	gen["Rune"] = 'b'
-	gen["Float64"] = 2.0
+	gen := Generic{
+		"Int":     1,
+		"Rune":    'b',
+		"Float64": 2.0,
+	}
 
 	type Model struct {
 		Int     int


### PR DESCRIPTION
Remove the NewGeneric utility as it was not used anywhere, except for in tests.

Also "modernize" the type, and use `any` instead of `interface{}`.


**- A picture of a cute animal (not mandatory but encouraged)**

