### PR TITLE
libnetwork/osl: remove Sandbox.Info()

### DIFF
--- a/libnetwork/drivers/overlay/ov_network.go
+++ b/libnetwork/drivers/overlay/ov_network.go
@@ -313,7 +313,7 @@ func (n *network) leaveSandbox() {
 // to be called while holding network lock
 func (n *network) destroySandbox() {
 	if n.sbox != nil {
-		for _, iface := range n.sbox.Info().Interfaces() {
+		for _, iface := range n.sbox.Interfaces() {
 			if err := iface.Remove(); err != nil {
 				log.G(context.TODO()).Debugf("Remove interface %s failed: %v", iface.SrcName(), err)
 			}
@@ -441,7 +441,7 @@ func (n *network) setupSubnetSandbox(s *subnet, brName, vxlanName string) error 
 		sbox.InterfaceOptions().Master(brName)); err != nil {
 		// If adding vxlan device to the overlay namespace fails, remove the bridge interface we
 		// already added to the namespace. This allows the caller to try the setup again.
-		for _, iface := range sbox.Info().Interfaces() {
+		for _, iface := range sbox.Interfaces() {
 			if iface.SrcName() == brName {
 				if ierr := iface.Remove(); ierr != nil {
 					log.G(context.TODO()).Errorf("removing bridge failed from ov ns %v failed, %v", n.sbox.Key(), ierr)
@@ -468,7 +468,7 @@ func (n *network) setupSubnetSandbox(s *subnet, brName, vxlanName string) error 
 
 func setDefaultVLAN(sbox osl.Sandbox) error {
 	var brName string
-	for _, i := range sbox.Info().Interfaces() {
+	for _, i := range sbox.Interfaces() {
 		if i.Bridge() {
 			brName = i.DstName()
 		}

--- a/libnetwork/osl/namespace_linux.go
+++ b/libnetwork/osl/namespace_linux.go
@@ -455,10 +455,6 @@ func (n *networkNamespace) nsPath() string {
 	return n.path
 }
 
-func (n *networkNamespace) Info() Info {
-	return n
-}
-
 func (n *networkNamespace) Key() string {
 	return n.path
 }

--- a/libnetwork/osl/sandbox.go
+++ b/libnetwork/osl/sandbox.go
@@ -86,9 +86,6 @@ type Sandbox interface {
 	// InvokeFunc invoke a function in the network namespace.
 	InvokeFunc(func()) error
 
-	// Info returns an interface with methods to get sandbox state.
-	Info() Info
-
 	// Destroy destroys the sandbox.
 	Destroy() error
 
@@ -97,6 +94,8 @@ type Sandbox interface {
 
 	// ApplyOSTweaks applies operating system specific knobs on the sandbox.
 	ApplyOSTweaks([]SandboxType)
+
+	Info
 }
 
 // NeighborOptionSetter interface defines the option setter methods for interface options

--- a/libnetwork/osl/sandbox_linux_test.go
+++ b/libnetwork/osl/sandbox_linux_test.go
@@ -407,7 +407,7 @@ func TestSandboxCreate(t *testing.T) {
 		t.Fatalf("Failed to generate new sandbox info: %v", err)
 	}
 
-	for _, i := range tbox.Info().Interfaces() {
+	for _, i := range tbox.Interfaces() {
 		err = s.AddInterface(i.SrcName(), i.DstName(),
 			tbox.InterfaceOptions().Bridge(i.Bridge()),
 			tbox.InterfaceOptions().Address(i.Address()),
@@ -417,12 +417,12 @@ func TestSandboxCreate(t *testing.T) {
 		}
 	}
 
-	err = s.SetGateway(tbox.Info().Gateway())
+	err = s.SetGateway(tbox.Gateway())
 	if err != nil {
 		t.Fatalf("Failed to set gateway to sandbox: %v", err)
 	}
 
-	err = s.SetGatewayIPv6(tbox.Info().GatewayIPv6())
+	err = s.SetGatewayIPv6(tbox.GatewayIPv6())
 	if err != nil {
 		t.Fatalf("Failed to set ipv6 gateway to sandbox: %v", err)
 	}
@@ -506,7 +506,7 @@ func TestAddRemoveInterface(t *testing.T) {
 		t.Fatalf("Failed to generate new sandbox info: %v", err)
 	}
 
-	for _, i := range tbox.Info().Interfaces() {
+	for _, i := range tbox.Interfaces() {
 		err = s.AddInterface(i.SrcName(), i.DstName(),
 			tbox.InterfaceOptions().Bridge(i.Bridge()),
 			tbox.InterfaceOptions().Address(i.Address()),
@@ -518,14 +518,14 @@ func TestAddRemoveInterface(t *testing.T) {
 
 	verifySandbox(t, s, []string{"0", "1", "2"})
 
-	interfaces := s.Info().Interfaces()
+	interfaces := s.Interfaces()
 	if err := interfaces[0].Remove(); err != nil {
 		t.Fatalf("Failed to remove interfaces from sandbox: %v", err)
 	}
 
 	verifySandbox(t, s, []string{"1", "2"})
 
-	i := tbox.Info().Interfaces()[0]
+	i := tbox.Interfaces()[0]
 	if err := s.AddInterface(i.SrcName(), i.DstName(),
 		tbox.InterfaceOptions().Bridge(i.Bridge()),
 		tbox.InterfaceOptions().Address(i.Address()),

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -140,7 +140,7 @@ func (sb *Sandbox) Statistics() (map[string]*types.InterfaceStatistics, error) {
 	}
 
 	var err error
-	for _, i := range osb.Info().Interfaces() {
+	for _, i := range osb.Interfaces() {
 		if m[i.DstName()], err = i.Statistics(); err != nil {
 			return m, err
 		}
@@ -705,7 +705,7 @@ func (sb *Sandbox) DisableService() (err error) {
 }
 
 func releaseOSSboxResources(osSbox osl.Sandbox, ep *Endpoint) {
-	for _, i := range osSbox.Info().Interfaces() {
+	for _, i := range osSbox.Interfaces() {
 		// Only remove the interfaces owned by this endpoint from the sandbox.
 		if ep.hasInterface(i.SrcName()) {
 			if err := i.Remove(); err != nil {

--- a/libnetwork/service_linux.go
+++ b/libnetwork/service_linux.go
@@ -69,7 +69,7 @@ func (n *Network) findLBEndpointSandbox() (*Endpoint, *Sandbox, error) {
 // aliases to the interface.
 func findIfaceDstName(sb *Sandbox, ep *Endpoint) string {
 	srcName := ep.Iface().SrcName()
-	for _, i := range sb.osSbox.Info().Interfaces() {
+	for _, i := range sb.osSbox.Interfaces() {
 		if i.SrcName() == srcName {
 			return i.DstName()
 		}


### PR DESCRIPTION
"Pay no attention to the implementation behind the curtain!"

There's only one implementation of the Sandbox interface, and only one implementation of the Info interface, and they both happens to be implemented by the same type: networkNamespace. Let's merge these interfaces.

And now that we know that there's one, and only one Info, we can drop the charade, and relieve the Sandbox from its dual personality.


**- A picture of a cute animal (not mandatory but encouraged)**

