### PR TITLE
api: Endpoints can now return a tree of errors

### DIFF
--- a/api/server/errorhandler.go
+++ b/api/server/errorhandler.go
@@ -1,13 +1,18 @@
 package server
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/docker/docker/api/server/httpstatus"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/errdefs"
 	"github.com/gorilla/mux"
+	"github.com/hashicorp/go-multierror"
 	"google.golang.org/grpc/status"
 )
 
@@ -17,18 +22,106 @@ func makeErrorHandler(err error) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		statusCode := httpstatus.FromError(err)
 		vars := mux.Vars(r)
-		if apiVersionSupportsJSONErrors(vars["version"]) {
-			response := &types.ErrorResponse{
-				Message: err.Error(),
-			}
-			_ = httputils.WriteJSON(w, statusCode, response)
-		} else {
+		version := vars["version"]
+
+		const firstAPIVersionWithJSONErrors = "1.24"
+		if version != "" && versions.LessThan(version, firstAPIVersionWithJSONErrors) {
 			http.Error(w, status.Convert(err).Message(), statusCode)
+			return
+		}
+
+		response := marshalErrorResponse(err)
+		const firstAPIVersionWithJSONMultiErrors = "1.44"
+		if version != "" && versions.LessThan(version, firstAPIVersionWithJSONMultiErrors) {
+			response.Errors = nil
+		}
+
+		_ = httputils.WriteJSON(w, statusCode, response)
+	}
+}
+
+type joiningError interface {
+	error
+	Unwrap() []error
+}
+
+type wrappingError interface {
+	error
+	Unwrap() error
+}
+
+// marshalErrorResponse returns a tree of [*types.ErrorResponse] representing the argument err.
+func marshalErrorResponse(err error) *types.ErrorResponse {
+	if errdefs.IsHTTPOnlyError(err) {
+		if wrappedErr := errors.Unwrap(err); wrappedErr != nil {
+			return marshalErrorResponse(wrappedErr)
+		}
+	}
+
+	switch err := err.(type) {
+	case joiningError:
+		return marshalJoinedErrors(err)
+	case *multierror.Error:
+		return marshalMultiErrors(err)
+	case wrappingError:
+		return &types.ErrorResponse{
+			Message: err.Error(),
+			Errors:  []*types.ErrorResponse{marshalErrorResponse(err.Unwrap())},
+		}
+	default:
+		return &types.ErrorResponse{
+			Message: err.Error(),
 		}
 	}
 }
 
-func apiVersionSupportsJSONErrors(version string) bool {
-	const firstAPIVersionWithJSONErrors = "1.23"
-	return version == "" || versions.GreaterThan(version, firstAPIVersionWithJSONErrors)
+func formatErrors(errs []*types.ErrorResponse) string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%d errors occurred:", len(errs)))
+	for _, err := range errs {
+		b.WriteString("\n\t* " + strings.Replace(err.Message, "\n", "\n\t", -1))
+	}
+	return b.String()
+}
+
+func marshalJoinedErrors(err joiningError) *types.ErrorResponse {
+	var subErrors []*types.ErrorResponse
+	for _, subErr := range err.Unwrap() {
+		if subErr != nil {
+			subErrors = append(subErrors, marshalErrorResponse(subErr))
+		}
+	}
+
+	errMsg := err.Error()
+	if len(subErrors) > 1 && err.Error() == errors.Join(err.Unwrap()...).Error() {
+		errMsg = formatErrors(subErrors)
+	} else if len(subErrors) == 1 && errMsg == subErrors[0].Message {
+		return subErrors[0]
+	}
+
+	return &types.ErrorResponse{
+		Message: errMsg,
+		Errors:  subErrors,
+	}
+}
+
+func marshalMultiErrors(err *multierror.Error) *types.ErrorResponse {
+	var subErrors []*types.ErrorResponse
+	for _, subErr := range err.WrappedErrors() {
+		if subErr != nil {
+			subErrors = append(subErrors, marshalErrorResponse(subErr))
+		}
+	}
+
+	if err.ErrorFormat != nil {
+		return &types.ErrorResponse{
+			Message: err.Error(),
+			Errors:  subErrors,
+		}
+	}
+
+	return &types.ErrorResponse{
+		Message: formatErrors(subErrors),
+		Errors:  subErrors,
+	}
 }

