### PR TITLE
api/build: Use v2 builder by default

### DIFF
--- a/daemon/server/router/build/build_routes.go
+++ b/daemon/server/router/build/build_routes.go
@@ -37,7 +37,7 @@ func (e invalidParam) InvalidParameter() {}
 
 func newImageBuildOptions(ctx context.Context, r *http.Request) (*build.ImageBuildOptions, error) {
 	options := &build.ImageBuildOptions{
-		Version:        build.BuilderV1, // Builder V1 is the default, but can be overridden
+		Version:        build.BuilderBuildKit,
 		Dockerfile:     r.FormValue("dockerfile"),
 		SuppressOutput: httputils.BoolValue(r, "q"),
 		NoCache:        httputils.BoolValue(r, "nocache"),


### PR DESCRIPTION
Use Buildkit based image builder by default when building via the API.

(A draft PR to see what CI thinks)

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

