### PR TITLE
libnet: Endpoint: remove isAnonymous & myAliases

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2530,6 +2530,21 @@ definitions:
         example:
           com.example.some-label: "some-value"
           com.example.some-other-label: "some-other-value"
+      DNSNames:
+        description: |
+          List of all DNS names an endpoint has on a specific network. This
+          list is based on the container name, network aliases, container short
+          ID, and hostname.
+
+          These DNS names are non-fully qualified but can contain several dots.
+          You can get fully qualified DNS names by appending `.<network-name>`.
+          For instance, if container name is `my.ctr` and the network is named
+          `testnet`, `DNSNames` will contain `my.ctr` and the FQDN will be
+          `my.ctr.testnet`.
+        type: array
+        items:
+          type: string
+        example: ["foobar", "server_x", "server_y", "my.ctr"]
 
   EndpointIPAMConfig:
     description: |

--- a/api/types/network/endpoint.go
+++ b/api/types/network/endpoint.go
@@ -13,7 +13,7 @@ type EndpointSettings struct {
 	// Configurations
 	IPAMConfig *EndpointIPAMConfig
 	Links      []string
-	Aliases    []string
+	Aliases    []string // Aliases holds the list of extra, user-specified DNS names for this endpoint.
 	MacAddress string
 	// Operational data
 	NetworkID           string
@@ -25,6 +25,9 @@ type EndpointSettings struct {
 	GlobalIPv6Address   string
 	GlobalIPv6PrefixLen int
 	DriverOpts          map[string]string
+	// DNSNames holds all the (non fully qualified) DNS names associated to this endpoint. First entry is used to
+	// generate PTR records.
+	DNSNames []string
 }
 
 // Copy makes a deep copy of `EndpointSettings`
@@ -43,6 +46,12 @@ func (es *EndpointSettings) Copy() *EndpointSettings {
 		aliases := make([]string, 0, len(es.Aliases))
 		epCopy.Aliases = append(aliases, es.Aliases...)
 	}
+
+	if len(es.DNSNames) > 0 {
+		epCopy.DNSNames = make([]string, len(es.DNSNames))
+		copy(epCopy.DNSNames, es.DNSNames)
+	}
+
 	return &epCopy
 }
 

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -122,9 +122,8 @@ func (daemon *Daemon) Register(c *container.Container) error {
 
 func (daemon *Daemon) newContainer(name string, operatingSystem string, config *containertypes.Config, hostConfig *containertypes.HostConfig, imgID image.ID, managed bool) (*container.Container, error) {
 	var (
-		id             string
-		err            error
-		noExplicitName = name == ""
+		id  string
+		err error
 	)
 	id, name, err = daemon.generateIDAndName(name)
 	if err != nil {
@@ -151,7 +150,7 @@ func (daemon *Daemon) newContainer(name string, operatingSystem string, config *
 	base.Config = config
 	base.HostConfig = &containertypes.HostConfig{}
 	base.ImageID = imgID
-	base.NetworkSettings = &network.Settings{IsAnonymousEndpoint: noExplicitName}
+	base.NetworkSettings = &network.Settings{}
 	base.Name = name
 	base.Driver = daemon.imageService.StorageDriver()
 	base.OS = operatingSystem

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -652,31 +652,6 @@ func cleanOperationalData(es *network.EndpointSettings) {
 func (daemon *Daemon) updateNetworkConfig(container *container.Container, n *libnetwork.Network, endpointConfig *networktypes.EndpointSettings, updateSettings bool) error {
 	if containertypes.NetworkMode(n.Name()).IsUserDefined() {
 		endpointConfig.DNSNames = buildEndpointDNSNames(container, endpointConfig.Aliases)
-
-		// TODO(aker): remove this code once endpoint's DNSNames is used for real.
-		addShortID := true
-		shortID := stringid.TruncateID(container.ID)
-		for _, alias := range endpointConfig.Aliases {
-			if alias == shortID {
-				addShortID = false
-				break
-			}
-		}
-		if addShortID {
-			endpointConfig.Aliases = append(endpointConfig.Aliases, shortID)
-		}
-		if container.Name != container.Config.Hostname {
-			addHostname := true
-			for _, alias := range endpointConfig.Aliases {
-				if alias == container.Config.Hostname {
-					addHostname = false
-					break
-				}
-			}
-			if addHostname {
-				endpointConfig.Aliases = append(endpointConfig.Aliases, container.Config.Hostname)
-			}
-		}
 	}
 
 	if err := validateEndpointSettings(n, n.Name(), endpointConfig); err != nil {

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/internal/multierror"
+	"github.com/docker/docker/internal/sliceutil"
 	"github.com/docker/docker/libnetwork"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/options"
@@ -650,6 +651,9 @@ func cleanOperationalData(es *network.EndpointSettings) {
 
 func (daemon *Daemon) updateNetworkConfig(container *container.Container, n *libnetwork.Network, endpointConfig *networktypes.EndpointSettings, updateSettings bool) error {
 	if containertypes.NetworkMode(n.Name()).IsUserDefined() {
+		endpointConfig.DNSNames = buildEndpointDNSNames(container, endpointConfig.Aliases)
+
+		// TODO(aker): remove this code once endpoint's DNSNames is used for real.
 		addShortID := true
 		shortID := stringid.TruncateID(container.ID)
 		for _, alias := range endpointConfig.Aliases {
@@ -685,6 +689,29 @@ func (daemon *Daemon) updateNetworkConfig(container *container.Container, n *lib
 		}
 	}
 	return nil
+}
+
+// buildEndpointDNSNames constructs the list of DNSNames that should be assigned to a given endpoint. The order within
+// the returned slice is important as the first entry will be used to generate the PTR records (for IPv4 and v6)
+// associated to this endpoint.
+func buildEndpointDNSNames(ctr *container.Container, aliases []string) []string {
+	var dnsNames []string
+
+	if ctr.Name != "" {
+		dnsNames = append(dnsNames, strings.TrimPrefix(ctr.Name, "/"))
+	}
+
+	dnsNames = append(dnsNames, aliases...)
+
+	if ctr.ID != "" {
+		dnsNames = append(dnsNames, stringid.TruncateID(ctr.ID))
+	}
+
+	if ctr.Config.Hostname != "" {
+		dnsNames = append(dnsNames, ctr.Config.Hostname)
+	}
+
+	return sliceutil.Dedup(dnsNames)
 }
 
 func (daemon *Daemon) connectToNetwork(cfg *config.Config, container *container.Container, idOrName string, endpointConfig *networktypes.EndpointSettings, updateSettings bool) (err error) {

--- a/daemon/container_operations_test.go
+++ b/daemon/container_operations_test.go
@@ -12,7 +12,7 @@ import (
 	is "gotest.tools/v3/assert/cmp"
 )
 
-func TestDNSNamesAreEquivalentToAliases(t *testing.T) {
+func TestDNSNamesOrder(t *testing.T) {
 	d := &Daemon{}
 	ctr := &container.Container{
 		ID:   "35de8003b19e27f636fc6ecbf4d7072558b872a8544f287fd69ad8182ad59023",
@@ -35,7 +35,6 @@ func TestDNSNamesAreEquivalentToAliases(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Check(t, is.DeepEqual(epSettings.Aliases, []string{"myctr", "35de8003b19e", "baz"}))
 	assert.Check(t, is.DeepEqual(epSettings.DNSNames, []string{"foobar", "myctr", "35de8003b19e", "baz"}))
 }
 

--- a/daemon/container_operations_test.go
+++ b/daemon/container_operations_test.go
@@ -1,0 +1,56 @@
+package daemon
+
+import (
+	"encoding/json"
+	"testing"
+
+	containertypes "github.com/docker/docker/api/types/container"
+	networktypes "github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/container"
+	"github.com/docker/docker/libnetwork"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestDNSNamesAreEquivalentToAliases(t *testing.T) {
+	d := &Daemon{}
+	ctr := &container.Container{
+		ID:   "35de8003b19e27f636fc6ecbf4d7072558b872a8544f287fd69ad8182ad59023",
+		Name: "foobar",
+		Config: &containertypes.Config{
+			Hostname: "baz",
+		},
+	}
+	nw := buildNetwork(t, map[string]any{
+		"id":          "1234567890",
+		"name":        "testnet",
+		"networkType": "bridge",
+		"enableIPv6":  false,
+	})
+	epSettings := &networktypes.EndpointSettings{
+		Aliases: []string{"myctr"},
+	}
+
+	if err := d.updateNetworkConfig(ctr, nw, epSettings, false); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Check(t, is.DeepEqual(epSettings.Aliases, []string{"myctr", "35de8003b19e", "baz"}))
+	assert.Check(t, is.DeepEqual(epSettings.DNSNames, []string{"foobar", "myctr", "35de8003b19e", "baz"}))
+}
+
+func buildNetwork(t *testing.T, config map[string]any) *libnetwork.Network {
+	t.Helper()
+
+	b, err := json.Marshal(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nw := &libnetwork.Network{}
+	if err := nw.UnmarshalJSON(b); err != nil {
+		t.Fatal(err)
+	}
+
+	return nw
+}

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -793,8 +793,7 @@ func buildCreateEndpointOptions(c *container.Container, n *libnetwork.Network, e
 	var genericOptions = make(options.Generic)
 
 	nwName := n.Name()
-	defaultNetName := runconfig.DefaultDaemonNetworkMode().NetworkName()
-	if c.NetworkSettings.IsAnonymousEndpoint || (nwName == defaultNetName && !serviceDiscoveryOnDefaultNetwork()) {
+	if c.NetworkSettings.IsAnonymousEndpoint {
 		createOptions = append(createOptions, libnetwork.CreateOptionAnonymous())
 	}
 

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -793,9 +793,6 @@ func buildCreateEndpointOptions(c *container.Container, n *libnetwork.Network, e
 	var genericOptions = make(options.Generic)
 
 	nwName := n.Name()
-	if c.NetworkSettings.IsAnonymousEndpoint {
-		createOptions = append(createOptions, libnetwork.CreateOptionAnonymous())
-	}
 
 	if epConfig != nil {
 		if ipam := epConfig.IPAMConfig; ipam != nil {

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -821,9 +821,12 @@ func buildCreateEndpointOptions(c *container.Container, n *libnetwork.Network, e
 			createOptions = append(createOptions, libnetwork.CreateOptionIpam(ip, ip6, ipList, nil))
 		}
 
+		// TODO(aker): remove this loop once endpoint's DNSNames is used for real
 		for _, alias := range epConfig.Aliases {
 			createOptions = append(createOptions, libnetwork.CreateOptionMyAlias(alias))
 		}
+		createOptions = append(createOptions, libnetwork.CreateOptionDNSNames(epConfig.DNSNames))
+
 		for k, v := range epConfig.DriverOpts {
 			createOptions = append(createOptions, libnetwork.EndpointOptionGeneric(options.Generic{k: v}))
 		}

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -818,10 +818,6 @@ func buildCreateEndpointOptions(c *container.Container, n *libnetwork.Network, e
 			createOptions = append(createOptions, libnetwork.CreateOptionIpam(ip, ip6, ipList, nil))
 		}
 
-		// TODO(aker): remove this loop once endpoint's DNSNames is used for real
-		for _, alias := range epConfig.Aliases {
-			createOptions = append(createOptions, libnetwork.CreateOptionMyAlias(alias))
-		}
 		createOptions = append(createOptions, libnetwork.CreateOptionDNSNames(epConfig.DNSNames))
 
 		for k, v := range epConfig.DriverOpts {

--- a/daemon/network/settings.go
+++ b/daemon/network/settings.go
@@ -24,7 +24,6 @@ type Settings struct {
 	Ports                  nat.PortMap
 	SecondaryIPAddresses   []networktypes.Address
 	SecondaryIPv6Addresses []networktypes.Address
-	IsAnonymousEndpoint    bool
 	HasSwarmEndpoint       bool
 }
 

--- a/daemon/rename.go
+++ b/daemon/rename.go
@@ -39,7 +39,6 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) (retErr error) {
 	defer container.Unlock()
 
 	oldName = container.Name
-	oldIsAnonymousEndpoint := container.NetworkSettings.IsAnonymousEndpoint
 
 	if oldName == newName {
 		return errdefs.InvalidParameter(errors.New("Renaming a container with the same name as its current name"))
@@ -63,12 +62,10 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) (retErr error) {
 	}
 
 	container.Name = newName
-	container.NetworkSettings.IsAnonymousEndpoint = false
 
 	defer func() {
 		if retErr != nil {
 			container.Name = oldName
-			container.NetworkSettings.IsAnonymousEndpoint = oldIsAnonymousEndpoint
 			daemon.reserveName(container.ID, oldName)
 			for k, v := range links {
 				daemon.containersReplica.ReserveName(oldName+k, v.ID)
@@ -102,7 +99,6 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) (retErr error) {
 	defer func() {
 		if retErr != nil {
 			container.Name = oldName
-			container.NetworkSettings.IsAnonymousEndpoint = oldIsAnonymousEndpoint
 			if err := container.CheckpointTo(daemon.containersReplica); err != nil {
 				log.G(context.TODO()).WithFields(log.Fields{
 					"containerID": container.ID,

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -70,6 +70,11 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `GET /info` now includes `status` properties in `Runtimes`.
 * A new field named `DNSNames` and containing all non-fully qualified DNS names
   a container takes on a specific network has been added to `GET /containers/{name:.*}/json`.
+* The `Aliases` field returned in calls to `GET /containers/{name:.*}/json` in v1.44  and older
+  versions contains the short container ID. This will change in the next API version,  v1.45.
+  Starting with that API version, this specific value will  be removed from the `Aliases` field
+  such that this field will reflect exactly the values originally submitted to the
+  `POST /containers/create` endpoint. The newly introduced `DNSNames` should now be used instead.
 
 ## v1.43 API changes
 

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -68,6 +68,8 @@ keywords: "API, Docker, rcli, REST, documentation"
 * The `Container` and `ContainerConfig` fields in the `GET /images/{name}/json`
   response are deprecated and will no longer be included in API v1.45.
 * `GET /info` now includes `status` properties in `Runtimes`.
+* A new field named `DNSNames` and containing all non-fully qualified DNS names
+  a container takes on a specific network has been added to `GET /containers/{name:.*}/json`.
 
 ## v1.43 API changes
 

--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -13,7 +13,8 @@ source hack/make/.integration-test-helpers
 # --deselect=tests/integration/api_container_test.py::AttachContainerTest::test_attach_no_stream
 # TODO re-enable test_attach_no_stream after https://github.com/docker/docker-py/issues/2513 is resolved
 # TODO re-enable test_run_container_reading_socket_ws. It's reported in https://github.com/docker/docker-py/issues/1478, and we're getting that error in our tests.
-: "${PY_TEST_OPTIONS:=--junitxml=${DEST}/junit-report.xml --deselect=tests/integration/api_container_test.py::AttachContainerTest::test_attach_no_stream --deselect=tests/integration/api_container_test.py::AttachContainerTest::test_run_container_reading_socket_ws}"
+# TODO re-enable test_run_with_networking_config once this issue is fixed: https://github.com/moby/moby/pull/46853#issuecomment-1864679942.
+: "${PY_TEST_OPTIONS:=--junitxml=${DEST}/junit-report.xml --deselect=tests/integration/api_container_test.py::AttachContainerTest::test_attach_no_stream --deselect=tests/integration/api_container_test.py::AttachContainerTest::test_run_container_reading_socket_ws --deselect=tests/integration/models_containers_test.py::ContainerCollectionTest::test_run_with_networking_config}"
 
 # build --squash is not supported with containerd integration.
 if [ -n "$TEST_INTEGRATION_USE_SNAPSHOTTER" ]; then

--- a/integration/service/network_test.go
+++ b/integration/service/network_test.go
@@ -5,6 +5,7 @@ import (
 
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/container"
 	net "github.com/docker/docker/integration/internal/network"
 	"github.com/docker/docker/integration/internal/swarm"
@@ -13,13 +14,13 @@ import (
 	"gotest.tools/v3/skip"
 )
 
-func TestDockerNetworkConnectAlias(t *testing.T) {
+func TestDockerNetworkConnectAliasPreV144(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	ctx := setupTest(t)
 
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
-	client := d.NewClientT(t)
+	client := d.NewClientT(t, client.WithVersion("1.43"))
 	defer client.Close()
 
 	name := t.Name() + "test-alias"

--- a/internal/sliceutil/sliceutil.go
+++ b/internal/sliceutil/sliceutil.go
@@ -1,0 +1,13 @@
+package sliceutil
+
+func Dedup[T comparable](slice []T) []T {
+	keys := make(map[T]struct{})
+	out := make([]T, 0, len(slice))
+	for _, s := range slice {
+		if _, ok := keys[s]; !ok {
+			out = append(out, s)
+			keys[s] = struct{}{}
+		}
+	}
+	return out
+}

--- a/libnetwork/default_gateway.go
+++ b/libnetwork/default_gateway.go
@@ -47,7 +47,7 @@ func (sb *Sandbox) setupDefaultGW() error {
 		}
 	}
 
-	createOptions := []EndpointOption{CreateOptionAnonymous()}
+	createOptions := []EndpointOption{}
 
 	var gwName string
 	if len(sb.containerID) <= gwEPlen {

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -308,10 +308,15 @@ func (ep *Endpoint) Network() string {
 	return ep.network.name
 }
 
-func (ep *Endpoint) isAnonymous() bool {
+// getDNSNames returns a copy of the DNS names associated to this endpoint. The first entry is the one used for PTR
+// records.
+func (ep *Endpoint) getDNSNames() []string {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
-	return ep.anonymous
+
+	dnsNames := make([]string, len(ep.dnsNames))
+	copy(dnsNames, ep.dnsNames)
+	return dnsNames
 }
 
 // isServiceEnabled check if service is enabled on the endpoint

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -972,6 +972,14 @@ func CreateOptionAnonymous() EndpointOption {
 	}
 }
 
+// CreateOptionDNSNames specifies the list of (non fully qualified) DNS names associated to an endpoint. These will be
+// used to populate the embedded DNS server. Order matters: first name will be used to generate PTR records.
+func CreateOptionDNSNames(names []string) EndpointOption {
+	return func(ep *Endpoint) {
+		ep.dnsNames = names
+	}
+}
+
 // CreateOptionDisableResolution function returns an option setter to indicate
 // this endpoint doesn't want embedded DNS server functionality
 func CreateOptionDisableResolution() EndpointOption {

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -192,7 +192,6 @@ func TestEndpointMarshalling(t *testing.T) {
 		name:      "Bau",
 		id:        "efghijklmno",
 		sandboxID: "ambarabaciccicocco",
-		anonymous: true,
 		iface: &EndpointInterface{
 			mac: []byte{11, 12, 13, 14, 15, 16},
 			addr: &net.IPNet{
@@ -220,7 +219,7 @@ func TestEndpointMarshalling(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if e.name != ee.name || e.id != ee.id || e.sandboxID != ee.sandboxID || !reflect.DeepEqual(e.dnsNames, ee.dnsNames) || !compareEndpointInterface(e.iface, ee.iface) || e.anonymous != ee.anonymous {
+	if e.name != ee.name || e.id != ee.id || e.sandboxID != ee.sandboxID || !reflect.DeepEqual(e.dnsNames, ee.dnsNames) || !compareEndpointInterface(e.iface, ee.iface) {
 		t.Fatalf("JSON marsh/unmarsh failed.\nOriginal:\n%#v\nDecoded:\n%#v\nOriginal iface: %#v\nDecodediface:\n%#v", e, ee, e.iface, ee.iface)
 	}
 }

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"reflect"
 	"runtime"
 	"testing"
 	"time"
@@ -205,6 +206,7 @@ func TestEndpointMarshalling(t *testing.T) {
 			v6PoolID:  "poolv6",
 			llAddrs:   lla,
 		},
+		dnsNames: []string{"test", "foobar", "baz"},
 	}
 
 	b, err := json.Marshal(e)
@@ -218,7 +220,7 @@ func TestEndpointMarshalling(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if e.name != ee.name || e.id != ee.id || e.sandboxID != ee.sandboxID || !compareEndpointInterface(e.iface, ee.iface) || e.anonymous != ee.anonymous {
+	if e.name != ee.name || e.id != ee.id || e.sandboxID != ee.sandboxID || !reflect.DeepEqual(e.dnsNames, ee.dnsNames) || !compareEndpointInterface(e.iface, ee.iface) || e.anonymous != ee.anonymous {
 		t.Fatalf("JSON marsh/unmarsh failed.\nOriginal:\n%#v\nDecoded:\n%#v\nOriginal iface: %#v\nDecodediface:\n%#v", e, ee, e.iface, ee.iface)
 	}
 }

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -175,7 +175,7 @@ func (i *IpamInfo) UnmarshalJSON(data []byte) error {
 type Network struct {
 	ctrlr            *Controller
 	name             string
-	networkType      string
+	networkType      string // networkType is the name of the netdriver used by this network
 	id               string
 	created          time.Time
 	scope            string // network data scope

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1302,8 +1302,6 @@ func (n *Network) updateSvcRecord(ep *Endpoint, isAdd bool) {
 	}
 
 	var ipv6 net.IP
-	epName := ep.Name()
-	myAliases := ep.MyAliases()
 	if iface.AddressIPv6() != nil {
 		ipv6 = iface.AddressIPv6().IP
 	}
@@ -1312,30 +1310,17 @@ func (n *Network) updateSvcRecord(ep *Endpoint, isAdd bool) {
 	if serviceID == "" {
 		serviceID = ep.ID()
 	}
+
+	dnsNames := ep.getDNSNames()
 	if isAdd {
-		// If anonymous endpoint has an alias use the first alias
-		// for ip->name mapping. Not having the reverse mapping
-		// breaks some apps
-		if ep.isAnonymous() {
-			if len(myAliases) > 0 {
-				n.addSvcRecords(ep.ID(), myAliases[0], serviceID, iface.Address().IP, ipv6, true, "updateSvcRecord")
-			}
-		} else {
-			n.addSvcRecords(ep.ID(), epName, serviceID, iface.Address().IP, ipv6, true, "updateSvcRecord")
-		}
-		for _, alias := range myAliases {
-			n.addSvcRecords(ep.ID(), alias, serviceID, iface.Address().IP, ipv6, false, "updateSvcRecord")
+		for i, dnsName := range dnsNames {
+			ipMapUpdate := i == 0 // ipMapUpdate indicates whether PTR records should be updated.
+			n.addSvcRecords(ep.ID(), dnsName, serviceID, iface.Address().IP, ipv6, ipMapUpdate, "updateSvcRecord")
 		}
 	} else {
-		if ep.isAnonymous() {
-			if len(myAliases) > 0 {
-				n.deleteSvcRecords(ep.ID(), myAliases[0], serviceID, iface.Address().IP, ipv6, true, "updateSvcRecord")
-			}
-		} else {
-			n.deleteSvcRecords(ep.ID(), epName, serviceID, iface.Address().IP, ipv6, true, "updateSvcRecord")
-		}
-		for _, alias := range myAliases {
-			n.deleteSvcRecords(ep.ID(), alias, serviceID, iface.Address().IP, ipv6, false, "updateSvcRecord")
+		for i, dnsName := range dnsNames {
+			ipMapUpdate := i == 0 // ipMapUpdate indicates whether PTR records should be updated.
+			n.deleteSvcRecords(ep.ID(), dnsName, serviceID, iface.Address().IP, ipv6, ipMapUpdate, "updateSvcRecord")
 		}
 	}
 }
@@ -1374,6 +1359,7 @@ func delNameToIP(svcMap *setmatrix.SetMatrix[svcMapEntry], name, serviceID strin
 	})
 }
 
+// TODO(aker): remove ipMapUpdate param and add a proper method dedicated to update PTR records.
 func (n *Network) addSvcRecords(eID, name, serviceID string, epIP, epIPv6 net.IP, ipMapUpdate bool, method string) {
 	// Do not add service names for ingress network as this is a
 	// routing only network

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -2162,10 +2162,6 @@ func (n *Network) createLoadBalancerSandbox() (retErr error) {
 		CreateOptionIpam(n.loadBalancerIP, nil, nil, nil),
 		CreateOptionLoadBalancer(),
 	}
-	if n.hasLoadBalancerEndpoint() && !n.ingress {
-		// Mark LB endpoints as anonymous so they don't show up in DNS
-		epOptions = append(epOptions, CreateOptionAnonymous())
-	}
 	ep, err := n.createEndpoint(endpointName, epOptions...)
 	if err != nil {
 		return err


### PR DESCRIPTION
**- What I did**

The `Endpoint` struct was containing two confusing fields:

1. `isAnonymous`: was set on endpoints which name shouldn't be taken into account when inserting DNS records into libnetwork's `Controller.svcRecords` (and into the NetworkDB). However, in that case the endpoint's aliases would still be used to create DNS records; thus, making those "anonymous endpoints" not so anonymous.
2. `myAliases`: there's also an `aliases` field in the `Endpoint` struct. `myAliases` was storing extra DNS names for the endpoint, while `aliases` stores extra DNS names for _other_ endpoints (but those extra DNS names are only accessible for the endpoint storing them -- yeah, it's confusing too).

To make it worse, the code that built the list of DNS names for a given endpoint was split in two:

1. `updateNetworkConfig` (in the `daemon` pkg) was adding the endpoint short ID and hostname to the list of aliases ;
2. In libnetwork, to handle "anonymous" endpoints as described above.

This PR replaces both fields with a new `DNSNames` containing _all_ (non-fully qualified) DNS names for a given endpoint. It's now built by the daemon during `updateNetworkConfig` and reimplements the same logic for aliases as before (a test has been added to make sure of that). An "anonymous" endpoint is now an endpoint with no `DNSNames`.

This new field is also stored in the "operational data" (ie. state) of the `EndpointSettings` struct exposed by the API via `GET /containers/{name:.*}/json`, making it easier for end-users and scripts to know every DNS names a container has on a specific network.

**- How to verify it**

`docker run --network testnet` with a variety of:

* `--name` ;
* `--hostname` ;
* `--network-alias` ;

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://www.nhm.ac.uk/resources/visit/wpy/2018/large/webp/14.webp)
