### PR TITLE
integration: don't poll for containers to be running

### DIFF
--- a/integration/container/checkpoint_test.go
+++ b/integration/container/checkpoint_test.go
@@ -47,10 +47,6 @@ func TestCheckpoint(t *testing.T) {
 		Type:   mounttypes.TypeTmpfs,
 		Target: "/tmp",
 	}))
-	poll.WaitOn(t,
-		container.IsInState(ctx, apiClient, cID, "running"),
-		poll.WithDelay(100*time.Millisecond),
-	)
 
 	// FIXME: ipv6 iptables modules are not uploaded in the test environment
 	stdoutStderr, err = exec.Command("bash", "-c", "set -x; "+

--- a/integration/container/devices_windows_test.go
+++ b/integration/container/devices_windows_test.go
@@ -3,14 +3,12 @@ package container // import "github.com/docker/docker/integration/container"
 import (
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/testutil"
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
 
@@ -107,10 +105,7 @@ func TestWindowsDevices(t *testing.T) {
 				assert.ErrorContains(t, err, d.expectedStartFailureMessage)
 				return
 			}
-
 			assert.NilError(t, err)
-
-			poll.WaitOn(t, container.IsInState(ctx, apiClient, id, "running"), poll.WithDelay(100*time.Millisecond))
 
 			// /Windows/System32/HostDriverStore is mounted from the host when class GUID 5B45201D-F2F2-4F3B-85BB-30FF1F953599
 			// is mounted. See `C:\windows\System32\containers\devices.def` on a Windows host for (slightly more) details.

--- a/integration/container/kill_test.go
+++ b/integration/container/kill_test.go
@@ -152,7 +152,6 @@ func TestKillDifferentUserContainer(t *testing.T) {
 	id := container.Run(ctx, t, apiClient, func(c *container.TestContainerConfig) {
 		c.Config.User = "daemon"
 	})
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, id, "running"), poll.WithDelay(100*time.Millisecond))
 
 	err := apiClient.ContainerKill(ctx, id, "SIGKILL")
 	assert.NilError(t, err)

--- a/integration/container/nat_test.go
+++ b/integration/container/nat_test.go
@@ -94,7 +94,7 @@ func startServerContainer(ctx context.Context, t *testing.T, msg string, port in
 	t.Helper()
 	apiClient := testEnv.APIClient()
 
-	cID := container.Run(ctx, t, apiClient,
+	return container.Run(ctx, t, apiClient,
 		container.WithName("server-"+t.Name()),
 		container.WithCmd("sh", "-c", fmt.Sprintf("echo %q | nc -lp %d", msg, port)),
 		container.WithExposedPorts(fmt.Sprintf("%d/tcp", port)),
@@ -106,11 +106,8 @@ func startServerContainer(ctx context.Context, t *testing.T, msg string, port in
 					},
 				},
 			}
-		})
-
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
-
-	return cID
+		},
+	)
 }
 
 // getExternalAddress() returns the external IP-address from eth0. If eth0 has

