### PR TITLE
Fix handling `--max-download-attempts=0`

### DIFF
--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -161,10 +161,10 @@ func (daemon *Daemon) reloadMaxConcurrentDownloadsAndUploads(txn *reloadTxn, new
 	newCfg.MaxConcurrentDownloads = config.DefaultMaxConcurrentDownloads
 	newCfg.MaxConcurrentUploads = config.DefaultMaxConcurrentUploads
 
-	if conf.IsValueSet("max-concurrent-downloads") && conf.MaxConcurrentDownloads != 0 {
+	if conf.IsValueSet("max-concurrent-downloads") && conf.MaxConcurrentDownloads > 0 {
 		newCfg.MaxConcurrentDownloads = conf.MaxConcurrentDownloads
 	}
-	if conf.IsValueSet("max-concurrent-uploads") && conf.MaxConcurrentUploads != 0 {
+	if conf.IsValueSet("max-concurrent-uploads") && conf.MaxConcurrentUploads > 0 {
 		newCfg.MaxConcurrentUploads = conf.MaxConcurrentUploads
 	}
 	txn.OnCommit(func() error {
@@ -190,7 +190,7 @@ func (daemon *Daemon) reloadMaxConcurrentDownloadsAndUploads(txn *reloadTxn, new
 func (daemon *Daemon) reloadMaxDownloadAttempts(txn *reloadTxn, newCfg *configStore, conf *config.Config, attributes map[string]string) error {
 	// We always "reset" as the cost is lightweight and easy to maintain.
 	newCfg.MaxDownloadAttempts = config.DefaultDownloadAttempts
-	if conf.IsValueSet("max-download-attempts") && conf.MaxDownloadAttempts != 0 {
+	if conf.IsValueSet("max-download-attempts") && conf.MaxDownloadAttempts > 0 {
 		newCfg.MaxDownloadAttempts = conf.MaxDownloadAttempts
 	}
 


### PR DESCRIPTION
closes #44921

**- What I did**
Restrict `0` value for:
- config.MaxConcurrentDownloads
- config.MaxConcurrentUploads
- config.MaxDownloadAttempts
- config.MTU (minimal value is set 68)

**- How I did it**

**- How to verify it**
The daemon should refuse to start.

$ docker run --rm -it --privileged docker:20.10.23-dind dockerd --max-download-attempts=0
invalid max download attempts: 0
$ docker run --rm -it --privileged docker:20.10.23-dind sh -c 'mkdir /etc/docker && echo '"'"'{"max-download-attempts": 0}'"'"' > /etc/docker/daemon.json && dockerd'
unable to configure the Docker daemon with file /etc/docker/daemon.json: configuration validation from file failed: invalid max download attempts: 0

**- Description for the changelog**


