### PR TITLE
rename uses of "max", "min", which are now builtins in go1.21

### DIFF
--- a/api/types/versions/compare.go
+++ b/api/types/versions/compare.go
@@ -16,11 +16,11 @@ func compare(v1, v2 string) int {
 		otherTab = strings.Split(v2, ".")
 	)
 
-	max := len(currTab)
-	if len(otherTab) > max {
-		max = len(otherTab)
+	maxVer := len(currTab)
+	if len(otherTab) > maxVer {
+		maxVer = len(otherTab)
 	}
-	for i := 0; i < max; i++ {
+	for i := 0; i < maxVer; i++ {
 		var currInt, otherInt int
 
 		if len(currTab) > i {

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -406,7 +406,7 @@ func (b *limitedBuffer) Write(data []byte) (int, error) {
 
 	bufLen := b.buf.Len()
 	dataLen := len(data)
-	keep := min(maxOutputLen-bufLen, dataLen)
+	keep := minInt(maxOutputLen-bufLen, dataLen)
 	if keep > 0 {
 		b.buf.Write(data[:keep])
 	}
@@ -436,7 +436,7 @@ func timeoutWithDefault(configuredValue time.Duration, defaultValue time.Duratio
 	return configuredValue
 }
 
-func min(x, y int) int {
+func minInt(x, y int) int {
 	if x < y {
 		return x
 	}

--- a/daemon/images/image_windows.go
+++ b/daemon/images/image_windows.go
@@ -18,8 +18,8 @@ func (i *ImageService) GetContainerLayerSize(ctx context.Context, containerID st
 // GetLayerFolders returns the layer folders from an image RootFS
 func (i *ImageService) GetLayerFolders(img *image.Image, rwLayer layer.RWLayer) ([]string, error) {
 	folders := []string{}
-	max := len(img.RootFS.DiffIDs)
-	for index := 1; index <= max; index++ {
+	rd := len(img.RootFS.DiffIDs)
+	for index := 1; index <= rd; index++ {
 		// FIXME: why does this mutate the RootFS?
 		img.RootFS.DiffIDs = img.RootFS.DiffIDs[:index]
 		if !system.IsOSSupported(img.OperatingSystem()) {

--- a/pkg/archive/changes_test.go
+++ b/pkg/archive/changes_test.go
@@ -21,7 +21,7 @@ import (
 	"gotest.tools/v3/skip"
 )
 
-func max(x, y int) int {
+func maxInt(x, y int) int {
 	if x >= y {
 		return x
 	}
@@ -404,7 +404,7 @@ func TestChangesDirsMutated(t *testing.T) {
 		{filepath.FromSlash("/symlinknew"), ChangeAdd},
 	}...)
 
-	for i := 0; i < max(len(changes), len(expectedChanges)); i++ {
+	for i := 0; i < maxInt(len(changes), len(expectedChanges)); i++ {
 		if i >= len(expectedChanges) {
 			t.Fatalf("unexpected change %s\n", changes[i].String())
 		}
@@ -530,7 +530,7 @@ func checkChanges(expectedChanges, changes []Change, t *testing.T) {
 	skip.If(t, runtime.GOOS != "windows" && os.Getuid() != 0, "skipping test that requires root")
 	sort.Sort(changesByPath(expectedChanges))
 	sort.Sort(changesByPath(changes))
-	for i := 0; i < max(len(changes), len(expectedChanges)); i++ {
+	for i := 0; i < maxInt(len(changes), len(expectedChanges)); i++ {
 		if i >= len(expectedChanges) {
 			t.Fatalf("unexpected change %s\n", changes[i].String())
 		}

--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -239,13 +239,13 @@ func (c *Client) callWithRetry(serviceMethod string, data io.Reader, retry bool,
 }
 
 func backoff(retries int) time.Duration {
-	b, max := 1, defaultTimeOut
-	for b < max && retries > 0 {
+	b, maxTimeout := 1, defaultTimeOut
+	for b < maxTimeout && retries > 0 {
 		b *= 2
 		retries--
 	}
-	if b > max {
-		b = max
+	if b > maxTimeout {
+		b = maxTimeout
 	}
 	return time.Duration(b) * time.Second
 }

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -151,13 +151,13 @@ func isCpusetListAvailable(provided, available string) (bool, error) {
 	}
 	// 8192 is the normal maximum number of CPUs in Linux, so accept numbers up to this
 	// or more if we actually have more CPUs.
-	max := 8192
+	maxCPUs := 8192
 	for m := range parsedAvailable {
-		if m > max {
-			max = m
+		if m > maxCPUs {
+			maxCPUs = m
 		}
 	}
-	parsedProvided, err := parsers.ParseUintListMaximum(provided, max)
+	parsedProvided, err := parsers.ParseUintListMaximum(provided, maxCPUs)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/tailfile/tailfile_test.go
+++ b/pkg/tailfile/tailfile_test.go
@@ -209,9 +209,9 @@ func TestNewTailReader(t *testing.T) {
 					test := test
 					t.Parallel()
 
-					max := len(test.data)
-					if max > 10 {
-						max = 10
+					maxLen := len(test.data)
+					if maxLen > 10 {
+						maxLen = 10
 					}
 
 					s := strings.Join(test.data, string(delim))
@@ -219,7 +219,7 @@ func TestNewTailReader(t *testing.T) {
 						s += string(delim)
 					}
 
-					for i := 1; i <= max; i++ {
+					for i := 1; i <= maxLen; i++ {
 						t.Run(fmt.Sprintf("%d lines", i), func(t *testing.T) {
 							i := i
 							t.Parallel()

--- a/restartmanager/restartmanager.go
+++ b/restartmanager/restartmanager.go
@@ -86,7 +86,7 @@ func (rm *RestartManager) ShouldRestart(exitCode uint32, hasBeenManuallyStopped 
 		restart = true
 	case rm.policy.IsOnFailure():
 		// the default value of 0 for MaximumRetryCount means that we will not enforce a maximum count
-		if max := rm.policy.MaximumRetryCount; max == 0 || rm.restartCount < max {
+		if maxRetryCount := rm.policy.MaximumRetryCount; maxRetryCount == 0 || rm.restartCount < maxRetryCount {
 			restart = exitCode != 0
 		}
 	}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/46069

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

