### PR TITLE
Make 'internal' bridge networks accessible from host

### DIFF
--- a/integration/networking/bridge_test.go
+++ b/integration/networking/bridge_test.go
@@ -477,3 +477,60 @@ func TestDefaultBridgeAddresses(t *testing.T) {
 		})
 	}
 }
+
+// Test that a container on an 'internal' network has IP connectivity with
+// the host (on its own subnet, because the n/w bridge has an address on that
+// subnet, and it's in the host's namespace).
+// Regression test for https://github.com/moby/moby/issues/47329
+func TestInternalNwConnectivity(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+
+	ctx := setupTest(t)
+
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t, "-D", "--experimental", "--ip6tables")
+	defer d.Stop(t)
+
+	c := d.NewClientT(t)
+	defer c.Close()
+
+	const bridgeName = "intnw"
+	const gw4 = "172.30.0.1"
+	const gw6 = "fda9:4130:4715::1234"
+	network.CreateNoError(ctx, t, c, bridgeName,
+		network.WithInternal(),
+		network.WithIPv6(),
+		network.WithIPAM("172.30.0.0/24", gw4),
+		network.WithIPAM("fda9:4130:4715::/64", gw6),
+		network.WithDriver("bridge"),
+		network.WithOption("com.docker.network.bridge.name", bridgeName),
+	)
+	defer network.RemoveNoError(ctx, t, c, bridgeName)
+
+	const ctrName = "intctr"
+	id := container.Run(ctx, t, c,
+		container.WithName(ctrName),
+		container.WithImage("busybox:latest"),
+		container.WithCmd("top"),
+		container.WithNetworkMode(bridgeName),
+	)
+	defer c.ContainerRemove(ctx, id, containertypes.RemoveOptions{Force: true})
+
+	execCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
+	res := container.ExecT(execCtx, t, c, id, []string{"ping", "-c1", "-W3", gw4})
+	assert.Check(t, is.Equal(res.ExitCode, 0))
+	assert.Check(t, is.Equal(res.Stderr(), ""))
+	assert.Check(t, is.Contains(res.Stdout(), "1 packets transmitted, 1 packets received"))
+
+	res = container.ExecT(execCtx, t, c, id, []string{"ping6", "-c1", "-W3", gw6})
+	assert.Check(t, is.Equal(res.ExitCode, 0))
+	assert.Check(t, is.Equal(res.Stderr(), ""))
+	assert.Check(t, is.Contains(res.Stdout(), "1 packets transmitted, 1 packets received"))
+
+	// Addresses outside the internal subnet must not be accessible.
+	res = container.ExecT(execCtx, t, c, id, []string{"ping", "-c1", "-W3", "8.8.8.8"})
+	assert.Check(t, is.Equal(res.ExitCode, 1))
+	assert.Check(t, is.Contains(res.Stderr(), "Network is unreachable"))
+}

