### PR TITLE
[25.0 backport] Set up DNS names for Windows default network

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -649,7 +649,10 @@ func cleanOperationalData(es *network.EndpointSettings) {
 }
 
 func (daemon *Daemon) updateNetworkConfig(container *container.Container, n *libnetwork.Network, endpointConfig *networktypes.EndpointSettings, updateSettings bool) error {
-	if containertypes.NetworkMode(n.Name()).IsUserDefined() {
+	// Set up DNS names for a user defined network, and for the default 'nat'
+	// network on Windows (IsBridge() returns true for nat).
+	if containertypes.NetworkMode(n.Name()).IsUserDefined() ||
+		(serviceDiscoveryOnDefaultNetwork() && containertypes.NetworkMode(n.Name()).IsBridge()) {
 		endpointConfig.DNSNames = buildEndpointDNSNames(container, endpointConfig.Aliases)
 	}
 


### PR DESCRIPTION
- Backport https://github.com/moby/moby/pull/47375
- Fix https://github.com/moby/moby/issues/47370

DNS names were only set up for user-defined networks. On Linux, none of the built-in networks (bridge/host/none) have built-in DNS, so they don't need DNS names.

But, on Windows, the default network is "nat" and it does need the DNS names.

(cherry picked from commit 443f56efb008ea45a0c6c5741d1b67546d0ae9df)

**- Description for the changelog**

```markdown changelog
Restore DNS names for containers in the default "nat" network on Windows.
```
