### PR TITLE
libnetwork: Controller.NetworkByID: remove redundant error-handling

### DIFF
--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -863,13 +863,7 @@ func (c *Controller) NetworkByID(id string) (*Network, error) {
 	if id == "" {
 		return nil, ErrInvalidID(id)
 	}
-
-	n, err := c.getNetworkFromStore(id)
-	if err != nil {
-		return nil, ErrNoSuchNetwork(id)
-	}
-
-	return n, nil
+	return c.getNetworkFromStore(id)
 }
 
 // NewSandbox creates a new sandbox for containerID.


### PR DESCRIPTION
Controller.getNetworkFromStore() already returns a ErrNoSuchNetwork if no network was found, so we don't need to convert the existing error.

**- A picture of a cute animal (not mandatory but encouraged)**

