### PR TITLE
quota: remove gotest.tools from testhelpers

### DIFF
--- a/quota/testhelpers.go
+++ b/quota/testhelpers.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 
 	"golang.org/x/sys/unix"
-	"gotest.tools/v3/assert"
-	"gotest.tools/v3/fs"
 )
 
 const imageSize = 64 * 1024 * 1024
@@ -78,10 +76,7 @@ func WrapMountTest(imageFileName string, enableQuota bool, testFunc func(t *test
 			mountOptions = mountOptions + ",prjquota"
 		}
 
-		mountPointDir := fs.NewDir(t, "xfs-mountPoint")
-		defer mountPointDir.Remove()
-		mountPoint := mountPointDir.Path()
-
+		mountPoint := t.TempDir()
 		out, err := exec.Command("mount", "-o", mountOptions, imageFileName, mountPoint).CombinedOutput()
 		if err != nil {
 			_, err := os.Stat("/proc/fs/xfs")
@@ -90,17 +85,25 @@ func WrapMountTest(imageFileName string, enableQuota bool, testFunc func(t *test
 			}
 		}
 
-		assert.NilError(t, err, "mount failed: %s", out)
+		if err != nil {
+			t.Fatalf("assertion failed: error is not nil: %v: mount failed: %s", err, out)
+		}
 
 		defer func() {
-			assert.NilError(t, unix.Unmount(mountPoint, 0))
+			if err := unix.Unmount(mountPoint, 0); err != nil {
+				t.Fatalf("assertion failed: error is not nil: %v", err)
+			}
 		}()
 
 		backingFsDev, err := makeBackingFsDev(mountPoint)
-		assert.NilError(t, err)
+		if err != nil {
+			t.Fatalf("assertion failed: error is not nil: %v", err)
+		}
 
 		testDir, err := os.MkdirTemp(mountPoint, "per-test")
-		assert.NilError(t, err)
+		if err != nil {
+			t.Fatalf("assertion failed: error is not nil: %v", err)
+		}
 		defer os.RemoveAll(testDir)
 
 		testFunc(t, mountPoint, backingFsDev, testDir)
@@ -112,10 +115,14 @@ func WrapMountTest(imageFileName string, enableQuota bool, testFunc func(t *test
 func WrapQuotaTest(testFunc func(t *testing.T, ctrl *Control, mountPoint, testDir, testSubDir string)) func(t *testing.T, mountPoint, backingFsDev, testDir string) {
 	return func(t *testing.T, mountPoint, backingFsDev, testDir string) {
 		ctrl, err := NewControl(testDir)
-		assert.NilError(t, err)
+		if err != nil {
+			t.Fatalf("assertion failed: error is not nil: %v", err)
+		}
 
 		testSubDir, err := os.MkdirTemp(testDir, "quota-test")
-		assert.NilError(t, err)
+		if err != nil {
+			t.Fatalf("assertion failed: error is not nil: %v", err)
+		}
 		testFunc(t, ctrl, mountPoint, testDir, testSubDir)
 	}
 }


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/45996


gotest.tools has an init() which registers a '-update' flag; https://github.com/gotestyourself/gotest.tools/blob/a80f057529047c44e1a85d0d017b200787e537e0/internal/source/update.go#L21-L23

The quota helper contains a testhelpers file, which is meant for usage in (integration) tests, but as it's in the same pacakge as production code, would also trigger the gotest.tools init.

This patch removes the gotest.tools code from this file.

Before this patch:

    $ (exec -a libnetwork-setkey "$(which dockerd)" -help)
    Usage of libnetwork-setkey:
      -exec-root string
            docker exec root (default "/run/docker")
      -update
            update golden values

With this patch applied:

    $ (exec -a libnetwork-setkey "$(which dockerd)" -help)
    Usage of libnetwork-setkey:
      -exec-root string
            docker exec root (default "/run/docker")

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

