### PR TITLE
libnetwork/drivers/bridge: assorted cleanups

### DIFF
--- a/libnetwork/drivers/bridge/bridge.go
+++ b/libnetwork/drivers/bridge/bridge.go
@@ -1373,9 +1373,7 @@ func (d *driver) link(network *bridgeNetwork, endpoint *bridgeEndpoint, enable b
 				return err
 			}
 
-			l := newLink(parentEndpoint.addr.IP.String(),
-				endpoint.addr.IP.String(),
-				ec.ExposedPorts, network.config.BridgeName)
+			l := newLink(parentEndpoint.addr.IP, endpoint.addr.IP, ec.ExposedPorts, network.config.BridgeName)
 			if enable {
 				err = l.Enable()
 				if err != nil {
@@ -1406,9 +1404,7 @@ func (d *driver) link(network *bridgeNetwork, endpoint *bridgeEndpoint, enable b
 			continue
 		}
 
-		l := newLink(endpoint.addr.IP.String(),
-			childEndpoint.addr.IP.String(),
-			childEndpoint.extConnConfig.ExposedPorts, network.config.BridgeName)
+		l := newLink(endpoint.addr.IP, childEndpoint.addr.IP, childEndpoint.extConnConfig.ExposedPorts, network.config.BridgeName)
 		if enable {
 			err = l.Enable()
 			if err != nil {

--- a/libnetwork/drivers/bridge/bridge.go
+++ b/libnetwork/drivers/bridge/bridge.go
@@ -310,13 +310,12 @@ func (n *bridgeNetwork) getNetworkBridgeName() string {
 }
 
 func (n *bridgeNetwork) getEndpoint(eid string) (*bridgeEndpoint, error) {
-	n.Lock()
-	defer n.Unlock()
-
 	if eid == "" {
 		return nil, InvalidEndpointIDError(eid)
 	}
 
+	n.Lock()
+	defer n.Unlock()
 	if ep, ok := n.endpoints[eid]; ok {
 		return ep, nil
 	}

--- a/libnetwork/drivers/bridge/bridge.go
+++ b/libnetwork/drivers/bridge/bridge.go
@@ -1378,7 +1378,10 @@ func (d *driver) link(network *bridgeNetwork, endpoint *bridgeEndpoint, enable b
 				return InvalidEndpointIDError(p)
 			}
 
-			l := newLink(parentEndpoint.addr.IP, endpoint.addr.IP, ec.ExposedPorts, network.config.BridgeName)
+			l, err := newLink(parentEndpoint.addr.IP, endpoint.addr.IP, ec.ExposedPorts, network.config.BridgeName)
+			if err != nil {
+				return err
+			}
 			if enable {
 				if err := l.Enable(); err != nil {
 					return err
@@ -1402,7 +1405,10 @@ func (d *driver) link(network *bridgeNetwork, endpoint *bridgeEndpoint, enable b
 			continue
 		}
 
-		l := newLink(endpoint.addr.IP, childEndpoint.addr.IP, childEndpoint.extConnConfig.ExposedPorts, network.config.BridgeName)
+		l, err := newLink(endpoint.addr.IP, childEndpoint.addr.IP, childEndpoint.extConnConfig.ExposedPorts, network.config.BridgeName)
+		if err != nil {
+			return err
+		}
 		if enable {
 			if err := l.Enable(); err != nil {
 				return err

--- a/libnetwork/drivers/bridge/link.go
+++ b/libnetwork/drivers/bridge/link.go
@@ -36,9 +36,12 @@ func (l *link) Enable() error {
 	linkFunction := func() error {
 		return linkContainers(iptables.Append, l.parentIP, l.childIP, l.ports, l.bridge, false)
 	}
+	if err := linkFunction(); err != nil {
+		return err
+	}
 
-	iptables.OnReloaded(func() { linkFunction() })
-	return linkFunction()
+	iptables.OnReloaded(func() { _ = linkFunction() })
+	return nil
 }
 
 func (l *link) Disable() {

--- a/libnetwork/drivers/bridge/link.go
+++ b/libnetwork/drivers/bridge/link.go
@@ -23,13 +23,20 @@ func (l *link) String() string {
 	return fmt.Sprintf("%s <-> %s [%v] on %s", l.parentIP, l.childIP, l.ports, l.bridge)
 }
 
-func newLink(parentIP, childIP net.IP, ports []types.TransportPort, bridge string) *link {
+func newLink(parentIP, childIP net.IP, ports []types.TransportPort, bridge string) (*link, error) {
+	if parentIP == nil {
+		return nil, fmt.Errorf("cannot link to a container with an empty parent IP address")
+	}
+	if childIP == nil {
+		return nil, fmt.Errorf("cannot link to a container with an empty child IP address")
+	}
+
 	return &link{
 		childIP:  childIP,
 		parentIP: parentIP,
 		ports:    ports,
 		bridge:   bridge,
-	}
+	}, nil
 }
 
 func (l *link) Enable() error {

--- a/libnetwork/drivers/bridge/link_test.go
+++ b/libnetwork/drivers/bridge/link_test.go
@@ -29,7 +29,10 @@ func TestLinkNew(t *testing.T) {
 	parentIP := net.ParseIP(pIP)
 	childIP := net.ParseIP(cIP)
 
-	l := newLink(parentIP, childIP, ports, bridgeName)
+	l, err := newLink(parentIP, childIP, ports, bridgeName)
+	if err != nil {
+		t.Errorf("unexpected error from newlink(): %v", err)
+	}
 	if l == nil {
 		t.FailNow()
 	}

--- a/libnetwork/drivers/bridge/link_test.go
+++ b/libnetwork/drivers/bridge/link_test.go
@@ -3,6 +3,7 @@
 package bridge
 
 import (
+	"net"
 	"testing"
 
 	"github.com/docker/docker/libnetwork/types"
@@ -19,23 +20,31 @@ func getPorts() []types.TransportPort {
 func TestLinkNew(t *testing.T) {
 	ports := getPorts()
 
-	link := newLink("172.0.17.3", "172.0.17.2", ports, "docker0")
+	const (
+		pIP        = "172.0.17.3"
+		cIP        = "172.0.17.2"
+		bridgeName = "docker0"
+	)
 
-	if link == nil {
+	parentIP := net.ParseIP(pIP)
+	childIP := net.ParseIP(cIP)
+
+	l := newLink(parentIP, childIP, ports, bridgeName)
+	if l == nil {
 		t.FailNow()
 	}
-	if link.parentIP != "172.0.17.3" {
+	if l.parentIP.String() != pIP {
 		t.Fail()
 	}
-	if link.childIP != "172.0.17.2" {
+	if l.childIP.String() != cIP {
 		t.Fail()
 	}
-	for i, p := range link.ports {
+	for i, p := range l.ports {
 		if p != ports[i] {
 			t.Fail()
 		}
 	}
-	if link.bridge != "docker0" {
+	if l.bridge != bridgeName {
 		t.Fail()
 	}
 }


### PR DESCRIPTION
### libnetwork/drivers/bridge: link.Enable, link.Disable use iptables types

The iptables package has types defined for these actions; use them directly
instead of creating a string only to convert it to a known value.

### libnetwork/drivers/bridge: link.Enable: don't register reload on error

Only register a reload function if we actually managed to enable the link.

### libnetwork/drivers/bridge: don't convert IP to string and back again

### libnetwork/drivers/bridge: driver.link: name return var for defer handling

Name the return variable to prevent accidental shadowing of the error,
which is used in defers.


### libnetwork/drivers/bridge: driver.link: don't defer in a loop

Collect a list of all the links we successfully enabled (if any), and
use a single defer to disable them.


### libnetwork/drivers/bridge: bridge.NetworkgetEndpoint(): move lock

Don't lock if there's no need to.

### ibnetwork/drivers/bridge: newLink: validate before creating


**- A picture of a cute animal (not mandatory but encouraged)**

