### PR TITLE
cdi: use separate feature-flag

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -270,13 +270,13 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 		return errors.Wrap(err, "failed to validate authorization plugin")
 	}
 
-	// Note that CDI is not inherrently linux-specific, there are some linux-specific assumptions / implementations in the code that
+	// Note that CDI is not inherently linux-specific, there are some linux-specific assumptions / implementations in the code that
 	// queries the properties of device on the host as wel as performs the injection of device nodes and their access permissions into the OCI spec.
 	//
 	// In order to lift this restriction the following would have to be addressed:
 	// - Support needs to be added to the cdi package for injecting Windows devices: https://tags.cncf.io/container-device-interface/issues/28
 	// - The DeviceRequests API must be extended to non-linux platforms.
-	if runtime.GOOS == "linux" && cli.Config.Experimental {
+	if runtime.GOOS == "linux" && cli.Config.Features["cdi"] {
 		daemon.RegisterCDIDriver(cli.Config.CDISpecDirs...)
 	}
 
@@ -611,8 +611,8 @@ func loadDaemonCliConfig(opts *daemonOptions) (*config.Config, error) {
 		// If CDISpecDirs is set to an empty string, we clear it to ensure that CDI is disabled.
 		conf.CDISpecDirs = nil
 	}
-	if !conf.Experimental {
-		// If experimental mode is not set, we clear the CDISpecDirs to ensure that CDI is disabled.
+	if !conf.Features["cdi"] {
+		// If the CDI feature is not enabled, we clear the CDISpecDirs to ensure that CDI is disabled.
 		conf.CDISpecDirs = nil
 	}
 

--- a/cmd/dockerd/daemon_test.go
+++ b/cmd/dockerd/daemon_test.go
@@ -227,44 +227,40 @@ func TestCDISpecDirs(t *testing.T) {
 	testCases := []struct {
 		description         string
 		configContent       string
-		experimental        bool
 		specDirs            []string
 		expectedCDISpecDirs []string
 	}{
 		{
-			description:         "experimental and no spec dirs specified returns default",
+			description:         "CDI enabled and no spec dirs specified returns default",
 			specDirs:            nil,
-			experimental:        true,
+			configContent:       `{"features": {"cdi": true}}`,
 			expectedCDISpecDirs: []string{"/etc/cdi", "/var/run/cdi"},
 		},
 		{
-			description:         "experimental and specified spec dirs are returned",
+			description:         "CDI enabled and specified spec dirs are returned",
 			specDirs:            []string{"/foo/bar", "/baz/qux"},
-			experimental:        true,
+			configContent:       `{"features": {"cdi": true}}`,
 			expectedCDISpecDirs: []string{"/foo/bar", "/baz/qux"},
 		},
 		{
-			description:         "experimental and empty string as spec dir returns empty slice",
+			description:         "CDI enabled and empty string as spec dir returns empty slice",
 			specDirs:            []string{""},
-			experimental:        true,
+			configContent:       `{"features": {"cdi": true}}`,
 			expectedCDISpecDirs: []string{},
 		},
 		{
-			description:         "experimental and empty config option returns empty slice",
-			configContent:       `{"cdi-spec-dirs": []}`,
-			experimental:        true,
+			description:         "CDI enabled and empty config option returns empty slice",
+			configContent:       `{"cdi-spec-dirs": [], "features": {"cdi": true}}`,
 			expectedCDISpecDirs: []string{},
 		},
 		{
-			description:         "non-experimental and no spec dirs specified returns no cdi spec dirs",
+			description:         "CDI disabled and no spec dirs specified returns no cdi spec dirs",
 			specDirs:            nil,
-			experimental:        false,
 			expectedCDISpecDirs: nil,
 		},
 		{
-			description:         "non-experimental and specified spec dirs returns no cdi spec dirs",
+			description:         "CDI disabled and specified spec dirs returns no cdi spec dirs",
 			specDirs:            []string{"/foo/bar", "/baz/qux"},
-			experimental:        false,
 			expectedCDISpecDirs: nil,
 		},
 	}
@@ -279,9 +275,6 @@ func TestCDISpecDirs(t *testing.T) {
 			flags := opts.flags
 			for _, specDir := range tc.specDirs {
 				assert.Check(t, flags.Set("cdi-spec-dir", specDir))
-			}
-			if tc.experimental {
-				assert.Check(t, flags.Set("experimental", "true"))
 			}
 
 			loadedConfig, err := loadDaemonCliConfig(opts)


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/45134
- https://github.com/moby/moby/pull/46004
- https://github.com/docker/cli/pull/4084
- https://github.com/docker/cli/pull/4525


**- What I did**

Move CDI enablement to a `"features": {"cdi": true}` style in daemon.json

**- How to verify it**

```json
{
  "features": {
    "cdi": true
  }
}
```

**- Description for the changelog**

```changelog
Support enabling CDI with the `cdi` flag in the config `features`.
```


**- A picture of a cute animal (not mandatory but encouraged)**

