### PR TITLE
distribution/xfer: fix pull progress message

### DIFF
--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -364,7 +364,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				return
 			}
 
-			progress.Update(progressOutput, descriptor.ID(), "PullOptions complete")
+			progress.Update(progressOutput, descriptor.ID(), "Pull complete")
 
 			if withRegistered, ok := descriptor.(DigestRegisterer); ok {
 				withRegistered.Registered(d.layer.DiffID())

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -316,8 +316,8 @@ func TestSuccessfulDownload(t *testing.T) {
 			if receivedProgress[d.ID()].Action != "Already exists" {
 				t.Fatalf("did not get 'Already exists' message for %v", d.ID())
 			}
-		} else if receivedProgress[d.ID()].Action != "PullOptions complete" {
-			t.Fatalf("did not get 'PullOptions complete' message for %v", d.ID())
+		} else if receivedProgress[d.ID()].Action != "Pull complete" {
+			t.Fatalf("did not get 'Pull complete' message for %v", d.ID())
 		}
 
 		if rootFS.DiffIDs[i] != descriptor.expectedDiffID {


### PR DESCRIPTION
- introduced in https://github.com/moby/moby/pull/47139

This message accidentally changed in ac2a028dcc05532109e14f8af105ca42c0abf1f3 because my IDE's "refactor tool" was a bit over-enthusiastic. It also went and updated the tests accordingly, so CI didn't catch this :)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

