### PR TITLE
pkg/plugins: some cleaning up (step 1)

### DIFF
--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -87,10 +87,16 @@ func newClientWithTransport(tr *transport.HTTPTransport, timeout time.Duration) 
 	}
 }
 
+// requestFactory defines an interface that transports can implement to
+// create new requests. It's used in testing.
+type requestFactory interface {
+	NewRequest(path string, data io.Reader) (*http.Request, error)
+}
+
 // Client represents a plugin client.
 type Client struct {
 	http           *http.Client // http client to use
-	requestFactory transport.RequestFactory
+	requestFactory requestFactory
 }
 
 // RequestOpts is the set of options that can be passed into a request

--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -26,7 +26,7 @@ const (
 	dummyHost = "plugin.moby.localhost"
 )
 
-func newTransport(addr string, tlsConfig *tlsconfig.Options) (transport.Transport, error) {
+func newTransport(addr string, tlsConfig *tlsconfig.Options) (*transport.HTTPTransport, error) {
 	tr := &http.Transport{}
 
 	if tlsConfig != nil {
@@ -77,7 +77,7 @@ func NewClientWithTimeout(addr string, tlsConfig *tlsconfig.Options, timeout tim
 }
 
 // newClientWithTransport creates a new plugin client with a given transport.
-func newClientWithTransport(tr transport.Transport, timeout time.Duration) *Client {
+func newClientWithTransport(tr *transport.HTTPTransport, timeout time.Duration) *Client {
 	return &Client{
 		http: &http.Client{
 			Transport: tr,

--- a/pkg/plugins/discovery.go
+++ b/pkg/plugins/discovery.go
@@ -26,7 +26,7 @@ type LocalRegistry struct {
 
 func NewLocalRegistry() LocalRegistry {
 	return LocalRegistry{
-		SpecsPaths,
+		SpecsPaths: specsPaths,
 	}
 }
 
@@ -109,6 +109,25 @@ func (l *LocalRegistry) Plugin(name string) (*Plugin, error) {
 		}
 	}
 	return nil, errors.Wrapf(ErrNotFound, "could not find plugin %s in v1 plugin registry", name)
+}
+
+// SpecsPaths returns paths in which to look for plugins, in order of priority.
+//
+// On Windows:
+//
+//   - "%programdata%\docker\plugins"
+//
+// On Unix in non-rootless mode:
+//
+//   - "/etc/docker/plugins"
+//   - "/usr/lib/docker/plugins"
+//
+// On Unix in rootless-mode:
+//
+//   - "$XDG_CONFIG_HOME/docker/plugins" (or "/etc/docker/plugins" if $XDG_CONFIG_HOME is not set)
+//   - "$HOME/.local/lib/docker/plugins" (pr "/usr/lib/docker/plugins" if $HOME is set)
+func SpecsPaths() []string {
+	return specsPaths()
 }
 
 func readPluginInfo(name, path string) (*Plugin, error) {

--- a/pkg/plugins/discovery.go
+++ b/pkg/plugins/discovery.go
@@ -21,12 +21,12 @@ var (
 
 // LocalRegistry defines a registry that is local (using unix socket).
 type LocalRegistry struct {
-	SpecsPaths func() []string
+	specsPaths []string
 }
 
 func NewLocalRegistry() LocalRegistry {
 	return LocalRegistry{
-		SpecsPaths: specsPaths,
+		specsPaths: specsPaths(),
 	}
 }
 
@@ -53,7 +53,7 @@ func (l *LocalRegistry) Scan() ([]string, error) {
 		}
 	}
 
-	for _, p := range l.SpecsPaths() {
+	for _, p := range l.specsPaths {
 		dirEntries, err = os.ReadDir(p)
 		if err != nil && !os.IsNotExist(err) {
 			return nil, errors.Wrap(err, "error reading dir entries")
@@ -95,7 +95,7 @@ func (l *LocalRegistry) Plugin(name string) (*Plugin, error) {
 	}
 
 	var txtSpecPaths []string
-	for _, p := range l.SpecsPaths() {
+	for _, p := range l.specsPaths {
 		txtSpecPaths = append(txtSpecPaths, pluginPaths(p, name, ".spec")...)
 		txtSpecPaths = append(txtSpecPaths, pluginPaths(p, name, ".json")...)
 	}

--- a/pkg/plugins/discovery_test.go
+++ b/pkg/plugins/discovery_test.go
@@ -15,13 +15,9 @@ func Setup(t *testing.T) (string, func(), LocalRegistry) {
 	socketsPath = tmpdir
 
 	return tmpdir, func() {
-			socketsPath = backup
-			os.RemoveAll(tmpdir)
-		}, LocalRegistry{
-			func() []string {
-				return []string{tmpdir}
-			},
-		}
+		socketsPath = backup
+		os.RemoveAll(tmpdir)
+	}, LocalRegistry{specsPaths: []string{tmpdir}}
 }
 
 func TestFileSpecPlugin(t *testing.T) {

--- a/pkg/plugins/discovery_test.go
+++ b/pkg/plugins/discovery_test.go
@@ -6,23 +6,12 @@ import (
 	"testing"
 )
 
-func Setup(t *testing.T) (string, func(), LocalRegistry) {
-	tmpdir, err := os.MkdirTemp("", "docker-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	backup := socketsPath
-	socketsPath = tmpdir
-
-	return tmpdir, func() {
-		socketsPath = backup
-		os.RemoveAll(tmpdir)
-	}, LocalRegistry{specsPaths: []string{tmpdir}}
-}
-
 func TestFileSpecPlugin(t *testing.T) {
-	tmpdir, unregister, r := Setup(t)
-	defer unregister()
+	tmpdir := t.TempDir()
+	r := LocalRegistry{
+		socketsPath: tmpdir,
+		specsPaths:  []string{tmpdir},
+	}
 
 	cases := []struct {
 		path string
@@ -70,8 +59,11 @@ func TestFileSpecPlugin(t *testing.T) {
 }
 
 func TestFileJSONSpecPlugin(t *testing.T) {
-	tmpdir, unregister, r := Setup(t)
-	defer unregister()
+	tmpdir := t.TempDir()
+	r := LocalRegistry{
+		socketsPath: tmpdir,
+		specsPaths:  []string{tmpdir},
+	}
 
 	p := filepath.Join(tmpdir, "example.json")
 	spec := `{
@@ -115,8 +107,11 @@ func TestFileJSONSpecPlugin(t *testing.T) {
 }
 
 func TestFileJSONSpecPluginWithoutTLSConfig(t *testing.T) {
-	tmpdir, unregister, r := Setup(t)
-	defer unregister()
+	tmpdir := t.TempDir()
+	r := LocalRegistry{
+		socketsPath: tmpdir,
+		specsPaths:  []string{tmpdir},
+	}
 
 	p := filepath.Join(tmpdir, "example.json")
 	spec := `{

--- a/pkg/plugins/discovery_unix.go
+++ b/pkg/plugins/discovery_unix.go
@@ -9,32 +9,23 @@ import (
 )
 
 func rootlessConfigPluginsPath() string {
-	configHome, err := homedir.GetConfigHome()
-	if err == nil {
+	if configHome, err := homedir.GetConfigHome(); err != nil {
 		return filepath.Join(configHome, "docker/plugins")
 	}
-
 	return "/etc/docker/plugins"
 }
 
 func rootlessLibPluginsPath() string {
-	libHome, err := homedir.GetLibHome()
-	if err == nil {
+	if libHome, err := homedir.GetLibHome(); err == nil {
 		return filepath.Join(libHome, "docker/plugins")
 	}
-
 	return "/usr/lib/docker/plugins"
 }
 
-// SpecsPaths returns
-// { "%programdata%\docker\plugins" } on Windows,
-// { "/etc/docker/plugins", "/usr/lib/docker/plugins" } on Unix in non-rootless mode,
-// { "$XDG_CONFIG_HOME/docker/plugins", "$HOME/.local/lib/docker/plugins" } on Unix in rootless mode
-// with fallback to the corresponding path in non-rootless mode if $XDG_CONFIG_HOME or $HOME is not set.
-func SpecsPaths() []string {
+// specsPaths is the non-Windows implementation of [SpecsPaths].
+func specsPaths() []string {
 	if rootless.RunningWithRootlessKit() {
 		return []string{rootlessConfigPluginsPath(), rootlessLibPluginsPath()}
 	}
-
 	return []string{"/etc/docker/plugins", "/usr/lib/docker/plugins"}
 }

--- a/pkg/plugins/discovery_unix_test.go
+++ b/pkg/plugins/discovery_unix_test.go
@@ -15,8 +15,11 @@ import (
 
 func TestLocalSocket(t *testing.T) {
 	// TODO Windows: Enable a similar version for Windows named pipes
-	tmpdir, unregister, r := Setup(t)
-	defer unregister()
+	tmpdir := t.TempDir()
+	r := LocalRegistry{
+		socketsPath: tmpdir,
+		specsPaths:  []string{tmpdir},
+	}
 
 	cases := []string{
 		filepath.Join(tmpdir, "echo.sock"),
@@ -62,8 +65,11 @@ func TestLocalSocket(t *testing.T) {
 }
 
 func TestScan(t *testing.T) {
-	tmpdir, unregister, r := Setup(t)
-	defer unregister()
+	tmpdir := t.TempDir()
+	r := LocalRegistry{
+		socketsPath: tmpdir,
+		specsPaths:  []string{tmpdir},
+	}
 
 	pluginNames, err := r.Scan()
 	if err != nil {
@@ -103,8 +109,11 @@ func TestScan(t *testing.T) {
 }
 
 func TestScanNotPlugins(t *testing.T) {
-	tmpdir, unregister, localRegistry := Setup(t)
-	defer unregister()
+	tmpdir := t.TempDir()
+	localRegistry := LocalRegistry{
+		socketsPath: tmpdir,
+		specsPaths:  []string{tmpdir},
+	}
 
 	// not that `Setup()` above sets the sockets path and spec path dirs, which
 	// `Scan()` uses to find plugins to the returned `tmpdir`

--- a/pkg/plugins/discovery_windows.go
+++ b/pkg/plugins/discovery_windows.go
@@ -5,11 +5,7 @@ import (
 	"path/filepath"
 )
 
-// SpecsPaths returns
-// { "%programdata%\docker\plugins" } on Windows,
-// { "/etc/docker/plugins", "/usr/lib/docker/plugins" } on Unix in non-rootless mode,
-// { "$XDG_CONFIG_HOME/docker/plugins", "$HOME/.local/lib/docker/plugins" } on Unix in rootless mode
-// with fallback to the corresponding path in non-rootless mode if $XDG_CONFIG_HOME or $HOME is not set.
-func SpecsPaths() []string {
+// specsPaths is the Windows implementation of [SpecsPaths].
+func specsPaths() []string {
 	return []string{filepath.Join(os.Getenv("programdata"), "docker", "plugins")}
 }

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -127,8 +127,11 @@ func TestPluginWithNoManifest(t *testing.T) {
 
 func TestGetAll(t *testing.T) {
 	t.Parallel()
-	tmpdir, unregister, r := Setup(t)
-	defer unregister()
+	tmpdir := t.TempDir()
+	r := LocalRegistry{
+		socketsPath: tmpdir,
+		specsPaths:  []string{tmpdir},
+	}
 
 	p := filepath.Join(tmpdir, "example.json")
 	spec := `{

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -64,27 +64,33 @@ func TestGet(t *testing.T) {
 	p.Manifest = &Manifest{Implements: []string{fruitImplements}}
 	storage.plugins[fruitPlugin] = p
 
-	plugin, err := Get(fruitPlugin, fruitImplements)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if p.Name() != plugin.Name() {
-		t.Fatalf("No matching plugin with name %s found", plugin.Name())
-	}
-	if plugin.Client() != nil {
-		t.Fatal("expected nil Client but found one")
-	}
-	if !plugin.IsV1() {
-		t.Fatal("Expected true for V1 plugin")
-	}
+	t.Run("success", func(t *testing.T) {
+		plugin, err := Get(fruitPlugin, fruitImplements)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if p.Name() != plugin.Name() {
+			t.Errorf("no matching plugin with name %s found", plugin.Name())
+		}
+		if plugin.Client() != nil {
+			t.Error("expected nil Client but found one")
+		}
+		if !plugin.IsV1() {
+			t.Error("Expected true for V1 plugin")
+		}
+	})
 
 	// check negative case where plugin fruit doesn't implement banana
-	_, err = Get("fruit", "banana")
-	assert.Assert(t, errors.Is(err, ErrNotImplements))
+	t.Run("not implemented", func(t *testing.T) {
+		_, err := Get("fruit", "banana")
+		assert.Assert(t, errors.Is(err, ErrNotImplements))
+	})
 
 	// check negative case where plugin vegetable doesn't exist
-	_, err = Get("vegetable", "potato")
-	assert.Assert(t, errors.Is(err, ErrNotFound))
+	t.Run("not exists", func(t *testing.T) {
+		_, err := Get("vegetable", "potato")
+		assert.Assert(t, errors.Is(err, ErrNotFound))
+	})
 }
 
 func TestPluginWithNoManifest(t *testing.T) {

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -201,10 +201,6 @@ func (p *Plugin) implements(kind string) bool {
 	return false
 }
 
-func load(name string) (*Plugin, error) {
-	return loadWithRetry(name, true)
-}
-
 func loadWithRetry(name string, retry bool) (*Plugin, error) {
 	registry := NewLocalRegistry()
 	start := time.Now()
@@ -254,7 +250,7 @@ func get(name string) (*Plugin, error) {
 	if ok {
 		return pl, pl.activate()
 	}
-	return load(name)
+	return loadWithRetry(name, true)
 }
 
 // Get returns the plugin given the specified name and requested implementation.

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -101,6 +101,12 @@ func (p *Plugin) IsV1() bool {
 	return true
 }
 
+// ScopedPath returns the path scoped to the plugin's rootfs.
+// For v1 plugins, this always returns the path unchanged as v1 plugins run directly on the host.
+func (p *Plugin) ScopedPath(s string) string {
+	return s
+}
+
 // NewLocalPlugin creates a new local plugin.
 func NewLocalPlugin(name, addr string) *Plugin {
 	return &Plugin{

--- a/pkg/plugins/plugins_unix.go
+++ b/pkg/plugins/plugins_unix.go
@@ -1,9 +1,0 @@
-//go:build !windows
-
-package plugins // import "github.com/docker/docker/pkg/plugins"
-
-// ScopedPath returns the path scoped to the plugin's rootfs.
-// For v1 plugins, this always returns the path unchanged as v1 plugins run directly on the host.
-func (p *Plugin) ScopedPath(s string) string {
-	return s
-}

--- a/pkg/plugins/plugins_windows.go
+++ b/pkg/plugins/plugins_windows.go
@@ -1,7 +1,0 @@
-package plugins // import "github.com/docker/docker/pkg/plugins"
-
-// ScopedPath returns the path scoped to the plugin's rootfs.
-// For v1 plugins, this always returns the path unchanged as v1 plugins run directly on the host.
-func (p *Plugin) ScopedPath(s string) string {
-	return s
-}

--- a/pkg/plugins/transport/http.go
+++ b/pkg/plugins/transport/http.go
@@ -3,6 +3,7 @@ package transport // import "github.com/docker/docker/pkg/plugins/transport"
 import (
 	"io"
 	"net/http"
+	"strings"
 )
 
 // httpTransport holds an http.RoundTripper
@@ -26,10 +27,14 @@ func NewHTTPTransport(r http.RoundTripper, scheme, addr string) Transport {
 // NewRequest creates a new http.Request and sets the URL
 // scheme and address with the transport's fields.
 func (t httpTransport) NewRequest(path string, data io.Reader) (*http.Request, error) {
-	req, err := newHTTPRequest(path, data)
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	req, err := http.NewRequest(http.MethodPost, path, data)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Add("Accept", VersionMimetype)
 	req.URL.Scheme = t.scheme
 	req.URL.Host = t.addr
 	return req, nil

--- a/pkg/plugins/transport/http.go
+++ b/pkg/plugins/transport/http.go
@@ -6,18 +6,18 @@ import (
 	"strings"
 )
 
-// httpTransport holds an http.RoundTripper
+// HTTPTransport holds an [http.RoundTripper]
 // and information about the scheme and address the transport
 // sends request to.
-type httpTransport struct {
+type HTTPTransport struct {
 	http.RoundTripper
 	scheme string
 	addr   string
 }
 
-// NewHTTPTransport creates a new httpTransport.
-func NewHTTPTransport(r http.RoundTripper, scheme, addr string) Transport {
-	return httpTransport{
+// NewHTTPTransport creates a new HTTPTransport.
+func NewHTTPTransport(r http.RoundTripper, scheme, addr string) *HTTPTransport {
+	return &HTTPTransport{
 		RoundTripper: r,
 		scheme:       scheme,
 		addr:         addr,
@@ -26,7 +26,7 @@ func NewHTTPTransport(r http.RoundTripper, scheme, addr string) Transport {
 
 // NewRequest creates a new http.Request and sets the URL
 // scheme and address with the transport's fields.
-func (t httpTransport) NewRequest(path string, data io.Reader) (*http.Request, error) {
+func (t HTTPTransport) NewRequest(path string, data io.Reader) (*http.Request, error) {
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}

--- a/pkg/plugins/transport/http_test.go
+++ b/pkg/plugins/transport/http_test.go
@@ -11,8 +11,7 @@ import (
 
 func TestHTTPTransport(t *testing.T) {
 	var r io.Reader
-	roundTripper := &http.Transport{}
-	newTransport := NewHTTPTransport(roundTripper, "http", "0.0.0.0")
+	newTransport := NewHTTPTransport(&http.Transport{}, "http", "0.0.0.0")
 	request, err := newTransport.NewRequest("", r)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/plugins/transport/transport.go
+++ b/pkg/plugins/transport/transport.go
@@ -3,7 +3,6 @@ package transport // import "github.com/docker/docker/pkg/plugins/transport"
 import (
 	"io"
 	"net/http"
-	"strings"
 )
 
 // VersionMimetype is the Content-Type the engine sends to plugins.
@@ -20,17 +19,4 @@ type RequestFactory interface {
 type Transport interface {
 	http.RoundTripper
 	RequestFactory
-}
-
-// newHTTPRequest creates a new request with a path and a body.
-func newHTTPRequest(path string, data io.Reader) (*http.Request, error) {
-	if !strings.HasPrefix(path, "/") {
-		path = "/" + path
-	}
-	req, err := http.NewRequest(http.MethodPost, path, data)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Add("Accept", VersionMimetype)
-	return req, nil
 }

--- a/pkg/plugins/transport/transport.go
+++ b/pkg/plugins/transport/transport.go
@@ -1,15 +1,4 @@
 package transport // import "github.com/docker/docker/pkg/plugins/transport"
 
-import (
-	"io"
-	"net/http"
-)
-
 // VersionMimetype is the Content-Type the engine sends to plugins.
 const VersionMimetype = "application/vnd.docker.plugins.v1.2+json"
-
-// RequestFactory defines an interface that
-// transports can implement to create new requests.
-type RequestFactory interface {
-	NewRequest(path string, data io.Reader) (*http.Request, error)
-}

--- a/pkg/plugins/transport/transport.go
+++ b/pkg/plugins/transport/transport.go
@@ -13,10 +13,3 @@ const VersionMimetype = "application/vnd.docker.plugins.v1.2+json"
 type RequestFactory interface {
 	NewRequest(path string, data io.Reader) (*http.Request, error)
 }
-
-// Transport defines an interface that plugin transports
-// must implement.
-type Transport interface {
-	http.RoundTripper
-	RequestFactory
-}


### PR DESCRIPTION
More collateral damage of things I was working on 😂 

### pkg/plugins: move Plugin.ScopedPath to platform-agnostic file

Since 0e5eaf8ee32662182147f5f62c1bfebef66f5c47, these implementations
were fully identical, so removing the duplicate, and move it to a
platform-agnostic file.

### plg/plugins: rename vars that collided, or poorly cased

Reduce some noise while reading the code in my IDE :)

### pkg/plugins: inline rootless paths, split exported from implementation

inline the rootlessConfigPluginsPath and rootlessLibPluginsPath funcs,
and split the exported SpecsPaths from the platform-specific implementations,
so that documentation can be maintained in a single location.


### pkg/plugins: remove LocalRegistry.SpecsPaths()

This field was exported, but never mutated outside of the package, and
effectively a rather "creative" way to define a method on LocalRegistry.

While un-exporting also store these paths in a field, instead of constructing
them on every call, as the results won't change during the lifecycle of the
LocalRegistry.


### pkg/plugins/transport: inline newHTTPRequest

It was only used in a single location; just inline the code


### pkg/plugins/transport: export httpTransport, and return concrete type

Make NewHTTPTransport return a concrete type.

### pkg/plugins/transport: remove unused Transport interface

The interface is not consumed anywhere, and only non-exported functions
produced one, so we can remove it.

### pkg/plugins/transport: remove RequestFactory interface

The client's transport can only be set by newClientWithTransport, which
is not exported, and always uses a transport.HTTPTransport.

However, requestFactory is mocked in one of the tests, so keep the interface,
but make it a local, non-exported one.


### pkg/plugins: remove "load()" function

It was used in a single place and was abstracting "loadWithRetry";
let's just inline it.


### pkg/plugins: make package-level socketsPath var a LocalRegistry field

This variable was only accessed from within LocalRegistry methods, but
due to being a package-level variable, tests had to deal with setting
and resetting it.

Move it to be a field scoped to the LocalRegistry. This simplifies the
tests, and to make this more transparent, also removing the "Setup()"
helper (which, wasn't marked as a t.Helper()).

### pkg/plugins: TestGet(): use sub-tests

**- A picture of a cute animal (not mandatory but encouraged)**

