### PR TITLE
daemon: remove dead code relying on SecondaryIPAddress

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -71,16 +71,6 @@ func (daemon *Daemon) buildSandboxOptions(cfg *config.Config, container *contain
 		sboxOptions = append(sboxOptions, libnetwork.OptionDNSOptions(cfg.DNSOptions))
 	}
 
-	if container.NetworkSettings.SecondaryIPAddresses != nil {
-		name := container.Config.Hostname
-		if container.Config.Domainname != "" {
-			name = name + "." + container.Config.Domainname
-		}
-		for _, a := range container.NetworkSettings.SecondaryIPAddresses {
-			sboxOptions = append(sboxOptions, libnetwork.OptionExtraHost(name, a.Addr))
-		}
-	}
-
 	for _, extraHost := range container.HostConfig.ExtraHosts {
 		// allow IPv6 addresses in extra hosts; only split on first ":"
 		if _, err := opts.ValidateExtraHost(extraHost); err != nil {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/16282
- extracted from https://github.com/moby/moby/pull/45945

Since commit d0e0c13b60 (https://github.com/moby/moby/pull/16282), `NetworkSettings.SecondaryAddress` is never written.


**- A picture of a cute animal (not mandatory but encouraged)**

