### PR TITLE
daemon: return an InvalidParameter error when ep settings are wrong

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -645,7 +645,7 @@ func (daemon *Daemon) updateNetworkConfig(container *container.Container, n *lib
 	}
 
 	if err := validateEndpointSettings(n, n.Name(), endpointConfig); err != nil {
-		return err
+		return errdefs.InvalidParameter(err)
 	}
 
 	if updateSettings {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/46183
- relates to https://github.com/docker/for-linux/issues/1481

**- What I did**

Since v25.0 (commit ff50388), we validate endpoint settings when containers are created, instead of doing so when containers are started. However, a container created prior to that release would still trigger validation error at start-time. In such case, the API returns a 500 status code because the Go error isn't wrapped into an InvalidParameter error. This is now fixed.

**- How to verify it**

1. Start the daemon from branch v24 ;
2. Create a container with an invalid networking config ;
3. Restart the daemon from branch v25 ;
4. Make sure there's no such log:

```
ERRO[2024-01-22T11:36:22.370050219Z] Handler for POST /v1.43/containers/86dfef1d48b1/start returned error: invalid endpoint settings:
network-scoped alias is supported only for containers in user defined networks 
```

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://www.thoughtco.com/thmb/AZI2uo1rBo8zPMgI9-xQ1yqBpLk=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/128898855-56a007375f9b58eba4ae8ce0.jpg)
