### PR TITLE
(Re)create endpoints in a stable order

### DIFF
--- a/api/server/router/network/backend.go
+++ b/api/server/router/network/backend.go
@@ -15,7 +15,7 @@ type Backend interface {
 	FindNetwork(idName string) (libnetwork.Network, error)
 	GetNetworks(filters.Args, types.NetworkListConfig) ([]types.NetworkResource, error)
 	CreateNetwork(nc types.NetworkCreateRequest) (*types.NetworkCreateResponse, error)
-	ConnectContainerToNetwork(containerName, networkName string, endpointConfig *network.EndpointSettings) error
+	ConnectContainerToNetwork(containerName, networkName string, endpointConfig *network.EndpointSettings, autoPriority bool) error
 	DisconnectContainerFromNetwork(containerName string, networkName string, force bool) error
 	DeleteNetwork(networkID string) error
 	NetworksPrune(ctx context.Context, pruneFilters filters.Args) (*types.NetworksPruneReport, error)

--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -258,7 +258,7 @@ func (n *networkRouter) postNetworkConnect(ctx context.Context, w http.ResponseW
 	// The reason is that, In case of attachable network in swarm scope, the actual local network
 	// may not be available at the time. At the same time, inside daemon `ConnectContainerToNetwork`
 	// does the ambiguity check anyway. Therefore, passing the name to daemon would be enough.
-	return n.backend.ConnectContainerToNetwork(connect.Container, vars["id"], connect.EndpointConfig)
+	return n.backend.ConnectContainerToNetwork(connect.Container, vars["id"], connect.EndpointConfig, true)
 }
 
 func (n *networkRouter) postNetworkDisconnect(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2460,6 +2460,10 @@ definitions:
         example:
           - "server_x"
           - "server_y"
+      Priority:
+        type: "number"
+        example:
+          - 10
 
       # Operational data
       NetworkID:
@@ -10044,6 +10048,7 @@ paths:
                 IPAMConfig:
                   IPv4Address: "172.24.56.89"
                   IPv6Address: "2001:db8::5689"
+                Priority: 100
       tags: ["Network"]
 
   /networks/{id}/disconnect:

--- a/api/types/network/network.go
+++ b/api/types/network/network.go
@@ -51,6 +51,7 @@ type EndpointSettings struct {
 	IPAMConfig *EndpointIPAMConfig
 	Links      []string
 	Aliases    []string
+	Priority   int
 	// Operational data
 	NetworkID           string
 	EndpointID          string

--- a/container/view.go
+++ b/container/view.go
@@ -377,6 +377,7 @@ func (v *View) transform(container *Container) *Snapshot {
 				GlobalIPv6PrefixLen: netw.GlobalIPv6PrefixLen,
 				MacAddress:          netw.MacAddress,
 				NetworkID:           netw.NetworkID,
+				Priority:            netw.Priority,
 			}
 			if netw.IPAMConfig != nil {
 				networks[name].IPAMConfig = &network.EndpointIPAMConfig{

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -42,7 +42,7 @@ type Backend interface {
 	ContainerStart(ctx context.Context, name string, hostConfig *container.HostConfig, checkpoint string, checkpointDir string) error
 	ContainerStop(ctx context.Context, name string, config container.StopOptions) error
 	ContainerLogs(ctx context.Context, name string, config *types.ContainerLogsOptions) (msgs <-chan *backend.LogMessage, tty bool, err error)
-	ConnectContainerToNetwork(containerName, networkName string, endpointConfig *network.EndpointSettings) error
+	ConnectContainerToNetwork(containerName, networkName string, endpointConfig *network.EndpointSettings, autoPriority bool) error
 	ActivateContainerServiceBinding(containerName string) error
 	DeactivateContainerServiceBinding(containerName string) error
 	UpdateContainerServiceConfig(containerName string, serviceConfig *clustertypes.ServiceConfig) error

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -306,7 +306,7 @@ func (c *containerAdapter) create(ctx context.Context) error {
 
 	if nc != nil {
 		for n, ep := range nc.EndpointsConfig {
-			if err := c.backend.ConnectContainerToNetwork(cr.ID, n, ep); err != nil {
+			if err := c.backend.ConnectContainerToNetwork(cr.ID, n, ep, false); err != nil {
 				return err
 			}
 		}

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -453,12 +453,12 @@ func (daemon *Daemon) UpdateContainerServiceConfig(containerName string, service
 // ConnectContainerToNetwork connects the given container to the given
 // network. If either cannot be found, an err is returned. If the
 // network cannot be set up, an err is returned.
-func (daemon *Daemon) ConnectContainerToNetwork(containerName, networkName string, endpointConfig *network.EndpointSettings) error {
+func (daemon *Daemon) ConnectContainerToNetwork(containerName, networkName string, endpointConfig *network.EndpointSettings, autoPriority bool) error {
 	ctr, err := daemon.GetContainer(containerName)
 	if err != nil {
 		return err
 	}
-	return daemon.ConnectToNetwork(ctr, networkName, endpointConfig)
+	return daemon.ConnectToNetwork(ctr, networkName, endpointConfig, autoPriority)
 }
 
 // DisconnectContainerFromNetwork disconnects the given container from

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -1076,7 +1076,7 @@ func buildEndpointInfo(networkSettings *internalnetwork.Settings, n libnetwork.N
 }
 
 // buildJoinOptions builds endpoint Join options from a given network.
-func buildJoinOptions(networkSettings *internalnetwork.Settings, n interface{ Name() string }) ([]libnetwork.EndpointOption, error) {
+func buildJoinOptions(networkSettings *internalnetwork.Settings, n libnetwork.Network, priority int) ([]libnetwork.EndpointOption, error) {
 	var joinOptions []libnetwork.EndpointOption
 	if epConfig, ok := networkSettings.Networks[n.Name()]; ok {
 		for _, str := range epConfig.Links {
@@ -1090,6 +1090,8 @@ func buildJoinOptions(networkSettings *internalnetwork.Settings, n interface{ Na
 			joinOptions = append(joinOptions, libnetwork.EndpointOptionGeneric(options.Generic{k: v}))
 		}
 	}
+
+	joinOptions = append(joinOptions, libnetwork.JoinOptionPriority(priority))
 
 	return joinOptions, nil
 }

--- a/daemon/network/settings_test.go
+++ b/daemon/network/settings_test.go
@@ -1,0 +1,31 @@
+package network // import "github.com/docker/docker/daemon/network"
+
+import (
+	"testing"
+
+	networktypes "github.com/docker/docker/api/types/network"
+	"gotest.tools/v3/assert"
+)
+
+func TestSortNetworks(t *testing.T) {
+	networks := map[string]*EndpointSettings{
+		"net1": &EndpointSettings{
+			EndpointSettings: &networktypes.EndpointSettings{
+				Priority: 1,
+			},
+		},
+		"net100": &EndpointSettings{
+			EndpointSettings: &networktypes.EndpointSettings{
+				Priority: 100,
+			},
+		},
+		"net50": &EndpointSettings{
+			EndpointSettings: &networktypes.EndpointSettings{
+				Priority: 50,
+			},
+		},
+	}
+
+	sortedNets := SortNetworks(networks)
+	assert.DeepEqual(t, sortedNets, []string{"net100", "net50", "net1"})
+}

--- a/integration/internal/container/exec.go
+++ b/integration/internal/container/exec.go
@@ -16,6 +16,10 @@ type ExecResult struct {
 	errBuffer *bytes.Buffer
 }
 
+func (res *ExecResult) RawStdout() *bytes.Buffer {
+	return res.outBuffer
+}
+
 // Stdout returns stdout output of a command run by Exec()
 func (res *ExecResult) Stdout() string {
 	return res.outBuffer.String()

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -146,6 +146,18 @@ func WithIPv6(network, ip string) func(*TestContainerConfig) {
 	}
 }
 
+func WithNetworkPriority(network string, priority int) func(config *TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		if c.NetworkingConfig.EndpointsConfig == nil {
+			c.NetworkingConfig.EndpointsConfig = map[string]*networktypes.EndpointSettings{}
+		}
+		if v, ok := c.NetworkingConfig.EndpointsConfig[network]; !ok || v == nil {
+			c.NetworkingConfig.EndpointsConfig[network] = &networktypes.EndpointSettings{}
+		}
+		c.NetworkingConfig.EndpointsConfig[network].Priority = priority
+	}
+}
+
 // WithLogDriver sets the log driver to use for the container
 func WithLogDriver(driver string) func(*TestContainerConfig) {
 	return func(c *TestContainerConfig) {


### PR DESCRIPTION
Related to:

- #20179
- #45906 
- moby/libnetwork#2093
- https://github.com/moby/moby/issues/20067

Fixes:

- https://github.com/moby/moby/issues/48868

**- What I did**

* 1st commit: Add a new `Priority` field to `EndpointSettings` ;
* 2nd commit:
  * Use this new field to make sure the calls to `daemon.connectToNetwork` are done in descending order ;
  * Also, use it to make sure the endpoints join the sandbox in the same order (that's what guarantees interface names are stable over restarts) ;
* 3rd commit: On `NetworkConnect`, the `Priority` value is automatically computed based on the lowest `Priority` minus one ;

The choice to use descending over ascending order has been made to match what the Compose spec defines.

This change brings interesting advantages for end users:

* Since the interface name/order is now stable, users can bind a specific interface without needing an external script to resolve what interface should be used ;
* The DNS resolver will always iterate on a container's networks in the exact same order, hence DNS resolution for a given name present on multiple networks a container is connected to will always resolve to the same thing ;

**- How to verify it**

* CI should be green.

**- Description for the changelog**

Interfaces are always created in the same order and their name is stable over restarts.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://www.caniprof.com/wp-content/uploads/2019/02/eurasier-4.jpg)

