### PR TITLE
builder-next: fix timing filter for default policy

### DIFF
--- a/builder/builder-next/worker/gc.go
+++ b/builder/builder-next/worker/gc.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"math"
+	"time"
 
 	"github.com/moby/buildkit/client"
 )
@@ -30,12 +31,12 @@ func DefaultGCPolicy(p string, defaultKeepBytes int64) []client.PruneInfo {
 		// if build cache uses more than 512MB delete the most easily reproducible data after it has not been used for 2 days
 		{
 			Filter:       []string{"type==source.local,type==exec.cachemount,type==source.git.checkout"},
-			KeepDuration: 48 * 3600, // 48h
+			KeepDuration: 48 * time.Hour,
 			KeepBytes:    tempCacheKeepBytes,
 		},
 		// remove any data not used for 60 days
 		{
-			KeepDuration: 60 * 24 * 3600, // 60d
+			KeepDuration: 60 * 24 * time.Hour,
 			KeepBytes:    keep,
 		},
 		// keep the unshared build cache under cap


### PR DESCRIPTION
When GC was enabled with `"defaultKeepStorage"` setting the time-based filters were not initialized with correct values. This could lead to policy being something like:

```
GC Policy rule#0:
 All:           false
 Filters:       type==source.local,type==exec.cachemount,type==source.git.checkout
 Keep Duration: 172.8µs
 Keep Bytes:    2.764GiB
GC Policy rule#1:
 All:           false
 Keep Duration: 5.184ms
 Keep Bytes:    20GiB
....
```
