### PR TITLE
cmd/dockerd: add basic support for sd_notify "reload" notifications

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -322,7 +322,7 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 	cli.setupConfigReloadTrap()
 
 	// after the daemon is done setting up we can notify systemd api
-	notifyReady()
+	go notifyReady()
 
 	// Daemon is fully initialized. Start handling API traffic
 	// and wait for serve API to complete.
@@ -354,7 +354,7 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 	c.Cleanup()
 
 	// notify systemd that we're shutting down
-	notifyStopping()
+	go notifyStopping()
 	shutdownDaemon(ctx, d)
 
 	if err := routerOpts.buildkit.Close(); err != nil {

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -485,6 +485,13 @@ func (cli *DaemonCli) reloadConfig() {
 		}
 	}
 
+	// On Linux, we use sd_notify to indicate we're reloading config. We send
+	// this signal as early as possible to let systemd know we're reloading,
+	// but must signal "ready" after this completes (even on failure), which
+	// is done by the reload function defined above.
+	done := notifyReloading()
+	defer done()
+
 	if err := config.Reload(*cli.configFile, cli.flags, reload); err != nil {
 		log.G(ctx).Error(err)
 	}

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -322,7 +322,7 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 	cli.setupConfigReloadTrap()
 
 	// after the daemon is done setting up we can notify systemd api
-	go notifyReady()
+	notifyReady()
 
 	// Daemon is fully initialized. Start handling API traffic
 	// and wait for serve API to complete.
@@ -354,7 +354,7 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 	c.Cleanup()
 
 	// notify systemd that we're shutting down
