### PR TITLE
[25.0 backport] update RootlessKit to 2.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -352,7 +352,7 @@ FROM base AS rootlesskit-src
 WORKDIR /usr/src/rootlesskit
 RUN git init . && git remote add origin "https://github.com/rootless-containers/rootlesskit.git"
 # When updating, also update vendor.mod and hack/dockerfile/install/rootlesskit.installer accordingly.
-ARG ROOTLESSKIT_VERSION=v2.0.1
+ARG ROOTLESSKIT_VERSION=v2.0.2
 RUN git fetch -q --depth 1 origin "${ROOTLESSKIT_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS rootlesskit-build

--- a/contrib/dockerd-rootless-setuptool.sh
+++ b/contrib/dockerd-rootless-setuptool.sh
@@ -269,6 +269,13 @@ init() {
 	# - sysctl: "net.ipv4.ip_unprivileged_port_start"
 	# - external binary: slirp4netns
 	# - external binary: fuse-overlayfs
+
+	# check RootlessKit functionality. RootlessKit will print hints if something is still unsatisfied.
+	# (e.g., `kernel.apparmor_restrict_unprivileged_userns` constraint)
+	if ! rootlesskit true; then
+		ERROR "RootlessKit failed, see the error messages and https://rootlesscontaine.rs/getting-started/common/ ."
+		exit 1
+	fi
 }
 
 # CLI subcommand: "check"

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # When updating, also update vendor.mod and Dockerfile accordingly.
-: "${ROOTLESSKIT_VERSION:=v2.0.1}"
+: "${ROOTLESSKIT_VERSION:=v2.0.2}"
 
 install_rootlesskit() {
 	case "$1" in


### PR DESCRIPTION
- partially backports: https://github.com/moby/moby/pull/47504 (without vendoring changes)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix https://github.com/moby/moby/issues/47480 (except docs) via:
- https://github.com/rootless-containers/rootlesskit/pull/421

**- How I did it**
Updated RootlessKit
https://github.com/rootless-containers/rootlesskit/compare/v2.0.1...v2.0.2


**- How to verify it**

`dockerd-rootless-setuptool.sh` will print the following error if the apparmor constraint is not satisfied
```
WARN[0000] [rootlesskit:parent] This error might have happened because /proc/sys/kernel/apparmor_restrict_unprivileged_userns is set to 1  error="fork/exec /proc/self/exe: permission denied"
WARN[0000] [rootlesskit:parent] Hint: try running the following commands:


########## BEGIN ##########
cat <<EOT | sudo tee "/etc/apparmor.d/home.suda.bin.rootlesskit"
# ref: https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces
abi <abi/4.0>,
include <tunables/global>

/home/suda/bin/rootlesskit flags=(unconfined) {
  userns,

  # Site-specific additions and overrides. See local/README for details.
  include if exists <local/home.suda.bin.rootlesskit>
}
EOT
sudo systemctl restart apparmor.service
########## END ##########
 
[rootlesskit:parent] error: failed to start the child: fork/exec /proc/self/exe: permission denied
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
update RootlessKit to [v2.0.2](https://github.com/rootless-containers/rootlesskit/releases/tag/v2.0.2)
```

**- A picture of a cute animal (not mandatory but encouraged)**

🐧 