### PR TITLE
libnetwork/drivers/bridge: rename some linux-only files

### DIFF
--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package bridge
 
 import (

--- a/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package bridge
 
 import (

--- a/libnetwork/drivers/bridge/interface_linux.go
+++ b/libnetwork/drivers/bridge/interface_linux.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package bridge
 
 import (

--- a/libnetwork/drivers/bridge/interface_linux_test.go
+++ b/libnetwork/drivers/bridge/interface_linux_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package bridge
 
 import (

--- a/libnetwork/drivers/bridge/network_linux_test.go
+++ b/libnetwork/drivers/bridge/network_linux_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package bridge
 
 import (

--- a/libnetwork/drivers/bridge/port_mapping_linux.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package bridge
 
 import (

--- a/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package bridge
 
 import (

--- a/libnetwork/drivers/bridge/setup_device_linux.go
+++ b/libnetwork/drivers/bridge/setup_device_linux.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package bridge
 
 import (

--- a/libnetwork/drivers/bridge/setup_device_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_device_linux_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package bridge
 
 import (

--- a/libnetwork/drivers/bridge/setup_ip_tables.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables.go
@@ -401,16 +401,28 @@ func setupInternalNetworkRules(bridgeIface string, addr *net.IPNet, icc, insert 
 
 	if addr.IP.To4() != nil {
 		version = iptables.IPv4
-		inDropRule = iptRule{table: iptables.Filter, chain: IsolationChain1, args: []string{
-			"-i", bridgeIface, "!", "-d", addr.String(), "-j", "DROP"}}
-		outDropRule = iptRule{table: iptables.Filter, chain: IsolationChain1, args: []string{
-			"-o", bridgeIface, "!", "-s", addr.String(), "-j", "DROP"}}
+		inDropRule = iptRule{
+			table: iptables.Filter,
+			chain: IsolationChain1,
+			args:  []string{"-i", bridgeIface, "!", "-d", addr.String(), "-j", "DROP"},
+		}
+		outDropRule = iptRule{
+			table: iptables.Filter,
+			chain: IsolationChain1,
+			args:  []string{"-o", bridgeIface, "!", "-s", addr.String(), "-j", "DROP"},
+		}
 	} else {
 		version = iptables.IPv6
-		inDropRule = iptRule{table: iptables.Filter, chain: IsolationChain1, args: []string{
-			"-i", bridgeIface, "!", "-o", bridgeIface, "!", "-d", addr.String(), "-j", "DROP"}}
-		outDropRule = iptRule{table: iptables.Filter, chain: IsolationChain1, args: []string{
-			"!", "-i", bridgeIface, "-o", bridgeIface, "!", "-s", addr.String(), "-j", "DROP"}}
+		inDropRule = iptRule{
+			table: iptables.Filter,
+			chain: IsolationChain1,
+			args:  []string{"-i", bridgeIface, "!", "-o", bridgeIface, "!", "-d", addr.String(), "-j", "DROP"},
+		}
+		outDropRule = iptRule{
+			table: iptables.Filter,
+			chain: IsolationChain1,
+			args:  []string{"!", "-i", bridgeIface, "-o", bridgeIface, "!", "-s", addr.String(), "-j", "DROP"},
+		}
 	}
 
 	if err := programChainRule(version, inDropRule, "DROP INCOMING", insert); err != nil {

--- a/libnetwork/drivers/bridge/setup_ip_tables_linux.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package bridge
 
 import (

--- a/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package bridge
 
 import (

--- a/libnetwork/drivers/bridge/setup_ipv4_linux.go
+++ b/libnetwork/drivers/bridge/setup_ipv4_linux.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package bridge
 
 import (

--- a/libnetwork/drivers/bridge/setup_ipv4_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_ipv4_linux_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package bridge
 
 import (

--- a/libnetwork/drivers/bridge/setup_ipv6_linux.go
+++ b/libnetwork/drivers/bridge/setup_ipv6_linux.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package bridge
 
 import (

--- a/libnetwork/drivers/bridge/setup_ipv6_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_ipv6_linux_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package bridge
 
 import (

--- a/libnetwork/drivers/bridge/setup_verify_linux.go
+++ b/libnetwork/drivers/bridge/setup_verify_linux.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package bridge
 
 import (

--- a/libnetwork/drivers/bridge/setup_verify_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_verify_linux_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package bridge
 
 import (


### PR DESCRIPTION
- chipping away bits from https://github.com/moby/moby/pull/46149

### libnetwork/drivers/bridge: minor formatting fixes

My IDE kept on re-formatting, so let's do so.


### libnetwork/drivers/bridge: rename some linux-only files

This makes it easier to spot if code is only used on Linux. Note that "all of"
the bridge driver is Linux-only.



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

