### PR TITLE
Detect IPv6 support in containers, generate '/etc/hosts' accordingly.

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -23,7 +23,6 @@ import (
 	"github.com/docker/docker/oci/caps"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/rootless/specconv"
-	"github.com/docker/docker/pkg/stringid"
 	volumemounts "github.com/docker/docker/volume/mounts"
 	"github.com/moby/sys/mount"
 	"github.com/moby/sys/mountinfo"
@@ -57,28 +56,6 @@ func withRlimits(daemon *Daemon, daemonCfg *dconfig.Config, c *container.Contain
 			s.Process = &specs.Process{}
 		}
 		s.Process.Rlimits = rlimits
-		return nil
-	}
-}
-
-// withLibnetwork sets the libnetwork hook
-func withLibnetwork(daemon *Daemon, daemonCfg *dconfig.Config, c *container.Container) coci.SpecOpts {
-	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
-		if c.Config.NetworkDisabled {
-			return nil
-		}
-		for _, ns := range s.Linux.Namespaces {
-			if ns.Type == specs.NetworkNamespace && ns.Path == "" {
-				if s.Hooks == nil {
-					s.Hooks = &specs.Hooks{}
-				}
-				shortNetCtlrID := stringid.TruncateID(daemon.netController.ID())
-				s.Hooks.Prestart = append(s.Hooks.Prestart, specs.Hook{
-					Path: filepath.Join("/proc", strconv.Itoa(os.Getpid()), "exe"),
-					Args: []string{"libnetwork-setkey", "-exec-root=" + daemonCfg.GetExecRoot(), c.ID, shortNetCtlrID},
-				})
-			}
-		}
 		return nil
 	}
 }
@@ -1070,7 +1047,6 @@ func (daemon *Daemon) createSpec(ctx context.Context, daemonCfg *configStore, c 
 		WithCapabilities(c),
 		WithSeccomp(daemon, c),
 		withMounts(daemon, daemonCfg, c, mounts),
-		withLibnetwork(daemon, &daemonCfg.Config, c),
 		WithApparmor(c),
 		WithSelinux(c),
 		WithOOMScore(&c.HostConfig.OomScoreAdj),

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -236,6 +236,10 @@ func (daemon *Daemon) containerStart(ctx context.Context, daemonCfg *configStore
 		}
 	}()
 
+	if err := daemon.initializeCreatedTask(ctx, tsk, container, spec); err != nil {
+		return err
+	}
+
 	if err := tsk.Start(context.TODO()); err != nil { // passing ctx caused integration tests to be stuck in the cleanup phase
 		return setExitCodeFromError(container.SetExitCode, err)
 	}

--- a/daemon/start_linux.go
+++ b/daemon/start_linux.go
@@ -1,0 +1,31 @@
+package daemon // import "github.com/docker/docker/daemon"
+
+import (
+	"context"
+	"fmt"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+
+	"github.com/docker/docker/container"
+	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/libcontainerd/types"
+	"github.com/docker/docker/oci"
+)
+
+// initializeCreatedTask performs any initialization that needs to be done to
+// prepare a freshly-created task to be started.
+func (daemon *Daemon) initializeCreatedTask(ctx context.Context, tsk types.Task, container *container.Container, spec *specs.Spec) error {
+	if !container.Config.NetworkDisabled {
+		nspath, ok := oci.NamespacePath(spec, specs.NetworkNamespace)
+		if ok && nspath == "" { // the runtime has been instructed to create a new network namespace for tsk.
+			sb, err := daemon.netController.GetSandbox(container.ID)
+			if err != nil {
+				return errdefs.System(err)
+			}
+			if err := sb.SetKey(fmt.Sprintf("/proc/%d/ns/net", tsk.Pid())); err != nil {
+				return errdefs.System(err)
+			}
+		}
+	}
+	return nil
+}

