### PR TITLE
Add WithTLSClientConfigVerification function to enable setting TLS verification flag without env var

### DIFF
--- a/client/options.go
+++ b/client/options.go
@@ -154,6 +154,25 @@ func WithTLSClientConfig(cacertPath, certPath, keyPath string) Opt {
 	}
 }
 
+func WithInsecureSkipVerifyTLSClientConfig(certPath, keyPath string) Opt {
+	return func(c *Client) error {
+		opts := tlsconfig.Options{
+			CertFile:           certPath,
+			KeyFile:            keyPath,
+			InsecureSkipVerify: true,
+		}
+		config, err := tlsconfig.Client(opts)
+		if err != nil {
+			return errors.Wrap(err, "failed to create tls config")
+		}
+		if transport, ok := c.client.Transport.(*http.Transport); ok {
+			transport.TLSClientConfig = config
+			return nil
+		}
+		return errors.Errorf("cannot apply tls config to transport: %T", c.client.Transport)
+	}
+}
+
 // WithTLSClientConfigFromEnv configures the client's TLS settings with the
 // settings in the DOCKER_CERT_PATH ([EnvOverrideCertPath]) and DOCKER_TLS_VERIFY
 // ([EnvTLSVerify]) environment variables. If DOCKER_CERT_PATH is not set or empty,


### PR DESCRIPTION
closes #46598

**- What I did**

I've created a function where we can set TLS verification flag without reading it from environment variables.

**- How I did it**

I've added a new function called `WithTLSClientConfigVerification` to [client/options.go](../blob/master/client/options.go) file.

**- How to verify it**

- I ran a Docker daemon with tls_verify=0
- I created a random ca.pem
- Then I called this new function, passing the random ca.pem, with both `tlsVerify` as true and `tlsVerify` as false
- I noticed I was able to connect with `tlsVerify` as true, and received a certificate error when running with `tlsVerify` as false, as expected

**- Description for the changelog**
Added `WithTLSClientConfigVerification` function to client options to enable setting TLS verification flag


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/moby/moby/assets/496350/3282a427-0b45-47bf-9b87-94fefcfbc58a)

