### PR TITLE
Dockerfile: update crun binary to v1.8.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -381,7 +381,7 @@ FROM binary-dummy AS rootlesskit-windows
 FROM rootlesskit-${TARGETOS} AS rootlesskit
 
 FROM base AS crun
-ARG CRUN_VERSION=1.4.5
+ARG CRUN_VERSION=1.8.7
 RUN --mount=type=cache,sharing=locked,id=moby-crun-aptlib,target=/var/lib/apt \
     --mount=type=cache,sharing=locked,id=moby-crun-aptcache,target=/var/cache/apt \
         apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
- relates to https://github.com/moby/moby/commit/5045a2de24e62095278bd10b7abce4153d713b2a / https://github.com/moby/moby/pull/45278


Updating the version of crun that we use in our tests to a version that supports the "features" command (crun v1.8.6 and up). This should prevent some warnings in our logs:

    WARN[2023-08-26T17:05:35.042978552Z] Failed to run [/usr/local/bin/crun features]: "unknown command features\n"  error="exit status 1"

full diff: https://github.com/containers/crun/compare/1.4.5...1.8.7

**- A picture of a cute animal (not mandatory but encouraged)**

