### PR TITLE
[24.0 backport] ci: extract buildkit version correctly with replace-d modules

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -84,7 +84,7 @@ jobs:
       -
         name: BuildKit ref
         run: |
-          echo "BUILDKIT_REF=$(./hack/buildkit-ref)" >> $GITHUB_ENV
+          echo "$(./hack/buildkit-ref)" >> $GITHUB_ENV
         working-directory: moby
       -
         name: Checkout BuildKit ${{ env.BUILDKIT_REF }}

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -49,8 +49,6 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     timeout-minutes: 120
-    env:
-      BUILDKIT_REPO: moby/buildkit
     needs:
       - build
     strategy:

--- a/hack/buildkit-ref
+++ b/hack/buildkit-ref
@@ -10,7 +10,10 @@ if [ -n "$BUILDKIT_REF" ]; then
 fi
 
 # get buildkit version from vendor.mod
-BUILDKIT_REF=$(./hack/with-go-mod.sh go list -mod=mod -modfile=vendor.mod -u -m -f '{{.Version}}' "github.com/${BUILDKIT_REPO}")
+BUILDKIT_REF=$(./hack/with-go-mod.sh go list -mod=mod -modfile=vendor.mod -u -m -f '{{if .Replace}}{{.Replace.Version}}{{else}}{{.Version}}{{end}}' "github.com/${BUILDKIT_REPO}")
+BUILDKIT_REPO=$(./hack/with-go-mod.sh go list -mod=mod -modfile=vendor.mod -u -m -f '{{if .Replace}}{{.Replace.Path}}{{else}}{{.Path}}{{end}}' "github.com/${BUILDKIT_REPO}")
+BUILDKIT_REPO=${BUILDKIT_REPO#github.com/}
+
 if [[ "${BUILDKIT_REF}" == *-*-* ]]; then
 	# if pseudo-version, figure out just the uncommon sha (https://github.com/golang/go/issues/34745)
 	BUILDKIT_REF=$(echo "${BUILDKIT_REF}" | awk -F"-" '{print $NF}' | awk 'BEGIN{FIELDWIDTHS="7"} {print $1}')
@@ -18,4 +21,5 @@ if [[ "${BUILDKIT_REF}" == *-*-* ]]; then
 	BUILDKIT_REF=$(curl -s "https://api.github.com/repos/${BUILDKIT_REPO}/commits/${BUILDKIT_REF}" | jq -r .sha)
 fi
 
-echo "$BUILDKIT_REF"
+echo "BUILDKIT_REPO=$BUILDKIT_REPO"
+echo "BUILDKIT_REF=$BUILDKIT_REF"

--- a/hack/buildkit-ref
+++ b/hack/buildkit-ref
@@ -1,17 +1,11 @@
 #!/usr/bin/env bash
 # This script returns the current BuildKit ref and source repository being used.
 # This script will only work with a BuildKit repository hosted on GitHub.
-# If BUILDKIT_REF is already set in the environment, it will be returned as-is.
 #
 # The output of this script may be valid shell script, but is intended for use with
 # GitHub Actions' $GITHUB_ENV.
 
 buildkit_pkg=github.com/moby/buildkit
-
-if [ -n "$BUILDKIT_REF" ]; then
-	echo "$BUILDKIT_REF"
-	exit 0
-fi
 
 # get buildkit version from vendor.mod
 buildkit_ref=$(./hack/with-go-mod.sh go list -mod=mod -modfile=vendor.mod -u -m -f '{{if .Replace}}{{.Replace.Version}}{{else}}{{.Version}}{{end}}' "$buildkit_pkg")

--- a/hack/buildkit-ref
+++ b/hack/buildkit-ref
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
-# This script returns the current BuildKit ref being used in moby.
+# This script returns the current BuildKit ref and source repository being used.
+# This script will only work with a BuildKit repository hosted on GitHub.
+# If BUILDKIT_REF is already set in the environment, it will be returned as-is.
+#
+# The output of this script may be valid shell script, but is intended for use with
+# GitHub Actions' $GITHUB_ENV.
 
-: "${BUILDKIT_REPO=moby/buildkit}"
-: "${BUILDKIT_REF=}"
+buildkit_pkg=github.com/moby/buildkit
 
 if [ -n "$BUILDKIT_REF" ]; then
 	echo "$BUILDKIT_REF"
@@ -10,16 +14,18 @@ if [ -n "$BUILDKIT_REF" ]; then
 fi
 
 # get buildkit version from vendor.mod
-BUILDKIT_REF=$(./hack/with-go-mod.sh go list -mod=mod -modfile=vendor.mod -u -m -f '{{if .Replace}}{{.Replace.Version}}{{else}}{{.Version}}{{end}}' "github.com/${BUILDKIT_REPO}")
-BUILDKIT_REPO=$(./hack/with-go-mod.sh go list -mod=mod -modfile=vendor.mod -u -m -f '{{if .Replace}}{{.Replace.Path}}{{else}}{{.Path}}{{end}}' "github.com/${BUILDKIT_REPO}")
-BUILDKIT_REPO=${BUILDKIT_REPO#github.com/}
+buildkit_ref=$(./hack/with-go-mod.sh go list -mod=mod -modfile=vendor.mod -u -m -f '{{if .Replace}}{{.Replace.Version}}{{else}}{{.Version}}{{end}}' "$buildkit_pkg")
+buildkit_repo=$(./hack/with-go-mod.sh go list -mod=mod -modfile=vendor.mod -u -m -f '{{if .Replace}}{{.Replace.Path}}{{else}}{{.Path}}{{end}}' "$buildkit_pkg")
+buildkit_repo=${buildkit_repo#github.com/}
 
-if [[ "${BUILDKIT_REF}" == *-*-* ]]; then
+if [[ "${buildkit_ref}" == *-*-* ]]; then
 	# if pseudo-version, figure out just the uncommon sha (https://github.com/golang/go/issues/34745)
-	BUILDKIT_REF=$(echo "${BUILDKIT_REF}" | awk -F"-" '{print $NF}' | awk 'BEGIN{FIELDWIDTHS="7"} {print $1}')
+	buildkit_ref=$(awk -F"-" '{print $NF}' <<< "$buildkit_ref" | awk 'BEGIN{FIELDWIDTHS="7"} {print $1}')
 	# use github api to return full sha to be able to use it as ref
-	BUILDKIT_REF=$(curl -s "https://api.github.com/repos/${BUILDKIT_REPO}/commits/${BUILDKIT_REF}" | jq -r .sha)
+	buildkit_ref=$(curl -s "https://api.github.com/repos/${buildkit_repo}/commits/${buildkit_ref}" | jq -r .sha)
 fi
 
-echo "BUILDKIT_REPO=$BUILDKIT_REPO"
-echo "BUILDKIT_REF=$BUILDKIT_REF"
+cat << EOF
+BUILDKIT_REPO=$buildkit_repo
+BUILDKIT_REF=$buildkit_ref
+EOF

--- a/hack/with-go-mod.sh
+++ b/hack/with-go-mod.sh
@@ -14,8 +14,10 @@ ROOTDIR="$(git -C "$SCRIPTDIR" rev-parse --show-toplevel)"
 if test -e "${ROOTDIR}/go.mod"; then
 	{
 		scriptname=$(basename "$0")
-		echo "${scriptname}: WARN: go.mod exists in the repository root!"
-		echo "${scriptname}: WARN: Using your go.mod instead of our generated version -- this may misbehave!"
+		cat >&2 <<- EOF
+			$scriptname: WARN: go.mod exists in the repository root!
+			$scriptname: WARN: Using your go.mod instead of our generated version -- this may misbehave!
+		EOF
 	} >&2
 else
 	set -x


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/45994
- backport of https://github.com/moby/moby/pull/46012

---

**- What I did**

Extract version from replace-d buildkit module, to ensure that the right version of buildkit is fetched during tests.

This is useful for working on testing/temporary forks, as in https://github.com/moby/moby/pull/45936.

**- How I did it**

**- How to verify it**

See https://github.com/moby/moby/pull/45936.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/moby/moby/assets/7352848/4c2852dc-ce40-4b8b-a143-c96025ccf9a5)

cc @crazy-max 

