### PR TITLE
c8d: Use a specific containerd namespace when userns are remapped

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -616,6 +616,10 @@ func loadDaemonCliConfig(opts *daemonOptions) (*config.Config, error) {
 		conf.CDISpecDirs = nil
 	}
 
+	if err := loadCLIPlatformConfig(conf); err != nil {
+		return nil, err
+	}
+
 	return conf, nil
 }
 

--- a/cmd/dockerd/daemon_linux.go
+++ b/cmd/dockerd/daemon_linux.go
@@ -3,10 +3,27 @@ package main
 import (
 	cdcgroups "github.com/containerd/cgroups/v3"
 	systemdDaemon "github.com/coreos/go-systemd/v22/daemon"
+	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/pkg/sysinfo"
 	"github.com/pkg/errors"
 )
+
+// loadCLIPlatformConfig loads the platform specific CLI configuration
+func loadCLIPlatformConfig(conf *config.Config) error {
+	if conf.RemappedRoot == "" {
+		return nil
+	}
+
+	containerdNamespace, containerdPluginNamespace, err := daemon.RemapContainerdNamespaces(conf)
+	if err != nil {
+		return err
+	}
+	conf.ContainerdNamespace = containerdNamespace
+	conf.ContainerdPluginNamespace = containerdPluginNamespace
+
+	return nil
+}
 
 // preNotifyReady sends a message to the host when the API is active, but before the daemon is
 func preNotifyReady() {

--- a/cmd/dockerd/daemon_windows.go
+++ b/cmd/dockerd/daemon_windows.go
@@ -16,6 +16,12 @@ func getDefaultDaemonConfigFile() (string, error) {
 	return "", nil
 }
 
+// loadCLIPlatformConfig loads the platform specific CLI configuration
+// there is none on windows, so this is a no-op
+func loadCLIPlatformConfig(conf *config.Config) error {
+	return nil
+}
+
 // setDefaultUmask doesn't do anything on windows
 func setDefaultUmask() error {
 	return nil

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1515,6 +1515,34 @@ func CreateDaemonRoot(config *config.Config) error {
 	return setupDaemonRoot(config, realRoot, idMapping.RootPair())
 }
 
+// RemapContainerdNamespaces returns the right containerd namespaces to use:
+// - if they are not already set in the config file
+// -  and the daemon is running with user namespace remapping enabled
+// Then it will return new namespace names, otherwise it will return the existing
+// namespaces
+func RemapContainerdNamespaces(config *config.Config) (ns string, pluginNs string, err error) {
+	idMapping, err := setupRemappedRoot(config)
+	if err != nil {
+		return "", "", err
+	}
+	if idMapping.Empty() {
+		return config.ContainerdNamespace, config.ContainerdPluginNamespace, nil
+	}
+	root := idMapping.RootPair()
+
+	ns = config.ContainerdNamespace
+	if _, ok := config.ValuesSet["containerd-namespace"]; !ok {
+		ns = fmt.Sprintf("%s-%d.%d", config.ContainerdNamespace, root.UID, root.GID)
+	}
+
+	pluginNs = config.ContainerdPluginNamespace
+	if _, ok := config.ValuesSet["containerd-plugin-namespace"]; !ok {
+		pluginNs = fmt.Sprintf("%s-%d.%d", config.ContainerdPluginNamespace, root.UID, root.GID)
+	}
+
+	return
+}
+
 // checkpointAndSave grabs a container lock to safely call container.CheckpointTo
 func (daemon *Daemon) checkpointAndSave(container *container.Container) error {
 	container.Lock()


### PR DESCRIPTION
**- What I did**

We need to isolate the images that we are remapping to a userns, we can't mix them with "normal" images. In the graph driver case this means that we create a new root directory where we store the images and everything else, in the containerd case we can use a new namespace.

**- How I did it**

**- How to verify it**

Run a daemon with `--userns-remap=default` and pull and image, then:

- stop the daemon
- run the daemon without userns remapping
- list images

And you shouldn't see the image that you pulled.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

