### PR TITLE
api: Deprecate `Container` and `ContainerConfig` for `/images/{id}/json`

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -338,8 +338,8 @@ func (ir *imageRouter) toImageInspect(img *image.Image) (*types.ImageInspect, er
 		Parent:          img.Parent.String(),
 		Comment:         comment,
 		Created:         created,
-		Container:       img.Container,
-		ContainerConfig: &img.ContainerConfig,
+		Container:       img.Container,        //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.45.
+		ContainerConfig: &img.ContainerConfig, //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.45.
 		DockerVersion:   img.DockerVersion,
 		Author:          img.Author,
 		Config:          img.Config,

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1744,10 +1744,15 @@ definitions:
           The ID of the container that was used to create the image.
 
           Depending on how the image was created, this field may be empty.
+
+          **Deprecated**: this field is kept for backward compatibility, but
+          will be removed in API v1.45.
         type: "string"
-        x-nullable: false
         example: "65974bc86f1770ae4bff79f651ebdbce166ae9aada632ee3fa9af3a264911735"
       ContainerConfig:
+        description: |
+          **Deprecated**: this field is kept for backward compatibility, but
+          will be removed in API v1.45.
         $ref: "#/definitions/ContainerConfig"
       DockerVersion:
         description: |

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -77,6 +77,8 @@ type ImageInspect struct {
 	// Container is the ID of the container that was used to create the image.
 	//
 	// Depending on how the image was created, this field may be empty.
+	//
+	// Deprecated: this field is omitted in API v1.45, but kept for backward compatibility.
 	Container string
 
 	// ContainerConfig is an optional field containing the configuration of the
@@ -84,6 +86,8 @@ type ImageInspect struct {
 	//
 	// Previous versions of Docker builder used this field to store build cache,
 	// and it is not in active use anymore.
+	//
+	// Deprecated: this field is omitted in API v1.45, but kept for backward compatibility.
 	ContainerConfig *container.Config
 
 	// DockerVersion is the version of Docker that was used to build the image.

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -65,6 +65,8 @@ keywords: "API, Docker, rcli, REST, documentation"
   The container-wide `MacAddress` field in `Config`, on `POST /containers/create`, is now deprecated.
 * The field `Networks` in the `POST /services/create` and `POST /services/{id}/update`
   requests is now deprecated. You should instead use the field `TaskTemplate.Networks`.
+* The `Container` and `ContainerConfig` fields in the `GET /images/{name}/json`
+  response are deprecated and will no longer be included in API v1.45.
 
 ## v1.43 API changes
 


### PR DESCRIPTION
- addresses: https://github.com/moby/moby/issues/46804
- replaces: https://github.com/moby/moby/pull/46931

These fields were an implementation detail of the classic image builder and are empty when using buildkit.

Deprecate them in API v1.44 (Moby v25) and schedule their removal for API v1.45 (Moby v26)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
```release-note
- api: Deprecate `Container` and `ContainerConfig` properties for `/images/{id}/json` (`docker image inspect`).
```

**- A picture of a cute animal (not mandatory but encouraged)**

