### PR TITLE
c8d/history: Fix nil dereference

### DIFF
--- a/daemon/containerd/image_history.go
+++ b/daemon/containerd/image_history.go
@@ -81,11 +81,15 @@ func (i *ImageService) ImageHistory(ctx context.Context, name string) ([]*imaget
 			sizes = sizes[1:]
 		}
 
+		var created int64
+		if h.Created != nil {
+			created = h.Created.Unix()
+		}
 		history = append([]*imagetype.HistoryResponseItem{{
 			ID:        "<missing>",
 			Comment:   h.Comment,
 			CreatedBy: h.CreatedBy,
-			Created:   h.Created.Unix(),
+			Created:   created,
 			Size:      size,
 			Tags:      nil,
 		}}, history...)


### PR DESCRIPTION
Check if `Created` is not nil before dereferencing.

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

