### PR TITLE
fix faulty tests for distribution-client

### DIFF
--- a/distribution/pull_v2_test.go
+++ b/distribution/pull_v2_test.go
@@ -268,6 +268,27 @@ func TestPullSchema2Config(t *testing.T) {
 			name: "unauthorized",
 			handler: func(callCount int, w http.ResponseWriter) {
 				w.WriteHeader(http.StatusUnauthorized)
+				// FIXME: current distribution client does not handle plain-text error-responses, so this response is ignored.
+				_, _ = w.Write([]byte("you need to be authenticated"))
+			},
+			expectError:    "unauthorized: authentication required",
+			expectAttempts: 1,
+		},
+		{
+			name: "unauthorized JSON",
+			handler: func(callCount int, w http.ResponseWriter) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`					{ "errors":	[{"code": "UNAUTHORIZED", "message": "you need to be authenticated", "detail": "more detail"}]}`))
+			},
+			expectError:    "unauthorized: you need to be authenticated",
+			expectAttempts: 1,
+		},
+		{
+			name: "unauthorized JSON no body",
+			handler: func(callCount int, w http.ResponseWriter) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
 			},
 			expectError:    "unauthorized: authentication required",
 			expectAttempts: 1,

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -235,13 +235,13 @@ func getTestTokenService(status int, body string, retries int) *httptest.Server 
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
 		if retries > 0 {
-			w.WriteHeader(http.StatusServiceUnavailable)
 			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
 			w.Write([]byte(`{"errors":[{"code":"UNAVAILABLE","message":"cannot create token at this time"}]}`))
 			retries--
 		} else {
-			w.WriteHeader(status)
 			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(status)
 			w.Write([]byte(body))
 		}
 		mu.Unlock()


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/46542

### integration-cli: fix getTestTokenService not sending header

This utility was setting the content-type header after WriteHeader was
called, and the header was not sent because of that.

### distribution: TestPullSchema2Config fix test response

The test was depending on the client constructing an error based on the
http-status code, and the client not reading the response body if the
response was not a JSON response.

This fix;

- adds the correct content-type headers in the response
- includes error-messages in the response
- adds additional tests to cover both the plain (non-JSON) and JSON
  error responses, as well as an empty response.


**- A picture of a cute animal (not mandatory but encouraged)**

