### PR TITLE
DNM: PoC Always set a userns

### DIFF
--- a/integration/container/default_userns_privs_test.go
+++ b/integration/container/default_userns_privs_test.go
@@ -1,0 +1,58 @@
+package container // import "github.com/docker/docker/integration/container"
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/integration/internal/container"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/icmd"
+)
+
+func TestDefaultUsernsPrivs(t *testing.T) {
+	ctx := setupTest(t)
+
+	apiClient := testEnv.APIClient()
+
+	// Make sure that 2 privileged containers have the same user namespace
+	hostNs1Res := container.RunAttach(ctx, t, apiClient, container.WithPrivileged(true), container.WithCmd("readlink", "/proc/self/ns/user"))
+	assert.Equal(t, hostNs1Res.ExitCode, 0)
+	hostns1 := strings.TrimSpace(hostNs1Res.Stdout.String())
+	assert.Assert(t, hostns1 != "", "user namespace should not be empty")
+
+	hostNs2Res := container.RunAttach(ctx, t, apiClient, container.WithPrivileged(true), container.WithCmd("readlink", "/proc/self/ns/user"))
+	assert.Equal(t, hostNs2Res.ExitCode, 0)
+	hostns2 := strings.TrimSpace(hostNs1Res.Stdout.String())
+	assert.Assert(t, hostns2 != "", "user namespace should not be empty")
+
+	assert.Equal(t, hostns1, hostns2, "privileged user namespaces should be the same")
+
+	if testEnv.IsLocalDaemon() {
+		// Make sure the privileged container has the same user namespace as the host
+		res := icmd.RunCommand("readlink", "/proc/self/ns/user")
+		res.Assert(t, icmd.Success)
+
+		out := strings.TrimSpace(res.Combined())
+		assert.NilError(t, res.Error, string(out))
+		assert.Equal(t, hostns1, out, "privileged user namespace should be the same as the host")
+	}
+
+	res := container.RunAttach(ctx, t, apiClient, container.WithCmd("readlink", "/proc/self/ns/user"))
+	assert.Equal(t, res.ExitCode, 0, res.Stderr)
+	cUserns := strings.TrimSpace(res.Stdout.String())
+	assert.Assert(t, cUserns != "", "user namespace should not be empty")
+	assert.Assert(t, cUserns != hostns1, "user namespace should not be the same as the host")
+
+	cmd := `
+set -e
+mkdir /test1
+mkdir /test2
+touch /test1/hello
+mount --bind /test1 /test2
+[ -f /test2/hello ]
+`
+
+	// TODO: For some reason this is failing in the test env but works just fine when running manually.
+	res = container.RunAttach(ctx, t, apiClient, container.WithCmd("sh", "-c", cmd))
+	assert.Equal(t, res.ExitCode, 0, res.Stderr)
+}

--- a/oci/caps/defaults.go
+++ b/oci/caps/defaults.go
@@ -3,6 +3,7 @@ package caps // import "github.com/docker/docker/oci/caps"
 // DefaultCapabilities returns a Linux kernel default capabilities
 func DefaultCapabilities() []string {
 	return []string{
+		"CAP_SYS_ADMIN",
 		"CAP_CHOWN",
 		"CAP_DAC_OVERRIDE",
 		"CAP_FSETID",


### PR DESCRIPTION
This is basically doing 2 things:

1. Always put a container in a new user namespace
2. Grant CAP_SYS_ADMIN by default

This makes it so all containers, unless specically requesting the host namespace with `--privileged` or `--userns=host`, are placed into a new user namespace. UIDs and GIDs are mapped 1:1, so uid 0 in the userns is uid 0 on the host.

The main thing this buys us is the containerized process no longer has privileges in the root userns which also allows us to safely(???) grant extra privileges to the container.

Specifically what's nice about this is now a containerized process can do bind and fuse mounts, and possibly overlay depending on which kernel you are running (ubuntu kernel allows unprivileged overlay mounts).

This *should* actually be more secure than allowing the container to run in the host namespace.
Even if we don't grant CAP_SYS_ADMIN it may still be a good change because it removes all privilege from the root namespace.

---


As noted in the test, this `mount` call still seems to be failing but *only* in the test environment (AFAICT). It seems to run fine for me if I just spin up a container and run the exact commands.
