### PR TITLE
libnetwork/config: remove IsValidName utility

### DIFF
--- a/libnetwork/config/config.go
+++ b/libnetwork/config/config.go
@@ -135,11 +135,6 @@ func OptionNetworkControlPlaneMTU(exp int) Option {
 	}
 }
 
-// IsValidName validates configuration objects supported by libnetwork
-func IsValidName(name string) bool {
-	return strings.TrimSpace(name) != ""
-}
-
 // OptionActiveSandboxes function returns an option setter for passing the sandboxes
 // which were active during previous daemon life
 func OptionActiveSandboxes(sandboxes map[string]interface{}) Option {

--- a/libnetwork/config/config_test.go
+++ b/libnetwork/config/config_test.go
@@ -26,15 +26,3 @@ func TestOptionsLabels(t *testing.T) {
 		}
 	}
 }
-
-func TestValidName(t *testing.T) {
-	if !IsValidName("test") {
-		t.Fatal("Name validation fails for a name that must be accepted")
-	}
-	if IsValidName("") {
-		t.Fatal("Name validation succeeds for a case when it is expected to fail")
-	}
-	if IsValidName("   ") {
-		t.Fatal("Name validation succeeds for a case when it is expected to fail")
-	}
-}

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -480,7 +480,7 @@ func (c *Controller) NewNetwork(networkType, name string, id string, options ...
 		}
 	}
 
-	if !config.IsValidName(name) {
+	if strings.TrimSpace(name) == "" {
 		return nil, ErrInvalidName(name)
 	}
 

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/log"
-	"github.com/docker/docker/libnetwork/config"
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/etchosts"
@@ -1150,7 +1149,7 @@ func (n *network) addEndpoint(ep *Endpoint) error {
 
 func (n *network) CreateEndpoint(name string, options ...EndpointOption) (*Endpoint, error) {
 	var err error
-	if !config.IsValidName(name) {
+	if strings.TrimSpace(name) == "" {
 		return nil, ErrInvalidName(name)
 	}
 


### PR DESCRIPTION
This utility was not used for "Config", but for Networks and Endpoints. Having this utility made it look like more than it was, and the related test was effectively testing stdlib.

Abstracting the validation also was hiding that, while validation does not allow "empty" names, it happily allows leading/trailing whitespace, and does not remove that before creating networks or endpoints;

    docker network create "bridge "
    docker network create "bridge  "
    docker network create "bridge   "
    docker network create " bridge  "
    docker network create "  bridge "
    docker network create "   bridge"

    docker network ls --filter driver=bridge
    NETWORK ID     NAME        DRIVER    SCOPE
    d4d53210f185      bridge   bridge    local
    e9afba0d99de     bridge    bridge    local
    69fb7a7ba67c    bridge     bridge    local
    a452bf065403   bridge      bridge    local
    49d96c59061d   bridge      bridge    local
    8eae1c4be12c   bridge      bridge    local
    86dd65b881b9   bridge      bridge    local


**- A picture of a cute animal (not mandatory but encouraged)**

