### PR TITLE
daemon/config: setPlatformDefaults: use debug for missing userland-proxy

### DIFF
--- a/cmd/dockerd/docker.go
+++ b/cmd/dockerd/docker.go
@@ -19,6 +19,7 @@ import (
 var honorXDG bool
 
 func newDaemonCommand() (*cobra.Command, error) {
+	// FIXME(thaJeztah): config.New also looks up default binary-path, but this code is also executed when running "--version".
 	cfg, err := config.New()
 	if err != nil {
 		return nil, err

--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -251,13 +251,17 @@ func setPlatformDefaults(cfg *Config) error {
 		var err error
 		cfg.BridgeConfig.UserlandProxyPath, err = exec.LookPath(userlandProxyBinary)
 		if err != nil {
-			// Log a warning, but don't error here. This allows running a daemon
-			// with userland-proxy disabled (which does not require the binary
+			// Log, but don't error here. This allows running a daemon with
+			// userland-proxy disabled (which does not require the binary
 			// to be present).
 			//
 			// An error is still produced by [Config.ValidatePlatformConfig] if
 			// userland-proxy is enabled in the configuration.
-			log.G(context.TODO()).WithError(err).Warn("failed to lookup default userland-proxy binary")
+			//
+			// We log this at "debug" level, as this code is also executed
+			// when running "--version", and we don't want to print logs in
+			// that case..
+			log.G(context.TODO()).WithError(err).Debug("failed to lookup default userland-proxy binary")
 		}
 		cfg.Root = "/var/lib/docker"
 		cfg.ExecRoot = "/var/run/docker"


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/47000

commit 4f9db655ede97ed58402687a1251cce9b92a61e5 moved looking up the userland-proxy binary to early in the startup process, and introduced a log-message if the binary was missing.

However, a side-effect of this was this message would also be printed when running "--version";

    dockerd --version
    time="2024-01-09T09:18:53.705271292Z" level=warning msg="failed to lookup default userland-proxy binary" error="exec: \"docker-proxy\": executable file not found in $PATH"
    Docker version v25.0.0-rc.1, build 9cebefa7175c849a0fb89be9a2c0c23755afb3e2

We should look if we can avoid this, but let's change the message to be a debug message as a short-term workaround.


**- A picture of a cute animal (not mandatory but encouraged)**

