### PR TITLE
[25.0 backport] libnet: bridge: ignore EINVAL when configuring bridge MTU 

### DIFF
--- a/libnetwork/drivers/bridge/setup_device_linux.go
+++ b/libnetwork/drivers/bridge/setup_device_linux.go
@@ -2,9 +2,11 @@ package bridge
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/libnetwork/netutils"
@@ -47,6 +49,14 @@ func setupDevice(config *networkConfiguration, i *bridgeInterface) error {
 
 func setupMTU(config *networkConfiguration, i *bridgeInterface) error {
 	if err := i.nlh.LinkSetMTU(i.Link, config.Mtu); err != nil {
+		// Before Linux v4.17, bridges couldn't be configured "manually" with an MTU greater than 1500, although it
+		// could be autoconfigured with such a value when interfaces were added to the bridge. In that case, the
+		// bridge MTU would be set automatically by the kernel to the lowest MTU of all interfaces attached. To keep
+		// compatibility with older kernels, we need to discard -EINVAL.
+		// TODO(aker): remove this once we drop support for CentOS/RHEL 7.
+		if config.Mtu > 1500 && config.Mtu <= 0xFFFF && errors.Is(err, syscall.EINVAL) {
+			return nil
+		}
 		log.G(context.TODO()).WithError(err).Errorf("Failed to set bridge MTU %s via netlink", config.BridgeName)
 		return err
 	}


### PR DESCRIPTION
- Backport https://github.com/moby/moby/pull/47309
- Fixes https://github.com/moby/moby/issues/47308
- Related to https://github.com/moby/moby/pull/46849

(cherry picked from commit 89470a7114703efd44a07be535a9556bef4d1e78)

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**

- Fix a bug preventing bridge networks to be created with a MTU > 1500 on RHEL/CentOS 7.