### PR TITLE
project: Add `impact/vendor` label

### DIFF
--- a/project/REVIEWING.md
+++ b/project/REVIEWING.md
@@ -36,6 +36,7 @@ Special status labels:
  * `impact/deprecation`
  * `impact/distribution`
  * `impact/dockerfile`
+ * `impact/vendor`
 
 ### Process labels (apply to merged pull requests)
 
@@ -186,6 +187,7 @@ to ease future classification:
  * `impact/cli` signifies the patch impacted a CLI command
  * `impact/dockerfile` signifies the patch impacted the Dockerfile syntax
  * `impact/deprecation` signifies the patch participates in deprecating an existing feature
+ * `impact/vendor` signifies the patch updated a vendored package
 
 ### Close
 


### PR DESCRIPTION
This is a proposal to add `impact/vendor` PR label that we would use to mark PRs that impact the vendored files (updating packages, and optionally when adding a new direct dependency).

