### PR TITLE
api/t/swarm: Fix deprecation for ServiceSpec.Networks

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4248,7 +4248,10 @@ definitions:
               - "stop-first"
               - "start-first"
       Networks:
-        description: "Specifies which networks the service should attach to."
+        description: |
+          Specifies which networks the service should attach to.
+
+          Deprecated: This field is deprecated since v1.44. The Networks field in TaskSpec should be used instead.
         type: "array"
         items:
           $ref: "#/definitions/NetworkAttachmentConfig"

--- a/api/types/swarm/service.go
+++ b/api/types/swarm/service.go
@@ -34,9 +34,9 @@ type ServiceSpec struct {
 	UpdateConfig   *UpdateConfig `json:",omitempty"`
 	RollbackConfig *UpdateConfig `json:",omitempty"`
 
-	// Networks field in ServiceSpec is deprecated. The
-	// same field in TaskSpec should be used instead.
-	// This field will be removed in a future release.
+	// Networks specifies which networks the service should attach to.
+	//
+	// Deprecated: This field is deprecated since v1.44. The Networks field in TaskSpec should be used instead.
 	Networks     []NetworkAttachmentConfig `json:",omitempty"`
 	EndpointSpec *EndpointSpec             `json:",omitempty"`
 }

--- a/daemon/cluster/convert/service.go
+++ b/daemon/cluster/convert/service.go
@@ -158,8 +158,8 @@ func ServiceSpecToGRPC(s types.ServiceSpec) (swarmapi.ServiceSpec, error) {
 		name = namesgenerator.GetRandomName(0)
 	}
 
-	serviceNetworks := make([]*swarmapi.NetworkAttachmentConfig, 0, len(s.Networks))
-	for _, n := range s.Networks {
+	serviceNetworks := make([]*swarmapi.NetworkAttachmentConfig, 0, len(s.Networks)) //nolint:staticcheck // ignore SA1019: field is deprecated.
+	for _, n := range s.Networks {                                                   //nolint:staticcheck // ignore SA1019: field is deprecated.
 		netConfig := &swarmapi.NetworkAttachmentConfig{Target: n.Target, Aliases: n.Aliases, DriverAttachmentOpts: n.DriverOpts}
 		serviceNetworks = append(serviceNetworks, netConfig)
 	}

--- a/daemon/cluster/networks.go
+++ b/daemon/cluster/networks.go
@@ -306,7 +306,7 @@ func (c *Cluster) populateNetworkID(ctx context.Context, client swarmapi.Control
 	// but fallback to service spec for backward compatibility
 	networks := s.TaskTemplate.Networks
 	if len(networks) == 0 {
-		networks = s.Networks
+		networks = s.Networks //nolint:staticcheck // ignore SA1019: field is deprecated.
 	}
 	for i, n := range networks {
 		apiNetwork, err := getNetwork(ctx, client, n.Target)

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -63,6 +63,8 @@ keywords: "API, Docker, rcli, REST, documentation"
 * A new endpoint-specific `MacAddress` field has been added to `NetworkSettings.EndpointSettings`
   on `POST /containers/create`, and to `EndpointConfig` on `POST /networks/{id}/connect`.
   The container-wide `MacAddress` field in `Config`, on `POST /containers/create`, is now deprecated.
+* The field `Networks` in the `POST /services/create` and `POST /services/{id}/update`
+  requests is now deprecated. You should instead use the field `TaskTemplate.Networks`.
 
 ## v1.43 API changes
 


### PR DESCRIPTION
**- What I did**

Fix the comment format to make linters able to catch the deprecation warning.

