### PR TITLE
libnetwork/iptables: cleaning up: "there's more where that came from"

### DIFF
--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -664,7 +664,14 @@ addToStore:
 		arrangeIngressFilterRule()
 		c.mu.Unlock()
 	}
-	arrangeUserFilterRule()
+
+	// Sets up the DOCKER-USER chain for each iptables version (IPv4, IPv6)
+	// that's enabled in the controller's configuration.
+	for _, ipVersion := range c.enabledIptablesVersions() {
+		if err := setupUserChain(ipVersion); err != nil {
+			log.G(context.TODO()).WithError(err).Warnf("Controller.NewNetwork %s:", name)
+		}
+	}
 
 	return nw, nil
 }

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -64,7 +64,6 @@ import (
 	"github.com/docker/docker/libnetwork/drvregistry"
 	"github.com/docker/docker/libnetwork/ipamapi"
 	"github.com/docker/docker/libnetwork/netlabel"
-	"github.com/docker/docker/libnetwork/options"
 	"github.com/docker/docker/libnetwork/osl"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/docker/docker/pkg/plugingetter"
@@ -1134,42 +1133,4 @@ func (c *Controller) IsDiagnosticEnabled() bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.DiagnosticServer.IsDiagnosticEnabled()
-}
-
-func (c *Controller) iptablesEnabled() bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.cfg == nil {
-		return false
-	}
-	// parse map cfg["bridge"]["generic"]["EnableIPTable"]
-	cfgBridge := c.cfg.DriverConfig("bridge")
-	cfgGeneric, ok := cfgBridge[netlabel.GenericData].(options.Generic)
-	if !ok {
-		return false
-	}
-	enabled, ok := cfgGeneric["EnableIPTables"].(bool)
-	if !ok {
-		// unless user explicitly stated, assume iptable is enabled
-		enabled = true
-	}
-	return enabled
-}
-
-func (c *Controller) ip6tablesEnabled() bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.cfg == nil {
-		return false
-	}
-	// parse map cfg["bridge"]["generic"]["EnableIP6Table"]
-	cfgBridge := c.cfg.DriverConfig("bridge")
-	cfgGeneric, ok := cfgBridge[netlabel.GenericData].(options.Generic)
-	if !ok {
-		return false
-	}
-	enabled, _ := cfgGeneric["EnableIP6Tables"].(bool)
-	return enabled
 }

--- a/libnetwork/controller_linux.go
+++ b/libnetwork/controller_linux.go
@@ -1,0 +1,33 @@
+package libnetwork
+
+import (
+	"github.com/docker/docker/libnetwork/iptables"
+	"github.com/docker/docker/libnetwork/netlabel"
+	"github.com/docker/docker/libnetwork/options"
+)
+
+// enabledIptablesVersions returns the iptables versions that are enabled
+// for the controller.
+func (c *Controller) enabledIptablesVersions() []iptables.IPVersion {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.cfg == nil {
+		return nil
+	}
+	// parse map cfg["bridge"]["generic"]["EnableIPTable"]
+	cfgBridge := c.cfg.DriverConfig("bridge")
+	cfgGeneric, ok := cfgBridge[netlabel.GenericData].(options.Generic)
+	if !ok {
+		return nil
+	}
+
+	var versions []iptables.IPVersion
+	if enabled, ok := cfgGeneric["EnableIPTables"].(bool); enabled || !ok {
+		// iptables is enabled unless user explicitly disabled it
+		versions = append(versions, iptables.IPv4)
+	}
+	if enabled, _ := cfgGeneric["EnableIP6Tables"].(bool); enabled {
+		versions = append(versions, iptables.IPv6)
+	}
+	return versions
+}

--- a/libnetwork/controller_others.go
+++ b/libnetwork/controller_others.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package libnetwork
+
+// enabledIptablesVersions is a no-op on non-Linux systems.
+func (c *Controller) enabledIptablesVersions() []any {
+	return nil
+}

--- a/libnetwork/firewall_linux.go
+++ b/libnetwork/firewall_linux.go
@@ -16,47 +16,33 @@ func setupArrangeUserFilterRule(c *Controller) {
 	iptables.OnReloaded(arrangeUserFilterRule)
 }
 
