### PR TITLE
libnetwork/datastore: miscellaneous code cleanups

### DIFF
--- a/libnetwork/datastore/cache.go
+++ b/libnetwork/datastore/cache.go
@@ -13,10 +13,10 @@ type kvMap map[string]KVObject
 type cache struct {
 	sync.Mutex
 	kmm map[string]kvMap
-	ds  *Store
+	ds  store.Store
 }
 
-func newCache(ds *Store) *cache {
+func newCache(ds store.Store) *cache {
 	return &cache{kmm: make(map[string]kvMap), ds: ds}
 }
 
@@ -40,7 +40,7 @@ func (c *cache) kmap(kvObject KVObject) (kvMap, error) {
 		return nil, errors.New("error while populating kmap, object does not implement KVConstructor interface")
 	}
 
-	kvList, err := c.ds.store.List(keyPrefix)
+	kvList, err := c.ds.List(keyPrefix)
 	if err != nil {
 		if err == store.ErrKeyNotFound {
 			// If the store doesn't have anything then there is nothing to

--- a/libnetwork/datastore/cache.go
+++ b/libnetwork/datastore/cache.go
@@ -1,7 +1,6 @@
 package datastore
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
@@ -34,12 +33,6 @@ func (c *cache) kmap(kvObject KVObject) (kvMap, error) {
 
 	kmap = kvMap{}
 
-	// Bail out right away if the kvObject does not implement KVConstructor
-	ctor, ok := kvObject.(KVConstructor)
-	if !ok {
-		return nil, errors.New("error while populating kmap, object does not implement KVConstructor interface")
-	}
-
 	kvList, err := c.ds.List(keyPrefix)
 	if err != nil {
 		if err == store.ErrKeyNotFound {
@@ -57,7 +50,7 @@ func (c *cache) kmap(kvObject KVObject) (kvMap, error) {
 			continue
 		}
 
-		dstO := ctor.New()
+		dstO := kvObject.New()
 		err = dstO.SetValue(kvPair.Value)
 		if err != nil {
 			return nil, err
@@ -152,12 +145,7 @@ func (c *cache) get(kvObject KVObject) error {
 		return ErrKeyNotFound
 	}
 
-	ctor, ok := o.(KVConstructor)
-	if !ok {
-		return errors.New("kvobject does not implement KVConstructor interface. could not get object")
-	}
-
-	return ctor.CopyTo(kvObject)
+	return o.CopyTo(kvObject)
 }
 
 func (c *cache) list(kvObject KVObject) ([]KVObject, error) {

--- a/libnetwork/datastore/datastore.go
+++ b/libnetwork/datastore/datastore.go
@@ -143,10 +143,7 @@ func newClient(kv string, addr string, config *store.Config) (*Store, error) {
 		return nil, err
 	}
 
-	ds := &Store{scope: scope.Local, store: s}
-	ds.cache = newCache(ds)
-
-	return ds, nil
+	return &Store{scope: scope.Local, store: s, cache: newCache(s)}, nil
 }
 
 // New creates a new Store instance.

--- a/libnetwork/datastore/datastore.go
+++ b/libnetwork/datastore/datastore.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/docker/libnetwork/discoverapi"
 	store "github.com/docker/docker/libnetwork/internal/kvstore"
 	"github.com/docker/docker/libnetwork/internal/kvstore/boltdb"
-	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -21,7 +20,6 @@ var (
 
 type Store struct {
 	mu    sync.Mutex
-	scope string
 	store store.Store
 	cache *cache
 }
@@ -139,7 +137,7 @@ func newClient(kv string, addr string, config *store.Config) (*Store, error) {
 		return nil, err
 	}
 
-	return &Store{scope: scope.Local, store: s, cache: newCache(s)}, nil
+	return &Store{store: s, cache: newCache(s)}, nil
 }
 
 // New creates a new Store instance.
@@ -180,11 +178,6 @@ func FromConfig(dsc discoverapi.DatastoreConfigData) (*Store, error) {
 // Close closes the data store.
 func (ds *Store) Close() {
 	ds.store.Close()
-}
-
-// Scope returns the scope of the store.
-func (ds *Store) Scope() string {
-	return ds.scope
 }
 
 // PutObjectAtomic provides an atomic add and update operation for a Record.

--- a/libnetwork/datastore/datastore.go
+++ b/libnetwork/datastore/datastore.go
@@ -41,8 +41,6 @@ type KVObject interface {
 	// Exists returns true if the object exists in the datastore, false if it hasn't been stored yet.
 	// When SetIndex() is called, the object has been stored.
 	Exists() bool
-	// DataScope indicates the storage scope of the KV object
-	DataScope() string
 	// Skip provides a way for a KV Object to avoid persisting it in the KV Store
 	Skip() bool
 	// New returns a new object which is created based on the

--- a/libnetwork/datastore/datastore_test.go
+++ b/libnetwork/datastore/datastore_test.go
@@ -14,7 +14,8 @@ const dummyKey = "dummy"
 
 // NewTestDataStore can be used by other Tests in order to use custom datastore
 func NewTestDataStore() *Store {
-	return &Store{scope: scope.Local, store: NewMockStore()}
+	s := NewMockStore()
+	return &Store{scope: scope.Local, store: s, cache: newCache(s)}
 }
 
 func TestKey(t *testing.T) {
@@ -154,6 +155,18 @@ func (n *dummyObject) UnmarshalJSON(b []byte) error {
 	n.NetworkType = netMap["networkType"].(string)
 	n.EnableIPv6 = netMap["enableIPv6"].(bool)
 	n.Generic = netMap["generic"].(map[string]interface{})
+	return nil
+}
+
+func (n *dummyObject) New() KVObject {
+	return &dummyObject{}
+}
+
+func (n *dummyObject) CopyTo(o KVObject) error {
+	if err := o.SetValue(n.Value()); err != nil {
+		return err
+	}
+	o.SetIndex(n.Index())
 	return nil
 }
 

--- a/libnetwork/datastore/datastore_test.go
+++ b/libnetwork/datastore/datastore_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/libnetwork/options"
-	"github.com/docker/docker/libnetwork/scope"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -131,10 +130,6 @@ func (n *dummyObject) Exists() bool {
 
 func (n *dummyObject) Skip() bool {
 	return n.SkipSave
-}
-
-func (n *dummyObject) DataScope() string {
-	return scope.Local
 }
 
 func (n *dummyObject) MarshalJSON() ([]byte, error) {

--- a/libnetwork/datastore/datastore_test.go
+++ b/libnetwork/datastore/datastore_test.go
@@ -15,7 +15,7 @@ const dummyKey = "dummy"
 // NewTestDataStore can be used by other Tests in order to use custom datastore
 func NewTestDataStore() *Store {
 	s := NewMockStore()
-	return &Store{scope: scope.Local, store: s, cache: newCache(s)}
+	return &Store{store: s, cache: newCache(s)}
 }
 
 func TestKey(t *testing.T) {

--- a/libnetwork/datastore/mockstore_test.go
+++ b/libnetwork/datastore/mockstore_test.go
@@ -1,7 +1,7 @@
 package datastore
 
 import (
-	"errors"
+	"strings"
 
 	store "github.com/docker/docker/libnetwork/internal/kvstore"
 	"github.com/docker/docker/libnetwork/types"
@@ -52,7 +52,16 @@ func (s *MockStore) Exists(key string) (bool, error) {
 
 // List gets a range of values at "directory"
 func (s *MockStore) List(prefix string) ([]*store.KVPair, error) {
-	return nil, errors.New("not implemented")
+	var res []*store.KVPair
+	for k, v := range s.db {
+		if strings.HasPrefix(k, prefix) {
+			res = append(res, &store.KVPair{Key: k, Value: v.Data, LastIndex: v.Index})
+		}
+	}
+	if len(res) == 0 {
+		return nil, store.ErrKeyNotFound
+	}
+	return res, nil
 }
 
 // AtomicPut put a value at "key" if the key has not been

--- a/libnetwork/datastore/mockstore_test.go
+++ b/libnetwork/datastore/mockstore_test.go
@@ -23,16 +23,6 @@ func NewMockStore() *MockStore {
 	return &MockStore{db: make(map[string]*MockData)}
 }
 
-// Get the value at "key", returns the last modified index
-// to use in conjunction to CAS calls
-func (s *MockStore) Get(key string) (*store.KVPair, error) {
-	mData := s.db[key]
-	if mData == nil {
-		return nil, nil
-	}
-	return &store.KVPair{Value: mData.Data, LastIndex: mData.Index}, nil
-}
-
 // Put a value at "key"
 func (s *MockStore) Put(key string, value []byte) error {
 	mData := s.db[key]

--- a/libnetwork/drivers/bridge/bridge_store.go
+++ b/libnetwork/drivers/bridge/bridge_store.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/discoverapi"
 	"github.com/docker/docker/libnetwork/netlabel"
-	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -267,10 +266,6 @@ func (ncfg *networkConfiguration) CopyTo(o datastore.KVObject) error {
 	return nil
 }
 
-func (ncfg *networkConfiguration) DataScope() string {
-	return scope.Local
-}
-
 func (ep *bridgeEndpoint) MarshalJSON() ([]byte, error) {
 	epMap := make(map[string]interface{})
 	epMap["id"] = ep.id
@@ -382,10 +377,6 @@ func (ep *bridgeEndpoint) CopyTo(o datastore.KVObject) error {
 	dstEp := o.(*bridgeEndpoint)
 	*dstEp = *ep
 	return nil
-}
-
-func (ep *bridgeEndpoint) DataScope() string {
-	return scope.Local
 }
 
 func (n *bridgeNetwork) restorePortAllocations(ep *bridgeEndpoint) {

--- a/libnetwork/drivers/ipvlan/ipvlan_store.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_store.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/discoverapi"
 	"github.com/docker/docker/libnetwork/netlabel"
-	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -258,10 +257,6 @@ func (config *configuration) CopyTo(o datastore.KVObject) error {
 	return nil
 }
 
-func (config *configuration) DataScope() string {
-	return scope.Local
-}
-
 func (ep *endpoint) MarshalJSON() ([]byte, error) {
 	epMap := make(map[string]interface{})
 	epMap["id"] = ep.id
@@ -356,8 +351,4 @@ func (ep *endpoint) CopyTo(o datastore.KVObject) error {
 	dstEp := o.(*endpoint)
 	*dstEp = *ep
 	return nil
-}
-
-func (ep *endpoint) DataScope() string {
-	return scope.Local
 }

--- a/libnetwork/drivers/macvlan/macvlan_store.go
+++ b/libnetwork/drivers/macvlan/macvlan_store.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/discoverapi"
 	"github.com/docker/docker/libnetwork/netlabel"
-	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -252,10 +251,6 @@ func (config *configuration) CopyTo(o datastore.KVObject) error {
 	return nil
 }
 
-func (config *configuration) DataScope() string {
-	return scope.Local
-}
-
 func (ep *endpoint) MarshalJSON() ([]byte, error) {
 	epMap := make(map[string]interface{})
 	epMap["id"] = ep.id
@@ -350,8 +345,4 @@ func (ep *endpoint) CopyTo(o datastore.KVObject) error {
 	dstEp := o.(*endpoint)
 	*dstEp = *ep
 	return nil
-}
-
-func (ep *endpoint) DataScope() string {
-	return scope.Local
 }

--- a/libnetwork/drivers/windows/windows_store.go
+++ b/libnetwork/drivers/windows/windows_store.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/discoverapi"
 	"github.com/docker/docker/libnetwork/netlabel"
-	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -221,10 +220,6 @@ func (ncfg *networkConfiguration) CopyTo(o datastore.KVObject) error {
 	return nil
 }
 
-func (ncfg *networkConfiguration) DataScope() string {
-	return scope.Local
-}
-
 func (ep *hnsEndpoint) MarshalJSON() ([]byte, error) {
 	epMap := make(map[string]interface{})
 	epMap["id"] = ep.id
@@ -332,8 +327,4 @@ func (ep *hnsEndpoint) CopyTo(o datastore.KVObject) error {
 	dstEp := o.(*hnsEndpoint)
 	*dstEp = *ep
 	return nil
-}
-
-func (ep *hnsEndpoint) DataScope() string {
-	return scope.Local
 }

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -1031,10 +1031,6 @@ func JoinOptionPriority(prio int) EndpointOption {
 	}
 }
 
-func (ep *Endpoint) DataScope() string {
-	return ep.getNetwork().DataScope()
-}
-
 func (ep *Endpoint) assignAddress(ipam ipamapi.Ipam, assignIPv4, assignIPv6 bool) error {
 	var err error
 

--- a/libnetwork/endpoint_cnt.go
+++ b/libnetwork/endpoint_cnt.go
@@ -97,10 +97,6 @@ func (ec *endpointCnt) CopyTo(o datastore.KVObject) error {
 	return nil
 }
 
-func (ec *endpointCnt) DataScope() string {
-	return ec.n.DataScope()
-}
-
 func (ec *endpointCnt) EndpointCnt() uint64 {
 	ec.Lock()
 	defer ec.Unlock()
@@ -111,7 +107,7 @@ func (ec *endpointCnt) EndpointCnt() uint64 {
 func (ec *endpointCnt) updateStore() error {
 	store := ec.n.getController().getStore()
 	if store == nil {
-		return fmt.Errorf("store not found for scope %s on endpoint count update", ec.DataScope())
+		return fmt.Errorf("store not found on endpoint count update")
 	}
 	// make a copy of count and n to avoid being overwritten by store.GetObject
 	count := ec.EndpointCnt()
@@ -140,7 +136,7 @@ func (ec *endpointCnt) setCnt(cnt uint64) error {
 func (ec *endpointCnt) atomicIncDecEpCnt(inc bool) error {
 	store := ec.n.getController().getStore()
 	if store == nil {
-		return fmt.Errorf("store not found for scope %s", ec.DataScope())
+		return fmt.Errorf("store not found on endpoint count atomic inc/dec")
 	}
 
 	tmp := &endpointCnt{n: ec.n}

--- a/libnetwork/internal/kvstore/kvstore.go
+++ b/libnetwork/internal/kvstore/kvstore.go
@@ -39,9 +39,6 @@ type Store interface {
 	// Put a value at the specified key
 	Put(key string, value []byte) error
 
-	// Get a value given its key
-	Get(key string) (*KVPair, error)
-
 	// Exists verifies if a Key exists in the store.
 	Exists(key string) (bool, error)
 

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -510,15 +510,6 @@ func (n *Network) CopyTo(o datastore.KVObject) error {
 	return nil
 }
 
-func (n *Network) DataScope() string {
-	s := n.Scope()
-	// All swarm scope networks have local datascope
-	if s == scope.Swarm {
-		s = scope.Local
-	}
-	return s
-}
-
 func (n *Network) getEpCnt() *endpointCnt {
 	n.mu.Lock()
 	defer n.mu.Unlock()
@@ -1768,7 +1759,7 @@ func (n *Network) deriveAddressSpace() (string, error) {
 	if err != nil {
 		return "", types.NotFoundErrorf("failed to get default address space: %v", err)
 	}
-	if n.DataScope() == scope.Global {
+	if n.Scope() == scope.Global {
 		return global, nil
 	}
 	return local, nil

--- a/libnetwork/sandbox_store.go
+++ b/libnetwork/sandbox_store.go
@@ -9,7 +9,6 @@ import (
 	"github.com/containerd/log"
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/osl"
-	"github.com/docker/docker/libnetwork/scope"
 )
 
 const (
@@ -120,10 +119,6 @@ func (sbs *sbState) CopyTo(o datastore.KVObject) error {
 	dstSbs.ExtDNS = append(dstSbs.ExtDNS, sbs.ExtDNS...)
 
 	return nil
-}
-
-func (sbs *sbState) DataScope() string {
-	return scope.Local
 }
 
 func (sb *Sandbox) storeUpdate() error {

--- a/libnetwork/sandbox_store.go
+++ b/libnetwork/sandbox_store.go
@@ -184,7 +184,7 @@ func (c *Controller) sandboxCleanup(activeSandboxes map[string]interface{}) erro
 			// It's normal for no sandboxes to be found. Just bail out.
 			return nil
 		}
-		return fmt.Errorf("failed to get sandboxes for scope %s: %v", store.Scope(), err)
+		return fmt.Errorf("failed to get sandboxes: %v", err)
 	}
 
 	for _, s := range sandboxStates {

--- a/libnetwork/store.go
+++ b/libnetwork/store.go
@@ -70,7 +70,7 @@ func (c *Controller) getNetworks() ([]*Network, error) {
 
 		n.epCnt = ec
 		if n.scope == "" {
-			n.scope = store.Scope()
+			n.scope = scope.Local
 		}
 		nl = append(nl, n)
 	}
@@ -107,7 +107,7 @@ func (c *Controller) getNetworksFromStore() []*Network { // FIXME: unify with c.
 			n.epCnt = ec
 		}
 		if n.scope == "" {
-			n.scope = store.Scope()
+			n.scope = scope.Local
 		}
 		n.mu.Unlock()
 		nl = append(nl, n)
@@ -134,8 +134,8 @@ func (n *Network) getEndpointsFromStore() ([]*Endpoint, error) {
 	kvol, err := store.List(datastore.Key(tmp.KeyPrefix()...), &Endpoint{network: n})
 	if err != nil {
 		if err != datastore.ErrKeyNotFound {
-			return nil, fmt.Errorf("failed to get endpoints for network %s scope %s: %w",
-				n.Name(), store.Scope(), err)
+			return nil, fmt.Errorf("failed to get endpoints for network %s: %w",
+				n.Name(), err)
 		}
 		return nil, nil
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Pruned some dead code from the libnetwork datastore and KVObjects, and applied some refactors to the remaining code to improve readability. It is now much more obvious that the datastore code paths covered by unit testing had little in common with the datastore code paths used in production, or that `Map()` bypasses the cache and has a side effect of inserting a key into the backing store.

**- How I did it**

**- How to verify it**
By inspection

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
N/A

**- A picture of a cute animal (not mandatory but encouraged)**

