### PR TITLE
daemon: clean up event handling-code, and remove some dead code

### DIFF
--- a/daemon/events.go
+++ b/daemon/events.go
@@ -145,27 +145,21 @@ func (daemon *Daemon) generateClusterEvent(msg *swarmapi.WatchMessage) {
 }
 
 func (daemon *Daemon) logNetworkEvent(action swarmapi.WatchActionKind, net *swarmapi.Network, oldNet *swarmapi.Network) {
-	attributes := map[string]string{
+	daemon.logClusterEvent(action, net.ID, events.NetworkEventType, eventTimestamp(net.Meta, action), map[string]string{
 		"name": net.Spec.Annotations.Name,
-	}
-	eventTime := eventTimestamp(net.Meta, action)
-	daemon.logClusterEvent(action, net.ID, "network", attributes, eventTime)
+	})
 }
 
 func (daemon *Daemon) logSecretEvent(action swarmapi.WatchActionKind, secret *swarmapi.Secret, oldSecret *swarmapi.Secret) {
-	attributes := map[string]string{
+	daemon.logClusterEvent(action, secret.ID, events.SecretEventType, eventTimestamp(secret.Meta, action), map[string]string{
 		"name": secret.Spec.Annotations.Name,
-	}
-	eventTime := eventTimestamp(secret.Meta, action)
-	daemon.logClusterEvent(action, secret.ID, "secret", attributes, eventTime)
+	})
 }
 
 func (daemon *Daemon) logConfigEvent(action swarmapi.WatchActionKind, config *swarmapi.Config, oldConfig *swarmapi.Config) {
-	attributes := map[string]string{
+	daemon.logClusterEvent(action, config.ID, events.ConfigEventType, eventTimestamp(config.Meta, action), map[string]string{
 		"name": config.Spec.Annotations.Name,
-	}
-	eventTime := eventTimestamp(config.Meta, action)
-	daemon.logClusterEvent(action, config.ID, "config", attributes, eventTime)
+	})
 }
 
 func (daemon *Daemon) logNodeEvent(action swarmapi.WatchActionKind, node *swarmapi.Node, oldNode *swarmapi.Node) {
@@ -210,7 +204,7 @@ func (daemon *Daemon) logNodeEvent(action swarmapi.WatchActionKind, node *swarma
 		}
 	}
 
-	daemon.logClusterEvent(action, node.ID, "node", attributes, eventTime)
+	daemon.logClusterEvent(action, node.ID, events.NodeEventType, eventTime, attributes)
 }
 
 func (daemon *Daemon) logServiceEvent(action swarmapi.WatchActionKind, service *swarmapi.Service, oldService *swarmapi.Service) {
@@ -257,7 +251,7 @@ func (daemon *Daemon) logServiceEvent(action swarmapi.WatchActionKind, service *
 			}
 		}
 	}
