### PR TITLE
c8d/docker-py: Temporarily skip test_save_and_load*

### DIFF
--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -18,6 +18,10 @@ source hack/make/.integration-test-helpers
 # build --squash is not supported with containerd integration.
 if [ -n "$TEST_INTEGRATION_USE_SNAPSHOTTER" ]; then
 	PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/api_build_test.py::BuildTest::test_build_squash"
+
+	# TODO(vvoland): re-enable after https://github.com/containerd/containerd/pull/9554 is merged and vendored.
+	PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/models_images_test.py::ImageCollectionTest::test_save_and_load"
+	PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/models_images_test.py::ImageCollectionTest::test_save_and_load_repo_name"
 fi
 (
 	bundle .integration-daemon-start


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/46760


They fail because exporting an image which targets a manifest list when only one platform is available exports only the platform-specific manifest and the ID of the loaded image is different (ID of the platform manifest, not manifest list).

They will be reenabled once we have the containerd changes which allow loading archives containing a manifest list referencing platforms that are not included in the archive.