### PR TITLE
libnetwork/osl: remove redundant locks, and assorted cleanups

### DIFF
--- a/libnetwork/osl/interface_linux.go
+++ b/libnetwork/osl/interface_linux.go
@@ -27,75 +27,75 @@ type nwIface struct {
 	routes      []*net.IPNet
 	bridge      bool
 	ns          *networkNamespace
-	sync.Mutex
+	mu          sync.Mutex
 }
 
 func (i *nwIface) SrcName() string {
-	i.Lock()
-	defer i.Unlock()
+	i.mu.Lock()
+	defer i.mu.Unlock()
 
 	return i.srcName
 }
 
 func (i *nwIface) DstName() string {
-	i.Lock()
-	defer i.Unlock()
+	i.mu.Lock()
+	defer i.mu.Unlock()
 
 	return i.dstName
 }
 
 func (i *nwIface) DstMaster() string {
-	i.Lock()
-	defer i.Unlock()
+	i.mu.Lock()
+	defer i.mu.Unlock()
 
 	return i.dstMaster
 }
 
 func (i *nwIface) Bridge() bool {
-	i.Lock()
-	defer i.Unlock()
+	i.mu.Lock()
+	defer i.mu.Unlock()
 
 	return i.bridge
 }
 
 func (i *nwIface) Master() string {
-	i.Lock()
-	defer i.Unlock()
+	i.mu.Lock()
+	defer i.mu.Unlock()
 
 	return i.master
 }
 
 func (i *nwIface) MacAddress() net.HardwareAddr {
-	i.Lock()
-	defer i.Unlock()
+	i.mu.Lock()
+	defer i.mu.Unlock()
 
 	return types.GetMacCopy(i.mac)
 }
 
 func (i *nwIface) Address() *net.IPNet {
-	i.Lock()
-	defer i.Unlock()
+	i.mu.Lock()
+	defer i.mu.Unlock()
 
 	return types.GetIPNetCopy(i.address)
 }
 
 func (i *nwIface) AddressIPv6() *net.IPNet {
-	i.Lock()
-	defer i.Unlock()
+	i.mu.Lock()
+	defer i.mu.Unlock()
 
 	return types.GetIPNetCopy(i.addressIPv6)
 }
 
 func (i *nwIface) LinkLocalAddresses() []*net.IPNet {
-	i.Lock()
-	defer i.Unlock()
+	i.mu.Lock()
+	defer i.mu.Unlock()
 
 	return i.llAddrs
 }
 
 func (i *nwIface) Routes() []*net.IPNet {
-	i.Lock()
-	defer i.Unlock()
+	i.mu.Lock()
+	defer i.mu.Unlock()
 
 	routes := make([]*net.IPNet, len(i.routes))
 	for index, route := range i.routes {
@@ -120,9 +120,9 @@ func (n *networkNamespace) Interfaces() []Interface {
 }
 
 func (i *nwIface) Remove() error {
-	i.Lock()
+	i.mu.Lock()
 	n := i.ns
-	i.Unlock()
+	i.mu.Unlock()
 
 	n.Lock()
 	isDefault := n.isDefault
@@ -175,9 +175,9 @@ func (i *nwIface) Remove() error {
 
 // Returns the sandbox's side veth interface statistics
 func (i *nwIface) Statistics() (*types.InterfaceStatistics, error) {
-	i.Lock()
+	i.mu.Lock()
 	n := i.ns
-	i.Unlock()
+	i.mu.Unlock()
 
 	l, err := n.nlHandle.LinkByName(i.DstName())
 	if err != nil {

--- a/libnetwork/osl/interface_linux.go
+++ b/libnetwork/osl/interface_linux.go
@@ -169,7 +169,11 @@ func (n *networkNamespace) findDst(srcName string, isBridge bool) string {
 }
 
 func (n *networkNamespace) AddInterface(srcName, dstPrefix string, options ...IfaceOption) error {
-	i := &nwIface{srcName: srcName, dstName: dstPrefix, ns: n}
+	i := &nwIface{
+		srcName: srcName,
+		dstName: dstPrefix,
+		ns:      n,
+	}
 	i.processInterfaceOptions(options...)
 
 	if i.master != "" {
@@ -197,12 +201,11 @@ func (n *networkNamespace) AddInterface(srcName, dstPrefix string, options ...If
 	// If it is a bridge interface we have to create the bridge inside
 	// the namespace so don't try to lookup the interface using srcName
 	if i.bridge {
-		link := &netlink.Bridge{
+		if err := nlh.LinkAdd(&netlink.Bridge{
 			LinkAttrs: netlink.LinkAttrs{
 				Name: i.srcName,
 			},
-		}
-		if err := nlh.LinkAdd(link); err != nil {
+		}); err != nil {
 			return fmt.Errorf("failed to create bridge %q: %v", i.srcName, err)
 		}
 	} else {

--- a/libnetwork/osl/interface_linux.go
+++ b/libnetwork/osl/interface_linux.go
@@ -73,14 +73,6 @@ func (i *nwIface) Routes() []*net.IPNet {
 	return routes
 }
 
-func (n *networkNamespace) Interfaces() []Interface {
-	ifaces := make([]Interface, len(n.iFaces))
-	for i, iface := range n.iFaces {
-		ifaces[i] = iface
-	}
-	return ifaces
-}
-
 func (i *nwIface) Remove() error {
 	i.ns.Lock()
 	isDefault := i.ns.isDefault

--- a/libnetwork/osl/namespace_linux.go
+++ b/libnetwork/osl/namespace_linux.go
@@ -474,7 +474,11 @@ func (n *networkNamespace) Destroy() error {
 func (n *networkNamespace) Restore(ifsopt map[Iface][]IfaceOption, routes []*types.StaticRoute, gw net.IP, gw6 net.IP) error {
 	// restore interfaces
 	for name, opts := range ifsopt {
-		i := &nwIface{srcName: name.SrcName, dstName: name.DstPrefix, ns: n}
+		i := &nwIface{
+			srcName: name.SrcName,
+			dstName: name.DstPrefix,
+			ns:      n,
+		}
 		i.processInterfaceOptions(opts...)
 		if i.master != "" {
 			i.dstMaster = n.findDst(i.master, true)

--- a/libnetwork/osl/namespace_linux.go
+++ b/libnetwork/osl/namespace_linux.go
@@ -46,23 +46,6 @@ var (
 	prefix           = defaultPrefix
 )
 
-// The networkNamespace type is the linux implementation of the Sandbox
-// interface. It represents a linux network namespace, and moves an interface
-// into it when called on method AddInterface or sets the gateway etc.
-type networkNamespace struct {
-	path         string
-	iFaces       []*nwIface
-	gw           net.IP
-	gwv6         net.IP
-	staticRoutes []*types.StaticRoute
-	neighbors    []*neigh
-	nextIfIndex  map[string]int
-	isDefault    bool
-	nlHandle     *netlink.Handle
-	loV6Enabled  bool
-	sync.Mutex
-}
-
 // SetBasePath sets the base url prefix for the ns path
 func SetBasePath(path string) {
 	prefix = path
@@ -242,14 +225,6 @@ func NewSandbox(key string, osCreate, isRestore bool) (Sandbox, error) {
 	return n, nil
 }
 
-func (n *networkNamespace) InterfaceOptions() IfaceOptionSetter {
-	return n
-}
-
-func (n *networkNamespace) NeighborOptions() NeighborOptionSetter {
-	return n
-}
-
 func mountNetworkNamespace(basePath string, lnPath string) error {
 	return syscall.Mount(basePath, lnPath, "bind", syscall.MS_BIND, "")
 }
@@ -336,6 +311,39 @@ func createNamespaceFile(path string) (err error) {
 	}
 
 	return err
+}
+
+// The networkNamespace type is the linux implementation of the Sandbox
+// interface. It represents a linux network namespace, and moves an interface
+// into it when called on method AddInterface or sets the gateway etc.
+type networkNamespace struct {
+	path         string
+	iFaces       []*nwIface
+	gw           net.IP
+	gwv6         net.IP
+	staticRoutes []*types.StaticRoute
+	neighbors    []*neigh
+	nextIfIndex  map[string]int
+	isDefault    bool
+	nlHandle     *netlink.Handle
+	loV6Enabled  bool
+	sync.Mutex
+}
+
+func (n *networkNamespace) Interfaces() []Interface {
+	ifaces := make([]Interface, len(n.iFaces))
+	for i, iface := range n.iFaces {
+		ifaces[i] = iface
+	}
+	return ifaces
+}
+
+func (n *networkNamespace) InterfaceOptions() IfaceOptionSetter {
+	return n
+}
+
+func (n *networkNamespace) NeighborOptions() NeighborOptionSetter {
+	return n
 }
 
 func (n *networkNamespace) loopbackUp() error {
@@ -598,6 +606,26 @@ func (n *networkNamespace) checkLoV6() {
 	n.loV6Enabled = enable
 }
 
+// ApplyOSTweaks applies linux configs on the sandbox
+func (n *networkNamespace) ApplyOSTweaks(types []SandboxType) {
+	for _, t := range types {
+		switch t {
+		case SandboxTypeLoadBalancer, SandboxTypeIngress:
+			kernel.ApplyOSTweaks(map[string]*kernel.OSValue{
+				// disables any special handling on port reuse of existing IPVS connection table entries
+				// more info: https://github.com/torvalds/linux/blame/v5.15/Documentation/networking/ipvs-sysctl.rst#L32
+				"net.ipv4.vs.conn_reuse_mode": {Value: "0", CheckFn: nil},
+				// expires connection from the IPVS connection table when the backend is not available
+				// more info: https://github.com/torvalds/linux/blame/v5.15/Documentation/networking/ipvs-sysctl.rst#L133
+				"net.ipv4.vs.expire_nodest_conn": {Value: "1", CheckFn: nil},
+				// expires persistent connections to destination servers with weights set to 0
+				// more info: https://github.com/torvalds/linux/blame/v5.15/Documentation/networking/ipvs-sysctl.rst#L151
+				"net.ipv4.vs.expire_quiescent_template": {Value: "1", CheckFn: nil},
+			})
+		}
+	}
+}
+
 func setIPv6(nspath, iface string, enable bool) error {
 	errCh := make(chan error, 1)
 	go func() {
@@ -662,24 +690,4 @@ func setIPv6(nspath, iface string, enable bool) error {
 		}
 	}()
 	return <-errCh
-}
-
-// ApplyOSTweaks applies linux configs on the sandbox
-func (n *networkNamespace) ApplyOSTweaks(types []SandboxType) {
-	for _, t := range types {
-		switch t {
-		case SandboxTypeLoadBalancer, SandboxTypeIngress:
-			kernel.ApplyOSTweaks(map[string]*kernel.OSValue{
-				// disables any special handling on port reuse of existing IPVS connection table entries
-				// more info: https://github.com/torvalds/linux/blame/v5.15/Documentation/networking/ipvs-sysctl.rst#L32
-				"net.ipv4.vs.conn_reuse_mode": {Value: "0", CheckFn: nil},
-				// expires connection from the IPVS connection table when the backend is not available
-				// more info: https://github.com/torvalds/linux/blame/v5.15/Documentation/networking/ipvs-sysctl.rst#L133
-				"net.ipv4.vs.expire_nodest_conn": {Value: "1", CheckFn: nil},
-				// expires persistent connections to destination servers with weights set to 0
-				// more info: https://github.com/torvalds/linux/blame/v5.15/Documentation/networking/ipvs-sysctl.rst#L151
-				"net.ipv4.vs.expire_quiescent_template": {Value: "1", CheckFn: nil},
-			})
-		}
-	}
 }

--- a/libnetwork/osl/sandbox.go
+++ b/libnetwork/osl/sandbox.go
@@ -156,8 +156,6 @@ type Info interface {
 	// directly connected routes are stored on the particular interface they
 	// refer to.
 	StaticRoutes() []*types.StaticRoute
-
-	// TODO: Add ip tables etc.
 }
 
 // Interface represents the settings and identity of a network device. It is

--- a/libnetwork/osl/sandbox_linux_test.go
+++ b/libnetwork/osl/sandbox_linux_test.go
@@ -37,6 +37,7 @@ func generateRandomName(prefix string, size int) (string, error) {
 }
 
 func newKey(t *testing.T) (string, error) {
+	t.Helper()
 	name, err := generateRandomName("netns", 12)
 	if err != nil {
 		return "", err
@@ -55,7 +56,8 @@ func newKey(t *testing.T) (string, error) {
 	return name, nil
 }
 
-func newInfo(hnd *netlink.Handle, t *testing.T) (Sandbox, error) {
+func newInfo(t *testing.T, hnd *netlink.Handle) (Sandbox, error) {
+	t.Helper()
 	veth := &netlink.Veth{
 		LinkAttrs: netlink.LinkAttrs{Name: vethName1, TxQLen: 0},
 		PeerName:  vethName2,
@@ -400,7 +402,7 @@ func TestSandboxCreate(t *testing.T) {
 		t.Fatalf("s.Key() returned %s. Expected %s", s.Key(), key)
 	}
 
-	tbox, err := newInfo(ns.NlHandle(), t)
+	tbox, err := newInfo(t, ns.NlHandle())
 	if err != nil {
 		t.Fatalf("Failed to generate new sandbox info: %v", err)
 	}
@@ -499,7 +501,7 @@ func TestAddRemoveInterface(t *testing.T) {
 		t.Fatalf("s.Key() returned %s. Expected %s", s.Key(), key)
 	}
 
-	tbox, err := newInfo(ns.NlHandle(), t)
+	tbox, err := newInfo(t, ns.NlHandle())
 	if err != nil {
 		t.Fatalf("Failed to generate new sandbox info: %v", err)
 	}

--- a/libnetwork/osl/sandbox_linux_test.go
+++ b/libnetwork/osl/sandbox_linux_test.go
@@ -58,66 +58,66 @@ func newKey(t *testing.T) (string, error) {
 
 func newInfo(t *testing.T, hnd *netlink.Handle) (Sandbox, error) {
 	t.Helper()
-	veth := &netlink.Veth{
+	err := hnd.LinkAdd(&netlink.Veth{
 		LinkAttrs: netlink.LinkAttrs{Name: vethName1, TxQLen: 0},
 		PeerName:  vethName2,
-	}
-	if err := hnd.LinkAdd(veth); err != nil {
+	})
+	if err != nil {
 		return nil, err
 	}
-
-	// Store the sandbox side pipe interface
-	// This is needed for cleanup on DeleteEndpoint()
-	intf1 := &nwIface{}
-	intf1.srcName = vethName2
-	intf1.dstName = sboxIfaceName
 
 	ip4, addr, err := net.ParseCIDR("192.168.1.100/24")
 	if err != nil {
 		return nil, err
 	}
-	intf1.address = addr
-	intf1.address.IP = ip4
+	addr.IP = ip4
 
 	ip6, addrv6, err := net.ParseCIDR("fe80::2/64")
 	if err != nil {
 		return nil, err
 	}
-	intf1.addressIPv6 = addrv6
-	intf1.addressIPv6.IP = ip6
+	addrv6.IP = ip6
 
 	_, route, err := net.ParseCIDR("192.168.2.1/32")
 	if err != nil {
 		return nil, err
 	}
 
-	intf1.routes = []*net.IPNet{route}
-
-	intf2 := &nwIface{}
-	intf2.srcName = "testbridge"
-	intf2.dstName = sboxIfaceName
-	intf2.bridge = true
-
-	veth = &netlink.Veth{
-		LinkAttrs: netlink.LinkAttrs{Name: vethName3, TxQLen: 0},
-		PeerName:  vethName4,
+	// Store the sandbox side pipe interface
+	// This is needed for cleanup on DeleteEndpoint()
+	intf1 := &nwIface{
+		srcName:     vethName2,
+		dstName:     sboxIfaceName,
+		address:     addr,
+		addressIPv6: addrv6,
+		routes:      []*net.IPNet{route},
 	}
 
-	if err := hnd.LinkAdd(veth); err != nil {
+	intf2 := &nwIface{
+		srcName: "testbridge",
+		dstName: sboxIfaceName,
+		bridge:  true,
+	}
+
+	err = hnd.LinkAdd(&netlink.Veth{
+		LinkAttrs: netlink.LinkAttrs{Name: vethName3, TxQLen: 0},
+		PeerName:  vethName4,
+	})
+	if err != nil {
 		return nil, err
 	}
 
-	intf3 := &nwIface{}
-	intf3.srcName = vethName4
-	intf3.dstName = sboxIfaceName
-	intf3.master = "testbridge"
+	intf3 := &nwIface{
+		srcName: vethName4,
+		dstName: sboxIfaceName,
+		master:  "testbridge",
+	}
 
-	info := &networkNamespace{iFaces: []*nwIface{intf1, intf2, intf3}}
-
-	info.gw = net.ParseIP("192.168.1.1")
-	info.gwv6 = net.ParseIP("fe80::1")
-
-	return info, nil
+	return &networkNamespace{
+		iFaces: []*nwIface{intf1, intf2, intf3},
+		gw:     net.ParseIP("192.168.1.1"),
+		gwv6:   net.ParseIP("fe80::1"),
+	}, nil
 }
 
 func verifySandbox(t *testing.T, s Sandbox, ifaceSuffixes []string) {


### PR DESCRIPTION
- first part of https://github.com/moby/moby/pull/46149, which still needs some work

### libnetwork/osl: let's not do this, etc.

No context in the commit that added it, but PR discussion shows that
the API was mostly exploratory, and it was 8 Years go, so let's not
head in that direction :) https://github.com/moby/libnetwork/commit/b6467848599a1b9ad504ba8f10fdce07afb4ea76

### libnetwork/osl: nwIface: unexport sync.Mutex

Don't make the mutex public. This also gives a better clue
if the mutex is used externally.

### libnetwork/osl: nwIface: remove mutex altogether

The mutex is only used on reads, but there's nothing protecting writes,
and it looks like nothing is mutating fields after creation, so let's
remove this altogether.

### libnetwork/osl: make newKey and newInfo a t.Helper()

Both were passed testing.T, but it was not used, so let's make use of it.

### libnetwork/osl: clean up newInfo() a bit

Use struct-literals in some places to make it slightly more visible
what we're creating where.

### libnetwork/osl: some minor nits

### libnetwork/osl: move all networkNamespace methods together

These methods were sprinkled throughout the code; let's move
them together.

### libnetwork/osl: nwIface: add godoc

Copy the godoc from the interface to the implementation.


**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

