### PR TITLE
c8d/push: Show Mounted/Already exists status

### DIFF
--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -120,9 +120,6 @@ func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, m
 	if err != nil {
 		return err
 	}
-	for dgst := range mountableBlobs {
-		pp.addMountable(dgst)
-	}
 
 	// Create a store which fakes the local existence of possibly mountable blobs.
 	// Otherwise they can't be pushed at all.

--- a/daemon/containerd/progress.go
+++ b/daemon/containerd/progress.go
@@ -171,30 +171,7 @@ func (p pullProgress) UpdateProgress(ctx context.Context, ongoing *jobs, out pro
 }
 
 type pushProgress struct {
-	Tracker   docker.StatusTracker
-	mountable map[digest.Digest]struct{}
-	mutex     sync.Mutex
-}
-
-func (p *pushProgress) addMountable(dgst digest.Digest) {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	if p.mountable == nil {
-		p.mountable = map[digest.Digest]struct{}{}
-	}
-	p.mountable[dgst] = struct{}{}
-}
-
-func (p *pushProgress) isMountable(dgst digest.Digest) bool {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	if p.mountable == nil {
-		return false
-	}
-	_, has := p.mountable[dgst]
-	return has
+	Tracker docker.StatusTracker
 }
 
 func (p *pushProgress) UpdateProgress(ctx context.Context, ongoing *jobs, out progress.Output, start time.Time) error {

--- a/daemon/containerd/progress.go
+++ b/daemon/containerd/progress.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/containerd/containerd/content"
 	cerrdefs "github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/log"
+	"github.com/distribution/reference"
 	"github.com/docker/docker/internal/compatcontext"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/stringid"
@@ -209,8 +211,18 @@ func (p *pushProgress) UpdateProgress(ctx context.Context, ongoing *jobs, out pr
 		}
 
 		if status.Committed && status.Offset >= status.Total {
-			if p.isMountable(j.Digest) {
-				progress.Update(out, id, "Mounted")
+			if status.MountedFrom != "" {
+				from := status.MountedFrom
+				if ref, err := reference.ParseNormalizedNamed(from); err == nil {
+					from = reference.Path(ref)
+				}
+				progress.Update(out, id, "Mounted from "+from)
+			} else if status.Exists {
+				if images.IsLayerType(j.MediaType) {
+					progress.Update(out, id, "Layer already exists")
+				} else {
+					progress.Update(out, id, "Already exists")
+				}
 			} else {
 				progress.Update(out, id, "Pushed")
 			}


### PR DESCRIPTION
- Needs: https://github.com/moby/moby/pull/46611
- Needs: https://github.com/containerd/containerd/pull/9193

**- What I did**
Implemented Mounted/Exists statuses when pushing

**- How I did it**
Use push statuses from containerd.

**- How to verify it**
```diff
$ docker pull alpine
$ printf 'FROM alpine\nRUN env>/env' | docker buildx build -t pawelgronowski465/pushpushpush -
(...)
 => => exporting manifest sha256:fbc9873dff2b770cb9a5fa1718d5c9191a8074b3eca4455d814efe3ddb3d4fd1                                                         0.0s
 => => exporting config sha256:f1ee5bc3732603844c32381d7e9f5e3a82558fb05de0fecdef0695b8a29e08f5                                                           0.0s
 => => exporting attestation manifest sha256:ac7fc162ed6f67cbb935b482bc33c510b840ea740e00d6a9613a8e16fba624ea                                             0.0s
 => => exporting manifest list sha256:63be88a405ec007463ceb1b9c5546cd88c9af839e55bb34add6a246962b078f8                                                    0.0s

$ docker push pawelgronowski465/pushpushpush
Using default tag: latest
The push refers to repository [docker.io/pawelgronowski465/pushpushpush]
f1ee5bc37326: Pushed
-579b34f0a95b: Pushed
+579b34f0a95b: Mounted from library/alpine
a882e643d830: Pushed
a8267b856818: Pushed
fcb00a1b7bad: Pushed
fbc9873dff2b: Pushed
ac7fc162ed6f: Pushed
63be88a405ec: Pushed
latest: digest: sha256:63be88a405ec007463ceb1b9c5546cd88c9af839e55bb34add6a246962b078f8 size: 855

$ docker push  pawelgronowski465/pushpushpush
Using default tag: latest
The push refers to repository [docker.io/pawelgronowski465/pushpushpush]
-579b34f0a95b: Pushed
-a882e643d830: Pushed
+579b34f0a95b: Layer already exists
+a882e643d830: Layer already exists
fbc9873dff2b: Pushed
ac7fc162ed6f: Pushed
63be88a405ec: Pushed
-a8267b856818: Pushed
-fcb00a1b7bad: Pushed
-f1ee5bc37326: Pushed
+a8267b856818: Already exists
+fcb00a1b7bad: Already exists
+f1ee5bc37326: Already exists
latest: digest: sha256:63be88a405ec007463ceb1b9c5546cd88c9af839e55bb34add6a246962b078f8 size: 855

```

**- Description for the changelog**
```release-note
containerd image store: `docker push` now supports `Layer already exists` and `Mounted from` progress statuses
```


**- A picture of a cute animal (not mandatory but encouraged)**

