### PR TITLE
[WIP] add platform selection to image inspect

### DIFF
--- a/api/server/router/image/image.go
+++ b/api/server/router/image/image.go
@@ -44,7 +44,7 @@ func (ir *imageRouter) initRoutes() {
 		router.NewGetRoute("/images/get", ir.getImagesGet),
 		router.NewGetRoute("/images/{name:.*}/get", ir.getImagesGet),
 		router.NewGetRoute("/images/{name:.*}/history", ir.getImagesHistory),
-		router.NewGetRoute("/images/{name:.*}/json", ir.getImagesByName),
+		router.NewGetRoute("/images/{name:.*}/json", ir.getImageInspect),
 		// POST
 		router.NewPostRoute("/images/load", ir.postImagesLoad),
 		router.NewPostRoute("/images/create", ir.postImagesCreate),

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -298,9 +298,6 @@ func (ir *imageRouter) getImageInspect(ctx context.Context, w http.ResponseWrite
 		}
 	}
 
-	// FIXME(thaJeztah): specifying a platform that's not present does not produce an error, and instead uses the "old" default (linux/amd64);
-	//     curl -s --unix-socket /var/run/docker.sock 'http://localhost/v1.44/images/alpine:latest/json?platform=windows/s390x' | jq .Architecture
-	//    "amd64"
 	img, err := ir.backend.GetImage(ctx, vars["name"], opts.GetImageOpts{
 		Platform: platform,
 		Details:  true,

--- a/api/types/image/opts.go
+++ b/api/types/image/opts.go
@@ -2,8 +2,19 @@ package image
 
 import ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
-// GetImageOpts holds parameters to inspect an image.
+// GetImageOpts holds parameters to retrieve image information
+// from the backend.
 type GetImageOpts struct {
 	Platform *ocispec.Platform
 	Details  bool
+}
+
+// InspectOptions contains options for inspecting images.
+type InspectOptions struct {
+	// Platform specifies the platform for which to show the inspect data
+	// if multiple variants exist for the inspected image.
+	//
+	// If no platform is set, the platform's default platform is used or,
+	// if not present, the first available variant.
+	Platform string
 }

--- a/client/image_inspect.go
+++ b/client/image_inspect.go
@@ -5,16 +5,23 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net/url"
+	"strings"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/image"
 )
 
 // ImageInspectWithRaw returns the image information and its raw representation.
-func (cli *Client) ImageInspectWithRaw(ctx context.Context, imageID string) (types.ImageInspect, []byte, error) {
+func (cli *Client) ImageInspectWithRaw(ctx context.Context, imageID string, options image.InspectOptions) (types.ImageInspect, []byte, error) {
 	if imageID == "" {
 		return types.ImageInspect{}, nil, objectNotFoundError{object: "image", id: imageID}
 	}
-	serverResp, err := cli.get(ctx, "/images/"+imageID+"/json", nil, nil)
+	query := url.Values{}
+	if options.Platform != "" {
+		query.Set("platform", strings.ToLower(options.Platform))
+	}
+	serverResp, err := cli.get(ctx, "/images/"+imageID+"/json", query, nil)
 	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return types.ImageInspect{}, nil, err

--- a/client/image_inspect_test.go
+++ b/client/image_inspect_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
@@ -23,7 +24,7 @@ func TestImageInspectError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, _, err := client.ImageInspectWithRaw(context.Background(), "nothing")
+	_, _, err := client.ImageInspectWithRaw(context.Background(), "nothing", image.InspectOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
@@ -32,7 +33,7 @@ func TestImageInspectImageNotFound(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusNotFound, "Server error")),
 	}
 
-	_, _, err := client.ImageInspectWithRaw(context.Background(), "unknown")
+	_, _, err := client.ImageInspectWithRaw(context.Background(), "unknown", image.InspectOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
@@ -42,7 +43,7 @@ func TestImageInspectWithEmptyID(t *testing.T) {
 			return nil, errors.New("should not make request")
 		}),
 	}
-	_, _, err := client.ImageInspectWithRaw(context.Background(), "")
+	_, _, err := client.ImageInspectWithRaw(context.Background(), "", image.InspectOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
@@ -68,7 +69,7 @@ func TestImageInspect(t *testing.T) {
 		}),
 	}
 
