### PR TITLE
Allocate IPv6 addresses after detecting IPv6 support

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -43,7 +43,7 @@ func ipAddresses(ips []net.IP) []string {
 	return addrs
 }
 
-func (daemon *Daemon) buildSandboxOptions(cfg *config.Config, ctr *container.Container) ([]libnetwork.SandboxOption, error) {
+func buildSandboxOptions(cfg *config.Config, ctr *container.Container) ([]libnetwork.SandboxOption, error) {
 	var sboxOptions []libnetwork.SandboxOption
 	sboxOptions = append(sboxOptions, libnetwork.OptionHostname(ctr.Config.Hostname), libnetwork.OptionDomainname(ctr.Config.Domainname))
 
@@ -248,7 +248,7 @@ func (daemon *Daemon) updateNetwork(cfg *config.Config, ctr *container.Container
 		return nil
 	}
 
-	sbOptions, err := daemon.buildSandboxOptions(cfg, ctr)
+	sbOptions, err := buildSandboxOptions(cfg, ctr)
 	if err != nil {
 		return fmt.Errorf("Update network failed: %v", err)
 	}
@@ -438,7 +438,7 @@ func (daemon *Daemon) allocateNetwork(ctx context.Context, cfg *config.Config, c
 
 	daemon.updateContainerNetworkSettings(ctr, nil)
 
-	sbOptions, err := daemon.buildSandboxOptions(cfg, ctr)
+	sbOptions, err := buildSandboxOptions(cfg, ctr)
 	if err != nil {
 		return err
 	}

--- a/daemon/container_operations_test.go
+++ b/daemon/container_operations_test.go
@@ -20,6 +20,7 @@ func TestDNSNamesOrder(t *testing.T) {
 		Config: &containertypes.Config{
 			Hostname: "baz",
 		},
+		HostConfig: &containertypes.HostConfig{},
 	}
 	nw := buildNetwork(t, map[string]any{
 		"id":          "1234567890",
@@ -31,7 +32,7 @@ func TestDNSNamesOrder(t *testing.T) {
 		Aliases: []string{"myctr"},
 	}
 
-	if err := d.updateNetworkConfig(ctr, nw, epSettings, false); err != nil {
+	if err := d.updateNetworkConfig(ctr, nw, epSettings); err != nil {
 		t.Fatal(err)
 	}
 

--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/config"
+	"github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/libnetwork"
 	"github.com/docker/docker/pkg/system"
 	"github.com/pkg/errors"
@@ -15,6 +16,16 @@ import (
 
 func (daemon *Daemon) setupLinkedContainers(ctr *container.Container) ([]string, error) {
 	return nil, nil
+}
+
+func (daemon *Daemon) addLegacyLinks(
+	ctx context.Context,
+	cfg *config.Config,
+	ctr *container.Container,
+	epConfig *network.EndpointSettings,
+	sb *libnetwork.Sandbox,
+) error {
+	return nil
 }
 
 func (daemon *Daemon) setupConfigDir(ctr *container.Container) (setupErr error) {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -473,7 +473,7 @@ func (daemon *Daemon) restore(cfg *configStore) error {
 
 				c.ResetRestartManager(false)
 				if !c.HostConfig.NetworkMode.IsContainer() && c.IsRunning() {
-					options, err := daemon.buildSandboxOptions(&cfg.Config, c)
+					options, err := buildSandboxOptions(&cfg.Config, c)
 					if err != nil {
 						logger(c).WithError(err).Warn("failed to build sandbox option to restore container")
 					}

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -916,6 +916,13 @@ func buildCreateEndpointOptions(c *container.Container, n *libnetwork.Network, e
 
 	createOptions = append(createOptions, libnetwork.EndpointOptionGeneric(genericOptions))
 
+	// IPv6 may be enabled on the network, but disabled in the container.
+	if n.IPv6Enabled() {
+		if sbIPv6, ok := sb.IPv6Enabled(); ok && !sbIPv6 {
+			createOptions = append(createOptions, libnetwork.CreateOptionDisableIPv6())
+		}
+	}
+
 	return createOptions, nil
 }
 

--- a/daemon/start_linux.go
+++ b/daemon/start_linux.go
@@ -2,6 +2,7 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
@@ -24,7 +25,9 @@ func (daemon *Daemon) initializeCreatedTask(ctx context.Context, tsk types.Task,
 			if err != nil {
 				return errdefs.System(err)
 			}
-			return sb.FinishConfig(ctx)
+			if err := sb.SetKey(ctx, fmt.Sprintf("/proc/%d/ns/net", tsk.Pid())); err != nil {
+				return errdefs.System(err)
+			}
 		}
 	}
 	return nil

--- a/daemon/start_linux.go
+++ b/daemon/start_linux.go
@@ -5,30 +5,34 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libcontainerd/types"
 	"github.com/docker/docker/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"go.opentelemetry.io/otel"
 )
 
 // initializeCreatedTask performs any initialization that needs to be done to
 // prepare a freshly-created task to be started.
-func (daemon *Daemon) initializeCreatedTask(ctx context.Context, tsk types.Task, container *container.Container, spec *specs.Spec) error {
-	ctx, span := otel.Tracer("").Start(ctx, "daemon.initializeCreatedTask")
-	defer span.End()
-
-	if !container.Config.NetworkDisabled {
-		nspath, ok := oci.NamespacePath(spec, specs.NetworkNamespace)
-		if ok && nspath == "" { // the runtime has been instructed to create a new network namespace for tsk.
-			sb, err := daemon.netController.GetSandbox(container.ID)
-			if err != nil {
-				return errdefs.System(err)
-			}
-			if err := sb.SetKey(ctx, fmt.Sprintf("/proc/%d/ns/net", tsk.Pid())); err != nil {
-				return errdefs.System(err)
-			}
+func (daemon *Daemon) initializeCreatedTask(
+	ctx context.Context,
+	cfg *config.Config,
+	tsk types.Task,
+	ctr *container.Container,
+	spec *specs.Spec,
+) error {
+	if ctr.Config.NetworkDisabled {
+		return nil
+	}
+	nspath, ok := oci.NamespacePath(spec, specs.NetworkNamespace)
+	if ok && nspath == "" { // the runtime has been instructed to create a new network namespace for tsk.
+		sb, err := daemon.netController.GetSandbox(ctr.ID)
+		if err != nil {
+			return errdefs.System(err)
+		}
+		if err := sb.SetKey(ctx, fmt.Sprintf("/proc/%d/ns/net", tsk.Pid())); err != nil {
+			return errdefs.System(err)
 		}
 	}
-	return nil
+	return daemon.allocateNetwork(ctx, cfg, ctr)
 }

--- a/daemon/start_notlinux.go
+++ b/daemon/start_notlinux.go
@@ -6,12 +6,13 @@ import (
 	"context"
 
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/libcontainerd/types"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // initializeCreatedTask performs any initialization that needs to be done to
 // prepare a freshly-created task to be started.
-func (daemon *Daemon) initializeCreatedTask(ctx context.Context, tsk types.Task, container *container.Container, spec *specs.Spec) error {
+func (daemon *Daemon) initializeCreatedTask(ctx context.Context, cfg *config.Config, tsk types.Task, container *container.Container, spec *specs.Spec) error {
 	return nil
 }

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -1522,6 +1522,15 @@ func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
 	return nil
 }
 
+func LegacyContainerLinkOptions(parentEndpoints, childEndpoints []string) map[string]interface{} {
+	return options.Generic{
+		netlabel.GenericData: options.Generic{
+			"ParentEndpoints": parentEndpoints,
+			"ChildEndpoints":  childEndpoints,
+		},
+	}
+}
+
 func (d *driver) link(network *bridgeNetwork, endpoint *bridgeEndpoint, enable bool) (retErr error) {
 	cc := endpoint.containerConfig
 	ec := endpoint.extConnConfig

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -1192,27 +1192,30 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 		return fmt.Errorf("could not set link up for host interface %s: %v", hostIfName, err)
 	}
 
+	// Generate a MAC-address-based IPv6 address, which may be used by the default
+	// bridge network instead of an IPAM allocated address.
 	if endpoint.addrv6 == nil && config.EnableIPv6 {
 		var ip6 net.IP
 		network := n.bridge.bridgeIPv6
 		if config.AddressIPv6 != nil {
 			network = config.AddressIPv6
 		}
+		// If there are fewer than 48 host-bits in the network, it's not possible to
+		// generate an IPv6 address from the MAC address. The network size has already
+		// been checked, so we can safely assume this endpoint must not need a MAC-based
+		// IPv6 address.
 		ones, _ := network.Mask.Size()
-		if ones > 80 {
-			err = types.ForbiddenErrorf("Cannot self generate an IPv6 address on network %v: At least 48 host bits are needed.", network)
-			return err
-		}
+		if ones <= 80 {
+			ip6 = make(net.IP, len(network.IP))
+			copy(ip6, network.IP)
+			for i, h := range endpoint.macAddress {
+				ip6[i+10] = h
+			}
 
-		ip6 = make(net.IP, len(network.IP))
-		copy(ip6, network.IP)
-		for i, h := range endpoint.macAddress {
-			ip6[i+10] = h
-		}
-
-		endpoint.addrv6 = &net.IPNet{IP: ip6, Mask: network.Mask}
-		if err = ifInfo.SetIPAddress(endpoint.addrv6); err != nil {
-			return err
+			endpoint.addrv6 = &net.IPNet{IP: ip6, Mask: network.Mask}
+			if err = ifInfo.SetIPAddress(endpoint.addrv6); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/libnetwork/drivers/macvlan/macvlan_joinleave.go
+++ b/libnetwork/drivers/macvlan/macvlan_joinleave.go
@@ -67,7 +67,7 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 				ep.addr.IP.String(), v4gw.String(), n.config.MacvlanMode, n.config.Parent)
 		}
 		// parse and match the endpoint address with the available v6 subnets
-		if len(n.config.Ipv6Subnets) > 0 {
+		if ep.addrv6 != nil && len(n.config.Ipv6Subnets) > 0 {
 			s := n.getSubnetforIPv6(ep.addrv6)
 			if s == nil {
 				return fmt.Errorf("could not find a valid ipv6 subnet for endpoint %s", eid)

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1963,9 +1963,11 @@ func (n *Network) hasLoadBalancerEndpoint() bool {
 	return len(n.loadBalancerIP) != 0
 }
 
+// ResolveName looks up addresses of ipType for name req.
+// Returns (addresses, true) if req is found, but len(addresses) may be 0 if
+// there are no addresses of ipType. If the name is not found, the bool return
+// will be false.
 func (n *Network) ResolveName(ctx context.Context, req string, ipType int) ([]net.IP, bool) {
-	var ipv6Miss bool
-
 	c := n.getController()
 	networkID := n.ID()
 
@@ -1979,39 +1981,33 @@ func (n *Network) ResolveName(ctx context.Context, req string, ipType int) ([]ne
 	// TODO(aker): release the lock earlier
 	defer c.mu.Unlock()
 	sr, ok := c.svcRecords[networkID]
-
 	if !ok {
 		return nil, false
 	}
 
 	req = strings.TrimSuffix(req, ".")
 	req = strings.ToLower(req)
-	ipSet, ok := sr.svcMap.Get(req)
 
+	ipSet, ok4 := sr.svcMap.Get(req)
+	ipSet6, ok6 := sr.svcIPv6Map.Get(req)
+	if !ok4 && !ok6 {
+		// No result for v4 or v6, the name doesn't exist.
+		return nil, false
+	}
 	if ipType == types.IPv6 {
-		// If the name resolved to v4 addresses then it's a valid name in the docker
-		// network domain. If there is no v6 address, because the network or the
-		// container is not v6 enabled, set ipv6Miss to stop the DNS query from going to
-		// external nameservers.
-		ipv6Miss = ok
-		ipSet, ok = sr.svcIPv6Map.Get(req)
+		ipSet = ipSet6
 	}
 
-	if ok && len(ipSet) > 0 {
-		// this map is to avoid IP duplicates, this can happen during a transition period where 2 services are using the same IP
-		noDup := make(map[string]bool)
-		var ipLocal []net.IP
-		for _, ip := range ipSet {
-			if _, dup := noDup[ip.ip]; !dup {
-				noDup[ip.ip] = true
-				ipLocal = append(ipLocal, net.ParseIP(ip.ip))
-			}
+	// this map is to avoid IP duplicates, this can happen during a transition period where 2 services are using the same IP
+	noDup := make(map[string]bool)
+	var ipLocal []net.IP
+	for _, ip := range ipSet {
+		if _, dup := noDup[ip.ip]; !dup {
+			noDup[ip.ip] = true
+			ipLocal = append(ipLocal, net.ParseIP(ip.ip))
 		}
-		// TODO(robmry) - the bool return is 'ipv6Miss', it should be 'false' here.
-		return ipLocal, ok
 	}
-
-	return nil, ipv6Miss
+	return ipLocal, true
 }
 
 func (n *Network) HandleQueryResp(name string, ip net.IP) {

--- a/libnetwork/resolver_test.go
+++ b/libnetwork/resolver_test.go
@@ -246,7 +246,7 @@ func (w tlogWriter) Write(p []byte) (n int, err error) {
 
 type noopDNSBackend struct{ DNSBackend }
 
-func (noopDNSBackend) ResolveName(_ context.Context, name string, iplen int) ([]net.IP, bool) {
+func (noopDNSBackend) ResolveName(_ context.Context, name string, ipType int) ([]net.IP, bool) {
 	return nil, false
 }
 

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -67,13 +67,6 @@ type hostsPathConfig struct {
 	hostsPath       string
 	originHostsPath string
 	extraHosts      []extraHost
-	parentUpdates   []parentUpdate
-}
-
-type parentUpdate struct {
-	cid  string
-	name string
-	ip   string
 }
 
 type extraHost struct {
@@ -271,6 +264,15 @@ func (sb *Sandbox) Refresh(ctx context.Context, options ...SandboxOption) error 
 	}
 
 	return nil
+}
+
+func (sb *Sandbox) UpdateLabels(labels map[string]interface{}) {
+	if sb.config.generic == nil {
+		sb.config.generic = make(map[string]interface{}, len(labels))
+	}
+	for k, v := range labels {
+		sb.config.generic[k] = v
+	}
 }
 
 func (sb *Sandbox) MarshalJSON() ([]byte, error) {

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -440,27 +440,18 @@ func (sb *Sandbox) ResolveName(ctx context.Context, name string, ipType int) ([]
 
 	for i := 0; i < len(reqName); i++ {
 		// First check for local container alias
-		ip, ipv6Miss := sb.resolveName(ctx, reqName[i], networkName[i], epList, true, ipType)
-		if ip != nil {
-			return ip, false
+		if ip, ok := sb.resolveName(ctx, reqName[i], networkName[i], epList, true, ipType); ok {
+			return ip, true
 		}
-		if ipv6Miss {
-			return ip, ipv6Miss
-		}
-
 		// Resolve the actual container name
-		ip, ipv6Miss = sb.resolveName(ctx, reqName[i], networkName[i], epList, false, ipType)
-		if ip != nil {
-			return ip, false
-		}
-		if ipv6Miss {
-			return ip, ipv6Miss
+		if ip, ok := sb.resolveName(ctx, reqName[i], networkName[i], epList, false, ipType); ok {
+			return ip, true
 		}
 	}
 	return nil, false
 }
 
-func (sb *Sandbox) resolveName(ctx context.Context, nameOrAlias string, networkName string, epList []*Endpoint, lookupAlias bool, ipType int) (_ []net.IP, ipv6Miss bool) {
+func (sb *Sandbox) resolveName(ctx context.Context, nameOrAlias string, networkName string, epList []*Endpoint, lookupAlias bool, ipType int) ([]net.IP, bool) {
 	ctx, span := otel.Tracer("").Start(ctx, "Sandbox.resolveName", trace.WithAttributes(
 		attribute.String("libnet.resolver.name-or-alias", nameOrAlias),
 		attribute.String("libnet.network.name", networkName),
@@ -498,15 +489,12 @@ func (sb *Sandbox) resolveName(ctx context.Context, nameOrAlias string, networkN
 			}
 		}
 
-		ip, miss := nw.ResolveName(ctx, name, ipType)
-		if ip != nil {
-			return ip, false
-		}
-		if miss {
-			ipv6Miss = miss
+		ip, ok := nw.ResolveName(ctx, name, ipType)
+		if ok {
+			return ip, true
 		}
 	}
-	return nil, ipv6Miss
+	return nil, false
 }
 
 // hasExternalAccess returns true if any of sb's Endpoints appear to have external

--- a/libnetwork/sandbox_dns_unix.go
+++ b/libnetwork/sandbox_dns_unix.go
@@ -28,10 +28,24 @@ const (
 	resolverIPSandbox = "127.0.0.11"
 )
 
-// finishInitDNS is to be called after the container namespace has been created,
-// before it the user process is started. The container's support for IPv6 can be
-// determined at this point.
-func (sb *Sandbox) finishInitDNS(ctx context.Context) error {
+// AddHostsEntry adds an entry to /etc/hosts.
+func (sb *Sandbox) AddHostsEntry(ctx context.Context, name, ip string) error {
+	sb.config.extraHosts = append(sb.config.extraHosts, extraHost{name: name, IP: ip})
+	return sb.rebuildHostsFile(ctx)
+}
+
+// UpdateHostsEntry updates the IP address in a /etc/hosts entry where the
+// name matches the regular expression regexp.
+func (sb *Sandbox) UpdateHostsEntry(regexp, ip string) error {
+	return etchosts.Update(sb.config.hostsPath, ip, regexp)
+}
+
+// rebuildHostsFile builds the container's /etc/hosts file, based on the current
+// state of the Sandbox (including extra hosts). If called after the container
+// namespace has been created, before the user process is started, the container's
+// support for IPv6 can be determined and IPv6 hosts will be included/excluded
+// accordingly.
+func (sb *Sandbox) rebuildHostsFile(ctx context.Context) error {
 	if err := sb.buildHostsFile(); err != nil {
 		return errdefs.System(err)
 	}
@@ -134,7 +148,7 @@ func (sb *Sandbox) buildHostsFile() error {
 		return err
 	}
 
-	return sb.updateParentHosts()
+	return nil
 }
 
 func (sb *Sandbox) updateHostsFile(ctx context.Context, ifaceIPs []string) error {
@@ -190,35 +204,6 @@ func (sb *Sandbox) deleteHostsEntries(recs []etchosts.Record) {
 	if err := etchosts.Delete(sb.config.hostsPath, recs); err != nil {
 		log.G(context.TODO()).Warnf("Failed deleting service host entries to the running container: %v", err)
 	}
-}
-
-func (sb *Sandbox) updateParentHosts() error {
-	var pSb *Sandbox
-
-	for _, update := range sb.config.parentUpdates {
-		// TODO(thaJeztah): was it intentional for this loop to re-use prior results of pSB? If not, we should make pSb local and always replace here.
-		if s, _ := sb.controller.GetSandbox(update.cid); s != nil {
-			pSb = s
-		}
-		if pSb == nil {
-			continue
-		}
-		// TODO(robmry) - filter out IPv6 addresses here if !sb.ipv6Enabled() but...
-		// - this is part of the implementation of '--link', which will be removed along
-		//   with the rest of legacy networking.
-		// - IPv6 addresses shouldn't be allocated if IPv6 is not available in a container,
-		//   and that change will come along later.
-		// - I think this may be dead code, it's not possible to start a parent container with
-		//   '--link child' unless the child has already started ("Error response from daemon:
-		//   Cannot link to a non running container"). So, when the child starts and this method
-		//   is called with updates for parents, the parents aren't running and GetSandbox()
-		//   returns nil.)
-		if err := etchosts.Update(pSb.config.hostsPath, update.ip, update.name); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func (sb *Sandbox) restoreResolvConfPath() {

--- a/libnetwork/sandbox_dns_unix.go
+++ b/libnetwork/sandbox_dns_unix.go
@@ -141,7 +141,7 @@ func (sb *Sandbox) buildHostsFile() error {
 
 	// Assume IPv6 support, unless it's definitely disabled.
 	buildf := etchosts.Build
-	if en, ok := sb.ipv6Enabled(); ok && !en {
+	if en, ok := sb.IPv6Enabled(); ok && !en {
 		buildf = etchosts.BuildNoIPv6
 	}
 	if err := buildf(sb.config.hostsPath, extraContent); err != nil {
@@ -186,7 +186,7 @@ func (sb *Sandbox) updateHostsFile(ctx context.Context, ifaceIPs []string) error
 
 func (sb *Sandbox) addHostsEntries(recs []etchosts.Record) {
 	// Assume IPv6 support, unless it's definitely disabled.
-	if en, ok := sb.ipv6Enabled(); ok && !en {
+	if en, ok := sb.IPv6Enabled(); ok && !en {
 		var filtered []etchosts.Record
 		for _, rec := range recs {
 			if addr, err := netip.ParseAddr(rec.IP); err == nil && !addr.Is6() {

--- a/libnetwork/sandbox_linux.go
+++ b/libnetwork/sandbox_linux.go
@@ -96,8 +96,12 @@ func (sb *Sandbox) updateGateway(ep *Endpoint) error {
 		return fmt.Errorf("failed to set gateway while updating gateway: %v", err)
 	}
 
-	if err := osSbox.SetGatewayIPv6(joinInfo.gw6); err != nil {
-		return fmt.Errorf("failed to set IPv6 gateway while updating gateway: %v", err)
+	// If IPv6 has been disabled in the sandbox a gateway may still have been
+	// configured, don't attempt to apply it.
+	if ipv6, _ := sb.ipv6Enabled(); ipv6 {
+		if err := osSbox.SetGatewayIPv6(joinInfo.gw6); err != nil {
+			return fmt.Errorf("failed to set IPv6 gateway while updating gateway: %v", err)
+		}
 	}
 
 	return nil
@@ -164,10 +168,8 @@ func (sb *Sandbox) SetKey(ctx context.Context, basePath string) error {
 		}
 	}
 
-	// Set up hosts and resolv.conf files. IPv6 support in the container can't be
-	// determined yet, as sysctls haven't been applied by the runtime. Calling
-	// FinishInit after the container task has been created, when sysctls have been
-	// applied will regenerate these files.
+	// Set up hosts and resolv.conf files.
+	osSbox.RefreshIPv6LoEnabled()
 	if err := sb.finishInitDNS(ctx); err != nil {
 		return err
 	}
@@ -179,27 +181,6 @@ func (sb *Sandbox) SetKey(ctx context.Context, basePath string) error {
 	}
 
 	return nil
-}
-
-// FinishConfig completes Sandbox configuration. If called after the container task has been
-// created, and sysctl settings applied, the configuration will be based on the container's
-// IPv6 support.
-func (sb *Sandbox) FinishConfig(ctx context.Context) error {
-	if sb.config.useDefaultSandBox {
-		return nil
-	}
-
-	sb.mu.Lock()
-	osSbox := sb.osSbox
-	sb.mu.Unlock()
-	if osSbox == nil {
-		return nil
-	}
-
-	// If sysctl changes have been made, IPv6 may have been enabled/disabled since last checked.
-	osSbox.RefreshIPv6LoEnabled()
-
-	return sb.finishInitDNS(ctx)
 }
 
 // IPv6 support can always be determined for host networking. For other network
@@ -314,7 +295,12 @@ func (sb *Sandbox) populateNetworkResources(ctx context.Context, ep *Endpoint) e
 
 		ifaceOptions = append(ifaceOptions, osl.WithIPv4Address(i.addr), osl.WithRoutes(i.routes))
 		if i.addrv6 != nil && i.addrv6.IP.To16() != nil {
-			ifaceOptions = append(ifaceOptions, osl.WithIPv6Address(i.addrv6))
+			// If IPv6 has been disabled in the Sandbox, an IPv6 address will still have
+			// been allocated. Don't apply it, because doing so would enable IPv6 on the
+			// interface.
+			if ipv6, ok := sb.ipv6Enabled(); !ok || ipv6 {
+				ifaceOptions = append(ifaceOptions, osl.WithIPv6Address(i.addrv6))
+			}
 		}
 		if len(i.llAddrs) != 0 {
 			ifaceOptions = append(ifaceOptions, osl.WithLinkLocalAddresses(i.llAddrs))

--- a/libnetwork/sandbox_linux.go
+++ b/libnetwork/sandbox_linux.go
@@ -168,9 +168,8 @@ func (sb *Sandbox) SetKey(ctx context.Context, basePath string) error {
 		}
 	}
 
-	// Set up hosts and resolv.conf files.
 	osSbox.RefreshIPv6LoEnabled()
-	if err := sb.finishInitDNS(ctx); err != nil {
+	if err := sb.rebuildHostsFile(ctx); err != nil {
 		return err
 	}
 

--- a/libnetwork/sandbox_options.go
+++ b/libnetwork/sandbox_options.go
@@ -46,14 +46,6 @@ func OptionExtraHost(name string, IP string) SandboxOption {
 	}
 }
 
-// OptionParentUpdate function returns an option setter for parent container
-// which needs to update the IP address for the linked container.
-func OptionParentUpdate(cid string, name, ip string) SandboxOption {
-	return func(sb *Sandbox) {
-		sb.config.parentUpdates = append(sb.config.parentUpdates, parentUpdate{cid: cid, name: name, ip: ip})
-	}
-}
-
 // OptionResolvConfPath function returns an option setter for resolvconfpath option to
 // be passed to net container methods.
 func OptionResolvConfPath(path string) SandboxOption {
@@ -107,20 +99,6 @@ func OptionUseDefaultSandbox() SandboxOption {
 func OptionUseExternalKey() SandboxOption {
 	return func(sb *Sandbox) {
 		sb.config.useExternalKey = true
-	}
-}
-
-// OptionGeneric function returns an option setter for Generic configuration
-// that is not managed by libNetwork but can be used by the Drivers during the call to
-// net container creation method. Container Labels are a good example.
-func OptionGeneric(generic map[string]interface{}) SandboxOption {
-	return func(sb *Sandbox) {
-		if sb.config.generic == nil {
-			sb.config.generic = make(map[string]interface{}, len(generic))
-		}
-		for k, v := range generic {
-			sb.config.generic[k] = v
-		}
 	}
 }
 

--- a/libnetwork/sandbox_windows.go
+++ b/libnetwork/sandbox_windows.go
@@ -32,3 +32,9 @@ func (sb *Sandbox) populateNetworkResources(context.Context, *Endpoint) error {
 	// not implemented on Windows (Sandbox.osSbox is always nil)
 	return nil
 }
+
+// IPv6Enabled always returns false on Windows as None of the Windows container
+// network drivers currently support IPv6.
+func (sb *Sandbox) IPv6Enabled() (enabled, ok bool) {
+	return false, true
+}


### PR DESCRIPTION
**- What I did**

If IPv6 is disabled for a container, do not allocate an IPv6 address when it's attached to an IPv6 network.

- Fix https://github.com/moby/moby/issues/47055

**- How I did it**

There are a few commits - it's probably easiest to review them separately ...

_**Unconditionally update container.NetworkSettings**_

 In `daemon.allocateNetwork()`, flag `updateSettings` was set if `container.NetworkSettings.Networks` was empty. That flag was passed down through the call stack to avoid a call to `daemon.updateNetworkSettings()` in `daemon.updateNetworkConfig()`.

Other calls to `daemon.updateNetworkSettings()`, which happen when connecting an existing container to another network, unconditionally made the NetworkSettings update.

I don't think there's a circumstance where NetworkSettings is not empty during container creation. Even if there is, the update is harmless and cheap. Eliminating the `updateSettings` flag simplifies the code a little and, in the next commit where `allocateNetwork()` is split out of `initializeNetworking()`, it avoids the need to pass that flag between the two.

_**Separate Sandbox/Endpoint construction**_

Previously, the `libnetwork.Sandbox` was created in `daemon.allocateNetwork()` if there was no network - otherwise it happened while connecting an Endpoint in `daemon.connectToNetwork()`. If there was an endpoint in the default bridge, it had to be connected first, because extra configuration is needed in the Sandbox for legacy links and that could only happen during Sandbox construction.

Now, config for legacy links is added to the Sandbox when constructing the Endpoint that needs it - removing the constraint on ordering of Endpoint construction, and the dependency between Endpoint and Sandbox construction.

So, now a Sandbox can be constructed in one place, before the first Endpoint.

Also, replaces some legacy-link specific Sandbox option-setters with Sandbox methods for updating `/etc/hosts`, and updates a legacy-link parent's IPv6 address as well as its IPv4 address when a child container restarts.

_**Configure network endpoints after creating a container**_

This commit splits the bulk of `daemon.allocateNetwork()` out of `daemon.initializeNetworking()`.

`daemon.initializeNetworking()` hasn't moved, but it now only prepares configuration and doesn't do any Endpoint construction or configuration. Sandbox construction still happens here.

Endpoint construction is in `daemon.allocateNetwork()` which, on non-Windows, is called after the container task has been created (before it's started).

On Windows, Endpoint construction still happens before the container task is created. If it's created afterwards, some DNS lookups for the container don't seem to end up in our resolver - see the TODO comment in the code. (But, Windows can't benefit from the delayed assignment of IPv6 addresses anyway.)

Doing the Endpoint construction after the `osSbox` has been set up makes it possible to probe the container's network for IPv6 support first - enabling the next commit ...

_**Only assign IPv6 addresses if required**_

If a Sandbox is provided to `CreateEndpointForSandbox`, check whether it has IPv6 before allocating IPv6 addresses.

Because no IPv6 address is added to the DNS when the Sandbox doesn't support it, a lookup for a container on an IPv6 network can now have no IPv6 address. The resolver is updated to treat a missing IPv6 address on an IPv4 hit as `ipv6miss` even if the network has IPv6 enabled. (So, an empty DNS response is returned, avoiding the upstream DNS request and NXDOMAIN.)

The `macvlan` driver expected an endpoint on a network with IPv6 subnets to have an IPv6 address - it searched the subnets for the address assigned to the endpoint, to work out which gateway address to use (crashing if there was no address). Now, it only makes that search if there is an IPv6 address.

**- How to verify it**

Existing regression tests for the refactoring.

New integration test checks that a container with IPv6 disabled via `sysctl` on an IPv6 network has no IPv6 address.

**- Description for the changelog**

If IPv6 is disabled for a container, do not allocate an IPv6 address when it's attached to an IPv6 network.