### PR TITLE
hack: Run integration tests through Delve

### DIFF
--- a/docs/contributing/debug.md
+++ b/docs/contributing/debug.md
@@ -25,7 +25,7 @@ outside the developer's machine and is not recommended.
 
 ## Running Docker daemon with debugger attached
 
-1. Run development container with build optimizations disabled and Delve enabled:
+1. Run development container with build optimizations disabled (ie. `DOCKER_DEBUG=1`) and Delve enabled:
    ```bash
    $ make BIND_DIR=. DOCKER_DEBUG=1 DELVE_PORT=127.0.0.1:2345:2345 shell
    ```
@@ -45,7 +45,27 @@ outside the developer's machine and is not recommended.
       The execution will stop and wait for the IDE or Delve CLI to attach
       to the port, specified with the `DELVE_PORT` variable.
       Once the IDE or Delve CLI is attached, the execution will continue.
-   
+
+## Running integration tests with debugger attached
+
+1. Run development container with build optimizations disabled (ie. `DOCKER_DEBUG=1`) and Delve enabled:
+
+   ```bash
+   $ make BIND_DIR=. DOCKER_DEBUG=1 DELVE_PORT=127.0.0.1:2345:2345 shell
+   ```
+
+2. Inside the development container, run the integration test you want through the `make.sh` script:
+
+   ```bash
+   $ TEST_INTEGRATION_DIR=./integration/networking \
+       TESTFLAGS='-test.run TestBridgeICC' \
+       ./hack/make.sh dynbinary test-integration
+   ```
+
+   The execution will pause and wait for the IDE or Delve CLI to attach
+   to the port, specified with the `DELVE_PORT` variable.
+   Once the IDE or Delve CLI is attached, the test execution will start.
+
 ## Debugging from IDE (on example of GoLand 2021.3)
 
 1. Open the project in GoLand

--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -110,13 +110,26 @@ run_test_integration_suites() {
 
 			echo "Running $PWD (${pkgname}) flags=${pkgtestflags}"
 			[ -n "$TESTDEBUG" ] && set -x
-			# shellcheck disable=SC2086
-			test_env gotestsum \
-				--format=standard-verbose \
-				--jsonfile="${ABS_DEST}/${pkgname//./-}-go-test-report.json" \
-				--junitfile="${ABS_DEST}/${pkgname//./-}-junit-report.xml" \
-				--raw-command \
-				-- go tool test2json -p "${pkgname}" -t ./test.main ${pkgtestflags}
+
+			if [ -n "$DELVE_PORT" ]; then
+				delve_listen_port="${DELVE_PORT##*:}"
+				test_env dlv --listen="0.0.0.0:${delve_listen_port}" \
+					--headless=true \
+					--log \
+					--api-version=2 \
+					--only-same-user=false \
+					--check-go-version=false \
+					--accept-multiclient \
+					test ./ -- ${pkgtestflags}
+			else
+				# shellcheck disable=SC2086
+				test_env gotestsum \
+					--format=standard-verbose \
+					--jsonfile="${ABS_DEST}/${pkgname//./-}-go-test-report.json" \
+					--junitfile="${ABS_DEST}/${pkgname//./-}-junit-report.xml" \
+					--raw-command \
+					-- go tool test2json -p "${pkgname}" -t ./test.main ${pkgtestflags}
+			fi
 		); then
 			if [ -n "${TEST_INTEGRATION_FAIL_FAST}" ]; then
 				return 1
@@ -189,6 +202,7 @@ test_env() {
 			DOCKER_REMOTE_DAEMON="$DOCKER_REMOTE_DAEMON" \
 			DOCKER_ROOTLESS="$DOCKER_ROOTLESS" \
 			GITHUB_ACTIONS="$GITHUB_ACTIONS" \
+			GO111MODULE="$GO111MODULE" \
 			GOCACHE="$GOCACHE" \
 			GOPATH="$GOPATH" \
 			GOTRACEBACK=all \


### PR DESCRIPTION
**- What I did**

Integration tests will now run through Delve when `DELVE_PORT` is set.