### PR TITLE
c8d/inspect: Fill `Parent` property

### DIFF
--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -37,6 +37,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+// Digest of the image which was the base image of the committed container.
 const imageLabelClassicBuilderParent = "org.mobyproject.image.parent"
 
 // GetImageAndReleasableLayer returns an image and releaseable layer for a


### PR DESCRIPTION
- address https://github.com/moby/moby/issues/46760

Before this change `ParentId` was filled for images when calling the `/images/json` (image list) endpoint but was not for the `/images/<image>/json` (image inspect).

This fixes part of `tests.integration.api_image_test.CommitTest` and `tests.integration.api_image_test.CommitTest` (not fully though, only the [`Parent` value check](https://github.com/docker/docker-py/blob/7d8a161b12f4c5e16776c57bfc5ce7077f404995/tests/integration/api_image_test.py#L95)).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

