### PR TITLE
[20.10] Discourage from building with Go older than 1.19

### DIFF
--- a/daemon/minimum_go_version_is_1.19.go
+++ b/daemon/minimum_go_version_is_1.19.go
@@ -1,0 +1,8 @@
+//go:build !go1.19
+package daemon
+// We don't have a go.mod in this version, so this is a hacky way to prevent
+// building this package with pre-1.19 Go version.
+//
+// If you really, really don't care about support and need to build using pre-1.19 version, please make sure to revendor the vendored dependencies (./hack/vendor.sh) and delete this file.
+Purposeful_build_error_Minimum_supported_Go_version_is_1_19
+


### PR DESCRIPTION
Last week some people reported issues with ownership issues (https://github.com/docker/cli/issues/4481, https://github.com/moby/moby/issues/46161) which were reproducible only on the 20.10.25 packaged by Ubuntu (`docker.io` package). This turned out to be an issue with a `unix` build flag not being set by the used Go compiler (more specifically - unix build flag which was introduced in Go 1.19).

This PR introduces an intentional build error when building with Go older than 1.19.
