### PR TITLE
Updated manifest v2 URLs in image spec README

### DIFF
--- a/image/spec/README.md
+++ b/image/spec/README.md
@@ -16,7 +16,7 @@ for an in-depth specification of the OCI Image specs.
 The v1 file layout and manifests are no longer used in Moby and Docker, except in `docker save` and `docker load`.
 
 However, v1 Image JSON (`application/vnd.docker.container.image.v1+json`) has been still widely
-used and officially adopted in [V2 manifest](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md)
+used and officially adopted in [V2 manifest](https://github.com/distribution/distribution/blob/main/docs/content/spec/manifest-v2-2.md)
 and in [OCI Image Format Specification](https://github.com/opencontainers/image-spec).
 
 ## v1.X rough Changelog
@@ -60,6 +60,6 @@ Changes:
 ## Related specifications
 
 * [Open Containers Initiative (OCI) Image Format Specification v1.0.0](https://github.com/opencontainers/image-spec/tree/v1.0.0)
-* [Docker Image Manifest Version 2, Schema 2](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md)
-* [Docker Image Manifest Version 2, Schema 1](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-1.md) (*DEPRECATED*)
+* [Docker Image Manifest Version 2, Schema 2](https://github.com/distribution/distribution/blob/main/docs/content/spec/manifest-v2-2.md)
+* [Docker Image Manifest Version 2, Schema 1](https://github.com/distribution/distribution/blob/main/docs/content/spec/deprecated-schema-v1.md) (*DEPRECATED*)
 * [Docker Registry HTTP API V2](https://docs.docker.com/registry/spec/api/)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I updated the URLs for the image manifest v2 spec to point to their current locations.

**- How I did it**

I followed the current links, observed they were no longer valid, and located the new locations of the intended content.

**- How to verify it**

Follow the updated links, observing that they point to real paths within the `distribution` repository.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Updated manifest v2 URLs in image spec README

**- A picture of a cute animal (not mandatory but encouraged)**

 \/\\_\/\\ 
( o.o ) 
 \> ^ <