### PR TITLE
daemon: ContainerRename: move log args to log fields

### DIFF
--- a/daemon/rename.go
+++ b/daemon/rename.go
@@ -102,8 +102,11 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) (retErr error) {
 		if retErr != nil {
 			container.Name = oldName
 			container.NetworkSettings.IsAnonymousEndpoint = oldIsAnonymousEndpoint
-			if e := container.CheckpointTo(daemon.containersReplica); e != nil {
-				log.G(context.TODO()).Errorf("%s: Failed in writing to Disk on rename failure: %v", container.ID, e)
+			if err := container.CheckpointTo(daemon.containersReplica); err != nil {
+				log.G(context.TODO()).WithFields(log.Fields{
+					"containerID": container.ID,
+					"error":       err,
+				}).Error("failed to write container state to disk during rename")
 			}
 		}
 	}()


### PR DESCRIPTION
**- What I did**

##### ContainerRename: Move log args to log fields

Also, err `e` is renamed into the more standard `err` as the defer already uses `retErr` to avoid clashes (changed in https://github.com/docker/docker/commit/f5a611a74c88fbe07a594c20d053fea14eab9b6e).
