### PR TITLE
exec/tests: add test for `--group-add` with `--user`

### DIFF
--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -2,6 +2,7 @@ package container // import "github.com/docker/docker/integration/container"
 
 import (
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -135,4 +136,24 @@ func TestExecUser(t *testing.T) {
 	assert.NilError(t, err)
 
 	assert.Assert(t, is.Contains(result.Stdout(), "uid=1(daemon) gid=1(daemon)"), "exec command not running as uid/gid 1")
+}
+
+// Test that additional groups set with `--group-add` are kept on exec when the container
+// also has a user set.
+// (regression test for https://github.com/moby/moby/issues/46712)
+func TestExecWithGroupAdd(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.39"), "broken in earlier versions")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME. Probably needs to wait for container to be in running state.")
+
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	cID := container.Run(ctx, t, apiClient, container.WithTty(true), container.WithUser("root:root"), container.WithAdditionalGroups("staff", "wheel", "audio", "777"), container.WithCmd("sleep", "5"))
+
+	result, err := container.Exec(ctx, apiClient, cID, []string{"id"})
+	assert.NilError(t, err)
+
+	assert.Assert(t,
+		is.Equal(strings.TrimSpace(result.Stdout()), "uid=0(root) gid=0(root) groups=0(root),10(wheel),29(audio),50(staff),777"),
+		"exec command not keeping additional groups w/ user")
 }

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -193,6 +193,13 @@ func WithUser(user string) func(c *TestContainerConfig) {
 	}
 }
 
+// WithAdditionalGroups sets the additional groups for the container
+func WithAdditionalGroups(groups ...string) func(c *TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.HostConfig.GroupAdd = groups
+	}
+}
+
 // WithPrivileged sets privileged mode for the container
 func WithPrivileged(privileged bool) func(*TestContainerConfig) {
 	return func(c *TestContainerConfig) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**Related:**
- https://github.com/moby/moby/issues/46712

Closes https://github.com/moby/moby/issues/46721

**- What I did**

Adds test ensuring that additional groups set with `--group-add` are kept on exec when container had `--user` set on run.

Regression test for https://github.com/moby/moby/issues/46712

**- How I did it**

**- How to verify it**

```
make DOCKER_GRAPHDRIVER=overlayfs TEST_FILTER=TestExecWithGroupAdd TEST_INTEGRATION_USE_SNAPSHOTTER=1 TEST_IGNORE_CGROUP_CHECK=1 test-integration
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/moby/moby/assets/70572044/be5da3eb-6cf6-448e-a1ff-7206c3616068)
