### PR TITLE
daemon: remove redundant withResetAdditionalGIDs option

### DIFF
--- a/daemon/exec_linux.go
+++ b/daemon/exec_linux.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/oci"
 	coci "github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/pkg/apparmor"
@@ -13,13 +12,6 @@ import (
 	"github.com/docker/docker/oci/caps"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
-
-func withResetAdditionalGIDs() oci.SpecOpts {
-	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *oci.Spec) error {
-		s.Process.User.AdditionalGids = nil
-		return nil
-	}
-}
 
 func getUserFromContainerd(ctx context.Context, containerdCli *containerd.Client, ec *container.ExecConfig) (specs.User, error) {
 	ctr, err := containerdCli.LoadContainer(ctx, ec.Container.ID)
@@ -39,7 +31,6 @@ func getUserFromContainerd(ctx context.Context, containerdCli *containerd.Client
 
 	opts := []oci.SpecOpts{
 		coci.WithUser(ec.User),
-		withResetAdditionalGIDs(),
 		coci.WithAdditionalGIDs(ec.User),
 		coci.WithAppendAdditionalGroups(ec.Container.HostConfig.GroupAdd...),
 	}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/46715#discussion_r1371301755


containerd's `WithUser` function now resets this property, starting with [3eda46af12b1deedab3d0802adb2e81cb3521950][1] (v1.7.0-beta.4), so we no longer need this function.

[1]: https://github.com/containerd/containerd/commit/3eda46af12b1deedab3d0802adb2e81cb3521950

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

