### PR TITLE
 hack/make: Strip "v" tag prefix name from VERSION

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -39,15 +39,12 @@ DEFAULT_BUNDLES=(
 )
 
 VERSION=${VERSION:-dev}
-if [[ $VERSION == refs/tags/v* ]]; then
-	VERSION=${VERSION#refs/tags/v}
-else if [[ $VERSION == refs/tags/* ]]; then
-	VERSION=${VERSION#refs/tags/}
-elif [[ $VERSION == refs/heads/* ]]; then
-	VERSION=$(sed <<< "${VERSION#refs/heads/}" -r 's#/+#-#g')
-elif [[ $VERSION == refs/pull/* ]]; then
-	VERSION=pr-$(grep <<< "$VERSION" -o '[0-9]\+')
-fi
+case "$VERSION" in
+	refs/tags/v*) VERSION=${VERSION#refs/tags/v} ;;
+	refs/tags/*) VERSION=${VERSION#refs/tags/} ;;
+	refs/heads/*) VERSION=$(echo "${VERSION#refs/heads/}" | sed -r 's#/+#-#g') ;;
+	refs/pull/*) VERSION=pr-$(echo "$VERSION" | grep -o '[0-9]\+') ;;
+esac
 
 ! BUILDTIME=$(date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')
 if [ "$DOCKER_GITCOMMIT" ]; then

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -39,7 +39,9 @@ DEFAULT_BUNDLES=(
 )
 
 VERSION=${VERSION:-dev}
-if [[ $VERSION == refs/tags/* ]]; then
+if [[ $VERSION == refs/tags/v* ]]; then
+	VERSION=${VERSION#refs/tags/v}
+else if [[ $VERSION == refs/tags/* ]]; then
 	VERSION=${VERSION#refs/tags/}
 elif [[ $VERSION == refs/heads/* ]]; then
 	VERSION=$(sed <<< "${VERSION#refs/heads/}" -r 's#/+#-#g')


### PR DESCRIPTION
To make the version format in the `moby-bin` consistent with the version we use in the release pipeline.

```diff
Server: Docker Engine - Community
 Engine:
-  Version:          v25.0.0
+  Version:          25.0.0
...
```

Also refactored the if-else tree into a `case` (and removed `<<<` bashism to be able to use the same code in the CLI script, [which is is ran with the POSIX shell)](https://github.com/docker/cli/blob/26e3eb32ce83ccfdf2c99aa306570ff4173b2369/scripts/build/binary#L1). 


**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

