### PR TITLE
[24.0 backport] add //go:build directives to prevent downgrading to go1.16 language

### DIFF
--- a/api/server/router/system/system.go
+++ b/api/server/router/system/system.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.19
+
 package system // import "github.com/docker/docker/api/server/router/system"
 
 import (

--- a/builder/builder-next/adapters/containerimage/pull.go
+++ b/builder/builder-next/adapters/containerimage/pull.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.19
+
 package containerimage
 
 import (

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.19
+
 package daemon // import "github.com/docker/docker/daemon"
 
 import (

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.19
+
 // Package daemon exposes the functions that occur on the host server
 // that the Docker daemon is running.
 //

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.19
+
 package daemon // import "github.com/docker/docker/daemon"
 
 import (

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.19
+
 package daemon // import "github.com/docker/docker/daemon"
 
 import (

--- a/libnetwork/config/config.go
+++ b/libnetwork/config/config.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.19
+
 package config
 
 import (

--- a/libnetwork/drivers/overlay/peerdb.go
+++ b/libnetwork/drivers/overlay/peerdb.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.19 && linux
 
 package overlay
 

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.19
+
 package libnetwork
 
 import (

--- a/libnetwork/internal/setmatrix/setmatrix.go
+++ b/libnetwork/internal/setmatrix/setmatrix.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.19
+
 package setmatrix
 
 import (

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.19
+
 package libnetwork
 
 import (

--- a/libnetwork/options/options.go
+++ b/libnetwork/options/options.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.19
+
 // Package options provides a way to pass unstructured sets of options to a
 // component expecting a strongly-typed configuration structure.
 package options

--- a/libnetwork/service.go
+++ b/libnetwork/service.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.19
+
 package libnetwork
 
 import (

--- a/testutil/helpers.go
+++ b/testutil/helpers.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.19
+
 package testutil // import "github.com/docker/docker/testutil"
 
 import (


### PR DESCRIPTION
(partial) backport:

- https://github.com/moby/moby/pull/47213
- https://github.com/moby/moby/pull/46942


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

