### PR TITLE
[23.0] Dockerfile: update containerd binary to v1.6.27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -191,7 +191,7 @@ RUN git init . && git remote add origin "https://github.com/containerd/container
 # When updating the binary version you may also need to update the vendor
 # version to pick up bug fixes or new APIs, however, usually the Go packages
 # are built from a commit from the master branch.
-ARG CONTAINERD_VERSION=v1.6.22
+ARG CONTAINERD_VERSION=v1.6.27
 RUN git fetch -q --depth 1 origin "${CONTAINERD_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS containerd-build


### PR DESCRIPTION
Update the binary version used in CI and for the static packages.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