--- a/daemon/start_notlinux.go
+++ b/daemon/start_notlinux.go
@@ -1,0 +1,17 @@
+//go:build !linux
+
+package daemon // import "github.com/docker/docker/daemon"
+
+import (
+	"context"
+
+	"github.com/docker/docker/container"
+	"github.com/docker/docker/libcontainerd/types"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// initializeCreatedTask performs any initialization that needs to be done to
+// prepare a freshly-created task to be started.
+func (daemon *Daemon) initializeCreatedTask(ctx context.Context, tsk types.Task, container *container.Container, spec *specs.Spec) error {
+	return nil
+}

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"maps"
 	"strings"
 
 	"github.com/docker/docker/api/types/container"
@@ -43,6 +44,13 @@ func WithCmd(cmds ...string) func(*TestContainerConfig) {
 func WithNetworkMode(mode string) func(*TestContainerConfig) {
 	return func(c *TestContainerConfig) {
 		c.HostConfig.NetworkMode = container.NetworkMode(mode)
+	}
+}
+
+// WithSysctls sets sysctl options for the container
+func WithSysctls(sysctls map[string]string) func(*TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.HostConfig.Sysctls = maps.Clone(sysctls)
 	}
 }
 

--- a/integration/networking/etchosts_test.go
+++ b/integration/networking/etchosts_test.go
@@ -1,0 +1,107 @@
+package networking
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	containertypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/testutil"
+	"github.com/docker/docker/testutil/daemon"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/skip"
+)
+
+// Check that the '/etc/hosts' file in a container is created according to
+// whether the container supports IPv6.
+// Regression test for https://github.com/moby/moby/issues/35954
+func TestEtcHostsIpv6(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+
+	ctx := setupTest(t)
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t,
+		"--ipv6",
+		"--ip6tables",
+		"--experimental",
+		"--fixed-cidr-v6=fdc8:ffe2:d8d7:1234::/64")
+	defer d.Stop(t)
+
+	c := d.NewClientT(t)
+	defer c.Close()
+
+	testcases := []struct {
+		name           string
+		sysctls        map[string]string
+		expIPv6Enabled bool
+		expEtcHosts    string
+	}{
+		{
+			// Create a container with no overrides, on the IPv6-enabled default bridge.
+			// Expect the container to have a working '::1' address, on the assumption
+			// the test host's kernel supports IPv6 - and for its '/etc/hosts' file to
+			// include IPv6 addresses.
+			name:           "IPv6 enabled",
+			expIPv6Enabled: true,
+			expEtcHosts: `127.0.0.1	localhost
+::1	localhost ip6-localhost ip6-loopback
+fe00::0	ip6-localnet
+ff00::0	ip6-mcastprefix
+ff02::1	ip6-allnodes
+ff02::2	ip6-allrouters
+`,
+		},
+		{
+			// Create a container in the same network, with IPv6 disabled. Expect '::1'
+			// not to be pingable, and no IPv6 addresses in its '/etc/hosts'.
+			name:           "IPv6 disabled",
+			sysctls:        map[string]string{"net.ipv6.conf.all.disable_ipv6": "1"},
+			expIPv6Enabled: false,
+			expEtcHosts:    "127.0.0.1\tlocalhost\n",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testutil.StartSpan(ctx, t)
+			ctrId := container.Run(ctx, t, c,
+				container.WithName("etchosts_"+sanitizeCtrName(t.Name())),
+				container.WithImage("busybox:latest"),
+				container.WithCmd("top"),
+				container.WithSysctls(tc.sysctls),
+			)
+			defer func() {
+				c.ContainerRemove(ctx, ctrId, containertypes.RemoveOptions{Force: true})
+			}()
+
+			runCmd := func(ctrId string, cmd []string, expExitCode int) string {
+				t.Helper()
+				execCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+				defer cancel()
+				res, err := container.Exec(execCtx, c, ctrId, cmd)
+				assert.Check(t, is.Nil(err))
+				assert.Check(t, is.Equal(res.ExitCode, expExitCode))
+				return res.Stdout()
+			}
+
+			// Check that IPv6 is/isn't enabled, as expected.
+			var expPingExitStatus int
+			if !tc.expIPv6Enabled {
+				expPingExitStatus = 1
+			}
+			runCmd(ctrId, []string{"ping", "-6", "-c1", "-W3", "::1"}, expPingExitStatus)
+
+			// Check the contents of /etc/hosts.
+			stdout := runCmd(ctrId, []string{"cat", "/etc/hosts"}, 0)
+			// Append the container's own addresses/name to the expected hosts file content.
+			inspect := container.Inspect(ctx, t, c, ctrId)
+			exp := tc.expEtcHosts + inspect.NetworkSettings.IPAddress + "\t" + inspect.Config.Hostname + "\n"
+			if tc.expIPv6Enabled {
+				exp += inspect.NetworkSettings.GlobalIPv6Address + "\t" + inspect.Config.Hostname + "\n"
+			}
+			assert.Check(t, is.Equal(stdout, exp))
+		})
+	}
+}

