### PR TITLE
integration/container: fix flaky resize tests, and some cleaning up

### DIFF
--- a/integration/container/resize_test.go
+++ b/integration/container/resize_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/container"
 	req "github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
@@ -49,13 +50,11 @@ func TestResizeWhenContainerNotStarted(t *testing.T) {
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()
 
-	cID := container.Run(ctx, t, apiClient, container.WithCmd("echo"))
-
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "exited"), poll.WithDelay(100*time.Millisecond))
-
+	cID := container.Create(ctx, t, apiClient, container.WithCmd("echo"))
 	err := apiClient.ContainerResize(ctx, cID, types.ResizeOptions{
 		Height: 40,
 		Width:  40,
 	})
+	assert.Check(t, is.ErrorType(err, errdefs.IsConflict))
 	assert.Check(t, is.ErrorContains(err, "is not running"))
 }

--- a/integration/container/resize_test.go
+++ b/integration/container/resize_test.go
@@ -18,37 +18,39 @@ func TestResize(t *testing.T) {
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()
 
-	cID := container.Run(ctx, t, apiClient, container.WithTty(true))
-	err := apiClient.ContainerResize(ctx, cID, types.ResizeOptions{
-		Height: 40,
-		Width:  40,
+	t.Run("success", func(t *testing.T) {
+		cID := container.Run(ctx, t, apiClient, container.WithTty(true))
+		err := apiClient.ContainerResize(ctx, cID, types.ResizeOptions{
+			Height: 40,
+			Width:  40,
+		})
+		assert.NilError(t, err)
+		// TODO(thaJeztah): also check if the resize happened
+		//
+		// Note: container inspect shows the initial size that was
+		// set when creating the container. Actual resize happens in
+		// containerd, and currently does not update the container's
+		// config after running (but does send a "resize" event).
 	})
-	assert.NilError(t, err)
-}
 
-func TestResizeWithInvalidSize(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.32"), "broken in earlier versions")
-	ctx := setupTest(t)
-	apiClient := testEnv.APIClient()
+	t.Run("invalid size", func(t *testing.T) {
+		skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.32"), "broken in earlier versions")
+		cID := container.Run(ctx, t, apiClient)
 
-	cID := container.Run(ctx, t, apiClient)
-
-	// Manually creating a request here, as the APIClient would invalidate
-	// these values before they're sent.
-	res, _, err := req.Post(ctx, "/containers/"+cID+"/resize?h=foo&w=bar")
-	assert.NilError(t, err)
-	assert.Check(t, is.DeepEqual(http.StatusBadRequest, res.StatusCode))
-}
-
-func TestResizeWhenContainerNotStarted(t *testing.T) {
-	ctx := setupTest(t)
-	apiClient := testEnv.APIClient()
-
-	cID := container.Create(ctx, t, apiClient, container.WithCmd("echo"))
-	err := apiClient.ContainerResize(ctx, cID, types.ResizeOptions{
-		Height: 40,
-		Width:  40,
+		// Manually creating a request here, as the APIClient would invalidate
+		// these values before they're sent.
+		res, _, err := req.Post(ctx, "/containers/"+cID+"/resize?h=foo&w=bar")
+		assert.NilError(t, err)
+		assert.Check(t, is.DeepEqual(http.StatusBadRequest, res.StatusCode))
 	})
-	assert.Check(t, is.ErrorType(err, errdefs.IsConflict))
-	assert.Check(t, is.ErrorContains(err, "is not running"))
+
+	t.Run("invalid state", func(t *testing.T) {
+		cID := container.Create(ctx, t, apiClient, container.WithCmd("echo"))
+		err := apiClient.ContainerResize(ctx, cID, types.ResizeOptions{
+			Height: 40,
+			Width:  40,
+		})
+		assert.Check(t, is.ErrorType(err, errdefs.IsConflict))
+		assert.Check(t, is.ErrorContains(err, "is not running"))
+	})
 }


### PR DESCRIPTION
### integration/container: fix flaky TestResizeWhenContainerNotStarted

This test was failing frequently on Windows, where the test was waiting
for the container to exit before continuing;

    === FAIL: github.com/docker/docker/integration/container TestResizeWhenContainerNotStarted (18.69s)
    resize_test.go:58: timeout hit after 10s: waiting for container to be one of (exited), currently running

It looks like this test is merely validating that a container in any non-
running state should produce an error, so there's no need to run a container
(waiting for it to stop), and just "creating" a container (which would be
in `created` state) should work for this purpose.



### integration/container: TestResize, TestResizeWithInvalidSize: rm poll.WaitOn

container.Run should be an synchronous operation; the container should
be running after the request was made (or produce an error). Simplify
these tests, and remove the redundant polling.

These were added as part of 8f800c941570ffcd087c920c37d3a368a5a19e6d,
but no such polls were in place before the refactor, and there's no
mention of these during review of the PR, so I assume these were just
added either as a "precaution", or a result of "copy/paste" from another
test.

### integration/container: combine TestResize tests into subtests

Reduce some of the boiler-plating, and by combining the tests, we skip
the testenv.Clean() in between each of the tests. Performance gain isn't
really measurable, but every bit should help :)


**- A picture of a cute animal (not mandatory but encouraged)**

