### PR TITLE
[25.0 backport] ci: Make `find` for test reports more specific

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -96,7 +96,7 @@ jobs:
       -
         name: Create summary
         run: |
-          teststat -markdown $(find /tmp/reports -type f -name '*.json' -print0 | xargs -0) >> $GITHUB_STEP_SUMMARY
+          find /tmp/reports -type f -name '*-go-test-report.json' -exec teststat -markdown {} \+ >> $GITHUB_STEP_SUMMARY
 
   docker-py:
     runs-on: ubuntu-20.04
@@ -297,7 +297,7 @@ jobs:
       -
         name: Create summary
         run: |
-          teststat -markdown $(find /tmp/reports -type f -name '*.json' -print0 | xargs -0) >> $GITHUB_STEP_SUMMARY
+          find /tmp/reports -type f -name '*-go-test-report.json' -exec teststat -markdown {} \+ >> $GITHUB_STEP_SUMMARY
 
   integration-cli-prepare:
     runs-on: ubuntu-20.04
@@ -435,4 +435,4 @@ jobs:
       -
         name: Create summary
         run: |
-          teststat -markdown $(find /tmp/reports -type f -name '*.json' -print0 | xargs -0) >> $GITHUB_STEP_SUMMARY
+          find /tmp/reports -type f -name '*-go-test-report.json' -exec teststat -markdown {} \+ >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -214,7 +214,7 @@ jobs:
       -
         name: Create summary
         run: |
-          teststat -markdown $(find /tmp/artifacts -type f -name '*.json' -print0 | xargs -0) >> $GITHUB_STEP_SUMMARY
+          find /tmp/artifacts -type f -name '*-go-test-report.json' -exec teststat -markdown {} \+ >> $GITHUB_STEP_SUMMARY
 
   integration-test-prepare:
     runs-on: ubuntu-latest
@@ -544,4 +544,4 @@ jobs:
       -
         name: Create summary
         run: |
-          teststat -markdown $(find /tmp/reports -type f -name '*.json' -print0 | xargs -0) >> $GITHUB_STEP_SUMMARY
+          find /tmp/reports -type f -name '*-go-test-report.json' -exec teststat -markdown {} \+ >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- backports: https://github.com/moby/moby/pull/47458

Don't use all `*.json` files blindly, take only these that are likely to be reports from go test.
Also, use `find ... -exec` instead of piping results to `xargs`.


(cherry picked from commit e4de4dea5cdbb0d91dd9d5f3e9b2e35ea33b56f2)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:

**- A picture of a cute animal (not mandatory but encouraged)**

