### PR TITLE
daemon: raise default minimum API version to v1.24

### DIFF
--- a/api/common_unix.go
+++ b/api/common_unix.go
@@ -1,6 +1,0 @@
-//go:build !windows
-
-package api // import "github.com/docker/docker/api"
-
-// MinVersion represents Minimum REST API version supported
-const MinVersion = "1.12"

--- a/api/common_windows.go
+++ b/api/common_windows.go
@@ -1,8 +1,0 @@
-package api // import "github.com/docker/docker/api"
-
-// MinVersion represents Minimum REST API version supported
-// Technically the first daemon API version released on Windows is v1.25 in
-// engine version 1.13. However, some clients are explicitly using downlevel
-// APIs (e.g. docker-compose v2.1 file format) and that is just too restrictive.
-// Hence also allowing 1.24 on Windows.
-const MinVersion string = "1.24"

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -15,7 +15,8 @@ import (
 func TestMiddlewares(t *testing.T) {
 	srv := &Server{}
 
-	srv.UseMiddleware(middleware.NewVersionMiddleware("0.1omega2", api.DefaultVersion, api.MinVersion))
+	const apiMinVersion = "1.12"
+	srv.UseMiddleware(middleware.NewVersionMiddleware("0.1omega2", api.DefaultVersion, apiMinVersion))
 
 	req, _ := http.NewRequest(http.MethodGet, "/containers/json", nil)
 	resp := httptest.NewRecorder()

--- a/client/client.go
+++ b/client/client.go
@@ -90,6 +90,13 @@ import (
 // [Go stdlib]: https://github.com/golang/go/blob/6244b1946bc2101b01955468f1be502dbadd6807/src/net/http/transport.go#L558-L569
 const DummyHost = "api.moby.localhost"
 
+// fallbackAPIVersion is the version to fallback to if API-version negotiation
+// fails. This version is the highest version of the API before API-version
+// negotiation was introduced. If negotiation fails (or no API version was
+// included in the API response), we assume the API server uses the most
+// recent version before negotiation was introduced.
+const fallbackAPIVersion = "1.24"
+
 // Client is the API client that performs all operations
 // against a docker server.
 type Client struct {
@@ -329,7 +336,7 @@ func (cli *Client) NegotiateAPIVersionPing(pingResponse types.Ping) {
 func (cli *Client) negotiateAPIVersionPing(pingResponse types.Ping) {
 	// default to the latest version before versioning headers existed
 	if pingResponse.APIVersion == "" {
-		pingResponse.APIVersion = "1.24"
+		pingResponse.APIVersion = fallbackAPIVersion
 	}
 
 	// if the client is not initialized with a version, start with the latest supported version

--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -29,6 +29,9 @@ const (
 	// StockRuntimeName is the reserved name/alias used to represent the
 	// OCI runtime being shipped with the docker daemon package.
 	StockRuntimeName = "runc"
+
+	// minAPIVersion represents Minimum REST API version supported
+	minAPIVersion = "1.12"
 )
 
 // BridgeConfig stores all the parameters for both the bridge driver and the default bridge network.

--- a/daemon/config/config_windows.go
+++ b/daemon/config/config_windows.go
@@ -13,6 +13,13 @@ const (
 	// default value. On Windows keep this empty so the value is auto-detected
 	// based on other options.
 	StockRuntimeName = ""
+
+	// minAPIVersion represents Minimum REST API version supported
+	// Technically the first daemon API version released on Windows is v1.25 in
+	// engine version 1.13. However, some clients are explicitly using downlevel
+	// APIs (e.g. docker-compose v2.1 file format) and that is just too restrictive.
+	// Hence also allowing 1.24 on Windows.
+	minAPIVersion string = "1.24"
 )
 
 // BridgeConfig is meant to store all the parameters for both the bridge driver and the default bridge network. On

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -113,7 +113,7 @@ func (daemon *Daemon) SystemVersion(ctx context.Context) (types.Version, error) 
 				Details: map[string]string{
 					"GitCommit":     dockerversion.GitCommit,
 					"ApiVersion":    api.DefaultVersion,
-					"MinAPIVersion": api.MinVersion,
+					"MinAPIVersion": cfg.MinAPIVersion,
 					"GoVersion":     runtime.Version(),
 					"Os":            runtime.GOOS,
 					"Arch":          runtime.GOARCH,
@@ -128,7 +128,7 @@ func (daemon *Daemon) SystemVersion(ctx context.Context) (types.Version, error) 
 		Version:       dockerversion.Version,
 		GitCommit:     dockerversion.GitCommit,
 		APIVersion:    api.DefaultVersion,
-		MinAPIVersion: api.MinVersion,
+		MinAPIVersion: cfg.MinAPIVersion,
 		GoVersion:     runtime.Version(),
 		Os:            runtime.GOOS,
 		Arch:          runtime.GOARCH,

--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -46,6 +46,9 @@ export DOCKER_ALLOW_SCHEMA1_PUSH_DONOTUSE=1
 export DOCKER_GRAPHDRIVER=${DOCKER_GRAPHDRIVER:-vfs}
 export DOCKER_USERLANDPROXY=${DOCKER_USERLANDPROXY:-true}
 
+# Allow testing old API versions
+export DOCKER_MIN_API_VERSION=1.12
+
 # example usage: DOCKER_STORAGE_OPTS="dm.basesize=20G,dm.loopdatasize=200G"
 storage_params=""
 if [ -n "$DOCKER_STORAGE_OPTS" ]; then


### PR DESCRIPTION
- depends on https://github.com/moby/moby/pull/46891

### daemon: raise default minimum API version to v1.24

The daemon currently provides support for API versions all the way back to v1.12, which is the version of the API that shipped with docker 1.0. On Windows, the minimum supported version is v1.24.

Such old versions of the client are rare, and supporting older API versions has accumulated significant amounts of code to remain backward-compatible (which is largely untested, and a "best-effort" at most).

This patch updates the minimum API version to v1.24, which is the fallback API version used when API-version negotiation fails. The intent is to start deprecating older API versions, but no code is removed yet as part of this patch, and a DOCKER_MIN_API_VERSION environment variable is added, which allows overriding the minimum version (to allow restoring the behavior from before this patch).

```bash
docker version
Client:
 Version:           24.0.2
 API version:       1.43
 Go version:        go1.20.4
 Git commit:        cb74dfc
 Built:             Thu May 25 21:50:49 2023
 OS/Arch:           linux/arm64
 Context:           default

Server:
 Engine:
  Version:          dev
  API version:      1.44 (minimum version 1.24)
  Go version:       go1.21.3
  Git commit:       0322a29b9ef8806aaa4b45dc9d9a2ebcf0244bf4
  Built:            Mon Dec  4 15:22:17 2023
  OS/Arch:          linux/arm64
  Experimental:     false
 containerd:
  Version:          v1.7.9
  GitCommit:        4f03e100cb967922bec7459a78d16ccbac9bb81d
 runc:
  Version:          1.1.10
  GitCommit:        v1.1.10-0-g18a0cb0
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```

Trying to use an older version of the API produces an error:

```bash
DOCKER_API_VERSION=1.23 docker version
Client:
 Version:           24.0.2
 API version:       1.23 (downgraded from 1.43)
 Go version:        go1.20.4
 Git commit:        cb74dfc
 Built:             Thu May 25 21:50:49 2023
 OS/Arch:           linux/arm64
 Context:           default
Error response from daemon: client version 1.23 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version
```

To restore the previous minimum, users can start the daemon with the DOCKER_MIN_API_VERSION environment variable set:

    DOCKER_MIN_API_VERSION=1.12 dockerd

API 1.12 is the oldest supported API version on Linux;

```bash
docker version
Client:
 Version:           24.0.2
 API version:       1.43
 Go version:        go1.20.4
 Git commit:        cb74dfc
 Built:             Thu May 25 21:50:49 2023
 OS/Arch:           linux/arm64
 Context:           default

Server:
 Engine:
  Version:          dev
  API version:      1.44 (minimum version 1.12)
  Go version:       go1.21.3
  Git commit:       0322a29b9ef8806aaa4b45dc9d9a2ebcf0244bf4
  Built:            Mon Dec  4 15:22:17 2023
  OS/Arch:          linux/arm64
  Experimental:     false
 containerd:
  Version:          v1.7.9
  GitCommit:        4f03e100cb967922bec7459a78d16ccbac9bb81d
 runc:
  Version:          1.1.10
  GitCommit:        v1.1.10-0-g18a0cb0
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```

When using the `DOCKER_MIN_API_VERSION` with a version of the API that is not supported, an error is produced when starting the daemon;

```bash
DOCKER_MIN_API_VERSION=1.11 dockerd --validate
invalid DOCKER_MIN_API_VERSION: minimum supported API version is 1.12: 1.11

DOCKER_MIN_API_VERSION=1.45 dockerd --validate
invalid DOCKER_MIN_API_VERSION: maximum supported API version is 1.44: 1.45
```

Specifying a malformed API version also produces the same error;

```bash
DOCKER_MIN_API_VERSION=hello dockerd --validate
invalid DOCKER_MIN_API_VERSION: minimum supported API version is 1.12: hello
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

