### PR TITLE
image: remove deprecated IDFromDigest

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -28,13 +28,6 @@ func (id ID) Digest() digest.Digest {
 	return digest.Digest(id)
 }
 
-// IDFromDigest creates an ID from a digest
-//
-// Deprecated: cast to an ID using ID(digest).
-func IDFromDigest(digest digest.Digest) ID {
-	return ID(digest)
-}
-
 // V1Image stores the V1 image configuration.
 type V1Image struct {
 	// ID is a unique 64 character identifier of the image


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/44426

This function was deprecated in 456ea1bb1dcdd7a07507f3ba71646bf4dfee5247 (Docker v24.0), and is no longer used.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
image: remove deprecated IDFromDigest
```

**- A picture of a cute animal (not mandatory but encouraged)**

