### PR TITLE
daemon: windows: set DNS config on all adapters

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -871,14 +871,7 @@ func buildCreateEndpointOptions(c *container.Container, n *libnetwork.Network, e
 	// On Windows, DNS config is a per-adapter config option whereas on Linux, it's a sandbox-wide parameter; hence why
 	// we're dealing with DNS config both here and in buildSandboxOptions. Following DNS options are only honored by
 	// Windows netdrivers, whereas DNS options in buildSandboxOptions are only honored by Linux netdrivers.
-	//
-	// Now that being said, you might ask: why is this cond checking whether there's already an endpoint with exposed /
-	// published ports tied to the container sandbox? Isn't that logic flawed? Well, probably it is! These DNS options
-	// were added by d1e0a78 at the end of buildCreateEndpointOptions. The fact that it was added *after* an
-	// early-return checking exposed / published ports was most probably overlooked by the original author and
-	// reviewers.
-	// TODO(aker): fix this ^
-	if !n.Internal() && len(getPortMapInfo(sb)) == 0 {
+	if !n.Internal() {
 		if len(c.HostConfig.DNS) > 0 {
 			createOptions = append(createOptions, libnetwork.CreateOptionDNS(c.HostConfig.DNS))
 		} else if len(daemonDNS) > 0 {


### PR DESCRIPTION
Related to:

- https://github.com/moby/moby/pull/46843

**- What I did**

DNS config is a property of each adapter on Windows, thus we've a dedicated `EndpointOption` for that.

The list of `EndpointOption` that should be applied to a given endpoint is built by `buildCreateEndpointOptions`. This function contains a seemingly flawed condition that adds the DNS config _iff_:

1. the network isn't internal ;
2. no ports are published / exposed through another sandbox endpoint ;

While 1. does make sense, there's actually no justification for 2., hence this commit remove this part of the condition.

This logic flaw has been made obvious by https://github.com/moby/moby/commit/0fd0e8255f3bc0c660abe6520c1e2fdf9fc187c2, but it was originally introduced by https://github.com/moby/moby/commit/d1e0a78614d4efa768c88c9db3868bc9e7782efc. Commit and PR comments don't mention why this is done like so. Most probably, this was overlooked both by the original author and the PR reviewers.
