### PR TITLE
daemon/config: Put params for the default network into a dedicated struct

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -278,7 +278,11 @@ func New() (*Config, error) {
 			MaxConcurrentDownloads: DefaultMaxConcurrentDownloads,
 			MaxConcurrentUploads:   DefaultMaxConcurrentUploads,
 			MaxDownloadAttempts:    DefaultDownloadAttempts,
-			BridgeConfig:           BridgeConfig{MTU: DefaultNetworkMtu},
+			BridgeConfig: BridgeConfig{
+				DefaultBridgeConfig: DefaultBridgeConfig{
+					MTU: DefaultNetworkMtu,
+				},
+			},
 			NetworkConfig: NetworkConfig{
 				NetworkControlPlaneMTU: DefaultNetworkMtu,
 				DefaultNetworkOpts:     make(map[string]map[string]string),

--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -31,27 +31,31 @@ const (
 	StockRuntimeName = "runc"
 )
 
-// BridgeConfig stores all the bridge driver specific
-// configuration.
+// BridgeConfig stores all the parameters for both the bridge driver and the default bridge network.
 type BridgeConfig struct {
-	commonBridgeConfig
+	DefaultBridgeConfig
 
-	// Fields below here are platform specific.
-	MTU                         int    `json:"mtu,omitempty"`
-	DefaultIP                   net.IP `json:"ip,omitempty"`
-	IP                          string `json:"bip,omitempty"`
-	DefaultGatewayIPv4          net.IP `json:"default-gateway,omitempty"`
-	DefaultGatewayIPv6          net.IP `json:"default-gateway-v6,omitempty"`
-	InterContainerCommunication bool   `json:"icc,omitempty"`
-
-	EnableIPv6          bool   `json:"ipv6,omitempty"`
 	EnableIPTables      bool   `json:"iptables,omitempty"`
 	EnableIP6Tables     bool   `json:"ip6tables,omitempty"`
 	EnableIPForward     bool   `json:"ip-forward,omitempty"`
 	EnableIPMasq        bool   `json:"ip-masq,omitempty"`
 	EnableUserlandProxy bool   `json:"userland-proxy,omitempty"`
 	UserlandProxyPath   string `json:"userland-proxy-path,omitempty"`
-	FixedCIDRv6         string `json:"fixed-cidr-v6,omitempty"`
+}
+
+// DefaultBridgeConfig stores all the parameters for the default bridge network.
+type DefaultBridgeConfig struct {
+	commonBridgeConfig
+
+	// Fields below here are platform specific.
+	EnableIPv6                  bool   `json:"ipv6,omitempty"`
+	FixedCIDRv6                 string `json:"fixed-cidr-v6,omitempty"`
+	MTU                         int    `json:"mtu,omitempty"`
+	DefaultIP                   net.IP `json:"ip,omitempty"`
+	IP                          string `json:"bip,omitempty"`
+	DefaultGatewayIPv4          net.IP `json:"default-gateway,omitempty"`
+	DefaultGatewayIPv6          net.IP `json:"default-gateway-v6,omitempty"`
+	InterContainerCommunication bool   `json:"icc,omitempty"`
 }
 
 // Config defines the configuration of a docker daemon.

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -286,7 +286,11 @@ func TestValidateConfigurationErrors(t *testing.T) {
 			name: "negative MTU",
 			config: &Config{
 				CommonConfig: CommonConfig{
-					BridgeConfig: BridgeConfig{MTU: -10},
+					BridgeConfig: BridgeConfig{
+						DefaultBridgeConfig: DefaultBridgeConfig{
+							MTU: -10,
+						},
+					},
 				},
 			},
 			expectedErr: "invalid default MTU: -10",
@@ -443,7 +447,11 @@ func TestValidateConfiguration(t *testing.T) {
 			field: "MTU",
 			config: &Config{
 				CommonConfig: CommonConfig{
-					BridgeConfig: BridgeConfig{MTU: 1234},
+					BridgeConfig: BridgeConfig{
+						DefaultBridgeConfig: DefaultBridgeConfig{
+							MTU: 1234,
+						},
+					},
 				},
 			},
 		},

--- a/daemon/config/config_windows.go
+++ b/daemon/config/config_windows.go
@@ -15,9 +15,14 @@ const (
 	StockRuntimeName = ""
 )
 
-// BridgeConfig stores all the bridge driver specific
-// configuration.
+// BridgeConfig is meant to store all the parameters for both the bridge driver and the default bridge network. On
+// Windows: 1. "bridge" in this context reference the nat driver and the default nat network; 2. the nat driver has no
+// specific parameters, so this struct effectively just stores parameters for the default nat network.
 type BridgeConfig struct {
+	DefaultBridgeConfig
+}
+
+type DefaultBridgeConfig struct {
 	commonBridgeConfig
 
 	// MTU is not actually used on Windows, but the --mtu option has always


### PR DESCRIPTION
**- What I did**

* Move all config parameters specific to the default bridge (or nat) network out of `BridgeConfig` and put them into a dedicated struct.
* Embed that struct into `BridgeConfig`.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://i.f1g.fr/media/cms/orig/2023/02/03/d0d13f473ac5cb9310f48b7aefef57af9974fcfc5c1a3e0ac21fb74033276847.jpg)