### PR TITLE
integration-cli: TestPutContainerArchiveErrSymlinkInVolumeToReadOnlyRootfs: use current API

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1287,7 +1287,7 @@ func (s *DockerAPISuite) TestPutContainerArchiveErrSymlinkInVolumeToReadOnlyRoot
 	// Attempt to extract to a symlink in the volume which points to a
 	// directory outside the volume. This should cause an error because the
 	// rootfs is read-only.
-	apiClient, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("v1.20"))
+	apiClient, err := client.NewClientWithOpts(client.FromEnv)
 	assert.NilError(c, err)
 
 	err = apiClient.CopyToContainer(testutil.GetContext(c), cID, "/vol2/symlinkToAbsDir", nil, types.CopyToContainerOptions{})


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/14885
- relates to https://github.com/moby/moby/pull/46887
- relates to https://github.com/moby/moby/pull/47149

This test was added in 75f6929b449a59335572436862d644afacf55cdb, but pinned to the API version that was current at the time (v1.20), which is now deprecated.

Update the test to use the current API version.


**- A picture of a cute animal (not mandatory but encouraged)**

