### PR TITLE
integration-cli: remove deprecated `dockerCmd` and `waitRun` utilities

### DIFF
--- a/integration-cli/benchmark_test.go
+++ b/integration-cli/benchmark_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/integration-cli/cli"
 	"gotest.tools/v3/assert"
 )
 
@@ -108,7 +109,7 @@ func (s *DockerBenchmarkSuite) BenchmarkConcurrentContainerActions(c *testing.B)
 }
 
 func (s *DockerBenchmarkSuite) BenchmarkLogsCLIRotateFollow(c *testing.B) {
-	out, _ := dockerCmd(c, "run", "-d", "--log-opt", "max-size=1b", "--log-opt", "max-file=10", "busybox", "sh", "-c", "while true; do usleep 50000; echo hello; done")
+	out := cli.DockerCmd(c, "run", "-d", "--log-opt", "max-size=1b", "--log-opt", "max-file=10", "busybox", "sh", "-c", "while true; do usleep 50000; echo hello; done").Combined()
 	id := strings.TrimSpace(out)
 	ch := make(chan error, 1)
 	go func() {

--- a/integration-cli/docker_api_exec_resize_test.go
+++ b/integration-cli/docker_api_exec_resize_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/request"
 	"github.com/pkg/errors"
@@ -19,7 +20,7 @@ import (
 
 func (s *DockerAPISuite) TestExecResizeAPIHeightWidthNoInt(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := cli.DockerCmd(c, "run", "-d", "busybox", "top").Stdout()
 	cleanedContainerID := strings.TrimSpace(out)
 
 	endpoint := "/exec/" + cleanedContainerID + "/resize?h=foo&w=bar"
@@ -35,7 +36,7 @@ func (s *DockerAPISuite) TestExecResizeAPIHeightWidthNoInt(c *testing.T) {
 // Part of #14845
 func (s *DockerAPISuite) TestExecResizeImmediatelyAfterExecStart(c *testing.T) {
 	name := "exec_resize_test"
-	dockerCmd(c, "run", "-d", "-i", "-t", "--name", name, "--restart", "always", "busybox", "/bin/sh")
+	cli.DockerCmd(c, "run", "-d", "-i", "-t", "--name", name, "--restart", "always", "busybox", "/bin/sh")
 
 	testExecResize := func() error {
 		data := map[string]interface{}{

--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
@@ -26,7 +27,7 @@ import (
 // Regression test for #9414
 func (s *DockerAPISuite) TestExecAPICreateNoCmd(c *testing.T) {
 	name := "exec_test"
-	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
+	cli.DockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
 
 	res, body, err := request.Post(testutil.GetContext(c), fmt.Sprintf("/containers/%s/exec", name), request.JSONBody(map[string]interface{}{"Cmd": nil}))
 	assert.NilError(c, err)
@@ -42,7 +43,7 @@ func (s *DockerAPISuite) TestExecAPICreateNoCmd(c *testing.T) {
 
 func (s *DockerAPISuite) TestExecAPICreateNoValidContentType(c *testing.T) {
 	name := "exec_test"
-	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
+	cli.DockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
 
 	jsonData := bytes.NewBuffer(nil)
 	if err := json.NewEncoder(jsonData).Encode(map[string]interface{}{"Cmd": nil}); err != nil {
@@ -65,9 +66,9 @@ func (s *DockerAPISuite) TestExecAPICreateContainerPaused(c *testing.T) {
 	// Not relevant on Windows as Windows containers cannot be paused
 	testRequires(c, DaemonIsLinux)
 	name := "exec_create_test"
-	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
+	cli.DockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
 
-	dockerCmd(c, "pause", name)
+	cli.DockerCmd(c, "pause", name)
 
 	apiClient, err := client.NewClientWithOpts(client.FromEnv)
 	assert.NilError(c, err)
@@ -82,7 +83,7 @@ func (s *DockerAPISuite) TestExecAPICreateContainerPaused(c *testing.T) {
 
 func (s *DockerAPISuite) TestExecAPIStart(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Uses pause/unpause but bits may be salvageable to Windows to Windows CI
-	dockerCmd(c, "run", "-d", "--name", "test", "busybox", "top")
+	cli.DockerCmd(c, "run", "-d", "--name", "test", "busybox", "top")
 
 	id := createExec(c, "test")
 	startExec(c, id, http.StatusOK)
@@ -92,24 +93,24 @@ func (s *DockerAPISuite) TestExecAPIStart(c *testing.T) {
 	assert.Assert(c, execJSON.PID > 1)
 
 	id = createExec(c, "test")
-	dockerCmd(c, "stop", "test")
+	cli.DockerCmd(c, "stop", "test")
 
 	startExec(c, id, http.StatusNotFound)
 
-	dockerCmd(c, "start", "test")
+	cli.DockerCmd(c, "start", "test")
 	startExec(c, id, http.StatusNotFound)
 
 	// make sure exec is created before pausing
 	id = createExec(c, "test")
-	dockerCmd(c, "pause", "test")
+	cli.DockerCmd(c, "pause", "test")
 	startExec(c, id, http.StatusConflict)
-	dockerCmd(c, "unpause", "test")
+	cli.DockerCmd(c, "unpause", "test")
 	startExec(c, id, http.StatusOK)
 }
 
 func (s *DockerAPISuite) TestExecAPIStartEnsureHeaders(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	dockerCmd(c, "run", "-d", "--name", "test", "busybox", "top")
+	cli.DockerCmd(c, "run", "-d", "--name", "test", "busybox", "top")
 
 	id := createExec(c, "test")
 	resp, _, err := request.Post(testutil.GetContext(c), fmt.Sprintf("/exec/%s/start", id), request.RawString(`{"Detach": true}`), request.JSON)
@@ -177,7 +178,7 @@ func (s *DockerAPISuite) TestExecAPIStartWithDetach(c *testing.T) {
 // #30311
 func (s *DockerAPISuite) TestExecAPIStartValidCommand(c *testing.T) {
 	name := "exec_test"
-	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
+	cli.DockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
 
 	id := createExecCmd(c, name, "true")
 	startExec(c, id, http.StatusOK)
@@ -194,7 +195,7 @@ func (s *DockerAPISuite) TestExecAPIStartValidCommand(c *testing.T) {
 // #30311
 func (s *DockerAPISuite) TestExecAPIStartInvalidCommand(c *testing.T) {
 	name := "exec_test"
-	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
+	cli.DockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
 
 	id := createExecCmd(c, name, "invalid")
 	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
@@ -217,7 +218,7 @@ func (s *DockerAPISuite) TestExecStateCleanup(c *testing.T) {
 	// This test checks accidental regressions. Not part of stable API.
 
 	name := "exec_cleanup"
-	cid, _ := dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
+	cid := cli.DockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh").Stdout()
 	cid = strings.TrimSpace(cid)
 
 	stateDir := "/var/run/docker/containerd/" + cid
@@ -246,7 +247,7 @@ func (s *DockerAPISuite) TestExecStateCleanup(c *testing.T) {
 
 	poll.WaitOn(c, pollCheck(c, checkReadDir, checker.Equals(len(fi))), poll.WithTimeout(5*time.Second))
 
-	dockerCmd(c, "stop", name)
+	cli.DockerCmd(c, "stop", name)
 	_, err = os.Stat(stateDir)
 	assert.ErrorContains(c, err, "")
 	assert.Assert(c, os.IsNotExist(err))

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -26,7 +26,7 @@ func (s *DockerAPISuite) TestAPIImagesSaveAndLoad(c *testing.T) {
 	defer body.Close()
 	assert.Equal(c, res.StatusCode, http.StatusOK)
 
-	dockerCmd(c, "rmi", id)
+	cli.DockerCmd(c, "rmi", id)
 
 	res, loadBody, err := request.Post(ctx, "/images/load", request.RawContent(body), request.ContentType("application/x-tar"))
 	assert.NilError(c, err)
@@ -49,7 +49,7 @@ func (s *DockerAPISuite) TestAPIImagesDelete(c *testing.T) {
 	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nENV FOO bar"))
 	id := getIDByName(c, name)
 
-	dockerCmd(c, "tag", name, "test:tag1")
+	cli.DockerCmd(c, "tag", name, "test:tag1")
 
 	_, err = apiClient.ImageRemove(testutil.GetContext(c), id, types.ImageRemoveOptions{})
 	assert.ErrorContains(c, err, "unable to delete")

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -8,15 +8,16 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions/v1p20"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/testutil"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
 
 func (s *DockerAPISuite) TestInspectAPIContainerResponse(c *testing.T) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
-
+	out := cli.DockerCmd(c, "run", "-d", "busybox", "true").Stdout()
 	cleanedContainerID := strings.TrimSpace(out)
+
 	keysBase := []string{
 		"Id", "State", "Created", "Path", "Args", "Config", "Image", "NetworkSettings",
 		"ResolvConfPath", "HostnamePath", "HostsPath", "LogPath", "Name", "Driver", "MountLabel", "ProcessLabel", "GraphDriver",
@@ -61,8 +62,7 @@ func (s *DockerAPISuite) TestInspectAPIContainerResponse(c *testing.T) {
 func (s *DockerAPISuite) TestInspectAPIContainerVolumeDriverLegacy(c *testing.T) {
 	// No legacy implications for Windows
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
-
+	out := cli.DockerCmd(c, "run", "-d", "busybox", "true").Stdout()
 	cleanedContainerID := strings.TrimSpace(out)
 
 	cases := []string{"v1.19", "v1.20"}
@@ -82,8 +82,7 @@ func (s *DockerAPISuite) TestInspectAPIContainerVolumeDriverLegacy(c *testing.T)
 }
 
 func (s *DockerAPISuite) TestInspectAPIContainerVolumeDriver(c *testing.T) {
-	out, _ := dockerCmd(c, "run", "-d", "--volume-driver", "local", "busybox", "true")
-
+	out := cli.DockerCmd(c, "run", "-d", "--volume-driver", "local", "busybox", "true").Stdout()
 	cleanedContainerID := strings.TrimSpace(out)
 
 	body := getInspectBody(c, "v1.25", cleanedContainerID)
@@ -106,7 +105,7 @@ func (s *DockerAPISuite) TestInspectAPIContainerVolumeDriver(c *testing.T) {
 }
 
 func (s *DockerAPISuite) TestInspectAPIImageResponse(c *testing.T) {
-	dockerCmd(c, "tag", "busybox:latest", "busybox:mytag")
+	cli.DockerCmd(c, "tag", "busybox:latest", "busybox:mytag")
 	apiClient, err := client.NewClientWithOpts(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
@@ -123,8 +122,7 @@ func (s *DockerAPISuite) TestInspectAPIImageResponse(c *testing.T) {
 func (s *DockerAPISuite) TestInspectAPIEmptyFieldsInConfigPre121(c *testing.T) {
 	// Not relevant on Windows
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
-
+	out := cli.DockerCmd(c, "run", "-d", "busybox", "true").Stdout()
 	cleanedContainerID := strings.TrimSpace(out)
 
 	cases := []string{"v1.19", "v1.20"}
@@ -147,9 +145,9 @@ func (s *DockerAPISuite) TestInspectAPIEmptyFieldsInConfigPre121(c *testing.T) {
 func (s *DockerAPISuite) TestInspectAPIBridgeNetworkSettings120(c *testing.T) {
 	// Not relevant on Windows, and besides it doesn't have any bridge network settings
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := cli.DockerCmd(c, "run", "-d", "busybox", "top").Stdout()
 	containerID := strings.TrimSpace(out)
-	waitRun(containerID)
+	cli.WaitRun(c, containerID)
 
 	body := getInspectBody(c, "v1.20", containerID)
 
@@ -164,9 +162,9 @@ func (s *DockerAPISuite) TestInspectAPIBridgeNetworkSettings120(c *testing.T) {
 func (s *DockerAPISuite) TestInspectAPIBridgeNetworkSettings121(c *testing.T) {
 	// Windows doesn't have any bridge network settings
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := cli.DockerCmd(c, "run", "-d", "busybox", "top").Stdout()
 	containerID := strings.TrimSpace(out)
-	waitRun(containerID)
+	cli.WaitRun(c, containerID)
 
 	body := getInspectBody(c, "v1.21", containerID)
 

--- a/integration-cli/docker_api_network_test.go
+++ b/integration-cli/docker_api_network_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
@@ -40,7 +41,7 @@ func (s *DockerAPISuite) TestAPINetworkInspectBridge(c *testing.T) {
 	assert.Equal(c, nr.Name, "bridge")
 
 	// run a container and attach it to the default bridge network
-	out, _ := dockerCmd(c, "run", "-d", "--name", "test", "busybox", "top")
+	out := cli.DockerCmd(c, "run", "-d", "--name", "test", "busybox", "top").Stdout()
 	containerID := strings.TrimSpace(out)
 	containerIP := findContainerIP(c, "test", "bridge")
 
@@ -104,7 +105,7 @@ func (s *DockerAPISuite) TestAPINetworkConnectDisconnect(c *testing.T) {
 	assert.Equal(c, len(nr.Containers), 0)
 
 	// run a container
-	out, _ := dockerCmd(c, "run", "-d", "--name", "test", "busybox", "top")
+	out := cli.DockerCmd(c, "run", "-d", "--name", "test", "busybox", "top").Stdout()
 	containerID := strings.TrimSpace(out)
 
 	// connect the container to the test network

--- a/integration-cli/docker_cli_attach_unix_test.go
+++ b/integration-cli/docker_cli_attach_unix_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/creack/pty"
+	"github.com/docker/docker/integration-cli/cli"
 	"gotest.tools/v3/assert"
 )
 
@@ -18,12 +19,11 @@ import (
 func (s *DockerCLIAttachSuite) TestAttachClosedOnContainerStop(c *testing.T) {
 	testRequires(c, testEnv.IsLocalDaemon)
 
-	out, _ := dockerCmd(c, "run", "-dti", "busybox", "/bin/sh", "-c", `trap 'exit 0' SIGTERM; while true; do sleep 1; done`)
-
+	out := cli.DockerCmd(c, "run", "-dti", "busybox", "/bin/sh", "-c", `trap 'exit 0' SIGTERM; while true; do sleep 1; done`).Stdout()
 	id := strings.TrimSpace(out)
-	assert.NilError(c, waitRun(id))
+	cli.WaitRun(c, id)
 
-	pty, tty, err := pty.Open()
+	pt, tty, err := pty.Open()
 	assert.NilError(c, err)
 
 	attachCmd := exec.Command(dockerBinary, "attach", id)
@@ -38,19 +38,19 @@ func (s *DockerCLIAttachSuite) TestAttachClosedOnContainerStop(c *testing.T) {
 		time.Sleep(300 * time.Millisecond)
 		defer close(errChan)
 		// Container is waiting for us to signal it to stop
-		dockerCmd(c, "stop", id)
+		cli.DockerCmd(c, "stop", id)
 		// And wait for the attach command to end
 		errChan <- attachCmd.Wait()
 	}()
 
 	// Wait for the docker to end (should be done by the
 	// stop command in the go routine)
-	dockerCmd(c, "wait", id)
+	cli.DockerCmd(c, "wait", id)
 
 	select {
 	case err := <-errChan:
 		tty.Close()
-		out, _ := io.ReadAll(pty)
+		out, _ := io.ReadAll(pt)
 		assert.Assert(c, err == nil, "out: %v", string(out))
 	case <-time.After(attachWait):
 		c.Fatal("timed out without attach returning")
@@ -73,7 +73,7 @@ func (s *DockerCLIAttachSuite) TestAttachAfterDetach(c *testing.T) {
 		close(cmdExit)
 	}()
 
-	assert.Assert(c, waitRun(name) == nil)
+	cli.WaitRun(c, name)
 
 	cpty.Write([]byte{16})
 	time.Sleep(100 * time.Millisecond)
@@ -123,9 +123,9 @@ func (s *DockerCLIAttachSuite) TestAttachAfterDetach(c *testing.T) {
 
 // TestAttachDetach checks that attach in tty mode can be detached using the long container ID
 func (s *DockerCLIAttachSuite) TestAttachDetach(c *testing.T) {
-	out, _ := dockerCmd(c, "run", "-itd", "busybox", "cat")
+	out := cli.DockerCmd(c, "run", "-itd", "busybox", "cat").Stdout()
 	id := strings.TrimSpace(out)
-	assert.NilError(c, waitRun(id))
+	cli.WaitRun(c, id)
 
 	cpty, tty, err := pty.Open()
 	assert.NilError(c, err)
@@ -138,7 +138,7 @@ func (s *DockerCLIAttachSuite) TestAttachDetach(c *testing.T) {
 	defer stdout.Close()
 	err = cmd.Start()
 	assert.NilError(c, err)
-	assert.NilError(c, waitRun(id))
+	cli.WaitRun(c, id)
 
 	_, err = cpty.Write([]byte("hello\n"))
 	assert.NilError(c, err)

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -51,7 +51,7 @@ func (s *DockerCLIBuildSuite) TestBuildJSONEmptyRun(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildShCmdJSONEntrypoint(c *testing.T) {
-	name := "testbuildshcmdjsonentrypoint"
+	const name = "testbuildshcmdjsonentrypoint"
 	expected := "/bin/sh -c echo test"
 	if testEnv.DaemonInfo.OSType == "windows" {
 		expected = "cmd /S /C echo test"
@@ -62,7 +62,7 @@ func (s *DockerCLIBuildSuite) TestBuildShCmdJSONEntrypoint(c *testing.T) {
     ENTRYPOINT ["echo"]
     CMD echo test
     `))
-	out, _ := dockerCmd(c, "run", "--rm", name)
+	out := cli.DockerCmd(c, "run", "--rm", name).Combined()
 
 	if strings.TrimSpace(out) != expected {
 		c.Fatalf("CMD did not contain %q : %q", expected, out)
@@ -72,7 +72,7 @@ func (s *DockerCLIBuildSuite) TestBuildShCmdJSONEntrypoint(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementUser(c *testing.T) {
 	// Windows does not support FROM scratch or the USER command
 	testRequires(c, DaemonIsLinux)
-	name := "testbuildenvironmentreplacement"
+	const name = "testbuildenvironmentreplacement"
 
 	buildImageSuccessfully(c, name, build.WithDockerfile(`
   FROM scratch
@@ -87,7 +87,7 @@ func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementUser(c *testing.T) 
 }
 
 func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementVolume(c *testing.T) {
-	name := "testbuildenvironmentreplacement"
+	const name = "testbuildenvironmentreplacement"
 
 	var volumePath string
 
@@ -113,7 +113,7 @@ func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementVolume(c *testing.T
 func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementExpose(c *testing.T) {
 	// Windows does not support FROM scratch or the EXPOSE command
 	testRequires(c, DaemonIsLinux)
-	name := "testbuildenvironmentreplacement"
+	const name = "testbuildenvironmentreplacement"
 
 	buildImageSuccessfully(c, name, build.WithDockerfile(`
   FROM scratch
@@ -135,7 +135,7 @@ func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementExpose(c *testing.T
 }
 
 func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementWorkdir(c *testing.T) {
-	name := "testbuildenvironmentreplacement"
+	const name = "testbuildenvironmentreplacement"
 
 	buildImageSuccessfully(c, name, build.WithDockerfile(`
   FROM busybox
@@ -155,7 +155,7 @@ func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementWorkdir(c *testing.
 }
 
 func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementAddCopy(c *testing.T) {
-	name := "testbuildenvironmentreplacement"
+	const name = "testbuildenvironmentreplacement"
 
 	buildImageSuccessfully(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `
@@ -181,7 +181,7 @@ func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementAddCopy(c *testing.
 func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementEnv(c *testing.T) {
 	// ENV expansions work differently in Windows
 	testRequires(c, DaemonIsLinux)
-	name := "testbuildenvironmentreplacement"
+	const name = "testbuildenvironmentreplacement"
 
 	buildImageSuccessfully(c, name, build.WithDockerfile(`
   FROM busybox
@@ -243,7 +243,7 @@ func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementEnv(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildHandleEscapesInVolume(c *testing.T) {
 	// The volume paths used in this test are invalid on Windows
 	testRequires(c, DaemonIsLinux)
-	name := "testbuildhandleescapes"
+	const name = "testbuildhandleescapes"
 
 	testCases := []struct {
 		volumeValue string
@@ -280,13 +280,13 @@ func (s *DockerCLIBuildSuite) TestBuildHandleEscapesInVolume(c *testing.T) {
 		}
 
 		// Remove the image for the next iteration
-		dockerCmd(c, "rmi", name)
+		cli.DockerCmd(c, "rmi", name)
 	}
 }
 
 func (s *DockerCLIBuildSuite) TestBuildOnBuildLowercase(c *testing.T) {
-	name := "testbuildonbuildlowercase"
-	name2 := "testbuildonbuildlowercase2"
+	const name = "testbuildonbuildlowercase"
+	const name2 = "testbuildonbuildlowercase2"
 
 	buildImageSuccessfully(c, name, build.WithDockerfile(`
   FROM busybox
@@ -310,14 +310,14 @@ func (s *DockerCLIBuildSuite) TestBuildOnBuildLowercase(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildEnvEscapes(c *testing.T) {
 	// ENV expansions work differently in Windows
 	testRequires(c, DaemonIsLinux)
-	name := "testbuildenvescapes"
+	const name = "testbuildenvescapes"
 	buildImageSuccessfully(c, name, build.WithDockerfile(`
     FROM busybox
     ENV TEST foo
     CMD echo \$
     `))
 
-	out, _ := dockerCmd(c, "run", "-t", name)
+	out := cli.DockerCmd(c, "run", "-t", name).Combined()
 	if strings.TrimSpace(out) != "$" {
 		c.Fatalf("Env TEST was not overwritten with bar when foo was supplied to dockerfile: was %q", strings.TrimSpace(out))
 	}
@@ -326,14 +326,14 @@ func (s *DockerCLIBuildSuite) TestBuildEnvEscapes(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildEnvOverwrite(c *testing.T) {
 	// ENV expansions work differently in Windows
 	testRequires(c, DaemonIsLinux)
-	name := "testbuildenvoverwrite"
+	const name = "testbuildenvoverwrite"
 	buildImageSuccessfully(c, name, build.WithDockerfile(`
     FROM busybox
     ENV TEST foo
     CMD echo ${TEST}
     `))
 
-	out, _ := dockerCmd(c, "run", "-e", "TEST=bar", "-t", name)
+	out := cli.DockerCmd(c, "run", "-e", "TEST=bar", "-t", name).Combined()
 	if strings.TrimSpace(out) != "bar" {
 		c.Fatalf("Env TEST was not overwritten with bar when foo was supplied to dockerfile: was %q", strings.TrimSpace(out))
 	}
@@ -341,8 +341,8 @@ func (s *DockerCLIBuildSuite) TestBuildEnvOverwrite(c *testing.T) {
 
 // FIXME(vdemeester) why we disabled cache here ?
 func (s *DockerCLIBuildSuite) TestBuildOnBuildCmdEntrypointJSON(c *testing.T) {
-	name1 := "onbuildcmd"
-	name2 := "onbuildgenerated"
+	const name1 = "onbuildcmd"
+	const name2 = "onbuildgenerated"
 
 	cli.BuildCmd(c, name1, build.WithDockerfile(`
 FROM busybox
@@ -358,8 +358,8 @@ ONBUILD RUN ["true"]`))
 
 // FIXME(vdemeester) why we disabled cache here ?
 func (s *DockerCLIBuildSuite) TestBuildOnBuildEntrypointJSON(c *testing.T) {
-	name1 := "onbuildcmd"
-	name2 := "onbuildgenerated"
+	const name1 = "onbuildcmd"
+	const name2 = "onbuildgenerated"
 
 	buildImageSuccessfully(c, name1, build.WithDockerfile(`
 FROM busybox
@@ -367,7 +367,7 @@ ONBUILD ENTRYPOINT ["echo"]`))
 
 	buildImageSuccessfully(c, name2, build.WithDockerfile(fmt.Sprintf("FROM %s\nCMD [\"hello world\"]\n", name1)))
 
-	out, _ := dockerCmd(c, "run", name2)
+	out := cli.DockerCmd(c, "run", name2).Combined()
 	if !regexp.MustCompile(`(?m)^hello world`).MatchString(out) {
 		c.Fatal("got malformed output from onbuild", out)
 	}
@@ -375,7 +375,7 @@ ONBUILD ENTRYPOINT ["echo"]`))
 
 func (s *DockerCLIBuildSuite) TestBuildCacheAdd(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Windows doesn't have httpserver image yet
-	name := "testbuildtwoimageswithadd"
+	const name = "testbuildtwoimageswithadd"
 	server := fakestorage.New(c, "", fakecontext.WithFiles(map[string]string{
 		"robots.txt": "hello",
 		"index.html": "world",
@@ -398,7 +398,7 @@ func (s *DockerCLIBuildSuite) TestBuildLastModified(c *testing.T) {
 	// has changed in the master busybox image.
 	testRequires(c, DaemonIsLinux)
 
-	name := "testbuildlastmodified"
+	const name = "testbuildlastmodified"
 
 	server := fakestorage.New(c, "", fakecontext.WithFiles(map[string]string{
 		"file": "hello",
@@ -446,7 +446,7 @@ ADD %s/file /`
 // Makes sure that we don't use the cache if the contents of
 // a file in a subfolder of the context is modified and we re-build.
 func (s *DockerCLIBuildSuite) TestBuildModifyFileInFolder(c *testing.T) {
-	name := "testbuildmodifyfileinfolder"
+	const name = "testbuildmodifyfileinfolder"
 
 	ctx := fakecontext.New(c, "", fakecontext.WithDockerfile(`FROM busybox
 RUN ["mkdir", "/test"]
@@ -484,7 +484,7 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`, expecte
 
 // Issue #3960: "ADD src ." hangs
 func (s *DockerCLIBuildSuite) TestBuildAddSingleFileToWorkdir(c *testing.T) {
-	name := "testaddsinglefiletoworkdir"
+	const name = "testaddsinglefiletoworkdir"
 	ctx := fakecontext.New(c, "", fakecontext.WithDockerfile(
 		`FROM busybox
 	       ADD test_file .`),
@@ -562,7 +562,7 @@ func (s *DockerCLIBuildSuite) TestBuildUsernamespaceValidateRemappedRoot(c *test
 		"COPY test_dir /new_dir",
 		"WORKDIR /new_dir",
 	}
-	name := "testbuildusernamespacevalidateremappedroot"
+	const name = "testbuildusernamespacevalidateremappedroot"
 	for _, tc := range testCases {
 		cli.BuildCmd(c, name, build.WithBuildContext(c,
 			build.WithFile("Dockerfile", fmt.Sprintf(`FROM busybox
@@ -576,7 +576,7 @@ RUN [ $(ls -l / | grep new_dir | awk '{print $3":"$4}') = 'root:root' ]`, tc)),
 
 func (s *DockerCLIBuildSuite) TestBuildAddAndCopyFileWithWhitespace(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Not currently passing on Windows
-	name := "testaddfilewithwhitespace"
+	const name = "testaddfilewithwhitespace"
 
 	for _, command := range []string{"ADD", "COPY"} {
 		cli.BuildCmd(c, name, build.WithBuildContext(c,
@@ -625,7 +625,7 @@ RUN find "test4" "C:/test_dir/test_file4"
 RUN find "test5" "C:/test dir/test_file5"
 RUN find "test6" "C:/test dir/test_file6"`
 
-	name := "testcopyfilewithwhitespace"
+	const name = "testcopyfilewithwhitespace"
 	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", dockerfile),
 		build.WithFile("test file1", "test1"),
@@ -638,7 +638,7 @@ RUN find "test6" "C:/test dir/test_file6"`
 }
 
 func (s *DockerCLIBuildSuite) TestBuildCopyWildcard(c *testing.T) {
-	name := "testcopywildcard"
+	const name = "testcopywildcard"
 	server := fakestorage.New(c, "", fakecontext.WithFiles(map[string]string{
 		"robots.txt": "hello",
 		"index.html": "world",
@@ -697,7 +697,7 @@ func (s *DockerCLIBuildSuite) TestBuildCopyWildcardInName(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildCopyWildcardCache(c *testing.T) {
-	name := "testcopywildcardcache"
+	const name = "testcopywildcardcache"
 	ctx := fakecontext.New(c, "", fakecontext.WithDockerfile(`FROM busybox
 	COPY file1.txt /tmp/`),
 		fakecontext.WithFiles(map[string]string{
@@ -826,7 +826,7 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`, expecte
 
 // Issue #3960: "ADD src ." hangs - adapted for COPY
 func (s *DockerCLIBuildSuite) TestBuildCopySingleFileToWorkdir(c *testing.T) {
-	name := "testcopysinglefiletoworkdir"
+	const name = "testcopysinglefiletoworkdir"
 	ctx := fakecontext.New(c, "", fakecontext.WithDockerfile(`FROM busybox
 COPY test_file .`),
 		fakecontext.WithFiles(map[string]string{
@@ -934,7 +934,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddBadLinks(c *testing.T) {
 		ADD foo.txt /symlink/
 		`
 	targetFile := "foo.txt"
-	name := "test-link-absolute"
+	const name = "test-link-absolute"
 	ctx := fakecontext.New(c, "", fakecontext.WithDockerfile(dockerfile))
 	defer ctx.Close()
 
@@ -1048,7 +1048,7 @@ func (s *DockerCLIBuildSuite) TestBuildWithInaccessibleFilesInContext(c *testing
 	testRequires(c, DaemonIsLinux, UnixCli, testEnv.IsLocalDaemon) // test uses chown/chmod: not available on windows
 
 	{
-		name := "testbuildinaccessiblefiles"
+		const name = "testbuildinaccessiblefiles"
 		ctx := fakecontext.New(c, "",
 			fakecontext.WithDockerfile("FROM scratch\nADD . /foo/"),
 			fakecontext.WithFiles(map[string]string{"fileWithoutReadAccess": "foo"}),
@@ -1081,7 +1081,7 @@ func (s *DockerCLIBuildSuite) TestBuildWithInaccessibleFilesInContext(c *testing
 		}
 	}
 	{
-		name := "testbuildinaccessibledirectory"
+		const name = "testbuildinaccessibledirectory"
 		ctx := fakecontext.New(c, "",
 			fakecontext.WithDockerfile("FROM scratch\nADD . /foo/"),
 			fakecontext.WithFiles(map[string]string{"directoryWeCantStat/bar": "foo"}),
@@ -1119,7 +1119,7 @@ func (s *DockerCLIBuildSuite) TestBuildWithInaccessibleFilesInContext(c *testing
 		}
 	}
 	{
-		name := "testlinksok"
+		const name = "testlinksok"
 		ctx := fakecontext.New(c, "", fakecontext.WithDockerfile("FROM scratch\nADD . /foo/"))
 		defer ctx.Close()
 
@@ -1133,7 +1133,7 @@ func (s *DockerCLIBuildSuite) TestBuildWithInaccessibleFilesInContext(c *testing
 		buildImageSuccessfully(c, name, build.WithExternalBuildContext(ctx))
 	}
 	{
-		name := "testbuildignoredinaccessible"
+		const name = "testbuildignoredinaccessible"
 		ctx := fakecontext.New(c, "",
 			fakecontext.WithDockerfile("FROM scratch\nADD . /foo/"),
 			fakecontext.WithFiles(map[string]string{
@@ -1168,7 +1168,7 @@ func (s *DockerCLIBuildSuite) TestBuildWithInaccessibleFilesInContext(c *testing
 
 func (s *DockerCLIBuildSuite) TestBuildForceRm(c *testing.T) {
 	containerCountBefore := getContainerCount(c)
-	name := "testbuildforcerm"
+	const name = "testbuildforcerm"
 
 	r := buildImage(name, cli.WithFlags("--force-rm"), build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `FROM busybox
@@ -1185,7 +1185,7 @@ func (s *DockerCLIBuildSuite) TestBuildForceRm(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildRm(c *testing.T) {
-	name := "testbuildrm"
+	const name = "testbuildrm"
 
 	testCases := []struct {
 		buildflags                []string
@@ -1223,7 +1223,7 @@ func (s *DockerCLIBuildSuite) TestBuildRm(c *testing.T) {
 			}
 		}
 
-		dockerCmd(c, "rmi", name)
+		cli.DockerCmd(c, "rmi", name)
 	}
 }
 
@@ -1262,7 +1262,7 @@ func (s *DockerCLIBuildSuite) TestBuildWithVolumes(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildMaintainer(c *testing.T) {
-	name := "testbuildmaintainer"
+	const name = "testbuildmaintainer"
 
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
         MAINTAINER dockerio`))
@@ -1276,7 +1276,7 @@ func (s *DockerCLIBuildSuite) TestBuildMaintainer(c *testing.T) {
 
 func (s *DockerCLIBuildSuite) TestBuildUser(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	name := "testbuilduser"
+	const name = "testbuilduser"
 	expected := "dockerio"
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
@@ -1289,7 +1289,7 @@ func (s *DockerCLIBuildSuite) TestBuildUser(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildRelativeWorkdir(c *testing.T) {
-	name := "testbuildrelativeworkdir"
+	const name = "testbuildrelativeworkdir"
 
 	var (
 		expected1     string
@@ -1375,7 +1375,7 @@ func (s *DockerCLIBuildSuite) TestBuildWindowsAddCopyPathProcessing(c *testing.T
 }
 
 func (s *DockerCLIBuildSuite) TestBuildWorkdirWithEnvVariables(c *testing.T) {
-	name := "testbuildworkdirwithenvvariables"
+	const name = "testbuildworkdirwithenvvariables"
 
 	var expected string
 	if testEnv.DaemonInfo.OSType == "windows" {
@@ -1435,7 +1435,7 @@ func (s *DockerCLIBuildSuite) TestBuildRelativeCopy(c *testing.T) {
 
 // FIXME(vdemeester) should be unit test
 func (s *DockerCLIBuildSuite) TestBuildBlankName(c *testing.T) {
-	name := "testbuildblankname"
+	const name = "testbuildblankname"
 	testCases := []struct {
 		expression     string
 		expectedStderr string
@@ -1465,7 +1465,7 @@ func (s *DockerCLIBuildSuite) TestBuildBlankName(c *testing.T) {
 
 func (s *DockerCLIBuildSuite) TestBuildEnv(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // ENV expansion is different in Windows
-	name := "testbuildenv"
+	const name = "testbuildenv"
 	expected := "[PATH=/test:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PORT=2375]"
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		ENV PATH /test:$PATH
@@ -1509,7 +1509,7 @@ func (s *DockerCLIBuildSuite) TestBuildPATH(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildContextCleanup(c *testing.T) {
 	testRequires(c, testEnv.IsLocalDaemon)
 
-	name := "testbuildcontextcleanup"
+	const name = "testbuildcontextcleanup"
 	entries, err := os.ReadDir(filepath.Join(testEnv.DaemonInfo.DockerRootDir, "tmp"))
 	if err != nil {
 		c.Fatalf("failed to list contents of tmp dir: %s", err)
@@ -1530,7 +1530,7 @@ func (s *DockerCLIBuildSuite) TestBuildContextCleanup(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildContextCleanupFailedBuild(c *testing.T) {
 	testRequires(c, testEnv.IsLocalDaemon)
 
-	name := "testbuildcontextcleanup"
+	const name = "testbuildcontextcleanup"
 	entries, err := os.ReadDir(filepath.Join(testEnv.DaemonInfo.DockerRootDir, "tmp"))
 	if err != nil {
 		c.Fatalf("failed to list contents of tmp dir: %s", err)
@@ -1570,7 +1570,7 @@ func compareDirectoryEntries(e1 []os.DirEntry, e2 []os.DirEntry) error {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildCmd(c *testing.T) {
-	name := "testbuildcmd"
+	const name = "testbuildcmd"
 	expected := "[/bin/echo Hello World]"
 
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
@@ -1584,7 +1584,7 @@ func (s *DockerCLIBuildSuite) TestBuildCmd(c *testing.T) {
 
 func (s *DockerCLIBuildSuite) TestBuildExpose(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Expose not implemented on Windows
-	name := "testbuildexpose"
+	const name = "testbuildexpose"
 	expected := "map[2375/tcp:{}]"
 
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM scratch
@@ -1622,7 +1622,7 @@ func (s *DockerCLIBuildSuite) TestBuildExposeMorePorts(c *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	tmpl.Execute(buf, portList)
 
-	name := "testbuildexpose"
+	const name = "testbuildexpose"
 	buildImageSuccessfully(c, name, build.WithDockerfile(buf.String()))
 
 	// check if all the ports are saved inside Config.ExposedPorts
@@ -1663,7 +1663,7 @@ func (s *DockerCLIBuildSuite) TestBuildExposeOrder(c *testing.T) {
 
 func (s *DockerCLIBuildSuite) TestBuildExposeUpperCaseProto(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Expose not implemented on Windows
-	name := "testbuildexposeuppercaseproto"
+	const name = "testbuildexposeuppercaseproto"
 	expected := "map[5678/udp:{}]"
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM scratch
         EXPOSE 5678/UDP`))
@@ -1674,8 +1674,8 @@ func (s *DockerCLIBuildSuite) TestBuildExposeUpperCaseProto(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildEmptyEntrypointInheritance(c *testing.T) {
-	name := "testbuildentrypointinheritance"
-	name2 := "testbuildentrypointinheritance2"
+	const name = "testbuildentrypointinheritance"
+	const name2 = "testbuildentrypointinheritance2"
 
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
         ENTRYPOINT ["/bin/echo"]`))
@@ -1697,7 +1697,7 @@ func (s *DockerCLIBuildSuite) TestBuildEmptyEntrypointInheritance(c *testing.T) 
 }
 
 func (s *DockerCLIBuildSuite) TestBuildEmptyEntrypoint(c *testing.T) {
-	name := "testbuildentrypoint"
+	const name = "testbuildentrypoint"
 	expected := "[]"
 
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
@@ -1710,7 +1710,7 @@ func (s *DockerCLIBuildSuite) TestBuildEmptyEntrypoint(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildEntrypoint(c *testing.T) {
-	name := "testbuildentrypoint"
+	const name = "testbuildentrypoint"
 
 	expected := "[/bin/echo]"
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
@@ -1743,7 +1743,7 @@ func (s *DockerCLIBuildSuite) TestBuildOnBuildLimitedInheritance(c *testing.T) {
 
 func (s *DockerCLIBuildSuite) TestBuildSameDockerfileWithAndWithoutCache(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Expose not implemented on Windows
-	name := "testbuildwithcache"
+	const name = "testbuildwithcache"
 	dockerfile := `FROM scratch
 		MAINTAINER dockerio
 		EXPOSE 5432
@@ -1764,7 +1764,7 @@ func (s *DockerCLIBuildSuite) TestBuildSameDockerfileWithAndWithoutCache(c *test
 
 // Make sure that ADD/COPY still populate the cache even if they don't use it
 func (s *DockerCLIBuildSuite) TestBuildConditionalCache(c *testing.T) {
-	name := "testbuildconditionalcache"
+	const name = "testbuildconditionalcache"
 
 	dockerfile := `
 		FROM busybox
@@ -1798,7 +1798,7 @@ func (s *DockerCLIBuildSuite) TestBuildConditionalCache(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildAddMultipleLocalFileWithAndWithoutCache(c *testing.T) {
-	name := "testbuildaddmultiplelocalfilewithcache"
+	const name = "testbuildaddmultiplelocalfilewithcache"
 	baseName := name + "-base"
 
 	cli.BuildCmd(c, baseName, build.WithDockerfile(`
@@ -1830,8 +1830,8 @@ func (s *DockerCLIBuildSuite) TestBuildAddMultipleLocalFileWithAndWithoutCache(c
 }
 
 func (s *DockerCLIBuildSuite) TestBuildCopyDirButNotFile(c *testing.T) {
-	name := "testbuildcopydirbutnotfile"
-	name2 := "testbuildcopydirbutnotfile2"
+	const name = "testbuildcopydirbutnotfile"
+	const name2 = "testbuildcopydirbutnotfile2"
 
 	dockerfile := `
         FROM ` + minimalBaseImage() + `
@@ -1854,10 +1854,10 @@ func (s *DockerCLIBuildSuite) TestBuildCopyDirButNotFile(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildAddCurrentDirWithCache(c *testing.T) {
-	name := "testbuildaddcurrentdirwithcache"
-	name2 := name + "2"
-	name3 := name + "3"
-	name4 := name + "4"
+	const name = "testbuildaddcurrentdirwithcache"
+	const name2 = name + "2"
+	const name3 = name + "3"
+	const name4 = name + "4"
 	dockerfile := `
         FROM ` + minimalBaseImage() + `
         MAINTAINER dockerio
@@ -1901,7 +1901,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddCurrentDirWithCache(c *testing.T) {
 
 // FIXME(vdemeester) this really seems to test the same thing as before (TestBuildAddMultipleLocalFileWithAndWithoutCache)
 func (s *DockerCLIBuildSuite) TestBuildAddCurrentDirWithoutCache(c *testing.T) {
-	name := "testbuildaddcurrentdirwithoutcache"
+	const name = "testbuildaddcurrentdirwithoutcache"
 	dockerfile := `
         FROM ` + minimalBaseImage() + `
         MAINTAINER dockerio
@@ -1920,7 +1920,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddCurrentDirWithoutCache(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildAddRemoteFileWithAndWithoutCache(c *testing.T) {
-	name := "testbuildaddremotefilewithcache"
+	const name = "testbuildaddremotefilewithcache"
 	server := fakestorage.New(c, "", fakecontext.WithFiles(map[string]string{
 		"baz": "hello",
 	}))
@@ -1945,9 +1945,9 @@ func (s *DockerCLIBuildSuite) TestBuildAddRemoteFileWithAndWithoutCache(c *testi
 }
 
 func (s *DockerCLIBuildSuite) TestBuildAddRemoteFileMTime(c *testing.T) {
-	name := "testbuildaddremotefilemtime"
-	name2 := name + "2"
-	name3 := name + "3"
+	const name = "testbuildaddremotefilemtime"
+	const name2 = name + "2"
+	const name3 = name + "3"
 
 	files := map[string]string{"baz": "hello"}
 	server := fakestorage.New(c, "", fakecontext.WithFiles(files))
@@ -1988,7 +1988,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddRemoteFileMTime(c *testing.T) {
 
 // FIXME(vdemeester) this really seems to test the same thing as before (combined)
 func (s *DockerCLIBuildSuite) TestBuildAddLocalAndRemoteFilesWithAndWithoutCache(c *testing.T) {
-	name := "testbuildaddlocalandremotefilewithcache"
+	const name = "testbuildaddlocalandremotefilewithcache"
 	server := fakestorage.New(c, "", fakecontext.WithFiles(map[string]string{
 		"baz": "hello",
 	}))
@@ -2030,7 +2030,7 @@ CMD ["cat", "/foo"]`),
 	if err != nil {
 		c.Fatalf("failed to build context tar: %v", err)
 	}
-	name := "contexttar"
+	const name = "contexttar"
 
 	cli.BuildCmd(c, name, build.WithStdinContext(context))
 }
@@ -2044,7 +2044,7 @@ func (s *DockerCLIBuildSuite) TestBuildContextTarNoCompression(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildNoContext(c *testing.T) {
-	name := "nocontext"
+	const name = "nocontext"
 	icmd.RunCmd(icmd.Cmd{
 		Command: []string{dockerBinary, "build", "-t", name, "-"},
 		Stdin: strings.NewReader(
@@ -2052,14 +2052,14 @@ func (s *DockerCLIBuildSuite) TestBuildNoContext(c *testing.T) {
 			CMD ["echo", "ok"]`),
 	}).Assert(c, icmd.Success)
 
-	if out, _ := dockerCmd(c, "run", "--rm", "nocontext"); out != "ok\n" {
+	if out := cli.DockerCmd(c, "run", "--rm", "nocontext").Combined(); out != "ok\n" {
 		c.Fatalf("run produced invalid output: %q, expected %q", out, "ok")
 	}
 }
 
 // FIXME(vdemeester) migrate to docker/cli e2e
 func (s *DockerCLIBuildSuite) TestBuildDockerfileStdin(c *testing.T) {
-	name := "stdindockerfile"
+	const name = "stdindockerfile"
 	tmpDir, err := os.MkdirTemp("", "fake-context")
 	assert.NilError(c, err)
 	err = os.WriteFile(filepath.Join(tmpDir, "foo"), []byte("bar"), 0o600)
@@ -2079,7 +2079,7 @@ CMD ["cat", "/foo"]`),
 
 // FIXME(vdemeester) migrate to docker/cli tests (unit or e2e)
 func (s *DockerCLIBuildSuite) TestBuildDockerfileStdinConflict(c *testing.T) {
-	name := "stdindockerfiletarcontext"
+	const name = "stdindockerfiletarcontext"
 	icmd.RunCmd(icmd.Cmd{
 		Command: []string{dockerBinary, "build", "-t", name, "-f", "-", "-"},
 	}).Assert(c, icmd.Expected{
@@ -2101,7 +2101,7 @@ func (s *DockerCLIBuildSuite) TestBuildDockerfileStdinDockerignoreIgnored(c *tes
 }
 
 func (s *DockerCLIBuildSuite) testBuildDockerfileStdinNoExtraFiles(c *testing.T, hasDockerignore, ignoreDockerignore bool) {
-	name := "stdindockerfilenoextra"
+	const name = "stdindockerfilenoextra"
 	tmpDir, err := os.MkdirTemp("", "fake-context")
 	assert.NilError(c, err)
 	defer os.RemoveAll(tmpDir)
@@ -2142,13 +2142,13 @@ COPY . /baz`),
 
 func (s *DockerCLIBuildSuite) TestBuildWithVolumeOwnership(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	name := "testbuildimg"
+	const name = "testbuildimg"
 
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox:latest
         RUN mkdir /test && chown daemon:daemon /test && chmod 0600 /test
         VOLUME /test`))
 
-	out, _ := dockerCmd(c, "run", "--rm", "testbuildimg", "ls", "-la", "/test")
+	out := cli.DockerCmd(c, "run", "--rm", "testbuildimg", "ls", "-la", "/test").Combined()
 	if expected := "drw-------"; !strings.Contains(out, expected) {
 		c.Fatalf("expected %s received %s", expected, out)
 	}
@@ -2160,7 +2160,7 @@ func (s *DockerCLIBuildSuite) TestBuildWithVolumeOwnership(c *testing.T) {
 // testing #1405 - config.Cmd does not get cleaned up if
 // utilizing cache
 func (s *DockerCLIBuildSuite) TestBuildEntrypointRunCleanup(c *testing.T) {
-	name := "testbuildcmdcleanup"
+	const name = "testbuildcmdcleanup"
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
         RUN echo "hello"`))
 
@@ -2179,7 +2179,7 @@ func (s *DockerCLIBuildSuite) TestBuildEntrypointRunCleanup(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildAddFileNotFound(c *testing.T) {
-	name := "testbuildaddnotfound"
+	const name = "testbuildaddnotfound"
 
 	buildImage(name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `FROM `+minimalBaseImage()+`
@@ -2192,7 +2192,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddFileNotFound(c *testing.T) {
 
 func (s *DockerCLIBuildSuite) TestBuildInheritance(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	name := "testbuildinheritance"
+	const name = "testbuildinheritance"
 
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM scratch
 		EXPOSE 2375`))
@@ -2212,7 +2212,7 @@ func (s *DockerCLIBuildSuite) TestBuildInheritance(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildFails(c *testing.T) {
-	name := "testbuildfails"
+	const name = "testbuildfails"
 	buildImage(name, build.WithDockerfile(`FROM busybox
 		RUN sh -c "exit 23"`)).Assert(c, icmd.Expected{
 		ExitCode: 23,
@@ -2221,7 +2221,7 @@ func (s *DockerCLIBuildSuite) TestBuildFails(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildOnBuild(c *testing.T) {
-	name := "testbuildonbuild"
+	const name = "testbuildonbuild"
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		ONBUILD RUN touch foobar`))
 	buildImageSuccessfully(c, name, build.WithDockerfile(fmt.Sprintf(`FROM %s
@@ -2234,7 +2234,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddToSymlinkDest(c *testing.T) {
 	if testEnv.DaemonInfo.OSType == "windows" {
 		makeLink = `mklink /D C:\bar C:\foo`
 	}
-	name := "testbuildaddtosymlinkdest"
+	const name = "testbuildaddtosymlinkdest"
 	buildImageSuccessfully(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `
 		FROM busybox
@@ -2248,7 +2248,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddToSymlinkDest(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildEscapeWhitespace(c *testing.T) {
-	name := "testbuildescapewhitespace"
+	const name = "testbuildescapewhitespace"
 
 	buildImageSuccessfully(c, name, build.WithDockerfile(`
   # ESCAPE=\
@@ -2266,20 +2266,20 @@ docker.com>"
 
 func (s *DockerCLIBuildSuite) TestBuildVerifyIntString(c *testing.T) {
 	// Verify that strings that look like ints are still passed as strings
-	name := "testbuildstringing"
+	const name = "testbuildstringing"
 
 	buildImageSuccessfully(c, name, build.WithDockerfile(`
 	FROM busybox
 	MAINTAINER 123`))
 
-	out, _ := dockerCmd(c, "inspect", name)
+	out := cli.DockerCmd(c, "inspect", name).Stdout()
 	if !strings.Contains(out, `"123"`) {
 		c.Fatalf("Output does not contain the int as a string:\n%s", out)
 	}
 }
 
 func (s *DockerCLIBuildSuite) TestBuildDockerignore(c *testing.T) {
-	name := "testbuilddockerignore"
+	const name = "testbuilddockerignore"
 	buildImageSuccessfully(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `
 		FROM busybox
@@ -2317,7 +2317,7 @@ dir`),
 }
 
 func (s *DockerCLIBuildSuite) TestBuildDockerignoreCleanPaths(c *testing.T) {
-	name := "testbuilddockerignorecleanpaths"
+	const name = "testbuilddockerignorecleanpaths"
 	buildImageSuccessfully(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `
         FROM busybox
@@ -2331,7 +2331,7 @@ func (s *DockerCLIBuildSuite) TestBuildDockerignoreCleanPaths(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildDockerignoreExceptions(c *testing.T) {
-	name := "testbuilddockerignoreexceptions"
+	const name = "testbuilddockerignoreexceptions"
 	buildImageSuccessfully(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `
 		FROM busybox
@@ -2376,7 +2376,7 @@ dir
 }
 
 func (s *DockerCLIBuildSuite) TestBuildDockerignoringDockerfile(c *testing.T) {
-	name := "testbuilddockerignoredockerfile"
+	const name = "testbuilddockerignoredockerfile"
 	dockerfile := `
 		FROM busybox
 		ADD . /tmp/
@@ -2394,7 +2394,7 @@ func (s *DockerCLIBuildSuite) TestBuildDockerignoringDockerfile(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildDockerignoringRenamedDockerfile(c *testing.T) {
-	name := "testbuilddockerignoredockerfile"
+	const name = "testbuilddockerignoredockerfile"
 	dockerfile := `
 		FROM busybox
 		ADD . /tmp/
@@ -2415,7 +2415,7 @@ func (s *DockerCLIBuildSuite) TestBuildDockerignoringRenamedDockerfile(c *testin
 }
 
 func (s *DockerCLIBuildSuite) TestBuildDockerignoringDockerignore(c *testing.T) {
-	name := "testbuilddockerignoredockerignore"
+	const name = "testbuilddockerignoredockerignore"
 	dockerfile := `
 		FROM busybox
 		ADD . /tmp/
@@ -2428,7 +2428,7 @@ func (s *DockerCLIBuildSuite) TestBuildDockerignoringDockerignore(c *testing.T) 
 }
 
 func (s *DockerCLIBuildSuite) TestBuildDockerignoreTouchDockerfile(c *testing.T) {
-	name := "testbuilddockerignoretouchdockerfile"
+	const name = "testbuilddockerignoretouchdockerfile"
 	dockerfile := `
         FROM busybox
 		ADD . /tmp/`
@@ -2470,7 +2470,7 @@ func (s *DockerCLIBuildSuite) TestBuildDockerignoreTouchDockerfile(c *testing.T)
 }
 
 func (s *DockerCLIBuildSuite) TestBuildDockerignoringWholeDir(c *testing.T) {
-	name := "testbuilddockerignorewholedir"
+	const name = "testbuilddockerignorewholedir"
 
 	dockerfile := `
 		FROM busybox
@@ -2487,7 +2487,7 @@ func (s *DockerCLIBuildSuite) TestBuildDockerignoringWholeDir(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildDockerignoringOnlyDotfiles(c *testing.T) {
-	name := "testbuilddockerignorewholedir"
+	const name = "testbuilddockerignorewholedir"
 
 	dockerfile := `
 		FROM busybox
@@ -2504,7 +2504,7 @@ func (s *DockerCLIBuildSuite) TestBuildDockerignoringOnlyDotfiles(c *testing.T) 
 }
 
 func (s *DockerCLIBuildSuite) TestBuildDockerignoringBadExclusion(c *testing.T) {
-	name := "testbuilddockerignorebadexclusion"
+	const name = "testbuilddockerignorebadexclusion"
 	buildImage(name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `
 		FROM busybox
@@ -2538,7 +2538,7 @@ func (s *DockerCLIBuildSuite) TestBuildDockerignoringWildTopDir(c *testing.T) {
 			build.WithFile(".dockerignore", variant),
 		))
 
-		dockerCmd(c, "rmi", "noname")
+		cli.DockerCmd(c, "rmi", "noname")
 	}
 }
 
@@ -2607,7 +2607,7 @@ dir1/dir3/**
 
 func (s *DockerCLIBuildSuite) TestBuildLineBreak(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	name := "testbuildlinebreak"
+	const name = "testbuildlinebreak"
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM  busybox
 RUN    sh -c 'echo root:testpass \
 	> /tmp/passwd'
@@ -2618,7 +2618,7 @@ RUN    sh -c "[ "$(ls -d /var/run/sshd)" = "/var/run/sshd" ]"`))
 
 func (s *DockerCLIBuildSuite) TestBuildEOLInLine(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	name := "testbuildeolinline"
+	const name = "testbuildeolinline"
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM   busybox
 RUN    sh -c 'echo root:testpass > /tmp/passwd'
 RUN    echo "foo \n bar"; echo "baz"
@@ -2629,7 +2629,7 @@ RUN    sh -c "[ "$(ls -d /var/run/sshd)" = "/var/run/sshd" ]"`))
 
 func (s *DockerCLIBuildSuite) TestBuildCommentsShebangs(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	name := "testbuildcomments"
+	const name = "testbuildcomments"
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 # This is an ordinary comment.
 RUN { echo '#!/bin/sh'; echo 'echo hello world'; } > /hello.sh
@@ -2643,7 +2643,7 @@ RUN [ "$(/hello.sh)" = "hello world" ]`))
 
 func (s *DockerCLIBuildSuite) TestBuildUsersAndGroups(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	name := "testbuildusers"
+	const name = "testbuildusers"
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 
 # Make sure our defaults work
@@ -2701,7 +2701,7 @@ func (s *DockerCLIBuildSuite) TestBuildEnvUsage(c *testing.T) {
 	// /docker/world/hello is not owned by the correct user
 	testRequires(c, NotUserNamespace)
 	testRequires(c, DaemonIsLinux)
-	name := "testbuildenvusage"
+	const name = "testbuildenvusage"
 	dockerfile := `FROM busybox
 ENV    HOME /root
 ENV    PATH $HOME/bin:$PATH
@@ -2732,7 +2732,7 @@ func (s *DockerCLIBuildSuite) TestBuildEnvUsage2(c *testing.T) {
 	// /docker/world/hello is not owned by the correct user
 	testRequires(c, NotUserNamespace)
 	testRequires(c, DaemonIsLinux)
-	name := "testbuildenvusage2"
+	const name = "testbuildenvusage2"
 	dockerfile := `FROM busybox
 ENV    abc=def def="hello world"
 RUN    [ "$abc,$def" = "def,hello world" ]
@@ -2799,7 +2799,7 @@ RUN    [ "$eee1,$eee2,$eee3,$eee4" = 'foo,foo,foo,foo' ]
 
 func (s *DockerCLIBuildSuite) TestBuildAddScript(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	name := "testbuildaddscript"
+	const name = "testbuildaddscript"
 	dockerfile := `
 FROM busybox
 ADD test /test
@@ -2816,7 +2816,7 @@ RUN [ "$(cat /testfile)" = 'test!' ]`
 func (s *DockerCLIBuildSuite) TestBuildAddTar(c *testing.T) {
 	// /test/foo is not owned by the correct user
 	testRequires(c, NotUserNamespace)
-	name := "testbuildaddtar"
+	const name = "testbuildaddtar"
 
 	ctx := func() *fakecontext.Fake {
 		dockerfile := `
@@ -2868,7 +2868,7 @@ RUN cat /existing-directory-trailing-slash/test/foo | grep Hi`
 }
 
 func (s *DockerCLIBuildSuite) TestBuildAddBrokenTar(c *testing.T) {
-	name := "testbuildaddbrokentar"
+	const name = "testbuildaddbrokentar"
 
 	ctx := func() *fakecontext.Fake {
 		dockerfile := `
@@ -2919,7 +2919,7 @@ ADD test.tar /`
 }
 
 func (s *DockerCLIBuildSuite) TestBuildAddNonTar(c *testing.T) {
-	name := "testbuildaddnontar"
+	const name = "testbuildaddnontar"
 
 	// Should not try to extract test.tar
 	buildImageSuccessfully(c, name, build.WithBuildContext(c,
@@ -2935,7 +2935,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddTarXz(c *testing.T) {
 	// /test/foo is not owned by the correct user
 	testRequires(c, NotUserNamespace)
 	testRequires(c, DaemonIsLinux)
-	name := "testbuildaddtarxz"
+	const name = "testbuildaddtarxz"
 
 	ctx := func() *fakecontext.Fake {
 		dockerfile := `
@@ -2982,7 +2982,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddTarXz(c *testing.T) {
 
 func (s *DockerCLIBuildSuite) TestBuildAddTarXzGz(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	name := "testbuildaddtarxzgz"
+	const name = "testbuildaddtarxzgz"
 
 	ctx := func() *fakecontext.Fake {
 		dockerfile := `
@@ -3034,7 +3034,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddTarXzGz(c *testing.T) {
 
 // FIXME(vdemeester) most of the from git tests could be moved to `docker/cli` e2e tests
 func (s *DockerCLIBuildSuite) TestBuildFromGit(c *testing.T) {
-	name := "testbuildfromgit"
+	const name = "testbuildfromgit"
 	git := fakegit.New(c, "repo", map[string]string{
 		"Dockerfile": `FROM busybox
 		ADD first /first
@@ -3053,7 +3053,7 @@ func (s *DockerCLIBuildSuite) TestBuildFromGit(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildFromGitWithContext(c *testing.T) {
-	name := "testbuildfromgit"
+	const name = "testbuildfromgit"
 	git := fakegit.New(c, "repo", map[string]string{
 		"docker/Dockerfile": `FROM busybox
 					ADD first /first
@@ -3072,7 +3072,7 @@ func (s *DockerCLIBuildSuite) TestBuildFromGitWithContext(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildFromGitWithF(c *testing.T) {
-	name := "testbuildfromgitwithf"
+	const name = "testbuildfromgitwithf"
 	git := fakegit.New(c, "repo", map[string]string{
 		"myApp/myDockerfile": `FROM busybox
 					RUN echo hi from Dockerfile`,
@@ -3085,7 +3085,7 @@ func (s *DockerCLIBuildSuite) TestBuildFromGitWithF(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildFromRemoteTarball(c *testing.T) {
-	name := "testbuildfromremotetarball"
+	const name = "testbuildfromremotetarball"
 
 	buffer := new(bytes.Buffer)
 	tw := tar.NewWriter(buffer)
@@ -3120,7 +3120,7 @@ func (s *DockerCLIBuildSuite) TestBuildFromRemoteTarball(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildCleanupCmdOnEntrypoint(c *testing.T) {
-	name := "testbuildcmdcleanuponentrypoint"
+	const name = "testbuildcmdcleanuponentrypoint"
 
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
 		CMD ["test"]
@@ -3139,7 +3139,7 @@ func (s *DockerCLIBuildSuite) TestBuildCleanupCmdOnEntrypoint(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildClearCmd(c *testing.T) {
-	name := "testbuildclearcmd"
+	const name = "testbuildclearcmd"
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
    ENTRYPOINT ["/bin/bash"]
    CMD []`))
@@ -3154,7 +3154,7 @@ func (s *DockerCLIBuildSuite) TestBuildEmptyCmd(c *testing.T) {
 	// Skip on Windows. Base image on Windows has a CMD set in the image.
 	testRequires(c, DaemonIsLinux)
 
-	name := "testbuildemptycmd"
+	const name = "testbuildemptycmd"
 	buildImageSuccessfully(c, name, build.WithDockerfile("FROM "+minimalBaseImage()+"\nMAINTAINER quux\n"))
 
 	res := inspectFieldJSON(c, name, "Config.Cmd")
@@ -3164,7 +3164,7 @@ func (s *DockerCLIBuildSuite) TestBuildEmptyCmd(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildOnBuildOutput(c *testing.T) {
-	name := "testbuildonbuildparent"
+	const name = "testbuildonbuildparent"
 	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nONBUILD RUN echo foo\n"))
 
 	buildImage(name, build.WithDockerfile("FROM "+name+"\nMAINTAINER quux\n")).Assert(c, icmd.Expected{
@@ -3182,7 +3182,7 @@ func (s *DockerCLIBuildSuite) TestBuildInvalidTag(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildCmdShDashC(c *testing.T) {
-	name := "testbuildcmdshc"
+	const name = "testbuildcmdshc"
 	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nCMD echo cmd\n"))
 
 	res := inspectFieldJSON(c, name, "Config.Cmd")
@@ -3199,7 +3199,7 @@ func (s *DockerCLIBuildSuite) TestBuildCmdSpaces(c *testing.T) {
 	// Test to make sure that when we strcat arrays we take into account
 	// the arg separator to make sure ["echo","hi"] and ["echo hi"] don't
 	// look the same
-	name := "testbuildcmdspaces"
+	const name = "testbuildcmdspaces"
 
 	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nCMD [\"echo hi\"]\n"))
 	id1 := getIDByName(c, name)
@@ -3222,7 +3222,7 @@ func (s *DockerCLIBuildSuite) TestBuildCmdSpaces(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildCmdJSONNoShDashC(c *testing.T) {
-	name := "testbuildcmdjson"
+	const name = "testbuildcmdjson"
 	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nCMD [\"echo\", \"cmd\"]"))
 
 	res := inspectFieldJSON(c, name, "Config.Cmd")
@@ -3277,15 +3277,15 @@ func (s *DockerCLIBuildSuite) TestBuildEntrypointCanBeOverriddenByChildInspect(c
 }
 
 func (s *DockerCLIBuildSuite) TestBuildRunShEntrypoint(c *testing.T) {
-	name := "testbuildentrypoint"
+	const name = "testbuildentrypoint"
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
                                 ENTRYPOINT echo`))
-	dockerCmd(c, "run", "--rm", name)
+	cli.DockerCmd(c, "run", "--rm", name)
 }
 
 func (s *DockerCLIBuildSuite) TestBuildExoticShellInterpolation(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	name := "testbuildexoticshellinterpolation"
+	const name = "testbuildexoticshellinterpolation"
 
 	buildImageSuccessfully(c, name, build.WithDockerfile(`
 		FROM busybox
@@ -3314,7 +3314,7 @@ func (s *DockerCLIBuildSuite) TestBuildVerifySingleQuoteFails(c *testing.T) {
 	// of double quotes (per the JSON spec). This means we interpret it
 	// as a "string" instead of "JSON array" and pass it on to "sh -c" and
 	// it should barf on it.
-	name := "testbuildsinglequotefails"
+	const name = "testbuildsinglequotefails"
 	expectedExitCode := 2
 
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
@@ -3326,7 +3326,7 @@ func (s *DockerCLIBuildSuite) TestBuildVerifySingleQuoteFails(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildVerboseOut(c *testing.T) {
-	name := "testbuildverboseout"
+	const name = "testbuildverboseout"
 	expected := "\n123\n"
 
 	if testEnv.DaemonInfo.OSType == "windows" {
@@ -3340,7 +3340,7 @@ RUN echo 123`)).Assert(c, icmd.Expected{
 }
 
 func (s *DockerCLIBuildSuite) TestBuildWithTabs(c *testing.T) {
-	name := "testbuildwithtabs"
+	const name = "testbuildwithtabs"
 	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nRUN echo\tone\t\ttwo"))
 	res := inspectFieldJSON(c, name, "ContainerConfig.Cmd")
 	expected1 := `["/bin/sh","-c","echo\tone\t\ttwo"]`
@@ -3355,7 +3355,7 @@ func (s *DockerCLIBuildSuite) TestBuildWithTabs(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildLabels(c *testing.T) {
-	name := "testbuildlabel"
+	const name = "testbuildlabel"
 	expected := `{"License":"GPL","Vendor":"Acme"}`
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		LABEL Vendor=Acme
@@ -3367,7 +3367,7 @@ func (s *DockerCLIBuildSuite) TestBuildLabels(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildLabelsCache(c *testing.T) {
-	name := "testbuildlabelcache"
+	const name = "testbuildlabelcache"
 
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		LABEL Vendor=Acme`))
@@ -3510,7 +3510,7 @@ func (s *DockerCLIBuildSuite) TestBuildNotVerboseFailureRemote(c *testing.T) {
 	// stderr in verbose mode are identical.
 	// TODO(vdemeester) with cobra, stdout has a carriage return too much so this test should not check stdout
 	URL := "http://something.invalid"
-	name := "quiet_build_wrong_remote"
+	const name = "quiet_build_wrong_remote"
 	quietResult := buildImage(name, cli.WithFlags("-q"), build.WithContextPath(URL))
 	quietResult.Assert(c, icmd.Expected{
 		ExitCode: 1,
@@ -3538,7 +3538,7 @@ func (s *DockerCLIBuildSuite) TestBuildNotVerboseFailureRemote(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildStderr(c *testing.T) {
 	// This test just makes sure that no non-error output goes
 	// to stderr
-	name := "testbuildstderr"
+	const name = "testbuildstderr"
 	result := buildImage(name, build.WithDockerfile("FROM busybox\nRUN echo one"))
 	result.Assert(c, icmd.Success)
 
@@ -3556,7 +3556,7 @@ func (s *DockerCLIBuildSuite) TestBuildStderr(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildChownSingleFile(c *testing.T) {
 	testRequires(c, UnixCli, DaemonIsLinux) // test uses chown: not available on windows
 
-	name := "testbuildchownsinglefile"
+	const name = "testbuildchownsinglefile"
 
 	ctx := fakecontext.New(c, "",
 		fakecontext.WithDockerfile(`
@@ -3578,7 +3578,7 @@ RUN [ $(ls -l /test | awk '{print $3":"$4}') = 'root:root' ]
 }
 
 func (s *DockerCLIBuildSuite) TestBuildSymlinkBreakout(c *testing.T) {
-	name := "testbuildsymlinkbreakout"
+	const name = "testbuildsymlinkbreakout"
 	tmpdir, err := os.MkdirTemp("", name)
 	assert.NilError(c, err)
 
@@ -3636,7 +3636,7 @@ func (s *DockerCLIBuildSuite) TestBuildXZHost(c *testing.T) {
 	// /usr/local/sbin/xz gets permission denied for the user
 	testRequires(c, NotUserNamespace)
 	testRequires(c, DaemonIsLinux)
-	name := "testbuildxzhost"
+	const name = "testbuildxzhost"
 
 	buildImageSuccessfully(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `
@@ -3673,7 +3673,7 @@ CMD cat /foo/file`),
 		build.WithFile("content", expected),
 	))
 
-	out, _ := dockerCmd(c, "run", "--rm", name)
+	out := cli.DockerCmd(c, "run", "--rm", name).Combined()
 	if out != expected {
 		c.Fatalf("expected file contents for /foo/file to be %q but received %q", expected, out)
 	}
@@ -3754,7 +3754,7 @@ RUN sh -c "find /tmp/" # sh -c is needed on Windows to use the correct find`)
 }
 
 func (s *DockerCLIBuildSuite) TestBuildFromOfficialNames(c *testing.T) {
-	name := "testbuildfromofficial"
+	const name = "testbuildfromofficial"
 	fromNames := []string{
 		"busybox",
 		"docker.io/busybox",
@@ -3766,7 +3766,7 @@ func (s *DockerCLIBuildSuite) TestBuildFromOfficialNames(c *testing.T) {
 	for idx, fromName := range fromNames {
 		imgName := fmt.Sprintf("%s%d", name, idx)
 		buildImageSuccessfully(c, imgName, build.WithDockerfile("FROM "+fromName))
-		dockerCmd(c, "rmi", imgName)
+		cli.DockerCmd(c, "rmi", imgName)
 	}
 }
 
@@ -3774,7 +3774,7 @@ func (s *DockerCLIBuildSuite) TestBuildFromOfficialNames(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildSpaces(c *testing.T) {
 	// Test to make sure that leading/trailing spaces on a command
 	// doesn't change the error msg we get
-	name := "testspaces"
+	const name = "testspaces"
 	ctx := fakecontext.New(c, "", fakecontext.WithDockerfile("FROM busybox\nCOPY\n"))
 	defer ctx.Close()
 
@@ -3835,7 +3835,7 @@ func (s *DockerCLIBuildSuite) TestBuildSpaces(c *testing.T) {
 
 func (s *DockerCLIBuildSuite) TestBuildSpacesWithQuotes(c *testing.T) {
 	// Test to make sure that spaces in quotes aren't lost
-	name := "testspacesquotes"
+	const name = "testspacesquotes"
 
 	dockerfile := `FROM busybox
 RUN echo "  \
@@ -3927,7 +3927,7 @@ func (s *DockerCLIBuildSuite) TestBuildDotDotFile(c *testing.T) {
 
 func (s *DockerCLIBuildSuite) TestBuildRUNoneJSON(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // No hello-world Windows image
-	name := "testbuildrunonejson"
+	const name = "testbuildrunonejson"
 
 	buildImage(name, build.WithDockerfile(`FROM hello-world:frozen
 RUN [ "/hello" ]`)).Assert(c, icmd.Expected{
@@ -3936,7 +3936,7 @@ RUN [ "/hello" ]`)).Assert(c, icmd.Expected{
 }
 
 func (s *DockerCLIBuildSuite) TestBuildEmptyStringVolume(c *testing.T) {
-	name := "testbuildemptystringvolume"
+	const name = "testbuildemptystringvolume"
 
 	buildImage(name, build.WithDockerfile(`
   FROM busybox
@@ -3979,7 +3979,7 @@ func (s *DockerCLIBuildSuite) TestBuildNoDupOutput(c *testing.T) {
 	// Check to make sure our build output prints the Dockerfile cmd
 	// property - there was a bug that caused it to be duplicated on the
 	// Step X  line
-	name := "testbuildnodupoutput"
+	const name = "testbuildnodupoutput"
 	result := buildImage(name, build.WithDockerfile(`
   FROM busybox
   RUN env`))
@@ -3994,7 +3994,7 @@ func (s *DockerCLIBuildSuite) TestBuildNoDupOutput(c *testing.T) {
 // FIXME(vdemeester) could be a unit test
 func (s *DockerCLIBuildSuite) TestBuildStartsFromOne(c *testing.T) {
 	// Explicit check to ensure that build starts from step 1 rather than 0
-	name := "testbuildstartsfromone"
+	const name = "testbuildstartsfromone"
 	result := buildImage(name, build.WithDockerfile(`FROM busybox`))
 	result.Assert(c, icmd.Success)
 	exp := "\nStep 1/1 : FROM busybox\n"
@@ -4006,7 +4006,7 @@ func (s *DockerCLIBuildSuite) TestBuildStartsFromOne(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildRUNErrMsg(c *testing.T) {
 	// Test to make sure the bad command is quoted with just "s and
 	// not as a Go []string
-	name := "testbuildbadrunerrmsg"
+	const name = "testbuildbadrunerrmsg"
 	shell := "/bin/sh -c"
 	exitCode := 127
 	if testEnv.DaemonInfo.OSType == "windows" {
@@ -4026,7 +4026,7 @@ func (s *DockerCLIBuildSuite) TestBuildRUNErrMsg(c *testing.T) {
 
 // Issue #15634: COPY fails when path starts with "null"
 func (s *DockerCLIBuildSuite) TestBuildNullStringInAddCopyVolume(c *testing.T) {
-	name := "testbuildnullstringinaddcopyvolume"
+	const name = "testbuildnullstringinaddcopyvolume"
 	volName := "nullvolume"
 	if testEnv.DaemonInfo.OSType == "windows" {
 		volName = `C:\\nullvolume`
@@ -4056,7 +4056,7 @@ func (s *DockerCLIBuildSuite) TestBuildStopSignal(c *testing.T) {
 	}
 
 	containerName := "test-container-stop-signal"
-	dockerCmd(c, "run", "-d", "--name", containerName, imgName, "top")
+	cli.DockerCmd(c, "run", "-d", "--name", containerName, imgName, "top")
 	res = inspectFieldJSON(c, containerName, "Config.StopSignal")
 	if res != `"SIGKILL"` {
 		c.Fatalf("Signal %s, expected SIGKILL", res)
@@ -4088,7 +4088,7 @@ func (s *DockerCLIBuildSuite) TestBuildBuildTimeArg(c *testing.T) {
 	})
 
 	containerName := "bldargCont"
-	out, _ := dockerCmd(c, "run", "--name", containerName, imgName)
+	out := cli.DockerCmd(c, "run", "--name", containerName, imgName).Combined()
 	out = strings.Trim(out, " \r\n'")
 	if out != "" {
 		c.Fatalf("run produced invalid output: %q, expected empty string", out)
@@ -4109,7 +4109,7 @@ func (s *DockerCLIBuildSuite) TestBuildBuildTimeArgHistory(c *testing.T) {
 		Out: envVal,
 	})
 
-	out, _ := dockerCmd(c, "history", "--no-trunc", imgName)
+	out := cli.DockerCmd(c, "history", "--no-trunc", imgName).Combined()
 	outputTabs := strings.Split(out, "\n")[1]
 	if !strings.Contains(outputTabs, envDef) {
 		c.Fatalf("failed to find arg default in image history output: %q expected: %q", outputTabs, envDef)
@@ -4259,7 +4259,7 @@ func (s *DockerCLIBuildSuite) TestBuildBuildTimeArgOverrideArgDefinedBeforeEnv(c
 	}
 
 	containerName := "bldargCont"
-	if out, _ := dockerCmd(c, "run", "--name", containerName, imgName); !strings.Contains(out, envValOverride) {
+	if out := cli.DockerCmd(c, "run", "--name", containerName, imgName).Combined(); !strings.Contains(out, envValOverride) {
 		c.Fatalf("run produced invalid output: %q, expected %q", out, envValOverride)
 	}
 }
@@ -4287,7 +4287,7 @@ func (s *DockerCLIBuildSuite) TestBuildBuildTimeArgOverrideEnvDefinedBeforeArg(c
 	}
 
 	containerName := "bldargCont"
-	if out, _ := dockerCmd(c, "run", "--name", containerName, imgName); !strings.Contains(out, envValOverride) {
+	if out := cli.DockerCmd(c, "run", "--name", containerName, imgName).Combined(); !strings.Contains(out, envValOverride) {
 		c.Fatalf("run produced invalid output: %q, expected %q", out, envValOverride)
 	}
 }
@@ -4405,7 +4405,7 @@ func (s *DockerCLIBuildSuite) TestBuildBuildTimeArgExpansionOverride(c *testing.
 	}
 
 	containerName := "bldargCont"
-	if out, _ := dockerCmd(c, "run", "--name", containerName, imgName); !strings.Contains(out, envValOverride) {
+	if out := cli.DockerCmd(c, "run", "--name", containerName, imgName).Combined(); !strings.Contains(out, envValOverride) {
 		c.Fatalf("run produced invalid output: %q, expected %q", out, envValOverride)
 	}
 }
@@ -4429,7 +4429,7 @@ func (s *DockerCLIBuildSuite) TestBuildBuildTimeArgUntrustedDefinedAfterUse(c *t
 	}
 
 	containerName := "bldargCont"
-	if out, _ := dockerCmd(c, "run", "--name", containerName, imgName); out != "\n" {
+	if out := cli.DockerCmd(c, "run", "--name", containerName, imgName).Combined(); out != "\n" {
 		c.Fatalf("run produced invalid output: %q, expected empty string", out)
 	}
 }
@@ -4452,7 +4452,7 @@ func (s *DockerCLIBuildSuite) TestBuildBuildTimeArgBuiltinArg(c *testing.T) {
 		c.Fatalf("failed to access environment variable in output: %q expected: %q", result.Combined(), envVal)
 	}
 	containerName := "bldargCont"
-	if out, _ := dockerCmd(c, "run", "--name", containerName, imgName); out != "\n" {
+	if out := cli.DockerCmd(c, "run", "--name", containerName, imgName).Combined(); out != "\n" {
 		c.Fatalf("run produced invalid output: %q, expected empty string", out)
 	}
 }
@@ -4478,7 +4478,7 @@ func (s *DockerCLIBuildSuite) TestBuildBuildTimeArgDefaultOverride(c *testing.T)
 	}
 
 	containerName := "bldargCont"
-	if out, _ := dockerCmd(c, "run", "--name", containerName, imgName); !strings.Contains(out, envValOverride) {
+	if out := cli.DockerCmd(c, "run", "--name", containerName, imgName).Combined(); !strings.Contains(out, envValOverride) {
 		c.Fatalf("run produced invalid output: %q, expected %q", out, envValOverride)
 	}
 }
@@ -4692,7 +4692,7 @@ func (s *DockerCLIBuildSuite) TestBuildNoNamedVolume(c *testing.T) {
 	if testEnv.DaemonInfo.OSType == "windows" {
 		volName = "testname:C:\\foo"
 	}
-	dockerCmd(c, "run", "-v", volName, "busybox", "sh", "-c", "touch /foo/oops")
+	cli.DockerCmd(c, "run", "-v", volName, "busybox", "sh", "-c", "touch /foo/oops")
 
 	dockerFile := `FROM busybox
 	VOLUME ` + volName + `
@@ -4712,7 +4712,7 @@ func (s *DockerCLIBuildSuite) TestBuildTagEvent(c *testing.T) {
 	buildImageSuccessfully(c, "test", build.WithDockerfile(dockerFile))
 
 	until := daemonUnixTime(c)
-	out, _ := dockerCmd(c, "events", "--since", since, "--until", until, "--filter", "type=image")
+	out := cli.DockerCmd(c, "events", "--since", since, "--until", until, "--filter", "type=image").Stdout()
 	events := strings.Split(strings.TrimSpace(out), "\n")
 	actions := eventActionsByIDAndType(c, events, "test:latest", "image")
 	var foundTag bool
@@ -4741,7 +4741,7 @@ func (s *DockerCLIBuildSuite) TestBuildMultipleTags(c *testing.T) {
 
 // #17290
 func (s *DockerCLIBuildSuite) TestBuildCacheBrokenSymlink(c *testing.T) {
-	name := "testbuildbrokensymlink"
+	const name = "testbuildbrokensymlink"
 	ctx := fakecontext.New(c, "",
 		fakecontext.WithDockerfile(`
 	FROM busybox
@@ -4768,7 +4768,7 @@ func (s *DockerCLIBuildSuite) TestBuildCacheBrokenSymlink(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildFollowSymlinkToFile(c *testing.T) {
-	name := "testbuildbrokensymlink"
+	const name = "testbuildbrokensymlink"
 	ctx := fakecontext.New(c, "",
 		fakecontext.WithDockerfile(`
 	FROM busybox
@@ -4797,7 +4797,7 @@ func (s *DockerCLIBuildSuite) TestBuildFollowSymlinkToFile(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildFollowSymlinkToDir(c *testing.T) {
-	name := "testbuildbrokensymlink"
+	const name = "testbuildbrokensymlink"
 	ctx := fakecontext.New(c, "",
 		fakecontext.WithDockerfile(`
 	FROM busybox
@@ -4829,7 +4829,7 @@ func (s *DockerCLIBuildSuite) TestBuildFollowSymlinkToDir(c *testing.T) {
 // TestBuildSymlinkBasename tests that target file gets basename from symlink,
 // not from the target file.
 func (s *DockerCLIBuildSuite) TestBuildSymlinkBasename(c *testing.T) {
-	name := "testbuildbrokensymlink"
+	const name = "testbuildbrokensymlink"
 	ctx := fakecontext.New(c, "",
 		fakecontext.WithDockerfile(`
 	FROM busybox
@@ -4850,7 +4850,7 @@ func (s *DockerCLIBuildSuite) TestBuildSymlinkBasename(c *testing.T) {
 
 // #17827
 func (s *DockerCLIBuildSuite) TestBuildCacheRootSource(c *testing.T) {
-	name := "testbuildrootsource"
+	const name = "testbuildrootsource"
 	ctx := fakecontext.New(c, "",
 		fakecontext.WithDockerfile(`
 	FROM busybox
@@ -4891,7 +4891,7 @@ func (s *DockerCLIBuildSuite) TestBuildFailsGitNotCallable(c *testing.T) {
 // TestBuildWorkdirWindowsPath tests that a Windows style path works as a workdir
 func (s *DockerCLIBuildSuite) TestBuildWorkdirWindowsPath(c *testing.T) {
 	testRequires(c, DaemonIsWindows)
-	name := "testbuildworkdirwindowspath"
+	const name = "testbuildworkdirwindowspath"
 	buildImageSuccessfully(c, name, build.WithDockerfile(`
 	FROM `+testEnv.PlatformDefaults.BaseImage+`
 	RUN mkdir C:\\work
@@ -4901,7 +4901,7 @@ func (s *DockerCLIBuildSuite) TestBuildWorkdirWindowsPath(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildLabel(c *testing.T) {
-	name := "testbuildlabel"
+	const name = "testbuildlabel"
 	testLabel := "foo"
 
 	buildImageSuccessfully(c, name, cli.WithFlags("--label", testLabel),
@@ -4918,7 +4918,7 @@ func (s *DockerCLIBuildSuite) TestBuildLabel(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildLabelOneNode(c *testing.T) {
-	name := "testbuildlabel"
+	const name = "testbuildlabel"
 	buildImageSuccessfully(c, name, cli.WithFlags("--label", "foo=bar"),
 		build.WithDockerfile("FROM busybox"))
 
@@ -4932,7 +4932,7 @@ func (s *DockerCLIBuildSuite) TestBuildLabelOneNode(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildLabelCacheCommit(c *testing.T) {
-	name := "testbuildlabelcachecommit"
+	const name = "testbuildlabelcachecommit"
 	testLabel := "foo"
 
 	buildImageSuccessfully(c, name, build.WithDockerfile(`
@@ -4953,7 +4953,7 @@ func (s *DockerCLIBuildSuite) TestBuildLabelCacheCommit(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildLabelMultiple(c *testing.T) {
-	name := "testbuildlabelmultiple"
+	const name = "testbuildlabelmultiple"
 	testLabels := map[string]string{
 		"foo": "bar",
 		"123": "456",
@@ -4979,7 +4979,7 @@ func (s *DockerCLIBuildSuite) TestBuildLabelMultiple(c *testing.T) {
 }
 
 func (s *DockerRegistryAuthHtpasswdSuite) TestBuildFromAuthenticatedRegistry(c *testing.T) {
-	dockerCmd(c, "login", "-u", s.reg.Username(), "-p", s.reg.Password(), privateRegistryURL)
+	cli.DockerCmd(c, "login", "-u", s.reg.Username(), "-p", s.reg.Password(), privateRegistryURL)
 	baseImage := privateRegistryURL + "/baseimage"
 
 	buildImageSuccessfully(c, baseImage, build.WithDockerfile(`
@@ -4987,8 +4987,8 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestBuildFromAuthenticatedRegistry(c *
 	ENV env1 val1
 	`))
 
-	dockerCmd(c, "push", baseImage)
-	dockerCmd(c, "rmi", baseImage)
+	cli.DockerCmd(c, "push", baseImage)
+	cli.DockerCmd(c, "rmi", baseImage)
 
 	buildImageSuccessfully(c, baseImage, build.WithDockerfile(fmt.Sprintf(`
 	FROM %s
@@ -5017,16 +5017,16 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestBuildWithExternalAuth(c *testing.T
 	err = os.WriteFile(configPath, []byte(externalAuthConfig), 0o644)
 	assert.NilError(c, err)
 
-	dockerCmd(c, "--config", tmp, "login", "-u", s.reg.Username(), "-p", s.reg.Password(), privateRegistryURL)
+	cli.DockerCmd(c, "--config", tmp, "login", "-u", s.reg.Username(), "-p", s.reg.Password(), privateRegistryURL)
 
 	b, err := os.ReadFile(configPath)
 	assert.NilError(c, err)
 	assert.Assert(c, !strings.Contains(string(b), "\"auth\":"))
-	dockerCmd(c, "--config", tmp, "tag", "busybox", repoName)
-	dockerCmd(c, "--config", tmp, "push", repoName)
+	cli.DockerCmd(c, "--config", tmp, "tag", "busybox", repoName)
+	cli.DockerCmd(c, "--config", tmp, "push", repoName)
 
 	// make sure the image is pulled when building
-	dockerCmd(c, "rmi", repoName)
+	cli.DockerCmd(c, "rmi", repoName)
 
 	icmd.RunCmd(icmd.Cmd{
 		Command: []string{dockerBinary, "--config", tmp, "build", "-"},
@@ -5115,7 +5115,7 @@ func (s *DockerCLIBuildSuite) TestBuildLabelsOverride(c *testing.T) {
 
 // Test case for #22855
 func (s *DockerCLIBuildSuite) TestBuildDeleteCommittedFile(c *testing.T) {
-	name := "test-delete-committed-file"
+	const name = "test-delete-committed-file"
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		RUN echo test > file
 		RUN test -e file
@@ -5130,7 +5130,7 @@ func (s *DockerCLIBuildSuite) TestBuildDockerignoreComment(c *testing.T) {
 	// it is more reliable, but that's not a good fix.
 	testRequires(c, DaemonIsLinux)
 
-	name := "testbuilddockerignorecleanpaths"
+	const name = "testbuilddockerignorecleanpaths"
 	dockerfile := `
         FROM busybox
         ADD . /tmp/
@@ -5159,7 +5159,7 @@ foo2
 
 // Test case for #23221
 func (s *DockerCLIBuildSuite) TestBuildWithUTF8BOM(c *testing.T) {
-	name := "test-with-utf8-bom"
+	const name = "test-with-utf8-bom"
 	dockerfile := []byte(`FROM busybox`)
 	bomDockerfile := append([]byte{0xEF, 0xBB, 0xBF}, dockerfile...)
 	buildImageSuccessfully(c, name, build.WithBuildContext(c,
@@ -5169,7 +5169,7 @@ func (s *DockerCLIBuildSuite) TestBuildWithUTF8BOM(c *testing.T) {
 
 // Test case for UTF-8 BOM in .dockerignore, related to #23221
 func (s *DockerCLIBuildSuite) TestBuildWithUTF8BOMDockerignore(c *testing.T) {
-	name := "test-with-utf8-bom-dockerignore"
+	const name = "test-with-utf8-bom-dockerignore"
 	dockerfile := `
         FROM busybox
 		ADD . /tmp/
@@ -5186,7 +5186,7 @@ func (s *DockerCLIBuildSuite) TestBuildWithUTF8BOMDockerignore(c *testing.T) {
 
 // #22489 Shell test to confirm config gets updated correctly
 func (s *DockerCLIBuildSuite) TestBuildShellUpdatesConfig(c *testing.T) {
-	name := "testbuildshellupdatesconfig"
+	const name = "testbuildshellupdatesconfig"
 
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
         SHELL ["foo", "-bar"]`))
@@ -5203,7 +5203,7 @@ func (s *DockerCLIBuildSuite) TestBuildShellUpdatesConfig(c *testing.T) {
 
 // #22489 Changing the shell multiple times and CMD after.
 func (s *DockerCLIBuildSuite) TestBuildShellMultiple(c *testing.T) {
-	name := "testbuildshellmultiple"
+	const name = "testbuildshellmultiple"
 
 	result := buildImage(name, build.WithDockerfile(`FROM busybox
 		RUN echo defaultshell
@@ -5231,7 +5231,7 @@ func (s *DockerCLIBuildSuite) TestBuildShellMultiple(c *testing.T) {
 
 	// A container started from the image uses the shell-form CMD.
 	// Last shell is ls. CMD is -l. So should contain 'total '.
-	outrun, _ := dockerCmd(c, "run", "--rm", name)
+	outrun := cli.DockerCmd(c, "run", "--rm", name).Combined()
 	if !strings.Contains(outrun, "total ") {
 		c.Fatalf("Expected started container to run ls -l. %s", outrun)
 	}
@@ -5239,14 +5239,14 @@ func (s *DockerCLIBuildSuite) TestBuildShellMultiple(c *testing.T) {
 
 // #22489. Changed SHELL with ENTRYPOINT
 func (s *DockerCLIBuildSuite) TestBuildShellEntrypoint(c *testing.T) {
-	name := "testbuildshellentrypoint"
+	const name = "testbuildshellentrypoint"
 
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		SHELL ["ls"]
 		ENTRYPOINT -l`))
 	// A container started from the image uses the shell-form ENTRYPOINT.
 	// Shell is ls. ENTRYPOINT is -l. So should contain 'total '.
-	outrun, _ := dockerCmd(c, "run", "--rm", name)
+	outrun := cli.DockerCmd(c, "run", "--rm", name).Combined()
 	if !strings.Contains(outrun, "total ") {
 		c.Fatalf("Expected started container to run ls -l. %s", outrun)
 	}
@@ -5254,10 +5254,10 @@ func (s *DockerCLIBuildSuite) TestBuildShellEntrypoint(c *testing.T) {
 
 // #22489 Shell test to confirm shell is inherited in a subsequent build
 func (s *DockerCLIBuildSuite) TestBuildShellInherited(c *testing.T) {
-	name1 := "testbuildshellinherited1"
+	const name1 = "testbuildshellinherited1"
 	buildImageSuccessfully(c, name1, build.WithDockerfile(`FROM busybox
         SHELL ["ls"]`))
-	name2 := "testbuildshellinherited2"
+	const name2 = "testbuildshellinherited2"
 	buildImage(name2, build.WithDockerfile(`FROM `+name1+`
         RUN -l`)).Assert(c, icmd.Expected{
 		// ls -l has "total " followed by some number in it, ls without -l does not.
@@ -5267,7 +5267,7 @@ func (s *DockerCLIBuildSuite) TestBuildShellInherited(c *testing.T) {
 
 // #22489 Shell test to confirm non-JSON doesn't work
 func (s *DockerCLIBuildSuite) TestBuildShellNotJSON(c *testing.T) {
-	name := "testbuildshellnotjson"
+	const name = "testbuildshellnotjson"
 
 	buildImage(name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
         sHeLl exec -form`, // Casing explicit to ensure error is upper-cased.
@@ -5281,7 +5281,7 @@ func (s *DockerCLIBuildSuite) TestBuildShellNotJSON(c *testing.T) {
 // This would error if the default shell were still cmd.
 func (s *DockerCLIBuildSuite) TestBuildShellWindowsPowershell(c *testing.T) {
 	testRequires(c, DaemonIsWindows)
-	name := "testbuildshellpowershell"
+	const name = "testbuildshellpowershell"
 	buildImage(name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
         SHELL ["powershell", "-command"]
 		RUN Write-Host John`)).Assert(c, icmd.Expected{
@@ -5293,16 +5293,16 @@ func (s *DockerCLIBuildSuite) TestBuildShellWindowsPowershell(c *testing.T) {
 // Tests WORKDIR, ADD
 func (s *DockerCLIBuildSuite) TestBuildEscapeNotBackslashWordTest(c *testing.T) {
 	testRequires(c, DaemonIsWindows)
-	name := "testbuildescapenotbackslashwordtesta"
-	buildImage(name, build.WithDockerfile(`# escape= `+"`"+`
+	const name1 = "testbuildescapenotbackslashwordtesta"
+	buildImage(name1, build.WithDockerfile(`# escape= `+"`"+`
 		FROM `+minimalBaseImage()+`
         WORKDIR c:\windows
 		RUN dir /w`)).Assert(c, icmd.Expected{
 		Out: "[System32]",
 	})
 
-	name = "testbuildescapenotbackslashwordtestb"
-	buildImage(name, build.WithDockerfile(`# escape= `+"`"+`
+	const name2 = "testbuildescapenotbackslashwordtestb"
+	buildImage(name2, build.WithDockerfile(`# escape= `+"`"+`
 		FROM `+minimalBaseImage()+`
 		SHELL ["powershell.exe"]
         WORKDIR c:\foo
@@ -5316,7 +5316,7 @@ func (s *DockerCLIBuildSuite) TestBuildEscapeNotBackslashWordTest(c *testing.T) 
 // but an exec-form CMD is marked.
 func (s *DockerCLIBuildSuite) TestBuildCmdShellArgsEscaped(c *testing.T) {
 	testRequires(c, DaemonIsWindows)
-	name1 := "testbuildcmdshellescapedshellform"
+	const name1 = "testbuildcmdshellescapedshellform"
 	buildImageSuccessfully(c, name1, build.WithDockerfile(`
   FROM `+minimalBaseImage()+`
   CMD "ipconfig"
@@ -5325,8 +5325,8 @@ func (s *DockerCLIBuildSuite) TestBuildCmdShellArgsEscaped(c *testing.T) {
 	if res != "true" {
 		c.Fatalf("CMD did not update Config.ArgsEscaped on image: %v", res)
 	}
-	dockerCmd(c, "run", "--name", "inspectme1", name1)
-	dockerCmd(c, "wait", "inspectme1")
+	cli.DockerCmd(c, "run", "--name", "inspectme1", name1)
+	cli.DockerCmd(c, "wait", "inspectme1")
 	res = inspectFieldJSON(c, name1, "Config.Cmd")
 
 	if res != `["cmd /S /C \"ipconfig\""]` {
@@ -5334,7 +5334,7 @@ func (s *DockerCLIBuildSuite) TestBuildCmdShellArgsEscaped(c *testing.T) {
 	}
 
 	// Now in JSON/exec-form
-	name2 := "testbuildcmdshellescapedexecform"
+	const name2 = "testbuildcmdshellescapedexecform"
 	buildImageSuccessfully(c, name2, build.WithDockerfile(`
   FROM `+minimalBaseImage()+`
   CMD ["ipconfig"]
@@ -5343,8 +5343,8 @@ func (s *DockerCLIBuildSuite) TestBuildCmdShellArgsEscaped(c *testing.T) {
 	if res != "false" {
 		c.Fatalf("CMD set Config.ArgsEscaped on image: %v", res)
 	}
-	dockerCmd(c, "run", "--name", "inspectme2", name2)
-	dockerCmd(c, "wait", "inspectme2")
+	cli.DockerCmd(c, "run", "--name", "inspectme2", name2)
+	cli.DockerCmd(c, "wait", "inspectme2")
 	res = inspectFieldJSON(c, name2, "Config.Cmd")
 
 	if res != `["ipconfig"]` {
@@ -5354,7 +5354,7 @@ func (s *DockerCLIBuildSuite) TestBuildCmdShellArgsEscaped(c *testing.T) {
 
 // Test case for #24912.
 func (s *DockerCLIBuildSuite) TestBuildStepsWithProgress(c *testing.T) {
-	name := "testbuildstepswithprogress"
+	const name = "testbuildstepswithprogress"
 	totalRun := 5
 	result := buildImage(name, build.WithDockerfile("FROM busybox\n"+strings.Repeat("RUN echo foo\n", totalRun)))
 	result.Assert(c, icmd.Success)
@@ -5365,7 +5365,7 @@ func (s *DockerCLIBuildSuite) TestBuildStepsWithProgress(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildWithFailure(c *testing.T) {
-	name := "testbuildwithfailure"
+	const name = "testbuildwithfailure"
 
 	// First test case can only detect `nobody` in runtime so all steps will show up
 	dockerfile := "FROM busybox\nRUN nobody"
@@ -5523,7 +5523,7 @@ func (s *DockerCLIBuildSuite) TestBuildMultiStageCache(c *testing.T) {
 
 func (s *DockerCLIBuildSuite) TestBuildNetNone(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	name := "testbuildnetnone"
+	const name = "testbuildnetnone"
 	buildImage(name, cli.WithFlags("--network=none"), build.WithDockerfile(`
   FROM busybox
   RUN ping -c 1 8.8.8.8
@@ -5536,23 +5536,23 @@ func (s *DockerCLIBuildSuite) TestBuildNetNone(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildNetContainer(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 
-	id, _ := dockerCmd(c, "run", "--hostname", "foobar", "-d", "busybox", "nc", "-ll", "-p", "1234", "-e", "hostname")
+	id := cli.DockerCmd(c, "run", "--hostname", "foobar", "-d", "busybox", "nc", "-ll", "-p", "1234", "-e", "hostname").Stdout()
 
-	name := "testbuildnetcontainer"
+	const name = "testbuildnetcontainer"
 	buildImageSuccessfully(c, name, cli.WithFlags("--network=container:"+strings.TrimSpace(id)),
 		build.WithDockerfile(`
   FROM busybox
   RUN nc localhost 1234 > /otherhost
   `))
 
-	host, _ := dockerCmd(c, "run", "testbuildnetcontainer", "cat", "/otherhost")
+	host := cli.DockerCmd(c, "run", "testbuildnetcontainer", "cat", "/otherhost").Combined()
 	assert.Equal(c, strings.TrimSpace(host), "foobar")
 }
 
 func (s *DockerCLIBuildSuite) TestBuildWithExtraHost(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 
-	name := "testbuildwithextrahost"
+	const name = "testbuildwithextrahost"
 	buildImageSuccessfully(c, name,
 		cli.WithFlags(
 			"--add-host", "foo:127.0.0.1",
@@ -5970,7 +5970,7 @@ func (s *DockerCLIBuildSuite) TestBuildOpaqueDirectory(c *testing.T) {
 // Windows test for USER in dockerfile
 func (s *DockerCLIBuildSuite) TestBuildWindowsUser(c *testing.T) {
 	testRequires(c, DaemonIsWindows)
-	name := "testbuildwindowsuser"
+	const name = "testbuildwindowsuser"
 	buildImage(name, build.WithDockerfile(`FROM `+testEnv.PlatformDefaults.BaseImage+`
 		RUN net user user /add
 		USER user
@@ -5986,7 +5986,7 @@ func (s *DockerCLIBuildSuite) TestBuildWindowsUser(c *testing.T) {
 // directory. Fix for 27545 (found on Windows, but regression good for Linux too).
 // Note 27545 was reverted in 28505, but a new fix was added subsequently in 28514.
 func (s *DockerCLIBuildSuite) TestBuildCopyFileDotWithWorkdir(c *testing.T) {
-	name := "testbuildcopyfiledotwithworkdir"
+	const name = "testbuildcopyfiledotwithworkdir"
 	buildImageSuccessfully(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `FROM busybox
 WORKDIR /foo
@@ -6000,7 +6000,7 @@ RUN ["cat", "/foo/file"]
 // Case-insensitive environment variables on Windows
 func (s *DockerCLIBuildSuite) TestBuildWindowsEnvCaseInsensitive(c *testing.T) {
 	testRequires(c, DaemonIsWindows)
-	name := "testbuildwindowsenvcaseinsensitive"
+	const name = "testbuildwindowsenvcaseinsensitive"
 	buildImageSuccessfully(c, name, build.WithDockerfile(`
 		FROM `+testEnv.PlatformDefaults.BaseImage+`
 		ENV FOO=bar foo=baz
@@ -6018,7 +6018,7 @@ func (s *DockerCLIBuildSuite) TestBuildWorkdirImageCmd(c *testing.T) {
 FROM busybox
 WORKDIR /foo/bar
 `))
-	out, _ := dockerCmd(c, "inspect", "--format", "{{ json .Config.Cmd }}", image)
+	out := cli.DockerCmd(c, "inspect", "--format", "{{ json .Config.Cmd }}", image).Stdout()
 	assert.Equal(c, strings.TrimSpace(out), `["sh"]`)
 
 	image = "testworkdirlabelimagecmd"
@@ -6028,14 +6028,14 @@ WORKDIR /foo/bar
 LABEL a=b
 `))
 
-	out, _ = dockerCmd(c, "inspect", "--format", "{{ json .Config.Cmd }}", image)
+	out = cli.DockerCmd(c, "inspect", "--format", "{{ json .Config.Cmd }}", image).Stdout()
 	assert.Equal(c, strings.TrimSpace(out), `["sh"]`)
 }
 
 // Test case for 28902/28909
 func (s *DockerCLIBuildSuite) TestBuildWorkdirCmd(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	name := "testbuildworkdircmd"
+	const name = "testbuildworkdircmd"
 	dockerFile := `
                 FROM busybox
                 WORKDIR /
@@ -6048,7 +6048,7 @@ func (s *DockerCLIBuildSuite) TestBuildWorkdirCmd(c *testing.T) {
 
 // FIXME(vdemeester) should be a unit test
 func (s *DockerCLIBuildSuite) TestBuildLineErrorOnBuild(c *testing.T) {
-	name := "test_build_line_error_onbuild"
+	const name = "test_build_line_error_onbuild"
 	buildImage(name, build.WithDockerfile(`FROM busybox
   ONBUILD
   `)).Assert(c, icmd.Expected{
@@ -6059,7 +6059,7 @@ func (s *DockerCLIBuildSuite) TestBuildLineErrorOnBuild(c *testing.T) {
 
 // FIXME(vdemeester) should be a unit test
 func (s *DockerCLIBuildSuite) TestBuildLineErrorUnknownInstruction(c *testing.T) {
-	name := "test_build_line_error_unknown_instruction"
+	const name = "test_build_line_error_unknown_instruction"
 	cli.Docker(cli.Args("build", "-t", name), build.WithDockerfile(`FROM busybox
   RUN echo hello world
   NOINSTRUCTION echo ba
@@ -6073,7 +6073,7 @@ func (s *DockerCLIBuildSuite) TestBuildLineErrorUnknownInstruction(c *testing.T)
 
 // FIXME(vdemeester) should be a unit test
 func (s *DockerCLIBuildSuite) TestBuildLineErrorWithEmptyLines(c *testing.T) {
-	name := "test_build_line_error_with_empty_lines"
+	const name = "test_build_line_error_with_empty_lines"
 	cli.Docker(cli.Args("build", "-t", name), build.WithDockerfile(`
   FROM busybox
 
@@ -6090,7 +6090,7 @@ func (s *DockerCLIBuildSuite) TestBuildLineErrorWithEmptyLines(c *testing.T) {
 
 // FIXME(vdemeester) should be a unit test
 func (s *DockerCLIBuildSuite) TestBuildLineErrorWithComments(c *testing.T) {
-	name := "test_build_line_error_with_comments"
+	const name = "test_build_line_error_with_comments"
 	cli.Docker(cli.Args("build", "-t", name), build.WithDockerfile(`FROM busybox
   # This will print hello world
   # and then ba
@@ -6113,7 +6113,7 @@ FROM build1
 CMD echo foo
 `))
 
-	out, _ := dockerCmd(c, "inspect", "--format", "{{ json .Config.Cmd }}", "build2")
+	out := cli.DockerCmd(c, "inspect", "--format", "{{ json .Config.Cmd }}", "build2").Stdout()
 	expected := `["/bin/sh","-c","echo foo"]`
 	if testEnv.DaemonInfo.OSType == "windows" {
 		expected = `["/bin/sh -c echo foo"]`
@@ -6130,7 +6130,7 @@ func (s *DockerCLIBuildSuite) TestBuildIidFile(c *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	tmpIidFile := filepath.Join(tmpDir, "iid")
 
-	name := "testbuildiidfile"
+	const name = "testbuildiidfile"
 	// Use a Dockerfile with multiple stages to ensure we get the last one
 	cli.BuildCmd(c, name,
 		build.WithDockerfile(`FROM `+minimalBaseImage()+` AS stage1

--- a/integration-cli/docker_cli_build_unix_test.go
+++ b/integration-cli/docker_cli_build_unix_test.go
@@ -25,8 +25,8 @@ import (
 
 func (s *DockerCLIBuildSuite) TestBuildResourceConstraintsAreUsed(c *testing.T) {
 	testRequires(c, cpuCfsQuota)
-	name := "testbuildresourceconstraints"
-	buildLabel := "DockerCLIBuildSuite.TestBuildResourceConstraintsAreUsed"
+	const name = "testbuildresourceconstraints"
+	const buildLabel = "DockerCLIBuildSuite.TestBuildResourceConstraintsAreUsed"
 
 	ctx := fakecontext.New(c, "", fakecontext.WithDockerfile(`
 	FROM hello-world:frozen
@@ -85,7 +85,7 @@ func (s *DockerCLIBuildSuite) TestBuildResourceConstraintsAreUsed(c *testing.T) 
 
 func (s *DockerCLIBuildSuite) TestBuildAddChangeOwnership(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	name := "testbuildaddown"
+	const name = "testbuildaddown"
 
 	ctx := func() *fakecontext.Fake {
 		dockerfile := `
@@ -131,7 +131,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddChangeOwnership(c *testing.T) {
 // Potential issue: newEventObserver uses docker events, which is not hooked up to buildkit.
 func (s *DockerCLIBuildSuite) TestBuildCancellationKillsSleep(c *testing.T) {
 	testRequires(c, DaemonIsLinux, TODOBuildkit)
-	name := "testbuildcancellation"
+	const name = "testbuildcancellation"
 
 	observer, err := newEventObserver(c)
 	assert.NilError(c, err)

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -40,57 +40,56 @@ func (s *DockerCLICommitSuite) TestCommitAfterContainerIsDone(c *testing.T) {
 
 func (s *DockerCLICommitSuite) TestCommitWithoutPause(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-i", "-a", "stdin", "busybox", "echo", "foo")
+	out := cli.DockerCmd(c, "run", "-i", "-a", "stdin", "busybox", "echo", "foo").Combined()
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	dockerCmd(c, "wait", cleanedContainerID)
+	cli.DockerCmd(c, "wait", cleanedContainerID)
 
-	out, _ = dockerCmd(c, "commit", "-p=false", cleanedContainerID)
+	out = cli.DockerCmd(c, "commit", "-p=false", cleanedContainerID).Combined()
 
 	cleanedImageID := strings.TrimSpace(out)
 
-	dockerCmd(c, "inspect", cleanedImageID)
+	cli.DockerCmd(c, "inspect", cleanedImageID)
 }
 
 // TestCommitPausedContainer tests that a paused container is not unpaused after being committed
 func (s *DockerCLICommitSuite) TestCommitPausedContainer(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-i", "-d", "busybox")
+	containerID := cli.DockerCmd(c, "run", "-i", "-d", "busybox").Stdout()
+	containerID = strings.TrimSpace(containerID)
 
-	cleanedContainerID := strings.TrimSpace(out)
+	cli.DockerCmd(c, "pause", containerID)
+	cli.DockerCmd(c, "commit", containerID)
 
-	dockerCmd(c, "pause", cleanedContainerID)
-	dockerCmd(c, "commit", cleanedContainerID)
-
-	out = inspectField(c, cleanedContainerID, "State.Paused")
+	out := inspectField(c, containerID, "State.Paused")
 	// commit should not unpause a paused container
 	assert.Assert(c, strings.Contains(out, "true"))
 }
 
 func (s *DockerCLICommitSuite) TestCommitNewFile(c *testing.T) {
-	dockerCmd(c, "run", "--name", "committer", "busybox", "/bin/sh", "-c", "echo koye > /foo")
+	cli.DockerCmd(c, "run", "--name", "committer", "busybox", "/bin/sh", "-c", "echo koye > /foo")
 
-	imageID, _ := dockerCmd(c, "commit", "committer")
+	imageID := cli.DockerCmd(c, "commit", "committer").Stdout()
 	imageID = strings.TrimSpace(imageID)
 
-	out, _ := dockerCmd(c, "run", imageID, "cat", "/foo")
+	out := cli.DockerCmd(c, "run", imageID, "cat", "/foo").Combined()
 	actual := strings.TrimSpace(out)
 	assert.Equal(c, actual, "koye")
 }
 
 func (s *DockerCLICommitSuite) TestCommitHardlink(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	firstOutput, _ := dockerCmd(c, "run", "-t", "--name", "hardlinks", "busybox", "sh", "-c", "touch file1 && ln file1 file2 && ls -di file1 file2")
+	firstOutput := cli.DockerCmd(c, "run", "-t", "--name", "hardlinks", "busybox", "sh", "-c", "touch file1 && ln file1 file2 && ls -di file1 file2").Combined()
 
 	chunks := strings.Split(strings.TrimSpace(firstOutput), " ")
 	inode := chunks[0]
 	chunks = strings.SplitAfterN(strings.TrimSpace(firstOutput), " ", 2)
 	assert.Assert(c, strings.Contains(chunks[1], chunks[0]), "Failed to create hardlink in a container. Expected to find %q in %q", inode, chunks[1:])
-	imageID, _ := dockerCmd(c, "commit", "hardlinks", "hardlinks")
+	imageID := cli.DockerCmd(c, "commit", "hardlinks", "hardlinks").Stdout()
 	imageID = strings.TrimSpace(imageID)
 
-	secondOutput, _ := dockerCmd(c, "run", "-t", imageID, "ls", "-di", "file1", "file2")
+	secondOutput := cli.DockerCmd(c, "run", "-t", imageID, "ls", "-di", "file1", "file2").Combined()
 
 	chunks = strings.Split(strings.TrimSpace(secondOutput), " ")
 	inode = chunks[0]
@@ -99,28 +98,28 @@ func (s *DockerCLICommitSuite) TestCommitHardlink(c *testing.T) {
 }
 
 func (s *DockerCLICommitSuite) TestCommitTTY(c *testing.T) {
-	dockerCmd(c, "run", "-t", "--name", "tty", "busybox", "/bin/ls")
+	cli.DockerCmd(c, "run", "-t", "--name", "tty", "busybox", "/bin/ls")
 
-	imageID, _ := dockerCmd(c, "commit", "tty", "ttytest")
+	imageID := cli.DockerCmd(c, "commit", "tty", "ttytest").Stdout()
 	imageID = strings.TrimSpace(imageID)
 
-	dockerCmd(c, "run", imageID, "/bin/ls")
+	cli.DockerCmd(c, "run", imageID, "/bin/ls")
 }
 
 func (s *DockerCLICommitSuite) TestCommitWithHostBindMount(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	dockerCmd(c, "run", "--name", "bind-commit", "-v", "/dev/null:/winning", "busybox", "true")
+	cli.DockerCmd(c, "run", "--name", "bind-commit", "-v", "/dev/null:/winning", "busybox", "true")
 
-	imageID, _ := dockerCmd(c, "commit", "bind-commit", "bindtest")
+	imageID := cli.DockerCmd(c, "commit", "bind-commit", "bindtest").Stdout()
 	imageID = strings.TrimSpace(imageID)
 
-	dockerCmd(c, "run", imageID, "true")
+	cli.DockerCmd(c, "run", imageID, "true")
 }
 
 func (s *DockerCLICommitSuite) TestCommitChange(c *testing.T) {
-	dockerCmd(c, "run", "--name", "test", "busybox", "true")
+	cli.DockerCmd(c, "run", "--name", "test", "busybox", "true")
 
-	imageID, _ := dockerCmd(c, "commit",
+	imageID := cli.DockerCmd(c, "commit",
 		"--change", `EXPOSE 8080`,
 		"--change", `ENV DEBUG true`,
 		"--change", `ENV test 1`,
@@ -132,7 +131,8 @@ func (s *DockerCLICommitSuite) TestCommitChange(c *testing.T) {
 		"--change", `USER testuser`,
 		"--change", `VOLUME /var/lib/docker`,
 		"--change", `ONBUILD /usr/local/bin/python-build --dir /app/src`,
-		"test", "test-commit")
+		"test", "test-commit",
+	).Stdout()
 	imageID = strings.TrimSpace(imageID)
 
 	expectedEnv := "[DEBUG=true test=1 PATH=/foo]"
@@ -168,11 +168,9 @@ func (s *DockerCLICommitSuite) TestCommitChange(c *testing.T) {
 }
 
 func (s *DockerCLICommitSuite) TestCommitChangeLabels(c *testing.T) {
-	dockerCmd(c, "run", "--name", "test", "--label", "some=label", "busybox", "true")
+	cli.DockerCmd(c, "run", "--name", "test", "--label", "some=label", "busybox", "true")
 
-	imageID, _ := dockerCmd(c, "commit",
-		"--change", "LABEL some=label2",
-		"test", "test-commit")
+	imageID := cli.DockerCmd(c, "commit", "--change", "LABEL some=label2", "test", "test-commit").Stdout()
 	imageID = strings.TrimSpace(imageID)
 
 	assert.Equal(c, inspectField(c, imageID, "Config.Labels"), "map[some:label2]")

--- a/integration-cli/docker_cli_cp_to_container_unix_test.go
+++ b/integration-cli/docker_cli_cp_to_container_unix_test.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/docker/docker/integration-cli/cli"
 	"gotest.tools/v3/assert"
 )
 
@@ -25,9 +26,9 @@ func (s *DockerCLICpSuite) TestCpToContainerWithPermissions(c *testing.T) {
 
 	containerName := "permtest"
 
-	_, exc := dockerCmd(c, "create", "--name", containerName, "busybox", "/bin/sh", "-c", "stat -c '%u %g %a' /permdirtest /permdirtest/permtest")
+	exc := cli.DockerCmd(c, "create", "--name", containerName, "busybox", "/bin/sh", "-c", "stat -c '%u %g %a' /permdirtest /permdirtest/permtest").ExitCode
 	assert.Equal(c, exc, 0)
-	defer dockerCmd(c, "rm", "-f", containerName)
+	defer cli.DockerCmd(c, "rm", "-f", containerName)
 
 	srcPath := cpPath(tmpDir, "permdirtest")
 	dstPath := containerCpPath(containerName, "/")

--- a/integration-cli/docker_cli_cp_utils_test.go
+++ b/integration-cli/docker_cli_cp_utils_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/pkg/archive"
 	"gotest.tools/v3/assert"
 )
@@ -150,15 +151,15 @@ func makeTestContainer(c *testing.T, options testContainerOptions) (containerID 
 
 	args = append(args, "busybox", "/bin/sh", "-c", options.command)
 
-	out, _ := dockerCmd(c, args...)
+	out := cli.DockerCmd(c, args...).Combined()
 
 	containerID = strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "wait", containerID)
+	out = cli.DockerCmd(c, "wait", containerID).Combined()
 
 	exitCode := strings.TrimSpace(out)
 	if exitCode != "0" {
-		out, _ = dockerCmd(c, "logs", containerID)
+		out = cli.DockerCmd(c, "logs", containerID).Combined()
 	}
 	assert.Equal(c, exitCode, "0", "failed to make test container: %s", out)
 

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -14,6 +14,7 @@ import (
 	"unicode"
 
 	"github.com/creack/pty"
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"golang.org/x/sys/unix"
 	"gotest.tools/v3/assert"
@@ -24,7 +25,7 @@ import (
 // #5979
 func (s *DockerCLIEventSuite) TestEventsRedirectStdout(c *testing.T) {
 	since := daemonUnixTime(c)
-	dockerCmd(c, "run", "busybox", "true")
+	cli.DockerCmd(c, "run", "busybox", "true")
 
 	file, err := os.CreateTemp("", "")
 	assert.NilError(c, err, "could not create temp file")
@@ -67,7 +68,7 @@ func (s *DockerCLIEventSuite) TestEventsOOMDisableFalse(c *testing.T) {
 		c.Fatal("Timeout waiting for container to die on OOM")
 	}
 
-	out, _ := dockerCmd(c, "events", "--since=0", "-f", "container=oomFalse", "--until", daemonUnixTime(c))
+	out := cli.DockerCmd(c, "events", "--since=0", "-f", "container=oomFalse", "--until", daemonUnixTime(c)).Stdout()
 	events := strings.Split(strings.TrimSuffix(out, "\n"), "\n")
 	nEvents := len(events)
 
@@ -98,7 +99,7 @@ func (s *DockerCLIEventSuite) TestEventsOOMDisableTrue(c *testing.T) {
 		}
 	}()
 
-	assert.NilError(c, waitRun("oomTrue"))
+	cli.WaitRun(c, "oomTrue")
 	defer dockerCmdWithResult("kill", "oomTrue")
 	containerID := inspectField(c, "oomTrue", "Id")
 
@@ -130,13 +131,13 @@ func (s *DockerCLIEventSuite) TestEventsOOMDisableTrue(c *testing.T) {
 // #18453
 func (s *DockerCLIEventSuite) TestEventsContainerFilterByName(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	cOut, _ := dockerCmd(c, "run", "--name=foo", "-d", "busybox", "top")
+	cOut := cli.DockerCmd(c, "run", "--name=foo", "-d", "busybox", "top").Stdout()
 	c1 := strings.TrimSpace(cOut)
-	waitRun("foo")
-	cOut, _ = dockerCmd(c, "run", "--name=bar", "-d", "busybox", "top")
+	cli.WaitRun(c, "foo")
+	cOut = cli.DockerCmd(c, "run", "--name=bar", "-d", "busybox", "top").Stdout()
 	c2 := strings.TrimSpace(cOut)
-	waitRun("bar")
-	out, _ := dockerCmd(c, "events", "-f", "container=foo", "--since=0", "--until", daemonUnixTime(c))
+	cli.WaitRun(c, "bar")
+	out := cli.DockerCmd(c, "events", "-f", "container=foo", "--since=0", "--until", daemonUnixTime(c)).Stdout()
 	assert.Assert(c, strings.Contains(out, c1), out)
 	assert.Assert(c, !strings.Contains(out, c2), out)
 }
@@ -153,7 +154,7 @@ func (s *DockerCLIEventSuite) TestEventsContainerFilterBeforeCreate(c *testing.T
 
 	// Sleep for a second to make sure we are testing the case where events are listened before container starts.
 	time.Sleep(time.Second)
-	id, _ := dockerCmd(c, "run", "--name=foo", "-d", "busybox", "top")
+	id := cli.DockerCmd(c, "run", "--name=foo", "-d", "busybox", "top").Stdout()
 	cID := strings.TrimSpace(id)
 	for i := 0; ; i++ {
 		out := buf.String()
@@ -173,16 +174,15 @@ func (s *DockerCLIEventSuite) TestVolumeEvents(c *testing.T) {
 	since := daemonUnixTime(c)
 
 	// Observe create/mount volume actions
-	dockerCmd(c, "volume", "create", "test-event-volume-local")
-	dockerCmd(c, "run", "--name", "test-volume-container", "--volume", "test-event-volume-local:/foo", "-d", "busybox", "true")
-	waitRun("test-volume-container")
+	cli.DockerCmd(c, "volume", "create", "test-event-volume-local")
+	cli.DockerCmd(c, "run", "--name", "test-volume-container", "--volume", "test-event-volume-local:/foo", "-d", "busybox", "true")
 
 	// Observe unmount/destroy volume actions
-	dockerCmd(c, "rm", "-f", "test-volume-container")
-	dockerCmd(c, "volume", "rm", "test-event-volume-local")
+	cli.DockerCmd(c, "rm", "-f", "test-volume-container")
+	cli.DockerCmd(c, "volume", "rm", "test-event-volume-local")
 
 	until := daemonUnixTime(c)
-	out, _ := dockerCmd(c, "events", "--since", since, "--until", until)
+	out := cli.DockerCmd(c, "events", "--since", since, "--until", until).Stdout()
 	events := strings.Split(strings.TrimSpace(out), "\n")
 	assert.Assert(c, len(events) > 3)
 
@@ -200,16 +200,15 @@ func (s *DockerCLIEventSuite) TestNetworkEvents(c *testing.T) {
 	since := daemonUnixTime(c)
 
 	// Observe create/connect network actions
-	dockerCmd(c, "network", "create", "test-event-network-local")
-	dockerCmd(c, "run", "--name", "test-network-container", "--net", "test-event-network-local", "-d", "busybox", "true")
-	waitRun("test-network-container")
+	cli.DockerCmd(c, "network", "create", "test-event-network-local")
+	cli.DockerCmd(c, "run", "--name", "test-network-container", "--net", "test-event-network-local", "-d", "busybox", "true")
 
 	// Observe disconnect/destroy network actions
-	dockerCmd(c, "rm", "-f", "test-network-container")
-	dockerCmd(c, "network", "rm", "test-event-network-local")
+	cli.DockerCmd(c, "rm", "-f", "test-network-container")
+	cli.DockerCmd(c, "network", "rm", "test-event-network-local")
 
 	until := daemonUnixTime(c)
-	out, _ := dockerCmd(c, "events", "--since", since, "--until", until)
+	out := cli.DockerCmd(c, "events", "--since", since, "--until", until).Stdout()
 	events := strings.Split(strings.TrimSpace(out), "\n")
 	assert.Assert(c, len(events) > 4)
 
@@ -225,18 +224,18 @@ func (s *DockerCLIEventSuite) TestEventsContainerWithMultiNetwork(c *testing.T) 
 	testRequires(c, DaemonIsLinux)
 
 	// Observe create/connect network actions
-	dockerCmd(c, "network", "create", "test-event-network-local-1")
-	dockerCmd(c, "network", "create", "test-event-network-local-2")
-	dockerCmd(c, "run", "--name", "test-network-container", "--net", "test-event-network-local-1", "-td", "busybox", "sh")
-	waitRun("test-network-container")
-	dockerCmd(c, "network", "connect", "test-event-network-local-2", "test-network-container")
+	cli.DockerCmd(c, "network", "create", "test-event-network-local-1")
+	cli.DockerCmd(c, "network", "create", "test-event-network-local-2")
+	cli.DockerCmd(c, "run", "--name", "test-network-container", "--net", "test-event-network-local-1", "-td", "busybox", "sh")
+	cli.WaitRun(c, "test-network-container")
+	cli.DockerCmd(c, "network", "connect", "test-event-network-local-2", "test-network-container")
 
 	since := daemonUnixTime(c)
 
-	dockerCmd(c, "stop", "-t", "1", "test-network-container")
+	cli.DockerCmd(c, "stop", "-t", "1", "test-network-container")
 
 	until := daemonUnixTime(c)
-	out, _ := dockerCmd(c, "events", "--since", since, "--until", until, "-f", "type=network")
+	out := cli.DockerCmd(c, "events", "--since", since, "--until", until, "-f", "type=network").Stdout()
 	netEvents := strings.Split(strings.TrimSpace(out), "\n")
 
 	// received two network disconnect events
@@ -258,7 +257,7 @@ func (s *DockerCLIEventSuite) TestEventsStreaming(c *testing.T) {
 	assert.NilError(c, err)
 	defer observer.Stop()
 
-	out, _ := dockerCmd(c, "run", "-d", "busybox:latest", "true")
+	out := cli.DockerCmd(c, "run", "-d", "busybox:latest", "true").Stdout()
 	containerID := strings.TrimSpace(out)
 
 	testActions := map[string]chan bool{
@@ -293,7 +292,7 @@ func (s *DockerCLIEventSuite) TestEventsStreaming(c *testing.T) {
 		// ignore, done
 	}
 
-	dockerCmd(c, "rm", containerID)
+	cli.DockerCmd(c, "rm", containerID)
 
 	select {
 	case <-time.After(5 * time.Second):
@@ -347,10 +346,10 @@ func (s *DockerCLIEventSuite) TestEventsFilterVolumeAndNetworkType(c *testing.T)
 
 	since := daemonUnixTime(c)
 
-	dockerCmd(c, "network", "create", "test-event-network-type")
-	dockerCmd(c, "volume", "create", "test-event-volume-type")
+	cli.DockerCmd(c, "network", "create", "test-event-network-type")
+	cli.DockerCmd(c, "volume", "create", "test-event-volume-type")
 
-	out, _ := dockerCmd(c, "events", "--filter", "type=volume", "--filter", "type=network", "--since", since, "--until", daemonUnixTime(c))
+	out := cli.DockerCmd(c, "events", "--filter", "type=volume", "--filter", "type=network", "--since", since, "--until", daemonUnixTime(c)).Stdout()
 	events := strings.Split(strings.TrimSpace(out), "\n")
 	assert.Assert(c, len(events) >= 2, out)
 
@@ -366,8 +365,8 @@ func (s *DockerCLIEventSuite) TestEventsFilterVolumeID(c *testing.T) {
 
 	since := daemonUnixTime(c)
 
-	dockerCmd(c, "volume", "create", "test-event-volume-id")
-	out, _ := dockerCmd(c, "events", "--filter", "volume=test-event-volume-id", "--since", since, "--until", daemonUnixTime(c))
+	cli.DockerCmd(c, "volume", "create", "test-event-volume-id")
+	out := cli.DockerCmd(c, "events", "--filter", "volume=test-event-volume-id", "--since", since, "--until", daemonUnixTime(c)).Stdout()
 	events := strings.Split(strings.TrimSpace(out), "\n")
 	assert.Equal(c, len(events), 1)
 
@@ -381,8 +380,8 @@ func (s *DockerCLIEventSuite) TestEventsFilterNetworkID(c *testing.T) {
 
 	since := daemonUnixTime(c)
 
-	dockerCmd(c, "network", "create", "test-event-network-local")
-	out, _ := dockerCmd(c, "events", "--filter", "network=test-event-network-local", "--since", since, "--until", daemonUnixTime(c))
+	cli.DockerCmd(c, "network", "create", "test-event-network-local")
+	out := cli.DockerCmd(c, "events", "--filter", "network=test-event-network-local", "--since", since, "--until", daemonUnixTime(c)).Stdout()
 	events := strings.Split(strings.TrimSpace(out), "\n")
 	assert.Equal(c, len(events), 1)
 	assert.Assert(c, strings.Contains(events[0], "test-event-network-local"))

--- a/integration-cli/docker_cli_exec_unix_test.go
+++ b/integration-cli/docker_cli_exec_unix_test.go
@@ -11,13 +11,14 @@ import (
 	"time"
 
 	"github.com/creack/pty"
+	"github.com/docker/docker/integration-cli/cli"
 	"gotest.tools/v3/assert"
 )
 
 // regression test for #12546
 func (s *DockerCLIExecSuite) TestExecInteractiveStdinClose(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-itd", "busybox", "/bin/cat")
+	out := cli.DockerCmd(c, "run", "-itd", "busybox", "/bin/cat").Stdout()
 	contID := strings.TrimSpace(out)
 
 	cmd := exec.Command(dockerBinary, "exec", "-i", contID, "echo", "-n", "hello")
@@ -46,7 +47,7 @@ func (s *DockerCLIExecSuite) TestExecInteractiveStdinClose(c *testing.T) {
 
 func (s *DockerCLIExecSuite) TestExecTTY(c *testing.T) {
 	testRequires(c, DaemonIsLinux, testEnv.IsLocalDaemon)
-	dockerCmd(c, "run", "-d", "--name=test", "busybox", "sh", "-c", "echo hello > /foo && top")
+	cli.DockerCmd(c, "run", "-d", "--name=test", "busybox", "sh", "-c", "echo hello > /foo && top")
 
 	cmd := exec.Command(dockerBinary, "exec", "-it", "test", "sh")
 	p, err := pty.Start(cmd)
@@ -76,7 +77,7 @@ func (s *DockerCLIExecSuite) TestExecTTY(c *testing.T) {
 // Test the TERM env var is set when -t is provided on exec
 func (s *DockerCLIExecSuite) TestExecWithTERM(c *testing.T) {
 	testRequires(c, DaemonIsLinux, testEnv.IsLocalDaemon)
-	out, _ := dockerCmd(c, "run", "-id", "busybox", "/bin/cat")
+	out := cli.DockerCmd(c, "run", "-id", "busybox", "/bin/cat").Stdout()
 	contID := strings.TrimSpace(out)
 	cmd := exec.Command(dockerBinary, "exec", "-t", contID, "sh", "-c", "if [ -z $TERM ]; then exit 1; else exit 0; fi")
 	if err := cmd.Run(); err != nil {
@@ -88,7 +89,7 @@ func (s *DockerCLIExecSuite) TestExecWithTERM(c *testing.T) {
 // on run
 func (s *DockerCLIExecSuite) TestExecWithNoTERM(c *testing.T) {
 	testRequires(c, DaemonIsLinux, testEnv.IsLocalDaemon)
-	out, _ := dockerCmd(c, "run", "-itd", "busybox", "/bin/cat")
+	out := cli.DockerCmd(c, "run", "-itd", "busybox", "/bin/cat").Stdout()
 	contID := strings.TrimSpace(out)
 	cmd := exec.Command(dockerBinary, "exec", contID, "sh", "-c", "if [ -z $TERM ]; then exit 0; else exit 1; fi")
 	if err := cmd.Run(); err != nil {

--- a/integration-cli/docker_cli_history_test.go
+++ b/integration-cli/docker_cli_history_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
@@ -28,7 +29,7 @@ func (s *DockerCLIHistorySuite) OnTimeout(c *testing.T) {
 // This is a heisen-test.  Because the created timestamp of images and the behavior of
 // sort is not predictable it doesn't always fail.
 func (s *DockerCLIHistorySuite) TestBuildHistory(c *testing.T) {
-	name := "testbuildhistory"
+	const name = "testbuildhistory"
 	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
 LABEL label.A="A"
 LABEL label.B="B"
@@ -57,7 +58,7 @@ LABEL label.X="X"
 LABEL label.Y="Y"
 LABEL label.Z="Z"`))
 
-	out, _ := dockerCmd(c, "history", name)
+	out := cli.DockerCmd(c, "history", name).Combined()
 	actualValues := strings.Split(out, "\n")[1:27]
 	expectedValues := [26]string{"Z", "Y", "X", "W", "V", "U", "T", "S", "R", "Q", "P", "O", "N", "M", "L", "K", "J", "I", "H", "G", "F", "E", "D", "C", "B", "A"}
 
@@ -69,7 +70,7 @@ LABEL label.Z="Z"`))
 }
 
 func (s *DockerCLIHistorySuite) TestHistoryExistentImage(c *testing.T) {
-	dockerCmd(c, "history", "busybox")
+	cli.DockerCmd(c, "history", "busybox")
 }
 
 func (s *DockerCLIHistorySuite) TestHistoryNonExistentImage(c *testing.T) {
@@ -78,26 +79,24 @@ func (s *DockerCLIHistorySuite) TestHistoryNonExistentImage(c *testing.T) {
 }
 
 func (s *DockerCLIHistorySuite) TestHistoryImageWithComment(c *testing.T) {
-	name := "testhistoryimagewithcomment"
+	const name = "testhistoryimagewithcomment"
 
 	// make an image through docker commit <container id> [ -m messages ]
+	cli.DockerCmd(c, "run", "--name", name, "busybox", "true")
+	cli.DockerCmd(c, "wait", name)
 
-	dockerCmd(c, "run", "--name", name, "busybox", "true")
-	dockerCmd(c, "wait", name)
-
-	comment := "This_is_a_comment"
-	dockerCmd(c, "commit", "-m="+comment, name, name)
+	const comment = "This_is_a_comment"
+	cli.DockerCmd(c, "commit", "-m="+comment, name, name)
 
 	// test docker history <image id> to check comment messages
-
-	out, _ := dockerCmd(c, "history", name)
+	out := cli.DockerCmd(c, "history", name).Combined()
 	outputTabs := strings.Fields(strings.Split(out, "\n")[1])
 	actualValue := outputTabs[len(outputTabs)-1]
 	assert.Assert(c, strings.Contains(actualValue, comment))
 }
 
 func (s *DockerCLIHistorySuite) TestHistoryHumanOptionFalse(c *testing.T) {
-	out, _ := dockerCmd(c, "history", "--human=false", "busybox")
+	out := cli.DockerCmd(c, "history", "--human=false", "busybox").Combined()
 	lines := strings.Split(out, "\n")
 	sizeColumnRegex, _ := regexp.Compile("SIZE +")
 	indices := sizeColumnRegex.FindStringIndex(lines[0])
@@ -115,7 +114,7 @@ func (s *DockerCLIHistorySuite) TestHistoryHumanOptionFalse(c *testing.T) {
 }
 
 func (s *DockerCLIHistorySuite) TestHistoryHumanOptionTrue(c *testing.T) {
-	out, _ := dockerCmd(c, "history", "--human=true", "busybox")
+	out := cli.DockerCmd(c, "history", "--human=true", "busybox").Combined()
 	lines := strings.Split(out, "\n")
 	sizeColumnRegex, _ := regexp.Compile("SIZE +")
 	humanSizeRegexRaw := "\\d+.*B" // Matches human sizes like 10 MB, 3.2 KB, etc

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/pkg/stringid"
 	"gotest.tools/v3/assert"
@@ -31,22 +32,22 @@ func (s *DockerCLIImagesSuite) OnTimeout(c *testing.T) {
 }
 
 func (s *DockerCLIImagesSuite) TestImagesEnsureImageIsListed(c *testing.T) {
-	imagesOut, _ := dockerCmd(c, "images")
+	imagesOut := cli.DockerCmd(c, "images").Stdout()
 	assert.Assert(c, strings.Contains(imagesOut, "busybox"))
 }
 
 func (s *DockerCLIImagesSuite) TestImagesEnsureImageWithTagIsListed(c *testing.T) {
-	name := "imagewithtag"
-	dockerCmd(c, "tag", "busybox", name+":v1")
-	dockerCmd(c, "tag", "busybox", name+":v1v1")
-	dockerCmd(c, "tag", "busybox", name+":v2")
+	const name = "imagewithtag"
+	cli.DockerCmd(c, "tag", "busybox", name+":v1")
+	cli.DockerCmd(c, "tag", "busybox", name+":v1v1")
+	cli.DockerCmd(c, "tag", "busybox", name+":v2")
 
-	imagesOut, _ := dockerCmd(c, "images", name+":v1")
+	imagesOut := cli.DockerCmd(c, "images", name+":v1").Stdout()
 	assert.Assert(c, strings.Contains(imagesOut, name))
 	assert.Assert(c, strings.Contains(imagesOut, "v1"))
 	assert.Assert(c, !strings.Contains(imagesOut, "v2"))
 	assert.Assert(c, !strings.Contains(imagesOut, "v1v1"))
-	imagesOut, _ = dockerCmd(c, "images", name)
+	imagesOut = cli.DockerCmd(c, "images", name).Stdout()
 	assert.Assert(c, strings.Contains(imagesOut, name))
 	assert.Assert(c, strings.Contains(imagesOut, "v1"))
 	assert.Assert(c, strings.Contains(imagesOut, "v1v1"))
@@ -54,7 +55,7 @@ func (s *DockerCLIImagesSuite) TestImagesEnsureImageWithTagIsListed(c *testing.T
 }
 
 func (s *DockerCLIImagesSuite) TestImagesEnsureImageWithBadTagIsNotListed(c *testing.T) {
-	imagesOut, _ := dockerCmd(c, "images", "busybox:nonexistent")
+	imagesOut := cli.DockerCmd(c, "images", "busybox:nonexistent").Stdout()
 	assert.Assert(c, !strings.Contains(imagesOut, "busybox"))
 }
 
@@ -71,7 +72,7 @@ func (s *DockerCLIImagesSuite) TestImagesOrderedByCreationDate(c *testing.T) {
                 MAINTAINER dockerio3`))
 	id3 := getIDByName(c, "order:test_b")
 
-	out, _ := dockerCmd(c, "images", "-q", "--no-trunc")
+	out := cli.DockerCmd(c, "images", "-q", "--no-trunc").Stdout()
 	imgs := strings.Split(out, "\n")
 	assert.Equal(c, imgs[0], id3, fmt.Sprintf("First image must be %s, got %s", id3, imgs[0]))
 	assert.Equal(c, imgs[1], id2, fmt.Sprintf("First image must be %s, got %s", id2, imgs[1]))
@@ -85,9 +86,9 @@ func (s *DockerCLIImagesSuite) TestImagesErrorWithInvalidFilterNameTest(c *testi
 }
 
 func (s *DockerCLIImagesSuite) TestImagesFilterLabelMatch(c *testing.T) {
-	imageName1 := "images_filter_test1"
-	imageName2 := "images_filter_test2"
-	imageName3 := "images_filter_test3"
+	const imageName1 = "images_filter_test1"
+	const imageName2 = "images_filter_test2"
+	const imageName3 = "images_filter_test3"
 	buildImageSuccessfully(c, imageName1, build.WithDockerfile(`FROM busybox
                  LABEL match me`))
 	image1ID := getIDByName(c, imageName1)
@@ -100,7 +101,7 @@ func (s *DockerCLIImagesSuite) TestImagesFilterLabelMatch(c *testing.T) {
                  LABEL nomatch me`))
 	image3ID := getIDByName(c, imageName3)
 
-	out, _ := dockerCmd(c, "images", "--no-trunc", "-q", "-f", "label=match")
+	out := cli.DockerCmd(c, "images", "--no-trunc", "-q", "-f", "label=match").Stdout()
 	out = strings.TrimSpace(out)
 	assert.Assert(c, is.Regexp(fmt.Sprintf("^[\\s\\w:]*%s[\\s\\w:]*$", image1ID), out))
 
@@ -108,7 +109,7 @@ func (s *DockerCLIImagesSuite) TestImagesFilterLabelMatch(c *testing.T) {
 
 	assert.Assert(c, !is.Regexp(fmt.Sprintf("^[\\s\\w:]*%s[\\s\\w:]*$", image3ID), out)().Success())
 
-	out, _ = dockerCmd(c, "images", "--no-trunc", "-q", "-f", "label=match=me too")
+	out = cli.DockerCmd(c, "images", "--no-trunc", "-q", "-f", "label=match=me too").Stdout()
 	out = strings.TrimSpace(out)
 	assert.Equal(c, out, image2ID)
 }
@@ -116,12 +117,12 @@ func (s *DockerCLIImagesSuite) TestImagesFilterLabelMatch(c *testing.T) {
 // Regression : #15659
 func (s *DockerCLIImagesSuite) TestCommitWithFilterLabel(c *testing.T) {
 	// Create a container
-	dockerCmd(c, "run", "--name", "bar", "busybox", "/bin/sh")
+	cli.DockerCmd(c, "run", "--name", "bar", "busybox", "/bin/sh")
 	// Commit with labels "using changes"
-	out, _ := dockerCmd(c, "commit", "-c", "LABEL foo.version=1.0.0-1", "-c", "LABEL foo.name=bar", "-c", "LABEL foo.author=starlord", "bar", "bar:1.0.0-1")
-	imageID := strings.TrimSpace(out)
+	imageID := cli.DockerCmd(c, "commit", "-c", "LABEL foo.version=1.0.0-1", "-c", "LABEL foo.name=bar", "-c", "LABEL foo.author=starlord", "bar", "bar:1.0.0-1").Stdout()
+	imageID = strings.TrimSpace(imageID)
 
-	out, _ = dockerCmd(c, "images", "--no-trunc", "-q", "-f", "label=foo.version=1.0.0-1")
+	out := cli.DockerCmd(c, "images", "--no-trunc", "-q", "-f", "label=foo.version=1.0.0-1").Stdout()
 	out = strings.TrimSpace(out)
 	assert.Equal(c, out, imageID)
 }
@@ -139,34 +140,34 @@ LABEL number=3`))
 
 	expected := []string{imageID3, imageID2}
 
-	out, _ := dockerCmd(c, "images", "-f", "since=image:1", "image")
+	out := cli.DockerCmd(c, "images", "-f", "since=image:1", "image").Stdout()
 	assert.Equal(c, assertImageList(out, expected), true, fmt.Sprintf("SINCE filter: Image list is not in the correct order: %v\n%s", expected, out))
 
-	out, _ = dockerCmd(c, "images", "-f", "since="+imageID1, "image")
+	out = cli.DockerCmd(c, "images", "-f", "since="+imageID1, "image").Stdout()
 	assert.Equal(c, assertImageList(out, expected), true, fmt.Sprintf("SINCE filter: Image list is not in the correct order: %v\n%s", expected, out))
 
 	expected = []string{imageID3}
 
-	out, _ = dockerCmd(c, "images", "-f", "since=image:2", "image")
+	out = cli.DockerCmd(c, "images", "-f", "since=image:2", "image").Stdout()
 	assert.Equal(c, assertImageList(out, expected), true, fmt.Sprintf("SINCE filter: Image list is not in the correct order: %v\n%s", expected, out))
 
-	out, _ = dockerCmd(c, "images", "-f", "since="+imageID2, "image")
+	out = cli.DockerCmd(c, "images", "-f", "since="+imageID2, "image").Stdout()
 	assert.Equal(c, assertImageList(out, expected), true, fmt.Sprintf("SINCE filter: Image list is not in the correct order: %v\n%s", expected, out))
 
 	expected = []string{imageID2, imageID1}
 
-	out, _ = dockerCmd(c, "images", "-f", "before=image:3", "image")
+	out = cli.DockerCmd(c, "images", "-f", "before=image:3", "image").Stdout()
 	assert.Equal(c, assertImageList(out, expected), true, fmt.Sprintf("BEFORE filter: Image list is not in the correct order: %v\n%s", expected, out))
 
-	out, _ = dockerCmd(c, "images", "-f", "before="+imageID3, "image")
+	out = cli.DockerCmd(c, "images", "-f", "before="+imageID3, "image").Stdout()
 	assert.Equal(c, assertImageList(out, expected), true, fmt.Sprintf("BEFORE filter: Image list is not in the correct order: %v\n%s", expected, out))
 
 	expected = []string{imageID1}
 
-	out, _ = dockerCmd(c, "images", "-f", "before=image:2", "image")
+	out = cli.DockerCmd(c, "images", "-f", "before=image:2", "image").Stdout()
 	assert.Equal(c, assertImageList(out, expected), true, fmt.Sprintf("BEFORE filter: Image list is not in the correct order: %v\n%s", expected, out))
 
-	out, _ = dockerCmd(c, "images", "-f", "before="+imageID2, "image")
+	out = cli.DockerCmd(c, "images", "-f", "before="+imageID2, "image").Stdout()
 	assert.Equal(c, assertImageList(out, expected), true, fmt.Sprintf("BEFORE filter: Image list is not in the correct order: %v\n%s", expected, out))
 }
 
@@ -197,7 +198,7 @@ func assertImageList(out string, expected []string) bool {
 
 // FIXME(vdemeester) should be a unit test on `docker image ls`
 func (s *DockerCLIImagesSuite) TestImagesFilterSpaceTrimCase(c *testing.T) {
-	imageName := "images_filter_test"
+	const imageName = "images_filter_test"
 	// Build a image and fail to build so that we have dangling images ?
 	buildImage(imageName, build.WithDockerfile(`FROM busybox
                  RUN touch /test/foo
@@ -216,7 +217,7 @@ func (s *DockerCLIImagesSuite) TestImagesFilterSpaceTrimCase(c *testing.T) {
 
 	imageListings := make([][]string, 5)
 	for idx, filter := range filters {
-		out, _ := dockerCmd(c, "images", "-q", "-f", filter)
+		out := cli.DockerCmd(c, "images", "-q", "-f", filter).Stdout()
 		listing := strings.Split(out, "\n")
 		sort.Strings(listing)
 		imageListings[idx] = listing
@@ -239,24 +240,24 @@ func (s *DockerCLIImagesSuite) TestImagesFilterSpaceTrimCase(c *testing.T) {
 func (s *DockerCLIImagesSuite) TestImagesEnsureDanglingImageOnlyListedOnce(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 	// create container 1
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
-	containerID1 := strings.TrimSpace(out)
+	containerID1 := cli.DockerCmd(c, "run", "-d", "busybox", "true").Stdout()
+	containerID1 = strings.TrimSpace(containerID1)
 
 	// tag as foobox
-	out, _ = dockerCmd(c, "commit", containerID1, "foobox")
-	imageID := stringid.TruncateID(strings.TrimSpace(out))
+	imageID := cli.DockerCmd(c, "commit", containerID1, "foobox").Stdout()
+	imageID = stringid.TruncateID(strings.TrimSpace(imageID))
 
 	// overwrite the tag, making the previous image dangling
-	dockerCmd(c, "tag", "busybox", "foobox")
+	cli.DockerCmd(c, "tag", "busybox", "foobox")
 
-	out, _ = dockerCmd(c, "images", "-q", "-f", "dangling=true")
+	out := cli.DockerCmd(c, "images", "-q", "-f", "dangling=true").Stdout()
 	// Expect one dangling image
 	assert.Equal(c, strings.Count(out, imageID), 1)
 
-	out, _ = dockerCmd(c, "images", "-q", "-f", "dangling=false")
+	out = cli.DockerCmd(c, "images", "-q", "-f", "dangling=false").Stdout()
 	// dangling=false would not include dangling images
 	assert.Assert(c, !strings.Contains(out, imageID))
-	out, _ = dockerCmd(c, "images")
+	out = cli.DockerCmd(c, "images").Stdout()
 	// docker images still include dangling images
 	assert.Assert(c, strings.Contains(out, imageID))
 }
@@ -269,11 +270,11 @@ func (s *DockerCLIImagesSuite) TestImagesWithIncorrectFilter(c *testing.T) {
 }
 
 func (s *DockerCLIImagesSuite) TestImagesEnsureOnlyHeadsImagesShown(c *testing.T) {
-	dockerfile := `
+	const dockerfile = `
         FROM busybox
         MAINTAINER docker
         ENV foo bar`
-	name := "scratch-image"
+	const name = "scratch-image"
 	result := buildImage(name, build.WithDockerfile(dockerfile))
 	result.Assert(c, icmd.Success)
 	id := getIDByName(c, name)
@@ -284,7 +285,7 @@ func (s *DockerCLIImagesSuite) TestImagesEnsureOnlyHeadsImagesShown(c *testing.T
 	split := strings.Split(result.Combined(), "\n")
 	intermediate := strings.TrimSpace(split[5][7:])
 
-	out, _ := dockerCmd(c, "images")
+	out := cli.DockerCmd(c, "images").Stdout()
 	// images shouldn't show non-heads images
 	assert.Assert(c, !strings.Contains(out, intermediate))
 	// images should contain final built images
@@ -293,15 +294,15 @@ func (s *DockerCLIImagesSuite) TestImagesEnsureOnlyHeadsImagesShown(c *testing.T
 
 func (s *DockerCLIImagesSuite) TestImagesEnsureImagesFromScratchShown(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Windows does not support FROM scratch
-	dockerfile := `
+	const dockerfile = `
         FROM scratch
         MAINTAINER docker`
 
-	name := "scratch-image"
+	const name = "scratch-image"
 	buildImageSuccessfully(c, name, build.WithDockerfile(dockerfile))
 	id := getIDByName(c, name)
 
-	out, _ := dockerCmd(c, "images")
+	out := cli.DockerCmd(c, "images").Stdout()
 	// images should contain images built from scratch
 	assert.Assert(c, strings.Contains(out, stringid.TruncateID(id)))
 }
@@ -309,41 +310,41 @@ func (s *DockerCLIImagesSuite) TestImagesEnsureImagesFromScratchShown(c *testing
 // For W2W - equivalent to TestImagesEnsureImagesFromScratchShown but Windows
 // doesn't support from scratch
 func (s *DockerCLIImagesSuite) TestImagesEnsureImagesFromBusyboxShown(c *testing.T) {
-	dockerfile := `
+	const dockerfile = `
         FROM busybox
         MAINTAINER docker`
-	name := "busybox-image"
+	const name = "busybox-image"
 
 	buildImageSuccessfully(c, name, build.WithDockerfile(dockerfile))
 	id := getIDByName(c, name)
 
-	out, _ := dockerCmd(c, "images")
+	out := cli.DockerCmd(c, "images").Stdout()
 	// images should contain images built from busybox
 	assert.Assert(c, strings.Contains(out, stringid.TruncateID(id)))
 }
 
 // #18181
 func (s *DockerCLIImagesSuite) TestImagesFilterNameWithPort(c *testing.T) {
-	tag := "a.b.c.d:5000/hello"
-	dockerCmd(c, "tag", "busybox", tag)
-	out, _ := dockerCmd(c, "images", tag)
+	const tag = "a.b.c.d:5000/hello"
+	cli.DockerCmd(c, "tag", "busybox", tag)
+	out := cli.DockerCmd(c, "images", tag).Stdout()
 	assert.Assert(c, strings.Contains(out, tag))
-	out, _ = dockerCmd(c, "images", tag+":latest")
+	out = cli.DockerCmd(c, "images", tag+":latest").Stdout()
 	assert.Assert(c, strings.Contains(out, tag))
-	out, _ = dockerCmd(c, "images", tag+":no-such-tag")
+	out = cli.DockerCmd(c, "images", tag+":no-such-tag").Stdout()
 	assert.Assert(c, !strings.Contains(out, tag))
 }
 
 func (s *DockerCLIImagesSuite) TestImagesFormat(c *testing.T) {
 	// testRequires(c, DaemonIsLinux)
-	tag := "myimage"
-	dockerCmd(c, "tag", "busybox", tag+":v1")
-	dockerCmd(c, "tag", "busybox", tag+":v2")
+	const imageName = "myimage"
+	cli.DockerCmd(c, "tag", "busybox", imageName+":v1")
+	cli.DockerCmd(c, "tag", "busybox", imageName+":v2")
 
-	out, _ := dockerCmd(c, "images", "--format", "{{.Repository}}", tag)
+	out := cli.DockerCmd(c, "images", "--format", "{{.Repository}}", imageName).Stdout()
 	lines := strings.Split(strings.TrimSpace(out), "\n")
 
-	expected := []string{"myimage", "myimage"}
+	expected := []string{imageName, imageName}
 	var names []string
 	names = append(names, lines...)
 	assert.Assert(c, is.DeepEqual(names, expected), "Expected array with truncated names: %v, got: %v", expected, names)
@@ -354,14 +355,14 @@ func (s *DockerCLIImagesSuite) TestImagesFormatDefaultFormat(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 
 	// create container 1
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
-	containerID1 := strings.TrimSpace(out)
+	containerID1 := cli.DockerCmd(c, "run", "-d", "busybox", "true").Stdout()
+	containerID1 = strings.TrimSpace(containerID1)
 
 	// tag as foobox
-	out, _ = dockerCmd(c, "commit", containerID1, "myimage")
-	imageID := stringid.TruncateID(strings.TrimSpace(out))
+	imageID := cli.DockerCmd(c, "commit", containerID1, "myimage").Stdout()
+	imageID = stringid.TruncateID(strings.TrimSpace(imageID))
 
-	config := `{
+	const config = `{
 		"imagesFormat": "{{ .ID }} default"
 }`
 	d, err := os.MkdirTemp("", "integration-cli-")
@@ -371,6 +372,6 @@ func (s *DockerCLIImagesSuite) TestImagesFormatDefaultFormat(c *testing.T) {
 	err = os.WriteFile(filepath.Join(d, "config.json"), []byte(config), 0o644)
 	assert.NilError(c, err)
 
-	out, _ = dockerCmd(c, "--config", d, "images", "-q", "myimage")
+	out := cli.DockerCmd(c, "--config", d, "images", "-q", "myimage").Stdout()
 	assert.Equal(c, out, imageID+"\n", "Expected to print only the image id, got %v\n", out)
 }

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/runconfig"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -62,8 +63,8 @@ func testLinkPingOnNetwork(c *testing.T, network string) {
 	runArgs2 := append([]string{"run", "-d", "--name", "container2", "--hostname", "wilma"}, postArgs...)
 
 	// Run the two named containers
-	dockerCmd(c, runArgs1...)
-	dockerCmd(c, runArgs2...)
+	cli.DockerCmd(c, runArgs1...)
+	cli.DockerCmd(c, runArgs2...)
 
 	postArgs = []string{}
 	if network != "" {
@@ -77,34 +78,32 @@ func testLinkPingOnNetwork(c *testing.T, network string) {
 
 	// test ping by alias, ping by name, and ping by hostname
 	// 1. Ping by alias
-	dockerCmd(c, append(runArgs, fmt.Sprintf(pingCmd, "alias1", "alias2"))...)
+	cli.DockerCmd(c, append(runArgs, fmt.Sprintf(pingCmd, "alias1", "alias2"))...)
 	// 2. Ping by container name
-	dockerCmd(c, append(runArgs, fmt.Sprintf(pingCmd, "container1", "container2"))...)
+	cli.DockerCmd(c, append(runArgs, fmt.Sprintf(pingCmd, "container1", "container2"))...)
 	// 3. Ping by hostname
-	dockerCmd(c, append(runArgs, fmt.Sprintf(pingCmd, "fred", "wilma"))...)
+	cli.DockerCmd(c, append(runArgs, fmt.Sprintf(pingCmd, "fred", "wilma"))...)
 
 	// Clean for next round
-	dockerCmd(c, "rm", "-f", "container1")
-	dockerCmd(c, "rm", "-f", "container2")
+	cli.DockerCmd(c, "rm", "-f", "container1")
+	cli.DockerCmd(c, "rm", "-f", "container2")
 }
 
 func (s *DockerCLILinksSuite) TestLinksPingLinkedContainersAfterRename(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-d", "--name", "container1", "busybox", "top")
-	idA := strings.TrimSpace(out)
-	out, _ = dockerCmd(c, "run", "-d", "--name", "container2", "busybox", "top")
-	idB := strings.TrimSpace(out)
-	dockerCmd(c, "rename", "container1", "container_new")
-	dockerCmd(c, "run", "--rm", "--link", "container_new:alias1", "--link", "container2:alias2", "busybox", "sh", "-c", "ping -c 1 alias1 -W 1 && ping -c 1 alias2 -W 1")
-	dockerCmd(c, "kill", idA)
-	dockerCmd(c, "kill", idB)
+	idA := cli.DockerCmd(c, "run", "-d", "--name", "container1", "busybox", "top").Stdout()
+	idB := cli.DockerCmd(c, "run", "-d", "--name", "container2", "busybox", "top").Stdout()
+	cli.DockerCmd(c, "rename", "container1", "container_new")
+	cli.DockerCmd(c, "run", "--rm", "--link", "container_new:alias1", "--link", "container2:alias2", "busybox", "sh", "-c", "ping -c 1 alias1 -W 1 && ping -c 1 alias2 -W 1")
+	cli.DockerCmd(c, "kill", strings.TrimSpace(idA))
+	cli.DockerCmd(c, "kill", strings.TrimSpace(idB))
 }
 
 func (s *DockerCLILinksSuite) TestLinksInspectLinksStarted(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	dockerCmd(c, "run", "-d", "--name", "container1", "busybox", "top")
-	dockerCmd(c, "run", "-d", "--name", "container2", "busybox", "top")
-	dockerCmd(c, "run", "-d", "--name", "testinspectlink", "--link", "container1:alias1", "--link", "container2:alias2", "busybox", "top")
+	cli.DockerCmd(c, "run", "-d", "--name", "container1", "busybox", "top")
+	cli.DockerCmd(c, "run", "-d", "--name", "container2", "busybox", "top")
+	cli.DockerCmd(c, "run", "-d", "--name", "testinspectlink", "--link", "container1:alias1", "--link", "container2:alias2", "busybox", "top")
 	links := inspectFieldJSON(c, "testinspectlink", "HostConfig.Links")
 
 	var result []string
@@ -122,9 +121,9 @@ func (s *DockerCLILinksSuite) TestLinksInspectLinksStarted(c *testing.T) {
 func (s *DockerCLILinksSuite) TestLinksInspectLinksStopped(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 
-	dockerCmd(c, "run", "-d", "--name", "container1", "busybox", "top")
-	dockerCmd(c, "run", "-d", "--name", "container2", "busybox", "top")
-	dockerCmd(c, "run", "-d", "--name", "testinspectlink", "--link", "container1:alias1", "--link", "container2:alias2", "busybox", "true")
+	cli.DockerCmd(c, "run", "-d", "--name", "container1", "busybox", "top")
+	cli.DockerCmd(c, "run", "-d", "--name", "container2", "busybox", "top")
+	cli.DockerCmd(c, "run", "-d", "--name", "testinspectlink", "--link", "container1:alias1", "--link", "container2:alias2", "busybox", "true")
 	links := inspectFieldJSON(c, "testinspectlink", "HostConfig.Links")
 
 	var result []string
@@ -141,22 +140,20 @@ func (s *DockerCLILinksSuite) TestLinksInspectLinksStopped(c *testing.T) {
 
 func (s *DockerCLILinksSuite) TestLinksNotStartedParentNotFail(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	dockerCmd(c, "create", "--name=first", "busybox", "top")
-	dockerCmd(c, "create", "--name=second", "--link=first:first", "busybox", "top")
-	dockerCmd(c, "start", "first")
+	cli.DockerCmd(c, "create", "--name=first", "busybox", "top")
+	cli.DockerCmd(c, "create", "--name=second", "--link=first:first", "busybox", "top")
+	cli.DockerCmd(c, "start", "first")
 }
 
 func (s *DockerCLILinksSuite) TestLinksHostsFilesInject(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 	testRequires(c, testEnv.IsLocalDaemon)
 
-	out, _ := dockerCmd(c, "run", "-itd", "--name", "one", "busybox", "top")
-	idOne := strings.TrimSpace(out)
-
-	out, _ = dockerCmd(c, "run", "-itd", "--name", "two", "--link", "one:onetwo", "busybox", "top")
-	idTwo := strings.TrimSpace(out)
-
-	assert.Assert(c, waitRun(idTwo) == nil)
+	idOne := cli.DockerCmd(c, "run", "-itd", "--name", "one", "busybox", "top").Stdout()
+	idOne = strings.TrimSpace(idOne)
+	idTwo := cli.DockerCmd(c, "run", "-itd", "--name", "two", "--link", "one:onetwo", "busybox", "top").Stdout()
+	idTwo = strings.TrimSpace(idTwo)
+	cli.WaitRun(c, idTwo)
 
 	readContainerFileWithExec(c, idOne, "/etc/hosts")
 	contentTwo := readContainerFileWithExec(c, idTwo, "/etc/hosts")
@@ -167,9 +164,9 @@ func (s *DockerCLILinksSuite) TestLinksHostsFilesInject(c *testing.T) {
 func (s *DockerCLILinksSuite) TestLinksUpdateOnRestart(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 	testRequires(c, testEnv.IsLocalDaemon)
-	dockerCmd(c, "run", "-d", "--name", "one", "busybox", "top")
-	out, _ := dockerCmd(c, "run", "-d", "--name", "two", "--link", "one:onetwo", "--link", "one:one", "busybox", "top")
-	id := strings.TrimSpace(out)
+	cli.DockerCmd(c, "run", "-d", "--name", "one", "busybox", "top")
+	id := cli.DockerCmd(c, "run", "-d", "--name", "two", "--link", "one:onetwo", "--link", "one:one", "busybox", "top").Stdout()
+	id = strings.TrimSpace(id)
 
 	realIP := inspectField(c, "one", "NetworkSettings.Networks.bridge.IPAddress")
 	content := readContainerFileWithExec(c, id, "/etc/hosts")
@@ -186,7 +183,7 @@ func (s *DockerCLILinksSuite) TestLinksUpdateOnRestart(c *testing.T) {
 	ip = getIP(content, "onetwo")
 	assert.Check(c, is.Equal(ip, realIP))
 
-	dockerCmd(c, "restart", "one")
+	cli.DockerCmd(c, "restart", "one")
 	realIP = inspectField(c, "one", "NetworkSettings.Networks.bridge.IPAddress")
 
 	content = readContainerFileWithExec(c, id, "/etc/hosts")
@@ -199,8 +196,8 @@ func (s *DockerCLILinksSuite) TestLinksUpdateOnRestart(c *testing.T) {
 
 func (s *DockerCLILinksSuite) TestLinksEnvs(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	dockerCmd(c, "run", "-d", "-e", "e1=", "-e", "e2=v2", "-e", "e3=v3=v3", "--name=first", "busybox", "top")
-	out, _ := dockerCmd(c, "run", "--name=second", "--link=first:first", "busybox", "env")
+	cli.DockerCmd(c, "run", "-d", "-e", "e1=", "-e", "e2=v2", "-e", "e3=v3=v3", "--name=first", "busybox", "top")
+	out := cli.DockerCmd(c, "run", "--name=second", "--link=first:first", "busybox", "env").Stdout()
 	assert.Assert(c, is.Contains(out, "FIRST_ENV_e1=\n"))
 	assert.Assert(c, is.Contains(out, "FIRST_ENV_e2=v2"))
 	assert.Assert(c, is.Contains(out, "FIRST_ENV_e3=v3=v3"))
@@ -208,15 +205,13 @@ func (s *DockerCLILinksSuite) TestLinksEnvs(c *testing.T) {
 
 func (s *DockerCLILinksSuite) TestLinkShortDefinition(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-d", "--name", "shortlinkdef", "busybox", "top")
+	cid := cli.DockerCmd(c, "run", "-d", "--name", "shortlinkdef", "busybox", "top").Stdout()
+	cid = strings.TrimSpace(cid)
+	cli.WaitRun(c, cid)
 
-	cid := strings.TrimSpace(out)
-	assert.Assert(c, waitRun(cid) == nil)
-
-	out, _ = dockerCmd(c, "run", "-d", "--name", "link2", "--link", "shortlinkdef", "busybox", "top")
-
-	cid2 := strings.TrimSpace(out)
-	assert.Assert(c, waitRun(cid2) == nil)
+	cid2 := cli.DockerCmd(c, "run", "-d", "--name", "link2", "--link", "shortlinkdef", "busybox", "top").Stdout()
+	cid2 = strings.TrimSpace(cid2)
+	cli.WaitRun(c, cid2)
 
 	links := inspectFieldJSON(c, cid2, "HostConfig.Links")
 	assert.Equal(c, links, `["/shortlinkdef:/link2/shortlinkdef"]`)
@@ -224,7 +219,7 @@ func (s *DockerCLILinksSuite) TestLinkShortDefinition(c *testing.T) {
 
 func (s *DockerCLILinksSuite) TestLinksNetworkHostContainer(c *testing.T) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
-	dockerCmd(c, "run", "-d", "--net", "host", "--name", "host_container", "busybox", "top")
+	cli.DockerCmd(c, "run", "-d", "--net", "host", "--name", "host_container", "busybox", "top")
 	out, _, err := dockerCmdWithError("run", "--name", "should_fail", "--link", "host_container:tester", "busybox", "true")
 
 	// Running container linking to a container with --net host should have failed
@@ -235,14 +230,14 @@ func (s *DockerCLILinksSuite) TestLinksNetworkHostContainer(c *testing.T) {
 
 func (s *DockerCLILinksSuite) TestLinksEtcHostsRegularFile(c *testing.T) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
-	out, _ := dockerCmd(c, "run", "--net=host", "busybox", "ls", "-la", "/etc/hosts")
+	out := cli.DockerCmd(c, "run", "--net=host", "busybox", "ls", "-la", "/etc/hosts").Stdout()
 	// /etc/hosts should be a regular file
 	assert.Assert(c, is.Regexp("^-.+\n$", out))
 }
 
 func (s *DockerCLILinksSuite) TestLinksMultipleWithSameName(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	dockerCmd(c, "run", "-d", "--name=upstream-a", "busybox", "top")
-	dockerCmd(c, "run", "-d", "--name=upstream-b", "busybox", "top")
-	dockerCmd(c, "run", "--link", "upstream-a:upstream", "--link", "upstream-b:upstream", "busybox", "sh", "-c", "ping -c 1 upstream")
+	cli.DockerCmd(c, "run", "-d", "--name=upstream-a", "busybox", "top")
+	cli.DockerCmd(c, "run", "-d", "--name=upstream-b", "busybox", "top")
+	cli.DockerCmd(c, "run", "--link", "upstream-a:upstream", "--link", "upstream-b:upstream", "busybox", "sh", "-c", "ping -c 1 upstream")
 }

--- a/integration-cli/docker_cli_login_test.go
+++ b/integration-cli/docker_cli_login_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/integration-cli/cli"
 	"gotest.tools/v3/assert"
 )
 
@@ -30,7 +31,7 @@ func (s *DockerCLILoginSuite) TestLoginWithoutTTY(c *testing.T) {
 
 	// run the command and block until it's done
 	err := cmd.Run()
-	assert.ErrorContains(c, err, "") //"Expected non nil err when logging in & TTY not available"
+	assert.ErrorContains(c, err, "") // "Expected non nil err when logging in & TTY not available"
 }
 
 func (s *DockerRegistryAuthHtpasswdSuite) TestLoginToPrivateRegistry(c *testing.T) {
@@ -40,5 +41,5 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestLoginToPrivateRegistry(c *testing.
 	assert.Assert(c, strings.Contains(out, "401 Unauthorized"))
 
 	// now it's fine
-	dockerCmd(c, "login", "-u", s.reg.Username(), "-p", s.reg.Password(), privateRegistryURL)
+	cli.DockerCmd(c, "login", "-u", s.reg.Username(), "-p", s.reg.Password(), privateRegistryURL)
 }

--- a/integration-cli/docker_cli_netmode_test.go
+++ b/integration-cli/docker_cli_netmode_test.go
@@ -29,12 +29,11 @@ func (s *DockerCLINetmodeSuite) OnTimeout(c *testing.T) {
 }
 
 // DockerCmdWithFail executes a docker command that is supposed to fail and returns
-// the output, the exit code. If the command returns a Nil error, it will fail and
-// stop the tests.
-func dockerCmdWithFail(c *testing.T, args ...string) (string, int) {
-	out, status, err := dockerCmdWithError(args...)
+// the output. If the command returns a Nil error, it will fail and stop the tests.
+func dockerCmdWithFail(c *testing.T, args ...string) string {
+	out, _, err := dockerCmdWithError(args...)
 	assert.Assert(c, err != nil, "%v", out)
-	return out, status
+	return out
 }
 
 func (s *DockerCLINetmodeSuite) TestNetHostnameWithNetHost(c *testing.T) {
@@ -53,48 +52,48 @@ func (s *DockerCLINetmodeSuite) TestNetHostname(c *testing.T) {
 	assert.Assert(c, strings.Contains(out, stringCheckPS))
 	out = cli.DockerCmd(c, "run", "-h=name", "--net=none", "busybox", "ps").Stdout()
 	assert.Assert(c, strings.Contains(out, stringCheckPS))
-	out, _ = dockerCmdWithFail(c, "run", "-h=name", "--net=container:other", "busybox", "ps")
+	out = dockerCmdWithFail(c, "run", "-h=name", "--net=container:other", "busybox", "ps")
 	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictNetworkHostname.Error()))
-	out, _ = dockerCmdWithFail(c, "run", "--net=container", "busybox", "ps")
+	out = dockerCmdWithFail(c, "run", "--net=container", "busybox", "ps")
 	assert.Assert(c, strings.Contains(out, "invalid container format container:<name|id>"))
-	out, _ = dockerCmdWithFail(c, "run", "--net=weird", "busybox", "ps")
+	out = dockerCmdWithFail(c, "run", "--net=weird", "busybox", "ps")
 	assert.Assert(c, strings.Contains(strings.ToLower(out), "not found"))
 }
 
 func (s *DockerCLINetmodeSuite) TestConflictContainerNetworkAndLinks(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 
-	out, _ := dockerCmdWithFail(c, "run", "--net=container:other", "--link=zip:zap", "busybox", "ps")
+	out := dockerCmdWithFail(c, "run", "--net=container:other", "--link=zip:zap", "busybox", "ps")
 	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictContainerNetworkAndLinks.Error()))
 }
 
 func (s *DockerCLINetmodeSuite) TestConflictContainerNetworkHostAndLinks(c *testing.T) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
 
-	out, _ := dockerCmdWithFail(c, "run", "--net=host", "--link=zip:zap", "busybox", "ps")
+	out := dockerCmdWithFail(c, "run", "--net=host", "--link=zip:zap", "busybox", "ps")
 	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictHostNetworkAndLinks.Error()))
 }
 
 func (s *DockerCLINetmodeSuite) TestConflictNetworkModeNetHostAndOptions(c *testing.T) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
 
-	out, _ := dockerCmdWithFail(c, "run", "--net=host", "--mac-address=92:d0:c6:0a:29:33", "busybox", "ps")
+	out := dockerCmdWithFail(c, "run", "--net=host", "--mac-address=92:d0:c6:0a:29:33", "busybox", "ps")
 	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictContainerNetworkAndMac.Error()))
 }
 
 func (s *DockerCLINetmodeSuite) TestConflictNetworkModeAndOptions(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 
-	out, _ := dockerCmdWithFail(c, "run", "--net=container:other", "--dns=8.8.8.8", "busybox", "ps")
+	out := dockerCmdWithFail(c, "run", "--net=container:other", "--dns=8.8.8.8", "busybox", "ps")
 	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictNetworkAndDNS.Error()))
-	out, _ = dockerCmdWithFail(c, "run", "--net=container:other", "--add-host=name:8.8.8.8", "busybox", "ps")
+	out = dockerCmdWithFail(c, "run", "--net=container:other", "--add-host=name:8.8.8.8", "busybox", "ps")
 	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictNetworkHosts.Error()))
-	out, _ = dockerCmdWithFail(c, "run", "--net=container:other", "--mac-address=92:d0:c6:0a:29:33", "busybox", "ps")
+	out = dockerCmdWithFail(c, "run", "--net=container:other", "--mac-address=92:d0:c6:0a:29:33", "busybox", "ps")
 	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictContainerNetworkAndMac.Error()))
-	out, _ = dockerCmdWithFail(c, "run", "--net=container:other", "-P", "busybox", "ps")
+	out = dockerCmdWithFail(c, "run", "--net=container:other", "-P", "busybox", "ps")
 	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictNetworkPublishPorts.Error()))
-	out, _ = dockerCmdWithFail(c, "run", "--net=container:other", "-p", "8080", "busybox", "ps")
+	out = dockerCmdWithFail(c, "run", "--net=container:other", "-p", "8080", "busybox", "ps")
 	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictNetworkPublishPorts.Error()))
-	out, _ = dockerCmdWithFail(c, "run", "--net=container:other", "--expose", "8000-9000", "busybox", "ps")
+	out = dockerCmdWithFail(c, "run", "--net=container:other", "--expose", "8000-9000", "busybox", "ps")
 	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictNetworkExposePorts.Error()))
 }

--- a/integration-cli/docker_cli_netmode_test.go
+++ b/integration-cli/docker_cli_netmode_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/runconfig"
 	"gotest.tools/v3/assert"
 )
@@ -39,18 +40,18 @@ func dockerCmdWithFail(c *testing.T, args ...string) (string, int) {
 func (s *DockerCLINetmodeSuite) TestNetHostnameWithNetHost(c *testing.T) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
 
-	out, _ := dockerCmd(c, "run", "--net=host", "busybox", "ps")
+	out := cli.DockerCmd(c, "run", "--net=host", "busybox", "ps").Stdout()
 	assert.Assert(c, strings.Contains(out, stringCheckPS))
 }
 
 func (s *DockerCLINetmodeSuite) TestNetHostname(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 
-	out, _ := dockerCmd(c, "run", "-h=name", "busybox", "ps")
+	out := cli.DockerCmd(c, "run", "-h=name", "busybox", "ps").Stdout()
 	assert.Assert(c, strings.Contains(out, stringCheckPS))
-	out, _ = dockerCmd(c, "run", "-h=name", "--net=bridge", "busybox", "ps")
+	out = cli.DockerCmd(c, "run", "-h=name", "--net=bridge", "busybox", "ps").Stdout()
 	assert.Assert(c, strings.Contains(out, stringCheckPS))
-	out, _ = dockerCmd(c, "run", "-h=name", "--net=none", "busybox", "ps")
+	out = cli.DockerCmd(c, "run", "-h=name", "--net=none", "busybox", "ps").Stdout()
 	assert.Assert(c, strings.Contains(out, stringCheckPS))
 	out, _ = dockerCmdWithFail(c, "run", "-h=name", "--net=container:other", "busybox", "ps")
 	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictNetworkHostname.Error()))

--- a/integration-cli/docker_cli_plugins_logdriver_test.go
+++ b/integration-cli/docker_cli_plugins_logdriver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/testutil"
 	"gotest.tools/v3/assert"
 )
@@ -25,28 +26,28 @@ func (s *DockerCLIPluginLogDriverSuite) OnTimeout(c *testing.T) {
 func (s *DockerCLIPluginLogDriverSuite) TestPluginLogDriver(c *testing.T) {
 	testRequires(c, IsAmd64, DaemonIsLinux)
 
-	pluginName := "cpuguy83/docker-logdriver-test:latest"
+	const pluginName = "cpuguy83/docker-logdriver-test:latest"
 
-	dockerCmd(c, "plugin", "install", pluginName)
-	dockerCmd(c, "run", "--log-driver", pluginName, "--name=test", "busybox", "echo", "hello")
-	out, _ := dockerCmd(c, "logs", "test")
+	cli.DockerCmd(c, "plugin", "install", pluginName)
+	cli.DockerCmd(c, "run", "--log-driver", pluginName, "--name=test", "busybox", "echo", "hello")
+	out := cli.DockerCmd(c, "logs", "test").Combined()
 	assert.Equal(c, strings.TrimSpace(out), "hello")
 
-	dockerCmd(c, "start", "-a", "test")
-	out, _ = dockerCmd(c, "logs", "test")
+	cli.DockerCmd(c, "start", "-a", "test")
+	out = cli.DockerCmd(c, "logs", "test").Combined()
 	assert.Equal(c, strings.TrimSpace(out), "hello\nhello")
 
-	dockerCmd(c, "rm", "test")
-	dockerCmd(c, "plugin", "disable", pluginName)
-	dockerCmd(c, "plugin", "rm", pluginName)
+	cli.DockerCmd(c, "rm", "test")
+	cli.DockerCmd(c, "plugin", "disable", pluginName)
+	cli.DockerCmd(c, "plugin", "rm", pluginName)
 }
 
 // Make sure log drivers are listed in info, and v2 plugins are not.
 func (s *DockerCLIPluginLogDriverSuite) TestPluginLogDriverInfoList(c *testing.T) {
 	testRequires(c, IsAmd64, DaemonIsLinux)
-	pluginName := "cpuguy83/docker-logdriver-test"
+	const pluginName = "cpuguy83/docker-logdriver-test"
 
-	dockerCmd(c, "plugin", "install", pluginName)
+	cli.DockerCmd(c, "plugin", "install", pluginName)
 
 	apiClient, err := client.NewClientWithOpts(client.FromEnv)
 	assert.NilError(c, err)

--- a/integration-cli/docker_cli_prune_unix_test.go
+++ b/integration-cli/docker_cli_prune_unix_test.go
@@ -169,42 +169,48 @@ func (s *DockerCLIPruneSuite) TestPruneContainerLabel(c *testing.T) {
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id2))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id3))
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id4))
+
 	out = cli.DockerCmd(c, "container", "prune", "--force", "--filter", "label=foo").Combined()
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id1))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id2))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id3))
+
 	out = cli.DockerCmd(c, "ps", "-a", "-q", "--no-trunc").Combined()
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id1))
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id2))
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id3))
+
 	out = cli.DockerCmd(c, "container", "prune", "--force", "--filter", "label!=bar").Combined()
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id2))
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id3))
+
 	out = cli.DockerCmd(c, "ps", "-a", "-q", "--no-trunc").Combined()
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id2))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id3))
+
 	// With config.json label=foobar and CLI label!=foobar, CLI label!=foobar supersede
 	out = cli.DockerCmd(c, "--config", d, "container", "prune", "--force", "--filter", "label!=foobar").Combined()
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id2))
+
 	out = cli.DockerCmd(c, "ps", "-a", "-q", "--no-trunc").Combined()
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id2))
 }
 
 func (s *DockerCLIPruneSuite) TestPruneVolumeLabel(c *testing.T) {
-	out, _ := dockerCmd(c, "volume", "create", "--label", "foo")
-	id1 := strings.TrimSpace(out)
+	id1 := cli.DockerCmd(c, "volume", "create", "--label", "foo").Stdout()
+	id1 = strings.TrimSpace(id1)
 	assert.Assert(c, id1 != "")
 
-	out, _ = dockerCmd(c, "volume", "create", "--label", "bar")
-	id2 := strings.TrimSpace(out)
+	id2 := cli.DockerCmd(c, "volume", "create", "--label", "bar").Stdout()
+	id2 = strings.TrimSpace(id2)
 	assert.Assert(c, id2 != "")
 
-	out, _ = dockerCmd(c, "volume", "create")
-	id3 := strings.TrimSpace(out)
+	id3 := cli.DockerCmd(c, "volume", "create").Stdout()
+	id3 = strings.TrimSpace(id3)
 	assert.Assert(c, id3 != "")
 
-	out, _ = dockerCmd(c, "volume", "create", "--label", "foobar")
-	id4 := strings.TrimSpace(out)
+	id4 := cli.DockerCmd(c, "volume", "create", "--label", "foobar").Stdout()
+	id4 = strings.TrimSpace(id4)
 	assert.Assert(c, id4 != "")
 
 	// Add a config file of label=foobar, that will have no impact if cli is label!=foobar
@@ -216,46 +222,53 @@ func (s *DockerCLIPruneSuite) TestPruneVolumeLabel(c *testing.T) {
 	assert.NilError(c, err)
 
 	// With config.json only, prune based on label=foobar
-	out, _ = dockerCmd(c, "--config", d, "volume", "prune", "--force")
+	out := cli.DockerCmd(c, "--config", d, "volume", "prune", "--force").Combined()
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id1))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id2))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id3))
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id4))
-	out, _ = dockerCmd(c, "volume", "prune", "--force", "--filter", "label=foo")
+
+	out = cli.DockerCmd(c, "volume", "prune", "--force", "--filter", "label=foo").Combined()
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id1))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id2))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id3))
-	out, _ = dockerCmd(c, "volume", "ls", "--format", "{{.Name}}")
+
+	out = cli.DockerCmd(c, "volume", "ls", "--format", "{{.Name}}").Stdout()
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id1))
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id2))
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id3))
-	out, _ = dockerCmd(c, "volume", "prune", "--force", "--filter", "label!=bar")
+
+	out = cli.DockerCmd(c, "volume", "prune", "--force", "--filter", "label!=bar").Combined()
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id2))
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id3))
-	out, _ = dockerCmd(c, "volume", "ls", "--format", "{{.Name}}")
+
+	out = cli.DockerCmd(c, "volume", "ls", "--format", "{{.Name}}").Stdout()
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id2))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id3))
+
 	// With config.json label=foobar and CLI label!=foobar, CLI label!=foobar supersede
-	out, _ = dockerCmd(c, "--config", d, "volume", "prune", "--force", "--filter", "label!=foobar")
+	out = cli.DockerCmd(c, "--config", d, "volume", "prune", "--force", "--filter", "label!=foobar").Combined()
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id2))
-	out, _ = dockerCmd(c, "volume", "ls", "--format", "{{.Name}}")
+	out = cli.DockerCmd(c, "volume", "ls", "--format", "{{.Name}}").Stdout()
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id2))
 }
 
 func (s *DockerCLIPruneSuite) TestPruneNetworkLabel(c *testing.T) {
-	dockerCmd(c, "network", "create", "--label", "foo", "n1")
-	dockerCmd(c, "network", "create", "--label", "bar", "n2")
-	dockerCmd(c, "network", "create", "n3")
+	cli.DockerCmd(c, "network", "create", "--label", "foo", "n1")
+	cli.DockerCmd(c, "network", "create", "--label", "bar", "n2")
+	cli.DockerCmd(c, "network", "create", "n3")
 
-	out, _ := dockerCmd(c, "network", "prune", "--force", "--filter", "label=foo")
+	out := cli.DockerCmd(c, "network", "prune", "--force", "--filter", "label=foo").Combined()
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), "n1"))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), "n2"))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), "n3"))
-	out, _ = dockerCmd(c, "network", "prune", "--force", "--filter", "label!=bar")
+
+	out = cli.DockerCmd(c, "network", "prune", "--force", "--filter", "label!=bar").Combined()
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), "n1"))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), "n2"))
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), "n3"))
-	out, _ = dockerCmd(c, "network", "prune", "--force")
+
+	out = cli.DockerCmd(c, "network", "prune", "--force").Combined()
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), "n1"))
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), "n2"))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), "n3"))
@@ -282,17 +295,21 @@ func (s *DockerDaemonSuite) TestPruneImageLabel(c *testing.T) {
 	)
 	result.Assert(c, icmd.Success)
 	id2 := strings.TrimSpace(result.Combined())
+
 	out, err = s.d.Cmd("images", "-q", "--no-trunc")
 	assert.NilError(c, err)
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id2))
+
 	out, err = s.d.Cmd("image", "prune", "--force", "--all", "--filter", "label=foo=bar")
 	assert.NilError(c, err)
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id1))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id2))
+
 	out, err = s.d.Cmd("image", "prune", "--force", "--all", "--filter", "label!=bar=foo")
 	assert.NilError(c, err)
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id1))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id2))
+
 	out, err = s.d.Cmd("image", "prune", "--force", "--all", "--filter", "label=bar=foo")
 	assert.NilError(c, err)
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id1))

--- a/integration-cli/docker_cli_pull_local_test.go
+++ b/integration-cli/docker_cli_pull_local_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/distribution/manifest"
 	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/manifest/schema2"
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/opencontainers/go-digest"
 	"gotest.tools/v3/assert"
@@ -24,26 +25,26 @@ import (
 //
 // Ref: docker/docker#8141
 func testPullImageWithAliases(c *testing.T) {
-	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
+	const imgRepo = privateRegistryURL + "/dockercli/busybox"
 
 	var repos []string
 	for _, tag := range []string{"recent", "fresh"} {
-		repos = append(repos, fmt.Sprintf("%v:%v", repoName, tag))
+		repos = append(repos, fmt.Sprintf("%v:%v", imgRepo, tag))
 	}
 
 	// Tag and push the same image multiple times.
 	for _, repo := range repos {
-		dockerCmd(c, "tag", "busybox", repo)
-		dockerCmd(c, "push", repo)
+		cli.DockerCmd(c, "tag", "busybox", repo)
+		cli.DockerCmd(c, "push", repo)
 	}
 
 	// Clear local images store.
 	args := append([]string{"rmi"}, repos...)
-	dockerCmd(c, args...)
+	cli.DockerCmd(c, args...)
 
 	// Pull a single tag and verify it doesn't bring down all aliases.
-	dockerCmd(c, "pull", repos[0])
-	dockerCmd(c, "inspect", repos[0])
+	cli.DockerCmd(c, "pull", repos[0])
+	cli.DockerCmd(c, "inspect", repos[0])
 	for _, repo := range repos[1:] {
 		_, _, err := dockerCmdWithError("inspect", repo)
 		assert.ErrorContains(c, err, "", "Image %v shouldn't have been pulled down", repo)
@@ -60,11 +61,11 @@ func (s *DockerSchema1RegistrySuite) TestPullImageWithAliases(c *testing.T) {
 
 // testConcurrentPullWholeRepo pulls the same repo concurrently.
 func testConcurrentPullWholeRepo(c *testing.T) {
-	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
+	const imgRepo = privateRegistryURL + "/dockercli/busybox"
 
 	var repos []string
 	for _, tag := range []string{"recent", "fresh", "todays"} {
-		repo := fmt.Sprintf("%v:%v", repoName, tag)
+		repo := fmt.Sprintf("%v:%v", imgRepo, tag)
 		buildImageSuccessfully(c, repo, build.WithDockerfile(fmt.Sprintf(`
 		    FROM busybox
 		    ENTRYPOINT ["/bin/echo"]
@@ -72,13 +73,13 @@ func testConcurrentPullWholeRepo(c *testing.T) {
 		    ENV BAR bar
 		    CMD echo %s
 		`, repo)))
-		dockerCmd(c, "push", repo)
+		cli.DockerCmd(c, "push", repo)
 		repos = append(repos, repo)
 	}
 
 	// Clear local images store.
 	args := append([]string{"rmi"}, repos...)
-	dockerCmd(c, args...)
+	cli.DockerCmd(c, args...)
 
 	// Run multiple re-pulls concurrently
 	numPulls := 3
@@ -86,7 +87,7 @@ func testConcurrentPullWholeRepo(c *testing.T) {
 
 	for i := 0; i != numPulls; i++ {
 		go func() {
-			result := icmd.RunCommand(dockerBinary, "pull", "-a", repoName)
+			result := icmd.RunCommand(dockerBinary, "pull", "-a", imgRepo)
 			results <- result.Error
 		}()
 	}
@@ -100,8 +101,8 @@ func testConcurrentPullWholeRepo(c *testing.T) {
 
 	// Ensure all tags were pulled successfully
 	for _, repo := range repos {
-		dockerCmd(c, "inspect", repo)
-		out, _ := dockerCmd(c, "run", "--rm", repo)
+		cli.DockerCmd(c, "inspect", repo)
+		out := cli.DockerCmd(c, "run", "--rm", repo).Combined()
 		assert.Equal(c, strings.TrimSpace(out), "/bin/sh -c echo "+repo)
 	}
 }
@@ -116,7 +117,7 @@ func (s *DockerSchema1RegistrySuite) TestConcurrentPullWholeRepo(c *testing.T) {
 
 // testConcurrentFailingPull tries a concurrent pull that doesn't succeed.
 func testConcurrentFailingPull(c *testing.T) {
-	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
+	const imgRepo = privateRegistryURL + "/dockercli/busybox"
 
 	// Run multiple pulls concurrently
 	numPulls := 3
@@ -124,7 +125,7 @@ func testConcurrentFailingPull(c *testing.T) {
 
 	for i := 0; i != numPulls; i++ {
 		go func() {
-			result := icmd.RunCommand(dockerBinary, "pull", repoName+":asdfasdf")
+			result := icmd.RunCommand(dockerBinary, "pull", imgRepo+":asdfasdf")
 			results <- result.Error
 		}()
 	}
@@ -148,11 +149,11 @@ func (s *DockerSchema1RegistrySuite) TestConcurrentFailingPull(c *testing.T) {
 // testConcurrentPullMultipleTags pulls multiple tags from the same repo
 // concurrently.
 func testConcurrentPullMultipleTags(c *testing.T) {
-	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
+	const imgRepo = privateRegistryURL + "/dockercli/busybox"
 
 	var repos []string
 	for _, tag := range []string{"recent", "fresh", "todays"} {
-		repo := fmt.Sprintf("%v:%v", repoName, tag)
+		repo := fmt.Sprintf("%v:%v", imgRepo, tag)
 		buildImageSuccessfully(c, repo, build.WithDockerfile(fmt.Sprintf(`
 		    FROM busybox
 		    ENTRYPOINT ["/bin/echo"]
@@ -160,13 +161,13 @@ func testConcurrentPullMultipleTags(c *testing.T) {
 		    ENV BAR bar
 		    CMD echo %s
 		`, repo)))
-		dockerCmd(c, "push", repo)
+		cli.DockerCmd(c, "push", repo)
 		repos = append(repos, repo)
 	}
 
 	// Clear local images store.
 	args := append([]string{"rmi"}, repos...)
-	dockerCmd(c, args...)
+	cli.DockerCmd(c, args...)
 
 	// Re-pull individual tags, in parallel
 	results := make(chan error, len(repos))
@@ -187,8 +188,8 @@ func testConcurrentPullMultipleTags(c *testing.T) {
 
 	// Ensure all tags were pulled successfully
 	for _, repo := range repos {
-		dockerCmd(c, "inspect", repo)
-		out, _ := dockerCmd(c, "run", "--rm", repo)
+		cli.DockerCmd(c, "inspect", repo)
+		out := cli.DockerCmd(c, "run", "--rm", repo).Combined()
 		assert.Equal(c, strings.TrimSpace(out), "/bin/sh -c echo "+repo)
 	}
 }
@@ -204,8 +205,8 @@ func (s *DockerSchema1RegistrySuite) TestConcurrentPullMultipleTags(c *testing.T
 // testPullIDStability verifies that pushing an image and pulling it back
 // preserves the image ID.
 func testPullIDStability(c *testing.T) {
-	derivedImage := privateRegistryURL + "/dockercli/id-stability"
-	baseImage := "busybox"
+	const derivedImage = privateRegistryURL + "/dockercli/id-stability"
+	const baseImage = "busybox"
 
 	buildImageSuccessfully(c, derivedImage, build.WithDockerfile(fmt.Sprintf(`
 	    FROM %s
@@ -216,10 +217,10 @@ func testPullIDStability(c *testing.T) {
 	`, baseImage, derivedImage)))
 
 	originalID := getIDByName(c, derivedImage)
-	dockerCmd(c, "push", derivedImage)
+	cli.DockerCmd(c, "push", derivedImage)
 
 	// Pull
-	out, _ := dockerCmd(c, "pull", derivedImage)
+	out := cli.DockerCmd(c, "pull", derivedImage).Combined()
 	if strings.Contains(out, "Pull complete") {
 		c.Fatalf("repull redownloaded a layer: %s", out)
 	}
@@ -231,24 +232,23 @@ func testPullIDStability(c *testing.T) {
 	}
 
 	// Make sure the image runs correctly
-	out, _ = dockerCmd(c, "run", "--rm", derivedImage)
+	out = cli.DockerCmd(c, "run", "--rm", derivedImage).Combined()
 	if strings.TrimSpace(out) != derivedImage {
 		c.Fatalf("expected %s; got %s", derivedImage, out)
 	}
 
 	// Confirm that repushing and repulling does not change the computed ID
-	dockerCmd(c, "push", derivedImage)
-	dockerCmd(c, "rmi", derivedImage)
-	dockerCmd(c, "pull", derivedImage)
+	cli.DockerCmd(c, "push", derivedImage)
+	cli.DockerCmd(c, "rmi", derivedImage)
+	cli.DockerCmd(c, "pull", derivedImage)
 
 	derivedIDAfterPull = getIDByName(c, derivedImage)
-
 	if derivedIDAfterPull != originalID {
 		c.Fatal("image's ID unexpectedly changed after a repush/repull")
 	}
 
 	// Make sure the image still runs
-	out, _ = dockerCmd(c, "run", "--rm", derivedImage)
+	out = cli.DockerCmd(c, "run", "--rm", derivedImage).Combined()
 	if strings.TrimSpace(out) != derivedImage {
 		c.Fatalf("expected %s; got %s", derivedImage, out)
 	}
@@ -264,14 +264,14 @@ func (s *DockerSchema1RegistrySuite) TestPullIDStability(c *testing.T) {
 
 // #21213
 func testPullNoLayers(c *testing.T) {
-	repoName := fmt.Sprintf("%v/dockercli/scratch", privateRegistryURL)
+	const imgRepo = privateRegistryURL + "/dockercli/scratch"
 
-	buildImageSuccessfully(c, repoName, build.WithDockerfile(`
+	buildImageSuccessfully(c, imgRepo, build.WithDockerfile(`
 	FROM scratch
 	ENV foo bar`))
-	dockerCmd(c, "push", repoName)
-	dockerCmd(c, "rmi", repoName)
-	dockerCmd(c, "pull", repoName)
+	cli.DockerCmd(c, "push", imgRepo)
+	cli.DockerCmd(c, "rmi", imgRepo)
+	cli.DockerCmd(c, "pull", imgRepo)
 }
 
 func (s *DockerRegistrySuite) TestPullNoLayers(c *testing.T) {
@@ -348,7 +348,7 @@ func (s *DockerRegistrySuite) TestPullManifestList(c *testing.T) {
 	assert.NilError(c, err, "error writing tag link")
 
 	// Verify that the image can be pulled through the manifest list.
-	out, _ := dockerCmd(c, "pull", repoName)
+	out := cli.DockerCmd(c, "pull", repoName).Combined()
 
 	// The pull output includes "Digest: <digest>", so find that
 	matches := digestRegex.FindStringSubmatch(out)
@@ -359,9 +359,9 @@ func (s *DockerRegistrySuite) TestPullManifestList(c *testing.T) {
 	assert.Equal(c, manifestListDigest.String(), pullDigest)
 
 	// Was the image actually created?
-	dockerCmd(c, "inspect", repoName)
+	cli.DockerCmd(c, "inspect", repoName)
 
-	dockerCmd(c, "rmi", repoName)
+	cli.DockerCmd(c, "rmi", repoName)
 }
 
 // #23100
@@ -375,7 +375,7 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestPullWithExternalAuthLoginWithSchem
 	testPath := fmt.Sprintf("%s%c%s", osPath, filepath.ListSeparator, absolute)
 	c.Setenv("PATH", testPath)
 
-	repoName := fmt.Sprintf("%v/dockercli/busybox:authtest", privateRegistryURL)
+	const imgRepo = privateRegistryURL + "/dockercli/busybox:authtest"
 
 	tmp, err := os.MkdirTemp("", "integration-cli-")
 	assert.NilError(c, err)
@@ -386,25 +386,25 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestPullWithExternalAuthLoginWithSchem
 	err = os.WriteFile(configPath, []byte(externalAuthConfig), 0o644)
 	assert.NilError(c, err)
 
-	dockerCmd(c, "--config", tmp, "login", "-u", s.reg.Username(), "-p", s.reg.Password(), privateRegistryURL)
+	cli.DockerCmd(c, "--config", tmp, "login", "-u", s.reg.Username(), "-p", s.reg.Password(), privateRegistryURL)
 
 	b, err := os.ReadFile(configPath)
 	assert.NilError(c, err)
 	assert.Assert(c, !strings.Contains(string(b), `"auth":`))
-	dockerCmd(c, "--config", tmp, "tag", "busybox", repoName)
-	dockerCmd(c, "--config", tmp, "push", repoName)
+	cli.DockerCmd(c, "--config", tmp, "tag", "busybox", imgRepo)
+	cli.DockerCmd(c, "--config", tmp, "push", imgRepo)
 
-	dockerCmd(c, "--config", tmp, "logout", privateRegistryURL)
-	dockerCmd(c, "--config", tmp, "login", "-u", s.reg.Username(), "-p", s.reg.Password(), "https://"+privateRegistryURL)
-	dockerCmd(c, "--config", tmp, "pull", repoName)
+	cli.DockerCmd(c, "--config", tmp, "logout", privateRegistryURL)
+	cli.DockerCmd(c, "--config", tmp, "login", "-u", s.reg.Username(), "-p", s.reg.Password(), "https://"+privateRegistryURL)
+	cli.DockerCmd(c, "--config", tmp, "pull", imgRepo)
 
 	// likewise push should work
 	repoName2 := fmt.Sprintf("%v/dockercli/busybox:nocreds", privateRegistryURL)
-	dockerCmd(c, "tag", repoName, repoName2)
-	dockerCmd(c, "--config", tmp, "push", repoName2)
+	cli.DockerCmd(c, "tag", imgRepo, repoName2)
+	cli.DockerCmd(c, "--config", tmp, "push", repoName2)
 
 	// logout should work w scheme also because it will be stripped
-	dockerCmd(c, "--config", tmp, "logout", "https://"+privateRegistryURL)
+	cli.DockerCmd(c, "--config", tmp, "logout", "https://"+privateRegistryURL)
 }
 
 func (s *DockerRegistryAuthHtpasswdSuite) TestPullWithExternalAuth(c *testing.T) {
@@ -417,7 +417,7 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestPullWithExternalAuth(c *testing.T)
 	testPath := fmt.Sprintf("%s%c%s", osPath, filepath.ListSeparator, absolute)
 	c.Setenv("PATH", testPath)
 
-	repoName := fmt.Sprintf("%v/dockercli/busybox:authtest", privateRegistryURL)
+	const imgRepo = privateRegistryURL + "/dockercli/busybox:authtest"
 
 	tmp, err := os.MkdirTemp("", "integration-cli-")
 	assert.NilError(c, err)
@@ -428,34 +428,34 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestPullWithExternalAuth(c *testing.T)
 	err = os.WriteFile(configPath, []byte(externalAuthConfig), 0o644)
 	assert.NilError(c, err)
 
-	dockerCmd(c, "--config", tmp, "login", "-u", s.reg.Username(), "-p", s.reg.Password(), privateRegistryURL)
+	cli.DockerCmd(c, "--config", tmp, "login", "-u", s.reg.Username(), "-p", s.reg.Password(), privateRegistryURL)
 
 	b, err := os.ReadFile(configPath)
 	assert.NilError(c, err)
 	assert.Assert(c, !strings.Contains(string(b), `"auth":`))
-	dockerCmd(c, "--config", tmp, "tag", "busybox", repoName)
-	dockerCmd(c, "--config", tmp, "push", repoName)
+	cli.DockerCmd(c, "--config", tmp, "tag", "busybox", imgRepo)
+	cli.DockerCmd(c, "--config", tmp, "push", imgRepo)
 
-	dockerCmd(c, "--config", tmp, "pull", repoName)
+	cli.DockerCmd(c, "--config", tmp, "pull", imgRepo)
 }
 
 // TestRunImplicitPullWithNoTag should pull implicitly only the default tag (latest)
 func (s *DockerRegistrySuite) TestRunImplicitPullWithNoTag(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	repo := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
-	repoTag1 := fmt.Sprintf("%v:latest", repo)
-	repoTag2 := fmt.Sprintf("%v:t1", repo)
+	const imgRepo = privateRegistryURL + "/dockercli/busybox"
+	const repoTag1 = imgRepo + ":latest"
+	const repoTag2 = imgRepo + ":t1"
 	// tag the image and upload it to the private registry
-	dockerCmd(c, "tag", "busybox", repoTag1)
-	dockerCmd(c, "tag", "busybox", repoTag2)
-	dockerCmd(c, "push", repo)
-	dockerCmd(c, "rmi", repoTag1)
-	dockerCmd(c, "rmi", repoTag2)
+	cli.DockerCmd(c, "tag", "busybox", repoTag1)
+	cli.DockerCmd(c, "tag", "busybox", repoTag2)
+	cli.DockerCmd(c, "push", imgRepo)
+	cli.DockerCmd(c, "rmi", repoTag1)
+	cli.DockerCmd(c, "rmi", repoTag2)
 
-	out, _ := dockerCmd(c, "run", repo)
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf("Unable to find image '%s:latest' locally", repo)))
+	out := cli.DockerCmd(c, "run", imgRepo).Combined()
+	assert.Assert(c, strings.Contains(out, fmt.Sprintf("Unable to find image '%s:latest' locally", imgRepo)))
 	// There should be only one line for repo, the one with repo:latest
-	outImageCmd, _ := dockerCmd(c, "images", repo)
+	outImageCmd := cli.DockerCmd(c, "images", imgRepo).Stdout()
 	splitOutImageCmd := strings.Split(strings.TrimSpace(outImageCmd), "\n")
 	assert.Equal(c, len(splitOutImageCmd), 2)
 }

--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -181,9 +181,9 @@ func (s *DockerHubPullSuite) TestPullAllTagsFromCentralRegistry(c *testing.T) {
 // Ref: docker/docker#15589
 func (s *DockerHubPullSuite) TestPullClientDisconnect(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	repoName := "hello-world:latest"
+	const imgRepo = "hello-world:latest"
 
-	pullCmd := s.MakeCmd("pull", repoName)
+	pullCmd := s.MakeCmd("pull", imgRepo)
 	stdout, err := pullCmd.StdoutPipe()
 	assert.NilError(c, err)
 	err = pullCmd.Start()
@@ -199,7 +199,7 @@ func (s *DockerHubPullSuite) TestPullClientDisconnect(c *testing.T) {
 	assert.NilError(c, err)
 
 	time.Sleep(2 * time.Second)
-	_, err = s.CmdWithError("inspect", repoName)
+	_, err = s.CmdWithError("inspect", imgRepo)
 	assert.ErrorContains(c, err, "", "image was pulled after client disconnected")
 }
 

--- a/integration-cli/docker_cli_registry_user_agent_test.go
+++ b/integration-cli/docker_cli_registry_user_agent_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 	"os"
 	"regexp"
@@ -80,7 +79,7 @@ func (s *DockerRegistrySuite) TestUserAgentPassThrough(c *testing.T) {
 	defer reg.Close()
 
 	registerUserAgentHandler(reg, &ua)
-	repoName := fmt.Sprintf("%s/busybox", reg.URL())
+	imgRepo := reg.URL() + "/busybox"
 
 	s.d.StartWithBusybox(ctx, c, "--insecure-registry", reg.URL())
 
@@ -88,7 +87,7 @@ func (s *DockerRegistrySuite) TestUserAgentPassThrough(c *testing.T) {
 	assert.NilError(c, err)
 	defer os.RemoveAll(tmp)
 
-	dockerfile, err := makefile(tmp, fmt.Sprintf("FROM %s", repoName))
+	dockerfile, err := makefile(tmp, "FROM "+imgRepo)
 	assert.NilError(c, err, "Unable to create test dockerfile")
 
 	s.d.Cmd("build", "--file", dockerfile, tmp)
@@ -97,10 +96,10 @@ func (s *DockerRegistrySuite) TestUserAgentPassThrough(c *testing.T) {
 	s.d.Cmd("login", "-u", "richard", "-p", "testtest", reg.URL())
 	regexpCheckUA(c, ua)
 
-	s.d.Cmd("pull", repoName)
+	s.d.Cmd("pull", imgRepo)
 	regexpCheckUA(c, ua)
 
-	s.d.Cmd("tag", "busybox", repoName)
-	s.d.Cmd("push", repoName)
+	s.d.Cmd("tag", "busybox", imgRepo)
+	s.d.Cmd("push", imgRepo)
 	regexpCheckUA(c, ua)
 }

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2450,7 +2450,7 @@ func (s *DockerCLIRunSuite) TestRunModeUTSHost(c *testing.T) {
 		c.Fatalf("UTS should be different without --uts=host %s == %s\n", hostUTS, out)
 	}
 
-	out, _ = dockerCmdWithFail(c, "run", "-h=name", "--uts=host", "busybox", "ps")
+	out = dockerCmdWithFail(c, "run", "-h=name", "--uts=host", "busybox", "ps")
 	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictUTSHostname.Error()))
 }
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -54,7 +54,7 @@ func (s *DockerCLIRunSuite) OnTimeout(c *testing.T) {
 
 // "test123" should be printed by docker run
 func (s *DockerCLIRunSuite) TestRunEchoStdout(c *testing.T) {
-	out, _ := dockerCmd(c, "run", "busybox", "echo", "test123")
+	out := cli.DockerCmd(c, "run", "busybox", "echo", "test123").Combined()
 	if out != "test123\n" {
 		c.Fatalf("container should've printed 'test123', got '%s'", out)
 	}
@@ -62,7 +62,7 @@ func (s *DockerCLIRunSuite) TestRunEchoStdout(c *testing.T) {
 
 // "test" should be printed
 func (s *DockerCLIRunSuite) TestRunEchoNamedContainer(c *testing.T) {
-	out, _ := dockerCmd(c, "run", "--name", "testfoonamedcontainer", "busybox", "echo", "test")
+	out := cli.DockerCmd(c, "run", "--name", "testfoonamedcontainer", "busybox", "echo", "test").Combined()
 	if out != "test\n" {
 		c.Errorf("container should've printed 'test'")
 	}
@@ -72,7 +72,7 @@ func (s *DockerCLIRunSuite) TestRunEchoNamedContainer(c *testing.T) {
 // specific functionality and cannot run on Windows.
 func (s *DockerCLIRunSuite) TestRunLeakyFileDescriptors(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "busybox", "ls", "-C", "/proc/self/fd")
+	out := cli.DockerCmd(c, "run", "busybox", "ls", "-C", "/proc/self/fd").Combined()
 
 	// normally, we should only get 0, 1, and 2, but 3 gets created by "ls" when it does "opendir" on the "fd" directory
 	if out != "0  1  2  3\n" {
@@ -87,15 +87,15 @@ func (s *DockerCLIRunSuite) TestRunLookupGoogleDNS(c *testing.T) {
 	if testEnv.DaemonInfo.OSType == "windows" {
 		// nslookup isn't present in Windows busybox. Is built-in. Further,
 		// nslookup isn't present in nanoserver. Hence just use PowerShell...
-		dockerCmd(c, "run", testEnv.PlatformDefaults.BaseImage, "powershell", "Resolve-DNSName", "google.com")
+		cli.DockerCmd(c, "run", testEnv.PlatformDefaults.BaseImage, "powershell", "Resolve-DNSName", "google.com")
 	} else {
-		dockerCmd(c, "run", "busybox", "nslookup", "google.com")
+		cli.DockerCmd(c, "run", "busybox", "nslookup", "google.com")
 	}
 }
 
 // the exit code should be 0
 func (s *DockerCLIRunSuite) TestRunExitCodeZero(c *testing.T) {
-	dockerCmd(c, "run", "busybox", "true")
+	cli.DockerCmd(c, "run", "busybox", "true")
 }
 
 // the exit code should be 1
@@ -117,30 +117,27 @@ func (s *DockerCLIRunSuite) TestRunStdinPipe(c *testing.T) {
 	out := result.Stdout()
 
 	out = strings.TrimSpace(out)
-	dockerCmd(c, "wait", out)
+	cli.DockerCmd(c, "wait", out)
 
-	logsOut, _ := dockerCmd(c, "logs", out)
-
-	containerLogs := strings.TrimSpace(logsOut)
+	containerLogs := cli.DockerCmd(c, "logs", out).Combined()
+	containerLogs = strings.TrimSpace(containerLogs)
 	if containerLogs != "blahblah" {
 		c.Errorf("logs didn't print the container's logs %s", containerLogs)
 	}
 
-	dockerCmd(c, "rm", out)
+	cli.DockerCmd(c, "rm", out)
 }
 
 // the container's ID should be printed when starting a container in detached mode
 func (s *DockerCLIRunSuite) TestRunDetachedContainerIDPrinting(c *testing.T) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
+	id := cli.DockerCmd(c, "run", "-d", "busybox", "true").Stdout()
+	id = strings.TrimSpace(id)
+	cli.DockerCmd(c, "wait", id)
 
-	out = strings.TrimSpace(out)
-	dockerCmd(c, "wait", out)
-
-	rmOut, _ := dockerCmd(c, "rm", out)
-
+	rmOut := cli.DockerCmd(c, "rm", id).Stdout()
 	rmOut = strings.TrimSpace(rmOut)
-	if rmOut != out {
-		c.Errorf("rm didn't print the container ID %s %s", out, rmOut)
+	if rmOut != id {
+		c.Errorf("rm didn't print the container ID %s %s", id, rmOut)
 	}
 }
 
@@ -153,16 +150,14 @@ func (s *DockerCLIRunSuite) TestRunWorkingDirectory(c *testing.T) {
 	}
 
 	// First with -w
-	out, _ := dockerCmd(c, "run", "-w", dir, image, "pwd")
-	out = strings.TrimSpace(out)
-	if out != dir {
+	out := cli.DockerCmd(c, "run", "-w", dir, image, "pwd").Stdout()
+	if strings.TrimSpace(out) != dir {
 		c.Errorf("-w failed to set working directory")
 	}
 
 	// Then with --workdir
-	out, _ = dockerCmd(c, "run", "--workdir", dir, image, "pwd")
-	out = strings.TrimSpace(out)
-	if out != dir {
+	out = cli.DockerCmd(c, "run", "--workdir", dir, image, "pwd").Stdout()
+	if strings.TrimSpace(out) != dir {
 		c.Errorf("--workdir failed to set working directory")
 	}
 }
@@ -191,11 +186,11 @@ func (s *DockerCLIRunSuite) TestRunLinksContainerWithContainerName(c *testing.T)
 	// TODO Windows: This test cannot run on a Windows daemon as the networking
 	// settings are not populated back yet on inspect.
 	testRequires(c, DaemonIsLinux)
-	dockerCmd(c, "run", "-i", "-t", "-d", "--name", "parent", "busybox")
+	cli.DockerCmd(c, "run", "-i", "-t", "-d", "--name", "parent", "busybox")
 
 	ip := inspectField(c, "parent", "NetworkSettings.Networks.bridge.IPAddress")
 
-	out, _ := dockerCmd(c, "run", "--link", "parent:test", "busybox", "/bin/cat", "/etc/hosts")
+	out := cli.DockerCmd(c, "run", "--link", "parent:test", "busybox", "/bin/cat", "/etc/hosts").Combined()
 	if !strings.Contains(out, ip+"	test") {
 		c.Fatalf("use a container name to link target failed")
 	}
@@ -206,12 +201,11 @@ func (s *DockerCLIRunSuite) TestRunLinksContainerWithContainerID(c *testing.T) {
 	// TODO Windows: This test cannot run on a Windows daemon as the networking
 	// settings are not populated back yet on inspect.
 	testRequires(c, DaemonIsLinux)
-	cID, _ := dockerCmd(c, "run", "-i", "-t", "-d", "busybox")
-
+	cID := cli.DockerCmd(c, "run", "-i", "-t", "-d", "busybox").Stdout()
 	cID = strings.TrimSpace(cID)
 	ip := inspectField(c, cID, "NetworkSettings.Networks.bridge.IPAddress")
 
-	out, _ := dockerCmd(c, "run", "--link", cID+":test", "busybox", "/bin/cat", "/etc/hosts")
+	out := cli.DockerCmd(c, "run", "--link", cID+":test", "busybox", "/bin/cat", "/etc/hosts").Combined()
 	if !strings.Contains(out, ip+"	test") {
 		c.Fatalf("use a container id to link target failed")
 	}
@@ -219,16 +213,15 @@ func (s *DockerCLIRunSuite) TestRunLinksContainerWithContainerID(c *testing.T) {
 
 func (s *DockerCLIRunSuite) TestUserDefinedNetworkLinks(c *testing.T) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
-	dockerCmd(c, "network", "create", "-d", "bridge", "udlinkNet")
+	cli.DockerCmd(c, "network", "create", "-d", "bridge", "udlinkNet")
 
-	dockerCmd(c, "run", "-d", "--net=udlinkNet", "--name=first", "busybox", "top")
-	assert.Assert(c, waitRun("first") == nil)
+	cli.DockerCmd(c, "run", "-d", "--net=udlinkNet", "--name=first", "busybox", "top")
+	cli.WaitRun(c, "first")
 
 	// run a container in user-defined network udlinkNet with a link for an existing container
 	// and a link for a container that doesn't exist
-	dockerCmd(c, "run", "-d", "--net=udlinkNet", "--name=second", "--link=first:foo",
-		"--link=third:bar", "busybox", "top")
-	assert.Assert(c, waitRun("second") == nil)
+	cli.DockerCmd(c, "run", "-d", "--net=udlinkNet", "--name=second", "--link=first:foo", "--link=third:bar", "busybox", "top")
+	cli.WaitRun(c, "second")
 
 	// ping to first and its alias foo must succeed
 	_, _, err := dockerCmdWithError("exec", "second", "ping", "-c", "1", "first")
@@ -243,8 +236,8 @@ func (s *DockerCLIRunSuite) TestUserDefinedNetworkLinks(c *testing.T) {
 	assert.ErrorContains(c, err, "")
 
 	// start third container now
-	dockerCmd(c, "run", "-d", "--net=udlinkNet", "--name=third", "busybox", "top")
-	assert.Assert(c, waitRun("third") == nil)
+	cli.DockerCmd(c, "run", "-d", "--net=udlinkNet", "--name=third", "busybox", "top")
+	cli.WaitRun(c, "third")
 
 	// ping to third and its alias must succeed now
 	_, _, err = dockerCmdWithError("exec", "second", "ping", "-c", "1", "third")
@@ -255,14 +248,13 @@ func (s *DockerCLIRunSuite) TestUserDefinedNetworkLinks(c *testing.T) {
 
 func (s *DockerCLIRunSuite) TestUserDefinedNetworkLinksWithRestart(c *testing.T) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
-	dockerCmd(c, "network", "create", "-d", "bridge", "udlinkNet")
+	cli.DockerCmd(c, "network", "create", "-d", "bridge", "udlinkNet")
 
-	dockerCmd(c, "run", "-d", "--net=udlinkNet", "--name=first", "busybox", "top")
-	assert.Assert(c, waitRun("first") == nil)
+	cli.DockerCmd(c, "run", "-d", "--net=udlinkNet", "--name=first", "busybox", "top")
+	cli.WaitRun(c, "first")
 
-	dockerCmd(c, "run", "-d", "--net=udlinkNet", "--name=second", "--link=first:foo",
-		"busybox", "top")
-	assert.Assert(c, waitRun("second") == nil)
+	cli.DockerCmd(c, "run", "-d", "--net=udlinkNet", "--name=second", "--link=first:foo", "busybox", "top")
+	cli.WaitRun(c, "second")
 
 	// ping to first and its alias foo must succeed
 	_, _, err := dockerCmdWithError("exec", "second", "ping", "-c", "1", "first")
@@ -271,8 +263,8 @@ func (s *DockerCLIRunSuite) TestUserDefinedNetworkLinksWithRestart(c *testing.T)
 	assert.NilError(c, err)
 
 	// Restart first container
-	dockerCmd(c, "restart", "first")
-	assert.Assert(c, waitRun("first") == nil)
+	cli.DockerCmd(c, "restart", "first")
+	cli.WaitRun(c, "first")
 
 	// ping to first and its alias foo must still succeed
 	_, _, err = dockerCmdWithError("exec", "second", "ping", "-c", "1", "first")
@@ -281,8 +273,8 @@ func (s *DockerCLIRunSuite) TestUserDefinedNetworkLinksWithRestart(c *testing.T)
 	assert.NilError(c, err)
 
 	// Restart second container
-	dockerCmd(c, "restart", "second")
-	assert.Assert(c, waitRun("second") == nil)
+	cli.DockerCmd(c, "restart", "second")
+	cli.WaitRun(c, "second")
 
 	// ping to first and its alias foo must still succeed
 	_, _, err = dockerCmdWithError("exec", "second", "ping", "-c", "1", "first")
@@ -295,8 +287,8 @@ func (s *DockerCLIRunSuite) TestRunWithNetAliasOnDefaultNetworks(c *testing.T) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
 
 	defaults := []string{"bridge", "host", "none"}
-	for _, net := range defaults {
-		out, _, err := dockerCmdWithError("run", "-d", "--net", net, "--net-alias", "alias_"+net, "busybox", "top")
+	for _, nw := range defaults {
+		out, _, err := dockerCmdWithError("run", "-d", "--net", nw, "--net-alias", "alias_"+nw, "busybox", "top")
 		assert.ErrorContains(c, err, "")
 		assert.Assert(c, strings.Contains(out, runconfig.ErrUnsupportedNetworkAndAlias.Error()))
 	}
@@ -304,17 +296,17 @@ func (s *DockerCLIRunSuite) TestRunWithNetAliasOnDefaultNetworks(c *testing.T) {
 
 func (s *DockerCLIRunSuite) TestUserDefinedNetworkAlias(c *testing.T) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
-	dockerCmd(c, "network", "create", "-d", "bridge", "net1")
+	cli.DockerCmd(c, "network", "create", "-d", "bridge", "net1")
 
-	cid1, _ := dockerCmd(c, "run", "-d", "--net=net1", "--name=first", "--net-alias=foo1", "--net-alias=foo2", "busybox:glibc", "top")
-	assert.Assert(c, waitRun("first") == nil)
+	cid1 := cli.DockerCmd(c, "run", "-d", "--net=net1", "--name=first", "--net-alias=foo1", "--net-alias=foo2", "busybox:glibc", "top").Stdout()
+	cli.WaitRun(c, "first")
 
 	// Check if default short-id alias is added automatically
 	id := strings.TrimSpace(cid1)
 	aliases := inspectField(c, id, "NetworkSettings.Networks.net1.Aliases")
 	assert.Assert(c, strings.Contains(aliases, stringid.TruncateID(id)))
-	cid2, _ := dockerCmd(c, "run", "-d", "--net=net1", "--name=second", "busybox:glibc", "top")
-	assert.Assert(c, waitRun("second") == nil)
+	cid2 := cli.DockerCmd(c, "run", "-d", "--net=net1", "--name=second", "busybox:glibc", "top").Stdout()
+	cli.WaitRun(c, "second")
 
 	// Check if default short-id alias is added automatically
 	id = strings.TrimSpace(cid2)
@@ -332,8 +324,8 @@ func (s *DockerCLIRunSuite) TestUserDefinedNetworkAlias(c *testing.T) {
 	assert.NilError(c, err)
 
 	// Restart first container
-	dockerCmd(c, "restart", "first")
-	assert.Assert(c, waitRun("first") == nil)
+	cli.DockerCmd(c, "restart", "first")
+	cli.WaitRun(c, "first")
 
 	// ping to first and its network-scoped aliases must succeed
 	_, _, err = dockerCmdWithError("exec", "second", "ping", "-c", "1", "first")
@@ -356,29 +348,26 @@ func (s *DockerCLIRunSuite) TestRunWithDaemonFlags(c *testing.T) {
 
 // Regression test for #4979
 func (s *DockerCLIRunSuite) TestRunWithVolumesFromExited(c *testing.T) {
-	var (
-		out      string
-		exitCode int
-	)
+	var result *icmd.Result
 
 	// Create a file in a volume
 	if testEnv.DaemonInfo.OSType == "windows" {
-		out, exitCode = dockerCmd(c, "run", "--name", "test-data", "--volume", `c:\some\dir`, testEnv.PlatformDefaults.BaseImage, "cmd", "/c", `echo hello > c:\some\dir\file`)
+		result = cli.DockerCmd(c, "run", "--name", "test-data", "--volume", `c:\some\dir`, testEnv.PlatformDefaults.BaseImage, "cmd", "/c", `echo hello > c:\some\dir\file`)
 	} else {
-		out, exitCode = dockerCmd(c, "run", "--name", "test-data", "--volume", "/some/dir", "busybox", "touch", "/some/dir/file")
+		result = cli.DockerCmd(c, "run", "--name", "test-data", "--volume", "/some/dir", "busybox", "touch", "/some/dir/file")
 	}
-	if exitCode != 0 {
-		c.Fatal("1", out, exitCode)
+	if result.ExitCode != 0 {
+		c.Fatal("1", result.Combined(), result.ExitCode)
 	}
 
 	// Read the file from another container using --volumes-from to access the volume in the second container
 	if testEnv.DaemonInfo.OSType == "windows" {
-		out, exitCode = dockerCmd(c, "run", "--volumes-from", "test-data", testEnv.PlatformDefaults.BaseImage, "cmd", "/c", `type c:\some\dir\file`)
+		result = cli.DockerCmd(c, "run", "--volumes-from", "test-data", testEnv.PlatformDefaults.BaseImage, "cmd", "/c", `type c:\some\dir\file`)
 	} else {
-		out, exitCode = dockerCmd(c, "run", "--volumes-from", "test-data", "busybox", "cat", "/some/dir/file")
+		result = cli.DockerCmd(c, "run", "--volumes-from", "test-data", "busybox", "cat", "/some/dir/file")
 	}
-	if exitCode != 0 {
-		c.Fatal("2", out, exitCode)
+	if result.ExitCode != 0 {
+		c.Fatal("2", result.Combined(), result.ExitCode)
 	}
 }
 
@@ -424,7 +413,7 @@ func (s *DockerCLIRunSuite) TestRunCreateVolumesInSymlinkDir(c *testing.T) {
 		cmd = "true"
 	}
 	buildImageSuccessfully(c, name, build.WithDockerfile(dockerFile))
-	dockerCmd(c, "run", "-v", containerPath, name, cmd)
+	cli.DockerCmd(c, "run", "-v", containerPath, name, cmd)
 }
 
 // Volume path is a symlink in the container
@@ -449,7 +438,7 @@ func (s *DockerCLIRunSuite) TestRunCreateVolumesInSymlinkDir2(c *testing.T) {
 		cmd = "true"
 	}
 	buildImageSuccessfully(c, name, build.WithDockerfile(dockerFile))
-	dockerCmd(c, "run", "-v", containerPath, name, cmd)
+	cli.DockerCmd(c, "run", "-v", containerPath, name, cmd)
 }
 
 func (s *DockerCLIRunSuite) TestRunVolumesMountedAsReadonly(c *testing.T) {
@@ -471,7 +460,7 @@ func (s *DockerCLIRunSuite) TestRunVolumesFromInReadonlyModeFails(c *testing.T) 
 		volumeDir = "/test"
 		fileInVol = `/test/file`
 	}
-	dockerCmd(c, "run", "--name", "parent", "-v", volumeDir, "busybox", "true")
+	cli.DockerCmd(c, "run", "--name", "parent", "-v", volumeDir, "busybox", "true")
 
 	if _, code, err := dockerCmdWithError("run", "--volumes-from", "parent:ro", "busybox", "touch", fileInVol); err == nil || code == 0 {
 		c.Fatalf("run should fail because volume is ro: exit code %d", code)
@@ -492,14 +481,14 @@ func (s *DockerCLIRunSuite) TestRunVolumesFromInReadWriteMode(c *testing.T) {
 		fileInVol = "/test/file"
 	}
 
-	dockerCmd(c, "run", "--name", "parent", "-v", volumeDir, "busybox", "true")
-	dockerCmd(c, "run", "--volumes-from", "parent:rw", "busybox", "touch", fileInVol)
+	cli.DockerCmd(c, "run", "--name", "parent", "-v", volumeDir, "busybox", "true")
+	cli.DockerCmd(c, "run", "--volumes-from", "parent:rw", "busybox", "touch", fileInVol)
 
 	if out, _, err := dockerCmdWithError("run", "--volumes-from", "parent:bar", "busybox", "touch", fileInVol); err == nil || !strings.Contains(out, `invalid mode: bar`) {
 		c.Fatalf("running --volumes-from parent:bar should have failed with invalid mode: %q", out)
 	}
 
-	dockerCmd(c, "run", "--volumes-from", "parent", "busybox", "touch", fileInVol)
+	cli.DockerCmd(c, "run", "--volumes-from", "parent", "busybox", "touch", fileInVol)
 }
 
 func (s *DockerCLIRunSuite) TestVolumesFromGetsProperMode(c *testing.T) {
@@ -511,14 +500,14 @@ func (s *DockerCLIRunSuite) TestVolumesFromGetsProperMode(c *testing.T) {
 	}
 	defer os.RemoveAll(hostpath)
 
-	dockerCmd(c, "run", "--name", "parent", "-v", hostpath+":"+prefix+slash+"test:ro", "busybox", "true")
+	cli.DockerCmd(c, "run", "--name", "parent", "-v", hostpath+":"+prefix+slash+"test:ro", "busybox", "true")
 
 	// Expect this "rw" mode to be be ignored since the inherited volume is "ro"
 	if _, _, err := dockerCmdWithError("run", "--volumes-from", "parent:rw", "busybox", "touch", prefix+slash+"test"+slash+"file"); err == nil {
 		c.Fatal("Expected volumes-from to inherit read-only volume even when passing in `rw`")
 	}
 
-	dockerCmd(c, "run", "--name", "parent2", "-v", hostpath+":"+prefix+slash+"test:ro", "busybox", "true")
+	cli.DockerCmd(c, "run", "--name", "parent2", "-v", hostpath+":"+prefix+slash+"test:ro", "busybox", "true")
 
 	// Expect this to be read-only since both are "ro"
 	if _, _, err := dockerCmdWithError("run", "--volumes-from", "parent2:ro", "busybox", "touch", prefix+slash+"test"+slash+"file"); err == nil {
@@ -570,11 +559,11 @@ func (s *DockerCLIRunSuite) TestRunNoDupVolumes(c *testing.T) {
 	}
 	// create failed should have create volume volumename1 or volumename2
 	// we should remove volumename2 or volumename2 successfully
-	out, _ := dockerCmd(c, "volume", "ls")
+	out := cli.DockerCmd(c, "volume", "ls").Stdout()
 	if strings.Contains(out, volumename1) {
-		dockerCmd(c, "volume", "rm", volumename1)
+		cli.DockerCmd(c, "volume", "rm", volumename1)
 	} else {
-		dockerCmd(c, "volume", "rm", volumename2)
+		cli.DockerCmd(c, "volume", "rm", volumename2)
 	}
 }
 
@@ -584,8 +573,8 @@ func (s *DockerCLIRunSuite) TestRunApplyVolumesFromBeforeVolumes(c *testing.T) {
 	if testEnv.DaemonInfo.OSType == "windows" {
 		prefix = `c:`
 	}
-	dockerCmd(c, "run", "--name", "parent", "-v", prefix+"/test", "busybox", "touch", prefix+"/test/foo")
-	dockerCmd(c, "run", "--volumes-from", "parent", "-v", prefix+"/test", "busybox", "cat", prefix+"/test/foo")
+	cli.DockerCmd(c, "run", "--name", "parent", "-v", prefix+"/test", "busybox", "touch", prefix+"/test/foo")
+	cli.DockerCmd(c, "run", "--volumes-from", "parent", "-v", prefix+"/test", "busybox", "cat", prefix+"/test/foo")
 }
 
 func (s *DockerCLIRunSuite) TestRunMultipleVolumesFrom(c *testing.T) {
@@ -593,9 +582,9 @@ func (s *DockerCLIRunSuite) TestRunMultipleVolumesFrom(c *testing.T) {
 	if testEnv.DaemonInfo.OSType == "windows" {
 		prefix = `c:`
 	}
-	dockerCmd(c, "run", "--name", "parent1", "-v", prefix+"/test", "busybox", "touch", prefix+"/test/foo")
-	dockerCmd(c, "run", "--name", "parent2", "-v", prefix+"/other", "busybox", "touch", prefix+"/other/bar")
-	dockerCmd(c, "run", "--volumes-from", "parent1", "--volumes-from", "parent2", "busybox", "sh", "-c", "cat /test/foo && cat /other/bar")
+	cli.DockerCmd(c, "run", "--name", "parent1", "-v", prefix+"/test", "busybox", "touch", prefix+"/test/foo")
+	cli.DockerCmd(c, "run", "--name", "parent2", "-v", prefix+"/other", "busybox", "touch", prefix+"/other/bar")
+	cli.DockerCmd(c, "run", "--volumes-from", "parent1", "--volumes-from", "parent2", "busybox", "sh", "-c", "cat /test/foo && cat /other/bar")
 }
 
 // this tests verifies the ID format for the container
@@ -623,7 +612,7 @@ func (s *DockerCLIRunSuite) TestRunCreateVolume(c *testing.T) {
 	if testEnv.DaemonInfo.OSType == "windows" {
 		prefix = `c:`
 	}
-	dockerCmd(c, "run", "-v", prefix+"/var/lib/data", "busybox", "true")
+	cli.DockerCmd(c, "run", "-v", prefix+"/var/lib/data", "busybox", "true")
 }
 
 // Test that creating a volume with a symlink in its path works correctly. Test for #5152.
@@ -726,7 +715,7 @@ func (s *DockerCLIRunSuite) TestRunUserDefaults(c *testing.T) {
 	if testEnv.DaemonInfo.OSType == "windows" {
 		expected = "uid=0(root) gid=0(root) groups=0(root)"
 	}
-	out, _ := dockerCmd(c, "run", "busybox", "id")
+	out := cli.DockerCmd(c, "run", "busybox", "id").Stdout()
 	if !strings.Contains(out, expected) {
 		c.Fatalf("expected '%s' got %s", expected, out)
 	}
@@ -736,7 +725,7 @@ func (s *DockerCLIRunSuite) TestRunUserByName(c *testing.T) {
 	// TODO Windows: This test cannot run on a Windows daemon as Windows does
 	// not support the use of -u
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-u", "root", "busybox", "id")
+	out := cli.DockerCmd(c, "run", "-u", "root", "busybox", "id").Stdout()
 	if !strings.Contains(out, "uid=0(root) gid=0(root)") {
 		c.Fatalf("expected root user got %s", out)
 	}
@@ -746,7 +735,7 @@ func (s *DockerCLIRunSuite) TestRunUserByID(c *testing.T) {
 	// TODO Windows: This test cannot run on a Windows daemon as Windows does
 	// not support the use of -u
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-u", "1", "busybox", "id")
+	out := cli.DockerCmd(c, "run", "-u", "1", "busybox", "id").Stdout()
 	if !strings.Contains(out, "uid=1(daemon) gid=1(daemon)") {
 		c.Fatalf("expected daemon user got %s", out)
 	}
@@ -931,9 +920,9 @@ func (s *DockerCLIRunSuite) TestRunEnvironmentOverride(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunContainerNetwork(c *testing.T) {
 	if testEnv.DaemonInfo.OSType == "windows" {
 		// Windows busybox does not have ping. Use built in ping instead.
-		dockerCmd(c, "run", testEnv.PlatformDefaults.BaseImage, "ping", "-n", "1", "127.0.0.1")
+		cli.DockerCmd(c, "run", testEnv.PlatformDefaults.BaseImage, "ping", "-n", "1", "127.0.0.1")
 	} else {
-		dockerCmd(c, "run", "busybox", "ping", "-c", "1", "127.0.0.1")
+		cli.DockerCmd(c, "run", "busybox", "ping", "-c", "1", "127.0.0.1")
 	}
 }
 
@@ -941,7 +930,7 @@ func (s *DockerCLIRunSuite) TestRunNetHostNotAllowedWithLinks(c *testing.T) {
 	// TODO Windows: This is Linux specific as --link is not supported and
 	// this will be deprecated in favor of container networking model.
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
-	dockerCmd(c, "run", "--name", "linked", "busybox", "true")
+	cli.DockerCmd(c, "run", "--name", "linked", "busybox", "true")
 
 	_, _, err := dockerCmdWithError("run", "--net=host", "--link", "linked:linked", "busybox", "true")
 	if err == nil {
@@ -957,7 +946,7 @@ func (s *DockerCLIRunSuite) TestRunNetHostNotAllowedWithLinks(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunFullHostnameSet(c *testing.T) {
 	// TODO Windows: -h is not yet functional.
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-h", "foo.bar.baz", "busybox", "hostname")
+	out := cli.DockerCmd(c, "run", "-h", "foo.bar.baz", "busybox", "hostname").Combined()
 	if actual := strings.Trim(out, "\r\n"); actual != "foo.bar.baz" {
 		c.Fatalf("expected hostname 'foo.bar.baz', received %s", actual)
 	}
@@ -967,7 +956,7 @@ func (s *DockerCLIRunSuite) TestRunPrivilegedCanMknod(c *testing.T) {
 	// Not applicable for Windows as Windows daemon does not support
 	// the concept of --privileged, and mknod is a Unix concept.
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
-	out, _ := dockerCmd(c, "run", "--privileged", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok")
+	out := cli.DockerCmd(c, "run", "--privileged", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok").Combined()
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
 		c.Fatalf("expected output ok received %s", actual)
 	}
@@ -977,7 +966,7 @@ func (s *DockerCLIRunSuite) TestRunUnprivilegedCanMknod(c *testing.T) {
 	// Not applicable for Windows as Windows daemon does not support
 	// the concept of --privileged, and mknod is a Unix concept.
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
-	out, _ := dockerCmd(c, "run", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok")
+	out := cli.DockerCmd(c, "run", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok").Combined()
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
 		c.Fatalf("expected output ok received %s", actual)
 	}
@@ -1033,7 +1022,7 @@ func (s *DockerCLIRunSuite) TestRunCapDropALLCannotMknod(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunCapDropALLAddMknodCanMknod(c *testing.T) {
 	// Not applicable for Windows as there is no concept of --cap-drop or mknod
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
-	out, _ := dockerCmd(c, "run", "--cap-drop=ALL", "--cap-add=MKNOD", "--cap-add=SETGID", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok")
+	out := cli.DockerCmd(c, "run", "--cap-drop=ALL", "--cap-add=MKNOD", "--cap-add=SETGID", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok").Combined()
 
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
 		c.Fatalf("expected output ok received %s", actual)
@@ -1052,7 +1041,7 @@ func (s *DockerCLIRunSuite) TestRunCapAddInvalid(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunCapAddCanDownInterface(c *testing.T) {
 	// Not applicable for Windows as there is no concept of --cap-add
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "--cap-add=NET_ADMIN", "busybox", "sh", "-c", "ip link set eth0 down && echo ok")
+	out := cli.DockerCmd(c, "run", "--cap-add=NET_ADMIN", "busybox", "sh", "-c", "ip link set eth0 down && echo ok").Combined()
 
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
 		c.Fatalf("expected output ok received %s", actual)
@@ -1062,7 +1051,7 @@ func (s *DockerCLIRunSuite) TestRunCapAddCanDownInterface(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunCapAddALLCanDownInterface(c *testing.T) {
 	// Not applicable for Windows as there is no concept of --cap-add
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "--cap-add=ALL", "busybox", "sh", "-c", "ip link set eth0 down && echo ok")
+	out := cli.DockerCmd(c, "run", "--cap-add=ALL", "busybox", "sh", "-c", "ip link set eth0 down && echo ok").Combined()
 
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
 		c.Fatalf("expected output ok received %s", actual)
@@ -1084,7 +1073,7 @@ func (s *DockerCLIRunSuite) TestRunCapAddALLDropNetAdminCanDownInterface(c *test
 func (s *DockerCLIRunSuite) TestRunGroupAdd(c *testing.T) {
 	// Not applicable for Windows as there is no concept of --group-add
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "--group-add=audio", "--group-add=staff", "--group-add=777", "busybox", "sh", "-c", "id")
+	out := cli.DockerCmd(c, "run", "--group-add=audio", "--group-add=staff", "--group-add=777", "busybox", "sh", "-c", "id").Combined()
 
 	groupsList := "uid=0(root) gid=0(root) groups=0(root),10(wheel),29(audio),50(staff),777"
 	if actual := strings.Trim(out, "\r\n"); actual != groupsList {
@@ -1095,7 +1084,7 @@ func (s *DockerCLIRunSuite) TestRunGroupAdd(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunPrivilegedCanMount(c *testing.T) {
 	// Not applicable for Windows as there is no concept of --privileged
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
-	out, _ := dockerCmd(c, "run", "--privileged", "busybox", "sh", "-c", "mount -t tmpfs none /tmp && echo ok")
+	out := cli.DockerCmd(c, "run", "--privileged", "busybox", "sh", "-c", "mount -t tmpfs none /tmp && echo ok").Combined()
 
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
 		c.Fatalf("expected output ok received %s", actual)
@@ -1142,7 +1131,7 @@ func (s *DockerCLIRunSuite) TestRunProcNotWritableInNonPrivilegedContainers(c *t
 func (s *DockerCLIRunSuite) TestRunProcWritableInPrivilegedContainers(c *testing.T) {
 	// Not applicable for Windows as there is no concept of --privileged
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
-	if _, code := dockerCmd(c, "run", "--privileged", "busybox", "sh", "-c", "touch /proc/sysrq-trigger"); code != 0 {
+	if result := cli.DockerCmd(c, "run", "--privileged", "busybox", "sh", "-c", "touch /proc/sysrq-trigger"); result.ExitCode != 0 {
 		c.Fatalf("proc should be writable in privileged container")
 	}
 }
@@ -1151,7 +1140,7 @@ func (s *DockerCLIRunSuite) TestRunDeviceNumbers(c *testing.T) {
 	// Not applicable on Windows as /dev/ is a Unix specific concept
 	// TODO: NotUserNamespace could be removed here if "root" "root" is replaced w user
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
-	out, _ := dockerCmd(c, "run", "busybox", "sh", "-c", "ls -l /dev/null")
+	out := cli.DockerCmd(c, "run", "busybox", "sh", "-c", "ls -l /dev/null").Combined()
 	deviceLineFields := strings.Fields(out)
 	deviceLineFields[6] = ""
 	deviceLineFields[7] = ""
@@ -1166,7 +1155,7 @@ func (s *DockerCLIRunSuite) TestRunDeviceNumbers(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunThatCharacterDevicesActLikeCharacterDevices(c *testing.T) {
 	// Not applicable on Windows as /dev/ is a Unix specific concept
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "busybox", "sh", "-c", "dd if=/dev/zero of=/zero bs=1k count=5 2> /dev/null ; du -h /zero")
+	out := cli.DockerCmd(c, "run", "busybox", "sh", "-c", "dd if=/dev/zero of=/zero bs=1k count=5 2> /dev/null ; du -h /zero").Combined()
 	if actual := strings.Trim(out, "\r\n"); actual[0] == '0' {
 		c.Fatalf("expected a new file called /zero to be create that is greater than 0 bytes long, but du says: %s", actual)
 	}
@@ -1175,13 +1164,13 @@ func (s *DockerCLIRunSuite) TestRunThatCharacterDevicesActLikeCharacterDevices(c
 func (s *DockerCLIRunSuite) TestRunUnprivilegedWithChroot(c *testing.T) {
 	// Not applicable on Windows as it does not support chroot
 	testRequires(c, DaemonIsLinux)
-	dockerCmd(c, "run", "busybox", "chroot", "/", "true")
+	cli.DockerCmd(c, "run", "busybox", "chroot", "/", "true")
 }
 
 func (s *DockerCLIRunSuite) TestRunAddingOptionalDevices(c *testing.T) {
 	// Not applicable on Windows as Windows does not support --device
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
-	out, _ := dockerCmd(c, "run", "--device", "/dev/zero:/dev/nulo", "busybox", "sh", "-c", "ls /dev/nulo")
+	out := cli.DockerCmd(c, "run", "--device", "/dev/zero:/dev/nulo", "busybox", "sh", "-c", "ls /dev/nulo").Combined()
 	if actual := strings.Trim(out, "\r\n"); actual != "/dev/nulo" {
 		c.Fatalf("expected output /dev/nulo, received %s", actual)
 	}
@@ -1190,7 +1179,7 @@ func (s *DockerCLIRunSuite) TestRunAddingOptionalDevices(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunAddingOptionalDevicesNoSrc(c *testing.T) {
 	// Not applicable on Windows as Windows does not support --device
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
-	out, _ := dockerCmd(c, "run", "--device", "/dev/zero:rw", "busybox", "sh", "-c", "ls /dev/zero")
+	out := cli.DockerCmd(c, "run", "--device", "/dev/zero:rw", "busybox", "sh", "-c", "ls /dev/zero").Combined()
 	if actual := strings.Trim(out, "\r\n"); actual != "/dev/zero" {
 		c.Fatalf("expected output /dev/zero, received %s", actual)
 	}
@@ -1209,13 +1198,13 @@ func (s *DockerCLIRunSuite) TestRunModeHostname(c *testing.T) {
 	// Not applicable on Windows as Windows does not support -h
 	testRequires(c, testEnv.IsLocalDaemon, DaemonIsLinux, NotUserNamespace)
 
-	out, _ := dockerCmd(c, "run", "-h=testhostname", "busybox", "cat", "/etc/hostname")
+	out := cli.DockerCmd(c, "run", "-h=testhostname", "busybox", "cat", "/etc/hostname").Combined()
 
 	if actual := strings.Trim(out, "\r\n"); actual != "testhostname" {
 		c.Fatalf("expected 'testhostname', but says: %q", actual)
 	}
 
-	out, _ = dockerCmd(c, "run", "--net=host", "busybox", "cat", "/etc/hostname")
+	out = cli.DockerCmd(c, "run", "--net=host", "busybox", "cat", "/etc/hostname").Combined()
 
 	hostname, err := os.Hostname()
 	if err != nil {
@@ -1227,7 +1216,7 @@ func (s *DockerCLIRunSuite) TestRunModeHostname(c *testing.T) {
 }
 
 func (s *DockerCLIRunSuite) TestRunRootWorkdir(c *testing.T) {
-	out, _ := dockerCmd(c, "run", "--workdir", "/", "busybox", "pwd")
+	out := cli.DockerCmd(c, "run", "--workdir", "/", "busybox", "pwd").Combined()
 	expected := "/\n"
 	if testEnv.DaemonInfo.OSType == "windows" {
 		expected = "C:" + expected
@@ -1240,9 +1229,9 @@ func (s *DockerCLIRunSuite) TestRunRootWorkdir(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunAllowBindMountingRoot(c *testing.T) {
 	if testEnv.DaemonInfo.OSType == "windows" {
 		// Windows busybox will fail with Permission Denied on items such as pagefile.sys
-		dockerCmd(c, "run", "-v", `c:\:c:\host`, testEnv.PlatformDefaults.BaseImage, "cmd", "-c", "dir", `c:\host`)
+		cli.DockerCmd(c, "run", "-v", `c:\:c:\host`, testEnv.PlatformDefaults.BaseImage, "cmd", "-c", "dir", `c:\host`)
 	} else {
-		dockerCmd(c, "run", "-v", "/:/host", "busybox", "ls", "/host")
+		cli.DockerCmd(c, "run", "-v", "/:/host", "busybox", "ls", "/host")
 	}
 }
 
@@ -1284,7 +1273,7 @@ func (s *DockerCLIRunSuite) TestRunDNSDefaultOptions(c *testing.T) {
 		c.Fatal(err)
 	}
 
-	actual, _ := dockerCmd(c, "run", "busybox", "cat", "/etc/resolv.conf")
+	actual := cli.DockerCmd(c, "run", "busybox", "cat", "/etc/resolv.conf").Combined()
 	// check that the actual defaults are appended to the commented out
 	// localhost resolver (which should be preserved)
 	// NOTE: if we ever change the defaults from google dns, this will break
@@ -1340,8 +1329,7 @@ func (s *DockerCLIRunSuite) TestRunDNSOptionsBasedOnHostResolvConf(c *testing.T)
 	hostNameservers := resolvconf.GetNameservers(origResolvConf, resolvconf.IP)
 	hostSearch := resolvconf.GetSearchDomains(origResolvConf)
 
-	var out string
-	out, _ = dockerCmd(c, "run", "--dns=127.0.0.1", "busybox", "cat", "/etc/resolv.conf")
+	out := cli.DockerCmd(c, "run", "--dns=127.0.0.1", "busybox", "cat", "/etc/resolv.conf").Combined()
 
 	if actualNameservers := resolvconf.GetNameservers([]byte(out), resolvconf.IP); actualNameservers[0] != "127.0.0.1" {
 		c.Fatalf("expected '127.0.0.1', but says: %q", actualNameservers[0])
@@ -1357,7 +1345,7 @@ func (s *DockerCLIRunSuite) TestRunDNSOptionsBasedOnHostResolvConf(c *testing.T)
 		}
 	}
 
-	out, _ = dockerCmd(c, "run", "--dns-search=mydomain", "busybox", "cat", "/etc/resolv.conf")
+	out = cli.DockerCmd(c, "run", "--dns-search=mydomain", "busybox", "cat", "/etc/resolv.conf").Combined()
 
 	actualNameservers := resolvconf.GetNameservers([]byte(out), resolvconf.IP)
 	if len(actualNameservers) != len(hostNameservers) {
@@ -1392,7 +1380,7 @@ func (s *DockerCLIRunSuite) TestRunDNSOptionsBasedOnHostResolvConf(c *testing.T)
 
 	hostSearch = resolvconf.GetSearchDomains(resolvConf)
 
-	out, _ = dockerCmd(c, "run", "busybox", "cat", "/etc/resolv.conf")
+	out = cli.DockerCmd(c, "run", "busybox", "cat", "/etc/resolv.conf").Combined()
 	if actualNameservers = resolvconf.GetNameservers([]byte(out), resolvconf.IP); actualNameservers[0] != "12.34.56.78" || len(actualNameservers) != 1 {
 		c.Fatalf("expected '12.34.56.78', but has: %v", actualNameservers)
 	}
@@ -1414,7 +1402,7 @@ func (s *DockerCLIRunSuite) TestRunNonRootUserResolvName(c *testing.T) {
 	// Not applicable on Windows as Windows does not support --user
 	testRequires(c, testEnv.IsLocalDaemon, Network, DaemonIsLinux)
 
-	dockerCmd(c, "run", "--name=testperm", "--user=nobody", "busybox", "nslookup", "example.com")
+	cli.DockerCmd(c, "run", "--name=testperm", "--user=nobody", "busybox", "nslookup", "example.com")
 
 	cID := getIDByName(c, "testperm")
 
@@ -1465,7 +1453,7 @@ func (s *DockerCLIRunSuite) TestRunResolvconfUpdate(c *testing.T) {
 	}()
 
 	// 1. test that a restarting container gets an updated resolv.conf
-	dockerCmd(c, "run", "--name=first", "busybox", "true")
+	cli.DockerCmd(c, "run", "--name=first", "busybox", "true")
 	containerID1 := getIDByName(c, "first")
 
 	// replace resolv.conf with our temporary copy
@@ -1474,7 +1462,7 @@ func (s *DockerCLIRunSuite) TestRunResolvconfUpdate(c *testing.T) {
 	}
 
 	// start the container again to pickup changes
-	dockerCmd(c, "start", "first")
+	cli.DockerCmd(c, "start", "first")
 
 	// check for update in container
 	containerResolv := readContainerFile(c, containerID1, "resolv.conf")
@@ -1488,7 +1476,7 @@ func (s *DockerCLIRunSuite) TestRunResolvconfUpdate(c *testing.T) {
 								} */
 	// 2. test that a restarting container does not receive resolv.conf updates
 	//   if it modified the container copy of the starting point resolv.conf
-	dockerCmd(c, "run", "--name=second", "busybox", "sh", "-c", "echo 'search mylittlepony.com' >>/etc/resolv.conf")
+	cli.DockerCmd(c, "run", "--name=second", "busybox", "sh", "-c", "echo 'search mylittlepony.com' >>/etc/resolv.conf")
 	containerID2 := getIDByName(c, "second")
 
 	// make a change to resolv.conf (in this case replacing our tmp copy with orig copy)
@@ -1497,7 +1485,7 @@ func (s *DockerCLIRunSuite) TestRunResolvconfUpdate(c *testing.T) {
 	}
 
 	// start the container again
-	dockerCmd(c, "start", "second")
+	cli.DockerCmd(c, "start", "second")
 
 	// check for update in container
 	containerResolv = readContainerFile(c, containerID2, "resolv.conf")
@@ -1506,8 +1494,8 @@ func (s *DockerCLIRunSuite) TestRunResolvconfUpdate(c *testing.T) {
 	}
 
 	// 3. test that a running container's resolv.conf is not modified while running
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
-	runningContainerID := strings.TrimSpace(out)
+	runningContainerID := cli.DockerCmd(c, "run", "-d", "busybox", "top").Stdout()
+	runningContainerID = strings.TrimSpace(runningContainerID)
 
 	// replace resolv.conf
 	if err := os.WriteFile("/etc/resolv.conf", tmpResolvConf, 0o644); err != nil {
@@ -1522,7 +1510,7 @@ func (s *DockerCLIRunSuite) TestRunResolvconfUpdate(c *testing.T) {
 
 	// 4. test that a running container's resolv.conf is updated upon restart
 	//   (the above container is still running..)
-	dockerCmd(c, "restart", runningContainerID)
+	cli.DockerCmd(c, "restart", runningContainerID)
 
 	// check for update in container
 	containerResolv = readContainerFile(c, runningContainerID, "resolv.conf")
@@ -1539,7 +1527,7 @@ func (s *DockerCLIRunSuite) TestRunResolvconfUpdate(c *testing.T) {
 	}
 
 	// start the container again to pickup changes
-	dockerCmd(c, "start", "first")
+	cli.DockerCmd(c, "start", "first")
 
 	// our first exited container ID should have been updated, but with default DNS
 	// after the cleanup of resolv.conf found only a localhost nameserver:
@@ -1558,7 +1546,7 @@ func (s *DockerCLIRunSuite) TestRunResolvconfUpdate(c *testing.T) {
 	}
 
 	// Run the container so it picks up the old settings
-	dockerCmd(c, "run", "--name=third", "busybox", "true")
+	cli.DockerCmd(c, "run", "--name=third", "busybox", "true")
 	containerID3 := getIDByName(c, "third")
 
 	// Create a modified resolv.conf.aside and override resolv.conf with it
@@ -1572,7 +1560,7 @@ func (s *DockerCLIRunSuite) TestRunResolvconfUpdate(c *testing.T) {
 	}
 
 	// start the container again to pickup changes
-	dockerCmd(c, "start", "third")
+	cli.DockerCmd(c, "start", "third")
 
 	// check for update in container
 	containerResolv = readContainerFile(c, containerID3, "resolv.conf")
@@ -1586,7 +1574,7 @@ func (s *DockerCLIRunSuite) TestRunResolvconfUpdate(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunAddHost(c *testing.T) {
 	// Not applicable on Windows as it does not support --add-host
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "--add-host=extra:86.75.30.9", "busybox", "grep", "extra", "/etc/hosts")
+	out := cli.DockerCmd(c, "run", "--add-host=extra:86.75.30.9", "busybox", "grep", "extra", "/etc/hosts").Combined()
 
 	actual := strings.Trim(out, "\r\n")
 	if actual != "86.75.30.9\textra" {
@@ -1596,7 +1584,7 @@ func (s *DockerCLIRunSuite) TestRunAddHost(c *testing.T) {
 
 // Regression test for #6983
 func (s *DockerCLIRunSuite) TestRunAttachStdErrOnlyTTYMode(c *testing.T) {
-	_, exitCode := dockerCmd(c, "run", "-t", "-a", "stderr", "busybox", "true")
+	exitCode := cli.DockerCmd(c, "run", "-t", "-a", "stderr", "busybox", "true").ExitCode
 	if exitCode != 0 {
 		c.Fatalf("Container should have exited with error code 0")
 	}
@@ -1604,7 +1592,7 @@ func (s *DockerCLIRunSuite) TestRunAttachStdErrOnlyTTYMode(c *testing.T) {
 
 // Regression test for #6983
 func (s *DockerCLIRunSuite) TestRunAttachStdOutOnlyTTYMode(c *testing.T) {
-	_, exitCode := dockerCmd(c, "run", "-t", "-a", "stdout", "busybox", "true")
+	exitCode := cli.DockerCmd(c, "run", "-t", "-a", "stdout", "busybox", "true").ExitCode
 	if exitCode != 0 {
 		c.Fatalf("Container should have exited with error code 0")
 	}
@@ -1612,7 +1600,7 @@ func (s *DockerCLIRunSuite) TestRunAttachStdOutOnlyTTYMode(c *testing.T) {
 
 // Regression test for #6983
 func (s *DockerCLIRunSuite) TestRunAttachStdOutAndErrTTYMode(c *testing.T) {
-	_, exitCode := dockerCmd(c, "run", "-t", "-a", "stdout", "-a", "stderr", "busybox", "true")
+	exitCode := cli.DockerCmd(c, "run", "-t", "-a", "stdout", "-a", "stderr", "busybox", "true").ExitCode
 	if exitCode != 0 {
 		c.Fatalf("Container should have exited with error code 0")
 	}
@@ -1631,9 +1619,9 @@ func (s *DockerCLIRunSuite) TestRunAttachWithDetach(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunState(c *testing.T) {
 	// TODO Windows: This needs some rework as Windows busybox does not support top
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	id := cli.DockerCmd(c, "run", "-d", "busybox", "top").Stdout()
+	id = strings.TrimSpace(id)
 
-	id := strings.TrimSpace(out)
 	state := inspectField(c, id, "State.Running")
 	if state != "true" {
 		c.Fatal("Container state is 'not running'")
@@ -1643,7 +1631,7 @@ func (s *DockerCLIRunSuite) TestRunState(c *testing.T) {
 		c.Fatal("Container state Pid 0")
 	}
 
-	dockerCmd(c, "stop", id)
+	cli.DockerCmd(c, "stop", id)
 	state = inspectField(c, id, "State.Running")
 	if state != "false" {
 		c.Fatal("Container state is 'running'")
@@ -1653,7 +1641,7 @@ func (s *DockerCLIRunSuite) TestRunState(c *testing.T) {
 		c.Fatalf("Container state Pid %s, but expected %s", pid2, pid1)
 	}
 
-	dockerCmd(c, "start", id)
+	cli.DockerCmd(c, "start", id)
 	state = inspectField(c, id, "State.Running")
 	if state != "true" {
 		c.Fatal("Container state is 'not running'")
@@ -1675,7 +1663,7 @@ func (s *DockerCLIRunSuite) TestRunCopyVolumeUIDGID(c *testing.T) {
 		RUN mkdir -p /hello && touch /hello/test && chown dockerio.dockerio /hello`))
 
 	// Test that the uid and gid is copied from the image to the volume
-	out, _ := dockerCmd(c, "run", "--rm", "-v", "/hello", name, "sh", "-c", `ls -l / | grep hello | awk '{print $3":"$4}'`)
+	out := cli.DockerCmd(c, "run", "--rm", "-v", "/hello", name, "sh", "-c", `ls -l / | grep hello | awk '{print $3":"$4}'`).Combined()
 	out = strings.TrimSpace(out)
 	if out != "dockerio:dockerio" {
 		c.Fatalf("Wrong /hello ownership: %s, expected dockerio:dockerio", out)
@@ -1692,7 +1680,7 @@ func (s *DockerCLIRunSuite) TestRunCopyVolumeContent(c *testing.T) {
 		RUN mkdir -p /hello/local && echo hello > /hello/local/world`))
 
 	// Test that the content is copied from the image to the volume
-	out, _ := dockerCmd(c, "run", "--rm", "-v", "/hello", name, "find", "/hello")
+	out := cli.DockerCmd(c, "run", "--rm", "-v", "/hello", name, "find", "/hello").Combined()
 	if !(strings.Contains(out, "/hello/local/world") && strings.Contains(out, "/hello/local")) {
 		c.Fatal("Container failed to transfer content to volume")
 	}
@@ -1704,11 +1692,11 @@ func (s *DockerCLIRunSuite) TestRunCleanupCmdOnEntrypoint(c *testing.T) {
 		ENTRYPOINT ["echo"]
 		CMD ["testingpoint"]`))
 
-	out, exit := dockerCmd(c, "run", "--entrypoint", "whoami", name)
-	if exit != 0 {
-		c.Fatalf("expected exit code 0 received %d, out: %q", exit, out)
+	result := cli.DockerCmd(c, "run", "--entrypoint", "whoami", name)
+	out := strings.TrimSpace(result.Combined())
+	if result.ExitCode != 0 {
+		c.Fatalf("expected exit code 0 received %d, out: %q", result.ExitCode, out)
 	}
-	out = strings.TrimSpace(out)
 	expected := "root"
 	if testEnv.DaemonInfo.OSType == "windows" {
 		if strings.Contains(testEnv.PlatformDefaults.BaseImage, "servercore") {
@@ -1820,12 +1808,12 @@ func (s *DockerCLIRunSuite) TestRunWriteSpecialFilesAndNotCommit(c *testing.T) {
 
 func testRunWriteSpecialFilesAndNotCommit(c *testing.T, name, path string) {
 	command := fmt.Sprintf("echo test2267 >> %s && cat %s", path, path)
-	out, _ := dockerCmd(c, "run", "--name", name, "busybox", "sh", "-c", command)
+	out := cli.DockerCmd(c, "run", "--name", name, "busybox", "sh", "-c", command).Combined()
 	if !strings.Contains(out, "test2267") {
 		c.Fatalf("%s should contain 'test2267'", path)
 	}
 
-	out, _ = dockerCmd(c, "diff", name)
+	out = cli.DockerCmd(c, "diff", name).Combined()
 	if len(strings.Trim(out, "\r\n")) != 0 && !eqToBaseDiff(out, c) {
 		c.Fatal("diff should be empty")
 	}
@@ -1833,9 +1821,9 @@ func testRunWriteSpecialFilesAndNotCommit(c *testing.T, name, path string) {
 
 func eqToBaseDiff(out string, c *testing.T) bool {
 	name := "eqToBaseDiff" + testutil.GenerateRandomAlphaOnlyString(32)
-	dockerCmd(c, "run", "--name", name, "busybox", "echo", "hello")
+	cli.DockerCmd(c, "run", "--name", name, "busybox", "echo", "hello")
 	cID := getIDByName(c, name)
-	baseDiff, _ := dockerCmd(c, "diff", cID)
+	baseDiff := cli.DockerCmd(c, "diff", cID).Combined()
 	baseArr := strings.Split(baseDiff, "\n")
 	sort.Strings(baseArr)
 	outArr := strings.Split(out, "\n")
@@ -1873,11 +1861,10 @@ func (s *DockerCLIRunSuite) TestRunWithBadDevice(c *testing.T) {
 }
 
 func (s *DockerCLIRunSuite) TestRunEntrypoint(c *testing.T) {
-	name := "entrypoint"
+	const name = "entrypoint"
+	const expected = "foobar"
 
-	out, _ := dockerCmd(c, "run", "--name", name, "--entrypoint", "echo", "busybox", "-n", "foobar")
-	expected := "foobar"
-
+	out := cli.DockerCmd(c, "run", "--name", name, "--entrypoint", "echo", "busybox", "-n", "foobar").Combined()
 	if out != expected {
 		c.Fatalf("Output should be %q, actual out: %q", expected, out)
 	}
@@ -1900,16 +1887,16 @@ func (s *DockerCLIRunSuite) TestRunBindMounts(c *testing.T) {
 	writeFile(path.Join(tmpDir, "touch-me"), "", c)
 
 	// Test reading from a read-only bind mount
-	out, _ := dockerCmd(c, "run", "-v", fmt.Sprintf("%s:%s/tmpx:ro", tmpDir, prefix), "busybox", "ls", prefix+"/tmpx")
+	out := cli.DockerCmd(c, "run", "-v", fmt.Sprintf("%s:%s/tmpx:ro", tmpDir, prefix), "busybox", "ls", prefix+"/tmpx").Combined()
 	if !strings.Contains(out, "touch-me") {
 		c.Fatal("Container failed to read from bind mount")
 	}
 
 	// test writing to bind mount
 	if testEnv.DaemonInfo.OSType == "windows" {
-		dockerCmd(c, "run", "-v", fmt.Sprintf(`%s:c:\tmp:rw`, tmpDir), "busybox", "touch", "c:/tmp/holla")
+		cli.DockerCmd(c, "run", "-v", fmt.Sprintf(`%s:c:\tmp:rw`, tmpDir), "busybox", "touch", "c:/tmp/holla")
 	} else {
-		dockerCmd(c, "run", "-v", fmt.Sprintf("%s:/tmp:rw", tmpDir), "busybox", "touch", "/tmp/holla")
+		cli.DockerCmd(c, "run", "-v", fmt.Sprintf("%s:/tmp:rw", tmpDir), "busybox", "touch", "/tmp/holla")
 	}
 
 	readFile(path.Join(tmpDir, "holla"), c) // Will fail if the file doesn't exist
@@ -1923,7 +1910,7 @@ func (s *DockerCLIRunSuite) TestRunBindMounts(c *testing.T) {
 	// Windows does not (and likely never will) support mounting a single file
 	if testEnv.DaemonInfo.OSType != "windows" {
 		// test mount a file
-		dockerCmd(c, "run", "-v", fmt.Sprintf("%s/holla:/tmp/holla:rw", tmpDir), "busybox", "sh", "-c", "echo -n 'yotta' > /tmp/holla")
+		cli.DockerCmd(c, "run", "-v", fmt.Sprintf("%s/holla:/tmp/holla:rw", tmpDir), "busybox", "sh", "-c", "echo -n 'yotta' > /tmp/holla")
 		content := readFile(path.Join(tmpDir, "holla"), c) // Will fail if the file doesn't exist
 		expected := "yotta"
 		if content != expected {
@@ -1970,9 +1957,8 @@ func (s *DockerCLIRunSuite) TestRunCidFileCheckIDLength(c *testing.T) {
 	tmpCidFile := path.Join(tmpDir, "cid")
 	defer os.RemoveAll(tmpDir)
 
-	out, _ := dockerCmd(c, "run", "-d", "--cidfile", tmpCidFile, "busybox", "true")
-
-	id := strings.TrimSpace(out)
+	id := cli.DockerCmd(c, "run", "-d", "--cidfile", tmpCidFile, "busybox", "true").Stdout()
+	id = strings.TrimSpace(id)
 	buffer, err := os.ReadFile(tmpCidFile)
 	if err != nil {
 		c.Fatal(err)
@@ -1991,10 +1977,10 @@ func (s *DockerCLIRunSuite) TestRunSetMacAddress(c *testing.T) {
 	mac := "12:34:56:78:9a:bc"
 	var out string
 	if testEnv.DaemonInfo.OSType == "windows" {
-		out, _ = dockerCmd(c, "run", "-i", "--rm", fmt.Sprintf("--mac-address=%s", mac), "busybox", "sh", "-c", "ipconfig /all | grep 'Physical Address' | awk '{print $12}'")
+		out = cli.DockerCmd(c, "run", "-i", "--rm", fmt.Sprintf("--mac-address=%s", mac), "busybox", "sh", "-c", "ipconfig /all | grep 'Physical Address' | awk '{print $12}'").Combined()
 		mac = strings.ReplaceAll(strings.ToUpper(mac), ":", "-") // To Windows-style MACs
 	} else {
-		out, _ = dockerCmd(c, "run", "-i", "--rm", fmt.Sprintf("--mac-address=%s", mac), "busybox", "/bin/sh", "-c", "ip link show eth0 | tail -1 | awk '{print $2}'")
+		out = cli.DockerCmd(c, "run", "-i", "--rm", fmt.Sprintf("--mac-address=%s", mac), "busybox", "/bin/sh", "-c", "ip link show eth0 | tail -1 | awk '{print $2}'").Combined()
 	}
 
 	actualMac := strings.TrimSpace(out)
@@ -2006,8 +1992,8 @@ func (s *DockerCLIRunSuite) TestRunSetMacAddress(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunInspectMacAddress(c *testing.T) {
 	// TODO Windows. Network settings are not propagated back to inspect.
 	testRequires(c, DaemonIsLinux)
-	mac := "12:34:56:78:9a:bc"
-	out, _ := dockerCmd(c, "run", "-d", "--mac-address="+mac, "busybox", "top")
+	const mac = "12:34:56:78:9a:bc"
+	out := cli.DockerCmd(c, "run", "-d", "--mac-address="+mac, "busybox", "top").Combined()
 
 	id := strings.TrimSpace(out)
 	inspectedMac := inspectField(c, id, "NetworkSettings.Networks.bridge.MacAddress")
@@ -2048,7 +2034,7 @@ func (s *DockerCLIRunSuite) TestRunPortInUse(c *testing.T) {
 	testRequires(c, testEnv.IsLocalDaemon, DaemonIsLinux)
 
 	port := "1234"
-	dockerCmd(c, "run", "-d", "-p", port+":80", "busybox", "top")
+	cli.DockerCmd(c, "run", "-d", "-p", port+":80", "busybox", "top")
 
 	out, _, err := dockerCmdWithError("run", "-d", "-p", port+":80", "busybox", "top")
 	if err == nil {
@@ -2064,10 +2050,10 @@ func (s *DockerCLIRunSuite) TestRunAllocatePortInReservedRange(c *testing.T) {
 	// TODO Windows. -P is not yet supported
 	testRequires(c, DaemonIsLinux)
 	// allocate a dynamic port to get the most recent
-	out, _ := dockerCmd(c, "run", "-d", "-P", "-p", "80", "busybox", "top")
+	id := cli.DockerCmd(c, "run", "-d", "-P", "-p", "80", "busybox", "top").Stdout()
+	id = strings.TrimSpace(id)
 
-	id := strings.TrimSpace(out)
-	out, _ = dockerCmd(c, "inspect", "--format", `{{index .NetworkSettings.Ports "80/tcp" 0 "HostPort" }}`, id)
+	out := cli.DockerCmd(c, "inspect", "--format", `{{index .NetworkSettings.Ports "80/tcp" 0 "HostPort" }}`, id).Stdout()
 	out = strings.TrimSpace(out)
 	port, err := strconv.ParseInt(out, 10, 64)
 	if err != nil {
@@ -2076,7 +2062,7 @@ func (s *DockerCLIRunSuite) TestRunAllocatePortInReservedRange(c *testing.T) {
 
 	// allocate a static port and a dynamic port together, with static port
 	// takes the next recent port in dynamic port range.
-	dockerCmd(c, "run", "-d", "-P", "-p", "80", "-p", fmt.Sprintf("%d:8080", port+1), "busybox", "top")
+	cli.DockerCmd(c, "run", "-d", "-P", "-p", "80", "-p", fmt.Sprintf("%d:8080", port+1), "busybox", "top")
 }
 
 // Regression test for #7792
@@ -2115,7 +2101,7 @@ func (s *DockerCLIRunSuite) TestRunMountOrdering(c *testing.T) {
 		c.Fatal(err)
 	}
 
-	dockerCmd(c, "run",
+	cli.DockerCmd(c, "run",
 		"-v", fmt.Sprintf("%s:"+prefix+"/tmp", tmpDir),
 		"-v", fmt.Sprintf("%s:"+prefix+"/tmp/foo", fooDir),
 		"-v", fmt.Sprintf("%s:"+prefix+"/tmp/tmp2", tmpDir2),
@@ -2143,11 +2129,11 @@ func (s *DockerCLIRunSuite) TestRunReuseBindVolumeThatIsSymlink(c *testing.T) {
 	defer os.RemoveAll(linkPath)
 
 	// Create first container
-	dockerCmd(c, "run", "-v", fmt.Sprintf("%s:"+prefix+"/tmp/test", linkPath), "busybox", "ls", prefix+"/tmp/test")
+	cli.DockerCmd(c, "run", "-v", fmt.Sprintf("%s:"+prefix+"/tmp/test", linkPath), "busybox", "ls", prefix+"/tmp/test")
 
 	// Create second container with same symlinked path
 	// This will fail if the referenced issue is hit with a "Volume exists" error
-	dockerCmd(c, "run", "-v", fmt.Sprintf("%s:"+prefix+"/tmp/test", linkPath), "busybox", "ls", prefix+"/tmp/test")
+	cli.DockerCmd(c, "run", "-v", fmt.Sprintf("%s:"+prefix+"/tmp/test", linkPath), "busybox", "ls", prefix+"/tmp/test")
 }
 
 // GH#10604: Test an "/etc" volume doesn't overlay special bind mounts in container
@@ -2155,17 +2141,17 @@ func (s *DockerCLIRunSuite) TestRunCreateVolumeEtc(c *testing.T) {
 	// While Windows supports volumes, it does not support --add-host hence
 	// this test is not applicable on Windows.
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "--dns=127.0.0.1", "-v", "/etc", "busybox", "cat", "/etc/resolv.conf")
+	out := cli.DockerCmd(c, "run", "--dns=127.0.0.1", "-v", "/etc", "busybox", "cat", "/etc/resolv.conf").Stdout()
 	if !strings.Contains(out, "nameserver 127.0.0.1") {
 		c.Fatal("/etc volume mount hides /etc/resolv.conf")
 	}
 
-	out, _ = dockerCmd(c, "run", "-h=test123", "-v", "/etc", "busybox", "cat", "/etc/hostname")
+	out = cli.DockerCmd(c, "run", "-h=test123", "-v", "/etc", "busybox", "cat", "/etc/hostname").Stdout()
 	if !strings.Contains(out, "test123") {
 		c.Fatal("/etc volume mount hides /etc/hostname")
 	}
 
-	out, _ = dockerCmd(c, "run", "--add-host=test:192.168.0.1", "-v", "/etc", "busybox", "cat", "/etc/hosts")
+	out = cli.DockerCmd(c, "run", "--add-host=test:192.168.0.1", "-v", "/etc", "busybox", "cat", "/etc/hosts").Stdout()
 	out = strings.ReplaceAll(out, "\n", " ")
 	if !strings.Contains(out, "192.168.0.1\ttest") || !strings.Contains(out, "127.0.0.1\tlocalhost") {
 		c.Fatal("/etc volume mount hides /etc/hosts")
@@ -2180,7 +2166,7 @@ func (s *DockerCLIRunSuite) TestVolumesNoCopyData(c *testing.T) {
 	buildImageSuccessfully(c, "dataimage", build.WithDockerfile(`FROM busybox
 		RUN ["mkdir", "-p", "/foo"]
 		RUN ["touch", "/foo/bar"]`))
-	dockerCmd(c, "run", "--name", "test", "-v", prefix+slash+"foo", "busybox")
+	cli.DockerCmd(c, "run", "--name", "test", "-v", prefix+slash+"foo", "busybox")
 
 	if out, _, err := dockerCmdWithError("run", "--volumes-from", "test", "dataimage", "ls", "-lh", "/foo/bar"); err == nil || !strings.Contains(out, "No such file or directory") {
 		c.Fatalf("Data was copied on volumes-from but shouldn't be:\n%q", out)
@@ -2210,7 +2196,7 @@ func (s *DockerCLIRunSuite) TestRunVolumesCleanPaths(c *testing.T) {
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
 	buildImageSuccessfully(c, "run_volumes_clean_paths", build.WithDockerfile(`FROM busybox
 		VOLUME `+prefix+`/foo/`))
-	dockerCmd(c, "run", "-v", prefix+"/foo", "-v", prefix+"/bar/", "--name", "dark_helmet", "run_volumes_clean_paths")
+	cli.DockerCmd(c, "run", "-v", prefix+"/foo", "-v", prefix+"/bar/", "--name", "dark_helmet", "run_volumes_clean_paths")
 
 	out, err := inspectMountSourceField("dark_helmet", prefix+slash+"foo"+slash)
 	if err != errMountNotFound {
@@ -2268,9 +2254,9 @@ func (s *DockerCLIRunSuite) TestRunAllowPortRangeThroughExpose(c *testing.T) {
 	// TODO Windows: -P is not currently supported. Also network
 	// settings are not propagated back.
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-d", "--expose", "3000-3003", "-P", "busybox", "top")
+	id := cli.DockerCmd(c, "run", "-d", "--expose", "3000-3003", "-P", "busybox", "top").Stdout()
+	id = strings.TrimSpace(id)
 
-	id := strings.TrimSpace(out)
 	portstr := inspectFieldJSON(c, id, "NetworkSettings.Ports")
 	var ports nat.PortMap
 	if err := json.Unmarshal([]byte(portstr), &ports); err != nil {
@@ -2302,13 +2288,13 @@ func (s *DockerCLIRunSuite) TestRunModeIpcHost(c *testing.T) {
 		c.Fatal(err)
 	}
 
-	out, _ := dockerCmd(c, "run", "--ipc=host", "busybox", "readlink", "/proc/self/ns/ipc")
+	out := cli.DockerCmd(c, "run", "--ipc=host", "busybox", "readlink", "/proc/self/ns/ipc").Combined()
 	out = strings.Trim(out, "\n")
 	if hostIpc != out {
 		c.Fatalf("IPC different with --ipc=host %s != %s\n", hostIpc, out)
 	}
 
-	out, _ = dockerCmd(c, "run", "busybox", "readlink", "/proc/self/ns/ipc")
+	out = cli.DockerCmd(c, "run", "busybox", "readlink", "/proc/self/ns/ipc").Combined()
 	out = strings.Trim(out, "\n")
 	if hostIpc == out {
 		c.Fatalf("IPC should be different without --ipc=host %s == %s\n", hostIpc, out)
@@ -2328,9 +2314,9 @@ func (s *DockerCLIRunSuite) TestRunModeIpcContainerNotRunning(c *testing.T) {
 	// Not applicable on Windows as uses Unix-specific capabilities
 	testRequires(c, testEnv.IsLocalDaemon, DaemonIsLinux)
 
-	out, _ := dockerCmd(c, "create", "busybox")
+	id := cli.DockerCmd(c, "create", "busybox").Stdout()
+	id = strings.TrimSpace(id)
 
-	id := strings.TrimSpace(out)
 	out, _, err := dockerCmdWithError("run", fmt.Sprintf("--ipc=container:%s", id), "busybox")
 	if err == nil {
 		c.Fatalf("Run container with ipc mode container should fail with non running container: %s\n%s", out, err)
@@ -2341,9 +2327,9 @@ func (s *DockerCLIRunSuite) TestRunModePIDContainer(c *testing.T) {
 	// Not applicable on Windows as uses Unix-specific capabilities
 	testRequires(c, testEnv.IsLocalDaemon, DaemonIsLinux)
 
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", "top")
+	id := cli.DockerCmd(c, "run", "-d", "busybox", "sh", "-c", "top").Stdout()
+	id = strings.TrimSpace(id)
 
-	id := strings.TrimSpace(out)
 	state := inspectField(c, id, "State.Running")
 	if state != "true" {
 		c.Fatal("Container state is 'not running'")
@@ -2355,7 +2341,7 @@ func (s *DockerCLIRunSuite) TestRunModePIDContainer(c *testing.T) {
 		c.Fatal(err)
 	}
 
-	out, _ = dockerCmd(c, "run", fmt.Sprintf("--pid=container:%s", id), "busybox", "readlink", "/proc/self/ns/pid")
+	out := cli.DockerCmd(c, "run", fmt.Sprintf("--pid=container:%s", id), "busybox", "readlink", "/proc/self/ns/pid").Combined()
 	out = strings.Trim(out, "\n")
 	if parentContainerPid != out {
 		c.Fatalf("PID different with --pid=container:%s %s != %s\n", id, parentContainerPid, out)
@@ -2375,9 +2361,9 @@ func (s *DockerCLIRunSuite) TestRunModePIDContainerNotRunning(c *testing.T) {
 	// Not applicable on Windows as uses Unix-specific capabilities
 	testRequires(c, testEnv.IsLocalDaemon, DaemonIsLinux)
 
-	out, _ := dockerCmd(c, "create", "busybox")
+	id := cli.DockerCmd(c, "create", "busybox").Stdout()
+	id = strings.TrimSpace(id)
 
-	id := strings.TrimSpace(out)
 	out, _, err := dockerCmdWithError("run", fmt.Sprintf("--pid=container:%s", id), "busybox")
 	if err == nil {
 		c.Fatalf("Run container with pid mode container should fail with non running container: %s\n%s", out, err)
@@ -2388,7 +2374,7 @@ func (s *DockerCLIRunSuite) TestRunMountShmMqueueFromHost(c *testing.T) {
 	// Not applicable on Windows as uses Unix-specific capabilities
 	testRequires(c, testEnv.IsLocalDaemon, DaemonIsLinux, NotUserNamespace)
 
-	dockerCmd(c, "run", "-d", "--name", "shmfromhost", "-v", "/dev/shm:/dev/shm", "-v", "/dev/mqueue:/dev/mqueue", "busybox", "sh", "-c", "echo -n test > /dev/shm/test && touch /dev/mqueue/toto && top")
+	cli.DockerCmd(c, "run", "-d", "--name", "shmfromhost", "-v", "/dev/shm:/dev/shm", "-v", "/dev/mqueue:/dev/mqueue", "busybox", "sh", "-c", "echo -n test > /dev/shm/test && touch /dev/mqueue/toto && top")
 	defer os.Remove("/dev/mqueue/toto")
 	defer os.Remove("/dev/shm/test")
 	volPath, err := inspectMountSourceField("shmfromhost", "/dev/shm")
@@ -2397,7 +2383,7 @@ func (s *DockerCLIRunSuite) TestRunMountShmMqueueFromHost(c *testing.T) {
 		c.Fatalf("volumePath should have been /dev/shm, was %s", volPath)
 	}
 
-	out, _ := dockerCmd(c, "run", "--name", "ipchost", "--ipc", "host", "busybox", "cat", "/dev/shm/test")
+	out := cli.DockerCmd(c, "run", "--name", "ipchost", "--ipc", "host", "busybox", "cat", "/dev/shm/test").Combined()
 	if out != "test" {
 		c.Fatalf("Output of /dev/shm/test expected test but found: %s", out)
 	}
@@ -2412,9 +2398,9 @@ func (s *DockerCLIRunSuite) TestContainerNetworkMode(c *testing.T) {
 	// Not applicable on Windows as uses Unix-specific capabilities
 	testRequires(c, testEnv.IsLocalDaemon, DaemonIsLinux)
 
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
-	id := strings.TrimSpace(out)
-	assert.NilError(c, waitRun(id))
+	id := cli.DockerCmd(c, "run", "-d", "busybox", "top").Stdout()
+	id = strings.TrimSpace(id)
+	cli.WaitRun(c, id)
 	pid1 := inspectField(c, id, "State.Pid")
 
 	parentContainerNet, err := os.Readlink(fmt.Sprintf("/proc/%s/ns/net", pid1))
@@ -2422,7 +2408,7 @@ func (s *DockerCLIRunSuite) TestContainerNetworkMode(c *testing.T) {
 		c.Fatal(err)
 	}
 
-	out, _ = dockerCmd(c, "run", fmt.Sprintf("--net=container:%s", id), "busybox", "readlink", "/proc/self/ns/net")
+	out := cli.DockerCmd(c, "run", fmt.Sprintf("--net=container:%s", id), "busybox", "readlink", "/proc/self/ns/net").Combined()
 	out = strings.Trim(out, "\n")
 	if parentContainerNet != out {
 		c.Fatalf("NET different with --net=container:%s %s != %s\n", id, parentContainerNet, out)
@@ -2438,13 +2424,13 @@ func (s *DockerCLIRunSuite) TestRunModeUTSHost(c *testing.T) {
 		c.Fatal(err)
 	}
 
-	out, _ := dockerCmd(c, "run", "--uts=host", "busybox", "readlink", "/proc/self/ns/uts")
+	out := cli.DockerCmd(c, "run", "--uts=host", "busybox", "readlink", "/proc/self/ns/uts").Combined()
 	out = strings.Trim(out, "\n")
 	if hostUTS != out {
 		c.Fatalf("UTS different with --uts=host %s != %s\n", hostUTS, out)
 	}
 
-	out, _ = dockerCmd(c, "run", "busybox", "readlink", "/proc/self/ns/uts")
+	out = cli.DockerCmd(c, "run", "busybox", "readlink", "/proc/self/ns/uts").Combined()
 	out = strings.Trim(out, "\n")
 	if hostUTS == out {
 		c.Fatalf("UTS should be different without --uts=host %s == %s\n", hostUTS, out)
@@ -2475,11 +2461,10 @@ func (s *DockerCLIRunSuite) TestRunPortFromDockerRangeInUse(c *testing.T) {
 	// re-instated.
 	testRequires(c, DaemonIsLinux)
 	// first find allocator current position
-	out, _ := dockerCmd(c, "run", "-d", "-p", ":80", "busybox", "top")
+	id := cli.DockerCmd(c, "run", "-d", "-p", ":80", "busybox", "top").Stdout()
+	id = strings.TrimSpace(id)
 
-	id := strings.TrimSpace(out)
-
-	out, _ = dockerCmd(c, "inspect", "--format", `{{index .NetworkSettings.Ports "80/tcp" 0 "HostPort" }}`, id)
+	out := cli.DockerCmd(c, "inspect", "--format", `{{index .NetworkSettings.Ports "80/tcp" 0 "HostPort" }}`, id).Stdout()
 	out = strings.TrimSpace(out)
 	if out == "" {
 		c.Fatal("docker port command output is empty")
@@ -2495,10 +2480,9 @@ func (s *DockerCLIRunSuite) TestRunPortFromDockerRangeInUse(c *testing.T) {
 	}
 	defer l.Close()
 
-	out, _ = dockerCmd(c, "run", "-d", "-p", ":80", "busybox", "top")
-
-	id = strings.TrimSpace(out)
-	dockerCmd(c, "port", id)
+	id = cli.DockerCmd(c, "run", "-d", "-p", ":80", "busybox", "top").Stdout()
+	id = strings.TrimSpace(id)
+	cli.DockerCmd(c, "port", id)
 }
 
 func (s *DockerCLIRunSuite) TestRunTTYWithPipe(c *testing.T) {
@@ -2545,7 +2529,7 @@ func (s *DockerCLIRunSuite) TestRunNonLocalMacAddress(c *testing.T) {
 		expected = strings.ReplaceAll(strings.ToUpper(addr), ":", "-")
 	}
 
-	if out, _ := dockerCmd(c, args...); !strings.Contains(out, expected) {
+	if out := cli.DockerCmd(c, args...).Combined(); !strings.Contains(out, expected) {
 		c.Fatalf("Output should have contained %q: %s", expected, out)
 	}
 }
@@ -2559,13 +2543,13 @@ func (s *DockerCLIRunSuite) TestRunNetHost(c *testing.T) {
 		c.Fatal(err)
 	}
 
-	out, _ := dockerCmd(c, "run", "--net=host", "busybox", "readlink", "/proc/self/ns/net")
+	out := cli.DockerCmd(c, "run", "--net=host", "busybox", "readlink", "/proc/self/ns/net").Combined()
 	out = strings.Trim(out, "\n")
 	if hostNet != out {
 		c.Fatalf("Net namespace different with --net=host %s != %s\n", hostNet, out)
 	}
 
-	out, _ = dockerCmd(c, "run", "busybox", "readlink", "/proc/self/ns/net")
+	out = cli.DockerCmd(c, "run", "busybox", "readlink", "/proc/self/ns/net").Combined()
 	out = strings.Trim(out, "\n")
 	if hostNet == out {
 		c.Fatalf("Net namespace should be different without --net=host %s == %s\n", hostNet, out)
@@ -2577,8 +2561,8 @@ func (s *DockerCLIRunSuite) TestRunNetHostTwiceSameName(c *testing.T) {
 	// CNM, this test may be possible to enable on Windows.
 	testRequires(c, testEnv.IsLocalDaemon, DaemonIsLinux, NotUserNamespace)
 
-	dockerCmd(c, "run", "--rm", "--name=thost", "--net=host", "busybox", "true")
-	dockerCmd(c, "run", "--rm", "--name=thost", "--net=host", "busybox", "true")
+	cli.DockerCmd(c, "run", "--rm", "--name=thost", "--net=host", "busybox", "true")
+	cli.DockerCmd(c, "run", "--rm", "--name=thost", "--net=host", "busybox", "true")
 }
 
 func (s *DockerCLIRunSuite) TestRunNetContainerWhichHost(c *testing.T) {
@@ -2590,9 +2574,9 @@ func (s *DockerCLIRunSuite) TestRunNetContainerWhichHost(c *testing.T) {
 		c.Fatal(err)
 	}
 
-	dockerCmd(c, "run", "-d", "--net=host", "--name=test", "busybox", "top")
+	cli.DockerCmd(c, "run", "-d", "--net=host", "--name=test", "busybox", "top")
 
-	out, _ := dockerCmd(c, "run", "--net=container:test", "busybox", "readlink", "/proc/self/ns/net")
+	out := cli.DockerCmd(c, "run", "--net=container:test", "busybox", "readlink", "/proc/self/ns/net").Combined()
 	out = strings.Trim(out, "\n")
 	if hostNet != out {
 		c.Fatalf("Container should have host network namespace")
@@ -2604,21 +2588,20 @@ func (s *DockerCLIRunSuite) TestRunAllowPortRangeThroughPublish(c *testing.T) {
 	// Windows does not currently support --expose, or populate the network
 	// settings seen through inspect.
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-d", "--expose", "3000-3003", "-p", "3000-3003", "busybox", "top")
-
-	id := strings.TrimSpace(out)
-	portstr := inspectFieldJSON(c, id, "NetworkSettings.Ports")
+	id := cli.DockerCmd(c, "run", "-d", "--expose", "3000-3003", "-p", "3000-3003", "busybox", "top").Stdout()
+	id = strings.TrimSpace(id)
+	portStr := inspectFieldJSON(c, id, "NetworkSettings.Ports")
 
 	var ports nat.PortMap
-	err := json.Unmarshal([]byte(portstr), &ports)
-	assert.NilError(c, err, "failed to unmarshal: %v", portstr)
+	err := json.Unmarshal([]byte(portStr), &ports)
+	assert.NilError(c, err, "failed to unmarshal: %v", portStr)
 	for port, binding := range ports {
 		portnum, _ := strconv.Atoi(strings.Split(string(port), "/")[0])
 		if portnum < 3000 || portnum > 3003 {
 			c.Fatalf("Port %d is out of range ", portnum)
 		}
 		if len(binding) == 0 || len(binding[0].HostPort) == 0 {
-			c.Fatal("Port is not mapped for the port "+port, out)
+			c.Fatal("Port is not mapped for the port "+port, id)
 		}
 	}
 }
@@ -2632,13 +2615,13 @@ func (s *DockerCLIRunSuite) TestRunSetDefaultRestartPolicy(c *testing.T) {
 }
 
 func (s *DockerCLIRunSuite) TestRunRestartMaxRetries(c *testing.T) {
-	out, _ := dockerCmd(c, "run", "-d", "--restart=on-failure:3", "busybox", "false")
+	id := cli.DockerCmd(c, "run", "-d", "--restart=on-failure:3", "busybox", "false").Stdout()
+	id = strings.TrimSpace(id)
 	timeout := 10 * time.Second
 	if testEnv.DaemonInfo.OSType == "windows" {
 		timeout = 120 * time.Second
 	}
 
-	id := strings.TrimSpace(out)
 	if err := waitInspect(id, "{{ .State.Restarting }} {{ .State.Running }}", "false false", timeout); err != nil {
 		c.Fatal(err)
 	}
@@ -2655,7 +2638,7 @@ func (s *DockerCLIRunSuite) TestRunRestartMaxRetries(c *testing.T) {
 }
 
 func (s *DockerCLIRunSuite) TestRunContainerWithWritableRootfs(c *testing.T) {
-	dockerCmd(c, "run", "--rm", "busybox", "touch", "/file")
+	cli.DockerCmd(c, "run", "--rm", "busybox", "touch", "/file")
 }
 
 func (s *DockerCLIRunSuite) TestRunContainerWithReadonlyRootfs(c *testing.T) {
@@ -2676,10 +2659,11 @@ func (s *DockerCLIRunSuite) TestPermissionsPtsReadonlyRootfs(c *testing.T) {
 	testRequires(c, DaemonIsLinux, UserNamespaceROMount)
 
 	// Ensure we have not broken writing /dev/pts
-	out, status := dockerCmd(c, "run", "--read-only", "--rm", "busybox", "mount")
-	if status != 0 {
+	result := cli.DockerCmd(c, "run", "--read-only", "--rm", "busybox", "mount")
+	if result.ExitCode != 0 {
 		c.Fatal("Could not obtain mounts when checking /dev/pts mntpnt.")
 	}
+	out := result.Combined()
 	expected := "type devpts (rw,"
 	if !strings.Contains(out, expected) {
 		c.Fatalf("expected output to contain %s but contains %s", expected, out)
@@ -2713,9 +2697,9 @@ func (s *DockerCLIRunSuite) TestRunContainerWithReadonlyEtcHostsAndLinkedContain
 	// Not applicable on Windows which does not support --link
 	testRequires(c, DaemonIsLinux, UserNamespaceROMount)
 
-	dockerCmd(c, "run", "-d", "--name", "test-etc-hosts-ro-linked", "busybox", "top")
+	cli.DockerCmd(c, "run", "-d", "--name", "test-etc-hosts-ro-linked", "busybox", "top")
 
-	out, _ := dockerCmd(c, "run", "--read-only", "--link", "test-etc-hosts-ro-linked:testlinked", "busybox", "cat", "/etc/hosts")
+	out := cli.DockerCmd(c, "run", "--read-only", "--link", "test-etc-hosts-ro-linked:testlinked", "busybox", "cat", "/etc/hosts").Stdout()
 	if !strings.Contains(out, "testlinked") {
 		c.Fatal("Expected /etc/hosts to be updated even if --read-only enabled")
 	}
@@ -2725,7 +2709,7 @@ func (s *DockerCLIRunSuite) TestRunContainerWithReadonlyRootfsWithDNSFlag(c *tes
 	// Not applicable on Windows which does not support either --read-only or --dns.
 	testRequires(c, DaemonIsLinux, UserNamespaceROMount)
 
-	out, _ := dockerCmd(c, "run", "--read-only", "--dns", "1.1.1.1", "busybox", "/bin/cat", "/etc/resolv.conf")
+	out := cli.DockerCmd(c, "run", "--read-only", "--dns", "1.1.1.1", "busybox", "/bin/cat", "/etc/resolv.conf").Stdout()
 	if !strings.Contains(out, "1.1.1.1") {
 		c.Fatal("Expected /etc/resolv.conf to be updated even if --read-only enabled and --dns flag used")
 	}
@@ -2735,7 +2719,7 @@ func (s *DockerCLIRunSuite) TestRunContainerWithReadonlyRootfsWithAddHostFlag(c 
 	// Not applicable on Windows which does not support --read-only
 	testRequires(c, DaemonIsLinux, UserNamespaceROMount)
 
-	out, _ := dockerCmd(c, "run", "--read-only", "--add-host", "testreadonly:127.0.0.1", "busybox", "/bin/cat", "/etc/hosts")
+	out := cli.DockerCmd(c, "run", "--read-only", "--add-host", "testreadonly:127.0.0.1", "busybox", "/bin/cat", "/etc/hosts").Stdout()
 	if !strings.Contains(out, "testreadonly") {
 		c.Fatal("Expected /etc/hosts to be updated even if --read-only enabled and --add-host flag used")
 	}
@@ -2747,10 +2731,10 @@ func (s *DockerCLIRunSuite) TestRunVolumesFromRestartAfterRemoved(c *testing.T) 
 	runSleepingContainer(c, "--name=restarter", "--volumes-from", "voltest")
 
 	// Remove the main volume container and restart the consuming container
-	dockerCmd(c, "rm", "-f", "voltest")
+	cli.DockerCmd(c, "rm", "-f", "voltest")
 
 	// This should not fail since the volumes-from were already applied
-	dockerCmd(c, "restart", "restarter")
+	cli.DockerCmd(c, "restart", "restarter")
 }
 
 // run container with --rm should remove container if exit code != 0
@@ -2790,9 +2774,8 @@ func (s *DockerCLIRunSuite) TestRunPIDHostWithChildIsKillable(c *testing.T) {
 	// Not applicable on Windows as uses Unix specific functionality
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
 	name := "ibuildthecloud"
-	dockerCmd(c, "run", "-d", "--pid=host", "--name", name, "busybox", "sh", "-c", "sleep 30; echo hi")
-
-	assert.Assert(c, waitRun(name) == nil)
+	cli.DockerCmd(c, "run", "-d", "--pid=host", "--name", name, "busybox", "sh", "-c", "sleep 30; echo hi")
+	cli.WaitRun(c, name)
 
 	errchan := make(chan error, 1)
 	go func() {
@@ -2900,7 +2883,7 @@ func (s *DockerCLIRunSuite) TestMountIntoSys(c *testing.T) {
 	// Not applicable on Windows as uses Unix specific functionality
 	testRequires(c, DaemonIsLinux)
 	testRequires(c, NotUserNamespace)
-	dockerCmd(c, "run", "-v", "/sys/fs/cgroup", "busybox", "true")
+	cli.DockerCmd(c, "run", "-v", "/sys/fs/cgroup", "busybox", "true")
 }
 
 func (s *DockerCLIRunSuite) TestRunUnshareProc(c *testing.T) {
@@ -2964,8 +2947,8 @@ func (s *DockerCLIRunSuite) TestRunUnshareProc(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunPublishPort(c *testing.T) {
 	// TODO Windows: This may be possible once Windows moves to libnetwork and CNM
 	testRequires(c, DaemonIsLinux)
-	dockerCmd(c, "run", "-d", "--name", "test", "--expose", "8080", "busybox", "top")
-	out, _ := dockerCmd(c, "port", "test")
+	cli.DockerCmd(c, "run", "-d", "--name", "test", "--expose", "8080", "busybox", "top")
+	out := cli.DockerCmd(c, "port", "test").Stdout()
 	out = strings.Trim(out, "\r\n")
 	if out != "" {
 		c.Fatalf("run without --publish-all should not publish port, out should be nil, but got: %s", out)
@@ -2977,10 +2960,11 @@ func (s *DockerCLIRunSuite) TestDevicePermissions(c *testing.T) {
 	// Not applicable on Windows as uses Unix specific functionality
 	testRequires(c, DaemonIsLinux)
 	const permissions = "crw-rw-rw-"
-	out, status := dockerCmd(c, "run", "--device", "/dev/fuse:/dev/fuse:mrw", "busybox:latest", "ls", "-l", "/dev/fuse")
-	if status != 0 {
-		c.Fatalf("expected status 0, got %d", status)
+	result := cli.DockerCmd(c, "run", "--device", "/dev/fuse:/dev/fuse:mrw", "busybox:latest", "ls", "-l", "/dev/fuse")
+	if result.ExitCode != 0 {
+		c.Fatalf("expected status 0, got %d", result.ExitCode)
 	}
+	out := result.Combined()
 	if !strings.HasPrefix(out, permissions) {
 		c.Fatalf("output should begin with %q, got %q", permissions, out)
 	}
@@ -2989,7 +2973,7 @@ func (s *DockerCLIRunSuite) TestDevicePermissions(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunCapAddCHOWN(c *testing.T) {
 	// Not applicable on Windows as uses Unix specific functionality
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "--cap-drop=ALL", "--cap-add=CHOWN", "busybox", "sh", "-c", "adduser -D -H newuser && chown newuser /home && echo ok")
+	out := cli.DockerCmd(c, "run", "--cap-drop=ALL", "--cap-add=CHOWN", "busybox", "sh", "-c", "adduser -D -H newuser && chown newuser /home && echo ok").Combined()
 
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
 		c.Fatalf("expected output ok received %s", actual)
@@ -3000,10 +2984,10 @@ func (s *DockerCLIRunSuite) TestRunCapAddCHOWN(c *testing.T) {
 func (s *DockerCLIRunSuite) TestVolumeFromMixedRWOptions(c *testing.T) {
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
 
-	dockerCmd(c, "run", "--name", "parent", "-v", prefix+"/test", "busybox", "true")
+	cli.DockerCmd(c, "run", "--name", "parent", "-v", prefix+"/test", "busybox", "true")
 
-	dockerCmd(c, "run", "--volumes-from", "parent:ro", "--name", "test-volumes-1", "busybox", "true")
-	dockerCmd(c, "run", "--volumes-from", "parent:rw", "--name", "test-volumes-2", "busybox", "true")
+	cli.DockerCmd(c, "run", "--volumes-from", "parent:ro", "--name", "test-volumes-1", "busybox", "true")
+	cli.DockerCmd(c, "run", "--volumes-from", "parent:rw", "--name", "test-volumes-2", "busybox", "true")
 
 	if testEnv.DaemonInfo.OSType != "windows" {
 		mRO, err := inspectMountPoint("test-volumes-1", prefix+slash+"test")
@@ -3064,7 +3048,7 @@ func (s *DockerCLIRunSuite) TestRunNetworkFilesBindMount(c *testing.T) {
 	nwfiles := []string{"/etc/resolv.conf", "/etc/hosts", "/etc/hostname"}
 
 	for i := range nwfiles {
-		actual, _ := dockerCmd(c, "run", "-v", filename+":"+nwfiles[i], "busybox", "cat", nwfiles[i])
+		actual := cli.DockerCmd(c, "run", "-v", filename+":"+nwfiles[i], "busybox", "cat", nwfiles[i]).Combined()
 		if actual != expected {
 			c.Fatalf("expected %s be: %q, but was: %q", nwfiles[i], expected, actual)
 		}
@@ -3108,7 +3092,7 @@ func (s *DockerCLIRunSuite) TestRunNetworkFilesBindMountROFilesystem(c *testing.
 	nwfiles := []string{"/etc/resolv.conf", "/etc/hosts", "/etc/hostname"}
 
 	for i := range nwfiles {
-		_, exitCode := dockerCmd(c, "run", "-v", filename+":"+nwfiles[i], "--read-only", "busybox", "touch", nwfiles[i])
+		exitCode := cli.DockerCmd(c, "run", "-v", filename+":"+nwfiles[i], "--read-only", "busybox", "touch", nwfiles[i]).ExitCode
 		if exitCode != 0 {
 			c.Fatalf("run should not fail because %s is mounted writable on read-only root filesystem: exit code %d", nwfiles[i], exitCode)
 		}
@@ -3126,9 +3110,9 @@ func (s *DockerCLIRunSuite) TestPtraceContainerProcsFromHost(c *testing.T) {
 	// Not applicable on Windows as uses Unix specific functionality
 	testRequires(c, DaemonIsLinux, testEnv.IsLocalDaemon)
 
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
-	id := strings.TrimSpace(out)
-	assert.NilError(c, waitRun(id))
+	id := cli.DockerCmd(c, "run", "-d", "busybox", "top").Stdout()
+	id = strings.TrimSpace(id)
+	cli.WaitRun(c, id)
 	pid1 := inspectField(c, id, "State.Pid")
 
 	_, err := os.Readlink(fmt.Sprintf("/proc/%s/ns/net", pid1))
@@ -3176,7 +3160,7 @@ func (s *DockerCLIRunSuite) TestRunCapAddSYSTIME(c *testing.T) {
 	// Not applicable on Windows as uses Unix specific functionality
 	testRequires(c, DaemonIsLinux)
 
-	dockerCmd(c, "run", "--cap-drop=ALL", "--cap-add=SYS_TIME", "busybox", "sh", "-c", "grep ^CapEff /proc/self/status | sed 's/^CapEff:\t//' | grep ^0000000002000000$")
+	cli.DockerCmd(c, "run", "--cap-drop=ALL", "--cap-add=SYS_TIME", "busybox", "sh", "-c", "grep ^CapEff /proc/self/status | sed 's/^CapEff:\t//' | grep ^0000000002000000$")
 }
 
 // run create container failed should clean up the container
@@ -3195,12 +3179,12 @@ func (s *DockerCLIRunSuite) TestRunCreateContainerFailedCleanUp(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunNamedVolume(c *testing.T) {
 	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
 	testRequires(c, DaemonIsLinux)
-	dockerCmd(c, "run", "--name=test", "-v", "testing:"+prefix+"/foo", "busybox", "sh", "-c", "echo hello > "+prefix+"/foo/bar")
+	cli.DockerCmd(c, "run", "--name=test", "-v", "testing:"+prefix+"/foo", "busybox", "sh", "-c", "echo hello > "+prefix+"/foo/bar")
 
-	out, _ := dockerCmd(c, "run", "--volumes-from", "test", "busybox", "sh", "-c", "cat "+prefix+"/foo/bar")
+	out := cli.DockerCmd(c, "run", "--volumes-from", "test", "busybox", "sh", "-c", "cat "+prefix+"/foo/bar").Combined()
 	assert.Equal(c, strings.TrimSpace(out), "hello")
 
-	out, _ = dockerCmd(c, "run", "-v", "testing:"+prefix+"/foo", "busybox", "sh", "-c", "cat "+prefix+"/foo/bar")
+	out = cli.DockerCmd(c, "run", "-v", "testing:"+prefix+"/foo", "busybox", "sh", "-c", "cat "+prefix+"/foo/bar").Combined()
 	assert.Equal(c, strings.TrimSpace(out), "hello")
 }
 
@@ -3208,7 +3192,7 @@ func (s *DockerCLIRunSuite) TestRunWithUlimits(c *testing.T) {
 	// Not applicable on Windows as uses Unix specific functionality
 	testRequires(c, DaemonIsLinux)
 
-	out, _ := dockerCmd(c, "run", "--name=testulimits", "--ulimit", "nofile=42", "busybox", "/bin/sh", "-c", "ulimit -n")
+	out := cli.DockerCmd(c, "run", "--name=testulimits", "--ulimit", "nofile=42", "busybox", "/bin/sh", "-c", "ulimit -n").Combined()
 	ul := strings.TrimSpace(out)
 	if ul != "42" {
 		c.Fatalf("expected `ulimit -n` to be 42, got %s", ul)
@@ -3238,8 +3222,8 @@ func testRunContainerWithCgroupParent(c *testing.T, cgroupParent, name string) {
 	id := getIDByName(c, name)
 	expectedCgroup := path.Join(cgroupParent, id)
 	found := false
-	for _, path := range cgroupPaths {
-		if strings.HasSuffix(path, expectedCgroup) {
+	for _, p := range cgroupPaths {
+		if strings.HasSuffix(p, expectedCgroup) {
 			found = true
 			break
 		}
@@ -3278,8 +3262,8 @@ func testRunInvalidCgroupParent(c *testing.T, cgroupParent, cleanCgroupParent, n
 	id := getIDByName(c, name)
 	expectedCgroup := path.Join(cleanCgroupParent, id)
 	found := false
-	for _, path := range cgroupPaths {
-		if strings.HasSuffix(path, expectedCgroup) {
+	for _, p := range cgroupPaths {
+		if strings.HasSuffix(p, expectedCgroup) {
 			found = true
 			break
 		}
@@ -3341,7 +3325,7 @@ func (s *DockerCLIRunSuite) TestRunContainerNetModeWithDNSMacHosts(c *testing.T)
 func (s *DockerCLIRunSuite) TestRunContainerNetModeWithExposePort(c *testing.T) {
 	// Not applicable on Windows which does not support --net=container
 	testRequires(c, DaemonIsLinux)
-	dockerCmd(c, "run", "-d", "--name", "parent", "busybox", "top")
+	cli.DockerCmd(c, "run", "-d", "--name", "parent", "busybox", "top")
 
 	out, _, err := dockerCmdWithError("run", "-p", "5000:5000", "--net=container:parent", "busybox")
 	if err == nil || !strings.Contains(out, runconfig.ErrConflictNetworkPublishPorts.Error()) {
@@ -3362,17 +3346,17 @@ func (s *DockerCLIRunSuite) TestRunContainerNetModeWithExposePort(c *testing.T) 
 func (s *DockerCLIRunSuite) TestRunLinkToContainerNetMode(c *testing.T) {
 	// Not applicable on Windows which does not support --net=container or --link
 	testRequires(c, DaemonIsLinux)
-	dockerCmd(c, "run", "--name", "test", "-d", "busybox", "top")
-	dockerCmd(c, "run", "--name", "parent", "-d", "--net=container:test", "busybox", "top")
-	dockerCmd(c, "run", "-d", "--link=parent:parent", "busybox", "top")
-	dockerCmd(c, "run", "--name", "child", "-d", "--net=container:parent", "busybox", "top")
-	dockerCmd(c, "run", "-d", "--link=child:child", "busybox", "top")
+	cli.DockerCmd(c, "run", "--name", "test", "-d", "busybox", "top")
+	cli.DockerCmd(c, "run", "--name", "parent", "-d", "--net=container:test", "busybox", "top")
+	cli.DockerCmd(c, "run", "-d", "--link=parent:parent", "busybox", "top")
+	cli.DockerCmd(c, "run", "--name", "child", "-d", "--net=container:parent", "busybox", "top")
+	cli.DockerCmd(c, "run", "-d", "--link=child:child", "busybox", "top")
 }
 
 func (s *DockerCLIRunSuite) TestRunLoopbackOnlyExistsWhenNetworkingDisabled(c *testing.T) {
 	// TODO Windows: This may be possible to convert.
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "--net=none", "busybox", "ip", "-o", "-4", "a", "show", "up")
+	out := cli.DockerCmd(c, "run", "--net=none", "busybox", "ip", "-o", "-4", "a", "show", "up").Combined()
 
 	var (
 		count = 0
@@ -3397,9 +3381,9 @@ func (s *DockerCLIRunSuite) TestRunLoopbackOnlyExistsWhenNetworkingDisabled(c *t
 // Issue #4681
 func (s *DockerCLIRunSuite) TestRunLoopbackWhenNetworkDisabled(c *testing.T) {
 	if testEnv.DaemonInfo.OSType == "windows" {
-		dockerCmd(c, "run", "--net=none", testEnv.PlatformDefaults.BaseImage, "ping", "-n", "1", "127.0.0.1")
+		cli.DockerCmd(c, "run", "--net=none", testEnv.PlatformDefaults.BaseImage, "ping", "-n", "1", "127.0.0.1")
 	} else {
-		dockerCmd(c, "run", "--net=none", "busybox", "ping", "-c", "1", "127.0.0.1")
+		cli.DockerCmd(c, "run", "--net=none", "busybox", "ping", "-c", "1", "127.0.0.1")
 	}
 }
 
@@ -3407,9 +3391,9 @@ func (s *DockerCLIRunSuite) TestRunModeNetContainerHostname(c *testing.T) {
 	// Windows does not support --net=container
 	testRequires(c, DaemonIsLinux)
 
-	dockerCmd(c, "run", "-i", "-d", "--name", "parent", "busybox", "top")
-	out, _ := dockerCmd(c, "exec", "parent", "cat", "/etc/hostname")
-	out1, _ := dockerCmd(c, "run", "--net=container:parent", "busybox", "cat", "/etc/hostname")
+	cli.DockerCmd(c, "run", "-i", "-d", "--name", "parent", "busybox", "top")
+	out := cli.DockerCmd(c, "exec", "parent", "cat", "/etc/hostname").Combined()
+	out1 := cli.DockerCmd(c, "run", "--net=container:parent", "busybox", "cat", "/etc/hostname").Combined()
 
 	if out1 != out {
 		c.Fatal("containers with shared net namespace should have same hostname")
@@ -3420,8 +3404,8 @@ func (s *DockerCLIRunSuite) TestRunNetworkNotInitializedNoneMode(c *testing.T) {
 	// TODO Windows: Network settings are not currently propagated. This may
 	// be resolved in the future with the move to libnetwork and CNM.
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-d", "--net=none", "busybox", "top")
-	id := strings.TrimSpace(out)
+	id := cli.DockerCmd(c, "run", "-d", "--net=none", "busybox", "top").Stdout()
+	id = strings.TrimSpace(id)
 	res := inspectField(c, id, "NetworkSettings.Networks.none.IPAddress")
 	if res != "" {
 		c.Fatalf("For 'none' mode network must not be initialized, but container got IP: %s", res)
@@ -3431,61 +3415,61 @@ func (s *DockerCLIRunSuite) TestRunNetworkNotInitializedNoneMode(c *testing.T) {
 func (s *DockerCLIRunSuite) TestTwoContainersInNetHost(c *testing.T) {
 	// Not applicable as Windows does not support --net=host
 	testRequires(c, DaemonIsLinux, NotUserNamespace, NotUserNamespace)
-	dockerCmd(c, "run", "-d", "--net=host", "--name=first", "busybox", "top")
-	dockerCmd(c, "run", "-d", "--net=host", "--name=second", "busybox", "top")
-	dockerCmd(c, "stop", "first")
-	dockerCmd(c, "stop", "second")
+	cli.DockerCmd(c, "run", "-d", "--net=host", "--name=first", "busybox", "top")
+	cli.DockerCmd(c, "run", "-d", "--net=host", "--name=second", "busybox", "top")
+	cli.DockerCmd(c, "stop", "first")
+	cli.DockerCmd(c, "stop", "second")
 }
 
 func (s *DockerCLIRunSuite) TestContainersInUserDefinedNetwork(c *testing.T) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
-	dockerCmd(c, "network", "create", "-d", "bridge", "testnetwork")
-	dockerCmd(c, "run", "-d", "--net=testnetwork", "--name=first", "busybox", "top")
-	assert.Assert(c, waitRun("first") == nil)
-	dockerCmd(c, "run", "-t", "--net=testnetwork", "--name=second", "busybox", "ping", "-c", "1", "first")
+	cli.DockerCmd(c, "network", "create", "-d", "bridge", "testnetwork")
+	cli.DockerCmd(c, "run", "-d", "--net=testnetwork", "--name=first", "busybox", "top")
+	cli.WaitRun(c, "first")
+	cli.DockerCmd(c, "run", "-t", "--net=testnetwork", "--name=second", "busybox", "ping", "-c", "1", "first")
 }
 
 func (s *DockerCLIRunSuite) TestContainersInMultipleNetworks(c *testing.T) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
 	// Create 2 networks using bridge driver
-	dockerCmd(c, "network", "create", "-d", "bridge", "testnetwork1")
-	dockerCmd(c, "network", "create", "-d", "bridge", "testnetwork2")
+	cli.DockerCmd(c, "network", "create", "-d", "bridge", "testnetwork1")
+	cli.DockerCmd(c, "network", "create", "-d", "bridge", "testnetwork2")
 	// Run and connect containers to testnetwork1
-	dockerCmd(c, "run", "-d", "--net=testnetwork1", "--name=first", "busybox", "top")
-	assert.Assert(c, waitRun("first") == nil)
-	dockerCmd(c, "run", "-d", "--net=testnetwork1", "--name=second", "busybox", "top")
-	assert.Assert(c, waitRun("second") == nil)
+	cli.DockerCmd(c, "run", "-d", "--net=testnetwork1", "--name=first", "busybox", "top")
+	cli.WaitRun(c, "first")
+	cli.DockerCmd(c, "run", "-d", "--net=testnetwork1", "--name=second", "busybox", "top")
+	cli.WaitRun(c, "second")
 	// Check connectivity between containers in testnetwork2
-	dockerCmd(c, "exec", "first", "ping", "-c", "1", "second.testnetwork1")
+	cli.DockerCmd(c, "exec", "first", "ping", "-c", "1", "second.testnetwork1")
 	// Connect containers to testnetwork2
-	dockerCmd(c, "network", "connect", "testnetwork2", "first")
-	dockerCmd(c, "network", "connect", "testnetwork2", "second")
+	cli.DockerCmd(c, "network", "connect", "testnetwork2", "first")
+	cli.DockerCmd(c, "network", "connect", "testnetwork2", "second")
 	// Check connectivity between containers
-	dockerCmd(c, "exec", "second", "ping", "-c", "1", "first.testnetwork2")
+	cli.DockerCmd(c, "exec", "second", "ping", "-c", "1", "first.testnetwork2")
 }
 
 func (s *DockerCLIRunSuite) TestContainersNetworkIsolation(c *testing.T) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
 	// Create 2 networks using bridge driver
-	dockerCmd(c, "network", "create", "-d", "bridge", "testnetwork1")
-	dockerCmd(c, "network", "create", "-d", "bridge", "testnetwork2")
+	cli.DockerCmd(c, "network", "create", "-d", "bridge", "testnetwork1")
+	cli.DockerCmd(c, "network", "create", "-d", "bridge", "testnetwork2")
 	// Run 1 container in testnetwork1 and another in testnetwork2
-	dockerCmd(c, "run", "-d", "--net=testnetwork1", "--name=first", "busybox", "top")
-	assert.Assert(c, waitRun("first") == nil)
-	dockerCmd(c, "run", "-d", "--net=testnetwork2", "--name=second", "busybox", "top")
-	assert.Assert(c, waitRun("second") == nil)
+	cli.DockerCmd(c, "run", "-d", "--net=testnetwork1", "--name=first", "busybox", "top")
+	cli.WaitRun(c, "first")
+	cli.DockerCmd(c, "run", "-d", "--net=testnetwork2", "--name=second", "busybox", "top")
+	cli.WaitRun(c, "second")
 
 	// Check Isolation between containers : ping must fail
 	_, _, err := dockerCmdWithError("exec", "first", "ping", "-c", "1", "second")
 	assert.ErrorContains(c, err, "")
 	// Connect first container to testnetwork2
-	dockerCmd(c, "network", "connect", "testnetwork2", "first")
+	cli.DockerCmd(c, "network", "connect", "testnetwork2", "first")
 	// ping must succeed now
 	_, _, err = dockerCmdWithError("exec", "first", "ping", "-c", "1", "second")
 	assert.NilError(c, err)
 
 	// Disconnect first container from testnetwork2
-	dockerCmd(c, "network", "disconnect", "testnetwork2", "first")
+	cli.DockerCmd(c, "network", "disconnect", "testnetwork2", "first")
 	// ping must fail again
 	_, _, err = dockerCmdWithError("exec", "first", "ping", "-c", "1", "second")
 	assert.ErrorContains(c, err, "")
@@ -3494,17 +3478,17 @@ func (s *DockerCLIRunSuite) TestContainersNetworkIsolation(c *testing.T) {
 func (s *DockerCLIRunSuite) TestNetworkRmWithActiveContainers(c *testing.T) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
 	// Create 2 networks using bridge driver
-	dockerCmd(c, "network", "create", "-d", "bridge", "testnetwork1")
+	cli.DockerCmd(c, "network", "create", "-d", "bridge", "testnetwork1")
 	// Run and connect containers to testnetwork1
-	dockerCmd(c, "run", "-d", "--net=testnetwork1", "--name=first", "busybox", "top")
-	assert.Assert(c, waitRun("first") == nil)
-	dockerCmd(c, "run", "-d", "--net=testnetwork1", "--name=second", "busybox", "top")
-	assert.Assert(c, waitRun("second") == nil)
+	cli.DockerCmd(c, "run", "-d", "--net=testnetwork1", "--name=first", "busybox", "top")
+	cli.WaitRun(c, "first")
+	cli.DockerCmd(c, "run", "-d", "--net=testnetwork1", "--name=second", "busybox", "top")
+	cli.WaitRun(c, "second")
 	// Network delete with active containers must fail
 	_, _, err := dockerCmdWithError("network", "rm", "testnetwork1")
 	assert.ErrorContains(c, err, "")
 
-	dockerCmd(c, "stop", "first")
+	cli.DockerCmd(c, "stop", "first")
 	_, _, err = dockerCmdWithError("network", "rm", "testnetwork1")
 	assert.ErrorContains(c, err, "")
 }
@@ -3512,43 +3496,43 @@ func (s *DockerCLIRunSuite) TestNetworkRmWithActiveContainers(c *testing.T) {
 func (s *DockerCLIRunSuite) TestContainerRestartInMultipleNetworks(c *testing.T) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
 	// Create 2 networks using bridge driver
-	dockerCmd(c, "network", "create", "-d", "bridge", "testnetwork1")
-	dockerCmd(c, "network", "create", "-d", "bridge", "testnetwork2")
+	cli.DockerCmd(c, "network", "create", "-d", "bridge", "testnetwork1")
+	cli.DockerCmd(c, "network", "create", "-d", "bridge", "testnetwork2")
 
 	// Run and connect containers to testnetwork1
-	dockerCmd(c, "run", "-d", "--net=testnetwork1", "--name=first", "busybox", "top")
-	assert.Assert(c, waitRun("first") == nil)
-	dockerCmd(c, "run", "-d", "--net=testnetwork1", "--name=second", "busybox", "top")
-	assert.Assert(c, waitRun("second") == nil)
+	cli.DockerCmd(c, "run", "-d", "--net=testnetwork1", "--name=first", "busybox", "top")
+	cli.WaitRun(c, "first")
+	cli.DockerCmd(c, "run", "-d", "--net=testnetwork1", "--name=second", "busybox", "top")
+	cli.WaitRun(c, "second")
 	// Check connectivity between containers in testnetwork2
-	dockerCmd(c, "exec", "first", "ping", "-c", "1", "second.testnetwork1")
+	cli.DockerCmd(c, "exec", "first", "ping", "-c", "1", "second.testnetwork1")
 	// Connect containers to testnetwork2
-	dockerCmd(c, "network", "connect", "testnetwork2", "first")
-	dockerCmd(c, "network", "connect", "testnetwork2", "second")
+	cli.DockerCmd(c, "network", "connect", "testnetwork2", "first")
+	cli.DockerCmd(c, "network", "connect", "testnetwork2", "second")
 	// Check connectivity between containers
-	dockerCmd(c, "exec", "second", "ping", "-c", "1", "first.testnetwork2")
+	cli.DockerCmd(c, "exec", "second", "ping", "-c", "1", "first.testnetwork2")
 
 	// Stop second container and test ping failures on both networks
-	dockerCmd(c, "stop", "second")
+	cli.DockerCmd(c, "stop", "second")
 	_, _, err := dockerCmdWithError("exec", "first", "ping", "-c", "1", "second.testnetwork1")
 	assert.ErrorContains(c, err, "")
 	_, _, err = dockerCmdWithError("exec", "first", "ping", "-c", "1", "second.testnetwork2")
 	assert.ErrorContains(c, err, "")
 
 	// Start second container and connectivity must be restored on both networks
-	dockerCmd(c, "start", "second")
-	dockerCmd(c, "exec", "first", "ping", "-c", "1", "second.testnetwork1")
-	dockerCmd(c, "exec", "second", "ping", "-c", "1", "first.testnetwork2")
+	cli.DockerCmd(c, "start", "second")
+	cli.DockerCmd(c, "exec", "first", "ping", "-c", "1", "second.testnetwork1")
+	cli.DockerCmd(c, "exec", "second", "ping", "-c", "1", "first.testnetwork2")
 }
 
 func (s *DockerCLIRunSuite) TestContainerWithConflictingHostNetworks(c *testing.T) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
 	// Run a container with --net=host
-	dockerCmd(c, "run", "-d", "--net=host", "--name=first", "busybox", "top")
-	assert.Assert(c, waitRun("first") == nil)
+	cli.DockerCmd(c, "run", "-d", "--net=host", "--name=first", "busybox", "top")
+	cli.WaitRun(c, "first")
 
 	// Create a network using bridge driver
-	dockerCmd(c, "network", "create", "-d", "bridge", "testnetwork1")
+	cli.DockerCmd(c, "network", "create", "-d", "bridge", "testnetwork1")
 
 	// Connecting to the user defined network must fail
 	_, _, err := dockerCmdWithError("network", "connect", "testnetwork1", "first")
@@ -3557,14 +3541,14 @@ func (s *DockerCLIRunSuite) TestContainerWithConflictingHostNetworks(c *testing.
 
 func (s *DockerCLIRunSuite) TestContainerWithConflictingSharedNetwork(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	dockerCmd(c, "run", "-d", "--name=first", "busybox", "top")
-	assert.Assert(c, waitRun("first") == nil)
+	cli.DockerCmd(c, "run", "-d", "--name=first", "busybox", "top")
+	cli.WaitRun(c, "first")
 	// Run second container in first container's network namespace
-	dockerCmd(c, "run", "-d", "--net=container:first", "--name=second", "busybox", "top")
-	assert.Assert(c, waitRun("second") == nil)
+	cli.DockerCmd(c, "run", "-d", "--net=container:first", "--name=second", "busybox", "top")
+	cli.WaitRun(c, "second")
 
 	// Create a network using bridge driver
-	dockerCmd(c, "network", "create", "-d", "bridge", "testnetwork1")
+	cli.DockerCmd(c, "network", "create", "-d", "bridge", "testnetwork1")
 
 	// Connecting to the user defined network must fail
 	out, _, err := dockerCmdWithError("network", "connect", "testnetwork1", "second")
@@ -3574,19 +3558,19 @@ func (s *DockerCLIRunSuite) TestContainerWithConflictingSharedNetwork(c *testing
 
 func (s *DockerCLIRunSuite) TestContainerWithConflictingNoneNetwork(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	dockerCmd(c, "run", "-d", "--net=none", "--name=first", "busybox", "top")
-	assert.Assert(c, waitRun("first") == nil)
+	cli.DockerCmd(c, "run", "-d", "--net=none", "--name=first", "busybox", "top")
+	cli.WaitRun(c, "first")
 
 	// Create a network using bridge driver
-	dockerCmd(c, "network", "create", "-d", "bridge", "testnetwork1")
+	cli.DockerCmd(c, "network", "create", "-d", "bridge", "testnetwork1")
 
 	// Connecting to the user defined network must fail
 	out, _, err := dockerCmdWithError("network", "connect", "testnetwork1", "first")
 	assert.ErrorContains(c, err, "")
 	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictNoNetwork.Error()))
 	// create a container connected to testnetwork1
-	dockerCmd(c, "run", "-d", "--net=testnetwork1", "--name=second", "busybox", "top")
-	assert.Assert(c, waitRun("second") == nil)
+	cli.DockerCmd(c, "run", "-d", "--net=testnetwork1", "--name=second", "busybox", "top")
+	cli.WaitRun(c, "second")
 
 	// Connect second container to none network. it must fail as well
 	_, _, err = dockerCmdWithError("network", "connect", "none", "second")
@@ -3713,7 +3697,7 @@ func (s *DockerCLIRunSuite) TestRunInitLayerPathOwnership(c *testing.T) {
 		RUN chown dockerio:dockerio /etc`))
 
 	// Test that dockerio ownership of /etc is retained at runtime
-	out, _ := dockerCmd(c, "run", "--rm", name, "stat", "-c", "%U:%G", "/etc")
+	out := cli.DockerCmd(c, "run", "--rm", name, "stat", "-c", "%U:%G", "/etc").Combined()
 	out = strings.TrimSpace(out)
 	if out != "dockerio:dockerio" {
 		c.Fatalf("Wrong /etc ownership: expected dockerio:dockerio, got %q", out)
@@ -3723,10 +3707,10 @@ func (s *DockerCLIRunSuite) TestRunInitLayerPathOwnership(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunWithOomScoreAdj(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 
-	expected := "642"
-	out, _ := dockerCmd(c, "run", "--oom-score-adj", expected, "busybox", "cat", "/proc/self/oom_score_adj")
+	const expected = "642"
+	out := cli.DockerCmd(c, "run", "--oom-score-adj", expected, "busybox", "cat", "/proc/self/oom_score_adj").Combined()
 	oomScoreAdj := strings.TrimSpace(out)
-	if oomScoreAdj != "642" {
+	if oomScoreAdj != expected {
 		c.Fatalf("Expected oom_score_adj set to %q, got %q instead", expected, oomScoreAdj)
 	}
 }
@@ -3764,34 +3748,34 @@ func (s *DockerCLIRunSuite) TestRunNamedVolumeCopyImageData(c *testing.T) {
 	RUN mkdir -p /foo && echo hello > /foo/hello
 	`))
 
-	dockerCmd(c, "run", "-v", "foo:/foo", testImg)
-	out, _ := dockerCmd(c, "run", "-v", "foo:/foo", "busybox", "cat", "/foo/hello")
+	cli.DockerCmd(c, "run", "-v", "foo:/foo", testImg)
+	out := cli.DockerCmd(c, "run", "-v", "foo:/foo", "busybox", "cat", "/foo/hello").Stdout()
 	assert.Equal(c, strings.TrimSpace(out), "hello")
 }
 
 func (s *DockerCLIRunSuite) TestRunNamedVolumeNotRemoved(c *testing.T) {
 	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
 
-	dockerCmd(c, "volume", "create", "test")
+	cli.DockerCmd(c, "volume", "create", "test")
 
-	dockerCmd(c, "run", "--rm", "-v", "test:"+prefix+"/foo", "-v", prefix+"/bar", "busybox", "true")
-	dockerCmd(c, "volume", "inspect", "test")
-	out, _ := dockerCmd(c, "volume", "ls", "-q")
+	cli.DockerCmd(c, "run", "--rm", "-v", "test:"+prefix+"/foo", "-v", prefix+"/bar", "busybox", "true")
+	cli.DockerCmd(c, "volume", "inspect", "test")
+	out := cli.DockerCmd(c, "volume", "ls", "-q").Combined()
 	assert.Assert(c, strings.Contains(out, "test"))
 
-	dockerCmd(c, "run", "--name=test", "-v", "test:"+prefix+"/foo", "-v", prefix+"/bar", "busybox", "true")
-	dockerCmd(c, "rm", "-fv", "test")
-	dockerCmd(c, "volume", "inspect", "test")
-	out, _ = dockerCmd(c, "volume", "ls", "-q")
+	cli.DockerCmd(c, "run", "--name=test", "-v", "test:"+prefix+"/foo", "-v", prefix+"/bar", "busybox", "true")
+	cli.DockerCmd(c, "rm", "-fv", "test")
+	cli.DockerCmd(c, "volume", "inspect", "test")
+	out = cli.DockerCmd(c, "volume", "ls", "-q").Combined()
 	assert.Assert(c, strings.Contains(out, "test"))
 }
 
 func (s *DockerCLIRunSuite) TestRunNamedVolumesFromNotRemoved(c *testing.T) {
 	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
 
-	dockerCmd(c, "volume", "create", "test")
-	cid, _ := dockerCmd(c, "run", "-d", "--name=parent", "-v", "test:"+prefix+"/foo", "-v", prefix+"/bar", "busybox", "true")
-	dockerCmd(c, "run", "--name=child", "--volumes-from=parent", "busybox", "true")
+	cli.DockerCmd(c, "volume", "create", "test")
+	cid := cli.DockerCmd(c, "run", "-d", "--name=parent", "-v", "test:"+prefix+"/foo", "-v", prefix+"/bar", "busybox", "true").Stdout()
+	cli.DockerCmd(c, "run", "--name=child", "--volumes-from=parent", "busybox", "true")
 
 	apiClient, err := client.NewClientWithOpts(client.FromEnv)
 	assert.NilError(c, err)
@@ -3808,11 +3792,11 @@ func (s *DockerCLIRunSuite) TestRunNamedVolumesFromNotRemoved(c *testing.T) {
 	assert.Assert(c, vname != "")
 
 	// Remove the parent so there are not other references to the volumes
-	dockerCmd(c, "rm", "-f", "parent")
+	cli.DockerCmd(c, "rm", "-f", "parent")
 	// now remove the child and ensure the named volume (and only the named volume) still exists
-	dockerCmd(c, "rm", "-fv", "child")
-	dockerCmd(c, "volume", "inspect", "test")
-	out, _ := dockerCmd(c, "volume", "ls", "-q")
+	cli.DockerCmd(c, "rm", "-fv", "child")
+	cli.DockerCmd(c, "volume", "inspect", "test")
+	out := cli.DockerCmd(c, "volume", "ls", "-q").Combined()
 	assert.Assert(c, strings.Contains(out, "test"))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), vname))
 }
@@ -3872,7 +3856,7 @@ func (s *DockerCLIRunSuite) TestRunAttachFailedNoLeak(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunVolumeWithOneCharacter(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 
-	out, _ := dockerCmd(c, "run", "-v", "/tmp/q:/foo", "busybox", "sh", "-c", "find /foo")
+	out := cli.DockerCmd(c, "run", "-v", "/tmp/q:/foo", "busybox", "sh", "-c", "find /foo").Combined()
 	assert.Equal(c, strings.TrimSpace(out), "/foo")
 }
 
@@ -3881,23 +3865,23 @@ func (s *DockerCLIRunSuite) TestRunVolumeCopyFlag(c *testing.T) {
 	buildImageSuccessfully(c, "volumecopy", build.WithDockerfile(`FROM busybox
 		RUN mkdir /foo && echo hello > /foo/bar
 		CMD cat /foo/bar`))
-	dockerCmd(c, "volume", "create", "test")
+	cli.DockerCmd(c, "volume", "create", "test")
 
 	// test with the nocopy flag
 	out, _, err := dockerCmdWithError("run", "-v", "test:/foo:nocopy", "volumecopy")
 	assert.ErrorContains(c, err, "", out)
 	// test default behavior which is to copy for non-binds
-	out, _ = dockerCmd(c, "run", "-v", "test:/foo", "volumecopy")
+	out = cli.DockerCmd(c, "run", "-v", "test:/foo", "volumecopy").Combined()
 	assert.Equal(c, strings.TrimSpace(out), "hello")
 	// error out when the volume is already populated
 	out, _, err = dockerCmdWithError("run", "-v", "test:/foo:copy", "volumecopy")
 	assert.ErrorContains(c, err, "", out)
 	// do not error out when copy isn't explicitly set even though it's already populated
-	out, _ = dockerCmd(c, "run", "-v", "test:/foo", "volumecopy")
+	out = cli.DockerCmd(c, "run", "-v", "test:/foo", "volumecopy").Combined()
 	assert.Equal(c, strings.TrimSpace(out), "hello")
 
 	// do not allow copy modes on volumes-from
-	dockerCmd(c, "run", "--name=test", "-v", "/foo", "busybox", "true")
+	cli.DockerCmd(c, "run", "--name=test", "-v", "/foo", "busybox", "true")
 	out, _, err = dockerCmdWithError("run", "--volumes-from=test:copy", "busybox", "true")
 	assert.ErrorContains(c, err, "", out)
 	out, _, err = dockerCmdWithError("run", "--volumes-from=test:nocopy", "busybox", "true")
@@ -3950,12 +3934,12 @@ func (s *DockerCLIRunSuite) TestRunAddHostInHostMode(c *testing.T) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
 
 	expectedOutput := "1.2.3.4\textra"
-	out, _ := dockerCmd(c, "run", "--add-host=extra:1.2.3.4", "--net=host", "busybox", "cat", "/etc/hosts")
+	out := cli.DockerCmd(c, "run", "--add-host=extra:1.2.3.4", "--net=host", "busybox", "cat", "/etc/hosts").Combined()
 	assert.Assert(c, strings.Contains(out, expectedOutput), "Expected '%s', but got %q", expectedOutput, out)
 }
 
 func (s *DockerCLIRunSuite) TestRunRmAndWait(c *testing.T) {
-	dockerCmd(c, "run", "--name=test", "--rm", "-d", "busybox", "sh", "-c", "sleep 3;exit 2")
+	cli.DockerCmd(c, "run", "--name=test", "--rm", "-d", "busybox", "sh", "-c", "sleep 3;exit 2")
 
 	out, code, err := dockerCmdWithError("wait", "test")
 	assert.Assert(c, err == nil, "out: %s; exit code: %d", out, code)
@@ -4088,7 +4072,7 @@ func (s *DockerCLIRunSuite) TestRunCredentialSpecWellFormed(c *testing.T) {
 	for _, value := range []string{"file://valid.json", "raw://" + validCredSpecs} {
 		// `nltest /PARENTDOMAIN` simply reads the local config, and does not require having an AD
 		// controller handy
-		out, _ := dockerCmd(c, "run", "--rm", "--security-opt=credentialspec="+value, minimalBaseImage(), "nltest", "/PARENTDOMAIN")
+		out := cli.DockerCmd(c, "run", "--rm", "--security-opt=credentialspec="+value, minimalBaseImage(), "nltest", "/PARENTDOMAIN").Combined()
 
 		assert.Assert(c, strings.Contains(out, "hyperv.local."))
 		assert.Assert(c, strings.Contains(out, "The command completed successfully"))
@@ -4108,7 +4092,7 @@ func (s *DockerCLIRunSuite) TestRunDuplicateMount(c *testing.T) {
 	}
 
 	name := "test"
-	out, _ := dockerCmd(c, "run", "--name", name, "-v", "/tmp:/tmp", "-v", "/tmp:/tmp", "busybox", "sh", "-c", "cat "+tmpFile.Name()+" && ls /")
+	out := cli.DockerCmd(c, "run", "--name", name, "-v", "/tmp:/tmp", "-v", "/tmp:/tmp", "busybox", "sh", "-c", "cat "+tmpFile.Name()+" && ls /").Combined()
 	assert.Assert(c, !strings.Contains(out, "tmp:"))
 	assert.Assert(c, strings.Contains(out, data))
 	out = inspectFieldJSON(c, name, "Config.Volumes")
@@ -4118,7 +4102,7 @@ func (s *DockerCLIRunSuite) TestRunDuplicateMount(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunWindowsWithCPUCount(c *testing.T) {
 	testRequires(c, DaemonIsWindows)
 
-	out, _ := dockerCmd(c, "run", "--cpu-count=1", "--name", "test", "busybox", "echo", "testing")
+	out := cli.DockerCmd(c, "run", "--cpu-count=1", "--name", "test", "busybox", "echo", "testing").Combined()
 	assert.Equal(c, strings.TrimSpace(out), "testing")
 
 	out = inspectField(c, "test", "HostConfig.CPUCount")
@@ -4128,7 +4112,7 @@ func (s *DockerCLIRunSuite) TestRunWindowsWithCPUCount(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunWindowsWithCPUShares(c *testing.T) {
 	testRequires(c, DaemonIsWindows)
 
-	out, _ := dockerCmd(c, "run", "--cpu-shares=1000", "--name", "test", "busybox", "echo", "testing")
+	out := cli.DockerCmd(c, "run", "--cpu-shares=1000", "--name", "test", "busybox", "echo", "testing").Combined()
 	assert.Equal(c, strings.TrimSpace(out), "testing")
 
 	out = inspectField(c, "test", "HostConfig.CPUShares")
@@ -4138,7 +4122,7 @@ func (s *DockerCLIRunSuite) TestRunWindowsWithCPUShares(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunWindowsWithCPUPercent(c *testing.T) {
 	testRequires(c, DaemonIsWindows)
 
-	out, _ := dockerCmd(c, "run", "--cpu-percent=80", "--name", "test", "busybox", "echo", "testing")
+	out := cli.DockerCmd(c, "run", "--cpu-percent=80", "--name", "test", "busybox", "echo", "testing").Combined()
 	assert.Equal(c, strings.TrimSpace(out), "testing")
 
 	out = inspectField(c, "test", "HostConfig.CPUPercent")
@@ -4148,7 +4132,7 @@ func (s *DockerCLIRunSuite) TestRunWindowsWithCPUPercent(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunProcessIsolationWithCPUCountCPUSharesAndCPUPercent(c *testing.T) {
 	testRequires(c, DaemonIsWindows, testEnv.DaemonInfo.Isolation.IsProcess)
 
-	out, _ := dockerCmd(c, "run", "--cpu-count=1", "--cpu-shares=1000", "--cpu-percent=80", "--name", "test", "busybox", "echo", "testing")
+	out := cli.DockerCmd(c, "run", "--cpu-count=1", "--cpu-shares=1000", "--cpu-percent=80", "--name", "test", "busybox", "echo", "testing").Combined()
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), "WARNING: Conflicting options: CPU count takes priority over CPU shares on Windows Server Containers. CPU shares discarded"))
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), "WARNING: Conflicting options: CPU count takes priority over CPU percent on Windows Server Containers. CPU percent discarded"))
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), "testing"))
@@ -4165,7 +4149,7 @@ func (s *DockerCLIRunSuite) TestRunProcessIsolationWithCPUCountCPUSharesAndCPUPe
 func (s *DockerCLIRunSuite) TestRunHypervIsolationWithCPUCountCPUSharesAndCPUPercent(c *testing.T) {
 	testRequires(c, DaemonIsWindows, testEnv.DaemonInfo.Isolation.IsHyperV)
 
-	out, _ := dockerCmd(c, "run", "--cpu-count=1", "--cpu-shares=1000", "--cpu-percent=80", "--name", "test", "busybox", "echo", "testing")
+	out := cli.DockerCmd(c, "run", "--cpu-count=1", "--cpu-shares=1000", "--cpu-percent=80", "--name", "test", "busybox", "echo", "testing").Combined()
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), "testing"))
 	out = inspectField(c, "test", "HostConfig.CPUCount")
 	assert.Equal(c, out, "1")
@@ -4270,11 +4254,11 @@ func (s *DockerCLIRunSuite) TestRunMount(c *testing.T) {
 		c.Fatal(err)
 	}
 	testCatFooBar := func(cName string) error {
-		out, _ := dockerCmd(c, "exec", cName, "cat", "/foo/test1")
+		out := cli.DockerCmd(c, "exec", cName, "cat", "/foo/test1").Stdout()
 		if out != "test1" {
 			return fmt.Errorf("%s not mounted on /foo", mnt1)
 		}
-		out, _ = dockerCmd(c, "exec", cName, "cat", "/bar/test2")
+		out = cli.DockerCmd(c, "exec", cName, "cat", "/bar/test2").Stdout()
 		if out != "test2" {
 			return fmt.Errorf("%s not mounted on /bar", mnt2)
 		}
@@ -4361,7 +4345,7 @@ func (s *DockerCLIRunSuite) TestRunMount(c *testing.T) {
 			},
 			valid: true,
 			fn: func(cName string) error {
-				out, _ := dockerCmd(c, "exec", cName, "cat", "/foo/test1")
+				out := cli.DockerCmd(c, "exec", cName, "cat", "/foo/test1").Combined()
 				if out != "test1" {
 					return fmt.Errorf("%s not mounted on /foo", mnt1)
 				}
@@ -4414,7 +4398,7 @@ func (s *DockerCLIRunSuite) TestRunMount(c *testing.T) {
 			if testCase.valid {
 				assert.Assert(c, err == nil, "got error while creating a container with %v (%s)", opts, cName)
 				assert.Assert(c, testCase.fn(cName) == nil, "got error while executing test for %v (%s)", opts, cName)
-				dockerCmd(c, "rm", "-f", cName)
+				cli.DockerCmd(c, "rm", "-f", cName)
 			} else {
 				assert.Assert(c, err != nil, "got nil while creating a container with %v (%s)", opts, cName)
 			}
@@ -4428,10 +4412,10 @@ func (s *DockerCLIRunSuite) TestRunHostnameFQDN(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 
 	expectedOutput := "foobar.example.com\nfoobar.example.com\nfoobar\nexample.com\nfoobar.example.com"
-	out, _ := dockerCmd(c, "run", "--hostname=foobar.example.com", "busybox", "sh", "-c", `cat /etc/hostname && hostname && hostname -s && hostname -d && hostname -f`)
+	out := cli.DockerCmd(c, "run", "--hostname=foobar.example.com", "busybox", "sh", "-c", `cat /etc/hostname && hostname && hostname -s && hostname -d && hostname -f`).Combined()
 	assert.Equal(c, strings.TrimSpace(out), expectedOutput)
 
-	out, _ = dockerCmd(c, "run", "--hostname=foobar.example.com", "busybox", "sh", "-c", `cat /etc/hosts`)
+	out = cli.DockerCmd(c, "run", "--hostname=foobar.example.com", "busybox", "sh", "-c", `cat /etc/hosts`).Combined()
 	expectedOutput = "foobar.example.com foobar"
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), expectedOutput))
 }
@@ -4440,28 +4424,28 @@ func (s *DockerCLIRunSuite) TestRunHostnameFQDN(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunHostnameInHostMode(c *testing.T) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
 
-	expectedOutput := "foobar\nfoobar"
-	out, _ := dockerCmd(c, "run", "--net=host", "--hostname=foobar", "busybox", "sh", "-c", `echo $HOSTNAME && hostname`)
+	const expectedOutput = "foobar\nfoobar"
+	out := cli.DockerCmd(c, "run", "--net=host", "--hostname=foobar", "busybox", "sh", "-c", `echo $HOSTNAME && hostname`).Combined()
 	assert.Equal(c, strings.TrimSpace(out), expectedOutput)
 }
 
 func (s *DockerCLIRunSuite) TestRunAddDeviceCgroupRule(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 
-	deviceRule := "c 7:128 rwm"
+	const deviceRule = "c 7:128 rwm"
 
-	out, _ := dockerCmd(c, "run", "--rm", "busybox", "cat", "/sys/fs/cgroup/devices/devices.list")
+	out := cli.DockerCmd(c, "run", "--rm", "busybox", "cat", "/sys/fs/cgroup/devices/devices.list").Combined()
 	if strings.Contains(out, deviceRule) {
 		c.Fatalf("%s shouldn't been in the device.list", deviceRule)
 	}
 
-	out, _ = dockerCmd(c, "run", "--rm", fmt.Sprintf("--device-cgroup-rule=%s", deviceRule), "busybox", "grep", deviceRule, "/sys/fs/cgroup/devices/devices.list")
+	out = cli.DockerCmd(c, "run", "--rm", fmt.Sprintf("--device-cgroup-rule=%s", deviceRule), "busybox", "grep", deviceRule, "/sys/fs/cgroup/devices/devices.list").Combined()
 	assert.Equal(c, strings.TrimSpace(out), deviceRule)
 }
 
 // Verifies that running as local system is operating correctly on Windows
 func (s *DockerCLIRunSuite) TestWindowsRunAsSystem(c *testing.T) {
 	testRequires(c, DaemonIsWindows)
-	out, _ := dockerCmd(c, "run", "--net=none", `--user=nt authority\system`, "--hostname=XYZZY", minimalBaseImage(), "cmd", "/c", `@echo %USERNAME%`)
+	out := cli.DockerCmd(c, "run", "--net=none", `--user=nt authority\system`, "--hostname=XYZZY", minimalBaseImage(), "cmd", "/c", `@echo %USERNAME%`).Combined()
 	assert.Equal(c, strings.TrimSpace(out), "XYZZY$")
 }

--- a/integration-cli/docker_cli_search_test.go
+++ b/integration-cli/docker_cli_search_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/integration-cli/cli"
 	"gotest.tools/v3/assert"
 )
 
@@ -23,7 +24,7 @@ func (s *DockerCLISearchSuite) OnTimeout(c *testing.T) {
 
 // search for repos named  "registry" on the central registry
 func (s *DockerCLISearchSuite) TestSearchOnCentralRegistry(c *testing.T) {
-	out, _ := dockerCmd(c, "search", "busybox")
+	out := cli.DockerCmd(c, "search", "busybox").Stdout()
 	assert.Assert(c, strings.Contains(out, "Busybox base image."), "couldn't find any repository named (or containing) 'Busybox base image.'")
 }
 
@@ -46,35 +47,35 @@ func (s *DockerCLISearchSuite) TestSearchStarsOptionWithWrongParameter(c *testin
 }
 
 func (s *DockerCLISearchSuite) TestSearchCmdOptions(c *testing.T) {
-	outSearchCmd, _ := dockerCmd(c, "search", "busybox")
+	outSearchCmd := cli.DockerCmd(c, "search", "busybox").Combined()
 	assert.Assert(c, strings.Count(outSearchCmd, "\n") > 3, outSearchCmd)
 
-	outSearchCmdautomated, _ := dockerCmd(c, "search", "--filter", "is-automated=true", "busybox") // The busybox is a busybox base image, not an AUTOMATED image.
+	outSearchCmdautomated := cli.DockerCmd(c, "search", "--filter", "is-automated=true", "busybox").Combined() // The busybox is a busybox base image, not an AUTOMATED image.
 	outSearchCmdautomatedSlice := strings.Split(outSearchCmdautomated, "\n")
 	for i := range outSearchCmdautomatedSlice {
 		assert.Assert(c, !strings.HasPrefix(outSearchCmdautomatedSlice[i], "busybox "), "The busybox is not an AUTOMATED image: %s", outSearchCmdautomated)
 	}
 
-	outSearchCmdNotOfficial, _ := dockerCmd(c, "search", "--filter", "is-official=false", "busybox") // The busybox is a busybox base image, official image.
+	outSearchCmdNotOfficial := cli.DockerCmd(c, "search", "--filter", "is-official=false", "busybox").Combined() // The busybox is a busybox base image, official image.
 	outSearchCmdNotOfficialSlice := strings.Split(outSearchCmdNotOfficial, "\n")
 	for i := range outSearchCmdNotOfficialSlice {
 		assert.Assert(c, !strings.HasPrefix(outSearchCmdNotOfficialSlice[i], "busybox "), "The busybox is not an OFFICIAL image: %s", outSearchCmdNotOfficial)
 	}
 
-	outSearchCmdOfficial, _ := dockerCmd(c, "search", "--filter", "is-official=true", "busybox") // The busybox is a busybox base image, official image.
+	outSearchCmdOfficial := cli.DockerCmd(c, "search", "--filter", "is-official=true", "busybox").Combined() // The busybox is a busybox base image, official image.
 	outSearchCmdOfficialSlice := strings.Split(outSearchCmdOfficial, "\n")
 	assert.Equal(c, len(outSearchCmdOfficialSlice), 3) // 1 header, 1 line, 1 carriage return
 	assert.Assert(c, strings.HasPrefix(outSearchCmdOfficialSlice[1], "busybox "), "The busybox is an OFFICIAL image: %s", outSearchCmdOfficial)
 
-	outSearchCmdStars, _ := dockerCmd(c, "search", "--filter", "stars=10", "busybox")
+	outSearchCmdStars := cli.DockerCmd(c, "search", "--filter", "stars=10", "busybox").Combined()
 	assert.Assert(c, strings.Count(outSearchCmdStars, "\n") <= strings.Count(outSearchCmd, "\n"), "Number of images with 10+ stars should be less than that of all images:\noutSearchCmdStars: %s\noutSearch: %s\n", outSearchCmdStars, outSearchCmd)
 
-	dockerCmd(c, "search", "--filter", "is-automated=true", "--filter", "stars=2", "--no-trunc=true", "busybox")
+	cli.DockerCmd(c, "search", "--filter", "is-automated=true", "--filter", "stars=2", "--no-trunc=true", "busybox")
 }
 
 // search for repos which start with "ubuntu-" on the central registry
 func (s *DockerCLISearchSuite) TestSearchOnCentralRegistryWithDash(c *testing.T) {
-	dockerCmd(c, "search", "ubuntu-")
+	cli.DockerCmd(c, "search", "ubuntu-")
 }
 
 // test case for #23055

--- a/integration-cli/docker_cli_stats_test.go
+++ b/integration-cli/docker_cli_stats_test.go
@@ -29,9 +29,9 @@ func (s *DockerCLIStatsSuite) OnTimeout(c *testing.T) {
 func (s *DockerCLIStatsSuite) TestStatsNoStream(c *testing.T) {
 	// Windows does not support stats
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
-	id := strings.TrimSpace(out)
-	assert.NilError(c, waitRun(id))
+	id := cli.DockerCmd(c, "run", "-d", "busybox", "top").Stdout()
+	id = strings.TrimSpace(id)
+	cli.WaitRun(c, id)
 
 	statsCmd := exec.Command(dockerBinary, "stats", "--no-stream", id)
 	type output struct {
@@ -72,18 +72,18 @@ func (s *DockerCLIStatsSuite) TestStatsAllRunningNoStream(c *testing.T) {
 	// Windows does not support stats
 	testRequires(c, DaemonIsLinux)
 
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
-	id1 := strings.TrimSpace(out)[:12]
-	assert.NilError(c, waitRun(id1))
-	out, _ = dockerCmd(c, "run", "-d", "busybox", "top")
-	id2 := strings.TrimSpace(out)[:12]
-	assert.NilError(c, waitRun(id2))
-	out, _ = dockerCmd(c, "run", "-d", "busybox", "top")
-	id3 := strings.TrimSpace(out)[:12]
-	assert.NilError(c, waitRun(id3))
-	dockerCmd(c, "stop", id3)
+	id1 := cli.DockerCmd(c, "run", "-d", "busybox", "top").Stdout()
+	id1 = strings.TrimSpace(id1)[:12]
+	cli.WaitRun(c, id1)
+	id2 := cli.DockerCmd(c, "run", "-d", "busybox", "top").Stdout()
+	id2 = strings.TrimSpace(id2)[:12]
+	cli.WaitRun(c, id2)
+	id3 := cli.DockerCmd(c, "run", "-d", "busybox", "top").Stdout()
+	id3 = strings.TrimSpace(id3)[:12]
+	cli.WaitRun(c, id3)
+	cli.DockerCmd(c, "stop", id3)
 
-	out, _ = dockerCmd(c, "stats", "--no-stream")
+	out := cli.DockerCmd(c, "stats", "--no-stream").Combined()
 	if !strings.Contains(out, id1) || !strings.Contains(out, id2) {
 		c.Fatalf("Expected stats output to contain both %s and %s, got %s", id1, id2, out)
 	}
@@ -108,15 +108,15 @@ func (s *DockerCLIStatsSuite) TestStatsAllNoStream(c *testing.T) {
 	// Windows does not support stats
 	testRequires(c, DaemonIsLinux)
 
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
-	id1 := strings.TrimSpace(out)[:12]
-	assert.NilError(c, waitRun(id1))
-	dockerCmd(c, "stop", id1)
-	out, _ = dockerCmd(c, "run", "-d", "busybox", "top")
-	id2 := strings.TrimSpace(out)[:12]
-	assert.NilError(c, waitRun(id2))
+	id1 := cli.DockerCmd(c, "run", "-d", "busybox", "top").Stdout()
+	id1 = strings.TrimSpace(id1)[:12]
+	cli.WaitRun(c, id1)
+	cli.DockerCmd(c, "stop", id1)
+	id2 := cli.DockerCmd(c, "run", "-d", "busybox", "top").Stdout()
+	id2 = strings.TrimSpace(id2)[:12]
+	cli.WaitRun(c, id2)
 
-	out, _ = dockerCmd(c, "stats", "--all", "--no-stream")
+	out := cli.DockerCmd(c, "stats", "--all", "--no-stream").Combined()
 	if !strings.Contains(out, id1) || !strings.Contains(out, id2) {
 		c.Fatalf("Expected stats output to contain both %s and %s, got %s", id1, id2, out)
 	}
@@ -164,7 +164,7 @@ func (s *DockerCLIStatsSuite) TestStatsAllNewContainersAdded(c *testing.T) {
 	}()
 
 	out := runSleepingContainer(c, "-d")
-	assert.NilError(c, waitRun(strings.TrimSpace(out)))
+	cli.WaitRun(c, out)
 	id <- strings.TrimSpace(out)[:12]
 
 	select {

--- a/integration-cli/docker_cli_top_test.go
+++ b/integration-cli/docker_cli_top_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/integration-cli/cli"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
 )
@@ -32,7 +33,7 @@ func (s *DockerCLITopSuite) TestTopMultipleArgs(c *testing.T) {
 	default:
 		expected = icmd.Expected{Out: "PID"}
 	}
-	result := dockerCmdWithResult("top", cleanedContainerID, "-o", "pid")
+	result := cli.Docker(cli.Args("top", cleanedContainerID, "-o", "pid"))
 	result.Assert(c, expected)
 }
 
@@ -40,9 +41,9 @@ func (s *DockerCLITopSuite) TestTopNonPrivileged(c *testing.T) {
 	out := runSleepingContainer(c, "-d")
 	cleanedContainerID := strings.TrimSpace(out)
 
-	out1, _ := dockerCmd(c, "top", cleanedContainerID)
-	out2, _ := dockerCmd(c, "top", cleanedContainerID)
-	dockerCmd(c, "kill", cleanedContainerID)
+	out1 := cli.DockerCmd(c, "top", cleanedContainerID).Combined()
+	out2 := cli.DockerCmd(c, "top", cleanedContainerID).Combined()
+	cli.DockerCmd(c, "kill", cleanedContainerID)
 
 	// Windows will list the name of the launched executable which in this case is busybox.exe, without the parameters.
 	// Linux will display the command executed in the container
@@ -62,9 +63,8 @@ func (s *DockerCLITopSuite) TestTopNonPrivileged(c *testing.T) {
 // very different to Linux in this regard.
 func (s *DockerCLITopSuite) TestTopWindowsCoreProcesses(c *testing.T) {
 	testRequires(c, DaemonIsWindows)
-	out := runSleepingContainer(c, "-d")
-	cleanedContainerID := strings.TrimSpace(out)
-	out1, _ := dockerCmd(c, "top", cleanedContainerID)
+	cID := runSleepingContainer(c, "-d")
+	out1 := cli.DockerCmd(c, "top", cID).Combined()
 	lookingFor := []string{"smss.exe", "csrss.exe", "wininit.exe", "services.exe", "lsass.exe", "CExecSvc.exe"}
 	for i, s := range lookingFor {
 		assert.Assert(c, strings.Contains(out1, s), "top should've listed `%s` in the process list, but failed. Test case %d", s, i)
@@ -74,12 +74,12 @@ func (s *DockerCLITopSuite) TestTopWindowsCoreProcesses(c *testing.T) {
 func (s *DockerCLITopSuite) TestTopPrivileged(c *testing.T) {
 	// Windows does not support --privileged
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
-	out, _ := dockerCmd(c, "run", "--privileged", "-i", "-d", "busybox", "top")
-	cleanedContainerID := strings.TrimSpace(out)
+	cID := cli.DockerCmd(c, "run", "--privileged", "-i", "-d", "busybox", "top").Stdout()
+	cID = strings.TrimSpace(cID)
 
-	out1, _ := dockerCmd(c, "top", cleanedContainerID)
-	out2, _ := dockerCmd(c, "top", cleanedContainerID)
-	dockerCmd(c, "kill", cleanedContainerID)
+	out1 := cli.DockerCmd(c, "top", cID).Combined()
+	out2 := cli.DockerCmd(c, "top", cID).Combined()
+	cli.DockerCmd(c, "kill", cID)
 
 	assert.Assert(c, strings.Contains(out1, "top"), "top should've listed `top` in the process list, but failed the first time")
 	assert.Assert(c, strings.Contains(out2, "top"), "top should've listed `top` in the process list, but failed the second time")

--- a/integration-cli/docker_deprecated_api_v124_unix_test.go
+++ b/integration-cli/docker_deprecated_api_v124_unix_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
@@ -13,10 +14,10 @@ import (
 
 // #19100 This is a deprecated feature test, it should be removed in Docker 1.12
 func (s *DockerNetworkSuite) TestDeprecatedDockerNetworkStartAPIWithHostconfig(c *testing.T) {
-	netName := "test"
-	conName := "foo"
-	dockerCmd(c, "network", "create", netName)
-	dockerCmd(c, "create", "--name", conName, "busybox", "top")
+	const netName = "test"
+	const conName = "foo"
+	cli.DockerCmd(c, "network", "create", netName)
+	cli.DockerCmd(c, "create", "--name", conName, "busybox", "top")
 
 	config := map[string]interface{}{
 		"HostConfig": map[string]interface{}{
@@ -25,7 +26,7 @@ func (s *DockerNetworkSuite) TestDeprecatedDockerNetworkStartAPIWithHostconfig(c
 	}
 	_, _, err := request.Post(testutil.GetContext(c), formatV123StartAPIURL("/containers/"+conName+"/start"), request.JSONBody(config))
 	assert.NilError(c, err)
-	assert.NilError(c, waitRun(conName))
+	cli.WaitRun(c, conName)
 	networks := inspectField(c, conName, "NetworkSettings.Networks")
 	assert.Assert(c, strings.Contains(networks, netName), "Should contain '%s' network", netName)
 	assert.Assert(c, !strings.Contains(networks, "bridge"), "Should not contain 'bridge' network")

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -40,13 +40,6 @@ func dockerCmdWithError(args ...string) (string, int, error) {
 }
 
 // Deprecated: use cli.Docker or cli.DockerCmd
-func dockerCmd(c testing.TB, args ...string) (string, int) {
-	c.Helper()
-	result := cli.DockerCmd(c, args...)
-	return result.Combined(), result.ExitCode
-}
-
-// Deprecated: use cli.Docker or cli.DockerCmd
 func dockerCmdWithResult(args ...string) *icmd.Result {
 	return cli.Docker(cli.Args(args...))
 }
@@ -216,9 +209,7 @@ func runCommandAndReadContainerFile(c *testing.T, filename string, command strin
 	result := icmd.RunCommand(command, args...)
 	result.Assert(c, icmd.Success)
 	contID := strings.TrimSpace(result.Combined())
-	if err := waitRun(contID); err != nil {
-		c.Fatalf("%v: %q", contID, err)
-	}
+	cli.WaitRun(c, contID)
 	return readContainerFile(c, contID, filename)
 }
 
@@ -307,12 +298,6 @@ func createTmpFile(c *testing.T, content string) string {
 	assert.NilError(c, err)
 
 	return filename
-}
-
-// waitRun will wait for the specified container to be running, maximum 5 seconds.
-// Deprecated: use cli.WaitFor
-func waitRun(contID string) error {
-	return daemon.WaitInspectWithArgs(dockerBinary, contID, "{{.State.Running}}", "true", 5*time.Second)
 }
 
 // waitInspect will wait for the specified container to have the specified string

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -53,7 +53,7 @@ func dockerCmdWithResult(args ...string) *icmd.Result {
 
 func findContainerIP(c *testing.T, id string, network string) string {
 	c.Helper()
-	out, _ := dockerCmd(c, "inspect", fmt.Sprintf("--format='{{ .NetworkSettings.Networks.%s.IPAddress }}'", network), id)
+	out := cli.DockerCmd(c, "inspect", fmt.Sprintf("--format='{{ .NetworkSettings.Networks.%s.IPAddress }}'", network), id).Stdout()
 	return strings.Trim(out, " \r\n'")
 }
 

--- a/integration-cli/events_utils_test.go
+++ b/integration-cli/events_utils_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/containerd/log"
 	eventstestutils "github.com/docker/docker/daemon/events/testutils"
+	"github.com/docker/docker/integration-cli/cli"
 	"gotest.tools/v3/assert"
 )
 
@@ -100,7 +101,7 @@ func (e *eventObserver) CheckEventError(c *testing.T, id, event string, match ev
 
 	if e.disconnectionError != nil {
 		until := daemonUnixTime(c)
-		out, _ := dockerCmd(c, "events", "--since", e.startTime, "--until", until)
+		out := cli.DockerCmd(c, "events", "--since", e.startTime, "--until", until).Stdout()
 		events := strings.Split(strings.TrimSpace(out), "\n")
 		for _, e := range events {
 			if _, ok := match(e); ok {

--- a/integration-cli/fixtures_linux_daemon_test.go
+++ b/integration-cli/fixtures_linux_daemon_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/testutil/fixtures/load"
 	"gotest.tools/v3/assert"
 )
@@ -61,7 +62,7 @@ func ensureSyscallTest(ctx context.Context, c *testing.T) {
 	}
 	buildArgs = append(buildArgs, []string{"-q", "-t", "syscall-test", tmp}...)
 	buildArgs = append([]string{"build"}, buildArgs...)
-	dockerCmd(c, buildArgs...)
+	cli.DockerCmd(c, buildArgs...)
 }
 
 func ensureSyscallTestBuild(ctx context.Context, c *testing.T) {
@@ -74,7 +75,7 @@ func ensureSyscallTestBuild(ctx context.Context, c *testing.T) {
 	}
 	buildArgs = append(buildArgs, []string{"-q", "-t", "syscall-test", "../contrib/syscall-test"}...)
 	buildArgs = append([]string{"build"}, buildArgs...)
-	dockerCmd(c, buildArgs...)
+	cli.DockerCmd(c, buildArgs...)
 }
 
 func ensureNNPTest(ctx context.Context, c *testing.T) {
@@ -116,7 +117,7 @@ func ensureNNPTest(ctx context.Context, c *testing.T) {
 	}
 	buildArgs = append(buildArgs, []string{"-q", "-t", "nnp-test", tmp}...)
 	buildArgs = append([]string{"build"}, buildArgs...)
-	dockerCmd(c, buildArgs...)
+	cli.DockerCmd(c, buildArgs...)
 }
 
 func ensureNNPTestBuild(ctx context.Context, c *testing.T) {
@@ -129,5 +130,5 @@ func ensureNNPTestBuild(ctx context.Context, c *testing.T) {
 	}
 	buildArgs = append(buildArgs, []string{"-q", "-t", "npp-test", "../contrib/nnp-test"}...)
 	buildArgs = append([]string{"build"}, buildArgs...)
-	dockerCmd(c, buildArgs...)
+	cli.DockerCmd(c, buildArgs...)
 }

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/requirement"
 	"github.com/docker/docker/testutil/registry"
 )
@@ -173,7 +174,7 @@ func TODOBuildkit() bool {
 }
 
 func DockerCLIVersion(t testing.TB) string {
-	out, _ := dockerCmd(t, "--version")
+	out := cli.DockerCmd(t, "--version").Stdout()
 	version := strings.Fields(out)
 	if len(version) < 3 {
 		t.Fatal("unknown version output", version)

--- a/integration-cli/utils_test.go
+++ b/integration-cli/utils_test.go
@@ -23,19 +23,14 @@ func getPrefixAndSlashFromDaemonPlatform() (prefix, slash string) {
 // TODO: update code to call cmd.RunCmd directly, and remove this function
 // Deprecated: use gotest.tools/icmd
 func runCommandWithOutput(execCmd *exec.Cmd) (string, int, error) {
-	result := icmd.RunCmd(transformCmd(execCmd))
-	return result.Combined(), result.ExitCode, result.Error
-}
-
-// Temporary shim for migrating commands to the new function
-func transformCmd(execCmd *exec.Cmd) icmd.Cmd {
-	return icmd.Cmd{
+	result := icmd.RunCmd(icmd.Cmd{
 		Command: execCmd.Args,
 		Env:     execCmd.Env,
 		Dir:     execCmd.Dir,
 		Stdin:   execCmd.Stdin,
 		Stdout:  execCmd.Stdout,
-	}
+	})
+	return result.Combined(), result.ExitCode, result.Error
 }
 
 // ParseCgroupPaths parses 'procCgroupData', which is output of '/proc/<pid>/cgroup', and returns

--- a/integration-cli/utils_test.go
+++ b/integration-cli/utils_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/testutil"
 	"github.com/pkg/errors"
 	"gotest.tools/v3/icmd"
@@ -130,7 +131,7 @@ func existingElements(c *testing.T, opts elementListOptions) []string {
 	if opts.format != "" {
 		args = append(args, "--format", opts.format)
 	}
-	out, _ := dockerCmd(c, args...)
+	out := cli.DockerCmd(c, args...).Combined()
 	var lines []string
 	for _, l := range strings.Split(out, "\n") {
 		if l != "" {


### PR DESCRIPTION
- [x] depends on / to be rebased after https://github.com/moby/moby/pull/45652

Dusting off some old branches 😂 

- integration-cli: remove transformCmd utility
- integration-cli: DockerCLIPsSuite: replace dockerCmd and waitRun
- integration-cli: DockerCLIInspectSuite: replace dockerCmd and waitRun
- integration-cli: DockerNetworkSuite: replace dockerCmd and waitRun
- integration-cli: DockerCLINetmodeSuite: replace dockerCmd and waitRun
- integration-cli: dockerCmdWithFail: remove unused return
- integration-cli: DockerAPISuite: replace dockerCmd and waitRun
- integration-cli: DockerCLIAttachSuite: replace dockerCmd and waitRun
- integration-cli: DockerCLIEventSuite: replace dockerCmd and waitRun
- integration-cli: DockerCLIExecSuite: replace dockerCmd and waitRun
- integration-cli: DockerCLIInfoSuite: replace dockerCmd and waitRun
- integration-cli: findContainerIP: replace dockerCmd
- integration-cli: DockerBenchmarkSuite: replace dockerCmd and waitRun
- integration-cli: DockerCLIHealthSuite: replace dockerCmd and waitRun
- integration-cli: DockerCLILinksSuite: replace dockerCmd and waitRun
- integration-cli: DockerRegistryAuthHtpasswdSuite: replace dockerCmd
- integration-cli: DockerCLILogsSuite: replace dockerCmd and waitRun
- integration-cli: DockerCLIRunSuite: replace dockerCmd and waitRun
- integration-cli: DockerCLISaveLoadSuite: replace dockerCmd
- integration-cli: DockerCLIBuildSuite: replace dockerCmd
- integration-cli: DockerCLICpSuite: replace dockerCmd
- integration-cli: DockerRegistrySuite: replace dockerCmd
- integration-cli: replace dockerCmd
- integration-cli: DockerCLISearchSuite: replace dockerCmd
- integration-cli: DockerCLIRmiSuite: replace dockerCmd
- integration-cli: DockerCLIPortSuite: replace dockerCmd and waitRun
- integration-cli: DockerCLIImagesSuite: replace dockerCmd
- integration-cli: DockerCLIVolumeSuite: replace dockerCmd
- integration-cli: DockerDaemonSuite: replace dockerCmd
- integration-cli: DockerCLIUpdateSuite: replace dockerCmd and waitRun
- integration-cli: DockerCLIStartSuite: replace dockerCmd
- integration-cli: DockerCLICommitSuite: replace dockerCmd
- integration-cli: DockerCLIStatsSuite: replace dockerCmd and waitRun

**- A picture of a cute animal (not mandatory but encouraged)**

