### PR TITLE
libnetwork/ipam: assorted cleanup and refactor

### DIFF
--- a/libnetwork/ipam/allocator.go
+++ b/libnetwork/ipam/allocator.go
@@ -67,8 +67,8 @@ func (a *Allocator) GetDefaultAddressSpaces() (string, string, error) {
 // If pool is the empty string then the default predefined pool for addressSpace will be used, otherwise pool must be a valid IP address and length in CIDR notation.
 // If subPool is not empty, it must be a valid IP address and length in CIDR notation which is a sub-range of pool.
 // subPool must be empty if pool is empty.
-func (a *Allocator) RequestPool(addressSpace, pool, subPool string, options map[string]string, v6 bool) (string, *net.IPNet, map[string]string, error) {
-	log.G(context.TODO()).Debugf("RequestPool(%s, %s, %s, %v, %t)", addressSpace, pool, subPool, options, v6)
+func (a *Allocator) RequestPool(addressSpace, pool, subPool string, _ map[string]string, v6 bool) (string, *net.IPNet, map[string]string, error) {
+	log.G(context.TODO()).Debugf("RequestPool(%s, %s, %s, _, %t)", addressSpace, pool, subPool, v6)
 
 	parseErr := func(err error) error {
 		return types.InternalErrorf("failed to parse pool request for address space %q pool %q subpool %q: %v", addressSpace, pool, subPool, err)

--- a/libnetwork/ipam/allocator.go
+++ b/libnetwork/ipam/allocator.go
@@ -117,8 +117,8 @@ func (a *Allocator) RequestPool(addressSpace, requestedPool, requestedSubPool st
 // ReleasePool releases the address pool identified by the passed id
 func (a *Allocator) ReleasePool(poolID string) error {
 	log.G(context.TODO()).Debugf("ReleasePool(%s)", poolID)
-	k := PoolID{}
-	if err := k.FromString(poolID); err != nil {
+	k, err := PoolIDFromString(poolID)
+	if err != nil {
 		return types.BadRequestErrorf("invalid pool id: %s", poolID)
 	}
 
@@ -226,8 +226,8 @@ func (aSpace *addrSpace) allocatePredefinedPool(ipV6 bool) (netip.Prefix, error)
 // RequestAddress returns an address from the specified pool ID
 func (a *Allocator) RequestAddress(poolID string, prefAddress net.IP, opts map[string]string) (*net.IPNet, map[string]string, error) {
 	log.G(context.TODO()).Debugf("RequestAddress(%s, %v, %v)", poolID, prefAddress, opts)
-	k := PoolID{}
-	if err := k.FromString(poolID); err != nil {
+	k, err := PoolIDFromString(poolID)
+	if err != nil {
 		return nil, nil, types.BadRequestErrorf("invalid pool id: %s", poolID)
 	}
 
@@ -286,8 +286,8 @@ func (aSpace *addrSpace) requestAddress(nw, sub netip.Prefix, prefAddress netip.
 // ReleaseAddress releases the address from the specified pool ID
 func (a *Allocator) ReleaseAddress(poolID string, address net.IP) error {
 	log.G(context.TODO()).Debugf("ReleaseAddress(%s, %v)", poolID, address)
-	k := PoolID{}
-	if err := k.FromString(poolID); err != nil {
+	k, err := PoolIDFromString(poolID)
+	if err != nil {
 		return types.BadRequestErrorf("invalid pool id: %s", poolID)
 	}
 

--- a/libnetwork/ipam/allocator_test.go
+++ b/libnetwork/ipam/allocator_test.go
@@ -1276,3 +1276,14 @@ func TestParallelPredefinedRequest4(t *testing.T) {
 func TestParallelPredefinedRequest5(t *testing.T) {
 	runParallelTests(t, 4)
 }
+
+func BenchmarkPoolIDToString(b *testing.B) {
+	const poolIDString = "default/172.27.0.0/16/172.27.3.0/24"
+	k := PoolID{}
+	_ = k.FromString(poolIDString)
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = k.String()
+	}
+}

--- a/libnetwork/ipam/allocator_test.go
+++ b/libnetwork/ipam/allocator_test.go
@@ -29,8 +29,7 @@ func TestKeyString(t *testing.T) {
 		t.Fatalf("Unexpected key string: %s", k.String())
 	}
 
-	k2 := &PoolID{}
-	err := k2.FromString(expected)
+	k2, err := PoolIDFromString(expected)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,7 +43,7 @@ func TestKeyString(t *testing.T) {
 		t.Fatalf("Unexpected key string: %s", k.String())
 	}
 
-	err = k2.FromString(expected)
+	k2, err = PoolIDFromString(expected)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +132,6 @@ func TestAddReleasePoolID(t *testing.T) {
 	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
 	assert.NilError(t, err)
 
-	var k0, k1 PoolID
 	_, err = a.getAddrSpace(localAddressSpace)
 	if err != nil {
 		t.Fatal(err)
@@ -143,7 +141,8 @@ func TestAddReleasePoolID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected failure in adding pool: %v", err)
 	}
-	if err := k0.FromString(pid0); err != nil {
+	k0, err := PoolIDFromString(pid0)
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -160,7 +159,8 @@ func TestAddReleasePoolID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected failure in adding sub pool: %v", err)
 	}
-	if err := k1.FromString(pid1); err != nil {
+	k1, err := PoolIDFromString(pid1)
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -1279,11 +1279,25 @@ func TestParallelPredefinedRequest5(t *testing.T) {
 
 func BenchmarkPoolIDToString(b *testing.B) {
 	const poolIDString = "default/172.27.0.0/16/172.27.3.0/24"
-	k := PoolID{}
-	_ = k.FromString(poolIDString)
+	k, err := PoolIDFromString(poolIDString)
+	if err != nil {
+		b.Fatal(err)
+	}
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		_ = k.String()
+	}
+}
+
+func BenchmarkPoolIDFromString(b *testing.B) {
+	const poolIDString = "default/172.27.0.0/16/172.27.3.0/24"
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := PoolIDFromString(poolIDString)
+		if err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/libnetwork/ipam/structures.go
+++ b/libnetwork/ipam/structures.go
@@ -45,11 +45,11 @@ type addrSpace struct {
 
 // String returns the string form of the SubnetKey object
 func (s *PoolID) String() string {
-	k := fmt.Sprintf("%s/%s", s.AddressSpace, s.Subnet)
-	if s.ChildSubnet != (netip.Prefix{}) {
-		k = fmt.Sprintf("%s/%s", k, s.ChildSubnet)
+	if s.ChildSubnet == (netip.Prefix{}) {
+		return s.AddressSpace + "/" + s.Subnet.String()
+	} else {
+		return s.AddressSpace + "/" + s.Subnet.String() + "/" + s.ChildSubnet.String()
 	}
-	return k
 }
 
 // FromString populates the SubnetKey object reading it from string

--- a/libnetwork/ipamapi/contract.go
+++ b/libnetwork/ipamapi/contract.go
@@ -51,12 +51,12 @@ type Ipam interface {
 	// GetDefaultAddressSpaces returns the default local and global address spaces for this ipam
 	GetDefaultAddressSpaces() (string, string, error)
 	// RequestPool returns an address pool along with its unique id. Address space is a mandatory field
-	// which denotes a set of non-overlapping pools. pool describes the pool of addresses in CIDR notation.
-	// subpool indicates a smaller range of addresses from the pool, for now it is specified in CIDR notation.
-	// Both pool and subpool are non mandatory fields. When they are not specified, Ipam driver may choose to
+	// which denotes a set of non-overlapping pools. requestedPool describes the pool of addresses in CIDR notation.
+	// requestedSubPool indicates a smaller range of addresses from the pool, for now it is specified in CIDR notation.
+	// Both requestedPool and requestedSubPool are non-mandatory fields. When they are not specified, Ipam driver may choose to
 	// return a self chosen pool for this request. In such case the v6 flag needs to be set appropriately so
 	// that the driver would return the expected ip version pool.
-	RequestPool(addressSpace, pool, subPool string, options map[string]string, v6 bool) (string, *net.IPNet, map[string]string, error)
+	RequestPool(addressSpace, requestedPool, requestedSubPool string, options map[string]string, v6 bool) (poolID string, pool *net.IPNet, meta map[string]string, err error)
 	// ReleasePool releases the address pool identified by the passed id
 	ReleasePool(poolID string) error
 	// RequestAddress request an address from the specified pool ID. Input options or required IP can be passed.

--- a/libnetwork/ipams/null/null.go
+++ b/libnetwork/ipams/null/null.go
@@ -3,27 +3,28 @@
 package null
 
 import (
-	"fmt"
 	"net"
 
 	"github.com/docker/docker/libnetwork/ipamapi"
 	"github.com/docker/docker/libnetwork/types"
 )
 
-var (
-	defaultAS      = "null"
-	defaultPool, _ = types.ParseCIDR("0.0.0.0/0")
-	defaultPoolID  = fmt.Sprintf("%s/%s", defaultAS, defaultPool.String())
+const (
+	defaultAddressSpace = "null"
+	defaultPoolCIDR     = "0.0.0.0/0"
+	defaultPoolID       = defaultAddressSpace + "/" + defaultPoolCIDR
 )
+
+var defaultPool, _ = types.ParseCIDR(defaultPoolCIDR)
 
 type allocator struct{}
 
 func (a *allocator) GetDefaultAddressSpaces() (string, string, error) {
-	return defaultAS, defaultAS, nil
+	return defaultAddressSpace, defaultAddressSpace, nil
 }
 
-func (a *allocator) RequestPool(addressSpace, pool, subPool string, options map[string]string, v6 bool) (string, *net.IPNet, map[string]string, error) {
-	if addressSpace != defaultAS {
+func (a *allocator) RequestPool(addressSpace, pool, subPool string, _ map[string]string, v6 bool) (string, *net.IPNet, map[string]string, error) {
+	if addressSpace != defaultAddressSpace {
 		return "", nil, nil, types.BadRequestErrorf("unknown address space: %s", addressSpace)
 	}
 	if pool != "" {

--- a/libnetwork/ipams/null/null.go
+++ b/libnetwork/ipams/null/null.go
@@ -23,14 +23,14 @@ func (a *allocator) GetDefaultAddressSpaces() (string, string, error) {
 	return defaultAddressSpace, defaultAddressSpace, nil
 }
 
-func (a *allocator) RequestPool(addressSpace, pool, subPool string, _ map[string]string, v6 bool) (string, *net.IPNet, map[string]string, error) {
+func (a *allocator) RequestPool(addressSpace, requestedPool, requestedSubPool string, _ map[string]string, v6 bool) (string, *net.IPNet, map[string]string, error) {
 	if addressSpace != defaultAddressSpace {
 		return "", nil, nil, types.BadRequestErrorf("unknown address space: %s", addressSpace)
 	}
-	if pool != "" {
+	if requestedPool != "" {
 		return "", nil, nil, types.BadRequestErrorf("null ipam driver does not handle specific address pool requests")
 	}
-	if subPool != "" {
+	if requestedSubPool != "" {
 		return "", nil, nil, types.BadRequestErrorf("null ipam driver does not handle specific address subpool requests")
 	}
 	if v6 {

--- a/libnetwork/ipams/null/null_test.go
+++ b/libnetwork/ipams/null/null_test.go
@@ -9,7 +9,7 @@ import (
 func TestPoolRequest(t *testing.T) {
 	a := allocator{}
 
-	pid, pool, _, err := a.RequestPool(defaultAS, "", "", nil, false)
+	pid, pool, _, err := a.RequestPool(defaultAddressSpace, "", "", nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,17 +25,17 @@ func TestPoolRequest(t *testing.T) {
 		t.Fatal("Unexpected success")
 	}
 
-	_, _, _, err = a.RequestPool(defaultAS, "192.168.0.0/16", "", nil, false)
+	_, _, _, err = a.RequestPool(defaultAddressSpace, "192.168.0.0/16", "", nil, false)
 	if err == nil {
 		t.Fatal("Unexpected success")
 	}
 
-	_, _, _, err = a.RequestPool(defaultAS, "", "192.168.0.0/24", nil, false)
+	_, _, _, err = a.RequestPool(defaultAddressSpace, "", "192.168.0.0/24", nil, false)
 	if err == nil {
 		t.Fatal("Unexpected success")
 	}
 
-	_, _, _, err = a.RequestPool(defaultAS, "", "", nil, true)
+	_, _, _, err = a.RequestPool(defaultAddressSpace, "", "", nil, true)
 	if err == nil {
 		t.Fatal("Unexpected success")
 	}

--- a/libnetwork/ipams/remote/remote.go
+++ b/libnetwork/ipams/remote/remote.go
@@ -116,8 +116,8 @@ func (a *allocator) GetDefaultAddressSpaces() (string, string, error) {
 }
 
 // RequestPool requests an address pool in the specified address space
-func (a *allocator) RequestPool(addressSpace, pool, subPool string, options map[string]string, v6 bool) (string, *net.IPNet, map[string]string, error) {
-	req := &api.RequestPoolRequest{AddressSpace: addressSpace, Pool: pool, SubPool: subPool, Options: options, V6: v6}
+func (a *allocator) RequestPool(addressSpace, requestedPool, requestedSubPool string, options map[string]string, v6 bool) (string, *net.IPNet, map[string]string, error) {
+	req := &api.RequestPoolRequest{AddressSpace: addressSpace, Pool: requestedPool, SubPool: requestedSubPool, Options: options, V6: v6}
 	res := &api.RequestPoolResponse{}
 	if err := a.call("RequestPool", req, res); err != nil {
 		return "", nil, nil, err

--- a/libnetwork/ipams/windowsipam/windowsipam.go
+++ b/libnetwork/ipams/windowsipam/windowsipam.go
@@ -32,17 +32,17 @@ func (a *allocator) GetDefaultAddressSpaces() (string, string, error) {
 
 // RequestPool returns an address pool along with its unique id. This is a null ipam driver. It allocates the
 // subnet user asked and does not validate anything. Doesn't support subpool allocation
-func (a *allocator) RequestPool(addressSpace, pool, subPool string, options map[string]string, v6 bool) (string, *net.IPNet, map[string]string, error) {
-	log.G(context.TODO()).Debugf("RequestPool(%s, %s, %s, %v, %t)", addressSpace, pool, subPool, options, v6)
-	if subPool != "" || v6 {
+func (a *allocator) RequestPool(addressSpace, requestedPool, requestedSubPool string, options map[string]string, v6 bool) (string, *net.IPNet, map[string]string, error) {
+	log.G(context.TODO()).Debugf("RequestPool(%s, %s, %s, %v, %t)", addressSpace, requestedPool, requestedSubPool, options, v6)
+	if requestedSubPool != "" || v6 {
 		return "", nil, nil, types.InternalErrorf("This request is not supported by null ipam driver")
 	}
 
 	var ipNet *net.IPNet
 	var err error
 
-	if pool != "" {
-		_, ipNet, err = net.ParseCIDR(pool)
+	if requestedPool != "" {
+		_, ipNet, err = net.ParseCIDR(requestedPool)
 		if err != nil {
 			return "", nil, nil, err
 		}

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1560,14 +1560,6 @@ func (n *Network) requestPoolHelper(ipam ipamapi.Ipam, addressSpace, requestedPo
 		// when we have either obtained a non-overlapping pool or ran out of
 		// pre-defined pools.
 		tmpPoolLeases = append(tmpPoolLeases, poolID)
-
-		// If this is a preferred pool request and the network
-		// is local scope and there is an overlap, we fail the
-		// network creation right here. The pool will be
-		// released in the defer.
-		if requestedPool != "" {
-			return "", nil, nil, fmt.Errorf("requested subnet %s overlaps in the host", requestedPool)
-		}
 	}
 }
 

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1524,16 +1524,16 @@ func (n *Network) ipamAllocate() error {
 	return err
 }
 
-func (n *Network) requestPoolHelper(ipam ipamapi.Ipam, addressSpace, preferredPool, subPool string, options map[string]string, v6 bool) (string, *net.IPNet, map[string]string, error) {
+func (n *Network) requestPoolHelper(ipam ipamapi.Ipam, addressSpace, requestedPool, requestedSubPool string, options map[string]string, v6 bool) (poolID string, pool *net.IPNet, meta map[string]string, err error) {
 	for {
-		poolID, pool, meta, err := ipam.RequestPool(addressSpace, preferredPool, subPool, options, v6)
+		poolID, pool, meta, err = ipam.RequestPool(addressSpace, requestedPool, requestedSubPool, options, v6)
 		if err != nil {
 			return "", nil, nil, err
 		}
 
 		// If the network belongs to global scope or the pool was
 		// explicitly chosen or it is invalid, do not perform the overlap check.
-		if n.Scope() == scope.Global || preferredPool != "" || !types.IsIPNetValid(pool) {
+		if n.Scope() == scope.Global || requestedPool != "" || !types.IsIPNetValid(pool) {
 			return poolID, pool, meta, nil
 		}
 
@@ -1559,8 +1559,8 @@ func (n *Network) requestPoolHelper(ipam ipamapi.Ipam, addressSpace, preferredPo
 		// is local scope and there is an overlap, we fail the
 		// network creation right here. The pool will be
 		// released in the defer.
-		if preferredPool != "" {
-			return "", nil, nil, fmt.Errorf("requested subnet %s overlaps in the host", preferredPool)
+		if requestedPool != "" {
+			return "", nil, nil, fmt.Errorf("requested subnet %s overlaps in the host", requestedPool)
 		}
 	}
 }

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1794,56 +1794,54 @@ func (n *Network) Scope() string {
 	return n.scope
 }
 
-func (n *Network) IpamConfig() (string, map[string]string, []*IpamConf, []*IpamConf) {
+func (n *Network) IpamConfig() (ipamType string, ipamOptions map[string]string, ipamV4Config []*IpamConf, ipamV6Config []*IpamConf) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
-	v4L := make([]*IpamConf, len(n.ipamV4Config))
-	v6L := make([]*IpamConf, len(n.ipamV6Config))
-
+	ipamV4Config = make([]*IpamConf, len(n.ipamV4Config))
 	for i, c := range n.ipamV4Config {
 		cc := &IpamConf{}
 		if err := c.CopyTo(cc); err != nil {
 			log.G(context.TODO()).WithError(err).Error("Error copying ipam ipv4 config")
 		}
-		v4L[i] = cc
+		ipamV4Config[i] = cc
 	}
 
+	ipamV6Config = make([]*IpamConf, len(n.ipamV6Config))
 	for i, c := range n.ipamV6Config {
 		cc := &IpamConf{}
 		if err := c.CopyTo(cc); err != nil {
 			log.G(context.TODO()).WithError(err).Debug("Error copying ipam ipv6 config")
 		}
-		v6L[i] = cc
+		ipamV6Config[i] = cc
 	}
 
-	return n.ipamType, n.ipamOptions, v4L, v6L
+	return n.ipamType, n.ipamOptions, ipamV4Config, ipamV6Config
 }
 
-func (n *Network) IpamInfo() ([]*IpamInfo, []*IpamInfo) {
+func (n *Network) IpamInfo() (ipamV4Info []*IpamInfo, ipamV6Info []*IpamInfo) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
-	v4Info := make([]*IpamInfo, len(n.ipamV4Info))
-	v6Info := make([]*IpamInfo, len(n.ipamV6Info))
-
+	ipamV4Info = make([]*IpamInfo, len(n.ipamV4Info))
 	for i, info := range n.ipamV4Info {
 		ic := &IpamInfo{}
 		if err := info.CopyTo(ic); err != nil {
-			log.G(context.TODO()).WithError(err).Error("Error copying ipv4 ipam config")
+			log.G(context.TODO()).WithError(err).Error("Error copying IPv4 IPAM config")
 		}
-		v4Info[i] = ic
+		ipamV4Info[i] = ic
 	}
 
+	ipamV6Info = make([]*IpamInfo, len(n.ipamV6Info))
 	for i, info := range n.ipamV6Info {
 		ic := &IpamInfo{}
 		if err := info.CopyTo(ic); err != nil {
-			log.G(context.TODO()).WithError(err).Error("Error copying ipv6 ipam config")
+			log.G(context.TODO()).WithError(err).Error("Error copying IPv6 IPAM config")
 		}
-		v6Info[i] = ic
+		ipamV6Info[i] = ic
 	}
 
-	return v4Info, v6Info
+	return ipamV4Info, ipamV6Info
 }
 
 func (n *Network) Internal() bool {


### PR DESCRIPTION
### libnetwork/ipams/null: use consts for fixed values

### libnetwork/ipam: Allocator.RequestPool: make parseErr only handle errors

This makes it slightly more readable to see what's returned in each of
the code-paths. Also move validation of pool/subpool earlier in the
function.

### libnetwork/ipam: Allocator.RequestPool: mark options arg as unused

The options are unused, other than for debug-logging, which made it look
as if they were actually consumed anywhere, but they aren't.

### libnetwork/ipam: Allocator.RequestPool: name args, output vars

network.requestPoolHelper and Allocator.RequestPool have many args and
output vars with generic types. Add names for them to make it easier to
grasp what's what.

### libnetwork/ipam: PoolID.String(): don't use fmt.Sprintf

As this function may be called repeatedly to convert to/from a string,
it may be worth optimizing it a bit. Adding a minimal Benchmark for
it as well.

Before/after:

    BenchmarkPoolIDToString-10   2842830   424.3 ns/op   232 B/op  12 allocs/op
    BenchmarkPoolIDToString-10   7176738   166.8 ns/op   112 B/op   7 allocs/op


libnetwork/ipam: move PoolID.FromString() to a PoolIDFromString() func

This makes it easier to consume, without first having to create an empty
PoolID.

Performance is the same:

    BenchmarkPoolIDFromString-10   6100345   196.5 ns/op  112 B/op   3 allocs/op
    BenchmarkPoolIDFromString-10   6252750   192.0 ns/op  112 B/op   3 allocs/op

Note that I opted not to change the return-type to a pointer, as that seems
to perform less;

    BenchmarkPoolIDFromString-10   6252750   192.0 ns/op  112 B/op   3 allocs/op
    BenchmarkPoolIDFromString-10   5288682   226.6 ns/op  192 B/op   4 allocs/op


### libnetwork: network.IpamConfig, network.IpamInfo: name output vars

Both functions have multiple output vars with generic types, which made
it hard to grasp what's what.


### libnetwork: network.requestPoolHelper: don't defer in a loop

This function intentionally holds a lock / lease on address-pools to
prevent trying the same pool repeatedly.

Let's try to make this logic slightly more transparent, and prevent
defining defers in a loop. Releasing all the pools in a singe defer
also allows us to get the network-name once, which prevents locking
and unlocking the network for each iteration.

### libnetwork: network.requestPoolHelper: remove dead code

This code was only run if no preferred pool was specified, however,
since [libnetwork#1162][2], the function would already return early
if a preferred pools was set (and the overlap check to be skipped),
so this was now just dead code.

[2]: https://github.com/moby/libnetwork/commit/9cc3385f4421ff00a5b7dfc2d9ad44289aa21c85


### libnetwork: network.requestPoolHelper: slightly optimize order of checks

Check the preferredPool first, as other checks could be doing more
(such as locking, or validating / parsing). Also adding a note, as
it's unclear why we're ignoring invalid pools here.

The "invalid" conditions was added in [libnetwork#1095][1], which
moved code to reduce os-specific dependencies in the ipam package,
but also introduced a types.IsIPNetValid() function, which considers
"0.0.0.0/0" invalid, and added it to the condition to return early.

Unfortunately review does not mention this change, so there's no
context why. Possibly this was done to prevent errors further down
the line (when checking for overlaps), but returning an error here
instead would likely have avoided that as well, so we can only guess.

To make this code slightly more transparent, this patch also inlines
the "types.IsIPNetValid" function, as it's not used anywhere else,
and inlining it makes it more visible.

[1]: https://github.com/moby/libnetwork/commit/5ca79d6b87873264516323a7b76f0af7d0298492#diff-bdcd879439d041827d334846f9aba01de6e3683ed8fdd01e63917dae6df23846



**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

