### PR TITLE
c8d/pull: Handle pull all tags (2nd approach)

### DIFF
--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -2,6 +2,7 @@ package containerd
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/containerd/containerd"
@@ -12,7 +13,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types/events"
-	"github.com/docker/docker/api/types/registry"
+	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/distribution"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/internal/compatcontext"
@@ -21,8 +22,43 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// PullImage initiates a pull operation. ref is the image to pull.
-func (i *ImageService) PullImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error {
+// PullImage initiates a pull operation. baseRef is the image to pull.
+// If reference is not tagged, all tags are pulled.
+func (i *ImageService) PullImage(ctx context.Context, baseRef reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registrytypes.AuthConfig, outStream io.Writer) error {
+	out := streamformatter.NewJSONProgressOutput(outStream, false)
+
+	if tagged, ok := baseRef.(reference.NamedTagged); ok {
+		return i.pullTag(ctx, tagged, platform, metaHeaders, authConfig, out)
+	}
+
+	tags, err := distribution.Tags(ctx, baseRef, &distribution.Config{
+		RegistryService: i.registryService,
+		MetaHeaders:     metaHeaders,
+		AuthConfig:      authConfig,
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, tag := range tags {
+		ref, err := reference.WithTag(baseRef, tag)
+		if err != nil {
+			log.G(ctx).WithFields(log.Fields{
+				"tag":     tag,
+				"baseRef": baseRef,
+			}).Warn("invalid tag, won't pull")
+			continue
+		}
+
+		if err := i.pullTag(ctx, ref, platform, metaHeaders, authConfig, out); err != nil {
+			return fmt.Errorf("error pulling %s: %w", ref, err)
+		}
+	}
+
+	return nil
+}
+
+func (i *ImageService) pullTag(ctx context.Context, ref reference.NamedTagged, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registrytypes.AuthConfig, out progress.Output) error {
 	var opts []containerd.RemoteOpt
 	if platform != nil {
 		opts = append(opts, containerd.WithPlatform(platforms.Format(*platform)))
@@ -49,7 +85,6 @@ func (i *ImageService) PullImage(ctx context.Context, ref reference.Named, platf
 	})
 	opts = append(opts, containerd.WithImageHandler(h))
 
-	out := streamformatter.NewJSONProgressOutput(outStream, false)
 	pp := pullProgress{store: i.client.ContentStore(), showExists: true}
 	finishProgress := jobs.showProgress(ctx, out, pp)
 

--- a/daemon/containerd/resolver.go
+++ b/daemon/containerd/resolver.go
@@ -31,7 +31,7 @@ func (i *ImageService) newResolverFromAuthConfig(ctx context.Context, authConfig
 	}), tracker
 }
 
-func hostsWrapper(hostsFn docker.RegistryHosts, optAuthConfig *registrytypes.AuthConfig, regService RegistryConfigProvider) docker.RegistryHosts {
+func hostsWrapper(hostsFn docker.RegistryHosts, optAuthConfig *registrytypes.AuthConfig, regService registryResolver) docker.RegistryHosts {
 	var authorizer docker.Authorizer
 	if optAuthConfig != nil {
 		authorizer = authorizerFromAuthConfig(*optAuthConfig)

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -30,16 +30,18 @@ type ImageService struct {
 	containers      container.Store
 	snapshotter     string
 	registryHosts   docker.RegistryHosts
-	registryService RegistryConfigProvider
+	registryService registryResolver
 	eventsService   *daemonevents.Events
 	pruneRunning    atomic.Bool
 	refCountMounter snapshotter.Mounter
 	idMapping       idtools.IdentityMapping
 }
 
-type RegistryConfigProvider interface {
+type registryResolver interface {
 	IsInsecureRegistry(host string) bool
 	ResolveRepository(name reference.Named) (*registry.RepositoryInfo, error)
+	LookupPullEndpoints(hostname string) ([]registry.APIEndpoint, error)
+	LookupPushEndpoints(hostname string) ([]registry.APIEndpoint, error)
 }
 
 type ImageServiceConfig struct {
@@ -47,7 +49,7 @@ type ImageServiceConfig struct {
 	Containers      container.Store
 	Snapshotter     string
 	RegistryHosts   docker.RegistryHosts
-	Registry        RegistryConfigProvider
+	Registry        registryResolver
 	EventsService   *daemonevents.Events
 	RefCountMounter snapshotter.Mounter
 	IDMapping       idtools.IdentityMapping

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types/events"
 	refstore "github.com/docker/docker/reference"
+	"github.com/docker/docker/registry"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
@@ -16,73 +17,33 @@ import (
 // Pull initiates a pull operation. image is the repository name to pull, and
 // tag may be either empty, or indicate a specific tag to pull.
 func Pull(ctx context.Context, ref reference.Named, config *ImagePullConfig, local ContentStore) error {
-	// Resolve the Repository name from fqn to RepositoryInfo
-	repoInfo, err := config.RegistryService.ResolveRepository(ref)
-	if err != nil {
-		return err
-	}
-
-	// makes sure name is not `scratch`
-	if err := validateRepoName(repoInfo.Name); err != nil {
-		return err
-	}
-
-	endpoints, err := config.RegistryService.LookupPullEndpoints(reference.Domain(repoInfo.Name))
-	if err != nil {
-		return err
-	}
-
-	var (
-		lastErr error
-
-		// confirmedTLSRegistries is a map indicating which registries
-		// are known to be using TLS. There should never be a plaintext
-		// retry for any of these.
-		confirmedTLSRegistries = make(map[string]struct{})
-	)
-	for _, endpoint := range endpoints {
-		if endpoint.URL.Scheme != "https" {
-			if _, confirmedTLS := confirmedTLSRegistries[endpoint.URL.Host]; confirmedTLS {
-				log.G(ctx).Debugf("Skipping non-TLS endpoint %s for host/port that appears to use TLS", endpoint.URL)
-				continue
-			}
-		}
-
+	repoInfo, err := pullEndpoints(ctx, config.RegistryService, ref, func(ctx context.Context, repoInfo registry.RepositoryInfo, endpoint registry.APIEndpoint) error {
 		log.G(ctx).Debugf("Trying to pull %s from %s", reference.FamiliarName(repoInfo.Name), endpoint.URL)
+		puller := newPuller(endpoint, &repoInfo, config, local)
+		return puller.pull(ctx, ref)
+	})
 
-		if err := newPuller(endpoint, repoInfo, config, local).pull(ctx, ref); err != nil {
-			// Was this pull cancelled? If so, don't try to fall
-			// back.
-			fallback := false
-			select {
-			case <-ctx.Done():
-			default:
-				if fallbackErr, ok := err.(fallbackError); ok {
-					fallback = true
-					if fallbackErr.transportOK && endpoint.URL.Scheme == "https" {
-						confirmedTLSRegistries[endpoint.URL.Host] = struct{}{}
-					}
-					err = fallbackErr.err
-				}
-			}
-			if fallback {
-				lastErr = err
-				log.G(ctx).Infof("Attempting next endpoint for pull after error: %v", err)
-				continue
-			}
-			log.G(ctx).Errorf("Not continuing with pull after error: %v", err)
-			return translatePullError(err, ref)
+	if err == nil {
+		config.ImageEventLogger(reference.FamiliarString(ref), reference.FamiliarName(repoInfo.Name), events.ActionPull)
+	}
+
+	return err
+}
+
+// Tags returns available tags for the given image in the remote repository.
+func Tags(ctx context.Context, ref reference.Named, config *Config) ([]string, error) {
+	var tags []string
+	_, err := pullEndpoints(ctx, config.RegistryService, ref, func(ctx context.Context, repoInfo registry.RepositoryInfo, endpoint registry.APIEndpoint) error {
+		repo, err := newRepository(ctx, &repoInfo, endpoint, config.MetaHeaders, config.AuthConfig, "pull")
+		if err != nil {
+			return err
 		}
 
-		config.ImageEventLogger(reference.FamiliarString(ref), reference.FamiliarName(repoInfo.Name), events.ActionPull)
-		return nil
-	}
+		tags, err = repo.Tags(ctx).All(ctx)
+		return err
+	})
 
-	if lastErr == nil {
-		lastErr = fmt.Errorf("no endpoints found for %s", reference.FamiliarString(ref))
-	}
-
-	return translatePullError(lastErr, ref)
+	return tags, err
 }
 
 // validateRepoName validates the name of a repository.
@@ -110,4 +71,82 @@ func addDigestReference(store refstore.Store, ref reference.Named, dgst digest.D
 	}
 
 	return store.AddDigest(dgstRef, id, true)
+}
+
+func pullEndpoints(ctx context.Context, registryService RegistryResolver, ref reference.Named,
+	f func(context.Context, registry.RepositoryInfo, registry.APIEndpoint) error,
+) (*registry.RepositoryInfo, error) {
+	// Resolve the Repository name from fqn to RepositoryInfo
+	repoInfo, err := registryService.ResolveRepository(ref)
+	if err != nil {
+		return nil, err
+	}
+
+	// makes sure name is not `scratch`
+	if err := validateRepoName(repoInfo.Name); err != nil {
+		return repoInfo, err
+	}
+
+	endpoints, err := registryService.LookupPullEndpoints(reference.Domain(repoInfo.Name))
+	if err != nil {
+		return repoInfo, err
+	}
+
+	var (
+		lastErr error
+
+		// confirmedTLSRegistries is a map indicating which registries
+		// are known to be using TLS. There should never be a plaintext
+		// retry for any of these.
+		confirmedTLSRegistries = make(map[string]struct{})
+	)
+	for _, endpoint := range endpoints {
+		if endpoint.URL.Scheme != "https" {
+			if _, confirmedTLS := confirmedTLSRegistries[endpoint.URL.Host]; confirmedTLS {
+				log.G(ctx).Debugf("Skipping non-TLS endpoint %s for host/port that appears to use TLS", endpoint.URL)
+				continue
+			}
+		}
+
+		log.G(ctx).Debugf("Trying to pull %s from %s", reference.FamiliarName(repoInfo.Name), endpoint.URL)
+
+		if err := f(ctx, *repoInfo, endpoint); err != nil {
+			if _, ok := err.(fallbackError); !ok && continueOnError(err, endpoint.Mirror) {
+				err = fallbackError{
+					err:         err,
+					transportOK: true,
+				}
+			}
+
+			// Was this pull cancelled? If so, don't try to fall
+			// back.
+			fallback := false
+			select {
+			case <-ctx.Done():
+			default:
+				if fallbackErr, ok := err.(fallbackError); ok {
+					fallback = true
+					if fallbackErr.transportOK && endpoint.URL.Scheme == "https" {
+						confirmedTLSRegistries[endpoint.URL.Host] = struct{}{}
+					}
+					err = fallbackErr.err
+				}
+			}
+			if fallback {
+				lastErr = err
+				log.G(ctx).Infof("Attempting next endpoint for pull after error: %v", err)
+				continue
+			}
+			log.G(ctx).Errorf("Not continuing with pull after error: %v", err)
+			return repoInfo, translatePullError(err, ref)
+		}
+
+		return repoInfo, nil
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no endpoints found for %s", reference.FamiliarString(ref))
+	}
+
+	return repoInfo, translatePullError(lastErr, ref)
 }

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -86,18 +86,7 @@ func (p *puller) pull(ctx context.Context, ref reference.Named) (err error) {
 		return err
 	}
 
-	if err = p.pullRepository(ctx, ref); err != nil {
-		if _, ok := err.(fallbackError); ok {
-			return err
-		}
-		if continueOnError(err, p.endpoint.Mirror) {
-			return fallbackError{
-				err:         err,
-				transportOK: true,
-			}
-		}
-	}
-	return err
+	return p.pullRepository(ctx, ref)
 }
 
 func (p *puller) pullRepository(ctx context.Context, ref reference.Named) (err error) {


### PR DESCRIPTION
- alternative to: https://github.com/moby/moby/pull/46516
- closes https://github.com/moby/moby/pull/46516

**distribution: Add Tags**

Add a function to return tags for the given repository reference. This
is needed to implement the `pull -a` (pull all tags) for containerd
which doesn't directly use distribution, but we need to somehow make an
API call to the registry to obtain the available tags.

**c8d/pull: Handle pull all tags**

Use the distribution code to query the remote repository for tags and
pull them sequentially just like the non-c8d pull.


**- How to verify it**
```diff
$ docker pull -a docker/doodle
-Error response from daemon: failed to resolve reference "docker.io/docker/doodle": object required
+birthday: Pulling from docker/doodle
+ecaf003f35ec: Download complete
+Digest: sha256:4a203cbea73f32a4885f8d9ee05233246445aa95dd4362887058ec663a7b8088
+Status: Downloaded newer image for docker/doodle:birthday
+birthday2019: Pulling from docker/doodle
+Digest: sha256:4a203cbea73f32a4885f8d9ee05233246445aa95dd4362887058ec663a7b8088
+Status: Downloaded newer image for docker/doodle:birthday2019
(...)
+summer: Pulling from docker/doodle
+6fe738df11e6: Download complete
+Digest: sha256:f7fdfd4a030d16a619f32f183307c9f60ddd9206dc92b1c3b1e1c2f1450567fc
+Status: Downloaded newer image for docker/doodle:summer
+summer2019: Pulling from docker/doodle
+Digest: sha256:f7fdfd4a030d16a619f32f183307c9f60ddd9206dc92b1c3b1e1c2f1450567fc
+Status: Downloaded newer image for docker/doodle:summer2019
+docker.io/docker/doodle


```

**- Description for the changelog**
```release-note
- containerd image store: Implement pulling all tags (`docker pull -a`)
```

**- A picture of a cute animal (not mandatory but encouraged)**

