### PR TITLE
docker-bake: Add `windows/arm64` to binary-cross

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -428,7 +428,7 @@ RUN git init . && git remote add origin "https://github.com/docker-archive/windo
 ARG CONTAINERUTILITY_VERSION=aa1ba87e99b68e0113bd27ec26c60b88f9d4ccd9
 RUN git fetch -q --depth 1 origin "${CONTAINERUTILITY_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
-FROM base AS containerutil-build
+FROM --platform=$TARGETPLATFORM base AS containerutil-build
 WORKDIR /usr/src/containerutil
 ARG TARGETPLATFORM
 RUN xx-apt-get install -y --no-install-recommends \
@@ -447,6 +447,7 @@ EOT
 
 FROM binary-dummy AS containerutil-linux
 FROM containerutil-build AS containerutil-windows-amd64
+FROM containerutil-build AS containerutil-windows-arm64
 FROM containerutil-windows-${TARGETARCH} AS containerutil-windows
 FROM containerutil-${TARGETOS} AS containerutil
 FROM docker/buildx-bin:${BUILDX_VERSION} as buildx

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -87,7 +87,8 @@ target "_platforms" {
     "linux/arm64",
     "linux/ppc64le",
     "linux/s390x",
-    "windows/amd64"
+    "windows/amd64",
+    "windows/arm64"
   ]
 }
 


### PR DESCRIPTION
While we currently don't support `windows/arm64` it's still valuable to have a "it builds" check in the CI.


