### PR TITLE
vendor: gotest.tools/v3 v3.5.0

### DIFF
--- a/hack/validate/golangci-lint.yml
+++ b/hack/validate/golangci-lint.yml
@@ -126,6 +126,10 @@ issues:
     - text: "SA1019: httputil.ErrPersistEOF"
       linters:
         - staticcheck
+    # FIXME temporarily suppress these (see https://github.com/gotestyourself/gotest.tools/issues/272)
+    - text: "SA1019: (assert|cmp|is)\\.ErrorType is deprecated"
+      linters:
+        - staticcheck
 
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-issues-per-linter: 0

--- a/vendor.mod
+++ b/vendor.mod
@@ -101,7 +101,7 @@ require (
 	golang.org/x/time v0.3.0
 	google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4
 	google.golang.org/grpc v1.53.0
-	gotest.tools/v3 v3.4.0
+	gotest.tools/v3 v3.5.0
 	resenje.org/singleflight v0.3.0
 )
 

--- a/vendor.sum
+++ b/vendor.sum
@@ -1738,7 +1738,6 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201202213521-69691e467435/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210303074136-134d130e1a04/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1865,7 +1864,6 @@ golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200916195026-c9a70fc28ce3/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
@@ -2042,8 +2040,8 @@ gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
-gotest.tools/v3 v3.4.0 h1:ZazjZUfuVeZGLAmlKKuyv3IKP5orXcwtOwDQH6YVr6o=
-gotest.tools/v3 v3.4.0/go.mod h1:CtbdzLSsqVhDgMtKsx03ird5YTGB3ar27v0u/yKBW5g=
+gotest.tools/v3 v3.5.0 h1:Ljk6PdHdOhAb5aDMWXjDLMMhph+BpztA4v1QdqEW2eY=
+gotest.tools/v3 v3.5.0/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20180920025451-e3ad64cb4ed3/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/vendor/gotest.tools/v3/assert/assert.go
+++ b/vendor/gotest.tools/v3/assert/assert.go
@@ -4,7 +4,7 @@ values in tests. When an assertion fails a helpful error message is printed.
 
 # Example usage
 
-All the assertions in this package use testing.T.Helper to mark themselves as
+All the assertions in this package use [testing.T.Helper] to mark themselves as
 test helpers. This allows the testing package to print the filename and line
 number of the file function that failed.
 
@@ -67,19 +67,19 @@ message is omitted from these examples for brevity.
 
 # Assert and Check
 
-Assert and Check are very similar, they both accept a Comparison, and fail
+[Assert] and [Check] are very similar, they both accept a [cmp.Comparison], and fail
 the test when the comparison fails. The one difference is that Assert uses
-testing.T.FailNow to fail the test, which will end the test execution immediately.
-Check uses testing.T.Fail to fail the test, which allows it to return the
+[testing.T.FailNow] to fail the test, which will end the test execution immediately.
+Check uses [testing.T.Fail] to fail the test, which allows it to return the
 result of the comparison, then proceed with the rest of the test case.
 
-Like testing.T.FailNow, Assert must be called from the goroutine running the test,
-not from other goroutines created during the test. Check is safe to use from any
+Like [testing.T.FailNow], [Assert] must be called from the goroutine running the test,
+not from other goroutines created during the test. [Check] is safe to use from any
 goroutine.
 
 # Comparisons
 
-Package http://pkg.go.dev/gotest.tools/v3/assert/cmp provides
+Package [gotest.tools/v3/assert/cmp] provides
 many common comparisons. Additional comparisons can be written to compare
 values in other ways. See the example Assert (CustomComparison).
 
@@ -98,11 +98,11 @@ import (
 	"gotest.tools/v3/internal/assert"
 )
 
-// BoolOrComparison can be a bool, cmp.Comparison, or error. See Assert for
+// BoolOrComparison can be a bool, [cmp.Comparison], or error. See [Assert] for
 // details about how this type is used.
 type BoolOrComparison interface{}
 
