### PR TITLE
Improve libnet/d/bridge errors

### DIFF
--- a/libnetwork/drivers/bridge/errors.go
+++ b/libnetwork/drivers/bridge/errors.go
@@ -209,16 +209,6 @@ func (fcv6 *FixedCIDRv6Error) Error() string {
 // InternalError denotes the type of this error
 func (fcv6 *FixedCIDRv6Error) InternalError() {}
 
-// InvalidIPTablesCfgError is returned when an invalid ip tables configuration is entered
-type InvalidIPTablesCfgError string
-
-func (action InvalidIPTablesCfgError) Error() string {
-	return fmt.Sprintf("Invalid IPTables action '%s'", string(action))
-}
-
-// Internal denotes the type of this error
-func (action InvalidIPTablesCfgError) Internal() {}
-
 // IPv4AddrAddError is returned when IPv4 address could not be added to the bridge.
 type IPv4AddrAddError struct {
 	IP  *net.IPNet

--- a/libnetwork/drivers/bridge/errors.go
+++ b/libnetwork/drivers/bridge/errors.go
@@ -209,16 +209,6 @@ func (fcv6 *FixedCIDRv6Error) Error() string {
 // InternalError denotes the type of this error
 func (fcv6 *FixedCIDRv6Error) InternalError() {}
 
-// IPTableCfgError is returned when an unexpected ip tables configuration is entered
-type IPTableCfgError string
-
-func (name IPTableCfgError) Error() string {
-	return fmt.Sprintf("unexpected request to set IP tables for interface: %s", string(name))
-}
-
-// BadRequest denotes the type of this error
-func (name IPTableCfgError) BadRequest() {}
-
 // InvalidIPTablesCfgError is returned when an invalid ip tables configuration is entered
 type InvalidIPTablesCfgError string
 

--- a/libnetwork/drivers/bridge/errors.go
+++ b/libnetwork/drivers/bridge/errors.go
@@ -245,18 +245,12 @@ func (ipv4 *IPv4AddrNoMatchError) Error() string {
 	return fmt.Sprintf("bridge IPv4 (%s) does not match requested configuration %s", ipv4.IP, ipv4.CfgIP)
 }
 
-// BadRequest denotes the type of this error
-func (ipv4 *IPv4AddrNoMatchError) BadRequest() {}
-
 // IPv6AddrNoMatchError is returned when the bridge's IPv6 address does not match configured.
 type IPv6AddrNoMatchError net.IPNet
 
 func (ipv6 *IPv6AddrNoMatchError) Error() string {
 	return fmt.Sprintf("bridge IPv6 addresses do not match the expected bridge configuration %s", (*net.IPNet)(ipv6).String())
 }
-
-// BadRequest denotes the type of this error
-func (ipv6 *IPv6AddrNoMatchError) BadRequest() {}
 
 // InvalidLinkIPAddrError is returned when a link is configured to a container with an invalid ip address
 type InvalidLinkIPAddrError string

--- a/libnetwork/drivers/bridge/errors.go
+++ b/libnetwork/drivers/bridge/errors.go
@@ -24,9 +24,6 @@ func (eidc *ErrInvalidDriverConfig) Error() string {
 	return "Invalid configuration passed to Bridge Driver"
 }
 
-// BadRequest denotes the type of this error
-func (eidc *ErrInvalidDriverConfig) BadRequest() {}
-
 // ErrInvalidNetworkConfig error is returned when a network is created on a driver without valid config.
 type ErrInvalidNetworkConfig struct{}
 
@@ -229,8 +226,8 @@ func (action InvalidIPTablesCfgError) Error() string {
 	return fmt.Sprintf("Invalid IPTables action '%s'", string(action))
 }
 
-// BadRequest denotes the type of this error
-func (action InvalidIPTablesCfgError) BadRequest() {}
+// Internal denotes the type of this error
+func (action InvalidIPTablesCfgError) Internal() {}
 
 // IPv4AddrAddError is returned when IPv4 address could not be added to the bridge.
 type IPv4AddrAddError struct {

--- a/libnetwork/drivers/bridge/errors.go
+++ b/libnetwork/drivers/bridge/errors.go
@@ -37,16 +37,6 @@ func (einc *ErrInvalidNetworkConfig) Error() string {
 // Forbidden denotes the type of this error
 func (einc *ErrInvalidNetworkConfig) Forbidden() {}
 
-// ErrInvalidContainerConfig error is returned when an endpoint create is attempted with an invalid configuration.
-type ErrInvalidContainerConfig struct{}
-
-func (eicc *ErrInvalidContainerConfig) Error() string {
-	return "Error in joining a container due to invalid configuration"
-}
-
-// BadRequest denotes the type of this error
-func (eicc *ErrInvalidContainerConfig) BadRequest() {}
-
 // ErrInvalidEndpointConfig error is returned when an endpoint create is attempted with an invalid endpoint configuration.
 type ErrInvalidEndpointConfig struct{}
 
@@ -117,16 +107,6 @@ func (eim ErrInvalidMtu) Error() string {
 // BadRequest denotes the type of this error
 func (eim ErrInvalidMtu) BadRequest() {}
 
-// ErrInvalidPort is returned when the container or host port specified in the port binding is not valid.
-type ErrInvalidPort string
-
-func (ip ErrInvalidPort) Error() string {
-	return fmt.Sprintf("invalid transport port: %s", string(ip))
-}
-
-// BadRequest denotes the type of this error
-func (ip ErrInvalidPort) BadRequest() {}
-
 // ErrUnsupportedAddressType is returned when the specified address type is not supported.
 type ErrUnsupportedAddressType string
 
@@ -136,16 +116,6 @@ func (uat ErrUnsupportedAddressType) Error() string {
 
 // BadRequest denotes the type of this error
 func (uat ErrUnsupportedAddressType) BadRequest() {}
-
-// ErrInvalidAddressBinding is returned when the host address specified in the port binding is not valid.
-type ErrInvalidAddressBinding string
-
-func (iab ErrInvalidAddressBinding) Error() string {
-	return fmt.Sprintf("invalid host address in port binding: %s", string(iab))
-}
-
-// BadRequest denotes the type of this error
-func (iab ErrInvalidAddressBinding) BadRequest() {}
 
 // ActiveEndpointsError is returned when there are
 // still active endpoints in the network being deleted.
@@ -179,17 +149,6 @@ func (ieie InvalidEndpointIDError) Error() string {
 
 // BadRequest denotes the type of this error
 func (ieie InvalidEndpointIDError) BadRequest() {}
-
-// InvalidSandboxIDError is returned when the passed
-// sandbox id is not valid.
-type InvalidSandboxIDError string
-
-func (isie InvalidSandboxIDError) Error() string {
-	return fmt.Sprintf("invalid sandbox id: %s", string(isie))
-}
-
-// BadRequest denotes the type of this error
-func (isie InvalidSandboxIDError) BadRequest() {}
 
 // EndpointNotFoundError is returned when the no endpoint
 // with the passed endpoint id is found.
@@ -272,16 +231,6 @@ func (action InvalidIPTablesCfgError) Error() string {
 
 // BadRequest denotes the type of this error
 func (action InvalidIPTablesCfgError) BadRequest() {}
-
-// IPv4AddrRangeError is returned when a valid IP address range couldn't be found.
-type IPv4AddrRangeError string
-
-func (name IPv4AddrRangeError) Error() string {
-	return fmt.Sprintf("can't find an address range for interface %q", string(name))
-}
-
-// BadRequest denotes the type of this error
-func (name IPv4AddrRangeError) BadRequest() {}
 
 // IPv4AddrAddError is returned when IPv4 address could not be added to the bridge.
 type IPv4AddrAddError struct {

--- a/libnetwork/drivers/bridge/errors.go
+++ b/libnetwork/drivers/bridge/errors.go
@@ -251,13 +251,3 @@ type IPv6AddrNoMatchError net.IPNet
 func (ipv6 *IPv6AddrNoMatchError) Error() string {
 	return fmt.Sprintf("bridge IPv6 addresses do not match the expected bridge configuration %s", (*net.IPNet)(ipv6).String())
 }
-
-// InvalidLinkIPAddrError is returned when a link is configured to a container with an invalid ip address
-type InvalidLinkIPAddrError string
-
-func (address InvalidLinkIPAddrError) Error() string {
-	return fmt.Sprintf("Cannot link to a container with Invalid IP Address '%s'", string(address))
-}
-
-// BadRequest denotes the type of this error
-func (address InvalidLinkIPAddrError) BadRequest() {}

--- a/libnetwork/drivers/bridge/link.go
+++ b/libnetwork/drivers/bridge/link.go
@@ -63,7 +63,7 @@ func linkContainers(action, parentIP, childIP string, ports []types.TransportPor
 	case "-D":
 		nfAction = iptables.Delete
 	default:
-		return InvalidIPTablesCfgError(action)
+		return fmt.Errorf("invalid iptables action: %s", action)
 	}
 
 	ip1 := net.ParseIP(parentIP)

--- a/libnetwork/drivers/bridge/link.go
+++ b/libnetwork/drivers/bridge/link.go
@@ -68,11 +68,11 @@ func linkContainers(action, parentIP, childIP string, ports []types.TransportPor
 
 	ip1 := net.ParseIP(parentIP)
 	if ip1 == nil {
-		return InvalidLinkIPAddrError(parentIP)
+		return fmt.Errorf("cannot link to a container with an invalid parent IP address %q", parentIP)
 	}
 	ip2 := net.ParseIP(childIP)
 	if ip2 == nil {
-		return InvalidLinkIPAddrError(childIP)
+		return fmt.Errorf("cannot link to a container with an invalid child IP address %q", childIP)
 	}
 
 	chain := iptables.ChainInfo{Name: DockerChain}

--- a/libnetwork/drivers/bridge/setup_firewalld.go
+++ b/libnetwork/drivers/bridge/setup_firewalld.go
@@ -2,7 +2,11 @@
 
 package bridge
 
-import "github.com/docker/docker/libnetwork/iptables"
+import (
+	"errors"
+
+	"github.com/docker/docker/libnetwork/iptables"
+)
 
 func (n *bridgeNetwork) setupFirewalld(config *networkConfiguration, i *bridgeInterface) error {
 	d := n.driver
@@ -12,7 +16,7 @@ func (n *bridgeNetwork) setupFirewalld(config *networkConfiguration, i *bridgeIn
 
 	// Sanity check.
 	if !driverConfig.EnableIPTables {
-		return IPTableCfgError(config.BridgeName)
+		return errors.New("no need to register firewalld hooks, iptables is disabled")
 	}
 
 	iptables.OnReloaded(func() { n.setupIP4Tables(config, i) })
@@ -28,7 +32,7 @@ func (n *bridgeNetwork) setupFirewalld6(config *networkConfiguration, i *bridgeI
 
 	// Sanity check.
 	if !driverConfig.EnableIP6Tables {
-		return IPTableCfgError(config.BridgeName)
+		return errors.New("no need to register firewalld hooks, ip6tables is disabled")
 	}
 
 	iptables.OnReloaded(func() { n.setupIP6Tables(config, i) })


### PR DESCRIPTION
**- What I did**

#### libnet/d/bridge: Remove unused error types

These error types are removed:

- ErrInvalidContainerConfig
- ErrInvalidPort
- ErrInvalidAddressBinding
- InvalidSandboxIDError
- IPv4AddrRangeError

#### libnet/d/bridge: Change interface implemented by error types

- InvalidIPTablesCfgError: implement InternalError instead of
  BadRequestError. This error is returned when an invalid iptables
  action is passed as argument (ie. none of -A, -I, or -D).
- ErrInvalidDriverConfig: don't implement BadRequestError. This is
  returned when libnetwork controller initialization pass bad driver
  config -- there's no call from an HTTP route.

#### libnet/d/bridge: Inline IPTableCfgError

This error is only used in defensive checks whereas the precondition is
already checked by caller. If we reach it, we messed something else. So
it's definitely not a BadRequest but an InternalError. Since there's no
type assertion, it adds no value.

#### libnet/d/bridge: Inline InvalidIPTablesCfgError

This error is an InternalError and is never type asserted, so no need to
keep it around.

#### libnet/d/bridge: Remove pointless BadRequestError impl

IPv4AddrNoMatchError and IPv6AddrNoMatchError are currently implementing
BadRequestError. They are returned in two cases, and none are due to a
bad user request:

- When calling daemon's CreateNetwork route, if the bridge's IPv4
  address or none of the bridge's IPv6 addresses match what's requested.
  If that happens, there's a big issue somewhere in libnetwork or the
  kernel.
- When restoring a network, for the same reason. In that case, the
  on-disk state drifted from the interface state.

#### libnet/d/bridge: Inline InvalidLinkIPAddrError
