### PR TITLE
integration-cli: Update plugin test install image error

### DIFF
--- a/integration-cli/docker_cli_plugins_test.go
+++ b/integration-cli/docker_cli_plugins_test.go
@@ -233,7 +233,7 @@ func (ps *DockerPluginSuite) TestPluginInstallImage(c *testing.T) {
 
 	out, _, err := dockerCmdWithError("plugin", "install", imgRepo)
 	assert.ErrorContains(c, err, "")
-	assert.Check(c, is.Contains(out, `Encountered remote "application/vnd.docker.container.image.v1+json"(image) when fetching`))
+	assert.Check(c, is.Contains(out, `did not find plugin config for specified reference`))
 }
 
 func (ps *DockerPluginSuite) TestPluginEnableDisableNegative(c *testing.T) {


### PR DESCRIPTION
Check for the error returned by the plugin pull logic based off the containerd pull code. This code is used regardless of graphdriver or snapshotter.

Locally this test is failing for me on overlay2 and overlayfs snapshotter. The message which was previously being checked is in the old pull code which the plugin logic moved away from a few years ago. Let's see is CI handles it differently.

