### PR TITLE
libnetwork: rewrite Network.isClusterEligible to return agent

### DIFF
--- a/libnetwork/agent.go
+++ b/libnetwork/agent.go
@@ -214,9 +214,8 @@ func (c *Controller) handleKeyChange(keys []*types.EncryptionKey) error {
 
 func (c *Controller) agentSetup(clusterProvider cluster.Provider) error {
 	agent := c.getAgent()
-
-	// If the agent is already present there is no need to try to initialize it again
 	if agent != nil {
+		// agent is already present, so there is no need initialize it again.
 		return nil
 	}
 
@@ -235,7 +234,7 @@ func (c *Controller) agentSetup(clusterProvider cluster.Provider) error {
 
 	log.G(context.TODO()).Infof("Initializing Libnetwork Agent Listen-Addr=%s Local-addr=%s Adv-addr=%s Data-addr=%s Remote-addr-list=%v MTU=%d",
 		listenAddr, bindAddr, advAddr, dataAddr, remoteAddrList, c.Config().NetworkControlPlaneMTU)
-	if advAddr != "" && agent == nil {
+	if advAddr != "" {
 		if err := c.agentInit(listenAddr, bindAddr, advAddr, dataAddr); err != nil {
 			log.G(context.TODO()).Errorf("error in agentInit: %v", err)
 			return err


### PR DESCRIPTION
### libnetwork: Controller.agentSetup: remove redundant condition

The function returns at the start if there agent is non-nil.

### libnetwork: Controller.agentSetup: use structured logs

### libnetwork: Endpoint: return early if no agent was found

This removes redundant nil-checks in Endpoint.deleteServiceInfoFromCluster
and Endpoint.addServiceInfoToCluster.

These functions return early if the network is not ["cluster eligible"][1],
and the function used for that (`Network.isClusterEligible`) requires the
[agent to not be `nil`][2].

This check moved around a few times ([3][3], [4][4]), but was originally
added in [libnetwork 1570][5] which, among others, tried to avoid a nil-pointer
exception reported in [moby 28712][6], which accessed the `Controller.agent`
[without locking][7]. That issue was addressed by adding locks, adding a
`Controller.getAgent` accessor, and updating deleteServiceInfoFromCluster
to use a local var. It also sprinkled this `nil` check to be on the safe
side, but as `Network.isClusterEligible` already checks for the agent
to not be `nil`, this should not be redundant.

[1]: https://github.com/moby/moby/blob/5b53ddfcdd1c0721f875d3e237078ab7de891a57/libnetwork/agent.go#L529-L534
[2]: https://github.com/moby/moby/blob/5b53ddfcdd1c0721f875d3e237078ab7de891a57/libnetwork/agent.go#L688-L696
[3]: https://github.com/moby/libnetwork/commit/f2307265c77fd6db5d92310857c3ffad1184ad24
[4]: https://github.com/moby/libnetwork/commit/6426d1e66f33c0b0c8bb135b7ee547447f54d043
[5]: https://github.com/moby/libnetwork/commit/8dcf9960aa81767376e580f20d9ecea3e68f62ad
[6]: https://github.com/moby/moby/issues/28712
[7]: https://github.com/moby/moby/blob/75fd88ba8938f120ce1f2a21b19cf13c12071b16/vendor/github.com/docker/libnetwork/agent.go#L452


### libnetwork: rewrite Network.isClusterEligible to return agent

This function was used to check if the network is a multi-host, swarm-scoped
network. Part of this check involved a check whether the cluster-agent was
present.

In all places where this function was used, the next step after checking if
the network was "cluster eligible", was to get the agent, and (again) check
if it was not nil.

This patch rewrites the isClusterEligible utility into a clusterAgent utility,
which both checks if the network is cluster-eligible, and returns the agent
(if set). For convenience, an "ok" bool is added, which callers can use to
return early (although just checking for nilness would likely have been
sufficient).


libnetwork: Controller.handleDriverTableEvent: reduce some duplication

I guess the attempt here was to not duplicate code, but in doing so,
there was actually more code-duplication than necessary.


**- A picture of a cute animal (not mandatory but encouraged)**

