### PR TITLE
api/types/image: move GetImageOpts to api/types/backend

### DIFF
--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/registry"
@@ -25,7 +26,7 @@ type imageBackend interface {
 	ImageDelete(ctx context.Context, imageRef string, force, prune bool) ([]image.DeleteResponse, error)
 	ImageHistory(ctx context.Context, imageName string) ([]*image.HistoryResponseItem, error)
 	Images(ctx context.Context, opts types.ImageListOptions) ([]*image.Summary, error)
-	GetImage(ctx context.Context, refOrID string, options image.GetImageOpts) (*dockerimage.Image, error)
+	GetImage(ctx context.Context, refOrID string, options backend.GetImageOpts) (*dockerimage.Image, error)
 	TagImage(ctx context.Context, id dockerimage.ID, newRef reference.Named) error
 	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*types.ImagesPruneReport, error)
 }

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -15,8 +15,9 @@ import (
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/filters"
-	opts "github.com/docker/docker/api/types/image"
+	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/builder/remotecontext"
@@ -285,7 +286,7 @@ func (ir *imageRouter) deleteImages(ctx context.Context, w http.ResponseWriter, 
 }
 
 func (ir *imageRouter) getImagesByName(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	img, err := ir.backend.GetImage(ctx, vars["name"], opts.GetImageOpts{Details: true})
+	img, err := ir.backend.GetImage(ctx, vars["name"], backend.GetImageOpts{Details: true})
 	if err != nil {
 		return err
 	}
@@ -353,7 +354,7 @@ func (ir *imageRouter) toImageInspect(img *image.Image) (*types.ImageInspect, er
 			Data: img.Details.Metadata,
 		},
 		RootFS: rootFSToAPIType(img.RootFS),
-		Metadata: opts.Metadata{
+		Metadata: imagetypes.Metadata{
 			LastTagTime: img.Details.LastUpdated,
 		},
 	}, nil
@@ -452,7 +453,7 @@ func (ir *imageRouter) postImagesTag(ctx context.Context, w http.ResponseWriter,
 		return errdefs.InvalidParameter(errors.New("refusing to create an ambiguous tag using digest algorithm as name"))
 	}
 
-	img, err := ir.backend.GetImage(ctx, vars["name"], opts.GetImageOpts{})
+	img, err := ir.backend.GetImage(ctx, vars["name"], backend.GetImageOpts{})
 	if err != nil {
 		return errdefs.NotFound(err)
 	}

--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -130,6 +130,13 @@ type CreateImageConfig struct {
 	Changes []string
 }
 
+// GetImageOpts holds parameters to retrieve image information
+// from the backend.
+type GetImageOpts struct {
+	Platform *ocispec.Platform
+	Details  bool
+}
+
 // CommitConfig is the configuration for creating an image as part of a build.
 type CommitConfig struct {
 	Author              string

--- a/api/types/image/opts.go
+++ b/api/types/image/opts.go
@@ -1,9 +1,0 @@
-package image
-
-import ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-
-// GetImageOpts holds parameters to inspect an image.
-type GetImageOpts struct {
-	Platform *ocispec.Platform
-	Details  bool
-}

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
-	opts "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm"
@@ -78,5 +77,5 @@ type VolumeBackend interface {
 type ImageBackend interface {
 	PullImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
 	GetRepositories(context.Context, reference.Named, *registry.AuthConfig) ([]distribution.Repository, error)
-	GetImage(ctx context.Context, refOrID string, options opts.GetImageOpts) (*image.Image, error)
+	GetImage(ctx context.Context, refOrID string, options backend.GetImageOpts) (*image.Image, error)
 }

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -17,7 +17,6 @@ import (
 	"github.com/docker/docker/api/types/backend"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
-	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/registry"
 	containerpkg "github.com/docker/docker/container"
 	"github.com/docker/docker/daemon"
@@ -76,7 +75,7 @@ func (c *containerAdapter) pullImage(ctx context.Context) error {
 	named, err := reference.ParseNormalizedNamed(spec.Image)
 	if err == nil {
 		if _, ok := named.(reference.Canonical); ok {
-			_, err := c.imageBackend.GetImage(ctx, spec.Image, imagetypes.GetImageOpts{})
+			_, err := c.imageBackend.GetImage(ctx, spec.Image, backend.GetImageOpts{})
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return err
 			}

--- a/daemon/containerd/cache.go
+++ b/daemon/containerd/cache.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
-	imagetype "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
@@ -31,7 +31,7 @@ func (i *ImageService) MakeImageCache(ctx context.Context, cacheFrom []string) (
 		}
 		for _, hi := range h {
 			if hi.ID != "<missing>" {
-				im, err := i.GetImage(ctx, hi.ID, imagetype.GetImageOpts{})
+				im, err := i.GetImage(ctx, hi.ID, backend.GetImageOpts{})
 				if err != nil {
 					return nil, err
 				}
@@ -99,7 +99,7 @@ func (ic *localCache) GetCache(parentID string, cfg *container.Config) (imageID 
 		}
 
 		if isMatch(&cc, cfg) {
-			childImage, err := ic.imageService.GetImage(ctx, child.String(), imagetype.GetImageOpts{})
+			childImage, err := ic.imageService.GetImage(ctx, child.String(), backend.GetImageOpts{})
 			if err != nil {
 				return "", err
 			}
@@ -142,7 +142,7 @@ func (ic *imageCache) GetCache(parentID string, cfg *container.Config) (imageID 
 	lenHistory := 0
 
 	if parentID != "" {
-		parent, err = ic.imageService.GetImage(ctx, parentID, imagetype.GetImageOpts{})
+		parent, err = ic.imageService.GetImage(ctx, parentID, backend.GetImageOpts{})
 		if err != nil {
 			return "", err
 		}
@@ -200,7 +200,7 @@ func (ic *imageCache) isParent(ctx context.Context, img *image.Image, parentID i
 		return parent == parentID.String()
 	}
 
-	p, err := ic.imageService.GetImage(ctx, parentID.String(), imagetype.GetImageOpts{})
+	p, err := ic.imageService.GetImage(ctx, parentID.String(), backend.GetImageOpts{})
 	if err != nil {
 		return false
 	}

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -15,7 +15,7 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
-	imagetype "github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
@@ -31,7 +31,7 @@ var truncatedID = regexp.MustCompile(`^(sha256:)?([a-f0-9]{4,64})$`)
 var errInconsistentData error = errors.New("consistency error: data changed during operation, retry")
 
 // GetImage returns an image corresponding to the image referred to by refOrID.
-func (i *ImageService) GetImage(ctx context.Context, refOrID string, options imagetype.GetImageOpts) (*image.Image, error) {
+func (i *ImageService) GetImage(ctx context.Context, refOrID string, options backend.GetImageOpts) (*image.Image, error) {
 	desc, err := i.resolveImage(ctx, refOrID)
 	if err != nil {
 		return nil, err
@@ -156,7 +156,7 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 	return img, nil
 }
 
-func (i *ImageService) GetImageManifest(ctx context.Context, refOrID string, options imagetype.GetImageOpts) (*ocispec.Descriptor, error) {
+func (i *ImageService) GetImageManifest(ctx context.Context, refOrID string, options backend.GetImageOpts) (*ocispec.Descriptor, error) {
 	platform := matchAllWithPreference(platforms.Default())
 	if options.Platform != nil {
 		platform = platforms.Only(*options.Platform)

--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -23,7 +23,6 @@ import (
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
-	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/errdefs"
@@ -84,7 +83,7 @@ func (i *ImageService) GetImageAndReleasableLayer(ctx context.Context, refOrID s
 
 	if opts.PullOption != backend.PullOptionForcePull {
 		// TODO(laurazard): same as below
-		img, err := i.GetImage(ctx, refOrID, imagetypes.GetImageOpts{Platform: opts.Platform})
+		img, err := i.GetImage(ctx, refOrID, backend.GetImageOpts{Platform: opts.Platform})
 		if err != nil && opts.PullOption == backend.PullOptionNoPull {
 			return nil, nil, err
 		}
@@ -119,7 +118,7 @@ func (i *ImageService) GetImageAndReleasableLayer(ctx context.Context, refOrID s
 
 	// TODO(laurazard): pullForBuilder should return whatever we
 	// need here instead of having to go and get it again
-	img, err := i.GetImage(ctx, refOrID, imagetypes.GetImageOpts{
+	img, err := i.GetImage(ctx, refOrID, backend.GetImageOpts{
 		Platform: opts.Platform,
 	})
 	if err != nil {
@@ -156,7 +155,7 @@ func (i *ImageService) pullForBuilder(ctx context.Context, name string, authConf
 		return nil, err
 	}
 
-	img, err := i.GetImage(ctx, name, imagetypes.GetImageOpts{Platform: platform})
+	img, err := i.GetImage(ctx, name, backend.GetImageOpts{Platform: platform})
 	if err != nil {
 		if errdefs.IsNotFound(err) && img != nil && platform != nil {
 			imgPlat := ocispec.Platform{

--- a/daemon/containerd/image_events.go
+++ b/daemon/containerd/image_events.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/containerd/containerd/images"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/events"
-	imagetypes "github.com/docker/docker/api/types/image"
 )
 
 // LogImageEvent generates an event related to an image with only the default attributes.
@@ -13,7 +13,7 @@ func (i *ImageService) LogImageEvent(imageID, refName string, action events.Acti
 	ctx := context.TODO()
 	attributes := map[string]string{}
 
-	img, err := i.GetImage(ctx, imageID, imagetypes.GetImageOpts{})
+	img, err := i.GetImage(ctx, imageID, backend.GetImageOpts{})
 	if err == nil && img.Config != nil {
 		// image has not been removed yet.
 		// it could be missing if the event is `delete`.

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/filters"
 	imagetypes "github.com/docker/docker/api/types/image"
 	timetypes "github.com/docker/docker/api/types/time"
@@ -320,13 +321,13 @@ type imageFilterFunc func(image images.Image) bool
 func (i *ImageService) setupFilters(ctx context.Context, imageFilters filters.Args) (filterFunc imageFilterFunc, outErr error) {
 	var fltrs []imageFilterFunc
 	err := imageFilters.WalkValues("before", func(value string) error {
-		img, err := i.GetImage(ctx, value, imagetypes.GetImageOpts{})
+		img, err := i.GetImage(ctx, value, backend.GetImageOpts{})
 		if err != nil {
 			return err
 		}
 		if img != nil && img.Created != nil {
 			fltrs = append(fltrs, func(candidate images.Image) bool {
-				cand, err := i.GetImage(ctx, candidate.Name, imagetypes.GetImageOpts{})
+				cand, err := i.GetImage(ctx, candidate.Name, backend.GetImageOpts{})
 				if err != nil {
 					return false
 				}
@@ -340,13 +341,13 @@ func (i *ImageService) setupFilters(ctx context.Context, imageFilters filters.Ar
 	}
 
 	err = imageFilters.WalkValues("since", func(value string) error {
-		img, err := i.GetImage(ctx, value, imagetypes.GetImageOpts{})
+		img, err := i.GetImage(ctx, value, backend.GetImageOpts{})
 		if err != nil {
 			return err
 		}
 		if img != nil && img.Created != nil {
 			fltrs = append(fltrs, func(candidate images.Image) bool {
-				cand, err := i.GetImage(ctx, candidate.Name, imagetypes.GetImageOpts{})
+				cand, err := i.GetImage(ctx, candidate.Name, backend.GetImageOpts{})
 				if err != nil {
 					return false
 				}

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/docker/api/types/backend"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
-	imagetypes "github.com/docker/docker/api/types/image"
 	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/config"
@@ -83,7 +82,7 @@ func (daemon *Daemon) containerCreate(ctx context.Context, daemonCfg *configStor
 	}
 
 	if opts.params.Platform == nil && opts.params.Config.Image != "" {
-		img, err := daemon.imageService.GetImage(ctx, opts.params.Config.Image, imagetypes.GetImageOpts{Platform: opts.params.Platform})
+		img, err := daemon.imageService.GetImage(ctx, opts.params.Config.Image, backend.GetImageOpts{Platform: opts.params.Platform})
 		if err != nil {
 			return containertypes.CreateResponse{}, err
 		}
@@ -139,7 +138,7 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 	)
 
 	if opts.params.Config.Image != "" {
-		img, err = daemon.imageService.GetImage(ctx, opts.params.Config.Image, imagetypes.GetImageOpts{Platform: opts.params.Platform})
+		img, err = daemon.imageService.GetImage(ctx, opts.params.Config.Image, backend.GetImageOpts{Platform: opts.params.Platform})
 		if err != nil {
 			return nil, err
 		}
@@ -147,7 +146,7 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 		// image manifest so we can store it and later deterministically
 		// resolve the specific image the container is running
 		if daemon.UsesSnapshotter() {
-			imgManifest, err = daemon.imageService.GetImageManifest(ctx, opts.params.Config.Image, imagetypes.GetImageOpts{Platform: opts.params.Platform})
+			imgManifest, err = daemon.imageService.GetImageManifest(ctx, opts.params.Config.Image, backend.GetImageOpts{Platform: opts.params.Platform})
 			if err != nil {
 				log.G(ctx).WithError(err).Error("failed to find image manifest")
 				return nil, err

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -40,7 +40,7 @@ type ImageService interface {
 	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*types.ImagesPruneReport, error)
 	ImportImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, msg string, layerReader io.Reader, changes []string) (image.ID, error)
 	TagImage(ctx context.Context, imageID image.ID, newTag reference.Named) error
-	GetImage(ctx context.Context, refOrID string, options imagetype.GetImageOpts) (*image.Image, error)
+	GetImage(ctx context.Context, refOrID string, options backend.GetImageOpts) (*image.Image, error)
 	ImageHistory(ctx context.Context, name string) ([]*imagetype.HistoryResponseItem, error)
 	CommitImage(ctx context.Context, c backend.CommitConfig) (image.ID, error)
 	SquashImage(id, parent string) (string, error)
@@ -48,7 +48,7 @@ type ImageService interface {
 	// Containerd related methods
 
 	PrepareSnapshot(ctx context.Context, id string, parentImage string, platform *ocispec.Platform, setupInit func(string) error) error
-	GetImageManifest(ctx context.Context, refOrID string, options imagetype.GetImageOpts) (*ocispec.Descriptor, error)
+	GetImageManifest(ctx context.Context, refOrID string, options backend.GetImageOpts) (*ocispec.Descriptor, error)
 
 	// Layers
 

--- a/daemon/images/cache.go
+++ b/daemon/images/cache.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/containerd/log"
-	imagetypes "github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/image/cache"
 	"github.com/pkg/errors"
@@ -19,7 +19,7 @@ func (i *ImageService) MakeImageCache(ctx context.Context, sourceRefs []string) 
 	cache := cache.New(i.imageStore)
 
 	for _, ref := range sourceRefs {
-		img, err := i.GetImage(ctx, ref, imagetypes.GetImageOpts{})
+		img, err := i.GetImage(ctx, ref, backend.GetImageOpts{})
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return nil, err

--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -13,7 +13,7 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
-	imagetypes "github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
@@ -164,7 +164,7 @@ func (i *ImageService) manifestMatchesPlatform(ctx context.Context, img *image.I
 }
 
 // GetImage returns an image corresponding to the image referred to by refOrID.
-func (i *ImageService) GetImage(ctx context.Context, refOrID string, options imagetypes.GetImageOpts) (*image.Image, error) {
+func (i *ImageService) GetImage(ctx context.Context, refOrID string, options backend.GetImageOpts) (*image.Image, error) {
 	img, err := i.getImage(ctx, refOrID, options)
 	if err != nil {
 		return nil, err
@@ -201,11 +201,11 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 	return img, nil
 }
 
-func (i *ImageService) GetImageManifest(ctx context.Context, refOrID string, options imagetypes.GetImageOpts) (*ocispec.Descriptor, error) {
+func (i *ImageService) GetImageManifest(ctx context.Context, refOrID string, options backend.GetImageOpts) (*ocispec.Descriptor, error) {
 	panic("not implemented")
 }
 
-func (i *ImageService) getImage(ctx context.Context, refOrID string, options imagetypes.GetImageOpts) (retImg *image.Image, retErr error) {
+func (i *ImageService) getImage(ctx context.Context, refOrID string, options backend.GetImageOpts) (retImg *image.Image, retErr error) {
 	defer func() {
 		if retErr != nil || retImg == nil || options.Platform == nil {
 			return

--- a/daemon/images/image_builder.go
+++ b/daemon/images/image_builder.go
@@ -10,7 +10,6 @@ import (
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types/backend"
-	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/errdefs"
@@ -172,7 +171,7 @@ func (i *ImageService) pullForBuilder(ctx context.Context, name string, authConf
 		return nil, err
 	}
 
-	img, err := i.GetImage(ctx, name, imagetypes.GetImageOpts{Platform: platform})
+	img, err := i.GetImage(ctx, name, backend.GetImageOpts{Platform: platform})
 	if errdefs.IsNotFound(err) && img != nil && platform != nil {
 		imgPlat := ocispec.Platform{
 			OS:           img.OS,
@@ -214,7 +213,7 @@ func (i *ImageService) GetImageAndReleasableLayer(ctx context.Context, refOrID s
 	}
 
 	if opts.PullOption != backend.PullOptionForcePull {
-		img, err := i.GetImage(ctx, refOrID, imagetypes.GetImageOpts{Platform: opts.Platform})
+		img, err := i.GetImage(ctx, refOrID, backend.GetImageOpts{Platform: opts.Platform})
 		if err != nil && opts.PullOption == backend.PullOptionNoPull {
 			return nil, nil, err
 		}

--- a/daemon/images/image_delete.go
+++ b/daemon/images/image_delete.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/distribution/reference"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/events"
 	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/container"
@@ -64,7 +65,7 @@ func (i *ImageService) ImageDelete(ctx context.Context, imageRef string, force, 
 	start := time.Now()
 	records := []imagetypes.DeleteResponse{}
 
-	img, err := i.GetImage(ctx, imageRef, imagetypes.GetImageOpts{})
+	img, err := i.GetImage(ctx, imageRef, backend.GetImageOpts{})
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/images/image_events.go
+++ b/daemon/images/image_events.go
@@ -3,8 +3,8 @@ package images // import "github.com/docker/docker/daemon/images"
 import (
 	"context"
 
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/events"
-	imagetypes "github.com/docker/docker/api/types/image"
 )
 
 // LogImageEvent generates an event related to an image with only the default attributes.
@@ -12,7 +12,7 @@ func (i *ImageService) LogImageEvent(imageID, refName string, action events.Acti
 	ctx := context.TODO()
 	attributes := map[string]string{}
 
-	img, err := i.GetImage(ctx, imageID, imagetypes.GetImageOpts{})
+	img, err := i.GetImage(ctx, imageID, backend.GetImageOpts{})
 	if err == nil && img.Config != nil {
 		// image has not been removed yet.
 		// it could be missing if the event is `delete`.

--- a/daemon/images/image_history.go
+++ b/daemon/images/image_history.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/distribution/reference"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/layer"
 )
@@ -14,7 +15,7 @@ import (
 // name by walking the image lineage.
 func (i *ImageService) ImageHistory(ctx context.Context, name string) ([]*image.HistoryResponseItem, error) {
 	start := time.Now()
-	img, err := i.GetImage(ctx, name, image.GetImageOpts{})
+	img, err := i.GetImage(ctx, name, backend.GetImageOpts{})
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +71,7 @@ func (i *ImageService) ImageHistory(ctx context.Context, name string) ([]*image.
 		if id == "" {
 			break
 		}
-		histImg, err = i.GetImage(ctx, id.String(), image.GetImageOpts{})
+		histImg, err = i.GetImage(ctx, id.String(), backend.GetImageOpts{})
 		if err != nil {
 			break
 		}

--- a/daemon/images/image_list.go
+++ b/daemon/images/image_list.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/backend"
 	imagetypes "github.com/docker/docker/api/types/image"
 	timetypes "github.com/docker/docker/api/types/time"
 	"github.com/docker/docker/container"
@@ -46,7 +47,7 @@ func (i *ImageService) Images(ctx context.Context, opts types.ImageListOptions) 
 
 	var beforeFilter, sinceFilter time.Time
 	err = opts.Filters.WalkValues("before", func(value string) error {
-		img, err := i.GetImage(ctx, value, imagetypes.GetImageOpts{})
+		img, err := i.GetImage(ctx, value, backend.GetImageOpts{})
 		if err != nil {
 			return err
 		}
@@ -81,7 +82,7 @@ func (i *ImageService) Images(ctx context.Context, opts types.ImageListOptions) 
 	}
 
 	err = opts.Filters.WalkValues("since", func(value string) error {
-		img, err := i.GetImage(ctx, value, imagetypes.GetImageOpts{})
+		img, err := i.GetImage(ctx, value, backend.GetImageOpts{})
 		if err != nil {
 			return err
 		}

--- a/daemon/images/image_pull.go
+++ b/daemon/images/image_pull.go
@@ -9,7 +9,7 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
-	imagetypes "github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/distribution"
 	progressutils "github.com/docker/docker/distribution/utils"
@@ -38,7 +38,7 @@ func (i *ImageService) PullImage(ctx context.Context, ref reference.Named, platf
 		// we allow the image to have a non-matching architecture. The code
 		// below checks for this situation, and returns a warning to the client,
 		// as well as logging it to the daemon logs.
-		img, err := i.GetImage(ctx, ref.String(), imagetypes.GetImageOpts{Platform: platform})
+		img, err := i.GetImage(ctx, ref.String(), backend.GetImageOpts{Platform: platform})
 
 		// Note that this is a special case where GetImage returns both an image
 		// and an error: https://github.com/docker/docker/blob/v20.10.7/daemon/images/image.go#L175-L183

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/backend"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
-	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
@@ -294,7 +294,7 @@ func (daemon *Daemon) foldFilter(ctx context.Context, view *container.View, conf
 	if psFilters.Contains("ancestor") {
 		ancestorFilter = true
 		err := psFilters.WalkValues("ancestor", func(ancestor string) error {
-			img, err := daemon.imageService.GetImage(ctx, ancestor, imagetypes.GetImageOpts{})
+			img, err := daemon.imageService.GetImage(ctx, ancestor, backend.GetImageOpts{})
 			if err != nil {
 				log.G(ctx).Warnf("Error while looking up for image %v", ancestor)
 				return nil
@@ -594,7 +594,7 @@ func (daemon *Daemon) refreshImage(ctx context.Context, s *container.Snapshot) (
 	}
 
 	// Check if the image reference still resolves to the same digest.
-	img, err := daemon.imageService.GetImage(ctx, s.Image, imagetypes.GetImageOpts{})
+	img, err := daemon.imageService.GetImage(ctx, s.Image, backend.GetImageOpts{})
 	// If the image is no longer found or can't be resolved for some other
 	// reason. Update the Image to the specific ID of the original image it
 	// resolved to when the container was created.

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -11,8 +11,8 @@ import (
 	"github.com/Microsoft/hcsshim"
 	coci "github.com/containerd/containerd/oci"
 	"github.com/containerd/log"
+	"github.com/docker/docker/api/types/backend"
 	containertypes "github.com/docker/docker/api/types/container"
-	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/errdefs"
@@ -93,7 +93,7 @@ func (daemon *Daemon) isHyperV(c *container.Container) bool {
 }
 
 func (daemon *Daemon) createSpec(ctx context.Context, daemonCfg *configStore, c *container.Container, mounts []container.Mount) (*specs.Spec, error) {
-	img, err := daemon.imageService.GetImage(ctx, string(c.ImageID), imagetypes.GetImageOpts{})
+	img, err := daemon.imageService.GetImage(ctx, string(c.ImageID), backend.GetImageOpts{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
similar to:

- https://github.com/moby/moby/pull/46901
- https://github.com/moby/moby/pull/46898


The `GetImageOpts` struct is used for options to be passed to the backend, and are not used in client code. This struct currently is intended for internal use only.

This patch moves the `GetImageOpts` struct to the backend package to prevent it being imported in the client, and to make it more clear that this is part of internal APIs, and not public-facing.



**- A picture of a cute animal (not mandatory but encouraged)**

