### PR TITLE
Allow overlapping change in bridge's IPv6 network.

### DIFF
--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containerd/cgroups/v3"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/system"
+	"github.com/docker/docker/libnetwork/drivers/bridge"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/homedir"
 	"github.com/docker/docker/pkg/rootless"
@@ -173,6 +174,10 @@ func (conf *Config) ValidatePlatformConfig() error {
 	}
 	if err := verifyDefaultIpcMode(conf.IpcMode); err != nil {
 		return err
+	}
+
+	if err := bridge.ValidateFixedCIDRV6(conf.FixedCIDRv6); err != nil {
+		return errors.Wrap(err, "invalid fixed-cidr-v6")
 	}
 
 	return verifyDefaultCgroupNsMode(conf.CgroupNamespaceMode)

--- a/libnetwork/drivers/bridge/errors.go
+++ b/libnetwork/drivers/bridge/errors.go
@@ -222,19 +222,6 @@ func (ipv4 *IPv4AddrAddError) Error() string {
 // InternalError denotes the type of this error
 func (ipv4 *IPv4AddrAddError) InternalError() {}
 
-// IPv6AddrAddError is returned when IPv6 address could not be added to the bridge.
-type IPv6AddrAddError struct {
-	IP  *net.IPNet
-	Err error
-}
-
-func (ipv6 *IPv6AddrAddError) Error() string {
-	return fmt.Sprintf("failed to add IPv6 address %s to bridge: %v", ipv6.IP, ipv6.Err)
-}
-
-// InternalError denotes the type of this error
-func (ipv6 *IPv6AddrAddError) InternalError() {}
-
 // IPv4AddrNoMatchError is returned when the bridge's IPv4 address does not match configured.
 type IPv4AddrNoMatchError struct {
 	IP    net.IP

--- a/libnetwork/drivers/bridge/interface_linux_test.go
+++ b/libnetwork/drivers/bridge/interface_linux_test.go
@@ -1,11 +1,42 @@
 package bridge
 
 import (
+	"net"
+	"net/netip"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker/internal/testutils/netnsutils"
+	"github.com/google/go-cmp/cmp"
 	"github.com/vishvananda/netlink"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
+
+func cidrToIPNet(t *testing.T, cidr string) *net.IPNet {
+	t.Helper()
+	ip, ipNet, err := net.ParseCIDR(cidr)
+	assert.Assert(t, is.Nil(err))
+	return &net.IPNet{IP: ip, Mask: ipNet.Mask}
+}
+
+func addAddr(t *testing.T, link netlink.Link, addr string) {
+	t.Helper()
+	ipNet := cidrToIPNet(t, addr)
+	err := netlink.AddrAdd(link, &netlink.Addr{IPNet: ipNet})
+	assert.Assert(t, is.Nil(err))
+}
+
+func prepTestBridge(t *testing.T, nc *networkConfiguration) *bridgeInterface {
+	t.Helper()
+	nh, err := netlink.NewHandle()
+	assert.Assert(t, err)
+	i, err := newInterface(nh, nc)
+	assert.Assert(t, err)
+	err = setupDevice(nc, i)
+	assert.Assert(t, err)
+	return i
+}
 
 func TestInterfaceDefaultName(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
@@ -16,35 +47,142 @@ func TestInterfaceDefaultName(t *testing.T) {
 	}
 	config := &networkConfiguration{}
 	_, err = newInterface(nh, config)
-	if err != nil {
-		t.Fatalf("newInterface() failed: %v", err)
-	}
+	assert.Check(t, err)
+	assert.Equal(t, config.BridgeName, DefaultBridgeName)
+}
 
-	if config.BridgeName != DefaultBridgeName {
-		t.Fatalf("Expected default interface name %q, got %q", DefaultBridgeName, config.BridgeName)
-	}
+func TestAddressesNoInterface(t *testing.T) {
+	i := bridgeInterface{}
+	addrs, err := i.addresses(netlink.FAMILY_V6)
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(addrs, 0))
 }
 
 func TestAddressesEmptyInterface(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 
 	nh, err := netlink.NewHandle()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
+
 	inf, err := newInterface(nh, &networkConfiguration{})
-	if err != nil {
-		t.Fatalf("newInterface() failed: %v", err)
+	assert.NilError(t, err)
+
+	addrsv4, err := inf.addresses(netlink.FAMILY_V4)
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(addrsv4, 0))
+
+	addrsv6, err := inf.addresses(netlink.FAMILY_V6)
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(addrsv6, 0))
+}
+
+func TestAddressesNonEmptyInterface(t *testing.T) {
+	defer netnsutils.SetupTestOSContext(t)()
+
+	i := prepTestBridge(t, &networkConfiguration{})
+
+	const expAddrV4, expAddrV6 = "192.168.1.2/24", "fd00:1234::/64"
+	addAddr(t, i.Link, expAddrV4)
+	addAddr(t, i.Link, expAddrV6)
+
+	addrs, err := i.addresses(netlink.FAMILY_V4)
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(addrs, 1))
+	assert.Equal(t, addrs[0].IPNet.String(), expAddrV4)
+
+	addrs, err = i.addresses(netlink.FAMILY_V6)
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(addrs, 1))
+	assert.Equal(t, addrs[0].IPNet.String(), expAddrV6)
+}
+
+func TestGetRequiredIPv6Addrs(t *testing.T) {
+	testcases := []struct {
+		name         string
+		addressIPv6  string
+		expReqdAddrs []string
+	}{
+		{
+			name:         "Regular address, expect default link local",
+			addressIPv6:  "2000:3000::1/80",
+			expReqdAddrs: []string{"fe80::1/64", "2000:3000::1/80"},
+		},
+		{
+			name:         "Standard link local address only",
+			addressIPv6:  "fe80::1/64",
+			expReqdAddrs: []string{"fe80::1/64"},
+		},
+		{
+			name:         "Nonstandard link local address",
+			addressIPv6:  "fe80:abcd::1/42",
+			expReqdAddrs: []string{"fe80:abcd::1/42", "fe80::1/64"},
+		},
 	}
 
-	addrsv4, addrsv6, err := inf.addresses()
-	if err != nil {
-		t.Fatalf("Failed to get addresses of default interface: %v", err)
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := &networkConfiguration{
+				AddressIPv6: cidrToIPNet(t, tc.addressIPv6),
+			}
+
+			expResult := map[netip.Addr]netip.Prefix{}
+			for _, addr := range tc.expReqdAddrs {
+				expResult[netip.MustParseAddr(strings.Split(addr, "/")[0])] = netip.MustParsePrefix(addr)
+			}
+
+			reqd, addr, gw, err := getRequiredIPv6Addrs(config)
+			assert.Check(t, is.Nil(err))
+			assert.Check(t, is.DeepEqual(addr, config.AddressIPv6))
+			assert.Check(t, is.DeepEqual(gw, config.AddressIPv6.IP))
+			assert.Check(t, is.DeepEqual(reqd, expResult,
+				cmp.Comparer(func(a, b netip.Prefix) bool { return a == b })))
+		})
 	}
