### PR TITLE
Make sure that make doesn't rm -rf the system out of existence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,9 @@ swagger-docs: ## preview the API documentation
 .PHONY: generate-files
 generate-files:
 	$(eval $@_TMP_OUT := $(shell mktemp -d -t moby-output.XXXXXXXXXX))
+	ifeq ($($@_TMP_OUT),)
+		$(error Could not create temp directory.)
+	endif
 	$(BUILD_CMD) --target "update" \
 		--output "type=local,dest=$($@_TMP_OUT)" \
 		--file "./hack/dockerfiles/generate-files.Dockerfile" .


### PR DESCRIPTION
**- What I did**

Ensure that make raises an error if `mktemp`, for whatever reason, returns an empty string. This could possibly happen if, for some reason, the `/tmp` directory was chown'd or there was no free space left on the system.

This pull request makes sure that it won't `rm -rf /*` the system out of existence in case `$@_TMP_OUT` is an empty string.

If `$($@_TMP_OUT)` was empty,
```
rm -rf "$($@_TMP_OUT)"/*
```
would evaluate to
```
rm -rf /*
```
What would happen next is up to your imagination

**- How I did it**

I did it by adding
```
ifeq ($($@_TMP_OUT),)
    $(error Could not create temp directory.)
endif
```
after
```
$(eval $@_TMP_OUT := $(shell mktemp -d -t moby-output.XXXXXXXXXX))
```
in the Makefile

**- How to verify it**

Run `make generate-files`

**- Description for the changelog**
- Fix potential system wipe

