### PR TITLE
internal/sliceutil: add utilities to map values

### DIFF
--- a/internal/sliceutil/sliceutil.go
+++ b/internal/sliceutil/sliceutil.go
@@ -11,3 +11,21 @@ func Dedup[T comparable](slice []T) []T {
 	}
 	return out
 }
+
+func Map[S ~[]In, In, Out any](s S, fn func(In) Out) []Out {
+	res := make([]Out, len(s))
+	for i, v := range s {
+		res[i] = fn(v)
+	}
+	return res
+}
+
+func Mapper[In, Out any](fn func(In) Out) func([]In) []Out {
+	return func(s []In) []Out {
+		res := make([]Out, len(s))
+		for i, v := range s {
+			res[i] = fn(v)
+		}
+		return res
+	}
+}

--- a/internal/sliceutil/sliceutil_test.go
+++ b/internal/sliceutil/sliceutil_test.go
@@ -1,0 +1,49 @@
+package sliceutil_test
+
+import (
+	"net/netip"
+	"strconv"
+	"testing"
+
+	"github.com/docker/docker/internal/sliceutil"
+)
+
+func TestMap(t *testing.T) {
+	s := []int{1, 2, 3}
+	m := sliceutil.Map(s, func(i int) int { return i * 2 })
+	if len(m) != len(s) {
+		t.Fatalf("expected len %d, got %d", len(s), len(m))
+	}
+	for i, v := range m {
+		if expected := s[i] * 2; v != expected {
+			t.Fatalf("expected %d, got %d", expected, v)
+		}
+	}
+}
+
+func TestMap_TypeConvert(t *testing.T) {
+	s := []int{1, 2, 3}
+	m := sliceutil.Map(s, func(i int) string { return strconv.Itoa(i) })
+	if len(m) != len(s) {
+		t.Fatalf("expected len %d, got %d", len(s), len(m))
+	}
+	for i, v := range m {
+		if expected := strconv.Itoa(s[i]); v != expected {
+			t.Fatalf("expected %s, got %s", expected, v)
+		}
+	}
+}
+
+func TestMapper(t *testing.T) {
+	s := []string{"1.2.3.4", "fe80::1"}
+	mapper := sliceutil.Mapper(netip.MustParseAddr)
+	m := mapper(s)
+	if len(m) != len(s) {
+		t.Fatalf("expected len %d, got %d", len(s), len(m))
+	}
+	for i, v := range m {
+		if expected := netip.MustParseAddr(s[i]); v != expected {
+			t.Fatalf("expected %s, got %s", expected, v)
+		}
+	}
+}


### PR DESCRIPTION
Functional programming for the win! Add a utility function to map the values of a slice, along with a curried variant, to tide us over until equivalent functionality gets added to the standard library (https://go.dev/issue/61898)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

