### PR TITLE
[23.0 backport] daemon/logger/local: always use UTC for timestamps

### DIFF
--- a/daemon/logger/local/local.go
+++ b/daemon/logger/local/local.go
@@ -187,7 +187,7 @@ func messageToProto(msg *logger.Message, proto *logdriver.LogEntry, partial *log
 func protoToMessage(proto *logdriver.LogEntry) *logger.Message {
 	msg := &logger.Message{
 		Source:    proto.Source,
-		Timestamp: time.Unix(0, proto.TimeNano),
+		Timestamp: time.Unix(0, proto.TimeNano).UTC(),
 	}
 	if proto.Partial {
 		var md backend.PartialLogMetaData


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/46913
- fixes https://github.com/moby/moby/issues/46910


When reading logs, timestamps should always be presented in UTC. Unlike the "json-file" and other logging drivers, the "local" logging driver was using local time.

Thanks to Roman Valov for reporting this issue, and locating the bug.

Before this change:

    echo $TZ
    Europe/Amsterdam

    docker run -d --log-driver=local nginx:alpine
    fc166c6b2c35c871a13247dddd95de94f5796459e2130553eee91cac82766af3

    docker logs --timestamps fc166c6b2c35c871a13247dddd95de94f5796459e2130553eee91cac82766af3
    2023-12-08T18:16:56.291023422+01:00 /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
    2023-12-08T18:16:56.291056463+01:00 /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
    2023-12-08T18:16:56.291890130+01:00 /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
    ...

With this patch:

    echo $TZ
    Europe/Amsterdam

    docker run -d --log-driver=local nginx:alpine
    14e780cce4c827ce7861d7bc3ccf28b21f6e460b9bfde5cd39effaa73a42b4d5

    docker logs --timestamps 14e780cce4c827ce7861d7bc3ccf28b21f6e460b9bfde5cd39effaa73a42b4d5
    2023-12-08T17:18:46.635967625Z /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
    2023-12-08T17:18:46.635989792Z /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
    2023-12-08T17:18:46.636897417Z /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
    ...


(cherry picked from commit afe281964d6699e152ef4dfe6c822dc99922e5a5)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

