### PR TITLE
volume/local: Make host resolution backwards compatible

### DIFF
--- a/volume/local/local_unix.go
+++ b/volume/local/local_unix.go
@@ -127,16 +127,20 @@ func (v *localVolume) mount() error {
 	mountDevice := v.opts.MountDevice
 
 	switch v.opts.MountType {
-	case "nfs":
+	case "nfs", "cifs":
 		if addrValue := getAddress(v.opts.MountOpts); addrValue != "" && net.ParseIP(addrValue).To4() == nil {
 			ipAddr, err := net.ResolveIPAddr("ip", addrValue)
 			if err != nil {
-				return errors.Wrapf(err, "error resolving passed in network volume address")
+				return errors.Wrap(err, "error resolving passed in network volume address")
 			}
 			mountOpts = strings.Replace(mountOpts, "addr="+addrValue, "addr="+ipAddr.String(), 1)
 		}
-	case "cifs":
-		deviceURL, err := url.Parse(v.opts.MountDevice)
+
+		if v.opts.MountType != "cifs" {
+			break
+		}
+
+		deviceURL, err := url.Parse(mountDevice)
 		if err != nil {
 			return errors.Wrapf(err, "error parsing mount device url")
 		}


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/47184
- relates to https://github.com/docker/cli/issues/4816

Commit 8ae94cafa50a90192a0c0189f54443abac7a9b44 added a DNS resolution of the `device` part of the volume option.

The previous way to resolve the passed hostname was to use `addr` option, which was handled by the same code path as the `nfs` mount type.

The issue is that `addr` is also an SMB module option handled by kernel and passing a hostname as `addr` produces an invalid argument error.

To fix that, restore the old behavior to handle `addr` the same way as before, and only perform the new DNS resolution of `device` if there is no `addr` passed.

NOTE: While kernel docs don't mention the `addr` option (https://www.kernel.org/doc/html/latest/admin-guide/cifs/usage.html#use-instructions), it's actually present in the source: https://github.com/torvalds/linux/blob/7ed2632ec7d72e926b9e8bcc9ad1bb0cd37274bf/fs/smb/client/fs_context.c#L166

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
```release-note
- Fix CIFS volume mount error when passing an `addr` mount option
```

**- A picture of a cute animal (not mandatory but encouraged)**

