### PR TITLE
libnetwork: fan out firewall reload top-down

### DIFF
--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -167,7 +167,7 @@ func New(cfgOptions ...config.Option) (*Controller, error) {
 		return nil, err
 	}
 
-	c.setupArrangeUserFilterRule()
+	c.setupFirewallReloadHandler()
 	return c, nil
 }
 

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -167,7 +167,7 @@ func New(cfgOptions ...config.Option) (*Controller, error) {
 		return nil, err
 	}
 
-	setupArrangeUserFilterRule(c)
+	c.setupArrangeUserFilterRule()
 	return c, nil
 }
 

--- a/libnetwork/driverapi/driverapi.go
+++ b/libnetwork/driverapi/driverapi.go
@@ -82,6 +82,15 @@ type Driver interface {
 	IsBuiltIn() bool
 }
 
+// FirewallReplayer needs to be implemented by drivers which depend on ephemeral
+// system firewall configuration to function.
+type FirewallReplayer interface {
+	// ReplayFirewallConfig replays all firewall configuration required
+	// to restore connectivity within the networks managed by the driver
+	// after the system firewall configuration has been flushed.
+	ReplayFirewallConfig()
+}
+
 // NetworkInfo provides a go interface for drivers to provide network
 // specific information to libnetwork.
 type NetworkInfo interface {

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -126,6 +126,10 @@ type bridgeEndpoint struct {
 	portMapping     []types.PortBinding // Operation port bindings
 	dbIndex         uint64
 	dbExists        bool
+
+	// Ephemeral state not persisted to the store.
+
+	isLinked bool
 }
 
 type bridgeNetwork struct {
@@ -390,14 +394,6 @@ func (d *driver) configure(option map[string]interface{}) error {
 		if err != nil {
 			return err
 		}
-
-		// Make sure on firewall reload, first thing being re-played is chains creation
-		iptables.OnReloaded(func() {
-			log.G(context.TODO()).Debugf("Recreating iptables chains on firewall reload")
-			if _, _, _, _, err := setupIPChains(config, iptables.IPv4); err != nil {
-				log.G(context.TODO()).WithError(err).Error("Error reloading iptables chains")
-			}
-		})
 	}
 
 	if config.EnableIP6Tables {
@@ -407,14 +403,6 @@ func (d *driver) configure(option map[string]interface{}) error {
 		if err != nil {
 			return err
 		}
-
-		// Make sure on firewall reload, first thing being re-played is chains creation
-		iptables.OnReloaded(func() {
-			log.G(context.TODO()).Debugf("Recreating ip6tables chains on firewall reload")
-			if _, _, _, _, err := setupIPChains(config, iptables.IPv6); err != nil {
-				log.G(context.TODO()).WithError(err).Error("Error reloading ip6tables chains")
-			}
-		})
 	}
 
 	if config.EnableIPForwarding {
@@ -761,12 +749,6 @@ func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 
 		// Setup IP6Tables.
 		{config.EnableIPv6 && d.config.EnableIP6Tables, network.setupIP6Tables},
-
-		// We want to track firewalld configuration so that
-		// if it is started/reloaded, the rules can be applied correctly
-		{d.config.EnableIPTables, network.setupFirewalld},
-		// same for IPv6
-		{config.EnableIPv6 && d.config.EnableIP6Tables, network.setupFirewalld6},
 
 		// Setup DefaultGatewayIPv4
 		{config.DefaultGatewayIPv4 != nil, setupGatewayIPv4},
@@ -1251,7 +1233,8 @@ func (d *driver) Leave(nid, eid string) error {
 	}
 
 	if !network.config.EnableICC {
-		if err = d.link(network, endpoint, false); err != nil {
+		endpoint.isLinked = false
+		if err = network.link(endpoint, false); err != nil {
 			return err
 		}
 	}
@@ -1304,7 +1287,11 @@ func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string
 	}
 
 	if !network.config.EnableICC {
-		return d.link(network, endpoint, true)
+		if err := network.link(endpoint, true); err != nil {
+			return err
+		}
+		// Mark that the endpoint linking needs to be replayed when we reload the firewall ruleset.
+		endpoint.isLinked = true
 	}
 
 	return nil
@@ -1344,7 +1331,7 @@ func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
 	return nil
 }
 
-func (d *driver) link(network *bridgeNetwork, endpoint *bridgeEndpoint, enable bool) (retErr error) {
+func (network *bridgeNetwork) link(endpoint *bridgeEndpoint, enable bool) (retErr error) {
 	cc := endpoint.containerConfig
 	ec := endpoint.extConnConfig
 	if cc == nil || ec == nil || (len(cc.ParentEndpoints) == 0 && len(cc.ChildEndpoints) == 0) {

--- a/libnetwork/drivers/bridge/link.go
+++ b/libnetwork/drivers/bridge/link.go
@@ -40,15 +40,7 @@ func newLink(parentIP, childIP net.IP, ports []types.TransportPort, bridge strin
 }
 
 func (l *link) Enable() error {
-	linkFunction := func() error {
-		return linkContainers(iptables.Append, l.parentIP, l.childIP, l.ports, l.bridge, false)
-	}
-	if err := linkFunction(); err != nil {
-		return err
-	}
-
-	iptables.OnReloaded(func() { _ = linkFunction() })
-	return nil
+	return linkContainers(iptables.Append, l.parentIP, l.childIP, l.ports, l.bridge, false)
 }
 
 func (l *link) Disable() {

--- a/libnetwork/drivers/bridge/setup_firewalld.go
+++ b/libnetwork/drivers/bridge/setup_firewalld.go
@@ -3,39 +3,51 @@
 package bridge
 
 import (
-	"errors"
+	"context"
 
+	"github.com/containerd/log"
+	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/iptables"
 )
 
-func (n *bridgeNetwork) setupFirewalld(config *networkConfiguration, i *bridgeInterface) error {
-	d := n.driver
-	d.Lock()
-	driverConfig := d.config
-	d.Unlock()
+var _ driverapi.FirewallReplayer = (*driver)(nil)
 
-	// Sanity check.
-	if !driverConfig.EnableIPTables {
-		return errors.New("no need to register firewalld hooks, iptables is disabled")
+func (d *driver) ReplayFirewallConfig() {
+	// Make sure on firewall reload, first thing being re-played is chains creation
+	if d.config.EnableIPTables {
+		log.G(context.TODO()).Debugf("Recreating iptables chains on firewall reload")
+		if _, _, _, _, err := setupIPChains(d.config, iptables.IPv4); err != nil {
+			log.G(context.TODO()).WithError(err).Error("Error reloading iptables chains")
+		}
+	}
+	if d.config.EnableIP6Tables {
+		log.G(context.TODO()).Debugf("Recreating ip6tables chains on firewall reload")
+		if _, _, _, _, err := setupIPChains(d.config, iptables.IPv6); err != nil {
+			log.G(context.TODO()).WithError(err).Error("Error reloading ip6tables chains")
+		}
 	}
 
-	iptables.OnReloaded(func() { n.setupIP4Tables(config, i) })
-	iptables.OnReloaded(n.portMapper.ReMapAll)
-	return nil
+	replaySetupIPForwarding(d.config.EnableIPTables, d.config.EnableIP6Tables)
+
+	for _, n := range d.getNetworks() {
+		n.replayFirewallConfig()
+	}
 }
 
-func (n *bridgeNetwork) setupFirewalld6(config *networkConfiguration, i *bridgeInterface) error {
-	d := n.driver
-	d.Lock()
-	driverConfig := d.config
-	d.Unlock()
-
-	// Sanity check.
-	if !driverConfig.EnableIP6Tables {
-		return errors.New("no need to register firewalld hooks, ip6tables is disabled")
+func (n *bridgeNetwork) replayFirewallConfig() {
+	if n.driver.config.EnableIPTables {
+		n.setupIP4Tables(n.config, n.bridge)
+		n.portMapper.ReMapAll()
 	}
 
-	iptables.OnReloaded(func() { n.setupIP6Tables(config, i) })
-	iptables.OnReloaded(n.portMapperV6.ReMapAll)
-	return nil
+	if n.config.EnableIPv6 && n.driver.config.EnableIP6Tables {
+		n.setupIP6Tables(n.config, n.bridge)
+		n.portMapperV6.ReMapAll()
+	}
+
+	for _, ep := range n.endpoints {
+		if ep.isLinked {
+			_ = n.link(ep, true)
+		}
+	}
 }

--- a/libnetwork/firewall_linux.go
+++ b/libnetwork/firewall_linux.go
@@ -10,20 +10,14 @@ import (
 
 const userChain = "DOCKER-USER"
 
-var ctrl *Controller
-
-func setupArrangeUserFilterRule(c *Controller) {
-	ctrl = c
-	iptables.OnReloaded(arrangeUserFilterRule)
+func (c *Controller) setupArrangeUserFilterRule() {
+	iptables.OnReloaded(func() { arrangeUserFilterRule(c.enabledIptablesVersions()...) })
 }
 
 // arrangeUserFilterRule sets up the DOCKER-USER chain for each iptables version
-// (IPv4, IPv6) that's enabled in the controller's configuration.
-func arrangeUserFilterRule() {
-	if ctrl == nil {
-		return
-	}
-	for _, ipVersion := range ctrl.enabledIptablesVersions() {
+// (IPv4, IPv6) specified in the arguments.
+func arrangeUserFilterRule(ipVersions ...iptables.IPVersion) {
+	for _, ipVersion := range ipVersions {
 		if err := setupUserChain(ipVersion); err != nil {
 			log.G(context.TODO()).WithError(err).Warn("arrangeUserFilterRule")
 		}

--- a/libnetwork/firewall_linux_test.go
+++ b/libnetwork/firewall_linux_test.go
@@ -73,7 +73,7 @@ func TestUserChain(t *testing.T) {
 				_, err = iptable6.Raw("-A", fwdChainName, "-j", "DROP")
 				assert.Check(t, err)
 			}
-			arrangeUserFilterRule()
+			arrangeUserFilterRule(c.enabledIptablesVersions()...)
 
 			assert.Check(t, is.DeepEqual(getRules(t, iptable4, fwdChainName), tc.fwdChain))
 			assert.Check(t, is.DeepEqual(getRules(t, iptable6, fwdChainName), tc.fwdChain))

--- a/libnetwork/firewall_others.go
+++ b/libnetwork/firewall_others.go
@@ -2,5 +2,5 @@
 
 package libnetwork
 
-func (c *Controller) setupArrangeUserFilterRule() {}
+func (c *Controller) setupFirewallReloadHandler() {}
 func setupUserChain(ipVersion any) error          { return nil }

--- a/libnetwork/firewall_others.go
+++ b/libnetwork/firewall_others.go
@@ -2,6 +2,5 @@
 
 package libnetwork
 
-func setupArrangeUserFilterRule(c *Controller) {}
-func arrangeUserFilterRule()                   {}
-func setupUserChain(ipVersion any) error       { return nil }
+func (c *Controller) setupArrangeUserFilterRule() {}
+func setupUserChain(ipVersion any) error          { return nil }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- Related to #46237

The pattern of having low-level code that sets up iptables rules register reload callbacks for itself is not ideal. Callbacks can not be unregistered, so any values captured by the closures can never be GC'ed. And the callback registry is a singleton. While these issues could be overcome by iterating on the API, there are some other insurmountable issues which cannot be overcome without a complete overhaul of how the firewall reload logic is plumbed through. Imperative callback registration makes the control flow hard to reason about and the order of callbacks is implied by the order they were registered.

**- What I did**
Make the libnetwork Controller ultimately responsible for replaying firewall configuration when the firewall rulesets have been flushed externally. It fans out the reload signal to the drivers, which in turn fan out to the individual networks.

**- How I did it**
Made `(*Controller).handleFirewallReload` the only registered `iptables.OnReloaded` callback. It handles replaying firewall configuration for the controller, then calls into all the drivers which implement `FirewallReplayer` to handle replaying their own firewall configuration.

**- How to verify it**
TODO - UNVERIFIED

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
N/A

**- A picture of a cute animal (not mandatory but encouraged)**

