### PR TITLE
c8d/integration-cli: Skip part of TestListDanglingImagesWithDigests

### DIFF
--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -326,6 +326,9 @@ func (s *DockerRegistrySuite) TestListImagesWithDigests(c *testing.T) {
 }
 
 func (s *DockerRegistrySuite) TestListDanglingImagesWithDigests(c *testing.T) {
+	// See https://github.com/moby/moby/pull/46856
+	skip.If(c, testEnv.UsingSnapshotter(), "dangling=true filter behaves a bit differently with c8d")
+
 	// setup image1
 	digest1, err := setupImageWithTag(c, "dangle1")
 	assert.NilError(c, err, "error setting up image")


### PR DESCRIPTION
- alternative to: https://github.com/moby/moby/pull/46856

**- What I did**
Skip part of TestListDanglingImagesWithDigests which tests graphdriver implementation specific behavior of `docker images --filter dangling=true`.

**- How I did it**

**- How to verify it**
Check TestListDanglingImagesWithDigests test result

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

