### PR TITLE
api/types: remove deprecated type-aliases

### DIFF
--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -6,21 +6,6 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 )
 
-// ImageDeleteResponseItem image delete response item.
-//
-// Deprecated: use [image.DeleteResponse].
-type ImageDeleteResponseItem = image.DeleteResponse
-
-// ImageSummary image summary.
-//
-// Deprecated: use [image.Summary].
-type ImageSummary = image.Summary
-
-// ImageMetadata contains engine-local data about the image.
-//
-// Deprecated: use [image.Metadata].
-type ImageMetadata = image.Metadata
-
 // ServiceCreateResponse contains the information returned to a client
 // on the creation of a new service.
 //

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -1,31 +1,10 @@
 package types
 
 import (
-	"github.com/docker/docker/api/types/checkpoint"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/swarm"
 )
-
-// CheckpointCreateOptions holds parameters to create a checkpoint from a container.
-//
-// Deprecated: use [checkpoint.CreateOptions].
-type CheckpointCreateOptions = checkpoint.CreateOptions
-
-// CheckpointListOptions holds parameters to list checkpoints for a container
-//
-// Deprecated: use [checkpoint.ListOptions].
-type CheckpointListOptions = checkpoint.ListOptions
-
-// CheckpointDeleteOptions holds parameters to delete a checkpoint from a container
-//
-// Deprecated: use [checkpoint.DeleteOptions].
-type CheckpointDeleteOptions = checkpoint.DeleteOptions
-
-// Checkpoint represents the details of a checkpoint when listing endpoints.
-//
-// Deprecated: use [checkpoint.Summary].
-type Checkpoint = checkpoint.Summary
 
 // ImageDeleteResponseItem image delete response item.
 //

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -3,19 +3,7 @@ package types
 import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/api/types/swarm"
 )
-
-// ServiceCreateResponse contains the information returned to a client
-// on the creation of a new service.
-//
-// Deprecated: use [swarm.ServiceCreateResponse].
-type ServiceCreateResponse = swarm.ServiceCreateResponse
-
-// ServiceUpdateResponse service update response.
-//
-// Deprecated: use [swarm.ServiceUpdateResponse].
-type ServiceUpdateResponse = swarm.ServiceUpdateResponse
 
 // ContainerStartOptions holds parameters to start containers.
 //

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -5,7 +5,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/api/types/system"
 )
 
 // CheckpointCreateOptions holds parameters to create a checkpoint from a container.
@@ -27,44 +26,6 @@ type CheckpointDeleteOptions = checkpoint.DeleteOptions
 //
 // Deprecated: use [checkpoint.Summary].
 type Checkpoint = checkpoint.Summary
-
-// Info contains response of Engine API:
-// GET "/info"
-//
-// Deprecated: use [system.Info].
-type Info = system.Info
-
-// Commit holds the Git-commit (SHA1) that a binary was built from, as reported
-// in the version-string of external tools, such as containerd, or runC.
-//
-// Deprecated: use [system.Commit].
-type Commit = system.Commit
-
-// PluginsInfo is a temp struct holding Plugins name
-// registered with docker daemon. It is used by [system.Info] struct
-//
-// Deprecated: use [system.PluginsInfo].
-type PluginsInfo = system.PluginsInfo
-
-// NetworkAddressPool is a temp struct used by [system.Info] struct.
-//
-// Deprecated: use [system.NetworkAddressPool].
-type NetworkAddressPool = system.NetworkAddressPool
-
-// Runtime describes an OCI runtime.
-//
-// Deprecated: use [system.Runtime].
-type Runtime = system.Runtime
-
-// SecurityOpt contains the name and options of a security option.
-//
-// Deprecated: use [system.SecurityOpt].
-type SecurityOpt = system.SecurityOpt
-
-// KeyValue holds a key/value pair.
-//
-// Deprecated: use [system.KeyValue].
-type KeyValue = system.KeyValue
 
 // ImageDeleteResponseItem image delete response item.
 //
@@ -128,14 +89,6 @@ type ContainerLogsOptions = container.LogsOptions
 //
 // Deprecated: use [container.RemoveOptions].
 type ContainerRemoveOptions = container.RemoveOptions
