### PR TITLE
Revert "daemon: automatically set network EnableIPv6 if needed"

### DIFF
--- a/api/types/network/ipam.go
+++ b/api/types/network/ipam.go
@@ -49,12 +49,12 @@ func ValidateIPAM(ipam *IPAM, enableIPv6 bool) error {
 			subnetFamily = ip6
 		}
 
-		if subnet != subnet.Masked() {
-			errs = append(errs, fmt.Errorf("invalid subnet %s: it should be %s", subnet, subnet.Masked()))
+		if !enableIPv6 && subnetFamily == ip6 {
+			continue
 		}
 
-		if !enableIPv6 && subnetFamily == ip6 {
-			errs = append(errs, fmt.Errorf("invalid subnet %s: IPv6 has not been enabled for this network", subnet))
+		if subnet != subnet.Masked() {
+			errs = append(errs, fmt.Errorf("invalid subnet %s: it should be %s", subnet, subnet.Masked()))
 		}
 
 		if ipRangeErrs := validateIPRange(cfg.IPRange, subnet, subnetFamily); len(ipRangeErrs) > 0 {

--- a/api/types/network/ipam_test.go
+++ b/api/types/network/ipam_test.go
@@ -31,10 +31,10 @@ func TestNetworkWithInvalidIPAM(t *testing.T) {
 			},
 		},
 		{
-			name:           "IPv6 subnet is discarded when IPv6 is disabled",
-			ipam:           IPAM{Config: []IPAMConfig{{Subnet: "2001:db8::/32"}}},
-			ipv6:           false,
-			expectedErrors: []string{"invalid subnet 2001:db8::/32: IPv6 has not been enabled for this network"},
+			// Regression test for https://github.com/moby/moby/issues/47202
+			name: "IPv6 subnet is discarded with no error when IPv6 is disabled",
+			ipam: IPAM{Config: []IPAMConfig{{Subnet: "2001:db8::/32"}}},
+			ipv6: false,
 		},
 		{
 			name: "Invalid data - Subnet",

--- a/api/types/network/ipam_test.go
+++ b/api/types/network/ipam_test.go
@@ -31,6 +31,12 @@ func TestNetworkWithInvalidIPAM(t *testing.T) {
 			},
 		},
 		{
+			name:           "IPv6 subnet is discarded when IPv6 is disabled",
+			ipam:           IPAM{Config: []IPAMConfig{{Subnet: "2001:db8::/32"}}},
+			ipv6:           false,
+			expectedErrors: []string{"invalid subnet 2001:db8::/32: IPv6 has not been enabled for this network"},
+		},
+		{
 			name: "Invalid data - Subnet",
 			ipam: IPAM{Config: []IPAMConfig{{Subnet: "foobar"}}},
 			expectedErrors: []string{
@@ -122,7 +128,7 @@ func TestNetworkWithInvalidIPAM(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			errs := ValidateIPAM(&tc.ipam)
+			errs := ValidateIPAM(&tc.ipam, tc.ipv6)
 			if tc.expectedErrors == nil {
 				assert.NilError(t, errs)
 				return

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -305,10 +305,6 @@ func (daemon *Daemon) createNetwork(cfg *config.Config, create types.NetworkCrea
 		return nil, errdefs.Forbidden(errors.New(`This node is not a swarm manager. Use "docker swarm init" or "docker swarm join" to connect this node to swarm and try again.`))
 	}
 
-	if network.HasIPv6Subnets(create.IPAM) {
-		create.EnableIPv6 = true
-	}
-
 	networkOptions := make(map[string]string)
 	for k, v := range create.Options {
 		networkOptions[k] = v
@@ -335,7 +331,7 @@ func (daemon *Daemon) createNetwork(cfg *config.Config, create types.NetworkCrea
 		nwOptions = append(nwOptions, libnetwork.NetworkOptionConfigOnly())
 	}
 
-	if err := network.ValidateIPAM(create.IPAM); err != nil {
+	if err := network.ValidateIPAM(create.IPAM, create.EnableIPv6); err != nil {
 		return nil, errdefs.InvalidParameter(err)
 	}
 


### PR DESCRIPTION
- Related to https://github.com/moby/moby/issues/47202
- Revert https://github.com/moby/moby/pull/46455
- Related to https://github.com/moby/moby/pull/45759

**- What I did**

Turns out some users expect a network created with an IPv6 subnet and EnableIPv6=false to actually have no IPv6 connectivity. This PR restores that behavior.

**- How to verify it**

The unit test `TestNetworkWithInvalidIPAM` has been updated to make sure IPv6 subnets are ignored by `ValidateIPAM` when EnableIPv6=false.

**- Description for the changelog**

- Make sure networks' parameter `EnableIPv6` isn't ignored.