### PR TITLE
containerd integration: Persist Docker-specific ImageConfig fields

### DIFF
--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -390,43 +390,7 @@ func (i *ImageService) CreateImage(ctx context.Context, config []byte, parent st
 		return nil, err
 	}
 
-	rootFS := ocispec.RootFS{
-		Type:    imgToCreate.RootFS.Type,
-		DiffIDs: []digest.Digest{},
-	}
-	for _, diffId := range imgToCreate.RootFS.DiffIDs {
-		rootFS.DiffIDs = append(rootFS.DiffIDs, digest.Digest(diffId))
-	}
-	exposedPorts := make(map[string]struct{}, len(imgToCreate.Config.ExposedPorts))
-	for k, v := range imgToCreate.Config.ExposedPorts {
-		exposedPorts[string(k)] = v
-	}
-
-	// make an ocispec.Image from the docker/image.Image
-	ociImgToCreate := ocispec.Image{
-		Created: imgToCreate.Created,
-		Author:  imgToCreate.Author,
-		Platform: ocispec.Platform{
-			Architecture: imgToCreate.Architecture,
-			Variant:      imgToCreate.Variant,
-			OS:           imgToCreate.OS,
-			OSVersion:    imgToCreate.OSVersion,
-			OSFeatures:   imgToCreate.OSFeatures,
-		},
-		Config: ocispec.ImageConfig{
-			User:         imgToCreate.Config.User,
-			ExposedPorts: exposedPorts,
-			Env:          imgToCreate.Config.Env,
-			Entrypoint:   imgToCreate.Config.Entrypoint,
-			Cmd:          imgToCreate.Config.Cmd,
-			Volumes:      imgToCreate.Config.Volumes,
-			WorkingDir:   imgToCreate.Config.WorkingDir,
-			Labels:       imgToCreate.Config.Labels,
-			StopSignal:   imgToCreate.Config.StopSignal,
-		},
-		RootFS:  rootFS,
-		History: imgToCreate.History,
-	}
+	ociImgToCreate := dockerImageToDockerOCIImage(*imgToCreate)
 
 	var layers []ocispec.Descriptor
 	// if the image has a parent, we need to start with the parents layers descriptors

