### PR TITLE
daemon: remove --oom-score-adjust flag

### DIFF
--- a/cmd/dockerd/config_unix.go
+++ b/cmd/dockerd/config_unix.go
@@ -45,9 +45,6 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.StringVar(&conf.CgroupParent, "cgroup-parent", "", "Set parent cgroup for all containers")
 	flags.StringVar(&conf.RemappedRoot, "userns-remap", "", "User/Group setting for user namespaces")
 	flags.BoolVar(&conf.LiveRestoreEnabled, "live-restore", false, "Enable live restore of docker when containers are still running")
-	// TODO(thaJeztah): Used to produce a deprecation error; remove the flag and the OOMScoreAdjust field for the next release after v25.0.0.
-	flags.IntVar(&conf.OOMScoreAdjust, "oom-score-adjust", 0, "Set the oom_score_adj for the daemon (deprecated)")
-	_ = flags.MarkDeprecated("oom-score-adjust", "and will be removed in the next release.")
 	flags.BoolVar(&conf.Init, "init", false, "Run an init in the container to forward signals and reap processes")
 	flags.StringVar(&conf.InitPath, "init-path", "", "Path to the docker-init binary")
 	flags.Int64Var(&conf.CPURealtimePeriod, "cpu-rt-period", 0, "Limit the CPU real-time period in microseconds for the parent cgroup for all containers (not supported with cgroups v2)")

--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -83,7 +83,6 @@ type Config struct {
 	Ulimits              map[string]*units.Ulimit  `json:"default-ulimits,omitempty"`
 	CPURealtimePeriod    int64                     `json:"cpu-rt-period,omitempty"`
 	CPURealtimeRuntime   int64                     `json:"cpu-rt-runtime,omitempty"`
-	OOMScoreAdjust       int                       `json:"oom-score-adjust,omitempty"` // Deprecated: configure the daemon's oom-score-adjust using a process manager instead.
 	Init                 bool                      `json:"init,omitempty"`
 	InitPath             string                    `json:"init-path,omitempty"`
 	SeccompProfile       string                    `json:"seccomp-profile,omitempty"`
@@ -178,10 +177,6 @@ func verifyDefaultCgroupNsMode(mode string) error {
 
 // ValidatePlatformConfig checks if any platform-specific configuration settings are invalid.
 func (conf *Config) ValidatePlatformConfig() error {
-	if conf.OOMScoreAdjust != 0 {
-		return errors.New(`DEPRECATED: The "oom-score-adjust" config parameter and the dockerd "--oom-score-adjust" options have been removed.`)
-	}
-
 	if conf.EnableUserlandProxy {
 		if conf.UserlandProxyPath == "" {
 			return errors.New("invalid userland-proxy-path: userland-proxy is enabled, but userland-proxy-path is not set")


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/45315

**- What I did**

This flag was marked as deprecated in commit 5a922dc16 (released in v24.0) and to be removed in the next release.

**- Description for the changelog**

* The daemon flag `--oom-score-adjust` has been deprecated in v24.0 and is now removed.
