### PR TITLE
api/types/network: split EndpointSettings config and operational data

### DIFF
--- a/api/types/network/network.go
+++ b/api/types/network/network.go
@@ -47,12 +47,21 @@ type PeerInfo struct {
 
 // EndpointSettings stores the network endpoint details
 type EndpointSettings struct {
-	// Configurations
+	// Configuration
+	NetworkID  string
 	IPAMConfig *EndpointIPAMConfig
 	Links      []string
 	Aliases    []string
+	DriverOpts map[string]string
+
 	// Operational data
-	NetworkID           string
+	EndpointOperationalData
+}
+
+// EndpointOperationalData is operational data of the endpoint,
+// which can be set and reset at runtime when connecting/disconnecting
+// an endpoint.
+type EndpointOperationalData struct {
 	EndpointID          string
 	Gateway             string
 	IPAddress           string
@@ -61,7 +70,6 @@ type EndpointSettings struct {
 	GlobalIPv6Address   string
 	GlobalIPv6PrefixLen int
 	MacAddress          string
-	DriverOpts          map[string]string
 }
 
 // Task carries the information about one backend task

--- a/container/view.go
+++ b/container/view.go
@@ -368,15 +368,17 @@ func (v *View) transform(container *Container) *Snapshot {
 				continue
 			}
 			networks[name] = &network.EndpointSettings{
-				EndpointID:          netw.EndpointID,
-				Gateway:             netw.Gateway,
-				IPAddress:           netw.IPAddress,
-				IPPrefixLen:         netw.IPPrefixLen,
-				IPv6Gateway:         netw.IPv6Gateway,
-				GlobalIPv6Address:   netw.GlobalIPv6Address,
-				GlobalIPv6PrefixLen: netw.GlobalIPv6PrefixLen,
-				MacAddress:          netw.MacAddress,
-				NetworkID:           netw.NetworkID,
+				NetworkID: netw.NetworkID,
+				EndpointOperationalData: network.EndpointOperationalData{
+					EndpointID:          netw.EndpointID,
+					Gateway:             netw.Gateway,
+					IPAddress:           netw.IPAddress,
+					IPPrefixLen:         netw.IPPrefixLen,
+					IPv6Gateway:         netw.IPv6Gateway,
+					GlobalIPv6Address:   netw.GlobalIPv6Address,
+					GlobalIPv6PrefixLen: netw.GlobalIPv6PrefixLen,
+					MacAddress:          netw.MacAddress,
+				},
 			}
 			if netw.IPAMConfig != nil {
 				networks[name].IPAMConfig = &network.EndpointIPAMConfig{

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -671,6 +671,12 @@ func validateNetworkingConfig(n libnetwork.Network, epConfig *networktypes.Endpo
 
 // cleanOperationalData resets the operational data from the passed endpoint settings
 func cleanOperationalData(es *network.EndpointSettings) {
+	if es.EndpointSettings == nil {
+		// network.EndpointSettings is a wrapper around types.EndpointSettings,
+		// and the fields being cleared are all in that struct, so if it's nil,
+		// there's nothing to do.
+		return
+	}
 	es.EndpointID = ""
 	es.Gateway = ""
 	es.IPAddress = ""
@@ -1023,11 +1029,6 @@ func (daemon *Daemon) releaseNetwork(container *container.Container) {
 		if nw, err := daemon.FindNetwork(getNetworkID(n, epSettings.EndpointSettings)); err == nil {
 			networks = append(networks, nw)
 		}
-
-		if epSettings.EndpointSettings == nil {
-			continue
-		}
-
 		cleanOperationalData(epSettings)
 	}
 

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -677,16 +677,9 @@ func cleanOperationalData(es *network.EndpointSettings) {
 		// there's nothing to do.
 		return
 	}
-	es.EndpointID = ""
-	es.Gateway = ""
-	es.IPAddress = ""
-	es.IPPrefixLen = 0
-	es.IPv6Gateway = ""
-	es.GlobalIPv6Address = ""
-	es.GlobalIPv6PrefixLen = 0
-	es.MacAddress = ""
+	es.EndpointSettings.EndpointOperationalData = networktypes.EndpointOperationalData{}
 	if es.IPAMOperational {
-		es.IPAMConfig = nil
+		es.EndpointSettings.IPAMConfig = nil
 	}
 }
 

--- a/daemon/network/settings.go
+++ b/daemon/network/settings.go
@@ -28,9 +28,9 @@ type Settings struct {
 	HasSwarmEndpoint       bool
 }
 
-// EndpointSettings is a package local wrapper for
-// networktypes.EndpointSettings which stores Endpoint state that
-// needs to be persisted to disk but not exposed in the api.
+// EndpointSettings is a wrapper for [networktypes.EndpointSettings] which
+// stores Endpoint state that needs to be persisted to disk but not exposed
+// in the API.
 type EndpointSettings struct {
 	*networktypes.EndpointSettings
 	IPAMOperational bool


### PR DESCRIPTION
### daemon: Daemon.releaseNetwork move nil-check to cleanOperationalData

network.EndpointSettings is a wrapper around types.EndpointSettings,
and the fields being cleared are all in that struct, so if it's nil,
there's nothing to do.

Making the nil-check a responsibility of the caller didn't make sense,
so let's move it inside that function.

### api/types/network: split EndpointSettings config and operational data

EndpointSettings holds both "Config" data (definition) and runtime ("operational")
data. Fields for the latter one are set/reset at runtime. Resetting is handled
by the `cleanOperationalData` function, but it does so for each field individually.

This handling is slightly brittle, as the `cleanOperationalData` must be
updated when adding new "operational" data, which can easily be overlooked.

This patch updates the EndpointSettings type to split the "config" and
"operational" data into separate structs. The new `EndpointOperationalData`
struct is embedded in the existing type, so the net-result should be the
same for most cases (except for constructing struct-literals).

Resetting the operational data now allows for the `EndpointOperationalData`
to be set to an empty struct (resetting its values to their defaults / empty).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

