### PR TITLE
contrib/check-config: Only add color if output is a terminal.

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -25,6 +25,10 @@ if ! command -v zgrep > /dev/null 2>&1; then
 	}
 fi
 
+useColor=true
+if [ "$NO_COLOR" = "1" ] || [ ! -t 1 ]; then
+	useColor=false
+fi
 kernelVersion="$(uname -r)"
 kernelMajor="${kernelVersion%%.*}"
 kernelMinor="${kernelVersion#$kernelMajor.}"
@@ -41,6 +45,10 @@ is_set_as_module() {
 }
 
 color() {
+	# if stdout is not a terminal, then don't do color codes.
+	if [ "$useColor" = "false" ]; then
+		return 0
+	fi
 	codes=
 	if [ "$1" = 'bold' ]; then
 		codes='1'


### PR DESCRIPTION
Redirecting check-config.sh output to a file puts control character output into that file, which isn't helpful for reading.

If the program's stdout (fd 1) is not a terminal then skip the colors.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

   if output of 'check-config' is not a terminal, then turn off color

**- How I did it**

   use shell '[ -t  1]' which checks if stdout (fd 1) is a terminal

**- How to verify it**

    $ ./tools/check-config.sh > check.txt

    then look at check.txt, it should not have color codes.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

