### PR TITLE
api/image/list: Add `container-count` parameter

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -363,11 +363,17 @@ func (ir *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter,
 		manifests = httputils.BoolValue(r, "manifests")
 	}
 
+	var containerCount bool
+	if versions.GreaterThanOrEqualTo(version, "1.47") {
+		containerCount = httputils.BoolValue(r, "container-count")
+	}
+
 	images, err := ir.backend.Images(ctx, imagetypes.ListOptions{
-		All:        httputils.BoolValue(r, "all"),
-		Filters:    imageFilters,
-		SharedSize: sharedSize,
-		Manifests:  manifests,
+		All:            httputils.BoolValue(r, "all"),
+		Filters:        imageFilters,
+		SharedSize:     sharedSize,
+		Manifests:      manifests,
+		ContainerCount: containerCount,
 	})
 	if err != nil {
 		return err

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8749,6 +8749,11 @@ paths:
           description: "Compute and show shared size as a `SharedSize` field on each image."
           type: "boolean"
           default: false
+        - name: "container-count"
+          in: "query"
+          description: "Compute and show container count using this image as a `Containers` field."
+          type: "boolean"
+          default: false
         - name: "digests"
           in: "query"
           description: "Show digest information as a `RepoDigests` field on each image."

--- a/client/image_list.go
+++ b/client/image_list.go
@@ -52,8 +52,13 @@ func (cli *Client) ImageList(ctx context.Context, options image.ListOptions) ([]
 	if options.SharedSize && versions.GreaterThanOrEqualTo(cli.version, "1.42") {
 		query.Set("shared-size", "1")
 	}
-	if options.Manifests && versions.GreaterThanOrEqualTo(cli.version, "1.47") {
-		query.Set("manifests", "1")
+	if versions.GreaterThanOrEqualTo(cli.version, "1.47") {
+		if options.Manifests {
+			query.Set("manifests", "1")
+		}
+		if options.ContainerCount {
+			query.Set("container-count", "1")
+		}
 	}
 
 	serverResp, err := cli.get(ctx, "/images/json", query, nil)

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -29,6 +29,9 @@ keywords: "API, Docker, rcli, REST, documentation"
   query parameter to `true`.
   WARNING: This is experimental and may change at any time without any backward
   compatibility.
+* `GET /images/json` now accepts query parameter `container-count`. When set `true`,
+  images returned will include `Containers`, which provides the count of containers
+  using the image.
 
 ## v1.46 API changes
 


### PR DESCRIPTION
- related to: https://github.com/moby/moby/pull/42531
- closes: https://github.com/moby/moby/pull/48345
- alternative to: https://github.com/moby/moby/pull/48345

This parameter was already supported for some time in the backend (for purposes related to `docker system prune`).
It was also already present in the `imagetypes.ListOptions` but was never actually handled by the client.

This makes the client respect the `ContainerCount` and set the form field when sending the request.


**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
`GET /images/json` now supports the `container-count` parameter which makes the response fill the `Containers` field with a count of containers using the image.  
```

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/moby/moby/assets/5046555/8ba4e302-f31b-4cea-ab6b-a525c7ce0bfd)
