### PR TITLE
registry: deprecate APIEndpoint.Version and APIVersion type

### DIFF
--- a/distribution/pull_v2_test.go
+++ b/distribution/pull_v2_test.go
@@ -331,7 +331,6 @@ func testNewPuller(t *testing.T, rawurl string) *puller {
 	endpoint := registry.APIEndpoint{
 		Mirror:       false,
 		URL:          uri,
-		Version:      registry.APIVersion2,
 		Official:     false,
 		TrimHostname: false,
 		TLSConfig:    nil,

--- a/distribution/push_v2_test.go
+++ b/distribution/push_v2_test.go
@@ -534,9 +534,8 @@ func TestWhenEmptyAuthConfig(t *testing.T) {
 			endpoint: registrypkg.APIEndpoint{
 				URL: &url.URL{
 					Scheme: "https",
-					Host:   "index.docker.io",
+					Host:   registrypkg.IndexHostname,
 				},
-				Version:      registrypkg.APIVersion2,
 				TrimHostname: true,
 			},
 		}

--- a/distribution/registry_unit_test.go
+++ b/distribution/registry_unit_test.go
@@ -43,7 +43,6 @@ func testTokenPassThru(t *testing.T, ts *httptest.Server) {
 	endpoint := registrypkg.APIEndpoint{
 		Mirror:       false,
 		URL:          uri,
-		Version:      registrypkg.APIVersion2,
 		Official:     false,
 		TrimHostname: false,
 		TLSConfig:    nil,

--- a/registry/service.go
+++ b/registry/service.go
@@ -115,7 +115,7 @@ func (s *Service) ResolveRepository(name reference.Named) (*RepositoryInfo, erro
 type APIEndpoint struct {
 	Mirror                         bool
 	URL                            *url.URL
-	Version                        APIVersion
+	Version                        APIVersion // Deprecated: v1 registries are deprecated, and endpoints are always v2.
 	AllowNondistributableArtifacts bool
 	Official                       bool
 	TrimHostname                   bool

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -25,7 +25,7 @@ func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, e
 			}
 			endpoints = append(endpoints, APIEndpoint{
 				URL:          mirrorURL,
-				Version:      APIVersion2,
+				Version:      APIVersion2, //nolint:staticcheck // ignore SA1019 (Version is deprecated) to allow potential consumers to transition.
 				Mirror:       true,
 				TrimHostname: true,
 				TLSConfig:    mirrorTLSConfig,
@@ -33,7 +33,7 @@ func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, e
 		}
 		endpoints = append(endpoints, APIEndpoint{
 			URL:          DefaultV2Registry,
-			Version:      APIVersion2,
+			Version:      APIVersion2, //nolint:staticcheck // ignore SA1019 (Version is deprecated) to allow potential consumers to transition.
 			Official:     true,
 			TrimHostname: true,
 			TLSConfig:    tlsconfig.ServerDefault(),
@@ -55,7 +55,7 @@ func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, e
 				Scheme: "https",
 				Host:   hostname,
 			},
-			Version:                        APIVersion2,
+			Version:                        APIVersion2, //nolint:staticcheck // ignore SA1019 (Version is deprecated) to allow potential consumers to transition.
 			AllowNondistributableArtifacts: ana,
 			TrimHostname:                   true,
 			TLSConfig:                      tlsConfig,
@@ -68,7 +68,7 @@ func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, e
 				Scheme: "http",
 				Host:   hostname,
 			},
-			Version:                        APIVersion2,
+			Version:                        APIVersion2, //nolint:staticcheck // ignore SA1019 (Version is deprecated) to allow potential consumers to transition.
 			AllowNondistributableArtifacts: ana,
 			TrimHostname:                   true,
 			// used to check if supposed to be secure via InsecureSkipVerify

--- a/registry/types.go
+++ b/registry/types.go
@@ -7,6 +7,8 @@ import (
 
 // APIVersion is an integral representation of an API version (presently
 // either 1 or 2)
+//
+// Deprecated: v1 registries are deprecated, and endpoints are always v2.
 type APIVersion int
 
 func (av APIVersion) String() string {
@@ -15,8 +17,8 @@ func (av APIVersion) String() string {
 
 // API Version identifiers.
 const (
-	APIVersion1 APIVersion = 1
-	APIVersion2 APIVersion = 2
+	APIVersion1 APIVersion = 1 // Deprecated: v1 registries are deprecated, and endpoints are always v2.
+	APIVersion2 APIVersion = 2 // Deprecated: v1 registries are deprecated, and endpoints are always v2.
 )
 
 var apiVersions = map[APIVersion]string{


### PR DESCRIPTION
This field was used when the code supported both "v1" and "v2" registries. We no longer support v1 registries, and the only v1 endpoint that's still used is for the legacy "search" endpoint, which does not use the APIEndpoint type.

As no code is using this field, and the value will always be set to "v2", we can deprecated the Version field.

I'm keeping this field for 1 release, to give notice to any potential external consumer, after which we can delete it.

**- A picture of a cute animal (not mandatory but encouraged)**

