### PR TITLE
daemon: convert short network ID into full name

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -696,6 +696,11 @@ func (daemon *Daemon) connectToNetwork(cfg *config.Config, container *container.
 			return err
 		}
 	}
+	// If idOrName is a partial ID, we just delete the matching entry from container's endpoint settings. An entry
+	// will be recreated below with the network name used as a key.
+	if idOrName != n.ID() && idOrName != nwName {
+		delete(container.NetworkSettings.Networks, idOrName)
+	}
 
 	var operIPAM bool
 	if nwCfg != nil {

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -302,3 +302,35 @@ func TestMacAddressIsAppliedToMainNetworkWithShortID(t *testing.T) {
 	c := container.Inspect(ctx, t, apiClient, cid)
 	assert.Equal(t, c.NetworkSettings.Networks["testnet"].MacAddress, "02:42:08:26:a9:55")
 }
+
+func TestShortNetworkIDIsReplacedWithNetworkName(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon)
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+
+	ctx := testutil.StartSpan(baseContext, t)
+
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t)
+	defer d.Stop(t)
+
+	apiClient := d.NewClientT(t)
+
+	n := net.CreateNoError(ctx, t, apiClient, "testnet",
+		net.WithIPAM("192.168.100.0/24", "192.168.100.1"))
+
+	cid := container.Run(ctx, t, apiClient,
+		container.WithImage("busybox:latest"),
+		container.WithCmd("/bin/sleep", "infinity"),
+		container.WithStopSignal("SIGKILL"),
+		container.WithNetworkMode(n[:10]),
+		container.WithIPv4(n[:10], "192.168.100.10"))
+	defer container.Remove(ctx, t, apiClient, cid, types.ContainerRemoveOptions{Force: true})
+
+	c := container.Inspect(ctx, t, apiClient, cid)
+	networks := make([]string, 0, len(c.NetworkSettings.Networks))
+	for n := range c.NetworkSettings.Networks {
+		networks = append(networks, n)
+	}
+
+	assert.DeepEqual(t, networks, []string{"testnet"})
+}


### PR DESCRIPTION
**- What I did**

The daemon already expect in many places that endpoints in `container.NetworkSettings.Networks` to be keyed by network's full name, once the endpoint has been effectively created.

Also, it already handles full ID -> full name conversion but it doesn't properly handle the case where user-specified settings where stored with a partial network ID key.

Because of this missing case, if a container is created with a reference to a partial network ID, two entries for the same network are inserted in `container.NetworkSettings.Networks`.

Beside bad UX (ie. duplicated entry when inspecting the container), there's another concrete issue: when such container is disconnected from a network and then restarted, the container will be unintendedly reconnected to that network.

**- How to verify it**

New integration test is green, or by hand:

```
$ docker network create --subnet 192.168.100.0/24 testnet1
9b8a3a46b182e42523fcc625629e83ee00435a5b16016f8b4823f810e7f2a3e6

$ docker run --rm --name test --network 9b8a3a46b1 --ip 192.168.100.24 -d nicolaka/netshoot /bin/sleep 1m

# Prior to this fix:
$ docker inspect test | jq '.[] | .NetworkSettings.Networks | keys'
[
  "9b8a3a46b1",
  "testnet1"
]
# And after:
$ docker inspect test | jq '.[] | .NetworkSettings.Networks | keys'
[
  "testnet1"
]
```

**- A picture of a cute animal (not mandatory but encouraged)**

<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/Sea_Otter_%28Enhydra_lutris%29_%2825169790524%29_crop.jpg/800px-Sea_Otter_%28Enhydra_lutris%29_%2825169790524%29_crop.jpg" width=75% height=75% />
