### PR TITLE
ci(bin-image): fix merge job run condition

### DIFF
--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -144,9 +144,9 @@ jobs:
 
   merge:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'pull_request' && github.repository == 'moby/moby'
     needs:
       - build
+    if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && github.event_name != 'pull_request' && github.repository == 'moby/moby'
     steps:
       -
         name: Download meta bake definition

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ on:
     branches:
       - 'master'
       - '[0-9]+.[0-9]+'
-    tags:
-      - 'v*'
   pull_request:
 
 env:


### PR DESCRIPTION
**- What I did**

All underlying jobs inherit from the status of all parent jobs in the tree, not just the very first parent. We need to apply the same kind of special condition as #46936 in the merge job.

Also remove push tag event from ci workflow similar to https://github.com/moby/moby/pull/46936#discussion_r1426884190.

**- How I did it**

**- How to verify it**

See https://github.com/crazy-max/moby/actions/runs/7290417584

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

