### PR TITLE
libnetwork: remove Endpoint.Interface()

### DIFF
--- a/libnetwork/endpoint_info.go
+++ b/libnetwork/endpoint_info.go
@@ -203,23 +203,13 @@ func (ep *Endpoint) Info() EndpointInfo {
 func (ep *Endpoint) Iface() *EndpointInterface {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
-
-	if ep.iface != nil {
-		return ep.iface
-	}
-
-	return nil
+	return ep.iface
 }
 
 func (ep *Endpoint) Interface() driverapi.InterfaceInfo {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
-
-	if ep.iface != nil {
-		return ep.iface
-	}
-
-	return nil
+	return ep.iface
 }
 
 // SetMacAddress allows the driver to set the mac address to the endpoint interface

--- a/libnetwork/endpoint_info.go
+++ b/libnetwork/endpoint_info.go
@@ -206,12 +206,6 @@ func (ep *Endpoint) Iface() *EndpointInterface {
 	return ep.iface
 }
 
-func (ep *Endpoint) Interface() driverapi.InterfaceInfo {
-	ep.mu.Lock()
-	defer ep.mu.Unlock()
-	return ep.iface
-}
-
 // SetMacAddress allows the driver to set the mac address to the endpoint interface
 // during the call to CreateEndpoint, if the mac address is not already set.
 func (epi *EndpointInterface) SetMacAddress(mac net.HardwareAddr) error {

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1085,7 +1085,7 @@ func (n *Network) addEndpoint(ep *Endpoint) error {
 		return fmt.Errorf("failed to add endpoint: %v", err)
 	}
 
-	err = d.CreateEndpoint(n.id, ep.id, ep.Interface(), ep.generic)
+	err = d.CreateEndpoint(n.id, ep.id, ep.Iface(), ep.generic)
 	if err != nil {
 		return types.InternalErrorf("failed to create endpoint %s on network %s: %v",
 			ep.Name(), n.Name(), err)


### PR DESCRIPTION
### libnetwork: Endpoint.Iface, Endpoint.Interface remove redundant "if"

### libnetwork: remove Endpoint.Interface

This method is not part of any interface, and identical to Endpoint.Iface,
but one returns an Interface-type (driverapi.InterfaceInfo) and the other
returns a concrete type (EndpointInterface).

Interface-matching should generally happen on the receiver side, and this
function was only used in a single location, and passed as argument to
Driver.CreateEndpoint, which already matches the interface by accepting
a driverapi.InterfaceInfo.


**- A picture of a cute animal (not mandatory but encouraged)**

