### PR TITLE
[24.0 backport] Dockerfile: update buildx to v0.11.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG DOCKERCLI_VERSION=v24.0.2
 # cli version used for integration-cli tests
 ARG DOCKERCLI_INTEGRATION_REPOSITORY="https://github.com/docker/cli.git"
 ARG DOCKERCLI_INTEGRATION_VERSION=v17.06.2-ce
-ARG BUILDX_VERSION=0.11.0
+ARG BUILDX_VERSION=0.11.2
 
 ARG SYSTEMD="false"
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
- partial backport of https://github.com/moby/moby/pull/46022

Update the BUILDX_VERSION :)

release notes:

- https://github.com/docker/buildx/releases/tag/v0.11.1
- https://github.com/docker/buildx/releases/tag/v0.11.2

full diff: https://github.com/docker/buildx/compare/v0.11.0...v0.11.2


(cherry picked from commit d78893921aac0556ec050172c7f915a3750741b1)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

