### PR TITLE
api: normalize the default NetworkMode

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -658,7 +658,7 @@ func handleMACAddressBC(config *container.Config, hostConfig *container.HostConf
 			}
 			return "", nil
 		}
-		if !hostConfig.NetworkMode.IsDefault() && !hostConfig.NetworkMode.IsBridge() && !hostConfig.NetworkMode.IsUserDefined() {
+		if !hostConfig.NetworkMode.IsBridge() && !hostConfig.NetworkMode.IsUserDefined() {
 			return "", runconfig.ErrConflictContainerNetworkAndMac
 		}
 
@@ -687,7 +687,7 @@ func handleMACAddressBC(config *container.Config, hostConfig *container.HostConf
 		return "", nil
 	}
 	var warning string
-	if hostConfig.NetworkMode.IsDefault() || hostConfig.NetworkMode.IsBridge() || hostConfig.NetworkMode.IsUserDefined() {
+	if hostConfig.NetworkMode.IsBridge() || hostConfig.NetworkMode.IsUserDefined() {
 		nwName := hostConfig.NetworkMode.NetworkName()
 		// If there's no endpoint config, create a place to store the configured address.
 		if len(networkingConfig.EndpointsConfig) == 0 {

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -456,14 +456,26 @@ func (s *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 	if hostConfig == nil {
 		hostConfig = &container.HostConfig{}
 	}
-	if hostConfig.NetworkMode == "" {
-		hostConfig.NetworkMode = "default"
-	}
 	if networkingConfig == nil {
 		networkingConfig = &network.NetworkingConfig{}
 	}
 	if networkingConfig.EndpointsConfig == nil {
 		networkingConfig.EndpointsConfig = make(map[string]*network.EndpointSettings)
+	}
+	// The NetworkMode "default" is used as a way to express a container should
+	// be attached to the OS-dependant default network, in an OS-independent
+	// way. Doing this conversion as soon as possible ensures we have less
+	// NetworkMode to handle down the path (including in the
+	// backward-compatibility layer we have just below).
+	//
+	// Note that this is not the only place where this conversion has to be
+	// done (as there are various other places where containers get created).
+	if hostConfig.NetworkMode == "" || hostConfig.NetworkMode.IsDefault() {
+		hostConfig.NetworkMode = runconfig.DefaultDaemonNetworkMode()
+		if nw, ok := networkingConfig.EndpointsConfig[network.NetworkDefault]; ok {
+			networkingConfig.EndpointsConfig[hostConfig.NetworkMode.NetworkName()] = nw
+			delete(networkingConfig.EndpointsConfig, network.NetworkDefault)
+		}
 	}
 
 	version := httputils.VersionFromContext(ctx)

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -420,9 +420,6 @@ func (daemon *Daemon) updateContainerNetworkSettings(container *container.Contai
 	}
 
 	networkName := mode.NetworkName()
-	if mode.IsDefault() {
-		networkName = daemon.netController.Config().DefaultNetwork
-	}
 
 	if mode.IsUserDefined() {
 		var err error
@@ -458,15 +455,6 @@ func (daemon *Daemon) updateContainerNetworkSettings(container *container.Contai
 		container.NetworkSettings.Networks = make(map[string]*network.EndpointSettings)
 		container.NetworkSettings.Networks[networkName] = &network.EndpointSettings{
 			EndpointSettings: &networktypes.EndpointSettings{},
-		}
-	}
-
-	// Convert any settings added by client in default name to
-	// engine's default network name key
-	if mode.IsDefault() {
-		if nConf, ok := container.NetworkSettings.Networks[mode.NetworkName()]; ok {
-			container.NetworkSettings.Networks[networkName] = nConf
-			delete(container.NetworkSettings.Networks, mode.NetworkName())
 		}
 	}
 

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -130,12 +130,8 @@ func (daemon *Daemon) getInspectData(daemonCfg *config.Config, container *contai
 	// unconditionally, to keep backward compatibility with clients that use
 	// unversioned API endpoints.
 	if container.Config != nil && container.Config.MacAddress == "" { //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
-		if nwm := hostConfig.NetworkMode; nwm.IsDefault() || nwm.IsBridge() || nwm.IsUserDefined() {
-			name := nwm.NetworkName()
-			if nwm.IsDefault() {
-				name = daemon.netController.Config().DefaultNetwork
-			}
-			if epConf, ok := container.NetworkSettings.Networks[name]; ok {
+		if nwm := hostConfig.NetworkMode; nwm.IsBridge() || nwm.IsUserDefined() {
+			if epConf, ok := container.NetworkSettings.Networks[nwm.NetworkName()]; ok {
 				container.Config.MacAddress = epConf.DesiredMacAddress //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
 			}
 		}


### PR DESCRIPTION
Related to:
- https://github.com/moby/moby/issues/19421

**- What I did**

The NetworkMode "default" is now normalized into the value it aliases ("bridge" on Linux and "nat" on Windows) by the ContainerCreate endpoint, and by the restore codepath.

Going forward, this will make maintenance easier as there's one less NetworkMode to care about.

This is purposefully done in the `api` package for a couple reasons: 1. to make sure it's done as early as possible; 2. because the `default` `NetworkMode` only exists to have cross-OS compatibility and thus is effectively just an API concern.

2nd commit remove all the calls to `NetworkMode.IsDefault()` as this is now unneeded.

**- How to verify it**

For the restore code path:

1. Start the engine with `--live-restore` without this patch applied ;
2. Create a container: `docker run -d --name c0 alpine top` ;
3. Stop the engine and apply this patch ;
4. Restart the engine ;
5. `docker inspect c0`

For the `ContainerCreate` code path: step 2. and 5. above.