### PR TITLE
tests: Move libnetwork/testutils to internal/testutils/netnsutils

### DIFF
--- a/daemon/daemon_linux_test.go
+++ b/daemon/daemon_linux_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	containertypes "github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/libnetwork/testutils"
+	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/moby/sys/mount"
@@ -357,7 +357,7 @@ func TestIfaceAddrs(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			defer testutils.SetupTestOSContext(t)()
+			defer netnsutils.SetupTestOSContext(t)()
 
 			createBridge(t, "test", tt.nws...)
 

--- a/internal/testutils/logger.go
+++ b/internal/testutils/logger.go
@@ -1,0 +1,10 @@
+package testutils
+
+import "testing"
+
+// Logger is used to log non-fatal messages during tests.
+type Logger interface {
+	Logf(format string, args ...any)
+}
+
+var _ Logger = (*testing.T)(nil)

--- a/internal/testutils/netnsutils/context.go
+++ b/internal/testutils/netnsutils/context.go
@@ -1,13 +1,8 @@
 package netnsutils
 
-import "testing"
-
-// Logger is used to log non-fatal messages during tests.
-type Logger interface {
-	Logf(format string, args ...any)
-}
-
-var _ Logger = (*testing.T)(nil)
+import (
+	"testing"
+)
 
 // SetupTestOSContext joins the current goroutine to a new network namespace,
 // and returns its associated teardown function.

--- a/internal/testutils/netnsutils/context.go
+++ b/internal/testutils/netnsutils/context.go
@@ -1,4 +1,4 @@
-package testutils
+package netnsutils
 
 import "testing"
 

--- a/internal/testutils/netnsutils/context_unix.go
+++ b/internal/testutils/netnsutils/context_unix.go
@@ -1,6 +1,6 @@
 //go:build linux || freebsd
 
-package testutils
+package netnsutils
 
 import (
 	"fmt"

--- a/internal/testutils/netnsutils/context_unix.go
+++ b/internal/testutils/netnsutils/context_unix.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/docker/docker/internal/testutils"
 	"github.com/docker/docker/libnetwork/ns"
 	"github.com/pkg/errors"
 	"github.com/vishvananda/netns"
@@ -131,7 +132,7 @@ func (c *OSContext) restore(t *testing.T) {
 //			t.Fatalf("%+v", err)
 //		}
 //	}
-func (c *OSContext) Set() (func(Logger), error) {
+func (c *OSContext) Set() (func(testutils.Logger), error) {
 	runtime.LockOSThread()
 	orig, err := netns.Get()
 	if err != nil {
@@ -146,7 +147,7 @@ func (c *OSContext) Set() (func(Logger), error) {
 	tid := unix.Gettid()
 	_, file, line, callerOK := runtime.Caller(0)
 
-	return func(log Logger) {
+	return func(log testutils.Logger) {
 		if unix.Gettid() != tid {
 			msg := "teardown function must be called from the same goroutine as c.Set()"
 			if callerOK {

--- a/internal/testutils/netnsutils/context_windows.go
+++ b/internal/testutils/netnsutils/context_windows.go
@@ -1,4 +1,4 @@
-package testutils
+package netnsutils
 
 import "testing"
 

--- a/internal/testutils/netnsutils/context_windows.go
+++ b/internal/testutils/netnsutils/context_windows.go
@@ -1,6 +1,10 @@
 package netnsutils
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/docker/docker/internal/testutils"
+)
 
 type OSContext struct{}
 
@@ -10,6 +14,6 @@ func SetupTestOSContextEx(*testing.T) *OSContext {
 
 func (*OSContext) Cleanup(t *testing.T) {}
 
-func (*OSContext) Set() (func(Logger), error) {
-	return func(Logger) {}, nil
+func (*OSContext) Set() (func(testutils.Logger), error) {
+	return func(testutils.Logger) {}, nil
 }

--- a/internal/testutils/netnsutils/sanity_linux.go
+++ b/internal/testutils/netnsutils/sanity_linux.go
@@ -1,4 +1,4 @@
-package testutils
+package netnsutils
 
 import (
 	"errors"

--- a/internal/testutils/netnsutils/sanity_notlinux.go
+++ b/internal/testutils/netnsutils/sanity_notlinux.go
@@ -1,6 +1,6 @@
 //go:build !linux
 
-package testutils
+package netnsutils
 
 import (
 	"syscall"

--- a/libnetwork/drivers/bridge/bridge_test.go
+++ b/libnetwork/drivers/bridge/bridge_test.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/ipamutils"
 	"github.com/docker/docker/libnetwork/iptables"
@@ -18,7 +19,6 @@ import (
 	"github.com/docker/docker/libnetwork/netutils"
 	"github.com/docker/docker/libnetwork/options"
 	"github.com/docker/docker/libnetwork/portallocator"
-	"github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/vishvananda/netlink"
 )
@@ -181,7 +181,7 @@ func getIPv4Data(t *testing.T, iface string) []driverapi.IPAMData {
 }
 
 func TestCreateFullOptions(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver()
 
 	config := &configuration{
@@ -235,7 +235,7 @@ func TestCreateFullOptions(t *testing.T) {
 }
 
 func TestCreateNoConfig(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver()
 
 	netconfig := &networkConfiguration{BridgeName: DefaultBridgeName}
@@ -248,7 +248,7 @@ func TestCreateNoConfig(t *testing.T) {
 }
 
 func TestCreateFullOptionsLabels(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver()
 
 	config := &configuration{
@@ -354,7 +354,7 @@ func TestCreateFullOptionsLabels(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	d := newDriver()
 
@@ -380,7 +380,7 @@ func TestCreate(t *testing.T) {
 }
 
 func TestCreateFail(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	d := newDriver()
 
@@ -398,7 +398,7 @@ func TestCreateFail(t *testing.T) {
 }
 
 func TestCreateMultipleNetworks(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	d := newDriver()
 
@@ -606,7 +606,7 @@ func TestQueryEndpointInfoHairpin(t *testing.T) {
 }
 
 func testQueryEndpointInfo(t *testing.T, ulPxyEnabled bool) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver()
 	d.portAllocator = portallocator.NewInstance()
 
@@ -708,7 +708,7 @@ func getPortMapping() []types.PortBinding {
 }
 
 func TestLinkContainers(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	d := newDriver()
 	iptable := iptables.GetIptable(iptables.IPv4)
@@ -862,7 +862,7 @@ func TestLinkContainers(t *testing.T) {
 }
 
 func TestValidateConfig(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	// Test mtu
 	c := networkConfiguration{Mtu: -2}
@@ -933,7 +933,7 @@ func TestValidateConfig(t *testing.T) {
 }
 
 func TestSetDefaultGw(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	d := newDriver()
 
@@ -985,7 +985,7 @@ func TestSetDefaultGw(t *testing.T) {
 }
 
 func TestCleanupIptableRules(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	bridgeChain := []iptables.ChainInfo{
 		{Name: DockerChain, Table: iptables.Nat},
 		{Name: DockerChain, Table: iptables.Filter},
@@ -1015,7 +1015,7 @@ func TestCleanupIptableRules(t *testing.T) {
 }
 
 func TestCreateWithExistingBridge(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver()
 
 	if err := d.configure(nil); err != nil {
@@ -1085,7 +1085,7 @@ func TestCreateWithExistingBridge(t *testing.T) {
 }
 
 func TestCreateParallel(t *testing.T) {
-	c := testutils.SetupTestOSContextEx(t)
+	c := netnsutils.SetupTestOSContextEx(t)
 	defer c.Cleanup(t)
 
 	d := newDriver()

--- a/libnetwork/drivers/bridge/interface_test.go
+++ b/libnetwork/drivers/bridge/interface_test.go
@@ -5,12 +5,12 @@ package bridge
 import (
 	"testing"
 
-	"github.com/docker/docker/libnetwork/testutils"
+	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/vishvananda/netlink"
 )
 
 func TestInterfaceDefaultName(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	nh, err := netlink.NewHandle()
 	if err != nil {
@@ -28,7 +28,7 @@ func TestInterfaceDefaultName(t *testing.T) {
 }
 
 func TestAddressesEmptyInterface(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	nh, err := netlink.NewHandle()
 	if err != nil {

--- a/libnetwork/drivers/bridge/network_test.go
+++ b/libnetwork/drivers/bridge/network_test.go
@@ -5,14 +5,14 @@ package bridge
 import (
 	"testing"
 
+	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/netlabel"
-	"github.com/docker/docker/libnetwork/testutils"
 	"github.com/vishvananda/netlink"
 )
 
 func TestLinkCreate(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver()
 
 	if err := d.configure(nil); err != nil {
@@ -107,7 +107,7 @@ func TestLinkCreate(t *testing.T) {
 }
 
 func TestLinkCreateTwo(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver()
 
 	if err := d.configure(nil); err != nil {
@@ -145,7 +145,7 @@ func TestLinkCreateTwo(t *testing.T) {
 }
 
 func TestLinkCreateNoEnableIPv6(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver()
 
 	if err := d.configure(nil); err != nil {
@@ -180,7 +180,7 @@ func TestLinkCreateNoEnableIPv6(t *testing.T) {
 }
 
 func TestLinkDelete(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver()
 
 	if err := d.configure(nil); err != nil {

--- a/libnetwork/drivers/bridge/port_mapping_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_test.go
@@ -5,14 +5,14 @@ package bridge
 import (
 	"testing"
 
+	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/ns"
-	"github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/libnetwork/types"
 )
 
 func TestPortMappingConfig(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver()
 
 	config := &configuration{
@@ -91,7 +91,7 @@ func TestPortMappingConfig(t *testing.T) {
 }
 
 func TestPortMappingV6Config(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	if err := loopbackUp(); err != nil {
 		t.Fatalf("Could not bring loopback iface up: %v", err)
 	}

--- a/libnetwork/drivers/bridge/setup_device_test.go
+++ b/libnetwork/drivers/bridge/setup_device_test.go
@@ -7,13 +7,13 @@ import (
 	"net"
 	"testing"
 
+	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/netutils"
-	"github.com/docker/docker/libnetwork/testutils"
 	"github.com/vishvananda/netlink"
 )
 
 func TestSetupNewBridge(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	nh, err := netlink.NewHandle()
 	if err != nil {
@@ -39,7 +39,7 @@ func TestSetupNewBridge(t *testing.T) {
 }
 
 func TestSetupNewNonDefaultBridge(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	nh, err := netlink.NewHandle()
 	if err != nil {
@@ -61,7 +61,7 @@ func TestSetupNewNonDefaultBridge(t *testing.T) {
 }
 
 func TestSetupDeviceUp(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	nh, err := netlink.NewHandle()
 	if err != nil {
@@ -86,7 +86,7 @@ func TestSetupDeviceUp(t *testing.T) {
 }
 
 func TestGenerateRandomMAC(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	mac1 := netutils.GenerateRandomMAC()
 	mac2 := netutils.GenerateRandomMAC()

--- a/libnetwork/drivers/bridge/setup_ip_tables_test.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_test.go
@@ -6,9 +6,9 @@ import (
 	"net"
 	"testing"
 
+	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/iptables"
 	"github.com/docker/docker/libnetwork/portmapper"
-	"github.com/docker/docker/libnetwork/testutils"
 	"github.com/vishvananda/netlink"
 )
 
@@ -18,7 +18,7 @@ const (
 
 func TestProgramIPTable(t *testing.T) {
 	// Create a test bridge with a basic bridge configuration (name + IPv4).
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	nh, err := netlink.NewHandle()
 	if err != nil {
@@ -48,7 +48,7 @@ func TestProgramIPTable(t *testing.T) {
 
 func TestSetupIPChains(t *testing.T) {
 	// Create a test bridge with a basic bridge configuration (name + IPv4).
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	nh, err := netlink.NewHandle()
 	if err != nil {

--- a/libnetwork/drivers/bridge/setup_ipv4_test.go
+++ b/libnetwork/drivers/bridge/setup_ipv4_test.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/docker/docker/libnetwork/testutils"
+	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/vishvananda/netlink"
 )
 
@@ -23,7 +23,7 @@ func setupTestInterface(t *testing.T, nh *netlink.Handle) (*networkConfiguration
 }
 
 func TestSetupBridgeIPv4Fixed(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	ip, netw, err := net.ParseCIDR("192.168.1.1/24")
 	if err != nil {
@@ -61,7 +61,7 @@ func TestSetupBridgeIPv4Fixed(t *testing.T) {
 }
 
 func TestSetupGatewayIPv4(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	nh, err := netlink.NewHandle()
 	if err != nil {

--- a/libnetwork/drivers/bridge/setup_ipv6_test.go
+++ b/libnetwork/drivers/bridge/setup_ipv6_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/docker/docker/libnetwork/testutils"
+	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/vishvananda/netlink"
 )
 
 func TestSetupIPv6(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	nh, err := netlink.NewHandle()
 	if err != nil {
@@ -55,7 +55,7 @@ func TestSetupIPv6(t *testing.T) {
 }
 
 func TestSetupGatewayIPv6(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	_, nw, _ := net.ParseCIDR("2001:db8:ea9:9abc:ffff::/80")
 	gw := net.ParseIP("2001:db8:ea9:9abc:ffff::254")

--- a/libnetwork/drivers/bridge/setup_verify_test.go
+++ b/libnetwork/drivers/bridge/setup_verify_test.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/docker/docker/libnetwork/testutils"
+	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/vishvananda/netlink"
 )
 
@@ -29,7 +29,7 @@ func setupVerifyTest(t *testing.T) *bridgeInterface {
 }
 
 func TestSetupVerify(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	addrv4 := net.IPv4(192, 168, 1, 1)
 	inf := setupVerifyTest(t)
@@ -46,7 +46,7 @@ func TestSetupVerify(t *testing.T) {
 }
 
 func TestSetupVerifyBad(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	addrv4 := net.IPv4(192, 168, 1, 1)
 	inf := setupVerifyTest(t)
@@ -64,7 +64,7 @@ func TestSetupVerifyBad(t *testing.T) {
 }
 
 func TestSetupVerifyMissing(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	addrv4 := net.IPv4(192, 168, 1, 1)
 	inf := setupVerifyTest(t)
@@ -77,7 +77,7 @@ func TestSetupVerifyMissing(t *testing.T) {
 }
 
 func TestSetupVerifyIPv6(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	addrv4 := net.IPv4(192, 168, 1, 1)
 	inf := setupVerifyTest(t)
@@ -98,7 +98,7 @@ func TestSetupVerifyIPv6(t *testing.T) {
 }
 
 func TestSetupVerifyIPv6Missing(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	addrv4 := net.IPv4(192, 168, 1, 1)
 	inf := setupVerifyTest(t)

--- a/libnetwork/endpoint_test.go
+++ b/libnetwork/endpoint_test.go
@@ -6,13 +6,13 @@ import (
 	"os"
 	"testing"
 
+	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/ipamapi"
 	"github.com/docker/docker/libnetwork/osl"
-	"github.com/docker/docker/libnetwork/testutils"
 )
 
 func TestHostsEntries(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	expectedHostsFile := `127.0.0.1	localhost
 ::1	localhost ip6-localhost ip6-loopback

--- a/libnetwork/firewall_linux_test.go
+++ b/libnetwork/firewall_linux_test.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/config"
 	"github.com/docker/docker/libnetwork/iptables"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/options"
-	"github.com/docker/docker/libnetwork/testutils"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -51,7 +51,7 @@ func TestUserChain(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(fmt.Sprintf("iptables=%v,insert=%v", tc.iptables, tc.insert), func(t *testing.T) {
-			defer testutils.SetupTestOSContext(t)()
+			defer netnsutils.SetupTestOSContext(t)()
 			defer resetIptables(t)
 
 			c, err := New(config.OptionDriverConfig("bridge", map[string]any{

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -8,13 +8,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/discoverapi"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/ipamapi"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/netutils"
-	"github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/libnetwork/types"
 	"gotest.tools/v3/skip"
 )
@@ -311,7 +311,7 @@ func compareNwLists(a, b []*net.IPNet) bool {
 }
 
 func TestAuxAddresses(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	c, err := New()
 	if err != nil {
@@ -350,7 +350,7 @@ func TestAuxAddresses(t *testing.T) {
 func TestSRVServiceQuery(t *testing.T) {
 	skip.If(t, runtime.GOOS == "windows", "test only works on linux")
 
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	c, err := New()
 	if err != nil {
@@ -447,7 +447,7 @@ func TestSRVServiceQuery(t *testing.T) {
 func TestServiceVIPReuse(t *testing.T) {
 	skip.If(t, runtime.GOOS == "windows", "test only works on linux")
 
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	c, err := New()
 	if err != nil {
@@ -564,7 +564,7 @@ func TestServiceVIPReuse(t *testing.T) {
 func TestIpamReleaseOnNetDriverFailures(t *testing.T) {
 	skip.If(t, runtime.GOOS == "windows", "test only works on linux")
 
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	c, err := New(OptionBoltdbWithRandomDBFile(t))
 	if err != nil {

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -13,12 +13,12 @@ import (
 	"testing"
 
 	"github.com/containerd/containerd/log"
+	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork"
 	"github.com/docker/docker/libnetwork/ipamapi"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/options"
 	"github.com/docker/docker/libnetwork/osl"
-	"github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func makeTesthostNetwork(t *testing.T, c *libnetwork.Controller) *libnetwork.Net
 }
 
 func TestHost(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	sbx1, err := controller.NewSandbox("host_c1",
@@ -142,7 +142,7 @@ func TestHost(t *testing.T) {
 
 // Testing IPV6 from MAC address
 func TestBridgeIpv6FromMac(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	netOption := options.Generic{
@@ -217,7 +217,7 @@ func checkSandbox(t *testing.T, info libnetwork.EndpointInfo) {
 }
 
 func TestEndpointJoin(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	// Create network 1 and add 2 endpoint: ep11, ep12
@@ -392,7 +392,7 @@ func TestExternalKey(t *testing.T) {
 }
 
 func externalKeyTest(t *testing.T, reexec bool) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
@@ -553,7 +553,7 @@ func reexecSetKey(key string, containerID string, controllerID string) error {
 }
 
 func TestEnableIPv6(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	tmpResolvConf := []byte("search pommesfrites.fr\nnameserver 12.34.56.78\nnameserver 2001:4860:4860::8888\n")
@@ -630,7 +630,7 @@ func TestEnableIPv6(t *testing.T) {
 }
 
 func TestResolvConfHost(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	tmpResolvConf := []byte("search localhost.net\nnameserver 127.0.0.1\nnameserver 2001:4860:4860::8888\n")
@@ -705,7 +705,7 @@ func TestResolvConfHost(t *testing.T) {
 }
 
 func TestResolvConf(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	tmpResolvConf1 := []byte("search pommesfrites.fr\nnameserver 12.34.56.78\nnameserver 2001:4860:4860::8888\n")
@@ -845,7 +845,7 @@ func TestResolvConf(t *testing.T) {
 }
 
 type parallelTester struct {
-	osctx      *testutils.OSContext
+	osctx      *netnsutils.OSContext
 	controller *libnetwork.Controller
 	net1, net2 *libnetwork.Network
 	iterCnt    int
@@ -912,7 +912,7 @@ func TestParallel(t *testing.T) {
 		iterCnt    = 25
 	)
 
-	osctx := testutils.SetupTestOSContextEx(t)
+	osctx := netnsutils.SetupTestOSContextEx(t)
 	defer osctx.Cleanup(t)
 	controller := newController(t)
 
@@ -974,7 +974,7 @@ func TestParallel(t *testing.T) {
 }
 
 func TestBridge(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	netOption := options.Generic{
@@ -1062,7 +1062,7 @@ func isV6Listenable() bool {
 }
 
 func TestNullIpam(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	_, err := controller.NewNetwork(bridgeNetType, "testnetworkinternal", "", libnetwork.NetworkOptionIpam(ipamapi.NullIPAM, "", nil, nil, nil))

--- a/libnetwork/libnetwork_test.go
+++ b/libnetwork/libnetwork_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork"
 	"github.com/docker/docker/libnetwork/config"
 	"github.com/docker/docker/libnetwork/datastore"
@@ -18,7 +19,6 @@ import (
 	"github.com/docker/docker/libnetwork/ipamapi"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/options"
-	"github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/docker/docker/pkg/plugins"
 )
@@ -73,7 +73,7 @@ func isNotFound(err error) bool {
 }
 
 func TestNull(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	cnt, err := controller.NewSandbox("null_container",
@@ -123,7 +123,7 @@ func TestNull(t *testing.T) {
 }
 
 func TestUnknownDriver(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	_, err := createTestNetwork(controller, "unknowndriver", "testnetwork", options.Generic{}, nil, nil)
@@ -137,7 +137,7 @@ func TestUnknownDriver(t *testing.T) {
 }
 
 func TestNilRemoteDriver(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	_, err := controller.NewNetwork("framerelay", "dummy", "",
@@ -152,7 +152,7 @@ func TestNilRemoteDriver(t *testing.T) {
 }
 
 func TestNetworkName(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	netOption := options.Generic{
@@ -187,7 +187,7 @@ func TestNetworkName(t *testing.T) {
 }
 
 func TestNetworkType(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	netOption := options.Generic{
@@ -212,7 +212,7 @@ func TestNetworkType(t *testing.T) {
 }
 
 func TestNetworkID(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	netOption := options.Generic{
@@ -237,7 +237,7 @@ func TestNetworkID(t *testing.T) {
 }
 
 func TestDeleteNetworkWithActiveEndpoints(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	netOption := options.Generic{
@@ -277,7 +277,7 @@ func TestDeleteNetworkWithActiveEndpoints(t *testing.T) {
 }
 
 func TestNetworkConfig(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	// Verify config network cannot inherit another config network
@@ -378,7 +378,7 @@ func TestNetworkConfig(t *testing.T) {
 }
 
 func TestUnknownNetwork(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	netOption := options.Generic{
@@ -409,7 +409,7 @@ func TestUnknownNetwork(t *testing.T) {
 }
 
 func TestUnknownEndpoint(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	netOption := options.Generic{
@@ -450,7 +450,7 @@ func TestUnknownEndpoint(t *testing.T) {
 }
 
 func TestNetworkEndpointsWalkers(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	// Create network 1 and add 2 endpoint: ep11, ep12
@@ -579,7 +579,7 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 }
 
 func TestDuplicateEndpoint(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	netOption := options.Generic{
@@ -627,7 +627,7 @@ func TestDuplicateEndpoint(t *testing.T) {
 }
 
 func TestControllerQuery(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	// Create network 1
@@ -728,7 +728,7 @@ func TestControllerQuery(t *testing.T) {
 }
 
 func TestNetworkQuery(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	// Create network 1 and add 2 endpoint: ep11, ep12
@@ -814,7 +814,7 @@ func TestNetworkQuery(t *testing.T) {
 const containerID = "valid_c"
 
 func TestEndpointDeleteWithActiveContainer(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
@@ -888,7 +888,7 @@ func TestEndpointDeleteWithActiveContainer(t *testing.T) {
 }
 
 func TestEndpointMultipleJoins(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testmultiple", options.Generic{
@@ -961,7 +961,7 @@ func TestEndpointMultipleJoins(t *testing.T) {
 }
 
 func TestLeaveAll(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
@@ -1025,7 +1025,7 @@ func TestLeaveAll(t *testing.T) {
 }
 
 func TestContainerInvalidLeave(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
@@ -1090,7 +1090,7 @@ func TestContainerInvalidLeave(t *testing.T) {
 }
 
 func TestEndpointUpdateParent(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{

--- a/libnetwork/netutils/utils_linux_test.go
+++ b/libnetwork/netutils/utils_linux_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/ipamutils"
-	"github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/vishvananda/netlink"
 	"gotest.tools/v3/assert"
@@ -247,7 +247,7 @@ func TestUtilGenerateRandomMAC(t *testing.T) {
 }
 
 func TestNetworkRequest(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	nw, err := FindAvailableNetwork(ipamutils.GetLocalScopeDefaultNetworks())
 	if err != nil {

--- a/libnetwork/osl/sandbox_linux_test.go
+++ b/libnetwork/osl/sandbox_linux_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/ns"
-	"github.com/docker/docker/libnetwork/testutils"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
@@ -160,7 +160,7 @@ func verifyCleanup(t *testing.T, s Sandbox, wait bool) {
 }
 
 func TestDisableIPv6DAD(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	key, err := newKey(t)
 	if err != nil {
@@ -219,7 +219,7 @@ func destroyTest(t *testing.T, s Sandbox) {
 }
 
 func TestSetInterfaceIP(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	key, err := newKey(t)
 	if err != nil {
@@ -293,7 +293,7 @@ func TestSetInterfaceIP(t *testing.T) {
 }
 
 func TestLiveRestore(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	key, err := newKey(t)
 	if err != nil {
@@ -384,7 +384,7 @@ func TestLiveRestore(t *testing.T) {
 }
 
 func TestSandboxCreate(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	key, err := newKey(t)
 	if err != nil {
@@ -435,7 +435,7 @@ func TestSandboxCreate(t *testing.T) {
 }
 
 func TestSandboxCreateTwice(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	key, err := newKey(t)
 	if err != nil {
@@ -483,7 +483,7 @@ func TestSandboxGC(t *testing.T) {
 }
 
 func TestAddRemoveInterface(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	key, err := newKey(t)
 	if err != nil {

--- a/libnetwork/resolver_test.go
+++ b/libnetwork/resolver_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/log"
-	"github.com/docker/docker/libnetwork/testutils"
+	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/miekg/dns"
 	"github.com/sirupsen/logrus"
 	"gotest.tools/v3/assert"
@@ -98,7 +98,7 @@ func checkDNSRRType(t *testing.T, actual, expected uint16) {
 func TestDNSIPQuery(t *testing.T) {
 	skip.If(t, runtime.GOOS == "windows", "test only works on linux")
 
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	c, err := New()
 	if err != nil {
 		t.Fatal(err)
@@ -237,7 +237,7 @@ func waitForLocalDNSServer(t *testing.T) {
 func TestDNSProxyServFail(t *testing.T) {
 	skip.If(t, runtime.GOOS == "windows", "test only works on linux")
 
-	osctx := testutils.SetupTestOSContextEx(t)
+	osctx := netnsutils.SetupTestOSContextEx(t)
 	defer osctx.Cleanup(t)
 
 	c, err := New()
@@ -501,7 +501,7 @@ func TestProxyNXDOMAIN(t *testing.T) {
 	// whether we are leaking unlocked OS threads set to the wrong network
 	// namespace. Make a best-effort attempt to detect that situation so we
 	// are not left chasing ghosts next time.
-	testutils.AssertSocketSameNetNS(t, srv.PacketConn.(*net.UDPConn))
+	netnsutils.AssertSocketSameNetNS(t, srv.PacketConn.(*net.UDPConn))
 
 	srvAddr := srv.PacketConn.LocalAddr().(*net.UDPAddr)
 	rsv := NewResolver("", true, noopDNSBackend{})

--- a/libnetwork/sandbox_test.go
+++ b/libnetwork/sandbox_test.go
@@ -5,12 +5,12 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/config"
 	"github.com/docker/docker/libnetwork/ipamapi"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/options"
 	"github.com/docker/docker/libnetwork/osl"
-	"github.com/docker/docker/libnetwork/testutils"
 	"gotest.tools/v3/skip"
 )
 
@@ -74,7 +74,7 @@ func TestSandboxAddEmpty(t *testing.T) {
 
 // // If different priorities are specified, internal option and ipv6 addresses mustn't influence endpoint order
 func TestSandboxAddMultiPrio(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	opts := [][]NetworkOption{
 		{NetworkOptionEnableIPv6(true), NetworkOptionIpam(ipamapi.DefaultIPAM, "", nil, []*IpamConf{{PreferredPool: "fe90::/64"}}, nil)},
@@ -158,7 +158,7 @@ func TestSandboxAddMultiPrio(t *testing.T) {
 }
 
 func TestSandboxAddSamePrio(t *testing.T) {
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 
 	opts := [][]NetworkOption{
 		{},

--- a/libnetwork/service_common_test.go
+++ b/libnetwork/service_common_test.go
@@ -5,8 +5,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/resolvconf"
-	"github.com/docker/docker/libnetwork/testutils"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
@@ -15,7 +15,7 @@ import (
 func TestCleanupServiceDiscovery(t *testing.T) {
 	skip.If(t, runtime.GOOS == "windows", "test only works on linux")
 
-	defer testutils.SetupTestOSContext(t)()
+	defer netnsutils.SetupTestOSContext(t)()
 	c, err := New()
 	assert.NilError(t, err)
 	defer c.Stop()


### PR DESCRIPTION
**- What I did**

As requested by @corhere here: https://github.com/moby/moby/pull/45850#issuecomment-1648491789

**- How to verify it**

CI is green

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://encrypted-tbn2.gstatic.com/licensed-image?q=tbn:ANd9GcQ2CxJwjPASIEho4ojDWfA3IGdq8-T9UugXdIepcF7Ao2lcX16jb0txok8JtgQHx2NlHAvRQHAUXGPhKm8)