--- a/daemon/containerd/image_import_test.go
+++ b/daemon/containerd/image_import_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 // regression test for https://github.com/moby/moby/issues/45904
-func TestContainerConfigToOciImageConfig(t *testing.T) {
-	ociCFG := containerConfigToOciImageConfig(&container.Config{
+func TestContainerConfigToDockerImageConfig(t *testing.T) {
+	ociCFG := containerConfigToDockerOCIImageConfig(&container.Config{
 		ExposedPorts: nat.PortSet{
 			"80/tcp": struct{}{},
 		},

--- a/daemon/containerd/imagespec.go
+++ b/daemon/containerd/imagespec.go
@@ -1,0 +1,128 @@
+package containerd
+
+import (
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/dockerversion"
+	"github.com/docker/docker/image"
+	imagespec "github.com/docker/docker/image/spec/specs-go/v1"
+	"github.com/docker/docker/layer"
+	"github.com/docker/go-connections/nat"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// dockerOciImageToDockerImagePartial creates an image.Image from the imagespec.DockerOCIImage
+// It doesn't set:
+// - V1Image.ContainerConfig
+// - V1Image.Container
+// - Details
+func dockerOciImageToDockerImagePartial(id image.ID, img imagespec.DockerOCIImage) *image.Image {
+	v1Image := image.V1Image{
+		DockerVersion: dockerversion.Version,
+		Config:        dockerOCIImageConfigToContainerConfig(img.Config),
+		Architecture:  img.Platform.Architecture,
+		Variant:       img.Platform.Variant,
+		OS:            img.Platform.OS,
+		Author:        img.Author,
+		Created:       img.Created,
+	}
+
+	rootFS := &image.RootFS{
+		Type: img.RootFS.Type,
+	}
+	for _, diffId := range img.RootFS.DiffIDs {
+		rootFS.DiffIDs = append(rootFS.DiffIDs, layer.DiffID(diffId))
+	}
+
+	out := image.NewImage(id)
+	out.V1Image = v1Image
+	out.RootFS = rootFS
+	out.History = img.History
+	out.OSFeatures = img.OSFeatures
+	out.OSVersion = img.OSVersion
+	return out
+}
+
+func dockerImageToDockerOCIImage(img image.Image) imagespec.DockerOCIImage {
+	rootfs := ocispec.RootFS{
+		Type:    img.RootFS.Type,
+		DiffIDs: []digest.Digest{},
+	}
+	for _, diffId := range img.RootFS.DiffIDs {
+		rootfs.DiffIDs = append(rootfs.DiffIDs, digest.Digest(diffId))
+	}
+
+	return imagespec.DockerOCIImage{
+		Image: ocispec.Image{
+			Created: img.Created,
+			Author:  img.Author,
+			Platform: ocispec.Platform{
+				Architecture: img.Architecture,
+				Variant:      img.Variant,
+				OS:           img.OS,
+				OSVersion:    img.OSVersion,
+				OSFeatures:   img.OSFeatures,
+			},
+			RootFS:  rootfs,
+			History: img.History,
+		},
+		Config: containerConfigToDockerOCIImageConfig(img.Config),
+	}
+}
+
+func containerConfigToDockerOCIImageConfig(cfg *container.Config) imagespec.DockerOCIImageConfig {
+	var ociCfg ocispec.ImageConfig
+	var ext imagespec.DockerOCIImageConfigExt
+
+	if cfg != nil {
+		ociCfg = ocispec.ImageConfig{
+			User:        cfg.User,
+			Env:         cfg.Env,
+			Entrypoint:  cfg.Entrypoint,
+			Cmd:         cfg.Cmd,
+			Volumes:     cfg.Volumes,
+			WorkingDir:  cfg.WorkingDir,
+			Labels:      cfg.Labels,
+			StopSignal:  cfg.StopSignal,
+			ArgsEscaped: cfg.ArgsEscaped, //nolint:staticcheck // Ignore SA1019. Need to keep it in image.
+		}
+
+		if len(cfg.ExposedPorts) > 0 {
+			ociCfg.ExposedPorts = map[string]struct{}{}
+			for k, v := range cfg.ExposedPorts {
+				ociCfg.ExposedPorts[string(k)] = v
+			}
+		}
+		ext.Healthcheck = cfg.Healthcheck
+		ext.OnBuild = cfg.OnBuild
+		ext.Shell = cfg.Shell
+	}
+
+	return imagespec.DockerOCIImageConfig{
+		ImageConfig:             ociCfg,
+		DockerOCIImageConfigExt: ext,
+	}
+}
+
+func dockerOCIImageConfigToContainerConfig(cfg imagespec.DockerOCIImageConfig) *container.Config {
+	exposedPorts := make(nat.PortSet, len(cfg.ExposedPorts))
+	for k, v := range cfg.ExposedPorts {
+		exposedPorts[nat.Port(k)] = v
+	}
+
+	return &container.Config{
+		Entrypoint:   cfg.Entrypoint,
+		Env:          cfg.Env,
+		Cmd:          cfg.Cmd,
+		User:         cfg.User,
+		WorkingDir:   cfg.WorkingDir,
+		ExposedPorts: exposedPorts,
+		Volumes:      cfg.Volumes,
+		Labels:       cfg.Labels,
+		ArgsEscaped:  cfg.ArgsEscaped, //nolint:staticcheck // Ignore SA1019. Need to keep it in image.
+		StopSignal:   cfg.StopSignal,
+		Healthcheck:  cfg.Healthcheck,
+		OnBuild:      cfg.OnBuild,
+		Shell:        cfg.Shell,
+	}
+}

--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -303,9 +303,13 @@ func (s *DockerAPISuite) TestBuildOnBuildCache(c *testing.T) {
 	client := testEnv.APIClient()
 
 	// check parentID is correct
-	image, _, err := client.ImageInspectWithRaw(context.Background(), childID)
-	assert.NilError(c, err)
-	assert.Check(c, is.Equal(parentID, image.Parent))
+	// Parent is graphdriver-only
+	if !testEnv.UsingSnapshotter() {
+		image, _, err := client.ImageInspectWithRaw(context.Background(), childID)
+		assert.NilError(c, err)
+
+		assert.Check(c, is.Equal(parentID, image.Parent))
+	}
 }
 
 func (s *DockerRegistrySuite) TestBuildCopyFromForcePull(c *testing.T) {


### PR DESCRIPTION
- Depends on: https://github.com/moby/moby/pull/46363

This fixes `ONBUILD`, `MAINTAINER` and Healthcheck in containerd integration.

**- What I did**
Fixed `ONBUILD`, `MAINTAINER` and healthchecks in containerd integration.

**- How I did it**
Use wrappers for OCI Image and ImageConfig which preserve Docker specific config fields when serializing/deserializing images. 

**- How to verify it**
```diff
$ make DOCKER_GRAPHDRIVER=overlayfs  \
   DOCKER_BUILDKIT=0 \
   TEST_INTEGRATION_USE_SNAPSHOTTER=1  \
   TEST_FILTER='(Health|OnBuild|TestBuildMaintainer|TestBuildFrom)'    test-integration
(...)
- DONE 74 tests, 1 skipped, 17 failures in 85.404s
+ DONE 74 tests, 1 skipped in 58.001s
```

Also, test case (for healthcheck) reported by user:
```diff
$ docker run -d syncthing/syncthing
40280b7b22645ef2967bdae63fdfee3522e9e7003c3de7d5eae689f6a1713a53

$ docker ps
- CONTAINER ID   IMAGE                 COMMAND                  CREATED         STATUS        PORTS                                       NAMES
- 3e797ed5e0ee   syncthing/syncthing   "/bin/entrypoint.sh …"   2 seconds ago   Up 1 second   8384/tcp, 21027/udp, 22000/tcp, 22000/udp   kind_cray
+ CONTAINER ID   IMAGE                 COMMAND                  CREATED         STATUS                           PORTS                                       NAMES
+ 40280b7b2264   syncthing/syncthing   "/bin/entrypoint.sh …"   2 seconds ago   Up 1 second (health: starting)   8384/tcp, 21027/udp, 22000/tcp, 22000/udp   charming_shamir
```

**- Description for the changelog**
```release-notes
- containerd integration: Fixed `ONBUILD` and `MAINTAINER` Dockerfile instruction
- containerd integration: Fixed healthchecks
```

**- A picture of a cute animal (not mandatory but encouraged)**



