### PR TITLE
c8d: Fix `docker diff`

### DIFF
--- a/daemon/containerd/image_changes.go
+++ b/daemon/containerd/image_changes.go
@@ -2,68 +2,35 @@ package containerd
 
 import (
 	"context"
-	"encoding/json"
 
-	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/pkg/archive"
-	"github.com/google/uuid"
-	"github.com/opencontainers/image-spec/identity"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func (i *ImageService) Changes(ctx context.Context, container *container.Container) ([]archive.Change, error) {
-	cs := i.client.ContentStore()
-
-	imageManifest, err := getContainerImageManifest(container)
-	if err != nil {
-		return nil, err
-	}
-
-	imageManifestBytes, err := content.ReadBlob(ctx, cs, imageManifest)
-	if err != nil {
-		return nil, err
-	}
-	var manifest ocispec.Manifest
-	if err := json.Unmarshal(imageManifestBytes, &manifest); err != nil {
-		return nil, err
-	}
-
-	imageConfigBytes, err := content.ReadBlob(ctx, cs, manifest.Config)
-	if err != nil {
-		return nil, err
-	}
-	var image ocispec.Image
-	if err := json.Unmarshal(imageConfigBytes, &image); err != nil {
-		return nil, err
-	}
-
-	rnd, err := uuid.NewRandom()
-	if err != nil {
-		return nil, err
-	}
-
 	snapshotter := i.client.SnapshotService(container.Driver)
-
-	diffIDs := image.RootFS.DiffIDs
-	parent, err := snapshotter.View(ctx, rnd.String(), identity.ChainID(diffIDs).String())
+	info, err := snapshotter.Stat(ctx, container.ID)
 	if err != nil {
 		return nil, err
 	}
+
+	imageMounts, _ := snapshotter.View(ctx, container.ID+"-parent-view", info.Parent)
+
 	defer func() {
-		if err := snapshotter.Remove(ctx, rnd.String()); err != nil {
-			log.G(ctx).WithError(err).WithField("key", rnd.String()).Warn("remove temporary snapshot")
+		if err := snapshotter.Remove(ctx, container.ID+"-parent-view"); err != nil {
+			log.G(ctx).WithError(err).Warn("error removing the parent view snapshot")
 		}
 	}()
 
 	var changes []archive.Change
-	err = i.PerformWithBaseFS(ctx, container, func(containerRootfs string) error {
-		return mount.WithReadonlyTempMount(ctx, parent, func(parentRootfs string) error {
-			changes, err = archive.ChangesDirs(containerRootfs, parentRootfs)
+	err = i.PerformWithBaseFS(ctx, container, func(containerRoot string) error {
+		return mount.WithReadonlyTempMount(ctx, imageMounts, func(imageRoot string) error {
+			changes, err = archive.ChangesDirs(containerRoot, imageRoot)
 			return err
 		})
 	})
+
 	return changes, err
 }

--- a/daemon/containerd/image_snapshot_windows.go
+++ b/daemon/containerd/image_snapshot_windows.go
@@ -3,10 +3,9 @@ package containerd
 import (
 	"context"
 
-	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/snapshots"
 )
 
-func (i *ImageService) remapSnapshot(ctx context.Context, snapshotter snapshots.Snapshotter, id string, parentSnapshot string, lease leases.Lease) error {
+func (i *ImageService) remapSnapshot(ctx context.Context, snapshotter snapshots.Snapshotter, id string, parentSnapshot string) error {
 	return nil
 }

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -21,7 +21,6 @@ import (
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/registry"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -185,15 +184,4 @@ func (i *ImageService) GetContainerLayerSize(ctx context.Context, containerID st
 
 	// TODO(thaJeztah): include content-store size for the image (similar to "GET /images/json")
 	return rwLayerUsage.Size, rwLayerUsage.Size + unpackedUsage.Size, nil
-}
-
-// getContainerImageManifest safely dereferences ImageManifest.
-// ImageManifest can be nil for containers created with Docker Desktop with old
-// containerd image store integration enabled which didn't set this field.
-func getContainerImageManifest(ctr *container.Container) (ocispec.Descriptor, error) {
-	if ctr.ImageManifest == nil {
-		return ocispec.Descriptor{}, errdefs.InvalidParameter(errors.New("container is missing ImageManifest (probably created on old version), please recreate it"))
-	}
-
-	return *ctr.ImageManifest, nil
 }

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -195,7 +195,7 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 	ctr.ImageManifest = imgManifest
 
 	if daemon.UsesSnapshotter() {
-		if err := daemon.imageService.PrepareSnapshot(ctx, ctr.ID, opts.params.Config.Image, opts.params.Platform); err != nil {
+		if err := daemon.imageService.PrepareSnapshot(ctx, ctr.ID, opts.params.Config.Image, opts.params.Platform, setupInitLayer(daemon.idMapping)); err != nil {
 			return nil, err
 		}
 	} else {

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -47,7 +47,7 @@ type ImageService interface {
 
 	// Containerd related methods
 
-	PrepareSnapshot(ctx context.Context, id string, image string, platform *ocispec.Platform) error
+	PrepareSnapshot(ctx context.Context, id string, parentImage string, platform *ocispec.Platform, setupInit func(string) error) error
 	GetImageManifest(ctx context.Context, refOrID string, options imagetype.GetImageOpts) (*ocispec.Descriptor, error)
 
 	// Layers

--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -46,7 +46,7 @@ type manifest struct {
 	Config ocispec.Descriptor `json:"config"`
 }
 
-func (i *ImageService) PrepareSnapshot(ctx context.Context, id string, image string, platform *ocispec.Platform) error {
+func (i *ImageService) PrepareSnapshot(ctx context.Context, id string, parentImage string, platform *ocispec.Platform, setupInit func(string) error) error {
 	// Only makes sense when conatinerd image store is used
 	panic("not implemented")
 }


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/46607

**- What I did**

Diffing a container yielded some extra changes that come from the files/directories that we mount inside the container (/etc/resolv.conf for example). To avoid that we create an intermediate snapshot that has these files, with this we can now diff the container fs with its parent and only get the differences that were made inside the container.

**- How I did it**

Added a layer for the base snapshot of a container containing the files that are created by the runtime.

**- How to verify it**

Run `TestDiff`

```console
$ make DOCKER_GRAPHDRIVER=overlayfs TEST_FILTER=TestDiff TEST_INTEGRATION_USE_SNAPSHOTTER=1 TEST_IGNORE_CGROUP_CHECK=1 test-integration
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- containerd integration: Fixed `docker diff` containing extra differences

**- A picture of a cute animal (not mandatory but encouraged)**

