### PR TITLE
c8d: Just enough Windows support to run the test suite

### DIFF
--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	ctd "github.com/containerd/containerd"
@@ -91,6 +92,14 @@ func newSnapshotterController(ctx context.Context, rt http.RoundTripper, opt Opt
 	nc := netproviders.Opt{
 		Mode: "host",
 	}
+
+	// HACK! Windows doesn't have 'host' mode networking.
+	if runtime.GOOS == "windows" {
+		nc = netproviders.Opt{
+			Mode: "auto",
+		}
+	}
+
 	dns := getDNSConfig(opt.DNSConfig)
 
 	wo, err := containerd.NewWorkerOpt(opt.Root, opt.ContainerdAddress, opt.Snapshotter, opt.ContainerdNamespace,

--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -389,7 +389,7 @@ func (rw *rwlayer) Release() (outErr error) {
 	}
 
 	if err := mount.UnmountAll(rw.root, 0); err != nil && !errors.Is(err, os.ErrNotExist) {
-		log.G(context.TODO()).WithError(err).WithField("root", rw.root).Error("failed to unmount ROLayer")
+		log.G(context.TODO()).WithError(err).WithField("root", rw.root).Error("failed to unmount RWLayer")
 		return err
 	}
 	if err := os.Remove(rw.root); err != nil && !errors.Is(err, os.ErrNotExist) {

--- a/daemon/containerd/image_commit.go
+++ b/daemon/containerd/image_commit.go
@@ -264,18 +264,15 @@ func (i *ImageService) createDiff(ctx context.Context, name string, sn snapshots
 
 // applyDiffLayer will apply diff layer content created by createDiff into the snapshotter.
 func (i *ImageService) applyDiffLayer(ctx context.Context, name string, containerID string, sn snapshots.Snapshotter, differ diff.Applier, diffDesc ocispec.Descriptor) (retErr error) {
-	var (
-		key    = uniquePart() + "-" + name
-		mounts []mount.Mount
-		err    error
-	)
+	// Let containerd know that this snapshot is only for diff-applying.
+	key := snapshots.UnpackKeyPrefix + "-" + uniquePart() + "-" + name
 
 	info, err := sn.Stat(ctx, containerID)
 	if err != nil {
 		return err
 	}
 
-	mounts, err = sn.Prepare(ctx, key, info.Parent)
+	mounts, err := sn.Prepare(ctx, key, info.Parent)
 	if err != nil {
 		return fmt.Errorf("failed to prepare snapshot: %w", err)
 	}

--- a/daemon/containerd/image_snapshot.go
+++ b/daemon/containerd/image_snapshot.go
@@ -87,10 +87,12 @@ func (i *ImageService) prepareInitLayer(ctx context.Context, id string, parent s
 		return err
 	}
 
-	if err := mount.WithTempMount(ctx, mounts, func(root string) error {
-		return setupInit(root)
-	}); err != nil {
-		return err
+	if setupInit != nil {
+		if err := mount.WithTempMount(ctx, mounts, func(root string) error {
+			return setupInit(root)
+		}); err != nil {
+			return err
+		}
 	}
 
 	return snapshotter.Commit(ctx, id+"-init", id+"-init-key")

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -19,7 +19,6 @@ import (
 	dimages "github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/daemon/snapshotter"
 	"github.com/docker/docker/errdefs"
-	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/registry"
@@ -154,11 +153,6 @@ func (i *ImageService) LayerDiskUsage(ctx context.Context) (int64, error) {
 // called from reload.go
 func (i *ImageService) UpdateConfig(maxDownloads, maxUploads int) {
 	log.G(context.TODO()).Warn("max downloads and uploads is not yet implemented with the containerd store")
-}
-
-// GetLayerFolders returns the layer folders from an image RootFS.
-func (i *ImageService) GetLayerFolders(img *image.Image, rwLayer layer.RWLayer) ([]string, error) {
-	return nil, errdefs.NotImplemented(errors.New("not implemented"))
 }
 
 // GetContainerLayerSize returns the real size & virtual size of the container.

--- a/daemon/containerd/service_unix.go
+++ b/daemon/containerd/service_unix.go
@@ -1,0 +1,15 @@
+//go:build linux || freebsd
+
+package containerd
+
+import (
+	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/image"
+	"github.com/docker/docker/layer"
+	"github.com/pkg/errors"
+)
+
+// GetLayerFolders returns the layer folders from an image RootFS.
+func (i *ImageService) GetLayerFolders(img *image.Image, rwLayer layer.RWLayer, containerID string) ([]string, error) {
+	return nil, errdefs.NotImplemented(errors.New("not implemented"))
+}

--- a/daemon/containerd/service_windows.go
+++ b/daemon/containerd/service_windows.go
@@ -1,0 +1,31 @@
+package containerd
+
+import (
+	"context"
+
+	"github.com/docker/docker/image"
+	"github.com/docker/docker/layer"
+	"github.com/pkg/errors"
+)
+
+// GetLayerFolders returns the layer folders from an image RootFS.
+func (i *ImageService) GetLayerFolders(img *image.Image, rwLayer layer.RWLayer, containerID string) ([]string, error) {
+	if rwLayer != nil {
+		return nil, errors.New("RWLayer is unexpectedly not nil")
+	}
+
+	snapshotter := i.client.SnapshotService(i.StorageDriver())
+	mounts, err := snapshotter.Mounts(context.TODO(), containerID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "snapshotter.Mounts failed: container %s", containerID)
+	}
+
+	// This is the same logic used by the hcsshim containerd runtime shim's createInternal
+	// to convert an array of Mounts into windows layers.
+	// See https://github.com/microsoft/hcsshim/blob/release/0.11/cmd/containerd-shim-runhcs-v1/service_internal.go
+	parentPaths, err := mounts[0].GetParentPaths()
+	if err != nil {
+		return nil, errors.Wrapf(err, "GetParentPaths failed: container %s", containerID)
+	}
+	return append(parentPaths, mounts[0].Source), nil
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1062,7 +1062,11 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	// be set through an environment variable, a daemon start parameter, or chosen through
 	// initialization of the layerstore through driver priority order for example.
 	driverName := os.Getenv("DOCKER_DRIVER")
-	if isWindows {
+	if isWindows && d.UsesSnapshotter() {
+		// Containerd WCOW snapshotter
+		driverName = "windows"
+	} else if isWindows {
+		// Docker WCOW graphdriver
 		driverName = "windowsfilter"
 	} else if driverName != "" {
 		log.G(ctx).Infof("Setting the storage driver from the $DOCKER_DRIVER environment variable (%s)", driverName)

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -65,7 +65,7 @@ type ImageService interface {
 
 	// Windows specific
 
-	GetLayerFolders(img *image.Image, rwLayer layer.RWLayer) ([]string, error)
+	GetLayerFolders(img *image.Image, rwLayer layer.RWLayer, containerID string) ([]string, error)
 
 	// Build
 

--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -47,7 +47,7 @@ type manifest struct {
 }
 
 func (i *ImageService) PrepareSnapshot(ctx context.Context, id string, parentImage string, platform *ocispec.Platform, setupInit func(string) error) error {
-	// Only makes sense when conatinerd image store is used
+	// Only makes sense when containerd image store is used
 	panic("not implemented")
 }
 

--- a/daemon/images/image_unix.go
+++ b/daemon/images/image_unix.go
@@ -11,7 +11,7 @@ import (
 )
 
 // GetLayerFolders returns the layer folders from an image RootFS
-func (i *ImageService) GetLayerFolders(img *image.Image, rwLayer layer.RWLayer) ([]string, error) {
+func (i *ImageService) GetLayerFolders(img *image.Image, rwLayer layer.RWLayer, containerID string) ([]string, error) {
 	// Windows specific
 	panic("not implemented")
 }

--- a/daemon/images/image_windows.go
+++ b/daemon/images/image_windows.go
@@ -15,7 +15,7 @@ func (i *ImageService) GetContainerLayerSize(ctx context.Context, containerID st
 }
 
 // GetLayerFolders returns the layer folders from an image RootFS
-func (i *ImageService) GetLayerFolders(img *image.Image, rwLayer layer.RWLayer) ([]string, error) {
+func (i *ImageService) GetLayerFolders(img *image.Image, rwLayer layer.RWLayer, containerID string) ([]string, error) {
 	folders := []string{}
 	rd := len(img.RootFS.DiffIDs)
 	for index := 1; index <= rd; index++ {

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Microsoft/hcsshim"
 	coci "github.com/containerd/containerd/oci"
 	"github.com/containerd/log"
 	containertypes "github.com/docker/docker/api/types/container"
@@ -249,7 +250,24 @@ func (daemon *Daemon) createSpecWindowsFields(c *container.Container, s *specs.S
 			return errors.New("createSpecWindowsFields: BaseFS of container " + c.ID + " is unexpectedly empty")
 		}
 
-		s.Root.Path = c.BaseFS // This is not set for Hyper-V containers
+		if daemon.UsesSnapshotter() {
+			// daemon.Mount() for the snapshotters actually mounts the filesystem to the host
+			// using containerd/mount.All and BaseFS is the directory where this is mounted.
+			// This is consistent with Linux-based graphdriver implementations.
+			// For the windowsfilter graphdriver, the underlying Get() call does not actually mount
+			// the filesystem to a path, and BaseFS is the Volume GUID of the prepared/activated
+			// filesystem.
+
+			// The spec for Root.Path for Windows specifies that for Process-isolated containers,
+			// it must be in the Volume GUID (\\?\\Volume{GUID} style), not a host-mounted directory.
+			backingDevicePath, err := getBackingDeviceForContainerdMount(c.BaseFS)
+			if err != nil {
+				return errors.Wrapf(err, "createSpecWindowsFields: Failed to get backing device of BaseFS of container %s", c.ID)
+			}
+			s.Root.Path = backingDevicePath
+		} else {
+			s.Root.Path = c.BaseFS // This is not set for Hyper-V containers
+		}
 		if !strings.HasSuffix(s.Root.Path, `\`) {
 			s.Root.Path = s.Root.Path + `\` // Ensure a correctly formatted volume GUID path \\?\Volume{GUID}\
 		}
@@ -273,6 +291,48 @@ func (daemon *Daemon) createSpecWindowsFields(c *container.Container, s *specs.S
 	s.Windows.Devices = append(s.Windows.Devices, devices...)
 
 	return nil
+}
+
+// getBackingDeviceForContainerdMount extracts the backing device or directory mounted at mountPoint
+// by containerd's mount.Mount implementation for Windows.
+func getBackingDeviceForContainerdMount(mountPoint string) (string, error) {
+	// NOTE: This relies on details of the behaviour of containerd's mount implementation for Windows,
+	// and so is somewhat fragile.
+	// TODO: Upstream this into the mount package.
+	// The implementation would be the same, but it'll be better-encapsulated.
+
+	// See containerd/containerd/mount/mount_windows.go
+	// This is mostly just copied from mount.Unmount
+
+	const sourceStreamName = "containerd.io-source"
+
+	mountPoint = filepath.Clean(mountPoint)
+	adsFile := mountPoint + ":" + sourceStreamName
+	var layerPath string
+
+	if _, err := os.Lstat(adsFile); err == nil {
+		layerPathb, err := os.ReadFile(mountPoint + ":" + sourceStreamName)
+		if err != nil {
+			return "", fmt.Errorf("failed to retrieve layer source for mount %s: %w", mountPoint, err)
+		}
+		layerPath = string(layerPathb)
+	}
+
+	if layerPath == "" {
+		return "", fmt.Errorf("no layer source for mount %s", mountPoint)
+	}
+
+	home, layerID := filepath.Split(layerPath)
+	di := hcsshim.DriverInfo{
+		HomeDir: home,
+	}
+
+	backingDevice, err := hcsshim.GetLayerMountPath(di, layerID)
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve backing device for layer %s: %w", mountPoint, err)
+	}
+
+	return backingDevice, nil
 }
 
 var errInvalidCredentialSpecSecOpt = errdefs.InvalidParameter(fmt.Errorf("invalid credential spec security option - value must be prefixed by 'file://', 'registry://', or 'raw://' followed by a non-empty value"))

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -138,9 +138,9 @@ func (daemon *Daemon) createSpec(ctx context.Context, daemonCfg *configStore, c 
 		}
 	}
 	s.Process.User.Username = c.Config.User
-	s.Windows.LayerFolders, err = daemon.imageService.GetLayerFolders(img, c.RWLayer)
+	s.Windows.LayerFolders, err = daemon.imageService.GetLayerFolders(img, c.RWLayer, c.ID)
 	if err != nil {
-		return nil, errors.Wrapf(err, "container %s", c.ID)
+		return nil, errors.Wrapf(err, "GetLayerFolders failed: container %s", c.ID)
 	}
 
 	// Get endpoints for the libnetwork allocated networks to the container


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Building upon ~~#46402~~ #46572 to bring the containerd image-store support on Windows up to something that is worth having tests enabled for.

**- How I did it**

Firstly, cherry-picked #46402 onto the mainline branch, once containerd 1.7.6 had been vendored by #45966. Update: Currently based directly on #46402 until it merges, unless something important lands in mainline first.

Secondly, got the snapshotter tests functional on Windows matching the Linux version. (Two-liner, most of the work was done by @rumpl in #46402).

~~Violently beat my head against~~ Iteratively worked through failures observed in the integration test suite setup, building the busybox image. As it happens, this step does most of the things we seem to care about, so it was a good test-case.

Rebased the results of the above after #46572 landed, which integrated the outcomes of the second paragraph already.

Remaining TODOs to undraft this PR:

- [x] Label this PR with `containerd-integration` (someone needs to do that for me) and drop the last (0d5edcdca184c8bd3c50b8b25d75544fa9e7d190) commit
- [x] Rebase once ~~#46402~~ #46572 is merged, dropping the first couple of commits
- [x] Make and implement a decision about hack 1 (53777db68e5172cc50568a21959dff704565110d)
- [x] Make and implement a decision about hack 2 (https://github.com/moby/moby/pull/46539/commits/6e48f48df593fb689bb26894a36949632f61bd24 or [`b099f42`](https://github.com/moby/moby/pull/46539/files/53777db68e5172cc50568a21959dff704565110d..b099f42423c30eeaa26c77de32b0e169103c9e82))

----

*- Hack 1 (53777db68e5172cc50568a21959dff704565110d)*

builder-next specifies the `host` network provider, but [that fails on Windows](https://github.com/moby/buildkit/blob/v0.12.2/util/network/netproviders/network_windows.go#L11-L13), blocking daemon startup even though we don't currently support builder-next.

My current hack is to use `auto`, since that means [`cni` if configured](https://github.com/moby/buildkit/blob/v0.12.2/util/network/netproviders/network.go#L36-L46) and if not, [on Windows it falls back to `null`](https://github.com/moby/buildkit/blob/v0.12.2/util/network/netproviders/network_windows.go#L15-L18), and [on Linux it falls back to `host`](https://github.com/moby/buildkit/blob/v0.12.2/util/network/netproviders/network_unix.go#L15-L18).

I've currently only done this for Windows with a `runtime.GOOS` test, but I'm inclined to think we should use `auto` always, since: it does the right thing on Linux, and if we ever do need a more-complex network setup, CNI is the obvious path. If we ever do get builder-next working for Windows, it'll need to use CNI anyway, even for the equivalent of host networking.

----

*- Hack 2 (https://github.com/moby/moby/pull/46539/commits/6e48f48df593fb689bb26894a36949632f61bd24 or [`b099f42`](https://github.com/moby/moby/pull/46539/files/53777db68e5172cc50568a21959dff704565110d..b099f42423c30eeaa26c77de32b0e169103c9e82))*

The windowfilter graphdriver is a bit weird: When you "mount" an image from it, it actually [only does the volume setup (Prepare and Activate in HCS terms)](https://github.com/moby/moby/blob/51f0e7b0e49c709729d67559c9c07616c1da019b/daemon/graphdriver/windows/windows.go#L385-L407) and then [returns the `\\?\Volume{GUID}\` formatted volume name](https://github.com/moby/moby/blob/51f0e7b0e49c709729d67559c9c07616c1da019b/daemon/graphdriver/windows/windows.go#L414-L416), where other graphdrivers (and all the containerd snapshotters) actually [mount the image to a host directory](https://github.com/moby/moby/blob/51f0e7b0e49c709729d67559c9c07616c1da019b/daemon/graphdriver/overlay2/overlay.go#L596-L598) and [return that directory](https://github.com/moby/moby/blob/51f0e7b0e49c709729d67559c9c07616c1da019b/daemon/graphdriver/overlay2/overlay.go#L608).

However, starting a container as we do now [requires us to pass that `\\?\Volume{GUID}\`-formatted volume name in the OCI spec as `Root.Path`](https://github.com/opencontainers/runtime-spec/blob/main/config.md#root).

Normally, containerd doesn't expose that volume name to callers, but we can use the underlying Windows API to get the volume name from the mount point, which relies on [internal knowledge of the containerd/mount implementation](https://github.com/moby/moby/pull/46539/files#diff-6688f4342adf127b206582942bc147a0efab01c2e376b8a1a81e62c4bfee3ce1R296-R337) ([earlier implementation of the same idea that I'm less confident in](https://github.com/moby/moby/pull/46539/files/6e48f48df593fb689bb26894a36949632f61bd24#diff-6688f4342adf127b206582942bc147a0efab01c2e376b8a1a81e62c4bfee3ce1R296-R322)).

The BindFilter approach was pretty messy though, and I didn't like it very much. (There's probably a bunch of overlooked edge cases there too. I have no idea why I see four copies of the bind-mount there, which is another vote against the older BindFilter version.) The `GetLayerMountPath` isn't too bad, it's still poking at internal details, but they're details that containerd's mount package could trivially provide an API to expose, if we go this way.

Beyond cleaning it up, an alternative approach would be to not populate `Windows.LayerFolders` nor `Root.Path` at all (removing the need for 1ad566e21dee685a0c10b01054bd40c5de7a0e5b as well) and instead use [containerd's `WithSnapshot` and `WithSnapshotter` config-functor-things](https://github.com/containerd/containerd/blob/v1.7.6/container_opts.go#L178-L207) when setting up the container.

However, this would, at least on Windows, require us to unmount the directory before starting the container, as this flow makes hcsshim responsible for both [mounting of the root layer](https://github.com/microsoft/hcsshim/blob/v0.11.1/internal/hcsoci/resources_wcow.go#L60-L73) and [deriving `Windows.LayerFolders` from the snapshot](https://github.com/microsoft/hcsshim/blob/v0.11.1/cmd/containerd-shim-runhcs-v1/service_internal.go#L118-L158). Note that in the latter case, [there's a bug where hcsshim'll *append* to any `Windows.LayerFolders` passed in](https://github.com/opencontainers/runtime-spec/issues/1185#issuecomment-1474549056) ([0.12 onwards rejects this case explicitly instead](https://github.com/microsoft/hcsshim/blob/main/cmd/containerd-shim-runhcs-v1/rootfs.go#L15-L45)), so we *must not* populate it in this case. `nil` is fine, even though it's [out-of-spec](https://github.com/opencontainers/runtime-spec/issues/1185).

This should be _feasible_ as we already have the `conditionalMountOnStart` hook, but code flows after that is called need to be checked to ensure they are correctly handling the case of not mounting the container filesystem locally. For example, I noticed code on the Windows side that checks the same conditions as the current `conditionalMountOnStart` check, and if they match, does a temporary mount of the image; clearly there's some scope for refactoring that to not duplicate the condition around.

If it was just Windows, I'd have tried to go with this approach. However, I think it'd be cleaner if we use `WithSnapshot` for both Windows and Linux when executing containers. This would be a larger change, and probably has repercussions I'm unaware of at this time, since I haven't really worked to understand the overarching flow and its rationales. (Most other containerd-calling code [appears to use `WithNewSnapshot`](https://github.com/containerd/nerdctl/blob/v1.6.0/pkg/cmd/container/create.go#L316), but moby currently has a pile of stuff it wants to do to the image first, so I'm not considering that here.)

----

**- How to verify it**

CI.

This PR has the `containerd-integration` label applied, so the new snapshotter test suite introduced in ~~#46402~~ #46572 will run for this PR (and any PR with that label), giving us both Windows and Linux coverage. As long as the failures in the snapshotter test suite are consistent across platforms (and I didn't break anything), we're probably fine.

All of the changes made here (except an interface change while the compiler will validate) are only in the "use snapshotter" code-path, so verification should be low-risk.

If someone wants to take the time and try this out with the WASM runtime, that'd be awesome. I have no particular plans to do so, even though that's what started me on this piece of work, months ago.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Containerd image store on Windows is slightly usable.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/moby/moby/assets/138397/149b0bcc-f13b-4b02-be07-a49dcfbee82b)
