### PR TITLE
Set containerd container image ref

### DIFF
--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -97,6 +97,10 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 				info.Runtimes[k] = system.RuntimeWithStatus{Runtime: rt.Runtime}
 			}
 		}
+		if versions.LessThan(version, "1.46") {
+			// Containerd field introduced in API v1.46.
+			info.Containerd = nil
+		}
 		if versions.GreaterThanOrEqualTo(version, "1.42") {
 			info.KernelMemory = false
 		}

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5824,6 +5824,58 @@ definitions:
         example:
           - "/etc/cdi"
           - "/var/run/cdi"
+      Containerd:
+        $ref: "#/definitions/ContainerdInfo"
+        x-nullable: true
+
+  ContainerdInfo:
+    description: |
+      Information for connecting to the containerd instance that is used by the daemon.
+      This is included for debugging purposes only.
+    type: "object"
+    properties:
+      Address:
+        description: "The address of the containerd socket."
+        type: "string"
+        example: "/run/containerd/containerd.sock"
+      Namespaces:
+        description: |
+          The namespaces that the daemon uses for running containers and
+          plugins in containerd. These namespaces can be configured in the
+          daemon configuration, and are considered to be used exclusively
+          by the daemon, Tampering with the containerd instance may cause
+          unexpected behavior.
+
+          As these namespaces are considered to be exclusively accessed
+          by the daemon, it is not recommended to change these values,
+          or to change them to a value that is used by other systems,
+          such as cri-containerd.
+        type: "object"
+        properties:
+          Containers:
+            description: |
+              The default containerd namespace used for containers managed
+              by the daemon.
+
+              The default namespace for containers is "moby", but will be
+              suffixed with the `<uid>.<gid>` of the remapped `root` if
+              user-namespaces are enabled and the containerd image-store
+              is used.
+            type: "string"
+            default: "moby"
+            example: "moby"
+          Plugins:
+            description: |
+              The default containerd namespace used for plugins managed by
+              the daemon.
+
+              The default namespace for plugins is "plugins.moby", but will be
+              suffixed with the `<uid>.<gid>` of the remapped `root` if
+              user-namespaces are enabled and the containerd image-store
+              is used.
+            type: "string"
+            default: "plugins.moby"
+            example: "plugins.moby"
 
   # PluginsInfo is a temp struct holding Plugins name
   # registered with docker daemon. It is used by Info struct

--- a/api/types/system/info.go
+++ b/api/types/system/info.go
@@ -75,6 +75,8 @@ type Info struct {
 	DefaultAddressPools []NetworkAddressPool `json:",omitempty"`
 	CDISpecDirs         []string
 
+	Containerd *ContainerdInfo `json:",omitempty"`
+
 	// Legacy API fields for older API versions.
 	legacyFields
 
@@ -83,6 +85,43 @@ type Info struct {
 	// messages for the user, and are not intended to be parsed / used for
 	// other purposes, as they do not have a fixed format.
 	Warnings []string
+}
+
+// ContainerdInfo holds information about the containerd instance used by the daemon.
+type ContainerdInfo struct {
+	// Address is the path to the containerd socket.
+	Address string `json:",omitempty"`
+	// Namespaces is the containerd namespaces used by the daemon.
+	Namespaces ContainerdNamespaces
+}
+
+// ContainerdNamespaces reflects the containerd namespaces used by the daemon.
+//
+// These namespaces can be configured in the daemon configuration, and are
+// considered to be used exclusively by the daemon,
+//
+// As these namespaces are considered to be exclusively accessed
+// by the daemon, it is not recommended to change these values,
+// or to change them to a value that is used by other systems,
+// such as cri-containerd.
+type ContainerdNamespaces struct {
+	// Containers holds the default containerd namespace used for
+	// containers managed by the daemon.
+	//
+	// The default namespace for containers is "moby", but will be
+	// suffixed with the `<uid>.<gid>` of the remapped `root` if
+	// user-namespaces are enabled and the containerd image-store
+	// is used.
+	Containers string
+
+	// Plugins holds the default containerd namespace used for
+	// plugins managed by the daemon.
+	//
+	// The default namespace for plugins is "moby", but will be
+	// suffixed with the `<uid>.<gid>` of the remapped `root` if
+	// user-namespaces are enabled and the containerd image-store
+	// is used.
+	Plugins string
 }
 
 type legacyFields struct {

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -273,6 +273,11 @@ func (i *ImageService) resolveDescriptor(ctx context.Context, refOrID string) (o
 	return img.Target, nil
 }
 
+// ResolveImage looks up an image by reference or identifier in the image store.
+func (i *ImageService) ResolveImage(ctx context.Context, refOrID string) (containerdimages.Image, error) {
+	return i.resolveImage(ctx, refOrID)
+}
+
 func (i *ImageService) resolveImage(ctx context.Context, refOrID string) (containerdimages.Image, error) {
 	parsed, err := reference.ParseAnyReference(refOrID)
 	if err != nil {

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -82,7 +82,9 @@ func (daemon *Daemon) SystemInfo(ctx context.Context) (*system.Info, error) {
 
 	daemon.fillContainerStates(v)
 	daemon.fillDebugInfo(ctx, v)
+	daemon.fillContainerdInfo(v, &cfg.Config)
 	daemon.fillAPIInfo(v, &cfg.Config)
+
 	// Retrieve platform specific info
 	if err := daemon.fillPlatformInfo(ctx, v, sysInfo, cfg); err != nil {
 		return nil, err
@@ -227,6 +229,22 @@ func (daemon *Daemon) fillDebugInfo(ctx context.Context, v *system.Info) {
 	v.NFd = fileutils.GetTotalUsedFds(ctx)
 	v.NGoroutines = runtime.NumGoroutine()
 	v.NEventsListener = daemon.EventsService.SubscribersCount()
+
+}
+
+// fillContainerdInfo provides information about the containerd configuration
+// for debugging purposes.
+func (daemon *Daemon) fillContainerdInfo(v *system.Info, cfg *config.Config) {
+	if cfg.ContainerdAddr == "" {
+		return
+	}
+	v.Containerd = &system.ContainerdInfo{
+		Address: cfg.ContainerdAddr,
+		Namespaces: system.ContainerdNamespaces{
+			Containers: cfg.ContainerdNamespace,
+			Plugins:    cfg.ContainerdPluginNamespace,
+		},
+	}
 }
 
 func (daemon *Daemon) fillAPIInfo(v *system.Info, cfg *config.Config) {

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -17,6 +17,9 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.46](https://docs.docker.com/engine/api/v1.46/) documentation
 
+* `GET /info` now includes a `Containerd` field containing information about
+  the location of the containerd API socket and containerd namespaces used
+  by the daemon to run containers and plugins.
 * `POST /containers/create` field `NetworkingConfig.EndpointsConfig.DriverOpts`,
   and `POST /networks/{id}/connect` field `EndpointsConfig.DriverOpts`, now
   support label `com.docker.network.endpoint.sysctls` for setting per-interface


### PR DESCRIPTION
This populates the "Image" field on containerd containers, but only when 
using the containerd image store.
This allows containerd clients to look up the image information.

In order to be able to test this change I have also added the containerd connection info to the `/info` endpoint.
This also just generally helpful for debugging purposes.

I found that we weren't setting this while reviewing https://github.com/containerd/runwasi/pull/405
In that PR the shim is traversing the container object to get the image info (as mentioned it in the PR comments it would be nice if there was an immutable ref available, but that's a whole other thing).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
* API: `GET /info` now includes a `Containerd` field containing information about
  the location of the containerd API socket and containerd namespaces used
  by the daemon to run containers and plugins.
```

