### PR TITLE
builder-next: make sure worker platforms normalized for containerd

### DIFF
--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -10,6 +10,7 @@ import (
 	ctd "github.com/containerd/containerd"
 	"github.com/containerd/containerd/content/local"
 	ctdmetadata "github.com/containerd/containerd/metadata"
+	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/types"
@@ -103,6 +104,11 @@ func newSnapshotterController(ctx context.Context, rt http.RoundTripper, opt Opt
 	policy, err := getGCPolicy(opt.BuilderConfig, opt.Root)
 	if err != nil {
 		return nil, err
+	}
+
+	// make sure platforms are normalized moby/buildkit#4391
+	for i, p := range wo.Platforms {
+		wo.Platforms[i] = platforms.Normalize(p)
 	}
 
 	wo.GCPolicy = policy


### PR DESCRIPTION
These platforms are filled by default from containerd introspection API and may not be normalized. Initializing the wrong platform here results in an incorrect platform for BUILDPLATFORM and TARGETPLATFORM build-args for Dockerfile frontend (and probably other side effects).

This can be removed after https://github.com/moby/buildkit/pull/4391 is vendored.