### PR TITLE
libnet: remove retry logic from a few data management code paths

### DIFF
--- a/libnetwork/drivers/bridge/bridge_store.go
+++ b/libnetwork/drivers/bridge/bridge_store.go
@@ -119,18 +119,7 @@ func (d *driver) storeDelete(kvObject datastore.KVObject) error {
 		return nil
 	}
 
-retry:
-	if err := d.store.DeleteObjectAtomic(kvObject); err != nil {
-		if err == datastore.ErrKeyModified {
-			if err := d.store.GetObject(datastore.Key(kvObject.Key()...), kvObject); err != nil {
-				return fmt.Errorf("could not update the kvobject to latest when trying to delete: %v", err)
-			}
-			goto retry
-		}
-		return err
-	}
-
-	return nil
+	return d.store.DeleteObjectAtomic(kvObject)
 }
 
 func (ncfg *networkConfiguration) MarshalJSON() ([]byte, error) {

--- a/libnetwork/drivers/ipvlan/ipvlan_store.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_store.go
@@ -134,18 +134,8 @@ func (d *driver) storeDelete(kvObject datastore.KVObject) error {
 		log.G(context.TODO()).Debugf("ipvlan store not initialized. kv object %s is not deleted from store", datastore.Key(kvObject.Key()...))
 		return nil
 	}
-retry:
-	if err := d.store.DeleteObjectAtomic(kvObject); err != nil {
-		if err == datastore.ErrKeyModified {
-			if err := d.store.GetObject(datastore.Key(kvObject.Key()...), kvObject); err != nil {
-				return fmt.Errorf("could not update the kvobject to latest when trying to delete: %v", err)
-			}
-			goto retry
-		}
-		return err
-	}
 
-	return nil
+	return d.store.DeleteObjectAtomic(kvObject)
 }
 
 func (config *configuration) MarshalJSON() ([]byte, error) {

--- a/libnetwork/drivers/macvlan/macvlan_store.go
+++ b/libnetwork/drivers/macvlan/macvlan_store.go
@@ -133,18 +133,8 @@ func (d *driver) storeDelete(kvObject datastore.KVObject) error {
 		log.G(context.TODO()).Debugf("macvlan store not initialized. kv object %s is not deleted from store", datastore.Key(kvObject.Key()...))
 		return nil
 	}
-retry:
-	if err := d.store.DeleteObjectAtomic(kvObject); err != nil {
-		if err == datastore.ErrKeyModified {
-			if err := d.store.GetObject(datastore.Key(kvObject.Key()...), kvObject); err != nil {
-				return fmt.Errorf("could not update the kvobject to latest when trying to delete: %v", err)
-			}
-			goto retry
-		}
-		return err
-	}
 
-	return nil
+	return d.store.DeleteObjectAtomic(kvObject)
 }
 
 func (config *configuration) MarshalJSON() ([]byte, error) {

--- a/libnetwork/endpoint_cnt.go
+++ b/libnetwork/endpoint_cnt.go
@@ -105,25 +105,7 @@ func (ec *endpointCnt) EndpointCnt() uint64 {
 }
 
 func (ec *endpointCnt) updateStore() error {
-	store := ec.n.getController().getStore()
-	if store == nil {
-		return fmt.Errorf("store not found on endpoint count update")
-	}
-	// make a copy of count and n to avoid being overwritten by store.GetObject
-	count := ec.EndpointCnt()
-	n := ec.n
-	for {
-		if err := ec.n.getController().updateToStore(ec); err == nil || err != datastore.ErrKeyModified {
-			return err
-		}
-		if err := store.GetObject(datastore.Key(ec.Key()...), ec); err != nil {
-			return fmt.Errorf("could not update the kvobject to latest on endpoint count update: %v", err)
-		}
-		ec.Lock()
-		ec.Count = count
-		ec.n = n
-		ec.Unlock()
-	}
+	return ec.n.getController().updateToStore(ec)
 }
 
 func (ec *endpointCnt) setCnt(cnt uint64) error {

--- a/libnetwork/endpoint_cnt.go
+++ b/libnetwork/endpoint_cnt.go
@@ -143,7 +143,7 @@ func (ec *endpointCnt) atomicIncDecEpCnt(inc bool) error {
 	if err := store.GetObject(datastore.Key(ec.Key()...), tmp); err != nil {
 		return err
 	}
-retry:
+
 	ec.Lock()
 	if inc {
 		ec.Count++
@@ -154,19 +154,7 @@ retry:
 	}
 	ec.Unlock()
 
-	if err := ec.n.getController().updateToStore(ec); err != nil {
-		if err == datastore.ErrKeyModified {
-			if err := store.GetObject(datastore.Key(ec.Key()...), ec); err != nil {
-				return fmt.Errorf("could not update the kvobject to latest when trying to atomic add endpoint count: %v", err)
-			}
-
-			goto retry
-		}
-
-		return err
-	}
-
-	return nil
+	return ec.n.getController().updateToStore(ec)
 }
 
 func (ec *endpointCnt) IncEndpointCnt() error {


### PR DESCRIPTION
**- What I did**

All four commits have explanations about why they're safe to carry. But the common trait is that all retry logic was added to work around issues posed by either:

1. Classic Swarm and the eventually consistent data store it supported ;
2. Requests to the local datastore not being serialized, leading to consistency issues between the underlying cache and the on-disk state ;
3. Because `datastore.GetObject()` method was (and still is) hydrating the `KVObject` parameter passed as argument instead of returning the object in the cache (if any). As a consequence, two instances of the same object could live in memory at the same. This would defeat the purpose of mutex, and one instance could lag behind the other (in terms of dbIndex, the version ID used for optimistic locking).

While both issue 1. and 2. are a thing of the past, 3. remains. Fortuantely, after analyzing the code, it seems there's no case where that could happen -- making these changes safe.

**- How I did it**

By carrying out a static analysis of the code.

**- How to verify it**

CI.

