### PR TITLE
doc: Correct typo in doc comments for volume/mounts/mounts/MountPoint

### DIFF
--- a/volume/mounts/mounts.go
+++ b/volume/mounts/mounts.go
@@ -61,7 +61,7 @@ type MountPoint struct {
 	// This should be set by calls to `Mount` and unset by calls to `Unmount`
 	ID string `json:",omitempty"`
 
-	// Sepc is a copy of the API request that created this mount.
+	// Spec is a copy of the API request that created this mount.
 	Spec mounttypes.Mount
 
 	// Some bind mounts should not be automatically created.


### PR DESCRIPTION
Hello moby!

**- What I did**
Fixed a simple typo `Sepc` to `Spec` from doc comments.

**- How I did it**
-

**- How to verify it**
-

**- Description for the changelog**
Fixed a simple typo `Sepc` to `Spec` in doc comments for volumes/mounts/mounts/MountPoint.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/moby/moby/assets/14137676/0afe3a5e-a393-470a-9dd9-78c563eb55e6)
