### PR TITLE
libnet: boltdb: remove PersistConnection 

### DIFF
--- a/libnetwork/datastore/datastore.go
+++ b/libnetwork/datastore/datastore.go
@@ -92,7 +92,6 @@ func DefaultScope(dataDir string) ScopeCfg {
 			Config: &store.Config{
 				Bucket:            "libnetwork",
 				ConnectionTimeout: time.Minute,
-				PersistConnection: true,
 			},
 		},
 	}

--- a/libnetwork/internal/kvstore/kvstore.go
+++ b/libnetwork/internal/kvstore/kvstore.go
@@ -28,7 +28,6 @@ var (
 type Config struct {
 	ConnectionTimeout time.Duration
 	Bucket            string
-	PersistConnection bool
 }
 
 // Store represents the backend K/V storage

--- a/libnetwork/store_test.go
+++ b/libnetwork/store_test.go
@@ -80,18 +80,3 @@ func OptionBoltdbWithRandomDBFile(t *testing.T) config.Option {
 		c.Scope.Client.Config = &store.Config{Bucket: "testBackend"}
 	}
 }
-
-func TestMultipleControllersWithSameStore(t *testing.T) {
-	cfgOptions := OptionBoltdbWithRandomDBFile(t)
-	ctrl1, err := New(cfgOptions)
-	if err != nil {
-		t.Fatalf("Error new controller: %v", err)
-	}
-	defer ctrl1.Stop()
-	// Use the same boltdb file without closing the previous controller
-	ctrl2, err := New(cfgOptions)
-	if err != nil {
-		t.Fatalf("Local store must support concurrent controllers")
-	}
-	ctrl2.Stop()
-}


### PR DESCRIPTION
- Related to https://github.com/moby/moby/pull/47285#discussion_r1474834278

**- What I did**

This parameter was used to tell the boltdb kvstore not to open/close the underlying boltdb db file before/after each get/put operation.

Since https://github.com/moby/moby/commit/d21d0884aebf991b418481efab619f6dce95d945, we've a single datastore instance shared by all components that need it. That commit set `PersistConnection=true`. We can now safely remove this param altogether, and remove all the code that was opening and closing the db file before and after each operation -- it's dead code!

Also, inline `getDBhandle()` as it's now a one-liner just returning a struct member -- making it useless.

**- How to verify it**

CI is green.