-// TestingT is the subset of testing.T used by the assert package.
+// TestingT is the subset of [testing.T] (see also [testing.TB]) used by the assert package.
 type TestingT interface {
 	FailNow()
 	Fail()
@@ -133,11 +133,11 @@ type helperT interface {
 //
 // Extra details can be added to the failure message using msgAndArgs. msgAndArgs
 // may be either a single string, or a format string and args that will be
-// passed to fmt.Sprintf.
+// passed to [fmt.Sprintf].
 //
-// Assert uses t.FailNow to fail the test. Like t.FailNow, Assert must be called
+// Assert uses [testing.TB.FailNow] to fail the test. Like t.FailNow, Assert must be called
 // from the goroutine running the test function, not from other
-// goroutines created during the test. Use Check from other goroutines.
+// goroutines created during the test. Use [Check] from other goroutines.
 func Assert(t TestingT, comparison BoolOrComparison, msgAndArgs ...interface{}) {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
@@ -151,7 +151,7 @@ func Assert(t TestingT, comparison BoolOrComparison, msgAndArgs ...interface{}) 
 // failed, a failure message is printed, and Check returns false. If the comparison
 // is successful Check returns true. Check may be called from any goroutine.
 //
-// See Assert for details about the comparison arg and failure messages.
+// See [Assert] for details about the comparison arg and failure messages.
 func Check(t TestingT, comparison BoolOrComparison, msgAndArgs ...interface{}) bool {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
@@ -166,9 +166,9 @@ func Check(t TestingT, comparison BoolOrComparison, msgAndArgs ...interface{}) b
 // NilError fails the test immediately if err is not nil, and includes err.Error
 // in the failure message.
 //
-// NilError uses t.FailNow to fail the test. Like t.FailNow, NilError must be
+// NilError uses [testing.TB.FailNow] to fail the test. Like t.FailNow, NilError must be
 // called from the goroutine running the test function, not from other
-// goroutines created during the test. Use Check from other goroutines.
+// goroutines created during the test. Use [Check] from other goroutines.
 func NilError(t TestingT, err error, msgAndArgs ...interface{}) {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
@@ -193,9 +193,9 @@ func NilError(t TestingT, err error, msgAndArgs ...interface{}) {
 // the unified diff will be augmented by replacing whitespace characters with
 // visible characters to identify the whitespace difference.
 //
-// Equal uses t.FailNow to fail the test. Like t.FailNow, Equal must be
+// Equal uses [testing.T.FailNow] to fail the test. Like t.FailNow, Equal must be
 // called from the goroutine running the test function, not from other
-// goroutines created during the test. Use Check with cmp.Equal from other
+// goroutines created during the test. Use [Check] with [cmp.Equal] from other
 // goroutines.
 func Equal(t TestingT, x, y interface{}, msgAndArgs ...interface{}) {
 	if ht, ok := t.(helperT); ok {
@@ -206,15 +206,15 @@ func Equal(t TestingT, x, y interface{}, msgAndArgs ...interface{}) {
 	}
 }
 
-// DeepEqual uses google/go-cmp (https://godoc.org/github.com/google/go-cmp/cmp)
+// DeepEqual uses [github.com/google/go-cmp/cmp]
 // to assert two values are equal and fails the test if they are not equal.
 //
-// Package http://pkg.go.dev/gotest.tools/v3/assert/opt provides some additional
+// Package [gotest.tools/v3/assert/opt] provides some additional
 // commonly used Options.
 //
-// DeepEqual uses t.FailNow to fail the test. Like t.FailNow, DeepEqual must be
+// DeepEqual uses [testing.T.FailNow] to fail the test. Like t.FailNow, DeepEqual must be
 // called from the goroutine running the test function, not from other
-// goroutines created during the test. Use Check with cmp.DeepEqual from other
+// goroutines created during the test. Use [Check] with [cmp.DeepEqual] from other
 // goroutines.
 func DeepEqual(t TestingT, x, y interface{}, opts ...gocmp.Option) {
 	if ht, ok := t.(helperT); ok {
@@ -227,13 +227,13 @@ func DeepEqual(t TestingT, x, y interface{}, opts ...gocmp.Option) {
 
 // Error fails the test if err is nil, or if err.Error is not equal to expected.
 // Both err.Error and expected will be included in the failure message.
-// Error performs an exact match of the error text. Use ErrorContains if only
-// part of the error message is relevant. Use ErrorType or ErrorIs to compare
+// Error performs an exact match of the error text. Use [ErrorContains] if only
+// part of the error message is relevant. Use [ErrorType] or [ErrorIs] to compare
 // errors by type.
 //
-// Error uses t.FailNow to fail the test. Like t.FailNow, Error must be
+// Error uses [testing.T.FailNow] to fail the test. Like t.FailNow, Error must be
 // called from the goroutine running the test function, not from other
-// goroutines created during the test. Use Check with cmp.Error from other
+// goroutines created during the test. Use [Check] with [cmp.Error] from other
 // goroutines.
 func Error(t TestingT, err error, expected string, msgAndArgs ...interface{}) {
 	if ht, ok := t.(helperT); ok {
@@ -248,9 +248,9 @@ func Error(t TestingT, err error, expected string, msgAndArgs ...interface{}) {
 // contain the expected substring. Both err.Error and the expected substring
 // will be included in the failure message.
 //
-// ErrorContains uses t.FailNow to fail the test. Like t.FailNow, ErrorContains
+// ErrorContains uses [testing.T.FailNow] to fail the test. Like t.FailNow, ErrorContains
 // must be called from the goroutine running the test function, not from other
-// goroutines created during the test. Use Check with cmp.ErrorContains from other
+// goroutines created during the test. Use [Check] with [cmp.ErrorContains] from other
 // goroutines.
 func ErrorContains(t TestingT, err error, substring string, msgAndArgs ...interface{}) {
 	if ht, ok := t.(helperT); ok {
@@ -262,8 +262,7 @@ func ErrorContains(t TestingT, err error, substring string, msgAndArgs ...interf
 }
 
 // ErrorType fails the test if err is nil, or err is not the expected type.
-// Most new code should use ErrorIs instead. ErrorType may be deprecated in the
-// future.
+// New code should use ErrorIs instead.
 //
 // Expected can be one of:
 //
@@ -281,10 +280,12 @@ func ErrorContains(t TestingT, err error, substring string, msgAndArgs ...interf
 //	reflect.Type
 //	  The assertion fails if err does not implement the reflect.Type.
 //
-// ErrorType uses t.FailNow to fail the test. Like t.FailNow, ErrorType
+// ErrorType uses [testing.T.FailNow] to fail the test. Like t.FailNow, ErrorType
 // must be called from the goroutine running the test function, not from other
-// goroutines created during the test. Use Check with cmp.ErrorType from other
+// goroutines created during the test. Use [Check] with [cmp.ErrorType] from other
 // goroutines.
+//
+// Deprecated: Use [ErrorIs]
 func ErrorType(t TestingT, err error, expected interface{}, msgAndArgs ...interface{}) {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
@@ -295,12 +296,12 @@ func ErrorType(t TestingT, err error, expected interface{}, msgAndArgs ...interf
 }
 
 // ErrorIs fails the test if err is nil, or the error does not match expected
-// when compared using errors.Is. See https://golang.org/pkg/errors/#Is for
+// when compared using errors.Is. See [errors.Is] for
 // accepted arguments.
 //
-// ErrorIs uses t.FailNow to fail the test. Like t.FailNow, ErrorIs
+// ErrorIs uses [testing.T.FailNow] to fail the test. Like t.FailNow, ErrorIs
 // must be called from the goroutine running the test function, not from other
-// goroutines created during the test. Use Check with cmp.ErrorIs from other
+// goroutines created during the test. Use [Check] with [cmp.ErrorIs] from other
 // goroutines.
 func ErrorIs(t TestingT, err error, expected error, msgAndArgs ...interface{}) {
 	if ht, ok := t.(helperT); ok {

--- a/vendor/gotest.tools/v3/assert/cmp/compare.go
+++ b/vendor/gotest.tools/v3/assert/cmp/compare.go
@@ -12,17 +12,16 @@ import (
 	"gotest.tools/v3/internal/format"
 )
 
-// Comparison is a function which compares values and returns ResultSuccess if
+// Comparison is a function which compares values and returns [ResultSuccess] if
 // the actual value matches the expected value. If the values do not match the
-// Result will contain a message about why it failed.
+// [Result] will contain a message about why it failed.
 type Comparison func() Result
 
-// DeepEqual compares two values using google/go-cmp
-// (https://godoc.org/github.com/google/go-cmp/cmp)
+// DeepEqual compares two values using [github.com/google/go-cmp/cmp]
 // and succeeds if the values are equal.
 //
 // The comparison can be customized using comparison Options.
-// Package http://pkg.go.dev/gotest.tools/v3/assert/opt provides some additional
+// Package [gotest.tools/v3/assert/opt] provides some additional
 // commonly used Options.
 func DeepEqual(x, y interface{}, opts ...cmp.Option) Comparison {
 	return func() (result Result) {
@@ -61,7 +60,7 @@ func toResult(success bool, msg string) Result {
 	return ResultFailure(msg)
 }
 
-// RegexOrPattern may be either a *regexp.Regexp or a string that is a valid
+// RegexOrPattern may be either a [*regexp.Regexp] or a string that is a valid
 // regexp pattern.
 type RegexOrPattern interface{}
 
@@ -95,7 +94,7 @@ func Regexp(re RegexOrPattern, v string) Comparison {
 	}
 }
 
-// Equal succeeds if x == y. See assert.Equal for full documentation.
+// Equal succeeds if x == y. See [gotest.tools/v3/assert.Equal] for full documentation.
 func Equal(x, y interface{}) Comparison {
 	return func() Result {
 		switch {
@@ -159,10 +158,10 @@ func Len(seq interface{}, expected int) Comparison {
 // slice, or array.
 //
 // If collection is a string, item must also be a string, and is compared using
-// strings.Contains().
+// [strings.Contains].
 // If collection is a Map, contains will succeed if item is a key in the map.
 // If collection is a slice or array, item is compared to each item in the
-// sequence using reflect.DeepEqual().
+// sequence using [reflect.DeepEqual].
 func Contains(collection interface{}, item interface{}) Comparison {
 	return func() Result {
 		colValue := reflect.ValueOf(collection)
@@ -259,7 +258,7 @@ func formatErrorMessage(err error) string {
 
 // Nil succeeds if obj is a nil interface, pointer, or function.
 //
-// Use NilError() for comparing errors. Use Len(obj, 0) for comparing slices,
+// Use [gotest.tools/v3/assert.NilError] for comparing errors. Use Len(obj, 0) for comparing slices,
 // maps, and channels.
 func Nil(obj interface{}) Comparison {
 	msgFunc := func(value reflect.Value) string {
@@ -306,7 +305,9 @@ func isNil(obj interface{}, msgFunc func(reflect.Value) string) Comparison {
 //
 //	reflect.Type
 //
-// Fails if err does not implement the reflect.Type
+// Fails if err does not implement the [reflect.Type].
+//
+// Deprecated: Use [ErrorIs]
 func ErrorType(err error, expected interface{}) Comparison {
 	return func() Result {
 		switch expectedType := expected.(type) {
@@ -381,7 +382,7 @@ var (
 )
 
 // ErrorIs succeeds if errors.Is(actual, expected) returns true. See
-// https://golang.org/pkg/errors/#Is for accepted argument values.
+// [errors.Is] for accepted argument values.
 func ErrorIs(actual error, expected error) Comparison {
 	return func() Result {
 		if errors.Is(actual, expected) {

--- a/vendor/gotest.tools/v3/assert/cmp/result.go
+++ b/vendor/gotest.tools/v3/assert/cmp/result.go
@@ -10,12 +10,12 @@ import (
 	"gotest.tools/v3/internal/source"
 )
 
-// A Result of a Comparison.
+// A Result of a [Comparison].
 type Result interface {
 	Success() bool
 }
 
-// StringResult is an implementation of Result that reports the error message
+// StringResult is an implementation of [Result] that reports the error message
 // string verbatim and does not provide any templating or formatting of the
 // message.
 type StringResult struct {
@@ -34,16 +34,16 @@ func (r StringResult) FailureMessage() string {
 	return r.message
 }
 
-// ResultSuccess is a constant which is returned by a ComparisonWithResult to
+// ResultSuccess is a constant which is returned by a [Comparison] to
 // indicate success.
 var ResultSuccess = StringResult{success: true}
 
-// ResultFailure returns a failed Result with a failure message.
+// ResultFailure returns a failed [Result] with a failure message.
 func ResultFailure(message string) StringResult {
 	return StringResult{message: message}
 }
 
-// ResultFromError returns ResultSuccess if err is nil. Otherwise ResultFailure
+// ResultFromError returns [ResultSuccess] if err is nil. Otherwise [ResultFailure]
 // is returned with the error message as the failure message.
 func ResultFromError(err error) Result {
 	if err == nil {
@@ -74,7 +74,7 @@ func (r templatedResult) UpdatedExpected(stackIndex int) error {
 	return source.UpdateExpectedValue(stackIndex+1, r.data["x"], r.data["y"])
 }
 
-// ResultFailureTemplate returns a Result with a template string and data which
+// ResultFailureTemplate returns a [Result] with a template string and data which
 // can be used to format a failure message. The template may access data from .Data,
 // the comparison args with the callArg function, and the formatNode function may
 // be used to format the call args.

--- a/vendor/gotest.tools/v3/assert/opt/opt.go
+++ b/vendor/gotest.tools/v3/assert/opt/opt.go
@@ -11,7 +11,7 @@ import (
 	gocmp "github.com/google/go-cmp/cmp"
 )
 
-// DurationWithThreshold returns a gocmp.Comparer for comparing time.Duration. The
+// DurationWithThreshold returns a [gocmp.Comparer] for comparing [time.Duration]. The
 // Comparer returns true if the difference between the two Duration values is
 // within the threshold and neither value is zero.
 func DurationWithThreshold(threshold time.Duration) gocmp.Option {
@@ -28,7 +28,7 @@ func cmpDuration(threshold time.Duration) func(x, y time.Duration) bool {
 	}
 }
 
-// TimeWithThreshold returns a gocmp.Comparer for comparing time.Time. The
+// TimeWithThreshold returns a [gocmp.Comparer] for comparing [time.Time]. The
 // Comparer returns true if the difference between the two Time values is
 // within the threshold and neither value is zero.
 func TimeWithThreshold(threshold time.Duration) gocmp.Option {
@@ -45,12 +45,12 @@ func cmpTime(threshold time.Duration) func(x, y time.Time) bool {
 	}
 }
 
-// PathString is a gocmp.FilterPath filter that returns true when path.String()
+// PathString is a [gocmp.FilterPath] filter that returns true when path.String()
 // matches any of the specs.
 //
 // The path spec is a dot separated string where each segment is a field name.
 // Slices, Arrays, and Maps are always matched against every element in the
-// sequence. gocmp.Indirect, gocmp.Transform, and gocmp.TypeAssertion are always
+// sequence. [gocmp.Indirect], [gocmp.Transform], and [gocmp.TypeAssertion] are always
 // ignored.
 //
 // Note: this path filter is not type safe. Incorrect paths will be silently
@@ -66,7 +66,7 @@ func PathString(specs ...string) func(path gocmp.Path) bool {
 	}
 }
 
-// PathDebug is a gocmp.FilerPath filter that always returns false. It prints
+// PathDebug is a [gocmp.FilterPath] filter that always returns false. It prints
 // each path it receives. It can be used to debug path matching problems.
 func PathDebug(path gocmp.Path) bool {
 	fmt.Printf("PATH string=%s gostring=%s\n", path, path.GoString())
@@ -95,7 +95,7 @@ func stepTypeFields(step gocmp.PathStep) string {
 	return ""
 }
 
-// PathField is a gocmp.FilerPath filter that matches a struct field by name.
+// PathField is a [gocmp.FilterPath] filter that matches a struct field by name.
 // PathField will match every instance of the field in a recursive or nested
 // structure.
 func PathField(structType interface{}, field string) func(gocmp.Path) bool {

--- a/vendor/gotest.tools/v3/env/env.go
+++ b/vendor/gotest.tools/v3/env/env.go
@@ -72,7 +72,7 @@ func PatchAll(t assert.TestingT, env map[string]string) func() {
 	return clean
 }
 
-// ToMap takes a list of strings in the format returned by os.Environ() and
+// ToMap takes a list of strings in the format returned by [os.Environ] and
 // returns a mapping of keys to values.
 func ToMap(env []string) map[string]string {
 	result := map[string]string{}

--- a/vendor/gotest.tools/v3/icmd/ops.go
+++ b/vendor/gotest.tools/v3/icmd/ops.go
@@ -38,6 +38,20 @@ func WithStdin(r io.Reader) CmdOp {
 	}
 }
 
+// WithStdout sets the standard output of the command to the specified writer
+func WithStdout(w io.Writer) CmdOp {
+	return func(c *Cmd) {
+		c.Stdout = w
+	}
+}
+
+// WithStderr sets the standard error of the command to the specified writer
+func WithStderr(w io.Writer) CmdOp {
+	return func(c *Cmd) {
+		c.Stderr = w
+	}
+}
+
 // WithExtraFile adds a file descriptor to the command
 func WithExtraFile(f *os.File) CmdOp {
 	return func(c *Cmd) {

--- a/vendor/gotest.tools/v3/poll/check.go
+++ b/vendor/gotest.tools/v3/poll/check.go
@@ -5,7 +5,7 @@ import (
 	"os"
 )
 
-// Check is a function which will be used as check for the WaitOn method.
+// Check is a function which will be used as check for the [WaitOn] method.
 type Check func(t LogT) Result
 
 // FileExists looks on filesystem and check that path exists.
@@ -29,7 +29,7 @@ func FileExists(path string) Check {
 }
 
 // Connection try to open a connection to the address on the
-// named network. See net.Dial for a description of the network and
+// named network. See [net.Dial] for a description of the network and
 // address parameters.
 func Connection(network, address string) Check {
 	return func(t LogT) Result {

--- a/vendor/gotest.tools/v3/poll/poll.go
+++ b/vendor/gotest.tools/v3/poll/poll.go
@@ -11,13 +11,13 @@ import (
 	"gotest.tools/v3/internal/assert"
 )
 
-// TestingT is the subset of testing.T used by WaitOn
+// TestingT is the subset of [testing.T] used by [WaitOn]
 type TestingT interface {
 	LogT
 	Fatalf(format string, args ...interface{})
 }
 
-// LogT is a logging interface that is passed to the WaitOn check function
+// LogT is a logging interface that is passed to the [WaitOn] check function
 type LogT interface {
 	Log(args ...interface{})
 	Logf(format string, args ...interface{})
@@ -27,7 +27,7 @@ type helperT interface {
 	Helper()
 }
 
-// Settings are used to configure the behaviour of WaitOn
+// Settings are used to configure the behaviour of [WaitOn]
 type Settings struct {
 	// Timeout is the maximum time to wait for the condition. Defaults to 10s.
 	Timeout time.Duration
@@ -57,7 +57,7 @@ func WithTimeout(timeout time.Duration) SettingOp {
 	}
 }
 
-// Result of a check performed by WaitOn
+// Result of a check performed by [WaitOn]
 type Result interface {
 	// Error indicates that the check failed and polling should stop, and the
 	// the has failed
@@ -86,20 +86,20 @@ func (r result) Error() error {
 	return r.err
 }
 
-// Continue returns a Result that indicates to WaitOn that it should continue
+// Continue returns a [Result] that indicates to [WaitOn] that it should continue
 // polling. The message text will be used as the failure message if the timeout
 // is reached.
 func Continue(message string, args ...interface{}) Result {
 	return result{message: fmt.Sprintf(message, args...)}
 }
 
-// Success returns a Result where Done() returns true, which indicates to WaitOn
+// Success returns a [Result] where Done() returns true, which indicates to [WaitOn]
 // that it should stop polling and exit without an error.
 func Success() Result {
 	return result{done: true}
 }
 
-// Error returns a Result that indicates to WaitOn that it should fail the test
+// Error returns a [Result] that indicates to [WaitOn] that it should fail the test
 // and stop polling.
 func Error(err error) Result {
 	return result{err: err}
@@ -143,9 +143,9 @@ func WaitOn(t TestingT, check Check, pollOps ...SettingOp) {
 	}
 }
 
-// Compare values using the cmp.Comparison. If the comparison fails return a
+// Compare values using the [cmp.Comparison]. If the comparison fails return a
 // result which indicates to WaitOn that it should continue waiting.
-// If the comparison is successful then WaitOn stops polling.
+// If the comparison is successful then [WaitOn] stops polling.
 func Compare(compare cmp.Comparison) Result {
 	buf := new(logBuffer)
 	if assert.RunComparison(buf, assert.ArgsAtZeroIndex, compare) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1383,8 +1383,8 @@ google.golang.org/protobuf/types/pluginpb
 # gopkg.in/yaml.v2 v2.4.0
 ## explicit; go 1.15
 gopkg.in/yaml.v2
-# gotest.tools/v3 v3.4.0
-## explicit; go 1.13
+# gotest.tools/v3 v3.5.0
+## explicit; go 1.17
 gotest.tools/v3/assert
 gotest.tools/v3/assert/cmp
 gotest.tools/v3/assert/opt


### PR DESCRIPTION
- go.mod: update dependencies and go version by
- Use Go1.20
- Fix couple of typos
- Added `WithStdout` and `WithStderr` helpers
- Moved `cmdOperators` handling from `RunCmd` to `StartCmd`
- Deprecate `assert.ErrorType`
- Remove outdated Dockerfile
- add godoc links

full diff: https://github.com/gotestyourself/gotest.tools/compare/v3.4.0...v3.5.0


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

