### PR TITLE
libnetwork: remove some dead code, and un-export internal functions

### DIFF
--- a/libnetwork/drivers/bridge/bridge_test.go
+++ b/libnetwork/drivers/bridge/bridge_test.go
@@ -148,10 +148,48 @@ func compareConnConfig(a, b *connectivityConfiguration) bool {
 		}
 	}
 	for i := 0; i < len(a.PortBindings); i++ {
-		if !a.PortBindings[i].Equal(&b.PortBindings[i]) {
+		if !comparePortBinding(&a.PortBindings[i], &b.PortBindings[i]) {
 			return false
 		}
 	}
+	return true
+}
+
+// comparePortBinding returns whether the given PortBindings are equal.
+func comparePortBinding(p *types.PortBinding, o *types.PortBinding) bool {
+	if p == o {
+		return true
+	}
+
+	if o == nil {
+		return false
+	}
+
+	if p.Proto != o.Proto || p.Port != o.Port ||
+		p.HostPort != o.HostPort || p.HostPortEnd != o.HostPortEnd {
+		return false
+	}
+
+	if p.IP != nil {
+		if !p.IP.Equal(o.IP) {
+			return false
+		}
+	} else {
+		if o.IP != nil {
+			return false
+		}
+	}
+
+	if p.HostIP != nil {
+		if !p.HostIP.Equal(o.HostIP) {
+			return false
+		}
+	} else {
+		if o.HostIP != nil {
+			return false
+		}
+	}
+
 	return true
 }
 
