### PR TITLE
daemon/create.go: Supersede github.com/pkg/errors

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -305,7 +305,7 @@ func (daemon *Daemon) mergeAndVerifyConfig(config *containertypes.Config, img *i
 		config.Entrypoint = nil
 	}
 	if len(config.Entrypoint) == 0 && len(config.Cmd) == 0 {
-		return fmt.Errorf("No command specified")
+		return fmt.Errorf("no command specified")
 	}
 	return nil
 }
@@ -321,7 +321,7 @@ func verifyNetworkingConfig(nwConfig *networktypes.NetworkingConfig) error {
 		for k := range nwConfig.EndpointsConfig {
 			l = append(l, k)
 		}
-		return fmt.Errorf("Container cannot be connected to network endpoints: %s", strings.Join(l, ", "))
+		return fmt.Errorf("container cannot be connected to network endpoints: %s", strings.Join(l, ", "))
 	}
 
 	for k, v := range nwConfig.EndpointsConfig {

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -2,6 +2,7 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"runtime"
@@ -23,7 +24,6 @@ import (
 	"github.com/docker/docker/runconfig"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/selinux/go-selinux"
-	"github.com/pkg/errors"
 	archvariant "github.com/tonistiigi/go-archvariant"
 )
 
@@ -321,23 +321,23 @@ func verifyNetworkingConfig(nwConfig *networktypes.NetworkingConfig) error {
 		for k := range nwConfig.EndpointsConfig {
 			l = append(l, k)
 		}
-		return errors.Errorf("Container cannot be connected to network endpoints: %s", strings.Join(l, ", "))
+		return fmt.Errorf("Container cannot be connected to network endpoints: %s", strings.Join(l, ", "))
 	}
 
 	for k, v := range nwConfig.EndpointsConfig {
 		if v == nil {
-			return errors.Errorf("no EndpointSettings for %s", k)
+			return fmt.Errorf("no EndpointSettings for %s", k)
 		}
 		if v.IPAMConfig != nil {
 			if v.IPAMConfig.IPv4Address != "" && net.ParseIP(v.IPAMConfig.IPv4Address).To4() == nil {
-				return errors.Errorf("invalid IPv4 address: %s", v.IPAMConfig.IPv4Address)
+				return fmt.Errorf("invalid IPv4 address: %s", v.IPAMConfig.IPv4Address)
 			}
 			if v.IPAMConfig.IPv6Address != "" {
 				n := net.ParseIP(v.IPAMConfig.IPv6Address)
 				// if the address is an invalid network address (ParseIP == nil) or if it is
 				// an IPv4 address (To4() != nil), then it is an invalid IPv6 address
 				if n == nil || n.To4() != nil {
-					return errors.Errorf("invalid IPv6 address: %s", v.IPAMConfig.IPv6Address)
+					return fmt.Errorf("invalid IPv6 address: %s", v.IPAMConfig.IPv6Address)
 				}
 			}
 		}

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -550,8 +550,7 @@ func (s *DockerAPISuite) TestContainerAPICreateEmptyConfig(c *testing.T) {
 
 	_, err = apiClient.ContainerCreate(context.Background(), &container.Config{}, &container.HostConfig{}, &network.NetworkingConfig{}, nil, "")
 
-	expected := "No command specified"
-	assert.ErrorContains(c, err, expected)
+	assert.ErrorContains(c, err, "no command specified")
 }
 
 func (s *DockerAPISuite) TestContainerAPICreateMultipleNetworksConfig(c *testing.T) {
@@ -575,7 +574,7 @@ func (s *DockerAPISuite) TestContainerAPICreateMultipleNetworksConfig(c *testing
 	_, err = apiClient.ContainerCreate(context.Background(), &config, &container.HostConfig{}, &networkingConfig, nil, "")
 	msg := err.Error()
 	// network name order in error message is not deterministic
-	assert.Assert(c, strings.Contains(msg, "Container cannot be connected to network endpoints"))
+	assert.Assert(c, strings.Contains(msg, "container cannot be connected to network endpoints"))
 	assert.Assert(c, strings.Contains(msg, "net1"))
 	assert.Assert(c, strings.Contains(msg, "net2"))
 	assert.Assert(c, strings.Contains(msg, "net3"))

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1948,7 +1948,7 @@ func (s *DockerCLIRunSuite) TestRunCidFileCleanupIfEmpty(c *testing.T) {
 	out, _, err := dockerCmdWithError("run", "--cidfile", tmpCidFile, image)
 	if err == nil {
 		c.Fatalf("Run without command must fail. out=%s", out)
-	} else if !strings.Contains(out, "No command specified") {
+	} else if !strings.Contains(out, "no command specified") {
 		c.Fatalf("Run without command failed with wrong output. out=%s\nerr=%v", out, err)
 	}
 
@@ -3988,7 +3988,7 @@ exec "$@"`,
 	// CMD will be reset as well (the same as setting a custom entrypoint)
 	cli.Docker(cli.Args("run", "--entrypoint=", "-t", name)).Assert(c, icmd.Expected{
 		ExitCode: 125,
-		Err:      "No command specified",
+		Err:      "no command specified",
 	})
 }
 


### PR DESCRIPTION
**- What I did**

Replaced `github.com/pkg/errors` with std `errors`. It'll make it possible to use `errors.Join()` in that file. And also, fixed some errors capitalization while at it.
