### PR TITLE
libnetwork/iptables: refactor firewalld code

### DIFF
--- a/libnetwork/iptables/firewalld.go
+++ b/libnetwork/iptables/firewalld.go
@@ -268,16 +268,16 @@ func (fwd *firewalldConnection) setupDockerZone() error {
 	return nil
 }
 
-// AddInterfaceFirewalld adds the interface to the trusted zone. It is a
-// no-op if firewalld is not running.
-func AddInterfaceFirewalld(intf string) error {
-	if !firewalld.isRunning() {
+// addInterface adds the interface to the trusted zone. It is a no-op if
+// firewalld is not running or firewalldConnection not initialized.
+func (fwd *firewalldConnection) addInterface(intf string) error {
+	if !fwd.isRunning() {
 		return nil
 	}
 
 	var intfs []string
 	// Check if interface is already added to the zone
-	if err := firewalld.sysObj.Call(dbusInterface+".zone.getInterfaces", 0, dockerZone).Store(&intfs); err != nil {
+	if err := fwd.sysObj.Call(dbusInterface+".zone.getInterfaces", 0, dockerZone).Store(&intfs); err != nil {
 		return err
 	}
 	// Return if interface is already part of the zone
@@ -288,16 +288,16 @@ func AddInterfaceFirewalld(intf string) error {
 
 	log.G(context.TODO()).Debugf("Firewalld: adding %s interface to %s zone", intf, dockerZone)
 	// Runtime
-	if err := firewalld.sysObj.Call(dbusInterface+".zone.addInterface", 0, dockerZone, intf).Err; err != nil {
+	if err := fwd.sysObj.Call(dbusInterface+".zone.addInterface", 0, dockerZone, intf).Err; err != nil {
 		return err
 	}
 	return nil
 }
 
-// DelInterfaceFirewalld removes the interface from the trusted zone It is a
-// no-op if firewalld is not running.
-func DelInterfaceFirewalld(intf string) error {
-	if !firewalld.isRunning() {
+// delInterface removes the interface from the trusted zone It is a no-op if
+// firewalld is not running or firewalldConnection not initialized.
+func (fwd *firewalldConnection) delInterface(intf string) error {
+	if !fwd.isRunning() {
 		return nil
 	}
 
@@ -317,6 +317,18 @@ func DelInterfaceFirewalld(intf string) error {
 		return err
 	}
 	return nil
+}
+
+// AddInterfaceFirewalld adds the interface to the trusted zone. It is a
+// no-op if firewalld is not running.
+func AddInterfaceFirewalld(intf string) error {
+	return firewalld.addInterface(intf)
+}
+
+// DelInterfaceFirewalld removes the interface from the trusted zone It is a
+// no-op if firewalld is not running.
+func DelInterfaceFirewalld(intf string) error {
+	return firewalld.delInterface(intf)
 }
 
 type interfaceNotFound struct{ error }

--- a/libnetwork/iptables/firewalld.go
+++ b/libnetwork/iptables/firewalld.go
@@ -180,20 +180,6 @@ func (fwd *firewalldConnection) registerReloadCallback(callback func()) {
 	fwd.onReloaded = append(fwd.onReloaded, &callback)
 }
 
-// OnReloaded adds a callback to be executed when firewalld is reloaded.
-// Adding a callback is idempotent; it ignores the given callback if it's
-// already registered.
-//
-// Callbacks can be registered regardless if firewalld is currently running,
-// but it will initialize firewalld before executing.
-func OnReloaded(callback func()) {
-	// Make sure firewalld is initialized before we register callbacks.
-	// This function is also called from setupArrangeUserFilterRule,
-	// which is called during controller initialization.
-	_ = initCheck()
-	firewalld.registerReloadCallback(callback)
-}
-
 // checkRunning checks if firewalld is running.
 //
 // It calls some remote method to see whether the service is actually running.
@@ -364,18 +350,6 @@ func (fwd *firewalldConnection) delInterface(intf string) error {
 		return err
 	}
 	return nil
-}
-
-// AddInterfaceFirewalld adds the interface to the trusted zone. It is a
-// no-op if firewalld is not running.
-func AddInterfaceFirewalld(intf string) error {
-	return firewalld.addInterface(intf)
-}
-
-// DelInterfaceFirewalld removes the interface from the trusted zone It is a
-// no-op if firewalld is not running.
-func DelInterfaceFirewalld(intf string) error {
-	return firewalld.delInterface(intf)
 }
 
 type interfaceNotFound struct{ error }

--- a/libnetwork/iptables/firewalld.go
+++ b/libnetwork/iptables/firewalld.go
@@ -48,7 +48,7 @@ func firewalldInit() error {
 	var err error
 
 	if firewalld, err = newConnection(); err != nil {
-		return fmt.Errorf("Failed to connect to D-Bus system bus: %v", err)
+		return err
 	}
 	firewalldRunning = checkRunning()
 	if !firewalldRunning {
@@ -72,7 +72,7 @@ func newConnection() (*firewalldConnection, error) {
 	var err error
 	c.conn, err = dbus.SystemBus()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to connect to D-Bus system bus: %v", err)
 	}
 
 	// This never fails, even if the service is not running atm.

--- a/libnetwork/iptables/firewalld.go
+++ b/libnetwork/iptables/firewalld.go
@@ -12,14 +12,11 @@ import (
 	dbus "github.com/godbus/dbus/v5"
 )
 
-// IPV defines the table string
-type IPV string
-
 const (
-	// Iptables point ipv4 table
-	Iptables IPV = "ipv4"
-	// IP6Tables point to ipv6 table
-	IP6Tables IPV = "ipv6"
+	// ipTables point ipv4 table
+	ipTables = "ipv4"
+	// ip6Tables point to ipv6 table
+	ip6Tables = "ipv6"
 )
 
 const (
@@ -219,7 +216,13 @@ func (fwd *firewalldConnection) isRunning() bool {
 }
 
 // Passthrough method simply passes args through to iptables/ip6tables
-func Passthrough(ipv IPV, args ...string) ([]byte, error) {
+func Passthrough(ipVersion IPVersion, args ...string) ([]byte, error) {
+	// select correct IP version for firewalld
+	ipv := ipTables
+	if ipVersion == IPv6 {
+		ipv = ip6Tables
+	}
+
 	var output string
 	log.G(context.TODO()).Debugf("Firewalld passthrough: %s, %s", ipv, args)
 	if err := firewalld.sysObj.Call(dbusInterface+".direct.passthrough", 0, ipv, args).Store(&output); err != nil {

--- a/libnetwork/iptables/firewalld.go
+++ b/libnetwork/iptables/firewalld.go
@@ -44,22 +44,22 @@ var (
 )
 
 // firewalldInit initializes firewalld management code.
-func firewalldInit() error {
-	var err error
-	firewalld, err = newConnection()
+func firewalldInit() (*firewalldConnection, error) {
+	fwd, err := newConnection()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// start handling D-Bus signals that were registered.
-	firewalld.handleSignals()
+	fwd.handleSignals()
 
-	err = firewalld.setupDockerZone()
+	err = fwd.setupDockerZone()
 	if err != nil {
-		return err
+		_ = fwd.conn.Close()
+		return nil, err
 	}
 
-	return nil
+	return fwd, nil
 }
 
 // newConnection establishes a connection to the system D-Bus and registers

--- a/libnetwork/iptables/firewalld_helpers_linux.go
+++ b/libnetwork/iptables/firewalld_helpers_linux.go
@@ -1,0 +1,27 @@
+package iptables
+
+// OnReloaded adds a callback to be executed when firewalld is reloaded.
+// Adding a callback is idempotent; it ignores the given callback if it's
+// already registered.
+//
+// Callbacks can be registered regardless if firewalld is currently running,
+// but it will initialize firewalld before executing.
+func OnReloaded(callback func()) {
+	// Make sure firewalld is initialized before we register callbacks.
+	// This function is also called from setupArrangeUserFilterRule,
+	// which is called during controller initialization.
+	_ = initCheck()
+	firewalld.registerReloadCallback(callback)
+}
+
+// AddInterfaceFirewalld adds the interface to the trusted zone. It is a
+// no-op if firewalld is not running.
+func AddInterfaceFirewalld(intf string) error {
+	return firewalld.addInterface(intf)
+}
+
+// DelInterfaceFirewalld removes the interface from the trusted zone It is a
+// no-op if firewalld is not running.
+func DelInterfaceFirewalld(intf string) error {
+	return firewalld.delInterface(intf)
+}

--- a/libnetwork/iptables/firewalld_test.go
+++ b/libnetwork/iptables/firewalld_test.go
@@ -27,9 +27,11 @@ func skipIfNoFirewalld(t *testing.T) {
 
 func TestFirewalldInit(t *testing.T) {
 	skipIfNoFirewalld(t)
-	if err := firewalldInit(); err != nil {
+	fwd, err := firewalldInit()
+	if err != nil {
 		t.Fatal(err)
 	}
+	_ = fwd.conn.Close()
 }
 
 func TestReloaded(t *testing.T) {

--- a/libnetwork/iptables/firewalld_test.go
+++ b/libnetwork/iptables/firewalld_test.go
@@ -103,3 +103,13 @@ func TestPassthrough(t *testing.T) {
 		t.Fatal("rule1 does not exist")
 	}
 }
+
+// TestFirewalldUninitialized checks that calling methods, such as isRunning()
+// on an empty, uninitialized firewalldConnection doesn't panic, and returns
+// the expected status.
+func TestFirewalldUninitialized(t *testing.T) {
+	var fwd *firewalldConnection
+	if fwd.isRunning() {
+		t.Error("did not expect an uninitialized firewalldConnection to be running")
+	}
+}

--- a/libnetwork/iptables/firewalld_test.go
+++ b/libnetwork/iptables/firewalld_test.go
@@ -100,7 +100,7 @@ func TestPassthrough(t *testing.T) {
 		"-j", "ACCEPT",
 	}
 
-	_, err := Passthrough(Iptables, append([]string{"-A"}, rule1...)...)
+	_, err := Passthrough(IPv4, append([]string{"-A"}, rule1...)...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/iptables/firewalld_test.go
+++ b/libnetwork/iptables/firewalld_test.go
@@ -112,4 +112,12 @@ func TestFirewalldUninitialized(t *testing.T) {
 	if fwd.isRunning() {
 		t.Error("did not expect an uninitialized firewalldConnection to be running")
 	}
+	err := fwd.addInterface("anything")
+	if err != nil {
+		t.Errorf("unexpected error when calling addInterface on an uninitialized firewalldConnection: %v", err)
+	}
+	err = fwd.delInterface("anything")
+	if err != nil {
+		t.Errorf("unexpected error when calling delInterface on an uninitialized firewalldConnection: %v", err)
+	}
 }

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -519,14 +519,8 @@ func filterOutput(start time.Time, output []byte, args ...string) []byte {
 // Raw calls 'iptables' system command, passing supplied arguments.
 func (iptable IPTable) Raw(args ...string) ([]byte, error) {
 	if firewalld.isRunning() {
-		// select correct IP version for firewalld
-		ipv := Iptables
-		if iptable.ipVersion == IPv6 {
-			ipv = IP6Tables
-		}
-
 		startTime := time.Now()
-		output, err := Passthrough(ipv, args...)
+		output, err := Passthrough(iptable.ipVersion, args...)
 		if err == nil || !strings.Contains(err.Error(), "was not provided by any .service files") {
 			return filterOutput(startTime, output, args...), err
 		}

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -520,7 +520,7 @@ func filterOutput(start time.Time, output []byte, args ...string) []byte {
 func (iptable IPTable) Raw(args ...string) ([]byte, error) {
 	if firewalld.isRunning() {
 		startTime := time.Now()
-		output, err := Passthrough(iptable.ipVersion, args...)
+		output, err := firewalld.passthrough(iptable.ipVersion, args...)
 		if err == nil || !strings.Contains(err.Error(), "was not provided by any .service files") {
 			return filterOutput(startTime, output, args...), err
 		}

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -518,7 +518,7 @@ func filterOutput(start time.Time, output []byte, args ...string) []byte {
 
 // Raw calls 'iptables' system command, passing supplied arguments.
 func (iptable IPTable) Raw(args ...string) ([]byte, error) {
-	if firewalldRunning {
+	if firewalld.isRunning() {
 		// select correct IP version for firewalld
 		ipv := Iptables
 		if iptable.ipVersion == IPv6 {

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -138,7 +138,9 @@ func initFirewalld() {
 		log.G(context.TODO()).Info("skipping firewalld management for rootless mode")
 		return
 	}
-	if err := firewalldInit(); err != nil {
+	var err error
+	firewalld, err = firewalldInit()
+	if err != nil {
 		log.G(context.TODO()).WithError(err).Debugf("unable to initialize firewalld; using raw iptables instead")
 	}
 }

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -206,11 +206,11 @@ func (iptable IPTable) ProgramChain(c *ChainInfo, bridgeName string, hairpinMode
 
 	// Either add or remove the interface from the firewalld zone, if firewalld is running.
 	if enable {
-		if err := AddInterfaceFirewalld(bridgeName); err != nil {
+		if err := firewalld.addInterface(bridgeName); err != nil {
 			return err
 		}
 	} else {
-		if err := DelInterfaceFirewalld(bridgeName); err != nil && !errdefs.IsNotFound(err) {
+		if err := firewalld.delInterface(bridgeName); err != nil && !errdefs.IsNotFound(err) {
 			return err
 		}
 	}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/46190 https://github.com/moby/moby/pull/46190#discussion_r1291052416
- [x] depends on https://github.com/moby/moby/pull/46245
- [x] depends on https://github.com/moby/moby/pull/46246
- [x] depends on https://github.com/moby/moby/pull/46247
- [x] depends on https://github.com/moby/moby/pull/46304

### libnetwork/iptables: un-export Conn

Un-export Conn, as it's only used internally. Rename it to firewalldConnection,
to make clearer what it's used for, and rename the sysconn field.

libnetwork/iptables: firewalldInit: move error message to newConnection

Move generating the error-message to where we know what the cause is,
instead of assuming we're unable to make a D-Bus connection.

### libnetwork/iptables: firewalldInit: move error message to newConnection

Move generating the error-message to where we know what the cause is,
instead of assuming we're unable to make a D-Bus connection.

### libnetwork/iptables: make newConnection() slightly more idiomatic

Don't consider a connection successful if firewalld is not running. If
it's not running, return a suitable error message. We only use the D-Bus
connection to communicate with firewalld, so no need to return a connection
if it's not running.

### libnetwork/iptables: make signalHandler a method

Make it a method on the firewalldConnection, which felt more natural
than being implemented as a standalone function that depended on the
package-level variable.

### libnetwork/iptables: move setting up signals into handleSignals

newConnection was setting up these listeners, but in the event we
failed to check if firewalld was running, we would error-out, and
close the connection.

Looking at b052827e025267336f0d426df44ec536745821f8, all of this code
is directly related to handling signals, so let's combine this into the
handleSignals method.



### libnetwork/iptables: make setupDockerZone a method

Make it a method on the firewalldConnection, which felt more natural
than being implemented as a standalone function that depended on the
package-level variable.

Also improve some error-messages to include context about the failure.


### libnetwork/iptables: make firewalldInit more atomic 

firewalldInit was returning an error if we failed to set up the docker
zone, but did not close the D-Bus connection. Given that we consider
firewalld to "not be usable" in case of an error, let's also close
the connection;

    unable to initialize firewalld; using raw iptables instead

And return the connection on success, instead of implicitly setting the
package-level `firewalld` variable.


### libnetwork/iptables: remove firewalldRunning package-var

Make the firewalld status a property of firewalldConnection, so that all
status is captured in the `firewalld` instance.

firewalldInit() already checks if firewalld is running when initializing,
in which case the `firewalld` variable would be nil.

While refactoring, also use an `atomic.Bool`; the running-status can be
updated as part of `startSignalHandler()`, which means that there's a
potential concurrency-issue with other code accessing the firewalld
status.

### libnetwork/iptables: implement addInterface/delInterface methods

Move the implementation from AddInterfaceFirewalld and DelInterfaceFirewalld
to a method on firewalldConnection, but keeping the exported utility-functions.

### libnetwork/iptables: register callbacks on firewalldConnection

Register callbacks on the firewalldConnection instance instead of a global
variable. These callbacks should only be needed if firewalld is initialized
and running, so associate them with the firewalldConnection that we created.


### libnetwork/iptables: Passthrough: re-use IPVersion type

Use the existing IPVersion type to switch between ipv4 and ipv6. The IPV
type was only used for this function, and currently required callers to
map a IPVersion to IPV.

### libnetwork/iptables: implement passthrough as method

Move the Passthrough implementation to a method on firewalldConnection,
and add a check if firewalld is initialized and running.

### libnetwork/iptables: move firewalld helpers together

Move the exported helpers to a separate file.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

