### PR TITLE
[24.0]: Update buildkit to fix source policy order

### DIFF
--- a/builder/builder-next/worker/worker.go
+++ b/builder/builder-next/worker/worker.go
@@ -50,7 +50,7 @@ import (
 )
 
 func init() {
-	version.Version = "v0.11.6+616c3f613b54"
+	version.Version = "v0.11.7+d3e6c1360f6e"
 }
 
 const labelCreatedAt = "buildkit/createdat"

--- a/vendor.mod
+++ b/vendor.mod
@@ -56,7 +56,7 @@ require (
 	github.com/klauspost/compress v1.16.3
 	github.com/miekg/dns v1.1.43
 	github.com/mistifyio/go-zfs/v3 v3.0.1
-	github.com/moby/buildkit v0.11.7-0.20230723230859-616c3f613b54 // IMPORTANT: when updating, also update the version in builder/builder-next/worker/worker.go
+	github.com/moby/buildkit v0.11.7-0.20230908085316-d3e6c1360f6e // IMPORTANT: when updating, also update the version in builder/builder-next/worker/worker.go
 	github.com/moby/ipvs v1.1.0
 	github.com/moby/locker v1.0.1
 	github.com/moby/patternmatcher v0.5.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -1043,8 +1043,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/mapstructure v1.3.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/moby/buildkit v0.8.1/go.mod h1:/kyU1hKy/aYCuP39GZA9MaKioovHku57N6cqlKZIaiQ=
-github.com/moby/buildkit v0.11.7-0.20230723230859-616c3f613b54 h1:LSh03Csyx/zQq8MreC9MYMQE/+5EkohwZMvXSS6kMZo=
-github.com/moby/buildkit v0.11.7-0.20230723230859-616c3f613b54/go.mod h1:bMQDryngJKGvJ/ZuRFhrejurbvYSv3NkGCheQ59X4AM=
+github.com/moby/buildkit v0.11.7-0.20230908085316-d3e6c1360f6e h1:iDGoHMw0bMy+AVD59fVDM+jH6rivbFKCVF4iZ+Uw1Rc=
+github.com/moby/buildkit v0.11.7-0.20230908085316-d3e6c1360f6e/go.mod h1:bMQDryngJKGvJ/ZuRFhrejurbvYSv3NkGCheQ59X4AM=
 github.com/moby/ipvs v1.1.0 h1:ONN4pGaZQgAx+1Scz5RvWV4Q7Gb+mvfRh3NsPS+1XQQ=
 github.com/moby/ipvs v1.1.0/go.mod h1:4VJMWuf098bsUMmZEiD4Tjk/O7mOn3l1PTD3s4OoYAs=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=

--- a/vendor/github.com/moby/buildkit/solver/llbsolver/solver.go
+++ b/vendor/github.com/moby/buildkit/solver/llbsolver/solver.go
@@ -977,27 +977,21 @@ func loadEntitlements(b solver.Builder) (entitlements.Set, error) {
 }
 
 func loadSourcePolicy(b solver.Builder) (*spb.Policy, error) {
-	set := make(map[spb.Rule]struct{}, 0)
+	var srcPol spb.Policy
 	err := b.EachValue(context.TODO(), keySourcePolicy, func(v interface{}) error {
 		x, ok := v.(spb.Policy)
 		if !ok {
 			return errors.Errorf("invalid source policy %T", v)
 		}
 		for _, f := range x.Rules {
-			set[*f] = struct{}{}
+			r := *f
+			srcPol.Rules = append(srcPol.Rules, &r)
 		}
+		srcPol.Version = x.Version
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	var srcPol *spb.Policy
-	if len(set) > 0 {
-		srcPol = &spb.Policy{}
-		for k := range set {
-			k := k
-			srcPol.Rules = append(srcPol.Rules, &k)
-		}
-	}
-	return srcPol, nil
+	return &srcPol, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -577,7 +577,7 @@ github.com/mistifyio/go-zfs/v3
 # github.com/mitchellh/hashstructure/v2 v2.0.2
 ## explicit; go 1.14
 github.com/mitchellh/hashstructure/v2
-# github.com/moby/buildkit v0.11.7-0.20230723230859-616c3f613b54
+# github.com/moby/buildkit v0.11.7-0.20230908085316-d3e6c1360f6e
 ## explicit; go 1.18
 github.com/moby/buildkit/api/services/control
 github.com/moby/buildkit/api/types


### PR DESCRIPTION
This brings in moby/buildkit#4215 which fixes a major issue with source policies in buildkit.
