### PR TITLE
libnetwork/osl: Namespace: assorted cleanups 

### DIFF
--- a/libnetwork/osl/interface_linux.go
+++ b/libnetwork/osl/interface_linux.go
@@ -281,6 +281,7 @@ func (n *Namespace) RemoveInterface(i *Interface) error {
 		return err
 	}
 
+	// TODO(aker): Why are we doing this? This would fail if the initial interface set up failed before the "dest interface" was moved into its own namespace; see https://github.com/moby/moby/pull/46315/commits/108595c2fe852a5264b78e96f9e63cda284990a6#r1331253578
 	err = nlh.LinkSetName(iface, i.SrcName())
 	if err != nil {
 		log.G(context.TODO()).Debugf("LinkSetName failed for interface %s: %v", i.SrcName(), err)
@@ -294,6 +295,7 @@ func (n *Namespace) RemoveInterface(i *Interface) error {
 		}
 	} else if !isDefault {
 		// Move the network interface to caller namespace.
+		// TODO(aker): What's this really doing? There are no calls to LinkDel in this package: is this code really used? (Interface.Remove() has 3 callers); see https://github.com/moby/moby/pull/46315/commits/108595c2fe852a5264b78e96f9e63cda284990a6#r1331265335
 		if err := nlh.LinkSetNsFd(iface, ns.ParseHandlerInt()); err != nil {
 			log.G(context.TODO()).Debugf("LinkSetNsFd failed for interface %s: %v", i.SrcName(), err)
 			return err
@@ -309,6 +311,7 @@ func (n *Namespace) RemoveInterface(i *Interface) error {
 	}
 	n.mu.Unlock()
 
+	// TODO(aker): This function will disable IPv6 on lo interface if the removed interface was the last one offering IPv6 connectivity. That's a weird behavior, and shouldn't be hiding this deep down in this function.
 	n.checkLoV6()
 	return nil
 }

--- a/libnetwork/osl/namespace_linux.go
+++ b/libnetwork/osl/namespace_linux.go
@@ -493,8 +493,7 @@ func (n *Namespace) Restore(interfaces map[Iface][]IfaceOption, routes []*types.
 		if i.master != "" {
 			i.dstMaster = n.findDst(i.master, true)
 			if i.dstMaster == "" {
-				return fmt.Errorf("could not find an appropriate master %q for %q",
-					i.master, i.srcName)
+				return fmt.Errorf("could not find an appropriate master %q for %q", i.master, i.srcName)
 			}
 		}
 		if n.isDefault {
@@ -512,11 +511,9 @@ func (n *Namespace) Restore(interfaces map[Iface][]IfaceOption, routes []*types.
 					return err
 				}
 				ifaceName := link.Attrs().Name
-				if strings.HasPrefix(ifaceName, "vxlan") {
-					if i.dstName == "vxlan" {
-						i.dstName = ifaceName
-						break
-					}
+				if i.dstName == "vxlan" && strings.HasPrefix(ifaceName, "vxlan") {
+					i.dstName = ifaceName
+					break
 				}
 				// find the interface name by ip
 				if i.address != nil {
@@ -525,26 +522,22 @@ func (n *Namespace) Restore(interfaces map[Iface][]IfaceOption, routes []*types.
 							i.dstName = ifaceName
 							break
 						}
-						continue
 					}
 					if i.dstName == ifaceName {
 						break
 					}
 				}
 				// This is to find the interface name of the pair in overlay sandbox
-				if strings.HasPrefix(ifaceName, "veth") {
-					if i.master != "" && i.dstName == "veth" {
-						i.dstName = ifaceName
-					}
+				if i.master != "" && i.dstName == "veth" && strings.HasPrefix(ifaceName, "veth") {
+					i.dstName = ifaceName
 				}
 			}
 
 			var index int
-			indexStr := strings.TrimPrefix(i.dstName, iface.DstPrefix)
-			if indexStr != "" {
-				index, err = strconv.Atoi(indexStr)
+			if idx := strings.TrimPrefix(i.dstName, iface.DstPrefix); idx != "" {
+				index, err = strconv.Atoi(idx)
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to restore interface in network namespace %q: invalid dstName for interface: %s: %v", n.path, i.dstName, err)
 				}
 			}
 			index++

--- a/libnetwork/osl/namespace_linux.go
+++ b/libnetwork/osl/namespace_linux.go
@@ -557,26 +557,16 @@ func (n *Namespace) Restore(ifsopt map[Iface][]IfaceOption, routes []*types.Stat
 		}
 	}
 
-	// restore routes
-	for _, r := range routes {
-		n.mu.Lock()
-		n.staticRoutes = append(n.staticRoutes, r)
-		n.mu.Unlock()
-	}
-
-	// restore gateway
+	// restore routes and gateways
+	n.mu.Lock()
+	n.staticRoutes = append(n.staticRoutes, routes...)
 	if len(gw) > 0 {
-		n.mu.Lock()
 		n.gw = gw
-		n.mu.Unlock()
 	}
-
 	if len(gw6) > 0 {
-		n.mu.Lock()
 		n.gwv6 = gw6
-		n.mu.Unlock()
 	}
-
+	n.mu.Unlock()
 	return nil
 }
 

--- a/libnetwork/osl/namespace_linux.go
+++ b/libnetwork/osl/namespace_linux.go
@@ -304,6 +304,8 @@ func createNamespaceFile(path string) error {
 
 	// wait for garbage collection to complete if it is in progress
 	// before trying to create the file.
+	//
+	// TODO(aker): This garbage-collection was for a kernel bug in kernels 3.18-4.0.1: is this still needed on current kernels (and on kernel 3.10)? see https://github.com/moby/moby/pull/46315/commits/c0a6beba8e61d4019e1806d5241ba22007072ca2#r1331327103
 	gpmWg.Wait()
 
 	f, err := os.Create(path)

--- a/libnetwork/osl/namespace_linux.go
+++ b/libnetwork/osl/namespace_linux.go
@@ -506,10 +506,6 @@ func (n *Namespace) Restore(interfaces map[Iface][]IfaceOption, routes []*types.
 			// due to the docker network connect/disconnect, so the dstName should
 			// restore from the namespace
 			for _, link := range links {
-				addresses, err := n.nlHandle.AddrList(link, netlink.FAMILY_V4)
-				if err != nil {
-					return err
-				}
 				ifaceName := link.Attrs().Name
 				if i.dstName == "vxlan" && strings.HasPrefix(ifaceName, "vxlan") {
 					i.dstName = ifaceName
@@ -517,6 +513,10 @@ func (n *Namespace) Restore(interfaces map[Iface][]IfaceOption, routes []*types.
 				}
 				// find the interface name by ip
 				if i.address != nil {
+					addresses, err := n.nlHandle.AddrList(link, netlink.FAMILY_V4)
+					if err != nil {
+						return err
+					}
 					for _, addr := range addresses {
 						if addr.IPNet.String() == i.address.String() {
 							i.dstName = ifaceName

--- a/libnetwork/osl/namespace_linux.go
+++ b/libnetwork/osl/namespace_linux.go
@@ -482,19 +482,9 @@ func (n *Namespace) Destroy() error {
 func (n *Namespace) Restore(interfaces map[Iface][]IfaceOption, routes []*types.StaticRoute, gw net.IP, gw6 net.IP) error {
 	// restore interfaces
 	for iface, opts := range interfaces {
-		i := &Interface{
-			srcName: iface.SrcName,
-			dstName: iface.DstPrefix,
-			ns:      n,
-		}
-		if err := i.processInterfaceOptions(opts...); err != nil {
+		i, err := newInterface(n, iface.SrcName, iface.DstPrefix, opts...)
+		if err != nil {
 			return err
-		}
-		if i.master != "" {
-			i.dstMaster = n.findDst(i.master, true)
-			if i.dstMaster == "" {
-				return fmt.Errorf("could not find an appropriate master %q for %q", i.master, i.srcName)
-			}
 		}
 		if n.isDefault {
 			i.dstName = i.srcName

--- a/libnetwork/osl/options_linux.go
+++ b/libnetwork/osl/options_linux.go
@@ -24,18 +24,6 @@ func WithFamily(family int) NeighOption {
 	}
 }
 
-func (i *Interface) processInterfaceOptions(options ...IfaceOption) error {
-	for _, opt := range options {
-		if opt != nil {
-			// TODO(thaJeztah): use multi-error instead of returning early.
-			if err := opt(i); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
 // WithIsBridge sets whether the interface is a bridge.
 func WithIsBridge(isBridge bool) IfaceOption {
 	return func(i *Interface) error {

--- a/libnetwork/osl/route_linux.go
+++ b/libnetwork/osl/route_linux.go
@@ -10,16 +10,16 @@ import (
 
 // Gateway returns the IPv4 gateway for the sandbox.
 func (n *Namespace) Gateway() net.IP {
-	n.Lock()
-	defer n.Unlock()
+	n.mu.Lock()
+	defer n.mu.Unlock()
 
 	return n.gw
 }
 
 // GatewayIPv6 returns the IPv6 gateway for the sandbox.
 func (n *Namespace) GatewayIPv6() net.IP {
-	n.Lock()
-	defer n.Unlock()
+	n.mu.Lock()
+	defer n.mu.Unlock()
 
 	return n.gwv6
 }
@@ -28,8 +28,8 @@ func (n *Namespace) GatewayIPv6() net.IP {
 // directly connected routes are stored on the particular interface they
 // refer to.
 func (n *Namespace) StaticRoutes() []*types.StaticRoute {
-	n.Lock()
-	defer n.Unlock()
+	n.mu.Lock()
+	defer n.mu.Unlock()
 
 	routes := make([]*types.StaticRoute, len(n.staticRoutes))
 	for i, route := range n.staticRoutes {
@@ -41,15 +41,15 @@ func (n *Namespace) StaticRoutes() []*types.StaticRoute {
 }
 
 func (n *Namespace) setGateway(gw net.IP) {
-	n.Lock()
+	n.mu.Lock()
 	n.gw = gw
-	n.Unlock()
+	n.mu.Unlock()
 }
 
 func (n *Namespace) setGatewayIPv6(gwv6 net.IP) {
-	n.Lock()
+	n.mu.Lock()
 	n.gwv6 = gwv6
-	n.Unlock()
+	n.mu.Unlock()
 }
 
 // SetGateway sets the default IPv4 gateway for the sandbox.
@@ -173,9 +173,9 @@ func (n *Namespace) UnsetGatewayIPv6() error {
 
 	err := n.programGateway(gwv6, false)
 	if err == nil {
-		n.Lock()
+		n.mu.Lock()
 		n.gwv6 = net.IP{}
-		n.Unlock()
+		n.mu.Unlock()
 	}
 
 	return err
@@ -185,9 +185,9 @@ func (n *Namespace) UnsetGatewayIPv6() error {
 func (n *Namespace) AddStaticRoute(r *types.StaticRoute) error {
 	err := n.programRoute(n.nsPath(), r.Destination, r.NextHop)
 	if err == nil {
-		n.Lock()
+		n.mu.Lock()
 		n.staticRoutes = append(n.staticRoutes, r)
-		n.Unlock()
+		n.mu.Unlock()
 	}
 	return err
 }
@@ -196,7 +196,7 @@ func (n *Namespace) AddStaticRoute(r *types.StaticRoute) error {
 func (n *Namespace) RemoveStaticRoute(r *types.StaticRoute) error {
 	err := n.removeRoute(n.nsPath(), r.Destination, r.NextHop)
 	if err == nil {
-		n.Lock()
+		n.mu.Lock()
 		lastIndex := len(n.staticRoutes) - 1
 		for i, v := range n.staticRoutes {
 			if v == r {
@@ -207,7 +207,7 @@ func (n *Namespace) RemoveStaticRoute(r *types.StaticRoute) error {
 				break
 			}
 		}
-		n.Unlock()
+		n.mu.Unlock()
 	}
 	return err
 }

--- a/libnetwork/osl/route_linux.go
+++ b/libnetwork/osl/route_linux.go
@@ -118,7 +118,7 @@ func (n *Namespace) programGateway(gw net.IP, isAdd bool) error {
 }
 
 // Program a route in to the namespace routing table.
-func (n *Namespace) programRoute(path string, dest *net.IPNet, nh net.IP) error {
+func (n *Namespace) programRoute(dest *net.IPNet, nh net.IP) error {
 	gwRoutes, err := n.nlHandle.RouteGet(nh)
 	if err != nil {
 		return fmt.Errorf("route for the next hop %s could not be found: %v", nh, err)
@@ -133,7 +133,7 @@ func (n *Namespace) programRoute(path string, dest *net.IPNet, nh net.IP) error 
 }
 
 // Delete a route from the namespace routing table.
-func (n *Namespace) removeRoute(path string, dest *net.IPNet, nh net.IP) error {
+func (n *Namespace) removeRoute(dest *net.IPNet, nh net.IP) error {
 	gwRoutes, err := n.nlHandle.RouteGet(nh)
 	if err != nil {
 		return fmt.Errorf("route for the next hop could not be found: %v", err)
@@ -183,7 +183,7 @@ func (n *Namespace) UnsetGatewayIPv6() error {
 
 // AddStaticRoute adds a static route to the sandbox.
 func (n *Namespace) AddStaticRoute(r *types.StaticRoute) error {
-	err := n.programRoute(n.nsPath(), r.Destination, r.NextHop)
+	err := n.programRoute(r.Destination, r.NextHop)
 	if err == nil {
 		n.mu.Lock()
 		n.staticRoutes = append(n.staticRoutes, r)
@@ -194,7 +194,7 @@ func (n *Namespace) AddStaticRoute(r *types.StaticRoute) error {
 
 // RemoveStaticRoute removes a static route from the sandbox.
 func (n *Namespace) RemoveStaticRoute(r *types.StaticRoute) error {
-	err := n.removeRoute(n.nsPath(), r.Destination, r.NextHop)
+	err := n.removeRoute(r.Destination, r.NextHop)
 	if err == nil {
 		n.mu.Lock()
 		lastIndex := len(n.staticRoutes) - 1

--- a/libnetwork/osl/route_linux.go
+++ b/libnetwork/osl/route_linux.go
@@ -40,18 +40,6 @@ func (n *Namespace) StaticRoutes() []*types.StaticRoute {
 	return routes
 }
 
-func (n *Namespace) setGateway(gw net.IP) {
-	n.mu.Lock()
-	n.gw = gw
-	n.mu.Unlock()
-}
-
-func (n *Namespace) setGatewayIPv6(gwv6 net.IP) {
-	n.mu.Lock()
-	n.gwv6 = gwv6
-	n.mu.Unlock()
-}
-
 // SetGateway sets the default IPv4 gateway for the sandbox. It is a no-op
 // if the given gateway is empty.
 func (n *Namespace) SetGateway(gw net.IP) error {
@@ -62,7 +50,9 @@ func (n *Namespace) SetGateway(gw net.IP) error {
 	if err := n.programGateway(gw, true); err != nil {
 		return err
 	}
-	n.setGateway(gw)
+	n.mu.Lock()
+	n.gw = gw
+	n.mu.Unlock()
 	return nil
 }
 
@@ -77,7 +67,9 @@ func (n *Namespace) UnsetGateway() error {
 	if err := n.programGateway(gw, false); err != nil {
 		return err
 	}
-	n.setGateway(net.IP{})
+	n.mu.Lock()
+	n.gw = net.IP{}
+	n.mu.Unlock()
 	return nil
 }
 
@@ -155,7 +147,9 @@ func (n *Namespace) SetGatewayIPv6(gwv6 net.IP) error {
 		return err
 	}
 
-	n.setGatewayIPv6(gwv6)
+	n.mu.Lock()
+	n.gwv6 = gwv6
+	n.mu.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
### libnetwork/osl: implement Namespace.RemoveInterface

Interface.Remove() was directly accessing Namespace "internals", such
as locking/unlocking. Move the code from Interface.Remove() into the
Namespace instead.

### libnetwork/osl: Namespace: make mutex private

Make the mutex internal to the Namespace; locking/unlocking should not
be done externally, and this makes it easier to see where it's used.

### libnetwork/osl: Namespace: programRoute, removeRoute rm path arg

Remove the argument, because it was not used.

### libnetwork/osl: Namespace: make error-handling more idiomatic

Check for non-nil errors (and return early) instead of the reverse.

### libnetwork/osl: Namespace: inline setGateway and setGatewayIPv6

They were not consistently used, and the locations where they were
used were already "setters", so we may as well inline the code.

Also updating Namespace.Restore to keep the lock slightly longer,
instead of locking/unlocking for each property individually, although
we should consider to keep the long for the duration of the whole
function to make it more atomic.


### libnetwork/osl: Namespace.Restore: rename vars for readability

### libnetwork/osl: Namespace.Restore: flatten nested conditions

Flatten some nested "if"-statements, and improve error.

Errors returned by this function are not handled, and only logged, so
make them more informative if debugging is needed.

### libnetwork/osl: Namespace.Restore: conditionally fetch IPs

We're only using the results if the interface doesn't have an address
yet, so skip this step if we don't use it.

### libnetwork/osl: make constructing Interfaces more atomic

It's still not "great", but implement a `newInterface()` constructor
to create a new Interface instance, instead of creating a partial
instance and applying "options" after the fact.




**- A picture of a cute animal (not mandatory but encouraged)**

