### PR TITLE
libnetwork: remove InterfaceInfo interface

### DIFF
--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -25,7 +25,7 @@ type Endpoint struct {
 	name              string
 	id                string
 	network           *Network
-	iface             *endpointInterface
+	iface             *EndpointInterface
 	joinInfo          *endpointJoinInfo
 	sandboxID         string
 	exposedPorts      []types.TransportPort
@@ -223,7 +223,7 @@ func (ep *Endpoint) CopyTo(o datastore.KVObject) error {
 	copy(dstEp.ingressPorts, ep.ingressPorts)
 
 	if ep.iface != nil {
-		dstEp.iface = &endpointInterface{}
+		dstEp.iface = &EndpointInterface{}
 		if err := ep.iface.CopyTo(dstEp.iface); err != nil {
 			return err
 		}

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -191,7 +191,7 @@ func TestEndpointMarshalling(t *testing.T) {
 		id:        "efghijklmno",
 		sandboxID: "ambarabaciccicocco",
 		anonymous: true,
-		iface: &endpointInterface{
+		iface: &EndpointInterface{
 			mac: []byte{11, 12, 13, 14, 15, 16},
 			addr: &net.IPNet{
 				IP:   net.IP{10, 0, 1, 23},
@@ -222,7 +222,7 @@ func TestEndpointMarshalling(t *testing.T) {
 	}
 }
 
-func compareEndpointInterface(a, b *endpointInterface) bool {
+func compareEndpointInterface(a, b *EndpointInterface) bool {
 	if a == b {
 		return true
 	}

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1119,7 +1119,7 @@ func (n *Network) CreateEndpoint(name string, options ...EndpointOption) (*Endpo
 func (n *Network) createEndpoint(name string, options ...EndpointOption) (*Endpoint, error) {
 	var err error
 
-	ep := &Endpoint{name: name, generic: make(map[string]interface{}), iface: &endpointInterface{}}
+	ep := &Endpoint{name: name, generic: make(map[string]interface{}), iface: &EndpointInterface{}}
 	ep.id = stringid.GenerateRandomID()
 
 	// Initialize ep.network with a possibly stale copy of n. We need this to get network from


### PR DESCRIPTION
Use the only implementation (EndpointInterface) instead.


**- A picture of a cute animal (not mandatory but encouraged)**

