### PR TITLE
bin-image: metadata cleanup, take two

### DIFF
--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -18,10 +18,9 @@ env:
   MOBYBIN_REPO_SLUG: moby/moby-bin
   DOCKER_GITCOMMIT: ${{ github.sha }}
   VERSION: ${{ github.ref }}
-  PLATFORM: Moby Engine
-  PRODUCT: Moby
-  DEFAULT_PRODUCT_LICENSE: Moby
-  PACKAGER_NAME: Moby
+  PLATFORM: Moby Engine - Nightly
+  PRODUCT: moby-bin
+  PACKAGER_NAME: The Moby Project
 
 jobs:
   validate-dco:

--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -16,6 +16,8 @@ on:
 
 env:
   MOBYBIN_REPO_SLUG: moby/moby-bin
+  DOCKER_GITCOMMIT: ${{ github.sha }}
+  VERSION: ${{ github.ref }}
   PLATFORM: Moby Engine
   PRODUCT: Moby
   DEFAULT_PRODUCT_LICENSE: Moby
@@ -113,8 +115,6 @@ jobs:
         name: Build
         id: bake
         uses: docker/bake-action@v3
-        env:
-          DOCKER_GITCOMMIT: ${{ github.sha }}
         with:
           files: |
             ./docker-bake.hcl

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BUILDX ?= $(DOCKER) buildx
 DOCKER_GRAPHDRIVER := $(if $(DOCKER_GRAPHDRIVER),$(DOCKER_GRAPHDRIVER),$(shell docker info 2>&1 | grep "Storage Driver" | sed 's/.*: //'))
 export DOCKER_GRAPHDRIVER
 
-DOCKER_GITCOMMIT := $(shell git rev-parse --short HEAD || echo unsupported)
+DOCKER_GITCOMMIT := $(shell git rev-parse HEAD)
 export DOCKER_GITCOMMIT
 
 # allow overriding the repository and branch that validation scripts are running

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -47,18 +47,6 @@ variable "PACKAGER_NAME" {
   default = ""
 }
 
-# GITHUB_REF is the actual ref that triggers the workflow and used as version
-# when tag is pushed: https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
-variable "GITHUB_REF" {
-  default = ""
-}
-
-# GITHUB_SHA is the commit SHA that triggered the workflow and used as commit.
-# https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
-variable "GITHUB_SHA" {
-  default = ""
-}
-
 # Special target: https://github.com/docker/metadata-action#bake-definition
 target "docker-metadata-action" {
   tags = ["moby-bin:local"]
@@ -81,8 +69,8 @@ target "_common" {
     DOCKER_STATIC = DOCKER_STATIC
     DOCKER_LDFLAGS = DOCKER_LDFLAGS
     DOCKER_BUILDTAGS = DOCKER_BUILDTAGS
-    DOCKER_GITCOMMIT = DOCKER_GITCOMMIT != null ? DOCKER_GITCOMMIT : GITHUB_SHA
-    VERSION = VERSION != "" ? VERSION : GITHUB_REF
+    DOCKER_GITCOMMIT = DOCKER_GITCOMMIT
+    VERSION = VERSION
     PLATFORM = PLATFORM
     PRODUCT = PRODUCT
     DEFAULT_PRODUCT_LICENSE = DEFAULT_PRODUCT_LICENSE

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -51,7 +51,7 @@ fi
 if [ "$DOCKER_GITCOMMIT" ]; then
 	GITCOMMIT="$DOCKER_GITCOMMIT"
 elif command -v git &> /dev/null && [ -e .git ] && git rev-parse &> /dev/null; then
-	GITCOMMIT=$(git rev-parse --short HEAD)
+	GITCOMMIT=$(git rev-parse HEAD)
 	if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
 		GITCOMMIT="$GITCOMMIT-unsupported"
 		echo "#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
@@ -66,8 +66,8 @@ elif command -v git &> /dev/null && [ -e .git ] && git rev-parse &> /dev/null; t
 else
 	echo >&2 'error: .git directory missing and DOCKER_GITCOMMIT not specified'
 	echo >&2 '  Please either build with the .git directory accessible, or specify the'
-	echo >&2 '  exact (--short) commit hash you are building using DOCKER_GITCOMMIT for'
-	echo >&2 '  future accountability in diagnosing build issues.  Thanks!'
+	echo >&2 '  exact commit hash you are building using DOCKER_GITCOMMIT for future'
+	echo >&2 '  accountability in diagnosing build issues.  Thanks!'
 	exit 1
 fi
 


### PR DESCRIPTION
- Replacement for https://github.com/moby/moby/pull/46267, which was opened from the wrong branch

**- What I did**

Move GHA-related arguments out of the bakefile and into the GHA workflows, and clean up the metadata applied to `moby-bin` builds.

I'm not entirely thrilled with the end state, but this is less invasive than the more aggressive refactors I have in mind; in general these variables are a nightmare to manage, and we should really have something better. Today is not that day, however.

**- A picture of a cute animal (not mandatory but encouraged)**

