### PR TITLE
image/spec: minor fixes and touch-ups in markdown files

### DIFF
--- a/image/spec/v1.1.md
+++ b/image/spec/v1.1.md
@@ -142,7 +142,7 @@ Here is an example image JSON file:
         ],
         "Volumes": {
             "/var/job-result-data": {},
-            "/var/log/my-app-logs": {},
+            "/var/log/my-app-logs": {}
         },
         "WorkingDir": "/home/alice"
     },
@@ -297,8 +297,8 @@ whitespace. It has been added to this example for clarity.
                     </li>
                 </ul>
                 with the default protocol being <code>"tcp"</code> if not
-                specified. These values act as defaults and are merged with any
-                specified when creating a container.
+                specified. These values act as defaults and are merged with
+                any specified when creating a container.
             </dd>
             <dt>
                 Env <code>array of strings</code>
@@ -405,7 +405,7 @@ whitespace. It has been added to this example for clarity.
             filesystem).
           </li>
         </ul>
-Here is an example history section:
+        Here is an example history section:
 <pre>"history": [
   {
     "created": "2015-10-31T22:22:54.690851953Z",
@@ -472,7 +472,7 @@ f60c56784b83/
         my-app-tools
 ```
 
-This example change is going add a configuration directory at `/etc/my-app.d`
+This example change adds a configuration directory at `/etc/my-app.d`
 which contains a default config file. There's also a change to the
 `my-app-tools` binary to handle the config layout change. The `f60c56784b83`
 directory then looks like this:
@@ -535,13 +535,13 @@ For example, here's what the full archive of `library/busybox` is (displayed in
 .
 ├── 47bcc53f74dc94b1920f0b34f6036096526296767650f223433fe65c35f149eb.json
 ├── 5f29f704785248ddb9d06b90a11b5ea36c534865e9035e4022bb2e71d4ecbb9a
-│   ├── VERSION
-│   ├── json
-│   └── layer.tar
+│   ├── VERSION
+│   ├── json
+│   └── layer.tar
 ├── a65da33792c5187473faa80fa3e1b975acba06712852d1dea860692ccddf3198
-│   ├── VERSION
-│   ├── json
-│   └── layer.tar
+│   ├── VERSION
+│   ├── json
+│   └── layer.tar
 ├── manifest.json
 └── repositories
 ```
@@ -569,7 +569,7 @@ metadata schema:
 1.0
 ```
 
-The `repositories` file is another JSON file which describes names/tags:
+The `repositories` file is a JSON file which describes names/tags:
 
 ```
 {  

--- a/image/spec/v1.2.md
+++ b/image/spec/v1.2.md
@@ -528,7 +528,7 @@ f60c56784b83/
         my-app-tools
 ```
 
-This example change is going add a configuration directory at `/etc/my-app.d`
+This example change adds a configuration directory at `/etc/my-app.d`
 which contains a default config file. There's also a change to the
 `my-app-tools` binary to handle the config layout change. The `f60c56784b83`
 directory then looks like this:
@@ -591,13 +591,13 @@ For example, here's what the full archive of `library/busybox` is (displayed in
 .
 ├── 47bcc53f74dc94b1920f0b34f6036096526296767650f223433fe65c35f149eb.json
 ├── 5f29f704785248ddb9d06b90a11b5ea36c534865e9035e4022bb2e71d4ecbb9a
-│   ├── VERSION
-│   ├── json
-│   └── layer.tar
+│   ├── VERSION
+│   ├── json
+│   └── layer.tar
 ├── a65da33792c5187473faa80fa3e1b975acba06712852d1dea860692ccddf3198
-│   ├── VERSION
-│   ├── json
-│   └── layer.tar
+│   ├── VERSION
+│   ├── json
+│   └── layer.tar
 ├── manifest.json
 └── repositories
 ```
@@ -625,7 +625,7 @@ metadata schema:
 1.0
 ```
 
-The `repositories` file is another JSON file which describes names/tags:
+The `repositories` file is a JSON file which describes names/tags:
 
 ```
 {  

--- a/image/spec/v1.md
+++ b/image/spec/v1.md
@@ -149,7 +149,7 @@ Here is an example image JSON file:
         ],
         "Volumes": {
             "/var/job-result-data": {},
-            "/var/log/my-app-logs": {},
+            "/var/log/my-app-logs": {}
         },
         "WorkingDir": "/home/alice"
     }
@@ -316,8 +316,8 @@ Here is an example image JSON file:
                     </li>
                 </ul>
                 with the default protocol being <code>"tcp"</code> if not
-                specified. These values act as defaults and are merged with any specified
-                when creating a container.
+                specified. These values act as defaults and are merged with
+                any specified when creating a container.
             </dd>
             <dt>
                 Env <code>array of strings</code>
@@ -429,7 +429,7 @@ f60c56784b83/
         my-app-tools
 ```
 
-This example change is going to add a configuration directory at `/etc/my-app.d`
+This example change adds a configuration directory at `/etc/my-app.d`
 which contains a default config file. There's also a change to the
 `my-app-tools` binary to handle the config layout change. The `f60c56784b83`
 directory then looks like this:
@@ -524,7 +524,7 @@ metadata schema:
 1.0
 ```
 
-And the `repositories` file is another JSON file which describes names/tags:
+The `repositories` file is a JSON file which describes names/tags:
 
 ```
 {  


### PR DESCRIPTION
- remove some trailing commas, which made the JSON invalid (some of these were fixed in the 1.2 spec, but not in older versions).
- synchronise some formatting / phrasing between versions, to make them easier to compare.
- remove non-breaking spaces (`NBSP`) in example outputs, and replace them with regular spaces.


**- A picture of a cute animal (not mandatory but encouraged)**

