### PR TITLE
 libnetwork: Controller: getKeys, getPrimaryKeyTag: prevent panic and small refactor

### DIFF
--- a/libnetwork/agent.go
+++ b/libnetwork/agent.go
@@ -266,16 +266,16 @@ func (c *Controller) agentSetup(clusterProvider cluster.Provider) error {
 
 // For a given subsystem getKeys sorts the keys by lamport time and returns
 // slice of keys and lamport time which can used as a unique tag for the keys
-func (c *Controller) getKeys(subsys string) ([][]byte, []uint64) {
+func (c *Controller) getKeys(subsystem string) (keys [][]byte, tags []uint64) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	sort.Sort(ByTime(c.keys))
 
-	keys := [][]byte{}
-	tags := []uint64{}
+	keys = make([][]byte, 0, len(c.keys))
+	tags = make([]uint64, 0, len(c.keys))
 	for _, key := range c.keys {
-		if key.Subsystem == subsys {
+		if key.Subsystem == subsystem {
 			keys = append(keys, key.Key)
 			tags = append(tags, key.LamportTime)
 		}
@@ -291,18 +291,18 @@ func (c *Controller) getKeys(subsys string) ([][]byte, []uint64) {
 
 // getPrimaryKeyTag returns the primary key for a given subsystem from the
 // list of sorted key and the associated tag
-func (c *Controller) getPrimaryKeyTag(subsys string) ([]byte, uint64, error) {
+func (c *Controller) getPrimaryKeyTag(subsystem string) (key []byte, lamportTime uint64, _ error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	sort.Sort(ByTime(c.keys))
-	keys := []*types.EncryptionKey{}
-	for _, key := range c.keys {
-		if key.Subsystem == subsys {
-			keys = append(keys, key)
+	keys := make([]*types.EncryptionKey, 0, len(c.keys))
+	for _, k := range c.keys {
+		if k.Subsystem == subsystem {
+			keys = append(keys, k)
 		}
 	}
 	if len(keys) < 2 {
-		return nil, 0, fmt.Errorf("no primary key found for %s subsystem: %d keys found on controller, expected at least 2", subsys, len(keys))
+		return nil, 0, fmt.Errorf("no primary key found for %s subsystem: %d keys found on controller, expected at least 2", subsystem, len(keys))
 	}
 	return keys[1].Key, keys[1].LamportTime, nil
 }

--- a/libnetwork/agent.go
+++ b/libnetwork/agent.go
@@ -281,8 +281,11 @@ func (c *Controller) getKeys(subsys string) ([][]byte, []uint64) {
 		}
 	}
 
-	keys[0], keys[1] = keys[1], keys[0]
-	tags[0], tags[1] = tags[1], tags[0]
+	if len(keys) > 1 {
+		// TODO(thaJeztah): why are we swapping order here? This code was added in https://github.com/moby/libnetwork/commit/e83d68b7d1fd9c479120914024242238f791b4dc
+		keys[0], keys[1] = keys[1], keys[0]
+		tags[0], tags[1] = tags[1], tags[0]
+	}
 	return keys, tags
 }
 
@@ -297,6 +300,9 @@ func (c *Controller) getPrimaryKeyTag(subsys string) ([]byte, uint64, error) {
 		if key.Subsystem == subsys {
 			keys = append(keys, key)
 		}
+	}
+	if len(keys) < 2 {
+		return nil, 0, fmt.Errorf("no primary key found for %s subsystem: %d keys found on controller, expected at least 2", subsys, len(keys))
 	}
 	return keys[1].Key, keys[1].LamportTime, nil
 }


### PR DESCRIPTION
### libnetwork: Controller: getKeys, getPrimaryKeyTag: prevent panic

Prevent potential panics if we don't have the expected number of keys
for the subsystem.

### libnetwork: Controller: getKeys, getPrimaryKeyTag: slight refactor

- use named return variables to make the function more self-describing
- rename variable for readability
- slightly optimize slice initialization, and keep linters happy



**- A picture of a cute animal (not mandatory but encouraged)**

