### PR TITLE
bridge: Add unit tests for outgoing NAT rules

### DIFF
--- a/libnetwork/drivers/bridge/setup_ip_tables_linux.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/libnetwork/iptables"
@@ -239,6 +240,14 @@ func (r iptRule) Delete() error {
 		return nil
 	}
 	return r.exec(iptables.Delete)
+}
+
+func (r iptRule) String() string {
+	cmd := append([]string{"iptables"}, r.cmdArgs("-A")...)
+	if r.ipv == iptables.IPv6 {
+		cmd[0] = "ip6tables"
+	}
+	return strings.Join(cmd, " ")
 }
 
 func setupIPTablesInternal(ipVer iptables.IPVersion, config *networkConfiguration, addr *net.IPNet, hairpin, enable bool) error {


### PR DESCRIPTION
**- What I did**

Added unit tests for outgoing NAT rules.

This commit is preparation for [my work-in-progress fix](https://github.com/rhansen/moby/commit/host_ipv6) for #46469.

**- How to verify it**

```shell
make TESTDIRS='github.com/docker/docker/libnetwork/drivers/bridge/...' test-unit
```

**- Description for the changelog**

(not needed)
