### PR TITLE
libnetwork: re-enabe TestExternalKeyWithReexec test

### DIFF
--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -1682,6 +1682,10 @@ func TestExternalKey(t *testing.T) {
 	externalKeyTest(t, false)
 }
 
+func TestExternalKeyWithReexec(t *testing.T) {
+	externalKeyTest(t, true)
+}
+
 func externalKeyTest(t *testing.T, reexec bool) {
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)


### PR DESCRIPTION
relates to:

- https://github.com/moby/libnetwork/pull/515
- https://github.com/moby/moby/pull/20662
- https://github.com/moby/libnetwork/issues/829
- https://github.com/moby/libnetwork/pull/921


Support for "libnetwork-setkey" re-exec was added in libnetwork in commit [6175353964906b1279cd3477437b15cca9b1a2e0][1] (https://github.com/moby/libnetwork/pull/515) which included a test for both Sandbox.SetKey, and setting the key through the "libnetwork-setkey" re-exec.

During the integration with [containerd 1.0][2], it was found that the re-exec hook used the wrong type (https://github.com/moby/libnetwork/issues/829):

> In https://github.com/docker/libnetwork/blob/df3f8a10796e2173732aeafa41af45f970ced9f6/sandbox_externalkey_unix.go#L48
> the code is expecting libcontainer.State as input but data provided by
> libcontainer actually has the type libcontainer/configs.HookState.
>
> That means that this data doesn't contain netns path and the SetKey should not work.

This issue was fixed in [e84aad941e0577ee501de9b5ba9667e2f5daf38f][3] (https://github.com/moby/libnetwork/pull/921), but lacking a test-environment, the `TestExternalKeyWithReexec` test was removed.

[1]: https://github.com/moby/libnetwork/commit/6175353964906b1279cd3477437b15cca9b1a2e0
[2]: https://github.com/moby/moby/pull/20662
[3]: https://github.com/moby/libnetwork/commit/e84aad941e0577ee501de9b5ba9667e2f5daf38f

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

