### PR TITLE
[23.0] Dockerfile: update containerd binary for windows to 1.6.27

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -168,7 +168,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ARG GO_VERSION=1.20.13
 ARG GOTESTSUM_VERSION=v1.8.2
 ARG GOWINRES_VERSION=v0.3.0
-ARG CONTAINERD_VERSION=v1.6.22
+ARG CONTAINERD_VERSION=v1.6.27
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/47226

Update the containerd binary that's used in CI to align with the version used for Linux. This was missed in d6abda0710383ecaf928687c31567d1c86dc70f3.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

