### PR TITLE
[23.0 backport] builder-next: fix timing filter for default policy

### DIFF
--- a/builder/builder-next/worker/gc.go
+++ b/builder/builder-next/worker/gc.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"math"
+	"time"
 
 	"github.com/moby/buildkit/client"
 )
@@ -30,12 +31,12 @@ func DefaultGCPolicy(p string, defaultKeepBytes int64) []client.PruneInfo {
 		// if build cache uses more than 512MB delete the most easily reproducible data after it has not been used for 2 days
 		{
 			Filter:       []string{"type==source.local,type==exec.cachemount,type==source.git.checkout"},
-			KeepDuration: 48 * 3600, // 48h
+			KeepDuration: 48 * time.Hour,
 			KeepBytes:    tempCacheKeepBytes,
 		},
 		// remove any data not used for 60 days
 		{
-			KeepDuration: 60 * 24 * 3600, // 60d
+			KeepDuration: 60 * 24 * time.Hour,
 			KeepBytes:    keep,
 		},
 		// keep the unshared build cache under cap


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/46861

(cherry picked from commit 49d088d9ce62fa86aa08dc05dedc3a3b0746675b)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

