### PR TITLE
c8d: Fix image commit with userns mapping

### DIFF
--- a/daemon/containerd/image_snapshot.go
+++ b/daemon/containerd/image_snapshot.go
@@ -17,8 +17,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const remapSuffix = "-remap"
-
 // PrepareSnapshot prepares a snapshot from a parent image for a container
 func (i *ImageService) PrepareSnapshot(ctx context.Context, id string, parentImage string, platform *ocispec.Platform, setupInit func(string) error) error {
 	var parentSnapshot string


### PR DESCRIPTION
**- What I did**

Fixed image commit with userns mapping

The remapping in the commit code was in the wrong place, we would create a diff and then remap the snapshot, but the descriptor created in "CreateDiff" was still pointing to the old snapshot, we now remap the snapshot before creating a diff. Also make sure we don't lose any capabilities, they used to be lost after the chown.

Somewhat related to https://github.com/moby/moby/pull/41724


**- How I did it**

* did the remap before creating a diff on commit
* save the xattrs before chowning the file and resetting them after

**- How to verify it**

The test `TestBuildUserNamespaceValidateCapabilitiesAreV2` should pass now

```console
$ make DOCKER_GRAPHDRIVER=overlayfs TEST_FILTER=TestBuildUserNamespaceValidateCapabilitiesAreV2 TEST_INTEGRATION_USE_SNAPSHOTTER=1 TEST_IGNORE_CGROUP_CHECK=1 test-integration
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

