### PR TITLE
net=host: remove /var/run/docker/netns/default from OCI config

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -285,10 +285,7 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 					})
 				}
 			case networkMode.IsHost():
-				setNamespace(s, specs.LinuxNamespace{
-					Type: specs.NetworkNamespace,
-					Path: c.NetworkSettings.SandboxKey,
-				})
+				oci.RemoveNamespace(s, specs.NetworkNamespace)
 			default:
 				setNamespace(s, specs.LinuxNamespace{
 					Type: specs.NetworkNamespace,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Close #47100

Prior to this commit, a container running with `--net=host` had `{"type":"network","path":"/var/run/docker/netns/default"}` in the ``.linux.namespaces` field of the OCI Runtime Config, but this wasn't needed.

**- How I did it**
`oci.RemoveNamespace(s, specs.NetworkNamespace)` when `networkMode.isHost()`

**- How to verify it**
`docker run --net=host` still works, `ip a` in a container shows the host network interfaces, and the `config.json` has no reference to `/var/run/docker/netns/default`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
net=host: remove `/var/run/docker/netns/default` from OCI config

**- A picture of a cute animal (not mandatory but encouraged)**
🐧 
