### PR TITLE
pkg/homedir: remove deprecated Key() and GetShortcutString()

### DIFF
--- a/pkg/homedir/homedir.go
+++ b/pkg/homedir/homedir.go
@@ -6,14 +6,6 @@ import (
 	"runtime"
 )
 
-// Key returns the env var name for the user's home dir based on
-// the platform being run on.
-//
-// Deprecated: this function is no longer used, and will be removed in the next release.
-func Key() string {
-	return envKeyName
-}
-
 // Get returns the home directory of the current user with the help of
 // environment variables depending on the target operating system.
 // Returned path should be used with "path/filepath" to form new paths.
@@ -33,12 +25,4 @@ func Get() string {
 		}
 	}
 	return home
-}
-
-// GetShortcutString returns the string that is shortcut to user's home directory
-// in the native shell of the platform running on.
-//
-// Deprecated: this function is no longer used, and will be removed in the next release.
-func GetShortcutString() string {
-	return homeShortCut
 }

--- a/pkg/homedir/homedir_test.go
+++ b/pkg/homedir/homedir_test.go
@@ -15,10 +15,3 @@ func TestGet(t *testing.T) {
 		t.Fatalf("returned path is not absolute: %s", home)
 	}
 }
-
-func TestGetShortcutString(t *testing.T) {
-	shortcut := GetShortcutString() //nolint:staticcheck // ignore SA1019 (GetShortcutString is deprecated)
-	if shortcut == "" {
-		t.Fatal("returned shortcut string is empty")
-	}
-}

--- a/pkg/homedir/homedir_unix.go
+++ b/pkg/homedir/homedir_unix.go
@@ -1,8 +1,0 @@
-//go:build !windows
-
-package homedir // import "github.com/docker/docker/pkg/homedir"
-
-const (
-	envKeyName   = "HOME"
-	homeShortCut = "~"
-)

--- a/pkg/homedir/homedir_windows.go
+++ b/pkg/homedir/homedir_windows.go
@@ -1,6 +1,0 @@
-package homedir // import "github.com/docker/docker/pkg/homedir"
-
-const (
-	envKeyName   = "USERPROFILE"
-	homeShortCut = "%USERPROFILE%" // be careful while using in format functions
-)


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/45814
- relates to https://github.com/moby/moby/pull/45814


These were deprecated in ddd9665289fae5f2f62343d9355e9d5e1b97a2d8 (v25.0), and 3c1de2e667f4ff99e2f05993e9fb5e66b1c77b68, and are no longer used.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
- pkg/homedir: remove deprecated Key() and GetShortcutString()
```


**- A picture of a cute animal (not mandatory but encouraged)**

