### PR TITLE
[24.0 backport] Dockerfile: update rootlesskit to v1.1.1, and use tags as reference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -344,8 +344,8 @@ FROM tini-${TARGETOS} AS tini
 FROM base AS rootlesskit-src
 WORKDIR /usr/src/rootlesskit
 RUN git init . && git remote add origin "https://github.com/rootless-containers/rootlesskit.git"
-# When updating, also update rootlesskit commit in vendor.mod accordingly.
-ARG ROOTLESSKIT_VERSION=v1.1.0
+# When updating, also update vendor.mod and hack/dockerfile/install/rootlesskit.installer accordingly.
+ARG ROOTLESSKIT_VERSION=v1.1.1
 RUN git fetch -q --depth 1 origin "${ROOTLESSKIT_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS rootlesskit-build

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,8 +1,7 @@
 #!/bin/sh
 
-# When updating, also update rootlesskit commit in vendor.mod accordingly
-# v1.1.1
-: "${ROOTLESSKIT_VERSION:=a2c596ff9b3fddc0c2becb38f2ef4004f15765b5}"
+# When updating, also update vendor.mod and Dockerfile accordingly.
+: "${ROOTLESSKIT_VERSION:=v1.1.1}"
 
 install_rootlesskit() {
 	case "$1" in


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/47046
- relates to https://github.com/moby/moby/pull/45706

Commit 0b1c1877c5285fc78c0faa35a040e255d46a40a6 updated the version in hack/dockerfile/install/rootlesskit.installer, but forgot to update the version in Dockerfile.

Also updating both to use a tag, instead of commit. While it's good to pin by an immutable reference, I think it's reasonably safe to use the tag, which is easier to use, and what we do for other binaries, such as runc as well.

Full diff: https://github.com/rootless-containers/rootlesskit/compare/v1.1.0...v1.1.1


(cherry picked from commit e27ffdab0f883034507272645e1f226886717224)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

