### PR TITLE
docs(API): Add reason to network connect 403 error

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -10084,6 +10084,7 @@ paths:
   /networks/{id}/connect:
     post:
       summary: "Connect a container to a network"
+      description: "The network must be either a local-scoped network or a swarm-scoped network with the `attachable` option set. A network cannot be re-attached to a running container"
       operationId: "NetworkConnect"
       consumes:
         - "application/json"
@@ -10095,7 +10096,7 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
         403:
-          description: "Operation not supported for swarm scoped networks"
+          description: "Operation forbidden"
           schema:
             $ref: "#/definitions/ErrorResponse"
         404:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I documented another case in which the 403 error might be returned for the network connect endpoint. In addition to unsupported swarm operations, it is also returned when the given container is already connected to the network and is currently running. I noticed this when during the following PR: https://github.com/containers/podman/pull/20365

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Documented that the network connect API endpoint returns a 403 error if the container is currently running and already connected to the given network.


**- A picture of a cute animal (not mandatory but encouraged)**

