### PR TITLE
registry: simplify `trimV1Address`

### DIFF
--- a/registry/endpoint_test.go
+++ b/registry/endpoint_test.go
@@ -42,7 +42,7 @@ func TestV1EndpointParse(t *testing.T) {
 		},
 		{
 			address:     "https://0.0.0.0:5000/v2/",
-			expectedErr: "unsupported V1 version path v2",
+			expectedErr: "search is not supported on v2 endpoints: https://0.0.0.0:5000/v2/",
 		},
 	}
 	for _, tc := range tests {

--- a/registry/endpoint_v1.go
+++ b/registry/endpoint_v1.go
@@ -82,23 +82,14 @@ func validateEndpoint(endpoint *v1Endpoint) error {
 	return nil
 }
 
-// trimV1Address trims the version off the address and returns the
-// trimmed address or an error if there is a non-V1 version.
+// trimV1Address trims the "v1" version suffix off the address and returns
+// the trimmed address. It returns an error on "v2" endpoints.
 func trimV1Address(address string) (string, error) {
-	address = strings.TrimSuffix(address, "/")
-	chunks := strings.Split(address, "/")
-	apiVersionStr := chunks[len(chunks)-1]
-	if apiVersionStr == "v1" {
-		return strings.Join(chunks[:len(chunks)-1], "/"), nil
+	trimmed := strings.TrimSuffix(address, "/")
+	if strings.HasSuffix(trimmed, "/v2") {
+		return "", invalidParamf("unsupported V1 version path v2")
 	}
-
-	for k, v := range apiVersions {
-		if k != APIVersion1 && apiVersionStr == v {
-			return "", invalidParamf("unsupported V1 version path %s", apiVersionStr)
-		}
-	}
-
-	return address, nil
+	return strings.TrimSuffix(trimmed, "/v1"), nil
 }
 
 func newV1EndpointFromStr(address string, tlsConfig *tls.Config, headers http.Header) (*v1Endpoint, error) {

--- a/registry/endpoint_v1.go
+++ b/registry/endpoint_v1.go
@@ -87,7 +87,7 @@ func validateEndpoint(endpoint *v1Endpoint) error {
 func trimV1Address(address string) (string, error) {
 	trimmed := strings.TrimSuffix(address, "/")
 	if strings.HasSuffix(trimmed, "/v2") {
-		return "", invalidParamf("unsupported V1 version path v2")
+		return "", invalidParamf("search is not supported on v2 endpoints: %s", address)
 	}
 	return strings.TrimSuffix(trimmed, "/v1"), nil
 }


### PR DESCRIPTION
### registry: combine TestEndpointParse and TestEndpointParseInvalid

Combine the two tests into a TestV1EndpointParse function, and rewrite
them to use gotest.tools for asserting.

Also changing the test-cases to use "https://", as the scheme doesn't
matter for this test, but using "http://" may trip-up some linters,
so let's avoid that.

### registry: simplify `trimV1Address`

First, remove the loop over `apiVersions`. The `apiVersions` map has two
entries (`APIVersion1 => "v1"`, and `APIVersion2 => "v2"`), and `APIVersion1`
is skipped, which means that the loop effectively translates to;

    if apiVersionStr == "v2" {
        return "", invalidParamf("unsupported V1 version path %s", apiVersionStr)
    }

Which leaves us with "anything else" being returned as-is.

This patch removes the loop, and replaces the remaining handling to check
for the "v2" suffix to produce an error, or to strip the "v1" suffix.

### registry: improve error for invalid search endpoints

Explain that search is not supported on v2 endpoints, and include the
offending endpoint in the error-message.




**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

