### PR TITLE
integration-cli/build: Parse multiline images -q output 

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/command"
 	"github.com/opencontainers/go-digest"
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/assert/cmp"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
 )
 
@@ -4626,7 +4626,7 @@ func (s *DockerCLIBuildSuite) TestBuildMultiStageArg(c *testing.T) {
 	result.Assert(c, icmd.Success)
 
 	imgs := strings.Split(strings.TrimSpace(result.Stdout()), "\n")
-	assert.Assert(c, cmp.Len(imgs, 1), `only one image with "multifromtest" label is expected`)
+	assert.Assert(c, is.Len(imgs, 1), `only one image with "multifromtest" label is expected`)
 
 	parentID := imgs[0]
 
@@ -4656,7 +4656,7 @@ func (s *DockerCLIBuildSuite) TestBuildMultiStageGlobalArg(c *testing.T) {
 	result.Assert(c, icmd.Success)
 
 	imgs := strings.Split(strings.TrimSpace(result.Stdout()), "\n")
-	assert.Assert(c, cmp.Len(imgs, 1), `only one image with "multifromtest" label is expected`)
+	assert.Assert(c, is.Len(imgs, 1), `only one image with "multifromtest" label is expected`)
 
 	parentID := imgs[0]
 
@@ -4783,7 +4783,7 @@ func (s *DockerCLIBuildSuite) TestBuildFollowSymlinkToFile(c *testing.T) {
 	cli.BuildCmd(c, name, build.WithExternalBuildContext(ctx))
 
 	out := cli.DockerCmd(c, "run", "--rm", name, "cat", "target").Combined()
-	assert.Assert(c, cmp.Regexp("^bar$", out))
+	assert.Assert(c, is.Regexp("^bar$", out))
 
 	// change target file should invalidate cache
 	err = os.WriteFile(filepath.Join(ctx.Dir, "foo"), []byte("baz"), 0o644)
@@ -4792,7 +4792,7 @@ func (s *DockerCLIBuildSuite) TestBuildFollowSymlinkToFile(c *testing.T) {
 	result := cli.BuildCmd(c, name, build.WithExternalBuildContext(ctx))
 	assert.Assert(c, !strings.Contains(result.Combined(), "Using cache"))
 	out = cli.DockerCmd(c, "run", "--rm", name, "cat", "target").Combined()
-	assert.Assert(c, cmp.Regexp("^baz$", out))
+	assert.Assert(c, is.Regexp("^baz$", out))
 }
 
 func (s *DockerCLIBuildSuite) TestBuildFollowSymlinkToDir(c *testing.T) {
@@ -4813,7 +4813,7 @@ func (s *DockerCLIBuildSuite) TestBuildFollowSymlinkToDir(c *testing.T) {
 	cli.BuildCmd(c, name, build.WithExternalBuildContext(ctx))
 
 	out := cli.DockerCmd(c, "run", "--rm", name, "cat", "abc", "def").Combined()
-	assert.Assert(c, cmp.Regexp("^barbaz$", out))
+	assert.Assert(c, is.Regexp("^barbaz$", out))
 
 	// change target file should invalidate cache
 	err = os.WriteFile(filepath.Join(ctx.Dir, "foo/def"), []byte("bax"), 0o644)
@@ -4822,7 +4822,7 @@ func (s *DockerCLIBuildSuite) TestBuildFollowSymlinkToDir(c *testing.T) {
 	result := cli.BuildCmd(c, name, build.WithExternalBuildContext(ctx))
 	assert.Assert(c, !strings.Contains(result.Combined(), "Using cache"))
 	out = cli.DockerCmd(c, "run", "--rm", name, "cat", "abc", "def").Combined()
-	assert.Assert(c, cmp.Regexp("^barbax$", out))
+	assert.Assert(c, is.Regexp("^barbax$", out))
 }
 
 // TestBuildSymlinkBasename tests that target file gets basename from symlink,
@@ -4844,7 +4844,7 @@ func (s *DockerCLIBuildSuite) TestBuildSymlinkBasename(c *testing.T) {
 	cli.BuildCmd(c, name, build.WithExternalBuildContext(ctx))
 
 	out := cli.DockerCmd(c, "run", "--rm", name, "cat", "asymlink").Combined()
-	assert.Assert(c, cmp.Regexp("^bar$", out))
+	assert.Assert(c, is.Regexp("^bar$", out))
 }
 
 // #17827

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4623,7 +4623,12 @@ func (s *DockerCLIBuildSuite) TestBuildMultiStageArg(c *testing.T) {
 	result.Assert(c, icmd.Success)
 
 	result = cli.DockerCmd(c, "images", "-q", "-f", "label=multifromtest=1")
-	parentID := strings.TrimSpace(result.Stdout())
+	result.Assert(c, icmd.Success)
+
+	imgs := strings.Split(strings.TrimSpace(result.Stdout()), "\n")
+	assert.Assert(c, cmp.Len(imgs, 1), `only one image with "multifromtest" label is expected`)
+
+	parentID := imgs[0]
 
 	result = cli.DockerCmd(c, "run", "--rm", parentID, "cat", "/out")
 	assert.Assert(c, strings.Contains(result.Stdout(), "foo=abc"))
@@ -4648,7 +4653,12 @@ func (s *DockerCLIBuildSuite) TestBuildMultiStageGlobalArg(c *testing.T) {
 	result.Assert(c, icmd.Success)
 
 	result = cli.DockerCmd(c, "images", "-q", "-f", "label=multifromtest=1")
-	parentID := strings.TrimSpace(result.Stdout())
+	result.Assert(c, icmd.Success)
+
+	imgs := strings.Split(strings.TrimSpace(result.Stdout()), "\n")
+	assert.Assert(c, cmp.Len(imgs, 1), `only one image with "multifromtest" label is expected`)
+
+	parentID := imgs[0]
 
 	result = cli.DockerCmd(c, "run", "--rm", parentID, "cat", "/out")
 	assert.Assert(c, !strings.Contains(result.Stdout(), "tag"))


### PR DESCRIPTION
**- What I did**
Fixed `TestBuildMultiStageArg` and `TestBuildMultiStageGlobalArg` to have a saner error message when `docker images` returns more than one image.




**- How I did it**

**- How to verify it**
```bash
$ make DOCKER_GRAPHDRIVER=overlayfs \
             DOCKER_BUILDKIT=0 \
             TEST_INTEGRATION_USE_SNAPSHOTTER=1  \
             TEST_FILTER='(TestBuildMultiStageArg|TestBuildMultiStageGlobalArg)'  \
              test-integration
```


<details>

<summary>Before</summary>


```
=== FAIL: arm64.integration-cli TestDockerCLIBuildSuite/TestBuildMultiStageArg (1.74s)
    docker_cli_build_test.go:4628: assertion failed:
        Command:  /usr/local/cli-integration/docker run --rm 24133bd11b7a
        e43aad44e67b cat /out
        ExitCode: 125
        Error:    exit status 125
        Stdout:
        Stderr:   docker: invalid reference format.
        See 'docker run --help'.


        Failures:
        ExitCode was 125 expected 0
        Expected no error
    --- FAIL: TestDockerCLIBuildSuite/TestBuildMultiStageArg (1.74s)

=== FAIL: arm64.integration-cli TestDockerCLIBuildSuite/TestBuildMultiStageGlobalArg (1.21s)
    docker_cli_build_test.go:4653: assertion failed:
        Command:  /usr/local/cli-integration/docker run --rm c94132f5d3b5
        d81ffc1589dc cat /out
        ExitCode: 125
        Error:    exit status 125
        Stdout:
        Stderr:   docker: invalid reference format.
        See 'docker run --help'.


        Failures:
        ExitCode was 125 expected 0
        Expected no error
    --- FAIL: TestDockerCLIBuildSuite/TestBuildMultiStageGlobalArg (1.21s)

=== FAIL: arm64.integration-cli TestDockerCLIBuildSuite (2.95s)

```

</details>

<details>

<summary>After</summary>

```
=== FAIL: arm64.integration-cli TestDockerCLIBuildSuite/TestBuildMultiStageArg (4.06s)
    docker_cli_build_test.go:4629: assertion failed: expected [3c977a3fb50e b732767e946c] (length 2) to have length 1: only one image with "multifromtest" label is expected
    --- FAIL: TestDockerCLIBuildSuite/TestBuildMultiStageArg (4.06s)

=== FAIL: arm64.integration-cli TestDockerCLIBuildSuite/TestBuildMultiStageGlobalArg (5.44s)
    docker_cli_build_test.go:4659: assertion failed: expected [801c8500dd4a da5eea1f7933] (length 2) to have length 1: only one image with "multifromtest" label is expected
    --- FAIL: TestDockerCLIBuildSuite/TestBuildMultiStageGlobalArg (5.44s)

=== FAIL: arm64.integration-cli TestDockerCLIBuildSuite (9.51s)

```

</details>

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

