### PR TITLE
Fix isGitURL regular expression

### DIFF
--- a/builder/remotecontext/urlutil/urlutil.go
+++ b/builder/remotecontext/urlutil/urlutil.go
@@ -12,7 +12,7 @@ import (
 
 // urlPathWithFragmentSuffix matches fragments to use as Git reference and build
 // context from the Git repository. See IsGitURL for details.
-var urlPathWithFragmentSuffix = regexp.MustCompile(".git(?:#.+)?$")
+var urlPathWithFragmentSuffix = regexp.MustCompile(`\.git(?:#.+)?$`)
 
 // IsURL returns true if the provided str is an HTTP(S) URL by checking if it
 // has a http:// or https:// scheme. No validation is performed to verify if the

--- a/builder/remotecontext/urlutil/urlutil_test.go
+++ b/builder/remotecontext/urlutil/urlutil_test.go
@@ -17,6 +17,7 @@ var (
 	}
 	invalidGitUrls = []string{
 		"http://github.com/docker/docker.git:#branch",
+		"https://github.com/docker/dgit",
 	}
 )
 


### PR DESCRIPTION
- relates to https://github.com/moby/buildkit/pull/454
- relates to https://github.com/moby/buildkit/pull/416#pullrequestreview-129559513

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Escape period (.) so regular expression does not match any character before "git".

**- How I did it**

Created a failing test, fixed the regular expression, and verified the test passed.

**- How to verify it**

Run the tests.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix IsGitURL regular expression to not match any character before ending "git"

**- A picture of a cute animal (not mandatory but encouraged)**

![two-words](https://github.com/moby/moby/assets/141646279/8926f7c8-f4cc-44e1-bd6e-fb5faed0f2db)


