### PR TITLE
c8d: Fix building Dockerfiles that have `FROM scratch`

### DIFF
--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	cerrdefs "github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/log"
 	"github.com/docker/docker/api/types"
@@ -149,8 +150,10 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, config ty
 				ID: container.ID,
 			}
 			if err := ls.Delete(context.Background(), lease, leases.SynchronousDelete); err != nil {
-				container.SetRemovalError(err)
-				return err
+				if !cerrdefs.IsNotFound(err) {
+					container.SetRemovalError(err)
+					return err
+				}
 			}
 		}
 	}

--- a/pkg/archive/diff.go
+++ b/pkg/archive/diff.go
@@ -224,6 +224,25 @@ func ApplyUncompressedLayer(dest string, layer io.Reader, options *TarOptions) (
 	return applyLayerHandler(dest, layer, options, false)
 }
 
+// IsEmpty checks if the tar archive is empty (doesn't contain any entries).
+func IsEmpty(rd io.Reader) (bool, error) {
+	decompRd, err := DecompressStream(rd)
+	if err != nil {
+		return true, fmt.Errorf("failed to decompress archive: %v", err)
+	}
+	defer decompRd.Close()
+
+	tarReader := tar.NewReader(decompRd)
+	if _, err := tarReader.Next(); err != nil {
+		if err == io.EOF {
+			return true, nil
+		}
+		return false, fmt.Errorf("failed to read next archive header: %v", err)
+	}
+
+	return false, nil
+}
+
 // do the bulk load of ApplyLayer, but allow for not calling DecompressStream
 func applyLayerHandler(dest string, layer io.Reader, options *TarOptions, decompress bool) (int64, error) {
 	dest = filepath.Clean(dest)


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/46248
- addresses https://github.com/docker/for-mac/issues/6853#issuecomment-1680977603

**- What I did**
Fix running containers with empty `Image`.

**- How I did it**
See commits.

**- How to verify it**
c8d integration tests (https://github.com/moby/moby/pull/45232) from `TestDockerCLIBuildSuite`:
```diff
- DONE 250 tests, 13 skipped, 58 failures in 352.552s
+ DONE 250 tests, 13 skipped, 42 failures in 406.027s
```

**Before**
```bash
$ printf 'FROM scratch\nLABEL asdf=1' | DOCKER_BUILDKIT=0 docker build -t asdf -
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            BuildKit is currently disabled; enable it by removing the DOCKER_BUILDKIT=0
            environment-variable.

Sending build context to Docker daemon  2.048kB
Step 1/2 : FROM scratch
 --->
Step 2/2 : LABEL asdf=1
invalid reference format
```

**After**
```bash
$ printf 'FROM scratch\nLABEL asdf=1' | DOCKER_BUILDKIT=0 docker build -t asdf -
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            BuildKit is currently disabled; enable it by removing the DOCKER_BUILDKIT=0
            environment-variable.

Sending build context to Docker daemon  2.048kB
Step 1/2 : FROM scratch
 --->
Step 2/2 : LABEL asdf=1
 ---> Running in 08bc1d65adb1
 ---> Removed intermediate container 08bc1d65adb1
 ---> 7072ecaf239f
Successfully built 7072ecaf239f
Successfully tagged asdf:latest
```

**- Description for the changelog**
```release-notes
containerd integration: Fix building Dockerfiles with `FROM scratch` instruction when using the legacy builder (non buildkit).
```

**- A picture of a cute animal (not mandatory but encouraged)**

