### PR TITLE
daemon: cleanup Daemon.buildSandboxOptions

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -121,26 +121,25 @@ func (daemon *Daemon) buildSandboxOptions(cfg *config.Config, container *contain
 			Port:  portNum,
 		})
 
-		binding := bindings[port]
-		for i := 0; i < len(binding); i++ {
-			newP, err := nat.NewPort(nat.SplitProtoPort(binding[i].HostPort))
+		for _, binding := range bindings[port] {
+			newP, err := nat.NewPort(nat.SplitProtoPort(binding.HostPort))
 			var portStart, portEnd int
 			if err == nil {
 				portStart, portEnd, err = newP.Range()
 			}
 			if err != nil {
-				return nil, fmt.Errorf("Error parsing HostPort value(%s):%v", binding[i].HostPort, err)
+				return nil, fmt.Errorf("Error parsing HostPort value(%s):%v", binding.HostPort, err)
 			}
 			publishedPorts = append(publishedPorts, types.PortBinding{
 				Proto:       portProto,
 				Port:        portNum,
-				HostIP:      net.ParseIP(binding[i].HostIP),
+				HostIP:      net.ParseIP(binding.HostIP),
 				HostPort:    uint16(portStart),
 				HostPortEnd: uint16(portEnd),
 			})
 		}
 
-		if container.HostConfig.PublishAllPorts && len(binding) == 0 {
+		if container.HostConfig.PublishAllPorts && len(bindings[port]) == 0 {
 			publishedPorts = append(publishedPorts, types.PortBinding{
 				Proto: portProto,
 				Port:  portNum,

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -28,18 +28,6 @@ import (
 	"github.com/docker/go-connections/nat"
 )
 
-func (daemon *Daemon) getDNSSearchSettings(cfg *config.Config, container *container.Container) []string {
-	if len(container.HostConfig.DNSSearch) > 0 {
-		return container.HostConfig.DNSSearch
-	}
-
-	if len(cfg.DNSSearch) > 0 {
-		return cfg.DNSSearch
-	}
-
-	return nil
-}
-
 func (daemon *Daemon) buildSandboxOptions(cfg *config.Config, container *container.Container) ([]libnetwork.SandboxOption, error) {
 	var (
 		sboxOptions []libnetwork.SandboxOption
@@ -77,8 +65,12 @@ func (daemon *Daemon) buildSandboxOptions(cfg *config.Config, container *contain
 		sboxOptions = append(sboxOptions, libnetwork.OptionDNS(d))
 	}
 
-	dnsSearch := daemon.getDNSSearchSettings(cfg, container)
-
+	var dnsSearch []string
+	if len(container.HostConfig.DNSSearch) > 0 {
+		dnsSearch = container.HostConfig.DNSSearch
+	} else if len(cfg.DNSSearch) > 0 {
+		dnsSearch = cfg.DNSSearch
+	}
 	for _, ds := range dnsSearch {
 		sboxOptions = append(sboxOptions, libnetwork.OptionDNSSearch(ds))
 	}

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -32,8 +32,6 @@ func (daemon *Daemon) buildSandboxOptions(cfg *config.Config, container *contain
 	var (
 		sboxOptions []libnetwork.SandboxOption
 		err         error
-		dns         []string
-		dnsOptions  []string
 		bindings    = make(nat.PortMap)
 		pbList      []types.PortBinding
 		exposeList  []types.TransportPort
@@ -56,33 +54,19 @@ func (daemon *Daemon) buildSandboxOptions(cfg *config.Config, container *contain
 	}
 
 	if len(container.HostConfig.DNS) > 0 {
-		dns = container.HostConfig.DNS
+		sboxOptions = append(sboxOptions, libnetwork.OptionDNS(container.HostConfig.DNS))
 	} else if len(cfg.DNS) > 0 {
-		dns = cfg.DNS
+		sboxOptions = append(sboxOptions, libnetwork.OptionDNS(cfg.DNS))
 	}
-
-	for _, d := range dns {
-		sboxOptions = append(sboxOptions, libnetwork.OptionDNS(d))
-	}
-
-	var dnsSearch []string
 	if len(container.HostConfig.DNSSearch) > 0 {
-		dnsSearch = container.HostConfig.DNSSearch
+		sboxOptions = append(sboxOptions, libnetwork.OptionDNSSearch(container.HostConfig.DNSSearch))
 	} else if len(cfg.DNSSearch) > 0 {
-		dnsSearch = cfg.DNSSearch
+		sboxOptions = append(sboxOptions, libnetwork.OptionDNSSearch(cfg.DNSSearch))
 	}
-	for _, ds := range dnsSearch {
-		sboxOptions = append(sboxOptions, libnetwork.OptionDNSSearch(ds))
-	}
-
 	if len(container.HostConfig.DNSOptions) > 0 {
-		dnsOptions = container.HostConfig.DNSOptions
+		sboxOptions = append(sboxOptions, libnetwork.OptionDNSOptions(container.HostConfig.DNSOptions))
 	} else if len(cfg.DNSOptions) > 0 {
-		dnsOptions = cfg.DNSOptions
-	}
-
-	for _, ds := range dnsOptions {
-		sboxOptions = append(sboxOptions, libnetwork.OptionDNSOptions(ds))
+		sboxOptions = append(sboxOptions, libnetwork.OptionDNSOptions(cfg.DNSOptions))
 	}
 
 	if container.NetworkSettings.SecondaryIPAddresses != nil {

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -63,7 +63,7 @@ func (daemon *Daemon) buildSandboxOptions(cfg *config.Config, container *contain
 		sboxOptions = append(sboxOptions, libnetwork.OptionUseExternalKey())
 	}
 
-	if err = daemon.setupPathsAndSandboxOptions(container, cfg, &sboxOptions); err != nil {
+	if err = setupPathsAndSandboxOptions(container, cfg, &sboxOptions); err != nil {
 		return nil, err
 	}
 

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -382,7 +382,7 @@ func serviceDiscoveryOnDefaultNetwork() bool {
 	return false
 }
 
-func (daemon *Daemon) setupPathsAndSandboxOptions(container *container.Container, cfg *config.Config, sboxOptions *[]libnetwork.SandboxOption) error {
+func setupPathsAndSandboxOptions(container *container.Container, cfg *config.Config, sboxOptions *[]libnetwork.SandboxOption) error {
 	var err error
 
 	// Set the correct paths for /etc/hosts and /etc/resolv.conf, based on the

--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -163,7 +163,7 @@ func serviceDiscoveryOnDefaultNetwork() bool {
 	return true
 }
 
-func (daemon *Daemon) setupPathsAndSandboxOptions(container *container.Container, cfg *config.Config, sboxOptions *[]libnetwork.SandboxOption) error {
+func setupPathsAndSandboxOptions(container *container.Container, cfg *config.Config, sboxOptions *[]libnetwork.SandboxOption) error {
 	return nil
 }
 

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -112,8 +112,7 @@ func (daemon *Daemon) createSpec(ctx context.Context, daemonCfg *configStore, c 
 		mounts = append(mounts, secretMounts...)
 	}
 
-	configMounts := c.ConfigMounts()
-	if configMounts != nil {
+	if configMounts := c.ConfigMounts(); configMounts != nil {
 		mounts = append(mounts, configMounts...)
 	}
 
@@ -144,8 +143,6 @@ func (daemon *Daemon) createSpec(ctx context.Context, daemonCfg *configStore, c 
 	if err != nil {
 		return nil, errors.Wrapf(err, "container %s", c.ID)
 	}
-
-	dnsSearch := daemon.getDNSSearchSettings(&daemonCfg.Config, c)
 
 	// Get endpoints for the libnetwork allocated networks to the container
 	var epList []string
@@ -195,6 +192,13 @@ func (daemon *Daemon) createSpec(ctx context.Context, daemonCfg *configStore, c 
 
 	if gwHNSID != "" {
 		epList = append(epList, gwHNSID)
+	}
+
+	var dnsSearch []string
+	if len(c.HostConfig.DNSSearch) > 0 {
+		dnsSearch = c.HostConfig.DNSSearch
+	} else if len(daemonCfg.DNSSearch) > 0 {
+		dnsSearch = daemonCfg.DNSSearch
 	}
 
 	s.Windows.Network = &specs.WindowsNetwork{

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -1068,25 +1068,25 @@ func OptionOriginResolvConfPath(path string) SandboxOption {
 
 // OptionDNS function returns an option setter for dns entry option to
 // be passed to container Create method.
-func OptionDNS(dns string) SandboxOption {
+func OptionDNS(dns []string) SandboxOption {
 	return func(sb *Sandbox) {
-		sb.config.dnsList = append(sb.config.dnsList, dns)
+		sb.config.dnsList = dns
 	}
 }
 
 // OptionDNSSearch function returns an option setter for dns search entry option to
 // be passed to container Create method.
-func OptionDNSSearch(search string) SandboxOption {
+func OptionDNSSearch(search []string) SandboxOption {
 	return func(sb *Sandbox) {
-		sb.config.dnsSearchList = append(sb.config.dnsSearchList, search)
+		sb.config.dnsSearchList = search
 	}
 }
 
 // OptionDNSOptions function returns an option setter for dns options entry option to
 // be passed to container Create method.
-func OptionDNSOptions(options string) SandboxOption {
+func OptionDNSOptions(options []string) SandboxOption {
 	return func(sb *Sandbox) {
-		sb.config.dnsOptionsList = append(sb.config.dnsOptionsList, options)
+		sb.config.dnsOptionsList = options
 	}
 }
 


### PR DESCRIPTION
- similar to https://github.com/moby/moby/pull/46055


### daemon: change Daemon.setupPathsAndSandboxOptions to a regular func

It's not using the daemon in any way, so let's change it to a regular
function.

### daemon: inline Daemon.getDNSSearchSettings

This function was created as a "method", but didn't use the Daemon in any
way, and all other options were checked inline, so let's not pretend this
function is more "special" than the other checks, and inline the code.

### libnetwork: make OptionDNS, OptionDNSOptions, OptionDNSSearch take a slice

Outside of some tests, these options are the only code setting these fields,
so we can update them to set the value, instead of appending.

### daemon: Daemon.buildSandboxOptions: move vars to where they're used

Move variables closer to where they're used instead of defining them all
at the start of the function.

Also removing some intermediate variables, unwrapped some lines, and combined
some checks to a single check.

### daemon: Daemon.buildSandboxOptions: remove intermediate vars

These were not adding much, so just getting rid of them. Also added a
TODO to move this code to the type.


### daemon: Daemon.buildSandboxOptions: don't use PortBinding.GetCopy()

This code was initializing a new PortBinding, and creating a deep copy
for each binding. It's unclear what the intent was here, but at least
PortBinding.GetCopy() wasn't adding much value, as it created a new
PortBinding, [copying all values from the original][1], which includes
a [copy of IPAddresses in it][2]. Our original "template" did not have any
of that, so let's forego that, and just create new PortBindings as we go.

[1]: https://github.com/moby/moby/blob/454b6a7cf5187d1153159e5fe07f4b25c7a95e7f/libnetwork/types/types.go#L110-L120
[2]: https://github.com/moby/moby/blob/454b6a7cf5187d1153159e5fe07f4b25c7a95e7f/libnetwork/types/types.go#L236-L244

Benchmarking before/after;

    BenchmarkPortBindingCopy-10    166752   6230 ns/op  1600 B/op  100 allocs/op
    BenchmarkPortBindingNoCopy-10  226989   5056 ns/op  1600 B/op  100 allocs/op


### daemon: Daemon.buildSandboxOptions: use range when looping

Makes the code slightly more readable.

**- A picture of a cute animal (not mandatory but encouraged)**

