### PR TITLE
c8d/changes: Fix concurrents diffs

### DIFF
--- a/daemon/containerd/image_changes.go
+++ b/daemon/containerd/image_changes.go
@@ -7,6 +7,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/stringid"
 )
 
 func (i *ImageService) Changes(ctx context.Context, container *container.Container) ([]archive.Change, error) {
@@ -16,10 +17,12 @@ func (i *ImageService) Changes(ctx context.Context, container *container.Contain
 		return nil, err
 	}
 
-	imageMounts, _ := snapshotter.View(ctx, container.ID+"-parent-view", info.Parent)
+	id := stringid.GenerateRandomID()
+	parentViewKey := container.ID + "-parent-view-" + id
+	imageMounts, _ := snapshotter.View(ctx, parentViewKey, info.Parent)
 
 	defer func() {
-		if err := snapshotter.Remove(ctx, container.ID+"-parent-view"); err != nil {
+		if err := snapshotter.Remove(ctx, parentViewKey); err != nil {
 			log.G(ctx).WithError(err).Warn("error removing the parent view snapshot")
 		}
 	}()


### PR DESCRIPTION
Use a unique parent view snapshot key for each diff request.

I considered using singleflight at first, but I realized it wouldn't really be correct.
The diff can take some time, so there's a window of time between the diff start and finish, where the file system can change. These changes not always will be reflected in the running diff.

With singleflight, the second diff request which happened before the previous diff was finished, would not include changes made to the container filesystem after the first diff request has started.


**- What I did**

**- How I did it**

**- How to verify it**
```diff
$ docker run --name asdf -d alpine touch /1
$ docker diff asdf & docker diff asdf
-[1] 5931
-A /usr
-A /usr/share
-A /usr/share/misc
-A /usr/share/udhcpc
-A /usr/share/udhcpc/default.script
-A /usr/share/apk
-A /usr/share/apk/keys
-A /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616db30d.rsa.pub
-A /usr/share/apk/keys/aarch64
-(...) # A LOT OF FILES THERE
-A /lib/firmware
-A /lib/libapk.so.2.14.0
-A /lib/libssl.so.3
-A /lib/libz.so.1.2.13
-A /lib/modules-load.d
-A /media
-A /media/cdrom
-A /media/floppy
-A /media/usb
-A /mnt
-A /1
-[1]+  Done                    docker diff asdf
+[2] 5181
+A /1
+A /1
+[1]   Done                    docker diff asdf
+[2]+  Done                    docker diff asdf
```


**- Description for the changelog**
```release-note
containerd image store: Fix `docker diff` not working correctly when called multiple times concurrently for the same container
```

**- A picture of a cute animal (not mandatory but encouraged)**

