### PR TITLE
Set `Created` to `0001-01-01T00:00:00Z` on older API versions

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -299,6 +299,12 @@ func (ir *imageRouter) getImagesByName(ctx context.Context, w http.ResponseWrite
 	version := httputils.VersionFromContext(ctx)
 	if versions.LessThan(version, "1.44") {
 		imageInspect.VirtualSize = imageInspect.Size //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.44.
+
+		if imageInspect.Created == "" {
+			// backwards compatibility for Created not existing returning "0001-01-01T00:00:00Z"
+			// https://github.com/moby/moby/issues/47368
+			imageInspect.Created = time.Time{}.Format(time.RFC3339Nano)
+		}
 	}
 	return httputils.WriteJSON(w, http.StatusOK, imageInspect)
 }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1746,7 +1746,7 @@ definitions:
       Created:
         description: |
           Date and time at which the image was created, formatted in
-          [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+          [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds, or empty if the field was not set in the image config.
         type: "string"
         x-nullable: false
         example: "2022-02-04T21:20:12.497794809Z"

--- a/docs/api/v1.44.yaml
+++ b/docs/api/v1.44.yaml
@@ -1742,7 +1742,7 @@ definitions:
       Created:
         description: |
           Date and time at which the image was created, formatted in
-          [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+          [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds, or empty if the field was not set in the image config.
         type: "string"
         x-nullable: false
         example: "2022-02-04T21:20:12.497794809Z"

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -86,6 +86,9 @@ keywords: "API, Docker, rcli, REST, documentation"
   `SecondaryIPv6Addresses` available in `NetworkSettings` when calling `GET /containers/{id}/json` are
   deprecated and will be removed in a future release. You should instead look for the default network in
   `NetworkSettings.Networks`.
+* `GET /images/{id}/json` now responds with an empty `Created` field
+  (previously it was `0001-01-01T00:00:00Z`) if the `Created` field is missing
+  from the image config.
 
 ## v1.43 API changes
 


### PR DESCRIPTION
This matches the prior behavior before 2a6ff3c24fd790e5d42d2eabaf6acf06edfe6975.

This also updates the Swagger documentation for the current version to note that the field might be the empty string and what that means.

Fixes #47368

(if accepted, this should be backported to 25.x)

## Changelog

```
- API: Populate a missing `Created` field in `GET /images/{id}/json` with `0001-01-01T00:00:00Z` for API version <= 1.43.
```