### PR TITLE
pkg/platforms: internalize in daemon/containerd

### DIFF
--- a/daemon/containerd/image_exporter.go
+++ b/daemon/containerd/image_exporter.go
@@ -12,7 +12,7 @@ import (
 	containerdimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/images/archive"
 	"github.com/containerd/containerd/leases"
-	cplatforms "github.com/containerd/containerd/platforms"
+	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types/events"
@@ -20,7 +20,6 @@ import (
 	"github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/errdefs"
 	dockerarchive "github.com/docker/docker/pkg/archive"
-	"github.com/docker/docker/pkg/platforms"
 	"github.com/docker/docker/pkg/streamformatter"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -49,7 +48,7 @@ func (i *ImageService) PerformWithBaseFS(ctx context.Context, c *container.Conta
 //
 // TODO(thaJeztah): produce JSON stream progress response and image events; see https://github.com/moby/moby/issues/43910
 func (i *ImageService) ExportImage(ctx context.Context, names []string, outStream io.Writer) error {
-	platform := platforms.AllPlatformsWithPreference(cplatforms.Default())
+	platform := matchAllWithPreference(platforms.Default())
 	opts := []archive.ExportOpt{
 		archive.WithSkipNonDistributableBlobs(),
 
@@ -236,7 +235,7 @@ func (i *ImageService) LoadImage(ctx context.Context, inTar io.ReadCloser, outSt
 
 	opts := []containerd.ImportOpt{
 		// TODO(vvoland): Allow user to pass platform
-		containerd.WithImportPlatform(cplatforms.All),
+		containerd.WithImportPlatform(platforms.All),
 
 		containerd.WithSkipMissing(),
 

--- a/daemon/containerd/image_history.go
+++ b/daemon/containerd/image_history.go
@@ -6,12 +6,11 @@ import (
 
 	"github.com/containerd/containerd/images"
 	containerdimages "github.com/containerd/containerd/images"
-	cplatforms "github.com/containerd/containerd/platforms"
+	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
 	imagetype "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/errdefs"
-	"github.com/docker/docker/pkg/platforms"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -28,7 +27,7 @@ func (i *ImageService) ImageHistory(ctx context.Context, name string) ([]*imaget
 
 	cs := i.client.ContentStore()
 	// TODO: pass platform in from the CLI
-	platform := platforms.AllPlatformsWithPreference(cplatforms.Default())
+	platform := matchAllWithPreference(platforms.Default())
 
 	var presentImages []ocispec.Image
 	err = i.walkImageManifests(ctx, img, func(img *ImageManifest) error {

--- a/daemon/containerd/image_manifest.go
+++ b/daemon/containerd/image_manifest.go
@@ -8,7 +8,7 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
 	containerdimages "github.com/containerd/containerd/images"
-	cplatforms "github.com/containerd/containerd/platforms"
+	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/errdefs"
 	"github.com/moby/buildkit/util/attestation"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -65,7 +65,7 @@ func (i *ImageService) NewImageManifest(ctx context.Context, img containerdimage
 	parent := img.Target
 	img.Target = manifestDesc
 
-	c8dImg := containerd.NewImageWithPlatform(i.client, img, cplatforms.All)
+	c8dImg := containerd.NewImageWithPlatform(i.client, img, platforms.All)
 	return &ImageManifest{
 		Image:      c8dImg,
 		RealTarget: parent,
@@ -122,7 +122,7 @@ func (im *ImageManifest) Manifest(ctx context.Context) (ocispec.Manifest, error)
 
 func (im *ImageManifest) CheckContentAvailable(ctx context.Context) (bool, error) {
 	// The target is already a platform-specific manifest, so no need to match platform.
-	pm := cplatforms.All
+	pm := platforms.All
 
 	available, _, _, missing, err := containerdimages.Check(ctx, im.ContentStore(), im.Target(), pm)
 	if err != nil {

--- a/daemon/containerd/platform_matchers.go
+++ b/daemon/containerd/platform_matchers.go
@@ -1,17 +1,17 @@
-package platforms
+package containerd
 
 import (
-	cplatforms "github.com/containerd/containerd/platforms"
+	"github.com/containerd/containerd/platforms"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type allPlatformsWithPreferenceMatcher struct {
-	preferred cplatforms.MatchComparer
+	preferred platforms.MatchComparer
 }
 
-// AllPlatformsWithPreference will return a platform matcher that matches all
+// matchAllWithPreference will return a platform matcher that matches all
 // platforms but will order platforms matching the preferred matcher first.
-func AllPlatformsWithPreference(preferred cplatforms.MatchComparer) cplatforms.MatchComparer {
+func matchAllWithPreference(preferred platforms.MatchComparer) platforms.MatchComparer {
 	return allPlatformsWithPreferenceMatcher{
 		preferred: preferred,
 	}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/43818
- relates to https://github.com/moby/moby/issues/32989

This matcher was only used internally in the containerd implementation of the image store. Un-export it, and make it a local utility in that package to prevent external use.

This package was introduced in 1616a09b613b07e56926ae23b1ae710f9a2c64fe (v24.0), and there are no known external consumers of this package, so there should be no need to deprecate / alias the old location.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

