### PR TITLE
c8d/import: Don't close compressed stream twice

### DIFF
--- a/daemon/containerd/image_import.go
+++ b/daemon/containerd/image_import.go
@@ -258,7 +258,6 @@ func compressAndWriteBlob(ctx context.Context, cs content.Store, compression arc
 	if err != nil {
 		return "", "", errdefs.InvalidParameter(err)
 	}
-	defer compressor.Close()
 
 	writeChan := make(chan digest.Digest)
 	// Start copying the blob to the content store from the pipe.


### PR DESCRIPTION
The compressor is already closed a few lines below and there's no error
returns between so the defer is not needed.

Calling Close twice on a writerCloserWrapper is unsafe as it causes it
to put the same buffer to the pool multiple times.

**- What I did**
Fixed random stack overflow daemon panics after import is performed.

**- How I did it**
Removed double `Close`.

**- How to verify it**
```bash
$ make DOCKER_GRAPHDRIVER=overlayfs  TEST_INTEGRATION_USE_SNAPSHOTTER=1 TEST_FILTER='TestImport'    test-integration
```
Check the daemon doesn't panic with stack overflow.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

