### PR TITLE
New `host_ipv6` bridge option to SNAT IPv6 connections

### DIFF
--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -74,6 +74,7 @@ type networkConfiguration struct {
 	DefaultBindingIP     net.IP
 	DefaultBridge        bool
 	HostIPv4             net.IP
+	HostIPv6             net.IP
 	ContainerIfacePrefix string
 	// Internal fields set after ipam data parsing
 	AddressIPv4        *net.IPNet
@@ -268,6 +269,10 @@ func (c *networkConfiguration) fromLabels(labels map[string]string) error {
 			c.ContainerIfacePrefix = value
 		case netlabel.HostIPv4:
 			if c.HostIPv4 = net.ParseIP(value); c.HostIPv4 == nil {
+				return parseErr(label, value, "nil ip")
+			}
+		case netlabel.HostIPv6:
+			if c.HostIPv6 = net.ParseIP(value); c.HostIPv6 == nil {
 				return parseErr(label, value, "nil ip")
 			}
 		}

--- a/libnetwork/drivers/bridge/bridge_store.go
+++ b/libnetwork/drivers/bridge/bridge_store.go
@@ -148,6 +148,7 @@ func (ncfg *networkConfiguration) MarshalJSON() ([]byte, error) {
 	nMap["DefaultBindingIP"] = ncfg.DefaultBindingIP.String()
 	// This key is "HostIP" instead of "HostIPv4" to preserve compatibility with the on-disk format.
 	nMap["HostIP"] = ncfg.HostIPv4.String()
+	nMap["HostIPv6"] = ncfg.HostIPv6.String()
 	nMap["DefaultGatewayIPv4"] = ncfg.DefaultGatewayIPv4.String()
 	nMap["DefaultGatewayIPv6"] = ncfg.DefaultGatewayIPv6.String()
 	nMap["ContainerIfacePrefix"] = ncfg.ContainerIfacePrefix
@@ -193,6 +194,9 @@ func (ncfg *networkConfiguration) UnmarshalJSON(b []byte) error {
 	// This key is "HostIP" instead of "HostIPv4" to preserve compatibility with the on-disk format.
 	if v, ok := nMap["HostIP"]; ok {
 		ncfg.HostIPv4 = net.ParseIP(v.(string))
+	}
+	if v, ok := nMap["HostIPv6"]; ok {
+		ncfg.HostIPv6 = net.ParseIP(v.(string))
 	}
 
 	ncfg.DefaultBridge = nMap["DefaultBridge"].(bool)

--- a/libnetwork/drivers/bridge/setup_ip_tables_linux.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux.go
@@ -258,9 +258,13 @@ func setupIPTablesInternal(ipVer iptables.IPVersion, config *networkConfiguratio
 		natArgs   []string
 		hpNatArgs []string
 	)
-	// If config.HostIPv4 is set, the user wants IPv4 SNAT with the given address.
-	if config.HostIPv4 != nil && ipVer == iptables.IPv4 {
-		hostAddr := config.HostIPv4.String()
+	hostIP := config.HostIPv4
+	if ipVer == iptables.IPv6 {
+		hostIP = config.HostIPv6
+	}
+	// If hostIP is set, the user wants IPv4/IPv6 SNAT with the given address.
+	if hostIP != nil {
+		hostAddr := hostIP.String()
 		natArgs = []string{"-s", address, "!", "-o", config.BridgeName, "-j", "SNAT", "--to-source", hostAddr}
 		hpNatArgs = []string{"-m", "addrtype", "--src-type", "LOCAL", "-o", config.BridgeName, "-j", "SNAT", "--to-source", hostAddr}
 		// Else use MASQUERADE which picks the src-ip based on NH from the route table

--- a/libnetwork/netlabel/labels.go
+++ b/libnetwork/netlabel/labels.go
@@ -47,6 +47,9 @@ const (
 	// HostIPv4 is the Source-IPv4 Address used to SNAT IPv4 container traffic
 	HostIPv4 = Prefix + ".host_ipv4"
 
+	// HostIPv6 is the Source-IPv6 Address used to SNAT IPv6 container traffic
+	HostIPv6 = Prefix + ".host_ipv6"
+
 	// LocalKVClient constants represents the local kv store client
 	LocalKVClient = DriverPrivatePrefix + "localkv_client"
 )


### PR DESCRIPTION
**- What I did**

This PR adds a new `com.docker.network.host_ipv6` bridge option to compliment the existing `com.docker.network.host_ipv4` option. When set to an IPv6 address, this causes the bridge to insert `SNAT` rules instead of `MASQUERADE` rules (assuming `ip6tables` is enabled).  `SNAT` makes it possible for users to control the source IP address used for outgoing connections.

fixes #46469

**- How I did it**

Copied the approach taken by `com.docker.network.host_ipv4`.

**- How to verify it**

```shell
# Assumptions:
#   - desired_ipv6_subnet is set to your favorite ULA subnet
#   - desired_ipv6_addr is set to any global IPv6 address that routes to the host

dockerd --experimental --ip6tables
docker network create \
    -d bridge \
    --ipv6 \
    --subnet "${desired_ipv6_subnet?}" \
    --opt com.docker.network.host_ipv6="${desired_ipv6_addr?}" \
    bridge1
docker network inspect bridge1
ip6tables -t nat -L POSTROUTING
docker run --rm --network bridge1 heywoodlh/dnsutils \
    dig @one.one.one.one -6 -c ch -t txt whoami.cloudflare +short
```

**- Description for the changelog**

New `com.docker.network.host_ipv6` bridge option to control the IPv6 address used for outgoing connections.
