### PR TITLE
libnetwork: move datastore Scope consts to libnetwork/scope

### DIFF
--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -13,7 +13,7 @@ import (
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork"
-	"github.com/docker/docker/libnetwork/datastore"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/pkg/errors"
 )
 
@@ -102,7 +102,7 @@ func (n *networkRouter) getNetwork(ctx context.Context, w http.ResponseWriter, r
 			return errors.Wrapf(invalidRequestError{err}, "invalid value for verbose: %s", v)
 		}
 	}
-	scope := r.URL.Query().Get("scope")
+	networkScope := r.URL.Query().Get("scope")
 
 	// In case multiple networks have duplicate names, return error.
 	// TODO (yongtang): should we wrap with version here for backward compatibility?
@@ -118,8 +118,8 @@ func (n *networkRouter) getNetwork(ctx context.Context, w http.ResponseWriter, r
 	// TODO(@cpuguy83): All this logic for figuring out which network to return does not belong here
 	// Instead there should be a backend function to just get one network.
 	filter := filters.NewArgs(filters.Arg("idOrName", term))
-	if scope != "" {
-		filter.Add("scope", scope)
+	if networkScope != "" {
+		filter.Add("scope", networkScope)
 	}
 	networks, _ := n.backend.GetNetworks(filter, types.NetworkListConfig{Detailed: true, Verbose: verbose})
 	for _, nw := range networks {
@@ -144,7 +144,7 @@ func (n *networkRouter) getNetwork(ctx context.Context, w http.ResponseWriter, r
 		// or if the get network was passed with a network name and scope as swarm
 		// return the network. Skipped using isMatchingScope because it is true if the scope
 		// is not set which would be case if the client API v1.30
-		if strings.HasPrefix(nwk.ID, term) || (datastore.SwarmScope == scope) {
+		if strings.HasPrefix(nwk.ID, term) || networkScope == scope.Swarm {
 			// If we have a previous match "backend", return it, we need verbose when enabled
 			// ex: overlay/partial_ID or name/swarm_scope
 			if nwv, ok := listByPartialID[nwk.ID]; ok {

--- a/daemon/cluster/convert/network.go
+++ b/daemon/cluster/convert/network.go
@@ -6,7 +6,7 @@ import (
 	basictypes "github.com/docker/docker/api/types"
 	networktypes "github.com/docker/docker/api/types/network"
 	types "github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/libnetwork/datastore"
+	"github.com/docker/docker/libnetwork/scope"
 	gogotypes "github.com/gogo/protobuf/types"
 	swarmapi "github.com/moby/swarmkit/v2/api"
 )
@@ -31,7 +31,7 @@ func networkFromGRPC(n *swarmapi.Network) types.Network {
 				Attachable:  n.Spec.Attachable,
 				Ingress:     IsIngressNetwork(n),
 				IPAMOptions: ipamFromGRPC(n.Spec.IPAM),
-				Scope:       datastore.SwarmScope,
+				Scope:       scope.Swarm,
 			},
 			IPAMOptions: ipamFromGRPC(n.IPAM),
 		}
@@ -160,7 +160,7 @@ func BasicNetworkFromGRPC(n swarmapi.Network) basictypes.NetworkResource {
 	nr := basictypes.NetworkResource{
 		ID:         n.ID,
 		Name:       n.Spec.Annotations.Name,
-		Scope:      datastore.SwarmScope,
+		Scope:      scope.Swarm,
 		EnableIPv6: spec.Ipv6Enabled,
 		IPAM:       ipam,
 		Internal:   spec.Internal,

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -20,7 +20,7 @@ import (
 	"github.com/docker/docker/daemon/cluster/convert"
 	executorpkg "github.com/docker/docker/daemon/cluster/executor"
 	clustertypes "github.com/docker/docker/daemon/cluster/provider"
-	"github.com/docker/docker/libnetwork/datastore"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/go-connections/nat"
 	"github.com/docker/go-units"
 	gogotypes "github.com/gogo/protobuf/types"
@@ -645,7 +645,7 @@ func (c *containerConfig) networkCreateRequest(name string) (clustertypes.Networ
 		Ingress:        convert.IsIngressNetwork(na.Network),
 		EnableIPv6:     na.Network.Spec.Ipv6Enabled,
 		CheckDuplicate: true,
-		Scope:          datastore.SwarmScope,
+		Scope:          scope.Swarm,
 	}
 
 	if na.Network.Spec.GetNetwork() != "" {

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -18,9 +18,9 @@ import (
 	"github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork"
-	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/options"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/stringid"
@@ -270,7 +270,7 @@ func (daemon *Daemon) updateNetworkSettings(container *container.Container, n *l
 			// is an attachable network, which may not
 			// be locally available previously.
 			// So always update.
-			if n.Info().Scope() == datastore.SwarmScope {
+			if n.Info().Scope() == scope.Swarm {
 				continue
 			}
 			// Avoid duplicate config

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -18,10 +18,10 @@ import (
 	"github.com/docker/docker/libcontainerd/remote"
 	"github.com/docker/docker/libnetwork"
 	nwconfig "github.com/docker/docker/libnetwork/config"
-	"github.com/docker/docker/libnetwork/datastore"
 	winlibnetwork "github.com/docker/docker/libnetwork/drivers/windows"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/options"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/parsers/operatingsystem"
@@ -290,7 +290,7 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 			}
 
 			// global networks should not be deleted by local HNS
-			if v.Info().Scope() != datastore.GlobalScope {
+			if v.Info().Scope() != scope.Global {
 				err = v.Delete()
 				if err != nil {
 					log.G(context.TODO()).Errorf("Error occurred when removing network %v", err)
@@ -341,7 +341,7 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 			nid = n.ID()
 
 			// global networks should not be deleted by local HNS
-			if n.Info().Scope() == datastore.GlobalScope {
+			if n.Info().Scope() == scope.Global {
 				continue
 			}
 			v.Name = n.Name()

--- a/libnetwork/agent.go
+++ b/libnetwork/agent.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/containerd/containerd/log"
 	"github.com/docker/docker/libnetwork/cluster"
-	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/discoverapi"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/networkdb"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/docker/go-events"
 	"github.com/gogo/protobuf/proto"
@@ -234,7 +234,7 @@ func (c *Controller) agentSetup(clusterProvider cluster.Provider) error {
 			return err
 		}
 		c.drvRegistry.WalkDrivers(func(name string, driver driverapi.Driver, capability driverapi.Capability) bool {
-			if capability.ConnectivityScope == datastore.GlobalScope {
+			if capability.ConnectivityScope == scope.Global {
 				if d, ok := driver.(discoverapi.Discover); ok {
 					c.agentDriverNotify(d)
 				}
@@ -526,7 +526,7 @@ func (n *Network) Services() map[string]ServiceInfo {
 }
 
 func (n *Network) isClusterEligible() bool {
-	if n.scope != datastore.SwarmScope || !n.driverIsMultihost() {
+	if n.scope != scope.Swarm || !n.driverIsMultihost() {
 		return false
 	}
 	return n.getController().getAgent() != nil

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -66,6 +66,7 @@ import (
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/options"
 	"github.com/docker/docker/libnetwork/osl"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/docker/pkg/plugins"
@@ -344,7 +345,7 @@ func (c *Controller) makeDriverConfig(ntype string) map[string]interface{} {
 		// FIXME: every driver instance constructs a new DataStore
 		// instance against the same database. Yikes!
 		cfg[netlabel.LocalKVClient] = discoverapi.DatastoreConfigData{
-			Scope:    datastore.LocalScope,
+			Scope:    scope.Local,
 			Provider: c.cfg.Scope.Client.Provider,
 			Address:  c.cfg.Scope.Client.Address,
 			Config:   c.cfg.Scope.Client.Config,
@@ -399,7 +400,7 @@ func (c *Controller) pushNodeDiscovery(d discoverapi.Discover, cap driverapi.Cap
 		self = net.ParseIP(agent.advertiseAddr)
 	}
 
-	if d == nil || cap.ConnectivityScope != datastore.GlobalScope || nodes == nil {
+	if d == nil || cap.ConnectivityScope != scope.Global || nodes == nil {
 		return
 	}
 
@@ -515,7 +516,7 @@ func (c *Controller) NewNetwork(networkType, name string, id string, options ...
 	// network drivers is needed so that this special network is not
 	// usable by old engine versions.
 	if nw.configOnly {
-		nw.scope = datastore.LocalScope
+		nw.scope = scope.Local
 		nw.networkType = "null"
 		goto addToStore
 	}
@@ -525,15 +526,15 @@ func (c *Controller) NewNetwork(networkType, name string, id string, options ...
 		return nil, err
 	}
 
-	if nw.scope == datastore.LocalScope && caps.DataScope == datastore.GlobalScope {
+	if nw.scope == scope.Local && caps.DataScope == scope.Global {
 		return nil, types.ForbiddenErrorf("cannot downgrade network scope for %s networks", networkType)
 	}
-	if nw.ingress && caps.DataScope != datastore.GlobalScope {
+	if nw.ingress && caps.DataScope != scope.Global {
 		return nil, types.ForbiddenErrorf("Ingress network can only be global scope network")
 	}
 
 	// At this point the network scope is still unknown if not set by user
-	if (caps.DataScope == datastore.GlobalScope || nw.scope == datastore.SwarmScope) &&
+	if (caps.DataScope == scope.Global || nw.scope == scope.Swarm) &&
 		!c.isDistributedControl() && !nw.dynamic {
 		if c.isManager() {
 			// For non-distributed controlled environment, globalscoped non-dynamic networks are redirected to Manager
@@ -542,7 +543,7 @@ func (c *Controller) NewNetwork(networkType, name string, id string, options ...
 		return nil, types.ForbiddenErrorf("Cannot create a multi-host network from a worker node. Please create the network from a manager node.")
 	}
 
-	if nw.scope == datastore.SwarmScope && c.isDistributedControl() {
+	if nw.scope == scope.Swarm && c.isDistributedControl() {
 		return nil, types.ForbiddenErrorf("cannot create a swarm scoped network when swarm is not active")
 	}
 

--- a/libnetwork/datastore/datastore.go
+++ b/libnetwork/datastore/datastore.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/docker/libnetwork/discoverapi"
 	store "github.com/docker/docker/libnetwork/internal/kvstore"
 	"github.com/docker/docker/libnetwork/internal/kvstore/boltdb"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -72,13 +73,18 @@ type ScopeClientCfg struct {
 
 const (
 	// LocalScope indicates to store the KV object in local datastore such as boltdb
-	LocalScope = "local"
+	//
+	// Deprecated: use [scope.Local].
+	LocalScope = scope.Local
 	// GlobalScope indicates to store the KV object in global datastore
-	GlobalScope = "global"
+	//
+	// Deprecated: use [scope.Global].
+	GlobalScope = scope.Global
 	// SwarmScope is not indicating a datastore location. It is defined here
 	// along with the other two scopes just for consistency.
-	SwarmScope    = "swarm"
-	defaultPrefix = "/var/lib/docker/network/files"
+	//
+	// Deprecated: use [scope.Swarm].
+	SwarmScope = scope.Swarm
 )
 
 const (
@@ -92,6 +98,8 @@ var (
 	defaultRootChain = []string{"docker", "network", "v1.0"}
 	rootChain        = defaultRootChain
 )
+
+const defaultPrefix = "/var/lib/docker/network/files"
 
 // DefaultScope returns a default scope config for clients to use.
 func DefaultScope(dataDir string) ScopeCfg {
@@ -151,7 +159,7 @@ func newClient(kv string, addr string, config *store.Config) (*Store, error) {
 		return nil, err
 	}
 
-	ds := &Store{scope: LocalScope, store: s}
+	ds := &Store{scope: scope.Local, store: s}
 	ds.cache = newCache(ds)
 
 	return ds, nil

--- a/libnetwork/datastore/datastore_test.go
+++ b/libnetwork/datastore/datastore_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/libnetwork/options"
+	"github.com/docker/docker/libnetwork/scope"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -13,7 +14,7 @@ const dummyKey = "dummy"
 
 // NewTestDataStore can be used by other Tests in order to use custom datastore
 func NewTestDataStore() *Store {
-	return &Store{scope: LocalScope, store: NewMockStore()}
+	return &Store{scope: scope.Local, store: NewMockStore()}
 }
 
 func TestKey(t *testing.T) {
@@ -132,7 +133,7 @@ func (n *dummyObject) Skip() bool {
 }
 
 func (n *dummyObject) DataScope() string {
-	return LocalScope
+	return scope.Local
 }
 
 func (n *dummyObject) MarshalJSON() ([]byte, error) {

--- a/libnetwork/drivers/bridge/bridge.go
+++ b/libnetwork/drivers/bridge/bridge.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/docker/libnetwork/options"
 	"github.com/docker/docker/libnetwork/portallocator"
 	"github.com/docker/docker/libnetwork/portmapper"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/vishvananda/netlink"
 )
@@ -174,8 +175,8 @@ func Register(r driverapi.Registerer, config map[string]interface{}) error {
 		return err
 	}
 	return r.RegisterDriver(NetworkType, d, driverapi.Capability{
-		DataScope:         datastore.LocalScope,
-		ConnectivityScope: datastore.LocalScope,
+		DataScope:         scope.Local,
+		ConnectivityScope: scope.Local,
 	})
 }
 

--- a/libnetwork/drivers/bridge/bridge_store.go
+++ b/libnetwork/drivers/bridge/bridge_store.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/discoverapi"
 	"github.com/docker/docker/libnetwork/netlabel"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -265,7 +266,7 @@ func (ncfg *networkConfiguration) CopyTo(o datastore.KVObject) error {
 }
 
 func (ncfg *networkConfiguration) DataScope() string {
-	return datastore.LocalScope
+	return scope.Local
 }
 
 func (ep *bridgeEndpoint) MarshalJSON() ([]byte, error) {
@@ -382,7 +383,7 @@ func (ep *bridgeEndpoint) CopyTo(o datastore.KVObject) error {
 }
 
 func (ep *bridgeEndpoint) DataScope() string {
-	return datastore.LocalScope
+	return scope.Local
 }
 
 func (n *bridgeNetwork) restorePortAllocations(ep *bridgeEndpoint) {

--- a/libnetwork/drivers/bridge/brmanager/brmanager.go
+++ b/libnetwork/drivers/bridge/brmanager/brmanager.go
@@ -1,8 +1,8 @@
 package brmanager
 
 import (
-	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/driverapi"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -13,8 +13,8 @@ type driver struct{}
 // Register registers a new instance of the bridge manager driver with r.
 func Register(r driverapi.Registerer) error {
 	return r.RegisterDriver(networkType, &driver{}, driverapi.Capability{
-		DataScope:         datastore.LocalScope,
-		ConnectivityScope: datastore.LocalScope,
+		DataScope:         scope.Local,
+		ConnectivityScope: scope.Local,
 	})
 }
 

--- a/libnetwork/drivers/host/host.go
+++ b/libnetwork/drivers/host/host.go
@@ -3,8 +3,8 @@ package host
 import (
 	"sync"
 
-	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/driverapi"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -17,8 +17,8 @@ type driver struct {
 
 func Register(r driverapi.Registerer) error {
 	return r.RegisterDriver(NetworkType, &driver{}, driverapi.Capability{
-		DataScope:         datastore.LocalScope,
-		ConnectivityScope: datastore.LocalScope,
+		DataScope:         scope.Local,
+		ConnectivityScope: scope.Local,
 	})
 }
 

--- a/libnetwork/drivers/ipvlan/ipvlan.go
+++ b/libnetwork/drivers/ipvlan/ipvlan.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/driverapi"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -70,8 +71,8 @@ func Register(r driverapi.Registerer, config map[string]interface{}) error {
 		return err
 	}
 	return r.RegisterDriver(NetworkType, d, driverapi.Capability{
-		DataScope:         datastore.LocalScope,
-		ConnectivityScope: datastore.GlobalScope,
+		DataScope:         scope.Local,
+		ConnectivityScope: scope.Global,
 	})
 }
 

--- a/libnetwork/drivers/ipvlan/ipvlan_store.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/discoverapi"
 	"github.com/docker/docker/libnetwork/netlabel"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -259,7 +260,7 @@ func (config *configuration) CopyTo(o datastore.KVObject) error {
 }
 
 func (config *configuration) DataScope() string {
-	return datastore.LocalScope
+	return scope.Local
 }
 
 func (ep *endpoint) MarshalJSON() ([]byte, error) {
@@ -359,5 +360,5 @@ func (ep *endpoint) CopyTo(o datastore.KVObject) error {
 }
 
 func (ep *endpoint) DataScope() string {
-	return datastore.LocalScope
+	return scope.Local
 }

--- a/libnetwork/drivers/ipvlan/ivmanager/ivmanager.go
+++ b/libnetwork/drivers/ipvlan/ivmanager/ivmanager.go
@@ -1,8 +1,8 @@
 package ivmanager
 
 import (
-	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/driverapi"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -13,8 +13,8 @@ type driver struct{}
 // Register registers a new instance of the ipvlan manager driver.
 func Register(r driverapi.Registerer) error {
 	return r.RegisterDriver(networkType, &driver{}, driverapi.Capability{
-		DataScope:         datastore.LocalScope,
-		ConnectivityScope: datastore.GlobalScope,
+		DataScope:         scope.Local,
+		ConnectivityScope: scope.Global,
 	})
 }
 

--- a/libnetwork/drivers/macvlan/macvlan.go
+++ b/libnetwork/drivers/macvlan/macvlan.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/driverapi"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -64,8 +65,8 @@ func Register(r driverapi.Registerer, config map[string]interface{}) error {
 		return err
 	}
 	return r.RegisterDriver(NetworkType, d, driverapi.Capability{
-		DataScope:         datastore.LocalScope,
-		ConnectivityScope: datastore.GlobalScope,
+		DataScope:         scope.Local,
+		ConnectivityScope: scope.Global,
 	})
 }
 

--- a/libnetwork/drivers/macvlan/macvlan_store.go
+++ b/libnetwork/drivers/macvlan/macvlan_store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/discoverapi"
 	"github.com/docker/docker/libnetwork/netlabel"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -253,7 +254,7 @@ func (config *configuration) CopyTo(o datastore.KVObject) error {
 }
 
 func (config *configuration) DataScope() string {
-	return datastore.LocalScope
+	return scope.Local
 }
 
 func (ep *endpoint) MarshalJSON() ([]byte, error) {
@@ -353,5 +354,5 @@ func (ep *endpoint) CopyTo(o datastore.KVObject) error {
 }
 
 func (ep *endpoint) DataScope() string {
-	return datastore.LocalScope
+	return scope.Local
 }

--- a/libnetwork/drivers/macvlan/mvmanager/mvmanager.go
+++ b/libnetwork/drivers/macvlan/mvmanager/mvmanager.go
@@ -1,8 +1,8 @@
 package mvmanager
 
 import (
-	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/driverapi"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -13,8 +13,8 @@ type driver struct{}
 // Register registers a new instance of the macvlan manager driver.
 func Register(r driverapi.Registerer) error {
 	return r.RegisterDriver(networkType, &driver{}, driverapi.Capability{
-		DataScope:         datastore.LocalScope,
-		ConnectivityScope: datastore.GlobalScope,
+		DataScope:         scope.Local,
+		ConnectivityScope: scope.Global,
 	})
 }
 

--- a/libnetwork/drivers/null/null.go
+++ b/libnetwork/drivers/null/null.go
@@ -3,8 +3,8 @@ package null
 import (
 	"sync"
 
-	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/driverapi"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -18,7 +18,7 @@ type driver struct {
 // Register registers a new instance of the null driver.
 func Register(r driverapi.Registerer) error {
 	return r.RegisterDriver(NetworkType, &driver{}, driverapi.Capability{
-		DataScope: datastore.LocalScope,
+		DataScope: scope.Local,
 	})
 }
 

--- a/libnetwork/drivers/overlay/overlay.go
+++ b/libnetwork/drivers/overlay/overlay.go
@@ -10,9 +10,9 @@ import (
 	"sync"
 
 	"github.com/containerd/containerd/log"
-	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/discoverapi"
 	"github.com/docker/docker/libnetwork/driverapi"
+	"github.com/docker/docker/libnetwork/scope"
 )
 
 const (
@@ -51,8 +51,8 @@ func Register(r driverapi.Registerer, config map[string]interface{}) error {
 		config: config,
 	}
 	return r.RegisterDriver(NetworkType, d, driverapi.Capability{
-		DataScope:         datastore.GlobalScope,
-		ConnectivityScope: datastore.GlobalScope,
+		DataScope:         scope.Global,
+		ConnectivityScope: scope.Global,
 	})
 }
 

--- a/libnetwork/drivers/overlay/ovmanager/ovmanager.go
+++ b/libnetwork/drivers/overlay/ovmanager/ovmanager.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/containerd/containerd/log"
 	"github.com/docker/docker/libnetwork/bitmap"
-	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/drivers/overlay/overlayutils"
 	"github.com/docker/docker/libnetwork/netlabel"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -48,8 +48,8 @@ type network struct {
 // Register registers a new instance of the overlay driver.
 func Register(r driverapi.Registerer) error {
 	return r.RegisterDriver(networkType, newDriver(), driverapi.Capability{
-		DataScope:         datastore.GlobalScope,
-		ConnectivityScope: datastore.GlobalScope,
+		DataScope:         scope.Global,
+		ConnectivityScope: scope.Global,
 	})
 }
 

--- a/libnetwork/drivers/remote/driver.go
+++ b/libnetwork/drivers/remote/driver.go
@@ -6,10 +6,10 @@ import (
 	"net"
 
 	"github.com/containerd/containerd/log"
-	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/discoverapi"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/drivers/remote/api"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/docker/pkg/plugins"
@@ -97,19 +97,15 @@ func (d *driver) getCapabilities() (*driverapi.Capability, error) {
 
 	c := &driverapi.Capability{}
 	switch capResp.Scope {
-	case "global":
-		c.DataScope = datastore.GlobalScope
-	case "local":
-		c.DataScope = datastore.LocalScope
+	case scope.Global, scope.Local:
+		c.DataScope = capResp.Scope
 	default:
 		return nil, fmt.Errorf("invalid capability: expecting 'local' or 'global', got %s", capResp.Scope)
 	}
 
 	switch capResp.ConnectivityScope {
-	case "global":
-		c.ConnectivityScope = datastore.GlobalScope
-	case "local":
-		c.ConnectivityScope = datastore.LocalScope
+	case scope.Global, scope.Local:
+		c.ConnectivityScope = capResp.ConnectivityScope
 	case "":
 		c.ConnectivityScope = c.DataScope
 	default:

--- a/libnetwork/drivers/remote/driver_test.go
+++ b/libnetwork/drivers/remote/driver_test.go
@@ -14,9 +14,9 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/discoverapi"
 	"github.com/docker/docker/libnetwork/driverapi"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/docker/docker/pkg/plugins"
 )
@@ -276,10 +276,10 @@ func TestGetExtraCapabilities(t *testing.T) {
 	c, err := d.getCapabilities()
 	if err != nil {
 		t.Fatal(err)
-	} else if c.DataScope != datastore.LocalScope {
+	} else if c.DataScope != scope.Local {
 		t.Fatalf("get capability '%s', expecting 'local'", c.DataScope)
-	} else if c.ConnectivityScope != datastore.GlobalScope {
-		t.Fatalf("get capability '%s', expecting %q", c.ConnectivityScope, datastore.GlobalScope)
+	} else if c.ConnectivityScope != scope.Global {
+		t.Fatalf("get capability '%s', expecting %q", c.ConnectivityScope, scope.Global)
 	}
 }
 
@@ -430,7 +430,7 @@ func TestRemoteDriver(t *testing.T) {
 	c, err := d.getCapabilities()
 	if err != nil {
 		t.Fatal(err)
-	} else if c.DataScope != datastore.GlobalScope {
+	} else if c.DataScope != scope.Global {
 		t.Fatalf("get capability '%s', expecting 'global'", c.DataScope)
 	}
 

--- a/libnetwork/drivers/windows/overlay/overlay_windows.go
+++ b/libnetwork/drivers/windows/overlay/overlay_windows.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/Microsoft/hcsshim"
 	"github.com/containerd/containerd/log"
-	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/discoverapi"
 	"github.com/docker/docker/libnetwork/driverapi"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -34,8 +34,8 @@ func Register(r driverapi.Registerer) error {
 	d.restoreHNSNetworks()
 
 	return r.RegisterDriver(NetworkType, d, driverapi.Capability{
-		DataScope:         datastore.GlobalScope,
-		ConnectivityScope: datastore.GlobalScope,
+		DataScope:         scope.Global,
+		ConnectivityScope: scope.Global,
 	})
 }
 

--- a/libnetwork/drivers/windows/windows.go
+++ b/libnetwork/drivers/windows/windows.go
@@ -27,6 +27,7 @@ import (
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/portmapper"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -140,8 +141,8 @@ func RegisterBuiltinLocalDrivers(r driverapi.Registerer, driverConfig func(strin
 		}
 
 		err = r.RegisterDriver(networkType, d, driverapi.Capability{
-			DataScope:         datastore.LocalScope,
-			ConnectivityScope: datastore.LocalScope,
+			DataScope:         scope.Local,
+			ConnectivityScope: scope.Local,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to register %q driver: %w", networkType, err)

--- a/libnetwork/drivers/windows/windows_store.go
+++ b/libnetwork/drivers/windows/windows_store.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/discoverapi"
 	"github.com/docker/docker/libnetwork/netlabel"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -221,7 +222,7 @@ func (ncfg *networkConfiguration) CopyTo(o datastore.KVObject) error {
 }
 
 func (ncfg *networkConfiguration) DataScope() string {
-	return datastore.LocalScope
+	return scope.Local
 }
 
 func (ep *hnsEndpoint) MarshalJSON() ([]byte, error) {
@@ -334,5 +335,5 @@ func (ep *hnsEndpoint) CopyTo(o datastore.KVObject) error {
 }
 
 func (ep *hnsEndpoint) DataScope() string {
-	return datastore.LocalScope
+	return scope.Local
 }

--- a/libnetwork/drvregistry/networks_test.go
+++ b/libnetwork/drvregistry/networks_test.go
@@ -3,8 +3,8 @@ package drvregistry
 import (
 	"testing"
 
-	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/driverapi"
+	"github.com/docker/docker/libnetwork/scope"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -15,7 +15,7 @@ type mockDriver struct {
 	driverapi.Driver
 }
 
-var mockDriverCaps = driverapi.Capability{DataScope: datastore.LocalScope}
+var mockDriverCaps = driverapi.Capability{DataScope: scope.Local}
 
 var md = mockDriver{}
 

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -9,11 +9,11 @@ import (
 	"time"
 
 	"github.com/docker/docker/internal/testutils/netnsutils"
-	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/ipamapi"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/netutils"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 	"gotest.tools/v3/skip"
 )
@@ -639,7 +639,7 @@ type badDriver struct {
 var bd = badDriver{failNetworkCreation: true}
 
 func badDriverRegister(reg driverapi.Registerer) error {
-	return reg.RegisterDriver(badDriverName, &bd, driverapi.Capability{DataScope: datastore.LocalScope})
+	return reg.RegisterDriver(badDriverName, &bd, driverapi.Capability{DataScope: scope.Local})
 }
 
 func (b *badDriver) CreateNetwork(nid string, options map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {

--- a/libnetwork/sandbox_store.go
+++ b/libnetwork/sandbox_store.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/osl"
+	"github.com/docker/docker/libnetwork/scope"
 )
 
 const (
@@ -121,7 +122,7 @@ func (sbs *sbState) CopyTo(o datastore.KVObject) error {
 }
 
 func (sbs *sbState) DataScope() string {
-	return datastore.LocalScope
+	return scope.Local
 }
 
 func (sb *Sandbox) storeUpdate() error {

--- a/libnetwork/scope/scope.go
+++ b/libnetwork/scope/scope.go
@@ -1,0 +1,12 @@
+package scope
+
+// Data scopes.
+const (
+	// Local indicates to store the KV object in local datastore such as boltdb
+	Local = "local"
+	// Global indicates to store the KV object in global datastore
+	Global = "global"
+	// Swarm is not indicating a datastore location. It is defined here
+	// along with the other two scopes just for consistency.
+	Swarm = "swarm"
+)

--- a/libnetwork/store.go
+++ b/libnetwork/store.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containerd/containerd/log"
 	"github.com/docker/docker/libnetwork/datastore"
+	"github.com/docker/docker/libnetwork/scope"
 )
 
 func (c *Controller) initStores() error {
@@ -217,7 +218,7 @@ func (c *Controller) unWatchSvcRecord(ep *Endpoint) {
 
 func (c *Controller) processEndpointCreate(nmap map[string]*netWatch, ep *Endpoint) {
 	n := ep.getNetwork()
-	if !c.isDistributedControl() && n.Scope() == datastore.SwarmScope && n.driverIsMultihost() {
+	if !c.isDistributedControl() && n.Scope() == scope.Swarm && n.driverIsMultihost() {
 		return
 	}
 
@@ -261,7 +262,7 @@ func (c *Controller) processEndpointCreate(nmap map[string]*netWatch, ep *Endpoi
 
 func (c *Controller) processEndpointDelete(nmap map[string]*netWatch, ep *Endpoint) {
 	n := ep.getNetwork()
-	if !c.isDistributedControl() && n.Scope() == datastore.SwarmScope && n.driverIsMultihost() {
+	if !c.isDistributedControl() && n.Scope() == scope.Swarm && n.driverIsMultihost() {
 		return
 	}
 


### PR DESCRIPTION
libnetwork: move Scope const to libnetwork/scope

The "Capability" type defines DataScope and ConnectivityScope fields,
but their value was set from consts in the datastore package, which
required importing that package and its dependencies for the consts
only.

This patch:

- Moves the consts to a separate "scope" package
- Adds aliases for the consts in the datastore package.


**- A picture of a cute animal (not mandatory but encouraged)**

