### PR TITLE
[24.0 backport] libcontainerd/supervisor: fix data race

### DIFF
--- a/libcontainerd/supervisor/remote_daemon.go
+++ b/libcontainerd/supervisor/remote_daemon.go
@@ -185,12 +185,13 @@ func (r *remote) startContainerd() error {
 		runtime.LockOSThread()
 		defer runtime.UnlockOSThread()
 		err := cmd.Start()
-		startedCh <- err
 		if err != nil {
+			startedCh <- err
 			return
 		}
-
 		r.daemonWaitCh = make(chan struct{})
+		startedCh <- nil
+
 		// Reap our child when needed
 		if err := cmd.Wait(); err != nil {
 			r.logger.WithError(err).Errorf("containerd did not exit successfully")


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/47300
- related to https://github.com/moby/moby/pull/44215
- fixes https://github.com/moby/moby/issues/47287


The monitorDaemon() goroutine calls startContainerd() then blocks on <-daemonWaitCh to wait for it to exit. The startContainerd() function would (re)initialize the daemonWaitCh so a restarted containerd could be waited on. This implementation was race-free because startContainerd() would synchronously initialize the daemonWaitCh before returning. When the call to start the managed containerd process was moved into the waiter goroutine, the code to initialize the daemonWaitCh struct field was also moved into the goroutine. This introduced a race condition.

Move the daemonWaitCh initialization to guarantee that it happens before the startContainerd() call returns.


(cherry picked from commit dd20bf4862319485a9a9c66ac8907993a3142e3c)

**- What I did**
I fixed a data race in libcontainerd/supervisor that I added in #44215.

**- How I did it**
The monitorDaemon() goroutine calls startContainerd() then blocks on <-daemonWaitCh to wait for it to exit. The startContainerd() function would (re)initialize the daemonWaitCh so a restarted containerd could be waited on. This implementation was race-free because startContainerd() would synchronously initialize the daemonWaitCh before returning. When the call to start the managed containerd process was moved into the waiter goroutine, the code to initialize the daemonWaitCh struct field was also moved into the goroutine. This introduced a race condition.

Move the daemonWaitCh initialization to guarantee that it happens before the startContainerd() call returns.

**- How to verify it**
Build a daemon with `BUILDFLAGS=-race`. Start it and check that no `WARNING: DATA RACE` messages are emitted.

Verify that the containerd supervisor is working correctly: it is launched when the daemon starts up, is restarted when killed, and is shut down when the daemon shuts down.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Fixed a potential race condition in the managed containerd supervisor

**- A picture of a cute animal (not mandatory but encouraged)**
