### PR TITLE
bakefile: Remove default value of DOCKER_GITCOMMIT

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -14,7 +14,7 @@ variable "DOCKER_BUILDTAGS" {
   default = ""
 }
 variable "DOCKER_GITCOMMIT" {
-  default = "HEAD"
+  default = null
 }
 
 # Docker version such as 23.0.0-dev. Automatically generated through Git ref.
@@ -81,7 +81,7 @@ target "_common" {
     DOCKER_STATIC = DOCKER_STATIC
     DOCKER_LDFLAGS = DOCKER_LDFLAGS
     DOCKER_BUILDTAGS = DOCKER_BUILDTAGS
-    DOCKER_GITCOMMIT = DOCKER_GITCOMMIT != "" ? DOCKER_GITCOMMIT : GITHUB_SHA
+    DOCKER_GITCOMMIT = DOCKER_GITCOMMIT != null ? DOCKER_GITCOMMIT : GITHUB_SHA
     VERSION = VERSION != "" ? VERSION : GITHUB_REF
     PLATFORM = PLATFORM
     PRODUCT = PRODUCT


### PR DESCRIPTION
"HEAD" will still be used as a version if no DOCKER_COMMIT is provided (for example when not running via `make`), but it won't prevent it being set to the GITHUB_SHA variable when it's present.

This will fix `Git commit` reported by `docker version` for the binaries generated by `moby-bin`.

https://github.com/moby/moby/blob/7baab8bd6c0674475f108f4cd1158d9ea30a62cb/docker-bake.hcl#L84

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