--- a/api/server/errorhandler_test.go
+++ b/api/server/errorhandler_test.go
@@ -1,0 +1,115 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
+	"github.com/hashicorp/go-multierror"
+	"gotest.tools/v3/assert"
+)
+
+func TestUnwrapErrors(t *testing.T) {
+	testcases := map[string]struct {
+		err      error
+		expected *types.ErrorResponse
+	}{
+		"non-HTTP error": {
+			err:      errors.New("foobar"),
+			expected: &types.ErrorResponse{Message: "foobar"},
+		},
+		"error wrapped by a HTTP-only error": {
+			err:      errdefs.InvalidParameter(errors.New("foobar")),
+			expected: &types.ErrorResponse{Message: "foobar"},
+		},
+		"error wrapped multiple times with a HTTP-only error": {
+			err:      errdefs.InvalidParameter(errdefs.Conflict(errors.New("foobar"))),
+			expected: &types.ErrorResponse{Message: "foobar"},
+		},
+		"wrapping error with no context": {
+			err:      fmt.Errorf("%w", errors.New("foobar")),
+			expected: &types.ErrorResponse{Message: "foobar", Errors: []*types.ErrorResponse{{Message: "foobar"}}},
+		},
+		"tree with errors.Join": {
+			err: errors.Join(
+				errors.New("foo"),
+				errors.Join(errors.New("bar"), errors.New("baz")),
+				errors.New("one more error"),
+			),
+			expected: &types.ErrorResponse{
+				Message: `3 errors occurred:
+	* foo
+	* 2 errors occurred:
+		* bar
+		* baz
+	* one more error`,
+				Errors: []*types.ErrorResponse{
+					{Message: "foo"},
+					{
+						Message: `2 errors occurred:
+	* bar
+	* baz`,
+						Errors: []*types.ErrorResponse{
+							{Message: "bar"},
+							{Message: "baz"},
+						},
+					},
+					{Message: "one more error"},
+				},
+			},
+		},
+		"page not found error": {err: pageNotFoundError{}, expected: &types.ErrorResponse{Message: "page not found"}},
+		"multi %w verb": {
+			err: fmt.Errorf("foo: %w, %w", errors.New("bar"), errors.New("baz")),
+			expected: &types.ErrorResponse{
+				Message: "foo: bar, baz",
+				Errors: []*types.ErrorResponse{
+					{Message: "bar"},
+					{Message: "baz"},
+				},
+			},
+		},
+		"tree with github.com/hashicorp/go-multierror, multi %w verbs and errors.Join": {
+			err: multierror.Append(
+				errors.New("foo"),
+				fmt.Errorf("bar: %w, %w", errors.New("baz"), errors.New("blah")),
+				errors.Join(errors.New("one more error"), errors.New("and a last one"))),
+			expected: &types.ErrorResponse{
+				Message: `3 errors occurred:
+	* foo
+	* bar: baz, blah
+	* 2 errors occurred:
+		* one more error
+		* and a last one`,
+				Errors: []*types.ErrorResponse{
+					{Message: "foo"},
+					{
+						Message: "bar: baz, blah",
+						Errors: []*types.ErrorResponse{
+							{Message: "baz"},
+							{Message: "blah"},
+						},
+					},
+					{
+						Message: `2 errors occurred:
+	* one more error
+	* and a last one`,
+						Errors: []*types.ErrorResponse{
+							{Message: "one more error"},
+							{Message: "and a last one"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for tcname, tc := range testcases {
+		t.Run(tcname, func(t *testing.T) {
+			result := marshalErrorResponse(tc.err)
+			assert.DeepEqual(t, tc.expected, result)
+		})
+	}
+}

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2423,11 +2423,22 @@ definitions:
     required: ["message"]
     properties:
       message:
-        description: "The error message."
+        description: "The error message. It is precomposed if multiple error messages are coalesced."
         type: "string"
         x-nullable: false
+      errors:
+        description: "The list of underlying errors making up the precomposed error message, if applicable."
+        type: "array"
+        items:
+          $ref: "#/definitions/ErrorResponse"
     example:
-      message: "Something went wrong."
+      message: |
+        2 errors occurred:
+            * Something went wrong.
+            * And something else went wrong too.
+      errors:
+        - message: "Something went wrong."
+        - message: "And something else went wrong too."
 
   IdResponse:
     description: "Response to an API call that returns just an Id"

--- a/api/types/error_response.go
+++ b/api/types/error_response.go
@@ -7,7 +7,10 @@ package types
 // swagger:model ErrorResponse
 type ErrorResponse struct {
 
-	// The error message.
+	// The list of underlying errors making up the precomposed error message, if applicable.
+	Errors []*ErrorResponse `json:"errors"`
+
+	// The error message. It is precomposed if multiple error messages are coalesced.
 	// Required: true
 	Message string `json:"message"`
 }

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -38,6 +38,10 @@ keywords: "API, Docker, rcli, REST, documentation"
   specifications directories. The use of the applied setting requires the daemon
   to have expermental enabled, and for non-experimental daemons an empty list is
   always returned.
+* Endpoints can now return multiple, nested error messages. In such case, the
+  `message` field will contain precomposed text and a new `errors` field will
+  contain a list of sub-errors. These sub-errors are `ErrorResponse`
+  themselves, the same type as the root error.
 
 ## v1.43 API changes
 

--- a/errdefs/is.go
+++ b/errdefs/is.go
@@ -28,6 +28,32 @@ func getImplementer(err error) error {
 	}
 }
 
+// IsHTTPOnlyError checks whether err is one of the un-exported HTTP error type provided by this package. These errors
+// only define what HTTP status code should be returned, but don't add additional context to the actual error they
+// wrap. By contrast, error types implementing the interfaces defined in this package are also adding such additional
+// context.
+func IsHTTPOnlyError(err error) bool {
+	switch err.(type) {
+	case
+		errNotFound,
+		errInvalidParameter,
+		errConflict,
+		errUnauthorized,
+		errUnavailable,
+		errForbidden,
+		errSystem,
+		errNotModified,
+		errNotImplemented,
+		errCancelled,
+		errDeadline,
+		errDataLoss,
+		errUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
 // IsNotFound returns if the passed in error is an ErrNotFound
 func IsNotFound(err error) bool {
 	_, ok := getImplementer(err).(ErrNotFound)


### PR DESCRIPTION
**- What I did**

There're cases like input validation where it makes sense to gather multiple errors and return them all to the client.

Prior to this PR, the API would only return a string `message` field. As a consequence, it requires those errors to be coalesced into a single string using a specific format, whether it's just a newline separator or some more complicated format.

This PR adds a new `errors` field containing a list of `ErrorResponse`.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://media.npr.org/assets/img/2017/04/25/istock-115796521-fcf434f36d3d0865301cdcb9c996cfd80578ca99-s1100-c50.jpg)
