### PR TITLE
Fix case where health start interval is 0 uses default

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -248,7 +248,7 @@ func handleProbeResult(d *Daemon, c *container.Container, result *types.Healthch
 // There is never more than one monitor thread running per container at a time.
 func monitor(d *Daemon, c *container.Container, stop chan struct{}, probe probe) {
 	probeInterval := timeoutWithDefault(c.Config.Healthcheck.Interval, defaultProbeInterval)
-	startInterval := timeoutWithDefault(c.Config.Healthcheck.StartInterval, defaultProbeInterval)
+	startInterval := timeoutWithDefault(c.Config.Healthcheck.StartInterval, probeInterval)
 	startPeriod := timeoutWithDefault(c.Config.Healthcheck.StartPeriod, defaultStartPeriod)
 
 	c.Lock()


### PR DESCRIPTION
When the start interval is 0 we should treat that as unset. This is especially important for older API versions where we reset the value to 0.

Instead of using the default probe value we should be using the configured `interval` value (which may be a default as well) which gives us back the old behavior before support for start interval was added.

- Fixes #46733
- Relates to https://github.com/moby/moby/pull/40894
