### PR TITLE
image/save: Fix missing layers in manifest

### DIFF
--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -523,5 +523,13 @@ func (s *saveSession) saveLayer(id layer.ChainID, legacyImg image.V1Image, creat
 	if fs, ok := l.(distribution.Describable); ok {
 		src = fs.Descriptor()
 	}
+
+	if src.Digest == "" {
+		src = distribution.Descriptor{
+			MediaType: ocispec.MediaTypeImageLayer,
+			Digest:    lDgst,
+			Size:      l.Size(),
+		}
+	}
 	return src, nil
 }


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/47065

The new OCI-compatible archive export relies on the Descriptors returned by the layer (`distribution.Describable` interface implementation).

The issue with that is that the `roLayer` and the `referencedCacheLayer` types don't implement this interface. Implementing that interface for them based on their `descriptor` doesn't work though, because that descriptor is empty.

To workaround this issue, just create a new descriptor if the one provided by the layer is empty.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
New test in CI

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

