### PR TITLE
dockerd-rootless-setuptool.sh: add `nsenter` subcommand (for debugging)

### DIFF
--- a/contrib/dockerd-rootless-setuptool.sh
+++ b/contrib/dockerd-rootless-setuptool.sh
@@ -273,8 +273,16 @@ init() {
 
 # CLI subcommand: "check"
 cmd_entrypoint_check() {
+	init
 	# requirements are already checked in init()
 	INFO "Requirements are satisfied"
+}
+
+# CLI subcommand: "nsenter"
+cmd_entrypoint_nsenter() {
+	# No need to call init()
+	pid=$(cat "$XDG_RUNTIME_DIR/dockerd-rootless/child_pid")
+	exec nsenter --no-fork --wd="$(pwd)" --preserve-credentials -m -n -U -t "$pid" -- "$@"
 }
 
 show_systemd_error() {
@@ -383,6 +391,7 @@ cli_ctx_rm() {
 
 # CLI subcommand: "install"
 cmd_entrypoint_install() {
+	init
 	# requirements are already checked in init()
 	if [ -z "$SYSTEMD" ]; then
 		install_nonsystemd
@@ -416,6 +425,7 @@ cmd_entrypoint_install() {
 
 # CLI subcommand: "uninstall"
 cmd_entrypoint_uninstall() {
+	init
 	# requirements are already checked in init()
 	if [ -z "$SYSTEMD" ]; then
 		INFO "systemd not detected, ${DOCKERD_ROOTLESS_SH} needs to be stopped manually:"
@@ -461,6 +471,7 @@ usage() {
 	echo
 	echo "Commands:"
 	echo "  check        Check prerequisites"
+	echo "  nsenter      Enter into RootlessKit namespaces (mostly for debugging)"
 	echo "  install      Install systemd unit (if systemd is available) and show how to manage the service"
 	echo "  uninstall    Uninstall systemd unit"
 }
@@ -508,5 +519,4 @@ if ! command -v "cmd_entrypoint_${command}" > /dev/null 2>&1; then
 fi
 
 # main
-init
-"cmd_entrypoint_${command}"
+"cmd_entrypoint_${command}" "$@"

--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -9,6 +9,7 @@
 # * Either one of slirp4netns (>= v0.4.0), VPNKit, lxc-user-nic needs to be installed.
 #
 # Recognized environment variables:
+# * DOCKERD_ROOTLESS_ROOTLESSKIT_STATE_DIR=DIR: the rootlesskit state dir. Defaults to "$XDG_RUNTIME_DIR/dockerd-rootless".
 # * DOCKERD_ROOTLESS_ROOTLESSKIT_NET=(slirp4netns|vpnkit|pasta|lxc-user-nic): the rootlesskit network driver. Defaults to "slirp4netns" if slirp4netns (>= v0.4.0) is installed. Otherwise defaults to "vpnkit".
 # * DOCKERD_ROOTLESS_ROOTLESSKIT_MTU=NUM: the MTU value for the rootlesskit network driver. Defaults to 65520 for slirp4netns, 1500 for other drivers.
 # * DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=(builtin|slirp4netns|implicit): the rootlesskit port driver. Defaults to "builtin".
@@ -64,6 +65,7 @@ if [ -z "$rootlesskit" ]; then
 	exit 1
 fi
 
+: "${DOCKERD_ROOTLESS_ROOTLESSKIT_STATE_DIR:=$XDG_RUNTIME_DIR/dockerd-rootless}"
 : "${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:=}"
 : "${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:=}"
 : "${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:=builtin}"
@@ -119,6 +121,7 @@ if [ -z "$_DOCKERD_ROOTLESS_CHILD" ]; then
 	#         (by either systemd-networkd or NetworkManager)
 	# * /run: copy-up is required so that we can create /run/docker (hardcoded for plugins) in our namespace
 	exec $rootlesskit \
+		--state-dir=$DOCKERD_ROOTLESS_ROOTLESSKIT_STATE_DIR \
 		--net=$net --mtu=$mtu \
 		--slirp4netns-sandbox=$DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SANDBOX \
 		--slirp4netns-seccomp=$DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SECCOMP \

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -174,7 +174,9 @@ func NewDaemon(workingDir string, ops ...Option) (*Daemon, error) {
 		if err := os.Chown(d.execRoot, uid, gid); err != nil {
 			return nil, err
 		}
-		d.rootlessXDGRuntimeDir = filepath.Join(d.Folder, "xdgrun")
+		// $XDG_RUNTIME_DIR mustn't be too long, as ${XDG_RUNTIME_DIR/dockerd-rootless
+		// contains Unix sockets
+		d.rootlessXDGRuntimeDir = filepath.Join(os.TempDir(), "xdgrun-"+id)
 		if err := os.MkdirAll(d.rootlessXDGRuntimeDir, 0o700); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added `nsenter` subcommand to `dockerd-rootless-setuptool.sh`.

Expected to be used for debugging.

**- How I did it**
Ported `containerd-rootless-setuptool.sh nsenter` (part of nerdctl) to `dockerd-rootless-setuptool.sh`
https://github.com/containerd/nerdctl/blob/v1.7.2/extras/rootless/containerd-rootless-setuptool.sh#L142-L147


**- How to verify it**

```console
$ dockerd-rootless-setuptool.sh nsenter -- ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
2: tap0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 65520 qdisc pfifo_fast state UP group default qlen 1000
    link/ether ae:c3:a3:20:53:3e brd ff:ff:ff:ff:ff:ff
    inet 10.0.2.100/24 scope global tap0
       valid_lft forever preferred_lft forever
    inet6 fe80::acc3:a3ff:fe20:533e/64 scope link 
       valid_lft forever preferred_lft forever
3: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default 
    link/ether 02:42:a6:36:b0:a9 brd ff:ff:ff:ff:ff:ff
    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0
       valid_lft forever preferred_lft forever
```

```console
$ dockerd-rootless-setuptool.sh nsenter -- cat /proc/self/uid_map 
         0       1001          1
         1     100000      65536
     65537     200000      65536
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
dockerd-rootless-setuptool.sh: add `nsenter` subcommand (for debugging)

**- A picture of a cute animal (not mandatory but encouraged)**
🐧 
