### PR TITLE
libnetwork: remove Network interface

### DIFF
--- a/api/server/router/network/backend.go
+++ b/api/server/router/network/backend.go
@@ -12,7 +12,7 @@ import (
 // Backend is all the methods that need to be implemented
 // to provide network specific functionality.
 type Backend interface {
-	FindNetwork(idName string) (libnetwork.Network, error)
+	FindNetwork(idName string) (*libnetwork.Network, error)
 	GetNetworks(filters.Args, types.NetworkListConfig) ([]types.NetworkResource, error)
 	CreateNetwork(nc types.NetworkCreateRequest) (*types.NetworkCreateResponse, error)
 	ConnectContainerToNetwork(containerName, networkName string, endpointConfig *network.EndpointSettings) error

--- a/builder/builder-next/executor_unix.go
+++ b/builder/builder-next/executor_unix.go
@@ -95,7 +95,7 @@ type lnInterface struct {
 	provider *bridgeProvider
 }
 
-func (iface *lnInterface) init(c *libnetwork.Controller, n libnetwork.Network) {
+func (iface *lnInterface) init(c *libnetwork.Controller, n *libnetwork.Network) {
 	defer close(iface.ready)
 	id := identity.NewID()
 

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -35,7 +35,7 @@ import (
 type Backend interface {
 	CreateManagedNetwork(clustertypes.NetworkCreateRequest) error
 	DeleteManagedNetwork(networkID string) error
-	FindNetwork(idName string) (libnetwork.Network, error)
+	FindNetwork(idName string) (*libnetwork.Network, error)
 	SetupIngress(clustertypes.NetworkCreateRequest, string) (<-chan struct{}, error)
 	ReleaseIngress() (<-chan struct{}, error)
 	CreateManagedContainer(ctx context.Context, config types.ContainerCreateConfig) (container.CreateResponse, error)

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -247,7 +247,7 @@ func (daemon *Daemon) buildSandboxOptions(cfg *config.Config, container *contain
 	return sboxOptions, nil
 }
 
-func (daemon *Daemon) updateNetworkSettings(container *container.Container, n libnetwork.Network, endpointConfig *networktypes.EndpointSettings) error {
+func (daemon *Daemon) updateNetworkSettings(container *container.Container, n *libnetwork.Network, endpointConfig *networktypes.EndpointSettings) error {
 	if container.NetworkSettings == nil {
 		container.NetworkSettings = &network.Settings{}
 	}
@@ -293,7 +293,7 @@ func (daemon *Daemon) updateNetworkSettings(container *container.Container, n li
 	return nil
 }
 
-func (daemon *Daemon) updateEndpointNetworkSettings(cfg *config.Config, container *container.Container, n libnetwork.Network, ep *libnetwork.Endpoint) error {
+func (daemon *Daemon) updateEndpointNetworkSettings(cfg *config.Config, container *container.Container, n *libnetwork.Network, ep *libnetwork.Endpoint) error {
 	if err := buildEndpointInfo(container.NetworkSettings, n, ep); err != nil {
 		return err
 	}
@@ -320,7 +320,7 @@ func (daemon *Daemon) updateNetwork(cfg *config.Config, container *container.Con
 	}
 
 	// Find if container is connected to the default bridge network
-	var n libnetwork.Network
+	var n *libnetwork.Network
 	for name, v := range container.NetworkSettings.Networks {
 		sn, err := daemon.FindNetwork(getNetworkID(name, v.EndpointSettings))
 		if err != nil {
@@ -351,7 +351,7 @@ func (daemon *Daemon) updateNetwork(cfg *config.Config, container *container.Con
 	return nil
 }
 
-func (daemon *Daemon) findAndAttachNetwork(container *container.Container, idOrName string, epConfig *networktypes.EndpointSettings) (libnetwork.Network, *networktypes.NetworkingConfig, error) {
+func (daemon *Daemon) findAndAttachNetwork(container *container.Container, idOrName string, epConfig *networktypes.EndpointSettings) (*libnetwork.Network, *networktypes.NetworkingConfig, error) {
 	id := getNetworkID(idOrName, epConfig)
 
 	n, err := daemon.FindNetwork(id)
@@ -451,7 +451,7 @@ func (daemon *Daemon) findAndAttachNetwork(container *container.Container, idOrN
 
 // updateContainerNetworkSettings updates the network settings
 func (daemon *Daemon) updateContainerNetworkSettings(container *container.Container, endpointsConfig map[string]*networktypes.EndpointSettings) {
-	var n libnetwork.Network
+	var n *libnetwork.Network
 
 	mode := container.HostConfig.NetworkMode
 	if container.Config.NetworkDisabled || mode.IsContainer() {
@@ -622,7 +622,7 @@ func hasUserDefinedIPAddress(ipamConfig *networktypes.EndpointIPAMConfig) bool {
 }
 
 // User specified ip address is acceptable only for networks with user specified subnets.
-func validateNetworkingConfig(n libnetwork.Network, epConfig *networktypes.EndpointSettings) error {
+func validateNetworkingConfig(n *libnetwork.Network, epConfig *networktypes.EndpointSettings) error {
 	if n == nil || epConfig == nil {
 		return nil
 	}
@@ -684,7 +684,7 @@ func cleanOperationalData(es *network.EndpointSettings) {
 	}
 }
 
-func (daemon *Daemon) updateNetworkConfig(container *container.Container, n libnetwork.Network, endpointConfig *networktypes.EndpointSettings, updateSettings bool) error {
+func (daemon *Daemon) updateNetworkConfig(container *container.Container, n *libnetwork.Network, endpointConfig *networktypes.EndpointSettings, updateSettings bool) error {
 	if containertypes.NetworkMode(n.Name()).IsUserDefined() {
 		addShortID := true
 		shortID := stringid.TruncateID(container.ID)
@@ -835,7 +835,7 @@ func (daemon *Daemon) connectToNetwork(cfg *config.Config, container *container.
 	return nil
 }
 
-func updateJoinInfo(networkSettings *network.Settings, n libnetwork.Network, ep *libnetwork.Endpoint) error {
+func updateJoinInfo(networkSettings *network.Settings, n *libnetwork.Network, ep *libnetwork.Endpoint) error {
 	if ep == nil {
 		return errors.New("invalid enppoint whhile building portmap info")
 	}
@@ -880,7 +880,7 @@ func (daemon *Daemon) ForceEndpointDelete(name string, networkName string) error
 	return ep.Delete(true)
 }
 
-func (daemon *Daemon) disconnectFromNetwork(container *container.Container, n libnetwork.Network, force bool) error {
+func (daemon *Daemon) disconnectFromNetwork(container *container.Container, n *libnetwork.Network, force bool) error {
 	var (
 		ep   *libnetwork.Endpoint
 		sbox *libnetwork.Sandbox
@@ -932,7 +932,7 @@ func (daemon *Daemon) disconnectFromNetwork(container *container.Container, n li
 	return nil
 }
 
-func (daemon *Daemon) tryDetachContainerFromClusterNetwork(network libnetwork.Network, container *container.Container) {
+func (daemon *Daemon) tryDetachContainerFromClusterNetwork(network *libnetwork.Network, container *container.Container) {
 	if daemon.clusterProvider != nil && network.Info().Dynamic() && !container.Managed {
 		if err := daemon.clusterProvider.DetachNetwork(network.Name(), container.ID); err != nil {
 			log.G(context.TODO()).Warnf("error detaching from network %s: %v", network.Name(), err)
@@ -1018,7 +1018,7 @@ func (daemon *Daemon) releaseNetwork(container *container.Container) {
 		return
 	}
 
-	var networks []libnetwork.Network
+	var networks []*libnetwork.Network
 	for n, epSettings := range settings {
 		if nw, err := daemon.FindNetwork(getNetworkID(n, epSettings.EndpointSettings)); err == nil {
 			networks = append(networks, nw)

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -323,8 +323,8 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 		if networkTypeNorm == "private" || networkTypeNorm == "internal" {
 			continue // workaround for HNS reporting unsupported networks
 		}
-		var n libnetwork.Network
-		s := func(current libnetwork.Network) bool {
+		var n *libnetwork.Network
+		s := func(current *libnetwork.Network) bool {
 			hnsid := current.Info().DriverOptions()[winlibnetwork.HNSID]
 			if hnsid == v.Id {
 				n = current

--- a/daemon/events.go
+++ b/daemon/events.go
@@ -67,12 +67,12 @@ func (daemon *Daemon) LogVolumeEvent(volumeID, action string, attributes map[str
 }
 
 // LogNetworkEvent generates an event related to a network with only the default attributes.
-func (daemon *Daemon) LogNetworkEvent(nw libnetwork.Network, action string) {
+func (daemon *Daemon) LogNetworkEvent(nw *libnetwork.Network, action string) {
 	daemon.LogNetworkEventWithAttributes(nw, action, map[string]string{})
 }
 
 // LogNetworkEventWithAttributes generates an event related to a network with specific given attributes.
-func (daemon *Daemon) LogNetworkEventWithAttributes(nw libnetwork.Network, action string, attributes map[string]string) {
+func (daemon *Daemon) LogNetworkEventWithAttributes(nw *libnetwork.Network, action string, attributes map[string]string) {
 	attributes["name"] = nw.Name()
 	attributes["type"] = nw.Type()
 	actor := events.Actor{

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -61,9 +61,9 @@ func (daemon *Daemon) NetworkController() *libnetwork.Controller {
 // 2. Full Name
 // 3. Partial ID
 // as long as there is no ambiguity
-func (daemon *Daemon) FindNetwork(term string) (libnetwork.Network, error) {
-	listByFullName := []libnetwork.Network{}
-	listByPartialID := []libnetwork.Network{}
+func (daemon *Daemon) FindNetwork(term string) (*libnetwork.Network, error) {
+	listByFullName := []*libnetwork.Network{}
+	listByPartialID := []*libnetwork.Network{}
 	for _, nw := range daemon.getAllNetworks() {
 		if nw.ID() == term {
 			return nw, nil
@@ -94,7 +94,7 @@ func (daemon *Daemon) FindNetwork(term string) (libnetwork.Network, error) {
 
 // GetNetworkByID function returns a network whose ID matches the given ID.
 // It fails with an error if no matching network is found.
-func (daemon *Daemon) GetNetworkByID(id string) (libnetwork.Network, error) {
+func (daemon *Daemon) GetNetworkByID(id string) (*libnetwork.Network, error) {
 	c := daemon.netController
 	if c == nil {
 		return nil, errors.Wrap(libnetwork.ErrNoSuchNetwork(id), "netcontroller is nil")
@@ -104,7 +104,7 @@ func (daemon *Daemon) GetNetworkByID(id string) (libnetwork.Network, error) {
 
 // GetNetworkByName function returns a network for a given network name.
 // If no network name is given, the default network is returned.
-func (daemon *Daemon) GetNetworkByName(name string) (libnetwork.Network, error) {
+func (daemon *Daemon) GetNetworkByName(name string) (*libnetwork.Network, error) {
 	c := daemon.netController
 	if c == nil {
 		return nil, libnetwork.ErrNoSuchNetwork(name)
@@ -116,13 +116,13 @@ func (daemon *Daemon) GetNetworkByName(name string) (libnetwork.Network, error) 
 }
 
 // GetNetworksByIDPrefix returns a list of networks whose ID partially matches zero or more networks
-func (daemon *Daemon) GetNetworksByIDPrefix(partialID string) []libnetwork.Network {
+func (daemon *Daemon) GetNetworksByIDPrefix(partialID string) []*libnetwork.Network {
 	c := daemon.netController
 	if c == nil {
 		return nil
 	}
-	list := []libnetwork.Network{}
-	l := func(nw libnetwork.Network) bool {
+	list := []*libnetwork.Network{}
+	l := func(nw *libnetwork.Network) bool {
 		if strings.HasPrefix(nw.ID(), partialID) {
 			list = append(list, nw)
 		}
@@ -134,7 +134,7 @@ func (daemon *Daemon) GetNetworksByIDPrefix(partialID string) []libnetwork.Netwo
 }
 
 // getAllNetworks returns a list containing all networks
-func (daemon *Daemon) getAllNetworks() []libnetwork.Network {
+func (daemon *Daemon) getAllNetworks() []*libnetwork.Network {
 	c := daemon.netController
 	if c == nil {
 		return nil
@@ -527,7 +527,7 @@ func (daemon *Daemon) DeleteNetwork(networkID string) error {
 	return daemon.deleteNetwork(n, false)
 }
 
-func (daemon *Daemon) deleteNetwork(nw libnetwork.Network, dynamic bool) error {
+func (daemon *Daemon) deleteNetwork(nw *libnetwork.Network, dynamic bool) error {
 	if runconfig.IsPreDefinedNetwork(nw.Name()) && !dynamic {
 		err := fmt.Errorf("%s is a pre-defined network and cannot be removed", nw.Name())
 		return errdefs.Forbidden(err)
@@ -564,9 +564,9 @@ func (daemon *Daemon) GetNetworks(filter filters.Args, config types.NetworkListC
 	networks := daemon.getAllNetworks()
 
 	list := make([]types.NetworkResource, 0, len(networks))
-	var idx map[string]libnetwork.Network
+	var idx map[string]*libnetwork.Network
 	if config.Detailed {
-		idx = make(map[string]libnetwork.Network)
+		idx = make(map[string]*libnetwork.Network)
 	}
 
 	for _, n := range networks {
@@ -594,7 +594,7 @@ func (daemon *Daemon) GetNetworks(filter filters.Args, config types.NetworkListC
 	return list, nil
 }
 
-func buildNetworkResource(nw libnetwork.Network) types.NetworkResource {
+func buildNetworkResource(nw *libnetwork.Network) types.NetworkResource {
 	r := types.NetworkResource{}
 	if nw == nil {
 		return r
@@ -628,7 +628,7 @@ func buildNetworkResource(nw libnetwork.Network) types.NetworkResource {
 	return r
 }
 
-func buildDetailedNetworkResources(r *types.NetworkResource, nw libnetwork.Network, verbose bool) {
+func buildDetailedNetworkResources(r *types.NetworkResource, nw *libnetwork.Network, verbose bool) {
 	if nw == nil {
 		return
 	}
@@ -797,7 +797,7 @@ func (daemon *Daemon) clearAttachableNetworks() {
 }
 
 // buildCreateEndpointOptions builds endpoint options from a given network.
-func buildCreateEndpointOptions(c *container.Container, n libnetwork.Network, epConfig *network.EndpointSettings, sb *libnetwork.Sandbox, daemonDNS []string) ([]libnetwork.EndpointOption, error) {
+func buildCreateEndpointOptions(c *container.Container, n *libnetwork.Network, epConfig *network.EndpointSettings, sb *libnetwork.Sandbox, daemonDNS []string) ([]libnetwork.EndpointOption, error) {
 	var (
 		bindings      = make(nat.PortMap)
 		pbList        []networktypes.PortBinding
@@ -1028,7 +1028,7 @@ func getEndpointPortMapInfo(ep *libnetwork.Endpoint) (nat.PortMap, error) {
 }
 
 // buildEndpointInfo sets endpoint-related fields on container.NetworkSettings based on the provided network and endpoint.
-func buildEndpointInfo(networkSettings *internalnetwork.Settings, n libnetwork.Network, ep *libnetwork.Endpoint) error {
+func buildEndpointInfo(networkSettings *internalnetwork.Settings, n *libnetwork.Network, ep *libnetwork.Endpoint) error {
 	if ep == nil {
 		return errors.New("endpoint cannot be nil")
 	}

--- a/daemon/network_windows.go
+++ b/daemon/network_windows.go
@@ -7,7 +7,7 @@ import (
 )
 
 // getEndpointInNetwork returns the container's endpoint to the provided network.
-func getEndpointInNetwork(name string, n libnetwork.Network) (*libnetwork.Endpoint, error) {
+func getEndpointInNetwork(name string, n *libnetwork.Network) (*libnetwork.Endpoint, error) {
 	endpointName := strings.TrimPrefix(name, "/")
 	return n.EndpointByName(endpointName)
 }

--- a/daemon/prune.go
+++ b/daemon/prune.go
@@ -102,7 +102,7 @@ func (daemon *Daemon) localNetworksPrune(ctx context.Context, pruneFilters filte
 	until, _ := getUntilFromPruneFilters(pruneFilters)
 
 	// When the function returns true, the walk will stop.
-	l := func(nw libnetwork.Network) bool {
+	daemon.netController.WalkNetworks(func(nw *libnetwork.Network) bool {
 		select {
 		case <-ctx.Done():
 			// context cancelled
@@ -131,8 +131,7 @@ func (daemon *Daemon) localNetworksPrune(ctx context.Context, pruneFilters filte
 		}
 		rep.NetworksDeleted = append(rep.NetworksDeleted, nwName)
 		return false
-	}
-	daemon.netController.WalkNetworks(l)
+	})
 	return rep
 }
 

--- a/libnetwork/agent.go
+++ b/libnetwork/agent.go
@@ -436,7 +436,7 @@ type epRecord struct {
 	lbIndex int
 }
 
-func (n *network) Services() map[string]ServiceInfo {
+func (n *Network) Services() map[string]ServiceInfo {
 	eps := make(map[string]epRecord)
 
 	if !n.isClusterEligible() {
@@ -519,14 +519,14 @@ func (n *network) Services() map[string]ServiceInfo {
 	return sinfo
 }
 
-func (n *network) isClusterEligible() bool {
+func (n *Network) isClusterEligible() bool {
 	if n.scope != datastore.SwarmScope || !n.driverIsMultihost() {
 		return false
 	}
 	return n.getController().getAgent() != nil
 }
 
-func (n *network) joinCluster() error {
+func (n *Network) joinCluster() error {
 	if !n.isClusterEligible() {
 		return nil
 	}
@@ -539,7 +539,7 @@ func (n *network) joinCluster() error {
 	return agent.networkDB.JoinNetwork(n.ID())
 }
 
-func (n *network) leaveCluster() error {
+func (n *Network) leaveCluster() error {
 	if !n.isClusterEligible() {
 		return nil
 	}
@@ -743,7 +743,7 @@ func (ep *Endpoint) deleteServiceInfoFromCluster(sb *Sandbox, fullRemove bool, m
 	return nil
 }
 
-func disableServiceInNetworkDB(a *agent, n *network, ep *Endpoint) {
+func disableServiceInNetworkDB(a *agent, n *Network, ep *Endpoint) {
 	var epRec EndpointRecord
 
 	log.G(context.TODO()).Debugf("disableServiceInNetworkDB for %s %s", ep.svcName, ep.ID())
@@ -772,7 +772,7 @@ func disableServiceInNetworkDB(a *agent, n *network, ep *Endpoint) {
 	}
 }
 
-func (n *network) addDriverWatches() {
+func (n *Network) addDriverWatches() {
 	if !n.isClusterEligible() {
 		return
 	}
@@ -808,7 +808,7 @@ func (n *network) addDriverWatches() {
 	}
 }
 
-func (n *network) cancelDriverWatches() {
+func (n *Network) cancelDriverWatches() {
 	if !n.isClusterEligible() {
 		return
 	}
@@ -839,7 +839,7 @@ func (c *Controller) handleTableEvents(ch *events.Channel, fn func(events.Event)
 	}
 }
 
-func (n *network) handleDriverTableEvent(ev events.Event) {
+func (n *Network) handleDriverTableEvent(ev events.Event) {
 	d, err := n.driver(false)
 	if err != nil {
 		log.G(context.TODO()).Errorf("Could not resolve driver %s while handling driver table event: %v", n.networkType, err)

--- a/libnetwork/default_gateway.go
+++ b/libnetwork/default_gateway.go
@@ -162,7 +162,7 @@ func (ep *Endpoint) endpointInGWNetwork() bool {
 
 // Looks for the default gw network and creates it if not there.
 // Parallel executions are serialized.
-func (c *Controller) defaultGwNetwork() (Network, error) {
+func (c *Controller) defaultGwNetwork() (*Network, error) {
 	procGwNetwork <- true
 	defer func() { <-procGwNetwork }()
 

--- a/libnetwork/default_gateway_freebsd.go
+++ b/libnetwork/default_gateway_freebsd.go
@@ -8,6 +8,6 @@ func getPlatformOption() EndpointOption {
 	return nil
 }
 
-func (c *Controller) createGWNetwork() (Network, error) {
+func (c *Controller) createGWNetwork() (*Network, error) {
 	return nil, types.NotImplementedErrorf("default gateway functionality is not implemented in freebsd")
 }

--- a/libnetwork/default_gateway_linux.go
+++ b/libnetwork/default_gateway_linux.go
@@ -13,15 +13,13 @@ func getPlatformOption() EndpointOption {
 	return nil
 }
 
-func (c *Controller) createGWNetwork() (Network, error) {
-	netOption := map[string]string{
-		bridge.BridgeName:         libnGWNetwork,
-		bridge.EnableICC:          strconv.FormatBool(false),
-		bridge.EnableIPMasquerade: strconv.FormatBool(true),
-	}
-
+func (c *Controller) createGWNetwork() (*Network, error) {
 	n, err := c.NewNetwork("bridge", libnGWNetwork, "",
-		NetworkOptionDriverOpts(netOption),
+		NetworkOptionDriverOpts(map[string]string{
+			bridge.BridgeName:         libnGWNetwork,
+			bridge.EnableICC:          strconv.FormatBool(false),
+			bridge.EnableIPMasquerade: strconv.FormatBool(true),
+		}),
 		NetworkOptionEnableIPv6(false),
 	)
 	if err != nil {

--- a/libnetwork/default_gateway_windows.go
+++ b/libnetwork/default_gateway_windows.go
@@ -16,6 +16,6 @@ func getPlatformOption() EndpointOption {
 	return EndpointOptionGeneric(epOption)
 }
 
-func (c *Controller) createGWNetwork() (Network, error) {
+func (c *Controller) createGWNetwork() (*Network, error) {
 	return nil, types.NotImplementedErrorf("default gateway functionality is not implemented in windows")
 }

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -24,7 +24,7 @@ type EndpointOption func(ep *Endpoint)
 type Endpoint struct {
 	name              string
 	id                string
-	network           *network
+	network           *Network
 	iface             *endpointInterface
 	joinInfo          *endpointJoinInfo
 	sandboxID         string
@@ -378,14 +378,14 @@ func (ep *Endpoint) processOptions(options ...EndpointOption) {
 	}
 }
 
-func (ep *Endpoint) getNetwork() *network {
+func (ep *Endpoint) getNetwork() *Network {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
 	return ep.network
 }
 
-func (ep *Endpoint) getNetworkFromStore() (*network, error) {
+func (ep *Endpoint) getNetworkFromStore() (*Network, error) {
 	if ep.network == nil {
 		return nil, fmt.Errorf("invalid network object in endpoint %s", ep.Name())
 	}
@@ -932,7 +932,7 @@ func CreateOptionIpam(ipV4, ipV6 net.IP, llIPs []net.IP, ipamOptions map[string]
 }
 
 // CreateOptionExposedPorts function returns an option setter for the container exposed
-// ports option to be passed to network.CreateEndpoint() method.
+// ports option to be passed to [Network.CreateEndpoint] method.
 func CreateOptionExposedPorts(exposedPorts []types.TransportPort) EndpointOption {
 	return func(ep *Endpoint) {
 		// Defensive copy
@@ -945,7 +945,7 @@ func CreateOptionExposedPorts(exposedPorts []types.TransportPort) EndpointOption
 }
 
 // CreateOptionPortMapping function returns an option setter for the mapping
-// ports option to be passed to network.CreateEndpoint() method.
+// ports option to be passed to [Network.CreateEndpoint] method.
 func CreateOptionPortMapping(portBindings []types.PortBinding) EndpointOption {
 	return func(ep *Endpoint) {
 		// Store a copy of the bindings as generic data to pass to the driver

--- a/libnetwork/endpoint_cnt.go
+++ b/libnetwork/endpoint_cnt.go
@@ -9,7 +9,7 @@ import (
 )
 
 type endpointCnt struct {
-	n        *network
+	n        *Network
 	Count    uint64
 	dbIndex  uint64
 	dbExists bool

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestNetworkMarshalling(t *testing.T) {
-	n := &network{
+	n := &Network{
 		name:        "Miao",
 		id:          "abccba",
 		ipamType:    "default",
@@ -128,7 +128,7 @@ func TestNetworkMarshalling(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	nn := &network{}
+	nn := &Network{}
 	err = json.Unmarshal(b, nn)
 	if err != nil {
 		t.Fatal(err)
@@ -319,7 +319,7 @@ func TestAuxAddresses(t *testing.T) {
 	}
 	defer c.Stop()
 
-	n := &network{ipamType: ipamapi.DefaultIPAM, networkType: "bridge", ctrlr: c}
+	n := &Network{ipamType: ipamapi.DefaultIPAM, networkType: "bridge", ctrlr: c}
 
 	input := []struct {
 		masterPool   string
@@ -486,12 +486,12 @@ func TestServiceVIPReuse(t *testing.T) {
 	}
 
 	// Add 2 services with same name but different service ID to share the same VIP
-	n.(*network).addSvcRecords("ep1", "service_test", "serviceID1", net.ParseIP("192.168.0.1"), net.IP{}, true, "test")
-	n.(*network).addSvcRecords("ep2", "service_test", "serviceID2", net.ParseIP("192.168.0.1"), net.IP{}, true, "test")
+	n.addSvcRecords("ep1", "service_test", "serviceID1", net.ParseIP("192.168.0.1"), net.IP{}, true, "test")
+	n.addSvcRecords("ep2", "service_test", "serviceID2", net.ParseIP("192.168.0.1"), net.IP{}, true, "test")
 
 	ipToResolve := netutils.ReverseIP("192.168.0.1")
 
-	ipList, _ := n.(*network).ResolveName("service_test", types.IPv4)
+	ipList, _ := n.ResolveName("service_test", types.IPv4)
 	if len(ipList) == 0 {
 		t.Fatal("There must be the VIP")
 	}
@@ -501,7 +501,7 @@ func TestServiceVIPReuse(t *testing.T) {
 	if ipList[0].String() != "192.168.0.1" {
 		t.Fatal("The service VIP is 192.168.0.1")
 	}
-	name := n.(*network).ResolveIP(ipToResolve)
+	name := n.ResolveIP(ipToResolve)
 	if name == "" {
 		t.Fatal("It must return a name")
 	}
@@ -510,8 +510,8 @@ func TestServiceVIPReuse(t *testing.T) {
 	}
 
 	// Delete service record for one of the services, the IP should remain because one service is still associated with it
-	n.(*network).deleteSvcRecords("ep1", "service_test", "serviceID1", net.ParseIP("192.168.0.1"), net.IP{}, true, "test")
-	ipList, _ = n.(*network).ResolveName("service_test", types.IPv4)
+	n.deleteSvcRecords("ep1", "service_test", "serviceID1", net.ParseIP("192.168.0.1"), net.IP{}, true, "test")
+	ipList, _ = n.ResolveName("service_test", types.IPv4)
 	if len(ipList) == 0 {
 		t.Fatal("There must be the VIP")
 	}
@@ -521,7 +521,7 @@ func TestServiceVIPReuse(t *testing.T) {
 	if ipList[0].String() != "192.168.0.1" {
 		t.Fatal("The service VIP is 192.168.0.1")
 	}
-	name = n.(*network).ResolveIP(ipToResolve)
+	name = n.ResolveIP(ipToResolve)
 	if name == "" {
 		t.Fatal("It must return a name")
 	}
@@ -530,8 +530,8 @@ func TestServiceVIPReuse(t *testing.T) {
 	}
 
 	// Delete again the service using the previous service ID, nothing should happen
-	n.(*network).deleteSvcRecords("ep2", "service_test", "serviceID1", net.ParseIP("192.168.0.1"), net.IP{}, true, "test")
-	ipList, _ = n.(*network).ResolveName("service_test", types.IPv4)
+	n.deleteSvcRecords("ep2", "service_test", "serviceID1", net.ParseIP("192.168.0.1"), net.IP{}, true, "test")
+	ipList, _ = n.ResolveName("service_test", types.IPv4)
 	if len(ipList) == 0 {
 		t.Fatal("There must be the VIP")
 	}
@@ -541,7 +541,7 @@ func TestServiceVIPReuse(t *testing.T) {
 	if ipList[0].String() != "192.168.0.1" {
 		t.Fatal("The service VIP is 192.168.0.1")
 	}
-	name = n.(*network).ResolveIP(ipToResolve)
+	name = n.ResolveIP(ipToResolve)
 	if name == "" {
 		t.Fatal("It must return a name")
 	}
@@ -550,12 +550,12 @@ func TestServiceVIPReuse(t *testing.T) {
 	}
 
 	// Delete now using the second service ID, now all the entries should be gone
-	n.(*network).deleteSvcRecords("ep2", "service_test", "serviceID2", net.ParseIP("192.168.0.1"), net.IP{}, true, "test")
-	ipList, _ = n.(*network).ResolveName("service_test", types.IPv4)
+	n.deleteSvcRecords("ep2", "service_test", "serviceID2", net.ParseIP("192.168.0.1"), net.IP{}, true, "test")
+	ipList, _ = n.ResolveName("service_test", types.IPv4)
 	if len(ipList) != 0 {
 		t.Fatal("All the VIPs should be gone now")
 	}
-	name = n.(*network).ResolveIP(ipToResolve)
+	name = n.ResolveIP(ipToResolve)
 	if name != "" {
 		t.Fatalf("It must return empty no more services associated, instead:%s", name)
 	}

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -31,7 +31,7 @@ const (
 	bridgeNetType = "bridge"
 )
 
-func makeTesthostNetwork(t *testing.T, c *libnetwork.Controller) libnetwork.Network {
+func makeTesthostNetwork(t *testing.T, c *libnetwork.Controller) *libnetwork.Network {
 	t.Helper()
 	n, err := createTestNetwork(c, "host", "testhost", options.Generic{}, nil, nil)
 	if err != nil {
@@ -847,7 +847,7 @@ func TestResolvConf(t *testing.T) {
 type parallelTester struct {
 	osctx      *testutils.OSContext
 	controller *libnetwork.Controller
-	net1, net2 libnetwork.Network
+	net1, net2 *libnetwork.Network
 	iterCnt    int
 }
 

--- a/libnetwork/libnetwork_test.go
+++ b/libnetwork/libnetwork_test.go
@@ -47,7 +47,7 @@ func newController(t *testing.T) *libnetwork.Controller {
 	return c
 }
 
-func createTestNetwork(c *libnetwork.Controller, networkType, networkName string, netOption options.Generic, ipamV4Configs, ipamV6Configs []*libnetwork.IpamConf) (libnetwork.Network, error) {
+func createTestNetwork(c *libnetwork.Controller, networkType, networkName string, netOption options.Generic, ipamV4Configs, ipamV6Configs []*libnetwork.IpamConf) (*libnetwork.Network, error) {
 	return c.NewNetwork(networkType, networkName, "",
 		libnetwork.NetworkOptionGeneric(netOption),
 		libnetwork.NetworkOptionIpam(ipamapi.DefaultIPAM, "", ipamV4Configs, ipamV6Configs, nil))
@@ -549,8 +549,8 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 
 	// Test Network Walk method
 	var netName string
-	var netWanted libnetwork.Network
-	nwWlk := func(nw libnetwork.Network) bool {
+	var netWanted *libnetwork.Network
+	nwWlk := func(nw *libnetwork.Network) bool {
 		if nw.Name() == netName {
 			netWanted = nw
 			return true

--- a/libnetwork/network_unix.go
+++ b/libnetwork/network_unix.go
@@ -6,7 +6,7 @@ import "github.com/docker/docker/libnetwork/ipamapi"
 
 // Stub implementations for DNS related functions
 
-func (n *network) startResolver() {
+func (n *Network) startResolver() {
 }
 
 func defaultIpamForNetworkType(networkType string) string {

--- a/libnetwork/network_windows.go
+++ b/libnetwork/network_windows.go
@@ -28,7 +28,7 @@ func executeInCompartment(compartmentID uint32, x func()) {
 	x()
 }
 
-func (n *network) startResolver() {
+func (n *Network) startResolver() {
 	if n.networkType == "ics" {
 		return
 	}

--- a/libnetwork/resolver_test.go
+++ b/libnetwork/resolver_test.go
@@ -139,7 +139,7 @@ func TestDNSIPQuery(t *testing.T) {
 	}
 
 	// add service records which are used to resolve names. These are the real targets for the DNS querries
-	n.(*network).addSvcRecords("ep1", "name1", "svc1", net.ParseIP("192.168.0.1"), net.IP{}, true, "test")
+	n.addSvcRecords("ep1", "name1", "svc1", net.ParseIP("192.168.0.1"), net.IP{}, true, "test")
 
 	w := new(tstwriter)
 	// the unit tests right now will focus on non-proxyed DNS requests

--- a/libnetwork/sandbox_store.go
+++ b/libnetwork/sandbox_store.go
@@ -234,7 +234,7 @@ func (c *Controller) sandboxCleanup(activeSandboxes map[string]interface{}) {
 			var ep *Endpoint
 			if err != nil {
 				log.G(context.TODO()).Errorf("getNetworkFromStore for nid %s failed while trying to build sandbox for cleanup: %v", eps.Nid, err)
-				n = &network{id: eps.Nid, ctrlr: c, drvOnce: &sync.Once{}, persist: true}
+				n = &Network{id: eps.Nid, ctrlr: c, drvOnce: &sync.Once{}, persist: true}
 				ep = &Endpoint{id: eps.Eid, network: n, sandboxID: sbs.ID}
 			} else {
 				ep, err = n.getEndpointFromStore(eps.Eid)

--- a/libnetwork/sandbox_test.go
+++ b/libnetwork/sandbox_test.go
@@ -14,7 +14,7 @@ import (
 	"gotest.tools/v3/skip"
 )
 
-func getTestEnv(t *testing.T, opts ...[]NetworkOption) (*Controller, []Network) {
+func getTestEnv(t *testing.T, opts ...[]NetworkOption) (*Controller, []*Network) {
 	skip.If(t, runtime.GOOS == "windows", "test only works on linux")
 
 	const netType = "bridge"
@@ -33,7 +33,7 @@ func getTestEnv(t *testing.T, opts ...[]NetworkOption) (*Controller, []Network) 
 		return c, nil
 	}
 
-	nwList := make([]Network, 0, len(opts))
+	nwList := make([]*Network, 0, len(opts))
 	for i, opt := range opts {
 		name := "test_nw_" + strconv.Itoa(i)
 		newOptions := []NetworkOption{

--- a/libnetwork/service_common.go
+++ b/libnetwork/service_common.go
@@ -31,23 +31,23 @@ func (c *Controller) addEndpointNameResolution(svcName, svcID, nID, eID, contain
 	}
 
 	// Add endpoint IP to special "tasks.svc_name" so that the applications have access to DNS RR.
-	n.(*network).addSvcRecords(eID, "tasks."+svcName, serviceID, ip, nil, false, method)
+	n.addSvcRecords(eID, "tasks."+svcName, serviceID, ip, nil, false, method)
 	for _, alias := range serviceAliases {
-		n.(*network).addSvcRecords(eID, "tasks."+alias, serviceID, ip, nil, false, method)
+		n.addSvcRecords(eID, "tasks."+alias, serviceID, ip, nil, false, method)
 	}
 
 	// Add service name to vip in DNS, if vip is valid. Otherwise resort to DNS RR
 	if len(vip) == 0 {
-		n.(*network).addSvcRecords(eID, svcName, serviceID, ip, nil, false, method)
+		n.addSvcRecords(eID, svcName, serviceID, ip, nil, false, method)
 		for _, alias := range serviceAliases {
-			n.(*network).addSvcRecords(eID, alias, serviceID, ip, nil, false, method)
+			n.addSvcRecords(eID, alias, serviceID, ip, nil, false, method)
 		}
 	}
 
 	if addService && len(vip) != 0 {
-		n.(*network).addSvcRecords(eID, svcName, serviceID, vip, nil, false, method)
+		n.addSvcRecords(eID, svcName, serviceID, vip, nil, false, method)
 		for _, alias := range serviceAliases {
-			n.(*network).addSvcRecords(eID, alias, serviceID, vip, nil, false, method)
+			n.addSvcRecords(eID, alias, serviceID, vip, nil, false, method)
 		}
 	}
 
@@ -62,11 +62,11 @@ func (c *Controller) addContainerNameResolution(nID, eID, containerName string, 
 	log.G(context.TODO()).Debugf("addContainerNameResolution %s %s", eID, containerName)
 
 	// Add resolution for container name
-	n.(*network).addSvcRecords(eID, containerName, eID, ip, nil, true, method)
+	n.addSvcRecords(eID, containerName, eID, ip, nil, true, method)
 
 	// Add resolution for taskaliases
 	for _, alias := range taskAliases {
-		n.(*network).addSvcRecords(eID, alias, eID, ip, nil, false, method)
+		n.addSvcRecords(eID, alias, eID, ip, nil, false, method)
 	}
 
 	return nil
@@ -93,25 +93,25 @@ func (c *Controller) deleteEndpointNameResolution(svcName, svcID, nID, eID, cont
 
 	// Delete the special "tasks.svc_name" backend record.
 	if !multipleEntries {
-		n.(*network).deleteSvcRecords(eID, "tasks."+svcName, serviceID, ip, nil, false, method)
+		n.deleteSvcRecords(eID, "tasks."+svcName, serviceID, ip, nil, false, method)
 		for _, alias := range serviceAliases {
-			n.(*network).deleteSvcRecords(eID, "tasks."+alias, serviceID, ip, nil, false, method)
+			n.deleteSvcRecords(eID, "tasks."+alias, serviceID, ip, nil, false, method)
 		}
 	}
 
 	// If we are doing DNS RR delete the endpoint IP from DNS record right away.
 	if !multipleEntries && len(vip) == 0 {
-		n.(*network).deleteSvcRecords(eID, svcName, serviceID, ip, nil, false, method)
+		n.deleteSvcRecords(eID, svcName, serviceID, ip, nil, false, method)
 		for _, alias := range serviceAliases {
-			n.(*network).deleteSvcRecords(eID, alias, serviceID, ip, nil, false, method)
+			n.deleteSvcRecords(eID, alias, serviceID, ip, nil, false, method)
 		}
 	}
 
 	// Remove the DNS record for VIP only if we are removing the service
 	if rmService && len(vip) != 0 && !multipleEntries {
-		n.(*network).deleteSvcRecords(eID, svcName, serviceID, vip, nil, false, method)
+		n.deleteSvcRecords(eID, svcName, serviceID, vip, nil, false, method)
 		for _, alias := range serviceAliases {
-			n.(*network).deleteSvcRecords(eID, alias, serviceID, vip, nil, false, method)
+			n.deleteSvcRecords(eID, alias, serviceID, vip, nil, false, method)
 		}
 	}
 
@@ -126,11 +126,11 @@ func (c *Controller) delContainerNameResolution(nID, eID, containerName string, 
 	log.G(context.TODO()).Debugf("delContainerNameResolution %s %s", eID, containerName)
 
 	// Delete resolution for container name
-	n.(*network).deleteSvcRecords(eID, containerName, eID, ip, nil, true, method)
+	n.deleteSvcRecords(eID, containerName, eID, ip, nil, true, method)
 
 	// Delete resolution for taskaliases
 	for _, alias := range taskAliases {
-		n.(*network).deleteSvcRecords(eID, alias, eID, ip, nil, true, method)
+		n.deleteSvcRecords(eID, alias, eID, ip, nil, true, method)
 	}
 
 	return nil
@@ -299,7 +299,7 @@ func (c *Controller) addServiceBinding(svcName, svcID, nID, eID, containerName s
 	}
 
 	// Add loadbalancer service and backend to the network
-	n.(*network).addLBBackend(ip, lb)
+	n.addLBBackend(ip, lb)
 
 	// Add the appropriate name resolutions
 	if err := c.addEndpointNameResolution(svcName, svcID, nID, eID, containerName, vip, serviceAliases, taskAliases, ip, addService, "addServiceBinding"); err != nil {
@@ -382,7 +382,7 @@ func (c *Controller) rmServiceBinding(svcName, svcID, nID, eID, containerName st
 		// removing the network from the store or dataplane.
 		n, err := c.NetworkByID(nID)
 		if err == nil {
-			n.(*network).rmLBBackend(ip, lb, rmService, fullRemove)
+			n.rmLBBackend(ip, lb, rmService, fullRemove)
 		}
 	}
 

--- a/libnetwork/service_common_test.go
+++ b/libnetwork/service_common_test.go
@@ -20,7 +20,7 @@ func TestCleanupServiceDiscovery(t *testing.T) {
 	assert.NilError(t, err)
 	defer c.Stop()
 
-	cleanup := func(n Network) {
+	cleanup := func(n *Network) {
 		if err := n.Delete(); err != nil {
 			t.Error(err)
 		}
@@ -33,11 +33,11 @@ func TestCleanupServiceDiscovery(t *testing.T) {
 	assert.NilError(t, err)
 	defer cleanup(n2)
 
-	n1.(*network).addSvcRecords("N1ep1", "service_test", "serviceID1", net.ParseIP("192.168.0.1"), net.IP{}, true, "test")
-	n1.(*network).addSvcRecords("N2ep2", "service_test", "serviceID2", net.ParseIP("192.168.0.2"), net.IP{}, true, "test")
+	n1.addSvcRecords("N1ep1", "service_test", "serviceID1", net.ParseIP("192.168.0.1"), net.IP{}, true, "test")
+	n1.addSvcRecords("N2ep2", "service_test", "serviceID2", net.ParseIP("192.168.0.2"), net.IP{}, true, "test")
 
-	n2.(*network).addSvcRecords("N2ep1", "service_test", "serviceID1", net.ParseIP("192.168.1.1"), net.IP{}, true, "test")
-	n2.(*network).addSvcRecords("N2ep2", "service_test", "serviceID2", net.ParseIP("192.168.1.2"), net.IP{}, true, "test")
+	n2.addSvcRecords("N2ep1", "service_test", "serviceID1", net.ParseIP("192.168.1.1"), net.IP{}, true, "test")
+	n2.addSvcRecords("N2ep2", "service_test", "serviceID2", net.ParseIP("192.168.1.2"), net.IP{}, true, "test")
 
 	if len(c.svcRecords) != 2 {
 		t.Fatalf("Service record not added correctly:%v", c.svcRecords)

--- a/libnetwork/service_linux.go
+++ b/libnetwork/service_linux.go
@@ -38,7 +38,7 @@ func (sb *Sandbox) populateLoadBalancers(ep *Endpoint) {
 	}
 }
 
-func (n *network) findLBEndpointSandbox() (*Endpoint, *Sandbox, error) {
+func (n *Network) findLBEndpointSandbox() (*Endpoint, *Sandbox, error) {
 	// TODO: get endpoint from store?  See EndpointInfo()
 	var ep *Endpoint
 	// Find this node's LB sandbox endpoint:  there should be exactly one
@@ -79,7 +79,7 @@ func findIfaceDstName(sb *Sandbox, ep *Endpoint) string {
 
 // Add loadbalancer backend to the loadbalncer sandbox for the network.
 // If needed add the service as well.
-func (n *network) addLBBackend(ip net.IP, lb *loadBalancer) {
+func (n *Network) addLBBackend(ip net.IP, lb *loadBalancer) {
 	if len(lb.vip) == 0 {
 		return
 	}
@@ -168,7 +168,7 @@ func (n *network) addLBBackend(ip net.IP, lb *loadBalancer) {
 // network. If 'rmService' is true, then remove the service entry as well.
 // If 'fullRemove' is true then completely remove the entry, otherwise
 // just deweight it for now.
-func (n *network) rmLBBackend(ip net.IP, lb *loadBalancer, rmService bool, fullRemove bool) {
+func (n *Network) rmLBBackend(ip net.IP, lb *loadBalancer, rmService bool, fullRemove bool) {
 	if len(lb.vip) == 0 {
 		return
 	}

--- a/libnetwork/service_windows.go
+++ b/libnetwork/service_windows.go
@@ -15,7 +15,7 @@ type policyLists struct {
 
 var lbPolicylistMap = make(map[*loadBalancer]*policyLists)
 
-func (n *network) addLBBackend(ip net.IP, lb *loadBalancer) {
+func (n *Network) addLBBackend(ip net.IP, lb *loadBalancer) {
 	if len(lb.vip) == 0 {
 		return
 	}
@@ -117,7 +117,7 @@ func (n *network) addLBBackend(ip net.IP, lb *loadBalancer) {
 	}
 }
 
-func (n *network) rmLBBackend(ip net.IP, lb *loadBalancer, rmService bool, fullRemove bool) {
+func (n *Network) rmLBBackend(ip net.IP, lb *loadBalancer, rmService bool, fullRemove bool) {
 	if len(lb.vip) == 0 {
 		return
 	}

--- a/libnetwork/store.go
+++ b/libnetwork/store.go
@@ -46,7 +46,7 @@ func (c *Controller) getStore() datastore.DataStore {
 	return c.store
 }
 
-func (c *Controller) getNetworkFromStore(nid string) (*network, error) {
+func (c *Controller) getNetworkFromStore(nid string) (*Network, error) {
 	for _, n := range c.getNetworksFromStore() {
 		if n.id == nid {
 			return n, nil
@@ -55,8 +55,8 @@ func (c *Controller) getNetworkFromStore(nid string) (*network, error) {
 	return nil, ErrNoSuchNetwork(nid)
 }
 
-func (c *Controller) getNetworks() ([]*network, error) {
-	var nl []*network
+func (c *Controller) getNetworks() ([]*Network, error) {
+	var nl []*Network
 
 	store := c.getStore()
 	if store == nil {
@@ -64,13 +64,13 @@ func (c *Controller) getNetworks() ([]*network, error) {
 	}
 
 	kvol, err := store.List(datastore.Key(datastore.NetworkKeyPrefix),
-		&network{ctrlr: c})
+		&Network{ctrlr: c})
 	if err != nil && err != datastore.ErrKeyNotFound {
 		return nil, fmt.Errorf("failed to get networks: %w", err)
 	}
 
 	for _, kvo := range kvol {
-		n := kvo.(*network)
+		n := kvo.(*Network)
 		n.ctrlr = c
 
 		ec := &endpointCnt{n: n}
@@ -90,11 +90,11 @@ func (c *Controller) getNetworks() ([]*network, error) {
 	return nl, nil
 }
 
-func (c *Controller) getNetworksFromStore() []*network { // FIXME: unify with c.getNetworks()
-	var nl []*network
+func (c *Controller) getNetworksFromStore() []*Network { // FIXME: unify with c.getNetworks()
+	var nl []*Network
 
 	store := c.getStore()
-	kvol, err := store.List(datastore.Key(datastore.NetworkKeyPrefix), &network{ctrlr: c})
+	kvol, err := store.List(datastore.Key(datastore.NetworkKeyPrefix), &Network{ctrlr: c})
 	if err != nil {
 		if err != datastore.ErrKeyNotFound {
 			log.G(context.TODO()).Debugf("failed to get networks from store: %v", err)
@@ -108,7 +108,7 @@ func (c *Controller) getNetworksFromStore() []*network { // FIXME: unify with c.
 	}
 
 	for _, kvo := range kvol {
-		n := kvo.(*network)
+		n := kvo.(*Network)
 		n.mu.Lock()
 		n.ctrlr = c
 		ec := &endpointCnt{n: n}
@@ -128,7 +128,7 @@ func (c *Controller) getNetworksFromStore() []*network { // FIXME: unify with c.
 	return nl
 }
 
-func (n *network) getEndpointFromStore(eid string) (*Endpoint, error) {
+func (n *Network) getEndpointFromStore(eid string) (*Endpoint, error) {
 	store := n.ctrlr.getStore()
 	ep := &Endpoint{id: eid, network: n}
 	err := store.GetObject(datastore.Key(ep.Key()...), ep)
@@ -138,7 +138,7 @@ func (n *network) getEndpointFromStore(eid string) (*Endpoint, error) {
 	return ep, nil
 }
 
-func (n *network) getEndpointsFromStore() ([]*Endpoint, error) {
+func (n *Network) getEndpointsFromStore() ([]*Endpoint, error) {
 	var epl []*Endpoint
 
 	tmp := Endpoint{network: n}
@@ -332,8 +332,8 @@ func (c *Controller) networkCleanup() {
 	}
 }
 
-var populateSpecial NetworkWalker = func(nw Network) bool {
-	if n := nw.(*network); n.hasSpecialDriver() && !n.ConfigOnly() {
+var populateSpecial NetworkWalker = func(nw *Network) bool {
+	if n := nw; n.hasSpecialDriver() && !n.ConfigOnly() {
 		if err := n.getController().addNetwork(n); err != nil {
 			log.G(context.TODO()).Warnf("Failed to populate network %q with driver %q", nw.Name(), nw.Type())
 		}


### PR DESCRIPTION
There's only one implementation; drop the interface and use the concrete type instead.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

