### PR TITLE
[25.0 backport] daemon: return an InvalidParameter error when ep settings are wrong

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -645,7 +645,7 @@ func (daemon *Daemon) updateNetworkConfig(container *container.Container, n *lib
 	}
 
 	if err := validateEndpointSettings(n, n.Name(), endpointConfig); err != nil {
-		return err
+		return errdefs.InvalidParameter(err)
 	}
 
 	if updateSettings {


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/47159
- relates to https://github.com/moby/moby/pull/46183

Since v25.0 (commit ff50388), we validate endpoint settings when containers are created, instead of doing so when containers are started. However, a container created prior to that release would still trigger validation error at start-time. In such case, the API returns a 500 status code because the Go error isn't wrapped into an InvalidParameter error. This is now fixed.


(cherry picked from commit fcc651972e9865f24d31803d23d149ecfa0eaf62)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