--- a/integration/container/pause_test.go
+++ b/integration/container/pause_test.go
@@ -27,7 +27,6 @@ func TestPause(t *testing.T) {
 	apiClient := testEnv.APIClient()
 
 	cID := container.Run(ctx, t, apiClient)
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	since := request.DaemonUnixTime(ctx, t, apiClient, testEnv)
 
@@ -58,8 +57,6 @@ func TestPauseFailsOnWindowsServerContainers(t *testing.T) {
 	apiClient := testEnv.APIClient()
 
 	cID := container.Run(ctx, t, apiClient)
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
-
 	err := apiClient.ContainerPause(ctx, cID)
 	assert.Check(t, is.ErrorContains(err, cerrdefs.ErrNotImplemented.Error()))
 }
@@ -72,8 +69,6 @@ func TestPauseStopPausedContainer(t *testing.T) {
 	apiClient := testEnv.APIClient()
 
 	cID := container.Run(ctx, t, apiClient)
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
-
 	err := apiClient.ContainerPause(ctx, cID)
 	assert.NilError(t, err)
 

--- a/integration/container/pidmode_linux_test.go
+++ b/integration/container/pidmode_linux_test.go
@@ -3,14 +3,12 @@ package container // import "github.com/docker/docker/integration/container"
 import (
 	"os"
 	"testing"
-	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/container"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
-	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
 
@@ -25,12 +23,10 @@ func TestPIDModeHost(t *testing.T) {
 	apiClient := testEnv.APIClient()
 
 	cID := container.Run(ctx, t, apiClient, container.WithPIDMode("host"))
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
 	cPid := container.GetContainerNS(ctx, t, apiClient, cID, "pid")
 	assert.Assert(t, hostPid == cPid)
 
 	cID = container.Run(ctx, t, apiClient)
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
 	cPid = container.GetContainerNS(ctx, t, apiClient, cID, "pid")
 	assert.Assert(t, hostPid != cPid)
 }

--- a/integration/container/run_cgroupns_linux_test.go
+++ b/integration/container/run_cgroupns_linux_test.go
@@ -3,7 +3,6 @@ package container // import "github.com/docker/docker/integration/container"
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/container"
@@ -11,7 +10,6 @@ import (
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
 
@@ -24,7 +22,6 @@ func testRunWithCgroupNs(ctx context.Context, t *testing.T, daemonNsMode string,
 	defer d.Stop(t)
 
 	cID := container.Run(ctx, t, apiClient, containerOpts...)
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	daemonCgroup := d.CgroupNamespace(t)
 	containerCgroup := container.GetContainerNS(ctx, t, apiClient, cID, "cgroup")
@@ -148,7 +145,6 @@ func TestCgroupNamespacesRunOlderClient(t *testing.T) {
 	defer d.Stop(t)
 
 	cID := container.Run(ctx, t, apiClient)
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	daemonCgroup := d.CgroupNamespace(t)
 	containerCgroup := container.GetContainerNS(ctx, t, apiClient, cID, "cgroup")

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -49,9 +49,6 @@ func TestNISDomainname(t *testing.T) {
 		c.Config.Hostname = hostname
 		c.Config.Domainname = domainname
 	})
-
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
-
 	inspect, err := apiClient.ContainerInspect(ctx, cID)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(hostname, inspect.Config.Hostname))
@@ -92,9 +89,6 @@ func TestHostnameDnsResolution(t *testing.T) {
 		c.Config.Hostname = hostname
 		c.HostConfig.NetworkMode = containertypes.NetworkMode(netName)
 	})
-
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
-
 	inspect, err := apiClient.ContainerInspect(ctx, cID)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(hostname, inspect.Config.Hostname))
@@ -117,8 +111,6 @@ func TestUnprivilegedPortsAndPing(t *testing.T) {
 	cID := container.Run(ctx, t, apiClient, func(c *container.TestContainerConfig) {
 		c.Config.User = "1000:1000"
 	})
-
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	// Check net.ipv4.ping_group_range.
 	res, err := container.Exec(ctx, apiClient, cID, []string{"cat", "/proc/sys/net/ipv4/ping_group_range"})
@@ -164,8 +156,6 @@ func TestPrivilegedHostDevices(t *testing.T) {
 	defer os.Remove(devRootOnlyTest)
 
 	cID := container.Run(ctx, t, apiClient, container.WithPrivileged(true))
-
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	// Check test device.
 	res, err := container.Exec(ctx, apiClient, cID, []string{"ls", devTest})

--- a/integration/container/stats_test.go
+++ b/integration/container/stats_test.go
@@ -5,13 +5,11 @@ import (
 	"io"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/integration/internal/container"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
-	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
 
@@ -26,9 +24,6 @@ func TestStats(t *testing.T) {
 	assert.NilError(t, err)
 
 	cID := container.Run(ctx, t, apiClient)
-
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
-
 	resp, err := apiClient.ContainerStats(ctx, cID, false)
 	assert.NilError(t, err)
 	defer resp.Body.Close()

--- a/integration/container/stop_linux_test.go
+++ b/integration/container/stop_linux_test.go
@@ -88,7 +88,6 @@ func TestStopContainerWithTimeoutCancel(t *testing.T) {
 	id := container.Run(ctx, t, apiClient,
 		container.WithCmd("sh", "-c", "trap 'echo received TERM' TERM; while true; do usleep 10; done"),
 	)
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, id, "running"))
 
 	ctxCancel, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)

--- a/integration/container/update_linux_test.go
+++ b/integration/container/update_linux_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
-	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
 
@@ -32,8 +31,6 @@ func TestUpdateMemory(t *testing.T) {
 			Memory: 200 * 1024 * 1024,
 		}
 	})
-
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	const (
 		setMemory     int64 = 314572800

--- a/integration/container/wait_test.go
+++ b/integration/container/wait_test.go
@@ -86,8 +86,6 @@ func TestWaitBlocked(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.StartSpan(ctx, t)
 			containerID := container.Run(ctx, t, cli, container.WithCmd("sh", "-c", tc.cmd))
-			poll.WaitOn(t, container.IsInState(ctx, cli, containerID, "running"), poll.WithTimeout(30*time.Second), poll.WithDelay(100*time.Millisecond))
-
 			waitResC, errC := cli.ContainerWait(ctx, containerID, "")
 
 			err := cli.ContainerStop(ctx, containerID, containertypes.StopOptions{})
@@ -213,8 +211,6 @@ func TestWaitRestartedContainer(t *testing.T) {
 				container.WithCmd("sh", "-c", "trap 'exit 5' SIGTERM; while true; do sleep 0.1; done"),
 			)
 			defer cli.ContainerRemove(ctx, containerID, types.ContainerRemoveOptions{Force: true})
-
-			poll.WaitOn(t, container.IsInState(ctx, cli, containerID, "running"), poll.WithTimeout(30*time.Second), poll.WithDelay(100*time.Millisecond))
 
 			// Container is running now, wait for exit
 			waitResC, errC := cli.ContainerWait(ctx, containerID, tc.waitCond)

--- a/integration/plugin/authz/authz_plugin_test.go
+++ b/integration/plugin/authz/authz_plugin_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/docker/docker/pkg/authorization"
 	"github.com/docker/docker/testutil/environment"
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
 
@@ -227,7 +226,6 @@ func TestAuthZPluginAllowEventStream(t *testing.T) {
 
 	// Create a container and wait for the creation events
 	cID := container.Run(ctx, t, c)
-	poll.WaitOn(t, container.IsInState(ctx, c, cID, "running"))
 
 	created := false
 	started := false


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/46422 (https://github.com/moby/moby/pull/46422#discussion_r1319487337)


container.Run() should be a synchronous operation in normal circumstances; the container is created and started, so polling after that for the container to be in the "running" state should not be needed.

This should also prevent issues when a container (for whatever reason) exited immediately after starting; in that case we would continue polling for it to be running (which likely would never happen).

Let's skip the polling; if the container is not in the expected state (i.e. exited), tests should fail as well.


**- A picture of a cute animal (not mandatory but encouraged)**

