### PR TITLE
libnet: remove the `EndpointInfo` interface 

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -822,16 +822,11 @@ func updateJoinInfo(networkSettings *network.Settings, n *libnetwork.Network, ep
 		networkSettings.Ports = pm
 	}
 
-	epInfo := ep.Info()
-	if epInfo == nil {
-		// It is not an error to get an empty endpoint info
-		return nil
+	if ep.Gateway() != nil {
+		networkSettings.Networks[n.Name()].Gateway = ep.Gateway().String()
 	}
-	if epInfo.Gateway() != nil {
-		networkSettings.Networks[n.Name()].Gateway = epInfo.Gateway().String()
-	}
-	if epInfo.GatewayIPv6().To16() != nil {
-		networkSettings.Networks[n.Name()].IPv6Gateway = epInfo.GatewayIPv6().String()
+	if ep.GatewayIPv6().To16() != nil {
+		networkSettings.Networks[n.Name()].IPv6Gateway = ep.GatewayIPv6().String()
 	}
 	return nil
 }
@@ -856,11 +851,7 @@ func (daemon *Daemon) disconnectFromNetwork(container *container.Container, n *l
 		sbox *libnetwork.Sandbox
 	)
 	n.WalkEndpoints(func(current *libnetwork.Endpoint) bool {
-		epInfo := current.Info()
-		if epInfo == nil {
-			return false
-		}
-		if sb := epInfo.Sandbox(); sb != nil {
+		if sb := ep.Sandbox(); sb != nil {
 			if sb.ContainerID() == container.ID {
 				ep = current
 				sbox = sb

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -472,11 +472,6 @@ func (ep *Endpoint) sbJoin(sb *Sandbox, options ...EndpointOption) (err error) {
 		return fmt.Errorf("failed to get network from store during join: %v", err)
 	}
 
-	ep, err = n.getEndpointFromStore(ep.ID())
-	if err != nil {
-		return fmt.Errorf("failed to get endpoint from store during join: %v", err)
-	}
-
 	ep.mu.Lock()
 	if ep.sandboxID != "" {
 		ep.mu.Unlock()

--- a/libnetwork/endpoint_info.go
+++ b/libnetwork/endpoint_info.go
@@ -9,32 +9,6 @@ import (
 	"github.com/docker/docker/libnetwork/types"
 )
 
-// EndpointInfo provides an interface to retrieve network resources bound to the endpoint.
-type EndpointInfo interface {
-	// Iface returns information about the interface which was assigned to
-	// the endpoint by the driver. This can be used after the
-	// endpoint has been created.
-	Iface() *EndpointInterface
-
-	// Gateway returns the IPv4 gateway assigned by the driver.
-	// This will only return a valid value if a container has joined the endpoint.
-	Gateway() net.IP
-
-	// GatewayIPv6 returns the IPv6 gateway assigned by the driver.
-	// This will only return a valid value if a container has joined the endpoint.
-	GatewayIPv6() net.IP
-
-	// StaticRoutes returns the list of static routes configured by the network
-	// driver when the container joins a network
-	StaticRoutes() []*types.StaticRoute
-
-	// Sandbox returns the attached sandbox if there, nil otherwise.
-	Sandbox() *Sandbox
-
-	// LoadBalancer returns whether the endpoint is the load balancer endpoint for the network.
-	LoadBalancer() bool
-}
-
 // EndpointInterface holds interface addresses bound to the endpoint.
 type EndpointInterface struct {
 	mac       net.HardwareAddr
@@ -167,34 +141,6 @@ type tableEntry struct {
 	tableName string
 	key       string
 	value     []byte
-}
-
-// Info hydrates the endpoint and returns certain operational data belonging
-// to this endpoint.
-//
-// TODO(thaJeztah): make sure that Endpoint is always fully hydrated, and remove the EndpointInfo interface, and use Endpoint directly.
-func (ep *Endpoint) Info() EndpointInfo {
-	if ep.sandboxID != "" {
-		return ep
-	}
-	n, err := ep.getNetworkFromStore()
-	if err != nil {
-		return nil
-	}
-
-	ep, err = n.getEndpointFromStore(ep.ID())
-	if err != nil {
-		return nil
-	}
-
-	sb, ok := ep.getSandbox()
-	if !ok {
-		// endpoint hasn't joined any sandbox.
-		// Just return the endpoint
-		return ep
-	}
-
-	return sb.GetEndpoint(ep.ID())
 }
 
 // Iface returns information about the interface which was assigned to

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -421,7 +421,7 @@ func TestSRVServiceQuery(t *testing.T) {
 	c.svcRecords[n.ID()] = sr
 
 	ctx := context.Background()
-	_, ip := ep.Info().Sandbox().ResolveService(ctx, "_http._tcp.web.swarm")
+	_, ip := ep.Sandbox().ResolveService(ctx, "_http._tcp.web.swarm")
 
 	if len(ip) == 0 {
 		t.Fatal(err)
@@ -430,7 +430,7 @@ func TestSRVServiceQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, ip = ep.Info().Sandbox().ResolveService(ctx, "_host_http._tcp.web.swarm")
+	_, ip = ep.Sandbox().ResolveService(ctx, "_host_http._tcp.web.swarm")
 
 	if len(ip) == 0 {
 		t.Fatal(err)
@@ -440,7 +440,7 @@ func TestSRVServiceQuery(t *testing.T) {
 	}
 
 	// Service name with invalid protocol name. Should fail without error
-	_, ip = ep.Info().Sandbox().ResolveService(ctx, "_http._icmp.web.swarm")
+	_, ip = ep.Sandbox().ResolveService(ctx, "_http._icmp.web.swarm")
 	if len(ip) != 0 {
 		t.Fatal("Valid response for invalid service name")
 	}
@@ -629,8 +629,8 @@ func TestIpamReleaseOnNetDriverFailures(t *testing.T) {
 	defer ep.Delete(false) //nolint:errcheck
 
 	expectedIP, _ := types.ParseCIDR("10.35.0.1/16")
-	if !types.CompareIPNet(ep.Info().Iface().Address(), expectedIP) {
-		t.Fatalf("Ipam release must have failed, endpoint has unexpected address: %v", ep.Info().Iface().Address())
+	if !types.CompareIPNet(ep.Iface().Address(), expectedIP) {
+		t.Fatalf("Ipam release must have failed, endpoint has unexpected address: %v", ep.Iface().Address())
 	}
 }
 

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -1435,7 +1435,7 @@ func TestBridgeIpv6FromMac(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	iface := ep.Info().Iface()
+	iface := ep.Iface()
 	if !bytes.Equal(iface.MacAddress(), mac) {
 		t.Fatalf("Unexpected mac address: %v", iface.MacAddress())
 	}
@@ -1455,7 +1455,7 @@ func TestBridgeIpv6FromMac(t *testing.T) {
 	}
 }
 
-func checkSandbox(t *testing.T, info libnetwork.EndpointInfo) {
+func checkSandbox(t *testing.T, info *libnetwork.Endpoint) {
 	key := info.Sandbox().Key()
 	sbNs, err := netns.GetFromPath(key)
 	if err != nil {
@@ -1517,8 +1517,7 @@ func TestEndpointJoin(t *testing.T) {
 	}()
 
 	// Validate if ep.Info() only gives me IP address info and not names and gateway during CreateEndpoint()
-	info := ep1.Info()
-	iface := info.Iface()
+	iface := ep1.Iface()
 	if iface.Address() != nil && iface.Address().IP.To4() == nil {
 		t.Fatalf("Invalid IP address returned: %v", iface.Address())
 	}
@@ -1526,15 +1525,15 @@ func TestEndpointJoin(t *testing.T) {
 		t.Fatalf("Invalid IPv6 address returned: %v", iface.Address())
 	}
 
-	if len(info.Gateway()) != 0 {
-		t.Fatalf("Expected empty gateway for an empty endpoint. Instead found a gateway: %v", info.Gateway())
+	if len(ep1.Gateway()) != 0 {
+		t.Fatalf("Expected empty gateway for an empty endpoint. Instead found a gateway: %v", ep1.Gateway())
 	}
-	if len(info.GatewayIPv6()) != 0 {
-		t.Fatalf("Expected empty gateway for an empty ipv6 endpoint. Instead found a gateway: %v", info.GatewayIPv6())
+	if len(ep1.GatewayIPv6()) != 0 {
+		t.Fatalf("Expected empty gateway for an empty ipv6 endpoint. Instead found a gateway: %v", ep1.GatewayIPv6())
 	}
 
-	if info.Sandbox() != nil {
-		t.Fatalf("Expected an empty sandbox key for an empty endpoint. Instead found a non-empty sandbox key: %s", info.Sandbox().Key())
+	if ep1.Sandbox() != nil {
+		t.Fatalf("Expected an empty sandbox key for an empty endpoint. Instead found a non-empty sandbox key: %s", ep1.Sandbox().Key())
 	}
 
 	// test invalid joins
@@ -1579,21 +1578,20 @@ func TestEndpointJoin(t *testing.T) {
 		}
 	}()
 
-	// Validate if ep.Info() only gives valid gateway and sandbox key after has container has joined.
-	info = ep1.Info()
-	if len(info.Gateway()) == 0 {
-		t.Fatalf("Expected a valid gateway for a joined endpoint. Instead found an invalid gateway: %v", info.Gateway())
+	// Validate if ep.Info() only gives valid gateway and sandbox key after has container has joined.=
+	if len(ep1.Gateway()) == 0 {
+		t.Fatalf("Expected a valid gateway for a joined endpoint. Instead found an invalid gateway: %v", ep1.Gateway())
 	}
-	if len(info.GatewayIPv6()) == 0 {
-		t.Fatalf("Expected a valid ipv6 gateway for a joined endpoint. Instead found an invalid gateway: %v", info.GatewayIPv6())
+	if len(ep1.GatewayIPv6()) == 0 {
+		t.Fatalf("Expected a valid ipv6 gateway for a joined endpoint. Instead found an invalid gateway: %v", ep1.GatewayIPv6())
 	}
 
-	if info.Sandbox() == nil {
+	if ep1.Sandbox() == nil {
 		t.Fatalf("Expected an non-empty sandbox key for a joined endpoint. Instead found an empty sandbox key")
 	}
 
 	// Check endpoint provided container information
-	if ep1.Info().Sandbox().Key() != sb.Key() {
+	if ep1.Sandbox().Key() != sb.Key() {
 		t.Fatalf("Endpoint Info returned unexpected sandbox key: %s", sb.Key())
 	}
 
@@ -1643,11 +1641,11 @@ func TestEndpointJoin(t *testing.T) {
 		}
 	}()
 
-	if ep1.Info().Sandbox().Key() != ep2.Info().Sandbox().Key() {
+	if ep1.Sandbox().Key() != ep2.Sandbox().Key() {
 		t.Fatalf("ep1 and ep2 returned different container sandbox key")
 	}
 
-	checkSandbox(t, info)
+	checkSandbox(t, ep1)
 }
 
 func TestExternalKey(t *testing.T) {
@@ -1732,7 +1730,7 @@ func externalKeyTest(t *testing.T, reexec bool) {
 		}
 	}()
 
-	sbox := ep.Info().Sandbox()
+	sbox := ep.Sandbox()
 	if sbox == nil {
 		t.Fatalf("Expected to have a valid Sandbox")
 	}
@@ -1783,11 +1781,11 @@ func externalKeyTest(t *testing.T, reexec bool) {
 		}
 	}()
 
-	if ep.Info().Sandbox().Key() != ep2.Info().Sandbox().Key() {
+	if ep.Sandbox().Key() != ep2.Sandbox().Key() {
 		t.Fatalf("ep1 and ep2 returned different container sandbox key")
 	}
 
-	checkSandbox(t, ep.Info())
+	checkSandbox(t, ep)
 }
 
 func reexecSetKey(key string, containerID string, controllerID string) error {

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -2191,14 +2191,11 @@ func (n *Network) deleteLoadBalancerSandbox() error {
 	if err != nil {
 		log.G(context.TODO()).Warnf("Failed to find load balancer endpoint %s on network %s: %v", endpointName, name, err)
 	} else {
-		info := endpoint.Info()
-		if info != nil {
-			sb := info.Sandbox()
-			if sb != nil {
-				if err := sb.DisableService(); err != nil {
-					log.G(context.TODO()).Warnf("Failed to disable service on sandbox %s: %v", sandboxName, err)
-					// Ignore error and attempt to delete the load balancer endpoint
-				}
+		sb := endpoint.Sandbox()
+		if sb != nil {
+			if err := sb.DisableService(); err != nil {
+				log.G(context.TODO()).Warnf("Failed to disable service on sandbox %s: %v", sandboxName, err)
+				// Ignore error and attempt to delete the load balancer endpoint
 			}
 		}
 

--- a/libnetwork/service_linux.go
+++ b/libnetwork/service_linux.go
@@ -43,8 +43,7 @@ func (n *Network) findLBEndpointSandbox() (*Endpoint, *Sandbox, error) {
 	var ep *Endpoint
 	// Find this node's LB sandbox endpoint:  there should be exactly one
 	for _, e := range n.Endpoints() {
-		epi := e.Info()
-		if epi != nil && epi.LoadBalancer() {
+		if e.LoadBalancer() {
 			ep = e
 			break
 		}

--- a/libnetwork/service_windows.go
+++ b/libnetwork/service_windows.go
@@ -28,12 +28,8 @@ func (n *Network) addLBBackend(ip net.IP, lb *loadBalancer) {
 	// find the load balancer IP for the network.
 	var sourceVIP string
 	for _, e := range n.Endpoints() {
-		epInfo := e.Info()
-		if epInfo == nil {
-			continue
-		}
-		if epInfo.LoadBalancer() {
-			sourceVIP = epInfo.Iface().Address().IP.String()
+		if e.LoadBalancer() {
+			sourceVIP = e.Iface().Address().IP.String()
 			break
 		}
 	}


### PR DESCRIPTION
- Temporarily stacked on top of #47216 to make `TestSRVServiceQuery` pass

**- What I did**

`EndpointInfo` was introduced in https://github.com/moby/libnetwork/commit/d8ba1e231. The commit's message states:

> This sort of deisgn hides the libnetwork specific type details from drivers.

9 years later it turns out the `Endpoint` struct is the only implementor of that interface, and `libnetwork` and `daemon` packages are the only consumers. This is adding an unneeded level of indirection.

`(*Endpoint).Info()` is the only function that returns an `EndpointInfo`. It's basically 12 lines of cursed indirection packed together. But, as noted by thaJeztah in https://github.com/moby/moby/commit/210abfaef6d67eb6e404e88d7e20c7ac30820a1f, we need to make sure the `*Endpoint` receiver is always fully hydrated to get rid of it. So here we go.

As the diff shows, most of the time `(*Endpoint).Info()` is called right after a call to `(*Network).Endpoints()` (sometimes through an indirection). That method in turns calls `getEndpointsFromStore`, which is calling `(*Store).List()`, which is either retrieving all objects of a given type from its internal cache (if it was populated), or retrieve them all from boltdb. In that case, `*Endpoint`s are fully hydrated.

- `disconnectFromNetwork`: calls `WalkEndpoints`, which calls `(*Network).Endpoints()`, right before ;
- `buildContainerAttachments`: calls `(*Network).Endpoints()` right before ;
- `buildEndpointResource`: `ep` and `info` are actually both the same thing ;
- `clearAttachableNetworks`: calls `(*Network).Endpoints()` right before ;
- `findLBEndpointSandbox`: calls `(*Network).Endpoints()` right before ;
- `addLBBackend`: calls `(*Network).Endpoints()` right before ;
- `deleteLoadBalancerSandbox`: calls `(*Network).EndpointByName()`, which calls `WalkEndpoint` (see above).

We're left with the following, less obvious cases:

- `updateJoinInfo`: called from `(*Daemon).connectToNetwork()`, where `*Endpoint`s are created ;
- `buildEndpointInfo`: called from `(*Daemon).updateEndpointNetworkSettings()`, again called from `(*Daemon).connectToNetwork()` ;

Meaning, we can now safely assume `*Endpoint`s are always fully hydrated before calling its `Info()` method. We can finally ditch it! 🎉

**- How I did it**

Static analysis of the code

**- How to verify it**

CI is green.
