### PR TITLE
c8d/push: Support pushing all tags 

### DIFF
--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -27,7 +29,8 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
-// PushImage initiates a push operation of the image pointed to by targetRef.
+// PushImage initiates a push operation of the image pointed to by sourceRef.
+// If reference is untagged, all tags from the reference repository are pushed.
 // Image manifest (or index) is pushed as is, which will probably fail if you
 // don't have all content referenced by the index.
 // Cross-repo mounts will be attempted for non-existing blobs.
@@ -36,13 +39,44 @@ import (
 // pointing to the new target repository. This will allow subsequent pushes
 // to perform cross-repo mounts of the shared content when pushing to a different
 // repository on the same registry.
-func (i *ImageService) PushImage(ctx context.Context, targetRef reference.Named, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) (retErr error) {
-	if _, tagged := targetRef.(reference.Tagged); !tagged {
-		if _, digested := targetRef.(reference.Digested); !digested {
-			return errdefs.NotImplemented(errors.New("push all tags is not implemented"))
+func (i *ImageService) PushImage(ctx context.Context, sourceRef reference.Named, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) (retErr error) {
+	out := streamformatter.NewJSONProgressOutput(outStream, false)
+
+	if _, tagged := sourceRef.(reference.Tagged); !tagged {
+		if _, digested := sourceRef.(reference.Digested); !digested {
+			// Image is not tagged nor digested, that means all tags push was requested.
+
+			// Find all images with the same repository.
+			nameFilter := "^" + regexp.QuoteMeta(sourceRef.Name()) + ":" + reference.TagRegexp.String() + "$"
+			imgs, err := i.client.ImageService().List(ctx, "name~="+strconv.Quote(nameFilter))
+			if err != nil {
+				return err
+			}
+
+			for _, img := range imgs {
+				named, err := reference.ParseNamed(img.Name)
+				if err != nil {
+					// This shouldn't happen, but log a warning just in case.
+					log.G(ctx).WithFields(log.Fields{
+						"image":     img.Name,
+						"sourceRef": sourceRef,
+					}).Warn("refusing to push an invalid tag")
+					continue
+				}
+
+				if err := i.pushRef(ctx, named, metaHeaders, authConfig, out); err != nil {
+					return err
+				}
+			}
+
+			return nil
 		}
 	}
 
+	return i.pushRef(ctx, sourceRef, metaHeaders, authConfig, out)
+}
+
+func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, metaHeaders map[string][]string, authConfig *registry.AuthConfig, out progress.Output) (retErr error) {
 	leasedCtx, release, err := i.client.WithLease(ctx)
 	if err != nil {
 		return err
@@ -52,8 +86,6 @@ func (i *ImageService) PushImage(ctx context.Context, targetRef reference.Named,
 			log.G(ctx).WithField("image", targetRef).WithError(err).Warn("failed to release lease created for push")
 		}
 	}()
-
-	out := streamformatter.NewJSONProgressOutput(outStream, false)
 
 	img, err := i.client.ImageService().Get(ctx, targetRef.String())
 	if err != nil {

--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -41,6 +41,7 @@ import (
 // repository on the same registry.
 func (i *ImageService) PushImage(ctx context.Context, sourceRef reference.Named, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) (retErr error) {
 	out := streamformatter.NewJSONProgressOutput(outStream, false)
+	progress.Messagef(out, "", "The push refers to repository [%s]", sourceRef.Name())
 
 	if _, tagged := sourceRef.(reference.Tagged); !tagged {
 		if _, digested := sourceRef.(reference.Digested); !digested {


### PR DESCRIPTION
 **c8d/push: Support pushing all tags**

Implement missing feature that pushes all tags from the provided local
repository.

**c8d/push: Add missing message about repository**

(a bit unrelated but I decided to include it here since it's only one line and I'm already making changes here)

Add "The push referers to repository X" message which is present in the
push output when using the graphdrivers.


**- How to verify it**
[c8d integration tests CI](https://github.com/moby/moby/actions/runs/6187498841/job/16797538706?pr=45232)
```diff
-DONE 277 tests, 5 skipped, 54 failures in 447.508s
+DONE 277 tests, 5 skipped, 47 failures in 501.680s
```

```bash
$ make TEST_FILTER='TestPushMultipleTags'  TEST_IGNORE_CGROUP_CHECK=1 DOCKERCLI_INTEGRATION_VERSION=v24.0.5  DOCKER_GRAPHDRIVER=overlayfs TEST_INTEGRATION_USE_SNAPSHOTTER=1 test-integration
...
=== RUN   TestDockerRegistrySuite/TestPushMultipleTags
--- PASS: TestDockerRegistrySuite (0.27s)
    --- PASS: TestDockerRegistrySuite/TestPushMultipleTags (0.27s)
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

