### PR TITLE
api/types/events: make events.Type an actual type

### DIFF
--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -1,7 +1,7 @@
 package events // import "github.com/docker/docker/api/types/events"
 
 // Type is used for event-types.
-type Type = string
+type Type string
 
 // List of known event types.
 const (

--- a/client/events_test.go
+++ b/client/events_test.go
@@ -60,7 +60,7 @@ func TestEventsErrorFromServer(t *testing.T) {
 func TestEvents(t *testing.T) {
 	const expectedURL = "/events"
 
-	fltrs := filters.NewArgs(filters.Arg("type", events.ContainerEventType))
+	fltrs := filters.NewArgs(filters.Arg("type", string(events.ContainerEventType)))
 	expectedFiltersJSON := fmt.Sprintf(`{"type":{"%s":true}}`, events.ContainerEventType)
 
 	eventsCases := []struct {

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -722,7 +722,7 @@ func (c *containerConfig) applyPrivileges(hc *enginecontainer.HostConfig) {
 
 func (c *containerConfig) eventFilter() filters.Args {
 	return filters.NewArgs(
-		filters.Arg("type", events.ContainerEventType),
+		filters.Arg("type", string(events.ContainerEventType)),
 		filters.Arg("name", c.name()),
 		filters.Arg("label", fmt.Sprintf("%v.task.id=%v", systemLabelPrefix, c.task.ID)),
 	)

--- a/daemon/events/filter.go
+++ b/daemon/events/filter.go
@@ -19,7 +19,7 @@ func NewFilter(filter filters.Args) *Filter {
 // Include returns true when the event ev is included by the filters
 func (ef *Filter) Include(ev events.Message) bool {
 	return ef.matchEvent(ev) &&
-		ef.filter.ExactMatch("type", ev.Type) &&
+		ef.filter.ExactMatch("type", string(ev.Type)) &&
 		ef.matchScope(ev.Scope) &&
 		ef.matchDaemon(ev) &&
 		ef.matchContainer(ev) &&
@@ -103,8 +103,7 @@ func (ef *Filter) matchConfig(ev events.Message) bool {
 }
 
 func (ef *Filter) fuzzyMatchName(ev events.Message, eventType events.Type) bool {
-	return ef.filter.FuzzyMatch(eventType, ev.Actor.ID) ||
-		ef.filter.FuzzyMatch(eventType, ev.Actor.Attributes["name"])
+	return ef.filter.FuzzyMatch(string(eventType), ev.Actor.ID) || ef.filter.FuzzyMatch(string(eventType), ev.Actor.Attributes["name"])
 }
 
 // matchImage matches against both event.Actor.ID (for image events)

--- a/daemon/events/testutils/testutils.go
+++ b/daemon/events/testutils/testutils.go
@@ -65,7 +65,7 @@ func Scan(text string) (*events.Message, error) {
 	return &events.Message{
 		Time:     t,
 		TimeNano: time.Unix(t, tn).UnixNano(),
-		Type:     md["eventType"],
+		Type:     events.Type(md["eventType"]),
 		Action:   md["action"],
 		Actor: events.Actor{
 			ID:         md["id"],

--- a/integration/container/pause_test.go
+++ b/integration/container/pause_test.go
@@ -48,7 +48,7 @@ func TestPause(t *testing.T) {
 	messages, errs := apiClient.Events(ctx, types.EventsOptions{
 		Since:   since,
 		Until:   until,
-		Filters: filters.NewArgs(filters.Arg(events.ContainerEventType, cID)),
+		Filters: filters.NewArgs(filters.Arg(string(events.ContainerEventType), cID)),
 	})
 	assert.Check(t, is.DeepEqual([]string{"pause", "unpause"}, getEventActions(t, messages, errs)))
 }


### PR DESCRIPTION
- [x] follow-up to / depends on https://github.com/moby/moby/pull/46338
- relates to / follow-up to https://github.com/moby/moby/pull/42770

### api/types/events: make events.Type an actual type

This type was added in 247f4796d21d98909974410ff27b61233776ae3a (https://github.com/moby/moby/pull/42770), and
at the time was added as an alias for string;

> api/types/events: add "Type" type for event-type enum
>
> Currently just an alias for string, but we can change it to be an
> actual type.

Now that all code uses the defined types, we should be able to make
this an actual type.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

