### PR TITLE
c8d/getImageLabelByDigest: Fix misspelled `labels` check

### DIFF
--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -363,7 +363,7 @@ func imageFamiliarName(img containerdimages.Image) string {
 // targeting the specified digest.
 // If images have different values, an errdefs.Conflict error will be returned.
 func (i *ImageService) getImageLabelByDigest(ctx context.Context, target digest.Digest, labelKey string) (string, error) {
-	imgs, err := i.client.ImageService().List(ctx, "target.digest=="+target.String()+",label."+labelKey)
+	imgs, err := i.client.ImageService().List(ctx, "target.digest=="+target.String()+",labels."+labelKey)
 	if err != nil {
 		return "", errdefs.System(err)
 	}


### PR DESCRIPTION
- follow up to: https://github.com/moby/moby/pull/46912

It should be `labels.*` not `label.*`.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

