### PR TITLE
registry: remove jsonmessage dependency

### DIFF
--- a/registry/search_session.go
+++ b/registry/search_session.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -17,7 +16,6 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/ioutils"
-	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/pkg/errors"
 )
 
@@ -208,10 +206,8 @@ func (r *session) searchRepositories(term string, limit int) (*registry.SearchRe
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return nil, errdefs.Unknown(&jsonmessage.JSONError{
-			Message: "Unexpected status code " + strconv.Itoa(res.StatusCode),
-			Code:    res.StatusCode,
-		})
+		// TODO(thaJeztah): return upstream response body for errors (see https://github.com/moby/moby/issues/27286).
+		return nil, errdefs.Unknown(fmt.Errorf("Unexpected status code %d", res.StatusCode))
 	}
 	result := &registry.SearchResults{}
 	err = json.NewDecoder(res.Body).Decode(result)


### PR DESCRIPTION
Just return a regular error, because the API converts the error to the expected ErrorResponse. Before/After produce the same API response:

    curl -v --unix-socket /var/run/docker.sock 'http://localhost/v1.43/images/search?term=hello'
    *   Trying /var/run/docker.sock:0...
    * Connected to localhost (/var/run/docker.sock) port 80 (#0)
    > GET /v1.43/images/search?term=hello HTTP/1.1
    > Host: localhost
    > User-Agent: curl/7.74.0
    > Accept: */*
    >
    * Mark bundle as not supporting multiuse
    < HTTP/1.1 500 Internal Server Error
    < Api-Version: 1.44
    < Content-Type: application/json
    < Docker-Experimental: false
    < Ostype: linux
    < Server: Docker/dev (linux)
    < Traceparent: 00-c38c2da5cf30305fcb66836a28e227bf-d16f4f7d2c7002a1-01
    < Date: Mon, 18 Sep 2023 14:30:18 GMT
    < Content-Length: 41
    <
    {"message":"Unexpected status code 409"}
    * Connection #0 to host localhost left intact


**- A picture of a cute animal (not mandatory but encouraged)**

