### PR TITLE
ci: remove check for cgroupv2 in integration-cli

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -331,7 +331,7 @@ jobs:
           echo ${{ steps.tests.outputs.matrix }}
 
   integration-cli:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     timeout-minutes: 120
     needs:
@@ -339,6 +339,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu-20.04
+          - ubuntu-22.04
         test: ${{ fromJson(needs.integration-cli-prepare.outputs.matrix) }}
     steps:
       -

--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -72,12 +72,6 @@ if [ "$DOCKER_EXPERIMENTAL" ]; then
 fi
 
 dockerd="dockerd"
-if [ -f "/sys/fs/cgroup/cgroup.controllers" ]; then
-	if [ -z "$TEST_IGNORE_CGROUP_CHECK" ] && [ -z "$TEST_SKIP_INTEGRATION_CLI" ]; then
-		echo >&2 '# cgroup v2 requires TEST_SKIP_INTEGRATION_CLI to be set'
-		exit 1
-	fi
-fi
 
 if [ -n "$DOCKER_ROOTLESS" ]; then
 	if [ -z "$TEST_SKIP_INTEGRATION_CLI" ]; then


### PR DESCRIPTION
**- What I did**

Removed the check for cgroup v2 for the integration-cli tests. Draft for now, I want to see what fails.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

