### PR TITLE
libnetwork: Sandbox.ResolveName: refactor ordering of endpoints

### DIFF
--- a/libnetwork/endpoint_test.go
+++ b/libnetwork/endpoint_test.go
@@ -1,0 +1,43 @@
+package libnetwork
+
+import (
+	"sort"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestSortByNetworkType(t *testing.T) {
+	nws := []*Network{
+		{name: "local2"},
+		{name: "ovl2", dynamic: true},
+		{name: "local3"},
+		{name: "ingress", ingress: true},
+		{name: "ovl3", dynamic: true},
+		{name: "local1"},
+		{name: "ovl1", dynamic: true},
+	}
+	eps := make([]*Endpoint, 0, len(nws))
+	for _, nw := range nws {
+		eps = append(eps, &Endpoint{
+			name:    "ep-" + nw.name,
+			network: nw,
+		})
+	}
+	sort.Sort(ByNetworkType(eps))
+	actual := make([]string, 0, len(eps))
+	for _, ep := range eps {
+		actual = append(actual, ep.name)
+	}
+	expected := []string{
+		"ep-ovl2",
+		"ep-ovl3",
+		"ep-ovl1",
+		"ep-ingress",
+		"ep-local2",
+		"ep-local3",
+		"ep-local1",
+	}
+	assert.Check(t, is.DeepEqual(actual, expected))
+}

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -392,38 +392,6 @@ func (sb *Sandbox) ResolveService(ctx context.Context, name string) ([]*net.SRV,
 	return nil, nil
 }
 
-func getDynamicNwEndpoints(epList []*Endpoint) []*Endpoint {
-	eps := []*Endpoint{}
-	for _, ep := range epList {
-		n := ep.getNetwork()
-		if n.dynamic && !n.ingress {
-			eps = append(eps, ep)
-		}
-	}
-	return eps
-}
-
-func getIngressNwEndpoint(epList []*Endpoint) *Endpoint {
-	for _, ep := range epList {
-		n := ep.getNetwork()
-		if n.ingress {
-			return ep
-		}
-	}
-	return nil
-}
-
-func getLocalNwEndpoints(epList []*Endpoint) []*Endpoint {
-	eps := []*Endpoint{}
-	for _, ep := range epList {
-		n := ep.getNetwork()
-		if !n.dynamic && !n.ingress {
-			eps = append(eps, ep)
-		}
-	}
-	return eps
-}
-
 func (sb *Sandbox) ResolveName(ctx context.Context, name string, ipType int) ([]net.IP, bool) {
 	// Embedded server owns the docker network domain. Resolution should work
 	// for both container_name and container_name.network_name
@@ -455,18 +423,17 @@ func (sb *Sandbox) ResolveName(ctx context.Context, name string, ipType int) ([]
 
 	epList := sb.Endpoints()
 
-	// In swarm mode services with exposed ports are connected to user overlay
-	// network, ingress network and docker_gwbridge network. Name resolution
+	// In swarm mode, services with exposed ports are connected to user overlay
+	// network, ingress network and docker_gwbridge networks. Name resolution
 	// should prioritize returning the VIP/IPs on user overlay network.
-	newList := []*Endpoint{}
+	//
+	// Re-order the endpoints based on the network-type they're attached to;
+	//
+	//  1. dynamic networks (user overlay networks)
+	//  2. ingress network(s)
+	//  3. local networks ("docker_gwbridge")
 	if sb.controller.isSwarmNode() {
-		newList = append(newList, getDynamicNwEndpoints(epList)...)
-		ingressEP := getIngressNwEndpoint(epList)
-		if ingressEP != nil {
-			newList = append(newList, ingressEP)
-		}
-		newList = append(newList, getLocalNwEndpoints(epList)...)
-		epList = newList
+		sort.Sort(ByNetworkType(epList))
 	}
 
 	for i := 0; i < len(reqName); i++ {


### PR DESCRIPTION
When resolving names in swarm mode, services with exposed ports are connected to user overlay network, ingress network, and local (docker_gwbridge) networks. Name resolution should prioritize returning the VIP/IPs on user overlay network over ingress and local networks.

Sandbox.ResolveName implemented this by taking the list of endpoints, splitting the list into 3 separate lists based on the type of network that the endpoint was attached to (dynamic, ingress, local), and then creating a new list, applying the networks in that order.

This patch refactors that logic to use a custom sorter (sort.Interface), which makes the code more transparent, and prevents iterating over the list of endpoints multiple times.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

