### PR TITLE
[25.0 backport] c8d/windows: Temporarily skip two failing tests

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -3587,6 +3587,7 @@ RUN [ $(ls -l /test | awk '{print $3":"$4}') = 'root:root' ]
 }
 
 func (s *DockerCLIBuildSuite) TestBuildSymlinkBreakout(c *testing.T) {
+	skip.If(c, testEnv.UsingSnapshotter(), "FIXME: https://github.com/moby/moby/issues/47107")
 	const name = "testbuildsymlinkbreakout"
 	tmpdir, err := os.MkdirTemp("", name)
 	assert.NilError(c, err)

--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -32,6 +32,7 @@ func TestCopyFromContainerPathDoesNotExist(t *testing.T) {
 }
 
 func TestCopyFromContainerPathIsNotDir(t *testing.T) {
+	skip.If(t, testEnv.UsingSnapshotter(), "FIXME: https://github.com/moby/moby/issues/47107")
 	ctx := setupTest(t)
 
 	apiClient := testEnv.APIClient()


### PR DESCRIPTION
- Backport https://github.com/moby/moby/pull/47455
- Related to https://github.com/moby/moby/issues/47107

They're failing the CI and we have a tracking ticket: #47107

(cherry picked from commit 44167988c3957c5570550016bbed19506ab660e9)
