### PR TITLE
[24.0 backport] update golangci-lint to v1.55.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -228,7 +228,7 @@ FROM binary-dummy AS containerd-windows
 FROM containerd-${TARGETOS} AS containerd
 
 FROM base AS golangci_lint
-ARG GOLANGCI_LINT_VERSION=v1.54.2
+ARG GOLANGCI_LINT_VERSION=v1.55.2
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
         GOBIN=/build/ GO111MODULE=on go install "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}" \


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/47016
- full diff: https://github.com/golangci/golangci-lint/compare/v1.54.2...v1.55.2


(cherry picked from commit d5a3fccb068f895ab745c4388c91597a79be555e)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

