### PR TITLE
seccomp: allow specifying a custom profile with `--privileged`

### DIFF
--- a/daemon/seccomp_linux.go
+++ b/daemon/seccomp_linux.go
@@ -22,7 +22,11 @@ func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {
 			return nil
 		}
 		if c.HostConfig.Privileged {
-			return nil
+			var err error
+			if c.SeccompProfile != "" {
+				s.Linux.Seccomp, err = seccomp.LoadProfile(c.SeccompProfile, s)
+			}
+			return err
 		}
 		if !daemon.RawSysInfo().Seccomp {
 			if c.SeccompProfile != "" && c.SeccompProfile != dconfig.SeccompProfileDefault {


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**


Fix #47499

**- How I did it**

Updated `daemon/seccomp_linux.go`

**- How to verify it**

```console
$ cat <<EOF >foo.json
{
 "defaultAction": "SCMP_ACT_ALLOW",
 "syscalls": [ { "names": [ "connect" ], "action": "SCMP_ACT_ERRNO" } ]
}
EOF

$ docker run --security-opt seccomp=foo.json --privileged busybox wget -O- http://1.1.1.1/
Connecting to 1.1.1.1 (1.1.1.1:80)
wget: can't connect to remote host (1.1.1.1): Operation not permitted
```
"Operation not permitted" is the expected error here.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
seccomp: allow specifying a custom profile with `--privileged`
```

**- A picture of a cute animal (not mandatory but encouraged)**
🐧 
