### PR TITLE
volume/local: Unmount on startup only if needed

### DIFF
--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -79,13 +79,17 @@ func New(scope string, rootIdentity idtools.Identity) (*Root, error) {
 			quotaCtl:   r.quotaCtl,
 		}
 
-		// unmount anything that may still be mounted (for example, from an
-		// unclean shutdown). This is a no-op on windows
-		unmount(v.path)
-
 		if err := v.loadOpts(); err != nil {
 			return nil, err
 		}
+
+		// Unmount data directory if might been mounted by the daemon and
+		// possibly wasn't unmounted (for example due to an unclean shutdown).
+		// This is a no-op on Windows.
+		if v.needsMount() {
+			unmount(v.path)
+		}
+
 		r.volumes[name] = v
 	}
 


### PR DESCRIPTION
Previously, the unmount was performed only when loading the `opts.json` file succeded. This protected from calling the unmount on Windows, but also from unmounting `_data` directories NOT mounted by the daemon. This is because local volume driver only performs the mount if it's needed by the additional volume mount opts.

The behavior was changed when the mount was turned into a no-op on Windows and the unmount was moved and became unconditional. This missed the fact that the mount could NOT have been performed by the daemon, if the volume didn't have any volume options.

This partially the old behavior and unmounts the data directory only if conditions for mounting it are true.
(reverts: 7e907e29a32e1a3b7d5a1569e74e361d19876b0c)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

