### PR TITLE
Update example in README.md to close cli object (carry 46292)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -483,6 +483,8 @@ Milind Chawre <milindchawre@gmail.com>
 Misty Stanley-Jones <misty@docker.com> <misty@apache.org>
 Mohammad Banikazemi <MBanikazemi@gmail.com>
 Mohammad Banikazemi <MBanikazemi@gmail.com> <mb@us.ibm.com>
+Mohd Sadiq <mohdsadiq058@gmail.com> <mohdsadiq058@gmail.com>
+Mohd Sadiq <mohdsadiq058@gmail.com> <42430865+msadiq058@users.noreply.github.com">
 Mohit Soni <mosoni@ebay.com> <mohitsoni1989@gmail.com>
 Moorthy RS <rsmoorthy@gmail.com> <rsmoorthy@users.noreply.github.com>
 Moysés Borges <moysesb@gmail.com>

--- a/client/README.md
+++ b/client/README.md
@@ -20,6 +20,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	defer cli.Close()
 
 	containers, err := cli.ContainerList(context.Background(), types.ContainerListOptions{})
 	if err != nil {


### PR DESCRIPTION
- rebase of https://github.com/moby/moby/pull/46292, which pulled in some foreign commits
- supersedes / closes https://github.com/moby/moby/pull/46292


**- A picture of a cute animal (not mandatory but encouraged)**

