### PR TITLE
libnetwork: svc record update without store

### DIFF
--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -241,7 +241,7 @@ func (c *Controller) clusterAgentInit() {
 			c.mu.Unlock()
 			fallthrough
 		case cluster.EventSocketChange, cluster.EventNodeReady:
-			if keysAvailable && !c.isDistributedControl() {
+			if keysAvailable && c.isSwarmNode() {
 				c.agentOperationStart()
 				if err := c.agentSetup(clusterProvider); err != nil {
 					c.agentStopComplete()
@@ -451,8 +451,8 @@ func (c *Controller) isAgent() bool {
 	return c.cfg.ClusterProvider.IsAgent()
 }
 
-func (c *Controller) isDistributedControl() bool {
-	return !c.isManager() && !c.isAgent()
+func (c *Controller) isSwarmNode() bool {
+	return c.isManager() || c.isAgent()
 }
 
 func (c *Controller) GetPluginGetter() plugingetter.PluginGetter {
@@ -553,7 +553,7 @@ func (c *Controller) NewNetwork(networkType, name string, id string, options ...
 
 	// At this point the network scope is still unknown if not set by user
 	if (caps.DataScope == scope.Global || nw.scope == scope.Swarm) &&
-		!c.isDistributedControl() && !nw.dynamic {
+		c.isSwarmNode() && !nw.dynamic {
 		if c.isManager() {
 			// For non-distributed controlled environment, globalscoped non-dynamic networks are redirected to Manager
 			return nil, ManagerRedirectError(name)
@@ -561,7 +561,7 @@ func (c *Controller) NewNetwork(networkType, name string, id string, options ...
 		return nil, types.ForbiddenErrorf("Cannot create a multi-host network from a worker node. Please create the network from a manager node.")
 	}
 
-	if nw.scope == scope.Swarm && c.isDistributedControl() {
+	if nw.scope == scope.Swarm && !c.isSwarmNode() {
 		return nil, types.ForbiddenErrorf("cannot create a swarm scoped network when swarm is not active")
 	}
 
@@ -704,7 +704,7 @@ addToStore:
 		}
 	}
 
-	if !c.isDistributedControl() {
+	if c.isSwarmNode() {
 		c.mu.Lock()
 		arrangeIngressFilterRule()
 		c.mu.Unlock()

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -87,8 +87,6 @@ type Controller struct {
 	cfg              *config.Config
 	store            *datastore.Store
 	extKeyListener   net.Listener
-	watchCh          chan *Endpoint
-	unWatchCh        chan *Endpoint
 	svcRecords       map[string]*svcInfo
 	nmap             map[string]*netWatch
 	serviceBindings  map[serviceKey]*service
@@ -114,6 +112,7 @@ func New(cfgOptions ...config.Option) (*Controller, error) {
 		sandboxes:        map[string]*Sandbox{},
 		svcRecords:       make(map[string]*svcInfo),
 		serviceBindings:  make(map[serviceKey]*service),
+		nmap:             make(map[string]*netWatch),
 		agentInitDone:    make(chan struct{}),
 		networkLocker:    locker.New(),
 		DiagnosticServer: diagnostic.New(),

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -88,7 +88,6 @@ type Controller struct {
 	store            *datastore.Store
 	extKeyListener   net.Listener
 	svcRecords       map[string]*svcInfo
-	nmap             map[string]*netWatch
 	serviceBindings  map[serviceKey]*service
 	ingressSandbox   *Sandbox
 	agent            *nwAgent
@@ -112,7 +111,6 @@ func New(cfgOptions ...config.Option) (*Controller, error) {
 		sandboxes:        map[string]*Sandbox{},
 		svcRecords:       make(map[string]*svcInfo),
 		serviceBindings:  make(map[serviceKey]*service),
-		nmap:             make(map[string]*netWatch),
 		agentInitDone:    make(chan struct{}),
 		networkLocker:    locker.New(),
 		DiagnosticServer: diagnostic.New(),

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -589,13 +589,6 @@ func (ep *Endpoint) rename(name string) error {
 			return types.InternalErrorf("Could not delete service state for endpoint %s from cluster on rename: %v", ep.Name(), err)
 		}
 	} else {
-		c.mu.Lock()
-		_, ok = c.nmap[n.ID()]
-		c.mu.Unlock()
-		if !ok {
-			// FIXME(thaJeztah): what is this check for, or is this to prevent a race condition (network removed)?
-			return fmt.Errorf("watch null for network %q", n.Name())
-		}
 		n.updateSvcRecord(ep, false)
 	}
 
@@ -636,14 +629,6 @@ func (ep *Endpoint) rename(name string) error {
 	if err = c.updateToStore(ep); err != nil {
 		return err
 	}
-	// After the name change do a dummy endpoint count update to
-	// trigger the service record update in the peer nodes
-
-	// Ignore the error because updateStore fail for EpCnt is a
-	// benign error. Besides there is no meaningful recovery that
-	// we can do. When the cluster recovers subsequent EpCnt update
-	// will force the peers to get the correct EP name.
-	_ = n.getEpCnt().updateStore()
 
 	return err
 }

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1225,13 +1225,14 @@ func (n *Network) createEndpoint(name string, options ...EndpointOption) (*Endpo
 		return nil, err
 	}
 
-	// Watch for service records
-	n.getController().watchSvcRecord(ep)
-	defer func() {
-		if err != nil {
-			n.getController().unWatchSvcRecord(ep)
-		}
-	}()
+	if !n.getController().isSwarmNode() || n.Scope() != scope.Swarm || !n.driverIsMultihost() {
+		n.updateSvcRecord(ep, true)
+		defer func() {
+			if err != nil {
+				n.updateSvcRecord(ep, false)
+			}
+		}()
+	}
 
 	// Increment endpoint count to indicate completion of endpoint addition
 	if err = n.getEpCnt().IncEndpointCnt(); err != nil {

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -162,7 +162,7 @@ func (sb *Sandbox) delete(force bool) error {
 		}
 		// Retain the sanbdox if we can't obtain the network from store.
 		if _, err := c.getNetworkFromStore(ep.getNetwork().ID()); err != nil {
-			if c.isDistributedControl() {
+			if !c.isSwarmNode() {
 				retain = true
 			}
 			log.G(context.TODO()).Warnf("Failed getting network for ep %s during sandbox %s delete: %v", ep.ID(), sb.ID(), err)
@@ -459,7 +459,7 @@ func (sb *Sandbox) ResolveName(ctx context.Context, name string, ipType int) ([]
 	// network, ingress network and docker_gwbridge network. Name resolution
 	// should prioritize returning the VIP/IPs on user overlay network.
 	newList := []*Endpoint{}
-	if !sb.controller.isDistributedControl() {
+	if sb.controller.isSwarmNode() {
 		newList = append(newList, getDynamicNwEndpoints(epList)...)
 		ingressEP := getIngressNwEndpoint(epList)
 		if ingressEP != nil {

--- a/libnetwork/sandbox_store.go
+++ b/libnetwork/sandbox_store.go
@@ -278,9 +278,11 @@ func (c *Controller) sandboxCleanup(activeSandboxes map[string]interface{}) erro
 		}
 
 		for _, ep := range sb.endpoints {
-			// Watch for service records
 			if !c.isAgent() {
-				c.watchSvcRecord(ep)
+				n := ep.getNetwork()
+				if !c.isSwarmNode() || n.Scope() != scope.Swarm || !n.driverIsMultihost() {
+					n.updateSvcRecord(ep, true)
+				}
 			}
 		}
 	}

--- a/libnetwork/store.go
+++ b/libnetwork/store.go
@@ -198,7 +198,7 @@ func (c *Controller) unWatchSvcRecord(ep *Endpoint) {
 
 func (c *Controller) processEndpointCreate(ep *Endpoint) {
 	n := ep.getNetwork()
-	if !c.isDistributedControl() && n.Scope() == scope.Swarm && n.driverIsMultihost() {
+	if c.isSwarmNode() && n.Scope() == scope.Swarm && n.driverIsMultihost() {
 		return
 	}
 
@@ -220,7 +220,7 @@ func (c *Controller) processEndpointCreate(ep *Endpoint) {
 
 func (c *Controller) processEndpointDelete(ep *Endpoint) {
 	n := ep.getNetwork()
-	if !c.isDistributedControl() && n.Scope() == scope.Swarm && n.driverIsMultihost() {
+	if c.isSwarmNode() && n.Scope() == scope.Swarm && n.driverIsMultihost() {
 		return
 	}
 

--- a/libnetwork/store.go
+++ b/libnetwork/store.go
@@ -185,7 +185,7 @@ retry:
 }
 
 type netWatch struct {
-	localEps map[string]*Endpoint
+	localEps map[string]struct{}
 }
 
 func (c *Controller) watchSvcRecord(ep *Endpoint) {
@@ -212,9 +212,9 @@ func (c *Controller) processEndpointCreate(ep *Endpoint) {
 	c.mu.Lock()
 	_, ok := c.nmap[networkID]
 	if !ok {
-		c.nmap[networkID] = &netWatch{localEps: make(map[string]*Endpoint)}
+		c.nmap[networkID] = &netWatch{localEps: make(map[string]struct{})}
 	}
-	c.nmap[networkID].localEps[endpointID] = ep
+	c.nmap[networkID].localEps[endpointID] = struct{}{}
 	c.mu.Unlock()
 }
 

--- a/libnetwork/store.go
+++ b/libnetwork/store.go
@@ -239,9 +239,6 @@ func (c *Controller) processEndpointDelete(ep *Endpoint) {
 
 		c.mu.Lock()
 		if len(nw.localEps) == 0 {
-			// This is the last container going away for the network. Destroy
-			// this network's svc db entry
-			delete(c.svcRecords, networkID)
 			delete(c.nmap, networkID)
 		}
 	}

--- a/libnetwork/store.go
+++ b/libnetwork/store.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/libnetwork/datastore"
-	"github.com/docker/docker/libnetwork/scope"
 )
 
 func (c *Controller) initStores() error {
@@ -182,32 +181,6 @@ retry:
 	}
 
 	return nil
-}
-
-func (c *Controller) watchSvcRecord(ep *Endpoint) {
-	go c.processEndpointCreate(ep)
-}
-
-func (c *Controller) unWatchSvcRecord(ep *Endpoint) {
-	go c.processEndpointDelete(ep)
-}
-
-func (c *Controller) processEndpointCreate(ep *Endpoint) {
-	n := ep.getNetwork()
-	if c.isSwarmNode() && n.Scope() == scope.Swarm && n.driverIsMultihost() {
-		return
-	}
-
-	n.updateSvcRecord(ep, true)
-}
-
-func (c *Controller) processEndpointDelete(ep *Endpoint) {
-	n := ep.getNetwork()
-	if c.isSwarmNode() && n.Scope() == scope.Swarm && n.driverIsMultihost() {
-		return
-	}
-
-	n.updateSvcRecord(ep, false)
 }
 
 func (c *Controller) networkCleanup() {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Peeled away all the extraneous layers between `(*Controller).watchSvcRecord` and `(*Network).updateSvcRecord`
- Renamed and inverted the meaning of `(*Controller).isDistributedControl()` to help with readability at call sites

**- How I did it**
Iteratively.

**- How to verify it**
Manual static analysis. A call to `func (*Network) updateSvcRecord` could block on `(*Endpoint).mu.Lock()`, `(*Network).mu.Lock()`, `(*Controller).mu.Lock()` and `(*SetMatrix[T]).mu.Lock()`. The setmatrix mutex can be ignored as it is only locked in leaf functions which unlock them upon return.

This PR adds three new calls to `updateSvcRecord`.

`func (*Endpoint) sbJoin`
- If called when `(*Controller).mu` is locked, it would block on [`n.getController().isAgent()`](https://github.com/moby/moby/blob/4039b9c9c4161afba957224ee3c3a0e7da95958c/libnetwork/endpoint.go#L460) -> [`c.mu.Lock()`](https://github.com/moby/moby/blob/cff4f20c44a3a7c882ed73934dec6a77246c6323/libnetwork/controller.go#L447)
- If called when `(*Network).mu` is locked, it would block on the very first line:
  - [`ep.getNetworkFromStore()`](https://github.com/moby/moby/blob/4039b9c9c4161afba957224ee3c3a0e7da95958c/libnetwork/endpoint.go#L410) -> [`ep.network.getController()`](https://github.com/moby/moby/blob/4039b9c9c4161afba957224ee3c3a0e7da95958c/libnetwork/endpoint.go#L393) -> [`n.mu.Lock()`](https://github.com/moby/moby/blob/4039b9c9c4161afba957224ee3c3a0e7da95958c/libnetwork/network.go#L1480)
- If called when `(*Endpoint).mu` is locked, it would block on the [`ep.mu.Lock()`](https://github.com/moby/moby/blob/4039b9c9c4161afba957224ee3c3a0e7da95958c/libnetwork/endpoint.go#L420) call in the function body.

`func (*Endpoint) Delete`
- If called when `(*Controller).mu` is locked, it would block on [`n.getController().SandboxById(_)`](https://github.com/moby/moby/blob/4039b9c9c4161afba957224ee3c3a0e7da95958c/libnetwork/endpoint.go#L797) -> [`c.mu.Lock()`](https://github.com/moby/moby/blob/cff4f20c44a3a7c882ed73934dec6a77246c6323/libnetwork/controller.go#L1012)
- If called when `(*Network).mu` is locked, it would block on [`ep.getNetworkFromStore()`](https://github.com/moby/moby/blob/4039b9c9c4161afba957224ee3c3a0e7da95958c/libnetwork/endpoint.go#L781)
- If called when `(*Endpoint).mu` is locked, it would block on the [`ep.mu.Lock()`](https://github.com/moby/moby/blob/4039b9c9c4161afba957224ee3c3a0e7da95958c/libnetwork/endpoint.go#L791) call in the function body.

`func (*Network) createEndpoint`
- I was unable to locate a path to `(*Controller).mu.Lock()` other than `updateSvcRecord`. All callers of `createEndpoint` within the libnetwork must therefore be analyzed.
  - [`func (*Network) CreateEndpoint`](https://github.com/moby/moby/blob/4039b9c9c4161afba957224ee3c3a0e7da95958c/libnetwork/network.go#L1134) is not very interesting. Callers:
    - [`func (*Sandbox) setupDefaultGW()`](https://github.com/moby/moby/blob/cff4f20c44a3a7c882ed73934dec6a77246c6323/libnetwork/default_gateway.go#L74) calls [`(*Endpoint).sbJoin(_)`](https://github.com/moby/moby/blob/cff4f20c44a3a7c882ed73934dec6a77246c6323/libnetwork/default_gateway.go#L88)
    - [`func (*Network) createLoadBalancerSandbox()`](https://github.com/moby/moby/blob/4039b9c9c4161afba957224ee3c3a0e7da95958c/libnetwork/network.go#L2175) calls [`n.ctrlr.NewSandbox`](https://github.com/moby/moby/blob/4039b9c9c4161afba957224ee3c3a0e7da95958c/libnetwork/network.go#L2154) -> [`c.mu.Lock()`](https://github.com/moby/moby/blob/cff4f20c44a3a7c882ed73934dec6a77246c6323/libnetwork/controller.go#L887)
- If called when `(*Network).mu` is locked, it would block on [`ep.getNetworkFromStore()`](https://github.com/moby/moby/blob/4039b9c9c4161afba957224ee3c3a0e7da95958c/libnetwork/network.go#L1146)
- `(*Endpoint).mu` cannot be locked as the `Endpoint` is constructed in the function body

All new code paths which lead to `updateSvcRecord` lock all the mutexes which `updateSvcRecord` would block on before or after the call, therefore changing the calls to `updateSvcRecord` to be synchronous cannot introduce new deadlocks which were not already possible in the existing code.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
N/A

**- A picture of a cute animal (not mandatory but encouraged)**

