### PR TITLE
Fixing Erroneous Behavior

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
+	// "github.com/pkg/errors" //imports from this is giving undefined 
+	"errors"
+
 )
 
 // errConnectionFailed implements an error returned when connection failed.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->


**- What I did**

Replaced the usage of `errors.Wrap` with `fmt.Errorf` in the Docker client package to resolve an issue where `errors.Wrap` was causing problems. Additionally, added the `errors` package for error handling, but as it didn't include the `Wrap` method, I used `fmt.Errorf` as an alternative.

![mobyproerror](https://github.com/moby/moby/assets/111894942/fe470ba0-5939-4c73-b574-0c89868766dc)

**- How I did it**
Identified the issue with `errors.Wrap` in the Docker client package and implemented a workaround by replacing it with `fmt.Errorf`. Added the `errors` package for error handling but opted for `fmt.Errorf` due to the absence of the `Wrap` method.


![mobyproafterresolve](https://github.com/moby/moby/assets/111894942/4b5fd88a-982d-4600-bbc0-0d16f045d866)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Replaced usage of `errors.Wrap` with `fmt.Errorf` in the Docker client package to resolve compatibility issues. Also, added the `errors` package for error handling, using `fmt.Errorf` as an alternative due to the absence of the `Wrap` method.
```

**- A picture of a cute animal (not mandatory but encouraged)**
![cutecat](https://github.com/moby/moby/assets/111894942/7a23783e-2933-4e7f-bc63-929f6c65a486)

