### PR TITLE
integration/system: update TestInfoAPI to not use string-matching

### DIFF
--- a/integration/system/info_test.go
+++ b/integration/system/info_test.go
@@ -20,29 +20,22 @@ func TestInfoAPI(t *testing.T) {
 	info, err := client.Info(ctx)
 	assert.NilError(t, err)
 
-	// always shown fields
-	stringsToCheck := []string{
-		"ID",
-		"Containers",
-		"ContainersRunning",
-		"ContainersPaused",
-		"ContainersStopped",
-		"Images",
-		"LoggingDriver",
-		"OperatingSystem",
-		"NCPU",
-		"OSType",
-		"Architecture",
-		"MemTotal",
-		"KernelVersion",
-		"Driver",
-		"ServerVersion",
-		"SecurityOptions",
-	}
-
-	out := fmt.Sprintf("%+v", info)
-	for _, linePrefix := range stringsToCheck {
-		assert.Check(t, is.Contains(out, linePrefix))
+	// TODO(thaJeztah): make sure we have other tests that run a local daemon and check other fields based on known state.
+	assert.Check(t, info.ID != "")
+	assert.Check(t, is.Equal(info.Containers, info.ContainersRunning+info.ContainersPaused+info.ContainersStopped))
+	assert.Check(t, info.LoggingDriver != "")
+	assert.Check(t, info.OperatingSystem != "")
+	assert.Check(t, info.NCPU != 0)
+	assert.Check(t, info.OSType != "")
+	assert.Check(t, info.Architecture != "")
+	assert.Check(t, info.MemTotal != 0)
+	assert.Check(t, info.KernelVersion != "")
+	assert.Check(t, info.Driver != "")
+	assert.Check(t, info.ServerVersion != "")
+	assert.Check(t, info.SystemTime != "")
+	if testEnv.DaemonInfo.OSType != "windows" {
+		// Windows currently doesn't have security-options in the info response.
+		assert.Check(t, len(info.SecurityOptions) != 0)
 	}
 }
 
@@ -91,7 +84,6 @@ func TestInfoDebug(t *testing.T) {
 	// TODO need a stable way to generate event listeners
 	// assert.Check(t, info.NEventsListener != 0)
 	assert.Check(t, info.NGoroutines != 0)
-	assert.Check(t, info.SystemTime != "")
 	assert.Equal(t, info.DockerRootDir, d.Root)
 }
 


### PR DESCRIPTION
- addresses part of https://github.com/moby/moby/issues/40156
- relates to (extracted from) https://github.com/moby/moby/pull/46395


### integration/system: update TestInfoAPI to not use string-matching

This test was rewritten from an integration-cli test in commit
68d9beedbe0994af5c91022874daa271b657be8c, and originally implemented in
f4942ed864f00a31591ef0257a971ef41ddd4c70, which rewrote it from a unit-
test to an integration test.

Originally, it would check for the raw JSON response from the daemon, and
check for individual fields to be present in the output, but after commit
0fd5a654280ef509a6512f84981f28d559869b90 (https://github.com/moby/moby/pull/33534), `client.Info()` was used, and
now the response is unmarshalled into a `system.Info`.

The remainder of the test remained the same in that rewrite, and as a
result were were now effectively testing if a `system.Info` struct,
when marshalled as JSON would show all the fields (surprise: it does).

TL;DR; the test would even pass with an empty `system.Info{}` struct,
which didn't provide much coverage, as it passed without a daemon:

    func TestInfoAPI(t *testing.T) {
        // always shown fields
        stringsToCheck := []string{
            "ID",
            "Containers",
            "ContainersRunning",
            "ContainersPaused",
            "ContainersStopped",
            "Images",
            "LoggingDriver",
            "OperatingSystem",
            "NCPU",
            "OSType",
            "Architecture",
            "MemTotal",
            "KernelVersion",
            "Driver",
            "ServerVersion",
            "SecurityOptions",
        }
    
        out := fmt.Sprintf("%+v", system.Info{})
        for _, linePrefix := range stringsToCheck {
            assert.Check(t, is.Contains(out, linePrefix))
        }
    }

This patch makes the test _slightly_ better by checking if the fields
are non-empty. More work is needed on this test though; currently it
uses the (already running) daemon, so it's hard to check for specific
fields to be correct (withouth knowing state of the daemon), but it's
not unlikely that other tests (partially) cover some of that. A TODO
comment was added to look into that (we should probably combine some
tests to prevent overlap, and make it easier to spot "gaps" as well).

While working on this, also moving the `SystemTime` into this test,
because that field is (no longer) dependent on "debug" state

(It is was actually this change that led me down this rabbit-hole)

                         ()_()
                         (-.-)
                        '(")(")'


**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

