### PR TITLE
[25.0 backport] Assert temp output directory is not an empty string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,9 @@ swagger-docs: ## preview the API documentation
 .PHONY: generate-files
 generate-files:
 	$(eval $@_TMP_OUT := $(shell mktemp -d -t moby-output.XXXXXXXXXX))
+	ifeq ($($@_TMP_OUT),)
+		$(error Could not create temp directory.)
+	endif
 	$(BUILD_CMD) --target "update" \
 		--output "type=local,dest=$($@_TMP_OUT)" \
 		--file "./hack/dockerfiles/generate-files.Dockerfile" .


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/47121

(cherry picked from commit c655b7dc78b3a0773f33f92e9c923a2e48e9c62b)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

