### PR TITLE
integration: fix disk usage test for c8d

### DIFF
--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -263,7 +263,7 @@ func (i *ImageService) singlePlatformImage(ctx context.Context, contentStore con
 		if err != nil {
 			logger.WithError(err).Error("failed to create digested reference")
 		} else {
-			repoDigests = append(repoDigests, digested.String())
+			repoDigests = append(repoDigests, reference.FamiliarString(digested))
 		}
 	}
 


### PR DESCRIPTION
Check for accurate values that may contain content sizes unknown to the usage test in the calculation. Avoid asserting using deep equals when only the expected value range is known to the test.

Always use familiarized string in images output.