### PR TITLE
api/types/filters: fix errors not being matched by errors.Is()

### DIFF
--- a/api/types/filters/parse.go
+++ b/api/types/filters/parse.go
@@ -98,7 +98,7 @@ func FromJSON(p string) (Args, error) {
 	// Fallback to parsing arguments in the legacy slice format
 	deprecated := map[string][]string{}
 	if legacyErr := json.Unmarshal(raw, &deprecated); legacyErr != nil {
-		return args, invalidFilter{}
+		return args, &invalidFilter{}
 	}
 
 	args.fields = deprecatedArgs(deprecated)
@@ -206,7 +206,7 @@ func (args Args) GetBoolOrDefault(key string, defaultValue bool) (bool, error) {
 	}
 
 	if len(fieldValues) == 0 {
-		return defaultValue, invalidFilter{key, nil}
+		return defaultValue, &invalidFilter{key, nil}
 	}
 
 	isFalse := fieldValues["0"] || fieldValues["false"]
@@ -216,7 +216,7 @@ func (args Args) GetBoolOrDefault(key string, defaultValue bool) (bool, error) {
 	invalid := !isFalse && !isTrue
 
 	if conflicting || invalid {
-		return defaultValue, invalidFilter{key, args.Get(key)}
+		return defaultValue, &invalidFilter{key, args.Get(key)}
 	} else if isFalse {
 		return false, nil
 	} else if isTrue {
@@ -224,7 +224,7 @@ func (args Args) GetBoolOrDefault(key string, defaultValue bool) (bool, error) {
 	}
 
 	// This code shouldn't be reached.
-	return defaultValue, unreachableCode{Filter: key, Value: args.Get(key)}
+	return defaultValue, &unreachableCode{Filter: key, Value: args.Get(key)}
 }
 
 // ExactMatch returns true if the source matches exactly one of the values.
@@ -282,7 +282,7 @@ func (args Args) Contains(field string) bool {
 func (args Args) Validate(accepted map[string]bool) error {
 	for name := range args.fields {
 		if !accepted[name] {
-			return invalidFilter{name, nil}
+			return &invalidFilter{name, nil}
 		}
 	}
 	return nil


### PR DESCRIPTION
- relates to / these were added in https://github.com/moby/moby/commit/0d68591c8edfca95dc1f9d582656fdf2daf110a8 / https://github.com/moby/moby/pull/44003


I found that the errors returned weren't matched with `errors.Is()` when wrapped.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

