### PR TITLE
libnetwork: clean up ovmanager pseudo-driver

### DIFF
--- a/libnetwork/drivers/overlay/ovmanager/ovmanager.go
+++ b/libnetwork/drivers/overlay/ovmanager/ovmanager.go
@@ -92,6 +92,10 @@ func (d *driver) NetworkAllocate(id string, option map[string]string, ipV4Data, 
 
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	if _, ok := d.networks[id]; ok {
+		return nil, fmt.Errorf("network %s already exists", id)
+	}
+
 	for i, ipd := range ipV4Data {
 		s := &subnet{
 			subnetIP: ipd.Pool,
@@ -125,12 +129,7 @@ func (d *driver) NetworkAllocate(id string, option map[string]string, ipV4Data, 
 	}
 	opts[netlabel.OverlayVxlanIDList] = val
 
-	if _, ok := d.networks[id]; ok {
-		n.releaseVxlanID()
-		return nil, fmt.Errorf("network %s already exists", id)
-	}
 	d.networks[id] = n
-
 	return opts, nil
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
The ovmanager driver does not do very much. Its primary function is to ensure that each subnet of each overlay network in the Swarm has a unique VXLAN ID assigned. It only cares about the number of IPAM pools, not the specifics. Stop the ovmanager driver from holding unnecessary state.

**- How I did it**

**- How to verify it**
TODO TODO TODO

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

