### PR TITLE
integration-cli/TestCrossRepositoryLayerPush: Change repo name

### DIFF
--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -172,7 +172,7 @@ func (s *DockerRegistrySuite) TestConcurrentPush(c *testing.T) {
 }
 
 func (s *DockerRegistrySuite) TestCrossRepositoryLayerPush(c *testing.T) {
-	const sourceRepoName = privateRegistryURL + "/dockercli/busybox"
+	const sourceRepoName = privateRegistryURL + "/crossrepopush/busybox"
 
 	// tag the image to upload it to the private registry
 	cli.DockerCmd(c, "tag", "busybox", sourceRepoName)
@@ -185,7 +185,7 @@ func (s *DockerRegistrySuite) TestCrossRepositoryLayerPush(c *testing.T) {
 	digest1 := reference.DigestRegexp.FindString(out1)
 	assert.Assert(c, len(digest1) > 0, "no digest found for pushed manifest")
 
-	const destRepoName = privateRegistryURL + "/dockercli/crossrepopush"
+	const destRepoName = privateRegistryURL + "/crossrepopush/img"
 
 	// retag the image to upload the same layers to another repo in the same registry
 	cli.DockerCmd(c, "tag", "busybox", destRepoName)
@@ -194,7 +194,7 @@ func (s *DockerRegistrySuite) TestCrossRepositoryLayerPush(c *testing.T) {
 	assert.NilError(c, err, "pushing the image to the private registry has failed: %s", out2)
 
 	// ensure that layers were mounted from the first repo during push
-	assert.Assert(c, strings.Contains(out2, "Mounted from dockercli/busybox"))
+	assert.Assert(c, strings.Contains(out2, "Mounted from crossrepopush/busybox"))
 
 	digest2 := reference.DigestRegexp.FindString(out2)
 	assert.Assert(c, len(digest2) > 0, "no digest found for pushed manifest")


### PR DESCRIPTION
Change the repo name used as for an intermediate image so it doesn't try to mount from the image pushed by `TestBuildMultiStageImplicitPull`.

Before this patch, this test failed because the distribution.source labels are not cleared between tests and the busybox content still has the distribution.source label pointing to the `dockercli/testf` repository which is no longer present in the test registry. So both `dockercli/busybox` and `dockercli/testf` are equally valid mount candidates for `dockercli/crossrepopush` and containerd algorithm just happens to select the last one.

This changes the repo name to not have the common repository component (`dockercli`) with the `dockercli/testf` repository.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
Observe `TestCrossRepositoryLayerPush` result in CI.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

