### PR TITLE
[24.0 backport] docs/api: update redirect metadata for hugo

### DIFF
--- a/docs/api/v1.18.md
+++ b/docs/api/v1.18.md
@@ -2,7 +2,7 @@
 title: "Engine API v1.18"
 description: "API Documentation for Docker"
 keywords: "API, Docker, rcli, REST, documentation"
-redirect_from:
+aliases:
 - /engine/reference/api/docker_remote_api_v1.18/
 - /reference/api/docker_remote_api_v1.18/
 ---

--- a/docs/api/v1.19.md
+++ b/docs/api/v1.19.md
@@ -2,7 +2,7 @@
 title: "Engine API v1.19"
 description: "API Documentation for Docker"
 keywords: "API, Docker, rcli, REST, documentation"
-redirect_from:
+aliases:
 - /engine/reference/api/docker_remote_api_v1.19/
 - /reference/api/docker_remote_api_v1.19/
 ---

--- a/docs/api/v1.20.md
+++ b/docs/api/v1.20.md
@@ -2,7 +2,7 @@
 title: "Engine API v1.20"
 description: "API Documentation for Docker"
 keywords: "API, Docker, rcli, REST, documentation"
-redirect_from:
+aliases:
 - /engine/reference/api/docker_remote_api_v1.20/
 - /reference/api/docker_remote_api_v1.20/
 ---

--- a/docs/api/v1.21.md
+++ b/docs/api/v1.21.md
@@ -2,7 +2,7 @@
 title: "Engine API v1.21"
 description: "API Documentation for Docker"
 keywords: "API, Docker, rcli, REST, documentation"
-redirect_from:
+aliases:
 - /engine/reference/api/docker_remote_api_v1.21/
 - /reference/api/docker_remote_api_v1.21/
 ---

--- a/docs/api/v1.22.md
+++ b/docs/api/v1.22.md
@@ -2,7 +2,7 @@
 title: "Engine API v1.22"
 description: "API Documentation for Docker"
 keywords: "API, Docker, rcli, REST, documentation"
-redirect_from:
+aliases:
 - /engine/reference/api/docker_remote_api_v1.22/
 - /reference/api/docker_remote_api_v1.22/
 ---

--- a/docs/api/v1.23.md
+++ b/docs/api/v1.23.md
@@ -2,7 +2,7 @@
 title: "Engine API v1.23"
 description: "API Documentation for Docker"
 keywords: "API, Docker, rcli, REST, documentation"
-redirect_from:
+aliases:
 - /engine/reference/api/docker_remote_api_v1.23/
 - /reference/api/docker_remote_api_v1.23/
 ---

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -2,7 +2,7 @@
 title: "Engine API v1.24"
 description: "API Documentation for Docker"
 keywords: "API, Docker, rcli, REST, documentation"
-redirect_from:
+aliases:
 - /engine/reference/api/docker_remote_api_v1.24/
 - /reference/api/docker_remote_api_v1.24/
 ---


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/46777

docs.docker.com switched from Jekyll to Hugo, which uses "aliases" instead of "redirect_from".


(cherry picked from commit c1a289e05aa00c4c5fd5553ebd74ad93b61e1d87)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

