### PR TITLE
client: fix race condition in API version negotiation

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -49,6 +49,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/docker/docker/api"
@@ -125,6 +126,9 @@ type Client struct {
 
 	// negotiated indicates that API version negotiation took place
 	negotiated bool
+
+	// negotiationMutex locks negotiateVersion and negotiated.
+	negotiationMutex sync.Mutex
 
 	tp trace.TracerProvider
 
@@ -259,7 +263,10 @@ func (cli *Client) Close() error {
 // be negotiated when making the actual requests, and for which cases
 // we cannot do the negotiation lazily.
 func (cli *Client) checkVersion(ctx context.Context) {
-	if cli.negotiateVersion && !cli.negotiated {
+	cli.negotiationMutex.Lock()
+	shouldNegotiate := cli.negotiateVersion && !cli.negotiated
+	cli.negotiationMutex.Unlock()
+	if shouldNegotiate {
 		cli.NegotiateAPIVersion(ctx)
 	}
 }
@@ -327,6 +334,9 @@ func (cli *Client) NegotiateAPIVersionPing(pingResponse types.Ping) {
 // negotiateAPIVersionPing queries the API and updates the version to match the
 // API version from the ping response.
 func (cli *Client) negotiateAPIVersionPing(pingResponse types.Ping) {
+	cli.negotiationMutex.Lock()
+	defer cli.negotiationMutex.Unlock()
+
 	// default to the latest version before versioning headers existed
 	if pingResponse.APIVersion == "" {
 		pingResponse.APIVersion = "1.24"


### PR DESCRIPTION
Especially when using Docker client in Go applications, concurrent access is possible.
If for example multiple calls to `ImageBuild` are made and the client was created with the option for version negotiation, this will lead to race conditions when setting certain fields.
Although, this does not seem to be critical, running tests with race detection will fail due to this issue.

This PR adds a mutex to properly synchronize access to `Client.negotiateVersion` and `Client.negotiated`.
Multiple negotiations may still be possible but this doesn't seem to bother anyone, so only minimal changes were made to avoid the concurrent access to fields in `Client`.

**- What I did**

Synchronized access to multiple fields in `client.Client` that are involved in API version negotiation.

**- How I did it**

Added a mutex to ensure thread safety when negotiating the API version.

**- How to verify it**

Also added a new test, `TestClient_NegotiateAPIVersion_race`, to verify correct concurrent behavior. This test can only confirm thread-safety when race detection is enabled.

**- Description for the changelog**

Added proper thread safety for API version negotiation in `client.Client`.

