### PR TITLE
[24.0 backport] pkg/idtools: remove sync.Once, and include lookup error

### DIFF
--- a/pkg/idtools/idtools_unix.go
+++ b/pkg/idtools/idtools_unix.go
@@ -11,15 +11,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
-	"sync"
 	"syscall"
 
 	"github.com/opencontainers/runc/libcontainer/user"
-)
-
-var (
-	entOnce   sync.Once
-	getentCmd string
 )
 
 func mkdirAs(path string, mode os.FileMode, owner Identity, mkAll, chownExisting bool) error {
@@ -162,10 +156,10 @@ func getentGroup(name string) (user.Group, error) {
 }
 
 func callGetent(database, key string) (io.Reader, error) {
-	entOnce.Do(func() { getentCmd, _ = resolveBinary("getent") })
-	// if no `getent` command on host, can't do anything else
-	if getentCmd == "" {
-		return nil, fmt.Errorf("unable to find getent command")
+	getentCmd, err := resolveBinary("getent")
+	// if no `getent` command within the execution environment, can't do anything else
+	if err != nil {
+		return nil, fmt.Errorf("unable to find getent command: %w", err)
 	}
 	command := exec.Command(getentCmd, database, key)
 	// we run getent within container filesystem, but without /dev so /dev/null is not available for exec to mock stdin


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/46417

When running a `docker cp` to copy files to/from a container, the lookup of the `getent` executable happens within the container's filesystem, so we cannot re-use the results.

Unfortunately, that also means we can't preserve the results for any other uses of these functions, but probably the lookup should not be "too" costly.


(cherry picked from commit b5376c7cec61d08d08b3d3c8c49fe8d0c28f2126)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

