### PR TITLE
replace errors.Errorf with fmt.Errorf

### DIFF
--- a/api/server/httputils/httputils.go
+++ b/api/server/httputils/httputils.go
@@ -3,6 +3,7 @@ package httputils // import "github.com/docker/docker/api/server/httputils"
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"mime"
 	"net/http"
@@ -128,7 +129,7 @@ func matchesContentType(contentType, expectedType string) error {
 		return errdefs.InvalidParameter(errors.Wrapf(err, "malformed Content-Type header (%s)", contentType))
 	}
 	if mimetype != expectedType {
-		return errdefs.InvalidParameter(errors.Errorf("unsupported Content-Type header (%s): must be '%s'", contentType, expectedType))
+		return errdefs.InvalidParameter(fmt.Errorf("unsupported Content-Type header (%s): must be '%s'", contentType, expectedType))
 	}
 	return nil
 }

--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -102,7 +102,7 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 	if i := r.FormValue("isolation"); i != "" {
 		options.Isolation = container.Isolation(i)
 		if !options.Isolation.IsValid() {
-			return nil, invalidParam{errors.Errorf("unsupported isolation: %q", i)}
+			return nil, invalidParam{fmt.Errorf("unsupported isolation: %q", i)}
 		}
 	}
 
@@ -168,7 +168,7 @@ func parseVersion(s string) (types.BuilderVersion, error) {
 	case types.BuilderBuildKit:
 		return types.BuilderBuildKit, nil
 	default:
-		return "", invalidParam{errors.Errorf("invalid version %q", s)}
+		return "", invalidParam{fmt.Errorf("invalid version %q", s)}
 	}
 }
 

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -359,7 +359,7 @@ func (s *containerRouter) postContainersWait(ctx context.Context, w http.Respons
 				waitCondition = containerpkg.WaitConditionRemoved
 				legacyRemovalWaitPre134 = versions.LessThan(version, "1.34")
 			default:
-				return errdefs.InvalidParameter(errors.Errorf("invalid condition: %q", v))
+				return errdefs.InvalidParameter(fmt.Errorf("invalid condition: %q", v))
 			}
 		}
 	}
@@ -624,7 +624,7 @@ func (s *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 			for k := range networkingConfig.EndpointsConfig {
 				l = append(l, k)
 			}
-			return errdefs.InvalidParameter(errors.Errorf("Container cannot be created with multiple network endpoints: %s", strings.Join(l, ", ")))
+			return errdefs.InvalidParameter(fmt.Errorf("Container cannot be created with multiple network endpoints: %s", strings.Join(l, ", ")))
 		}
 	}
 
@@ -756,7 +756,7 @@ func (s *containerRouter) postContainersAttach(ctx context.Context, w http.Respo
 
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
-		return errdefs.InvalidParameter(errors.Errorf("error attaching to container %s, hijack connection missing", containerName))
+		return errdefs.InvalidParameter(fmt.Errorf("error attaching to container %s, hijack connection missing", containerName))
 	}
 
 	contentType := types.MediaTypeRawStream

