### PR TITLE
volume: remove the short RRO forms in favor of the long forms

### DIFF
--- a/integration/container/mounts_linux_test.go
+++ b/integration/container/mounts_linux_test.go
@@ -480,7 +480,6 @@ func TestContainerBindMountRecursivelyReadOnly(t *testing.T) {
 		ReadOnlyNonRecursive: true,
 		Propagation:          mounttypes.PropagationRPrivate,
 	}
-	nonRecursiveAsStr := nonRecursive.Source + ":" + nonRecursive.Target + ":ro-non-recursive,rprivate"
 
 	// Force recursive
 	forceRecursive := ro
@@ -488,7 +487,6 @@ func TestContainerBindMountRecursivelyReadOnly(t *testing.T) {
 		ReadOnlyForceRecursive: true,
 		Propagation:            mounttypes.PropagationRPrivate,
 	}
-	forceRecursiveAsStr := forceRecursive.Source + ":" + forceRecursive.Target + ":ro-force-recursive,rprivate"
 
 	ctx := context.Background()
 	client := testEnv.APIClient()
@@ -498,13 +496,11 @@ func TestContainerBindMountRecursivelyReadOnly(t *testing.T) {
 		container.Run(ctx, t, client, container.WithBindRaw(roAsStr), container.WithCmd(roVerifier...)),
 
 		container.Run(ctx, t, client, container.WithMount(nonRecursive), container.WithCmd(nonRecursiveVerifier...)),
-		container.Run(ctx, t, client, container.WithBindRaw(nonRecursiveAsStr), container.WithCmd(nonRecursiveVerifier...)),
 	}
 
 	if rroSupported {
 		containers = append(containers,
 			container.Run(ctx, t, client, container.WithMount(forceRecursive), container.WithCmd(forceRecursiveVerifier...)),
-			container.Run(ctx, t, client, container.WithBindRaw(forceRecursiveAsStr), container.WithCmd(forceRecursiveVerifier...)),
 		)
 	}
 

