### PR TITLE
daemon: refactor buildNetworkResource

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -593,34 +593,32 @@ func (daemon *Daemon) GetNetworks(filter filters.Args, config types.NetworkListC
 	return networks, nil
 }
 
+// buildNetworkResource builds a [types.NetworkResource] from the given
+// [libnetwork.Network], to be returned by the API.
 func buildNetworkResource(nw *libnetwork.Network) types.NetworkResource {
-	r := types.NetworkResource{}
 	if nw == nil {
-		return r
+		return types.NetworkResource{}
 	}
 
 	info := nw.Info()
-	r.Name = nw.Name()
-	r.ID = nw.ID()
-	r.Created = info.Created()
-	r.Scope = info.Scope()
-	r.Driver = nw.Type()
-	r.EnableIPv6 = info.IPv6Enabled()
-	r.Internal = info.Internal()
-	r.Attachable = info.Attachable()
-	r.Ingress = info.Ingress()
-	r.Options = info.DriverOptions()
-	r.Containers = make(map[string]types.EndpointResource)
-	r.IPAM = buildIPAMResources(info)
-	r.Labels = info.Labels()
-	r.ConfigOnly = info.ConfigOnly()
-	r.Peers = buildPeerInfoResources(info.Peers())
-
-	if cn := info.ConfigFrom(); cn != "" {
-		r.ConfigFrom = network.ConfigReference{Network: cn}
+	return types.NetworkResource{
+		Name:       nw.Name(),
+		ID:         nw.ID(),
+		Created:    info.Created(),
+		Scope:      info.Scope(),
+		Driver:     nw.Type(),
+		EnableIPv6: info.IPv6Enabled(),
+		IPAM:       buildIPAMResources(info),
+		Internal:   info.Internal(),
+		Attachable: info.Attachable(),
+		Ingress:    info.Ingress(),
+		ConfigFrom: network.ConfigReference{Network: info.ConfigFrom()},
+		ConfigOnly: info.ConfigOnly(),
+		Containers: map[string]types.EndpointResource{},
+		Options:    info.DriverOptions(),
+		Labels:     info.Labels(),
+		Peers:      buildPeerInfoResources(info.Peers()),
 	}
-
-	return r
 }
 
 // buildContainerAttachments creates a [types.EndpointResource] map of all

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -615,14 +615,10 @@ func buildNetworkResource(nw *libnetwork.Network) types.NetworkResource {
 	buildIpamResources(&r, info)
 	r.Labels = info.Labels()
 	r.ConfigOnly = info.ConfigOnly()
+	r.Peers = buildPeerInfoResources(info.Peers())
 
 	if cn := info.ConfigFrom(); cn != "" {
 		r.ConfigFrom = network.ConfigReference{Network: cn}
-	}
-
-	peers := info.Peers()
-	if len(peers) != 0 {
-		r.Peers = buildPeerInfoResources(peers)
 	}
 
 	return r
@@ -672,13 +668,16 @@ func buildDetailedNetworkResources(r *types.NetworkResource, nw *libnetwork.Netw
 	}
 }
 
+// buildPeerInfoResources converts a list of [networkdb.PeerInfo] to a
+// [network.PeerInfo] for inclusion in API responses. It returns nil if
+// the list of peers is empty.
 func buildPeerInfoResources(peers []networkdb.PeerInfo) []network.PeerInfo {
+	if len(peers) == 0 {
+		return nil
+	}
 	peerInfo := make([]network.PeerInfo, 0, len(peers))
 	for _, peer := range peers {
-		peerInfo = append(peerInfo, network.PeerInfo{
-			Name: peer.Name,
-			IP:   peer.IP,
-		})
+		peerInfo = append(peerInfo, network.PeerInfo(peer))
 	}
 	return peerInfo
 }


### PR DESCRIPTION
- related to https://github.com/moby/moby/pull/46050

These are all functions to convert from internal types to API types. We can probably move these to the API, but let's first clean them up (also related to https://github.com/moby/moby/pull/46050) 


### daemon: refactor buildPeerInfoResources

Move the length-check into the function, and rename it to toNetworkPeerInfo.


### daemon: refactor buildIpamResources

Make the function return the constructed network.IPAM instead of applying
it to a network struct, and rename it to "buildIPAMResources".

Rewrite the function itself:

- Use struct-literals where possible to make it slightly more readable.
- Use a boolean (hasIPv4Config, hasIPv6Config) for both IPv4 and IPv6 to
  check whether the IPAM-info needs to be added. This makes the logic the
  same for both, and makes the processing order-independent. This also
  allows for the `network.IpamInfo()` call to be skipped if it's not needed.
- Change order of "ipv4 config / ipv4 info" and "ipv6 config / ipv4 info"
  blocks to make it slightly clearer (and to allow skipping the forementioned
  call to `network.IpamInfo()`).


### daemon: refactor buildEndpointResource

- Pass the endpoint and endpoint-info, instead of individual fields from the
  endpoint.
- Remove redundant nil-check, as it's already checked on the call-side
  in `buildDetailedNetworkResources`, which skips endpoints without info.


### daemon: split buildDetailedNetworkResources into two functions

Split the buildDetailedNetworkResources function into separate functions for
collecting container attachments (`buildContainerAttachments`) and service
attachments (`buildServiceAttachments`). This allows us to get rid of the
"verbose" bool, and makes the logic slightly more transparent.


### daemon: refactor buildNetworkResource to use a struct-literal

Now that all helper functions are updated, we can use a struct-literal
for this function, which makes it slightly easier to read.




**- A picture of a cute animal (not mandatory but encouraged)**

