### PR TITLE
c8d/integration: Adjust error in TestPullLinuxImageFailsOnWindows

### DIFF
--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -207,7 +207,13 @@ func (s *DockerHubPullSuite) TestPullClientDisconnect(c *testing.T) {
 func (s *DockerCLIPullSuite) TestPullLinuxImageFailsOnWindows(c *testing.T) {
 	testRequires(c, DaemonIsWindows, Network)
 	_, _, err := dockerCmdWithError("pull", "ubuntu")
-	assert.ErrorContains(c, err, "no matching manifest for windows")
+
+	errorMessage := "no matching manifest for windows"
+	if testEnv.UsingSnapshotter() {
+		errorMessage = "no match for platform in manifest"
+	}
+
+	assert.ErrorContains(c, err, errorMessage)
 }
 
 // Regression test for https://github.com/docker/docker/issues/28892


### PR DESCRIPTION
- related: https://github.com/moby/moby/pull/46517

Message is different with containerd backend. The Linux test `TestPullLinuxImageFailsOnLinux` was adjusted before, but we missed this one.


**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

