### PR TITLE
libnet: bridge: ignore EINVAL when configuring bridge MTU

### DIFF
--- a/libnetwork/drivers/bridge/setup_device_linux.go
+++ b/libnetwork/drivers/bridge/setup_device_linux.go
@@ -2,9 +2,11 @@ package bridge
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/libnetwork/netutils"
@@ -47,6 +49,14 @@ func setupDevice(config *networkConfiguration, i *bridgeInterface) error {
 
 func setupMTU(config *networkConfiguration, i *bridgeInterface) error {
 	if err := i.nlh.LinkSetMTU(i.Link, config.Mtu); err != nil {
+		// Before Linux v4.17, bridges couldn't be configured "manually" with an MTU greater than 1500, although it
+		// could be autoconfigured with such a value when interfaces were added to the bridge. In that case, the
+		// bridge MTU would be set automatically by the kernel to the lowest MTU of all interfaces attached. To keep
+		// compatibility with older kernels, we need to discard -EINVAL.
+		// TODO(aker): remove this once we drop support for CentOS/RHEL 7.
+		if config.Mtu > 1500 && config.Mtu <= 0xFFFF && errors.Is(err, syscall.EINVAL) {
+			return nil
+		}
 		log.G(context.TODO()).WithError(err).Errorf("Failed to set bridge MTU %s via netlink", config.BridgeName)
 		return err
 	}


### PR DESCRIPTION
- Related to https://github.com/moby/moby/issues/47308
- Related to https://github.com/moby/moby/pull/46849

**- What I did**

Since 964ab7158c, we explicitly set the bridge MTU if it was specified. Unfortunately, kernel <v4.17 have a check preventing us to manually set the MTU to anything greater than 1500 if no links is attached to the bridge, which is how we do things -- create the bridge, set its MTU and later on, attach veths to it.

Relevant kernel commit: https://github.com/torvalds/linux/commit/804b854d374e39f5f8bff9638fd274b9a9ca7d33

As we still have to support CentOS/RHEL 7 (and their old v3.10 kernels) for a few more months, we need to ignore EINVAL. An error will still be logged nonetheless, as the MTU could very well be invalid.

**- How to verify it**

We have no CI runners with Linux v3.10 to test the exact issue reported in https://github.com/moby/moby/issues/47308. So the best proxy is the added test: make sure `setupMTU` doesn't return an error if it tries to set a too high MTU.

**- Description for the changelog**

- Fix a bug preventing bridge networks to be created with a MTU > 1500 on RHEL/CentOS 7.