--- a/api/server/router/distribution/distribution_routes.go
+++ b/api/server/router/distribution/distribution_routes.go
@@ -3,6 +3,7 @@ package distribution // import "github.com/docker/docker/api/server/router/distr
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/distribution/reference"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/errdefs"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 func (s *distributionRouter) getDistributionInfo(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
@@ -34,9 +34,9 @@ func (s *distributionRouter) getDistributionInfo(ctx context.Context, w http.Res
 	if !ok {
 		if _, ok := ref.(reference.Digested); ok {
 			// full image ID
-			return errors.Errorf("no manifest found for full image ID")
+			return fmt.Errorf("no manifest found for full image ID")
 		}
-		return errdefs.InvalidParameter(errors.Errorf("unknown image reference format: %s", image))
+		return errdefs.InvalidParameter(fmt.Errorf("unknown image reference format: %s", image))
 	}
 
 	// For a search it is not an error if no auth was given. Ignore invalid
@@ -54,7 +54,7 @@ func (s *distributionRouter) getDistributionInfo(ctx context.Context, w http.Res
 
 		taggedRef, ok := namedRef.(reference.NamedTagged)
 		if !ok {
-			return errdefs.InvalidParameter(errors.Errorf("image reference not tagged: %s", image))
+			return errdefs.InvalidParameter(fmt.Errorf("image reference not tagged: %s", image))
 		}
 
 		descriptor, err := distrepo.Tags(ctx).Get(ctx, taggedRef.Tag())

--- a/api/server/router/grpc/grpc_routes.go
+++ b/api/server/router/grpc/grpc_routes.go
@@ -2,6 +2,7 @@ package grpc // import "github.com/docker/docker/api/server/router/grpc"
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -18,7 +19,7 @@ func (gr *grpcRouter) serveGRPC(ctx context.Context, w http.ResponseWriter, r *h
 		return errors.New("no upgrade proto in request")
 	}
 	if proto != "h2c" {
-		return errors.Errorf("protocol %s not supported", proto)
+		return fmt.Errorf("protocol %s not supported", proto)
 	}
 
 	conn, _, err := h.Hijack()

--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -2,6 +2,7 @@ package network // import "github.com/docker/docker/api/server/router/network"
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -358,7 +359,7 @@ func (n *networkRouter) findUniqueNetwork(term string) (types.NetworkResource, e
 		}
 	}
 	if len(listByFullName) > 1 {
-		return types.NetworkResource{}, errdefs.InvalidParameter(errors.Errorf("network %s is ambiguous (%d matches found based on name)", term, len(listByFullName)))
+		return types.NetworkResource{}, errdefs.InvalidParameter(fmt.Errorf("network %s is ambiguous (%d matches found based on name)", term, len(listByFullName)))
 	}
 
 	// Find based on partial ID, returns true only if no duplicates
@@ -368,7 +369,7 @@ func (n *networkRouter) findUniqueNetwork(term string) (types.NetworkResource, e
 		}
 	}
 	if len(listByPartialID) > 1 {
-		return types.NetworkResource{}, errdefs.InvalidParameter(errors.Errorf("network %s is ambiguous (%d matches found based on ID prefix)", term, len(listByPartialID)))
+		return types.NetworkResource{}, errdefs.InvalidParameter(fmt.Errorf("network %s is ambiguous (%d matches found based on ID prefix)", term, len(listByPartialID)))
 	}
 
 	return types.NetworkResource{}, errdefs.NotFound(libnetwork.ErrNoSuchNetwork(term))

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -439,7 +439,7 @@ func (sr *swarmRouter) createSecret(ctx context.Context, w http.ResponseWriter, 
 	}
 	version := httputils.VersionFromContext(ctx)
 	if secret.Templating != nil && versions.LessThan(version, "1.37") {
-		return errdefs.InvalidParameter(errors.Errorf("secret templating is not supported on the specified API version: %s", version))
+		return errdefs.InvalidParameter(fmt.Errorf("secret templating is not supported on the specified API version: %s", version))
 	}
 
 	id, err := sr.backend.CreateSecret(secret)
@@ -511,7 +511,7 @@ func (sr *swarmRouter) createConfig(ctx context.Context, w http.ResponseWriter, 
 
 	version := httputils.VersionFromContext(ctx)
 	if config.Templating != nil && versions.LessThan(version, "1.37") {
-		return errdefs.InvalidParameter(errors.Errorf("config templating is not supported on the specified API version: %s", version))
+		return errdefs.InvalidParameter(fmt.Errorf("config templating is not supported on the specified API version: %s", version))
 	}
 
 	id, err := sr.backend.CreateConfig(config)

--- a/builder/builder-next/adapters/containerimage/pull.go
+++ b/builder/builder-next/adapters/containerimage/pull.go
@@ -176,7 +176,7 @@ func (is *Source) ResolveImageConfig(ctx context.Context, ref string, opt llb.Re
 func (is *Source) Resolve(ctx context.Context, id source.Identifier, sm *session.Manager, vtx solver.Vertex) (source.SourceInstance, error) {
 	imageIdentifier, ok := id.(*source.ImageIdentifier)
 	if !ok {
-		return nil, errors.Errorf("invalid image identifier %v", id)
+		return nil, fmt.Errorf("invalid image identifier %v", id)
 	}
 
 	platform := platforms.DefaultSpec()
@@ -344,7 +344,7 @@ func (p *puller) CacheKey(ctx context.Context, g session.Group, index int) (stri
 	}
 
 	if len(p.config) == 0 && p.desc.MediaType != images.MediaTypeDockerSchema1Manifest {
-		return "", "", nil, false, errors.Errorf("invalid empty config file resolved for %s", p.src.Reference.String())
+		return "", "", nil, false, fmt.Errorf("invalid empty config file resolved for %s", p.src.Reference.String())
 	}
 
 	k := cacheKeyFromConfig(p.config).String()
@@ -513,7 +513,7 @@ func (p *puller) Snapshot(ctx context.Context, g session.Group) (cache.Immutable
 	}
 
 	if len(mfst.Layers) != len(img.RootFS.DiffIDs) {
-		return nil, errors.Errorf("invalid config for manifest")
+		return nil, fmt.Errorf("invalid config for manifest")
 	}
 
 	pchan := make(chan pkgprogress.Progress, 10)
@@ -883,7 +883,7 @@ func applySourcePolicies(ctx context.Context, str string, spls []*spb.Policy) (s
 		)
 		t, newRef, ok := strings.Cut(op.GetSource().GetIdentifier(), "://")
 		if !ok {
-			return "", errors.Errorf("could not parse ref: %s", op.GetSource().GetIdentifier())
+			return "", fmt.Errorf("could not parse ref: %s", op.GetSource().GetIdentifier())
 		}
 		if ok && t != srctypes.DockerImageScheme {
 			return "", &imageutil.ResolveToNonImageError{Ref: str, Updated: newRef}

--- a/builder/builder-next/adapters/localinlinecache/inlinecache.go
+++ b/builder/builder-next/adapters/localinlinecache/inlinecache.go
@@ -3,6 +3,7 @@ package localinlinecache
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/containerd/containerd/content"
@@ -19,7 +20,6 @@ import (
 	"github.com/moby/buildkit/worker"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 // ResolveCacheImporterFunc returns a resolver function for local inline cache
@@ -157,5 +157,5 @@ func parseCreatedLayerInfo(img image) ([]string, []string, error) {
 type emptyProvider struct{}
 
 func (p *emptyProvider) ReaderAt(ctx context.Context, dec ocispec.Descriptor) (content.ReaderAt, error) {
-	return nil, errors.Errorf("ReaderAt not implemented for empty provider")
+	return nil, fmt.Errorf("ReaderAt not implemented for empty provider")
 }

--- a/builder/builder-next/adapters/snapshot/layer.go
+++ b/builder/builder-next/adapters/snapshot/layer.go
@@ -2,12 +2,12 @@ package snapshot
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/longpath"
-	"github.com/pkg/errors"
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/sync/errgroup"
 )
@@ -31,7 +31,7 @@ func (s *snapshotter) EnsureLayer(ctx context.Context, key string) ([]layer.Diff
 
 	id, committed := s.getGraphDriverID(key)
 	if !committed {
-		return nil, errors.Errorf("can not convert active %s to layer", key)
+		return nil, fmt.Errorf("can not convert active %s to layer", key)
 	}
 
 	info, err := s.Stat(ctx, key)
@@ -119,5 +119,5 @@ func getGraphID(l layer.Layer) (string, error) {
 	}); ok {
 		return l.CacheID(), nil
 	}
-	return "", errors.Errorf("couldn't access cacheID for %s", l.ChainID())
+	return "", fmt.Errorf("couldn't access cacheID for %s", l.ChainID())
 }

--- a/builder/builder-next/adapters/snapshot/snapshot.go
+++ b/builder/builder-next/adapters/snapshot/snapshot.go
@@ -2,6 +2,7 @@ package snapshot
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -67,7 +68,7 @@ func NewSnapshotter(opt Opt, prevLM leases.Manager, ns string) (snapshot.Snapsho
 
 	reg, ok := opt.LayerStore.(graphIDRegistrar)
 	if !ok {
-		return nil, nil, errors.Errorf("layerstore doesn't support graphID registration")
+		return nil, nil, fmt.Errorf("layerstore doesn't support graphID registration")
 	}
 
 	s := &snapshotter{
@@ -327,7 +328,7 @@ func (s *snapshotter) Mounts(ctx context.Context, key string) (snapshot.Mountabl
 }
 
 func (s *snapshotter) Remove(ctx context.Context, key string) error {
-	return errors.Errorf("calling snapshot.remove is forbidden")
+	return fmt.Errorf("calling snapshot.remove is forbidden")
 }
 
 func (s *snapshotter) remove(ctx context.Context, key string) error {

--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -225,7 +225,7 @@ func (b *Builder) Prune(ctx context.Context, opts types.BuildCachePruneOptions) 
 // Build executes a build request
 func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.Result, error) {
 	if len(opt.Options.Outputs) > 1 {
-		return nil, errors.Errorf("multiple outputs not supported")
+		return nil, fmt.Errorf("multiple outputs not supported")
 	}
 
 	rc := opt.Source
@@ -336,7 +336,7 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 		frontendAttrs["force-network-mode"] = opt.Options.NetworkMode
 	case "", "default":
 	default:
-		return nil, errors.Errorf("network mode %q not supported by buildkit", opt.Options.NetworkMode)
+		return nil, fmt.Errorf("network mode %q not supported by buildkit", opt.Options.NetworkMode)
 	}
 
 	extraHosts, err := toBuildkitExtraHosts(opt.Options.ExtraHosts, b.dnsconfig.HostGatewayIP)
@@ -416,7 +416,7 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 		}
 		id, ok := resp.ExporterResponse["containerimage.digest"]
 		if !ok {
-			return errors.Errorf("missing image id")
+			return fmt.Errorf("missing image id")
 		}
 		out.ImageID = id
 		return aux.Emit("moby.image.id", types.BuildResult{ID: id})
@@ -591,7 +591,7 @@ func toBuildkitExtraHosts(inp []string, hostGatewayIP net.IP) (string, error) {
 	for _, h := range inp {
 		host, ip, ok := strings.Cut(h, ":")
 		if !ok || host == "" || ip == "" {
-			return "", errors.Errorf("invalid host %s", h)
+			return "", fmt.Errorf("invalid host %s", h)
 		}
 		// If the IP Address is a "host-gateway", replace this value with the
 		// IP address stored in the daemon level HostGatewayIP config variable.

--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -2,6 +2,7 @@ package buildkit
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -206,7 +207,7 @@ func newGraphDriverController(ctx context.Context, rt http.RoundTripper, opt Opt
 	}); ok {
 		driver = ls.Driver()
 	} else {
-		return nil, errors.Errorf("could not access graphdriver")
+		return nil, fmt.Errorf("could not access graphdriver")
 	}
 
 	innerStore, err := local.NewStore(filepath.Join(root, "content"))
@@ -244,7 +245,7 @@ func newGraphDriverController(ctx context.Context, rt http.RoundTripper, opt Opt
 
 	layerGetter, ok := snapshotter.(imagerefchecker.LayerGetter)
 	if !ok {
-		return nil, errors.Errorf("snapshotter does not implement layergetter")
+		return nil, fmt.Errorf("snapshotter does not implement layergetter")
 	}
 
 	refChecker := imagerefchecker.New(imagerefchecker.Opt{
@@ -289,7 +290,7 @@ func newGraphDriverController(ctx context.Context, rt http.RoundTripper, opt Opt
 
 	differ, ok := snapshotter.(mobyexporter.Differ)
 	if !ok {
-		return nil, errors.Errorf("snapshotter doesn't support differ")
+		return nil, fmt.Errorf("snapshotter doesn't support differ")
 	}
 
 	exp, err := mobyexporter.New(mobyexporter.Opt{
@@ -318,7 +319,7 @@ func newGraphDriverController(ctx context.Context, rt http.RoundTripper, opt Opt
 
 	layers, ok := snapshotter.(mobyworker.LayerAccess)
 	if !ok {
-		return nil, errors.Errorf("snapshotter doesn't support differ")
+		return nil, fmt.Errorf("snapshotter doesn't support differ")
 	}
 
 	leases, err := lm.List(ctx, `labels."buildkit/lease.temporary"`)

--- a/builder/builder-next/exporter/mobyexporter/export.go
+++ b/builder/builder-next/exporter/mobyexporter/export.go
@@ -112,7 +112,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, inp *exporter.Source
 			return nil, nil, errors.Wrapf(err, "failed to parse platforms passed to exporter")
 		}
 		if len(p.Platforms) != len(inp.Refs) {
-			return nil, nil, errors.Errorf("number of platforms does not match references %d %d", len(p.Platforms), len(inp.Refs))
+			return nil, nil, fmt.Errorf("number of platforms does not match references %d %d", len(p.Platforms), len(inp.Refs))
 		}
 		config = inp.Metadata[fmt.Sprintf("%s/%s", exptypes.ExporterImageConfigKey, p.Platforms[0].ID)]
 	}

--- a/builder/builder-next/reqbodyhandler.go
+++ b/builder/builder-next/reqbodyhandler.go
@@ -1,13 +1,13 @@
 package buildkit
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"sync"
 
 	"github.com/moby/buildkit/identity"
-	"github.com/pkg/errors"
 )
 
 const urlPrefix = "build-context-"
@@ -43,7 +43,7 @@ func (h *reqBodyHandler) RoundTrip(req *http.Request) (*http.Response, error) {
 	host := req.URL.Host
 	if strings.HasPrefix(host, urlPrefix) {
 		if req.Method != http.MethodGet {
-			return nil, errors.Errorf("invalid request")
+			return nil, fmt.Errorf("invalid request")
 		}
 		id := strings.TrimPrefix(host, urlPrefix)
 		h.mu.Lock()
@@ -52,7 +52,7 @@ func (h *reqBodyHandler) RoundTrip(req *http.Request) (*http.Response, error) {
 		h.mu.Unlock()
 
 		if !ok {
-			return nil, errors.Errorf("context not found")
+			return nil, fmt.Errorf("context not found")
 		}
 
 		resp := &http.Response{

--- a/builder/builder-next/worker/worker.go
+++ b/builder/builder-next/worker/worker.go
@@ -47,7 +47,6 @@ import (
 	"github.com/moby/buildkit/version"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -232,7 +231,7 @@ func (w *Worker) ResolveOp(v solver.Vertex, s frontend.FrontendLLBBridge, sm *se
 			return ops.NewDiffOp(v, op, w)
 		}
 	}
-	return nil, errors.Errorf("could not resolve %v", v)
+	return nil, fmt.Errorf("could not resolve %v", v)
 }
 
 // ResolveImageConfig returns image config for an image
@@ -264,7 +263,7 @@ func (w *Worker) Exporter(name string, sm *session.Manager) (exporter.Exporter, 
 			SessionManager: sm,
 		})
 	default:
-		return nil, errors.Errorf("exporter %q could not be found", name)
+		return nil, fmt.Errorf("exporter %q could not be found", name)
 	}
 }
 
@@ -388,7 +387,7 @@ func (w *Worker) FromRemote(ctx context.Context, remote *solver.Remote) (cache.I
 	defer release()
 
 	if len(rootFS.DiffIDs) != len(layers) {
-		return nil, errors.Errorf("invalid layer count mismatch %d vs %d", len(rootFS.DiffIDs), len(layers))
+		return nil, fmt.Errorf("invalid layer count mismatch %d vs %d", len(rootFS.DiffIDs), len(layers))
 	}
 
 	for i := range rootFS.DiffIDs {
@@ -412,7 +411,7 @@ func (w *Worker) FromRemote(ctx context.Context, remote *solver.Remote) (cache.I
 		defer ref.Release(context.TODO())
 	}
 
-	return nil, errors.Errorf("unreachable")
+	return nil, fmt.Errorf("unreachable")
 }
 
 // Executor returns executor.Executor for running processes
@@ -485,7 +484,7 @@ func getLayers(ctx context.Context, descs []ocispec.Descriptor) ([]rootfs.Layer,
 	for i, desc := range descs {
 		diffIDStr := desc.Annotations["containerd.io/uncompressed"]
 		if diffIDStr == "" {
-			return nil, errors.Errorf("%s missing uncompressed digest", desc.Digest)
+			return nil, fmt.Errorf("%s missing uncompressed digest", desc.Digest)
 		}
 		diffID, err := digest.Parse(diffIDStr)
 		if err != nil {
@@ -524,5 +523,5 @@ func oneOffProgress(ctx context.Context, id string) func(err error) error {
 type emptyProvider struct{}
 
 func (p *emptyProvider) ReaderAt(ctx context.Context, dec ocispec.Descriptor) (content.ReaderAt, error) {
-	return nil, errors.Errorf("ReaderAt not implemented for empty provider")
+	return nil, fmt.Errorf("ReaderAt not implemented for empty provider")
 }

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -199,7 +199,7 @@ func (b *Builder) build(ctx context.Context, source builder.Source, dockerfile *
 		targetIx, found := instructions.HasStage(stages, b.options.Target)
 		if !found {
 			buildsFailed.WithValues(metricsBuildTargetNotReachableError).Inc()
-			return nil, errdefs.InvalidParameter(errors.Errorf("target stage %q could not be found", b.options.Target))
+			return nil, errdefs.InvalidParameter(fmt.Errorf("target stage %q could not be found", b.options.Target))
 		}
 		stages = stages[:targetIx+1]
 	}
@@ -340,7 +340,7 @@ func BuildFromConfig(ctx context.Context, config *container.Config, changes []st
 	// ensure that the commands are valid
 	for _, n := range dockerfile.AST.Children {
 		if !validCommitCommands[strings.ToLower(n.Value)] {
-			return nil, errdefs.InvalidParameter(errors.Errorf("%s is not a valid change command", n.Value))
+			return nil, errdefs.InvalidParameter(fmt.Errorf("%s is not a valid change command", n.Value))
 		}
 	}
 

--- a/builder/dockerfile/copy.go
+++ b/builder/dockerfile/copy.go
@@ -116,7 +116,7 @@ func (o *copier) createCopyInstruction(sourcesAndDest instructions.SourcesAndDes
 		return inst, errors.Wrapf(err, "%s failed", cmdName)
 	}
 	if len(infos) > 1 && !strings.HasSuffix(inst.dest, string(os.PathSeparator)) {
-		return inst, errors.Errorf("When using %s with more than one source file, the destination must be a directory and end with a /", cmdName)
+		return inst, fmt.Errorf("When using %s with more than one source file, the destination must be a directory and end with a /", cmdName)
 	}
 	inst.infos = infos
 	return inst, nil
@@ -154,7 +154,7 @@ func (o *copier) getCopyInfoForSourcePath(orig, dest string) ([]copyInfo, error)
 	// We have to make sure dest is available
 	if path == "" {
 		if strings.HasSuffix(dest, "/") {
-			return nil, errors.Errorf("cannot determine filename for source %s", orig)
+			return nil, fmt.Errorf("cannot determine filename for source %s", orig)
 		}
 		path = unnamedFilename
 	}
@@ -206,7 +206,7 @@ func (o *copier) calcCopyInfo(origPath string, allowWildcards bool) ([]copyInfo,
 	}
 
 	if o.source == nil {
-		return nil, errors.Errorf("missing build context")
+		return nil, fmt.Errorf("missing build context")
 	}
 
 	// Work in daemon-specific OS filepath semantics

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -273,7 +273,7 @@ func (d *dispatchRequest) getFromImage(ctx context.Context, shlex *shell.Lex, ba
 	// Empty string is interpreted to FROM scratch by images.GetImageAndReleasableLayer,
 	// so validate expanded result is not empty.
 	if name == "" {
-		return nil, errors.Errorf("base name (%s) should not be blank", basename)
+		return nil, fmt.Errorf("base name (%s) should not be blank", basename)
 	}
 
 	return d.getImageOrStage(ctx, name, platform)
@@ -336,7 +336,7 @@ func dispatchRun(ctx context.Context, d dispatchRequest, c *instructions.RunComm
 
 	if len(c.FlagsUsed) > 0 {
 		// classic builder RUN currently does not support any flags, so fail on the first one
-		return errors.Errorf("the --%s option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled", c.FlagsUsed[0])
+		return fmt.Errorf("the --%s option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled", c.FlagsUsed[0])
 	}
 
 	stateRunConfig := d.state.runConfig

--- a/builder/dockerfile/evaluator.go
+++ b/builder/dockerfile/evaluator.go
@@ -21,6 +21,7 @@ package dockerfile // import "github.com/docker/docker/builder/dockerfile"
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -101,7 +102,7 @@ func dispatch(ctx context.Context, d dispatchRequest, cmd instructions.Command) 
 	case *instructions.ShellCommand:
 		return dispatchShell(ctx, d, c)
 	}
-	return errors.Errorf("unsupported command type: %v", reflect.TypeOf(cmd))
+	return fmt.Errorf("unsupported command type: %v", reflect.TypeOf(cmd))
 }
 
 // dispatchState is a data object which is modified by dispatchers
@@ -165,7 +166,7 @@ func (r *stagesBuildResults) get(nameOrIndex string) (*container.Config, error) 
 func (r *stagesBuildResults) checkStageNameAvailable(name string) error {
 	if name != "" {
 		if _, ok := r.getByName(name); ok {
-			return errors.Errorf("%s stage name already used", name)
+			return fmt.Errorf("%s stage name already used", name)
 		}
 	}
 	return nil
@@ -174,7 +175,7 @@ func (r *stagesBuildResults) checkStageNameAvailable(name string) error {
 func (r *stagesBuildResults) commitStage(name string, config *container.Config) error {
 	if name != "" {
 		if _, ok := r.getByName(name); ok {
-			return errors.Errorf("%s stage name already used", name)
+			return fmt.Errorf("%s stage name already used", name)
 		}
 		r.indexed[strings.ToLower(name)] = config
 	}

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -71,7 +71,7 @@ func (b *Builder) exportImage(ctx context.Context, state *dispatchState, layer b
 
 	parentImage, ok := parent.(*image.Image)
 	if !ok {
-		return errors.Errorf("unexpected image type")
+		return fmt.Errorf("unexpected image type")
 	}
 
 	platform := &ocispec.Platform{

--- a/builder/remotecontext/detect.go
+++ b/builder/remotecontext/detect.go
@@ -66,7 +66,7 @@ func withDockerfileFromContext(c modifiableContext, dockerfilePath string) (buil
 					return withDockerfileFromContext(c, lowercase)
 				}
 			}
-			return nil, nil, errors.Errorf("Cannot locate specified Dockerfile: %s", dockerfilePath) // backwards compatible error
+			return nil, nil, fmt.Errorf("Cannot locate specified Dockerfile: %s", dockerfilePath) // backwards compatible error
 		}
 		c.Close()
 		return nil, nil, err
@@ -145,7 +145,7 @@ func readAndParseDockerfile(name string, rc io.Reader) (*parser.Result, error) {
 	br := bufio.NewReader(rc)
 	if _, err := br.Peek(1); err != nil {
 		if err == io.EOF {
-			return nil, errdefs.InvalidParameter(errors.Errorf("the Dockerfile (%s) cannot be empty", name))
+			return nil, errdefs.InvalidParameter(fmt.Errorf("the Dockerfile (%s) cannot be empty", name))
 		}
 		return nil, errors.Wrap(err, "unexpected error reading Dockerfile")
 	}

--- a/builder/remotecontext/git/gitutils.go
+++ b/builder/remotecontext/git/gitutils.go
@@ -1,6 +1,7 @@
 package git // import "github.com/docker/docker/builder/remotecontext/git"
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -113,7 +114,7 @@ func parseRemoteURL(remoteURL string) (gitRepo, error) {
 	}
 
 	if strings.HasPrefix(repo.ref, "-") {
-		return gitRepo{}, errors.Errorf("invalid refspec: %s", repo.ref)
+		return gitRepo{}, fmt.Errorf("invalid refspec: %s", repo.ref)
 	}
 
 	return repo, nil
@@ -190,7 +191,7 @@ func (repo gitRepo) checkout(root string) (string, error) {
 			return "", err
 		}
 		if !fi.IsDir() {
-			return "", errors.Errorf("error setting git context, not a directory: %s", newCtx)
+			return "", fmt.Errorf("error setting git context, not a directory: %s", newCtx)
 		}
 		root = newCtx
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -44,6 +44,7 @@ package client // import "github.com/docker/docker/client"
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -365,7 +366,7 @@ func (cli *Client) HTTPClient() *http.Client {
 func ParseHostURL(host string) (*url.URL, error) {
 	proto, addr, ok := strings.Cut(host, "://")
 	if !ok || addr == "" {
-		return nil, errors.Errorf("unable to parse docker host `%s`", host)
+		return nil, fmt.Errorf("unable to parse docker host `%s`", host)
 	}
 
 	var basePath string

--- a/client/options.go
+++ b/client/options.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -53,7 +54,7 @@ func WithDialContext(dialContext func(ctx context.Context, network, addr string)
 			transport.DialContext = dialContext
 			return nil
 		}
-		return errors.Errorf("cannot apply dialer to transport: %T", c.client.Transport)
+		return fmt.Errorf("cannot apply dialer to transport: %T", c.client.Transport)
 	}
 }
 
@@ -71,7 +72,7 @@ func WithHost(host string) Opt {
 		if transport, ok := c.client.Transport.(*http.Transport); ok {
 			return sockets.ConfigureTransport(transport, c.proto, c.addr)
 		}
-		return errors.Errorf("cannot apply host to transport: %T", c.client.Transport)
+		return fmt.Errorf("cannot apply host to transport: %T", c.client.Transport)
 	}
 }
 
@@ -138,7 +139,7 @@ func WithTLSClientConfig(cacertPath, certPath, keyPath string) Opt {
 	return func(c *Client) error {
 		transport, ok := c.client.Transport.(*http.Transport)
 		if !ok {
-			return errors.Errorf("cannot apply tls config to transport: %T", c.client.Transport)
+			return fmt.Errorf("cannot apply tls config to transport: %T", c.client.Transport)
 		}
 		config, err := tlsconfig.Client(tlsconfig.Options{
 			CAFile:             cacertPath,

--- a/client/plugin_install.go
+++ b/client/plugin_install.go
@@ -3,6 +3,7 @@ package client // import "github.com/docker/docker/client"
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -110,7 +111,7 @@ func (cli *Client) checkPluginPermissions(ctx context.Context, query url.Values,
 			return nil, err
 		}
 		if !accept {
-			return nil, errors.Errorf("permission denied while installing plugin %s", options.RemoteRef)
+			return nil, fmt.Errorf("permission denied while installing plugin %s", options.RemoteRef)
 		}
 	}
 	return privileges, nil

--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os"
 	"os/signal"
@@ -49,7 +50,7 @@ func setDefaultUmask() error {
 	desiredUmask := 0o022
 	unix.Umask(desiredUmask)
 	if umask := unix.Umask(desiredUmask); umask != desiredUmask {
-		return errors.Errorf("failed to set umask: expected %#o, got %#o", desiredUmask, umask)
+		return fmt.Errorf("failed to set umask: expected %#o, got %#o", desiredUmask, umask)
 	}
 
 	return nil
@@ -89,13 +90,13 @@ func allocateDaemonPort(addr string) error {
 	if parsedIP := net.ParseIP(host); parsedIP != nil {
 		hostIPs = append(hostIPs, parsedIP)
 	} else if hostIPs, err = net.LookupIP(host); err != nil {
-		return errors.Errorf("failed to lookup %s address in host specification", host)
+		return fmt.Errorf("failed to lookup %s address in host specification", host)
 	}
 
 	pa := portallocator.Get()
 	for _, hostIP := range hostIPs {
 		if _, err := pa.RequestPort(hostIP, "tcp", intPort); err != nil {
-			return errors.Errorf("failed to allocate daemon listening port %d (err: %v)", intPort, err)
+			return fmt.Errorf("failed to allocate daemon listening port %d (err: %v)", intPort, err)
 		}
 	}
 	return nil

--- a/cmd/dockerd/required.go
+++ b/cmd/dockerd/required.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -14,10 +14,10 @@ func NoArgs(cmd *cobra.Command, args []string) error {
 	}
 
 	if cmd.HasSubCommands() {
-		return errors.Errorf("\n" + strings.TrimRight(cmd.UsageString(), "\n"))
+		return fmt.Errorf("\n" + strings.TrimRight(cmd.UsageString(), "\n"))
 	}
 
-	return errors.Errorf(
+	return fmt.Errorf(
 		"\"%s\" accepts no argument(s).\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
 		cmd.CommandPath(),
 		cmd.CommandPath(),

--- a/container/container.go
+++ b/container/container.go
@@ -283,7 +283,7 @@ func (container *Container) SetupWorkingDirectory(rootIdentity idtools.Identity)
 	if err := idtools.MkdirAllAndChownNew(pth, 0o755, rootIdentity); err != nil {
 		pthInfo, err2 := os.Stat(pth)
 		if err2 == nil && pthInfo != nil && !pthInfo.IsDir() {
-			return errors.Errorf("Cannot mkdir: %s is not a directory", container.Config.WorkingDir)
+			return fmt.Errorf("Cannot mkdir: %s is not a directory", container.Config.WorkingDir)
 		}
 
 		return err

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -24,7 +24,7 @@ func (daemon *Daemon) ContainerAttach(prefixOrName string, c *backend.ContainerA
 	if c.DetachKeys != "" {
 		keys, err = term.ToBytes(c.DetachKeys)
 		if err != nil {
-			return errdefs.InvalidParameter(errors.Errorf("Invalid detach keys (%s) provided", c.DetachKeys))
+			return errdefs.InvalidParameter(fmt.Errorf("Invalid detach keys (%s) provided", c.DetachKeys))
 		}
 	}
 

--- a/daemon/cluster/controllers/plugin/controller.go
+++ b/daemon/cluster/controllers/plugin/controller.go
@@ -2,6 +2,7 @@ package plugin // import "github.com/docker/docker/daemon/cluster/controllers/pl
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -111,7 +112,7 @@ func (p *Controller) Prepare(ctx context.Context) (err error) {
 
 	if err == nil && pl != nil {
 		if pl.SwarmServiceID != p.serviceID {
-			return errors.Errorf("plugin already exists: %s", p.spec.Name)
+			return fmt.Errorf("plugin already exists: %s", p.spec.Name)
 		}
 		if pl.IsEnabled() {
 			if err := p.backend.Disable(pl.GetID(), &types.PluginDisableConfig{ForceDisable: true}); err != nil {

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -620,7 +620,7 @@ func (c *Cluster) imageWithDigestString(ctx context.Context, image string, authC
 		if _, ok := ref.(reference.Digested); ok {
 			return image, nil
 		}
-		return "", errors.Errorf("unknown image reference format: %s", image)
+		return "", fmt.Errorf("unknown image reference format: %s", image)
 	}
 	// only query registry if not a canonical reference (i.e. with digest)
 	if _, ok := namedRef.(reference.Canonical); !ok {
@@ -628,7 +628,7 @@ func (c *Cluster) imageWithDigestString(ctx context.Context, image string, authC
 
 		taggedRef, ok := namedRef.(reference.NamedTagged)
 		if !ok {
-			return "", errors.Errorf("image reference not tagged: %s", image)
+			return "", fmt.Errorf("image reference not tagged: %s", image)
 		}
 
 		repo, err := c.config.ImageBackend.GetRepository(ctx, taggedRef, authConfig)

--- a/daemon/cluster/swarm.go
+++ b/daemon/cluster/swarm.go
@@ -351,7 +351,7 @@ func (c *Cluster) UnlockSwarm(req types.UnlockRequest) error {
 		if errors.Is(err, errSwarmLocked) {
 			return invalidUnlockKey{}
 		}
-		return errors.Errorf("swarm component could not be started: %v", err)
+		return fmt.Errorf("swarm component could not be started: %v", err)
 	}
 	return nil
 }

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/builder/dockerfile"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 )
 
 // merge merges two Config, the image container configuration (defaults values),
@@ -132,7 +131,7 @@ func (daemon *Daemon) CreateImageFromContainer(ctx context.Context, name string,
 
 	// It is not possible to commit a running container on Windows
 	if isWindows && container.IsRunning() {
-		return "", errors.Errorf("%+v does not support commit of a running container", runtime.GOOS)
+		return "", fmt.Errorf("%+v does not support commit of a running container", runtime.GOOS)
 	}
 
 	if container.IsDead() {

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -311,7 +311,7 @@ func GetConflictFreeLabels(labels []string) ([]string, error) {
 		if ok {
 			// If there is a conflict we will return an error
 			if v, ok := labelMap[key]; ok && v != val {
-				return nil, errors.Errorf("conflict labels for %s=%s and %s=%s", key, val, key, v)
+				return nil, fmt.Errorf("conflict labels for %s=%s and %s=%s", key, val, key, v)
 			}
 			labelMap[key] = val
 		}
@@ -544,7 +544,7 @@ func findConfigurationConflicts(config map[string]interface{}, flags *pflag.Flag
 		for key := range unknownKeys {
 			unknown = append(unknown, key)
 		}
-		return errors.Errorf("the following directives don't match any configuration option: %s", strings.Join(unknown, ", "))
+		return fmt.Errorf("the following directives don't match any configuration option: %s", strings.Join(unknown, ", "))
 	}
 
 	var conflicts []string
@@ -578,7 +578,7 @@ func findConfigurationConflicts(config map[string]interface{}, flags *pflag.Flag
 	flags.Visit(duplicatedConflicts)
 
 	if len(conflicts) > 0 {
-		return errors.Errorf("the following directives are specified both as a flag and in the configuration file: %s", strings.Join(conflicts, ", "))
+		return fmt.Errorf("the following directives are specified both as a flag and in the configuration file: %s", strings.Join(conflicts, ", "))
 	}
 	return nil
 }
@@ -595,7 +595,7 @@ func Validate(config *Config) error {
 		case "panic", "fatal", "error", "warn", "info", "debug", "trace":
 			// These are valid. See [log.SetLevel] for a list of accepted levels.
 		default:
-			return errors.Errorf("invalid logging level: %s", config.LogLevel)
+			return fmt.Errorf("invalid logging level: %s", config.LogLevel)
 		}
 	}
 
@@ -605,7 +605,7 @@ func Validate(config *Config) error {
 		case log.TextFormat, log.JSONFormat:
 			// These are valid
 		default:
-			return errors.Errorf("invalid log format: %s", logFormat)
+			return fmt.Errorf("invalid log format: %s", logFormat)
 		}
 	}
 
@@ -632,16 +632,16 @@ func Validate(config *Config) error {
 
 	// TODO(thaJeztah) Validations below should not accept "0" to be valid; see Validate() for a more in-depth description of this problem
 	if config.MTU < 0 {
-		return errors.Errorf("invalid default MTU: %d", config.MTU)
+		return fmt.Errorf("invalid default MTU: %d", config.MTU)
 	}
 	if config.MaxConcurrentDownloads < 0 {
-		return errors.Errorf("invalid max concurrent downloads: %d", config.MaxConcurrentDownloads)
+		return fmt.Errorf("invalid max concurrent downloads: %d", config.MaxConcurrentDownloads)
 	}
 	if config.MaxConcurrentUploads < 0 {
-		return errors.Errorf("invalid max concurrent uploads: %d", config.MaxConcurrentUploads)
+		return fmt.Errorf("invalid max concurrent uploads: %d", config.MaxConcurrentUploads)
 	}
 	if config.MaxDownloadAttempts < 0 {
-		return errors.Errorf("invalid max download attempts: %d", config.MaxDownloadAttempts)
+		return fmt.Errorf("invalid max download attempts: %d", config.MaxDownloadAttempts)
 	}
 
 	if _, err := ParseGenericResources(config.NodeGenericResources); err != nil {

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -270,7 +270,7 @@ func validateHostConfig(hostConfig *containertypes.HostConfig) error {
 	}
 
 	if hostConfig.AutoRemove && !hostConfig.RestartPolicy.IsNone() {
-		return errors.Errorf("can't create 'AutoRemove' container with restart policy")
+		return fmt.Errorf("can't create 'AutoRemove' container with restart policy")
 	}
 	// Validate mounts; check if host directories still exist
 	parser := volumemounts.NewParser()
@@ -295,11 +295,11 @@ func validateHostConfig(hostConfig *containertypes.HostConfig) error {
 		return err
 	}
 	if !hostConfig.Isolation.IsValid() {
-		return errors.Errorf("invalid isolation '%s' on %s", hostConfig.Isolation, runtime.GOOS)
+		return fmt.Errorf("invalid isolation '%s' on %s", hostConfig.Isolation, runtime.GOOS)
 	}
 	for k := range hostConfig.Annotations {
 		if k == "" {
-			return errors.Errorf("invalid Annotations: the empty string is not permitted as an annotation key")
+			return fmt.Errorf("invalid Annotations: the empty string is not permitted as an annotation key")
 		}
 	}
 	return nil
@@ -322,19 +322,19 @@ func validateHealthCheck(healthConfig *containertypes.HealthConfig) error {
 		return nil
 	}
 	if healthConfig.Interval != 0 && healthConfig.Interval < containertypes.MinimumDuration {
-		return errors.Errorf("Interval in Healthcheck cannot be less than %s", containertypes.MinimumDuration)
+		return fmt.Errorf("Interval in Healthcheck cannot be less than %s", containertypes.MinimumDuration)
 	}
 	if healthConfig.Timeout != 0 && healthConfig.Timeout < containertypes.MinimumDuration {
-		return errors.Errorf("Timeout in Healthcheck cannot be less than %s", containertypes.MinimumDuration)
+		return fmt.Errorf("Timeout in Healthcheck cannot be less than %s", containertypes.MinimumDuration)
 	}
 	if healthConfig.Retries < 0 {
-		return errors.Errorf("Retries in Healthcheck cannot be negative")
+		return fmt.Errorf("Retries in Healthcheck cannot be negative")
 	}
 	if healthConfig.StartPeriod != 0 && healthConfig.StartPeriod < containertypes.MinimumDuration {
-		return errors.Errorf("StartPeriod in Healthcheck cannot be less than %s", containertypes.MinimumDuration)
+		return fmt.Errorf("StartPeriod in Healthcheck cannot be less than %s", containertypes.MinimumDuration)
 	}
 	if healthConfig.StartInterval != 0 && healthConfig.StartInterval < containertypes.MinimumDuration {
-		return errors.Errorf("StartInterval in Healthcheck cannot be less than %s", containertypes.MinimumDuration)
+		return fmt.Errorf("StartInterval in Healthcheck cannot be less than %s", containertypes.MinimumDuration)
 	}
 	return nil
 }
@@ -343,12 +343,12 @@ func validatePortBindings(ports nat.PortMap) error {
 	for port := range ports {
 		_, portStr := nat.SplitProtoPort(string(port))
 		if _, err := nat.ParsePort(portStr); err != nil {
-			return errors.Errorf("invalid port specification: %q", portStr)
+			return fmt.Errorf("invalid port specification: %q", portStr)
 		}
 		for _, pb := range ports[port] {
 			_, err := nat.NewPort(nat.SplitProtoPort(pb.HostPort))
 			if err != nil {
-				return errors.Errorf("invalid port specification: %q", pb.HostPort)
+				return fmt.Errorf("invalid port specification: %q", pb.HostPort)
 			}
 		}
 	}

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -355,7 +355,7 @@ func killProcessDirectly(container *container.Container) error {
 			return err
 		}
 		if isZombie {
-			return errdefs.System(errors.Errorf("container %s PID %d is zombie and can not be killed. Use the --init option when creating containers to run an init inside the container that forwards signals and reaps processes", stringid.TruncateID(container.ID), pid))
+			return errdefs.System(fmt.Errorf("container %s PID %d is zombie and can not be killed. Use the --init option when creating containers to run an init inside the container that forwards signals and reaps processes", stringid.TruncateID(container.ID), pid))
 		}
 	}
 	return nil

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -180,9 +180,9 @@ func (i *ImageService) GetImageManifest(ctx context.Context, refOrID string, opt
 
 		if options.Platform != nil {
 			if plat == nil {
-				return nil, errdefs.NotFound(errors.Errorf("image with reference %s was found but does not match the specified platform: wanted %s, actual: nil", refOrID, cplatforms.Format(*options.Platform)))
+				return nil, errdefs.NotFound(fmt.Errorf("image with reference %s was found but does not match the specified platform: wanted %s, actual: nil", refOrID, cplatforms.Format(*options.Platform)))
 			} else if !platform.Match(*plat) {
-				return nil, errdefs.NotFound(errors.Errorf("image with reference %s was found but does not match the specified platform: wanted %s, actual: %s", refOrID, cplatforms.Format(*options.Platform), cplatforms.Format(*plat)))
+				return nil, errdefs.NotFound(fmt.Errorf("image with reference %s was found but does not match the specified platform: wanted %s, actual: %s", refOrID, cplatforms.Format(*options.Platform), cplatforms.Format(*plat)))
 			}
 		}
 

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -661,16 +661,16 @@ func verifyPlatformContainerSettings(daemon *Daemon, daemonCfg *configStore, hos
 	}
 
 	if !hostConfig.IpcMode.Valid() {
-		return warnings, errors.Errorf("invalid IPC mode: %v", hostConfig.IpcMode)
+		return warnings, fmt.Errorf("invalid IPC mode: %v", hostConfig.IpcMode)
 	}
 	if !hostConfig.PidMode.Valid() {
-		return warnings, errors.Errorf("invalid PID mode: %v", hostConfig.PidMode)
+		return warnings, fmt.Errorf("invalid PID mode: %v", hostConfig.PidMode)
 	}
 	if hostConfig.ShmSize < 0 {
 		return warnings, fmt.Errorf("SHM size can not be less than 0")
 	}
 	if !hostConfig.UTSMode.Valid() {
-		return warnings, errors.Errorf("invalid UTS mode: %v", hostConfig.UTSMode)
+		return warnings, fmt.Errorf("invalid UTS mode: %v", hostConfig.UTSMode)
 	}
 
 	if hostConfig.OomScoreAdj < -1000 || hostConfig.OomScoreAdj > 1000 {

--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -16,7 +16,7 @@ func isNotRunning(err error) bool {
 }
 
 func errNotRunning(id string) error {
-	return &containerNotRunningError{errors.Errorf("container %s is not running", id)}
+	return &containerNotRunningError{fmt.Errorf("container %s is not running", id)}
 }
 
 type containerNotRunningError struct {
@@ -41,7 +41,7 @@ func (e objNotFoundError) Error() string {
 func (e objNotFoundError) NotFound() {}
 
 func errContainerIsRestarting(containerID string) error {
-	cause := errors.Errorf("Container %s is restarting, wait until the container is running", containerID)
+	cause := fmt.Errorf("Container %s is restarting, wait until the container is running", containerID)
 	return errdefs.Conflict(cause)
 }
 
@@ -50,12 +50,12 @@ func errExecNotFound(id string) error {
 }
 
 func errExecPaused(id string) error {
-	cause := errors.Errorf("Container %s is paused, unpause the container before exec", id)
+	cause := fmt.Errorf("Container %s is paused, unpause the container before exec", id)
 	return errdefs.Conflict(cause)
 }
 
 func errNotPaused(id string) error {
-	cause := errors.Errorf("Container %s is already paused", id)
+	cause := fmt.Errorf("Container %s is already paused", id)
 	return errdefs.Conflict(cause)
 }
 

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/plugingetter"
-	"github.com/pkg/errors"
 	"github.com/vbatts/tar-split/tar/storage"
 )
 
@@ -150,7 +149,7 @@ func init() {
 // Register registers an InitFunc for the driver.
 func Register(name string, initFunc InitFunc) error {
 	if _, exists := drivers[name]; exists {
-		return errors.Errorf("name already registered %s", name)
+		return fmt.Errorf("name already registered %s", name)
 	}
 	drivers[name] = initFunc
 
@@ -225,7 +224,7 @@ func New(name string, pg plugingetter.PluginGetter, config Options) (Driver, err
 					driversSlice = append(driversSlice, name)
 				}
 
-				err = errors.Errorf("%s contains several valid graphdrivers: %s; cleanup or explicitly choose storage driver (-s <DRIVER>)", config.Root, strings.Join(driversSlice, ", "))
+				err = fmt.Errorf("%s contains several valid graphdrivers: %s; cleanup or explicitly choose storage driver (-s <DRIVER>)", config.Root, strings.Join(driversSlice, ", "))
 				log.G(ctx).Errorf("[graphdriver] %v", err)
 				return nil, err
 			}
@@ -260,7 +259,7 @@ func New(name string, pg plugingetter.PluginGetter, config Options) (Driver, err
 		return driver, nil
 	}
 
-	return nil, errors.Errorf("no supported storage driver found")
+	return nil, fmt.Errorf("no supported storage driver found")
 }
 
 // scanPriorDrivers returns an un-ordered scan of directories of prior storage

--- a/daemon/graphdriver/plugin.go
+++ b/daemon/graphdriver/plugin.go
@@ -39,7 +39,7 @@ func newPluginDriver(name string, pl plugingetter.CompatPlugin, config Options) 
 		proxy = &graphDriverProxy{name, pl, Capabilities{}, pt.Client()}
 	case plugingetter.PluginAddr:
 		if pt.Protocol() != plugins.ProtocolSchemeHTTPV1 {
-			return nil, errors.Errorf("plugin protocol not supported: %s", pt.Protocol())
+			return nil, fmt.Errorf("plugin protocol not supported: %s", pt.Protocol())
 		}
 		addr := pt.Addr()
 		client, err := plugins.NewClientWithTimeout(addr.Network()+"://"+addr.String(), nil, pt.Timeout())
@@ -48,7 +48,7 @@ func newPluginDriver(name string, pl plugingetter.CompatPlugin, config Options) 
 		}
 		proxy = &graphDriverProxy{name, pl, Capabilities{}, client}
 	default:
-		return nil, errdefs.System(errors.Errorf("got unknown plugin type %T", pt))
+		return nil, errdefs.System(fmt.Errorf("got unknown plugin type %T", pt))
 	}
 
 	return proxy, proxy.Init(filepath.Join(home, name), config.DriverOptions, config.IDMap)

--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -115,11 +115,11 @@ func (d *Driver) parseOptions(options []string) error {
 			}
 		case xattrsStorageOpt:
 			if val != bestEffortXattrsOptValue {
-				return errdefs.InvalidParameter(errors.Errorf("do not set the " + xattrsStorageOpt + " option unless you are willing to accept the consequences"))
+				return errdefs.InvalidParameter(fmt.Errorf("do not set the " + xattrsStorageOpt + " option unless you are willing to accept the consequences"))
 			}
 			d.bestEffortXattrs = true
 		default:
-			return errdefs.InvalidParameter(errors.Errorf("unknown option %s for vfs", key))
+			return errdefs.InvalidParameter(fmt.Errorf("unknown option %s for vfs", key))
 		}
 	}
 	return nil
@@ -143,7 +143,7 @@ func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 				}
 				quotaSize = uint64(size)
 			default:
-				return errdefs.InvalidParameter(errors.Errorf("Storage opt %s not supported", key))
+				return errdefs.InvalidParameter(fmt.Errorf("Storage opt %s not supported", key))
 			}
 		}
 	}

--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -19,7 +19,6 @@ import (
 	"github.com/docker/docker/layer"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 // ErrImageDoesNotExist is error returned when no image can be found for a reference.
@@ -231,7 +230,7 @@ func (i *ImageService) getImage(ctx context.Context, refOrID string, options ima
 		//   This may be confusing.
 		//   The alternative to this is to return an errdefs.Conflict error with a helpful message, but clients will not be
 		//   able to automatically tell what causes the conflict.
-		retErr = errdefs.NotFound(errors.Errorf("image with reference %s was found but does not match the specified platform: wanted %s, actual: %s", refOrID, platforms.Format(p), platforms.Format(imgPlat)))
+		retErr = errdefs.NotFound(fmt.Errorf("image with reference %s was found but does not match the specified platform: wanted %s, actual: %s", refOrID, platforms.Format(p), platforms.Format(imgPlat)))
 	}()
 	ref, err := reference.ParseAnyReference(refOrID)
 	if err != nil {

--- a/daemon/images/image_commit.go
+++ b/daemon/images/image_commit.go
@@ -3,13 +3,13 @@ package images // import "github.com/docker/docker/daemon/images"
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/ioutils"
-	"github.com/pkg/errors"
 )
 
 // CommitImage creates a new image from a commit config
@@ -118,7 +118,7 @@ func (i *ImageService) CommitBuildStep(ctx context.Context, c backend.CommitConf
 	ctr := i.containers.Get(c.ContainerID)
 	if ctr == nil {
 		// TODO: use typed error
-		return "", errors.Errorf("container not found: %s", c.ContainerID)
+		return "", fmt.Errorf("container not found: %s", c.ContainerID)
 	}
 	c.ContainerMountLabel = ctr.MountLabel
 	c.ContainerOS = ctr.OS

--- a/daemon/images/image_delete.go
+++ b/daemon/images/image_delete.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/stringid"
-	"github.com/pkg/errors"
 )
 
 type conflictType int
@@ -88,7 +87,7 @@ func (i *ImageService) ImageDelete(ctx context.Context, imageRef string, force, 
 				// this image would remain "dangling" and since
 				// we really want to avoid that the client must
 				// explicitly force its removal.
-				err := errors.Errorf("conflict: unable to remove repository reference %q (must force) - container %s is using its referenced image %s", imageRef, stringid.TruncateID(ctr.ID), stringid.TruncateID(imgID.String()))
+				err := fmt.Errorf("conflict: unable to remove repository reference %q (must force) - container %s is using its referenced image %s", imageRef, stringid.TruncateID(ctr.ID), stringid.TruncateID(imgID.String()))
 				return nil, errdefs.Conflict(err)
 			}
 		}

--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -315,7 +315,7 @@ func parseInitVersion(v string) (version string, commit string, err error) {
 		version = strings.TrimPrefix(parts[0], "tini version ")
 	}
 	if version == "" && commit == "" {
-		err = errors.Errorf("unknown output format: %s", v)
+		err = fmt.Errorf("unknown output format: %s", v)
 	}
 	return version, commit, err
 }
@@ -343,7 +343,7 @@ func parseRuntimeVersion(v string) (runtime, version, commit string, err error) 
 		}
 	}
 	if version == "" && commit == "" {
-		err = errors.Errorf("unknown output format: %s", v)
+		err = fmt.Errorf("unknown output format: %s", v)
 	}
 	return runtime, version, commit, err
 }

--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -42,7 +42,7 @@ func (daemon *Daemon) ContainerKill(name, stopSignal string) error {
 			return errdefs.InvalidParameter(err)
 		}
 		if !signal.ValidSignalForPlatform(sig) {
-			return errdefs.InvalidParameter(errors.Errorf("the %s daemon does not support signal %d", runtime.GOOS, sig))
+			return errdefs.InvalidParameter(fmt.Errorf("the %s daemon does not support signal %d", runtime.GOOS, sig))
 		}
 	}
 	container, err := daemon.GetContainer(name)

--- a/daemon/listeners/listeners_linux.go
+++ b/daemon/listeners/listeners_linux.go
@@ -3,6 +3,7 @@ package listeners // import "github.com/docker/docker/daemon/listeners"
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"os"
 	"strconv"
@@ -53,7 +54,7 @@ func Init(proto, addr, socketGroup string, tlsConfig *tls.Config) ([]net.Listene
 		}
 		ls = append(ls, l)
 	default:
-		return nil, errors.Errorf("invalid protocol format: %q", proto)
+		return nil, fmt.Errorf("invalid protocol format: %q", proto)
 	}
 
 	return ls, nil
@@ -87,14 +88,14 @@ func listenFD(addr string, tlsConfig *tls.Config) ([]net.Listener, error) {
 
 	fdNum, err := strconv.Atoi(addr)
 	if err != nil {
-		return nil, errors.Errorf("failed to parse systemd fd address: should be a number: %v", addr)
+		return nil, fmt.Errorf("failed to parse systemd fd address: should be a number: %v", addr)
 	}
 	fdOffset := fdNum - 3
 	if len(listeners) < fdOffset+1 {
 		return nil, errors.New("too few socket activated files passed in by systemd")
 	}
 	if listeners[fdOffset] == nil {
-		return nil, errors.Errorf("failed to listen on systemd activated file: fd %d", fdOffset+3)
+		return nil, fmt.Errorf("failed to listen on systemd activated file: fd %d", fdOffset+3)
 	}
 	for i, ls := range listeners {
 		if i == fdOffset || ls == nil {

--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -4,6 +4,7 @@ package fluentd // import "github.com/docker/docker/daemon/logger/fluentd"
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"net/url"
 	"strconv"
@@ -158,7 +159,7 @@ func ValidateLogOpt(cfg map[string]string) error {
 		case subSecondPrecisionKey:
 			// Accepted
 		default:
-			return errors.Errorf("unknown log opt '%s' for fluentd log driver", key)
+			return fmt.Errorf("unknown log opt '%s' for fluentd log driver", key)
 		}
 	}
 
@@ -202,7 +203,7 @@ func parseConfig(cfg map[string]string) (fluent.Config, error) {
 	}
 
 	if cfg[asyncKey] != "" && cfg[asyncConnectKey] != "" {
-		return config, errors.Errorf("conflicting options: cannot specify both '%s' and '%s", asyncKey, asyncConnectKey)
+		return config, fmt.Errorf("conflicting options: cannot specify both '%s' and '%s", asyncKey, asyncConnectKey)
 	}
 
 	async := false
@@ -227,7 +228,7 @@ func parseConfig(cfg map[string]string) (fluent.Config, error) {
 			return config, errors.Wrapf(err, "invalid value for %s", asyncReconnectIntervalKey)
 		}
 		if interval != 0 && (interval < minReconnectInterval || interval > maxReconnectInterval) {
-			return config, errors.Errorf("invalid value for %s: value (%q) must be between %s and %s",
+			return config, fmt.Errorf("invalid value for %s: value (%q) must be between %s and %s",
 				asyncReconnectIntervalKey, interval, minReconnectInterval, maxReconnectInterval)
 		}
 		asyncReconnectInterval = int(interval.Milliseconds())
@@ -294,7 +295,7 @@ func parseAddress(address string) (*location, error) {
 	case "tcp", "tls":
 		// continue processing below
 	default:
-		return nil, errors.Errorf("unsupported scheme: '%s'", addr.Scheme)
+		return nil, fmt.Errorf("unsupported scheme: '%s'", addr.Scheme)
 	}
 
 	if addr.Path != "" {

--- a/daemon/logger/local/local.go
+++ b/daemon/logger/local/local.go
@@ -2,6 +2,7 @@ package local // import "github.com/docker/docker/daemon/logger/local"
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 	"math/bits"
 	"strconv"
@@ -46,7 +47,7 @@ var LogOptKeys = map[string]bool{
 func ValidateLogOpt(cfg map[string]string) error {
 	for key := range cfg {
 		if !LogOptKeys[key] {
-			return errors.Errorf("unknown log opt '%s' for log driver %s", key, Name)
+			return fmt.Errorf("unknown log opt '%s' for log driver %s", key, Name)
 		}
 	}
 	return nil

--- a/daemon/logger/local/read.go
+++ b/daemon/logger/local/read.go
@@ -25,7 +25,7 @@ func (d *driver) ReadLogs(config logger.ReadConfig) *logger.LogWatcher {
 func getTailReader(ctx context.Context, r loggerutils.SizeReaderAt, req int) (io.Reader, int, error) {
 	size := r.Size()
 	if req < 0 {
-		return nil, 0, errdefs.InvalidParameter(errors.Errorf("invalid number of lines to tail: %d", req))
+		return nil, 0, errdefs.InvalidParameter(fmt.Errorf("invalid number of lines to tail: %d", req))
 	}
 
 	if size < (encodeBinaryLen*2)+1 {

--- a/daemon/logger/loggerutils/cache/validate.go
+++ b/daemon/logger/loggerutils/cache/validate.go
@@ -1,11 +1,11 @@
 package cache
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/logger/local"
-	"github.com/pkg/errors"
 )
 
 func init() {
@@ -20,7 +20,7 @@ func validateLogCacheOpts(cfg map[string]string) error {
 	if v := cfg[cacheDisabledKey]; v != "" {
 		_, err := strconv.ParseBool(v)
 		if err != nil {
-			return errors.Errorf("invalid value for option %s: %s", cacheDisabledKey, cfg[cacheDisabledKey])
+			return fmt.Errorf("invalid value for option %s: %s", cacheDisabledKey, cfg[cacheDisabledKey])
 		}
 	}
 	return nil

--- a/daemon/logger/plugin.go
+++ b/daemon/logger/plugin.go
@@ -52,11 +52,11 @@ func makePluginClient(p getter.CompatPlugin) (logPlugin, error) {
 	}
 	pa, ok := p.(getter.PluginAddr)
 	if !ok {
-		return nil, errdefs.System(errors.Errorf("got unknown plugin type %T", p))
+		return nil, errdefs.System(fmt.Errorf("got unknown plugin type %T", p))
 	}
 
 	if pa.Protocol() != plugins.ProtocolSchemeHTTPV1 {
-		return nil, errors.Errorf("plugin protocol not supported: %s", p)
+		return nil, fmt.Errorf("plugin protocol not supported: %s", p)
 	}
 
 	addr := pa.Addr()

--- a/daemon/metrics.go
+++ b/daemon/metrics.go
@@ -2,6 +2,7 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/containerd/log"
@@ -149,11 +150,11 @@ func makePluginAdapter(p plugingetter.CompatPlugin) (metricsPlugin, error) {
 
 	pa, ok := p.(plugingetter.PluginAddr)
 	if !ok {
-		return nil, errdefs.System(errors.Errorf("got unknown plugin type %T", p))
+		return nil, errdefs.System(fmt.Errorf("got unknown plugin type %T", p))
 	}
 
 	if pa.Protocol() != plugins.ProtocolSchemeHTTPV1 {
-		return nil, errors.Errorf("plugin protocol not supported: %s", pa.Protocol())
+		return nil, fmt.Errorf("plugin protocol not supported: %s", pa.Protocol())
 	}
 
 	addr := pa.Addr()

--- a/daemon/names.go
+++ b/daemon/names.go
@@ -59,7 +59,7 @@ func (daemon *Daemon) generateIDAndName(name string) (string, string, error) {
 
 func (daemon *Daemon) reserveName(id, name string) (string, error) {
 	if !validContainerNamePattern.MatchString(strings.TrimPrefix(name, "/")) {
-		return "", errdefs.InvalidParameter(errors.Errorf("Invalid container name (%s), only %s are allowed", name, validContainerNameChars))
+		return "", errdefs.InvalidParameter(fmt.Errorf("Invalid container name (%s), only %s are allowed", name, validContainerNameChars))
 	}
 	if name[0] != '/' {
 		name = "/" + name

--- a/daemon/network/filter.go
+++ b/daemon/network/filter.go
@@ -1,6 +1,8 @@
 package network // import "github.com/docker/docker/daemon/network"
 
 import (
+	"fmt"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/errdefs"
@@ -124,7 +126,7 @@ func filterNetworkByType(nws []types.NetworkResource, netType string) ([]types.N
 			}
 		}
 	default:
-		return nil, errors.Errorf("invalid filter: 'type'='%s'", netType)
+		return nil, fmt.Errorf("invalid filter: 'type'='%s'", netType)
 	}
 	return retNws, nil
 }

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -299,7 +299,7 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		// ipc
 		ipcMode := c.HostConfig.IpcMode
 		if !ipcMode.Valid() {
-			return errdefs.InvalidParameter(errors.Errorf("invalid IPC mode: %v", ipcMode))
+			return errdefs.InvalidParameter(fmt.Errorf("invalid IPC mode: %v", ipcMode))
 		}
 		switch {
 		case ipcMode.IsContainer():
@@ -335,7 +335,7 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		// pid
 		pidMode := c.HostConfig.PidMode
 		if !pidMode.Valid() {
-			return errdefs.InvalidParameter(errors.Errorf("invalid PID mode: %v", pidMode))
+			return errdefs.InvalidParameter(fmt.Errorf("invalid PID mode: %v", pidMode))
 		}
 		switch {
 		case pidMode.IsContainer():
@@ -366,7 +366,7 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 
 		// uts
 		if !c.HostConfig.UTSMode.Valid() {
-			return errdefs.InvalidParameter(errors.Errorf("invalid UTS mode: %v", c.HostConfig.UTSMode))
+			return errdefs.InvalidParameter(fmt.Errorf("invalid UTS mode: %v", c.HostConfig.UTSMode))
 		}
 		if c.HostConfig.UTSMode.IsHost() {
 			oci.RemoveNamespace(s, specs.UTSNamespace)
@@ -375,7 +375,7 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 
 		// cgroup
 		if !c.HostConfig.CgroupnsMode.Valid() {
-			return errdefs.InvalidParameter(errors.Errorf("invalid cgroup namespace mode: %v", c.HostConfig.CgroupnsMode))
+			return errdefs.InvalidParameter(fmt.Errorf("invalid cgroup namespace mode: %v", c.HostConfig.CgroupnsMode))
 		}
 		if c.HostConfig.CgroupnsMode.IsPrivate() {
 			setNamespace(s, specs.LinuxNamespace{
@@ -453,7 +453,7 @@ func ensureShared(path string) error {
 	}
 	// Make sure source mount point is shared.
 	if !hasMountInfoOption(optionalOpts, sharedPropagationOption) {
-		return errors.Errorf("path %s is mounted on %s but it is not a shared mount", path, sourceMount)
+		return fmt.Errorf("path %s is mounted on %s but it is not a shared mount", path, sourceMount)
 	}
 	return nil
 }
@@ -466,7 +466,7 @@ func ensureSharedOrSlave(path string) error {
 	}
 
 	if !hasMountInfoOption(optionalOpts, sharedPropagationOption, slavePropagationOption) {
-		return errors.Errorf("path %s is mounted on %s but it is not a shared or slave mount", path, sourceMount)
+		return fmt.Errorf("path %s is mounted on %s but it is not a shared or slave mount", path, sourceMount)
 	}
 	return nil
 }

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -475,10 +475,10 @@ func setupWindowsDevices(devices []containertypes.DeviceMapping) (specDevices []
 		} else {
 			idType, id, ok := strings.Cut(deviceMapping.PathOnHost, "://")
 			if !ok {
-				return nil, errors.Errorf("invalid device assignment path: '%s', must be 'class/ID' or 'IDType://ID'", deviceMapping.PathOnHost)
+				return nil, fmt.Errorf("invalid device assignment path: '%s', must be 'class/ID' or 'IDType://ID'", deviceMapping.PathOnHost)
 			}
 			if idType == "" {
-				return nil, errors.Errorf("invalid device assignment path: '%s', IDType cannot be empty", deviceMapping.PathOnHost)
+				return nil, fmt.Errorf("invalid device assignment path: '%s', IDType cannot be empty", deviceMapping.PathOnHost)
 			}
 			specDevices = append(specDevices, specs.WindowsDevice{
 				ID:     id,

--- a/daemon/rename.go
+++ b/daemon/rename.go
@@ -2,6 +2,7 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/containerd/log"
@@ -47,7 +48,7 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) (retErr error) {
 	links := map[string]*dockercontainer.Container{}
 	for k, v := range daemon.linkIndex.children(container) {
 		if !strings.HasPrefix(k, oldName) {
-			return errdefs.InvalidParameter(errors.Errorf("Linked container %s does not match parent %s", k, oldName))
+			return errdefs.InvalidParameter(fmt.Errorf("Linked container %s does not match parent %s", k, oldName))
 		}
 		links[strings.TrimPrefix(k, oldName)] = v
 	}

--- a/daemon/runtime_unix.go
+++ b/daemon/runtime_unix.go
@@ -100,7 +100,7 @@ func initRuntimesDir(cfg *config.Config) error {
 
 func setupRuntimes(cfg *config.Config) (runtimes, error) {
 	if _, ok := cfg.Runtimes[config.StockRuntimeName]; ok {
-		return runtimes{}, errors.Errorf("runtime name '%s' is reserved", config.StockRuntimeName)
+		return runtimes{}, fmt.Errorf("runtime name '%s' is reserved", config.StockRuntimeName)
 	}
 
 	newrt := runtimes{
@@ -115,7 +115,7 @@ func setupRuntimes(cfg *config.Config) (runtimes, error) {
 		_, isStock := newrt.configured[newrt.Default]
 		_, isConfigured := cfg.Runtimes[newrt.Default]
 		if !isStock && !isConfigured && !isPermissibleC8dRuntimeName(newrt.Default) {
-			return runtimes{}, errors.Errorf("specified default runtime '%s' does not exist", newrt.Default)
+			return runtimes{}, fmt.Errorf("specified default runtime '%s' does not exist", newrt.Default)
 		}
 	} else {
 		newrt.Default = config.StockRuntimeName
@@ -125,14 +125,14 @@ func setupRuntimes(cfg *config.Config) (runtimes, error) {
 	for name, rt := range cfg.Runtimes {
 		var c *shimConfig
 		if rt.Path == "" && rt.Type == "" {
-			return runtimes{}, errors.Errorf("runtime %s: either a runtimeType or a path must be configured", name)
+			return runtimes{}, fmt.Errorf("runtime %s: either a runtimeType or a path must be configured", name)
 		}
 		if rt.Path != "" {
 			if rt.Type != "" {
-				return runtimes{}, errors.Errorf("runtime %s: cannot configure both path and runtimeType for the same runtime", name)
+				return runtimes{}, fmt.Errorf("runtime %s: cannot configure both path and runtimeType for the same runtime", name)
 			}
 			if len(rt.Options) > 0 {
-				return runtimes{}, errors.Errorf("runtime %s: options cannot be used with a path runtime", name)
+				return runtimes{}, fmt.Errorf("runtime %s: options cannot be used with a path runtime", name)
 			}
 
 			binaryName := rt.Path
@@ -155,7 +155,7 @@ func setupRuntimes(cfg *config.Config) (runtimes, error) {
 			}
 		} else {
 			if len(rt.Args) > 0 {
-				return runtimes{}, errors.Errorf("runtime %s: args cannot be used with a runtimeType runtime", name)
+				return runtimes{}, fmt.Errorf("runtime %s: args cannot be used with a runtimeType runtime", name)
 			}
 			// Unlike implicit runtimes, there is no restriction on configuring a shim by path.
 			c = &shimConfig{Shim: rt.Type}
@@ -218,7 +218,7 @@ func (r *runtimes) Get(name string) (string, interface{}, error) {
 	}
 
 	if !isPermissibleC8dRuntimeName(name) {
-		return "", nil, errdefs.InvalidParameter(errors.Errorf("unknown or invalid runtime name: %s", name))
+		return "", nil, errdefs.InvalidParameter(fmt.Errorf("unknown or invalid runtime name: %s", name))
 	}
 	return name, nil, nil
 }

--- a/daemon/stats_unix.go
+++ b/daemon/stats_unix.go
@@ -53,7 +53,7 @@ func (daemon *Daemon) stats(c *container.Container) (*types.StatsJSON, error) {
 	case *statsV2.Metrics:
 		return daemon.statsV2(s, t)
 	default:
-		return nil, errors.Errorf("unexpected type of metrics %+v", t)
+		return nil, fmt.Errorf("unexpected type of metrics %+v", t)
 	}
 }
 

--- a/daemon/volumes_linux.go
+++ b/daemon/volumes_linux.go
@@ -1,11 +1,11 @@
 package daemon
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 )
 
 // validateBindDaemonRoot ensures that if a given mountpoint's source is within
@@ -32,5 +32,5 @@ func (daemon *Daemon) validateBindDaemonRoot(m mount.Mount) (bool, error) {
 	default:
 	}
 
-	return false, errdefs.InvalidParameter(errors.Errorf(`invalid mount config: must use either propagation mode "rslave" or "rshared" when mount source is within the daemon root, daemon root: %q, bind mount source: %q, propagation: %q`, daemon.root, m.Source, m.BindOptions.Propagation))
+	return false, errdefs.InvalidParameter(fmt.Errorf(`invalid mount config: must use either propagation mode "rslave" or "rshared" when mount source is within the daemon root, daemon root: %q, bind mount source: %q, propagation: %q`, daemon.root, m.Source, m.BindOptions.Propagation))
 }

--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -103,7 +103,7 @@ func (l *tarexporter) parseNames(names []string) (desc map[image.ID]*imageDescri
 				}
 				continue
 			}
-			return nil, errors.Errorf("invalid reference: %v", name)
+			return nil, fmt.Errorf("invalid reference: %v", name)
 		}
 
 		if reference.FamiliarName(namedRef) == string(digest.Canonical) {

--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/testutil/daemon"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
 )
@@ -69,7 +68,7 @@ func (d *Daemon) inspectFilter(name, filter string) (string, error) {
 	format := fmt.Sprintf("{{%s}}", filter)
 	out, err := d.Cmd("inspect", "-f", format, name)
 	if err != nil {
-		return "", errors.Errorf("failed to inspect %s: %s", name, out)
+		return "", fmt.Errorf("failed to inspect %s: %s", name, out)
 	}
 	return strings.TrimSpace(out), nil
 }
@@ -108,7 +107,7 @@ func WaitInspectWithArgs(dockerBinary, name, expr, expected string, timeout time
 		result := icmd.RunCommand(dockerBinary, args...)
 		if result.Error != nil {
 			if !strings.Contains(strings.ToLower(result.Stderr()), "no such") {
-				return errors.Errorf("error executing docker inspect: %v\n%s",
+				return fmt.Errorf("error executing docker inspect: %v\n%s",
 					result.Stderr(), result.Stdout())
 			}
 			select {
@@ -127,7 +126,7 @@ func WaitInspectWithArgs(dockerBinary, name, expr, expected string, timeout time
 
 		select {
 		case <-after:
-			return errors.Errorf("condition \"%q == %q\" not true in time (%v)", out, expected, timeout)
+			return fmt.Errorf("condition \"%q == %q\" not true in time (%v)", out, expected, timeout)
 		default:
 		}
 

--- a/integration-cli/docker_api_containers_windows_test.go
+++ b/integration-cli/docker_api_containers_windows_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/testutil"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -75,5 +74,5 @@ func (s *DockerAPISuite) TestContainersAPICreateMountsBindNamedPipe(c *testing.T
 
 func mountWrapper(device, target, mType, options string) error {
 	// This should never be called.
-	return errors.Errorf("there is no implementation of Mount on this platform")
+	return fmt.Errorf("there is no implementation of Mount on this platform")
 }

--- a/integration-cli/docker_api_exec_resize_test.go
+++ b/integration-cli/docker_api_exec_resize_test.go
@@ -49,7 +49,7 @@ func (s *DockerAPISuite) TestExecResizeImmediatelyAfterExecStart(c *testing.T) {
 			return err
 		}
 		if res.StatusCode != http.StatusCreated {
-			return errors.Errorf("POST %s is expected to return %d, got %d", uri, http.StatusCreated, res.StatusCode)
+			return fmt.Errorf("POST %s is expected to return %d, got %d", uri, http.StatusCreated, res.StatusCode)
 		}
 
 		buf, err := request.ReadBody(body)

--- a/integration/internal/container/states.go
+++ b/integration/internal/container/states.go
@@ -2,11 +2,11 @@ package container
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/poll"
 )
 
@@ -53,7 +53,7 @@ func IsSuccessful(ctx context.Context, apiClient client.APIClient, containerID s
 			if inspect.State.ExitCode == 0 {
 				return poll.Success()
 			}
-			return poll.Error(errors.Errorf("expected exit code 0, got %d", inspect.State.ExitCode))
+			return poll.Error(fmt.Errorf("expected exit code 0, got %d", inspect.State.ExitCode))
 		}
 		return poll.Continue("waiting for container to be \"exited\", currently %s", inspect.State.Status)
 	}

--- a/layer/filestore.go
+++ b/layer/filestore.go
@@ -4,6 +4,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -193,7 +194,7 @@ func (fms *fileMetadataStore) GetCacheID(layer ChainID) (string, error) {
 	content := strings.TrimSpace(string(contentBytes))
 
 	if content == "" {
-		return "", errors.Errorf("invalid cache id value")
+		return "", fmt.Errorf("invalid cache id value")
 	}
 
 	return content, nil

--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -321,7 +321,7 @@ func (c *client) createWindows(id string, spec *specs.Spec, runtimeOptions inter
 			// Per https://github.com/microsoft/hcsshim/blob/v0.9.2/internal/uvm/virtual_device.go#L17-L18,
 			// these represent an Interface Class GUID.
 			if d.IDType != "class" && d.IDType != "vpci-class-guid" {
-				return nil, errors.Errorf("device assignment of type '%s' is not supported", d.IDType)
+				return nil, fmt.Errorf("device assignment of type '%s' is not supported", d.IDType)
 			}
 			configuration.AssignedDevices = append(configuration.AssignedDevices, hcsshim.AssignedDevice{InterfaceClassGUID: d.ID})
 		}

--- a/libcontainerd/remote/client_windows.go
+++ b/libcontainerd/remote/client_windows.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containerd/log"
 	libcontainerdtypes "github.com/docker/docker/libcontainerd/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 func summaryFromInterface(i interface{}) (*libcontainerdtypes.Summary, error) {
@@ -31,7 +30,7 @@ func summaryFromInterface(i interface{}) (*libcontainerdtypes.Summary, error) {
 			ExecID:                       pd.ExecID,
 		}, nil
 	default:
-		return nil, errors.Errorf("Unknown process details type %T", pd)
+		return nil, fmt.Errorf("Unknown process details type %T", pd)
 	}
 }
 

--- a/libnetwork/drivers/remote/driver.go
+++ b/libnetwork/drivers/remote/driver.go
@@ -73,11 +73,11 @@ func getPluginClient(p plugingetter.CompatPlugin) (*plugins.Client, error) {
 
 	pa, ok := p.(plugingetter.PluginAddr)
 	if !ok {
-		return nil, errors.Errorf("unknown plugin type %T", p)
+		return nil, fmt.Errorf("unknown plugin type %T", p)
 	}
 
 	if pa.Protocol() != plugins.ProtocolSchemeHTTPV1 {
-		return nil, errors.Errorf("unsupported plugin protocol %s", pa.Protocol())
+		return nil, fmt.Errorf("unsupported plugin protocol %s", pa.Protocol())
 	}
 
 	addr := pa.Addr()

--- a/libnetwork/ipams/remote/remote.go
+++ b/libnetwork/ipams/remote/remote.go
@@ -71,11 +71,11 @@ func getPluginClient(p plugingetter.CompatPlugin) (*plugins.Client, error) {
 
 	pa, ok := p.(plugingetter.PluginAddr)
 	if !ok {
-		return nil, errors.Errorf("unknown plugin type %T", p)
+		return nil, fmt.Errorf("unknown plugin type %T", p)
 	}
 
 	if pa.Protocol() != plugins.ProtocolSchemeHTTPV1 {
-		return nil, errors.Errorf("unsupported plugin protocol %s", pa.Protocol())
+		return nil, fmt.Errorf("unsupported plugin protocol %s", pa.Protocol())
 	}
 
 	addr := pa.Addr()

--- a/opts/hosts.go
+++ b/opts/hosts.go
@@ -1,6 +1,7 @@
 package opts // import "github.com/docker/docker/opts"
 
 import (
+	"fmt"
 	"net"
 	"net/url"
 	"path/filepath"
@@ -101,7 +102,7 @@ func parseDaemonHost(address string) (string, error) {
 	case "fd":
 		return address, nil
 	default:
-		return "", errors.Errorf("invalid bind address (%s): unsupported proto '%s'", address, proto)
+		return "", fmt.Errorf("invalid bind address (%s): unsupported proto '%s'", address, proto)
 	}
 }
 
@@ -111,7 +112,7 @@ func parseDaemonHost(address string) (string, error) {
 // defaultAddr if addr is a blank string.
 func parseSimpleProtoAddr(proto, addr, defaultAddr string) (string, error) {
 	if strings.Contains(addr, "://") {
-		return "", errors.Errorf("invalid %s address: %s", proto, addr)
+		return "", fmt.Errorf("invalid %s address: %s", proto, addr)
 	}
 	if addr == "" {
 		addr = defaultAddr
@@ -159,7 +160,7 @@ func parseTCPAddr(address string, strict bool) (*url.URL, error) {
 		return nil, err
 	}
 	if parsedURL.Scheme != "tcp" {
-		return nil, errors.Errorf("unsupported proto '%s'", parsedURL.Scheme)
+		return nil, fmt.Errorf("unsupported proto '%s'", parsedURL.Scheme)
 	}
 	if parsedURL.Path != "" {
 		return nil, errors.New("should not contain a path element")
@@ -169,7 +170,7 @@ func parseTCPAddr(address string, strict bool) (*url.URL, error) {
 	}
 	if parsedURL.Port() != "" || strict {
 		if p, err := strconv.Atoi(parsedURL.Port()); err != nil || p == 0 {
-			return nil, errors.Errorf("invalid port: %s", parsedURL.Port())
+			return nil, fmt.Errorf("invalid port: %s", parsedURL.Port())
 		}
 	}
 	return parsedURL, nil
@@ -181,12 +182,12 @@ func ValidateExtraHost(val string) (string, error) {
 	// allow for IPv6 addresses in extra hosts by only splitting on first ":"
 	name, ip, ok := strings.Cut(val, ":")
 	if !ok || name == "" {
-		return "", errors.Errorf("bad format for add-host: %q", val)
+		return "", fmt.Errorf("bad format for add-host: %q", val)
 	}
 	// Skip IPaddr validation for special "host-gateway" string
 	if ip != HostGatewayName {
 		if _, err := ValidateIPAddress(ip); err != nil {
-			return "", errors.Errorf("invalid IP address in add-host: %q", ip)
+			return "", fmt.Errorf("invalid IP address in add-host: %q", ip)
 		}
 	}
 	return val, nil

--- a/plugin/backend_linux.go
+++ b/plugin/backend_linux.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -199,7 +200,7 @@ func (pm *Manager) Privileges(ctx context.Context, ref reference.Named, metaHead
 	}
 
 	if !configSeen {
-		return types.PluginPrivileges{}, errors.Errorf("did not find plugin config for specified reference %s", ref)
+		return types.PluginPrivileges{}, fmt.Errorf("did not find plugin config for specified reference %s", ref)
 	}
 
 	return computePrivileges(config), nil
@@ -628,7 +629,7 @@ func (pm *Manager) CreateFromContext(ctx context.Context, tarCtx io.ReadCloser, 
 		return errors.Wrapf(err, "failed to parse reference %v", options.RepoName)
 	}
 	if _, ok := ref.(reference.Canonical); ok {
-		return errors.Errorf("canonical references are not permitted")
+		return fmt.Errorf("canonical references are not permitted")
 	}
 	name := reference.FamiliarString(reference.TagNameOnly(ref))
 

--- a/quota/projectquota.go
+++ b/quota/projectquota.go
@@ -54,6 +54,7 @@ import "C"
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -253,7 +254,7 @@ func (q *Control) GetQuota(targetPath string, quota *Quota) error {
 	projectID, ok := q.quotas[targetPath]
 	q.RUnlock()
 	if !ok {
-		return errors.Errorf("quota not found for path: %s", targetPath)
+		return fmt.Errorf("quota not found for path: %s", targetPath)
 	}
 
 	//
@@ -342,7 +343,7 @@ func (q *Control) findNextProjectID(home string, baseID uint32) error {
 
 	files, err := os.ReadDir(home)
 	if err != nil {
-		return errors.Errorf("read directory failed: %s", home)
+		return fmt.Errorf("read directory failed: %s", home)
 	}
 	for _, file := range files {
 		if !file.IsDir() {
@@ -358,7 +359,7 @@ func (q *Control) findNextProjectID(home string, baseID uint32) error {
 		}
 		subfiles, err := os.ReadDir(path)
 		if err != nil {
-			return errors.Errorf("read directory failed: %s", path)
+			return fmt.Errorf("read directory failed: %s", path)
 		}
 		for _, subfile := range subfiles {
 			if !subfile.IsDir() {
@@ -385,7 +386,7 @@ func openDir(path string) (*C.DIR, error) {
 
 	dir := C.opendir(Cpath)
 	if dir == nil {
-		return nil, errors.Errorf("failed to open dir: %s", path)
+		return nil, fmt.Errorf("failed to open dir: %s", path)
 	}
 	return dir, nil
 }

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -2,6 +2,7 @@ package registry // import "github.com/docker/docker/registry"
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/distribution/registry/client/auth/challenge"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/api/types/registry"
-	"github.com/pkg/errors"
 )
 
 // AuthClientID is used the ClientID used for the token server
@@ -99,7 +99,7 @@ func loginV2(authConfig *registry.AuthConfig, endpoint APIEndpoint, userAgent st
 	}
 
 	// TODO(dmcgowan): Attempt to further interpret result, status code and error code string
-	return "", "", errors.Errorf("login attempt to %s failed with status: %d %s", endpointStr, resp.StatusCode, http.StatusText(resp.StatusCode))
+	return "", "", fmt.Errorf("login attempt to %s failed with status: %d %s", endpointStr, resp.StatusCode, http.StatusText(resp.StatusCode))
 }
 
 func v2AuthHTTPClient(endpoint *url.URL, authTransport http.RoundTripper, modifiers []transport.RequestModifier, creds auth.CredentialStore, scopes []auth.Scope) (*http.Client, error) {

--- a/registry/errors.go
+++ b/registry/errors.go
@@ -1,6 +1,7 @@
 package registry // import "github.com/docker/docker/registry"
 
 import (
+	"fmt"
 	"net/url"
 
 	"github.com/docker/distribution/registry/api/errcode"
@@ -28,7 +29,7 @@ func invalidParam(err error) error {
 }
 
 func invalidParamf(format string, args ...interface{}) error {
-	return errdefs.InvalidParameter(errors.Errorf(format, args...))
+	return errdefs.InvalidParameter(fmt.Errorf(format, args...))
 }
 
 func invalidParamWrapf(err error, format string, args ...interface{}) error {

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -432,7 +433,7 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 	d.args = []string{}
 	if d.rootlessUser != nil {
 		if d.dockerdBinary != defaultDockerdBinary {
-			return errors.Errorf("[%s] DOCKER_ROOTLESS doesn't support non-default dockerd binary path %q", d.id, d.dockerdBinary)
+			return fmt.Errorf("[%s] DOCKER_ROOTLESS doesn't support non-default dockerd binary path %q", d.id, d.dockerdBinary)
 		}
 		dockerdBinary = "sudo"
 		d.args = append(d.args,
@@ -805,7 +806,7 @@ func (d *Daemon) ReloadConfig() error {
 			return errors.Wrapf(err, "[%s] error waiting for daemon reload event", d.id)
 		}
 	case <-time.After(30 * time.Second):
-		return errors.Errorf("[%s] daemon reload event timed out after 30 seconds", d.id)
+		return fmt.Errorf("[%s] daemon reload event timed out after 30 seconds", d.id)
 	}
 	return nil
 }

--- a/testutil/request/request.go
+++ b/testutil/request/request.go
@@ -219,6 +219,6 @@ func SockConn(timeout time.Duration, daemon string) (net.Conn, error) {
 		}
 		return net.DialTimeout(daemonURL.Scheme, daemonURL.Host, timeout)
 	default:
-		return c, errors.Errorf("unknown scheme %v (%s)", daemonURL.Scheme, daemon)
+		return c, fmt.Errorf("unknown scheme %v (%s)", daemonURL.Scheme, daemon)
 	}
 }

--- a/volume/drivers/extpoint.go
+++ b/volume/drivers/extpoint.go
@@ -220,11 +220,11 @@ func makePluginAdapter(p getter.CompatPlugin) (*volumeDriverAdapter, error) {
 
 	pa, ok := p.(getter.PluginAddr)
 	if !ok {
-		return nil, errdefs.System(errors.Errorf("got unknown plugin instance %T", p))
+		return nil, errdefs.System(fmt.Errorf("got unknown plugin instance %T", p))
 	}
 
 	if pa.Protocol() != plugins.ProtocolSchemeHTTPV1 {
-		return nil, errors.Errorf("plugin protocol not supported: %s", p)
+		return nil, fmt.Errorf("plugin protocol not supported: %s", p)
 	}
 
 	addr := pa.Addr()

--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -6,6 +6,7 @@ package local // import "github.com/docker/docker/volume/local"
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -189,7 +190,7 @@ func (r *Root) Remove(v volume.Volume) error {
 
 	lv, ok := v.(*localVolume)
 	if !ok {
-		return errdefs.System(errors.Errorf("unknown volume type %T", v))
+		return errdefs.System(fmt.Errorf("unknown volume type %T", v))
 	}
 
 	if lv.active.count > 0 {
@@ -212,7 +213,7 @@ func (r *Root) Remove(v volume.Volume) error {
 	}
 
 	if realPath == r.path || !strings.HasPrefix(realPath, r.path) {
-		return errdefs.System(errors.Errorf("unable to remove a directory outside of the local volume root %s: %s", r.path, realPath))
+		return errdefs.System(fmt.Errorf("unable to remove a directory outside of the local volume root %s: %s", r.path, realPath))
 	}
 
 	if err := removePath(realPath); err != nil {
@@ -254,7 +255,7 @@ func (r *Root) validateName(name string) error {
 		return errdefs.InvalidParameter(errors.New("volume name is too short, names should be at least two alphanumeric characters"))
 	}
 	if !volumeNameRegex.MatchString(name) {
-		return errdefs.InvalidParameter(errors.Errorf("%q includes invalid characters for a local volume name, only %q are allowed. If you intended to pass a host directory, use absolute path", name, names.RestrictedNameChars))
+		return errdefs.InvalidParameter(fmt.Errorf("%q includes invalid characters for a local volume name, only %q are allowed. If you intended to pass a host directory, use absolute path", name, names.RestrictedNameChars))
 	}
 	return nil
 }

--- a/volume/local/local_unix.go
+++ b/volume/local/local_unix.go
@@ -52,7 +52,7 @@ func (r *Root) validateOpts(opts map[string]string) error {
 	}
 	for opt := range opts {
 		if _, ok := validOpts[opt]; !ok {
-			return errdefs.InvalidParameter(errors.Errorf("invalid option: %q", opt))
+			return errdefs.InvalidParameter(fmt.Errorf("invalid option: %q", opt))
 		}
 	}
 	if val, ok := opts["size"]; ok {
@@ -68,7 +68,7 @@ func (r *Root) validateOpts(opts map[string]string) error {
 		if _, ok := opts[opt]; ok {
 			for _, reqopt := range reqopts {
 				if _, ok := opts[reqopt]; !ok {
-					return errdefs.InvalidParameter(errors.Errorf("missing required option: %q", reqopt))
+					return errdefs.InvalidParameter(fmt.Errorf("missing required option: %q", reqopt))
 				}
 			}
 		}

--- a/volume/mounts/mounts.go
+++ b/volume/mounts/mounts.go
@@ -201,9 +201,9 @@ func (m *MountPoint) Path() string {
 }
 
 func errInvalidMode(mode string) error {
-	return errors.Errorf("invalid mode: %v", mode)
+	return fmt.Errorf("invalid mode: %v", mode)
 }
 
 func errInvalidSpec(spec string) error {
-	return errors.Errorf("invalid volume specification: '%s'", spec)
+	return fmt.Errorf("invalid volume specification: '%s'", spec)
 }

--- a/volume/mounts/validate.go
+++ b/volume/mounts/validate.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/api/types/mount"
-	"github.com/pkg/errors"
 )
 
 type errMountConfig struct {
@@ -17,13 +16,13 @@ func (e *errMountConfig) Error() string {
 }
 
 func errBindSourceDoesNotExist(path string) error {
-	return errors.Errorf("bind source path does not exist: %s", path)
+	return fmt.Errorf("bind source path does not exist: %s", path)
 }
 
 func errExtraField(name string) error {
-	return errors.Errorf("field %s must not be specified", name)
+	return fmt.Errorf("field %s must not be specified", name)
 }
 
 func errMissingField(name string) error {
-	return errors.Errorf("field %s must not be empty", name)
+	return fmt.Errorf("field %s must not be empty", name)
 }

--- a/volume/service/store.go
+++ b/volume/service/store.go
@@ -327,7 +327,7 @@ func (s *VolumeStore) filter(ctx context.Context, vols *[]volume.Volume, by By) 
 		}
 		filter(vols, filterFunc(f))
 	default:
-		return nil, errdefs.InvalidParameter(errors.Errorf("unsupported filter: %T", f))
+		return nil, errdefs.InvalidParameter(fmt.Errorf("unsupported filter: %T", f))
 	}
 	return warnings, nil
 }
@@ -355,7 +355,7 @@ func (s *VolumeStore) Find(ctx context.Context, by By) (vols []volume.Volume, wa
 		warnings, err = s.filter(ctx, f.ls, f.by)
 	default:
 		// Really shouldn't be possible, but makes sure that any new By's are added to this check.
-		err = errdefs.InvalidParameter(errors.Errorf("unsupported filter type: %T", f))
+		err = errdefs.InvalidParameter(fmt.Errorf("unsupported filter type: %T", f))
 	}
 	if err != nil {
 		return nil, nil, &OpErr{Err: err, Op: "list"}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

github.com/pkg/errors is is archived ans can be replaced by errors and fmt standard packages.  As the old package is used in a lot of places I propose to start by this simple replacement and then make the errors.Wrap replacementq per package.

**- What I did**
replace errors.Errorf with fmt.Errorf

**- How I did it**

**- How to verify it**
The tests are valid
**- Description for the changelog**
replace errors.Errorf with fmt.Errorf
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

