### PR TITLE
quota: increase sparse test-image to 300MB

### DIFF
--- a/quota/testhelpers.go
+++ b/quota/testhelpers.go
@@ -10,8 +10,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const imageSize = 64 * 1024 * 1024
-
 // CanTestQuota - checks if xfs prjquota can be tested
 // returns a reason if not
 func CanTestQuota() (string, bool) {
@@ -28,6 +26,12 @@ func CanTestQuota() (string, bool) {
 // PrepareQuotaTestImage - prepares an xfs prjquota test image
 // returns the path the the image on success
 func PrepareQuotaTestImage(t *testing.T) (string, error) {
+	// imageSize is the size of the test-image. The minimum size allowed
+	// is 300MB.
+	//
+	// See https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/commit/?id=6e0ed3d19c54603f0f7d628ea04b550151d8a262
+	const imageSize = 300 * 1024 * 1024
+
 	mkfs, err := exec.LookPath("mkfs.xfs")
 	if err != nil {
 		return "", err


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/45789

Starting with [6e0ed3d19c54603f0f7d628ea04b550151d8a262], the minimum allowed size is now 300MB. Given that this is a sparse image, and the size of the image is irrelevant to the test (we check for limits defined through project-quotas, not the size of the device itself), we can raise the size of this image.

[6e0ed3d19c54603f0f7d628ea04b550151d8a262]: https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/commit/?id=6e0ed3d19c54603f0f7d628ea04b550151d8a262

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

