### PR TITLE
Fix libnetwork/osl test TestAddRemoveInterface

### DIFF
--- a/libnetwork/osl/sandbox_linux_test.go
+++ b/libnetwork/osl/sandbox_linux_test.go
@@ -72,7 +72,7 @@ func newInfo(t *testing.T, hnd *netlink.Handle) (*Namespace, error) {
 	}
 	addr.IP = ip4
 
-	ip6, addrv6, err := net.ParseCIDR("fe80::2/64")
+	ip6, addrv6, err := net.ParseCIDR("fdac:97b4:dbcc::2/64")
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func newInfo(t *testing.T, hnd *netlink.Handle) (*Namespace, error) {
 	return &Namespace{
 		iFaces: []*Interface{intf1, intf2, intf3},
 		gw:     net.ParseIP("192.168.1.1"),
-		gwv6:   net.ParseIP("fe80::1"),
+		gwv6:   net.ParseIP("fdac:97b4:dbcc::1/64"),
 	}, nil
 }
 


### PR DESCRIPTION
**- What I did**

For some time, when adding an interface with no IPv6 address (an interface to a network that does not have IPv6 enabled), we've been disabling IPv6 on that interface.

As part of a separate change, I'm removing that logic - there's nothing wrong with having IPv6 enabled on an interface with no routable address. The difference is that the kernel will assign a link-local address.

TestAddRemoveInterface does this...
- Assign an IPv6 link-local address to one end of a veth interface, and add it to a namespace.
- Add a bridge with no assigned IPv6 address to the namespace.
- Remove the veth interface from the namespace.
- Put the veth interface back into the namespace, still with an explicitly assigned IPv6 link local address.

When IPv6 is disabled on the bridge interface, the test passes.

But, when IPv6 is enabled, the bridge gets a kernel assigned link-local address.

Then, when re-adding the veth interface, the test generates an error in 'osl/interface_linux.go:checkRouteConflict()'. The conflict is between the explicitly assigned fe80::2 on the veth, and a route for fe80::/64 belonging to the bridge.

**- How I did it**

So, in preparation for not-disabling IPv6 on these interfaces, use a unique-local address in the test instead of link-local.

I don't think that changes the intent of the test.

**- How to verify it**

It's a unit test.

With the change to not-always disable IPv6, it is possible to repro the problem with a real container, disconnect and re-connect a user-defined network with '--subnet fe80::/64' while the container's connected to an IPv4 network. So, strictly speaking, that will be a regression.

But, it's also possible to repro the problem in master, by disconnecting and re-connecting the fe80::/64 network while another IPv6 network is connected. (So, I don't think it's a problem we need to address, perhaps other than by prohibiting '--subnet fe80::/64'.)

**- Description for the changelog**

Fix a unit test.

**- A picture of a cute animal (not mandatory but encouraged)**

