### PR TITLE
Use process substitution to redirect to tee

### DIFF
--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -68,4 +68,4 @@ source hack/make/.integration-test-helpers
 		exec docker run --rm ${run_opts} --mount type=bind,"src=${ABS_DEST}","dst=/src/${DEST}" "${docker_py_image}" pytest ${PY_TEST_OPTIONS} tests/integration
 	)
 	bundle .integration-daemon-stop
-) 2>&1 | tee -a "$DEST/test.log"
+) &> >(tee -a "$DEST/test.log")

--- a/hack/make/test-integration
+++ b/hack/make/test-integration
@@ -24,4 +24,4 @@ fi
 	set -x
 	exit ${testexit}
 
-) 2>&1 | tee -a "$DEST/test.log"
+) &> >(tee -a "$DEST/test.log")


### PR DESCRIPTION
**- What I did**

In some cases, when the daemon launched by a test panics and quits, the cleanup code would end with an error when trying to kill it by its pid. In those cases the whole suite will end up waiting for the daemon that we start in .integration-daemon-start to finish and we end up waiting 2 hours for the CI to cancel after a timeout.

Using process substitution makes the integration tests quit.

**- How I did it**

**- How to verify it**

Run 

```console
$ make DOCKER_GRAPHDRIVER=overlayfs TEST_FILTER=TestRunWithRuntimeFromConfigFile TEST_INTEGRATION_USE_SNAPSHOTTER=1 test-integration
```

Before this change this will never stop and hang after the `/go/src/github.com/docker/docker/hack/make/.integration-daemon-stop: line 11: kill: (1269) - No such process` error.

After this change the script will stop after the kill error in the cleanup code.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

