### PR TITLE
HealthCheck: add validation for minimum accepted start-interval (1ms)

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -333,6 +333,9 @@ func validateHealthCheck(healthConfig *containertypes.HealthConfig) error {
 	if healthConfig.StartPeriod != 0 && healthConfig.StartPeriod < containertypes.MinimumDuration {
 		return errors.Errorf("StartPeriod in Healthcheck cannot be less than %s", containertypes.MinimumDuration)
 	}
+	if healthConfig.StartInterval != 0 && healthConfig.StartInterval < containertypes.MinimumDuration {
+		return errors.Errorf("StartInterval in Healthcheck cannot be less than %s", containertypes.MinimumDuration)
+	}
 	return nil
 }
 

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -343,12 +343,13 @@ func TestCreateWithInvalidHealthcheckParams(t *testing.T) {
 	apiClient := testEnv.APIClient()
 
 	testCases := []struct {
-		doc         string
-		interval    time.Duration
-		timeout     time.Duration
-		retries     int
-		startPeriod time.Duration
-		expectedErr string
+		doc           string
+		interval      time.Duration
+		timeout       time.Duration
+		retries       int
+		startPeriod   time.Duration
+		startInterval time.Duration
+		expectedErr   string
 	}{
 		{
 			doc:         "test invalid Interval in Healthcheck: less than 0s",
@@ -386,6 +387,15 @@ func TestCreateWithInvalidHealthcheckParams(t *testing.T) {
 			startPeriod: 100 * time.Microsecond,
 			expectedErr: fmt.Sprintf("StartPeriod in Healthcheck cannot be less than %s", container.MinimumDuration),
 		},
+		{
+			doc:           "test invalid StartInterval in Healthcheck: not 0 and less than 1ms",
+			interval:      time.Second,
+			timeout:       time.Second,
+			retries:       1000,
+			startPeriod:   time.Second,
+			startInterval: 100 * time.Microsecond,
+			expectedErr:   fmt.Sprintf("StartInterval in Healthcheck cannot be less than %s", container.MinimumDuration),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -396,9 +406,10 @@ func TestCreateWithInvalidHealthcheckParams(t *testing.T) {
 			cfg := container.Config{
 				Image: "busybox",
 				Healthcheck: &container.HealthConfig{
-					Interval: tc.interval,
-					Timeout:  tc.timeout,
-					Retries:  tc.retries,
+					Interval:      tc.interval,
+					Timeout:       tc.timeout,
+					Retries:       tc.retries,
+					StartInterval: tc.startInterval,
 				},
 			}
 			if tc.startPeriod != 0 {


### PR DESCRIPTION
- follow-up to / relates to https://github.com/moby/moby/pull/40894

This is a follow-up to 2216d3ca8d65c5b0c85e297a3eb351a05db3a4d2 (https://github.com/moby/moby/pull/40894), which implemented the StartInterval for health-checks, but did not add validation for the minimum accepted interval;

> The time to wait between checks in nanoseconds during the start period.
> It should be 0 or at least 1000000 (1 ms). 0 means inherit.

This patch adds validation for the minimum accepted interval (1ms).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

