### PR TITLE
libnetwork/drivers/remote: tests: cleanup dead code, and return concrete types

### DIFF
--- a/libnetwork/drivers/remote/driver.go
+++ b/libnetwork/drivers/remote/driver.go
@@ -169,8 +169,7 @@ func (d *driver) CreateNetwork(id string, options map[string]interface{}, nInfo 
 }
 
 func (d *driver) DeleteNetwork(nid string) error {
-	delete := &api.DeleteNetworkRequest{NetworkID: nid}
-	return d.call("DeleteNetwork", delete, &api.DeleteNetworkResponse{})
+	return d.call("DeleteNetwork", &api.DeleteNetworkRequest{NetworkID: nid}, &api.DeleteNetworkResponse{})
 }
 
 func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {

--- a/libnetwork/drivers/remote/driver_test.go
+++ b/libnetwork/drivers/remote/driver_test.go
@@ -546,7 +546,7 @@ func TestMissingValues(t *testing.T) {
 
 type rollbackEndpoint struct{}
 
-func (r *rollbackEndpoint) Interface() driverapi.InterfaceInfo {
+func (r *rollbackEndpoint) Interface() *rollbackEndpoint {
 	return r
 }
 

--- a/libnetwork/drivers/remote/driver_test.go
+++ b/libnetwork/drivers/remote/driver_test.go
@@ -95,10 +95,6 @@ type testEndpoint struct {
 	disableGatewayService bool
 }
 
-func (test *testEndpoint) Interface() driverapi.InterfaceInfo {
-	return test
-}
-
 func (test *testEndpoint) Address() *net.IPNet {
 	if test.address == "" {
 		return nil


### PR DESCRIPTION
### libnetwork/drivers/remote: remove unused testEndpoint.Interface

### libnetwork/drivers/remote: driver.DeleteNetwork: remove var that collided

`delete` is a builtin

### libnetwork/drivers/remote: rollbackEndpoint.Interface: return concrete type

Interface-matching should generally happen on the receiver side, and this
function was only used in a single location, and passed as argument to
Driver.CreateEndpoint, which already matches the interface by accepting
a driverapi.InterfaceInfo.



**- A picture of a cute animal (not mandatory but encouraged)**

