### PR TITLE
integration: Reset `OTEL_EXPORTER_OTLP_ENDPOINT` for sub-daemons 

### DIFF
--- a/integration/daemon/daemon_test.go
+++ b/integration/daemon/daemon_test.go
@@ -2,7 +2,6 @@ package daemon // import "github.com/docker/docker/integration/daemon"
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -183,9 +182,7 @@ func TestConfigDaemonSeccompProfiles(t *testing.T) {
 func TestDaemonProxy(t *testing.T) {
 	skip.If(t, runtime.GOOS == "windows", "cannot start multiple daemons on windows")
 	skip.If(t, os.Getenv("DOCKER_ROOTLESS") != "", "cannot connect to localhost proxy in rootless environment")
-
-	// Don't setup OTEL here to avoid it hitting the HTTP proxy.
-	ctx := context.Background()
+	ctx := testutil.StartSpan(baseContext, t)
 
 	newProxy := func(rcvd *string, t *testing.T) *httptest.Server {
 		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -203,6 +200,7 @@ func TestDaemonProxy(t *testing.T) {
 	t.Run("environment variables", func(t *testing.T) {
 		t.Parallel()
 
+		ctx := testutil.StartSpan(ctx, t)
 		var received string
 		proxyServer := newProxy(&received, t)
 
@@ -234,6 +232,8 @@ func TestDaemonProxy(t *testing.T) {
 	// Configure proxy through command-line flags
 	t.Run("command-line options", func(t *testing.T) {
 		t.Parallel()
+
+		ctx := testutil.StartSpan(ctx, t)
 
 		var received string
 		proxyServer := newProxy(&received, t)
@@ -283,6 +283,7 @@ func TestDaemonProxy(t *testing.T) {
 	// Configure proxy through configuration file
 	t.Run("configuration file", func(t *testing.T) {
 		t.Parallel()
+		ctx := testutil.StartSpan(ctx, t)
 
 		var received string
 		proxyServer := newProxy(&received, t)
@@ -331,6 +332,7 @@ func TestDaemonProxy(t *testing.T) {
 
 	// Conflicting options (passed both through command-line options and config file)
 	t.Run("conflicting options", func(t *testing.T) {
+		ctx := testutil.StartSpan(ctx, t)
 		const (
 			proxyRawURL = "https://" + userPass + "example.org"
 			proxyURL    = "https://xxxxx:xxxxx@example.org"
@@ -355,6 +357,7 @@ func TestDaemonProxy(t *testing.T) {
 	// Make sure values are sanitized when reloading the daemon-config
 	t.Run("reload sanitized", func(t *testing.T) {
 		t.Parallel()
+		ctx := testutil.StartSpan(ctx, t)
 
 		const (
 			proxyRawURL = "https://" + userPass + "example.org"

--- a/integration/daemon/daemon_test.go
+++ b/integration/daemon/daemon_test.go
@@ -208,6 +208,7 @@ func TestDaemonProxy(t *testing.T) {
 			"HTTP_PROXY="+proxyServer.URL,
 			"HTTPS_PROXY="+proxyServer.URL,
 			"NO_PROXY=example.com",
+			"OTEL_EXPORTER_OTLP_ENDPOINT=", // To avoid OTEL hitting the proxy.
 		))
 		c := d.NewClientT(t)
 
@@ -245,6 +246,7 @@ func TestDaemonProxy(t *testing.T) {
 			"https_proxy="+"https://"+userPass+"myuser:mypassword@from-env-https-invalid",
 			"NO_PROXY=ignore.invalid",
 			"no_proxy=ignore.invalid",
+			"OTEL_EXPORTER_OTLP_ENDPOINT=", // To avoid OTEL hitting the proxy.
 		))
 		d.Start(t, "--iptables=false", "--http-proxy", proxyServer.URL, "--https-proxy", proxyServer.URL, "--no-proxy", "example.com")
 		defer d.Stop(t)
@@ -295,6 +297,7 @@ func TestDaemonProxy(t *testing.T) {
 			"https_proxy="+"https://"+userPass+"myuser:mypassword@from-env-https-invalid",
 			"NO_PROXY=ignore.invalid",
 			"no_proxy=ignore.invalid",
+			"OTEL_EXPORTER_OTLP_ENDPOINT=", // To avoid OTEL hitting the proxy.
 		))
 		c := d.NewClientT(t)
 
@@ -364,7 +367,9 @@ func TestDaemonProxy(t *testing.T) {
 			proxyURL    = "https://xxxxx:xxxxx@example.org"
 		)
 
-		d := daemon.New(t)
+		d := daemon.New(t, daemon.WithEnvVars(
+			"OTEL_EXPORTER_OTLP_ENDPOINT=", // To avoid OTEL hitting the proxy.
+		))
 		d.Start(t, "--iptables=false", "--http-proxy", proxyRawURL, "--https-proxy", proxyRawURL, "--no-proxy", "example.com")
 		defer d.Stop(t)
 		err := d.Signal(syscall.SIGHUP)


### PR DESCRIPTION
- follow up to: https://github.com/moby/moby/pull/47410
- related to: https://github.com/moby/moby/pull/47460#issuecomment-1967374420

**- What I did**
Revert the last commit (removing spans on "client" side) and reset the `OTEL_EXPORTER_OTLP_ENDPOINT` variable for the sub-daemons created in test.

This should only disable OTEL for the child daemons (which we set the proxy for) instead of the test itself.

**- How to verify it**
`TestDaemonProxy`

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**