--- a/libnetwork/drivers/bridge/port_mapping_linux.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux.go
@@ -6,9 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"sync"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/libnetwork/netutils"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/ishidawataru/sctp"
 )
@@ -55,7 +55,7 @@ func (n *bridgeNetwork) allocatePortsInternal(bindings []types.PortBinding, cont
 		// skip adding implicit v6 addr, when the kernel was booted with `ipv6.disable=1`
 		// https://github.com/moby/moby/issues/42288
 		isV6Binding := c.HostIP != nil && c.HostIP.To4() == nil
-		if !isV6Binding && !IsV6Listenable() {
+		if !isV6Binding && !netutils.IsV6Listenable() {
 			continue
 		}
 
@@ -218,27 +218,4 @@ func (n *bridgeNetwork) releasePort(bnd types.PortBinding) error {
 	}
 
 	return portmapper.Unmap(host)
-}
-
-var (
-	v6ListenableCached bool
-	v6ListenableOnce   sync.Once
-)
-
-// IsV6Listenable returns true when `[::1]:0` is listenable.
-// IsV6Listenable returns false mostly when the kernel was booted with `ipv6.disable=1` option.
-func IsV6Listenable() bool {
-	v6ListenableOnce.Do(func() {
-		ln, err := net.Listen("tcp6", "[::1]:0")
-		if err != nil {
-			// When the kernel was booted with `ipv6.disable=1`,
-			// we get err "listen tcp6 [::1]:0: socket: address family not supported by protocol"
-			// https://github.com/moby/moby/issues/42288
-			log.G(context.TODO()).Debugf("port_mapping: v6Listenable=false (%v)", err)
-		} else {
-			v6ListenableCached = true
-			ln.Close()
-		}
-	})
-	return v6ListenableCached
 }

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -478,18 +478,8 @@ func (ep *Endpoint) sbJoin(sb *Sandbox, options ...EndpointOption) (err error) {
 		}
 	}
 
