### PR TITLE
daemon: Remove unneeded error wrapping in verifyNetworkingConfig

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -326,7 +326,7 @@ func verifyNetworkingConfig(nwConfig *networktypes.NetworkingConfig) error {
 
 	for k, v := range nwConfig.EndpointsConfig {
 		if v == nil {
-			return errdefs.InvalidParameter(errors.Errorf("no EndpointSettings for %s", k))
+			return errors.Errorf("no EndpointSettings for %s", k)
 		}
 		if v.IPAMConfig != nil {
 			if v.IPAMConfig.IPv4Address != "" && net.ParseIP(v.IPAMConfig.IPv4Address).To4() == nil {

--- a/daemon/create_test.go
+++ b/daemon/create_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/network"
-	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 // Test case for 35752
@@ -17,5 +17,5 @@ func TestVerifyNetworkingConfig(t *testing.T) {
 		EndpointsConfig: endpoints,
 	}
 	err := verifyNetworkingConfig(nwConfig)
-	assert.Check(t, errdefs.IsInvalidParameter(err))
+	assert.Check(t, is.Error(err, "no EndpointSettings for mynet"), "should produce an error because no EndpointSettings were passed")
 }


### PR DESCRIPTION
**- What I did**

Related to:

- https://github.com/moby/moby/pull/45906#discussion_r1280796908

This function is called by `daemon.containerCreate()` which is already wrapping errors coming from `verifyNetworkingConfig()` with `errdefs.InvalidParameter()`. So `verifyNetworkingConfig()` should only return standard errors.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://www.animalspot.net/wp-content/uploads/2014/08/Mandarinfish-Baby.jpg)
