### PR TITLE
c8d/rmi: Don't emit Untagged for dangling images

### DIFF
--- a/daemon/containerd/image_delete.go
+++ b/daemon/containerd/image_delete.go
@@ -64,7 +64,8 @@ func (i *ImageService) ImageDelete(ctx context.Context, imageRef string, force, 
 
 	imgID := image.ID(img.Target.Digest)
 
-	if isImageIDPrefix(imgID.String(), imageRef) {
+	explicitDanglingRef := strings.HasPrefix(imageRef, imageNameDanglingPrefix) && isDanglingImage(img)
+	if isImageIDPrefix(imgID.String(), imageRef) || explicitDanglingRef {
 		return i.deleteAll(ctx, img, force, prune)
 	}
 

--- a/daemon/containerd/image_delete.go
+++ b/daemon/containerd/image_delete.go
@@ -260,8 +260,10 @@ func (i *ImageService) imageDeleteHelper(ctx context.Context, img images.Image, 
 		return err
 	}
 
-	i.LogImageEvent(imgID.String(), imgID.String(), events.ActionUnTag)
-	*records = append(*records, types.ImageDeleteResponseItem{Untagged: reference.FamiliarString(untaggedRef)})
+	if !isDanglingImage(img) {
+		i.LogImageEvent(imgID.String(), imgID.String(), events.ActionUnTag)
+		*records = append(*records, types.ImageDeleteResponseItem{Untagged: reference.FamiliarString(untaggedRef)})
+	}
 
 	return nil
 }

--- a/daemon/containerd/soft_delete.go
+++ b/daemon/containerd/soft_delete.go
@@ -11,6 +11,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const imageNameDanglingPrefix = "moby-dangling@"
+
 // softImageDelete deletes the image, making sure that there are other images
 // that reference the content of the deleted image.
 // If no other image exists, a dangling one is created.
@@ -74,7 +76,7 @@ func (i *ImageService) ensureDanglingImage(ctx context.Context, from containerdi
 }
 
 func danglingImageName(digest digest.Digest) string {
-	return "moby-dangling@" + digest.String()
+	return imageNameDanglingPrefix + digest.String()
 }
 
 func isDanglingImage(image containerdimages.Image) bool {


### PR DESCRIPTION
A dangling image isn't really a tag.

**- What I did**

**- How I did it**

**- How to verify it**
```diff
$ docker rmi 63be88a405ec
-Untagged: moby-dangling@sha256:63be88a405ec007463ceb1b9c5546cd88c9af839e55bb34add6a246962b078f8
Deleted: sha256:63be88a405ec007463ceb1b9c5546cd88c9af839e55bb34add6a246962b078f8
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

