### PR TITLE
client: TestImageTagInvalidSourceImageName remove invalid test-case

### DIFF
--- a/client/image_tag_test.go
+++ b/client/image_tag_test.go
@@ -45,7 +45,7 @@ func TestImageTagInvalidSourceImageName(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "client should not have made an API call")),
 	}
 
-	invalidRepos := []string{"fo$z$", "Foo@3cc", "Foo$3", "Foo*3", "Fo^3", "Foo!3", "F)xcz(", "fo%asd", "FOO/bar", "aa/asdf$$^/aa"}
+	invalidRepos := []string{"fo$z$", "Foo@3cc", "Foo$3", "Foo*3", "Fo^3", "Foo!3", "F)xcz(", "fo%asd", "aa/asdf$$^/aa"}
 	for _, repo := range invalidRepos {
 		repo := repo
 		t.Run("invalidRepo/"+repo, func(t *testing.T) {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/46376

The test considered `Foo/bar` to be an invalid name, with the assumption that it was `[docker.io]/Foo/bar`. However, this was incorrect, and the test passed because the reference parsing had a bug; if the first element (`Foo`) is not lowercase (so not a valid namespace /  "path element"), then it *should* be considered a domain (as uppercase domain names are valid).

The reference parser did not account for this, and running the test with a version of the parser with a fix caused the test to fail:

    === Failed
    === FAIL: client TestImageTagInvalidSourceImageName/invalidRepo/FOO/bar (0.00s)
        image_tag_test.go:54: assertion failed: expected error to contain "not a valid repository/tag", got "Error response from daemon: client should not have made an API call"
            Error response from daemon: client should not have made an API call

    === FAIL: client TestImageTagInvalidSourceImageName (0.00s)

This patch removes the faulty test-case.


**- A picture of a cute animal (not mandatory but encouraged)**

