### PR TITLE
c8d: ImageService.GetImage: fix filtering by platform

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -83,6 +83,14 @@ func (daemon *Daemon) containerCreate(ctx context.Context, daemonCfg *configStor
 	}
 
 	if opts.params.Platform == nil && opts.params.Config.Image != "" {
+		// FIXME(thaJeztah); we checked that "opts.params.Platform" is nil, whhy are we passing it to daemon.imageService.GetImage ?
+		// code was added in https://github.com/moby/moby/commit/300c11c7c9143ca077890050deb83917e67fe250
+		// but that was a refactor, combining multiple branches, so before that we already passed it unconditionally.
+		//
+		// Should we;
+		//
+		// - always lookup the image?
+		// - should `GetImage` use OnlyPlatformWithFallback as default (if no platform is specified)?
 		img, err := daemon.imageService.GetImage(ctx, opts.params.Config.Image, imagetypes.GetImageOpts{Platform: opts.params.Platform})
 		if err != nil {
 			return containertypes.CreateResponse{}, err

--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -24,7 +24,8 @@ import (
 
 // ErrImageDoesNotExist is error returned when no image can be found for a reference.
 type ErrImageDoesNotExist struct {
-	Ref reference.Reference
+	Ref      reference.Reference
+	Platform *ocispec.Platform
 }
 
 func (e ErrImageDoesNotExist) Error() string {
@@ -32,7 +33,10 @@ func (e ErrImageDoesNotExist) Error() string {
 	if named, ok := ref.(reference.Named); ok {
 		ref = reference.TagNameOnly(named)
 	}
-	return fmt.Sprintf("No such image: %s", reference.FamiliarString(ref))
+	if e.Platform == nil {
+		return fmt.Sprintf("No such image: %s", reference.FamiliarString(ref))
+	}
+	return fmt.Sprintf("No such image: %s for platform: %s", reference.FamiliarString(ref), platforms.Format(*e.Platform))
 }
 
 // NotFound implements the NotFound interface


### PR DESCRIPTION
- extracting from https://github.com/moby/moby/pull/47114
- see https://github.com/moby/moby/pull/47114#discussion_r1458826051
- also related: https://github.com/moby/moby/pull/47167


Before this patch, it would find all images (and platform) are found, and return the first image (or the old default: "linux/amd64");

With this patch, an error is returned if a platform is set, and no results were found:

    No such image: alpine:latest for platform: windows/s390x

Looking at consumers of this function, there may be something to fix though; https://github.com/moby/moby/blob/178651733852a26bc11e6fa272b48ff37ecc7447/daemon/create.go#L85-L86

    if opts.params.Platform == nil && opts.params.Config.Image != "" {
        img, err := daemon.imageService.GetImage(ctx, opts.params.Config.Image, imagetypes.GetImageOpts{Platform: opts.params.Platform})

The code above looks to check for _NO_ platform to be passed in parameters, but then to pass that platform as `imagetypes.GetImageOpts.Platform`.

That code was added in 300c11c7c9143ca077890050deb83917e67fe250 but that was a refactor, combining multiple branches, so before that we passed platform unconditionally (but only used the image in some cases, so that was an optimization).

Should we;

- always lookup the image?
- should `GetImage` use OnlyPlatformWithFallback as default (if no platform is specified)? To select any image, but _prefer_ local platform?

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

