### PR TITLE
Don't enforce new validation rules for existing networks

### DIFF
--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -213,6 +213,10 @@ func (n *networkRouter) postNetworkCreate(ctx context.Context, w http.ResponseWr
 		return libnetwork.NetworkNameError(create.Name)
 	}
 
+	// For a Swarm-scoped network, this call to backend.CreateNetwork is used to
+	// validate the configuration. The network will not be created but, if the
+	// configuration is valid, ManagerRedirectError will be returned and handled
+	// below.
 	nw, err := n.backend.CreateNetwork(create)
 	if err != nil {
 		if _, ok := err.(libnetwork.ManagerRedirectError); !ok {

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -332,7 +332,27 @@ func (daemon *Daemon) createNetwork(cfg *config.Config, create types.NetworkCrea
 	}
 
 	if err := network.ValidateIPAM(create.IPAM, create.EnableIPv6); err != nil {
-		return nil, errdefs.InvalidParameter(err)
+		if agent {
+			// This function is called with agent=false for all networks. For swarm-scoped
+			// networks, the configuration is validated but ManagerRedirectError is returned
+			// and the network is not created. Then, each time a swarm-scoped network is
+			// needed, this function is called again with agent=true.
+			//
+			// Non-swarm networks created before ValidateIPAM was introduced continue to work
+			// as they did before-upgrade, even if they would fail the new checks on creation
+			// (for example, by having host-bits set in their subnet). Those networks are not
+			// seen again here.
+			//
+			// By dropping errors for agent networks, existing swarm-scoped networks also
+			// continue to behave as they did before upgrade - but new networks are still
+			// validated.
+			log.G(context.TODO()).WithFields(log.Fields{
+				"error":   err,
+				"network": create.Name,
+			}).Warn("Continuing with validation errors in agent IPAM")
+		} else {
+			return nil, errdefs.InvalidParameter(err)
+		}
 	}
 
 	if create.IPAM != nil {


### PR DESCRIPTION
**- What I did**

Non-swarm networks created before validation checks were added on network creation (https://github.com/moby/moby/pull/45759) continued working in 25.0.x because the checks were not re-run.

But, a swarm network with invalid IPAM config (for example, subnet `10.0.0.1/24`) fails to initialise on upgrade to 25.0.x.

Fixes https://github.com/moby/moby/issues/47331

**- How I did it**

Swarm creates networks (with `agent=true`) to ensure they exist on each agent, when needed - ignoring the NetworkNameError that says the network already existed.

By ignoring IPAM validation errors on creation of a network with `agent=true`, pre-existing swarm networks with IPAM config that would fail the new checks will continue to work too.

New swarm (overlay) networks are still validated, because they are initially created with 'agent=false'.

**- How to verify it**

As described in https://github.com/moby/moby/issues/47331 ...

Start with a 24.0.x build:
- docker network rm ingress
- docker network create --driver overlay --ingress ingress --subnet=10.0.0.1/1
- docker service create -p 80:80 nginx
- Upgrade to docker 25.0.3

The service failed to start, logging errors like this ...

```
level=error msg="fatal task error" error="invalid network config:\ninvalid subnet 10.0.0.1/16: it should be 10.0.0.0/16" module=node/agent/taskmanager node.id=s6ui3u8t66gml6czf2jwxhpgn service.id=rty5ui8sw8j6a1yl5tl98e6z9 task.id=lffsjphhk89mcwhhvn6heb91x
```

With this change, the service starts, and log lines like this are generated ("ingress" is configured as above, "oln" is a non-ingress overlay network) ...

```
WARN[2024-02-08T17:38:29.881000427Z] Continuing with validation errors in agent network IPAM  error="invalid network config:\ninvalid subnet 10.0.0.1/16: it should be 10.0.0.0/16" network=ingress
WARN[2024-02-08T17:38:29.881073302Z] Continuing with validation errors in agent network IPAM  error="invalid network config:\ninvalid subnet 10.1.0.1/16: it should be 10.1.0.0/16" network=oln
```

It's not possible to create new overlay and bridge networks with the same issue ...

```
# docker network create --subnet 10.10.0.1/24 nnn
Error response from daemon: invalid network config:
invalid subnet 10.10.0.1/24: it should be 10.10.0.0/24

# docker network create --driver overlay ooo --subnet=10.2.0.1/16
Error response from daemon: invalid network config:
invalid subnet 10.2.0.1/16: it should be 10.2.0.0/16
```

**- Description for the changelog**

Do not enforce new validation rules for existing swarm networks