### PR TITLE
[24.0 backport] Dockerfile: Windows: update Golang download domains to cut down redirects

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -224,7 +224,7 @@ RUN `
   `
   Write-Host INFO: Downloading go...; `
   $dlGoVersion=$Env:GO_VERSION -replace '\.0$',''; `
-  Download-File "https://golang.org/dl/go${dlGoVersion}.windows-amd64.zip" C:\go.zip; `
+  Download-File "https://go.dev/dl/go${dlGoVersion}.windows-amd64.zip" C:\go.zip; `
   `
   Write-Host INFO: Downloading compiler 1 of 3...; `
   Download-File https://raw.githubusercontent.com/moby/docker-tdmgcc/master/gcc.zip C:\gcc.zip; `

--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -459,7 +459,7 @@ Try {
     if (-not $inContainer) { Verify-GoVersion }
 
     # Verify GOPATH is set
-    if ($env:GOPATH.Length -eq 0) { Throw "Missing GOPATH environment variable. See https://golang.org/doc/code.html#GOPATH" }
+    if ($env:GOPATH.Length -eq 0) { Throw "Missing GOPATH environment variable. See https://pkg.go.dev/cmd/go#hdr-GOPATH_environment_variable" }
 
     # Run autogen if building daemon.
     if ($Daemon) {

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -79,7 +79,7 @@ if [ "$AUTO_GOPATH" ]; then
 fi
 
 if [ ! "$GOPATH" ]; then
-	echo >&2 'error: missing GOPATH; please see https://golang.org/doc/code.html#GOPATH'
+	echo >&2 'error: missing GOPATH; please see https://pkg.go.dev/cmd/go#hdr-GOPATH_environment_variable'
 	echo >&2 '  alternatively, set AUTO_GOPATH=1'
 	exit 1
 fi


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/46324
- relates to https://github.com/moby/moby/pull/46069

---

### hack: update link to GOPATH documentation

This documentation moved to a different page, and the Go documentation
moved to the https://go.dev/ domain.

### Dockerfile: Windows: update Golang download domains to cut down redirects

The `golang.org` domain moved to `go.dev`, and the download-URLs we were
using resulted in 2 redirects;

    curl -sI https://golang.org/dl/go1.20.windows-amd64.zip | grep 'location'
    location: https://go.dev/dl/go1.20.windows-amd64.zip
    
    curl -sI https://go.dev/dl/go1.20.windows-amd64.zip | grep 'location'
    location: https://dl.google.com/go/go1.20.windows-amd64.zip
    
    curl -sI https://dl.google.com/go/go1.20.windows-amd64.zip
    HTTP/2 200
    # ...

This patch cuts it down to one redirects. I decided not to use the "final"
(`dl.google.com`) URL, because that URL is not documented in the Golang docs,
and visiting the domain itself (https://dl.google.com/) redirects to a marketing
page for "Google Chrome".

Trying the `/go/` path (https://dl.google.com/go/) also does not show a landing
page that lists downloads, so I'm considering those URLs to be "unstable".


**- A picture of a cute animal (not mandatory but encouraged)**

