### PR TITLE
profiles/seccomp: add syscalls for kernel v5.17 - v6.6, match containerd's profile

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -134,6 +134,7 @@
 				"futex",
 				"futex_requeue",
 				"futex_time64",
+				"futex_wait",
 				"futex_waitv",
 				"futimesat",
 				"getcpu",

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -205,6 +205,7 @@
 				"lstat",
 				"lstat64",
 				"madvise",
+				"map_shadow_stack",
 				"membarrier",
 				"memfd_create",
 				"memfd_secret",

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -132,6 +132,7 @@
 				"ftruncate",
 				"ftruncate64",
 				"futex",
+				"futex_requeue",
 				"futex_time64",
 				"futex_waitv",
 				"futimesat",

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -780,7 +780,8 @@
 			"names": [
 				"get_mempolicy",
 				"mbind",
-				"set_mempolicy"
+				"set_mempolicy",
+				"set_mempolicy_home_node"
 			],
 			"action": "SCMP_ACT_ALLOW",
 			"includes": {

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -136,6 +136,7 @@
 				"futex_time64",
 				"futex_wait",
 				"futex_waitv",
+				"futex_wake",
 				"futimesat",
 				"getcpu",
 				"getcwd",

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -64,6 +64,7 @@
 				"alarm",
 				"bind",
 				"brk",
+				"cachestat",
 				"capget",
 				"capset",
 				"chdir",

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -110,6 +110,7 @@
 				"fchdir",
 				"fchmod",
 				"fchmodat",
+				"fchmodat2",
 				"fchown",
 				"fchown32",
 				"fchownat",

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -768,6 +768,7 @@ func DefaultProfile() *Seccomp {
 					"get_mempolicy",
 					"mbind",
 					"set_mempolicy",
+					"set_mempolicy_home_node", // kernel v5.17, libseccomp v2.5.4
 				},
 				Action: specs.ActAllow,
 			},

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -197,6 +197,7 @@ func DefaultProfile() *Seccomp {
 					"lstat",
 					"lstat64",
 					"madvise",
+					"map_shadow_stack", // kernel v6.6, libseccomp v2.5.5
 					"membarrier",
 					"memfd_create",
 					"memfd_secret",

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -124,6 +124,7 @@ func DefaultProfile() *Seccomp {
 					"ftruncate",
 					"ftruncate64",
 					"futex",
+					"futex_requeue", // kernel v6.7, libseccomp v2.5.5
 					"futex_time64",
 					"futex_waitv",
 					"futimesat",

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -56,6 +56,7 @@ func DefaultProfile() *Seccomp {
 					"alarm",
 					"bind",
 					"brk",
+					"cachestat", // kernel v6.5, libseccomp v2.5.5
 					"capget",
 					"capset",
 					"chdir",

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -102,6 +102,7 @@ func DefaultProfile() *Seccomp {
 					"fchdir",
 					"fchmod",
 					"fchmodat",
+					"fchmodat2", // kernel v6.6, libseccomp v2.5.5
 					"fchown",
 					"fchown32",
 					"fchownat",

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -126,6 +126,7 @@ func DefaultProfile() *Seccomp {
 					"futex",
 					"futex_requeue", // kernel v6.7, libseccomp v2.5.5
 					"futex_time64",
+					"futex_wait", // kernel v6.7, libseccomp v2.5.5
 					"futex_waitv",
 					"futimesat",
 					"getcpu",

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -128,6 +128,7 @@ func DefaultProfile() *Seccomp {
 					"futex_time64",
 					"futex_wait", // kernel v6.7, libseccomp v2.5.5
 					"futex_waitv",
+					"futex_wake", // kernel v6.7, libseccomp v2.5.5
 					"futimesat",
 					"getcpu",
 					"getcwd",


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/9684

### seccomp: add set_mempolicy_home_node syscall (kernel v5.17, libseccomp v2.5.4)

This syscall is gated by CAP_SYS_NICE, matching the profile in containerd.

containerd: https://github.com/containerd/containerd/commit/a6e52c74fa043a63d7dae4ac6998215f6c1bb6ac
libseccomp: https://github.com/seccomp/libseccomp/commit/d83cb7ac252db91e9ca9c372ea4743e02ba97c50
kernel: https://github.com/torvalds/linux/commit/c6018b4b254971863bd0ad36bb5e7d0fa0f0ddb0

    mm/mempolicy: add set_mempolicy_home_node syscall
    This syscall can be used to set a home node for the MPOL_BIND and
    MPOL_PREFERRED_MANY memory policy.  Users should use this syscall after
    setting up a memory policy for the specified range as shown below.
    
      mbind(p, nr_pages * page_size, MPOL_BIND, new_nodes->maskp,
            new_nodes->size + 1, 0);
      sys_set_mempolicy_home_node((unsigned long)p, nr_pages * page_size,
                    home_node, 0);
    
    The syscall allows specifying a home node/preferred node from which
    kernel will fulfill memory allocation requests first.
    ...


### seccomp: add cachestat syscall (kernel v6.5, libseccomp v2.5.5)


Add this syscall to match the profile in containerd

containerd: https://github.com/containerd/containerd/commit/a6e52c74fa043a63d7dae4ac6998215f6c1bb6ac
libseccomp: https://github.com/seccomp/libseccomp/commit/53267af3fb56eed93a50b8ef92f41825c97a7813
kernel: https://github.com/torvalds/linux/commit/cf264e1329fb0307e044f7675849f9f38b44c11a


    NAME
        cachestat - query the page cache statistics of a file.
    
    SYNOPSIS
        #include <sys/mman.h>
    
        struct cachestat_range {
            __u64 off;
            __u64 len;
        };
    
        struct cachestat {
            __u64 nr_cache;
            __u64 nr_dirty;
            __u64 nr_writeback;
            __u64 nr_evicted;
            __u64 nr_recently_evicted;
        };
    
        int cachestat(unsigned int fd, struct cachestat_range *cstat_range,
            struct cachestat *cstat, unsigned int flags);
    
    DESCRIPTION
        cachestat() queries the number of cached pages, number of dirty
        pages, number of pages marked for writeback, number of evicted
        pages, number of recently evicted pages, in the bytes range given by
        `off` and `len`.

### seccomp: add fchmodat2 syscall (kernel v6.6, libseccomp v2.5.5)

Add this syscall to match the profile in containerd

containerd: https://github.com/containerd/containerd/commit/a6e52c74fa043a63d7dae4ac6998215f6c1bb6ac
libseccomp: https://github.com/seccomp/libseccomp/commit/53267af3fb56eed93a50b8ef92f41825c97a7813
kernel: https://github.com/torvalds/linux/commit/09da082b07bbae1c11d9560c8502800039aebcea

    fs: Add fchmodat2()
    
    On the userspace side fchmodat(3) is implemented as a wrapper
    function which implements the POSIX-specified interface. This
    interface differs from the underlying kernel system call, which does not
    have a flags argument. Most implementations require procfs [1][2].
    
    There doesn't appear to be a good userspace workaround for this issue
    but the implementation in the kernel is pretty straight-forward.
    
    The new fchmodat2() syscall allows to pass the AT_SYMLINK_NOFOLLOW flag,
    unlike existing fchmodat.


### seccomp: add map_shadow_stack syscall (kernel v6.6, libseccomp v2.5.5)

Add this syscall to match the profile in containerd

containerd: https://github.com/containerd/containerd/commit/a6e52c74fa043a63d7dae4ac6998215f6c1bb6ac
libseccomp: https://github.com/seccomp/libseccomp/commit/53267af3fb56eed93a50b8ef92f41825c97a7813
kernel: https://github.com/torvalds/linux/commit/c35559f94ebc3e3bc82e56e07161bb5986cd9761

    x86/shstk: Introduce map_shadow_stack syscall
    
    When operating with shadow stacks enabled, the kernel will automatically
    allocate shadow stacks for new threads, however in some cases userspace
    will need additional shadow stacks. The main example of this is the
    ucontext family of functions, which require userspace allocating and
    pivoting to userspace managed stacks.
    
    Unlike most other user memory permissions, shadow stacks need to be
    provisioned with special data in order to be useful. They need to be setup
    with a restore token so that userspace can pivot to them via the RSTORSSP
    instruction. But, the security design of shadow stacks is that they
    should not be written to except in limited circumstances. This presents a
    problem for userspace, as to how userspace can provision this special
    data, without allowing for the shadow stack to be generally writable.

### seccomp: add futex_requeue syscall (kernel v6.7, libseccomp v2.5.5)

Add this syscall to match the profile in containerd

containerd: https://github.com/containerd/containerd/commit/a6e52c74fa043a63d7dae4ac6998215f6c1bb6ac
libseccomp: https://github.com/seccomp/libseccomp/commit/53267af3fb56eed93a50b8ef92f41825c97a7813
kernel: https://github.com/torvalds/linux/commit/0f4b5f972216782a4acb1ae00dcb55173847c2ff

    futex: Add sys_futex_requeue()
    
    Finish off the 'simple' futex2 syscall group by adding
    sys_futex_requeue(). Unlike sys_futex_{wait,wake}() its arguments are
    too numerous to fit into a regular syscall. As such, use struct
    futex_waitv to pass the 'source' and 'destination' futexes to the
    syscall.
    
    This syscall implements what was previously known as FUTEX_CMP_REQUEUE
    and uses {val, uaddr, flags} for source and {uaddr, flags} for
    destination.
    
    This design explicitly allows requeueing between different types of
    futex by having a different flags word per uaddr.

### seccomp: add futex_wait syscall (kernel v6.7, libseccomp v2.5.5)

Add this syscall to match the profile in containerd

containerd: https://github.com/containerd/containerd/commit/a6e52c74fa043a63d7dae4ac6998215f6c1bb6ac
libseccomp: https://github.com/seccomp/libseccomp/commit/53267af3fb56eed93a50b8ef92f41825c97a7813
kernel: https://github.com/torvalds/linux/commit/cb8c4312afca1b2dc64107e7e7cea81911055612

    futex: Add sys_futex_wait()
    
    To complement sys_futex_waitv()/wake(), add sys_futex_wait(). This
    syscall implements what was previously known as FUTEX_WAIT_BITSET
    except it uses 'unsigned long' for the value and bitmask arguments,
    takes timespec and clockid_t arguments for the absolute timeout and
    uses FUTEX2 flags.
    
    The 'unsigned long' allows FUTEX2_SIZE_U64 on 64bit platforms.


### seccomp: add futex_wake syscall (kernel v6.7, libseccomp v2.5.5)

Add this syscall to match the profile in containerd

containerd: https://github.com/containerd/containerd/commit/a6e52c74fa043a63d7dae4ac6998215f6c1bb6ac
libseccomp: https://github.com/seccomp/libseccomp/commit/53267af3fb56eed93a50b8ef92f41825c97a7813
kernel: https://github.com/torvalds/linux/commit/9f6c532f59b20580acf8ede9409c9b8dce6e74e1

    futex: Add sys_futex_wake()
    
    To complement sys_futex_waitv() add sys_futex_wake(). This syscall
    implements what was previously known as FUTEX_WAKE_BITSET except it
    uses 'unsigned long' for the bitmask and takes FUTEX2 flags.
    
    The 'unsigned long' allows FUTEX2_SIZE_U64 on 64bit platforms.





**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
The following syscalls were added since kernel v5.16:

- v5.17 (libseccomp v2.5.4): set_mempolicy_home_node
- v6.5  (libseccomp v2.5.5): cachestat
- v6.6  (libseccomp v2.5.5): fchmodat2, map_shadow_stack
- v6.7  (libseccomp v2.5.5): futex_wake, futex_wait, futex_requeue
```


**- A picture of a cute animal (not mandatory but encouraged)**

