### PR TITLE
Delete erroneous sanity check in `setupIPChains`

### DIFF
--- a/libnetwork/drivers/bridge/setup_ip_tables_linux.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux.go
@@ -32,11 +32,6 @@ const (
 )
 
 func setupIPChains(config configuration, version iptables.IPVersion) (natChain *iptables.ChainInfo, filterChain *iptables.ChainInfo, isolationChain1 *iptables.ChainInfo, isolationChain2 *iptables.ChainInfo, retErr error) {
-	// Sanity check.
-	if !config.EnableIPTables {
-		return nil, nil, nil, nil, errors.New("cannot create new chains, EnableIPTable is disabled")
-	}
-
 	hairpinMode := !config.EnableUserlandProxy
 
 	iptable := iptables.GetIptable(version)

--- a/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
@@ -144,9 +144,11 @@ func assertIPTableChainProgramming(rule iptRule, descr string, t *testing.T) {
 func assertChainConfig(d *driver, t *testing.T) {
 	var err error
 
-	d.natChain, d.filterChain, d.isolationChain1, d.isolationChain2, err = setupIPChains(d.config, iptables.IPv4)
-	if err != nil {
-		t.Fatal(err)
+	if d.config.EnableIPTables {
+		d.natChain, d.filterChain, d.isolationChain1, d.isolationChain2, err = setupIPChains(d.config, iptables.IPv4)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	if d.config.EnableIP6Tables {
 		d.natChainV6, d.filterChainV6, d.isolationChain1V6, d.isolationChain2V6, err = setupIPChains(d.config, iptables.IPv6)
@@ -272,6 +274,22 @@ func TestOutgoingNATRules(t *testing.T) {
 			enableIPMasquerade: true,
 			hostIPv4:           hostIPv4,
 			wantIPv4Snat:       true,
+		},
+		{
+			// Regression test for https://github.com/moby/moby/issues/46467
+			desc:               "iptables disabled, IPv6 masquerade",
+			enableIP6Tables:    true,
+			enableIPv6:         true,
+			enableIPMasquerade: true,
+			wantIPv6Masq:       true,
+		},
+		{
+			desc:               "iptables disabled, IPv6 SNAT",
+			enableIP6Tables:    true,
+			enableIPv6:         true,
+			enableIPMasquerade: true,
+			hostIPv6:           hostIPv6,
+			wantIPv6Snat:       true,
 		},
 		{
 			desc:               "IPv4 masquerade, IPv6 masquerade",


### PR DESCRIPTION
This function is called for both IPv4 and IPv6, so this check broke `dockerd --iptables=false --ip6tables=true`.

**- How to verify it**

```
dockerd --ipv6 --fixed-cidr-v6=fd00::/64 --iptables=false --experimental --ip6tables
```

**- Description for the changelog**

`dockerd --iptables=false --ip6tables=true` now works.

fixes #46467 