### PR TITLE
daemon: withLibnetwork(): return early if networking is disabled

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -68,7 +68,7 @@ func withLibnetwork(daemon *Daemon, daemonCfg *dconfig.Config, c *container.Cont
 			s.Hooks = &specs.Hooks{}
 		}
 		for _, ns := range s.Linux.Namespaces {
-			if ns.Type == "network" && ns.Path == "" && !c.Config.NetworkDisabled {
+			if ns.Type == specs.NetworkNamespace && ns.Path == "" && !c.Config.NetworkDisabled {
 				target := filepath.Join("/proc", strconv.Itoa(os.Getpid()), "exe")
 				shortNetCtlrID := stringid.TruncateID(daemon.netController.ID())
 				s.Hooks.Prestart = append(s.Hooks.Prestart, specs.Hook{


### PR DESCRIPTION
### daemon: withLibnetwork(): use OCI-spec consts for namespaces

### daemon: withLibnetwork(): return early if networking is disabled

The function was checking in a loop if networking for the container was
disabled. Change the function to return early, and to only set hooks
if one needs to be set.


**- A picture of a cute animal (not mandatory but encouraged)**

