### PR TITLE
[25.0 backport] Don't enforce new validation rules for existing networks

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -332,7 +332,27 @@ func (daemon *Daemon) createNetwork(cfg *config.Config, create types.NetworkCrea
 	}
 
 	if err := network.ValidateIPAM(create.IPAM, create.EnableIPv6); err != nil {
-		return nil, errdefs.InvalidParameter(err)
+		if agent {
+			// This function is called with agent=false for all networks. For swarm-scoped
+			// networks, the configuration is validated but ManagerRedirectError is returned
+			// and the network is not created. Then, each time a swarm-scoped network is
+			// needed, this function is called again with agent=true.
+			//
+			// Non-swarm networks created before ValidateIPAM was introduced continue to work
+			// as they did before-upgrade, even if they would fail the new checks on creation
+			// (for example, by having host-bits set in their subnet). Those networks are not
+			// seen again here.
+			//
+			// By dropping errors for agent networks, existing swarm-scoped networks also
+			// continue to behave as they did before upgrade - but new networks are still
+			// validated.
+			log.G(context.TODO()).WithFields(log.Fields{
+				"error":   err,
+				"network": create.Name,
+			}).Warn("Continuing with validation errors in agent IPAM")
+		} else {
+			return nil, errdefs.InvalidParameter(err)
+		}
 	}
 
 	if create.IPAM != nil {


### PR DESCRIPTION
- Backport https://github.com/moby/moby/pull/47361
- Fixes https://github.com/moby/moby/issues/47331

Non-swarm networks created before network-creation-time validation was added in 25.0.0 continued working, because the checks are not re-run.

But, swarm creates networks when needed (with 'agent=true'), to ensure they exist on each agent - ignoring the NetworkNameError that says the network already existed.

By ignoring validation errors on creation of a network with agent=true, pre-existing swarm networks with IPAM config that would fail the new checks will continue to work too.

New swarm (overlay) networks are still validated, because they are initially created with 'agent=false'.

(cherry picked from commit 571af915d59d2fa68eb10cf0ec3cf9cd85b1eef2)

**- Description for the changelog**

```markdown changelog
Do not enforce new validation rules for existing swarm networks
```

