### PR TITLE
libnetwork/osl: Namespace.DeleteNeighbor: assorted cleanups, and ignore "non-exist" warnings

### DIFF
--- a/libnetwork/drivers/overlay/peerdb.go
+++ b/libnetwork/drivers/overlay/peerdb.go
@@ -377,7 +377,7 @@ func (d *driver) peerDeleteOp(nid, eid string, peerIP net.IP, peerIPMask net.IPM
 	// Local peers do not have any local configuration to delete
 	if !localPeer {
 		// Remove fdb entry to the bridge for the peer mac
-		if err := sbox.DeleteNeighbor(vtep, peerMac, true); err != nil {
+		if err := sbox.DeleteNeighbor(vtep, peerMac); err != nil {
 			if _, ok := err.(osl.NeighborSearchError); ok && dbEntries > 0 {
 				// We fall in here if there is a transient state and if the neighbor that is being deleted
 				// was never been configured into the kernel (we allow only 1 configuration at the time per <ip,mac> mapping)
@@ -387,7 +387,7 @@ func (d *driver) peerDeleteOp(nid, eid string, peerIP net.IP, peerIPMask net.IPM
 		}
 
 		// Delete neighbor entry for the peer IP
-		if err := sbox.DeleteNeighbor(peerIP, peerMac, true); err != nil {
+		if err := sbox.DeleteNeighbor(peerIP, peerMac); err != nil {
 			return fmt.Errorf("could not delete neighbor entry for nid:%s eid:%s into the sandbox:%v", nid, eid, err)
 		}
 	}

--- a/libnetwork/osl/neigh_linux.go
+++ b/libnetwork/osl/neigh_linux.go
@@ -46,11 +46,6 @@ func (n *Namespace) findNeighbor(dstIP net.IP, dstMac net.HardwareAddr) *neigh {
 
 // DeleteNeighbor deletes neighbor entry from the sandbox.
 func (n *Namespace) DeleteNeighbor(dstIP net.IP, dstMac net.HardwareAddr) error {
-	var (
-		iface netlink.Link
-		err   error
-	)
-
 	nh := n.findNeighbor(dstIP, dstMac)
 	if nh == nil {
 		return NeighborSearchError{dstIP, dstMac, false}
@@ -60,26 +55,25 @@ func (n *Namespace) DeleteNeighbor(dstIP net.IP, dstMac net.HardwareAddr) error 
 	nlh := n.nlHandle
 	n.Unlock()
 
+	var linkIndex int
 	if nh.linkDst != "" {
-		iface, err = nlh.LinkByName(nh.linkDst)
+		iface, err := nlh.LinkByName(nh.linkDst)
 		if err != nil {
 			return fmt.Errorf("could not find interface with destination name %s: %v", nh.linkDst, err)
 		}
+		linkIndex = iface.Attrs().Index
 	}
 
 	nlnh := &netlink.Neigh{
-		IP:     dstIP,
-		State:  netlink.NUD_PERMANENT,
-		Family: nh.family,
+		LinkIndex: linkIndex,
+		IP:        dstIP,
+		State:     netlink.NUD_PERMANENT,
+		Family:    nh.family,
 	}
 
-	if nlnh.Family > 0 {
+	if nh.family > 0 {
 		nlnh.HardwareAddr = dstMac
 		nlnh.Flags = netlink.NTF_SELF
-	}
-
-	if nh.linkDst != "" {
-		nlnh.LinkIndex = iface.Attrs().Index
 	}
 
 	// If the kernel deletion fails for the neighbor entry still remove it
@@ -90,25 +84,21 @@ func (n *Namespace) DeleteNeighbor(dstIP net.IP, dstMac net.HardwareAddr) error 
 	}
 
 	// Delete the dynamic entry in the bridge
-	if nlnh.Family > 0 {
-		nlnh := &netlink.Neigh{
-			IP:     dstIP,
-			Family: nh.family,
-		}
-
-		nlnh.HardwareAddr = dstMac
-		nlnh.Flags = netlink.NTF_MASTER
-		if nh.linkDst != "" {
-			nlnh.LinkIndex = iface.Attrs().Index
-		}
-		if err := nlh.NeighDel(nlnh); err != nil && !errors.Is(err, os.ErrNotExist) {
+	if nh.family > 0 {
+		if err := nlh.NeighDel(&netlink.Neigh{
+			LinkIndex:    linkIndex,
+			IP:           dstIP,
+			Family:       nh.family,
+			HardwareAddr: dstMac,
+			Flags:        netlink.NTF_MASTER,
+		}); err != nil && !errors.Is(err, os.ErrNotExist) {
 			log.G(context.TODO()).WithError(err).Warn("error while deleting neighbor entry")
 		}
 	}
 
 	n.Lock()
-	for i, nh := range n.neighbors {
-		if nh.dstIP.Equal(dstIP) && bytes.Equal(nh.dstMac, dstMac) {
+	for i, neighbor := range n.neighbors {
+		if neighbor.dstIP.Equal(dstIP) && bytes.Equal(neighbor.dstMac, dstMac) {
 			n.neighbors = append(n.neighbors[:i], n.neighbors[i+1:]...)
 			break
 		}


### PR DESCRIPTION
- relates to / addresses https://github.com/moby/moby/issues/46241

### libnetwork/osl: Namespace.DeleteNeighbor: don't warn on non-existing neighbor

The code ignores these errors, but will unconditionally print a warning;

> If the kernel deletion fails for the neighbor entry still remote it
> from the namespace cache. Otherwise if the neighbor moves back to the
> same host again, kernel update can fail.

Let's reduce noise if the neighbor wasn't found, to prevent logs like:

    Aug 16 13:26:35 master1.local dockerd[4019880]: time="2023-08-16T13:26:35.186662370+02:00" level=warning msg="error while deleting neighbor entry" error="no such file or directory"
    Aug 16 13:26:35 master1.local dockerd[4019880]: time="2023-08-16T13:26:35.366585939+02:00" level=warning msg="error while deleting neighbor entry" error="no such file or directory"
    Aug 16 13:26:42 master1.local dockerd[4019880]: time="2023-08-16T13:26:42.366658513+02:00" level=warning msg="error while deleting neighbor entry" error="no such file or directory"

### libnetwork/osl: Namespace.DeleteNeighbor: remove osDelete argument

This argument was originally added in libnetwork:
https://github.com/moby/libnetwork/commit/03f440667f79f33ef3cb1faeb13c0bca1a0f8737

At the time, this argument was conditional, but currently it's always set
to "true", so let's remove it.

### libnetwork/osl: Namespace.DeleteNeighbor: remove intermediate vars

- store linkIndex in a local variable so that it can be reused
- remove / rename some intermediate vars that shadowed existing declaration





**- A picture of a cute animal (not mandatory but encouraged)**

