### PR TITLE
Remove slices.Clone() calls to avoid Go bug

### DIFF
--- a/libnetwork/internal/resolvconf/resolvconf.go
+++ b/libnetwork/internal/resolvconf/resolvconf.go
@@ -18,13 +18,11 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	_ "embed"
 	"fmt"
 	"io"
 	"io/fs"
 	"net/netip"
 	"os"
-	"slices"
 	"strconv"
 	"strings"
 	"text/template"
@@ -141,7 +139,7 @@ func (rc *ResolvConf) SetHeader(c string) {
 
 // NameServers returns addresses used in nameserver directives.
 func (rc *ResolvConf) NameServers() []netip.Addr {
-	return slices.Clone(rc.nameServers)
+	return append([]netip.Addr(nil), rc.nameServers...)
 }
 
 // OverrideNameServers replaces the current set of nameservers.
@@ -152,7 +150,7 @@ func (rc *ResolvConf) OverrideNameServers(nameServers []netip.Addr) {
 
 // Search returns the current DNS search domains.
 func (rc *ResolvConf) Search() []string {
-	return slices.Clone(rc.search)
+	return append([]string(nil), rc.search...)
 }
 
 // OverrideSearch replaces the current DNS search domains.
@@ -169,7 +167,7 @@ func (rc *ResolvConf) OverrideSearch(search []string) {
 
 // Options returns the current options.
 func (rc *ResolvConf) Options() []string {
-	return slices.Clone(rc.options)
+	return append([]string(nil), rc.options...)
 }
 
 // Option finds the last option named search, and returns (value, true) if
@@ -192,7 +190,7 @@ func (rc *ResolvConf) Option(search string) (string, bool) {
 
 // OverrideOptions replaces the current DNS options.
 func (rc *ResolvConf) OverrideOptions(options []string) {
-	rc.options = slices.Clone(options)
+	rc.options = append([]string(nil), options...)
 	rc.md.NDotsFrom = ""
 	if _, exists := rc.Option("ndots"); exists {
 		rc.md.NDotsFrom = "override"
@@ -314,7 +312,7 @@ func (rc *ResolvConf) TransformForIntNS(
 	}
 
 	rc.md.Transform = "internal resolver"
-	return slices.Clone(rc.md.ExtNameServers), nil
+	return append([]ExtDNSEntry(nil), rc.md.ExtNameServers...), nil
 }
 
 // Generate returns content suitable for writing to a resolv.conf file. If comments

--- a/libnetwork/internal/resolvconf/resolvconf_test.go
+++ b/libnetwork/internal/resolvconf/resolvconf_test.go
@@ -221,15 +221,15 @@ func TestRCModify(t *testing.T) {
 				rc.OverrideSearch(tc.overrideSearch)
 				rc.OverrideOptions(tc.overrideOptions)
 
-				assert.Check(t, is.DeepEqual(rc.NameServers(), overrideNS, cmpopts.EquateComparable(netip.Addr{})))
-				assert.Check(t, is.DeepEqual(rc.Search(), tc.overrideSearch))
-				assert.Check(t, is.DeepEqual(rc.Options(), tc.overrideOptions))
+				assert.Check(t, is.DeepEqual(rc.NameServers(), overrideNS, cmpopts.EquateEmpty(), cmpopts.EquateComparable(netip.Addr{})))
+				assert.Check(t, is.DeepEqual(rc.Search(), tc.overrideSearch, cmpopts.EquateEmpty()))
+				assert.Check(t, is.DeepEqual(rc.Options(), tc.overrideOptions, cmpopts.EquateEmpty()))
 			}
 
 			if tc.addOption != "" {
 				options := rc.Options()
 				rc.AddOption(tc.addOption)
-				assert.Check(t, is.DeepEqual(rc.Options(), append(options, tc.addOption)))
+				assert.Check(t, is.DeepEqual(rc.Options(), append(options, tc.addOption), cmpopts.EquateEmpty()))
 			}
 
 			d := t.TempDir()


### PR DESCRIPTION
**- What I did**

- relates to https://github.com/moby/moby/pull/46942
- relates to https://github.com/moby/moby/pull/47041

Without this change, the buildkit build initially failed with ...

```
47.94 # github.com/docker/docker/libnetwork/internal/resolvconf
47.94 embedding interface element ~[]netip.Addr requires go1.18 or later (-lang was set to go1.16; check go.mod)
47.94 embedding interface element ~[]string requires go1.18 or later (-lang was set to go1.16; check go.mod)
47.94 embedding interface element ~[]ExtDNSEntry requires go1.18 or later (-lang was set to go1.16; check go.mod)
47.94 vendor/github.com/docker/docker/libnetwork/internal/resolvconf/resolvconf.go:144:9: implicit function instantiation requires go1.18 or later (-lang was set to go1.16; check go.mod)
47.94 vendor/github.com/docker/docker/libnetwork/internal/resolvconf/resolvconf.go:155:9: implicit function instantiation requires go1.18 or later (-lang was set to go1.16; check go.mod)
47.94 vendor/github.com/docker/docker/libnetwork/internal/resolvconf/resolvconf.go:172:9: implicit function instantiation requires go1.18 or later (-lang was set to go1.16; check go.mod)
47.94 vendor/github.com/docker/docker/libnetwork/internal/resolvconf/resolvconf.go:195:15: implicit function instantiation requires go1.18 or later (-lang was set to go1.16; check go.mod)
47.94 vendor/github.com/docker/docker/libnetwork/internal/resolvconf/resolvconf.go:317:9: implicit function instantiation requires go1.18 or later (-lang was set to go1.16; check go.mod)
```

The second set of errors there ("implicit function instantiation requires go1.18 or later") are due to the go.mod related language-version downgrade ... they could be worked around using a "go:build go1.16" directive - which was the original purpose of this PR.

But, the "embedding interface element" weren't fixed by that, as [described below](https://github.com/moby/moby/pull/47477#issuecomment-1972718719).

So, the "go:build" directive has been removed, and now this PR replaces the problematic calls to `slices.Clone()`.

**- How I did it**

Replaced calls to `slices.Clone()`.

**- How to verify it**

Compile as part of buildkit.

**- Description for the changelog**
