### PR TITLE
ci(bin-image): populate DOCKER_GITCOMMIT, take 2

### DIFF
--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -113,13 +113,13 @@ jobs:
         name: Build
         id: bake
         uses: docker/bake-action@v3
+        env:
+          DOCKER_GITCOMMIT: ${{ github.sha }}
         with:
           files: |
             ./docker-bake.hcl
             /tmp/bake-meta.json
           targets: bin-image
-          env:
-            DOCKER_GITCOMMIT: ${{ github.sha }}
           set: |
             *.platform=${{ matrix.platform }}
             *.output=type=image,name=${{ env.MOBYBIN_REPO_SLUG }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
- Follow-up to https://github.com/moby/moby/pull/46257, which was mildly incorrect for reasons of YAML indentation (but should have been caught due to reordering of the block 😅)