### PR TITLE
integration-cli: Make TestPsListContainersSize work with c8d

### DIFF
--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +12,7 @@ import (
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/pkg/stringid"
+	"github.com/docker/go-units"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
@@ -159,8 +159,8 @@ func (s *DockerCLIPsSuite) TestPsListContainersSize(c *testing.T) {
 	baseOut, _ := dockerCmd(c, "ps", "-s", "-n=1")
 	baseLines := strings.Split(strings.Trim(baseOut, "\n "), "\n")
 	baseSizeIndex := strings.Index(baseLines[0], "SIZE")
-	baseFoundsize := baseLines[1][baseSizeIndex:]
-	baseBytes, err := strconv.Atoi(strings.Split(baseFoundsize, "B")[0])
+	baseFoundsize, _, _ := strings.Cut(baseLines[1][baseSizeIndex:], " ")
+	baseBytes, err := units.FromHumanSize(baseFoundsize)
 	assert.NilError(c, err)
 
 	name := "test_size"
@@ -186,7 +186,7 @@ func (s *DockerCLIPsSuite) TestPsListContainersSize(c *testing.T) {
 	idIndex := strings.Index(lines[0], "CONTAINER ID")
 	foundID := lines[1][idIndex : idIndex+12]
 	assert.Equal(c, foundID, id[:12], fmt.Sprintf("Expected id %s, got %s", id[:12], foundID))
-	expectedSize := fmt.Sprintf("%dB", 2+baseBytes)
+	expectedSize := units.HumanSize(float64(baseBytes + 2))
 	foundSize := lines[1][sizeIndex:]
 	assert.Assert(c, strings.Contains(foundSize, expectedSize), "Expected size %q, got %q", expectedSize, foundSize)
 }


### PR DESCRIPTION
The reported size is bigger with snapshotters (because it also includes the size of the filesystem metadata).
Adjust the test to also handle other sizes correctly.

**- What I did**
Made `TestPsListContainersSize` green with c8d.

**- How I did it**
See commits.

**- How to verify it**
```diff
$ make TEST_IGNORE_CGROUP_CHECK=1 DOCKERCLI_INTEGRATION_VERSION=v24.0.5  DOCKER_GRAPHDRIVER=overlayfs TEST_INTEGRATION_USE_SNAPSHOTTER=1 DOCKER_BUILDKIT=0  'TEST_FILTER=TestPsListContainersSize' test-integration

-=== FAIL: amd64.integration-cli TestDockerCLIPsSuite/TestPsListContainersSize (0.38s)
-    docker_cli_ps_test.go:164: assertion failed: error is not nil: strconv.Atoi: parsing "4.1k": invalid syntax
-    --- FAIL: TestDockerCLIPsSuite/TestPsListContainersSize (0.38s)
+--- PASS: TestDockerCLIPsSuite (1.03s)
+    --- PASS: TestDockerCLIPsSuite/TestPsListContainersSize (1.03s)
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

