### PR TITLE
docker info: expose runtime features ("rro" mount mode, etc.), in machine-parsable format

### DIFF
--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -91,6 +91,12 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 				info.OperatingSystem = "<unknown>"
 			}
 		}
+		if versions.LessThan(version, "1.44") {
+			for k, rt := range info.Runtimes {
+				// Status field introduced inl API v1.44.
+				info.Runtimes[k] = system.RuntimeWithStatus{Runtime: rt.Runtime}
+			}
+		}
 		if versions.GreaterThanOrEqualTo(version, "1.42") {
 			info.KernelMemory = false
 		}

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5618,6 +5618,28 @@ definitions:
         items:
           type: "string"
         example: ["--debug", "--systemd-cgroup=false"]
+      status:
+        description: |
+          Information specific to the runtime.
+
+          While this API specification does not define data provided by runtimes,
+          the following well-known properties may be provided by runtimes:
+
+          `org.opencontainers.runtime-spec.features`: features structure as defined
+          in the [OCI Runtime Specification](https://github.com/opencontainers/runtime-spec/blob/main/features.md),
+          in a JSON string representation.
+
+          <p><br /></p>
+
+          > **Note**: The information returned in this field, including the
+          > formatting of values and labels, should not be considered stable,
+          > and may change without notice.
+        type: "object"
+        x-nullable: true
+        additionalProperties:
+          type: "string"
+        example:
+          "org.opencontainers.runtime-spec.features": "{\"ociVersionMin\":\"1.0.0\",\"ociVersionMax\":\"1.1.0\",\"...\":\"...\"}"
 
   Commit:
     description: |

--- a/api/types/system/info.go
+++ b/api/types/system/info.go
@@ -58,7 +58,7 @@ type Info struct {
 	Labels             []string
 	ExperimentalBuild  bool
 	ServerVersion      string
-	Runtimes           map[string]Runtime
+	Runtimes           map[string]RuntimeWithStatus
 	DefaultRuntime     string
 	Swarm              swarm.Info
 	// LiveRestoreEnabled determines whether containers should be kept

--- a/api/types/system/runtime.go
+++ b/api/types/system/runtime.go
@@ -12,3 +12,9 @@ type Runtime struct {
 	Type    string                 `json:"runtimeType,omitempty"`
 	Options map[string]interface{} `json:"options,omitempty"`
 }
+
+// RuntimeWithStatus extends [Runtime] to hold [RuntimeStatus].
+type RuntimeWithStatus struct {
+	Runtime
+	Status map[string]string `json:"status,omitempty"`
+}

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -67,6 +67,7 @@ keywords: "API, Docker, rcli, REST, documentation"
   requests is now deprecated. You should instead use the field `TaskTemplate.Networks`.
 * The `Container` and `ContainerConfig` fields in the `GET /images/{name}/json`
   response are deprecated and will no longer be included in API v1.45.
+* `GET /info` now includes `status` properties in `Runtimes`.
 
 ## v1.43 API changes
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix #46580

**- How I did it**

Added the following fields:

```diff
diff --git a/api/types/system/info.go b/api/types/system/info.go
index 09dbbd0926..89d4a0098e 100644
--- a/api/types/system/info.go
+++ b/api/types/system/info.go
@@ -58,7 +58,7 @@ type Info struct {
        Labels             []string
        ExperimentalBuild  bool
        ServerVersion      string
-       Runtimes           map[string]Runtime
+       Runtimes           map[string]RuntimeWithStatus
        DefaultRuntime     string
        Swarm              swarm.Info
        // LiveRestoreEnabled determines whether containers should be kept
diff --git a/api/types/system/runtime.go b/api/types/system/runtime.go
index 83433acf92..d077295a0d 100644
--- a/api/types/system/runtime.go
+++ b/api/types/system/runtime.go
@@ -12,3 +12,9 @@ type Runtime struct {
        Type    string                 `json:"runtimeType,omitempty"`
        Options map[string]interface{} `json:"options,omitempty"`
 }
+
+// RuntimeWithStatus extends [Runtime] to hold [RuntimeStatus].
+type RuntimeWithStatus struct {
+       Runtime
+       Status map[string]string `json:"status,omitempty"`
+}
```

**- How to verify it**

```console
$ curl -s --unix-socket /var/run/docker.sock http://docker/v1.44/info | jq .Runtimes
{
  "crun": {
    "path": "/usr/local/bin/crun",
    "status": {
      "org.opencontainers.runtime-spec.features": "{\"ociVersionMin\":\"1.0.0\",...}"
    }
  },
  "io.containerd.runc.v2": {
    "path": "runc",
    "status": {
      "org.opencontainers.runtime-spec.features": "{\"ociVersionMin\":\"1.0.0\",...}"
    }
  },
  "runc": {
    "path": "runc",
    "status": {
      "org.opencontainers.runtime-spec.features": "{\"ociVersionMin\":\"1.0.0\",...}"
    }
  },
  "runsc": {
    "path": "/usr/local/bin/runsc"
  }
}
```

(`docker info --format json` cannot be used until vendoring this PR into the CLI repo)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
docker info: expose runtime features ("rro" mount mode, etc.)

**- A picture of a cute animal (not mandatory but encouraged)**

🐧 