### PR TITLE
daemon/cluster: Cluster.imageWithDigestString: include mirrors to resolve digest

### DIFF
--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -77,7 +77,6 @@ type VolumeBackend interface {
 // ImageBackend is used by an executor to perform image operations
 type ImageBackend interface {
 	PullImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
-	GetRepository(context.Context, reference.Named, *registry.AuthConfig) (distribution.Repository, error)
 	GetRepositories(context.Context, reference.Named, *registry.AuthConfig) ([]distribution.Repository, error)
 	GetImage(ctx context.Context, refOrID string, options opts.GetImageOpts) (*image.Image, error)
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1586,16 +1586,6 @@ type imageBackend struct {
 	registryService *registry.Service
 }
 
-// GetRepository returns a repository from the registry.
-func (i *imageBackend) GetRepository(ctx context.Context, ref reference.Named, authConfig *registrytypes.AuthConfig) (dist.Repository, error) {
-	return distribution.GetRepository(ctx, ref, &distribution.ImagePullConfig{
-		Config: distribution.Config{
-			AuthConfig:      authConfig,
-			RegistryService: i.registryService,
-		},
-	})
-}
-
 // GetRepositories returns a list of repositories configured for the given
 // reference. Multiple repositories can be returned if the reference is for
 // the default (Docker Hub) registry and a mirror is configured, but it omits

--- a/distribution/repository.go
+++ b/distribution/repository.go
@@ -9,15 +9,6 @@ import (
 	"github.com/docker/docker/errdefs"
 )
 
-// GetRepository returns a repository from the registry.
-func GetRepository(ctx context.Context, ref reference.Named, config *ImagePullConfig) (repository distribution.Repository, lastError error) {
-	repos, err := getRepositories(ctx, ref, config, true)
-	if len(repos) == 0 {
-		return nil, err
-	}
-	return repos[0], nil
-}
-
 // GetRepositories returns a list of repositories configured for the given
 // reference. Multiple repositories can be returned if the reference is for
 // the default (Docker Hub) registry and a mirror is configured, but it omits
@@ -26,10 +17,6 @@ func GetRepository(ctx context.Context, ref reference.Named, config *ImagePullCo
 // It returns an error if it was unable to reach any of the registries for
 // the given reference, or if the provided reference is invalid.
 func GetRepositories(ctx context.Context, ref reference.Named, config *ImagePullConfig) ([]distribution.Repository, error) {
-	return getRepositories(ctx, ref, config, false)
-}
-
-func getRepositories(ctx context.Context, ref reference.Named, config *ImagePullConfig, firstOnly bool) ([]distribution.Repository, error) {
 	repoInfo, err := config.RegistryService.ResolveRepository(ref)
 	if err != nil {
 		return nil, errdefs.InvalidParameter(err)
@@ -56,9 +43,6 @@ func getRepositories(ctx context.Context, ref reference.Named, config *ImagePull
 			continue
 		}
 		repositories = append(repositories, repo)
-		if firstOnly {
-			return repositories, nil
-		}
 	}
 	if len(repositories) == 0 {
 		return nil, lastError


### PR DESCRIPTION
- [x] follow-up to / depends on https://github.com/moby/moby/pull/47023


### daemon/cluster: Cluster.imageWithDigestString: include mirrors to resolve digest

If the daemon is configured to use a mirror for the default (Docker Hub)
registry, the endpoint did not fall back to querying the upstream if the mirror
did not contain the given reference.

For pull-through registry-mirrors, this was not a problem, as in that case the
registry would forward the request, but for other mirrors, no fallback would
happen. This was inconsistent with how "pulling" images handled this situation;
when pulling images, both the mirror and upstream would be tried.

This patch brings the daemon-side lookup of image-manifests on-par with the
client-side lookup (the GET /distribution endpoint) as used in API 1.30 and
higher.



**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

