### PR TITLE
[24.0 backport] c8d/inspect: Include platform Variant

### DIFF
--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -102,6 +102,7 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 		OS:           ociimage.OS,
 		Architecture: ociimage.Architecture,
 		Created:      derefTimeSafely(ociimage.Created),
+		Variant:      ociimage.Variant,
 		Config: &containertypes.Config{
 			Entrypoint:   ociimage.Config.Entrypoint,
 			Env:          ociimage.Config.Env,


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/46024


Variant was mistakenly omitted in the returned V1Image.


(cherry picked from commit 2659f7f740d7037e793a821f03d6722bc4add906)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
```release-notes
- Fix `Variant` not being included in the `docker image inspect` output.
```

**- A picture of a cute animal (not mandatory but encouraged)**

