### PR TITLE
ci(bin-image): fix conditional run for skipped job

### DIFF
--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -82,6 +82,7 @@ jobs:
     needs:
       - validate-dco
       - prepare
+    if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,6 @@ on:
     branches:
       - 'master'
       - '[0-9]+.[0-9]+'
-    tags:
-      - 'v*'
   pull_request:
 
 env:


### PR DESCRIPTION
follow-up https://github.com/moby/moby/pull/46154#issuecomment-1855789619

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

When the dco job is skipped, the dependent ones will be skipped as well. To fix this issue we need to apply special conditions to always run dependent jobs but not if canceled or failed.

**- How I did it**

**- How to verify it**

See https://github.com/crazy-max/moby/actions/runs/7209189577

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

