### PR TITLE
[25.0] daemon: only add short cid to aliases for custom networks

### DIFF
--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
+	containertypes "github.com/docker/docker/api/types/container"
 	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/api/types/versions/v1p20"
@@ -36,8 +37,10 @@ func (daemon *Daemon) ContainerInspect(ctx context.Context, name string, size bo
 		}
 
 		shortCID := stringid.TruncateID(ctr.ID)
-		for _, ep := range ctr.NetworkSettings.Networks {
-			ep.Aliases = sliceutil.Dedup(append(ep.Aliases, shortCID, ctr.Config.Hostname))
+		for nwName, ep := range ctr.NetworkSettings.Networks {
+			if containertypes.NetworkMode(nwName).IsUserDefined() {
+				ep.Aliases = sliceutil.Dedup(append(ep.Aliases, shortCID, ctr.Config.Hostname))
+			}
 		}
 
 		return ctr, nil

--- a/integration/container/inspect_test.go
+++ b/integration/container/inspect_test.go
@@ -2,10 +2,12 @@ package container // import "github.com/docker/docker/integration/container"
 
 import (
 	"encoding/json"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/testutil/request"
@@ -67,4 +69,34 @@ func TestInspectAnnotations(t *testing.T) {
 	inspect, err := apiClient.ContainerInspect(ctx, id)
 	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual(inspect.HostConfig.Annotations, annotations))
+}
+
+// TestNetworkAliasesAreEmpty verifies that network-scoped aliases are not set
+// for non-custom networks (network-scoped aliases are only supported for
+// custom networks, except for the "Default Switch" network on Windows).
+func TestNetworkAliasesAreEmpty(t *testing.T) {
+	ctx := setupTest(t)
+	apiClient := request.NewAPIClient(t)
+
+	netModes := []string{"host", "bridge", "none"}
+	if runtime.GOOS == "windows" {
+		netModes = []string{"nat", "none"}
+	}
+
+	for _, nwMode := range netModes {
+		t.Run(nwMode, func(t *testing.T) {
+			ctr := container.Create(ctx, t, apiClient,
+				container.WithName("ctr-"+nwMode),
+				container.WithImage("busybox:latest"),
+				container.WithNetworkMode(nwMode))
+			defer apiClient.ContainerRemove(ctx, ctr, containertypes.RemoveOptions{
+				Force: true,
+			})
+
+			inspect := container.Inspect(ctx, t, apiClient, ctr)
+			netAliases := inspect.NetworkSettings.Networks[nwMode].Aliases
+
+			assert.Check(t, is.Nil(netAliases))
+		})
+	}
 }


### PR DESCRIPTION
- Backport https://github.com/moby/moby/pull/47181
- Related to https://github.com/testcontainers/testcontainers-go/pull/2135
- Related to https://github.com/docker/for-linux/issues/1481

**- What I did**

Prior to 7a9b680a, the container short ID was added to the network aliases only for custom networks. However, this logic wasn't preserved in 6a2542d and now the cid is always added to the list of network aliases.

This commit reintroduces the old logic.

(cherry picked from commit 9cc48be0b1f198cd38e5e5b51f43df577756e605)

**- How to verify it**

Manually or through the added integration test.

```
$ docker run --rm -d --name c0 alpine top
$ docker inspect --format="{{ .NetworkSettings.Networks.bridge.Aliases }}" c0
[]
```

**- Description for the changelog**

- Fix an issue causing containers to have their short ID added to their network alias when inspecting them.