### PR TITLE
Add anonymous label to created containers if name omitted

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6335,6 +6335,10 @@ paths:
           description: |
             Assign the specified name to the container. Must match
             `/?[a-zA-Z0-9][a-zA-Z0-9_.-]+`.
+
+            If the option is not set, the container name will be automatically
+            generated and `com.docker.container.anonymous` will be added as a
+            container label.
           type: "string"
           pattern: "^/?[a-zA-Z0-9][a-zA-Z0-9_.-]+$"
         - name: "platform"

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -120,6 +120,10 @@ func (daemon *Daemon) Register(c *container.Container) error {
 	return c.CheckpointTo(daemon.containersReplica)
 }
 
+// AnonymousLabel is the label used to indicate that a container is anonymous
+// This is set automatically on a container when a container is created without a name specified, and as such an id is generated for it.
+const AnonymousLabel = "com.docker.container.anonymous"
+
 func (daemon *Daemon) newContainer(name string, operatingSystem string, config *containertypes.Config, hostConfig *containertypes.HostConfig, imgID image.ID, managed bool) (*container.Container, error) {
 	var (
 		id             string
@@ -129,6 +133,13 @@ func (daemon *Daemon) newContainer(name string, operatingSystem string, config *
 	id, name, err = daemon.generateIDAndName(name)
 	if err != nil {
 		return nil, err
+	}
+
+	if noExplicitName {
+		if config.Labels == nil {
+			config.Labels = map[string]string{}
+		}
+		config.Labels[AnonymousLabel] = ""
 	}
 
 	if hostConfig.NetworkMode.IsHost() {

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -673,3 +673,43 @@ func TestCreateWithCustomMACs(t *testing.T) {
 		assert.Equal(t, mac, "02:32:1c:23:00:04")
 	}
 }
+
+func TestCreateAnonymousNameLabel(t *testing.T) {
+	ctx := setupTest(t)
+
+	client := testEnv.APIClient()
+
+	const AnonymousLabel string = "com.docker.container.anonymous"
+	const AnonymousValue string = ""
+
+	// Test with non-empty name given
+	ctr, err := client.ContainerCreate(ctx,
+		&container.Config{
+			Image: "busybox",
+		},
+		&container.HostConfig{},
+		&network.NetworkingConfig{},
+		nil,
+		"foo", // This is the container name
+	)
+	assert.Equal(t, err, nil)
+	inspect, err := client.ContainerInspect(ctx, ctr.ID)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, is.Contains(inspect.Config.Labels, AnonymousLabel)().Success(), false)
+
+	// Test with empty name given
+	ctr, err = client.ContainerCreate(ctx,
+		&container.Config{
+			Image: "busybox",
+		},
+		&container.HostConfig{},
+		&network.NetworkingConfig{},
+		nil,
+		"", // This is the container name
+	)
+	assert.Equal(t, err, nil)
+	inspect, err = client.ContainerInspect(ctx, ctr.ID)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, is.Contains(inspect.Config.Labels, AnonymousLabel)().Success(), true)
+	assert.Equal(t, inspect.Config.Labels[AnonymousLabel], AnonymousValue)
+}


### PR DESCRIPTION
closes #45755 

This is my first contribution to the project, so please let me know if anything needs to be changed.

**- What I did**
I've updated `daemon/container.go` file's `newContainer` method in order to attach the "com.docker.container.anonymous" label to newly created containers that had an empty string input as the name parameter in the client request.

**- How I did it**
Simply used the existing `noExplicitName` variable within the `newContainer` method to add the anonymous label to the config, if true.

**- How to verify it**
Integration test included. The test asserts that a container created with the provided name "foo" **does not** have the anonymous label after creation, and a container created with the provided name "" **does** have the anonymous label after creation.

**- Description for the changelog**
Add anonymous label to newly created containers when empty string is given as input parameter name.


**- A picture of a cute animal (not mandatory but encouraged)**
If you insist :)
![image](https://github.com/moby/moby/assets/99206009/e0810a94-c73d-4186-b130-25aff698a0cb)
