### PR TITLE
c8d: Skip TestRemoveImageGarbageCollector

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2539,15 +2539,15 @@ func (s *DockerDaemonSuite) TestExecWithUserAfterLiveRestore(c *testing.T) {
 }
 
 func (s *DockerDaemonSuite) TestRemoveContainerAfterLiveRestore(c *testing.T) {
-	testRequires(c, DaemonIsLinux, overlayFSSupported, testEnv.IsLocalDaemon)
-	s.d.StartWithBusybox(testutil.GetContext(c), c, "--live-restore", "--storage-driver", "overlay2")
+	testRequires(c, DaemonIsLinux, testEnv.IsLocalDaemon)
+	s.d.StartWithBusybox(testutil.GetContext(c), c, "--live-restore")
 	out, err := s.d.Cmd("run", "-d", "--name=top", "busybox", "top")
 	assert.NilError(c, err, "Output: %s", out)
 
 	s.d.WaitRun("top")
 
 	// restart daemon.
-	s.d.Restart(c, "--live-restore", "--storage-driver", "overlay2")
+	s.d.Restart(c, "--live-restore")
 
 	out, err = s.d.Cmd("stop", "top")
 	assert.NilError(c, err, "Output: %s", out)

--- a/integration-cli/requirements_unix_test.go
+++ b/integration-cli/requirements_unix_test.go
@@ -3,9 +3,7 @@
 package main
 
 import (
-	"bytes"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/docker/docker/pkg/sysinfo"
@@ -72,13 +70,4 @@ func bridgeNfIptables() bool {
 func unprivilegedUsernsClone() bool {
 	content, err := os.ReadFile("/proc/sys/kernel/unprivileged_userns_clone")
 	return err != nil || !strings.Contains(string(content), "0")
-}
-
-func overlayFSSupported() bool {
-	cmd := exec.Command(dockerBinary, "run", "--rm", "busybox", "/bin/sh", "-c", "cat /proc/filesystems")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return false
-	}
-	return bytes.Contains(out, []byte("overlay\n"))
 }

--- a/integration/image/remove_unix_test.go
+++ b/integration/image/remove_unix_test.go
@@ -33,6 +33,7 @@ func TestRemoveImageGarbageCollector(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 	skip.If(t, testEnv.NotAmd64)
 	skip.If(t, testEnv.IsRootless, "rootless mode doesn't support overlay2 on most distros")
+	skip.If(t, testEnv.UsingSnapshotter, "tests the graph driver layer store that's not used with the containerd image store")
 
 	ctx := testutil.StartSpan(baseContext, t)
 


### PR DESCRIPTION
**- What I did**

- Skipped `TestRemoveImageGarbageCollector`, it tests the layer store
- Fixed `TestRemoveContainerAfterLiveRestore`, there is no need to pass the storage driver when starting the daemon

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

This test checks how the layer store works, so we don't need it when we
use containerd as image store

Signed-off-by: Djordje Lukic <djordje.lukic@docker.com>