### PR TITLE
client: return explicit "nil" for no errors, and remove nil check

### DIFF
--- a/client/container_stats.go
+++ b/client/container_stats.go
@@ -21,8 +21,10 @@ func (cli *Client) ContainerStats(ctx context.Context, containerID string, strea
 		return types.ContainerStats{}, err
 	}
 
-	osType := getDockerOS(resp.header.Get("Server"))
-	return types.ContainerStats{Body: resp.body, OSType: osType}, err
+	return types.ContainerStats{
+		Body:   resp.body,
+		OSType: getDockerOS(resp.header.Get("Server")),
+	}, nil
 }
 
 // ContainerStatsOneShot gets a single stat entry from a container.
@@ -37,6 +39,8 @@ func (cli *Client) ContainerStatsOneShot(ctx context.Context, containerID string
 		return types.ContainerStats{}, err
 	}
 
-	osType := getDockerOS(resp.header.Get("Server"))
-	return types.ContainerStats{Body: resp.body, OSType: osType}, err
+	return types.ContainerStats{
+		Body:   resp.body,
+		OSType: getDockerOS(resp.header.Get("Server")),
+	}, nil
 }

--- a/client/request.go
+++ b/client/request.go
@@ -227,13 +227,8 @@ func (cli *Client) checkResponseErr(serverResp serverResponse) error {
 		return fmt.Errorf("request returned %s for API route and version %s, check if the server supports the requested API version", http.StatusText(serverResp.statusCode), serverResp.reqURL)
 	}
 
-	var ct string
-	if serverResp.header != nil {
-		ct = serverResp.header.Get("Content-Type")
-	}
-
 	var errorMessage string
-	if (cli.version == "" || versions.GreaterThan(cli.version, "1.23")) && ct == "application/json" {
+	if serverResp.header.Get("Content-Type") == "application/json" && (cli.version == "" || versions.GreaterThan(cli.version, "1.23")) {
 		var errorResponse types.ErrorResponse
 		if err := json.Unmarshal(body, &errorResponse); err != nil {
 			return errors.Wrap(err, "Error reading JSON")


### PR DESCRIPTION
some changes I had in another branch


- remove some intermediate variables
- explicitly return "nil" if there's no error
- remove redundant check for response-headers being nil

**- A picture of a cute animal (not mandatory but encouraged)**