@@ -160,7 +198,7 @@ func compareBindings(a, b []types.PortBinding) bool {
 		return false
 	}
 	for i := 0; i < len(a); i++ {
-		if !a[i].Equal(&b[i]) {
+		if !comparePortBinding(&a[i], &b[i]) {
 			return false
 		}
 	}
@@ -674,7 +712,7 @@ func testQueryEndpointInfo(t *testing.T, ulPxyEnabled bool) {
 		t.Fatal("Incomplete data for port mapping in endpoint operational data")
 	}
 	for i, pb := range ep.portMapping {
-		if !pb.Equal(&pm[i]) {
+		if !comparePortBinding(&pb, &pm[i]) {
 			t.Fatal("Unexpected data for port mapping in endpoint operational data")
 		}
 	}

--- a/libnetwork/drivers/overlay/encryption.go
+++ b/libnetwork/drivers/overlay/encryption.go
@@ -352,6 +352,16 @@ func programSA(localIP, remoteIP net.IP, spi *spi, k *key, dir int, add bool) (f
 	return
 }
 
+// getMinimalIP returns the address in its shortest form
+// If ip contains an IPv4-mapped IPv6 address, the 4-octet form of the IPv4 address will be returned.
+// Otherwise ip is returned unchanged.
+func getMinimalIP(ip net.IP) net.IP {
+	if ip != nil && ip.To4() != nil {
+		return ip.To4()
+	}
+	return ip
+}
+
 func programSP(fSA *netlink.XfrmState, rSA *netlink.XfrmState, add bool) error {
 	action := "Removing"
 	xfrmProgram := ns.NlHandle().XfrmPolicyDel
@@ -361,8 +371,8 @@ func programSP(fSA *netlink.XfrmState, rSA *netlink.XfrmState, add bool) error {
 	}
 
 	// Create a congruent cidr
-	s := types.GetMinimalIP(fSA.Src)
-	d := types.GetMinimalIP(fSA.Dst)
+	s := getMinimalIP(fSA.Src)
+	d := getMinimalIP(fSA.Dst)
 	fullMask := net.CIDRMask(8*len(s), 8*len(s))
 
 	fPol := &netlink.XfrmPolicy{
@@ -575,8 +585,8 @@ func updateNodeKey(lIP, aIP, rIP net.IP, idxs []*spi, curKeys []*key, newIdx, pr
 		fSA2, _, _ := programSA(lIP, rIP, spis[priIdx], curKeys[priIdx], forward, true)
 
 		// +fSP2, -fSP1
-		s := types.GetMinimalIP(fSA2.Src)
-		d := types.GetMinimalIP(fSA2.Dst)
+		s := getMinimalIP(fSA2.Src)
+		d := getMinimalIP(fSA2.Dst)
 		fullMask := net.CIDRMask(8*len(s), 8*len(s))
 
 		fSP1 := &netlink.XfrmPolicy{

--- a/libnetwork/error.go
+++ b/libnetwork/error.go
@@ -1,7 +1,6 @@
 package libnetwork
 
 import (
-	"errors"
 	"fmt"
 )
 
@@ -108,7 +107,3 @@ func (mr ManagerRedirectError) Error() string {
 
 // Maskable denotes the type of this error
 func (mr ManagerRedirectError) Maskable() {}
-
-// ErrDataStoreNotInitialized is returned if an invalid data scope is passed
-// for getting data store
-var ErrDataStoreNotInitialized = errors.New("datastore is not initialized")

--- a/libnetwork/error.go
+++ b/libnetwork/error.go
@@ -25,17 +25,6 @@ func (nse ErrNoSuchEndpoint) Error() string {
 // NotFound denotes the type of this error
 func (nse ErrNoSuchEndpoint) NotFound() {}
 
-// ErrInvalidJoin is returned if a join is attempted on an endpoint
-// which already has a container joined.
-type ErrInvalidJoin struct{}
-
-func (ij ErrInvalidJoin) Error() string {
-	return "a container has already joined the endpoint"
-}
-
-// BadRequest denotes the type of this error
-func (ij ErrInvalidJoin) BadRequest() {}
-
 // ErrNoContainer is returned when the endpoint has no container
 // attached to it.
 type ErrNoContainer struct{}

--- a/libnetwork/error.go
+++ b/libnetwork/error.go
@@ -47,13 +47,6 @@ func (in ErrInvalidName) Error() string {
 // BadRequest denotes the type of this error
 func (in ErrInvalidName) BadRequest() {}
 
-// ErrInvalidConfigFile type is returned when an invalid LibNetwork config file is detected
-type ErrInvalidConfigFile string
-
-func (cf ErrInvalidConfigFile) Error() string {
-	return fmt.Sprintf("Invalid Config file %q", string(cf))
-}
-
 // NetworkTypeError type is returned when the network type string is not
 // known to libnetwork.
 type NetworkTypeError string

--- a/libnetwork/error.go
+++ b/libnetwork/error.go
@@ -85,20 +85,6 @@ func (aee *ActiveEndpointsError) Error() string {
 // Forbidden denotes the type of this error
 func (aee *ActiveEndpointsError) Forbidden() {}
 
-// UnknownEndpointError is returned when libnetwork could not find in its database
-// an endpoint with the same name and id.
-type UnknownEndpointError struct {
-	name string
-	id   string
-}
-
-func (uee *UnknownEndpointError) Error() string {
-	return fmt.Sprintf("unknown endpoint %s id %s", uee.name, uee.id)
-}
-
-// NotFound denotes the type of this error
-func (uee *UnknownEndpointError) NotFound() {}
-
 // ActiveContainerError is returned when an endpoint is deleted which has active
 // containers attached to it.
 type ActiveContainerError struct {

--- a/libnetwork/error.go
+++ b/libnetwork/error.go
@@ -25,17 +25,6 @@ func (nse ErrNoSuchEndpoint) Error() string {
 // NotFound denotes the type of this error
 func (nse ErrNoSuchEndpoint) NotFound() {}
 
-// ErrInvalidNetworkDriver is returned if an invalid driver
-// name is passed.
-type ErrInvalidNetworkDriver string
-
-func (ind ErrInvalidNetworkDriver) Error() string {
-	return fmt.Sprintf("invalid driver bound to network: %s", string(ind))
-}
-
-// BadRequest denotes the type of this error
-func (ind ErrInvalidNetworkDriver) BadRequest() {}
-
 // ErrInvalidJoin is returned if a join is attempted on an endpoint
 // which already has a container joined.
 type ErrInvalidJoin struct{}

--- a/libnetwork/error.go
+++ b/libnetwork/error.go
@@ -99,17 +99,6 @@ func (ace *ActiveContainerError) Error() string {
 // Forbidden denotes the type of this error
 func (ace *ActiveContainerError) Forbidden() {}
 
-// InvalidContainerIDError is returned when an invalid container id is passed
-// in Join/Leave
-type InvalidContainerIDError string
-
-func (id InvalidContainerIDError) Error() string {
-	return fmt.Sprintf("invalid container id %s", string(id))
-}
-
-// BadRequest denotes the type of this error
-func (id InvalidContainerIDError) BadRequest() {}
-
 // ManagerRedirectError is returned when the request should be redirected to Manager
 type ManagerRedirectError string
 

--- a/libnetwork/error.go
+++ b/libnetwork/error.go
@@ -47,17 +47,6 @@ func (in ErrInvalidName) Error() string {
 // BadRequest denotes the type of this error
 func (in ErrInvalidName) BadRequest() {}
 
-// NetworkTypeError type is returned when the network type string is not
-// known to libnetwork.
-type NetworkTypeError string
-
-func (nt NetworkTypeError) Error() string {
-	return fmt.Sprintf("unknown driver %q", string(nt))
-}
-
-// NotFound denotes the type of this error
-func (nt NetworkTypeError) NotFound() {}
-
 // NetworkNameError is returned when a network with the same name already exists.
 type NetworkNameError string
 

--- a/libnetwork/error.go
+++ b/libnetwork/error.go
@@ -25,17 +25,6 @@ func (nse ErrNoSuchEndpoint) Error() string {
 // NotFound denotes the type of this error
 func (nse ErrNoSuchEndpoint) NotFound() {}
 
-// ErrNoContainer is returned when the endpoint has no container
-// attached to it.
-type ErrNoContainer struct{}
-
-func (nc ErrNoContainer) Error() string {
-	return "no container is attached to the endpoint"
-}
-
-// Maskable denotes the type of this error
-func (nc ErrNoContainer) Maskable() {}
-
 // ErrInvalidID is returned when a query-by-id method is being invoked
 // with an empty id parameter
 type ErrInvalidID string

--- a/libnetwork/errors_test.go
+++ b/libnetwork/errors_test.go
@@ -25,7 +25,7 @@ func TestErrorInterfaces(t *testing.T) {
 		}
 	}
 
-	notFoundErrorList := []error{NetworkTypeError(""), &UnknownNetworkError{}, &UnknownEndpointError{}, ErrNoSuchNetwork(""), ErrNoSuchEndpoint("")}
+	notFoundErrorList := []error{&UnknownNetworkError{}, &UnknownEndpointError{}, ErrNoSuchNetwork(""), ErrNoSuchEndpoint("")}
 	for _, err := range notFoundErrorList {
 		switch u := err.(type) {
 		case types.NotFoundError:

--- a/libnetwork/errors_test.go
+++ b/libnetwork/errors_test.go
@@ -16,7 +16,7 @@ func TestErrorInterfaces(t *testing.T) {
 		}
 	}
 
-	maskableErrorList := []error{ErrNoContainer{}}
+	maskableErrorList := []error{ManagerRedirectError("")}
 	for _, err := range maskableErrorList {
 		switch u := err.(type) {
 		case types.MaskableError:

--- a/libnetwork/errors_test.go
+++ b/libnetwork/errors_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestErrorInterfaces(t *testing.T) {
-	badRequestErrorList := []error{ErrInvalidID(""), ErrInvalidName(""), ErrInvalidJoin{}, ErrInvalidNetworkDriver(""), InvalidContainerIDError("")}
+	badRequestErrorList := []error{ErrInvalidID(""), ErrInvalidName(""), ErrInvalidJoin{}, InvalidContainerIDError("")}
 	for _, err := range badRequestErrorList {
 		switch u := err.(type) {
 		case types.BadRequestError:

--- a/libnetwork/errors_test.go
+++ b/libnetwork/errors_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestErrorInterfaces(t *testing.T) {
-	badRequestErrorList := []error{ErrInvalidID(""), ErrInvalidName(""), ErrInvalidJoin{}, InvalidContainerIDError("")}
+	badRequestErrorList := []error{ErrInvalidID(""), ErrInvalidName(""), InvalidContainerIDError("")}
 	for _, err := range badRequestErrorList {
 		switch u := err.(type) {
 		case types.BadRequestError:

--- a/libnetwork/errors_test.go
+++ b/libnetwork/errors_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestErrorInterfaces(t *testing.T) {
-	badRequestErrorList := []error{ErrInvalidID(""), ErrInvalidName(""), InvalidContainerIDError("")}
+	badRequestErrorList := []error{ErrInvalidID(""), ErrInvalidName("")}
 	for _, err := range badRequestErrorList {
 		switch u := err.(type) {
 		case types.BadRequestError:

--- a/libnetwork/errors_test.go
+++ b/libnetwork/errors_test.go
@@ -25,7 +25,7 @@ func TestErrorInterfaces(t *testing.T) {
 		}
 	}
 
-	notFoundErrorList := []error{&UnknownNetworkError{}, &UnknownEndpointError{}, ErrNoSuchNetwork(""), ErrNoSuchEndpoint("")}
+	notFoundErrorList := []error{&UnknownNetworkError{}, ErrNoSuchNetwork(""), ErrNoSuchEndpoint("")}
 	for _, err := range notFoundErrorList {
 		switch u := err.(type) {
 		case types.NotFoundError:

--- a/libnetwork/store.go
+++ b/libnetwork/store.go
@@ -157,7 +157,7 @@ func (n *Network) getEndpointsFromStore() ([]*Endpoint, error) {
 func (c *Controller) updateToStore(kvObject datastore.KVObject) error {
 	cs := c.getStore()
 	if cs == nil {
-		return ErrDataStoreNotInitialized
+		return fmt.Errorf("datastore is not initialized")
 	}
 
 	if err := cs.PutObjectAtomic(kvObject); err != nil {
@@ -173,7 +173,7 @@ func (c *Controller) updateToStore(kvObject datastore.KVObject) error {
 func (c *Controller) deleteFromStore(kvObject datastore.KVObject) error {
 	cs := c.getStore()
 	if cs == nil {
-		return ErrDataStoreNotInitialized
+		return fmt.Errorf("datastore is not initialized")
 	}
 
 retry:

--- a/libnetwork/types/types.go
+++ b/libnetwork/types/types.go
@@ -226,16 +226,6 @@ func CompareIPNet(a, b *net.IPNet) bool {
 	return a.IP.Equal(b.IP) && bytes.Equal(a.Mask, b.Mask)
 }
 
-// GetMinimalIP returns the address in its shortest form
-// If ip contains an IPv4-mapped IPv6 address, the 4-octet form of the IPv4 address will be returned.
-// Otherwise ip is returned unchanged.
-func GetMinimalIP(ip net.IP) net.IP {
-	if ip != nil && ip.To4() != nil {
-		return ip.To4()
-	}
-	return ip
-}
-
 // IsIPNetValid returns true if the ipnet is a valid network/mask
 // combination. Otherwise returns false.
 func IsIPNetValid(nw *net.IPNet) bool {

--- a/libnetwork/types/types.go
+++ b/libnetwork/types/types.go
@@ -413,12 +413,6 @@ type MaskableError interface {
 	Maskable()
 }
 
-// RetryError is an interface for errors which might get resolved through retry
-type RetryError interface {
-	// Retry makes implementer into RetryError type
-	Retry()
-}
-
 // BadRequestError is an interface for errors originated by a bad request
 type BadRequestError interface {
 	// BadRequest makes implementer into BadRequestError type
@@ -441,12 +435,6 @@ type ForbiddenError interface {
 type NoServiceError interface {
 	// NoService makes implementer into NoServiceError type
 	NoService()
-}
-
-// TimeoutError is an interface for errors raised because of timeout
-type TimeoutError interface {
-	// Timeout makes implementer into TimeoutError type
-	Timeout()
 }
 
 // NotImplementedError is an interface for errors raised because of requested functionality is not yet implemented
@@ -490,11 +478,6 @@ func NotImplementedErrorf(format string, params ...interface{}) error {
 	return notImpl(fmt.Sprintf(format, params...))
 }
 
-// TimeoutErrorf creates an instance of TimeoutError
-func TimeoutErrorf(format string, params ...interface{}) error {
-	return timeout(fmt.Sprintf(format, params...))
-}
-
 // InternalErrorf creates an instance of InternalError
 func InternalErrorf(format string, params ...interface{}) error {
 	return internal(fmt.Sprintf(format, params...))
@@ -503,11 +486,6 @@ func InternalErrorf(format string, params ...interface{}) error {
 // InternalMaskableErrorf creates an instance of InternalError and MaskableError
 func InternalMaskableErrorf(format string, params ...interface{}) error {
 	return maskInternal(fmt.Sprintf(format, params...))
-}
-
-// RetryErrorf creates an instance of RetryError
-func RetryErrorf(format string, params ...interface{}) error {
-	return retry(fmt.Sprintf(format, params...))
 }
 
 /***********************
@@ -541,13 +519,6 @@ func (ns noService) Error() string {
 }
 func (ns noService) NoService() {}
 
-type timeout string
-
-func (to timeout) Error() string {
-	return string(to)
-}
-func (to timeout) Timeout() {}
-
 type notImpl string
 
 func (ni notImpl) Error() string {
@@ -569,10 +540,3 @@ func (mnt maskInternal) Error() string {
 }
 func (mnt maskInternal) Internal() {}
 func (mnt maskInternal) Maskable() {}
-
-type retry string
-
-func (r retry) Error() string {
-	return string(r)
-}
-func (r retry) Retry() {}

--- a/libnetwork/types/types.go
+++ b/libnetwork/types/types.go
@@ -86,7 +86,7 @@ func (p PortBinding) HostAddr() (net.Addr, error) {
 	case SCTP:
 		return &sctp.SCTPAddr{IPAddrs: []net.IPAddr{{IP: p.HostIP}}, Port: int(p.HostPort)}, nil
 	default:
-		return nil, ErrInvalidProtocolBinding(p.Proto.String())
+		return nil, fmt.Errorf("invalid transport protocol: %s", p.Proto.String())
 	}
 }
 
@@ -100,7 +100,7 @@ func (p PortBinding) ContainerAddr() (net.Addr, error) {
 	case SCTP:
 		return &sctp.SCTPAddr{IPAddrs: []net.IPAddr{{IP: p.IP}}, Port: int(p.Port)}, nil
 	default:
-		return nil, ErrInvalidProtocolBinding(p.Proto.String())
+		return nil, fmt.Errorf("invalid transport protocol: %s", p.Proto.String())
 	}
 }
 
@@ -128,13 +128,6 @@ func (p *PortBinding) String() string {
 	}
 	ret = fmt.Sprintf("%s:%d", ret, p.HostPort)
 	return ret
-}
-
-// ErrInvalidProtocolBinding is returned when the port binding protocol is not valid.
-type ErrInvalidProtocolBinding string
-
-func (ipb ErrInvalidProtocolBinding) Error() string {
-	return fmt.Sprintf("invalid transport protocol: %s", string(ipb))
 }
 
 const (

--- a/libnetwork/types/types.go
+++ b/libnetwork/types/types.go
@@ -28,9 +28,6 @@ type EncryptionKey struct {
 	LamportTime uint64
 }
 
-// UUID represents a globally unique ID of various resources like network and endpoint
-type UUID string
-
 // QosPolicy represents a quality of service policy on an endpoint
 type QosPolicy struct {
 	MaxEgressBandwidth uint64

--- a/libnetwork/types/types.go
+++ b/libnetwork/types/types.go
@@ -130,44 +130,6 @@ func (p *PortBinding) String() string {
 	return ret
 }
 
-// Equal checks if this instance of PortBinding is equal to the passed one
-func (p *PortBinding) Equal(o *PortBinding) bool {
-	if p == o {
-		return true
-	}
-
-	if o == nil {
-		return false
-	}
-
-	if p.Proto != o.Proto || p.Port != o.Port ||
-		p.HostPort != o.HostPort || p.HostPortEnd != o.HostPortEnd {
-		return false
-	}
-
-	if p.IP != nil {
-		if !p.IP.Equal(o.IP) {
-			return false
-		}
-	} else {
-		if o.IP != nil {
-			return false
-		}
-	}
-
-	if p.HostIP != nil {
-		if !p.HostIP.Equal(o.HostIP) {
-			return false
-		}
-	} else {
-		if o.HostIP != nil {
-			return false
-		}
-	}
-
-	return true
-}
-
 // ErrInvalidProtocolBinding is returned when the port binding protocol is not valid.
 type ErrInvalidProtocolBinding string
 

--- a/libnetwork/types/types_test.go
+++ b/libnetwork/types/types_test.go
@@ -19,17 +19,6 @@ func TestErrorConstructors(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = RetryErrorf("Incy wincy %s went up the spout again", "spider")
-	if err.Error() != "Incy wincy spider went up the spout again" {
-		t.Fatal(err)
-	}
-	if _, ok := err.(RetryError); !ok {
-		t.Fatal(err)
-	}
-	if _, ok := err.(MaskableError); ok {
-		t.Fatal(err)
-	}
-
 	err = NotFoundErrorf("Can't find the %s", "keys")
 	if err.Error() != "Can't find the keys" {
 		t.Fatal(err)
@@ -57,17 +46,6 @@ func TestErrorConstructors(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, ok := err.(NotImplementedError); !ok {
-		t.Fatal(err)
-	}
-	if _, ok := err.(MaskableError); ok {
-		t.Fatal(err)
-	}
-
-	err = TimeoutErrorf("Process %s timed out", "abc")
-	if err.Error() != "Process abc timed out" {
-		t.Fatal(err)
-	}
-	if _, ok := err.(TimeoutError); !ok {
 		t.Fatal(err)
 	}
 	if _, ok := err.(MaskableError); ok {


### PR DESCRIPTION
### libnetwork/types: remove unused RetryError and TimeoutError

### libnetwork/types: remove unused UUID type

This type was added moved to the types package as part of a refactor
in https://github.com/moby/libnetwork/commit/778e2a72b3c6b739d8a9d430b99c75d6ef35f797
but the introduction of the sandbox API changed the existing API to
weak types (not using a plain string);
https://github.com/moby/libnetwork/commit/9a47be244afb706a919fdafa4daef20d3d1b8510

### libnetwork/types: remove PortBinding.Equal

It was only used in tests, so move it to a utility in the tests.

### libnetwork/types: remove ErrInvalidProtocolBinding

It was not used as a sentinel error, and didn't carry a specific type,
which made it a rather complex way to create an error.

### libnetwork/types: move GetMinimalIP to overlay-driver and un-export

It was only used in drivers/overlay, and was not a function for any
"type" defined by libnetwork.

### libnetwork: remove unused ErrInvalidNetworkDriver

### libnetwork: remove unused ErrInvalidJoin

### libnetwork: remove unused ErrNoContainer

### libnetwork: remove unused ErrInvalidConfigFile

### libnetwork: remove unused NetworkTypeError

### libnetwork: remove unused UnknownEndpointError

### libnetwork: remove unused InvalidContainerIDError

### libnetwork: remove ErrDataStoreNotInitialized

If was not used as a sentinel error, so inline the error.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