--- a/volume/mounts/linux_parser.go
+++ b/volume/mounts/linux_parser.go
@@ -198,7 +198,7 @@ func (p *linuxParser) ReadWrite(mode string) bool {
 	}
 
 	for _, o := range strings.Split(mode, ",") {
-		if o == "ro" || strings.HasPrefix(o, "ro-") || o == "rro" {
+		if o == "ro" {
 			return false
 		}
 	}
@@ -263,24 +263,6 @@ func (p *linuxParser) ParseMountRaw(raw, volumeDriver string) (*MountPoint, erro
 	if linuxHasPropagation(mode) {
 		spec.BindOptions = &mount.BindOptions{
 			Propagation: linuxGetPropagation(mode),
-		}
-	}
-
-	for _, m := range strings.Split(mode, ",") {
-		m = strings.TrimSpace(m)
-		if strings.HasPrefix(m, "ro-") || m == "rro" {
-			if spec.Type != mount.TypeBind {
-				return nil, fmt.Errorf("mount mode %q requires a bind mount: %w", mode, errInvalidSpec(raw))
-			}
-			if spec.BindOptions == nil {
-				spec.BindOptions = &mount.BindOptions{}
-			}
-			switch m {
-			case "ro-non-recursive":
-				spec.BindOptions.ReadOnlyNonRecursive = true
-			case "ro-force-recursive", "rro":
-				spec.BindOptions.ReadOnlyForceRecursive = true
-			}
 		}
 	}
 
@@ -352,9 +334,6 @@ func (p *linuxParser) ParseVolumesFrom(spec string) (string, string, error) {
 	}
 	if !linuxValidMountMode(mode) {
 		return "", "", errInvalidMode(mode)
-	}
-	if strings.HasPrefix(mode, "ro-") || mode == "rro" {
-		return "", "", fmt.Errorf("mount mode %q is not supported for volumes-from mounts: %w", mode, errInvalidMode(mode))
 	}
 	// For now don't allow propagation properties while importing
 	// volumes from data container. These volumes will inherit

--- a/volume/mounts/linux_parser_test.go
+++ b/volume/mounts/linux_parser_test.go
@@ -99,30 +99,25 @@ func TestLinuxParseMountRaw(t *testing.T) {
 
 func TestLinuxParseMountRawSplit(t *testing.T) {
 	cases := []struct {
-		bind        string
-		driver      string
-		expType     mount.Type
-		expDest     string
-		expSource   string
-		expName     string
-		expDriver   string
-		expRW       bool
-		expNonRRO   bool
-		expForceRRO bool
-		fail        bool
+		bind      string
+		driver    string
+		expType   mount.Type
+		expDest   string
+		expSource string
+		expName   string
+		expDriver string
+		expRW     bool
+		fail      bool
 	}{
-		{"/tmp:/tmp1", "", mount.TypeBind, "/tmp1", "/tmp", "", "", true, false, false, false},
-		{"/tmp:/tmp2:ro", "", mount.TypeBind, "/tmp2", "/tmp", "", "", false, false, false, false},
-		{"/tmp:/tmp3:rw", "", mount.TypeBind, "/tmp3", "/tmp", "", "", true, false, false, false},
-		{"/tmp:/tmp4:foo", "", mount.TypeBind, "", "", "", "", false, false, false, true},
-		{"/tmp:/tmp5:ro-non-recursive", "", mount.TypeBind, "/tmp5", "/tmp", "", "", false, true, false, false},
-		{"/tmp:/tmp6:ro-force-recursive,rprivate", "", mount.TypeBind, "/tmp6", "/tmp", "", "", false, false, true, false},
-		{"/tmp:/tmp7:rro", "", mount.TypeBind, "/tmp7", "/tmp", "", "", false, false, true, false},
-		{"name:/named1", "", mount.TypeVolume, "/named1", "", "name", "", true, false, false, false},
-		{"name:/named2", "external", mount.TypeVolume, "/named2", "", "name", "external", true, false, false, false},
-		{"name:/named3:ro", "local", mount.TypeVolume, "/named3", "", "name", "local", false, false, false, false},
-		{"local/name:/tmp:rw", "", mount.TypeVolume, "/tmp", "", "local/name", "", true, false, false, false},
-		{"/tmp:tmp", "", mount.TypeBind, "", "", "", "", true, false, false, true},
+		{"/tmp:/tmp1", "", mount.TypeBind, "/tmp1", "/tmp", "", "", true, false},
+		{"/tmp:/tmp2:ro", "", mount.TypeBind, "/tmp2", "/tmp", "", "", false, false},
+		{"/tmp:/tmp3:rw", "", mount.TypeBind, "/tmp3", "/tmp", "", "", true, false},
+		{"/tmp:/tmp4:foo", "", mount.TypeBind, "", "", "", "", false, true},
+		{"name:/named1", "", mount.TypeVolume, "/named1", "", "name", "", true, false},
+		{"name:/named2", "external", mount.TypeVolume, "/named2", "", "name", "external", true, false},
+		{"name:/named3:ro", "local", mount.TypeVolume, "/named3", "", "name", "local", false, false},
+		{"local/name:/tmp:rw", "", mount.TypeVolume, "/tmp", "", "local/name", "", true, false},
+		{"/tmp:tmp", "", mount.TypeBind, "", "", "", "", true, true},
 	}
 
 	parser := NewLinuxParser()
@@ -146,13 +141,6 @@ func TestLinuxParseMountRawSplit(t *testing.T) {
 			assert.Equal(t, m.Driver, c.expDriver)
 			assert.Equal(t, m.RW, c.expRW)
 			assert.Equal(t, m.Type, c.expType)
-			var nonRRO, forceRRO bool
-			if m.Spec.BindOptions != nil {
-				nonRRO = m.Spec.BindOptions.ReadOnlyNonRecursive
-				forceRRO = m.Spec.BindOptions.ReadOnlyForceRecursive
-			}
-			assert.Equal(t, nonRRO, c.expNonRRO)
-			assert.Equal(t, forceRRO, c.expForceRRO)
 		})
 	}
 }

--- a/volume/mounts/parser.go
+++ b/volume/mounts/parser.go
@@ -13,11 +13,8 @@ var ErrVolumeTargetIsRoot = errors.New("invalid specification: destination can't
 
 // read-write modes
 var rwModes = map[string]bool{
-	"rw":                 true,
-	"ro":                 true, // attempts recursive read-only if possible
-	"ro-non-recursive":   true, // makes the mount non-recursively read-only, but still leaves the mount recursive
-	"ro-force-recursive": true, // raises an error if the mount cannot be made recursively read-only
-	"rro":                true, // alias for ro-force-recursive
+	"rw": true,
+	"ro": true, // attempts recursive read-only if possible
 }
 
 // Parser represents a platform specific parser for mount expressions


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

"ro-non-recursive", "ro-force-recursive", and "rro" are now removed from the legacy mount API.

CLI may still support them via the new mount API (if we want).

Partially revert:
- #45278 (Milestone: v25.0.0)

See also:
- https://github.com/docker/cli/pull/4316

**- How to verify it**

Observe the CI


**- A picture of a cute animal (not mandatory but encouraged)**

🐧 