### PR TITLE
environment: Error when t.Parallel was called before Protect

### DIFF
--- a/integration/container/stop_linux_test.go
+++ b/integration/container/stop_linux_test.go
@@ -78,11 +78,11 @@ func TestStopContainerWithTimeout(t *testing.T) {
 // if the request is cancelled.
 // See issue https://github.com/moby/moby/issues/45731
 func TestStopContainerWithTimeoutCancel(t *testing.T) {
-	t.Parallel()
-
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()
 	t.Cleanup(func() { _ = apiClient.Close() })
+
+	t.Parallel()
 
 	id := container.Run(ctx, t, apiClient,
 		container.WithCmd("sh", "-c", "trap 'echo received TERM' TERM; while true; do usleep 10; done"),

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -111,8 +111,9 @@ func TestVolumesRemove(t *testing.T) {
 func TestVolumesRemoveSwarmEnabled(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "TODO enable on windows")
-	t.Parallel()
 	ctx := setupTest(t)
+
+	t.Parallel()
 
 	// Spin up a new daemon, so that we can run this test in parallel (it's a slow test)
 	d := daemon.New(t)

--- a/testutil/environment/protect.go
+++ b/testutil/environment/protect.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/testutil"
 	"go.opentelemetry.io/otel"
 	"gotest.tools/v3/assert"
 )
@@ -38,6 +39,8 @@ func newProtectedElements() protectedElements {
 // volumes, and, on Linux, plugins) from being cleaned up at the end of test
 // runs
 func ProtectAll(ctx context.Context, t testing.TB, testEnv *Execution) {
+	testutil.CheckNotParallel(t)
+
 	t.Helper()
 	ctx, span := otel.Tracer("").Start(ctx, "ProtectAll")
 	defer span.End()


### PR DESCRIPTION
- related to: https://github.com/moby/moby/pull/47082

Protecting the environment relies on the shared state (containers, images, etc) which might already be mutated by other tests if the test opted in into the Parallel execution before Protect was called.

It uses reflection because there's no public API to check this, but considering that this is only used in tests - worst case scenario is that it won't work when upgrading to a new Golang version and we'll need to adjust the check or revert it.


**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

