### PR TITLE
Move StartedAt time to before starting the container

### DIFF
--- a/container/state.go
+++ b/container/state.go
@@ -268,13 +268,23 @@ func (s *State) SetExitCode(ec int) {
 	s.ExitCodeValue = ec
 }
 
-// SetRunning sets the state of the container to "running".
-func (s *State) SetRunning(ctr libcontainerdtypes.Container, tsk libcontainerdtypes.Task, initial bool) {
+// SetRunning sets the running state along with StartedAt time.
+func (s *State) SetRunning(ctr libcontainerdtypes.Container, tsk libcontainerdtypes.Task, start time.Time) {
+	s.setRunning(ctr, tsk, &start)
+}
+
+// SetRunningExternal sets the running state without setting the `StartedAt` time (used for containers not started by Docker instead of SetRunning).
+func (s *State) SetRunningExternal(ctr libcontainerdtypes.Container, tsk libcontainerdtypes.Task) {
+	s.setRunning(ctr, tsk, nil)
+}
+
+// setRunning sets the state of the container to "running".
+func (s *State) setRunning(ctr libcontainerdtypes.Container, tsk libcontainerdtypes.Task, start *time.Time) {
 	s.ErrorMsg = ""
 	s.Paused = false
 	s.Running = true
 	s.Restarting = false
-	if initial {
+	if start != nil {
 		s.Paused = false
 	}
 	s.ExitCodeValue = 0
@@ -286,8 +296,8 @@ func (s *State) SetRunning(ctr libcontainerdtypes.Container, tsk libcontainerdty
 		s.Pid = 0
 	}
 	s.OOMKilled = false
-	if initial {
-		s.StartedAt = time.Now().UTC()
+	if start != nil {
+		s.StartedAt = start.UTC()
 	}
 }
 

--- a/container/state_test.go
+++ b/container/state_test.go
@@ -68,7 +68,7 @@ func TestStateRunStop(t *testing.T) {
 
 		// Set the state to "Running".
 		s.Lock()
-		s.SetRunning(nil, &mockTask{pid: uint32(i)}, true)
+		s.SetRunning(nil, &mockTask{pid: uint32(i)}, time.Now())
 		s.Unlock()
 
 		// Assert desired state.
@@ -133,7 +133,7 @@ func TestStateTimeoutWait(t *testing.T) {
 	s := NewState()
 
 	s.Lock()
-	s.SetRunning(nil, nil, true)
+	s.SetRunning(nil, nil, time.Now())
 	s.Unlock()
 
 	// Start a wait with a timeout.
@@ -182,7 +182,7 @@ func TestCorrectStateWaitResultAfterRestart(t *testing.T) {
 	s := NewState()
 
 	s.Lock()
-	s.SetRunning(nil, nil, true)
+	s.SetRunning(nil, nil, time.Now())
 	s.Unlock()
 
 	waitC := s.Wait(context.Background(), WaitConditionNotRunning)
@@ -193,7 +193,7 @@ func TestCorrectStateWaitResultAfterRestart(t *testing.T) {
 	s.Unlock()
 
 	s.Lock()
-	s.SetRunning(nil, nil, true)
+	s.SetRunning(nil, nil, time.Now())
 	s.Unlock()
 
 	got := <-waitC

--- a/daemon/delete_test.go
+++ b/daemon/delete_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types/backend"
 	containertypes "github.com/docker/docker/api/types/container"
@@ -52,7 +53,7 @@ func TestContainerDelete(t *testing.T) {
 			errMsg: "container is restarting: stop the container before removing or force remove",
 			initContainer: func() *container.Container {
 				c := newContainerWithState(container.NewState())
-				c.SetRunning(nil, nil, true)
+				c.SetRunning(nil, nil, time.Now())
 				c.SetRestarting(&container.ExitStatus{})
 				return c
 			},

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -254,7 +254,7 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerdtypes.EventType, ei
 				}
 				return err
 			}
-			c.SetRunning(ctr, tsk, false)
+			c.SetRunningExternal(ctr, tsk)
 			c.HasBeenManuallyStopped = false
 			c.HasBeenStartedBefore = true
 			daemon.setStateCounter(c)

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -199,6 +199,7 @@ func (daemon *Daemon) containerStart(ctx context.Context, daemonCfg *configStore
 		return setExitCodeFromError(container.SetExitCode, err)
 	}
 
+	startupTime := time.Now()
 	// TODO(mlaventure): we need to specify checkpoint options here
 	tsk, err := ctr.Start(context.TODO(), // Passing ctx to ctr.Start caused integration tests to be stuck in the cleanup phase
 		checkpointDir, container.StreamConfig.Stdin() != nil || container.Config.Tty,
@@ -212,7 +213,7 @@ func (daemon *Daemon) containerStart(ctx context.Context, daemonCfg *configStore
 	}
 
 	container.HasBeenManuallyRestarted = false
-	container.SetRunning(ctr, tsk, true)
+	container.SetRunning(ctr, tsk, startupTime)
 	container.HasBeenStartedBefore = true
 	daemon.setStateCounter(container)
 

--- a/integration/container/daemon_linux_test.go
+++ b/integration/container/daemon_linux_test.go
@@ -256,7 +256,7 @@ func TestHardRestartWhenContainerIsRunning(t *testing.T) {
 
 	for _, id := range []string{noPolicy, onFailure} {
 		d.TamperWithContainerConfig(t, id, func(c *realcontainer.Container) {
-			c.SetRunning(nil, nil, true)
+			c.SetRunning(nil, nil, time.Now())
 			c.HasBeenStartedBefore = true
 		})
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Fixes #45445

**- What I did**
Moby reports the StartedAt and FinishedAt times of containers. The StartedAt time is inaccurate as it is set too late in the container startup process, being set way past the moment the container is started. This not only makes the StartedAt be reported as relatively late, and the difference between StartedAt and FinishedAt be too optimistic, but with very short-lived containers the StartedAt is reported later than the FinishedAt, meaning the container took a negative amount of time to complete.

This MR moves the StartedAt time recording to right before the container is told to start. This makes the code slightly more complex, as the StartedAt time now has to be passed to the moment it can be recorded, but improves the accuracy of the StartedAt time.

Hello-world prior to the change:
"StartedAt": "2023-12-28T22:15:43.373989192Z",
"FinishedAt": "2023-12-28T22:15:43.373677346Z"

Hello-world after the change:
"StartedAt": "2023-12-30T14:19:39.241397794Z",
"FinishedAt": "2023-12-30T14:19:39.423867882Z"

**- How I did it**
I record the start time using time.Now() right before `ctr.Start`. I then pass this variable to the `SetRunning` function, which is called later and actually records the StartedAt time. Previously, this time was generated within the SetRunning function. For all unit tests and the health monitor, I simply generate the time right on the function call (So I pass time.Now() as a parameter). For unit tests, the StartedAt time doesn't matter, and for the monitor, I could not find a better place to record the time prior to SetRunning.

**- How to verify it**
- Run tests to verify that tests have been properly adapted to this new parameter.
- Include the built version in dockerd using this process: https://github.com/moby/moby/blob/master/docs/contributing/set-up-dev-env.md. Then you can run containers and see the StartedAt and FinishedAt times using `docker inspect`.

**- Description for the changelog**
```markdown changelog
Container's `StartedAt` property is now recorded before container startup, guaranteeing that the `StartedAt` is always before `FinishedAt`.
```


**- A picture of a cute animal (not mandatory but encouraged)**
![20170629_165245](https://github.com/moby/moby/assets/60571459/367e7293-70c3-4c48-aef4-739d881278f2)
