### PR TITLE
c8d/inspect: Fill `Container` property

### DIFF
--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -85,6 +85,9 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 
 	img := dockerOciImageToDockerImagePartial(image.ID(desc.Target.Digest), ociimage)
 
+	if img.Container, err = i.getImageLabelByDigest(ctx, desc.Target.Digest, imageLabelClassicBuilderContainer); err != nil {
+		return nil, errdefs.System(fmt.Errorf("failed to determine Container property: %w", err))
+	}
 	parent, err := i.getImageLabelByDigest(ctx, desc.Target.Digest, imageLabelClassicBuilderParent)
 	if err != nil {
 		log.G(ctx).WithError(err).Warn("failed to determine Parent property")

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -84,6 +84,14 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 	ociimage := presentImages[0]
 
 	img := dockerOciImageToDockerImagePartial(image.ID(desc.Target.Digest), ociimage)
+
+	parent, err := i.getImageLabelByDigest(ctx, desc.Target.Digest, imageLabelClassicBuilderParent)
+	if err != nil {
+		log.G(ctx).WithError(err).Warn("failed to determine Parent property")
+	} else {
+		img.Parent = image.ID(parent)
+	}
+
 	if options.Details {
 		lastUpdated := time.Unix(0, 0)
 		size, err := i.size(ctx, desc.Target, platform)
@@ -351,4 +359,26 @@ func imageFamiliarName(img containerdimages.Image) string {
 		return reference.FamiliarString(ref)
 	}
 	return img.Name
+}
+
+// getImageLabelByDigest will return the value of the label for images
+// targeting the specified digest.
+// If images have different values, an errdefs.Conflict error will be returned.
+func (i *ImageService) getImageLabelByDigest(ctx context.Context, target digest.Digest, labelKey string) (string, error) {
+	imgs, err := i.client.ImageService().List(ctx, "target.digest=="+target.String())
+	if err != nil {
+		return "", errdefs.System(err)
+	}
+
+	var value string
+	for _, img := range imgs {
+		if v, ok := img.Labels[labelKey]; ok {
+			if value != "" && value != v {
+				return value, errdefs.Conflict(fmt.Errorf("conflicting label value %q and %q", value, v))
+			}
+			value = v
+		}
+	}
+
+	return value, nil
 }

--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -37,6 +37,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+// Digest of the image which was the base image of the committed container.
 const imageLabelClassicBuilderParent = "org.mobyproject.image.parent"
 
 // GetImageAndReleasableLayer returns an image and releaseable layer for a

--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -37,8 +37,13 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// Digest of the image which was the base image of the committed container.
-const imageLabelClassicBuilderParent = "org.mobyproject.image.parent"
+const (
+	// Digest of the image which was the base image of the committed container.
+	imageLabelClassicBuilderParent = "org.mobyproject.image.parent"
+
+	// ID of the container the image was committed from.
+	imageLabelClassicBuilderContainer = "org.mobyproject.image.container"
+)
 
 // GetImageAndReleasableLayer returns an image and releaseable layer for a
 // reference or ID. Every call to GetImageAndReleasableLayer MUST call
@@ -465,7 +470,8 @@ func (i *ImageService) CreateImage(ctx context.Context, config []byte, parent st
 		Target:    commitManifestDesc,
 		CreatedAt: time.Now(),
 		Labels: map[string]string{
-			imageLabelClassicBuilderParent: parentDigest.String(),
+			imageLabelClassicBuilderParent:    parentDigest.String(),
+			imageLabelClassicBuilderContainer: imgToCreate.Container,
 		},
 	}
 

--- a/daemon/containerd/image_commit.go
+++ b/daemon/containerd/image_commit.go
@@ -109,7 +109,8 @@ func (i *ImageService) CommitImage(ctx context.Context, cc backend.CommitConfig)
 		Target:    commitManifestDesc,
 		CreatedAt: time.Now(),
 		Labels: map[string]string{
-			imageLabelClassicBuilderParent: cc.ParentImageID,
+			imageLabelClassicBuilderParent:    cc.ParentImageID,
+			imageLabelClassicBuilderContainer: cc.ContainerID,
 		},
 	}
 


### PR DESCRIPTION
- depends on: https://github.com/moby/moby/pull/46912

**- What I did**
Store the container ID the image was committed from in containerd image object label.

This fixes `test_commit_with_changes` and partially `test_commit` from  `tests.integration.api_image_test.CommitTest`.

**- How I did it**

**- How to verify it**
docker-py: `test_commit_with_changes` should pass now

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

