### PR TITLE
libnetwork: notify another driver registerer

### DIFF
--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -124,7 +124,7 @@ func New(cfgOptions ...config.Option) (*Controller, error) {
 		return nil, err
 	}
 
-	c.drvRegistry.Notify = c.RegisterDriver
+	c.drvRegistry.Notify = c
 
 	// External plugins don't need config passed through daemon. They can
 	// bootstrap themselves.

--- a/libnetwork/drvregistry/networks.go
+++ b/libnetwork/drvregistry/networks.go
@@ -11,9 +11,6 @@ import (
 // DriverWalkFunc defines the network driver table walker function signature.
 type DriverWalkFunc func(name string, driver driverapi.Driver, capability driverapi.Capability) bool
 
-// DriverNotifyFunc defines the notify function signature when a new network driver gets registered.
-type DriverNotifyFunc func(name string, driver driverapi.Driver, capability driverapi.Capability) error
-
 type driverData struct {
 	driver     driverapi.Driver
 	capability driverapi.Capability
@@ -23,7 +20,7 @@ type driverData struct {
 // driver registry, ready to use.
 type Networks struct {
 	// Notify is called whenever a network driver is registered.
-	Notify DriverNotifyFunc
+	Notify driverapi.Registerer
 
 	mu      sync.Mutex
 	drivers map[string]driverData
@@ -76,7 +73,7 @@ func (nr *Networks) RegisterDriver(ntype string, driver driverapi.Driver, capabi
 	}
 
 	if nr.Notify != nil {
-		if err := nr.Notify(ntype, driver, capability); err != nil {
+		if err := nr.Notify.RegisterDriver(ntype, driver, capability); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
There is no meaningful distinction between `driverapi.Registerer` and `drvregistry.DriverNotifyFunc`. They are both used to register a network driver with an interested party. They have the same function signature. The only difference is that the latter could be satisfied by an anonymous closure. However, in practice the only implementation of `drvregistry.DriverNotifyFunc` is the `(*libnetwork.Controller).RegisterDriver` method. This same method also makes the `libnetwork.Controller` type satisfy the `Registerer` interface, therefore the `DriverNotifyFunc` type is redundant. Change `drvregistry.Networks` to notify a `Registerer` and drop the `DriverNotifyFunc` type.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

