### PR TITLE
c8d/exec: Add additional groups on exec

### DIFF
--- a/daemon/exec_linux.go
+++ b/daemon/exec_linux.go
@@ -41,6 +41,7 @@ func getUserFromContainerd(ctx context.Context, containerdCli *containerd.Client
 		coci.WithUser(ec.User),
 		withResetAdditionalGIDs(),
 		coci.WithAdditionalGIDs(ec.User),
+		coci.WithAppendAdditionalGroups(ec.Container.HostConfig.GroupAdd...),
 	}
 	for _, opt := range opts {
 		if err := opt(ctx, containerdCli, &cinfo, spec); err != nil {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Closes #46712

**- What I did**

Add configured additional groups from the container's host config on exec.

**- How I did it**

With 1 extra line!

**- How to verify it**

1. `docker run -d --name test --user root:root --group-add staff --group-add wheel --group-add audio --group-add 777 busybox top`
2. `docker exec test id`
3. (find expected groups)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

``

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="497" alt="image" src="https://github.com/moby/moby/assets/70572044/ed1942ad-835c-4b3c-8ace-b6d761ab2c06">


