### PR TITLE
api/pull: Move reference parsing from imageService, validate repo

### DIFF
--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -37,7 +37,7 @@ type importExportBackend interface {
 }
 
 type registryBackend interface {
-	PullImage(ctx context.Context, image, tag string, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
+	PullImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
 	PushImage(ctx context.Context, ref reference.Named, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
 }
 

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -76,7 +76,7 @@ type VolumeBackend interface {
 
 // ImageBackend is used by an executor to perform image operations
 type ImageBackend interface {
-	PullImage(ctx context.Context, image, tag string, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
+	PullImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
 	GetRepository(context.Context, reference.Named, *registry.AuthConfig) (distribution.Repository, error)
 	GetImage(ctx context.Context, refOrID string, options opts.GetImageOpts) (*image.Image, error)
 }

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -104,7 +104,10 @@ func (c *containerAdapter) pullImage(ctx context.Context) error {
 	go func() {
 		// TODO LCOW Support: This will need revisiting as
 		// the stack is built up to include LCOW support for swarm.
-		err := c.imageBackend.PullImage(ctx, c.container.image(), "", nil, metaHeaders, authConfig, pw)
+
+		// Make sure the image has a tag, otherwise it will pull all tags.
+		ref := reference.TagNameOnly(named)
+		err := c.imageBackend.PullImage(ctx, ref, nil, metaHeaders, authConfig, pw)
 		pw.CloseWithError(err)
 	}()
 

--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -117,7 +117,6 @@ func (i *ImageService) pullForBuilder(ctx context.Context, name string, authConf
 	if err != nil {
 		return nil, err
 	}
-	taggedRef := reference.TagNameOnly(ref)
 
 	pullRegistryAuth := &registry.AuthConfig{}
 	if len(authConfigs) > 0 {
@@ -131,7 +130,7 @@ func (i *ImageService) pullForBuilder(ctx context.Context, name string, authConf
 		pullRegistryAuth = &resolvedConfig
 	}
 
-	if err := i.PullImage(ctx, ref.Name(), taggedRef.(reference.NamedTagged).Tag(), platform, nil, pullRegistryAuth, output); err != nil {
+	if err := i.PullImage(ctx, reference.TagNameOnly(ref), platform, nil, pullRegistryAuth, output); err != nil {
 		return nil, err
 	}
 

--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -16,35 +16,14 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
-	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// PullImage initiates a pull operation. image is the repository name to pull, and
-// tagOrDigest may be either empty, or indicate a specific tag or digest to pull.
-func (i *ImageService) PullImage(ctx context.Context, image, tagOrDigest string, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error {
+// PullImage initiates a pull operation. ref is the image to pull.
+func (i *ImageService) PullImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error {
 	var opts []containerd.RemoteOpt
 	if platform != nil {
 		opts = append(opts, containerd.WithPlatform(platforms.Format(*platform)))
-	}
-	ref, err := reference.ParseNormalizedNamed(image)
-	if err != nil {
-		return errdefs.InvalidParameter(err)
-	}
-
-	// TODO(thaJeztah) this could use a WithTagOrDigest() utility
-	if tagOrDigest != "" {
-		// The "tag" could actually be a digest.
-		var dgst digest.Digest
-		dgst, err = digest.Parse(tagOrDigest)
-		if err == nil {
-			ref, err = reference.WithDigest(reference.TrimNamed(ref), dgst)
-		} else {
-			ref, err = reference.WithTag(ref, tagOrDigest)
-		}
-		if err != nil {
-			return errdefs.InvalidParameter(err)
-		}
 	}
 
 	resolver, _ := i.newResolverFromAuthConfig(ctx, authConfig)
@@ -77,6 +56,12 @@ func (i *ImageService) PullImage(ctx context.Context, image, tagOrDigest string,
 	ah := images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 		if images.IsManifestType(desc.MediaType) {
 			if !sentPullingFrom {
+				var tagOrDigest string
+				if tagged, ok := ref.(reference.Tagged); ok {
+					tagOrDigest = tagged.Tag()
+				} else {
+					tagOrDigest = ref.String()
+				}
 				progress.Message(out, tagOrDigest, "Pulling from "+reference.Path(ref))
 				sentPullingFrom = true
 			}

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -27,7 +27,7 @@ import (
 type ImageService interface {
 	// Images
 
-	PullImage(ctx context.Context, name, tag string, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
+	PullImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
 	PushImage(ctx context.Context, ref reference.Named, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
 	CreateImage(ctx context.Context, config []byte, parent string, contentStoreDigest digest.Digest) (builder.Image, error)
 	ImageDelete(ctx context.Context, imageRef string, force, prune bool) ([]types.ImageDeleteResponseItem, error)

--- a/daemon/images/image_pull.go
+++ b/daemon/images/image_pull.go
@@ -3,7 +3,6 @@ package images // import "github.com/docker/docker/daemon/images"
 import (
 	"context"
 	"io"
-	"strings"
 	"time"
 
 	"github.com/containerd/containerd/leases"
@@ -17,40 +16,16 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
-	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
 // PullImage initiates a pull operation. image is the repository name to pull, and
 // tag may be either empty, or indicate a specific tag to pull.
-func (i *ImageService) PullImage(ctx context.Context, image, tag string, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error {
+func (i *ImageService) PullImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error {
 	start := time.Now()
-	// Special case: "pull -a" may send an image name with a
-	// trailing :. This is ugly, but let's not break API
-	// compatibility.
-	image = strings.TrimSuffix(image, ":")
 
-	ref, err := reference.ParseNormalizedNamed(image)
-	if err != nil {
-		return errdefs.InvalidParameter(err)
-	}
-
-	if tag != "" {
-		// The "tag" could actually be a digest.
-		var dgst digest.Digest
-		dgst, err = digest.Parse(tag)
-		if err == nil {
-			ref, err = reference.WithDigest(reference.TrimNamed(ref), dgst)
-		} else {
-			ref, err = reference.WithTag(ref, tag)
-		}
-		if err != nil {
-			return errdefs.InvalidParameter(err)
-		}
-	}
-
-	err = i.pullImageWithReference(ctx, ref, platform, metaHeaders, authConfig, outStream)
+	err := i.pullImageWithReference(ctx, ref, platform, metaHeaders, authConfig, outStream)
 	imageActions.WithValues("pull").UpdateSince(start)
 	if err != nil {
 		return err
@@ -70,7 +45,7 @@ func (i *ImageService) PullImage(ctx context.Context, image, tag string, platfor
 		if errdefs.IsNotFound(err) && img != nil {
 			po := streamformatter.NewJSONProgressOutput(outStream, false)
 			progress.Messagef(po, "", `WARNING: %s`, err.Error())
-			log.G(ctx).WithError(err).WithField("image", image).Warn("ignoring platform mismatch on single-arch image")
+			log.G(ctx).WithError(err).WithField("image", reference.FamiliarName(ref)).Warn("ignoring platform mismatch on single-arch image")
 		} else if err != nil {
 			return err
 		}


### PR DESCRIPTION
**imageService/PullImage: Move reference parse to api**

Make `PullImage` accept `reference.Named` directly instead of
duplicating the parsing code for both graphdriver and containerd image
service implementations.

**api/pull: Validate repo name**

Copy the check for "scratch" image pull attempt from the distribution
to the API.



**- How to verify it**
1. CI still passes
2. `TestPullScratchNotAllowed` is now green with c8d integration

```diff
$ make TEST_FILTER='TestPullScratchNotAllowed'  TEST_IGNORE_CGROUP_CHECK=1 DOCKER_GRAPHDRIVER=overlayfs TEST_INTEGRATION_USE_SNAPSHOTTER=1   test-integration

=== RUN   TestDockerHubPullSuite/TestPullScratchNotAllowed
-    docker_cli_pull_test.go:203: assertion failed: expression is false: strings.Contains(out, "'scratch' is a reserved -name")
---- FAIL: TestDockerHubPullSuite (2.21s)
-    --- FAIL: TestDockerHubPullSuite/TestPullScratchNotAllowed (2.20s)
-FAIL
+--- PASS: TestDockerHubPullSuite (2.17s)
+    --- PASS: TestDockerHubPullSuite/TestPullScratchNotAllowed (2.14s)
+PASS
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

