### PR TITLE
libnetwork/datastore: remove DataStore interface, and rename constructor

### DIFF
--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -91,7 +91,7 @@ type Controller struct {
 	ipamRegistry     drvregistry.IPAMs
 	sandboxes        sandboxTable
 	cfg              *config.Config
-	store            datastore.DataStore
+	store            *datastore.Store
 	extKeyListener   net.Listener
 	watchCh          chan *Endpoint
 	unWatchCh        chan *Endpoint

--- a/libnetwork/datastore/cache.go
+++ b/libnetwork/datastore/cache.go
@@ -13,10 +13,10 @@ type kvMap map[string]KVObject
 type cache struct {
 	sync.Mutex
 	kmm map[string]kvMap
-	ds  *datastore
+	ds  *Store
 }
 
-func newCache(ds *datastore) *cache {
+func newCache(ds *Store) *cache {
 	return &cache{kmm: make(map[string]kvMap), ds: ds}
 }
 

--- a/libnetwork/datastore/datastore.go
+++ b/libnetwork/datastore/datastore.go
@@ -2,7 +2,6 @@ package datastore
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -130,17 +129,6 @@ func Key(key ...string) string {
 	keychain := append(rootChain, key...)
 	str := strings.Join(keychain, "/")
 	return str + "/"
-}
-
-// ParseKey provides convenient method to unpack the key to complement the Key function
-func ParseKey(key string) ([]string, error) {
-	chain := strings.Split(strings.Trim(key, "/"), "/")
-
-	// The key must at least be equal to the rootChain in order to be considered as valid
-	if len(chain) <= len(rootChain) || !reflect.DeepEqual(chain[0:len(rootChain)], rootChain) {
-		return nil, types.BadRequestErrorf("invalid Key : %s", key)
-	}
-	return chain[len(rootChain):], nil
 }
 
 // newClient used to connect to KV Store

--- a/libnetwork/datastore/datastore_test.go
+++ b/libnetwork/datastore/datastore_test.go
@@ -2,7 +2,6 @@ package datastore
 
 import (
 	"encoding/json"
-	"reflect"
 	"testing"
 
 	"github.com/docker/docker/libnetwork/options"
@@ -21,17 +20,6 @@ func TestKey(t *testing.T) {
 	sKey := Key(eKey...)
 	if sKey != "docker/network/v1.0/hello/world/" {
 		t.Fatalf("unexpected key : %s", sKey)
-	}
-}
-
-func TestParseKey(t *testing.T) {
-	keySlice, err := ParseKey("/docker/network/v1.0/hello/world/")
-	if err != nil {
-		t.Fatal(err)
-	}
-	eKey := []string{"hello", "world"}
-	if len(keySlice) < 2 || !reflect.DeepEqual(eKey, keySlice) {
-		t.Fatalf("unexpected unkey : %s", keySlice)
 	}
 }
 

--- a/libnetwork/datastore/datastore_test.go
+++ b/libnetwork/datastore/datastore_test.go
@@ -11,9 +11,9 @@ import (
 
 var dummyKey = "dummy"
 
-// NewCustomDataStore can be used by other Tests in order to use custom datastore
-func NewTestDataStore() DataStore {
-	return &datastore{scope: LocalScope, store: NewMockStore()}
+// NewTestDataStore can be used by other Tests in order to use custom datastore
+func NewTestDataStore() *Store {
+	return &Store{scope: LocalScope, store: NewMockStore()}
 }
 
 func TestKey(t *testing.T) {
@@ -36,13 +36,12 @@ func TestParseKey(t *testing.T) {
 }
 
 func TestInvalidDataStore(t *testing.T) {
-	config := ScopeCfg{
+	_, err := New(ScopeCfg{
 		Client: ScopeClientCfg{
 			Provider: "invalid",
 			Address:  "localhost:8500",
 		},
-	}
-	_, err := NewDataStore(config)
+	})
 	if err == nil {
 		t.Fatal("Invalid Datastore connection configuration must result in a failure")
 	}

--- a/libnetwork/datastore/mockstore_test.go
+++ b/libnetwork/datastore/mockstore_test.go
@@ -7,9 +7,6 @@ import (
 	"github.com/docker/docker/libnetwork/types"
 )
 
-// ErrNotImplemented exported
-var ErrNotImplemented = errors.New("Functionality not implemented")
-
 // MockData exported
 type MockData struct {
 	Data  []byte
@@ -23,8 +20,7 @@ type MockStore struct {
 
 // NewMockStore creates a Map backed Datastore that is useful for mocking
 func NewMockStore() *MockStore {
-	db := make(map[string]*MockData)
-	return &MockStore{db}
+	return &MockStore{db: make(map[string]*MockData)}
 }
 
 // Get the value at "key", returns the last modified index
@@ -56,7 +52,7 @@ func (s *MockStore) Exists(key string) (bool, error) {
 
 // List gets a range of values at "directory"
 func (s *MockStore) List(prefix string) ([]*store.KVPair, error) {
-	return nil, ErrNotImplemented
+	return nil, errors.New("not implemented")
 }
 
 // AtomicPut put a value at "key" if the key has not been

--- a/libnetwork/drivers/bridge/bridge.go
+++ b/libnetwork/drivers/bridge/bridge.go
@@ -153,7 +153,7 @@ type driver struct {
 	isolationChain1V6 *iptables.ChainInfo
 	isolationChain2V6 *iptables.ChainInfo
 	networks          map[string]*bridgeNetwork
-	store             datastore.DataStore
+	store             *datastore.Store
 	nlh               *netlink.Handle
 	configNetwork     sync.Mutex
 	portAllocator     *portallocator.PortAllocator // Overridable for tests.

--- a/libnetwork/drivers/bridge/bridge_store.go
+++ b/libnetwork/drivers/bridge/bridge_store.go
@@ -30,7 +30,7 @@ func (d *driver) initStore(option map[string]interface{}) error {
 		if !ok {
 			return types.InternalErrorf("incorrect data in datastore configuration: %v", data)
 		}
-		d.store, err = datastore.NewDataStoreFromConfig(dsc)
+		d.store, err = datastore.FromConfig(dsc)
 		if err != nil {
 			return types.InternalErrorf("bridge driver failed to initialize data store: %v", err)
 		}

--- a/libnetwork/drivers/ipvlan/ipvlan.go
+++ b/libnetwork/drivers/ipvlan/ipvlan.go
@@ -40,7 +40,7 @@ type driver struct {
 	networks networkTable
 	sync.Once
 	sync.Mutex
-	store datastore.DataStore
+	store *datastore.Store
 }
 
 type endpoint struct {

--- a/libnetwork/drivers/ipvlan/ipvlan_store.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_store.go
@@ -50,7 +50,7 @@ func (d *driver) initStore(option map[string]interface{}) error {
 		if !ok {
 			return types.InternalErrorf("incorrect data in datastore configuration: %v", data)
 		}
-		d.store, err = datastore.NewDataStoreFromConfig(dsc)
+		d.store, err = datastore.FromConfig(dsc)
 		if err != nil {
 			return types.InternalErrorf("ipvlan driver failed to initialize data store: %v", err)
 		}

--- a/libnetwork/drivers/macvlan/macvlan.go
+++ b/libnetwork/drivers/macvlan/macvlan.go
@@ -34,7 +34,7 @@ type driver struct {
 	networks networkTable
 	sync.Once
 	sync.Mutex
-	store datastore.DataStore
+	store *datastore.Store
 }
 
 type endpoint struct {

--- a/libnetwork/drivers/macvlan/macvlan_store.go
+++ b/libnetwork/drivers/macvlan/macvlan_store.go
@@ -49,7 +49,7 @@ func (d *driver) initStore(option map[string]interface{}) error {
 		if !ok {
 			return types.InternalErrorf("incorrect data in datastore configuration: %v", data)
 		}
-		d.store, err = datastore.NewDataStoreFromConfig(dsc)
+		d.store, err = datastore.FromConfig(dsc)
 		if err != nil {
 			return types.InternalErrorf("macvlan driver failed to initialize data store: %v", err)
 		}

--- a/libnetwork/drivers/windows/windows.go
+++ b/libnetwork/drivers/windows/windows.go
@@ -101,7 +101,7 @@ type hnsNetwork struct {
 type driver struct {
 	name     string
 	networks map[string]*hnsNetwork
-	store    datastore.DataStore
+	store    *datastore.Store
 	sync.Mutex
 }
 

--- a/libnetwork/drivers/windows/windows_store.go
+++ b/libnetwork/drivers/windows/windows_store.go
@@ -27,7 +27,7 @@ func (d *driver) initStore(option map[string]interface{}) error {
 		if !ok {
 			return types.InternalErrorf("incorrect data in datastore configuration: %v", data)
 		}
-		d.store, err = datastore.NewDataStoreFromConfig(dsc)
+		d.store, err = datastore.FromConfig(dsc)
 		if err != nil {
 			return types.InternalErrorf("windows driver failed to initialize data store: %v", err)
 		}

--- a/libnetwork/store.go
+++ b/libnetwork/store.go
@@ -24,7 +24,7 @@ func (c *Controller) initStores() error {
 		return nil
 	}
 	var err error
-	c.store, err = datastore.NewDataStore(c.cfg.Scope)
+	c.store, err = datastore.New(c.cfg.Scope)
 	if err != nil {
 		return err
 	}
@@ -39,7 +39,7 @@ func (c *Controller) closeStores() {
 	}
 }
 
-func (c *Controller) getStore() datastore.DataStore {
+func (c *Controller) getStore() *datastore.Store {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 


### PR DESCRIPTION
### libnetwork/datastore: move MockData to a _test file

It's only used in tests, and only within this package.


### libnetwork/datastore: remove DataStore interface

It only had a single implementation, so let's remove the interface.

While changing, also renaming;

- datastore.DataStore -> datastore.Store
- datastore.NewDataStore -> datastore.New
- datastore.NewDataStoreFromConfig -> datastore.FromConfig

### libnetwork/datastore: remove unused ParseKey() utility



**- A picture of a cute animal (not mandatory but encouraged)**

