### PR TITLE
c8d: Skip history layer test with containerd snapshotters

### DIFF
--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -261,6 +261,7 @@ func (s *DockerCLIRmiSuite) TestRmiContainerImageNotFound(c *testing.T) {
 
 // #13422
 func (s *DockerCLIRmiSuite) TestRmiUntagHistoryLayer(c *testing.T) {
+	skip.If(c, testEnv.UsingSnapshotter, "intermediate layers don't have IDs with containerd")
 	image := "tmp1"
 	// Build an image for testing.
 	dockerfile := `FROM busybox


### PR DESCRIPTION
**- What I did**

Skipped history layer test with containerd snapshotters

We don't keep the image ID of the intermediate images created during a build. This is also only a feature of the classic builder, buildkit doesn't create intermediate images either.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

