### PR TITLE
Default the auth config domain to the target image domain

### DIFF
--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -67,7 +67,7 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.NamedTagged, p
 		opts = append(opts, containerd.WithPlatform(platforms.Format(*platform)))
 	}
 
-	resolver, _ := i.newResolverFromAuthConfig(ctx, authConfig)
+	resolver, _ := i.newResolverFromAuthConfig(ctx, authConfig, ref)
 	opts = append(opts, containerd.WithResolver(resolver))
 
 	old, err := i.resolveDescriptor(ctx, ref.String())

--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -102,7 +102,7 @@ func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, m
 	target := img.Target
 	store := i.client.ContentStore()
 
-	resolver, tracker := i.newResolverFromAuthConfig(ctx, authConfig)
+	resolver, tracker := i.newResolverFromAuthConfig(ctx, authConfig, targetRef)
 	pp := pushProgress{Tracker: tracker}
 	jobsQueue := newJobs()
 	finishProgress := jobsQueue.showProgress(ctx, out, combinedProgress([]progressUpdater{


### PR DESCRIPTION
- supersedes / closes https://github.com/moby/moby/pull/46745
- closes https://github.com/moby/moby/issues/46743

When server address is not provided with the auth configuration, use the domain from the image provided with the auth.

Alternative to #46745 without support for sending a single auth config to multiple hosts. This is similar to containerd's default handlers.  To support multi-host authorization in the future, we can use the transfer service API or define a credential callback. 