-	if len(addrsv4) != 0 {
-		t.Fatalf("Default interface has unexpected IPv4: %s", addrsv4)
+}
+
+func TestProgramIPv6Addresses(t *testing.T) {
+	defer netnsutils.SetupTestOSContext(t)()
+
+	checkAddrs := func(i *bridgeInterface, expAddrs []string) {
+		t.Helper()
+		exp := []netlink.Addr{}
+		for _, a := range expAddrs {
+			ipNet := cidrToIPNet(t, a)
+			exp = append(exp, netlink.Addr{IPNet: ipNet})
+		}
+		actual, err := i.addresses(netlink.FAMILY_V6)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, exp, actual)
 	}
-	if len(addrsv6) != 0 {
-		t.Fatalf("Default interface has unexpected IPv6: %v", addrsv6)
-	}
+
+	nc := &networkConfiguration{}
+	i := prepTestBridge(t, nc)
+
+	// The bridge has no addresses, ask for a regular IPv6 network and expect it to
+	// be added to the bridge, with the default link local address.
+	nc.AddressIPv6 = cidrToIPNet(t, "2000:3000::1/64")
+	err := i.programIPv6Addresses(nc)
+	assert.NilError(t, err)
+	checkAddrs(i, []string{"2000:3000::1/64", "fe80::1/64"})
+
+	// Shrink the subnet of that regular address, the prefix length of the address
+	// will not be modified - but it's informational-only, the address itself has
+	// not changed.
+	nc.AddressIPv6 = cidrToIPNet(t, "2000:3000::1/80")
+	err = i.programIPv6Addresses(nc)
+	assert.NilError(t, err)
+	checkAddrs(i, []string{"2000:3000::1/64", "fe80::1/64"})
+
+	// Ask for link-local only, by specifying an address with the Link Local prefix.
+	// The regular address should be removed.
+	nc.AddressIPv6 = cidrToIPNet(t, "fe80::1/64")
+	err = i.programIPv6Addresses(nc)
+	assert.NilError(t, err)
+	checkAddrs(i, []string{"fe80::1/64"})
+
+	// Swap the standard link local address for a nonstandard one.
+	nc.AddressIPv6 = cidrToIPNet(t, "fe80:5555::1/55")
+	err = i.programIPv6Addresses(nc)
+	assert.NilError(t, err)
+	checkAddrs(i, []string{"fe80:5555::1/55", "fe80::1/64"})
 }

