### PR TITLE
daemon/c8d: Use non cancellable context in defers

### DIFF
--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/docker/api/types/backend"
 	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/internal/compatcontext"
 	registrypkg "github.com/docker/docker/registry"
 
 	// "github.com/docker/docker/api/types/container"
@@ -450,7 +451,7 @@ func (i *ImageService) CreateImage(ctx context.Context, config []byte, parent st
 		return nil, err
 	}
 	defer func() {
-		if err := release(ctx); err != nil {
+		if err := release(compatcontext.WithoutCancel(ctx)); err != nil {
 			log.G(ctx).WithError(err).Warn("failed to release lease created for create")
 		}
 	}()

--- a/daemon/containerd/image_commit.go
+++ b/daemon/containerd/image_commit.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/image"
 	imagespec "github.com/docker/docker/image/spec/specs-go/v1"
+	"github.com/docker/docker/internal/compatcontext"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
@@ -74,7 +75,7 @@ func (i *ImageService) CommitImage(ctx context.Context, cc backend.CommitConfig)
 		return "", fmt.Errorf("failed to create lease for commit: %w", err)
 	}
 	defer func() {
-		if err := release(ctx); err != nil {
+		if err := release(compatcontext.WithoutCancel(ctx)); err != nil {
 			log.G(ctx).WithError(err).Warn("failed to release lease created for commit")
 		}
 	}()

--- a/daemon/containerd/image_import.go
+++ b/daemon/containerd/image_import.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	imagespec "github.com/docker/docker/image/spec/specs-go/v1"
+	"github.com/docker/docker/internal/compatcontext"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/pools"
 	"github.com/google/uuid"
@@ -49,7 +50,7 @@ func (i *ImageService) ImportImage(ctx context.Context, ref reference.Named, pla
 		return "", errdefs.System(err)
 	}
 	defer func() {
-		if err := release(ctx); err != nil {
+		if err := release(compatcontext.WithoutCancel(ctx)); err != nil {
 			logger.WithError(err).Warn("failed to release lease created for import")
 		}
 	}()

--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/internal/compatcontext"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/opencontainers/go-digest"
@@ -84,7 +85,7 @@ func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, m
 		return err
 	}
 	defer func() {
-		if err := release(leasedCtx); err != nil {
+		if err := release(compatcontext.WithoutCancel(leasedCtx)); err != nil {
 			log.G(ctx).WithField("image", targetRef).WithError(err).Warn("failed to release lease created for push")
 		}
 	}()


### PR DESCRIPTION
Fixes leases not being released when operation was cancelled.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

