### PR TITLE
Revert "Return no basic auth creds error when needed"

### DIFF
--- a/daemon/containerd/resolver.go
+++ b/daemon/containerd/resolver.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/containerd/version"
 	"github.com/containerd/log"
-	"github.com/docker/distribution/registry/client/auth"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/pkg/useragent"
@@ -76,14 +75,10 @@ func authorizerFromAuthConfig(authConfig registrytypes.AuthConfig) docker.Author
 				"host":    host,
 				"cfgHost": cfgHost,
 			}).Warn("Host doesn't match")
-			return "", "", auth.ErrNoBasicAuthCredentials
+			return "", "", nil
 		}
 		if authConfig.IdentityToken != "" {
 			return "", authConfig.IdentityToken, nil
-		}
-
-		if authConfig.Username == "" && authConfig.Password == "" {
-			return "", "", auth.ErrNoBasicAuthCredentials
 		}
 		return authConfig.Username, authConfig.Password, nil
 	}))


### PR DESCRIPTION
This reverts commit 87775923971f93828610335b272129b33571541e (https://github.com/moby/moby/pull/46631), which turns out to break other test cases/the registry flow.

The correct place to handle missing credentials is instead https://github.com/containerd/containerd/blob/15bf23df09f974fe4813dd65eb550763f621fc0b/remotes/docker/authorizer.go#L200.