### PR TITLE
c8d: handle user namespace remapping on commit

### DIFF
--- a/daemon/containerd/image_snapshot_windows.go
+++ b/daemon/containerd/image_snapshot_windows.go
@@ -3,9 +3,14 @@ package containerd
 import (
 	"context"
 
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshots"
 )
 
 func (i *ImageService) remapSnapshot(ctx context.Context, snapshotter snapshots.Snapshotter, id string, parentSnapshot string) error {
+	return nil
+}
+
+func (i *ImageService) unremapRootFS(ctx context.Context, mounts []mount.Mount) error {
 	return nil
 }

--- a/integration/image/commit_test.go
+++ b/integration/image/commit_test.go
@@ -1,12 +1,14 @@
 package image // import "github.com/docker/docker/integration/image"
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
@@ -46,4 +48,27 @@ func TestCommitInheritsEnv(t *testing.T) {
 	assert.NilError(t, err)
 	expectedEnv2 := []string{"PATH=/usr/bin:/bin"}
 	assert.Check(t, is.DeepEqual(expectedEnv2, image2.Config.Env))
+}
+
+// Verify that files created are owned by the remapped user even after a commit
+func TestUsernsCommit(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.IsRemoteDaemon())
+	skip.If(t, !testEnv.IsUserNamespaceInKernel())
+	skip.If(t, testEnv.IsRootless())
+
+	ctx := context.Background()
+	dUserRemap := daemon.New(t, daemon.WithUserNsRemap("default"))
+	dUserRemap.StartWithBusybox(ctx, t)
+	clientUserRemap := dUserRemap.NewClientT(t)
+	defer clientUserRemap.Close()
+
+	container.Run(ctx, t, clientUserRemap, container.WithName(t.Name()), container.WithImage("busybox"), container.WithCmd("sh", "-c", "echo hello world > /hello.txt && chown 1000:1000 /hello.txt"))
+	img, err := clientUserRemap.ContainerCommit(ctx, t.Name(), containertypes.CommitOptions{})
+	assert.NilError(t, err)
+
+	res := container.RunAttach(ctx, t, clientUserRemap, container.WithImage(img.ID), container.WithCmd("sh", "-c", "stat -c %u:%g /hello.txt"))
+	assert.Check(t, is.Equal(res.ExitCode, 0))
+	assert.Check(t, is.Equal(res.Stderr.String(), ""))
+	assert.Assert(t, is.Equal(strings.TrimSpace(res.Stdout.String()), "1000:1000"))
 }

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -83,6 +83,7 @@ type Daemon struct {
 	args                       []string
 	extraEnv                   []string
 	containerdSocket           string
+	usernsRemap                string
 	rootlessUser               *user.User
 	rootlessXDGRuntimeDir      string
 
@@ -455,6 +456,10 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 	)
 	if d.containerdSocket != "" {
 		d.args = append(d.args, "--containerd", d.containerdSocket)
+	}
+
+	if d.usernsRemap != "" {
+		d.args = append(d.args, "--userns-remap", d.usernsRemap)
 	}
 
 	if d.defaultCgroupNamespaceMode != "" {

--- a/testutil/daemon/ops.go
+++ b/testutil/daemon/ops.go
@@ -19,6 +19,12 @@ func WithContainerdSocket(socket string) Option {
 	}
 }
 
+func WithUserNsRemap(remap string) Option {
+	return func(d *Daemon) {
+		d.usernsRemap = remap
+	}
+}
+
 // WithDefaultCgroupNamespaceMode sets the default cgroup namespace mode for the daemon
 func WithDefaultCgroupNamespaceMode(mode string) Option {
 	return func(d *Daemon) {


### PR DESCRIPTION
**- What I did**

This fixes `docker commit` against a userns remapped daemon. We have to inverse the map before creating the image from a container.

**- How I did it**

By doing the inverse remapping that we do on container create when a container is commited.

**- How to verify it**

Added a test for this.

Before:

```console
=== RUN   TestUsernsCommit
    commit_test.go:70: assertion failed: error is not nil: Error response from daemon: mount callback failed on /tmp/containerd-mount216445661: Container ID 166536 cannot be mapped to a host ID
--- FAIL: TestUsernsCommit (1.69s)
```

After:

```console
=== RUN   TestUsernsCommit
--- PASS: TestUsernsCommit (2.20s)
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

