### PR TITLE
#46621 ensure that errors reading the response body are returned to the caller

### DIFF
--- a/client/container_wait.go
+++ b/client/container_wait.go
@@ -72,8 +72,12 @@ func (cli *Client) ContainerWait(ctx context.Context, containerID string, condit
 			//
 			// If there's a JSON parsing error, read the real error message
 			// off the body and send it to the client.
-			_, _ = io.ReadAll(io.LimitReader(stream, containerWaitErrorMsgLimit))
-			errC <- errors.New(responseText.String())
+			if errors.As(err, new(*json.SyntaxError)) {
+				_, _ = io.ReadAll(io.LimitReader(stream, containerWaitErrorMsgLimit))
+				errC <- errors.New(responseText.String())
+			} else {
+				errC <- err
+			}
 			return
 		}
 


### PR DESCRIPTION
Fixes #46621 by returning a `context.Canceled` error to the caller.

**- What I did**

I added a check id `err` is a `context.Canceled` error. If so, we return the `err` directly to the caller through `errC`. In all other cases the error is generated from the API response just as before the change.

**- How I did it**

It's as easy as checking the type of `err`. If it's a `context.Canceled` we skip creating an error from the (then empty) API response.

**- How to verify it**

Call `client.ContainerWait()` with a cancelable context and while waiting for the method to end, cancel the given context. before the change an error with an empty (`""`) error message has been returned on `errC`. After the change a `context.Canceled` error will be returned on the `errC`.

**- Description for the changelog**

`client.ContainerWait()` now returns a `context.Canceled` error on the error channel when the operation is canceled via its context.


