### PR TITLE
c8d: Remove the panic from UpdateConfig

### DIFF
--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -142,7 +142,7 @@ func (i *ImageService) LayerDiskUsage(ctx context.Context) (int64, error) {
 //
 // called from reload.go
 func (i *ImageService) UpdateConfig(maxDownloads, maxUploads int) {
-	panic("not implemented")
+	log.G(context.TODO()).Warn("max downloads and uploads is not yet implemented with the containerd store")
 }
 
 // GetLayerFolders returns the layer folders from an image RootFS.


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Remove the last panic from the image service, I only removed it, didn't fid the download/upload limits...

We don't really want the daemon to panic for this so let's log a warning about max downloads and uploads

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

