### PR TITLE
image/spec: Add Go structs

### DIFF
--- a/api/types/container/config.go
+++ b/api/types/container/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/strslice"
+	dockerspec "github.com/docker/docker/image/spec/specs-go/v1"
 	"github.com/docker/go-connections/nat"
 )
 
@@ -33,26 +34,7 @@ type StopOptions struct {
 }
 
 // HealthConfig holds configuration settings for the HEALTHCHECK feature.
-type HealthConfig struct {
-	// Test is the test to perform to check that the container is healthy.
-	// An empty slice means to inherit the default.
-	// The options are:
-	// {} : inherit healthcheck
-	// {"NONE"} : disable healthcheck
-	// {"CMD", args...} : exec arguments directly
-	// {"CMD-SHELL", command} : run command with system's default shell
-	Test []string `json:",omitempty"`
-
-	// Zero means to inherit. Durations are expressed as integer nanoseconds.
-	Interval      time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
-	Timeout       time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
-	StartPeriod   time.Duration `json:",omitempty"` // The start period for the container to initialize before the retries starts to count down.
-	StartInterval time.Duration `json:",omitempty"` // The interval to attempt healthchecks at during the start period
-
-	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
-	// Zero means inherit.
-	Retries int `json:",omitempty"`
-}
+type HealthConfig = dockerspec.HealthcheckConfig
 
 // ExecStartOptions holds the options to start container's exec.
 type ExecStartOptions struct {

--- a/image/spec/specs-go/v1/image.go
+++ b/image/spec/specs-go/v1/image.go
@@ -1,0 +1,54 @@
+package v1
+
+import (
+	"time"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+const DockerOCIImageMediaType = "application/vnd.docker.container.image.v1+json"
+
+// DockerOCIImage is a ocispec.Image extended with Docker specific Config.
+type DockerOCIImage struct {
+	ocispec.Image
+
+	// Shadow ocispec.Image.Config
+	Config DockerOCIImageConfig `json:"config,omitempty"`
+}
+
+// DockerOCIImageConfig is a ocispec.ImageConfig extended with Docker specific fields.
+type DockerOCIImageConfig struct {
+	ocispec.ImageConfig
+
+	DockerOCIImageConfigExt
+}
+
+// DockerOCIImageConfigExt contains Docker-specific fields in DockerImageConfig.
+type DockerOCIImageConfigExt struct {
+	Healthcheck *HealthcheckConfig `json:",omitempty"` // Healthcheck describes how to check the container is healthy
+
+	OnBuild []string `json:",omitempty"` // ONBUILD metadata that were defined on the image Dockerfile
+	Shell   []string `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
+}
+
+// HealthcheckConfig holds configuration settings for the HEALTHCHECK feature.
+type HealthcheckConfig struct {
+	// Test is the test to perform to check that the container is healthy.
+	// An empty slice means to inherit the default.
+	// The options are:
+	// {} : inherit healthcheck
+	// {"NONE"} : disable healthcheck
+	// {"CMD", args...} : exec arguments directly
+	// {"CMD-SHELL", command} : run command with system's default shell
+	Test []string `json:",omitempty"`
+
+	// Zero means to inherit. Durations are expressed as integer nanoseconds.
+	Interval      time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
+	Timeout       time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
+	StartPeriod   time.Duration `json:",omitempty"` // The start period for the container to initialize before the retries starts to count down.
+	StartInterval time.Duration `json:",omitempty"` // The interval to attempt healthchecks at during the start period
+
+	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
+	// Zero means inherit.
+	Retries int `json:",omitempty"`
+}

--- a/image/spec/specs-go/version.go
+++ b/image/spec/specs-go/version.go
@@ -1,0 +1,7 @@
+package v1
+
+const (
+	Version      = "v1.3"
+	VersionMajor = 1
+	VersionMinor = 3
+)


### PR DESCRIPTION
- Related to: https://github.com/moby/moby/pull/46313

This is an initial effort to add a canonical implementation of the Docker Image spec (`application/vnd.docker.container.image.v1+json`).

The intent was to share as much of the implementation with the [OCI image spec](https://github.com/opencontainers/image-spec) and allow for easy conversion between OCI image and Docker OCI image.


**- What I did**
Add Go structs describing the image spec which extend the OCI types.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

