### PR TITLE
libnet: Don't forward to upstream resolvers on internal nw

### DIFF
--- a/integration/networking/bridge_test.go
+++ b/integration/networking/bridge_test.go
@@ -36,7 +36,7 @@ func TestBridgeICC(t *testing.T) {
 		name           string
 		bridgeOpts     []func(*types.NetworkCreate)
 		ctr1MacAddress string
-		linkLocal      bool
+		isLinkLocal    bool
 		pingHost       string
 	}{
 		{
@@ -74,7 +74,7 @@ func TestBridgeICC(t *testing.T) {
 				// 2. the one dynamically assigned by the IPAM driver.
 				network.WithIPAM("fe80::/64", "fe80::1"),
 			},
-			linkLocal: true,
+			isLinkLocal: true,
 		},
 		{
 			name: "IPv6 link-local address on internal network",
@@ -84,7 +84,7 @@ func TestBridgeICC(t *testing.T) {
 				// See the note above about link-local addresses.
 				network.WithIPAM("fe80::/64", "fe80::1"),
 			},
-			linkLocal: true,
+			isLinkLocal: true,
 		},
 		{
 			// As for 'LL non-internal', but ping the container by name instead of by address
@@ -162,7 +162,7 @@ func TestBridgeICC(t *testing.T) {
 
 			pingHost := tc.pingHost
 			if pingHost == "" {
-				if tc.linkLocal {
+				if tc.isLinkLocal {
 					inspect := container.Inspect(ctx, t, c, id1)
 					pingHost = inspect.NetworkSettings.Networks[bridgeName].GlobalIPv6Address + "%eth0"
 				} else {

--- a/libnetwork/resolver.go
+++ b/libnetwork/resolver.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/containerd/log"
@@ -75,7 +76,7 @@ type Resolver struct {
 	tcpListen     *net.TCPListener
 	err           error
 	listenAddress string
-	proxyDNS      bool
+	proxyDNS      atomic.Bool
 	startCh       chan struct{}
 	logger        *log.Entry
 
@@ -85,15 +86,17 @@ type Resolver struct {
 
 // NewResolver creates a new instance of the Resolver
 func NewResolver(address string, proxyDNS bool, backend DNSBackend) *Resolver {
-	return &Resolver{
+	r := &Resolver{
 		backend:       backend,
-		proxyDNS:      proxyDNS,
 		listenAddress: address,
 		err:           fmt.Errorf("setup not done yet"),
 		startCh:       make(chan struct{}, 1),
 		fwdSem:        semaphore.NewWeighted(maxConcurrent),
 		logInverval:   rate.Sometimes{Interval: logInterval},
 	}
+	r.proxyDNS.Store(proxyDNS)
+
+	return r
 }
 
 func (r *Resolver) log(ctx context.Context) *log.Entry {
@@ -191,6 +194,14 @@ func (r *Resolver) SetExtServers(extDNS []extDNSEntry) {
 	}
 	for i := 0; i < l; i++ {
 		r.extDNSList[i] = extDNS[i]
+	}
+}
+
+// SetForwardingPolicy re-configures the embedded DNS resolver to either enable or disable forwarding DNS queries to
+// external servers.
+func (r *Resolver) SetForwardingPolicy(policy bool) {
+	if r != nil {
+		r.proxyDNS.Store(policy)
 	}
 }
 
@@ -421,7 +432,7 @@ func (r *Resolver) serveDNS(w dns.ResponseWriter, query *dns.Msg) {
 		return
 	}
 
-	if r.proxyDNS {
+	if r.proxyDNS.Load() {
 		// If the user sets ndots > 0 explicitly and the query is
 		// in the root domain don't forward it out. We will return
 		// failure and let the client retry with the search domain

--- a/libnetwork/sandbox_dns_unix.go
+++ b/libnetwork/sandbox_dns_unix.go
@@ -44,10 +44,7 @@ func (sb *Sandbox) finishInitDNS() error {
 func (sb *Sandbox) startResolver(restore bool) {
 	sb.resolverOnce.Do(func() {
 		var err error
-		// The embedded resolver is always started with proxyDNS set as true, even when the sandbox is only attached to
-		// an internal network. This way, it's the driver responsibility to make sure `connect` syscall fails fast when
-		// no external connectivity is available (eg. by not setting a default gateway).
-		sb.resolver = NewResolver(resolverIPSandbox, true, sb)
+		sb.resolver = NewResolver(resolverIPSandbox, sb.getGatewayEndpoint() != nil, sb)
 		defer func() {
 			if err != nil {
 				sb.resolver = nil


### PR DESCRIPTION
- Stacked on top of #46603
- Related to CI failures seen on #46531

**- What I did**

First commit adds a way to enable/disable upstream forwarding to the embedded resolver. When an endpoint joins/leaves a sandbox, this forwarding policy is modified based on whether there's an endpoint providing external connectivity.

Second commit ensures the resolver return a REFUSED response with the RA bit (ie. Recursion Available) unset when upstream forwarding is disabled and no matching container/alias can be found.

**- Description for the changelog**

* The embedded DNS resolver now returns a REFUSED response when upstream forwarding is disabled (ie. on internal networks, or on Windows) and no container/alias match the queried name.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://ohlavache.org/wp-content/uploads/2021/11/TM-2-1024x683.jpg)