### PR TITLE
[24.0 backport] Don't return an error if the lease is not found

### DIFF
--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -54,10 +54,13 @@ func (i *ImageService) PrepareSnapshot(ctx context.Context, id string, image str
 func (i *ImageService) manifestMatchesPlatform(ctx context.Context, img *image.Image, platform ocispec.Platform) (bool, error) {
 	logger := logrus.WithField("image", img.ID).WithField("desiredPlatform", platforms.Format(platform))
 
-	ls, leaseErr := i.leases.ListResources(ctx, leases.Lease{ID: imageKey(img.ID().String())})
-	if leaseErr != nil {
-		logger.WithError(leaseErr).Error("Error looking up image leases")
-		return false, leaseErr
+	ls, err := i.leases.ListResources(ctx, leases.Lease{ID: imageKey(img.ID().String())})
+	if err != nil {
+		if cerrdefs.IsNotFound(err) {
+			return false, nil
+		}
+		logger.WithError(err).Error("Error looking up image leases")
+		return false, err
 	}
 
 	// Note we are comparing against manifest lists here, which we expect to always have a CPU variant set (where applicable).


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/46293
- relates to https://github.com/moby/moby/pull/43939

If the image for the wanted platform doesn't exist then the lease doesn't exist either. Returning this error hides the real error, so let's not return it.


(cherry picked from commit b8ff8ea58ee37d672f42e94da4d73442d8a81fc9)

---

**- What I did**

#43939 changed the signature of `manifestMatchesPlatform` and started returning the lease error, the issue is that, if the image for the wanted platform doesn't exist, then the lease doesn't exist either. We shouldn't return an error if the lease is not found

**- How I did it**

By checking the error returned when we list lease resources.

**- How to verify it**

With this compose file

```yaml
services:
  test:
    build:
      context: .
      dockerfile: Dockerfile
```

And this Dockerfile:

```dockerfile
FROM alpine
```

Run the compose project once:

```console
$ docker compose up
```
Then run it but with a preferred platform specified:

Before:

```console
$ DOCKER_DEFAULT_PLATFORM=linux/arm64 docker-compose up
[+] Running 0/0
 ⠋ Container compose-platform-test-1  Recreate                                                                                                                         0.0s 
Error response from daemon: lease "moby-image-sha256:e22aab0781e952e8ae9c49b2162eda23ef9a62d26a7b1e6a2d66b77f6751c45e": not found
```
After:

```console
$ DOCKER_DEFAULT_PLATFORM=linux/arm64 docker-compose up
[+] Running 0/0
 ⠋ Container compose-platform-test-1  Recreate                                                                                                                         0.0s 
Error response from daemon: image with reference compose-platform-test was found but does not match the specified platform: wanted linux/arm64, actual: linux/amd64
```

This was reported in multiple places:

* https://github.com/laravel/sail/issues/597
* https://github.com/docker/compose/issues/10856#issuecomment-1682601800
* https://stackoverflow.com/questions/76413014/error-response-from-daemon-lease-moby-image-sha256c274-not-found

**- Description for the changelog**
Fixed the reported error when the local image's platform mismatches the wanted one

**- A picture of a cute animal (not mandatory but encouraged)**


