### PR TITLE
[24.0 backport] registry: allow mirror path prefix in config

### DIFF
--- a/registry/config.go
+++ b/registry/config.go
@@ -328,8 +328,8 @@ func ValidateMirror(val string) (string, error) {
 	if uri.Scheme != "http" && uri.Scheme != "https" {
 		return "", invalidParamf("invalid mirror: unsupported scheme %q in %q", uri.Scheme, uri)
 	}
-	if (uri.Path != "" && uri.Path != "/") || uri.RawQuery != "" || uri.Fragment != "" {
-		return "", invalidParamf("invalid mirror: path, query, or fragment at end of the URI %q", uri)
+	if uri.RawQuery != "" || uri.Fragment != "" {
+		return "", invalidParamf("invalid mirror: query or fragment at end of the URI %q", uri)
 	}
 	if uri.User != nil {
 		// strip password from output

--- a/registry/config_test.go
+++ b/registry/config_test.go
@@ -142,21 +142,21 @@ func TestValidateMirror(t *testing.T) {
 		"https://127.0.0.1",
 		"http://127.0.0.1:5000",
 		"https://127.0.0.1:5000",
+		"http://mirror-1.example.com/v1/",
+		"https://mirror-1.example.com/v1/",
 	}
 
 	invalid := []string{
 		"!invalid!://%as%",
 		"ftp://mirror-1.example.com",
 		"http://mirror-1.example.com/?q=foo",
-		"http://mirror-1.example.com/v1/",
 		"http://mirror-1.example.com/v1/?q=foo",
 		"http://mirror-1.example.com/v1/?q=foo#frag",
 		"http://mirror-1.example.com?q=foo",
 		"https://mirror-1.example.com#frag",
 		"https://mirror-1.example.com/#frag",
 		"http://foo:bar@mirror-1.example.com/",
-		"https://mirror-1.example.com/v1/",
-		"https://mirror-1.example.com/v1/#",
+		"https://mirror-1.example.com/v1/#frag",
 		"https://mirror-1.example.com?q",
 	}
 


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/46594
- closes https://github.com/moby/moby/issues/36598

Path prefixes were originally disallowed in the `--registry-mirrors` option because the /v1 endpoint was assumed to be at the root of the URI. This is no longer the case in v2.


(cherry picked from commit c587ba34229948e5c0b8fdc4bbdb1eaf6727aaa6)



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

