### PR TITLE
libnetwork/ipam: refactor prefix-overlap checks

### DIFF
--- a/libnetwork/ipam/allocator.go
+++ b/libnetwork/ipam/allocator.go
@@ -214,7 +214,7 @@ func (aSpace *addrSpace) allocatePredefinedPool(ipV6 bool) (netip.Prefix, error)
 		}
 		// Shouldn't be necessary, but check prevents IP collisions should
 		// predefined pools overlap for any reason.
-		if !aSpace.contains(nw) {
+		if !aSpace.overlaps(nw) {
 			aSpace.updatePredefinedStartIndex(i + 1)
 			err := aSpace.allocateSubnetL(nw, netip.Prefix{})
 			if err != nil {

--- a/libnetwork/ipam/structures.go
+++ b/libnetwork/ipam/structures.go
@@ -107,7 +107,7 @@ func (aSpace *addrSpace) allocateSubnet(nw, sub netip.Prefix) error {
 func (aSpace *addrSpace) allocateSubnetL(nw, sub netip.Prefix) error {
 	// If master pool, check for overlap
 	if sub == (netip.Prefix{}) {
-		if aSpace.contains(nw) {
+		if aSpace.overlaps(nw) {
 			return ipamapi.ErrPoolOverlap
 		}
 		// This is a new master pool, add it along with corresponding bitmask
@@ -157,10 +157,11 @@ func (aSpace *addrSpace) releaseSubnet(nw, sub netip.Prefix) error {
 	return nil
 }
 
-// contains checks whether nw is a superset or subset of any of the existing subnets in this address space.
-func (aSpace *addrSpace) contains(nw netip.Prefix) bool {
+// overlaps reports whether nw contains any IP addresses in common with any of
+// the existing subnets in this address space.
+func (aSpace *addrSpace) overlaps(nw netip.Prefix) bool {
 	for pool := range aSpace.subnets {
-		if nw.Contains(pool.Addr()) || pool.Contains(nw.Addr()) {
+		if pool.Overlaps(nw) {
 			return true
 		}
 	}


### PR DESCRIPTION
I am finally convinced that, given two netip.Prefix values a and b, the expression

    a.Contains(b.Addr()) || b.Contains(a.Addr())

is functionally equivalent to

    a.Overlaps(b)

The [`(netip.Prefix).Contains`](https://cs.opensource.google/go/go/+/refs/tags/go1.21.3:src/net/netip/netip.go;l=1331) method works by masking the address with the prefix's mask and testing whether the remaining most-significant bits are equal to the same bits in the prefix. The [`(netip.Prefix).Overlaps`](https://cs.opensource.google/go/go/+/refs/tags/go1.21.3:src/net/netip/netip.go;l=1361) method works by masking the longer prefix to the length of the shorter prefix and testing whether the remaining most-significant bits are equal. This is equivalent to `shorterPrefix.Contains(longerPrefix.Addr())`, therefore applying `Contains` symmetrically to two prefixes will always yield the same result as applying `Overlaps` to the two prefixes in either order.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

