### PR TITLE
hack: compile w/o optimizations & inlining when debugging

### DIFF
--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -74,11 +74,15 @@ source "${MAKEDIR}/.go-autogen"
 		fi
 	fi
 
+	if [ -n "${DOCKER_DEBUG}" ]; then
+		GCFLAGS="all=-N -l"
+	fi
+
 	echo "Building $([ "$DOCKER_STATIC" = "1" ] && echo "static" || echo "dynamic") $DEST/$BINARY_FULLNAME ($PLATFORM_NAME)..."
 	if [ -n "$DOCKER_DEBUG" ]; then
 		set -x
 	fi
-	./hack/with-go-mod.sh go build -mod=vendor -modfile=vendor.mod -o "$DEST/$BINARY_FULLNAME" "${BUILDFLAGS[@]}" -ldflags "$LDFLAGS $LDFLAGS_STATIC $DOCKER_LDFLAGS" "$GO_PACKAGE"
+	./hack/with-go-mod.sh go build -mod=vendor -modfile=vendor.mod -o "$DEST/$BINARY_FULLNAME" "${BUILDFLAGS[@]}" -ldflags "$LDFLAGS $LDFLAGS_STATIC $DOCKER_LDFLAGS" -gcflags="${GCFLAGS}" "$GO_PACKAGE"
 )
 
 echo "Created binary: $DEST/$BINARY_FULLNAME"


### PR DESCRIPTION
**- What I did**

Without these compile flags, Delve is unable to report the value of some variables and it's not possible to jump into inlined code.

As the contributing docs already mention that `DOCKER_DEBUG` should disable "build optimizations", the env var is reused here instead of introducing a new one.

**- How to verify it**

```
$ objdump --dwarf bundles/binary-daemon/dockerd | grep DW_AT_producer | grep -m 1 -- "-N -l"
    <47>   DW_AT_producer    : Go cmd/compile go1.20.7; -N -l regabi
```

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://www.numerama.com/wp-content/uploads/2023/04/castor.jpg)

