### PR TITLE
c8d/pull: Progress fixes

### DIFF
--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -117,6 +117,9 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 			progress.Message(out, "", distribution.DeprecatedSchema1ImageMessage(ref))
 			sentSchema1Deprecation = true
 		}
+		if images.IsLayerType(desc.MediaType) {
+			progress.Update(out, desc.Digest.String(), "Pulling fs layer")
+		}
 		if images.IsManifestType(desc.MediaType) {
 			if !sentPullingFrom {
 				var tagOrDigest string

--- a/daemon/containerd/progress.go
+++ b/daemon/containerd/progress.go
@@ -135,6 +135,9 @@ func (p pullProgress) UpdateProgress(ctx context.Context, ongoing *jobs, out pro
 		}
 		key := remotes.MakeRefKey(ctx, j)
 		if info, ok := pulling[key]; ok {
+			if info.Offset == 0 {
+				continue
+			}
 			out.WriteProgress(progress.Progress{
 				ID:      stringid.TruncateID(j.Digest.Encoded()),
 				Action:  "Downloading",


### PR DESCRIPTION


**- What I did**
- Emit `Pulling fs layer` (fixes issue in Docker Desktop)
- Guard `io.Writer` in `progressOutput` with a mutex
- Don't emit `Downloading` when no progress was made yet 

**- How I did it**
See commits.

**- How to verify it**

**- Description for the changelog**
```markdown changelog
containerd image store: Fix image pull not emitting `Pulling fs layer` status
```

**- A picture of a cute animal (not mandatory but encouraged)**

