### PR TITLE
c8d: show the real image creation date when listing images

### DIFF
--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -29,6 +29,9 @@ import (
 
 // Subset of ocispec.Image that only contains Labels
 type configLabels struct {
+	// Created is the combined date and time at which the image was created, formatted as defined by RFC 3339, section 5.6.
+	Created *time.Time `json:"created,omitempty"`
+
 	Config struct {
 		Labels map[string]string `json:"Labels,omitempty"`
 	} `json:"config,omitempty"`
@@ -277,9 +280,8 @@ func (i *ImageService) singlePlatformImage(ctx context.Context, contentStore con
 	}
 
 	summary := &imagetypes.Summary{
-		ParentID:    "",
+		ParentID:    rawImg.Labels[imageLabelClassicBuilderParent],
 		ID:          target.String(),
-		Created:     rawImg.CreatedAt.Unix(),
 		RepoDigests: repoDigests,
 		RepoTags:    repoTags,
 		Size:        totalSize,
@@ -290,6 +292,9 @@ func (i *ImageService) singlePlatformImage(ctx context.Context, contentStore con
 		// consider both "0" and "nil" to be "empty".
 		SharedSize: -1,
 		Containers: -1,
+	}
+	if cfg.Created != nil {
+		summary.Created = cfg.Created.Unix()
 	}
 
 	if opts.ContainerCount {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Used the creation date of the imge from the config and not from the containerd metadata,

```diff
$ docker pull busybox
$ docker images      
REPOSITORY   TAG       IMAGE ID       CREATED        SIZE
-busybox      latest    3fbc63216742   20 seconds ago   6.61MB
+busybox      latest    3fbc63216742   3 months ago   6.61MB
```

Also set the `ParentID` to whatever we find in the image labels

**- How I did it**

**- How to verify it**


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

