### PR TITLE
graphdriver/copy: faster copy of hard links

### DIFF
--- a/daemon/graphdriver/copy/copy.go
+++ b/daemon/graphdriver/copy/copy.go
@@ -159,6 +159,7 @@ func DirCopy(srcDir, dstDir string, copyMode Mode, copyOpaqueXattrs bool) error 
 					return err2
 				}
 			} else if hardLinkDstPath, ok := copiedFiles[id]; ok {
+				isHardlink = true
 				if err2 := os.Link(hardLinkDstPath, dstPath); err2 != nil {
 					return err2
 				}


### PR DESCRIPTION
Fixes https://github.com/moby/moby/issues/46810

- What I did

Speed up vfs's copy of a BusyBox filesystem (which consists mainly of hard links to a single binary), making moby's integration tests run more quickly and more reliably in a dev container.

- How I did it

The DirCopy() function in "graphdriver/copy/copy.go" has a special case for skip file-attribute copying when making a hard link to an already-copied file, if "copyMode == Hardlink". Do the same for copies of hard-links in the source filesystem.

- How to verify it

Running the integration tests, as described in https://github.com/moby/moby/issues/46810 ...

Without the change (and with the printfs described above), in this case all the tests finished just within their 5s timeouts in ~88s:

```
INFO: Testing against a local daemon
=== RUN   TestBridgeICC
=== RUN   TestBridgeICC/IPv4_non-internal_network
CLI Post call took 4.730112544s
CLI Post call took 4.702928253s
=== RUN   TestBridgeICC/IPv4_internal_network
CLI Post call took 4.674024294s
CLI Post call took 4.757430418s
=== RUN   TestBridgeICC/IPv6_ULA_on_non-internal_network
CLI Post call took 4.743797003s
CLI Post call took 4.734315211s
=== RUN   TestBridgeICC/IPv6_ULA_on_internal_network
CLI Post call took 4.754429169s
CLI Post call took 4.753247336s
=== RUN   TestBridgeICC/IPv6_link-local_address_on_non-internal_network
CLI Post call took 4.897648835s
CLI Post call took 4.752835585s
=== RUN   TestBridgeICC/IPv6_link-local_address_on_internal_network
CLI Post call took 5.149620378s
CLI Post call took 4.732314336s
=== RUN   TestBridgeICC/IPv6_non-internal_network_with_SLAAC_LL_address
CLI Post call took 4.896428502s
CLI Post call took 4.747824461s
=== RUN   TestBridgeICC/IPv6_internal_network_with_SLAAC_LL_address
CLI Post call took 5.117011001s
CLI Post call took 4.738395294s
--- PASS: TestBridgeICC (88.47s)
    --- PASS: TestBridgeICC/IPv4_non-internal_network (10.49s)
    --- PASS: TestBridgeICC/IPv4_internal_network (10.44s)
    --- PASS: TestBridgeICC/IPv6_ULA_on_non-internal_network (10.60s)
    --- PASS: TestBridgeICC/IPv6_ULA_on_internal_network (10.53s)
    --- PASS: TestBridgeICC/IPv6_link-local_address_on_non-internal_network (10.76s)
    --- PASS: TestBridgeICC/IPv6_link-local_address_on_internal_network (10.91s)
    --- PASS: TestBridgeICC/IPv6_non-internal_network_with_SLAAC_LL_address (10.74s)
    --- PASS: TestBridgeICC/IPv6_internal_network_with_SLAAC_LL_address (10.93s)
PASS

DONE 9 tests in 88.516s
```
With the change, tests completed in ~22s:

```
INFO: Testing against a local daemon
=== RUN   TestBridgeICC
=== RUN   TestBridgeICC/IPv4_non-internal_network
CLI Post call took 414.793708ms
CLI Post call took 412.339542ms
=== RUN   TestBridgeICC/IPv4_internal_network
CLI Post call took 413.349417ms
CLI Post call took 415.359375ms
=== RUN   TestBridgeICC/IPv6_ULA_on_non-internal_network
CLI Post call took 433.486417ms
CLI Post call took 410.262041ms
=== RUN   TestBridgeICC/IPv6_ULA_on_internal_network
CLI Post call took 430.581ms
CLI Post call took 412.697042ms
=== RUN   TestBridgeICC/IPv6_link-local_address_on_non-internal_network
CLI Post call took 466.356583ms
CLI Post call took 413.003459ms
=== RUN   TestBridgeICC/IPv6_link-local_address_on_internal_network
CLI Post call took 449.755042ms
CLI Post call took 407.237459ms
=== RUN   TestBridgeICC/IPv6_non-internal_network_with_SLAAC_LL_address
CLI Post call took 446.003292ms
CLI Post call took 430.060083ms
=== RUN   TestBridgeICC/IPv6_internal_network_with_SLAAC_LL_address
CLI Post call took 431.701709ms
CLI Post call took 403.693125ms
--- PASS: TestBridgeICC (21.49s)
    --- PASS: TestBridgeICC/IPv4_non-internal_network (1.91s)
    --- PASS: TestBridgeICC/IPv4_internal_network (1.84s)
    --- PASS: TestBridgeICC/IPv6_ULA_on_non-internal_network (1.91s)
    --- PASS: TestBridgeICC/IPv6_ULA_on_internal_network (1.82s)
    --- PASS: TestBridgeICC/IPv6_link-local_address_on_non-internal_network (1.96s)
    --- PASS: TestBridgeICC/IPv6_link-local_address_on_internal_network (1.86s)
    --- PASS: TestBridgeICC/IPv6_non-internal_network_with_SLAAC_LL_address (3.10s)
    --- PASS: TestBridgeICC/IPv6_internal_network_with_SLAAC_LL_address (4.09s)
PASS

DONE 9 tests in 22.711s
```
Unit tests are still happy...

```ok  	github.com/docker/docker/daemon/graphdriver/copy	0.080s
The other timed-out integration tests listed in the original description also pass.
```

- Description for the changelog

graphdriver/copy: faster copy of hard links