### PR TITLE
[25.0 backport] plugins: Fix panic when fetching by digest 

### DIFF
--- a/plugin/fetch_linux.go
+++ b/plugin/fetch_linux.go
@@ -200,8 +200,13 @@ func withFetchProgress(cs content.Store, out progress.Output, ref reference.Name
 		switch desc.MediaType {
 		case ocispec.MediaTypeImageManifest, images.MediaTypeDockerSchema2Manifest:
 			tn := reference.TagNameOnly(ref)
-			tagged := tn.(reference.Tagged)
-			progress.Messagef(out, tagged.Tag(), "Pulling from %s", reference.FamiliarName(ref))
+			var tagOrDigest string
+			if tagged, ok := tn.(reference.Tagged); ok {
+				tagOrDigest = tagged.Tag()
+			} else {
+				tagOrDigest = tn.String()
+			}
+			progress.Messagef(out, tagOrDigest, "Pulling from %s", reference.FamiliarName(ref))
 			progress.Messagef(out, "", "Digest: %s", desc.Digest.String())
 			return nil, nil
 		case


### PR DESCRIPTION
- backport of https://github.com/moby/moby/pull/47299
- relates to https://github.com/docker/cli/pull/4839

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added a test for, and fixed a panic at:
https://github.com/moby/moby/blob/71fa3ab079ec13d17257f86fa92db8d7f24802f1/plugin/fetch_linux.go#L202-L203
when doing something like:
```
docker plugin install vieux/sshfs@sha256:1d3c3e42c12138da5ef7873b97f7f32cf99fb6edde75fa4f0bcf9ed277855811
```

By checking if the cast is safe, and only printing the tag if there is a tag to print.

**- How I did it**
With tag:
```
 docker plugin install vieux/sshfs
Plugin "vieux/sshfs" is requesting the following privileges:
 - network: [host]
 - mount: [/var/lib/docker/plugins/]
 - mount: []
 - device: [/dev/fuse]
 - capabilities: [CAP_SYS_ADMIN]
Do you grant the above permissions? [y/N] y
latest: Pulling from vieux/sshfs
Digest: sha256:1d3c3e42c12138da5ef7873b97f7f32cf99fb6edde75fa4f0bcf9ed277855811
52d435ada6a4: Complete
Installed plugin vieux/sshfs
```
With digest:
```
 docker plugin install vieux/sshfs@sha256:1d3c3e42c12138da5ef7873b97f7f32cf99fb6edde75fa4f0bcf9ed277855811
Plugin "vieux/sshfs@sha256:1d3c3e42c12138da5ef7873b97f7f32cf99fb6edde75fa4f0bcf9ed277855811" is requesting the following privileges:
 - network: [host]
 - mount: [/var/lib/docker/plugins/]
 - mount: []
 - device: [/dev/fuse]
 - capabilities: [CAP_SYS_ADMIN]
Do you grant the above permissions? [y/N] y
Pulling from vieux/sshfs
Digest: sha256:1d3c3e42c12138da5ef7873b97f7f32cf99fb6edde75fa4f0bcf9ed277855811
52d435ada6a4: Complete
Installed plugin vieux/sshfs@sha256:1d3c3e42c12138da5ef7873b97f7f32cf99fb6edde75fa4f0bcf9ed277855811
```

**- How to verify it**

```
$ make DOCKER_GRAPHDRIVER=overlayfs TEST_FILTER=TestPluginInstall TEST_IGNORE_CGROUP_CHECK=1 test-integration
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="444" alt="Screenshot 2024-02-01 at 20 02 48" src="https://github.com/moby/moby/assets/70572044/7bd56a45-6f3d-42fb-88af-4ec426742e3c">
