### PR TITLE
[24.0 backport] daemon: release sandbox even when NetworkDisabled

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -1027,10 +1027,17 @@ func (daemon *Daemon) getNetworkedContainer(containerID, connectedContainerID st
 
 func (daemon *Daemon) releaseNetwork(container *container.Container) {
 	start := time.Now()
+	// If live-restore is enabled, the daemon cleans up dead containers when it starts up. In that case, the
+	// netController hasn't been initialized yet and so we can't proceed.
+	// TODO(aker): If we hit this case, the endpoint state won't be cleaned up (ie. no call to cleanOperationalData).
 	if daemon.netController == nil {
 		return
 	}
-	if container.HostConfig.NetworkMode.IsContainer() || container.Config.NetworkDisabled {
+	// If the container uses the network namespace of another container, it doesn't own it -- nothing to do here.
+	if container.HostConfig.NetworkMode.IsContainer() {
+		return
+	}
+	if container.NetworkSettings == nil {
 		return
 	}
 


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/46651
- Fix https://github.com/moby/moby/issues/42461
- Fix https://github.com/moby/moby/issues/46583
- Closes https://github.com/moby/moby/pull/42454. Commit message has been improved and a couple comments have been added.

**- What I did**

When the default bridge is disabled by setting dockerd's `--bridge=none` option, the daemon still creates a sandbox for containers with no network attachment specified. In that case `NetworkDisabled` will be set to true.

However, currently the `releaseNetwork` call will early return if NetworkDisabled is true. Thus, these sandboxes won't be deleted until the daemon is restarted. If a high number of such containers are created, the daemon would then take few minutes to start.

As a side note, `NetworkDisabled` semantics is weird/broken and should be revised:

* On one hand a sandbox is created even if `NetworkDisbled` is set. Thus it allows these containers to be manually connected to other networks;
* OTOH, when manually connecting such container to a network nothing happens and no error is returned (ie. no interface and no route provisioned, no embedded DNS, etc...);

**- Description for the changelog**

* Fix a bug that would prevent network sandboxes to be properly deleted when stopping containers with no network attachment are specified and dockerd's `--bridge=none` option is specified.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://hips.hearstapps.com/goodhousekeeping-uk/main/embedded/21976/giant_panda_bear-snow-good_housekeeping_uk.jpg?crop=1xw:0.75xh;center,top&resize=1200:*)
