### PR TITLE
daemon: Daemon.connectToNetwork, Daemon.ContainerRename: improve err-handling in defers

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -679,7 +679,7 @@ func buildEndpointDNSNames(ctr *container.Container, aliases []string) []string 
 	return sliceutil.Dedup(dnsNames)
 }
 
-func (daemon *Daemon) connectToNetwork(cfg *config.Config, container *container.Container, idOrName string, endpointConfig *networktypes.EndpointSettings, updateSettings bool) (err error) {
+func (daemon *Daemon) connectToNetwork(cfg *config.Config, container *container.Container, idOrName string, endpointConfig *networktypes.EndpointSettings, updateSettings bool) (retErr error) {
 	start := time.Now()
 	if container.HostConfig.NetworkMode.IsContainer() {
 		return runconfig.ErrConflictSharedNetwork
@@ -737,8 +737,8 @@ func (daemon *Daemon) connectToNetwork(cfg *config.Config, container *container.
 		return err
 	}
 	defer func() {
-		if err != nil {
-			if e := ep.Delete(false); e != nil {
+		if retErr != nil {
+			if err := ep.Delete(false); err != nil {
 				log.G(context.TODO()).Warnf("Could not rollback container connection to network %s", idOrName)
 			}
 		}


### PR DESCRIPTION
Slight refactor to somewhat future-proof these functions and prevent accidental shadowing of the error that's handled in defer statements (Daemon.ContainerRename is still messy and could still use some improvements)

### daemon: Daemon.connectToNetwork: rename named return to prevent shadowing

The output var was used in a `defer`, but named `err` and shadowed in various
places. Rename the var to a more explicit name to make clear where it's used
and to prevent it being accidentally shadowed.

### daemon: Daemon.ContainerRename: use named return to prevent shadowing

The output var was used in a `defer`. Rename the var to a more explicit
name to make clear where it's used and to prevent it being accidentally
shadowed.

### daemon: Daemon.ContainerRename: move vars closer to where they're used

Also break-up some "if" statements that were hiding that they were updating
existing variables.



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

