### PR TITLE
API: bump version to 1.45

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -3,7 +3,7 @@ package api // import "github.com/docker/docker/api"
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of Current REST API
-	DefaultVersion = "1.44"
+	DefaultVersion = "1.45"
 
 	// NoBaseImageSpecifier is the symbol used by the FROM
 	// command to specify that no base image is to be used.

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -19,10 +19,10 @@ produces:
 consumes:
   - "application/json"
   - "text/plain"
-basePath: "/v1.44"
+basePath: "/v1.45"
 info:
   title: "Docker Engine API"
-  version: "1.44"
+  version: "1.45"
   x-logo:
     url: "https://docs.docker.com/assets/images/logo-docker-main.png"
   description: |
@@ -55,8 +55,8 @@ info:
     the URL is not supported by the daemon, a HTTP `400 Bad Request` error message
     is returned.
 
-    If you omit the version-prefix, the current version of the API (v1.44) is used.
-    For example, calling `/info` is the same as calling `/v1.44/info`. Using the
+    If you omit the version-prefix, the current version of the API (v1.45) is used.
+    For example, calling `/info` is the same as calling `/v1.45/info`. Using the
     API without a version-prefix is deprecated and will be removed in a future release.
 
     Engine releases in the near future should support this version of the API,

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -13,6 +13,10 @@ keywords: "API, Docker, rcli, REST, documentation"
      will be rejected.
 -->
 
+## v1.45 API changes
+
+[Docker Engine API v1.45](https://docs.docker.com/engine/api/v1.45/) documentation
+
 ## v1.44 API changes
 
 [Docker Engine API v1.44](https://docs.docker.com/engine/api/v1.44/) documentation


### PR DESCRIPTION
Docker 25.0 was released with API v1.44, so any change in the API should now target v1.45.

(no new changes to `docs/api/v1.44.yaml` since last copy from `swagger.yaml`)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

