### PR TITLE
[25.0 backport] builder/dockerfile: ADD with best-effort xattrs

### DIFF
--- a/builder/dockerfile/copy.go
+++ b/builder/dockerfile/copy.go
@@ -459,7 +459,16 @@ func performCopyForInfo(dest copyInfo, source copyInfo, options copyFileOptions)
 		return copyDirectory(archiver, srcPath, destPath, options.identity)
 	}
 	if options.decompress && archive.IsArchivePath(srcPath) && !source.noDecompress {
-		return archiver.UntarPath(srcPath, destPath)
+		f, err := os.Open(srcPath)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		options := &archive.TarOptions{
+			IDMap:            archiver.IDMapping,
+			BestEffortXattrs: true,
+		}
+		return archiver.Untar(f, destPath, options)
 	}
 
 	destExistsAsDir, err := isExistingDirectory(destPath)


### PR DESCRIPTION
- Backport https://github.com/moby/moby/pull/47175
- Fixes https://github.com/moby/moby/issues/47137
- Closes https://github.com/moby/moby/pull/47347

Archives being unpacked by Dockerfiles may have been created on other OSes with different conventions and semantics for xattrs, making them impossible to apply when extracting. Restore the old best-effort xattr behaviour users have come to depend on in the classic builder.

The (archive.Archiver).UntarPath function does not allow the options passed to Untar to be customized. It also happens to be a trivial wrapper around the Untar function. Inline the function body and add the option.


(cherry picked from commit 5bcd2f6860fb4247c844e6e9338a4fef7e07f9f7)

**- Description for the changelog**

```markdown changelog
Fix a regression introduced in v25.0 that prevented the classic buidler from ADDing a tar archive with xattrs created on a non-Linux OS 
```
