### PR TITLE
builder/dockerfile: errmsg: quote build target

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -199,7 +199,7 @@ func (b *Builder) build(ctx context.Context, source builder.Source, dockerfile *
 		targetIx, found := instructions.HasStage(stages, b.options.Target)
 		if !found {
 			buildsFailed.WithValues(metricsBuildTargetNotReachableError).Inc()
-			return nil, errdefs.InvalidParameter(errors.Errorf("failed to reach build target %s in Dockerfile", b.options.Target))
+			return nil, errdefs.InvalidParameter(errors.Errorf("target stage %q could not be found", b.options.Target))
 		}
 		stages = stages[:targetIx+1]
 	}

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5946,7 +5946,7 @@ func (s *DockerCLIBuildSuite) TestBuildIntermediateTarget(c *testing.T) {
 		cli.WithFlags("--target", "nosuchtarget"))
 	result.Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err:      "failed to reach build target",
+		Err:      "target stage \"nosuchtarget\" could not be found",
 	})
 }
 


### PR DESCRIPTION
Hi,

The build target is not quoted and it makes it difficult for some persons to see what the problem is.

By quoting it we emphasize that the target name is variable.

**- Description for the changelog**

builder/dockerfile: errmsg: quote build target

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/moby/moby/assets/17879459/a7fc3df9-7138-4984-b6ec-75f34052d6bc)

Thanks and cheers !

