### PR TITLE
[24.0 backport] volume/local: Don't unmount, restore mounted status

### DIFF
--- a/volume/local/local_unix.go
+++ b/volume/local/local_unix.go
@@ -99,10 +99,6 @@ func (v *localVolume) setOpts(opts map[string]string) error {
 	return v.saveOpts()
 }
 
-func unmount(path string) {
-	_ = mount.Unmount(path)
-}
-
 func (v *localVolume) needsMount() bool {
 	if v.opts == nil {
 		return false
@@ -160,6 +156,29 @@ func (v *localVolume) unmount() error {
 		}
 		v.active.mounted = false
 	}
+	return nil
+}
+
+// restoreIfMounted restores the mounted status if the _data directory is already mounted.
+func (v *localVolume) restoreIfMounted() error {
+	if v.needsMount() {
+		// Check if the _data directory is already mounted.
+		mounted, err := mountinfo.Mounted(v.path)
+		if err != nil {
+			return fmt.Errorf("failed to determine if volume _data path is already mounted: %w", err)
+		}
+
+		if mounted {
+			// Mark volume as mounted, but don't increment active count. If
+			// any container needs this, the refcount will be incremented
+			// by the live-restore (if enabled).
+			// In other case, refcount will be zero but the volume will
+			// already be considered as mounted when Mount is called, and
+			// only the refcount will be incremented.
+			v.active.mounted = true
+		}
+	}
+
 	return nil
 }
 

--- a/volume/local/local_windows.go
+++ b/volume/local/local_windows.go
@@ -43,6 +43,11 @@ func (v *localVolume) postMount() error {
 	return nil
 }
 
+// restoreIfMounted is a no-op on Windows (because mounts are not supported).
+func (v *localVolume) restoreIfMounted() error {
+	return nil
+}
+
 func (v *localVolume) CreatedAt() (time.Time, error) {
 	fileInfo, err := os.Stat(v.rootPath)
 	if err != nil {


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/46253
- addresses https://github.com/moby/moby/issues/46148
- fixes https://github.com/docker/for-linux/issues/1470

----



On startup all local volumes were unmounted as a cleanup mechanism for the non-clean exit of the last engine process.

This caused live-restored volumes that used special volume opt mount flags to be broken. While the refcount was restored, the _data directory was just unmounted, so all new containers mounting this volume would just have the access to the empty _data directory instead of the real volume.

With this patch, the mountpoint isn't unmounted. Instead, if the volume is already mounted, just mark it as mounted, so the next time Mount is called only the ref count is incremented, but no second attempt to mount it is performed.

**- What I did**
Fixed the case where live-restore of volumes that specified custom volume opts wouldn't work properly.

**- How I did it**
See commits.

**- How to verify it**
CI

**- Description for the changelog**
```release-notes
- Fixed a bug which caused named volumes that set custom `device` or `type` volume option to be unmounted when restarting the daemon and not live-restoring it properly.
```

**- A picture of a cute animal (not mandatory but encouraged)**
