### PR TITLE
disable pulling legacy image formats by default

### DIFF
--- a/api/server/router/distribution/distribution_routes.go
+++ b/api/server/router/distribution/distribution_routes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"os"
 
 	"github.com/distribution/reference"
 	"github.com/docker/distribution"
@@ -12,6 +13,7 @@ import (
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types/registry"
+	distributionpkg "github.com/docker/docker/distribution"
 	"github.com/docker/docker/errdefs"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -153,6 +155,9 @@ func (s *distributionRouter) fetchManifest(ctx context.Context, distrepo distrib
 			}
 		}
 	case *schema1.SignedManifest:
+		if os.Getenv("DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE") == "" {
+			return registry.DistributionInspect{}, distributionpkg.DeprecatedSchema1ImageError(namedRef)
+		}
 		platform := ocispec.Platform{
 			Architecture: mnfstObj.Architecture,
 			OS:           "linux",

--- a/distribution/errors.go
+++ b/distribution/errors.go
@@ -213,6 +213,15 @@ func (e reservedNameError) Error() string {
 
 func (e reservedNameError) Forbidden() {}
 
-func DeprecatedSchema1ImageMessage(ref reference.Named) string {
-	return fmt.Sprintf("[DEPRECATION NOTICE] Docker Image Format v1, and Docker Image manifest version 2, schema 1 support will be removed in an upcoming release. Suggest the author of %s to upgrade the image to the OCI Format, or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/", ref)
+type invalidArgumentErr struct{ error }
+
+func (invalidArgumentErr) InvalidParameter() {}
+
+func DeprecatedSchema1ImageError(ref reference.Named) error {
+	msg := "[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release."
+	if ref != nil {
+		msg += " Suggest the author of " + ref.String() + " to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2."
+	}
+	msg += " More information at https://docs.docker.com/go/deprecated-image-specs/"
+	return invalidArgumentErr{errors.New(msg)}
 }

--- a/distribution/manifest.go
+++ b/distribution/manifest.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/containerd/containerd/content"
@@ -292,6 +293,11 @@ func detectManifestBlobMediaType(dt []byte) (string, error) {
 		}
 		return mfst.MediaType, nil
 	case schema1.MediaTypeManifest:
+		if os.Getenv("DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE") == "" {
+			err := DeprecatedSchema1ImageError(nil)
+			log.G(context.TODO()).Warn(err.Error())
+			return "", err
+		}
 		if mfst.Manifests != nil || mfst.Layers != nil {
 			return "", fmt.Errorf(`media-type: %q should not have "manifests" or "layers"`, mfst.MediaType)
 		}
@@ -303,6 +309,11 @@ func detectManifestBlobMediaType(dt []byte) (string, error) {
 	}
 	switch {
 	case mfst.FSLayers != nil && mfst.Manifests == nil && mfst.Layers == nil && mfst.Config == nil:
+		if os.Getenv("DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE") == "" {
+			err := DeprecatedSchema1ImageError(nil)
+			log.G(context.TODO()).Warn(err.Error())
+			return "", err
+		}
 		return schema1.MediaTypeManifest, nil
 	case mfst.Config != nil && mfst.Manifests == nil && mfst.FSLayers == nil,
 		mfst.Layers != nil && mfst.Manifests == nil && mfst.FSLayers == nil:

--- a/distribution/manifest_test.go
+++ b/distribution/manifest_test.go
@@ -362,6 +362,7 @@ func TestDetectManifestBlobMediaType(t *testing.T) {
 		"mediaType and fsLayers set": {[]byte(`{"mediaType": "bananas", "fsLayers": []}`), "bananas"},
 	}
 
+	t.Setenv("DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE", "1")
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			mt, err := detectManifestBlobMediaType(tc.json)
@@ -431,6 +432,7 @@ func TestDetectManifestBlobMediaTypeInvalid(t *testing.T) {
 		},
 	}
 
+	t.Setenv("DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE", "1")
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			mt, err := detectManifestBlobMediaType(tc.json)

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -424,9 +424,12 @@ func (p *puller) pullTag(ctx context.Context, ref reference.Named, platform *oci
 
 	switch v := manifest.(type) {
 	case *schema1.SignedManifest:
-		msg := DeprecatedSchema1ImageMessage(ref)
-		log.G(ctx).Warn(msg)
-		progress.Message(p.config.ProgressOutput, "", msg)
+		err := DeprecatedSchema1ImageError(ref)
+		log.G(ctx).Warn(err.Error())
+		if os.Getenv("DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE") == "" {
+			return false, err
+		}
+		progress.Message(p.config.ProgressOutput, "", err.Error())
 
 		id, manifestDigest, err = p.pullSchema1(ctx, ref, v, platform)
 		if err != nil {
@@ -857,9 +860,12 @@ func (p *puller) pullManifestList(ctx context.Context, ref reference.Named, mfst
 
 		switch v := manifest.(type) {
 		case *schema1.SignedManifest:
-			msg := DeprecatedSchema1ImageMessage(ref)
-			log.G(ctx).Warn(msg)
-			progress.Message(p.config.ProgressOutput, "", msg)
+			err := DeprecatedSchema1ImageError(ref)
+			log.G(ctx).Warn(err.Error())
+			if os.Getenv("DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE") == "" {
+				return "", "", err
+			}
+			progress.Message(p.config.ProgressOutput, "", err.Error())
 
 			platform := toOCIPlatform(match.Platform)
 			id, _, err = p.pullSchema1(ctx, manifestRef, v, platform)

--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -46,6 +46,9 @@ export DOCKER_ALLOW_SCHEMA1_PUSH_DONOTUSE=1
 export DOCKER_GRAPHDRIVER=${DOCKER_GRAPHDRIVER:-vfs}
 export DOCKER_USERLANDPROXY=${DOCKER_USERLANDPROXY:-true}
 
+# Allow testing push/pull of legacy image formats
+export DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE=1
+
 # example usage: DOCKER_STORAGE_OPTS="dm.basesize=20G,dm.loopdatasize=200G"
 storage_params=""
 if [ -n "$DOCKER_STORAGE_OPTS" ]; then


### PR DESCRIPTION
- relates to https://github.com/docker/roadmap/issues/173
- relates to https://github.com/moby/moby/pull/42300
- relates to https://github.com/containerd/containerd/pull/9765

This patch disables pulling legacy (schema1 and schema 2, version 1) images by default.

A `DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE` environment-variable is introduced to allow re-enabling this feature, aligning with the environment variable used in containerd 2.0 (`CONTAINERD_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE`).

With this patch, attempts to pull a legacy image produces an error:

With graphdrivers:

    docker pull docker:1.0
    1.0: Pulling from library/docker
    [DEPRECATION NOTICE] Docker Image Format v1, and Docker Image manifest version 2, schema 1 support will be removed in an upcoming release. Suggest the author of docker.io/library/docker:1.0 to upgrade the image to the OCI Format, or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/

With the containerd image store enabled, output is slightly different as it returns the error before printing the `1.0: pulling ...`:

    docker pull docker:1.0
    Error response from daemon: [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/library/docker:1.0 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/

Using the "distribution" endpoint to resolve the digest for an image also produces an error:

    curl -v --unix-socket /var/run/docker.sock http://foo/distribution/docker.io/library/docker:1.0/json
    *   Trying /var/run/docker.sock:0...
    * Connected to foo (/var/run/docker.sock) port 80 (#0)
    > GET /distribution/docker.io/library/docker:1.0/json HTTP/1.1
    > Host: foo
    > User-Agent: curl/7.88.1
    > Accept: */*
    >
    < HTTP/1.1 400 Bad Request
    < Api-Version: 1.45
    < Content-Type: application/json
    < Docker-Experimental: false
    < Ostype: linux
    < Server: Docker/dev (linux)
    < Date: Tue, 27 Feb 2024 16:09:42 GMT
    < Content-Length: 354
    <
    {"message":"[DEPRECATION NOTICE] Docker Image Format v1, and Docker Image manifest version 2, schema 1 support will be removed in an upcoming release. Suggest the author of docker.io/library/docker:1.0 to upgrade the image to the OCI Format, or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/"}
    * Connection #0 to host foo left intact

Starting the daemon with the `DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE` env-var set to a non-empty value allows pulling the image;

    docker pull docker:1.0
    [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/library/docker:1.0 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
    b0a0e6710d13: Already exists
    d193ad713811: Already exists
    ba7268c3149b: Already exists
    c862d82a67a2: Already exists
    Digest: sha256:5e7081837926c7a40e58881bbebc52044a95a62a2ea52fb240db3fc539212fe5
    Status: Image is up to date for docker:1.0
    docker.io/library/docker:1.0

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
- Disable pulling of deprecated image formats by default. These image formats are deprecated, and support will be removed in a future version.
```

**- A picture of a cute animal (not mandatory but encouraged)**

