### PR TITLE
ci: extract buildkit version correctly with replace-d modules

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -84,7 +84,7 @@ jobs:
       -
         name: BuildKit ref
         run: |
-          echo "BUILDKIT_REF=$(./hack/buildkit-ref)" >> $GITHUB_ENV
+          echo "$(./hack/buildkit-ref)" >> $GITHUB_ENV
         working-directory: moby
       -
         name: Checkout BuildKit ${{ env.BUILDKIT_REF }}

--- a/hack/buildkit-ref
+++ b/hack/buildkit-ref
@@ -10,7 +10,10 @@ if [ -n "$BUILDKIT_REF" ]; then
 fi
 
 # get buildkit version from vendor.mod
-BUILDKIT_REF=$(./hack/with-go-mod.sh go list -mod=mod -modfile=vendor.mod -u -m -f '{{.Version}}' "github.com/${BUILDKIT_REPO}")
+BUILDKIT_REF=$(./hack/with-go-mod.sh go list -mod=mod -modfile=vendor.mod -u -m -f '{{if .Replace}}{{.Replace.Version}}{{else}}{{.Version}}{{end}}' "github.com/${BUILDKIT_REPO}")
+BUILDKIT_REPO=$(./hack/with-go-mod.sh go list -mod=mod -modfile=vendor.mod -u -m -f '{{if .Replace}}{{.Replace.Path}}{{else}}{{.Path}}{{end}}' "github.com/${BUILDKIT_REPO}")
+BUILDKIT_REPO=${BUILDKIT_REPO#github.com/}
+
 if [[ "${BUILDKIT_REF}" == *-*-* ]]; then
 	# if pseudo-version, figure out just the uncommon sha (https://github.com/golang/go/issues/34745)
 	BUILDKIT_REF=$(echo "${BUILDKIT_REF}" | awk -F"-" '{print $NF}' | awk 'BEGIN{FIELDWIDTHS="7"} {print $1}')
@@ -18,4 +21,5 @@ if [[ "${BUILDKIT_REF}" == *-*-* ]]; then
 	BUILDKIT_REF=$(curl -s "https://api.github.com/repos/${BUILDKIT_REPO}/commits/${BUILDKIT_REF}" | jq -r .sha)
 fi
 
-echo "$BUILDKIT_REF"
+echo "BUILDKIT_REPO=$BUILDKIT_REPO"
+echo "BUILDKIT_REF=$BUILDKIT_REF"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Extract version from replace-d buildkit module, to ensure that the right version of buildkit is fetched during tests.

This is useful for working on testing/temporary forks, as in https://github.com/moby/moby/pull/45936.

**- How I did it**

**- How to verify it**

See https://github.com/moby/moby/pull/45936.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/moby/moby/assets/7352848/4c2852dc-ce40-4b8b-a143-c96025ccf9a5)

cc @crazy-max 
