### PR TITLE
Skip the busybox digest check when containerd is enabled

### DIFF
--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -317,9 +317,12 @@ func (s *DockerRegistrySuite) TestListImagesWithDigests(c *testing.T) {
 	assert.Assert(c, reWithDigest1.MatchString(out), "expected %q: %s", reWithDigest1.String(), out)
 	// make sure image 2 has repo, tag, digest
 	assert.Assert(c, reWithDigest2.MatchString(out), "expected %q: %s", reWithDigest2.String(), out)
-	// make sure busybox has tag, but not digest
-	busyboxRe := regexp.MustCompile(`\s*busybox\s*latest\s*<none>\s`)
-	assert.Assert(c, busyboxRe.MatchString(out), "expected %q: %s", busyboxRe.String(), out)
+	// We always have a digest when using containerd to store images
+	if !testEnv.UsingSnapshotter() {
+		// make sure busybox has tag, but not digest
+		busyboxRe := regexp.MustCompile(`\s*busybox\s*latest\s*<none>\s`)
+		assert.Assert(c, busyboxRe.MatchString(out), "expected %q: %s", busyboxRe.String(), out)
+	}
 }
 
 func (s *DockerRegistrySuite) TestListDanglingImagesWithDigests(c *testing.T) {


### PR DESCRIPTION
**- What I did**

Skipped the busybox digest check when containerd is enabled since we always have a digest

**- How I did it**

**- How to verify it**

`TestListImagesWithDigests` should pass now.

```console
$ make DOCKER_GRAPHDRIVER=overlayfs TEST_FILTER=TestListImagesWithDigests TEST_INTEGRATION_USE_SNAPSHOTTER=1 TEST_IGNORE_CGROUP_CHECK=1 test-integration
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

