### PR TITLE
logger/fluentd: remove deprecated fluentd-async-connect option

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -329,6 +329,16 @@ func (daemon *Daemon) restore(cfg *configStore) error {
 						delete(c.NetworkSettings.Networks, networktypes.NetworkDefault)
 					}
 				}
+
+				// The logger option 'fluentd-async-connect' has been
+				// deprecated in v20.10 in favor of 'fluentd-async', and
+				// removed in v28.0.
+				// TODO(aker): remove this migration once the next LTS version of MCR is released.
+				if _, ok := c.HostConfig.LogConfig.Config["fluentd-async-connect"]; ok {
+					if _, ok := c.HostConfig.LogConfig.Config["fluentd-async"]; !ok {
+						c.HostConfig.LogConfig.Config["fluentd-async"] = c.HostConfig.LogConfig.Config["fluentd-async-connect"]
+					}
+				}
 			}
 
 			if err := daemon.checkpointAndSave(c); err != nil {

--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -52,7 +52,6 @@ const (
 
 	addressKey                = "fluentd-address"
 	asyncKey                  = "fluentd-async"
-	asyncConnectKey           = "fluentd-async-connect" // deprecated option (use fluent-async instead)
 	asyncReconnectIntervalKey = "fluentd-async-reconnect-interval"
 	bufferLimitKey            = "fluentd-buffer-limit"
 	maxRetriesKey             = "fluentd-max-retries"
@@ -149,7 +148,6 @@ func ValidateLogOpt(cfg map[string]string) error {
 
 		case addressKey:
 		case asyncKey:
-		case asyncConnectKey:
 		case asyncReconnectIntervalKey:
 		case bufferLimitKey:
 		case maxRetriesKey:
@@ -201,21 +199,9 @@ func parseConfig(cfg map[string]string) (fluent.Config, error) {
 		maxRetries = int(mr64)
 	}
 
-	if cfg[asyncKey] != "" && cfg[asyncConnectKey] != "" {
-		return config, errors.Errorf("conflicting options: cannot specify both '%s' and '%s", asyncKey, asyncConnectKey)
-	}
-
 	async := false
 	if cfg[asyncKey] != "" {
 		if async, err = strconv.ParseBool(cfg[asyncKey]); err != nil {
-			return config, err
-		}
-	}
-
-	// TODO fluentd-async-connect is deprecated in driver v1.4.0. Remove after two stable releases
-	asyncConnect := false
-	if cfg[asyncConnectKey] != "" {
-		if asyncConnect, err = strconv.ParseBool(cfg[asyncConnectKey]); err != nil {
 			return config, err
 		}
 	}
@@ -256,11 +242,10 @@ func parseConfig(cfg map[string]string) (fluent.Config, error) {
 		RetryWait:              retryWait,
 		MaxRetry:               maxRetries,
 		Async:                  async,
-		AsyncConnect:           asyncConnect,
 		AsyncReconnectInterval: asyncReconnectInterval,
 		SubSecondPrecision:     subSecondPrecision,
 		RequestAck:             requestAck,
-		ForceStopAsyncSend:     async || asyncConnect,
+		ForceStopAsyncSend:     async,
 	}
 
 	return config, nil


### PR DESCRIPTION
Related:

- https://github.com/docker/cli/pull/5740

**- What I did**

This option was marked as deprecated in cc1f3c750 (released in v20.10). The option `fluentd-async`, introduced in the same commit, should be used instead.

There's no target for removal defined in our docs (cf. https://docs.docker.com/engine/deprecated/#fluentd-async-connect-log-opt), but let's see what other maintainers think about dropping it in v25.0 or v26.0.

**- Description for the changelog**

```markdown changelog
- The Fluent logger option `fluentd-async-connect` has been deprecated in v20.10 and is now removed.
```