### PR TITLE
libnetwork, libnetwork/drivers: some minor cleanups

### DIFF
--- a/libnetwork/drivers/bridge/bridge.go
+++ b/libnetwork/drivers/bridge/bridge.go
@@ -440,12 +440,7 @@ func (d *driver) configure(option map[string]interface{}) error {
 	d.config = config
 	d.Unlock()
 
-	err = d.initStore(option)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return d.initStore(option)
 }
 
 func (d *driver) getNetwork(id string) (*bridgeNetwork, error) {

--- a/libnetwork/drivers/bridge/setup_device_test.go
+++ b/libnetwork/drivers/bridge/setup_device_test.go
@@ -52,7 +52,7 @@ func TestSetupNewNonDefaultBridge(t *testing.T) {
 
 	err = setupDevice(config, br)
 	if err == nil {
-		t.Fatal("Expected bridge creation failure with \"non default name\", succeeded")
+		t.Fatal(`Expected bridge creation failure with "non default name", succeeded`)
 	}
 
 	if _, ok := err.(NonDefaultBridgeExistError); !ok {

--- a/libnetwork/drivers/host/host.go
+++ b/libnetwork/drivers/host/host.go
@@ -43,7 +43,7 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 	defer d.Unlock()
 
 	if d.network != "" {
-		return types.ForbiddenErrorf("only one instance of \"%s\" network is allowed", NetworkType)
+		return types.ForbiddenErrorf("only one instance of %q network is allowed", NetworkType)
 	}
 
 	d.network = id
@@ -52,7 +52,7 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 }
 
 func (d *driver) DeleteNetwork(nid string) error {
-	return types.ForbiddenErrorf("network of type \"%s\" cannot be deleted", NetworkType)
+	return types.ForbiddenErrorf("network of type %q cannot be deleted", NetworkType)
 }
 
 func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {

--- a/libnetwork/drivers/null/null.go
+++ b/libnetwork/drivers/null/null.go
@@ -43,7 +43,7 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 	defer d.Unlock()
 
 	if d.network != "" {
-		return types.ForbiddenErrorf("only one instance of \"%s\" network is allowed", NetworkType)
+		return types.ForbiddenErrorf("only one instance of %q network is allowed", NetworkType)
 	}
 
 	d.network = id
@@ -52,7 +52,7 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 }
 
 func (d *driver) DeleteNetwork(nid string) error {
-	return types.ForbiddenErrorf("network of type \"%s\" cannot be deleted", NetworkType)
+	return types.ForbiddenErrorf("network of type %q cannot be deleted", NetworkType)
 }
 
 func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {

--- a/libnetwork/drivers/overlay/overlayutils/utils_test.go
+++ b/libnetwork/drivers/overlay/overlayutils/utils_test.go
@@ -43,14 +43,14 @@ func TestAppendVNIList(t *testing.T) {
 			slice:   []uint32{4, 5, 6},
 			csv:     "1,2,3,abc",
 			want:    []uint32{4, 5, 6, 1, 2, 3},
-			wantErr: "invalid vxlan id value \"abc\" passed",
+			wantErr: `invalid vxlan id value "abc" passed`,
 		},
 		{
 			name:    "InvalidVNI2",
 			slice:   []uint32{4, 5, 6},
 			csv:     "abc,1,2,3",
 			want:    []uint32{4, 5, 6},
-			wantErr: "invalid vxlan id value \"abc\" passed",
+			wantErr: `invalid vxlan id value "abc" passed`,
 		},
 	}
 	for _, tt := range cases {


### PR DESCRIPTION
### libnetwork/drivers/bridge: driver.configure: remove redundant err-check

### libnetwork/drivers: rewrite some strings to reduce quote-escaping

### libnetwork: getTestEnv(): use literals for options

Contructing these options was a bit convoluted; let's use literals for these.


**- A picture of a cute animal (not mandatory but encouraged)**

