### PR TITLE
libnetwork: remove some dead code around netWatch

### DIFF
--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -567,9 +567,8 @@ func (ep *Endpoint) sbJoin(sb *Sandbox, options ...EndpointOption) (err error) {
 
 func (ep *Endpoint) rename(name string) error {
 	var (
-		err      error
-		netWatch *netWatch
-		ok       bool
+		err error
+		ok  bool
 	)
 
 	n := ep.getNetwork()
@@ -591,12 +590,13 @@ func (ep *Endpoint) rename(name string) error {
 		}
 	} else {
 		c.mu.Lock()
-		netWatch, ok = c.nmap[n.ID()]
+		_, ok = c.nmap[n.ID()]
 		c.mu.Unlock()
 		if !ok {
+			// FIXME(thaJeztah): what is this check for, or is this to prevent a race condition (network removed)?
 			return fmt.Errorf("watch null for network %q", n.Name())
 		}
-		n.updateSvcRecord(ep, c.getLocalEps(netWatch), false)
+		n.updateSvcRecord(ep, false)
 	}
 
 	oldName := ep.name
@@ -621,13 +621,13 @@ func (ep *Endpoint) rename(name string) error {
 			}
 		}()
 	} else {
-		n.updateSvcRecord(ep, c.getLocalEps(netWatch), true)
+		n.updateSvcRecord(ep, true)
 		defer func() {
 			if err != nil {
-				n.updateSvcRecord(ep, c.getLocalEps(netWatch), false)
+				n.updateSvcRecord(ep, false)
 				ep.name = oldName
 				ep.anonymous = oldAnonymous
-				n.updateSvcRecord(ep, c.getLocalEps(netWatch), true)
+				n.updateSvcRecord(ep, true)
 			}
 		}()
 	}

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1272,7 +1272,7 @@ func (n *Network) EndpointByID(id string) (*Endpoint, error) {
 	return ep, nil
 }
 
-func (n *Network) updateSvcRecord(ep *Endpoint, localEps []*Endpoint, isAdd bool) {
+func (n *Network) updateSvcRecord(ep *Endpoint, isAdd bool) {
 	var ipv6 net.IP
 	epName := ep.Name()
 	if iface := ep.Iface(); iface != nil && iface.Address() != nil {

--- a/libnetwork/store.go
+++ b/libnetwork/store.go
@@ -196,18 +196,6 @@ type netWatch struct {
 	remoteEps map[string]*Endpoint
 }
 
-func (c *Controller) getLocalEps(nw *netWatch) []*Endpoint {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	var epl []*Endpoint
-	for _, ep := range nw.localEps {
-		epl = append(epl, ep)
-	}
-
-	return epl
-}
-
 func (c *Controller) watchSvcRecord(ep *Endpoint) {
 	c.watchCh <- ep
 }
@@ -231,7 +219,7 @@ func (c *Controller) processEndpointCreate(ep *Endpoint) {
 
 	if ok {
 		// Update the svc db for the local endpoint join right away
-		n.updateSvcRecord(ep, c.getLocalEps(nw), true)
+		n.updateSvcRecord(ep, true)
 
 		c.mu.Lock()
 		nw.localEps[endpointID] = ep
@@ -252,7 +240,7 @@ func (c *Controller) processEndpointCreate(ep *Endpoint) {
 	// Update the svc db for the local endpoint join right away
 	// Do this before adding this ep to localEps so that we don't
 	// try to update this ep's container's svc records
-	n.updateSvcRecord(ep, c.getLocalEps(nw), true)
+	n.updateSvcRecord(ep, true)
 
 	c.mu.Lock()
 	nw.localEps[endpointID] = ep
@@ -277,7 +265,7 @@ func (c *Controller) processEndpointDelete(ep *Endpoint) {
 		// Update the svc db about local endpoint leave right away
 		// Do this after we remove this ep from localEps so that we
 		// don't try to remove this svc record from this ep's container.
-		n.updateSvcRecord(ep, c.getLocalEps(nw), false)
+		n.updateSvcRecord(ep, false)
 
 		c.mu.Lock()
 		if len(nw.localEps) == 0 {


### PR DESCRIPTION
### libnetwork: Controller.processEndpointCreate, Delete: remove nmap arg

It was used to pass the controller's own field; let's just use the
field directly instead.

### libnetwork: Network.updateSvcRecord: remove unused localEps arg

### libnetwork: remove netWatch.remoteEps, as it's unused




**- A picture of a cute animal (not mandatory but encouraged)**

