### PR TITLE
c8d: Handle userns properly

### DIFF
--- a/daemon/containerd/image_snapshot_unix.go
+++ b/daemon/containerd/image_snapshot_unix.go
@@ -1,0 +1,84 @@
+//go:build !windows
+
+package containerd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/containerd/containerd/leases"
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/docker/docker/pkg/idtools"
+)
+
+func (i *ImageService) remapSnapshot(ctx context.Context, snapshotter snapshots.Snapshotter, id string, parentSnapshot string, lease leases.Lease) error {
+	ls := i.client.LeasesService()
+	rootPair := i.idMapping.RootPair()
+	usernsID := fmt.Sprintf("%s-%d-%d", parentSnapshot, rootPair.UID, rootPair.GID)
+	remappedID := usernsID + remapSuffix
+
+	// If the remapped snapshot already exist we only need to prepare the new snapshot
+	if _, err := snapshotter.Stat(ctx, usernsID); err == nil {
+		_, err = snapshotter.Prepare(ctx, id, usernsID)
+		return err
+	}
+
+	if err := ls.AddResource(ctx, lease, leases.Resource{
+		ID:   remappedID,
+		Type: "snapshots/" + i.StorageDriver(),
+	}); err != nil {
+		return err
+	}
+	if err := ls.AddResource(ctx, lease, leases.Resource{
+		ID:   usernsID,
+		Type: "snapshots/" + i.StorageDriver(),
+	}); err != nil {
+		return err
+	}
+
+	mounts, err := snapshotter.Prepare(ctx, remappedID, parentSnapshot)
+	if err != nil {
+		return err
+	}
+
+	if err := i.remapRootFS(ctx, mounts); err != nil {
+		if rmErr := snapshotter.Remove(ctx, usernsID); rmErr != nil {
+			log.G(ctx).WithError(rmErr).Warn("failed to remove snapshot after remap error")
+		}
+		return err
+	}
+
+	if err := snapshotter.Commit(ctx, usernsID, remappedID); err != nil {
+		return err
+	}
+
+	_, err = snapshotter.Prepare(ctx, id, usernsID)
+	return err
+}
+
+func (i *ImageService) remapRootFS(ctx context.Context, mounts []mount.Mount) error {
+	return mount.WithTempMount(ctx, mounts, func(root string) error {
+		return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			stat := info.Sys().(*syscall.Stat_t)
+			if stat == nil {
+				return fmt.Errorf("cannot get underlying data for %s", path)
+			}
+
+			ids, err := i.idMapping.ToHost(idtools.Identity{UID: int(stat.Uid), GID: int(stat.Gid)})
+			if err != nil {
+				return err
+			}
+
+			return os.Lchown(path, ids.UID, ids.GID)
+		})
+	})
+}

--- a/daemon/containerd/image_snapshot_windows.go
+++ b/daemon/containerd/image_snapshot_windows.go
@@ -1,0 +1,12 @@
+package containerd
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/leases"
+	"github.com/containerd/containerd/snapshots"
+)
+
+func (i *ImageService) remapSnapshot(ctx context.Context, snapshotter snapshots.Snapshotter, id string, parentSnapshot string, lease leases.Lease) error {
+	return nil
+}

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
+	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/registry"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -34,6 +35,7 @@ type ImageService struct {
 	eventsService   *daemonevents.Events
 	pruneRunning    atomic.Bool
 	refCountMounter snapshotter.Mounter
+	idMapping       idtools.IdentityMapping
 }
 
 type RegistryConfigProvider interface {
@@ -49,6 +51,7 @@ type ImageServiceConfig struct {
 	Registry        RegistryConfigProvider
 	EventsService   *daemonevents.Events
 	RefCountMounter snapshotter.Mounter
+	IDMapping       idtools.IdentityMapping
 }
 
 // NewService creates a new ImageService.
@@ -61,6 +64,7 @@ func NewService(config ImageServiceConfig) *ImageService {
 		registryService: config.Registry,
 		eventsService:   config.EventsService,
 		refCountMounter: config.RefCountMounter,
+		idMapping:       config.IDMapping,
 	}
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1072,6 +1072,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 			RegistryHosts:   d.RegistryHosts,
 			Registry:        d.registryService,
 			EventsService:   d.EventsService,
+			IDMapping:       idMapping,
 			RefCountMounter: snapshotter.NewMounter(config.Root, driverName, idMapping),
 		})
 	} else {

--- a/daemon/snapshotter/mount.go
+++ b/daemon/snapshotter/mount.go
@@ -93,7 +93,13 @@ func (m *refCountMounter) Mount(mounts []mount.Mount, containerID string) (targe
 	}()
 
 	root := m.idMap.RootPair()
-	if err := idtools.MkdirAllAndChown(target, 0o700, root); err != nil {
+	if err := idtools.MkdirAllAndChown(filepath.Dir(target), 0o710, idtools.Identity{
+		UID: idtools.CurrentIdentity().UID,
+		GID: root.GID,
+	}); err != nil {
+		return "", err
+	}
+	if err := idtools.MkdirAllAndChown(target, 0o710, root); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
**- What I did**

Remapped the GID/UID when a snapshot is created if the daemon is started with `--userns-remap`. This implementation differs from the graph driver one slightly. With graph drivers the files/directories are chown'ed when the image is downloaded and the contents extracted. Basically, with graph drivers we remap on pull and with containerd we remap on run.

Note: with this change builds still fail, my guess is because buildkit still mounts the roots in normal mode, I'll continue looking but I think we can merge this one, I am pretty sure some changes in buildkit are needed:

```console
$ docker build -t userns . 
[+] Building 1.7s (6/6) FINISHED                                                                                                                               docker:local
 => [internal] load build definition from dd                                                                                                                           0.0s
 => => transferring dockerfile: 71B                                                                                                                                    0.0s
 => [internal] load .dockerignore                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/debian:bullseye-slim                                                                                                1.3s
 => [auth] library/debian:pull token for registry-1.docker.io                                                                                                          0.0s
 => CACHED [1/2] FROM docker.io/library/debian:bullseye-slim@sha256:61386e11b5256efa33823cbfafd668dd651dbce810b24a8fb7b2e32fa7f65a85                                   0.0s
 => => resolve docker.io/library/debian:bullseye-slim@sha256:61386e11b5256efa33823cbfafd668dd651dbce810b24a8fb7b2e32fa7f65a85                                          0.0s
 => ERROR [2/2] RUN touch testa                                                                                                                                        0.3s
------
 > [2/2] RUN touch testa:
0.287 runc run failed: unable to start container process: error during container init: error mounting "/tmp/root/165536.165536/buildkit/executor/hosts.iv21cdui6qvdwqel9cdo93spo" to rootfs at "/etc/hosts": open /tmp/root/165536.165536/buildkit/executor/7yecjv2i25qdu44khgx41b450/rootfs/etc/hosts: permission denied
------
dd:2
--------------------
   1 |     FROM debian:bullseye-slim
   2 | >>> RUN touch testa
   3 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c touch testa" did not complete successfully: exit code: 1
```

**- How I did it**

**- How to verify it**

`TestDaemonUserNamespaceRootSetting` should not fail any more
 
```console
$ make DOCKER_GRAPHDRIVER=overlayfs TEST_FILTER=TestDaemonUserNamespaceRootSetting TEST_INTEGRATION_USE_SNAPSHOTTER=1 test-integration
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
