### PR TITLE
api/server/router/network: remove unused Backend.FindNetwork

### DIFF
--- a/api/server/router/network/backend.go
+++ b/api/server/router/network/backend.go
@@ -6,13 +6,11 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
-	"github.com/docker/docker/libnetwork"
 )
 
 // Backend is all the methods that need to be implemented
 // to provide network specific functionality.
 type Backend interface {
-	FindNetwork(idName string) (*libnetwork.Network, error)
 	GetNetworks(filters.Args, types.NetworkListConfig) ([]types.NetworkResource, error)
 	CreateNetwork(nc types.NetworkCreateRequest) (*types.NetworkCreateResponse, error)
 	ConnectContainerToNetwork(containerName, networkName string, endpointConfig *network.EndpointSettings) error


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/35966

This function was used by the postNetworkConnect() handler, but is handled by the backend itself, starting with d63a5a1ff593f14957f3e0a9678633e8237defc9 (https://github.com/moby/moby/pull/35966). Since that commit, this function was no longer used, so we can remove it.

**- A picture of a cute animal (not mandatory but encouraged)**

