### PR TITLE
[23.0 backport] image/cache: Ignore Build and Revision on Windows

### DIFF
--- a/image/cache/cache.go
+++ b/image/cache/cache.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/containerd/containerd/platforms"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/image"
@@ -255,11 +254,12 @@ func getLocalCachedImage(imageStore image.Store, imgID image.ID, config *contain
 				OSFeatures:   img.OSFeatures,
 				Variant:      img.Variant,
 			}
+
 			// Discard old linux/amd64 images with empty platform.
 			if imgPlatform.OS == "" && imgPlatform.Architecture == "" {
 				continue
 			}
-			if !platforms.OnlyStrict(platform).Match(imgPlatform) {
+			if !comparePlatform(platform, imgPlatform) {
 				continue
 			}
 

--- a/image/cache/compare.go
+++ b/image/cache/compare.go
@@ -26,6 +26,13 @@ func comparePlatform(builderPlatform, imagePlatform ocispec.Platform) bool {
 		builderParts := strings.Split(builderPlatform.OSVersion, ".")
 		imageParts := strings.Split(imagePlatform.OSVersion, ".")
 
+		// Major and minor must match.
+		for i := 0; i < 2; i++ {
+			if len(builderParts) > i && len(imageParts) > i && builderParts[i] != imageParts[i] {
+				return false
+			}
+		}
+
 		if len(builderParts) >= 3 && len(imageParts) >= 3 {
 			// Keep only Major & Minor.
 			builderParts[0] = imageParts[0]

--- a/image/cache/compare_test.go
+++ b/image/cache/compare_test.go
@@ -4,10 +4,10 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/go-connections/nat"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -132,63 +132,63 @@ func TestCompare(t *testing.T) {
 func TestPlatformCompare(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
-		builder  platforms.Platform
-		image    platforms.Platform
+		builder  ocispec.Platform
+		image    ocispec.Platform
 		expected bool
 	}{
 		{
 			name:     "same os and arch",
-			builder:  platforms.Platform{Architecture: "amd64", OS: runtime.GOOS},
-			image:    platforms.Platform{Architecture: "amd64", OS: runtime.GOOS},
+			builder:  ocispec.Platform{Architecture: "amd64", OS: runtime.GOOS},
+			image:    ocispec.Platform{Architecture: "amd64", OS: runtime.GOOS},
 			expected: true,
 		},
 		{
 			name:     "same os different arch",
-			builder:  platforms.Platform{Architecture: "amd64", OS: runtime.GOOS},
-			image:    platforms.Platform{Architecture: "arm64", OS: runtime.GOOS},
+			builder:  ocispec.Platform{Architecture: "amd64", OS: runtime.GOOS},
+			image:    ocispec.Platform{Architecture: "arm64", OS: runtime.GOOS},
 			expected: false,
 		},
 		{
 			name:     "same os smaller host variant",
-			builder:  platforms.Platform{Variant: "v7", Architecture: "arm", OS: runtime.GOOS},
-			image:    platforms.Platform{Variant: "v8", Architecture: "arm", OS: runtime.GOOS},
+			builder:  ocispec.Platform{Variant: "v7", Architecture: "arm", OS: runtime.GOOS},
+			image:    ocispec.Platform{Variant: "v8", Architecture: "arm", OS: runtime.GOOS},
 			expected: false,
 		},
 		{
 			name:     "same os higher host variant",
-			builder:  platforms.Platform{Variant: "v8", Architecture: "arm", OS: runtime.GOOS},
-			image:    platforms.Platform{Variant: "v7", Architecture: "arm", OS: runtime.GOOS},
+			builder:  ocispec.Platform{Variant: "v8", Architecture: "arm", OS: runtime.GOOS},
+			image:    ocispec.Platform{Variant: "v7", Architecture: "arm", OS: runtime.GOOS},
 			expected: true,
 		},
 		{
 			// Test for https://github.com/moby/moby/issues/47307
 			name:     "different build and revision",
-			builder:  platforms.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.22621"},
-			image:    platforms.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.17763.5329"},
+			builder:  ocispec.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.22621"},
+			image:    ocispec.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.17763.5329"},
 			expected: true,
 		},
 		{
 			name:     "different revision",
-			builder:  platforms.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.17763.1234"},
-			image:    platforms.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.17763.5329"},
+			builder:  ocispec.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.17763.1234"},
+			image:    ocispec.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.17763.5329"},
 			expected: true,
 		},
 		{
 			name:     "different major",
-			builder:  platforms.Platform{Architecture: "amd64", OS: "windows", OSVersion: "11.0.17763.5329"},
-			image:    platforms.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.17763.5329"},
+			builder:  ocispec.Platform{Architecture: "amd64", OS: "windows", OSVersion: "11.0.17763.5329"},
+			image:    ocispec.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.17763.5329"},
 			expected: false,
 		},
 		{
 			name:     "different minor same osver",
-			builder:  platforms.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.17763.5329"},
-			image:    platforms.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.1.17763.5329"},
+			builder:  ocispec.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.17763.5329"},
+			image:    ocispec.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.1.17763.5329"},
 			expected: false,
 		},
 		{
 			name:     "different arch same osver",
-			builder:  platforms.Platform{Architecture: "arm64", OS: "windows", OSVersion: "10.0.17763.5329"},
-			image:    platforms.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.17763.5329"},
+			builder:  ocispec.Platform{Architecture: "arm64", OS: "windows", OSVersion: "10.0.17763.5329"},
+			image:    ocispec.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.17763.5329"},
 			expected: false,
 		},
 	} {

--- a/image/cache/compare_test.go
+++ b/image/cache/compare_test.go
@@ -193,12 +193,6 @@ func TestPlatformCompare(t *testing.T) {
 		},
 	} {
 		tc := tc
-		// OSVersion comparison is only performed by containerd platform
-		// matcher if built on Windows.
-		if (tc.image.OSVersion != "" || tc.builder.OSVersion != "") && runtime.GOOS != "windows" {
-			continue
-		}
-
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Check(t, is.Equal(comparePlatform(tc.builder, tc.image), tc.expected))
 		})

--- a/image/cache/compare_test.go
+++ b/image/cache/compare_test.go
@@ -1,11 +1,15 @@
 package cache // import "github.com/docker/docker/image/cache"
 
 import (
+	"runtime"
 	"testing"
 
+	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/go-connections/nat"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 // Just to make life easier
@@ -122,5 +126,81 @@ func TestCompare(t *testing.T) {
 		if compare(config1, config2) {
 			t.Fatalf("Compare should be false for [%v] and [%v]", config1, config2)
 		}
+	}
+}
+
+func TestPlatformCompare(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		builder  platforms.Platform
+		image    platforms.Platform
+		expected bool
+	}{
+		{
+			name:     "same os and arch",
+			builder:  platforms.Platform{Architecture: "amd64", OS: runtime.GOOS},
+			image:    platforms.Platform{Architecture: "amd64", OS: runtime.GOOS},
+			expected: true,
+		},
+		{
+			name:     "same os different arch",
+			builder:  platforms.Platform{Architecture: "amd64", OS: runtime.GOOS},
+			image:    platforms.Platform{Architecture: "arm64", OS: runtime.GOOS},
+			expected: false,
+		},
+		{
+			name:     "same os smaller host variant",
+			builder:  platforms.Platform{Variant: "v7", Architecture: "arm", OS: runtime.GOOS},
+			image:    platforms.Platform{Variant: "v8", Architecture: "arm", OS: runtime.GOOS},
+			expected: false,
+		},
+		{
+			name:     "same os higher host variant",
+			builder:  platforms.Platform{Variant: "v8", Architecture: "arm", OS: runtime.GOOS},
+			image:    platforms.Platform{Variant: "v7", Architecture: "arm", OS: runtime.GOOS},
+			expected: true,
+		},
+		{
+			// Test for https://github.com/moby/moby/issues/47307
+			name:     "different build and revision",
+			builder:  platforms.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.22621"},
+			image:    platforms.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.17763.5329"},
+			expected: true,
+		},
+		{
+			name:     "different revision",
+			builder:  platforms.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.17763.1234"},
+			image:    platforms.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.17763.5329"},
+			expected: true,
+		},
+		{
+			name:     "different major",
+			builder:  platforms.Platform{Architecture: "amd64", OS: "windows", OSVersion: "11.0.17763.5329"},
+			image:    platforms.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.17763.5329"},
+			expected: false,
+		},
+		{
+			name:     "different minor same osver",
+			builder:  platforms.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.17763.5329"},
+			image:    platforms.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.1.17763.5329"},
+			expected: false,
+		},
+		{
+			name:     "different arch same osver",
+			builder:  platforms.Platform{Architecture: "arm64", OS: "windows", OSVersion: "10.0.17763.5329"},
+			image:    platforms.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.17763.5329"},
+			expected: false,
+		},
+	} {
+		tc := tc
+		// OSVersion comparison is only performed by containerd platform
+		// matcher if built on Windows.
+		if (tc.image.OSVersion != "" || tc.builder.OSVersion != "") && runtime.GOOS != "windows" {
+			continue
+		}
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Check(t, is.Equal(comparePlatform(tc.builder, tc.image), tc.expected))
+		})
 	}
 }


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/47330
- backport: https://github.com/moby/moby/pull/47342
- fixes: https://github.com/moby/moby/issues/47307

The compatibility depends on whether `hyperv` or `process` container isolation is used.
This fixes cache not being used when building images based on older Windows versions on a newer Windows host.

**- How to verify it**

**- Description for the changelog**
```release-note
- Windows: Fix cache not being used when building images based on Windows versions older than the host's version
```

**- A picture of a cute animal (not mandatory but encouraged)**

