### PR TITLE
ci(bin-image): populate DOCKER_GITCOMMIT

### DIFF
--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -118,6 +118,8 @@ jobs:
             ./docker-bake.hcl
             /tmp/bake-meta.json
           targets: bin-image
+          env:
+            DOCKER_GITCOMMIT: ${{ github.sha }}
           set: |
             *.platform=${{ matrix.platform }}
             *.output=type=image,name=${{ env.MOBYBIN_REPO_SLUG }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
**- What I did**

Ensure that `GitCommit` is populated in `GET /version` by setting `DOCKER_GITCOMMIT` in moby-bin builds.

**- How I did it**

**- How to verify it**

`docker version`

**- Description for the changelog**
N/A


**- A picture of a cute animal (not mandatory but encouraged)**

