### PR TITLE
daemon/events; fix TestLoadBufferedEventsOnlyFromPast

### DIFF
--- a/daemon/events/events_test.go
+++ b/daemon/events/events_test.go
@@ -200,7 +200,7 @@ func TestLoadBufferedEventsOnlyFromPast(t *testing.T) {
 
 	messages := evts.loadBufferedEvents(since, until, nil)
 	assert.Assert(t, is.Len(messages, 1))
-	assert.Check(t, is.Equal(messages[0].Type, "network"))
+	assert.Check(t, is.Equal(messages[0].Type, events.NetworkEventType))
 }
 
 // Regression-test for https://github.com/moby/moby/issues/13753


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/46350


commit 70ad5b818fa94891d0778daba2f830e5ca6382a7 changed event.Type to be a strong type, no longer an alias for string. for some reason, this test passed on the PR, but failed later on;

    === Failed
    === FAIL: daemon/events TestLoadBufferedEventsOnlyFromPast (0.00s)
        events_test.go:203: assertion failed: network (messages[0].Type events.Type) != network (string)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

