### PR TITLE
Revert "temporary: Disable deprecate-integration-cli validation"

### DIFF
--- a/hack/validate/default
+++ b/hack/validate/default
@@ -12,6 +12,6 @@ SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "${SCRIPTDIR}"/swagger
 . "${SCRIPTDIR}"/swagger-gen
 . "${SCRIPTDIR}"/toml
-#. "${SCRIPTDIR}"/deprecate-integration-cli
+. "${SCRIPTDIR}"/deprecate-integration-cli
 . "${SCRIPTDIR}"/golangci-lint
 . "${SCRIPTDIR}"/shfmt

--- a/hack/validate/deprecate-integration-cli
+++ b/hack/validate/deprecate-integration-cli
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Check that no new tests are being added to integration-cli
+
+SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPTDIR}/.validate"
+
+new_tests=$(
+	validate_diff --diff-filter=ACMR --unified=0 -- 'integration-cli/*_api_*.go' 'integration-cli/*_cli_*.go' \
+		| grep -E '^\+func (.*) Test' || true
+)
+
+if [ -n "$new_tests" ]; then
+	{
+		echo "The following new tests were added to integration-cli:"
+		echo
+		echo "$new_tests"
+		echo
+		echo "integration-cli is deprecated. Please add an API integration test to"
+		echo "./integration/COMPONENT/. See ./TESTING.md for more details."
+		echo
+	} >&2
+	false
+else
+	echo 'Congratulations!  No new tests were added to integration-cli.'
+fi


### PR DESCRIPTION
re-enable the check that was temporarily disabled in https://github.com/moby/moby/pull/46634

This reverts commit bdc7d0c2db6b72164da6fcce8f946fa4fb485bad.


**- A picture of a cute animal (not mandatory but encouraged)**

