### PR TITLE
daemon: WithNamespaces(): improve error-handling, and assorted cleanups

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -68,16 +68,6 @@ func (daemon *Daemon) GetContainer(prefixOrName string) (*container.Container, e
 	return ctr, nil
 }
 
-// checkContainer make sure the specified container validates the specified conditions
-func (daemon *Daemon) checkContainer(container *container.Container, conditions ...func(*container.Container) error) error {
-	for _, condition := range conditions {
-		if err := condition(container); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // Exists returns a true if a container of the specified ID or name exists,
 // false otherwise.
 func (daemon *Daemon) Exists(id string) bool {

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -86,8 +86,7 @@ func (daemon *Daemon) getIpcContainer(id string) (*container.Container, error) {
 	return ctr, nil
 }
 
-func (daemon *Daemon) getPidContainer(ctr *container.Container) (*container.Container, error) {
-	id := ctr.HostConfig.PidMode.Container()
+func (daemon *Daemon) getPIDContainer(id string) (*container.Container, error) {
 	ctr, err := daemon.GetContainer(id)
 	if err != nil {
 		return nil, errdefs.InvalidParameter(err)

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -61,15 +61,19 @@ func (daemon *Daemon) setupLinkedContainers(container *container.Container) ([]s
 
 func (daemon *Daemon) getIpcContainer(id string) (*container.Container, error) {
 	errMsg := "can't join IPC of container " + id
-	// Check the container exists
+
+	// Check if the container exists, is running, and not restarting
 	ctr, err := daemon.GetContainer(id)
 	if err != nil {
 		return nil, errors.Wrap(err, errMsg)
 	}
-	// Check the container is running and not restarting
-	if err := daemon.checkContainer(ctr, containerIsRunning, containerIsNotRestarting); err != nil {
-		return nil, errors.Wrap(err, errMsg)
+	if !ctr.IsRunning() {
+		return nil, errNotRunning(id)
 	}
+	if ctr.IsRestarting() {
+		return nil, errContainerIsRestarting(id)
+	}
+
 	// Check the container ipc is shareable
 	if st, err := os.Stat(ctr.ShmPath); err != nil || !st.IsDir() {
 		if err == nil || os.IsNotExist(err) {
@@ -83,26 +87,19 @@ func (daemon *Daemon) getIpcContainer(id string) (*container.Container, error) {
 }
 
 func (daemon *Daemon) getPidContainer(ctr *container.Container) (*container.Container, error) {
-	containerID := ctr.HostConfig.PidMode.Container()
-	ctr, err := daemon.GetContainer(containerID)
+	id := ctr.HostConfig.PidMode.Container()
+	ctr, err := daemon.GetContainer(id)
 	if err != nil {
-		return nil, errors.Wrapf(err, "cannot join PID of a non running container: %s", containerID)
+		return nil, errors.Wrapf(err, "cannot join PID of a non running container: %s", id)
 	}
-	return ctr, daemon.checkContainer(ctr, containerIsRunning, containerIsNotRestarting)
-}
+	if !ctr.IsRunning() {
+		return nil, errNotRunning(id)
+	}
+	if ctr.IsRestarting() {
+		return nil, errContainerIsRestarting(id)
+	}
 
-func containerIsRunning(c *container.Container) error {
-	if !c.IsRunning() {
-		return errdefs.Conflict(errors.Errorf("container %s is not running", c.ID))
-	}
-	return nil
-}
-
-func containerIsNotRestarting(c *container.Container) error {
-	if c.IsRestarting() {
-		return errContainerIsRestarting(c.ID)
-	}
-	return nil
+	return ctr, nil
 }
 
 func (daemon *Daemon) setupIpcDirs(c *container.Container) error {

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -65,7 +65,7 @@ func (daemon *Daemon) getIpcContainer(id string) (*container.Container, error) {
 	// Check if the container exists, is running, and not restarting
 	ctr, err := daemon.GetContainer(id)
 	if err != nil {
-		return nil, errors.Wrap(err, errMsg)
+		return nil, errdefs.InvalidParameter(errors.Wrap(err, errMsg))
 	}
 	if !ctr.IsRunning() {
 		return nil, errNotRunning(id)
@@ -77,10 +77,10 @@ func (daemon *Daemon) getIpcContainer(id string) (*container.Container, error) {
 	// Check the container ipc is shareable
 	if st, err := os.Stat(ctr.ShmPath); err != nil || !st.IsDir() {
 		if err == nil || os.IsNotExist(err) {
-			return nil, errors.New(errMsg + ": non-shareable IPC (hint: use IpcMode:shareable for the donor container)")
+			return nil, errdefs.InvalidParameter(errors.New(errMsg + ": non-shareable IPC (hint: use IpcMode:shareable for the donor container)"))
 		}
 		// stat() failed?
-		return nil, errors.Wrap(err, errMsg+": unexpected error from stat "+ctr.ShmPath)
+		return nil, errdefs.System(errors.Wrap(err, errMsg+": unexpected error from stat "+ctr.ShmPath))
 	}
 
 	return ctr, nil
@@ -90,7 +90,7 @@ func (daemon *Daemon) getPidContainer(ctr *container.Container) (*container.Cont
 	id := ctr.HostConfig.PidMode.Container()
 	ctr, err := daemon.GetContainer(id)
 	if err != nil {
-		return nil, errors.Wrapf(err, "cannot join PID of a non running container: %s", id)
+		return nil, errdefs.InvalidParameter(err)
 	}
 	if !ctr.IsRunning() {
 		return nil, errNotRunning(id)

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -292,9 +292,9 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		}
 		switch {
 		case ipcMode.IsContainer():
-			ic, err := daemon.getIpcContainer(ipcMode.Container())
+			ic, err := daemon.getIPCContainer(ipcMode.Container())
 			if err != nil {
-				return errors.Wrapf(err, "invalid IPC mode: %v", ipcMode)
+				return errors.Wrap(err, "failed to join IPC namespace")
 			}
 			setNamespace(s, specs.LinuxNamespace{
 				Type: specs.IPCNamespace,
@@ -526,7 +526,7 @@ func withMounts(daemon *Daemon, daemonCfg *configStore, c *container.Container) 
 			return err
 		}
 
-		if err := daemon.setupIpcDirs(c); err != nil {
+		if err := daemon.setupIPCDirs(c); err != nil {
 			return err
 		}
 

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -362,12 +362,10 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		if !c.HostConfig.CgroupnsMode.Valid() {
 			return errdefs.InvalidParameter(errors.Errorf("invalid cgroup namespace mode: %v", c.HostConfig.CgroupnsMode))
 		}
-		if !c.HostConfig.CgroupnsMode.IsEmpty() {
-			if c.HostConfig.CgroupnsMode.IsPrivate() {
-				setNamespace(s, specs.LinuxNamespace{
-					Type: specs.CgroupNamespace,
-				})
-			}
+		if c.HostConfig.CgroupnsMode.IsPrivate() {
+			setNamespace(s, specs.LinuxNamespace{
+				Type: specs.CgroupNamespace,
+			})
 		}
 
 		return nil

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -268,6 +268,8 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 				})
 				if userNS {
 					// to share a net namespace, the containers must also share a user namespace.
+					//
+					// FIXME(thaJeztah): this will silently overwrite an earlier user namespace when joining multiple containers: https://github.com/moby/moby/issues/46210
 					setNamespace(s, specs.LinuxNamespace{
 						Type: specs.UserNamespace,
 						Path: fmt.Sprintf("/proc/%d/ns/user", nc.State.GetPID()),
@@ -302,6 +304,8 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 			})
 			if userNS {
 				// to share a IPC namespace, the containers must also share a user namespace.
+				//
+				// FIXME(thaJeztah): this will silently overwrite an earlier user namespace when joining multiple containers: https://github.com/moby/moby/issues/46210
 				setNamespace(s, specs.LinuxNamespace{
 					Type: specs.UserNamespace,
 					Path: fmt.Sprintf("/proc/%d/ns/user", ic.State.GetPID()),
@@ -336,6 +340,8 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 			})
 			if userNS {
 				// to share a PID namespace, the containers must also share a user namespace.
+				//
+				// FIXME(thaJeztah): this will silently overwrite an earlier user namespace when joining multiple containers: https://github.com/moby/moby/issues/46210
 				setNamespace(s, specs.LinuxNamespace{
 					Type: specs.UserNamespace,
 					Path: fmt.Sprintf("/proc/%d/ns/user", pc.State.GetPID()),

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -326,7 +326,7 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		}
 		switch {
 		case pidMode.IsContainer():
-			pc, err := daemon.getPidContainer(c)
+			pc, err := daemon.getPIDContainer(pidMode.Container())
 			if err != nil {
 				return errors.Wrap(err, "failed to join PID namespace")
 			}

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -294,7 +294,7 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		case ipcMode.IsContainer():
 			ic, err := daemon.getIpcContainer(ipcMode.Container())
 			if err != nil {
-				return errdefs.InvalidParameter(errors.Wrapf(err, "invalid IPC mode: %v", ipcMode))
+				return errors.Wrapf(err, "invalid IPC mode: %v", ipcMode)
 			}
 			setNamespace(s, specs.LinuxNamespace{
 				Type: specs.IPCNamespace,
@@ -328,7 +328,7 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		case pidMode.IsContainer():
 			pc, err := daemon.getPidContainer(c)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "failed to join PID namespace")
 			}
 			setNamespace(s, specs.LinuxNamespace{
 				Type: specs.PIDNamespace,

--- a/integration/container/pidmode_linux_test.go
+++ b/integration/container/pidmode_linux_test.go
@@ -6,8 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/container"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
@@ -32,4 +35,42 @@ func TestPIDModeHost(t *testing.T) {
 	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
 	cPid = container.GetContainerNS(ctx, t, apiClient, cID, "pid")
 	assert.Assert(t, hostPid != cPid)
+}
+
+func TestPIDModeContainer(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+
+	defer setupTest(t)()
+	apiClient := testEnv.APIClient()
+	ctx := context.Background()
+
+	t.Run("non-existing container", func(t *testing.T) {
+		_, err := container.CreateFromConfig(ctx, apiClient, container.NewTestConfig(container.WithPIDMode("container:nosuchcontainer")))
+		assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+		assert.Check(t, is.ErrorContains(err, "No such container: nosuchcontainer"))
+	})
+
+	t.Run("non-running container", func(t *testing.T) {
+		const pidCtrName = "stopped-pid-namespace-container"
+		cPIDContainerID := container.Create(ctx, t, apiClient, container.WithName(pidCtrName))
+
+		ctr, err := container.CreateFromConfig(ctx, apiClient, container.NewTestConfig(container.WithPIDMode("container:"+pidCtrName)))
+		assert.NilError(t, err, "should not produce an error when creating, only when starting")
+
+		err = apiClient.ContainerStart(ctx, ctr.ID, types.ContainerStartOptions{})
+		assert.Check(t, is.ErrorType(err, errdefs.IsSystem), "should produce a System error when starting an existing container from an invalid state")
+		assert.Check(t, is.ErrorContains(err, "failed to join PID namespace"))
+		assert.Check(t, is.ErrorContains(err, cPIDContainerID+" is not running"))
+	})
+
+	t.Run("running container", func(t *testing.T) {
+		const pidCtrName = "running-pid-namespace-container"
+		container.Run(ctx, t, apiClient, container.WithName(pidCtrName))
+
+		ctr, err := container.CreateFromConfig(ctx, apiClient, container.NewTestConfig(container.WithPIDMode("container:"+pidCtrName)))
+		assert.NilError(t, err)
+
+		err = apiClient.ContainerStart(ctx, ctr.ID, types.ContainerStartOptions{})
+		assert.Check(t, err)
+	})
 }


### PR DESCRIPTION
- [x] depends on https://github.com/moby/moby/pull/46209
- related: https://github.com/moby/moby/issues/46210

----

### daemon: remove Daemon.checkContainer and related utils

This was added in 12485d62eeba27119260dc5eb54ac4fa83c3130b to save some
duplication, but was really over-engineered to save a few lines of code,
at the cost of hiding away what it does and also potentially returning
inconsistent errors (not addressed in this patch). Let's start with
inlining these.

This removes;

- Daemon.checkContainer
- daemon.containerIsRunning
- daemon.containerIsNotRestarting

### daemon: WithNamespaces(): inline variables

### daemon: WithNamespaces(): use OCI-spec consts for namespaces

### daemon: WithNamespaces(): use switch instead of if/else if/else

We were using a mixture of approaches for these; aligning them a bit
to all use switch statements.

### daemon: WithNamespaces(): remove redundant "if"

This check was originally used to only validate the mode if it was set to
a non-empty value (see commit 072400fc4b8d6a38a2007d41072b765666a4c288), but
validation was made unconditional in c3d7a0c6033a2764dd85c3863809ac498ef129f2.

Given that a `CgroupnsMode` can't be both [`CgroupnsMode.IsEmpty()`][1]
and [`CgroupnsMode.IsPrivate`][2], we can remove the extra check.

[1]: https://github.com/moby/moby/blob/e0da5cb9291982a4c7b3c6b0642eeced4ba9f8ac/api/types/container/hostconfig.go#L33-L36
[2]: https://github.com/moby/moby/blob/e0da5cb9291982a4c7b3c6b0642eeced4ba9f8ac/api/types/container/hostconfig.go#L23-L26


### daemon: WithNamespaces(): fix incorrect error for PID namespace

`Daemon.getPidContainer()` was wrapping the error-message with a message
("cannot join PID of a non running container") that did not reflect the
actual reason for the error; `Daemon.GetContainer()` could either return
an invalid parameter (invalid / empty identifier), or a "not found" error
if the specified container-ID could not be found.

In the latter case, we don't want to return a "not found" error through
the API, as this would indicate that the container we're _starting_ was
not found (which is not the case), so we need to convert the error into
an `errdefs.ErrInvalidParameter` (the container-ID specified for the PID
namespace is invalid if the container doesn't exist).

This logic is similar to what we do for IPC namespaces. which received
a similar fix in c3d7a0c6033a2764dd85c3863809ac498ef129f2.

It's worth noting that, while `WithNamespaces()` may return an "invalid
parameter" error, the `start` endpoint itself may _not_ be. as outlined
in commit bf1fb97575ae0c929075f8340d7deb4ae9f41fae, starting a container
that has an invalid configuration should be considered an internal server
error, and is not an invalid _request_. However, for uses other than
container "start", `WithNamespaces()` should return the correct error
to allow code to handle it accordingly.


### daemon: Daemon.getPidContainer: change to accept "id" argument

This function didn't need the whole container, only its ID, so let's
use that as argument. This also makes it consistent with getIpcContainer.


### daemon: Daemon.getIpcContainer: make errors less repetitive

- Most error-message returned would already include "container" and the
  container ID in the error-message (e.g. "container %s is not running"),
  so there's no need to add a custom prefix for that.
- os.Stat returns a PathError, which already includes the operation ("stat"),
  the path, and the underlying error that occurred.

And while updating, let's also fix the name to be proper camelCase :)

### daemon: WithNamespaces(): add notes about user-namespaces

While working on this code, I noticed that there's currently an issue
with userns enabled. When userns is enabled, joining another container's
namespace must also join its user-namespace.

However, a container can only be in a single user namespace, so if a
container joins namespaces from multiple containers, latter user-namespaces
overwrite former ones.

We must add validation for this, but in the meantime, add notes / todo's.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

