### PR TITLE
pkg/chrootarchive: fix Darwin build

### DIFF
--- a/pkg/chrootarchive/archive_unix_nolinux.go
+++ b/pkg/chrootarchive/archive_unix_nolinux.go
@@ -1,3 +1,5 @@
+//go:build unix && !linux
+
 package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
 
 import (
@@ -15,9 +17,9 @@ import (
 )
 
 const (
-	packCmd        = "freebsd-pack-in-chroot"
-	unpackCmd      = "freebsd-unpack-in-chroot"
-	unpackLayerCmd = "freebsd-unpack-layer-in-chroot"
+	packCmd        = "chrootarchive-pack-in-chroot"
+	unpackCmd      = "chrootarchive-unpack-in-chroot"
+	unpackLayerCmd = "chrootarchive-unpack-layer-in-chroot"
 )
 
 func init() {

--- a/pkg/chrootarchive/archive_unix_nolinux_test.go
+++ b/pkg/chrootarchive/archive_unix_nolinux_test.go
@@ -1,3 +1,5 @@
+//go:build unix && !linux
+
 package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
 
 import (


### PR DESCRIPTION
Before this commit, `doPack`, `doUnpack` and `doUnpackLayer` were not implemented for Darwin, causing build failure.

This change allows all non-Linux Unixes to use FreeBSD reexec-based pack/unpack implementation

See also: moby/buildkit#4059
See also: 8b843732b36541b8b8a11ecb83cf5d51837ae22f

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Allowed FreeBSD chrootarchive implementation to be used on all Unixes (except Linux that has a separate one).

**- How I did it**

Renamed `archive_freebsd.go` to `archive_unix_nolinux.go` and adjusted `go:build` accordingly.

**- How to verify it**

Run chrootarchive tests on Darwin. I've verified that they pass.

This PR (combined with https://github.com/moby/buildkit/pull/4059) also allows buildkit to compile on Darwin.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

