### PR TITLE
pkg/plugins: some cleaning up (step 2)

### DIFF
--- a/integration-cli/docker_cli_external_volume_driver_test.go
+++ b/integration-cli/docker_cli_external_volume_driver_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/api/types"
 	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/integration-cli/daemon"
+	"github.com/docker/docker/pkg/plugins"
 	"github.com/docker/docker/pkg/stringid"
 	testdaemon "github.com/docker/docker/testutil/daemon"
 	"github.com/docker/docker/volume"
@@ -104,10 +105,10 @@ func newVolumePlugin(c *testing.T, name string) *volumePlugin {
 		case error:
 			http.Error(w, t.Error(), 500)
 		case string:
-			w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+			w.Header().Set("Content-Type", plugins.VersionMimetype)
 			fmt.Fprintln(w, t)
 		default:
-			w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+			w.Header().Set("Content-Type", plugins.VersionMimetype)
 			json.NewEncoder(w).Encode(&data)
 		}
 	}

--- a/integration/plugin/graphdriver/external_test.go
+++ b/integration/plugin/graphdriver/external_test.go
@@ -126,7 +126,7 @@ func setupPlugin(t *testing.T, ec map[string]*graphEventsCounter, ext string, mu
 	}
 
 	respond := func(w http.ResponseWriter, data interface{}) {
-		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		w.Header().Set("Content-Type", plugins.VersionMimetype)
 		switch t := data.(type) {
 		case error:
 			fmt.Fprintf(w, "{\"Err\": %q}\n", t.Error())

--- a/libnetwork/drivers/remote/driver_test.go
+++ b/libnetwork/drivers/remote/driver_test.go
@@ -66,7 +66,7 @@ func setupPlugin(t *testing.T, name string, mux *http.ServeMux) func() {
 	}
 
 	mux.HandleFunc("/Plugin.Activate", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		w.Header().Set("Content-Type", plugins.VersionMimetype)
 		fmt.Fprintf(w, `{"Implements": ["%s"]}`, driverapi.NetworkPluginEndpointType)
 	})
 

--- a/libnetwork/ipams/remote/remote_test.go
+++ b/libnetwork/ipams/remote/remote_test.go
@@ -61,7 +61,7 @@ func setupPlugin(t *testing.T, name string, mux *http.ServeMux) func() {
 	}
 
 	mux.HandleFunc("/Plugin.Activate", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		w.Header().Set("Content-Type", plugins.VersionMimetype)
 		fmt.Fprintf(w, `{"Implements": ["%s"]}`, ipamapi.PluginEndpointType)
 	})
 

--- a/libnetwork/libnetwork_test.go
+++ b/libnetwork/libnetwork_test.go
@@ -1164,7 +1164,7 @@ func TestInvalidRemoteDriver(t *testing.T) {
 	defer server.Close()
 
 	mux.HandleFunc("/Plugin.Activate", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		w.Header().Set("Content-Type", plugins.VersionMimetype)
 		fmt.Fprintln(w, `{"Implements": ["InvalidDriver"]}`)
 	})
 
@@ -1207,19 +1207,19 @@ func TestValidRemoteDriver(t *testing.T) {
 	defer server.Close()
 
 	mux.HandleFunc("/Plugin.Activate", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		w.Header().Set("Content-Type", plugins.VersionMimetype)
 		fmt.Fprintf(w, `{"Implements": ["%s"]}`, driverapi.NetworkPluginEndpointType)
 	})
 	mux.HandleFunc(fmt.Sprintf("/%s.GetCapabilities", driverapi.NetworkPluginEndpointType), func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		w.Header().Set("Content-Type", plugins.VersionMimetype)
 		fmt.Fprintf(w, `{"Scope":"local"}`)
 	})
 	mux.HandleFunc(fmt.Sprintf("/%s.CreateNetwork", driverapi.NetworkPluginEndpointType), func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		w.Header().Set("Content-Type", plugins.VersionMimetype)
 		fmt.Fprintf(w, "null")
 	})
 	mux.HandleFunc(fmt.Sprintf("/%s.DeleteNetwork", driverapi.NetworkPluginEndpointType), func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		w.Header().Set("Content-Type", plugins.VersionMimetype)
 		fmt.Fprintf(w, "null")
 	})
 

