### PR TITLE
Add IPv6 nameserver to the internal DNS's upstreams.

### DIFF
--- a/libnetwork/internal/resolvconf/resolvconf.go
+++ b/libnetwork/internal/resolvconf/resolvconf.go
@@ -237,7 +237,7 @@ func (rc *ResolvConf) TransformForLegacyNw(ipv6 bool) {
 // use in a network sandbox that has an internal DNS resolver.
 //   - Add internalNS as a nameserver.
 //   - Remove other nameservers, stashing them as ExtNameServers for the
-//     internal resolver to use. (Apart from IPv6 nameservers, if keepIPv6.)
+//     internal resolver to use.
 //   - Mark ExtNameServers that must be used in the host namespace.
 //   - If no ExtNameServer addresses are found, use the defaults.
 //   - Return an error if an "ndots" option inherited from the host's config, or
@@ -246,7 +246,7 @@ func (rc *ResolvConf) TransformForLegacyNw(ipv6 bool) {
 //     option includes a ':', and an option with a matching prefix exists, it
 //     is not modified.
 func (rc *ResolvConf) TransformForIntNS(
-	keepIPv6 bool,
+	ipv6 bool,
 	internalNS netip.Addr,
 	reqdOptions []string,
 ) ([]ExtDNSEntry, error) {
@@ -256,30 +256,16 @@ func (rc *ResolvConf) TransformForIntNS(
 	// internal nameserver.
 	rc.md.ExtNameServers = nil
 	for _, addr := range rc.nameServers {
-		// The internal resolver only uses IPv4 addresses so, keep IPv6 nameservers in
-		// the container's file if keepIPv6, else drop them.
-		if addr.Is6() {
-			if keepIPv6 {
-				newNSs = append(newNSs, addr)
-			}
-		} else {
-			// Extract this NS. Mark loopback addresses that did not come from an override as
-			// 'HostLoopback'. Upstream requests for these servers will be made in the host's
-			// network namespace. (So, '--dns 127.0.0.53' means use a nameserver listening on
-			// the container's loopback interface. But, if the host's resolv.conf contains
-			// 'nameserver 127.0.0.53', the host's resolver will be used.)
-			//
-			//  TODO(robmry) - why only loopback addresses?
-			//   Addresses from the host's resolv.conf must be usable in the host's namespace,
-			//   and a lookup from the container's namespace is more expensive? And, for
-			//   example, if the host has a nameserver with an IPv6 LL address with a zone-id,
-			//   it won't work from the container's namespace (now, while the address is left in
-			//   the container's resolv.conf, or in future for the internal resolver).
-			rc.md.ExtNameServers = append(rc.md.ExtNameServers, ExtDNSEntry{
-				Addr:         addr,
-				HostLoopback: addr.IsLoopback() && !rc.md.NSOverride,
-			})
-		}
+		// Extract this NS. Mark addresses that did not come from an override, but will
+		// definitely not work in the container's namespace as 'HostLoopback'. Upstream
+		// requests for these servers will be made in the host's network namespace. (So,
+		// '--dns 127.0.0.53' means use a nameserver listening on the container's
+		// loopback interface. But, if the host's resolv.conf contains 'nameserver
+		// 127.0.0.53', the host's resolver will be used.)
+		rc.md.ExtNameServers = append(rc.md.ExtNameServers, ExtDNSEntry{
+			Addr:         addr,
+			HostLoopback: !rc.md.NSOverride && (addr.IsLoopback() || (addr.Is6() && !ipv6) || addr.Zone() != ""),
+		})
 	}
 	rc.nameServers = newNSs
 
@@ -287,7 +273,7 @@ func (rc *ResolvConf) TransformForIntNS(
 	// internal resolver, use the defaults as ext nameservers.
 	if len(rc.md.ExtNameServers) == 0 && len(rc.nameServers) == 1 {
 		log.G(context.TODO()).Info("No non-localhost DNS nameservers are left in resolv.conf. Using default external servers")
-		for _, addr := range defaultNSAddrs(keepIPv6) {
+		for _, addr := range defaultNSAddrs(ipv6) {
 			rc.md.ExtNameServers = append(rc.md.ExtNameServers, ExtDNSEntry{Addr: addr})
 		}
 		rc.md.UsedDefaultNS = true

--- a/libnetwork/internal/resolvconf/resolvconf_test.go
+++ b/libnetwork/internal/resolvconf/resolvconf_test.go
@@ -351,16 +351,22 @@ func TestRCTransformForIntNS(t *testing.T) {
 			expExtServers: []ExtDNSEntry{mke("10.0.0.1", false)},
 		},
 		{
-			name:          "IPv4 and IPv6, ipv6 enabled",
-			input:         "nameserver 10.0.0.1\nnameserver fdb6:b8fe:b528::1",
-			ipv6:          true,
-			expExtServers: []ExtDNSEntry{mke("10.0.0.1", false)},
+			name:  "IPv4 and IPv6, ipv6 enabled",
+			input: "nameserver 10.0.0.1\nnameserver fdb6:b8fe:b528::1",
+			ipv6:  true,
+			expExtServers: []ExtDNSEntry{
+				mke("10.0.0.1", false),
+				mke("fdb6:b8fe:b528::1", false),
+			},
 		},
 		{
-			name:          "IPv4 and IPv6, ipv6 disabled",
-			input:         "nameserver 10.0.0.1\nnameserver fdb6:b8fe:b528::1",
-			ipv6:          false,
-			expExtServers: []ExtDNSEntry{mke("10.0.0.1", false)},
+			name:  "IPv4 and IPv6, ipv6 disabled",
+			input: "nameserver 10.0.0.1\nnameserver fdb6:b8fe:b528::1",
+			ipv6:  false,
+			expExtServers: []ExtDNSEntry{
+				mke("10.0.0.1", false),
+				mke("fdb6:b8fe:b528::1", true),
+			},
 		},
 		{
 			name:          "IPv4 localhost",
@@ -384,37 +390,46 @@ func TestRCTransformForIntNS(t *testing.T) {
 			expExtServers: []ExtDNSEntry{mke("127.0.0.53", true)},
 		},
 		{
-			name:  "IPv6 addr, IPv6 enabled",
-			input: "nameserver fd14:6e0e:f855::1",
+			name:          "IPv6 addr, IPv6 enabled",
+			input:         "nameserver fd14:6e0e:f855::1",
+			ipv6:          true,
+			expExtServers: []ExtDNSEntry{mke("fd14:6e0e:f855::1", false)},
+		},
+		{
+			name:  "IPv4 and IPv6 localhost, IPv6 disabled",
+			input: "nameserver 127.0.0.53\nnameserver ::1",
+			ipv6:  false,
+			expExtServers: []ExtDNSEntry{
+				mke("127.0.0.53", true),
+				mke("::1", true),
+			},
+		},
+		{
+			name:  "IPv4 and IPv6 localhost, ipv6 enabled",
+			input: "nameserver 127.0.0.53\nnameserver ::1",
 			ipv6:  true,
-			// Note that there are no ext servers in this case, the internal resolver
-			// will only look up container names. The default nameservers aren't added
-			// because the host's IPv6 nameserver remains in the container's resolv.conf,
-			// (because only IPv4 ext servers are currently allowed).
+			expExtServers: []ExtDNSEntry{
+				mke("127.0.0.53", true),
+				mke("::1", true),
+			},
 		},
 		{
-			name:          "IPv4 and IPv6 localhost, IPv6 disabled",
-			input:         "nameserver 127.0.0.53\nnameserver ::1",
-			ipv6:          false,
-			expExtServers: []ExtDNSEntry{mke("127.0.0.53", true)},
+			name:  "IPv4 localhost, IPv6 private, IPv6 enabled",
+			input: "nameserver 127.0.0.53\nnameserver fd3e:2d1a:1f5a::1",
+			ipv6:  true,
+			expExtServers: []ExtDNSEntry{
+				mke("127.0.0.53", true),
+				mke("fd3e:2d1a:1f5a::1", false),
+			},
 		},
 		{
-			name:          "IPv4 and IPv6 localhost, ipv6 enabled",
-			input:         "nameserver 127.0.0.53\nnameserver ::1",
-			ipv6:          true,
-			expExtServers: []ExtDNSEntry{mke("127.0.0.53", true)},
-		},
-		{
-			name:          "IPv4 localhost, IPv6 private, IPv6 enabled",
-			input:         "nameserver 127.0.0.53\nnameserver fd3e:2d1a:1f5a::1",
-			ipv6:          true,
-			expExtServers: []ExtDNSEntry{mke("127.0.0.53", true)},
-		},
-		{
-			name:          "IPv4 localhost, IPv6 private, IPv6 disabled",
-			input:         "nameserver 127.0.0.53\nnameserver fd3e:2d1a:1f5a::1",
-			ipv6:          false,
-			expExtServers: []ExtDNSEntry{mke("127.0.0.53", true)},
+			name:  "IPv4 localhost, IPv6 private, IPv6 disabled",
+			input: "nameserver 127.0.0.53\nnameserver fd3e:2d1a:1f5a::1",
+			ipv6:  false,
+			expExtServers: []ExtDNSEntry{
+				mke("127.0.0.53", true),
+				mke("fd3e:2d1a:1f5a::1", true),
+			},
 		},
 		{
 			name:  "No host nameserver, no iv6",

--- a/libnetwork/internal/resolvconf/testdata/TestRCTransformForIntNS/IPv4_and_IPv6,_ipv6_disabled.golden
+++ b/libnetwork/internal/resolvconf/testdata/TestRCTransformForIntNS/IPv4_and_IPv6,_ipv6_disabled.golden
@@ -1,5 +1,5 @@
 nameserver 127.0.0.11
 
 # Based on host file: '/etc/resolv.conf' (internal resolver)
-# ExtServers: [10.0.0.1]
+# ExtServers: [10.0.0.1 host(fdb6:b8fe:b528::1)]
 # Overrides: []

--- a/libnetwork/internal/resolvconf/testdata/TestRCTransformForIntNS/IPv4_and_IPv6,_ipv6_enabled.golden
+++ b/libnetwork/internal/resolvconf/testdata/TestRCTransformForIntNS/IPv4_and_IPv6,_ipv6_enabled.golden
@@ -1,6 +1,5 @@
 nameserver 127.0.0.11
-nameserver fdb6:b8fe:b528::1
 
 # Based on host file: '/etc/resolv.conf' (internal resolver)
-# ExtServers: [10.0.0.1]
+# ExtServers: [10.0.0.1 fdb6:b8fe:b528::1]
 # Overrides: []

--- a/libnetwork/internal/resolvconf/testdata/TestRCTransformForIntNS/IPv4_and_IPv6_localhost,_IPv6_disabled.golden
+++ b/libnetwork/internal/resolvconf/testdata/TestRCTransformForIntNS/IPv4_and_IPv6_localhost,_IPv6_disabled.golden
@@ -1,5 +1,5 @@
 nameserver 127.0.0.11
 
 # Based on host file: '/etc/resolv.conf' (internal resolver)
-# ExtServers: [host(127.0.0.53)]
+# ExtServers: [host(127.0.0.53) host(::1)]
 # Overrides: []

--- a/libnetwork/internal/resolvconf/testdata/TestRCTransformForIntNS/IPv4_and_IPv6_localhost,_ipv6_enabled.golden
+++ b/libnetwork/internal/resolvconf/testdata/TestRCTransformForIntNS/IPv4_and_IPv6_localhost,_ipv6_enabled.golden
@@ -1,6 +1,5 @@
 nameserver 127.0.0.11
-nameserver ::1
 
 # Based on host file: '/etc/resolv.conf' (internal resolver)
-# ExtServers: [host(127.0.0.53)]
+# ExtServers: [host(127.0.0.53) host(::1)]
 # Overrides: []

--- a/libnetwork/internal/resolvconf/testdata/TestRCTransformForIntNS/IPv4_localhost,_IPv6_private,_IPv6_disabled.golden
+++ b/libnetwork/internal/resolvconf/testdata/TestRCTransformForIntNS/IPv4_localhost,_IPv6_private,_IPv6_disabled.golden
@@ -1,5 +1,5 @@
 nameserver 127.0.0.11
 
 # Based on host file: '/etc/resolv.conf' (internal resolver)
-# ExtServers: [host(127.0.0.53)]
+# ExtServers: [host(127.0.0.53) host(fd3e:2d1a:1f5a::1)]
 # Overrides: []

--- a/libnetwork/internal/resolvconf/testdata/TestRCTransformForIntNS/IPv4_localhost,_IPv6_private,_IPv6_enabled.golden
+++ b/libnetwork/internal/resolvconf/testdata/TestRCTransformForIntNS/IPv4_localhost,_IPv6_private,_IPv6_enabled.golden
@@ -1,6 +1,5 @@
 nameserver 127.0.0.11
-nameserver fd3e:2d1a:1f5a::1
 
 # Based on host file: '/etc/resolv.conf' (internal resolver)
-# ExtServers: [host(127.0.0.53)]
+# ExtServers: [host(127.0.0.53) fd3e:2d1a:1f5a::1]
 # Overrides: []

--- a/libnetwork/internal/resolvconf/testdata/TestRCTransformForIntNS/IPv6_addr,_IPv6_enabled.golden
+++ b/libnetwork/internal/resolvconf/testdata/TestRCTransformForIntNS/IPv6_addr,_IPv6_enabled.golden
@@ -1,5 +1,5 @@
 nameserver 127.0.0.11
-nameserver fd14:6e0e:f855::1
 
 # Based on host file: '/etc/resolv.conf' (internal resolver)
+# ExtServers: [fd14:6e0e:f855::1]
 # Overrides: []

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -1838,7 +1838,7 @@ func TestResolvConf(t *testing.T) {
 			makeNet:          makeTestIPv6Network,
 			delNet:           true,
 			originResolvConf: "search pommesfrites.fr\nnameserver 12.34.56.78\nnameserver 2001:4860:4860::8888\n",
-			expResolvConf:    "nameserver 127.0.0.11\nnameserver 2001:4860:4860::8888\nsearch pommesfrites.fr\noptions ndots:0",
+			expResolvConf:    "nameserver 127.0.0.11\nsearch pommesfrites.fr\noptions ndots:0",
 		},
 		{
 			name:             "host network",


### PR DESCRIPTION
**- What I did**

When configuring the internal DNS resolver - rather than keep IPv6 nameservers read from the host's resolv.conf in the container's resolv.conf, treat them like IPv4 addresses and use them as upstream resolvers.

Fixes https://github.com/moby/moby/issues/46329

**- How I did it**

For IPv6 nameservers, if there's a zone identifier in the address or the container itself doesn't have IPv6 support, mark the upstream addresses for use in the host's network namespace.

**- How to verify it**

Updated unit tests.

I gather our test hosts don't have IPv6, so I don't think we can have an integration test with an IPv6 upstream resolver (?).

On an Ubuntu VM ...

With the host's `resolv.conf` listing one of Google's IPv6 nameservers - before this change, the IPv6 nameserver ends up in the container's `resolv.conf` along with the internal resolver ...

```
$ docker run --rm -ti --network nnn6 --name ccc alpine
/ # cat /etc/resolv.conf
# Generated by Docker Engine.
# This file can be edited; Docker Engine will not make further changes once it
# has been modified.

nameserver 127.0.0.11
nameserver 2001:4860:4860::8888
search Home
options edns0 trust-ad ndots:0

# Based on host file: '/etc/resolv.conf' (internal resolver)
# Overrides: []
# Option ndots from: internal
/ #
```

With the change, the upstream IPv6 server is listed as an "ExtServer" ...

```
$ docker run --rm -ti --network nnn6 --name ccc alpine
/ # cat /etc/resolv.conf
# Generated by Docker Engine.
# This file can be edited; Docker Engine will not make further changes once it
# has been modified.

nameserver 127.0.0.11
search Home
options edns0 trust-ad ndots:0

# Based on host file: '/etc/resolv.conf' (internal resolver)
# ExtServers: [2001:4860:4860::8888]
# Overrides: []
# Option ndots from: internal
/ # ping -6 google.com
PING google.com (2a00:1450:4009:827::200e): 56 data bytes
64 bytes from 2a00:1450:4009:827::200e: seq=0 ttl=118 time=9.584 ms
64 bytes from 2a00:1450:4009:827::200e: seq=1 ttl=118 time=9.184 ms
^C
--- google.com ping statistics ---
2 packets transmitted, 2 packets received, 0% packet loss
round-trip min/avg/max = 9.184/9.384/9.584 ms
/ # ping ccc
PING ccc (172.19.0.2): 56 data bytes
64 bytes from 172.19.0.2: seq=0 ttl=64 time=0.021 ms
^C
--- ccc ping statistics ---
1 packets transmitted, 1 packets received, 0% packet loss
round-trip min/avg/max = 0.021/0.021/0.021 ms
/ # ping -6 ccc
PING ccc (fd00:1234::2): 56 data bytes
64 bytes from fd00:1234::2: seq=0 ttl=64 time=0.039 ms
64 bytes from fd00:1234::2: seq=1 ttl=64 time=0.144 ms
^C
```

When the host's `resolv.conf` has a zone-id in the nameserver's address, the ExtServer is listed with the `host` marker, meaning the upstream request will happen in the host's namespace ...

```
$ docker run --rm -ti --network nnn6 --name ccc alpine
/ # cat /etc/resolv.conf
# Generated by Docker Engine.
# This file can be edited; Docker Engine will not make further changes once it
# has been modified.

nameserver 127.0.0.11
search Home
options edns0 trust-ad ndots:0

# Based on host file: '/etc/resolv.conf' (internal resolver)
# ExtServers: [host(2001:4860:4860::8888%enp0s3)]
# Overrides: []
# Option ndots from: internal
/ # ping google.com
PING google.com (216.58.204.78): 56 data bytes
64 bytes from 216.58.204.78: seq=0 ttl=118 time=8.762 ms
64 bytes from 216.58.204.78: seq=1 ttl=118 time=10.361 ms
^C
```

When the container has IPv6 disabled, the IPv6 ExtServer is still used - but from the host's namespace ...

```
$ docker run --rm -ti --network nnn6 --name ccc --sysctl net.ipv6.conf.all.disable_ipv6=1  alpine
/ # cat /etc/resolv.conf
# Generated by Docker Engine.
# This file can be edited; Docker Engine will not make further changes once it
# has been modified.

nameserver 127.0.0.11
search Home
options edns0 trust-ad ndots:0

# Based on host file: '/etc/resolv.conf' (internal resolver)
# ExtServers: [host(2001:4860:4860::8888)]
# Overrides: []
# Option ndots from: internal
/ # ping google.com
PING google.com (216.58.204.78): 56 data bytes
64 bytes from 216.58.204.78: seq=0 ttl=118 time=14.229 ms
^C
```

**- Description for the changelog**
```markdown changelog
Use IPv6 nameservers from the host's `resolv.conf` as upstream resolvers for Docker Engine's internal DNS, rather than listing them in the container's `resolv.conf`.
```
