### PR TITLE
feature: clear container logs from the api

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -54,6 +54,7 @@ type monitorBackend interface {
 	ContainerStats(ctx context.Context, name string, config *backend.ContainerStatsConfig) error
 	ContainerTop(name string, psArgs string) (*container.ContainerTopOKBody, error)
 	Containers(ctx context.Context, config *container.ListOptions) ([]*types.Container, error)
+	ContainerLogsClear(name string) error
 }
 
 // attachBackend includes function to implement to provide container attaching functionality.

--- a/api/server/router/container/container.go
+++ b/api/server/router/container/container.go
@@ -58,6 +58,7 @@ func (r *containerRouter) initRoutes() {
 		router.NewPostRoute("/containers/{name:.*}/attach", r.postContainersAttach),
 		router.NewPostRoute("/containers/{name:.*}/copy", r.postContainersCopy), // Deprecated since 1.8 (API v1.20), errors out since 1.12 (API v1.24)
 		router.NewPostRoute("/containers/{name:.*}/exec", r.postContainerExecCreate),
+		router.NewPostRoute("/containers/{name:.*}/logs/clear", r.postContainersLogsClear),
 		router.NewPostRoute("/exec/{name:.*}/start", r.postContainerExecStart),
 		router.NewPostRoute("/exec/{name:.*}/resize", r.postContainerExecResize),
 		router.NewPostRoute("/containers/{name:.*}/rename", r.postContainerRename),

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -897,3 +897,19 @@ func (s *containerRouter) postContainersPrune(ctx context.Context, w http.Respon
 	}
 	return httputils.WriteJSON(w, http.StatusOK, pruneReport)
 }
+
+func (s *containerRouter) postContainersLogsClear(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if err := httputils.ParseForm(r); err != nil {
+		return err
+	}
+
+	name := vars["name"]
+
+	if err := s.backend.ContainerLogsClear(name); err != nil {
+		return err
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+
+	return nil
+}

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6949,6 +6949,33 @@ paths:
           type: "string"
           default: "all"
       tags: ["Container"]
+  /containers/{id}/logs/clear:
+    post:
+      summary: "Clear logs of a container"
+      description: |
+        Clear the logs of a container by emptying the log file of the container in disk.
+      operationId: "ContainerLogsClear"
+      responses:
+        204:
+          description: "no error"
+        404:
+          description: "no such container"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+          examples:
+            application/json:
+              message: "No such container: c2ada9df5af8"
+        500:
+          description: "server error"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          type: "string"
+      tags: ["Container"]
   /containers/{id}/changes:
     get:
       summary: "Get changes on a container’s filesystem"

--- a/client/container_logs_clear.go
+++ b/client/container_logs_clear.go
@@ -1,0 +1,12 @@
+package client // import "github.com/docker/docker/client"
+
+import (
+	"context"
+)
+
+// ContainerLogsClear clears the logs of a container.
+func (cli *Client) ContainerLogsClear(ctx context.Context, containerID string) error {
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/logs/clear", nil, nil, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/client/container_logs_clear_test.go
+++ b/client/container_logs_clear_test.go
@@ -1,0 +1,51 @@
+package client // import "github.com/docker/docker/client"
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestContainerLogsClearError(t *testing.T) {
+	client := &Client{
+		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	}
+	err := client.ContainerLogsClear(context.Background(), "nothing")
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
+}
+
+func TestContainerLogsClearNotFoundError(t *testing.T) {
+	client := &Client{
+		client: newMockClient(errorMock(http.StatusNotFound, "Not found")),
+	}
+	err := client.ContainerLogsClear(context.Background(), "container_id")
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+}
+
+func TestContainerLogsClear(t *testing.T) {
+	expectedURL := "/containers/container_id/logs/clear"
+	client := &Client{
+		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
+			}, nil
+		}),
+	}
+
+	err := client.ContainerLogsClear(context.Background(), "container_id")
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/daemon/logs_clear.go
+++ b/daemon/logs_clear.go
@@ -1,0 +1,28 @@
+package daemon // import "github.com/docker/docker/daemon"
+
+import (
+	"os"
+
+	"github.com/docker/docker/errdefs"
+)
+
+func (daemon *Daemon) ContainerLogsClear(containerName string) error {
+	container, err := daemon.GetContainer(containerName)
+	if err != nil {
+		return errdefs.System(err)
+	}
+
+	f, err := os.OpenFile(container.LogPath, os.O_WRONLY, 0755)
+	if err != nil {
+		return errdefs.System(err)
+	}
+
+	defer f.Close()
+
+	err = f.Truncate(0)
+	if err != nil {
+		return errdefs.System(err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
closes #44445

**- What I did**
Add functionality to clear container logs with the API.

**- How I did it**
I added a route /containers/{id}/logs/clear route that gets the container.LogPath and opens the file and call Truncate(0) on it to make it empty.
I also updated the go client and added test for it.

**- How to verify it**
- `docker run --name hello hello-world` run a hello-world container
- `docker logs hello` (there is logs)
- `curl -X 'POST' 0.0.0.0:2375/containers/hello/logs/clear` Call the new route and clear the logs
- `docker logs hello` (no more logs)

**- Notes**
This also works for container that are running.
I plan to work on the docker CLI command in docker/cli as well to add the command. something like `docker logs --clear hello` maybe.

**- Description for the changelog**
Added functionality to clear the logs of a container with the API without needing to kill and remove the container.

**- A picture of a cute animal (not mandatory but encouraged)**
sadly none on my pc right now. next time, I will have one.
