### PR TITLE
container: internalize InitAttachContext

### DIFF
--- a/container/attach_context.go
+++ b/container/attach_context.go
@@ -1,0 +1,35 @@
+package container
+
+import (
+	"context"
+	"sync"
+)
+
+// attachContext is the context used for for attach calls.
+type attachContext struct {
+	mu         sync.Mutex
+	ctx        context.Context
+	cancelFunc context.CancelFunc
+}
+
+// init returns the context for attach calls. It creates a new context
+// if no context is created yet.
+func (ac *attachContext) init() context.Context {
+	ac.mu.Lock()
+	defer ac.mu.Unlock()
+	if ac.ctx == nil {
+		ac.ctx, ac.cancelFunc = context.WithCancel(context.Background())
+	}
+	return ac.ctx
+}
+
+// cancelFunc cancels the attachContext. All attach calls should detach
+// after this call.
+func (ac *attachContext) cancel() {
+	ac.mu.Lock()
+	if ac.ctx != nil {
+		ac.cancelFunc()
+		ac.ctx = nil
+	}
+	ac.mu.Unlock()
+}

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -175,7 +175,7 @@ func (daemon *Daemon) containerAttach(c *container.Container, cfg *stream.Attach
 		}()
 	}
 
-	ctx := c.InitAttachContext()
+	ctx := c.AttachContext()
 	err := <-c.StreamConfig.CopyStreams(ctx, cfg)
 	if err != nil {
 		var ierr term.EscapeError


### PR DESCRIPTION
Move the initialization logic to the attachContext itself, so that
the container doesn't have to be aware about mutexes and other logic.


**- A picture of a cute animal (not mandatory but encouraged)**

