### PR TITLE
c8d/history: Fill ID for parents without the label

### DIFF
--- a/daemon/containerd/image_history.go
+++ b/daemon/containerd/image_history.go
@@ -121,7 +121,8 @@ func (i *ImageService) ImageHistory(ctx context.Context, name string) ([]*imaget
 
 		foundNext := false
 		for _, img := range parents {
-			if _, ok := img.Labels[imageLabelClassicBuilderParent]; ok {
+			_, hasLabel := img.Labels[imageLabelClassicBuilderParent]
+			if !foundNext || hasLabel {
 				currentImg = img
 				foundNext = true
 			}


### PR DESCRIPTION
- related to: https://github.com/moby/moby/pull/46653

Thanks @rumpl for finding this!

When choosing the next image, don't reject images without the classic builder parent label. The intention was to *prefer* images them instead of making that a condition.
This fixes the ID not being filled for parent images that weren't built with the classic builder.

**- What I did**

**- How I did it**
Choose any of the parent images, but prefer one that has the label pointing to the parent.

**- How to verify it**
```diff
$ printf 'FROM alpine\nRUN echo 1\nRUN echo 2\nRUN echo 3' | DOCKER_BUILDKIT=0 docker build -t asdf -
$ docker history asdf
IMAGE          CREATED         CREATED BY                                      SIZE      COMMENT
107a4ed2ba01   3 minutes ago   /bin/sh -c echo 3                               0B
6636787a339b   3 minutes ago   /bin/sh -c echo 2                               0B
583a867ce6a0   3 minutes ago   /bin/sh -c echo 1                               0B
-<missing>      2 weeks ago     /bin/sh -c #(nop)  CMD ["/bin/sh"]              0B
+eece025e4321   2 weeks ago     /bin/sh -c #(nop)  CMD ["/bin/sh"]              0B
<missing>      2 weeks ago     /bin/sh -c #(nop) ADD file:ff3112828967e8004…   8.35MB


```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

