### PR TITLE
[24.0 backport] c8d: Fix building Dockerfiles that have `FROM scratch`

### DIFF
--- a/daemon/containerd/image_commit.go
+++ b/daemon/containerd/image_commit.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containerd/containerd/snapshots"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/image"
+	"github.com/docker/docker/pkg/archive"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
 	"github.com/opencontainers/image-spec/specs-go"
@@ -38,28 +39,27 @@ func (i *ImageService) CommitImage(ctx context.Context, cc backend.CommitConfig)
 	container := i.containers.Get(cc.ContainerID)
 	cs := i.client.ContentStore()
 
-	imageManifest, err := getContainerImageManifest(container)
-	if err != nil {
-		return "", err
-	}
+	var parentManifest ocispec.Manifest
+	var parentImage ocispec.Image
 
-	imageManifestBytes, err := content.ReadBlob(ctx, cs, imageManifest)
-	if err != nil {
-		return "", err
-	}
+	// ImageManifest can be nil when committing an image with base FROM scratch
+	if container.ImageManifest != nil {
+		imageManifestBytes, err := content.ReadBlob(ctx, cs, *container.ImageManifest)
+		if err != nil {
+			return "", err
+		}
 
-	var manifest ocispec.Manifest
-	if err := json.Unmarshal(imageManifestBytes, &manifest); err != nil {
-		return "", err
-	}
+		if err := json.Unmarshal(imageManifestBytes, &parentManifest); err != nil {
+			return "", err
+		}
 
-	imageConfigBytes, err := content.ReadBlob(ctx, cs, manifest.Config)
-	if err != nil {
-		return "", err
-	}
-	var ociimage ocispec.Image
-	if err := json.Unmarshal(imageConfigBytes, &ociimage); err != nil {
-		return "", err
+		imageConfigBytes, err := content.ReadBlob(ctx, cs, parentManifest.Config)
+		if err != nil {
+			return "", err
+		}
+		if err := json.Unmarshal(imageConfigBytes, &parentImage); err != nil {
+			return "", err
+		}
 	}
 
 	var (
@@ -78,15 +78,19 @@ func (i *ImageService) CommitImage(ctx context.Context, cc backend.CommitConfig)
 	if err != nil {
 		return "", fmt.Errorf("failed to export layer: %w", err)
 	}
+	imageConfig := generateCommitImageConfig(parentImage, diffID, cc)
 
-	imageConfig := generateCommitImageConfig(ociimage, diffID, cc)
+	layers := parentManifest.Layers
+	if diffLayerDesc != nil {
+		rootfsID := identity.ChainID(imageConfig.RootFS.DiffIDs).String()
 
-	rootfsID := identity.ChainID(imageConfig.RootFS.DiffIDs).String()
-	if err := applyDiffLayer(ctx, rootfsID, ociimage, sn, differ, diffLayerDesc); err != nil {
-		return "", fmt.Errorf("failed to apply diff: %w", err)
+		if err := applyDiffLayer(ctx, rootfsID, parentImage, sn, differ, *diffLayerDesc); err != nil {
+			return "", fmt.Errorf("failed to apply diff: %w", err)
+		}
+
+		layers = append(layers, *diffLayerDesc)
 	}
 
-	layers := append(manifest.Layers, diffLayerDesc)
 	commitManifestDesc, err := writeContentsForImage(ctx, container.Driver, cs, imageConfig, layers)
 	if err != nil {
 		return "", err
@@ -130,6 +134,12 @@ func generateCommitImageConfig(baseConfig ocispec.Image, diffID digest.Digest, o
 		logrus.Warnf("assuming os=%q", os)
 	}
 	logrus.Debugf("generateCommitImageConfig(): arch=%q, os=%q", arch, os)
+
+	diffIds := baseConfig.RootFS.DiffIDs
+	if diffID != "" {
+		diffIds = append(diffIds, diffID)
+	}
+
 	return ocispec.Image{
 		Platform: ocispec.Platform{
 			Architecture: arch,
@@ -140,7 +150,7 @@ func generateCommitImageConfig(baseConfig ocispec.Image, diffID digest.Digest, o
 		Config:  containerConfigToOciImageConfig(opts.Config),
 		RootFS: ocispec.RootFS{
 			Type:    "layers",
-			DiffIDs: append(baseConfig.RootFS.DiffIDs, diffID),
+			DiffIDs: diffIds,
 		},
 		History: append(baseConfig.History, ocispec.History{
 			Created:   &createdTime,
@@ -217,28 +227,43 @@ func writeContentsForImage(ctx context.Context, snName string, cs content.Store,
 }
 
 // createDiff creates a layer diff into containerd's content store.
-func createDiff(ctx context.Context, name string, sn snapshots.Snapshotter, cs content.Store, comparer diff.Comparer) (ocispec.Descriptor, digest.Digest, error) {
+// If the diff is empty it returns nil empty digest and no error.
+func createDiff(ctx context.Context, name string, sn snapshots.Snapshotter, cs content.Store, comparer diff.Comparer) (*ocispec.Descriptor, digest.Digest, error) {
 	newDesc, err := rootfs.CreateDiff(ctx, name, sn, comparer)
 	if err != nil {
-		return ocispec.Descriptor{}, "", err
+		return nil, "", err
+	}
+
+	ra, err := cs.ReaderAt(ctx, newDesc)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to read diff archive: %w", err)
+	}
+	defer ra.Close()
+
+	empty, err := archive.IsEmpty(content.NewReader(ra))
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to check if archive is empty: %w", err)
+	}
+	if empty {
+		return nil, "", nil
 	}
 
 	info, err := cs.Info(ctx, newDesc.Digest)
 	if err != nil {
-		return ocispec.Descriptor{}, "", err
+		return nil, "", fmt.Errorf("failed to get content info: %w", err)
 	}
 
 	diffIDStr, ok := info.Labels["containerd.io/uncompressed"]
 	if !ok {
-		return ocispec.Descriptor{}, "", fmt.Errorf("invalid differ response with no diffID")
+		return nil, "", fmt.Errorf("invalid differ response with no diffID")
 	}
 
 	diffID, err := digest.Parse(diffIDStr)
 	if err != nil {
-		return ocispec.Descriptor{}, "", err
+		return nil, "", err
 	}
 
-	return ocispec.Descriptor{
+	return &ocispec.Descriptor{
 		MediaType: ocispec.MediaTypeImageLayerGzip,
 		Digest:    newDesc.Digest,
 		Size:      info.Size,
@@ -254,7 +279,7 @@ func applyDiffLayer(ctx context.Context, name string, baseImg ocispec.Image, sn 
 
 	mount, err := sn.Prepare(ctx, key, parent)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to prepare snapshot: %w", err)
 	}
 
 	defer func() {

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	cerrdefs "github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/leases"
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
@@ -144,8 +145,10 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, config ty
 				ID: container.ID,
 			}
 			if err := ls.Delete(context.Background(), lease, leases.SynchronousDelete); err != nil {
-				container.SetRemovalError(err)
-				return err
+				if !cerrdefs.IsNotFound(err) {
+					container.SetRemovalError(err)
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/46284
- Fixes: https://github.com/moby/moby/issues/46248
- addresses https://github.com/docker/for-mac/issues/6853#issuecomment-1680977603


**- What I did**
Fix running containers with empty `Image`.

**- How I did it**
See commits.

**- How to verify it**
c8d integration tests (https://github.com/moby/moby/pull/45232) from `TestDockerCLIBuildSuite`:
```diff
- DONE 250 tests, 13 skipped, 58 failures in 352.552s
+ DONE 250 tests, 13 skipped, 42 failures in 406.027s
```

**Before**
```bash
$ printf 'FROM scratch\nLABEL asdf=1' | DOCKER_BUILDKIT=0 docker build -t asdf -
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            BuildKit is currently disabled; enable it by removing the DOCKER_BUILDKIT=0
            environment-variable.

Sending build context to Docker daemon  2.048kB
Step 1/2 : FROM scratch
 --->
Step 2/2 : LABEL asdf=1
invalid reference format
```

**After**
```bash
$ printf 'FROM scratch\nLABEL asdf=1' | DOCKER_BUILDKIT=0 docker build -t asdf -
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            BuildKit is currently disabled; enable it by removing the DOCKER_BUILDKIT=0
            environment-variable.

Sending build context to Docker daemon  2.048kB
Step 1/2 : FROM scratch
 --->
Step 2/2 : LABEL asdf=1
 ---> Running in 08bc1d65adb1
 ---> Removed intermediate container 08bc1d65adb1
 ---> 7072ecaf239f
Successfully built 7072ecaf239f
Successfully tagged asdf:latest
```

**- Description for the changelog**
```release-notes
containerd integration: Fix building Dockerfiles with `FROM scratch` instruction when using the legacy builder (non buildkit).
```

**- A picture of a cute animal (not mandatory but encouraged)**

