### PR TITLE
libnetwork/portmapper: Remove unused arg from New(), and un-export PortMapper.Allocator

### DIFF
--- a/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
@@ -140,8 +140,8 @@ func assertChainConfig(d *driver, t *testing.T) {
 // Assert function which pushes chains based on bridge config parameters.
 func assertBridgeConfig(config *networkConfiguration, br *bridgeInterface, d *driver, t *testing.T) {
 	nw := bridgeNetwork{
-		portMapper:   portmapper.New(""),
-		portMapperV6: portmapper.New(""),
+		portMapper:   portmapper.New(),
+		portMapperV6: portmapper.New(),
 		config:       config,
 	}
 	nw.driver = d

--- a/libnetwork/drivers/windows/overlay/ov_network_windows.go
+++ b/libnetwork/drivers/windows/overlay/ov_network_windows.go
@@ -96,7 +96,7 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 		driver:     d,
 		endpoints:  endpointTable{},
 		subnets:    []*subnet{},
-		portMapper: portmapper.New(""),
+		portMapper: portmapper.New(),
 	}
 
 	genData, ok := option[netlabel.GenericData].(map[string]string)

--- a/libnetwork/drivers/windows/windows.go
+++ b/libnetwork/drivers/windows/windows.go
@@ -261,7 +261,7 @@ func (d *driver) createNetwork(config *networkConfiguration) *hnsNetwork {
 		endpoints:  make(map[string]*hnsEndpoint),
 		config:     config,
 		driver:     d,
-		portMapper: portmapper.New(""),
+		portMapper: portmapper.New(),
 	}
 
 	d.Lock()

--- a/libnetwork/portmapper/mapper.go
+++ b/libnetwork/portmapper/mapper.go
@@ -41,7 +41,7 @@ func New() *PortMapper {
 func NewWithPortAllocator(allocator *portallocator.PortAllocator, proxyPath string) *PortMapper {
 	return &PortMapper{
 		currentMappings: make(map[string]*mapping),
-		Allocator:       allocator,
+		allocator:       allocator,
 		proxyPath:       proxyPath,
 	}
 }
@@ -65,7 +65,7 @@ func (pm *PortMapper) MapRange(container net.Addr, hostIP net.IP, hostPortStart,
 	switch t := container.(type) {
 	case *net.TCPAddr:
 		proto = "tcp"
-		if allocatedHostPort, err = pm.Allocator.RequestPortInRange(hostIP, proto, hostPortStart, hostPortEnd); err != nil {
+		if allocatedHostPort, err = pm.allocator.RequestPortInRange(hostIP, proto, hostPortStart, hostPortEnd); err != nil {
 			return nil, err
 		}
 
@@ -88,7 +88,7 @@ func (pm *PortMapper) MapRange(container net.Addr, hostIP net.IP, hostPortStart,
 		}
 	case *net.UDPAddr:
 		proto = "udp"
-		if allocatedHostPort, err = pm.Allocator.RequestPortInRange(hostIP, proto, hostPortStart, hostPortEnd); err != nil {
+		if allocatedHostPort, err = pm.allocator.RequestPortInRange(hostIP, proto, hostPortStart, hostPortEnd); err != nil {
 			return nil, err
 		}
 
@@ -111,7 +111,7 @@ func (pm *PortMapper) MapRange(container net.Addr, hostIP net.IP, hostPortStart,
 		}
 	case *sctp.SCTPAddr:
 		proto = "sctp"
-		if allocatedHostPort, err = pm.Allocator.RequestPortInRange(hostIP, proto, hostPortStart, hostPortEnd); err != nil {
+		if allocatedHostPort, err = pm.allocator.RequestPortInRange(hostIP, proto, hostPortStart, hostPortEnd); err != nil {
 			return nil, err
 		}
 
@@ -143,7 +143,7 @@ func (pm *PortMapper) MapRange(container net.Addr, hostIP net.IP, hostPortStart,
 	// release the allocated port on any further error during return.
 	defer func() {
 		if err != nil {
-			pm.Allocator.ReleasePort(hostIP, proto, allocatedHostPort)
+			pm.allocator.ReleasePort(hostIP, proto, allocatedHostPort)
 		}
 	}()
 
@@ -161,7 +161,7 @@ func (pm *PortMapper) MapRange(container net.Addr, hostIP net.IP, hostPortStart,
 		// need to undo the iptables rules before we return
 		m.userlandProxy.Stop()
 		pm.DeleteForwardingTableEntry(m.proto, hostIP, allocatedHostPort, containerIP.String(), containerPort)
-		if err := pm.Allocator.ReleasePort(hostIP, m.proto, allocatedHostPort); err != nil {
+		if err := pm.allocator.ReleasePort(hostIP, m.proto, allocatedHostPort); err != nil {
 			return err
 		}
 
@@ -204,14 +204,14 @@ func (pm *PortMapper) Unmap(host net.Addr) error {
 
 	switch a := host.(type) {
 	case *net.TCPAddr:
-		return pm.Allocator.ReleasePort(a.IP, "tcp", a.Port)
+		return pm.allocator.ReleasePort(a.IP, "tcp", a.Port)
 	case *net.UDPAddr:
-		return pm.Allocator.ReleasePort(a.IP, "udp", a.Port)
+		return pm.allocator.ReleasePort(a.IP, "udp", a.Port)
 	case *sctp.SCTPAddr:
 		if len(a.IPAddrs) == 0 {
 			return ErrSCTPAddrNoIP
 		}
-		return pm.Allocator.ReleasePort(a.IPAddrs[0].IP, "sctp", a.Port)
+		return pm.allocator.ReleasePort(a.IPAddrs[0].IP, "sctp", a.Port)
 	}
 	return ErrUnknownBackendAddressType
 }

--- a/libnetwork/portmapper/mapper.go
+++ b/libnetwork/portmapper/mapper.go
@@ -33,8 +33,8 @@ var (
 )
 
 // New returns a new instance of PortMapper
-func New(proxyPath string) *PortMapper {
-	return NewWithPortAllocator(portallocator.Get(), proxyPath)
+func New() *PortMapper {
+	return NewWithPortAllocator(portallocator.Get(), "")
 }
 
 // NewWithPortAllocator returns a new instance of PortMapper which will use the specified PortAllocator

--- a/libnetwork/portmapper/mapper_linux.go
+++ b/libnetwork/portmapper/mapper_linux.go
@@ -18,7 +18,7 @@ type PortMapper struct {
 
 	proxyPath string
 
-	Allocator *portallocator.PortAllocator
+	allocator *portallocator.PortAllocator
 	chain     *iptables.ChainInfo
 }
 

--- a/libnetwork/portmapper/mapper_linux_test.go
+++ b/libnetwork/portmapper/mapper_linux_test.go
@@ -14,7 +14,7 @@ func init() {
 }
 
 func TestSetIptablesChain(t *testing.T) {
-	pm := New("")
+	pm := New()
 
 	c := &iptables.ChainInfo{
 		Name: "TEST",
@@ -31,7 +31,7 @@ func TestSetIptablesChain(t *testing.T) {
 }
 
 func TestMapTCPPorts(t *testing.T) {
-	pm := New("")
+	pm := New()
 	dstIP1 := net.ParseIP("192.168.0.1")
 	dstIP2 := net.ParseIP("192.168.0.2")
 	dstAddr1 := &net.TCPAddr{IP: dstIP1, Port: 80}
@@ -110,7 +110,7 @@ func TestGetUDPIPAndPort(t *testing.T) {
 }
 
 func TestMapUDPPorts(t *testing.T) {
-	pm := New("")
+	pm := New()
 	dstIP1 := net.ParseIP("192.168.0.1")
 	dstIP2 := net.ParseIP("192.168.0.2")
 	dstAddr1 := &net.UDPAddr{IP: dstIP1, Port: 80}
@@ -156,7 +156,7 @@ func TestMapUDPPorts(t *testing.T) {
 }
 
 func TestMapAllPortsSingleInterface(t *testing.T) {
-	pm := New("")
+	pm := New()
 	dstIP1 := net.ParseIP("0.0.0.0")
 	srcAddr1 := &net.TCPAddr{Port: 1080, IP: net.ParseIP("172.16.0.1")}
 
@@ -195,7 +195,7 @@ func TestMapAllPortsSingleInterface(t *testing.T) {
 }
 
 func TestMapTCPDummyListen(t *testing.T) {
-	pm := New("")
+	pm := New()
 	dstIP := net.ParseIP("0.0.0.0")
 	dstAddr := &net.TCPAddr{IP: dstIP, Port: 80}
 
@@ -232,7 +232,7 @@ func TestMapTCPDummyListen(t *testing.T) {
 }
 
 func TestMapUDPDummyListen(t *testing.T) {
-	pm := New("")
+	pm := New()
 	dstIP := net.ParseIP("0.0.0.0")
 	dstAddr := &net.UDPAddr{IP: dstIP, Port: 80}
 

--- a/libnetwork/portmapper/mapper_linux_test.go
+++ b/libnetwork/portmapper/mapper_linux_test.go
@@ -171,7 +171,7 @@ func TestMapAllPortsSingleInterface(t *testing.T) {
 	}()
 
 	for i := 0; i < 10; i++ {
-		start, end := pm.Allocator.Begin, pm.Allocator.End
+		start, end := pm.allocator.Begin, pm.allocator.End
 		for i := start; i < end; i++ {
 			if host, err = pm.Map(srcAddr1, dstIP1, 0, true); err != nil {
 				t.Fatal(err)

--- a/libnetwork/portmapper/mapper_windows.go
+++ b/libnetwork/portmapper/mapper_windows.go
@@ -17,7 +17,7 @@ type PortMapper struct {
 
 	proxyPath string
 
-	Allocator *portallocator.PortAllocator
+	allocator *portallocator.PortAllocator
 }
 
 // AppendForwardingTableEntry adds a port mapping to the forwarding table

--- a/libnetwork/portmapper/mapper_windows.go
+++ b/libnetwork/portmapper/mapper_windows.go
@@ -29,9 +29,3 @@ func (pm *PortMapper) AppendForwardingTableEntry(proto string, sourceIP net.IP, 
 func (pm *PortMapper) DeleteForwardingTableEntry(proto string, sourceIP net.IP, sourcePort int, containerIP string, containerPort int) error {
 	return nil
 }
-
-// checkIP checks if IP is valid and matching to chain version
-func (pm *PortMapper) checkIP(ip net.IP) bool {
-	// no IPv6 for port mapper on windows -> only IPv4 valid
-	return ip.To4() != nil
-}


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/46446#discussion_r1321384136

### libnetwork/portmapper: New(): remove unused argument

None of the code using this function was setting the value, so let's
simplify and remove the argument.


### libnetwork/portmapper: un-export PortMapper.Allocator

It was only accessed through methods on PortMapper, and in tests.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

