### PR TITLE
pkg/containerfs: remove deprecated ResolveScopedPath

### DIFF
--- a/pkg/containerfs/containerfs.go
+++ b/pkg/containerfs/containerfs.go
@@ -1,10 +1,6 @@
 package containerfs // import "github.com/docker/docker/pkg/containerfs"
 
-import (
-	"path/filepath"
-
-	"github.com/moby/sys/symlink"
-)
+import "path/filepath"
 
 // CleanScopedPath prepares the given path to be combined with a mount path or
 // a drive-letter. On Windows, it removes any existing driveletter (e.g. "C:").
@@ -16,12 +12,4 @@ func CleanScopedPath(path string) string {
 		}
 	}
 	return filepath.Join(string(filepath.Separator), path)
-}
-
-// ResolveScopedPath evaluates the given path scoped to the root.
-// For example, if root=/a, and path=/b/c, then this function would return /a/b/c.
-//
-// Deprecated: use [symlink.FollowSymlinkInScope].
-func ResolveScopedPath(root, path string) (string, error) {
-	return symlink.FollowSymlinkInScope(filepath.Join(root, path), root)
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/47006

This function was deprecated in b8f2caa80ab9a412e53e207de89cc1181aee6516 (v25.0), and is no longer in use.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
pkg/containerfs: remove deprecated ResolveScopedPath
```


**- A picture of a cute animal (not mandatory but encouraged)**

