### PR TITLE
libnetwork/remote: newDriver(): return concrete type

### DIFF
--- a/libnetwork/drivers/remote/driver.go
+++ b/libnetwork/drivers/remote/driver.go
@@ -25,7 +25,7 @@ type maybeError interface {
 	GetError() string
 }
 
-func newDriver(name string, client *plugins.Client) driverapi.Driver {
+func newDriver(name string, client *plugins.Client) *driver {
 	return &driver{networkType: name, endpoint: client}
 }
 
@@ -35,7 +35,7 @@ func Register(r driverapi.Registerer, pg plugingetter.PluginGetter) error {
 	newPluginHandler := func(name string, client *plugins.Client) {
 		// negotiate driver capability with client
 		d := newDriver(name, client)
-		c, err := d.(*driver).getCapabilities()
+		c, err := d.getCapabilities()
 		if err != nil {
 			log.G(context.TODO()).Errorf("error getting capability for %s due to %v", name, err)
 			return

--- a/libnetwork/drivers/remote/driver_test.go
+++ b/libnetwork/drivers/remote/driver_test.go
@@ -239,7 +239,7 @@ func TestGetEmptyCapabilities(t *testing.T) {
 		t.Fatal("Driver type does not match that given")
 	}
 
-	_, err = d.(*driver).getCapabilities()
+	_, err = d.getCapabilities()
 	if err == nil {
 		t.Fatal("There should be error reported when get empty capability")
 	}
@@ -273,7 +273,7 @@ func TestGetExtraCapabilities(t *testing.T) {
 		t.Fatal("Driver type does not match that given")
 	}
 
-	c, err := d.(*driver).getCapabilities()
+	c, err := d.getCapabilities()
 	if err != nil {
 		t.Fatal(err)
 	} else if c.DataScope != datastore.LocalScope {
@@ -309,7 +309,7 @@ func TestGetInvalidCapabilities(t *testing.T) {
 		t.Fatal("Driver type does not match that given")
 	}
 
-	_, err = d.(*driver).getCapabilities()
+	_, err = d.getCapabilities()
 	if err == nil {
 		t.Fatal("There should be error reported when get invalid capability")
 	}
@@ -427,7 +427,7 @@ func TestRemoteDriver(t *testing.T) {
 		t.Fatal("Driver type does not match that given")
 	}
 
-	c, err := d.(*driver).getCapabilities()
+	c, err := d.getCapabilities()
 	if err != nil {
 		t.Fatal(err)
 	} else if c.DataScope != datastore.GlobalScope {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/46086

Interface matching will happen on the receiver side.

**- A picture of a cute animal (not mandatory but encouraged)**

