### PR TITLE
c8d/push: Return error when repository has no tags

### DIFF
--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -53,6 +53,10 @@ func (i *ImageService) PushImage(ctx context.Context, sourceRef reference.Named,
 				return err
 			}
 
+			if len(imgs) == 0 {
+				return fmt.Errorf("An image does not exist locally with the tag: %s", reference.FamiliarName(sourceRef))
+			}
+
 			for _, img := range imgs {
 				named, err := reference.ParseNamed(img.Name)
 				if err != nil {


### PR DESCRIPTION
In case of `docker push -a`, we need to return an error if there is no image for the given repository.


**- What I did**

**- How I did it**

**- How to verify it**
`TestPushUntagged` should pass now

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

