### PR TITLE
c8d: fix support for pull by digest

### DIFF
--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -30,8 +30,8 @@ import (
 func (i *ImageService) PullImage(ctx context.Context, baseRef reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registrytypes.AuthConfig, outStream io.Writer) error {
 	out := streamformatter.NewJSONProgressOutput(outStream, false)
 
-	if tagged, ok := baseRef.(reference.NamedTagged); ok {
-		return i.pullTag(ctx, tagged, platform, metaHeaders, authConfig, out)
+	if !reference.IsNameOnly(baseRef) {
+		return i.pullTag(ctx, baseRef, platform, metaHeaders, authConfig, out)
 	}
 
 	tags, err := distribution.Tags(ctx, baseRef, &distribution.Config{
@@ -61,7 +61,7 @@ func (i *ImageService) PullImage(ctx context.Context, baseRef reference.Named, p
 	return nil
 }
 
-func (i *ImageService) pullTag(ctx context.Context, ref reference.NamedTagged, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registrytypes.AuthConfig, out progress.Output) error {
+func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registrytypes.AuthConfig, out progress.Output) error {
 	var opts []containerd.RemoteOpt
 	if platform != nil {
 		opts = append(opts, containerd.WithPlatform(platforms.Format(*platform)))


### PR DESCRIPTION
Pull by digest regressed in #46618, causing a fallback to the pull all tags logic. The `pullTag` logic already properly handles tag or digest.

Fixes at least 3 tests from containerd integration:
* TestDockerRegistrySuite/TestInspectImageWithDigests
* TestDockerRegistrySuite/TestListImagesWithDigests
* TestDockerRegistrySuite/TestPullByDigestNoFallback