-	// Do not update hosts file with internal networks endpoint IP
-	if !n.ingress && n.Name() != libnGWNetwork {
-		var addresses []string
-		if ip := ep.getFirstInterfaceIPv4Address(); ip != nil {
-			addresses = append(addresses, ip.String())
-		}
-		if ip := ep.getFirstInterfaceIPv6Address(); ip != nil {
-			addresses = append(addresses, ip.String())
-		}
-		if err = sb.updateHostsFile(addresses); err != nil {
-			return err
-		}
+	if err := sb.updateHostsFile(ep.getEtcHostsAddrs()); err != nil {
+		return err
 	}
 	if err = sb.updateDNS(n.enableIPv6); err != nil {
 		return err
@@ -860,26 +850,24 @@ func (ep *Endpoint) getSandbox() (*Sandbox, bool) {
 	return ps, ok
 }
 
-func (ep *Endpoint) getFirstInterfaceIPv4Address() net.IP {
+// Return a list of this endpoint's addresses to add to '/etc/hosts'.
+func (ep *Endpoint) getEtcHostsAddrs() []string {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
+	// Do not update hosts file with internal network's endpoint IP
+	if n := ep.network; n == nil || n.ingress || n.Name() == libnGWNetwork {
+		return nil
+	}
+
+	var addresses []string
 	if ep.iface.addr != nil {
-		return ep.iface.addr.IP
+		addresses = append(addresses, ep.iface.addr.IP.String())
 	}
-
-	return nil
-}
-
-func (ep *Endpoint) getFirstInterfaceIPv6Address() net.IP {
-	ep.mu.Lock()
-	defer ep.mu.Unlock()
-
 	if ep.iface.addrv6 != nil {
-		return ep.iface.addrv6.IP
+		addresses = append(addresses, ep.iface.addrv6.IP.String())
 	}
-
-	return nil
+	return addresses
 }
 
 // EndpointOptionGeneric function returns an option setter for a Generic option defined

--- a/libnetwork/osl/interface_linux.go
+++ b/libnetwork/osl/interface_linux.go
@@ -257,8 +257,6 @@ func (n *Namespace) AddInterface(srcName, dstPrefix string, options ...IfaceOpti
 	n.iFaces = append(n.iFaces, i)
 	n.mu.Unlock()
 
-	n.checkLoV6()
-
 	return nil
 }
 
@@ -311,8 +309,6 @@ func (n *Namespace) RemoveInterface(i *Interface) error {
 	}
 	n.mu.Unlock()
 
-	// TODO(aker): This function will disable IPv6 on lo interface if the removed interface was the last one offering IPv6 connectivity. That's a weird behavior, and shouldn't be hiding this deep down in this function.
-	n.checkLoV6()
 	return nil
 }
 

--- a/libnetwork/osl/namespace_linux.go
+++ b/libnetwork/osl/namespace_linux.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/docker/libnetwork/osl/kernel"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink/nl"
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
 )
@@ -206,16 +207,6 @@ func NewSandbox(key string, osCreate, isRestore bool) (*Namespace, error) {
 	if err != nil {
 		log.G(context.TODO()).Warnf("Failed to set the timeout on the sandbox netlink handle sockets: %v", err)
 	}
-	// In live-restore mode, IPV6 entries are getting cleaned up due to below code
-	// We should retain IPV6 configurations in live-restore mode when Docker Daemon
-	// comes back. It should work as it is on other cases
-	// As starting point, disable IPv6 on all interfaces
-	if !isRestore && !n.isDefault {
-		err = setIPv6(n.path, "all", false)
-		if err != nil {
-			log.G(context.TODO()).Warnf("Failed to disable IPv6 on all interfaces on network namespace %q: %v", n.path, err)
-		}
-	}
 
 	if err = n.loopbackUp(); err != nil {
 		n.nlHandle.Close()
@@ -258,12 +249,6 @@ func GetSandboxForExternalKey(basePath string, key string) (*Namespace, error) {
 	err = n.nlHandle.SetSocketTimeout(ns.NetlinkSocketsTimeout)
 	if err != nil {
 		log.G(context.TODO()).Warnf("Failed to set the timeout on the sandbox netlink handle sockets: %v", err)
-	}
-
-	// As starting point, disable IPv6 on all interfaces
-	err = setIPv6(n.path, "all", false)
-	if err != nil {
-		log.G(context.TODO()).Warnf("Failed to disable IPv6 on all interfaces on network namespace %q: %v", n.path, err)
 	}
 
 	if err = n.loopbackUp(); err != nil {
@@ -325,17 +310,18 @@ func createNamespaceFile(path string) error {
 // or sets the gateway etc. It holds a list of Interfaces, routes etc., and more
 // can be added dynamically.
 type Namespace struct {
-	path         string
-	iFaces       []*Interface
-	gw           net.IP
-	gwv6         net.IP
-	staticRoutes []*types.StaticRoute
-	neighbors    []*neigh
-	nextIfIndex  map[string]int
-	isDefault    bool
-	nlHandle     *netlink.Handle
-	loV6Enabled  bool
-	mu           sync.Mutex
+	path                string
+	iFaces              []*Interface
+	gw                  net.IP
+	gwv6                net.IP
+	staticRoutes        []*types.StaticRoute
+	neighbors           []*neigh
+	nextIfIndex         map[string]int
+	isDefault           bool
+	ipv6LoEnabledOnce   sync.Once
+	ipv6LoEnabledCached bool
+	nlHandle            *netlink.Handle
+	mu                  sync.Mutex
 }
 
 // Interfaces returns the collection of Interface previously added with the AddInterface
@@ -559,32 +545,24 @@ func (n *Namespace) Restore(interfaces map[Iface][]IfaceOption, routes []*types.
 	return nil
 }
 
-// Checks whether IPv6 needs to be enabled/disabled on the loopback interface
-func (n *Namespace) checkLoV6() {
-	var (
-		enable = false
-		action = "disable"
-	)
-
-	n.mu.Lock()
-	for _, iface := range n.iFaces {
-		if iface.AddressIPv6() != nil {
-			enable = true
-			action = "enable"
-			break
+// IPv6LoEnabled checks whether the loopback interface has an IPv6 address ('::1'
+// is assigned by the kernel if IPv6 is enabled).
+func (n *Namespace) IPv6LoEnabled() bool {
+	n.ipv6LoEnabledOnce.Do(func() {
+		// If anything goes wrong, assume no-IPv6.
+		iface, err := n.nlHandle.LinkByName("lo")
+		if err != nil {
+			log.G(context.TODO()).WithError(err).Warn("Unable to find 'lo' to determine IPv6 support")
+			return
 		}
-	}
-	n.mu.Unlock()
-
-	if n.loV6Enabled == enable {
-		return
-	}
-
-	if err := setIPv6(n.path, "lo", enable); err != nil {
-		log.G(context.TODO()).Warnf("Failed to %s IPv6 on loopback interface on network namespace %q: %v", action, n.path, err)
-	}
-
-	n.loV6Enabled = enable
+		addrs, err := n.nlHandle.AddrList(iface, nl.FAMILY_V6)
+		if err != nil {
+			log.G(context.TODO()).WithError(err).Warn("Unable to get 'lo' addresses to determine IPv6 support")
+			return
+		}
+		n.ipv6LoEnabledCached = len(addrs) > 0
+	})
+	return n.ipv6LoEnabledCached
 }
 
 // ApplyOSTweaks applies operating system specific knobs on the sandbox.

--- a/libnetwork/osl/namespace_linux.go
+++ b/libnetwork/osl/namespace_linux.go
@@ -226,7 +226,11 @@ func NewSandbox(key string, osCreate, isRestore bool) (*Namespace, error) {
 }
 
 func mountNetworkNamespace(basePath string, lnPath string) error {
-	return syscall.Mount(basePath, lnPath, "bind", syscall.MS_BIND, "")
+	err := syscall.Mount(basePath, lnPath, "bind", syscall.MS_BIND, "")
+	if err != nil {
+		return fmt.Errorf("bind-mount %s -> %s: %w", basePath, lnPath, err)
+	}
+	return nil
 }
 
 // GetSandboxForExternalKey returns sandbox object for the supplied path

--- a/libnetwork/sandbox_linux.go
+++ b/libnetwork/sandbox_linux.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/libnetwork/netutils"
 	"github.com/docker/docker/libnetwork/osl"
 	"github.com/docker/docker/libnetwork/types"
 )
@@ -157,12 +158,37 @@ func (sb *Sandbox) SetKey(basePath string) error {
 		}
 	}
 
+	if err := sb.finishInitDNS(); err != nil {
+		return err
+	}
+
 	for _, ep := range sb.Endpoints() {
 		if err = sb.populateNetworkResources(ep); err != nil {
 			return err
 		}
 	}
+
 	return nil
+}
+
+// IPv6 support can always be determined for host networking. For other network
+// types it can only be determined once there's a container namespace to probe,
+// return ok=false in that case.
+func (sb *Sandbox) ipv6Enabled() (enabled, ok bool) {
+	// For host networking, IPv6 support depends on the host.
+	if sb.config.useDefaultSandBox {
+		return netutils.IsV6Listenable(), true
+	}
+
+	// For other network types, look at whether the container's loopback interface has an IPv6 address.
+	sb.mu.Lock()
+	osSbox := sb.osSbox
+	sb.mu.Unlock()
+
+	if osSbox == nil {
+		return false, false
+	}
+	return osSbox.IPv6LoEnabled(), true
 }
 
 func (sb *Sandbox) releaseOSSbox() error {

--- a/oci/namespaces.go
+++ b/oci/namespaces.go
@@ -14,3 +14,14 @@ func RemoveNamespace(s *specs.Spec, nsType specs.LinuxNamespaceType) {
 		}
 	}
 }
+
+// NamespacePath returns the configured Path of the first namespace in
+// s.Linux.Namespaces of type nsType.
+func NamespacePath(s *specs.Spec, nsType specs.LinuxNamespaceType) (path string, ok bool) {
+	for _, n := range s.Linux.Namespaces {
+		if n.Type == nsType {
+			return n.Path, true
+		}
+	}
+	return "", false
+}


### PR DESCRIPTION
**- What I did**

Some configuration in a container depends on whether it has support for IPv6 (including default entries for `::1` etc in `/etc/hosts`).

Before this change, the container's support for IPv6 was determined by whether it was connected to any IPv6-enabled networks. But, that can change over time, it isn't a property of the container itself.

So, instead, detect IPv6 support by looking for `::1` on the container's loopback interface. That address will not be present if the kernel does not have IPv6 support, or the user has disabled it in new namespaces by other means. To disable IPv6 when creating a container, use `--sysctl net.ipv6.conf.all.disable_ipv6=1`.

This change uses the new approach to determining whether a container supports IPv6 to ensure that IPv6 entries are only included in '/etc/hosts' if IPv6 is enabled - which fixes #35954

This change is a start, further work is needed:
- Like 'hosts', 'resolv.conf' needs to be built according to this detected IPv6-ness.
- An endpoint for an IPv6 network, in a container with no IPv6 support, is allocated an IPv6 address.
  - That address won't show up on the container's interface to a network added when the container is created, but it will on interfaces to networks that are created later.
  - The address will be reserved for the lifetime of the container.
  - The internal resolver is populated with those IPv6 addreses, and will return them.
  - _Similarly, a container with IPv6 and a legacy-network `--link` to a non-IPv6 container will get that non-functional IPv6 address in its '/etc/hosts'._
- Check for more cases where the plumbing needs to change for this new way of detecting the IPv6 capability of a container.
- Check that docs describe the `--sysctl` as the way to disable IPv6 in a container.

**- How I did it**

The first commit here, written by @corhere, results in `Sandbox.SetKey()` being called after the daemon has created the container task. At that point, `sysctl` options have been applied, making it possible to use the existence of `::1` on the loopback interface to detect IPv6 support when the user provides sysctl `net.ipv6.conf.all.disable_ipv6` to explicitly enable or disable IPv6 when creating a container. (`SetKey()` will still be called from the prestart hook for buildkit, but it doesn't allow sysctl overrides.)

The second commit probes for `::1`, and uses the result to re-generate `/etc/hosts` accordingly.

The daemon no longer disables IPv6 on all interfaces during initialisation.  It now disables IPv6 only for interfaces that have not been assigned an IPv6 address:
- fixes #33099
- fixes #42748
- fixes #34070

**- How to verify it**

Updated unit tests, new integration test.

**- Description for the changelog**

By default, IPv6 will remain enabled on a container's loopback interface when the container is not connected to an IPv6-enabled network. So, for example, containers that are only connected to an IPv4-only network will now have the '::1' address on their loopback interface.

To disable IPv6 in a container, use option '--sysctl net.ipv6.conf.all.disable_ipv6=1' in the 'create' or 'run' command, or the equivalent 'sysctls' option in the service configuration section of a Compose file.

If IPv6 is not available in a container because it has been explicitly disabled for the container, the host's networking stack does not have IPv6 enabled, or for any other reason - the container's '/etc/hosts' file will not include IPv6 entries.