### PR TITLE
[25.0 backport] libnetwork: loosen container IPAM validation

### DIFF
--- a/integration/internal/network/ops.go
+++ b/integration/internal/network/ops.go
@@ -73,6 +73,11 @@ func WithOption(key, value string) func(*types.NetworkCreate) {
 
 // WithIPAM adds an IPAM with the specified Subnet and Gateway to the network
 func WithIPAM(subnet, gateway string) func(*types.NetworkCreate) {
+	return WithIPAMRange(subnet, "", gateway)
+}
+
+// WithIPAM adds an IPAM with the specified Subnet, IPRange and Gateway to the network
+func WithIPAMRange(subnet, iprange, gateway string) func(*types.NetworkCreate) {
 	return func(n *types.NetworkCreate) {
 		if n.IPAM == nil {
 			n.IPAM = &network.IPAM{}
@@ -80,6 +85,7 @@ func WithIPAM(subnet, gateway string) func(*types.NetworkCreate) {
 
 		n.IPAM.Config = append(n.IPAM.Config, network.IPAMConfig{
 			Subnet:     subnet,
+			IPRange:    iprange,
 			Gateway:    gateway,
 			AuxAddress: map[string]string{},
 		})

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -83,7 +83,7 @@ type IpamConf struct {
 	// PreferredPool is the master address pool for containers and network interfaces.
 	PreferredPool string
 	// SubPool is a subset of the master pool. If specified,
-	// this becomes the container pool.
+	// this becomes the container pool for automatic address allocations.
 	SubPool string
 	// Gateway is the preferred Network Gateway address (optional).
 	Gateway string
@@ -100,7 +100,7 @@ func (c *IpamConf) Validate() error {
 	return nil
 }
 
-// Contains checks whether the ipamSubnet contains [addr].
+// Contains checks whether the ipam master address pool contains [addr].
 func (c *IpamConf) Contains(addr net.IP) bool {
 	if c == nil {
 		return false
@@ -110,9 +110,6 @@ func (c *IpamConf) Contains(addr net.IP) bool {
 	}
 
 	_, allowedRange, _ := net.ParseCIDR(c.PreferredPool)
-	if c.SubPool != "" {
-		_, allowedRange, _ = net.ParseCIDR(c.SubPool)
-	}
 
 	return allowedRange.Contains(addr)
 }


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/47132
- Fixes #47120

(cherry picked from commit 058b30023f538b5c53b960675dae9bd163aeef8e)

**- What I did**
Permit container network attachments to set any static IP address within the network's IPAM master pool, including when a subpool is configured. Users have come to depend on being able to statically assign container IP addresses which are guaranteed not to collide with automatically- assigned container addresses.

**- How I did it**
By deleting a couple lines of code

**- How to verify it**
New regression test

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Fixed a regression which restricted static container IP address assignments to the `--ip-range` of a container network

**- A picture of a cute animal (not mandatory but encouraged)**
