### PR TITLE
c8d/pull: Handle pull all tags 

### DIFF
--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -41,6 +41,7 @@ type ImageService struct {
 type RegistryConfigProvider interface {
 	IsInsecureRegistry(host string) bool
 	ResolveRepository(name reference.Named) (*registry.RepositoryInfo, error)
+	LookupPullEndpoints(hostname string) ([]registry.APIEndpoint, error)
 }
 
 type ImageServiceConfig struct {

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -86,18 +86,7 @@ func (p *puller) pull(ctx context.Context, ref reference.Named) (err error) {
 		return err
 	}
 
-	if err = p.pullRepository(ctx, ref); err != nil {
-		if _, ok := err.(fallbackError); ok {
-			return err
-		}
-		if continueOnError(err, p.endpoint.Mirror) {
-			return fallbackError{
-				err:         err,
-				transportOK: true,
-			}
-		}
-	}
-	return err
+	return p.pullRepository(ctx, ref)
 }
 
 func (p *puller) pullRepository(ctx context.Context, ref reference.Named) (err error) {

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -75,7 +75,7 @@ type puller struct {
 
 func (p *puller) pull(ctx context.Context, ref reference.Named) (err error) {
 	// TODO(tiborvass): was ReceiveTimeout
-	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
+	p.repo, err = NewRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
 	if err != nil {
 		log.G(ctx).Warnf("Error getting v2 registry: %v", err)
 		return err

--- a/distribution/pull_v2_test.go
+++ b/distribution/pull_v2_test.go
@@ -356,7 +356,7 @@ func testNewPuller(t *testing.T, rawurl string) *puller {
 	}
 
 	p := newPuller(endpoint, repoInfo, imagePullConfig, nil)
-	p.repo, err = newRepository(context.Background(), p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
+	p.repo, err = NewRepository(context.Background(), p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -74,7 +74,7 @@ type pushState struct {
 func (p *pusher) push(ctx context.Context) (err error) {
 	p.pushState.remoteLayers = make(map[layer.DiffID]distribution.Descriptor)
 
-	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "push", "pull")
+	p.repo, err = NewRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "push", "pull")
 	p.pushState.hasAuthInfo = p.config.AuthConfig.RegistryToken != "" || (p.config.AuthConfig.Username != "" && p.config.AuthConfig.Password != "")
 	if err != nil {
 		log.G(ctx).Debugf("Error getting v2 registry: %v", err)

--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -69,10 +69,10 @@ func init() {
 	}
 }
 
-// newRepository returns a repository (v2 only). It creates an HTTP transport
+// NewRepository returns a repository (v2 only). It creates an HTTP transport
 // providing timeout settings and authentication support, and also verifies the
 // remote API version.
-func newRepository(
+func NewRepository(
 	ctx context.Context, repoInfo *registry.RepositoryInfo, endpoint registry.APIEndpoint,
 	metaHeaders http.Header, authConfig *registrytypes.AuthConfig, actions ...string,
 ) (distribution.Repository, error) {

--- a/distribution/registry_unit_test.go
+++ b/distribution/registry_unit_test.go
@@ -68,7 +68,7 @@ func testTokenPassThru(t *testing.T, ts *httptest.Server) {
 	}
 	p := newPuller(endpoint, repoInfo, imagePullConfig, nil)
 	ctx := context.Background()
-	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
+	p.repo, err = NewRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/distribution/repository.go
+++ b/distribution/repository.go
@@ -25,7 +25,7 @@ func GetRepository(ctx context.Context, ref reference.Named, config *ImagePullCo
 	}
 
 	for _, endpoint := range endpoints {
-		repository, lastError = newRepository(ctx, repoInfo, endpoint, nil, config.AuthConfig, "pull")
+		repository, lastError = NewRepository(ctx, repoInfo, endpoint, nil, config.AuthConfig, "pull")
 		if lastError == nil {
 			break
 		}


### PR DESCRIPTION
**distribution: Export NewRepository**

Make the function public

**distribution: Extract PullEndpoints from Pull**

Extract the function to iterate over available pull endpoints for the
given image reference.

**c8d/pull: Handle pull all tags**

Use the distribution code to query the remote repository for tags and
pull them sequentially just like the non-c8d pull.

Note: This uses the distribution code to query the remote registry for available tags. Theoretically these endpoints could be a little bit different than what the containerd pull would use as we don't pass these (and have no ability to do so) to the containerd pull.

**- How to verify it**
```diff
$ docker pull -a docker/doodle
-Error response from daemon: failed to resolve reference "docker.io/docker/doodle": object required
+birthday: Pulling from docker/doodle
+ecaf003f35ec: Download complete
+Digest: sha256:4a203cbea73f32a4885f8d9ee05233246445aa95dd4362887058ec663a7b8088
+Status: Downloaded newer image for docker/doodle:birthday
+birthday2019: Pulling from docker/doodle
+Digest: sha256:4a203cbea73f32a4885f8d9ee05233246445aa95dd4362887058ec663a7b8088
+Status: Downloaded newer image for docker/doodle:birthday2019
(...)
+summer: Pulling from docker/doodle
+6fe738df11e6: Download complete
+Digest: sha256:f7fdfd4a030d16a619f32f183307c9f60ddd9206dc92b1c3b1e1c2f1450567fc
+Status: Downloaded newer image for docker/doodle:summer
+summer2019: Pulling from docker/doodle
+Digest: sha256:f7fdfd4a030d16a619f32f183307c9f60ddd9206dc92b1c3b1e1c2f1450567fc
+Status: Downloaded newer image for docker/doodle:summer2019
+docker.io/docker/doodle


```

**- Description for the changelog**
```release-note
- containerd image store: Implement pulling all tags (`docker pull -a`)
```


**- A picture of a cute animal (not mandatory but encouraged)**

