### PR TITLE
liverestore: Don't remove `--rm` containers on restart

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -495,9 +495,12 @@ func (daemon *Daemon) restore(cfg *configStore) error {
 				restartContainers[c] = make(chan struct{})
 				mapLock.Unlock()
 			} else if c.HostConfig != nil && c.HostConfig.AutoRemove {
-				mapLock.Lock()
-				removeContainers[c.ID] = c
-				mapLock.Unlock()
+				// Remove the container if live-restore is disabled or if the container has already exited.
+				if !cfg.LiveRestoreEnabled || !alive {
+					mapLock.Lock()
+					removeContainers[c.ID] = c
+					mapLock.Unlock()
+				}
 			}
 
 			c.Lock()

--- a/integration/daemon/daemon_test.go
+++ b/integration/daemon/daemon_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
@@ -381,6 +382,66 @@ func TestLiveRestore(t *testing.T) {
 	_ = testutil.StartSpan(baseContext, t)
 
 	t.Run("volume references", testLiveRestoreVolumeReferences)
+	t.Run("autoremove", testLiveRestoreAutoRemove)
+}
+
+func testLiveRestoreAutoRemove(t *testing.T) {
+	skip.If(t, testEnv.IsRootless(), "restarted rootless daemon will have a new process namespace")
+
+	t.Parallel()
+	ctx := testutil.StartSpan(baseContext, t)
+
+	run := func(t *testing.T) (*daemon.Daemon, func(), string) {
+		d := daemon.New(t)
+		d.StartWithBusybox(ctx, t, "--live-restore", "--iptables=false")
+		t.Cleanup(func() {
+			d.Stop(t)
+			d.Cleanup(t)
+		})
+
+		tmpDir := t.TempDir()
+
+		apiClient := d.NewClientT(t)
+
+		cID := container.Run(ctx, t, apiClient,
+			container.WithBind(tmpDir, "/v"),
+			// Run until a 'stop' file is created.
+			container.WithCmd("sh", "-c", "while [ ! -f /v/stop ]; do sleep 0.1; done"),
+			container.WithAutoRemove)
+		t.Cleanup(func() { apiClient.ContainerRemove(ctx, cID, containertypes.RemoveOptions{Force: true}) })
+		finishContainer := func() {
+			file, err := os.Create(filepath.Join(tmpDir, "stop"))
+			assert.NilError(t, err, "Failed to create 'stop' file")
+			file.Close()
+		}
+		return d, finishContainer, cID
+	}
+
+	t.Run("engine restart shouldnt kill alive containers", func(t *testing.T) {
+		d, finishContainer, cID := run(t)
+
+		d.Restart(t, "--live-restore", "--iptables=false")
+
+		apiClient := d.NewClientT(t)
+		_, err := apiClient.ContainerInspect(ctx, cID)
+		assert.NilError(t, err, "Container shouldn't be removed after engine restart")
+
+		finishContainer()
+
+		poll.WaitOn(t, container.IsRemoved(ctx, apiClient, cID))
+	})
+	t.Run("engine restart should remove containers that exited", func(t *testing.T) {
+		d, finishContainer, cID := run(t)
+
+		d.Stop(t)
+
+		finishContainer()
+		time.Sleep(time.Millisecond * 200)
+
+		d.Start(t, "--live-restore", "--iptables=false")
+
+		poll.WaitOn(t, container.IsRemoved(ctx, d.NewClientT(t), cID))
+	})
 }
 
 func testLiveRestoreVolumeReferences(t *testing.T) {

--- a/integration/daemon/daemon_test.go
+++ b/integration/daemon/daemon_test.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"syscall"
 	"testing"
-	"time"
 
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
@@ -22,6 +21,7 @@ import (
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/integration/internal/process"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
@@ -433,14 +433,21 @@ func testLiveRestoreAutoRemove(t *testing.T) {
 	t.Run("engine restart should remove containers that exited", func(t *testing.T) {
 		d, finishContainer, cID := run(t)
 
+		apiClient := d.NewClientT(t)
+
+		// Get PID of the container process.
+		inspect, err := apiClient.ContainerInspect(ctx, cID)
+		assert.NilError(t, err)
+		pid := inspect.State.Pid
+
 		d.Stop(t)
 
 		finishContainer()
-		time.Sleep(time.Millisecond * 200)
+		poll.WaitOn(t, process.NotAlive(pid))
 
 		d.Start(t, "--live-restore", "--iptables=false")
 
-		poll.WaitOn(t, container.IsRemoved(ctx, d.NewClientT(t), cID))
+		poll.WaitOn(t, container.IsRemoved(ctx, apiClient, cID))
 	})
 }
 

--- a/integration/internal/process/wait.go
+++ b/integration/internal/process/wait.go
@@ -1,0 +1,17 @@
+package process
+
+import (
+	procpkg "github.com/docker/docker/pkg/process"
+	"gotest.tools/v3/poll"
+)
+
+// NotAlive verifies the process doesn't exist (finished or never started).
+func NotAlive(pid int) func(log poll.LogT) poll.Result {
+	return func(log poll.LogT) poll.Result {
+		if !procpkg.Alive(pid) {
+			return poll.Success()
+		}
+
+		return poll.Continue("waiting for process to finish")
+	}
+}


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/46308

When live-restore is enabled, containers with autoremove enabled shouldn't be forcibly killed when engine restarts.

**- What I did**

**- How I did it**
Added extra check and integration test.

**- How to verify it**
TestLiveRestore

**- Description for the changelog**
```release-note
- live restore: Containers with auto remove (`docker run --rm`) are no longer forcibly removed on engine restart.
```


**- A picture of a cute animal (not mandatory but encouraged)**

