### PR TITLE
Add until filter to docker image ls

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8075,6 +8075,7 @@ paths:
             - `label=key` or `label="key=value"` of an image label
             - `reference`=(`<image-name>[:<tag>]`)
             - `since`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
+            - `until=<timestamp>`
           type: "string"
         - name: "shared-size"
           in: "query"

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -17,6 +17,11 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.44](https://docs.docker.com/engine/api/v1.44/) documentation
 
+* GET `/images/json` now accepts an `until` filter. This accepts a timestamp and
+  lists all images created before it. The `<timestamp>` can be Unix timestamps,
+  date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`)
+  computed relative to the daemon machine’s time. This change is not versioned,
+  and affects all API versions if the daemon has this patch.
 * The `VirtualSize` field in the `GET /images/{name}/json`, `GET /images/json`,
   and `GET /system/df` responses is now omitted. Use the `Size` field instead,
   which contains the same information.

--- a/integration/image/list_test.go
+++ b/integration/image/list_test.go
@@ -57,6 +57,50 @@ func TestImagesFilterMultiReference(t *testing.T) {
 	}
 }
 
+func TestImagesFilterUntil(t *testing.T) {
+	ctx := setupTest(t)
+
+	client := testEnv.APIClient()
+
+	name := strings.ToLower(t.Name())
+	ctr := container.Create(ctx, t, client, container.WithName(name))
+
+	imgs := make([]string, 5)
+	for i := range imgs {
+		if i > 0 {
+			// Make really really sure each image has a distinct timestamp.
+			time.Sleep(time.Millisecond)
+		}
+		id, err := client.ContainerCommit(ctx, ctr, containertypes.CommitOptions{Reference: fmt.Sprintf("%s:v%d", name, i)})
+		assert.NilError(t, err)
+		imgs[i] = id.ID
+	}
+
+	olderImage, _, err := client.ImageInspectWithRaw(ctx, imgs[2])
+	assert.NilError(t, err)
+	olderUntil := olderImage.Created
+
+	laterImage, _, err := client.ImageInspectWithRaw(ctx, imgs[3])
+	assert.NilError(t, err)
+	laterUntil := laterImage.Created
+
+	filter := filters.NewArgs(
+		filters.Arg("since", imgs[0]),
+		filters.Arg("until", olderUntil),
+		filters.Arg("until", laterUntil),
+		filters.Arg("before", imgs[len(imgs)-1]),
+	)
+	list, err := client.ImageList(ctx, types.ImageListOptions{Filters: filter})
+	assert.NilError(t, err)
+
+	var listedIDs []string
+	for _, i := range list {
+		t.Logf("ImageList: ID=%v RepoTags=%v", i.ID, i.RepoTags)
+		listedIDs = append(listedIDs, i.ID)
+	}
+	assert.DeepEqual(t, listedIDs, imgs[1:2], cmpopts.SortSlices(func(a, b string) bool { return a < b }))
+}
+
 func TestImagesFilterBeforeSince(t *testing.T) {
 	ctx := setupTest(t)
 


### PR DESCRIPTION
- Fixes https://github.com/moby/moby/issues/46576

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added the ability to filter the results of `docker image ls` or `docker images` through timestamps by adding the `until` filter.

**- How I did it**
Modified the `acceptedImageFilterTags` map in `daemon/containerd/image_list.go` to include an `until` key. Then I modified `setupFilters` function in the same file to process the value assigned to the until key

**- How to verify it**
I added an integration test function `TestImagesFilterUntil`. I did not see any unit tests that test the `setupFilters` function directly, which is why I decided to add this new test instead. Let me know if there is a simpler or better way to test this. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
`docker image ls` now allows filtering by timestamp

**- A picture of a cute animal (not mandatory but encouraged)**

