### PR TITLE
[25.0 backport] daemon/cluster/executer: Add missing `StartInterval`

### DIFF
--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -377,12 +377,14 @@ func (c *containerConfig) healthcheck() *enginecontainer.HealthConfig {
 	interval, _ := gogotypes.DurationFromProto(hcSpec.Interval)
 	timeout, _ := gogotypes.DurationFromProto(hcSpec.Timeout)
 	startPeriod, _ := gogotypes.DurationFromProto(hcSpec.StartPeriod)
+	startInterval, _ := gogotypes.DurationFromProto(hcSpec.StartInterval)
 	return &enginecontainer.HealthConfig{
-		Test:        hcSpec.Test,
-		Interval:    interval,
-		Timeout:     timeout,
-		Retries:     int(hcSpec.Retries),
-		StartPeriod: startPeriod,
+		Test:          hcSpec.Test,
+		Interval:      interval,
+		Timeout:       timeout,
+		Retries:       int(hcSpec.Retries),
+		StartPeriod:   startPeriod,
+		StartInterval: startInterval,
 	}
 }
 


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/47162
- fixes https://github.com/moby/moby/issues/47152


(cherry picked from commit 6100190e5c8acdf279997bd53ad850a66bc8075a)

**- What I did**
Propagate `StartInterval` field in cluster executor.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
```release-note
- swarm: Fixed `start_interval` not being passed to the container config
```


**- A picture of a cute animal (not mandatory but encouraged)**


