### PR TITLE
inte/networking:  ping with -6 specified when needed

### DIFF
--- a/integration/networking/bridge_test.go
+++ b/integration/networking/bridge_test.go
@@ -36,6 +36,7 @@ func TestBridgeICC(t *testing.T) {
 		name           string
 		bridgeOpts     []func(*types.NetworkCreate)
 		ctr1MacAddress string
+		isIPv6         bool
 		isLinkLocal    bool
 		pingHost       string
 	}{
@@ -55,6 +56,7 @@ func TestBridgeICC(t *testing.T) {
 				network.WithIPv6(),
 				network.WithIPAM("fdf1:a844:380c:b200::/64", "fdf1:a844:380c:b200::1"),
 			},
+			isIPv6: true,
 		},
 		{
 			name: "IPv6 ULA on internal network",
@@ -63,6 +65,7 @@ func TestBridgeICC(t *testing.T) {
 				network.WithInternal(),
 				network.WithIPAM("fdf1:a844:380c:b247::/64", "fdf1:a844:380c:b247::1"),
 			},
+			isIPv6: true,
 		},
 		{
 			name: "IPv6 link-local address on non-internal network",
@@ -75,6 +78,7 @@ func TestBridgeICC(t *testing.T) {
 				network.WithIPAM("fe80::/64", "fe80::1"),
 			},
 			isLinkLocal: true,
+			isIPv6:      true,
 		},
 		{
 			name: "IPv6 link-local address on internal network",
@@ -85,9 +89,10 @@ func TestBridgeICC(t *testing.T) {
 				network.WithIPAM("fe80::/64", "fe80::1"),
 			},
 			isLinkLocal: true,
+			isIPv6:      true,
 		},
 		{
-			// As for 'LL non-internal', but ping the container by name instead of by address
+			// As for 'LL non-internal', ping the container by name instead of by address
 			// - the busybox test containers only have one interface with a link local
 			// address, so the zone index is not required:
 			//   RFC-4007, section 6: "[...] for nodes with only a single non-loopback
@@ -99,6 +104,7 @@ func TestBridgeICC(t *testing.T) {
 				network.WithIPv6(),
 				network.WithIPAM("fe80::/64", "fe80::1"),
 			},
+			isIPv6: true,
 		},
 		{
 			name: "IPv6 nonstandard link-local subnet on non-internal network ping by name",
@@ -111,6 +117,7 @@ func TestBridgeICC(t *testing.T) {
 				network.WithIPv6(),
 				network.WithIPAM("fe80:1234::/64", "fe80:1234::1"),
 			},
+			isIPv6: true,
 		},
 		{
 			name: "IPv6 non-internal network with SLAAC LL address",
@@ -122,6 +129,7 @@ func TestBridgeICC(t *testing.T) {
 			// specify one here to hardcode the SLAAC LL address below.
 			ctr1MacAddress: "02:42:ac:11:00:02",
 			pingHost:       "fe80::42:acff:fe11:2%eth0",
+			isIPv6:         true,
 		},
 		{
 			name: "IPv6 internal network with SLAAC LL address",
@@ -133,6 +141,7 @@ func TestBridgeICC(t *testing.T) {
 			// specify one here to hardcode the SLAAC LL address below.
 			ctr1MacAddress: "02:42:ac:11:00:02",
 			pingHost:       "fe80::42:acff:fe11:2%eth0",
+			isIPv6:         true,
 		},
 	}
 
@@ -170,7 +179,12 @@ func TestBridgeICC(t *testing.T) {
 				}
 			}
 
-			pingCmd := []string{"ping", "-c1", "-W3", pingHost}
+			ipv := "-4"
+			if tc.isIPv6 {
+				ipv = "-6"
+			}
+
+			pingCmd := []string{"ping", "-c1", "-W3", ipv, pingHost}
 
 			ctr2Name := fmt.Sprintf("ctr-icc-%d-2", tcID)
 			attachCtx, cancel := context.WithTimeout(ctx, 5*time.Second)

--- a/integration/networking/bridge_test.go
+++ b/integration/networking/bridge_test.go
@@ -36,7 +36,7 @@ func TestBridgeICC(t *testing.T) {
 		name           string
 		bridgeOpts     []func(*types.NetworkCreate)
 		ctr1MacAddress string
-		linkLocal      bool
+		isLinkLocal    bool
 		pingHost       string
 	}{
 		{
@@ -74,7 +74,7 @@ func TestBridgeICC(t *testing.T) {
 				// 2. the one dynamically assigned by the IPAM driver.
 				network.WithIPAM("fe80::/64", "fe80::1"),
 			},
-			linkLocal: true,
+			isLinkLocal: true,
 		},
 		{
 			name: "IPv6 link-local address on internal network",
@@ -84,7 +84,7 @@ func TestBridgeICC(t *testing.T) {
 				// See the note above about link-local addresses.
 				network.WithIPAM("fe80::/64", "fe80::1"),
 			},
-			linkLocal: true,
+			isLinkLocal: true,
 		},
 		{
 			// As for 'LL non-internal', but ping the container by name instead of by address
@@ -162,7 +162,7 @@ func TestBridgeICC(t *testing.T) {
 
 			pingHost := tc.pingHost
 			if pingHost == "" {
-				if tc.linkLocal {
+				if tc.isLinkLocal {
 					inspect := container.Inspect(ctx, t, c, id1)
 					pingHost = inspect.NetworkSettings.Networks[bridgeName].GlobalIPv6Address + "%eth0"
 				} else {


### PR DESCRIPTION
Related to:

- https://github.com/moby/moby/pull/46609

**- What I did**

Make sure the `ping` command used by `TestBridgeICC` actually has the `-6` flag when it runs IPv6 test cases.  Without this flag, IPv6 connectivity isn't tested properly.

**- How to verify it**

CI is green.