### PR TITLE
c8d/pull: Support legacy schema1 prettyjws manifests

### DIFF
--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -104,6 +104,10 @@ func (i *ImageService) PullImage(ctx context.Context, image, tagOrDigest string,
 	infoHandler := snapshotters.AppendInfoHandlerWrapper(ref.String())
 	opts = append(opts, containerd.WithImageHandlerWrapper(infoHandler))
 
+	// Allow pulling application/vnd.docker.distribution.manifest.v1+prettyjws images
+	// by converting them to OCI manifests.
+	opts = append(opts, containerd.WithSchema1Conversion)
+
 	img, err := i.client.Pull(ctx, ref.String(), opts...)
 	if err != nil {
 		return err

--- a/distribution/errors.go
+++ b/distribution/errors.go
@@ -212,3 +212,7 @@ func (e reservedNameError) Error() string {
 }
 
 func (e reservedNameError) Forbidden() {}
+
+func DeprecatedSchema1ImageMessage(ref reference.Named) string {
+	return fmt.Sprintf("[DEPRECATION NOTICE] Docker Image Format v1, and Docker Image manifest version 2, schema 1 support will be removed in an upcoming release. Suggest the author of %s to upgrade the image to the OCI Format, or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/", ref)
+}

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -435,7 +435,7 @@ func (p *puller) pullTag(ctx context.Context, ref reference.Named, platform *oci
 
 	switch v := manifest.(type) {
 	case *schema1.SignedManifest:
-		msg := fmt.Sprintf("[DEPRECATION NOTICE] Docker Image Format v1, and Docker Image manifest version 2, schema 1 support will be removed in an upcoming release. Suggest the author of %s to upgrade the image to the OCI Format, or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/", ref)
+		msg := DeprecatedSchema1ImageMessage(ref)
 		log.G(ctx).Warn(msg)
 		progress.Message(p.config.ProgressOutput, "", msg)
 
@@ -868,7 +868,7 @@ func (p *puller) pullManifestList(ctx context.Context, ref reference.Named, mfst
 
 		switch v := manifest.(type) {
 		case *schema1.SignedManifest:
-			msg := fmt.Sprintf("[DEPRECATION NOTICE] Docker Image Format v1, and Docker Image manifest version 2, schema 1 support will be removed in an upcoming release. Suggest the author of %s to upgrade the image to the OCI Format, or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/", ref)
+			msg := DeprecatedSchema1ImageMessage(ref)
 			log.G(ctx).Warn(msg)
 			progress.Message(p.config.ProgressOutput, "", msg)
 


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/pull/46513

Makes it possible to pull `application/vnd.docker.distribution.manifest.v1+prettyjws` legacy manifests.

They are not stored in their original form but are converted to the OCI manifests.

**- How to verify it**
```diff
$ docker pull ubuntu:10.04
-Error response from daemon: application/vnd.docker.distribution.manifest.v1+prettyjws not supported
+86b54f4b6a4e: Download complete
+Digest: sha256:fb69ce785f2a695210a62bc4531fc85a0a0f28664d24ee83fb8205bc3763a9df
+Status: Downloaded newer image for ubuntu:10.04
+docker.io/library/ubuntu:10.04

```

**- Description for the changelog**
```release-notes
- containerd-integration: Support pulling legacy schema1 images
```


**- A picture of a cute animal (not mandatory but encouraged)**

