### PR TITLE
ci: Unconditionally run Linux integration with c8d store

### DIFF
--- a/.github/workflows/.test-prepare.yml
+++ b/.github/workflows/.test-prepare.yml
@@ -16,20 +16,6 @@ jobs:
     outputs:
       matrix: ${{ steps.set.outputs.matrix }}
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-      -
-        name: Create matrix
+      - name: Create matrix
         id: set
-        uses: actions/github-script@v6
-        with:
-          script: |
-            let matrix = ['graphdriver'];
-            if ("${{ contains(github.event.pull_request.labels.*.name, 'containerd-integration') || github.event_name != 'pull_request' }}" == "true") {
-              matrix.push('snapshotter');
-            }
-            await core.group(`Set matrix`, async () => {
-              core.info(`matrix: ${JSON.stringify(matrix)}`);
-              core.setOutput('matrix', JSON.stringify(matrix));
-            });
+        run: echo 'matrix=["graphdriver", "snapshotter"]' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -217,6 +217,7 @@ jobs:
           teststat -markdown $(find /tmp/artifacts -type f -name '*.json' -print0 | xargs -0) >> $GITHUB_STEP_SUMMARY
 
   integration-test-prepare:
+    if: inputs.storage != 'snapshotter' || github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'containerd-integration')
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.tests.outputs.matrix }}
@@ -506,7 +507,7 @@ jobs:
   integration-test-report:
     runs-on: ubuntu-latest
     continue-on-error: ${{ inputs.storage == 'snapshotter' && github.event_name != 'pull_request' }}
-    if: always()
+    if: always() && (inputs.storage != 'snapshotter' || github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'containerd-integration'))
     needs:
       - integration-test
     strategy:


### PR DESCRIPTION
Don't require the `containerd-integration` label in PRs to run the integration tests on Linux with the containerd image store enabled.

The label is only required to run the integration tests on Windows.

**- How to verify it**
Observe CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

