### PR TITLE
[20.10 backport] Go 1.20 Enablement

### DIFF
--- a/daemon/daemon_unix_test.go
+++ b/daemon/daemon_unix_test.go
@@ -356,6 +356,7 @@ func TestVerifyPlatformContainerResources(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			warnings, err := verifyPlatformContainerResources(&tc.resources, &tc.sysInfo, tc.update)

--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -1374,7 +1374,7 @@ func TestCollectBatchWithDuplicateTimestamps(t *testing.T) {
 	for i := 0; i < times; i++ {
 		line := fmt.Sprintf("%d", i)
 		if i%2 == 0 {
-			timestamp.Add(1 * time.Nanosecond)
+			timestamp = timestamp.Add(1 * time.Nanosecond)
 		}
 		stream.Log(&logger.Message{
 			Line:      []byte(line),

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -392,6 +392,7 @@ func TestMaxDownloadAttempts(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			layerStore := &mockLayerStore{make(map[layer.ChainID]*mockLayer)}

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -382,7 +382,7 @@ func TestMaxDownloadAttempts(t *testing.T) {
 			name:                "max-attempts=5, fail at 6th attempt",
 			simulateRetries:     6,
 			maxDownloadAttempts: 5,
-			expectedErr:         "simulating download attempt 5/6",
+			expectedErr:         "simulating download attempt 6/6",
 		},
 		{
 			name:                "max-attempts=0, fail after 1 attempt",

--- a/hack/dockerfile/install/golangci_lint.installer
+++ b/hack/dockerfile/install/golangci_lint.installer
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-: "${GOLANGCI_LINT_VERSION=v1.49.0}"
+: "${GOLANGCI_LINT_VERSION=v1.51.2}"
 
 install_golangci_lint() {
 	set -e

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -90,6 +90,7 @@ func TestBuildWithRemoveAndForceRemove(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 	for _, c := range cases {
+		c := c
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 			dockerfile := []byte(c.dockerfile)

--- a/integration/container/container_test.go
+++ b/integration/container/container_test.go
@@ -13,7 +13,6 @@ func TestContainerInvalidJSON(t *testing.T) {
 	defer setupTest(t)()
 
 	endpoints := []string{
-		"/containers/foobar/copy",
 		"/containers/foobar/exec",
 		"/exec/foobar/start",
 	}

--- a/integration/container/container_test.go
+++ b/integration/container/container_test.go
@@ -19,6 +19,7 @@ func TestContainerInvalidJSON(t *testing.T) {
 	}
 
 	for _, ep := range endpoints {
+		ep := ep
 		t.Run(ep, func(t *testing.T) {
 			t.Parallel()
 

--- a/integration/network/network_test.go
+++ b/integration/network/network_test.go
@@ -72,6 +72,7 @@ func TestNetworkInvalidJSON(t *testing.T) {
 	}
 
 	for _, ep := range endpoints {
+		ep := ep
 		t.Run(ep, func(t *testing.T) {
 			t.Parallel()
 
@@ -105,6 +106,7 @@ func TestNetworkList(t *testing.T) {
 	}
 
 	for _, ep := range endpoints {
+		ep := ep
 		t.Run(ep, func(t *testing.T) {
 			t.Parallel()
 

--- a/integration/plugin/common/plugin_test.go
+++ b/integration/plugin/common/plugin_test.go
@@ -35,6 +35,7 @@ func TestPluginInvalidJSON(t *testing.T) {
 	endpoints := []string{"/plugins/foobar/set"}
 
 	for _, ep := range endpoints {
+		ep := ep
 		t.Run(ep, func(t *testing.T) {
 			t.Parallel()
 

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -110,6 +110,7 @@ func TestVolumesInvalidJSON(t *testing.T) {
 	endpoints := []string{"/volumes/create"}
 
 	for _, ep := range endpoints {
+		ep := ep
 		t.Run(ep, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -599,7 +599,7 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 			}
 		}
 
-	case tar.TypeReg, tar.TypeRegA:
+	case tar.TypeReg:
 		// Source is regular file. We use system.OpenFileSequential to use sequential
 		// file access to avoid depleting the standby list on Windows.
 		// On Linux, this equates to a regular os.OpenFile


### PR DESCRIPTION
- Prerequisite of #46692

(Partial) backports of the following to 20.10:
- #42874
- #42666 
- #45004
- #45007
- #45062 (yes, backport of a backport)
- #45063

The cherry-picks all applied cleanly enough, so might as well keep linting happy on the 20.10 branch.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

