### PR TITLE
c8d/pull: Output truncated id for `Pulling fs layer`

### DIFF
--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker/internal/compatcontext"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
+	"github.com/docker/docker/pkg/stringid"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
@@ -118,7 +119,8 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 			sentSchema1Deprecation = true
 		}
 		if images.IsLayerType(desc.MediaType) {
-			progress.Update(out, desc.Digest.String(), "Pulling fs layer")
+			id := stringid.TruncateID(desc.Digest.String())
+			progress.Update(out, id, "Pulling fs layer")
 		}
 		if images.IsManifestType(desc.MediaType) {
 			if !sentPullingFrom {


### PR DESCRIPTION
- follow up to: https://github.com/moby/moby/pull/47432

All other progress updates are emitted with truncated id.

```diff
$ docker pull --platform linux/amd64 alpine
Using default tag: latest
latest: Pulling from library/alpine
-sha256:4abcf20661432fb2d719aaf90656f55c287f8ca915dc1c92ec14ff61e67fbaf8: Pulling fs layer
+4abcf2066143: Download complete
Digest: sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b Status: Image is up to date for alpine:latest
docker.io/library/alpine:latest
```



**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

