### PR TITLE
daemon: use the registry service config for getting registry hosts

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -207,6 +207,13 @@ func (daemon *Daemon) RegistryHosts(host string) ([]docker.RegistryHost, error) 
 		}
 		m[k] = c
 	}
+	if _, ok := m[host]; !ok && daemon.registryService.IsInsecureRegistry(host) {
+		c := resolverconfig.RegistryConfig{}
+		t := true
+		c.PlainHTTP = &t
+		c.Insecure = &t
+		m[host] = c
+	}
 
 	for k, v := range m {
 		v.TLSConfigDir = []string{registry.HostCertsDir(k)}


### PR DESCRIPTION

**- What I did**

Fixes https://github.com/docker/buildx/issues/1642 (this one was an utter pain to track down :tada:)

The logic in `RegistryHosts` appears to be shared between BuildKit and the containerd snapshotter, so this may also be a [containerd related fix](https://github.com/moby/moby/blob/ee794231240b4f4087cffb434dcc67b06f402a47/daemon/daemon.go#L1065)?

> **Note**
>
> This patch fixes the above issue, but the underlying bug in the issue is actually the use of `url.Parse`, which can incorrectly parse "foo-registry:5000" with opaque data: https://play.golang.com/p/469UqjaiVhg.
>
> Instead of just fixing this directly, it makes more sense to actually just use the same logic that we already have for parsing the insecure registries config.

**- How I did it**

The logic previously used in `RegistryHosts` was duplicated logic from the config we've already parsed - however, there were significant differences in exactly the outputs it produced.

To resolve the above buildx issue, it's sufficient to just update `RegistryHosts` to use the already parsed configs, which have been validated and cleaned appropriately. We can also add support for the CIDR notation allowed in insecure-registries while we're in the area.

**- How to verify it**

See the reproduction instructions in https://github.com/docker/buildx/issues/1642#issuecomment-1624435786. Before the patches in this PR you should see:

```
#3 [internal] load metadata for foo-registry:5000/library/hello-world:linux
#3 ERROR: failed to do request: Head "https://foo-registry:5000/v2/library/hello-world/manifests/linux": http: server gave HTTP response to HTTPS client
------
 > [internal] load metadata for foo-registry:5000/library/hello-world:linux:
------
Dockerfile:1
--------------------
   1 | >>> FROM foo-registry:5000/library/hello-world:linux
   2 |     RUN ["/hello"]
--------------------
ERROR: failed to solve: foo-registry:5000/library/hello-world:linux: failed to do request: Head "https://foo-registry:5000/v2/library/hello-world/manifests/linux": http: server gave HTTP response to HTTPS client
```

And after the patches, the build should complete successfully, with no error displayed.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Resolve `insecure-registries` consistently for BuildKit builds

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/moby/moby/assets/7352848/1f0b60a0-2282-477b-a6b0-429ba94bd0a2)

cc @tianon @tonistiigi @crazy-max