### PR TITLE
[24.0 backport] c8d/legacybuilder: Fix `mismatched image rootfs` errors

### DIFF
--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -505,9 +505,6 @@ func (i *ImageService) CreateImage(ctx context.Context, config []byte, parent st
 		return nil, err
 	}
 
-	newImage := dimage.NewImage(dimage.ID(createdImage.Target.Digest))
-	newImage.V1Image = imgToCreate.V1Image
-	newImage.V1Image.ID = string(createdImage.Target.Digest)
-	newImage.History = imgToCreate.History
+	newImage := dimage.Clone(imgToCreate, dimage.ID(createdImage.Target.Digest))
 	return newImage, nil
 }

--- a/image/image.go
+++ b/image/image.go
@@ -248,6 +248,15 @@ func NewChildImage(img *Image, child ChildConfig, os string) *Image {
 	}
 }
 
+// Clone clones an image and changes ID.
+func Clone(base *Image, id ID) *Image {
+	img := *base
+	img.RootFS = img.RootFS.Clone()
+	img.V1Image.ID = id.String()
+	img.computedID = id
+	return &img
+}
+
 // History stores build commands that were used to create an image
 type History struct {
 	// Created is the timestamp at which the image was created


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/46301

**- What I did**
Fixed `CreateImage` losing the parent layers when creating a child image.

This fixes `failed to export image: mismatched image rootfs and manifest layers` errors in integration-cli build tests with c8d enabled (https://github.com/moby/moby/pull/45232). Although this doesn't make all these tests green, as they now fail due to: https://github.com/moby/moby/issues/46194.



**- How I did it**
Clone the passed `Image` and replace its ID instead of recreating it from scratch (and not setting all needed fields).

**- How to verify it**
Before

```bash
$ make  DOCKER_GRAPHDRIVER=overlayfs TEST_INTEGRATION_USE_SNAPSHOTTER=1  TEST_FILTER='TestBuildAddBadLinks'  test-integration
...
=== RUN   TestDockerCLIBuildSuite/TestBuildAddBadLinks
    docker_cli_build_test.go:998: assertion failed: 
        Command:  /usr/local/cli-integration/docker build -t test-link-absolute .
        ExitCode: 1
        Error:    exit status 1
        Stdout:   Sending build context to Docker daemon   5.12kB


        Step 1/3 : FROM scratch
         ---> 
        Step 2/3 : ADD links.tar /
         ---> 7f60960c7521
        Step 3/3 : ADD foo.txt /symlink/
        
        Stderr:   failed to export image: mismatched image rootfs and manifest layers
        
        
        Failures:
        ExitCode was 1 expected 0
        Expected no error
...
```

After
```bash
$ make  DOCKER_GRAPHDRIVER=overlayfs TEST_INTEGRATION_USE_SNAPSHOTTER=1  TEST_FILTER='TestBuildAddBadLinks'  test-integration
...
--- PASS: TestDockerCLIBuildSuite (3.24s)
    --- PASS: TestDockerCLIBuildSuite/TestBuildAddBadLinks (2.32s)
    --- PASS: TestDockerCLIBuildSuite/TestBuildAddBadLinksVolume (0.92s)
...
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

