### PR TITLE
un-containerize TestDaemonNoSpaceLeftOnDeviceError

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1646,16 +1646,15 @@ func (s *DockerDaemonSuite) TestDaemonNoSpaceLeftOnDeviceError(c *testing.T) {
 	assert.Assert(c, mount.MakeRShared(testDir) == nil)
 	defer mount.Unmount(testDir)
 
-	// create a 3MiB image (with a 2MiB ext4 fs) and mount it as graph root
-	//
-	// Why in a container? Because `mount` sometimes behaves weirdly and often
-	// fails outright on this test in debian:jessie (which is what the test suite
-	// runs under if run from the Makefile at the time this patch was added).
-	cli.DockerCmd(c, "run", "--rm", "-v", testDir+":/test", "busybox", "sh", "-c", "dd of=/test/testfs.img bs=1M seek=3 count=0")
-	icmd.RunCommand("mkfs.ext4", "-F", filepath.Join(testDir, "testfs.img")).Assert(c, icmd.Success)
+	// create a 3MiB image (with a 2MiB ext4 fs) and mount it as storage root
+	storageFS := filepath.Join(testDir, "testfs.img")
+	icmd.RunCommand("dd", "of="+storageFS, "bs=1M", "seek=3", "count=0").Assert(c, icmd.Success)
+	icmd.RunCommand("mkfs.ext4", "-F", storageFS).Assert(c, icmd.Success)
 
-	cli.DockerCmd(c, "run", "--privileged", "--rm", "-v", testDir+":/test:shared", "busybox", "sh", "-c", "mkdir -p /test/test-mount && mount -n -t ext4 /test/testfs.img /test/test-mount")
-	defer mount.Unmount(filepath.Join(testDir, "test-mount"))
+	testMount, err := os.MkdirTemp(testDir, "test-mount")
+	assert.NilError(c, err)
+	icmd.RunCommand("mount", "-n", "-t", "ext4", storageFS, testMount).Assert(c, icmd.Success)
+	defer mount.Unmount(testMount)
 
 	driver := "vfs"
 	if testEnv.UsingSnapshotter() {
@@ -1663,11 +1662,11 @@ func (s *DockerDaemonSuite) TestDaemonNoSpaceLeftOnDeviceError(c *testing.T) {
 	}
 
 	s.d.Start(c,
-		"--data-root", filepath.Join(testDir, "test-mount"),
+		"--data-root", testMount,
 		"--storage-driver", driver,
 
 		// Pass empty containerd socket to force daemon to create a new
-		// supervised containerd daemon. Otherwise the global containerd daemon
+		// supervised containerd daemon, otherwise the global containerd daemon
 		// will be used and its data won't be stored in the specified data-root.
 		"--containerd", "",
 	)


### PR DESCRIPTION
- follow-up to / depends on https://github.com/moby/moby/pull/45789
- relates to https://github.com/moby/moby/pull/22172

Commit 59b83d8aae106cdc4042c29c900069fc804b2b68 containerized these steps, as they didn't work well on Debian Jessie:

> Because the `mount` here will sometimes fail when run in `debian:jessie`,
> which is what the environrment hosting the test suite is running if run
> from the `Makefile`.
> Also, why the heck not containerize it, all the things.

Follow-up commits, such as 228d74842fd1ac97b5c8d11fd6a3c313eae5c051, and 1c5806cf57e008e6f3ef66e6c1c57c42bbd5d3aa updated the Debian distro, but also updated this comment, losing the original context (the issue was (originally) related to Debian Jessie).

This patch changes the test back to not use containers, which seems to work fine (at least "it worked on my machine").

    make TEST_IGNORE_CGROUP_CHECK=1 TEST_FILTER=TestDaemonNoSpaceLeftOnDeviceError DOCKER_GRAPHDRIVER=overlay2 test-integration
    
    === RUN   TestDockerDaemonSuite/TestDaemonNoSpaceLeftOnDeviceError
        check_test.go:589: [df36ad96a412b] daemon is not started
    --- PASS: TestDockerDaemonSuite (5.12s)
        --- PASS: TestDockerDaemonSuite/TestDaemonNoSpaceLeftOnDeviceError (5.12s)


**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

