### PR TITLE
c8d/push: Set distribution source recursively

### DIFF
--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -182,7 +182,8 @@ func appendDistributionSourceLabel(ctx context.Context, realStore content.Store,
 		return
 	}
 
-	if err := containerdimages.Dispatch(ctx, appendSource, nil, target); err != nil {
+	handler := presentChildrenHandler(realStore, appendSource)
+	if err := containerdimages.Dispatch(ctx, handler, nil, target); err != nil {
 		// Shouldn't happen, but even if it would fail, then make it only a warning
 		// because it doesn't affect the pushed data.
 		log.G(ctx).WithError(err).Warn("failed to append distribution source labels to pushed content")


### PR DESCRIPTION
After a successful push, all pushed blobs should have a distribution.source label pointing to the new registry.

Before this commit, the label was only appended to the top-level blob (manifest or manifest list). Adjust this to also do that recursively to its children.


**- How to verify it**
```diff
$ make TEST_FILTER='TestCrossRepositoryLayerPush'  TEST_IGNORE_CGROUP_CHECK=1   DOCKER_GRAPHDRIVER=overlayfs TEST_INTEGRATION_USE_SNAPSHOTTER=1   test-integration
-=== FAIL: arm64.integration-cli TestDockerRegistrySuite/TestCrossRepositoryLayerPush (0.31s)
-    docker_cli_push_test.go:193: assertion failed: expression is false: strings.Contains(out2, "Mounted from dockercli/busybox")
-    check_test.go:476: [d0718e9a70ac8] daemon is not started
-    --- FAIL: TestDockerRegistrySuite/TestCrossRepositoryLayerPush (0.31s)
-
-=== FAIL: arm64.integration-cli TestDockerRegistrySuite (0.31s)
+=== RUN   TestDockerRegistrySuite/TestCrossRepositoryLayerPush
+    check_test.go:476: [d5f85572549ed] daemon is not started
+--- PASS: TestDockerRegistrySuite (0.79s)
+    --- PASS: TestDockerRegistrySuite/TestCrossRepositoryLayerPush (0.79s)
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

