### PR TITLE
classic builder: align "removing intermediate container" output

### DIFF
--- a/builder/dockerfile/containerbackend.go
+++ b/builder/dockerfile/containerbackend.go
@@ -141,6 +141,6 @@ func (c *containerManager) RemoveAll(stdout io.Writer) {
 			return
 		}
 		delete(c.tmpContainers, containerID)
-		fmt.Fprintf(stdout, "Removing intermediate container %s\n", stringid.TruncateID(containerID))
+		_, _ = fmt.Fprintf(stdout, " ---> Removed intermediate container %s\n", stringid.TruncateID(containerID))
 	}
 }


### PR DESCRIPTION
This is something that stood out to me: removing the intermediate container is part of a build step, but unlike the other output from the build, wasn't indented (and prefixed with `--->`) to be shown as part of the build.

This patch adds the `--->` prefix, to make it clearer what step the removal was part of.

While at it, I also updated the message itself: this output is printed _after_ the intermediate container has been removed, so we may as well make it match reality, so I changed "removing" to "removed".

Before:


```bash
echo -e 'FROM busybox\nRUN echo hello > /dev/null\nRUN echo world > /dev/null\n' | DOCKER_BUILDKIT=0 docker build --no-cache -
Sending build context to Docker daemon  2.048kB
Step 1/3 : FROM busybox
 ---> a416a98b71e2
Step 2/3 : RUN echo hello > /dev/null
 ---> Running in a1a65b9365ac
Removing intermediate container a1a65b9365ac
 ---> 8c6b57ebebdd
Step 3/3 : RUN echo world > /dev/null
 ---> Running in 9fa977b763a5
Removing intermediate container 9fa977b763a5
 ---> 795c1f2fc7b9
Successfully built 795c1f2fc7b9
```

After:

```bash
echo -e 'FROM busybox\nRUN echo hello > /dev/null\nRUN echo world > /dev/null\n' | DOCKER_BUILDKIT=0 docker build --no-cache -
Sending build context to Docker daemon  2.048kB
Step 1/3 : FROM busybox
 ---> fc9db2894f4e
Step 2/3 : RUN echo hello > /dev/null
 ---> Running in 38d7c34c2178
 ---> Removed intermediate container 38d7c34c2178
 ---> 7c0dbc45111d
Step 3/3 : RUN echo world > /dev/null
 ---> Running in 629620285d4c
 ---> Removed intermediate container 629620285d4c
 ---> b92f70f2e57d
Successfully built b92f70f2e57d
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

