### PR TITLE
integration / integration-cil: cleanup and fix API versions used in tests

### DIFF
--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -413,8 +413,7 @@ func (s *DockerAPISuite) TestBuildAddRemoteNoDecompress(c *testing.T) {
 }
 
 func (s *DockerAPISuite) TestBuildChownOnCopy(c *testing.T) {
-	// new feature added in 1.31 - https://github.com/moby/moby/pull/34263
-	testRequires(c, DaemonIsLinux, MinimumAPIVersion("1.31"))
+	testRequires(c, DaemonIsLinux)
 	dockerfile := `FROM busybox
 		RUN echo 'test1:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 		RUN echo 'test1:x:1001:' >> /etc/group

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
 	dconfig "github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/errdefs"
@@ -633,30 +632,20 @@ func (s *DockerAPISuite) TestContainerAPIVerifyHeader(c *testing.T) {
 	// Try with no content-type
 	res, body, err := create("")
 	assert.NilError(c, err)
-	// todo: we need to figure out a better way to compare between dockerd versions
-	// comparing between daemon API version is not precise.
-	if versions.GreaterThanOrEqualTo(testEnv.DaemonAPIVersion(), "1.32") {
-		assert.Equal(c, res.StatusCode, http.StatusBadRequest)
-	} else {
-		assert.Assert(c, res.StatusCode != http.StatusOK)
-	}
-	body.Close()
+	assert.Equal(c, res.StatusCode, http.StatusBadRequest)
+	_ = body.Close()
 
 	// Try with wrong content-type
 	res, body, err = create("application/xml")
 	assert.NilError(c, err)
-	if versions.GreaterThanOrEqualTo(testEnv.DaemonAPIVersion(), "1.32") {
-		assert.Equal(c, res.StatusCode, http.StatusBadRequest)
-	} else {
-		assert.Assert(c, res.StatusCode != http.StatusOK)
-	}
-	body.Close()
+	assert.Equal(c, res.StatusCode, http.StatusBadRequest)
+	_ = body.Close()
 
 	// now application/json
 	res, body, err = create("application/json")
 	assert.NilError(c, err)
 	assert.Equal(c, res.StatusCode, http.StatusCreated)
-	body.Close()
+	_ = body.Close()
 }
 
 // Issue 14230. daemon should return 500 for invalid port syntax
@@ -675,11 +664,7 @@ func (s *DockerAPISuite) TestContainerAPIInvalidPortSyntax(c *testing.T) {
 
 	res, body, err := request.Post(testutil.GetContext(c), "/containers/create", request.RawString(config), request.JSON)
 	assert.NilError(c, err)
-	if versions.GreaterThanOrEqualTo(testEnv.DaemonAPIVersion(), "1.32") {
-		assert.Equal(c, res.StatusCode, http.StatusBadRequest)
-	} else {
-		assert.Assert(c, res.StatusCode != http.StatusOK)
-	}
+	assert.Equal(c, res.StatusCode, http.StatusBadRequest)
 
 	b, err := request.ReadBody(body)
 	assert.NilError(c, err)
@@ -699,11 +684,7 @@ func (s *DockerAPISuite) TestContainerAPIRestartPolicyInvalidPolicyName(c *testi
 
 	res, body, err := request.Post(testutil.GetContext(c), "/containers/create", request.RawString(config), request.JSON)
 	assert.NilError(c, err)
-	if versions.GreaterThanOrEqualTo(testEnv.DaemonAPIVersion(), "1.32") {
-		assert.Equal(c, res.StatusCode, http.StatusBadRequest)
-	} else {
-		assert.Assert(c, res.StatusCode != http.StatusOK)
-	}
+	assert.Equal(c, res.StatusCode, http.StatusBadRequest)
 
 	b, err := request.ReadBody(body)
 	assert.NilError(c, err)
@@ -723,11 +704,7 @@ func (s *DockerAPISuite) TestContainerAPIRestartPolicyRetryMismatch(c *testing.T
 
 	res, body, err := request.Post(testutil.GetContext(c), "/containers/create", request.RawString(config), request.JSON)
 	assert.NilError(c, err)
-	if versions.GreaterThanOrEqualTo(testEnv.DaemonAPIVersion(), "1.32") {
-		assert.Equal(c, res.StatusCode, http.StatusBadRequest)
-	} else {
-		assert.Assert(c, res.StatusCode != http.StatusOK)
-	}
+	assert.Equal(c, res.StatusCode, http.StatusBadRequest)
 
 	b, err := request.ReadBody(body)
 	assert.NilError(c, err)
@@ -747,11 +724,7 @@ func (s *DockerAPISuite) TestContainerAPIRestartPolicyNegativeRetryCount(c *test
 
 	res, body, err := request.Post(testutil.GetContext(c), "/containers/create", request.RawString(config), request.JSON)
 	assert.NilError(c, err)
-	if versions.GreaterThanOrEqualTo(testEnv.DaemonAPIVersion(), "1.32") {
-		assert.Equal(c, res.StatusCode, http.StatusBadRequest)
-	} else {
-		assert.Assert(c, res.StatusCode != http.StatusOK)
-	}
+	assert.Equal(c, res.StatusCode, http.StatusBadRequest)
 
 	b, err := request.ReadBody(body)
 	assert.NilError(c, err)
@@ -836,11 +809,7 @@ func (s *DockerAPISuite) TestCreateWithTooLowMemoryLimit(c *testing.T) {
 	b, err2 := request.ReadBody(body)
 	assert.Assert(c, err2 == nil)
 
-	if versions.GreaterThanOrEqualTo(testEnv.DaemonAPIVersion(), "1.32") {
-		assert.Equal(c, res.StatusCode, http.StatusBadRequest)
-	} else {
-		assert.Assert(c, res.StatusCode != http.StatusOK)
-	}
+	assert.Equal(c, res.StatusCode, http.StatusBadRequest)
 	assert.Assert(c, strings.Contains(string(b), "Minimum memory limit allowed is 6MB"))
 }
 
@@ -1030,11 +999,7 @@ func (s *DockerAPISuite) TestContainerAPICopyResourcePathEmptyPre124(c *testing.
 
 	res, body, err := request.Post(testutil.GetContext(c), "/v1.23/containers/"+name+"/copy", request.JSONBody(postData))
 	assert.NilError(c, err)
-	if versions.GreaterThanOrEqualTo(testEnv.DaemonAPIVersion(), "1.32") {
-		assert.Equal(c, res.StatusCode, http.StatusBadRequest)
-	} else {
-		assert.Assert(c, res.StatusCode != http.StatusOK)
-	}
+	assert.Equal(c, res.StatusCode, http.StatusBadRequest)
 	b, err := request.ReadBody(body)
 	assert.NilError(c, err)
 	assert.Assert(c, is.Regexp("^Path cannot be empty\n$", string(b)))
@@ -1051,11 +1016,7 @@ func (s *DockerAPISuite) TestContainerAPICopyResourcePathNotFoundPre124(c *testi
 
 	res, body, err := request.Post(testutil.GetContext(c), "/v1.23/containers/"+name+"/copy", request.JSONBody(postData))
 	assert.NilError(c, err)
-	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
-		assert.Equal(c, res.StatusCode, http.StatusInternalServerError)
-	} else {
-		assert.Equal(c, res.StatusCode, http.StatusNotFound)
-	}
+	assert.Equal(c, res.StatusCode, http.StatusNotFound)
 	b, err := request.ReadBody(body)
 	assert.NilError(c, err)
 	assert.Assert(c, is.Regexp("^Could not find the file /notexist in container "+name+"\n$", string(b)))
@@ -1487,11 +1448,7 @@ func (s *DockerAPISuite) TestPostContainersCreateMemorySwappinessHostConfigOmitt
 	containerJSON, err := apiClient.ContainerInspect(testutil.GetContext(c), ctr.ID)
 	assert.NilError(c, err)
 
-	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.31") {
-		assert.Equal(c, *containerJSON.HostConfig.MemorySwappiness, int64(-1))
-	} else {
-		assert.Assert(c, containerJSON.HostConfig.MemorySwappiness == nil)
-	}
+	assert.Assert(c, containerJSON.HostConfig.MemorySwappiness == nil)
 }
 
 // check validation is done daemon side and not only in cli
@@ -1954,13 +1911,8 @@ func (s *DockerAPISuite) TestContainersAPICreateMountsCreate(c *testing.T) {
 	}
 
 	var selinuxSharedLabel string
-	// this test label was added after a bug fix in 1.32, thus add requirements min API >= 1.32
-	// for the sake of making test pass in earlier versions
-	// bug fixed in https://github.com/moby/moby/pull/34684
-	if !versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
-		if runtime.GOOS == "linux" {
-			selinuxSharedLabel = "z"
-		}
+	if runtime.GOOS == "linux" {
+		selinuxSharedLabel = "z"
 	}
 
 	cases := []testCase{

--- a/integration-cli/docker_api_exec_resize_test.go
+++ b/integration-cli/docker_api_exec_resize_test.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/request"
@@ -26,11 +25,7 @@ func (s *DockerAPISuite) TestExecResizeAPIHeightWidthNoInt(c *testing.T) {
 	endpoint := "/exec/" + cleanedContainerID + "/resize?h=foo&w=bar"
 	res, _, err := request.Post(testutil.GetContext(c), endpoint)
 	assert.NilError(c, err)
-	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
-		assert.Equal(c, res.StatusCode, http.StatusInternalServerError)
-	} else {
-		assert.Equal(c, res.StatusCode, http.StatusBadRequest)
-	}
+	assert.Equal(c, res.StatusCode, http.StatusBadRequest)
 }
 
 // Part of #14845

--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/cli"
@@ -31,11 +30,7 @@ func (s *DockerAPISuite) TestExecAPICreateNoCmd(c *testing.T) {
 
 	res, body, err := request.Post(testutil.GetContext(c), fmt.Sprintf("/containers/%s/exec", name), request.JSONBody(map[string]interface{}{"Cmd": nil}))
 	assert.NilError(c, err)
-	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
-		assert.Equal(c, res.StatusCode, http.StatusInternalServerError)
-	} else {
-		assert.Equal(c, res.StatusCode, http.StatusBadRequest)
-	}
+	assert.Equal(c, res.StatusCode, http.StatusBadRequest)
 	b, err := request.ReadBody(body)
 	assert.NilError(c, err)
 	assert.Assert(c, strings.Contains(getErrorMessage(c, b), "No exec command specified"), "Expected message when creating exec command with no Cmd specified")
@@ -52,11 +47,7 @@ func (s *DockerAPISuite) TestExecAPICreateNoValidContentType(c *testing.T) {
 
 	res, body, err := request.Post(testutil.GetContext(c), fmt.Sprintf("/containers/%s/exec", name), request.RawContent(io.NopCloser(jsonData)), request.ContentType("test/plain"))
 	assert.NilError(c, err)
-	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
-		assert.Equal(c, res.StatusCode, http.StatusInternalServerError)
-	} else {
-		assert.Equal(c, res.StatusCode, http.StatusBadRequest)
-	}
+	assert.Equal(c, res.StatusCode, http.StatusBadRequest)
 	b, err := request.ReadBody(body)
 	assert.NilError(c, err)
 	assert.Assert(c, is.Contains(getErrorMessage(c, b), "unsupported Content-Type header (test/plain): must be 'application/json'"))
@@ -198,11 +189,7 @@ func (s *DockerAPISuite) TestExecAPIStartInvalidCommand(c *testing.T) {
 	cli.DockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
 
 	id := createExecCmd(c, name, "invalid")
-	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
-		startExec(c, id, http.StatusNotFound)
-	} else {
-		startExec(c, id, http.StatusBadRequest)
-	}
+	startExec(c, id, http.StatusBadRequest)
 	ctx := testutil.GetContext(c)
 	waitForExec(ctx, c, id)
 

--- a/integration-cli/docker_api_logs_test.go
+++ b/integration-cli/docker_api_logs_test.go
@@ -163,7 +163,6 @@ func (s *DockerAPISuite) TestLogsAPIUntilFutureFollow(c *testing.T) {
 }
 
 func (s *DockerAPISuite) TestLogsAPIUntil(c *testing.T) {
-	testRequires(c, MinimumAPIVersion("1.34"))
 	const name = "logsuntil"
 	cli.DockerCmd(c, "run", "--name", name, "busybox", "/bin/sh", "-c", "for i in $(seq 1 3); do echo log$i; sleep 1; done")
 

--- a/integration-cli/docker_api_network_test.go
+++ b/integration-cli/docker_api_network_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/request"
@@ -162,11 +161,7 @@ func (s *DockerAPISuite) TestAPINetworkIPAMMultipleBridgeNetworks(c *testing.T) 
 			IPAM:   ipam1,
 		},
 	}
-	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
-		createNetwork(c, config1, http.StatusInternalServerError)
-	} else {
-		createNetwork(c, config1, http.StatusForbidden)
-	}
+	createNetwork(c, config1, http.StatusForbidden)
 	assert.Assert(c, !isNetworkAvailable(c, "test1"))
 
 	ipam2 := &network.IPAM{
@@ -213,15 +208,6 @@ func createDeletePredefinedNetwork(c *testing.T, name string) {
 	// Create pre-defined network
 	config := types.NetworkCreateRequest{Name: name}
 	expectedStatus := http.StatusForbidden
-	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.34") {
-		// In the early test code it uses bool value to represent
-		// whether createNetwork() is expected to fail or not.
-		// Therefore, we use negation to handle the same logic after
-		// the code was changed in https://github.com/moby/moby/pull/35030
-		// -http.StatusCreated will also be checked as NOT equal to
-		// http.StatusCreated in createNetwork() function.
-		expectedStatus = -http.StatusCreated
-	}
 	createNetwork(c, config, expectedStatus)
 	deleteNetwork(c, name, false)
 }

--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/request"
@@ -71,11 +70,7 @@ func (s *DockerAPISuite) TestAPIClientVersionOldNotSupported(c *testing.T) {
 func (s *DockerAPISuite) TestAPIErrorJSON(c *testing.T) {
 	httpResp, body, err := request.Post(testutil.GetContext(c), "/containers/create", request.JSONBody(struct{}{}))
 	assert.NilError(c, err)
-	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
-		assert.Equal(c, httpResp.StatusCode, http.StatusInternalServerError)
-	} else {
-		assert.Equal(c, httpResp.StatusCode, http.StatusBadRequest)
-	}
+	assert.Equal(c, httpResp.StatusCode, http.StatusBadRequest)
 	assert.Assert(c, strings.Contains(httpResp.Header.Get("Content-Type"), "application/json"))
 	b, err := request.ReadBody(body)
 	assert.NilError(c, err)
@@ -88,11 +83,7 @@ func (s *DockerAPISuite) TestAPIErrorPlainText(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 	httpResp, body, err := request.Post(testutil.GetContext(c), "/v1.23/containers/create", request.JSONBody(struct{}{}))
 	assert.NilError(c, err)
-	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
-		assert.Equal(c, httpResp.StatusCode, http.StatusInternalServerError)
-	} else {
-		assert.Equal(c, httpResp.StatusCode, http.StatusBadRequest)
-	}
+	assert.Equal(c, httpResp.StatusCode, http.StatusBadRequest)
 	assert.Assert(c, strings.Contains(httpResp.Header.Get("Content-Type"), "text/plain"))
 	b, err := request.ReadBody(body)
 	assert.NilError(c, err)

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration-cli/cli"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/skip"
@@ -136,9 +135,7 @@ func (s *DockerCLICommitSuite) TestCommitChange(c *testing.T) {
 	imageID = strings.TrimSpace(imageID)
 
 	expectedEnv := "[DEBUG=true test=1 PATH=/foo]"
-	// bug fixed in 1.36, add min APi >= 1.36 requirement
-	// PR record https://github.com/moby/moby/pull/35582
-	if versions.GreaterThan(testEnv.DaemonAPIVersion(), "1.35") && testEnv.DaemonInfo.OSType != "windows" {
+	if testEnv.DaemonInfo.OSType != "windows" {
 		// The ordering here is due to `PATH` being overridden from the container's
 		// ENV.  On windows, the container doesn't have a `PATH` ENV variable so
 		// the ordering is the same as the cli.

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/pkg/stringid"
@@ -223,13 +222,9 @@ func (s *DockerCLIPsSuite) TestPsListContainersFilterStatus(c *testing.T) {
 	assert.Equal(c, RemoveOutputForExistingElements(containerOut, existingContainers), secondID)
 
 	result := cli.Docker(cli.Args("ps", "-a", "-q", "--filter=status=rubbish"), cli.WithTimeout(time.Second*60))
-	err := "invalid filter 'status=rubbish'"
-	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
-		err = "Unrecognised filter value for status: rubbish"
-	}
 	result.Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err:      err,
+		Err:      "invalid filter 'status=rubbish'",
 	})
 	// Windows doesn't support pausing of containers
 	if testEnv.DaemonInfo.OSType != "windows" {
@@ -858,7 +853,7 @@ func (s *DockerCLIPsSuite) TestPsListContainersFilterPorts(c *testing.T) {
 }
 
 func (s *DockerCLIPsSuite) TestPsNotShowLinknamesOfDeletedContainer(c *testing.T) {
-	testRequires(c, DaemonIsLinux, MinimumAPIVersion("1.31"))
+	testRequires(c, DaemonIsLinux)
 	existingContainers := ExistingContainerNames(c)
 
 	cli.DockerCmd(c, "create", "--name=aaa", "busybox", "top")

--- a/integration-cli/docker_deprecated_api_v124_test.go
+++ b/integration-cli/docker_deprecated_api_v124_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/request"
@@ -29,14 +28,11 @@ func (s *DockerAPISuite) TestDeprecatedContainerAPIStartHostConfig(c *testing.T)
 	res, body, err := request.Post(testutil.GetContext(c), "/containers/"+name+"/start", request.JSONBody(config))
 	assert.NilError(c, err)
 	assert.Equal(c, res.StatusCode, http.StatusBadRequest)
-	if versions.GreaterThanOrEqualTo(testEnv.DaemonAPIVersion(), "1.32") {
-		// assertions below won't work before 1.32
-		buf, err := request.ReadBody(body)
-		assert.NilError(c, err)
+	buf, err := request.ReadBody(body)
+	assert.NilError(c, err)
 
-		assert.Equal(c, res.StatusCode, http.StatusBadRequest)
-		assert.Assert(c, strings.Contains(string(buf), "was deprecated since API v1.22"))
-	}
+	assert.Equal(c, res.StatusCode, http.StatusBadRequest)
+	assert.Assert(c, strings.Contains(string(buf), "was deprecated since API v1.22"))
 }
 
 func (s *DockerAPISuite) TestDeprecatedContainerAPIStartVolumeBinds(c *testing.T) {
@@ -94,12 +90,7 @@ func (s *DockerAPISuite) TestDeprecatedContainerAPIStartDupVolumeBinds(c *testin
 
 	buf, err := request.ReadBody(body)
 	assert.NilError(c, err)
-
-	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
-		assert.Equal(c, res.StatusCode, http.StatusInternalServerError)
-	} else {
-		assert.Equal(c, res.StatusCode, http.StatusBadRequest)
-	}
+	assert.Equal(c, res.StatusCode, http.StatusBadRequest)
 	assert.Assert(c, strings.Contains(string(buf), "Duplicate mount point"), "Expected failure due to duplicate bind mounts to same path, instead got: %q with error: %v", string(buf), err)
 }
 
@@ -171,11 +162,7 @@ func (s *DockerAPISuite) TestDeprecatedStartWithTooLowMemoryLimit(c *testing.T) 
 	assert.NilError(c, err)
 	b, err := request.ReadBody(body)
 	assert.NilError(c, err)
-	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
-		assert.Equal(c, res.StatusCode, http.StatusInternalServerError)
-	} else {
-		assert.Equal(c, res.StatusCode, http.StatusBadRequest)
-	}
+	assert.Equal(c, res.StatusCode, http.StatusBadRequest)
 	assert.Assert(c, is.Contains(string(b), "Minimum memory limit allowed is 6MB"))
 }
 

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containerd/containerd/plugin"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/requirement"
@@ -26,12 +25,6 @@ func DaemonIsWindows() bool {
 
 func DaemonIsLinux() bool {
 	return testEnv.DaemonInfo.OSType == "linux"
-}
-
-func MinimumAPIVersion(version string) func() bool {
-	return func() bool {
-		return versions.GreaterThanOrEqualTo(testEnv.DaemonAPIVersion(), version)
-	}
 }
 
 func OnlyDefaultNetworks(ctx context.Context) bool {

--- a/integration/build/build_session_test.go
+++ b/integration/build/build_session_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/versions"
 	dclient "github.com/docker/docker/client"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/fakecontext"
@@ -25,7 +24,6 @@ import (
 func TestBuildWithSession(t *testing.T) {
 	t.Skip("TODO: BuildKit")
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.39"), "experimental in older versions")
 
 	ctx := testutil.StartSpan(baseContext, t)
 

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/testutil"
@@ -189,7 +188,6 @@ func TestBuildMultiStageCopy(t *testing.T) {
 }
 
 func TestBuildMultiStageParentConfig(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.35"), "broken in earlier versions")
 	dockerfile := `
 		FROM busybox AS stage0
 		ENV WHO=parent
@@ -233,7 +231,6 @@ func TestBuildMultiStageParentConfig(t *testing.T) {
 
 // Test cases in #36996
 func TestBuildLabelWithTargets(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.38"), "test added after 1.38")
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	imgName := strings.ToLower(t.Name() + "-a")
 	testLabels := map[string]string{
@@ -340,7 +337,6 @@ func TestBuildWithEmptyLayers(t *testing.T) {
 // multiple subsequent stages
 // #35652
 func TestBuildMultiStageOnBuild(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.33"), "broken in earlier versions")
 	ctx := setupTest(t)
 
 	// test both metadata and layer based commands as they may be implemented differently
@@ -386,7 +382,6 @@ RUN cat somefile`
 
 // #35403 #36122
 func TestBuildUncleanTarFilenames(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.37"), "broken in earlier versions")
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 
 	ctx := setupTest(t)
@@ -446,7 +441,6 @@ COPY bar /`
 // docker/for-linux#135
 // #35641
 func TestBuildMultiStageLayerLeak(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.37"), "broken in earlier versions")
 	ctx := setupTest(t)
 
 	// all commands need to match until COPY
@@ -572,7 +566,6 @@ COPY --from=intermediate C:\\stuff C:\\stuff
 }
 
 func TestBuildWithEmptyDockerfile(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"), "broken in earlier versions")
 	ctx := setupTest(t)
 
 	tests := []struct {
@@ -628,7 +621,6 @@ func TestBuildWithEmptyDockerfile(t *testing.T) {
 
 func TestBuildPreserveOwnership(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"), "broken in earlier versions")
 
 	ctx := testutil.StartSpan(baseContext, t)
 
@@ -667,8 +659,6 @@ func TestBuildPreserveOwnership(t *testing.T) {
 }
 
 func TestBuildPlatformInvalid(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"), "experimental in older versions")
-
 	ctx := setupTest(t)
 
 	dockerfile := `FROM busybox

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -421,12 +421,7 @@ func TestCreateWithInvalidHealthcheckParams(t *testing.T) {
 
 			resp, err := apiClient.ContainerCreate(ctx, &cfg, &container.HostConfig{}, nil, nil, "")
 			assert.Check(t, is.Equal(len(resp.Warnings), 0))
-
-			if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
-				assert.Check(t, errdefs.IsSystem(err))
-			} else {
-				assert.Check(t, errdefs.IsInvalidParameter(err))
-			}
+			assert.Check(t, errdefs.IsInvalidParameter(err))
 			assert.ErrorContains(t, err, tc.expectedErr)
 		})
 	}

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/strslice"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration/internal/container"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -18,7 +17,6 @@ import (
 // TestExecWithCloseStdin adds case for moby#37870 issue.
 func TestExecWithCloseStdin(t *testing.T) {
 	skip.If(t, testEnv.RuntimeIsWindowsContainerd(), "FIXME. Hang on Windows + containerd combination")
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.39"), "broken in earlier versions")
 	ctx := setupTest(t)
 
 	apiClient := testEnv.APIClient()
@@ -84,7 +82,6 @@ func TestExecWithCloseStdin(t *testing.T) {
 }
 
 func TestExec(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.35"), "broken in earlier versions")
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()
 
@@ -125,7 +122,6 @@ func TestExec(t *testing.T) {
 }
 
 func TestExecUser(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.39"), "broken in earlier versions")
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME. Probably needs to wait for container to be in running state.")
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()
@@ -142,7 +138,6 @@ func TestExecUser(t *testing.T) {
 // also has a user set.
 // (regression test for https://github.com/moby/moby/issues/46712)
 func TestExecWithGroupAdd(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.39"), "broken in earlier versions")
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME. Probably needs to wait for container to be in running state.")
 
 	ctx := setupTest(t)

--- a/integration/container/ipcmode_linux_test.go
+++ b/integration/container/ipcmode_linux_test.go
@@ -299,7 +299,6 @@ func TestDaemonIpcModeShareableFromConfig(t *testing.T) {
 // TestIpcModeOlderClient checks that older client gets shareable IPC mode
 // by default, even when the daemon default is private.
 func TestIpcModeOlderClient(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"), "requires a daemon with DefaultIpcMode: private")
 	apiClient := testEnv.APIClient()
 	skip.If(t, versions.LessThan(apiClient.ClientVersion(), "1.40"), "requires client API >= 1.40")
 

--- a/integration/container/kill_test.go
+++ b/integration/container/kill_test.go
@@ -147,7 +147,7 @@ func TestKillDifferentUserContainer(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "User containers (container.Config.User) are not yet supported on %q platform", testEnv.DaemonInfo.OSType)
 
 	ctx := setupTest(t)
-	apiClient := request.NewAPIClient(t, client.WithVersion("1.19"))
+	apiClient := request.NewAPIClient(t)
 
 	id := container.Run(ctx, t, apiClient, func(c *container.TestContainerConfig) {
 		c.Config.User = "daemon"

--- a/integration/container/mounts_linux_test.go
+++ b/integration/container/mounts_linux_test.go
@@ -216,7 +216,6 @@ func TestMountDaemonRoot(t *testing.T) {
 
 func TestContainerBindMountNonRecursive(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon)
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"), "BindOptions.NonRecursive requires API v1.40")
 	skip.If(t, testEnv.IsRootless, "cannot be tested because RootlessKit executes the daemon in private mount namespace (https://github.com/rootless-containers/rootlesskit/issues/97)")
 
 	ctx := setupTest(t)

--- a/integration/container/pause_test.go
+++ b/integration/container/pause_test.go
@@ -10,7 +10,6 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
@@ -63,7 +62,6 @@ func TestPauseFailsOnWindowsServerContainers(t *testing.T) {
 
 func TestPauseStopPausedContainer(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.31"), "broken in earlier versions")
 	skip.If(t, testEnv.DaemonInfo.CgroupDriver == "none")
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()

--- a/integration/container/rename_test.go
+++ b/integration/container/rename_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/pkg/stringid"
 	"gotest.tools/v3/assert"
@@ -21,7 +20,6 @@ import (
 // and then deleting and recreating the source container linked to the new target.
 // This checks that "rename" updates source container correctly and doesn't set it to null.
 func TestRenameLinkedContainer(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.32"), "broken in earlier versions")
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()

--- a/integration/container/resize_test.go
+++ b/integration/container/resize_test.go
@@ -5,13 +5,11 @@ import (
 	"testing"
 
 	containertypes "github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/container"
 	req "github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
-	"gotest.tools/v3/skip"
 )
 
 func TestResize(t *testing.T) {
@@ -34,7 +32,6 @@ func TestResize(t *testing.T) {
 	})
 
 	t.Run("invalid size", func(t *testing.T) {
-		skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.32"), "broken in earlier versions")
 		cID := container.Run(ctx, t, apiClient)
 
 		// Manually creating a request here, as the APIClient would invalidate

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -26,10 +26,6 @@ import (
 )
 
 func TestNISDomainname(t *testing.T) {
-	// Older versions of the daemon would concatenate hostname and domainname,
-	// so hostname "foobar" and domainname "baz.cyphar.com" would produce
-	// `foobar.baz.cyphar.com` as hostname.
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"), "skip test from new feature")
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 
 	// Rootless supports custom Hostname but doesn't support custom Domainname

--- a/integration/image/commit_test.go
+++ b/integration/image/commit_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	containertypes "github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
@@ -15,7 +14,6 @@ import (
 )
 
 func TestCommitInheritsEnv(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.36"), "broken in earlier versions")
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	ctx := setupTest(t)
 

--- a/integration/image/list_test.go
+++ b/integration/image/list_test.go
@@ -9,18 +9,15 @@ import (
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/testutil"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
-	"gotest.tools/v3/skip"
 )
 
 // Regression : #38171
 func TestImagesFilterMultiReference(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"), "broken in earlier versions")
 	ctx := setupTest(t)
 
 	client := testEnv.APIClient()

--- a/integration/image/pull_test.go
+++ b/integration/image/pull_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/testutil/registry"
 	"github.com/opencontainers/go-digest"
@@ -28,7 +27,6 @@ import (
 )
 
 func TestImagePullPlatformInvalid(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"), "experimental in older versions")
 	ctx := setupTest(t)
 
 	client := testEnv.APIClient()

--- a/integration/network/delete_test.go
+++ b/integration/network/delete_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/versions"
 	dclient "github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/network"
 	"gotest.tools/v3/assert"
@@ -61,7 +60,6 @@ func TestNetworkCreateDelete(t *testing.T) {
 // equal to another network's ID exists, the Network with the given
 // ID is removed, and not the network with the given name.
 func TestDockerNetworkDeletePreferID(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.34"), "broken in earlier versions")
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows",
 		"FIXME. Windows doesn't run DinD and uses networks shared between control daemon and daemon under test")
 

--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/network"
 	"github.com/docker/docker/integration/internal/swarm"
@@ -30,7 +29,6 @@ func delInterface(ctx context.Context, t *testing.T, ifName string) {
 func TestDaemonRestartWithLiveRestore(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, testEnv.IsRemoteDaemon)
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.38"), "skip test from new feature")
 	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
 	ctx := testutil.StartSpan(baseContext, t)
 
@@ -62,7 +60,6 @@ func TestDaemonDefaultNetworkPools(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	// Remove docker0 bridge and the start daemon defining the predefined address pools
 	skip.If(t, testEnv.IsRemoteDaemon)
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.38"), "skip test from new feature")
 	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
 	ctx := testutil.StartSpan(baseContext, t)
 
@@ -106,7 +103,6 @@ func TestDaemonDefaultNetworkPools(t *testing.T) {
 func TestDaemonRestartWithExistingNetwork(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, testEnv.IsRemoteDaemon)
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.38"), "skip test from new feature")
 	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
 	ctx := testutil.StartSpan(baseContext, t)
 
@@ -142,7 +138,6 @@ func TestDaemonRestartWithExistingNetwork(t *testing.T) {
 func TestDaemonRestartWithExistingNetworkWithDefaultPoolRange(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, testEnv.IsRemoteDaemon)
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.38"), "skip test from new feature")
 	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
 
 	ctx := testutil.StartSpan(baseContext, t)
@@ -196,7 +191,6 @@ func TestDaemonRestartWithExistingNetworkWithDefaultPoolRange(t *testing.T) {
 func TestDaemonWithBipAndDefaultNetworkPool(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, testEnv.IsRemoteDaemon)
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.38"), "skip test from new feature")
 	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
 
 	ctx := testutil.StartSpan(baseContext, t)
@@ -345,7 +339,6 @@ func noServices(ctx context.Context, client client.ServiceAPIClient) func(log po
 
 func TestServiceWithDataPathPortInit(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"), "DataPathPort was added in API v1.40")
 	skip.If(t, testEnv.IsRootless, "rootless mode doesn't support Swarm-mode")
 	ctx := setupTest(t)
 

--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/strslice"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/network"
@@ -330,11 +329,6 @@ func TestCreateServiceConfigFileMode(t *testing.T) {
 // confident won't be modified by the container runtime, and won't blow
 // anything up in the test environment
 func TestCreateServiceSysctls(t *testing.T) {
-	skip.If(
-		t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"),
-		"setting service sysctls is unsupported before api v1.40",
-	)
-
 	ctx := setupTest(t)
 
 	d := swarm.NewSwarm(ctx, t, testEnv)
@@ -410,11 +404,6 @@ func TestCreateServiceSysctls(t *testing.T) {
 // capabilities option with the correct value, we can assume that the capabilities has been
 // plumbed correctly.
 func TestCreateServiceCapabilities(t *testing.T) {
-	skip.If(
-		t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.41"),
-		"setting service capabilities is unsupported before api v1.41",
-	)
-
 	ctx := setupTest(t)
 
 	d := swarm.NewSwarm(ctx, t, testEnv)

--- a/integration/service/list_test.go
+++ b/integration/service/list_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration/internal/swarm"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -29,8 +28,6 @@ import (
 func TestServiceListWithStatuses(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon)
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
-	// statuses were added in API version 1.41
-	skip.If(t, versions.LessThan(testEnv.DaemonInfo.ServerVersion, "1.41"))
 
 	ctx := setupTest(t)
 

--- a/integration/service/update_test.go
+++ b/integration/service/update_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/network"
 	"github.com/docker/docker/integration/internal/swarm"
@@ -252,10 +251,6 @@ func TestServiceUpdateNetwork(t *testing.T) {
 
 // TestServiceUpdatePidsLimit tests creating and updating a service with PidsLimit
 func TestServiceUpdatePidsLimit(t *testing.T) {
-	skip.If(
-		t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.41"),
-		"setting pidslimit for services is not supported before api v1.41",
-	)
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 	tests := []struct {
 		name      string

--- a/integration/session/session_test.go
+++ b/integration/session/session_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/docker/docker/api/types/versions"
 	req "github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -13,7 +12,6 @@ import (
 
 func TestSessionCreate(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.39"), "experimental in older versions")
 
 	ctx := setupTest(t)
 	daemonHost := req.DaemonHost()
@@ -34,7 +32,6 @@ func TestSessionCreate(t *testing.T) {
 
 func TestSessionCreateWithBadUpgrade(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.39"), "experimental in older versions")
 
 	ctx := setupTest(t)
 	daemonHost := req.DaemonHost()

--- a/integration/system/event_test.go
+++ b/integration/system/event_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/strslice"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -28,7 +27,6 @@ import (
 )
 
 func TestEventsExecDie(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.36"), "broken in earlier versions")
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME. Suspect may need to wait until container is running before exec")
 	ctx := setupTest(t)
 	client := testEnv.APIClient()

--- a/integration/system/info_linux_test.go
+++ b/integration/system/info_linux_test.go
@@ -33,13 +33,15 @@ func TestInfoAPIVersioned(t *testing.T) {
 	ctx := testutil.StartSpan(baseContext, t)
 	// Windows only supports 1.25 or later
 
-	res, body, err := req.Get(ctx, "/v1.20/info")
+	res, body, err := req.Get(ctx, "/v1.24/info")
 	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual(res.StatusCode, http.StatusOK))
 
 	b, err := req.ReadBody(body)
 	assert.NilError(t, err)
 
+	// Verify the old response on API 1.24 and older before commit
+	// 6d98e344c7702a8a713cb9e02a19d83a79d3f930.
 	out := string(b)
 	assert.Check(t, is.Contains(out, "ExecutionDriver"))
 	assert.Check(t, is.Contains(out, "not supported"))

--- a/integration/system/ping_test.go
+++ b/integration/system/ping_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
 	"github.com/docker/docker/testutil/request"
@@ -19,7 +18,6 @@ import (
 )
 
 func TestPingCacheHeaders(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"), "skip test from new feature")
 	ctx := setupTest(t)
 
 	res, _, err := request.Get(ctx, "/_ping")
@@ -44,7 +42,6 @@ func TestPingGet(t *testing.T) {
 }
 
 func TestPingHead(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"), "skip test from new feature")
 	ctx := setupTest(t)
 
 	res, body, err := request.Head(ctx, "/_ping")


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/46887

### integration/container: TestKillDifferentUserContainer: adjust API version

- relates to https://github.com/moby/moby/pull/36259

TestKillDifferentUserContainer was migrated from integration-cli in
commit 0855922cd3cd1e9d846fd85ef968653ff8649a44. Before migration, it
was not using a specific API version, so we can assume "current"
API version.


### integration/container: TestInfoAPIVersioned: adjust API version

- relates to https://github.com/moby/moby/pull/25721
- relates to https://github.com/moby/moby/pull/27630

This test was using API version 1.20 to test old behavior, but the actual change
in behavior was API v1.25; see commit 6d98e344c7702a8a713cb9e02a19d83a79d3f930
and 63b5a372037081175ab4ea8f3c7a7bef2195ec0b.
This updates the test to use API v1.24 to test the old behavior.

### integration-cli: TestAPIClientVersionOldNotSupported: use daemon API version

Use the minimum API version as advertised by the test-daemon, instead of the
hard-coded API version from code.

### integration(-cli): remove skips for old daemon versions (<20.10)

- relates to https://github.com/moby/moby/pull/37003

This removes various skips that accounted for running the integration tests
against older versions of the daemon before 20.10 (API version v1.41). Those
versions are EOL, and we don't run tests against them.

This reverts most of e440831802a500b28ecf16c2627a294dc31dfeb9, and similar
PRs.


**- A picture of a cute animal (not mandatory but encouraged)**

