### PR TITLE
api: fix "GET /distribution" endpoint ignoring mirrors

### DIFF
--- a/api/server/router/distribution/backend.go
+++ b/api/server/router/distribution/backend.go
@@ -11,5 +11,5 @@ import (
 // Backend is all the methods that need to be implemented
 // to provide image specific functionality.
 type Backend interface {
-	GetRepository(context.Context, reference.Named, *registry.AuthConfig) (distribution.Repository, error)
+	GetRepositories(context.Context, reference.Named, *registry.AuthConfig) ([]distribution.Repository, error)
 }

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -78,5 +78,6 @@ type VolumeBackend interface {
 type ImageBackend interface {
 	PullImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
 	GetRepository(context.Context, reference.Named, *registry.AuthConfig) (distribution.Repository, error)
+	GetRepositories(context.Context, reference.Named, *registry.AuthConfig) ([]distribution.Repository, error)
 	GetImage(ctx context.Context, refOrID string, options opts.GetImageOpts) (*image.Image, error)
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1595,3 +1595,19 @@ func (i *imageBackend) GetRepository(ctx context.Context, ref reference.Named, a
 		},
 	})
 }
+
+// GetRepositories returns a list of repositories configured for the given
+// reference. Multiple repositories can be returned if the reference is for
+// the default (Docker Hub) registry and a mirror is configured, but it omits
+// registries that were not reachable (pinging the /v2/ endpoint failed).
+//
+// It returns an error if it was unable to reach any of the registries for
+// the given reference, or if the provided reference is invalid.
+func (i *imageBackend) GetRepositories(ctx context.Context, ref reference.Named, authConfig *registrytypes.AuthConfig) ([]dist.Repository, error) {
+	return distribution.GetRepositories(ctx, ref, &distribution.ImagePullConfig{
+		Config: distribution.Config{
+			AuthConfig:      authConfig,
+			RegistryService: i.registryService,
+		},
+	})
+}

--- a/distribution/repository.go
+++ b/distribution/repository.go
@@ -3,6 +3,7 @@ package distribution
 import (
 	"context"
 
+	"github.com/containerd/log"
 	"github.com/distribution/reference"
 	"github.com/docker/distribution"
 	"github.com/docker/docker/errdefs"
@@ -10,6 +11,25 @@ import (
 
 // GetRepository returns a repository from the registry.
 func GetRepository(ctx context.Context, ref reference.Named, config *ImagePullConfig) (repository distribution.Repository, lastError error) {
+	repos, err := getRepositories(ctx, ref, config, true)
+	if len(repos) == 0 {
+		return nil, err
+	}
+	return repos[0], nil
+}
+
+// GetRepositories returns a list of repositories configured for the given
+// reference. Multiple repositories can be returned if the reference is for
+// the default (Docker Hub) registry and a mirror is configured, but it omits
+// registries that were not reachable (pinging the /v2/ endpoint failed).
+//
+// It returns an error if it was unable to reach any of the registries for
+// the given reference, or if the provided reference is invalid.
+func GetRepositories(ctx context.Context, ref reference.Named, config *ImagePullConfig) ([]distribution.Repository, error) {
+	return getRepositories(ctx, ref, config, false)
+}
+
+func getRepositories(ctx context.Context, ref reference.Named, config *ImagePullConfig, firstOnly bool) ([]distribution.Repository, error) {
 	repoInfo, err := config.RegistryService.ResolveRepository(ref)
 	if err != nil {
 		return nil, errdefs.InvalidParameter(err)
@@ -24,11 +44,24 @@ func GetRepository(ctx context.Context, ref reference.Named, config *ImagePullCo
 		return nil, err
 	}
 
+	var (
+		repositories []distribution.Repository
+		lastError    error
+	)
 	for _, endpoint := range endpoints {
-		repository, lastError = newRepository(ctx, repoInfo, endpoint, nil, config.AuthConfig, "pull")
-		if lastError == nil {
-			break
+		repo, err := newRepository(ctx, repoInfo, endpoint, nil, config.AuthConfig, "pull")
+		if err != nil {
+			log.G(ctx).WithFields(log.Fields{"endpoint": endpoint.URL.String(), "error": err}).Info("endpoint")
+			lastError = err
+			continue
+		}
+		repositories = append(repositories, repo)
+		if firstOnly {
+			return repositories, nil
 		}
 	}
-	return repository, lastError
+	if len(repositories) == 0 {
+		return nil, lastError
+	}
+	return repositories, nil
 }


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/47012

If the daemon is configured to use a mirror for the default (Docker Hub) registry, the endpoint did not fall back to querying the upstream if the mirror did not contain the given reference.

If the daemon is configured to use a mirror for the default (Docker Hub) registry, did not fall back to querying the upstream if the mirror did not contain the given reference.

For pull-through registry-mirrors, this was not a problem, as in that case the registry would forward the request, but for other mirrors, no fallback would happen. This was inconsistent with how "pulling" images handled this situation; when pulling images, both the mirror and upstream would be tried.

This problem was caused by the logic used in GetRepository, which had an optimization to only return the first registry it was successfully able to configure (and connect to), with the assumption that the mirror either contained all images used, or to be configured as a pull-through mirror.

This patch:

- Introduces a GetRepositories method, which returns all candidates (both mirror(s) and upstream).
- Updates the endpoint to try all

Before this patch:

    # the daemon is configured to use a mirror for Docker Hub
    cat /etc/docker/daemon.json
    { "registry-mirrors": ["http://localhost:5000"]}

    # start the mirror (empty registry, not configured as pull-through mirror)
    docker run -d --name registry -p 127.0.0.1:5000:5000 registry:2

    # querying the endpoint fails, because the image-manifest is not found in the mirror:
    curl -s --unix-socket /var/run/docker.sock http://localhost/v1.43/distribution/docker.io/library/hello-world:latest/json
    {
      "message": "manifest unknown: manifest unknown"
    }

With this patch applied:

    # the daemon is configured to use a mirror for Docker Hub
    cat /etc/docker/daemon.json
    { "registry-mirrors": ["http://localhost:5000"]}

    # start the mirror (empty registry, not configured as pull-through mirror)
    docker run -d --name registry -p 127.0.0.1:5000:5000 registry:2

    # querying the endpoint succeeds (manifest is fetched from the upstream Docker Hub registry):
    curl -s --unix-socket /var/run/docker.sock http://localhost/v1.43/distribution/docker.io/library/hello-world:latest/json | jq .
    {
      "Descriptor": {
        "mediaType": "application/vnd.oci.image.index.v1+json",
        "digest": "sha256:1b9844d846ce3a6a6af7013e999a373112c3c0450aca49e155ae444526a2c45e",
        "size": 3849
      },
      "Platforms": [
        {
          "architecture": "amd64",
          "os": "linux"
        }
      ]
    }



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
Fix "GET /distribution" endpoint ignoring mirrors when resolving image manifests.
```

**- A picture of a cute animal (not mandatory but encouraged)**

