### PR TITLE
reduce named (error)-returns and some minor linting-fixes

### DIFF
--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -263,17 +263,16 @@ func (s *DockerCLILogsSuite) TestLogsFollowSlowStdoutConsumer(c *testing.T) {
 // ConsumeWithSpeed reads chunkSize bytes from reader before sleeping
 // for interval duration. Returns total read bytes. Send true to the
 // stop channel to return before reading to EOF on the reader.
-func ConsumeWithSpeed(reader io.Reader, chunkSize int, interval time.Duration, stop chan bool) (n int, err error) {
+func ConsumeWithSpeed(reader io.Reader, chunkSize int, interval time.Duration, stop chan bool) (n int, _ error) {
 	buffer := make([]byte, chunkSize)
 	for {
-		var readBytes int
-		readBytes, err = reader.Read(buffer)
+		readBytes, err := reader.Read(buffer)
 		n += readBytes
 		if err != nil {
-			if err == io.EOF {
-				err = nil
+			if err != io.EOF {
+				return n, err
 			}
-			return n, err
+			return n, nil
 		}
 		select {
 		case <-stop:

--- a/integration-cli/utils_test.go
+++ b/integration-cli/utils_test.go
@@ -67,8 +67,9 @@ func RandomTmpDirPath(s string, platform string) string {
 // of each pipelined with the following (like cmd1 | cmd2 | cmd3 would do).
 // It returns the final output, the exitCode different from 0 and the error
 // if something bad happened.
+//
 // Deprecated: use icmd instead
-func RunCommandPipelineWithOutput(cmds ...*exec.Cmd) (output string, err error) {
+func RunCommandPipelineWithOutput(cmds ...*exec.Cmd) (output string, retErr error) {
 	if len(cmds) < 2 {
 		return "", errors.New("pipeline does not have multiple cmds")
 	}
@@ -77,6 +78,7 @@ func RunCommandPipelineWithOutput(cmds ...*exec.Cmd) (output string, err error) 
 	for i, cmd := range cmds {
 		if i > 0 {
 			prevCmd := cmds[i-1]
+			var err error
 			cmd.Stdin, err = prevCmd.StdoutPipe()
 			if err != nil {
 				return "", fmt.Errorf("cannot set stdout pipe for %s: %v", cmd.Path, err)
@@ -86,7 +88,7 @@ func RunCommandPipelineWithOutput(cmds ...*exec.Cmd) (output string, err error) 
 
 	// start all cmds except the last
 	for _, cmd := range cmds[:len(cmds)-1] {
-		if err = cmd.Start(); err != nil {
+		if err := cmd.Start(); err != nil {
 			return "", fmt.Errorf("starting %s failed with error: %v", cmd.Path, err)
 		}
 	}
@@ -95,12 +97,12 @@ func RunCommandPipelineWithOutput(cmds ...*exec.Cmd) (output string, err error) 
 		var pipeErrMsgs []string
 		// wait all cmds except the last to release their resources
 		for _, cmd := range cmds[:len(cmds)-1] {
-			if pipeErr := cmd.Wait(); pipeErr != nil {
-				pipeErrMsgs = append(pipeErrMsgs, fmt.Sprintf("command %s failed with error: %v", cmd.Path, pipeErr))
+			if err := cmd.Wait(); err != nil {
+				pipeErrMsgs = append(pipeErrMsgs, fmt.Sprintf("command %s failed with error: %v", cmd.Path, err))
 			}
 		}
-		if len(pipeErrMsgs) > 0 && err == nil {
-			err = fmt.Errorf("pipelineError from Wait: %v", strings.Join(pipeErrMsgs, ", "))
+		if len(pipeErrMsgs) > 0 && retErr == nil {
+			retErr = fmt.Errorf("pipelineError from Wait: %v", strings.Join(pipeErrMsgs, ", "))
 		}
 	}()
 

--- a/internal/testutils/specialimage/emptyfs.go
+++ b/internal/testutils/specialimage/emptyfs.go
@@ -57,7 +57,7 @@ func EmptyFS(dir string) (*ocispec.Index, error) {
 
 type zeroReader struct{}
 
-func (zeroReader) Read(p []byte) (n int, err error) {
+func (zeroReader) Read(p []byte) (int, error) {
 	l := len(p)
 	for idx := 0; idx < l; idx++ {
 		p[idx] = 0

--- a/libcontainerd/local/process_windows.go
+++ b/libcontainerd/local/process_windows.go
@@ -13,12 +13,12 @@ type autoClosingReader struct {
 	sync.Once
 }
 
-func (r *autoClosingReader) Read(b []byte) (n int, err error) {
-	n, err = r.ReadCloser.Read(b)
+func (r *autoClosingReader) Read(b []byte) (int, error) {
+	n, err := r.ReadCloser.Read(b)
 	if err != nil {
 		r.Once.Do(func() { r.ReadCloser.Close() })
 	}
-	return
+	return n, err
 }
 
 func createStdInCloser(pipe io.WriteCloser, process hcsshim.Process) io.WriteCloser {

--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -92,18 +92,19 @@ func (c *container) newTask(t containerd.Task) *task {
 	return &task{Task: t, ctr: c}
 }
 
-func (c *container) AttachTask(ctx context.Context, attachStdio libcontainerdtypes.StdioCallback) (_ libcontainerdtypes.Task, err error) {
+func (c *container) AttachTask(ctx context.Context, attachStdio libcontainerdtypes.StdioCallback) (_ libcontainerdtypes.Task, retErr error) {
 	var dio *cio.DirectIO
 	defer func() {
-		if err != nil && dio != nil {
+		if retErr != nil && dio != nil {
 			dio.Cancel()
-			dio.Close()
+			_ = dio.Close()
 		}
 	}()
 
 	attachIO := func(fifos *cio.FIFOSet) (cio.IO, error) {
 		// dio must be assigned to the previously defined dio for the defer above
 		// to handle cleanup
+		var err error
 		dio, err = c.client.newDirectIO(ctx, fifos)
 		if err != nil {
 			return nil, err

--- a/libcontainerd/remote/client_io_windows.go
+++ b/libcontainerd/remote/client_io_windows.go
@@ -41,7 +41,7 @@ func (dc *delayedConnection) unblockConnectionWaiters() {
 }
 
 func (dc *delayedConnection) Close() error {
-	dc.l.Close()
+	_ = dc.l.Close()
 	if dc.con != nil {
 		return dc.con.Close()
 	}
@@ -56,7 +56,7 @@ type stdioPipes struct {
 }
 
 // newStdioPipes creates actual fifos for stdio.
-func (c *client) newStdioPipes(fifos *cio.FIFOSet) (_ *stdioPipes, err error) {
+func (c *client) newStdioPipes(fifos *cio.FIFOSet) (_ *stdioPipes, retErr error) {
 	p := &stdioPipes{}
 	if fifos.Stdin != "" {
 		c.logger.WithField("stdin", fifos.Stdin).Debug("listen")
@@ -69,8 +69,8 @@ func (c *client) newStdioPipes(fifos *cio.FIFOSet) (_ *stdioPipes, err error) {
 		}
 		dc.wg.Add(1)
 		defer func() {
-			if err != nil {
-				dc.Close()
+			if retErr != nil {
+				_ = dc.Close()
 			}
 		}()
 		p.stdin = dc
@@ -79,7 +79,7 @@ func (c *client) newStdioPipes(fifos *cio.FIFOSet) (_ *stdioPipes, err error) {
 			c.logger.WithField("stdin", fifos.Stdin).Debug("accept")
 			conn, err := l.Accept()
 			if err != nil {
-				dc.Close()
+				_ = dc.Close()
 				if err != winio.ErrPipeListenerClosed {
 					c.logger.WithError(err).Errorf("failed to accept stdin connection on %s", fifos.Stdin)
 				}
@@ -102,8 +102,8 @@ func (c *client) newStdioPipes(fifos *cio.FIFOSet) (_ *stdioPipes, err error) {
 		}
 		dc.wg.Add(1)
 		defer func() {
-			if err != nil {
-				dc.Close()
+			if retErr != nil {
+				_ = dc.Close()
 			}
 		}()
 		p.stdout = dc
@@ -112,7 +112,7 @@ func (c *client) newStdioPipes(fifos *cio.FIFOSet) (_ *stdioPipes, err error) {
 			c.logger.WithField("stdout", fifos.Stdout).Debug("accept")
 			conn, err := l.Accept()
 			if err != nil {
-				dc.Close()
+				_ = dc.Close()
 				if err != winio.ErrPipeListenerClosed {
 					c.logger.WithFields(log.Fields{"error": err, "stdout": fifos.Stdout}).Error("failed to accept stdout connection")
 				}
@@ -135,8 +135,8 @@ func (c *client) newStdioPipes(fifos *cio.FIFOSet) (_ *stdioPipes, err error) {
 		}
 		dc.wg.Add(1)
 		defer func() {
-			if err != nil {
-				dc.Close()
+			if retErr != nil {
+				_ = dc.Close()
 			}
 		}()
 		p.stderr = dc
@@ -145,7 +145,7 @@ func (c *client) newStdioPipes(fifos *cio.FIFOSet) (_ *stdioPipes, err error) {
 			c.logger.WithField("stderr", fifos.Stderr).Debug("accept")
 			conn, err := l.Accept()
 			if err != nil {
-				dc.Close()
+				_ = dc.Close()
 				if err != winio.ErrPipeListenerClosed {
 					c.logger.WithError(err).Errorf("failed to accept stderr connection on %s", fifos.Stderr)
 				}

--- a/libnetwork/drivers/remote/driver_test.go
+++ b/libnetwork/drivers/remote/driver_test.go
@@ -24,15 +24,10 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func decodeToMap(r *http.Request) (map[string]interface{}, error) {
-	var res map[string]interface{}
-	err := json.NewDecoder(r.Body).Decode(&res)
-	return res, err
-}
-
 func handle(t *testing.T, mux *http.ServeMux, method string, h func(map[string]interface{}) interface{}) {
 	mux.HandleFunc(fmt.Sprintf("/%s.%s", driverapi.NetworkPluginEndpointType, method), func(w http.ResponseWriter, r *http.Request) {
-		ask, err := decodeToMap(r)
+		var ask map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&ask)
 		if err != nil && err != io.EOF {
 			t.Fatal(err)
 		}

--- a/libnetwork/ipams/remote/remote_test.go
+++ b/libnetwork/ipams/remote/remote_test.go
@@ -18,15 +18,10 @@ import (
 	is "gotest.tools/v3/assert/cmp"
 )
 
-func decodeToMap(r *http.Request) (map[string]interface{}, error) {
-	var res map[string]interface{}
-	err := json.NewDecoder(r.Body).Decode(&res)
-	return res, err
-}
-
 func handle(t *testing.T, mux *http.ServeMux, method string, h func(map[string]interface{}) interface{}) {
 	mux.HandleFunc(fmt.Sprintf("/%s.%s", ipamapi.PluginEndpointType, method), func(w http.ResponseWriter, r *http.Request) {
-		ask, err := decodeToMap(r)
+		var ask map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&ask)
 		if err != nil && err != io.EOF {
 			t.Fatal(err)
 		}

--- a/libnetwork/portallocator/portallocator_freebsd.go
+++ b/libnetwork/portallocator/portallocator_freebsd.go
@@ -6,13 +6,13 @@ import (
 	"os/exec"
 )
 
-func getDynamicPortRange() (start int, end int, err error) {
+func getDynamicPortRange() (start int, end int, _ error) {
 	portRangeKernelSysctl := []string{"net.inet.ip.portrange.hifirst", "net.ip.portrange.hilast"}
 	portRangeLowCmd := exec.Command("/sbin/sysctl", portRangeKernelSysctl[0])
 	var portRangeLowOut bytes.Buffer
 	portRangeLowCmd.Stdout = &portRangeLowOut
-	cmdErr := portRangeLowCmd.Run()
-	if cmdErr != nil {
+	err := portRangeLowCmd.Run()
+	if err != nil {
 		return 0, 0, fmt.Errorf("port allocator - sysctl net.inet.ip.portrange.hifirst failed: %v", err)
 	}
 	n, err := fmt.Sscanf(portRangeLowOut.String(), "%d", &start)
@@ -26,8 +26,8 @@ func getDynamicPortRange() (start int, end int, err error) {
 	portRangeHighCmd := exec.Command("/sbin/sysctl", portRangeKernelSysctl[1])
 	var portRangeHighOut bytes.Buffer
 	portRangeHighCmd.Stdout = &portRangeHighOut
-	cmdErr = portRangeHighCmd.Run()
-	if cmdErr != nil {
+	err = portRangeHighCmd.Run()
+	if err != nil {
 		return 0, 0, fmt.Errorf("port allocator - sysctl net.inet.ip.portrange.hilast failed: %v", err)
 	}
 	n, err = fmt.Sscanf(portRangeHighOut.String(), "%d", &end)

--- a/libnetwork/portallocator/portallocator_linux.go
+++ b/libnetwork/portallocator/portallocator_linux.go
@@ -6,7 +6,7 @@ import (
 	"os"
 )
 
-func getDynamicPortRange() (start int, end int, err error) {
+func getDynamicPortRange() (start int, end int, _ error) {
 	const portRangeKernelParam = "/proc/sys/net/ipv4/ip_local_port_range"
 	file, err := os.Open(portRangeKernelParam)
 	if err != nil {

--- a/libnetwork/portallocator/portallocator_windows.go
+++ b/libnetwork/portallocator/portallocator_windows.go
@@ -7,6 +7,6 @@ const (
 	defaultPortRangeEnd = 65000
 )
 
-func getDynamicPortRange() (start int, end int, err error) {
+func getDynamicPortRange() (start int, end int, _ error) {
 	return defaultPortRangeStart, defaultPortRangeEnd, nil
 }

--- a/libnetwork/resolver_test.go
+++ b/libnetwork/resolver_test.go
@@ -239,7 +239,7 @@ func testLogger(t *testing.T) *logrus.Entry {
 
 type tlogWriter struct{ t *testing.T }
 
-func (w tlogWriter) Write(p []byte) (n int, err error) {
+func (w tlogWriter) Write(p []byte) (int, error) {
 	w.t.Logf("%s", p)
 	return len(p), nil
 }

--- a/oci/devices_linux.go
+++ b/oci/devices_linux.go
@@ -21,7 +21,7 @@ func deviceCgroup(d *specs.LinuxDevice, permissions string) specs.LinuxDeviceCgr
 }
 
 // DevicesFromPath computes a list of devices and device permissions from paths (pathOnHost and pathInContainer) and cgroup permissions.
-func DevicesFromPath(pathOnHost, pathInContainer, cgroupPermissions string) (devs []specs.LinuxDevice, devPermissions []specs.LinuxDeviceCgroup, err error) {
+func DevicesFromPath(pathOnHost, pathInContainer, cgroupPermissions string) (devs []specs.LinuxDevice, devPermissions []specs.LinuxDeviceCgroup, _ error) {
 	resolvedPathOnHost := pathOnHost
 
 	// check if it is a symbolic link

--- a/plugin/backend_linux.go
+++ b/plugin/backend_linux.go
@@ -92,7 +92,7 @@ func (pm *Manager) Enable(refOrID string, config *backend.PluginEnableConfig) er
 }
 
 // Inspect examines a plugin config
-func (pm *Manager) Inspect(refOrID string) (tp *types.Plugin, err error) {
+func (pm *Manager) Inspect(refOrID string) (*types.Plugin, error) {
 	p, err := pm.config.Store.GetV2Plugin(refOrID)
 	if err != nil {
 		return nil, err
@@ -209,7 +209,7 @@ func (pm *Manager) Privileges(ctx context.Context, ref reference.Named, metaHead
 // Upgrade upgrades a plugin
 //
 // TODO: replace reference package usage with simpler url.Parse semantics
-func (pm *Manager) Upgrade(ctx context.Context, ref reference.Named, name string, metaHeader http.Header, authConfig *registry.AuthConfig, privileges types.PluginPrivileges, outStream io.Writer) (err error) {
+func (pm *Manager) Upgrade(ctx context.Context, ref reference.Named, name string, metaHeader http.Header, authConfig *registry.AuthConfig, privileges types.PluginPrivileges, outStream io.Writer) error {
 	p, err := pm.config.Store.GetV2Plugin(name)
 	if err != nil {
 		return err
@@ -257,7 +257,7 @@ func (pm *Manager) Upgrade(ctx context.Context, ref reference.Named, name string
 // Pull pulls a plugin, check if the correct privileges are provided and install the plugin.
 //
 // TODO: replace reference package usage with simpler url.Parse semantics
-func (pm *Manager) Pull(ctx context.Context, ref reference.Named, name string, metaHeader http.Header, authConfig *registry.AuthConfig, privileges types.PluginPrivileges, outStream io.Writer, opts ...CreateOpt) (err error) {
+func (pm *Manager) Pull(ctx context.Context, ref reference.Named, name string, metaHeader http.Header, authConfig *registry.AuthConfig, privileges types.PluginPrivileges, outStream io.Writer, opts ...CreateOpt) error {
 	pm.muGC.RLock()
 	defer pm.muGC.RUnlock()
 

--- a/plugin/backend_unsupported.go
+++ b/plugin/backend_unsupported.go
@@ -28,7 +28,7 @@ func (pm *Manager) Enable(name string, config *backend.PluginEnableConfig) error
 }
 
 // Inspect examines a plugin config
-func (pm *Manager) Inspect(refOrID string) (tp *types.Plugin, err error) {
+func (pm *Manager) Inspect(refOrID string) (*types.Plugin, error) {
 	return nil, errNotSupported
 }
 

--- a/plugin/fetch_linux.go
+++ b/plugin/fetch_linux.go
@@ -59,7 +59,7 @@ func setupProgressOutput(outStream io.Writer, cancel func()) (progress.Output, f
 
 // fetch the content related to the passed in reference into the blob store and appends the provided c8dimages.Handlers
 // There is no need to use remotes.FetchHandler since it already gets set
-func (pm *Manager) fetch(ctx context.Context, ref reference.Named, auth *registry.AuthConfig, out progress.Output, metaHeader http.Header, handlers ...c8dimages.Handler) (err error) {
+func (pm *Manager) fetch(ctx context.Context, ref reference.Named, auth *registry.AuthConfig, out progress.Output, metaHeader http.Header, handlers ...c8dimages.Handler) error {
 	// We need to make sure we have a domain on the reference
 	withDomain, err := reference.ParseNormalizedNamed(ref.String())
 	if err != nil {

--- a/registry/resumable/resumablerequestreader.go
+++ b/registry/resumable/resumablerequestreader.go
@@ -34,10 +34,12 @@ func NewRequestReaderWithInitialResponse(c *http.Client, r *http.Request, maxfai
 	return &requestReader{client: c, request: r, maxFailures: maxfail, totalSize: totalsize, currentResponse: initialResponse, waitDuration: 5 * time.Second}
 }
 
-func (r *requestReader) Read(p []byte) (n int, err error) {
+func (r *requestReader) Read(p []byte) (n int, _ error) {
 	if r.client == nil || r.request == nil {
 		return 0, fmt.Errorf("client and request can't be nil")
 	}
+
+	var err error
 	isFreshRequest := false
 	if r.lastRange != 0 && r.currentResponse == nil {
 		readRange := fmt.Sprintf("bytes=%d-%d", r.lastRange, r.totalSize)

--- a/registry/resumable/resumablerequestreader_test.go
+++ b/registry/resumable/resumablerequestreader_test.go
@@ -85,8 +85,8 @@ type errorReaderCloser struct{}
 
 func (errorReaderCloser) Close() error { return nil }
 
-func (errorReaderCloser) Read(p []byte) (n int, err error) {
-	return 0, fmt.Errorf("An error occurred")
+func (errorReaderCloser) Read(p []byte) (int, error) {
+	return 0, fmt.Errorf("an error occurred")
 }
 
 // If an unknown error is encountered, return 0, nil and log it

--- a/registry/service.go
+++ b/registry/service.go
@@ -40,7 +40,7 @@ func (s *Service) ServiceConfig() *registry.ServiceConfig {
 
 // ReplaceConfig prepares a transaction which will atomically replace the
 // registry service's configuration when the returned commit function is called.
-func (s *Service) ReplaceConfig(options ServiceOptions) (commit func(), err error) {
+func (s *Service) ReplaceConfig(options ServiceOptions) (commit func(), _ error) {
 	config, err := newServiceConfig(options)
 	if err != nil {
 		return nil, err
@@ -148,7 +148,7 @@ type APIEndpoint struct {
 
 // LookupPullEndpoints creates a list of v2 endpoints to try to pull from, in order of preference.
 // It gives preference to mirrors over the actual registry, and HTTPS over plain HTTP.
-func (s *Service) LookupPullEndpoints(hostname string) (endpoints []APIEndpoint, err error) {
+func (s *Service) LookupPullEndpoints(hostname string) ([]APIEndpoint, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -157,7 +157,7 @@ func (s *Service) LookupPullEndpoints(hostname string) (endpoints []APIEndpoint,
 
 // LookupPushEndpoints creates a list of v2 endpoints to try to push to, in order of preference.
 // It gives preference to HTTPS over plain HTTP. Mirrors are not included.
-func (s *Service) LookupPushEndpoints(hostname string) (endpoints []APIEndpoint, err error) {
+func (s *Service) LookupPushEndpoints(hostname string) ([]APIEndpoint, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -699,13 +699,13 @@ func (d *Daemon) Stop(t testing.TB) {
 // If it timeouts, a SIGKILL is sent.
 // Stop will not delete the daemon directory. If a purged daemon is needed,
 // instantiate a new one with NewDaemon.
-func (d *Daemon) StopWithError() (err error) {
+func (d *Daemon) StopWithError() (retErr error) {
 	if d.cmd == nil || d.Wait == nil {
 		return errDaemonNotStarted
 	}
 	defer func() {
-		if err != nil {
-			d.log.Logf("[%s] error while stopping daemon: %v", d.id, err)
+		if retErr != nil {
+			d.log.Logf("[%s] error while stopping daemon: %v", d.id, retErr)
 		} else {
 			d.log.Logf("[%s] daemon stopped", d.id)
 			if d.pidFile != "" {

--- a/testutil/helpers.go
+++ b/testutil/helpers.go
@@ -30,7 +30,7 @@ var DevZero io.Reader = devZero{}
 
 type devZero struct{}
 
-func (d devZero) Read(p []byte) (n int, err error) {
+func (d devZero) Read(p []byte) (int, error) {
 	for i := range p {
 		p[i] = 0
 	}

--- a/volume/mounts/parser_test.go
+++ b/volume/mounts/parser_test.go
@@ -12,7 +12,7 @@ import (
 
 type mockFiProvider struct{}
 
-func (mockFiProvider) fileInfo(path string) (exists, isDir bool, err error) {
+func (mockFiProvider) fileInfo(path string) (exists, isDir bool, _ error) {
 	dirs := map[string]struct{}{
 		`c:\`:                    {},
 		`c:\windows\`:            {},

--- a/volume/mounts/windows_parser.go
+++ b/volume/mounts/windows_parser.go
@@ -201,7 +201,7 @@ type fileInfoProvider interface {
 
 type defaultFileInfoProvider struct{}
 
-func (defaultFileInfoProvider) fileInfo(path string) (exist, isDir bool, err error) {
+func (defaultFileInfoProvider) fileInfo(path string) (exist, isDir bool, _ error) {
 	fi, err := os.Stat(path)
 	if err != nil {
 		if !os.IsNotExist(err) {

--- a/volume/service/service.go
+++ b/volume/service/service.go
@@ -262,18 +262,18 @@ func (s *VolumesService) Prune(ctx context.Context, filter filters.Args) (*volum
 
 // List gets the list of volumes which match the past in filters
 // If filters is nil or empty all volumes are returned.
-func (s *VolumesService) List(ctx context.Context, filter filters.Args) (volumesOut []*volumetypes.Volume, warnings []string, err error) {
+func (s *VolumesService) List(ctx context.Context, filter filters.Args) (volumes []*volumetypes.Volume, warnings []string, _ error) {
 	by, err := filtersToBy(filter, acceptedListFilters)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	volumes, warnings, err := s.vs.Find(ctx, by)
+	vols, warns, err := s.vs.Find(ctx, by)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return s.volumesToAPI(ctx, volumes, useCachedPath(true)), warnings, nil
+	return s.volumesToAPI(ctx, vols, useCachedPath(true)), warns, nil
 }
 
 // Shutdown shuts down the image service and dependencies


### PR DESCRIPTION
Reduce the use to named (error) returns, and when used, use a distinctive name for the error-return, instead of `err`, which is error-prone, as it's easy to shadow, which could cause issues when handled in a defer.

See individual commits for details.



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