--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -26,6 +26,9 @@ const (
 	dummyHost = "plugin.moby.localhost"
 )
 
+// VersionMimetype is the Content-Type the engine sends to plugins.
+const VersionMimetype = transport.VersionMimetype
+
 func newTransport(addr string, tlsConfig *tlsconfig.Options) (*transport.HTTPTransport, error) {
 	tr := &http.Transport{}
 

--- a/pkg/plugins/transport/mimetype.go
+++ b/pkg/plugins/transport/mimetype.go
@@ -1,4 +1,6 @@
 package transport // import "github.com/docker/docker/pkg/plugins/transport"
 
 // VersionMimetype is the Content-Type the engine sends to plugins.
+//
+// For convenience, there is an alias in [github.com/docker/docker/pkg/plugins.VersionMimetype].
 const VersionMimetype = "application/vnd.docker.plugins.v1.2+json"

--- a/volume/drivers/proxy_test.go
+++ b/volume/drivers/proxy_test.go
@@ -18,42 +18,42 @@ func TestVolumeRequestError(t *testing.T) {
 	defer server.Close()
 
 	mux.HandleFunc("/VolumeDriver.Create", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		w.Header().Set("Content-Type", plugins.VersionMimetype)
 		fmt.Fprintln(w, `{"Err": "Cannot create volume"}`)
 	})
 
 	mux.HandleFunc("/VolumeDriver.Remove", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		w.Header().Set("Content-Type", plugins.VersionMimetype)
 		fmt.Fprintln(w, `{"Err": "Cannot remove volume"}`)
 	})
 
 	mux.HandleFunc("/VolumeDriver.Mount", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		w.Header().Set("Content-Type", plugins.VersionMimetype)
 		fmt.Fprintln(w, `{"Err": "Cannot mount volume"}`)
 	})
 
 	mux.HandleFunc("/VolumeDriver.Unmount", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		w.Header().Set("Content-Type", plugins.VersionMimetype)
 		fmt.Fprintln(w, `{"Err": "Cannot unmount volume"}`)
 	})
 
 	mux.HandleFunc("/VolumeDriver.Path", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		w.Header().Set("Content-Type", plugins.VersionMimetype)
 		fmt.Fprintln(w, `{"Err": "Unknown volume"}`)
 	})
 
 	mux.HandleFunc("/VolumeDriver.List", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		w.Header().Set("Content-Type", plugins.VersionMimetype)
 		fmt.Fprintln(w, `{"Err": "Cannot list volumes"}`)
 	})
 
 	mux.HandleFunc("/VolumeDriver.Get", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		w.Header().Set("Content-Type", plugins.VersionMimetype)
 		fmt.Fprintln(w, `{"Err": "Cannot get volume"}`)
 	})
 
 	mux.HandleFunc("/VolumeDriver.Capabilities", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		w.Header().Set("Content-Type", plugins.VersionMimetype)
 		http.Error(w, "error", 500)
 	})
 


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/46017
- some more to come, but was running into an issue that I still need to debug, so chipping away bits from my "WIP branch"

### pkg/plugins: add convenience alias for VersionMimeType

Add an alias in the pkg/plugins package.


### integration-cli: use plugin Content-Type headers v1.2

The MediaType was changed twice in;

- b3b7eb2723461b1eb4be692f4bced0ae8ea9cb58 (https://github.com/moby/moby/pull/14242) ("application/vnd.docker.plugins.v1+json" -> "application/vnd.docker.plugins.v1.1+json")
- 54587d861d6664d6d32bc62a46c0c7ea0c7853e6 (https://github.com/moby/moby/pull/19549) ("application/vnd.docker.plugins.v1.1+json" -> "application/vnd.docker.plugins.v1.2+json")

But the (integration) tests were still using the old version, so let's
use the VersionMimeType const that's defined, and use the updated version.


### libnetwork: use plugin Content-Type headers v1.2

same

volume/drivers: use plugin Content-Type headers v1.2

same


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

