### PR TITLE
daemon/info: add BuildKit version

### DIFF
--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/docker/pkg/rootless"
 	"github.com/docker/docker/pkg/sysinfo"
 	"github.com/pkg/errors"
+	bkversion "github.com/moby/buildkit/version"
 	rkclient "github.com/rootless-containers/rootlesskit/pkg/api/client"
 )
 
@@ -213,6 +214,15 @@ func (daemon *Daemon) fillPlatformVersion(v *types.Version, cfg *configStore) {
 	} else {
 		log.G(context.TODO()).Warnf("failed to retrieve %s version: %s", initBinary, err)
 	}
+
+	bkVersion := strings.Split(bkversion.Version, "+")
+	v.Components = append(v.Components, types.ComponentVersion{
+		Name:    "BuildKit",
+		Version: bkVersion[0],
+		Details: map[string]string{
+			"GitCommit": bkVersion[1],
+		},
+	})
 
 	daemon.fillRootlessVersion(v)
 }


### PR DESCRIPTION
This is a very simple first implementation; it relies on the way that `bkversion.Version` is overwritten in an initializer, and it doesn't expose the built-in Dockerfile frontend version/revision as that information is not currently available to BuildKit.

That being said, this is still a useful debug tool as-is given the increasing importance of the integrated BuildKit version for many users.

```
Server:
 Engine:
  Version:          dev
  API version:      1.44 (minimum version 1.12)
  Go version:       go1.21.3
  Git commit:       HEAD
  Built:            Tue Oct 17 02:21:39 2023
  OS/Arch:          linux/arm64
  Experimental:     false
 containerd:
  Version:          v1.7.6
  GitCommit:        091922f03c2762540fd057fba91260237ff86acb
 runc:
  Version:          1.1.9
  GitCommit:        v1.1.9-0-gccaecfc
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
 BuildKit:
  Version:          v0.12.2
  GitCommit:        6560bb937e8c
```