### PR TITLE
hack/test: Fix `TEST_FILTER` with regex matching integration and integration-cli tests

### DIFF
--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -25,7 +25,11 @@ setup_integration_test_filter() {
 	fi
 
 	local dirs
-	dirs=$(grep -rIlE --include '*_test.go' "func .*${TEST_FILTER}.*\(. \*testing\.T\)" ./integration*/ | xargs -I file dirname file | uniq)
+	local files
+	if files=$(grep -rIlE --include '*_test.go' "func .*${TEST_FILTER}.*\(. \*testing\.T\)" ./integration*/); then
+		dirs=$(echo "$files" | xargs -I file dirname file | uniq)
+	fi
+
 	if [ -z "${TEST_SKIP_INTEGRATION}" ]; then
 		: "${TEST_INTEGRATION_DIR:=$(echo "$dirs" | grep -v '^\./integration-cli$')}"
 		if [ -z "${TEST_INTEGRATION_DIR}" ]; then

--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -37,7 +37,7 @@ setup_integration_test_filter() {
 	fi
 
 	if [ -z "${TEST_SKIP_INTEGRATION_CLI}" ]; then
-		if echo "$dirs" | grep -vq '^./integration-cli$'; then
+		if ! echo "$dirs" | grep -q '^./integration-cli$'; then
 			TEST_SKIP_INTEGRATION_CLI=1
 			echo "Skipping integration-cli tests since the supplied filter \"${TEST_FILTER}\" omits all integration-cli tests"
 		else

--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -31,8 +31,6 @@ setup_integration_test_filter() {
 		if [ -z "${TEST_INTEGRATION_DIR}" ]; then
 			echo "Skipping integration tests since the supplied filter \"${TEST_FILTER}\" omits all integration tests"
 			TEST_SKIP_INTEGRATION=1
-		else
-			TESTFLAGS+=" -test.run ${TEST_FILTER}"
 		fi
 	fi
 
@@ -40,8 +38,6 @@ setup_integration_test_filter() {
 		if ! echo "$dirs" | grep -q '^./integration-cli$'; then
 			TEST_SKIP_INTEGRATION_CLI=1
 			echo "Skipping integration-cli tests since the supplied filter \"${TEST_FILTER}\" omits all integration-cli tests"
-		else
-			TESTFLAGS+=" -test.run /${TEST_FILTER}"
 		fi
 	fi
 }
@@ -64,8 +60,15 @@ run_test_integration() {
 }
 
 run_test_integration_suites() {
-	local flags="-test.v -test.timeout=${TIMEOUT} $TESTFLAGS"
 	local dirs="$1"
+	local flags="-test.v -test.timeout=${TIMEOUT} $TESTFLAGS "
+	if [ -n "${TEST_FILTER}" ]; then
+		if [ "$dirs" == "integration-cli" ]; then
+			flags+=" -test.run /${TEST_FILTER}"
+		else
+			flags+=" -test.run ${TEST_FILTER}"
+		fi
+	fi
 	local failed=0
 	for dir in ${dirs}; do
 		if ! (


### PR DESCRIPTION
**- What I did**
Fixed `make test-integration` with `TEST_FILTER` not working correctly when passing a regular expression that matches multiple tests in both `integration` and `integration-cli` suites.

**- How I did it**
See individual commits

**- How to verify it**

# Before


<details>

<summary>TEST_FILTER='(TestPushBusyboxImage|TestDiff)'</summary>


```bash
$ make TEST_FILTER='(TestPushBusyboxImage|TestDiff)' test-integration
(...)
---> Making bundle: test-integration (in bundles/test-integration)
Skipping integration-cli tests since the supplied filter "(TestPushBusyboxImage|TestDiff)" omits all integration-cli tests
SCRIPTDIR=/go/src/github.com/docker/docker/hack
HOSTNAME=385d291ba1a7
VALIDATE_ORIGIN_BRANCH=
DEST=bundles/test-integration
PWD=/go/src/github.com/docker/docker
CONTAINERD_ADDRESS=/run/docker/containerd/containerd.sock
DOCKER_GITCOMMIT=8dcad20eae
container=docker
HOME=/root
CONTAINERD_NAMESPACE=moby
GOLANG_VERSION=1.20.6
VALIDATE_REPO=
VALIDATE_BRANCH=
TERM=xterm
DOCKER_PKG=github.com/docker/docker
TEST_CLIENT_BINARY=/usr/local/cli-integration/docker
SHLVL=1
DOCKER_GRAPHDRIVER=overlay2
GO111MODULE=off
PATH=/usr/local/cli:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
MAKEDIR=/go/src/github.com/docker/docker/hack/make
TEST_FILTER=(TestPushBusyboxImage|TestDiff)
GOPATH=/go
PKG_CONFIG=pkg-config
_=/usr/bin/env
Building test suite binary ./integration/container/test.main
---> Making bundle: .integration-daemon-start (in bundles/test-integration)
Using test binary /usr/local/cli-integration/docker
INFO: Waiting for daemon to start...
Starting dockerd
.
---> Making bundle: .build-empty-images (in bundles/test-integration)
Loaded image: emptyfs:latest
Loaded image ID: sha256:0df1207206e5288f4a989a2f13d1f5b3c4e70467702c1d5d21dfc9f002b7bd43
Running integration-test (iteration 1)
Running /go/src/github.com/docker/docker/integration/container (arm64.integration.container) flags=-test.v -test.timeout=5m  -test.run (TestPushBusyboxImage|TestDiff)
Loaded image: busybox:latest
Loaded image: busybox:glibc
Loaded image: debian:bullseye-slim
Loaded image: hello-world:latest
Loaded image: arm32v7/hello-world:latest
INFO: Testing against a local daemon
=== RUN   TestDiff
--- PASS: TestDiff (0.48s)
PASS

DONE 1 tests in 1.900s
---> Making bundle: .integration-daemon-stop (in bundles/test-integration)
Removing test suite binaries
exiting test-integration
++ exit 0

```
</details>


# After

<details>

<summary>TEST_FILTER='(TestPushBusyboxImage|TestDiff)'</summary>


```bash
$ make TEST_FILTER='(TestPushBusyboxImage|TestDiff)' test-integration
(..)
---> Making bundle: test-integration (in bundles/test-integration)
SCRIPTDIR=/go/src/github.com/docker/docker/hack
HOSTNAME=162ed7cc7b58
VALIDATE_ORIGIN_BRANCH=
DEST=bundles/test-integration
PWD=/go/src/github.com/docker/docker
CONTAINERD_ADDRESS=/run/docker/containerd/containerd.sock
DOCKER_GITCOMMIT=ca9db07ddb
container=docker
HOME=/root
CONTAINERD_NAMESPACE=moby
GOLANG_VERSION=1.20.7
VALIDATE_REPO=
VALIDATE_BRANCH=
TERM=xterm
DOCKER_PKG=github.com/docker/docker
TEST_CLIENT_BINARY=/usr/local/cli-integration/docker
SHLVL=1
DOCKER_GRAPHDRIVER=overlay2
GO111MODULE=off
PATH=/usr/local/cli:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
MAKEDIR=/go/src/github.com/docker/docker/hack/make
TEST_FILTER=(TestPushBusyboxImage|TestDiff)
GOPATH=/go
PKG_CONFIG=pkg-config
_=/usr/bin/env
Building test suite binary ./integration-cli/test.main
Building test suite binary ./integration/container/test.main
---> Making bundle: .integration-daemon-start (in bundles/test-integration)
Using test binary /usr/local/cli-integration/docker
INFO: Waiting for daemon to start...
Starting dockerd
.
---> Making bundle: .build-empty-images (in bundles/test-integration)
Loaded image: emptyfs:latest
Loaded image ID: sha256:0df1207206e5288f4a989a2f13d1f5b3c4e70467702c1d5d21dfc9f002b7bd43
Running integration-test (iteration 1)
Running /go/src/github.com/docker/docker/integration/container (arm64.integration.container) flags=-test.v -test.timeout=5m    -test.run (TestPushBusyboxImage|TestDiff)
Loaded image: busybox:latest
Loaded image: busybox:glibc
Loaded image: debian:bullseye-slim
Loaded image: hello-world:latest
Loaded image: arm32v7/hello-world:latest
INFO: Testing against a local daemon
=== RUN   TestDiff
--- PASS: TestDiff (0.37s)
PASS

DONE 1 tests in 1.804s
Running /go/src/github.com/docker/docker/integration-cli (arm64.integration-cli) flags=-test.v -test.timeout=360m    -test.run /(TestPushBusyboxImage|TestDiff)
INFO: Testing against a local daemon
INFO: Testing with docker cli version:
Client:
 Version:      unknown-version
 API version:  1.30
 Go version:   go1.20.7
 Git commit:   unknown-commit
 Built:        unknown-buildtime
 OS/Arch:      linux/arm64

Server:
 Version:      dev
 API version:  1.44 (minimum version 1.12)
 Go version:   go1.20.7
 Git commit:   ca9db07ddb
 Built:        Tue Aug  8 11:34:23 2023
 OS/Arch:      linux/arm64
 Experimental: false

=== RUN   TestDockerAPISuite
--- PASS: TestDockerAPISuite (0.01s)
=== RUN   TestDockerBenchmarkSuite
--- PASS: TestDockerBenchmarkSuite (0.00s)
=== RUN   TestDockerCLIAttachSuite
--- PASS: TestDockerCLIAttachSuite (0.00s)
=== RUN   TestDockerCLIBuildSuite
--- PASS: TestDockerCLIBuildSuite (0.00s)
=== RUN   TestDockerCLICommitSuite
--- PASS: TestDockerCLICommitSuite (0.00s)
=== RUN   TestDockerCLICpSuite
--- PASS: TestDockerCLICpSuite (0.00s)
=== RUN   TestDockerCLICreateSuite
--- PASS: TestDockerCLICreateSuite (0.00s)
=== RUN   TestDockerCLIEventSuite
--- PASS: TestDockerCLIEventSuite (0.00s)
=== RUN   TestDockerCLIExecSuite
--- PASS: TestDockerCLIExecSuite (0.00s)
=== RUN   TestDockerCLIHealthSuite
--- PASS: TestDockerCLIHealthSuite (0.00s)
=== RUN   TestDockerCLIHistorySuite
--- PASS: TestDockerCLIHistorySuite (0.00s)
=== RUN   TestDockerCLIImagesSuite
--- PASS: TestDockerCLIImagesSuite (0.00s)
=== RUN   TestDockerCLIImportSuite
--- PASS: TestDockerCLIImportSuite (0.00s)
=== RUN   TestDockerCLIInfoSuite
--- PASS: TestDockerCLIInfoSuite (0.00s)
=== RUN   TestDockerCLIInspectSuite
--- PASS: TestDockerCLIInspectSuite (0.00s)
=== RUN   TestDockerCLILinksSuite
--- PASS: TestDockerCLILinksSuite (0.00s)
=== RUN   TestDockerCLILoginSuite
--- PASS: TestDockerCLILoginSuite (0.00s)
=== RUN   TestDockerCLILogsSuite
--- PASS: TestDockerCLILogsSuite (0.00s)
=== RUN   TestDockerCLINetmodeSuite
--- PASS: TestDockerCLINetmodeSuite (0.00s)
=== RUN   TestDockerCLINetworkSuite
--- PASS: TestDockerCLINetworkSuite (0.00s)
=== RUN   TestDockerCLIPluginLogDriverSuite
--- PASS: TestDockerCLIPluginLogDriverSuite (0.00s)
=== RUN   TestDockerCLIPluginsSuite
--- PASS: TestDockerCLIPluginsSuite (0.00s)
=== RUN   TestDockerCLIPortSuite
--- PASS: TestDockerCLIPortSuite (0.00s)
=== RUN   TestDockerCLIProxySuite
--- PASS: TestDockerCLIProxySuite (0.00s)
=== RUN   TestDockerCLIPruneSuite
--- PASS: TestDockerCLIPruneSuite (0.00s)
=== RUN   TestDockerCLIPsSuite
--- PASS: TestDockerCLIPsSuite (0.00s)
=== RUN   TestDockerCLIPullSuite
--- PASS: TestDockerCLIPullSuite (0.00s)
=== RUN   TestDockerCLIPushSuite
--- PASS: TestDockerCLIPushSuite (0.00s)
=== RUN   TestDockerCLIRestartSuite
--- PASS: TestDockerCLIRestartSuite (0.00s)
=== RUN   TestDockerCLIRmiSuite
--- PASS: TestDockerCLIRmiSuite (0.00s)
=== RUN   TestDockerCLIRunSuite
--- PASS: TestDockerCLIRunSuite (0.00s)
=== RUN   TestDockerCLISaveLoadSuite
--- PASS: TestDockerCLISaveLoadSuite (0.00s)
=== RUN   TestDockerCLISearchSuite
--- PASS: TestDockerCLISearchSuite (0.00s)
=== RUN   TestDockerCLISNISuite
--- PASS: TestDockerCLISNISuite (0.00s)
=== RUN   TestDockerCLIStartSuite
--- PASS: TestDockerCLIStartSuite (0.00s)
=== RUN   TestDockerCLIStatsSuite
--- PASS: TestDockerCLIStatsSuite (0.00s)
=== RUN   TestDockerCLITopSuite
--- PASS: TestDockerCLITopSuite (0.00s)
=== RUN   TestDockerCLIUpdateSuite
--- PASS: TestDockerCLIUpdateSuite (0.00s)
=== RUN   TestDockerCLIVolumeSuite
--- PASS: TestDockerCLIVolumeSuite (0.00s)
=== RUN   TestDockerRegistrySuite
=== RUN   TestDockerRegistrySuite/TestPushBusyboxImage
    check_test.go:394: [ddcb5c090f43d] daemon is not started
--- PASS: TestDockerRegistrySuite (0.22s)
    --- PASS: TestDockerRegistrySuite/TestPushBusyboxImage (0.22s)
=== RUN   TestDockerSchema1RegistrySuite
--- PASS: TestDockerSchema1RegistrySuite (0.00s)
=== RUN   TestDockerRegistryAuthHtpasswdSuite
--- PASS: TestDockerRegistryAuthHtpasswdSuite (0.00s)
=== RUN   TestDockerRegistryAuthTokenSuite
--- PASS: TestDockerRegistryAuthTokenSuite (0.00s)
=== RUN   TestDockerDaemonSuite
--- PASS: TestDockerDaemonSuite (0.00s)
=== RUN   TestDockerSwarmSuite
--- PASS: TestDockerSwarmSuite (0.00s)
=== RUN   TestDockerPluginSuite
--- PASS: TestDockerPluginSuite (0.00s)
=== RUN   TestDockerExternalVolumeSuite
--- PASS: TestDockerExternalVolumeSuite (0.00s)
=== RUN   TestDockerNetworkSuite
--- PASS: TestDockerNetworkSuite (0.00s)
=== RUN   TestDockerHubPullSuite
--- PASS: TestDockerHubPullSuite (0.00s)
PASS

DONE 50 tests in 0.331s
---> Making bundle: .integration-daemon-stop (in bundles/test-integration)
Removing test suite binaries
exiting test-integration
++ exit 0

```
</details>





<details>

<summary>TEST_FILTER='TestPushBusyboxImage'</summary>

```bash
$ make TEST_FILTER='TestPushBusyboxImage' test-integration
(...)
---> Making bundle: test-integration (in bundles/test-integration)
Skipping integration tests since the supplied filter "TestPushBusyboxImage" omits all integration tests
SCRIPTDIR=/go/src/github.com/docker/docker/hack
HOSTNAME=3f4905a3db54
VALIDATE_ORIGIN_BRANCH=
DEST=bundles/test-integration
PWD=/go/src/github.com/docker/docker
CONTAINERD_ADDRESS=/run/docker/containerd/containerd.sock
DOCKER_GITCOMMIT=ca9db07ddb
container=docker
HOME=/root
CONTAINERD_NAMESPACE=moby
GOLANG_VERSION=1.20.7
VALIDATE_REPO=
VALIDATE_BRANCH=
TERM=xterm
DOCKER_PKG=github.com/docker/docker
TEST_CLIENT_BINARY=/usr/local/cli-integration/docker
SHLVL=1
DOCKER_GRAPHDRIVER=overlay2
GO111MODULE=off
PATH=/usr/local/cli:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
MAKEDIR=/go/src/github.com/docker/docker/hack/make
TEST_FILTER=TestPushBusyboxImage
GOPATH=/go
PKG_CONFIG=pkg-config
_=/usr/bin/env
Building test suite binary ./integration-cli/test.main
---> Making bundle: .integration-daemon-start (in bundles/test-integration)
Using test binary /usr/local/cli-integration/docker
INFO: Waiting for daemon to start...
Starting dockerd
.
---> Making bundle: .build-empty-images (in bundles/test-integration)
Loaded image: emptyfs:latest
Loaded image ID: sha256:0df1207206e5288f4a989a2f13d1f5b3c4e70467702c1d5d21dfc9f002b7bd43
Running integration-test (iteration 1)
Running /go/src/github.com/docker/docker/integration-cli (arm64.integration-cli) flags=-test.v -test.timeout=360m    -test.run /TestPushBusyboxImage
Loaded image: busybox:latest
Loaded image: busybox:glibc
Loaded image: debian:bullseye-slim
Loaded image: hello-world:latest
Loaded image: arm32v7/hello-world:latest
INFO: Testing against a local daemon
INFO: Testing with docker cli version:
Client:
 Version:      unknown-version
 API version:  1.30
 Go version:   go1.20.7
 Git commit:   unknown-commit
 Built:        unknown-buildtime
 OS/Arch:      linux/arm64

Server:
 Version:      dev
 API version:  1.44 (minimum version 1.12)
 Go version:   go1.20.7
 Git commit:   ca9db07ddb
 Built:        Tue Aug  8 11:34:52 2023
 OS/Arch:      linux/arm64
 Experimental: false

=== RUN   TestDockerAPISuite
--- PASS: TestDockerAPISuite (0.01s)
=== RUN   TestDockerBenchmarkSuite
--- PASS: TestDockerBenchmarkSuite (0.00s)
=== RUN   TestDockerCLIAttachSuite
--- PASS: TestDockerCLIAttachSuite (0.00s)
=== RUN   TestDockerCLIBuildSuite
--- PASS: TestDockerCLIBuildSuite (0.00s)
=== RUN   TestDockerCLICommitSuite
--- PASS: TestDockerCLICommitSuite (0.00s)
=== RUN   TestDockerCLICpSuite
--- PASS: TestDockerCLICpSuite (0.00s)
=== RUN   TestDockerCLICreateSuite
--- PASS: TestDockerCLICreateSuite (0.00s)
=== RUN   TestDockerCLIEventSuite
--- PASS: TestDockerCLIEventSuite (0.00s)
=== RUN   TestDockerCLIExecSuite
--- PASS: TestDockerCLIExecSuite (0.00s)
=== RUN   TestDockerCLIHealthSuite
--- PASS: TestDockerCLIHealthSuite (0.00s)
=== RUN   TestDockerCLIHistorySuite
--- PASS: TestDockerCLIHistorySuite (0.00s)
=== RUN   TestDockerCLIImagesSuite
--- PASS: TestDockerCLIImagesSuite (0.00s)
=== RUN   TestDockerCLIImportSuite
--- PASS: TestDockerCLIImportSuite (0.00s)
=== RUN   TestDockerCLIInfoSuite
--- PASS: TestDockerCLIInfoSuite (0.00s)
=== RUN   TestDockerCLIInspectSuite
--- PASS: TestDockerCLIInspectSuite (0.00s)
=== RUN   TestDockerCLILinksSuite
--- PASS: TestDockerCLILinksSuite (0.00s)
=== RUN   TestDockerCLILoginSuite
--- PASS: TestDockerCLILoginSuite (0.00s)
=== RUN   TestDockerCLILogsSuite
--- PASS: TestDockerCLILogsSuite (0.00s)
=== RUN   TestDockerCLINetmodeSuite
--- PASS: TestDockerCLINetmodeSuite (0.00s)
=== RUN   TestDockerCLINetworkSuite
--- PASS: TestDockerCLINetworkSuite (0.00s)
=== RUN   TestDockerCLIPluginLogDriverSuite
--- PASS: TestDockerCLIPluginLogDriverSuite (0.00s)
=== RUN   TestDockerCLIPluginsSuite
--- PASS: TestDockerCLIPluginsSuite (0.00s)
=== RUN   TestDockerCLIPortSuite
--- PASS: TestDockerCLIPortSuite (0.00s)
=== RUN   TestDockerCLIProxySuite
--- PASS: TestDockerCLIProxySuite (0.00s)
=== RUN   TestDockerCLIPruneSuite
--- PASS: TestDockerCLIPruneSuite (0.00s)
=== RUN   TestDockerCLIPsSuite
--- PASS: TestDockerCLIPsSuite (0.00s)
=== RUN   TestDockerCLIPullSuite
--- PASS: TestDockerCLIPullSuite (0.00s)
=== RUN   TestDockerCLIPushSuite
--- PASS: TestDockerCLIPushSuite (0.00s)
=== RUN   TestDockerCLIRestartSuite
--- PASS: TestDockerCLIRestartSuite (0.00s)
=== RUN   TestDockerCLIRmiSuite
--- PASS: TestDockerCLIRmiSuite (0.00s)
=== RUN   TestDockerCLIRunSuite
--- PASS: TestDockerCLIRunSuite (0.00s)
=== RUN   TestDockerCLISaveLoadSuite
--- PASS: TestDockerCLISaveLoadSuite (0.00s)
=== RUN   TestDockerCLISearchSuite
--- PASS: TestDockerCLISearchSuite (0.00s)
=== RUN   TestDockerCLISNISuite
--- PASS: TestDockerCLISNISuite (0.00s)
=== RUN   TestDockerCLIStartSuite
--- PASS: TestDockerCLIStartSuite (0.00s)
=== RUN   TestDockerCLIStatsSuite
--- PASS: TestDockerCLIStatsSuite (0.00s)
=== RUN   TestDockerCLITopSuite
--- PASS: TestDockerCLITopSuite (0.00s)
=== RUN   TestDockerCLIUpdateSuite
--- PASS: TestDockerCLIUpdateSuite (0.00s)
=== RUN   TestDockerCLIVolumeSuite
--- PASS: TestDockerCLIVolumeSuite (0.00s)
=== RUN   TestDockerRegistrySuite
=== RUN   TestDockerRegistrySuite/TestPushBusyboxImage
    check_test.go:394: [d50c46941f372] daemon is not started
--- PASS: TestDockerRegistrySuite (0.24s)
    --- PASS: TestDockerRegistrySuite/TestPushBusyboxImage (0.24s)
=== RUN   TestDockerSchema1RegistrySuite
--- PASS: TestDockerSchema1RegistrySuite (0.00s)
=== RUN   TestDockerRegistryAuthHtpasswdSuite
--- PASS: TestDockerRegistryAuthHtpasswdSuite (0.00s)
=== RUN   TestDockerRegistryAuthTokenSuite
--- PASS: TestDockerRegistryAuthTokenSuite (0.00s)
=== RUN   TestDockerDaemonSuite
--- PASS: TestDockerDaemonSuite (0.00s)
=== RUN   TestDockerSwarmSuite
--- PASS: TestDockerSwarmSuite (0.00s)
=== RUN   TestDockerPluginSuite
--- PASS: TestDockerPluginSuite (0.00s)
=== RUN   TestDockerExternalVolumeSuite
--- PASS: TestDockerExternalVolumeSuite (0.00s)
=== RUN   TestDockerNetworkSuite
--- PASS: TestDockerNetworkSuite (0.00s)
=== RUN   TestDockerHubPullSuite
--- PASS: TestDockerHubPullSuite (0.00s)
PASS

DONE 50 tests in 1.823s
---> Making bundle: .integration-daemon-stop (in bundles/test-integration)
Removing test suite binaries
exiting test-integration
++ exit 0

```
</details>

<details>
<summary>TEST_FILTER='TestDiff'</summary>

```
$ make TEST_FILTER='TestDiff' test-integration
(...)
---> Making bundle: test-integration (in bundles/test-integration)
Skipping integration-cli tests since the supplied filter "TestDiff" omits all integration-cli tests
SCRIPTDIR=/go/src/github.com/docker/docker/hack
HOSTNAME=be4281caa771
VALIDATE_ORIGIN_BRANCH=
DEST=bundles/test-integration
PWD=/go/src/github.com/docker/docker
CONTAINERD_ADDRESS=/run/docker/containerd/containerd.sock
DOCKER_GITCOMMIT=ca9db07ddb
container=docker
HOME=/root
CONTAINERD_NAMESPACE=moby
GOLANG_VERSION=1.20.7
VALIDATE_REPO=
VALIDATE_BRANCH=
TERM=xterm
DOCKER_PKG=github.com/docker/docker
TEST_CLIENT_BINARY=/usr/local/cli-integration/docker
SHLVL=1
DOCKER_GRAPHDRIVER=overlay2
GO111MODULE=off
PATH=/usr/local/cli:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
MAKEDIR=/go/src/github.com/docker/docker/hack/make
TEST_FILTER=TestDiff
GOPATH=/go
PKG_CONFIG=pkg-config
_=/usr/bin/env
Building test suite binary ./integration/container/test.main
---> Making bundle: .integration-daemon-start (in bundles/test-integration)
Using test binary /usr/local/cli-integration/docker
INFO: Waiting for daemon to start...
Starting dockerd
.
---> Making bundle: .build-empty-images (in bundles/test-integration)
Loaded image: emptyfs:latest
Loaded image ID: sha256:0df1207206e5288f4a989a2f13d1f5b3c4e70467702c1d5d21dfc9f002b7bd43
Running integration-test (iteration 1)
Running /go/src/github.com/docker/docker/integration/container (arm64.integration.container) flags=-test.v -test.timeout=5m    -test.run TestDiff
Loaded image: busybox:latest
Loaded image: busybox:glibc
Loaded image: debian:bullseye-slim
Loaded image: hello-world:latest
Loaded image: arm32v7/hello-world:latest
INFO: Testing against a local daemon
=== RUN   TestDiff
--- PASS: TestDiff (0.34s)
PASS

DONE 1 tests in 1.825s
---> Making bundle: .integration-daemon-stop (in bundles/test-integration)
Removing test suite binaries
exiting test-integration
++ exit 0

```

</details>


**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/moby/moby/assets/5046555/57a17938-1e16-4f9e-aab3-51f0eee17e52)
