### PR TITLE
api: remove support for legacy filter format (api < v1.22)

### DIFF
--- a/api/types/filters/parse_test.go
+++ b/api/types/filters/parse_test.go
@@ -71,19 +71,10 @@ func TestFromJSON(t *testing.T) {
 		"{'key': 'value'}",
 		`{"key": "value"}`,
 	}
-	valid := map[*Args][]string{
-		{fields: map[string]map[string]bool{"key": {"value": true}}}: {
-			`{"key": ["value"]}`,
-			`{"key": {"value": true}}`,
-		},
-		{fields: map[string]map[string]bool{"key": {"value1": true, "value2": true}}}: {
-			`{"key": ["value1", "value2"]}`,
-			`{"key": {"value1": true, "value2": true}}`,
-		},
-		{fields: map[string]map[string]bool{"key1": {"value1": true}, "key2": {"value2": true}}}: {
-			`{"key1": ["value1"], "key2": ["value2"]}`,
-			`{"key1": {"value1": true}, "key2": {"value2": true}}`,
-		},
+	valid := map[*Args]string{
+		{fields: map[string]map[string]bool{"key": {"value": true}}}:                             `{"key": {"value": true}}`,
+		{fields: map[string]map[string]bool{"key": {"value1": true, "value2": true}}}:            `{"key": {"value1": true, "value2": true}}`,
+		{fields: map[string]map[string]bool{"key1": {"value1": true}, "key2": {"value2": true}}}: `{"key1": {"value1": true}, "key2": {"value2": true}}`,
 	}
 
 	for _, invalid := range invalids {
@@ -99,19 +90,17 @@ func TestFromJSON(t *testing.T) {
 		})
 	}
 
-	for expectedArgs, matchers := range valid {
-		for _, jsonString := range matchers {
-			args, err := FromJSON(jsonString)
-			assert.Check(t, err)
-			assert.Check(t, is.Equal(args.Len(), expectedArgs.Len()))
-			for key, expectedValues := range expectedArgs.fields {
-				values := args.Get(key)
-				assert.Check(t, is.Len(values, len(expectedValues)), expectedArgs)
+	for expectedArgs, jsonString := range valid {
+		args, err := FromJSON(jsonString)
+		assert.Check(t, err)
+		assert.Check(t, is.Equal(args.Len(), expectedArgs.Len()))
+		for key, expectedValues := range expectedArgs.fields {
+			values := args.Get(key)
+			assert.Check(t, is.Len(values, len(expectedValues)), expectedArgs)
 
-				for _, v := range values {
-					if !expectedValues[v] {
-						t.Errorf("Expected %v, go %v", expectedArgs, args)
-					}
+			for _, v := range values {
+				if !expectedValues[v] {
+					t.Errorf("Expected %v, go %v", expectedArgs, args)
 				}
 			}
 		}


### PR DESCRIPTION
- extracted from https://github.com/moby/moby/pull/47155, but it looks like docker-py uses the legacy format.

related to

- https://github.com/moby/moby/pull/34756
- https://github.com/moby/moby/commit/93d1dd8036d57f5cf1e5cbbbad875ae9a6fa6180 / https://github.com/moby/moby/pull/18266


Remove tha fallback code for the legacy (api < v1.22) filter format.

API v1.23 and older are deprecated, so we can remove support for plain-text error responses.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

