### PR TITLE
integration-cli: Skip TestRmiParentImageFail when using c8d snapshotters

### DIFF
--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/pkg/stringid"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
+	"gotest.tools/v3/skip"
 )
 
 type DockerCLIRmiSuite struct {
@@ -303,6 +304,8 @@ RUN echo 2 #layer2
 }
 
 func (*DockerCLIRmiSuite) TestRmiParentImageFail(c *testing.T) {
+	skip.If(c, testEnv.UsingSnapshotter(), "image are independent when using the containerd image store")
+
 	buildImageSuccessfully(c, "test", build.WithDockerfile(`
 	FROM busybox
 	RUN echo hello`))


### PR DESCRIPTION
With containerd image store the images don't depend on each other even if they share the same content and it's totally fine to delete the "parent" image.

The skip is necessary because deleting the "parent" image does not produce an error with the c8d image store and deleting the `busybox` image breaks other tests.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

