### PR TITLE
daemon: GetImageAndReleasableLayer: simplify "FROM scratch" case

### DIFF
--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -45,22 +45,18 @@ const imageLabelClassicBuilderParent = "org.mobyproject.image.parent"
 // reference or ID. Every call to GetImageAndReleasableLayer MUST call
 // releasableLayer.Release() to prevent leaking of layers.
 func (i *ImageService) GetImageAndReleasableLayer(ctx context.Context, refOrID string, opts backend.GetImageAndLayerOptions) (builder.Image, builder.ROLayer, error) {
-	if refOrID == "" { // from SCRATCH
-		imgOS := runtime.GOOS
+	if refOrID == "" { // FROM scratch
 		if runtime.GOOS == "windows" {
-			imgOS = "linux"
+			return nil, nil, fmt.Errorf(`"FROM scratch" is not supported on Windows`)
 		}
 		if opts.Platform != nil {
-			imgOS = opts.Platform.OS
-		}
-		if err := dimage.CheckOS(imgOS); err != nil {
-			return nil, nil, err
+			if err := dimage.CheckOS(opts.Platform.OS); err != nil {
+				return nil, nil, err
+			}
 		}
 		return nil, &rolayer{
-			key:         "",
 			c:           i.client,
 			snapshotter: i.snapshotter,
-			diffID:      "",
 		}, nil
 	}
 


### PR DESCRIPTION
Windows doesn't support "FROM scratch", and the platform was only used for validation on other platforms if a platform was provided, so no need to set defaults.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

