### PR TITLE
libnetwork/portallocator: PortAllocator.ReleasePort: remove unused err-return

### DIFF
--- a/libnetwork/portallocator/portallocator.go
+++ b/libnetwork/portallocator/portallocator.go
@@ -154,7 +154,7 @@ func (p *PortAllocator) RequestPortInRange(ip net.IP, proto string, portStart, p
 }
 
 // ReleasePort releases port from global ports pool for specified ip and proto.
-func (p *PortAllocator) ReleasePort(ip net.IP, proto string, port int) error {
+func (p *PortAllocator) ReleasePort(ip net.IP, proto string, port int) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
@@ -163,10 +163,9 @@ func (p *PortAllocator) ReleasePort(ip net.IP, proto string, port int) error {
 	}
 	protomap, ok := p.ipMap[ip.String()]
 	if !ok {
-		return nil
+		return
 	}
 	delete(protomap[proto].p, port)
-	return nil
 }
 
 func (p *PortAllocator) newPortMap() *portMap {

--- a/libnetwork/portallocator/portallocator_test.go
+++ b/libnetwork/portallocator/portallocator_test.go
@@ -48,9 +48,7 @@ func TestReleasePort(t *testing.T) {
 		t.Fatalf("Expected port 5000 got %d", port)
 	}
 
-	if err := p.ReleasePort(defaultIP, "tcp", 5000); err != nil {
-		t.Fatal(err)
-	}
+	p.ReleasePort(defaultIP, "tcp", 5000)
 }
 
 func TestReuseReleasedPort(t *testing.T) {
@@ -65,9 +63,7 @@ func TestReuseReleasedPort(t *testing.T) {
 		t.Fatalf("Expected port 5000 got %d", port)
 	}
 
-	if err := p.ReleasePort(defaultIP, "tcp", 5000); err != nil {
-		t.Fatal(err)
-	}
+	p.ReleasePort(defaultIP, "tcp", 5000)
 
 	port, err = p.RequestPort(defaultIP, "tcp", 5000)
 	if err != nil {
@@ -131,9 +127,7 @@ func TestAllocateAllPorts(t *testing.T) {
 
 	// release a port in the middle and ensure we get another tcp port
 	port := p.Begin + 5
-	if err := p.ReleasePort(defaultIP, "tcp", port); err != nil {
-		t.Fatal(err)
-	}
+	p.ReleasePort(defaultIP, "tcp", port)
 	newPort, err := p.RequestPort(defaultIP, "tcp", 0)
 	if err != nil {
 		t.Fatal(err)
@@ -144,9 +138,7 @@ func TestAllocateAllPorts(t *testing.T) {
 
 	// now pm.last == newPort, release it so that it's the only free port of
 	// the range, and ensure we get it back
-	if err := p.ReleasePort(defaultIP, "tcp", newPort); err != nil {
-		t.Fatal(err)
-	}
+	p.ReleasePort(defaultIP, "tcp", newPort)
 	port, err = p.RequestPort(defaultIP, "tcp", 0)
 	if err != nil {
 		t.Fatal(err)
@@ -215,9 +207,7 @@ func TestPortAllocation(t *testing.T) {
 	if _, err := p.RequestPort(ip2, "tcp", 80); err == nil {
 		t.Fatalf("Acquiring a port already in use should return an error")
 	}
-	if err := p.ReleasePort(ip, "tcp", 80); err != nil {
-		t.Fatal(err)
-	}
+	p.ReleasePort(ip, "tcp", 80)
 	if _, err := p.RequestPort(ip, "tcp", 80); err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/portmapper/mapper.go
+++ b/libnetwork/portmapper/mapper.go
@@ -211,16 +211,19 @@ func (pm *PortMapper) Unmap(host net.Addr) error {
 
 	switch a := host.(type) {
 	case *net.TCPAddr:
-		return pm.allocator.ReleasePort(a.IP, "tcp", a.Port)
+		pm.allocator.ReleasePort(a.IP, "tcp", a.Port)
 	case *net.UDPAddr:
-		return pm.allocator.ReleasePort(a.IP, "udp", a.Port)
+		pm.allocator.ReleasePort(a.IP, "udp", a.Port)
 	case *sctp.SCTPAddr:
 		if len(a.IPAddrs) == 0 {
 			return ErrSCTPAddrNoIP
 		}
-		return pm.allocator.ReleasePort(a.IPAddrs[0].IP, "sctp", a.Port)
+		pm.allocator.ReleasePort(a.IPAddrs[0].IP, "sctp", a.Port)
+	default:
+		return ErrUnknownBackendAddressType
 	}
-	return ErrUnknownBackendAddressType
+
+	return nil
 }
 
 // ReMapAll re-applies all port mappings


### PR DESCRIPTION
- [x] follow-up to https://github.com/moby/moby/pull/47001

### libnetwork/portallocator: PortAllocator.ReleasePort: remove unused err-return

This function never returned an error, and was not matching an interface, so
remove the error-return.



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

