### PR TITLE
Set up DNS names for Windows default network

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -649,7 +649,10 @@ func cleanOperationalData(es *network.EndpointSettings) {
 }
 
 func (daemon *Daemon) updateNetworkConfig(container *container.Container, n *libnetwork.Network, endpointConfig *networktypes.EndpointSettings, updateSettings bool) error {
-	if containertypes.NetworkMode(n.Name()).IsUserDefined() {
+	// Set up DNS names for a user defined network, and for the default 'nat'
+	// network on Windows (IsBridge() returns true for nat).
+	if containertypes.NetworkMode(n.Name()).IsUserDefined() ||
+		(serviceDiscoveryOnDefaultNetwork() && containertypes.NetworkMode(n.Name()).IsBridge()) {
 		endpointConfig.DNSNames = buildEndpointDNSNames(container, endpointConfig.Aliases)
 	}
 


### PR DESCRIPTION
**- What I did**

Fixes https://github.com/moby/moby/issues/47370

**- How I did it**

DNS names were only set up for user-defined networks. On Linux, none of the built-in networks (bridge/host/none) have built-in DNS, so they don't need DNS names.

But, on Windows, the default network is "nat" and it does need the DNS names.

_This is meant as a minimal change that we can ship in a patch if we make one ... but we probably need a better predicate to determine whether a container's going to get an internal resolver, here and elsewhere._

**- How to verify it**

As described in https://github.com/moby/moby/issues/47370.

Also, without the fix, in `inspect` output ...

```
"DNSNames": null
```

And, with the fix ...

```
"DNSNames": [
    "container1",
    "ac0225674b22"
]
```

_Will also need a regression test._

**- Description for the changelog**

Restore DNS names for containers in the default "nat" network on Windows.