### PR TITLE
libnetwork: write ServFail if DNS reply msg is bad

### DIFF
--- a/libnetwork/resolver_test.go
+++ b/libnetwork/resolver_test.go
@@ -38,6 +38,10 @@ type tstwriter struct {
 }
 
 func (w *tstwriter) WriteMsg(m *dns.Msg) (err error) {
+	// Assert that the message is serializable.
+	if _, err := m.Pack(); err != nil {
+		return err
+	}
 	w.msg = m
 	return nil
 }

--- a/libnetwork/resolver_test.go
+++ b/libnetwork/resolver_test.go
@@ -86,7 +86,7 @@ func checkDNSAnswersCount(t *testing.T, m *dns.Msg, expected int) {
 func checkDNSResponseCode(t *testing.T, m *dns.Msg, expected int) {
 	t.Helper()
 	if m.MsgHdr.Rcode != expected {
-		t.Fatalf("Expected DNS response code: %d. Found: %d", expected, m.MsgHdr.Rcode)
+		t.Fatalf("Expected DNS response code: %d (%s). Found: %d (%s)", expected, dns.RcodeToString[expected], m.MsgHdr.Rcode, dns.RcodeToString[m.MsgHdr.Rcode])
 	}
 }
 
@@ -358,4 +358,27 @@ func TestProxyNXDOMAIN(t *testing.T) {
 	assert.Assert(t, is.Len(resp.Answer, 0))
 	assert.Assert(t, is.Len(resp.Ns, 1))
 	assert.Equal(t, resp.Ns[0].String(), mockSOA.String())
+}
+
+type ptrDNSBackend struct {
+	noopDNSBackend
+	zone map[string]string
+}
+
+func (b *ptrDNSBackend) ResolveIP(_ context.Context, name string) string {
+	return b.zone[name]
+}
+
+// Regression test for https://github.com/moby/moby/issues/46928
+func TestInvalidReverseDNS(t *testing.T) {
+	rsv := NewResolver("", false, &ptrDNSBackend{zone: map[string]string{"4.3.2.1": "sixtyfourcharslong9012345678901234567890123456789012345678901234"}})
+	rsv.logger = testLogger(t)
+
+	w := &tstwriter{}
+	q := new(dns.Msg).SetQuestion("4.3.2.1.in-addr.arpa.", dns.TypePTR)
+	rsv.serveDNS(w, q)
+	resp := w.GetResponse()
+	checkNonNullResponse(t, resp)
+	t.Log("Response: ", resp.String())
+	checkDNSResponseCode(t, resp, dns.RcodeServerFailure)
 }

--- a/libnetwork/resolver_unix_test.go
+++ b/libnetwork/resolver_unix_test.go
@@ -61,7 +61,7 @@ func TestDNSIPQuery(t *testing.T) {
 
 	// test name1's IP is resolved correctly with the default A type query
 	// Also make sure DNS lookups are case insensitive
-	names := []string{"name1", "NaMe1"}
+	names := []string{"name1.", "NaMe1."}
 	for _, name := range names {
 		q := new(dns.Msg)
 		q.SetQuestion(name, dns.TypeA)
@@ -84,7 +84,7 @@ func TestDNSIPQuery(t *testing.T) {
 
 	// test MX query with name1 results in Success response with 0 answer records
 	q := new(dns.Msg)
-	q.SetQuestion("name1", dns.TypeMX)
+	q.SetQuestion("name1.", dns.TypeMX)
 	r.serveDNS(w, q)
 	resp := w.GetResponse()
 	checkNonNullResponse(t, resp)
@@ -96,7 +96,7 @@ func TestDNSIPQuery(t *testing.T) {
 	// test MX query with non existent name results in ServFail response with 0 answer records
 	// since this is a unit test env, we disable proxying DNS above which results in ServFail rather than NXDOMAIN
 	q = new(dns.Msg)
-	q.SetQuestion("nonexistent", dns.TypeMX)
+	q.SetQuestion("nonexistent.", dns.TypeMX)
 	r.serveDNS(w, q)
 	resp = w.GetResponse()
 	checkNonNullResponse(t, resp)


### PR DESCRIPTION
- Relates to #46928 

If the resolver's DNSBackend returns a name that cannot be marshaled into a well-formed DNS message, the resolver will only discover this when it attempts to write the reply message and it fails with an error. No reply message is sent, leaving the client to wait out its timeout and the user in the dark about what went wrong.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Make a best-effort attempt to inform the client of the failure.

**- How I did it**

When writing the intended reply message fails, retry once with a ServFail response to inform the client and user that the DNS query was not resolved due to a problem with to the resolver, not the network.

**- How to verify it**

New unit test.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- The container DNS resolver will send ServFail replies instead of failing silently in more situations.

**- A picture of a cute animal (not mandatory but encouraged)**

