### PR TITLE
Fix graphdriver lookup in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DOCKER ?= docker
 BUILDX ?= $(DOCKER) buildx
 
 # set the graph driver as the current graphdriver if not set
-DOCKER_GRAPHDRIVER := $(if $(DOCKER_GRAPHDRIVER),$(DOCKER_GRAPHDRIVER),$(shell docker info -f {{ .Driver }} 2>&1))
+DOCKER_GRAPHDRIVER := $(if $(DOCKER_GRAPHDRIVER),$(DOCKER_GRAPHDRIVER),$(shell docker info -f '{{ .Driver }}' 2>&1))
 export DOCKER_GRAPHDRIVER
 
 DOCKER_GITCOMMIT := $(shell git rev-parse HEAD)


### PR DESCRIPTION
When graphdriver is not provided the graphdriver is looked up from docker info, but without quotes it may fail and set the graphdriver to an incorrect value.

On my local system without this change I was getting
```
DOCKER_GRAPHDRIVER="docker info" accepts no arguments. See 'docker info --help'.  Usage:  docker info [OPTIONS]  Display system-wide information
```