### PR TITLE
libnet/ipamapi: Remove unused errors

### DIFF
--- a/libnetwork/ipamapi/contract.go
+++ b/libnetwork/ipamapi/contract.go
@@ -29,14 +29,9 @@ type Registerer interface {
 
 // Well-known errors returned by IPAM
 var (
-	ErrIpamInternalError   = types.InternalErrorf("IPAM Internal Error")
 	ErrInvalidAddressSpace = types.BadRequestErrorf("Invalid Address Space")
 	ErrInvalidPool         = types.BadRequestErrorf("Invalid Address Pool")
 	ErrInvalidSubPool      = types.BadRequestErrorf("Invalid Address SubPool")
-	ErrInvalidRequest      = types.BadRequestErrorf("Invalid Request")
-	ErrPoolNotFound        = types.BadRequestErrorf("Address Pool not found")
-	ErrOverlapPool         = types.ForbiddenErrorf("Address pool overlaps with existing pool on this address space")
-	ErrNoAvailablePool     = types.NoServiceErrorf("No available pool")
 	ErrNoAvailableIPs      = types.NoServiceErrorf("No available addresses on this pool")
 	ErrNoIPReturned        = types.NoServiceErrorf("No address returned")
 	ErrIPAlreadyAllocated  = types.ForbiddenErrorf("Address already in use")


### PR DESCRIPTION
**- What I did**

These errors aren't used in our repo and seem unused by the OSS community (this was checked with Sourcegraph).

- ErrIpamInternalError has never been used
- ErrInvalidRequest is unused since moby/libnetwork@c85356efa
- ErrPoolNotFound has never been used
- ErrOverlapPool has never been used
- ErrNoAvailablePool has never been used

For the record, here's [a link](https://sourcegraph.com/search?q=context:global+file:%5C.go%24+-repo:moby/moby+-repo:docker/docker-ce+-repo:moby/libnetwork+-file:vendor/+content:%22github.com/docker/docker%22+content:ErrNoAvailablePool&patternType=regexp&sm=1&groupBy=repo) to one of my Sourcegraph query. As can be seen, the only result is an old repo which is vendoring `github.com/docker/docker` in a weird way (and has seen no activity in the past 5 years).
