### PR TITLE
libcontainerd: change the digest used when restoring

### DIFF
--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -723,7 +723,7 @@ func (c *client) writeContent(ctx context.Context, mediaType, ref string, r io.R
 	}
 	return &types.Descriptor{
 		MediaType: mediaType,
-		Digest:    writer.Digest().Encoded(),
+		Digest:    writer.Digest().String(),
 		Size:      size,
 	}, nil
 }


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/42900

For current implementation of Checkpoint Restore (C/R) in docker, it will write the checkpoint to content store. However, when restoring libcontainerd uses `.Digest().Encoded()`, which will remove the info of algorithms, leading to a NotFound error.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

For now when using C/R to start a container like:

```
docker run  --name=demo -d ubuntu sleep infinity
docker checkpoint create demo ckpt1
docker start --checkpoint ckpt1 demo
```

It will failed like:

```
Error response from daemon: failed to create task for container: content digest 4ba0864fec064b253c12a12d4a2369086d6036c3dd1ecda0239f96796181b705: not found: unknown
```

The reason is that when restoring, it query the content store with `.Digest().Encoded()`.

**- How I did it**
Change it to use `.Diegest().String()`

**- How to verify it**
```
docker run  --name=demo -d ubuntu sleep infinity
docker checkpoint create demo ckpt1
docker start --checkpoint ckpt1 demo
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix `docker start` failing when used with `--checkpoint`
```