### PR TITLE
pkg/system: return even richer xattr errors

### DIFF
--- a/builder/remotecontext/archive.go
+++ b/builder/remotecontext/archive.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/longpath"
+	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/pkg/tarsum"
 	"github.com/moby/sys/symlink"
 	"github.com/pkg/errors"
@@ -24,9 +25,11 @@ func (c *archiveContext) Close() error {
 }
 
 func convertPathError(err error, cleanpath string) error {
-	if err, ok := err.(*os.PathError); ok {
+	switch err := err.(type) {
+	case *os.PathError:
 		err.Path = cleanpath
-		return err
+	case *system.XattrError:
+		err.Path = cleanpath
 	}
 	return err
 }

--- a/pkg/system/xattrs.go
+++ b/pkg/system/xattrs.go
@@ -1,0 +1,18 @@
+package system // import "github.com/docker/docker/pkg/system"
+
+type XattrError struct {
+	Op   string
+	Attr string
+	Path string
+	Err  error
+}
+
+func (e *XattrError) Error() string { return e.Op + " " + e.Attr + " " + e.Path + ": " + e.Err.Error() }
+
+func (e *XattrError) Unwrap() error { return e.Err }
+
+// Timeout reports whether this error represents a timeout.
+func (e *XattrError) Timeout() bool {
+	t, ok := e.Err.(interface{ Timeout() bool })
+	return ok && t.Timeout()
+}


### PR DESCRIPTION
- Follow-up to #45464
- Related to #47137

The names of extended attributes are not completely freeform. Attributes are namespaced, and the kernel enforces (among other things) that only attributes whose names are prefixed with a valid namespace are permitted. The name of the attribute therefore needs to be known in order to diagnose issues with lsetxattr. Include the name of the extended attribute in the errors returned from the Lsetxattr and Lgetxattr so users and us can more easily troubleshoot xattr-related issues. Include the name in a separate rich-error field to provide code handling the error enough information to determine whether or not the failure can be ignored.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- To assist in troubleshooting, the name of the xattr which could not be set is now reported in error messages

**- A picture of a cute animal (not mandatory but encouraged)**

