### PR TITLE
c8d: disable schema1 registry integration tests

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -28,6 +28,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/skip"
 )
 
 const (
@@ -364,6 +365,7 @@ func TestDockerRegistrySuite(t *testing.T) {
 }
 
 func TestDockerSchema1RegistrySuite(t *testing.T) {
+	skip.If(t, testEnv.UsingSnapshotter())
 	ctx := testutil.StartSpan(baseContext, t)
 	ensureTestEnvSetup(ctx, t)
 	suite.Run(ctx, t, &DockerSchema1RegistrySuite{ds: &DockerSuite{}})


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Disabled schema1 registry integration tests

schema1 was deprecated a while ago, containerd fails to push to a schema1 registry, let's just skip these tests for the containerd integration

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

