### PR TITLE
integration-cli/SaveLoad: Don't check `repositories` file

### DIFF
--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/docker/integration-cli/cli/build"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
 )
 
@@ -93,11 +94,15 @@ func (s *DockerCLISaveLoadSuite) TestSaveSingleTag(c *testing.T) {
 	out, _ := dockerCmd(c, "images", "-q", "--no-trunc", repoName)
 	cleanedImageID := strings.TrimSpace(out)
 
+	filesFilter := fmt.Sprintf("(^manifest.json$|%v)", cleanedImageID)
+	if testEnv.UsingSnapshotter() {
+		filesFilter = fmt.Sprintf("(^index.json$|^manifest.json$|%v)", cleanedImageID)
+	}
 	out, err := RunCommandPipelineWithOutput(
 		exec.Command(dockerBinary, "save", fmt.Sprintf("%v:latest", repoName)),
 		exec.Command("tar", "t"),
-		exec.Command("grep", "-E", fmt.Sprintf("(^repositories$|%v)", cleanedImageID)))
-	assert.NilError(c, err, "failed to save repo with image ID and 'repositories' file: %s, %v", out, err)
+		exec.Command("grep", "-E", filesFilter))
+	assert.NilError(c, err, "failed to save repo with image ID and index files: %s, %v", out, err)
 }
 
 func (s *DockerCLISaveLoadSuite) TestSaveImageId(c *testing.T) {
@@ -174,18 +179,20 @@ func (s *DockerCLISaveLoadSuite) TestSaveMultipleNames(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 	repoName := "foobar-save-multi-name-test"
 
-	// Make one image
-	dockerCmd(c, "tag", "emptyfs:latest", fmt.Sprintf("%v-one:latest", repoName))
+	oneTag := fmt.Sprintf("%v-one:latest", repoName)
+	twoTag := fmt.Sprintf("%v-two:latest", repoName)
 
-	// Make two images
-	dockerCmd(c, "tag", "emptyfs:latest", fmt.Sprintf("%v-two:latest", repoName))
+	dockerCmd(c, "tag", "emptyfs:latest", oneTag)
+	dockerCmd(c, "tag", "emptyfs:latest", twoTag)
 
 	out, err := RunCommandPipelineWithOutput(
-		exec.Command(dockerBinary, "save", fmt.Sprintf("%v-one", repoName), fmt.Sprintf("%v-two:latest", repoName)),
-		exec.Command("tar", "xO", "repositories"),
-		exec.Command("grep", "-q", "-E", "(-one|-two)"),
+		exec.Command(dockerBinary, "save", strings.TrimSuffix(oneTag, ":latest"), twoTag),
+		exec.Command("tar", "xO", "index.json"),
 	)
 	assert.NilError(c, err, "failed to save multiple repos: %s, %v", out, err)
+
+	assert.Check(c, is.Contains(out, oneTag))
+	assert.Check(c, is.Contains(out, twoTag))
 }
 
 // Test loading a weird image where one of the layers is of zero size.


### PR DESCRIPTION
- extracted from: https://github.com/moby/moby/pull/46533

Rewrite TestSaveMultipleNames and TestSaveSingleTag  so that they don't use legacy `repositories` file (which isn't present in the OCI archives).
`docker save` output is now OCI compatible, so we don't need to use the legacy file.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

