### PR TITLE
api: Add consts for predefined networks

### DIFF
--- a/api/types/container/hostconfig.go
+++ b/api/types/container/hostconfig.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/docker/api/types/blkiodev"
 	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/go-connections/nat"
 	units "github.com/docker/go-units"
@@ -133,12 +134,12 @@ type NetworkMode string
 
 // IsNone indicates whether container isn't using a network stack.
 func (n NetworkMode) IsNone() bool {
-	return n == "none"
+	return n == network.NetworkNone
 }
 
 // IsDefault indicates whether container uses the default network stack.
 func (n NetworkMode) IsDefault() bool {
-	return n == "default"
+	return n == network.NetworkDefault
 }
 
 // IsPrivate indicates whether container uses its private network stack.

--- a/api/types/container/hostconfig_unix.go
+++ b/api/types/container/hostconfig_unix.go
@@ -2,6 +2,8 @@
 
 package container // import "github.com/docker/docker/api/types/container"
 
+import "github.com/docker/docker/api/types/network"
+
 // IsValid indicates if an isolation technology is valid
 func (i Isolation) IsValid() bool {
 	return i.IsDefault()
@@ -10,15 +12,15 @@ func (i Isolation) IsValid() bool {
 // NetworkName returns the name of the network stack.
 func (n NetworkMode) NetworkName() string {
 	if n.IsBridge() {
-		return "bridge"
+		return network.NetworkBridge
 	} else if n.IsHost() {
-		return "host"
+		return network.NetworkHost
 	} else if n.IsContainer() {
 		return "container"
 	} else if n.IsNone() {
-		return "none"
+		return network.NetworkNone
 	} else if n.IsDefault() {
-		return "default"
+		return network.NetworkDefault
 	} else if n.IsUserDefined() {
 		return n.UserDefined()
 	}
@@ -27,12 +29,12 @@ func (n NetworkMode) NetworkName() string {
 
 // IsBridge indicates whether container uses the bridge network stack
 func (n NetworkMode) IsBridge() bool {
-	return n == "bridge"
+	return n == network.NetworkBridge
 }
 
 // IsHost indicates whether container uses the host network stack.
 func (n NetworkMode) IsHost() bool {
-	return n == "host"
+	return n == network.NetworkHost
 }
 
 // IsUserDefined indicates user-created network

--- a/api/types/container/hostconfig_windows.go
+++ b/api/types/container/hostconfig_windows.go
@@ -1,9 +1,11 @@
 package container // import "github.com/docker/docker/api/types/container"
 
+import "github.com/docker/docker/api/types/network"
+
 // IsBridge indicates whether container uses the bridge network stack
 // in windows it is given the name NAT
 func (n NetworkMode) IsBridge() bool {
-	return n == "nat"
+	return n == network.NetworkNat
 }
 
 // IsHost indicates whether container uses the host network stack.
@@ -25,11 +27,11 @@ func (i Isolation) IsValid() bool {
 // NetworkName returns the name of the network stack.
 func (n NetworkMode) NetworkName() string {
 	if n.IsDefault() {
-		return "default"
+		return network.NetworkDefault
 	} else if n.IsBridge() {
-		return "nat"
+		return network.NetworkNat
 	} else if n.IsNone() {
-		return "none"
+		return network.NetworkNone
 	} else if n.IsContainer() {
 		return "container"
 	} else if n.IsUserDefined() {

--- a/api/types/network/network.go
+++ b/api/types/network/network.go
@@ -1,6 +1,20 @@
 package network // import "github.com/docker/docker/api/types/network"
+
 import (
 	"github.com/docker/docker/api/types/filters"
+)
+
+const (
+	// NetworkDefault is a platform-independent alias to choose the platform-specific default network stack.
+	NetworkDefault = "default"
+	// NetworkHost is the name of the predefined network used when the NetworkMode host is selected (only available on Linux)
+	NetworkHost = "host"
+	// NetworkNone is the name of the predefined network used when the NetworkMode none is selected (available on both Linux and Windows)
+	NetworkNone = "none"
+	// NetworkBridge is the name of the default network on Linux
+	NetworkBridge = "bridge"
+	// NetworkNat is the name of the default network on Windows
+	NetworkNat = "nat"
 )
 
 // Address represents an IP address

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/containerd/containerd/log"
 	containertypes "github.com/docker/docker/api/types/container"
+	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/libcontainerd/local"
@@ -261,7 +262,7 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 
 		if !found {
 			// non-default nat networks should be re-created if missing from HNS
-			if v.Type() == "nat" && v.Name() != "nat" {
+			if v.Type() == "nat" && v.Name() != networktypes.NetworkNat {
 				_, _, v4Conf, v6Conf := v.IpamConfig()
 				netOption := map[string]string{}
 				for k, v := range v.DriverOptions() {

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -270,7 +270,7 @@ func (daemon *Daemon) getBackwardsCompatibleNetworkSettings(settings *network.Se
 func (daemon *Daemon) getDefaultNetworkSettings(networks map[string]*network.EndpointSettings) types.DefaultNetworkSettings {
 	var settings types.DefaultNetworkSettings
 
-	if defaultNetwork, ok := networks["bridge"]; ok && defaultNetwork.EndpointSettings != nil {
+	if defaultNetwork, ok := networks[networktypes.NetworkBridge]; ok && defaultNetwork.EndpointSettings != nil {
 		settings.EndpointID = defaultNetwork.EndpointID
 		settings.Gateway = defaultNetwork.Gateway
 		settings.GlobalIPv6Address = defaultNetwork.GlobalIPv6Address

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
 )
 
 // DecodeHostConfig creates a HostConfig based on the specified Reader.
@@ -23,7 +24,7 @@ func decodeHostConfig(src io.Reader) (*container.HostConfig, error) {
 // docker daemon.
 func SetDefaultNetModeIfBlank(hc *container.HostConfig) {
 	if hc != nil && hc.NetworkMode == "" {
-		hc.NetworkMode = "default"
+		hc.NetworkMode = network.NetworkDefault
 	}
 }
 

--- a/runconfig/hostconfig_unix.go
+++ b/runconfig/hostconfig_unix.go
@@ -7,13 +7,14 @@ import (
 	"runtime"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/pkg/sysinfo"
 )
 
 // DefaultDaemonNetworkMode returns the default network stack the daemon should
 // use.
 func DefaultDaemonNetworkMode() container.NetworkMode {
-	return "bridge"
+	return network.NetworkBridge
 }
 
 // IsPreDefinedNetwork indicates if a network is predefined by the daemon

--- a/runconfig/hostconfig_windows.go
+++ b/runconfig/hostconfig_windows.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/pkg/sysinfo"
 )
 
 // DefaultDaemonNetworkMode returns the default network stack the daemon should
 // use.
 func DefaultDaemonNetworkMode() container.NetworkMode {
-	return "nat"
+	return network.NetworkNat
 }
 
 // IsPreDefinedNetwork indicates if a network is predefined by the daemon

--- a/testutil/environment/clean.go
+++ b/testutil/environment/clean.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/errdefs"
@@ -150,13 +151,13 @@ func deleteAllNetworks(ctx context.Context, t testing.TB, c client.NetworkAPICli
 	assert.Check(t, err, "failed to list networks")
 
 	for _, n := range networks {
-		if n.Name == "bridge" || n.Name == "none" || n.Name == "host" {
+		if n.Name == network.NetworkBridge || n.Name == network.NetworkNone || n.Name == network.NetworkHost {
 			continue
 		}
 		if _, ok := protectedNetworks[n.ID]; ok {
 			continue
 		}
-		if daemonPlatform == "windows" && strings.ToLower(n.Name) == "nat" {
+		if daemonPlatform == "windows" && strings.ToLower(n.Name) == network.NetworkNat {
 			// nat is a pre-defined network on Windows and cannot be removed
 			continue
 		}


### PR DESCRIPTION
Related to:

- https://github.com/docker/cli/pull/4493#discussion_r1298609663
- https://github.com/moby/moby/issues/19421

**- What I did**

Constants for both platform-specific and platform-independent networks are added to the api/network package.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://cdn.cdnparenting.com/articles/2019/06/01154838/Parrot-Facts-for-Kids-1115777186.webp)