### PR TITLE
daemon/logger/journald: quit waiting when the logger closes

### DIFF
--- a/daemon/logger/journald/read_test.go
+++ b/daemon/logger/journald/read_test.go
@@ -3,6 +3,7 @@
 package journald // import "github.com/docker/docker/daemon/logger/journald"
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -46,32 +47,37 @@ func TestLogRead(t *testing.T) {
 			assert.NilError(t, rotatedJournal.Send("a log message from a totally different process in the active journal", journal.PriInfo, nil))
 
 			return func(t *testing.T) logger.Logger {
+				l, err := new(info)
+				assert.NilError(t, err)
+				l.journalReadDir = journalDir
+				sl := &syncLogger{journald: l, waiters: map[uint64]chan<- struct{}{}}
+
 				s := make(chan sendit, 100)
 				t.Cleanup(func() { close(s) })
 				go func() {
 					for m := range s {
 						<-m.after
 						activeJournal.Send(m.message, m.priority, m.vars)
-						if m.sent != nil {
-							close(m.sent)
+						sl.mu.Lock()
+						sl.sent++
+						if notify, ok := sl.waiters[sl.sent]; ok {
+							delete(sl.waiters, sl.sent)
+							close(notify)
 						}
+						sl.mu.Unlock()
 					}
 				}()
-				l, err := new(info)
-				assert.NilError(t, err)
-				l.journalReadDir = journalDir
 
-				sl := &syncLogger{journald: l}
 				l.sendToJournal = func(message string, priority journal.Priority, vars map[string]string) error {
-					sent := make(chan struct{})
+					sl.mu.Lock()
+					sl.queued++
+					sl.mu.Unlock()
 					s <- sendit{
 						message:  message,
 						priority: priority,
 						vars:     vars,
 						after:    time.After(150 * time.Millisecond),
-						sent:     sent,
 					}
-					sl.waitOn = sent
 					return nil
 				}
 				l.readSyncTimeout = 3 * time.Second
@@ -88,17 +94,26 @@ type sendit struct {
 	priority journal.Priority
 	vars     map[string]string
 	after    <-chan time.Time
-	sent     chan<- struct{}
 }
 
 type syncLogger struct {
 	*journald
-	waitOn <-chan struct{}
+
+	mu           sync.Mutex
+	queued, sent uint64
+	waiters      map[uint64]chan<- struct{}
 }
 
 func (l *syncLogger) Sync() error {
-	if l.waitOn != nil {
-		<-l.waitOn
+	l.mu.Lock()
+	waitFor := l.queued
+	if l.sent >= l.queued {
+		l.mu.Unlock()
+		return nil
 	}
+	notify := make(chan struct{})
+	l.waiters[waitFor] = notify
+	l.mu.Unlock()
+	<-notify
 	return nil
 }

--- a/daemon/logger/journald/read_test.go
+++ b/daemon/logger/journald/read_test.go
@@ -117,3 +117,8 @@ func (l *syncLogger) Sync() error {
 	<-notify
 	return nil
 }
+
+func (l *syncLogger) Close() error {
+	_ = l.Sync()
+	return l.journald.Close()
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
- Follow-up to #47019

**- What I did**
Fixed a regression in the journald log reader which manifested as rare test failures. The root cause was that it waited for nothing after the logger is closed. In the process I found and fixed some issues with the tests that were getting in the way of debugging. One of the fixes made the `Follow` tests consistently catch the bug without needing to write a new regression test.

**- How I did it**
I ran the journald tests repeatedly (e.g. using `-count=100`) in an attempt to replicate the `TestLogRead/Follow/Tail=0` failure seen once in CI. While that test did not fail locally, `TestLogRead/Follow/Concurrent` would fail ~1% of the time with test output that provided almost no useful information. I ran the tests again with the race detector enabled and discovered that there was a data race in the journald reader harness. I fixed the data race to stop it from obscuring any data races in the journald code (there were no other data races detected) and to make sure that the race was not causing the tests to flake out. Fixing it had no effect on the TestConcurrent failure rate. So I made some improvements to TestConcurrent to make it easier to debug and to address deficiencies I had suspected of being the source of flakiness. One of the interim improvements was to add an explicit flush before closing the logger. It did fix the flakiness, but not in the way I had expected: the test was now consistently _failing_! That allowed me to run the tests under a debugger and identify the reader bug.

**- How to verify it**
`go test -race ./daemon/logger/journald` passes

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

