### PR TITLE
volume/local: Break early if `addr` was specified

### DIFF
--- a/volume/local/local_unix.go
+++ b/volume/local/local_unix.go
@@ -134,6 +134,7 @@ func (v *localVolume) mount() error {
 				return errors.Wrap(err, "error resolving passed in network volume address")
 			}
 			mountOpts = strings.Replace(mountOpts, "addr="+addrValue, "addr="+ipAddr.String(), 1)
+			break
 		}
 
 		if v.opts.MountType != "cifs" {


### PR DESCRIPTION
- follow up to: https://github.com/moby/moby/pull/47185

I made a mistake in the last commit - after resolving the IP from the passed `addr` for CIFS it would still resolve the `device` part.

Apply only one name resolution

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

