### PR TITLE
[backport 24.0] daemon: fix under what conditions container's mac-address is applied

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -875,8 +875,8 @@ func buildCreateEndpointOptions(c *container.Container, n libnetwork.Network, ep
 	// to which container was connected to on docker run.
 	// Ideally all these network-specific endpoint configurations must be moved under
 	// container.NetworkSettings.Networks[n.Name()]
-	if n.Name() == c.HostConfig.NetworkMode.NetworkName() ||
-		(n.Name() == defaultNetName && c.HostConfig.NetworkMode.IsDefault()) {
+	netMode := c.HostConfig.NetworkMode
+	if n.Name() == netMode.NetworkName() || n.ID() == netMode.NetworkName() || (n.Name() == defaultNetName && netMode.IsDefault()) {
 		if c.Config.MacAddress != "" {
 			mac, err := net.ParseMAC(c.Config.MacAddress)
 			if err != nil {

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -291,3 +291,29 @@ func TestRunWithAlternativeContainerdShim(t *testing.T) {
 
 	assert.Equal(t, strings.TrimSpace(b.String()), "Hello, world!")
 }
+
+func TestMacAddressIsAppliedToMainNetworkWithShortID(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon)
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+
+	ctx := context.Background()
+
+	d := daemon.New(t)
+	d.StartWithBusybox(t)
+	defer d.Stop(t)
+
+	apiClient := d.NewClientT(t)
+
+	n := net.CreateNoError(ctx, t, apiClient, "testnet", net.WithIPAM("192.168.101.0/24", "192.168.101.1"))
+
+	cid := container.Run(ctx, t, apiClient,
+		container.WithImage("busybox:latest"),
+		container.WithCmd("/bin/sleep", "infinity"),
+		container.WithStopSignal("SIGKILL"),
+		container.WithNetworkMode(n[:10]),
+		container.WithMacAddress("02:42:08:26:a9:55"))
+	defer container.Remove(ctx, t, apiClient, cid, types.ContainerRemoveOptions{Force: true})
+
+	c := container.Inspect(ctx, t, apiClient, cid)
+	assert.Equal(t, c.NetworkSettings.Networks["testnet"].MacAddress, "02:42:08:26:a9:55")
+}

--- a/integration/internal/container/container.go
+++ b/integration/internal/container/container.go
@@ -71,3 +71,19 @@ func Run(ctx context.Context, t *testing.T, client client.APIClient, ops ...func
 
 	return id
 }
+
+func Remove(ctx context.Context, t *testing.T, apiClient client.APIClient, container string, options types.ContainerRemoveOptions) {
+	t.Helper()
+
+	err := apiClient.ContainerRemove(ctx, container, options)
+	assert.NilError(t, err)
+}
+
+func Inspect(ctx context.Context, t *testing.T, apiClient client.APIClient, containerRef string) types.ContainerJSON {
+	t.Helper()
+
+	c, err := apiClient.ContainerInspect(ctx, containerRef)
+	assert.NilError(t, err)
+
+	return c
+}

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -255,3 +255,15 @@ func WithSecurityOpt(opt string) func(*TestContainerConfig) {
 		c.HostConfig.SecurityOpt = append(c.HostConfig.SecurityOpt, opt)
 	}
 }
+
+func WithStopSignal(stopSignal string) func(c *TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.Config.StopSignal = stopSignal
+	}
+}
+
+func WithMacAddress(address string) func(c *TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.Config.MacAddress = address
+	}
+}


### PR DESCRIPTION
Backports:

- https://github.com/moby/moby/pull/46406
- fixes https://github.com/moby/moby/issues/46404
- fixes docker/compose#10796