--- a/libnetwork/drivers/bridge/setup_ipv4_linux.go
+++ b/libnetwork/drivers/bridge/setup_ipv4_linux.go
@@ -32,10 +32,6 @@ func setupBridgeIPv4(config *networkConfiguration, i *bridgeInterface) error {
 	//             are decoupled, we should assign it only when it's really needed.
 	i.bridgeIPv4 = config.AddressIPv4
 
-	if config.Internal {
-		return nil
-	}
-
 	if !config.InhibitIPv4 {
 		addrv4List, err := i.addresses(netlink.FAMILY_V4)
 		if err != nil {
@@ -57,8 +53,10 @@ func setupBridgeIPv4(config *networkConfiguration, i *bridgeInterface) error {
 		}
 	}
 
-	// Store the default gateway
-	i.gatewayIPv4 = config.AddressIPv4.IP
+	if !config.Internal {
+		// Store the default gateway
+		i.gatewayIPv4 = config.AddressIPv4.IP
+	}
 
 	return nil
 }

--- a/libnetwork/drivers/bridge/setup_verify_linux.go
+++ b/libnetwork/drivers/bridge/setup_verify_linux.go
@@ -20,12 +20,12 @@ func setupVerifyAndReconcileIPv4(config *networkConfiguration, i *bridgeInterfac
 	addrv4, _ := selectIPv4Address(addrsv4, config.AddressIPv4)
 
 	// Verify that the bridge has an IPv4 address.
-	if !config.Internal && addrv4.IPNet == nil {
+	if addrv4.IPNet == nil {
 		return &ErrNoIPAddr{}
 	}
 
 	// Verify that the bridge IPv4 address matches the requested configuration.
-	if config.AddressIPv4 != nil && addrv4.IPNet != nil && !addrv4.IP.Equal(config.AddressIPv4.IP) {
+	if config.AddressIPv4 != nil && !addrv4.IP.Equal(config.AddressIPv4.IP) {
 		return &IPv4AddrNoMatchError{IP: addrv4.IP, CfgIP: config.AddressIPv4.IP}
 	}
 


### PR DESCRIPTION
**- What I did**

Prior to release 25.0.0 (https://github.com/moby/moby/pull/46603), the bridge in an internal network was assigned an IP address - making the internal network accessible from the host, giving containers on the network access to anything listening on the bridge's address (or INADDR_ANY on the host).

This change restores that behaviour. It does not restore the default route that was configured in the container, because packets sent outside the internal network's subnet have always been dropped. So, a 'connect()' to an address outside the subnet will still fail fast.

Fixes https://github.com/moby/moby/issues/47329
Fixes 

**- How I did it**

Partly reverted changes in https://github.com/moby/moby/pull/46603

**- How to verify it**

New integration test.

Also ...

```
# docker network create --internal iii
# docker run --rm -d --network iii nginx
# docker container inspect -f '{{ .NetworkSettings.Networks.iii.IPAddress }}' nginx
172.20.0.2
root@223cd28b6075:/go/src/github.com/docker/docker# curl -I http://172.20.0.2
HTTP/1.1 200 OK
Server: nginx/1.25.3
...
```

For IPv6 - which isn't directly affected by this change ...

```
# docker network create --ipv6 --subnet fd12:f481:ae0a::/64 --internal in6
53a657e669c0b16211c13010342a81ae96fccd6feb16e573fe07e6ff831c9340
# docker run -ti --rm --network in6 alpine
/ # ping 2001:4860:4860::8888
PING 2001:4860:4860::8888 (2001:4860:4860::8888): 56 data bytes
ping: sendto: Network unreachable
/ # ip a show eth0
97: eth0@if98: <BROADCAST,MULTICAST,UP,LOWER_UP,M-DOWN> mtu 1500 qdisc noqueue state UP
    link/ether 02:42:ac:13:00:02 brd ff:ff:ff:ff:ff:ff
    inet 172.19.0.2/16 brd 172.19.255.255 scope global eth0
       valid_lft forever preferred_lft forever
    inet6 fd12:f481:ae0a::2/64 scope global flags 02
       valid_lft forever preferred_lft forever
    inet6 fe80::42:acff:fe13:2/64 scope link
       valid_lft forever preferred_lft forever
/ # route -n
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
172.19.0.0      0.0.0.0         255.255.0.0     U     0      0        0 eth0
/ # route -A inet6 -n
Kernel IPv6 routing table
Destination                                 Next Hop                                Flags Metric Ref    Use Iface
fd12:f481:ae0a::/64                         ::                                      U     256    2        0 eth0
fe80::/64                                   ::                                      U     256    1        0 eth0
::/0                                        ::                                      !n    -1     1        0 lo
::1/128                                     ::                                      Un    0      4        0 lo
fd12:f481:ae0a::2/128                       ::                                      Un    0      3        0 eth0
fe80::42:acff:fe13:2/128                    ::                                      Un    0      2        0 eth0
ff00::/8                                    ::                                      U     256    3        0 eth0
::/0

And, with nginx, similar to the above ...

# curl -I 'http://[fd12:f481:ae0a::2]'
HTTP/1.1 200 OK
Server: nginx/1.25.3
...
```

**- Description for the changelog**

Restore IP connectivity between the host and containers on an internal bridge network.