### PR TITLE
daemon: work around go1.21 compiler bug

### DIFF
--- a/daemon/info.go
+++ b/daemon/info.go
@@ -351,11 +351,14 @@ func getConfigOrEnv(config string, env ...string) string {
 	return getEnvAny(env...)
 }
 
-// promoteNil converts a nil slice to an empty slice of that type.
+// promoteNil converts a nil slice to an empty slice.
 // A non-nil slice is returned as is.
-func promoteNil[S ~[]E, E any](s S) S {
+//
+// TODO: make generic again once we are a go module,
+// go.dev/issue/64759 is fixed, or we drop support for Go 1.21.
+func promoteNil(s []string) []string {
 	if s == nil {
-		return S{}
+		return []string{}
 	}
 	return s
 }


### PR DESCRIPTION
- taken from https://github.com/moby/moby/pull/46941
- relates to https://github.com/moby/moby/pull/46942
- relates to https://github.com/golang/go/issues/64759


The Go 1.21.5 compiler has a bug: per-file language version override directives do not take effect when instantiating generic functions which have certain nontrivial type constraints. Consequently, a module-mode project with Moby as a dependency may fail to compile when the compiler incorrectly applies go1.16 semantics to the generic function call.

As the offending function is trivial and is only used in one place, work around the issue by converting it to a concretely-typed function.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

