### PR TITLE
daemon/RegistryHosts: Don't lose mirrors

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -196,7 +196,7 @@ func (daemon *Daemon) RegistryHosts(host string) ([]docker.RegistryHost, error) 
 	}
 	conf := daemon.registryService.ServiceConfig().IndexConfigs
 	for k, v := range conf {
-		c := resolverconfig.RegistryConfig{}
+		c := m[k]
 		if !v.Secure {
 			t := true
 			c.PlainHTTP = &t
@@ -204,8 +204,7 @@ func (daemon *Daemon) RegistryHosts(host string) ([]docker.RegistryHost, error) 
 		}
 		m[k] = c
 	}
-	if _, ok := m[host]; !ok && daemon.registryService.IsInsecureRegistry(host) {
-		c := resolverconfig.RegistryConfig{}
+	if c, ok := m[host]; !ok && daemon.registryService.IsInsecureRegistry(host) {
 		t := true
 		c.PlainHTTP = &t
 		c.Insecure = &t

--- a/vendor.mod
+++ b/vendor.mod
@@ -61,7 +61,7 @@ require (
 	github.com/miekg/dns v1.1.43
 	github.com/mistifyio/go-zfs/v3 v3.0.1
 	github.com/mitchellh/copystructure v1.2.0
-	github.com/moby/buildkit v0.12.2
+	github.com/moby/buildkit v0.12.3-0.20231002214633-f94ed7cec313 // v0.12 branch
 	github.com/moby/ipvs v1.1.0
 	github.com/moby/locker v1.0.1
 	github.com/moby/patternmatcher v0.6.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -909,8 +909,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mndrix/tap-go v0.0.0-20171203230836-629fa407e90b/go.mod h1:pzzDgJWZ34fGzaAZGFW22KVZDfyrYW+QABMrWnJBnSs=
 github.com/moby/buildkit v0.8.1/go.mod h1:/kyU1hKy/aYCuP39GZA9MaKioovHku57N6cqlKZIaiQ=
-github.com/moby/buildkit v0.12.2 h1:B7guBgY6sfk4dBlv/ORUxyYlp0UojYaYyATgtNwSCXc=
-github.com/moby/buildkit v0.12.2/go.mod h1:adB4y0SxxX8trnrY+oEulb48ODLqPO6pKMF0ppGcCoI=
+github.com/moby/buildkit v0.12.3-0.20231002214633-f94ed7cec313 h1:6obdxayNqgEFbed+9RL6NzejXtP9wuMa7ouqxYsEGXA=
+github.com/moby/buildkit v0.12.3-0.20231002214633-f94ed7cec313/go.mod h1:adB4y0SxxX8trnrY+oEulb48ODLqPO6pKMF0ppGcCoI=
 github.com/moby/ipvs v1.1.0 h1:ONN4pGaZQgAx+1Scz5RvWV4Q7Gb+mvfRh3NsPS+1XQQ=
 github.com/moby/ipvs v1.1.0/go.mod h1:4VJMWuf098bsUMmZEiD4Tjk/O7mOn3l1PTD3s4OoYAs=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=

--- a/vendor/github.com/moby/buildkit/util/resolver/resolver.go
+++ b/vendor/github.com/moby/buildkit/util/resolver/resolver.go
@@ -130,9 +130,10 @@ func NewRegistryConfig(m map[string]config.RegistryConfig) docker.RegistryHosts 
 
 			var out []docker.RegistryHost
 
-			for _, mirror := range c.Mirrors {
-				h := newMirrorRegistryHost(mirror)
-				hosts, err := fillInsecureOpts(mirror, m[mirror], h)
+			for _, rawMirror := range c.Mirrors {
+				h := newMirrorRegistryHost(rawMirror)
+				mirrorHost := h.Host
+				hosts, err := fillInsecureOpts(mirrorHost, m[mirrorHost], h)
 				if err != nil {
 					return nil, err
 				}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -668,7 +668,7 @@ github.com/mitchellh/hashstructure/v2
 # github.com/mitchellh/reflectwalk v1.0.2
 ## explicit
 github.com/mitchellh/reflectwalk
-# github.com/moby/buildkit v0.12.2
+# github.com/moby/buildkit v0.12.3-0.20231002214633-f94ed7cec313
 ## explicit; go 1.20
 github.com/moby/buildkit/api/services/control
 github.com/moby/buildkit/api/types


### PR DESCRIPTION
- related to: https://github.com/moby/moby/pull/45992

`docker.io` is present in the `IndexConfigs` so the `Mirrors` property would get lost because a fresh `RegistryConfig` object was created.

Instead of creating a new object, reuse the existing one and just mutate its fields.

**- What I did**
Fixed mirrors not working with buildkit.

**- How I did it**
See commit.

**- How to verify it**
Try to use registry mirror.

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**

