### PR TITLE
Dockerfile: update criu stage to Debian 12 (Bookworm)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,10 +46,11 @@ FROM base AS criu
 ADD --chmod=0644 https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_11/Release.key /etc/apt/trusted.gpg.d/criu.gpg.asc
 RUN --mount=type=cache,sharing=locked,id=moby-criu-aptlib,target=/var/lib/apt \
     --mount=type=cache,sharing=locked,id=moby-criu-aptcache,target=/var/cache/apt \
-        echo 'deb https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_11/ /' > /etc/apt/sources.list.d/criu.list \
+        echo 'deb https://download.opensuse.org/repositories/devel:/tools:/criu/Debian_12/ /' > /etc/apt/sources.list.d/criu.list \
         && apt-get update \
         && apt-get install -y --no-install-recommends criu \
-        && install -D /usr/sbin/criu /build/criu
+        && install -D /usr/sbin/criu /build/criu \
+        && /build/criu --version
 
 # registry
 FROM base AS registry-src


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/45789
- related: https://github.com/moby/moby/pull/45597



Follow-up to e72c4818c400efe0b0b942bfcbc244287cfdfbd3, which updated the Dockerfile to use Debian 12 "bookworm", but forgot to update the package repository to use for the CRIU packages. Note that the criu stage is currently not built by default (see d3d2823edfb0247fe3ee320414dc3c836e53a3b9), so to verify the stage, it needs to be built manually;

    docker build --target=criu .

This patch adds an extra `criu --version` to the build, so that it's verified to be "functional".


**- A picture of a cute animal (not mandatory but encouraged)**

