### PR TITLE
integration-cli: adjust inspect tests to use current API version

### DIFF
--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -159,6 +159,11 @@ func (s *DockerAPISuite) TestInspectAPIBridgeNetworkSettings120(c *testing.T) {
 	assert.Assert(c, len(settings.IPAddress) != 0)
 }
 
+// Inspect for API v1.21 and up; see
+//
+// - https://github.com/moby/moby/issues/17131
+// - https://github.com/moby/moby/issues/17139
+// - https://github.com/moby/moby/issues/17173
 func (s *DockerAPISuite) TestInspectAPIBridgeNetworkSettings121(c *testing.T) {
 	// Windows doesn't have any bridge network settings
 	testRequires(c, DaemonIsLinux)
@@ -166,7 +171,7 @@ func (s *DockerAPISuite) TestInspectAPIBridgeNetworkSettings121(c *testing.T) {
 	containerID := strings.TrimSpace(out)
 	cli.WaitRun(c, containerID)
 
-	body := getInspectBody(c, "v1.21", containerID)
+	body := getInspectBody(c, "", containerID)
 
 	var inspectJSON types.ContainerJSON
 	err := json.Unmarshal(body, &inspectJSON)

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1022,15 +1022,16 @@ func (s *DockerCLINetworkSuite) TestInspectAPIMultipleNetworks(c *testing.T) {
 
 	versionedIP := inspect120.NetworkSettings.IPAddress
 
-	body = getInspectBody(c, "v1.21", id)
-	var inspect121 types.ContainerJSON
-	err = json.Unmarshal(body, &inspect121)
+	// Current API version (API v1.21 and up)
+	body = getInspectBody(c, "", id)
+	var inspectCurrent types.ContainerJSON
+	err = json.Unmarshal(body, &inspectCurrent)
 	assert.NilError(c, err)
-	assert.Equal(c, len(inspect121.NetworkSettings.Networks), 3)
+	assert.Equal(c, len(inspectCurrent.NetworkSettings.Networks), 3)
 
-	bridge := inspect121.NetworkSettings.Networks["bridge"]
+	bridge := inspectCurrent.NetworkSettings.Networks["bridge"]
 	assert.Equal(c, bridge.IPAddress, versionedIP)
-	assert.Equal(c, bridge.IPAddress, inspect121.NetworkSettings.IPAddress)
+	assert.Equal(c, bridge.IPAddress, inspectCurrent.NetworkSettings.IPAddress)
 }
 
 func connectContainerToNetworks(c *testing.T, d *daemon.Daemon, cName string, nws []string) {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/46887
- relates to https://github.com/moby/moby/pull/17538

### integration-cli: TestInspectAPIBridgeNetworkSettings121: use current version

This test was added in f301c5765a0d7f4b6866cedfdface6f87874ff53 to test
inspect output for API > v1.21, however, it was pinned to API v1.21,
which is now deprecated.

Remove the fixed version, as the intent was to test "current" API versions
(API v1.21 and up),

### integration-cli: TestInspectAPIMultipleNetworks: use current version

This test was added in f301c5765a0d7f4b6866cedfdface6f87874ff53 to test
inspect output for API > v1.21, however, it was pinned to API v1.21,
which is now deprecated.

Remove the fixed version, as the intent was to test "current" API versions
(API v1.21 and up),


**- A picture of a cute animal (not mandatory but encouraged)**

