### PR TITLE
bin-image: metadata cleanup

### DIFF
--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -18,10 +18,9 @@ env:
   MOBYBIN_REPO_SLUG: moby/moby-bin
   DOCKER_GITCOMMIT: ${{ github.sha }}
   VERSION: ${{ github.ref }}
-  PLATFORM: Moby Engine
-  PRODUCT: Moby
-  DEFAULT_PRODUCT_LICENSE: Moby
-  PACKAGER_NAME: Moby
+  PLATFORM: Moby Engine - Nightly
+  PRODUCT: Moby Engine
+  PACKAGER_NAME: The Moby Project
 
 jobs:
   validate-dco:

--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -16,6 +16,8 @@ on:
 
 env:
   MOBYBIN_REPO_SLUG: moby/moby-bin
+  DOCKER_GITCOMMIT: ${{ github.sha }}
+  VERSION: ${{ github.ref }}
   PLATFORM: Moby Engine
   PRODUCT: Moby
   DEFAULT_PRODUCT_LICENSE: Moby
@@ -113,8 +115,6 @@ jobs:
         name: Build
         id: bake
         uses: docker/bake-action@v3
-        env:
-          DOCKER_GITCOMMIT: ${{ github.sha }}
         with:
           files: |
             ./docker-bake.hcl

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -15,6 +15,7 @@ on:
 env:
   GO_VERSION: "1.20.7"
   DESTDIR: ./build
+  DOCKER_GITCOMMIT: ${{ github.sha }}
 
 jobs:
   validate-dco:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ env:
   ITG_CLI_MATRIX_SIZE: 6
   DOCKER_EXPERIMENTAL: 1
   DOCKER_GRAPHDRIVER: overlay2
+  DOCKER_GITCOMMIT: ${{ github.sha }}
 
 jobs:
   validate-dco:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BUILDX ?= $(DOCKER) buildx
 DOCKER_GRAPHDRIVER := $(if $(DOCKER_GRAPHDRIVER),$(DOCKER_GRAPHDRIVER),$(shell docker info 2>&1 | grep "Storage Driver" | sed 's/.*: //'))
 export DOCKER_GRAPHDRIVER
 
-DOCKER_GITCOMMIT := $(shell git rev-parse --short HEAD || echo unsupported)
+DOCKER_GITCOMMIT := $(shell git rev-parse HEAD || echo unsupported)
 export DOCKER_GITCOMMIT
 
 # allow overriding the repository and branch that validation scripts are running

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -14,7 +14,7 @@ variable "DOCKER_BUILDTAGS" {
   default = ""
 }
 variable "DOCKER_GITCOMMIT" {
-  default = null
+  default = ""
 }
 
 # Docker version such as 23.0.0-dev. Automatically generated through Git ref.
@@ -47,18 +47,6 @@ variable "PACKAGER_NAME" {
   default = ""
 }
 
-# GITHUB_REF is the actual ref that triggers the workflow and used as version
-# when tag is pushed: https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
-variable "GITHUB_REF" {
-  default = ""
-}
-
-# GITHUB_SHA is the commit SHA that triggered the workflow and used as commit.
-# https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
-variable "GITHUB_SHA" {
-  default = ""
-}
-
 # Special target: https://github.com/docker/metadata-action#bake-definition
 target "docker-metadata-action" {
   tags = ["moby-bin:local"]
@@ -81,8 +69,8 @@ target "_common" {
     DOCKER_STATIC = DOCKER_STATIC
     DOCKER_LDFLAGS = DOCKER_LDFLAGS
     DOCKER_BUILDTAGS = DOCKER_BUILDTAGS
-    DOCKER_GITCOMMIT = DOCKER_GITCOMMIT != null ? DOCKER_GITCOMMIT : GITHUB_SHA
-    VERSION = VERSION != "" ? VERSION : GITHUB_REF
+    DOCKER_GITCOMMIT = DOCKER_GITCOMMIT
+    VERSION = VERSION
     PLATFORM = PLATFORM
     PRODUCT = PRODUCT
     DEFAULT_PRODUCT_LICENSE = DEFAULT_PRODUCT_LICENSE

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -66,8 +66,8 @@ elif command -v git &> /dev/null && [ -e .git ] && git rev-parse &> /dev/null; t
 else
 	echo >&2 'error: .git directory missing and DOCKER_GITCOMMIT not specified'
 	echo >&2 '  Please either build with the .git directory accessible, or specify the'
-	echo >&2 '  exact (--short) commit hash you are building using DOCKER_GITCOMMIT for'
-	echo >&2 '  future accountability in diagnosing build issues.  Thanks!'
+	echo >&2 '  exact commit hash you are building using DOCKER_GITCOMMIT for future'
+	echo >&2 '  accountability in diagnosing build issues.  Thanks!'
 	exit 1
 fi
 


### PR DESCRIPTION
**- What I did**

Remove GHA-specific variables from the bakefile, and moderately clean up the metadata we build `moby-bin` images with, making it more clear these are nightly builds.

**- A picture of a cute animal (not mandatory but encouraged)**

