### PR TITLE
c8d: Add image events

### DIFF
--- a/daemon/containerd/image_exporter.go
+++ b/daemon/containerd/image_exporter.go
@@ -113,6 +113,8 @@ func (i *ImageService) ExportImage(ctx context.Context, names []string, outStrea
 				"target": target,
 			}).Debug("export image without name")
 		}
+
+		i.LogImageEvent(target.Digest.String(), target.Digest.String(), events.ActionSave)
 	}
 
 	return i.client.Export(ctx, outStream, opts...)

--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containerd/containerd/pkg/snapshotters"
 	"github.com/containerd/containerd/platforms"
 	"github.com/distribution/reference"
+	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/streamformatter"
@@ -88,5 +89,8 @@ func (i *ImageService) PullImage(ctx context.Context, image, tagOrDigest string,
 		// error to not mark the pull as failed.
 		logger.WithError(err).Warn("unexpected error while removing outdated dangling image reference")
 	}
+
+	i.LogImageEvent(reference.FamiliarString(ref), reference.FamiliarName(ref), events.ActionPull)
+
 	return nil
 }

--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/distribution/reference"
+	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/progress"
@@ -147,6 +148,9 @@ func (i *ImageService) PushImage(ctx context.Context, targetRef reference.Named,
 		}
 	}
 
+	if err == nil {
+		i.LogImageEvent(reference.FamiliarString(targetRef), reference.FamiliarName(targetRef), events.ActionPush)
+	}
 	return err
 }
 


### PR DESCRIPTION
**- What I did**

Added image events for 

- push
- pull
- save

**- How I did it**

With my hands

**- How to verify it**

Change line 84 in `hack/make/.integration-test-helpers` to say
```
flags+=" -test.run ${TEST_FILTER}/"
```

and run:

```console
$ make DOCKER_GRAPHDRIVER=overlayfs TEST_FILTER=DockerCLIEventSuite TEST_INTEGRATION_USE_SNAPSHOTTER=1 test-integration
```

All the tests should pass.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Djordje Lukic <djordje.lukic@docker.com>