### PR TITLE
libnetwork: Controller.cleanupLocalEndpoints, sandboxCleanup: return errors

### DIFF
--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -151,7 +151,9 @@ func New(cfgOptions ...config.Option) (*Controller, error) {
 	if err := c.sandboxCleanup(c.cfg.ActiveSandboxes); err != nil {
 		log.G(context.TODO()).WithError(err).Error("error during sandbox cleanup")
 	}
-	c.cleanupLocalEndpoints()
+	if err := c.cleanupLocalEndpoints(); err != nil {
+		log.G(context.TODO()).WithError(err).Warnf("error during endpoint cleanup")
+	}
 	c.networkCleanup()
 
 	if err := c.startExternalKeyListener(); err != nil {

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -148,7 +148,9 @@ func New(cfgOptions ...config.Option) (*Controller, error) {
 	c.reservePools()
 
 	// Cleanup resources
-	c.sandboxCleanup(c.cfg.ActiveSandboxes)
+	if err := c.sandboxCleanup(c.cfg.ActiveSandboxes); err != nil {
+		log.G(context.TODO()).WithError(err).Error("error during sandbox cleanup")
+	}
 	c.cleanupLocalEndpoints()
 	c.networkCleanup()
 

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -1144,7 +1144,7 @@ func (ep *Endpoint) releaseAddress() {
 	}
 }
 
-func (c *Controller) cleanupLocalEndpoints() {
+func (c *Controller) cleanupLocalEndpoints() error {
 	// Get used endpoints
 	eps := make(map[string]interface{})
 	for _, sb := range c.sandboxes {
@@ -1154,8 +1154,7 @@ func (c *Controller) cleanupLocalEndpoints() {
 	}
 	nl, err := c.getNetworks()
 	if err != nil {
-		log.G(context.TODO()).Warnf("Could not get list of networks during endpoint cleanup: %v", err)
-		return
+		return fmt.Errorf("could not get list of networks: %v", err)
 	}
 
 	for _, n := range nl {
@@ -1192,4 +1191,6 @@ func (c *Controller) cleanupLocalEndpoints() {
 			}
 		}
 	}
+
+	return nil
 }


### PR DESCRIPTION
Log errors on the call-site to make it more transparent that errors may occur, but we're ignoring them.

**- A picture of a cute animal (not mandatory but encouraged)**

