### PR TITLE
daemon: fix under what conditions container's mac-address is applied

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -870,7 +870,8 @@ func buildCreateEndpointOptions(c *container.Container, n *libnetwork.Network, e
 	// to which container was connected to on docker run.
 	// Ideally all these network-specific endpoint configurations must be moved under
 	// container.NetworkSettings.Networks[n.Name()]
-	if nwName == c.HostConfig.NetworkMode.NetworkName() || (nwName == defaultNetName && c.HostConfig.NetworkMode.IsDefault()) {
+	netMode := c.HostConfig.NetworkMode
+	if nwName == netMode.NetworkName() || n.ID() == netMode.NetworkName() || (nwName == defaultNetName && netMode.IsDefault()) {
 		if c.Config.MacAddress != "" {
 			mac, err := net.ParseMAC(c.Config.MacAddress)
 			if err != nil {

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -286,3 +286,29 @@ func TestRunWithAlternativeContainerdShim(t *testing.T) {
 
 	assert.Equal(t, strings.TrimSpace(b.String()), "Hello, world!")
 }
+
+func TestMacAddressIsAppliedToMainNetworkWithShortID(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon)
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+
+	ctx := testutil.StartSpan(baseContext, t)
+
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t)
+	defer d.Stop(t)
+
+	apiClient := d.NewClientT(t)
+
+	n := net.CreateNoError(ctx, t, apiClient, "testnet", net.WithIPAM("192.168.101.0/24", "192.168.101.1"))
+
+	cid := container.Run(ctx, t, apiClient,
+		container.WithImage("busybox:latest"),
+		container.WithCmd("/bin/sleep", "infinity"),
+		container.WithStopSignal("SIGKILL"),
+		container.WithNetworkMode(n[:10]),
+		container.WithMacAddress("02:42:08:26:a9:55"))
+	defer container.Remove(ctx, t, apiClient, cid, types.ContainerRemoveOptions{Force: true})
+
+	c := container.Inspect(ctx, t, apiClient, cid)
+	assert.Equal(t, c.NetworkSettings.Networks["testnet"].MacAddress, "02:42:08:26:a9:55")
+}

--- a/integration/internal/container/container.go
+++ b/integration/internal/container/container.go
@@ -154,3 +154,19 @@ func demultiplexStreams(ctx context.Context, resp types.HijackedResponse) (strea
 	wg.Wait()
 	return s, err
 }
+
+func Remove(ctx context.Context, t *testing.T, apiClient client.APIClient, container string, options types.ContainerRemoveOptions) {
+	t.Helper()
+
+	err := apiClient.ContainerRemove(ctx, container, options)
+	assert.NilError(t, err)
+}
+
+func Inspect(ctx context.Context, t *testing.T, apiClient client.APIClient, containerRef string) types.ContainerJSON {
+	t.Helper()
+
+	c, err := apiClient.ContainerInspect(ctx, containerRef)
+	assert.NilError(t, err)
+
+	return c
+}

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -280,3 +280,15 @@ func WithPIDMode(mode container.PidMode) func(c *TestContainerConfig) {
 		c.HostConfig.PidMode = mode
 	}
 }
+
+func WithStopSignal(stopSignal string) func(c *TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.Config.StopSignal = stopSignal
+	}
+}
+
+func WithMacAddress(address string) func(c *TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.Config.MacAddress = address
+	}
+}


### PR DESCRIPTION
**- What I did**

- Fix https://github.com/moby/moby/issues/46404
- Fix docker/compose#10796

The daemon would pass an EndpointCreateOption to set the interface MAC address if the network name and the provided network mode were matching. Obviously, if the network mode is a network ID, it won't work. To make things worse, the network mode is never normalized if it's a partial ID.

To fix that: 1. the condition under what the container's mac-address is applied is updated to also match the full ID; 2. the network mode is normalized to a full ID when it's only a partial one.

**- How to verify it**

```
$ docker run --rm --name test --network 6cabee8406 --mac-address "02:42:ac:11:00:02" nicolaka/netshoot ip -brief link show dev eth0
eth0@if92        UP             02:42:ac:11:00:02 <BROADCAST,MULTICAST,UP,LOWER_UP> 
```

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://upload.wikimedia.org/wikipedia/commons/d/d4/Sea_otter_pair2.jpg)
