### PR TITLE
libnetwork: refactor TestErrorInterfaces into a test

### DIFF
--- a/libnetwork/errors_test.go
+++ b/libnetwork/errors_test.go
@@ -7,13 +7,12 @@ import (
 )
 
 func TestErrorInterfaces(t *testing.T) {
-	badRequestErrorList := []error{ErrInvalidID(""), ErrInvalidName(""), ErrInvalidJoin{}, ErrInvalidNetworkDriver(""), InvalidContainerIDError(""), ErrNoSuchNetwork(""), ErrNoSuchEndpoint("")}
+	badRequestErrorList := []error{ErrInvalidID(""), ErrInvalidName(""), ErrInvalidJoin{}, ErrInvalidNetworkDriver(""), InvalidContainerIDError("")}
 	for _, err := range badRequestErrorList {
 		switch u := err.(type) {
 		case types.BadRequestError:
-			return
 		default:
-			t.Fatalf("Failed to detect err %v is of type BadRequestError. Got type: %T", err, u)
+			t.Errorf("Failed to detect err %v is of type BadRequestError. Got type: %T", err, u)
 		}
 	}
 
@@ -21,29 +20,26 @@ func TestErrorInterfaces(t *testing.T) {
 	for _, err := range maskableErrorList {
 		switch u := err.(type) {
 		case types.MaskableError:
-			return
 		default:
-			t.Fatalf("Failed to detect err %v is of type MaskableError. Got type: %T", err, u)
+			t.Errorf("Failed to detect err %v is of type MaskableError. Got type: %T", err, u)
 		}
 	}
 
-	notFoundErrorList := []error{NetworkTypeError(""), &UnknownNetworkError{}, &UnknownEndpointError{}}
+	notFoundErrorList := []error{NetworkTypeError(""), &UnknownNetworkError{}, &UnknownEndpointError{}, ErrNoSuchNetwork(""), ErrNoSuchEndpoint("")}
 	for _, err := range notFoundErrorList {
 		switch u := err.(type) {
 		case types.NotFoundError:
-			return
 		default:
-			t.Fatalf("Failed to detect err %v is of type NotFoundError. Got type: %T", err, u)
+			t.Errorf("Failed to detect err %v is of type NotFoundError. Got type: %T", err, u)
 		}
 	}
 
-	forbiddenErrorList := []error{NetworkTypeError(""), &UnknownNetworkError{}, &UnknownEndpointError{}}
+	forbiddenErrorList := []error{&ActiveContainerError{}}
 	for _, err := range forbiddenErrorList {
 		switch u := err.(type) {
 		case types.ForbiddenError:
-			return
 		default:
-			t.Fatalf("Failed to detect err %v is of type ForbiddenError. Got type: %T", err, u)
+			t.Errorf("Failed to detect err %v is of type ForbiddenError. Got type: %T", err, u)
 		}
 	}
 }


### PR DESCRIPTION
This function was added in libnetwork through https://github.com/moby/libnetwork/commit/50964c994831c3a960d306ff130ff42983e2fe4a and, based on the name of the function and its signature, I think it was meant to be a test. This patch refactors it to be one.

Changing it into a test made it slightly broken:

    go test -v -run TestErrorInterfaces
    === RUN   TestErrorInterfaces
        errors_test.go:15: Failed to detect err network  not found is of type BadRequestError. Got type: libnetwork.ErrNoSuchNetwork
        errors_test.go:15: Failed to detect err endpoint  not found is of type BadRequestError. Got type: libnetwork.ErrNoSuchEndpoint
        errors_test.go:42: Failed to detect err unknown driver "" is of type ForbiddenError. Got type: libnetwork.NetworkTypeError
        errors_test.go:42: Failed to detect err unknown network  id  is of type ForbiddenError. Got type: *libnetwork.UnknownNetworkError
        errors_test.go:42: Failed to detect err unknown endpoint  id  is of type ForbiddenError. Got type: *libnetwork.UnknownEndpointError
    --- FAIL: TestErrorInterfaces (0.00s)
    FAIL

This was because some errors were tested twice, but for the wrong type (`NetworkTypeError`, `UnknownNetworkError`, `UnknownEndpointError`).

Moving them to the right test left no test-cases for `types.ForbiddenError`, so I added `ActiveContainerError` to not make that part of the code feel lonely.

Other failures were because some errors were changed from `types.BadRequestError` to a `types.NotFoundError` error in commit https://github.com/moby/libnetwork/commit/ba012a703a42e3f6c77386cf995a4a09249fd58a, so I moved those to the right part.

Before this patch:

    go test -v -run TestErrorInterfaces
    === RUN   TestErrorInterfaces
    --- PASS: TestErrorInterfaces (0.00s)
    PASS
    ok  	github.com/docker/docker/libnetwork	0.013s

After this patch:

    go test -v -run TestErrorInterfaces
    === RUN   TestErrorInterfaces
    --- PASS: TestErrorInterfaces (0.00s)
    PASS
    ok  	github.com/docker/docker/libnetwork	0.013s


**- A picture of a cute animal (not mandatory but encouraged)**

![desktop-wallpaper-see-no-evil-hear-no-evil-speak-no-evil-the-three-wise-monkeys](https://github.com/moby/moby/assets/1804568/b9e5707f-a806-4d2f-9607-b22f1e7642f0)

