### PR TITLE
libnetwork: fix missing imports, code comment, and minor comment change (dupwords)

### DIFF
--- a/libnetwork/drivers_freebsd.go
+++ b/libnetwork/drivers_freebsd.go
@@ -1,6 +1,7 @@
 package libnetwork
 
 import (
+	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/drivers/null"
 )
 

--- a/libnetwork/drivers_unsupported.go
+++ b/libnetwork/drivers_unsupported.go
@@ -2,6 +2,8 @@
 
 package libnetwork
 
+import "github.com/docker/docker/libnetwork/driverapi"
+
 func registerNetworkDrivers(r driverapi.Registerer, driverConfig func(string) map[string]interface{}) error {
 	return nil
 }

--- a/libnetwork/service_common.go
+++ b/libnetwork/service_common.go
@@ -228,8 +228,8 @@ func (c *Controller) addServiceBinding(svcName, svcID, nID, eID, containerName s
 	var addService bool
 
 	// Failure to lock the network ID on add can result in racing
-	// racing against network deletion resulting in inconsistent
-	// state in the c.serviceBindings map and it's sub-maps. Also,
+	// against network deletion resulting in inconsistent state
+	// in the c.serviceBindings map and it's sub-maps. Also,
 	// always lock network ID before services to avoid deadlock.
 	c.networkLocker.Lock(nID)
 	defer c.networkLocker.Unlock(nID) //nolint:errcheck


### PR DESCRIPTION
### libnetwork: fix some missing imports on macOS and FreeBSD

This was introduced in 1980deffaeed881e04abe48aba6295fd67d84f4a (https://github.com/moby/moby/pull/45881), which
changed the implementation, but forgot to update imports in these.

### libnetwork: Controller.addServiceBinding: fix duplicate word in comment

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