-
-// DecodeSecurityOptions decodes a security options string slice to a type safe
-// [system.SecurityOpt].
-//
-// Deprecated: use [system.DecodeSecurityOptions].
-func DecodeSecurityOptions(opts []string) ([]system.SecurityOpt, error) {
-	return system.DecodeSecurityOptions(opts)
-}
 
 // ImageImportOptions holds information to import images from the client host.
 //

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -1,46 +1,8 @@
 package types
 
 import (
-	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 )
-
-// ContainerStartOptions holds parameters to start containers.
-//
-// Deprecated: use [container.StartOptions].
-type ContainerStartOptions = container.StartOptions
-
-// ResizeOptions holds parameters to resize a TTY.
-// It can be used to resize container TTYs and
-// exec process TTYs too.
-//
-// Deprecated: use [container.ResizeOptions].
-type ResizeOptions = container.ResizeOptions
-
-// ContainerAttachOptions holds parameters to attach to a container.
-//
-// Deprecated: use [container.AttachOptions].
-type ContainerAttachOptions = container.AttachOptions
-
-// ContainerCommitOptions holds parameters to commit changes into a container.
-//
-// Deprecated: use [container.CommitOptions].
-type ContainerCommitOptions = container.CommitOptions
-
-// ContainerListOptions holds parameters to list containers with.
-//
-// Deprecated: use [container.ListOptions].
-type ContainerListOptions = container.ListOptions
-
-// ContainerLogsOptions holds parameters to filter logs with.
-//
-// Deprecated: use [container.LogsOptions].
-type ContainerLogsOptions = container.LogsOptions
-
-// ContainerRemoveOptions holds parameters to remove containers.
-//
-// Deprecated: use [container.RemoveOptions].
-type ContainerRemoveOptions = container.RemoveOptions
 
 // ImageImportOptions holds information to import images from the client host.
 //


### PR DESCRIPTION
relates to:

- [x] depends on / stacked on https://github.com/moby/moby/pull/47139
- https://github.com/moby/moby/pull/45901
- https://github.com/moby/moby/pull/46335
- https://github.com/moby/moby/pull/46483

### api/types: remove deprecated system info types and functions

These types were deprecated in c90229ed9aea7c5bde53a11437c54dd3fc60e71a
(v25.0), and moved to api/types/system.

This patch removes the aliases for;

- api/types.Info
- api/types.Commit
- api/types.PluginsInfo
- api/types.NetworkAddressPool
- api/types.Runtime
- api/types.SecurityOpt
- api/types.KeyValue
- api/types.DecodeSecurityOptions

### api/types: remove deprecated checkpoint-types

These types were deprecated in b688af22263237c0591b5e516eaaa70bca49487d
(v25.0), and moved to api/types/checkpoint.

This patch removes the aliases for;

- api/types.CheckpointCreateOptions
- api/types.CheckpointListOptions
- api/types.CheckpointDeleteOptions
- api/types.Checkpoint


### api/types: remove deprecated image-types

These types were deprecated in 48cacbca24c48d451db6e6bfbb08dffa36d97078
(v25.0), and moved to api/types/image.

This patch removes the aliases for;

- api/types.ImageDeleteResponseItem
- api/types.ImageSummary
- api/types.ImageMetadata

### api/types: remove deprecated service-types

These types were deprecated in v25.0, and moved to api/types/swarm;

This patch removes the aliases for;

- api/types.ServiceUpdateResponse (deprecated in 5b3e6555a3e25294630d5013dd3b059c45171dab)
- api/types.ServiceCreateResponse (deprecated in ec69501e94d98b7e8d2ae6c62823e245d71d2f9f)


### api/types: remove deprecated container-types

These types were deprecated in v25.0, and moved to api/types/container;

This patch removes the aliases for;

- api/types.ResizeOptions (deprecated in 95b92b1f979c9c965f171e1763b6e6dc7397006e)
- api/types.ContainerAttachOptions (deprecated in 30f09b4a1a611094878e2c3956f28dfd05be2d6d)
- api/types.ContainerCommitOptions (deprecated in 9498d897ab27c94f21800d4ffb8361239280d8f0)
- api/types.ContainerRemoveOptions (deprecated in 0f77875220a3a8124660c4f7ee43400ce8b873af)
- api/types.ContainerStartOptions (deprecated in 7bce33eb0fe3a7e1bddfecf71888869c4b699d22)
- api/types.ContainerListOptions (deprecated in 9670d9364dc1b0a2c94b5290f7f865816b34a152)
- api/types.ContainerLogsOptions (deprecated in ebef4efb8824c516e70dd17c123360d20d23d7b9)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```markdown
Remove deprecated aliases from the api/types package. These types were deprecated
in v25.0.0, which provided temporary aliases. These aliases are now removed:

- api/types.Info
- api/types.Commit
- api/types.PluginsInfo
- api/types.NetworkAddressPool
- api/types.Runtime
- api/types.SecurityOpt
- api/types.KeyValue
- api/types.DecodeSecurityOptions
- api/types.CheckpointCreateOptions
- api/types.CheckpointListOptions
- api/types.CheckpointDeleteOptions
- api/types.Checkpoint
- api/types.ImageDeleteResponseItem
- api/types.ImageSummary
- api/types.ImageMetadata
- api/types.ServiceUpdateResponse
- api/types.ServiceCreateResponse
- api/types.ResizeOptions
- api/types.ContainerAttachOptions
- api/types.ContainerCommitOptions
- api/types.ContainerRemoveOptions
- api/types.ContainerStartOptions
- api/types.ContainerListOptions
- api/types.ContainerLogsOptions
```



**- A picture of a cute animal (not mandatory but encouraged)**

