### PR TITLE
[24.0 backport] hack/test: Don't fail-fast before integration-cli

### DIFF
--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -55,11 +55,23 @@ fi
 
 run_test_integration() {
 	set_platform_timeout
+	local failed=0
 	if [ -z "${TEST_SKIP_INTEGRATION}" ]; then
-		run_test_integration_suites "${integration_api_dirs}"
+		if ! run_test_integration_suites "${integration_api_dirs}"; then
+			if [ -n "${TEST_INTEGRATION_FAIL_FAST}" ]; then
+				return 1
+			fi
+			failed=1
+		fi
 	fi
 	if [ -z "${TEST_SKIP_INTEGRATION_CLI}" ]; then
-		TIMEOUT=360m run_test_integration_suites integration-cli
+		if ! TIMEOUT=360m run_test_integration_suites integration-cli; then
+			return 1
+		fi
+	fi
+
+	if [ $failed -eq 1 ]; then
+		return 1
 	fi
 }
 
@@ -99,13 +111,13 @@ run_test_integration_suites() {
 				-- go tool test2json -p "${pkgname}" -t ./test.main ${pkgtestflags}
 		); then
 			if [ -n "${TEST_INTEGRATION_FAIL_FAST}" ]; then
-				exit 1
+				return 1
 			fi
 			failed=1
 		fi
 	done
 	if [ $failed -eq 1 ]; then
-		exit 1
+		return 1
 	fi
 }
 


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/46168

If TEST_INTEGRATION_FAIL_FAST is not set, run the integration-cli tests even if integration tests failed.

(cherry picked from commit 6841a53d1764bd65d08fe655a147ae3c24c977c1)

**- What I did**
Don't fail-fast after `integration` tests failed but before `integration-cli` tests are started.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

