### PR TITLE
Fix missing import for "scope" package

### DIFF
--- a/libnetwork/sandbox_store.go
+++ b/libnetwork/sandbox_store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/osl"
+	"github.com/docker/docker/libnetwork/scope"
 )
 
 const (

--- a/libnetwork/store.go
+++ b/libnetwork/store.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/libnetwork/datastore"
+	"github.com/docker/docker/libnetwork/scope"
 )
 
 func (c *Controller) initStores() error {


### PR DESCRIPTION
I believe this happened due to conflicting PR's that got merged without CI re-running between them.
