### PR TITLE
[24.0 backport] daemon/cluster: format code with gofumpt

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -140,7 +140,7 @@ type attacher struct {
 // New creates a new Cluster instance using provided config.
 func New(config Config) (*Cluster, error) {
 	root := filepath.Join(config.Root, swarmDirName)
-	if err := os.MkdirAll(root, 0700); err != nil {
+	if err := os.MkdirAll(root, 0o700); err != nil {
 		return nil, err
 	}
 	if config.RuntimeRoot == "" {
@@ -154,7 +154,7 @@ func New(config Config) (*Cluster, error) {
 		config.RaftElectionTick = 10 * config.RaftHeartbeatTick
 	}
 
-	if err := os.MkdirAll(config.RuntimeRoot, 0700); err != nil {
+	if err := os.MkdirAll(config.RuntimeRoot, 0o700); err != nil {
 		return nil, err
 	}
 	c := &Cluster{

--- a/daemon/cluster/controllers/plugin/controller.go
+++ b/daemon/cluster/controllers/plugin/controller.go
@@ -65,7 +65,8 @@ func NewController(backend Backend, t *api.Task) (*Controller, error) {
 			"controller": "plugin",
 			"task":       t.ID,
 			"plugin":     spec.Name,
-		})}, nil
+		}),
+	}, nil
 }
 
 func readSpec(t *api.Task) (runtime.PluginSpec, error) {

--- a/daemon/cluster/convert/network.go
+++ b/daemon/cluster/convert/network.go
@@ -118,7 +118,8 @@ func endpointFromGRPC(e *swarmapi.Endpoint) types.Endpoint {
 		for _, v := range e.VirtualIPs {
 			endpoint.VirtualIPs = append(endpoint.VirtualIPs, types.EndpointVirtualIP{
 				NetworkID: v.NetworkID,
-				Addr:      v.Addr})
+				Addr:      v.Addr,
+			})
 		}
 	}
 

--- a/daemon/cluster/convert/node_test.go
+++ b/daemon/cluster/convert/node_test.go
@@ -15,12 +15,12 @@ func TestNodeCSIInfoFromGRPC(t *testing.T) {
 		ID: "someID",
 		Description: &swarmapi.NodeDescription{
 			CSIInfo: []*swarmapi.NodeCSIInfo{
-				&swarmapi.NodeCSIInfo{
+				{
 					PluginName:        "plugin1",
 					NodeID:            "p1n1",
 					MaxVolumesPerNode: 1,
 				},
-				&swarmapi.NodeCSIInfo{
+				{
 					PluginName:        "plugin2",
 					NodeID:            "p2n1",
 					MaxVolumesPerNode: 2,

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -412,7 +412,7 @@ func (c *containerAdapter) wait(ctx context.Context) (<-chan containerpkg.StateS
 }
 
 func (c *containerAdapter) shutdown(ctx context.Context) error {
-	var options = containertypes.StopOptions{}
+	options := containertypes.StopOptions{}
 	// Default stop grace period to nil (daemon will use the stopTimeout of the container)
 	if spec := c.container.spec(); spec.StopGracePeriod != nil {
 		timeout := int(spec.StopGracePeriod.Seconds)

--- a/daemon/cluster/executor/container/adapter_test.go
+++ b/daemon/cluster/executor/container/adapter_test.go
@@ -1,9 +1,8 @@
 package container // import "github.com/docker/docker/daemon/cluster/executor/container"
 
 import (
-	"testing"
-
 	"context"
+	"testing"
 	"time"
 
 	"github.com/docker/docker/daemon"

--- a/daemon/cluster/listen_addr.go
+++ b/daemon/cluster/listen_addr.go
@@ -142,6 +142,7 @@ func getDataPathPort(portNum uint32) (uint32, error) {
 	}
 	return portNum, nil
 }
+
 func resolveDataPathAddr(dataPathAddr string) (string, error) {
 	if dataPathAddr == "" {
 		// dataPathAddr is not defined

--- a/daemon/cluster/utils.go
+++ b/daemon/cluster/utils.go
@@ -32,7 +32,7 @@ func savePersistentState(root string, config nodeStartConfig) error {
 	if err != nil {
 		return err
 	}
-	return ioutils.AtomicWriteFile(filepath.Join(root, stateFile), dt, 0600)
+	return ioutils.AtomicWriteFile(filepath.Join(root, stateFile), dt, 0o600)
 }
 
 func clearPersistentState(root string) error {


### PR DESCRIPTION
backporting a single commit from https://github.com/moby/moby/pull/43169, because this one was bothering me 😂  https://goreportcard.com/report/github.com/docker/docker

<img width="1009" alt="Screenshot 2023-09-26 at 10 02 37" src="https://github.com/moby/moby/assets/1804568/c0256384-bbd7-4174-84a0-f52858f42195">




Formatting the code with https://github.com/mvdan/gofumpt

(cherry picked from commit 2d12dc3a58ca18d10ff93c413e78ea1bc83d2dc8)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

