### PR TITLE
daemon: cleanup buildCreateEndpointOptions

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -920,10 +920,8 @@ func buildCreateEndpointOptions(c *container.Container, n *libnetwork.Network, e
 			Port:  portNum,
 		})
 
-		pb := networktypes.PortBinding{Port: portNum, Proto: portProto}
 		binding := bindings[port]
 		for i := 0; i < len(binding); i++ {
-			pbCopy := pb.GetCopy()
 			newP, err := nat.NewPort(nat.SplitProtoPort(binding[i].HostPort))
 			var portStart, portEnd int
 			if err == nil {
@@ -932,14 +930,20 @@ func buildCreateEndpointOptions(c *container.Container, n *libnetwork.Network, e
 			if err != nil {
 				return nil, errors.Wrapf(err, "Error parsing HostPort value (%s)", binding[i].HostPort)
 			}
-			pbCopy.HostPort = uint16(portStart)
-			pbCopy.HostPortEnd = uint16(portEnd)
-			pbCopy.HostIP = net.ParseIP(binding[i].HostIP)
-			publishedPorts = append(publishedPorts, pbCopy)
+			publishedPorts = append(publishedPorts, networktypes.PortBinding{
+				Proto:       portProto,
+				Port:        portNum,
+				HostIP:      net.ParseIP(binding[i].HostIP),
+				HostPort:    uint16(portStart),
+				HostPortEnd: uint16(portEnd),
+			})
 		}
 
 		if c.HostConfig.PublishAllPorts && len(binding) == 0 {
-			publishedPorts = append(publishedPorts, pb)
+			publishedPorts = append(publishedPorts, networktypes.PortBinding{
+				Proto: portProto,
+				Port:  portNum,
+			})
 		}
 	}
 

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -61,17 +61,17 @@ func (daemon *Daemon) NetworkController() *libnetwork.Controller {
 // 3. Partial ID
 // as long as there is no ambiguity
 func (daemon *Daemon) FindNetwork(term string) (*libnetwork.Network, error) {
-	listByFullName := []*libnetwork.Network{}
-	listByPartialID := []*libnetwork.Network{}
+	var listByFullName, listByPartialID []*libnetwork.Network
 	for _, nw := range daemon.getAllNetworks() {
-		if nw.ID() == term {
+		nwID := nw.ID()
+		if nwID == term {
 			return nw, nil
-		}
-		if nw.Name() == term {
-			listByFullName = append(listByFullName, nw)
 		}
 		if strings.HasPrefix(nw.ID(), term) {
 			listByPartialID = append(listByPartialID, nw)
+		}
+		if nw.Name() == term {
+			listByFullName = append(listByFullName, nw)
 		}
 	}
 	switch {

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -920,26 +920,25 @@ func buildCreateEndpointOptions(c *container.Container, n *libnetwork.Network, e
 			Port:  portNum,
 		})
 
-		binding := bindings[port]
-		for i := 0; i < len(binding); i++ {
-			newP, err := nat.NewPort(nat.SplitProtoPort(binding[i].HostPort))
+		for _, binding := range bindings[port] {
+			newP, err := nat.NewPort(nat.SplitProtoPort(binding.HostPort))
 			var portStart, portEnd int
 			if err == nil {
 				portStart, portEnd, err = newP.Range()
 			}
 			if err != nil {
-				return nil, errors.Wrapf(err, "Error parsing HostPort value (%s)", binding[i].HostPort)
+				return nil, errors.Wrapf(err, "Error parsing HostPort value (%s)", binding.HostPort)
 			}
 			publishedPorts = append(publishedPorts, networktypes.PortBinding{
 				Proto:       portProto,
 				Port:        portNum,
-				HostIP:      net.ParseIP(binding[i].HostIP),
+				HostIP:      net.ParseIP(binding.HostIP),
 				HostPort:    uint16(portStart),
 				HostPortEnd: uint16(portEnd),
 			})
 		}
 
-		if c.HostConfig.PublishAllPorts && len(binding) == 0 {
+		if c.HostConfig.PublishAllPorts && len(bindings[port]) == 0 {
 			publishedPorts = append(publishedPorts, networktypes.PortBinding{
 				Proto: portProto,
 				Port:  portNum,

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -840,9 +840,11 @@ func buildCreateEndpointOptions(c *container.Container, n *libnetwork.Network, e
 	}
 
 	if svcCfg := c.NetworkSettings.Service; svcCfg != nil {
-		var vip string
-		if svcCfg.VirtualAddresses[n.ID()] != nil {
-			vip = svcCfg.VirtualAddresses[n.ID()].IPv4
+		nwID := n.ID()
+
+		var vip net.IP
+		if virtualAddress := svcCfg.VirtualAddresses[nwID]; virtualAddress != nil {
+			vip = net.ParseIP(virtualAddress.IPv4)
 		}
 
 		var portConfigs []*libnetwork.PortConfig
@@ -855,7 +857,7 @@ func buildCreateEndpointOptions(c *container.Container, n *libnetwork.Network, e
 			})
 		}
 
-		createOptions = append(createOptions, libnetwork.CreateOptionService(svcCfg.Name, svcCfg.ID, net.ParseIP(vip), portConfigs, svcCfg.Aliases[n.ID()]))
+		createOptions = append(createOptions, libnetwork.CreateOptionService(svcCfg.Name, svcCfg.ID, vip, portConfigs, svcCfg.Aliases[nwID]))
 	}
 
 	if !containertypes.NetworkMode(n.Name()).IsUserDefined() {

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -893,9 +893,10 @@ func buildCreateEndpointOptions(c *container.Container, n *libnetwork.Network, e
 		}
 	}
 
-	// Port-mapping rules belong to the container & applicable only to non-internal networks
-	portmaps := getPortMapInfo(sb)
-	if n.Info().Internal() || len(portmaps) > 0 {
+	// Port-mapping rules belong to the container & applicable only to non-internal networks.
+	//
+	// TODO(thaJeztah): Look if we can provide a more minimal function for getPortMapInfo, as it does a lot, and we only need the "length".
+	if n.Info().Internal() || len(getPortMapInfo(sb)) > 0 {
 		return createOptions, nil
 	}
 


### PR DESCRIPTION
### daemon: FindNetwork: minor cleanups

- don't initialize slices; it's not needed to append to them
- store network-ID in a var to prevent repeated lock/unlocking in nw.ID()

### daemon: buildCreateEndpointOptions: skip getPortMapInfo() if not needed

`getPortMapInfo` does many things; it creates a copy of all the sandbox
endpoints, gets the driver, endpoints, and network from store, and creates
port-bindings for all exposed and mapped ports.

We should look if we can create a more minimal implementation for this
purpose, but in the meantime, let's prevent it being called if we don't
need it by making it the second condition in the check.

### daemon: buildCreateEndpointOptions: move vars to where they're used

Move variables closer to where they're used instead of defining them all
at the start of the function.

### daemon: buildCreateEndpointOptions: don't parse empty vip

Also keep network.ID() in a local variable to prevent locking the network
twice.

### daemon: buildCreateEndpointOptions: remove intermediate vars

These were not adding much, so just getting rid of them. Also added a
TODO to move this code to the type.

### daemon: buildCreateEndpointOptions: don't use PortBinding.GetCopy()

This code was initializing a new PortBinding, and creating a deep copy
for each binding. It's unclear what the intent was here, but at least
PortBinding.GetCopy() wasn't adding much value, as it created a new
PortBinding, [copying all values from the original][1], which includes
a [copy of IPAddresses in it][2]. Our original "template" did not have any
of that, so let's forego that, and just create new PortBindings as we go.

[1]: https://github.com/moby/moby/blob/454b6a7cf5187d1153159e5fe07f4b25c7a95e7f/libnetwork/types/types.go#L110-L120
[2]: https://github.com/moby/moby/blob/454b6a7cf5187d1153159e5fe07f4b25c7a95e7f/libnetwork/types/types.go#L236-L244

I wrote a small benchmark to verify that I was not missing something;

    BenchmarkPortBindingCopy-10    166752   6230 ns/op  1600 B/op  100 allocs/op
    BenchmarkPortBindingNoCopy-10  226989   5056 ns/op  1600 B/op  100 allocs/op

Benchmark:

```go
func BenchmarkPortBindingCopy(b *testing.B) {
    pb := PortBinding{Port: 8080, Proto: TCP}

    b.ReportAllocs()
    for i := 0; i < b.N; i++ {
        pbList := make([]PortBinding, 0, 100)
        for i := 0; i < 100; i++ {
            pbCopy := pb.GetCopy()
            pbCopy.HostPort = uint16(i)
            pbCopy.HostPortEnd = uint16(i + 1)
            pbCopy.HostIP = net.ParseIP("127.0.0." + strconv.Itoa(i))
            pbList = append(pbList, pbCopy)
        }
    }
}

func BenchmarkPortBindingNoCopy(b *testing.B) {
    b.ReportAllocs()
    for i := 0; i < b.N; i++ {
        pbList := make([]PortBinding, 0, 100)
        for i := 0; i < 100; i++ {
            pbList = append(pbList, PortBinding{
                Port:        8080,
                Proto:       TCP,
                HostPort:    uint16(i),
                HostPortEnd: uint16(i + 1),
                HostIP:      net.ParseIP("127.0.0." + strconv.Itoa(i)),
            })
        }
    }
}
```

### daemon: buildCreateEndpointOptions: use range when looping

Makes the code slightly more readable.

### daemon: buildCreateEndpointOptions: minor nits

- store network.Name() in a variable to reduce repeatedly locking/unlocking
  of the network (although this is very, very minimal in the grand scheme
  of things).
- un-wrap long conditions
- ever so slightly optimise some conditions by changeing the order of checks.



**- A picture of a cute animal (not mandatory but encouraged)**

