### PR TITLE
daemon/c8d: Use WithoutCancel instead of context.Background

### DIFF
--- a/daemon/containerd/image_delete.go
+++ b/daemon/containerd/image_delete.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/image"
+	"github.com/docker/docker/internal/compatcontext"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -135,7 +136,7 @@ func (i *ImageService) deleteAll(ctx context.Context, img images.Image, force, p
 		return nil, err
 	}
 	defer func() {
-		if err := i.unleaseSnapshotsFromDeletedConfigs(context.Background(), possiblyDeletedConfigs); err != nil {
+		if err := i.unleaseSnapshotsFromDeletedConfigs(compatcontext.WithoutCancel(ctx), possiblyDeletedConfigs); err != nil {
 			log.G(ctx).WithError(err).Warn("failed to unlease snapshots")
 		}
 	}()

--- a/daemon/containerd/image_prune.go
+++ b/daemon/containerd/image_prune.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/internal/compatcontext"
 	"github.com/hashicorp/go-multierror"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -147,7 +148,7 @@ func (i *ImageService) pruneUnused(ctx context.Context, filterFunc imageFilterFu
 
 	// Workaround for https://github.com/moby/buildkit/issues/3797
 	defer func() {
-		if err := i.unleaseSnapshotsFromDeletedConfigs(context.Background(), possiblyDeletedConfigs); err != nil {
+		if err := i.unleaseSnapshotsFromDeletedConfigs(compatcontext.WithoutCancel(ctx), possiblyDeletedConfigs); err != nil {
 			errs = multierror.Append(errs, err)
 		}
 	}()

--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/distribution"
 	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/internal/compatcontext"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -129,7 +130,7 @@ func (i *ImageService) PullImage(ctx context.Context, ref reference.Named, platf
 	logger.Info("image pulled")
 
 	// The pull succeeded, so try to remove any dangling image we have for this target
-	err = i.client.ImageService().Delete(context.Background(), danglingImageName(img.Target().Digest))
+	err = i.client.ImageService().Delete(compatcontext.WithoutCancel(ctx), danglingImageName(img.Target().Digest))
 	if err != nil && !cerrdefs.IsNotFound(err) {
 		// Image pull succeeded, but cleaning up the dangling image failed. Ignore the
 		// error to not mark the pull as failed.

--- a/daemon/containerd/progress.go
+++ b/daemon/containerd/progress.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
+	"github.com/docker/docker/internal/compatcontext"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/opencontainers/go-digest"
@@ -52,7 +53,7 @@ func (j *jobs) showProgress(ctx context.Context, out progress.Output, updater pr
 					}
 				}
 			case <-ctx.Done():
-				ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
+				ctx, cancel := context.WithTimeout(compatcontext.WithoutCancel(ctx), time.Millisecond*500)
 				defer cancel()
 				updater.UpdateProgress(ctx, j, out, start)
 				close(lastUpdate)

--- a/daemon/containerd/soft_delete.go
+++ b/daemon/containerd/soft_delete.go
@@ -6,6 +6,7 @@ import (
 	cerrdefs "github.com/containerd/containerd/errdefs"
 	containerdimages "github.com/containerd/containerd/images"
 	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/internal/compatcontext"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -30,7 +31,7 @@ func (i *ImageService) softImageDelete(ctx context.Context, img containerdimages
 
 	// Create dangling image if this is the last image pointing to this target.
 	if len(imgs) == 1 {
-		err = i.ensureDanglingImage(context.Background(), img)
+		err = i.ensureDanglingImage(compatcontext.WithoutCancel(ctx), img)
 
 		// Error out in case we couldn't persist the old image.
 		if err != nil {
@@ -40,7 +41,7 @@ func (i *ImageService) softImageDelete(ctx context.Context, img containerdimages
 	}
 
 	// Free the target name.
-	err = is.Delete(context.Background(), img.Name)
+	err = is.Delete(compatcontext.WithoutCancel(ctx), img.Name)
 	if err != nil {
 		if !cerrdefs.IsNotFound(err) {
 			return errdefs.System(errors.Wrapf(err, "failed to delete image %s which existed a moment before", img.Name))
@@ -64,7 +65,7 @@ func (i *ImageService) ensureDanglingImage(ctx context.Context, from containerdi
 	}
 	danglingImage.Name = danglingImageName(from.Target.Digest)
 
-	_, err := i.client.ImageService().Create(context.Background(), danglingImage)
+	_, err := i.client.ImageService().Create(compatcontext.WithoutCancel(ctx), danglingImage)
 	// If it already exists, then just continue.
 	if cerrdefs.IsAlreadyExists(err) {
 		return nil


### PR DESCRIPTION
Instead of passing a completely fresh context without any values, just discard the cancellation.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

