### PR TITLE
Fix 'resolv.conf' parsing issues

### DIFF
--- a/libnetwork/internal/resolvconf/resolvconf.go
+++ b/libnetwork/internal/resolvconf/resolvconf.go
@@ -452,18 +452,8 @@ func UserModified(rcPath, rcHashPath string) (bool, error) {
 func (rc *ResolvConf) processLine(line string) {
 	fields := strings.Fields(line)
 
-	// Strip comments.
-	// TODO(robmry) - ignore comment chars except in column 0.
-	//   This preserves old behaviour, but it's wrong. For example, resolvers
-	//   will honour the option in line "options # ndots:0" (and ignore the
-	//   "#" as an unknown option).
-	for i, s := range fields {
-		if s[0] == '#' || s[0] == ';' {
-			fields = fields[:i]
-			break
-		}
-	}
-	if len(fields) == 0 {
+	// Strip blank lines and comments.
+	if len(fields) == 0 || fields[0][0] == '#' || fields[0][0] == ';' {
 		return
 	}
 

--- a/libnetwork/internal/resolvconf/resolvconf.go
+++ b/libnetwork/internal/resolvconf/resolvconf.go
@@ -293,21 +293,17 @@ func (rc *ResolvConf) TransformForIntNS(
 		rc.md.UsedDefaultNS = true
 	}
 
-	// Validate the ndots option from host config or overrides, if present.
-	// TODO(robmry) - pre-existing behaviour, but ...
-	//   Validating ndots from an override is good, but not-liking something in the
-	//   host's resolv.conf isn't a reason to fail - just remove? (And it'll be
-	//   replaced by the value in reqdOptions, if given.)
-	if ndots, exists := rc.Option("ndots"); exists {
-		if n, err := strconv.Atoi(ndots); err != nil || n < 0 {
-			return nil, errdefs.InvalidParameter(
-				fmt.Errorf("invalid number for ndots option: %v", ndots))
-		}
-	}
-	// For each option required by the nameserver, add it if not already
-	// present (if the option already has a value don't change it).
+	// For each option required by the nameserver, add it if not already present. If
+	// the option is already present, don't override it. Apart from ndots - if the
+	// ndots value is invalid and an ndots option is required, replace the existing
+	// value.
 	for _, opt := range reqdOptions {
 		optName, _, _ := strings.Cut(opt, ":")
+		if optName == "ndots" {
+			rc.options = removeInvalidNDots(rc.options)
+			// No need to update rc.md.NDotsFrom, if there is no ndots option remaining,
+			// it'll be set to "internal" when the required value is added.
+		}
 		if _, exists := rc.Option(optName); !exists {
 			rc.AddOption(opt)
 		}
@@ -495,4 +491,23 @@ func defaultNSAddrs(ipv6 bool) []netip.Addr {
 		addrs = append(addrs, defaultIPv6NSs...)
 	}
 	return addrs
+}
+
+// removeInvalidNDots filters ill-formed "ndots" settings from options.
+// The backing array of the options slice is reused.
+func removeInvalidNDots(options []string) []string {
+	n := 0
+	for _, opt := range options {
+		k, v, _ := strings.Cut(opt, ":")
+		if k == "ndots" {
+			ndots, err := strconv.Atoi(v)
+			if err != nil || ndots < 0 {
+				continue
+			}
+		}
+		options[n] = opt
+		n++
+	}
+	clear(options[n:]) // Zero out the obsolete elements, for GC.
+	return options[:n]
 }

--- a/libnetwork/internal/resolvconf/resolvconf.go
+++ b/libnetwork/internal/resolvconf/resolvconf.go
@@ -480,10 +480,8 @@ func (rc *ResolvConf) processLine(line string) {
 		if len(fields) < 2 {
 			return
 		}
-		// Replace options from earlier directives.
-		// TODO(robmry) - preserving incorrect behaviour, options should accumulate.
-		//     rc.options = append(rc.options, fields[1:]...)
-		rc.options = fields[1:]
+		// Accumulate options.
+		rc.options = append(rc.options, fields[1:]...)
 	default:
 		// Copy anything that's not a recognised directive.
 		rc.other = append(rc.other, line)

--- a/libnetwork/resolvconf/resolvconf_unix_test.go
+++ b/libnetwork/resolvconf/resolvconf_unix_test.go
@@ -149,16 +149,16 @@ func TestGetSearchDomains(t *testing.T) {
 			result: []string{"example.com"},
 		},
 		{
-			input:  `search example.com # ignored`,
-			result: []string{"example.com"},
+			input:  `search example.com # notignored`,
+			result: []string{"example.com", "#", "notignored"},
 		},
 		{
 			input:  `	  search	 example.com	  `,
 			result: []string{"example.com"},
 		},
 		{
-			input:  `	  search	 example.com	  # ignored`,
-			result: []string{"example.com"},
+			input:  `	  search	 example.com	  # notignored`,
+			result: []string{"example.com", "#", "notignored"},
 		},
 		{
 			input:  `search foo.example.com example.com`,
@@ -169,8 +169,8 @@ func TestGetSearchDomains(t *testing.T) {
 			result: []string{"foo.example.com", "example.com"},
 		},
 		{
-			input:  `	   search	   foo.example.com	 example.com	# ignored`,
-			result: []string{"foo.example.com", "example.com"},
+			input:  `	   search	   foo.example.com	 example.com	# notignored`,
+			result: []string{"foo.example.com", "example.com", "#", "notignored"},
 		},
 		{
 			input: `nameserver 1.2.3.4
@@ -213,6 +213,9 @@ func TestGetOptions(t *testing.T) {
 			input: `# ignored`,
 		},
 		{
+			input: `; ignored`,
+		},
+		{
 			input: `nameserver 1.2.3.4`,
 		},
 		{
@@ -220,32 +223,36 @@ func TestGetOptions(t *testing.T) {
 			result: []string{"opt1"},
 		},
 		{
-			input:  `options opt1 # ignored`,
-			result: []string{"opt1"},
+			input:  `options opt1 # notignored`,
+			result: []string{"opt1", "#", "notignored"},
+		},
+		{
+			input:  `options opt1 ; notignored`,
+			result: []string{"opt1", ";", "notignored"},
 		},
 		{
 			input:  `	  options	 opt1	  `,
 			result: []string{"opt1"},
 		},
 		{
-			input:  `	  options	 opt1	  # ignored`,
-			result: []string{"opt1"},
+			input:  `	  options	 opt1	  # notignored`,
+			result: []string{"opt1", "#", "notignored"},
 		},
 		{
 			input:  `options opt1 opt2 opt3`,
 			result: []string{"opt1", "opt2", "opt3"},
 		},
 		{
-			input:  `options opt1 opt2 opt3 # ignored`,
-			result: []string{"opt1", "opt2", "opt3"},
+			input:  `options opt1 opt2 opt3 # notignored`,
+			result: []string{"opt1", "opt2", "opt3", "#", "notignored"},
 		},
 		{
 			input:  `	   options	 opt1	 opt2	 opt3	`,
 			result: []string{"opt1", "opt2", "opt3"},
 		},
 		{
-			input:  `	   options	 opt1	 opt2	 opt3	# ignored`,
-			result: []string{"opt1", "opt2", "opt3"},
+			input:  `	   options	 opt1	 opt2	 opt3	# notignored`,
+			result: []string{"opt1", "opt2", "opt3", "#", "notignored"},
 		},
 		{
 			input: `nameserver 1.2.3.4

--- a/libnetwork/resolvconf/resolvconf_unix_test.go
+++ b/libnetwork/resolvconf/resolvconf_unix_test.go
@@ -263,7 +263,7 @@ options opt1 opt2 opt3`,
 			input: `nameserver 1.2.3.4
 options opt1 opt2
 options opt3 opt4`,
-			result: []string{"opt3", "opt4"},
+			result: []string{"opt1", "opt2", "opt3", "opt4"},
 		},
 	} {
 		test := GetOptions([]byte(tc.input))

--- a/libnetwork/sandbox_dns_unix_test.go
+++ b/libnetwork/sandbox_dns_unix_test.go
@@ -77,11 +77,19 @@ func TestDNSOptions(t *testing.T) {
 	err = sb2.setupDNS()
 	assert.NilError(t, err)
 	err = sb2.rebuildDNS()
-	assert.Error(t, err, "invalid number for ndots option: foobar")
+	assert.NilError(t, err)
+	currRC, err = resolvconf.GetSpecific(sb2.config.resolvConfPath)
+	assert.NilError(t, err)
+	dnsOptionsList = resolvconf.GetOptions(currRC.Content)
+	assert.Check(t, is.DeepEqual([]string{"ndots:0"}, dnsOptionsList))
 
 	sb2.config.dnsOptionsList = []string{"ndots:-1"}
 	err = sb2.setupDNS()
 	assert.NilError(t, err)
 	err = sb2.rebuildDNS()
-	assert.Error(t, err, "invalid number for ndots option: -1")
+	assert.NilError(t, err)
+	currRC, err = resolvconf.GetSpecific(sb2.config.resolvConfPath)
+	assert.NilError(t, err)
+	dnsOptionsList = resolvconf.GetOptions(currRC.Content)
+	assert.Check(t, is.DeepEqual([]string{"ndots:0"}, dnsOptionsList))
 }


### PR DESCRIPTION
**- What I did**

Fix issues in `resolv.conf` that were preserved by the refactoring in PR https://github.com/moby/moby/pull/47041.

**- How I did it**

Three commits ...

_**1. Comments**_

Previously, we treated a comment as anything on a line following a `#` (or post-refactor, a `;`). But comments in `resolv.conf` have the comment marker in the first column. [manpage](https://linux.die.net/man/5/resolv.conf#:~:text=Lines%20that%20contain%20a%20semicolon%20(%3B)%20or%20hash%20character%20(%23)%20in%20the%20first%20column%20are%20treated%20as%20comments.), and checked that both glibc and musl-libc treat the line `search # example` as two search domains.

_**2. Accumulate options**_

Options from multiple `options` lines accumulate, rather than replacing earlier lines.

_**3. Ignore bad ndots**_

Previously, an invalid `ndots` would be raised as an error while starting the internal resolver, whether the value came from the host's file, or `--dns-option`. Unfortunately, an error raised at that point doesn't make it out to the user, it just stops the `resolv.conf` rewrite for the internal resolver from completing (I didn't notice that during the refactoring, but that behaviour didn't change). So, simply remove any invalid `ndots` options before deciding whether to add our `ndots:0`.

**- How to verify it**

**- Description for the changelog**
```markdown changelog
Fix `resolv.conf` generation:
- Ignore comment characters, apart from in column one.
- Accumulate `options` over multiple options lines, rather than replacing them.
- When starting the internal DNS resolver, ignore an invalid `ndots` option from the host config or `--dns-option` override.
```

