### PR TITLE
libnet/d/bridge: Don't set container's gateway when network is internal

### DIFF
--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
 )
 
@@ -1611,7 +1612,7 @@ func (s *DockerCLINetworkSuite) TestDockerNetworkInternalMode(c *testing.T) {
 	assert.Assert(c, waitRun("second") == nil)
 	out, _, err := dockerCmdWithError("exec", "first", "ping", "-W", "4", "-c", "1", "8.8.8.8")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "100% packet loss"))
+	assert.Assert(c, is.Contains(out, "Network is unreachable"))
 	_, _, err = dockerCmdWithError("exec", "second", "ping", "-c", "1", "first")
 	assert.NilError(c, err)
 }

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -1223,14 +1223,16 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 		return err
 	}
 
-	err = jinfo.SetGateway(network.bridge.gatewayIPv4)
-	if err != nil {
-		return err
-	}
+	if !network.config.Internal {
+		err = jinfo.SetGateway(network.bridge.gatewayIPv4)
+		if err != nil {
+			return err
+		}
 
-	err = jinfo.SetGatewayIPv6(network.bridge.gatewayIPv6)
-	if err != nil {
-		return err
+		err = jinfo.SetGatewayIPv6(network.bridge.gatewayIPv6)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -1218,19 +1218,15 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 	if network.config.ContainerIfacePrefix != "" {
 		containerVethPrefix = network.config.ContainerIfacePrefix
 	}
-	err = iNames.SetNames(endpoint.srcName, containerVethPrefix)
-	if err != nil {
+	if err := iNames.SetNames(endpoint.srcName, containerVethPrefix); err != nil {
 		return err
 	}
 
 	if !network.config.Internal {
-		err = jinfo.SetGateway(network.bridge.gatewayIPv4)
-		if err != nil {
+		if err := jinfo.SetGateway(network.bridge.gatewayIPv4); err != nil {
 			return err
 		}
-
-		err = jinfo.SetGatewayIPv6(network.bridge.gatewayIPv6)
-		if err != nil {
+		if err := jinfo.SetGatewayIPv6(network.bridge.gatewayIPv6); err != nil {
 			return err
 		}
 	}

--- a/libnetwork/sandbox_dns_unix.go
+++ b/libnetwork/sandbox_dns_unix.go
@@ -30,6 +30,9 @@ const (
 func (sb *Sandbox) startResolver(restore bool) {
 	sb.resolverOnce.Do(func() {
 		var err error
+		// The embedded resolver is always started with proxyDNS set as true, even when the sandbox is only attached to
+		// an internal network. This way, it's the driver responsibility to make sure `connect` syscall fails fast when
+		// no external connectivity is available (eg. by not setting a default gateway).
 		sb.resolver = NewResolver(resolverIPSandbox, true, sb)
 		defer func() {
 			if err != nil {


### PR DESCRIPTION
Related to:

- CI failures seen on https://github.com/moby/moby/pull/46531

**- What I did**

So far, internal networks were only isolated from the host by iptables DROP rules. As a consequence, outbound connections from containers would timeout instead of being "rejected" through an immediate ICMP dest/port unreachable, a TCP RST or a failing `connect` syscall.

This was visible when internal containers were trying to resolve a domain that don't match any container on the same network (be it a truly "external" domain, or a container that don't exist/is dead). In that case, the embedded resolver would try to forward DNS queries for the different values of resolv.conf `search` option, making DNS resolution slow to return an error, and the slowness being exacerbated by some libc implementations.

This change makes `connect` syscall to return ENETUNREACH, and thus solves the broader issue of failing fast when external connections are attempted.

**- How to verify it**

CI is green.

**- Description for the changelog**

* Make `connect` syscall fail fast when a container is only attached to an internal network.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://cdn.naturettl.com/wp-content/uploads/2014/10/08201805/john-speirs_i-guess-summers-over-800x504.jpg)