### PR TITLE
libnetwork/iptables: ProgramChain: don't fail if interface not found

### DIFF
--- a/libnetwork/iptables/firewalld.go
+++ b/libnetwork/iptables/firewalld.go
@@ -271,7 +271,7 @@ func DelInterfaceFirewalld(intf string) error {
 	}
 	// Remove interface if it exists
 	if !contains(intfs, intf) {
-		return fmt.Errorf("Firewalld: unable to find interface %s in %s zone", intf, dockerZone)
+		return &interfaceNotFound{fmt.Errorf("firewalld: interface %q not found in %s zone", intf, dockerZone)}
 	}
 
 	log.G(context.TODO()).Debugf("Firewalld: removing %s interface from %s zone", intf, dockerZone)
@@ -281,6 +281,10 @@ func DelInterfaceFirewalld(intf string) error {
 	}
 	return nil
 }
+
+type interfaceNotFound struct{ error }
+
+func (interfaceNotFound) NotFound() {}
 
 func contains(list []string, val string) bool {
 	for _, v := range list {

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/log"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/rootless"
 )
 
@@ -209,7 +210,7 @@ func (iptable IPTable) ProgramChain(c *ChainInfo, bridgeName string, hairpinMode
 				return err
 			}
 		} else {
-			if err := DelInterfaceFirewalld(bridgeName); err != nil {
+			if err := DelInterfaceFirewalld(bridgeName); err != nil && !errdefs.IsNotFound(err) {
 				return err
 			}
 		}


### PR DESCRIPTION
DelInterfaceFirewalld returns an error if the interface to delete was not found. Let's ignore cases where we were successfully able to get the list of interfaces in the zone, but the interface was not part of the zone.

This patch changes the error for these cases to an errdefs.ErrNotFound, and updates IPTable.ProgramChain to ignore those errors.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

