### PR TITLE
pkg/archive, pkg/tarsum: replace use of Xattrs with PAXRecords

### DIFF
--- a/hack/validate/golangci-lint.yml
+++ b/hack/validate/golangci-lint.yml
@@ -113,10 +113,6 @@ issues:
       path: "api/types/(volume|container)/"
       linters:
         - revive
-    # FIXME temporarily suppress these. See #39924
-    - text: "SA1019: .*\\.Xattrs has been deprecated since Go 1.10: Use PAXRecords instead"
-      linters:
-        - staticcheck
     # FIXME temporarily suppress these. See #39926
     - text: "SA1019: httputil.NewClientConn"
       linters:

--- a/pkg/archive/archive_linux.go
+++ b/pkg/archive/archive_linux.go
@@ -41,9 +41,7 @@ func (overlayWhiteoutConverter) ConvertWrite(hdr *tar.Header, path string, fi os
 			return nil, err
 		}
 		if len(opaque) == 1 && opaque[0] == 'y' {
-			if hdr.Xattrs != nil {
-				delete(hdr.Xattrs, "trusted.overlay.opaque")
-			}
+			delete(hdr.PAXRecords, paxSchilyXattr+"trusted.overlay.opaque")
 
 			// create a header for the whiteout file
 			// it should inherit some properties from the parent, but be a regular file

--- a/pkg/tarsum/versioning.go
+++ b/pkg/tarsum/versioning.go
@@ -115,15 +115,18 @@ func v0TarHeaderSelect(h *tar.Header) (orderedHeaders [][2]string) {
 
 func v1TarHeaderSelect(h *tar.Header) (orderedHeaders [][2]string) {
 	// Get extended attributes.
-	xAttrKeys := make([]string, len(h.Xattrs))
-	for k := range h.Xattrs {
-		xAttrKeys = append(xAttrKeys, k)
+	const paxSchilyXattr = "SCHILY.xattr."
+	var xattrs [][2]string
+	for k, v := range h.PAXRecords {
+		if xattr, ok := strings.CutPrefix(k, paxSchilyXattr); ok {
+			xattrs = append(xattrs, [2]string{xattr, v})
+		}
 	}
-	sort.Strings(xAttrKeys)
+	sort.Slice(xattrs, func(i, j int) bool { return xattrs[i][0] < xattrs[j][0] })
 
 	// Make the slice with enough capacity to hold the 11 basic headers
 	// we want from the v0 selector plus however many xattrs we have.
-	orderedHeaders = make([][2]string, 0, 11+len(xAttrKeys))
+	orderedHeaders = make([][2]string, 0, 11+len(xattrs))
 
 	// Copy all headers from v0 excluding the 'mtime' header (the 5th element).
 	v0headers := v0TarHeaderSelect(h)
@@ -131,9 +134,7 @@ func v1TarHeaderSelect(h *tar.Header) (orderedHeaders [][2]string) {
 	orderedHeaders = append(orderedHeaders, v0headers[6:]...)
 
 	// Finally, append the sorted xattrs.
-	for _, k := range xAttrKeys {
-		orderedHeaders = append(orderedHeaders, [2]string{k, h.Xattrs[k]})
-	}
+	orderedHeaders = append(orderedHeaders, xattrs...)
 
 	return
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- Fixes #39924

**- What I did**
Replaced use of Xattrs with PAXRecords.

**- How I did it**
Extended the pkg/archive unit tests to verify that these changes do not introduce any regressions in xattr handling. And I checked that the tests fail as expected when the handling of extended attributes is deliberately broken. (No changes to the pkg/tarsum tests were required.)

**- How to verify it**
CI is green.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