-	go notifyStopping()
+	notifyStopping()
 	shutdownDaemon(ctx, d)
 
 	if err := routerOpts.buildkit.Close(); err != nil {

--- a/cmd/dockerd/daemon_freebsd.go
+++ b/cmd/dockerd/daemon_freebsd.go
@@ -10,6 +10,10 @@ func preNotifyReady() {
 func notifyReady() {
 }
 
+// notifyReloading sends a message to the host when the server got signaled to
+// reloading its configuration. It is a no-op on FreeBSD.
+func notifyReloading() func() { return func() {} }
+
 // notifyStopping sends a message to the host when the server is shutting down
 func notifyStopping() {
 }

--- a/cmd/dockerd/daemon_linux.go
+++ b/cmd/dockerd/daemon_linux.go
@@ -35,6 +35,44 @@ func notifyReady() {
 	_, _ = systemdDaemon.SdNotify(false, systemdDaemon.SdNotifyReady)
 }
 
+// notifyReloading sends a message to the host when the server got signaled to
+// reloading its configuration, see [sd_notify(3)]. The server should be running
+// as a systemd unit with "Type=notify" (see [systemd.service(5)]).
+//
+// notifyReloading returns a callback that must be called after reloading completes
+// (either successfully or unsuccessfully) to send [notifyReady]
+//
+// Note: we currently use the pre-systemd 253 implementation, which uses "Type=notify",
+// combined with [ExecReload]. The [ExecReload] option is designed to be synchronous,
+// which complicates its use when signals (SIGHUP) is used to reload:
+//
+// > Note however that reloading a daemon by enqueuing a signal (...) is usually
+// > not a good choice, because this is an asynchronous operation and hence not
+// > suitable when ordering reloads of multiple services against each other.
+//
+// Systemd 253 introduced a new Type (Type=notify-reload, see [systemd#25916]),
+// which allows setting a "ReloadSignal" instead, and requires sending a
+// [MONOTONIC_USEC] message.
+//
+// We currently still support distros that do not provide systemd 253, so cannot
+// use this new feature, but sending "RELOADING=1 / "READY=1" should at least
+// provide more information to systemd for the time being.
+//
+// [sd_notify(3)]: https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html#RELOADING=1
+// [systemd.service(5)]: https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Type=
+// [ExecReload]: https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#ExecReload=
+// [MONOTONIC_USEC]: https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html#MONOTONIC_USEC=…
+// [systemd#25916]: https://github.com/systemd/systemd/pull/25916
+func notifyReloading() (done func()) {
+	// TODO(thaJeztah): Set "MONOTONIC_USEC" once we drop support for systemd < 253, and supported by github.com/coreos/go-systemd, and update systemd unit accordingly; see https://github.com/moby/moby/pull/47358#discussion_r1483533255.
+	sent, _ := systemdDaemon.SdNotify(false, systemdDaemon.SdNotifyReloading)
+	if !sent {
+		// Nothing to do if no reloading event was sent.
+		return func() {}
+	}
+	return notifyReady
+}
+
 // notifyStopping sends a message to the host when the server is shutting down
 func notifyStopping() {
 	_, _ = systemdDaemon.SdNotify(false, systemdDaemon.SdNotifyStopping)

--- a/cmd/dockerd/daemon_linux.go
+++ b/cmd/dockerd/daemon_linux.go
@@ -32,12 +32,12 @@ func preNotifyReady() {
 // notifyReady sends a message to the host when the server is ready to be used
 func notifyReady() {
 	// Tell the init daemon we are accepting requests
-	go systemdDaemon.SdNotify(false, systemdDaemon.SdNotifyReady)
+	_, _ = systemdDaemon.SdNotify(false, systemdDaemon.SdNotifyReady)
 }
 
 // notifyStopping sends a message to the host when the server is shutting down
 func notifyStopping() {
-	go systemdDaemon.SdNotify(false, systemdDaemon.SdNotifyStopping)
+	_, _ = systemdDaemon.SdNotify(false, systemdDaemon.SdNotifyStopping)
 }
 
 func validateCPURealtimeOptions(config *config.Config) error {

--- a/cmd/dockerd/daemon_windows.go
+++ b/cmd/dockerd/daemon_windows.go
@@ -43,6 +43,10 @@ func preNotifyReady() {
 func notifyReady() {
 }
 
+// notifyReloading sends a message to the host when the server got signaled to
+// reloading its configuration. It is a no-op on Windows.
+func notifyReloading() func() { return func() {} }
+
 // notifyStopping sends a message to the host when the server is shutting down
 func notifyStopping() {
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/22446
- addresses https://github.com/moby/moby/issues/47353


commit f74b856e1ac2805fe48ceb52bc83cd7a3cec870c added an ExecReload to the systemd unit, which allows users to signal the daemon to reload its config through systemd (`systemctl reload docker.service`).

While reloading works, systemd expects the `ExecReload` command to be synchronous, so that it knows when the reload completes, and can account for this when managing dependent services.

> Note however that reloading a daemon by enqueuing a signal (...) is usually
> not a good choice, because this is an asynchronous operation and hence not
> suitable when ordering reloads of multiple services against each other.

Systemd 253 introduced a new Type (Type=notify-reload, see [systemd#25916]), which allows setting a "ReloadSignal" instead, in addition to sending a [MONOTONIC_USEC].

We currently still support distros that do not provide systemd 253, so cannot use this new feature, but sending "RELOADING=1 / "READY=1" should at least provide more information to systemd for the time being.

This patch:

- adds reload notifications to the daemon to notify when the daemon got signaled to reload its configuration see [sd_notify(3)].
- adds a [notifyReady] to notify when the reload finished, which we currently send regardless if the reload was successful or failed (which could be due to an invalid config).

We can re-implement this using `Type=notify-reload` once we no longer have to support systemd versions before 253.

[sd_notify(3)]: https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html#RELOADING=1
[systemd.service(5)]: https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Type=
[ExecReload]: https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#ExecReload=
[MONOTONIC_USEC]: https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html#MONOTONIC_USEC=…
[systemd#25916]: https://github.com/systemd/systemd/pull/25916

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```
- Send sd_notify ["READY"](https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html#READY=1) and ["STOPPING"](https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html#STOPPING=1) synchronously to make sure they are sent before we proceed.
- Add sd_notify ["RELOADING"](https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html#RELOADING=1) notifications when signalling the daemon to reload its configuration.
```



**- A picture of a cute animal (not mandatory but encouraged)**

