### PR TITLE
Explicitly set MTU on bridge devices.

### DIFF
--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -735,6 +735,14 @@ func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 		bridgeSetup.queueStep(setupDefaultSysctl)
 	}
 
+	// Always set the bridge's MTU if specified. This is purely cosmetic; a bridge's
+	// MTU is the min MTU of device connected to it, and MTU will be set on each
+	// 'veth'. But, for a non-default MTU, the bridge's MTU will look wrong until a
+	// container is attached.
+	if config.Mtu > 0 {
+		bridgeSetup.queueStep(setupMTU)
+	}
+
 	// Even if a bridge exists try to setup IPv4.
 	bridgeSetup.queueStep(setupBridgeIPv4)
 

--- a/libnetwork/drivers/bridge/setup_device_linux.go
+++ b/libnetwork/drivers/bridge/setup_device_linux.go
@@ -45,6 +45,14 @@ func setupDevice(config *networkConfiguration, i *bridgeInterface) error {
 	return nil
 }
 
+func setupMTU(config *networkConfiguration, i *bridgeInterface) error {
+	if err := i.nlh.LinkSetMTU(i.Link, config.Mtu); err != nil {
+		log.G(context.TODO()).WithError(err).Errorf("Failed to set bridge MTU %s via netlink", config.BridgeName)
+		return err
+	}
+	return nil
+}
+
 func setupDefaultSysctl(config *networkConfiguration, i *bridgeInterface) error {
 	// Disable IPv6 router advertisements originating on the bridge
 	sysPath := filepath.Join("/proc/sys/net/ipv6/conf/", config.BridgeName, "accept_ra")


### PR DESCRIPTION
**- What I did**

This is purely cosmetic - if a non-default MTU is configured, the bridge will have the default MTU=1500 until a container's 'veth' is connected and an MTU is set on the veth.

That's a disconcerting, it looks like the config has been ignored - so, set the bridge's MTU explicitly.

Closes #37937

**- How I did it**

When a bridge is created or updated, set its MTU to the configured value.

**- How to verify it**

Updated integration tests.

**- Description for the changelog**

Explicitly set MTU on bridge devices.