### PR TITLE
dockerd-rootless.sh: fix inconsistent description about "builtin" driver

### DIFF
--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -31,7 +31,7 @@
 #  vpnkit         | builtin        | Slow           | Fast ✅         | ❌     | ✅      | Default when slirp4netns is not installed
 #  slirp4netns    | slirp4netns    | Slow           | Slow            | ✅     | ✅      |
 #  pasta          | implicit       | Slow           | Fast ✅         | ✅     | ✅      | Experimental; Needs recent version of pasta (2023_12_04)
-#  lxc-user-nic   | builtin        | Fast ✅        | Slow            | ❌     | ❌      | Experimental
+#  lxc-user-nic   | builtin        | Fast ✅        | Fast ✅         | ❌     | ❌      | Experimental
 #  (bypass4netns) | (bypass4netns) | Fast ✅        | Fast ✅         | ✅     | ✅      | (Not integrated to RootlessKit)
 
 # See the documentation for the further information: https://docs.docker.com/go/rootless/


### PR DESCRIPTION
The "builtin" port driver was marked as "Slow" in the row for the lxc-user-nic network driver, while it was marked as "Fast" in other rows.

It had to be consistently marked as "Fast" regardless to the network driver. It is still not as fast as rootful.

Follow-up to #47076
Fixes: b5a5ecf4a383466bbcf3d9a89dd490bc4533d803


- - -
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed an inconsistent description about the "builtin" port driver

**- How I did it**

Marked it "Fast" consistently

**- How to verify it**

```console
$ DOCKERD_ROOTLESS_ROOTLESSKIT_NET=lxc-user-nic \
  DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=builtin \
  dockerd-rootless.sh
```
```console
$ docker --context=rootless run -it --rm -p 5201:5201 alpine
/ # apk add iperf3
/ # iperf3 -s
```
```console
$ iperf3 -c 127.0.0.1
Connecting to host 127.0.0.1, port 5201
[  5] local 127.0.0.1 port 51260 connected to 127.0.0.1 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  4.23 GBytes  36.4 Gbits/sec   10   3.50 MBytes       
[  5]   1.00-2.00   sec  5.32 GBytes  45.7 Gbits/sec   36   3.50 MBytes       
[  5]   2.00-3.00   sec  5.00 GBytes  43.0 Gbits/sec   18   3.50 MBytes       
[  5]   3.00-4.00   sec  4.92 GBytes  42.3 Gbits/sec   35   3.50 MBytes       
[  5]   4.00-5.00   sec  4.05 GBytes  34.8 Gbits/sec    2   3.50 MBytes       
[  5]   5.00-6.00   sec  5.50 GBytes  47.2 Gbits/sec   13   3.50 MBytes       
[  5]   6.00-7.00   sec  5.52 GBytes  47.4 Gbits/sec   57   3.50 MBytes       
[  5]   7.00-8.00   sec  5.54 GBytes  47.6 Gbits/sec   23   3.50 MBytes       
[  5]   8.00-9.00   sec  5.27 GBytes  45.3 Gbits/sec   48   3.12 MBytes       
[  5]   9.00-10.00  sec  5.44 GBytes  46.7 Gbits/sec   39   3.12 MBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  50.8 GBytes  43.6 Gbits/sec  281             sender
[  5]   0.00-10.00  sec  50.8 GBytes  43.6 Gbits/sec                  receiver

iperf Done.
```

Not as fast as rootful (45.4 Gbps), but quite faster than slirp4netns port driver (1.59 Gbps)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
dockerd-rootless.sh: fix inconsistent description about "builtin" driver

**- A picture of a cute animal (not mandatory but encouraged)**
🐧 
