### PR TITLE
libnetwork/iptables: (Add|Del)InterfaceFirewalld: check firewalld status

### DIFF
--- a/libnetwork/iptables/firewalld.go
+++ b/libnetwork/iptables/firewalld.go
@@ -243,8 +243,13 @@ func setupDockerZone() error {
 	return nil
 }
 
-// AddInterfaceFirewalld adds the interface to the trusted zone
+// AddInterfaceFirewalld adds the interface to the trusted zone. It is a
+// no-op if firewalld is not running.
 func AddInterfaceFirewalld(intf string) error {
+	if !firewalldRunning {
+		return nil
+	}
+
 	var intfs []string
 	// Check if interface is already added to the zone
 	if err := connection.sysObj.Call(dbusInterface+".zone.getInterfaces", 0, dockerZone).Store(&intfs); err != nil {
@@ -264,8 +269,13 @@ func AddInterfaceFirewalld(intf string) error {
 	return nil
 }
 
-// DelInterfaceFirewalld removes the interface from the trusted zone
+// DelInterfaceFirewalld removes the interface from the trusted zone It is a
+// no-op if firewalld is not running.
 func DelInterfaceFirewalld(intf string) error {
+	if !firewalldRunning {
+		return nil
+	}
+
 	var intfs []string
 	// Check if interface is part of the zone
 	if err := connection.sysObj.Call(dbusInterface+".zone.getInterfaces", 0, dockerZone).Store(&intfs); err != nil {

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -203,16 +203,14 @@ func (iptable IPTable) ProgramChain(c *ChainInfo, bridgeName string, hairpinMode
 		return errors.New("could not program chain, missing chain name")
 	}
 
-	// Either add or remove the interface from the firewalld zone
-	if firewalldRunning {
-		if enable {
-			if err := AddInterfaceFirewalld(bridgeName); err != nil {
-				return err
-			}
-		} else {
-			if err := DelInterfaceFirewalld(bridgeName); err != nil && !errdefs.IsNotFound(err) {
-				return err
-			}
+	// Either add or remove the interface from the firewalld zone, if firewalld is running.
+	if enable {
+		if err := AddInterfaceFirewalld(bridgeName); err != nil {
+			return err
+		}
+	} else {
+		if err := DelInterfaceFirewalld(bridgeName); err != nil && !errdefs.IsNotFound(err) {
+			return err
 		}
 	}
 


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/46190#discussion_r1291052416

Check if firewalld is running before running the function, so that consumers of the function don't have to check for the status.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

