### PR TITLE
image/save: Fix untagged images not present in index.json

### DIFF
--- a/daemon/containerd/image_exporter.go
+++ b/daemon/containerd/image_exporter.go
@@ -168,6 +168,12 @@ func (i *ImageService) ExportImage(ctx context.Context, names []string, outStrea
 
 		ref, refErr := reference.ParseNormalizedNamed(name)
 
+		if refErr == nil {
+			if _, ok := ref.(reference.Digested); ok {
+				specificDigestResolved = true
+			}
+		}
+
 		if resolveErr != nil || !specificDigestResolved {
 			// Name didn't resolve to anything, or name wasn't explicitly referencing a digest
 			if refErr == nil && reference.IsNameOnly(ref) {

--- a/internal/testutils/archive.go
+++ b/internal/testutils/archive.go
@@ -1,0 +1,24 @@
+package testutils
+
+import (
+	"io"
+
+	"github.com/docker/docker/pkg/archive"
+	"github.com/opencontainers/go-digest"
+)
+
+// UncompressedTarDigest returns the canonical digest of the uncompressed tar stream.
+func UncompressedTarDigest(compressedTar io.Reader) (digest.Digest, error) {
+	rd, err := archive.DecompressStream(compressedTar)
+	if err != nil {
+		return "", err
+	}
+
+	defer rd.Close()
+
+	digester := digest.Canonical.Digester()
+	if _, err := io.Copy(digester.Hash(), rd); err != nil {
+		return "", err
+	}
+	return digester.Digest(), nil
+}

--- a/internal/testutils/specialimage/load.go
+++ b/internal/testutils/specialimage/load.go
@@ -1,6 +1,7 @@
 package specialimage
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -41,7 +42,10 @@ func Load(ctx context.Context, t *testing.T, apiClient client.APIClient, imageFu
 		t.Fatalf("Failed load: %s", string(respBody))
 	}
 
-	decoder := json.NewDecoder(resp.Body)
+	all, err := io.ReadAll(resp.Body)
+	assert.NilError(t, err)
+
+	decoder := json.NewDecoder(bytes.NewReader(all))
 	for {
 		var msg jsonmessage.JSONMessage
 		err := decoder.Decode(&msg)
@@ -61,6 +65,6 @@ func Load(ctx context.Context, t *testing.T, apiClient client.APIClient, imageFu
 		}
 	}
 
-	t.Fatal("failed to read image ID")
+	t.Fatalf("failed to read image ID\n%s", string(all))
 	return ""
 }

--- a/internal/testutils/specialimage/multilayer.go
+++ b/internal/testutils/specialimage/multilayer.go
@@ -1,0 +1,201 @@
+package specialimage
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/containerd/containerd/platforms"
+	"github.com/distribution/reference"
+	"github.com/docker/docker/pkg/archive"
+	"github.com/google/uuid"
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func MultiLayer(dir string) error {
+	const imageRef = "multilayer:latest"
+
+	layer1Desc, err := writeLayerWithOneFile(dir, "foo", []byte("1"))
+	if err != nil {
+		return err
+	}
+	layer2Desc, err := writeLayerWithOneFile(dir, "bar", []byte("2"))
+	if err != nil {
+		return err
+	}
+	layer3Desc, err := writeLayerWithOneFile(dir, "hello", []byte("world"))
+	if err != nil {
+		return err
+	}
+
+	configDesc, err := writeJsonBlob(dir, ocispec.MediaTypeImageConfig, ocispec.Image{
+		Platform: platforms.DefaultSpec(),
+		Config: ocispec.ImageConfig{
+			Env: []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
+		},
+		RootFS: ocispec.RootFS{
+			Type:    "layers",
+			DiffIDs: []digest.Digest{layer1Desc.Digest, layer2Desc.Digest, layer3Desc.Digest},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	manifest := ocispec.Manifest{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config:    configDesc,
+		Layers:    []ocispec.Descriptor{layer1Desc, layer2Desc, layer3Desc},
+	}
+
+	legacyManifests := []manifestItem{
+		manifestItem{
+			Config:   blobPath(configDesc),
+			RepoTags: []string{imageRef},
+			Layers:   []string{blobPath(layer1Desc), blobPath(layer2Desc), blobPath(layer3Desc)},
+		},
+	}
+
+	ref, err := reference.ParseNormalizedNamed(imageRef)
+	if err != nil {
+		return err
+	}
+	return singlePlatformImage(dir, ref, manifest, legacyManifests)
+}
+
+// Legacy manifest item (manifests.json)
+type manifestItem struct {
+	Config   string
+	RepoTags []string
+	Layers   []string
+}
+
+func singlePlatformImage(dir string, ref reference.Named, manifest ocispec.Manifest, legacyManifests []manifestItem) error {
+	manifestDesc, err := writeJsonBlob(dir, ocispec.MediaTypeImageManifest, manifest)
+	if err != nil {
+		return err
+	}
+
+	if ref != nil {
+		manifestDesc.Annotations = map[string]string{
+			"io.containerd.image.name": ref.String(),
+		}
+
+		if tagged, ok := ref.(reference.Tagged); ok {
+			manifestDesc.Annotations[ocispec.AnnotationRefName] = tagged.Tag()
+		}
+	}
+
+	if err := writeJson(ocispec.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: []ocispec.Descriptor{manifestDesc},
+	}, filepath.Join(dir, "index.json")); err != nil {
+		return err
+	}
+	if err != nil {
+		return err
+	}
+
+	if err := writeJson(legacyManifests, filepath.Join(dir, "manifest.json")); err != nil {
+		return err
+	}
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(dir, "oci-layout"), []byte(`{"imageLayoutVersion": "1.0.0"}`), 0o644)
+}
+
+func fileArchive(dir string, name string, content []byte) (io.ReadCloser, error) {
+	tmp, err := os.MkdirTemp("", "")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.WriteFile(filepath.Join(tmp, name), content, 0o644); err != nil {
+		return nil, err
+	}
+
+	return archive.Tar(tmp, archive.Uncompressed)
+}
+
+func writeLayerWithOneFile(dir string, filename string, content []byte) (ocispec.Descriptor, error) {
+	rd, err := fileArchive(dir, filename, content)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	return writeBlob(dir, ocispec.MediaTypeImageLayer, rd)
+}
+
+func writeJsonBlob(dir string, mt string, obj any) (ocispec.Descriptor, error) {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	return writeBlob(dir, mt, bytes.NewReader(b))
+}
+
+func writeJson(obj any, path string) error {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, b, 0o644)
+}
+
+func writeBlob(dir string, mt string, rd io.Reader) (_ ocispec.Descriptor, outErr error) {
+	digester := digest.Canonical.Digester()
+	hashTee := io.TeeReader(rd, digester.Hash())
+
+	blobsPath := filepath.Join(dir, "blobs", "sha256")
+	if err := os.MkdirAll(blobsPath, 0o755); err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	tmpPath := filepath.Join(blobsPath, uuid.New().String())
+	file, err := os.Create(tmpPath)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	defer func() {
+		if outErr != nil {
+			file.Close()
+			os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := io.Copy(file, hashTee); err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	digest := digester.Digest()
+
+	stat, err := os.Stat(tmpPath)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	file.Close()
+	if err := os.Rename(tmpPath, filepath.Join(blobsPath, digest.Encoded())); err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	return ocispec.Descriptor{
+		MediaType: mt,
+		Digest:    digest,
+		Size:      stat.Size(),
+	}, nil
+}
+
+func blobPath(desc ocispec.Descriptor) string {
+	return "blobs/sha256/" + desc.Digest.Encoded()
+}


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/47210
- closes: https://github.com/moby/moby/issues/47165

Saving an image via digested reference, ID or truncated ID doesn't store the image reference in the archive. This also causes the save code to not add the image's manifest to the index.json.
This PR explicitly adds the untagged manifests to the index.json if no tagged manifests were added.


**- How to verify it**

- TestSaveOCI integration test

#### By digest
```bash
$ docker save hello-world@sha256:4bd78111b6914a99dbc560e6a20eab57ff6655aea4a80c50b0c5491968cbc2e6 | tar xO index.json | jq
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:411caf340c828657e915a83ed561a79d2b8150dabad4dc079d881cbfe6f86afe",
      "size": 447,
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    }
  ]
}

```

#### By tag
```bash
$ docker save hello-world | tar xO index.json | jq
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:411caf340c828657e915a83ed561a79d2b8150dabad4dc079d881cbfe6f86afe",
      "size": 447,
      "annotations": {
        "io.containerd.image.name": "docker.io/library/hello-world:latest",
        "org.opencontainers.image.ref.name": "latest"
      },
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    }
  ]
}

```

#### Tag and digest
```bash
$ docker tag hello-world my:hello
$ docker save hello-world my:hello \
   hello-world@sha256:4bd78111b6914a99dbc560e6a20eab57ff6655aea4a80c50b0c5491968cbc2e6 | \
   tar xO index.json | jq
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:411caf340c828657e915a83ed561a79d2b8150dabad4dc079d881cbfe6f86afe",
      "size": 447,
      "annotations": {
        "io.containerd.image.name": "docker.io/library/hello-world:latest",
        "org.opencontainers.image.ref.name": "latest"
      },
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:411caf340c828657e915a83ed561a79d2b8150dabad4dc079d881cbfe6f86afe",
      "size": 447,
      "annotations": {
        "io.containerd.image.name": "docker.io/library/my:hello",
        "org.opencontainers.image.ref.name": "hello"
      },
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    }
  ]
}

```

**- Description for the changelog**
```release-note
- Fix `docker save <image>@<digest>` producing an OCI archive with index without manifests
```

**- A picture of a cute animal (not mandatory but encouraged)**

