### PR TITLE
[24.0 backport] profiles/seccomp: add syscalls for kernel v5.17 - v6.6, match containerd's profile

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -134,6 +134,7 @@
 				"futex",
 				"futex_requeue",
 				"futex_time64",
+				"futex_wait",
 				"futex_waitv",
 				"futimesat",
 				"getcpu",

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -132,6 +132,7 @@
 				"ftruncate",
 				"ftruncate64",
 				"futex",
+				"futex_requeue",
 				"futex_time64",
 				"futex_waitv",
 				"futimesat",

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -136,6 +136,7 @@
 				"futex_time64",
 				"futex_wait",
 				"futex_waitv",
+				"futex_wake",
 				"futimesat",
 				"getcpu",
 				"getcwd",

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -783,7 +783,8 @@
 			"names": [
 				"get_mempolicy",
 				"mbind",
-				"set_mempolicy"
+				"set_mempolicy",
+				"set_mempolicy_home_node"
 			],
 			"action": "SCMP_ACT_ALLOW",
 			"includes": {

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -208,6 +208,7 @@
 				"lstat",
 				"lstat64",
 				"madvise",
+				"map_shadow_stack",
 				"membarrier",
 				"memfd_create",
 				"memfd_secret",

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -64,6 +64,7 @@
 				"alarm",
 				"bind",
 				"brk",
+				"cachestat",
 				"capget",
 				"capset",
 				"chdir",

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -110,6 +110,7 @@
 				"fchdir",
 				"fchmod",
 				"fchmodat",
+				"fchmodat2",
 				"fchown",
 				"fchown32",
 				"fchownat",

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -200,6 +200,7 @@ func DefaultProfile() *Seccomp {
 					"lstat",
 					"lstat64",
 					"madvise",
+					"map_shadow_stack", // kernel v6.6, libseccomp v2.5.5
 					"membarrier",
 					"memfd_create",
 					"memfd_secret",

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -124,6 +124,7 @@ func DefaultProfile() *Seccomp {
 					"ftruncate",
 					"ftruncate64",
 					"futex",
+					"futex_requeue", // kernel v6.7, libseccomp v2.5.5
 					"futex_time64",
 					"futex_waitv",
 					"futimesat",

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -56,6 +56,7 @@ func DefaultProfile() *Seccomp {
 					"alarm",
 					"bind",
 					"brk",
+					"cachestat", // kernel v6.5, libseccomp v2.5.5
 					"capget",
 					"capset",
 					"chdir",

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -102,6 +102,7 @@ func DefaultProfile() *Seccomp {
 					"fchdir",
 					"fchmod",
 					"fchmodat",
+					"fchmodat2", // kernel v6.6, libseccomp v2.5.5
 					"fchown",
 					"fchown32",
 					"fchownat",

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -126,6 +126,7 @@ func DefaultProfile() *Seccomp {
 					"futex",
 					"futex_requeue", // kernel v6.7, libseccomp v2.5.5
 					"futex_time64",
+					"futex_wait", // kernel v6.7, libseccomp v2.5.5
 					"futex_waitv",
 					"futimesat",
 					"getcpu",

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -771,6 +771,7 @@ func DefaultProfile() *Seccomp {
 					"get_mempolicy",
 					"mbind",
 					"set_mempolicy",
+					"set_mempolicy_home_node", // kernel v5.17, libseccomp v2.5.4
 				},
 				Action: specs.ActAllow,
 			},

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -128,6 +128,7 @@ func DefaultProfile() *Seccomp {
 					"futex_time64",
 					"futex_wait", // kernel v6.7, libseccomp v2.5.5
 					"futex_waitv",
+					"futex_wake", // kernel v6.7, libseccomp v2.5.5
 					"futimesat",
 					"getcpu",
 					"getcwd",


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/47341
- relates to https://github.com/containerd/containerd/pull/9684



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

