### PR TITLE
api: omit missing Created field from ImageInspect response

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1746,9 +1746,13 @@ definitions:
       Created:
         description: |
           Date and time at which the image was created, formatted in
-          [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds, or empty if the field was not set in the image config.
+          [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+
+          This information is only available if present in the image,
+          and omitted otherwise.
         type: "string"
-        x-nullable: false
+        format: "dateTime"
+        x-nullable: true
         example: "2022-02-04T21:20:12.497794809Z"
       Container:
         description: |

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -72,7 +72,10 @@ type ImageInspect struct {
 
 	// Created is the date and time at which the image was created, formatted in
 	// RFC 3339 nano-seconds (time.RFC3339Nano).
-	Created string
+	//
+	// This information is only available if present in the image,
+	// and omitted otherwise.
+	Created string `json:",omitempty"`
 
 	// Container is the ID of the container that was used to create the image.
 	//

--- a/docs/api/v1.44.yaml
+++ b/docs/api/v1.44.yaml
@@ -1742,9 +1742,13 @@ definitions:
       Created:
         description: |
           Date and time at which the image was created, formatted in
-          [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds, or empty if the field was not set in the image config.
+          [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+
+          This information is only available if present in the image,
+          and omitted otherwise.
         type: "string"
-        x-nullable: false
+        format: "dateTime"
+        x-nullable: true
         example: "2022-02-04T21:20:12.497794809Z"
       Container:
         description: |

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -86,9 +86,8 @@ keywords: "API, Docker, rcli, REST, documentation"
   `SecondaryIPv6Addresses` available in `NetworkSettings` when calling `GET /containers/{id}/json` are
   deprecated and will be removed in a future release. You should instead look for the default network in
   `NetworkSettings.Networks`.
-* `GET /images/{id}/json` now responds with an empty `Created` field
-  (previously it was `0001-01-01T00:00:00Z`) if the `Created` field is missing
-  from the image config.
+* `GET /images/{id}/json` omits the `Created` field (previously it was `0001-01-01T00:00:00Z`)
+  if the `Created` field is missing from the image config.
 
 ## v1.43 API changes
 


### PR DESCRIPTION
- Follow-up to https://github.com/moby/moby/pull/47374

Set the `Created` field in image inspect to `omitempty` so we don't return it when it is absent from the image config, as opposed to returning an empty string.

```markdown changelog
* api: `GET /images/{id}/json` omits the `Created` field (previously it was `0001-01-01T00:00:00Z`)
  if the `Created` field is missing from the image config.
```