### PR TITLE
[25.0 backport] pkg/ioutils: Make subsequent Close attempts noop

### DIFF
--- a/pkg/ioutils/readers.go
+++ b/pkg/ioutils/readers.go
@@ -3,11 +3,15 @@ package ioutils // import "github.com/docker/docker/pkg/ioutils"
 import (
 	"context"
 	"io"
+	"runtime/debug"
+	"sync/atomic"
 
 	// make sure crypto.SHA256, crypto.sha512 and crypto.SHA384 are registered
 	// TODO remove once https://github.com/opencontainers/go-digest/pull/64 is merged.
 	_ "crypto/sha256"
 	_ "crypto/sha512"
+
+	"github.com/containerd/log"
 )
 
 // ReadCloserWrapper wraps an io.Reader, and implements an io.ReadCloser
@@ -16,10 +20,15 @@ import (
 type ReadCloserWrapper struct {
 	io.Reader
 	closer func() error
+	closed atomic.Bool
 }
 
 // Close calls back the passed closer function
 func (r *ReadCloserWrapper) Close() error {
+	if !r.closed.CompareAndSwap(false, true) {
+		subsequentCloseWarn("ReadCloserWrapper")
+		return nil
+	}
 	return r.closer()
 }
 
@@ -87,6 +96,7 @@ type cancelReadCloser struct {
 	cancel func()
 	pR     *io.PipeReader // Stream to read from
 	pW     *io.PipeWriter
+	closed atomic.Bool
 }
 
 // NewCancelReadCloser creates a wrapper that closes the ReadCloser when the
@@ -146,6 +156,17 @@ func (p *cancelReadCloser) closeWithError(err error) {
 // Close closes the wrapper its underlying reader. It will cause
 // future calls to Read to return io.EOF.
 func (p *cancelReadCloser) Close() error {
+	if !p.closed.CompareAndSwap(false, true) {
+		subsequentCloseWarn("cancelReadCloser")
+		return nil
+	}
 	p.closeWithError(io.EOF)
 	return nil
+}
+
+func subsequentCloseWarn(name string) {
+	log.G(context.TODO()).Error("subsequent attempt to close " + name)
+	if log.GetLevel() >= log.DebugLevel {
+		log.G(context.TODO()).Errorf("stack trace: %s", string(debug.Stack()))
+	}
 }


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/46419

Turn subsequent `Close` calls into a no-op and produce a warning with an optional stack trace (if debug mode is enabled).


(cherry picked from commit 585d74bad162e0946d17808e316d10e60cb9ac59)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

