### PR TITLE
Fix host_ipv4 bridge option when IPv6 and ip6tables are enabled

### DIFF
--- a/libnetwork/drivers/bridge/setup_ip_tables_linux.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux.go
@@ -157,11 +157,15 @@ func (n *bridgeNetwork) setupIPTables(ipVersion iptables.IPVersion, maskedAddr *
 			return setupInternalNetworkRules(config.BridgeName, maskedAddr, config.EnableICC, false)
 		})
 	} else {
-		if err = setupIPTablesInternal(config.HostIP, config.BridgeName, maskedAddr, config.EnableICC, config.EnableIPMasquerade, hairpinMode, true); err != nil {
+		hostIP := config.HostIP
+		if ipVersion != iptables.IPv4 {
+			hostIP = nil
+		}
+		if err = setupIPTablesInternal(hostIP, config.BridgeName, maskedAddr, config.EnableICC, config.EnableIPMasquerade, hairpinMode, true); err != nil {
 			return fmt.Errorf("Failed to Setup IP tables: %s", err.Error())
 		}
 		n.registerIptCleanFunc(func() error {
-			return setupIPTablesInternal(config.HostIP, config.BridgeName, maskedAddr, config.EnableICC, config.EnableIPMasquerade, hairpinMode, false)
+			return setupIPTablesInternal(hostIP, config.BridgeName, maskedAddr, config.EnableICC, config.EnableIPMasquerade, hairpinMode, false)
 		})
 		natChain, filterChain, _, _, err := n.getDriverChains(ipVersion)
 		if err != nil {


### PR DESCRIPTION
Before this commit, setting the `com.docker.network.host_ipv4` bridge option when `enable_ipv6` is true and the experimental `ip6tables` option is enabled would cause Docker to fail to create the network:

> failed to create network `test-network`: Error response from daemon: Failed to Setup IP tables: Unable to enable NAT rule: (iptables failed: `ip6tables --wait -t nat -I POSTROUTING -s fd01::/64 ! -o br-test -j SNAT --to-source 192.168.0.2`: ip6tables v1.8.7 (nf_tables): Bad IP address "192.168.0.2"
>
> Try `ip6tables -h` or `ip6tables --help` for more information.
>  (exit status 2))

Fix this error by passing nil—not the `host_ipv4` address—when creating the IPv6 rules.

**- How to verify it**

Unit tests:

`make TESTDIRS=github.com/docker/docker/libnetwork/drivers/bridge test-unit`

Testing a fully built binary:

```
dockerd --ipv6 --fixed-cidr-v6=fd00::/64 --experimental --ip6tables
docker network create -d bridge --ipv6 --subnet fd01::/64 --opt com.docker.network.host_ipv4=192.168.0.2 test-network
```

**- Description for the changelog**

Fixed `com.docker.network.host_ipv4` option when IPv6 and `ip6tables` are enabled.

Fixes #46445 
