### PR TITLE
[24.0 backport] Fix DOCKER_GITCOMMIT in moby-bin

### DIFF
--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -113,13 +113,13 @@ jobs:
         name: Build
         id: bake
         uses: docker/bake-action@v3
+        env:
+          DOCKER_GITCOMMIT: ${{ github.sha }}
         with:
           files: |
             ./docker-bake.hcl
             /tmp/bake-meta.json
           targets: bin-image
-          env:
-            DOCKER_GITCOMMIT: ${{ github.sha }}
           set: |
             *.platform=${{ matrix.platform }}
             *.output=type=image,name=${{ env.MOBYBIN_REPO_SLUG }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -118,6 +118,8 @@ jobs:
             ./docker-bake.hcl
             /tmp/bake-meta.json
           targets: bin-image
+          env:
+            DOCKER_GITCOMMIT: ${{ github.sha }}
           set: |
             *.platform=${{ matrix.platform }}
             *.output=type=image,name=${{ env.MOBYBIN_REPO_SLUG }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -14,7 +14,7 @@ variable "DOCKER_BUILDTAGS" {
   default = ""
 }
 variable "DOCKER_GITCOMMIT" {
-  default = "HEAD"
+  default = null
 }
 
 # Docker version such as 23.0.0-dev. Automatically generated through Git ref.
@@ -81,7 +81,7 @@ target "_common" {
     DOCKER_STATIC = DOCKER_STATIC
     DOCKER_LDFLAGS = DOCKER_LDFLAGS
     DOCKER_BUILDTAGS = DOCKER_BUILDTAGS
-    DOCKER_GITCOMMIT = DOCKER_GITCOMMIT != "" ? DOCKER_GITCOMMIT : GITHUB_SHA
+    DOCKER_GITCOMMIT = DOCKER_GITCOMMIT != null ? DOCKER_GITCOMMIT : GITHUB_SHA
     VERSION = VERSION != "" ? VERSION : GITHUB_REF
     PLATFORM = PLATFORM
     PRODUCT = PRODUCT


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/46130
- backport: https://github.com/moby/moby/pull/46257
- backport: https://github.com/moby/moby/pull/46259

I forgot to backport the first PR and a second fix on master was made.
Backport all fixes to the 24.

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

