### PR TITLE
ci: Require changelog description

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,9 +22,12 @@ Please provide the following information:
 **- Description for the changelog**
 <!--
 Write a short (one line) summary that describes the changes in this
-pull request for inclusion in the changelog:
+pull request for inclusion in the changelog.
+It must be placed inside the below triple backticks section:
 -->
+```markdown changelog
 
+```
 
 **- A picture of a cute animal (not mandatory but encouraged)**
 

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,0 +1,46 @@
+name: validate-pr
+
+on:
+  pull_request:
+    types: [opened, edited, labeled, unlabeled]
+
+jobs:
+  check-area-label:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Missing `area/` label
+        if: contains(join(github.event.pull_request.labels.*.name, ','), 'impact/') && !contains(join(github.event.pull_request.labels.*.name, ','), 'area/')
+        run: |
+          echo "Every PR with an \`impact/*\` label should also have an \`area/*\` label"
+          exit 1
+      - name: OK
+        run: exit 0
+
+  check-changelog:
+    if: contains(join(github.event.pull_request.labels.*.name, ','), 'impact/')
+    runs-on: ubuntu-20.04
+    env:
+      PR_BODY: |
+        ${{ github.event.pull_request.body }}
+    steps:
+      - name: Check changelog description
+        run: |
+          # Extract the `markdown changelog` note code block
+          block=$(echo -n "$PR_BODY" | tr -d '\r' | awk '/^```markdown changelog$/{flag=1;next}/^```$/{flag=0}flag')
+
+          # Strip empty lines
+          desc=$(echo "$block" |  awk NF)
+
+          if [ -z "$desc" ]; then
+            echo "Changelog section is empty. Please provide a description for the changelog."
+            exit 1
+          fi
+
+          len=$(echo -n "$desc" | wc -c)
+          if [[ $len -le 6 ]]; then
+            echo "Description looks too short: $desc"
+            exit 1
+          fi
+
+          echo "This PR will be included in the release notes with the following note:"
+          echo "$desc"


### PR DESCRIPTION
Any PR that is labeled with any `impact/*` label should have a description for the changelog and an `area/*` label.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"
Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```markdown changelog
```

**- A picture of a cute animal (not mandatory but encouraged)**

