### PR TITLE
integration: make TestSaveRepoWithMultipleImages less flaky

### DIFF
--- a/integration/image/save_test.go
+++ b/integration/image/save_test.go
@@ -2,7 +2,6 @@ package image
 
 import (
 	"archive/tar"
-	"context"
 	"encoding/json"
 	"io"
 	"io/fs"
@@ -86,23 +85,10 @@ func TestSaveRepoWithMultipleImages(t *testing.T) {
 	client := testEnv.APIClient()
 
 	makeImage := func(from string, tag string) string {
-		id := container.Run(ctx, t, client, func(cfg *container.TestContainerConfig) {
+		id := container.Create(ctx, t, client, func(cfg *container.TestContainerConfig) {
 			cfg.Config.Image = from
 			cfg.Config.Cmd = []string{"true"}
 		})
-
-		chW, chErr := client.ContainerWait(ctx, id, containertypes.WaitConditionNotRunning)
-
-		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		defer cancel()
-
-		select {
-		case <-chW:
-		case err := <-chErr:
-			assert.NilError(t, err)
-		case <-ctx.Done():
-			t.Fatal("timeout waiting for container to exit")
-		}
 
 		res, err := client.ContainerCommit(ctx, id, containertypes.CommitOptions{Reference: tag})
 		assert.NilError(t, err)

--- a/integration/image/save_test.go
+++ b/integration/image/save_test.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/cpuguy83/tar2go"
-	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/integration/internal/build"
 	"github.com/docker/docker/integration/internal/container"
@@ -109,8 +108,6 @@ func TestSaveRepoWithMultipleImages(t *testing.T) {
 	idFoo := makeImage("busybox:latest", tagFoo)
 	idBar := makeImage("busybox:latest", tagBar)
 	idBusybox := busyboxImg.ID
-
-	client.ImageRemove(ctx, repoName, types.ImageRemoveOptions{Force: true})
 
 	rdr, err := client.ImageSave(ctx, []string{repoName, "busybox:latest"})
 	assert.NilError(t, err)

--- a/integration/image/save_test.go
+++ b/integration/image/save_test.go
@@ -101,9 +101,9 @@ func TestSaveRepoWithMultipleImages(t *testing.T) {
 	busyboxImg, _, err := client.ImageInspectWithRaw(ctx, "busybox:latest")
 	assert.NilError(t, err)
 
-	repoName := "foobar-save-multi-images-test"
-	tagFoo := repoName + ":foo"
-	tagBar := repoName + ":bar"
+	const repoName = "foobar-save-multi-images-test"
+	const tagFoo = repoName + ":foo"
+	const tagBar = repoName + ":bar"
 
 	idFoo := makeImage("busybox:latest", tagFoo)
 	idBar := makeImage("busybox:latest", tagBar)
@@ -125,8 +125,8 @@ func TestSaveRepoWithMultipleImages(t *testing.T) {
 	for _, m := range mfstLs {
 		actual = append(actual, strings.TrimPrefix(m.Config, "blobs/sha256/"))
 		// make sure the blob actually exists
-		_, err := fs.Stat(tarfs, m.Config)
-		assert.Check(t, cmp.Nil(err))
+		_, err = fs.Stat(tarfs, m.Config)
+		assert.Check(t, err)
 	}
 
 	expected := []string{idBusybox, idFoo, idBar}
@@ -141,8 +141,8 @@ func TestSaveRepoWithMultipleImages(t *testing.T) {
 		// ID of image won't match the Config ID from manifest.json
 		// Just check if manifests exist in blobs
 		for _, blob := range expected {
-			_, err := fs.Stat(tarfs, "blobs/sha256/"+blob)
-			assert.Check(t, cmp.Nil(err))
+			_, err = fs.Stat(tarfs, "blobs/sha256/"+blob)
+			assert.Check(t, err)
 		}
 	} else {
 		sort.Strings(actual)


### PR DESCRIPTION
### integration: make TestSaveRepoWithMultipleImages less flaky

Shutting down containers on Windows can take a long time (with hyper-v),
causing this test to be flaky; seen failing on windows 2022;

    === FAIL: github.com/docker/docker/integration/image TestSaveRepoWithMultipleImages (23.16s)
        save_test.go:104: timeout waiting for container to exit

Looking at the test, we run a container only to commit it, and the test
does not make changes to the container's filesystem; it only runs a container
with a custom command (`true`).

Instead of running the container, we can _create_ a container and commit it;
this simplifies the tests, and prevents having to wait for the container to
exit (before committing).

To verify:

    make BIND_DIR=. DOCKER_GRAPHDRIVER=vfs TEST_FILTER=TestSaveRepoWithMultipleImages test-integration
    
    INFO: Testing against a local daemon
    === RUN   TestSaveRepoWithMultipleImages
    --- PASS: TestSaveRepoWithMultipleImages (1.20s)
    PASS
    
    DONE 1 tests in 2.668s


### integration: TestSaveRepoWithMultipleImages remove redundant remove

This delete was originally added in b37fdc5dd1db196209ebb860c88a37d67bb2cf98
and migrated from `deleteImages(repoName)` in commit 1e55ace87549a874a552e60e43b1bf62575e9c83,
however, deleting `foobar-save-multi-images-test` (`foobar-save-multi-images-test:latest`)
always resulted in an error;

    Error response from daemon: No such image: foobar-save-multi-images-test:latest

This patch removes the redundant image delete.

### integration: TestSaveRepoWithMultipleImages: minor cleanup

- use consts for fixed values
- remove redundant `cmp.Nil(err)`

**- A picture of a cute animal (not mandatory but encouraged)**

