### PR TITLE
libcontainerd: create unstarted tasks

### DIFF
--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -387,7 +387,7 @@ func (c *client) extractResourcesFromSpec(spec *specs.Spec, configuration *hcssh
 	}
 }
 
-func (ctr *container) Start(_ context.Context, _ string, withStdin bool, attachStdio libcontainerdtypes.StdioCallback) (_ libcontainerdtypes.Task, retErr error) {
+func (ctr *container) NewTask(_ context.Context, _ string, withStdin bool, attachStdio libcontainerdtypes.StdioCallback) (_ libcontainerdtypes.Task, retErr error) {
 	ctr.mu.Lock()
 	defer ctr.mu.Unlock()
 
@@ -512,6 +512,11 @@ func (ctr *container) Start(_ context.Context, _ string, withStdin bool, attachS
 	})
 	logger.Debug("start() completed")
 	return t, nil
+}
+
+func (*task) Start(context.Context) error {
+	// No-op on Windows.
+	return nil
 }
 
 func (ctr *container) Task(context.Context) (libcontainerdtypes.Task, error) {

--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -145,8 +145,8 @@ func (c *client) NewContainer(ctx context.Context, id string, ociSpec *specs.Spe
 	return &created, nil
 }
 
-// Start create and start a task for the specified containerd id
-func (c *container) Start(ctx context.Context, checkpointDir string, withStdin bool, attachStdio libcontainerdtypes.StdioCallback) (libcontainerdtypes.Task, error) {
+// NewTask creates a task for the specified containerd id
+func (c *container) NewTask(ctx context.Context, checkpointDir string, withStdin bool, attachStdio libcontainerdtypes.StdioCallback) (libcontainerdtypes.Task, error) {
 	var (
 		checkpoint     *types.Descriptor
 		t              containerd.Task
@@ -236,17 +236,12 @@ func (c *container) Start(ctx context.Context, checkpointDir string, withStdin b
 	// Signal c.createIO that it can call CloseIO
 	stdinCloseSync <- t
 
-	if err := t.Start(ctx); err != nil {
-		// Only Stopped tasks can be deleted. Created tasks have to be
-		// killed first, to transition them to Stopped.
-		if _, err := t.Delete(ctx, containerd.WithProcessKill); err != nil {
-			c.client.logger.WithError(err).WithField("container", c.c8dCtr.ID()).
-				Error("failed to delete task after fail start")
-		}
-		return nil, wrapError(err)
-	}
-
 	return c.newTask(t), nil
+}
+
+func (t *task) Start(ctx context.Context) error {
+	return wrapError(t.Task.Start(ctx))
+
 }
 
 // Exec creates exec process.

--- a/libcontainerd/types/types.go
+++ b/libcontainerd/types/types.go
@@ -64,7 +64,7 @@ type Client interface {
 
 // Container provides access to a containerd container.
 type Container interface {
-	Start(ctx context.Context, checkpointDir string, withStdin bool, attachStdio StdioCallback) (Task, error)
+	NewTask(ctx context.Context, checkpointDir string, withStdin bool, attachStdio StdioCallback) (Task, error)
 	Task(ctx context.Context) (Task, error)
 	// AttachTask returns the current task for the container and reattaches
 	// to the IO for the running task. If no task exists for the container
@@ -79,6 +79,8 @@ type Container interface {
 // Task provides access to a running containerd container.
 type Task interface {
 	Process
+	// Start begins execution of the task
+	Start(context.Context) error
 	// Pause suspends the execution of the task
 	Pause(context.Context) error
 	// Resume the execution of the task

--- a/plugin/executor/containerd/containerd.go
+++ b/plugin/executor/containerd/containerd.go
@@ -81,8 +81,12 @@ func (e *Executor) Create(id string, spec specs.Spec, stdout, stderr io.WriteClo
 	}
 
 	p := c8dPlugin{log: log.G(ctx).WithField("plugin", id), ctr: ctr}
-	p.tsk, err = ctr.Start(ctx, "", false, attachStreamsFunc(stdout, stderr))
+	p.tsk, err = ctr.NewTask(ctx, "", false, attachStreamsFunc(stdout, stderr))
 	if err != nil {
+		p.deleteTaskAndContainer(ctx)
+		return err
+	}
+	if err := p.tsk.Start(ctx); err != nil {
 		p.deleteTaskAndContainer(ctx)
 		return err
 	}


### PR DESCRIPTION
- Split from #44385

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Split task creation and start into two separate method calls in the libcontainerd API. Clients now have the opportunity to inspect the freshly-created task and customize its runtime environment before starting execution of the user-specified binary.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

