### PR TITLE
libnetwork: cleanup SetBasePath, un-export SetExternalKey and other cleanups

### DIFF
--- a/libnetwork/config/config_freebsd.go
+++ b/libnetwork/config/config_freebsd.go
@@ -1,0 +1,8 @@
+package config
+
+// FIXME(thaJeztah): ExecRoot is only used for Controller.startExternalKeyListener(), but "libnetwork-setkey" is only implemented on Linux.
+func optionExecRoot(execRoot string) Option {
+	return func(c *Config) {
+		c.ExecRoot = execRoot
+	}
+}

--- a/libnetwork/config/config_linux.go
+++ b/libnetwork/config/config_linux.go
@@ -1,0 +1,11 @@
+package config
+
+import "github.com/docker/docker/libnetwork/osl"
+
+// optionExecRoot on Linux sets both the controller's ExecRoot and osl.basePath.
+func optionExecRoot(execRoot string) Option {
+	return func(c *Config) {
+		c.ExecRoot = execRoot
+		osl.SetBasePath(execRoot)
+	}
+}

--- a/libnetwork/config/config_unsupported.go
+++ b/libnetwork/config/config_unsupported.go
@@ -1,0 +1,8 @@
+//go:build !linux && !freebsd
+
+package config
+
+// optionExecRoot is a no-op on non-unix platforms.
+func optionExecRoot(execRoot string) Option {
+	return func(*Config) {}
+}

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -477,7 +477,7 @@ func externalKeyTest(t *testing.T, reexec bool) {
 	if reexec {
 		err := reexecSetKey("this-must-fail", containerID, controller.ID())
 		if err == nil {
-			t.Fatalf("SetExternalKey must fail if the corresponding namespace is not created")
+			t.Fatalf("libnetwork-setkey must fail if the corresponding namespace is not created")
 		}
 	} else {
 		// Setting an non-existing key (namespace) must fail
@@ -500,7 +500,7 @@ func externalKeyTest(t *testing.T, reexec bool) {
 	if reexec {
 		err := reexecSetKey("ValidKey", containerID, controller.ID())
 		if err != nil {
-			t.Fatalf("SetExternalKey failed with %v", err)
+			t.Fatalf("libnetwork-setkey failed with %v", err)
 		}
 	} else {
 		if err := sbox.SetKey("ValidKey"); err != nil {

--- a/libnetwork/osl/namespace_linux.go
+++ b/libnetwork/osl/namespace_linux.go
@@ -43,16 +43,16 @@ var (
 	gpmWg            sync.WaitGroup
 	gpmCleanupPeriod = 60 * time.Second
 	gpmChan          = make(chan chan struct{})
-	prefix           = defaultPrefix
+	netnsBasePath    = filepath.Join(defaultPrefix, "netns")
 )
 
 // SetBasePath sets the base url prefix for the ns path
 func SetBasePath(path string) {
-	prefix = path
+	netnsBasePath = filepath.Join(path, "netns")
 }
 
 func basePath() string {
-	return filepath.Join(prefix, "netns")
+	return netnsBasePath
 }
 
 func createBasePath() {

--- a/libnetwork/osl/namespace_unsupported.go
+++ b/libnetwork/osl/namespace_unsupported.go
@@ -11,7 +11,3 @@ func GC() {
 func GetSandboxForExternalKey(path string, key string) (Sandbox, error) {
 	return nil, nil
 }
-
-// SetBasePath sets the base url prefix for the ns path
-func SetBasePath(path string) {
-}

--- a/libnetwork/osl/namespace_windows.go
+++ b/libnetwork/osl/namespace_windows.go
@@ -18,9 +18,4 @@ func GetSandboxForExternalKey(path string, key string) (Sandbox, error) {
 
 // GC triggers garbage collection of namespace path right away
 // and waits for it.
-func GC() {
-}
-
-// SetBasePath sets the base url prefix for the ns path
-func SetBasePath(path string) {
-}
+func GC() {}

--- a/libnetwork/osl/sandbox_freebsd.go
+++ b/libnetwork/osl/sandbox_freebsd.go
@@ -26,7 +26,3 @@ func GetSandboxForExternalKey(path string, key string) (Sandbox, error) {
 // and waits for it.
 func GC() {
 }
-
-// SetBasePath sets the base url prefix for the ns path
-func SetBasePath(path string) {
-}

--- a/libnetwork/sandbox_externalkey_unix.go
+++ b/libnetwork/sandbox_externalkey_unix.go
@@ -65,11 +65,11 @@ func setKey() error {
 		return err
 	}
 
-	return SetExternalKey(shortCtlrID, containerID, fmt.Sprintf("/proc/%d/ns/net", state.Pid), *execRoot)
+	return setExternalKey(shortCtlrID, containerID, fmt.Sprintf("/proc/%d/ns/net", state.Pid), *execRoot)
 }
 
-// SetExternalKey provides a convenient way to set an External key to a sandbox
-func SetExternalKey(shortCtlrID string, containerID string, key string, execRoot string) error {
+// setExternalKey provides a convenient way to set an External key to a sandbox
+func setExternalKey(shortCtlrID string, containerID string, key string, execRoot string) error {
 	uds := filepath.Join(execRoot, execSubdir, shortCtlrID+".sock")
 	c, err := net.Dial("unix", uds)
 	if err != nil {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/46149

### libnetwork/osl: use filepath.Join() only when changing basedir

Use filepath.Join() only when the base-path is updated, instead of every
time it is accessed.

### libnetwork/options: OptionExecRoot: skip osl.SetBasePath on non-Linux

The basepath is only used on Linux, so no need to call it on other
platforms. SetBasePath was already stubbed out on other platforms,
but "osl" was still imported in various places where it was not actually
used, so trying to reduce imports to get a better picture of what parts
are used (and not used).

### libnetwork: un-export SetExternalKey

It's only called as part of the "libnetwork-setkey" re-exec, so un-exporting
it to make clear it's not for external use.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

