### PR TITLE
devcontainer: Add Golang extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,5 +9,13 @@
   "workspaceMount": "source=${localWorkspaceFolder},target=/go/src/github.com/docker/docker,type=bind,consistency=cached",
 
   "remoteUser": "root",
-  "runArgs": ["--privileged"]
+  "runArgs": ["--privileged"],
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go"
+      ]
+    }
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "build": {
     "context": "..",
     "dockerfile": "../Dockerfile",
-    "target": "dev"
+    "target": "devcontainer"
   },
   "workspaceFolder": "/go/src/github.com/docker/docker",
   "workspaceMount": "source=${localWorkspaceFolder},target=/go/src/github.com/docker/docker,type=bind,consistency=cached",

--- a/Dockerfile
+++ b/Dockerfile
@@ -251,6 +251,12 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
         GOBIN=/build/ GO111MODULE=on go install "mvdan.cc/sh/v3/cmd/shfmt@${SHFMT_VERSION}" \
      && /build/shfmt --version
 
+FROM base AS gopls
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+        GOBIN=/build/ GO111MODULE=on go install "golang.org/x/tools/gopls@latest" \
+     && /build/gopls version
+
 FROM base AS dockercli
 WORKDIR /go/src/github.com/docker/cli
 ARG DOCKERCLI_REPOSITORY
@@ -654,6 +660,11 @@ RUN <<EOT
   file docker-proxy
   docker-proxy --version
 EOT
+
+# devcontainer is a stage used by .devcontainer/devcontainer.json
+FROM dev-base AS devcontainer
+COPY --link . .
+COPY --link --from=gopls         /build/ /usr/local/bin/
 
 # usage:
 # > make shell


### PR DESCRIPTION
**devcontainer: Add Golang extension automatically**

When using devcontainers in VSCode, install the Go extension automatically in the container.

**devcontainer: Use a separate devcontainer target**

Use a separate `devcontainer` Dockerfile target, this allows to include the `gopls` in the devcontainer so it doesn't have to be installed by the Go vscode extension.
