### PR TITLE
daemon: strongly type containerd log.OutputFormat

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -516,7 +516,7 @@ func loadDaemonCliConfig(opts *daemonOptions) (*config.Config, error) {
 	conf.Debug = opts.Debug
 	conf.Hosts = opts.Hosts
 	conf.LogLevel = opts.LogLevel
-	conf.LogFormat = opts.LogFormat
+	conf.LogFormat = log.OutputFormat(opts.LogFormat)
 
 	if flags.Changed(FlagTLS) {
 		conf.TLS = &opts.TLS
@@ -914,7 +914,7 @@ func systemContainerdRunning(honorXDG bool) (string, bool, error) {
 // configureDaemonLogs sets the logging level and formatting. It expects
 // the passed configuration to already be validated, and ignores invalid options.
 func configureDaemonLogs(conf *config.Config) {
-	switch log.OutputFormat(conf.LogFormat) {
+	switch conf.LogFormat {
 	case log.JSONFormat:
 		if err := log.SetFormat(log.JSONFormat); err != nil {
 			panic(err.Error())

--- a/cmd/dockerd/daemon_test.go
+++ b/cmd/dockerd/daemon_test.go
@@ -164,7 +164,7 @@ func TestLoadDaemonCliConfigWithLogFormat(t *testing.T) {
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
 	assert.Assert(t, loadedConfig != nil)
-	assert.Check(t, is.Equal(log.JSONFormat, log.OutputFormat(loadedConfig.LogFormat)))
+	assert.Check(t, is.Equal(log.JSONFormat, loadedConfig.LogFormat))
 }
 
 func TestLoadDaemonCliConfigWithInvalidLogFormat(t *testing.T) {

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -180,12 +180,12 @@ type CommonConfig struct {
 	// to stop when daemon is being shutdown
 	ShutdownTimeout int `json:"shutdown-timeout,omitempty"`
 
-	Debug     bool     `json:"debug,omitempty"`
-	Hosts     []string `json:"hosts,omitempty"`
-	LogLevel  string   `json:"log-level,omitempty"`
-	LogFormat string   `json:"log-format,omitempty"`
-	TLS       *bool    `json:"tls,omitempty"`
-	TLSVerify *bool    `json:"tlsverify,omitempty"`
+	Debug     bool             `json:"debug,omitempty"`
+	Hosts     []string         `json:"hosts,omitempty"`
+	LogLevel  string           `json:"log-level,omitempty"`
+	LogFormat log.OutputFormat `json:"log-format,omitempty"`
+	TLS       *bool            `json:"tls,omitempty"`
+	TLSVerify *bool            `json:"tlsverify,omitempty"`
 
 	// Embedded structs that allow config
 	// deserialization without the full struct.
@@ -597,7 +597,7 @@ func Validate(config *Config) error {
 
 	// validate log-format
 	if logFormat := config.LogFormat; logFormat != "" {
-		switch log.OutputFormat(logFormat) {
+		switch logFormat {
 		case log.TextFormat, log.JSONFormat:
 			// These are valid
 		default:

--- a/libcontainerd/supervisor/remote_daemon_options.go
+++ b/libcontainerd/supervisor/remote_daemon_options.go
@@ -1,5 +1,9 @@
 package supervisor // import "github.com/docker/docker/libcontainerd/supervisor"
 
+import (
+	"github.com/containerd/containerd/log"
+)
+
 // WithLogLevel defines which log level to start containerd with.
 func WithLogLevel(lvl string) DaemonOpt {
 	return func(r *remote) error {
@@ -15,9 +19,9 @@ func WithLogLevel(lvl string) DaemonOpt {
 
 // WithLogFormat defines the containerd log format.
 // This only makes sense if WithStartDaemon() was set to true.
-func WithLogFormat(format string) DaemonOpt {
+func WithLogFormat(format log.OutputFormat) DaemonOpt {
 	return func(r *remote) error {
-		r.Debug.Format = format
+		r.Debug.Format = string(format)
 		return nil
 	}
 }


### PR DESCRIPTION
- extracted from https://github.com/moby/moby/pull/45966
- relates to https://github.com/moby/moby/pull/45966#discussion_r1332018618
- follow-up to https://github.com/moby/moby/pull/46489

For context: in https://github.com/moby/moby/pull/46489 I didn't want to change the type of `CommonConfig.LogFormat` (daemon/config/config.go). And in https://github.com/moby/moby/pull/45966#discussion_r1332018618 I suggested to move this to a separate PR; both for visibility and for discussion (whether we want our daemon's Config struct to have a direct dependency on containerd/log's types.


This type was introduced in
https://github.com/containerd/containerd/commit/0a79e67e4f7bff1128c81ee14a8b2a74a8c55c51

**- A picture of a cute animal (not mandatory but encouraged)**

