### PR TITLE
libnetwork: remove Network.Info() and remove NetworkInfo interface

### DIFF
--- a/daemon/cluster/networks.go
+++ b/daemon/cluster/networks.go
@@ -321,7 +321,7 @@ func (c *Cluster) populateNetworkID(ctx context.Context, client swarmapi.Control
 				}
 				goto setid
 			}
-			if ln != nil && !ln.Info().Dynamic() {
+			if ln != nil && !ln.Dynamic() {
 				errMsg := fmt.Sprintf("The network %s cannot be used with services. Only networks scoped to the swarm can be used, such as those created with the overlay driver.", ln.Name())
 				return errors.WithStack(notAllowedError(errMsg))
 			}

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -232,7 +232,7 @@ func (daemon *Daemon) updateNetworkSettings(container *container.Container, n *l
 			// is an attachable network, which may not
 			// be locally available previously.
 			// So always update.
-			if n.Info().Scope() == scope.Swarm {
+			if n.Scope() == scope.Swarm {
 				continue
 			}
 			// Avoid duplicate config
@@ -327,7 +327,7 @@ func (daemon *Daemon) findAndAttachNetwork(container *container.Container, idOrN
 	// If we found a network and if it is not dynamically created
 	// we should never attempt to attach to that network here.
 	if n != nil {
-		if container.Managed || !n.Info().Dynamic() {
+		if container.Managed || !n.Dynamic() {
 			return n, nil, nil
 		}
 		// Throw an error if the container is already attached to the network
@@ -591,7 +591,7 @@ func validateNetworkingConfig(n *libnetwork.Network, epConfig *networktypes.Endp
 		return nil
 	}
 
-	_, _, nwIPv4Configs, nwIPv6Configs := n.Info().IpamConfig()
+	_, _, nwIPv4Configs, nwIPv6Configs := n.IpamConfig()
 	for _, s := range []struct {
 		ipConfigured  bool
 		subnetConfigs []*libnetwork.IpamConf
@@ -879,7 +879,7 @@ func (daemon *Daemon) disconnectFromNetwork(container *container.Container, n *l
 }
 
 func (daemon *Daemon) tryDetachContainerFromClusterNetwork(network *libnetwork.Network, container *container.Container) {
-	if !container.Managed && daemon.clusterProvider != nil && network.Info().Dynamic() {
+	if !container.Managed && daemon.clusterProvider != nil && network.Dynamic() {
 		if err := daemon.clusterProvider.DetachNetwork(network.Name(), container.ID); err != nil {
 			log.G(context.TODO()).WithError(err).Warn("error detaching from network")
 			if err := daemon.clusterProvider.DetachNetwork(network.ID(), container.ID); err != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -192,11 +192,9 @@ func (daemon *Daemon) UsesSnapshotter() bool {
 // RegistryHosts returns the registry hosts configuration for the host component
 // of a distribution image reference.
 func (daemon *Daemon) RegistryHosts(host string) ([]docker.RegistryHost, error) {
-	m := map[string]resolverconfig.RegistryConfig{}
-
-	mirrors := daemon.registryService.ServiceConfig().Mirrors
-	m["docker.io"] = resolverconfig.RegistryConfig{Mirrors: mirrors}
-
+	m := map[string]resolverconfig.RegistryConfig{
+		"docker.io": {Mirrors: daemon.registryService.ServiceConfig().Mirrors},
+	}
 	conf := daemon.registryService.ServiceConfig().IndexConfigs
 	for k, v := range conf {
 		c := resolverconfig.RegistryConfig{}
@@ -1323,10 +1321,8 @@ func (daemon *Daemon) Subnets() ([]net.IPNet, []net.IPNet) {
 	var v4Subnets []net.IPNet
 	var v6Subnets []net.IPNet
 
-	managedNetworks := daemon.netController.Networks()
-
-	for _, managedNetwork := range managedNetworks {
-		v4infos, v6infos := managedNetwork.Info().IpamInfo()
+	for _, managedNetwork := range daemon.netController.Networks() {
+		v4infos, v6infos := managedNetwork.IpamInfo()
 		for _, info := range v4infos {
 			if info.IPAMData.Pool != nil {
 				v4Subnets = append(v4Subnets, *info.IPAMData.Pool)

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -899,14 +899,12 @@ func setHostGatewayIP(controller *libnetwork.Controller, config *config.Config) 
 		return
 	}
 	if n, err := controller.NetworkByName("bridge"); err == nil {
-		v4Info, v6Info := n.Info().IpamInfo()
-		var gateway net.IP
+		v4Info, v6Info := n.IpamInfo()
 		if len(v4Info) > 0 {
-			gateway = v4Info[0].Gateway.IP
+			config.HostGatewayIP = v4Info[0].Gateway.IP
 		} else if len(v6Info) > 0 {
-			gateway = v6Info[0].Gateway.IP
+			config.HostGatewayIP = v6Info[0].Gateway.IP
 		}
-		config.HostGatewayIP = gateway
 	}
 }
 

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -249,7 +249,7 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 
 	// Remove networks not present in HNS
 	for _, v := range daemon.netController.Networks() {
-		hnsid := v.Info().DriverOptions()[winlibnetwork.HNSID]
+		hnsid := v.DriverOptions()[winlibnetwork.HNSID]
 		found := false
 
 		for _, v := range hnsresponse {
@@ -262,9 +262,9 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 		if !found {
 			// non-default nat networks should be re-created if missing from HNS
 			if v.Type() == "nat" && v.Name() != "nat" {
-				_, _, v4Conf, v6Conf := v.Info().IpamConfig()
+				_, _, v4Conf, v6Conf := v.IpamConfig()
 				netOption := map[string]string{}
-				for k, v := range v.Info().DriverOptions() {
+				for k, v := range v.DriverOptions() {
 					if k != winlibnetwork.NetworkName && k != winlibnetwork.HNSID {
 						netOption[k] = v
 					}
@@ -290,7 +290,7 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 			}
 
 			// global networks should not be deleted by local HNS
-			if v.Info().Scope() != scope.Global {
+			if v.Scope() != scope.Global {
 				err = v.Delete()
 				if err != nil {
 					log.G(context.TODO()).Errorf("Error occurred when removing network %v", err)
@@ -307,7 +307,7 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 	defaultNetworkExists := false
 
 	if network, err := daemon.netController.NetworkByName(runconfig.DefaultDaemonNetworkMode().NetworkName()); err == nil {
-		hnsid := network.Info().DriverOptions()[winlibnetwork.HNSID]
+		hnsid := network.DriverOptions()[winlibnetwork.HNSID]
 		for _, v := range hnsresponse {
 			if hnsid == v.Id {
 				defaultNetworkExists = true
@@ -325,7 +325,7 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 		}
 		var n *libnetwork.Network
 		s := func(current *libnetwork.Network) bool {
-			hnsid := current.Info().DriverOptions()[winlibnetwork.HNSID]
+			hnsid := current.DriverOptions()[winlibnetwork.HNSID]
 			if hnsid == v.Id {
 				n = current
 				return true
@@ -341,7 +341,7 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 			nid = n.ID()
 
 			// global networks should not be deleted by local HNS
-			if n.Info().Scope() == scope.Global {
+			if n.Scope() == scope.Global {
 				continue
 			}
 			v.Name = n.Name()
@@ -349,7 +349,7 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 			// is not yet populated in the libnetwork windows driver
 
 			// restore option if it existed before
-			drvOptions = n.Info().DriverOptions()
+			drvOptions = n.DriverOptions()
 			n.Delete()
 		}
 		netOption := map[string]string{

--- a/daemon/prune.go
+++ b/daemon/prune.go
@@ -109,13 +109,13 @@ func (daemon *Daemon) localNetworksPrune(ctx context.Context, pruneFilters filte
 			return true
 		default:
 		}
-		if nw.Info().ConfigOnly() {
+		if nw.ConfigOnly() {
 			return false
 		}
-		if !until.IsZero() && nw.Info().Created().After(until) {
+		if !until.IsZero() && nw.Created().After(until) {
 			return false
 		}
-		if !matchLabels(pruneFilters, nw.Info().Labels()) {
+		if !matchLabels(pruneFilters, nw.Labels()) {
 			return false
 		}
 		nwName := nw.Name()

--- a/libnetwork/agent.go
+++ b/libnetwork/agent.go
@@ -442,9 +442,9 @@ type epRecord struct {
 	lbIndex int
 }
 
+// Services returns a map of services keyed by the service name with the details
+// of all the tasks that belong to the service. Applicable only in swarm mode.
 func (n *Network) Services() map[string]ServiceInfo {
-	eps := make(map[string]epRecord)
-
 	if !n.isClusterEligible() {
 		return nil
 	}
@@ -455,6 +455,7 @@ func (n *Network) Services() map[string]ServiceInfo {
 
 	// Walk through libnetworkEPTable and fetch the driver agnostic endpoint info
 	entries := agent.networkDB.GetTableByNetwork(libnetworkEPTable, n.id)
+	eps := make(map[string]epRecord)
 	for eid, value := range entries {
 		var epRec EndpointRecord
 		nid := n.ID()

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -25,31 +25,6 @@ import (
 	"github.com/docker/docker/pkg/stringid"
 )
 
-// NetworkInfo returns some configuration and operational information about the network
-type NetworkInfo interface {
-	IpamConfig() (string, map[string]string, []*IpamConf, []*IpamConf)
-	IpamInfo() ([]*IpamInfo, []*IpamInfo)
-	DriverOptions() map[string]string
-	Scope() string
-	IPv6Enabled() bool
-	Internal() bool
-	Attachable() bool
-	Ingress() bool
-	ConfigFrom() string
-	ConfigOnly() bool
-	Labels() map[string]string
-	Dynamic() bool
-	Created() time.Time
-	// Peers returns a slice of PeerInfo structures which has the information about the peer
-	// nodes participating in the same overlay network. This is currently the per-network
-	// gossip cluster. For non-dynamic overlay networks and bridge networks it returns an
-	// empty slice
-	Peers() []networkdb.PeerInfo
-	// Services returns a map of services keyed by the service name with the details
-	// of all the tasks that belong to the service. Applicable only in swarm mode.
-	Services() map[string]ServiceInfo
-}
-
 // EndpointWalker is a client provided function which will be used to walk the Endpoints.
 // When the function returns true, the walk will stop.
 type EndpointWalker func(ep *Endpoint) bool
@@ -1772,11 +1747,10 @@ func (n *Network) deriveAddressSpace() (string, error) {
 	return local, nil
 }
 
-// Info returns certain operational data belonging to this network.
-func (n *Network) Info() NetworkInfo {
-	return n
-}
-
+// Peers returns a slice of PeerInfo structures which has the information about the peer
+// nodes participating in the same overlay network. This is currently the per-network
+// gossip cluster. For non-dynamic overlay networks and bridge networks it returns an
+// empty slice
 func (n *Network) Peers() []networkdb.PeerInfo {
 	if !n.Dynamic() {
 		return []networkdb.PeerInfo{}

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -2118,7 +2118,7 @@ func (n *Network) NdotsSet() bool {
 func (c *Controller) getConfigNetwork(name string) (*Network, error) {
 	var n *Network
 	c.WalkNetworks(func(current *Network) bool {
-		if current.Info().ConfigOnly() && current.Name() == name {
+		if current.ConfigOnly() && current.Name() == name {
 			n = current
 			return true
 		}

--- a/libnetwork/network_windows.go
+++ b/libnetwork/network_windows.go
@@ -34,9 +34,7 @@ func (n *Network) startResolver() {
 	}
 	n.resolverOnce.Do(func() {
 		log.G(context.TODO()).Debugf("Launching DNS server for network %q", n.Name())
-		options := n.Info().DriverOptions()
-		hnsid := options[windows.HNSID]
-
+		hnsid := n.DriverOptions()[windows.HNSID]
 		if hnsid == "" {
 			return
 		}


### PR DESCRIPTION
follow-up to:

- [x] https://github.com/moby/moby/pull/46050
- [x] https://github.com/moby/moby/pull/46052


### remove uses of libnetwork/Network.Info()

Now that we removed the interface, there's no need to cast the Network
to a NetworkInfo interface, so we can remove uses of the `Info()` method.

### libnetwork: remove Network.Info() and remove NetworkInfo interface

**- A picture of a cute animal (not mandatory but encouraged)**

