### PR TITLE
image/spec: remove link to docs.docker.com "registry" specification

### DIFF
--- a/image/spec/README.md
+++ b/image/spec/README.md
@@ -62,4 +62,3 @@ Changes:
 * [Open Containers Initiative (OCI) Image Format Specification v1.0.0](https://github.com/opencontainers/image-spec/tree/v1.0.0)
 * [Docker Image Manifest Version 2, Schema 2](https://github.com/distribution/distribution/blob/main/docs/content/spec/manifest-v2-2.md)
 * [Docker Image Manifest Version 2, Schema 1](https://github.com/distribution/distribution/blob/main/docs/content/spec/deprecated-schema-v1.md) (*DEPRECATED*)
-* [Docker Registry HTTP API V2](https://docs.docker.com/registry/spec/api/)


### PR DESCRIPTION
This spec is not directly relevant for the image spec, and the Docker documentation no longer includes the actual specification.

**- A picture of a cute animal (not mandatory but encouraged)**

