### PR TITLE
Add testutil.TempDir function

### DIFF
--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -209,18 +209,8 @@ func TestRunWithAlternativeContainerdShim(t *testing.T) {
 	realShimPath, err = filepath.Abs(realShimPath)
 	assert.Assert(t, err)
 
-	// t.TempDir() can't be used here as the temporary directory returned by
-	// that function cannot be accessed by the fake-root user for rootless
-	// Docker. It creates a nested hierarchy of directories where the
-	// outermost has permission 0700.
-	shimDir, err := os.MkdirTemp("", t.Name())
+	shimDir := testutil.TempDir(t)
 	assert.Assert(t, err)
-	t.Cleanup(func() {
-		if err := os.RemoveAll(shimDir); err != nil {
-			t.Errorf("shimDir RemoveAll cleanup: %v", err)
-		}
-	})
-	assert.Assert(t, os.Chmod(shimDir, 0o777))
 	shimDir, err = filepath.Abs(shimDir)
 	assert.Assert(t, err)
 	assert.Assert(t, os.Symlink(realShimPath, filepath.Join(shimDir, "containerd-shim-realfake-v42")))

--- a/testutil/temp_files.go
+++ b/testutil/temp_files.go
@@ -1,0 +1,26 @@
+package testutil // import "github.com/docker/docker/testutil"
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TempDir returns a temporary directory for use in tests.
+// t.TempDir() can't be used as the temporary directory returned by
+// that function cannot be accessed by the fake-root user for rootless
+// Docker. It creates a nested hierarchy of directories where the
+// outermost has permission 0700.
+func TempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	parent := filepath.Dir(dir)
+	if parent != "" {
+		if err := os.Chmod(parent, 0o777); err != nil {
+			t.Fatalf("Failed to chmod parent of temp directory %q: %v", parent, err)
+		}
+	}
+
+	return dir
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added a `testutil.TempDir` function that ensures the correct permissions for the fake-root user in rootless mode.

**- How I did it**
Moved the existing code to the `testutil` package.

**- How to verify it**
No functional changes.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

