### PR TITLE
libnetwork/driver: remove discoverAPI from Windows and Windows overlay

### DIFF
--- a/libnetwork/drivers/windows/overlay/overlay_windows.go
+++ b/libnetwork/drivers/windows/overlay/overlay_windows.go
@@ -10,10 +10,8 @@ import (
 
 	"github.com/Microsoft/hcsshim"
 	"github.com/containerd/containerd/log"
-	"github.com/docker/docker/libnetwork/discoverapi"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/scope"
-	"github.com/docker/docker/libnetwork/types"
 )
 
 const (
@@ -110,14 +108,4 @@ func (d *driver) Type() string {
 
 func (d *driver) IsBuiltIn() bool {
 	return true
-}
-
-// DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
-func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
-// DiscoverDelete is a notification for a discovery delete event, such as a node leaving a cluster
-func (d *driver) DiscoverDelete(dType discoverapi.DiscoveryType, data interface{}) error {
-	return types.NotImplementedErrorf("not implemented")
 }

--- a/libnetwork/drivers/windows/windows.go
+++ b/libnetwork/drivers/windows/windows.go
@@ -23,7 +23,6 @@ import (
 	"github.com/Microsoft/hcsshim"
 	"github.com/containerd/containerd/log"
 	"github.com/docker/docker/libnetwork/datastore"
-	"github.com/docker/docker/libnetwork/discoverapi"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/portmapper"
@@ -904,14 +903,4 @@ func (d *driver) Type() string {
 
 func (d *driver) IsBuiltIn() bool {
 	return true
-}
-
-// DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
-func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
-	return nil
-}
-
-// DiscoverDelete is a notification for a discovery delete event, such as a node leaving a cluster
-func (d *driver) DiscoverDelete(dType discoverapi.DiscoveryType, data interface{}) error {
-	return nil
 }


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/46086

Follow-up to fca38bcd0aabcb3ab95705704e6bbc1b317575a4 (https://github.com/moby/moby/pull/46086), which made the Discover API optional for drivers to implement, but forgot to remove the stubs from the Windows drivers, which didn't implement this API.


**- A picture of a cute animal (not mandatory but encouraged)**

