### PR TITLE
add TaskStatus to swagger docs

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3978,6 +3978,44 @@ definitions:
       - "remove"
       - "orphaned"
 
+  ContainerStatus:
+    type: "object"
+    description: "represents the status of a container."
+    properties:
+      ContainerID:
+        type: "string"
+      PID:
+        type: "integer"
+      ExitCode:
+        type: "integer"
+
+  PortStatus:
+    type: "object"
+    description: "represents the port status of a task's host ports whose service has published host ports"
+    properties:
+      Ports:
+        type: "array"
+        items:
+          $ref: "#/definitions/EndpointPortConfig"
+
+  TaskStatus:
+    type: "object"
+    description: "represents the status of a task."
+    properties:
+      Timestamp:
+        type: "string"
+        format: "dateTime"
+      State:
+        $ref: "#/definitions/TaskState"
+      Message:
+        type: "string"
+      Err:
+        type: "string"
+      ContainerStatus:
+        $ref: "#/definitions/ContainerStatus"
+      PortStatus:
+        $ref: "#/definitions/PortStatus"
+
   Task:
     type: "object"
     properties:
@@ -4013,26 +4051,7 @@ definitions:
       AssignedGenericResources:
         $ref: "#/definitions/GenericResources"
       Status:
-        type: "object"
-        properties:
-          Timestamp:
-            type: "string"
-            format: "dateTime"
-          State:
-            $ref: "#/definitions/TaskState"
-          Message:
-            type: "string"
-          Err:
-            type: "string"
-          ContainerStatus:
-            type: "object"
-            properties:
-              ContainerID:
-                type: "string"
-              PID:
-                type: "integer"
-              ExitCode:
-                type: "integer"
+        $ref: "#/definitions/TaskStatus"
       DesiredState:
         $ref: "#/definitions/TaskState"
       JobIteration:


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/27917
- addresses #46049

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I've added the TaskStatus to the Swagger docs.

**- How I did it**

**- How to verify it**
Visit e.g. https://editor.swagger.io/ and copy&paste the updated swagger.yaml, look for TaskStatus, which should have the portstatus.

**- Description for the changelog**

Add the TaskStatus, PortStatus, and ContainerStatus to API docs. TaskStatus was moved to the root of the swagger definition from the anonymous type definition, and PortStatus and Container Status are its dependencies.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Solves #46049

**- A picture of a cute animal (not mandatory but encouraged)**
My dog Looyzah :)
<img width="500" alt="image" src="https://github.com/moby/moby/assets/4950200/a7ce343d-83c8-490a-94b5-881674fe50f4">
