### PR TITLE
libnet: Revert "Only check if route overlaps routes with scope: LINK"

### DIFF
--- a/libnetwork/netutils/utils_linux.go
+++ b/libnetwork/netutils/utils_linux.go
@@ -28,7 +28,7 @@ func CheckRouteOverlaps(toCheck *net.IPNet) error {
 		return err
 	}
 	for _, network := range networks {
-		if network.Dst != nil && network.Scope == netlink.SCOPE_LINK && NetworkOverlaps(toCheck, network.Dst) {
+		if network.Dst != nil && NetworkOverlaps(toCheck, network.Dst) {
 			return ErrNetworkOverlaps
 		}
 	}

--- a/libnetwork/netutils/utils_linux_test.go
+++ b/libnetwork/netutils/utils_linux_test.go
@@ -49,11 +49,8 @@ func TestCheckRouteOverlaps(t *testing.T) {
 		routes := []netlink.Route{}
 		for _, addr := range routesData {
 			_, netX, _ := net.ParseCIDR(addr)
-			routes = append(routes, netlink.Route{Dst: netX, Scope: netlink.SCOPE_LINK})
+			routes = append(routes, netlink.Route{Dst: netX})
 		}
-		// Add a route with a scope which should not overlap
-		_, netX, _ := net.ParseCIDR("10.0.5.0/24")
-		routes = append(routes, netlink.Route{Dst: netX, Scope: netlink.SCOPE_UNIVERSE})
 		return routes, nil
 	}
 	defer func() { networkGetRoutesFct = nil }()
@@ -66,11 +63,6 @@ func TestCheckRouteOverlaps(t *testing.T) {
 	_, netX, _ = net.ParseCIDR("10.0.2.0/24")
 	if err := CheckRouteOverlaps(netX); err == nil {
 		t.Fatal("10.0.2.0/24 and 10.0.2.0 should overlap but it doesn't")
-	}
-
-	_, netX, _ = net.ParseCIDR("10.0.5.0/24")
-	if err := CheckRouteOverlaps(netX); err != nil {
-		t.Fatal("10.0.5.0/24 and 10.0.5.0 with scope UNIVERSE should not overlap but it does")
 	}
 }
 


### PR DESCRIPTION
**- What I did**

- Resolve moby/moby#46615.
- Revert commit ee9e52676409b2e428a816ac59f42f5ba61089dd from https://github.com/moby/moby/pull/42598
- reopens https://github.com/moby/moby/issues/41525
- reopens https://github.com/moby/moby/issues/33925

Route scope is used by the kernel to choose what source IP address should be used when establishing an outbound connection. As such, filtering routes based on their scope doesn't make sense. It happened to work for the original contributor only by chance.

I didn't take much time to look into all the issues related to `CheckRouteOverlaps` but it'd be probably better to add an option to skip this check if the user wants it.

**- How to verify it**

See the reproducer in https://github.com/moby/moby/issues/46615

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://i.natgeofe.com/n/70f8fe9c-d289-4965-9e07-3c430fefba08/02_animal_day_gallery_prairie_dog_2x3.jpg)
