### PR TITLE
c8d: Various images/json API fixes

### DIFF
--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -357,22 +357,23 @@ func (i *ImageService) setupFilters(ctx context.Context, imageFilters filters.Ar
 		})
 	}
 
-	err = imageFilters.WalkValues("reference", func(value string) error {
+	if refs := imageFilters.Get("reference"); len(refs) != 0 {
 		fltrs = append(fltrs, func(image images.Image) bool {
 			ref, err := reference.ParseNormalizedNamed(image.Name)
 			if err != nil {
 				return false
 			}
-			found, err := reference.FamiliarMatch(value, ref)
-			if err != nil {
-				return false
+			for _, value := range refs {
+				found, err := reference.FamiliarMatch(value, ref)
+				if err != nil {
+					return false
+				}
+				if found {
+					return found
+				}
 			}
-			return found
+			return false
 		})
-		return nil
-	})
-	if err != nil {
-		return nil, err
 	}
 
 	return func(image images.Image) bool {

--- a/daemon/containerd/image_prune.go
+++ b/daemon/containerd/image_prune.go
@@ -53,7 +53,7 @@ func (i *ImageService) ImagesPrune(ctx context.Context, fltrs filters.Args) (*ty
 		fltrs.Del("dangling", v)
 	}
 
-	_, filterFunc, err := i.setupFilters(ctx, fltrs)
+	filterFunc, err := i.setupFilters(ctx, fltrs)
 	if err != nil {
 		return nil, err
 	}

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -8,49 +8,12 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
 )
-
-func (s *DockerAPISuite) TestAPIImagesFilter(c *testing.T) {
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
-	assert.NilError(c, err)
-	defer apiClient.Close()
-
-	name := "utest:tag1"
-	name2 := "utest/docker:tag2"
-	name3 := "utest:5000/docker:tag3"
-	for _, n := range []string{name, name2, name3} {
-		dockerCmd(c, "tag", "busybox", n)
-	}
-	getImages := func(filter string) []types.ImageSummary {
-		options := types.ImageListOptions{
-			All:     false,
-			Filters: filters.NewArgs(filters.Arg("reference", filter)),
-		}
-		images, err := apiClient.ImageList(context.Background(), options)
-		assert.NilError(c, err)
-
-		return images
-	}
-
-	// incorrect number of matches returned
-	images := getImages("utest*/*")
-	assert.Equal(c, len(images[0].RepoTags), 2)
-
-	images = getImages("utest")
-	assert.Equal(c, len(images[0].RepoTags), 1)
-
-	images = getImages("utest*")
-	assert.Equal(c, len(images[0].RepoTags), 1)
-
-	images = getImages("*5000*/*")
-	assert.Equal(c, len(images[0].RepoTags), 1)
-}
 
 func (s *DockerAPISuite) TestAPIImagesSaveAndLoad(c *testing.T) {
 	testRequires(c, Network)

--- a/integration/image/list_test.go
+++ b/integration/image/list_test.go
@@ -20,7 +20,7 @@ import (
 // Regression : #38171
 func TestImagesFilterMultiReference(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"), "broken in earlier versions")
-	defer setupTest(t)()
+	t.Cleanup(setupTest(t))
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
@@ -42,13 +42,13 @@ func TestImagesFilterMultiReference(t *testing.T) {
 	filter.Add("reference", repoTags[1])
 	filter.Add("reference", repoTags[2])
 	options := types.ImageListOptions{
-		All:     false,
 		Filters: filter,
 	}
 	images, err := client.ImageList(ctx, options)
 	assert.NilError(t, err)
 
-	assert.Check(t, is.Equal(len(images[0].RepoTags), 3))
+	assert.Assert(t, is.Len(images, 1))
+	assert.Check(t, is.Len(images[0].RepoTags, 3))
 	for _, repoTag := range images[0].RepoTags {
 		if repoTag != repoTags[0] && repoTag != repoTags[1] && repoTag != repoTags[2] {
 			t.Errorf("list images doesn't match any repoTag we expected, repoTag: %s", repoTag)
@@ -57,7 +57,7 @@ func TestImagesFilterMultiReference(t *testing.T) {
 }
 
 func TestImagesFilterBeforeSince(t *testing.T) {
-	defer setupTest(t)()
+	t.Cleanup(setupTest(t))
 	client := testEnv.APIClient()
 	ctx := context.Background()
 


### PR DESCRIPTION
**- What I did**

- Added more tests for the image list filters
- Added the image labels to the image list
- Sort the images by creation date
- Populate `RepoTags` with all the tags pointing to an image instead of having multiple objects of the same image in the array.

Fixes #43848
Fixes #43852
Also partially fix*s #43861, I didn't touch `RepoDigests`

**- How I did it**

...

**- How to verify it**

Run
- `make DOCKER_GRAPHDRIVER=overlayfs TEST_FILTER=TestAPIImagesFilter TEST_INTEGRATION_USE_SNAPSHOTTER=1 test-integration`
- `make DOCKER_GRAPHDRIVER=overlayfs TEST_FILTER=TestImagesFilterMultiReference TEST_INTEGRATION_USE_SNAPSHOTTER=1 test-integration`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
