### PR TITLE
c8d/integration-cli: Adjust TestBuildClearCmd

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -3144,9 +3144,13 @@ func (s *DockerCLIBuildSuite) TestBuildClearCmd(c *testing.T) {
    ENTRYPOINT ["/bin/bash"]
    CMD []`))
 
-	res := inspectFieldJSON(c, name, "Config.Cmd")
-	if res != "[]" {
-		c.Fatalf("Cmd %s, expected %s", res, "[]")
+	cmd := inspectFieldJSON(c, name, "Config.Cmd")
+	// OCI types specify `omitempty` JSON annotation which doesn't serialize
+	// empty arrays and the Cmd will not be present at all.
+	if testEnv.UsingSnapshotter() {
+		assert.Check(c, is.Equal(cmd, "null"))
+	} else {
+		assert.Check(c, is.Equal(cmd, "[]"))
 	}
 }
 


### PR DESCRIPTION
- addresses https://github.com/moby/moby/issues/46760

Config serialization performed by the graphdriver implementation maintained the distinction between an empty array and having no `Cmd` set.

With containerd integration we serialize the OCI types directly that use the `omitempty` option which doesn't persist that distinction.

Considering that both values should have exactly the same semantics (no cmd being passed) it should be fine if in this case the Cmd would be null instead of an empty array.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
`TestBuildClearCmd`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

