### PR TITLE
Edit '/etc/hosts' to add/remove IPv6 records.

### DIFF
--- a/integration/networking/etchosts_test.go
+++ b/integration/networking/etchosts_test.go
@@ -1,0 +1,149 @@
+package networking
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	containertypes "github.com/docker/docker/api/types/container"
+	networktypes "github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/integration/internal/network"
+	"github.com/docker/docker/testutil/daemon"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/skip"
+)
+
+type netOptsList []func(*types.NetworkCreate)
+
+// Check that the '/etc/hosts' file in a container is updated according to
+// whether it's connected to an IPv6 network.
+func TestEtcHostsUpdates(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+
+	ctx := setupTest(t)
+
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t, "-D", "--experimental", "--ip6tables")
+	defer d.Stop(t)
+
+	c := d.NewClientT(t)
+	defer c.Close()
+
+	// Create two networks, one without IPv6, one with.
+
+	createNetwork := func(name string, opts netOptsList) func() {
+		t.Helper()
+		opts = append(opts, netOptsList{
+			network.WithDriver("bridge"),
+			network.WithOption("com.docker.network.bridge.name", name),
+		}...)
+		network.CreateNoError(ctx, t, c, name, opts...)
+		return func() {
+			network.RemoveNoError(ctx, t, c, name)
+		}
+	}
+
+	const netName4, netName6 = "testnet4", "testnet6"
+	defer createNetwork(netName4, netOptsList{})()
+	defer createNetwork(netName6, netOptsList{
+		network.WithIPv6(),
+		network.WithIPAM("fd32:56f2:1f81::/64", "fd32:56f2:1f81::1"),
+	})()
+
+	// Run a container, connected to the IPv4 network.
+
+	const ctrName = "test_container"
+	ctrId := container.Run(ctx, t, c,
+		container.WithName(ctrName),
+		container.WithImage("busybox:latest"),
+		container.WithCmd("top"),
+		container.WithNetworkMode(netName4),
+	)
+	defer c.ContainerRemove(ctx, ctrId, containertypes.RemoveOptions{
+		Force: true,
+	})
+
+	runCmd := func(cmd []string, expExitCode int, expStdout, expStderr []string) {
+		t.Helper()
+		execCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		res, err := container.Exec(execCtx, c, ctrId, cmd)
+		assert.Check(t, is.Nil(err))
+		assert.Check(t, is.Equal(res.ExitCode, expExitCode))
+		if len(expStdout) == 0 {
+			assert.Check(t, is.Len(res.Stdout(), 0), "Check stdout")
+		} else {
+			for _, s := range expStdout {
+				assert.Check(t, is.Contains(res.Stdout(), s), "Check stdout")
+			}
+		}
+		if len(expStderr) == 0 {
+			assert.Check(t, is.Len(res.Stderr(), 0), "Check stderr")
+		} else {
+			for _, s := range expStderr {
+				assert.Check(t, is.Contains(res.Stderr(), s), "Check stderr")
+			}
+		}
+	}
+
+	catEtcHosts := []string{"cat", "/etc/hosts"}
+	pingIP6LoAddr := []string{"ping", "-6", "-c1", "-W3", "::1"}
+	pingIP6Localhost := []string{"ping", "-6", "-c1", "-W3", "ip6-localhost"}
+	pingIP4Localhost := []string{"ping", "-c1", "-W3", "localhost"}
+
+	checkNoIPv6 := func() {
+		t.Helper()
+		runCmd(catEtcHosts, 0,
+			[]string{"127.0.0.1\tlocalhost"},
+			nil)
+		runCmd(pingIP6LoAddr, 1,
+			[]string{"PING ::1 (::1)"},
+			[]string{"sendto: Cannot assign requested address"})
+		if !testEnv.IsRootless() {
+			// The host's '/etc/hosts' file isn't normally used to generate DNS records
+			// inside a container. But, in rootless mode, it is. So, in most cases, with no
+			// '/etc/hosts' entry for 'ip6-localhost' in the container it is not resolvable.
+			// But, in rootless mode, the container's behaviour depends on the content of the
+			// host's '/etc/hosts'.
+			runCmd(pingIP6Localhost, 1, nil,
+				[]string{"ping: bad address 'ip6-localhost'"})
+		}
+		runCmd(pingIP4Localhost, 0,
+			[]string{"1 packets transmitted, 1 packets received, 0% packet loss"},
+			nil)
+	}
+
+	checkHaveIPv6 := func() {
+		t.Helper()
+		runCmd(catEtcHosts, 0,
+			[]string{"127.0.0.1\tlocalhost", "::1\tlocalhost ip6-localhost ip6-loopback"},
+			nil)
+		runCmd(pingIP6LoAddr, 0,
+			[]string{"1 packets transmitted, 1 packets received, 0% packet loss"},
+			nil)
+		runCmd(pingIP6Localhost, 0,
+			[]string{"1 packets transmitted, 1 packets received, 0% packet loss"},
+			nil)
+		runCmd(pingIP4Localhost, 0,
+			[]string{"1 packets transmitted, 1 packets received, 0% packet loss"},
+			nil)
+	}
+
+	// The container is only attached to an IPv4 network, it shouldn't have the
+	// built-in IPv6 entries in "/etc/hosts".
+	checkNoIPv6()
+
+	// Attach the container to an IPv6 network, check that IPv6 loopback starts
+	// working and /etc/hosts has been updated.
+	err := c.NetworkConnect(ctx, netName6, ctrId, &networktypes.EndpointSettings{})
+	assert.NilError(t, err)
+	checkHaveIPv6()
+
+	// Detach from the IPv6 network, check that IPv6 loopback stops working.
+	err = c.NetworkDisconnect(ctx, netName6, ctrId, true)
+	assert.NilError(t, err)
+	checkNoIPv6()
+}

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -484,9 +484,11 @@ func (ep *Endpoint) sbJoin(sb *Sandbox, options ...EndpointOption) (err error) {
 	extEp := sb.getGatewayEndpoint()
 
 	sb.addEndpoint(ep)
+	sb.updateBuiltinHosts()
 	defer func() {
 		if err != nil {
 			sb.removeEndpoint(ep)
+			sb.updateBuiltinHosts()
 		}
 	}()
 

--- a/libnetwork/endpoint_unix_test.go
+++ b/libnetwork/endpoint_unix_test.go
@@ -14,12 +14,12 @@ import (
 func TestHostsEntries(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 
-	expectedHostsFile := `127.0.0.1	localhost
-::1	localhost ip6-localhost ip6-loopback
+	expectedHostsFile := `::1	localhost ip6-localhost ip6-loopback
 fe00::0	ip6-localnet
 ff00::0	ip6-mcastprefix
 ff02::1	ip6-allnodes
 ff02::2	ip6-allrouters
+127.0.0.1	localhost
 192.168.222.2	somehost.example.com somehost
 fe90::2	somehost.example.com somehost
 `

--- a/libnetwork/endpoint_unix_test.go
+++ b/libnetwork/endpoint_unix_test.go
@@ -36,6 +36,7 @@ fe90::2	somehost.example.com somehost
 		t.Fatal(err)
 	}
 	defer os.Remove(hostsFile.Name())
+	hostsFile.Close()
 
 	sbx, err := ctrlr.NewSandbox("sandbox1", OptionHostsPath(hostsFile.Name()), OptionHostname("somehost.example.com"))
 	if err != nil {

--- a/libnetwork/etchosts/fuzz_test.go
+++ b/libnetwork/etchosts/fuzz_test.go
@@ -35,6 +35,6 @@ func FuzzAdd(f *testing.F) {
 		if err != nil {
 			return
 		}
-		_ = Add(testFile, recs)
+		_ = Add(testFile, recs, true)
 	})
 }

--- a/libnetwork/internal/filelease/filelease.go
+++ b/libnetwork/internal/filelease/filelease.go
@@ -1,0 +1,134 @@
+// Package filelease implements "best effort" file locking, for Linux hosts, by
+// wrapping fcntl(2)'s F_SETLEASE.
+//
+// A file that is bind mounted into a container (for example "/etc/hosts",
+// "/etc/resolv.conf") can't be updated by moving a new version into place. So,
+// when updating it, it's possible for consumers inside the container to see a
+// truncated or incomplete version of the file. If a write lease can be obtained
+// for one of these files, processes attempting to open the file in the container
+// will block until the lease is dropped.
+//
+// If the file already has open descriptors, a lease cannot be obtained. OpenFile
+// can be configured to retry, and to return an open file descriptor even if the
+// lease cannot be acquired.
+package filelease
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/containerd/log"
+	"github.com/docker/docker/libnetwork/types"
+	"github.com/pkg/errors"
+)
+
+// Use OpenFile to open a file, attempt to acquire a write lease, and
+// construct a FileLease.
+type FileLease struct {
+	*os.File
+	leaseErr error
+}
+
+// Opts describes options for NewFileLeaser.
+type Opts struct {
+	flags    int           // flag for os.OpenFile()
+	mode     os.FileMode   // perm for os.OpenFile()
+	attempts int           // Max attempts to acquire lease.
+	interval time.Duration // Interval between attempts to acquire lease.
+}
+
+// defaultOpts returns a default set of options that can be modified by the WithXXX() functions below.
+func defaultOpts() *Opts {
+	return &Opts{
+		flags:    os.O_CREATE | os.O_RDWR,
+		mode:     0644,
+		attempts: 2,
+		interval: 10 * time.Millisecond,
+	}
+}
+
+// WithFlags can be used to modify the flag value passed to os.OpenFile().
+func WithFlags(flags int) func(*Opts) {
+	return func(o *Opts) {
+		o.flags = flags
+	}
+}
+
+// WithFileMode can be used to modify the perm value passed to os.OpenFile().
+func WithFileMode(mode os.FileMode) func(*Opts) {
+	return func(o *Opts) {
+		o.mode = mode
+	}
+}
+
+// WithRetry can be used to modify the number of attempts to make at acquiring
+// the write lease, and the interval between attempts, when it fails because the
+// file is already open.
+func WithRetry(attempts int, interval time.Duration) func(*Opts) {
+	return func(o *Opts) {
+		o.attempts = attempts
+		o.interval = interval
+	}
+}
+
+// OpenFile opens a file and tries to acquire a write lease on it.
+//
+// If mustLease is false, the lease is best-effort - if it cannot be acquired (or
+// file leases are not implemented for this OS) the open fd is returned without a
+// lease. In this case, an error is only returned if the file cannot be opened.
+//
+// If a lease is acquired, it's automatically released when the file is closed.
+// Until then, other readers and writers will block when they try to open the
+// file. SIGIO will be delivered to this process when a second reader or writer
+// attempts to open the file, it is ignored by default. (The lease is forcibly
+// released by the kernel "/proc/sys/fs/lease-break-time" seconds after the
+// signal is delivered.)
+//
+// If there is already an open descriptor for the file, belonging to this or any
+// other process, this function will try to obtain the lease Opts.Attempts times,
+// at intervals of Opts.Interval.
+//
+// File leasing is only implemented for Linux. For other OSs, the file is just
+// opened normally, and OpenFile with mustLease will always fail.
+func OpenFile(path string, mustLease bool, options ...func(*Opts)) (*FileLease, error) {
+	opts := defaultOpts()
+	for _, opt := range options {
+		opt(opts)
+	}
+
+	f, err := os.OpenFile(path, opts.flags, opts.mode)
+	if err != nil {
+		return nil, err
+	}
+	err = getWriteLease(f, opts)
+	if err != nil {
+		if mustLease {
+			f.Close()
+			return nil, err
+		}
+		// Return the open file without a lease.
+		if _, ok := err.(types.NotImplementedError); !ok {
+			// File leasing is implemented, so log the conflict.
+			log.G(context.TODO()).WithError(err).WithField("path", path).Info("opened without lease")
+		}
+	}
+	return &FileLease{File: f, leaseErr: err}, nil
+}
+
+// Leased returns true if the write lease was obtained after the file was opened.
+func (fl *FileLease) Leased() bool {
+	return fl.leaseErr == nil
+}
+
+// WriteFile rewrites an open file by truncating it, then writing b.
+func (fl *FileLease) WriteFile(b []byte) error {
+	if err := fl.File.Truncate(0); err != nil {
+		return errors.Wrap(err, "truncate file for rewrite")
+	}
+	if _, err := fl.File.Seek(0, 0); err != nil {
+		return errors.Wrap(err, "seek to start of file for rewrite")
+	}
+	_, err := fl.File.Write(b)
+	return errors.Wrap(err, "rewrite file")
+}

--- a/libnetwork/internal/filelease/filelease_linux.go
+++ b/libnetwork/internal/filelease/filelease_linux.go
@@ -1,0 +1,24 @@
+package filelease
+
+import (
+	"os"
+	"time"
+
+	"github.com/docker/docker/libnetwork/types"
+
+	"golang.org/x/sys/unix"
+)
+
+func getWriteLease(f *os.File, opts *Opts) (retErr error) {
+	for retry, attempt := true, 0; retry && attempt < opts.attempts; attempt += 1 {
+		if attempt > 0 {
+			time.Sleep(opts.interval)
+		}
+		_, retErr = unix.FcntlInt(f.Fd(), unix.F_SETLEASE, unix.F_WRLCK)
+		retry = retErr == unix.EAGAIN
+	}
+	if retErr == unix.EINVAL {
+		return types.NotImplementedErrorf("not implemented")
+	}
+	return retErr
+}

--- a/libnetwork/internal/filelease/filelease_linux_test.go
+++ b/libnetwork/internal/filelease/filelease_linux_test.go
@@ -1,0 +1,121 @@
+package filelease
+
+import (
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func appendToFile(fname, content string, ch chan error) {
+	f, err := os.OpenFile(fname, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		ch <- err
+		return
+	}
+	defer f.Close()
+	_, err = f.Write([]byte(content))
+	ch <- err
+}
+
+// Check that a file lease can be obtained, and that it delays other writers.
+func TestFileLeaseDefaults(t *testing.T) {
+	td := t.TempDir()
+	fname := path.Join(td, "testfile")
+
+	fl, err := OpenFile(fname, false)
+	assert.NilError(t, err)
+	assert.Check(t, fl.Leased())
+
+	ch := make(chan error, 1)
+	go appendToFile(fname, "second", ch)
+
+	// Sleep while holding the lease to give appendToFile() plenty of time
+	// to sneak in its write, if it can.
+	time.Sleep(1 * time.Second)
+	err = fl.WriteFile([]byte("first"))
+	assert.NilError(t, err)
+	fl.Close()
+
+	err = <-ch
+	assert.NilError(t, err)
+
+	content, _ := os.ReadFile(fname)
+	assert.Check(t, cmp.Equal(string(content), "firstsecond"))
+}
+
+// Check that, if !mustLease, and a lease cannot be obtained because there is
+// already an open file descriptor, the file is still opened.
+func TestFileLeaseFail(t *testing.T) {
+	td := t.TempDir()
+	fname := path.Join(td, "testfile")
+
+	clashFd, err := os.OpenFile(fname, os.O_CREATE|os.O_WRONLY, 0644)
+	assert.NilError(t, err)
+	defer clashFd.Close()
+
+	fl, err := OpenFile(fname, false, WithFlags(os.O_WRONLY), WithFileMode(0777))
+	assert.NilError(t, err)
+	assert.Check(t, !fl.Leased())
+
+	ch := make(chan error, 1)
+	go appendToFile(fname, "second", ch)
+
+	time.Sleep(1 * time.Second)
+	err = fl.WriteFile([]byte("first"))
+	assert.NilError(t, err)
+	fl.Close()
+
+	err = <-ch
+	assert.NilError(t, err)
+
+	content, _ := os.ReadFile(fname)
+	assert.Check(t, cmp.Equal(string(content), "first"))
+}
+
+// Check that if a lease cannot be obtained because there is already an open file
+// descriptor, the open fails if that is what's required.
+func TestFileLeaseMustFail(t *testing.T) {
+	td := t.TempDir()
+	fname := path.Join(td, "testfile")
+
+	clashFd, err := os.OpenFile(fname, os.O_CREATE|os.O_WRONLY, 0644)
+	assert.NilError(t, err)
+	defer clashFd.Close()
+
+	fl, err := OpenFile(fname, true)
+	assert.Check(t, fl == nil)
+	assert.Check(t, cmp.Error(err, "resource temporarily unavailable"))
+}
+
+// Check that if a lease cannot be obtained immediately because there is already
+// an open file descriptor, the FileLeaser can wait and retry, if that is what
+// is required.
+func TestFileLeaseRetry(t *testing.T) {
+	td := t.TempDir()
+	fname := path.Join(td, "testfile")
+
+	// Create the file and keep an open file descriptor.
+	clashFd, err := os.OpenFile(fname, os.O_CREATE|os.O_WRONLY, 0644)
+	assert.NilError(t, err)
+	// Close the clashing descriptor after one second.
+	go func() {
+		time.Sleep(1 * time.Second)
+		clashFd.Close()
+	}()
+
+	// Immediately try to open and lease the file, a retry will be needed, allow
+	// retries for up to 5 seconds.
+	start := time.Now()
+	fl, err := OpenFile(fname, false, WithRetry(10, 500*time.Millisecond))
+	elapsed := time.Since(start)
+	assert.NilError(t, err)
+	defer fl.Close()
+	assert.Check(t, fl.Leased())
+
+	// Check that the lease was acquired soon after the clashing descriptor closed.
+	assert.Check(t, elapsed < 2*time.Second)
+}

--- a/libnetwork/internal/filelease/filelease_others.go
+++ b/libnetwork/internal/filelease/filelease_others.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package filelease
+
+import (
+	"os"
+
+	"github.com/docker/docker/libnetwork/types"
+)
+
+func getWriteLease(f *os.File, opts *Opts) error {
+	return types.NotImplementedErrorf("not implemented")
+}

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1455,6 +1455,9 @@ func (n *Network) getSvcRecords(ep *Endpoint) []etchosts.Record {
 		return nil
 	}
 
+	// This doesn't look at "sr.svcIP6Map". But, this method is only used to work out
+	// which entries to remove from '/etc/hosts', and entries are removed by name,
+	// not address+name. So, IPv6 entries are removed, just not explicitly.
 	svcMapKeys := sr.svcMap.Keys()
 	// Loop on service names on this network
 	for _, k := range svcMapKeys {

--- a/libnetwork/sandbox_dns_windows.go
+++ b/libnetwork/sandbox_dns_windows.go
@@ -18,6 +18,8 @@ func (sb *Sandbox) updateHostsFile(ifaceIP []string) error {
 	return nil
 }
 
+func (sb *Sandbox) updateBuiltinHosts() {}
+
 func (sb *Sandbox) deleteHostsEntries(recs []etchosts.Record) {}
 
 func (sb *Sandbox) updateDNS(ipv6Enabled bool) error {

--- a/libnetwork/sandbox_store.go
+++ b/libnetwork/sandbox_store.go
@@ -244,6 +244,10 @@ func (c *Controller) sandboxCleanup(activeSandboxes map[string]interface{}) erro
 						sandboxID: sbs.ID,
 					}
 				}
+				if n.enableIPv6 {
+					// Non-Windows containers will already have IPv6 built-in '/etc/hosts' entries.
+					sb.haveIPv6BuiltinHosts = true
+				}
 			}
 			if _, ok := activeSandboxes[sb.ID()]; ok && err != nil {
 				log.G(context.TODO()).Errorf("failed to restore endpoint %s in %s for container %s due to %v", eps.Eid, eps.Nid, sb.ContainerID(), err)


### PR DESCRIPTION
**- What I did**

Only add built-in records ('ip6-localhost', 'ip6-mcastprefix', ...) to a container's '/etc/hosts' when the container is connected to an IPv6 network - and remove them when it's no longer connected.

Fixes #35954

**- How I did it**

Use the existing `etchosts` functionality to add/remove IPv6-related built-in records from `/etc/hosts` when an endpoint is added/removed from a container's sandbox.

IPv6 records are always added at the top of the `/etc/hosts` file. This changes the order of entries, the IPv4 loopback host is currently always added so it now comes after the IPv6 - the ordering was checked by some tests, which I've updated.

_A matching follow-up change will probably be needed to add/remove the IPv4 localhost record according to whether the container has IPv4  connectivity._

_The built-in IPv6 hostnames may be DNS-resolvable when running in 'rootless' mode because, in that mode, entries in the host's `/etc/hosts` are used to respond to DNS requests from the container._

**- How to verify it**

New integration test, and updated unit tests.

With live-restore enabled, restarted the daemon, checked that previously-running containers were still updated as expected when IPv6 connectivity changed.

**- Description for the changelog**

Edit '/etc/hosts' to add/remove IPv6 records when IPv6 connectivity changes.

**- A picture of a cute animal (not mandatory but encouraged)**

