### PR TITLE
errdefs: remove gotest.tools dependency and remove some redundant import comments

### DIFF
--- a/errdefs/defs.go
+++ b/errdefs/defs.go
@@ -1,4 +1,4 @@
-package errdefs // import "github.com/docker/docker/errdefs"
+package errdefs
 
 // ErrNotFound signals that the requested object doesn't exist
 type ErrNotFound interface {

--- a/errdefs/helpers.go
+++ b/errdefs/helpers.go
@@ -1,4 +1,4 @@
-package errdefs // import "github.com/docker/docker/errdefs"
+package errdefs
 
 import "context"
 

--- a/errdefs/helpers_test.go
+++ b/errdefs/helpers_test.go
@@ -1,4 +1,4 @@
-package errdefs // import "github.com/docker/docker/errdefs"
+package errdefs
 
 import (
 	"errors"

--- a/errdefs/http_helpers.go
+++ b/errdefs/http_helpers.go
@@ -1,4 +1,4 @@
-package errdefs // import "github.com/docker/docker/errdefs"
+package errdefs
 
 import (
 	"net/http"

--- a/errdefs/http_helpers_test.go
+++ b/errdefs/http_helpers_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-
-	"gotest.tools/v3/assert"
 )
 
 func TestFromStatusCode(t *testing.T) {
@@ -86,7 +84,9 @@ func TestFromStatusCode(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(http.StatusText(tc.status), func(t *testing.T) {
 			err := FromStatusCode(tc.err, tc.status)
-			assert.Check(t, tc.check(err), "unexpected error-type %T", err)
+			if !tc.check(err) {
+				t.Errorf("unexpected error-type %T", err)
+			}
 		})
 	}
 }

--- a/errdefs/is.go
+++ b/errdefs/is.go
@@ -1,4 +1,4 @@
-package errdefs // import "github.com/docker/docker/errdefs"
+package errdefs
 
 type causer interface {
 	Cause() error


### PR DESCRIPTION
### errdefs: remove gotest.tools dependency

It was only used in a single test, and was not using any of the gotest.tools features, so let's remove it as dependency.

With this, the package has no external dependencies (only stdlib).

### errdefs: remove redundant import comments

A package only needs one "import" comment to enforce, so keeping one in the go.doc.

It should be noted that even with that; in most cases, go will ignore these comments (if go modules are used, even in "vendor" mode).

**- A picture of a cute animal (not mandatory but encouraged)**

