### PR TITLE
libnetwork: Controller: remove mutex for "store"

### DIFF
--- a/libnetwork/store.go
+++ b/libnetwork/store.go
@@ -11,9 +11,6 @@ import (
 )
 
 func (c *Controller) initStores() error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	if c.cfg == nil {
 		return nil
 	}
@@ -34,9 +31,6 @@ func (c *Controller) closeStores() {
 }
 
 func (c *Controller) getStore() *datastore.Store {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	return c.store
 }
 


### PR DESCRIPTION
The store field is only mutated by Controller.initStores(), which is only called inside the cosntructor (libnetwork.New), so there should be no need to protect the field with a mutex in non-exported functions.

**- A picture of a cute animal (not mandatory but encouraged)**

