### PR TITLE
image/specs: add missing OnBuild (v1.0), ArgsEscaped (v1.1), and Shell (v1.2) fields

### DIFF
--- a/image/spec/v1.1.md
+++ b/image/spec/v1.1.md
@@ -327,6 +327,18 @@ whitespace. It has been added to this example for clarity.
                 array should be interpreted as the executable to run.
             </dd>
             <dt>
+                ArgsEscaped <code>boolean</code>
+            </dt>
+            <dd>
+                Used for Windows images to indicate that the <code>Entrypoint</code>
+                or <code>Cmd</code> or both, contain only a single element array
+                that is a pre-escaped, and combined into a single string, **CommandLine**.
+                If "true", the value in <code>Entrypoint</code> or <code>Cmd</code>Cmd
+                should be used as-is to avoid double escaping.
+                Note, the exact behavior of <code>ArgsEscaped</code> is complex
+                and subject to implementation details.
+            </dd>
+            <dt>
                 Volumes <code>struct</code>
             </dt>
             <dd>

--- a/image/spec/v1.1.md
+++ b/image/spec/v1.1.md
@@ -349,6 +349,16 @@ whitespace. It has been added to this example for clarity.
                 in the container. This value acts as a default and is replaced
                 by a working directory specified when creating a container.
             </dd>
+            <dt>
+                OnBuild <code>array of strings</code>
+            </dt>
+            <dd>
+                This metadata defines "trigger" instructions to be executed at
+                a later time, when the image is used as the base for another
+                build. Each trigger will be executed in the context of the
+                downstream build, as if it had been inserted immediately after
+                the *FROM* instruction in the downstream Dockerfile.
+            </dd>
         </dl>
     </dd>
     <dt>

--- a/image/spec/v1.2.md
+++ b/image/spec/v1.2.md
@@ -427,6 +427,17 @@ whitespace. It has been added to this example for clarity.
                 downstream build, as if it had been inserted immediately after
                 the *FROM* instruction in the downstream Dockerfile.
             </dd>
+            <dt>
+                Shell <code>array of strings</code>
+            </dt>
+            <dd>
+                Override the default shell used for the *shell* form of
+                commands during "build". The default shell on Linux is
+                <code>["/bin/sh", "-c"]</code>, and <code>["cmd", "/S", "/C"]</code>
+                on Windows. This field is set by the <code>SHELL</code>
+                instruction in a Dockerfile, and *must* be written in JSON
+                form.
+            </dd>
         </dl>
     </dd>
     <dt>

--- a/image/spec/v1.2.md
+++ b/image/spec/v1.2.md
@@ -327,6 +327,18 @@ whitespace. It has been added to this example for clarity.
                 array should be interpreted as the executable to run.
             </dd>
             <dt>
+                ArgsEscaped <code>boolean</code>
+            </dt>
+            <dd>
+                Used for Windows images to indicate that the <code>Entrypoint</code>
+                or <code>Cmd</code> or both, contain only a single element array
+                that is a pre-escaped, and combined into a single string, **CommandLine**.
+                If "true", the value in <code>Entrypoint</code> or <code>Cmd</code>Cmd
+                should be used as-is to avoid double escaping.
+                Note, the exact behavior of <code>ArgsEscaped</code> is complex
+                and subject to implementation details.
+            </dd>
+            <dt>
                 Healthcheck <code>struct</code>
             </dt>
             <dd>

--- a/image/spec/v1.2.md
+++ b/image/spec/v1.2.md
@@ -405,6 +405,16 @@ whitespace. It has been added to this example for clarity.
                 in the container. This value acts as a default and is replaced
                 by a working directory specified when creating a container.
             </dd>
+            <dt>
+                OnBuild <code>array of strings</code>
+            </dt>
+            <dd>
+                This metadata defines "trigger" instructions to be executed at
+                a later time, when the image is used as the base for another
+                build. Each trigger will be executed in the context of the
+                downstream build, as if it had been inserted immediately after
+                the *FROM* instruction in the downstream Dockerfile.
+            </dd>
         </dl>
     </dd>
     <dt>

--- a/image/spec/v1.md
+++ b/image/spec/v1.md
@@ -368,6 +368,16 @@ Here is an example image JSON file:
                 in the container. This value acts as a default and is replaced
                 by a working directory specified when creating a container.
             </dd>
+            <dt>
+                OnBuild <code>array of strings</code>
+            </dt>
+            <dd>
+                This metadata defines "trigger" instructions to be executed at
+                a later time, when the image is used as the base for another
+                build. Each trigger will be executed in the context of the
+                downstream build, as if it had been inserted immediately after
+                the *FROM* instruction in the downstream Dockerfile.
+            </dd>
         </dl>
     </dd>
 </dl>


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/46363
- ONBUILD was added in https://github.com/moby/moby/pull/3254 (which was before the image spec v1.0.0 was added in https://github.com/moby/moby/pull/9560)
- ArgsEscaped was added in https://github.com/moby/moby/pull/17851 (v1.12.0-rc1, image-spec v1.2.0)
- https://github.com/opencontainers/image-spec/pull/892
- SHELL was added in https://github.com/moby/moby/commit/b18ae8c9ccc2eb6cf8aa947f25eb6f1d20089776 / https://github.com/moby/moby/pull/22489 (v1.12.0-rc1, image-spec v1.2.0)



### image/spec: add missing "OnBuild" field

This field was added in commit 9f994c96468e2495a2dc118355b6565e7dac0f44,
which was merged before the image-spec v1.0.0 was released (which happened
in commit 79910625f0a7aa76590e4362817dda22f28343aa).

This patch back-fills the specifications to describe the property.

### image/spec: add missing "ArgsEscaped" field (v1.1, v1.2)

This field was added in 9db5db1b94bc1000d151315851096dcc6cd3512d, which
was part of v1.10.0-rc1 and later, which used image spec v1.1.0.

It's worth noting that documentation for the v1.1.0 image spec was not
yet available until commit 4fa0eccd10c5c120fe1f641285db920cf643dbe8,
which was included in v1.12.0-rc1 and up. The `ArgsEscaped` field was
also adopted by the OCI image spec since [v1.1.0-rc3][1], but considered
deprecated, and not recommended to be used.

This patch amends the v1.1 and v1.2 specifications to describe the field.

[1]: https://github.com/opencontainers/image-spec/commit/59780aa56914ae9cf4ca68c10989d3f89337d1e0

### image/spec: add missing "Shell" field (v1.2)

This field was added in b18ae8c9ccc2eb6cf8aa947f25eb6f1d20089776, which
was part of v1.12.0-rc1 and later, which used image spec v1.2.0.

This patch amends the v1.2 spec to include the missing field.

**- A picture of a cute animal (not mandatory but encouraged)**

