### PR TITLE
deprecate pkg/loopback (utility package for devicemapper)

### DIFF
--- a/pkg/loopback/attach_loopback.go
+++ b/pkg/loopback/attach_loopback.go
@@ -88,6 +88,8 @@ func openNextAvailableLoopback(index int, sparseFile *os.File) (loopFile *os.Fil
 
 // AttachLoopDevice attaches the given sparse file to the next
 // available loopback device. It returns an opened *os.File.
+//
+// Deprecated: the loopback package is deprected and will be removed in the next release.
 func AttachLoopDevice(sparseName string) (loop *os.File, err error) {
 	// Try to retrieve the next available loopback device via syscall.
 	// If it fails, we discard error and start looping for a

--- a/pkg/loopback/loopback.go
+++ b/pkg/loopback/loopback.go
@@ -1,5 +1,9 @@
 //go:build linux && cgo
 
+// Package loopback provides utilities to work with loopback devices.
+//
+// Deprecated: this package is deprecated and will be removed in the next release.
+
 package loopback // import "github.com/docker/docker/pkg/loopback"
 
 import (
@@ -21,6 +25,8 @@ func getLoopbackBackingFile(file *os.File) (uint64, uint64, error) {
 }
 
 // SetCapacity reloads the size for the loopback device.
+//
+// Deprecated: the loopback package is deprected and will be removed in the next release.
 func SetCapacity(file *os.File) error {
 	if err := unix.IoctlSetInt(int(file.Fd()), unix.LOOP_SET_CAPACITY, 0); err != nil {
 		log.G(context.TODO()).Errorf("Error loopbackSetCapacity: %s", err)
@@ -31,6 +37,8 @@ func SetCapacity(file *os.File) error {
 
 // FindLoopDeviceFor returns a loopback device file for the specified file which
 // is backing file of a loop back device.
+//
+// Deprecated: the loopback package is deprected and will be removed in the next release.
 func FindLoopDeviceFor(file *os.File) *os.File {
 	var stat unix.Stat_t
 	err := unix.Stat(file.Name(), &stat)


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/18651
- relates to https://github.com/moby/moby/pull/43637


This package was introduced in af597527121c0ad973e9d0ae4f9cf970da1513cc (https://github.com/moby/moby/pull/18651) as a utility package for devicemapper, which was removed in commit dc11d2a2d8e1df0a90ce289f5dd06cad38193073 (https://github.com/moby/moby/pull/43637)(v25.0.0).

It looks like there's no external consumers of this package, so we should consider removing it, but deprecating it first, just in case.

**- A picture of a cute animal (not mandatory but encouraged)**

