### PR TITLE
c8d/prune: Default `dangling` to true, familiarize untagged images

### DIFF
--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -341,3 +341,14 @@ func (i *ImageService) getAllImagesWithRepository(ctx context.Context, ref refer
 	nameFilter := "^" + regexp.QuoteMeta(ref.Name()) + ":" + reference.TagRegexp.String() + "$"
 	return i.client.ImageService().List(ctx, "name~="+strconv.Quote(nameFilter))
 }
+
+func imageFamiliarName(img containerdimages.Image) string {
+	if isDanglingImage(img) {
+		return img.Target.Digest.String()
+	}
+
+	if ref, err := reference.ParseNamed(img.Name); err == nil {
+		return reference.FamiliarString(ref)
+	}
+	return img.Name
+}

--- a/daemon/containerd/image_prune.go
+++ b/daemon/containerd/image_prune.go
@@ -184,7 +184,7 @@ func (i *ImageService) pruneUnused(ctx context.Context, filterFunc imageFilterFu
 
 		report.ImagesDeleted = append(report.ImagesDeleted,
 			image.DeleteResponse{
-				Untagged: img.Name,
+				Untagged: imageFamiliarName(img),
 			},
 		)
 

--- a/daemon/containerd/image_prune.go
+++ b/daemon/containerd/image_prune.go
@@ -42,7 +42,7 @@ func (i *ImageService) ImagesPrune(ctx context.Context, fltrs filters.Args) (*ty
 		return nil, err
 	}
 
-	danglingOnly, err := fltrs.GetBoolOrDefault("dangling", false)
+	danglingOnly, err := fltrs.GetBoolOrDefault("dangling", true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- addresses https://github.com/moby/moby/issues/46760

**c8d/prune: Default dangling filter to true**

If no `dangling` filter is specified, prune should only delete dangling
images.

This wasn't visible by doing `docker image prune` because the CLI
explicitly sets this filter to true.

**c8d/prune: Familiarize image names that were untagged**

To align with the graphdriver implementation.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>

**- How to verify it**
docker-py  `tests.integration.api_image_test.PruneImagesTest` should pass now

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

