### PR TITLE
libnetwork: implement Controller.GetSandbox, remove Controller.WalkSandboxes and related code

### DIFF
--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -82,14 +82,12 @@ type NetworkWalker func(nw *Network) bool
 // When the function returns true, the walk will stop.
 type SandboxWalker func(sb *Sandbox) bool
 
-type sandboxTable map[string]*Sandbox
-
 // Controller manages networks.
 type Controller struct {
 	id               string
 	drvRegistry      drvregistry.Networks
 	ipamRegistry     drvregistry.IPAMs
-	sandboxes        sandboxTable
+	sandboxes        map[string]*Sandbox
 	cfg              *config.Config
 	store            *datastore.Store
 	extKeyListener   net.Listener
@@ -115,7 +113,7 @@ func New(cfgOptions ...config.Option) (*Controller, error) {
 	c := &Controller{
 		id:               stringid.GenerateRandomID(),
 		cfg:              config.New(cfgOptions...),
-		sandboxes:        sandboxTable{},
+		sandboxes:        map[string]*Sandbox{},
 		svcRecords:       make(map[string]*svcInfo),
 		serviceBindings:  make(map[serviceKey]*service),
 		agentInitDone:    make(chan struct{}),

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -966,24 +966,6 @@ func (c *Controller) NewSandbox(containerID string, options ...SandboxOption) (*
 	return sb, nil
 }
 
-// Sandboxes returns the list of Sandbox(s) managed by this controller.
-func (c *Controller) Sandboxes() []*Sandbox {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	list := make([]*Sandbox, 0, len(c.sandboxes))
-	for _, s := range c.sandboxes {
-		// Hide stub sandboxes from libnetwork users
-		if s.isStub {
-			continue
-		}
-
-		list = append(list, s)
-	}
-
-	return list
-}
-
 // GetSandbox returns the Sandbox which has the passed id.
 //
 // It returns an [ErrInvalidID] when passing an invalid ID, or an

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -1045,17 +1045,6 @@ func SandboxContainerWalker(out **Sandbox, containerID string) SandboxWalker {
 	}
 }
 
-// SandboxKeyWalker returns a Sandbox Walker function which looks for an existing Sandbox with the passed key
-func SandboxKeyWalker(out **Sandbox, key string) SandboxWalker {
-	return func(sb *Sandbox) bool {
-		if sb.Key() == key {
-			*out = sb
-			return true
-		}
-		return false
-	}
-}
-
 func (c *Controller) loadDriver(networkType string) error {
 	var err error
 

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -78,10 +78,6 @@ import (
 // When the function returns true, the walk will stop.
 type NetworkWalker func(nw *Network) bool
 
-// SandboxWalker is a client provided function which will be used to walk the Sandboxes.
-// When the function returns true, the walk will stop.
-type SandboxWalker func(sb *Sandbox) bool
-
 // Controller manages networks.
 type Controller struct {
 	id               string
@@ -988,15 +984,6 @@ func (c *Controller) Sandboxes() []*Sandbox {
 	return list
 }
 
-// WalkSandboxes uses the provided function to walk the Sandbox(s) managed by this controller.
-func (c *Controller) WalkSandboxes(walker SandboxWalker) {
-	for _, sb := range c.Sandboxes() {
-		if walker(sb) {
-			return
-		}
-	}
-}
-
 // GetSandbox returns the Sandbox which has the passed id.
 //
 // It returns an [ErrInvalidID] when passing an invalid ID, or an
@@ -1056,17 +1043,6 @@ func (c *Controller) SandboxDestroy(id string) error {
 	}
 
 	return sb.Delete()
-}
-
-// SandboxContainerWalker returns a Sandbox Walker function which looks for an existing Sandbox with the passed containerID
-func SandboxContainerWalker(out **Sandbox, containerID string) SandboxWalker {
-	return func(sb *Sandbox) bool {
-		if sb.ContainerID() == containerID {
-			*out = sb
-			return true
-		}
-		return false
-	}
 }
 
 func (c *Controller) loadDriver(networkType string) error {

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -2089,24 +2089,17 @@ type parallelTester struct {
 }
 
 func (pt parallelTester) Do(t *testing.T, thrNumber int) error {
-	var (
-		ep  *libnetwork.Endpoint
-		sb  *libnetwork.Sandbox
-		err error
-	)
-
 	teardown, err := pt.osctx.Set()
 	if err != nil {
 		return err
 	}
 	defer teardown(t)
 
-	epName := fmt.Sprintf("pep%d", thrNumber)
-
+	var ep *libnetwork.Endpoint
 	if thrNumber == 1 {
-		ep, err = pt.net1.EndpointByName(epName)
+		ep, err = pt.net1.EndpointByName(fmt.Sprintf("pep%d", thrNumber))
 	} else {
-		ep, err = pt.net2.EndpointByName(epName)
+		ep, err = pt.net2.EndpointByName(fmt.Sprintf("pep%d", thrNumber))
 	}
 
 	if err != nil {
@@ -2116,6 +2109,7 @@ func (pt parallelTester) Do(t *testing.T, thrNumber int) error {
 		return errors.New("got nil ep with no error")
 	}
 
+	var sb *libnetwork.Sandbox
 	cid := fmt.Sprintf("%drace", thrNumber)
 	pt.controller.WalkSandboxes(libnetwork.SandboxContainerWalker(&sb, cid))
 	if sb == nil {

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -2109,11 +2109,10 @@ func (pt parallelTester) Do(t *testing.T, thrNumber int) error {
 		return errors.New("got nil ep with no error")
 	}
 
-	var sb *libnetwork.Sandbox
 	cid := fmt.Sprintf("%drace", thrNumber)
-	pt.controller.WalkSandboxes(libnetwork.SandboxContainerWalker(&sb, cid))
-	if sb == nil {
-		return errors.Errorf("got nil sandbox for container: %s", cid)
+	sb, err := pt.controller.GetSandbox(cid)
+	if err != nil {
+		return err
 	}
 
 	for i := 0; i < pt.iterCnt; i++ {

--- a/libnetwork/sandbox_dns_unix.go
+++ b/libnetwork/sandbox_dns_unix.go
@@ -147,7 +147,10 @@ func (sb *Sandbox) updateParentHosts() error {
 	var pSb *Sandbox
 
 	for _, update := range sb.config.parentUpdates {
-		sb.controller.WalkSandboxes(SandboxContainerWalker(&pSb, update.cid))
+		// TODO(thaJeztah): was it intentional for this loop to re-use prior results of pSB? If not, we should make pSb local and always replace here.
+		if s, _ := sb.controller.GetSandbox(update.cid); s != nil {
+			pSb = s
+		}
 		if pSb == nil {
 			continue
 		}

--- a/libnetwork/sandbox_externalkey_unix.go
+++ b/libnetwork/sandbox_externalkey_unix.go
@@ -164,15 +164,11 @@ func (c *Controller) processExternalKey(conn net.Conn) error {
 	if err = json.Unmarshal(buf[0:nr], &s); err != nil {
 		return err
 	}
-
-	var sandbox *Sandbox
-	search := SandboxContainerWalker(&sandbox, s.ContainerID)
-	c.WalkSandboxes(search)
-	if sandbox == nil {
-		return types.InvalidParameterErrorf("no sandbox present for %s", s.ContainerID)
+	sb, err := c.GetSandbox(s.ContainerID)
+	if err != nil {
+		return types.InvalidParameterErrorf("failed to get sandbox for %s", s.ContainerID)
 	}
-
-	return sandbox.SetKey(s.Key)
+	return sb.SetKey(s.Key)
 }
 
 func (c *Controller) stopExternalKeyListener() {


### PR DESCRIPTION
## libnetwork: implement Controller.GetSandbox, remove Controller.WalkSandboxes and related code

### libnetwork: remove unused SandboxKeyWalker

### libnetwork: remove redundant sandboxTable type

It was not exported so let's remove the abstraction to not make it look
like something more than it is.

### libnetwork: parallelTester: move vars closer to where they're used

### libnetwork: implement Controller.GetSandbox(containerID)

Various parts of the code were using "walkers" to iterate over the
controller's sandboxes, and the only condition for all of them was
to find the sandbox for a given container-ID. Iterating over all
sandboxes was also sub-optimal, because on Windows, the ContainerID
is used as Sandbox-ID, which can be used to lookup the sandbox from
the "sandboxes" map on the controller.

This patch implements a GetSandbox method on the controller that
looks up the sandbox for a given container-ID, using the most optimal
approach (depending on the platform).

The new method can return errors for invalid (empty) container-IDs, and
a "not found" error to allow consumers to detect non-existing sandboxes,
or potentially invalid IDs.

This new method replaces the (non-exported) Daemon.getNetworkSandbox(),
which was only used internally, in favor of directly accessing the
controller's method.

### libnetwork: remove Controller.WalkSandboxes and related code

This functionality has been replaced with Controller.GetSandbox, and is
no longer used anywhere.

This patch removes:

- the Controller.WalkSandboxes method
- the SandboxContainerWalker SandboxWalker
- the SandboxWalker type

### libnetwork: remove Controller.Sandboxes as it's no longer used

The Controller.Sandboxes method was used by some SandboxWalkers. Now
that those have been removed, there are no longer any consumers of this
method, so let's remove it for now.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

