### PR TITLE
multierror: make it consistent when there's a single error

### DIFF
--- a/internal/multierror/multierror.go
+++ b/internal/multierror/multierror.go
@@ -31,9 +31,6 @@ type joinError struct {
 }
 
 func (e *joinError) Error() string {
-	if len(e.errs) == 1 {
-		return strings.TrimSpace(e.errs[0].Error())
-	}
 	stringErrs := make([]string, 0, len(e.errs))
 	for _, subErr := range e.errs {
 		stringErrs = append(stringErrs, strings.Replace(subErr.Error(), "\n", "\n\t", -1))

--- a/internal/multierror/multierror_test.go
+++ b/internal/multierror/multierror_test.go
@@ -10,10 +10,12 @@ import (
 
 func TestErrorJoin(t *testing.T) {
 	t.Run("single", func(t *testing.T) {
-		err := Join(fmt.Errorf("invalid config: %w", Join(errors.New("foo"))))
-		const expected = `invalid config: foo`
+		err := fmt.Errorf("invalid config:\n%w", Join(errors.New("foo")))
+		const expected = `invalid config:
+* foo`
 		assert.Equal(t, err.Error(), expected)
 	})
+
 	t.Run("multiple", func(t *testing.T) {
 		err := Join(errors.New("foobar"), fmt.Errorf("invalid config: \n%w", Join(errors.New("foo"), errors.New("bar"))))
 		const expected = `* foobar


### PR DESCRIPTION
Related to:

- https://github.com/moby/moby/pull/46188

**- What I did**

If a single error is passed to `multierror.Join`, `joinError.Error()` returns the error as is. However, due to the multiline formatting applied otherwise, it's better to add a line break between the preamble and the multierror string when wrapping it, eg.:

```golang
fmt.Errorf("invalid network config:\n%w", multierror.Join(errs...))
```

This commit removes this special case to make the format consistent no matter how many errors are joined:

```
# Before
invalid network config:
some error

# After
invalid network config:
* some error
```