-	imageInspect, _, err := client.ImageInspectWithRaw(context.Background(), "image_id")
+	imageInspect, _, err := client.ImageInspectWithRaw(context.Background(), "image_id", image.InspectOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/interface.go
+++ b/client/interface.go
@@ -93,7 +93,7 @@ type ImageAPIClient interface {
 	ImageCreate(ctx context.Context, parentReference string, options types.ImageCreateOptions) (io.ReadCloser, error)
 	ImageHistory(ctx context.Context, image string) ([]image.HistoryResponseItem, error)
 	ImageImport(ctx context.Context, source types.ImageImportSource, ref string, options types.ImageImportOptions) (io.ReadCloser, error)
-	ImageInspectWithRaw(ctx context.Context, image string) (types.ImageInspect, []byte, error)
+	ImageInspectWithRaw(ctx context.Context, image string, options image.InspectOptions) (types.ImageInspect, []byte, error)
 	ImageList(ctx context.Context, options types.ImageListOptions) ([]image.Summary, error)
 	ImageLoad(ctx context.Context, input io.Reader, quiet bool) (types.ImageLoadResponse, error)
 	ImagePull(ctx context.Context, ref string, options types.ImagePullOptions) (io.ReadCloser, error)

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -39,6 +39,7 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 
 	platform := matchAllWithPreference(platforms.Default())
 	if options.Platform != nil {
+		log.G(ctx).WithField("platform", platforms.Format(*options.Platform)).Info("filtering by platform")
 		platform = platforms.OnlyStrict(*options.Platform)
 	}
 
@@ -76,6 +77,7 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 		ref, _ := reference.ParseAnyReference(refOrID)
 		return nil, images.ErrImageDoesNotExist{Ref: ref}
 	}
+	log.G(ctx).WithField("images", len(presentImages)).Info("found images")
 
 	sort.SliceStable(presentImages, func(i, j int) bool {
 		return platform.Less(presentImages[i].Platform, presentImages[j].Platform)

--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -24,7 +24,8 @@ import (
 
 // ErrImageDoesNotExist is error returned when no image can be found for a reference.
 type ErrImageDoesNotExist struct {
-	Ref reference.Reference
+	Ref      reference.Reference
+	Platform *ocispec.Platform
 }
 
 func (e ErrImageDoesNotExist) Error() string {
@@ -32,7 +33,10 @@ func (e ErrImageDoesNotExist) Error() string {
 	if named, ok := ref.(reference.Named); ok {
 		ref = reference.TagNameOnly(named)
 	}
-	return fmt.Sprintf("No such image: %s", reference.FamiliarString(ref))
+	if e.Platform == nil {
+		return fmt.Sprintf("No such image: %s", reference.FamiliarString(ref))
+	}
+	return fmt.Sprintf("No such image: %s for platform: %s", reference.FamiliarString(ref), platforms.Format(*e.Platform))
 }
 
 // NotFound implements the NotFound interface

--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/fakecontext"
 	"github.com/docker/docker/testutil/fakegit"
@@ -320,10 +321,10 @@ func (s *DockerAPISuite) TestBuildOnBuildCache(c *testing.T) {
 	// check parentID is correct
 	// Parent is graphdriver-only
 	if !testEnv.UsingSnapshotter() {
-		image, _, err := client.ImageInspectWithRaw(ctx, childID)
+		img, _, err := client.ImageInspectWithRaw(ctx, childID, image.InspectOptions{})
 		assert.NilError(c, err)
 
-		assert.Check(c, is.Equal(parentID, image.Parent))
+		assert.Check(c, is.Equal(parentID, img.Parent))
 	}
 }
 

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/versions/v1p20"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/cli"
@@ -110,7 +111,7 @@ func (s *DockerAPISuite) TestInspectAPIImageResponse(c *testing.T) {
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
-	imageJSON, _, err := apiClient.ImageInspectWithRaw(testutil.GetContext(c), "busybox")
+	imageJSON, _, err := apiClient.ImageInspectWithRaw(testutil.GetContext(c), "busybox", image.InspectOptions{})
 	assert.NilError(c, err)
 
 	assert.Check(c, len(imageJSON.RepoTags) == 2)

--- a/integration/build/build_squash_test.go
+++ b/integration/build/build_squash_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
 	dclient "github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/pkg/stdcopy"
@@ -63,7 +64,7 @@ func TestBuildSquashParent(t *testing.T) {
 	resp.Body.Close()
 	assert.NilError(t, err)
 
-	inspect, _, err := client.ImageInspectWithRaw(ctx, name)
+	inspect, _, err := client.ImageInspectWithRaw(ctx, name, image.InspectOptions{})
 	assert.NilError(t, err)
 	origID := inspect.ID
 
@@ -110,7 +111,7 @@ func TestBuildSquashParent(t *testing.T) {
 	testHistory, err := client.ImageHistory(ctx, name)
 	assert.NilError(t, err)
 
-	inspect, _, err = client.ImageInspectWithRaw(ctx, name)
+	inspect, _, err = client.ImageInspectWithRaw(ctx, name, image.InspectOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Len(testHistory, len(origHistory)+1))
 	assert.Check(t, is.Len(inspect.RootFS.Layers, 2))

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/testutil"
@@ -178,7 +179,7 @@ func TestBuildMultiStageCopy(t *testing.T) {
 			assert.NilError(t, err)
 
 			// verify the image was successfully built
-			_, _, err = apiclient.ImageInspectWithRaw(ctx, imgName)
+			_, _, err = apiclient.ImageInspectWithRaw(ctx, imgName, image.InspectOptions{})
 			if err != nil {
 				t.Log(out)
 			}
@@ -219,7 +220,7 @@ func TestBuildMultiStageParentConfig(t *testing.T) {
 	assert.Check(t, resp.Body.Close())
 	assert.NilError(t, err)
 
-	img, _, err := apiclient.ImageInspectWithRaw(ctx, imgName)
+	img, _, err := apiclient.ImageInspectWithRaw(ctx, imgName, image.InspectOptions{})
 	assert.NilError(t, err)
 
 	expected := "/foo/sub2"
@@ -268,7 +269,7 @@ func TestBuildLabelWithTargets(t *testing.T) {
 	assert.Check(t, resp.Body.Close())
 	assert.NilError(t, err)
 
-	img, _, err := apiclient.ImageInspectWithRaw(ctx, imgName)
+	img, _, err := apiclient.ImageInspectWithRaw(ctx, imgName, image.InspectOptions{})
 	assert.NilError(t, err)
 
 	testLabels["label-a"] = "inline-a"
@@ -295,7 +296,7 @@ func TestBuildLabelWithTargets(t *testing.T) {
 	assert.Check(t, resp.Body.Close())
 	assert.NilError(t, err)
 
-	img, _, err = apiclient.ImageInspectWithRaw(ctx, imgName)
+	img, _, err = apiclient.ImageInspectWithRaw(ctx, imgName, image.InspectOptions{})
 	assert.NilError(t, err)
 
 	testLabels["label-b"] = "inline-b"
@@ -377,7 +378,7 @@ RUN cat somefile`
 	assert.NilError(t, err)
 	assert.Assert(t, is.Equal(3, len(imageIDs)))
 
-	img, _, err := apiclient.ImageInspectWithRaw(ctx, imageIDs[2])
+	img, _, err := apiclient.ImageInspectWithRaw(ctx, imageIDs[2], image.InspectOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Contains(img.Config.Env, "bar=baz"))
 }

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
@@ -479,7 +480,7 @@ func TestCreateDifferentPlatform(t *testing.T) {
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()
 
-	img, _, err := apiClient.ImageInspectWithRaw(ctx, "busybox:latest")
+	img, _, err := apiClient.ImageInspectWithRaw(ctx, "busybox:latest", image.InspectOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, img.Architecture != "")
 

--- a/integration/image/commit_test.go
+++ b/integration/image/commit_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	containertypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
@@ -28,7 +29,7 @@ func TestCommitInheritsEnv(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
-	image1, _, err := client.ImageInspectWithRaw(ctx, commitResp1.ID)
+	image1, _, err := client.ImageInspectWithRaw(ctx, commitResp1.ID, image.InspectOptions{})
 	assert.NilError(t, err)
 
 	expectedEnv1 := []string{"PATH=/bin"}
@@ -42,7 +43,7 @@ func TestCommitInheritsEnv(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
-	image2, _, err := client.ImageInspectWithRaw(ctx, commitResp2.ID)
+	image2, _, err := client.ImageInspectWithRaw(ctx, commitResp2.ID, image.InspectOptions{})
 	assert.NilError(t, err)
 	expectedEnv2 := []string{"PATH=/usr/bin:/bin"}
 	assert.Check(t, is.DeepEqual(expectedEnv2, image2.Config.Env))

--- a/integration/image/import_test.go
+++ b/integration/image/import_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	imgtypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
@@ -113,7 +114,7 @@ func TestImportWithCustomPlatform(t *testing.T) {
 				types.ImageImportOptions{Platform: tc.platform})
 			assert.NilError(t, err)
 
-			inspect, _, err := client.ImageInspectWithRaw(ctx, reference)
+			inspect, _, err := client.ImageInspectWithRaw(ctx, reference, imgtypes.InspectOptions{})
 			assert.NilError(t, err)
 			assert.Equal(t, inspect.Os, tc.expected.OS)
 			assert.Equal(t, inspect.Architecture, tc.expected.Architecture)

--- a/integration/image/inspect_test.go
+++ b/integration/image/inspect_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/internal/testutils/specialimage"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -19,7 +20,7 @@ func TestImageInspectEmptyTagsAndDigests(t *testing.T) {
 
 	danglingID := specialimage.Load(ctx, t, client, specialimage.Dangling)
 
-	inspect, raw, err := client.ImageInspectWithRaw(ctx, danglingID)
+	inspect, raw, err := client.ImageInspectWithRaw(ctx, danglingID, image.InspectOptions{})
 	assert.NilError(t, err)
 
 	// Must be a zero length array, not null.

--- a/integration/image/list_test.go
+++ b/integration/image/list_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/testutil"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -73,11 +74,11 @@ func TestImagesFilterUntil(t *testing.T) {
 		imgs[i] = id.ID
 	}
 
-	olderImage, _, err := client.ImageInspectWithRaw(ctx, imgs[2])
+	olderImage, _, err := client.ImageInspectWithRaw(ctx, imgs[2], image.InspectOptions{})
 	assert.NilError(t, err)
 	olderUntil := olderImage.Created
 
-	laterImage, _, err := client.ImageInspectWithRaw(ctx, imgs[3])
+	laterImage, _, err := client.ImageInspectWithRaw(ctx, imgs[3], image.InspectOptions{})
 	assert.NilError(t, err)
 	laterUntil := laterImage.Created
 

--- a/integration/image/prune_test.go
+++ b/integration/image/prune_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/internal/testutils/specialimage"
 	"github.com/docker/docker/testutil/daemon"
@@ -28,7 +29,7 @@ func TestPruneDontDeleteUsedDangling(t *testing.T) {
 
 	danglingID := specialimage.Load(ctx, t, client, specialimage.Dangling)
 
-	_, _, err := client.ImageInspectWithRaw(ctx, danglingID)
+	_, _, err := client.ImageInspectWithRaw(ctx, danglingID, image.InspectOptions{})
 	assert.NilError(t, err, "Test dangling image doesn't exist")
 
 	container.Create(ctx, t, client,
@@ -44,6 +45,6 @@ func TestPruneDontDeleteUsedDangling(t *testing.T) {
 		}
 	}
 
-	_, _, err = client.ImageInspectWithRaw(ctx, danglingID)
+	_, _, err = client.ImageInspectWithRaw(ctx, danglingID, image.InspectOptions{})
 	assert.NilError(t, err, "Test dangling image should still exist")
 }

--- a/integration/image/remove_test.go
+++ b/integration/image/remove_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/container"
 	"gotest.tools/v3/assert"
@@ -29,7 +30,7 @@ func TestRemoveImageOrphaning(t *testing.T) {
 	assert.NilError(t, err)
 
 	// verifies that reference now points to first image
-	resp, _, err := client.ImageInspectWithRaw(ctx, imgName)
+	resp, _, err := client.ImageInspectWithRaw(ctx, imgName, image.InspectOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(resp.ID, commitResp1.ID))
 
@@ -42,7 +43,7 @@ func TestRemoveImageOrphaning(t *testing.T) {
 	assert.NilError(t, err)
 
 	// verifies that reference now points to second image
-	resp, _, err = client.ImageInspectWithRaw(ctx, imgName)
+	resp, _, err = client.ImageInspectWithRaw(ctx, imgName, image.InspectOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(resp.ID, commitResp2.ID))
 
@@ -51,12 +52,12 @@ func TestRemoveImageOrphaning(t *testing.T) {
 	assert.NilError(t, err)
 
 	// check if the first image is still there
-	resp, _, err = client.ImageInspectWithRaw(ctx, commitResp1.ID)
+	resp, _, err = client.ImageInspectWithRaw(ctx, commitResp1.ID, image.InspectOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(resp.ID, commitResp1.ID))
 
 	// check if the second image has been deleted
-	_, _, err = client.ImageInspectWithRaw(ctx, commitResp2.ID)
+	_, _, err = client.ImageInspectWithRaw(ctx, commitResp2.ID, image.InspectOptions{})
 	assert.Check(t, is.ErrorContains(err, "No such image:"))
 }
 
@@ -69,7 +70,7 @@ func TestRemoveByDigest(t *testing.T) {
 	err := client.ImageTag(ctx, "busybox", "test-remove-by-digest:latest")
 	assert.NilError(t, err)
 
-	inspect, _, err := client.ImageInspectWithRaw(ctx, "test-remove-by-digest")
+	inspect, _, err := client.ImageInspectWithRaw(ctx, "test-remove-by-digest", image.InspectOptions{})
 	assert.NilError(t, err)
 
 	id := ""
@@ -85,9 +86,9 @@ func TestRemoveByDigest(t *testing.T) {
 	_, err = client.ImageRemove(ctx, id, types.ImageRemoveOptions{})
 	assert.NilError(t, err)
 
-	inspect, _, err = client.ImageInspectWithRaw(ctx, "busybox")
+	inspect, _, err = client.ImageInspectWithRaw(ctx, "busybox", image.InspectOptions{})
 	assert.Check(t, err, "busybox image got deleted")
 
-	inspect, _, err = client.ImageInspectWithRaw(ctx, "test-remove-by-digest")
+	inspect, _, err = client.ImageInspectWithRaw(ctx, "test-remove-by-digest", image.InspectOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }

--- a/integration/image/remove_unix_test.go
+++ b/integration/image/remove_unix_test.go
@@ -13,6 +13,7 @@ import (
 	"unsafe"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/image"
 	_ "github.com/docker/docker/daemon/graphdriver/register" // register graph drivers
 	"github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/layer"
@@ -47,7 +48,7 @@ func TestRemoveImageGarbageCollector(t *testing.T) {
 
 	layerStore, _ := layer.NewStoreFromOptions(layer.StoreOptions{
 		Root:                      d.Root,
-		MetadataStorePathTemplate: filepath.Join(d.RootDir(), "image", "%s", "layerdb"),
+		MetadataStorePathTemplate: filepath.Join(d.RootDir(), "img", "%s", "layerdb"),
 		GraphDriver:               d.StorageDriver(),
 		GraphDriverOptions:        nil,
 		IDMapping:                 idtools.IdentityMapping{},
@@ -76,11 +77,11 @@ func TestRemoveImageGarbageCollector(t *testing.T) {
 	_, err = io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
 	assert.NilError(t, err)
-	image, _, err := client.ImageInspectWithRaw(ctx, imgName)
+	img, _, err := client.ImageInspectWithRaw(ctx, imgName, image.InspectOptions{})
 	assert.NilError(t, err)
 
 	// Mark latest image layer to immutable
-	data := image.GraphDriver.Data
+	data := img.GraphDriver.Data
 	file, _ := os.Open(data["UpperDir"])
 	attr := 0x00000010
 	fsflags := uintptr(0x40086602)

--- a/integration/image/save_test.go
+++ b/integration/image/save_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cpuguy83/tar2go"
 	containertypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration/internal/build"
 	"github.com/docker/docker/integration/internal/container"
@@ -58,7 +59,7 @@ func TestSaveCheckTimes(t *testing.T) {
 	client := testEnv.APIClient()
 
 	const repoName = "busybox:latest"
-	img, _, err := client.ImageInspectWithRaw(ctx, repoName)
+	img, _, err := client.ImageInspectWithRaw(ctx, repoName, image.InspectOptions{})
 	assert.NilError(t, err)
 
 	rdr, err := client.ImageSave(ctx, []string{repoName})
@@ -97,7 +98,7 @@ func TestSaveCheckManifestLayers(t *testing.T) {
 	t.Parallel()
 
 	const repoName = "busybox:latest"
-	img, _, err := client.ImageInspectWithRaw(ctx, repoName)
+	img, _, err := client.ImageInspectWithRaw(ctx, repoName, image.InspectOptions{})
 	assert.NilError(t, err)
 
 	rdr, err := client.ImageSave(ctx, []string{repoName})
@@ -149,7 +150,7 @@ func TestSaveRepoWithMultipleImages(t *testing.T) {
 		return res.ID
 	}
 
-	busyboxImg, _, err := client.ImageInspectWithRaw(ctx, "busybox:latest")
+	busyboxImg, _, err := client.ImageInspectWithRaw(ctx, "busybox:latest", image.InspectOptions{})
 	assert.NilError(t, err)
 
 	const repoName = "foobar-save-multi-images-test"

--- a/integration/image/tag_test.go
+++ b/integration/image/tag_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/docker/docker/api/types/image"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -19,7 +20,7 @@ func TestTagUnprefixedRepoByNameOrName(t *testing.T) {
 	assert.NilError(t, err)
 
 	// By ID
-	insp, _, err := client.ImageInspectWithRaw(ctx, "busybox")
+	insp, _, err := client.ImageInspectWithRaw(ctx, "busybox", image.InspectOptions{})
 	assert.NilError(t, err)
 	err = client.ImageTag(ctx, insp.ID, "testfoobarbaz")
 	assert.NilError(t, err)
@@ -80,7 +81,7 @@ func TestTagOfficialNames(t *testing.T) {
 			assert.NilError(t, err)
 
 			// ensure we don't have multiple tag names.
-			insp, _, err := client.ImageInspectWithRaw(ctx, "busybox")
+			insp, _, err := client.ImageInspectWithRaw(ctx, "busybox", image.InspectOptions{})
 			assert.NilError(t, err)
 			// TODO(vvoland): Not sure what's actually being tested here. Is is still doing anything useful?
 			assert.Assert(t, !is.Contains(insp.RepoTags, name)().Success())
@@ -102,6 +103,6 @@ func TestTagMatchesDigest(t *testing.T) {
 	assert.Check(t, is.ErrorContains(err, "refusing to create a tag with a digest reference"))
 
 	// check that no new image matches the digest
-	_, _, err = client.ImageInspectWithRaw(ctx, digest)
+	_, _, err = client.ImageInspectWithRaw(ctx, digest, image.InspectOptions{})
 	assert.Check(t, is.ErrorContains(err, fmt.Sprintf("No such image: %s", digest)))
 }

--- a/testutil/fixtures/load/frozen.go
+++ b/testutil/fixtures/load/frozen.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/moby/term"
@@ -85,7 +86,7 @@ func FrozenImagesLinux(ctx context.Context, client client.APIClient, images ...s
 func imageExists(ctx context.Context, client client.APIClient, name string) bool {
 	ctx, span := otel.Tracer("").Start(ctx, "check image exists: "+name)
 	defer span.End()
-	_, _, err := client.ImageInspectWithRaw(ctx, name)
+	_, _, err := client.ImageInspectWithRaw(ctx, name, image.InspectOptions{})
 	if err != nil {
 		span.RecordError(err)
 	}


### PR DESCRIPTION
If an image has multiple platforms in the local image store, we default to the host's default platform when inspecting the image.

With this patch applied, the inspect endpoint now allows a platform query-parameter to be passed to select the variant to inspect;

    hack/make.sh binary && make install
    TEST_INTEGRATION_USE_SNAPSHOTTER=1 dockerd --debug --storage-driver=overlayfs

    docker pull --platform=linux/arm64 alpine
    docker pull --platform=linux/amd64 alpine

    curl -s --unix-socket /var/run/docker.sock 'http://localhost/v1.44/images/alpine:latest/json?platform=linux/arm64' | jq .Architecture
    "arm64"
    curl -s --unix-socket /var/run/docker.sock 'http://localhost/v1.44/images/alpine:latest/json?platform=linux/amd64' | jq .Architecture
    "amd64"

Still to fix: when passing a platform for which no images are present, all images
are found, and it returns the first image (or the old default: "linux/amd64");

    curl -s --unix-socket /var/run/docker.sock 'http://localhost/v1.44/images/alpine:latest/json?platform=windows/s390x' | jq .Architecture
    "amd64"

Daemon logs:

    INFO[2024-01-19T09:51:13.692119375Z] API listen on /var/run/docker.sock
    DEBU[2024-01-19T09:51:15.421193584Z] Calling GET /v1.44/images/alpine:latest/json?platform=windows/s390x
    INFO[2024-01-19T09:51:15.422053417Z] filtering by platform                         platform=windows/s390x
    INFO[2024-01-19T09:51:15.429996542Z] found images                                  images=2

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

