### PR TITLE
opts: ValidateIPAddress: improve error, godoc, and tests

### DIFF
--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -247,7 +247,7 @@ func TestValidateConfigurationErrors(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: "1.1.1.1o is not an ip address",
+			expectedErr: "IP address is not correctly formatted: 1.1.1.1o",
 		},
 		{
 			name: "multiple DNS, invalid IP-address",
@@ -258,7 +258,7 @@ func TestValidateConfigurationErrors(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: "1.1.1.1o is not an ip address",
+			expectedErr: "IP address is not correctly formatted: 1.1.1.1o",
 		},
 		{
 			name: "single DNSSearch",

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -298,13 +298,18 @@ type ValidatorFctType func(val string) (string, error)
 // ValidatorFctListType defines a validator function that returns a validated list of string and/or an error
 type ValidatorFctListType func(val string) ([]string, error)
 
-// ValidateIPAddress validates an Ip address.
+// ValidateIPAddress validates if the given value is a correctly formatted
+// IP address, and returns the value in normalized form. Leading and trailing
+// whitespace is allowed, but it does not allow IPv6 addresses surrounded by
+// square brackets ("[::1]").
+//
+// Refer to [net.ParseIP] for accepted formats.
 func ValidateIPAddress(val string) (string, error) {
 	ip := net.ParseIP(strings.TrimSpace(val))
 	if ip != nil {
 		return ip.String(), nil
 	}
-	return "", fmt.Errorf("%s is not an ip address", val)
+	return "", fmt.Errorf("IP address is not correctly formatted: %s", val)
 }
 
 // ValidateDNSSearch validates domain for resolvconf search configuration.


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/4657

----

- document accepted values
- add test-coverage for the function's behavior (including whitespace handling), and use sub-tests.
- improve error-message to use uppercase for "IP", and to use a common prefix.


**- A picture of a cute animal (not mandatory but encouraged)**

