### PR TITLE
[25.0 backport] c8d/pull: Progress fixes

### DIFF
--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -117,6 +117,9 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 			progress.Message(out, "", distribution.DeprecatedSchema1ImageMessage(ref))
 			sentSchema1Deprecation = true
 		}
+		if images.IsLayerType(desc.MediaType) {
+			progress.Update(out, desc.Digest.String(), "Pulling fs layer")
+		}
 		if images.IsManifestType(desc.MediaType) {
 			if !sentPullingFrom {
 				var tagOrDigest string

--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker/internal/compatcontext"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
+	"github.com/docker/docker/pkg/stringid"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
@@ -118,7 +119,8 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 			sentSchema1Deprecation = true
 		}
 		if images.IsLayerType(desc.MediaType) {
-			progress.Update(out, desc.Digest.String(), "Pulling fs layer")
+			id := stringid.TruncateID(desc.Digest.String())
+			progress.Update(out, id, "Pulling fs layer")
 		}
 		if images.IsManifestType(desc.MediaType) {
 			if !sentPullingFrom {

--- a/daemon/containerd/progress.go
+++ b/daemon/containerd/progress.go
@@ -135,6 +135,9 @@ func (p pullProgress) UpdateProgress(ctx context.Context, ongoing *jobs, out pro
 		}
 		key := remotes.MakeRefKey(ctx, j)
 		if info, ok := pulling[key]; ok {
+			if info.Offset == 0 {
+				continue
+			}
 			out.WriteProgress(progress.Progress{
 				ID:      stringid.TruncateID(j.Digest.Encoded()),
 				Action:  "Downloading",


### PR DESCRIPTION
- Backport https://github.com/moby/moby/pull/47432
- Backport https://github.com/moby/moby/pull/47454

**pkg/streamformatter: Make progressOutput concurrency safe**

Sync access to the underlying `io.Writer` with a mutex.

(cherry picked from commit https://github.com/moby/moby/commit/5689dabfb357b673abdb4391eef426f297d7d1bb)

**c8d/pull: Emit Pulling fs layer**

(cherry picked from commit https://github.com/moby/moby/commit/ff5f780f2b57be7cbe7ea27c179fb2edfb869ddd)

**c8d/pull: Don't emit Downloading with 0 progress**

To align with the graphdrivers behavior and don't send unnecessary
progress messages.

(cherry picked from commit https://github.com/moby/moby/commit/14df52b709d7ad00f1d9064b996aeba23ff024d5)

**c8d/pull: Output truncated id for Pulling fs layer**

All other progress updates are emitted with truncated id.

```diff
$ docker pull --platform linux/amd64 alpine
Using default tag: latest
latest: Pulling from library/alpine
-sha256:4abcf20661432fb2d719aaf90656f55c287f8ca915dc1c92ec14ff61e67fbaf8: Pulling fs layer
+4abcf2066143: Download complete
Digest: sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
Status: Image is up to date for alpine:latest
docker.io/library/alpine:latest
```

(cherry picked from commit https://github.com/moby/moby/commit/16aa7dd67fc20f15690b145f30e921d783746cb6)

**- Description for the changelog**

```markdown changelog
containerd image store: Fix image pull not emitting `Pulling fs layer` status
```


