### PR TITLE
daemon/containerd: Replace pkg/errors with std errors

### DIFF
--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -2,6 +2,7 @@ package containerd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -24,7 +25,6 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -271,7 +271,7 @@ func (i *ImageService) resolveImage(ctx context.Context, refOrID string) (contai
 	if ok {
 		imgs, err := is.List(ctx, "target.digest=="+digested.Digest().String())
 		if err != nil {
-			return containerdimages.Image{}, errors.Wrap(err, "failed to lookup digest")
+			return containerdimages.Image{}, fmt.Errorf("failed to lookup digest: %w", err)
 		}
 		if len(imgs) == 0 {
 			return containerdimages.Image{}, images.ErrImageDoesNotExist{Ref: parsed}

--- a/daemon/containerd/image_exporter.go
+++ b/daemon/containerd/image_exporter.go
@@ -2,6 +2,7 @@ package containerd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -20,7 +21,6 @@ import (
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 func (i *ImageService) PerformWithBaseFS(ctx context.Context, c *container.Container, fn func(root string) error) error {
@@ -212,7 +212,7 @@ func (i *ImageService) LoadImage(ctx context.Context, inTar io.ReadCloser, outSt
 			return nil
 		})
 		if err != nil {
-			return errors.Wrap(err, "failed to unpack loaded image")
+			return fmt.Errorf("failed to unpack loaded image: %w", err)
 		}
 
 		fmt.Fprintf(progress, "%s: %s\n", loadedMsg, name)

--- a/daemon/containerd/image_history.go
+++ b/daemon/containerd/image_history.go
@@ -2,6 +2,7 @@ package containerd
 
 import (
 	"context"
+	"errors"
 	"sort"
 
 	cplatforms "github.com/containerd/containerd/platforms"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/docker/pkg/platforms"
 	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 // ImageHistory returns a slice of HistoryResponseItem structures for the

--- a/daemon/containerd/image_manifest.go
+++ b/daemon/containerd/image_manifest.go
@@ -3,6 +3,7 @@ package containerd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/moby/buildkit/util/attestation"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 var (

--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -2,6 +2,7 @@ package containerd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -21,7 +22,6 @@ import (
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -130,7 +130,7 @@ func (i *ImageService) PushImage(ctx context.Context, targetRef reference.Named,
 		if err != nil {
 			// This shouldn't happen at this point because the reference would have to be invalid
 			// and if it was, then it would error out earlier.
-			return errdefs.Unknown(errors.Wrap(err, "failed to create an handler that appends distribution source label to pushed content"))
+			return errdefs.Unknown(fmt.Errorf("failed to create an handler that appends distribution source label to pushed content: %w", err))
 		}
 
 		if err := containerdimages.Dispatch(ctx, appendSource, nil, target); err != nil {
@@ -165,7 +165,7 @@ func findMissingMountable(ctx context.Context, store content.Store, queue *jobs,
 		_, err := store.Info(ctx, desc.Digest)
 		if err != nil {
 			if !cerrdefs.IsNotFound(err) {
-				return nil, errdefs.System(errors.Wrapf(err, "failed to get metadata of content %s", desc.Digest.String()))
+				return nil, errdefs.System(fmt.Errorf("failed to get metadata of content %s: %w", desc.Digest.String(), err))
 			}
 
 			for _, source := range sources {

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -2,6 +2,7 @@ package containerd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 
@@ -21,7 +22,6 @@ import (
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/registry"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 // ImageService implements daemon.ImageService
@@ -163,7 +163,7 @@ func (i *ImageService) GetContainerLayerSize(ctx context.Context, containerID st
 		if cerrdefs.IsNotFound(err) {
 			return 0, 0, errdefs.NotFound(fmt.Errorf("rw layer snapshot not found for container %s", containerID))
 		}
-		return 0, 0, errdefs.System(errors.Wrapf(err, "snapshotter.Usage failed for %s", containerID))
+		return 0, 0, errdefs.System(fmt.Errorf("snapshotter.Usage failed for %s: %w", containerID, err))
 	}
 
 	unpackedUsage, err := calculateSnapshotParentUsage(ctx, snapshotter, containerID)

--- a/daemon/containerd/soft_delete.go
+++ b/daemon/containerd/soft_delete.go
@@ -2,13 +2,13 @@ package containerd
 
 import (
 	"context"
+	"fmt"
 
 	cerrdefs "github.com/containerd/containerd/errdefs"
 	containerdimages "github.com/containerd/containerd/images"
 	"github.com/docker/docker/errdefs"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 // softImageDelete deletes the image, making sure that there are other images
@@ -22,7 +22,7 @@ func (i *ImageService) softImageDelete(ctx context.Context, img containerdimages
 	dgst := img.Target.Digest.String()
 	imgs, err := is.List(ctx, "target.digest=="+dgst)
 	if err != nil {
-		return errdefs.System(errors.Wrapf(err, "failed to check if there are images targeting digest %s", dgst))
+		return errdefs.System(fmt.Errorf("failed to check if there are images targeting digest %s: %w", dgst, err))
 	}
 
 	// From this point explicitly ignore the passed context
@@ -34,8 +34,8 @@ func (i *ImageService) softImageDelete(ctx context.Context, img containerdimages
 
 		// Error out in case we couldn't persist the old image.
 		if err != nil {
-			return errdefs.System(errors.Wrapf(err, "failed to create a dangling image for the replaced image %s with digest %s",
-				img.Name, img.Target.Digest.String()))
+			return errdefs.System(fmt.Errorf("failed to create a dangling image for the replaced image %s with digest %s: %w",
+				img.Name, img.Target.Digest.String(), err))
 		}
 	}
 
@@ -43,7 +43,7 @@ func (i *ImageService) softImageDelete(ctx context.Context, img containerdimages
 	err = is.Delete(context.Background(), img.Name)
 	if err != nil {
 		if !cerrdefs.IsNotFound(err) {
-			return errdefs.System(errors.Wrapf(err, "failed to delete image %s which existed a moment before", img.Name))
+			return errdefs.System(fmt.Errorf("failed to delete image %s which existed a moment before: %w", img.Name, err))
 		}
 	}
 


### PR DESCRIPTION
**- What I did**
Replaced `errors.Wrap` with `fmt.Errorf`

**- How I did it**

**- How to verify it**

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

