### PR TITLE
Return no basic auth creds error when needed

### DIFF
--- a/daemon/containerd/resolver.go
+++ b/daemon/containerd/resolver.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/containerd/version"
 	"github.com/containerd/log"
+	"github.com/docker/distribution/registry/client/auth"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/pkg/useragent"
@@ -75,10 +76,14 @@ func authorizerFromAuthConfig(authConfig registrytypes.AuthConfig) docker.Author
 				"host":    host,
 				"cfgHost": cfgHost,
 			}).Warn("Host doesn't match")
-			return "", "", nil
+			return "", "", auth.ErrNoBasicAuthCredentials
 		}
 		if authConfig.IdentityToken != "" {
 			return "", authConfig.IdentityToken, nil
+		}
+
+		if authConfig.Username == "" && authConfig.Password == "" {
+			return "", "", auth.ErrNoBasicAuthCredentials
 		}
 		return authConfig.Username, authConfig.Password, nil
 	}))


### PR DESCRIPTION
**- What I did**

Changed the autorizer configuration to return `ErrNoBasicAuthCredentials` error when needed.
If the auth config contains an empty username/password we should return an error

**- How I did it**

**- How to verify it**

`TestLogoutWithExternalAuth` should pass now

```
$ make DOCKER_GRAPHDRIVER=overlayfs TEST_FILTER=TestLogoutWithExternalAuth TEST_INTEGRATION_USE_SNAPSHOTTER=1 TEST_IGNORE_CGROUP_CHECK=1 test-integration
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

