### PR TITLE
Conditionally disable tests when not root

### DIFF
--- a/daemon/daemon_linux_test.go
+++ b/daemon/daemon_linux_test.go
@@ -12,6 +12,7 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/types"
+	"github.com/docker/docker/testutil"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/moby/sys/mount"
 	"github.com/moby/sys/mountinfo"
@@ -333,6 +334,8 @@ func TestRootMountCleanup(t *testing.T) {
 }
 
 func TestIfaceAddrs(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	CIDR := func(cidr string) *net.IPNet {
 		t.Helper()
 		nw, err := types.ParseCIDR(cidr)

--- a/daemon/oci_linux_test.go
+++ b/daemon/oci_linux_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/libnetwork"
+	"github.com/docker/docker/testutil"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
@@ -203,6 +204,8 @@ func TestSysctlOverrideHost(t *testing.T) {
 }
 
 func TestGetSourceMount(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	// must be able to find source mount for /
 	mnt, _, err := getSourceMount("/")
 	assert.NilError(t, err)

--- a/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/libnetwork/options"
 	"github.com/docker/docker/libnetwork/portallocator"
 	"github.com/docker/docker/libnetwork/types"
+	"github.com/docker/docker/testutil"
 	"github.com/vishvananda/netlink"
 )
 
@@ -217,6 +218,8 @@ func getIPv4Data(t *testing.T) []driverapi.IPAMData {
 }
 
 func TestCreateFullOptions(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver()
 
@@ -271,6 +274,8 @@ func TestCreateFullOptions(t *testing.T) {
 }
 
 func TestCreateNoConfig(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver()
 
@@ -284,6 +289,8 @@ func TestCreateNoConfig(t *testing.T) {
 }
 
 func TestCreateFullOptionsLabels(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver()
 
@@ -390,6 +397,8 @@ func TestCreateFullOptionsLabels(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	d := newDriver()
@@ -416,6 +425,8 @@ func TestCreate(t *testing.T) {
 }
 
 func TestCreateFail(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	d := newDriver()
@@ -434,6 +445,8 @@ func TestCreateFail(t *testing.T) {
 }
 
 func TestCreateMultipleNetworks(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	d := newDriver()
@@ -638,6 +651,8 @@ func TestQueryEndpointInfoHairpin(t *testing.T) {
 }
 
 func testQueryEndpointInfo(t *testing.T, ulPxyEnabled bool) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver()
 	d.portAllocator = portallocator.NewInstance()
@@ -740,6 +755,8 @@ func getPortMapping() []types.PortBinding {
 }
 
 func TestLinkContainers(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	d := newDriver()
@@ -894,6 +911,8 @@ func TestLinkContainers(t *testing.T) {
 }
 
 func TestValidateConfig(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	// Test mtu
@@ -965,6 +984,8 @@ func TestValidateConfig(t *testing.T) {
 }
 
 func TestSetDefaultGw(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	d := newDriver()
@@ -1017,6 +1038,8 @@ func TestSetDefaultGw(t *testing.T) {
 }
 
 func TestCleanupIptableRules(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	bridgeChain := []iptables.ChainInfo{
 		{Name: DockerChain, Table: iptables.Nat},
@@ -1047,6 +1070,8 @@ func TestCleanupIptableRules(t *testing.T) {
 }
 
 func TestCreateWithExistingBridge(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver()
 
@@ -1117,6 +1142,8 @@ func TestCreateWithExistingBridge(t *testing.T) {
 }
 
 func TestCreateParallel(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	c := netnsutils.SetupTestOSContextEx(t)
 	defer c.Cleanup(t)
 

--- a/libnetwork/drivers/bridge/interface_linux_test.go
+++ b/libnetwork/drivers/bridge/interface_linux_test.go
@@ -4,10 +4,13 @@ import (
 	"testing"
 
 	"github.com/docker/docker/internal/testutils/netnsutils"
+	"github.com/docker/docker/testutil"
 	"github.com/vishvananda/netlink"
 )
 
 func TestInterfaceDefaultName(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	nh, err := netlink.NewHandle()
@@ -26,6 +29,8 @@ func TestInterfaceDefaultName(t *testing.T) {
 }
 
 func TestAddressesEmptyInterface(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	nh, err := netlink.NewHandle()

--- a/libnetwork/drivers/bridge/network_linux_test.go
+++ b/libnetwork/drivers/bridge/network_linux_test.go
@@ -6,10 +6,13 @@ import (
 	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/netlabel"
+	"github.com/docker/docker/testutil"
 	"github.com/vishvananda/netlink"
 )
 
 func TestLinkCreate(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver()
 
@@ -105,6 +108,8 @@ func TestLinkCreate(t *testing.T) {
 }
 
 func TestLinkCreateTwo(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver()
 
@@ -143,6 +148,8 @@ func TestLinkCreateTwo(t *testing.T) {
 }
 
 func TestLinkCreateNoEnableIPv6(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver()
 
@@ -178,6 +185,8 @@ func TestLinkCreateNoEnableIPv6(t *testing.T) {
 }
 
 func TestLinkDelete(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver()
 

--- a/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -7,9 +7,12 @@ import (
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/ns"
 	"github.com/docker/docker/libnetwork/types"
+	"github.com/docker/docker/testutil"
 )
 
 func TestPortMappingConfig(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver()
 
@@ -89,6 +92,8 @@ func TestPortMappingConfig(t *testing.T) {
 }
 
 func TestPortMappingV6Config(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	if err := loopbackUp(); err != nil {
 		t.Fatalf("Could not bring loopback iface up: %v", err)

--- a/libnetwork/drivers/bridge/setup_device_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_device_linux_test.go
@@ -7,10 +7,13 @@ import (
 
 	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/netutils"
+	"github.com/docker/docker/testutil"
 	"github.com/vishvananda/netlink"
 )
 
 func TestSetupNewBridge(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	nh, err := netlink.NewHandle()
@@ -37,6 +40,8 @@ func TestSetupNewBridge(t *testing.T) {
 }
 
 func TestSetupNewNonDefaultBridge(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	nh, err := netlink.NewHandle()
@@ -59,6 +64,8 @@ func TestSetupNewNonDefaultBridge(t *testing.T) {
 }
 
 func TestSetupDeviceUp(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	nh, err := netlink.NewHandle()
@@ -84,6 +91,8 @@ func TestSetupDeviceUp(t *testing.T) {
 }
 
 func TestGenerateRandomMAC(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	mac1 := netutils.GenerateRandomMAC()

--- a/libnetwork/drivers/bridge/setup_ip_forwarding_test.go
+++ b/libnetwork/drivers/bridge/setup_ip_forwarding_test.go
@@ -6,9 +6,13 @@ import (
 	"bytes"
 	"os"
 	"testing"
+
+	"github.com/docker/docker/testutil"
 )
 
 func TestSetupIPForwarding(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	// Read current setting and ensure the original value gets restored
 	procSetting := readCurrentIPForwardingSetting(t)
 	defer reconcileIPForwardingSetting(t, procSetting)

--- a/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/libnetwork/iptables"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/portmapper"
+	"github.com/docker/docker/testutil"
 	"github.com/vishvananda/netlink"
 )
 
@@ -16,6 +17,8 @@ const (
 )
 
 func TestProgramIPTable(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	// Create a test bridge with a basic bridge configuration (name + IPv4).
 	defer netnsutils.SetupTestOSContext(t)()
 
@@ -46,6 +49,8 @@ func TestProgramIPTable(t *testing.T) {
 }
 
 func TestSetupIPChains(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	// Create a test bridge with a basic bridge configuration (name + IPv4).
 	defer netnsutils.SetupTestOSContext(t)()
 

--- a/libnetwork/drivers/bridge/setup_ipv4_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_ipv4_linux_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/internal/testutils/netnsutils"
+	"github.com/docker/docker/testutil"
 	"github.com/vishvananda/netlink"
 )
 
@@ -21,6 +22,8 @@ func setupTestInterface(t *testing.T, nh *netlink.Handle) (*networkConfiguration
 }
 
 func TestSetupBridgeIPv4Fixed(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	ip, netw, err := net.ParseCIDR("192.168.1.1/24")
@@ -59,6 +62,8 @@ func TestSetupBridgeIPv4Fixed(t *testing.T) {
 }
 
 func TestSetupGatewayIPv4(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	nh, err := netlink.NewHandle()

--- a/libnetwork/drivers/bridge/setup_ipv6_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_ipv6_linux_test.go
@@ -8,10 +8,13 @@ import (
 	"testing"
 
 	"github.com/docker/docker/internal/testutils/netnsutils"
+	"github.com/docker/docker/testutil"
 	"github.com/vishvananda/netlink"
 )
 
 func TestSetupIPv6(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	nh, err := netlink.NewHandle()
@@ -53,6 +56,8 @@ func TestSetupIPv6(t *testing.T) {
 }
 
 func TestSetupGatewayIPv6(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	_, nw, _ := net.ParseCIDR("2001:db8:ea9:9abc:ffff::/80")

--- a/libnetwork/drivers/bridge/setup_verify_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_verify_linux_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/internal/testutils/netnsutils"
+	"github.com/docker/docker/testutil"
 	"github.com/vishvananda/netlink"
 )
 
@@ -27,6 +28,8 @@ func setupVerifyTest(t *testing.T) *bridgeInterface {
 }
 
 func TestSetupVerify(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	addrv4 := net.IPv4(192, 168, 1, 1)
@@ -44,6 +47,8 @@ func TestSetupVerify(t *testing.T) {
 }
 
 func TestSetupVerifyBad(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	addrv4 := net.IPv4(192, 168, 1, 1)
@@ -62,6 +67,8 @@ func TestSetupVerifyBad(t *testing.T) {
 }
 
 func TestSetupVerifyMissing(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	addrv4 := net.IPv4(192, 168, 1, 1)
@@ -75,6 +82,8 @@ func TestSetupVerifyMissing(t *testing.T) {
 }
 
 func TestSetupVerifyIPv6(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	addrv4 := net.IPv4(192, 168, 1, 1)
@@ -96,6 +105,8 @@ func TestSetupVerifyIPv6(t *testing.T) {
 }
 
 func TestSetupVerifyIPv6Missing(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	addrv4 := net.IPv4(192, 168, 1, 1)

--- a/libnetwork/endpoint_unix_test.go
+++ b/libnetwork/endpoint_unix_test.go
@@ -9,9 +9,12 @@ import (
 	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/ipamapi"
 	"github.com/docker/docker/libnetwork/osl"
+	"github.com/docker/docker/testutil"
 )
 
 func TestHostsEntries(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	expectedHostsFile := `127.0.0.1	localhost

--- a/libnetwork/firewall_linux_test.go
+++ b/libnetwork/firewall_linux_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker/libnetwork/iptables"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/options"
+	"github.com/docker/docker/testutil"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -20,6 +21,8 @@ const (
 )
 
 func TestUserChain(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	iptable4 := iptables.GetIptable(iptables.IPv4)
 	iptable6 := iptables.GetIptable(iptables.IPv6)
 

--- a/libnetwork/iptables/firewalld_test.go
+++ b/libnetwork/iptables/firewalld_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/docker/docker/testutil"
 	"github.com/godbus/dbus/v5"
 )
 
@@ -33,6 +34,8 @@ func TestFirewalldInit(t *testing.T) {
 }
 
 func TestReloaded(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	iptable := GetIptable(IPv4)
 	fwdChain, err := iptable.NewChain("FWD", Filter, false)
 	if err != nil {

--- a/libnetwork/iptables/iptables_test.go
+++ b/libnetwork/iptables/iptables_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/testutil"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -18,6 +19,8 @@ const (
 )
 
 func createNewChain(t *testing.T) (*IPTable, *ChainInfo, *ChainInfo) {
+	testutil.SkipWhenUnprivileged(t)
+
 	t.Helper()
 	iptable := GetIptable(IPv4)
 

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/libnetwork/netutils"
 	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
+	"github.com/docker/docker/testutil"
 	"gotest.tools/v3/skip"
 )
 
@@ -310,6 +311,8 @@ func compareNwLists(a, b []*net.IPNet) bool {
 }
 
 func TestAuxAddresses(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	c, err := New()
@@ -347,6 +350,8 @@ func TestAuxAddresses(t *testing.T) {
 }
 
 func TestSRVServiceQuery(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	skip.If(t, runtime.GOOS == "windows", "test only works on linux")
 
 	defer netnsutils.SetupTestOSContext(t)()
@@ -444,6 +449,8 @@ func TestSRVServiceQuery(t *testing.T) {
 }
 
 func TestServiceVIPReuse(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	skip.If(t, runtime.GOOS == "windows", "test only works on linux")
 
 	defer netnsutils.SetupTestOSContext(t)()
@@ -561,6 +568,8 @@ func TestServiceVIPReuse(t *testing.T) {
 }
 
 func TestIpamReleaseOnNetDriverFailures(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	skip.If(t, runtime.GOOS == "windows", "test only works on linux")
 
 	defer netnsutils.SetupTestOSContext(t)()

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/docker/docker/pkg/plugins"
 	"github.com/docker/docker/pkg/reexec"
+	"github.com/docker/docker/testutil"
 	"github.com/pkg/errors"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
@@ -88,6 +89,8 @@ func isNotFound(err error) bool {
 }
 
 func TestNull(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -138,6 +141,8 @@ func TestNull(t *testing.T) {
 }
 
 func TestUnknownDriver(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -152,6 +157,8 @@ func TestUnknownDriver(t *testing.T) {
 }
 
 func TestNilRemoteDriver(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -167,6 +174,8 @@ func TestNilRemoteDriver(t *testing.T) {
 }
 
 func TestNetworkName(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -202,6 +211,8 @@ func TestNetworkName(t *testing.T) {
 }
 
 func TestNetworkType(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -227,6 +238,8 @@ func TestNetworkType(t *testing.T) {
 }
 
 func TestNetworkID(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -252,6 +265,8 @@ func TestNetworkID(t *testing.T) {
 }
 
 func TestDeleteNetworkWithActiveEndpoints(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -292,6 +307,8 @@ func TestDeleteNetworkWithActiveEndpoints(t *testing.T) {
 }
 
 func TestNetworkConfig(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -393,6 +410,8 @@ func TestNetworkConfig(t *testing.T) {
 }
 
 func TestUnknownNetwork(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -424,6 +443,8 @@ func TestUnknownNetwork(t *testing.T) {
 }
 
 func TestUnknownEndpoint(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -465,6 +486,8 @@ func TestUnknownEndpoint(t *testing.T) {
 }
 
 func TestNetworkEndpointsWalkers(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -594,6 +617,8 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 }
 
 func TestDuplicateEndpoint(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -642,6 +667,8 @@ func TestDuplicateEndpoint(t *testing.T) {
 }
 
 func TestControllerQuery(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -829,6 +856,8 @@ func TestNetworkQuery(t *testing.T) {
 const containerID = "valid_c"
 
 func TestEndpointDeleteWithActiveContainer(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -903,6 +932,8 @@ func TestEndpointDeleteWithActiveContainer(t *testing.T) {
 }
 
 func TestEndpointMultipleJoins(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -976,6 +1007,8 @@ func TestEndpointMultipleJoins(t *testing.T) {
 }
 
 func TestLeaveAll(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -1040,6 +1073,8 @@ func TestLeaveAll(t *testing.T) {
 }
 
 func TestContainerInvalidLeave(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -1105,6 +1140,8 @@ func TestContainerInvalidLeave(t *testing.T) {
 }
 
 func TestEndpointUpdateParent(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -1171,6 +1208,8 @@ func TestEndpointUpdateParent(t *testing.T) {
 }
 
 func TestInvalidRemoteDriver(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
 	if server == nil {
@@ -1214,6 +1253,8 @@ func TestInvalidRemoteDriver(t *testing.T) {
 }
 
 func TestValidRemoteDriver(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
 	if server == nil {
@@ -1278,6 +1319,8 @@ func makeTesthostNetwork(t *testing.T, c *libnetwork.Controller) *libnetwork.Net
 }
 
 func TestHost(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -1379,6 +1422,8 @@ func TestHost(t *testing.T) {
 
 // Testing IPV6 from MAC address
 func TestBridgeIpv6FromMac(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -1454,6 +1499,8 @@ func checkSandbox(t *testing.T, info libnetwork.EndpointInfo) {
 }
 
 func TestEndpointJoin(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -1625,6 +1672,8 @@ func TestEndpointJoin(t *testing.T) {
 }
 
 func TestExternalKey(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	externalKeyTest(t, false)
 }
 
@@ -1790,6 +1839,8 @@ func reexecSetKey(key string, containerID string, controllerID string) error {
 }
 
 func TestEnableIPv6(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -1867,6 +1918,8 @@ func TestEnableIPv6(t *testing.T) {
 }
 
 func TestResolvConfHost(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -1942,6 +1995,8 @@ func TestResolvConfHost(t *testing.T) {
 }
 
 func TestResolvConf(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -2135,6 +2190,8 @@ func (pt parallelTester) Do(t *testing.T, thrNumber int) error {
 }
 
 func TestParallel(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	const (
 		first      = 1
 		last       = 3
@@ -2204,6 +2261,8 @@ func TestParallel(t *testing.T) {
 }
 
 func TestBridge(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
@@ -2292,6 +2351,8 @@ func isV6Listenable() bool {
 }
 
 func TestNullIpam(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 

--- a/libnetwork/netutils/utils_linux_test.go
+++ b/libnetwork/netutils/utils_linux_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/ipamutils"
 	"github.com/docker/docker/libnetwork/types"
+	"github.com/docker/docker/testutil"
 	"github.com/vishvananda/netlink"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -247,6 +248,8 @@ func TestUtilGenerateRandomMAC(t *testing.T) {
 }
 
 func TestNetworkRequest(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	nw, err := FindAvailableNetwork(ipamutils.GetLocalScopeDefaultNetworks())

--- a/libnetwork/networkdb/networkdb_test.go
+++ b/libnetwork/networkdb/networkdb_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/containerd/containerd/log"
 	"github.com/docker/docker/pkg/stringid"
+	"github.com/docker/docker/testutil"
 	"github.com/docker/go-events"
 	"github.com/hashicorp/memberlist"
 	"gotest.tools/v3/assert"
@@ -271,6 +272,8 @@ func TestNetworkDBCRUDTableEntry(t *testing.T) {
 }
 
 func TestNetworkDBCRUDTableEntries(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	dbs := createNetworkDBInstances(t, 2, "node", DefaultConfig())
 
 	err := dbs[0].JoinNetwork("network1")

--- a/libnetwork/portmapper/mapper_linux_test.go
+++ b/libnetwork/portmapper/mapper_linux_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/libnetwork/iptables"
+	"github.com/docker/docker/testutil"
 )
 
 func init() {
@@ -195,6 +196,8 @@ func TestMapAllPortsSingleInterface(t *testing.T) {
 }
 
 func TestMapTCPDummyListen(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	pm := New()
 	dstIP := net.ParseIP("0.0.0.0")
 	dstAddr := &net.TCPAddr{IP: dstIP, Port: 80}
@@ -232,6 +235,8 @@ func TestMapTCPDummyListen(t *testing.T) {
 }
 
 func TestMapUDPDummyListen(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	pm := New()
 	dstIP := net.ParseIP("0.0.0.0")
 	dstAddr := &net.UDPAddr{IP: dstIP, Port: 80}

--- a/libnetwork/sandbox_unix_test.go
+++ b/libnetwork/sandbox_unix_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/options"
 	"github.com/docker/docker/libnetwork/osl"
+	"github.com/docker/docker/testutil"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -91,6 +92,8 @@ func TestControllerGetSandbox(t *testing.T) {
 }
 
 func TestSandboxAddEmpty(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	ctrlr, _ := getTestEnv(t)
 
 	sbx, err := ctrlr.NewSandbox("sandbox0")
@@ -111,6 +114,8 @@ func TestSandboxAddEmpty(t *testing.T) {
 
 // // If different priorities are specified, internal option and ipv6 addresses mustn't influence endpoint order
 func TestSandboxAddMultiPrio(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	opts := [][]NetworkOption{
@@ -195,6 +200,8 @@ func TestSandboxAddMultiPrio(t *testing.T) {
 }
 
 func TestSandboxAddSamePrio(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 
 	opts := [][]NetworkOption{

--- a/libnetwork/service_common_unix_test.go
+++ b/libnetwork/service_common_unix_test.go
@@ -7,10 +7,13 @@ import (
 	"testing"
 
 	"github.com/docker/docker/internal/testutils/netnsutils"
+	"github.com/docker/docker/testutil"
 	"gotest.tools/v3/assert"
 )
 
 func TestCleanupServiceDiscovery(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer netnsutils.SetupTestOSContext(t)()
 	c, err := New()
 	assert.NilError(t, err)

--- a/libnetwork/store_linux_test.go
+++ b/libnetwork/store_linux_test.go
@@ -9,9 +9,12 @@ import (
 	"github.com/docker/docker/libnetwork/config"
 	"github.com/docker/docker/libnetwork/datastore"
 	store "github.com/docker/docker/libnetwork/internal/kvstore"
+	"github.com/docker/docker/testutil"
 )
 
 func TestBoltdbBackend(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	defer os.Remove(datastore.DefaultScope("").Client.Address)
 	testLocalBackend(t, "", "", nil)
 	tmpPath := filepath.Join(t.TempDir(), "boltdb.db")
@@ -21,6 +24,8 @@ func TestBoltdbBackend(t *testing.T) {
 }
 
 func TestNoPersist(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	dbFile := filepath.Join(t.TempDir(), "bolt.db")
 	configOption := func(c *config.Config) {
 		c.Scope.Client.Provider = "boltdb"

--- a/libnetwork/store_test.go
+++ b/libnetwork/store_test.go
@@ -10,6 +10,7 @@ import (
 	store "github.com/docker/docker/libnetwork/internal/kvstore"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/options"
+	"github.com/docker/docker/testutil"
 )
 
 func testLocalBackend(t *testing.T, provider, url string, storeConfig *store.Config) {
@@ -83,6 +84,8 @@ func OptionBoltdbWithRandomDBFile(t *testing.T) config.Option {
 }
 
 func TestMultipleControllersWithSameStore(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
+
 	cfgOptions := OptionBoltdbWithRandomDBFile(t)
 	ctrl1, err := New(cfgOptions)
 	if err != nil {

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containerd/containerd/pkg/userns"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/ioutils"
+	"github.com/docker/docker/testutil"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
@@ -1244,6 +1245,7 @@ func TestXGlobalNoParent(t *testing.T) {
 // header entries are created recursively with the default mode (permissions) stored in ImpliedDirectoryMode. This test
 // also verifies that the permissions of explicit directories are respected.
 func TestImpliedDirectoryPermissions(t *testing.T) {
+	testutil.SkipWhenUnprivileged(t)
 	skip.If(t, runtime.GOOS == "windows", "skipping test that requires Unix permissions")
 
 	buf := &bytes.Buffer{}

--- a/testutil/helpers.go
+++ b/testutil/helpers.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"gotest.tools/v3/icmd"
+	"gotest.tools/v3/skip"
 )
 
 // DevZero acts like /dev/zero but in an OS-independent fashion.
@@ -156,4 +157,15 @@ func SetContext(t TestingT, ctx context.Context) {
 
 func CleanupContext(t *testing.T) {
 	testContexts.Delete(t)
+}
+
+// SkipWhenUnprivileged skips test when run by an unprivileged user, such as a distro package build.
+func SkipWhenUnprivileged(t *testing.T, reason ...string) {
+	r := "requires root"
+
+	if len(reason) > 0 {
+		r = reason[0]
+	}
+
+	skip.If(t, os.Getuid() != 0, r)
 }


### PR DESCRIPTION
Root resources are not available when building moby in a Linux package build environment. This change conditionally disables them when not run as root. See discussion at https://github.com/moby/moby/discussions/46387. Not being a Go programmer, I've done my best to try and match the local style; C&C welcome.

**- What I did**
I have added conditional skips in unit tests which require root privileges.

**- How I did it**
N/A

**- How to verify it**
This is a port of a patch I made to get moby building in an RPM mock environment. We like to run as much of a projects testing as we can to build confidence that our build is correct and functional. If you run this in an RPM mock environment you'll see some of these tests skip (the mock builder is not run as root). They're run with a standard `go test` invocation. Some modules are skipped entirely, and are not modified here.

I have verified that the preferred way of developing Moby is unaffected by running `make test-unit` and verifying that tests are not skipped erroneously. (DONE 3142 tests, 27 skipped in 37.667s and DONE 344 tests, 2 skipped in 243.128s).

**- Description for the changelog**
(not a user-facing change)

**- A picture of a cute animal (not mandatory but encouraged)**

![Image from iOS_cropped](https://github.com/moby/moby/assets/278804/dd2ee6b8-dedc-4c81-be87-fcccb0db1519)