### PR TITLE
c8d/integration: Adjust TestSaveCheckTimes

### DIFF
--- a/integration/image/save_test.go
+++ b/integration/image/save_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
 )
 
@@ -76,7 +77,12 @@ func TestSaveCheckTimes(t *testing.T) {
 	created, err := time.Parse(time.RFC3339, img.Created)
 	assert.NilError(t, err)
 
-	assert.Equal(t, created.Format(time.RFC3339), info.ModTime().Format(time.RFC3339), "expected: %s, actual: %s", created, info.ModTime())
+	if testEnv.UsingSnapshotter() {
+		// containerd archive export sets the mod time to zero.
+		assert.Check(t, is.Equal(info.ModTime(), time.Unix(0, 0)))
+	} else {
+		assert.Check(t, is.Equal(info.ModTime().Format(time.RFC3339), created.Format(time.RFC3339)))
+	}
 }
 
 func TestSaveRepoWithMultipleImages(t *testing.T) {


### PR DESCRIPTION
The graphdriver implementation sets the ModTime of all image content to match the `Created` time from the image config, whereas the containerd's archive export code just leaves it empty (zero).

Adjust the test in the case where containerd integration is enabled to check if config file ModTime is equal to zero (UNIX epoch) instead.

This behaviour is not a part of the Docker Image Specification and the intention behind introducing it was to make the `docker save` produce the same archive regardless of the time it was performed (see https://github.com/moby/moby/pull/16076 and https://github.com/moby/moby/issues/8819#issuecomment-137606443). 

It would also be a bit problematic with the OCI archive layout which can contain multiple images referencing the same content.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
Watch TestSaveCheckTimes in CI.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

