### PR TITLE
ci(bin-image): skip dco on push tag events

### DIFF
--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -24,6 +24,7 @@ env:
 
 jobs:
   validate-dco:
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     uses: ./.github/workflows/.dco.yml
 
   prepare:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

`bin-image` has failed on dco step when `v24.0.5` tag has been pushed: https://github.com/moby/moby/actions/runs/5647118881/job/15296540926#step:5:13

```
fatal: couldn't find remote ref refs/heads/refs/tags/v24.0.5
Error: Process completed with exit code 128.
```

We should just skip DCO on push tag events.

**- How I did it**

Tried setting the right based ref in a previous attempt but it's null in the payload: https://github.com/moby/moby/actions/runs/5647118881/job/15296540926#step:3:17

![image](https://github.com/moby/moby/assets/1951866/0ac82743-82d7-4bb1-948d-2410a4201c19)

This is slightly related to an issue we had in metadata action as well https://github.com/docker/metadata-action/blob/f3c3cad8ad5e1076ffba2449385b1547f1e3c566/src/meta.ts#L391-L397

So instead we should just skip the DCO step on push tag events as it's already checked anyway.

**- How to verify it**

On new release :crossed_fingers:

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

