### PR TITLE
daemon: assorted fixes with signal / kill handling

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -338,12 +338,11 @@ func killProcessDirectly(container *container.Container) error {
 	}
 
 	if err := unix.Kill(pid, syscall.SIGKILL); err != nil {
-		if err != unix.ESRCH {
-			return errdefs.System(err)
+		if err == unix.ESRCH {
+			log.G(context.TODO()).WithField("container", container.ID).Debugf("cannot kill process (pid=%d) with signal %d: no such process", container.GetPID(), syscall.SIGKILL)
+			return nil
 		}
-		err = errNoSuchProcess{pid, syscall.SIGKILL}
-		log.G(context.TODO()).WithError(err).WithField("container", container.ID).Debug("no such process")
-		return err
+		return errdefs.System(err)
 	}
 
 	// In case there were some exceptions(e.g., state of zombie and D)

--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -139,11 +139,10 @@ func (daemon *Daemon) Kill(container *containerpkg.Container) error {
 	}
 
 	// 1. Send SIGKILL
-	if err := daemon.killPossiblyDeadProcess(container, syscall.SIGKILL); err != nil {
-		// kill failed, check if process is no longer running.
-		if errors.As(err, &errNoSuchProcess{}) {
-			return nil
-		}
+	err := daemon.killPossiblyDeadProcess(container, syscall.SIGKILL)
+	if err == nil {
+		// SIGKILL was sent successfully, or process was already gone. We're done.
+		return nil
 	}
 
 	waitTimeout := 10 * time.Second
@@ -182,9 +181,8 @@ func (daemon *Daemon) Kill(container *containerpkg.Container) error {
 func (daemon *Daemon) killPossiblyDeadProcess(container *containerpkg.Container, sig syscall.Signal) error {
 	err := daemon.killWithSignal(container, sig)
 	if errdefs.IsNotFound(err) {
-		err = errNoSuchProcess{container.GetPID(), sig}
-		log.G(context.TODO()).Debug(err)
-		return err
+		log.G(context.TODO()).Debugf("cannot kill process (pid=%d) with signal %d: no such process", container.GetPID(), sig)
+		return nil
 	}
 	return err
 }

--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -161,9 +161,6 @@ func (daemon *Daemon) Kill(container *containerpkg.Container) error {
 	log.G(ctx).WithError(status.Err()).WithField("container", container.ID).Errorf("Container failed to exit within %v of kill - trying direct SIGKILL", waitTimeout)
 
 	if err := killProcessDirectly(container); err != nil {
-		if errors.As(err, &errNoSuchProcess{}) {
-			return nil
-		}
 		return err
 	}
 


### PR DESCRIPTION
### daemon: Daemon.killPossiblyDeadProcess(): fix error return

This function is meant to suppress "no such process" errors, but was
still returning them.

### daemon: Daemon.killProcessDirectly() don't return error that will be ignored

Daemon.Kill is the only consumer of this function, and will ignore "no such
process" errors, so simplify the code for consumers of this function to
not have to selectively ignore errors.



**- A picture of a cute animal (not mandatory but encouraged)**

