### PR TITLE
remove some remaining pre-go1.17 build-tags

### DIFF
--- a/daemon/graphdriver/copy/copy.go
+++ b/daemon/graphdriver/copy/copy.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package copy // import "github.com/docker/docker/daemon/graphdriver/copy"
 

--- a/daemon/graphdriver/copy/copy_test.go
+++ b/daemon/graphdriver/copy/copy_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package copy // import "github.com/docker/docker/daemon/graphdriver/copy"
 

--- a/daemon/graphdriver/overlayutils/overlayutils.go
+++ b/daemon/graphdriver/overlayutils/overlayutils.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package overlayutils // import "github.com/docker/docker/daemon/graphdriver/overlayutils"
 

--- a/daemon/graphdriver/overlayutils/randomid.go
+++ b/daemon/graphdriver/overlayutils/randomid.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package overlayutils // import "github.com/docker/docker/daemon/graphdriver/overlayutils"
 

--- a/daemon/graphdriver/overlayutils/userxattr.go
+++ b/daemon/graphdriver/overlayutils/userxattr.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Forked from https://github.com/containerd/containerd/blob/9ade247b38b5a685244e1391c86ff41ab109556e/snapshots/overlay/check.go
 /*

--- a/daemon/graphdriver/windows/windows.go
+++ b/daemon/graphdriver/windows/windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package windows // import "github.com/docker/docker/daemon/graphdriver/windows"
 

--- a/daemon/initlayer/setup_unix.go
+++ b/daemon/initlayer/setup_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package initlayer // import "github.com/docker/docker/daemon/initlayer"
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -1,5 +1,4 @@
 //go:build tools
-// +build tools
 
 // Package tools tracks dependencies on binaries not referenced in this codebase.
 // https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module

--- a/internal/unshare/unshare_linux.go
+++ b/internal/unshare/unshare_linux.go
@@ -1,5 +1,4 @@
 //go:build go1.10
-// +build go1.10
 
 package unshare // import "github.com/docker/docker/internal/unshare"
 

--- a/libnetwork/drivers/ipvlan/ipvlan.go
+++ b/libnetwork/drivers/ipvlan/ipvlan.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package ipvlan
 

--- a/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package ipvlan
 

--- a/libnetwork/drivers/ipvlan/ipvlan_joinleave.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_joinleave.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package ipvlan
 

--- a/libnetwork/drivers/ipvlan/ipvlan_network.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_network.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package ipvlan
 

--- a/libnetwork/drivers/ipvlan/ipvlan_setup.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_setup.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package ipvlan
 

--- a/libnetwork/drivers/ipvlan/ipvlan_setup_test.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_setup_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package ipvlan
 

--- a/libnetwork/drivers/ipvlan/ipvlan_state.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_state.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package ipvlan
 

--- a/libnetwork/drivers/ipvlan/ipvlan_store.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_store.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package ipvlan
 

--- a/libnetwork/drivers/ipvlan/ipvlan_test.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package ipvlan
 

--- a/libnetwork/drivers/macvlan/macvlan.go
+++ b/libnetwork/drivers/macvlan/macvlan.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package macvlan
 

--- a/libnetwork/drivers/macvlan/macvlan_endpoint.go
+++ b/libnetwork/drivers/macvlan/macvlan_endpoint.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package macvlan
 

--- a/libnetwork/drivers/macvlan/macvlan_joinleave.go
+++ b/libnetwork/drivers/macvlan/macvlan_joinleave.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package macvlan
 

--- a/libnetwork/drivers/macvlan/macvlan_network.go
+++ b/libnetwork/drivers/macvlan/macvlan_network.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package macvlan
 

--- a/libnetwork/drivers/macvlan/macvlan_setup.go
+++ b/libnetwork/drivers/macvlan/macvlan_setup.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package macvlan
 

--- a/libnetwork/drivers/macvlan/macvlan_setup_test.go
+++ b/libnetwork/drivers/macvlan/macvlan_setup_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package macvlan
 

--- a/libnetwork/drivers/macvlan/macvlan_state.go
+++ b/libnetwork/drivers/macvlan/macvlan_state.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package macvlan
 

--- a/libnetwork/drivers/macvlan/macvlan_store.go
+++ b/libnetwork/drivers/macvlan/macvlan_store.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package macvlan
 

--- a/libnetwork/drivers/macvlan/macvlan_test.go
+++ b/libnetwork/drivers/macvlan/macvlan_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package macvlan
 

--- a/libnetwork/iptables/conntrack.go
+++ b/libnetwork/iptables/conntrack.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package iptables
 

--- a/libnetwork/iptables/firewalld.go
+++ b/libnetwork/iptables/firewalld.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package iptables
 

--- a/libnetwork/iptables/firewalld_test.go
+++ b/libnetwork/iptables/firewalld_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package iptables
 

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package iptables
 

--- a/libnetwork/iptables/iptables_test.go
+++ b/libnetwork/iptables/iptables_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package iptables
 

--- a/pkg/loopback/attach_loopback.go
+++ b/pkg/loopback/attach_loopback.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package loopback // import "github.com/docker/docker/pkg/loopback"
 

--- a/pkg/loopback/loopback.go
+++ b/pkg/loopback/loopback.go
@@ -1,5 +1,4 @@
 //go:build linux && cgo
-// +build linux,cgo
 
 package loopback // import "github.com/docker/docker/pkg/loopback"
 

--- a/profiles/apparmor/apparmor.go
+++ b/profiles/apparmor/apparmor.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package apparmor // import "github.com/docker/docker/profiles/apparmor"
 

--- a/profiles/apparmor/template.go
+++ b/profiles/apparmor/template.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package apparmor // import "github.com/docker/docker/profiles/apparmor"
 


### PR DESCRIPTION
- relates to / follow-up to https://github.com/moby/moby/pull/45475

commit ab35df454d0666ef1214168938f952cc74c1d659 (https://github.com/moby/moby/pull/45475) removed most of the pre-go1.17 build-tags, but for some reason, "go fix" doesn't remove these, so removing the remaining ones manually


**- A picture of a cute animal (not mandatory but encouraged)**

