### PR TITLE
hack, Dockerfile: remove devicemapper leftover,  build-tags, and libdevmapper-dev dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -555,7 +555,6 @@ RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,target=/var/lib/apt \
             pkg-config \
             dpkg-dev \
             libapparmor-dev \
-            libdevmapper-dev \
             libseccomp-dev \
             libsecret-1-dev \
             libsystemd-dev \
@@ -583,7 +582,6 @@ RUN --mount=type=cache,sharing=locked,id=moby-build-aptlib,target=/var/lib/apt \
             gcc \
             libapparmor-dev \
             libc6-dev \
-            libdevmapper-dev \
             libseccomp-dev \
             libsecret-1-dev \
             libsystemd-dev \

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -26,7 +26,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		cmake \
 		git \
 		libapparmor-dev \
-		libdevmapper-dev \
 		libseccomp-dev \
 		ca-certificates \
 		e2fsprogs \

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -84,22 +84,8 @@ if [ ! "$GOPATH" ]; then
 	exit 1
 fi
 
-# Adds $1_$2 to DOCKER_BUILDTAGS unless it already
-# contains a word starting from $1_
-add_buildtag() {
-	[[ " $DOCKER_BUILDTAGS" == *" $1_"* ]] || DOCKER_BUILDTAGS+=" $1_$2"
-}
-
 if ${PKG_CONFIG} 'libsystemd' 2> /dev/null; then
 	DOCKER_BUILDTAGS+=" journald"
-fi
-
-# test whether "libdevmapper.h" is new enough to support deferred remove
-# functionality. We favour libdm_dlsym_deferred_remove over
-# libdm_no_deferred_remove in dynamic cases because the binary could be shipped
-# with a newer libdevmapper than the one it was built with.
-if command -v gcc &> /dev/null && ! (echo -e '#include <libdevmapper.h>\nint main() { dm_task_deferred_remove(NULL); }' | gcc -xc - -o /dev/null $(${PKG_CONFIG} --libs devmapper 2> /dev/null) &> /dev/null); then
-	add_buildtag libdm dlsym_deferred_remove
 fi
 
 # Use these flags when compiling the tests and final binary

--- a/hack/test/unit
+++ b/hack/test/unit
@@ -12,7 +12,7 @@
 #
 set -eux -o pipefail
 
-BUILDFLAGS=(-tags 'netgo libdm_no_deferred_remove journald')
+BUILDFLAGS=(-tags 'netgo journald')
 TESTFLAGS+=" -test.timeout=${TIMEOUT:-5m}"
 TESTDIRS="${TESTDIRS:-./...}"
 exclude_paths='/vendor/|/integration'


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/35518
- relates to https://github.com/moby/moby/pull/43637
- relates to https://github.com/docker/docker-ce-packaging/issues/898


This check was added in 98fe4bd8f1e35f8e498e268f6### hack: remove devicemapper leftovers and build-tags

This check was added in 98fe4bd8f1e35f8e498e268f653a43cbfa31e751, to check
whether dm_task_deferred_remove could be removed, and to conditionally set
the corresponding build-tags. Now that the devicemapper graphdriver has been
removed in dc11d2a2d8e1df0a90ce289f5dd06cad38193073, we no longer need this.

This patch:

- removes uses of the (no longer used) `libdm`, `dlsym_deferred_remove`,
  and `libdm_no_deferred_remove` build-tags.
- removes the `add_buildtag` utility, which is now unused.


### Dockerfile: remove libdevmapper-dev

The devicemapper graphdriver has been removed in commit dc11d2a2d8e1df0a90ce289f5dd06cad38193073, and we should no longer need this.


**- A picture of a cute animal (not mandatory but encouraged)**

