### PR TITLE
c8d/builder: Store parent in c8d image label 

### DIFF
--- a/daemon/containerd/image_commit.go
+++ b/daemon/containerd/image_commit.go
@@ -106,6 +106,9 @@ func (i *ImageService) CommitImage(ctx context.Context, cc backend.CommitConfig)
 		Name:      danglingImageName(commitManifestDesc.Digest),
 		Target:    commitManifestDesc,
 		CreatedAt: time.Now(),
+		Labels: map[string]string{
+			imageLabelClassicBuilderParent: cc.ParentImageID,
+		},
 	}
 
 	if _, err := i.client.ImageService().Update(ctx, img); err != nil {

--- a/daemon/containerd/image_tag.go
+++ b/daemon/containerd/image_tag.go
@@ -73,6 +73,17 @@ func (i *ImageService) TagImage(ctx context.Context, imageID image.ID, newTag re
 		return nil
 	}
 
+	builderLabel, ok := sourceDanglingImg.Labels[imageLabelClassicBuilderParent]
+	if ok {
+		newImg.Labels = map[string]string{
+			imageLabelClassicBuilderParent: builderLabel,
+		}
+
+		if _, err := is.Update(context.Background(), newImg, "labels"); err != nil {
+			logger.WithError(err).Warnf("failed to set %s label on the newly tagged image", imageLabelClassicBuilderParent)
+		}
+	}
+
 	// Delete the source dangling image, as it's no longer dangling.
 	if err := is.Delete(context.Background(), sourceDanglingImg.Name); err != nil {
 		logger.WithError(err).Warn("unexpected error when deleting dangling image")

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4642,7 +4642,7 @@ func (s *DockerCLIBuildSuite) TestBuildMultiStageGlobalArg(c *testing.T) {
 	imgName := "multifrombldargtest"
 	dockerfile := `ARG tag=nosuchtag
      FROM busybox:${tag}
-     LABEL multifromtest=1
+     LABEL multifromtest2=1
      RUN env > /out
      FROM busybox:${tag}
      ARG tag
@@ -4653,7 +4653,7 @@ func (s *DockerCLIBuildSuite) TestBuildMultiStageGlobalArg(c *testing.T) {
 		cli.WithFlags("--build-arg", "tag=latest"))
 	result.Assert(c, icmd.Success)
 
-	result = cli.DockerCmd(c, "images", "-q", "-f", "label=multifromtest=1")
+	result = cli.DockerCmd(c, "images", "-q", "-f", "label=multifromtest2=1")
 	result.Assert(c, icmd.Success)
 
 	imgs := strings.Split(strings.TrimSpace(result.Stdout()), "\n")


### PR DESCRIPTION

**- What I did**
Fixed `docker images` showing intermediate layers by default (they should be visible only with `--all`)

**- How I did it**
Store information about parent image as a containerd image object label and use that when listing.

**- How to verify it**
```diff
$ DOCKER_BUILDKIT=0 docker build -t asdf .
Sending build context to Docker daemon  2.048kB
Step 1/4 : FROM busybox
3fbc63216742: Download complete
1fa89c01cd04: Download complete
fc9db2894f4e: Download complete
8a0af25e8c2e: Download complete
 ---> 3fbc63216742
Step 2/4 : LABEL asdf=1
 ---> Running in 8815b66a12a4
 ---> Removed intermediate container 8815b66a12a4
 ---> a2b5f145d9d2
Step 3/4 : RUN env>/env
 ---> Running in 2f71fc879fda
 ---> Removed intermediate container 2f71fc879fda
 ---> 53ef1dea7427
Step 4/4 : CMD ["echo", "hi"]
 ---> Running in 26fb9dab31b2
 ---> Removed intermediate container 26fb9dab31b2
 ---> 59da756a8eb8
Successfully built 59da756a8eb8
Successfully tagged asdf:latest
$ docker images --all
REPOSITORY   TAG       IMAGE ID       CREATED         SIZE
asdf         latest    59da756a8eb8   4 seconds ago   6.11MB
<none>       <none>    53ef1dea7427   4 seconds ago   6.11MB
busybox      latest    3fbc63216742   5 seconds ago   6.09MB
<none>       <none>    a2b5f145d9d2   5 seconds ago   6.09MB
$ docker images
REPOSITORY   TAG       IMAGE ID       CREATED         SIZE
-asdf         latest    59da756a8eb8   4 seconds ago   6.11MB
-<none>       <none>    53ef1dea7427   4 seconds ago   6.11MB
-busybox      latest    3fbc63216742   5 seconds ago   6.09MB
-<none>       <none>    a2b5f145d9d2   5 seconds ago   6.09MB
+asdf         latest    59da756a8eb8   1 second ago    6.11MB
+busybox      latest    3fbc63216742   2 seconds ago   6.09MB
```


Also `TestBuildMultiStageArg` and `TestBuildMultiStageGlobalArg`.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

