### PR TITLE
[25.0 backport] image/save: Fix layers order in OCI manifest

### DIFF
--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -210,7 +210,9 @@ func (s *saveSession) save(outStream io.Writer) error {
 			foreign  = make([]ocispec.Descriptor, 0, len(foreignSrcs))
 		)
 
-		for _, desc := range foreignSrcs {
+		// Layers in manifest must follow the actual layer order from config.
+		for _, l := range imageDescr.layers {
+			desc := foreignSrcs[l]
 			foreign = append(foreign, ocispec.Descriptor{
 				MediaType:   desc.MediaType,
 				Digest:      desc.Digest,


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/47160
- fixes https://github.com/moby/moby/issues/47150

Order the layers in OCI manifest by their actual apply order. This is required by the OCI image spec.


**- How to verify it**
```
$ docker save nginx:1.25.3 >a.tar
$ ctr image import --platform linux/amd64  a.tar
unpacking docker.io/library/nginx:1.25.3 (sha256:978a1ef6837b075ba0d8209ca4280191bfa28c6bfc08fd526e91303c410a18c0)...done
```

**- Description for the changelog**
```release-note
- Fix layer order in the OCI manifest produced by `docker save`
```


**- A picture of a cute animal (not mandatory but encouraged)**

