### PR TITLE
libnetwork: node-discovery: fix error-handling, and some refactor

### DIFF
--- a/libnetwork/agent.go
+++ b/libnetwork/agent.go
@@ -846,9 +846,8 @@ func (n *Network) handleDriverTableEvent(ev events.Event) {
 
 func (c *Controller) handleNodeTableEvent(ev events.Event) {
 	var (
-		value    []byte
-		isAdd    bool
-		nodeAddr networkdb.NodeAddr
+		value []byte
+		isAdd bool
 	)
 	switch event := ev.(type) {
 	case networkdb.CreateEvent:
@@ -860,22 +859,20 @@ func (c *Controller) handleNodeTableEvent(ev events.Event) {
 		log.G(context.TODO()).Errorf("Unexpected update node table event = %#v", event)
 	}
 
-	err := json.Unmarshal(value, &nodeAddr)
+	var node networkdb.NodeAddr
+	err := json.Unmarshal(value, &node)
 	if err != nil {
 		log.G(context.TODO()).Errorf("Error unmarshalling node table event %v", err)
 		return
 	}
-	c.processNodeDiscovery([]net.IP{nodeAddr.Addr}, isAdd)
+	c.processNodeDiscovery([]net.IP{node.Addr}, isAdd)
 }
 
 func (c *Controller) handleEpTableEvent(ev events.Event) {
 	var (
-		nid   string
-		eid   string
-		value []byte
-		epRec EndpointRecord
+		nid, eid string
+		value    []byte
 	)
-
 	switch event := ev.(type) {
 	case networkdb.CreateEvent:
 		nid = event.NetworkID
@@ -894,6 +891,7 @@ func (c *Controller) handleEpTableEvent(ev events.Event) {
 		return
 	}
 
+	var epRec EndpointRecord
 	err := proto.Unmarshal(value, &epRec)
 	if err != nil {
 		log.G(context.TODO()).Errorf("Failed to unmarshal service table value: %v", err)

--- a/libnetwork/agent.go
+++ b/libnetwork/agent.go
@@ -869,7 +869,11 @@ func (c *Controller) handleNodeTableEvent(ev events.Event) {
 		log.G(context.TODO()).Errorf("Error unmarshalling node table %s event %v", evtType, err)
 		return
 	}
-	c.processNodeDiscovery([]net.IP{node.Addr}, isAdd)
+	if node.Addr == nil {
+		log.G(context.TODO()).Warnf("received an empty IP-address when handling node table %s event", evtType)
+		return
+	}
+	c.processNodeDiscovery(node.Addr, isAdd)
 }
 
 func (c *Controller) handleEpTableEvent(ev events.Event) {

--- a/libnetwork/agent.go
+++ b/libnetwork/agent.go
@@ -846,15 +846,18 @@ func (n *Network) handleDriverTableEvent(ev events.Event) {
 
 func (c *Controller) handleNodeTableEvent(ev events.Event) {
 	var (
-		value []byte
-		isAdd bool
+		value   []byte
+		isAdd   bool
+		evtType string
 	)
 	switch event := ev.(type) {
 	case networkdb.CreateEvent:
 		value = event.Value
 		isAdd = true
+		evtType = "create"
 	case networkdb.DeleteEvent:
 		value = event.Value
+		evtType = "delete"
 	case networkdb.UpdateEvent:
 		log.G(context.TODO()).Errorf("Unexpected update node table event = %#v", event)
 		return
@@ -863,7 +866,7 @@ func (c *Controller) handleNodeTableEvent(ev events.Event) {
 	var node networkdb.NodeAddr
 	err := json.Unmarshal(value, &node)
 	if err != nil {
-		log.G(context.TODO()).Errorf("Error unmarshalling node table event %v", err)
+		log.G(context.TODO()).Errorf("Error unmarshalling node table %s event %v", evtType, err)
 		return
 	}
 	c.processNodeDiscovery([]net.IP{node.Addr}, isAdd)

--- a/libnetwork/agent.go
+++ b/libnetwork/agent.go
@@ -857,6 +857,7 @@ func (c *Controller) handleNodeTableEvent(ev events.Event) {
 		value = event.Value
 	case networkdb.UpdateEvent:
 		log.G(context.TODO()).Errorf("Unexpected update node table event = %#v", event)
+		return
 	}
 
 	var node networkdb.NodeAddr

--- a/libnetwork/agent.go
+++ b/libnetwork/agent.go
@@ -831,32 +831,17 @@ func (n *Network) handleDriverTableEvent(ev events.Event) {
 		return
 	}
 
-	var (
-		etype driverapi.EventType
-		tname string
-		key   string
-		value []byte
-	)
-
 	switch event := ev.(type) {
 	case networkdb.CreateEvent:
-		tname = event.Table
-		key = event.Key
-		value = event.Value
-		etype = driverapi.Create
+		d.EventNotify(driverapi.Create, n.ID(), event.Table, event.Key, event.Value)
 	case networkdb.DeleteEvent:
-		tname = event.Table
-		key = event.Key
-		value = event.Value
-		etype = driverapi.Delete
+		d.EventNotify(driverapi.Delete, n.ID(), event.Table, event.Key, event.Value)
 	case networkdb.UpdateEvent:
-		tname = event.Table
-		key = event.Key
-		value = event.Value
-		etype = driverapi.Delete
+		// TODO(thaJeztah): is it intentional for an "networkdb.UpdateEvent" event to send a "driverapi.Delete" notification?
+		d.EventNotify(driverapi.Delete, n.ID(), event.Table, event.Key, event.Value)
+	default:
+		log.G(context.TODO()).Debugf("Network.handleDriverTableEvent: unhandled table event %v (%[1]T) for driver %s", ev, n.networkType)
 	}
-
-	d.EventNotify(etype, n.ID(), tname, key, value)
 }
 
 func (c *Controller) handleNodeTableEvent(ev events.Event) {

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -396,16 +396,14 @@ func (c *Controller) processNodeDiscovery(nodes []net.IP, add bool) {
 }
 
 func (c *Controller) pushNodeDiscovery(d discoverapi.Discover, capability driverapi.Capability, nodes []net.IP, add bool) {
+	if d == nil || capability.ConnectivityScope != scope.Global || nodes == nil {
+		return
+	}
 	var self net.IP
 	// try swarm-mode config
 	if agent := c.getAgent(); agent != nil {
 		self = net.ParseIP(agent.advertiseAddr)
 	}
-
-	if d == nil || capability.ConnectivityScope != scope.Global || nodes == nil {
-		return
-	}
-
 	for _, node := range nodes {
 		nodeData := discoverapi.NodeDiscoveryData{Address: node.String(), Self: node.Equal(self)}
 		var err error

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -386,17 +386,17 @@ func (c *Controller) BuiltinIPAMDrivers() []string {
 	return drivers
 }
 
-func (c *Controller) processNodeDiscovery(nodes []net.IP, add bool) {
+func (c *Controller) processNodeDiscovery(nodeAddress net.IP, add bool) {
 	c.drvRegistry.WalkDrivers(func(name string, driver driverapi.Driver, capability driverapi.Capability) bool {
 		if d, ok := driver.(discoverapi.Discover); ok {
-			c.pushNodeDiscovery(d, capability, nodes, add)
+			c.pushNodeDiscovery(d, capability, nodeAddress, add)
 		}
 		return false
 	})
 }
 
-func (c *Controller) pushNodeDiscovery(d discoverapi.Discover, capability driverapi.Capability, nodes []net.IP, add bool) {
-	if d == nil || capability.ConnectivityScope != scope.Global || nodes == nil {
+func (c *Controller) pushNodeDiscovery(d discoverapi.Discover, capability driverapi.Capability, nodeAddress net.IP, add bool) {
+	if d == nil || capability.ConnectivityScope != scope.Global || nodeAddress == nil {
 		return
 	}
 	var self net.IP
@@ -404,17 +404,15 @@ func (c *Controller) pushNodeDiscovery(d discoverapi.Discover, capability driver
 	if agent := c.getAgent(); agent != nil {
 		self = net.ParseIP(agent.advertiseAddr)
 	}
-	for _, node := range nodes {
-		nodeData := discoverapi.NodeDiscoveryData{Address: node.String(), Self: node.Equal(self)}
-		var err error
-		if add {
-			err = d.DiscoverNew(discoverapi.NodeDiscovery, nodeData)
-		} else {
-			err = d.DiscoverDelete(discoverapi.NodeDiscovery, nodeData)
-		}
-		if err != nil {
-			log.G(context.TODO()).Debugf("discovery notification error: %v", err)
-		}
+	nodeData := discoverapi.NodeDiscoveryData{Address: nodeAddress.String(), Self: nodeAddress.Equal(self)}
+	var err error
+	if add {
+		err = d.DiscoverNew(discoverapi.NodeDiscovery, nodeData)
+	} else {
+		err = d.DiscoverDelete(discoverapi.NodeDiscovery, nodeData)
+	}
+	if err != nil {
+		log.G(context.TODO()).Debugf("discovery notification error: %v", err)
 	}
 }
 

--- a/libnetwork/networkdb/delegate.go
+++ b/libnetwork/networkdb/delegate.go
@@ -230,7 +230,13 @@ func (nDB *NetworkDB) handleTableEvent(tEvent *TableEvent, isBulkSync bool) bool
 		op = driverapi.Delete
 	}
 
-	nDB.broadcaster.Write(makeEvent(op, tEvent.TableName, tEvent.NetworkID, tEvent.Key, tEvent.Value))
+	_ = nDB.broadcaster.Write(Event{
+		Type:      op,
+		Table:     tEvent.TableName,
+		NetworkID: tEvent.NetworkID,
+		Key:       tEvent.Key,
+		Value:     tEvent.Value,
+	})
 	return network.inSync
 }
 

--- a/libnetwork/networkdb/delegate.go
+++ b/libnetwork/networkdb/delegate.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/gogo/protobuf/proto"
 )
 
@@ -219,14 +220,14 @@ func (nDB *NetworkDB) handleTableEvent(tEvent *TableEvent, isBulkSync bool) bool
 		return network.inSync && e.reapTime > nDB.config.reapEntryInterval/6
 	}
 
-	var op opType
+	var op driverapi.EventType
 	switch tEvent.Type {
 	case TableEventTypeCreate:
-		op = opCreate
+		op = driverapi.Create
 	case TableEventTypeUpdate:
-		op = opUpdate
+		op = driverapi.Update
 	case TableEventTypeDelete:
-		op = opDelete
+		op = driverapi.Delete
 	}
 
 	nDB.broadcaster.Write(makeEvent(op, tEvent.TableName, tEvent.NetworkID, tEvent.Key, tEvent.Value))

--- a/libnetwork/networkdb/event_delegate.go
+++ b/libnetwork/networkdb/event_delegate.go
@@ -20,7 +20,11 @@ func (e *eventDelegate) broadcastNodeEvent(addr net.IP, op driverapi.EventType) 
 	if err != nil {
 		return fmt.Errorf("error marshalling node broadcast event %s", addr.String())
 	}
-	return e.nDB.broadcaster.Write(makeEvent(op, NodeTable, "", "", value))
+	return e.nDB.broadcaster.Write(Event{
+		Type:  op,
+		Table: NodeTable,
+		Value: value,
+	})
 }
 
 func (e *eventDelegate) NotifyJoin(mn *memberlist.Node) {

--- a/libnetwork/networkdb/networkdb.go
+++ b/libnetwork/networkdb/networkdb.go
@@ -550,7 +550,13 @@ func (nDB *NetworkDB) deleteNodeNetworkEntries(nid, node string) {
 
 			// Notify to the upper layer only entries not already marked for deletion
 			if !oldEntry.deleting {
-				nDB.broadcaster.Write(makeEvent(driverapi.Delete, tname, nid, key, entry.value))
+				_ = nDB.broadcaster.Write(Event{
+					Type:      driverapi.Delete,
+					Table:     tname,
+					NetworkID: nid,
+					Key:       key,
+					Value:     entry.value,
+				})
 			}
 			return false
 		})
@@ -571,7 +577,13 @@ func (nDB *NetworkDB) deleteNodeTableEntries(node string) {
 		nDB.deleteEntry(nid, tname, key)
 
 		if !oldEntry.deleting {
-			nDB.broadcaster.Write(makeEvent(driverapi.Delete, tname, nid, key, oldEntry.value))
+			_ = nDB.broadcaster.Write(Event{
+				Type:      driverapi.Delete,
+				Table:     tname,
+				NetworkID: nid,
+				Key:       key,
+				Value:     oldEntry.value,
+			})
 		}
 		return false
 	})

--- a/libnetwork/networkdb/networkdb.go
+++ b/libnetwork/networkdb/networkdb.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/go-events"
@@ -549,7 +550,7 @@ func (nDB *NetworkDB) deleteNodeNetworkEntries(nid, node string) {
 
 			// Notify to the upper layer only entries not already marked for deletion
 			if !oldEntry.deleting {
-				nDB.broadcaster.Write(makeEvent(opDelete, tname, nid, key, entry.value))
+				nDB.broadcaster.Write(makeEvent(driverapi.Delete, tname, nid, key, entry.value))
 			}
 			return false
 		})
@@ -570,7 +571,7 @@ func (nDB *NetworkDB) deleteNodeTableEntries(node string) {
 		nDB.deleteEntry(nid, tname, key)
 
 		if !oldEntry.deleting {
-			nDB.broadcaster.Write(makeEvent(opDelete, tname, nid, key, oldEntry.value))
+			nDB.broadcaster.Write(makeEvent(driverapi.Delete, tname, nid, key, oldEntry.value))
 		}
 		return false
 	})

--- a/libnetwork/networkdb/watch.go
+++ b/libnetwork/networkdb/watch.go
@@ -85,18 +85,3 @@ func (nDB *NetworkDB) Watch(tname, nid string) (*events.Channel, func()) {
 		sink.Close()
 	}
 }
-
-func makeEvent(op driverapi.EventType, tname, nid, key string, value []byte) events.Event {
-	switch op {
-	case driverapi.Create, driverapi.Update, driverapi.Delete:
-		return Event{
-			Type:      op,
-			Table:     tname,
-			NetworkID: nid,
-			Key:       key,
-			Value:     value,
-		}
-	default:
-		return nil
-	}
-}

--- a/libnetwork/networkdb/watch.go
+++ b/libnetwork/networkdb/watch.go
@@ -3,15 +3,8 @@ package networkdb
 import (
 	"net"
 
+	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/go-events"
-)
-
-type opType uint8
-
-const (
-	opCreate opType = 1 + iota
-	opUpdate
-	opDelete
 )
 
 type event struct {
@@ -85,7 +78,7 @@ func (nDB *NetworkDB) Watch(tname, nid string) (*events.Channel, func()) {
 	}
 }
 
-func makeEvent(op opType, tname, nid, key string, value []byte) events.Event {
+func makeEvent(op driverapi.EventType, tname, nid, key string, value []byte) events.Event {
 	ev := event{
 		Table:     tname,
 		NetworkID: nid,
@@ -94,11 +87,11 @@ func makeEvent(op opType, tname, nid, key string, value []byte) events.Event {
 	}
 
 	switch op {
-	case opCreate:
+	case driverapi.Create:
 		return CreateEvent(ev)
-	case opUpdate:
+	case driverapi.Update:
 		return UpdateEvent(ev)
-	case opDelete:
+	case driverapi.Delete:
 		return DeleteEvent(ev)
 	}
 


### PR DESCRIPTION
### libnetwork: handleDriverTableEvent: reduce some duplication

I guess the attempt here was to not duplicate code, but in doing so,
there was actually more code-duplication than necessary.


### libnetwork: Controller.handleNodeTableEvent, handleEpTableEvent move vars

move variables closer to where they're used, and rename them where appropriate.

### libnetwork: Controller.handleNodeTableEvent: skip networkdb.UpdateEvent

Controller.handleNodeTableEvent was logging an error if it would handle
a `networkdb.UpdateEvent`, however, the function would still continue
processing the event, and attempt to unmarshal an empty `[]byte` to a
`networkdb.NodeAddr` (resulting in an `unexpected end of JSON input` error).

If it _would_ proceed (i.e., if the unmarshal would not error), it would;

- call `Controller.processNodeDiscovery` (with an empty list of IPs)
- which would iterate over all registered drivers, calling `Controller.pushNodeDiscovery`
  for drivers that implement `discoverapi.Discover`.
- ultimately ending up in `Controller.pushNodeDiscovery` returning early
  because no IPs were provided.

Based on the above, it looks like returning early here is the right thing
to do.

### libnetwork: Controller.pushNodeDiscovery: return early

Skip fetching the agent and parsing its IP-address if we don't use it.

### libnetwork: Controller.handleNodeTableEvent: log event-type in errors

Allow discovering what kind of event was received if an error occurs.

### libnetwork: Controller.pushNodeDiscovery: take single IP, ignore nil

The signature to take multiple addresses originates in [libnetwork/188][1]
("Libnetwork Host Discovery using Swarm Discovery pkg), which initially
had a `diff` function as part of the `hostdiscovery` package, which would
produce a list of changes in IP-addresses (added, removed).

Discovery with external k/v stores was removed, and the `hostdiscovery`
package was removed in 00f9b23c3ae1614b648e9da1c6423c381f58153e (https://github.com/moby/moby/pull/42247), and
current code always pass a single IP-address (if any).

The Controller.pushNodeDiscovery method contained a check whether the
passed list of node-addresses was nil, however, this was never the
case because `Controller.handleNodeTableEvent` would unconditionally
[initialize a slice][2] (even if the event had a `nil` IP-address).

In case of a `nil` IP-address, this address would be;

- compared with the agent's advertiseAddr to determine if this is `self`
- encoded as a string, and sent as `NodeDiscoveryData.Address`. This string
  would be a literal `"<nil>"`.

While I don't know if there's other implementations that treat this information
different, looking at the [overlay implementation of `driver.DiscoverNew`][3],
it would check the field to be an empty string, and otherwise produce an
error (which wouldn't apply if it contained `"<nil>"`), and set the
driver's advertiseAddress to this value, effectively un-setting it
(`net.ParseIP()` silently ignores invalid values), or producing an error
(`netip.ParseAddr()` will error).

For completeness: `driver.DiscoverDelete` has no implementation in the
overlay driver, but both `driver.DiscoverNew` and `driver.DiscoverDelete`
are both implemented by the `remote` driver, which sends them to the
remote "as-is", so it will depend on the receiving end to handle.

So based on the overlay implementation, my assumption is that an empty
node-address should be considered _invalid_ (both for `DiscoverDelete`
and `DiscoverNew`), so let's return early if we encounter one, but log
a warning to discover cases where this happened.

[1]: https://github.com/moby/libnetwork/commit/ac4d7b61367e34ac341c2171d70d8b6a0a0fbecf
[2]: https://github.com/moby/moby/blob/5b53ddfcdd1c0721f875d3e237078ab7de891a57/libnetwork/agent.go#L905
[3]: https://github.com/moby/moby/blob/5b53ddfcdd1c0721f875d3e237078ab7de891a57/libnetwork/drivers/overlay/overlay.go#L92-L97


**- A picture of a cute animal (not mandatory but encouraged)**

