### PR TITLE
daemon: use context.WithoutCancel in more places

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -48,6 +48,7 @@ import (
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
+	"github.com/docker/docker/internal/compatcontext"
 	"github.com/docker/docker/layer"
 	libcontainerdtypes "github.com/docker/docker/libcontainerd/types"
 	"github.com/docker/docker/libnetwork"
@@ -1212,14 +1213,16 @@ func (daemon *Daemon) waitForStartupDone() {
 }
 
 func (daemon *Daemon) shutdownContainer(c *container.Container) error {
+	ctx := compatcontext.WithoutCancel(context.TODO())
+
 	// If container failed to exit in stopTimeout seconds of SIGTERM, then using the force
-	if err := daemon.containerStop(context.TODO(), c, containertypes.StopOptions{}); err != nil {
+	if err := daemon.containerStop(ctx, c, containertypes.StopOptions{}); err != nil {
 		return fmt.Errorf("Failed to stop container %s with error: %v", c.ID, err)
 	}
 
 	// Wait without timeout for the container to exit.
 	// Ignore the result.
-	<-c.Wait(context.Background(), container.WaitConditionNotRunning)
+	<-c.Wait(ctx, container.WaitConditionNotRunning)
 	return nil
 }
 


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/45738

### daemon: daemon.containerStop: use context.WithoutCancel

Follow-up to fc94ed0a86dbac35f9e4cbdd778ead7bc2d53bf9 (https://github.com/moby/moby/pull/45738). Now that
f6e44bc0e82572885b5cfac3d2f67c583d657a07 (https://github.com/moby/moby/pull/46552) added the compatcontext
package, we can start using context.WithoutCancel.


### daemon: daemon.shutdownContainer: use context.WithoutCancel

Use context.WithoutCancel so that both the containerStop and
container.Wait can share the same parent context. This context is still
a "TODO", but can be wired up in future.

It's worth noting that daemon.containerStop already uses context.WithoutCancel,
so in that function, we'll be wrapping the context twice, but this should
likely not cause issues (just redundant for this code-path).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

