### PR TITLE
update runc binary to v1.1.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -283,7 +283,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged. When updating RUNC_VERSION,
 # consider updating runc in vendor.mod accordingly.
-ARG RUNC_VERSION=v1.1.10
+ARG RUNC_VERSION=v1.1.11
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=v1.1.10}"
+: "${RUNC_VERSION:=v1.1.11}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"


### PR DESCRIPTION
This is the eleventh patch release in the 1.1.z release branch of runc. It primarily fixes a few issues with runc's handling of containers that are configured to join existing user namespaces, as well as improvements to cgroupv2 support.

- Fix several issues with userns path handling.
- Support memory.peak and memory.swap.peak in cgroups v2. Add swapOnlyUsage in MemoryStats. This field reports swap-only usage. For cgroupv1, Usage and Failcnt are set by subtracting memory usage from memory+swap usage. For cgroupv2, Usage, Limit, and MaxUsage are set.
- build(deps): bump github.com/cyphar/filepath-securejoin.

- release notes: https://github.com/opencontainers/runc/releases/tag/v1.1.11
- full diff: https://github.com/opencontainers/runc/compare/v1.1.10...v1.1.11


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

