### PR TITLE
ci: bump remaining gha to latest stable

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -65,9 +65,9 @@ jobs:
       -
         name: Upload reports
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.storage }}-unit-reports
+          name: test-reports-unit-${{ inputs.storage }}
           path: /tmp/reports/*
 
   unit-report:
@@ -85,9 +85,9 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       -
         name: Download reports
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.storage }}-unit-reports
+          name: test-reports-unit-${{ inputs.storage }}
           path: /tmp/reports
       -
         name: Install teststat
@@ -145,9 +145,9 @@ jobs:
       -
         name: Upload reports
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.storage }}-docker-py-reports
+          name: test-reports-docker-py-${{ inputs.storage }}
           path: /tmp/reports/*
 
   integration-flaky:
@@ -236,10 +236,13 @@ jobs:
         name: Prepare reports
         if: always()
         run: |
-          reportsPath="/tmp/reports/${{ matrix.os }}"
+          reportsName=${{ matrix.os }}
           if [ -n "${{ matrix.mode }}" ]; then
-            reportsPath="$reportsPath-${{ matrix.mode }}"
+            reportsName="$reportsName-${{ matrix.mode }}"
           fi
+          reportsPath="/tmp/reports/$reportsName"
+          echo "TESTREPORTS_NAME=$reportsName" >> $GITHUB_ENV
+          
           mkdir -p bundles $reportsPath
           find bundles -path '*/root/*overlay2' -prune -o -type f \( -name '*-report.json' -o -name '*.log' -o -name '*.out' -o -name '*.prof' -o -name '*-report.xml' \) -print | xargs sudo tar -czf /tmp/reports.tar.gz
           tar -xzf /tmp/reports.tar.gz -C $reportsPath
@@ -262,9 +265,9 @@ jobs:
       -
         name: Upload reports
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.storage }}-integration-reports
+          name: test-reports-integration-${{ inputs.storage }}-${{ env.TESTREPORTS_NAME }}
           path: /tmp/reports/*
 
   integration-report:
@@ -282,10 +285,11 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       -
         name: Download reports
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.storage }}-integration-reports
           path: /tmp/reports
+          pattern: test-reports-integration-${{ inputs.storage }}-*
+          merge-multiple: true
       -
         name: Install teststat
         run: |
@@ -372,7 +376,10 @@ jobs:
         name: Prepare reports
         if: always()
         run: |
-          reportsPath=/tmp/reports/$(echo -n "${{ matrix.test }}" | sha256sum | cut -d " " -f 1)
+          reportsName=$(echo -n "${{ matrix.test }}" | sha256sum | cut -d " " -f 1)
+          reportsPath=/tmp/reports/$reportsName
+          echo "TESTREPORTS_NAME=$reportsName" >> $GITHUB_ENV
+          
           mkdir -p bundles $reportsPath
           echo "${{ matrix.test }}" | tr -s '|' '\n' | tee -a "$reportsPath/tests.txt"
           find bundles -path '*/root/*overlay2' -prune -o -type f \( -name '*-report.json' -o -name '*.log' -o -name '*.out' -o -name '*.prof' -o -name '*-report.xml' \) -print | xargs sudo tar -czf /tmp/reports.tar.gz
@@ -396,9 +403,9 @@ jobs:
       -
         name: Upload reports
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.storage }}-integration-cli-reports
+          name: test-reports-integration-cli-${{ inputs.storage }}-${{ env.TESTREPORTS_NAME }}
           path: /tmp/reports/*
 
   integration-cli-report:
@@ -416,10 +423,11 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       -
         name: Download reports
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.storage }}-integration-cli-reports
           path: /tmp/reports
+          pattern: test-reports-integration-cli-${{ inputs.storage }}-*
+          merge-multiple: true
       -
         name: Install teststat
         run: |

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -57,7 +57,7 @@ jobs:
           tree -nh /tmp/reports
       -
         name: Send to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: ./bundles
           env_vars: RUNNER_OS
@@ -252,7 +252,7 @@ jobs:
           curl -sSLf localhost:16686/api/traces?service=integration-test-client > $reportsPath/jaeger-trace.json
       -
         name: Send to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: ./bundles/test-integration
           env_vars: RUNNER_OS
@@ -390,7 +390,7 @@ jobs:
           curl -sSLf localhost:16686/api/traces?service=integration-test-client > $reportsPath/jaeger-trace.json
       -
         name: Send to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: ./bundles/test-integration
           env_vars: RUNNER_OS

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -176,7 +176,7 @@ jobs:
       -
         name: Send to Codecov
         if: inputs.send_coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           working-directory: ${{ env.GOPATH }}\src\github.com\docker\docker
           directory: bundles
@@ -449,7 +449,7 @@ jobs:
       -
         name: Send to Codecov
         if: inputs.send_coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           working-directory: ${{ env.GOPATH }}\src\github.com\docker\docker
           directory: bundles

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -103,7 +103,7 @@ jobs:
           docker cp "${{ env.TEST_CTN_NAME }}`:c`:\containerd\bin\containerd-shim-runhcs-v1.exe" ${{ env.BIN_OUT }}\
       -
         name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-${{ inputs.storage }}-${{ inputs.os }}
           path: ${{ env.BIN_OUT }}/*
@@ -185,7 +185,7 @@ jobs:
       -
         name: Upload reports
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.os }}-${{ inputs.storage }}-unit-reports
           path: ${{ env.GOPATH }}\src\github.com\docker\docker\bundles\*
@@ -203,7 +203,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       -
         name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.os }}-${{ inputs.storage }}-unit-reports
           path: /tmp/artifacts
@@ -282,6 +282,7 @@ jobs:
         with:
           path: ${{ env.GOPATH }}/src/github.com/docker/docker
       -
+        name: Set up Jaeger
         run: |
           # Jaeger is set up on Linux through the setup-tracing action. If you update Jaeger here, don't forget to
           # update the version set in .github/actions/setup-tracing/action.yml.
@@ -296,7 +297,7 @@ jobs:
           Get-ChildItem Env: | Out-String
       -
         name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-${{ inputs.storage }}-${{ inputs.os }}
           path: ${{ env.BIN_OUT }}
@@ -310,6 +311,9 @@ jobs:
             echo "WINDOWS_BASE_IMAGE_TAG=${{ env.WINDOWS_BASE_TAG_2022 }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           }
           Write-Output "${{ env.BIN_OUT }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          
+          $testName = ([System.BitConverter]::ToString((New-Object System.Security.Cryptography.SHA256Managed).ComputeHash([System.Text.Encoding]::UTF8.GetBytes("${{ matrix.test }}"))) -replace '-').ToLower()
+          echo "TESTREPORTS_NAME=$testName" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
       -
         # removes docker service that is currently installed on the runner. we
         # could use Uninstall-Package but not yet available on Windows runners.
@@ -498,9 +502,9 @@ jobs:
       -
         name: Upload reports
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.os }}-${{ inputs.storage }}-integration-reports-${{ matrix.runtime }}
+          name: ${{ inputs.os }}-${{ inputs.storage }}-integration-reports-${{ matrix.runtime }}-${{ env.TESTREPORTS_NAME }}
           path: ${{ env.GOPATH }}\src\github.com\docker\docker\bundles\*
 
   integration-test-report:
@@ -527,11 +531,12 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       -
-        name: Download artifacts
-        uses: actions/download-artifact@v3
+        name: Download reports
+        uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.os }}-${{ inputs.storage }}-integration-reports-${{ matrix.runtime }}
-          path: /tmp/artifacts
+          path: /tmp/reports
+          pattern: ${{ inputs.os }}-${{ inputs.storage }}-integration-reports-${{ matrix.runtime }}-*
+          merge-multiple: true
       -
         name: Install teststat
         run: |
@@ -539,4 +544,4 @@ jobs:
       -
         name: Create summary
         run: |
-          teststat -markdown $(find /tmp/artifacts -type f -name '*.json' -print0 | xargs -0) >> $GITHUB_STEP_SUMMARY
+          teststat -markdown $(find /tmp/reports -type f -name '*.json' -print0 | xargs -0) >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -62,7 +62,7 @@ jobs:
           }
       -
         name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~\AppData\Local\go-build
@@ -142,7 +142,7 @@ jobs:
           }
       -
         name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~\AppData\Local\go-build

--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -67,7 +67,7 @@ jobs:
           mv "${bakeFile#cwd://}" "/tmp/bake-meta.json"
       -
         name: Upload meta bake definition
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bake-meta
           path: /tmp/bake-meta.json
@@ -91,13 +91,18 @@ jobs:
         platform: ${{ fromJson(needs.prepare.outputs.platforms) }}
     steps:
       -
+        name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+      -
         name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
       -
         name: Download meta bake definition
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bake-meta
           path: /tmp
@@ -137,9 +142,9 @@ jobs:
       -
         name: Upload digest
         if: github.event_name != 'pull_request' && github.repository == 'moby/moby'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: digests
+          name: digests-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -152,16 +157,17 @@ jobs:
     steps:
       -
         name: Download meta bake definition
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bake-meta
           path: /tmp
       -
         name: Download digests
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: digests
           path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -122,7 +122,7 @@ jobs:
       -
         name: Build
         id: bake
-        uses: docker/bake-action@v3
+        uses: docker/bake-action@v4
         with:
           files: |
             ./docker-bake.hcl

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -38,7 +38,7 @@ jobs:
           targets: binary
       -
         name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: binary
           path: ${{ env.DESTDIR }}
@@ -104,7 +104,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Download binary artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: binary
           path: ./buildkit/build/moby/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           find ${{ env.DESTDIR }} -type f -exec file -e ascii -- {} +
       -
         name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}
           path: ${{ env.DESTDIR }}
@@ -121,7 +121,7 @@ jobs:
           find ${{ env.DESTDIR }} -type f -exec file -e ascii -- {} +
       -
         name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cross-${{ env.PLATFORM_PAIR }}
           path: ${{ env.DESTDIR }}


### PR DESCRIPTION
follow-up https://github.com/moby/moby/pull/47250#issuecomment-1918889881

**- What I did**

* Similar to https://github.com/docker/buildx/pull/2210, bump upload/download artifact actions to v4 and make slight changes to handle merging multiple artifacts. More info: https://github.com/actions/upload-artifact/issues/472#issuecomment-1861571655
* Also updates cache action to v4. No specific changes needed.
* Update codecov action to v4 as well for node20 support.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

