### PR TITLE
Don't allow port in CIFS URL

### DIFF
--- a/volume/local/local_linux_test.go
+++ b/volume/local/local_linux_test.go
@@ -199,6 +199,32 @@ func TestVolCreateValidation(t *testing.T) {
 				"o":      "foo",
 			},
 		},
+		{
+			doc: "cifs",
+			opts: map[string]string{
+				"type":   "cifs",
+				"device": "//some.example.com/thepath",
+				"o":      "foo",
+			},
+		},
+		{
+			doc: "cifs with port in url",
+			opts: map[string]string{
+				"type":   "cifs",
+				"device": "//some.example.com:2345/thepath",
+				"o":      "foo",
+			},
+			expectedErr: "port not allowed in CIFS device URL, include 'port' in 'o='",
+		},
+		{
+			doc: "cifs with bad url",
+			opts: map[string]string{
+				"type":   "cifs",
+				"device": ":::",
+				"o":      "foo",
+			},
+			expectedErr: `error parsing mount device url: parse ":::": missing protocol scheme`,
+		},
 	}
 
 	for i, tc := range tests {


### PR DESCRIPTION
**- What I did**

When creating a CIFS volume, generate an error if the device URL includes a port number, for example:
   `--opt device="//some.server.com:2345/thepath"`

The port must be specified in the port option instead, for example:
   ` --opt o=username=USERNAME,password=PASSWORD,vers=3,sec=ntlmsspi,port=1234`

As discussed in https://github.com/moby/moby/pull/46863#issuecomment-1833646398

**- How I did it**

Check the CIFS URL during the 'volume create', revert to using the whole Host part of the URL when mounting the volume.

**- How to verify it**

Updated unit test, and ...

```
# docker volume create --driver local --opt type=cifs --opt o=username=auser,password=verysecret,vers=3,sec=ntlmsspi,port=1234 --opt device="//some.server.com:2345/thepath" myvol
Error response from daemon: create myvol: port not allowed in CIFS device URL, include 'port' in 'o='

# docker volume create --driver local --opt type=cifs --opt o=username=auser,password=verysecret,vers=3,sec=ntlmsspi,port=1234 --opt device=":::" myvol
Error response from daemon: create myvol: error parsing mount device url: parse ":::": missing protocol scheme

# docker volume create --driver local --opt type=cifs --opt o=username=auser,password=verysecret,vers=3,sec=ntlmsspi,port=1234 --opt device="//some.server.com/thepath" myvol
myvol
```

**- Description for the changelog**

Don't allow port in CIFS URL