### PR TITLE
libnetwork/config: add Config.DriverConfig() and un-export DriverCfg

### DIFF
--- a/libnetwork/config/config.go
+++ b/libnetwork/config/config.go
@@ -25,7 +25,7 @@ type Config struct {
 	DefaultNetwork         string
 	DefaultDriver          string
 	Labels                 []string
-	DriverCfg              map[string]interface{}
+	driverCfg              map[string]map[string]any
 	ClusterProvider        cluster.Provider
 	NetworkControlPlaneMTU int
 	DefaultAddressPool     []*ipamutils.NetworkToSplit
@@ -37,7 +37,7 @@ type Config struct {
 // New creates a new Config and initializes it with the given Options.
 func New(opts ...Option) *Config {
 	cfg := &Config{
-		DriverCfg: make(map[string]interface{}),
+		driverCfg: make(map[string]map[string]any),
 	}
 
 	for _, opt := range opts {
@@ -51,6 +51,10 @@ func New(opts ...Option) *Config {
 		cfg.Scope = datastore.DefaultScope(cfg.DataDir)
 	}
 	return cfg
+}
+
+func (c *Config) DriverConfig(name string) map[string]any {
+	return c.driverCfg[name]
 }
 
 // Option is an option setter function type used to pass various configurations
@@ -81,9 +85,9 @@ func OptionDefaultAddressPoolConfig(addressPool []*ipamutils.NetworkToSplit) Opt
 }
 
 // OptionDriverConfig returns an option setter for driver configuration.
-func OptionDriverConfig(networkType string, config map[string]interface{}) Option {
+func OptionDriverConfig(networkType string, config map[string]any) Option {
 	return func(c *Config) {
-		c.DriverCfg[networkType] = config
+		c.driverCfg[networkType] = config
 	}
 }
 

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -335,11 +335,9 @@ func (c *Controller) makeDriverConfig(ntype string) map[string]interface{} {
 		cfg[key] = val
 	}
 
-	drvCfg, ok := c.cfg.DriverCfg[ntype]
-	if ok {
-		for k, v := range drvCfg.(map[string]interface{}) {
-			cfg[k] = v
-		}
+	// Merge in the existing config for this driver.
+	for k, v := range c.cfg.DriverConfig(ntype) {
+		cfg[k] = v
 	}
 
 	if c.cfg.Scope.IsValid() {
@@ -1146,10 +1144,7 @@ func (c *Controller) iptablesEnabled() bool {
 		return false
 	}
 	// parse map cfg["bridge"]["generic"]["EnableIPTable"]
-	cfgBridge, ok := c.cfg.DriverCfg["bridge"].(map[string]interface{})
-	if !ok {
-		return false
-	}
+	cfgBridge := c.cfg.DriverConfig("bridge")
 	cfgGeneric, ok := cfgBridge[netlabel.GenericData].(options.Generic)
 	if !ok {
 		return false
@@ -1170,10 +1165,7 @@ func (c *Controller) ip6tablesEnabled() bool {
 		return false
 	}
 	// parse map cfg["bridge"]["generic"]["EnableIP6Table"]
-	cfgBridge, ok := c.cfg.DriverCfg["bridge"].(map[string]interface{})
-	if !ok {
-		return false
-	}
+	cfgBridge := c.cfg.DriverConfig("bridge")
 	cfgGeneric, ok := cfgBridge[netlabel.GenericData].(options.Generic)
 	if !ok {
 		return false

--- a/libnetwork/firewall_linux_test.go
+++ b/libnetwork/firewall_linux_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/libnetwork/config"
 	"github.com/docker/docker/libnetwork/iptables"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/options"
@@ -52,15 +53,14 @@ func TestUserChain(t *testing.T) {
 			defer testutils.SetupTestOSContext(t)()
 			defer resetIptables(t)
 
-			c, err := New()
-			assert.NilError(t, err)
-			defer c.Stop()
-			c.cfg.DriverCfg["bridge"] = map[string]interface{}{
+			c, err := New(config.OptionDriverConfig("bridge", map[string]any{
 				netlabel.GenericData: options.Generic{
 					"EnableIPTables":  tc.iptables,
 					"EnableIP6Tables": tc.iptables,
 				},
-			}
+			}))
+			assert.NilError(t, err)
+			defer c.Stop()
 
 			// init. condition, FORWARD chain empty DOCKER-USER not exist
 			assert.DeepEqual(t, getRules(t, iptables.IPv4, fwdChainName), []string{"-P FORWARD ACCEPT"})

--- a/libnetwork/firewall_linux_test.go
+++ b/libnetwork/firewall_linux_test.go
@@ -69,9 +69,9 @@ func TestUserChain(t *testing.T) {
 
 			if tc.insert {
 				_, err = iptable4.Raw("-A", fwdChainName, "-j", "DROP")
-				assert.NilError(t, err)
+				assert.Check(t, err)
 				_, err = iptable6.Raw("-A", fwdChainName, "-j", "DROP")
-				assert.NilError(t, err)
+				assert.Check(t, err)
 			}
 			arrangeUserFilterRule()
 
@@ -81,10 +81,10 @@ func TestUserChain(t *testing.T) {
 				assert.Check(t, is.DeepEqual(getRules(t, iptable4, usrChainName), tc.userChain))
 				assert.Check(t, is.DeepEqual(getRules(t, iptable6, usrChainName), tc.userChain))
 			} else {
-				_, err := iptable4.Raw("-S", usrChainName)
-				assert.Assert(t, err != nil, "ipv4 chain %v: created unexpectedly", usrChainName)
+				_, err = iptable4.Raw("-S", usrChainName)
+				assert.Check(t, is.ErrorContains(err, "No chain/target/match by that name"), "ipv4 chain %v: created unexpectedly", usrChainName)
 				_, err = iptable6.Raw("-S", usrChainName)
-				assert.Assert(t, err != nil, "ipv6 chain %v: created unexpectedly", usrChainName)
+				assert.Check(t, is.ErrorContains(err, "No chain/target/match by that name"), "ipv6 chain %v: created unexpectedly", usrChainName)
 			}
 		})
 	}


### PR DESCRIPTION
### libnetwork: TestUserChain: don't manually manipulate Controller.cfg.DriverCfg

`libnetwork.New()` allows for driver-options to be passed using the `config.OptionDriverConfig`.
Update the test to not manually mutate the controller's configuration after
creating.

### libnetwork: TestUserChain: re-use IPTables instances

The test already creates instances for each ip-version, so let's re-use them. While changing, also use assert.Check to not fail early.

### libnetwork: TestUserChain: use assert.Check and is.ErrorContains

Don't fail early if we can still test more, and be slightly more strict in what error we're looking for.

### libnetwork/config: add Config.DriverConfig() and un-export DriverCfg

The driver-configurations are only set when creating a new controller,
using the `config.OptionDriverConfig()` option that can be passed to
`New()`, and used as "read-only" after that.

Taking away any other paths that set these options, the only type used
for per-driver options are a `map[string]interface{}`, so we can change
the type from `map[string]interface{}` to a `map[string]map[string]interface{}`,
(or its "modern" variant: `map[string]map[string]any`), so that it's
no longer needed to cast the type before use.


**- A picture of a cute animal (not mandatory but encouraged)**

