### PR TITLE
api/types: move Plugin-types and NetworkListConfig to api/types/backend

### DIFF
--- a/api/server/router/network/backend.go
+++ b/api/server/router/network/backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
 )
@@ -11,7 +12,7 @@ import (
 // Backend is all the methods that need to be implemented
 // to provide network specific functionality.
 type Backend interface {
-	GetNetworks(filters.Args, types.NetworkListConfig) ([]types.NetworkResource, error)
+	GetNetworks(filters.Args, backend.NetworkListConfig) ([]types.NetworkResource, error)
 	CreateNetwork(nc types.NetworkCreateRequest) (*types.NetworkCreateResponse, error)
 	ConnectContainerToNetwork(containerName, networkName string, endpointConfig *network.EndpointSettings) error
 	DisconnectContainerFromNetwork(containerName string, networkName string, force bool) error

--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/versions"
@@ -39,7 +40,7 @@ func (n *networkRouter) getNetworksList(ctx context.Context, w http.ResponseWrit
 
 	// Combine the network list returned by Docker daemon if it is not already
 	// returned by the cluster manager
-	localNetworks, err := n.backend.GetNetworks(filter, types.NetworkListConfig{Detailed: versions.LessThan(httputils.VersionFromContext(ctx), "1.28")})
+	localNetworks, err := n.backend.GetNetworks(filter, backend.NetworkListConfig{Detailed: versions.LessThan(httputils.VersionFromContext(ctx), "1.28")})
 	if err != nil {
 		return err
 	}
@@ -117,7 +118,7 @@ func (n *networkRouter) getNetwork(ctx context.Context, w http.ResponseWriter, r
 	if networkScope != "" {
 		filter.Add("scope", networkScope)
 	}
-	networks, _ := n.backend.GetNetworks(filter, types.NetworkListConfig{Detailed: true, Verbose: verbose})
+	networks, _ := n.backend.GetNetworks(filter, backend.NetworkListConfig{Detailed: true, Verbose: verbose})
 	for _, nw := range networks {
 		if nw.ID == term {
 			return httputils.WriteJSON(w, http.StatusOK, nw)
@@ -311,7 +312,7 @@ func (n *networkRouter) findUniqueNetwork(term string) (types.NetworkResource, e
 	listByPartialID := map[string]types.NetworkResource{}
 
 	filter := filters.NewArgs(filters.Arg("idOrName", term))
-	networks, _ := n.backend.GetNetworks(filter, types.NetworkListConfig{Detailed: true})
+	networks, _ := n.backend.GetNetworks(filter, backend.NetworkListConfig{Detailed: true})
 	for _, nw := range networks {
 		if nw.ID == term {
 			return nw, nil

--- a/api/server/router/plugin/backend.go
+++ b/api/server/router/plugin/backend.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/plugin"
@@ -14,11 +15,11 @@ import (
 
 // Backend for Plugin
 type Backend interface {
-	Disable(name string, config *types.PluginDisableConfig) error
-	Enable(name string, config *types.PluginEnableConfig) error
+	Disable(name string, config *backend.PluginDisableConfig) error
+	Enable(name string, config *backend.PluginEnableConfig) error
 	List(filters.Args) ([]types.Plugin, error)
 	Inspect(name string) (*types.Plugin, error)
-	Remove(name string, config *types.PluginRmConfig) error
+	Remove(name string, config *backend.PluginRmConfig) error
 	Set(name string, args []string) error
 	Privileges(ctx context.Context, ref reference.Named, metaHeaders http.Header, authConfig *registry.AuthConfig) (types.PluginPrivileges, error)
 	Pull(ctx context.Context, ref reference.Named, name string, metaHeaders http.Header, authConfig *registry.AuthConfig, privileges types.PluginPrivileges, outStream io.Writer, opts ...plugin.CreateOpt) error

--- a/api/server/router/plugin/plugin_routes.go
+++ b/api/server/router/plugin/plugin_routes.go
@@ -9,6 +9,7 @@ import (
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/pkg/ioutils"
@@ -207,7 +208,7 @@ func (pr *pluginRouter) enablePlugin(ctx context.Context, w http.ResponseWriter,
 	if err != nil {
 		return err
 	}
-	config := &types.PluginEnableConfig{Timeout: timeout}
+	config := &backend.PluginEnableConfig{Timeout: timeout}
 
 	return pr.backend.Enable(name, config)
 }
@@ -218,7 +219,7 @@ func (pr *pluginRouter) disablePlugin(ctx context.Context, w http.ResponseWriter
 	}
 
 	name := vars["name"]
-	config := &types.PluginDisableConfig{
+	config := &backend.PluginDisableConfig{
 		ForceDisable: httputils.BoolValue(r, "force"),
 	}
 
@@ -231,7 +232,7 @@ func (pr *pluginRouter) removePlugin(ctx context.Context, w http.ResponseWriter,
 	}
 
 	name := vars["name"]
-	config := &types.PluginRmConfig{
+	config := &backend.PluginRmConfig{
 		ForceRemove: httputils.BoolValue(r, "force"),
 	}
 	return pr.backend.Remove(name, config)

--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -141,3 +141,18 @@ type CommitConfig struct {
 	ContainerOS         string
 	ParentImageID       string
 }
+
+// PluginRmConfig holds arguments for plugin remove.
+type PluginRmConfig struct {
+	ForceRemove bool
+}
+
+// PluginEnableConfig holds arguments for plugin enable
+type PluginEnableConfig struct {
+	Timeout int
+}
+
+// PluginDisableConfig holds arguments for plugin disable.
+type PluginDisableConfig struct {
+	ForceDisable bool
+}

--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -156,3 +156,10 @@ type PluginEnableConfig struct {
 type PluginDisableConfig struct {
 	ForceDisable bool
 }
+
+// NetworkListConfig stores the options available for listing networks
+type NetworkListConfig struct {
+	// TODO(@cpuguy83): naming is hard, this is pulled from what was being used in the router before moving here
+	Detailed bool
+	Verbose  bool
+}

--- a/api/types/configs.go
+++ b/api/types/configs.go
@@ -21,21 +21,6 @@ type ExecConfig struct {
 	Cmd          []string // Execution commands and args
 }
 
-// PluginRmConfig holds arguments for plugin remove.
-type PluginRmConfig struct {
-	ForceRemove bool
-}
-
-// PluginEnableConfig holds arguments for plugin enable
-type PluginEnableConfig struct {
-	Timeout int
-}
-
-// PluginDisableConfig holds arguments for plugin disable.
-type PluginDisableConfig struct {
-	ForceDisable bool
-}
-
 // NetworkListConfig stores the options available for listing networks
 type NetworkListConfig struct {
 	// TODO(@cpuguy83): naming is hard, this is pulled from what was being used in the router before moving here

--- a/api/types/configs.go
+++ b/api/types/configs.go
@@ -1,9 +1,5 @@
 package types // import "github.com/docker/docker/api/types"
 
-// configs holds structs used for internal communication between the
-// frontend (such as an http server) and the backend (such as the
-// docker daemon).
-
 // ExecConfig is a small subset of the Config struct that holds the configuration
 // for the exec feature of docker.
 type ExecConfig struct {
@@ -19,11 +15,4 @@ type ExecConfig struct {
 	Env          []string // Environment variables
 	WorkingDir   string   // Working directory
 	Cmd          []string // Execution commands and args
-}
-
-// NetworkListConfig stores the options available for listing networks
-type NetworkListConfig struct {
-	// TODO(@cpuguy83): naming is hard, this is pulled from what was being used in the router before moving here
-	Detailed bool
-	Verbose  bool
 }

--- a/daemon/cluster/controllers/plugin/controller.go
+++ b/daemon/cluster/controllers/plugin/controller.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm/runtime"
 	"github.com/docker/docker/errdefs"
@@ -42,9 +43,9 @@ type Controller struct {
 // Backend is the interface for interacting with the plugin manager
 // Controller actions are passed to the configured backend to do the real work.
 type Backend interface {
-	Disable(name string, config *types.PluginDisableConfig) error
-	Enable(name string, config *types.PluginEnableConfig) error
-	Remove(name string, config *types.PluginRmConfig) error
+	Disable(name string, config *backend.PluginDisableConfig) error
+	Enable(name string, config *backend.PluginEnableConfig) error
+	Remove(name string, config *backend.PluginRmConfig) error
 	Pull(ctx context.Context, ref reference.Named, name string, metaHeaders http.Header, authConfig *registry.AuthConfig, privileges types.PluginPrivileges, outStream io.Writer, opts ...plugin.CreateOpt) error
 	Upgrade(ctx context.Context, ref reference.Named, name string, metaHeaders http.Header, authConfig *registry.AuthConfig, privileges types.PluginPrivileges, outStream io.Writer) error
 	Get(name string) (*v2.Plugin, error)
@@ -114,7 +115,7 @@ func (p *Controller) Prepare(ctx context.Context) (err error) {
 			return errors.Errorf("plugin already exists: %s", p.spec.Name)
 		}
 		if pl.IsEnabled() {
-			if err := p.backend.Disable(pl.GetID(), &types.PluginDisableConfig{ForceDisable: true}); err != nil {
+			if err := p.backend.Disable(pl.GetID(), &backend.PluginDisableConfig{ForceDisable: true}); err != nil {
 				p.logger.WithError(err).Debug("could not disable plugin before running upgrade")
 			}
 		}
@@ -145,12 +146,12 @@ func (p *Controller) Start(ctx context.Context) error {
 
 	if p.spec.Disabled {
 		if pl.IsEnabled() {
-			return p.backend.Disable(p.pluginID, &types.PluginDisableConfig{ForceDisable: false})
+			return p.backend.Disable(p.pluginID, &backend.PluginDisableConfig{ForceDisable: false})
 		}
 		return nil
 	}
 	if !pl.IsEnabled() {
-		return p.backend.Enable(p.pluginID, &types.PluginEnableConfig{Timeout: 30})
+		return p.backend.Enable(p.pluginID, &backend.PluginEnableConfig{Timeout: 30})
 	}
 	return nil
 }
@@ -234,7 +235,7 @@ func (p *Controller) Remove(ctx context.Context) error {
 
 	// This may error because we have exactly 1 plugin, but potentially multiple
 	// tasks which are calling remove.
-	err = p.backend.Remove(p.pluginID, &types.PluginRmConfig{ForceRemove: true})
+	err = p.backend.Remove(p.pluginID, &backend.PluginRmConfig{ForceRemove: true})
 	if isNotFound(err) {
 		return nil
 	}

--- a/daemon/cluster/controllers/plugin/controller_test.go
+++ b/daemon/cluster/controllers/plugin/controller_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm/runtime"
 	"github.com/docker/docker/plugin"
@@ -343,19 +344,19 @@ type mockBackend struct {
 	pub *pubsub.Publisher
 }
 
-func (m *mockBackend) Disable(name string, config *types.PluginDisableConfig) error {
+func (m *mockBackend) Disable(name string, config *backend.PluginDisableConfig) error {
 	m.p.PluginObj.Enabled = false
 	m.pub.Publish(plugin.EventDisable{})
 	return nil
 }
 
-func (m *mockBackend) Enable(name string, config *types.PluginEnableConfig) error {
+func (m *mockBackend) Enable(name string, config *backend.PluginEnableConfig) error {
 	m.p.PluginObj.Enabled = true
 	m.pub.Publish(plugin.EventEnable{})
 	return nil
 }
 
-func (m *mockBackend) Remove(name string, config *types.PluginRmConfig) error {
+func (m *mockBackend) Remove(name string, config *backend.PluginRmConfig) error {
 	m.p = nil
 	m.pub.Publish(plugin.EventRemove{})
 	return nil

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/backend"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
@@ -550,7 +551,7 @@ func (daemon *Daemon) deleteNetwork(nw *libnetwork.Network, dynamic bool) error 
 }
 
 // GetNetworks returns a list of all networks
-func (daemon *Daemon) GetNetworks(filter filters.Args, config types.NetworkListConfig) (networks []types.NetworkResource, err error) {
+func (daemon *Daemon) GetNetworks(filter filters.Args, config backend.NetworkListConfig) (networks []types.NetworkResource, err error) {
 	var idx map[string]*libnetwork.Network
 	if config.Detailed {
 		idx = make(map[string]*libnetwork.Network)

--- a/plugin/backend_linux.go
+++ b/plugin/backend_linux.go
@@ -23,6 +23,7 @@ import (
 	"github.com/distribution/reference"
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/registry"
@@ -47,7 +48,7 @@ var acceptedPluginFilterTags = map[string]bool{
 }
 
 // Disable deactivates a plugin. This means resources (volumes, networks) cant use them.
-func (pm *Manager) Disable(refOrID string, config *types.PluginDisableConfig) error {
+func (pm *Manager) Disable(refOrID string, config *backend.PluginDisableConfig) error {
 	p, err := pm.config.Store.GetV2Plugin(refOrID)
 	if err != nil {
 		return err
@@ -75,7 +76,7 @@ func (pm *Manager) Disable(refOrID string, config *types.PluginDisableConfig) er
 }
 
 // Enable activates a plugin, which implies that they are ready to be used by containers.
-func (pm *Manager) Enable(refOrID string, config *types.PluginEnableConfig) error {
+func (pm *Manager) Enable(refOrID string, config *backend.PluginEnableConfig) error {
 	p, err := pm.config.Store.GetV2Plugin(refOrID)
 	if err != nil {
 		return err
@@ -559,7 +560,7 @@ func writeManifest(ctx context.Context, cs content.Store, m *manifest) (ocispec.
 }
 
 // Remove deletes plugin's root directory.
-func (pm *Manager) Remove(name string, config *types.PluginRmConfig) error {
+func (pm *Manager) Remove(name string, config *backend.PluginRmConfig) error {
 	p, err := pm.config.Store.GetV2Plugin(name)
 	pm.mu.RLock()
 	c := pm.cMap[p]

--- a/plugin/backend_unsupported.go
+++ b/plugin/backend_unsupported.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/registry"
 )
@@ -17,12 +18,12 @@ import (
 var errNotSupported = errors.New("plugins are not supported on this platform")
 
 // Disable deactivates a plugin, which implies that they cannot be used by containers.
-func (pm *Manager) Disable(name string, config *types.PluginDisableConfig) error {
+func (pm *Manager) Disable(name string, config *backend.PluginDisableConfig) error {
 	return errNotSupported
 }
 
 // Enable activates a plugin, which implies that they are ready to be used by containers.
-func (pm *Manager) Enable(name string, config *types.PluginEnableConfig) error {
+func (pm *Manager) Enable(name string, config *backend.PluginEnableConfig) error {
 	return errNotSupported
 }
 
@@ -57,7 +58,7 @@ func (pm *Manager) Push(ctx context.Context, name string, metaHeader http.Header
 }
 
 // Remove deletes plugin's root directory.
-func (pm *Manager) Remove(name string, config *types.PluginRmConfig) error {
+func (pm *Manager) Remove(name string, config *backend.PluginRmConfig) error {
 	return errNotSupported
 }
 

--- a/plugin/manager_linux_test.go
+++ b/plugin/manager_linux_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/pkg/containerfs"
 	"github.com/docker/docker/pkg/stringid"
@@ -63,7 +64,7 @@ func TestManagerWithPluginMounts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := m.Remove(p1.GetID(), &types.PluginRmConfig{ForceRemove: true}); err != nil {
+	if err := m.Remove(p1.GetID(), &backend.PluginRmConfig{ForceRemove: true}); err != nil {
 		t.Fatal(err)
 	}
 	if mounted, err := mountinfo.Mounted(p2Mount); !mounted || err != nil {
@@ -127,7 +128,7 @@ func TestCreateFailed(t *testing.T) {
 		t.Fatalf("expected Create failed error, got %v", err)
 	}
 
-	if err := m.Remove(p.GetID(), &types.PluginRmConfig{ForceRemove: true}); err != nil {
+	if err := m.Remove(p.GetID(), &backend.PluginRmConfig{ForceRemove: true}); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
- follow-up / similar to https://github.com/moby/moby/pull/46898

### api/types: move Plugin-types to api/types/backend

These structs are intended for internal use only for the backend, and are
not intended to be used externally.

This moves the plugin-related `PluginRmConfig`, `PluginEnableConfig`, and
`PluginDisableConfig` types to the backend package to prevent them being
imported in the client, and to make it more clear that this is part of
internal APIs, and not public-facing.

### api/types: move NetworkListConfig to api/types/backend

This struct is intended for internal use only for the backend, and is
not intended to be used externally.

This moves the plugin-related `NetworkListConfig` types to the backend
package to prevent it being imported in the client, and to make it more
clear that this is part of internal APIs, and not public-facing.


**- A picture of a cute animal (not mandatory but encouraged)**

