### PR TITLE
TestDiskUsage: don't panic if results don't match

### DIFF
--- a/integration/system/disk_usage_test.go
+++ b/integration/system/disk_usage_test.go
@@ -79,6 +79,7 @@ func TestDiskUsage(t *testing.T) {
 				assert.NilError(t, err)
 				assert.Equal(t, len(du.Containers), 1)
 				assert.Equal(t, len(du.Containers[0].Names), 1)
+				assert.Assert(t, len(prev.Images) > 0)
 				assert.Assert(t, du.Containers[0].Created >= prev.Images[0].Created)
 				assert.DeepEqual(t, du, types.DiskUsage{
 					LayersSize: prev.LayersSize,


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/45232

This test is currently failing with containerd-integration, which should be looked into, but let's start with preventing it from panicking, to make the test-failures less noisy;

        --- FAIL: TestDiskUsage/after_container.Run (0.26s)
    panic: runtime error: index out of range [0] with length 0 [recovered]
        panic: runtime error: index out of range [0] with length 0

    goroutine 280 [running]:
    testing.tRunner.func1.2({0xb07a00, 0x40002006a8})
        /usr/local/go/src/testing/testing.go:1526 +0x1c8
    testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1529 +0x364
    panic({0xb07a00, 0x40002006a8})
        /usr/local/go/src/runtime/panic.go:884 +0x1f4
    github.com/docker/docker/integration/system.TestDiskUsage.func3(0x0?, {0x0, {0x14ea4a8, 0x0, 0x0}, {0x14ea4a8, 0x0, 0x0}, {0x14ea4a8, 0x0, ...}, ...})
        /go/src/github.com/docker/docker/integration/system/disk_usage_test.go:82 +0x7e4
    github.com/docker/docker/integration/system.TestDiskUsage.func4(0x4000235c80?)
        /go/src/github.com/docker/docker/integration/system/disk_usage_test.go:118 +0x8c

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

