### PR TITLE
test/volume: Replace Check with NilError where suitable

### DIFF
--- a/volume/mounts/lcow_parser_test.go
+++ b/volume/mounts/lcow_parser_test.go
@@ -220,7 +220,7 @@ func TestLCOWParseMountRawSplit(t *testing.T) {
 				return
 			}
 
-			assert.Check(t, err)
+			assert.NilError(t, err)
 			assert.Check(t, is.Equal(m.Destination, tc.expDest))
 			assert.Check(t, is.Equal(m.Source, tc.expSource))
 			assert.Check(t, is.Equal(m.Name, tc.expName))

--- a/volume/mounts/linux_parser_test.go
+++ b/volume/mounts/linux_parser_test.go
@@ -188,7 +188,7 @@ func TestLinuxParseMountRawSplit(t *testing.T) {
 				return
 			}
 
-			assert.Check(t, err)
+			assert.NilError(t, err)
 			assert.Check(t, is.Equal(m.Destination, tc.expDest))
 			assert.Check(t, is.Equal(m.Source, tc.expSource))
 			assert.Check(t, is.Equal(m.Name, tc.expName))

--- a/volume/mounts/parser_test.go
+++ b/volume/mounts/parser_test.go
@@ -82,7 +82,8 @@ func TestParseMountSpec(t *testing.T) {
 		tc := tc
 		t.Run("", func(t *testing.T) {
 			mp, err := parser.ParseMountSpec(tc.input)
-			assert.Check(t, err)
+			assert.NilError(t, err)
+
 			assert.Check(t, is.Equal(mp.Type, tc.expected.Type))
 			assert.Check(t, is.Equal(mp.Destination, tc.expected.Destination))
 			assert.Check(t, is.Equal(mp.Source, tc.expected.Source))

--- a/volume/mounts/windows_parser_test.go
+++ b/volume/mounts/windows_parser_test.go
@@ -234,7 +234,7 @@ func TestWindowsParseMountRawSplit(t *testing.T) {
 				return
 			}
 
-			assert.Check(t, err)
+			assert.NilError(t, err)
 			assert.Check(t, is.Equal(m.Destination, tc.expDest))
 			assert.Check(t, is.Equal(m.Source, tc.expSource))
 			assert.Check(t, is.Equal(m.Name, tc.expName))

--- a/volume/service/store_test.go
+++ b/volume/service/store_test.go
@@ -379,7 +379,7 @@ func setupTest(t *testing.T) (*VolumeStore, func()) {
 	}
 
 	s, err := NewStore(dir, volumedrivers.NewStore(nil))
-	assert.Check(t, err)
+	assert.NilError(t, err)
 	return s, func() {
 		s.Shutdown()
 		cleanup()


### PR DESCRIPTION
In these cases, continuing after a non nil error will result in a nil dereference in panic.
Change the `assert.Check` to `assert.NilError` to avoid that.

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

