### PR TITLE
libnetwork/datastore: remove deprecated scope consts

### DIFF
--- a/libnetwork/datastore/datastore.go
+++ b/libnetwork/datastore/datastore.go
@@ -72,22 +72,6 @@ type ScopeClientCfg struct {
 }
 
 const (
-	// LocalScope indicates to store the KV object in local datastore such as boltdb
-	//
-	// Deprecated: use [scope.Local].
-	LocalScope = scope.Local
-	// GlobalScope indicates to store the KV object in global datastore
-	//
-	// Deprecated: use [scope.Global].
-	GlobalScope = scope.Global
-	// SwarmScope is not indicating a datastore location. It is defined here
-	// along with the other two scopes just for consistency.
-	//
-	// Deprecated: use [scope.Swarm].
-	SwarmScope = scope.Swarm
-)
-
-const (
 	// NetworkKeyPrefix is the prefix for network key in the kv store
 	NetworkKeyPrefix = "network"
 	// EndpointKeyPrefix is the prefix for endpoint key in the kv store


### PR DESCRIPTION
- [x] depends on https://github.com/moby/moby/pull/46242
- relates to https://github.com/moby/moby/pull/46108


### libnetwork: remove deprecated scope consts

Removes the deprecated consts, which moved to a separate "scope" package
in commit 6ec03d6745dc986d5175ac8270bb9052e04c1c2c, and are no longer used;

- datastore.LocalScope
- datastore.GlobalScope
- datastore.SwarmScope


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

