### PR TITLE
libnetwork/diagnostic: clean up Server type

### DIFF
--- a/libnetwork/agent.go
+++ b/libnetwork/agent.go
@@ -332,7 +332,7 @@ func (c *Controller) agentInit(listenAddr, bindAddrOrInterface, advertiseAddr, d
 	}
 
 	// Register the diagnostic handlers
-	c.DiagnosticServer.RegisterHandler(nDB, networkdb.NetDbPaths2Func)
+	nDB.RegisterDiagnosticHandlers(c.DiagnosticServer)
 
 	var cancelList []func()
 	ch, cancel := nDB.Watch(libnetworkEPTable, "")

--- a/libnetwork/cmd/networkdb-test/dbserver/ndbServer.go
+++ b/libnetwork/cmd/networkdb-test/dbserver/ndbServer.go
@@ -21,11 +21,7 @@ var (
 	ipAddr string
 )
 
-var testerPaths2Func = map[string]diagnostic.HTTPHandlerFunc{
-	"/myip": ipaddress,
-}
-
-func ipaddress(ctx interface{}, w http.ResponseWriter, r *http.Request) {
+func ipaddress(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "%s\n", ipAddr)
 }
 
@@ -63,9 +59,9 @@ func Server(args []string) {
 	}
 
 	// Register network db handlers
-	server.RegisterHandler(nDB, networkdb.NetDbPaths2Func)
-	server.RegisterHandler(nil, testerPaths2Func)
-	server.RegisterHandler(nDB, dummyclient.DummyClientPaths2Func)
+	nDB.RegisterDiagnosticHandlers(server)
+	server.HandleFunc("/myip", ipaddress)
+	dummyclient.RegisterDiagnosticHandlers(server, nDB)
 	server.EnableDiagnostic("", port)
 	// block here
 	select {}

--- a/libnetwork/cmd/networkdb-test/dbserver/ndbServer.go
+++ b/libnetwork/cmd/networkdb-test/dbserver/ndbServer.go
@@ -52,7 +52,6 @@ func Server(args []string) {
 	log.G(context.TODO()).Infof("%s uses IP %s\n", localNodeName, ipAddr)
 
 	server = diagnostic.New()
-	server.Init()
 	conf := networkdb.DefaultConfig()
 	conf.Hostname = localNodeName
 	conf.AdvertiseAddr = ipAddr

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -115,7 +115,6 @@ func New(cfgOptions ...config.Option) (*Controller, error) {
 		networkLocker:    locker.New(),
 		DiagnosticServer: diagnostic.New(),
 	}
-	c.DiagnosticServer.Init()
 
 	if err := c.initStores(); err != nil {
 		return nil, err

--- a/libnetwork/diagnostic/server.go
+++ b/libnetwork/diagnostic/server.go
@@ -49,17 +49,12 @@ type Server struct {
 
 // New creates a new diagnostic server
 func New() *Server {
-	return &Server{
+	s := &Server{
+		mux:               http.NewServeMux(),
 		registeredHanders: make(map[string]bool),
 	}
-}
-
-// Init initialize the mux for the http handling and register the base hooks
-func (s *Server) Init() {
-	s.mux = http.NewServeMux()
-
-	// Register local handlers
 	s.RegisterHandler(s, diagPaths2Func)
+	return s
 }
 
 // RegisterHandler allows to register new handlers to the mux and to a specific path

--- a/libnetwork/diagnostic/server.go
+++ b/libnetwork/diagnostic/server.go
@@ -147,9 +147,11 @@ func (s *Server) help(w http.ResponseWriter, r *http.Request) {
 	}).Info("help done")
 
 	var result string
+	s.mu.Lock()
 	for path := range s.handlers {
 		result += fmt.Sprintf("%s\n", path)
 	}
+	s.mu.Unlock()
 	_, _ = HTTPReply(w, CommandSucceed(&StringCmd{Info: result}), jsonOutput)
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Refactored `diagnostic.Server` to be more idiomatic.
- Un-embedded the mutex field to stop it from implementing `sync.Locker`
- Folded the `Init` method into the `diagnostic.New()` constructor because constructors are supposed to return constructed objects
- Refactored the diagnostic request handlers into standard `http.Handler` functions as there was no reason (aside from ignorance of the Go language) for the handlers to be implemented the way they were

**- How I did it**
By knowing what a closure is.

**- How to verify it**
Add a `network-diagnostic-port` entry to daemon.json, start the daemon and SIGHUP it to trigger a config reload. (The diagnostic server is not started until the config is reloaded. Smells like a bug...to address separately.) cURL the different endpoints to make sure they still work and don't crash the daemon. Initialize a swarm and check that the networkdb diagnostic endpoints are registered, work, and don't crash the daemon.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

