### PR TITLE
test: remove platform related timeout values

### DIFF
--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -14,6 +14,7 @@ source "${MAKEDIR}/.go-autogen"
 
 # Set defaults
 : "${TEST_REPEAT:=1}"
+: "${TIMEOUT:=5m}"
 : "${TESTFLAGS:=}"
 : "${TESTDEBUG:=}"
 : "${TESTCOVERAGE:=}"
@@ -54,7 +55,7 @@ else
 fi
 
 run_test_integration() {
-	set_platform_timeout
+	set_repeat_timeout
 	local failed=0
 	if [ -z "${TEST_SKIP_INTEGRATION}" ]; then
 		if ! run_test_integration_suites "${integration_api_dirs}"; then
@@ -181,7 +182,6 @@ test_env() {
 			DOCKER_INTEGRATION_DAEMON_DEST="$DOCKER_INTEGRATION_DAEMON_DEST" \
 			DOCKER_TLS_VERIFY="$DOCKER_TEST_TLS_VERIFY" \
 			DOCKER_CERT_PATH="$DOCKER_TEST_CERT_PATH" \
-			DOCKER_ENGINE_GOARCH="$DOCKER_ENGINE_GOARCH" \
 			DOCKER_GRAPHDRIVER="$DOCKER_GRAPHDRIVER" \
 			DOCKER_USERLANDPROXY="$DOCKER_USERLANDPROXY" \
 			DOCKER_HOST="$DOCKER_HOST" \
@@ -201,16 +201,7 @@ test_env() {
 	)
 }
 
-set_platform_timeout() {
-	# Test timeout.
-	if [ "${DOCKER_ENGINE_GOARCH}" = "arm64" ] || [ "${DOCKER_ENGINE_GOARCH}" = "arm" ]; then
-		: "${TIMEOUT:=10m}"
-	elif [ "${DOCKER_ENGINE_GOARCH}" = "windows" ]; then
-		: "${TIMEOUT:=8m}"
-	else
-		: "${TIMEOUT:=5m}"
-	fi
-
+set_repeat_timeout() {
 	if [ "${TEST_REPEAT}" -gt 1 ]; then
 		# TIMEOUT needs to take TEST_REPEAT into account, or a premature time out may happen.
 		# The following ugliness will:


### PR DESCRIPTION
**- What I did**

Removed platform related timeout values.

These were dependent on the DOCKER_ENGINE_GOARCH environment variable but this var was no longer set. There was also some weird check to see if the architecture is "windows" which doesn't make sense. Seeing how nothing failed ever since the TIMEOUT was no longer platform-dependent we can safely remove this check.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

