### PR TITLE
libnetwork: inline populateSpecial NetworkWalker

### DIFF
--- a/libnetwork/store.go
+++ b/libnetwork/store.go
@@ -287,12 +287,3 @@ func (c *Controller) networkCleanup() {
 		}
 	}
 }
-
-var populateSpecial NetworkWalker = func(nw *Network) bool {
-	if n := nw; n.hasSpecialDriver() && !n.ConfigOnly() {
-		if err := n.getController().addNetwork(n); err != nil {
-			log.G(context.TODO()).Warnf("Failed to populate network %q with driver %q", nw.Name(), nw.Type())
-		}
-	}
-	return false
-}


### PR DESCRIPTION
It was only used in a single place, and it was defined far away from where it was used.

Move the code inline, so that it's clear at a glance what it's doing.


**- A picture of a cute animal (not mandatory but encouraged)**

