### PR TITLE
registry: assorted fixes for search

### DIFF
--- a/registry/registry_mock_test.go
+++ b/registry/registry_mock_test.go
@@ -76,35 +76,30 @@ func makeHTTPSURL(req string) string {
 }
 
 func makeIndex(req string) *registry.IndexInfo {
-	index := &registry.IndexInfo{
+	return &registry.IndexInfo{
 		Name: makeURL(req),
 	}
-	return index
 }
 
 func makeHTTPSIndex(req string) *registry.IndexInfo {
-	index := &registry.IndexInfo{
+	return &registry.IndexInfo{
 		Name: makeHTTPSURL(req),
 	}
-	return index
 }
 
 func makePublicIndex() *registry.IndexInfo {
-	index := &registry.IndexInfo{
+	return &registry.IndexInfo{
 		Name:     IndexServer,
 		Secure:   true,
 		Official: true,
 	}
-	return index
 }
 
 func makeServiceConfig(mirrors []string, insecureRegistries []string) (*serviceConfig, error) {
-	options := ServiceOptions{
+	return newServiceConfig(ServiceOptions{
 		Mirrors:            mirrors,
 		InsecureRegistries: insecureRegistries,
-	}
-
-	return newServiceConfig(options)
+	})
 }
 
 func writeHeaders(w http.ResponseWriter) {

--- a/registry/registry_mock_test.go
+++ b/registry/registry_mock_test.go
@@ -114,8 +114,6 @@ func writeHeaders(w http.ResponseWriter) {
 	h.Add("Content-Type", "application/json")
 	h.Add("Pragma", "no-cache")
 	h.Add("Cache-Control", "no-cache")
-	h.Add("X-Docker-Registry-Version", "0.0.0")
-	h.Add("X-Docker-Registry-Config", "mock")
 }
 
 func writeResponse(w http.ResponseWriter, message interface{}, code int) {
@@ -156,5 +154,5 @@ func TestPing(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal(t, res.StatusCode, http.StatusOK, "")
-	assert.Equal(t, res.Header.Get("X-Docker-Registry-Config"), "mock", "This is not a Mocked Registry")
+	assert.Equal(t, res.Header.Get("Server"), "docker-tests/mock")
 }

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,14 +1,12 @@
 package registry // import "github.com/docker/docker/registry"
 
 import (
-	"os"
 	"testing"
 
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types/registry"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
-	"gotest.tools/v3/skip"
 )
 
 func TestParseRepositoryInfo(t *testing.T) {
@@ -381,7 +379,6 @@ func TestNewIndexInfo(t *testing.T) {
 }
 
 func TestMirrorEndpointLookup(t *testing.T) {
-	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 	containsMirror := func(endpoints []APIEndpoint) bool {
 		for _, pe := range endpoints {
 			if pe.URL.Host == "my.mirror" {

--- a/registry/search_endpoint_v1.go
+++ b/registry/search_endpoint_v1.go
@@ -15,12 +15,8 @@ import (
 )
 
 // v1PingResult contains the information returned when pinging a registry. It
-// indicates the registry's version and whether the registry claims to be a
-// standalone registry.
+// indicates whether the registry claims to be a standalone registry.
 type v1PingResult struct {
-	// Version is the registry version supplied by the registry in an HTTP
-	// header
-	Version string `json:"version"`
 	// Standalone is set to true if the registry indicates it is a
 	// standalone registry in the X-Docker-Registry-Standalone
 	// header
@@ -158,10 +154,6 @@ func (e *v1Endpoint) ping() (v1PingResult, error) {
 		log.G(context.TODO()).WithError(err).Debug("error unmarshaling _ping response")
 		// don't stop here. Just assume sane defaults
 	}
-	if hdr := resp.Header.Get("X-Docker-Registry-Version"); hdr != "" {
-		info.Version = hdr
-	}
-	log.G(context.TODO()).Debugf("v1PingResult.Version: %q", info.Version)
 
 	standalone := resp.Header.Get("X-Docker-Registry-Standalone")
 

--- a/registry/search_endpoint_v1.go
+++ b/registry/search_endpoint_v1.go
@@ -48,37 +48,24 @@ func newV1Endpoint(index *registry.IndexInfo, headers http.Header) (*v1Endpoint,
 		return endpoint, nil
 	}
 
-	err = validateEndpoint(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	return endpoint, nil
-}
-
-func validateEndpoint(endpoint *v1Endpoint) error {
 	// Try HTTPS ping to registry
 	endpoint.URL.Scheme = "https"
 	if _, err := endpoint.ping(); err != nil {
 		if endpoint.IsSecure {
 			// If registry is secure and HTTPS failed, show user the error and tell them about `--insecure-registry`
-			// in case that's what they need. DO NOT accept unknown CA certificates, and DO NOT fallback to HTTP.
-			return invalidParamf("invalid registry endpoint %s: %v. If this private registry supports only HTTP or HTTPS with an unknown CA certificate, please add `--insecure-registry %s` to the daemon's arguments. In the case of HTTPS, if you have access to the registry's CA certificate, no need for the flag; simply place the CA certificate at /etc/docker/certs.d/%s/ca.crt", endpoint, err, endpoint.URL.Host, endpoint.URL.Host)
+			// in case that's what they need. DO NOT accept unknown CA certificates, and DO NOT fall back to HTTP.
+			return nil, invalidParamf("invalid registry endpoint %s: %v. If this private registry supports only HTTP or HTTPS with an unknown CA certificate, please add `--insecure-registry %s` to the daemon's arguments. In the case of HTTPS, if you have access to the registry's CA certificate, no need for the flag; simply place the CA certificate at /etc/docker/certs.d/%s/ca.crt", endpoint, err, endpoint.URL.Host, endpoint.URL.Host)
 		}
 
-		// If registry is insecure and HTTPS failed, fallback to HTTP.
+		// registry is insecure and HTTPS failed, fallback to HTTP.
 		log.G(context.TODO()).WithError(err).Debugf("error from registry %q marked as insecure - insecurely falling back to HTTP", endpoint)
 		endpoint.URL.Scheme = "http"
-
-		var err2 error
-		if _, err2 = endpoint.ping(); err2 == nil {
-			return nil
+		if _, err2 := endpoint.ping(); err2 != nil {
+			return nil, invalidParamf("invalid registry endpoint %q. HTTPS attempt: %v. HTTP attempt: %v", endpoint, err, err2)
 		}
-
-		return invalidParamf("invalid registry endpoint %q. HTTPS attempt: %v. HTTP attempt: %v", endpoint, err, err2)
 	}
 
-	return nil
+	return endpoint, nil
 }
 
 // trimV1Address trims the "v1" version suffix off the address and returns

--- a/registry/search_endpoint_v1.go
+++ b/registry/search_endpoint_v1.go
@@ -42,6 +42,12 @@ func newV1Endpoint(index *registry.IndexInfo, headers http.Header) (*v1Endpoint,
 		return nil, err
 	}
 
+	if endpoint.String() == IndexServer {
+		// Skip the check, we know this one is valid
+		// (and we never want to fall back to http in case of error)
+		return endpoint, nil
+	}
+
 	err = validateEndpoint(endpoint)
 	if err != nil {
 		return nil, err

--- a/registry/search_endpoint_v1.go
+++ b/registry/search_endpoint_v1.go
@@ -51,8 +51,6 @@ func newV1Endpoint(index *registry.IndexInfo, headers http.Header) (*v1Endpoint,
 }
 
 func validateEndpoint(endpoint *v1Endpoint) error {
-	log.G(context.TODO()).Debugf("pinging registry endpoint %s", endpoint)
-
 	// Try HTTPS ping to registry
 	endpoint.URL.Scheme = "https"
 	if _, err := endpoint.ping(); err != nil {
@@ -125,8 +123,8 @@ func (e *v1Endpoint) ping() (v1PingResult, error) {
 		return v1PingResult{}, nil
 	}
 
-	log.G(context.TODO()).Debugf("attempting v1 ping for registry endpoint %s", e)
 	pingURL := e.String() + "_ping"
+	log.G(context.TODO()).WithField("url", pingURL).Debug("attempting v1 ping for registry endpoint")
 	req, err := http.NewRequest(http.MethodGet, pingURL, nil)
 	if err != nil {
 		return v1PingResult{}, invalidParam(err)

--- a/registry/search_endpoint_v1_test.go
+++ b/registry/search_endpoint_v1_test.go
@@ -3,7 +3,6 @@ package registry // import "github.com/docker/docker/registry"
 import (
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -168,17 +167,8 @@ func TestV1EndpointValidate(t *testing.T) {
 	testServer := httptest.NewServer(requireBasicAuthHandler)
 	defer testServer.Close()
 
-	testServerURL, err := url.Parse(testServer.URL)
+	testEndpoint, err := newV1Endpoint(&registry.IndexInfo{Name: testServer.URL}, nil)
 	if err != nil {
-		t.Fatal(err)
-	}
-
-	testEndpoint := v1Endpoint{
-		URL:    testServerURL,
-		client: httpClient(newTransport(nil)),
-	}
-
-	if err = validateEndpoint(&testEndpoint); err != nil {
 		t.Fatal(err)
 	}
 

--- a/registry/search_endpoint_v1_test.go
+++ b/registry/search_endpoint_v1_test.go
@@ -3,18 +3,15 @@ package registry // import "github.com/docker/docker/registry"
 import (
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types/registry"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
-	"gotest.tools/v3/skip"
 )
 
 func TestV1EndpointPing(t *testing.T) {
-	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 	testPing := func(index *registry.IndexInfo, expectedStandalone bool, assertMessage string) {
 		ep, err := newV1Endpoint(index, nil)
 		if err != nil {
@@ -34,7 +31,6 @@ func TestV1EndpointPing(t *testing.T) {
 }
 
 func TestV1Endpoint(t *testing.T) {
-	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 	// Simple wrapper to fail test if err != nil
 	expandEndpoint := func(index *registry.IndexInfo) *v1Endpoint {
 		endpoint, err := newV1Endpoint(index, nil)


### PR DESCRIPTION
There's more to be fixed here (e.g. in most cases we're not even using the client that's constructed for the  `v1Endpoint`, so there's probably a lot more to be removed, but here's some bits I had lying around.


### registry: remove use of v1 Version field and X-Docker-Registry-Version

- The `Version` field was not used for any purpose, other than a debug log
- The `X-Docker-Registry-Version` header was part of the registry v1 spec,
  however, as we're not using the `Version` field, we don't need the
  header for anything.
- The `X-Docker-Registry-Config` header was only set by the mock registry;
  there's no code consuming it, so we don't need to mock it (even if an
  actual v1 registry / search API would return it).

It's also worth noting that we never call the `_ping` endpoint when using
Docker Hub's search API, and Docker Hub does not even implement the `_ping`
endpoint;

    curl -fsSL https://index.docker.io/_ping | head -n 4
    <!DOCTYPE html>
    <html lang="en">
    <head>
    <title>Docker</title>


### registry: v1Endpoint.ping: add fast-path for X-Docker-Registry-Standalone

This function was making a request to the `_ping` endpoint, which (if
implemented) would return a JSON response, which we unmarshal (the only
field we use from the response is the `Standalone` field).

However, if the response had a `X-Docker-Registry-Standalone`, that header
took precedence, and would overwrite the earlier `Standalone` value we
obtained from the JSON response.

This patch adds a fast-path for situations where the header is present,
in which case we can skip handling the JSON response altogether.

### registry: v1Endpoint.ping: don't io.Readall the response

We have the response available, which is an io.Reader, so we don't have
to read the entire response into memory before decoding.

### registry: v1Endpoint.ping: include URL in debug log

Also remove log from `validateEndpoint`, because we don't actually
ping the default (Docker Hub).

### registry: newV1Endpoint: make it clear we skip validation for Docker Hub

validateEndpoint uses `v1Endpoint.ping` to verify if the search API can
use a secure connection, and to fall back to basic auth. For Docker Hub,
we don't allow insecure connections, and `v1Endpoint.ping` will not connect
to Docker Hub (Docker Hub also does not implement the `_ping` endpoint,
so doing so would always fail).

Let's make it more clear that we don't do any validation, and return
early.

### registry: remove intermediate vars in mock


### registry: merge validateEndpoint into newV1Endpoint

validateEndpoint was doing more than just validating; it was also implicitly
mutating the endpoint that was passed to it (by reference).

Given that validation only happend when constructing a new v1Endpoint, let's
merge these functions.









**- A picture of a cute animal (not mandatory but encouraged)**

