### PR TITLE
[25.0 backport] libcontainerd: change the digest used when restoring

### DIFF
--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -723,7 +723,7 @@ func (c *client) writeContent(ctx context.Context, mediaType, ref string, r io.R
 	}
 	return &types.Descriptor{
 		MediaType: mediaType,
-		Digest:    writer.Digest().Encoded(),
+		Digest:    writer.Digest().String(),
 		Size:      size,
 	}, nil
 }


### PR DESCRIPTION
- backport: #47456 

Fix the bugs related to `Digest` used while restoring, which comes from https://github.com/moby/moby/commit/fd6dd6935b1706ad99cc65b3a74456b680423333#diff-c3c703e02023ce6a127448365c946281594c6ee77acf7981fbfba77d3d97a89cR740

(cherry picked from commit da643c0b8a4f287596289fe4d81d6a032565ac47)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**


**- How I did it**

**- How to verify it**

**- Description for the changelog**
```markdown changelog
Fix `docker start` failing when used with `--checkpoint`
```

**- A picture of a cute animal (not mandatory but encouraged)**

