### PR TITLE
libnetwork/iptables: some cleanups and refactoring: the sequel

### DIFF
--- a/libnetwork/drivers/bridge/setup_ip_tables.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables.go
@@ -376,7 +376,7 @@ func setINC(version iptables.IPVersion, iface string, enable bool) error {
 const oldIsolationChain = "DOCKER-ISOLATION"
 
 func removeIPChains(version iptables.IPVersion) {
-	ipt := iptables.IPTable{Version: version}
+	ipt := iptables.GetIptable(version)
 
 	// Remove obsolete rules from default chains
 	ipt.ProgramRule(iptables.Filter, "FORWARD", iptables.Delete, []string{"-j", oldIsolationChain})

--- a/libnetwork/firewall_linux_test.go
+++ b/libnetwork/firewall_linux_test.go
@@ -111,6 +111,6 @@ func resetIptables(t *testing.T) {
 
 		_, err := iptable.Raw("-F", fwdChainName)
 		assert.Check(t, err)
-		_ = iptable.RemoveExistingChain(usrChainName, "")
+		_ = iptable.RemoveExistingChain(usrChainName, iptables.Filter)
 	}
 }

--- a/libnetwork/iptables/firewalld.go
+++ b/libnetwork/iptables/firewalld.go
@@ -65,8 +65,8 @@ var (
 	onReloaded       []*func() // callbacks when Firewalld has been reloaded
 )
 
-// FirewalldInit initializes firewalld management code.
-func FirewalldInit() error {
+// firewalldInit initializes firewalld management code.
+func firewalldInit() error {
 	var err error
 
 	if connection, err = newConnection(); err != nil {

--- a/libnetwork/iptables/firewalld_test.go
+++ b/libnetwork/iptables/firewalld_test.go
@@ -13,7 +13,7 @@ func TestFirewalldInit(t *testing.T) {
 	if !checkRunning() {
 		t.Skip("firewalld is not running")
 	}
-	if err := FirewalldInit(); err != nil {
+	if err := firewalldInit(); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -71,9 +71,9 @@ var (
 	initOnce       sync.Once
 )
 
-// IPTable defines struct with IPVersion
+// IPTable defines struct with [IPVersion].
 type IPTable struct {
-	Version IPVersion
+	ipVersion IPVersion
 }
 
 // ChainInfo defines the iptables chain.
@@ -146,7 +146,7 @@ func initCheck() error {
 
 // GetIptable returns an instance of IPTable with specified version
 func GetIptable(version IPVersion) *IPTable {
-	return &IPTable{Version: version}
+	return &IPTable{ipVersion: version}
 }
 
 // NewChain adds a new chain to ip table.
@@ -169,13 +169,13 @@ func (iptable IPTable) NewChain(name string, table Table, hairpinMode bool) (*Ch
 		Name:        name,
 		Table:       table,
 		HairpinMode: hairpinMode,
-		IPVersion:   iptable.Version,
+		IPVersion:   iptable.ipVersion,
 	}, nil
 }
 
 // LoopbackByVersion returns loopback address by version
 func (iptable IPTable) LoopbackByVersion() string {
-	if iptable.Version == IPv6 {
+	if iptable.ipVersion == IPv6 {
 		return "::1/128"
 	}
 	return "127.0.0.0/8"
@@ -292,7 +292,7 @@ func (iptable IPTable) RemoveExistingChain(name string, table Table) error {
 	c := &ChainInfo{
 		Name:      name,
 		Table:     table,
-		IPVersion: iptable.Version,
+		IPVersion: iptable.ipVersion,
 	}
 	return c.Remove()
 }
@@ -506,7 +506,7 @@ func (iptable IPTable) Raw(args ...string) ([]byte, error) {
 	if firewalldRunning {
 		// select correct IP version for firewalld
 		ipv := Iptables
-		if iptable.Version == IPv6 {
+		if iptable.ipVersion == IPv6 {
 			ipv = IP6Tables
 		}
 
@@ -525,7 +525,7 @@ func (iptable IPTable) raw(args ...string) ([]byte, error) {
 	}
 	path := iptablesPath
 	commandName := "iptables"
-	if iptable.Version == IPv6 {
+	if iptable.ipVersion == IPv6 {
 		if ip6tablesPath == "" {
 			return nil, fmt.Errorf("ip6tables is missing")
 		}

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -66,7 +66,6 @@ var (
 	iptablesPath  string
 	ip6tablesPath string
 	supportsXlock = false
-	xLockWaitMsg  = "Another app is currently holding the xtables lock"
 	// used to lock iptables commands if xtables lock is not supported
 	bestEffortLock sync.Mutex
 	initOnce       sync.Once
@@ -474,9 +473,13 @@ func (iptable IPTable) exists(native bool, table Table, chain string, rule ...st
 	return err == nil
 }
 
-// Maximum duration that an iptables operation can take
-// before flagging a warning.
-const opWarnTime = 2 * time.Second
+const (
+	// opWarnTime is the maximum duration that an iptables operation can take before flagging a warning.
+	opWarnTime = 2 * time.Second
+
+	// xLockWaitMsg is the iptables warning about xtables lock that can be suppressed.
+	xLockWaitMsg = "Another app is currently holding the xtables lock"
+)
 
 func filterOutput(start time.Time, output []byte, args ...string) []byte {
 	// Flag operations that have taken a long time to complete

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -144,8 +144,18 @@ func initCheck() error {
 	return nil
 }
 
-// GetIptable returns an instance of IPTable with specified version
+// GetIptable returns an instance of IPTable with specified version ([IPv4]
+// or [IPv6]). It panics if an invalid [IPVersion] is provided.
 func GetIptable(version IPVersion) *IPTable {
+	switch version {
+	case IPv4, IPv6:
+		// valid version
+	case "":
+		// default is IPv4 for backward-compatibility
+		version = IPv4
+	default:
+		panic("unknown IP version: " + version)
+	}
 	return &IPTable{ipVersion: version}
 }
 

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -125,7 +125,7 @@ func initFirewalld() {
 		log.G(context.TODO()).Info("skipping firewalld management for rootless mode")
 		return
 	}
-	if err := FirewalldInit(); err != nil {
+	if err := firewalldInit(); err != nil {
 		log.G(context.TODO()).WithError(err).Debugf("unable to initialize firewalld; using raw iptables instead")
 	}
 }

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -151,8 +151,11 @@ func GetIptable(version IPVersion) *IPTable {
 
 // NewChain adds a new chain to ip table.
 func (iptable IPTable) NewChain(name string, table Table, hairpinMode bool) (*ChainInfo, error) {
+	if name == "" {
+		return nil, fmt.Errorf("could not create chain: chain name is empty")
+	}
 	if table == "" {
-		table = Filter
+		return nil, fmt.Errorf("could not create chain %s: invalid table name: table name is empty", name)
 	}
 	// Add chain if it doesn't exist
 	if _, err := iptable.Raw("-t", string(table), "-n", "-L", name); err != nil {
@@ -280,8 +283,11 @@ func (iptable IPTable) ProgramChain(c *ChainInfo, bridgeName string, hairpinMode
 
 // RemoveExistingChain removes existing chain from the table.
 func (iptable IPTable) RemoveExistingChain(name string, table Table) error {
+	if name == "" {
+		return fmt.Errorf("could not remove chain: chain name is empty")
+	}
 	if table == "" {
-		table = Filter
+		return fmt.Errorf("could not remove chain %s: invalid table name: table name is empty", name)
 	}
 	c := &ChainInfo{
 		Name:      name,

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -554,10 +554,8 @@ func (iptable IPTable) RawCombinedOutputNative(args ...string) error {
 
 // ExistChain checks if a chain exists
 func (iptable IPTable) ExistChain(chain string, table Table) bool {
-	if _, err := iptable.Raw("-t", string(table), "-nL", chain); err == nil {
-		return true
-	}
-	return false
+	_, err := iptable.Raw("-t", string(table), "-nL", chain)
+	return err == nil
 }
 
 // SetDefaultPolicy sets the passed default policy for the table/chain

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -21,15 +21,6 @@ import (
 // Action signifies the iptable action.
 type Action string
 
-// Policy is the default iptable policies
-type Policy string
-
-// Table refers to Nat, Filter or Mangle.
-type Table string
-
-// IPVersion refers to IP version, v4 or v6
-type IPVersion string
-
 const (
 	// Append appends the rule at the end of the chain.
 	Append Action = "-A"
@@ -37,19 +28,37 @@ const (
 	Delete Action = "-D"
 	// Insert inserts the rule at the top of the chain.
 	Insert Action = "-I"
+)
+
+// Policy is the default iptable policies
+type Policy string
+
+const (
+	// Drop is the default iptables DROP policy.
+	Drop Policy = "DROP"
+	// Accept is the default iptables ACCEPT policy.
+	Accept Policy = "ACCEPT"
+)
+
+// Table refers to Nat, Filter or Mangle.
+type Table string
+
+const (
 	// Nat table is used for nat translation rules.
 	Nat Table = "nat"
 	// Filter table is used for filter rules.
 	Filter Table = "filter"
 	// Mangle table is used for mangling the packet.
 	Mangle Table = "mangle"
-	// Drop is the default iptables DROP policy
-	Drop Policy = "DROP"
-	// Accept is the default iptables ACCEPT policy
-	Accept Policy = "ACCEPT"
-	// IPv4 is version 4
+)
+
+// IPVersion refers to IP version, v4 or v6
+type IPVersion string
+
+const (
+	// IPv4 is version 4.
 	IPv4 IPVersion = "IPV4"
-	// IPv6 is version 6
+	// IPv6 is version 6.
 	IPv6 IPVersion = "IPV6"
 )
 


### PR DESCRIPTION
- first follow-up to https://github.com/moby/moby/pull/45888

### libnetwork/iptables: IPTable.ExistChain(): remove redundant if/else

### libnetwork/iptables: group "enum" consts per type

### libnetwork/iptables: make xLockWaitMsg a const

### libnetwork/iptables: un-export FirewalldInit

It's only used internally, and it was last used in commit:
https://github.com/moby/libnetwork/commit/0220b06cd6e0048adef13aba5cba3fea8be7fede

But moved into the iptables package in this commit:
https://github.com/moby/libnetwork/commit/998f3ce22c641b33f062d111f043e92495e3804c

### libnetwork/iptables: resetIptables(): don't pass empty table name

Don't depend on a default being set, but explicitly pass the table.

### libnetwork/iptables: NewChain, RemoveExistingChain: validate chain, table

Now that all consumers of these functions are passing non-empty values,
let's validate that no empty strings for either chain or table are passed. 

### libnetwork/iptables: make some vars local, and move bestEffortLock lock

Make some variables local to the if-branches to be slightly more iodiomatic,
and to make clear it's only used in that branch.

Move the bestEffortLock locking later in IPtable.raw(), because that function'
could return before the lock was even needed.

### libnetwork/iptables: un-export IPTable.Version

We have the GetIptable "constructor". Let's make that the canonical way
to initialize.

### libnetwork/iptables: GetIptable: validate provided IPversion

libnetwork/iptables: move IPTable.LoopbackByVersion() to a utility

Not critical, but when used from ChainInfo, we had to construct an IPTable
based on the version of the ChainInfo, which then only used the version
we passed to get the right loopback.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

