### PR TITLE
libnetwork: resolve: assorted cleanups

### DIFF
--- a/libnetwork/resolver.go
+++ b/libnetwork/resolver.go
@@ -266,17 +266,17 @@ func (r *Resolver) handleIPQuery(query *dns.Msg, ipType int) (*dns.Msg, error) {
 	}
 	if ipType == types.IPv4 {
 		for _, ip := range addr {
-			rr := new(dns.A)
-			rr.Hdr = dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: respTTL}
-			rr.A = ip
-			resp.Answer = append(resp.Answer, rr)
+			resp.Answer = append(resp.Answer, &dns.A{
+				Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: respTTL},
+				A:   ip,
+			})
 		}
 	} else {
 		for _, ip := range addr {
-			rr := new(dns.AAAA)
-			rr.Hdr = dns.RR_Header{Name: name, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: respTTL}
-			rr.AAAA = ip
-			resp.Answer = append(resp.Answer, rr)
+			resp.Answer = append(resp.Answer, &dns.AAAA{
+				Hdr:  dns.RR_Header{Name: name, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: respTTL},
+				AAAA: ip,
+			})
 		}
 	}
 	return resp, nil
@@ -303,11 +303,10 @@ func (r *Resolver) handlePTRQuery(query *dns.Msg) (*dns.Msg, error) {
 	fqdn := dns.Fqdn(host)
 
 	resp := createRespMsg(query)
-
-	rr := new(dns.PTR)
-	rr.Hdr = dns.RR_Header{Name: ptr, Rrtype: dns.TypePTR, Class: dns.ClassINET, Ttl: respTTL}
-	rr.Ptr = fqdn
-	resp.Answer = append(resp.Answer, rr)
+	resp.Answer = append(resp.Answer, &dns.PTR{
+		Hdr: dns.RR_Header{Name: ptr, Rrtype: dns.TypePTR, Class: dns.ClassINET, Ttl: respTTL},
+		Ptr: fqdn,
+	})
 	return resp, nil
 }
 
@@ -325,16 +324,15 @@ func (r *Resolver) handleSRVQuery(query *dns.Msg) (*dns.Msg, error) {
 	resp := createRespMsg(query)
 
 	for i, r := range srv {
-		rr := new(dns.SRV)
-		rr.Hdr = dns.RR_Header{Name: svc, Rrtype: dns.TypePTR, Class: dns.ClassINET, Ttl: respTTL}
-		rr.Port = r.Port
-		rr.Target = r.Target
-		resp.Answer = append(resp.Answer, rr)
-
-		rr1 := new(dns.A)
-		rr1.Hdr = dns.RR_Header{Name: r.Target, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: respTTL}
-		rr1.A = ip[i]
-		resp.Extra = append(resp.Extra, rr1)
+		resp.Answer = append(resp.Answer, &dns.SRV{
+			Hdr:    dns.RR_Header{Name: svc, Rrtype: dns.TypePTR, Class: dns.ClassINET, Ttl: respTTL},
+			Port:   r.Port,
+			Target: r.Target,
+		})
+		resp.Extra = append(resp.Extra, &dns.A{
+			Hdr: dns.RR_Header{Name: r.Target, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: respTTL},
+			A:   ip[i],
+		})
 	}
 	return resp, nil
 }

--- a/libnetwork/resolver.go
+++ b/libnetwork/resolver.go
@@ -199,10 +199,6 @@ func (r *Resolver) ResolverOptions() []string {
 	return []string{"ndots:0"}
 }
 
-func setCommonFlags(msg *dns.Msg) {
-	msg.RecursionAvailable = true
-}
-
 //nolint:gosec // The RNG is not used in a security-sensitive context.
 var (
 	shuffleRNG   = rand.New(rand.NewSource(time.Now().Unix()))
@@ -220,9 +216,9 @@ func shuffleAddr(addr []net.IP) []net.IP {
 }
 
 func createRespMsg(query *dns.Msg) *dns.Msg {
-	resp := new(dns.Msg)
+	resp := &dns.Msg{}
 	resp.SetReply(query)
-	setCommonFlags(resp)
+	resp.RecursionAvailable = true
 
 	return resp
 }
@@ -306,9 +302,7 @@ func (r *Resolver) handlePTRQuery(query *dns.Msg) (*dns.Msg, error) {
 	r.log().Debugf("[resolver] lookup for IP %s: name %s", name, host)
 	fqdn := dns.Fqdn(host)
 
-	resp := new(dns.Msg)
-	resp.SetReply(query)
-	setCommonFlags(resp)
+	resp := createRespMsg(query)
 
 	rr := new(dns.PTR)
 	rr.Hdr = dns.RR_Header{Name: ptr, Rrtype: dns.TypePTR, Class: dns.ClassINET, Ttl: respTTL}


### PR DESCRIPTION
extracting some commits from another branch I was working on

### libnetwork: resolver: remove setCommonFlags, use createRespMsg

This function was added in 36fd9d02be9014b8016adb5d255cdacd6dc9e64d (libnetwork: https://github.com/moby/libnetwork/commit/ce6c6e8c350aed8e3de1910c571b93c2f4d69a8b),
because there were multiple places where a DNS response was created,
which had to use the same options. However, new "common" options were
added since, and having it in a function separate from the other (also
common) options was just hiding logic, so let's remove it.

What the above probably _should_ have done was to create a common utility
to create a DNS response (as all other options are shared as well). This
was actually done in 0c22e1bd07d75f7a719fe72e466a8ff6dadfd167 (libnetwork: https://github.com/moby/libnetwork/commit/be3531759b8025fcfeec765101c0d018a86981fc),
which added a `createRespMsg` utility, but missed that it could be used
for both cases.

This patch:

- removes the setCommonFlags function
- uses createRespMsg instead to share common options

### libnetwork: resolver: remove some intermediate variables

Use struct-literals where possible for slightly more readable code.

### libnetwork: resolver: Resolver.dialExtDNS use joinHostPort and cleanup

Slightly refactor Resolver.dialExtDNS:

- use net.JoinHostPort to properly format IPv6 addresses
- define a const for the default port, and avoid int ->  string
  conversion if no custom port is defined
- slightly simplify logic if the HostLoopback is used (at the cost of
  duplicating one line); in that case we don't need to define the closure


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

