### PR TITLE
containerd: Image delete fixes and cleanup

### DIFF
--- a/daemon/containerd/handlers.go
+++ b/daemon/containerd/handlers.go
@@ -12,8 +12,7 @@ import (
 // walkPresentChildren is a simple wrapper for containerdimages.Walk with presentChildrenHandler.
 // This is only a convenient helper to reduce boilerplate.
 func (i *ImageService) walkPresentChildren(ctx context.Context, target ocispec.Descriptor, f func(context.Context, ocispec.Descriptor) error) error {
-	store := i.client.ContentStore()
-	return containerdimages.Walk(ctx, presentChildrenHandler(store, containerdimages.HandlerFunc(
+	return containerdimages.Walk(ctx, presentChildrenHandler(i.content, containerdimages.HandlerFunc(
 		func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 			return nil, f(ctx, desc)
 		})), target)

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -483,7 +483,12 @@ func (i *ImageService) resolveAllReferences(ctx context.Context, refOrID string)
 			if !cerrdefs.IsNotFound(err) {
 				return nil, nil, convertError(err)
 			}
-			return nil, nil, images.ErrImageDoesNotExist{Ref: parsed}
+			// If digest is given, continue looking up for matching targets.
+			// There will be no exact match found but the caller may attempt
+			// to match across images with the matching target.
+			if dgst == "" {
+				return nil, nil, images.ErrImageDoesNotExist{Ref: parsed}
+			}
 		} else {
 			img = &cimg
 			if dgst != "" && img.Target.Digest != dgst {
@@ -492,7 +497,6 @@ func (i *ImageService) resolveAllReferences(ctx context.Context, refOrID string)
 			}
 			dgst = img.Target.Digest
 		}
-
 	}
 
 	// Lookup up all associated images and check for consistency with first reference

--- a/daemon/containerd/image_delete.go
+++ b/daemon/containerd/image_delete.go
@@ -53,123 +53,161 @@ import (
 //
 // TODO(thaJeztah): image delete should send prometheus counters; see https://github.com/moby/moby/issues/45268
 func (i *ImageService) ImageDelete(ctx context.Context, imageRef string, force, prune bool) ([]imagetypes.DeleteResponse, error) {
-	parsedRef, err := reference.ParseNormalizedNamed(imageRef)
+	var c conflictType
+	if !force {
+		c |= conflictSoft
+	}
+
+	img, all, err := i.resolveAllReferences(ctx, imageRef)
 	if err != nil {
 		return nil, err
 	}
 
-	img, err := i.resolveImage(ctx, imageRef)
-	if err != nil {
-		return nil, err
-	}
-
-	imgID := image.ID(img.Target.Digest)
-
-	explicitDanglingRef := strings.HasPrefix(imageRef, imageNameDanglingPrefix) && isDanglingImage(img)
-	if isImageIDPrefix(imgID.String(), imageRef) || explicitDanglingRef {
-		return i.deleteAll(ctx, img, force, prune)
-	}
-
-	singleRef, err := i.isSingleReference(ctx, img)
-	if err != nil {
-		return nil, err
-	}
-	if !singleRef {
-		err := i.client.ImageService().Delete(ctx, img.Name)
+	var imgID image.ID
+	if img == nil {
+		if len(all) == 0 {
+			parsed, _ := reference.ParseAnyReference(imageRef)
+			return nil, dimages.ErrImageDoesNotExist{Ref: parsed}
+		}
+		imgID = image.ID(all[0].Target.Digest)
+		sameRef, err := i.getSameReferences(ctx, nil, all)
 		if err != nil {
 			return nil, err
 		}
-		i.LogImageEvent(imgID.String(), imgID.String(), events.ActionUnTag)
-		records := []imagetypes.DeleteResponse{{Untagged: reference.FamiliarString(reference.TagNameOnly(parsedRef))}}
-		return records, nil
-	}
 
-	using := func(c *container.Container) bool {
-		return c.ImageID == imgID
-	}
-	ctr := i.containers.First(using)
-	if ctr != nil {
-		if !force {
-			// If we removed the repository reference then
-			// this image would remain "dangling" and since
-			// we really want to avoid that the client must
-			// explicitly force its removal.
-			refString := reference.FamiliarString(reference.TagNameOnly(parsedRef))
-			err := &imageDeleteConflict{
-				reference: refString,
-				used:      true,
-				message: fmt.Sprintf("container %s is using its referenced image %s",
-					stringid.TruncateID(ctr.ID),
-					stringid.TruncateID(imgID.String())),
+		if len(sameRef) == len(all) && !force {
+			c &= ^conflictActiveReference
+		}
+	} else {
+		imgID = image.ID(img.Target.Digest)
+		explicitDanglingRef := strings.HasPrefix(imageRef, imageNameDanglingPrefix) && isDanglingImage(*img)
+		if isImageIDPrefix(imgID.String(), imageRef) || explicitDanglingRef {
+			return i.deleteAll(ctx, imgID, all, c, prune)
+		}
+		parsedRef, err := reference.ParseNormalizedNamed(img.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		sameRef, err := i.getSameReferences(ctx, img, all)
+		if err != nil {
+			return nil, err
+		}
+		if len(sameRef) != len(all) {
+			var records []imagetypes.DeleteResponse
+			for _, ref := range sameRef {
+				// TODO: Add with target
+				err := i.images.Delete(ctx, ref.Name)
+				if err != nil {
+					return nil, err
+				}
+				if nn, err := reference.ParseNormalizedNamed(ref.Name); err == nil {
+					familiarRef := reference.FamiliarString(nn)
+					i.logImageEvent(ref, familiarRef, events.ActionUnTag)
+					records = append(records, imagetypes.DeleteResponse{Untagged: familiarRef})
+				}
 			}
-			return nil, err
+			return records, nil
+		} else if !force {
+			// Since only a single used reference, remove all active
+			// TODO: Consider keeping the conflict and changing active
+			// reference calculation in image checker.
+			c &= ^conflictActiveReference
 		}
 
-		err := i.softImageDelete(ctx, img)
-		if err != nil {
-			return nil, err
+		using := func(c *container.Container) bool {
+			return c.ImageID == imgID
 		}
+		ctr := i.containers.First(using)
+		if ctr != nil {
+			familiarRef := reference.FamiliarString(parsedRef)
+			if !force {
+				// If we removed the repository reference then
+				// this image would remain "dangling" and since
+				// we really want to avoid that the client must
+				// explicitly force its removal.
+				err := &imageDeleteConflict{
+					reference: familiarRef,
+					used:      true,
+					message: fmt.Sprintf("container %s is using its referenced image %s",
+						stringid.TruncateID(ctr.ID),
+						stringid.TruncateID(imgID.String())),
+				}
+				return nil, err
+			}
 
-		i.LogImageEvent(imgID.String(), imgID.String(), events.ActionUnTag)
-		records := []imagetypes.DeleteResponse{{Untagged: reference.FamiliarString(reference.TagNameOnly(parsedRef))}}
-		return records, nil
+			// Delete all images
+			err := i.softImageDelete(ctx, *img, all)
+			if err != nil {
+				return nil, err
+			}
+
+			i.logImageEvent(*img, familiarRef, events.ActionUnTag)
+			records := []imagetypes.DeleteResponse{{Untagged: familiarRef}}
+			return records, nil
+		}
 	}
 
-	return i.deleteAll(ctx, img, force, prune)
+	return i.deleteAll(ctx, imgID, all, c, prune)
 }
 
 // deleteAll deletes the image from the daemon, and if prune is true,
 // also deletes dangling parents if there is no conflict in doing so.
 // Parent images are removed quietly, and if there is any issue/conflict
 // it is logged but does not halt execution/an error is not returned.
-func (i *ImageService) deleteAll(ctx context.Context, img images.Image, force, prune bool) ([]imagetypes.DeleteResponse, error) {
-	var records []imagetypes.DeleteResponse
-
+func (i *ImageService) deleteAll(ctx context.Context, imgID image.ID, all []images.Image, c conflictType, prune bool) (records []imagetypes.DeleteResponse, err error) {
 	// Workaround for: https://github.com/moby/buildkit/issues/3797
 	possiblyDeletedConfigs := map[digest.Digest]struct{}{}
-	err := i.walkPresentChildren(ctx, img.Target, func(_ context.Context, d ocispec.Descriptor) error {
-		if images.IsConfigType(d.MediaType) {
-			possiblyDeletedConfigs[d.Digest] = struct{}{}
+	if len(all) > 0 && i.content != nil {
+		handled := map[digest.Digest]struct{}{}
+		for _, img := range all {
+			if _, ok := handled[img.Target.Digest]; ok {
+				continue
+			} else {
+				handled[img.Target.Digest] = struct{}{}
+			}
+			err := i.walkPresentChildren(ctx, img.Target, func(_ context.Context, d ocispec.Descriptor) error {
+				if images.IsConfigType(d.MediaType) {
+					possiblyDeletedConfigs[d.Digest] = struct{}{}
+				}
+				return nil
+			})
+			if err != nil {
+				return nil, err
+			}
 		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
 	}
 	defer func() {
-		if err := i.unleaseSnapshotsFromDeletedConfigs(compatcontext.WithoutCancel(ctx), possiblyDeletedConfigs); err != nil {
-			log.G(ctx).WithError(err).Warn("failed to unlease snapshots")
+		if len(possiblyDeletedConfigs) > 0 {
+			if err := i.unleaseSnapshotsFromDeletedConfigs(compatcontext.WithoutCancel(ctx), possiblyDeletedConfigs); err != nil {
+				log.G(ctx).WithError(err).Warn("failed to unlease snapshots")
+			}
 		}
 	}()
 
-	imgID := img.Target.Digest.String()
-
 	var parents []imageWithRootfs
 	if prune {
-		parents, err = i.parents(ctx, image.ID(imgID))
+		// TODO(dmcgowan): Consider using GC labels to walk for deletion
+		parents, err = i.parents(ctx, imgID)
 		if err != nil {
 			log.G(ctx).WithError(err).Warn("failed to get image parents")
 		}
 		sortParentsByAffinity(parents)
 	}
 
-	imageRefs, err := i.client.ImageService().List(ctx, "target.digest=="+imgID)
-	if err != nil {
-		return nil, err
-	}
-	for _, imageRef := range imageRefs {
-		if err := i.imageDeleteHelper(ctx, imageRef, &records, force); err != nil {
+	for _, imageRef := range all {
+		if err := i.imageDeleteHelper(ctx, imageRef, all, &records, c); err != nil {
 			return records, err
 		}
 	}
-	i.LogImageEvent(imgID, imgID, events.ActionDelete)
-	records = append(records, imagetypes.DeleteResponse{Deleted: imgID})
+	i.LogImageEvent(imgID.String(), imgID.String(), events.ActionDelete)
+	records = append(records, imagetypes.DeleteResponse{Deleted: imgID.String()})
 
 	for _, parent := range parents {
 		if !isDanglingImage(parent.img) {
 			break
 		}
-		err = i.imageDeleteHelper(ctx, parent.img, &records, false)
+		err = i.imageDeleteHelper(ctx, parent.img, all, &records, conflictSoft)
 		if err != nil {
 			log.G(ctx).WithError(err).Warn("failed to remove image parent")
 			break
@@ -205,19 +243,71 @@ func sortParentsByAffinity(parents []imageWithRootfs) {
 	})
 }
 
-// isSingleReference returns true if there are no other images in the
-// daemon targeting the same content as `img` that are not dangling.
-func (i *ImageService) isSingleReference(ctx context.Context, img images.Image) (bool, error) {
-	refs, err := i.client.ImageService().List(ctx, "target.digest=="+img.Target.Digest.String())
-	if err != nil {
-		return false, err
-	}
-	for _, ref := range refs {
-		if !isDanglingImage(ref) && ref.Name != img.Name {
-			return false, nil
+// getSameReferences returns the set of images which are the same as:
+// - the provided img if non-nil
+// - OR the first named image found in the provided image set
+// - OR the full set of provided images if no named references in the set
+//
+// References are considered the same if:
+// - Both contain the same name and tag
+// - Both contain the same name, one is untagged and no other differing tags in set
+// - One is dangling
+//
+// Note: All imgs should have the same target, only the image name will be considered
+// for determining whether images are the same.
+func (i *ImageService) getSameReferences(ctx context.Context, img *images.Image, imgs []images.Image) ([]images.Image, error) {
+	var (
+		named      reference.Named
+		tag        string
+		sameRef    []images.Image
+		digestRefs = []images.Image{}
+	)
+	if img != nil {
+		repoRef, err := reference.ParseNamed(img.Name)
+		if err != nil {
+			return nil, err
+		}
+		named = repoRef
+		if tagged, ok := named.(reference.Tagged); ok {
+			tag = tagged.Tag()
 		}
 	}
-	return true, nil
+	for _, ref := range imgs {
+		if !isDanglingImage(ref) {
+			if repoRef, err := reference.ParseNamed(ref.Name); err == nil {
+				if named == nil {
+					named = repoRef
+					if tagged, ok := named.(reference.Tagged); ok {
+						tag = tagged.Tag()
+					}
+				} else if named.Name() != repoRef.Name() {
+					continue
+				} else if tagged, ok := repoRef.(reference.Tagged); ok {
+					if tag == "" {
+						tag = tagged.Tag()
+					} else if tag != tagged.Tag() {
+						// Same repo, different tag, do not include digest refs
+						digestRefs = nil
+						continue
+					}
+				} else {
+					if digestRefs != nil {
+						digestRefs = append(digestRefs, ref)
+					}
+					// Add digest refs at end if no other tags in the same name
+					continue
+				}
+			} else {
+				// Ignore names which do not parse
+				log.G(ctx).WithError(err).WithField("image", ref.Name).Info("failed to parse image name, ignoring")
+			}
+		}
+		sameRef = append(sameRef, ref)
+	}
+	if digestRefs != nil {
+		sameRef = append(sameRef, digestRefs...)
+	}
+	return sameRef, nil
 }
 
 type conflictType int
@@ -238,17 +328,14 @@ const (
 // images and untagged references are appended to the given records. If any
 // error or conflict is encountered, it will be returned immediately without
 // deleting the image.
-func (i *ImageService) imageDeleteHelper(ctx context.Context, img images.Image, records *[]imagetypes.DeleteResponse, force bool) error {
+func (i *ImageService) imageDeleteHelper(ctx context.Context, img images.Image, all []images.Image, records *[]imagetypes.DeleteResponse, extra conflictType) error {
 	// First, determine if this image has any conflicts. Ignore soft conflicts
 	// if force is true.
-	c := conflictHard
-	if !force {
-		c |= conflictSoft
-	}
+	c := conflictHard | extra
 
 	imgID := image.ID(img.Target.Digest)
 
-	err := i.checkImageDeleteConflict(ctx, imgID, c)
+	err := i.checkImageDeleteConflict(ctx, imgID, all, c)
 	if err != nil {
 		return err
 	}
@@ -257,13 +344,15 @@ func (i *ImageService) imageDeleteHelper(ctx context.Context, img images.Image, 
 	if err != nil {
 		return err
 	}
-	err = i.client.ImageService().Delete(ctx, img.Name, images.SynchronousDelete())
+
+	// TODO: Add target option
+	err = i.images.Delete(ctx, img.Name, images.SynchronousDelete())
 	if err != nil {
 		return err
 	}
 
 	if !isDanglingImage(img) {
-		i.LogImageEvent(imgID.String(), imgID.String(), events.ActionUnTag)
+		i.logImageEvent(img, reference.FamiliarString(untaggedRef), events.ActionUnTag)
 		*records = append(*records, imagetypes.DeleteResponse{Untagged: reference.FamiliarString(untaggedRef)})
 	}
 
@@ -299,7 +388,7 @@ func (imageDeleteConflict) Conflict() {}
 // nil if there are none. It takes a bitmask representing a
 // filter for which conflict types the caller cares about,
 // and will only check for these conflict types.
-func (i *ImageService) checkImageDeleteConflict(ctx context.Context, imgID image.ID, mask conflictType) error {
+func (i *ImageService) checkImageDeleteConflict(ctx context.Context, imgID image.ID, all []images.Image, mask conflictType) error {
 	if mask&conflictRunningContainer != 0 {
 		running := func(c *container.Container) bool {
 			return c.ImageID == imgID && c.IsRunning()
@@ -328,11 +417,8 @@ func (i *ImageService) checkImageDeleteConflict(ctx context.Context, imgID image
 	}
 
 	if mask&conflictActiveReference != 0 {
-		refs, err := i.client.ImageService().List(ctx, "target.digest=="+imgID.String())
-		if err != nil {
-			return err
-		}
-		if len(refs) > 1 {
+		// TODO: Count unexpired references...
+		if len(all) > 1 {
 			return &imageDeleteConflict{
 				reference: stringid.TruncateID(imgID.String()),
 				message:   "image is referenced in multiple repositories",

--- a/daemon/containerd/image_delete_test.go
+++ b/daemon/containerd/image_delete_test.go
@@ -1,0 +1,218 @@
+package containerd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/metadata"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/log/logtest"
+	"github.com/docker/docker/container"
+	daemonevents "github.com/docker/docker/daemon/events"
+	dimages "github.com/docker/docker/daemon/images"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestImageDelete(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.TODO(), "testing")
+
+	for _, tc := range []struct {
+		ref       string
+		starting  []images.Image
+		remaining []images.Image
+		err       error
+		// TODO: Records
+		// TODO: Containers
+		// TODO: Events
+	}{
+		{
+			ref: "nothingthere",
+			err: dimages.ErrImageDoesNotExist{Ref: nameTag("nothingthere", "latest")},
+		},
+		{
+			ref: "justoneimage",
+			starting: []images.Image{
+				{
+					Name:   "docker.io/library/justoneimage:latest",
+					Target: desc(10),
+				},
+			},
+		},
+		{
+			ref: "justoneref",
+			starting: []images.Image{
+				{
+					Name:   "docker.io/library/justoneref:latest",
+					Target: desc(10),
+				},
+				{
+					Name:   "docker.io/library/differentrepo:latest",
+					Target: desc(10),
+				},
+			},
+			remaining: []images.Image{
+				{
+					Name:   "docker.io/library/differentrepo:latest",
+					Target: desc(10),
+				},
+			},
+		},
+		{
+			ref: "hasdigest",
+			starting: []images.Image{
+				{
+					Name:   "docker.io/library/hasdigest:latest",
+					Target: desc(10),
+				},
+				{
+					Name:   "docker.io/library/hasdigest@" + digestFor(10).String(),
+					Target: desc(10),
+				},
+			},
+		},
+		{
+			ref: digestFor(11).String(),
+			starting: []images.Image{
+				{
+					Name:   "docker.io/library/byid:latest",
+					Target: desc(11),
+				},
+				{
+					Name:   "docker.io/library/byid@" + digestFor(11).String(),
+					Target: desc(11),
+				},
+			},
+		},
+		{
+			ref: "bydigest@" + digestFor(12).String(),
+			starting: []images.Image{
+				{
+					Name:   "docker.io/library/bydigest:latest",
+					Target: desc(12),
+				},
+				{
+					Name:   "docker.io/library/bydigest@" + digestFor(12).String(),
+					Target: desc(12),
+				},
+			},
+		},
+		{
+			ref: "onerefoftwo",
+			starting: []images.Image{
+				{
+					Name:   "docker.io/library/onerefoftwo:latest",
+					Target: desc(12),
+				},
+				{
+					Name:   "docker.io/library/onerefoftwo:other",
+					Target: desc(12),
+				},
+				{
+					Name:   "docker.io/library/onerefoftwo@" + digestFor(12).String(),
+					Target: desc(12),
+				},
+			},
+			remaining: []images.Image{
+				{
+					Name:   "docker.io/library/onerefoftwo:other",
+					Target: desc(12),
+				},
+				{
+					Name:   "docker.io/library/onerefoftwo@" + digestFor(12).String(),
+					Target: desc(12),
+				},
+			},
+		},
+		{
+			ref: "otherreporemaining",
+			starting: []images.Image{
+				{
+					Name:   "docker.io/library/otherreporemaining:latest",
+					Target: desc(12),
+				},
+				{
+					Name:   "docker.io/library/otherreporemaining@" + digestFor(12).String(),
+					Target: desc(12),
+				},
+				{
+					Name:   "docker.io/library/someotherrepo:latest",
+					Target: desc(12),
+				},
+			},
+			remaining: []images.Image{
+				{
+					Name:   "docker.io/library/someotherrepo:latest",
+					Target: desc(12),
+				},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.ref, func(t *testing.T) {
+			t.Parallel()
+			ctx := logtest.WithT(ctx, t)
+			mdb := newTestDB(ctx, t)
+			service := &ImageService{
+				images:        metadata.NewImageStore(mdb),
+				containers:    emptyTestContainerStore(),
+				eventsService: daemonevents.New(),
+			}
+			for _, img := range tc.starting {
+				if _, err := service.images.Create(ctx, img); err != nil {
+					t.Fatalf("failed to create image %q: %v", img.Name, err)
+				}
+			}
+
+			_, err := service.ImageDelete(ctx, tc.ref, false, false)
+			if tc.err == nil {
+				assert.NilError(t, err)
+			} else {
+				assert.Error(t, err, tc.err.Error())
+			}
+
+			all, err := service.images.List(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, len(tc.remaining), len(all))
+
+			// Order should match
+			for i := range all {
+				assert.Check(t, is.Equal(all[i].Name, tc.remaining[i].Name), "image[%d]", i)
+				assert.Check(t, is.Equal(all[i].Target.Digest, tc.remaining[i].Target.Digest), "image[%d]", i)
+				// TODO: Check labels too
+			}
+		})
+	}
+
+}
+
+type testContainerStore struct{}
+
+func emptyTestContainerStore() container.Store {
+	return &testContainerStore{}
+}
+
+func (*testContainerStore) Add(string, *container.Container) {}
+
+func (*testContainerStore) Get(string) *container.Container {
+	return nil
+}
+
+func (*testContainerStore) Delete(string) {}
+
+func (*testContainerStore) List() []*container.Container {
+	return []*container.Container{}
+}
+
+func (*testContainerStore) Size() int {
+	return 0
+}
+
+func (*testContainerStore) First(container.StoreFilter) *container.Container {
+	return nil
+}
+
+func (*testContainerStore) ApplyAll(container.StoreReducer) {}

--- a/daemon/containerd/image_delete_test.go
+++ b/daemon/containerd/image_delete_test.go
@@ -148,6 +148,76 @@ func TestImageDelete(t *testing.T) {
 				},
 			},
 		},
+		{
+			ref: "repoanddigest@" + digestFor(15).String(),
+			starting: []images.Image{
+				{
+					Name:   "docker.io/library/repoanddigest:latest",
+					Target: desc(15),
+				},
+				{
+					Name:   "docker.io/library/repoanddigest:latest@" + digestFor(15).String(),
+					Target: desc(15),
+				},
+				{
+					Name:   "docker.io/library/someotherrepo:latest",
+					Target: desc(15),
+				},
+			},
+			remaining: []images.Image{
+				{
+					Name:   "docker.io/library/someotherrepo:latest",
+					Target: desc(15),
+				},
+			},
+		},
+		{
+			ref: "repoanddigestothertags@" + digestFor(15).String(),
+			starting: []images.Image{
+				{
+					Name:   "docker.io/library/repoanddigestothertags:v1",
+					Target: desc(15),
+				},
+				{
+					Name:   "docker.io/library/repoanddigestothertags:v1@" + digestFor(15).String(),
+					Target: desc(15),
+				},
+				{
+					Name:   "docker.io/library/repoanddigestothertags:v2",
+					Target: desc(15),
+				},
+				{
+					Name:   "docker.io/library/repoanddigestothertags:v2@" + digestFor(15).String(),
+					Target: desc(15),
+				},
+				{
+					Name:   "docker.io/library/someotherrepo:latest",
+					Target: desc(15),
+				},
+			},
+			remaining: []images.Image{
+				{
+					Name:   "docker.io/library/someotherrepo:latest",
+					Target: desc(15),
+				},
+			},
+		},
+		{
+			ref: "repoanddigestzerocase@" + digestFor(16).String(),
+			starting: []images.Image{
+				{
+					Name:   "docker.io/library/someotherrepo:latest",
+					Target: desc(16),
+				},
+			},
+			remaining: []images.Image{
+				{
+					Name:   "docker.io/library/someotherrepo:latest",
+					Target: desc(16),
+				},
+			},
+			err: dimages.ErrImageDoesNotExist{Ref: nameDigest("repoanddigestzerocase", digestFor(16))},
+		},
 	} {
 		tc := tc
 		t.Run(tc.ref, func(t *testing.T) {
@@ -173,10 +243,8 @@ func TestImageDelete(t *testing.T) {
 			}
 
 			all, err := service.images.List(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-			assert.Equal(t, len(tc.remaining), len(all))
+			assert.NilError(t, err)
+			assert.Assert(t, is.Len(tc.remaining, len(all)))
 
 			// Order should match
 			for i := range all {

--- a/daemon/containerd/image_events.go
+++ b/daemon/containerd/image_events.go
@@ -3,6 +3,7 @@ package containerd
 import (
 	"context"
 
+	"github.com/containerd/containerd/images"
 	"github.com/docker/docker/api/types/events"
 	imagetypes "github.com/docker/docker/api/types/image"
 )
@@ -23,6 +24,18 @@ func (i *ImageService) LogImageEvent(imageID, refName string, action events.Acti
 	}
 	i.eventsService.Log(action, events.ImageEventType, events.Actor{
 		ID:         imageID,
+		Attributes: attributes,
+	})
+}
+
+// logImageEvent generates an event related to an image with only name attribute.
+func (i *ImageService) logImageEvent(img images.Image, refName string, action events.Action) {
+	attributes := map[string]string{}
+	if refName != "" {
+		attributes["name"] = refName
+	}
+	i.eventsService.Log(action, events.ImageEventType, events.Actor{
+		ID:         img.Target.Digest.String(),
 		Attributes: attributes,
 	})
 }

--- a/daemon/containerd/image_test.go
+++ b/daemon/containerd/image_test.go
@@ -1,0 +1,287 @@
+package containerd
+
+import (
+	"context"
+	"io"
+	"math/rand"
+	"path/filepath"
+	"testing"
+
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/metadata"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/log/logtest"
+	"github.com/distribution/reference"
+	dockerimages "github.com/docker/docker/daemon/images"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"go.etcd.io/bbolt"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestLookup(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.TODO(), "testing")
+	ctx = logtest.WithT(ctx, t)
+	mdb := newTestDB(ctx, t)
+	service := &ImageService{
+		images: metadata.NewImageStore(mdb),
+	}
+
+	ubuntuLatest := images.Image{
+		Name:   "docker.io/library/ubuntu:latest",
+		Target: desc(10),
+	}
+	ubuntuLatestWithDigest := images.Image{
+		Name:   "docker.io/library/ubuntu:latest@" + digestFor(10).String(),
+		Target: desc(10),
+	}
+	ubuntuLatestWithOldDigest := images.Image{
+		Name:   "docker.io/library/ubuntu:latest@" + digestFor(11).String(),
+		Target: desc(11),
+	}
+	ambiguousShortName := images.Image{
+		Name:   "docker.io/library/abcdef:latest",
+		Target: desc(12),
+	}
+	ambiguousShortNameWithDigest := images.Image{
+		Name:   "docker.io/library/abcdef:latest@" + digestFor(12).String(),
+		Target: desc(12),
+	}
+	shortNameIsHashAlgorithm := images.Image{
+		Name:   "docker.io/library/sha256:defcab",
+		Target: desc(13),
+	}
+
+	testImages := []images.Image{
+		ubuntuLatest,
+		ubuntuLatestWithDigest,
+		ubuntuLatestWithOldDigest,
+		ambiguousShortName,
+		ambiguousShortNameWithDigest,
+		shortNameIsHashAlgorithm,
+		{
+			Name:   "docker.io/test/volatile:retried",
+			Target: desc(14),
+		},
+		{
+			Name:   "docker.io/test/volatile:inconsistent",
+			Target: desc(15),
+		},
+	}
+	for _, img := range testImages {
+		if _, err := service.images.Create(ctx, img); err != nil {
+			t.Fatalf("failed to create image %q: %v", img.Name, err)
+		}
+	}
+
+	for _, tc := range []struct {
+		lookup string
+		img    *images.Image
+		all    []images.Image
+		err    error
+	}{
+		{
+			// Get ubuntu images with default "latest" tag
+			lookup: "ubuntu",
+			img:    &ubuntuLatest,
+			all:    []images.Image{ubuntuLatest, ubuntuLatestWithDigest},
+		},
+		{
+			// Get all images by image id
+			lookup: ubuntuLatest.Target.Digest.String(),
+			img:    nil,
+			all:    []images.Image{ubuntuLatest, ubuntuLatestWithDigest},
+		},
+		{
+			// Fail to lookup reference with no tag, reference has both tag and digest
+			lookup: "ubuntu@" + ubuntuLatestWithOldDigest.Target.Digest.String(),
+			err:    dockerimages.ErrImageDoesNotExist{Ref: nameDigest("ubuntu", ubuntuLatestWithOldDigest.Target.Digest)},
+		},
+		{
+			// Get all image with both tag and digest
+			lookup: "ubuntu:latest@" + ubuntuLatestWithOldDigest.Target.Digest.String(),
+			img:    &ubuntuLatestWithOldDigest,
+			all:    []images.Image{ubuntuLatestWithOldDigest},
+		},
+		{
+			// Get abcdef image which also matches short image id
+			lookup: "abcdef",
+			img:    &ambiguousShortName,
+			all:    []images.Image{ambiguousShortName, ambiguousShortNameWithDigest},
+		},
+		{
+			// Fail to lookup image named "sha256" with tag that doesn't exist
+			lookup: "sha256:abcdef",
+			err:    dockerimages.ErrImageDoesNotExist{Ref: nameTag("sha256", "abcdef")},
+		},
+		{
+			// Lookup with shortened image id
+			lookup: ambiguousShortName.Target.Digest.Encoded()[:8],
+			img:    nil,
+			all:    []images.Image{ambiguousShortName, ambiguousShortNameWithDigest},
+		},
+		{
+			// Lookup an actual image named "sha256" in the default namespace
+			lookup: "sha256:defcab",
+			img:    &shortNameIsHashAlgorithm,
+			all:    []images.Image{shortNameIsHashAlgorithm},
+		},
+	} {
+		tc := tc
+		t.Run(tc.lookup, func(t *testing.T) {
+			t.Parallel()
+			img, all, err := service.resolveAllReferences(ctx, tc.lookup)
+			if tc.err == nil {
+				assert.NilError(t, err)
+			} else {
+				assert.Error(t, err, tc.err.Error())
+			}
+			if tc.img == nil {
+				assert.Assert(t, is.Nil(img))
+			} else {
+				assert.Assert(t, img != nil)
+				assert.Check(t, is.Equal(img.Name, tc.img.Name))
+				assert.Check(t, is.Equal(img.Target.Digest, tc.img.Target.Digest))
+			}
+
+			assert.Assert(t, is.Len(tc.all, len(all)))
+
+			// Order should match
+			for i := range all {
+				assert.Check(t, is.Equal(all[i].Name, tc.all[i].Name), "image[%d]", i)
+				assert.Check(t, is.Equal(all[i].Target.Digest, tc.all[i].Target.Digest), "image[%d]", i)
+			}
+		})
+	}
+
+	t.Run("fail-inconsistency", func(t *testing.T) {
+		service := &ImageService{
+			images: &mutateOnGetImageStore{
+				Store: service.images,
+				getMutations: []images.Image{
+					{
+						Name:   "docker.io/test/volatile:inconsistent",
+						Target: desc(18),
+					},
+					{
+						Name:   "docker.io/test/volatile:inconsistent",
+						Target: desc(19),
+					},
+					{
+						Name:   "docker.io/test/volatile:inconsistent",
+						Target: desc(20),
+					},
+					{
+						Name:   "docker.io/test/volatile:inconsistent",
+						Target: desc(21),
+					},
+					{
+						Name:   "docker.io/test/volatile:inconsistent",
+						Target: desc(22),
+					},
+				},
+				t: t,
+			},
+		}
+
+		_, _, err := service.resolveAllReferences(ctx, "test/volatile:inconsistent")
+		assert.ErrorIs(t, err, errInconsistentData)
+	})
+
+	t.Run("retry-inconsistency", func(t *testing.T) {
+		service := &ImageService{
+			images: &mutateOnGetImageStore{
+				Store: service.images,
+				getMutations: []images.Image{
+					{
+						Name:   "docker.io/test/volatile:retried",
+						Target: desc(16),
+					},
+					{
+						Name:   "docker.io/test/volatile:retried",
+						Target: desc(17),
+					},
+				},
+				t: t,
+			},
+		}
+
+		img, all, err := service.resolveAllReferences(ctx, "test/volatile:retried")
+		assert.NilError(t, err)
+
+		assert.Assert(t, img != nil)
+		assert.Check(t, is.Equal(img.Name, "docker.io/test/volatile:retried"))
+		assert.Check(t, is.Equal(img.Target.Digest, digestFor(17)))
+		assert.Assert(t, is.Len(all, 1))
+		assert.Check(t, is.Equal(all[0].Name, "docker.io/test/volatile:retried"))
+		assert.Check(t, is.Equal(all[0].Target.Digest, digestFor(17)))
+	})
+}
+
+type mutateOnGetImageStore struct {
+	images.Store
+	getMutations []images.Image
+	t            *testing.T
+}
+
+func (m *mutateOnGetImageStore) Get(ctx context.Context, name string) (images.Image, error) {
+	img, err := m.Store.Get(ctx, name)
+	if len(m.getMutations) > 0 {
+		m.Store.Update(ctx, m.getMutations[0])
+		m.getMutations = m.getMutations[1:]
+		m.t.Logf("Get %s", name)
+	}
+	return img, err
+}
+
+func nameDigest(name string, dgst digest.Digest) reference.Reference {
+	named, _ := reference.WithName(name)
+	digested, _ := reference.WithDigest(named, dgst)
+	return digested
+}
+
+func nameTag(name, tag string) reference.Reference {
+	named, _ := reference.WithName(name)
+	tagged, _ := reference.WithTag(named, tag)
+	return tagged
+}
+
+func desc(size int64) ocispec.Descriptor {
+	return ocispec.Descriptor{
+		Digest:    digestFor(size),
+		Size:      size,
+		MediaType: ocispec.MediaTypeImageIndex,
+	}
+
+}
+
+func digestFor(i int64) digest.Digest {
+	r := rand.New(rand.NewSource(i))
+	dgstr := digest.SHA256.Digester()
+	_, err := io.Copy(dgstr.Hash(), io.LimitReader(r, i))
+	if err != nil {
+		panic(err)
+	}
+	return dgstr.Digest()
+}
+
+func newTestDB(ctx context.Context, t *testing.T) *metadata.DB {
+	t.Helper()
+
+	p := filepath.Join(t.TempDir(), "metadata")
+	bdb, err := bbolt.Open(p, 0600, &bbolt.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { bdb.Close() })
+
+	mdb := metadata.NewDB(bdb, nil, nil)
+	if err := mdb.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	return mdb
+}

--- a/daemon/containerd/image_test.go
+++ b/daemon/containerd/image_test.go
@@ -98,13 +98,24 @@ func TestLookup(t *testing.T) {
 		{
 			// Fail to lookup reference with no tag, reference has both tag and digest
 			lookup: "ubuntu@" + ubuntuLatestWithOldDigest.Target.Digest.String(),
-			err:    dockerimages.ErrImageDoesNotExist{Ref: nameDigest("ubuntu", ubuntuLatestWithOldDigest.Target.Digest)},
+			img:    nil,
+			all:    []images.Image{ubuntuLatestWithOldDigest},
 		},
 		{
 			// Get all image with both tag and digest
 			lookup: "ubuntu:latest@" + ubuntuLatestWithOldDigest.Target.Digest.String(),
 			img:    &ubuntuLatestWithOldDigest,
 			all:    []images.Image{ubuntuLatestWithOldDigest},
+		},
+		{
+			// Fail to lookup reference with no tag for digest that doesn't exist
+			lookup: "ubuntu@" + digestFor(20).String(),
+			err:    dockerimages.ErrImageDoesNotExist{Ref: nameDigest("ubuntu", digestFor(20))},
+		},
+		{
+			// Fail to lookup reference with nonexistent tag
+			lookup: "ubuntu:nonexistent",
+			err:    dockerimages.ErrImageDoesNotExist{Ref: nameTag("ubuntu", "nonexistent")},
 		},
 		{
 			// Get abcdef image which also matches short image id

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containerd/containerd"
 	cerrdefs "github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/containerd/snapshots"
@@ -14,7 +15,7 @@ import (
 	"github.com/distribution/reference"
 	"github.com/docker/docker/container"
 	daemonevents "github.com/docker/docker/daemon/events"
-	"github.com/docker/docker/daemon/images"
+	daemonimages "github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/daemon/snapshotter"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
@@ -27,6 +28,7 @@ import (
 // ImageService implements daemon.ImageService
 type ImageService struct {
 	client          *containerd.Client
+	images          images.Store
 	containers      container.Store
 	snapshotter     string
 	registryHosts   docker.RegistryHosts
@@ -59,6 +61,7 @@ type ImageServiceConfig struct {
 func NewService(config ImageServiceConfig) *ImageService {
 	return &ImageService{
 		client:          config.Client,
+		images:          config.Client.ImageService(),
 		containers:      config.Containers,
 		snapshotter:     config.Snapshotter,
 		registryHosts:   config.RegistryHosts,
@@ -70,8 +73,8 @@ func NewService(config ImageServiceConfig) *ImageService {
 }
 
 // DistributionServices return services controlling daemon image storage.
-func (i *ImageService) DistributionServices() images.DistributionServices {
-	return images.DistributionServices{}
+func (i *ImageService) DistributionServices() daemonimages.DistributionServices {
+	return daemonimages.DistributionServices{}
 }
 
 // CountImages returns the number of images stored by ImageService

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/content"
 	cerrdefs "github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/plugin"
@@ -15,7 +16,7 @@ import (
 	"github.com/distribution/reference"
 	"github.com/docker/docker/container"
 	daemonevents "github.com/docker/docker/daemon/events"
-	daemonimages "github.com/docker/docker/daemon/images"
+	dimages "github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/daemon/snapshotter"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
@@ -29,6 +30,7 @@ import (
 type ImageService struct {
 	client          *containerd.Client
 	images          images.Store
+	content         content.Store
 	containers      container.Store
 	snapshotter     string
 	registryHosts   docker.RegistryHosts
@@ -62,6 +64,7 @@ func NewService(config ImageServiceConfig) *ImageService {
 	return &ImageService{
 		client:          config.Client,
 		images:          config.Client.ImageService(),
+		content:         config.Client.ContentStore(),
 		containers:      config.Containers,
 		snapshotter:     config.Snapshotter,
 		registryHosts:   config.RegistryHosts,
@@ -73,8 +76,8 @@ func NewService(config ImageServiceConfig) *ImageService {
 }
 
 // DistributionServices return services controlling daemon image storage.
-func (i *ImageService) DistributionServices() daemonimages.DistributionServices {
-	return daemonimages.DistributionServices{}
+func (i *ImageService) DistributionServices() dimages.DistributionServices {
+	return dimages.DistributionServices{}
 }
 
 // CountImages returns the number of images stored by ImageService

--- a/daemon/containerd/soft_delete.go
+++ b/daemon/containerd/soft_delete.go
@@ -17,23 +17,13 @@ const imageNameDanglingPrefix = "moby-dangling@"
 // softImageDelete deletes the image, making sure that there are other images
 // that reference the content of the deleted image.
 // If no other image exists, a dangling one is created.
-func (i *ImageService) softImageDelete(ctx context.Context, img containerdimages.Image) error {
-	is := i.client.ImageService()
-
-	// If the image already exists, persist it as dangling image
-	// but only if no other image has the same target.
-	dgst := img.Target.Digest.String()
-	imgs, err := is.List(ctx, "target.digest=="+dgst)
-	if err != nil {
-		return errdefs.System(errors.Wrapf(err, "failed to check if there are images targeting digest %s", dgst))
-	}
-
+func (i *ImageService) softImageDelete(ctx context.Context, img containerdimages.Image, imgs []containerdimages.Image) error {
 	// From this point explicitly ignore the passed context
 	// and don't allow to interrupt operation in the middle.
 
 	// Create dangling image if this is the last image pointing to this target.
 	if len(imgs) == 1 {
-		err = i.ensureDanglingImage(compatcontext.WithoutCancel(ctx), img)
+		err := i.ensureDanglingImage(compatcontext.WithoutCancel(ctx), img)
 
 		// Error out in case we couldn't persist the old image.
 		if err != nil {
@@ -43,7 +33,8 @@ func (i *ImageService) softImageDelete(ctx context.Context, img containerdimages
 	}
 
 	// Free the target name.
-	err = is.Delete(compatcontext.WithoutCancel(ctx), img.Name)
+	// TODO: Add with target option
+	err := i.images.Delete(compatcontext.WithoutCancel(ctx), img.Name)
 	if err != nil {
 		if !cerrdefs.IsNotFound(err) {
 			return errdefs.System(errors.Wrapf(err, "failed to delete image %s which existed a moment before", img.Name))
@@ -67,7 +58,7 @@ func (i *ImageService) ensureDanglingImage(ctx context.Context, from containerdi
 	}
 	danglingImage.Name = danglingImageName(from.Target.Digest)
 
-	_, err := i.client.ImageService().Create(compatcontext.WithoutCancel(ctx), danglingImage)
+	_, err := i.images.Create(compatcontext.WithoutCancel(ctx), danglingImage)
 	// If it already exists, then just continue.
 	if cerrdefs.IsAlreadyExists(err) {
 		return nil
@@ -81,5 +72,6 @@ func danglingImageName(digest digest.Digest) string {
 }
 
 func isDanglingImage(image containerdimages.Image) bool {
+	// TODO: Also check for expired
 	return image.Name == danglingImageName(image.Target.Digest)
 }

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -295,7 +295,7 @@ RUN echo 2 #layer2
 	// should not be untagged without the -f flag
 	assert.ErrorContains(c, err, "")
 	assert.Assert(c, strings.Contains(out, cID[:12]))
-	assert.Assert(c, strings.Contains(out, "(must force)"))
+	assert.Assert(c, strings.Contains(out, "(must force)") || strings.Contains(out, "(must be forced)"))
 	// Add the -f flag and test again.
 	out = cli.DockerCmd(c, "rmi", "-f", newTag).Combined()
 	// should be allowed to untag with the -f flag

--- a/vendor/github.com/containerd/log/logtest/context.go
+++ b/vendor/github.com/containerd/log/logtest/context.go
@@ -1,0 +1,56 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package logtest
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/containerd/log"
+	"github.com/sirupsen/logrus"
+)
+
+// WithT adds a logging hook for the given test
+// Changes debug level to debug, clears output, and
+// outputs all log messages as test logs.
+func WithT(ctx context.Context, t testing.TB) context.Context {
+	// Create a new logger to avoid adding hooks from multiple tests
+	l := logrus.New()
+
+	// Increase debug level for tests
+	l.SetLevel(logrus.DebugLevel)
+	l.SetOutput(io.Discard)
+	l.SetReportCaller(true)
+
+	// Add testing hook
+	l.AddHook(&testHook{
+		t: t,
+		fmt: &logrus.TextFormatter{
+			DisableColors:   true,
+			TimestampFormat: log.RFC3339NanoFixed,
+			CallerPrettyfier: func(frame *runtime.Frame) (string, string) {
+				return filepath.Base(frame.Function), fmt.Sprintf("%s:%d", frame.File, frame.Line)
+			},
+		},
+	})
+
+	return log.WithLogger(ctx, logrus.NewEntry(l).WithField("testcase", t.Name()))
+}

--- a/vendor/github.com/containerd/log/logtest/log_hook.go
+++ b/vendor/github.com/containerd/log/logtest/log_hook.go
@@ -1,0 +1,50 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package logtest
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+type testHook struct {
+	t   testing.TB
+	fmt logrus.Formatter
+	mu  sync.Mutex
+}
+
+func (*testHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (h *testHook) Fire(e *logrus.Entry) error {
+	s, err := h.fmt.Format(e)
+	if err != nil {
+		return err
+	}
+
+	// Because the logger could be called from multiple goroutines,
+	// but t.Log() is not designed for.
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.t.Log(string(bytes.TrimRight(s, "\n")))
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -359,6 +359,7 @@ github.com/containerd/go-runc
 # github.com/containerd/log v0.1.0
 ## explicit; go 1.20
 github.com/containerd/log
+github.com/containerd/log/logtest
 # github.com/containerd/nydus-snapshotter v0.8.2
 ## explicit; go 1.19
 github.com/containerd/nydus-snapshotter/pkg/converter


### PR DESCRIPTION
- addresses various tests in https://github.com/moby/moby/issues/46760

Ensure that when removing an image, an image is checked consistently against the images with the same target digest.
Update logic of determining which references are the same to fix failing tests.
Add unit testing around delete.