### PR TITLE
[24.0 backport] volume/local: Fix debug log typo

### DIFF
--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -310,7 +310,7 @@ func (v *localVolume) Mount(id string) (string, error) {
 			v.active.mounted = true
 		}
 		v.active.count++
-		logger.WithField("active mounts", v.active).Debug("Decremented active mount count")
+		logger.WithField("active mounts", v.active).Debug("Incremented active mount count")
 	}
 	if err := v.postMount(); err != nil {
 		return "", err


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/46261

Active count is incremented, but message claimed the opposite.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>
(cherry picked from commit 7f965d55c719b8777221c4dbf9a1eb93cfada8ab)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

