### PR TITLE
[25.0 backport] builder/dockerfile: ADD with best-effort xattrs

### DIFF
--- a/builder/dockerfile/copy.go
+++ b/builder/dockerfile/copy.go
@@ -459,7 +459,7 @@ func performCopyForInfo(dest copyInfo, source copyInfo, options copyFileOptions)
 		return copyDirectory(archiver, srcPath, destPath, options.identity)
 	}
 	if options.decompress && archive.IsArchivePath(srcPath) && !source.noDecompress {
-		return archiver.UntarPath(srcPath, destPath)
+		return archiver.UntarPath(srcPath, destPath, archive.WithBestEffortXattrs(true))
 	}
 
 	destExistsAsDir, err := isExistingDirectory(destPath)

--- a/layer/layer_test.go
+++ b/layer/layer_test.go
@@ -22,7 +22,7 @@ import (
 func init() {
 	graphdriver.ApplyUncompressedLayer = archive.UnpackLayer
 	defaultArchiver := archive.NewDefaultArchiver()
-	vfs.CopyDir = defaultArchiver.CopyWithTar
+	vfs.CopyDir = func(src, dst string) error { return defaultArchiver.CopyWithTar(src, dst) }
 }
 
 func newVFSGraphDriver(td string) (graphdriver.Driver, error) {


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/47175
- related to https://github.com/moby/moby/issues/47137


Archives being unpacked by Dockerfiles may have been created on other OSes with different conventions and semantics for xattrs, making them impossible to apply when extracting. Restore the old best-effort xattr behaviour users have come to depend on in the classic builder.


(cherry picked from commit ab6d760d29c0730450db834744bdb470b7cb29da)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

