### PR TITLE
c8d/push: Show progress only on blobs

### DIFF
--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -134,24 +134,22 @@ func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, m
 		return err
 	}
 
-	addChildrenToJobs := containerdimages.HandlerFunc(
+	addLayerJobs := containerdimages.HandlerFunc(
 		func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-			children, err := containerdimages.Children(ctx, store, desc)
-			if err != nil {
-				return nil, err
+			switch {
+			case containerdimages.IsIndexType(desc.MediaType),
+				containerdimages.IsManifestType(desc.MediaType),
+				containerdimages.IsConfigType(desc.MediaType):
+			default:
+				jobsQueue.Add(desc)
 			}
-			for _, c := range children {
-				jobsQueue.Add(c)
-			}
-
-			jobsQueue.Add(desc)
 
 			return nil, nil
 		},
 	)
 
 	handlerWrapper := func(h images.Handler) images.Handler {
-		return containerdimages.Handlers(addChildrenToJobs, h)
+		return containerdimages.Handlers(addLayerJobs, h)
 	}
 
 	err = remotes.PushContent(ctx, pusher, target, store, limiter, platforms.All, handlerWrapper)


### PR DESCRIPTION
To match the graphdriver's push behavior which only shows the progress for layers.
Exclude indexes, manifests and image configs from the push progress. Don't explicitly check for `IsLayerType` to also handle other potentially big blobs (like buildkit attestations).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
```bash
$ printf 'FROM ubuntu\nRUN env >/env' | docker build -t pawelgronowski465/pushtest  -
$ docker push  pawelgronowski465/testpush
Using default tag: latest
The push refers to repository [docker.io/pawelgronowski465/testpush]
b384ff348c0f: Pushed
3326f487ddb3: Pushed
c391327a0f1d: Pushed
latest: digest: sha256:085ca3ebd85e2fc2a8189b2d0f22665053d9783d0d714c5bb97384282609e86a size: 855
$


# b384ff348c0f - buildkit attestation
# 3326f487ddb3 - the extra layer (`RUN env>/env`)
# c391327a0f1d - ubuntu rootfs
```

**- Description for the changelog**
```release-note
- containerd image store: Hide push upload progress of manifests, configs and indexes (small json blobs) to match the original push behavior
```


**- A picture of a cute animal (not mandatory but encouraged)**

