### PR TITLE
ci: Setup otel tracing for windows integration tests

### DIFF
--- a/.github/actions/setup-tracing/action.yml
+++ b/.github/actions/setup-tracing/action.yml
@@ -6,6 +6,8 @@ runs:
   steps:
     - run: |
         set -e
+        # Jaeger is set up on Windows through an inline run step. If you update Jaeger here, don't forget to update
+        # the version set in .github/workflows/.windows.yml.
         docker run -d --net=host --name jaeger -e COLLECTOR_OTLP_ENABLED=true jaegertracing/all-in-one:1.46
         docker0_ip="$(ip -f inet addr show docker0 | grep -Po 'inet \K[\d.]+')"
         echo "OTEL_EXPORTER_OTLP_ENDPOINT=http://${docker0_ip}:4318" >> "${GITHUB_ENV}"

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -272,6 +272,15 @@ jobs:
         with:
           path: ${{ env.GOPATH }}/src/github.com/docker/docker
       -
+        run: |
+          # Jaeger is set up on Linux through the setup-tracing action. If you update Jaeger here, don't forget to
+          # update the version set in .github/actions/setup-tracing/action.yml.
+          Invoke-WebRequest -Uri "https://github.com/jaegertracing/jaeger/releases/download/v1.46.0/jaeger-1.46.0-windows-amd64.tar.gz" -OutFile ".\jaeger-1.46.0-windows-amd64.tar.gz"
+          tar -zxvf ".\jaeger-1.46.0-windows-amd64.tar.gz"
+          Start-Process '.\jaeger-1.46.0-windows-amd64\jaeger-all-in-one.exe'
+          echo "OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+        shell: pwsh
+      -
         name: Env
         run: |
           Get-ChildItem Env: | Out-String
@@ -464,6 +473,13 @@ jobs:
               Sort-Object @{Expression="TimeCreated";Descending=$false} |
               ForEach-Object {"$($_.TimeCreated.ToUniversalTime().ToString("o")) [$($_.LevelDisplayName)] $($_.Message)"} |
               Tee-Object -file ".\bundles\daemon.log"
+      -
+        name: Download Jaeger traces
+        if: always()
+        run: |
+          Invoke-WebRequest `
+            -Uri "http://127.0.0.1:16686/api/traces?service=integration-test-client" `
+            -OutFile ".\bundles\jaeger-trace.json"
       -
         name: Upload reports
         if: always()


### PR DESCRIPTION
Related to:

- https://github.com/moby/moby/pull/45652

**- What I did**

* Set up Jaeger before running integration tests on Windows builds
* Download traces and put them in build artifacts

Note that for both Linux and Windows builds, the trace file can't be fully imported in Jaeger due to its size. In addition, big trace files also tend to create many many DOM nodes, leading to unresponsive browser tab. One have to tweak the CI config on a given PR to limit how much integration tests are run to get a usable trace file.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://www.thesprucepets.com/thmb/bKgaPD0oT0AjK6-QdbbxpnX-3xM=/1280x0/filters:no_upscale():strip_icc()/step_6-clownfish-596f711ac4124400102014c2.jpg)