### PR TITLE
integration/container: refactor some test-utilities and fix var-names shadowing imports

### DIFF
--- a/integration/container/attach_test.go
+++ b/integration/container/attach_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestAttach(t *testing.T) {
 	t.Cleanup(setupTest(t))
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	tests := []struct {
 		doc               string
@@ -34,7 +34,7 @@ func TestAttach(t *testing.T) {
 		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			t.Parallel()
-			resp, err := client.ContainerCreate(context.Background(),
+			resp, err := apiClient.ContainerCreate(context.Background(),
 				&container.Config{
 					Image: "busybox",
 					Cmd:   []string{"echo", "hello"},
@@ -46,7 +46,7 @@ func TestAttach(t *testing.T) {
 				"",
 			)
 			assert.NilError(t, err)
-			attach, err := client.ContainerAttach(context.Background(), resp.ID, types.ContainerAttachOptions{
+			attach, err := apiClient.ContainerAttach(context.Background(), resp.ID, types.ContainerAttachOptions{
 				Stdout: true,
 				Stderr: true,
 			})

--- a/integration/container/cdi_test.go
+++ b/integration/container/cdi_test.go
@@ -30,16 +30,16 @@ func TestCreateWithCDIDevices(t *testing.T) {
 	d.StartWithBusybox(t, "--cdi-spec-dir="+filepath.Join(cwd, "testdata", "cdi"))
 	defer d.Stop(t)
 
-	client := d.NewClientT(t)
+	apiClient := d.NewClientT(t)
 
 	ctx := context.Background()
-	id := container.Run(ctx, t, client,
+	id := container.Run(ctx, t, apiClient,
 		container.WithCmd("/bin/sh", "-c", "env"),
 		container.WithCDIDevices("vendor1.com/device=foo"),
 	)
-	defer client.ContainerRemove(ctx, id, types.ContainerRemoveOptions{Force: true})
+	defer apiClient.ContainerRemove(ctx, id, types.ContainerRemoveOptions{Force: true})
 
-	inspect, err := client.ContainerInspect(ctx, id)
+	inspect, err := apiClient.ContainerInspect(ctx, id)
 	assert.NilError(t, err)
 
 	expectedRequests := []containertypes.DeviceRequest{
@@ -50,7 +50,7 @@ func TestCreateWithCDIDevices(t *testing.T) {
 	}
 	assert.Check(t, is.DeepEqual(inspect.HostConfig.DeviceRequests, expectedRequests))
 
-	reader, err := client.ContainerLogs(ctx, id, types.ContainerLogsOptions{
+	reader, err := apiClient.ContainerLogs(ctx, id, types.ContainerLogsOptions{
 		ShowStdout: true,
 	})
 	assert.NilError(t, err)

--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -25,10 +25,10 @@ func TestCopyFromContainerPathDoesNotExist(t *testing.T) {
 	defer setupTest(t)()
 
 	ctx := context.Background()
-	apiclient := testEnv.APIClient()
-	cid := container.Create(ctx, t, apiclient)
+	apiClient := testEnv.APIClient()
+	cid := container.Create(ctx, t, apiClient)
 
-	_, _, err := apiclient.CopyFromContainer(ctx, cid, "/dne")
+	_, _, err := apiClient.CopyFromContainer(ctx, cid, "/dne")
 	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 	assert.Check(t, is.ErrorContains(err, "Could not find the file /dne in container "+cid))
 }
@@ -37,8 +37,8 @@ func TestCopyFromContainerPathIsNotDir(t *testing.T) {
 	defer setupTest(t)()
 
 	ctx := context.Background()
-	apiclient := testEnv.APIClient()
-	cid := container.Create(ctx, t, apiclient)
+	apiClient := testEnv.APIClient()
+	cid := container.Create(ctx, t, apiClient)
 
 	path := "/etc/passwd/"
 	expected := "not a directory"
@@ -46,7 +46,7 @@ func TestCopyFromContainerPathIsNotDir(t *testing.T) {
 		path = "c:/windows/system32/drivers/etc/hosts/"
 		expected = "The filename, directory name, or volume label syntax is incorrect."
 	}
-	_, _, err := apiclient.CopyFromContainer(ctx, cid, path)
+	_, _, err := apiClient.CopyFromContainer(ctx, cid, path)
 	assert.Assert(t, is.ErrorContains(err, expected))
 }
 
@@ -54,10 +54,10 @@ func TestCopyToContainerPathDoesNotExist(t *testing.T) {
 	defer setupTest(t)()
 
 	ctx := context.Background()
-	apiclient := testEnv.APIClient()
-	cid := container.Create(ctx, t, apiclient)
+	apiClient := testEnv.APIClient()
+	cid := container.Create(ctx, t, apiClient)
 
-	err := apiclient.CopyToContainer(ctx, cid, "/dne", nil, types.CopyToContainerOptions{})
+	err := apiClient.CopyToContainer(ctx, cid, "/dne", nil, types.CopyToContainerOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 	assert.Check(t, is.ErrorContains(err, "Could not find the file /dne in container "+cid))
 }
@@ -66,28 +66,28 @@ func TestCopyEmptyFile(t *testing.T) {
 	defer setupTest(t)()
 
 	ctx := context.Background()
-	apiclient := testEnv.APIClient()
-	cid := container.Create(ctx, t, apiclient)
+	apiClient := testEnv.APIClient()
+	cid := container.Create(ctx, t, apiClient)
 
 	// empty content
 	dstDir, _ := makeEmptyArchive(t)
-	err := apiclient.CopyToContainer(ctx, cid, dstDir, bytes.NewReader([]byte("")), types.CopyToContainerOptions{})
+	err := apiClient.CopyToContainer(ctx, cid, dstDir, bytes.NewReader([]byte("")), types.CopyToContainerOptions{})
 	assert.NilError(t, err)
 
 	// tar with empty file
 	dstDir, preparedArchive := makeEmptyArchive(t)
-	err = apiclient.CopyToContainer(ctx, cid, dstDir, preparedArchive, types.CopyToContainerOptions{})
+	err = apiClient.CopyToContainer(ctx, cid, dstDir, preparedArchive, types.CopyToContainerOptions{})
 	assert.NilError(t, err)
 
 	// tar with empty file archive mode
 	dstDir, preparedArchive = makeEmptyArchive(t)
-	err = apiclient.CopyToContainer(ctx, cid, dstDir, preparedArchive, types.CopyToContainerOptions{
+	err = apiClient.CopyToContainer(ctx, cid, dstDir, preparedArchive, types.CopyToContainerOptions{
 		CopyUIDGID: true,
 	})
 	assert.NilError(t, err)
 
 	// copy from empty file
-	rdr, _, err := apiclient.CopyFromContainer(ctx, cid, dstDir)
+	rdr, _, err := apiClient.CopyFromContainer(ctx, cid, dstDir)
 	assert.NilError(t, err)
 	defer rdr.Close()
 }
@@ -123,14 +123,14 @@ func TestCopyToContainerPathIsNotDir(t *testing.T) {
 	defer setupTest(t)()
 
 	ctx := context.Background()
-	apiclient := testEnv.APIClient()
-	cid := container.Create(ctx, t, apiclient)
+	apiClient := testEnv.APIClient()
+	cid := container.Create(ctx, t, apiClient)
 
 	path := "/etc/passwd/"
 	if testEnv.DaemonInfo.OSType == "windows" {
 		path = "c:/windows/system32/drivers/etc/hosts/"
 	}
-	err := apiclient.CopyToContainer(ctx, cid, path, nil, types.CopyToContainerOptions{})
+	err := apiClient.CopyToContainer(ctx, cid, path, nil, types.CopyToContainerOptions{})
 	assert.Check(t, is.ErrorContains(err, "not a directory"))
 }
 

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestCreateFailsWhenIdentifierDoesNotExist(t *testing.T) {
 	t.Cleanup(setupTest(t))
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	testCases := []struct {
 		doc           string
@@ -53,7 +53,7 @@ func TestCreateFailsWhenIdentifierDoesNotExist(t *testing.T) {
 		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			t.Parallel()
-			_, err := client.ContainerCreate(context.Background(),
+			_, err := apiClient.ContainerCreate(context.Background(),
 				&container.Config{Image: tc.image},
 				&container.HostConfig{},
 				&network.NetworkingConfig{},
@@ -72,9 +72,9 @@ func TestCreateFailsWhenIdentifierDoesNotExist(t *testing.T) {
 func TestCreateLinkToNonExistingContainer(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "legacy links are not supported on windows")
 	defer setupTest(t)()
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
-	_, err := c.ContainerCreate(context.Background(),
+	_, err := apiClient.ContainerCreate(context.Background(),
 		&container.Config{
 			Image: "busybox",
 		},
@@ -91,7 +91,7 @@ func TestCreateLinkToNonExistingContainer(t *testing.T) {
 
 func TestCreateWithInvalidEnv(t *testing.T) {
 	t.Cleanup(setupTest(t))
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	testCases := []struct {
 		env           string
@@ -115,7 +115,7 @@ func TestCreateWithInvalidEnv(t *testing.T) {
 		tc := tc
 		t.Run(strconv.Itoa(index), func(t *testing.T) {
 			t.Parallel()
-			_, err := client.ContainerCreate(context.Background(),
+			_, err := apiClient.ContainerCreate(context.Background(),
 				&container.Config{
 					Image: "busybox",
 					Env:   []string{tc.env},
@@ -136,7 +136,7 @@ func TestCreateTmpfsMountsTarget(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	testCases := []struct {
 		target        string
@@ -161,7 +161,7 @@ func TestCreateTmpfsMountsTarget(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		_, err := client.ContainerCreate(context.Background(),
+		_, err := apiClient.ContainerCreate(context.Background(),
 			&container.Config{
 				Image: "busybox",
 			},
@@ -181,7 +181,7 @@ func TestCreateWithCustomMaskedPaths(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
 	testCases := []struct {
@@ -203,7 +203,7 @@ func TestCreateWithCustomMaskedPaths(t *testing.T) {
 	}
 
 	checkInspect := func(t *testing.T, ctx context.Context, name string, expected []string) {
-		_, b, err := client.ContainerInspectWithRaw(ctx, name, false)
+		_, b, err := apiClient.ContainerInspectWithRaw(ctx, name, false)
 		assert.NilError(t, err)
 
 		var inspectJSON map[string]interface{}
@@ -236,7 +236,7 @@ func TestCreateWithCustomMaskedPaths(t *testing.T) {
 		}
 
 		// Create the container.
-		c, err := client.ContainerCreate(context.Background(),
+		c, err := apiClient.ContainerCreate(context.Background(),
 			&config,
 			&hc,
 			&network.NetworkingConfig{},
@@ -248,10 +248,10 @@ func TestCreateWithCustomMaskedPaths(t *testing.T) {
 		checkInspect(t, ctx, name, tc.expected)
 
 		// Start the container.
-		err = client.ContainerStart(ctx, c.ID, types.ContainerStartOptions{})
+		err = apiClient.ContainerStart(ctx, c.ID, types.ContainerStartOptions{})
 		assert.NilError(t, err)
 
-		poll.WaitOn(t, ctr.IsInState(ctx, client, c.ID, "exited"), poll.WithDelay(100*time.Millisecond))
+		poll.WaitOn(t, ctr.IsInState(ctx, apiClient, c.ID, "exited"), poll.WithDelay(100*time.Millisecond))
 
 		checkInspect(t, ctx, name, tc.expected)
 	}
@@ -261,7 +261,7 @@ func TestCreateWithCustomReadonlyPaths(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
 	testCases := []struct {
@@ -283,7 +283,7 @@ func TestCreateWithCustomReadonlyPaths(t *testing.T) {
 	}
 
 	checkInspect := func(t *testing.T, ctx context.Context, name string, expected []string) {
-		_, b, err := client.ContainerInspectWithRaw(ctx, name, false)
+		_, b, err := apiClient.ContainerInspectWithRaw(ctx, name, false)
 		assert.NilError(t, err)
 
 		var inspectJSON map[string]interface{}
@@ -315,7 +315,7 @@ func TestCreateWithCustomReadonlyPaths(t *testing.T) {
 		}
 
 		// Create the container.
-		c, err := client.ContainerCreate(context.Background(),
+		c, err := apiClient.ContainerCreate(context.Background(),
 			&config,
 			&hc,
 			&network.NetworkingConfig{},
@@ -327,10 +327,10 @@ func TestCreateWithCustomReadonlyPaths(t *testing.T) {
 		checkInspect(t, ctx, name, tc.expected)
 
 		// Start the container.
-		err = client.ContainerStart(ctx, c.ID, types.ContainerStartOptions{})
+		err = apiClient.ContainerStart(ctx, c.ID, types.ContainerStartOptions{})
 		assert.NilError(t, err)
 
-		poll.WaitOn(t, ctr.IsInState(ctx, client, c.ID, "exited"), poll.WithDelay(100*time.Millisecond))
+		poll.WaitOn(t, ctr.IsInState(ctx, apiClient, c.ID, "exited"), poll.WithDelay(100*time.Millisecond))
 
 		checkInspect(t, ctx, name, tc.expected)
 	}
@@ -338,7 +338,7 @@ func TestCreateWithCustomReadonlyPaths(t *testing.T) {
 
 func TestCreateWithInvalidHealthcheckParams(t *testing.T) {
 	t.Cleanup(setupTest(t))
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
 	testCases := []struct {
@@ -403,7 +403,7 @@ func TestCreateWithInvalidHealthcheckParams(t *testing.T) {
 				cfg.Healthcheck.StartPeriod = tc.startPeriod
 			}
 
-			resp, err := client.ContainerCreate(ctx, &cfg, &container.HostConfig{}, nil, nil, "")
+			resp, err := apiClient.ContainerCreate(ctx, &cfg, &container.HostConfig{}, nil, nil, "")
 			assert.Check(t, is.Equal(len(resp.Warnings), 0))
 
 			if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
@@ -421,10 +421,10 @@ func TestCreateWithInvalidHealthcheckParams(t *testing.T) {
 func TestCreateTmpfsOverrideAnonymousVolume(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "windows does not support tmpfs")
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
-	id := ctr.Create(ctx, t, client,
+	id := ctr.Create(ctx, t, apiClient,
 		ctr.WithVolume("/foo"),
 		ctr.WithTmpfs("/foo"),
 		ctr.WithVolume("/bar"),
@@ -433,18 +433,18 @@ func TestCreateTmpfsOverrideAnonymousVolume(t *testing.T) {
 	)
 
 	defer func() {
-		err := client.ContainerRemove(ctx, id, types.ContainerRemoveOptions{Force: true})
+		err := apiClient.ContainerRemove(ctx, id, types.ContainerRemoveOptions{Force: true})
 		assert.NilError(t, err)
 	}()
 
-	inspect, err := client.ContainerInspect(ctx, id)
+	inspect, err := apiClient.ContainerInspect(ctx, id)
 	assert.NilError(t, err)
 	// tmpfs do not currently get added to inspect.Mounts
 	// Normally an anonymous volume would, except now tmpfs should prevent that.
 	assert.Assert(t, is.Len(inspect.Mounts, 0))
 
-	chWait, chErr := client.ContainerWait(ctx, id, container.WaitConditionNextExit)
-	assert.NilError(t, client.ContainerStart(ctx, id, types.ContainerStartOptions{}))
+	chWait, chErr := apiClient.ContainerWait(ctx, id, container.WaitConditionNextExit)
+	assert.NilError(t, apiClient.ContainerStart(ctx, id, types.ContainerStartOptions{}))
 
 	timeout := time.NewTimer(30 * time.Second)
 	defer timeout.Stop()
@@ -467,10 +467,10 @@ func TestCreateTmpfsOverrideAnonymousVolume(t *testing.T) {
 // error.
 func TestCreateDifferentPlatform(t *testing.T) {
 	defer setupTest(t)()
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
-	img, _, err := c.ImageInspectWithRaw(ctx, "busybox:latest")
+	img, _, err := apiClient.ImageInspectWithRaw(ctx, "busybox:latest")
 	assert.NilError(t, err)
 	assert.Assert(t, img.Architecture != "")
 
@@ -480,7 +480,7 @@ func TestCreateDifferentPlatform(t *testing.T) {
 			Architecture: img.Architecture,
 			Variant:      img.Variant,
 		}
-		_, err := c.ContainerCreate(ctx, &containertypes.Config{Image: "busybox:latest"}, &containertypes.HostConfig{}, nil, &p, "")
+		_, err := apiClient.ContainerCreate(ctx, &containertypes.Config{Image: "busybox:latest"}, &containertypes.HostConfig{}, nil, &p, "")
 		assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 	})
 	t.Run("different cpu arch", func(t *testing.T) {
@@ -489,16 +489,16 @@ func TestCreateDifferentPlatform(t *testing.T) {
 			Architecture: img.Architecture + "DifferentArch",
 			Variant:      img.Variant,
 		}
-		_, err := c.ContainerCreate(ctx, &containertypes.Config{Image: "busybox:latest"}, &containertypes.HostConfig{}, nil, &p, "")
+		_, err := apiClient.ContainerCreate(ctx, &containertypes.Config{Image: "busybox:latest"}, &containertypes.HostConfig{}, nil, &p, "")
 		assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 	})
 }
 
 func TestCreateVolumesFromNonExistingContainer(t *testing.T) {
 	defer setupTest(t)()
-	cli := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
-	_, err := cli.ContainerCreate(
+	_, err := apiClient.ContainerCreate(
 		context.Background(),
 		&container.Config{Image: "busybox"},
 		&container.HostConfig{VolumesFrom: []string{"nosuchcontainer"}},
@@ -516,9 +516,9 @@ func TestCreatePlatformSpecificImageNoPlatform(t *testing.T) {
 
 	skip.If(t, testEnv.DaemonInfo.Architecture == "arm", "test only makes sense to run on non-arm systems")
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux", "test image is only available on linux")
-	cli := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
-	_, err := cli.ContainerCreate(
+	_, err := apiClient.ContainerCreate(
 		context.Background(),
 		&container.Config{Image: "arm32v7/hello-world"},
 		&container.HostConfig{},

--- a/integration/container/daemon_test.go
+++ b/integration/container/daemon_test.go
@@ -27,25 +27,25 @@ func TestContainerKillOnDaemonStart(t *testing.T) {
 	d.StartWithBusybox(t, "--iptables=false")
 	defer d.Stop(t)
 
-	client := d.NewClientT(t)
+	apiClient := d.NewClientT(t)
 	ctx := context.Background()
 
 	// The intention of this container is to ignore stop signals.
 	// Sadly this means the test will take longer, but at least this test can be parallelized.
-	id := container.Run(ctx, t, client, container.WithCmd("/bin/sh", "-c", "while true; do echo hello; sleep 1; done"))
+	id := container.Run(ctx, t, apiClient, container.WithCmd("/bin/sh", "-c", "while true; do echo hello; sleep 1; done"))
 	defer func() {
-		err := client.ContainerRemove(ctx, id, types.ContainerRemoveOptions{Force: true})
+		err := apiClient.ContainerRemove(ctx, id, types.ContainerRemoveOptions{Force: true})
 		assert.NilError(t, err)
 	}()
 
-	inspect, err := client.ContainerInspect(ctx, id)
+	inspect, err := apiClient.ContainerInspect(ctx, id)
 	assert.NilError(t, err)
 	assert.Assert(t, inspect.State.Running)
 
 	assert.NilError(t, d.Kill())
 	d.Start(t, "--iptables=false")
 
-	inspect, err = client.ContainerInspect(ctx, id)
+	inspect, err = apiClient.ContainerInspect(ctx, id)
 	assert.Check(t, is.Nil(err))
 	assert.Assert(t, !inspect.State.Running)
 }

--- a/integration/container/diff_test.go
+++ b/integration/container/diff_test.go
@@ -15,10 +15,10 @@ import (
 func TestDiff(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(ctx, t, client, container.WithCmd("sh", "-c", `mkdir /foo; echo xyzzy > /foo/bar`))
+	cID := container.Run(ctx, t, apiClient, container.WithCmd("sh", "-c", `mkdir /foo; echo xyzzy > /foo/bar`))
 
 	// Wait for it to exit as cannot diff a running container on Windows, and
 	// it will take a few seconds to exit. Also there's no way in Windows to
@@ -29,14 +29,14 @@ func TestDiff(t *testing.T) {
 		{Kind: containertypes.ChangeAdd, Path: "/foo/bar"},
 	}
 	if testEnv.DaemonInfo.OSType == "windows" {
-		poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(60*time.Second))
+		poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "exited"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(60*time.Second))
 		expected = []containertypes.FilesystemChange{
 			{Kind: containertypes.ChangeModify, Path: "Files/foo"},
 			{Kind: containertypes.ChangeModify, Path: "Files/foo/bar"},
 		}
 	}
 
-	items, err := client.ContainerDiff(ctx, cID)
+	items, err := apiClient.ContainerDiff(ctx, cID)
 	assert.NilError(t, err)
 	assert.DeepEqual(t, expected, items)
 }

--- a/integration/container/exec_linux_test.go
+++ b/integration/container/exec_linux_test.go
@@ -17,12 +17,12 @@ func TestExecConsoleSize(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.42"), "skip test from new feature")
 
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(ctx, t, client, container.WithImage("busybox"))
+	cID := container.Run(ctx, t, apiClient, container.WithImage("busybox"))
 
-	result, err := container.Exec(ctx, client, cID, []string{"stty", "size"},
+	result, err := container.Exec(ctx, apiClient, cID, []string{"stty", "size"},
 		func(ec *types.ExecConfig) {
 			ec.Tty = true
 			ec.ConsoleSize = &[2]uint{57, 123}

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -22,13 +22,13 @@ func TestExecWithCloseStdin(t *testing.T) {
 	defer setupTest(t)()
 
 	ctx := context.Background()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	// run top with detached mode
-	cID := container.Run(ctx, t, client)
+	cID := container.Run(ctx, t, apiClient)
 
 	expected := "closeIO"
-	execResp, err := client.ContainerExecCreate(ctx, cID,
+	execResp, err := apiClient.ContainerExecCreate(ctx, cID,
 		types.ExecConfig{
 			AttachStdin:  true,
 			AttachStdout: true,
@@ -37,7 +37,7 @@ func TestExecWithCloseStdin(t *testing.T) {
 	)
 	assert.NilError(t, err)
 
-	resp, err := client.ContainerExecAttach(ctx, execResp.ID,
+	resp, err := apiClient.ContainerExecAttach(ctx, execResp.ID,
 		types.ExecStartCheck{
 			Detach: false,
 			Tty:    false,
@@ -88,11 +88,11 @@ func TestExec(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.35"), "broken in earlier versions")
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
-	cID := container.Run(ctx, t, client, container.WithTty(true), container.WithWorkingDir("/root"))
+	cID := container.Run(ctx, t, apiClient, container.WithTty(true), container.WithWorkingDir("/root"))
 
-	id, err := client.ContainerExecCreate(ctx, cID,
+	id, err := apiClient.ContainerExecCreate(ctx, cID,
 		types.ExecConfig{
 			WorkingDir:   "/tmp",
 			Env:          strslice.StrSlice([]string{"FOO=BAR"}),
@@ -102,11 +102,11 @@ func TestExec(t *testing.T) {
 	)
 	assert.NilError(t, err)
 
-	inspect, err := client.ContainerExecInspect(ctx, id.ID)
+	inspect, err := apiClient.ContainerExecInspect(ctx, id.ID)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(inspect.ExecID, id.ID))
 
-	resp, err := client.ContainerExecAttach(ctx, id.ID,
+	resp, err := apiClient.ContainerExecAttach(ctx, id.ID,
 		types.ExecStartCheck{
 			Detach: false,
 			Tty:    false,
@@ -131,11 +131,11 @@ func TestExecUser(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME. Probably needs to wait for container to be in running state.")
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
-	cID := container.Run(ctx, t, client, container.WithTty(true), container.WithUser("1:1"))
+	cID := container.Run(ctx, t, apiClient, container.WithTty(true), container.WithUser("1:1"))
 
-	result, err := container.Exec(ctx, client, cID, []string{"id"})
+	result, err := container.Exec(ctx, apiClient, cID, []string{"id"})
 	assert.NilError(t, err)
 
 	assert.Assert(t, is.Contains(result.Stdout(), "uid=1(daemon) gid=1(daemon)"), "exec command not running as uid/gid 1")

--- a/integration/container/export_test.go
+++ b/integration/container/export_test.go
@@ -23,16 +23,16 @@ func TestExportContainerAndImportImage(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(ctx, t, client, container.WithCmd("true"))
-	poll.WaitOn(t, container.IsStopped(ctx, client, cID), poll.WithDelay(100*time.Millisecond))
+	cID := container.Run(ctx, t, apiClient, container.WithCmd("true"))
+	poll.WaitOn(t, container.IsStopped(ctx, apiClient, cID), poll.WithDelay(100*time.Millisecond))
 
 	reference := "repo/" + strings.ToLower(t.Name()) + ":v1"
-	exportResp, err := client.ContainerExport(ctx, cID)
+	exportResp, err := apiClient.ContainerExport(ctx, cID)
 	assert.NilError(t, err)
-	importResp, err := client.ImageImport(ctx, types.ImageImportSource{
+	importResp, err := apiClient.ImageImport(ctx, types.ImageImportSource{
 		Source:     exportResp,
 		SourceName: "-",
 	}, reference, types.ImageImportOptions{})
@@ -46,7 +46,7 @@ func TestExportContainerAndImportImage(t *testing.T) {
 	err = dec.Decode(&jm)
 	assert.NilError(t, err)
 
-	images, err := client.ImageList(ctx, types.ImageListOptions{
+	images, err := apiClient.ImageList(ctx, types.ImageListOptions{
 		Filters: filters.NewArgs(filters.Arg("reference", reference)),
 	})
 	assert.NilError(t, err)

--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -21,9 +21,9 @@ func TestHealthCheckWorkdir(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
-	cID := container.Run(ctx, t, client, container.WithTty(true), container.WithWorkingDir("/foo"), func(c *container.TestContainerConfig) {
+	cID := container.Run(ctx, t, apiClient, container.WithTty(true), container.WithWorkingDir("/foo"), func(c *container.TestContainerConfig) {
 		c.Config.Healthcheck = &containertypes.HealthConfig{
 			Test:     []string{"CMD-SHELL", "if [ \"$PWD\" = \"/foo\" ]; then exit 0; else exit 1; fi;"},
 			Interval: 50 * time.Millisecond,
@@ -31,7 +31,7 @@ func TestHealthCheckWorkdir(t *testing.T) {
 		}
 	})
 
-	poll.WaitOn(t, pollForHealthStatus(ctx, client, cID, types.Healthy), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, pollForHealthStatus(ctx, apiClient, cID, types.Healthy), poll.WithDelay(100*time.Millisecond))
 }
 
 // GitHub #37263
@@ -41,9 +41,9 @@ func TestHealthKillContainer(t *testing.T) {
 	defer setupTest(t)()
 
 	ctx := context.Background()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
-	id := container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
+	id := container.Run(ctx, t, apiClient, func(c *container.TestContainerConfig) {
 		cmd := `
 # Set the initial HEALTH value so the healthcheck passes
 HEALTH="1"
@@ -77,21 +77,21 @@ while true; do sleep 1; done
 
 	ctxPoll, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	poll.WaitOn(t, pollForHealthStatus(ctxPoll, client, id, "healthy"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, pollForHealthStatus(ctxPoll, apiClient, id, "healthy"), poll.WithDelay(100*time.Millisecond))
 
-	err := client.ContainerKill(ctx, id, "SIGUSR1")
+	err := apiClient.ContainerKill(ctx, id, "SIGUSR1")
 	assert.NilError(t, err)
 
 	ctxPoll, cancel = context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	poll.WaitOn(t, pollForHealthStatus(ctxPoll, client, id, "unhealthy"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, pollForHealthStatus(ctxPoll, apiClient, id, "unhealthy"), poll.WithDelay(100*time.Millisecond))
 
-	err = client.ContainerKill(ctx, id, "SIGUSR1")
+	err = apiClient.ContainerKill(ctx, id, "SIGUSR1")
 	assert.NilError(t, err)
 
 	ctxPoll, cancel = context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	poll.WaitOn(t, pollForHealthStatus(ctxPoll, client, id, "healthy"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, pollForHealthStatus(ctxPoll, apiClient, id, "healthy"), poll.WithDelay(100*time.Millisecond))
 }
 
 // TestHealthCheckProcessKilled verifies that health-checks exec get killed on time-out.
@@ -115,10 +115,10 @@ func TestHealthStartInterval(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "The shell commands used in the test healthcheck do not work on Windows")
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	// Note: Windows is much slower than linux so this use longer intervals/timeouts
-	id := container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
+	id := container.Run(ctx, t, apiClient, func(c *container.TestContainerConfig) {
 		c.Config.Healthcheck = &containertypes.HealthConfig{
 			Test:          []string{"CMD-SHELL", `count="$(cat /tmp/health)"; if [ -z "${count}" ]; then let count=0; fi; let count=${count}+1; echo -n ${count} | tee /tmp/health; if [ ${count} -lt 3 ]; then exit 1; fi`},
 			Interval:      30 * time.Second,
@@ -136,7 +136,7 @@ func TestHealthStartInterval(t *testing.T) {
 		if ctxPoll.Err() != nil {
 			return poll.Error(ctxPoll.Err())
 		}
-		inspect, err := client.ContainerInspect(ctxPoll, id)
+		inspect, err := apiClient.ContainerInspect(ctxPoll, id)
 		if err != nil {
 			return poll.Error(err)
 		}
@@ -155,7 +155,7 @@ func TestHealthStartInterval(t *testing.T) {
 	dl, _ = ctxPoll.Deadline()
 
 	poll.WaitOn(t, func(log poll.LogT) poll.Result {
-		inspect, err := client.ContainerInspect(ctxPoll, id)
+		inspect, err := apiClient.ContainerInspect(ctxPoll, id)
 		if err != nil {
 			return poll.Error(err)
 		}

--- a/integration/container/inspect_test.go
+++ b/integration/container/inspect_test.go
@@ -20,7 +20,7 @@ func TestInspectCpusetInConfigPre120(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows" || !testEnv.DaemonInfo.CPUSet)
 
 	defer setupTest(t)()
-	client := request.NewAPIClient(t, client.WithVersion("1.19"))
+	apiClient := request.NewAPIClient(t, client.WithVersion("1.19"))
 	ctx := context.Background()
 
 	name := strings.ToLower(t.Name())
@@ -31,9 +31,9 @@ func TestInspectCpusetInConfigPre120(t *testing.T) {
 			c.HostConfig.Resources.CpusetCpus = "0"
 		},
 	)
-	poll.WaitOn(t, container.IsInState(ctx, client, name, "exited"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, name, "exited"), poll.WithDelay(100*time.Millisecond))
 
-	_, body, err := client.ContainerInspectWithRaw(ctx, name, false)
+	_, body, err := apiClient.ContainerInspectWithRaw(ctx, name, false)
 	assert.NilError(t, err)
 
 	var inspectJSON map[string]interface{}
@@ -50,7 +50,7 @@ func TestInspectCpusetInConfigPre120(t *testing.T) {
 
 func TestInspectAnnotations(t *testing.T) {
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	apiClient := request.NewAPIClient(t)
 	ctx := context.Background()
 
 	annotations := map[string]string{
@@ -59,7 +59,7 @@ func TestInspectAnnotations(t *testing.T) {
 	}
 
 	name := strings.ToLower(t.Name())
-	id := container.Create(ctx, t, client,
+	id := container.Create(ctx, t, apiClient,
 		container.WithName(name),
 		container.WithCmd("true"),
 		func(c *container.TestContainerConfig) {
@@ -67,7 +67,7 @@ func TestInspectAnnotations(t *testing.T) {
 		},
 	)
 
-	inspect, err := client.ContainerInspect(ctx, id)
+	inspect, err := apiClient.ContainerInspect(ctx, id)
 	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual(inspect.HostConfig.Annotations, annotations))
 }

--- a/integration/container/links_linux_test.go
+++ b/integration/container/links_linux_test.go
@@ -21,11 +21,11 @@ func TestLinksEtcHostsContentMatch(t *testing.T) {
 	skip.If(t, os.IsNotExist(err))
 
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(ctx, t, client, container.WithNetworkMode("host"))
-	res, err := container.Exec(ctx, client, cID, []string{"cat", "/etc/hosts"})
+	cID := container.Run(ctx, t, apiClient, container.WithNetworkMode("host"))
+	res, err := container.Exec(ctx, apiClient, cID, []string{"cat", "/etc/hosts"})
 	assert.NilError(t, err)
 	assert.Assert(t, is.Len(res.Stderr(), 0))
 	assert.Equal(t, 0, res.ExitCode)
@@ -37,15 +37,15 @@ func TestLinksContainerNames(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
 	containerA := "first_" + t.Name()
 	containerB := "second_" + t.Name()
-	container.Run(ctx, t, client, container.WithName(containerA))
-	container.Run(ctx, t, client, container.WithName(containerB), container.WithLinks(containerA+":"+containerA))
+	container.Run(ctx, t, apiClient, container.WithName(containerA))
+	container.Run(ctx, t, apiClient, container.WithName(containerB), container.WithLinks(containerA+":"+containerA))
 
-	containers, err := client.ContainerList(ctx, types.ContainerListOptions{
+	containers, err := apiClient.ContainerList(ctx, types.ContainerListOptions{
 		Filters: filters.NewArgs(filters.Arg("name", containerA)),
 	})
 	assert.NilError(t, err)

--- a/integration/container/logs_test.go
+++ b/integration/container/logs_test.go
@@ -26,12 +26,12 @@ func TestLogsFollowTailEmpty(t *testing.T) {
 	// FIXME(vdemeester) fails on a e2e run on linux...
 	skip.If(t, testEnv.IsRemoteDaemon)
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
-	id := container.Run(ctx, t, client, container.WithCmd("sleep", "100000"))
+	id := container.Run(ctx, t, apiClient, container.WithCmd("sleep", "100000"))
 
-	logs, err := client.ContainerLogs(ctx, id, types.ContainerLogsOptions{ShowStdout: true, Tail: "2"})
+	logs, err := apiClient.ContainerLogs(ctx, id, types.ContainerLogsOptions{ShowStdout: true, Tail: "2"})
 	if logs != nil {
 		defer logs.Close()
 	}
@@ -53,7 +53,7 @@ func TestLogs(t *testing.T) {
 
 func testLogs(t *testing.T, logDriver string) {
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
 	testCases := []struct {
@@ -134,18 +134,18 @@ func testLogs(t *testing.T, logDriver string) {
 		t.Run(tC.desc, func(t *testing.T) {
 			t.Parallel()
 			tty := tC.tty
-			id := container.Run(ctx, t, client,
+			id := container.Run(ctx, t, apiClient,
 				container.WithCmd("sh", "-c", "echo -n this is fine; echo -n accidents happen >&2"),
 				container.WithTty(tty),
 				container.WithLogDriver(logDriver),
 			)
-			defer client.ContainerRemove(ctx, id, types.ContainerRemoveOptions{Force: true})
+			defer apiClient.ContainerRemove(ctx, id, types.ContainerRemoveOptions{Force: true})
 
-			poll.WaitOn(t, container.IsStopped(ctx, client, id),
+			poll.WaitOn(t, container.IsStopped(ctx, apiClient, id),
 				poll.WithDelay(time.Millisecond*100),
 				poll.WithTimeout(pollTimeout))
 
-			logs, err := client.ContainerLogs(ctx, id, tC.logOps)
+			logs, err := apiClient.ContainerLogs(ctx, id, tC.logOps)
 			assert.NilError(t, err)
 			defer logs.Close()
 

--- a/integration/container/nat_test.go
+++ b/integration/container/nat_test.go
@@ -67,18 +67,18 @@ func TestNetworkLoopbackNat(t *testing.T) {
 
 	endpoint := getExternalAddress(t)
 
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(ctx, t, client,
+	cID := container.Run(ctx, t, apiClient,
 		container.WithCmd("sh", "-c", fmt.Sprintf("stty raw && nc -w 1 %s 8080", endpoint.String())),
 		container.WithTty(true),
 		container.WithNetworkMode("container:"+serverContainerID),
 	)
 
-	poll.WaitOn(t, container.IsStopped(ctx, client, cID), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsStopped(ctx, apiClient, cID), poll.WithDelay(100*time.Millisecond))
 
-	body, err := client.ContainerLogs(ctx, cID, types.ContainerLogsOptions{
+	body, err := apiClient.ContainerLogs(ctx, cID, types.ContainerLogsOptions{
 		ShowStdout: true,
 	})
 	assert.NilError(t, err)
@@ -93,10 +93,10 @@ func TestNetworkLoopbackNat(t *testing.T) {
 
 func startServerContainer(t *testing.T, msg string, port int) string {
 	t.Helper()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(ctx, t, client,
+	cID := container.Run(ctx, t, apiClient,
 		container.WithName("server-"+t.Name()),
 		container.WithCmd("sh", "-c", fmt.Sprintf("echo %q | nc -lp %d", msg, port)),
 		container.WithExposedPorts(fmt.Sprintf("%d/tcp", port)),
@@ -110,7 +110,7 @@ func startServerContainer(t *testing.T, msg string, port int) string {
 			}
 		})
 
-	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	return cID
 }

--- a/integration/container/pidmode_linux_test.go
+++ b/integration/container/pidmode_linux_test.go
@@ -20,18 +20,18 @@ func TestPidHost(t *testing.T) {
 	assert.NilError(t, err)
 
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
+	cID := container.Run(ctx, t, apiClient, func(c *container.TestContainerConfig) {
 		c.HostConfig.PidMode = "host"
 	})
-	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
-	cPid := container.GetContainerNS(ctx, t, client, cID, "pid")
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	cPid := container.GetContainerNS(ctx, t, apiClient, cID, "pid")
 	assert.Assert(t, hostPid == cPid)
 
-	cID = container.Run(ctx, t, client)
-	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
-	cPid = container.GetContainerNS(ctx, t, client, cID, "pid")
+	cID = container.Run(ctx, t, apiClient)
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	cPid = container.GetContainerNS(ctx, t, apiClient, cID, "pid")
 	assert.Assert(t, hostPid != cPid)
 }

--- a/integration/container/ps_test.go
+++ b/integration/container/ps_test.go
@@ -13,12 +13,12 @@ import (
 
 func TestPsFilter(t *testing.T) {
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
-	prev := container.Create(ctx, t, client)
-	top := container.Create(ctx, t, client)
-	next := container.Create(ctx, t, client)
+	prev := container.Create(ctx, t, apiClient)
+	top := container.Create(ctx, t, apiClient)
+	next := container.Create(ctx, t, apiClient)
 
 	containerIDs := func(containers []types.Container) []string {
 		var entries []string
@@ -29,7 +29,7 @@ func TestPsFilter(t *testing.T) {
 	}
 
 	t.Run("since", func(t *testing.T) {
-		results, err := client.ContainerList(ctx, types.ContainerListOptions{
+		results, err := apiClient.ContainerList(ctx, types.ContainerListOptions{
 			All:     true,
 			Filters: filters.NewArgs(filters.Arg("since", top)),
 		})
@@ -38,7 +38,7 @@ func TestPsFilter(t *testing.T) {
 	})
 
 	t.Run("before", func(t *testing.T) {
-		results, err := client.ContainerList(ctx, types.ContainerListOptions{
+		results, err := apiClient.ContainerList(ctx, types.ContainerListOptions{
 			All:     true,
 			Filters: filters.NewArgs(filters.Arg("before", top)),
 		})

--- a/integration/container/remove_test.go
+++ b/integration/container/remove_test.go
@@ -30,25 +30,25 @@ func TestRemoveContainerWithRemovedVolume(t *testing.T) {
 
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
 
 	tempDir := fs.NewDir(t, "test-rm-container-with-removed-volume", fs.WithMode(0o755))
 	defer tempDir.Remove()
 
-	cID := container.Run(ctx, t, client, container.WithCmd("true"), container.WithBind(tempDir.Path(), prefix+slash+"test"))
-	poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
+	cID := container.Run(ctx, t, apiClient, container.WithCmd("true"), container.WithBind(tempDir.Path(), prefix+slash+"test"))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "exited"), poll.WithDelay(100*time.Millisecond))
 
 	err := os.RemoveAll(tempDir.Path())
 	assert.NilError(t, err)
 
-	err = client.ContainerRemove(ctx, cID, types.ContainerRemoveOptions{
+	err = apiClient.ContainerRemove(ctx, cID, types.ContainerRemoveOptions{
 		RemoveVolumes: true,
 	})
 	assert.NilError(t, err)
 
-	_, _, err = client.ContainerInspectWithRaw(ctx, cID, true)
+	_, _, err = apiClient.ContainerInspectWithRaw(ctx, cID, true)
 	assert.Check(t, is.ErrorContains(err, "No such container"))
 }
 
@@ -56,24 +56,24 @@ func TestRemoveContainerWithRemovedVolume(t *testing.T) {
 func TestRemoveContainerWithVolume(t *testing.T) {
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
 
-	cID := container.Run(ctx, t, client, container.WithCmd("true"), container.WithVolume(prefix+slash+"srv"))
-	poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
+	cID := container.Run(ctx, t, apiClient, container.WithCmd("true"), container.WithVolume(prefix+slash+"srv"))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "exited"), poll.WithDelay(100*time.Millisecond))
 
-	insp, _, err := client.ContainerInspectWithRaw(ctx, cID, true)
+	insp, _, err := apiClient.ContainerInspectWithRaw(ctx, cID, true)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(1, len(insp.Mounts)))
 	volName := insp.Mounts[0].Name
 
-	err = client.ContainerRemove(ctx, cID, types.ContainerRemoveOptions{
+	err = apiClient.ContainerRemove(ctx, cID, types.ContainerRemoveOptions{
 		RemoveVolumes: true,
 	})
 	assert.NilError(t, err)
 
-	volumes, err := client.VolumeList(ctx, volume.ListOptions{
+	volumes, err := apiClient.VolumeList(ctx, volume.ListOptions{
 		Filters: filters.NewArgs(filters.Arg("name", volName)),
 	})
 	assert.NilError(t, err)
@@ -83,22 +83,22 @@ func TestRemoveContainerWithVolume(t *testing.T) {
 func TestRemoveContainerRunning(t *testing.T) {
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
-	cID := container.Run(ctx, t, client)
+	cID := container.Run(ctx, t, apiClient)
 
-	err := client.ContainerRemove(ctx, cID, types.ContainerRemoveOptions{})
+	err := apiClient.ContainerRemove(ctx, cID, types.ContainerRemoveOptions{})
 	assert.Check(t, is.ErrorContains(err, "cannot remove a running container"))
 }
 
 func TestRemoveContainerForceRemoveRunning(t *testing.T) {
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
-	cID := container.Run(ctx, t, client)
+	cID := container.Run(ctx, t, apiClient)
 
-	err := client.ContainerRemove(ctx, cID, types.ContainerRemoveOptions{
+	err := apiClient.ContainerRemove(ctx, cID, types.ContainerRemoveOptions{
 		Force: true,
 	})
 	assert.NilError(t, err)
@@ -107,8 +107,8 @@ func TestRemoveContainerForceRemoveRunning(t *testing.T) {
 func TestRemoveInvalidContainer(t *testing.T) {
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
-	err := client.ContainerRemove(ctx, "unknown", types.ContainerRemoveOptions{})
+	err := apiClient.ContainerRemove(ctx, "unknown", types.ContainerRemoveOptions{})
 	assert.Check(t, is.ErrorContains(err, "No such container"))
 }

--- a/integration/container/resize_test.go
+++ b/integration/container/resize_test.go
@@ -18,14 +18,14 @@ import (
 
 func TestResize(t *testing.T) {
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(ctx, t, client, container.WithTty(true))
+	cID := container.Run(ctx, t, apiClient, container.WithTty(true))
 
-	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
-	err := client.ContainerResize(ctx, cID, types.ResizeOptions{
+	err := apiClient.ContainerResize(ctx, cID, types.ResizeOptions{
 		Height: 40,
 		Width:  40,
 	})
@@ -35,12 +35,12 @@ func TestResize(t *testing.T) {
 func TestResizeWithInvalidSize(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.32"), "broken in earlier versions")
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(ctx, t, client)
+	cID := container.Run(ctx, t, apiClient)
 
-	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	endpoint := "/containers/" + cID + "/resize?h=foo&w=bar"
 	res, _, err := req.Post(endpoint)
@@ -50,14 +50,14 @@ func TestResizeWithInvalidSize(t *testing.T) {
 
 func TestResizeWhenContainerNotStarted(t *testing.T) {
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(ctx, t, client, container.WithCmd("echo"))
+	cID := container.Run(ctx, t, apiClient, container.WithCmd("echo"))
 
-	poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "exited"), poll.WithDelay(100*time.Millisecond))
 
-	err := client.ContainerResize(ctx, cID, types.ResizeOptions{
+	err := apiClient.ContainerResize(ctx, cID, types.ResizeOptions{
 		Height: 40,
 		Width:  40,
 	})

--- a/integration/container/run_cgroupns_linux_test.go
+++ b/integration/container/run_cgroupns_linux_test.go
@@ -17,17 +17,17 @@ import (
 // Bring up a daemon with the specified default cgroup namespace mode, and then create a container with the container options
 func testRunWithCgroupNs(t *testing.T, daemonNsMode string, containerOpts ...func(*container.TestContainerConfig)) (string, string) {
 	d := daemon.New(t, daemon.WithDefaultCgroupNamespaceMode(daemonNsMode))
-	client := d.NewClientT(t)
+	apiClient := d.NewClientT(t)
 	ctx := context.Background()
 
 	d.StartWithBusybox(t)
 	defer d.Stop(t)
 
-	cID := container.Run(ctx, t, client, containerOpts...)
-	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	cID := container.Run(ctx, t, apiClient, containerOpts...)
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	daemonCgroup := d.CgroupNamespace(t)
-	containerCgroup := container.GetContainerNS(ctx, t, client, cID, "cgroup")
+	containerCgroup := container.GetContainerNS(ctx, t, apiClient, cID, "cgroup")
 	return containerCgroup, daemonCgroup
 }
 
@@ -35,12 +35,12 @@ func testRunWithCgroupNs(t *testing.T, daemonNsMode string, containerOpts ...fun
 // expecting an error with the specified string
 func testCreateFailureWithCgroupNs(t *testing.T, daemonNsMode string, errStr string, containerOpts ...func(*container.TestContainerConfig)) {
 	d := daemon.New(t, daemon.WithDefaultCgroupNamespaceMode(daemonNsMode))
-	client := d.NewClientT(t)
+	apiClient := d.NewClientT(t)
 	ctx := context.Background()
 
 	d.StartWithBusybox(t)
 	defer d.Stop(t)
-	container.CreateExpectingErr(ctx, t, client, errStr, containerOpts...)
+	container.CreateExpectingErr(ctx, t, apiClient, errStr, containerOpts...)
 }
 
 func TestCgroupNamespacesRun(t *testing.T) {
@@ -126,17 +126,17 @@ func TestCgroupNamespacesRunOlderClient(t *testing.T) {
 	skip.If(t, !requirement.CgroupNamespacesEnabled())
 
 	d := daemon.New(t, daemon.WithDefaultCgroupNamespaceMode("private"))
-	client := d.NewClientT(t, client.WithVersion("1.39"))
+	apiClient := d.NewClientT(t, client.WithVersion("1.39"))
 
 	ctx := context.Background()
 	d.StartWithBusybox(t)
 	defer d.Stop(t)
 
-	cID := container.Run(ctx, t, client)
-	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	cID := container.Run(ctx, t, apiClient)
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	daemonCgroup := d.CgroupNamespace(t)
-	containerCgroup := container.GetContainerNS(ctx, t, client, cID, "cgroup")
+	containerCgroup := container.GetContainerNS(ctx, t, apiClient, cID, "cgroup")
 	if testEnv.DaemonInfo.CgroupVersion != "2" {
 		assert.Assert(t, daemonCgroup == containerCgroup)
 	} else {

--- a/integration/container/run_cgroupns_linux_test.go
+++ b/integration/container/run_cgroupns_linux_test.go
@@ -40,7 +40,8 @@ func testCreateFailureWithCgroupNs(t *testing.T, daemonNsMode string, errStr str
 
 	d.StartWithBusybox(t)
 	defer d.Stop(t)
-	container.CreateExpectingErr(ctx, t, apiClient, errStr, containerOpts...)
+	_, err := container.CreateFromConfig(ctx, apiClient, container.NewTestConfig(containerOpts...))
+	assert.ErrorContains(t, err, errStr)
 }
 
 func TestCgroupNamespacesRun(t *testing.T) {

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -38,7 +38,7 @@ func TestNISDomainname(t *testing.T) {
 	skip.If(t, testEnv.IsRootless, "rootless mode doesn't support setting Domainname (TODO: https://github.com/moby/moby/issues/40632)")
 
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
 	const (
@@ -46,20 +46,20 @@ func TestNISDomainname(t *testing.T) {
 		domainname = "baz.cyphar.com"
 	)
 
-	cID := container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
+	cID := container.Run(ctx, t, apiClient, func(c *container.TestContainerConfig) {
 		c.Config.Hostname = hostname
 		c.Config.Domainname = domainname
 	})
 
-	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
-	inspect, err := client.ContainerInspect(ctx, cID)
+	inspect, err := apiClient.ContainerInspect(ctx, cID)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(hostname, inspect.Config.Hostname))
 	assert.Check(t, is.Equal(domainname, inspect.Config.Domainname))
 
 	// Check hostname.
-	res, err := container.Exec(ctx, client, cID,
+	res, err := container.Exec(ctx, apiClient, cID,
 		[]string{"cat", "/proc/sys/kernel/hostname"})
 	assert.NilError(t, err)
 	assert.Assert(t, is.Len(res.Stderr(), 0))
@@ -67,7 +67,7 @@ func TestNISDomainname(t *testing.T) {
 	assert.Check(t, is.Equal(hostname, strings.TrimSpace(res.Stdout())))
 
 	// Check domainname.
-	res, err = container.Exec(ctx, client, cID,
+	res, err = container.Exec(ctx, apiClient, cID,
 		[]string{"cat", "/proc/sys/kernel/domainname"})
 	assert.NilError(t, err)
 	assert.Assert(t, is.Len(res.Stderr(), 0))
@@ -79,7 +79,7 @@ func TestHostnameDnsResolution(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
 	const (
@@ -88,21 +88,21 @@ func TestHostnameDnsResolution(t *testing.T) {
 
 	// using user defined network as we want to use internal DNS
 	netName := "foobar-net"
-	net.CreateNoError(context.Background(), t, client, netName, net.WithDriver("bridge"))
+	net.CreateNoError(context.Background(), t, apiClient, netName, net.WithDriver("bridge"))
 
-	cID := container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
+	cID := container.Run(ctx, t, apiClient, func(c *container.TestContainerConfig) {
 		c.Config.Hostname = hostname
 		c.HostConfig.NetworkMode = containertypes.NetworkMode(netName)
 	})
 
-	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
-	inspect, err := client.ContainerInspect(ctx, cID)
+	inspect, err := apiClient.ContainerInspect(ctx, cID)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(hostname, inspect.Config.Hostname))
 
 	// Clear hosts file so ping will use DNS for hostname resolution
-	res, err := container.Exec(ctx, client, cID,
+	res, err := container.Exec(ctx, apiClient, cID,
 		[]string{"sh", "-c", "echo 127.0.0.1 localhost | tee /etc/hosts && ping -c 1 foobar"})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal("", res.Stderr()))
@@ -114,24 +114,24 @@ func TestUnprivilegedPortsAndPing(t *testing.T) {
 	skip.If(t, testEnv.IsRootless, "rootless mode doesn't support setting net.ipv4.ping_group_range and net.ipv4.ip_unprivileged_port_start")
 
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
+	cID := container.Run(ctx, t, apiClient, func(c *container.TestContainerConfig) {
 		c.Config.User = "1000:1000"
 	})
 
-	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	// Check net.ipv4.ping_group_range.
-	res, err := container.Exec(ctx, client, cID, []string{"cat", "/proc/sys/net/ipv4/ping_group_range"})
+	res, err := container.Exec(ctx, apiClient, cID, []string{"cat", "/proc/sys/net/ipv4/ping_group_range"})
 	assert.NilError(t, err)
 	assert.Assert(t, is.Len(res.Stderr(), 0))
 	assert.Equal(t, 0, res.ExitCode)
 	assert.Equal(t, `0	2147483647`, strings.TrimSpace(res.Stdout()))
 
 	// Check net.ipv4.ip_unprivileged_port_start.
-	res, err = container.Exec(ctx, client, cID, []string{"cat", "/proc/sys/net/ipv4/ip_unprivileged_port_start"})
+	res, err = container.Exec(ctx, apiClient, cID, []string{"cat", "/proc/sys/net/ipv4/ip_unprivileged_port_start"})
 	assert.NilError(t, err)
 	assert.Assert(t, is.Len(res.Stderr(), 0))
 	assert.Equal(t, 0, res.ExitCode)
@@ -145,7 +145,7 @@ func TestPrivilegedHostDevices(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
 	const (
@@ -167,18 +167,18 @@ func TestPrivilegedHostDevices(t *testing.T) {
 	}
 	defer os.Remove(devRootOnlyTest)
 
-	cID := container.Run(ctx, t, client, container.WithPrivileged(true))
+	cID := container.Run(ctx, t, apiClient, container.WithPrivileged(true))
 
-	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	// Check test device.
-	res, err := container.Exec(ctx, client, cID, []string{"ls", devTest})
+	res, err := container.Exec(ctx, apiClient, cID, []string{"ls", devTest})
 	assert.NilError(t, err)
 	assert.Equal(t, 0, res.ExitCode)
 	assert.Check(t, is.Equal(strings.TrimSpace(res.Stdout()), devTest))
 
 	// Check root-only test device.
-	res, err = container.Exec(ctx, client, cID, []string{"ls", devRootOnlyTest})
+	res, err = container.Exec(ctx, apiClient, cID, []string{"ls", devRootOnlyTest})
 	assert.NilError(t, err)
 	if testEnv.IsRootless() {
 		assert.Equal(t, 1, res.ExitCode)
@@ -194,19 +194,19 @@ func TestRunConsoleSize(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.42"), "skip test from new feature")
 
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(ctx, t, client,
+	cID := container.Run(ctx, t, apiClient,
 		container.WithTty(true),
 		container.WithImage("busybox"),
 		container.WithCmd("stty", "size"),
 		container.WithConsoleSize(57, 123),
 	)
 
-	poll.WaitOn(t, container.IsStopped(ctx, client, cID), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsStopped(ctx, apiClient, cID), poll.WithDelay(100*time.Millisecond))
 
-	out, err := client.ContainerLogs(ctx, cID, types.ContainerLogsOptions{ShowStdout: true})
+	out, err := apiClient.ContainerLogs(ctx, cID, types.ContainerLogsOptions{ShowStdout: true})
 	assert.NilError(t, err)
 	defer out.Close()
 
@@ -249,18 +249,18 @@ func TestRunWithAlternativeContainerdShim(t *testing.T) {
 	d.StartWithBusybox(t)
 	defer d.Stop(t)
 
-	client := d.NewClientT(t)
+	apiClient := d.NewClientT(t)
 	ctx := context.Background()
 
-	cID := container.Run(ctx, t, client,
+	cID := container.Run(ctx, t, apiClient,
 		container.WithImage("busybox"),
 		container.WithCmd("sh", "-c", `echo 'Hello, world!'`),
 		container.WithRuntime("io.containerd.realfake.v42"),
 	)
 
-	poll.WaitOn(t, container.IsStopped(ctx, client, cID), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsStopped(ctx, apiClient, cID), poll.WithDelay(100*time.Millisecond))
 
-	out, err := client.ContainerLogs(ctx, cID, types.ContainerLogsOptions{ShowStdout: true})
+	out, err := apiClient.ContainerLogs(ctx, cID, types.ContainerLogsOptions{ShowStdout: true})
 	assert.NilError(t, err)
 	defer out.Close()
 
@@ -273,14 +273,14 @@ func TestRunWithAlternativeContainerdShim(t *testing.T) {
 	d.Stop(t)
 	d.Start(t, "--default-runtime="+"io.containerd.realfake.v42")
 
-	cID = container.Run(ctx, t, client,
+	cID = container.Run(ctx, t, apiClient,
 		container.WithImage("busybox"),
 		container.WithCmd("sh", "-c", `echo 'Hello, world!'`),
 	)
 
-	poll.WaitOn(t, container.IsStopped(ctx, client, cID), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsStopped(ctx, apiClient, cID), poll.WithDelay(100*time.Millisecond))
 
-	out, err = client.ContainerLogs(ctx, cID, types.ContainerLogsOptions{ShowStdout: true})
+	out, err = apiClient.ContainerLogs(ctx, cID, types.ContainerLogsOptions{ShowStdout: true})
 	assert.NilError(t, err)
 	defer out.Close()
 

--- a/integration/container/stats_test.go
+++ b/integration/container/stats_test.go
@@ -21,17 +21,17 @@ func TestStats(t *testing.T) {
 	skip.If(t, !testEnv.DaemonInfo.MemoryLimit)
 
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
-	info, err := client.Info(ctx)
+	info, err := apiClient.Info(ctx)
 	assert.NilError(t, err)
 
-	cID := container.Run(ctx, t, client)
+	cID := container.Run(ctx, t, apiClient)
 
-	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
-	resp, err := client.ContainerStats(ctx, cID, false)
+	resp, err := apiClient.ContainerStats(ctx, cID, false)
 	assert.NilError(t, err)
 	defer resp.Body.Close()
 
@@ -43,7 +43,7 @@ func TestStats(t *testing.T) {
 	err = json.NewDecoder(resp.Body).Decode(&v)
 	assert.Assert(t, is.ErrorContains(err, ""), io.EOF)
 
-	resp, err = client.ContainerStatsOneShot(ctx, cID)
+	resp, err = apiClient.ContainerStatsOneShot(ctx, cID)
 	assert.NilError(t, err)
 	defer resp.Body.Close()
 

--- a/integration/container/stop_linux_test.go
+++ b/integration/container/stop_linux_test.go
@@ -25,7 +25,7 @@ import (
 // waiting is not limited (issue #35311).
 func TestStopContainerWithTimeout(t *testing.T) {
 	t.Cleanup(setupTest(t))
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
 	testCmd := container.WithCmd("sh", "-c", "sleep 2 && exit 42")
@@ -58,15 +58,15 @@ func TestStopContainerWithTimeout(t *testing.T) {
 		d := d
 		t.Run(strconv.Itoa(d.timeout), func(t *testing.T) {
 			t.Parallel()
-			id := container.Run(ctx, t, client, testCmd)
+			id := container.Run(ctx, t, apiClient, testCmd)
 
-			err := client.ContainerStop(ctx, id, containertypes.StopOptions{Timeout: &d.timeout})
+			err := apiClient.ContainerStop(ctx, id, containertypes.StopOptions{Timeout: &d.timeout})
 			assert.NilError(t, err)
 
-			poll.WaitOn(t, container.IsStopped(ctx, client, id),
+			poll.WaitOn(t, container.IsStopped(ctx, apiClient, id),
 				poll.WithDelay(100*time.Millisecond))
 
-			inspect, err := client.ContainerInspect(ctx, id)
+			inspect, err := apiClient.ContainerInspect(ctx, id)
 			assert.NilError(t, err)
 			assert.Equal(t, inspect.State.ExitCode, d.expectedExitCode)
 		})

--- a/integration/container/stop_test.go
+++ b/integration/container/stop_test.go
@@ -16,12 +16,12 @@ const StopContainerWindowsPollTimeout = 75 * time.Second
 
 func TestStopContainerWithRestartPolicyAlways(t *testing.T) {
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
 	names := []string{"verifyRestart1-" + t.Name(), "verifyRestart2-" + t.Name()}
 	for _, name := range names {
-		container.Run(ctx, t, client,
+		container.Run(ctx, t, apiClient,
 			container.WithName(name),
 			container.WithCmd("false"),
 			container.WithRestartPolicy("always"),
@@ -29,15 +29,15 @@ func TestStopContainerWithRestartPolicyAlways(t *testing.T) {
 	}
 
 	for _, name := range names {
-		poll.WaitOn(t, container.IsInState(ctx, client, name, "running", "restarting"), poll.WithDelay(100*time.Millisecond))
+		poll.WaitOn(t, container.IsInState(ctx, apiClient, name, "running", "restarting"), poll.WithDelay(100*time.Millisecond))
 	}
 
 	for _, name := range names {
-		err := client.ContainerStop(ctx, name, containertypes.StopOptions{})
+		err := apiClient.ContainerStop(ctx, name, containertypes.StopOptions{})
 		assert.NilError(t, err)
 	}
 
 	for _, name := range names {
-		poll.WaitOn(t, container.IsStopped(ctx, client, name), poll.WithDelay(100*time.Millisecond))
+		poll.WaitOn(t, container.IsStopped(ctx, apiClient, name), poll.WithDelay(100*time.Millisecond))
 	}
 }

--- a/integration/container/stop_windows_test.go
+++ b/integration/container/stop_windows_test.go
@@ -19,7 +19,7 @@ import (
 func TestStopContainerWithTimeout(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	t.Cleanup(setupTest(t))
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
 	testCmd := container.WithCmd("sh", "-c", "sleep 2 && exit 42")
@@ -52,15 +52,15 @@ func TestStopContainerWithTimeout(t *testing.T) {
 		d := d
 		t.Run(strconv.Itoa(d.timeout), func(t *testing.T) {
 			t.Parallel()
-			id := container.Run(ctx, t, client, testCmd)
+			id := container.Run(ctx, t, apiClient, testCmd)
 
-			err := client.ContainerStop(ctx, id, containertypes.StopOptions{Timeout: &d.timeout})
+			err := apiClient.ContainerStop(ctx, id, containertypes.StopOptions{Timeout: &d.timeout})
 			assert.NilError(t, err)
 
-			poll.WaitOn(t, container.IsStopped(ctx, client, id),
+			poll.WaitOn(t, container.IsStopped(ctx, apiClient, id),
 				poll.WithDelay(100*time.Millisecond))
 
-			inspect, err := client.ContainerInspect(ctx, id)
+			inspect, err := apiClient.ContainerInspect(ctx, id)
 			assert.NilError(t, err)
 			assert.Equal(t, inspect.State.ExitCode, d.expectedExitCode)
 		})

--- a/integration/container/update_linux_test.go
+++ b/integration/container/update_linux_test.go
@@ -24,23 +24,23 @@ func TestUpdateMemory(t *testing.T) {
 	skip.If(t, !testEnv.DaemonInfo.SwapLimit)
 
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
+	cID := container.Run(ctx, t, apiClient, func(c *container.TestContainerConfig) {
 		c.HostConfig.Resources = containertypes.Resources{
 			Memory: 200 * 1024 * 1024,
 		}
 	})
 
-	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	const (
 		setMemory     int64 = 314572800
 		setMemorySwap int64 = 524288000
 	)
 
-	_, err := client.ContainerUpdate(ctx, cID, containertypes.UpdateConfig{
+	_, err := apiClient.ContainerUpdate(ctx, cID, containertypes.UpdateConfig{
 		Resources: containertypes.Resources{
 			Memory:     setMemory,
 			MemorySwap: setMemorySwap,
@@ -48,7 +48,7 @@ func TestUpdateMemory(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
-	inspect, err := client.ContainerInspect(ctx, cID)
+	inspect, err := apiClient.ContainerInspect(ctx, cID)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(setMemory, inspect.HostConfig.Memory))
 	assert.Check(t, is.Equal(setMemorySwap, inspect.HostConfig.MemorySwap))
@@ -57,7 +57,7 @@ func TestUpdateMemory(t *testing.T) {
 	if testEnv.DaemonInfo.CgroupVersion == "2" {
 		memoryFile = "/sys/fs/cgroup/memory.max"
 	}
-	res, err := container.Exec(ctx, client, cID,
+	res, err := container.Exec(ctx, apiClient, cID,
 		[]string{"cat", memoryFile})
 	assert.NilError(t, err)
 	assert.Assert(t, is.Len(res.Stderr(), 0))
@@ -67,14 +67,14 @@ func TestUpdateMemory(t *testing.T) {
 	// see ConvertMemorySwapToCgroupV2Value() for the convention:
 	// https://github.com/opencontainers/runc/commit/c86be8a2c118ca7bad7bbe9eaf106c659a83940d
 	if testEnv.DaemonInfo.CgroupVersion == "2" {
-		res, err = container.Exec(ctx, client, cID,
+		res, err = container.Exec(ctx, apiClient, cID,
 			[]string{"cat", "/sys/fs/cgroup/memory.swap.max"})
 		assert.NilError(t, err)
 		assert.Assert(t, is.Len(res.Stderr(), 0))
 		assert.Equal(t, 0, res.ExitCode)
 		assert.Check(t, is.Equal(strconv.FormatInt(setMemorySwap-setMemory, 10), strings.TrimSpace(res.Stdout())))
 	} else {
-		res, err = container.Exec(ctx, client, cID,
+		res, err = container.Exec(ctx, apiClient, cID,
 			[]string{"cat", "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes"})
 		assert.NilError(t, err)
 		assert.Assert(t, is.Len(res.Stderr(), 0))
@@ -86,10 +86,10 @@ func TestUpdateMemory(t *testing.T) {
 func TestUpdateCPUQuota(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.CgroupDriver == "none")
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(ctx, t, client)
+	cID := container.Run(ctx, t, apiClient)
 
 	for _, test := range []struct {
 		desc   string
@@ -104,7 +104,7 @@ func TestUpdateCPUQuota(t *testing.T) {
 			// On v2, specifying CPUQuota without CPUPeriod is currently broken:
 			// https://github.com/opencontainers/runc/issues/2456
 			// As a workaround we set them together.
-			_, err := client.ContainerUpdate(ctx, cID, containertypes.UpdateConfig{
+			_, err := apiClient.ContainerUpdate(ctx, cID, containertypes.UpdateConfig{
 				Resources: containertypes.Resources{
 					CPUQuota:  test.update,
 					CPUPeriod: 100000,
@@ -112,7 +112,7 @@ func TestUpdateCPUQuota(t *testing.T) {
 			})
 			assert.NilError(t, err)
 		} else {
-			_, err := client.ContainerUpdate(ctx, cID, containertypes.UpdateConfig{
+			_, err := apiClient.ContainerUpdate(ctx, cID, containertypes.UpdateConfig{
 				Resources: containertypes.Resources{
 					CPUQuota: test.update,
 				},
@@ -120,12 +120,12 @@ func TestUpdateCPUQuota(t *testing.T) {
 			assert.NilError(t, err)
 		}
 
-		inspect, err := client.ContainerInspect(ctx, cID)
+		inspect, err := apiClient.ContainerInspect(ctx, cID)
 		assert.NilError(t, err)
 		assert.Check(t, is.Equal(test.update, inspect.HostConfig.CPUQuota))
 
 		if testEnv.DaemonInfo.CgroupVersion == "2" {
-			res, err := container.Exec(ctx, client, cID,
+			res, err := container.Exec(ctx, apiClient, cID,
 				[]string{"/bin/cat", "/sys/fs/cgroup/cpu.max"})
 			assert.NilError(t, err)
 			assert.Assert(t, is.Len(res.Stderr(), 0))
@@ -139,7 +139,7 @@ func TestUpdateCPUQuota(t *testing.T) {
 				assert.Check(t, is.Equal(strconv.FormatInt(test.update, 10), quota))
 			}
 		} else {
-			res, err := container.Exec(ctx, client, cID,
+			res, err := container.Exec(ctx, apiClient, cID,
 				[]string{"/bin/cat", "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"})
 			assert.NilError(t, err)
 			assert.Assert(t, is.Len(res.Stderr(), 0))
@@ -157,7 +157,7 @@ func TestUpdatePidsLimit(t *testing.T) {
 
 	defer setupTest(t)()
 	apiClient := testEnv.APIClient()
-	oldAPIclient := request.NewAPIClient(t, client.WithVersion("1.24"))
+	oldAPIClient := request.NewAPIClient(t, client.WithVersion("1.24"))
 	ctx := context.Background()
 
 	intPtr := func(i int64) *int64 {
@@ -182,7 +182,7 @@ func TestUpdatePidsLimit(t *testing.T) {
 	} {
 		c := apiClient
 		if test.oldAPI {
-			c = oldAPIclient
+			c = oldAPIClient
 		}
 
 		t.Run(test.desc, func(t *testing.T) {

--- a/integration/container/update_test.go
+++ b/integration/container/update_test.go
@@ -14,17 +14,17 @@ import (
 
 func TestUpdateRestartPolicy(t *testing.T) {
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(ctx, t, client, container.WithCmd("sh", "-c", "sleep 1 && false"), func(c *container.TestContainerConfig) {
+	cID := container.Run(ctx, t, apiClient, container.WithCmd("sh", "-c", "sleep 1 && false"), func(c *container.TestContainerConfig) {
 		c.HostConfig.RestartPolicy = containertypes.RestartPolicy{
 			Name:              "on-failure",
 			MaximumRetryCount: 3,
 		}
 	})
 
-	_, err := client.ContainerUpdate(ctx, cID, containertypes.UpdateConfig{
+	_, err := apiClient.ContainerUpdate(ctx, cID, containertypes.UpdateConfig{
 		RestartPolicy: containertypes.RestartPolicy{
 			Name:              "on-failure",
 			MaximumRetryCount: 5,
@@ -37,9 +37,9 @@ func TestUpdateRestartPolicy(t *testing.T) {
 		timeout = 180 * time.Second
 	}
 
-	poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(timeout))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "exited"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(timeout))
 
-	inspect, err := client.ContainerInspect(ctx, cID)
+	inspect, err := apiClient.ContainerInspect(ctx, cID)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(inspect.RestartCount, 5))
 	assert.Check(t, is.Equal(inspect.HostConfig.RestartPolicy.MaximumRetryCount, 5))
@@ -47,12 +47,12 @@ func TestUpdateRestartPolicy(t *testing.T) {
 
 func TestUpdateRestartWithAutoRemove(t *testing.T) {
 	defer setupTest(t)()
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(ctx, t, client, container.WithAutoRemove)
+	cID := container.Run(ctx, t, apiClient, container.WithAutoRemove)
 
-	_, err := client.ContainerUpdate(ctx, cID, containertypes.UpdateConfig{
+	_, err := apiClient.ContainerUpdate(ctx, cID, containertypes.UpdateConfig{
 		RestartPolicy: containertypes.RestartPolicy{
 			Name: "always",
 		},

--- a/integration/internal/container/container.go
+++ b/integration/internal/container/container.go
@@ -28,7 +28,7 @@ type TestContainerConfig struct {
 }
 
 // create creates a container with the specified options
-func create(ctx context.Context, t *testing.T, client client.APIClient, ops ...func(*TestContainerConfig)) (container.CreateResponse, error) {
+func create(ctx context.Context, t *testing.T, apiClient client.APIClient, ops ...func(*TestContainerConfig)) (container.CreateResponse, error) {
 	t.Helper()
 	cmd := []string{"top"}
 	if runtime.GOOS == "windows" {
@@ -47,30 +47,30 @@ func create(ctx context.Context, t *testing.T, client client.APIClient, ops ...f
 		op(config)
 	}
 
-	return client.ContainerCreate(ctx, config.Config, config.HostConfig, config.NetworkingConfig, config.Platform, config.Name)
+	return apiClient.ContainerCreate(ctx, config.Config, config.HostConfig, config.NetworkingConfig, config.Platform, config.Name)
 }
 
 // Create creates a container with the specified options, asserting that there was no error
-func Create(ctx context.Context, t *testing.T, client client.APIClient, ops ...func(*TestContainerConfig)) string {
+func Create(ctx context.Context, t *testing.T, apiClient client.APIClient, ops ...func(*TestContainerConfig)) string {
 	t.Helper()
-	c, err := create(ctx, t, client, ops...)
+	c, err := create(ctx, t, apiClient, ops...)
 	assert.NilError(t, err)
 
 	return c.ID
 }
 
 // CreateExpectingErr creates a container, expecting an error with the specified message
-func CreateExpectingErr(ctx context.Context, t *testing.T, client client.APIClient, errMsg string, ops ...func(*TestContainerConfig)) {
-	_, err := create(ctx, t, client, ops...)
+func CreateExpectingErr(ctx context.Context, t *testing.T, apiClient client.APIClient, errMsg string, ops ...func(*TestContainerConfig)) {
+	_, err := create(ctx, t, apiClient, ops...)
 	assert.ErrorContains(t, err, errMsg)
 }
 
 // Run creates and start a container with the specified options
-func Run(ctx context.Context, t *testing.T, client client.APIClient, ops ...func(*TestContainerConfig)) string {
+func Run(ctx context.Context, t *testing.T, apiClient client.APIClient, ops ...func(*TestContainerConfig)) string {
 	t.Helper()
-	id := Create(ctx, t, client, ops...)
+	id := Create(ctx, t, apiClient, ops...)
 
-	err := client.ContainerStart(ctx, id, types.ContainerStartOptions{})
+	err := apiClient.ContainerStart(ctx, id, types.ContainerStartOptions{})
 	assert.NilError(t, err)
 
 	return id
@@ -83,23 +83,23 @@ type RunResult struct {
 	Stderr      *bytes.Buffer
 }
 
-func RunAttach(ctx context.Context, t *testing.T, client client.APIClient, ops ...func(config *TestContainerConfig)) RunResult {
+func RunAttach(ctx context.Context, t *testing.T, apiClient client.APIClient, ops ...func(config *TestContainerConfig)) RunResult {
 	t.Helper()
 
 	ops = append(ops, func(c *TestContainerConfig) {
 		c.Config.AttachStdout = true
 		c.Config.AttachStderr = true
 	})
-	id := Create(ctx, t, client, ops...)
+	id := Create(ctx, t, apiClient, ops...)
 
-	aresp, err := client.ContainerAttach(ctx, id, types.ContainerAttachOptions{
+	aresp, err := apiClient.ContainerAttach(ctx, id, types.ContainerAttachOptions{
 		Stream: true,
 		Stdout: true,
 		Stderr: true,
 	})
 	assert.NilError(t, err)
 
-	err = client.ContainerStart(ctx, id, types.ContainerStartOptions{})
+	err = apiClient.ContainerStart(ctx, id, types.ContainerStartOptions{})
 	assert.NilError(t, err)
 
 	s, err := demultiplexStreams(ctx, aresp)
@@ -109,7 +109,7 @@ func RunAttach(ctx context.Context, t *testing.T, client client.APIClient, ops .
 
 	// Inspect to get the exit code. A new context is used here to make sure that if the context passed as argument as
 	// reached timeout during the demultiplexStream call, we still return a RunResult.
-	resp, err := client.ContainerInspect(context.Background(), id)
+	resp, err := apiClient.ContainerInspect(context.Background(), id)
 	assert.NilError(t, err)
 
 	return RunResult{ContainerID: id, ExitCode: resp.State.ExitCode, Stdout: &s.stdout, Stderr: &s.stderr}

--- a/integration/internal/container/container.go
+++ b/integration/internal/container/container.go
@@ -62,11 +62,14 @@ func Create(ctx context.Context, t *testing.T, apiClient client.APIClient, ops .
 	return c.ID
 }
 
-// CreateExpectingErr creates a container, expecting an error with the specified message
-func CreateExpectingErr(ctx context.Context, t *testing.T, apiClient client.APIClient, errMsg string, ops ...func(*TestContainerConfig)) {
-	config := NewTestConfig(ops...)
-	_, err := apiClient.ContainerCreate(ctx, config.Config, config.HostConfig, config.NetworkingConfig, config.Platform, config.Name)
-	assert.ErrorContains(t, err, errMsg)
+// CreateFromConfig creates a container from the given TestContainerConfig.
+//
+// Example use:
+//
+//	ctr, err := container.CreateFromConfig(ctx, apiClient, container.NewTestConfig(container.WithAutoRemove))
+//	assert.Check(t, err)
+func CreateFromConfig(ctx context.Context, apiClient client.APIClient, config *TestContainerConfig) (container.CreateResponse, error) {
+	return apiClient.ContainerCreate(ctx, config.Config, config.HostConfig, config.NetworkingConfig, config.Platform, config.Name)
 }
 
 // Run creates and start a container with the specified options

--- a/integration/internal/container/exec.go
+++ b/integration/internal/container/exec.go
@@ -34,7 +34,7 @@ func (res *ExecResult) Combined() string {
 // containing stdout, stderr, and exit code. Note:
 //   - this is a synchronous operation;
 //   - cmd stdin is closed.
-func Exec(ctx context.Context, cli client.APIClient, id string, cmd []string, ops ...func(*types.ExecConfig)) (ExecResult, error) {
+func Exec(ctx context.Context, apiClient client.APIClient, id string, cmd []string, ops ...func(*types.ExecConfig)) (ExecResult, error) {
 	// prepare exec
 	execConfig := types.ExecConfig{
 		AttachStdout: true,
@@ -46,14 +46,14 @@ func Exec(ctx context.Context, cli client.APIClient, id string, cmd []string, op
 		op(&execConfig)
 	}
 
-	cresp, err := cli.ContainerExecCreate(ctx, id, execConfig)
+	cresp, err := apiClient.ContainerExecCreate(ctx, id, execConfig)
 	if err != nil {
 		return ExecResult{}, err
 	}
 	execID := cresp.ID
 
 	// run it, with stdout/stderr attached
-	aresp, err := cli.ContainerExecAttach(ctx, execID, types.ExecStartCheck{})
+	aresp, err := apiClient.ContainerExecAttach(ctx, execID, types.ExecStartCheck{})
 	if err != nil {
 		return ExecResult{}, err
 	}
@@ -65,7 +65,7 @@ func Exec(ctx context.Context, cli client.APIClient, id string, cmd []string, op
 	}
 
 	// get the exit code
-	iresp, err := cli.ContainerExecInspect(ctx, execID)
+	iresp, err := apiClient.ContainerExecInspect(ctx, execID)
 	if err != nil {
 		return ExecResult{}, err
 	}

--- a/integration/internal/container/ns.go
+++ b/integration/internal/container/ns.go
@@ -11,9 +11,9 @@ import (
 )
 
 // GetContainerNS gets the value of the specified namespace of a container
-func GetContainerNS(ctx context.Context, t *testing.T, client client.APIClient, cID, nsName string) string {
+func GetContainerNS(ctx context.Context, t *testing.T, apiClient client.APIClient, cID, nsName string) string {
 	t.Helper()
-	res, err := Exec(ctx, client, cID, []string{"readlink", "/proc/self/ns/" + nsName})
+	res, err := Exec(ctx, apiClient, cID, []string{"readlink", "/proc/self/ns/" + nsName})
 	assert.NilError(t, err)
 	assert.Assert(t, is.Len(res.Stderr(), 0))
 	assert.Equal(t, 0, res.ExitCode)

--- a/integration/internal/container/states.go
+++ b/integration/internal/container/states.go
@@ -11,9 +11,9 @@ import (
 )
 
 // IsStopped verifies the container is in stopped state.
-func IsStopped(ctx context.Context, client client.APIClient, containerID string) func(log poll.LogT) poll.Result {
+func IsStopped(ctx context.Context, apiClient client.APIClient, containerID string) func(log poll.LogT) poll.Result {
 	return func(log poll.LogT) poll.Result {
-		inspect, err := client.ContainerInspect(ctx, containerID)
+		inspect, err := apiClient.ContainerInspect(ctx, containerID)
 
 		switch {
 		case err != nil:
@@ -27,9 +27,9 @@ func IsStopped(ctx context.Context, client client.APIClient, containerID string)
 }
 
 // IsInState verifies the container is in one of the specified state, e.g., "running", "exited", etc.
-func IsInState(ctx context.Context, client client.APIClient, containerID string, state ...string) func(log poll.LogT) poll.Result {
+func IsInState(ctx context.Context, apiClient client.APIClient, containerID string, state ...string) func(log poll.LogT) poll.Result {
 	return func(log poll.LogT) poll.Result {
-		inspect, err := client.ContainerInspect(ctx, containerID)
+		inspect, err := apiClient.ContainerInspect(ctx, containerID)
 		if err != nil {
 			return poll.Error(err)
 		}
@@ -43,9 +43,9 @@ func IsInState(ctx context.Context, client client.APIClient, containerID string,
 }
 
 // IsSuccessful verifies state.Status == "exited" && state.ExitCode == 0
-func IsSuccessful(ctx context.Context, client client.APIClient, containerID string) func(log poll.LogT) poll.Result {
+func IsSuccessful(ctx context.Context, apiClient client.APIClient, containerID string) func(log poll.LogT) poll.Result {
 	return func(log poll.LogT) poll.Result {
-		inspect, err := client.ContainerInspect(ctx, containerID)
+		inspect, err := apiClient.ContainerInspect(ctx, containerID)
 		if err != nil {
 			return poll.Error(err)
 		}
@@ -60,9 +60,9 @@ func IsSuccessful(ctx context.Context, client client.APIClient, containerID stri
 }
 
 // IsRemoved verifies the container has been removed
-func IsRemoved(ctx context.Context, cli client.APIClient, containerID string) func(log poll.LogT) poll.Result {
+func IsRemoved(ctx context.Context, apiClient client.APIClient, containerID string) func(log poll.LogT) poll.Result {
 	return func(log poll.LogT) poll.Result {
-		inspect, err := cli.ContainerInspect(ctx, containerID)
+		inspect, err := apiClient.ContainerInspect(ctx, containerID)
 		if err != nil {
 			if errdefs.IsNotFound(err) {
 				return poll.Success()


### PR DESCRIPTION
These changes come from a branch I was working on, and for which I needed some changes in the test-utilities.

I also kept running in "change one-variable-at-a-time" for the `client` vars, so thought "let's do a one-time pass to change this in these packages".

### integration/container: use consistent name for api-client

The `client` variable was colliding with the `client` import. In some cases
the confusing `cli` name (it's not the "cli") was used. Given that such names
can easily start spreading (through copy/paste, or "code by example"), let's
make a one-time pass through all of them in this package to use the same name.

### integration/internal/container: use consistent name for api-client

The `client` variable was colliding with the `client` import. In some cases
the confusing `cli` name (it's not the "cli") was used. Given that such names
can easily start spreading (through copy/paste, or "code by example"), let's
make a one-time pass through all of them in this package to use the same name.

### integration/internal/container: add NewTestConfig utility

Introduce a NewTestConfig utility, to allow using the available utilities
for constructing a config, and use them with the regular API client.

### integration/internal/container: refactor CreateExpectingErr

This utility was only used for a single test, and it was very limited
in functionality as it only allowed for a certain error-string to be
matched.

Let's change it into a more generic function; a helper that allows a
container to be created from a `TestContainerConfig` (which can be
constructed using `NewTestConfig`) and that returns the response from
client.ContainerCreate(), so that any result from that can be tested,
leaving it up to the test to check the results.


**- A picture of a cute animal (not mandatory but encouraged)**

