### PR TITLE
Revert "libcontainerd: work around exec start bug in c8d"

### DIFF
--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -62,10 +62,6 @@ type container struct {
 type task struct {
 	containerd.Task
 	ctr *container
-
-	// Workaround for https://github.com/containerd/containerd/issues/8557.
-	// See also https://github.com/moby/moby/issues/45595.
-	serializeExecStartsWorkaround sync.Mutex
 }
 
 type process struct {
@@ -302,12 +298,7 @@ func (t *task) Exec(ctx context.Context, processID string, spec *specs.Process, 
 	// the stdin of exec process will be created after p.Start in containerd
 	defer func() { stdinCloseSync <- p }()
 
-	err = func() error {
-		t.serializeExecStartsWorkaround.Lock()
-		defer t.serializeExecStartsWorkaround.Unlock()
-		return p.Start(ctx)
-	}()
-	if err != nil {
+	if err = p.Start(ctx); err != nil {
 		// use new context for cleanup because old one may be cancelled by user, but leave a timeout to make sure
 		// we are not waiting forever if containerd is unresponsive or to work around fifo cancelling issues in
 		// older containerd-shim

--- a/project/PACKAGERS.md
+++ b/project/PACKAGERS.md
@@ -106,6 +106,8 @@ export DOCKER_BUILDTAGS='exclude_graphdriver_btrfs exclude_graphdriver_zfs'
 To function properly, the Docker daemon needs the following software to be
 installed and available at runtime:
 
+* containerd version 1.6.22 or later
+  * containerd versions 1.7.0 through 1.7.2 are incompatible
 * iptables version 1.4 or later
 * procps (or similar provider of a "ps" executable)
 * e2fsprogs version 1.4.12 or later (in use: mkfs.ext4, tune2fs)


### PR DESCRIPTION
The workaround is no longer required. The bug has been fixed in stable versions of all supported containerd branches.

This reverts commit fb7ec1555cca750f5d1d99bae5e99b4818712322.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Containerd versions below v1.6.22 and v1.7.3 are no longer supported

**- A picture of a cute animal (not mandatory but encouraged)**

