### PR TITLE
libnetwork: Endpoint: fixing some nits

### DIFF
--- a/libnetwork/endpoint_info.go
+++ b/libnetwork/endpoint_info.go
@@ -280,15 +280,16 @@ func (ep *Endpoint) InterfaceName() driverapi.InterfaceNameInfo {
 func (ep *Endpoint) AddStaticRoute(destination *net.IPNet, routeType int, nextHop net.IP) error {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
-
-	r := types.StaticRoute{Destination: destination, RouteType: routeType, NextHop: nextHop}
-
 	if routeType == types.NEXTHOP {
 		// If the route specifies a next-hop, then it's loosely routed (i.e. not bound to a particular interface).
-		ep.joinInfo.StaticRoutes = append(ep.joinInfo.StaticRoutes, &r)
+		ep.joinInfo.StaticRoutes = append(ep.joinInfo.StaticRoutes, &types.StaticRoute{
+			Destination: destination,
+			RouteType:   routeType,
+			NextHop:     nextHop,
+		})
 	} else {
 		// If the route doesn't specify a next-hop, it must be a connected route, bound to an interface.
-		ep.iface.routes = append(ep.iface.routes, r.Destination)
+		ep.iface.routes = append(ep.iface.routes, destination)
 	}
 	return nil
 }

--- a/libnetwork/endpoint_info.go
+++ b/libnetwork/endpoint_info.go
@@ -272,12 +272,7 @@ func (epi *EndpointInterface) SetNames(srcName string, dstPrefix string) error {
 func (ep *Endpoint) InterfaceName() driverapi.InterfaceNameInfo {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
-
-	if ep.iface != nil {
-		return ep.iface
-	}
-
-	return nil
+	return ep.iface
 }
 
 // AddStaticRoute adds a route to the sandbox.


### PR DESCRIPTION
Some breadcrumbs / left-overs from other work;

### libnetwork: Endpoint.InterfaceName: remove redundant nil check

### libnetwork: Endpoint.AddStaticRoute don't create StaticRoute if unused

This function either had to create a new StaticRoute, or add the destination
to the list of routes. Skip creating a StaticRoute struct if we're not
gonna use it.




**- A picture of a cute animal (not mandatory but encouraged)**

