### PR TITLE
[WIP] api: migrate swagger to OpenAPI v3

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1,4 +1,4 @@
-# A Swagger 2.0 (a.k.a. OpenAPI) definition of the Engine API.
+# OpenApi 3.0 (a.k.a. Swagger) definition of the Engine API.
 #
 # This is used for generating API documentation and the types used by the
 # client/server. See api/README.md for more information.
@@ -9,17 +9,9 @@
 # - There is no maximum line length, for ease of editing and pretty diffs.
 # - operationIds are in the format "NounVerb", with a singular noun.
 
-swagger: "2.0"
-schemes:
-  - "http"
-  - "https"
-produces:
-  - "application/json"
-  - "text/plain"
-consumes:
-  - "application/json"
-  - "text/plain"
-basePath: "/v1.44"
+openapi: 3.0.1
+servers:
+  - url: "/v1.44"
 info:
   title: "Docker Engine API"
   version: "1.44"
@@ -172,3900 +164,592 @@ tags:
   - name: "System"
     x-displayName: "System"
 
-definitions:
-  Port:
-    type: "object"
-    description: "An open port on a container"
-    required: [PrivatePort, Type]
-    properties:
-      IP:
-        type: "string"
-        format: "ip-address"
-        description: "Host IP address that the container's port is mapped to"
-      PrivatePort:
-        type: "integer"
-        format: "uint16"
-        x-nullable: false
-        description: "Port on the container"
-      PublicPort:
-        type: "integer"
-        format: "uint16"
-        description: "Port exposed on the host"
-      Type:
-        type: "string"
-        x-nullable: false
-        enum: ["tcp", "udp", "sctp"]
-    example:
-      PrivatePort: 8080
-      PublicPort: 80
-      Type: "tcp"
-
-  MountPoint:
-    type: "object"
-    description: |
-      MountPoint represents a mount point configuration inside the container.
-      This is used for reporting the mountpoints in use by a container.
-    properties:
-      Type:
-        description: |
-          The mount type:
-
-          - `bind` a mount of a file or directory from the host into the container.
-          - `volume` a docker volume with the given `Name`.
-          - `tmpfs` a `tmpfs`.
-          - `npipe` a named pipe from the host into the container.
-          - `cluster` a Swarm cluster volume
-        type: "string"
-        enum:
-          - "bind"
-          - "volume"
-          - "tmpfs"
-          - "npipe"
-          - "cluster"
-        example: "volume"
-      Name:
-        description: |
-          Name is the name reference to the underlying data defined by `Source`
-          e.g., the volume name.
-        type: "string"
-        example: "myvolume"
-      Source:
-        description: |
-          Source location of the mount.
-
-          For volumes, this contains the storage location of the volume (within
-          `/var/lib/docker/volumes/`). For bind-mounts, and `npipe`, this contains
-          the source (host) part of the bind-mount. For `tmpfs` mount points, this
-          field is empty.
-        type: "string"
-        example: "/var/lib/docker/volumes/myvolume/_data"
-      Destination:
-        description: |
-          Destination is the path relative to the container root (`/`) where
-          the `Source` is mounted inside the container.
-        type: "string"
-        example: "/usr/share/nginx/html/"
-      Driver:
-        description: |
-          Driver is the volume driver used to create the volume (if it is a volume).
-        type: "string"
-        example: "local"
-      Mode:
-        description: |
-          Mode is a comma separated list of options supplied by the user when
-          creating the bind/volume mount.
-
-          The default is platform-specific (`"z"` on Linux, empty on Windows).
-        type: "string"
-        example: "z"
-      RW:
-        description: |
-          Whether the mount is mounted writable (read-write).
-        type: "boolean"
-        example: true
-      Propagation:
-        description: |
-          Propagation describes how mounts are propagated from the host into the
-          mount point, and vice-versa. Refer to the [Linux kernel documentation](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt)
-          for details. This field is not used on Windows.
-        type: "string"
-        example: ""
-
-  DeviceMapping:
-    type: "object"
-    description: "A device mapping between the host and container"
-    properties:
-      PathOnHost:
-        type: "string"
-      PathInContainer:
-        type: "string"
-      CgroupPermissions:
-        type: "string"
-    example:
-      PathOnHost: "/dev/deviceName"
-      PathInContainer: "/dev/deviceName"
-      CgroupPermissions: "mrw"
-
-  DeviceRequest:
-    type: "object"
-    description: "A request for devices to be sent to device drivers"
-    properties:
-      Driver:
-        type: "string"
-        example: "nvidia"
-      Count:
-        type: "integer"
-        example: -1
-      DeviceIDs:
-        type: "array"
-        items:
+components:
+  schemas:
+    Port:
+      type: "object"
+      description: "An open port on a container"
+      required: [PrivatePort, Type]
+      properties:
+        IP:
           type: "string"
-        example:
-          - "0"
-          - "1"
-          - "GPU-fef8089b-4820-abfc-e83e-94318197576e"
-      Capabilities:
-        description: |
-          A list of capabilities; an OR list of AND lists of capabilities.
-        type: "array"
-        items:
+          format: "ip-address"
+          description: "Host IP address that the container's port is mapped to"
+        PrivatePort:
+          type: "integer"
+          format: "uint16"
+          x-nullable: false
+          description: "Port on the container"
+        PublicPort:
+          type: "integer"
+          format: "uint16"
+          description: "Port exposed on the host"
+        Type:
+          type: "string"
+          x-nullable: false
+          enum: ["tcp", "udp", "sctp"]
+      example:
+        PrivatePort: 8080
+        PublicPort: 80
+        Type: "tcp"
+
+    MountPoint:
+      type: "object"
+      description: |
+        MountPoint represents a mount point configuration inside the container.
+        This is used for reporting the mountpoints in use by a container.
+      properties:
+        Type:
+          description: |
+            The mount type:
+
+            - `bind` a mount of a file or directory from the host into the container.
+            - `volume` a docker volume with the given `Name`.
+            - `tmpfs` a `tmpfs`.
+            - `npipe` a named pipe from the host into the container.
+            - `cluster` a Swarm cluster volume
+          type: "string"
+          enum:
+            - "bind"
+            - "volume"
+            - "tmpfs"
+            - "npipe"
+            - "cluster"
+          example: "volume"
+        Name:
+          description: |
+            Name is the name reference to the underlying data defined by `Source`
+            e.g., the volume name.
+          type: "string"
+          example: "myvolume"
+        Source:
+          description: |
+            Source location of the mount.
+
+            For volumes, this contains the storage location of the volume (within
+            `/var/lib/docker/volumes/`). For bind-mounts, and `npipe`, this contains
+            the source (host) part of the bind-mount. For `tmpfs` mount points, this
+            field is empty.
+          type: "string"
+          example: "/var/lib/docker/volumes/myvolume/_data"
+        Destination:
+          description: |
+            Destination is the path relative to the container root (`/`) where
+            the `Source` is mounted inside the container.
+          type: "string"
+          example: "/usr/share/nginx/html/"
+        Driver:
+          description: |
+            Driver is the volume driver used to create the volume (if it is a volume).
+          type: "string"
+          example: "local"
+        Mode:
+          description: |
+            Mode is a comma separated list of options supplied by the user when
+            creating the bind/volume mount.
+
+            The default is platform-specific (`"z"` on Linux, empty on Windows).
+          type: "string"
+          example: "z"
+        RW:
+          description: |
+            Whether the mount is mounted writable (read-write).
+          type: "boolean"
+          example: true
+        Propagation:
+          description: |
+            Propagation describes how mounts are propagated from the host into the
+            mount point, and vice-versa. Refer to the [Linux kernel documentation](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt)
+            for details. This field is not used on Windows.
+          type: "string"
+          example: ""
+
+    DeviceMapping:
+      type: "object"
+      description: "A device mapping between the host and container"
+      properties:
+        PathOnHost:
+          type: "string"
+        PathInContainer:
+          type: "string"
+        CgroupPermissions:
+          type: "string"
+      example:
+        PathOnHost: "/dev/deviceName"
+        PathInContainer: "/dev/deviceName"
+        CgroupPermissions: "mrw"
+
+    DeviceRequest:
+      type: "object"
+      description: "A request for devices to be sent to device drivers"
+      properties:
+        Driver:
+          type: "string"
+          example: "nvidia"
+        Count:
+          type: "integer"
+          example: -1
+        DeviceIDs:
           type: "array"
           items:
             type: "string"
-        example:
-          # gpu AND nvidia AND compute
-          - ["gpu", "nvidia", "compute"]
-      Options:
-        description: |
-          Driver-specific options, specified as a key/value pairs. These options
-          are passed directly to the driver.
-        type: "object"
-        additionalProperties:
-          type: "string"
-
-  ThrottleDevice:
-    type: "object"
-    properties:
-      Path:
-        description: "Device path"
-        type: "string"
-      Rate:
-        description: "Rate"
-        type: "integer"
-        format: "int64"
-        minimum: 0
-
-  Mount:
-    type: "object"
-    properties:
-      Target:
-        description: "Container path."
-        type: "string"
-      Source:
-        description: "Mount source (e.g. a volume name, a host path)."
-        type: "string"
-      Type:
-        description: |
-          The mount type. Available types:
-
-          - `bind` Mounts a file or directory from the host into the container. Must exist prior to creating the container.
-          - `volume` Creates a volume with the given name and options (or uses a pre-existing volume with the same name and options). These are **not** removed when the container is removed.
-          - `tmpfs` Create a tmpfs with the given options. The mount source cannot be specified for tmpfs.
-          - `npipe` Mounts a named pipe from the host into the container. Must exist prior to creating the container.
-          - `cluster` a Swarm cluster volume
-        type: "string"
-        enum:
-          - "bind"
-          - "volume"
-          - "tmpfs"
-          - "npipe"
-          - "cluster"
-      ReadOnly:
-        description: "Whether the mount should be read-only."
-        type: "boolean"
-      Consistency:
-        description: "The consistency requirement for the mount: `default`, `consistent`, `cached`, or `delegated`."
-        type: "string"
-      BindOptions:
-        description: "Optional configuration for the `bind` type."
-        type: "object"
-        properties:
-          Propagation:
-            description: "A propagation mode with the value `[r]private`, `[r]shared`, or `[r]slave`."
+          example:
+            - "0"
+            - "1"
+            - "GPU-fef8089b-4820-abfc-e83e-94318197576e"
+        Capabilities:
+          description: |
+            A list of capabilities; an OR list of AND lists of capabilities.
+          type: "array"
+          items:
+            type: "array"
+            items:
+              type: "string"
+          example:
+            # gpu AND nvidia AND compute
+            - ["gpu", "nvidia", "compute"]
+        Options:
+          description: |
+            Driver-specific options, specified as a key/value pairs. These options
+            are passed directly to the driver.
+          type: "object"
+          additionalProperties:
             type: "string"
-            enum:
-              - "private"
-              - "rprivate"
-              - "shared"
-              - "rshared"
-              - "slave"
-              - "rslave"
-          NonRecursive:
-            description: "Disable recursive bind mount."
-            type: "boolean"
-            default: false
-          CreateMountpoint:
-            description: "Create mount point on host if missing"
-            type: "boolean"
-            default: false
-          ReadOnlyNonRecursive:
-            description: |
-               Make the mount non-recursively read-only, but still leave the mount recursive
-               (unless NonRecursive is set to true in conjunction).
-            type: "boolean"
-            default: false
-          ReadOnlyForceRecursive:
-            description: "Raise an error if the mount cannot be made recursively read-only."
-            type: "boolean"
-            default: false
-      VolumeOptions:
-        description: "Optional configuration for the `volume` type."
-        type: "object"
-        properties:
-          NoCopy:
-            description: "Populate volume with data from the target."
-            type: "boolean"
-            default: false
-          Labels:
-            description: "User-defined key/value metadata."
-            type: "object"
-            additionalProperties:
-              type: "string"
-          DriverConfig:
-            description: "Map of driver specific options"
-            type: "object"
-            properties:
-              Name:
-                description: "Name of the driver to use to create the volume."
-                type: "string"
-              Options:
-                description: "key/value map of driver specific options."
-                type: "object"
-                additionalProperties:
-                  type: "string"
-      TmpfsOptions:
-        description: "Optional configuration for the `tmpfs` type."
-        type: "object"
-        properties:
-          SizeBytes:
-            description: "The size for the tmpfs mount in bytes."
-            type: "integer"
-            format: "int64"
-          Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
-            type: "integer"
 
-  RestartPolicy:
-    description: |
-      The behavior to apply when the container exits. The default is not to
-      restart.
-
-      An ever increasing delay (double the previous delay, starting at 100ms) is
-      added before each restart to prevent flooding the server.
-    type: "object"
-    properties:
-      Name:
-        type: "string"
-        description: |
-          - Empty string means not to restart
-          - `no` Do not automatically restart
-          - `always` Always restart
-          - `unless-stopped` Restart always except when the user has manually stopped the container
-          - `on-failure` Restart only when the container exit code is non-zero
-        enum:
-          - ""
-          - "no"
-          - "always"
-          - "unless-stopped"
-          - "on-failure"
-      MaximumRetryCount:
-        type: "integer"
-        description: |
-          If `on-failure` is used, the number of times to retry before giving up.
-
-  Resources:
-    description: "A container's resources (cgroups config, ulimits, etc)"
-    type: "object"
-    properties:
-      # Applicable to all platforms
-      CpuShares:
-        description: |
-          An integer value representing this container's relative CPU weight
-          versus other containers.
-        type: "integer"
-      Memory:
-        description: "Memory limit in bytes."
-        type: "integer"
-        format: "int64"
-        default: 0
-      # Applicable to UNIX platforms
-      CgroupParent:
-        description: |
-          Path to `cgroups` under which the container's `cgroup` is created. If
-          the path is not absolute, the path is considered to be relative to the
-          `cgroups` path of the init process. Cgroups are created if they do not
-          already exist.
-        type: "string"
-      BlkioWeight:
-        description: "Block IO weight (relative weight)."
-        type: "integer"
-        minimum: 0
-        maximum: 1000
-      BlkioWeightDevice:
-        description: |
-          Block IO weight (relative device weight) in the form:
-
-          ```
-          [{"Path": "device_path", "Weight": weight}]
-          ```
-        type: "array"
-        items:
-          type: "object"
-          properties:
-            Path:
-              type: "string"
-            Weight:
-              type: "integer"
-              minimum: 0
-      BlkioDeviceReadBps:
-        description: |
-          Limit read rate (bytes per second) from a device, in the form:
-
-          ```
-          [{"Path": "device_path", "Rate": rate}]
-          ```
-        type: "array"
-        items:
-          $ref: "#/definitions/ThrottleDevice"
-      BlkioDeviceWriteBps:
-        description: |
-          Limit write rate (bytes per second) to a device, in the form:
-
-          ```
-          [{"Path": "device_path", "Rate": rate}]
-          ```
-        type: "array"
-        items:
-          $ref: "#/definitions/ThrottleDevice"
-      BlkioDeviceReadIOps:
-        description: |
-          Limit read rate (IO per second) from a device, in the form:
-
-          ```
-          [{"Path": "device_path", "Rate": rate}]
-          ```
-        type: "array"
-        items:
-          $ref: "#/definitions/ThrottleDevice"
-      BlkioDeviceWriteIOps:
-        description: |
-          Limit write rate (IO per second) to a device, in the form:
-
-          ```
-          [{"Path": "device_path", "Rate": rate}]
-          ```
-        type: "array"
-        items:
-          $ref: "#/definitions/ThrottleDevice"
-      CpuPeriod:
-        description: "The length of a CPU period in microseconds."
-        type: "integer"
-        format: "int64"
-      CpuQuota:
-        description: |
-          Microseconds of CPU time that the container can get in a CPU period.
-        type: "integer"
-        format: "int64"
-      CpuRealtimePeriod:
-        description: |
-          The length of a CPU real-time period in microseconds. Set to 0 to
-          allocate no time allocated to real-time tasks.
-        type: "integer"
-        format: "int64"
-      CpuRealtimeRuntime:
-        description: |
-          The length of a CPU real-time runtime in microseconds. Set to 0 to
-          allocate no time allocated to real-time tasks.
-        type: "integer"
-        format: "int64"
-      CpusetCpus:
-        description: |
-          CPUs in which to allow execution (e.g., `0-3`, `0,1`).
-        type: "string"
-        example: "0-3"
-      CpusetMems:
-        description: |
-          Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only
-          effective on NUMA systems.
-        type: "string"
-      Devices:
-        description: "A list of devices to add to the container."
-        type: "array"
-        items:
-          $ref: "#/definitions/DeviceMapping"
-      DeviceCgroupRules:
-        description: "a list of cgroup rules to apply to the container"
-        type: "array"
-        items:
-          type: "string"
-          example: "c 13:* rwm"
-      DeviceRequests:
-        description: |
-          A list of requests for devices to be sent to device drivers.
-        type: "array"
-        items:
-          $ref: "#/definitions/DeviceRequest"
-      KernelMemoryTCP:
-        description: |
-          Hard limit for kernel TCP buffer memory (in bytes). Depending on the
-          OCI runtime in use, this option may be ignored. It is no longer supported
-          by the default (runc) runtime.
-
-          This field is omitted when empty.
-        type: "integer"
-        format: "int64"
-      MemoryReservation:
-        description: "Memory soft limit in bytes."
-        type: "integer"
-        format: "int64"
-      MemorySwap:
-        description: |
-          Total memory limit (memory + swap). Set as `-1` to enable unlimited
-          swap.
-        type: "integer"
-        format: "int64"
-      MemorySwappiness:
-        description: |
-          Tune a container's memory swappiness behavior. Accepts an integer
-          between 0 and 100.
-        type: "integer"
-        format: "int64"
-        minimum: 0
-        maximum: 100
-      NanoCpus:
-        description: "CPU quota in units of 10<sup>-9</sup> CPUs."
-        type: "integer"
-        format: "int64"
-      OomKillDisable:
-        description: "Disable OOM Killer for the container."
-        type: "boolean"
-      Init:
-        description: |
-          Run an init inside the container that forwards signals and reaps
-          processes. This field is omitted if empty, and the default (as
-          configured on the daemon) is used.
-        type: "boolean"
-        x-nullable: true
-      PidsLimit:
-        description: |
-          Tune a container's PIDs limit. Set `0` or `-1` for unlimited, or `null`
-          to not change.
-        type: "integer"
-        format: "int64"
-        x-nullable: true
-      Ulimits:
-        description: |
-          A list of resource limits to set in the container. For example:
-
-          ```
-          {"Name": "nofile", "Soft": 1024, "Hard": 2048}
-          ```
-        type: "array"
-        items:
-          type: "object"
-          properties:
-            Name:
-              description: "Name of ulimit"
-              type: "string"
-            Soft:
-              description: "Soft limit"
-              type: "integer"
-            Hard:
-              description: "Hard limit"
-              type: "integer"
-      # Applicable to Windows
-      CpuCount:
-        description: |
-          The number of usable CPUs (Windows only).
-
-          On Windows Server containers, the processor resource controls are
-          mutually exclusive. The order of precedence is `CPUCount` first, then
-          `CPUShares`, and `CPUPercent` last.
-        type: "integer"
-        format: "int64"
-      CpuPercent:
-        description: |
-          The usable percentage of the available CPUs (Windows only).
-
-          On Windows Server containers, the processor resource controls are
-          mutually exclusive. The order of precedence is `CPUCount` first, then
-          `CPUShares`, and `CPUPercent` last.
-        type: "integer"
-        format: "int64"
-      IOMaximumIOps:
-        description: "Maximum IOps for the container system drive (Windows only)"
-        type: "integer"
-        format: "int64"
-      IOMaximumBandwidth:
-        description: |
-          Maximum IO in bytes per second for the container system drive
-          (Windows only).
-        type: "integer"
-        format: "int64"
-
-  Limit:
-    description: |
-      An object describing a limit on resources which can be requested by a task.
-    type: "object"
-    properties:
-      NanoCPUs:
-        type: "integer"
-        format: "int64"
-        example: 4000000000
-      MemoryBytes:
-        type: "integer"
-        format: "int64"
-        example: 8272408576
-      Pids:
-        description: |
-          Limits the maximum number of PIDs in the container. Set `0` for unlimited.
-        type: "integer"
-        format: "int64"
-        default: 0
-        example: 100
-
-  ResourceObject:
-    description: |
-      An object describing the resources which can be advertised by a node and
-      requested by a task.
-    type: "object"
-    properties:
-      NanoCPUs:
-        type: "integer"
-        format: "int64"
-        example: 4000000000
-      MemoryBytes:
-        type: "integer"
-        format: "int64"
-        example: 8272408576
-      GenericResources:
-        $ref: "#/definitions/GenericResources"
-
-  GenericResources:
-    description: |
-      User-defined resources can be either Integer resources (e.g, `SSD=3`) or
-      String resources (e.g, `GPU=UUID1`).
-    type: "array"
-    items:
+    ThrottleDevice:
       type: "object"
       properties:
-        NamedResourceSpec:
-          type: "object"
-          properties:
-            Kind:
-              type: "string"
-            Value:
-              type: "string"
-        DiscreteResourceSpec:
-          type: "object"
-          properties:
-            Kind:
-              type: "string"
-            Value:
-              type: "integer"
-              format: "int64"
-    example:
-      - DiscreteResourceSpec:
-          Kind: "SSD"
-          Value: 3
-      - NamedResourceSpec:
-          Kind: "GPU"
-          Value: "UUID1"
-      - NamedResourceSpec:
-          Kind: "GPU"
-          Value: "UUID2"
-
-  HealthConfig:
-    description: "A test to perform to check that the container is healthy."
-    type: "object"
-    properties:
-      Test:
-        description: |
-          The test to perform. Possible values are:
-
-          - `[]` inherit healthcheck from image or parent image
-          - `["NONE"]` disable healthcheck
-          - `["CMD", args...]` exec arguments directly
-          - `["CMD-SHELL", command]` run command with system's default shell
-        type: "array"
-        items:
+        Path:
+          description: "Device path"
           type: "string"
-      Interval:
-        description: |
-          The time to wait between checks in nanoseconds. It should be 0 or at
-          least 1000000 (1 ms). 0 means inherit.
-        type: "integer"
-        format: "int64"
-      Timeout:
-        description: |
-          The time to wait before considering the check to have hung. It should
-          be 0 or at least 1000000 (1 ms). 0 means inherit.
-        type: "integer"
-        format: "int64"
-      Retries:
-        description: |
-          The number of consecutive failures needed to consider a container as
-          unhealthy. 0 means inherit.
-        type: "integer"
-      StartPeriod:
-        description: |
-          Start period for the container to initialize before starting
-          health-retries countdown in nanoseconds. It should be 0 or at least
-          1000000 (1 ms). 0 means inherit.
-        type: "integer"
-        format: "int64"
-      StartInterval:
-        description: |
-          The time to wait between checks in nanoseconds during the start period.
-          It should be 0 or at least 1000000 (1 ms). 0 means inherit.
-        type: "integer"
-        format: "int64"
+        Rate:
+          description: "Rate"
+          type: "integer"
+          format: "int64"
+          minimum: 0
 
-  Health:
-    description: |
-      Health stores information about the container's healthcheck results.
-    type: "object"
-    x-nullable: true
-    properties:
-      Status:
-        description: |
-          Status is one of `none`, `starting`, `healthy` or `unhealthy`
+    Mount:
+      type: "object"
+      properties:
+        Target:
+          description: "Container path."
+          type: "string"
+        Source:
+          description: "Mount source (e.g. a volume name, a host path)."
+          type: "string"
+        Type:
+          description: |
+            The mount type. Available types:
 
-          - "none"      Indicates there is no healthcheck
-          - "starting"  Starting indicates that the container is not yet ready
-          - "healthy"   Healthy indicates that the container is running correctly
-          - "unhealthy" Unhealthy indicates that the container has a problem
-        type: "string"
-        enum:
-          - "none"
-          - "starting"
-          - "healthy"
-          - "unhealthy"
-        example: "healthy"
-      FailingStreak:
-        description: "FailingStreak is the number of consecutive failures"
-        type: "integer"
-        example: 0
-      Log:
-        type: "array"
-        description: |
-          Log contains the last few results (oldest first)
-        items:
-          $ref: "#/definitions/HealthcheckResult"
-
-  HealthcheckResult:
-    description: |
-      HealthcheckResult stores information about a single run of a healthcheck probe
-    type: "object"
-    x-nullable: true
-    properties:
-      Start:
-        description: |
-          Date and time at which this check started in
-          [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
-        type: "string"
-        format: "date-time"
-        example: "2020-01-04T10:44:24.496525531Z"
-      End:
-        description: |
-          Date and time at which this check ended in
-          [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
-        type: "string"
-        format: "dateTime"
-        example: "2020-01-04T10:45:21.364524523Z"
-      ExitCode:
-        description: |
-          ExitCode meanings:
-
-          - `0` healthy
-          - `1` unhealthy
-          - `2` reserved (considered unhealthy)
-          - other values: error running probe
-        type: "integer"
-        example: 0
-      Output:
-        description: "Output from last check"
-        type: "string"
-
-  HostConfig:
-    description: "Container configuration that depends on the host we are running on"
-    allOf:
-      - $ref: "#/definitions/Resources"
-      - type: "object"
-        properties:
-          # Applicable to all platforms
-          Binds:
-            type: "array"
-            description: |
-              A list of volume bindings for this container. Each volume binding
-              is a string in one of these forms:
-
-              - `host-src:container-dest[:options]` to bind-mount a host path
-                into the container. Both `host-src`, and `container-dest` must
-                be an _absolute_ path.
-              - `volume-name:container-dest[:options]` to bind-mount a volume
-                managed by a volume driver into the container. `container-dest`
-                must be an _absolute_ path.
-
-              `options` is an optional, comma-delimited list of:
-
-              - `nocopy` disables automatic copying of data from the container
-                path to the volume. The `nocopy` flag only applies to named volumes.
-              - `[ro|rw]` mounts a volume read-only or read-write, respectively.
-                If omitted or set to `rw`, volumes are mounted read-write.
-              - `[z|Z]` applies SELinux labels to allow or deny multiple containers
-                to read and write to the same volume.
-                  - `z`: a _shared_ content label is applied to the content. This
-                    label indicates that multiple containers can share the volume
-                    content, for both reading and writing.
-                  - `Z`: a _private unshared_ label is applied to the content.
-                    This label indicates that only the current container can use
-                    a private volume. Labeling systems such as SELinux require
-                    proper labels to be placed on volume content that is mounted
-                    into a container. Without a label, the security system can
-                    prevent a container's processes from using the content. By
-                    default, the labels set by the host operating system are not
-                    modified.
-              - `[[r]shared|[r]slave|[r]private]` specifies mount
-                [propagation behavior](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt).
-                This only applies to bind-mounted volumes, not internal volumes
-                or named volumes. Mount propagation requires the source mount
-                point (the location where the source directory is mounted in the
-                host operating system) to have the correct propagation properties.
-                For shared volumes, the source mount point must be set to `shared`.
-                For slave volumes, the mount must be set to either `shared` or
-                `slave`.
-            items:
-              type: "string"
-          ContainerIDFile:
-            type: "string"
-            description: "Path to a file where the container ID is written"
-          LogConfig:
-            type: "object"
-            description: "The logging configuration for this container"
-            properties:
-              Type:
-                type: "string"
-                enum:
-                  - "json-file"
-                  - "syslog"
-                  - "journald"
-                  - "gelf"
-                  - "fluentd"
-                  - "awslogs"
-                  - "splunk"
-                  - "etwlogs"
-                  - "none"
-              Config:
-                type: "object"
-                additionalProperties:
-                  type: "string"
-          NetworkMode:
-            type: "string"
-            description: |
-              Network mode to use for this container. Supported standard values
-              are: `bridge`, `host`, `none`, and `container:<name|id>`. Any
-              other value is taken as a custom network's name to which this
-              container should connect to.
-          PortBindings:
-            $ref: "#/definitions/PortMap"
-          RestartPolicy:
-            $ref: "#/definitions/RestartPolicy"
-          AutoRemove:
-            type: "boolean"
-            description: |
-              Automatically remove the container when the container's process
-              exits. This has no effect if `RestartPolicy` is set.
-          VolumeDriver:
-            type: "string"
-            description: "Driver that this container uses to mount volumes."
-          VolumesFrom:
-            type: "array"
-            description: |
-              A list of volumes to inherit from another container, specified in
-              the form `<container name>[:<ro|rw>]`.
-            items:
-              type: "string"
-          Mounts:
-            description: |
-              Specification for mounts to be added to the container.
-            type: "array"
-            items:
-              $ref: "#/definitions/Mount"
-          ConsoleSize:
-            type: "array"
-            description: |
-              Initial console size, as an `[height, width]` array.
-            x-nullable: true
-            minItems: 2
-            maxItems: 2
-            items:
-              type: "integer"
-              minimum: 0
-          Annotations:
-            type: "object"
-            description: |
-              Arbitrary non-identifying metadata attached to container and
-              provided to the runtime when the container is started.
-            additionalProperties:
-              type: "string"
-
-          # Applicable to UNIX platforms
-          CapAdd:
-            type: "array"
-            description: |
-              A list of kernel capabilities to add to the container. Conflicts
-              with option 'Capabilities'.
-            items:
-              type: "string"
-          CapDrop:
-            type: "array"
-            description: |
-              A list of kernel capabilities to drop from the container. Conflicts
-              with option 'Capabilities'.
-            items:
-              type: "string"
-          CgroupnsMode:
-            type: "string"
-            enum:
-              - "private"
-              - "host"
-            description: |
-              cgroup namespace mode for the container. Possible values are:
-
-              - `"private"`: the container runs in its own private cgroup namespace
-              - `"host"`: use the host system's cgroup namespace
-
-              If not specified, the daemon default is used, which can either be `"private"`
-              or `"host"`, depending on daemon version, kernel support and configuration.
-          Dns:
-            type: "array"
-            description: "A list of DNS servers for the container to use."
-            items:
-              type: "string"
-          DnsOptions:
-            type: "array"
-            description: "A list of DNS options."
-            items:
-              type: "string"
-          DnsSearch:
-            type: "array"
-            description: "A list of DNS search domains."
-            items:
-              type: "string"
-          ExtraHosts:
-            type: "array"
-            description: |
-              A list of hostnames/IP mappings to add to the container's `/etc/hosts`
-              file. Specified in the form `["hostname:IP"]`.
-            items:
-              type: "string"
-          GroupAdd:
-            type: "array"
-            description: |
-              A list of additional groups that the container process will run as.
-            items:
-              type: "string"
-          IpcMode:
-            type: "string"
-            description: |
-              IPC sharing mode for the container. Possible values are:
-
-              - `"none"`: own private IPC namespace, with /dev/shm not mounted
-              - `"private"`: own private IPC namespace
-              - `"shareable"`: own private IPC namespace, with a possibility to share it with other containers
-              - `"container:<name|id>"`: join another (shareable) container's IPC namespace
-              - `"host"`: use the host system's IPC namespace
-
-              If not specified, daemon default is used, which can either be `"private"`
-              or `"shareable"`, depending on daemon version and configuration.
-          Cgroup:
-            type: "string"
-            description: "Cgroup to use for the container."
-          Links:
-            type: "array"
-            description: |
-              A list of links for the container in the form `container_name:alias`.
-            items:
-              type: "string"
-          OomScoreAdj:
-            type: "integer"
-            description: |
-              An integer value containing the score given to the container in
-              order to tune OOM killer preferences.
-            example: 500
-          PidMode:
-            type: "string"
-            description: |
-              Set the PID (Process) Namespace mode for the container. It can be
-              either:
-
-              - `"container:<name|id>"`: joins another container's PID namespace
-              - `"host"`: use the host's PID namespace inside the container
-          Privileged:
-            type: "boolean"
-            description: "Gives the container full access to the host."
-          PublishAllPorts:
-            type: "boolean"
-            description: |
-              Allocates an ephemeral host port for all of a container's
-              exposed ports.
-
-              Ports are de-allocated when the container stops and allocated when
-              the container starts. The allocated port might be changed when
-              restarting the container.
-
-              The port is selected from the ephemeral port range that depends on
-              the kernel. For example, on Linux the range is defined by
-              `/proc/sys/net/ipv4/ip_local_port_range`.
-          ReadonlyRootfs:
-            type: "boolean"
-            description: "Mount the container's root filesystem as read only."
-          SecurityOpt:
-            type: "array"
-            description: |
-              A list of string values to customize labels for MLS systems, such
-              as SELinux.
-            items:
-              type: "string"
-          StorageOpt:
-            type: "object"
-            description: |
-              Storage driver options for this container, in the form `{"size": "120G"}`.
-            additionalProperties:
-              type: "string"
-          Tmpfs:
-            type: "object"
-            description: |
-              A map of container directories which should be replaced by tmpfs
-              mounts, and their corresponding mount options. For example:
-
-              ```
-              { "/run": "rw,noexec,nosuid,size=65536k" }
-              ```
-            additionalProperties:
-              type: "string"
-          UTSMode:
-            type: "string"
-            description: "UTS namespace to use for the container."
-          UsernsMode:
-            type: "string"
-            description: |
-              Sets the usernamespace mode for the container when usernamespace
-              remapping option is enabled.
-          ShmSize:
-            type: "integer"
-            format: "int64"
-            description: |
-              Size of `/dev/shm` in bytes. If omitted, the system uses 64MB.
-            minimum: 0
-          Sysctls:
-            type: "object"
-            description: |
-              A list of kernel parameters (sysctls) to set in the container.
-              For example:
-
-              ```
-              {"net.ipv4.ip_forward": "1"}
-              ```
-            additionalProperties:
-              type: "string"
-          Runtime:
-            type: "string"
-            description: "Runtime to use with this container."
-          # Applicable to Windows
-          Isolation:
-            type: "string"
-            description: |
-              Isolation technology of the container. (Windows only)
-            enum:
-              - "default"
-              - "process"
-              - "hyperv"
-          MaskedPaths:
-            type: "array"
-            description: |
-              The list of paths to be masked inside the container (this overrides
-              the default set of paths).
-            items:
-              type: "string"
-          ReadonlyPaths:
-            type: "array"
-            description: |
-              The list of paths to be set as read-only inside the container
-              (this overrides the default set of paths).
-            items:
-              type: "string"
-
-  ContainerConfig:
-    description: |
-      Configuration for a container that is portable between hosts.
-
-      When used as `ContainerConfig` field in an image, `ContainerConfig` is an
-      optional field containing the configuration of the container that was last
-      committed when creating the image.
-
-      Previous versions of Docker builder used this field to store build cache,
-      and it is not in active use anymore.
-    type: "object"
-    properties:
-      Hostname:
-        description: |
-          The hostname to use for the container, as a valid RFC 1123 hostname.
-        type: "string"
-        example: "439f4e91bd1d"
-      Domainname:
-        description: |
-          The domain name to use for the container.
-        type: "string"
-      User:
-        description: "The user that commands are run as inside the container."
-        type: "string"
-      AttachStdin:
-        description: "Whether to attach to `stdin`."
-        type: "boolean"
-        default: false
-      AttachStdout:
-        description: "Whether to attach to `stdout`."
-        type: "boolean"
-        default: true
-      AttachStderr:
-        description: "Whether to attach to `stderr`."
-        type: "boolean"
-        default: true
-      ExposedPorts:
-        description: |
-          An object mapping ports to an empty object in the form:
-
-          `{"<port>/<tcp|udp|sctp>": {}}`
-        type: "object"
-        x-nullable: true
-        additionalProperties:
-          type: "object"
+            - `bind` Mounts a file or directory from the host into the container. Must exist prior to creating the container.
+            - `volume` Creates a volume with the given name and options (or uses a pre-existing volume with the same name and options). These are **not** removed when the container is removed.
+            - `tmpfs` Create a tmpfs with the given options. The mount source cannot be specified for tmpfs.
+            - `npipe` Mounts a named pipe from the host into the container. Must exist prior to creating the container.
+            - `cluster` a Swarm cluster volume
+          type: "string"
           enum:
-            - {}
-          default: {}
-        example: {
-          "80/tcp": {},
-          "443/tcp": {}
-        }
-      Tty:
-        description: |
-          Attach standard streams to a TTY, including `stdin` if it is not closed.
-        type: "boolean"
-        default: false
-      OpenStdin:
-        description: "Open `stdin`"
-        type: "boolean"
-        default: false
-      StdinOnce:
-        description: "Close `stdin` after one attached client disconnects"
-        type: "boolean"
-        default: false
-      Env:
-        description: |
-          A list of environment variables to set inside the container in the
-          form `["VAR=value", ...]`. A variable without `=` is removed from the
-          environment, rather than to have an empty value.
-        type: "array"
-        items:
+            - "bind"
+            - "volume"
+            - "tmpfs"
+            - "npipe"
+            - "cluster"
+        ReadOnly:
+          description: "Whether the mount should be read-only."
+          type: "boolean"
+        Consistency:
+          description: "The consistency requirement for the mount: `default`, `consistent`, `cached`, or `delegated`."
           type: "string"
-        example:
-          - "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-      Cmd:
-        description: |
-          Command to run specified as a string or an array of strings.
-        type: "array"
-        items:
-          type: "string"
-        example: ["/bin/sh"]
-      Healthcheck:
-        $ref: "#/definitions/HealthConfig"
-      ArgsEscaped:
-        description: "Command is already escaped (Windows only)"
-        type: "boolean"
-        default: false
-        example: false
-        x-nullable: true
-      Image:
-        description: |
-          The name (or reference) of the image to use when creating the container,
-          or which was used when the container was created.
-        type: "string"
-        example: "example-image:1.0"
-      Volumes:
-        description: |
-          An object mapping mount point paths inside the container to empty
-          objects.
-        type: "object"
-        additionalProperties:
-          type: "object"
-          enum:
-            - {}
-          default: {}
-      WorkingDir:
-        description: "The working directory for commands to run in."
-        type: "string"
-        example: "/public/"
-      Entrypoint:
-        description: |
-          The entry point for the container as a string or an array of strings.
-
-          If the array consists of exactly one empty string (`[""]`) then the
-          entry point is reset to system default (i.e., the entry point used by
-          docker when there is no `ENTRYPOINT` instruction in the `Dockerfile`).
-        type: "array"
-        items:
-          type: "string"
-        example: []
-      NetworkDisabled:
-        description: "Disable networking for the container."
-        type: "boolean"
-        x-nullable: true
-      MacAddress:
-        description: "MAC address of the container."
-        type: "string"
-        x-nullable: true
-      OnBuild:
-        description: |
-          `ONBUILD` metadata that were defined in the image's `Dockerfile`.
-        type: "array"
-        x-nullable: true
-        items:
-          type: "string"
-        example: []
-      Labels:
-        description: "User-defined key/value metadata."
-        type: "object"
-        additionalProperties:
-          type: "string"
-        example:
-          com.example.some-label: "some-value"
-          com.example.some-other-label: "some-other-value"
-      StopSignal:
-        description: |
-          Signal to stop a container as a string or unsigned integer.
-        type: "string"
-        example: "SIGTERM"
-        x-nullable: true
-      StopTimeout:
-        description: "Timeout to stop a container in seconds."
-        type: "integer"
-        default: 10
-        x-nullable: true
-      Shell:
-        description: |
-          Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell.
-        type: "array"
-        x-nullable: true
-        items:
-          type: "string"
-        example: ["/bin/sh", "-c"]
-
-  NetworkingConfig:
-    description: |
-      NetworkingConfig represents the container's networking configuration for
-      each of its interfaces.
-      It is used for the networking configs specified in the `docker create`
-      and `docker network connect` commands.
-    type: "object"
-    properties:
-      EndpointsConfig:
-        description: |
-          A mapping of network name to endpoint configuration for that network.
-        type: "object"
-        additionalProperties:
-          $ref: "#/definitions/EndpointSettings"
-    example:
-      # putting an example here, instead of using the example values from
-      # /definitions/EndpointSettings, because containers/create currently
-      # does not support attaching to multiple networks, so the example request
-      # would be confusing if it showed that multiple networks can be contained
-      # in the EndpointsConfig.
-      # TODO remove once we support multiple networks on container create (see https://github.com/moby/moby/blob/07e6b843594e061f82baa5fa23c2ff7d536c2a05/daemon/create.go#L323)
-      EndpointsConfig:
-        isolated_nw:
-          IPAMConfig:
-            IPv4Address: "172.20.30.33"
-            IPv6Address: "2001:db8:abcd::3033"
-            LinkLocalIPs:
-              - "169.254.34.68"
-              - "fe80::3468"
-          Links:
-            - "container_1"
-            - "container_2"
-          Aliases:
-            - "server_x"
-            - "server_y"
-
-  NetworkSettings:
-    description: "NetworkSettings exposes the network settings in the API"
-    type: "object"
-    properties:
-      Bridge:
-        description: Name of the network's bridge (for example, `docker0`).
-        type: "string"
-        example: "docker0"
-      SandboxID:
-        description: SandboxID uniquely represents a container's network stack.
-        type: "string"
-        example: "9d12daf2c33f5959c8bf90aa513e4f65b561738661003029ec84830cd503a0c3"
-      HairpinMode:
-        description: |
-          Indicates if hairpin NAT should be enabled on the virtual interface.
-        type: "boolean"
-        example: false
-      LinkLocalIPv6Address:
-        description: IPv6 unicast address using the link-local prefix.
-        type: "string"
-        example: "fe80::42:acff:fe11:1"
-      LinkLocalIPv6PrefixLen:
-        description: Prefix length of the IPv6 unicast address.
-        type: "integer"
-        example: "64"
-      Ports:
-        $ref: "#/definitions/PortMap"
-      SandboxKey:
-        description: SandboxKey identifies the sandbox
-        type: "string"
-        example: "/var/run/docker/netns/8ab54b426c38"
-
-      # TODO is SecondaryIPAddresses actually used?
-      SecondaryIPAddresses:
-        description: ""
-        type: "array"
-        items:
-          $ref: "#/definitions/Address"
-        x-nullable: true
-
-      # TODO is SecondaryIPv6Addresses actually used?
-      SecondaryIPv6Addresses:
-        description: ""
-        type: "array"
-        items:
-          $ref: "#/definitions/Address"
-        x-nullable: true
-
-      # TODO properties below are part of DefaultNetworkSettings, which is
-      # marked as deprecated since Docker 1.9 and to be removed in Docker v17.12
-      EndpointID:
-        description: |
-          EndpointID uniquely represents a service endpoint in a Sandbox.
-
-          <p><br /></p>
-
-          > **Deprecated**: This field is only propagated when attached to the
-          > default "bridge" network. Use the information from the "bridge"
-          > network inside the `Networks` map instead, which contains the same
-          > information. This field was deprecated in Docker 1.9 and is scheduled
-          > to be removed in Docker 17.12.0
-        type: "string"
-        example: "b88f5b905aabf2893f3cbc4ee42d1ea7980bbc0a92e2c8922b1e1795298afb0b"
-      Gateway:
-        description: |
-          Gateway address for the default "bridge" network.
-
-          <p><br /></p>
-
-          > **Deprecated**: This field is only propagated when attached to the
-          > default "bridge" network. Use the information from the "bridge"
-          > network inside the `Networks` map instead, which contains the same
-          > information. This field was deprecated in Docker 1.9 and is scheduled
-          > to be removed in Docker 17.12.0
-        type: "string"
-        example: "172.17.0.1"
-      GlobalIPv6Address:
-        description: |
-          Global IPv6 address for the default "bridge" network.
-
-          <p><br /></p>
-
-          > **Deprecated**: This field is only propagated when attached to the
-          > default "bridge" network. Use the information from the "bridge"
-          > network inside the `Networks` map instead, which contains the same
-          > information. This field was deprecated in Docker 1.9 and is scheduled
-          > to be removed in Docker 17.12.0
-        type: "string"
-        example: "2001:db8::5689"
-      GlobalIPv6PrefixLen:
-        description: |
-          Mask length of the global IPv6 address.
-
-          <p><br /></p>
-
-          > **Deprecated**: This field is only propagated when attached to the
-          > default "bridge" network. Use the information from the "bridge"
-          > network inside the `Networks` map instead, which contains the same
-          > information. This field was deprecated in Docker 1.9 and is scheduled
-          > to be removed in Docker 17.12.0
-        type: "integer"
-        example: 64
-      IPAddress:
-        description: |
-          IPv4 address for the default "bridge" network.
-
-          <p><br /></p>
-
-          > **Deprecated**: This field is only propagated when attached to the
-          > default "bridge" network. Use the information from the "bridge"
-          > network inside the `Networks` map instead, which contains the same
-          > information. This field was deprecated in Docker 1.9 and is scheduled
-          > to be removed in Docker 17.12.0
-        type: "string"
-        example: "172.17.0.4"
-      IPPrefixLen:
-        description: |
-          Mask length of the IPv4 address.
-
-          <p><br /></p>
-
-          > **Deprecated**: This field is only propagated when attached to the
-          > default "bridge" network. Use the information from the "bridge"
-          > network inside the `Networks` map instead, which contains the same
-          > information. This field was deprecated in Docker 1.9 and is scheduled
-          > to be removed in Docker 17.12.0
-        type: "integer"
-        example: 16
-      IPv6Gateway:
-        description: |
-          IPv6 gateway address for this network.
-
-          <p><br /></p>
-
-          > **Deprecated**: This field is only propagated when attached to the
-          > default "bridge" network. Use the information from the "bridge"
-          > network inside the `Networks` map instead, which contains the same
-          > information. This field was deprecated in Docker 1.9 and is scheduled
-          > to be removed in Docker 17.12.0
-        type: "string"
-        example: "2001:db8:2::100"
-      MacAddress:
-        description: |
-          MAC address for the container on the default "bridge" network.
-
-          <p><br /></p>
-
-          > **Deprecated**: This field is only propagated when attached to the
-          > default "bridge" network. Use the information from the "bridge"
-          > network inside the `Networks` map instead, which contains the same
-          > information. This field was deprecated in Docker 1.9 and is scheduled
-          > to be removed in Docker 17.12.0
-        type: "string"
-        example: "02:42:ac:11:00:04"
-      Networks:
-        description: |
-          Information about all networks that the container is connected to.
-        type: "object"
-        additionalProperties:
-          $ref: "#/definitions/EndpointSettings"
-
-  Address:
-    description: Address represents an IPv4 or IPv6 IP address.
-    type: "object"
-    properties:
-      Addr:
-        description: IP address.
-        type: "string"
-      PrefixLen:
-        description: Mask length of the IP address.
-        type: "integer"
-
-  PortMap:
-    description: |
-      PortMap describes the mapping of container ports to host ports, using the
-      container's port-number and protocol as key in the format `<port>/<protocol>`,
-      for example, `80/udp`.
-
-      If a container's port is mapped for multiple protocols, separate entries
-      are added to the mapping table.
-    type: "object"
-    additionalProperties:
-      type: "array"
-      x-nullable: true
-      items:
-        $ref: "#/definitions/PortBinding"
-    example:
-      "443/tcp":
-        - HostIp: "127.0.0.1"
-          HostPort: "4443"
-      "80/tcp":
-        - HostIp: "0.0.0.0"
-          HostPort: "80"
-        - HostIp: "0.0.0.0"
-          HostPort: "8080"
-      "80/udp":
-        - HostIp: "0.0.0.0"
-          HostPort: "80"
-      "53/udp":
-        - HostIp: "0.0.0.0"
-          HostPort: "53"
-      "2377/tcp": null
-
-  PortBinding:
-    description: |
-      PortBinding represents a binding between a host IP address and a host
-      port.
-    type: "object"
-    properties:
-      HostIp:
-        description: "Host IP address that the container's port is mapped to."
-        type: "string"
-        example: "127.0.0.1"
-      HostPort:
-        description: "Host port number that the container's port is mapped to."
-        type: "string"
-        example: "4443"
-
-  GraphDriverData:
-    description: |
-      Information about the storage driver used to store the container's and
-      image's filesystem.
-    type: "object"
-    required: [Name, Data]
-    properties:
-      Name:
-        description: "Name of the storage driver."
-        type: "string"
-        x-nullable: false
-        example: "overlay2"
-      Data:
-        description: |
-          Low-level storage metadata, provided as key/value pairs.
-
-          This information is driver-specific, and depends on the storage-driver
-          in use, and should be used for informational purposes only.
-        type: "object"
-        x-nullable: false
-        additionalProperties:
-          type: "string"
-        example: {
-          "MergedDir": "/var/lib/docker/overlay2/ef749362d13333e65fc95c572eb525abbe0052e16e086cb64bc3b98ae9aa6d74/merged",
-          "UpperDir": "/var/lib/docker/overlay2/ef749362d13333e65fc95c572eb525abbe0052e16e086cb64bc3b98ae9aa6d74/diff",
-          "WorkDir": "/var/lib/docker/overlay2/ef749362d13333e65fc95c572eb525abbe0052e16e086cb64bc3b98ae9aa6d74/work"
-        }
-
-  FilesystemChange:
-    description: |
-      Change in the container's filesystem.
-    type: "object"
-    required: [Path, Kind]
-    properties:
-      Path:
-        description: |
-          Path to file or directory that has changed.
-        type: "string"
-        x-nullable: false
-      Kind:
-        $ref: "#/definitions/ChangeType"
-
-  ChangeType:
-    description: |
-      Kind of change
-
-      Can be one of:
-
-      - `0`: Modified ("C")
-      - `1`: Added ("A")
-      - `2`: Deleted ("D")
-    type: "integer"
-    format: "uint8"
-    enum: [0, 1, 2]
-    x-nullable: false
-
-  ImageInspect:
-    description: |
-      Information about an image in the local image cache.
-    type: "object"
-    properties:
-      Id:
-        description: |
-          ID is the content-addressable ID of an image.
-
-          This identifier is a content-addressable digest calculated from the
-          image's configuration (which includes the digests of layers used by
-          the image).
-
-          Note that this digest differs from the `RepoDigests` below, which
-          holds digests of image manifests that reference the image.
-        type: "string"
-        x-nullable: false
-        example: "sha256:ec3f0931a6e6b6855d76b2d7b0be30e81860baccd891b2e243280bf1cd8ad710"
-      RepoTags:
-        description: |
-          List of image names/tags in the local image cache that reference this
-          image.
-
-          Multiple image tags can refer to the same image, and this list may be
-          empty if no tags reference the image, in which case the image is
-          "untagged", in which case it can still be referenced by its ID.
-        type: "array"
-        items:
-          type: "string"
-        example:
-          - "example:1.0"
-          - "example:latest"
-          - "example:stable"
-          - "internal.registry.example.com:5000/example:1.0"
-      RepoDigests:
-        description: |
-          List of content-addressable digests of locally available image manifests
-          that the image is referenced from. Multiple manifests can refer to the
-          same image.
-
-          These digests are usually only available if the image was either pulled
-          from a registry, or if the image was pushed to a registry, which is when
-          the manifest is generated and its digest calculated.
-        type: "array"
-        items:
-          type: "string"
-        example:
-          - "example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb"
-          - "internal.registry.example.com:5000/example@sha256:b69959407d21e8a062e0416bf13405bb2b71ed7a84dde4158ebafacfa06f5578"
-      Parent:
-        description: |
-          ID of the parent image.
-
-          Depending on how the image was created, this field may be empty and
-          is only set for images that were built/created locally. This field
-          is empty if the image was pulled from an image registry.
-        type: "string"
-        x-nullable: false
-        example: ""
-      Comment:
-        description: |
-          Optional message that was set when committing or importing the image.
-        type: "string"
-        x-nullable: false
-        example: ""
-      Created:
-        description: |
-          Date and time at which the image was created, formatted in
-          [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
-        type: "string"
-        x-nullable: false
-        example: "2022-02-04T21:20:12.497794809Z"
-      Container:
-        description: |
-          The ID of the container that was used to create the image.
-
-          Depending on how the image was created, this field may be empty.
-        type: "string"
-        x-nullable: false
-        example: "65974bc86f1770ae4bff79f651ebdbce166ae9aada632ee3fa9af3a264911735"
-      ContainerConfig:
-        $ref: "#/definitions/ContainerConfig"
-      DockerVersion:
-        description: |
-          The version of Docker that was used to build the image.
-
-          Depending on how the image was created, this field may be empty.
-        type: "string"
-        x-nullable: false
-        example: "20.10.7"
-      Author:
-        description: |
-          Name of the author that was specified when committing the image, or as
-          specified through MAINTAINER (deprecated) in the Dockerfile.
-        type: "string"
-        x-nullable: false
-        example: ""
-      Config:
-        $ref: "#/definitions/ContainerConfig"
-      Architecture:
-        description: |
-          Hardware CPU architecture that the image runs on.
-        type: "string"
-        x-nullable: false
-        example: "arm"
-      Variant:
-        description: |
-          CPU architecture variant (presently ARM-only).
-        type: "string"
-        x-nullable: true
-        example: "v7"
-      Os:
-        description: |
-          Operating System the image is built to run on.
-        type: "string"
-        x-nullable: false
-        example: "linux"
-      OsVersion:
-        description: |
-          Operating System version the image is built to run on (especially
-          for Windows).
-        type: "string"
-        example: ""
-        x-nullable: true
-      Size:
-        description: |
-          Total size of the image including all layers it is composed of.
-        type: "integer"
-        format: "int64"
-        x-nullable: false
-        example: 1239828
-      VirtualSize:
-        description: |
-          Total size of the image including all layers it is composed of.
-
-          Deprecated: this field is omitted in API v1.44, but kept for backward compatibility. Use Size instead.
-        type: "integer"
-        format: "int64"
-        example: 1239828
-      GraphDriver:
-        $ref: "#/definitions/GraphDriverData"
-      RootFS:
-        description: |
-          Information about the image's RootFS, including the layer IDs.
-        type: "object"
-        required: [Type]
-        properties:
-          Type:
-            type: "string"
-            x-nullable: false
-            example: "layers"
-          Layers:
-            type: "array"
-            items:
-              type: "string"
-            example:
-              - "sha256:1834950e52ce4d5a88a1bbd131c537f4d0e56d10ff0dd69e66be3b7dfa9df7e6"
-              - "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
-      Metadata:
-        description: |
-          Additional metadata of the image in the local cache. This information
-          is local to the daemon, and not part of the image itself.
-        type: "object"
-        properties:
-          LastTagTime:
-            description: |
-              Date and time at which the image was last tagged in
-              [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
-
-              This information is only available if the image was tagged locally,
-              and omitted otherwise.
-            type: "string"
-            format: "dateTime"
-            example: "2022-02-28T14:40:02.623929178Z"
-            x-nullable: true
-  ImageSummary:
-    type: "object"
-    required:
-      - Id
-      - ParentId
-      - RepoTags
-      - RepoDigests
-      - Created
-      - Size
-      - SharedSize
-      - Labels
-      - Containers
-    properties:
-      Id:
-        description: |
-          ID is the content-addressable ID of an image.
-
-          This identifier is a content-addressable digest calculated from the
-          image's configuration (which includes the digests of layers used by
-          the image).
-
-          Note that this digest differs from the `RepoDigests` below, which
-          holds digests of image manifests that reference the image.
-        type: "string"
-        x-nullable: false
-        example: "sha256:ec3f0931a6e6b6855d76b2d7b0be30e81860baccd891b2e243280bf1cd8ad710"
-      ParentId:
-        description: |
-          ID of the parent image.
-
-          Depending on how the image was created, this field may be empty and
-          is only set for images that were built/created locally. This field
-          is empty if the image was pulled from an image registry.
-        type: "string"
-        x-nullable: false
-        example: ""
-      RepoTags:
-        description: |
-          List of image names/tags in the local image cache that reference this
-          image.
-
-          Multiple image tags can refer to the same image, and this list may be
-          empty if no tags reference the image, in which case the image is
-          "untagged", in which case it can still be referenced by its ID.
-        type: "array"
-        x-nullable: false
-        items:
-          type: "string"
-        example:
-          - "example:1.0"
-          - "example:latest"
-          - "example:stable"
-          - "internal.registry.example.com:5000/example:1.0"
-      RepoDigests:
-        description: |
-          List of content-addressable digests of locally available image manifests
-          that the image is referenced from. Multiple manifests can refer to the
-          same image.
-
-          These digests are usually only available if the image was either pulled
-          from a registry, or if the image was pushed to a registry, which is when
-          the manifest is generated and its digest calculated.
-        type: "array"
-        x-nullable: false
-        items:
-          type: "string"
-        example:
-          - "example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb"
-          - "internal.registry.example.com:5000/example@sha256:b69959407d21e8a062e0416bf13405bb2b71ed7a84dde4158ebafacfa06f5578"
-      Created:
-        description: |
-          Date and time at which the image was created as a Unix timestamp
-          (number of seconds sinds EPOCH).
-        type: "integer"
-        x-nullable: false
-        example: "1644009612"
-      Size:
-        description: |
-          Total size of the image including all layers it is composed of.
-        type: "integer"
-        format: "int64"
-        x-nullable: false
-        example: 172064416
-      SharedSize:
-        description: |
-          Total size of image layers that are shared between this image and other
-          images.
-
-          This size is not calculated by default. `-1` indicates that the value
-          has not been set / calculated.
-        type: "integer"
-        format: "int64"
-        x-nullable: false
-        example: 1239828
-      VirtualSize:
-        description: |-
-          Total size of the image including all layers it is composed of.
-
-          Deprecated: this field is omitted in API v1.44, but kept for backward compatibility. Use Size instead.
-        type: "integer"
-        format: "int64"
-        example: 172064416
-      Labels:
-        description: "User-defined key/value metadata."
-        type: "object"
-        x-nullable: false
-        additionalProperties:
-          type: "string"
-        example:
-          com.example.some-label: "some-value"
-          com.example.some-other-label: "some-other-value"
-      Containers:
-        description: |
-          Number of containers using this image. Includes both stopped and running
-          containers.
-
-          This size is not calculated by default, and depends on which API endpoint
-          is used. `-1` indicates that the value has not been set / calculated.
-        x-nullable: false
-        type: "integer"
-        example: 2
-
-  AuthConfig:
-    type: "object"
-    properties:
-      username:
-        type: "string"
-      password:
-        type: "string"
-      email:
-        type: "string"
-      serveraddress:
-        type: "string"
-    example:
-      username: "hannibal"
-      password: "xxxx"
-      serveraddress: "https://index.docker.io/v1/"
-
-  ProcessConfig:
-    type: "object"
-    properties:
-      privileged:
-        type: "boolean"
-      user:
-        type: "string"
-      tty:
-        type: "boolean"
-      entrypoint:
-        type: "string"
-      arguments:
-        type: "array"
-        items:
-          type: "string"
-
-  Volume:
-    type: "object"
-    required: [Name, Driver, Mountpoint, Labels, Scope, Options]
-    properties:
-      Name:
-        type: "string"
-        description: "Name of the volume."
-        x-nullable: false
-        example: "tardis"
-      Driver:
-        type: "string"
-        description: "Name of the volume driver used by the volume."
-        x-nullable: false
-        example: "custom"
-      Mountpoint:
-        type: "string"
-        description: "Mount path of the volume on the host."
-        x-nullable: false
-        example: "/var/lib/docker/volumes/tardis"
-      CreatedAt:
-        type: "string"
-        format: "dateTime"
-        description: "Date/Time the volume was created."
-        example: "2016-06-07T20:31:11.853781916Z"
-      Status:
-        type: "object"
-        description: |
-          Low-level details about the volume, provided by the volume driver.
-          Details are returned as a map with key/value pairs:
-          `{"key":"value","key2":"value2"}`.
-
-          The `Status` field is optional, and is omitted if the volume driver
-          does not support this feature.
-        additionalProperties:
-          type: "object"
-        example:
-          hello: "world"
-      Labels:
-        type: "object"
-        description: "User-defined key/value metadata."
-        x-nullable: false
-        additionalProperties:
-          type: "string"
-        example:
-          com.example.some-label: "some-value"
-          com.example.some-other-label: "some-other-value"
-      Scope:
-        type: "string"
-        description: |
-          The level at which the volume exists. Either `global` for cluster-wide,
-          or `local` for machine level.
-        default: "local"
-        x-nullable: false
-        enum: ["local", "global"]
-        example: "local"
-      ClusterVolume:
-        $ref: "#/definitions/ClusterVolume"
-      Options:
-        type: "object"
-        description: |
-          The driver specific options used when creating the volume.
-        additionalProperties:
-          type: "string"
-        example:
-          device: "tmpfs"
-          o: "size=100m,uid=1000"
-          type: "tmpfs"
-      UsageData:
-        type: "object"
-        x-nullable: true
-        x-go-name: "UsageData"
-        required: [Size, RefCount]
-        description: |
-          Usage details about the volume. This information is used by the
-          `GET /system/df` endpoint, and omitted in other endpoints.
-        properties:
-          Size:
-            type: "integer"
-            format: "int64"
-            default: -1
-            description: |
-              Amount of disk space used by the volume (in bytes). This information
-              is only available for volumes created with the `"local"` volume
-              driver. For volumes created with other volume drivers, this field
-              is set to `-1` ("not available")
-            x-nullable: false
-          RefCount:
-            type: "integer"
-            format: "int64"
-            default: -1
-            description: |
-              The number of containers referencing this volume. This field
-              is set to `-1` if the reference-count is not available.
-            x-nullable: false
-
-  VolumeCreateOptions:
-    description: "Volume configuration"
-    type: "object"
-    title: "VolumeConfig"
-    x-go-name: "CreateOptions"
-    properties:
-      Name:
-        description: |
-          The new volume's name. If not specified, Docker generates a name.
-        type: "string"
-        x-nullable: false
-        example: "tardis"
-      Driver:
-        description: "Name of the volume driver to use."
-        type: "string"
-        default: "local"
-        x-nullable: false
-        example: "custom"
-      DriverOpts:
-        description: |
-          A mapping of driver options and values. These options are
-          passed directly to the driver and are driver specific.
-        type: "object"
-        additionalProperties:
-          type: "string"
-        example:
-          device: "tmpfs"
-          o: "size=100m,uid=1000"
-          type: "tmpfs"
-      Labels:
-        description: "User-defined key/value metadata."
-        type: "object"
-        additionalProperties:
-          type: "string"
-        example:
-          com.example.some-label: "some-value"
-          com.example.some-other-label: "some-other-value"
-      ClusterVolumeSpec:
-        $ref: "#/definitions/ClusterVolumeSpec"
-
-  VolumeListResponse:
-    type: "object"
-    title: "VolumeListResponse"
-    x-go-name: "ListResponse"
-    description: "Volume list response"
-    properties:
-      Volumes:
-        type: "array"
-        description: "List of volumes"
-        items:
-          $ref: "#/definitions/Volume"
-      Warnings:
-        type: "array"
-        description: |
-          Warnings that occurred when fetching the list of volumes.
-        items:
-          type: "string"
-        example: []
-
-  Network:
-    type: "object"
-    properties:
-      Name:
-        type: "string"
-      Id:
-        type: "string"
-      Created:
-        type: "string"
-        format: "dateTime"
-      Scope:
-        type: "string"
-      Driver:
-        type: "string"
-      EnableIPv6:
-        type: "boolean"
-      IPAM:
-        $ref: "#/definitions/IPAM"
-      Internal:
-        type: "boolean"
-      Attachable:
-        type: "boolean"
-      Ingress:
-        type: "boolean"
-      Containers:
-        type: "object"
-        additionalProperties:
-          $ref: "#/definitions/NetworkContainer"
-      Options:
-        type: "object"
-        additionalProperties:
-          type: "string"
-      Labels:
-        type: "object"
-        additionalProperties:
-          type: "string"
-    example:
-      Name: "net01"
-      Id: "7d86d31b1478e7cca9ebed7e73aa0fdeec46c5ca29497431d3007d2d9e15ed99"
-      Created: "2016-10-19T04:33:30.360899459Z"
-      Scope: "local"
-      Driver: "bridge"
-      EnableIPv6: false
-      IPAM:
-        Driver: "default"
-        Config:
-          - Subnet: "172.19.0.0/16"
-            Gateway: "172.19.0.1"
-        Options:
-          foo: "bar"
-      Internal: false
-      Attachable: false
-      Ingress: false
-      Containers:
-        19a4d5d687db25203351ed79d478946f861258f018fe384f229f2efa4b23513c:
-          Name: "test"
-          EndpointID: "628cadb8bcb92de107b2a1e516cbffe463e321f548feb37697cce00ad694f21a"
-          MacAddress: "02:42:ac:13:00:02"
-          IPv4Address: "172.19.0.2/16"
-          IPv6Address: ""
-      Options:
-        com.docker.network.bridge.default_bridge: "true"
-        com.docker.network.bridge.enable_icc: "true"
-        com.docker.network.bridge.enable_ip_masquerade: "true"
-        com.docker.network.bridge.host_binding_ipv4: "0.0.0.0"
-        com.docker.network.bridge.name: "docker0"
-        com.docker.network.driver.mtu: "1500"
-      Labels:
-        com.example.some-label: "some-value"
-        com.example.some-other-label: "some-other-value"
-  IPAM:
-    type: "object"
-    properties:
-      Driver:
-        description: "Name of the IPAM driver to use."
-        type: "string"
-        default: "default"
-      Config:
-        description: |
-          List of IPAM configuration options, specified as a map:
-
-          ```
-          {"Subnet": <CIDR>, "IPRange": <CIDR>, "Gateway": <IP address>, "AuxAddress": <device_name:IP address>}
-          ```
-        type: "array"
-        items:
-          $ref: "#/definitions/IPAMConfig"
-      Options:
-        description: "Driver-specific options, specified as a map."
-        type: "object"
-        additionalProperties:
-          type: "string"
-
-  IPAMConfig:
-    type: "object"
-    properties:
-      Subnet:
-        type: "string"
-      IPRange:
-        type: "string"
-      Gateway:
-        type: "string"
-      AuxiliaryAddresses:
-        type: "object"
-        additionalProperties:
-          type: "string"
-
-  NetworkContainer:
-    type: "object"
-    properties:
-      Name:
-        type: "string"
-      EndpointID:
-        type: "string"
-      MacAddress:
-        type: "string"
-      IPv4Address:
-        type: "string"
-      IPv6Address:
-        type: "string"
-
-  BuildInfo:
-    type: "object"
-    properties:
-      id:
-        type: "string"
-      stream:
-        type: "string"
-      error:
-        type: "string"
-      errorDetail:
-        $ref: "#/definitions/ErrorDetail"
-      status:
-        type: "string"
-      progress:
-        type: "string"
-      progressDetail:
-        $ref: "#/definitions/ProgressDetail"
-      aux:
-        $ref: "#/definitions/ImageID"
-
-  BuildCache:
-    type: "object"
-    description: |
-      BuildCache contains information about a build cache record.
-    properties:
-      ID:
-        type: "string"
-        description: |
-          Unique ID of the build cache record.
-        example: "ndlpt0hhvkqcdfkputsk4cq9c"
-      Parent:
-        description: |
-          ID of the parent build cache record.
-
-          > **Deprecated**: This field is deprecated, and omitted if empty.
-        type: "string"
-        x-nullable: true
-        example: ""
-      Parents:
-        description: |
-          List of parent build cache record IDs.
-        type: "array"
-        items:
-          type: "string"
-        x-nullable: true
-        example: ["hw53o5aio51xtltp5xjp8v7fx"]
-      Type:
-        type: "string"
-        description: |
-          Cache record type.
-        example: "regular"
-        # see https://github.com/moby/buildkit/blob/fce4a32258dc9d9664f71a4831d5de10f0670677/client/diskusage.go#L75-L84
-        enum:
-          - "internal"
-          - "frontend"
-          - "source.local"
-          - "source.git.checkout"
-          - "exec.cachemount"
-          - "regular"
-      Description:
-        type: "string"
-        description: |
-          Description of the build-step that produced the build cache.
-        example: "mount / from exec /bin/sh -c echo 'Binary::apt::APT::Keep-Downloaded-Packages \"true\";' > /etc/apt/apt.conf.d/keep-cache"
-      InUse:
-        type: "boolean"
-        description: |
-          Indicates if the build cache is in use.
-        example: false
-      Shared:
-        type: "boolean"
-        description: |
-          Indicates if the build cache is shared.
-        example: true
-      Size:
-        description: |
-          Amount of disk space used by the build cache (in bytes).
-        type: "integer"
-        example: 51
-      CreatedAt:
-        description: |
-          Date and time at which the build cache was created in
-          [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
-        type: "string"
-        format: "dateTime"
-        example: "2016-08-18T10:44:24.496525531Z"
-      LastUsedAt:
-        description: |
-          Date and time at which the build cache was last used in
-          [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
-        type: "string"
-        format: "dateTime"
-        x-nullable: true
-        example: "2017-08-09T07:09:37.632105588Z"
-      UsageCount:
-        type: "integer"
-        example: 26
-
-  ImageID:
-    type: "object"
-    description: "Image ID or Digest"
-    properties:
-      ID:
-        type: "string"
-    example:
-      ID: "sha256:85f05633ddc1c50679be2b16a0479ab6f7637f8884e0cfe0f4d20e1ebb3d6e7c"
-
-  CreateImageInfo:
-    type: "object"
-    properties:
-      id:
-        type: "string"
-      error:
-        type: "string"
-      errorDetail:
-        $ref: "#/definitions/ErrorDetail"
-      status:
-        type: "string"
-      progress:
-        type: "string"
-      progressDetail:
-        $ref: "#/definitions/ProgressDetail"
-
-  PushImageInfo:
-    type: "object"
-    properties:
-      error:
-        type: "string"
-      status:
-        type: "string"
-      progress:
-        type: "string"
-      progressDetail:
-        $ref: "#/definitions/ProgressDetail"
-
-  ErrorDetail:
-    type: "object"
-    properties:
-      code:
-        type: "integer"
-      message:
-        type: "string"
-
-  ProgressDetail:
-    type: "object"
-    properties:
-      current:
-        type: "integer"
-      total:
-        type: "integer"
-
-  ErrorResponse:
-    description: "Represents an error."
-    type: "object"
-    required: ["message"]
-    properties:
-      message:
-        description: "The error message."
-        type: "string"
-        x-nullable: false
-    example:
-      message: "Something went wrong."
-
-  IdResponse:
-    description: "Response to an API call that returns just an Id"
-    type: "object"
-    required: ["Id"]
-    properties:
-      Id:
-        description: "The id of the newly created object."
-        type: "string"
-        x-nullable: false
-
-  EndpointSettings:
-    description: "Configuration for a network endpoint."
-    type: "object"
-    properties:
-      # Configurations
-      IPAMConfig:
-        $ref: "#/definitions/EndpointIPAMConfig"
-      Links:
-        type: "array"
-        items:
-          type: "string"
-        example:
-          - "container_1"
-          - "container_2"
-      Aliases:
-        type: "array"
-        items:
-          type: "string"
-        example:
-          - "server_x"
-          - "server_y"
-
-      # Operational data
-      NetworkID:
-        description: |
-          Unique ID of the network.
-        type: "string"
-        example: "08754567f1f40222263eab4102e1c733ae697e8e354aa9cd6e18d7402835292a"
-      EndpointID:
-        description: |
-          Unique ID for the service endpoint in a Sandbox.
-        type: "string"
-        example: "b88f5b905aabf2893f3cbc4ee42d1ea7980bbc0a92e2c8922b1e1795298afb0b"
-      Gateway:
-        description: |
-          Gateway address for this network.
-        type: "string"
-        example: "172.17.0.1"
-      IPAddress:
-        description: |
-          IPv4 address.
-        type: "string"
-        example: "172.17.0.4"
-      IPPrefixLen:
-        description: |
-          Mask length of the IPv4 address.
-        type: "integer"
-        example: 16
-      IPv6Gateway:
-        description: |
-          IPv6 gateway address.
-        type: "string"
-        example: "2001:db8:2::100"
-      GlobalIPv6Address:
-        description: |
-          Global IPv6 address.
-        type: "string"
-        example: "2001:db8::5689"
-      GlobalIPv6PrefixLen:
-        description: |
-          Mask length of the global IPv6 address.
-        type: "integer"
-        format: "int64"
-        example: 64
-      MacAddress:
-        description: |
-          MAC address for the endpoint on this network.
-        type: "string"
-        example: "02:42:ac:11:00:04"
-      DriverOpts:
-        description: |
-          DriverOpts is a mapping of driver options and values. These options
-          are passed directly to the driver and are driver specific.
-        type: "object"
-        x-nullable: true
-        additionalProperties:
-          type: "string"
-        example:
-          com.example.some-label: "some-value"
-          com.example.some-other-label: "some-other-value"
-
-  EndpointIPAMConfig:
-    description: |
-      EndpointIPAMConfig represents an endpoint's IPAM configuration.
-    type: "object"
-    x-nullable: true
-    properties:
-      IPv4Address:
-        type: "string"
-        example: "172.20.30.33"
-      IPv6Address:
-        type: "string"
-        example: "2001:db8:abcd::3033"
-      LinkLocalIPs:
-        type: "array"
-        items:
-          type: "string"
-        example:
-          - "169.254.34.68"
-          - "fe80::3468"
-
-  PluginMount:
-    type: "object"
-    x-nullable: false
-    required: [Name, Description, Settable, Source, Destination, Type, Options]
-    properties:
-      Name:
-        type: "string"
-        x-nullable: false
-        example: "some-mount"
-      Description:
-        type: "string"
-        x-nullable: false
-        example: "This is a mount that's used by the plugin."
-      Settable:
-        type: "array"
-        items:
-          type: "string"
-      Source:
-        type: "string"
-        example: "/var/lib/docker/plugins/"
-      Destination:
-        type: "string"
-        x-nullable: false
-        example: "/mnt/state"
-      Type:
-        type: "string"
-        x-nullable: false
-        example: "bind"
-      Options:
-        type: "array"
-        items:
-          type: "string"
-        example:
-          - "rbind"
-          - "rw"
-
-  PluginDevice:
-    type: "object"
-    required: [Name, Description, Settable, Path]
-    x-nullable: false
-    properties:
-      Name:
-        type: "string"
-        x-nullable: false
-      Description:
-        type: "string"
-        x-nullable: false
-      Settable:
-        type: "array"
-        items:
-          type: "string"
-      Path:
-        type: "string"
-        example: "/dev/fuse"
-
-  PluginEnv:
-    type: "object"
-    x-nullable: false
-    required: [Name, Description, Settable, Value]
-    properties:
-      Name:
-        x-nullable: false
-        type: "string"
-      Description:
-        x-nullable: false
-        type: "string"
-      Settable:
-        type: "array"
-        items:
-          type: "string"
-      Value:
-        type: "string"
-
-  PluginInterfaceType:
-    type: "object"
-    x-nullable: false
-    required: [Prefix, Capability, Version]
-    properties:
-      Prefix:
-        type: "string"
-        x-nullable: false
-      Capability:
-        type: "string"
-        x-nullable: false
-      Version:
-        type: "string"
-        x-nullable: false
-
-  PluginPrivilege:
-    description: |
-      Describes a permission the user has to accept upon installing
-      the plugin.
-    type: "object"
-    x-go-name: "PluginPrivilege"
-    properties:
-      Name:
-        type: "string"
-        example: "network"
-      Description:
-        type: "string"
-      Value:
-        type: "array"
-        items:
-          type: "string"
-        example:
-          - "host"
-
-  Plugin:
-    description: "A plugin for the Engine API"
-    type: "object"
-    required: [Settings, Enabled, Config, Name]
-    properties:
-      Id:
-        type: "string"
-        example: "5724e2c8652da337ab2eedd19fc6fc0ec908e4bd907c7421bf6a8dfc70c4c078"
-      Name:
-        type: "string"
-        x-nullable: false
-        example: "tiborvass/sample-volume-plugin"
-      Enabled:
-        description:
-          True if the plugin is running. False if the plugin is not running,
-          only installed.
-        type: "boolean"
-        x-nullable: false
-        example: true
-      Settings:
-        description: "Settings that can be modified by users."
-        type: "object"
-        x-nullable: false
-        required: [Args, Devices, Env, Mounts]
-        properties:
-          Mounts:
-            type: "array"
-            items:
-              $ref: "#/definitions/PluginMount"
-          Env:
-            type: "array"
-            items:
-              type: "string"
-            example:
-              - "DEBUG=0"
-          Args:
-            type: "array"
-            items:
-              type: "string"
-          Devices:
-            type: "array"
-            items:
-              $ref: "#/definitions/PluginDevice"
-      PluginReference:
-        description: "plugin remote reference used to push/pull the plugin"
-        type: "string"
-        x-nullable: false
-        example: "localhost:5000/tiborvass/sample-volume-plugin:latest"
-      Config:
-        description: "The config of a plugin."
-        type: "object"
-        x-nullable: false
-        required:
-          - Description
-          - Documentation
-          - Interface
-          - Entrypoint
-          - WorkDir
-          - Network
-          - Linux
-          - PidHost
-          - PropagatedMount
-          - IpcHost
-          - Mounts
-          - Env
-          - Args
-        properties:
-          DockerVersion:
-            description: "Docker Version used to create the plugin"
-            type: "string"
-            x-nullable: false
-            example: "17.06.0-ce"
-          Description:
-            type: "string"
-            x-nullable: false
-            example: "A sample volume plugin for Docker"
-          Documentation:
-            type: "string"
-            x-nullable: false
-            example: "https://docs.docker.com/engine/extend/plugins/"
-          Interface:
-            description: "The interface between Docker and the plugin"
-            x-nullable: false
-            type: "object"
-            required: [Types, Socket]
-            properties:
-              Types:
-                type: "array"
-                items:
-                  $ref: "#/definitions/PluginInterfaceType"
-                example:
-                  - "docker.volumedriver/1.0"
-              Socket:
-                type: "string"
-                x-nullable: false
-                example: "plugins.sock"
-              ProtocolScheme:
-                type: "string"
-                example: "some.protocol/v1.0"
-                description: "Protocol to use for clients connecting to the plugin."
-                enum:
-                  - ""
-                  - "moby.plugins.http/v1"
-          Entrypoint:
-            type: "array"
-            items:
-              type: "string"
-            example:
-              - "/usr/bin/sample-volume-plugin"
-              - "/data"
-          WorkDir:
-            type: "string"
-            x-nullable: false
-            example: "/bin/"
-          User:
-            type: "object"
-            x-nullable: false
-            properties:
-              UID:
-                type: "integer"
-                format: "uint32"
-                example: 1000
-              GID:
-                type: "integer"
-                format: "uint32"
-                example: 1000
-          Network:
-            type: "object"
-            x-nullable: false
-            required: [Type]
-            properties:
-              Type:
-                x-nullable: false
-                type: "string"
-                example: "host"
-          Linux:
-            type: "object"
-            x-nullable: false
-            required: [Capabilities, AllowAllDevices, Devices]
-            properties:
-              Capabilities:
-                type: "array"
-                items:
-                  type: "string"
-                example:
-                  - "CAP_SYS_ADMIN"
-                  - "CAP_SYSLOG"
-              AllowAllDevices:
-                type: "boolean"
-                x-nullable: false
-                example: false
-              Devices:
-                type: "array"
-                items:
-                  $ref: "#/definitions/PluginDevice"
-          PropagatedMount:
-            type: "string"
-            x-nullable: false
-            example: "/mnt/volumes"
-          IpcHost:
-            type: "boolean"
-            x-nullable: false
-            example: false
-          PidHost:
-            type: "boolean"
-            x-nullable: false
-            example: false
-          Mounts:
-            type: "array"
-            items:
-              $ref: "#/definitions/PluginMount"
-          Env:
-            type: "array"
-            items:
-              $ref: "#/definitions/PluginEnv"
-            example:
-              - Name: "DEBUG"
-                Description: "If set, prints debug messages"
-                Settable: null
-                Value: "0"
-          Args:
-            type: "object"
-            x-nullable: false
-            required: [Name, Description, Settable, Value]
-            properties:
-              Name:
-                x-nullable: false
-                type: "string"
-                example: "args"
-              Description:
-                x-nullable: false
-                type: "string"
-                example: "command line arguments"
-              Settable:
-                type: "array"
-                items:
-                  type: "string"
-              Value:
-                type: "array"
-                items:
-                  type: "string"
-          rootfs:
-            type: "object"
-            properties:
-              type:
-                type: "string"
-                example: "layers"
-              diff_ids:
-                type: "array"
-                items:
-                  type: "string"
-                example:
-                  - "sha256:675532206fbf3030b8458f88d6e26d4eb1577688a25efec97154c94e8b6b4887"
-                  - "sha256:e216a057b1cb1efc11f8a268f37ef62083e70b1b38323ba252e25ac88904a7e8"
-
-  ObjectVersion:
-    description: |
-      The version number of the object such as node, service, etc. This is needed
-      to avoid conflicting writes. The client must send the version number along
-      with the modified specification when updating these objects.
-
-      This approach ensures safe concurrency and determinism in that the change
-      on the object may not be applied if the version number has changed from the
-      last read. In other words, if two update requests specify the same base
-      version, only one of the requests can succeed. As a result, two separate
-      update requests that happen at the same time will not unintentionally
-      overwrite each other.
-    type: "object"
-    properties:
-      Index:
-        type: "integer"
-        format: "uint64"
-        example: 373531
-
-  NodeSpec:
-    type: "object"
-    properties:
-      Name:
-        description: "Name for the node."
-        type: "string"
-        example: "my-node"
-      Labels:
-        description: "User-defined key/value metadata."
-        type: "object"
-        additionalProperties:
-          type: "string"
-      Role:
-        description: "Role of the node."
-        type: "string"
-        enum:
-          - "worker"
-          - "manager"
-        example: "manager"
-      Availability:
-        description: "Availability of the node."
-        type: "string"
-        enum:
-          - "active"
-          - "pause"
-          - "drain"
-        example: "active"
-    example:
-      Availability: "active"
-      Name: "node-name"
-      Role: "manager"
-      Labels:
-        foo: "bar"
-
-  Node:
-    type: "object"
-    properties:
-      ID:
-        type: "string"
-        example: "24ifsmvkjbyhk"
-      Version:
-        $ref: "#/definitions/ObjectVersion"
-      CreatedAt:
-        description: |
-          Date and time at which the node was added to the swarm in
-          [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
-        type: "string"
-        format: "dateTime"
-        example: "2016-08-18T10:44:24.496525531Z"
-      UpdatedAt:
-        description: |
-          Date and time at which the node was last updated in
-          [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
-        type: "string"
-        format: "dateTime"
-        example: "2017-08-09T07:09:37.632105588Z"
-      Spec:
-        $ref: "#/definitions/NodeSpec"
-      Description:
-        $ref: "#/definitions/NodeDescription"
-      Status:
-        $ref: "#/definitions/NodeStatus"
-      ManagerStatus:
-        $ref: "#/definitions/ManagerStatus"
-
-  NodeDescription:
-    description: |
-      NodeDescription encapsulates the properties of the Node as reported by the
-      agent.
-    type: "object"
-    properties:
-      Hostname:
-        type: "string"
-        example: "bf3067039e47"
-      Platform:
-        $ref: "#/definitions/Platform"
-      Resources:
-        $ref: "#/definitions/ResourceObject"
-      Engine:
-        $ref: "#/definitions/EngineDescription"
-      TLSInfo:
-        $ref: "#/definitions/TLSInfo"
-
-  Platform:
-    description: |
-      Platform represents the platform (Arch/OS).
-    type: "object"
-    properties:
-      Architecture:
-        description: |
-          Architecture represents the hardware architecture (for example,
-          `x86_64`).
-        type: "string"
-        example: "x86_64"
-      OS:
-        description: |
-          OS represents the Operating System (for example, `linux` or `windows`).
-        type: "string"
-        example: "linux"
-
-  EngineDescription:
-    description: "EngineDescription provides information about an engine."
-    type: "object"
-    properties:
-      EngineVersion:
-        type: "string"
-        example: "17.06.0"
-      Labels:
-        type: "object"
-        additionalProperties:
-          type: "string"
-        example:
-          foo: "bar"
-      Plugins:
-        type: "array"
-        items:
+        BindOptions:
+          description: "Optional configuration for the `bind` type."
           type: "object"
           properties:
-            Type:
+            Propagation:
+              description: "A propagation mode with the value `[r]private`, `[r]shared`, or `[r]slave`."
               type: "string"
-            Name:
-              type: "string"
-        example:
-          - Type: "Log"
-            Name: "awslogs"
-          - Type: "Log"
-            Name: "fluentd"
-          - Type: "Log"
-            Name: "gcplogs"
-          - Type: "Log"
-            Name: "gelf"
-          - Type: "Log"
-            Name: "journald"
-          - Type: "Log"
-            Name: "json-file"
-          - Type: "Log"
-            Name: "logentries"
-          - Type: "Log"
-            Name: "splunk"
-          - Type: "Log"
-            Name: "syslog"
-          - Type: "Network"
-            Name: "bridge"
-          - Type: "Network"
-            Name: "host"
-          - Type: "Network"
-            Name: "ipvlan"
-          - Type: "Network"
-            Name: "macvlan"
-          - Type: "Network"
-            Name: "null"
-          - Type: "Network"
-            Name: "overlay"
-          - Type: "Volume"
-            Name: "local"
-          - Type: "Volume"
-            Name: "localhost:5000/vieux/sshfs:latest"
-          - Type: "Volume"
-            Name: "vieux/sshfs:latest"
-
-  TLSInfo:
-    description: |
-      Information about the issuer of leaf TLS certificates and the trusted root
-      CA certificate.
-    type: "object"
-    properties:
-      TrustRoot:
-        description: |
-          The root CA certificate(s) that are used to validate leaf TLS
-          certificates.
-        type: "string"
-      CertIssuerSubject:
-        description:
-          The base64-url-safe-encoded raw subject bytes of the issuer.
-        type: "string"
-      CertIssuerPublicKey:
-        description: |
-          The base64-url-safe-encoded raw public key bytes of the issuer.
-        type: "string"
-    example:
-      TrustRoot: |
-        -----BEGIN CERTIFICATE-----
-        MIIBajCCARCgAwIBAgIUbYqrLSOSQHoxD8CwG6Bi2PJi9c8wCgYIKoZIzj0EAwIw
-        EzERMA8GA1UEAxMIc3dhcm0tY2EwHhcNMTcwNDI0MjE0MzAwWhcNMzcwNDE5MjE0
-        MzAwWjATMREwDwYDVQQDEwhzd2FybS1jYTBZMBMGByqGSM49AgEGCCqGSM49AwEH
-        A0IABJk/VyMPYdaqDXJb/VXh5n/1Yuv7iNrxV3Qb3l06XD46seovcDWs3IZNV1lf
-        3Skyr0ofcchipoiHkXBODojJydSjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMB
-        Af8EBTADAQH/MB0GA1UdDgQWBBRUXxuRcnFjDfR/RIAUQab8ZV/n4jAKBggqhkjO
-        PQQDAgNIADBFAiAy+JTe6Uc3KyLCMiqGl2GyWGQqQDEcO3/YG36x7om65AIhAJvz
-        pxv6zFeVEkAEEkqIYi0omA9+CjanB/6Bz4n1uw8H
-        -----END CERTIFICATE-----
-      CertIssuerSubject: "MBMxETAPBgNVBAMTCHN3YXJtLWNh"
-      CertIssuerPublicKey: "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEmT9XIw9h1qoNclv9VeHmf/Vi6/uI2vFXdBveXTpcPjqx6i9wNazchk1XWV/dKTKvSh9xyGKmiIeRcE4OiMnJ1A=="
-
-  NodeStatus:
-    description: |
-      NodeStatus represents the status of a node.
-
-      It provides the current status of the node, as seen by the manager.
-    type: "object"
-    properties:
-      State:
-        $ref: "#/definitions/NodeState"
-      Message:
-        type: "string"
-        example: ""
-      Addr:
-        description: "IP address of the node."
-        type: "string"
-        example: "172.17.0.2"
-
-  NodeState:
-    description: "NodeState represents the state of a node."
-    type: "string"
-    enum:
-      - "unknown"
-      - "down"
-      - "ready"
-      - "disconnected"
-    example: "ready"
-
-  ManagerStatus:
-    description: |
-      ManagerStatus represents the status of a manager.
-
-      It provides the current status of a node's manager component, if the node
-      is a manager.
-    x-nullable: true
-    type: "object"
-    properties:
-      Leader:
-        type: "boolean"
-        default: false
-        example: true
-      Reachability:
-        $ref: "#/definitions/Reachability"
-      Addr:
-        description: |
-          The IP address and port at which the manager is reachable.
-        type: "string"
-        example: "10.0.0.46:2377"
-
-  Reachability:
-    description: "Reachability represents the reachability of a node."
-    type: "string"
-    enum:
-      - "unknown"
-      - "unreachable"
-      - "reachable"
-    example: "reachable"
-
-  SwarmSpec:
-    description: "User modifiable swarm configuration."
-    type: "object"
-    properties:
-      Name:
-        description: "Name of the swarm."
-        type: "string"
-        example: "default"
-      Labels:
-        description: "User-defined key/value metadata."
-        type: "object"
-        additionalProperties:
-          type: "string"
-        example:
-          com.example.corp.type: "production"
-          com.example.corp.department: "engineering"
-      Orchestration:
-        description: "Orchestration configuration."
-        type: "object"
-        x-nullable: true
-        properties:
-          TaskHistoryRetentionLimit:
-            description: |
-              The number of historic tasks to keep per instance or node. If
-              negative, never remove completed or failed tasks.
-            type: "integer"
-            format: "int64"
-            example: 10
-      Raft:
-        description: "Raft configuration."
-        type: "object"
-        properties:
-          SnapshotInterval:
-            description: "The number of log entries between snapshots."
-            type: "integer"
-            format: "uint64"
-            example: 10000
-          KeepOldSnapshots:
-            description: |
-              The number of snapshots to keep beyond the current snapshot.
-            type: "integer"
-            format: "uint64"
-          LogEntriesForSlowFollowers:
-            description: |
-              The number of log entries to keep around to sync up slow followers
-              after a snapshot is created.
-            type: "integer"
-            format: "uint64"
-            example: 500
-          ElectionTick:
-            description: |
-              The number of ticks that a follower will wait for a message from
-              the leader before becoming a candidate and starting an election.
-              `ElectionTick` must be greater than `HeartbeatTick`.
-
-              A tick currently defaults to one second, so these translate
-              directly to seconds currently, but this is NOT guaranteed.
-            type: "integer"
-            example: 3
-          HeartbeatTick:
-            description: |
-              The number of ticks between heartbeats. Every HeartbeatTick ticks,
-              the leader will send a heartbeat to the followers.
-
-              A tick currently defaults to one second, so these translate
-              directly to seconds currently, but this is NOT guaranteed.
-            type: "integer"
-            example: 1
-      Dispatcher:
-        description: "Dispatcher configuration."
-        type: "object"
-        x-nullable: true
-        properties:
-          HeartbeatPeriod:
-            description: |
-              The delay for an agent to send a heartbeat to the dispatcher.
-            type: "integer"
-            format: "int64"
-            example: 5000000000
-      CAConfig:
-        description: "CA configuration."
-        type: "object"
-        x-nullable: true
-        properties:
-          NodeCertExpiry:
-            description: "The duration node certificates are issued for."
-            type: "integer"
-            format: "int64"
-            example: 7776000000000000
-          ExternalCAs:
-            description: |
-              Configuration for forwarding signing requests to an external
-              certificate authority.
-            type: "array"
-            items:
+              enum:
+                - "private"
+                - "rprivate"
+                - "shared"
+                - "rshared"
+                - "slave"
+                - "rslave"
+            NonRecursive:
+              description: "Disable recursive bind mount."
+              type: "boolean"
+              default: false
+            CreateMountpoint:
+              description: "Create mount point on host if missing"
+              type: "boolean"
+              default: false
+            ReadOnlyNonRecursive:
+              description: |
+                Make the mount non-recursively read-only, but still leave the mount recursive
+                (unless NonRecursive is set to true in conjunction).
+              type: "boolean"
+              default: false
+            ReadOnlyForceRecursive:
+              description: "Raise an error if the mount cannot be made recursively read-only."
+              type: "boolean"
+              default: false
+        VolumeOptions:
+          description: "Optional configuration for the `volume` type."
+          type: "object"
+          properties:
+            NoCopy:
+              description: "Populate volume with data from the target."
+              type: "boolean"
+              default: false
+            Labels:
+              description: "User-defined key/value metadata."
               type: "object"
-              properties:
-                Protocol:
-                  description: |
-                    Protocol for communication with the external CA (currently
-                    only `cfssl` is supported).
-                  type: "string"
-                  enum:
-                    - "cfssl"
-                  default: "cfssl"
-                URL:
-                  description: |
-                    URL where certificate signing requests should be sent.
-                  type: "string"
-                Options:
-                  description: |
-                    An object with key/value pairs that are interpreted as
-                    protocol-specific options for the external CA driver.
-                  type: "object"
-                  additionalProperties:
-                    type: "string"
-                CACert:
-                  description: |
-                    The root CA certificate (in PEM format) this external CA uses
-                    to issue TLS certificates (assumed to be to the current swarm
-                    root CA certificate if not provided).
-                  type: "string"
-          SigningCACert:
-            description: |
-              The desired signing CA certificate for all swarm node TLS leaf
-              certificates, in PEM format.
-            type: "string"
-          SigningCAKey:
-            description: |
-              The desired signing CA key for all swarm node TLS leaf certificates,
-              in PEM format.
-            type: "string"
-          ForceRotate:
-            description: |
-              An integer whose purpose is to force swarm to generate a new
-              signing CA certificate and key, if none have been specified in
-              `SigningCACert` and `SigningCAKey`
-            format: "uint64"
-            type: "integer"
-      EncryptionConfig:
-        description: "Parameters related to encryption-at-rest."
-        type: "object"
-        properties:
-          AutoLockManagers:
-            description: |
-              If set, generate a key and use it to lock data stored on the
-              managers.
-            type: "boolean"
-            example: false
-      TaskDefaults:
-        description: "Defaults for creating tasks in this cluster."
-        type: "object"
-        properties:
-          LogDriver:
-            description: |
-              The log driver to use for tasks created in the orchestrator if
-              unspecified by a service.
-
-              Updating this value only affects new tasks. Existing tasks continue
-              to use their previously configured log driver until recreated.
-            type: "object"
-            properties:
-              Name:
-                description: |
-                  The log driver to use as a default for new tasks.
+              additionalProperties:
                 type: "string"
-                example: "json-file"
-              Options:
-                description: |
-                  Driver-specific options for the selectd log driver, specified
-                  as key/value pairs.
-                type: "object"
-                additionalProperties:
-                  type: "string"
-                example:
-                  "max-file": "10"
-                  "max-size": "100m"
-
-  # The Swarm information for `GET /info`. It is the same as `GET /swarm`, but
-  # without `JoinTokens`.
-  ClusterInfo:
-    description: |
-      ClusterInfo represents information about the swarm as is returned by the
-      "/info" endpoint. Join-tokens are not included.
-    x-nullable: true
-    type: "object"
-    properties:
-      ID:
-        description: "The ID of the swarm."
-        type: "string"
-        example: "abajmipo7b4xz5ip2nrla6b11"
-      Version:
-        $ref: "#/definitions/ObjectVersion"
-      CreatedAt:
-        description: |
-          Date and time at which the swarm was initialised in
-          [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
-        type: "string"
-        format: "dateTime"
-        example: "2016-08-18T10:44:24.496525531Z"
-      UpdatedAt:
-        description: |
-          Date and time at which the swarm was last updated in
-          [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
-        type: "string"
-        format: "dateTime"
-        example: "2017-08-09T07:09:37.632105588Z"
-      Spec:
-        $ref: "#/definitions/SwarmSpec"
-      TLSInfo:
-        $ref: "#/definitions/TLSInfo"
-      RootRotationInProgress:
-        description: |
-          Whether there is currently a root CA rotation in progress for the swarm
-        type: "boolean"
-        example: false
-      DataPathPort:
-        description: |
-          DataPathPort specifies the data path port number for data traffic.
-          Acceptable port range is 1024 to 49151.
-          If no port is set or is set to 0, the default port (4789) is used.
-        type: "integer"
-        format: "uint32"
-        default: 4789
-        example: 4789
-      DefaultAddrPool:
-        description: |
-          Default Address Pool specifies default subnet pools for global scope
-          networks.
-        type: "array"
-        items:
-          type: "string"
-          format: "CIDR"
-          example: ["10.10.0.0/16", "20.20.0.0/16"]
-      SubnetSize:
-        description: |
-          SubnetSize specifies the subnet size of the networks created from the
-          default subnet pool.
-        type: "integer"
-        format: "uint32"
-        maximum: 29
-        default: 24
-        example: 24
-
-  JoinTokens:
-    description: |
-      JoinTokens contains the tokens workers and managers need to join the swarm.
-    type: "object"
-    properties:
-      Worker:
-        description: |
-          The token workers can use to join the swarm.
-        type: "string"
-        example: "SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-1awxwuwd3z9j1z3puu7rcgdbx"
-      Manager:
-        description: |
-          The token managers can use to join the swarm.
-        type: "string"
-        example: "SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-7p73s1dx5in4tatdymyhg9hu2"
-
-  Swarm:
-    type: "object"
-    allOf:
-      - $ref: "#/definitions/ClusterInfo"
-      - type: "object"
-        properties:
-          JoinTokens:
-            $ref: "#/definitions/JoinTokens"
-
-  TaskSpec:
-    description: "User modifiable task configuration."
-    type: "object"
-    properties:
-      PluginSpec:
-        type: "object"
-        description: |
-          Plugin spec for the service.  *(Experimental release only.)*
-
-          <p><br /></p>
-
-          > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are
-          > mutually exclusive. PluginSpec is only used when the Runtime field
-          > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime
-          > field is set to `attachment`.
-        properties:
-          Name:
-            description: "The name or 'alias' to use for the plugin."
-            type: "string"
-          Remote:
-            description: "The plugin image reference to use."
-            type: "string"
-          Disabled:
-            description: "Disable the plugin once scheduled."
-            type: "boolean"
-          PluginPrivilege:
-            type: "array"
-            items:
-              $ref: "#/definitions/PluginPrivilege"
-      ContainerSpec:
-        type: "object"
-        description: |
-          Container spec for the service.
-
-          <p><br /></p>
-
-          > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are
-          > mutually exclusive. PluginSpec is only used when the Runtime field
-          > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime
-          > field is set to `attachment`.
-        properties:
-          Image:
-            description: "The image name to use for the container"
-            type: "string"
-          Labels:
-            description: "User-defined key/value data."
-            type: "object"
-            additionalProperties:
-              type: "string"
-          Command:
-            description: "The command to be run in the image."
-            type: "array"
-            items:
-              type: "string"
-          Args:
-            description: "Arguments to the command."
-            type: "array"
-            items:
-              type: "string"
-          Hostname:
-            description: |
-              The hostname to use for the container, as a valid
-              [RFC 1123](https://tools.ietf.org/html/rfc1123) hostname.
-            type: "string"
-          Env:
-            description: |
-              A list of environment variables in the form `VAR=value`.
-            type: "array"
-            items:
-              type: "string"
-          Dir:
-            description: "The working directory for commands to run in."
-            type: "string"
-          User:
-            description: "The user inside the container."
-            type: "string"
-          Groups:
-            type: "array"
-            description: |
-              A list of additional groups that the container process will run as.
-            items:
-              type: "string"
-          Privileges:
-            type: "object"
-            description: "Security options for the container"
-            properties:
-              CredentialSpec:
-                type: "object"
-                description: "CredentialSpec for managed service account (Windows only)"
-                properties:
-                  Config:
-                    type: "string"
-                    example: "0bt9dmxjvjiqermk6xrop3ekq"
-                    description: |
-                      Load credential spec from a Swarm Config with the given ID.
-                      The specified config must also be present in the Configs
-                      field with the Runtime property set.
-
-                      <p><br /></p>
-
-
-                      > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`,
-                      > and `CredentialSpec.Config` are mutually exclusive.
-                  File:
-                    type: "string"
-                    example: "spec.json"
-                    description: |
-                      Load credential spec from this file. The file is read by
-                      the daemon, and must be present in the `CredentialSpecs`
-                      subdirectory in the docker data directory, which defaults
-                      to `C:\ProgramData\Docker\` on Windows.
-
-                      For example, specifying `spec.json` loads
-                      `C:\ProgramData\Docker\CredentialSpecs\spec.json`.
-
-                      <p><br /></p>
-
-                      > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`,
-                      > and `CredentialSpec.Config` are mutually exclusive.
-                  Registry:
-                    type: "string"
-                    description: |
-                      Load credential spec from this value in the Windows
-                      registry. The specified registry value must be located in:
-
-                      `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Virtualization\Containers\CredentialSpecs`
-
-                      <p><br /></p>
-
-
-                      > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`,
-                      > and `CredentialSpec.Config` are mutually exclusive.
-              SELinuxContext:
-                type: "object"
-                description: "SELinux labels of the container"
-                properties:
-                  Disable:
-                    type: "boolean"
-                    description: "Disable SELinux"
-                  User:
-                    type: "string"
-                    description: "SELinux user label"
-                  Role:
-                    type: "string"
-                    description: "SELinux role label"
-                  Type:
-                    type: "string"
-                    description: "SELinux type label"
-                  Level:
-                    type: "string"
-                    description: "SELinux level label"
-          TTY:
-            description: "Whether a pseudo-TTY should be allocated."
-            type: "boolean"
-          OpenStdin:
-            description: "Open `stdin`"
-            type: "boolean"
-          ReadOnly:
-            description: "Mount the container's root filesystem as read only."
-            type: "boolean"
-          Mounts:
-            description: |
-              Specification for mounts to be added to containers created as part
-              of the service.
-            type: "array"
-            items:
-              $ref: "#/definitions/Mount"
-          StopSignal:
-            description: "Signal to stop the container."
-            type: "string"
-          StopGracePeriod:
-            description: |
-              Amount of time to wait for the container to terminate before
-              forcefully killing it.
-            type: "integer"
-            format: "int64"
-          HealthCheck:
-            $ref: "#/definitions/HealthConfig"
-          Hosts:
-            type: "array"
-            description: |
-              A list of hostname/IP mappings to add to the container's `hosts`
-              file. The format of extra hosts is specified in the
-              [hosts(5)](http://man7.org/linux/man-pages/man5/hosts.5.html)
-              man page:
-
-                  IP_address canonical_hostname [aliases...]
-            items:
-              type: "string"
-          DNSConfig:
-            description: |
-              Specification for DNS related configurations in resolver configuration
-              file (`resolv.conf`).
-            type: "object"
-            properties:
-              Nameservers:
-                description: "The IP addresses of the name servers."
-                type: "array"
-                items:
-                  type: "string"
-              Search:
-                description: "A search list for host-name lookup."
-                type: "array"
-                items:
-                  type: "string"
-              Options:
-                description: |
-                  A list of internal resolver variables to be modified (e.g.,
-                  `debug`, `ndots:3`, etc.).
-                type: "array"
-                items:
-                  type: "string"
-          Secrets:
-            description: |
-              Secrets contains references to zero or more secrets that will be
-              exposed to the service.
-            type: "array"
-            items:
-              type: "object"
-              properties:
-                File:
-                  description: |
-                    File represents a specific target that is backed by a file.
-                  type: "object"
-                  properties:
-                    Name:
-                      description: |
-                        Name represents the final filename in the filesystem.
-                      type: "string"
-                    UID:
-                      description: "UID represents the file UID."
-                      type: "string"
-                    GID:
-                      description: "GID represents the file GID."
-                      type: "string"
-                    Mode:
-                      description: "Mode represents the FileMode of the file."
-                      type: "integer"
-                      format: "uint32"
-                SecretID:
-                  description: |
-                    SecretID represents the ID of the specific secret that we're
-                    referencing.
-                  type: "string"
-                SecretName:
-                  description: |
-                    SecretName is the name of the secret that this references,
-                    but this is just provided for lookup/display purposes. The
-                    secret in the reference will be identified by its ID.
-                  type: "string"
-          Configs:
-            description: |
-              Configs contains references to zero or more configs that will be
-              exposed to the service.
-            type: "array"
-            items:
-              type: "object"
-              properties:
-                File:
-                  description: |
-                    File represents a specific target that is backed by a file.
-
-                    <p><br /><p>
-
-                    > **Note**: `Configs.File` and `Configs.Runtime` are mutually exclusive
-                  type: "object"
-                  properties:
-                    Name:
-                      description: |
-                        Name represents the final filename in the filesystem.
-                      type: "string"
-                    UID:
-                      description: "UID represents the file UID."
-                      type: "string"
-                    GID:
-                      description: "GID represents the file GID."
-                      type: "string"
-                    Mode:
-                      description: "Mode represents the FileMode of the file."
-                      type: "integer"
-                      format: "uint32"
-                Runtime:
-                  description: |
-                    Runtime represents a target that is not mounted into the
-                    container but is used by the task
-
-                    <p><br /><p>
-
-                    > **Note**: `Configs.File` and `Configs.Runtime` are mutually
-                    > exclusive
-                  type: "object"
-                ConfigID:
-                  description: |
-                    ConfigID represents the ID of the specific config that we're
-                    referencing.
-                  type: "string"
-                ConfigName:
-                  description: |
-                    ConfigName is the name of the config that this references,
-                    but this is just provided for lookup/display purposes. The
-                    config in the reference will be identified by its ID.
-                  type: "string"
-          Isolation:
-            type: "string"
-            description: |
-              Isolation technology of the containers running the service.
-              (Windows only)
-            enum:
-              - "default"
-              - "process"
-              - "hyperv"
-          Init:
-            description: |
-              Run an init inside the container that forwards signals and reaps
-              processes. This field is omitted if empty, and the default (as
-              configured on the daemon) is used.
-            type: "boolean"
-            x-nullable: true
-          Sysctls:
-            description: |
-              Set kernel namedspaced parameters (sysctls) in the container.
-              The Sysctls option on services accepts the same sysctls as the
-              are supported on containers. Note that while the same sysctls are
-              supported, no guarantees or checks are made about their
-              suitability for a clustered environment, and it's up to the user
-              to determine whether a given sysctl will work properly in a
-              Service.
-            type: "object"
-            additionalProperties:
-              type: "string"
-          # This option is not used by Windows containers
-          CapabilityAdd:
-            type: "array"
-            description: |
-              A list of kernel capabilities to add to the default set
-              for the container.
-            items:
-              type: "string"
-            example:
-              - "CAP_NET_RAW"
-              - "CAP_SYS_ADMIN"
-              - "CAP_SYS_CHROOT"
-              - "CAP_SYSLOG"
-          CapabilityDrop:
-            type: "array"
-            description: |
-              A list of kernel capabilities to drop from the default set
-              for the container.
-            items:
-              type: "string"
-            example:
-              - "CAP_NET_RAW"
-          Ulimits:
-            description: |
-              A list of resource limits to set in the container. For example: `{"Name": "nofile", "Soft": 1024, "Hard": 2048}`"
-            type: "array"
-            items:
+            DriverConfig:
+              description: "Map of driver specific options"
               type: "object"
               properties:
                 Name:
-                  description: "Name of ulimit"
+                  description: "Name of the driver to use to create the volume."
                   type: "string"
-                Soft:
-                  description: "Soft limit"
-                  type: "integer"
-                Hard:
-                  description: "Hard limit"
-                  type: "integer"
-      NetworkAttachmentSpec:
-        description: |
-          Read-only spec type for non-swarm containers attached to swarm overlay
-          networks.
-
-          <p><br /></p>
-
-          > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are
-          > mutually exclusive. PluginSpec is only used when the Runtime field
-          > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime
-          > field is set to `attachment`.
-        type: "object"
-        properties:
-          ContainerID:
-            description: "ID of the container represented by this task"
-            type: "string"
-      Resources:
-        description: |
-          Resource requirements which apply to each individual container created
-          as part of the service.
-        type: "object"
-        properties:
-          Limits:
-            description: "Define resources limits."
-            $ref: "#/definitions/Limit"
-          Reservations:
-            description: "Define resources reservation."
-            $ref: "#/definitions/ResourceObject"
-      RestartPolicy:
-        description: |
-          Specification for the restart policy which applies to containers
-          created as part of this service.
-        type: "object"
-        properties:
-          Condition:
-            description: "Condition for restart."
-            type: "string"
-            enum:
-              - "none"
-              - "on-failure"
-              - "any"
-          Delay:
-            description: "Delay between restart attempts."
-            type: "integer"
-            format: "int64"
-          MaxAttempts:
-            description: |
-              Maximum attempts to restart a given container before giving up
-              (default value is 0, which is ignored).
-            type: "integer"
-            format: "int64"
-            default: 0
-          Window:
-            description: |
-              Windows is the time window used to evaluate the restart policy
-              (default value is 0, which is unbounded).
-            type: "integer"
-            format: "int64"
-            default: 0
-      Placement:
-        type: "object"
-        properties:
-          Constraints:
-            description: |
-              An array of constraint expressions to limit the set of nodes where
-              a task can be scheduled. Constraint expressions can either use a
-              _match_ (`==`) or _exclude_ (`!=`) rule. Multiple constraints find
-              nodes that satisfy every expression (AND match). Constraints can
-              match node or Docker Engine labels as follows:
-
-              node attribute       | matches                        | example
-              ---------------------|--------------------------------|-----------------------------------------------
-              `node.id`            | Node ID                        | `node.id==2ivku8v2gvtg4`
-              `node.hostname`      | Node hostname                  | `node.hostname!=node-2`
-              `node.role`          | Node role (`manager`/`worker`) | `node.role==manager`
-              `node.platform.os`   | Node operating system          | `node.platform.os==windows`
-              `node.platform.arch` | Node architecture              | `node.platform.arch==x86_64`
-              `node.labels`        | User-defined node labels       | `node.labels.security==high`
-              `engine.labels`      | Docker Engine's labels         | `engine.labels.operatingsystem==ubuntu-14.04`
-
-              `engine.labels` apply to Docker Engine labels like operating system,
-              drivers, etc. Swarm administrators add `node.labels` for operational
-              purposes by using the [`node update endpoint`](#operation/NodeUpdate).
-
-            type: "array"
-            items:
-              type: "string"
-            example:
-              - "node.hostname!=node3.corp.example.com"
-              - "node.role!=manager"
-              - "node.labels.type==production"
-              - "node.platform.os==linux"
-              - "node.platform.arch==x86_64"
-          Preferences:
-            description: |
-              Preferences provide a way to make the scheduler aware of factors
-              such as topology. They are provided in order from highest to
-              lowest precedence.
-            type: "array"
-            items:
-              type: "object"
-              properties:
-                Spread:
+                Options:
+                  description: "key/value map of driver specific options."
                   type: "object"
-                  properties:
-                    SpreadDescriptor:
-                      description: |
-                        label descriptor, such as `engine.labels.az`.
-                      type: "string"
-            example:
-              - Spread:
-                  SpreadDescriptor: "node.labels.datacenter"
-              - Spread:
-                  SpreadDescriptor: "node.labels.rack"
-          MaxReplicas:
-            description: |
-              Maximum number of replicas for per node (default value is 0, which
-              is unlimited)
-            type: "integer"
-            format: "int64"
-            default: 0
-          Platforms:
-            description: |
-              Platforms stores all the platforms that the service's image can
-              run on. This field is used in the platform filter for scheduling.
-              If empty, then the platform filter is off, meaning there are no
-              scheduling restrictions.
-            type: "array"
-            items:
-              $ref: "#/definitions/Platform"
-      ForceUpdate:
-        description: |
-          A counter that triggers an update even if no relevant parameters have
-          been changed.
-        type: "integer"
-      Runtime:
-        description: |
-          Runtime is the type of runtime specified for the task executor.
-        type: "string"
-      Networks:
-        description: "Specifies which networks the service should attach to."
-        type: "array"
-        items:
-          $ref: "#/definitions/NetworkAttachmentConfig"
-      LogDriver:
-        description: |
-          Specifies the log driver to use for tasks created from this spec. If
-          not present, the default one for the swarm will be used, finally
-          falling back to the engine default if not specified.
-        type: "object"
-        properties:
-          Name:
-            type: "string"
-          Options:
-            type: "object"
-            additionalProperties:
-              type: "string"
+                  additionalProperties:
+                    type: "string"
+        TmpfsOptions:
+          description: "Optional configuration for the `tmpfs` type."
+          type: "object"
+          properties:
+            SizeBytes:
+              description: "The size for the tmpfs mount in bytes."
+              type: "integer"
+              format: "int64"
+            Mode:
+              description: "The permission mode for the tmpfs mount in an integer."
+              type: "integer"
 
-  TaskState:
-    type: "string"
-    enum:
-      - "new"
-      - "allocated"
-      - "pending"
-      - "assigned"
-      - "accepted"
-      - "preparing"
-      - "ready"
-      - "starting"
-      - "running"
-      - "complete"
-      - "shutdown"
-      - "failed"
-      - "rejected"
-      - "remove"
-      - "orphaned"
-
-  Task:
-    type: "object"
-    properties:
-      ID:
-        description: "The ID of the task."
-        type: "string"
-      Version:
-        $ref: "#/definitions/ObjectVersion"
-      CreatedAt:
-        type: "string"
-        format: "dateTime"
-      UpdatedAt:
-        type: "string"
-        format: "dateTime"
-      Name:
-        description: "Name of the task."
-        type: "string"
-      Labels:
-        description: "User-defined key/value metadata."
-        type: "object"
-        additionalProperties:
+    RestartPolicy:
+      description: |
+        The behavior to apply when the container exits. The default is not to
+        restart.
+  
+        An ever increasing delay (double the previous delay, starting at 100ms) is
+        added before each restart to prevent flooding the server.
+      type: "object"
+      properties:
+        Name:
           type: "string"
-      Spec:
-        $ref: "#/definitions/TaskSpec"
-      ServiceID:
-        description: "The ID of the service this task is part of."
-        type: "string"
-      Slot:
-        type: "integer"
-      NodeID:
-        description: "The ID of the node that this task is on."
-        type: "string"
-      AssignedGenericResources:
-        $ref: "#/definitions/GenericResources"
-      Status:
-        type: "object"
-        properties:
-          Timestamp:
-            type: "string"
-            format: "dateTime"
-          State:
-            $ref: "#/definitions/TaskState"
-          Message:
-            type: "string"
-          Err:
-            type: "string"
-          ContainerStatus:
+          description: |
+            - Empty string means not to restart
+            - `no` Do not automatically restart
+            - `always` Always restart
+            - `unless-stopped` Restart always except when the user has manually stopped the container
+            - `on-failure` Restart only when the container exit code is non-zero
+          enum:
+            - ""
+            - "no"
+            - "always"
+            - "unless-stopped"
+            - "on-failure"
+        MaximumRetryCount:
+          type: "integer"
+          description: |
+            If `on-failure` is used, the number of times to retry before giving up.
+
+    Resources:
+      description: "A container's resources (cgroups config, ulimits, etc)"
+      type: "object"
+      properties:
+        # Applicable to all platforms
+        CpuShares:
+          description: |
+            An integer value representing this container's relative CPU weight
+            versus other containers.
+          type: "integer"
+        Memory:
+          description: "Memory limit in bytes."
+          type: "integer"
+          format: "int64"
+          default: 0
+        # Applicable to UNIX platforms
+        CgroupParent:
+          description: |
+            Path to `cgroups` under which the container's `cgroup` is created. If
+            the path is not absolute, the path is considered to be relative to the
+            `cgroups` path of the init process. Cgroups are created if they do not
+            already exist.
+          type: "string"
+        BlkioWeight:
+          description: "Block IO weight (relative weight)."
+          type: "integer"
+          minimum: 0
+          maximum: 1000
+        BlkioWeightDevice:
+          description: |
+            Block IO weight (relative device weight) in the form:
+
+            ```
+            [{"Path": "device_path", "Weight": weight}]
+            ```
+          type: "array"
+          items:
             type: "object"
             properties:
-              ContainerID:
+              Path:
                 type: "string"
-              PID:
+              Weight:
                 type: "integer"
-              ExitCode:
+                minimum: 0
+        BlkioDeviceReadBps:
+          description: |
+            Limit read rate (bytes per second) from a device, in the form:
+
+            ```
+            [{"Path": "device_path", "Rate": rate}]
+            ```
+          type: "array"
+          items:
+            $ref: "#/components/schemas/ThrottleDevice"
+        BlkioDeviceWriteBps:
+          description: |
+            Limit write rate (bytes per second) to a device, in the form:
+
+            ```
+            [{"Path": "device_path", "Rate": rate}]
+            ```
+          type: "array"
+          items:
+            $ref: "#/components/schemas/ThrottleDevice"
+        BlkioDeviceReadIOps:
+          description: |
+            Limit read rate (IO per second) from a device, in the form:
+
+            ```
+            [{"Path": "device_path", "Rate": rate}]
+            ```
+          type: "array"
+          items:
+            $ref: "#/components/schemas/ThrottleDevice"
+        BlkioDeviceWriteIOps:
+          description: |
+            Limit write rate (IO per second) to a device, in the form:
+
+            ```
+            [{"Path": "device_path", "Rate": rate}]
+            ```
+          type: "array"
+          items:
+            $ref: "#/components/schemas/ThrottleDevice"
+        CpuPeriod:
+          description: "The length of a CPU period in microseconds."
+          type: "integer"
+          format: "int64"
+        CpuQuota:
+          description: |
+            Microseconds of CPU time that the container can get in a CPU period.
+          type: "integer"
+          format: "int64"
+        CpuRealtimePeriod:
+          description: |
+            The length of a CPU real-time period in microseconds. Set to 0 to
+            allocate no time allocated to real-time tasks.
+          type: "integer"
+          format: "int64"
+        CpuRealtimeRuntime:
+          description: |
+            The length of a CPU real-time runtime in microseconds. Set to 0 to
+            allocate no time allocated to real-time tasks.
+          type: "integer"
+          format: "int64"
+        CpusetCpus:
+          description: |
+            CPUs in which to allow execution (e.g., `0-3`, `0,1`).
+          type: "string"
+          example: "0-3"
+        CpusetMems:
+          description: |
+            Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only
+            effective on NUMA systems.
+          type: "string"
+        Devices:
+          description: "A list of devices to add to the container."
+          type: "array"
+          items:
+            $ref: "#/components/schemas/DeviceMapping"
+        DeviceCgroupRules:
+          description: "a list of cgroup rules to apply to the container"
+          type: "array"
+          items:
+            type: "string"
+            example: "c 13:* rwm"
+        DeviceRequests:
+          description: |
+            A list of requests for devices to be sent to device drivers.
+          type: "array"
+          items:
+            $ref: "#/components/schemas/DeviceRequest"
+        KernelMemoryTCP:
+          description: |
+            Hard limit for kernel TCP buffer memory (in bytes). Depending on the
+            OCI runtime in use, this option may be ignored. It is no longer supported
+            by the default (runc) runtime.
+
+            This field is omitted when empty.
+          type: "integer"
+          format: "int64"
+        MemoryReservation:
+          description: "Memory soft limit in bytes."
+          type: "integer"
+          format: "int64"
+        MemorySwap:
+          description: |
+            Total memory limit (memory + swap). Set as `-1` to enable unlimited
+            swap.
+          type: "integer"
+          format: "int64"
+        MemorySwappiness:
+          description: |
+            Tune a container's memory swappiness behavior. Accepts an integer
+            between 0 and 100.
+          type: "integer"
+          format: "int64"
+          minimum: 0
+          maximum: 100
+        NanoCpus:
+          description: "CPU quota in units of 10<sup>-9</sup> CPUs."
+          type: "integer"
+          format: "int64"
+        OomKillDisable:
+          description: "Disable OOM Killer for the container."
+          type: "boolean"
+        Init:
+          description: |
+            Run an init inside the container that forwards signals and reaps
+            processes. This field is omitted if empty, and the default (as
+            configured on the daemon) is used.
+          type: "boolean"
+          nullable: true
+          x-nullable: true
+        PidsLimit:
+          description: |
+            Tune a container's PIDs limit. Set `0` or `-1` for unlimited, or `null`
+            to not change.
+          type: "integer"
+          format: "int64"
+          nullable: true
+          x-nullable: true
+        Ulimits:
+          description: |
+            A list of resource limits to set in the container. For example:
+
+            ```
+            {"Name": "nofile", "Soft": 1024, "Hard": 2048}
+            ```
+          type: "array"
+          items:
+            type: "object"
+            properties:
+              Name:
+                description: "Name of ulimit"
+                type: "string"
+              Soft:
+                description: "Soft limit"
                 type: "integer"
-      DesiredState:
-        $ref: "#/definitions/TaskState"
-      JobIteration:
-        description: |
-          If the Service this Task belongs to is a job-mode service, contains
-          the JobIteration of the Service this Task was created for. Absent if
-          the Task was created for a Replicated or Global Service.
-        $ref: "#/definitions/ObjectVersion"
-    example:
-      ID: "0kzzo1i0y4jz6027t0k7aezc7"
-      Version:
-        Index: 71
-      CreatedAt: "2016-06-07T21:07:31.171892745Z"
-      UpdatedAt: "2016-06-07T21:07:31.376370513Z"
-      Spec:
-        ContainerSpec:
-          Image: "redis"
-        Resources:
-          Limits: {}
-          Reservations: {}
-        RestartPolicy:
-          Condition: "any"
-          MaxAttempts: 0
-        Placement: {}
-      ServiceID: "9mnpnzenvg8p8tdbtq4wvbkcz"
-      Slot: 1
-      NodeID: "60gvrl6tm78dmak4yl7srz94v"
-      Status:
-        Timestamp: "2016-06-07T21:07:31.290032978Z"
-        State: "running"
-        Message: "started"
-        ContainerStatus:
-          ContainerID: "e5d62702a1b48d01c3e02ca1e0212a250801fa8d67caca0b6f35919ebc12f035"
-          PID: 677
-      DesiredState: "running"
-      NetworksAttachments:
-        - Network:
-            ID: "4qvuz4ko70xaltuqbt8956gd1"
-            Version:
-              Index: 18
-            CreatedAt: "2016-06-07T20:31:11.912919752Z"
-            UpdatedAt: "2016-06-07T21:07:29.955277358Z"
-            Spec:
-              Name: "ingress"
-              Labels:
-                com.docker.swarm.internal: "true"
-              DriverConfiguration: {}
-              IPAMOptions:
-                Driver: {}
-                Configs:
-                  - Subnet: "10.255.0.0/16"
-                    Gateway: "10.255.0.1"
-            DriverState:
-              Name: "overlay"
-              Options:
-                com.docker.network.driver.overlay.vxlanid_list: "256"
-            IPAMOptions:
-              Driver:
-                Name: "default"
-              Configs:
-                - Subnet: "10.255.0.0/16"
-                  Gateway: "10.255.0.1"
-          Addresses:
-            - "10.255.0.10/16"
-      AssignedGenericResources:
+              Hard:
+                description: "Hard limit"
+                type: "integer"
+        # Applicable to Windows
+        CpuCount:
+          description: |
+            The number of usable CPUs (Windows only).
+
+            On Windows Server containers, the processor resource controls are
+            mutually exclusive. The order of precedence is `CPUCount` first, then
+            `CPUShares`, and `CPUPercent` last.
+          type: "integer"
+          format: "int64"
+        CpuPercent:
+          description: |
+            The usable percentage of the available CPUs (Windows only).
+
+            On Windows Server containers, the processor resource controls are
+            mutually exclusive. The order of precedence is `CPUCount` first, then
+            `CPUShares`, and `CPUPercent` last.
+          type: "integer"
+          format: "int64"
+        IOMaximumIOps:
+          description: "Maximum IOps for the container system drive (Windows only)"
+          type: "integer"
+          format: "int64"
+        IOMaximumBandwidth:
+          description: |
+            Maximum IO in bytes per second for the container system drive
+            (Windows only).
+          type: "integer"
+          format: "int64"
+
+    Limit:
+      description: |
+        An object describing a limit on resources which can be requested by a task.
+      type: "object"
+      properties:
+        NanoCPUs:
+          type: "integer"
+          format: "int64"
+          example: 4000000000
+        MemoryBytes:
+          type: "integer"
+          format: "int64"
+          example: 8272408576
+        Pids:
+          description: |
+            Limits the maximum number of PIDs in the container. Set `0` for unlimited.
+          type: "integer"
+          format: "int64"
+          default: 0
+          example: 100
+
+    ResourceObject:
+      description: |
+        An object describing the resources which can be advertised by a node and
+        requested by a task.
+      type: "object"
+      properties:
+        NanoCPUs:
+          type: "integer"
+          format: "int64"
+          example: 4000000000
+        MemoryBytes:
+          type: "integer"
+          format: "int64"
+          example: 8272408576
+        GenericResources:
+          $ref: "#/components/schemas/GenericResources"
+
+    GenericResources:
+      description: |
+        User-defined resources can be either Integer resources (e.g, `SSD=3`) or
+        String resources (e.g, `GPU=UUID1`).
+      type: "array"
+      items:
+        type: "object"
+        properties:
+          NamedResourceSpec:
+            type: "object"
+            properties:
+              Kind:
+                type: "string"
+              Value:
+                type: "string"
+          DiscreteResourceSpec:
+            type: "object"
+            properties:
+              Kind:
+                type: "string"
+              Value:
+                type: "integer"
+                format: "int64"
+      example:
         - DiscreteResourceSpec:
             Kind: "SSD"
             Value: 3
@@ -4076,325 +760,3362 @@ definitions:
             Kind: "GPU"
             Value: "UUID2"
 
-  ServiceSpec:
-    description: "User modifiable configuration for a service."
-    type: object
-    properties:
-      Name:
-        description: "Name of the service."
-        type: "string"
-      Labels:
-        description: "User-defined key/value metadata."
-        type: "object"
-        additionalProperties:
+    HealthConfig:
+      description: "A test to perform to check that the container is healthy."
+      type: "object"
+      properties:
+        Test:
+          description: |
+            The test to perform. Possible values are:
+
+            - `[]` inherit healthcheck from image or parent image
+            - `["NONE"]` disable healthcheck
+            - `["CMD", args...]` exec arguments directly
+            - `["CMD-SHELL", command]` run command with system's default shell
+          type: "array"
+          items:
+            type: "string"
+        Interval:
+          description: |
+            The time to wait between checks in nanoseconds. It should be 0 or at
+            least 1000000 (1 ms). 0 means inherit.
+          type: "integer"
+          format: "int64"
+        Timeout:
+          description: |
+            The time to wait before considering the check to have hung. It should
+            be 0 or at least 1000000 (1 ms). 0 means inherit.
+          type: "integer"
+          format: "int64"
+        Retries:
+          description: |
+            The number of consecutive failures needed to consider a container as
+            unhealthy. 0 means inherit.
+          type: "integer"
+        StartPeriod:
+          description: |
+            Start period for the container to initialize before starting
+            health-retries countdown in nanoseconds. It should be 0 or at least
+            1000000 (1 ms). 0 means inherit.
+          type: "integer"
+          format: "int64"
+        StartInterval:
+          description: |
+            The time to wait between checks in nanoseconds during the start period.
+            It should be 0 or at least 1000000 (1 ms). 0 means inherit.
+          type: "integer"
+          format: "int64"
+
+    Health:
+      description: |
+        Health stores information about the container's healthcheck results.
+      type: "object"
+      nullable: true
+      x-nullable: true
+      properties:
+        Status:
+          description: |
+            Status is one of `none`, `starting`, `healthy` or `unhealthy`
+
+            - "none"      Indicates there is no healthcheck
+            - "starting"  Starting indicates that the container is not yet ready
+            - "healthy"   Healthy indicates that the container is running correctly
+            - "unhealthy" Unhealthy indicates that the container has a problem
           type: "string"
-      TaskTemplate:
-        $ref: "#/definitions/TaskSpec"
-      Mode:
-        description: "Scheduling mode for the service."
-        type: "object"
-        properties:
-          Replicated:
-            type: "object"
-            properties:
-              Replicas:
+          enum:
+            - "none"
+            - "starting"
+            - "healthy"
+            - "unhealthy"
+          example: "healthy"
+        FailingStreak:
+          description: "FailingStreak is the number of consecutive failures"
+          type: "integer"
+          example: 0
+        Log:
+          type: "array"
+          description: |
+            Log contains the last few results (oldest first)
+          items:
+            $ref: "#/components/schemas/HealthcheckResult"
+
+    HealthcheckResult:
+      description: |
+        HealthcheckResult stores information about a single run of a healthcheck probe
+      type: "object"
+      nullable: true
+      x-nullable: true
+      properties:
+        Start:
+          description: |
+            Date and time at which this check started in
+            [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+          type: "string"
+          format: "date-time"
+          example: "2020-01-04T10:44:24.496525531Z"
+        End:
+          description: |
+            Date and time at which this check ended in
+            [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+          type: "string"
+          format: "dateTime"
+          example: "2020-01-04T10:45:21.364524523Z"
+        ExitCode:
+          description: |
+            ExitCode meanings:
+
+            - `0` healthy
+            - `1` unhealthy
+            - `2` reserved (considered unhealthy)
+            - other values: error running probe
+          type: "integer"
+          example: 0
+        Output:
+          description: "Output from last check"
+          type: "string"
+
+    HostConfig:
+      description: "Container configuration that depends on the host we are running on"
+      allOf:
+        - $ref: "#/components/schemas/Resources"
+        - type: "object"
+          properties:
+            # Applicable to all platforms
+            Binds:
+              type: "array"
+              description: |
+                A list of volume bindings for this container. Each volume binding
+                is a string in one of these forms:
+  
+                - `host-src:container-dest[:options]` to bind-mount a host path
+                  into the container. Both `host-src`, and `container-dest` must
+                  be an _absolute_ path.
+                - `volume-name:container-dest[:options]` to bind-mount a volume
+                  managed by a volume driver into the container. `container-dest`
+                  must be an _absolute_ path.
+  
+                `options` is an optional, comma-delimited list of:
+  
+                - `nocopy` disables automatic copying of data from the container
+                  path to the volume. The `nocopy` flag only applies to named volumes.
+                - `[ro|rw]` mounts a volume read-only or read-write, respectively.
+                  If omitted or set to `rw`, volumes are mounted read-write.
+                - `[z|Z]` applies SELinux labels to allow or deny multiple containers
+                  to read and write to the same volume.
+                    - `z`: a _shared_ content label is applied to the content. This
+                      label indicates that multiple containers can share the volume
+                      content, for both reading and writing.
+                    - `Z`: a _private unshared_ label is applied to the content.
+                      This label indicates that only the current container can use
+                      a private volume. Labeling systems such as SELinux require
+                      proper labels to be placed on volume content that is mounted
+                      into a container. Without a label, the security system can
+                      prevent a container's processes from using the content. By
+                      default, the labels set by the host operating system are not
+                      modified.
+                - `[[r]shared|[r]slave|[r]private]` specifies mount
+                  [propagation behavior](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt).
+                  This only applies to bind-mounted volumes, not internal volumes
+                  or named volumes. Mount propagation requires the source mount
+                  point (the location where the source directory is mounted in the
+                  host operating system) to have the correct propagation properties.
+                  For shared volumes, the source mount point must be set to `shared`.
+                  For slave volumes, the mount must be set to either `shared` or
+                  `slave`.
+              items:
+                type: "string"
+            ContainerIDFile:
+              type: "string"
+              description: "Path to a file where the container ID is written"
+            LogConfig:
+              type: "object"
+              description: "The logging configuration for this container"
+              properties:
+                Type:
+                  type: "string"
+                  enum:
+                    - "json-file"
+                    - "syslog"
+                    - "journald"
+                    - "gelf"
+                    - "fluentd"
+                    - "awslogs"
+                    - "splunk"
+                    - "etwlogs"
+                    - "none"
+                Config:
+                  type: "object"
+                  additionalProperties:
+                    type: "string"
+            NetworkMode:
+              type: "string"
+              description: |
+                Network mode to use for this container. Supported standard values
+                are: `bridge`, `host`, `none`, and `container:<name|id>`. Any
+                other value is taken as a custom network's name to which this
+                container should connect to.
+            PortBindings:
+              $ref: "#/components/schemas/PortMap"
+            RestartPolicy:
+              $ref: "#/components/schemas/RestartPolicy"
+            AutoRemove:
+              type: "boolean"
+              description: |
+                Automatically remove the container when the container's process
+                exits. This has no effect if `RestartPolicy` is set.
+            VolumeDriver:
+              type: "string"
+              description: "Driver that this container uses to mount volumes."
+            VolumesFrom:
+              type: "array"
+              description: |
+                A list of volumes to inherit from another container, specified in
+                the form `<container name>[:<ro|rw>]`.
+              items:
+                type: "string"
+            Mounts:
+              description: |
+                Specification for mounts to be added to the container.
+              type: "array"
+              items:
+                $ref: "#/components/schemas/Mount"
+            ConsoleSize:
+              type: "array"
+              description: |
+                Initial console size, as an `[height, width]` array.
+              nullable: true
+              x-nullable: true
+              minItems: 2
+              maxItems: 2
+              items:
                 type: "integer"
-                format: "int64"
-          Global:
+                minimum: 0
+            Annotations:
+              type: "object"
+              description: |
+                Arbitrary non-identifying metadata attached to container and
+                provided to the runtime when the container is started.
+              additionalProperties:
+                type: "string"
+
+            # Applicable to UNIX platforms
+            CapAdd:
+              type: "array"
+              description: |
+                A list of kernel capabilities to add to the container. Conflicts
+                with option 'Capabilities'.
+              items:
+                type: "string"
+            CapDrop:
+              type: "array"
+              description: |
+                A list of kernel capabilities to drop from the container. Conflicts
+                with option 'Capabilities'.
+              items:
+                type: "string"
+            CgroupnsMode:
+              type: "string"
+              enum:
+                - "private"
+                - "host"
+              description: |
+                cgroup namespace mode for the container. Possible values are:
+  
+                - `"private"`: the container runs in its own private cgroup namespace
+                - `"host"`: use the host system's cgroup namespace
+  
+                If not specified, the daemon default is used, which can either be `"private"`
+                or `"host"`, depending on daemon version, kernel support and configuration.
+            Dns:
+              type: "array"
+              description: "A list of DNS servers for the container to use."
+              items:
+                type: "string"
+            DnsOptions:
+              type: "array"
+              description: "A list of DNS options."
+              items:
+                type: "string"
+            DnsSearch:
+              type: "array"
+              description: "A list of DNS search domains."
+              items:
+                type: "string"
+            ExtraHosts:
+              type: "array"
+              description: |
+                A list of hostnames/IP mappings to add to the container's `/etc/hosts`
+                file. Specified in the form `["hostname:IP"]`.
+              items:
+                type: "string"
+            GroupAdd:
+              type: "array"
+              description: |
+                A list of additional groups that the container process will run as.
+              items:
+                type: "string"
+            IpcMode:
+              type: "string"
+              description: |
+                IPC sharing mode for the container. Possible values are:
+  
+                - `"none"`: own private IPC namespace, with /dev/shm not mounted
+                - `"private"`: own private IPC namespace
+                - `"shareable"`: own private IPC namespace, with a possibility to share it with other containers
+                - `"container:<name|id>"`: join another (shareable) container's IPC namespace
+                - `"host"`: use the host system's IPC namespace
+  
+                If not specified, daemon default is used, which can either be `"private"`
+                or `"shareable"`, depending on daemon version and configuration.
+            Cgroup:
+              type: "string"
+              description: "Cgroup to use for the container."
+            Links:
+              type: "array"
+              description: |
+                A list of links for the container in the form `container_name:alias`.
+              items:
+                type: "string"
+            OomScoreAdj:
+              type: "integer"
+              description: |
+                An integer value containing the score given to the container in
+                order to tune OOM killer preferences.
+              example: 500
+            PidMode:
+              type: "string"
+              description: |
+                Set the PID (Process) Namespace mode for the container. It can be
+                either:
+  
+                - `"container:<name|id>"`: joins another container's PID namespace
+                - `"host"`: use the host's PID namespace inside the container
+            Privileged:
+              type: "boolean"
+              description: "Gives the container full access to the host."
+            PublishAllPorts:
+              type: "boolean"
+              description: |
+                Allocates an ephemeral host port for all of a container's
+                exposed ports.
+  
+                Ports are de-allocated when the container stops and allocated when
+                the container starts. The allocated port might be changed when
+                restarting the container.
+  
+                The port is selected from the ephemeral port range that depends on
+                the kernel. For example, on Linux the range is defined by
+                `/proc/sys/net/ipv4/ip_local_port_range`.
+            ReadonlyRootfs:
+              type: "boolean"
+              description: "Mount the container's root filesystem as read only."
+            SecurityOpt:
+              type: "array"
+              description: |
+                A list of string values to customize labels for MLS systems, such
+                as SELinux.
+              items:
+                type: "string"
+            StorageOpt:
+              type: "object"
+              description: |
+                Storage driver options for this container, in the form `{"size": "120G"}`.
+              additionalProperties:
+                type: "string"
+            Tmpfs:
+              type: "object"
+              description: |
+                A map of container directories which should be replaced by tmpfs
+                mounts, and their corresponding mount options. For example:
+  
+                ```
+                { "/run": "rw,noexec,nosuid,size=65536k" }
+                ```
+              additionalProperties:
+                type: "string"
+            UTSMode:
+              type: "string"
+              description: "UTS namespace to use for the container."
+            UsernsMode:
+              type: "string"
+              description: |
+                Sets the usernamespace mode for the container when usernamespace
+                remapping option is enabled.
+            ShmSize:
+              type: "integer"
+              format: "int64"
+              description: |
+                Size of `/dev/shm` in bytes. If omitted, the system uses 64MB.
+              minimum: 0
+            Sysctls:
+              type: "object"
+              description: |
+                A list of kernel parameters (sysctls) to set in the container.
+                For example:
+  
+                ```
+                {"net.ipv4.ip_forward": "1"}
+                ```
+              additionalProperties:
+                type: "string"
+            Runtime:
+              type: "string"
+              description: "Runtime to use with this container."
+            # Applicable to Windows
+            Isolation:
+              type: "string"
+              description: |
+                Isolation technology of the container. (Windows only)
+              enum:
+                - "default"
+                - "process"
+                - "hyperv"
+            MaskedPaths:
+              type: "array"
+              description: |
+                The list of paths to be masked inside the container (this overrides
+                the default set of paths).
+              items:
+                type: "string"
+            ReadonlyPaths:
+              type: "array"
+              description: |
+                The list of paths to be set as read-only inside the container
+                (this overrides the default set of paths).
+              items:
+                type: "string"
+
+    ContainerConfig:
+      description: |
+        Configuration for a container that is portable between hosts.
+  
+        When used as `ContainerConfig` field in an image, `ContainerConfig` is an
+        optional field containing the configuration of the container that was last
+        committed when creating the image.
+  
+        Previous versions of Docker builder used this field to store build cache,
+        and it is not in active use anymore.
+      type: "object"
+      properties:
+        Hostname:
+          description: |
+            The hostname to use for the container, as a valid RFC 1123 hostname.
+          type: "string"
+          example: "439f4e91bd1d"
+        Domainname:
+          description: |
+            The domain name to use for the container.
+          type: "string"
+        User:
+          description: "The user that commands are run as inside the container."
+          type: "string"
+        AttachStdin:
+          description: "Whether to attach to `stdin`."
+          type: "boolean"
+          default: false
+        AttachStdout:
+          description: "Whether to attach to `stdout`."
+          type: "boolean"
+          default: true
+        AttachStderr:
+          description: "Whether to attach to `stderr`."
+          type: "boolean"
+          default: true
+        ExposedPorts:
+          description: |
+            An object mapping ports to an empty object in the form:
+
+            `{"<port>/<tcp|udp|sctp>": {}}`
+          type: "object"
+          nullable: true
+          x-nullable: true
+          additionalProperties:
             type: "object"
-          ReplicatedJob:
-            description: |
-              The mode used for services with a finite number of tasks that run
-              to a completed state.
+            enum:
+              - {}
+            properties: {}
+            default: {}
+          example: {
+            "80/tcp": {},
+            "443/tcp": {}
+          }
+        Tty:
+          description: |
+            Attach standard streams to a TTY, including `stdin` if it is not closed.
+          type: "boolean"
+          default: false
+        OpenStdin:
+          description: "Open `stdin`"
+          type: "boolean"
+          default: false
+        StdinOnce:
+          description: "Close `stdin` after one attached client disconnects"
+          type: "boolean"
+          default: false
+        Env:
+          description: |
+            A list of environment variables to set inside the container in the
+            form `["VAR=value", ...]`. A variable without `=` is removed from the
+            environment, rather than to have an empty value.
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        Cmd:
+          description: |
+            Command to run specified as a string or an array of strings.
+          type: "array"
+          items:
+            type: "string"
+          example: ["/bin/sh"]
+        Healthcheck:
+          $ref: "#/components/schemas/HealthConfig"
+        ArgsEscaped:
+          description: "Command is already escaped (Windows only)"
+          type: "boolean"
+          default: false
+          example: false
+          nullable: true
+          x-nullable: true
+        Image:
+          description: |
+            The name (or reference) of the image to use when creating the container,
+            or which was used when the container was created.
+          type: "string"
+          example: "example-image:1.0"
+        Volumes:
+          description: |
+            An object mapping mount point paths inside the container to empty
+            objects.
+          type: "object"
+          additionalProperties:
             type: "object"
-            properties:
-              MaxConcurrent:
-                description: |
-                  The maximum number of replicas to run simultaneously.
-                type: "integer"
-                format: "int64"
-                default: 1
-              TotalCompletions:
-                description: |
-                  The total number of replicas desired to reach the Completed
-                  state. If unset, will default to the value of `MaxConcurrent`
-                type: "integer"
-                format: "int64"
-          GlobalJob:
-            description: |
-              The mode used for services which run a task to the completed state
-              on each valid node.
-            type: "object"
-      UpdateConfig:
-        description: "Specification for the update strategy of the service."
-        type: "object"
-        properties:
-          Parallelism:
-            description: |
-              Maximum number of tasks to be updated in one iteration (0 means
-              unlimited parallelism).
-            type: "integer"
-            format: "int64"
-          Delay:
-            description: "Amount of time between updates, in nanoseconds."
-            type: "integer"
-            format: "int64"
-          FailureAction:
-            description: |
-              Action to take if an updated task fails to run, or stops running
-              during the update.
-            type: "string"
             enum:
-              - "continue"
-              - "pause"
-              - "rollback"
-          Monitor:
-            description: |
-              Amount of time to monitor each updated task for failures, in
-              nanoseconds.
-            type: "integer"
-            format: "int64"
-          MaxFailureRatio:
-            description: |
-              The fraction of tasks that may fail during an update before the
-              failure action is invoked, specified as a floating point number
-              between 0 and 1.
-            type: "number"
-            default: 0
-          Order:
-            description: |
-              The order of operations when rolling out an updated task. Either
-              the old task is shut down before the new task is started, or the
-              new task is started before the old task is shut down.
+              - {}
+            default: {}
+            properties: {}
+        WorkingDir:
+          description: "The working directory for commands to run in."
+          type: "string"
+          example: "/public/"
+        Entrypoint:
+          description: |
+            The entry point for the container as a string or an array of strings.
+
+            If the array consists of exactly one empty string (`[""]`) then the
+            entry point is reset to system default (i.e., the entry point used by
+            docker when there is no `ENTRYPOINT` instruction in the `Dockerfile`).
+          type: "array"
+          items:
             type: "string"
-            enum:
-              - "stop-first"
-              - "start-first"
-      RollbackConfig:
-        description: "Specification for the rollback strategy of the service."
-        type: "object"
-        properties:
-          Parallelism:
-            description: |
-              Maximum number of tasks to be rolled back in one iteration (0 means
-              unlimited parallelism).
-            type: "integer"
-            format: "int64"
-          Delay:
-            description: |
-              Amount of time between rollback iterations, in nanoseconds.
-            type: "integer"
-            format: "int64"
-          FailureAction:
-            description: |
-              Action to take if an rolled back task fails to run, or stops
-              running during the rollback.
+          example: []
+        NetworkDisabled:
+          description: "Disable networking for the container."
+          type: "boolean"
+          nullable: true
+          x-nullable: true
+        MacAddress:
+          description: "MAC address of the container."
+          type: "string"
+          nullable: true
+          x-nullable: true
+        OnBuild:
+          description: |
+            `ONBUILD` metadata that were defined in the image's `Dockerfile`.
+          type: "array"
+          nullable: true
+          x-nullable: true
+          items:
             type: "string"
-            enum:
-              - "continue"
-              - "pause"
-          Monitor:
-            description: |
-              Amount of time to monitor each rolled back task for failures, in
-              nanoseconds.
-            type: "integer"
-            format: "int64"
-          MaxFailureRatio:
-            description: |
-              The fraction of tasks that may fail during a rollback before the
-              failure action is invoked, specified as a floating point number
-              between 0 and 1.
-            type: "number"
-            default: 0
-          Order:
-            description: |
-              The order of operations when rolling back a task. Either the old
-              task is shut down before the new task is started, or the new task
-              is started before the old task is shut down.
+          example: []
+        Labels:
+          description: "User-defined key/value metadata."
+          type: "object"
+          additionalProperties:
             type: "string"
-            enum:
-              - "stop-first"
-              - "start-first"
-      Networks:
-        description: "Specifies which networks the service should attach to."
+          example:
+            com.example.some-label: "some-value"
+            com.example.some-other-label: "some-other-value"
+        StopSignal:
+          description: |
+            Signal to stop a container as a string or unsigned integer.
+          type: "string"
+          example: "SIGTERM"
+          nullable: true
+          x-nullable: true
+        StopTimeout:
+          description: "Timeout to stop a container in seconds."
+          type: "integer"
+          default: 10
+          nullable: true
+          x-nullable: true
+        Shell:
+          description: |
+            Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell.
+          type: "array"
+          nullable: true
+          x-nullable: true
+          items:
+            type: "string"
+          example: ["/bin/sh", "-c"]
+
+    NetworkingConfig:
+      description: |
+        NetworkingConfig represents the container's networking configuration for
+        each of its interfaces.
+        It is used for the networking configs specified in the `docker create`
+        and `docker network connect` commands.
+      type: "object"
+      properties:
+        EndpointsConfig:
+          description: |
+            A mapping of network name to endpoint configuration for that network.
+          type: "object"
+          additionalProperties:
+            $ref: "#/components/schemas/EndpointSettings"
+      example:
+        # putting an example here, instead of using the example values from
+        # /definitions/EndpointSettings, because containers/create currently
+        # does not support attaching to multiple networks, so the example request
+        # would be confusing if it showed that multiple networks can be contained
+        # in the EndpointsConfig.
+        # TODO remove once we support multiple networks on container create (see https://github.com/moby/moby/blob/07e6b843594e061f82baa5fa23c2ff7d536c2a05/daemon/create.go#L323)
+        EndpointsConfig:
+          isolated_nw:
+            IPAMConfig:
+              IPv4Address: "172.20.30.33"
+              IPv6Address: "2001:db8:abcd::3033"
+              LinkLocalIPs:
+                - "169.254.34.68"
+                - "fe80::3468"
+            Links:
+              - "container_1"
+              - "container_2"
+            Aliases:
+              - "server_x"
+              - "server_y"
+
+    NetworkSettings:
+      description: "NetworkSettings exposes the network settings in the API"
+      type: "object"
+      properties:
+        Bridge:
+          description: Name of the network's bridge (for example, `docker0`).
+          type: "string"
+          example: "docker0"
+        SandboxID:
+          description: SandboxID uniquely represents a container's network stack.
+          type: "string"
+          example: "9d12daf2c33f5959c8bf90aa513e4f65b561738661003029ec84830cd503a0c3"
+        HairpinMode:
+          description: |
+            Indicates if hairpin NAT should be enabled on the virtual interface.
+          type: "boolean"
+          example: false
+        LinkLocalIPv6Address:
+          description: IPv6 unicast address using the link-local prefix.
+          type: "string"
+          example: "fe80::42:acff:fe11:1"
+        LinkLocalIPv6PrefixLen:
+          description: Prefix length of the IPv6 unicast address.
+          type: "integer"
+          example: "64"
+        Ports:
+          $ref: "#/components/schemas/PortMap"
+        SandboxKey:
+          description: SandboxKey identifies the sandbox
+          type: "string"
+          example: "/var/run/docker/netns/8ab54b426c38"
+
+        # TODO is SecondaryIPAddresses actually used?
+        SecondaryIPAddresses:
+          description: ""
+          type: "array"
+          items:
+            $ref: "#/components/schemas/Address"
+          nullable: true
+          x-nullable: true
+
+        # TODO is SecondaryIPv6Addresses actually used?
+        SecondaryIPv6Addresses:
+          description: ""
+          type: "array"
+          items:
+            $ref: "#/components/schemas/Address"
+          nullable: true
+          x-nullable: true
+
+        # TODO properties below are part of DefaultNetworkSettings, which is
+        # marked as deprecated since Docker 1.9 and to be removed in Docker v17.12
+        EndpointID:
+          description: |
+            EndpointID uniquely represents a service endpoint in a Sandbox.
+
+            <p><br /></p>
+
+            > **Deprecated**: This field is only propagated when attached to the
+            > default "bridge" network. Use the information from the "bridge"
+            > network inside the `Networks` map instead, which contains the same
+            > information. This field was deprecated in Docker 1.9 and is scheduled
+            > to be removed in Docker 17.12.0
+          type: "string"
+          example: "b88f5b905aabf2893f3cbc4ee42d1ea7980bbc0a92e2c8922b1e1795298afb0b"
+        Gateway:
+          description: |
+            Gateway address for the default "bridge" network.
+
+            <p><br /></p>
+
+            > **Deprecated**: This field is only propagated when attached to the
+            > default "bridge" network. Use the information from the "bridge"
+            > network inside the `Networks` map instead, which contains the same
+            > information. This field was deprecated in Docker 1.9 and is scheduled
+            > to be removed in Docker 17.12.0
+          type: "string"
+          example: "172.17.0.1"
+        GlobalIPv6Address:
+          description: |
+            Global IPv6 address for the default "bridge" network.
+
+            <p><br /></p>
+
+            > **Deprecated**: This field is only propagated when attached to the
+            > default "bridge" network. Use the information from the "bridge"
+            > network inside the `Networks` map instead, which contains the same
+            > information. This field was deprecated in Docker 1.9 and is scheduled
+            > to be removed in Docker 17.12.0
+          type: "string"
+          example: "2001:db8::5689"
+        GlobalIPv6PrefixLen:
+          description: |
+            Mask length of the global IPv6 address.
+
+            <p><br /></p>
+
+            > **Deprecated**: This field is only propagated when attached to the
+            > default "bridge" network. Use the information from the "bridge"
+            > network inside the `Networks` map instead, which contains the same
+            > information. This field was deprecated in Docker 1.9 and is scheduled
+            > to be removed in Docker 17.12.0
+          type: "integer"
+          example: 64
+        IPAddress:
+          description: |
+            IPv4 address for the default "bridge" network.
+
+            <p><br /></p>
+
+            > **Deprecated**: This field is only propagated when attached to the
+            > default "bridge" network. Use the information from the "bridge"
+            > network inside the `Networks` map instead, which contains the same
+            > information. This field was deprecated in Docker 1.9 and is scheduled
+            > to be removed in Docker 17.12.0
+          type: "string"
+          example: "172.17.0.4"
+        IPPrefixLen:
+          description: |
+            Mask length of the IPv4 address.
+
+            <p><br /></p>
+
+            > **Deprecated**: This field is only propagated when attached to the
+            > default "bridge" network. Use the information from the "bridge"
+            > network inside the `Networks` map instead, which contains the same
+            > information. This field was deprecated in Docker 1.9 and is scheduled
+            > to be removed in Docker 17.12.0
+          type: "integer"
+          example: 16
+        IPv6Gateway:
+          description: |
+            IPv6 gateway address for this network.
+
+            <p><br /></p>
+
+            > **Deprecated**: This field is only propagated when attached to the
+            > default "bridge" network. Use the information from the "bridge"
+            > network inside the `Networks` map instead, which contains the same
+            > information. This field was deprecated in Docker 1.9 and is scheduled
+            > to be removed in Docker 17.12.0
+          type: "string"
+          example: "2001:db8:2::100"
+        MacAddress:
+          description: |
+            MAC address for the container on the default "bridge" network.
+
+            <p><br /></p>
+
+            > **Deprecated**: This field is only propagated when attached to the
+            > default "bridge" network. Use the information from the "bridge"
+            > network inside the `Networks` map instead, which contains the same
+            > information. This field was deprecated in Docker 1.9 and is scheduled
+            > to be removed in Docker 17.12.0
+          type: "string"
+          example: "02:42:ac:11:00:04"
+        Networks:
+          description: |
+            Information about all networks that the container is connected to.
+          type: "object"
+          additionalProperties:
+            $ref: "#/components/schemas/EndpointSettings"
+
+    Address:
+      description: Address represents an IPv4 or IPv6 IP address.
+      type: "object"
+      properties:
+        Addr:
+          description: IP address.
+          type: "string"
+        PrefixLen:
+          description: Mask length of the IP address.
+          type: "integer"
+
+    PortMap:
+      description: |
+        PortMap describes the mapping of container ports to host ports, using the
+        container's port-number and protocol as key in the format `<port>/<protocol>`,
+        for example, `80/udp`.
+
+        If a container's port is mapped for multiple protocols, separate entries
+        are added to the mapping table.
+      type: "object"
+      additionalProperties:
         type: "array"
+        nullable: true
+        x-nullable: true
         items:
-          $ref: "#/definitions/NetworkAttachmentConfig"
+          $ref: "#/components/schemas/PortBinding"
+      example:
+        "443/tcp":
+          - HostIp: "127.0.0.1"
+            HostPort: "4443"
+        "80/tcp":
+          - HostIp: "0.0.0.0"
+            HostPort: "80"
+          - HostIp: "0.0.0.0"
+            HostPort: "8080"
+        "80/udp":
+          - HostIp: "0.0.0.0"
+            HostPort: "80"
+        "53/udp":
+          - HostIp: "0.0.0.0"
+            HostPort: "53"
+        "2377/tcp": null
 
-      EndpointSpec:
-        $ref: "#/definitions/EndpointSpec"
+    PortBinding:
+      description: |
+        PortBinding represents a binding between a host IP address and a host
+        port.
+      type: "object"
+      properties:
+        HostIp:
+          description: "Host IP address that the container's port is mapped to."
+          type: "string"
+          example: "127.0.0.1"
+        HostPort:
+          description: "Host port number that the container's port is mapped to."
+          type: "string"
+          example: "4443"
 
-  EndpointPortConfig:
-    type: "object"
-    properties:
-      Name:
-        type: "string"
-      Protocol:
-        type: "string"
-        enum:
-          - "tcp"
-          - "udp"
-          - "sctp"
-      TargetPort:
-        description: "The port inside the container."
-        type: "integer"
-      PublishedPort:
-        description: "The port on the swarm hosts."
-        type: "integer"
-      PublishMode:
-        description: |
-          The mode in which port is published.
+    GraphDriverData:
+      description: |
+        Information about the storage driver used to store the container's and
+        image's filesystem.
+      type: "object"
+      required: [Name, Data]
+      properties:
+        Name:
+          description: "Name of the storage driver."
+          type: "string"
+          nullable: false
+          x-nullable: false
+          example: "overlay2"
+        Data:
+          description: |
+            Low-level storage metadata, provided as key/value pairs.
 
-          <p><br /></p>
+            This information is driver-specific, and depends on the storage-driver
+            in use, and should be used for informational purposes only.
+          type: "object"
+          nullable: false
+          x-nullable: false
+          additionalProperties:
+            type: "string"
+          example: {
+            "MergedDir": "/var/lib/docker/overlay2/ef749362d13333e65fc95c572eb525abbe0052e16e086cb64bc3b98ae9aa6d74/merged",
+            "UpperDir": "/var/lib/docker/overlay2/ef749362d13333e65fc95c572eb525abbe0052e16e086cb64bc3b98ae9aa6d74/diff",
+            "WorkDir": "/var/lib/docker/overlay2/ef749362d13333e65fc95c572eb525abbe0052e16e086cb64bc3b98ae9aa6d74/work"
+          }
 
-          - "ingress" makes the target port accessible on every node,
-            regardless of whether there is a task for the service running on
-            that node or not.
-          - "host" bypasses the routing mesh and publish the port directly on
-            the swarm node where that service is running.
+    FilesystemChange:
+      description: |
+        Change in the container's filesystem.
+      type: "object"
+      required: [Path, Kind]
+      properties:
+        Path:
+          description: |
+            Path to file or directory that has changed.
+          type: "string"
+          nullable: false
+          x-nullable: false
+        Kind:
+          $ref: "#/components/schemas/ChangeType"
 
-        type: "string"
-        enum:
-          - "ingress"
-          - "host"
-        default: "ingress"
-        example: "ingress"
+    ChangeType:
+      description: |
+        Kind of change
 
-  EndpointSpec:
-    description: "Properties that can be configured to access and load balance a service."
-    type: "object"
-    properties:
-      Mode:
-        description: |
-          The mode of resolution to use for internal load balancing between tasks.
-        type: "string"
-        enum:
-          - "vip"
-          - "dnsrr"
-        default: "vip"
-      Ports:
-        description: |
-          List of exposed ports that this service is accessible on from the
-          outside. Ports can only be provided if `vip` resolution mode is used.
-        type: "array"
-        items:
-          $ref: "#/definitions/EndpointPortConfig"
+        Can be one of:
 
-  Service:
-    type: "object"
-    properties:
-      ID:
-        type: "string"
-      Version:
-        $ref: "#/definitions/ObjectVersion"
-      CreatedAt:
-        type: "string"
-        format: "dateTime"
-      UpdatedAt:
-        type: "string"
-        format: "dateTime"
-      Spec:
-        $ref: "#/definitions/ServiceSpec"
-      Endpoint:
-        type: "object"
-        properties:
-          Spec:
-            $ref: "#/definitions/EndpointSpec"
-          Ports:
-            type: "array"
-            items:
-              $ref: "#/definitions/EndpointPortConfig"
-          VirtualIPs:
-            type: "array"
-            items:
+        - `0`: Modified ("C")
+        - `1`: Added ("A")
+        - `2`: Deleted ("D")
+      type: "integer"
+      format: "uint8"
+      enum: [0, 1, 2]
+      nullable: false
+      x-nullable: false
+
+    ImageInspect:
+      description: |
+        Information about an image in the local image cache.
+      type: "object"
+      properties:
+        Id:
+          description: |
+            ID is the content-addressable ID of an image.
+
+            This identifier is a content-addressable digest calculated from the
+            image's configuration (which includes the digests of layers used by
+            the image).
+
+            Note that this digest differs from the `RepoDigests` below, which
+            holds digests of image manifests that reference the image.
+          type: "string"
+          nullable: false
+          x-nullable: false
+          example: "sha256:ec3f0931a6e6b6855d76b2d7b0be30e81860baccd891b2e243280bf1cd8ad710"
+        RepoTags:
+          description: |
+            List of image names/tags in the local image cache that reference this
+            image.
+
+            Multiple image tags can refer to the same image, and this list may be
+            empty if no tags reference the image, in which case the image is
+            "untagged", in which case it can still be referenced by its ID.
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "example:1.0"
+            - "example:latest"
+            - "example:stable"
+            - "internal.registry.example.com:5000/example:1.0"
+        RepoDigests:
+          description: |
+            List of content-addressable digests of locally available image manifests
+            that the image is referenced from. Multiple manifests can refer to the
+            same image.
+
+            These digests are usually only available if the image was either pulled
+            from a registry, or if the image was pushed to a registry, which is when
+            the manifest is generated and its digest calculated.
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb"
+            - "internal.registry.example.com:5000/example@sha256:b69959407d21e8a062e0416bf13405bb2b71ed7a84dde4158ebafacfa06f5578"
+        Parent:
+          description: |
+            ID of the parent image.
+
+            Depending on how the image was created, this field may be empty and
+            is only set for images that were built/created locally. This field
+            is empty if the image was pulled from an image registry.
+          type: "string"
+          nullable: false
+          x-nullable: false
+          example: ""
+        Comment:
+          description: |
+            Optional message that was set when committing or importing the image.
+          type: "string"
+          nullable: false
+          x-nullable: false
+          example: ""
+        Created:
+          description: |
+            Date and time at which the image was created, formatted in
+            [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+          type: "string"
+          nullable: false
+          x-nullable: false
+          example: "2022-02-04T21:20:12.497794809Z"
+        Container:
+          description: |
+            The ID of the container that was used to create the image.
+
+            Depending on how the image was created, this field may be empty.
+          type: "string"
+          nullable: false
+          x-nullable: false
+          example: "65974bc86f1770ae4bff79f651ebdbce166ae9aada632ee3fa9af3a264911735"
+        ContainerConfig:
+          $ref: "#/components/schemas/ContainerConfig"
+        DockerVersion:
+          description: |
+            The version of Docker that was used to build the image.
+
+            Depending on how the image was created, this field may be empty.
+          type: "string"
+          nullable: false
+          x-nullable: false
+          example: "20.10.7"
+        Author:
+          description: |
+            Name of the author that was specified when committing the image, or as
+            specified through MAINTAINER (deprecated) in the Dockerfile.
+          type: "string"
+          nullable: false
+          x-nullable: false
+          example: ""
+        Config:
+          $ref: "#/components/schemas/ContainerConfig"
+        Architecture:
+          description: |
+            Hardware CPU architecture that the image runs on.
+          type: "string"
+          nullable: false
+          x-nullable: false
+          example: "arm"
+        Variant:
+          description: |
+            CPU architecture variant (presently ARM-only).
+          type: "string"
+          nullable: true
+          x-nullable: true
+          example: "v7"
+        Os:
+          description: |
+            Operating System the image is built to run on.
+          type: "string"
+          nullable: false
+          x-nullable: false
+          example: "linux"
+        OsVersion:
+          description: |
+            Operating System version the image is built to run on (especially
+            for Windows).
+          type: "string"
+          example: ""
+          nullable: true
+          x-nullable: true
+        Size:
+          description: |
+            Total size of the image including all layers it is composed of.
+          type: "integer"
+          format: "int64"
+          nullable: false
+          x-nullable: false
+          example: 1239828
+        VirtualSize:
+          description: |
+            Total size of the image including all layers it is composed of.
+
+            Deprecated: this field is omitted in API v1.44, but kept for backward compatibility. Use Size instead.
+          type: "integer"
+          format: "int64"
+          example: 1239828
+        GraphDriver:
+          $ref: "#/components/schemas/GraphDriverData"
+        RootFS:
+          description: |
+            Information about the image's RootFS, including the layer IDs.
+          type: "object"
+          required: [Type]
+          properties:
+            Type:
+              type: "string"
+              nullable: false
+              x-nullable: false
+              example: "layers"
+            Layers:
+              type: "array"
+              items:
+                type: "string"
+              example:
+                - "sha256:1834950e52ce4d5a88a1bbd131c537f4d0e56d10ff0dd69e66be3b7dfa9df7e6"
+                - "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
+        Metadata:
+          description: |
+            Additional metadata of the image in the local cache. This information
+            is local to the daemon, and not part of the image itself.
+          type: "object"
+          properties:
+            LastTagTime:
+              description: |
+                Date and time at which the image was last tagged in
+                [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+
+                This information is only available if the image was tagged locally,
+                and omitted otherwise.
+              type: "string"
+              format: "dateTime"
+              example: "2022-02-28T14:40:02.623929178Z"
+              nullable: true
+              x-nullable: true
+    ImageSummary:
+      type: "object"
+      required:
+        - Id
+        - ParentId
+        - RepoTags
+        - RepoDigests
+        - Created
+        - Size
+        - SharedSize
+        - Labels
+        - Containers
+      properties:
+        Id:
+          description: |
+            ID is the content-addressable ID of an image.
+
+            This identifier is a content-addressable digest calculated from the
+            image's configuration (which includes the digests of layers used by
+            the image).
+
+            Note that this digest differs from the `RepoDigests` below, which
+            holds digests of image manifests that reference the image.
+          type: "string"
+          nullable: false
+          x-nullable: false
+          example: "sha256:ec3f0931a6e6b6855d76b2d7b0be30e81860baccd891b2e243280bf1cd8ad710"
+        ParentId:
+          description: |
+            ID of the parent image.
+
+            Depending on how the image was created, this field may be empty and
+            is only set for images that were built/created locally. This field
+            is empty if the image was pulled from an image registry.
+          type: "string"
+          nullable: false
+          x-nullable: false
+          example: ""
+        RepoTags:
+          description: |
+            List of image names/tags in the local image cache that reference this
+            image.
+
+            Multiple image tags can refer to the same image, and this list may be
+            empty if no tags reference the image, in which case the image is
+            "untagged", in which case it can still be referenced by its ID.
+          type: "array"
+          nullable: false
+          x-nullable: false
+          items:
+            type: "string"
+          example:
+            - "example:1.0"
+            - "example:latest"
+            - "example:stable"
+            - "internal.registry.example.com:5000/example:1.0"
+        RepoDigests:
+          description: |
+            List of content-addressable digests of locally available image manifests
+            that the image is referenced from. Multiple manifests can refer to the
+            same image.
+
+            These digests are usually only available if the image was either pulled
+            from a registry, or if the image was pushed to a registry, which is when
+            the manifest is generated and its digest calculated.
+          type: "array"
+          nullable: false
+          x-nullable: false
+          items:
+            type: "string"
+          example:
+            - "example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb"
+            - "internal.registry.example.com:5000/example@sha256:b69959407d21e8a062e0416bf13405bb2b71ed7a84dde4158ebafacfa06f5578"
+        Created:
+          description: |
+            Date and time at which the image was created as a Unix timestamp
+            (number of seconds sinds EPOCH).
+          type: "integer"
+          nullable: false
+          x-nullable: false
+          example: "1644009612"
+        Size:
+          description: |
+            Total size of the image including all layers it is composed of.
+          type: "integer"
+          format: "int64"
+          nullable: false
+          x-nullable: false
+          example: 172064416
+        SharedSize:
+          description: |
+            Total size of image layers that are shared between this image and other
+            images.
+
+            This size is not calculated by default. `-1` indicates that the value
+            has not been set / calculated.
+          type: "integer"
+          format: "int64"
+          nullable: false
+          x-nullable: false
+          example: 1239828
+        VirtualSize:
+          description: |-
+            Total size of the image including all layers it is composed of.
+
+            Deprecated: this field is omitted in API v1.44, but kept for backward compatibility. Use Size instead.
+          type: "integer"
+          format: "int64"
+          example: 172064416
+        Labels:
+          description: "User-defined key/value metadata."
+          type: "object"
+          nullable: false
+          x-nullable: false
+          additionalProperties:
+            type: "string"
+          example:
+            com.example.some-label: "some-value"
+            com.example.some-other-label: "some-other-value"
+        Containers:
+          description: |
+            Number of containers using this image. Includes both stopped and running
+            containers.
+
+            This size is not calculated by default, and depends on which API endpoint
+            is used. `-1` indicates that the value has not been set / calculated.
+          nullable: false
+          x-nullable: false
+          type: "integer"
+          example: 2
+
+    AuthConfig:
+      type: "object"
+      properties:
+        username:
+          type: "string"
+        password:
+          type: "string"
+        email:
+          type: "string"
+        serveraddress:
+          type: "string"
+      example:
+        username: "hannibal"
+        password: "xxxx"
+        serveraddress: "https://index.docker.io/v1/"
+
+    ProcessConfig:
+      type: "object"
+      properties:
+        privileged:
+          type: "boolean"
+        user:
+          type: "string"
+        tty:
+          type: "boolean"
+        entrypoint:
+          type: "string"
+        arguments:
+          type: "array"
+          items:
+            type: "string"
+
+    Volume:
+      type: "object"
+      required: [Name, Driver, Mountpoint, Labels, Scope, Options]
+      properties:
+        Name:
+          type: "string"
+          description: "Name of the volume."
+          nullable: false
+          x-nullable: false
+          example: "tardis"
+        Driver:
+          type: "string"
+          description: "Name of the volume driver used by the volume."
+          nullable: false
+          x-nullable: false
+          example: "custom"
+        Mountpoint:
+          type: "string"
+          description: "Mount path of the volume on the host."
+          nullable: false
+          x-nullable: false
+          example: "/var/lib/docker/volumes/tardis"
+        CreatedAt:
+          type: "string"
+          format: "dateTime"
+          description: "Date/Time the volume was created."
+          example: "2016-06-07T20:31:11.853781916Z"
+        Status:
+          type: "object"
+          description: |
+            Low-level details about the volume, provided by the volume driver.
+            Details are returned as a map with key/value pairs:
+            `{"key":"value","key2":"value2"}`.
+
+            The `Status` field is optional, and is omitted if the volume driver
+            does not support this feature.
+          additionalProperties:
+            type: "object"
+            properties: {}
+          example:
+            hello: "world"
+        Labels:
+          type: "object"
+          description: "User-defined key/value metadata."
+          nullable: false
+          x-nullable: false
+          additionalProperties:
+            type: "string"
+          example:
+            com.example.some-label: "some-value"
+            com.example.some-other-label: "some-other-value"
+        Scope:
+          type: "string"
+          description: |
+            The level at which the volume exists. Either `global` for cluster-wide,
+            or `local` for machine level.
+          default: "local"
+          nullable: false
+          x-nullable: false
+          enum: ["local", "global"]
+          example: "local"
+        ClusterVolume:
+          $ref: "#/components/schemas/ClusterVolume"
+        Options:
+          type: "object"
+          description: |
+            The driver specific options used when creating the volume.
+          additionalProperties:
+            type: "string"
+          example:
+            device: "tmpfs"
+            o: "size=100m,uid=1000"
+            type: "tmpfs"
+        UsageData:
+          type: "object"
+          nullable: true
+          x-nullable: true
+          x-go-name: "UsageData"
+          required: [Size, RefCount]
+          description: |
+            Usage details about the volume. This information is used by the
+            `GET /system/df` endpoint, and omitted in other endpoints.
+          properties:
+            Size:
+              type: "integer"
+              format: "int64"
+              default: -1
+              description: |
+                Amount of disk space used by the volume (in bytes). This information
+                is only available for volumes created with the `"local"` volume
+                driver. For volumes created with other volume drivers, this field
+                is set to `-1` ("not available")
+              nullable: false
+              x-nullable: false
+            RefCount:
+              type: "integer"
+              format: "int64"
+              default: -1
+              description: |
+                The number of containers referencing this volume. This field
+                is set to `-1` if the reference-count is not available.
+              nullable: false
+              x-nullable: false
+
+    VolumeCreateOptions:
+      description: "Volume configuration"
+      type: "object"
+      title: "VolumeConfig"
+      x-go-name: "CreateOptions"
+      properties:
+        Name:
+          description: |
+            The new volume's name. If not specified, Docker generates a name.
+          type: "string"
+          nullable: false
+          x-nullable: false
+          example: "tardis"
+        Driver:
+          description: "Name of the volume driver to use."
+          type: "string"
+          default: "local"
+          nullable: false
+          x-nullable: false
+          example: "custom"
+        DriverOpts:
+          description: |
+            A mapping of driver options and values. These options are
+            passed directly to the driver and are driver specific.
+          type: "object"
+          additionalProperties:
+            type: "string"
+          example:
+            device: "tmpfs"
+            o: "size=100m,uid=1000"
+            type: "tmpfs"
+        Labels:
+          description: "User-defined key/value metadata."
+          type: "object"
+          additionalProperties:
+            type: "string"
+          example:
+            com.example.some-label: "some-value"
+            com.example.some-other-label: "some-other-value"
+        ClusterVolumeSpec:
+          $ref: "#/components/schemas/ClusterVolumeSpec"
+
+    VolumeListResponse:
+      type: "object"
+      title: "VolumeListResponse"
+      x-go-name: "ListResponse"
+      description: "Volume list response"
+      properties:
+        Volumes:
+          type: "array"
+          description: "List of volumes"
+          items:
+            $ref: "#/components/schemas/Volume"
+        Warnings:
+          type: "array"
+          description: |
+            Warnings that occurred when fetching the list of volumes.
+          items:
+            type: "string"
+          example: []
+
+    Network:
+      type: "object"
+      properties:
+        Name:
+          type: "string"
+        Id:
+          type: "string"
+        Created:
+          type: "string"
+          format: "dateTime"
+        Scope:
+          type: "string"
+        Driver:
+          type: "string"
+        EnableIPv6:
+          type: "boolean"
+        IPAM:
+          $ref: "#/components/schemas/IPAM"
+        Internal:
+          type: "boolean"
+        Attachable:
+          type: "boolean"
+        Ingress:
+          type: "boolean"
+        Containers:
+          type: "object"
+          additionalProperties:
+            $ref: "#/components/schemas/NetworkContainer"
+        Options:
+          type: "object"
+          additionalProperties:
+            type: "string"
+        Labels:
+          type: "object"
+          additionalProperties:
+            type: "string"
+      example:
+        Name: "net01"
+        Id: "7d86d31b1478e7cca9ebed7e73aa0fdeec46c5ca29497431d3007d2d9e15ed99"
+        Created: "2016-10-19T04:33:30.360899459Z"
+        Scope: "local"
+        Driver: "bridge"
+        EnableIPv6: false
+        IPAM:
+          Driver: "default"
+          Config:
+            - Subnet: "172.19.0.0/16"
+              Gateway: "172.19.0.1"
+          Options:
+            foo: "bar"
+        Internal: false
+        Attachable: false
+        Ingress: false
+        Containers:
+          19a4d5d687db25203351ed79d478946f861258f018fe384f229f2efa4b23513c:
+            Name: "test"
+            EndpointID: "628cadb8bcb92de107b2a1e516cbffe463e321f548feb37697cce00ad694f21a"
+            MacAddress: "02:42:ac:13:00:02"
+            IPv4Address: "172.19.0.2/16"
+            IPv6Address: ""
+        Options:
+          com.docker.network.bridge.default_bridge: "true"
+          com.docker.network.bridge.enable_icc: "true"
+          com.docker.network.bridge.enable_ip_masquerade: "true"
+          com.docker.network.bridge.host_binding_ipv4: "0.0.0.0"
+          com.docker.network.bridge.name: "docker0"
+          com.docker.network.driver.mtu: "1500"
+        Labels:
+          com.example.some-label: "some-value"
+          com.example.some-other-label: "some-other-value"
+    IPAM:
+      type: "object"
+      properties:
+        Driver:
+          description: "Name of the IPAM driver to use."
+          type: "string"
+          default: "default"
+        Config:
+          description: |
+            List of IPAM configuration options, specified as a map:
+
+            ```
+            {"Subnet": <CIDR>, "IPRange": <CIDR>, "Gateway": <IP address>, "AuxAddress": <device_name:IP address>}
+            ```
+          type: "array"
+          items:
+            $ref: "#/components/schemas/IPAMConfig"
+        Options:
+          description: "Driver-specific options, specified as a map."
+          type: "object"
+          additionalProperties:
+            type: "string"
+
+    IPAMConfig:
+      type: "object"
+      properties:
+        Subnet:
+          type: "string"
+        IPRange:
+          type: "string"
+        Gateway:
+          type: "string"
+        AuxiliaryAddresses:
+          type: "object"
+          additionalProperties:
+            type: "string"
+
+    NetworkContainer:
+      type: "object"
+      properties:
+        Name:
+          type: "string"
+        EndpointID:
+          type: "string"
+        MacAddress:
+          type: "string"
+        IPv4Address:
+          type: "string"
+        IPv6Address:
+          type: "string"
+
+    BuildInfo:
+      type: "object"
+      properties:
+        id:
+          type: "string"
+        stream:
+          type: "string"
+        error:
+          type: "string"
+        errorDetail:
+          $ref: "#/components/schemas/ErrorDetail"
+        status:
+          type: "string"
+        progress:
+          type: "string"
+        progressDetail:
+          $ref: "#/components/schemas/ProgressDetail"
+        aux:
+          $ref: "#/components/schemas/ImageID"
+
+    BuildCache:
+      type: "object"
+      description: |
+        BuildCache contains information about a build cache record.
+      properties:
+        ID:
+          type: "string"
+          description: |
+            Unique ID of the build cache record.
+          example: "ndlpt0hhvkqcdfkputsk4cq9c"
+        Parent:
+          description: |
+            ID of the parent build cache record.
+
+            > **Deprecated**: This field is deprecated, and omitted if empty.
+          type: "string"
+          nullable: true
+          x-nullable: true
+          example: ""
+        Parents:
+          description: |
+            List of parent build cache record IDs.
+          type: "array"
+          items:
+            type: "string"
+          nullable: true
+          x-nullable: true
+          example: ["hw53o5aio51xtltp5xjp8v7fx"]
+        Type:
+          type: "string"
+          description: |
+            Cache record type.
+          example: "regular"
+          # see https://github.com/moby/buildkit/blob/fce4a32258dc9d9664f71a4831d5de10f0670677/client/diskusage.go#L75-L84
+          enum:
+            - "internal"
+            - "frontend"
+            - "source.local"
+            - "source.git.checkout"
+            - "exec.cachemount"
+            - "regular"
+        Description:
+          type: "string"
+          description: |
+            Description of the build-step that produced the build cache.
+          example: "mount / from exec /bin/sh -c echo 'Binary::apt::APT::Keep-Downloaded-Packages \"true\";' > /etc/apt/apt.conf.d/keep-cache"
+        InUse:
+          type: "boolean"
+          description: |
+            Indicates if the build cache is in use.
+          example: false
+        Shared:
+          type: "boolean"
+          description: |
+            Indicates if the build cache is shared.
+          example: true
+        Size:
+          description: |
+            Amount of disk space used by the build cache (in bytes).
+          type: "integer"
+          example: 51
+        CreatedAt:
+          description: |
+            Date and time at which the build cache was created in
+            [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+          type: "string"
+          format: "dateTime"
+          example: "2016-08-18T10:44:24.496525531Z"
+        LastUsedAt:
+          description: |
+            Date and time at which the build cache was last used in
+            [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+          type: "string"
+          format: "dateTime"
+          nullable: true
+          x-nullable: true
+          example: "2017-08-09T07:09:37.632105588Z"
+        UsageCount:
+          type: "integer"
+          example: 26
+
+    ImageID:
+      type: "object"
+      description: "Image ID or Digest"
+      properties:
+        ID:
+          type: "string"
+      example:
+        ID: "sha256:85f05633ddc1c50679be2b16a0479ab6f7637f8884e0cfe0f4d20e1ebb3d6e7c"
+
+    CreateImageInfo:
+      type: "object"
+      properties:
+        id:
+          type: "string"
+        error:
+          type: "string"
+        errorDetail:
+          $ref: "#/components/schemas/ErrorDetail"
+        status:
+          type: "string"
+        progress:
+          type: "string"
+        progressDetail:
+          $ref: "#/components/schemas/ProgressDetail"
+
+    PushImageInfo:
+      type: "object"
+      properties:
+        error:
+          type: "string"
+        status:
+          type: "string"
+        progress:
+          type: "string"
+        progressDetail:
+          $ref: "#/components/schemas/ProgressDetail"
+
+    ErrorDetail:
+      type: "object"
+      properties:
+        code:
+          type: "integer"
+        message:
+          type: "string"
+
+    ProgressDetail:
+      type: "object"
+      properties:
+        current:
+          type: "integer"
+        total:
+          type: "integer"
+
+    ErrorResponse:
+      description: "Represents an error."
+      type: "object"
+      required: ["message"]
+      properties:
+        message:
+          description: "The error message."
+          type: "string"
+          nullable: false
+          x-nullable: false
+      example:
+        message: "Something went wrong."
+
+    IdResponse:
+      description: "Response to an API call that returns just an Id"
+      type: "object"
+      required: ["Id"]
+      properties:
+        Id:
+          description: "The id of the newly created object."
+          type: "string"
+          nullable: false
+          x-nullable: false
+
+    EndpointSettings:
+      description: "Configuration for a network endpoint."
+      type: "object"
+      properties:
+        # Configurations
+        IPAMConfig:
+          $ref: "#/components/schemas/EndpointIPAMConfig"
+        Links:
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "container_1"
+            - "container_2"
+        Aliases:
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "server_x"
+            - "server_y"
+
+        # Operational data
+        NetworkID:
+          description: |
+            Unique ID of the network.
+          type: "string"
+          example: "08754567f1f40222263eab4102e1c733ae697e8e354aa9cd6e18d7402835292a"
+        EndpointID:
+          description: |
+            Unique ID for the service endpoint in a Sandbox.
+          type: "string"
+          example: "b88f5b905aabf2893f3cbc4ee42d1ea7980bbc0a92e2c8922b1e1795298afb0b"
+        Gateway:
+          description: |
+            Gateway address for this network.
+          type: "string"
+          example: "172.17.0.1"
+        IPAddress:
+          description: |
+            IPv4 address.
+          type: "string"
+          example: "172.17.0.4"
+        IPPrefixLen:
+          description: |
+            Mask length of the IPv4 address.
+          type: "integer"
+          example: 16
+        IPv6Gateway:
+          description: |
+            IPv6 gateway address.
+          type: "string"
+          example: "2001:db8:2::100"
+        GlobalIPv6Address:
+          description: |
+            Global IPv6 address.
+          type: "string"
+          example: "2001:db8::5689"
+        GlobalIPv6PrefixLen:
+          description: |
+            Mask length of the global IPv6 address.
+          type: "integer"
+          format: "int64"
+          example: 64
+        MacAddress:
+          description: |
+            MAC address for the endpoint on this network.
+          type: "string"
+          example: "02:42:ac:11:00:04"
+        DriverOpts:
+          description: |
+            DriverOpts is a mapping of driver options and values. These options
+            are passed directly to the driver and are driver specific.
+          type: "object"
+          nullable: true
+          x-nullable: true
+          additionalProperties:
+            type: "string"
+          example:
+            com.example.some-label: "some-value"
+            com.example.some-other-label: "some-other-value"
+
+    EndpointIPAMConfig:
+      description: |
+        EndpointIPAMConfig represents an endpoint's IPAM configuration.
+      type: "object"
+      nullable: true
+      x-nullable: true
+      properties:
+        IPv4Address:
+          type: "string"
+          example: "172.20.30.33"
+        IPv6Address:
+          type: "string"
+          example: "2001:db8:abcd::3033"
+        LinkLocalIPs:
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "169.254.34.68"
+            - "fe80::3468"
+
+    PluginMount:
+      type: "object"
+      nullable: false
+      x-nullable: false
+      required: [Name, Description, Settable, Source, Destination, Type, Options]
+      properties:
+        Name:
+          type: "string"
+          nullable: false
+          x-nullable: false
+          example: "some-mount"
+        Description:
+          type: "string"
+          nullable: false
+          x-nullable: false
+          example: "This is a mount that's used by the plugin."
+        Settable:
+          type: "array"
+          items:
+            type: "string"
+        Source:
+          type: "string"
+          example: "/var/lib/docker/plugins/"
+        Destination:
+          type: "string"
+          nullable: false
+          x-nullable: false
+          example: "/mnt/state"
+        Type:
+          type: "string"
+          nullable: false
+          x-nullable: false
+          example: "bind"
+        Options:
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "rbind"
+            - "rw"
+
+    PluginDevice:
+      type: "object"
+      required: [Name, Description, Settable, Path]
+      nullable: false
+      x-nullable: false
+      properties:
+        Name:
+          type: "string"
+          nullable: false
+          x-nullable: false
+        Description:
+          type: "string"
+          nullable: false
+          x-nullable: false
+        Settable:
+          type: "array"
+          items:
+            type: "string"
+        Path:
+          type: "string"
+          example: "/dev/fuse"
+
+    PluginEnv:
+      type: "object"
+      nullable: false
+      x-nullable: false
+      required: [Name, Description, Settable, Value]
+      properties:
+        Name:
+          nullable: false
+          x-nullable: false
+          type: "string"
+        Description:
+          nullable: false
+          x-nullable: false
+          type: "string"
+        Settable:
+          type: "array"
+          items:
+            type: "string"
+        Value:
+          type: "string"
+
+    PluginInterfaceType:
+      type: "object"
+      nullable: false
+      x-nullable: false
+      required: [Prefix, Capability, Version]
+      properties:
+        Prefix:
+          type: "string"
+          nullable: false
+          x-nullable: false
+        Capability:
+          type: "string"
+          nullable: false
+          x-nullable: false
+        Version:
+          type: "string"
+          nullable: false
+          x-nullable: false
+
+    PluginPrivilege:
+      description: |
+        Describes a permission the user has to accept upon installing
+        the plugin.
+      type: "object"
+      x-go-name: "PluginPrivilege"
+      properties:
+        Name:
+          type: "string"
+          example: "network"
+        Description:
+          type: "string"
+        Value:
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "host"
+
+    Plugin:
+      description: "A plugin for the Engine API"
+      type: "object"
+      required: [Settings, Enabled, Config, Name]
+      properties:
+        Id:
+          type: "string"
+          example: "5724e2c8652da337ab2eedd19fc6fc0ec908e4bd907c7421bf6a8dfc70c4c078"
+        Name:
+          type: "string"
+          nullable: false
+          x-nullable: false
+          example: "tiborvass/sample-volume-plugin"
+        Enabled:
+          description:
+            True if the plugin is running. False if the plugin is not running,
+            only installed.
+          type: "boolean"
+          nullable: false
+          x-nullable: false
+          example: true
+        Settings:
+          description: "Settings that can be modified by users."
+          type: "object"
+          nullable: false
+          x-nullable: false
+          required: [Args, Devices, Env, Mounts]
+          properties:
+            Mounts:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/PluginMount"
+            Env:
+              type: "array"
+              items:
+                type: "string"
+              example:
+                - "DEBUG=0"
+            Args:
+              type: "array"
+              items:
+                type: "string"
+            Devices:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/PluginDevice"
+        PluginReference:
+          description: "plugin remote reference used to push/pull the plugin"
+          type: "string"
+          nullable: false
+          x-nullable: false
+          example: "localhost:5000/tiborvass/sample-volume-plugin:latest"
+        Config:
+          description: "The config of a plugin."
+          type: "object"
+          nullable: false
+          x-nullable: false
+          required:
+            - Description
+            - Documentation
+            - Interface
+            - Entrypoint
+            - WorkDir
+            - Network
+            - Linux
+            - PidHost
+            - PropagatedMount
+            - IpcHost
+            - Mounts
+            - Env
+            - Args
+          properties:
+            DockerVersion:
+              description: "Docker Version used to create the plugin"
+              type: "string"
+              nullable: false
+              x-nullable: false
+              example: "17.06.0-ce"
+            Description:
+              type: "string"
+              nullable: false
+              x-nullable: false
+              example: "A sample volume plugin for Docker"
+            Documentation:
+              type: "string"
+              nullable: false
+              x-nullable: false
+              example: "https://docs.docker.com/engine/extend/plugins/"
+            Interface:
+              description: "The interface between Docker and the plugin"
+              nullable: false
+              x-nullable: false
+              type: "object"
+              required: [Types, Socket]
+              properties:
+                Types:
+                  type: "array"
+                  items:
+                    $ref: "#/components/schemas/PluginInterfaceType"
+                  example:
+                    - "docker.volumedriver/1.0"
+                Socket:
+                  type: "string"
+                  nullable: false
+                  x-nullable: false
+                  example: "plugins.sock"
+                ProtocolScheme:
+                  type: "string"
+                  example: "some.protocol/v1.0"
+                  description: "Protocol to use for clients connecting to the plugin."
+                  enum:
+                    - ""
+                    - "moby.plugins.http/v1"
+            Entrypoint:
+              type: "array"
+              items:
+                type: "string"
+              example:
+                - "/usr/bin/sample-volume-plugin"
+                - "/data"
+            WorkDir:
+              type: "string"
+              nullable: false
+              x-nullable: false
+              example: "/bin/"
+            User:
+              type: "object"
+              nullable: false
+              x-nullable: false
+              properties:
+                UID:
+                  type: "integer"
+                  format: "uint32"
+                  example: 1000
+                GID:
+                  type: "integer"
+                  format: "uint32"
+                  example: 1000
+            Network:
+              type: "object"
+              nullable: false
+              x-nullable: false
+              required: [Type]
+              properties:
+                Type:
+                  nullable: false
+                  x-nullable: false
+                  type: "string"
+                  example: "host"
+            Linux:
+              type: "object"
+              nullable: false
+              x-nullable: false
+              required: [Capabilities, AllowAllDevices, Devices]
+              properties:
+                Capabilities:
+                  type: "array"
+                  items:
+                    type: "string"
+                  example:
+                    - "CAP_SYS_ADMIN"
+                    - "CAP_SYSLOG"
+                AllowAllDevices:
+                  type: "boolean"
+                  nullable: false
+                  x-nullable: false
+                  example: false
+                Devices:
+                  type: "array"
+                  items:
+                    $ref: "#/components/schemas/PluginDevice"
+            PropagatedMount:
+              type: "string"
+              nullable: false
+              x-nullable: false
+              example: "/mnt/volumes"
+            IpcHost:
+              type: "boolean"
+              nullable: false
+              x-nullable: false
+              example: false
+            PidHost:
+              type: "boolean"
+              nullable: false
+              x-nullable: false
+              example: false
+            Mounts:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/PluginMount"
+            Env:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/PluginEnv"
+              example:
+                - Name: "DEBUG"
+                  Description: "If set, prints debug messages"
+                  Settable: null
+                  Value: "0"
+            Args:
+              type: "object"
+              nullable: false
+              required: [Name, Description, Settable, Value]
+              properties:
+                Name:
+                  nullable: false
+                  x-nullable: false
+                  type: "string"
+                  example: "args"
+                Description:
+                  nullable: false
+                  x-nullable: false
+                  type: "string"
+                  example: "command line arguments"
+                Settable:
+                  type: "array"
+                  items:
+                    type: "string"
+                Value:
+                  type: "array"
+                  items:
+                    type: "string"
+            rootfs:
               type: "object"
               properties:
-                NetworkID:
+                type:
                   type: "string"
-                Addr:
+                  example: "layers"
+                diff_ids:
+                  type: "array"
+                  items:
+                    type: "string"
+                  example:
+                    - "sha256:675532206fbf3030b8458f88d6e26d4eb1577688a25efec97154c94e8b6b4887"
+                    - "sha256:e216a057b1cb1efc11f8a268f37ef62083e70b1b38323ba252e25ac88904a7e8"
+
+    ObjectVersion:
+      description: |
+        The version number of the object such as node, service, etc. This is needed
+        to avoid conflicting writes. The client must send the version number along
+        with the modified specification when updating these objects.
+
+        This approach ensures safe concurrency and determinism in that the change
+        on the object may not be applied if the version number has changed from the
+        last read. In other words, if two update requests specify the same base
+        version, only one of the requests can succeed. As a result, two separate
+        update requests that happen at the same time will not unintentionally
+        overwrite each other.
+      type: "object"
+      properties:
+        Index:
+          type: "integer"
+          format: "uint64"
+          example: 373531
+
+    NodeSpec:
+      type: "object"
+      properties:
+        Name:
+          description: "Name for the node."
+          type: "string"
+          example: "my-node"
+        Labels:
+          description: "User-defined key/value metadata."
+          type: "object"
+          additionalProperties:
+            type: "string"
+        Role:
+          description: "Role of the node."
+          type: "string"
+          enum:
+            - "worker"
+            - "manager"
+          example: "manager"
+        Availability:
+          description: "Availability of the node."
+          type: "string"
+          enum:
+            - "active"
+            - "pause"
+            - "drain"
+          example: "active"
+      example:
+        Availability: "active"
+        Name: "node-name"
+        Role: "manager"
+        Labels:
+          foo: "bar"
+
+    Node:
+      type: "object"
+      properties:
+        ID:
+          type: "string"
+          example: "24ifsmvkjbyhk"
+        Version:
+          $ref: "#/components/schemas/ObjectVersion"
+        CreatedAt:
+          description: |
+            Date and time at which the node was added to the swarm in
+            [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+          type: "string"
+          format: "dateTime"
+          example: "2016-08-18T10:44:24.496525531Z"
+        UpdatedAt:
+          description: |
+            Date and time at which the node was last updated in
+            [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+          type: "string"
+          format: "dateTime"
+          example: "2017-08-09T07:09:37.632105588Z"
+        Spec:
+          $ref: "#/components/schemas/NodeSpec"
+        Description:
+          $ref: "#/components/schemas/NodeDescription"
+        Status:
+          $ref: "#/components/schemas/NodeStatus"
+        ManagerStatus:
+          $ref: "#/components/schemas/ManagerStatus"
+
+    NodeDescription:
+      description: |
+        NodeDescription encapsulates the properties of the Node as reported by the
+        agent.
+      type: "object"
+      properties:
+        Hostname:
+          type: "string"
+          example: "bf3067039e47"
+        Platform:
+          $ref: "#/components/schemas/Platform"
+        Resources:
+          $ref: "#/components/schemas/ResourceObject"
+        Engine:
+          $ref: "#/components/schemas/EngineDescription"
+        TLSInfo:
+          $ref: "#/components/schemas/TLSInfo"
+
+    Platform:
+      description: |
+        Platform represents the platform (Arch/OS).
+      type: "object"
+      properties:
+        Architecture:
+          description: |
+            Architecture represents the hardware architecture (for example,
+            `x86_64`).
+          type: "string"
+          example: "x86_64"
+        OS:
+          description: |
+            OS represents the Operating System (for example, `linux` or `windows`).
+          type: "string"
+          example: "linux"
+
+    EngineDescription:
+      description: "EngineDescription provides information about an engine."
+      type: "object"
+      properties:
+        EngineVersion:
+          type: "string"
+          example: "17.06.0"
+        Labels:
+          type: "object"
+          additionalProperties:
+            type: "string"
+          example:
+            foo: "bar"
+        Plugins:
+          type: "array"
+          items:
+            type: "object"
+            properties:
+              Type:
+                type: "string"
+              Name:
+                type: "string"
+          example:
+            - Type: "Log"
+              Name: "awslogs"
+            - Type: "Log"
+              Name: "fluentd"
+            - Type: "Log"
+              Name: "gcplogs"
+            - Type: "Log"
+              Name: "gelf"
+            - Type: "Log"
+              Name: "journald"
+            - Type: "Log"
+              Name: "json-file"
+            - Type: "Log"
+              Name: "logentries"
+            - Type: "Log"
+              Name: "splunk"
+            - Type: "Log"
+              Name: "syslog"
+            - Type: "Network"
+              Name: "bridge"
+            - Type: "Network"
+              Name: "host"
+            - Type: "Network"
+              Name: "ipvlan"
+            - Type: "Network"
+              Name: "macvlan"
+            - Type: "Network"
+              Name: "null"
+            - Type: "Network"
+              Name: "overlay"
+            - Type: "Volume"
+              Name: "local"
+            - Type: "Volume"
+              Name: "localhost:5000/vieux/sshfs:latest"
+            - Type: "Volume"
+              Name: "vieux/sshfs:latest"
+
+    TLSInfo:
+      description: |
+        Information about the issuer of leaf TLS certificates and the trusted root
+        CA certificate.
+      type: "object"
+      properties:
+        TrustRoot:
+          description: |
+            The root CA certificate(s) that are used to validate leaf TLS
+            certificates.
+          type: "string"
+        CertIssuerSubject:
+          description:
+            The base64-url-safe-encoded raw subject bytes of the issuer.
+          type: "string"
+        CertIssuerPublicKey:
+          description: |
+            The base64-url-safe-encoded raw public key bytes of the issuer.
+          type: "string"
+      example:
+        TrustRoot: |
+          -----BEGIN CERTIFICATE-----
+          MIIBajCCARCgAwIBAgIUbYqrLSOSQHoxD8CwG6Bi2PJi9c8wCgYIKoZIzj0EAwIw
+          EzERMA8GA1UEAxMIc3dhcm0tY2EwHhcNMTcwNDI0MjE0MzAwWhcNMzcwNDE5MjE0
+          MzAwWjATMREwDwYDVQQDEwhzd2FybS1jYTBZMBMGByqGSM49AgEGCCqGSM49AwEH
+          A0IABJk/VyMPYdaqDXJb/VXh5n/1Yuv7iNrxV3Qb3l06XD46seovcDWs3IZNV1lf
+          3Skyr0ofcchipoiHkXBODojJydSjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMB
+          Af8EBTADAQH/MB0GA1UdDgQWBBRUXxuRcnFjDfR/RIAUQab8ZV/n4jAKBggqhkjO
+          PQQDAgNIADBFAiAy+JTe6Uc3KyLCMiqGl2GyWGQqQDEcO3/YG36x7om65AIhAJvz
+          pxv6zFeVEkAEEkqIYi0omA9+CjanB/6Bz4n1uw8H
+          -----END CERTIFICATE-----
+        CertIssuerSubject: "MBMxETAPBgNVBAMTCHN3YXJtLWNh"
+        CertIssuerPublicKey: "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEmT9XIw9h1qoNclv9VeHmf/Vi6/uI2vFXdBveXTpcPjqx6i9wNazchk1XWV/dKTKvSh9xyGKmiIeRcE4OiMnJ1A=="
+
+    NodeStatus:
+      description: |
+        NodeStatus represents the status of a node.
+  
+        It provides the current status of the node, as seen by the manager.
+      type: "object"
+      properties:
+        State:
+          $ref: "#/components/schemas/NodeState"
+        Message:
+          type: "string"
+          example: ""
+        Addr:
+          description: "IP address of the node."
+          type: "string"
+          example: "172.17.0.2"
+
+    NodeState:
+      description: "NodeState represents the state of a node."
+      type: "string"
+      enum:
+        - "unknown"
+        - "down"
+        - "ready"
+        - "disconnected"
+      example: "ready"
+
+    ManagerStatus:
+      description: |
+        ManagerStatus represents the status of a manager.
+  
+        It provides the current status of a node's manager component, if the node
+        is a manager.
+      nullable: true
+      x-nullable: true
+      type: "object"
+      properties:
+        Leader:
+          type: "boolean"
+          default: false
+          example: true
+        Reachability:
+          $ref: "#/components/schemas/Reachability"
+        Addr:
+          description: |
+            The IP address and port at which the manager is reachable.
+          type: "string"
+          example: "10.0.0.46:2377"
+
+    Reachability:
+      description: "Reachability represents the reachability of a node."
+      type: "string"
+      enum:
+        - "unknown"
+        - "unreachable"
+        - "reachable"
+      example: "reachable"
+
+    SwarmSpec:
+      description: "User modifiable swarm configuration."
+      type: "object"
+      properties:
+        Name:
+          description: "Name of the swarm."
+          type: "string"
+          example: "default"
+        Labels:
+          description: "User-defined key/value metadata."
+          type: "object"
+          additionalProperties:
+            type: "string"
+          example:
+            com.example.corp.type: "production"
+            com.example.corp.department: "engineering"
+        Orchestration:
+          description: "Orchestration configuration."
+          type: "object"
+          nullable: true
+          x-nullable: true
+          properties:
+            TaskHistoryRetentionLimit:
+              description: |
+                The number of historic tasks to keep per instance or node. If
+                negative, never remove completed or failed tasks.
+              type: "integer"
+              format: "int64"
+              example: 10
+        Raft:
+          description: "Raft configuration."
+          type: "object"
+          properties:
+            SnapshotInterval:
+              description: "The number of log entries between snapshots."
+              type: "integer"
+              format: "uint64"
+              example: 10000
+            KeepOldSnapshots:
+              description: |
+                The number of snapshots to keep beyond the current snapshot.
+              type: "integer"
+              format: "uint64"
+            LogEntriesForSlowFollowers:
+              description: |
+                The number of log entries to keep around to sync up slow followers
+                after a snapshot is created.
+              type: "integer"
+              format: "uint64"
+              example: 500
+            ElectionTick:
+              description: |
+                The number of ticks that a follower will wait for a message from
+                the leader before becoming a candidate and starting an election.
+                `ElectionTick` must be greater than `HeartbeatTick`.
+
+                A tick currently defaults to one second, so these translate
+                directly to seconds currently, but this is NOT guaranteed.
+              type: "integer"
+              example: 3
+            HeartbeatTick:
+              description: |
+                The number of ticks between heartbeats. Every HeartbeatTick ticks,
+                the leader will send a heartbeat to the followers.
+
+                A tick currently defaults to one second, so these translate
+                directly to seconds currently, but this is NOT guaranteed.
+              type: "integer"
+              example: 1
+        Dispatcher:
+          description: "Dispatcher configuration."
+          type: "object"
+          nullable: true
+          x-nullable: true
+          properties:
+            HeartbeatPeriod:
+              description: |
+                The delay for an agent to send a heartbeat to the dispatcher.
+              type: "integer"
+              format: "int64"
+              example: 5000000000
+        CAConfig:
+          description: "CA configuration."
+          type: "object"
+          nullable: true
+          x-nullable: true
+          properties:
+            NodeCertExpiry:
+              description: "The duration node certificates are issued for."
+              type: "integer"
+              format: "int64"
+              example: 7776000000000000
+            ExternalCAs:
+              description: |
+                Configuration for forwarding signing requests to an external
+                certificate authority.
+              type: "array"
+              items:
+                type: "object"
+                properties:
+                  Protocol:
+                    description: |
+                      Protocol for communication with the external CA (currently
+                      only `cfssl` is supported).
+                    type: "string"
+                    enum:
+                      - "cfssl"
+                    default: "cfssl"
+                  URL:
+                    description: |
+                      URL where certificate signing requests should be sent.
+                    type: "string"
+                  Options:
+                    description: |
+                      An object with key/value pairs that are interpreted as
+                      protocol-specific options for the external CA driver.
+                    type: "object"
+                    additionalProperties:
+                      type: "string"
+                  CACert:
+                    description: |
+                      The root CA certificate (in PEM format) this external CA uses
+                      to issue TLS certificates (assumed to be to the current swarm
+                      root CA certificate if not provided).
+                    type: "string"
+            SigningCACert:
+              description: |
+                The desired signing CA certificate for all swarm node TLS leaf
+                certificates, in PEM format.
+              type: "string"
+            SigningCAKey:
+              description: |
+                The desired signing CA key for all swarm node TLS leaf certificates,
+                in PEM format.
+              type: "string"
+            ForceRotate:
+              description: |
+                An integer whose purpose is to force swarm to generate a new
+                signing CA certificate and key, if none have been specified in
+                `SigningCACert` and `SigningCAKey`
+              format: "uint64"
+              type: "integer"
+        EncryptionConfig:
+          description: "Parameters related to encryption-at-rest."
+          type: "object"
+          properties:
+            AutoLockManagers:
+              description: |
+                If set, generate a key and use it to lock data stored on the
+                managers.
+              type: "boolean"
+              example: false
+        TaskDefaults:
+          description: "Defaults for creating tasks in this cluster."
+          type: "object"
+          properties:
+            LogDriver:
+              description: |
+                The log driver to use for tasks created in the orchestrator if
+                unspecified by a service.
+  
+                Updating this value only affects new tasks. Existing tasks continue
+                to use their previously configured log driver until recreated.
+              type: "object"
+              properties:
+                Name:
+                  description: |
+                    The log driver to use as a default for new tasks.
                   type: "string"
-      UpdateStatus:
-        description: "The status of a service update."
-        type: "object"
-        properties:
-          State:
+                  example: "json-file"
+                Options:
+                  description: |
+                    Driver-specific options for the selectd log driver, specified
+                    as key/value pairs.
+                  type: "object"
+                  additionalProperties:
+                    type: "string"
+                  example:
+                    "max-file": "10"
+                    "max-size": "100m"
+
+    # The Swarm information for `GET /info`. It is the same as `GET /swarm`, but
+    # without `JoinTokens`.
+    ClusterInfo:
+      description: |
+        ClusterInfo represents information about the swarm as is returned by the
+        "/info" endpoint. Join-tokens are not included.
+      nullable: true
+      x-nullable: true
+      type: "object"
+      properties:
+        ID:
+          description: "The ID of the swarm."
+          type: "string"
+          example: "abajmipo7b4xz5ip2nrla6b11"
+        Version:
+          $ref: "#/components/schemas/ObjectVersion"
+        CreatedAt:
+          description: |
+            Date and time at which the swarm was initialised in
+            [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+          type: "string"
+          format: "dateTime"
+          example: "2016-08-18T10:44:24.496525531Z"
+        UpdatedAt:
+          description: |
+            Date and time at which the swarm was last updated in
+            [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+          type: "string"
+          format: "dateTime"
+          example: "2017-08-09T07:09:37.632105588Z"
+        Spec:
+          $ref: "#/components/schemas/SwarmSpec"
+        TLSInfo:
+          $ref: "#/components/schemas/TLSInfo"
+        RootRotationInProgress:
+          description: |
+            Whether there is currently a root CA rotation in progress for the swarm
+          type: "boolean"
+          example: false
+        DataPathPort:
+          description: |
+            DataPathPort specifies the data path port number for data traffic.
+            Acceptable port range is 1024 to 49151.
+            If no port is set or is set to 0, the default port (4789) is used.
+          type: "integer"
+          format: "uint32"
+          default: 4789
+          example: 4789
+        DefaultAddrPool:
+          description: |
+            Default Address Pool specifies default subnet pools for global scope
+            networks.
+          type: "array"
+          items:
             type: "string"
-            enum:
-              - "updating"
-              - "paused"
-              - "completed"
-          StartedAt:
+            format: "CIDR"
+            example: ["10.10.0.0/16", "20.20.0.0/16"]
+        SubnetSize:
+          description: |
+            SubnetSize specifies the subnet size of the networks created from the
+            default subnet pool.
+          type: "integer"
+          format: "uint32"
+          maximum: 29
+          default: 24
+          example: 24
+
+    JoinTokens:
+      description: |
+        JoinTokens contains the tokens workers and managers need to join the swarm.
+      type: "object"
+      properties:
+        Worker:
+          description: |
+            The token workers can use to join the swarm.
+          type: "string"
+          example: "SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-1awxwuwd3z9j1z3puu7rcgdbx"
+        Manager:
+          description: |
+            The token managers can use to join the swarm.
+          type: "string"
+          example: "SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-7p73s1dx5in4tatdymyhg9hu2"
+
+    Swarm:
+      type: "object"
+      allOf:
+        - $ref: "#/components/schemas/ClusterInfo"
+        - type: "object"
+          properties:
+            JoinTokens:
+              $ref: "#/components/schemas/JoinTokens"
+
+    TaskSpec:
+      description: "User modifiable task configuration."
+      type: "object"
+      properties:
+        PluginSpec:
+          type: "object"
+          description: |
+            Plugin spec for the service.  *(Experimental release only.)*
+  
+            <p><br /></p>
+  
+            > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are
+            > mutually exclusive. PluginSpec is only used when the Runtime field
+            > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime
+            > field is set to `attachment`.
+          properties:
+            Name:
+              description: "The name or 'alias' to use for the plugin."
+              type: "string"
+            Remote:
+              description: "The plugin image reference to use."
+              type: "string"
+            Disabled:
+              description: "Disable the plugin once scheduled."
+              type: "boolean"
+            PluginPrivilege:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/PluginPrivilege"
+        ContainerSpec:
+          type: "object"
+          description: |
+            Container spec for the service.
+  
+            <p><br /></p>
+  
+            > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are
+            > mutually exclusive. PluginSpec is only used when the Runtime field
+            > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime
+            > field is set to `attachment`.
+          properties:
+            Image:
+              description: "The image name to use for the container"
+              type: "string"
+            Labels:
+              description: "User-defined key/value data."
+              type: "object"
+              additionalProperties:
+                type: "string"
+            Command:
+              description: "The command to be run in the image."
+              type: "array"
+              items:
+                type: "string"
+            Args:
+              description: "Arguments to the command."
+              type: "array"
+              items:
+                type: "string"
+            Hostname:
+              description: |
+                The hostname to use for the container, as a valid
+                [RFC 1123](https://tools.ietf.org/html/rfc1123) hostname.
+              type: "string"
+            Env:
+              description: |
+                A list of environment variables in the form `VAR=value`.
+              type: "array"
+              items:
+                type: "string"
+            Dir:
+              description: "The working directory for commands to run in."
+              type: "string"
+            User:
+              description: "The user inside the container."
+              type: "string"
+            Groups:
+              type: "array"
+              description: |
+                A list of additional groups that the container process will run as.
+              items:
+                type: "string"
+            Privileges:
+              type: "object"
+              description: "Security options for the container"
+              properties:
+                CredentialSpec:
+                  type: "object"
+                  description: "CredentialSpec for managed service account (Windows only)"
+                  properties:
+                    Config:
+                      type: "string"
+                      example: "0bt9dmxjvjiqermk6xrop3ekq"
+                      description: |
+                        Load credential spec from a Swarm Config with the given ID.
+                        The specified config must also be present in the Configs
+                        field with the Runtime property set.
+
+                        <p><br /></p>
+
+
+                        > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`,
+                        > and `CredentialSpec.Config` are mutually exclusive.
+                    File:
+                      type: "string"
+                      example: "spec.json"
+                      description: |
+                        Load credential spec from this file. The file is read by
+                        the daemon, and must be present in the `CredentialSpecs`
+                        subdirectory in the docker data directory, which defaults
+                        to `C:\ProgramData\Docker\` on Windows.
+
+                        For example, specifying `spec.json` loads
+                        `C:\ProgramData\Docker\CredentialSpecs\spec.json`.
+
+                        <p><br /></p>
+
+                        > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`,
+                        > and `CredentialSpec.Config` are mutually exclusive.
+                    Registry:
+                      type: "string"
+                      description: |
+                        Load credential spec from this value in the Windows
+                        registry. The specified registry value must be located in:
+
+                        `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Virtualization\Containers\CredentialSpecs`
+
+                        <p><br /></p>
+
+
+                        > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`,
+                        > and `CredentialSpec.Config` are mutually exclusive.
+                SELinuxContext:
+                  type: "object"
+                  description: "SELinux labels of the container"
+                  properties:
+                    Disable:
+                      type: "boolean"
+                      description: "Disable SELinux"
+                    User:
+                      type: "string"
+                      description: "SELinux user label"
+                    Role:
+                      type: "string"
+                      description: "SELinux role label"
+                    Type:
+                      type: "string"
+                      description: "SELinux type label"
+                    Level:
+                      type: "string"
+                      description: "SELinux level label"
+            TTY:
+              description: "Whether a pseudo-TTY should be allocated."
+              type: "boolean"
+            OpenStdin:
+              description: "Open `stdin`"
+              type: "boolean"
+            ReadOnly:
+              description: "Mount the container's root filesystem as read only."
+              type: "boolean"
+            Mounts:
+              description: |
+                Specification for mounts to be added to containers created as part
+                of the service.
+              type: "array"
+              items:
+                $ref: "#/components/schemas/Mount"
+            StopSignal:
+              description: "Signal to stop the container."
+              type: "string"
+            StopGracePeriod:
+              description: |
+                Amount of time to wait for the container to terminate before
+                forcefully killing it.
+              type: "integer"
+              format: "int64"
+            HealthCheck:
+              $ref: "#/components/schemas/HealthConfig"
+            Hosts:
+              type: "array"
+              description: |
+                A list of hostname/IP mappings to add to the container's `hosts`
+                file. The format of extra hosts is specified in the
+                [hosts(5)](http://man7.org/linux/man-pages/man5/hosts.5.html)
+                man page:
+
+                    IP_address canonical_hostname [aliases...]
+              items:
+                type: "string"
+            DNSConfig:
+              description: |
+                Specification for DNS related configurations in resolver configuration
+                file (`resolv.conf`).
+              type: "object"
+              properties:
+                Nameservers:
+                  description: "The IP addresses of the name servers."
+                  type: "array"
+                  items:
+                    type: "string"
+                Search:
+                  description: "A search list for host-name lookup."
+                  type: "array"
+                  items:
+                    type: "string"
+                Options:
+                  description: |
+                    A list of internal resolver variables to be modified (e.g.,
+                    `debug`, `ndots:3`, etc.).
+                  type: "array"
+                  items:
+                    type: "string"
+            Secrets:
+              description: |
+                Secrets contains references to zero or more secrets that will be
+                exposed to the service.
+              type: "array"
+              items:
+                type: "object"
+                properties:
+                  File:
+                    description: |
+                      File represents a specific target that is backed by a file.
+                    type: "object"
+                    properties:
+                      Name:
+                        description: |
+                          Name represents the final filename in the filesystem.
+                        type: "string"
+                      UID:
+                        description: "UID represents the file UID."
+                        type: "string"
+                      GID:
+                        description: "GID represents the file GID."
+                        type: "string"
+                      Mode:
+                        description: "Mode represents the FileMode of the file."
+                        type: "integer"
+                        format: "uint32"
+                  SecretID:
+                    description: |
+                      SecretID represents the ID of the specific secret that we're
+                      referencing.
+                    type: "string"
+                  SecretName:
+                    description: |
+                      SecretName is the name of the secret that this references,
+                      but this is just provided for lookup/display purposes. The
+                      secret in the reference will be identified by its ID.
+                    type: "string"
+            Configs:
+              description: |
+                Configs contains references to zero or more configs that will be
+                exposed to the service.
+              type: "array"
+              items:
+                type: "object"
+                properties:
+                  File:
+                    description: |
+                      File represents a specific target that is backed by a file.
+  
+                      <p><br /><p>
+  
+                      > **Note**: `Configs.File` and `Configs.Runtime` are mutually exclusive
+                    type: "object"
+                    properties:
+                      Name:
+                        description: |
+                          Name represents the final filename in the filesystem.
+                        type: "string"
+                      UID:
+                        description: "UID represents the file UID."
+                        type: "string"
+                      GID:
+                        description: "GID represents the file GID."
+                        type: "string"
+                      Mode:
+                        description: "Mode represents the FileMode of the file."
+                        type: "integer"
+                        format: "uint32"
+                  Runtime:
+                    description: |
+                      Runtime represents a target that is not mounted into the
+                      container but is used by the task
+
+                      <p><br /><p>
+
+                      > **Note**: `Configs.File` and `Configs.Runtime` are mutually
+                      > exclusive
+                    type: "object"
+                    properties: {}
+                  ConfigID:
+                    description: |
+                      ConfigID represents the ID of the specific config that we're
+                      referencing.
+                    type: "string"
+                  ConfigName:
+                    description: |
+                      ConfigName is the name of the config that this references,
+                      but this is just provided for lookup/display purposes. The
+                      config in the reference will be identified by its ID.
+                    type: "string"
+            Isolation:
+              type: "string"
+              description: |
+                Isolation technology of the containers running the service.
+                (Windows only)
+              enum:
+                - "default"
+                - "process"
+                - "hyperv"
+            Init:
+              description: |
+                Run an init inside the container that forwards signals and reaps
+                processes. This field is omitted if empty, and the default (as
+                configured on the daemon) is used.
+              type: "boolean"
+              nullable: true
+              x-nullable: true
+            Sysctls:
+              description: |
+                Set kernel namedspaced parameters (sysctls) in the container.
+                The Sysctls option on services accepts the same sysctls as the
+                are supported on containers. Note that while the same sysctls are
+                supported, no guarantees or checks are made about their
+                suitability for a clustered environment, and it's up to the user
+                to determine whether a given sysctl will work properly in a
+                Service.
+              type: "object"
+              additionalProperties:
+                type: "string"
+            # This option is not used by Windows containers
+            CapabilityAdd:
+              type: "array"
+              description: |
+                A list of kernel capabilities to add to the default set
+                for the container.
+              items:
+                type: "string"
+              example:
+                - "CAP_NET_RAW"
+                - "CAP_SYS_ADMIN"
+                - "CAP_SYS_CHROOT"
+                - "CAP_SYSLOG"
+            CapabilityDrop:
+              type: "array"
+              description: |
+                A list of kernel capabilities to drop from the default set
+                for the container.
+              items:
+                type: "string"
+              example:
+                - "CAP_NET_RAW"
+            Ulimits:
+              description: |
+                A list of resource limits to set in the container. For example: `{"Name": "nofile", "Soft": 1024, "Hard": 2048}`"
+              type: "array"
+              items:
+                type: "object"
+                properties:
+                  Name:
+                    description: "Name of ulimit"
+                    type: "string"
+                  Soft:
+                    description: "Soft limit"
+                    type: "integer"
+                  Hard:
+                    description: "Hard limit"
+                    type: "integer"
+        NetworkAttachmentSpec:
+          description: |
+            Read-only spec type for non-swarm containers attached to swarm overlay
+            networks.
+
+            <p><br /></p>
+
+            > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are
+            > mutually exclusive. PluginSpec is only used when the Runtime field
+            > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime
+            > field is set to `attachment`.
+          type: "object"
+          properties:
+            ContainerID:
+              description: "ID of the container represented by this task"
+              type: "string"
+        Resources:
+          description: |
+            Resource requirements which apply to each individual container created
+            as part of the service.
+          type: "object"
+          properties:
+            Limits:
+#              description: "Define resources limits."
+              $ref: "#/components/schemas/Limit"
+            Reservations:
+#              description: "Define resources reservation."
+              $ref: "#/components/schemas/ResourceObject"
+        RestartPolicy:
+          description: |
+            Specification for the restart policy which applies to containers
+            created as part of this service.
+          type: "object"
+          properties:
+            Condition:
+              description: "Condition for restart."
+              type: "string"
+              enum:
+                - "none"
+                - "on-failure"
+                - "any"
+            Delay:
+              description: "Delay between restart attempts."
+              type: "integer"
+              format: "int64"
+            MaxAttempts:
+              description: |
+                Maximum attempts to restart a given container before giving up
+                (default value is 0, which is ignored).
+              type: "integer"
+              format: "int64"
+              default: 0
+            Window:
+              description: |
+                Windows is the time window used to evaluate the restart policy
+                (default value is 0, which is unbounded).
+              type: "integer"
+              format: "int64"
+              default: 0
+        Placement:
+          type: "object"
+          properties:
+            Constraints:
+              description: |
+                An array of constraint expressions to limit the set of nodes where
+                a task can be scheduled. Constraint expressions can either use a
+                _match_ (`==`) or _exclude_ (`!=`) rule. Multiple constraints find
+                nodes that satisfy every expression (AND match). Constraints can
+                match node or Docker Engine labels as follows:
+
+                node attribute       | matches                        | example
+                ---------------------|--------------------------------|-----------------------------------------------
+                `node.id`            | Node ID                        | `node.id==2ivku8v2gvtg4`
+                `node.hostname`      | Node hostname                  | `node.hostname!=node-2`
+                `node.role`          | Node role (`manager`/`worker`) | `node.role==manager`
+                `node.platform.os`   | Node operating system          | `node.platform.os==windows`
+                `node.platform.arch` | Node architecture              | `node.platform.arch==x86_64`
+                `node.labels`        | User-defined node labels       | `node.labels.security==high`
+                `engine.labels`      | Docker Engine's labels         | `engine.labels.operatingsystem==ubuntu-14.04`
+
+                `engine.labels` apply to Docker Engine labels like operating system,
+                drivers, etc. Swarm administrators add `node.labels` for operational
+                purposes by using the [`node update endpoint`](#operation/NodeUpdate).
+
+              type: "array"
+              items:
+                type: "string"
+              example:
+                - "node.hostname!=node3.corp.example.com"
+                - "node.role!=manager"
+                - "node.labels.type==production"
+                - "node.platform.os==linux"
+                - "node.platform.arch==x86_64"
+            Preferences:
+              description: |
+                Preferences provide a way to make the scheduler aware of factors
+                such as topology. They are provided in order from highest to
+                lowest precedence.
+              type: "array"
+              items:
+                type: "object"
+                properties:
+                  Spread:
+                    type: "object"
+                    properties:
+                      SpreadDescriptor:
+                        description: |
+                          label descriptor, such as `engine.labels.az`.
+                        type: "string"
+              example:
+                - Spread:
+                    SpreadDescriptor: "node.labels.datacenter"
+                - Spread:
+                    SpreadDescriptor: "node.labels.rack"
+            MaxReplicas:
+              description: |
+                Maximum number of replicas for per node (default value is 0, which
+                is unlimited)
+              type: "integer"
+              format: "int64"
+              default: 0
+            Platforms:
+              description: |
+                Platforms stores all the platforms that the service's image can
+                run on. This field is used in the platform filter for scheduling.
+                If empty, then the platform filter is off, meaning there are no
+                scheduling restrictions.
+              type: "array"
+              items:
+                $ref: "#/components/schemas/Platform"
+        ForceUpdate:
+          description: |
+            A counter that triggers an update even if no relevant parameters have
+            been changed.
+          type: "integer"
+        Runtime:
+          description: |
+            Runtime is the type of runtime specified for the task executor.
+          type: "string"
+        Networks:
+          description: "Specifies which networks the service should attach to."
+          type: "array"
+          items:
+            $ref: "#/components/schemas/NetworkAttachmentConfig"
+        LogDriver:
+          description: |
+            Specifies the log driver to use for tasks created from this spec. If
+            not present, the default one for the swarm will be used, finally
+            falling back to the engine default if not specified.
+          type: "object"
+          properties:
+            Name:
+              type: "string"
+            Options:
+              type: "object"
+              additionalProperties:
+                type: "string"
+
+    TaskState:
+      type: "string"
+      enum:
+        - "new"
+        - "allocated"
+        - "pending"
+        - "assigned"
+        - "accepted"
+        - "preparing"
+        - "ready"
+        - "starting"
+        - "running"
+        - "complete"
+        - "shutdown"
+        - "failed"
+        - "rejected"
+        - "remove"
+        - "orphaned"
+
+    Task:
+      type: "object"
+      properties:
+        ID:
+          description: "The ID of the task."
+          type: "string"
+        Version:
+          $ref: "#/components/schemas/ObjectVersion"
+        CreatedAt:
+          type: "string"
+          format: "dateTime"
+        UpdatedAt:
+          type: "string"
+          format: "dateTime"
+        Name:
+          description: "Name of the task."
+          type: "string"
+        Labels:
+          description: "User-defined key/value metadata."
+          type: "object"
+          additionalProperties:
             type: "string"
-            format: "dateTime"
-          CompletedAt:
-            type: "string"
-            format: "dateTime"
-          Message:
-            type: "string"
-      ServiceStatus:
-        description: |
-          The status of the service's tasks. Provided only when requested as
-          part of a ServiceList operation.
-        type: "object"
-        properties:
-          RunningTasks:
-            description: |
-              The number of tasks for the service currently in the Running state.
-            type: "integer"
-            format: "uint64"
-            example: 7
-          DesiredTasks:
-            description: |
-              The number of tasks for the service desired to be running.
-              For replicated services, this is the replica count from the
-              service spec. For global services, this is computed by taking
-              count of all tasks for the service with a Desired State other
-              than Shutdown.
-            type: "integer"
-            format: "uint64"
-            example: 10
-          CompletedTasks:
-            description: |
-              The number of tasks for a job that are in the Completed state.
-              This field must be cross-referenced with the service type, as the
-              value of 0 may mean the service is not in a job mode, or it may
-              mean the job-mode service has no tasks yet Completed.
-            type: "integer"
-            format: "uint64"
-      JobStatus:
-        description: |
-          The status of the service when it is in one of ReplicatedJob or
-          GlobalJob modes. Absent on Replicated and Global mode services. The
-          JobIteration is an ObjectVersion, but unlike the Service's version,
-          does not need to be sent with an update request.
-        type: "object"
-        properties:
-          JobIteration:
-            description: |
-              JobIteration is a value increased each time a Job is executed,
-              successfully or otherwise. "Executed", in this case, means the
-              job as a whole has been started, not that an individual Task has
-              been launched. A job is "Executed" when its ServiceSpec is
-              updated. JobIteration can be used to disambiguate Tasks belonging
-              to different executions of a job.  Though JobIteration will
-              increase with each subsequent execution, it may not necessarily
-              increase by 1, and so JobIteration should not be used to
-            $ref: "#/definitions/ObjectVersion"
-          LastExecution:
-            description: |
-              The last time, as observed by the server, that this job was
-              started.
-            type: "string"
-            format: "dateTime"
-    example:
-      ID: "9mnpnzenvg8p8tdbtq4wvbkcz"
-      Version:
-        Index: 19
-      CreatedAt: "2016-06-07T21:05:51.880065305Z"
-      UpdatedAt: "2016-06-07T21:07:29.962229872Z"
-      Spec:
-        Name: "hopeful_cori"
-        TaskTemplate:
+        Spec:
+          $ref: "#/components/schemas/TaskSpec"
+        ServiceID:
+          description: "The ID of the service this task is part of."
+          type: "string"
+        Slot:
+          type: "integer"
+        NodeID:
+          description: "The ID of the node that this task is on."
+          type: "string"
+        AssignedGenericResources:
+          $ref: "#/components/schemas/GenericResources"
+        Status:
+          type: "object"
+          properties:
+            Timestamp:
+              type: "string"
+              format: "dateTime"
+            State:
+              $ref: "#/components/schemas/TaskState"
+            Message:
+              type: "string"
+            Err:
+              type: "string"
+            ContainerStatus:
+              type: "object"
+              properties:
+                ContainerID:
+                  type: "string"
+                PID:
+                  type: "integer"
+                ExitCode:
+                  type: "integer"
+        DesiredState:
+          $ref: "#/components/schemas/TaskState"
+        JobIteration:
+# FIXME(thaJeztah): OpenAPI v3 does not allow a description here, so we need to find a different solution.
+#        description: |
+#          If the Service this Task belongs to is a job-mode service, contains
+#          the JobIteration of the Service this Task was created for. Absent if
+#          the Task was created for a Replicated or Global Service.
+          $ref: "#/components/schemas/ObjectVersion"
+      example:
+        ID: "0kzzo1i0y4jz6027t0k7aezc7"
+        Version:
+          Index: 71
+        CreatedAt: "2016-06-07T21:07:31.171892745Z"
+        UpdatedAt: "2016-06-07T21:07:31.376370513Z"
+        Spec:
           ContainerSpec:
             Image: "redis"
           Resources:
@@ -4404,1663 +4125,2067 @@ definitions:
             Condition: "any"
             MaxAttempts: 0
           Placement: {}
-          ForceUpdate: 0
-        Mode:
-          Replicated:
-            Replicas: 1
-        UpdateConfig:
-          Parallelism: 1
-          Delay: 1000000000
-          FailureAction: "pause"
-          Monitor: 15000000000
-          MaxFailureRatio: 0.15
-        RollbackConfig:
-          Parallelism: 1
-          Delay: 1000000000
-          FailureAction: "pause"
-          Monitor: 15000000000
-          MaxFailureRatio: 0.15
-        EndpointSpec:
-          Mode: "vip"
-          Ports:
-            -
-              Protocol: "tcp"
-              TargetPort: 6379
-              PublishedPort: 30001
-      Endpoint:
-        Spec:
-          Mode: "vip"
-          Ports:
-            -
-              Protocol: "tcp"
-              TargetPort: 6379
-              PublishedPort: 30001
-        Ports:
-          -
-            Protocol: "tcp"
-            TargetPort: 6379
-            PublishedPort: 30001
-        VirtualIPs:
-          -
-            NetworkID: "4qvuz4ko70xaltuqbt8956gd1"
-            Addr: "10.255.0.2/16"
-          -
-            NetworkID: "4qvuz4ko70xaltuqbt8956gd1"
-            Addr: "10.255.0.3/16"
+        ServiceID: "9mnpnzenvg8p8tdbtq4wvbkcz"
+        Slot: 1
+        NodeID: "60gvrl6tm78dmak4yl7srz94v"
+        Status:
+          Timestamp: "2016-06-07T21:07:31.290032978Z"
+          State: "running"
+          Message: "started"
+          ContainerStatus:
+            ContainerID: "e5d62702a1b48d01c3e02ca1e0212a250801fa8d67caca0b6f35919ebc12f035"
+            PID: 677
+        DesiredState: "running"
+        NetworksAttachments:
+          - Network:
+              ID: "4qvuz4ko70xaltuqbt8956gd1"
+              Version:
+                Index: 18
+              CreatedAt: "2016-06-07T20:31:11.912919752Z"
+              UpdatedAt: "2016-06-07T21:07:29.955277358Z"
+              Spec:
+                Name: "ingress"
+                Labels:
+                  com.docker.swarm.internal: "true"
+                DriverConfiguration: {}
+                IPAMOptions:
+                  Driver: {}
+                  Configs:
+                    - Subnet: "10.255.0.0/16"
+                      Gateway: "10.255.0.1"
+              DriverState:
+                Name: "overlay"
+                Options:
+                  com.docker.network.driver.overlay.vxlanid_list: "256"
+              IPAMOptions:
+                Driver:
+                  Name: "default"
+                Configs:
+                  - Subnet: "10.255.0.0/16"
+                    Gateway: "10.255.0.1"
+            Addresses:
+              - "10.255.0.10/16"
+        AssignedGenericResources:
+          - DiscreteResourceSpec:
+              Kind: "SSD"
+              Value: 3
+          - NamedResourceSpec:
+              Kind: "GPU"
+              Value: "UUID1"
+          - NamedResourceSpec:
+              Kind: "GPU"
+              Value: "UUID2"
 
-  ImageDeleteResponseItem:
-    type: "object"
-    properties:
-      Untagged:
-        description: "The image ID of an image that was untagged"
-        type: "string"
-      Deleted:
-        description: "The image ID of an image that was deleted"
-        type: "string"
-
-  ServiceUpdateResponse:
-    type: "object"
-    properties:
-      Warnings:
-        description: "Optional warning messages"
-        type: "array"
-        items:
+    ServiceSpec:
+      description: "User modifiable configuration for a service."
+      type: object
+      properties:
+        Name:
+          description: "Name of the service."
           type: "string"
-    example:
-      Warning: "unable to pin image doesnotexist:latest to digest: image library/doesnotexist:latest not found"
-
-  ContainerSummary:
-    type: "object"
-    properties:
-      Id:
-        description: "The ID of this container"
-        type: "string"
-        x-go-name: "ID"
-      Names:
-        description: "The names that this container has been given"
-        type: "array"
-        items:
-          type: "string"
-      Image:
-        description: "The name of the image used when creating this container"
-        type: "string"
-      ImageID:
-        description: "The ID of the image that this container was created from"
-        type: "string"
-      Command:
-        description: "Command to run when starting the container"
-        type: "string"
-      Created:
-        description: "When the container was created"
-        type: "integer"
-        format: "int64"
-      Ports:
-        description: "The ports exposed by this container"
-        type: "array"
-        items:
-          $ref: "#/definitions/Port"
-      SizeRw:
-        description: "The size of files that have been created or changed by this container"
-        type: "integer"
-        format: "int64"
-      SizeRootFs:
-        description: "The total size of all the files in this container"
-        type: "integer"
-        format: "int64"
-      Labels:
-        description: "User-defined key/value metadata."
-        type: "object"
-        additionalProperties:
-          type: "string"
-      State:
-        description: "The state of this container (e.g. `Exited`)"
-        type: "string"
-      Status:
-        description: "Additional human-readable status of this container (e.g. `Exit 0`)"
-        type: "string"
-      HostConfig:
-        type: "object"
-        properties:
-          NetworkMode:
-            type: "string"
-      NetworkSettings:
-        description: "A summary of the container's network settings"
-        type: "object"
-        properties:
-          Networks:
-            type: "object"
-            additionalProperties:
-              $ref: "#/definitions/EndpointSettings"
-      Mounts:
-        type: "array"
-        items:
-          $ref: "#/definitions/MountPoint"
-
-  Driver:
-    description: "Driver represents a driver (network, logging, secrets)."
-    type: "object"
-    required: [Name]
-    properties:
-      Name:
-        description: "Name of the driver."
-        type: "string"
-        x-nullable: false
-        example: "some-driver"
-      Options:
-        description: "Key/value map of driver-specific options."
-        type: "object"
-        x-nullable: false
-        additionalProperties:
-          type: "string"
-        example:
-          OptionA: "value for driver-specific option A"
-          OptionB: "value for driver-specific option B"
-
-  SecretSpec:
-    type: "object"
-    properties:
-      Name:
-        description: "User-defined name of the secret."
-        type: "string"
-      Labels:
-        description: "User-defined key/value metadata."
-        type: "object"
-        additionalProperties:
-          type: "string"
-        example:
-          com.example.some-label: "some-value"
-          com.example.some-other-label: "some-other-value"
-      Data:
-        description: |
-          Base64-url-safe-encoded ([RFC 4648](https://tools.ietf.org/html/rfc4648#section-5))
-          data to store as secret.
-
-          This field is only used to _create_ a secret, and is not returned by
-          other endpoints.
-        type: "string"
-        example: ""
-      Driver:
-        description: |
-          Name of the secrets driver used to fetch the secret's value from an
-          external secret store.
-        $ref: "#/definitions/Driver"
-      Templating:
-        description: |
-          Templating driver, if applicable
-
-          Templating controls whether and how to evaluate the config payload as
-          a template. If no driver is set, no templating is used.
-        $ref: "#/definitions/Driver"
-
-  Secret:
-    type: "object"
-    properties:
-      ID:
-        type: "string"
-        example: "blt1owaxmitz71s9v5zh81zun"
-      Version:
-        $ref: "#/definitions/ObjectVersion"
-      CreatedAt:
-        type: "string"
-        format: "dateTime"
-        example: "2017-07-20T13:55:28.678958722Z"
-      UpdatedAt:
-        type: "string"
-        format: "dateTime"
-        example: "2017-07-20T13:55:28.678958722Z"
-      Spec:
-        $ref: "#/definitions/SecretSpec"
-
-  ConfigSpec:
-    type: "object"
-    properties:
-      Name:
-        description: "User-defined name of the config."
-        type: "string"
-      Labels:
-        description: "User-defined key/value metadata."
-        type: "object"
-        additionalProperties:
-          type: "string"
-      Data:
-        description: |
-          Base64-url-safe-encoded ([RFC 4648](https://tools.ietf.org/html/rfc4648#section-5))
-          config data.
-        type: "string"
-      Templating:
-        description: |
-          Templating driver, if applicable
-
-          Templating controls whether and how to evaluate the config payload as
-          a template. If no driver is set, no templating is used.
-        $ref: "#/definitions/Driver"
-
-  Config:
-    type: "object"
-    properties:
-      ID:
-        type: "string"
-      Version:
-        $ref: "#/definitions/ObjectVersion"
-      CreatedAt:
-        type: "string"
-        format: "dateTime"
-      UpdatedAt:
-        type: "string"
-        format: "dateTime"
-      Spec:
-        $ref: "#/definitions/ConfigSpec"
-
-  ContainerState:
-    description: |
-      ContainerState stores container's running state. It's part of ContainerJSONBase
-      and will be returned by the "inspect" command.
-    type: "object"
-    x-nullable: true
-    properties:
-      Status:
-        description: |
-          String representation of the container state. Can be one of "created",
-          "running", "paused", "restarting", "removing", "exited", or "dead".
-        type: "string"
-        enum: ["created", "running", "paused", "restarting", "removing", "exited", "dead"]
-        example: "running"
-      Running:
-        description: |
-          Whether this container is running.
-
-          Note that a running container can be _paused_. The `Running` and `Paused`
-          booleans are not mutually exclusive:
-
-          When pausing a container (on Linux), the freezer cgroup is used to suspend
-          all processes in the container. Freezing the process requires the process to
-          be running. As a result, paused containers are both `Running` _and_ `Paused`.
-
-          Use the `Status` field instead to determine if a container's state is "running".
-        type: "boolean"
-        example: true
-      Paused:
-        description: "Whether this container is paused."
-        type: "boolean"
-        example: false
-      Restarting:
-        description: "Whether this container is restarting."
-        type: "boolean"
-        example: false
-      OOMKilled:
-        description: |
-          Whether a process within this container has been killed because it ran
-          out of memory since the container was last started.
-        type: "boolean"
-        example: false
-      Dead:
-        type: "boolean"
-        example: false
-      Pid:
-        description: "The process ID of this container"
-        type: "integer"
-        example: 1234
-      ExitCode:
-        description: "The last exit code of this container"
-        type: "integer"
-        example: 0
-      Error:
-        type: "string"
-      StartedAt:
-        description: "The time when this container was last started."
-        type: "string"
-        example: "2020-01-06T09:06:59.461876391Z"
-      FinishedAt:
-        description: "The time when this container last exited."
-        type: "string"
-        example: "2020-01-06T09:07:59.461876391Z"
-      Health:
-        $ref: "#/definitions/Health"
-
-  ContainerCreateResponse:
-    description: "OK response to ContainerCreate operation"
-    type: "object"
-    title: "ContainerCreateResponse"
-    x-go-name: "CreateResponse"
-    required: [Id, Warnings]
-    properties:
-      Id:
-        description: "The ID of the created container"
-        type: "string"
-        x-nullable: false
-        example: "ede54ee1afda366ab42f824e8a5ffd195155d853ceaec74a927f249ea270c743"
-      Warnings:
-        description: "Warnings encountered when creating the container"
-        type: "array"
-        x-nullable: false
-        items:
-          type: "string"
-        example: []
-
-  ContainerWaitResponse:
-    description: "OK response to ContainerWait operation"
-    type: "object"
-    x-go-name: "WaitResponse"
-    title: "ContainerWaitResponse"
-    required: [StatusCode]
-    properties:
-      StatusCode:
-        description: "Exit code of the container"
-        type: "integer"
-        format: "int64"
-        x-nullable: false
-      Error:
-        $ref: "#/definitions/ContainerWaitExitError"
-
-  ContainerWaitExitError:
-    description: "container waiting error, if any"
-    type: "object"
-    x-go-name: "WaitExitError"
-    properties:
-      Message:
-        description: "Details of an error"
-        type: "string"
-
-  SystemVersion:
-    type: "object"
-    description: |
-      Response of Engine API: GET "/version"
-    properties:
-      Platform:
-        type: "object"
-        required: [Name]
-        properties:
-          Name:
-            type: "string"
-      Components:
-        type: "array"
-        description: |
-          Information about system components
-        items:
+        Labels:
+          description: "User-defined key/value metadata."
           type: "object"
-          x-go-name: ComponentVersion
-          required: [Name, Version]
+          additionalProperties:
+            type: "string"
+        TaskTemplate:
+          $ref: "#/components/schemas/TaskSpec"
+        Mode:
+          description: "Scheduling mode for the service."
+          type: "object"
           properties:
-            Name:
-              description: |
-                Name of the component
-              type: "string"
-              example: "Engine"
-            Version:
-              description: |
-                Version of the component
-              type: "string"
-              x-nullable: false
-              example: "19.03.12"
-            Details:
-              description: |
-                Key/value pairs of strings with additional information about the
-                component. These values are intended for informational purposes
-                only, and their content is not defined, and not part of the API
-                specification.
-
-                These messages can be printed by the client as information to the user.
+            Replicated:
               type: "object"
-              x-nullable: true
-      Version:
-        description: "The version of the daemon"
-        type: "string"
-        example: "19.03.12"
-      ApiVersion:
-        description: |
-          The default (and highest) API version that is supported by the daemon
-        type: "string"
-        example: "1.40"
-      MinAPIVersion:
-        description: |
-          The minimum API version that is supported by the daemon
-        type: "string"
-        example: "1.12"
-      GitCommit:
-        description: |
-          The Git commit of the source code that was used to build the daemon
-        type: "string"
-        example: "48a66213fe"
-      GoVersion:
-        description: |
-          The version Go used to compile the daemon, and the version of the Go
-          runtime in use.
-        type: "string"
-        example: "go1.13.14"
-      Os:
-        description: |
-          The operating system that the daemon is running on ("linux" or "windows")
-        type: "string"
-        example: "linux"
-      Arch:
-        description: |
-          The architecture that the daemon is running on
-        type: "string"
-        example: "amd64"
-      KernelVersion:
-        description: |
-          The kernel version (`uname -r`) that the daemon is running on.
+              properties:
+                Replicas:
+                  type: "integer"
+                  format: "int64"
+            Global:
+              type: "object"
+              properties: {}
+            ReplicatedJob:
+              description: |
+                The mode used for services with a finite number of tasks that run
+                to a completed state.
+              type: "object"
+              properties:
+                MaxConcurrent:
+                  description: |
+                    The maximum number of replicas to run simultaneously.
+                  type: "integer"
+                  format: "int64"
+                  default: 1
+                TotalCompletions:
+                  description: |
+                    The total number of replicas desired to reach the Completed
+                    state. If unset, will default to the value of `MaxConcurrent`
+                  type: "integer"
+                  format: "int64"
+            GlobalJob:
+              description: |
+                The mode used for services which run a task to the completed state
+                on each valid node.
+              type: "object"
+              properties: {}
+        UpdateConfig:
+          description: "Specification for the update strategy of the service."
+          type: "object"
+          properties:
+            Parallelism:
+              description: |
+                Maximum number of tasks to be updated in one iteration (0 means
+                unlimited parallelism).
+              type: "integer"
+              format: "int64"
+            Delay:
+              description: "Amount of time between updates, in nanoseconds."
+              type: "integer"
+              format: "int64"
+            FailureAction:
+              description: |
+                Action to take if an updated task fails to run, or stops running
+                during the update.
+              type: "string"
+              enum:
+                - "continue"
+                - "pause"
+                - "rollback"
+            Monitor:
+              description: |
+                Amount of time to monitor each updated task for failures, in
+                nanoseconds.
+              type: "integer"
+              format: "int64"
+            MaxFailureRatio:
+              description: |
+                The fraction of tasks that may fail during an update before the
+                failure action is invoked, specified as a floating point number
+                between 0 and 1.
+              type: "number"
+              default: 0
+            Order:
+              description: |
+                The order of operations when rolling out an updated task. Either
+                the old task is shut down before the new task is started, or the
+                new task is started before the old task is shut down.
+              type: "string"
+              enum:
+                - "stop-first"
+                - "start-first"
+        RollbackConfig:
+          description: "Specification for the rollback strategy of the service."
+          type: "object"
+          properties:
+            Parallelism:
+              description: |
+                Maximum number of tasks to be rolled back in one iteration (0 means
+                unlimited parallelism).
+              type: "integer"
+              format: "int64"
+            Delay:
+              description: |
+                Amount of time between rollback iterations, in nanoseconds.
+              type: "integer"
+              format: "int64"
+            FailureAction:
+              description: |
+                Action to take if an rolled back task fails to run, or stops
+                running during the rollback.
+              type: "string"
+              enum:
+                - "continue"
+                - "pause"
+            Monitor:
+              description: |
+                Amount of time to monitor each rolled back task for failures, in
+                nanoseconds.
+              type: "integer"
+              format: "int64"
+            MaxFailureRatio:
+              description: |
+                The fraction of tasks that may fail during a rollback before the
+                failure action is invoked, specified as a floating point number
+                between 0 and 1.
+              type: "number"
+              default: 0
+            Order:
+              description: |
+                The order of operations when rolling back a task. Either the old
+                task is shut down before the new task is started, or the new task
+                is started before the old task is shut down.
+              type: "string"
+              enum:
+                - "stop-first"
+                - "start-first"
+        Networks:
+          description: "Specifies which networks the service should attach to."
+          type: "array"
+          items:
+            $ref: "#/components/schemas/NetworkAttachmentConfig"
 
-          This field is omitted when empty.
-        type: "string"
-        example: "4.19.76-linuxkit"
-      Experimental:
-        description: |
-          Indicates if the daemon is started with experimental features enabled.
+        EndpointSpec:
+          $ref: "#/components/schemas/EndpointSpec"
 
-          This field is omitted when empty / false.
-        type: "boolean"
-        example: true
-      BuildTime:
-        description: |
-          The date and time that the daemon was compiled.
-        type: "string"
-        example: "2020-06-22T15:49:27.000000000+00:00"
+    EndpointPortConfig:
+      type: "object"
+      properties:
+        Name:
+          type: "string"
+        Protocol:
+          type: "string"
+          enum:
+            - "tcp"
+            - "udp"
+            - "sctp"
+        TargetPort:
+          description: "The port inside the container."
+          type: "integer"
+        PublishedPort:
+          description: "The port on the swarm hosts."
+          type: "integer"
+        PublishMode:
+          description: |
+            The mode in which port is published.
 
-  SystemInfo:
-    type: "object"
-    properties:
-      ID:
-        description: |
-          Unique identifier of the daemon.
+            <p><br /></p>
 
-          <p><br /></p>
+            - "ingress" makes the target port accessible on every node,
+              regardless of whether there is a task for the service running on
+              that node or not.
+            - "host" bypasses the routing mesh and publish the port directly on
+              the swarm node where that service is running.
 
-          > **Note**: The format of the ID itself is not part of the API, and
-          > should not be considered stable.
-        type: "string"
-        example: "7TRN:IPZB:QYBB:VPBQ:UMPP:KARE:6ZNR:XE6T:7EWV:PKF4:ZOJD:TPYS"
-      Containers:
-        description: "Total number of containers on the host."
-        type: "integer"
-        example: 14
-      ContainersRunning:
-        description: |
-          Number of containers with status `"running"`.
-        type: "integer"
-        example: 3
-      ContainersPaused:
-        description: |
-          Number of containers with status `"paused"`.
-        type: "integer"
-        example: 1
-      ContainersStopped:
-        description: |
-          Number of containers with status `"stopped"`.
-        type: "integer"
-        example: 10
-      Images:
-        description: |
-          Total number of images on the host.
+          type: "string"
+          enum:
+            - "ingress"
+            - "host"
+          default: "ingress"
+          example: "ingress"
 
-          Both _tagged_ and _untagged_ (dangling) images are counted.
-        type: "integer"
-        example: 508
-      Driver:
-        description: "Name of the storage driver in use."
-        type: "string"
-        example: "overlay2"
-      DriverStatus:
-        description: |
-          Information specific to the storage driver, provided as
-          "label" / "value" pairs.
+    EndpointSpec:
+      description: "Properties that can be configured to access and load balance a service."
+      type: "object"
+      properties:
+        Mode:
+          description: |
+            The mode of resolution to use for internal load balancing between tasks.
+          type: "string"
+          enum:
+            - "vip"
+            - "dnsrr"
+          default: "vip"
+        Ports:
+          description: |
+            List of exposed ports that this service is accessible on from the
+            outside. Ports can only be provided if `vip` resolution mode is used.
+          type: "array"
+          items:
+            $ref: "#/components/schemas/EndpointPortConfig"
 
-          This information is provided by the storage driver, and formatted
-          in a way consistent with the output of `docker info` on the command
-          line.
+    Service:
+      type: "object"
+      properties:
+        ID:
+          type: "string"
+        Version:
+          $ref: "#/components/schemas/ObjectVersion"
+        CreatedAt:
+          type: "string"
+          format: "dateTime"
+        UpdatedAt:
+          type: "string"
+          format: "dateTime"
+        Spec:
+          $ref: "#/components/schemas/ServiceSpec"
+        Endpoint:
+          type: "object"
+          properties:
+            Spec:
+              $ref: "#/components/schemas/EndpointSpec"
+            Ports:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/EndpointPortConfig"
+            VirtualIPs:
+              type: "array"
+              items:
+                type: "object"
+                properties:
+                  NetworkID:
+                    type: "string"
+                  Addr:
+                    type: "string"
+        UpdateStatus:
+          description: "The status of a service update."
+          type: "object"
+          properties:
+            State:
+              type: "string"
+              enum:
+                - "updating"
+                - "paused"
+                - "completed"
+            StartedAt:
+              type: "string"
+              format: "dateTime"
+            CompletedAt:
+              type: "string"
+              format: "dateTime"
+            Message:
+              type: "string"
+        ServiceStatus:
+          description: |
+            The status of the service's tasks. Provided only when requested as
+            part of a ServiceList operation.
+          type: "object"
+          properties:
+            RunningTasks:
+              description: |
+                The number of tasks for the service currently in the Running state.
+              type: "integer"
+              format: "uint64"
+              example: 7
+            DesiredTasks:
+              description: |
+                The number of tasks for the service desired to be running.
+                For replicated services, this is the replica count from the
+                service spec. For global services, this is computed by taking
+                count of all tasks for the service with a Desired State other
+                than Shutdown.
+              type: "integer"
+              format: "uint64"
+              example: 10
+            CompletedTasks:
+              description: |
+                The number of tasks for a job that are in the Completed state.
+                This field must be cross-referenced with the service type, as the
+                value of 0 may mean the service is not in a job mode, or it may
+                mean the job-mode service has no tasks yet Completed.
+              type: "integer"
+              format: "uint64"
+        JobStatus:
+          description: |
+            The status of the service when it is in one of ReplicatedJob or
+            GlobalJob modes. Absent on Replicated and Global mode services. The
+            JobIteration is an ObjectVersion, but unlike the Service's version,
+            does not need to be sent with an update request.
+          type: "object"
+          properties:
+            JobIteration:
+# FIXME(thaJeztah): OpenAPI v3 does not allow a description here, so we need to find a different solution.
+#            description: |
+#              JobIteration is a value increased each time a Job is executed,
+#              successfully or otherwise. "Executed", in this case, means the
+#              job as a whole has been started, not that an individual Task has
+#              been launched. A job is "Executed" when its ServiceSpec is
+#              updated. JobIteration can be used to disambiguate Tasks belonging
+#              to different executions of a job.  Though JobIteration will
+#              increase with each subsequent execution, it may not necessarily
+#              increase by 1, and so JobIteration should not be used to
+              $ref: "#/components/schemas/ObjectVersion"
+            LastExecution:
+              description: |
+                The last time, as observed by the server, that this job was
+                started.
+              type: "string"
+              format: "dateTime"
+      example:
+        ID: "9mnpnzenvg8p8tdbtq4wvbkcz"
+        Version:
+          Index: 19
+        CreatedAt: "2016-06-07T21:05:51.880065305Z"
+        UpdatedAt: "2016-06-07T21:07:29.962229872Z"
+        Spec:
+          Name: "hopeful_cori"
+          TaskTemplate:
+            ContainerSpec:
+              Image: "redis"
+            Resources:
+              Limits: {}
+              Reservations: {}
+            RestartPolicy:
+              Condition: "any"
+              MaxAttempts: 0
+            Placement: {}
+            ForceUpdate: 0
+          Mode:
+            Replicated:
+              Replicas: 1
+          UpdateConfig:
+            Parallelism: 1
+            Delay: 1000000000
+            FailureAction: "pause"
+            Monitor: 15000000000
+            MaxFailureRatio: 0.15
+          RollbackConfig:
+            Parallelism: 1
+            Delay: 1000000000
+            FailureAction: "pause"
+            Monitor: 15000000000
+            MaxFailureRatio: 0.15
+          EndpointSpec:
+            Mode: "vip"
+            Ports:
+              -
+                Protocol: "tcp"
+                TargetPort: 6379
+                PublishedPort: 30001
+        Endpoint:
+          Spec:
+            Mode: "vip"
+            Ports:
+              -
+                Protocol: "tcp"
+                TargetPort: 6379
+                PublishedPort: 30001
+          Ports:
+            -
+              Protocol: "tcp"
+              TargetPort: 6379
+              PublishedPort: 30001
+          VirtualIPs:
+            -
+              NetworkID: "4qvuz4ko70xaltuqbt8956gd1"
+              Addr: "10.255.0.2/16"
+            -
+              NetworkID: "4qvuz4ko70xaltuqbt8956gd1"
+              Addr: "10.255.0.3/16"
 
-          <p><br /></p>
+    ImageDeleteResponseItem:
+      type: "object"
+      properties:
+        Untagged:
+          description: "The image ID of an image that was untagged"
+          type: "string"
+        Deleted:
+          description: "The image ID of an image that was deleted"
+          type: "string"
 
-          > **Note**: The information returned in this field, including the
-          > formatting of values and labels, should not be considered stable,
-          > and may change without notice.
-        type: "array"
-        items:
+    ServiceUpdateResponse:
+      type: "object"
+      properties:
+        Warnings:
+          description: "Optional warning messages"
           type: "array"
           items:
             type: "string"
-        example:
-          - ["Backing Filesystem", "extfs"]
-          - ["Supports d_type", "true"]
-          - ["Native Overlay Diff", "true"]
-      DockerRootDir:
-        description: |
-          Root directory of persistent Docker state.
+      example:
+        Warning: "unable to pin image doesnotexist:latest to digest: image library/doesnotexist:latest not found"
 
-          Defaults to `/var/lib/docker` on Linux, and `C:\ProgramData\docker`
-          on Windows.
-        type: "string"
-        example: "/var/lib/docker"
-      Plugins:
-        $ref: "#/definitions/PluginsInfo"
-      MemoryLimit:
-        description: "Indicates if the host has memory limit support enabled."
-        type: "boolean"
-        example: true
-      SwapLimit:
-        description: "Indicates if the host has memory swap limit support enabled."
-        type: "boolean"
-        example: true
-      KernelMemoryTCP:
-        description: |
-          Indicates if the host has kernel memory TCP limit support enabled. This
-          field is omitted if not supported.
-
-          Kernel memory TCP limits are not supported when using cgroups v2, which
-          does not support the corresponding `memory.kmem.tcp.limit_in_bytes` cgroup.
-        type: "boolean"
-        example: true
-      CpuCfsPeriod:
-        description: |
-          Indicates if CPU CFS(Completely Fair Scheduler) period is supported by
-          the host.
-        type: "boolean"
-        example: true
-      CpuCfsQuota:
-        description: |
-          Indicates if CPU CFS(Completely Fair Scheduler) quota is supported by
-          the host.
-        type: "boolean"
-        example: true
-      CPUShares:
-        description: |
-          Indicates if CPU Shares limiting is supported by the host.
-        type: "boolean"
-        example: true
-      CPUSet:
-        description: |
-          Indicates if CPUsets (cpuset.cpus, cpuset.mems) are supported by the host.
-
-          See [cpuset(7)](https://www.kernel.org/doc/Documentation/cgroup-v1/cpusets.txt)
-        type: "boolean"
-        example: true
-      PidsLimit:
-        description: "Indicates if the host kernel has PID limit support enabled."
-        type: "boolean"
-        example: true
-      OomKillDisable:
-        description: "Indicates if OOM killer disable is supported on the host."
-        type: "boolean"
-      IPv4Forwarding:
-        description: "Indicates IPv4 forwarding is enabled."
-        type: "boolean"
-        example: true
-      BridgeNfIptables:
-        description: "Indicates if `bridge-nf-call-iptables` is available on the host."
-        type: "boolean"
-        example: true
-      BridgeNfIp6tables:
-        description: "Indicates if `bridge-nf-call-ip6tables` is available on the host."
-        type: "boolean"
-        example: true
-      Debug:
-        description: |
-          Indicates if the daemon is running in debug-mode / with debug-level
-          logging enabled.
-        type: "boolean"
-        example: true
-      NFd:
-        description: |
-          The total number of file Descriptors in use by the daemon process.
-
-          This information is only returned if debug-mode is enabled.
-        type: "integer"
-        example: 64
-      NGoroutines:
-        description: |
-          The  number of goroutines that currently exist.
-
-          This information is only returned if debug-mode is enabled.
-        type: "integer"
-        example: 174
-      SystemTime:
-        description: |
-          Current system-time in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt)
-          format with nano-seconds.
-        type: "string"
-        example: "2017-08-08T20:28:29.06202363Z"
-      LoggingDriver:
-        description: |
-          The logging driver to use as a default for new containers.
-        type: "string"
-      CgroupDriver:
-        description: |
-          The driver to use for managing cgroups.
-        type: "string"
-        enum: ["cgroupfs", "systemd", "none"]
-        default: "cgroupfs"
-        example: "cgroupfs"
-      CgroupVersion:
-        description: |
-          The version of the cgroup.
-        type: "string"
-        enum: ["1", "2"]
-        default: "1"
-        example: "1"
-      NEventsListener:
-        description: "Number of event listeners subscribed."
-        type: "integer"
-        example: 30
-      KernelVersion:
-        description: |
-          Kernel version of the host.
-
-          On Linux, this information obtained from `uname`. On Windows this
-          information is queried from the <kbd>HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\</kbd>
-          registry value, for example _"10.0 14393 (14393.1198.amd64fre.rs1_release_sec.170427-1353)"_.
-        type: "string"
-        example: "4.9.38-moby"
-      OperatingSystem:
-        description: |
-          Name of the host's operating system, for example: "Ubuntu 16.04.2 LTS"
-          or "Windows Server 2016 Datacenter"
-        type: "string"
-        example: "Alpine Linux v3.5"
-      OSVersion:
-        description: |
-          Version of the host's operating system
-
-          <p><br /></p>
-
-          > **Note**: The information returned in this field, including its
-          > very existence, and the formatting of values, should not be considered
-          > stable, and may change without notice.
-        type: "string"
-        example: "16.04"
-      OSType:
-        description: |
-          Generic type of the operating system of the host, as returned by the
-          Go runtime (`GOOS`).
-
-          Currently returned values are "linux" and "windows". A full list of
-          possible values can be found in the [Go documentation](https://go.dev/doc/install/source#environment).
-        type: "string"
-        example: "linux"
-      Architecture:
-        description: |
-          Hardware architecture of the host, as returned by the Go runtime
-          (`GOARCH`).
-
-          A full list of possible values can be found in the [Go documentation](https://go.dev/doc/install/source#environment).
-        type: "string"
-        example: "x86_64"
-      NCPU:
-        description: |
-          The number of logical CPUs usable by the daemon.
-
-          The number of available CPUs is checked by querying the operating
-          system when the daemon starts. Changes to operating system CPU
-          allocation after the daemon is started are not reflected.
-        type: "integer"
-        example: 4
-      MemTotal:
-        description: |
-          Total amount of physical memory available on the host, in bytes.
-        type: "integer"
-        format: "int64"
-        example: 2095882240
-
-      IndexServerAddress:
-        description: |
-          Address / URL of the index server that is used for image search,
-          and as a default for user authentication for Docker Hub and Docker Cloud.
-        default: "https://index.docker.io/v1/"
-        type: "string"
-        example: "https://index.docker.io/v1/"
-      RegistryConfig:
-        $ref: "#/definitions/RegistryServiceConfig"
-      GenericResources:
-        $ref: "#/definitions/GenericResources"
-      HttpProxy:
-        description: |
-          HTTP-proxy configured for the daemon. This value is obtained from the
-          [`HTTP_PROXY`](https://www.gnu.org/software/wget/manual/html_node/Proxies.html) environment variable.
-          Credentials ([user info component](https://tools.ietf.org/html/rfc3986#section-3.2.1)) in the proxy URL
-          are masked in the API response.
-
-          Containers do not automatically inherit this configuration.
-        type: "string"
-        example: "http://xxxxx:xxxxx@proxy.corp.example.com:8080"
-      HttpsProxy:
-        description: |
-          HTTPS-proxy configured for the daemon. This value is obtained from the
-          [`HTTPS_PROXY`](https://www.gnu.org/software/wget/manual/html_node/Proxies.html) environment variable.
-          Credentials ([user info component](https://tools.ietf.org/html/rfc3986#section-3.2.1)) in the proxy URL
-          are masked in the API response.
-
-          Containers do not automatically inherit this configuration.
-        type: "string"
-        example: "https://xxxxx:xxxxx@proxy.corp.example.com:4443"
-      NoProxy:
-        description: |
-          Comma-separated list of domain extensions for which no proxy should be
-          used. This value is obtained from the [`NO_PROXY`](https://www.gnu.org/software/wget/manual/html_node/Proxies.html)
-          environment variable.
-
-          Containers do not automatically inherit this configuration.
-        type: "string"
-        example: "*.local, 169.254/16"
-      Name:
-        description: "Hostname of the host."
-        type: "string"
-        example: "node5.corp.example.com"
-      Labels:
-        description: |
-          User-defined labels (key/value metadata) as set on the daemon.
-
-          <p><br /></p>
-
-          > **Note**: When part of a Swarm, nodes can both have _daemon_ labels,
-          > set through the daemon configuration, and _node_ labels, set from a
-          > manager node in the Swarm. Node labels are not included in this
-          > field. Node labels can be retrieved using the `/nodes/(id)` endpoint
-          > on a manager node in the Swarm.
-        type: "array"
-        items:
+    ContainerSummary:
+      type: "object"
+      properties:
+        Id:
+          description: "The ID of this container"
           type: "string"
-        example: ["storage=ssd", "production"]
-      ExperimentalBuild:
-        description: |
-          Indicates if experimental features are enabled on the daemon.
-        type: "boolean"
-        example: true
-      ServerVersion:
-        description: |
-          Version string of the daemon.
-        type: "string"
-        example: "24.0.2"
-      Runtimes:
-        description: |
-          List of [OCI compliant](https://github.com/opencontainers/runtime-spec)
-          runtimes configured on the daemon. Keys hold the "name" used to
-          reference the runtime.
-
-          The Docker daemon relies on an OCI compliant runtime (invoked via the
-          `containerd` daemon) as its interface to the Linux kernel namespaces,
-          cgroups, and SELinux.
-
-          The default runtime is `runc`, and automatically configured. Additional
-          runtimes can be configured by the user and will be listed here.
-        type: "object"
-        additionalProperties:
-          $ref: "#/definitions/Runtime"
-        default:
-          runc:
-            path: "runc"
-        example:
-          runc:
-            path: "runc"
-          runc-master:
-            path: "/go/bin/runc"
-          custom:
-            path: "/usr/local/bin/my-oci-runtime"
-            runtimeArgs: ["--debug", "--systemd-cgroup=false"]
-      DefaultRuntime:
-        description: |
-          Name of the default OCI runtime that is used when starting containers.
-
-          The default can be overridden per-container at create time.
-        type: "string"
-        default: "runc"
-        example: "runc"
-      Swarm:
-        $ref: "#/definitions/SwarmInfo"
-      LiveRestoreEnabled:
-        description: |
-          Indicates if live restore is enabled.
-
-          If enabled, containers are kept running when the daemon is shutdown
-          or upon daemon start if running containers are detected.
-        type: "boolean"
-        default: false
-        example: false
-      Isolation:
-        description: |
-          Represents the isolation technology to use as a default for containers.
-          The supported values are platform-specific.
-
-          If no isolation value is specified on daemon start, on Windows client,
-          the default is `hyperv`, and on Windows server, the default is `process`.
-
-          This option is currently not used on other platforms.
-        default: "default"
-        type: "string"
-        enum:
-          - "default"
-          - "hyperv"
-          - "process"
-      InitBinary:
-        description: |
-          Name and, optional, path of the `docker-init` binary.
-
-          If the path is omitted, the daemon searches the host's `$PATH` for the
-          binary and uses the first result.
-        type: "string"
-        example: "docker-init"
-      ContainerdCommit:
-        $ref: "#/definitions/Commit"
-      RuncCommit:
-        $ref: "#/definitions/Commit"
-      InitCommit:
-        $ref: "#/definitions/Commit"
-      SecurityOptions:
-        description: |
-          List of security features that are enabled on the daemon, such as
-          apparmor, seccomp, SELinux, user-namespaces (userns), rootless and
-          no-new-privileges.
-
-          Additional configuration options for each security feature may
-          be present, and are included as a comma-separated list of key/value
-          pairs.
-        type: "array"
-        items:
-          type: "string"
-        example:
-          - "name=apparmor"
-          - "name=seccomp,profile=default"
-          - "name=selinux"
-          - "name=userns"
-          - "name=rootless"
-      ProductLicense:
-        description: |
-          Reports a summary of the product license on the daemon.
-
-          If a commercial license has been applied to the daemon, information
-          such as number of nodes, and expiration are included.
-        type: "string"
-        example: "Community Engine"
-      DefaultAddressPools:
-        description: |
-          List of custom default address pools for local networks, which can be
-          specified in the daemon.json file or dockerd option.
-
-          Example: a Base "10.10.0.0/16" with Size 24 will define the set of 256
-          10.10.[0-255].0/24 address pools.
-        type: "array"
-        items:
-          type: "object"
-          properties:
-            Base:
-              description: "The network address in CIDR format"
-              type: "string"
-              example: "10.10.0.0/16"
-            Size:
-              description: "The network pool size"
-              type: "integer"
-              example: "24"
-      Warnings:
-        description: |
-          List of warnings / informational messages about missing features, or
-          issues related to the daemon configuration.
-
-          These messages can be printed by the client as information to the user.
-        type: "array"
-        items:
-          type: "string"
-        example:
-          - "WARNING: No memory limit support"
-          - "WARNING: bridge-nf-call-iptables is disabled"
-          - "WARNING: bridge-nf-call-ip6tables is disabled"
-      CDISpecDirs:
-        description: |
-          List of directories where (Container Device Interface) CDI
-          specifications are located.
-
-          These specifications define vendor-specific modifications to an OCI
-          runtime specification for a container being created.
-
-          An empty list indicates that CDI device injection is disabled.
-
-          Note that since using CDI device injection requires the daemon to have
-          experimental enabled. For non-experimental daemons an empty list will
-          always be returned.
-        type: "array"
-        items:
-          type: "string"
-        example:
-          - "/etc/cdi"
-          - "/var/run/cdi"
-
-  # PluginsInfo is a temp struct holding Plugins name
-  # registered with docker daemon. It is used by Info struct
-  PluginsInfo:
-    description: |
-      Available plugins per type.
-
-      <p><br /></p>
-
-      > **Note**: Only unmanaged (V1) plugins are included in this list.
-      > V1 plugins are "lazily" loaded, and are not returned in this list
-      > if there is no resource using the plugin.
-    type: "object"
-    properties:
-      Volume:
-        description: "Names of available volume-drivers, and network-driver plugins."
-        type: "array"
-        items:
-          type: "string"
-        example: ["local"]
-      Network:
-        description: "Names of available network-drivers, and network-driver plugins."
-        type: "array"
-        items:
-          type: "string"
-        example: ["bridge", "host", "ipvlan", "macvlan", "null", "overlay"]
-      Authorization:
-        description: "Names of available authorization plugins."
-        type: "array"
-        items:
-          type: "string"
-        example: ["img-authz-plugin", "hbm"]
-      Log:
-        description: "Names of available logging-drivers, and logging-driver plugins."
-        type: "array"
-        items:
-          type: "string"
-        example: ["awslogs", "fluentd", "gcplogs", "gelf", "journald", "json-file", "logentries", "splunk", "syslog"]
-
-
-  RegistryServiceConfig:
-    description: |
-      RegistryServiceConfig stores daemon registry services configuration.
-    type: "object"
-    x-nullable: true
-    properties:
-      AllowNondistributableArtifactsCIDRs:
-        description: |
-          List of IP ranges to which nondistributable artifacts can be pushed,
-          using the CIDR syntax [RFC 4632](https://tools.ietf.org/html/4632).
-
-          Some images (for example, Windows base images) contain artifacts
-          whose distribution is restricted by license. When these images are
-          pushed to a registry, restricted artifacts are not included.
-
-          This configuration override this behavior, and enables the daemon to
-          push nondistributable artifacts to all registries whose resolved IP
-          address is within the subnet described by the CIDR syntax.
-
-          This option is useful when pushing images containing
-          nondistributable artifacts to a registry on an air-gapped network so
-          hosts on that network can pull the images without connecting to
-          another server.
-
-          > **Warning**: Nondistributable artifacts typically have restrictions
-          > on how and where they can be distributed and shared. Only use this
-          > feature to push artifacts to private registries and ensure that you
-          > are in compliance with any terms that cover redistributing
-          > nondistributable artifacts.
-
-        type: "array"
-        items:
-          type: "string"
-        example: ["::1/128", "127.0.0.0/8"]
-      AllowNondistributableArtifactsHostnames:
-        description: |
-          List of registry hostnames to which nondistributable artifacts can be
-          pushed, using the format `<hostname>[:<port>]` or `<IP address>[:<port>]`.
-
-          Some images (for example, Windows base images) contain artifacts
-          whose distribution is restricted by license. When these images are
-          pushed to a registry, restricted artifacts are not included.
-
-          This configuration override this behavior for the specified
-          registries.
-
-          This option is useful when pushing images containing
-          nondistributable artifacts to a registry on an air-gapped network so
-          hosts on that network can pull the images without connecting to
-          another server.
-
-          > **Warning**: Nondistributable artifacts typically have restrictions
-          > on how and where they can be distributed and shared. Only use this
-          > feature to push artifacts to private registries and ensure that you
-          > are in compliance with any terms that cover redistributing
-          > nondistributable artifacts.
-        type: "array"
-        items:
-          type: "string"
-        example: ["registry.internal.corp.example.com:3000", "[2001:db8:a0b:12f0::1]:443"]
-      InsecureRegistryCIDRs:
-        description: |
-          List of IP ranges of insecure registries, using the CIDR syntax
-          ([RFC 4632](https://tools.ietf.org/html/4632)). Insecure registries
-          accept un-encrypted (HTTP) and/or untrusted (HTTPS with certificates
-          from unknown CAs) communication.
-
-          By default, local registries (`127.0.0.0/8`) are configured as
-          insecure. All other registries are secure. Communicating with an
-          insecure registry is not possible if the daemon assumes that registry
-          is secure.
-
-          This configuration override this behavior, insecure communication with
-          registries whose resolved IP address is within the subnet described by
-          the CIDR syntax.
-
-          Registries can also be marked insecure by hostname. Those registries
-          are listed under `IndexConfigs` and have their `Secure` field set to
-          `false`.
-
-          > **Warning**: Using this option can be useful when running a local
-          > registry, but introduces security vulnerabilities. This option
-          > should therefore ONLY be used for testing purposes. For increased
-          > security, users should add their CA to their system's list of trusted
-          > CAs instead of enabling this option.
-        type: "array"
-        items:
-          type: "string"
-        example: ["::1/128", "127.0.0.0/8"]
-      IndexConfigs:
-        type: "object"
-        additionalProperties:
-          $ref: "#/definitions/IndexInfo"
-        example:
-          "127.0.0.1:5000":
-            "Name": "127.0.0.1:5000"
-            "Mirrors": []
-            "Secure": false
-            "Official": false
-          "[2001:db8:a0b:12f0::1]:80":
-            "Name": "[2001:db8:a0b:12f0::1]:80"
-            "Mirrors": []
-            "Secure": false
-            "Official": false
-          "docker.io":
-            Name: "docker.io"
-            Mirrors: ["https://hub-mirror.corp.example.com:5000/"]
-            Secure: true
-            Official: true
-          "registry.internal.corp.example.com:3000":
-            Name: "registry.internal.corp.example.com:3000"
-            Mirrors: []
-            Secure: false
-            Official: false
-      Mirrors:
-        description: |
-          List of registry URLs that act as a mirror for the official
-          (`docker.io`) registry.
-
-        type: "array"
-        items:
-          type: "string"
-        example:
-          - "https://hub-mirror.corp.example.com:5000/"
-          - "https://[2001:db8:a0b:12f0::1]/"
-
-  IndexInfo:
-    description:
-      IndexInfo contains information about a registry.
-    type: "object"
-    x-nullable: true
-    properties:
-      Name:
-        description: |
-          Name of the registry, such as "docker.io".
-        type: "string"
-        example: "docker.io"
-      Mirrors:
-        description: |
-          List of mirrors, expressed as URIs.
-        type: "array"
-        items:
-          type: "string"
-        example:
-          - "https://hub-mirror.corp.example.com:5000/"
-          - "https://registry-2.docker.io/"
-          - "https://registry-3.docker.io/"
-      Secure:
-        description: |
-          Indicates if the registry is part of the list of insecure
-          registries.
-
-          If `false`, the registry is insecure. Insecure registries accept
-          un-encrypted (HTTP) and/or untrusted (HTTPS with certificates from
-          unknown CAs) communication.
-
-          > **Warning**: Insecure registries can be useful when running a local
-          > registry. However, because its use creates security vulnerabilities
-          > it should ONLY be enabled for testing purposes. For increased
-          > security, users should add their CA to their system's list of
-          > trusted CAs instead of enabling this option.
-        type: "boolean"
-        example: true
-      Official:
-        description: |
-          Indicates whether this is an official registry (i.e., Docker Hub / docker.io)
-        type: "boolean"
-        example: true
-
-  Runtime:
-    description: |
-      Runtime describes an [OCI compliant](https://github.com/opencontainers/runtime-spec)
-      runtime.
-
-      The runtime is invoked by the daemon via the `containerd` daemon. OCI
-      runtimes act as an interface to the Linux kernel namespaces, cgroups,
-      and SELinux.
-    type: "object"
-    properties:
-      path:
-        description: |
-          Name and, optional, path, of the OCI executable binary.
-
-          If the path is omitted, the daemon searches the host's `$PATH` for the
-          binary and uses the first result.
-        type: "string"
-        example: "/usr/local/bin/my-oci-runtime"
-      runtimeArgs:
-        description: |
-          List of command-line arguments to pass to the runtime when invoked.
-        type: "array"
-        x-nullable: true
-        items:
-          type: "string"
-        example: ["--debug", "--systemd-cgroup=false"]
-
-  Commit:
-    description: |
-      Commit holds the Git-commit (SHA1) that a binary was built from, as
-      reported in the version-string of external tools, such as `containerd`,
-      or `runC`.
-    type: "object"
-    properties:
-      ID:
-        description: "Actual commit ID of external tool."
-        type: "string"
-        example: "cfb82a876ecc11b5ca0977d1733adbe58599088a"
-      Expected:
-        description: |
-          Commit ID of external tool expected by dockerd as set at build time.
-        type: "string"
-        example: "2d41c047c83e09a6d61d464906feb2a2f3c52aa4"
-
-  SwarmInfo:
-    description: |
-      Represents generic information about swarm.
-    type: "object"
-    properties:
-      NodeID:
-        description: "Unique identifier of for this node in the swarm."
-        type: "string"
-        default: ""
-        example: "k67qz4598weg5unwwffg6z1m1"
-      NodeAddr:
-        description: |
-          IP address at which this node can be reached by other nodes in the
-          swarm.
-        type: "string"
-        default: ""
-        example: "10.0.0.46"
-      LocalNodeState:
-        $ref: "#/definitions/LocalNodeState"
-      ControlAvailable:
-        type: "boolean"
-        default: false
-        example: true
-      Error:
-        type: "string"
-        default: ""
-      RemoteManagers:
-        description: |
-          List of ID's and addresses of other managers in the swarm.
-        type: "array"
-        default: null
-        x-nullable: true
-        items:
-          $ref: "#/definitions/PeerNode"
-        example:
-          - NodeID: "71izy0goik036k48jg985xnds"
-            Addr: "10.0.0.158:2377"
-          - NodeID: "79y6h1o4gv8n120drcprv5nmc"
-            Addr: "10.0.0.159:2377"
-          - NodeID: "k67qz4598weg5unwwffg6z1m1"
-            Addr: "10.0.0.46:2377"
-      Nodes:
-        description: "Total number of nodes in the swarm."
-        type: "integer"
-        x-nullable: true
-        example: 4
-      Managers:
-        description: "Total number of managers in the swarm."
-        type: "integer"
-        x-nullable: true
-        example: 3
-      Cluster:
-        $ref: "#/definitions/ClusterInfo"
-
-  LocalNodeState:
-    description: "Current local status of this node."
-    type: "string"
-    default: ""
-    enum:
-      - ""
-      - "inactive"
-      - "pending"
-      - "active"
-      - "error"
-      - "locked"
-    example: "active"
-
-  PeerNode:
-    description: "Represents a peer-node in the swarm"
-    type: "object"
-    properties:
-      NodeID:
-        description: "Unique identifier of for this node in the swarm."
-        type: "string"
-      Addr:
-        description: |
-          IP address and ports at which this node can be reached.
-        type: "string"
-
-  NetworkAttachmentConfig:
-    description: |
-      Specifies how a service should be attached to a particular network.
-    type: "object"
-    properties:
-      Target:
-        description: |
-          The target network for attachment. Must be a network name or ID.
-        type: "string"
-      Aliases:
-        description: |
-          Discoverable alternate names for the service on this network.
-        type: "array"
-        items:
-          type: "string"
-      DriverOpts:
-        description: |
-          Driver attachment options for the network target.
-        type: "object"
-        additionalProperties:
-          type: "string"
-
-  EventActor:
-    description: |
-      Actor describes something that generates events, like a container, network,
-      or a volume.
-    type: "object"
-    properties:
-      ID:
-        description: "The ID of the object emitting the event"
-        type: "string"
-        example: "ede54ee1afda366ab42f824e8a5ffd195155d853ceaec74a927f249ea270c743"
-      Attributes:
-        description: |
-          Various key/value attributes of the object, depending on its type.
-        type: "object"
-        additionalProperties:
-          type: "string"
-        example:
-          com.example.some-label: "some-label-value"
-          image: "alpine:latest"
-          name: "my-container"
-
-  EventMessage:
-    description: |
-      EventMessage represents the information an event contains.
-    type: "object"
-    title: "SystemEventsResponse"
-    properties:
-      Type:
-        description: "The type of object emitting the event"
-        type: "string"
-        enum: ["builder", "config", "container", "daemon", "image", "network", "node", "plugin", "secret", "service", "volume"]
-        example: "container"
-      Action:
-        description: "The type of event"
-        type: "string"
-        example: "create"
-      Actor:
-        $ref: "#/definitions/EventActor"
-      scope:
-        description: |
-          Scope of the event. Engine events are `local` scope. Cluster (Swarm)
-          events are `swarm` scope.
-        type: "string"
-        enum: ["local", "swarm"]
-      time:
-        description: "Timestamp of event"
-        type: "integer"
-        format: "int64"
-        example: 1629574695
-      timeNano:
-        description: "Timestamp of event, with nanosecond accuracy"
-        type: "integer"
-        format: "int64"
-        example: 1629574695515050031
-
-  OCIDescriptor:
-    type: "object"
-    x-go-name: Descriptor
-    description: |
-      A descriptor struct containing digest, media type, and size, as defined in
-      the [OCI Content Descriptors Specification](https://github.com/opencontainers/image-spec/blob/v1.0.1/descriptor.md).
-    properties:
-      mediaType:
-        description: |
-          The media type of the object this schema refers to.
-        type: "string"
-        example: "application/vnd.docker.distribution.manifest.v2+json"
-      digest:
-        description: |
-          The digest of the targeted content.
-        type: "string"
-        example: "sha256:c0537ff6a5218ef531ece93d4984efc99bbf3f7497c0a7726c88e2bb7584dc96"
-      size:
-        description: |
-          The size in bytes of the blob.
-        type: "integer"
-        format: "int64"
-        example: 3987495
-        # TODO Not yet including these fields for now, as they are nil / omitted in our response.
-        # urls:
-        #   description: |
-        #     List of URLs from which this object MAY be downloaded.
-        #   type: "array"
-        #   items:
-        #     type: "string"
-        #     format: "uri"
-        # annotations:
-        #   description: |
-        #     Arbitrary metadata relating to the targeted content.
-        #   type: "object"
-        #   additionalProperties:
-        #     type: "string"
-        # platform:
-        #   $ref: "#/definitions/OCIPlatform"
-
-  OCIPlatform:
-    type: "object"
-    x-go-name: Platform
-    description: |
-      Describes the platform which the image in the manifest runs on, as defined
-      in the [OCI Image Index Specification](https://github.com/opencontainers/image-spec/blob/v1.0.1/image-index.md).
-    properties:
-      architecture:
-        description: |
-          The CPU architecture, for example `amd64` or `ppc64`.
-        type: "string"
-        example: "arm"
-      os:
-        description: |
-          The operating system, for example `linux` or `windows`.
-        type: "string"
-        example: "windows"
-      os.version:
-        description: |
-          Optional field specifying the operating system version, for example on
-          Windows `10.0.19041.1165`.
-        type: "string"
-        example: "10.0.19041.1165"
-      os.features:
-        description: |
-          Optional field specifying an array of strings, each listing a required
-          OS feature (for example on Windows `win32k`).
-        type: "array"
-        items:
-          type: "string"
-        example:
-          - "win32k"
-      variant:
-        description: |
-          Optional field specifying a variant of the CPU, for example `v7` to
-          specify ARMv7 when architecture is `arm`.
-        type: "string"
-        example: "v7"
-
-  DistributionInspect:
-    type: "object"
-    x-go-name: DistributionInspect
-    title: "DistributionInspectResponse"
-    required: [Descriptor, Platforms]
-    description: |
-      Describes the result obtained from contacting the registry to retrieve
-      image metadata.
-    properties:
-      Descriptor:
-        $ref: "#/definitions/OCIDescriptor"
-      Platforms:
-        type: "array"
-        description: |
-          An array containing all platforms supported by the image.
-        items:
-          $ref: "#/definitions/OCIPlatform"
-
-  ClusterVolume:
-    type: "object"
-    description: |
-      Options and information specific to, and only present on, Swarm CSI
-      cluster volumes.
-    properties:
-      ID:
-        type: "string"
-        description: |
-          The Swarm ID of this volume. Because cluster volumes are Swarm
-          objects, they have an ID, unlike non-cluster volumes. This ID can
-          be used to refer to the Volume instead of the name.
-      Version:
-        $ref: "#/definitions/ObjectVersion"
-      CreatedAt:
-        type: "string"
-        format: "dateTime"
-      UpdatedAt:
-        type: "string"
-        format: "dateTime"
-      Spec:
-        $ref: "#/definitions/ClusterVolumeSpec"
-      Info:
-        type: "object"
-        description: |
-          Information about the global status of the volume.
-        properties:
-          CapacityBytes:
-            type: "integer"
-            format: "int64"
-            description: |
-              The capacity of the volume in bytes. A value of 0 indicates that
-              the capacity is unknown.
-          VolumeContext:
-            type: "object"
-            description: |
-              A map of strings to strings returned from the storage plugin when
-              the volume is created.
-            additionalProperties:
-              type: "string"
-          VolumeID:
+          x-go-name: "ID"
+        Names:
+          description: "The names that this container has been given"
+          type: "array"
+          items:
             type: "string"
-            description: |
-              The ID of the volume as returned by the CSI storage plugin. This
-              is distinct from the volume's ID as provided by Docker. This ID
-              is never used by the user when communicating with Docker to refer
-              to this volume. If the ID is blank, then the Volume has not been
-              successfully created in the plugin yet.
-          AccessibleTopology:
-            type: "array"
-            description: |
-              The topology this volume is actually accessible from.
-            items:
-              $ref: "#/definitions/Topology"
-      PublishStatus:
-        type: "array"
-        description: |
-          The status of the volume as it pertains to its publishing and use on
-          specific nodes
-        items:
+        Image:
+          description: "The name of the image used when creating this container"
+          type: "string"
+        ImageID:
+          description: "The ID of the image that this container was created from"
+          type: "string"
+        Command:
+          description: "Command to run when starting the container"
+          type: "string"
+        Created:
+          description: "When the container was created"
+          type: "integer"
+          format: "int64"
+        Ports:
+          description: "The ports exposed by this container"
+          type: "array"
+          items:
+            $ref: "#/components/schemas/Port"
+        SizeRw:
+          description: "The size of files that have been created or changed by this container"
+          type: "integer"
+          format: "int64"
+        SizeRootFs:
+          description: "The total size of all the files in this container"
+          type: "integer"
+          format: "int64"
+        Labels:
+          description: "User-defined key/value metadata."
+          type: "object"
+          additionalProperties:
+            type: "string"
+        State:
+          description: "The state of this container (e.g. `Exited`)"
+          type: "string"
+        Status:
+          description: "Additional human-readable status of this container (e.g. `Exit 0`)"
+          type: "string"
+        HostConfig:
           type: "object"
           properties:
-            NodeID:
+            NetworkMode:
               type: "string"
-              description: |
-                The ID of the Swarm node the volume is published on.
-            State:
+        NetworkSettings:
+          description: "A summary of the container's network settings"
+          type: "object"
+          properties:
+            Networks:
+              type: "object"
+              additionalProperties:
+                $ref: "#/components/schemas/EndpointSettings"
+        Mounts:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/MountPoint"
+
+    Driver:
+      description: "Driver represents a driver (network, logging, secrets)."
+      type: "object"
+      required: [Name]
+      properties:
+        Name:
+          description: "Name of the driver."
+          type: "string"
+          nullable: false
+          x-nullable: false
+          example: "some-driver"
+        Options:
+          description: "Key/value map of driver-specific options."
+          type: "object"
+          nullable: false
+          x-nullable: false
+          additionalProperties:
+            type: "string"
+          example:
+            OptionA: "value for driver-specific option A"
+            OptionB: "value for driver-specific option B"
+
+    SecretSpec:
+      type: "object"
+      properties:
+        Name:
+          description: "User-defined name of the secret."
+          type: "string"
+        Labels:
+          description: "User-defined key/value metadata."
+          type: "object"
+          additionalProperties:
+            type: "string"
+          example:
+            com.example.some-label: "some-value"
+            com.example.some-other-label: "some-other-value"
+        Data:
+          description: |
+            Base64-url-safe-encoded ([RFC 4648](https://tools.ietf.org/html/rfc4648#section-5))
+            data to store as secret.
+
+            This field is only used to _create_ a secret, and is not returned by
+            other endpoints.
+          type: "string"
+          example: ""
+        Driver:
+# FIXME(thaJeztah): OpenAPI v3 does not allow a description here, so we need to find a different solution.
+#        description: |
+#          Name of the secrets driver used to fetch the secret's value from an
+#          external secret store.
+          $ref: "#/components/schemas/Driver"
+        Templating:
+# FIXME(thaJeztah): OpenAPI v3 does not allow a description here, so we need to find a different solution.
+#        description: |
+#          Templating driver, if applicable
+#
+#          Templating controls whether and how to evaluate the config payload as
+#          a template. If no driver is set, no templating is used.
+          $ref: "#/components/schemas/Driver"
+
+    Secret:
+      type: "object"
+      properties:
+        ID:
+          type: "string"
+          example: "blt1owaxmitz71s9v5zh81zun"
+        Version:
+          $ref: "#/components/schemas/ObjectVersion"
+        CreatedAt:
+          type: "string"
+          format: "dateTime"
+          example: "2017-07-20T13:55:28.678958722Z"
+        UpdatedAt:
+          type: "string"
+          format: "dateTime"
+          example: "2017-07-20T13:55:28.678958722Z"
+        Spec:
+          $ref: "#/components/schemas/SecretSpec"
+
+    ConfigSpec:
+      type: "object"
+      properties:
+        Name:
+          description: "User-defined name of the config."
+          type: "string"
+        Labels:
+          description: "User-defined key/value metadata."
+          type: "object"
+          additionalProperties:
+            type: "string"
+        Data:
+          description: |
+            Base64-url-safe-encoded ([RFC 4648](https://tools.ietf.org/html/rfc4648#section-5))
+            config data.
+          type: "string"
+        Templating:
+# FIXME(thaJeztah): OpenAPI v3 does not allow a description here, so we need to find a different solution.
+#        description: |
+#          Templating driver, if applicable
+#
+#          Templating controls whether and how to evaluate the config payload as
+#          a template. If no driver is set, no templating is used.
+          $ref: "#/components/schemas/Driver"
+
+    Config:
+      type: "object"
+      properties:
+        ID:
+          type: "string"
+        Version:
+          $ref: "#/components/schemas/ObjectVersion"
+        CreatedAt:
+          type: "string"
+          format: "dateTime"
+        UpdatedAt:
+          type: "string"
+          format: "dateTime"
+        Spec:
+          $ref: "#/components/schemas/ConfigSpec"
+
+    ContainerState:
+      description: |
+        ContainerState stores container's running state. It's part of ContainerJSONBase
+        and will be returned by the "inspect" command.
+      type: "object"
+      nullable: true
+      x-nullable: true
+      properties:
+        Status:
+          description: |
+            String representation of the container state. Can be one of "created",
+            "running", "paused", "restarting", "removing", "exited", or "dead".
+          type: "string"
+          enum: ["created", "running", "paused", "restarting", "removing", "exited", "dead"]
+          example: "running"
+        Running:
+          description: |
+            Whether this container is running.
+
+            Note that a running container can be _paused_. The `Running` and `Paused`
+            booleans are not mutually exclusive:
+
+            When pausing a container (on Linux), the freezer cgroup is used to suspend
+            all processes in the container. Freezing the process requires the process to
+            be running. As a result, paused containers are both `Running` _and_ `Paused`.
+
+            Use the `Status` field instead to determine if a container's state is "running".
+          type: "boolean"
+          example: true
+        Paused:
+          description: "Whether this container is paused."
+          type: "boolean"
+          example: false
+        Restarting:
+          description: "Whether this container is restarting."
+          type: "boolean"
+          example: false
+        OOMKilled:
+          description: |
+            Whether a process within this container has been killed because it ran
+            out of memory since the container was last started.
+          type: "boolean"
+          example: false
+        Dead:
+          type: "boolean"
+          example: false
+        Pid:
+          description: "The process ID of this container"
+          type: "integer"
+          example: 1234
+        ExitCode:
+          description: "The last exit code of this container"
+          type: "integer"
+          example: 0
+        Error:
+          type: "string"
+        StartedAt:
+          description: "The time when this container was last started."
+          type: "string"
+          example: "2020-01-06T09:06:59.461876391Z"
+        FinishedAt:
+          description: "The time when this container last exited."
+          type: "string"
+          example: "2020-01-06T09:07:59.461876391Z"
+        Health:
+          $ref: "#/components/schemas/Health"
+
+    ContainerCreateResponse:
+      description: "OK response to ContainerCreate operation"
+      type: "object"
+      title: "ContainerCreateResponse"
+      x-go-name: "CreateResponse"
+      required: [Id, Warnings]
+      properties:
+        Id:
+          description: "The ID of the created container"
+          type: "string"
+          nullable: false
+          x-nullable: false
+          example: "ede54ee1afda366ab42f824e8a5ffd195155d853ceaec74a927f249ea270c743"
+        Warnings:
+          description: "Warnings encountered when creating the container"
+          type: "array"
+          nullable: false
+          x-nullable: false
+          items:
+            type: "string"
+          example: []
+
+    ContainerWaitResponse:
+      description: "OK response to ContainerWait operation"
+      type: "object"
+      x-go-name: "WaitResponse"
+      title: "ContainerWaitResponse"
+      required: [StatusCode]
+      properties:
+        StatusCode:
+          description: "Exit code of the container"
+          type: "integer"
+          format: "int64"
+          nullable: false
+          x-nullable: false
+        Error:
+          $ref: "#/components/schemas/ContainerWaitExitError"
+
+    ContainerWaitExitError:
+      description: "container waiting error, if any"
+      type: "object"
+      x-go-name: "WaitExitError"
+      properties:
+        Message:
+          description: "Details of an error"
+          type: "string"
+
+    SystemVersion:
+      type: "object"
+      description: |
+        Response of Engine API: GET "/version"
+      properties:
+        Platform:
+          type: "object"
+          required: [Name]
+          properties:
+            Name:
               type: "string"
+        Components:
+          type: "array"
+          description: |
+            Information about system components
+          items:
+            type: "object"
+            x-go-name: ComponentVersion
+            required: [Name, Version]
+            properties:
+              Name:
+                description: |
+                  Name of the component
+                type: "string"
+                example: "Engine"
+              Version:
+                description: |
+                  Version of the component
+                type: "string"
+                nullable: false
+                x-nullable: false
+                example: "19.03.12"
+              Details:
+                description: |
+                  Key/value pairs of strings with additional information about the
+                  component. These values are intended for informational purposes
+                  only, and their content is not defined, and not part of the API
+                  specification.
+
+                  These messages can be printed by the client as information to the user.
+                type: "object"
+                properties: {}
+                nullable: true
+                x-nullable: true
+        Version:
+          description: "The version of the daemon"
+          type: "string"
+          example: "19.03.12"
+        ApiVersion:
+          description: |
+            The default (and highest) API version that is supported by the daemon
+          type: "string"
+          example: "1.40"
+        MinAPIVersion:
+          description: |
+            The minimum API version that is supported by the daemon
+          type: "string"
+          example: "1.12"
+        GitCommit:
+          description: |
+            The Git commit of the source code that was used to build the daemon
+          type: "string"
+          example: "48a66213fe"
+        GoVersion:
+          description: |
+            The version Go used to compile the daemon, and the version of the Go
+            runtime in use.
+          type: "string"
+          example: "go1.13.14"
+        Os:
+          description: |
+            The operating system that the daemon is running on ("linux" or "windows")
+          type: "string"
+          example: "linux"
+        Arch:
+          description: |
+            The architecture that the daemon is running on
+          type: "string"
+          example: "amd64"
+        KernelVersion:
+          description: |
+            The kernel version (`uname -r`) that the daemon is running on.
+
+            This field is omitted when empty.
+          type: "string"
+          example: "4.19.76-linuxkit"
+        Experimental:
+          description: |
+            Indicates if the daemon is started with experimental features enabled.
+
+            This field is omitted when empty / false.
+          type: "boolean"
+          example: true
+        BuildTime:
+          description: |
+            The date and time that the daemon was compiled.
+          type: "string"
+          example: "2020-06-22T15:49:27.000000000+00:00"
+
+    SystemInfo:
+      type: "object"
+      properties:
+        ID:
+          description: |
+            Unique identifier of the daemon.
+
+            <p><br /></p>
+
+            > **Note**: The format of the ID itself is not part of the API, and
+            > should not be considered stable.
+          type: "string"
+          example: "7TRN:IPZB:QYBB:VPBQ:UMPP:KARE:6ZNR:XE6T:7EWV:PKF4:ZOJD:TPYS"
+        Containers:
+          description: "Total number of containers on the host."
+          type: "integer"
+          example: 14
+        ContainersRunning:
+          description: |
+            Number of containers with status `"running"`.
+          type: "integer"
+          example: 3
+        ContainersPaused:
+          description: |
+            Number of containers with status `"paused"`.
+          type: "integer"
+          example: 1
+        ContainersStopped:
+          description: |
+            Number of containers with status `"stopped"`.
+          type: "integer"
+          example: 10
+        Images:
+          description: |
+            Total number of images on the host.
+
+            Both _tagged_ and _untagged_ (dangling) images are counted.
+          type: "integer"
+          example: 508
+        Driver:
+          description: "Name of the storage driver in use."
+          type: "string"
+          example: "overlay2"
+        DriverStatus:
+          description: |
+            Information specific to the storage driver, provided as
+            "label" / "value" pairs.
+
+            This information is provided by the storage driver, and formatted
+            in a way consistent with the output of `docker info` on the command
+            line.
+
+            <p><br /></p>
+
+            > **Note**: The information returned in this field, including the
+            > formatting of values and labels, should not be considered stable,
+            > and may change without notice.
+          type: "array"
+          items:
+            type: "array"
+            items:
+              type: "string"
+          example:
+            - ["Backing Filesystem", "extfs"]
+            - ["Supports d_type", "true"]
+            - ["Native Overlay Diff", "true"]
+        DockerRootDir:
+          description: |
+            Root directory of persistent Docker state.
+
+            Defaults to `/var/lib/docker` on Linux, and `C:\ProgramData\docker`
+            on Windows.
+          type: "string"
+          example: "/var/lib/docker"
+        Plugins:
+          $ref: "#/components/schemas/PluginsInfo"
+        MemoryLimit:
+          description: "Indicates if the host has memory limit support enabled."
+          type: "boolean"
+          example: true
+        SwapLimit:
+          description: "Indicates if the host has memory swap limit support enabled."
+          type: "boolean"
+          example: true
+        KernelMemoryTCP:
+          description: |
+            Indicates if the host has kernel memory TCP limit support enabled. This
+            field is omitted if not supported.
+
+            Kernel memory TCP limits are not supported when using cgroups v2, which
+            does not support the corresponding `memory.kmem.tcp.limit_in_bytes` cgroup.
+          type: "boolean"
+          example: true
+        CpuCfsPeriod:
+          description: |
+            Indicates if CPU CFS(Completely Fair Scheduler) period is supported by
+            the host.
+          type: "boolean"
+          example: true
+        CpuCfsQuota:
+          description: |
+            Indicates if CPU CFS(Completely Fair Scheduler) quota is supported by
+            the host.
+          type: "boolean"
+          example: true
+        CPUShares:
+          description: |
+            Indicates if CPU Shares limiting is supported by the host.
+          type: "boolean"
+          example: true
+        CPUSet:
+          description: |
+            Indicates if CPUsets (cpuset.cpus, cpuset.mems) are supported by the host.
+
+            See [cpuset(7)](https://www.kernel.org/doc/Documentation/cgroup-v1/cpusets.txt)
+          type: "boolean"
+          example: true
+        PidsLimit:
+          description: "Indicates if the host kernel has PID limit support enabled."
+          type: "boolean"
+          example: true
+        OomKillDisable:
+          description: "Indicates if OOM killer disable is supported on the host."
+          type: "boolean"
+        IPv4Forwarding:
+          description: "Indicates IPv4 forwarding is enabled."
+          type: "boolean"
+          example: true
+        BridgeNfIptables:
+          description: "Indicates if `bridge-nf-call-iptables` is available on the host."
+          type: "boolean"
+          example: true
+        BridgeNfIp6tables:
+          description: "Indicates if `bridge-nf-call-ip6tables` is available on the host."
+          type: "boolean"
+          example: true
+        Debug:
+          description: |
+            Indicates if the daemon is running in debug-mode / with debug-level
+            logging enabled.
+          type: "boolean"
+          example: true
+        NFd:
+          description: |
+            The total number of file Descriptors in use by the daemon process.
+
+            This information is only returned if debug-mode is enabled.
+          type: "integer"
+          example: 64
+        NGoroutines:
+          description: |
+            The  number of goroutines that currently exist.
+
+            This information is only returned if debug-mode is enabled.
+          type: "integer"
+          example: 174
+        SystemTime:
+          description: |
+            Current system-time in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt)
+            format with nano-seconds.
+          type: "string"
+          example: "2017-08-08T20:28:29.06202363Z"
+        LoggingDriver:
+          description: |
+            The logging driver to use as a default for new containers.
+          type: "string"
+        CgroupDriver:
+          description: |
+            The driver to use for managing cgroups.
+          type: "string"
+          enum: ["cgroupfs", "systemd", "none"]
+          default: "cgroupfs"
+          example: "cgroupfs"
+        CgroupVersion:
+          description: |
+            The version of the cgroup.
+          type: "string"
+          enum: ["1", "2"]
+          default: "1"
+          example: "1"
+        NEventsListener:
+          description: "Number of event listeners subscribed."
+          type: "integer"
+          example: 30
+        KernelVersion:
+          description: |
+            Kernel version of the host.
+
+            On Linux, this information obtained from `uname`. On Windows this
+            information is queried from the <kbd>HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\</kbd>
+            registry value, for example _"10.0 14393 (14393.1198.amd64fre.rs1_release_sec.170427-1353)"_.
+          type: "string"
+          example: "4.9.38-moby"
+        OperatingSystem:
+          description: |
+            Name of the host's operating system, for example: "Ubuntu 16.04.2 LTS"
+            or "Windows Server 2016 Datacenter"
+          type: "string"
+          example: "Alpine Linux v3.5"
+        OSVersion:
+          description: |
+            Version of the host's operating system
+
+            <p><br /></p>
+
+            > **Note**: The information returned in this field, including its
+            > very existence, and the formatting of values, should not be considered
+            > stable, and may change without notice.
+          type: "string"
+          example: "16.04"
+        OSType:
+          description: |
+            Generic type of the operating system of the host, as returned by the
+            Go runtime (`GOOS`).
+
+            Currently returned values are "linux" and "windows". A full list of
+            possible values can be found in the [Go documentation](https://go.dev/doc/install/source#environment).
+          type: "string"
+          example: "linux"
+        Architecture:
+          description: |
+            Hardware architecture of the host, as returned by the Go runtime
+            (`GOARCH`).
+
+            A full list of possible values can be found in the [Go documentation](https://go.dev/doc/install/source#environment).
+          type: "string"
+          example: "x86_64"
+        NCPU:
+          description: |
+            The number of logical CPUs usable by the daemon.
+
+            The number of available CPUs is checked by querying the operating
+            system when the daemon starts. Changes to operating system CPU
+            allocation after the daemon is started are not reflected.
+          type: "integer"
+          example: 4
+        MemTotal:
+          description: |
+            Total amount of physical memory available on the host, in bytes.
+          type: "integer"
+          format: "int64"
+          example: 2095882240
+
+        IndexServerAddress:
+          description: |
+            Address / URL of the index server that is used for image search,
+            and as a default for user authentication for Docker Hub and Docker Cloud.
+          default: "https://index.docker.io/v1/"
+          type: "string"
+          example: "https://index.docker.io/v1/"
+        RegistryConfig:
+          $ref: "#/components/schemas/RegistryServiceConfig"
+        GenericResources:
+          $ref: "#/components/schemas/GenericResources"
+        HttpProxy:
+          description: |
+            HTTP-proxy configured for the daemon. This value is obtained from the
+            [`HTTP_PROXY`](https://www.gnu.org/software/wget/manual/html_node/Proxies.html) environment variable.
+            Credentials ([user info component](https://tools.ietf.org/html/rfc3986#section-3.2.1)) in the proxy URL
+            are masked in the API response.
+
+            Containers do not automatically inherit this configuration.
+          type: "string"
+          example: "http://xxxxx:xxxxx@proxy.corp.example.com:8080"
+        HttpsProxy:
+          description: |
+            HTTPS-proxy configured for the daemon. This value is obtained from the
+            [`HTTPS_PROXY`](https://www.gnu.org/software/wget/manual/html_node/Proxies.html) environment variable.
+            Credentials ([user info component](https://tools.ietf.org/html/rfc3986#section-3.2.1)) in the proxy URL
+            are masked in the API response.
+
+            Containers do not automatically inherit this configuration.
+          type: "string"
+          example: "https://xxxxx:xxxxx@proxy.corp.example.com:4443"
+        NoProxy:
+          description: |
+            Comma-separated list of domain extensions for which no proxy should be
+            used. This value is obtained from the [`NO_PROXY`](https://www.gnu.org/software/wget/manual/html_node/Proxies.html)
+            environment variable.
+
+            Containers do not automatically inherit this configuration.
+          type: "string"
+          example: "*.local, 169.254/16"
+        Name:
+          description: "Hostname of the host."
+          type: "string"
+          example: "node5.corp.example.com"
+        Labels:
+          description: |
+            User-defined labels (key/value metadata) as set on the daemon.
+
+            <p><br /></p>
+
+            > **Note**: When part of a Swarm, nodes can both have _daemon_ labels,
+            > set through the daemon configuration, and _node_ labels, set from a
+            > manager node in the Swarm. Node labels are not included in this
+            > field. Node labels can be retrieved using the `/nodes/(id)` endpoint
+            > on a manager node in the Swarm.
+          type: "array"
+          items:
+            type: "string"
+          example: ["storage=ssd", "production"]
+        ExperimentalBuild:
+          description: |
+            Indicates if experimental features are enabled on the daemon.
+          type: "boolean"
+          example: true
+        ServerVersion:
+          description: |
+            Version string of the daemon.
+          type: "string"
+          example: "24.0.2"
+        Runtimes:
+          description: |
+            List of [OCI compliant](https://github.com/opencontainers/runtime-spec)
+            runtimes configured on the daemon. Keys hold the "name" used to
+            reference the runtime.
+
+            The Docker daemon relies on an OCI compliant runtime (invoked via the
+            `containerd` daemon) as its interface to the Linux kernel namespaces,
+            cgroups, and SELinux.
+
+            The default runtime is `runc`, and automatically configured. Additional
+            runtimes can be configured by the user and will be listed here.
+          type: "object"
+          additionalProperties:
+            $ref: "#/components/schemas/Runtime"
+          default:
+            runc:
+              path: "runc"
+          example:
+            runc:
+              path: "runc"
+            runc-master:
+              path: "/go/bin/runc"
+            custom:
+              path: "/usr/local/bin/my-oci-runtime"
+              runtimeArgs: ["--debug", "--systemd-cgroup=false"]
+        DefaultRuntime:
+          description: |
+            Name of the default OCI runtime that is used when starting containers.
+
+            The default can be overridden per-container at create time.
+          type: "string"
+          default: "runc"
+          example: "runc"
+        Swarm:
+          $ref: "#/components/schemas/SwarmInfo"
+        LiveRestoreEnabled:
+          description: |
+            Indicates if live restore is enabled.
+
+            If enabled, containers are kept running when the daemon is shutdown
+            or upon daemon start if running containers are detected.
+          type: "boolean"
+          default: false
+          example: false
+        Isolation:
+          description: |
+            Represents the isolation technology to use as a default for containers.
+            The supported values are platform-specific.
+
+            If no isolation value is specified on daemon start, on Windows client,
+            the default is `hyperv`, and on Windows server, the default is `process`.
+
+            This option is currently not used on other platforms.
+          default: "default"
+          type: "string"
+          enum:
+            - "default"
+            - "hyperv"
+            - "process"
+        InitBinary:
+          description: |
+            Name and, optional, path of the `docker-init` binary.
+
+            If the path is omitted, the daemon searches the host's `$PATH` for the
+            binary and uses the first result.
+          type: "string"
+          example: "docker-init"
+        ContainerdCommit:
+          $ref: "#/components/schemas/Commit"
+        RuncCommit:
+          $ref: "#/components/schemas/Commit"
+        InitCommit:
+          $ref: "#/components/schemas/Commit"
+        SecurityOptions:
+          description: |
+            List of security features that are enabled on the daemon, such as
+            apparmor, seccomp, SELinux, user-namespaces (userns), rootless and
+            no-new-privileges.
+
+            Additional configuration options for each security feature may
+            be present, and are included as a comma-separated list of key/value
+            pairs.
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "name=apparmor"
+            - "name=seccomp,profile=default"
+            - "name=selinux"
+            - "name=userns"
+            - "name=rootless"
+        ProductLicense:
+          description: |
+            Reports a summary of the product license on the daemon.
+
+            If a commercial license has been applied to the daemon, information
+            such as number of nodes, and expiration are included.
+          type: "string"
+          example: "Community Engine"
+        DefaultAddressPools:
+          description: |
+            List of custom default address pools for local networks, which can be
+            specified in the daemon.json file or dockerd option.
+
+            Example: a Base "10.10.0.0/16" with Size 24 will define the set of 256
+            10.10.[0-255].0/24 address pools.
+          type: "array"
+          items:
+            type: "object"
+            properties:
+              Base:
+                description: "The network address in CIDR format"
+                type: "string"
+                example: "10.10.0.0/16"
+              Size:
+                description: "The network pool size"
+                type: "integer"
+                example: "24"
+        Warnings:
+          description: |
+            List of warnings / informational messages about missing features, or
+            issues related to the daemon configuration.
+
+            These messages can be printed by the client as information to the user.
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "WARNING: No memory limit support"
+            - "WARNING: bridge-nf-call-iptables is disabled"
+            - "WARNING: bridge-nf-call-ip6tables is disabled"
+        CDISpecDirs:
+          description: |
+            List of directories where (Container Device Interface) CDI
+            specifications are located.
+
+            These specifications define vendor-specific modifications to an OCI
+            runtime specification for a container being created.
+
+            An empty list indicates that CDI device injection is disabled.
+
+            Note that since using CDI device injection requires the daemon to have
+            experimental enabled. For non-experimental daemons an empty list will
+            always be returned.
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "/etc/cdi"
+            - "/var/run/cdi"
+
+    # PluginsInfo is a temp struct holding Plugins name
+    # registered with docker daemon. It is used by Info struct
+    PluginsInfo:
+      description: |
+        Available plugins per type.
+  
+        <p><br /></p>
+  
+        > **Note**: Only unmanaged (V1) plugins are included in this list.
+        > V1 plugins are "lazily" loaded, and are not returned in this list
+        > if there is no resource using the plugin.
+      type: "object"
+      properties:
+        Volume:
+          description: "Names of available volume-drivers, and network-driver plugins."
+          type: "array"
+          items:
+            type: "string"
+          example: ["local"]
+        Network:
+          description: "Names of available network-drivers, and network-driver plugins."
+          type: "array"
+          items:
+            type: "string"
+          example: ["bridge", "host", "ipvlan", "macvlan", "null", "overlay"]
+        Authorization:
+          description: "Names of available authorization plugins."
+          type: "array"
+          items:
+            type: "string"
+          example: ["img-authz-plugin", "hbm"]
+        Log:
+          description: "Names of available logging-drivers, and logging-driver plugins."
+          type: "array"
+          items:
+            type: "string"
+          example: ["awslogs", "fluentd", "gcplogs", "gelf", "journald", "json-file", "logentries", "splunk", "syslog"]
+
+
+    RegistryServiceConfig:
+      description: |
+        RegistryServiceConfig stores daemon registry services configuration.
+      type: "object"
+      nullable: true
+      x-nullable: true
+      properties:
+        AllowNondistributableArtifactsCIDRs:
+          description: |
+            List of IP ranges to which nondistributable artifacts can be pushed,
+            using the CIDR syntax [RFC 4632](https://tools.ietf.org/html/4632).
+
+            Some images (for example, Windows base images) contain artifacts
+            whose distribution is restricted by license. When these images are
+            pushed to a registry, restricted artifacts are not included.
+
+            This configuration override this behavior, and enables the daemon to
+            push nondistributable artifacts to all registries whose resolved IP
+            address is within the subnet described by the CIDR syntax.
+
+            This option is useful when pushing images containing
+            nondistributable artifacts to a registry on an air-gapped network so
+            hosts on that network can pull the images without connecting to
+            another server.
+
+            > **Warning**: Nondistributable artifacts typically have restrictions
+            > on how and where they can be distributed and shared. Only use this
+            > feature to push artifacts to private registries and ensure that you
+            > are in compliance with any terms that cover redistributing
+            > nondistributable artifacts.
+
+          type: "array"
+          items:
+            type: "string"
+          example: ["::1/128", "127.0.0.0/8"]
+        AllowNondistributableArtifactsHostnames:
+          description: |
+            List of registry hostnames to which nondistributable artifacts can be
+            pushed, using the format `<hostname>[:<port>]` or `<IP address>[:<port>]`.
+
+            Some images (for example, Windows base images) contain artifacts
+            whose distribution is restricted by license. When these images are
+            pushed to a registry, restricted artifacts are not included.
+
+            This configuration override this behavior for the specified
+            registries.
+
+            This option is useful when pushing images containing
+            nondistributable artifacts to a registry on an air-gapped network so
+            hosts on that network can pull the images without connecting to
+            another server.
+
+            > **Warning**: Nondistributable artifacts typically have restrictions
+            > on how and where they can be distributed and shared. Only use this
+            > feature to push artifacts to private registries and ensure that you
+            > are in compliance with any terms that cover redistributing
+            > nondistributable artifacts.
+          type: "array"
+          items:
+            type: "string"
+          example: ["registry.internal.corp.example.com:3000", "[2001:db8:a0b:12f0::1]:443"]
+        InsecureRegistryCIDRs:
+          description: |
+            List of IP ranges of insecure registries, using the CIDR syntax
+            ([RFC 4632](https://tools.ietf.org/html/4632)). Insecure registries
+            accept un-encrypted (HTTP) and/or untrusted (HTTPS with certificates
+            from unknown CAs) communication.
+
+            By default, local registries (`127.0.0.0/8`) are configured as
+            insecure. All other registries are secure. Communicating with an
+            insecure registry is not possible if the daemon assumes that registry
+            is secure.
+
+            This configuration override this behavior, insecure communication with
+            registries whose resolved IP address is within the subnet described by
+            the CIDR syntax.
+
+            Registries can also be marked insecure by hostname. Those registries
+            are listed under `IndexConfigs` and have their `Secure` field set to
+            `false`.
+
+            > **Warning**: Using this option can be useful when running a local
+            > registry, but introduces security vulnerabilities. This option
+            > should therefore ONLY be used for testing purposes. For increased
+            > security, users should add their CA to their system's list of trusted
+            > CAs instead of enabling this option.
+          type: "array"
+          items:
+            type: "string"
+          example: ["::1/128", "127.0.0.0/8"]
+        IndexConfigs:
+          type: "object"
+          additionalProperties:
+            $ref: "#/components/schemas/IndexInfo"
+          example:
+            "127.0.0.1:5000":
+              "Name": "127.0.0.1:5000"
+              "Mirrors": []
+              "Secure": false
+              "Official": false
+            "[2001:db8:a0b:12f0::1]:80":
+              "Name": "[2001:db8:a0b:12f0::1]:80"
+              "Mirrors": []
+              "Secure": false
+              "Official": false
+            "docker.io":
+              Name: "docker.io"
+              Mirrors: ["https://hub-mirror.corp.example.com:5000/"]
+              Secure: true
+              Official: true
+            "registry.internal.corp.example.com:3000":
+              Name: "registry.internal.corp.example.com:3000"
+              Mirrors: []
+              Secure: false
+              Official: false
+        Mirrors:
+          description: |
+            List of registry URLs that act as a mirror for the official
+            (`docker.io`) registry.
+
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "https://hub-mirror.corp.example.com:5000/"
+            - "https://[2001:db8:a0b:12f0::1]/"
+
+    IndexInfo:
+      description:
+        IndexInfo contains information about a registry.
+      type: "object"
+      nullable: true
+      x-nullable: true
+      properties:
+        Name:
+          description: |
+            Name of the registry, such as "docker.io".
+          type: "string"
+          example: "docker.io"
+        Mirrors:
+          description: |
+            List of mirrors, expressed as URIs.
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "https://hub-mirror.corp.example.com:5000/"
+            - "https://registry-2.docker.io/"
+            - "https://registry-3.docker.io/"
+        Secure:
+          description: |
+            Indicates if the registry is part of the list of insecure
+            registries.
+
+            If `false`, the registry is insecure. Insecure registries accept
+            un-encrypted (HTTP) and/or untrusted (HTTPS with certificates from
+            unknown CAs) communication.
+
+            > **Warning**: Insecure registries can be useful when running a local
+            > registry. However, because its use creates security vulnerabilities
+            > it should ONLY be enabled for testing purposes. For increased
+            > security, users should add their CA to their system's list of
+            > trusted CAs instead of enabling this option.
+          type: "boolean"
+          example: true
+        Official:
+          description: |
+            Indicates whether this is an official registry (i.e., Docker Hub / docker.io)
+          type: "boolean"
+          example: true
+
+    Runtime:
+      description: |
+        Runtime describes an [OCI compliant](https://github.com/opencontainers/runtime-spec)
+        runtime.
+  
+        The runtime is invoked by the daemon via the `containerd` daemon. OCI
+        runtimes act as an interface to the Linux kernel namespaces, cgroups,
+        and SELinux.
+      type: "object"
+      properties:
+        path:
+          description: |
+            Name and, optional, path, of the OCI executable binary.
+
+            If the path is omitted, the daemon searches the host's `$PATH` for the
+            binary and uses the first result.
+          type: "string"
+          example: "/usr/local/bin/my-oci-runtime"
+        runtimeArgs:
+          description: |
+            List of command-line arguments to pass to the runtime when invoked.
+          type: "array"
+          nullable: true
+          x-nullable: true
+          items:
+            type: "string"
+          example: ["--debug", "--systemd-cgroup=false"]
+
+    Commit:
+      description: |
+        Commit holds the Git-commit (SHA1) that a binary was built from, as
+        reported in the version-string of external tools, such as `containerd`,
+        or `runC`.
+      type: "object"
+      properties:
+        ID:
+          description: "Actual commit ID of external tool."
+          type: "string"
+          example: "cfb82a876ecc11b5ca0977d1733adbe58599088a"
+        Expected:
+          description: |
+            Commit ID of external tool expected by dockerd as set at build time.
+          type: "string"
+          example: "2d41c047c83e09a6d61d464906feb2a2f3c52aa4"
+
+    SwarmInfo:
+      description: |
+        Represents generic information about swarm.
+      type: "object"
+      properties:
+        NodeID:
+          description: "Unique identifier of for this node in the swarm."
+          type: "string"
+          default: ""
+          example: "k67qz4598weg5unwwffg6z1m1"
+        NodeAddr:
+          description: |
+            IP address at which this node can be reached by other nodes in the
+            swarm.
+          type: "string"
+          default: ""
+          example: "10.0.0.46"
+        LocalNodeState:
+          $ref: "#/components/schemas/LocalNodeState"
+        ControlAvailable:
+          type: "boolean"
+          default: false
+          example: true
+        Error:
+          type: "string"
+          default: ""
+        RemoteManagers:
+          description: |
+            List of ID's and addresses of other managers in the swarm.
+          type: "array"
+          default: null
+          nullable: true
+          x-nullable: true
+          items:
+            $ref: "#/components/schemas/PeerNode"
+          example:
+            - NodeID: "71izy0goik036k48jg985xnds"
+              Addr: "10.0.0.158:2377"
+            - NodeID: "79y6h1o4gv8n120drcprv5nmc"
+              Addr: "10.0.0.159:2377"
+            - NodeID: "k67qz4598weg5unwwffg6z1m1"
+              Addr: "10.0.0.46:2377"
+        Nodes:
+          description: "Total number of nodes in the swarm."
+          type: "integer"
+          nullable: true
+          x-nullable: true
+          example: 4
+        Managers:
+          description: "Total number of managers in the swarm."
+          type: "integer"
+          nullable: true
+          x-nullable: true
+          example: 3
+        Cluster:
+          $ref: "#/components/schemas/ClusterInfo"
+
+    LocalNodeState:
+      description: "Current local status of this node."
+      type: "string"
+      default: ""
+      enum:
+        - ""
+        - "inactive"
+        - "pending"
+        - "active"
+        - "error"
+        - "locked"
+      example: "active"
+
+    PeerNode:
+      description: "Represents a peer-node in the swarm"
+      type: "object"
+      properties:
+        NodeID:
+          description: "Unique identifier of for this node in the swarm."
+          type: "string"
+        Addr:
+          description: |
+            IP address and ports at which this node can be reached.
+          type: "string"
+
+    NetworkAttachmentConfig:
+      description: |
+        Specifies how a service should be attached to a particular network.
+      type: "object"
+      properties:
+        Target:
+          description: |
+            The target network for attachment. Must be a network name or ID.
+          type: "string"
+        Aliases:
+          description: |
+            Discoverable alternate names for the service on this network.
+          type: "array"
+          items:
+            type: "string"
+        DriverOpts:
+          description: |
+            Driver attachment options for the network target.
+          type: "object"
+          additionalProperties:
+            type: "string"
+
+    EventActor:
+      description: |
+        Actor describes something that generates events, like a container, network,
+        or a volume.
+      type: "object"
+      properties:
+        ID:
+          description: "The ID of the object emitting the event"
+          type: "string"
+          example: "ede54ee1afda366ab42f824e8a5ffd195155d853ceaec74a927f249ea270c743"
+        Attributes:
+          description: |
+            Various key/value attributes of the object, depending on its type.
+          type: "object"
+          additionalProperties:
+            type: "string"
+          example:
+            com.example.some-label: "some-label-value"
+            image: "alpine:latest"
+            name: "my-container"
+
+    EventMessage:
+      description: |
+        EventMessage represents the information an event contains.
+      type: "object"
+      title: "SystemEventsResponse"
+      properties:
+        Type:
+          description: "The type of object emitting the event"
+          type: "string"
+          enum: ["builder", "config", "container", "daemon", "image", "network", "node", "plugin", "secret", "service", "volume"]
+          example: "container"
+        Action:
+          description: "The type of event"
+          type: "string"
+          example: "create"
+        Actor:
+          $ref: "#/components/schemas/EventActor"
+        scope:
+          description: |
+            Scope of the event. Engine events are `local` scope. Cluster (Swarm)
+            events are `swarm` scope.
+          type: "string"
+          enum: ["local", "swarm"]
+        time:
+          description: "Timestamp of event"
+          type: "integer"
+          format: "int64"
+          example: 1629574695
+        timeNano:
+          description: "Timestamp of event, with nanosecond accuracy"
+          type: "integer"
+          format: "int64"
+          example: 1629574695515050031
+
+    OCIDescriptor:
+      type: "object"
+      x-go-name: Descriptor
+      description: |
+        A descriptor struct containing digest, media type, and size, as defined in
+        the [OCI Content Descriptors Specification](https://github.com/opencontainers/image-spec/blob/v1.0.1/descriptor.md).
+      properties:
+        mediaType:
+          description: |
+            The media type of the object this schema refers to.
+          type: "string"
+          example: "application/vnd.docker.distribution.manifest.v2+json"
+        digest:
+          description: |
+            The digest of the targeted content.
+          type: "string"
+          example: "sha256:c0537ff6a5218ef531ece93d4984efc99bbf3f7497c0a7726c88e2bb7584dc96"
+        size:
+          description: |
+            The size in bytes of the blob.
+          type: "integer"
+          format: "int64"
+          example: 3987495
+          # TODO Not yet including these fields for now, as they are nil / omitted in our response.
+          # urls:
+          #   description: |
+          #     List of URLs from which this object MAY be downloaded.
+          #   type: "array"
+          #   items:
+          #     type: "string"
+          #     format: "uri"
+          # annotations:
+          #   description: |
+          #     Arbitrary metadata relating to the targeted content.
+          #   type: "object"
+          #   additionalProperties:
+          #     type: "string"
+          # platform:
+          #   $ref: "#/components/schemas/OCIPlatform"
+
+    OCIPlatform:
+      type: "object"
+      x-go-name: Platform
+      description: |
+        Describes the platform which the image in the manifest runs on, as defined
+        in the [OCI Image Index Specification](https://github.com/opencontainers/image-spec/blob/v1.0.1/image-index.md).
+      properties:
+        architecture:
+          description: |
+            The CPU architecture, for example `amd64` or `ppc64`.
+          type: "string"
+          example: "arm"
+        os:
+          description: |
+            The operating system, for example `linux` or `windows`.
+          type: "string"
+          example: "windows"
+        os.version:
+          description: |
+            Optional field specifying the operating system version, for example on
+            Windows `10.0.19041.1165`.
+          type: "string"
+          example: "10.0.19041.1165"
+        os.features:
+          description: |
+            Optional field specifying an array of strings, each listing a required
+            OS feature (for example on Windows `win32k`).
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "win32k"
+        variant:
+          description: |
+            Optional field specifying a variant of the CPU, for example `v7` to
+            specify ARMv7 when architecture is `arm`.
+          type: "string"
+          example: "v7"
+
+    DistributionInspect:
+      type: "object"
+      x-go-name: DistributionInspect
+      title: "DistributionInspectResponse"
+      required: [Descriptor, Platforms]
+      description: |
+        Describes the result obtained from contacting the registry to retrieve
+        image metadata.
+      properties:
+        Descriptor:
+          $ref: "#/components/schemas/OCIDescriptor"
+        Platforms:
+          type: "array"
+          description: |
+            An array containing all platforms supported by the image.
+          items:
+            $ref: "#/components/schemas/OCIPlatform"
+
+    ClusterVolume:
+      type: "object"
+      description: |
+        Options and information specific to, and only present on, Swarm CSI
+        cluster volumes.
+      properties:
+        ID:
+          type: "string"
+          description: |
+            The Swarm ID of this volume. Because cluster volumes are Swarm
+            objects, they have an ID, unlike non-cluster volumes. This ID can
+            be used to refer to the Volume instead of the name.
+        Version:
+          $ref: "#/components/schemas/ObjectVersion"
+        CreatedAt:
+          type: "string"
+          format: "dateTime"
+        UpdatedAt:
+          type: "string"
+          format: "dateTime"
+        Spec:
+          $ref: "#/components/schemas/ClusterVolumeSpec"
+        Info:
+          type: "object"
+          description: |
+            Information about the global status of the volume.
+          properties:
+            CapacityBytes:
+              type: "integer"
+              format: "int64"
               description: |
-                The published state of the volume.
-                * `pending-publish` The volume should be published to this node, but the call to the controller plugin to do so has not yet been successfully completed.
-                * `published` The volume is published successfully to the node.
-                * `pending-node-unpublish` The volume should be unpublished from the node, and the manager is awaiting confirmation from the worker that it has done so.
-                * `pending-controller-unpublish` The volume is successfully unpublished from the node, but has not yet been successfully unpublished on the controller.
-              enum:
-                - "pending-publish"
-                - "published"
-                - "pending-node-unpublish"
-                - "pending-controller-unpublish"
-            PublishContext:
+                The capacity of the volume in bytes. A value of 0 indicates that
+                the capacity is unknown.
+            VolumeContext:
               type: "object"
               description: |
-                A map of strings to strings returned by the CSI controller
-                plugin when a volume is published.
+                A map of strings to strings returned from the storage plugin when
+                the volume is created.
               additionalProperties:
                 type: "string"
-
-  ClusterVolumeSpec:
-    type: "object"
-    description: |
-      Cluster-specific options used to create the volume.
-    properties:
-      Group:
-        type: "string"
-        description: |
-          Group defines the volume group of this volume. Volumes belonging to
-          the same group can be referred to by group name when creating
-          Services.  Referring to a volume by group instructs Swarm to treat
-          volumes in that group interchangeably for the purpose of scheduling.
-          Volumes with an empty string for a group technically all belong to
-          the same, emptystring group.
-      AccessMode:
-        type: "object"
-        description: |
-          Defines how the volume is used by tasks.
-        properties:
-          Scope:
-            type: "string"
-            description: |
-              The set of nodes this volume can be used on at one time.
-              - `single` The volume may only be scheduled to one node at a time.
-              - `multi` the volume may be scheduled to any supported number of nodes at a time.
-            default: "single"
-            enum: ["single", "multi"]
-            x-nullable: false
-          Sharing:
-            type: "string"
-            description: |
-              The number and way that different tasks can use this volume
-              at one time.
-              - `none` The volume may only be used by one task at a time.
-              - `readonly` The volume may be used by any number of tasks, but they all must mount the volume as readonly
-              - `onewriter` The volume may be used by any number of tasks, but only one may mount it as read/write.
-              - `all` The volume may have any number of readers and writers.
-            default: "none"
-            enum: ["none", "readonly", "onewriter", "all"]
-            x-nullable: false
-          MountVolume:
+            VolumeID:
+              type: "string"
+              description: |
+                The ID of the volume as returned by the CSI storage plugin. This
+                is distinct from the volume's ID as provided by Docker. This ID
+                is never used by the user when communicating with Docker to refer
+                to this volume. If the ID is blank, then the Volume has not been
+                successfully created in the plugin yet.
+            AccessibleTopology:
+              type: "array"
+              description: |
+                The topology this volume is actually accessible from.
+              items:
+                $ref: "#/components/schemas/Topology"
+        PublishStatus:
+          type: "array"
+          description: |
+            The status of the volume as it pertains to its publishing and use on
+            specific nodes
+          items:
             type: "object"
-            description: |
-              Options for using this volume as a Mount-type volume.
-
-                  Either MountVolume or BlockVolume, but not both, must be
-                  present.
-                properties:
-                  FsType:
-                    type: "string"
-                    description: |
-                      Specifies the filesystem type for the mount volume.
-                      Optional.
-                  MountFlags:
-                    type: "array"
-                    description: |
-                      Flags to pass when mounting the volume. Optional.
-                    items:
-                      type: "string"
-              BlockVolume:
+            properties:
+              NodeID:
+                type: "string"
+                description: |
+                  The ID of the Swarm node the volume is published on.
+              State:
+                type: "string"
+                description: |
+                  The published state of the volume.
+                  * `pending-publish` The volume should be published to this node, but the call to the controller plugin to do so has not yet been successfully completed.
+                  * `published` The volume is published successfully to the node.
+                  * `pending-node-unpublish` The volume should be unpublished from the node, and the manager is awaiting confirmation from the worker that it has done so.
+                  * `pending-controller-unpublish` The volume is successfully unpublished from the node, but has not yet been successfully unpublished on the controller.
+                enum:
+                  - "pending-publish"
+                  - "published"
+                  - "pending-node-unpublish"
+                  - "pending-controller-unpublish"
+              PublishContext:
                 type: "object"
                 description: |
-                  Options for using this volume as a Block-type volume.
-                  Intentionally empty.
-          Secrets:
-            type: "array"
-            description: |
-              Swarm Secrets that are passed to the CSI storage plugin when
-              operating on this volume.
-            items:
+                  A map of strings to strings returned by the CSI controller
+                  plugin when a volume is published.
+                additionalProperties:
+                  type: "string"
+
+    ClusterVolumeSpec:
+      type: "object"
+      description: |
+        Cluster-specific options used to create the volume.
+      properties:
+        Group:
+          type: "string"
+          description: |
+            Group defines the volume group of this volume. Volumes belonging to
+            the same group can be referred to by group name when creating
+            Services.  Referring to a volume by group instructs Swarm to treat
+            volumes in that group interchangeably for the purpose of scheduling.
+            Volumes with an empty string for a group technically all belong to
+            the same, emptystring group.
+        AccessMode:
+          type: "object"
+          description: |
+            Defines how the volume is used by tasks.
+          properties:
+            Scope:
+              type: "string"
+              description: |
+                The set of nodes this volume can be used on at one time.
+                - `single` The volume may only be scheduled to one node at a time.
+                - `multi` the volume may be scheduled to any supported number of nodes at a time.
+              default: "single"
+              enum: ["single", "multi"]
+              nullable: false
+              x-nullable: false
+            Sharing:
+              type: "string"
+              description: |
+                The number and way that different tasks can use this volume
+                at one time.
+                - `none` The volume may only be used by one task at a time.
+                - `readonly` The volume may be used by any number of tasks, but they all must mount the volume as readonly
+                - `onewriter` The volume may be used by any number of tasks, but only one may mount it as read/write.
+                - `all` The volume may have any number of readers and writers.
+              default: "none"
+              enum: ["none", "readonly", "onewriter", "all"]
+              nullable: false
+              x-nullable: false
+            MountVolume:
+              type: "object"
+              properties: {}
+              description: |
+                Options for using this volume as a Mount-type volume.
+
+                    Either MountVolume or BlockVolume, but not both, must be
+                    present.
+                  properties:
+                    FsType:
+                      type: "string"
+                      description: |
+                        Specifies the filesystem type for the mount volume.
+                        Optional.
+                    MountFlags:
+                      type: "array"
+                      description: |
+                        Flags to pass when mounting the volume. Optional.
+                      items:
+                        type: "string"
+                BlockVolume:
+                  type: "object"
+                  description: |
+                    Options for using this volume as a Block-type volume.
+                    Intentionally empty.
+            Secrets:
+              type: "array"
+              description: |
+                Swarm Secrets that are passed to the CSI storage plugin when
+                operating on this volume.
+              items:
+                type: "object"
+                description: |
+                  One cluster volume secret entry. Defines a key-value pair that
+                  is passed to the plugin.
+                properties:
+                  Key:
+                    type: "string"
+                    description: |
+                      Key is the name of the key of the key-value pair passed to
+                      the plugin.
+                  Secret:
+                    type: "string"
+                    description: |
+                      Secret is the swarm Secret object from which to read data.
+                      This can be a Secret name or ID. The Secret data is
+                      retrieved by swarm and used as the value of the key-value
+                      pair passed to the plugin.
+            AccessibilityRequirements:
               type: "object"
               description: |
-                One cluster volume secret entry. Defines a key-value pair that
-                is passed to the plugin.
+                Requirements for the accessible topology of the volume. These
+                fields are optional. For an in-depth description of what these
+                fields mean, see the CSI specification.
               properties:
-                Key:
-                  type: "string"
+                Requisite:
+                  type: "array"
                   description: |
-                    Key is the name of the key of the key-value pair passed to
-                    the plugin.
-                Secret:
-                  type: "string"
+                    A list of required topologies, at least one of which the
+                    volume must be accessible from.
+                  items:
+                    $ref: "#/components/schemas/Topology"
+                Preferred:
+                  type: "array"
                   description: |
-                    Secret is the swarm Secret object from which to read data.
-                    This can be a Secret name or ID. The Secret data is
-                    retrieved by swarm and used as the value of the key-value
-                    pair passed to the plugin.
-          AccessibilityRequirements:
-            type: "object"
-            description: |
-              Requirements for the accessible topology of the volume. These
-              fields are optional. For an in-depth description of what these
-              fields mean, see the CSI specification.
-            properties:
-              Requisite:
-                type: "array"
-                description: |
-                  A list of required topologies, at least one of which the
-                  volume must be accessible from.
-                items:
-                  $ref: "#/definitions/Topology"
-              Preferred:
-                type: "array"
-                description: |
-                  A list of topologies that the volume should attempt to be
-                  provisioned in.
-                items:
-                  $ref: "#/definitions/Topology"
-          CapacityRange:
-            type: "object"
-            description: |
-              The desired capacity that the volume should be created with. If
-              empty, the plugin will decide the capacity.
-            properties:
-              RequiredBytes:
-                type: "integer"
-                format: "int64"
-                description: |
-                  The volume must be at least this big. The value of 0
-                  indicates an unspecified minimum
-              LimitBytes:
-                type: "integer"
-                format: "int64"
-                description: |
-                  The volume must not be bigger than this. The value of 0
-                  indicates an unspecified maximum.
-          Availability:
-            type: "string"
-            description: |
-              The availability of the volume for use in tasks.
-              - `active` The volume is fully available for scheduling on the cluster
-              - `pause` No new workloads should use the volume, but existing workloads are not stopped.
-              - `drain` All workloads using this volume should be stopped and rescheduled, and no new ones should be started.
-            default: "active"
-            x-nullable: false
-            enum:
-              - "active"
-              - "pause"
-              - "drain"
+                    A list of topologies that the volume should attempt to be
+                    provisioned in.
+                  items:
+                    $ref: "#/components/schemas/Topology"
+            CapacityRange:
+              type: "object"
+              description: |
+                The desired capacity that the volume should be created with. If
+                empty, the plugin will decide the capacity.
+              properties:
+                RequiredBytes:
+                  type: "integer"
+                  format: "int64"
+                  description: |
+                    The volume must be at least this big. The value of 0
+                    indicates an unspecified minimum
+                LimitBytes:
+                  type: "integer"
+                  format: "int64"
+                  description: |
+                    The volume must not be bigger than this. The value of 0
+                    indicates an unspecified maximum.
+            Availability:
+              type: "string"
+              description: |
+                The availability of the volume for use in tasks.
+                - `active` The volume is fully available for scheduling on the cluster
+                - `pause` No new workloads should use the volume, but existing workloads are not stopped.
+                - `drain` All workloads using this volume should be stopped and rescheduled, and no new ones should be started.
+              default: "active"
+              nullable: false
+              x-nullable: false
+              enum:
+                - "active"
+                - "pause"
+                - "drain"
 
-  Topology:
-    description: |
-      A map of topological domains to topological segments. For in depth
-      details, see documentation for the Topology object in the CSI
-      specification.
-    type: "object"
-    additionalProperties:
-      type: "string"
+    Topology:
+      description: |
+        A map of topological domains to topological segments. For in depth
+        details, see documentation for the Topology object in the CSI
+        specification.
+      type: "object"
+      additionalProperties:
+        type: "string"
 
 paths:
   /containers/json:
@@ -6074,27 +6199,28 @@ paths:
         than inspecting a single container. For example, the list of linked
         containers is not propagated .
       operationId: "ContainerList"
-      produces:
-        - "application/json"
       parameters:
         - name: "all"
           in: "query"
           description: |
             Return all containers. By default, only running containers are shown.
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "limit"
           in: "query"
           description: |
             Return this number of most recently created containers, including
             non-running ones.
-          type: "integer"
+          schema:
+            type: "integer"
         - name: "size"
           in: "query"
           description: |
             Return the size of container as fields `SizeRw` and `SizeRootFs`.
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "filters"
           in: "query"
           description: |
@@ -6119,167 +6245,169 @@ paths:
             - `since`=(`<container id>` or `<container name>`)
             - `status=`(`created`|`restarting`|`running`|`removing`|`paused`|`exited`|`dead`)
             - `volume`=(`<volume name>` or `<mount point destination>`)
-          type: "string"
+          schema:
+            type: "string"
       responses:
         200:
           description: "no error"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/ContainerSummary"
-          examples:
+          content:
             application/json:
-              - Id: "8dfafdbc3a40"
-                Names:
-                  - "/boring_feynman"
-                Image: "ubuntu:latest"
-                ImageID: "d74508fb6632491cea586a1fd7d748dfc5274cd6fdfedee309ecdcbc2bf5cb82"
-                Command: "echo 1"
-                Created: 1367854155
-                State: "Exited"
-                Status: "Exit 0"
-                Ports:
-                  - PrivatePort: 2222
-                    PublicPort: 3333
-                    Type: "tcp"
-                Labels:
-                  com.example.vendor: "Acme"
-                  com.example.license: "GPL"
-                  com.example.version: "1.0"
-                SizeRw: 12288
-                SizeRootFs: 0
-                HostConfig:
-                  NetworkMode: "default"
-                NetworkSettings:
-                  Networks:
-                    bridge:
-                      NetworkID: "7ea29fc1412292a2d7bba362f9253545fecdfa8ce9a6e37dd10ba8bee7129812"
-                      EndpointID: "2cdc4edb1ded3631c81f57966563e5c8525b81121bb3706a9a9a3ae102711f3f"
-                      Gateway: "172.17.0.1"
-                      IPAddress: "172.17.0.2"
-                      IPPrefixLen: 16
-                      IPv6Gateway: ""
-                      GlobalIPv6Address: ""
-                      GlobalIPv6PrefixLen: 0
-                      MacAddress: "02:42:ac:11:00:02"
-                Mounts:
-                  - Name: "fac362...80535"
-                    Source: "/data"
-                    Destination: "/data"
-                    Driver: "local"
-                    Mode: "ro,Z"
-                    RW: false
-                    Propagation: ""
-              - Id: "9cd87474be90"
-                Names:
-                  - "/coolName"
-                Image: "ubuntu:latest"
-                ImageID: "d74508fb6632491cea586a1fd7d748dfc5274cd6fdfedee309ecdcbc2bf5cb82"
-                Command: "echo 222222"
-                Created: 1367854155
-                State: "Exited"
-                Status: "Exit 0"
-                Ports: []
-                Labels: {}
-                SizeRw: 12288
-                SizeRootFs: 0
-                HostConfig:
-                  NetworkMode: "default"
-                NetworkSettings:
-                  Networks:
-                    bridge:
-                      NetworkID: "7ea29fc1412292a2d7bba362f9253545fecdfa8ce9a6e37dd10ba8bee7129812"
-                      EndpointID: "88eaed7b37b38c2a3f0c4bc796494fdf51b270c2d22656412a2ca5d559a64d7a"
-                      Gateway: "172.17.0.1"
-                      IPAddress: "172.17.0.8"
-                      IPPrefixLen: 16
-                      IPv6Gateway: ""
-                      GlobalIPv6Address: ""
-                      GlobalIPv6PrefixLen: 0
-                      MacAddress: "02:42:ac:11:00:08"
-                Mounts: []
-              - Id: "3176a2479c92"
-                Names:
-                  - "/sleepy_dog"
-                Image: "ubuntu:latest"
-                ImageID: "d74508fb6632491cea586a1fd7d748dfc5274cd6fdfedee309ecdcbc2bf5cb82"
-                Command: "echo 3333333333333333"
-                Created: 1367854154
-                State: "Exited"
-                Status: "Exit 0"
-                Ports: []
-                Labels: {}
-                SizeRw: 12288
-                SizeRootFs: 0
-                HostConfig:
-                  NetworkMode: "default"
-                NetworkSettings:
-                  Networks:
-                    bridge:
-                      NetworkID: "7ea29fc1412292a2d7bba362f9253545fecdfa8ce9a6e37dd10ba8bee7129812"
-                      EndpointID: "8b27c041c30326d59cd6e6f510d4f8d1d570a228466f956edf7815508f78e30d"
-                      Gateway: "172.17.0.1"
-                      IPAddress: "172.17.0.6"
-                      IPPrefixLen: 16
-                      IPv6Gateway: ""
-                      GlobalIPv6Address: ""
-                      GlobalIPv6PrefixLen: 0
-                      MacAddress: "02:42:ac:11:00:06"
-                Mounts: []
-              - Id: "4cb07b47f9fb"
-                Names:
-                  - "/running_cat"
-                Image: "ubuntu:latest"
-                ImageID: "d74508fb6632491cea586a1fd7d748dfc5274cd6fdfedee309ecdcbc2bf5cb82"
-                Command: "echo 444444444444444444444444444444444"
-                Created: 1367854152
-                State: "Exited"
-                Status: "Exit 0"
-                Ports: []
-                Labels: {}
-                SizeRw: 12288
-                SizeRootFs: 0
-                HostConfig:
-                  NetworkMode: "default"
-                NetworkSettings:
-                  Networks:
-                    bridge:
-                      NetworkID: "7ea29fc1412292a2d7bba362f9253545fecdfa8ce9a6e37dd10ba8bee7129812"
-                      EndpointID: "d91c7b2f0644403d7ef3095985ea0e2370325cd2332ff3a3225c4247328e66e9"
-                      Gateway: "172.17.0.1"
-                      IPAddress: "172.17.0.5"
-                      IPPrefixLen: 16
-                      IPv6Gateway: ""
-                      GlobalIPv6Address: ""
-                      GlobalIPv6PrefixLen: 0
-                      MacAddress: "02:42:ac:11:00:05"
-                Mounts: []
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/ContainerSummary"
+              example:
+                - Id: "8dfafdbc3a40"
+                  Names:
+                    - "/boring_feynman"
+                  Image: "ubuntu:latest"
+                  ImageID: "d74508fb6632491cea586a1fd7d748dfc5274cd6fdfedee309ecdcbc2bf5cb82"
+                  Command: "echo 1"
+                  Created: 1367854155
+                  State: "Exited"
+                  Status: "Exit 0"
+                  Ports:
+                    - PrivatePort: 2222
+                      PublicPort: 3333
+                      Type: "tcp"
+                  Labels:
+                    com.example.vendor: "Acme"
+                    com.example.license: "GPL"
+                    com.example.version: "1.0"
+                  SizeRw: 12288
+                  SizeRootFs: 0
+                  HostConfig:
+                    NetworkMode: "default"
+                  NetworkSettings:
+                    Networks:
+                      bridge:
+                        NetworkID: "7ea29fc1412292a2d7bba362f9253545fecdfa8ce9a6e37dd10ba8bee7129812"
+                        EndpointID: "2cdc4edb1ded3631c81f57966563e5c8525b81121bb3706a9a9a3ae102711f3f"
+                        Gateway: "172.17.0.1"
+                        IPAddress: "172.17.0.2"
+                        IPPrefixLen: 16
+                        IPv6Gateway: ""
+                        GlobalIPv6Address: ""
+                        GlobalIPv6PrefixLen: 0
+                        MacAddress: "02:42:ac:11:00:02"
+                  Mounts:
+                    - Name: "fac362...80535"
+                      Source: "/data"
+                      Destination: "/data"
+                      Driver: "local"
+                      Mode: "ro,Z"
+                      RW: false
+                      Propagation: ""
+                - Id: "9cd87474be90"
+                  Names:
+                    - "/coolName"
+                  Image: "ubuntu:latest"
+                  ImageID: "d74508fb6632491cea586a1fd7d748dfc5274cd6fdfedee309ecdcbc2bf5cb82"
+                  Command: "echo 222222"
+                  Created: 1367854155
+                  State: "Exited"
+                  Status: "Exit 0"
+                  Ports: []
+                  Labels: {}
+                  SizeRw: 12288
+                  SizeRootFs: 0
+                  HostConfig:
+                    NetworkMode: "default"
+                  NetworkSettings:
+                    Networks:
+                      bridge:
+                        NetworkID: "7ea29fc1412292a2d7bba362f9253545fecdfa8ce9a6e37dd10ba8bee7129812"
+                        EndpointID: "88eaed7b37b38c2a3f0c4bc796494fdf51b270c2d22656412a2ca5d559a64d7a"
+                        Gateway: "172.17.0.1"
+                        IPAddress: "172.17.0.8"
+                        IPPrefixLen: 16
+                        IPv6Gateway: ""
+                        GlobalIPv6Address: ""
+                        GlobalIPv6PrefixLen: 0
+                        MacAddress: "02:42:ac:11:00:08"
+                  Mounts: []
+                - Id: "3176a2479c92"
+                  Names:
+                    - "/sleepy_dog"
+                  Image: "ubuntu:latest"
+                  ImageID: "d74508fb6632491cea586a1fd7d748dfc5274cd6fdfedee309ecdcbc2bf5cb82"
+                  Command: "echo 3333333333333333"
+                  Created: 1367854154
+                  State: "Exited"
+                  Status: "Exit 0"
+                  Ports: []
+                  Labels: {}
+                  SizeRw: 12288
+                  SizeRootFs: 0
+                  HostConfig:
+                    NetworkMode: "default"
+                  NetworkSettings:
+                    Networks:
+                      bridge:
+                        NetworkID: "7ea29fc1412292a2d7bba362f9253545fecdfa8ce9a6e37dd10ba8bee7129812"
+                        EndpointID: "8b27c041c30326d59cd6e6f510d4f8d1d570a228466f956edf7815508f78e30d"
+                        Gateway: "172.17.0.1"
+                        IPAddress: "172.17.0.6"
+                        IPPrefixLen: 16
+                        IPv6Gateway: ""
+                        GlobalIPv6Address: ""
+                        GlobalIPv6PrefixLen: 0
+                        MacAddress: "02:42:ac:11:00:06"
+                  Mounts: []
+                - Id: "4cb07b47f9fb"
+                  Names:
+                    - "/running_cat"
+                  Image: "ubuntu:latest"
+                  ImageID: "d74508fb6632491cea586a1fd7d748dfc5274cd6fdfedee309ecdcbc2bf5cb82"
+                  Command: "echo 444444444444444444444444444444444"
+                  Created: 1367854152
+                  State: "Exited"
+                  Status: "Exit 0"
+                  Ports: []
+                  Labels: {}
+                  SizeRw: 12288
+                  SizeRootFs: 0
+                  HostConfig:
+                    NetworkMode: "default"
+                  NetworkSettings:
+                    Networks:
+                      bridge:
+                        NetworkID: "7ea29fc1412292a2d7bba362f9253545fecdfa8ce9a6e37dd10ba8bee7129812"
+                        EndpointID: "d91c7b2f0644403d7ef3095985ea0e2370325cd2332ff3a3225c4247328e66e9"
+                        Gateway: "172.17.0.1"
+                        IPAddress: "172.17.0.5"
+                        IPPrefixLen: 16
+                        IPv6Gateway: ""
+                        GlobalIPv6Address: ""
+                        GlobalIPv6PrefixLen: 0
+                        MacAddress: "02:42:ac:11:00:05"
+                  Mounts: []
         400:
           description: "bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       tags: ["Container"]
   /containers/create:
     post:
       summary: "Create a container"
       operationId: "ContainerCreate"
-      consumes:
-        - "application/json"
-        - "application/octet-stream"
-      produces:
-        - "application/json"
       parameters:
         - name: "name"
           in: "query"
           description: |
             Assign the specified name to the container. Must match
             `/?[a-zA-Z0-9][a-zA-Z0-9_.-]+`.
-          type: "string"
-          pattern: "^/?[a-zA-Z0-9][a-zA-Z0-9_.-]+$"
+          schema:
+            type: "string"
+            pattern: "^/?[a-zA-Z0-9][a-zA-Z0-9_.-]+$"
         - name: "platform"
           in: "query"
           description: |
@@ -6300,20 +6428,23 @@ paths:
                          match the detected host platform (linux/amd64) and no
                          specific platform was requested
 
-          type: "string"
-          default: ""
-        - name: "body"
-          in: "body"
-          description: "Container to create"
           schema:
-            allOf:
-              - $ref: "#/definitions/ContainerConfig"
-              - type: "object"
-                properties:
-                  HostConfig:
-                    $ref: "#/definitions/HostConfig"
-                  NetworkingConfig:
-                    $ref: "#/definitions/NetworkingConfig"
+            type: "string"
+            default: ""
+      x-codegen-request-body-name: "body"
+      requestBody:
+        description: "Container to create"
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/ContainerConfig"
+                - type: "object"
+                  properties:
+                    HostConfig:
+                      $ref: "#/components/schemas/HostConfig"
+                    NetworkingConfig:
+                      $ref: "#/components/schemas/NetworkingConfig"
             example:
               Hostname: ""
               Domainname: ""
@@ -6440,296 +6571,310 @@ paths:
                       - "server_x"
                       - "server_y"
 
-          required: true
+        required: true
       responses:
         201:
           description: "Container created successfully"
-          schema:
-            $ref: "#/definitions/ContainerCreateResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ContainerCreateResponse"
         400:
           description: "bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         404:
           description: "no such image"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such image: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such image: c2ada9df5af8"
         409:
           description: "conflict"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       tags: ["Container"]
   /containers/{id}/json:
     get:
       summary: "Inspect a container"
       description: "Return low-level information about a container."
       operationId: "ContainerInspect"
-      produces:
-        - "application/json"
       responses:
         200:
           description: "no error"
-          schema:
-            type: "object"
-            title: "ContainerInspectResponse"
-            properties:
-              Id:
-                description: "The ID of the container"
-                type: "string"
-              Created:
-                description: "The time the container was created"
-                type: "string"
-              Path:
-                description: "The path to the command being run"
-                type: "string"
-              Args:
-                description: "The arguments to the command being run"
-                type: "array"
-                items:
-                  type: "string"
-              State:
-                $ref: "#/definitions/ContainerState"
-              Image:
-                description: "The container's image ID"
-                type: "string"
-              ResolvConfPath:
-                type: "string"
-              HostnamePath:
-                type: "string"
-              HostsPath:
-                type: "string"
-              LogPath:
-                type: "string"
-              Name:
-                type: "string"
-              RestartCount:
-                type: "integer"
-              Driver:
-                type: "string"
-              Platform:
-                type: "string"
-              MountLabel:
-                type: "string"
-              ProcessLabel:
-                type: "string"
-              AppArmorProfile:
-                type: "string"
-              ExecIDs:
-                description: "IDs of exec instances that are running in the container."
-                type: "array"
-                items:
-                  type: "string"
-                x-nullable: true
-              HostConfig:
-                $ref: "#/definitions/HostConfig"
-              GraphDriver:
-                $ref: "#/definitions/GraphDriverData"
-              SizeRw:
-                description: |
-                  The size of files that have been created or changed by this
-                  container.
-                type: "integer"
-                format: "int64"
-              SizeRootFs:
-                description: "The total size of all the files in this container."
-                type: "integer"
-                format: "int64"
-              Mounts:
-                type: "array"
-                items:
-                  $ref: "#/definitions/MountPoint"
-              Config:
-                $ref: "#/definitions/ContainerConfig"
-              NetworkSettings:
-                $ref: "#/definitions/NetworkSettings"
-          examples:
+          content:
             application/json:
-              AppArmorProfile: ""
-              Args:
-                - "-c"
-                - "exit 9"
-              Config:
-                AttachStderr: true
-                AttachStdin: false
-                AttachStdout: true
-                Cmd:
-                  - "/bin/sh"
+              schema:
+                type: "object"
+                title: "ContainerInspectResponse"
+                properties:
+                  Id:
+                    description: "The ID of the container"
+                    type: "string"
+                  Created:
+                    description: "The time the container was created"
+                    type: "string"
+                  Path:
+                    description: "The path to the command being run"
+                    type: "string"
+                  Args:
+                    description: "The arguments to the command being run"
+                    type: "array"
+                    items:
+                      type: "string"
+                  State:
+                    $ref: "#/components/schemas/ContainerState"
+                  Image:
+                    description: "The container's image ID"
+                    type: "string"
+                  ResolvConfPath:
+                    type: "string"
+                  HostnamePath:
+                    type: "string"
+                  HostsPath:
+                    type: "string"
+                  LogPath:
+                    type: "string"
+                  Name:
+                    type: "string"
+                  RestartCount:
+                    type: "integer"
+                  Driver:
+                    type: "string"
+                  Platform:
+                    type: "string"
+                  MountLabel:
+                    type: "string"
+                  ProcessLabel:
+                    type: "string"
+                  AppArmorProfile:
+                    type: "string"
+                  ExecIDs:
+                    description: "IDs of exec instances that are running in the container."
+                    type: "array"
+                    items:
+                      type: "string"
+                    nullable: true
+                    x-nullable: true
+                  HostConfig:
+                    $ref: "#/components/schemas/HostConfig"
+                  GraphDriver:
+                    $ref: "#/components/schemas/GraphDriverData"
+                  SizeRw:
+                    description: |
+                      The size of files that have been created or changed by this
+                      container.
+                    type: "integer"
+                    format: "int64"
+                  SizeRootFs:
+                    description: "The total size of all the files in this container."
+                    type: "integer"
+                    format: "int64"
+                  Mounts:
+                    type: "array"
+                    items:
+                      $ref: "#/components/schemas/MountPoint"
+                  Config:
+                    $ref: "#/components/schemas/ContainerConfig"
+                  NetworkSettings:
+                    $ref: "#/components/schemas/NetworkSettings"
+              example:
+                AppArmorProfile: ""
+                Args:
                   - "-c"
                   - "exit 9"
-                Domainname: ""
-                Env:
-                  - "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-                Healthcheck:
-                  Test: ["CMD-SHELL", "exit 0"]
-                Hostname: "ba033ac44011"
-                Image: "ubuntu"
-                Labels:
-                  com.example.vendor: "Acme"
-                  com.example.license: "GPL"
-                  com.example.version: "1.0"
-                MacAddress: ""
-                NetworkDisabled: false
-                OpenStdin: false
-                StdinOnce: false
-                Tty: false
-                User: ""
-                Volumes:
-                  /volumes/data: {}
-                WorkingDir: ""
-                StopSignal: "SIGTERM"
-                StopTimeout: 10
-              Created: "2015-01-06T15:47:31.485331387Z"
-              Driver: "overlay2"
-              ExecIDs:
-                - "b35395de42bc8abd327f9dd65d913b9ba28c74d2f0734eeeae84fa1c616a0fca"
-                - "3fc1232e5cd20c8de182ed81178503dc6437f4e7ef12b52cc5e8de020652f1c4"
-              HostConfig:
-                MaximumIOps: 0
-                MaximumIOBps: 0
-                BlkioWeight: 0
-                BlkioWeightDevice:
-                  - {}
-                BlkioDeviceReadBps:
-                  - {}
-                BlkioDeviceWriteBps:
-                  - {}
-                BlkioDeviceReadIOps:
-                  - {}
-                BlkioDeviceWriteIOps:
-                  - {}
-                ContainerIDFile: ""
-                CpusetCpus: ""
-                CpusetMems: ""
-                CpuPercent: 80
-                CpuShares: 0
-                CpuPeriod: 100000
-                CpuRealtimePeriod: 1000000
-                CpuRealtimeRuntime: 10000
-                Devices: []
-                DeviceRequests:
-                  - Driver: "nvidia"
-                    Count: -1
-                    DeviceIDs": ["0", "1", "GPU-fef8089b-4820-abfc-e83e-94318197576e"]
-                    Capabilities: [["gpu", "nvidia", "compute"]]
-                    Options:
-                      property1: "string"
-                      property2: "string"
-                IpcMode: ""
-                Memory: 0
-                MemorySwap: 0
-                MemoryReservation: 0
-                OomKillDisable: false
-                OomScoreAdj: 500
-                NetworkMode: "bridge"
-                PidMode: ""
-                PortBindings: {}
-                Privileged: false
-                ReadonlyRootfs: false
-                PublishAllPorts: false
-                RestartPolicy:
-                  MaximumRetryCount: 2
-                  Name: "on-failure"
-                LogConfig:
-                  Type: "json-file"
-                Sysctls:
-                  net.ipv4.ip_forward: "1"
-                Ulimits:
-                  - {}
-                VolumeDriver: ""
-                ShmSize: 67108864
-              HostnamePath: "/var/lib/docker/containers/ba033ac4401106a3b513bc9d639eee123ad78ca3616b921167cd74b20e25ed39/hostname"
-              HostsPath: "/var/lib/docker/containers/ba033ac4401106a3b513bc9d639eee123ad78ca3616b921167cd74b20e25ed39/hosts"
-              LogPath: "/var/lib/docker/containers/1eb5fabf5a03807136561b3c00adcd2992b535d624d5e18b6cdc6a6844d9767b/1eb5fabf5a03807136561b3c00adcd2992b535d624d5e18b6cdc6a6844d9767b-json.log"
-              Id: "ba033ac4401106a3b513bc9d639eee123ad78ca3616b921167cd74b20e25ed39"
-              Image: "04c5d3b7b0656168630d3ba35d8889bd0e9caafcaeb3004d2bfbc47e7c5d35d2"
-              MountLabel: ""
-              Name: "/boring_euclid"
-              NetworkSettings:
-                Bridge: ""
-                SandboxID: ""
-                HairpinMode: false
-                LinkLocalIPv6Address: ""
-                LinkLocalIPv6PrefixLen: 0
-                SandboxKey: ""
-                EndpointID: ""
-                Gateway: ""
-                GlobalIPv6Address: ""
-                GlobalIPv6PrefixLen: 0
-                IPAddress: ""
-                IPPrefixLen: 0
-                IPv6Gateway: ""
-                MacAddress: ""
-                Networks:
-                  bridge:
-                    NetworkID: "7ea29fc1412292a2d7bba362f9253545fecdfa8ce9a6e37dd10ba8bee7129812"
-                    EndpointID: "7587b82f0dada3656fda26588aee72630c6fab1536d36e394b2bfbcf898c971d"
-                    Gateway: "172.17.0.1"
-                    IPAddress: "172.17.0.2"
-                    IPPrefixLen: 16
-                    IPv6Gateway: ""
-                    GlobalIPv6Address: ""
-                    GlobalIPv6PrefixLen: 0
-                    MacAddress: "02:42:ac:12:00:02"
-              Path: "/bin/sh"
-              ProcessLabel: ""
-              ResolvConfPath: "/var/lib/docker/containers/ba033ac4401106a3b513bc9d639eee123ad78ca3616b921167cd74b20e25ed39/resolv.conf"
-              RestartCount: 1
-              State:
-                Error: ""
-                ExitCode: 9
-                FinishedAt: "2015-01-06T15:47:32.080254511Z"
-                Health:
-                  Status: "healthy"
-                  FailingStreak: 0
-                  Log:
-                    - Start: "2019-12-22T10:59:05.6385933Z"
-                      End: "2019-12-22T10:59:05.8078452Z"
-                      ExitCode: 0
-                      Output: ""
-                OOMKilled: false
-                Dead: false
-                Paused: false
-                Pid: 0
-                Restarting: false
-                Running: true
-                StartedAt: "2015-01-06T15:47:32.072697474Z"
-                Status: "running"
-              Mounts:
-                - Name: "fac362...80535"
-                  Source: "/data"
-                  Destination: "/data"
-                  Driver: "local"
-                  Mode: "ro,Z"
-                  RW: false
-                  Propagation: ""
+                Config:
+                  AttachStderr: true
+                  AttachStdin: false
+                  AttachStdout: true
+                  Cmd:
+                    - "/bin/sh"
+                    - "-c"
+                    - "exit 9"
+                  Domainname: ""
+                  Env:
+                    - "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+                  Healthcheck:
+                    Test: ["CMD-SHELL", "exit 0"]
+                  Hostname: "ba033ac44011"
+                  Image: "ubuntu"
+                  Labels:
+                    com.example.vendor: "Acme"
+                    com.example.license: "GPL"
+                    com.example.version: "1.0"
+                  MacAddress: ""
+                  NetworkDisabled: false
+                  OpenStdin: false
+                  StdinOnce: false
+                  Tty: false
+                  User: ""
+                  Volumes:
+                    /volumes/data: {}
+                  WorkingDir: ""
+                  StopSignal: "SIGTERM"
+                  StopTimeout: 10
+                Created: "2015-01-06T15:47:31.485331387Z"
+                Driver: "overlay2"
+                ExecIDs:
+                  - "b35395de42bc8abd327f9dd65d913b9ba28c74d2f0734eeeae84fa1c616a0fca"
+                  - "3fc1232e5cd20c8de182ed81178503dc6437f4e7ef12b52cc5e8de020652f1c4"
+                HostConfig:
+                  MaximumIOps: 0
+                  MaximumIOBps: 0
+                  BlkioWeight: 0
+                  BlkioWeightDevice:
+                    - {}
+                  BlkioDeviceReadBps:
+                    - {}
+                  BlkioDeviceWriteBps:
+                    - {}
+                  BlkioDeviceReadIOps:
+                    - {}
+                  BlkioDeviceWriteIOps:
+                    - {}
+                  ContainerIDFile: ""
+                  CpusetCpus: ""
+                  CpusetMems: ""
+                  CpuPercent: 80
+                  CpuShares: 0
+                  CpuPeriod: 100000
+                  CpuRealtimePeriod: 1000000
+                  CpuRealtimeRuntime: 10000
+                  Devices: []
+                  DeviceRequests:
+                    - Driver: "nvidia"
+                      Count: -1
+                      DeviceIDs": ["0", "1", "GPU-fef8089b-4820-abfc-e83e-94318197576e"]
+                      Capabilities: [["gpu", "nvidia", "compute"]]
+                      Options:
+                        property1: "string"
+                        property2: "string"
+                  IpcMode: ""
+                  Memory: 0
+                  MemorySwap: 0
+                  MemoryReservation: 0
+                  OomKillDisable: false
+                  OomScoreAdj: 500
+                  NetworkMode: "bridge"
+                  PidMode: ""
+                  PortBindings: {}
+                  Privileged: false
+                  ReadonlyRootfs: false
+                  PublishAllPorts: false
+                  RestartPolicy:
+                    MaximumRetryCount: 2
+                    Name: "on-failure"
+                  LogConfig:
+                    Type: "json-file"
+                  Sysctls:
+                    net.ipv4.ip_forward: "1"
+                  Ulimits:
+                    - {}
+                  VolumeDriver: ""
+                  ShmSize: 67108864
+                HostnamePath: "/var/lib/docker/containers/ba033ac4401106a3b513bc9d639eee123ad78ca3616b921167cd74b20e25ed39/hostname"
+                HostsPath: "/var/lib/docker/containers/ba033ac4401106a3b513bc9d639eee123ad78ca3616b921167cd74b20e25ed39/hosts"
+                LogPath: "/var/lib/docker/containers/1eb5fabf5a03807136561b3c00adcd2992b535d624d5e18b6cdc6a6844d9767b/1eb5fabf5a03807136561b3c00adcd2992b535d624d5e18b6cdc6a6844d9767b-json.log"
+                Id: "ba033ac4401106a3b513bc9d639eee123ad78ca3616b921167cd74b20e25ed39"
+                Image: "04c5d3b7b0656168630d3ba35d8889bd0e9caafcaeb3004d2bfbc47e7c5d35d2"
+                MountLabel: ""
+                Name: "/boring_euclid"
+                NetworkSettings:
+                  Bridge: ""
+                  SandboxID: ""
+                  HairpinMode: false
+                  LinkLocalIPv6Address: ""
+                  LinkLocalIPv6PrefixLen: 0
+                  SandboxKey: ""
+                  EndpointID: ""
+                  Gateway: ""
+                  GlobalIPv6Address: ""
+                  GlobalIPv6PrefixLen: 0
+                  IPAddress: ""
+                  IPPrefixLen: 0
+                  IPv6Gateway: ""
+                  MacAddress: ""
+                  Networks:
+                    bridge:
+                      NetworkID: "7ea29fc1412292a2d7bba362f9253545fecdfa8ce9a6e37dd10ba8bee7129812"
+                      EndpointID: "7587b82f0dada3656fda26588aee72630c6fab1536d36e394b2bfbcf898c971d"
+                      Gateway: "172.17.0.1"
+                      IPAddress: "172.17.0.2"
+                      IPPrefixLen: 16
+                      IPv6Gateway: ""
+                      GlobalIPv6Address: ""
+                      GlobalIPv6PrefixLen: 0
+                      MacAddress: "02:42:ac:12:00:02"
+                Path: "/bin/sh"
+                ProcessLabel: ""
+                ResolvConfPath: "/var/lib/docker/containers/ba033ac4401106a3b513bc9d639eee123ad78ca3616b921167cd74b20e25ed39/resolv.conf"
+                RestartCount: 1
+                State:
+                  Error: ""
+                  ExitCode: 9
+                  FinishedAt: "2015-01-06T15:47:32.080254511Z"
+                  Health:
+                    Status: "healthy"
+                    FailingStreak: 0
+                    Log:
+                      - Start: "2019-12-22T10:59:05.6385933Z"
+                        End: "2019-12-22T10:59:05.8078452Z"
+                        ExitCode: 0
+                        Output: ""
+                  OOMKilled: false
+                  Dead: false
+                  Paused: false
+                  Pid: 0
+                  Restarting: false
+                  Running: true
+                  StartedAt: "2015-01-06T15:47:32.072697474Z"
+                  Status: "running"
+                Mounts:
+                  - Name: "fac362...80535"
+                    Source: "/data"
+                    Destination: "/data"
+                    Driver: "local"
+                    Mode: "ro,Z"
+                    RW: false
+                    Propagation: ""
         404:
           description: "no such container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the container"
-          type: "string"
+          schema:
+            type: "string"
         - name: "size"
           in: "query"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
           description: "Return the size of container as fields `SizeRw` and `SizeRootFs`"
       tags: ["Container"]
   /containers/{id}/top:
@@ -6742,77 +6887,83 @@ paths:
       responses:
         200:
           description: "no error"
-          schema:
-            type: "object"
-            title: "ContainerTopResponse"
-            description: "OK response to ContainerTop operation"
-            properties:
-              Titles:
-                description: "The ps column titles"
-                type: "array"
-                items:
-                  type: "string"
-              Processes:
-                description: |
-                  Each process running in the container, where each is process
-                  is an array of values corresponding to the titles.
-                type: "array"
-                items:
-                  type: "array"
-                  items:
-                    type: "string"
-          examples:
+          content:
             application/json:
-              Titles:
-                - "UID"
-                - "PID"
-                - "PPID"
-                - "C"
-                - "STIME"
-                - "TTY"
-                - "TIME"
-                - "CMD"
-              Processes:
-                -
-                  - "root"
-                  - "13642"
-                  - "882"
-                  - "0"
-                  - "17:03"
-                  - "pts/0"
-                  - "00:00:00"
-                  - "/bin/bash"
-                -
-                  - "root"
-                  - "13735"
-                  - "13642"
-                  - "0"
-                  - "17:06"
-                  - "pts/0"
-                  - "00:00:00"
-                  - "sleep 10"
+              schema:
+                type: "object"
+                title: "ContainerTopResponse"
+                description: "OK response to ContainerTop operation"
+                properties:
+                  Titles:
+                    description: "The ps column titles"
+                    type: "array"
+                    items:
+                      type: "string"
+                  Processes:
+                    description: |
+                      Each process running in the container, where each is process
+                      is an array of values corresponding to the titles.
+                    type: "array"
+                    items:
+                      type: "array"
+                      items:
+                        type: "string"
+              example:
+                Titles:
+                  - "UID"
+                  - "PID"
+                  - "PPID"
+                  - "C"
+                  - "STIME"
+                  - "TTY"
+                  - "TIME"
+                  - "CMD"
+                Processes:
+                  -
+                    - "root"
+                    - "13642"
+                    - "882"
+                    - "0"
+                    - "17:03"
+                    - "pts/0"
+                    - "00:00:00"
+                    - "/bin/bash"
+                  -
+                    - "root"
+                    - "13735"
+                    - "13642"
+                    - "0"
+                    - "17:06"
+                    - "pts/0"
+                    - "00:00:00"
+                    - "sleep 10"
         404:
           description: "no such container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the container"
-          type: "string"
+          schema:
+            type: "string"
         - name: "ps_args"
           in: "query"
           description: "The arguments to pass to `ps`. For example, `aux`"
-          type: "string"
-          default: "-ef"
+          schema:
+            type: "string"
+            default: "-ef"
       tags: ["Container"]
   /containers/{id}/logs:
     get:
@@ -6822,9 +6973,6 @@ paths:
 
         Note: This endpoint works only for containers with the `json-file` or
         `journald` logging driver.
-      produces:
-        - "application/vnd.docker.raw-stream"
-        - "application/vnd.docker.multiplexed-stream"
       operationId: "ContainerLogs"
       responses:
         200:
@@ -6833,63 +6981,80 @@ paths:
             For the stream format, [see the documentation for the attach endpoint](#operation/ContainerAttach).
             Note that unlike the attach endpoint, the logs endpoint does not
             upgrade the connection and does not set Content-Type.
-          schema:
-            type: "string"
-            format: "binary"
+          content:
+            application/vnd.docker.raw-stream:
+              schema:
+                type: "string"
+                format: "binary"
+            application/vnd.docker.multiplexed-stream:
+              schema:
+                type: "string"
+                format: "binary"
         404:
           description: "no such container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the container"
-          type: "string"
+          schema:
+            type: "string"
         - name: "follow"
           in: "query"
           description: "Keep connection after returning logs."
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "stdout"
           in: "query"
           description: "Return logs from `stdout`"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "stderr"
           in: "query"
           description: "Return logs from `stderr`"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "since"
           in: "query"
           description: "Only return logs since this time, as a UNIX timestamp"
-          type: "integer"
-          default: 0
+          schema:
+            type: "integer"
+            default: 0
         - name: "until"
           in: "query"
           description: "Only return logs before this time, as a UNIX timestamp"
-          type: "integer"
-          default: 0
+          schema:
+            type: "integer"
+            default: 0
         - name: "timestamps"
           in: "query"
           description: "Add timestamps to every log line"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "tail"
           in: "query"
           description: |
             Only return this number of log lines from the end of the logs.
             Specify as an integer or `all` to output all log lines.
-          type: "string"
-          default: "all"
+          schema:
+            type: "string"
+            default: "all"
       tags: ["Container"]
   /containers/{id}/changes:
     get:
@@ -6902,67 +7067,74 @@ paths:
         - `1`: Added ("A")
         - `2`: Deleted ("D")
       operationId: "ContainerChanges"
-      produces: ["application/json"]
       responses:
         200:
           description: "The list of changes"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/FilesystemChange"
-          examples:
+          content:
             application/json:
-              - Path: "/dev"
-                Kind: 0
-              - Path: "/dev/kmsg"
-                Kind: 1
-              - Path: "/test"
-                Kind: 1
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/FilesystemChange"
+              example:
+                - Path: "/dev"
+                  Kind: 0
+                - Path: "/dev/kmsg"
+                  Kind: 1
+                - Path: "/test"
+                  Kind: 1
         404:
           description: "no such container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the container"
-          type: "string"
+          schema:
+            type: "string"
       tags: ["Container"]
   /containers/{id}/export:
     get:
       summary: "Export a container"
       description: "Export the contents of a container as a tarball."
       operationId: "ContainerExport"
-      produces:
-        - "application/octet-stream"
       responses:
         200:
           description: "no error"
+          content: {}
         404:
           description: "no such container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the container"
-          type: "string"
+          schema:
+            type: "string"
       tags: ["Container"]
   /containers/{id}/stats:
     get:
@@ -6995,173 +7167,182 @@ paths:
         * number_cpus = `lenght(cpu_stats.cpu_usage.percpu_usage)` or `cpu_stats.online_cpus`
         * CPU usage % = `(cpu_delta / system_cpu_delta) * number_cpus * 100.0`
       operationId: "ContainerStats"
-      produces: ["application/json"]
       responses:
         200:
           description: "no error"
-          schema:
-            type: "object"
-          examples:
+          content:
             application/json:
-              read: "2015-01-08T22:57:31.547920715Z"
-              pids_stats:
-                current: 3
-              networks:
-                eth0:
-                  rx_bytes: 5338
-                  rx_dropped: 0
-                  rx_errors: 0
-                  rx_packets: 36
-                  tx_bytes: 648
-                  tx_dropped: 0
-                  tx_errors: 0
-                  tx_packets: 8
-                eth5:
-                  rx_bytes: 4641
-                  rx_dropped: 0
-                  rx_errors: 0
-                  rx_packets: 26
-                  tx_bytes: 690
-                  tx_dropped: 0
-                  tx_errors: 0
-                  tx_packets: 9
-              memory_stats:
-                stats:
-                  total_pgmajfault: 0
-                  cache: 0
-                  mapped_file: 0
-                  total_inactive_file: 0
-                  pgpgout: 414
-                  rss: 6537216
-                  total_mapped_file: 0
-                  writeback: 0
-                  unevictable: 0
-                  pgpgin: 477
-                  total_unevictable: 0
-                  pgmajfault: 0
-                  total_rss: 6537216
-                  total_rss_huge: 6291456
-                  total_writeback: 0
-                  total_inactive_anon: 0
-                  rss_huge: 6291456
-                  hierarchical_memory_limit: 67108864
-                  total_pgfault: 964
-                  total_active_file: 0
-                  active_anon: 6537216
-                  total_active_anon: 6537216
-                  total_pgpgout: 414
-                  total_cache: 0
-                  inactive_anon: 0
-                  active_file: 0
-                  pgfault: 964
-                  inactive_file: 0
-                  total_pgpgin: 477
-                max_usage: 6651904
-                usage: 6537216
-                failcnt: 0
-                limit: 67108864
-              blkio_stats: {}
-              cpu_stats:
-                cpu_usage:
-                  percpu_usage:
-                    - 8646879
-                    - 24472255
-                    - 36438778
-                    - 30657443
-                  usage_in_usermode: 50000000
-                  total_usage: 100215355
-                  usage_in_kernelmode: 30000000
-                system_cpu_usage: 739306590000000
-                online_cpus: 4
-                throttling_data:
-                  periods: 0
-                  throttled_periods: 0
-                  throttled_time: 0
-              precpu_stats:
-                cpu_usage:
-                  percpu_usage:
-                    - 8646879
-                    - 24350896
-                    - 36438778
-                    - 30657443
-                  usage_in_usermode: 50000000
-                  total_usage: 100093996
-                  usage_in_kernelmode: 30000000
-                system_cpu_usage: 9492140000000
-                online_cpus: 4
-                throttling_data:
-                  periods: 0
-                  throttled_periods: 0
-                  throttled_time: 0
+              schema:
+                type: "object"
+              example:
+                read: "2015-01-08T22:57:31.547920715Z"
+                pids_stats:
+                  current: 3
+                networks:
+                  eth0:
+                    rx_bytes: 5338
+                    rx_dropped: 0
+                    rx_errors: 0
+                    rx_packets: 36
+                    tx_bytes: 648
+                    tx_dropped: 0
+                    tx_errors: 0
+                    tx_packets: 8
+                  eth5:
+                    rx_bytes: 4641
+                    rx_dropped: 0
+                    rx_errors: 0
+                    rx_packets: 26
+                    tx_bytes: 690
+                    tx_dropped: 0
+                    tx_errors: 0
+                    tx_packets: 9
+                memory_stats:
+                  stats:
+                    total_pgmajfault: 0
+                    cache: 0
+                    mapped_file: 0
+                    total_inactive_file: 0
+                    pgpgout: 414
+                    rss: 6537216
+                    total_mapped_file: 0
+                    writeback: 0
+                    unevictable: 0
+                    pgpgin: 477
+                    total_unevictable: 0
+                    pgmajfault: 0
+                    total_rss: 6537216
+                    total_rss_huge: 6291456
+                    total_writeback: 0
+                    total_inactive_anon: 0
+                    rss_huge: 6291456
+                    hierarchical_memory_limit: 67108864
+                    total_pgfault: 964
+                    total_active_file: 0
+                    active_anon: 6537216
+                    total_active_anon: 6537216
+                    total_pgpgout: 414
+                    total_cache: 0
+                    inactive_anon: 0
+                    active_file: 0
+                    pgfault: 964
+                    inactive_file: 0
+                    total_pgpgin: 477
+                  max_usage: 6651904
+                  usage: 6537216
+                  failcnt: 0
+                  limit: 67108864
+                blkio_stats: {}
+                cpu_stats:
+                  cpu_usage:
+                    percpu_usage:
+                      - 8646879
+                      - 24472255
+                      - 36438778
+                      - 30657443
+                    usage_in_usermode: 50000000
+                    total_usage: 100215355
+                    usage_in_kernelmode: 30000000
+                  system_cpu_usage: 739306590000000
+                  online_cpus: 4
+                  throttling_data:
+                    periods: 0
+                    throttled_periods: 0
+                    throttled_time: 0
+                precpu_stats:
+                  cpu_usage:
+                    percpu_usage:
+                      - 8646879
+                      - 24350896
+                      - 36438778
+                      - 30657443
+                    usage_in_usermode: 50000000
+                    total_usage: 100093996
+                    usage_in_kernelmode: 30000000
+                  system_cpu_usage: 9492140000000
+                  online_cpus: 4
+                  throttling_data:
+                    periods: 0
+                    throttled_periods: 0
+                    throttled_time: 0
         404:
           description: "no such container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the container"
-          type: "string"
+          schema:
+            type: "string"
         - name: "stream"
           in: "query"
           description: |
             Stream the output. If false, the stats will be output once and then
             it will disconnect.
-          type: "boolean"
-          default: true
+          schema:
+            type: "boolean"
+            default: true
         - name: "one-shot"
           in: "query"
           description: |
             Only get a single stat instead of waiting for 2 cycles. Must be used
             with `stream=false`.
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
       tags: ["Container"]
   /containers/{id}/resize:
     post:
       summary: "Resize a container TTY"
       description: "Resize the TTY for a container."
       operationId: "ContainerResize"
-      consumes:
-        - "application/octet-stream"
-      produces:
-        - "text/plain"
       responses:
         200:
           description: "no error"
+          content: {}
         404:
           description: "no such container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         500:
           description: "cannot resize container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the container"
-          type: "string"
+          schema:
+            type: "string"
         - name: "h"
           in: "query"
           description: "Height of the TTY session in characters"
-          type: "integer"
+          schema:
+            type: "integer"
         - name: "w"
           in: "query"
           description: "Width of the TTY session in characters"
-          type: "integer"
+          schema:
+            type: "integer"
       tags: ["Container"]
   /containers/{id}/start:
     post:
@@ -7170,32 +7351,39 @@ paths:
       responses:
         204:
           description: "no error"
+          content: {}
         304:
           description: "container already started"
+          content: {}
         404:
           description: "no such container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the container"
-          type: "string"
+          schema:
+            type: "string"
         - name: "detachKeys"
           in: "query"
           description: |
             Override the key sequence for detaching a container. Format is a
             single character `[a-Z]` or `ctrl-<value>` where `<value>` is one
             of: `a-z`, `@`, `^`, `[`, `,` or `_`.
-          type: "string"
+          schema:
+            type: "string"
       tags: ["Container"]
   /containers/{id}/stop:
     post:
@@ -7204,34 +7392,42 @@ paths:
       responses:
         204:
           description: "no error"
+          content: {}
         304:
           description: "container already stopped"
+          content: {}
         404:
           description: "no such container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the container"
-          type: "string"
+          schema:
+            type: "string"
         - name: "signal"
           in: "query"
           description: |
             Signal to send to the container as an integer or string (e.g. `SIGINT`).
-          type: "string"
+          schema:
+            type: "string"
         - name: "t"
           in: "query"
           description: "Number of seconds to wait before killing the container"
-          type: "integer"
+          schema:
+            type: "integer"
       tags: ["Container"]
   /containers/{id}/restart:
     post:
@@ -7240,32 +7436,39 @@ paths:
       responses:
         204:
           description: "no error"
+          content: {}
         404:
           description: "no such container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the container"
-          type: "string"
+          schema:
+            type: "string"
         - name: "signal"
           in: "query"
           description: |
             Signal to send to the container as an integer or string (e.g. `SIGINT`).
-          type: "string"
+          schema:
+            type: "string"
         - name: "t"
           in: "query"
           description: "Number of seconds to wait before killing the container"
-          type: "integer"
+          schema:
+            type: "integer"
       tags: ["Container"]
   /containers/{id}/kill:
     post:
@@ -7277,36 +7480,43 @@ paths:
       responses:
         204:
           description: "no error"
+          content: {}
         404:
           description: "no such container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         409:
           description: "container is not running"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "Container d37cde0fe4ad63c3a7252023b2f9800282894247d145cb5933ddf6e52cc03a28 is not running"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "Container d37cde0fe4ad63c3a7252023b2f9800282894247d145cb5933ddf6e52cc03a28 is not running"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the container"
-          type: "string"
+          schema:
+            type: "string"
         - name: "signal"
           in: "query"
           description: |
             Signal to send to the container as an integer or string (e.g. `SIGINT`).
-          type: "string"
-          default: "SIGKILL"
+          schema:
+            type: "string"
+            default: "SIGKILL"
       tags: ["Container"]
   /containers/{id}/update:
     post:
@@ -7315,47 +7525,53 @@ paths:
         Change various configuration options of a container without having to
         recreate it.
       operationId: "ContainerUpdate"
-      consumes: ["application/json"]
-      produces: ["application/json"]
       responses:
         200:
           description: "The container has been updated."
-          schema:
-            type: "object"
-            title: "ContainerUpdateResponse"
-            description: "OK response to ContainerUpdate operation"
-            properties:
-              Warnings:
-                type: "array"
-                items:
-                  type: "string"
+          content:
+            application/json:
+              schema:
+                type: "object"
+                title: "ContainerUpdateResponse"
+                description: "OK response to ContainerUpdate operation"
+                properties:
+                  Warnings:
+                    type: "array"
+                    items:
+                      type: "string"
         404:
           description: "no such container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the container"
-          type: "string"
-        - name: "update"
-          in: "body"
-          required: true
           schema:
-            allOf:
-              - $ref: "#/definitions/Resources"
-              - type: "object"
-                properties:
-                  RestartPolicy:
-                    $ref: "#/definitions/RestartPolicy"
+            type: "string"
+      x-codegen-request-body-name: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/Resources"
+                - type: "object"
+                  properties:
+                    RestartPolicy:
+                      $ref: "#/components/schemas/RestartPolicy"
             example:
               BlkioWeight: 300
               CpuShares: 512
@@ -7379,32 +7595,40 @@ paths:
       responses:
         204:
           description: "no error"
+          content: {}
         404:
           description: "no such container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         409:
           description: "name already in use"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the container"
-          type: "string"
+          schema:
+            type: "string"
         - name: "name"
           in: "query"
           required: true
           description: "New name for the container"
-          type: "string"
+          schema:
+            type: "string"
       tags: ["Container"]
   /containers/{id}/pause:
     post:
@@ -7420,23 +7644,28 @@ paths:
       responses:
         204:
           description: "no error"
+          content: {}
         404:
           description: "no such container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the container"
-          type: "string"
+          schema:
+            type: "string"
       tags: ["Container"]
   /containers/{id}/unpause:
     post:
@@ -7446,23 +7675,28 @@ paths:
       responses:
         204:
           description: "no error"
+          content: {}
         404:
           description: "no such container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the container"
-          type: "string"
+          schema:
+            type: "string"
       tags: ["Container"]
   /containers/{id}/attach:
     post:
@@ -7564,42 +7798,48 @@ paths:
         `stdin`.
 
       operationId: "ContainerAttach"
-      produces:
-        - "application/vnd.docker.raw-stream"
-        - "application/vnd.docker.multiplexed-stream"
       responses:
         101:
           description: "no error, hints proxy about hijacking"
+          content: {}
         200:
           description: "no error, no upgrade header found"
+          content: {}
         400:
           description: "bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         404:
           description: "no such container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the container"
-          type: "string"
+          schema:
+            type: "string"
         - name: "detachKeys"
           in: "query"
           description: |
             Override the key sequence for detaching a container.Format is a single
             character `[a-Z]` or `ctrl-<value>` where `<value>` is one of: `a-z`,
             `@`, `^`, `[`, `,` or `_`.
-          type: "string"
+          schema:
+            type: "string"
         - name: "logs"
           in: "query"
           description: |
@@ -7611,29 +7851,34 @@ paths:
             If `stream` is also enabled, once all the previous output has been
             returned, it will seamlessly transition into streaming current
             output.
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "stream"
           in: "query"
           description: |
             Stream attached streams from the time the request was made onwards.
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "stdin"
           in: "query"
           description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "stdout"
           in: "query"
           description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "stderr"
           in: "query"
           description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
       tags: ["Container"]
   /containers/{id}/attach/ws:
     get:
@@ -7642,106 +7887,128 @@ paths:
       responses:
         101:
           description: "no error, hints proxy about hijacking"
+          content: {}
         200:
           description: "no error, no upgrade header found"
+          content: {}
         400:
           description: "bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         404:
           description: "no such container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the container"
-          type: "string"
+          schema:
+            type: "string"
         - name: "detachKeys"
           in: "query"
           description: |
             Override the key sequence for detaching a container.Format is a single
             character `[a-Z]` or `ctrl-<value>` where `<value>` is one of: `a-z`,
             `@`, `^`, `[`, `,`, or `_`.
-          type: "string"
+          schema:
+            type: "string"
         - name: "logs"
           in: "query"
           description: "Return logs"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "stream"
           in: "query"
           description: "Return stream"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "stdin"
           in: "query"
           description: "Attach to `stdin`"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "stdout"
           in: "query"
           description: "Attach to `stdout`"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "stderr"
           in: "query"
           description: "Attach to `stderr`"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
       tags: ["Container"]
   /containers/{id}/wait:
     post:
       summary: "Wait for a container"
       description: "Block until a container stops, then returns the exit code."
       operationId: "ContainerWait"
-      produces: ["application/json"]
       responses:
         200:
           description: "The container has exit."
-          schema:
-            $ref: "#/definitions/ContainerWaitResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ContainerWaitResponse"
         400:
           description: "bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         404:
           description: "no such container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the container"
-          type: "string"
+          schema:
+            type: "string"
         - name: "condition"
           in: "query"
           description: |
             Wait until a container state reaches the given condition.
 
             Defaults to `not-running` if omitted or empty.
-          type: "string"
-          enum:
-            - "not-running"
-            - "next-exit"
-            - "removed"
-          default: "not-running"
+          schema:
+            type: "string"
+            enum:
+              - "not-running"
+              - "next-exit"
+              - "removed"
+            default: "not-running"
       tags: ["Container"]
   /containers/{id}:
     delete:
@@ -7750,51 +8017,62 @@ paths:
       responses:
         204:
           description: "no error"
+          content: {}
         400:
           description: "bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         404:
           description: "no such container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         409:
           description: "conflict"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: |
-                You cannot remove a running container: c2ada9df5af8. Stop the
-                container before attempting removal or force remove
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: |
+                  You cannot remove a running container: c2ada9df5af8. Stop the
+                  container before attempting removal or force remove
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the container"
-          type: "string"
+          schema:
+            type: "string"
         - name: "v"
           in: "query"
           description: "Remove anonymous volumes associated with the container."
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "force"
           in: "query"
           description: "If the container is running, kill it before removing it."
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "link"
           in: "query"
           description: "Remove the specified link associated with the container."
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
       tags: ["Container"]
   /containers/{id}/archive:
     head:
@@ -7809,71 +8087,87 @@ paths:
           description: "no error"
           headers:
             X-Docker-Container-Path-Stat:
-              type: "string"
+              schema:
+                type: "string"
               description: |
                 A base64 - encoded JSON object with some filesystem header
                 information about the path
+          content: {}
         400:
           description: "Bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         404:
           description: "Container or path does not exist"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the container"
-          type: "string"
+          schema:
+            type: "string"
         - name: "path"
           in: "query"
           required: true
           description: "Resource in the container’s filesystem to archive."
-          type: "string"
+          schema:
+            type: "string"
       tags: ["Container"]
     get:
       summary: "Get an archive of a filesystem resource in a container"
       description: "Get a tar archive of a resource in the filesystem of container id."
       operationId: "ContainerArchive"
-      produces: ["application/x-tar"]
       responses:
         200:
           description: "no error"
+          content: {}
         400:
           description: "Bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         404:
           description: "Container or path does not exist"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the container"
-          type: "string"
+          schema:
+            type: "string"
         - name: "path"
           in: "query"
           required: true
           description: "Resource in the container’s filesystem to archive."
-          type: "string"
+          schema:
+            type: "string"
       tags: ["Container"]
     put:
       summary: "Extract an archive of files or folders to a directory in a container"
@@ -7882,72 +8176,86 @@ paths:
         `path` parameter is asserted to be a directory. If it exists as a file, 400 error
         will be returned with message "not a directory".
       operationId: "PutContainerArchive"
-      consumes: ["application/x-tar", "application/octet-stream"]
       responses:
         200:
           description: "The content was extracted successfully"
+          content: {}
         400:
           description: "Bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "not a directory"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "not a directory"
         403:
           description: "Permission denied, the volume or container rootfs is marked as read-only."
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         404:
           description: "No such container or path does not exist inside the container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the container"
-          type: "string"
+          schema:
+            type: "string"
         - name: "path"
           in: "query"
           required: true
           description: "Path to a directory in the container to extract the archive’s contents into. "
-          type: "string"
+          schema:
+            type: "string"
         - name: "noOverwriteDirNonDir"
           in: "query"
           description: |
             If `1`, `true`, or `True` then it will be an error if unpacking the
             given content would cause an existing directory to be replaced with
             a non-directory and vice versa.
-          type: "string"
+          schema:
+            type: "string"
         - name: "copyUIDGID"
           in: "query"
           description: |
             If `1`, `true`, then it will copy UID/GID maps to the dest file or
             dir
-          type: "string"
-        - name: "inputStream"
-          in: "body"
-          required: true
-          description: |
-            The input stream must be a tar archive compressed with one of the
-            following algorithms: `identity` (no compression), `gzip`, `bzip2`,
-            or `xz`.
           schema:
             type: "string"
-            format: "binary"
+      x-codegen-request-body-name: "inputStream"
+      requestBody:
+        required: true
+        description: |
+          The input stream must be a tar archive compressed with one of the
+          following algorithms: `identity` (no compression), `gzip`, `bzip2`,
+          or `xz`.
+        content:
+          application/x-tar:
+            schema:
+              type: "string"
+              format: "binary"
+          application/octet-stream:
+            schema:
+              type: "string"
+              format: "binary"
       tags: ["Container"]
   /containers/prune:
     post:
       summary: "Delete stopped containers"
-      produces:
-        - "application/json"
       operationId: "ContainerPrune"
       parameters:
         - name: "filters"
@@ -7958,52 +8266,60 @@ paths:
             Available filters:
             - `until=<timestamp>` Prune containers created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
             - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune containers with (or without, in case `label!=...` is used) the specified labels.
-          type: "string"
+          schema:
+            type: "string"
       responses:
         200:
           description: "No error"
-          schema:
-            type: "object"
-            title: "ContainerPruneResponse"
-            properties:
-              ContainersDeleted:
-                description: "Container IDs that were deleted"
-                type: "array"
-                items:
-                  type: "string"
-              SpaceReclaimed:
-                description: "Disk space reclaimed in bytes"
-                type: "integer"
-                format: "int64"
+          content:
+            application/json:
+              schema:
+                type: "object"
+                title: "ContainerPruneResponse"
+                properties:
+                  ContainersDeleted:
+                    description: "Container IDs that were deleted"
+                    type: "array"
+                    items:
+                      type: "string"
+                  SpaceReclaimed:
+                    description: "Disk space reclaimed in bytes"
+                    type: "integer"
+                    format: "int64"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       tags: ["Container"]
   /images/json:
     get:
       summary: "List Images"
       description: "Returns a list of images on the server. Note that it uses a different, smaller representation of an image than inspecting a single image."
       operationId: "ImageList"
-      produces:
-        - "application/json"
       responses:
         200:
           description: "Summary image data for the images matching the query"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/ImageSummary"
+          content:
+            application/json:
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/ImageSummary"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "all"
           in: "query"
           description: "Show all images. Only images from a final layer (no children) are shown by default."
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "filters"
           in: "query"
           description: |
@@ -8017,17 +8333,20 @@ paths:
             - `label=key` or `label="key=value"` of an image label
             - `reference`=(`<image-name>[:<tag>]`)
             - `since`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
-          type: "string"
+          schema:
+            type: "string"
         - name: "shared-size"
           in: "query"
           description: "Compute and show shared size as a `SharedSize` field on each image."
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "digests"
           in: "query"
           description: "Show digest information as a `RepoDigests` field on each image."
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
       tags: ["Image"]
   /build:
     post:
@@ -8041,86 +8360,101 @@ paths:
 
         The build is canceled if the client drops the connection by quitting or being killed.
       operationId: "ImageBuild"
-      consumes:
-        - "application/octet-stream"
-      produces:
-        - "application/json"
+      x-codegen-request-body-name: "inputStream"
+      requestBody:
+        description: "A tar archive compressed with one of the following algorithms: identity (no compression), gzip, bzip2, xz."
+        content:
+          application/octet-stream:
+            schema:
+              type: "string"
+              format: "binary"
+        required: false
       parameters:
-        - name: "inputStream"
-          in: "body"
-          description: "A tar archive compressed with one of the following algorithms: identity (no compression), gzip, bzip2, xz."
-          schema:
-            type: "string"
-            format: "binary"
         - name: "dockerfile"
           in: "query"
           description: "Path within the build context to the `Dockerfile`. This is ignored if `remote` is specified and points to an external `Dockerfile`."
-          type: "string"
-          default: "Dockerfile"
+          schema:
+            type: "string"
+            default: "Dockerfile"
         - name: "t"
           in: "query"
           description: "A name and optional tag to apply to the image in the `name:tag` format. If you omit the tag the default `latest` value is assumed. You can provide several `t` parameters."
-          type: "string"
+          schema:
+            type: "string"
         - name: "extrahosts"
           in: "query"
           description: "Extra hosts to add to /etc/hosts"
-          type: "string"
+          schema:
+            type: "string"
         - name: "remote"
           in: "query"
           description: "A Git repository URI or HTTP/HTTPS context URI. If the URI points to a single text file, the file’s contents are placed into a file called `Dockerfile` and the image is built from that file. If the URI points to a tarball, the file is downloaded by the daemon and the contents therein used as the context for the build. If the URI points to a tarball and the `dockerfile` parameter is also specified, there must be a file with the corresponding path inside the tarball."
-          type: "string"
+          schema:
+            type: "string"
         - name: "q"
           in: "query"
           description: "Suppress verbose build output."
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "nocache"
           in: "query"
           description: "Do not use the cache when building the image."
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "cachefrom"
           in: "query"
           description: "JSON array of images used for build cache resolution."
-          type: "string"
+          schema:
+            type: "string"
         - name: "pull"
           in: "query"
           description: "Attempt to pull the image even if an older image exists locally."
-          type: "string"
+          schema:
+            type: "string"
         - name: "rm"
           in: "query"
           description: "Remove intermediate containers after a successful build."
-          type: "boolean"
-          default: true
+          schema:
+            type: "boolean"
+            default: true
         - name: "forcerm"
           in: "query"
           description: "Always remove intermediate containers, even upon failure."
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "memory"
           in: "query"
           description: "Set memory limit for build."
-          type: "integer"
+          schema:
+            type: "integer"
         - name: "memswap"
           in: "query"
           description: "Total memory (memory + swap). Set as `-1` to disable swap."
-          type: "integer"
+          schema:
+            type: "integer"
         - name: "cpushares"
           in: "query"
           description: "CPU shares (relative weight)."
-          type: "integer"
+          schema:
+            type: "integer"
         - name: "cpusetcpus"
           in: "query"
           description: "CPUs in which to allow execution (e.g., `0-3`, `0,1`)."
-          type: "string"
+          schema:
+            type: "string"
         - name: "cpuperiod"
           in: "query"
           description: "The length of a CPU period in microseconds."
-          type: "integer"
+          schema:
+            type: "integer"
         - name: "cpuquota"
           in: "query"
           description: "Microseconds of CPU time that the container can get in a CPU period."
-          type: "integer"
+          schema:
+            type: "integer"
         - name: "buildargs"
           in: "query"
           description: >
@@ -8135,19 +8469,23 @@ paths:
 
 
             [Read more about the buildargs instruction.](https://docs.docker.com/engine/reference/builder/#arg)
-          type: "string"
+          schema:
+            type: "string"
         - name: "shmsize"
           in: "query"
           description: "Size of `/dev/shm` in bytes. The size must be greater than 0. If omitted the system uses 64MB."
-          type: "integer"
+          schema:
+            type: "integer"
         - name: "squash"
           in: "query"
           description: "Squash the resulting images layers into a single layer. *(Experimental release only.)*"
-          type: "boolean"
+          schema:
+            type: "boolean"
         - name: "labels"
           in: "query"
           description: "Arbitrary key/value labels to set on the image, as a JSON map of string pairs."
-          type: "string"
+          schema:
+            type: "string"
         - name: "networkmode"
           in: "query"
           description: |
@@ -8155,13 +8493,15 @@ paths:
             standard values are: `bridge`, `host`, `none`, and `container:<name|id>`.
             Any other value is taken as a custom network's name or ID to which this
             container should connect to.
-          type: "string"
+          schema:
+            type: "string"
         - name: "Content-type"
           in: "header"
-          type: "string"
-          enum:
-            - "application/x-tar"
-          default: "application/x-tar"
+          schema:
+            type: "string"
+            enum:
+              - "application/x-tar"
+            default: "application/x-tar"
         - name: "X-Registry-Config"
           in: "header"
           description: |
@@ -8183,53 +8523,63 @@ paths:
             ```
 
             Only the registry domain name (and port if not the default 443) are required. However, for legacy reasons, the Docker Hub registry must be specified with both a `https://` prefix and a `/v1/` suffix even though Docker will prefer to use the v2 registry API.
-          type: "string"
+          schema:
+            type: "string"
         - name: "platform"
           in: "query"
           description: "Platform in the format os[/arch[/variant]]"
-          type: "string"
-          default: ""
+          schema:
+            type: "string"
+            default: ""
         - name: "target"
           in: "query"
           description: "Target build stage"
-          type: "string"
-          default: ""
+          schema:
+            type: "string"
+            default: ""
         - name: "outputs"
           in: "query"
           description: "BuildKit output configuration"
-          type: "string"
-          default: ""
+          schema:
+            type: "string"
+            default: ""
       responses:
         200:
           description: "no error"
+          content: {}
         400:
           description: "Bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       tags: ["Image"]
   /build/prune:
     post:
       summary: "Delete builder cache"
-      produces:
-        - "application/json"
       operationId: "BuildPrune"
       parameters:
         - name: "keep-storage"
           in: "query"
           description: "Amount of disk space in bytes to keep for cache"
-          type: "integer"
-          format: "int64"
+          schema:
+            type: "integer"
+            format: "int64"
         - name: "all"
           in: "query"
-          type: "boolean"
+          schema:
+            type: "boolean"
           description: "Remove all types of build cache"
         - name: "filters"
           in: "query"
-          type: "string"
+          schema:
+            type: "string"
           description: |
             A JSON encoded value of the filters (a `map[string][]string`) to
             process on the list of build cache objects.
@@ -8247,72 +8597,86 @@ paths:
       responses:
         200:
           description: "No error"
-          schema:
-            type: "object"
-            title: "BuildPruneResponse"
-            properties:
-              CachesDeleted:
-                type: "array"
-                items:
-                  description: "ID of build cache object"
-                  type: "string"
-              SpaceReclaimed:
-                description: "Disk space reclaimed in bytes"
-                type: "integer"
-                format: "int64"
+          content:
+            application/json:
+              schema:
+                type: "object"
+                title: "BuildPruneResponse"
+                properties:
+                  CachesDeleted:
+                    type: "array"
+                    items:
+                      description: "ID of build cache object"
+                      type: "string"
+                  SpaceReclaimed:
+                    description: "Disk space reclaimed in bytes"
+                    type: "integer"
+                    format: "int64"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       tags: ["Image"]
   /images/create:
     post:
       summary: "Create an image"
       description: "Pull or import an image."
       operationId: "ImageCreate"
-      consumes:
-        - "text/plain"
-        - "application/octet-stream"
-      produces:
-        - "application/json"
       responses:
         200:
           description: "no error"
+          content: {}
         404:
           description: "repository does not exist or no read access"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-codegen-request-body-name: "inputImage"
+      requestBody:
+        description: "Image content if the value `-` has been specified in fromSrc query parameter"
+        content:
+          text/plain:
+            schema:
+              type: "string"
+          application/octet-stream:
+            schema:
+              type: "string"
+        required: false
       parameters:
         - name: "fromImage"
           in: "query"
           description: "Name of the image to pull. The name may include a tag or digest. This parameter may only be used when pulling an image. The pull is cancelled if the HTTP connection is closed."
-          type: "string"
+          schema:
+            type: "string"
         - name: "fromSrc"
           in: "query"
           description: "Source to import. The value may be a URL from which the image can be retrieved or `-` to read the image from the request body. This parameter may only be used when importing an image."
-          type: "string"
+          schema:
+            type: "string"
         - name: "repo"
           in: "query"
           description: "Repository name given to an image when it is imported. The repo may include a tag. This parameter may only be used when importing an image."
-          type: "string"
+          schema:
+            type: "string"
         - name: "tag"
           in: "query"
           description: "Tag or digest. If empty when pulling an image, this causes all tags for the given image to be pulled."
-          type: "string"
+          schema:
+            type: "string"
         - name: "message"
           in: "query"
           description: "Set commit message for imported image."
-          type: "string"
-        - name: "inputImage"
-          in: "body"
-          description: "Image content if the value `-` has been specified in fromSrc query parameter"
           schema:
             type: "string"
-          required: false
         - name: "X-Registry-Auth"
           in: "header"
           description: |
@@ -8320,7 +8684,8 @@ paths:
 
             Refer to the [authentication section](#section/Authentication) for
             details.
-          type: "string"
+          schema:
+            type: "string"
         - name: "changes"
           in: "query"
           description: |
@@ -8330,9 +8695,12 @@ paths:
 
             Supported `Dockerfile` instructions:
             `CMD`|`ENTRYPOINT`|`ENV`|`EXPOSE`|`ONBUILD`|`USER`|`VOLUME`|`WORKDIR`
-          type: "array"
-          items:
-            type: "string"
+          style: form
+          explode: false
+          schema:
+            type: "array"
+            items:
+              type: "string"
         - name: "platform"
           in: "query"
           description: |
@@ -8351,37 +8719,42 @@ paths:
             this option sets the platform information for the imported image. If
             the option is not set, the host's native OS and Architecture are used
             for the imported image.
-          type: "string"
-          default: ""
+          schema:
+            type: "string"
+            default: ""
       tags: ["Image"]
   /images/{name}/json:
     get:
       summary: "Inspect an image"
       description: "Return low-level information about an image."
       operationId: "ImageInspect"
-      produces:
-        - "application/json"
       responses:
         200:
           description: "No error"
-          schema:
-            $ref: "#/definitions/ImageInspect"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImageInspect"
         404:
           description: "No such image"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such image: someimage (tag: latest)"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such image: someimage (tag: latest)"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "name"
           in: "path"
           description: "Image name or id"
-          type: "string"
+          schema:
+            type: "string"
           required: true
       tags: ["Image"]
   /images/{name}/history:
@@ -8389,77 +8762,87 @@ paths:
       summary: "Get the history of an image"
       description: "Return parent layers of an image."
       operationId: "ImageHistory"
-      produces: ["application/json"]
       responses:
         200:
           description: "List of image layers"
-          schema:
-            type: "array"
-            items:
-              type: "object"
-              x-go-name: HistoryResponseItem
-              title: "HistoryResponseItem"
-              description: "individual image layer information in response to ImageHistory operation"
-              required: [Id, Created, CreatedBy, Tags, Size, Comment]
-              properties:
-                Id:
-                  type: "string"
-                  x-nullable: false
-                Created:
-                  type: "integer"
-                  format: "int64"
-                  x-nullable: false
-                CreatedBy:
-                  type: "string"
-                  x-nullable: false
-                Tags:
-                  type: "array"
-                  items:
-                    type: "string"
-                Size:
-                  type: "integer"
-                  format: "int64"
-                  x-nullable: false
-                Comment:
-                  type: "string"
-                  x-nullable: false
-          examples:
+          content:
             application/json:
-              - Id: "3db9c44f45209632d6050b35958829c3a2aa256d81b9a7be45b362ff85c54710"
-                Created: 1398108230
-                CreatedBy: "/bin/sh -c #(nop) ADD file:eb15dbd63394e063b805a3c32ca7bf0266ef64676d5a6fab4801f2e81e2a5148 in /"
-                Tags:
-                  - "ubuntu:lucid"
-                  - "ubuntu:10.04"
-                Size: 182964289
-                Comment: ""
-              - Id: "6cfa4d1f33fb861d4d114f43b25abd0ac737509268065cdfd69d544a59c85ab8"
-                Created: 1398108222
-                CreatedBy: "/bin/sh -c #(nop) MAINTAINER Tianon Gravi <admwiggin@gmail.com> - mkimage-debootstrap.sh -i iproute,iputils-ping,ubuntu-minimal -t lucid.tar.xz lucid http://archive.ubuntu.com/ubuntu/"
-                Tags: []
-                Size: 0
-                Comment: ""
-              - Id: "511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158"
-                Created: 1371157430
-                CreatedBy: ""
-                Tags:
-                  - "scratch12:latest"
-                  - "scratch:latest"
-                Size: 0
-                Comment: "Imported from -"
+              schema:
+                type: "array"
+                items:
+                  type: "object"
+                  x-go-name: HistoryResponseItem
+                  title: "HistoryResponseItem"
+                  description: "individual image layer information in response to ImageHistory operation"
+                  required: [Id, Created, CreatedBy, Tags, Size, Comment]
+                  properties:
+                    Id:
+                      type: "string"
+                      nullable: false
+                      x-nullable: false
+                    Created:
+                      type: "integer"
+                      format: "int64"
+                      nullable: false
+                      x-nullable: false
+                    CreatedBy:
+                      type: "string"
+                      nullable: false
+                      x-nullable: false
+                    Tags:
+                      type: "array"
+                      items:
+                        type: "string"
+                    Size:
+                      type: "integer"
+                      format: "int64"
+                      nullable: false
+                      x-nullable: false
+                    Comment:
+                      type: "string"
+                      nullable: false
+                      x-nullable: false
+              example:
+                - Id: "3db9c44f45209632d6050b35958829c3a2aa256d81b9a7be45b362ff85c54710"
+                  Created: 1398108230
+                  CreatedBy: "/bin/sh -c #(nop) ADD file:eb15dbd63394e063b805a3c32ca7bf0266ef64676d5a6fab4801f2e81e2a5148 in /"
+                  Tags:
+                    - "ubuntu:lucid"
+                    - "ubuntu:10.04"
+                  Size: 182964289
+                  Comment: ""
+                - Id: "6cfa4d1f33fb861d4d114f43b25abd0ac737509268065cdfd69d544a59c85ab8"
+                  Created: 1398108222
+                  CreatedBy: "/bin/sh -c #(nop) MAINTAINER Tianon Gravi <admwiggin@gmail.com> - mkimage-debootstrap.sh -i iproute,iputils-ping,ubuntu-minimal -t lucid.tar.xz lucid http://archive.ubuntu.com/ubuntu/"
+                  Tags: []
+                  Size: 0
+                  Comment: ""
+                - Id: "511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158"
+                  Created: 1371157430
+                  CreatedBy: ""
+                  Tags:
+                    - "scratch12:latest"
+                    - "scratch:latest"
+                  Size: 0
+                  Comment: "Imported from -"
         404:
           description: "No such image"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "name"
           in: "path"
           description: "Image name or ID"
-          type: "string"
+          schema:
+            type: "string"
           required: true
       tags: ["Image"]
   /images/{name}/push:
@@ -8474,29 +8857,34 @@ paths:
 
         The push is cancelled if the HTTP connection is closed.
       operationId: "ImagePush"
-      consumes:
-        - "application/octet-stream"
       responses:
         200:
           description: "No error"
+          content: {}
         404:
           description: "No such image"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "name"
           in: "path"
           description: "Image name or ID."
-          type: "string"
+          schema:
+            type: "string"
           required: true
         - name: "tag"
           in: "query"
           description: "The tag to associate with the image on the registry."
-          type: "string"
+          schema:
+            type: "string"
         - name: "X-Registry-Auth"
           in: "header"
           description: |
@@ -8504,7 +8892,8 @@ paths:
 
             Refer to the [authentication section](#section/Authentication) for
             details.
-          type: "string"
+          schema:
+            type: "string"
           required: true
       tags: ["Image"]
   /images/{name}/tag:
@@ -8515,36 +8904,48 @@ paths:
       responses:
         201:
           description: "No error"
+          content: {}
         400:
           description: "Bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         404:
           description: "No such image"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         409:
           description: "Conflict"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "name"
           in: "path"
           description: "Image name or ID to tag."
-          type: "string"
+          schema:
+            type: "string"
           required: true
         - name: "repo"
           in: "query"
           description: "The repository to tag in. For example, `someuser/someimage`."
-          type: "string"
+          schema:
+            type: "string"
         - name: "tag"
           in: "query"
           description: "The name of the new tag."
-          type: "string"
+          schema:
+            type: "string"
       tags: ["Image"]
   /images/{name}:
     delete:
@@ -8556,113 +8957,125 @@ paths:
         Images can't be removed if they have descendant images, are being
         used by a running container or are being used by a build.
       operationId: "ImageDelete"
-      produces: ["application/json"]
       responses:
         200:
           description: "The image was deleted successfully"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/ImageDeleteResponseItem"
-          examples:
+          content:
             application/json:
-              - Untagged: "3e2f21a89f"
-              - Deleted: "3e2f21a89f"
-              - Deleted: "53b4f83ac9"
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/ImageDeleteResponseItem"
+              example:
+                - Untagged: "3e2f21a89f"
+                - Deleted: "3e2f21a89f"
+                - Deleted: "53b4f83ac9"
         404:
           description: "No such image"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         409:
           description: "Conflict"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "name"
           in: "path"
           description: "Image name or ID"
-          type: "string"
+          schema:
+            type: "string"
           required: true
         - name: "force"
           in: "query"
           description: "Remove the image even if it is being used by stopped containers or has other tags"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "noprune"
           in: "query"
           description: "Do not delete untagged parent images"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
       tags: ["Image"]
   /images/search:
     get:
       summary: "Search images"
       description: "Search for an image on Docker Hub."
       operationId: "ImageSearch"
-      produces:
-        - "application/json"
       responses:
         200:
           description: "No error"
-          schema:
-            type: "array"
-            items:
-              type: "object"
-              title: "ImageSearchResponseItem"
-              properties:
-                description:
-                  type: "string"
-                is_official:
-                  type: "boolean"
-                is_automated:
-                  description: |
-                    Whether this repository has automated builds enabled.
-
-                    <p><br /></p>
-
-                    > **Deprecated**: This field is deprecated and will always
-                    > be "false" in future.
-                  type: "boolean"
-                  example: false
-                name:
-                  type: "string"
-                star_count:
-                  type: "integer"
-          examples:
+          content:
             application/json:
-              - description: "A minimal Docker image based on Alpine Linux with a complete package index and only 5 MB in size!"
-                is_official: true
-                is_automated: false
-                name: "alpine"
-                star_count: 10093
-              - description: "Busybox base image."
-                is_official: true
-                is_automated: false
-                name: "Busybox base image."
-                star_count: 3037
-              - description: "The PostgreSQL object-relational database system provides reliability and data integrity."
-                is_official: true
-                is_automated: false
-                name: "postgres"
-                star_count: 12408
+              schema:
+                type: "array"
+                items:
+                  type: "object"
+                  title: "ImageSearchResponseItem"
+                  properties:
+                    description:
+                      type: "string"
+                    is_official:
+                      type: "boolean"
+                    is_automated:
+                      description: |
+                        Whether this repository has automated builds enabled.
+
+                        <p><br /></p>
+
+                        > **Deprecated**: This field is deprecated and will always
+                        > be "false" in future.
+                      type: "boolean"
+                      example: false
+                    name:
+                      type: "string"
+                    star_count:
+                      type: "integer"
+              example:
+                - description: "A minimal Docker image based on Alpine Linux with a complete package index and only 5 MB in size!"
+                  is_official: true
+                  is_automated: false
+                  name: "alpine"
+                  star_count: 10093
+                - description: "Busybox base image."
+                  is_official: true
+                  is_automated: false
+                  name: "Busybox base image."
+                  star_count: 3037
+                - description: "The PostgreSQL object-relational database system provides reliability and data integrity."
+                  is_official: true
+                  is_automated: false
+                  name: "postgres"
+                  star_count: 12408
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "term"
           in: "query"
           description: "Term to search"
-          type: "string"
+          schema:
+            type: "string"
           required: true
         - name: "limit"
           in: "query"
           description: "Maximum number of results to return"
-          type: "integer"
+          schema:
+            type: "integer"
         - name: "filters"
           in: "query"
           description: |
@@ -8675,13 +9088,12 @@ paths:
             The `is-automated` filter is deprecated. The `is_automated` field has
             been deprecated by Docker Hub's search API. Consequently, searching
             for `is-automated=true` will yield no results.
-          type: "string"
+          schema:
+            type: "string"
       tags: ["Image"]
   /images/prune:
     post:
       summary: "Delete unused images"
-      produces:
-        - "application/json"
       operationId: "ImagePrune"
       parameters:
         - name: "filters"
@@ -8694,27 +9106,32 @@ paths:
                (or `0`), all unused images are pruned.
             - `until=<string>` Prune images created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
             - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune images with (or without, in case `label!=...` is used) the specified labels.
-          type: "string"
+          schema:
+            type: "string"
       responses:
         200:
           description: "No error"
-          schema:
-            type: "object"
-            title: "ImagePruneResponse"
-            properties:
-              ImagesDeleted:
-                description: "Images that were deleted"
-                type: "array"
-                items:
-                  $ref: "#/definitions/ImageDeleteResponseItem"
-              SpaceReclaimed:
-                description: "Disk space reclaimed in bytes"
-                type: "integer"
-                format: "int64"
+          content:
+            application/json:
+              schema:
+                type: "object"
+                title: "ImagePruneResponse"
+                properties:
+                  ImagesDeleted:
+                    description: "Images that were deleted"
+                    type: "array"
+                    items:
+                      $ref: "#/components/schemas/ImageDeleteResponseItem"
+                  SpaceReclaimed:
+                    description: "Disk space reclaimed in bytes"
+                    type: "integer"
+                    format: "int64"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       tags: ["Image"]
   /auth:
     post:
@@ -8723,95 +9140,112 @@ paths:
         Validate credentials for a registry and, if available, get an identity
         token for accessing the registry without password.
       operationId: "SystemAuth"
-      consumes: ["application/json"]
-      produces: ["application/json"]
       responses:
         200:
           description: "An identity token was generated successfully."
-          schema:
-            type: "object"
-            title: "SystemAuthResponse"
-            required: [Status]
-            properties:
-              Status:
-                description: "The status of the authentication"
-                type: "string"
-                x-nullable: false
-              IdentityToken:
-                description: "An opaque token used to authenticate a user after a successful login"
-                type: "string"
-                x-nullable: false
-          examples:
+          content:
             application/json:
-              Status: "Login Succeeded"
-              IdentityToken: "9cbaf023786cd7..."
+              schema:
+                type: "object"
+                title: "SystemAuthResponse"
+                required: [Status]
+                properties:
+                  Status:
+                    description: "The status of the authentication"
+                    type: "string"
+                    nullable: false
+                    x-nullable: false
+                  IdentityToken:
+                    description: "An opaque token used to authenticate a user after a successful login"
+                    type: "string"
+                    nullable: false
+                    x-nullable: false
+              example:
+                Status: "Login Succeeded"
+                IdentityToken: "9cbaf023786cd7..."
         204:
           description: "No error"
+          content: {}
         401:
           description: "Auth error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-      parameters:
-        - name: "authConfig"
-          in: "body"
-          description: "Authentication to check"
-          schema:
-            $ref: "#/definitions/AuthConfig"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-codegen-request-body-name: "authConfig"
+      requestBody:
+        description: "Authentication to check"
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AuthConfig"
       tags: ["System"]
   /info:
     get:
       summary: "Get system information"
       operationId: "SystemInfo"
-      produces:
-        - "application/json"
       responses:
         200:
           description: "No error"
-          schema:
-            $ref: "#/definitions/SystemInfo"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SystemInfo"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       tags: ["System"]
   /version:
     get:
       summary: "Get version"
       description: "Returns the version of Docker that is running and various information about the system that Docker is running on."
       operationId: "SystemVersion"
-      produces: ["application/json"]
       responses:
         200:
           description: "no error"
-          schema:
-            $ref: "#/definitions/SystemVersion"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SystemVersion"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       tags: ["System"]
   /_ping:
     get:
       summary: "Ping"
       description: "This is a dummy endpoint you can use to test if the server is accessible."
       operationId: "SystemPing"
-      produces: ["text/plain"]
       responses:
         200:
           description: "no error"
-          schema:
-            type: "string"
-            example: "OK"
+          content:
+            text/plain:
+              schema:
+                type: "string"
+                example: "OK"
           headers:
             API-Version:
-              type: "string"
+              schema:
+                type: "string"
               description: "Max API Version the server supports"
             Builder-Version:
-              type: "string"
+              schema:
+                type: "string"
+                default: "2"
               description: |
                 Default version of docker image builder
 
@@ -8822,133 +9256,160 @@ paths:
 
                 This value is a recommendation as advertised by the daemon, and
                 it is up to the client to choose which builder to use.
-              default: "2"
             Docker-Experimental:
-              type: "boolean"
+              schema:
+                type: "boolean"
               description: "If the server is running with experimental mode enabled"
             Swarm:
-              type: "string"
-              enum: ["inactive", "pending", "error", "locked", "active/worker", "active/manager"]
+              schema:
+                type: "string"
+                enum: ["inactive", "pending", "error", "locked", "active/worker", "active/manager"]
+                default: "inactive"
               description: |
                 Contains information about Swarm status of the daemon,
                 and if the daemon is acting as a manager or worker node.
-              default: "inactive"
             Cache-Control:
-              type: "string"
-              default: "no-cache, no-store, must-revalidate"
+              schema:
+                type: "string"
+                default: "no-cache, no-store, must-revalidate"
             Pragma:
-              type: "string"
-              default: "no-cache"
+              schema:
+                type: "string"
+                default: "no-cache"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
           headers:
             Cache-Control:
-              type: "string"
-              default: "no-cache, no-store, must-revalidate"
+              schema:
+                type: "string"
+                default: "no-cache, no-store, must-revalidate"
             Pragma:
-              type: "string"
-              default: "no-cache"
+              schema:
+                type: "string"
+                default: "no-cache"
       tags: ["System"]
     head:
       summary: "Ping"
       description: "This is a dummy endpoint you can use to test if the server is accessible."
       operationId: "SystemPingHead"
-      produces: ["text/plain"]
       responses:
         200:
           description: "no error"
-          schema:
-            type: "string"
-            example: "(empty)"
+          content:
+            text/plain:
+              schema:
+                type: "string"
+                example: "(empty)"
           headers:
             API-Version:
-              type: "string"
+              schema:
+                type: "string"
               description: "Max API Version the server supports"
             Builder-Version:
-              type: "string"
+              schema:
+                type: "string"
               description: "Default version of docker image builder"
             Docker-Experimental:
-              type: "boolean"
+              schema:
+                type: "boolean"
               description: "If the server is running with experimental mode enabled"
             Swarm:
-              type: "string"
-              enum: ["inactive", "pending", "error", "locked", "active/worker", "active/manager"]
+              schema:
+                type: "string"
+                enum: ["inactive", "pending", "error", "locked", "active/worker", "active/manager"]
+                default: "inactive"
               description: |
                 Contains information about Swarm status of the daemon,
                 and if the daemon is acting as a manager or worker node.
-              default: "inactive"
             Cache-Control:
-              type: "string"
-              default: "no-cache, no-store, must-revalidate"
+              schema:
+                type: "string"
+                default: "no-cache, no-store, must-revalidate"
             Pragma:
-              type: "string"
-              default: "no-cache"
+              schema:
+                type: "string"
+                default: "no-cache"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       tags: ["System"]
   /commit:
     post:
       summary: "Create a new image from a container"
       operationId: "ImageCommit"
-      consumes:
-        - "application/json"
-      produces:
-        - "application/json"
       responses:
         201:
           description: "no error"
-          schema:
-            $ref: "#/definitions/IdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IdResponse"
         404:
           description: "no such container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-codegen-request-body-name: "containerConfig"
+      requestBody:
+        description: "The container configuration"
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ContainerConfig"
+        required: false
       parameters:
-        - name: "containerConfig"
-          in: "body"
-          description: "The container configuration"
-          schema:
-            $ref: "#/definitions/ContainerConfig"
         - name: "container"
           in: "query"
           description: "The ID or name of the container to commit"
-          type: "string"
+          schema:
+            type: "string"
         - name: "repo"
           in: "query"
           description: "Repository name for the created image"
-          type: "string"
+          schema:
+            type: "string"
         - name: "tag"
           in: "query"
           description: "Tag name for the create image"
-          type: "string"
+          schema:
+            type: "string"
         - name: "comment"
           in: "query"
           description: "Commit message"
-          type: "string"
+          schema:
+            type: "string"
         - name: "author"
           in: "query"
           description: "Author of the image (e.g., `John Hannibal Smith <hannibal@a-team.com>`)"
-          type: "string"
+          schema:
+            type: "string"
         - name: "pause"
           in: "query"
           description: "Whether to pause the container before committing"
-          type: "boolean"
-          default: true
+          schema:
+            type: "boolean"
+            default: true
         - name: "changes"
           in: "query"
           description: "`Dockerfile` instructions to apply while committing"
-          type: "string"
+          schema:
+            type: "string"
       tags: ["Image"]
   /events:
     get:
@@ -8979,30 +9440,36 @@ paths:
         The Builder reports `prune` events
 
       operationId: "SystemEvents"
-      produces:
-        - "application/json"
       responses:
         200:
           description: "no error"
-          schema:
-            $ref: "#/definitions/EventMessage"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventMessage"
         400:
           description: "bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "since"
           in: "query"
           description: "Show events created since this timestamp then stream new events."
-          type: "string"
+          schema:
+            type: "string"
         - name: "until"
           in: "query"
           description: "Show events created until this timestamp then stop streaming."
-          type: "string"
+          schema:
+            type: "string"
         - name: "filters"
           in: "query"
           description: |
@@ -9022,7 +9489,8 @@ paths:
             - `service=<string>` service name or ID
             - `type=<string>` object to filter by, one of `container`, `image`, `volume`, `network`, `daemon`, `plugin`, `node`, `service`, `secret` or `config`
             - `volume=<string>` volume name
-          type: "string"
+          schema:
+            type: "string"
       tags: ["System"]
   /system/df:
     get:
@@ -9031,124 +9499,130 @@ paths:
       responses:
         200:
           description: "no error"
-          schema:
-            type: "object"
-            title: "SystemDataUsageResponse"
-            properties:
-              LayersSize:
-                type: "integer"
-                format: "int64"
-              Images:
-                type: "array"
-                items:
-                  $ref: "#/definitions/ImageSummary"
-              Containers:
-                type: "array"
-                items:
-                  $ref: "#/definitions/ContainerSummary"
-              Volumes:
-                type: "array"
-                items:
-                  $ref: "#/definitions/Volume"
-              BuildCache:
-                type: "array"
-                items:
-                  $ref: "#/definitions/BuildCache"
-            example:
-              LayersSize: 1092588
-              Images:
-                -
-                  Id: "sha256:2b8fd9751c4c0f5dd266fcae00707e67a2545ef34f9a29354585f93dac906749"
-                  ParentId: ""
-                  RepoTags:
-                    - "busybox:latest"
-                  RepoDigests:
-                    - "busybox@sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6"
-                  Created: 1466724217
-                  Size: 1092588
-                  SharedSize: 0
-                  Labels: {}
-                  Containers: 1
-              Containers:
-                -
-                  Id: "e575172ed11dc01bfce087fb27bee502db149e1a0fad7c296ad300bbff178148"
-                  Names:
-                    - "/top"
-                  Image: "busybox"
-                  ImageID: "sha256:2b8fd9751c4c0f5dd266fcae00707e67a2545ef34f9a29354585f93dac906749"
-                  Command: "top"
-                  Created: 1472592424
-                  Ports: []
-                  SizeRootFs: 1092588
-                  Labels: {}
-                  State: "exited"
-                  Status: "Exited (0) 56 minutes ago"
-                  HostConfig:
-                    NetworkMode: "default"
-                  NetworkSettings:
-                    Networks:
-                      bridge:
-                        IPAMConfig: null
-                        Links: null
-                        Aliases: null
-                        NetworkID: "d687bc59335f0e5c9ee8193e5612e8aee000c8c62ea170cfb99c098f95899d92"
-                        EndpointID: "8ed5115aeaad9abb174f68dcf135b49f11daf597678315231a32ca28441dec6a"
-                        Gateway: "172.18.0.1"
-                        IPAddress: "172.18.0.2"
-                        IPPrefixLen: 16
-                        IPv6Gateway: ""
-                        GlobalIPv6Address: ""
-                        GlobalIPv6PrefixLen: 0
-                        MacAddress: "02:42:ac:12:00:02"
-                  Mounts: []
-              Volumes:
-                -
-                  Name: "my-volume"
-                  Driver: "local"
-                  Mountpoint: "/var/lib/docker/volumes/my-volume/_data"
-                  Labels: null
-                  Scope: "local"
-                  Options: null
-                  UsageData:
-                    Size: 10920104
-                    RefCount: 2
-              BuildCache:
-                -
-                  ID: "hw53o5aio51xtltp5xjp8v7fx"
-                  Parents: []
-                  Type: "regular"
-                  Description: "pulled from docker.io/library/debian@sha256:234cb88d3020898631af0ccbbcca9a66ae7306ecd30c9720690858c1b007d2a0"
-                  InUse: false
-                  Shared: true
-                  Size: 0
-                  CreatedAt: "2021-06-28T13:31:01.474619385Z"
-                  LastUsedAt: "2021-07-07T22:02:32.738075951Z"
-                  UsageCount: 26
-                -
-                  ID: "ndlpt0hhvkqcdfkputsk4cq9c"
-                  Parents: ["ndlpt0hhvkqcdfkputsk4cq9c"]
-                  Type: "regular"
-                  Description: "mount / from exec /bin/sh -c echo 'Binary::apt::APT::Keep-Downloaded-Packages \"true\";' > /etc/apt/apt.conf.d/keep-cache"
-                  InUse: false
-                  Shared: true
-                  Size: 51
-                  CreatedAt: "2021-06-28T13:31:03.002625487Z"
-                  LastUsedAt: "2021-07-07T22:02:32.773909517Z"
-                  UsageCount: 26
+          content:
+            application/json:
+              schema:
+                type: "object"
+                title: "SystemDataUsageResponse"
+                properties:
+                  LayersSize:
+                    type: "integer"
+                    format: "int64"
+                  Images:
+                    type: "array"
+                    items:
+                      $ref: "#/components/schemas/ImageSummary"
+                  Containers:
+                    type: "array"
+                    items:
+                      $ref: "#/components/schemas/ContainerSummary"
+                  Volumes:
+                    type: "array"
+                    items:
+                      $ref: "#/components/schemas/Volume"
+                  BuildCache:
+                    type: "array"
+                    items:
+                      $ref: "#/components/schemas/BuildCache"
+                example:
+                  LayersSize: 1092588
+                  Images:
+                    -
+                      Id: "sha256:2b8fd9751c4c0f5dd266fcae00707e67a2545ef34f9a29354585f93dac906749"
+                      ParentId: ""
+                      RepoTags:
+                        - "busybox:latest"
+                      RepoDigests:
+                        - "busybox@sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6"
+                      Created: 1466724217
+                      Size: 1092588
+                      SharedSize: 0
+                      Labels: {}
+                      Containers: 1
+                  Containers:
+                    -
+                      Id: "e575172ed11dc01bfce087fb27bee502db149e1a0fad7c296ad300bbff178148"
+                      Names:
+                        - "/top"
+                      Image: "busybox"
+                      ImageID: "sha256:2b8fd9751c4c0f5dd266fcae00707e67a2545ef34f9a29354585f93dac906749"
+                      Command: "top"
+                      Created: 1472592424
+                      Ports: []
+                      SizeRootFs: 1092588
+                      Labels: {}
+                      State: "exited"
+                      Status: "Exited (0) 56 minutes ago"
+                      HostConfig:
+                        NetworkMode: "default"
+                      NetworkSettings:
+                        Networks:
+                          bridge:
+                            IPAMConfig: null
+                            Links: null
+                            Aliases: null
+                            NetworkID: "d687bc59335f0e5c9ee8193e5612e8aee000c8c62ea170cfb99c098f95899d92"
+                            EndpointID: "8ed5115aeaad9abb174f68dcf135b49f11daf597678315231a32ca28441dec6a"
+                            Gateway: "172.18.0.1"
+                            IPAddress: "172.18.0.2"
+                            IPPrefixLen: 16
+                            IPv6Gateway: ""
+                            GlobalIPv6Address: ""
+                            GlobalIPv6PrefixLen: 0
+                            MacAddress: "02:42:ac:12:00:02"
+                      Mounts: []
+                  Volumes:
+                    -
+                      Name: "my-volume"
+                      Driver: "local"
+                      Mountpoint: "/var/lib/docker/volumes/my-volume/_data"
+                      Labels: null
+                      Scope: "local"
+                      Options: null
+                      UsageData:
+                        Size: 10920104
+                        RefCount: 2
+                  BuildCache:
+                    -
+                      ID: "hw53o5aio51xtltp5xjp8v7fx"
+                      Parents: []
+                      Type: "regular"
+                      Description: "pulled from docker.io/library/debian@sha256:234cb88d3020898631af0ccbbcca9a66ae7306ecd30c9720690858c1b007d2a0"
+                      InUse: false
+                      Shared: true
+                      Size: 0
+                      CreatedAt: "2021-06-28T13:31:01.474619385Z"
+                      LastUsedAt: "2021-07-07T22:02:32.738075951Z"
+                      UsageCount: 26
+                    -
+                      ID: "ndlpt0hhvkqcdfkputsk4cq9c"
+                      Parents: ["ndlpt0hhvkqcdfkputsk4cq9c"]
+                      Type: "regular"
+                      Description: "mount / from exec /bin/sh -c echo 'Binary::apt::APT::Keep-Downloaded-Packages \"true\";' > /etc/apt/apt.conf.d/keep-cache"
+                      InUse: false
+                      Shared: true
+                      Size: 51
+                      CreatedAt: "2021-06-28T13:31:03.002625487Z"
+                      LastUsedAt: "2021-07-07T22:02:32.773909517Z"
+                      UsageCount: 26
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "type"
           in: "query"
           description: |
             Object types, for which to compute and return data.
-          type: "array"
-          collectionFormat: multi
-          items:
-            type: "string"
-            enum: ["container", "image", "volume", "build-cache"]
+          style: form
+          explode: true
+          schema:
+            type: "array"
+            items:
+              type: "string"
+              enum: ["container", "image", "volume", "build-cache"]
       tags: ["System"]
   /images/{name}/get:
     get:
@@ -9178,23 +9652,26 @@ paths:
         }
         ```
       operationId: "ImageGet"
-      produces:
-        - "application/x-tar"
       responses:
         200:
           description: "no error"
-          schema:
-            type: "string"
-            format: "binary"
+          content:
+            application/x-tar:
+              schema:
+                type: "string"
+                format: "binary"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/x-tar:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "name"
           in: "path"
           description: "Image name or ID"
-          type: "string"
+          schema:
+            type: "string"
           required: true
       tags: ["Image"]
   /images/get:
@@ -9212,25 +9689,30 @@ paths:
 
         For details on the format, see the [export image endpoint](#operation/ImageGet).
       operationId: "ImageGetAll"
-      produces:
-        - "application/x-tar"
       responses:
         200:
           description: "no error"
-          schema:
-            type: "string"
-            format: "binary"
+          content:
+            application/x-tar:
+              schema:
+                type: "string"
+                format: "binary"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/x-tar:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "names"
           in: "query"
           description: "Image names to filter by"
-          type: "array"
-          items:
-            type: "string"
+          style: form
+          explode: false
+          schema:
+            type: "array"
+            items:
+              type: "string"
       tags: ["Image"]
   /images/load:
     post:
@@ -9240,135 +9722,145 @@ paths:
 
         For details on the format, see the [export image endpoint](#operation/ImageGet).
       operationId: "ImageLoad"
-      consumes:
-        - "application/x-tar"
-      produces:
-        - "application/json"
       responses:
         200:
           description: "no error"
+          content: {}
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-codegen-request-body-name: "imagesTarball"
+      requestBody:
+        description: "Tar archive containing images"
+        content:
+          application/x-tar:
+            schema:
+              type: "string"
+              format: "binary"
+        required: false
       parameters:
-        - name: "imagesTarball"
-          in: "body"
-          description: "Tar archive containing images"
-          schema:
-            type: "string"
-            format: "binary"
         - name: "quiet"
           in: "query"
           description: "Suppress progress details during load."
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
       tags: ["Image"]
   /containers/{id}/exec:
     post:
       summary: "Create an exec instance"
       description: "Run a command inside a running container."
       operationId: "ContainerExec"
-      consumes:
-        - "application/json"
-      produces:
-        - "application/json"
       responses:
         201:
           description: "no error"
-          schema:
-            $ref: "#/definitions/IdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IdResponse"
         404:
           description: "no such container"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
         409:
           description: "container is paused"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-codegen-request-body-name: execConfig
+      requestBody:
+        description: "Exec configuration"
+        content:
+          application/json:
+            schema:
+              type: "object"
+              title: "ExecConfig"
+              properties:
+                AttachStdin:
+                  type: "boolean"
+                  description: "Attach to `stdin` of the exec command."
+                AttachStdout:
+                  type: "boolean"
+                  description: "Attach to `stdout` of the exec command."
+                AttachStderr:
+                  type: "boolean"
+                  description: "Attach to `stderr` of the exec command."
+                ConsoleSize:
+                  type: "array"
+                  description: "Initial console size, as an `[height, width]` array."
+                  nullable: true
+                  x-nullable: true
+                  minItems: 2
+                  maxItems: 2
+                  items:
+                    type: "integer"
+                    minimum: 0
+                DetachKeys:
+                  type: "string"
+                  description: |
+                    Override the key sequence for detaching a container. Format is
+                    a single character `[a-Z]` or `ctrl-<value>` where `<value>`
+                    is one of: `a-z`, `@`, `^`, `[`, `,` or `_`.
+                Tty:
+                  type: "boolean"
+                  description: "Allocate a pseudo-TTY."
+                Env:
+                  description: |
+                    A list of environment variables in the form `["VAR=value", ...]`.
+                  type: "array"
+                  items:
+                    type: "string"
+                Cmd:
+                  type: "array"
+                  description: "Command to run, as a string or array of strings."
+                  items:
+                    type: "string"
+                Privileged:
+                  type: "boolean"
+                  description: "Runs the exec process with extended privileges."
+                  default: false
+                User:
+                  type: "string"
+                  description: |
+                    The user, and optionally, group to run the exec process inside
+                    the container. Format is one of: `user`, `user:group`, `uid`,
+                    or `uid:gid`.
+                WorkingDir:
+                  type: "string"
+                  description: |
+                    The working directory for the exec process inside the container.
+              example:
+                AttachStdin: false
+                AttachStdout: true
+                AttachStderr: true
+                DetachKeys: "ctrl-p,ctrl-q"
+                Tty: false
+                Cmd:
+                  - "date"
+                Env:
+                  - "FOO=bar"
+                  - "BAZ=quux"
+        required: true
       parameters:
-        - name: "execConfig"
-          in: "body"
-          description: "Exec configuration"
-          schema:
-            type: "object"
-            title: "ExecConfig"
-            properties:
-              AttachStdin:
-                type: "boolean"
-                description: "Attach to `stdin` of the exec command."
-              AttachStdout:
-                type: "boolean"
-                description: "Attach to `stdout` of the exec command."
-              AttachStderr:
-                type: "boolean"
-                description: "Attach to `stderr` of the exec command."
-              ConsoleSize:
-                type: "array"
-                description: "Initial console size, as an `[height, width]` array."
-                x-nullable: true
-                minItems: 2
-                maxItems: 2
-                items:
-                  type: "integer"
-                  minimum: 0
-              DetachKeys:
-                type: "string"
-                description: |
-                  Override the key sequence for detaching a container. Format is
-                  a single character `[a-Z]` or `ctrl-<value>` where `<value>`
-                  is one of: `a-z`, `@`, `^`, `[`, `,` or `_`.
-              Tty:
-                type: "boolean"
-                description: "Allocate a pseudo-TTY."
-              Env:
-                description: |
-                  A list of environment variables in the form `["VAR=value", ...]`.
-                type: "array"
-                items:
-                  type: "string"
-              Cmd:
-                type: "array"
-                description: "Command to run, as a string or array of strings."
-                items:
-                  type: "string"
-              Privileged:
-                type: "boolean"
-                description: "Runs the exec process with extended privileges."
-                default: false
-              User:
-                type: "string"
-                description: |
-                  The user, and optionally, group to run the exec process inside
-                  the container. Format is one of: `user`, `user:group`, `uid`,
-                  or `uid:gid`.
-              WorkingDir:
-                type: "string"
-                description: |
-                  The working directory for the exec process inside the container.
-            example:
-              AttachStdin: false
-              AttachStdout: true
-              AttachStderr: true
-              DetachKeys: "ctrl-p,ctrl-q"
-              Tty: false
-              Cmd:
-                - "date"
-              Env:
-                - "FOO=bar"
-                - "BAZ=quux"
-          required: true
         - name: "id"
           in: "path"
           description: "ID or name of container"
-          type: "string"
+          schema:
+            type: "string"
           required: true
       tags: ["Exec"]
   /exec/{id}/start:
@@ -9379,53 +9871,64 @@ paths:
         returns immediately after starting the command. Otherwise, it sets up an
         interactive session with the command.
       operationId: "ExecStart"
-      consumes:
-        - "application/json"
-      produces:
-        - "application/vnd.docker.raw-stream"
-        - "application/vnd.docker.multiplexed-stream"
       responses:
         200:
           description: "No error"
+          content: {}
         404:
           description: "No such exec instance"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/vnd.docker.raw-stream:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+            application/vnd.docker.multiplexed-stream:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         409:
           description: "Container is stopped or paused"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/vnd.docker.raw-stream:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+            application/vnd.docker.multiplexed-stream:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-codegen-request-body-name: "execStartConfig"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: "object"
+              title: "ExecStartConfig"
+              properties:
+                Detach:
+                  type: "boolean"
+                  description: "Detach from the command."
+                Tty:
+                  type: "boolean"
+                  description: "Allocate a pseudo-TTY."
+                ConsoleSize:
+                  type: "array"
+                  description: "Initial console size, as an `[height, width]` array."
+                  nullable: true
+                  x-nullable: true
+                  minItems: 2
+                  maxItems: 2
+                  items:
+                    type: "integer"
+                    minimum: 0
+              example:
+                Detach: false
+                Tty: true
+                ConsoleSize: [80, 64]
       parameters:
-        - name: "execStartConfig"
-          in: "body"
-          schema:
-            type: "object"
-            title: "ExecStartConfig"
-            properties:
-              Detach:
-                type: "boolean"
-                description: "Detach from the command."
-              Tty:
-                type: "boolean"
-                description: "Allocate a pseudo-TTY."
-              ConsoleSize:
-                type: "array"
-                description: "Initial console size, as an `[height, width]` array."
-                x-nullable: true
-                minItems: 2
-                maxItems: 2
-                items:
-                  type: "integer"
-                  minimum: 0
-            example:
-              Detach: false
-              Tty: true
-              ConsoleSize: [80, 64]
         - name: "id"
           in: "path"
           description: "Exec instance ID"
           required: true
-          type: "string"
+          schema:
+            type: "string"
       tags: ["Exec"]
   /exec/{id}/resize:
     post:
@@ -9437,120 +9940,137 @@ paths:
       responses:
         200:
           description: "No error"
+          content: {}
         400:
           description: "bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         404:
           description: "No such exec instance"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           description: "Exec instance ID"
           required: true
-          type: "string"
+          schema:
+            type: "string"
         - name: "h"
           in: "query"
           description: "Height of the TTY session in characters"
-          type: "integer"
+          schema:
+            type: "integer"
         - name: "w"
           in: "query"
           description: "Width of the TTY session in characters"
-          type: "integer"
+          schema:
+            type: "integer"
       tags: ["Exec"]
   /exec/{id}/json:
     get:
       summary: "Inspect an exec instance"
       description: "Return low-level information about an exec instance."
       operationId: "ExecInspect"
-      produces:
-        - "application/json"
       responses:
         200:
           description: "No error"
-          schema:
-            type: "object"
-            title: "ExecInspectResponse"
-            properties:
-              CanRemove:
-                type: "boolean"
-              DetachKeys:
-                type: "string"
-              ID:
-                type: "string"
-              Running:
-                type: "boolean"
-              ExitCode:
-                type: "integer"
-              ProcessConfig:
-                $ref: "#/definitions/ProcessConfig"
-              OpenStdin:
-                type: "boolean"
-              OpenStderr:
-                type: "boolean"
-              OpenStdout:
-                type: "boolean"
-              ContainerID:
-                type: "string"
-              Pid:
-                type: "integer"
-                description: "The system process ID for the exec process."
-          examples:
+          content:
             application/json:
-              CanRemove: false
-              ContainerID: "b53ee82b53a40c7dca428523e34f741f3abc51d9f297a14ff874bf761b995126"
-              DetachKeys: ""
-              ExitCode: 2
-              ID: "f33bbfb39f5b142420f4759b2348913bd4a8d1a6d7fd56499cb41a1bb91d7b3b"
-              OpenStderr: true
-              OpenStdin: true
-              OpenStdout: true
-              ProcessConfig:
-                arguments:
-                  - "-c"
-                  - "exit 2"
-                entrypoint: "sh"
-                privileged: false
-                tty: true
-                user: "1000"
-              Running: false
-              Pid: 42000
+              schema:
+                type: "object"
+                title: "ExecInspectResponse"
+                properties:
+                  CanRemove:
+                    type: "boolean"
+                  DetachKeys:
+                    type: "string"
+                  ID:
+                    type: "string"
+                  Running:
+                    type: "boolean"
+                  ExitCode:
+                    type: "integer"
+                  ProcessConfig:
+                    $ref: "#/components/schemas/ProcessConfig"
+                  OpenStdin:
+                    type: "boolean"
+                  OpenStderr:
+                    type: "boolean"
+                  OpenStdout:
+                    type: "boolean"
+                  ContainerID:
+                    type: "string"
+                  Pid:
+                    type: "integer"
+                    description: "The system process ID for the exec process."
+              example:
+                CanRemove: false
+                ContainerID: "b53ee82b53a40c7dca428523e34f741f3abc51d9f297a14ff874bf761b995126"
+                DetachKeys: ""
+                ExitCode: 2
+                ID: "f33bbfb39f5b142420f4759b2348913bd4a8d1a6d7fd56499cb41a1bb91d7b3b"
+                OpenStderr: true
+                OpenStdin: true
+                OpenStdout: true
+                ProcessConfig:
+                  arguments:
+                    - "-c"
+                    - "exit 2"
+                  entrypoint: "sh"
+                  privileged: false
+                  tty: true
+                  user: "1000"
+                Running: false
+                Pid: 42000
         404:
           description: "No such exec instance"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           description: "Exec instance ID"
           required: true
-          type: "string"
+          schema:
+            type: "string"
       tags: ["Exec"]
 
   /volumes:
     get:
       summary: "List volumes"
       operationId: "VolumeList"
-      produces: ["application/json"]
       responses:
         200:
           description: "Summary volume data that matches the query"
-          schema:
-            $ref: "#/definitions/VolumeListResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VolumeListResponse"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "filters"
           in: "query"
@@ -9566,116 +10086,138 @@ paths:
             - `label=<key>` or `label=<key>:<value>` Matches volumes based on
                the presence of a `label` alone or a `label` and a value.
             - `name=<volume-name>` Matches all or part of a volume name.
-          type: "string"
-          format: "json"
+          schema:
+            type: "string"
+            format: "json"
       tags: ["Volume"]
 
   /volumes/create:
     post:
       summary: "Create a volume"
       operationId: "VolumeCreate"
-      consumes: ["application/json"]
-      produces: ["application/json"]
       responses:
         201:
           description: "The volume was created successfully"
-          schema:
-            $ref: "#/definitions/Volume"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Volume"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-      parameters:
-        - name: "volumeConfig"
-          in: "body"
-          required: true
-          description: "Volume configuration"
-          schema:
-            $ref: "#/definitions/VolumeCreateOptions"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-codegen-request-body-name: "volumeConfig"
+      requestBody:
+        required: true
+        description: "Volume configuration"
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/VolumeCreateOptions"
       tags: ["Volume"]
 
   /volumes/{name}:
     get:
       summary: "Inspect a volume"
       operationId: "VolumeInspect"
-      produces: ["application/json"]
       responses:
         200:
           description: "No error"
-          schema:
-            $ref: "#/definitions/Volume"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Volume"
         404:
           description: "No such volume"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "name"
           in: "path"
           required: true
           description: "Volume name or ID"
-          type: "string"
+          schema:
+            type: "string"
       tags: ["Volume"]
 
     put:
       summary: |
         "Update a volume. Valid only for Swarm cluster volumes"
       operationId: "VolumeUpdate"
-      consumes: ["application/json"]
-      produces: ["application/json"]
       responses:
         200:
           description: "no error"
+          content: {}
         400:
           description: "bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         404:
           description: "no such volume"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "name"
           in: "path"
           description: "The name or ID of the volume"
-          type: "string"
-          required: true
-        - name: "body"
-          in: "body"
           schema:
-            # though the schema for is an object that contains only a
-            # ClusterVolumeSpec, wrapping the ClusterVolumeSpec in this object
-            # means that if, later on, we support things like changing the
-            # labels, we can do so without duplicating that information to the
-            # ClusterVolumeSpec.
-            type: "object"
-            description: "Volume configuration"
-            properties:
-              Spec:
-                $ref: "#/definitions/ClusterVolumeSpec"
-          description: |
-            The spec of the volume to update. Currently, only Availability may
-            change. All other fields must remain unchanged.
+            type: "string"
+          required: true
         - name: "version"
           in: "query"
           description: |
             The version number of the volume being updated. This is required to
             avoid conflicting writes. Found in the volume's `ClusterVolume`
             field.
-          type: "integer"
-          format: "int64"
+          schema:
+            type: "integer"
+            format: "int64"
           required: true
+      x-codegen-request-body-name: "body"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              # though the schema for is an object that contains only a
+              # ClusterVolumeSpec, wrapping the ClusterVolumeSpec in this object
+              # means that if, later on, we support things like changing the
+              # labels, we can do so without duplicating that information to the
+              # ClusterVolumeSpec.
+              type: "object"
+              description: "Volume configuration"
+              properties:
+                Spec:
+                  $ref: "#/components/schemas/ClusterVolumeSpec"
+        description: |
+          The spec of the volume to update. Currently, only Availability may
+          change. All other fields must remain unchanged.
       tags: ["Volume"]
 
     delete:
@@ -9685,36 +10227,43 @@ paths:
       responses:
         204:
           description: "The volume was removed"
+          content: {}
         404:
           description: "No such volume or volume driver"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         409:
           description: "Volume is in use and cannot be removed"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "name"
           in: "path"
           required: true
           description: "Volume name or ID"
-          type: "string"
+          schema:
+            type: "string"
         - name: "force"
           in: "query"
           description: "Force the removal of the volume"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
       tags: ["Volume"]
 
   /volumes/prune:
     post:
       summary: "Delete unused volumes"
-      produces:
-        - "application/json"
       operationId: "VolumePrune"
       parameters:
         - name: "filters"
@@ -9725,27 +10274,32 @@ paths:
             Available filters:
             - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune volumes with (or without, in case `label!=...` is used) the specified labels.
             - `all` (`all=true`) - Consider all (local) volumes for pruning and not just anonymous volumes.
-          type: "string"
+          schema:
+            type: "string"
       responses:
         200:
           description: "No error"
-          schema:
-            type: "object"
-            title: "VolumePruneResponse"
-            properties:
-              VolumesDeleted:
-                description: "Volumes that were deleted"
-                type: "array"
-                items:
-                  type: "string"
-              SpaceReclaimed:
-                description: "Disk space reclaimed in bytes"
-                type: "integer"
-                format: "int64"
+          content:
+            application/json:
+              schema:
+                type: "object"
+                title: "VolumePruneResponse"
+                properties:
+                  VolumesDeleted:
+                    description: "Volumes that were deleted"
+                    type: "array"
+                    items:
+                      type: "string"
+                  SpaceReclaimed:
+                    description: "Disk space reclaimed in bytes"
+                    type: "integer"
+                    format: "int64"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       tags: ["Volume"]
   /networks:
     get:
@@ -9758,70 +10312,71 @@ paths:
         inspecting a single network. For example, the list of containers attached
         to the network is not propagated in API versions 1.28 and up.
       operationId: "NetworkList"
-      produces:
-        - "application/json"
       responses:
         200:
           description: "No error"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Network"
-          examples:
+          content:
             application/json:
-              - Name: "bridge"
-                Id: "f2de39df4171b0dc801e8002d1d999b77256983dfc63041c0f34030aa3977566"
-                Created: "2016-10-19T06:21:00.416543526Z"
-                Scope: "local"
-                Driver: "bridge"
-                EnableIPv6: false
-                Internal: false
-                Attachable: false
-                Ingress: false
-                IPAM:
-                  Driver: "default"
-                  Config:
-                    -
-                      Subnet: "172.17.0.0/16"
-                Options:
-                  com.docker.network.bridge.default_bridge: "true"
-                  com.docker.network.bridge.enable_icc: "true"
-                  com.docker.network.bridge.enable_ip_masquerade: "true"
-                  com.docker.network.bridge.host_binding_ipv4: "0.0.0.0"
-                  com.docker.network.bridge.name: "docker0"
-                  com.docker.network.driver.mtu: "1500"
-              - Name: "none"
-                Id: "e086a3893b05ab69242d3c44e49483a3bbbd3a26b46baa8f61ab797c1088d794"
-                Created: "0001-01-01T00:00:00Z"
-                Scope: "local"
-                Driver: "null"
-                EnableIPv6: false
-                Internal: false
-                Attachable: false
-                Ingress: false
-                IPAM:
-                  Driver: "default"
-                  Config: []
-                Containers: {}
-                Options: {}
-              - Name: "host"
-                Id: "13e871235c677f196c4e1ecebb9dc733b9b2d2ab589e30c539efeda84a24215e"
-                Created: "0001-01-01T00:00:00Z"
-                Scope: "local"
-                Driver: "host"
-                EnableIPv6: false
-                Internal: false
-                Attachable: false
-                Ingress: false
-                IPAM:
-                  Driver: "default"
-                  Config: []
-                Containers: {}
-                Options: {}
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/Network"
+              example:
+                - Name: "bridge"
+                  Id: "f2de39df4171b0dc801e8002d1d999b77256983dfc63041c0f34030aa3977566"
+                  Created: "2016-10-19T06:21:00.416543526Z"
+                  Scope: "local"
+                  Driver: "bridge"
+                  EnableIPv6: false
+                  Internal: false
+                  Attachable: false
+                  Ingress: false
+                  IPAM:
+                    Driver: "default"
+                    Config:
+                      -
+                        Subnet: "172.17.0.0/16"
+                  Options:
+                    com.docker.network.bridge.default_bridge: "true"
+                    com.docker.network.bridge.enable_icc: "true"
+                    com.docker.network.bridge.enable_ip_masquerade: "true"
+                    com.docker.network.bridge.host_binding_ipv4: "0.0.0.0"
+                    com.docker.network.bridge.name: "docker0"
+                    com.docker.network.driver.mtu: "1500"
+                - Name: "none"
+                  Id: "e086a3893b05ab69242d3c44e49483a3bbbd3a26b46baa8f61ab797c1088d794"
+                  Created: "0001-01-01T00:00:00Z"
+                  Scope: "local"
+                  Driver: "null"
+                  EnableIPv6: false
+                  Internal: false
+                  Attachable: false
+                  Ingress: false
+                  IPAM:
+                    Driver: "default"
+                    Config: []
+                  Containers: {}
+                  Options: {}
+                - Name: "host"
+                  Id: "13e871235c677f196c4e1ecebb9dc733b9b2d2ab589e30c539efeda84a24215e"
+                  Created: "0001-01-01T00:00:00Z"
+                  Scope: "local"
+                  Driver: "host"
+                  EnableIPv6: false
+                  Internal: false
+                  Attachable: false
+                  Ingress: false
+                  IPAM:
+                    Driver: "default"
+                    Config: []
+                  Containers: {}
+                  Options: {}
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "filters"
           in: "query"
@@ -9841,43 +10396,51 @@ paths:
             - `name=<network-name>` Matches all or part of a network name.
             - `scope=["swarm"|"global"|"local"]` Filters networks by scope (`swarm`, `global`, or `local`).
             - `type=["custom"|"builtin"]` Filters networks by type. The `custom` keyword returns all user-defined networks.
-          type: "string"
+          schema:
+            type: "string"
       tags: ["Network"]
 
   /networks/{id}:
     get:
       summary: "Inspect a network"
       operationId: "NetworkInspect"
-      produces:
-        - "application/json"
       responses:
         200:
           description: "No error"
-          schema:
-            $ref: "#/definitions/Network"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Network"
         404:
           description: "Network not found"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           description: "Network ID or name"
           required: true
-          type: "string"
+          schema:
+            type: "string"
         - name: "verbose"
           in: "query"
           description: "Detailed inspect output for troubleshooting"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "scope"
           in: "query"
           description: "Filter the network by scope (swarm, global, or local)"
-          type: "string"
+          schema:
+            type: "string"
       tags: ["Network"]
 
     delete:
@@ -9886,248 +10449,278 @@ paths:
       responses:
         204:
           description: "No error"
+          content: {}
         403:
           description: "operation not supported for pre-defined networks"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         404:
           description: "no such network"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           description: "Network ID or name"
           required: true
-          type: "string"
+          schema:
+            type: "string"
       tags: ["Network"]
 
   /networks/create:
     post:
       summary: "Create a network"
       operationId: "NetworkCreate"
-      consumes:
-        - "application/json"
-      produces:
-        - "application/json"
       responses:
         201:
           description: "No error"
-          schema:
-            type: "object"
-            title: "NetworkCreateResponse"
-            properties:
-              Id:
-                description: "The ID of the created network."
-                type: "string"
-              Warning:
-                type: "string"
-            example:
-              Id: "22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30"
-              Warning: ""
+          content:
+            application/json:
+              schema:
+                type: "object"
+                title: "NetworkCreateResponse"
+                properties:
+                  Id:
+                    description: "The ID of the created network."
+                    type: "string"
+                  Warning:
+                    type: "string"
+                example:
+                  Id: "22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30"
+                  Warning: ""
         400:
           description: "bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         403:
           description: |
             Forbidden operation. This happens when trying to create a network named after a pre-defined network,
             or when trying to create an overlay network on a daemon which is not part of a Swarm cluster.
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         404:
           description: "plugin not found"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-      parameters:
-        - name: "networkConfig"
-          in: "body"
-          description: "Network configuration"
-          required: true
-          schema:
-            type: "object"
-            title: "NetworkCreateRequest"
-            required: ["Name"]
-            properties:
-              Name:
-                description: "The network's name."
-                type: "string"
-              CheckDuplicate:
-                description: |
-                  Check for networks with duplicate names. Since Network is
-                  primarily keyed based on a random ID and not on the name, and
-                  network name is strictly a user-friendly alias to the network
-                  which is uniquely identified using ID, there is no guaranteed
-                  way to check for duplicates. CheckDuplicate is there to provide
-                  a best effort checking of any networks which has the same name
-                  but it is not guaranteed to catch all name collisions.
-                type: "boolean"
-              Driver:
-                description: "Name of the network driver plugin to use."
-                type: "string"
-                default: "bridge"
-              Internal:
-                description: "Restrict external access to the network."
-                type: "boolean"
-              Attachable:
-                description: |
-                  Globally scoped network is manually attachable by regular
-                  containers from workers in swarm mode.
-                type: "boolean"
-              Ingress:
-                description: |
-                  Ingress network is the network which provides the routing-mesh
-                  in swarm mode.
-                type: "boolean"
-              IPAM:
-                description: "Optional custom IP scheme for the network."
-                $ref: "#/definitions/IPAM"
-              EnableIPv6:
-                description: "Enable IPv6 on the network."
-                type: "boolean"
-              Options:
-                description: "Network specific options to be used by the drivers."
-                type: "object"
-                additionalProperties:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-codegen-request-body-name: "networkConfig"
+      requestBody:
+        description: "Network configuration"
+        required: true
+        content:
+          application/json:
+            schema:
+              type: "object"
+              title: "NetworkCreateRequest"
+              required: ["Name"]
+              properties:
+                Name:
+                  description: "The network's name."
                   type: "string"
-              Labels:
-                description: "User-defined key/value metadata."
-                type: "object"
-                additionalProperties:
+                CheckDuplicate:
+                  description: |
+                    Check for networks with duplicate names. Since Network is
+                    primarily keyed based on a random ID and not on the name, and
+                    network name is strictly a user-friendly alias to the network
+                    which is uniquely identified using ID, there is no guaranteed
+                    way to check for duplicates. CheckDuplicate is there to provide
+                    a best effort checking of any networks which has the same name
+                    but it is not guaranteed to catch all name collisions.
+                  type: "boolean"
+                Driver:
+                  description: "Name of the network driver plugin to use."
                   type: "string"
-            example:
-              Name: "isolated_nw"
-              CheckDuplicate: false
-              Driver: "bridge"
-              EnableIPv6: true
-              IPAM:
-                Driver: "default"
-                Config:
-                  - Subnet: "172.20.0.0/16"
-                    IPRange: "172.20.10.0/24"
-                    Gateway: "172.20.10.11"
-                  - Subnet: "2001:db8:abcd::/64"
-                    Gateway: "2001:db8:abcd::1011"
+                  default: "bridge"
+                Internal:
+                  description: "Restrict external access to the network."
+                  type: "boolean"
+                Attachable:
+                  description: |
+                    Globally scoped network is manually attachable by regular
+                    containers from workers in swarm mode.
+                  type: "boolean"
+                Ingress:
+                  description: |
+                    Ingress network is the network which provides the routing-mesh
+                    in swarm mode.
+                  type: "boolean"
+                IPAM:
+# FIXME(thaJeztah): OpenAPI v3 does not allow a description here, so we need to find a different solution.
+#                description: "Optional custom IP scheme for the network."
+                  $ref: "#/components/schemas/IPAM"
+                EnableIPv6:
+                  description: "Enable IPv6 on the network."
+                  type: "boolean"
                 Options:
-                  foo: "bar"
-              Internal: true
-              Attachable: false
-              Ingress: false
-              Options:
-                com.docker.network.bridge.default_bridge: "true"
-                com.docker.network.bridge.enable_icc: "true"
-                com.docker.network.bridge.enable_ip_masquerade: "true"
-                com.docker.network.bridge.host_binding_ipv4: "0.0.0.0"
-                com.docker.network.bridge.name: "docker0"
-                com.docker.network.driver.mtu: "1500"
-              Labels:
-                com.example.some-label: "some-value"
-                com.example.some-other-label: "some-other-value"
+                  description: "Network specific options to be used by the drivers."
+                  type: "object"
+                  additionalProperties:
+                    type: "string"
+                Labels:
+                  description: "User-defined key/value metadata."
+                  type: "object"
+                  additionalProperties:
+                    type: "string"
+              example:
+                Name: "isolated_nw"
+                CheckDuplicate: false
+                Driver: "bridge"
+                EnableIPv6: true
+                IPAM:
+                  Driver: "default"
+                  Config:
+                    - Subnet: "172.20.0.0/16"
+                      IPRange: "172.20.10.0/24"
+                      Gateway: "172.20.10.11"
+                    - Subnet: "2001:db8:abcd::/64"
+                      Gateway: "2001:db8:abcd::1011"
+                  Options:
+                    foo: "bar"
+                Internal: true
+                Attachable: false
+                Ingress: false
+                Options:
+                  com.docker.network.bridge.default_bridge: "true"
+                  com.docker.network.bridge.enable_icc: "true"
+                  com.docker.network.bridge.enable_ip_masquerade: "true"
+                  com.docker.network.bridge.host_binding_ipv4: "0.0.0.0"
+                  com.docker.network.bridge.name: "docker0"
+                  com.docker.network.driver.mtu: "1500"
+                Labels:
+                  com.example.some-label: "some-value"
+                  com.example.some-other-label: "some-other-value"
       tags: ["Network"]
 
   /networks/{id}/connect:
     post:
       summary: "Connect a container to a network"
       operationId: "NetworkConnect"
-      consumes:
-        - "application/json"
       responses:
         200:
           description: "No error"
+          content: {}
         403:
           description: "Operation not supported for swarm scoped networks"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         404:
           description: "Network or container not found"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           description: "Network ID or name"
           required: true
-          type: "string"
-        - name: "container"
-          in: "body"
-          required: true
           schema:
-            type: "object"
-            title: "NetworkConnectRequest"
-            properties:
-              Container:
-                type: "string"
-                description: "The ID or name of the container to connect to the network."
-              EndpointConfig:
-                $ref: "#/definitions/EndpointSettings"
-            example:
-              Container: "3613f73ba0e4"
-              EndpointConfig:
-                IPAMConfig:
-                  IPv4Address: "172.24.56.89"
-                  IPv6Address: "2001:db8::5689"
+            type: "string"
+      x-codegen-request-body-name: "container"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: "object"
+              title: "NetworkConnectRequest"
+              properties:
+                Container:
+                  type: "string"
+                  description: "The ID or name of the container to connect to the network."
+                EndpointConfig:
+                  $ref: "#/components/schemas/EndpointSettings"
+              example:
+                Container: "3613f73ba0e4"
+                EndpointConfig:
+                  IPAMConfig:
+                    IPv4Address: "172.24.56.89"
+                    IPv6Address: "2001:db8::5689"
       tags: ["Network"]
 
   /networks/{id}/disconnect:
     post:
       summary: "Disconnect a container from a network"
       operationId: "NetworkDisconnect"
-      consumes:
-        - "application/json"
       responses:
         200:
           description: "No error"
+          content: {}
         403:
           description: "Operation not supported for swarm scoped networks"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         404:
           description: "Network or container not found"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           description: "Network ID or name"
           required: true
-          type: "string"
-        - name: "container"
-          in: "body"
-          required: true
           schema:
-            type: "object"
-            title: "NetworkDisconnectRequest"
-            properties:
-              Container:
-                type: "string"
-                description: |
-                  The ID or name of the container to disconnect from the network.
-              Force:
-                type: "boolean"
-                description: |
-                  Force the container to disconnect from the network.
+            type: "string"
+      x-codegen-request-body-name: container
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: "object"
+              title: "NetworkDisconnectRequest"
+              properties:
+                Container:
+                  type: "string"
+                  description: |
+                    The ID or name of the container to disconnect from the network.
+                Force:
+                  type: "boolean"
+                  description: |
+                    Force the container to disconnect from the network.
       tags: ["Network"]
   /networks/prune:
     post:
       summary: "Delete unused networks"
-      produces:
-        - "application/json"
       operationId: "NetworkPrune"
       parameters:
         - name: "filters"
@@ -10138,45 +10731,54 @@ paths:
             Available filters:
             - `until=<timestamp>` Prune networks created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
             - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune networks with (or without, in case `label!=...` is used) the specified labels.
-          type: "string"
+          schema:
+            type: "string"
       responses:
         200:
           description: "No error"
-          schema:
-            type: "object"
-            title: "NetworkPruneResponse"
-            properties:
-              NetworksDeleted:
-                description: "Networks that were deleted"
-                type: "array"
-                items:
-                  type: "string"
+          content:
+            application/json:
+              schema:
+                type: "object"
+                title: "NetworkPruneResponse"
+                properties:
+                  NetworksDeleted:
+                    description: "Networks that were deleted"
+                    type: "array"
+                    items:
+                      type: "string"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       tags: ["Network"]
   /plugins:
     get:
       summary: "List plugins"
       operationId: "PluginList"
       description: "Returns information about installed plugins."
-      produces: ["application/json"]
       responses:
         200:
           description: "No error"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Plugin"
+          content:
+            application/json:
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/Plugin"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "filters"
           in: "query"
-          type: "string"
+          schema:
+            type: "string"
           description: |
             A JSON encoded value of the filters (a `map[string][]string`) to
             process on the plugin list.
@@ -10194,27 +10796,31 @@ paths:
       responses:
         200:
           description: "no error"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/PluginPrivilege"
-            example:
-              - Name: "network"
-                Description: ""
-                Value:
-                  - "host"
-              - Name: "mount"
-                Description: ""
-                Value:
-                  - "/data"
-              - Name: "device"
-                Description: ""
-                Value:
-                  - "/dev/cpu_dma_latency"
+          content:
+            application/json:
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/PluginPrivilege"
+                example:
+                  - Name: "network"
+                    Description: ""
+                    Value:
+                      - "host"
+                  - Name: "mount"
+                    Description: ""
+                    Value:
+                      - "/data"
+                  - Name: "device"
+                    Description: ""
+                    Value:
+                      - "/dev/cpu_dma_latency"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "remote"
           in: "query"
@@ -10222,7 +10828,8 @@ paths:
             The name of the plugin. The `:latest` tag is optional, and is the
             default if omitted.
           required: true
-          type: "string"
+          schema:
+            type: "string"
       tags:
         - "Plugin"
 
@@ -10233,60 +10840,67 @@ paths:
       description: |
         Pulls and installs a plugin. After the plugin is installed, it can be
         enabled using the [`POST /plugins/{name}/enable` endpoint](#operation/PostPluginsEnable).
-      produces:
-        - "application/json"
       responses:
         204:
           description: "no error"
+          content: {}
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "remote"
           in: "query"
           description: |
             Remote reference for plugin to install.
-
+            
             The `:latest` tag is optional, and is used as the default if omitted.
           required: true
-          type: "string"
+          schema:
+            type: "string"
         - name: "name"
           in: "query"
           description: |
             Local name for the pulled plugin.
-
+            
             The `:latest` tag is optional, and is used as the default if omitted.
           required: false
-          type: "string"
+          schema:
+            type: "string"
         - name: "X-Registry-Auth"
           in: "header"
           description: |
             A base64url-encoded auth configuration to use when pulling a plugin
             from a registry.
-
+            
             Refer to the [authentication section](#section/Authentication) for
             details.
-          type: "string"
-        - name: "body"
-          in: "body"
           schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/PluginPrivilege"
-            example:
-              - Name: "network"
-                Description: ""
-                Value:
-                  - "host"
-              - Name: "mount"
-                Description: ""
-                Value:
-                  - "/data"
-              - Name: "device"
-                Description: ""
-                Value:
-                  - "/dev/cpu_dma_latency"
+            type: "string"
+      x-codegen-request-body-name: "body"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/PluginPrivilege"
+              example:
+                - Name: "network"
+                  Description: ""
+                  Value:
+                    - "host"
+                - Name: "mount"
+                  Description: ""
+                  Value:
+                    - "/data"
+                - Name: "device"
+                  Description: ""
+                  Value:
+                    - "/dev/cpu_dma_latency"
       tags: ["Plugin"]
   /plugins/{name}/json:
     get:
@@ -10295,16 +10909,22 @@ paths:
       responses:
         200:
           description: "no error"
-          schema:
-            $ref: "#/definitions/Plugin"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Plugin"
         404:
           description: "plugin is not installed"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "name"
           in: "path"
@@ -10312,7 +10932,8 @@ paths:
             The name of the plugin. The `:latest` tag is optional, and is the
             default if omitted.
           required: true
-          type: "string"
+          schema:
+            type: "string"
       tags: ["Plugin"]
   /plugins/{name}:
     delete:
@@ -10321,16 +10942,22 @@ paths:
       responses:
         200:
           description: "no error"
-          schema:
-            $ref: "#/definitions/Plugin"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Plugin"
         404:
           description: "plugin is not installed"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "name"
           in: "path"
@@ -10338,14 +10965,16 @@ paths:
             The name of the plugin. The `:latest` tag is optional, and is the
             default if omitted.
           required: true
-          type: "string"
+          schema:
+            type: "string"
         - name: "force"
           in: "query"
           description: |
             Disable the plugin before removing. This may result in issues if the
             plugin is in use by a container.
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
       tags: ["Plugin"]
   /plugins/{name}/enable:
     post:
@@ -10354,14 +10983,19 @@ paths:
       responses:
         200:
           description: "no error"
+          content: {}
         404:
           description: "plugin is not installed"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "name"
           in: "path"
@@ -10369,12 +11003,14 @@ paths:
             The name of the plugin. The `:latest` tag is optional, and is the
             default if omitted.
           required: true
-          type: "string"
+          schema:
+            type: "string"
         - name: "timeout"
           in: "query"
           description: "Set the HTTP client timeout (in seconds)"
-          type: "integer"
-          default: 0
+          schema:
+            type: "integer"
+            default: 0
       tags: ["Plugin"]
   /plugins/{name}/disable:
     post:
@@ -10383,14 +11019,19 @@ paths:
       responses:
         200:
           description: "no error"
+          content: {}
         404:
           description: "plugin is not installed"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "name"
           in: "path"
@@ -10398,13 +11039,15 @@ paths:
             The name of the plugin. The `:latest` tag is optional, and is the
             default if omitted.
           required: true
-          type: "string"
+          schema:
+            type: "string"
         - name: "force"
           in: "query"
           description: |
             Force disable a plugin even if still in use.
           required: false
-          type: "boolean"
+          schema:
+            type: "boolean"
       tags: ["Plugin"]
   /plugins/{name}/upgrade:
     post:
@@ -10413,14 +11056,19 @@ paths:
       responses:
         204:
           description: "no error"
+          content: {}
         404:
           description: "plugin not installed"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "name"
           in: "path"
@@ -10428,57 +11076,64 @@ paths:
             The name of the plugin. The `:latest` tag is optional, and is the
             default if omitted.
           required: true
-          type: "string"
+          schema:
+            type: "string"
         - name: "remote"
           in: "query"
           description: |
             Remote reference to upgrade to.
-
+            
             The `:latest` tag is optional, and is used as the default if omitted.
           required: true
-          type: "string"
+          schema:
+            type: "string"
         - name: "X-Registry-Auth"
           in: "header"
           description: |
             A base64url-encoded auth configuration to use when pulling a plugin
             from a registry.
-
+            
             Refer to the [authentication section](#section/Authentication) for
             details.
-          type: "string"
-        - name: "body"
-          in: "body"
           schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/PluginPrivilege"
-            example:
-              - Name: "network"
-                Description: ""
-                Value:
-                  - "host"
-              - Name: "mount"
-                Description: ""
-                Value:
-                  - "/data"
-              - Name: "device"
-                Description: ""
-                Value:
-                  - "/dev/cpu_dma_latency"
+            type: "string"
+      x-codegen-request-body-name: body
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/PluginPrivilege"
+              example:
+                - Name: "network"
+                  Description: ""
+                  Value:
+                    - "host"
+                - Name: "mount"
+                  Description: ""
+                  Value:
+                    - "/data"
+                - Name: "device"
+                  Description: ""
+                  Value:
+                    - "/dev/cpu_dma_latency"
       tags: ["Plugin"]
   /plugins/create:
     post:
       summary: "Create a plugin"
       operationId: "PluginCreate"
-      consumes:
-        - "application/x-tar"
       responses:
         204:
           description: "no error"
+          content: {}
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "name"
           in: "query"
@@ -10486,13 +11141,17 @@ paths:
             The name of the plugin. The `:latest` tag is optional, and is the
             default if omitted.
           required: true
-          type: "string"
-        - name: "tarContext"
-          in: "body"
-          description: "Path to tar containing plugin rootfs and manifest"
           schema:
             type: "string"
-            format: "binary"
+      x-codegen-request-body-name: "tarContext"
+      requestBody:
+        description: "Path to tar containing plugin rootfs and manifest"
+        required: false
+        content:
+          application/x-tar:
+            schema:
+              type: "string"
+              format: "binary"
       tags: ["Plugin"]
   /plugins/{name}/push:
     post:
@@ -10507,25 +11166,29 @@ paths:
             The name of the plugin. The `:latest` tag is optional, and is the
             default if omitted.
           required: true
-          type: "string"
+          schema:
+            type: "string"
       responses:
         200:
           description: "no error"
+          content: {}
         404:
           description: "plugin not installed"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       tags: ["Plugin"]
   /plugins/{name}/set:
     post:
       summary: "Configure a plugin"
       operationId: "PluginSet"
-      consumes:
-        - "application/json"
       parameters:
         - name: "name"
           in: "path"
@@ -10533,25 +11196,34 @@ paths:
             The name of the plugin. The `:latest` tag is optional, and is the
             default if omitted.
           required: true
-          type: "string"
-        - name: "body"
-          in: "body"
           schema:
-            type: "array"
-            items:
-              type: "string"
-            example: ["DEBUG=1"]
+            type: "string"
+      x-codegen-request-body-name: "body"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: "array"
+              items:
+                type: "string"
+              example: ["DEBUG=1"]
+        required: false
       responses:
         204:
           description: "No error"
+          content: {}
         404:
           description: "Plugin not installed"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       tags: ["Plugin"]
   /nodes:
     get:
@@ -10560,18 +11232,24 @@ paths:
       responses:
         200:
           description: "no error"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Node"
+          content:
+            application/json:
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/Node"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "filters"
           in: "query"
@@ -10585,7 +11263,8 @@ paths:
             - `name=<node name>`
             - `node.label=<node label>`
             - `role=`(`manager`|`worker`)`
-          type: "string"
+          schema:
+            type: "string"
       tags: ["Node"]
   /nodes/{id}:
     get:
@@ -10594,25 +11273,34 @@ paths:
       responses:
         200:
           description: "no error"
-          schema:
-            $ref: "#/definitions/Node"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Node"
         404:
           description: "no such node"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           description: "The ID or name of the node"
-          type: "string"
+          schema:
+            type: "string"
           required: true
       tags: ["Node"]
     delete:
@@ -10621,29 +11309,38 @@ paths:
       responses:
         200:
           description: "no error"
+          content: {}
         404:
           description: "no such node"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           description: "The ID or name of the node"
-          type: "string"
+          schema:
+            type: "string"
           required: true
         - name: "force"
           in: "query"
           description: "Force remove a node from the swarm"
-          default: false
-          type: "boolean"
+          schema:
+            default: false
+            type: "boolean"
       tags: ["Node"]
   /nodes/{id}/update:
     post:
@@ -10652,40 +11349,54 @@ paths:
       responses:
         200:
           description: "no error"
+          content: {}
         400:
           description: "bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         404:
           description: "no such node"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           description: "The ID of the node"
-          type: "string"
-          required: true
-        - name: "body"
-          in: "body"
           schema:
-            $ref: "#/definitions/NodeSpec"
+            type: "string"
+          required: true
         - name: "version"
           in: "query"
           description: |
             The version number of the node object being updated. This is required
             to avoid conflicting writes.
-          type: "integer"
-          format: "int64"
+          schema:
+            type: "integer"
+            format: "int64"
           required: true
+      x-codegen-request-body-name: body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NodeSpec"
+        required: false
       tags: ["Node"]
   /swarm:
     get:
@@ -10694,126 +11405,140 @@ paths:
       responses:
         200:
           description: "no error"
-          schema:
-            $ref: "#/definitions/Swarm"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Swarm"
         404:
           description: "no such swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       tags: ["Swarm"]
   /swarm/init:
     post:
       summary: "Initialize a new swarm"
       operationId: "SwarmInit"
-      produces:
-        - "application/json"
-        - "text/plain"
       responses:
         200:
           description: "no error"
-          schema:
-            description: "The node ID"
-            type: "string"
-            example: "7v2t30z9blmxuhnyo6s4cpenp"
+          content:
+            text/plain:
+              schema:
+                description: "The node ID"
+                type: "string"
+                example: "7v2t30z9blmxuhnyo6s4cpenp"
         400:
           description: "bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is already part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-      parameters:
-        - name: "body"
-          in: "body"
-          required: true
-          schema:
-            type: "object"
-            title: "SwarmInitRequest"
-            properties:
-              ListenAddr:
-                description: |
-                  Listen address used for inter-manager communication, as well
-                  as determining the networking interface used for the VXLAN
-                  Tunnel Endpoint (VTEP). This can either be an address/port
-                  combination in the form `192.168.1.1:4567`, or an interface
-                  followed by a port number, like `eth0:4567`. If the port number
-                  is omitted, the default swarm listening port is used.
-                type: "string"
-              AdvertiseAddr:
-                description: |
-                  Externally reachable address advertised to other nodes. This
-                  can either be an address/port combination in the form
-                  `192.168.1.1:4567`, or an interface followed by a port number,
-                  like `eth0:4567`. If the port number is omitted, the port
-                  number from the listen address is used. If `AdvertiseAddr` is
-                  not specified, it will be automatically detected when possible.
-                type: "string"
-              DataPathAddr:
-                description: |
-                  Address or interface to use for data path traffic (format:
-                  `<ip|interface>`), for example,  `192.168.1.1`, or an interface,
-                  like `eth0`. If `DataPathAddr` is unspecified, the same address
-                  as `AdvertiseAddr` is used.
-
-                  The `DataPathAddr` specifies the address that global scope
-                  network drivers will publish towards other  nodes in order to
-                  reach the containers running on this node. Using this parameter
-                  it is possible to separate the container data traffic from the
-                  management traffic of the cluster.
-                type: "string"
-              DataPathPort:
-                description: |
-                  DataPathPort specifies the data path port number for data traffic.
-                  Acceptable port range is 1024 to 49151.
-                  if no port is set or is set to 0, default port 4789 will be used.
-                type: "integer"
-                format: "uint32"
-              DefaultAddrPool:
-                description: |
-                  Default Address Pool specifies default subnet pools for global
-                  scope networks.
-                type: "array"
-                items:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-codegen-request-body-name: "body"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: "object"
+              title: "SwarmInitRequest"
+              properties:
+                ListenAddr:
+                  description: |
+                    Listen address used for inter-manager communication, as well
+                    as determining the networking interface used for the VXLAN
+                    Tunnel Endpoint (VTEP). This can either be an address/port
+                    combination in the form `192.168.1.1:4567`, or an interface
+                    followed by a port number, like `eth0:4567`. If the port number
+                    is omitted, the default swarm listening port is used.
                   type: "string"
+                AdvertiseAddr:
+                  description: |
+                    Externally reachable address advertised to other nodes. This
+                    can either be an address/port combination in the form
+                    `192.168.1.1:4567`, or an interface followed by a port number,
+                    like `eth0:4567`. If the port number is omitted, the port
+                    number from the listen address is used. If `AdvertiseAddr` is
+                    not specified, it will be automatically detected when possible.
+                  type: "string"
+                DataPathAddr:
+                  description: |
+                    Address or interface to use for data path traffic (format:
+                    `<ip|interface>`), for example,  `192.168.1.1`, or an interface,
+                    like `eth0`. If `DataPathAddr` is unspecified, the same address
+                    as `AdvertiseAddr` is used.
+
+                    The `DataPathAddr` specifies the address that global scope
+                    network drivers will publish towards other  nodes in order to
+                    reach the containers running on this node. Using this parameter
+                    it is possible to separate the container data traffic from the
+                    management traffic of the cluster.
+                  type: "string"
+                DataPathPort:
+                  description: |
+                    DataPathPort specifies the data path port number for data traffic.
+                    Acceptable port range is 1024 to 49151.
+                    if no port is set or is set to 0, default port 4789 will be used.
+                  type: "integer"
+                  format: "uint32"
+                DefaultAddrPool:
+                  description: |
+                    Default Address Pool specifies default subnet pools for global
+                    scope networks.
+                  type: "array"
+                  items:
+                    type: "string"
                   example: ["10.10.0.0/16", "20.20.0.0/16"]
-              ForceNewCluster:
-                description: "Force creation of a new swarm."
-                type: "boolean"
-              SubnetSize:
-                description: |
-                  SubnetSize specifies the subnet size of the networks created
-                  from the default subnet pool.
-                type: "integer"
-                format: "uint32"
-              Spec:
-                $ref: "#/definitions/SwarmSpec"
-            example:
-              ListenAddr: "0.0.0.0:2377"
-              AdvertiseAddr: "192.168.1.1:2377"
-              DataPathPort: 4789
-              DefaultAddrPool: ["10.10.0.0/8", "20.20.0.0/8"]
-              SubnetSize: 24
-              ForceNewCluster: false
-              Spec:
-                Orchestration: {}
-                Raft: {}
-                Dispatcher: {}
-                CAConfig: {}
-                EncryptionConfig:
-                  AutoLockManagers: false
+                ForceNewCluster:
+                  description: "Force creation of a new swarm."
+                  type: "boolean"
+                SubnetSize:
+                  description: |
+                    SubnetSize specifies the subnet size of the networks created
+                    from the default subnet pool.
+                  type: "integer"
+                  format: "uint32"
+                Spec:
+                  $ref: "#/components/schemas/SwarmSpec"
+              example:
+                ListenAddr: "0.0.0.0:2377"
+                AdvertiseAddr: "192.168.1.1:2377"
+                DataPathPort: 4789
+                DefaultAddrPool: ["10.10.0.0/8", "20.20.0.0/8"]
+                SubnetSize: 24
+                ForceNewCluster: false
+                Spec:
+                  Orchestration: {}
+                  Raft: {}
+                  Dispatcher: {}
+                  CAConfig: {}
+                  EncryptionConfig:
+                    AutoLockManagers: false
       tags: ["Swarm"]
   /swarm/join:
     post:
@@ -10822,70 +11547,78 @@ paths:
       responses:
         200:
           description: "no error"
+          content: {}
         400:
           description: "bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is already part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-      parameters:
-        - name: "body"
-          in: "body"
-          required: true
-          schema:
-            type: "object"
-            title: "SwarmJoinRequest"
-            properties:
-              ListenAddr:
-                description: |
-                  Listen address used for inter-manager communication if the node
-                  gets promoted to manager, as well as determining the networking
-                  interface used for the VXLAN Tunnel Endpoint (VTEP).
-                type: "string"
-              AdvertiseAddr:
-                description: |
-                  Externally reachable address advertised to other nodes. This
-                  can either be an address/port combination in the form
-                  `192.168.1.1:4567`, or an interface followed by a port number,
-                  like `eth0:4567`. If the port number is omitted, the port
-                  number from the listen address is used. If `AdvertiseAddr` is
-                  not specified, it will be automatically detected when possible.
-                type: "string"
-              DataPathAddr:
-                description: |
-                  Address or interface to use for data path traffic (format:
-                  `<ip|interface>`), for example,  `192.168.1.1`, or an interface,
-                  like `eth0`. If `DataPathAddr` is unspecified, the same address
-                  as `AdvertiseAddr` is used.
-
-                  The `DataPathAddr` specifies the address that global scope
-                  network drivers will publish towards other nodes in order to
-                  reach the containers running on this node. Using this parameter
-                  it is possible to separate the container data traffic from the
-                  management traffic of the cluster.
-
-                type: "string"
-              RemoteAddrs:
-                description: |
-                  Addresses of manager nodes already participating in the swarm.
-                type: "array"
-                items:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-codegen-request-body-name: "body"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: "object"
+              title: "SwarmJoinRequest"
+              properties:
+                ListenAddr:
+                  description: |
+                    Listen address used for inter-manager communication if the node
+                    gets promoted to manager, as well as determining the networking
+                    interface used for the VXLAN Tunnel Endpoint (VTEP).
                   type: "string"
-              JoinToken:
-                description: "Secret token for joining this swarm."
-                type: "string"
-            example:
-              ListenAddr: "0.0.0.0:2377"
-              AdvertiseAddr: "192.168.1.1:2377"
-              RemoteAddrs:
-                - "node1:2377"
-              JoinToken: "SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-7p73s1dx5in4tatdymyhg9hu2"
+                AdvertiseAddr:
+                  description: |
+                    Externally reachable address advertised to other nodes. This
+                    can either be an address/port combination in the form
+                    `192.168.1.1:4567`, or an interface followed by a port number,
+                    like `eth0:4567`. If the port number is omitted, the port
+                    number from the listen address is used. If `AdvertiseAddr` is
+                    not specified, it will be automatically detected when possible.
+                  type: "string"
+                DataPathAddr:
+                  description: |
+                    Address or interface to use for data path traffic (format:
+                    `<ip|interface>`), for example,  `192.168.1.1`, or an interface,
+                    like `eth0`. If `DataPathAddr` is unspecified, the same address
+                    as `AdvertiseAddr` is used.
+
+                    The `DataPathAddr` specifies the address that global scope
+                    network drivers will publish towards other nodes in order to
+                    reach the containers running on this node. Using this parameter
+                    it is possible to separate the container data traffic from the
+                    management traffic of the cluster.
+
+                  type: "string"
+                RemoteAddrs:
+                  description: |
+                    Addresses of manager nodes already participating in the swarm.
+                  type: "array"
+                  items:
+                    type: "string"
+                JoinToken:
+                  description: "Secret token for joining this swarm."
+                  type: "string"
+              example:
+                ListenAddr: "0.0.0.0:2377"
+                AdvertiseAddr: "192.168.1.1:2377"
+                RemoteAddrs:
+                  - "node1:2377"
+                JoinToken: "SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-7p73s1dx5in4tatdymyhg9hu2"
       tags: ["Swarm"]
   /swarm/leave:
     post:
@@ -10894,22 +11627,28 @@ paths:
       responses:
         200:
           description: "no error"
+          content: {}
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "force"
           description: |
             Force leave swarm, even if this is the last manager or that it will
             break the cluster.
           in: "query"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
       tags: ["Swarm"]
   /swarm/update:
     post:
@@ -10918,107 +11657,126 @@ paths:
       responses:
         200:
           description: "no error"
+          content: {}
         400:
           description: "bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-codegen-request-body-name: "body"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SwarmSpec"
       parameters:
-        - name: "body"
-          in: "body"
-          required: true
-          schema:
-            $ref: "#/definitions/SwarmSpec"
         - name: "version"
           in: "query"
           description: |
             The version number of the swarm object being updated. This is
             required to avoid conflicting writes.
-          type: "integer"
-          format: "int64"
+          schema:
+            type: "integer"
+            format: "int64"
           required: true
         - name: "rotateWorkerToken"
           in: "query"
           description: "Rotate the worker join token."
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "rotateManagerToken"
           in: "query"
           description: "Rotate the manager join token."
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "rotateManagerUnlockKey"
           in: "query"
           description: "Rotate the manager unlock key."
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
       tags: ["Swarm"]
   /swarm/unlockkey:
     get:
       summary: "Get the unlock key"
       operationId: "SwarmUnlockkey"
-      consumes:
-        - "application/json"
       responses:
         200:
           description: "no error"
-          schema:
-            type: "object"
-            title: "UnlockKeyResponse"
-            properties:
-              UnlockKey:
-                description: "The swarm's unlock key."
-                type: "string"
-            example:
-              UnlockKey: "SWMKEY-1-7c37Cc8654o6p38HnroywCi19pllOnGtbdZEgtKxZu8"
+          content:
+            application/json:
+              schema:
+                type: "object"
+                title: "UnlockKeyResponse"
+                properties:
+                  UnlockKey:
+                    description: "The swarm's unlock key."
+                    type: "string"
+                example:
+                  UnlockKey: "SWMKEY-1-7c37Cc8654o6p38HnroywCi19pllOnGtbdZEgtKxZu8"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       tags: ["Swarm"]
   /swarm/unlock:
     post:
       summary: "Unlock a locked manager"
       operationId: "SwarmUnlock"
-      consumes:
-        - "application/json"
-      produces:
-        - "application/json"
-      parameters:
-        - name: "body"
-          in: "body"
-          required: true
-          schema:
-            type: "object"
-            title: "SwarmUnlockRequest"
-            properties:
-              UnlockKey:
-                description: "The swarm's unlock key."
-                type: "string"
-            example:
-              UnlockKey: "SWMKEY-1-7c37Cc8654o6p38HnroywCi19pllOnGtbdZEgtKxZu8"
+      x-codegen-request-body-name: "body"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: "object"
+              title: "SwarmUnlockRequest"
+              properties:
+                UnlockKey:
+                  description: "The swarm's unlock key."
+                  type: "string"
+              example:
+                UnlockKey: "SWMKEY-1-7c37Cc8654o6p38HnroywCi19pllOnGtbdZEgtKxZu8"
       responses:
         200:
           description: "no error"
+          content: {}
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       tags: ["Swarm"]
   /services:
     get:
@@ -11027,35 +11785,43 @@ paths:
       responses:
         200:
           description: "no error"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Service"
+          content:
+            application/json:
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/Service"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "filters"
           in: "query"
-          type: "string"
+          schema:
+            type: "string"
           description: |
             A JSON encoded value of the filters (a `map[string][]string`) to
             process on the services list.
-
+            
             Available filters:
-
+            
             - `id=<service id>`
             - `label=<service label>`
             - `mode=["replicated"|"global"]`
             - `name=<service name>`
         - name: "status"
           in: "query"
-          type: "boolean"
+          schema:
+            type: "boolean"
           description: |
             Include service status, with count of running and desired tasks.
       tags: ["Service"]
@@ -11063,130 +11829,141 @@ paths:
     post:
       summary: "Create a service"
       operationId: "ServiceCreate"
-      consumes:
-        - "application/json"
-      produces:
-        - "application/json"
       responses:
         201:
           description: "no error"
-          schema:
-            type: "object"
-            title: "ServiceCreateResponse"
-            properties:
-              ID:
-                description: "The ID of the created service."
-                type: "string"
-              Warning:
-                description: "Optional warning message"
-                type: "string"
-            example:
-              ID: "ak7w3gjqoa3kuz8xcpnyy0pvl"
-              Warning: "unable to pin image doesnotexist:latest to digest: image library/doesnotexist:latest not found"
+          content:
+            application/json:
+              schema:
+                type: "object"
+                title: "ServiceCreateResponse"
+                properties:
+                  ID:
+                    description: "The ID of the created service."
+                    type: "string"
+                  Warning:
+                    description: "Optional warning message"
+                    type: "string"
+                example:
+                  ID: "ak7w3gjqoa3kuz8xcpnyy0pvl"
+                  Warning: "unable to pin image doesnotexist:latest to digest: image library/doesnotexist:latest not found"
         400:
           description: "bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         403:
           description: "network is not eligible for services"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         409:
           description: "name conflicts with an existing service"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-codegen-request-body-name: "body"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/ServiceSpec"
+                - type: "object"
+                  example:
+                    Name: "web"
+                    TaskTemplate:
+                      ContainerSpec:
+                        Image: "nginx:alpine"
+                        Mounts:
+                          -
+                            ReadOnly: true
+                            Source: "web-data"
+                            Target: "/usr/share/nginx/html"
+                            Type: "volume"
+                            VolumeOptions:
+                              DriverConfig: {}
+                              Labels:
+                                com.example.something: "something-value"
+                        Hosts: ["10.10.10.10 host1", "ABCD:EF01:2345:6789:ABCD:EF01:2345:6789 host2"]
+                        User: "33"
+                        DNSConfig:
+                          Nameservers: ["8.8.8.8"]
+                          Search: ["example.org"]
+                          Options: ["timeout:3"]
+                        Secrets:
+                          -
+                            File:
+                              Name: "www.example.org.key"
+                              UID: "33"
+                              GID: "33"
+                              Mode: 384
+                            SecretID: "fpjqlhnwb19zds35k8wn80lq9"
+                            SecretName: "example_org_domain_key"
+                      LogDriver:
+                        Name: "json-file"
+                        Options:
+                          max-file: "3"
+                          max-size: "10M"
+                      Placement: {}
+                      Resources:
+                        Limits:
+                          MemoryBytes: 104857600
+                        Reservations: {}
+                      RestartPolicy:
+                        Condition: "on-failure"
+                        Delay: 10000000000
+                        MaxAttempts: 10
+                    Mode:
+                      Replicated:
+                        Replicas: 4
+                    UpdateConfig:
+                      Parallelism: 2
+                      Delay: 1000000000
+                      FailureAction: "pause"
+                      Monitor: 15000000000
+                      MaxFailureRatio: 0.15
+                    RollbackConfig:
+                      Parallelism: 1
+                      Delay: 1000000000
+                      FailureAction: "pause"
+                      Monitor: 15000000000
+                      MaxFailureRatio: 0.15
+                    EndpointSpec:
+                      Ports:
+                        -
+                          Protocol: "tcp"
+                          PublishedPort: 8080
+                          TargetPort: 80
+                    Labels:
+                      foo: "bar"
       parameters:
-        - name: "body"
-          in: "body"
-          required: true
-          schema:
-            allOf:
-              - $ref: "#/definitions/ServiceSpec"
-              - type: "object"
-                example:
-                  Name: "web"
-                  TaskTemplate:
-                    ContainerSpec:
-                      Image: "nginx:alpine"
-                      Mounts:
-                        -
-                          ReadOnly: true
-                          Source: "web-data"
-                          Target: "/usr/share/nginx/html"
-                          Type: "volume"
-                          VolumeOptions:
-                            DriverConfig: {}
-                            Labels:
-                              com.example.something: "something-value"
-                      Hosts: ["10.10.10.10 host1", "ABCD:EF01:2345:6789:ABCD:EF01:2345:6789 host2"]
-                      User: "33"
-                      DNSConfig:
-                        Nameservers: ["8.8.8.8"]
-                        Search: ["example.org"]
-                        Options: ["timeout:3"]
-                      Secrets:
-                        -
-                          File:
-                            Name: "www.example.org.key"
-                            UID: "33"
-                            GID: "33"
-                            Mode: 384
-                          SecretID: "fpjqlhnwb19zds35k8wn80lq9"
-                          SecretName: "example_org_domain_key"
-                    LogDriver:
-                      Name: "json-file"
-                      Options:
-                        max-file: "3"
-                        max-size: "10M"
-                    Placement: {}
-                    Resources:
-                      Limits:
-                        MemoryBytes: 104857600
-                      Reservations: {}
-                    RestartPolicy:
-                      Condition: "on-failure"
-                      Delay: 10000000000
-                      MaxAttempts: 10
-                  Mode:
-                    Replicated:
-                      Replicas: 4
-                  UpdateConfig:
-                    Parallelism: 2
-                    Delay: 1000000000
-                    FailureAction: "pause"
-                    Monitor: 15000000000
-                    MaxFailureRatio: 0.15
-                  RollbackConfig:
-                    Parallelism: 1
-                    Delay: 1000000000
-                    FailureAction: "pause"
-                    Monitor: 15000000000
-                    MaxFailureRatio: 0.15
-                  EndpointSpec:
-                    Ports:
-                      -
-                        Protocol: "tcp"
-                        PublishedPort: 8080
-                        TargetPort: 80
-                  Labels:
-                    foo: "bar"
         - name: "X-Registry-Auth"
           in: "header"
           description: |
             A base64url-encoded auth configuration for pulling from private
             registries.
-
+            
             Refer to the [authentication section](#section/Authentication) for
             details.
-          type: "string"
+          schema:
+            type: "string"
       tags: ["Service"]
   /services/{id}:
     get:
@@ -11195,31 +11972,41 @@ paths:
       responses:
         200:
           description: "no error"
-          schema:
-            $ref: "#/definitions/Service"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Service"
         404:
           description: "no such service"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           description: "ID or name of service."
           required: true
-          type: "string"
+          schema:
+            type: "string"
         - name: "insertDefaults"
           in: "query"
           description: "Fill empty fields with default values."
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
       tags: ["Service"]
     delete:
       summary: "Delete a service"
@@ -11227,98 +12014,117 @@ paths:
       responses:
         200:
           description: "no error"
+          content: {}
         404:
           description: "no such service"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           description: "ID or name of service."
           required: true
-          type: "string"
+          schema:
+            type: "string"
       tags: ["Service"]
   /services/{id}/update:
     post:
       summary: "Update a service"
       operationId: "ServiceUpdate"
-      consumes: ["application/json"]
-      produces: ["application/json"]
       responses:
         200:
           description: "no error"
-          schema:
-            $ref: "#/definitions/ServiceUpdateResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServiceUpdateResponse"
         400:
           description: "bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         404:
           description: "no such service"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-codegen-request-body-name: "body"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/ServiceSpec"
+                - type: "object"
+                  example:
+                    Name: "top"
+                    TaskTemplate:
+                      ContainerSpec:
+                        Image: "busybox"
+                        Args:
+                          - "top"
+                      Resources:
+                        Limits: {}
+                        Reservations: {}
+                      RestartPolicy:
+                        Condition: "any"
+                        MaxAttempts: 0
+                      Placement: {}
+                      ForceUpdate: 0
+                    Mode:
+                      Replicated:
+                        Replicas: 1
+                    UpdateConfig:
+                      Parallelism: 2
+                      Delay: 1000000000
+                      FailureAction: "pause"
+                      Monitor: 15000000000
+                      MaxFailureRatio: 0.15
+                    RollbackConfig:
+                      Parallelism: 1
+                      Delay: 1000000000
+                      FailureAction: "pause"
+                      Monitor: 15000000000
+                      MaxFailureRatio: 0.15
+                    EndpointSpec:
+                      Mode: "vip"
+
       parameters:
         - name: "id"
           in: "path"
           description: "ID or name of service."
           required: true
-          type: "string"
-        - name: "body"
-          in: "body"
-          required: true
           schema:
-            allOf:
-              - $ref: "#/definitions/ServiceSpec"
-              - type: "object"
-                example:
-                  Name: "top"
-                  TaskTemplate:
-                    ContainerSpec:
-                      Image: "busybox"
-                      Args:
-                        - "top"
-                    Resources:
-                      Limits: {}
-                      Reservations: {}
-                    RestartPolicy:
-                      Condition: "any"
-                      MaxAttempts: 0
-                    Placement: {}
-                    ForceUpdate: 0
-                  Mode:
-                    Replicated:
-                      Replicas: 1
-                  UpdateConfig:
-                    Parallelism: 2
-                    Delay: 1000000000
-                    FailureAction: "pause"
-                    Monitor: 15000000000
-                    MaxFailureRatio: 0.15
-                  RollbackConfig:
-                    Parallelism: 1
-                    Delay: 1000000000
-                    FailureAction: "pause"
-                    Monitor: 15000000000
-                    MaxFailureRatio: 0.15
-                  EndpointSpec:
-                    Mode: "vip"
-
+            type: "string"
         - name: "version"
           in: "query"
           description: |
@@ -11328,31 +12134,35 @@ paths:
             service *before* the update. You can find the current version by
             calling `GET /services/{id}`
           required: true
-          type: "integer"
+          schema:
+            type: "integer"
         - name: "registryAuthFrom"
           in: "query"
           description: |
             If the `X-Registry-Auth` header is not specified, this parameter
             indicates where to find registry authorization credentials.
-          type: "string"
-          enum: ["spec", "previous-spec"]
-          default: "spec"
+          schema:
+            type: "string"
+            enum: ["spec", "previous-spec"]
+            default: "spec"
         - name: "rollback"
           in: "query"
           description: |
             Set to this parameter to `previous` to cause a server-side rollback
             to the previous service spec. The supplied spec will be ignored in
             this case.
-          type: "string"
+          schema:
+            type: "string"
         - name: "X-Registry-Auth"
           in: "header"
           description: |
             A base64url-encoded auth configuration for pulling from private
             registries.
-
+            
             Refer to the [authentication section](#section/Authentication) for
             details.
-          type: "string"
+          schema:
+            type: "string"
 
       tags: ["Service"]
   /services/{id}/logs:
@@ -11364,217 +12174,238 @@ paths:
 
         **Note**: This endpoint works only for services with the `local`,
         `json-file` or `journald` logging drivers.
-      produces:
-        - "application/vnd.docker.raw-stream"
-        - "application/vnd.docker.multiplexed-stream"
       operationId: "ServiceLogs"
       responses:
         200:
           description: "logs returned as a stream in response body"
-          schema:
-            type: "string"
-            format: "binary"
+          content:
+            application/vnd.docker.raw-stream:
+              schema:
+                type: "string"
+                format: "binary"
+            application/vnd.docker.multiplexed-stream:
+              schema:
+                type: "string"
+                format: "binary"
         404:
           description: "no such service"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such service: c2ada9df5af8"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such service: c2ada9df5af8"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID or name of the service"
-          type: "string"
+          schema:
+            type: "string"
         - name: "details"
           in: "query"
           description: "Show service context and extra details provided to logs."
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "follow"
           in: "query"
           description: "Keep connection after returning logs."
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "stdout"
           in: "query"
           description: "Return logs from `stdout`"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "stderr"
           in: "query"
           description: "Return logs from `stderr`"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "since"
           in: "query"
           description: "Only return logs since this time, as a UNIX timestamp"
-          type: "integer"
-          default: 0
+          schema:
+            type: "integer"
+            default: 0
         - name: "timestamps"
           in: "query"
           description: "Add timestamps to every log line"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "tail"
           in: "query"
           description: |
             Only return this number of log lines from the end of the logs.
             Specify as an integer or `all` to output all log lines.
-          type: "string"
-          default: "all"
+          schema:
+            type: "string"
+            default: "all"
       tags: ["Service"]
   /tasks:
     get:
       summary: "List tasks"
       operationId: "TaskList"
-      produces:
-        - "application/json"
       responses:
         200:
           description: "no error"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Task"
-            example:
-              - ID: "0kzzo1i0y4jz6027t0k7aezc7"
-                Version:
-                  Index: 71
-                CreatedAt: "2016-06-07T21:07:31.171892745Z"
-                UpdatedAt: "2016-06-07T21:07:31.376370513Z"
-                Spec:
-                  ContainerSpec:
-                    Image: "redis"
-                  Resources:
-                    Limits: {}
-                    Reservations: {}
-                  RestartPolicy:
-                    Condition: "any"
-                    MaxAttempts: 0
-                  Placement: {}
-                ServiceID: "9mnpnzenvg8p8tdbtq4wvbkcz"
-                Slot: 1
-                NodeID: "60gvrl6tm78dmak4yl7srz94v"
-                Status:
-                  Timestamp: "2016-06-07T21:07:31.290032978Z"
-                  State: "running"
-                  Message: "started"
-                  ContainerStatus:
-                    ContainerID: "e5d62702a1b48d01c3e02ca1e0212a250801fa8d67caca0b6f35919ebc12f035"
-                    PID: 677
-                DesiredState: "running"
-                NetworksAttachments:
-                  - Network:
-                      ID: "4qvuz4ko70xaltuqbt8956gd1"
-                      Version:
-                        Index: 18
-                      CreatedAt: "2016-06-07T20:31:11.912919752Z"
-                      UpdatedAt: "2016-06-07T21:07:29.955277358Z"
-                      Spec:
-                        Name: "ingress"
-                        Labels:
-                          com.docker.swarm.internal: "true"
-                        DriverConfiguration: {}
-                        IPAMOptions:
-                          Driver: {}
-                          Configs:
-                            - Subnet: "10.255.0.0/16"
-                              Gateway: "10.255.0.1"
-                      DriverState:
-                        Name: "overlay"
-                        Options:
-                          com.docker.network.driver.overlay.vxlanid_list: "256"
-                      IPAMOptions:
-                        Driver:
-                          Name: "default"
-                        Configs:
-                          - Subnet: "10.255.0.0/16"
-                            Gateway: "10.255.0.1"
-                    Addresses:
-                      - "10.255.0.10/16"
-              - ID: "1yljwbmlr8er2waf8orvqpwms"
-                Version:
-                  Index: 30
-                CreatedAt: "2016-06-07T21:07:30.019104782Z"
-                UpdatedAt: "2016-06-07T21:07:30.231958098Z"
-                Name: "hopeful_cori"
-                Spec:
-                  ContainerSpec:
-                    Image: "redis"
-                  Resources:
-                    Limits: {}
-                    Reservations: {}
-                  RestartPolicy:
-                    Condition: "any"
-                    MaxAttempts: 0
-                  Placement: {}
-                ServiceID: "9mnpnzenvg8p8tdbtq4wvbkcz"
-                Slot: 1
-                NodeID: "60gvrl6tm78dmak4yl7srz94v"
-                Status:
-                  Timestamp: "2016-06-07T21:07:30.202183143Z"
-                  State: "shutdown"
-                  Message: "shutdown"
-                  ContainerStatus:
-                    ContainerID: "1cf8d63d18e79668b0004a4be4c6ee58cddfad2dae29506d8781581d0688a213"
-                DesiredState: "shutdown"
-                NetworksAttachments:
-                  - Network:
-                      ID: "4qvuz4ko70xaltuqbt8956gd1"
-                      Version:
-                        Index: 18
-                      CreatedAt: "2016-06-07T20:31:11.912919752Z"
-                      UpdatedAt: "2016-06-07T21:07:29.955277358Z"
-                      Spec:
-                        Name: "ingress"
-                        Labels:
-                          com.docker.swarm.internal: "true"
-                        DriverConfiguration: {}
-                        IPAMOptions:
-                          Driver: {}
-                          Configs:
-                            - Subnet: "10.255.0.0/16"
-                              Gateway: "10.255.0.1"
-                      DriverState:
-                        Name: "overlay"
-                        Options:
-                          com.docker.network.driver.overlay.vxlanid_list: "256"
-                      IPAMOptions:
-                        Driver:
-                          Name: "default"
-                        Configs:
-                          - Subnet: "10.255.0.0/16"
-                            Gateway: "10.255.0.1"
-                    Addresses:
-                      - "10.255.0.5/16"
+          content:
+            application/json:
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/Task"
+                example:
+                  - ID: "0kzzo1i0y4jz6027t0k7aezc7"
+                    Version:
+                      Index: 71
+                    CreatedAt: "2016-06-07T21:07:31.171892745Z"
+                    UpdatedAt: "2016-06-07T21:07:31.376370513Z"
+                    Spec:
+                      ContainerSpec:
+                        Image: "redis"
+                      Resources:
+                        Limits: {}
+                        Reservations: {}
+                      RestartPolicy:
+                        Condition: "any"
+                        MaxAttempts: 0
+                      Placement: {}
+                    ServiceID: "9mnpnzenvg8p8tdbtq4wvbkcz"
+                    Slot: 1
+                    NodeID: "60gvrl6tm78dmak4yl7srz94v"
+                    Status:
+                      Timestamp: "2016-06-07T21:07:31.290032978Z"
+                      State: "running"
+                      Message: "started"
+                      ContainerStatus:
+                        ContainerID: "e5d62702a1b48d01c3e02ca1e0212a250801fa8d67caca0b6f35919ebc12f035"
+                        PID: 677
+                    DesiredState: "running"
+                    NetworksAttachments:
+                      - Network:
+                          ID: "4qvuz4ko70xaltuqbt8956gd1"
+                          Version:
+                            Index: 18
+                          CreatedAt: "2016-06-07T20:31:11.912919752Z"
+                          UpdatedAt: "2016-06-07T21:07:29.955277358Z"
+                          Spec:
+                            Name: "ingress"
+                            Labels:
+                              com.docker.swarm.internal: "true"
+                            DriverConfiguration: {}
+                            IPAMOptions:
+                              Driver: {}
+                              Configs:
+                                - Subnet: "10.255.0.0/16"
+                                  Gateway: "10.255.0.1"
+                          DriverState:
+                            Name: "overlay"
+                            Options:
+                              com.docker.network.driver.overlay.vxlanid_list: "256"
+                          IPAMOptions:
+                            Driver:
+                              Name: "default"
+                            Configs:
+                              - Subnet: "10.255.0.0/16"
+                                Gateway: "10.255.0.1"
+                        Addresses:
+                          - "10.255.0.10/16"
+                  - ID: "1yljwbmlr8er2waf8orvqpwms"
+                    Version:
+                      Index: 30
+                    CreatedAt: "2016-06-07T21:07:30.019104782Z"
+                    UpdatedAt: "2016-06-07T21:07:30.231958098Z"
+                    Name: "hopeful_cori"
+                    Spec:
+                      ContainerSpec:
+                        Image: "redis"
+                      Resources:
+                        Limits: {}
+                        Reservations: {}
+                      RestartPolicy:
+                        Condition: "any"
+                        MaxAttempts: 0
+                      Placement: {}
+                    ServiceID: "9mnpnzenvg8p8tdbtq4wvbkcz"
+                    Slot: 1
+                    NodeID: "60gvrl6tm78dmak4yl7srz94v"
+                    Status:
+                      Timestamp: "2016-06-07T21:07:30.202183143Z"
+                      State: "shutdown"
+                      Message: "shutdown"
+                      ContainerStatus:
+                        ContainerID: "1cf8d63d18e79668b0004a4be4c6ee58cddfad2dae29506d8781581d0688a213"
+                    DesiredState: "shutdown"
+                    NetworksAttachments:
+                      - Network:
+                          ID: "4qvuz4ko70xaltuqbt8956gd1"
+                          Version:
+                            Index: 18
+                          CreatedAt: "2016-06-07T20:31:11.912919752Z"
+                          UpdatedAt: "2016-06-07T21:07:29.955277358Z"
+                          Spec:
+                            Name: "ingress"
+                            Labels:
+                              com.docker.swarm.internal: "true"
+                            DriverConfiguration: {}
+                            IPAMOptions:
+                              Driver: {}
+                              Configs:
+                                - Subnet: "10.255.0.0/16"
+                                  Gateway: "10.255.0.1"
+                          DriverState:
+                            Name: "overlay"
+                            Options:
+                              com.docker.network.driver.overlay.vxlanid_list: "256"
+                          IPAMOptions:
+                            Driver:
+                              Name: "default"
+                            Configs:
+                              - Subnet: "10.255.0.0/16"
+                                Gateway: "10.255.0.1"
+                        Addresses:
+                          - "10.255.0.5/16"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "filters"
           in: "query"
-          type: "string"
+          schema:
+            type: "string"
           description: |
             A JSON encoded value of the filters (a `map[string][]string`) to
             process on the tasks list.
-
+            
             Available filters:
-
+            
             - `desired-state=(running | shutdown | accepted)`
             - `id=<task id>`
             - `label=key` or `label="key=value"`
@@ -11586,31 +12417,38 @@ paths:
     get:
       summary: "Inspect a task"
       operationId: "TaskInspect"
-      produces:
-        - "application/json"
       responses:
         200:
           description: "no error"
-          schema:
-            $ref: "#/definitions/Task"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Task"
         404:
           description: "no such task"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           description: "ID of the task"
           required: true
-          type: "string"
+          schema:
+            type: "string"
       tags: ["Task"]
   /tasks/{id}/logs:
     get:
@@ -11622,129 +12460,148 @@ paths:
         **Note**: This endpoint works only for services with the `local`,
         `json-file` or `journald` logging drivers.
       operationId: "TaskLogs"
-      produces:
-        - "application/vnd.docker.raw-stream"
-        - "application/vnd.docker.multiplexed-stream"
       responses:
         200:
           description: "logs returned as a stream in response body"
-          schema:
-            type: "string"
-            format: "binary"
+          content:
+            application/vnd.docker.raw-stream:
+              schema:
+                type: "string"
+                format: "binary"
+            application/vnd.docker.multiplexed-stream:
+              schema:
+                type: "string"
+                format: "binary"
         404:
           description: "no such task"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such task: c2ada9df5af8"
+              example:
+                message: "No such task: c2ada9df5af8"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
           description: "ID of the task"
-          type: "string"
+          schema:
+            type: "string"
         - name: "details"
           in: "query"
           description: "Show task context and extra details provided to logs."
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "follow"
           in: "query"
           description: "Keep connection after returning logs."
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "stdout"
           in: "query"
           description: "Return logs from `stdout`"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "stderr"
           in: "query"
           description: "Return logs from `stderr`"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "since"
           in: "query"
           description: "Only return logs since this time, as a UNIX timestamp"
-          type: "integer"
-          default: 0
+          schema:
+            type: "integer"
+            default: 0
         - name: "timestamps"
           in: "query"
           description: "Add timestamps to every log line"
-          type: "boolean"
-          default: false
+          schema:
+            type: "boolean"
+            default: false
         - name: "tail"
           in: "query"
           description: |
             Only return this number of log lines from the end of the logs.
             Specify as an integer or `all` to output all log lines.
-          type: "string"
-          default: "all"
+          schema:
+            type: "string"
+            default: "all"
       tags: ["Task"]
   /secrets:
     get:
       summary: "List secrets"
       operationId: "SecretList"
-      produces:
-        - "application/json"
       responses:
         200:
           description: "no error"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Secret"
-            example:
-              - ID: "blt1owaxmitz71s9v5zh81zun"
-                Version:
-                  Index: 85
-                CreatedAt: "2017-07-20T13:55:28.678958722Z"
-                UpdatedAt: "2017-07-20T13:55:28.678958722Z"
-                Spec:
-                  Name: "mysql-passwd"
-                  Labels:
-                    some.label: "some.value"
-                  Driver:
-                    Name: "secret-bucket"
-                    Options:
-                      OptionA: "value for driver option A"
-                      OptionB: "value for driver option B"
-              - ID: "ktnbjxoalbkvbvedmg1urrz8h"
-                Version:
-                  Index: 11
-                CreatedAt: "2016-11-05T01:20:17.327670065Z"
-                UpdatedAt: "2016-11-05T01:20:17.327670065Z"
-                Spec:
-                  Name: "app-dev.crt"
-                  Labels:
-                    foo: "bar"
+          content:
+            application/json:
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/Secret"
+                example:
+                  - ID: "blt1owaxmitz71s9v5zh81zun"
+                    Version:
+                      Index: 85
+                    CreatedAt: "2017-07-20T13:55:28.678958722Z"
+                    UpdatedAt: "2017-07-20T13:55:28.678958722Z"
+                    Spec:
+                      Name: "mysql-passwd"
+                      Labels:
+                        some.label: "some.value"
+                      Driver:
+                        Name: "secret-bucket"
+                        Options:
+                          OptionA: "value for driver option A"
+                          OptionB: "value for driver option B"
+                  - ID: "ktnbjxoalbkvbvedmg1urrz8h"
+                    Version:
+                      Index: 11
+                    CreatedAt: "2016-11-05T01:20:17.327670065Z"
+                    UpdatedAt: "2016-11-05T01:20:17.327670065Z"
+                    Spec:
+                      Name: "app-dev.crt"
+                      Labels:
+                        foo: "bar"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "filters"
           in: "query"
-          type: "string"
+          schema:
+            type: "string"
           description: |
             A JSON encoded value of the filters (a `map[string][]string`) to
             process on the secrets list.
-
+            
             Available filters:
-
+            
             - `id=<secret id>`
             - `label=<key> or label=<key>=value`
             - `name=<secret name>`
@@ -11754,117 +12611,135 @@ paths:
     post:
       summary: "Create a secret"
       operationId: "SecretCreate"
-      consumes:
-        - "application/json"
-      produces:
-        - "application/json"
       responses:
         201:
           description: "no error"
-          schema:
-            $ref: "#/definitions/IdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IdResponse"
         409:
           description: "name conflicts with an existing object"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-      parameters:
-        - name: "body"
-          in: "body"
-          schema:
-            allOf:
-              - $ref: "#/definitions/SecretSpec"
-              - type: "object"
-                example:
-                  Name: "app-key.crt"
-                  Labels:
-                    foo: "bar"
-                  Data: "VEhJUyBJUyBOT1QgQSBSRUFMIENFUlRJRklDQVRFCg=="
-                  Driver:
-                    Name: "secret-bucket"
-                    Options:
-                      OptionA: "value for driver option A"
-                      OptionB: "value for driver option B"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-codegen-request-body-name: "body"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/SecretSpec"
+                - type: "object"
+                  example:
+                    Name: "app-key.crt"
+                    Labels:
+                      foo: "bar"
+                    Data: "VEhJUyBJUyBOT1QgQSBSRUFMIENFUlRJRklDQVRFCg=="
+                    Driver:
+                      Name: "secret-bucket"
+                      Options:
+                        OptionA: "value for driver option A"
+                        OptionB: "value for driver option B"
       tags: ["Secret"]
   /secrets/{id}:
     get:
       summary: "Inspect a secret"
       operationId: "SecretInspect"
-      produces:
-        - "application/json"
       responses:
         200:
           description: "no error"
-          schema:
-            $ref: "#/definitions/Secret"
-          examples:
+          content:
             application/json:
-              ID: "ktnbjxoalbkvbvedmg1urrz8h"
-              Version:
-                Index: 11
-              CreatedAt: "2016-11-05T01:20:17.327670065Z"
-              UpdatedAt: "2016-11-05T01:20:17.327670065Z"
-              Spec:
-                Name: "app-dev.crt"
-                Labels:
-                  foo: "bar"
-                Driver:
-                  Name: "secret-bucket"
-                  Options:
-                    OptionA: "value for driver option A"
-                    OptionB: "value for driver option B"
+              schema:
+                $ref: "#/components/schemas/Secret"
+              example:
+                ID: "ktnbjxoalbkvbvedmg1urrz8h"
+                Version:
+                  Index: 11
+                CreatedAt: "2016-11-05T01:20:17.327670065Z"
+                UpdatedAt: "2016-11-05T01:20:17.327670065Z"
+                Spec:
+                  Name: "app-dev.crt"
+                  Labels:
+                    foo: "bar"
+                  Driver:
+                    Name: "secret-bucket"
+                    Options:
+                      OptionA: "value for driver option A"
+                      OptionB: "value for driver option B"
 
         404:
           description: "secret not found"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
-          type: "string"
+          schema:
+            type: "string"
           description: "ID of the secret"
       tags: ["Secret"]
     delete:
       summary: "Delete a secret"
       operationId: "SecretDelete"
-      produces:
-        - "application/json"
       responses:
         204:
           description: "no error"
+          content: {}
         404:
           description: "secret not found"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
-          type: "string"
+          schema:
+            type: "string"
           description: "ID of the secret"
       tags: ["Secret"]
   /secrets/{id}/update:
@@ -11874,84 +12749,103 @@ paths:
       responses:
         200:
           description: "no error"
+          content: {}
         400:
           description: "bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         404:
           description: "no such secret"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-codegen-request-body-name: "body"
+      requestBody:
+        required: false
+        description: |
+          The spec of the secret to update. Currently, only the Labels field
+          can be updated. All other fields must remain unchanged from the
+          [SecretInspect endpoint](#operation/SecretInspect) response values.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SecretSpec"
       parameters:
         - name: "id"
           in: "path"
           description: "The ID or name of the secret"
-          type: "string"
-          required: true
-        - name: "body"
-          in: "body"
           schema:
-            $ref: "#/definitions/SecretSpec"
-          description: |
-            The spec of the secret to update. Currently, only the Labels field
-            can be updated. All other fields must remain unchanged from the
-            [SecretInspect endpoint](#operation/SecretInspect) response values.
+            type: "string"
+          required: true
         - name: "version"
           in: "query"
           description: |
             The version number of the secret object being updated. This is
             required to avoid conflicting writes.
-          type: "integer"
-          format: "int64"
+          schema:
+            type: "integer"
+            format: "int64"
           required: true
       tags: ["Secret"]
   /configs:
     get:
       summary: "List configs"
       operationId: "ConfigList"
-      produces:
-        - "application/json"
       responses:
         200:
           description: "no error"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Config"
-            example:
-              - ID: "ktnbjxoalbkvbvedmg1urrz8h"
-                Version:
-                  Index: 11
-                CreatedAt: "2016-11-05T01:20:17.327670065Z"
-                UpdatedAt: "2016-11-05T01:20:17.327670065Z"
-                Spec:
-                  Name: "server.conf"
+          content:
+            application/json:
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/Config"
+                example:
+                  - ID: "ktnbjxoalbkvbvedmg1urrz8h"
+                    Version:
+                      Index: 11
+                    CreatedAt: "2016-11-05T01:20:17.327670065Z"
+                    UpdatedAt: "2016-11-05T01:20:17.327670065Z"
+                    Spec:
+                      Name: "server.conf"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "filters"
           in: "query"
-          type: "string"
+          schema:
+            type: "string"
           description: |
             A JSON encoded value of the filters (a `map[string][]string`) to
             process on the configs list.
-
+            
             Available filters:
-
+            
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
@@ -11961,104 +12855,122 @@ paths:
     post:
       summary: "Create a config"
       operationId: "ConfigCreate"
-      consumes:
-        - "application/json"
-      produces:
-        - "application/json"
       responses:
         201:
           description: "no error"
-          schema:
-            $ref: "#/definitions/IdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IdResponse"
         409:
           description: "name conflicts with an existing object"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-      parameters:
-        - name: "body"
-          in: "body"
-          schema:
-            allOf:
-              - $ref: "#/definitions/ConfigSpec"
-              - type: "object"
-                example:
-                  Name: "server.conf"
-                  Labels:
-                    foo: "bar"
-                  Data: "VEhJUyBJUyBOT1QgQSBSRUFMIENFUlRJRklDQVRFCg=="
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-codegen-request-body-name: "body"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/ConfigSpec"
+                - type: "object"
+                  example:
+                    Name: "server.conf"
+                    Labels:
+                      foo: "bar"
+                    Data: "VEhJUyBJUyBOT1QgQSBSRUFMIENFUlRJRklDQVRFCg=="
       tags: ["Config"]
   /configs/{id}:
     get:
       summary: "Inspect a config"
       operationId: "ConfigInspect"
-      produces:
-        - "application/json"
       responses:
         200:
           description: "no error"
-          schema:
-            $ref: "#/definitions/Config"
-          examples:
+          content:
             application/json:
-              ID: "ktnbjxoalbkvbvedmg1urrz8h"
-              Version:
-                Index: 11
-              CreatedAt: "2016-11-05T01:20:17.327670065Z"
-              UpdatedAt: "2016-11-05T01:20:17.327670065Z"
-              Spec:
-                Name: "app-dev.crt"
+              schema:
+                $ref: "#/components/schemas/Config"
+              example:
+                ID: "ktnbjxoalbkvbvedmg1urrz8h"
+                Version:
+                  Index: 11
+                CreatedAt: "2016-11-05T01:20:17.327670065Z"
+                UpdatedAt: "2016-11-05T01:20:17.327670065Z"
+                Spec:
+                  Name: "app-dev.crt"
         404:
           description: "config not found"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
-          type: "string"
+          schema:
+            type: "string"
           description: "ID of the config"
       tags: ["Config"]
     delete:
       summary: "Delete a config"
       operationId: "ConfigDelete"
-      produces:
-        - "application/json"
       responses:
         204:
           description: "no error"
+          content: {}
         404:
           description: "config not found"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
           required: true
-          type: "string"
+          schema:
+            type: "string"
           description: "ID of the config"
       tags: ["Config"]
   /configs/{id}/update:
@@ -12068,43 +12980,57 @@ paths:
       responses:
         200:
           description: "no error"
+          content: {}
         400:
           description: "bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         404:
           description: "no such config"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         503:
           description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-codegen-request-body-name: "body"
+      requestBody:
+        required: false
+        description: |
+          The spec of the config to update. Currently, only the Labels field
+          can be updated. All other fields must remain unchanged from the
+          [ConfigInspect endpoint](#operation/ConfigInspect) response values.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConfigSpec"
       parameters:
         - name: "id"
           in: "path"
           description: "The ID or name of the config"
-          type: "string"
-          required: true
-        - name: "body"
-          in: "body"
           schema:
-            $ref: "#/definitions/ConfigSpec"
-          description: |
-            The spec of the config to update. Currently, only the Labels field
-            can be updated. All other fields must remain unchanged from the
-            [ConfigInspect endpoint](#operation/ConfigInspect) response values.
+            type: "string"
+          required: true
         - name: "version"
           in: "query"
           description: |
             The version number of the config object being updated. This is
             required to avoid conflicting writes.
-          type: "integer"
-          format: "int64"
+          schema:
+            type: "integer"
+            format: "int64"
           required: true
       tags: ["Config"]
   /distribution/{name}/json:
@@ -12113,29 +13039,33 @@ paths:
       description: |
         Return image digest and platform information by contacting the registry.
       operationId: "DistributionInspect"
-      produces:
-        - "application/json"
       responses:
         200:
           description: "descriptor and platform information"
-          schema:
-            $ref: "#/definitions/DistributionInspect"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DistributionInspect"
         401:
           description: "Failed authentication or no image found"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
+          content:
             application/json:
-              message: "No such image: someimage (tag: latest)"
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such image: someimage (tag: latest)"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: "name"
           in: "path"
           description: "Image name or id"
-          type: "string"
+          schema:
+            type: "string"
           required: true
       tags: ["Distribution"]
   /session:
@@ -12167,17 +13097,20 @@ paths:
         Upgrade: h2c
         ```
       operationId: "Session"
-      produces:
-        - "application/vnd.docker.raw-stream"
       responses:
         101:
           description: "no error, hijacking successful"
+          content: {}
         400:
           description: "bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/vnd.docker.raw-stream:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
+          content:
+            application/vnd.docker.raw-stream:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       tags: ["Session"]


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/45418

Initial conversion was done using the conversion-tool provided by swagger. I tried that conversion tool a few years back, and it wasn't great at the time, but it improved significantly. Nonetheless, quite some manual changes were needed after converting;

- The conversion tool uses a fixed order of fields, which didn't match the existing file, so made comparing impossible.
- The conversion tool optimizes YAML by leaving out quotes where possible, and using single-quotes in other cases. Ths again didn't match our existing file, and made comparing impossible.

Some General description of changes from v2 -> v3:

- `definitions` is now `components/schema`
- `parameters` with `in: body` now get their own field: `requestBody` (which can be per-mediaType)
- `parameters.type` is now `parameters.schema.type`
- `produces` / `consumes` (mediaTypes) is now defined per request / response. For example, a `200` response that can return either `application/json` or `plain/text`, now has a `content` struct, with entries for each mediaType.
- `x-nullable` is now supported by OpenAPI as `nullable`, but I kept both variants for now (to allow some tools to use the `x-` variant).

(Error) responses in multiple content-types:

OpenAPI v2 was limited in how to describe that an endpoint allowed for different content-types to be returned (produced). OpenAPI v3 addresses this limitation by allowing responses and requests to be defined per-media-type. Lacking more information, the conversion tool creates responses for every media-type, which includes variants for each error / status-code response (separate definitions for error-responses for archive/tar, application/json, text/plain, etc.). In some cases it would also create _requests_ for both, documenting a JSON request as `text/plain` (or other media-type).

Some of these may have been the result or incorrect definitions in the v2 swagger (i.e., only including a `produces`, not a `consumes`), but that's to be looked at.

There's some parts to look into;

- current version of the API should always return the JSON (ErrorResponse) type (API v1.23 and up, see [apiVersionSupportsJSONErrors][1]).
- however, the Content-Type may not be set correctly in all cases. For example, the `GET /images/get` endpoint (`imageRouter.getImagesGet`), can return either "no content type", or `application/x-tar`, depending on where in [the code the error happens][2].
- We could assume that any error (e.g. a `500`) _could_ return a plain-text error, but that's to be looked at.

For the time being, I limited most error returns to be JSON, and kept the `text/plain` variant for a follow-up.

There are some things remaining to be looked at;

- Our swagger contains "descriptions" in some places where OpenAPI V3 doesn't allow them. These look to be in cases where we re-use a single definition for multiple purposes, and try to document each of them individually. These descriptions were kept as comments, with a TODO
- Our go-swagger version does not support OpenAPI v3, which means that generating code from the swagger is currently broken. We need to update to a more recent version (something we had to do either way, as it was broken in many respects).

[1]: https://github.com/moby/moby/blob/6ce5aa1cd5a46e02ffaa3fe0c794642b35601676/api/server/errorhandler.go#L31-L34
[2]: https://github.com/moby/moby/blob/6ce5aa1cd5a46e02ffaa3fe0c794642b35601676/api/server/router/image/image_routes.go#L184-L207

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

