### PR TITLE
hack/make.ps1: Fix go list pattern

### DIFF
--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -348,7 +348,7 @@ Function Run-UnitTests() {
 Function Run-IntegrationTests() {
     $escRoot = [Regex]::Escape($root)
     $env:DOCKER_INTEGRATION_DAEMON_DEST = $bundlesDir + "\tmp"
-    $dirs = go list -test -f '{{- if ne .ForTest `"`" -}}{{- .Dir -}}{{- end -}}' .\integration\...
+    $dirs = go list -test -f '{{- if ne .ForTest "" -}}{{- .Dir -}}{{- end -}}' .\integration\...
     ForEach($dir in $dirs) {
         # Normalize directory name for using in the test results files.
         $normDir = $dir.Trim()


### PR DESCRIPTION
The double quotes inside a single quoted string don't need to be escaped.
Looks like different Powershell versions are treating this differently and it started failing unexpectedly without any changes on our side.

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

