### PR TITLE
vendor: github.com/cncf-tags/container-device-interface v0.6.1

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -24,7 +24,7 @@ require (
 	github.com/aws/smithy-go v1.13.5
 	github.com/bsphere/le_go v0.0.0-20200109081728-fc06dab2caa8
 	github.com/cloudflare/cfssl v1.6.4
-	github.com/container-orchestrated-devices/container-device-interface v0.6.0
+	github.com/container-orchestrated-devices/container-device-interface v0.6.1
 	github.com/containerd/cgroups/v3 v3.0.2
 	github.com/containerd/containerd v1.6.22
 	github.com/containerd/continuity v0.4.1

--- a/vendor.sum
+++ b/vendor.sum
@@ -311,8 +311,8 @@ github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOi
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codahale/hdrhistogram v0.0.0-20160425231609-f8ad88b59a58/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
-github.com/container-orchestrated-devices/container-device-interface v0.6.0 h1:aWwcz/Ep0Fd7ZuBjQGjU/jdPloM7ydhMW13h85jZNvk=
-github.com/container-orchestrated-devices/container-device-interface v0.6.0/go.mod h1:OQlgtJtDrOxSQ1BWODC8OZK1tzi9W69wek+Jy17ndzo=
+github.com/container-orchestrated-devices/container-device-interface v0.6.1 h1:mz77uJoP8im/4Zins+mPqt677ZMaflhoGaYrRAl5jvA=
+github.com/container-orchestrated-devices/container-device-interface v0.6.1/go.mod h1:40T6oW59rFrL/ksiSs7q45GzjGlbvxnA4xaK6cyq+kA=
 github.com/container-storage-interface/spec v1.5.0 h1:lvKxe3uLgqQeVQcrnL2CPQKISoKjTJxojEs9cBk+HXo=
 github.com/container-storage-interface/spec v1.5.0/go.mod h1:8K96oQNkJ7pFcC2R9Z1ynGGBB1I93kcS6PGg3SsOk8s=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=

--- a/vendor/github.com/container-orchestrated-devices/container-device-interface/pkg/cdi/cache.go
+++ b/vendor/github.com/container-orchestrated-devices/container-device-interface/pkg/cdi/cache.go
@@ -49,7 +49,7 @@ type Cache struct {
 }
 
 // WithAutoRefresh returns an option to control automatic Cache refresh.
-// By default auto-refresh is enabled, the list of Spec directories are
+// By default, auto-refresh is enabled, the list of Spec directories are
 // monitored and the Cache is automatically refreshed whenever a change
 // is detected. This option can be used to disable this behavior when a
 // manually refreshed mode is preferable.
@@ -203,7 +203,7 @@ func (c *Cache) refresh() error {
 // RefreshIfRequired triggers a refresh if necessary.
 func (c *Cache) refreshIfRequired(force bool) (bool, error) {
 	// We need to refresh if
-	// - it's forced by an explicitly call to Refresh() in manual mode
+	// - it's forced by an explicit call to Refresh() in manual mode
 	// - a missing Spec dir appears (added to watch) in auto-refresh mode
 	if force || (c.autoRefresh && c.watch.update(c.dirErrors)) {
 		return true, c.refresh()
@@ -244,7 +244,7 @@ func (c *Cache) InjectDevices(ociSpec *oci.Spec, devices ...string) ([]string, e
 
 	if unresolved != nil {
 		return unresolved, fmt.Errorf("unresolvable CDI devices %s",
-			strings.Join(devices, ", "))
+			strings.Join(unresolved, ", "))
 	}
 
 	if err := edits.Apply(ociSpec); err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -212,7 +212,7 @@ github.com/cloudflare/cfssl/log
 github.com/cloudflare/cfssl/ocsp/config
 github.com/cloudflare/cfssl/signer
 github.com/cloudflare/cfssl/signer/local
-# github.com/container-orchestrated-devices/container-device-interface v0.6.0
+# github.com/container-orchestrated-devices/container-device-interface v0.6.1
 ## explicit; go 1.17
 github.com/container-orchestrated-devices/container-device-interface/internal/multierror
 github.com/container-orchestrated-devices/container-device-interface/internal/validation


### PR DESCRIPTION
Removes uses of the github.com/opencontainers/runc/libcontainer/devices package.

full diff: https://github.com/cncf-tags/container-device-interface/compare/v0.6.0...v0.6.1


**- A picture of a cute animal (not mandatory but encouraged)**

