### PR TITLE
c8d/resolveImage: Fix Digested and Named reference

### DIFF
--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -256,6 +256,24 @@ func (i *ImageService) resolveImage(ctx context.Context, refOrID string) (contai
 			return containerdimages.Image{}, images.ErrImageDoesNotExist{Ref: parsed}
 		}
 
+		// If reference is both Named and Digested, make sure we don't match
+		// images with a different repository even if digest matches.
+		// For example, busybox@sha256:abcdef..., shouldn't match asdf@sha256:abcdef...
+		if parsedNamed, ok := parsed.(reference.Named); ok {
+			for _, img := range imgs {
+				imgNamed, err := reference.ParseNormalizedNamed(img.Name)
+				if err != nil {
+					log.G(ctx).WithError(err).WithField("image", img.Name).Warn("image with invalid name encountered")
+					continue
+				}
+
+				if parsedNamed.Name() == imgNamed.Name() {
+					return img, nil
+				}
+			}
+			return containerdimages.Image{}, images.ErrImageDoesNotExist{Ref: parsed}
+		}
+
 		return imgs[0], nil
 	}
 


### PR DESCRIPTION
When resolving a reference that is both a Named and Digested, it could be resolved to an image that has the same digest, but completely different repository name.

This caused a bunch of test failing with `Error response from daemon: No such image: busybox:latest` with the containerd integration enabled (https://github.com/moby/moby/pull/45232) because the `testEnv.Clean` deleted the source busybox image instead of the new tag created in test.

<details>

<summary>Example failing tests</summary>

```
=== FAIL: amd64.integration-cli TestDockerAPISuite/TestPostContainersCreateMemorySwappinessHostConfigOmitted (0.03s)
    docker_api_containers_test.go:1540: assertion failed: error is not nil: Error response from daemon: No such image: busybox:latest
    --- FAIL: TestDockerAPISuite/TestPostContainersCreateMemorySwappinessHostConfigOmitted (0.03s)

=== FAIL: amd64.integration-cli TestDockerAPISuite/TestPostContainersCreateShmSizeHostConfigOmitted (0.02s)
    docker_api_containers_test.go:1456: assertion failed: error is not nil: Error response from daemon: No such image: busybox:latest
    --- FAIL: TestDockerAPISuite/TestPostContainersCreateShmSizeHostConfigOmitted (0.02s)

=== FAIL: amd64.integration-cli TestDockerAPISuite/TestPostContainersCreateShmSizeOmitted (0.02s)
    docker_api_containers_test.go:1483: assertion failed: error is not nil: Error response from daemon: No such image: busybox:latest
    --- FAIL: TestDockerAPISuite/TestPostContainersCreateShmSizeOmitted (0.02s)

=== FAIL: amd64.integration-cli TestDockerAPISuite/TestPostContainersCreateWithShmSize (0.02s)
    docker_api_containers_test.go:1514: assertion failed: error is not nil: Error response from daemon: No such image: busybox:latest
    --- FAIL: TestDockerAPISuite/TestPostContainersCreateWithShmSize (0.02s)
```

</details>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix digested and named reference being resolved to an image with different repository

**- How I did it**

**- How to verify it**
Test: TestRemoveByDigest

manually:

Before:
```bash
$ docker pull alpine
Using default tag: latest
82d1e9d7ed48: Download complete
e3bd82196e98: Download complete
5053b247d78b: Download complete
8c6d1654570f: Download complete
ndocker.io/library/alpine:latest
$ docker tag alpine asdf
$docker images
REPOSITORY   TAG       IMAGE ID       CREATED         SIZE
alpine       latest    82d1e9d7ed48   4 seconds ago   11.7MB
asdf         latest    82d1e9d7ed48   2 seconds ago   11.7MB
$ docker rmi asdf@sha256:82d1e9d7ed48a7523bdebc18cf6290bdb97b82302a8a9c27d4fe885949ea94d1
Untagged: asdf@sha256:82d1e9d7ed48a7523bdebc18cf6290bdb97b82302a8a9c27d4fe885949ea94d1
$ docker images
REPOSITORY   TAG       IMAGE ID       CREATED          SIZE
asdf         latest    82d1e9d7ed48   15 seconds ago   11.7MB
```

After:
```bash
$ docker tag alpine asdf
$ docker images
REPOSITORY   TAG       IMAGE ID       CREATED         SIZE
alpine       latest    82d1e9d7ed48   5 seconds ago   11.7MB
asdf         latest    82d1e9d7ed48   2 seconds ago   11.7MB
$ docker rmi asdf@sha256:82d1e9d7ed48a7523bdebc18cf6290bdb97b82302a8a9c27d4fe885949ea94d1
Untagged: asdf@sha256:82d1e9d7ed48a7523bdebc18cf6290bdb97b82302a8a9c27d4fe885949ea94d1
$ docker images
REPOSITORY   TAG       IMAGE ID       CREATED         SIZE
alpine       latest    82d1e9d7ed48   9 seconds ago   11.7MB
```


**- Description for the changelog**
```release-notes
- Fix resolving a reference with repository name and digest to an image with a matching digest, but different repository.
```

**- A picture of a cute animal (not mandatory but encouraged)**

