### PR TITLE
daemon: improve daemon start informational log message

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1195,9 +1195,10 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	engineMemory.Set(float64(info.MemTotal))
 
 	log.G(ctx).WithFields(log.Fields{
-		"version":     dockerversion.Version,
-		"commit":      dockerversion.GitCommit,
-		"graphdriver": d.ImageService().StorageDriver(),
+		"version":                dockerversion.Version,
+		"commit":                 dockerversion.GitCommit,
+		"storage-driver":         d.ImageService().StorageDriver(),
+		"containerd-snapshotter": d.UsesSnapshotter(),
 	}).Info("Docker daemon")
 
 	return d, nil


### PR DESCRIPTION
When starting a daemon in debug mode (such as used in CI), many log-messages are printed during startup. As a result, the log message indicating whether graph-drivers or snapshotters are used may appear far separate from the informational log about the daemon (and selected storage-driver).

The existing log-driver also unconditionally uses the legacy "graph-driver" terminology, instead of the more generic "storage-driver".

This patch changes the log message shown during startup to use the generic "graph-driver" as field, and adds a new field that indicates wheter we're using snapshotters or graph-drivers.

Given that snapshotters will be the default at some point, an alternative could be to include the _type_ of driver used, for example; `io.containerd.snapshotter.v1`, which may continue to be relevant after snapshotters become the default, and at which point (potentially) the type of snapshotter becomes more relevant.

Before this change:

    TEST_INTEGRATION_USE_SNAPSHOTTER=1 DOCKER_GRAPHDRIVER=overlayfs dockerd
    ...
    INFO[2023-10-31T09:12:33.586269801Z] Starting daemon with containerd snapshotter integration enabled
    INFO[2023-10-31T09:12:33.586322176Z] Loading containers: start.
    INFO[2023-10-31T09:12:33.640514759Z] Loading containers: done.
    INFO[2023-10-31T09:12:33.646498134Z] Docker daemon                                 commit=dcf7287d647bcb515015e389df46ccf1e09855b7 graphdriver=overlayfs version=dev
    INFO[2023-10-31T09:12:33.646706551Z] Daemon has completed initialization
    INFO[2023-10-31T09:12:33.658840592Z] API listen on /var/run/docker.sock

With this change;

    TEST_INTEGRATION_USE_SNAPSHOTTER=1 DOCKER_GRAPHDRIVER=overlayfs dockerd
    ...
    INFO[2023-10-31T08:41:38.841155928Z] Starting daemon with containerd snapshotter integration enabled
    INFO[2023-10-31T08:41:38.841207512Z] Loading containers: start.
    INFO[2023-10-31T08:41:38.902461053Z] Loading containers: done.
    INFO[2023-10-31T08:41:38.910535137Z] Docker daemon                                 commit=dcf7287d647bcb515015e389df46ccf1e09855b7 containerd-snapshotter=true storage-driver=overlayfs version=dev
    INFO[2023-10-31T08:41:38.910936803Z] Daemon has completed initialization

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

