### PR TITLE
vendor: github.com/moby/swarmkit/v2 v2.0.0-20230815220644-3f2e40b3ed51

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -65,7 +65,7 @@ require (
 	github.com/moby/locker v1.0.1
 	github.com/moby/patternmatcher v0.5.0
 	github.com/moby/pubsub v1.0.0
-	github.com/moby/swarmkit/v2 v2.0.0-20230814163642-60421a63a7f1
+	github.com/moby/swarmkit/v2 v2.0.0-20230815220644-3f2e40b3ed51
 	github.com/moby/sys/mount v0.3.3
 	github.com/moby/sys/mountinfo v0.6.2
 	github.com/moby/sys/sequential v0.5.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -1025,8 +1025,8 @@ github.com/moby/patternmatcher v0.5.0 h1:YCZgJOeULcxLw1Q+sVR636pmS7sPEn1Qo2iAN6M
 github.com/moby/patternmatcher v0.5.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/pubsub v1.0.0 h1:jkp/imWsmJz2f6LyFsk7EkVeN2HxR/HTTOY8kHrsxfA=
 github.com/moby/pubsub v1.0.0/go.mod h1:bXSO+3h5MNXXCaEG+6/NlAIk7MMZbySZlnB+cUQhKKc=
-github.com/moby/swarmkit/v2 v2.0.0-20230814163642-60421a63a7f1 h1:B/mrXLRdSVXXJvwVNatNe+Yf+9WMS/TT7+mYKFMbgF0=
-github.com/moby/swarmkit/v2 v2.0.0-20230814163642-60421a63a7f1/go.mod h1:qYvjIScIddAio4DaXFZUyNuRxcHhm2Srm6GIrA/G/5c=
+github.com/moby/swarmkit/v2 v2.0.0-20230815220644-3f2e40b3ed51 h1:Am1RXolTCcQT5zaEUBGczaHZaV069crCKpLHckp9isM=
+github.com/moby/swarmkit/v2 v2.0.0-20230815220644-3f2e40b3ed51/go.mod h1:dHTjRFlamMrutFg1Vi0AEZKtVx2qZV/7A/imviPXQiE=
 github.com/moby/sys/mount v0.1.0/go.mod h1:FVQFLDRWwyBjDTBNQXDlWnSFREqOo3OKX9aqhmeoo74=
 github.com/moby/sys/mount v0.1.1/go.mod h1:FVQFLDRWwyBjDTBNQXDlWnSFREqOo3OKX9aqhmeoo74=
 github.com/moby/sys/mount v0.3.3 h1:fX1SVkXFJ47XWDoeFW4Sq7PdQJnV2QIDZAqjNqgEjUs=

--- a/vendor/github.com/moby/swarmkit/v2/manager/allocator/cnmallocator/manager.go
+++ b/vendor/github.com/moby/swarmkit/v2/manager/allocator/cnmallocator/manager.go
@@ -1,9 +1,8 @@
 package cnmallocator
 
 import (
-	"github.com/docker/docker/libnetwork/datastore"
-	"github.com/docker/docker/libnetwork/discoverapi"
 	"github.com/docker/docker/libnetwork/driverapi"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -14,8 +13,8 @@ type manager struct {
 // RegisterManager registers a new instance of the manager driver for networkType with r.
 func RegisterManager(r driverapi.Registerer, networkType string) error {
 	return r.RegisterDriver(networkType, &manager{networkType: networkType}, driverapi.Capability{
-		DataScope:         datastore.LocalScope,
-		ConnectivityScope: datastore.LocalScope,
+		DataScope:         scope.Local,
+		ConnectivityScope: scope.Local,
 	})
 }
 
@@ -68,14 +67,6 @@ func (d *manager) Type() string {
 
 func (d *manager) IsBuiltIn() bool {
 	return true
-}
-
-func (d *manager) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
-func (d *manager) DiscoverDelete(dType discoverapi.DiscoveryType, data interface{}) error {
-	return types.NotImplementedErrorf("not implemented")
 }
 
 func (d *manager) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {

--- a/vendor/github.com/moby/swarmkit/v2/manager/allocator/cnmallocator/networkallocator.go
+++ b/vendor/github.com/moby/swarmkit/v2/manager/allocator/cnmallocator/networkallocator.go
@@ -6,13 +6,13 @@ import (
 	"net"
 	"strings"
 
-	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/drivers/remote"
 	"github.com/docker/docker/libnetwork/drvregistry"
 	"github.com/docker/docker/libnetwork/ipamapi"
 	remoteipam "github.com/docker/docker/libnetwork/ipams/remote"
 	"github.com/docker/docker/libnetwork/netlabel"
+	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/moby/swarmkit/v2/api"
 	"github.com/moby/swarmkit/v2/log"
@@ -150,7 +150,7 @@ func (na *cnmNetworkAllocator) Allocate(n *api.Network) error {
 	nw := &network{
 		nw:          n,
 		endpoints:   make(map[string]string),
-		isNodeLocal: d.capability.DataScope == datastore.LocalScope,
+		isNodeLocal: d.capability.DataScope == scope.Local,
 	}
 
 	// No swarm-level allocation can be provided by the network driver for

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -793,7 +793,7 @@ github.com/moby/patternmatcher
 # github.com/moby/pubsub v1.0.0
 ## explicit; go 1.19
 github.com/moby/pubsub
-# github.com/moby/swarmkit/v2 v2.0.0-20230814163642-60421a63a7f1
+# github.com/moby/swarmkit/v2 v2.0.0-20230815220644-3f2e40b3ed51
 ## explicit; go 1.18
 github.com/moby/swarmkit/v2/agent
 github.com/moby/swarmkit/v2/agent/configs


### PR DESCRIPTION
Remove uses of deprecated datastore.LocalScope const

full diff: https://github.com/moby/swarmkit/compare/60421a63a7f1...3f2e40b3ed5167a50b3205973a73b0b2ea049810


**- A picture of a cute animal (not mandatory but encouraged)**

