### PR TITLE
libnetwork/iptables: reduce DeleteConntrackEntriesXX debug logs

### DIFF
--- a/libnetwork/iptables/conntrack.go
+++ b/libnetwork/iptables/conntrack.go
@@ -25,9 +25,9 @@ func checkConntrackProgrammable(nlh *netlink.Handle) error {
 
 // DeleteConntrackEntries deletes all the conntrack connections on the host for the specified IP
 // Returns the number of flows deleted for IPv4, IPv6 else error
-func DeleteConntrackEntries(nlh *netlink.Handle, ipv4List []net.IP, ipv6List []net.IP) (uint, uint, error) {
+func DeleteConntrackEntries(nlh *netlink.Handle, ipv4List []net.IP, ipv6List []net.IP) error {
 	if err := checkConntrackProgrammable(nlh); err != nil {
-		return 0, 0, err
+		return err
 	}
 
 	var totalIPv4FlowPurged uint
@@ -54,7 +54,7 @@ func DeleteConntrackEntries(nlh *netlink.Handle, ipv4List []net.IP, ipv6List []n
 		log.G(context.TODO()).Debugf("DeleteConntrackEntries purged ipv4:%d, ipv6:%d", totalIPv4FlowPurged, totalIPv6FlowPurged)
 	}
 
-	return totalIPv4FlowPurged, totalIPv6FlowPurged, nil
+	return nil
 }
 
 func DeleteConntrackEntriesByPort(nlh *netlink.Handle, proto types.Protocol, ports []uint16) error {

--- a/libnetwork/iptables/conntrack.go
+++ b/libnetwork/iptables/conntrack.go
@@ -50,7 +50,10 @@ func DeleteConntrackEntries(nlh *netlink.Handle, ipv4List []net.IP, ipv6List []n
 		totalIPv6FlowPurged += flowPurged
 	}
 
-	log.G(context.TODO()).Debugf("DeleteConntrackEntries purged ipv4:%d, ipv6:%d", totalIPv4FlowPurged, totalIPv6FlowPurged)
+	if totalIPv4FlowPurged > 0 || totalIPv6FlowPurged > 0 {
+		log.G(context.TODO()).Debugf("DeleteConntrackEntries purged ipv4:%d, ipv6:%d", totalIPv4FlowPurged, totalIPv6FlowPurged)
+	}
+
 	return totalIPv4FlowPurged, totalIPv6FlowPurged, nil
 }
 
@@ -86,7 +89,10 @@ func DeleteConntrackEntriesByPort(nlh *netlink.Handle, proto types.Protocol, por
 		totalIPv6FlowPurged += v6FlowPurged
 	}
 
-	log.G(context.TODO()).Debugf("DeleteConntrackEntriesByPort for %s ports purged ipv4:%d, ipv6:%d", proto.String(), totalIPv4FlowPurged, totalIPv6FlowPurged)
+	if totalIPv4FlowPurged > 0 || totalIPv6FlowPurged > 0 {
+		log.G(context.TODO()).Debugf("DeleteConntrackEntriesByPort for %s ports purged ipv4:%d, ipv6:%d", proto.String(), totalIPv4FlowPurged, totalIPv6FlowPurged)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
### libnetwork/iptables: reduce DeleteConntrackEntriesXX debug logs

Both functions were generating debug logs if there was nothing to log.
The function already produces logs if things failed while deleting entries,
so these logs would only be printed if there was nothing to delete, so can
safely be discarded.

Before this change:

    DEBU[2023-08-14T12:33:23.082052638Z] Revoking external connectivity on endpoint sweet_swirles (1519f9376a3abe7a1c981600c25e8df6bbd0a3bc3a074f1c2b3bcbad0438443b)
    DEBU[2023-08-14T12:33:23.085782847Z] DeleteConntrackEntries purged ipv4:0, ipv6:0
    DEBU[2023-08-14T12:33:23.085793847Z] DeleteConntrackEntriesByPort for udp ports purged ipv4:0, ipv6:0


### libnetwork/iptables: DeleteConntrackEntries: remove "totals" returns

There's nothing handling these results, and they're logged as debug-logs,
so we may as well remove the returned variables.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

