### PR TITLE
libnetwork/iptables: fix TestFirewalldInit

### DIFF
--- a/libnetwork/iptables/firewalld_test.go
+++ b/libnetwork/iptables/firewalld_test.go
@@ -7,12 +7,27 @@ import (
 	"net"
 	"strconv"
 	"testing"
+
+	"github.com/godbus/dbus/v5"
 )
 
-func TestFirewalldInit(t *testing.T) {
-	if !checkRunning() {
-		t.Skip("firewalld is not running")
+func skipIfNoFirewalld(t *testing.T) {
+	t.Helper()
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		t.Skipf("cannot connect to D-bus system bus: %v", err)
 	}
+	defer conn.Close()
+
+	var zone string
+	err = conn.Object(dbusInterface, dbusPath).Call(dbusInterface+".getDefaultZone", 0).Store(&zone)
+	if err != nil {
+		t.Skipf("firewalld is not running: %v", err)
+	}
+}
+
+func TestFirewalldInit(t *testing.T) {
+	skipIfNoFirewalld(t)
 	if err := firewalldInit(); err != nil {
 		t.Fatal(err)
 	}
@@ -71,9 +86,7 @@ func TestReloaded(t *testing.T) {
 }
 
 func TestPassthrough(t *testing.T) {
-	if !firewalldRunning {
-		t.Skip("firewalld is not running")
-	}
+	skipIfNoFirewalld(t)
 	rule1 := []string{
 		"-i", "lo",
 		"-p", "udp",


### PR DESCRIPTION
This test didn't make a lot of sense, because `checkRunning()` depends on the `connection` package-var being set, which is done by `firewalldInit()`, so would never be true on its own.

Add a small utility that opens its own D-Bus connection to verify if firewalld is running, and otherwise skips the tests (preserving any error in the process).

**- A picture of a cute animal (not mandatory but encouraged)**

