### PR TITLE
volume/local: Fix CIFS urls with spaces, add tests

### DIFF
--- a/volume/local/local_unix.go
+++ b/volume/local/local_unix.go
@@ -151,7 +151,11 @@ func getMountOptions(opts *optsConfig, resolveIP func(string, string) (*net.IPAd
 				return "", "", errors.Wrap(err, "error resolving passed in network volume address")
 			}
 			deviceURL.Host = ipAddr.String()
-			mountDevice = deviceURL.String()
+			dev, err := url.QueryUnescape(deviceURL.String())
+			if err != nil {
+				return "", "", fmt.Errorf("failed to unescape device URL: %q", deviceURL)
+			}
+			mountDevice = dev
 		}
 	}
 

--- a/volume/local/local_unix.go
+++ b/volume/local/local_unix.go
@@ -134,6 +134,7 @@ func (v *localVolume) mount() error {
 				return errors.Wrap(err, "error resolving passed in network volume address")
 			}
 			mountOpts = strings.Replace(mountOpts, "addr="+addrValue, "addr="+ipAddr.String(), 1)
+			break
 		}
 
 		if v.opts.MountType != "cifs" {

--- a/volume/local/local_unix.go
+++ b/volume/local/local_unix.go
@@ -118,42 +118,52 @@ func (v *localVolume) needsMount() bool {
 	return false
 }
 
-func (v *localVolume) mount() error {
-	if v.opts.MountDevice == "" {
-		return fmt.Errorf("missing device in volume options")
+func getMountOptions(opts *optsConfig, resolveIP func(string, string) (*net.IPAddr, error)) (mountDevice string, mountOpts string, _ error) {
+	if opts.MountDevice == "" {
+		return "", "", fmt.Errorf("missing device in volume options")
 	}
 
-	mountOpts := v.opts.MountOpts
-	mountDevice := v.opts.MountDevice
+	mountOpts = opts.MountOpts
+	mountDevice = opts.MountDevice
 
-	switch v.opts.MountType {
+	switch opts.MountType {
 	case "nfs", "cifs":
-		if addrValue := getAddress(v.opts.MountOpts); addrValue != "" && net.ParseIP(addrValue).To4() == nil {
-			ipAddr, err := net.ResolveIPAddr("ip", addrValue)
+		if addrValue := getAddress(opts.MountOpts); addrValue != "" && net.ParseIP(addrValue).To4() == nil {
+			ipAddr, err := resolveIP("ip", addrValue)
 			if err != nil {
-				return errors.Wrap(err, "error resolving passed in network volume address")
+				return "", "", errors.Wrap(err, "error resolving passed in network volume address")
 			}
 			mountOpts = strings.Replace(mountOpts, "addr="+addrValue, "addr="+ipAddr.String(), 1)
 			break
 		}
 
-		if v.opts.MountType != "cifs" {
+		if opts.MountType != "cifs" {
 			break
 		}
 
 		deviceURL, err := url.Parse(mountDevice)
 		if err != nil {
-			return errors.Wrapf(err, "error parsing mount device url")
+			return "", "", errors.Wrap(err, "error parsing mount device url")
 		}
 		if deviceURL.Host != "" && net.ParseIP(deviceURL.Host) == nil {
-			ipAddr, err := net.ResolveIPAddr("ip", deviceURL.Host)
+			ipAddr, err := resolveIP("ip", deviceURL.Host)
 			if err != nil {
-				return errors.Wrapf(err, "error resolving passed in network volume address")
+				return "", "", errors.Wrap(err, "error resolving passed in network volume address")
 			}
 			deviceURL.Host = ipAddr.String()
 			mountDevice = deviceURL.String()
 		}
 	}
+
+	return mountDevice, mountOpts, nil
+}
+
+func (v *localVolume) mount() error {
+	mountDevice, mountOpts, err := getMountOptions(v.opts, net.ResolveIPAddr)
+	if err != nil {
+		return err
+	}
+
 	if err := mount.Mount(mountDevice, v.path, v.opts.MountType, mountOpts); err != nil {
 		if password := getPassword(v.opts.MountOpts); password != "" {
 			err = errors.New(strings.Replace(err.Error(), "password="+password, "password=********", 1))


### PR DESCRIPTION
- follow up to: https://github.com/moby/moby/pull/47193
- relates to: https://github.com/docker/cli/issues/4816#issuecomment-1905935618
- supersedes / closes https://github.com/moby/moby/pull/47193


**- What I did**
Fixed spaces in CIFS address being escaped
Added tests

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

