### PR TITLE
Plumb context through info endpoint

### DIFF
--- a/api/server/router/system/backend.go
+++ b/api/server/router/system/backend.go
@@ -27,8 +27,8 @@ type DiskUsageOptions struct {
 // Backend is the methods that need to be implemented to provide
 // system specific functionality.
 type Backend interface {
-	SystemInfo() *system.Info
-	SystemVersion() types.Version
+	SystemInfo(context.Context) (*system.Info, error)
+	SystemVersion(context.Context) (types.Version, error)
 	SystemDiskUsage(ctx context.Context, opts DiskUsageOptions) (*types.DiskUsage, error)
 	SubscribeToEvents(since, until time.Time, ef filters.Args) ([]events.Message, chan interface{})
 	UnsubscribeFromEvents(chan interface{})
@@ -38,7 +38,7 @@ type Backend interface {
 // ClusterBackend is all the methods that need to be implemented
 // to provide cluster system specific functionality.
 type ClusterBackend interface {
-	Info() swarm.Info
+	Info(context.Context) swarm.Info
 }
 
 // StatusProvider provides methods to get the swarm status of the current node.

--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -60,10 +60,13 @@ func (s *systemRouter) swarmStatus() string {
 func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	version := httputils.VersionFromContext(ctx)
 	info, _, _ := s.collectSystemInfo.Do(ctx, version, func(ctx context.Context) (*system.Info, error) {
-		info := s.backend.SystemInfo()
+		info, err := s.backend.SystemInfo(ctx)
+		if err != nil {
+			return nil, err
+		}
 
 		if s.cluster != nil {
-			info.Swarm = s.cluster.Info()
+			info.Swarm = s.cluster.Info(ctx)
 			info.Warnings = append(info.Warnings, info.Swarm.Warnings...)
 		}
 
@@ -97,7 +100,10 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 }
 
 func (s *systemRouter) getVersion(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	info := s.backend.SystemVersion()
+	info, err := s.backend.SystemVersion(ctx)
+	if err != nil {
+		return err
+	}
 
 	return httputils.WriteJSON(w, http.StatusOK, info)
 }

--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -249,8 +249,8 @@ func (c *Cluster) newNodeRunner(conf nodeStartConfig) (*nodeRunner, error) {
 	return nr, nil
 }
 
-func (c *Cluster) getRequestContext() (context.Context, func()) { // TODO: not needed when requests don't block on qourum lost
-	return context.WithTimeout(context.Background(), swarmRequestTimeout)
+func (c *Cluster) getRequestContext(ctx context.Context) (context.Context, func()) { // TODO: not needed when requests don't block on qourum lost
+	return context.WithTimeout(ctx, swarmRequestTimeout)
 }
 
 // IsManager returns true if Cluster is participating as a manager.
@@ -443,7 +443,8 @@ func (c *Cluster) lockedManagerAction(fn func(ctx context.Context, state nodeSta
 		return c.errNoManager(state)
 	}
 
-	ctx, cancel := c.getRequestContext()
+	ctx := context.TODO()
+	ctx, cancel := c.getRequestContext(ctx)
 	defer cancel()
 
 	return fn(ctx, state)

--- a/daemon/cluster/configs.go
+++ b/daemon/cluster/configs.go
@@ -41,7 +41,9 @@ func (c *Cluster) GetConfigs(options apitypes.ConfigListOptions) ([]types.Config
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := c.getRequestContext()
+
+	ctx := context.TODO()
+	ctx, cancel := c.getRequestContext(ctx)
 	defer cancel()
 
 	r, err := state.controlClient.ListConfigs(ctx,

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -53,7 +53,7 @@ type Backend interface {
 	SetContainerDependencyStore(name string, store exec.DependencyGetter) error
 	SetContainerSecretReferences(name string, refs []*swarm.SecretReference) error
 	SetContainerConfigReferences(name string, refs []*swarm.ConfigReference) error
-	SystemInfo() *system.Info
+	SystemInfo(context.Context) (*system.Info, error)
 	Containers(ctx context.Context, config *container.ListOptions) ([]*types.Container, error)
 	SetNetworkBootstrapKeys([]*networktypes.EncryptionKey) error
 	DaemonJoinsCluster(provider cluster.Provider)

--- a/daemon/cluster/executor/container/executor.go
+++ b/daemon/cluster/executor/container/executor.go
@@ -58,7 +58,10 @@ func NewExecutor(b executorpkg.Backend, p plugin.Backend, i executorpkg.ImageBac
 
 // Describe returns the underlying node description from the docker client.
 func (e *executor) Describe(ctx context.Context) (*api.NodeDescription, error) {
-	info := e.backend.SystemInfo()
+	info, err := e.backend.SystemInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	plugins := map[api.PluginDescription]struct{}{}
 	addPlugins := func(typ string, names []string) {

--- a/daemon/cluster/nodes.go
+++ b/daemon/cluster/nodes.go
@@ -26,7 +26,8 @@ func (c *Cluster) GetNodes(options apitypes.NodeListOptions) ([]types.Node, erro
 		return nil, err
 	}
 
-	ctx, cancel := c.getRequestContext()
+	ctx := context.TODO()
+	ctx, cancel := c.getRequestContext(ctx)
 	defer cancel()
 
 	r, err := state.controlClient.ListNodes(
@@ -72,7 +73,8 @@ func (c *Cluster) UpdateNode(input string, version uint64, spec types.NodeSpec) 
 			return errdefs.InvalidParameter(err)
 		}
 
-		ctx, cancel := c.getRequestContext()
+		ctx := context.TODO()
+		ctx, cancel := c.getRequestContext(ctx)
 		defer cancel()
 
 		currentNode, err := getNode(ctx, state.controlClient, input)

--- a/daemon/cluster/secrets.go
+++ b/daemon/cluster/secrets.go
@@ -41,7 +41,9 @@ func (c *Cluster) GetSecrets(options apitypes.SecretListOptions) ([]types.Secret
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := c.getRequestContext()
+
+	ctx := context.TODO()
+	ctx, cancel := c.getRequestContext(ctx)
 	defer cancel()
 
 	r, err := state.controlClient.ListSecrets(ctx,

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -21,6 +21,7 @@ import (
 	timetypes "github.com/docker/docker/api/types/time"
 	"github.com/docker/docker/daemon/cluster/convert"
 	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/internal/compatcontext"
 	runconfigopts "github.com/docker/docker/runconfig/opts"
 	gogotypes "github.com/gogo/protobuf/types"
 	swarmapi "github.com/moby/swarmkit/v2/api"
@@ -65,7 +66,8 @@ func (c *Cluster) GetServices(options types.ServiceListOptions) ([]swarm.Service
 		Runtimes:     options.Filters.Get("runtime"),
 	}
 
-	ctx, cancel := c.getRequestContext()
+	ctx := context.TODO()
+	ctx, cancel := c.getRequestContext(ctx)
 	defer cancel()
 
 	r, err := state.controlClient.ListServices(
@@ -263,7 +265,8 @@ func (c *Cluster) CreateService(s swarm.ServiceSpec, encodedAuth string, queryRe
 				// "ctx" could make it impossible to create a service
 				// if the registry is slow or unresponsive.
 				var cancel func()
-				ctx, cancel = c.getRequestContext()
+				ctx = compatcontext.WithoutCancel(ctx)
+				ctx, cancel = c.getRequestContext(ctx)
 				defer cancel()
 			}
 
@@ -378,7 +381,8 @@ func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec swa
 				// "ctx" could make it impossible to update a service
 				// if the registry is slow or unresponsive.
 				var cancel func()
-				ctx, cancel = c.getRequestContext()
+				ctx = compatcontext.WithoutCancel(ctx)
+				ctx, cancel = c.getRequestContext(ctx)
 				defer cancel()
 			}
 		}

--- a/daemon/cluster/swarm.go
+++ b/daemon/cluster/swarm.go
@@ -429,7 +429,7 @@ func (c *Cluster) Leave(ctx context.Context, force bool) error {
 }
 
 // Info returns information about the current cluster state.
-func (c *Cluster) Info() types.Info {
+func (c *Cluster) Info(ctx context.Context) types.Info {
 	info := types.Info{
 		NodeAddr: c.GetAdvertiseAddress(),
 	}
@@ -442,7 +442,7 @@ func (c *Cluster) Info() types.Info {
 		info.Error = state.err.Error()
 	}
 
-	ctx, cancel := c.getRequestContext()
+	ctx, cancel := c.getRequestContext(ctx)
 	defer cancel()
 
 	if state.IsActiveManager() {

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -76,8 +76,8 @@ func (i *ImageService) DistributionServices() images.DistributionServices {
 
 // CountImages returns the number of images stored by ImageService
 // called from info.go
-func (i *ImageService) CountImages() int {
-	imgs, err := i.client.ListImages(context.TODO())
+func (i *ImageService) CountImages(ctx context.Context) int {
+	imgs, err := i.client.ListImages(ctx)
 	if err != nil {
 		return 0
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1175,7 +1175,10 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	}
 	close(d.startupDone)
 
-	info := d.SystemInfo()
+	info, err := d.SystemInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
 	for _, w := range info.Warnings {
 		log.G(ctx).Warn(w)
 	}
@@ -1349,7 +1352,7 @@ func (daemon *Daemon) Subnets() ([]net.IPNet, []net.IPNet) {
 	var v4Subnets []net.IPNet
 	var v6Subnets []net.IPNet
 
-	for _, managedNetwork := range daemon.netController.Networks() {
+	for _, managedNetwork := range daemon.netController.Networks(context.TODO()) {
 		v4infos, v6infos := managedNetwork.IpamInfo()
 		for _, info := range v4infos {
 			if info.IPAMData.Pool != nil {

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -247,8 +247,10 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 		return err
 	}
 
+	ctx := context.TODO()
+
 	// Remove networks not present in HNS
-	for _, v := range daemon.netController.Networks() {
+	for _, v := range daemon.netController.Networks(ctx) {
 		hnsid := v.DriverOptions()[winlibnetwork.HNSID]
 		found := false
 

--- a/daemon/events.go
+++ b/daemon/events.go
@@ -68,7 +68,7 @@ func (daemon *Daemon) LogNetworkEventWithAttributes(nw *libnetwork.Network, acti
 // LogDaemonEventWithAttributes generates an event related to the daemon itself with specific given attributes.
 func (daemon *Daemon) LogDaemonEventWithAttributes(action events.Action, attributes map[string]string) {
 	if daemon.EventsService != nil {
-		if name := hostName(); name != "" {
+		if name := hostName(context.TODO()); name != "" {
 			attributes["name"] = name
 		}
 		daemon.EventsService.Log(action, events.DaemonEventType, events.Actor{

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -36,7 +36,7 @@ type ImageService interface {
 	LoadImage(ctx context.Context, inTar io.ReadCloser, outStream io.Writer, quiet bool) error
 	Images(ctx context.Context, opts types.ImageListOptions) ([]*imagetype.Summary, error)
 	LogImageEvent(imageID, refName string, action events.Action)
-	CountImages() int
+	CountImages(ctx context.Context) int
 	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*types.ImagesPruneReport, error)
 	ImportImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, msg string, layerReader io.Reader, changes []string) (image.ID, error)
 	TagImage(ctx context.Context, imageID image.ID, newTag reference.Named) error

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -102,7 +102,7 @@ func (i *ImageService) DistributionServices() DistributionServices {
 
 // CountImages returns the number of images stored by ImageService
 // called from info.go
-func (i *ImageService) CountImages() int {
+func (i *ImageService) CountImages(ctx context.Context) int {
 	return i.imageStore.Len()
 }
 

--- a/daemon/info_windows.go
+++ b/daemon/info_windows.go
@@ -1,6 +1,8 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/system"
 	"github.com/docker/docker/daemon/config"
@@ -8,10 +10,13 @@ import (
 )
 
 // fillPlatformInfo fills the platform related info.
-func (daemon *Daemon) fillPlatformInfo(v *system.Info, sysInfo *sysinfo.SysInfo, cfg *configStore) {
+func (daemon *Daemon) fillPlatformInfo(ctx context.Context, v *system.Info, sysInfo *sysinfo.SysInfo, cfg *configStore) error {
+	return nil
 }
 
-func (daemon *Daemon) fillPlatformVersion(v *types.Version, cfg *configStore) {}
+func (daemon *Daemon) fillPlatformVersion(ctx context.Context, v *types.Version, cfg *configStore) error {
+	return nil
+}
 
 func fillDriverWarnings(v *system.Info) {
 }

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -139,7 +139,8 @@ func (daemon *Daemon) getAllNetworks() []*libnetwork.Network {
 	if c == nil {
 		return nil
 	}
-	return c.Networks()
+	ctx := context.TODO()
+	return c.Networks(ctx)
 }
 
 type ingressJob struct {
@@ -465,7 +466,7 @@ func (daemon *Daemon) DisconnectContainerFromNetwork(containerName string, netwo
 
 // GetNetworkDriverList returns the list of plugins drivers
 // registered for network.
-func (daemon *Daemon) GetNetworkDriverList() []string {
+func (daemon *Daemon) GetNetworkDriverList(ctx context.Context) []string {
 	if !daemon.NetworkControllerEnabled() {
 		return nil
 	}
@@ -483,7 +484,7 @@ func (daemon *Daemon) GetNetworkDriverList() []string {
 		pluginMap[plugin] = true
 	}
 
-	networks := daemon.netController.Networks()
+	networks := daemon.netController.Networks(ctx)
 
 	for _, nw := range networks {
 		if !pluginMap[nw.Type()] {

--- a/errdefs/is.go
+++ b/errdefs/is.go
@@ -1,5 +1,10 @@
 package errdefs
 
+import (
+	"context"
+	"errors"
+)
+
 type causer interface {
 	Cause() error
 }
@@ -104,4 +109,9 @@ func IsDeadline(err error) bool {
 func IsDataLoss(err error) bool {
 	_, ok := getImplementer(err).(ErrDataLoss)
 	return ok
+}
+
+// IsContext returns if the passed in error is due to context cancellation or deadline exceeded.
+func IsContext(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -820,10 +820,10 @@ func (c *Controller) addNetwork(n *Network) error {
 }
 
 // Networks returns the list of Network(s) managed by this controller.
-func (c *Controller) Networks() []*Network {
+func (c *Controller) Networks(ctx context.Context) []*Network {
 	var list []*Network
 
-	for _, n := range c.getNetworksFromStore() {
+	for _, n := range c.getNetworksFromStore(ctx) {
 		if n.inDelete {
 			continue
 		}
@@ -835,7 +835,7 @@ func (c *Controller) Networks() []*Network {
 
 // WalkNetworks uses the provided function to walk the Network(s) managed by this controller.
 func (c *Controller) WalkNetworks(walker NetworkWalker) {
-	for _, n := range c.Networks() {
+	for _, n := range c.Networks(context.TODO()) {
 		if walker(n) {
 			return
 		}

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -538,7 +538,8 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	current := len(controller.Networks())
+	ctx := context.TODO()
+	current := len(controller.Networks(ctx))
 
 	// Create network 2
 	netOption = options.Generic{
@@ -558,7 +559,7 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 	}()
 
 	// Test Networks method
-	if len(controller.Networks()) != current+1 {
+	if len(controller.Networks(ctx)) != current+1 {
 		t.Fatalf("Did not find the expected number of networks")
 	}
 

--- a/libnetwork/store.go
+++ b/libnetwork/store.go
@@ -34,7 +34,7 @@ func (c *Controller) getStore() *datastore.Store {
 }
 
 func (c *Controller) getNetworkFromStore(nid string) (*Network, error) {
-	for _, n := range c.getNetworksFromStore() {
+	for _, n := range c.getNetworksFromStore(context.TODO()) {
 		if n.id == nid {
 			return n, nil
 		}
@@ -77,21 +77,21 @@ func (c *Controller) getNetworks() ([]*Network, error) {
 	return nl, nil
 }
 
-func (c *Controller) getNetworksFromStore() []*Network { // FIXME: unify with c.getNetworks()
+func (c *Controller) getNetworksFromStore(ctx context.Context) []*Network { // FIXME: unify with c.getNetworks()
 	var nl []*Network
 
 	store := c.getStore()
 	kvol, err := store.List(datastore.Key(datastore.NetworkKeyPrefix), &Network{ctrlr: c})
 	if err != nil {
 		if err != datastore.ErrKeyNotFound {
-			log.G(context.TODO()).Debugf("failed to get networks from store: %v", err)
+			log.G(ctx).Debugf("failed to get networks from store: %v", err)
 		}
 		return nil
 	}
 
 	kvep, err := store.Map(datastore.Key(epCntKeyPrefix), &endpointCnt{})
 	if err != nil && err != datastore.ErrKeyNotFound {
-		log.G(context.TODO()).Warnf("failed to get endpoint_count map from store: %v", err)
+		log.G(ctx).Warnf("failed to get endpoint_count map from store: %v", err)
 	}
 
 	for _, kvo := range kvol {
@@ -185,7 +185,7 @@ retry:
 }
 
 func (c *Controller) networkCleanup() {
-	for _, n := range c.getNetworksFromStore() {
+	for _, n := range c.getNetworksFromStore(context.TODO()) {
 		if n.inDelete {
 			log.G(context.TODO()).Infof("Removing stale network %s (%s)", n.Name(), n.ID())
 			if err := n.delete(true, true); err != nil {

--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -1,6 +1,7 @@
 package fileutils // import "github.com/docker/docker/pkg/fileutils"
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path"
@@ -242,8 +243,9 @@ func TestCreateIfNotExistsFile(t *testing.T) {
 }
 
 func BenchmarkGetTotalUsedFds(b *testing.B) {
+	ctx := context.Background()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = GetTotalUsedFds()
+		_ = GetTotalUsedFds(ctx)
 	}
 }

--- a/pkg/fileutils/fileutils_windows.go
+++ b/pkg/fileutils/fileutils_windows.go
@@ -1,7 +1,9 @@
 package fileutils // import "github.com/docker/docker/pkg/fileutils"
 
+import "context"
+
 // GetTotalUsedFds Returns the number of used File Descriptors. Not supported
 // on Windows.
-func GetTotalUsedFds() int {
+func GetTotalUsedFds(ctx context.Context) int {
 	return -1
 }


### PR DESCRIPTION
I was trying to find out why `docker info` was sometimes slow so plumbing a context through to propagate trace data through.
