### PR TITLE
Skip TestPullManifestList when using containerd

### DIFF
--- a/integration-cli/docker_cli_pull_local_test.go
+++ b/integration-cli/docker_cli_pull_local_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
+	"gotest.tools/v3/skip"
 )
 
 // testPullImageWithAliases pulls a specific image tag and verifies that any aliases (i.e., other
@@ -283,6 +284,7 @@ func (s *DockerSchema1RegistrySuite) TestPullNoLayers(c *testing.T) {
 }
 
 func (s *DockerRegistrySuite) TestPullManifestList(c *testing.T) {
+	skip.If(c, testEnv.UsingSnapshotter(), "containerd knows how to pull manifest lists")
 	pushDigest, err := setupImage(c)
 	assert.NilError(c, err, "error setting up image")
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Skipped `TestPullManifestList` when using containerd

This test is very weird, the `Size` in the manifests that it creates is wrong, graph drivers only print a warning in that case but containerd fails because it verifies more things. The media types are also wrong in the containerd case, the manifest list forces the media type to be "schema2.MediaTypeManifest" but in the containerd case the media type is an OCI one.



**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