-// This chain allow users to configure firewall policies in a way that persists
-// docker operations/restarts. Docker will not delete or modify any pre-existing
-// rules from the DOCKER-USER filter chain.
-// Note once DOCKER-USER chain is created, docker engine does not remove it when
-// IPTableForwarding is disabled, because it contains rules configured by user that
-// are beyond docker engine's control.
+// arrangeUserFilterRule sets up the DOCKER-USER chain for each iptables version
+// (IPv4, IPv6) that's enabled in the controller's configuration.
+//
+// This chain allows users to configure firewall policies in a way that
+// persist daemon operations/restarts. The daemon does not delete or modify
+// any pre-existing rules from the DOCKER-USER filter chain.
+//
+// Once the DOCKER-USER chain is created, the daemon does not remove it when
+// IPTableForwarding is disabled, because it contains rules configured by user
+// that are beyond the daemon's control.
 func arrangeUserFilterRule() {
 	if ctrl == nil {
 		return
 	}
 
-	conds := []struct {
-		ipVer iptables.IPVersion
-		cond  bool
-	}{
-		{ipVer: iptables.IPv4, cond: ctrl.iptablesEnabled()},
-		{ipVer: iptables.IPv6, cond: ctrl.ip6tablesEnabled()},
-	}
-
-	for _, ipVerCond := range conds {
-		cond := ipVerCond.cond
-		if !cond {
-			continue
-		}
-
-		ipVer := ipVerCond.ipVer
-		iptable := iptables.GetIptable(ipVer)
-		_, err := iptable.NewChain(userChain, iptables.Filter, false)
-		if err != nil {
-			log.G(context.TODO()).WithError(err).Warnf("Failed to create %s %v chain", userChain, ipVer)
+	for _, ipVersion := range ctrl.enabledIptablesVersions() {
+		ipt := iptables.GetIptable(ipVersion)
+		if _, err := ipt.NewChain(userChain, iptables.Filter, false); err != nil {
+			log.G(context.TODO()).WithError(err).Warnf("Failed to create %s %v chain", userChain, ipVersion)
 			return
 		}
-
-		if err = iptable.AddReturnRule(userChain); err != nil {
-			log.G(context.TODO()).WithError(err).Warnf("Failed to add the RETURN rule for %s %v", userChain, ipVer)
+		if err := ipt.AddReturnRule(userChain); err != nil {
+			log.G(context.TODO()).WithError(err).Warnf("Failed to add the RETURN rule for %s %v", userChain, ipVersion)
 			return
 		}
-
-		err = iptable.EnsureJumpRule("FORWARD", userChain)
-		if err != nil {
-			log.G(context.TODO()).WithError(err).Warnf("Failed to ensure the jump rule for %s %v", userChain, ipVer)
+		if err := ipt.EnsureJumpRule("FORWARD", userChain); err != nil {
+			log.G(context.TODO()).WithError(err).Warnf("Failed to ensure the jump rule for %s %v", userChain, ipVersion)
 		}
 	}
 }

--- a/libnetwork/firewall_others.go
+++ b/libnetwork/firewall_others.go
@@ -4,3 +4,4 @@ package libnetwork
 
 func setupArrangeUserFilterRule(c *Controller) {}
 func arrangeUserFilterRule()                   {}
+func setupUserChain(ipVersion any) error       { return nil }

--- a/libnetwork/iptables/conntrack.go
+++ b/libnetwork/iptables/conntrack.go
@@ -14,19 +14,20 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-// ErrConntrackNotConfigurable means that conntrack module is not loaded or does not have the netlink module loaded
-var ErrConntrackNotConfigurable = errors.New("conntrack is not available")
-
-// IsConntrackProgrammable returns true if the handle supports the NETLINK_NETFILTER and the base modules are loaded
-func IsConntrackProgrammable(nlh *netlink.Handle) bool {
-	return nlh.SupportsNetlinkFamily(syscall.NETLINK_NETFILTER)
+// checkConntrackProgrammable checks if the handle supports the
+// NETLINK_NETFILTER and the base modules are loaded.
+func checkConntrackProgrammable(nlh *netlink.Handle) error {
+	if !nlh.SupportsNetlinkFamily(syscall.NETLINK_NETFILTER) {
+		return errors.New("conntrack is not available")
+	}
+	return nil
 }
 
 // DeleteConntrackEntries deletes all the conntrack connections on the host for the specified IP
 // Returns the number of flows deleted for IPv4, IPv6 else error
 func DeleteConntrackEntries(nlh *netlink.Handle, ipv4List []net.IP, ipv6List []net.IP) (uint, uint, error) {
-	if !IsConntrackProgrammable(nlh) {
-		return 0, 0, ErrConntrackNotConfigurable
+	if err := checkConntrackProgrammable(nlh); err != nil {
+		return 0, 0, err
 	}
 
 	var totalIPv4FlowPurged uint
@@ -54,8 +55,8 @@ func DeleteConntrackEntries(nlh *netlink.Handle, ipv4List []net.IP, ipv6List []n
 }
 
 func DeleteConntrackEntriesByPort(nlh *netlink.Handle, proto types.Protocol, ports []uint16) error {
-	if !IsConntrackProgrammable(nlh) {
-		return ErrConntrackNotConfigurable
+	if err := checkConntrackProgrammable(nlh); err != nil {
+		return err
 	}
 
 	var totalIPv4FlowPurged uint


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/45987
- follow-up to https://github.com/moby/moby/pull/45888
- also related to https://github.com/moby/moby/pull/44825

### libnetwork: Controller: combine iptablesEnabled and ip6tablesEnabled

These functions were mostly identical, except for iptables being enabled
by default (unless explicitly disabled by config).

Rewrite the function to a enabledIptablesVersions, which returns the list
of iptables-versions that are enabled for the controller. This prevents
having to acquire a lock twice, and simplifies arrangeUserFilterRule, which
can now just iterate over the enabled versions.


### libnetwork: arrangeUserFilterRule: don't return early

commit ffd75c2e0cd791ba9e57f905677904590deb6921 (https://github.com/moby/moby/pull/44825) updated this function to
set up the DOCKER-USER chain for both iptables and ip6tables, however the
function would return early if a failure happened (instead of continuing
with the next iptables version).

This patch extracts setting up the chain to a separate function, and updates
arrangeUserFilterRule to log the failure as a warning, but continue with
the next iptables version.

### libnetwork: Controller.NewNetwork: inline arrangeUserFilterRule()

arrangeUserFilterRule uses the package-level [`ctrl` variable][1], which
holds a reference to a controller instance. This variable is set by
[`setupArrangeUserFilterRule()`][2], which is called when initialization
a controller ([`libnetwork.New`][3]).

In normal circumstances, there would only be one controller, created during
daemon startup, and the instance of the controller would be the same as
the controller that `NewNetwork` is called from, but there's no protection
for the `ctrl` variable, and various integration tests create their own
controller instance.

The global `ctrl` var was introduced in [54e7900fb89b1aeeb188d935f29cf05514fd419b][4],
with the assumption that [only one controller could ever exist][5].

This patch tries to reduce uses of the `ctrl` variable, and as we're calling
this code from inside a method on a specific controller, we inline the code
and use that specific controller instead.


[1]: https://github.com/moby/moby/blob/37b908aa628ccf8f1e10182d2fc049423707422d/libnetwork/firewall_linux.go#L12
[2]: https://github.com/moby/moby/blob/37b908aa628ccf8f1e10182d2fc049423707422d/libnetwork/firewall_linux.go#L14-L17
[3]: https://github.com/moby/moby/blob/37b908aa628ccf8f1e10182d2fc049423707422d/libnetwork/controller.go#L163
[4]: https://github.com/moby/libnetwork/commit/54e7900fb89b1aeeb188d935f29cf05514fd419b
[5]: https://github.com/moby/libnetwork/pull/2471#discussion_r343457183


### libnetwork/iptables: un-export ErrConntrackNotConfigurable, IsConntrackProgrammable

These were only used internally, and ErrConntrackNotConfigurable was not used
as a sentinel error anywhere. Remove ErrConntrackNotConfigurable, and change
IsConntrackProgrammable to return an error instead.



**- A picture of a cute animal (not mandatory but encouraged)**

