### PR TITLE
pkg/ioutils: Fix double close in `CancelReadCloser`

### DIFF
--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -239,8 +239,9 @@ func (ld *layerDescriptor) Download(ctx context.Context, progressOutput progress
 		}
 	}
 
-	reader := progress.NewProgressReader(ioutils.NewCancelReadCloser(ctx, layerDownload), progressOutput, size-offset, ld.ID(), "Downloading")
-	defer reader.Close()
+	readerCtx, cancelReader := context.WithCancel(ctx)
+	reader := progress.NewProgressReader(ioutils.NewCancelReadCloser(readerCtx, layerDownload), progressOutput, size-offset, ld.ID(), "Downloading")
+	defer cancelReader()
 
 	if ld.verifier == nil {
 		ld.verifier = ld.digest.Verifier()

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -335,8 +335,9 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				parentLayer = l.ChainID()
 			}
 
-			reader := progress.NewProgressReader(ioutils.NewCancelReadCloser(d.transfer.context(), downloadReader), progressOutput, size, descriptor.ID(), "Extracting")
-			defer reader.Close()
+			readerCtx, cancel := context.WithCancel(d.transfer.context())
+			reader := progress.NewProgressReader(ioutils.NewCancelReadCloser(readerCtx, downloadReader), progressOutput, size, descriptor.ID(), "Extracting")
+			defer cancel()
 
 			inflatedLayerData, err := archive.DecompressStream(reader)
 			if err != nil {

--- a/pkg/ioutils/readers.go
+++ b/pkg/ioutils/readers.go
@@ -117,13 +117,10 @@ func NewCancelReadCloser(ctx context.Context, in io.ReadCloser) io.ReadCloser {
 		in.Close()
 	}()
 	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				p.closeWithError(ctx.Err())
-			case <-doneCtx.Done():
-				return
-			}
+		select {
+		case <-ctx.Done():
+			p.closeWithError(ctx.Err())
+		case <-doneCtx.Done():
 		}
 	}()
 


### PR DESCRIPTION
- follow up to: https://github.com/moby/moby/pull/46419

**- What I did**

**distribution: Fix double close**

Instead of closing the reader directly, cancel the context so that only
the CancelReadCloser invokes the close directly.

**pkg/ioutils: Fix possible double close in CancelReadCloser**

Picking the `select` branch is not deterministic - after `ctx.Done` is
closed and `doneCtx.Done` gets closed before the `select` block is
reached again there's no guarantee that the `doneCtx` case will be
picked and the `closeWithError` may be invoked again.

Remove the loop and exit the goroutine as soon as any of these contexts
is cancelled. `doneCtx` will only be cancelled by the `closeWithError`
so there's no need to call it again.


**- How to verify it**
```diff
+++ with https://github.com/moby/moby/pull/46419
--- with https://github.com/moby/moby/pull/46419 and this PR
$ go test ./pkg/ioutils -count 10 -v | grep 'subsequent attempt to close'
+time="2024-01-03T13:45:07+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
+time="2024-01-03T13:45:07+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
+time="2024-01-03T13:45:07+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
+time="2024-01-03T13:45:07+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
+time="2024-01-03T13:45:08+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
+time="2024-01-03T13:45:08+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
+time="2024-01-03T13:45:08+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
+time="2024-01-03T13:45:08+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
+time="2024-01-03T13:45:08+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
+time="2024-01-03T13:45:08+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
+time="2024-01-03T13:45:09+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
+time="2024-01-03T13:45:09+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
-time="2024-01-03T13:45:07+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
-time="2024-01-03T13:45:07+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
-time="2024-01-03T13:45:07+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
-time="2024-01-03T13:45:07+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
-time="2024-01-03T13:45:08+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
-time="2024-01-03T13:45:08+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
-time="2024-01-03T13:45:08+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
-time="2024-01-03T13:45:08+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
-time="2024-01-03T13:45:08+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
-time="2024-01-03T13:45:08+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
-time="2024-01-03T13:45:09+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
-time="2024-01-03T13:45:09+01:00" level=error msg="subsequent attempt to close cancelReadCloser"
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

