### PR TITLE
registry: allow mirror paths in config

### DIFF
--- a/registry/config.go
+++ b/registry/config.go
@@ -330,8 +330,8 @@ func ValidateMirror(val string) (string, error) {
 	if uri.Scheme != "http" && uri.Scheme != "https" {
 		return "", invalidParamf("invalid mirror: unsupported scheme %q in %q", uri.Scheme, uri)
 	}
-	if (uri.Path != "" && uri.Path != "/") || uri.RawQuery != "" || uri.Fragment != "" {
-		return "", invalidParamf("invalid mirror: path, query, or fragment at end of the URI %q", uri)
+	if uri.RawQuery != "" || uri.Fragment != "" {
+		return "", invalidParamf("invalid mirror: query or fragment at end of the URI %q", uri)
 	}
 	if uri.User != nil {
 		// strip password from output

--- a/registry/config_test.go
+++ b/registry/config_test.go
@@ -142,21 +142,21 @@ func TestValidateMirror(t *testing.T) {
 		"https://127.0.0.1",
 		"http://127.0.0.1:5000",
 		"https://127.0.0.1:5000",
+		"http://mirror-1.example.com/v1/",
+		"https://mirror-1.example.com/v1/",
 	}
 
 	invalid := []string{
 		"!invalid!://%as%",
 		"ftp://mirror-1.example.com",
 		"http://mirror-1.example.com/?q=foo",
-		"http://mirror-1.example.com/v1/",
 		"http://mirror-1.example.com/v1/?q=foo",
 		"http://mirror-1.example.com/v1/?q=foo#frag",
 		"http://mirror-1.example.com?q=foo",
 		"https://mirror-1.example.com#frag",
 		"https://mirror-1.example.com/#frag",
 		"http://foo:bar@mirror-1.example.com/",
-		"https://mirror-1.example.com/v1/",
-		"https://mirror-1.example.com/v1/#",
+		"https://mirror-1.example.com/v1/#frag",
 		"https://mirror-1.example.com?q",
 	}
 


### PR DESCRIPTION
Close #36598

Note that this is my first PR in the Moby project, or in any go-language project for that matter. Please forgive my mistakes, and give detailed instructions if changes are necessary.

**- What I did**

Allow users to run registry mirrors that are rooted at a subpath of a domain.

**- How I did it**

In the registry configuration validation step, I removed the parts that check that there is no path in the mirror URIs.

**- How to verify it**

Run a registry with docker.io proxy config:

docker-compose.yml:

```
services:

  registry:
    image: docker.io/registry:2
    volumes:
      - ./registry.yml:/etc/docker/registry/config.yml:ro
      - ./data/registry:/var/lib/registry
    restart: unless-stopped

  proxy:
    image: docker.io/caddy
    ports:
      - "5001:5001"
    volumes:
      - ./Caddyfile:/etc/caddy/Caddyfile:ro
    restart: unless-stopped
 ```

registry.yml:

```
version: 0.1
log:
  fields:
    service: registry
storage:
  cache:
    blobdescriptor: inmemory
  filesystem:
    rootdirectory: /var/lib/registry
http:
  addr: :5000
  headers:
    X-Content-Type-Options: [nosniff]
health:
  storagedriver:
    enabled: true
    interval: 10s
    threshold: 3
proxy:
  remoteurl: https://registry-1.docker.io
```

Caddyfile:

```
:5001 {
    handle_path /hub/* {
        reverse_proxy http://registry:5000
    }
}
```

Run a Docker daemon with the following configuration in /etc/docker/daemon.json:

```
{
    "registry-mirrors": [
        "http://localhost:5001/hub"
    ]
}
```

Then pull an image: `docker pull ubuntu` and verify that the request goes through the self-hosted registry.

**- Description for the changelog**

Make it possible to run a registry mirror with an URI that includes a path.

**- A picture of a cute animal (not mandatory but encouraged)**

![cute](https://github.com/moby/moby/assets/44319/df39b801-fdcd-4ae2-9ee0-8218020cff35)

