### PR TITLE
libnet: don't lock `*Endpoint` in the void

### DIFF
--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -469,11 +469,6 @@ func (ep *Endpoint) sbJoin(sb *Sandbox, options ...EndpointOption) (err error) {
 		return fmt.Errorf("failed to get network from store during join: %v", err)
 	}
 
-	ep, err = n.getEndpointFromStore(ep.ID())
-	if err != nil {
-		return fmt.Errorf("failed to get endpoint from store during join: %v", err)
-	}
-
 	ep.mu.Lock()
 	if ep.sandboxID != "" {
 		ep.mu.Unlock()
@@ -695,11 +690,6 @@ func (ep *Endpoint) sbLeave(sb *Sandbox, force bool, options ...EndpointOption) 
 	n, err := ep.getNetworkFromStore()
 	if err != nil {
 		return fmt.Errorf("failed to get network from store during leave: %v", err)
-	}
-
-	ep, err = n.getEndpointFromStore(ep.ID())
-	if err != nil {
-		return fmt.Errorf("failed to get endpoint from store during leave: %v", err)
 	}
 
 	ep.mu.Lock()


### PR DESCRIPTION
**- What I did**

`(*Endpoint).sbJoin()`, `(*Endpoint).sbLeave()` start by calling `(*Network).getEndpointFromStore()` before doing anything else. In turn this method calls `(*Store).GetObject()` with a freshly created `*Endpoint` instance, meaning the `*Endpoint` instance returned by `getEndpointFromStore` is a totally different reference than the one already living in memory. Thus, any mutex locks on these new instances actually lock *nothing* at all.

Another property of `GetObject()` is to fully hydrate a given object based on the "canonical" reference that lives in its cache.

Since both `sbJoin()` and `sbLeave()` are always called on an `*Endpoint` receiver which were either just created, or just retrieved from the datastore, there's no chance that the receiver was partially hydrated.

**- How I did it**

By conducting a static analysis of `sbJoin()`, `sbLeave()` and their callsites.

**- How to verify it**

CI