--- a/libnetwork/drivers/bridge/setup_ipv4_linux.go
+++ b/libnetwork/drivers/bridge/setup_ipv4_linux.go
@@ -37,7 +37,7 @@ func setupBridgeIPv4(config *networkConfiguration, i *bridgeInterface) error {
 	}
 
 	if !config.InhibitIPv4 {
-		addrv4List, _, err := i.addresses()
+		addrv4List, err := i.addresses(netlink.FAMILY_V4)
 		if err != nil {
 			return fmt.Errorf("failed to retrieve bridge interface addresses: %v", err)
 		}

--- a/libnetwork/drivers/bridge/setup_ipv6_linux.go
+++ b/libnetwork/drivers/bridge/setup_ipv6_linux.go
@@ -32,23 +32,9 @@ func setupBridgeIPv6(config *networkConfiguration, i *bridgeInterface) error {
 		}
 	}
 
-	// Store bridge network and default gateway
-	i.bridgeIPv6 = bridgeIPv6
-	i.gatewayIPv6 = i.bridgeIPv6.IP
-
-	if err := i.programIPv6Address(); err != nil {
-		return err
-	}
-
-	if config.AddressIPv6 == nil {
-		return nil
-	}
-
-	// Store the user specified bridge network and network gateway and program it
-	i.bridgeIPv6 = config.AddressIPv6
-	i.gatewayIPv6 = config.AddressIPv6.IP
-
-	if err := i.programIPv6Address(); err != nil {
+	// Remove unwanted addresses from the bridge, add required addresses, and assign
+	// values to "i.bridgeIPv6", "i.gatewayIPv6".
+	if err := i.programIPv6Addresses(config); err != nil {
 		return err
 	}
 

--- a/libnetwork/drivers/bridge/setup_verify_linux.go
+++ b/libnetwork/drivers/bridge/setup_verify_linux.go
@@ -1,28 +1,25 @@
 package bridge
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
-	"github.com/containerd/log"
 	"github.com/docker/docker/libnetwork/ns"
-	"github.com/docker/docker/libnetwork/types"
 	"github.com/vishvananda/netlink"
 )
 
