### PR TITLE
Replace use of httputil in client hijack

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -113,14 +113,6 @@ issues:
       path: "api/types/(volume|container)/"
       linters:
         - revive
-    # FIXME temporarily suppress these. See #39926
-    - text: "SA1019: httputil.NewClientConn"
-      linters:
-        - staticcheck
-    # FIXME temporarily suppress these (related to the ones above)
-    - text: "SA1019: httputil.ErrPersistEOF"
-      linters:
-        - staticcheck
     # FIXME temporarily suppress these (see https://github.com/gotestyourself/gotest.tools/issues/272)
     - text: "SA1019: (assert|cmp|is)\\.ErrorType is deprecated"
       linters:

--- a/client/hijack.go
+++ b/client/hijack.go
@@ -12,10 +12,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/pkg/errors"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 // postHijacked sends a POST request and hijacks the connection.
@@ -53,28 +50,6 @@ func (cli *Client) setupHijackConn(req *http.Request, proto string) (_ net.Conn,
 	req.Header.Set("Connection", "Upgrade")
 	req.Header.Set("Upgrade", proto)
 
-	// We aren't using the configured RoundTripper here so manually inject the trace context
-	tp := cli.tp
-	if tp == nil {
-		if span := trace.SpanFromContext(ctx); span.SpanContext().IsValid() {
-			tp = span.TracerProvider()
-		} else {
-			tp = otel.GetTracerProvider()
-		}
-	}
-
-	ctx, span := tp.Tracer("").Start(ctx, req.Method+" "+req.URL.Path, trace.WithSpanKind(trace.SpanKindClient))
-	// FIXME(thaJeztah): httpconv.ClientRequest is now an internal package; replace this with alternative for semconv v1.21
-	// span.SetAttributes(httpconv.ClientRequest(req)...)
-	defer func() {
-		if retErr != nil {
-			span.RecordError(retErr)
-			span.SetStatus(codes.Error, retErr.Error())
-		}
-		span.End()
-	}()
-	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
-
 	dialer := cli.Dialer()
 	conn, err := dialer(ctx)
 	if err != nil {
@@ -99,31 +74,7 @@ func (cli *Client) setupHijackConn(req *http.Request, proto string) (_ net.Conn,
 	hc := &hijackedConn{conn, bufio.NewReader(conn)}
 
 	// Server hijacks the connection, error 'connection closed' expected
-	resp, err := hc.RoundTrip(req)
-	if resp != nil {
-		// This is a simplified variant of "httpconv.ClientStatus(resp.StatusCode))";
-		//
-		// The main purpose of httpconv.ClientStatus() is to detect whether the
-		// status was successful (1xx, 2xx, 3xx) or non-successful (4xx/5xx).
-		//
-		// It also provides complex logic to *validate* status-codes against
-		// a hard-coded list meant to exclude "bogus" status codes in "success"
-		// ranges (1xx, 2xx) and convert them into an error status. That code
-		// seemed over-reaching (and not accounting for potential future valid
-		// status codes). We assume we only get valid status codes, and only
-		// look at status-code ranges.
-		//
-		// For reference, see:
-		// https://github.com/open-telemetry/opentelemetry-go/blob/v1.21.0/semconv/v1.17.0/httpconv/http.go#L85-L89
-		// https://github.com/open-telemetry/opentelemetry-go/blob/v1.21.0/semconv/internal/v2/http.go#L322-L330
-		// https://github.com/open-telemetry/opentelemetry-go/blob/v1.21.0/semconv/internal/v2/http.go#L356-L404
-		code := codes.Unset
-		if resp.StatusCode >= http.StatusBadRequest {
-			code = codes.Error
-		}
-		span.SetStatus(code, "")
-	}
-
+	resp, err := otelhttp.NewTransport(hc).RoundTrip(req)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
- addresses part of https://github.com/moby/moby/issues/39926


Simplify the hijack process by just performing the http request/response on the connection and returning the raw conn after success. The client conn from httputil is deprecated and easily replaced.

Just a draft to see if the tests are ok with it.