### PR TITLE
daemon: Daemon.killWithSignal(): don't fully discard errors, but log them

### DIFF
--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -111,7 +111,13 @@ func (daemon *Daemon) killWithSignal(container *containerpkg.Container, stopSign
 				defer cancel()
 				s := <-container.Wait(ctx, containerpkg.WaitConditionNotRunning)
 				if s.Err() != nil {
-					daemon.handleContainerExit(container, nil)
+					if err := daemon.handleContainerExit(container, nil); err != nil {
+						log.G(context.TODO()).WithFields(log.Fields{
+							"error":     err,
+							"container": container.ID,
+							"action":    "kill",
+						}).Warn("error while handling container exit")
+					}
 				}
 			}()
 		} else {

--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -87,7 +87,12 @@ func (daemon *Daemon) killWithSignal(container *containerpkg.Container, stopSign
 
 	if !daemon.IsShuttingDown() {
 		container.HasBeenManuallyStopped = true
-		container.CheckpointTo(daemon.containersReplica)
+		if err := container.CheckpointTo(daemon.containersReplica); err != nil {
+			log.G(context.TODO()).WithFields(log.Fields{
+				"error":     err,
+				"container": container.ID,
+			}).Warn("error checkpointing container state")
+		}
 	}
 
 	// if the container is currently restarting we do not need to send the signal


### PR DESCRIPTION
- extracting from https://github.com/moby/moby/pull/46225, which still needs some work

### daemon: Daemon.killWithSignal(): don't discard handleContainerExit error

Daemon.handleContainerExit() returns an error if snapshotting the container's
state to disk fails. There's not much we can do with the error if it occurs,
but let's log the error if that happens, instead of discarding it.

### daemon: Daemon.killWithSignal(): don't discard snapshotting errors

While there's not much we can do if we failed to store a snapshot of the
container's state, let's log the error in case it happens in stad of discarding.

Daemon.handleContainerExit() returns an error if snapshotting the container's
state to disk fails. There's not much we can do with the error if it occurs,
but let's log the error if that happens, instead of discarding it.




**- A picture of a cute animal (not mandatory but encouraged)**

