### PR TITLE
Dockerfile: Update dev cli to v26.0.0-rc1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG XX_VERSION=1.2.1
 ARG VPNKIT_VERSION=0.5.0
 
 ARG DOCKERCLI_REPOSITORY="https://github.com/docker/cli.git"
-ARG DOCKERCLI_VERSION=v25.0.2
+ARG DOCKERCLI_VERSION=v26.0.0-rc1
 # cli version used for integration-cli tests
 ARG DOCKERCLI_INTEGRATION_REPOSITORY="https://github.com/docker/cli.git"
 ARG DOCKERCLI_INTEGRATION_VERSION=v17.06.2-ce


### PR DESCRIPTION
Update CLI used in dev containers to v26.0.0-rc1
