### PR TITLE
api: Remove duplicated check on CheckDuplicate

### DIFF
--- a/libnetwork/error.go
+++ b/libnetwork/error.go
@@ -53,8 +53,8 @@ func (nnr NetworkNameError) Error() string {
 	return fmt.Sprintf("network with name %s already exists", string(nnr))
 }
 
-// Forbidden denotes the type of this error
-func (nnr NetworkNameError) Forbidden() {}
+// Conflict denotes the type of this error
+func (nnr NetworkNameError) Conflict() {}
 
 // UnknownNetworkError is returned when libnetwork could not find in its database
 // a network with the same name and id.


### PR DESCRIPTION
**- What I did**

Partially revert commit 94b880f.

The `CheckDuplicate` field has been introduced in commit 2ab94e1. At that time, this check was done in the network router. It was then moved to the daemon package in commit 3ca2982. However, commit 94b880f duplicated the logic into the network router for no apparent reason. Finally, commit ab18718 made sure a 409 would be returned instead of a 500.

As this logic is first done by the daemon, the error -> warning conversion can't happen because `CheckDuplicate` has to be true for the daemon package to return an error. If it's false, the daemon proceed with the network creation, set the Warning field of its return value and return no error.

Thus, the `CheckDuplicate` logic in the api is removed and `libnetwork.NetworkNameError` now implements the ErrConflict interface.
