### PR TITLE
api/image-inspect: Remove Container and ContainerConfig

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -306,6 +306,10 @@ func (ir *imageRouter) getImagesByName(ctx context.Context, w http.ResponseWrite
 			imageInspect.Created = time.Time{}.Format(time.RFC3339Nano)
 		}
 	}
+	if versions.GreaterThanOrEqualTo(version, "1.45") {
+		imageInspect.Container = ""        //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.45.
+		imageInspect.ContainerConfig = nil //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.45.
+	}
 	return httputils.WriteJSON(w, http.StatusOK, imageInspect)
 }
 

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -82,7 +82,7 @@ type ImageInspect struct {
 	// Depending on how the image was created, this field may be empty.
 	//
 	// Deprecated: this field is omitted in API v1.45, but kept for backward compatibility.
-	Container string
+	Container string `json:",omitempty"`
 
 	// ContainerConfig is an optional field containing the configuration of the
 	// container that was last committed when creating the image.
@@ -91,7 +91,7 @@ type ImageInspect struct {
 	// and it is not in active use anymore.
 	//
 	// Deprecated: this field is omitted in API v1.45, but kept for backward compatibility.
-	ContainerConfig *container.Config
+	ContainerConfig *container.Config `json:",omitempty"`
 
 	// DockerVersion is the version of Docker that was used to build the image.
 	//

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -22,6 +22,9 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `POST /images/search` will always assume a `false` value for the `is-automated`
   field. Consequently, searching for `is-automated=true` will yield no results,
   while `is-automated=false` will be a no-op.
+* `GET /images/{name}/json` no longer includes the `Container` and
+  `ContainerConfig` fields. To access image configuration, use `Config` field
+  instead.
 
 ## v1.44 API changes
 

--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -19,11 +19,11 @@ source hack/make/.integration-test-helpers
 # build --squash is not supported with containerd integration.
 if [ -n "$TEST_INTEGRATION_USE_SNAPSHOTTER" ]; then
 	PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/api_build_test.py::BuildTest::test_build_squash"
-
-	# TODO(vvoland): re-enable after https://github.com/docker/docker-py/pull/3203 is merged and in a tagged release.
-	PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/api_image_test.py::CommitTest::test_commit"
-	PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/api_image_test.py::CommitTest::test_commit_with_changes"
 fi
+
+# TODO(vvoland): re-enable after https://github.com/docker/docker-py/pull/3203 is included in the DOCKER_PY_COMMIT release.
+PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/api_image_test.py::CommitTest::test_commit"
+PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/api_image_test.py::CommitTest::test_commit_with_changes"
 (
 	bundle .integration-daemon-start
 


### PR DESCRIPTION
- related to: https://github.com/moby/moby/pull/47092

- related to: https://github.com/moby/moby/pull/46939
- related to: https://github.com/docker/cli/pull/4893

Don't include these fields starting from API v1.45.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```markdown changelog
Remove `Container` and `ContainerConfig` fields from the `GET /images/{name}/json` response.
```


**- A picture of a cute animal (not mandatory but encouraged)**

