### PR TITLE
c8d: Include the Config.Image on build/import/commit

### DIFF
--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -398,7 +398,7 @@ func (i *ImageService) CreateImage(ctx context.Context, config []byte, parent st
 		return nil, err
 	}
 
-	ociImgToCreate := dockerImageToDockerOCIImage(*imgToCreate)
+	ociImgToCreate := dockerImageToDockerOCIImage(*imgToCreate, parent)
 
 	var layers []ocispec.Descriptor
 

--- a/daemon/containerd/image_commit.go
+++ b/daemon/containerd/image_commit.go
@@ -178,8 +178,9 @@ func generateCommitImageConfig(baseConfig imagespec.DockerOCIImage, diffID diges
 				EmptyLayer: diffID == "",
 			}),
 		},
-		Config: containerConfigToDockerOCIImageConfig(opts.Config),
+		Config: containerConfigToDockerOCIImageConfig(opts.Config, opts.ParentImageID),
 	}
+
 }
 
 // writeContentsForImage will commit oci image config and manifest into containerd's content store.

--- a/daemon/containerd/image_import.go
+++ b/daemon/containerd/image_import.go
@@ -89,7 +89,7 @@ func (i *ImageService) ImportImage(ctx context.Context, ref reference.Named, pla
 		Size:      size,
 	}
 
-	dockerCfg := containerConfigToDockerOCIImageConfig(imageConfig)
+	dockerCfg := containerConfigToDockerOCIImageConfig(imageConfig, imageConfig.Image)
 	createdAt := time.Now()
 	config := imagespec.DockerOCIImage{
 		Image: ocispec.Image{

--- a/daemon/containerd/image_import_test.go
+++ b/daemon/containerd/image_import_test.go
@@ -15,7 +15,7 @@ func TestContainerConfigToDockerImageConfig(t *testing.T) {
 		ExposedPorts: nat.PortSet{
 			"80/tcp": struct{}{},
 		},
-	})
+	}, "")
 
 	expected := map[string]struct{}{"80/tcp": {}}
 	assert.Check(t, is.DeepEqual(ociCFG.ExposedPorts, expected))

--- a/daemon/containerd/imagespec.go
+++ b/daemon/containerd/imagespec.go
@@ -43,7 +43,7 @@ func dockerOciImageToDockerImagePartial(id image.ID, img imagespec.DockerOCIImag
 	return out
 }
 
-func dockerImageToDockerOCIImage(img image.Image) imagespec.DockerOCIImage {
+func dockerImageToDockerOCIImage(img image.Image, parent string) imagespec.DockerOCIImage {
 	rootfs := ocispec.RootFS{
 		Type:    img.RootFS.Type,
 		DiffIDs: []digest.Digest{},
@@ -66,11 +66,11 @@ func dockerImageToDockerOCIImage(img image.Image) imagespec.DockerOCIImage {
 			RootFS:  rootfs,
 			History: img.History,
 		},
-		Config: containerConfigToDockerOCIImageConfig(img.Config),
+		Config: containerConfigToDockerOCIImageConfig(img.Config, parent),
 	}
 }
 
-func containerConfigToDockerOCIImageConfig(cfg *container.Config) imagespec.DockerOCIImageConfig {
+func containerConfigToDockerOCIImageConfig(cfg *container.Config, parent string) imagespec.DockerOCIImageConfig {
 	var ociCfg ocispec.ImageConfig
 	var ext imagespec.DockerOCIImageConfigExt
 
@@ -96,6 +96,7 @@ func containerConfigToDockerOCIImageConfig(cfg *container.Config) imagespec.Dock
 		ext.Healthcheck = cfg.Healthcheck
 		ext.OnBuild = cfg.OnBuild
 		ext.Shell = cfg.Shell
+		ext.Image = parent
 	}
 
 	return imagespec.DockerOCIImageConfig{
@@ -124,5 +125,6 @@ func dockerOCIImageConfigToContainerConfig(cfg imagespec.DockerOCIImageConfig) *
 		Healthcheck:  cfg.Healthcheck,
 		OnBuild:      cfg.OnBuild,
 		Shell:        cfg.Shell,
+		Image:        cfg.Image,
 	}
 }

--- a/image/spec/specs-go/v1/image.go
+++ b/image/spec/specs-go/v1/image.go
@@ -29,6 +29,7 @@ type DockerOCIImageConfigExt struct {
 
 	OnBuild []string `json:",omitempty"` // ONBUILD metadata that were defined on the image Dockerfile
 	Shell   []string `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
+	Image   string   `json:",omitempty"`
 }
 
 // HealthcheckConfig holds configuration settings for the HEALTHCHECK feature.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Included the `Config.Image` information on build/commit/import

**- How I did it**

**- How to verify it**

This one shouldn't fail any more

```console 
$ make TEST_FILTER=TestBuildByDigest TEST_INTEGRATION_USE_SNAPSHOTTER=1 TEST_IGNORE_CGROUP_CHECK=1 DOCKER_GRAPHDRIVER=overlayfs test-integration
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