-// setupVerifyAndReconcile checks what IP addresses the given i interface has and ensures that they match the passed
-// network config. It also removes any extra unicast IPv6 addresses found.
-func setupVerifyAndReconcile(config *networkConfiguration, i *bridgeInterface) error {
+// setupVerifyAndReconcileIPv4 checks what IPv4 addresses the given i interface has
+// and ensures that they match the passed network config.
+func setupVerifyAndReconcileIPv4(config *networkConfiguration, i *bridgeInterface) error {
 	// Fetch a slice of IPv4 addresses and a slice of IPv6 addresses from the bridge.
-	addrsv4, addrsv6, err := i.addresses()
+	addrsv4, err := i.addresses(netlink.FAMILY_V4)
 	if err != nil {
 		return fmt.Errorf("Failed to verify ip addresses: %v", err)
 	}
 
 	addrv4, _ := selectIPv4Address(addrsv4, config.AddressIPv4)
 
-	// Verify that the bridge does have an IPv4 address.
+	// Verify that the bridge has an IPv4 address.
 	if !config.Internal && addrv4.IPNet == nil {
 		return &ErrNoIPAddr{}
 	}
@@ -32,32 +29,7 @@ func setupVerifyAndReconcile(config *networkConfiguration, i *bridgeInterface) e
 		return &IPv4AddrNoMatchError{IP: addrv4.IP, CfgIP: config.AddressIPv4.IP}
 	}
 
-	// Verify that one of the bridge IPv6 addresses matches the requested
-	// configuration.
-	if config.EnableIPv6 && !config.Internal && !findIPv6Address(netlink.Addr{IPNet: bridgeIPv6}, addrsv6) {
-		return (*IPv6AddrNoMatchError)(bridgeIPv6)
-	}
-
-	// Release any residual IPv6 address that might be there because of older daemon instances
-	for _, addrv6 := range addrsv6 {
-		addrv6 := addrv6
-		if addrv6.IP.IsGlobalUnicast() && !types.CompareIPNet(addrv6.IPNet, i.bridgeIPv6) {
-			if err := i.nlh.AddrDel(i.Link, &addrv6); err != nil {
-				log.G(context.TODO()).Warnf("Failed to remove residual IPv6 address %s from bridge: %v", addrv6.IPNet, err)
-			}
-		}
-	}
-
 	return nil
-}
-
-func findIPv6Address(addr netlink.Addr, addresses []netlink.Addr) bool {
-	for _, addrv6 := range addresses {
-		if addrv6.String() == addr.String() {
-			return true
-		}
-	}
-	return false
 }
 
 func bridgeInterfaceExists(name string) (bool, error) {

--- a/libnetwork/drivers/bridge/setup_verify_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_verify_linux_test.go
@@ -38,7 +38,7 @@ func TestSetupVerify(t *testing.T) {
 		t.Fatalf("Failed to assign IPv4 %s to interface: %v", config.AddressIPv4, err)
 	}
 
-	if err := setupVerifyAndReconcile(config, inf); err != nil {
+	if err := setupVerifyAndReconcileIPv4(config, inf); err != nil {
 		t.Fatalf("Address verification failed: %v", err)
 	}
 }
@@ -56,7 +56,7 @@ func TestSetupVerifyBad(t *testing.T) {
 		t.Fatalf("Failed to assign IPv4 %s to interface: %v", ipnet, err)
 	}
 
-	if err := setupVerifyAndReconcile(config, inf); err == nil {
+	if err := setupVerifyAndReconcileIPv4(config, inf); err == nil {
 		t.Fatal("Address verification was expected to fail")
 	}
 }
@@ -69,46 +69,7 @@ func TestSetupVerifyMissing(t *testing.T) {
 	config := &networkConfiguration{}
 	config.AddressIPv4 = &net.IPNet{IP: addrv4, Mask: addrv4.DefaultMask()}
 
-	if err := setupVerifyAndReconcile(config, inf); err == nil {
-		t.Fatal("Address verification was expected to fail")
-	}
-}
-
-func TestSetupVerifyIPv6(t *testing.T) {
-	defer netnsutils.SetupTestOSContext(t)()
-
-	addrv4 := net.IPv4(192, 168, 1, 1)
-	inf := setupVerifyTest(t)
-	config := &networkConfiguration{}
-	config.AddressIPv4 = &net.IPNet{IP: addrv4, Mask: addrv4.DefaultMask()}
-	config.EnableIPv6 = true
-
-	if err := netlink.AddrAdd(inf.Link, &netlink.Addr{IPNet: bridgeIPv6}); err != nil {
-		t.Fatalf("Failed to assign IPv6 %s to interface: %v", bridgeIPv6, err)
-	}
-	if err := netlink.AddrAdd(inf.Link, &netlink.Addr{IPNet: config.AddressIPv4}); err != nil {
-		t.Fatalf("Failed to assign IPv4 %s to interface: %v", config.AddressIPv4, err)
-	}
-
-	if err := setupVerifyAndReconcile(config, inf); err != nil {
-		t.Fatalf("Address verification failed: %v", err)
-	}
-}
-
-func TestSetupVerifyIPv6Missing(t *testing.T) {
-	defer netnsutils.SetupTestOSContext(t)()
-
-	addrv4 := net.IPv4(192, 168, 1, 1)
-	inf := setupVerifyTest(t)
-	config := &networkConfiguration{}
-	config.AddressIPv4 = &net.IPNet{IP: addrv4, Mask: addrv4.DefaultMask()}
-	config.EnableIPv6 = true
-
-	if err := netlink.AddrAdd(inf.Link, &netlink.Addr{IPNet: config.AddressIPv4}); err != nil {
-		t.Fatalf("Failed to assign IPv4 %s to interface: %v", config.AddressIPv4, err)
-	}
-
-	if err := setupVerifyAndReconcile(config, inf); err == nil {
+	if err := setupVerifyAndReconcileIPv4(config, inf); err == nil {
 		t.Fatal("Address verification was expected to fail")
 	}
 }

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -1121,7 +1121,7 @@ func (ep *Endpoint) releaseAddress() {
 		}
 	}
 
-	if ep.iface.addrv6 != nil && ep.iface.addrv6.IP.IsGlobalUnicast() {
+	if ep.iface.addrv6 != nil {
 		if err := ipam.ReleaseAddress(ep.iface.v6PoolID, ep.iface.addrv6.IP); err != nil {
 			log.G(context.TODO()).Warnf("Failed to release ip address %s on delete of endpoint %s (%s): %v", ep.iface.addrv6.IP, ep.Name(), ep.ID(), err)
 		}

--- a/libnetwork/internal/netiputil/netiputil.go
+++ b/libnetwork/internal/netiputil/netiputil.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/docker/libnetwork/ipbits"
 )
 
+// ToIPNet converts p into a *net.IPNet, returning nil if p is not valid.
 func ToIPNet(p netip.Prefix) *net.IPNet {
 	if !p.IsValid() {
 		return nil
@@ -17,6 +18,8 @@ func ToIPNet(p netip.Prefix) *net.IPNet {
 	}
 }
 
+// ToPrefix converts n into a netip.Prefix. If n is not a valid IPv4 or IPV6
+// address, ToPrefix returns netip.Prefix{}, false.
 func ToPrefix(n *net.IPNet) (netip.Prefix, bool) {
 	if ll := len(n.Mask); ll != net.IPv4len && ll != net.IPv6len {
 		return netip.Prefix{}, false
@@ -35,11 +38,13 @@ func ToPrefix(n *net.IPNet) (netip.Prefix, bool) {
 	return netip.PrefixFrom(addr.Unmap(), ones), true
 }
 
+// HostID masks out the 'bits' most-significant bits of addr. The result is
+// undefined if bits > addr.BitLen().
 func HostID(addr netip.Addr, bits uint) uint64 {
 	return ipbits.Field(addr, bits, uint(addr.BitLen()))
 }
 
-// subnetRange returns the amount to add to network.Addr() in order to yield the
+// SubnetRange returns the amount to add to network.Addr() in order to yield the
 // first and last addresses in subnet, respectively.
 func SubnetRange(network, subnet netip.Prefix) (start, end uint64) {
 	start = HostID(subnet.Addr(), uint(network.Bits()))

--- a/libnetwork/internal/netiputil/netiputil.go
+++ b/libnetwork/internal/netiputil/netiputil.go
@@ -1,4 +1,4 @@
-package ipam
+package netiputil
 
 import (
 	"net"
@@ -7,7 +7,7 @@ import (
 	"github.com/docker/docker/libnetwork/ipbits"
 )
 
-func toIPNet(p netip.Prefix) *net.IPNet {
+func ToIPNet(p netip.Prefix) *net.IPNet {
 	if !p.IsValid() {
 		return nil
 	}
@@ -17,7 +17,7 @@ func toIPNet(p netip.Prefix) *net.IPNet {
 	}
 }
 
-func toPrefix(n *net.IPNet) (netip.Prefix, bool) {
+func ToPrefix(n *net.IPNet) (netip.Prefix, bool) {
 	if ll := len(n.Mask); ll != net.IPv4len && ll != net.IPv6len {
 		return netip.Prefix{}, false
 	}
@@ -35,14 +35,14 @@ func toPrefix(n *net.IPNet) (netip.Prefix, bool) {
 	return netip.PrefixFrom(addr.Unmap(), ones), true
 }
 
-func hostID(addr netip.Addr, bits uint) uint64 {
+func HostID(addr netip.Addr, bits uint) uint64 {
 	return ipbits.Field(addr, bits, uint(addr.BitLen()))
 }
 
 // subnetRange returns the amount to add to network.Addr() in order to yield the
 // first and last addresses in subnet, respectively.
-func subnetRange(network, subnet netip.Prefix) (start, end uint64) {
-	start = hostID(subnet.Addr(), uint(network.Bits()))
+func SubnetRange(network, subnet netip.Prefix) (start, end uint64) {
+	start = HostID(subnet.Addr(), uint(network.Bits()))
 	end = start + (1 << uint64(subnet.Addr().BitLen()-subnet.Bits())) - 1
 	return start, end
 }


### PR DESCRIPTION
**- What I did**

The original ticket reports that the daemon won't start if the `fixed-cidr-v6` address is changed from `fe80::/64` to, for example, `fe80::/80` ... those are link local addresses, which turn out to be a special case. But, the same applies to any IPv6 subnet - if the daemon is started with IPv6 enabled on the default bridge, then the `fixed-cidr-v6` is changed to an overlapping subnet, the daemon fails to start. (For example, `2001:db8::/64` to `2001:db8::/80`.)

This change makes it possible to change the configured address for the default bridge to an overlapping subnet (without manually deleting the `docker0` bridge).

Link-local addresses were a special case because they were not released when a container stopped. So, for the default bridge where IP addresses are based on MAC addresses - and MAC addresses were recycled - with `fixed-cidr-v6=fe80::/64`, once a container was stopped new containers could not be started.  For non-default bridge networks with a link-local subnet, addresses leaked when containers stopped.

Linux always uses the `fe80::/64` network, the 'veth' devices get addresses in that subnet. So, overlapping LL subnets are not allowed by this change, other LL subnets are ok.

**- How I did it**

The code was doing this:
```
setupBridgeIPv6():
   - programIPv6Address(<default link local address>)
   - programIPv6Address(<configured address>)
if !config.InhibitIPv4 then setupVerifyAndReconcile():
  - some IPv4 stuff
  - remove global-unicast IPv6 addresses, apart from the configured on
```

So, it was trying to add the new configured address before deleting the old one. Nowhere in the code has a complete picture of the IPv6 addresses the bridge needs, so it's not able to reconcile existing/required config properly.

This change calculates the IPv6 addresses needed on the bridge, then reconciles them with the addresses on an existing bridge by deleting then adding addresses as required - all in `setupBridgeIPv6()`.

If the configured subnet is link-local, it replaces the default link local address/network.

Link local addresses are returned to their address pool when containers are stopped.

Also...

The only remaining calls of `bridgeInterface.addresses()` want either IPv4 or IPv6, but not both. So, made the address family a param.

Because the IPv6 addresses are now calculated and applied in one go, there's no need for `setupVerifyAndReconcile()` to check the set of IPv6 addresses on the bridge. And, that code was guarded by `!config.InhibitIPv4`, which can't have been right. So, removed its IPv6 parts, and added IPv4 to the function's name.

Fixes #46829

**- How to verify it**

New integration test, and updated unit tests.

Overlapping change to `--fixed-cidr-v6`:
```
# dockerd  --ipv6 --experimental --ip6tables --fixed-cidr-v6=fc00:1234::/64
...
# ip a
[...]
4: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default
    link/ether 02:42:b8:f5:44:23 brd ff:ff:ff:ff:ff:ff
    inet 172.18.0.1/16 brd 172.18.255.255 scope global docker0
       valid_lft forever preferred_lft forever
    inet6 fc00:1234::1/64 scope global
       valid_lft forever preferred_lft forever
    inet6 fe80::1/64 scope link
       valid_lft forever preferred_lft forever

# dockerd  --ipv6 --experimental --ip6tables --fixed-cidr-v6=fc00:1234::/80
...
# ip a
[...]
4: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default
    link/ether 02:42:b8:f5:44:23 brd ff:ff:ff:ff:ff:ff
    inet 172.18.0.1/16 brd 172.18.255.255 scope global docker0
       valid_lft forever preferred_lft forever
    inet6 fc00:1234::1/80 scope global
       valid_lft forever preferred_lft forever
    inet6 fe80::1/64 scope link
       valid_lft forever preferred_lft forever
```

Explicit errors if `--fixed-cidr-v6` is link local and overlaps with (but isn't equal to) `fe80::/64`:

```
# dockerd --ipv6 --experimental --ip6tables --fixed-cidr-v6=fe80::/65 --validate
unable to configure the Docker daemon with file /etc/docker/daemon.json: merged configuration validation from file and command line flags failed: invalid fixed-cidr-v6: clash with the Link-Local prefix 'fe80::/64'

# docker network create --subnet=fe80::/65 testnet
Error response from daemon: clash with the Link-Local prefix 'fe80::/64'
```

**- Description for the changelog**

Allow overlapping change in bridge's IPv6 subnet, support link-local subnets.