### PR TITLE
Add dependabot to update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,11 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "daily"
     groups:
       github-actions:
         patterns:
           - "*"
+    labels:
+      - "dependencies"
+      - "bot"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    groups:
-      github-actions:
-        patterns:
-          - "*"
     labels:
       - "dependencies"
       - "bot"


### PR DESCRIPTION
Fixes #46427.

**- What I did**
Added dependabot to keep GitHub Actions updated on a monthly basis. This takes advantage of dependabot's [grouped updates](https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/), so that the project only receives a single PR each month updating all GitHub Actions at once. See [this PR on my fork](https://github.com/pnacht/moby/pull/1) updating three out-of-date Actions in moby workflows.

I've selected a monthly update schedule so as to minimize the workload as much as possible. That being said, for what it's worth, the "default" schedule is "weekly". Let me know if you'd prefer I use the weekly schedule (or daily, if you're feeling wild!).

**- How I did it**
Added `.github/dependabot.yml` with a single global group for all GitHub Actions.

**- A picture of a cute animal (not mandatory but encouraged)**
![20170513_160019 (1)](https://github.com/moby/moby/assets/15221358/dcf3f0b8-6702-4375-901f-5873660b015e)

