### PR TITLE
ci: Make `find` for test reports more specific

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -97,7 +97,7 @@ jobs:
       -
         name: Create summary
         run: |
-          teststat -markdown $(find /tmp/reports -type f -name '*.json' -print0 | xargs -0) >> $GITHUB_STEP_SUMMARY
+          find /tmp/reports -type f -name '*-go-test-report.json' -exec teststat -markdown {} \+ >> $GITHUB_STEP_SUMMARY
 
   docker-py:
     runs-on: ubuntu-20.04
@@ -299,7 +299,7 @@ jobs:
       -
         name: Create summary
         run: |
-          teststat -markdown $(find /tmp/reports -type f -name '*.json' -print0 | xargs -0) >> $GITHUB_STEP_SUMMARY
+          find /tmp/reports -type f -name '*-go-test-report.json' -exec teststat -markdown {} \+ >> $GITHUB_STEP_SUMMARY
 
   integration-cli-prepare:
     runs-on: ubuntu-20.04
@@ -438,4 +438,4 @@ jobs:
       -
         name: Create summary
         run: |
-          teststat -markdown $(find /tmp/reports -type f -name '*.json' -print0 | xargs -0) >> $GITHUB_STEP_SUMMARY
+          find /tmp/reports -type f -name '*-go-test-report.json' -exec teststat -markdown {} \+ >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -215,7 +215,7 @@ jobs:
       -
         name: Create summary
         run: |
-          teststat -markdown $(find /tmp/artifacts -type f -name '*.json' -print0 | xargs -0) >> $GITHUB_STEP_SUMMARY
+          find /tmp/artifacts -type f -name '*-go-test-report.json' -exec teststat -markdown {} \+ >> $GITHUB_STEP_SUMMARY
 
   integration-test-prepare:
     runs-on: ubuntu-latest
@@ -546,4 +546,4 @@ jobs:
       -
         name: Create summary
         run: |
-          teststat -markdown $(find /tmp/reports -type f -name '*.json' -print0 | xargs -0) >> $GITHUB_STEP_SUMMARY
+          find /tmp/reports -type f -name '*-go-test-report.json' -exec teststat -markdown {} \+ >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Don't use all `*.json` files blindly, take only these that are likely to be reports from go test.

An attempt to prevent https://github.com/moby/moby/actions/runs/8064122892/job/22029045229?pr=47395 from happening


**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