-	daemon.logClusterEvent(action, service.ID, "service", attributes, eventTime)
+	daemon.logClusterEvent(action, service.ID, events.ServiceEventType, eventTime, attributes)
 }
 
 var clusterEventAction = map[swarmapi.WatchActionKind]string{
@@ -266,7 +260,7 @@ var clusterEventAction = map[swarmapi.WatchActionKind]string{
 	swarmapi.WatchActionKindRemove: "remove",
 }
 
-func (daemon *Daemon) logClusterEvent(action swarmapi.WatchActionKind, id, eventType string, attributes map[string]string, eventTime time.Time) {
+func (daemon *Daemon) logClusterEvent(action swarmapi.WatchActionKind, id string, eventType events.Type, eventTime time.Time, attributes map[string]string) {
 	daemon.EventsService.PublishMessage(events.Message{
 		Action: clusterEventAction[action],
 		Type:   eventType,

--- a/daemon/events.go
+++ b/daemon/events.go
@@ -133,30 +133,30 @@ func (daemon *Daemon) generateClusterEvent(msg *swarmapi.WatchMessage) {
 		case *swarmapi.Object_Service:
 			daemon.logServiceEvent(event.Action, v.Service, event.OldObject.GetService())
 		case *swarmapi.Object_Network:
-			daemon.logNetworkEvent(event.Action, v.Network, event.OldObject.GetNetwork())
+			daemon.logNetworkEvent(event.Action, v.Network)
 		case *swarmapi.Object_Secret:
-			daemon.logSecretEvent(event.Action, v.Secret, event.OldObject.GetSecret())
+			daemon.logSecretEvent(event.Action, v.Secret)
 		case *swarmapi.Object_Config:
-			daemon.logConfigEvent(event.Action, v.Config, event.OldObject.GetConfig())
+			daemon.logConfigEvent(event.Action, v.Config)
 		default:
 			log.G(context.TODO()).Warnf("unrecognized event: %v", event)
 		}
 	}
 }
 
-func (daemon *Daemon) logNetworkEvent(action swarmapi.WatchActionKind, net *swarmapi.Network, oldNet *swarmapi.Network) {
+func (daemon *Daemon) logNetworkEvent(action swarmapi.WatchActionKind, net *swarmapi.Network) {
 	daemon.logClusterEvent(action, net.ID, events.NetworkEventType, eventTimestamp(net.Meta, action), map[string]string{
 		"name": net.Spec.Annotations.Name,
 	})
 }
 
-func (daemon *Daemon) logSecretEvent(action swarmapi.WatchActionKind, secret *swarmapi.Secret, oldSecret *swarmapi.Secret) {
+func (daemon *Daemon) logSecretEvent(action swarmapi.WatchActionKind, secret *swarmapi.Secret) {
 	daemon.logClusterEvent(action, secret.ID, events.SecretEventType, eventTimestamp(secret.Meta, action), map[string]string{
 		"name": secret.Spec.Annotations.Name,
 	})
 }
 
-func (daemon *Daemon) logConfigEvent(action swarmapi.WatchActionKind, config *swarmapi.Config, oldConfig *swarmapi.Config) {
+func (daemon *Daemon) logConfigEvent(action swarmapi.WatchActionKind, config *swarmapi.Config) {
 	daemon.logClusterEvent(action, config.ID, events.ConfigEventType, eventTimestamp(config.Meta, action), map[string]string{
 		"name": config.Spec.Annotations.Name,
 	})

--- a/daemon/events.go
+++ b/daemon/events.go
@@ -36,15 +36,9 @@ func (daemon *Daemon) LogContainerEventWithAttributes(container *container.Conta
 
 // LogPluginEvent generates an event related to a plugin with only the default attributes.
 func (daemon *Daemon) LogPluginEvent(pluginID, refName, action string) {
-	daemon.LogPluginEventWithAttributes(pluginID, refName, action, map[string]string{})
-}
-
-// LogPluginEventWithAttributes generates an event related to a plugin with specific given attributes.
-func (daemon *Daemon) LogPluginEventWithAttributes(pluginID, refName, action string, attributes map[string]string) {
-	attributes["name"] = refName
 	daemon.EventsService.Log(action, events.PluginEventType, events.Actor{
 		ID:         pluginID,
-		Attributes: attributes,
+		Attributes: map[string]string{"name": refName},
 	})
 }
 

--- a/daemon/events/events_test.go
+++ b/daemon/events/events_test.go
@@ -190,14 +190,14 @@ func TestLoadBufferedEvents(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	events := &Events{
+	evts := &Events{
 		events: []events.Message{*m1, *m2, *m3},
 	}
 
 	since := time.Unix(s, sNano)
 	until := time.Time{}
 
-	out := events.loadBufferedEvents(since, until, nil)
+	out := evts.loadBufferedEvents(since, until, nil)
 	if len(out) != 1 {
 		t.Fatalf("expected 1 message, got %d: %v", len(out), out)
 	}
@@ -236,19 +236,19 @@ func TestLoadBufferedEventsOnlyFromPast(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	events := &Events{
+	evts := &Events{
 		events: []events.Message{*m1, *m2, *m3},
 	}
 
 	since := time.Unix(s, sNano)
 	until := time.Unix(u, uNano)
 
-	out := events.loadBufferedEvents(since, until, nil)
+	out := evts.loadBufferedEvents(since, until, nil)
 	if len(out) != 1 {
 		t.Fatalf("expected 1 message, got %d: %v", len(out), out)
 	}
 
-	if out[0].Type != "network" {
+	if out[0].Type != events.NetworkEventType {
 		t.Fatalf("expected network event, got %s", out[0].Type)
 	}
 }
@@ -268,14 +268,14 @@ func TestIgnoreBufferedWhenNoTimes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	events := &Events{
+	evts := &Events{
 		events: []events.Message{*m1, *m2, *m3},
 	}
 
 	since := time.Time{}
 	until := time.Time{}
 
-	out := events.loadBufferedEvents(since, until, nil)
+	out := evts.loadBufferedEvents(since, until, nil)
 	if len(out) != 0 {
 		t.Fatalf("expected 0 buffered events, got %q", out)
 	}

--- a/integration/container/pause_test.go
+++ b/integration/container/pause_test.go
@@ -48,7 +48,7 @@ func TestPause(t *testing.T) {
 	messages, errs := apiClient.Events(ctx, types.EventsOptions{
 		Since:   since,
 		Until:   until,
-		Filters: filters.NewArgs(filters.Arg("container", cID)),
+		Filters: filters.NewArgs(filters.Arg(events.ContainerEventType, cID)),
 	})
 	assert.Check(t, is.DeepEqual([]string{"pause", "unpause"}, getEventActions(t, messages, errs)))
 }

--- a/integration/system/event_test.go
+++ b/integration/system/event_test.go
@@ -60,7 +60,7 @@ func TestEventsExecDie(t *testing.T) {
 
 	select {
 	case m := <-msg:
-		assert.Equal(t, m.Type, "container")
+		assert.Equal(t, m.Type, events.ContainerEventType)
 		assert.Equal(t, m.Actor.ID, cID)
 		assert.Equal(t, m.Action, "exec_die")
 		assert.Equal(t, m.Actor.Attributes["execID"], id.ID)


### PR DESCRIPTION
### daemon: inline some vars when producing events

Also moves the clusterEventAction closer to where it's used.

### daemon: daemon.logClusterEvent: use events.Type for event-types

Also swapping the order of arguments; putting the "attributes" arguments
last, so that variables can be more cleanly inlined.

### daemon: logNetworkEvent, logSecretEvent, logConfigEvent rm unused args

### daemon: remove LogPluginEventWithAttributes as it's not used



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

