### PR TITLE
ci/actions/go-setup: Use `vendor.sum` as `go.sum`

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   GO_VERSION: "1.21.7"
+  GO_SUM_PATH: "vendor.sum"
   GOTESTLIST_VERSION: v0.3.1
   TESTSTAT_VERSION: v0.1.3
   ITG_CLI_MATRIX_SIZE: 6
@@ -83,6 +84,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v5
         with:
+          cache-dependency-path: ${{ env.GO_SUM_PATH }}
           go-version: ${{ env.GO_VERSION }}
       -
         name: Download reports
@@ -284,6 +286,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v5
         with:
+          cache-dependency-path: ${{ env.GO_SUM_PATH }}
           go-version: ${{ env.GO_VERSION }}
       -
         name: Download reports
@@ -314,6 +317,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v5
         with:
+          cache-dependency-path: ${{ env.GO_SUM_PATH }}
           go-version: ${{ env.GO_VERSION }}
       -
         name: Install gotestlist
@@ -423,6 +427,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v5
         with:
+          cache-dependency-path: ${{ env.GO_SUM_PATH }}
           go-version: ${{ env.GO_VERSION }}
       -
         name: Download reports

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -20,6 +20,7 @@ on:
 
 env:
   GO_VERSION: "1.21.7"
+  GO_SUM_PATH: "vendor.sum"
   GOTESTLIST_VERSION: v0.3.1
   TESTSTAT_VERSION: v0.1.3
   WINDOWS_BASE_IMAGE: mcr.microsoft.com/windows/servercore
@@ -201,6 +202,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v5
         with:
+          cache-dependency-path: ${{ env.GO_SUM_PATH }}
           go-version: ${{ env.GO_VERSION }}
       -
         name: Download artifacts
@@ -229,6 +231,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v5
         with:
+          cache-dependency-path: ${{ env.GO_SUM_PATH }}
           go-version: ${{ env.GO_VERSION }}
       -
         name: Install gotestlist
@@ -427,6 +430,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v5
         with:
+          cache-dependency-path: ${{ env.GO_SUM_PATH }}
           go-version: ${{ env.GO_VERSION }}
       -
         name: Test integration
@@ -531,6 +535,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v5
         with:
+          cache-dependency-path: ${{ env.GO_SUM_PATH }}
           go-version: ${{ env.GO_VERSION }}
       -
         name: Download reports


### PR DESCRIPTION
actions/go-setup tries to restore the go cache, but expects to read the `go.sum` which we don't have:
```
Run actions/setup-go@v5
...
Found in cache @ /opt/hostedtoolcache/go/1.21.7/x64
...
/opt/hostedtoolcache/go/1.21.7/x64/bin/go env GOMODCACHE
/opt/hostedtoolcache/go/1.21.7/x64/bin/go env GOCACHE
/home/runner/go/pkg/mod
/home/runner/.cache/go-build
Warning: Restore cache failed: Dependencies file is not found in /home/runner/work/moby/moby. Supported file pattern: go.sum
```

Make it use `vendor.sum` instead.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

