### PR TITLE
cmd/dockerd: remove various cobra templating

### DIFF
--- a/cmd/dockerd/cobra.go
+++ b/cmd/dockerd/cobra.go
@@ -10,10 +10,6 @@ import (
 // SetupRootCommand sets default usage, help, and error handling for the
 // root command.
 func SetupRootCommand(rootCmd *cobra.Command) {
-	cobra.AddTemplateFunc("hasSubCommands", hasSubCommands)
-	cobra.AddTemplateFunc("hasManagementSubCommands", hasManagementSubCommands)
-	cobra.AddTemplateFunc("operationSubCommands", operationSubCommands)
-	cobra.AddTemplateFunc("managementSubCommands", managementSubCommands)
 	cobra.AddTemplateFunc("wrappedFlagUsages", wrappedFlagUsages)
 
 	rootCmd.SetUsageTemplate(usageTemplate)
@@ -42,24 +38,6 @@ func FlagErrorFunc(cmd *cobra.Command, err error) error {
 	}
 }
 
-func hasSubCommands(cmd *cobra.Command) bool {
-	return len(operationSubCommands(cmd)) > 0
-}
-
-func hasManagementSubCommands(cmd *cobra.Command) bool {
-	return len(managementSubCommands(cmd)) > 0
-}
-
-func operationSubCommands(cmd *cobra.Command) []*cobra.Command {
-	var cmds []*cobra.Command
-	for _, sub := range cmd.Commands() {
-		if sub.IsAvailableCommand() && !sub.HasSubCommands() {
-			cmds = append(cmds, sub)
-		}
-	}
-	return cmds
-}
-
 func wrappedFlagUsages(cmd *cobra.Command) string {
 	width := 80
 	if ws, err := term.GetWinsize(0); err == nil {
@@ -68,20 +46,7 @@ func wrappedFlagUsages(cmd *cobra.Command) string {
 	return cmd.Flags().FlagUsagesWrapped(width - 1)
 }
 
-func managementSubCommands(cmd *cobra.Command) []*cobra.Command {
-	var cmds []*cobra.Command
-	for _, sub := range cmd.Commands() {
-		if sub.IsAvailableCommand() && sub.HasSubCommands() {
-			cmds = append(cmds, sub)
-		}
-	}
-	return cmds
-}
-
-var usageTemplate = `Usage:
-
-{{- if not .HasSubCommands}}	{{.UseLine}}{{end}}
-{{- if .HasSubCommands}}	{{ .CommandPath}} COMMAND{{end}}
+var usageTemplate = `Usage:	{{.UseLine}}
 
 {{ .Short | trim }}
 
@@ -102,28 +67,6 @@ Examples:
 Options:
 {{ wrappedFlagUsages . | trimRightSpace}}
 
-{{- end}}
-{{- if hasManagementSubCommands . }}
-
-Management Commands:
-
-{{- range managementSubCommands . }}
-  {{rpad .Name .NamePadding }} {{.Short}}
-{{- end}}
-
-{{- end}}
-{{- if hasSubCommands .}}
-
-Commands:
-
-{{- range operationSubCommands . }}
-  {{rpad .Name .NamePadding }} {{.Short}}
-{{- end}}
-{{- end}}
-
-{{- if .HasSubCommands }}
-
-Run '{{.CommandPath}} COMMAND --help' for more information on a command.
 {{- end}}
 `
 

--- a/cmd/dockerd/cobra.go
+++ b/cmd/dockerd/cobra.go
@@ -46,7 +46,7 @@ func wrappedFlagUsages(cmd *cobra.Command) string {
 	return cmd.Flags().FlagUsagesWrapped(width - 1)
 }
 
-var usageTemplate = `Usage:	{{.UseLine}}
+const usageTemplate = `Usage:	{{.UseLine}}
 
 {{ .Short | trim }}
 
@@ -70,5 +70,5 @@ Options:
 {{- end}}
 `
 
-var helpTemplate = `
+const helpTemplate = `
 {{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`


### PR DESCRIPTION
- addresses part of https://github.com/moby/moby/issues/44641
- relates to https://github.com/moby/moby/pull/26025


### cmd/dockerd: remove various cobra templating
This removes various templating functions that were added for the
docker CLI. These are not needed for the dockerd binary, which does
not have subcommands or management commands.

Revert "Only hide commands if the env variable is set."

This reverts commit https://github.com/moby/moby/commit/a7c8bcac2ba60d6dd25a1157085d9245bed556ce.

### cmd/dockerd: make cobra templates a const


**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

