### PR TITLE
distribution: update warning for deprecated image formats

### DIFF
--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -436,13 +436,9 @@ func (p *puller) pullTag(ctx context.Context, ref reference.Named, platform *oci
 
 	switch v := manifest.(type) {
 	case *schema1.SignedManifest:
-		// give registries time to upgrade to schema2 and only warn if we know a registry has been upgraded long time ago
-		// TODO: condition to be removed
-		if reference.Domain(ref) == "docker.io" {
-			msg := fmt.Sprintf("[DEPRECATION NOTICE] Docker Image Format v1, and Docker Image manifest version 2, schema 1 support will be removed in an upcoming release. Suggest the author of %s to upgrade the image to the OCI Format, or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/", ref)
-			log.G(ctx).Warn(msg)
-			progress.Message(p.config.ProgressOutput, "", msg)
-		}
+		msg := fmt.Sprintf("[DEPRECATION NOTICE] Docker Image Format v1, and Docker Image manifest version 2, schema 1 support will be removed in an upcoming release. Suggest the author of %s to upgrade the image to the OCI Format, or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/", ref)
+		log.G(ctx).Warn(msg)
+		progress.Message(p.config.ProgressOutput, "", msg)
 
 		id, manifestDigest, err = p.pullSchema1(ctx, ref, v, platform)
 		if err != nil {

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -439,7 +439,7 @@ func (p *puller) pullTag(ctx context.Context, ref reference.Named, platform *oci
 		// give registries time to upgrade to schema2 and only warn if we know a registry has been upgraded long time ago
 		// TODO: condition to be removed
 		if reference.Domain(ref) == "docker.io" {
-			msg := fmt.Sprintf("Image %s uses outdated schema1 manifest format. Please upgrade to a schema2 image for better future compatibility. More information at https://docs.docker.com/registry/spec/deprecated-schema-v1/", ref)
+			msg := fmt.Sprintf("[DEPRECATION NOTICE] Docker Image Format v1, and Docker Image manifest version 2, schema 1 support will be removed in an upcoming release. Suggest the author of %s to upgrade the image to the OCI Format, or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/", ref)
 			log.G(ctx).Warn(msg)
 			progress.Message(p.config.ProgressOutput, "", msg)
 		}
@@ -871,7 +871,7 @@ func (p *puller) pullManifestList(ctx context.Context, ref reference.Named, mfst
 
 		switch v := manifest.(type) {
 		case *schema1.SignedManifest:
-			msg := fmt.Sprintf("[DEPRECATION NOTICE] v2 schema1 manifests in manifest lists are not supported and will break in a future release. Suggest author of %s to upgrade to v2 schema2. More information at https://docs.docker.com/registry/spec/deprecated-schema-v1/", ref)
+			msg := fmt.Sprintf("[DEPRECATION NOTICE] Docker Image Format v1, and Docker Image manifest version 2, schema 1 support will be removed in an upcoming release. Suggest the author of %s to upgrade the image to the OCI Format, or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/", ref)
 			log.G(ctx).Warn(msg)
 			progress.Message(p.config.ProgressOutput, "", msg)
 


### PR DESCRIPTION
- [x] relates to / depends on https://github.com/docker/docs/pull/17858
- relates to https://github.com/moby/moby/pull/39736
- relates to https://github.com/moby/moby/issues/39701
- relates to https://github.com/distribution/distribution/issues/2976
- relates to https://github.com/moby/moby/issues/44521
- relates to https://github.com/moby/moby/pull/42300
- relates to https://github.com/docker/roadmap/issues/173


### distribution: update warning for deprecated image formats

- Use the same warning for both "v1 in manifest-index" and bare "v1" images.
- Update URL to use a "/go/" redirect, which allows the docs team to more
  easily redirect the URL to relevant docs (if things move).


### distribution: show image schema deprecation on all registries

When we added this deprecation warning, some registries had not yet
moved away from the deprecated specification, so we made the warning
conditional for pulling from Docker Hub.

That condition was added in 647dfe99a50badd27f0508c67eddc4b4923fcef7,
which is over 4 Years ago, which should be time enough for images
and registries to have moved to current specifications.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

