### PR TITLE
integration/c8d: Skip TestBuildSquashParent

### DIFF
--- a/integration/build/build_squash_test.go
+++ b/integration/build/build_squash_test.go
@@ -20,6 +20,7 @@ import (
 
 func TestBuildSquashParent(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+	skip.If(t, testEnv.UsingSnapshotter(), "squash is not implemented for containerd image store")
 
 	ctx := testutil.StartSpan(baseContext, t)
 


### PR DESCRIPTION
`docker build --squash` is an experimental feature which is not implemented for containerd image store.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

