### PR TITLE
libnet/d/bridge: dead code: no conflict on stale default nw 

### DIFF
--- a/libnetwork/drivers/bridge/errors.go
+++ b/libnetwork/drivers/bridge/errors.go
@@ -104,17 +104,6 @@ func (uat ErrUnsupportedAddressType) Error() string {
 // InvalidParameter denotes the type of this error
 func (uat ErrUnsupportedAddressType) InvalidParameter() {}
 
-// ActiveEndpointsError is returned when there are
-// still active endpoints in the network being deleted.
-type ActiveEndpointsError string
-
-func (aee ActiveEndpointsError) Error() string {
-	return fmt.Sprintf("network %s has active endpoint", string(aee))
-}
-
-// Forbidden denotes the type of this error
-func (aee ActiveEndpointsError) Forbidden() {}
-
 // InvalidNetworkIDError is returned when the passed
 // network id for an existing network is not a known id.
 type InvalidNetworkIDError string


### PR DESCRIPTION
**- What I did**

**libnet/d/bridge: remove dead ActiveEndpointsError**

This error is unused since https://github.com/moby/libnetwork/commit/6b158eac6.

**libnet/d/bridge: dead code: no conflict on stale default nw**

A check was added to the bridge driver to detect when it was called to create the default bridge nw whereas a stale default bridge already existed. In such case, the bridge driver was deleting the stale network before re-creating it. This check was introduced in https://github.com/moby/libnetwork/commit/6b158eac6a4877c27828f524ad1ca0ea4bd2a789 to fix an issue related to newly introduced live-restore.

However, since commit https://github.com/moby/moby/commit/ecffb6d58cf89371e3f4a20f55c2e614dbdfe880, the daemon doesn't even try to create default networks if there're active sandboxes (ie. due to live-restore).

Thus, now it's impossible for the default bridge network to be stale and to exists when the driver's CreateNetwork() method is called. As such, the check introduced in the first commit mentioned above is dead code and can be safely removed.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://www.lightstalking.com/wp-content/uploads/photo-by-jan-kopriva-2-compress.jpg)
