### PR TITLE
c8d/inspect: Include platform Variant

### DIFF
--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -83,6 +83,7 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 		ID:           string(desc.Target.Digest),
 		OS:           ociimage.OS,
 		Architecture: ociimage.Architecture,
+		Variant:      ociimage.Variant,
 		Created:      ociimage.Created,
 		Config: &containertypes.Config{
 			Entrypoint:   ociimage.Config.Entrypoint,


### PR DESCRIPTION
Variant was mistakenly omitted in the returned V1Image.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
```release-notes
- Fix `Variant` not being included in the `docker image inspect` output.
```

**- A picture of a cute animal (not mandatory but encouraged)**

