### PR TITLE
libnetwork/osl: remove Sandbox and Info interfaces

### DIFF
--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -103,7 +103,7 @@ type Controller struct {
 
 	// FIXME(thaJeztah): defOsSbox is always nil on non-Linux: move these fields to Linux-only files.
 	defOsSboxOnce sync.Once
-	defOsSbox     osl.Sandbox
+	defOsSbox     *osl.Namespace
 }
 
 // New creates a new instance of network controller.

--- a/libnetwork/controller_linux.go
+++ b/libnetwork/controller_linux.go
@@ -40,7 +40,7 @@ func (c *Controller) enabledIptablesVersions() []iptables.IPVersion {
 
 // getDefaultOSLSandbox returns the controller's default [osl.Sandbox]. It
 // creates the sandbox if it does not yet exist.
-func (c *Controller) getDefaultOSLSandbox(key string) (osl.Sandbox, error) {
+func (c *Controller) getDefaultOSLSandbox(key string) (*osl.Namespace, error) {
 	var err error
 	c.defOsSboxOnce.Do(func() {
 		c.defOsSbox, err = osl.NewSandbox(key, false, false)

--- a/libnetwork/osl/interface_linux.go
+++ b/libnetwork/osl/interface_linux.go
@@ -30,7 +30,7 @@ type Interface struct {
 	llAddrs     []*net.IPNet
 	routes      []*net.IPNet
 	bridge      bool
-	ns          *networkNamespace
+	ns          *Namespace
 }
 
 // SrcName returns the name of the interface in the origin network namespace.
@@ -159,7 +159,7 @@ func (i *Interface) Statistics() (*types.InterfaceStatistics, error) {
 	}, nil
 }
 
-func (n *networkNamespace) findDst(srcName string, isBridge bool) string {
+func (n *Namespace) findDst(srcName string, isBridge bool) string {
 	n.Lock()
 	defer n.Unlock()
 
@@ -179,7 +179,7 @@ func (n *networkNamespace) findDst(srcName string, isBridge bool) string {
 // interface according to the specified settings. The caller is expected
 // to only provide a prefix for DstName. The AddInterface api will auto-generate
 // an appropriate suffix for the DstName to disambiguate.
-func (n *networkNamespace) AddInterface(srcName, dstPrefix string, options ...IfaceOption) error {
+func (n *Namespace) AddInterface(srcName, dstPrefix string, options ...IfaceOption) error {
 	i := &Interface{
 		srcName: srcName,
 		dstName: dstPrefix,

--- a/libnetwork/osl/namespace_unsupported.go
+++ b/libnetwork/osl/namespace_unsupported.go
@@ -2,12 +2,16 @@
 
 package osl
 
+type Namespace struct{}
+
+func (n *Namespace) Destroy() error { return nil }
+
 // GC triggers garbage collection of namespace path right away
 // and waits for it.
 func GC() {
 }
 
 // GetSandboxForExternalKey returns sandbox object for the supplied path
-func GetSandboxForExternalKey(path string, key string) (Sandbox, error) {
+func GetSandboxForExternalKey(path string, key string) (*Namespace, error) {
 	return nil, nil
 }

--- a/libnetwork/osl/namespace_windows.go
+++ b/libnetwork/osl/namespace_windows.go
@@ -6,13 +6,17 @@ func GenerateKey(containerID string) string {
 	return containerID
 }
 
+type Namespace struct{}
+
+func (n *Namespace) Destroy() error { return nil }
+
 // NewSandbox provides a new sandbox instance created in an os specific way
 // provided a key which uniquely identifies the sandbox
-func NewSandbox(key string, osCreate, isRestore bool) (Sandbox, error) {
+func NewSandbox(key string, osCreate, isRestore bool) (*Namespace, error) {
 	return nil, nil
 }
 
-func GetSandboxForExternalKey(path string, key string) (Sandbox, error) {
+func GetSandboxForExternalKey(path string, key string) (*Namespace, error) {
 	return nil, nil
 }
 

--- a/libnetwork/osl/neigh_linux.go
+++ b/libnetwork/osl/neigh_linux.go
@@ -29,7 +29,7 @@ type neigh struct {
 	family   int
 }
 
-func (n *networkNamespace) findNeighbor(dstIP net.IP, dstMac net.HardwareAddr) *neigh {
+func (n *Namespace) findNeighbor(dstIP net.IP, dstMac net.HardwareAddr) *neigh {
 	n.Lock()
 	defer n.Unlock()
 
@@ -43,7 +43,7 @@ func (n *networkNamespace) findNeighbor(dstIP net.IP, dstMac net.HardwareAddr) *
 }
 
 // DeleteNeighbor deletes neighbor entry from the sandbox.
-func (n *networkNamespace) DeleteNeighbor(dstIP net.IP, dstMac net.HardwareAddr, osDelete bool) error {
+func (n *Namespace) DeleteNeighbor(dstIP net.IP, dstMac net.HardwareAddr, osDelete bool) error {
 	var (
 		iface netlink.Link
 		err   error
@@ -121,7 +121,7 @@ func (n *networkNamespace) DeleteNeighbor(dstIP net.IP, dstMac net.HardwareAddr,
 }
 
 // AddNeighbor adds a neighbor entry into the sandbox.
-func (n *networkNamespace) AddNeighbor(dstIP net.IP, dstMac net.HardwareAddr, force bool, options ...NeighOption) error {
+func (n *Namespace) AddNeighbor(dstIP net.IP, dstMac net.HardwareAddr, force bool, options ...NeighOption) error {
 	var (
 		iface                  netlink.Link
 		err                    error

--- a/libnetwork/osl/route_linux.go
+++ b/libnetwork/osl/route_linux.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Gateway returns the IPv4 gateway for the sandbox.
-func (n *networkNamespace) Gateway() net.IP {
+func (n *Namespace) Gateway() net.IP {
 	n.Lock()
 	defer n.Unlock()
 
@@ -17,7 +17,7 @@ func (n *networkNamespace) Gateway() net.IP {
 }
 
 // GatewayIPv6 returns the IPv6 gateway for the sandbox.
-func (n *networkNamespace) GatewayIPv6() net.IP {
+func (n *Namespace) GatewayIPv6() net.IP {
 	n.Lock()
 	defer n.Unlock()
 
@@ -27,7 +27,7 @@ func (n *networkNamespace) GatewayIPv6() net.IP {
 // StaticRoutes returns additional static routes for the sandbox. Note that
 // directly connected routes are stored on the particular interface they
 // refer to.
-func (n *networkNamespace) StaticRoutes() []*types.StaticRoute {
+func (n *Namespace) StaticRoutes() []*types.StaticRoute {
 	n.Lock()
 	defer n.Unlock()
 
@@ -40,20 +40,20 @@ func (n *networkNamespace) StaticRoutes() []*types.StaticRoute {
 	return routes
 }
 
-func (n *networkNamespace) setGateway(gw net.IP) {
+func (n *Namespace) setGateway(gw net.IP) {
 	n.Lock()
 	n.gw = gw
 	n.Unlock()
 }
 
-func (n *networkNamespace) setGatewayIPv6(gwv6 net.IP) {
+func (n *Namespace) setGatewayIPv6(gwv6 net.IP) {
 	n.Lock()
 	n.gwv6 = gwv6
 	n.Unlock()
 }
 
 // SetGateway sets the default IPv4 gateway for the sandbox.
-func (n *networkNamespace) SetGateway(gw net.IP) error {
+func (n *Namespace) SetGateway(gw net.IP) error {
 	// Silently return if the gateway is empty
 	if len(gw) == 0 {
 		return nil
@@ -68,7 +68,7 @@ func (n *networkNamespace) SetGateway(gw net.IP) error {
 }
 
 // UnsetGateway the previously set default IPv4 gateway in the sandbox.
-func (n *networkNamespace) UnsetGateway() error {
+func (n *Namespace) UnsetGateway() error {
 	gw := n.Gateway()
 
 	// Silently return if the gateway is empty
@@ -84,7 +84,7 @@ func (n *networkNamespace) UnsetGateway() error {
 	return err
 }
 
-func (n *networkNamespace) programGateway(gw net.IP, isAdd bool) error {
+func (n *Namespace) programGateway(gw net.IP, isAdd bool) error {
 	gwRoutes, err := n.nlHandle.RouteGet(gw)
 	if err != nil {
 		return fmt.Errorf("route for the gateway %s could not be found: %v", gw, err)
@@ -118,7 +118,7 @@ func (n *networkNamespace) programGateway(gw net.IP, isAdd bool) error {
 }
 
 // Program a route in to the namespace routing table.
-func (n *networkNamespace) programRoute(path string, dest *net.IPNet, nh net.IP) error {
+func (n *Namespace) programRoute(path string, dest *net.IPNet, nh net.IP) error {
 	gwRoutes, err := n.nlHandle.RouteGet(nh)
 	if err != nil {
 		return fmt.Errorf("route for the next hop %s could not be found: %v", nh, err)
@@ -133,7 +133,7 @@ func (n *networkNamespace) programRoute(path string, dest *net.IPNet, nh net.IP)
 }
 
 // Delete a route from the namespace routing table.
-func (n *networkNamespace) removeRoute(path string, dest *net.IPNet, nh net.IP) error {
+func (n *Namespace) removeRoute(path string, dest *net.IPNet, nh net.IP) error {
 	gwRoutes, err := n.nlHandle.RouteGet(nh)
 	if err != nil {
 		return fmt.Errorf("route for the next hop could not be found: %v", err)
@@ -148,7 +148,7 @@ func (n *networkNamespace) removeRoute(path string, dest *net.IPNet, nh net.IP) 
 }
 
 // SetGatewayIPv6 sets the default IPv6 gateway for the sandbox.
-func (n *networkNamespace) SetGatewayIPv6(gwv6 net.IP) error {
+func (n *Namespace) SetGatewayIPv6(gwv6 net.IP) error {
 	// Silently return if the gateway is empty
 	if len(gwv6) == 0 {
 		return nil
@@ -163,7 +163,7 @@ func (n *networkNamespace) SetGatewayIPv6(gwv6 net.IP) error {
 }
 
 // UnsetGatewayIPv6 unsets the previously set default IPv6 gateway in the sandbox.
-func (n *networkNamespace) UnsetGatewayIPv6() error {
+func (n *Namespace) UnsetGatewayIPv6() error {
 	gwv6 := n.GatewayIPv6()
 
 	// Silently return if the gateway is empty
@@ -182,7 +182,7 @@ func (n *networkNamespace) UnsetGatewayIPv6() error {
 }
 
 // AddStaticRoute adds a static route to the sandbox.
-func (n *networkNamespace) AddStaticRoute(r *types.StaticRoute) error {
+func (n *Namespace) AddStaticRoute(r *types.StaticRoute) error {
 	err := n.programRoute(n.nsPath(), r.Destination, r.NextHop)
 	if err == nil {
 		n.Lock()
@@ -193,7 +193,7 @@ func (n *networkNamespace) AddStaticRoute(r *types.StaticRoute) error {
 }
 
 // RemoveStaticRoute removes a static route from the sandbox.
-func (n *networkNamespace) RemoveStaticRoute(r *types.StaticRoute) error {
+func (n *Namespace) RemoveStaticRoute(r *types.StaticRoute) error {
 	err := n.removeRoute(n.nsPath(), r.Destination, r.NextHop)
 	if err == nil {
 		n.Lock()

--- a/libnetwork/osl/sandbox.go
+++ b/libnetwork/osl/sandbox.go
@@ -1,12 +1,6 @@
 // Package osl describes structures and interfaces which abstract os entities
 package osl
 
-import (
-	"net"
-
-	"github.com/docker/docker/libnetwork/types"
-)
-
 // SandboxType specify the time of the sandbox, this can be used to apply special configs
 type SandboxType int
 
@@ -26,90 +20,3 @@ type IfaceOption func(i *Interface) error
 
 // NeighOption is a function option type to set neighbor options.
 type NeighOption func(nh *neigh)
-
-// Sandbox represents a network sandbox, identified by a specific key.  It
-// holds a list of Interfaces, routes etc, and more can be added dynamically.
-type Sandbox interface {
-	// Key returns the path where the network namespace is mounted.
-	Key() string
-
-	// AddInterface adds an existing Interface to this sandbox. The operation will rename
-	// from the Interface SrcName to DstName as it moves, and reconfigure the
-	// interface according to the specified settings. The caller is expected
-	// to only provide a prefix for DstName. The AddInterface api will auto-generate
-	// an appropriate suffix for the DstName to disambiguate.
-	AddInterface(SrcName string, DstPrefix string, options ...IfaceOption) error
-
-	// SetGateway sets the default IPv4 gateway for the sandbox.
-	SetGateway(gw net.IP) error
-
-	// SetGatewayIPv6 sets the default IPv6 gateway for the sandbox.
-	SetGatewayIPv6(gw net.IP) error
-
-	// UnsetGateway the previously set default IPv4 gateway in the sandbox.
-	UnsetGateway() error
-
-	// UnsetGatewayIPv6 unsets the previously set default IPv6 gateway in the sandbox.
-	UnsetGatewayIPv6() error
-
-	// GetLoopbackIfaceName returns the name of the loopback interface
-	GetLoopbackIfaceName() string
-
-	// AddAliasIP adds the passed IP address to the named interface
-	AddAliasIP(ifName string, ip *net.IPNet) error
-
-	// RemoveAliasIP removes the passed IP address from the named interface
-	RemoveAliasIP(ifName string, ip *net.IPNet) error
-
-	// DisableARPForVIP disables ARP replies and requests for VIP addresses
-	// on a particular interface.
-	DisableARPForVIP(ifName string) error
-
-	// AddStaticRoute adds a static route to the sandbox.
-	AddStaticRoute(*types.StaticRoute) error
-
-	// RemoveStaticRoute removes a static route from the sandbox.
-	RemoveStaticRoute(*types.StaticRoute) error
-
-	// AddNeighbor adds a neighbor entry into the sandbox.
-	AddNeighbor(dstIP net.IP, dstMac net.HardwareAddr, force bool, option ...NeighOption) error
-
-	// DeleteNeighbor deletes neighbor entry from the sandbox.
-	DeleteNeighbor(dstIP net.IP, dstMac net.HardwareAddr, osDelete bool) error
-
-	// InvokeFunc invoke a function in the network namespace.
-	InvokeFunc(func()) error
-
-	// Destroy destroys the sandbox.
-	Destroy() error
-
-	// Restore restores the sandbox.
-	Restore(ifsopt map[Iface][]IfaceOption, routes []*types.StaticRoute, gw net.IP, gw6 net.IP) error
-
-	// ApplyOSTweaks applies operating system specific knobs on the sandbox.
-	ApplyOSTweaks([]SandboxType)
-
-	Info
-}
-
-// Info represents all possible information that
-// the driver wants to place in the sandbox which includes
-// interfaces, routes and gateway
-type Info interface {
-	// Interfaces returns the collection of Interface previously added with the AddInterface
-	// method. Note that this doesn't include network interfaces added in any
-	// other way (such as the default loopback interface which is automatically
-	// created on creation of a sandbox).
-	Interfaces() []*Interface
-
-	// Gateway returns the IPv4 gateway for the sandbox.
-	Gateway() net.IP
-
-	// GatewayIPv6 returns the IPv6 gateway for the sandbox.
-	GatewayIPv6() net.IP
-
-	// StaticRoutes returns additional static routes for the sandbox. Note that
-	// directly connected routes are stored on the particular interface they
-	// refer to.
-	StaticRoutes() []*types.StaticRoute
-}

--- a/libnetwork/osl/sandbox_freebsd.go
+++ b/libnetwork/osl/sandbox_freebsd.go
@@ -13,12 +13,12 @@ func GenerateKey(containerID string) string {
 
 // NewSandbox provides a new sandbox instance created in an os specific way
 // provided a key which uniquely identifies the sandbox
-func NewSandbox(key string, osCreate, isRestore bool) (Sandbox, error) {
+func NewSandbox(key string, osCreate, isRestore bool) (*Namespace, error) {
 	return nil, nil
 }
 
 // GetSandboxForExternalKey returns sandbox object for the supplied path
-func GetSandboxForExternalKey(path string, key string) (Sandbox, error) {
+func GetSandboxForExternalKey(path string, key string) (*Namespace, error) {
 	return nil, nil
 }
 

--- a/libnetwork/osl/sandbox_unsupported.go
+++ b/libnetwork/osl/sandbox_unsupported.go
@@ -9,7 +9,7 @@ var ErrNotImplemented = errors.New("not implemented")
 
 // NewSandbox provides a new sandbox instance created in an os specific way
 // provided a key which uniquely identifies the sandbox
-func NewSandbox(key string, osCreate, isRestore bool) (Sandbox, error) {
+func NewSandbox(key string, osCreate, isRestore bool) (*Namespace, error) {
 	return nil, ErrNotImplemented
 }
 

--- a/libnetwork/osl/sandbox_unsupported_test.go
+++ b/libnetwork/osl/sandbox_unsupported_test.go
@@ -13,6 +13,6 @@ func newKey(t *testing.T) (string, error) {
 	return "", ErrNotImplemented
 }
 
-func verifySandbox(t *testing.T, s Sandbox) {
+func verifySandbox(t *testing.T, ns *Namespace) {
 	return
 }

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -35,7 +35,7 @@ type Sandbox struct {
 	containerID        string
 	config             containerConfig
 	extDNS             []extDNSEntry
-	osSbox             osl.Sandbox
+	osSbox             *osl.Namespace
 	controller         *Controller
 	resolver           *Resolver
 	resolverOnce       sync.Once

--- a/libnetwork/sandbox_linux.go
+++ b/libnetwork/sandbox_linux.go
@@ -11,8 +11,8 @@ import (
 	"github.com/docker/docker/libnetwork/types"
 )
 
-func releaseOSSboxResources(osSbox osl.Sandbox, ep *Endpoint) {
-	for _, i := range osSbox.Interfaces() {
+func releaseOSSboxResources(ns *osl.Namespace, ep *Endpoint) {
+	for _, i := range ns.Interfaces() {
 		// Only remove the interfaces owned by this endpoint from the sandbox.
 		if ep.hasInterface(i.SrcName()) {
 			if err := i.Remove(); err != nil {
@@ -29,7 +29,7 @@ func releaseOSSboxResources(osSbox osl.Sandbox, ep *Endpoint) {
 
 	if len(vip) > 0 && lbModeIsDSR {
 		ipNet := &net.IPNet{IP: vip, Mask: net.CIDRMask(32, 32)}
-		if err := osSbox.RemoveAliasIP(osSbox.GetLoopbackIfaceName(), ipNet); err != nil {
+		if err := ns.RemoveAliasIP(ns.GetLoopbackIfaceName(), ipNet); err != nil {
 			log.G(context.TODO()).WithError(err).Debugf("failed to remove virtual ip %v to loopback", ipNet)
 		}
 	}
@@ -40,7 +40,7 @@ func releaseOSSboxResources(osSbox osl.Sandbox, ep *Endpoint) {
 
 	// Remove non-interface routes.
 	for _, r := range joinInfo.StaticRoutes {
-		if err := osSbox.RemoveStaticRoute(r); err != nil {
+		if err := ns.RemoveStaticRoute(r); err != nil {
 			log.G(context.TODO()).Debugf("Remove route failed: %v", err)
 		}
 	}

--- a/libnetwork/sandbox_unsupported.go
+++ b/libnetwork/sandbox_unsupported.go
@@ -4,7 +4,7 @@ package libnetwork
 
 import "github.com/docker/docker/libnetwork/osl"
 
-func releaseOSSboxResources(osl.Sandbox, *Endpoint) {}
+func releaseOSSboxResources(*osl.Namespace, *Endpoint) {}
 
 func (sb *Sandbox) updateGateway(*Endpoint) error {
 	// not implemented on Windows (Sandbox.osSbox is always nil)


### PR DESCRIPTION
- [x] depends on https://github.com/moby/moby/pull/46149


### libnetwork/osl: remove Sandbox and Info interfaces

It only has a single implementation.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

