### PR TITLE
c8d/inspect: Ignore manifest with missing config

### DIFF
--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -48,11 +48,25 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 	err = i.walkImageManifests(ctx, desc, func(img *ImageManifest) error {
 		conf, err := img.Config(ctx)
 		if err != nil {
-			return err
+			if cerrdefs.IsNotFound(err) {
+				log.G(ctx).WithFields(log.Fields{
+					"manifestDescriptor": img.Target(),
+				}).Debug("manifest was present, but accessing its config failed, ignoring")
+				return nil
+			}
+			return errdefs.System(fmt.Errorf("failed to get config descriptor: %w", err))
 		}
+
 		var ociimage ocispec.Image
 		if err := readConfig(ctx, cs, conf, &ociimage); err != nil {
-			return err
+			if cerrdefs.IsNotFound(err) {
+				log.G(ctx).WithFields(log.Fields{
+					"manifestDescriptor": img.Target(),
+					"configDescriptor":   conf,
+				}).Debug("manifest present, but its config is missing, ignoring")
+				return nil
+			}
+			return errdefs.System(fmt.Errorf("failed to read config of the manifest %v: %w", img.Target().Digest, err))
 		}
 		presentImages = append(presentImages, ociimage)
 		return nil
@@ -61,7 +75,8 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 		return nil, err
 	}
 	if len(presentImages) == 0 {
-		return nil, errdefs.NotFound(errors.New("failed to find image manifest"))
+		ref, _ := reference.ParseAnyReference(refOrID)
+		return nil, images.ErrImageDoesNotExist{Ref: ref}
 	}
 
 	sort.SliceStable(presentImages, func(i, j int) bool {


### PR DESCRIPTION

**- What I did**
Fixed failure to inspect image if any of its present manifest references an image config which isn't present locally.

**- How I did it**
Ignore c8d `NotFound` error when reading config in `walkImageManifests`.

**- How to verify it**
```bash
$ docker pull busybox:1.36.1
$ docker pull --platform linux/amd64 busybox:1.36.1
$ ctr content rm sha256:a416a98b71e224a31ee99cff8e16063554498227d2b696152a9c3e0aa65e5824 # Delete amd64 config
```

**Before**
```
$ docker image inspect busybox:1.36.1
[]
Error response from daemon: failed to read config content: content digest sha256:a416a98b71e224a31ee99cff8e16063554498227d2b696152a9c3e0aa65e5824: not found
```

**After**
```json
$ docker image inspect busybox:1.36.1
[
    {
        "Id": "sha256:3fbc632167424a6d997e74f52b878d7cc478225cffac6bc977eedfe51c7f4e79",
        "RepoTags": [
            "busybox:latest"
        ],
        "RepoDigests": [
            "busybox@sha256:3fbc632167424a6d997e74f52b878d7cc478225cffac6bc977eedfe51c7f4e79"
        ],
        (...)
        "Architecture": "arm64",
        "Variant": "v8",
        "Os": "linux",
        "Size": 1920927,
        "VirtualSize": 1920927,
        (...)
    }
]
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

