### PR TITLE
c8d/inspect: Don't duplicate digested ref

### DIFF
--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -112,7 +112,7 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 			return nil, err
 		}
 
-		// Each image will result in 2 references (named and digested).
+		// Usually each image will result in 2 references (named and digested).
 		refs := make([]reference.Named, 0, len(tagged)*2)
 		for _, i := range tagged {
 			if i.UpdatedAt.After(lastUpdated) {
@@ -136,6 +136,11 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 				continue
 			}
 			refs = append(refs, name)
+
+			if _, ok := name.(reference.Digested); ok {
+				// Image name already contains a digest, so no need to create a digested reference.
+				continue
+			}
 
 			digested, err := reference.WithDigest(reference.TrimNamed(name), desc.Target.Digest)
 			if err != nil {


### PR DESCRIPTION
If image name is already an untagged digested reference, don't produce additional digested ref.

Before:
```json
$ docker pull busybox@sha256:2376a0c12759aa1214ba83e771ff252c7b1663216b192fbe5e0fb364e952f85c
$ docker inspect busybox@sha256:2376a0c12759aa1214ba83e771ff252c7b1663216b192fbe5e0fb364e952f85c
[
    {
        "Id": "sha256:2376a0c12759aa1214ba83e771ff252c7b1663216b192fbe5e0fb364e952f85c",
        "RepoTags": [],
        "RepoDigests": [
            "busybox@sha256:2376a0c12759aa1214ba83e771ff252c7b1663216b192fbe5e0fb364e952f85c",
            "busybox@sha256:2376a0c12759aa1214ba83e771ff252c7b1663216b192fbe5e0fb364e952f85c"
        ],
    ...
```

After:
```json
$ docker pull busybox@sha256:2376a0c12759aa1214ba83e771ff252c7b1663216b192fbe5e0fb364e952f85c
$ docker inspect busybox@sha256:2376a0c12759aa1214ba83e771ff252c7b1663216b192fbe5e0fb364e952f85c
[
    {
        "Id": "sha256:2376a0c12759aa1214ba83e771ff252c7b1663216b192fbe5e0fb364e952f85c",
        "RepoTags": [],
        "RepoDigests": [
            "busybox@sha256:2376a0c12759aa1214ba83e771ff252c7b1663216b192fbe5e0fb364e952f85c"
        ],
    ...
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

