### PR TITLE
libc8d/supervisor: return waitCh from startContainerd

### DIFF
--- a/libcontainerd/supervisor/remote_daemon_linux.go
+++ b/libcontainerd/supervisor/remote_daemon_linux.go
@@ -30,28 +30,28 @@ func (r *remote) setDefaults() {
 	}
 }
 
-func (r *remote) stopDaemon() {
+func (r *remote) stopDaemon(pid int) {
 	// Ask the daemon to quit
-	syscall.Kill(r.daemonPid, syscall.SIGTERM)
+	syscall.Kill(pid, syscall.SIGTERM)
 	// Wait up to 15secs for it to stop
 	for i := time.Duration(0); i < shutdownTimeout; i += time.Second {
-		if !process.Alive(r.daemonPid) {
+		if !process.Alive(pid) {
 			break
 		}
 		time.Sleep(time.Second)
 	}
 
-	if process.Alive(r.daemonPid) {
-		r.logger.WithField("pid", r.daemonPid).Warn("daemon didn't stop within 15 secs, killing it")
-		syscall.Kill(r.daemonPid, syscall.SIGKILL)
+	if process.Alive(pid) {
+		r.logger.WithField("pid", pid).Warn("daemon didn't stop within 15 secs, killing it")
+		syscall.Kill(pid, syscall.SIGKILL)
 	}
 }
 
-func (r *remote) killDaemon() {
+func (r *remote) killDaemon(pid int) {
 	// Try to get a stack trace
-	_ = syscall.Kill(r.daemonPid, syscall.SIGUSR1)
+	_ = syscall.Kill(pid, syscall.SIGUSR1)
 	<-time.After(100 * time.Millisecond)
-	_ = process.Kill(r.daemonPid)
+	_ = process.Kill(pid)
 }
 
 func (r *remote) platformCleanup() {

--- a/libcontainerd/supervisor/remote_daemon_windows.go
+++ b/libcontainerd/supervisor/remote_daemon_windows.go
@@ -20,27 +20,27 @@ func (r *remote) setDefaults() {
 	}
 }
 
-func (r *remote) stopDaemon() {
-	p, err := os.FindProcess(r.daemonPid)
+func (r *remote) stopDaemon(pid int) {
+	p, err := os.FindProcess(pid)
 	if err != nil {
-		r.logger.WithField("pid", r.daemonPid).Warn("could not find daemon process")
+		r.logger.WithField("pid", pid).Warn("could not find daemon process")
 		return
 	}
 
 	if err = p.Kill(); err != nil {
-		r.logger.WithError(err).WithField("pid", r.daemonPid).Warn("could not kill daemon process")
+		r.logger.WithError(err).WithField("pid", pid).Warn("could not kill daemon process")
 		return
 	}
 
 	_, err = p.Wait()
 	if err != nil {
-		r.logger.WithError(err).WithField("pid", r.daemonPid).Warn("wait for daemon process")
+		r.logger.WithError(err).WithField("pid", pid).Warn("wait for daemon process")
 		return
 	}
 }
 
-func (r *remote) killDaemon() {
-	_ = process.Kill(r.daemonPid)
+func (r *remote) killDaemon(pid int) {
+	_ = process.Kill(pid)
 }
 
 func (r *remote) platformCleanup() {


### PR DESCRIPTION
- Follow-up to #47300 

The daemonWaitCh initialized by a call to startContainerd() will be closed when that particular containerd process exits. Storing the channel in a struct field obscures its association with a particular startContainerd() call and makes race conditions less obvious. Refactor the supervisor code so the daemonWaitCh and process pid are returned from startContainerd() and stored in local variables of monitorDaemon().

**WIP**
I am not confident that the implicit state machine in `monitorDaemon()` doesn't depend on a stale closed `daemonWaitCh` being kept around across a failed `startContainerd()` call. It may be worth refactoring into an explicit FSM with named states and transitions.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

