### PR TITLE
c8d: Refuse images with digest algo when tagging

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -24,6 +24,7 @@ import (
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
@@ -413,6 +414,11 @@ func (ir *imageRouter) postImagesTag(ctx context.Context, w http.ResponseWriter,
 	ref, err := httputils.RepoTagReference(r.Form.Get("repo"), r.Form.Get("tag"))
 	if ref == nil || err != nil {
 		return errdefs.InvalidParameter(err)
+	}
+
+	refName := reference.FamiliarName(ref)
+	if refName == string(digest.Canonical) {
+		return errdefs.InvalidParameter(errors.New("refusing to create an ambiguous tag using digest algorithm as name"))
 	}
 
 	img, err := ir.backend.GetImage(ctx, vars["name"], opts.GetImageOpts{})


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Checked if the tag resembles a digest algorithm name before tagging and returning an error.

**- How I did it**

**- How to verify it**

Run 

```console
$ make TEST_FILTER='TestTagUsingDigestAlgorithmAsName' TEST_IGNORE_CGROUP_CHECK=1 DOCKERCLI_INTEGRATION_VERSION=v24.0.5  DOCKER_GRAPHDRIVER=overlayfs TEST_INTEGRATION_USE_SNAPSHOTTER=1 test-integration
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

