### PR TITLE
libnetwork/datastore: prevent data races in Key()

### DIFF
--- a/libnetwork/datastore/datastore.go
+++ b/libnetwork/datastore/datastore.go
@@ -149,9 +149,14 @@ func (cfg *ScopeCfg) IsValid() bool {
 
 // Key provides convenient method to create a Key
 func Key(key ...string) string {
-	keychain := append(rootChain, key...)
-	str := strings.Join(keychain, "/")
-	return str + "/"
+	var b strings.Builder
+	for _, parts := range [][]string{rootChain, key} {
+		for _, part := range parts {
+			b.WriteString(part)
+			b.WriteString("/")
+		}
+	}
+	return b.String()
 }
 
 // ParseKey provides convenient method to unpack the key to complement the Key function


### PR DESCRIPTION
The rootChain variable that the Key function references is a package-global slice. As the append() built-in may append to the slice's backing array in place, it is theoretically possible for the temporary slices in concurrent Key() calls to share the same backing array, which would be a data race. Thankfully in my tests (on Go 1.20.6)

    cap(rootChain) == len(rootChain)

held true, so in practice a new slice is always allocated and there is no race. But that is a very brittle assumption to depend upon, which could blow up in our faces at any time without warning. Rewrite the implementation in a way which cannot lead to data races.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

