### PR TITLE
c8d/legacybuilder: Assorted fixes 

### DIFF
--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -194,11 +194,10 @@ func newROLayerForImage(ctx context.Context, imgDesc *ocispec.Descriptor, i *Ima
 		return nil, err
 	}
 
-	key := stringid.GenerateRandomID()
-	parent := identity.ChainID(diffIDs).String()
+	imageSnapshotID := identity.ChainID(diffIDs).String()
 
 	return &rolayer{
-		key:                key,
+		key:                imageSnapshotID,
 		c:                  i.client,
 		snapshotter:        i.snapshotter,
 		diffID:             "", // Image RO layer doesn't have a diff.
@@ -242,7 +241,7 @@ func (rl *rolayer) NewRWLayer() (builder.RWLayer, error) {
 	}
 
 	key := stringid.GenerateRandomID()
-	mounts, err := snapshotter.Prepare(ctx, key, rl.diffID.String())
+	mounts, err := snapshotter.Prepare(ctx, key, rl.key)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -201,7 +201,7 @@ func newROLayerForImage(ctx context.Context, imgDesc *ocispec.Descriptor, i *Ima
 		key:                key,
 		c:                  i.client,
 		snapshotter:        i.snapshotter,
-		diffID:             digest.Digest(parent),
+		diffID:             "", // Image RO layer doesn't have a diff.
 		contentStoreDigest: "",
 	}, nil
 }

--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -422,7 +422,7 @@ func (i *ImageService) CreateImage(ctx context.Context, config []byte, parent st
 		}
 	}
 
-	if err := i.unpackImage(ctx, createdImage, platforms.DefaultSpec()); err != nil {
+	if err := i.unpackImage(ctx, i.StorageDriver(), img, commitManifestDesc); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
- Requires: https://github.com/moby/moby/pull/46313

- Closes: https://github.com/moby/moby/issues/46194

**- What I did**
- Fixed `failed to prepare snapshot: parent snapshot <digest> does not exist: not found` error
- Removed unused mount of the rolayer snapshot
- Fixed `mismatched image rootfs and manifest layers` when producing a new image with an empty diff (empty layer was added to the manifest when it was intentionally not being added in the config)
- Replaced 1 hour leases with actual leases that are deleted when `Release` is called on ro/rw layer

**- How I did it**
- See commits

**- How to verify it**
Integrations tests with c8d enabled

```diff
 === FAIL: amd64.integration-cli TestDockerCLIBuildSuite (308.65s)

- DONE 250 tests, 13 skipped, 41 failures in 314.721s
+ DONE 250 tests, 13 skipped, 20 failures in 310.432s
```


**- Description for the changelog**
```release-notes
- containerd-integration: Fix legacy builder build errors when multiple COPY/ADD instructions are used
```


**- A picture of a cute animal (not mandatory but encouraged)**

