### PR TITLE
Add Fuzz Driver for MergeDaemonConfigurations API (Issue #44361)

### DIFF
--- a/daemon/config/FuzzTestBuilderGC.go
+++ b/daemon/config/FuzzTestBuilderGC.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"secsys/gout-transformation/pkg/transstruct"
+	"testing"
+
+	"gotest.tools/v3/fs"
+)
+
+func FuzzTestBuilderGC(XVl []byte) int {
+	t := &testing.T{}
+	_ = t
+	transstruct.SetFuzzData(XVl)
+	FDG_FuzzGlobal()
+
+	tempFile := fs.NewFile(t, "config", fs.WithContent(transstruct.GetString(`{
+  "builder": {
+    "gc": {
+      "enabled": true,
+      "policy": [
+        {"keepStorage": "10GB", "filter": ["unused-for=2200h"]},
+        {"keepStorage": "50GB", "filter": {"unused-for": {"3300h": true}}},
+        {"keepStorage": "100GB", "all": true}
+      ]
+    }
+  }
+}`)))
+	defer tempFile.Remove()
+	configFile := tempFile.Path()
+
+	MergeDaemonConfigurations(&Config{}, nil, configFile)
+	return 1
+}
+
+func FDG_FuzzGlobal() {
+
+}


### PR DESCRIPTION
## Overview

This pull request introduces a fuzz driver that addresses issue #44361. The purpose of this fuzz driver is to rigorously test the MergeDaemonConfigurations API by injecting mutated data into its arguments. By doing so, we aim to enhance our continuous testing efforts and ensure the robustness of this API.

## Details

The fuzz driver has been designed to thoroughly exercise the MergeDaemonConfigurations API.
It accomplishes this by systematically injecting various forms of mutated data into the API's arguments.
Through this approach, we can identify potential vulnerabilities and edge cases that might otherwise go unnoticed.
## Additional Information

We want to highlight that we have already developed numerous fuzz drivers, each serving as a valuable addition to our testing suite. If this PR is well-received, we are eager to contribute more fuzz drivers to further bolster our testing capabilities.

Thus, we are eager for your feedback and guidance on the process of adding fuzz drivers. Specifically, we would appreciate insights on the following:

- Deployment: How should we handle the deployment of these fuzz drivers within the project's testing infrastructure?
- Testing Metrics: Are there specific testing metrics or criteria that you consider essential for evaluating the effectiveness of these fuzz drivers?
- Any Other Concerns: Please let us know if you have any other concerns or preferences related to the inclusion of fuzz drivers in the project.

Thank you for considering this contribution, and we look forward to your feedback.