### PR TITLE
Fixes docker icc + firewalld docker zone

### DIFF
--- a/libnetwork/drivers/bridge/setup_ip_tables.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables.go
@@ -332,6 +332,13 @@ func setIcc(version iptables.IPVersion, bridgeIface string, iccEnable, insert bo
 		}
 	}
 
+	// Ensure bridge interface is added to the docker zone ONLY when icc is enabled
+	if iccEnable {
+		if err := iptables.SetupInterfaceFirewalldZone(bridgeIface, insert); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/libnetwork/drivers/bridge/setup_ip_tables.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables.go
@@ -341,7 +341,7 @@ func setIcc(version iptables.IPVersion, bridgeIface string, iccEnable, insert bo
 					return err
 				}
 			} else {
-				if err := iptables.DelInterfaceFirewalld(bridgeIface); err != nil && !errdefs.IsNotFound(err) {
+				if err := iptables.DelInterfaceFirewalld(bridgeIface); err != nil {
 					return err
 				}
 			}

--- a/libnetwork/drivers/bridge/setup_ip_tables.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables.go
@@ -334,8 +334,17 @@ func setIcc(version iptables.IPVersion, bridgeIface string, iccEnable, insert bo
 
 	// Ensure bridge interface is added to the docker zone ONLY when icc is enabled
 	if iccEnable {
-		if err := iptables.SetupInterfaceFirewalldZone(bridgeIface, insert); err != nil {
-			return err
+		// Is firewalld Running?
+		if iptables.FirewalldCheckRunning() {
+			if insert {
+				if err := iptables.AddInterfaceFirewalld(bridgeIface); err != nil {
+					return err
+				}
+			} else {
+				if err := iptables.DelInterfaceFirewalld(bridgeIface); err != nil && !errdefs.IsNotFound(err) {
+					return err
+				}
+			}
 		}
 	}
 

--- a/libnetwork/iptables/firewalld.go
+++ b/libnetwork/iptables/firewalld.go
@@ -282,6 +282,22 @@ func DelInterfaceFirewalld(intf string) error {
 	return nil
 }
 
+func SetupInterfaceFirewalldZone(bridgeName string, enable bool) error {
+	// Either add or remove the interface from the firewalld zone
+	if firewalldRunning {
+		if enable {
+			if err := AddInterfaceFirewalld(bridgeName); err != nil {
+				return err
+			}
+		} else {
+			if err := DelInterfaceFirewalld(bridgeName); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func contains(list []string, val string) bool {
 	for _, v := range list {
 		if v == val {

--- a/libnetwork/iptables/firewalld_test.go
+++ b/libnetwork/iptables/firewalld_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestFirewalldInit(t *testing.T) {
-	if !checkRunning() {
+	if !FirewalldCheckRunning() {
 		t.Skip("firewalld is not running")
 	}
 	if err := firewalldInit(); err != nil {

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -202,19 +202,6 @@ func (iptable IPTable) ProgramChain(c *ChainInfo, bridgeName string, hairpinMode
 		return errors.New("could not program chain, missing chain name")
 	}
 
-	// Either add or remove the interface from the firewalld zone
-	if firewalldRunning {
-		if enable {
-			if err := AddInterfaceFirewalld(bridgeName); err != nil {
-				return err
-			}
-		} else {
-			if err := DelInterfaceFirewalld(bridgeName); err != nil {
-				return err
-			}
-		}
-	}
-
 	switch c.Table {
 	case Nat:
 		preroute := []string{


### PR DESCRIPTION
- Fixes when docker should add the interface to the firewalld docker zone
- FollowUP of Issue #45126 / PR #45127

I had to open this new PR because the old one was autoclosed when I synched my fork with main repo.

After 2 failed attempts to fix the issue, and thanks to all the feedback, I decided to create a new test environment with an Ubuntu-22.04LTS VM and a Fedora38 VM for further testing/investigation. This helped clear my mind about what icc and internal really means to docker (hopefully).

After extensive testing, my conclusion was simple: any bridge interface with icc enabled should be added to the docker firewalld zone. The internal option is being handled correctly.

After re-analysing the code, came up with a new possible solution.

~~Here's some rationale about how I see docker bridges should behave:~~

~~Internal is meant to define wether the container should communicate with other hosts, and icc is meant to allow communication between containers. Those concepts were a bit mixed in my mind before.~~

~~Anyway, the current interaction of docker with firewalld does not result in the desired state, at least in an default install on Ubuntu/Fedora.~~

~~I have created a test script and a compose to automate the tests, and the network section of the compose file is this:~~

```yaml
networks:

  # Should communicate with containers and external hosts 
  default_bridge_settings:
    driver: bridge
    driver_opts:
      com.docker.network.bridge.name: docker_default

  # Group1: setting enable_icc to true
  
  # Should communicate with containers and external hosts
  icc_enabled:
    driver: bridge
    driver_opts:
      com.docker.network.bridge.name: icc
      com.docker.network.bridge.enable_icc: "true"
      
  # Should communicate with containers and external hosts 
  icc_enabled_nointernal:
    internal: false
    driver: bridge
    driver_opts:
      com.docker.network.bridge.name: icc_nointernal
      com.docker.network.bridge.enable_icc: "true"

  # Should communicate with containers ONLY
  icc_enabled_internal:
    internal: true
    driver: bridge
    driver_opts:
      com.docker.network.bridge.name: icc_internal
      com.docker.network.bridge.enable_icc: "true"

  # Group2: setting enable_icc to false
  
  # Should communicate with external hosts ONLY
  icc_disabled:
    driver: bridge
    driver_opts:
      com.docker.network.bridge.name: noicc
      com.docker.network.bridge.enable_icc: "false"

  # Should communicate with external hosts ONLY
  icc_disabled_nointernal:
    internal: false
    driver: bridge
    driver_opts:
      com.docker.network.bridge.name: noicc_noint
      com.docker.network.bridge.enable_icc: "false"

  # Should NOT communicate with any containers or external hosts 
  icc_disabled_internal:
    internal: true
    driver: bridge
    driver_opts:
      com.docker.network.bridge.name: noicc_internal
      com.docker.network.bridge.enable_icc: "false"
```

considering that the default value for internal is false AND com.docker.network.bridge.enable_icc is true, the **default_bridge_settings, icc_enabled and icc_enabled_internal** are the same, and **icc_disabled is equal to icc_disabled_nointernal**.

The only useful declarations are for icc_enabled_internal, where the network only works between the attached containers and icc_disabled/icc_disabled_nointernal where the container should communicate with external hosts only, not with other containers connected to the same bridge.

icc_enabled_internal configuration is meant to create a private network to be used between a backend and frontend container, where the frontend container should be connected to another network with the icc_disabled config type to the outide world or another private network such as an nginx proxy, which is then part of another network of config icc_disabled.

AND, from my observation, I believe those features only works when iptables is enabled in docker config.

Here's my test results:

![image](https://github.com/moby/moby/assets/834010/1d7580c7-058b-4763-8827-569fea8967b2)

![image](https://github.com/moby/moby/assets/834010/2a7a04e3-edc4-4e8d-a5f5-7a6bd7d4b93f)

A few notes about the above results:
- I had to add ens192 to the public firewalld zone on Ubuntu, to behave exactly like Fedora when using firewalld. And the "ens192 not in public zone" shows the behavior of firewalld without ens192 in public zone. Fedora defaults to add the iface to the public zone.
-  After re-reading the source and trying to track what exactly the code was doing with AddInterfaceFirewalld and DelInterfaceFirewalld, I hope I got it right this time.

Thanks for all the feedback / orientation