### PR TITLE
oci: DefaultLinuxSpec: use OCI-spec consts for namespaces

### DIFF
--- a/oci/defaults.go
+++ b/oci/defaults.go
@@ -122,11 +122,11 @@ func DefaultLinuxSpec() specs.Spec {
 				"/proc/sysrq-trigger",
 			},
 			Namespaces: []specs.LinuxNamespace{
-				{Type: "mount"},
-				{Type: "network"},
-				{Type: "uts"},
-				{Type: "pid"},
-				{Type: "ipc"},
+				{Type: specs.MountNamespace},
+				{Type: specs.NetworkNamespace},
+				{Type: specs.UTSNamespace},
+				{Type: specs.PIDNamespace},
+				{Type: specs.IPCNamespace},
 			},
 			// Devices implicitly contains the following devices:
 			// null, zero, full, random, urandom, tty, console, and ptmx.


### PR DESCRIPTION


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

