### PR TITLE
feat: more context on docker client

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -2,6 +2,7 @@ package types // import "github.com/docker/docker/api/types"
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"net"
 
@@ -176,7 +177,7 @@ type ImageLoadResponse struct {
 // This function returns the registry authentication
 // header value in base 64 format, or an error
 // if the privilege request fails.
-type RequestPrivilegeFunc func() (string, error)
+type RequestPrivilegeFunc func(context.Context) (string, error)
 
 // ImageSearchOptions holds parameters to search images with.
 type ImageSearchOptions struct {
@@ -289,7 +290,7 @@ type PluginInstallOptions struct {
 	RegistryAuth          string // RegistryAuth is the base64 encoded credentials for the registry
 	RemoteRef             string // RemoteRef is the plugin name on the registry
 	PrivilegeFunc         RequestPrivilegeFunc
-	AcceptPermissionsFunc func(PluginPrivileges) (bool, error)
+	AcceptPermissionsFunc func(context.Context, PluginPrivileges) (bool, error)
 	Args                  []string
 }
 

--- a/api/types/image/opts.go
+++ b/api/types/image/opts.go
@@ -1,6 +1,10 @@
 package image
 
-import "github.com/docker/docker/api/types/filters"
+import (
+	"context"
+
+	"github.com/docker/docker/api/types/filters"
+)
 
 // ImportOptions holds information to import images from the client host.
 type ImportOptions struct {
@@ -27,7 +31,7 @@ type PullOptions struct {
 	// privilege request fails.
 	//
 	// Also see [github.com/docker/docker/api/types.RequestPrivilegeFunc].
-	PrivilegeFunc func() (string, error)
+	PrivilegeFunc func(context.Context) (string, error)
 	Platform      string
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -271,7 +271,7 @@ func (cli *Client) checkVersion(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		cli.negotiateAPIVersionPing(ctx, ping)
+		cli.negotiateAPIVersionPing(ping)
 	}
 	return nil
 }
@@ -317,7 +317,7 @@ func (cli *Client) NegotiateAPIVersion(ctx context.Context) {
 			// FIXME(thaJeztah): Ping returns an error when failing to connect to the API; we should not swallow the error here, and instead returning it.
 			return
 		}
-		cli.negotiateAPIVersionPing(ctx, ping)
+		cli.negotiateAPIVersionPing(ping)
 	}
 }
 
@@ -336,13 +336,13 @@ func (cli *Client) NegotiateAPIVersion(ctx context.Context) {
 // added (1.24).
 func (cli *Client) NegotiateAPIVersionPing(ctx context.Context, pingResponse types.Ping) {
 	if !cli.manualOverride {
-		cli.negotiateAPIVersionPing(ctx, pingResponse)
+		cli.negotiateAPIVersionPing(pingResponse)
 	}
 }
 
 // negotiateAPIVersionPing queries the API and updates the version to match the
 // API version from the ping response.
-func (cli *Client) negotiateAPIVersionPing(_ context.Context, pingResponse types.Ping) {
+func (cli *Client) negotiateAPIVersionPing(pingResponse types.Ping) {
 	// default to the latest version before versioning headers existed
 	if pingResponse.APIVersion == "" {
 		pingResponse.APIVersion = fallbackAPIVersion

--- a/client/client_deprecated.go
+++ b/client/client_deprecated.go
@@ -17,14 +17,14 @@ import (
 // [WithHTTPClient] and [WithHTTPHeaders] options. We recommend enabling API
 // version negotiation by passing the [WithAPIVersionNegotiation] option instead
 // of WithVersion.
-func NewClient(ctx context.Context, host string, version string, client *http.Client, httpHeaders map[string]string) (*Client, error) {
-	return NewClientWithOpts(ctx, WithHost(host), WithVersion(version), WithHTTPClient(client), WithHTTPHeaders(httpHeaders))
+func NewClient(host string, version string, client *http.Client, httpHeaders map[string]string) (*Client, error) {
+	return NewClientWithOpts(context.Background(), WithHost(host), WithVersion(version), WithHTTPClient(client), WithHTTPHeaders(httpHeaders))
 }
 
 // NewEnvClient initializes a new API client based on environment variables.
 // See FromEnv for a list of support environment variables.
 //
 // Deprecated: use [NewClientWithOpts] passing the [FromEnv] option.
-func NewEnvClient(ctx context.Context) (*Client, error) {
-	return NewClientWithOpts(ctx, FromEnv)
+func NewEnvClient() (*Client, error) {
+	return NewClientWithOpts(context.Background(), FromEnv)
 }

--- a/client/client_deprecated.go
+++ b/client/client_deprecated.go
@@ -1,6 +1,9 @@
 package client
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // NewClient initializes a new API client for the given host and API version.
 // It uses the given http client as transport.
@@ -14,14 +17,14 @@ import "net/http"
 // [WithHTTPClient] and [WithHTTPHeaders] options. We recommend enabling API
 // version negotiation by passing the [WithAPIVersionNegotiation] option instead
 // of WithVersion.
-func NewClient(host string, version string, client *http.Client, httpHeaders map[string]string) (*Client, error) {
-	return NewClientWithOpts(WithHost(host), WithVersion(version), WithHTTPClient(client), WithHTTPHeaders(httpHeaders))
+func NewClient(ctx context.Context, host string, version string, client *http.Client, httpHeaders map[string]string) (*Client, error) {
+	return NewClientWithOpts(ctx, WithHost(host), WithVersion(version), WithHTTPClient(client), WithHTTPHeaders(httpHeaders))
 }
 
 // NewEnvClient initializes a new API client based on environment variables.
 // See FromEnv for a list of support environment variables.
 //
 // Deprecated: use [NewClientWithOpts] passing the [FromEnv] option.
-func NewEnvClient() (*Client, error) {
-	return NewClientWithOpts(FromEnv)
+func NewEnvClient(ctx context.Context) (*Client, error) {
+	return NewClientWithOpts(ctx, FromEnv)
 }

--- a/client/container_create.go
+++ b/client/container_create.go
@@ -46,22 +46,22 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 	}
 
 	if hostConfig != nil {
-		if versions.LessThan(cli.ClientVersion(), "1.25") {
+		if versions.LessThan(cli.ClientVersion(ctx), "1.25") {
 			// When using API 1.24 and under, the client is responsible for removing the container
 			hostConfig.AutoRemove = false
 		}
-		if versions.GreaterThanOrEqualTo(cli.ClientVersion(), "1.42") || versions.LessThan(cli.ClientVersion(), "1.40") {
+		if versions.GreaterThanOrEqualTo(cli.ClientVersion(ctx), "1.42") || versions.LessThan(cli.ClientVersion(ctx), "1.40") {
 			// KernelMemory was added in API 1.40, and deprecated in API 1.42
 			hostConfig.KernelMemory = 0
 		}
-		if platform != nil && platform.OS == "linux" && versions.LessThan(cli.ClientVersion(), "1.42") {
+		if platform != nil && platform.OS == "linux" && versions.LessThan(cli.ClientVersion(ctx), "1.42") {
 			// When using API under 1.42, the Linux daemon doesn't respect the ConsoleSize
 			hostConfig.ConsoleSize = [2]uint{0, 0}
 		}
 	}
 
 	// Since API 1.44, the container-wide MacAddress is deprecated and will trigger a WARNING if it's specified.
-	if versions.GreaterThanOrEqualTo(cli.ClientVersion(), "1.44") {
+	if versions.GreaterThanOrEqualTo(cli.ClientVersion(ctx), "1.44") {
 		config.MacAddress = "" //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
 	}
 

--- a/client/container_create_test.go
+++ b/client/container_create_test.go
@@ -119,7 +119,10 @@ func TestContainerCreateAutoRemove(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestContainerCreateConnectionError(t *testing.T) {
-	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	client, err := NewClientWithOpts(ctx, WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.ContainerCreate(context.Background(), nil, nil, nil, nil, "")

--- a/client/container_exec.go
+++ b/client/container_exec.go
@@ -25,7 +25,7 @@ func (cli *Client) ContainerExecCreate(ctx context.Context, container string, co
 	if err := cli.NewVersionError(ctx, "1.25", "env"); len(config.Env) != 0 && err != nil {
 		return response, err
 	}
-	if versions.LessThan(cli.ClientVersion(), "1.42") {
+	if versions.LessThan(cli.ClientVersion(ctx), "1.42") {
 		config.ConsoleSize = nil
 	}
 
@@ -40,7 +40,7 @@ func (cli *Client) ContainerExecCreate(ctx context.Context, container string, co
 
 // ContainerExecStart starts an exec process already created in the docker host.
 func (cli *Client) ContainerExecStart(ctx context.Context, execID string, config types.ExecStartCheck) error {
-	if versions.LessThan(cli.ClientVersion(), "1.42") {
+	if versions.LessThan(cli.ClientVersion(ctx), "1.42") {
 		config.ConsoleSize = nil
 	}
 	resp, err := cli.post(ctx, "/exec/"+execID+"/start", nil, config, nil)
@@ -53,7 +53,7 @@ func (cli *Client) ContainerExecStart(ctx context.Context, execID string, config
 // and the a reader to get output. It's up to the called to close
 // the hijacked connection by calling types.HijackedResponse.Close.
 func (cli *Client) ContainerExecAttach(ctx context.Context, execID string, config types.ExecStartCheck) (types.HijackedResponse, error) {
-	if versions.LessThan(cli.ClientVersion(), "1.42") {
+	if versions.LessThan(cli.ClientVersion(ctx), "1.42") {
 		config.ConsoleSize = nil
 	}
 	return cli.postHijacked(ctx, "/exec/"+execID+"/start", nil, config, http.Header{

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -29,7 +29,10 @@ func TestContainerExecCreateError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestContainerExecCreateConnectionError(t *testing.T) {
-	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	client, err := NewClientWithOpts(ctx, WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.ContainerExecCreate(context.Background(), "", types.ExecConfig{})

--- a/client/container_logs_test.go
+++ b/client/container_logs_test.go
@@ -152,7 +152,7 @@ func ExampleClient_ContainerLogs_withTimeout() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	client, _ := NewClientWithOpts(FromEnv)
+	client, _ := NewClientWithOpts(ctx, FromEnv)
 	reader, err := client.ContainerLogs(ctx, "container_id", container.LogsOptions{})
 	if err != nil {
 		log.Fatal(err)

--- a/client/container_restart_test.go
+++ b/client/container_restart_test.go
@@ -28,7 +28,10 @@ func TestContainerRestartError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestContainerRestartConnectionError(t *testing.T) {
-	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	client, err := NewClientWithOpts(ctx, WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	err = client.ContainerRestart(context.Background(), "nothing", container.StopOptions{})

--- a/client/container_stop_test.go
+++ b/client/container_stop_test.go
@@ -28,7 +28,10 @@ func TestContainerStopError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestContainerStopConnectionError(t *testing.T) {
-	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	client, err := NewClientWithOpts(ctx, WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	err = client.ContainerStop(context.Background(), "nothing", container.StopOptions{})

--- a/client/container_wait.go
+++ b/client/container_wait.go
@@ -42,7 +42,7 @@ func (cli *Client) ContainerWait(ctx context.Context, containerID string, condit
 		errC <- err
 		return resultC, errC
 	}
-	if versions.LessThan(cli.ClientVersion(), "1.30") {
+	if versions.LessThan(cli.ClientVersion(ctx), "1.30") {
 		return cli.legacyContainerWait(ctx, containerID)
 	}
 

--- a/client/container_wait_test.go
+++ b/client/container_wait_test.go
@@ -39,7 +39,10 @@ func TestContainerWaitError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestContainerWaitConnectionError(t *testing.T) {
-	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	client, err := NewClientWithOpts(ctx, WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	resultC, errC := client.ContainerWait(context.Background(), "nothing", "")
@@ -181,7 +184,7 @@ func ExampleClient_ContainerWait_withTimeout() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	client, _ := NewClientWithOpts(FromEnv)
+	client, _ := NewClientWithOpts(ctx, FromEnv)
 	_, errC := client.ContainerWait(ctx, "container_id", "")
 	if err := <-errC; err != nil {
 		log.Fatal(err)

--- a/client/hijack.go
+++ b/client/hijack.go
@@ -50,7 +50,7 @@ func (cli *Client) setupHijackConn(req *http.Request, proto string) (_ net.Conn,
 	req.Header.Set("Connection", "Upgrade")
 	req.Header.Set("Upgrade", proto)
 
-	dialer := cli.Dialer()
+	dialer := cli.Dialer(ctx)
 	conn, err := dialer(ctx)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "cannot connect to the Docker daemon. Is 'docker daemon' running on this host?")
@@ -97,7 +97,7 @@ func (cli *Client) setupHijackConn(req *http.Request, proto string) (_ net.Conn,
 	}
 
 	var mediaType string
-	if versions.GreaterThanOrEqualTo(cli.ClientVersion(), "1.42") {
+	if versions.GreaterThanOrEqualTo(cli.ClientVersion(ctx), "1.42") {
 		// Prior to 1.42, Content-Type is always set to raw-stream and not relevant
 		mediaType = resp.Header.Get("Content-Type")
 	}

--- a/client/hijack_test.go
+++ b/client/hijack_test.go
@@ -18,6 +18,8 @@ import (
 
 func TestTLSCloseWriter(t *testing.T) {
 	t.Parallel()
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
 
 	var chErr chan error
 	ts := &httptest.Server{Config: &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -78,10 +80,10 @@ func TestTLSCloseWriter(t *testing.T) {
 	serverURL, err := url.Parse(ts.URL)
 	assert.NilError(t, err)
 
-	client, err := NewClientWithOpts(WithHost("tcp://"+serverURL.Host), WithHTTPClient(ts.Client()))
+	client, err := NewClientWithOpts(ctx, WithHost("tcp://"+serverURL.Host), WithHTTPClient(ts.Client()))
 	assert.NilError(t, err)
 
-	resp, err := client.postHijacked(context.Background(), "/asdf", url.Values{}, nil, map[string][]string{"Content-Type": {"text/plain"}})
+	resp, err := client.postHijacked(ctx, "/asdf", url.Values{}, nil, map[string][]string{"Content-Type": {"text/plain"}})
 	assert.NilError(t, err)
 	defer resp.Close()
 

--- a/client/image_list_test.go
+++ b/client/image_list_test.go
@@ -32,7 +32,10 @@ func TestImageListError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestImageListConnectionError(t *testing.T) {
-	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	client, err := NewClientWithOpts(ctx, WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.ImageList(context.Background(), image.ListOptions{})

--- a/client/image_search.go
+++ b/client/image_search.go
@@ -34,7 +34,7 @@ func (cli *Client) ImageSearch(ctx context.Context, term string, options types.I
 	resp, err := cli.tryImageSearch(ctx, query, options.RegistryAuth)
 	defer ensureReaderClosed(resp)
 	if errdefs.IsUnauthorized(err) && options.PrivilegeFunc != nil {
-		newAuthHeader, privilegeErr := options.PrivilegeFunc()
+		newAuthHeader, privilegeErr := options.PrivilegeFunc(ctx)
 		if privilegeErr != nil {
 			return results, privilegeErr
 		}

--- a/client/image_search_test.go
+++ b/client/image_search_test.go
@@ -38,7 +38,7 @@ func TestImageSearchWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")),
 	}
-	privilegeFunc := func() (string, error) {
+	privilegeFunc := func(_ context.Context) (string, error) {
 		return "", fmt.Errorf("Error requesting privilege")
 	}
 	_, err := client.ImageSearch(context.Background(), "some-image", types.ImageSearchOptions{
@@ -53,7 +53,7 @@ func TestImageSearchWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")),
 	}
-	privilegeFunc := func() (string, error) {
+	privilegeFunc := func(_ context.Context) (string, error) {
 		return "a-auth-header", nil
 	}
 	_, err := client.ImageSearch(context.Background(), "some-image", types.ImageSearchOptions{
@@ -98,7 +98,7 @@ func TestImageSearchWithPrivilegedFuncNoError(t *testing.T) {
 			}, nil
 		}),
 	}
-	privilegeFunc := func() (string, error) {
+	privilegeFunc := func(_ context.Context) (string, error) {
 		return "IAmValid", nil
 	}
 	results, err := client.ImageSearch(context.Background(), "some-image", types.ImageSearchOptions{

--- a/client/interface.go
+++ b/client/interface.go
@@ -33,15 +33,15 @@ type CommonAPIClient interface {
 	SecretAPIClient
 	SystemAPIClient
 	VolumeAPIClient
-	ClientVersion() string
-	DaemonHost() string
-	HTTPClient() *http.Client
+	ClientVersion(context.Context) string
+	DaemonHost(context.Context) string
+	HTTPClient(context.Context) *http.Client
 	ServerVersion(ctx context.Context) (types.Version, error)
 	NegotiateAPIVersion(ctx context.Context)
-	NegotiateAPIVersionPing(types.Ping)
+	NegotiateAPIVersionPing(context.Context, types.Ping)
 	DialHijack(ctx context.Context, url, proto string, meta map[string][]string) (net.Conn, error)
-	Dialer() func(context.Context) (net.Conn, error)
-	Close() error
+	Dialer(context.Context) func(context.Context) (net.Conn, error)
+	Close(context.Context) error
 }
 
 // ContainerAPIClient defines API client methods for the containers

--- a/client/network_create_test.go
+++ b/client/network_create_test.go
@@ -30,7 +30,10 @@ func TestNetworkCreateError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestNetworkCreateConnectionError(t *testing.T) {
-	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	client, err := NewClientWithOpts(ctx, WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.NetworkCreate(context.Background(), "mynetwork", types.NetworkCreate{})

--- a/client/plugin_install.go
+++ b/client/plugin_install.go
@@ -84,7 +84,7 @@ func (cli *Client) checkPluginPermissions(ctx context.Context, query url.Values,
 	resp, err := cli.tryPluginPrivileges(ctx, query, options.RegistryAuth)
 	if errdefs.IsUnauthorized(err) && options.PrivilegeFunc != nil {
 		// todo: do inspect before to check existing name before checking privileges
-		newAuthHeader, privilegeErr := options.PrivilegeFunc()
+		newAuthHeader, privilegeErr := options.PrivilegeFunc(ctx)
 		if privilegeErr != nil {
 			ensureReaderClosed(resp)
 			return nil, privilegeErr
@@ -105,7 +105,7 @@ func (cli *Client) checkPluginPermissions(ctx context.Context, query url.Values,
 	ensureReaderClosed(resp)
 
 	if !options.AcceptAllPermissions && options.AcceptPermissionsFunc != nil && len(privileges) > 0 {
-		accept, err := options.AcceptPermissionsFunc(privileges)
+		accept, err := options.AcceptPermissionsFunc(ctx, privileges)
 		if err != nil {
 			return nil, err
 		}

--- a/client/service_create_test.go
+++ b/client/service_create_test.go
@@ -33,7 +33,10 @@ func TestServiceCreateError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestServiceCreateConnectionError(t *testing.T) {
-	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	client, err := NewClientWithOpts(ctx, WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, types.ServiceCreateOptions{})

--- a/client/service_logs_test.go
+++ b/client/service_logs_test.go
@@ -123,7 +123,7 @@ func ExampleClient_ServiceLogs_withTimeout() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	client, _ := NewClientWithOpts(FromEnv)
+	client, _ := NewClientWithOpts(ctx, FromEnv)
 	reader, err := client.ServiceLogs(ctx, "service_id", container.LogsOptions{})
 	if err != nil {
 		log.Fatal(err)

--- a/client/service_update_test.go
+++ b/client/service_update_test.go
@@ -30,7 +30,10 @@ func TestServiceUpdateError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestServiceUpdateConnectionError(t *testing.T) {
-	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	client, err := NewClientWithOpts(ctx, WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.ServiceUpdate(context.Background(), "service_id", swarm.Version{}, swarm.ServiceSpec{}, types.ServiceUpdateOptions{})

--- a/client/volume_remove_test.go
+++ b/client/volume_remove_test.go
@@ -28,7 +28,10 @@ func TestVolumeRemoveError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestVolumeRemoveConnectionError(t *testing.T) {
-	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	client, err := NewClientWithOpts(ctx, WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	err = client.VolumeRemove(context.Background(), "volume_id", false)

--- a/integration-cli/daemon/daemon_swarm.go
+++ b/integration-cli/daemon/daemon_swarm.go
@@ -101,7 +101,7 @@ func (d *Daemon) CheckServiceTasks(ctx context.Context, service string) func(*te
 func (d *Daemon) CheckRunningTaskNetworks(ctx context.Context) func(t *testing.T) (interface{}, string) {
 	return func(t *testing.T) (interface{}, string) {
 		cli := d.NewClientT(t)
-		defer cli.Close()
+		defer cli.Close(ctx)
 
 		tasks, err := cli.TaskList(ctx, types.TaskListOptions{
 			Filters: filters.NewArgs(filters.Arg("desired-state", "running")),
@@ -122,7 +122,7 @@ func (d *Daemon) CheckRunningTaskNetworks(ctx context.Context) func(t *testing.T
 func (d *Daemon) CheckRunningTaskImages(ctx context.Context) func(t *testing.T) (interface{}, string) {
 	return func(t *testing.T) (interface{}, string) {
 		cli := d.NewClientT(t)
-		defer cli.Close()
+		defer cli.Close(ctx)
 
 		tasks, err := cli.TaskList(ctx, types.TaskListOptions{
 			Filters: filters.NewArgs(filters.Arg("desired-state", "running")),
@@ -174,7 +174,7 @@ func (d *Daemon) CheckControlAvailable(ctx context.Context) func(t *testing.T) (
 func (d *Daemon) CheckLeader(ctx context.Context) func(t *testing.T) (interface{}, string) {
 	return func(t *testing.T) (interface{}, string) {
 		cli := d.NewClientT(t)
-		defer cli.Close()
+		defer cli.Close(ctx)
 
 		errList := "could not get node list"
 

--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -61,14 +61,17 @@ func (s *DockerAPISuite) TestExecAPICreateContainerPaused(c *testing.T) {
 
 	cli.DockerCmd(c, "pause", name)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	ctx, cancel := context.WithCancel(testutil.GetContext(c))
+	defer cancel()
+
+	apiClient, err := client.NewClientWithOpts(ctx, client.FromEnv)
 	assert.NilError(c, err)
-	defer apiClient.Close()
+	defer apiClient.Close(ctx)
 
 	config := types.ExecConfig{
 		Cmd: []string{"true"},
 	}
-	_, err = apiClient.ContainerExecCreate(testutil.GetContext(c), name, config)
+	_, err = apiClient.ContainerExecCreate(ctx, name, config)
 	assert.ErrorContains(c, err, "Container "+name+" is paused, unpause the container before exec", "Expected message when creating exec command with Container %s is paused", name)
 }
 
@@ -131,9 +134,9 @@ func (s *DockerAPISuite) TestExecAPIStartWithDetach(c *testing.T) {
 		AttachStderr: true,
 	}
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.NewClientWithOpts(ctx, client.FromEnv)
 	assert.NilError(c, err)
-	defer apiClient.Close()
+	defer apiClient.Close(ctx)
 
 	createResp, err := apiClient.ContainerExecCreate(ctx, name, config)
 	assert.NilError(c, err)

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -72,11 +73,14 @@ func (s *DockerAPISuite) TestInspectAPIContainerVolumeDriver(c *testing.T) {
 
 func (s *DockerAPISuite) TestInspectAPIImageResponse(c *testing.T) {
 	cli.DockerCmd(c, "tag", "busybox:latest", "busybox:mytag")
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
-	assert.NilError(c, err)
-	defer apiClient.Close()
+	ctx, cancel := context.WithCancel(testutil.GetContext(c))
+	defer cancel()
 
-	imageJSON, _, err := apiClient.ImageInspectWithRaw(testutil.GetContext(c), "busybox")
+	apiClient, err := client.NewClientWithOpts(ctx, client.FromEnv)
+	assert.NilError(c, err)
+	defer apiClient.Close(ctx)
+
+	imageJSON, _, err := apiClient.ImageInspectWithRaw(ctx, "busybox")
 	assert.NilError(c, err)
 
 	assert.Check(c, len(imageJSON.RepoTags) == 2)

--- a/integration-cli/docker_api_logs_test.go
+++ b/integration-cli/docker_api_logs_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -59,9 +60,13 @@ func (s *DockerAPISuite) TestLogsAPIWithStdout(c *testing.T) {
 func (s *DockerAPISuite) TestLogsAPINoStdoutNorStderr(c *testing.T) {
 	const name = "logs_test"
 	cli.DockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	apiClient, err := client.NewClientWithOpts(ctx, client.FromEnv)
 	assert.NilError(c, err)
-	defer apiClient.Close()
+	defer apiClient.Close(ctx)
 
 	_, err = apiClient.ContainerLogs(testutil.GetContext(c), name, container.LogsOptions{})
 	assert.ErrorContains(c, err, "Bad parameters: you must choose at least one stream")
@@ -101,7 +106,10 @@ func (s *DockerAPISuite) TestLogsAPIUntilFutureFollow(c *testing.T) {
 	assert.NilError(c, err)
 	until := daemonTime(c).Add(untilDur)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	apiClient, err := client.NewClientWithOpts(ctx, client.FromEnv)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -166,7 +174,10 @@ func (s *DockerAPISuite) TestLogsAPIUntil(c *testing.T) {
 	const name = "logsuntil"
 	cli.DockerCmd(c, "run", "--name", name, "busybox", "/bin/sh", "-c", "for i in $(seq 1 3); do echo log$i; sleep 1; done")
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	apiClient, err := client.NewClientWithOpts(ctx, client.FromEnv)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -203,7 +214,10 @@ func (s *DockerAPISuite) TestLogsAPIUntilDefaultValue(c *testing.T) {
 	const name = "logsuntildefaultval"
 	cli.DockerCmd(c, "run", "--name", name, "busybox", "/bin/sh", "-c", "for i in $(seq 1 3); do echo log$i; done")
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	apiClient, err := client.NewClientWithOpts(ctx, client.FromEnv)
 	if err != nil {
 		c.Fatal(err)
 	}

--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -229,9 +230,12 @@ func jsonBlobHasGTE121NetworkStats(blob map[string]interface{}) bool {
 
 func (s *DockerAPISuite) TestAPIStatsContainerNotFound(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	apiClient, err := client.NewClientWithOpts(ctx, client.FromEnv)
 	assert.NilError(c, err)
-	defer apiClient.Close()
+	defer apiClient.Close(ctx)
 
 	expected := "No such container: nonexistent"
 

--- a/integration-cli/docker_api_swarm_service_test.go
+++ b/integration-cli/docker_api_swarm_service_test.go
@@ -72,7 +72,7 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesCreate(c *testing.T) {
 	poll.WaitOn(c, pollCheck(c, d.CheckActiveContainerCount(ctx), checker.Equals(instances)), poll.WithTimeout(defaultReconciliationTimeout))
 
 	client := d.NewClientT(c)
-	defer client.Close()
+	defer client.Close(ctx)
 
 	options := types.ServiceInspectOptions{InsertDefaults: true}
 

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -409,7 +409,7 @@ func (s *DockerSwarmSuite) TestAPISwarmRaftQuorum(c *testing.T) {
 	simpleTestService(&service)
 	service.Spec.Name = "top2"
 	cli := d1.NewClientT(c)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	// d1 will eventually step down from leader because there is no longer an active quorum, wait for that to happen
 	poll.WaitOn(c, pollCheck(c, func(c *testing.T) (interface{}, string) {
@@ -889,7 +889,7 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesUpdateWithName(c *testing.T) {
 
 	setInstances(instances)(service)
 	cli := d.NewClientT(c)
-	defer cli.Close()
+	defer cli.Close(ctx)
 	_, err := cli.ServiceUpdate(ctx, service.Spec.Name, service.Version, service.Spec, types.ServiceUpdateOptions{})
 	assert.NilError(c, err)
 	poll.WaitOn(c, pollCheck(c, d.CheckActiveContainerCount(ctx), checker.Equals(instances)), poll.WithTimeout(defaultReconciliationTimeout))

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -449,9 +449,12 @@ func (s *DockerCLIEventSuite) TestEventsResize(c *testing.T) {
 	cID := runSleepingContainer(c, "-d", "-t")
 	cli.WaitRun(c, cID)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	apiClient, err := client.NewClientWithOpts(ctx, client.FromEnv)
 	assert.NilError(c, err)
-	defer apiClient.Close()
+	defer apiClient.Close(ctx)
 
 	options := container.ResizeOptions{
 		Height: 80,

--- a/integration-cli/docker_cli_info_unix_test.go
+++ b/integration-cli/docker_cli_info_unix_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"testing"
 
 	"github.com/docker/docker/client"
@@ -18,9 +19,12 @@ func (s *DockerCLIInfoSuite) TestInfoSecurityOptions(c *testing.T) {
 		c.Skip("test requires Seccomp and/or AppArmor")
 	}
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	apiClient, err := client.NewClientWithOpts(ctx, client.FromEnv)
 	assert.NilError(c, err)
-	defer apiClient.Close()
+	defer apiClient.Close(ctx)
 	info, err := apiClient.Info(testutil.GetContext(c))
 	assert.NilError(c, err)
 

--- a/integration-cli/docker_cli_plugins_logdriver_test.go
+++ b/integration-cli/docker_cli_plugins_logdriver_test.go
@@ -49,9 +49,12 @@ func (s *DockerCLIPluginLogDriverSuite) TestPluginLogDriverInfoList(c *testing.T
 
 	cli.DockerCmd(c, "plugin", "install", pluginName)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	apiClient, err := client.NewClientWithOpts(ctx, client.FromEnv)
 	assert.NilError(c, err)
-	defer apiClient.Close()
+	defer apiClient.Close(ctx)
 
 	info, err := apiClient.Info(testutil.GetContext(c))
 	assert.NilError(c, err)

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -1562,7 +1563,10 @@ func (s *DockerCLIRunSuite) TestRunWithNanoCPUs(c *testing.T) {
 	out := cli.DockerCmd(c, "run", "--cpus", "0.5", "--name", "test", "busybox", "sh", "-c", fmt.Sprintf("cat %s && cat %s", file1, file2)).Combined()
 	assert.Equal(c, strings.TrimSpace(out), "50000\n100000")
 
-	clt, err := client.NewClientWithOpts(client.FromEnv)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	clt, err := client.NewClientWithOpts(ctx, client.FromEnv)
 	assert.NilError(c, err)
 	inspect, err := clt.ContainerInspect(testutil.GetContext(c), "test")
 	assert.NilError(c, err)

--- a/integration-cli/docker_cli_update_unix_test.go
+++ b/integration-cli/docker_cli_update_unix_test.go
@@ -254,9 +254,12 @@ func (s *DockerCLIUpdateSuite) TestUpdateWithNanoCPUs(c *testing.T) {
 	out = cli.DockerCmd(c, "exec", "top", "sh", "-c", fmt.Sprintf("cat %s && cat %s", file1, file2)).Combined()
 	assert.Equal(c, strings.TrimSpace(out), "50000\n100000")
 
-	clt, err := client.NewClientWithOpts(client.FromEnv)
+	ctx, cancel := context.WithCancel(testutil.GetContext(c))
+	defer cancel()
+
+	clt, err := client.NewClientWithOpts(ctx, client.FromEnv)
 	assert.NilError(c, err)
-	inspect, err := clt.ContainerInspect(testutil.GetContext(c), "top")
+	inspect, err := clt.ContainerInspect(ctx, "top")
 	assert.NilError(c, err)
 	assert.Equal(c, inspect.HostConfig.NanoCPUs, int64(500000000))
 

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -575,10 +575,13 @@ func (s *DockerCLIVolumeSuite) TestDuplicateMountpointsForVolumesFromAndMounts(c
 	err := os.MkdirAll("/tmp/data", 0o755)
 	assert.NilError(c, err)
 
+	ctx, cancel := context.WithCancel(testutil.GetContext(c))
+	defer cancel()
+
 	// Mounts is available in API
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.NewClientWithOpts(ctx, client.FromEnv)
 	assert.NilError(c, err)
-	defer apiClient.Close()
+	defer apiClient.Close(ctx)
 
 	config := container.Config{
 		Cmd:   []string{"top"},
@@ -595,7 +598,7 @@ func (s *DockerCLIVolumeSuite) TestDuplicateMountpointsForVolumesFromAndMounts(c
 			},
 		},
 	}
-	_, err = apiClient.ContainerCreate(testutil.GetContext(c), &config, &hostConfig, &network.NetworkingConfig{}, nil, "app")
+	_, err = apiClient.ContainerCreate(ctx, &config, &hostConfig, &network.NetworkingConfig{}, nil, "app")
 
 	assert.NilError(c, err)
 

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -28,7 +28,7 @@ func DaemonIsLinux() bool {
 }
 
 func OnlyDefaultNetworks(ctx context.Context) bool {
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.NewClientWithOpts(ctx, client.FromEnv)
 	if err != nil {
 		return false
 	}

--- a/integration/build/build_session_test.go
+++ b/integration/build/build_session_test.go
@@ -41,7 +41,7 @@ func TestBuildWithSession(t *testing.T) {
 	)
 	defer fctx.Close()
 
-	out := testBuildWithSession(ctx, t, client, client.DaemonHost(), fctx.Dir, dockerfile)
+	out := testBuildWithSession(ctx, t, client, client.DaemonHost(ctx), fctx.Dir, dockerfile)
 	assert.Check(t, is.Contains(out, "some content"))
 
 	fctx.Add("second", "contentcontent")
@@ -51,7 +51,7 @@ func TestBuildWithSession(t *testing.T) {
 	RUN cat /second
 	`
 
-	out = testBuildWithSession(ctx, t, client, client.DaemonHost(), fctx.Dir, dockerfile)
+	out = testBuildWithSession(ctx, t, client, client.DaemonHost(ctx), fctx.Dir, dockerfile)
 	assert.Check(t, is.Equal(strings.Count(out, "Using cache"), 2))
 	assert.Check(t, is.Contains(out, "contentcontent"))
 
@@ -59,7 +59,7 @@ func TestBuildWithSession(t *testing.T) {
 	assert.Check(t, err)
 	assert.Check(t, du.BuilderSize > 10)
 
-	out = testBuildWithSession(ctx, t, client, client.DaemonHost(), fctx.Dir, dockerfile)
+	out = testBuildWithSession(ctx, t, client, client.DaemonHost(ctx), fctx.Dir, dockerfile)
 	assert.Check(t, is.Equal(strings.Count(out, "Using cache"), 4))
 
 	du2, err := client.DiskUsage(ctx, types.DiskUsageOptions{})
@@ -71,7 +71,7 @@ func TestBuildWithSession(t *testing.T) {
 	// FIXME(vdemeester) use sock here
 	res, body, err := request.Do(ctx,
 		"/build",
-		request.Host(client.DaemonHost()),
+		request.Host(client.DaemonHost(ctx)),
 		request.Method(http.MethodPost),
 		request.RawContent(fctx.AsTarReader(t)),
 		request.ContentType("application/x-tar"))

--- a/integration/build/build_userns_linux_test.go
+++ b/integration/build/build_userns_linux_test.go
@@ -42,7 +42,7 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 	dUserRemap := daemon.New(t)
 	dUserRemap.Start(t, "--userns-remap", "default")
 	clientUserRemap := dUserRemap.NewClientT(t)
-	defer clientUserRemap.Close()
+	defer clientUserRemap.Close(ctx)
 
 	err = load.FrozenImagesLinux(ctx, clientUserRemap, "debian:bookworm-slim")
 	assert.NilError(t, err)
@@ -99,7 +99,7 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 	}()
 
 	clientNoUserRemap := dNoUserRemap.NewClientT(t)
-	defer clientNoUserRemap.Close()
+	defer clientNoUserRemap.Close(ctx)
 
 	tarFile, err := os.Open(tmp + "/image.tar")
 	assert.NilError(t, err, "failed to open image tar file")

--- a/integration/config/config_test.go
+++ b/integration/config/config_test.go
@@ -30,7 +30,7 @@ func TestConfigInspect(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	testName := t.Name()
 	configID := createConfig(ctx, t, c, testName, []byte("TESTINGDATA"), nil)
@@ -53,7 +53,7 @@ func TestConfigList(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	// This test case is ported from the original TestConfigsEmptyList
 	configs, err := c.ConfigList(ctx, types.ConfigListOptions{})
@@ -139,7 +139,7 @@ func TestConfigsCreateAndDelete(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	testName := "test_config-" + t.Name()
 	configID := createConfig(ctx, t, c, testName, []byte("TESTINGDATA"), nil)
@@ -177,7 +177,7 @@ func TestConfigsUpdate(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	testName := "test_config-" + t.Name()
 	configID := createConfig(ctx, t, c, testName, []byte("TESTINGDATA"), nil)
@@ -228,7 +228,7 @@ func TestTemplatedConfig(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	referencedSecretName := "referencedsecret-" + t.Name()
 	referencedSecretSpec := swarmtypes.SecretSpec{
@@ -341,7 +341,7 @@ func TestConfigCreateResolve(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	configName := "test_config_" + t.Name()
 	configID := createConfig(ctx, t, c, configName, []byte("foo"), nil)

--- a/integration/container/checkpoint_test.go
+++ b/integration/container/checkpoint_test.go
@@ -40,7 +40,7 @@ func TestCheckpoint(t *testing.T) {
 	t.Logf("%s", stdoutStderr)
 	assert.NilError(t, err)
 
-	apiClient := request.NewAPIClient(t)
+	apiClient := request.NewAPIClient(ctx, t)
 
 	t.Log("Start a container")
 	cID := container.Run(ctx, t, apiClient, container.WithMount(mounttypes.Mount{

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -596,6 +596,8 @@ func TestCreateInvalidHostConfig(t *testing.T) {
 
 func TestCreateWithMultipleEndpointSettings(t *testing.T) {
 	ctx := setupTest(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	testcases := []struct {
 		apiVersion  string
@@ -607,7 +609,10 @@ func TestCreateWithMultipleEndpointSettings(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run("with API v"+tc.apiVersion, func(t *testing.T) {
-			apiClient, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion(tc.apiVersion))
+			ctx2, cancel2 := context.WithCancel(ctx)
+			defer cancel2()
+
+			apiClient, err := client.NewClientWithOpts(ctx2, client.FromEnv, client.WithVersion(tc.apiVersion))
 			assert.NilError(t, err)
 
 			config := container.Config{
@@ -620,7 +625,7 @@ func TestCreateWithMultipleEndpointSettings(t *testing.T) {
 					"net3": {},
 				},
 			}
-			_, err = apiClient.ContainerCreate(ctx, &config, &container.HostConfig{}, &networkingConfig, nil, "")
+			_, err = apiClient.ContainerCreate(ctx2, &config, &container.HostConfig{}, &networkingConfig, nil, "")
 			if tc.expectedErr == "" {
 				assert.NilError(t, err)
 			} else {

--- a/integration/container/inspect_test.go
+++ b/integration/container/inspect_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestInspectAnnotations(t *testing.T) {
 	ctx := setupTest(t)
-	apiClient := request.NewAPIClient(t)
+	apiClient := request.NewAPIClient(ctx, t)
 
 	annotations := map[string]string{
 		"hello": "world",
@@ -40,7 +40,7 @@ func TestInspectAnnotations(t *testing.T) {
 // custom networks, except for the "Default Switch" network on Windows).
 func TestNetworkAliasesAreEmpty(t *testing.T) {
 	ctx := setupTest(t)
-	apiClient := request.NewAPIClient(t)
+	apiClient := request.NewAPIClient(ctx, t)
 
 	netModes := []string{"host", "bridge", "none"}
 	if runtime.GOOS == "windows" {

--- a/integration/container/ipcmode_linux_test.go
+++ b/integration/container/ipcmode_linux_test.go
@@ -299,12 +299,12 @@ func TestDaemonIpcModeShareableFromConfig(t *testing.T) {
 // TestIpcModeOlderClient checks that older client gets shareable IPC mode
 // by default, even when the daemon default is private.
 func TestIpcModeOlderClient(t *testing.T) {
+	ctx := testutil.StartSpan(baseContext, t)
+
 	apiClient := testEnv.APIClient()
-	skip.If(t, versions.LessThan(apiClient.ClientVersion(), "1.40"), "requires client API >= 1.40")
+	skip.If(t, versions.LessThan(apiClient.ClientVersion(ctx), "1.40"), "requires client API >= 1.40")
 
 	t.Parallel()
-
-	ctx := testutil.StartSpan(baseContext, t)
 
 	// pre-check: default ipc mode in daemon is private
 	cID := container.Create(ctx, t, apiClient, container.WithAutoRemove)
@@ -314,7 +314,7 @@ func TestIpcModeOlderClient(t *testing.T) {
 	assert.Check(t, is.Equal(string(inspect.HostConfig.IpcMode), "private"))
 
 	// main check: using older client creates "shareable" container
-	apiClient = request.NewAPIClient(t, client.WithVersion("1.39"))
+	apiClient = request.NewAPIClient(ctx, t, client.WithVersion("1.39"))
 	cID = container.Create(ctx, t, apiClient, container.WithAutoRemove)
 
 	inspect, err = apiClient.ContainerInspect(ctx, cID)

--- a/integration/container/kill_test.go
+++ b/integration/container/kill_test.go
@@ -137,7 +137,7 @@ func TestKillDifferentUserContainer(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "User containers (container.Config.User) are not yet supported on %q platform", testEnv.DaemonInfo.OSType)
 
 	ctx := setupTest(t)
-	apiClient := request.NewAPIClient(t)
+	apiClient := request.NewAPIClient(ctx, t)
 
 	id := container.Run(ctx, t, apiClient, func(c *container.TestContainerConfig) {
 		c.Config.User = "daemon"

--- a/integration/container/mounts_linux_test.go
+++ b/integration/container/mounts_linux_test.go
@@ -60,9 +60,9 @@ func TestContainerNetworkMountsNoChown(t *testing.T) {
 		},
 	}
 
-	cli, err := client.NewClientWithOpts(client.FromEnv)
+	cli, err := client.NewClientWithOpts(ctx, client.FromEnv)
 	assert.NilError(t, err)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	ctrCreate, err := cli.ContainerCreate(ctx, &config, &hostConfig, &network.NetworkingConfig{}, nil, "")
 	assert.NilError(t, err)
@@ -463,7 +463,7 @@ func TestContainerBindMountReadOnlyDefault(t *testing.T) {
 			skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), minDaemonVersion), "requires API v"+minDaemonVersion)
 
 			if tc.clientVersion != "" {
-				c, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion(tc.clientVersion))
+				c, err := client.NewClientWithOpts(ctx, client.FromEnv, client.WithVersion(tc.clientVersion))
 				assert.NilError(t, err, "failed to create client with version v%s", tc.clientVersion)
 				apiClient = c
 			}

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -273,7 +273,7 @@ func TestMacAddressIsAppliedToMainNetworkWithShortID(t *testing.T) {
 	d.StartWithBusybox(ctx, t)
 	defer d.Stop(t)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.43"))
+	apiClient, err := client.NewClientWithOpts(ctx, client.FromEnv, client.WithVersion("1.43"))
 	assert.NilError(t, err)
 
 	n := net.CreateNoError(ctx, t, apiClient, "testnet", net.WithIPAM("192.168.101.0/24", "192.168.101.1"))
@@ -300,7 +300,7 @@ func TestStaticIPOutsideSubpool(t *testing.T) {
 	d.StartWithBusybox(ctx, t)
 	defer d.Stop(t)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.43"))
+	apiClient, err := client.NewClientWithOpts(ctx, client.FromEnv, client.WithVersion("1.43"))
 	assert.NilError(t, err)
 
 	const netname = "subnet-range"

--- a/integration/container/stop_linux_test.go
+++ b/integration/container/stop_linux_test.go
@@ -80,7 +80,7 @@ func TestStopContainerWithTimeout(t *testing.T) {
 func TestStopContainerWithTimeoutCancel(t *testing.T) {
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()
-	t.Cleanup(func() { _ = apiClient.Close() })
+	t.Cleanup(func() { _ = apiClient.Close(ctx) })
 
 	t.Parallel()
 

--- a/integration/container/update_linux_test.go
+++ b/integration/container/update_linux_test.go
@@ -153,7 +153,7 @@ func TestUpdatePidsLimit(t *testing.T) {
 
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()
-	oldAPIClient := request.NewAPIClient(t, client.WithVersion("1.24"))
+	oldAPIClient := request.NewAPIClient(ctx, t, client.WithVersion("1.24"))
 
 	intPtr := func(i int64) *int64 {
 		return &i

--- a/integration/container/wait_test.go
+++ b/integration/container/wait_test.go
@@ -17,7 +17,7 @@ import (
 func TestWaitNonBlocked(t *testing.T) {
 	ctx := setupTest(t)
 
-	cli := request.NewAPIClient(t)
+	cli := request.NewAPIClient(ctx, t)
 
 	testCases := []struct {
 		doc          string
@@ -61,7 +61,7 @@ func TestWaitBlocked(t *testing.T) {
 	// granularity. It will always exit 0x40010004.
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 	ctx := setupTest(t)
-	cli := request.NewAPIClient(t)
+	cli := request.NewAPIClient(ctx, t)
 
 	testCases := []struct {
 		doc          string
@@ -104,7 +104,7 @@ func TestWaitBlocked(t *testing.T) {
 
 func TestWaitConditions(t *testing.T) {
 	ctx := setupTest(t)
-	cli := request.NewAPIClient(t)
+	cli := request.NewAPIClient(ctx, t)
 
 	testCases := []struct {
 		doc      string
@@ -179,7 +179,7 @@ func TestWaitConditions(t *testing.T) {
 
 func TestWaitRestartedContainer(t *testing.T) {
 	ctx := setupTest(t)
-	cli := request.NewAPIClient(t)
+	cli := request.NewAPIClient(ctx, t)
 
 	testCases := []struct {
 		doc      string

--- a/integration/image/prune_test.go
+++ b/integration/image/prune_test.go
@@ -24,7 +24,7 @@ func TestPruneDontDeleteUsedDangling(t *testing.T) {
 	defer d.Stop(t)
 
 	client := d.NewClientT(t)
-	defer client.Close()
+	defer client.Close(ctx)
 
 	danglingID := specialimage.Load(ctx, t, client, specialimage.Dangling)
 

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -70,7 +70,7 @@ func CreateService(ctx context.Context, t *testing.T, d *daemon.Daemon, opts ...
 	t.Helper()
 
 	client := d.NewClientT(t)
-	defer client.Close()
+	defer client.Close(ctx)
 
 	spec := CreateServiceSpec(t, opts...)
 	resp, err := client.ServiceCreate(ctx, spec, types.ServiceCreateOptions{})
@@ -224,7 +224,7 @@ func GetRunningTasks(ctx context.Context, t *testing.T, c client.ServiceAPIClien
 func ExecTask(ctx context.Context, t *testing.T, d *daemon.Daemon, task swarmtypes.Task, config types.ExecConfig) types.HijackedResponse {
 	t.Helper()
 	client := d.NewClientT(t)
-	defer client.Close()
+	defer client.Close(ctx)
 
 	resp, err := client.ContainerExecCreate(ctx, task.Status.ContainerStatus.ContainerID, config)
 	assert.NilError(t, err, "error creating exec")

--- a/integration/network/inspect_test.go
+++ b/integration/network/inspect_test.go
@@ -20,7 +20,7 @@ func TestInspectNetwork(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	networkName := "Overlay" + t.Name()
 	overlayID := network.CreateNoError(ctx, t, c, networkName,

--- a/integration/network/network_test.go
+++ b/integration/network/network_test.go
@@ -170,7 +170,7 @@ func TestHostIPv4BridgeLabel(t *testing.T) {
 	d.Start(t)
 	defer d.Stop(t)
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	ipv4SNATAddr := "172.0.0.172"
 	// Create a bridge network with --opt com.docker.network.host_ipv4=172.0.0.172
@@ -225,7 +225,7 @@ func TestDefaultNetworkOpts(t *testing.T) {
 			d.StartWithBusybox(ctx, t, tc.args...)
 			defer d.Stop(t)
 			c := d.NewClientT(t)
-			defer c.Close()
+			defer c.Close(ctx)
 
 			if tc.configFrom {
 				// Create a new network config
@@ -279,7 +279,7 @@ func TestForbidDuplicateNetworkNames(t *testing.T) {
 	defer d.Stop(t)
 
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	network.CreateNoError(ctx, t, c, "testnet")
 

--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -37,7 +37,7 @@ func TestDaemonRestartWithLiveRestore(t *testing.T) {
 	d.Start(t)
 
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	// Verify bridge network's subnet
 	out, err := c.NetworkInspect(ctx, "bridge", types.NetworkInspectOptions{})
@@ -73,7 +73,7 @@ func TestDaemonDefaultNetworkPools(t *testing.T) {
 	)
 
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	// Verify bridge network's subnet
 	out, err := c.NetworkInspect(ctx, "bridge", types.NetworkInspectOptions{})
@@ -111,7 +111,7 @@ func TestDaemonRestartWithExistingNetwork(t *testing.T) {
 	d.Start(t)
 	defer d.Stop(t)
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	// Create a bridge network
 	name := "elango" + t.Name()
@@ -147,7 +147,7 @@ func TestDaemonRestartWithExistingNetworkWithDefaultPoolRange(t *testing.T) {
 	d.Start(t)
 	defer d.Stop(t)
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	// Create a bridge network
 	name := "elango" + t.Name()
@@ -205,7 +205,7 @@ func TestDaemonWithBipAndDefaultNetworkPool(t *testing.T) {
 	)
 
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	// Verify bridge network's subnet
 	out, err := c.NetworkInspect(ctx, "bridge", types.NetworkInspectOptions{})
@@ -223,7 +223,7 @@ func TestServiceWithPredefinedNetwork(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	hostName := "host"
 	var instances uint64 = 1
@@ -256,7 +256,7 @@ func TestServiceRemoveKeepsIngressNetwork(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	poll.WaitOn(t, swarmIngressReady(ctx, c), swarm.NetworkPoll)
 
@@ -367,7 +367,7 @@ func TestServiceWithDataPathPortInit(t *testing.T) {
 	poll.WaitOn(t, swarm.NoTasks(ctx, c), swarm.ServicePoll)
 	err = c.NetworkRemove(ctx, overlayID)
 	assert.NilError(t, err)
-	c.Close()
+	c.Close(ctx)
 	err = d.SwarmLeave(ctx, t, true)
 	assert.NilError(t, err)
 	d.Stop(t)
@@ -377,7 +377,7 @@ func TestServiceWithDataPathPortInit(t *testing.T) {
 	d = swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	nc := d.NewClientT(t)
-	defer nc.Close()
+	defer nc.Close(ctx)
 	// Create a overlay network
 	name = "not-saanvisthira" + t.Name()
 	overlayID = network.CreateNoError(ctx, t, nc, name,
@@ -414,7 +414,7 @@ func TestServiceWithDefaultAddressPoolInit(t *testing.T) {
 		daemon.WithSwarmDefaultAddrPoolSubnetSize(24))
 	defer d.Stop(t)
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	// Create a overlay network
 	name := "sthira" + t.Name()

--- a/integration/networking/bridge_test.go
+++ b/integration/networking/bridge_test.go
@@ -30,7 +30,7 @@ func TestBridgeICC(t *testing.T) {
 	defer d.Stop(t)
 
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	testcases := []struct {
 		name           string
@@ -262,7 +262,7 @@ func TestBridgeINC(t *testing.T) {
 	defer d.Stop(t)
 
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	type bridgesOpts struct {
 		bridge1Opts []func(*types.NetworkCreate)
@@ -416,7 +416,7 @@ func TestDefaultBridgeIPv6(t *testing.T) {
 			defer d.Stop(t)
 
 			c := d.NewClientT(t)
-			defer c.Close()
+			defer c.Close(ctx)
 
 			cID := container.Run(ctx, t, c,
 				container.WithImage("busybox:latest"),
@@ -552,7 +552,7 @@ func TestInternalNwConnectivity(t *testing.T) {
 	defer d.Stop(t)
 
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	const bridgeName = "intnw"
 	const gw4 = "172.30.0.1"

--- a/integration/networking/etchosts_test.go
+++ b/integration/networking/etchosts_test.go
@@ -30,7 +30,7 @@ func TestEtcHostsIpv6(t *testing.T) {
 	defer d.Stop(t)
 
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	testcases := []struct {
 		name           string

--- a/integration/networking/mac_addr_test.go
+++ b/integration/networking/mac_addr_test.go
@@ -33,7 +33,7 @@ func TestMACAddrOnRestart(t *testing.T) {
 	defer d.Stop(t)
 
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	const netName = "testmacaddrs"
 	network.CreateNoError(ctx, t, c, netName,
@@ -93,7 +93,7 @@ func TestCfgdMACAddrOnRestart(t *testing.T) {
 	defer d.Stop(t)
 
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	const netName = "testcfgmacaddr"
 	network.CreateNoError(ctx, t, c, netName,
@@ -191,7 +191,7 @@ func TestInspectCfgdMAC(t *testing.T) {
 				copts = append(copts, client.WithVersion("1.43"))
 			}
 			c := d.NewClientT(t, copts...)
-			defer c.Close()
+			defer c.Close(ctx)
 
 			if tc.netName != "bridge" {
 				const netName = "inspectcfgmac"

--- a/integration/networking/resolvconf_test.go
+++ b/integration/networking/resolvconf_test.go
@@ -37,7 +37,7 @@ func TestResolvConfLocalhostIPv6(t *testing.T) {
 	defer d.Stop(t)
 
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	netName := "nnn"
 	network.CreateNoError(ctx, t, c, netName,

--- a/integration/plugin/authz/authz_plugin_test.go
+++ b/integration/plugin/authz/authz_plugin_test.go
@@ -136,7 +136,7 @@ func TestAuthZPluginTLS(t *testing.T) {
 	ctrl.reqRes.Allow = true
 	ctrl.resRes.Allow = true
 
-	c, err := newTLSAPIClient(testDaemonHTTPSAddr, cacertPath, clientCertPath, clientKeyPath)
+	c, err := newTLSAPIClient(ctx, testDaemonHTTPSAddr, cacertPath, clientCertPath, clientKeyPath)
 	assert.NilError(t, err)
 
 	_, err = c.ServerVersion(ctx)
@@ -146,12 +146,12 @@ func TestAuthZPluginTLS(t *testing.T) {
 	assert.Equal(t, "client", ctrl.resUser)
 }
 
-func newTLSAPIClient(host, cacertPath, certPath, keyPath string) (client.APIClient, error) {
+func newTLSAPIClient(ctx context.Context, host, cacertPath, certPath, keyPath string) (client.APIClient, error) {
 	dialer := &net.Dialer{
 		KeepAlive: 30 * time.Second,
 		Timeout:   30 * time.Second,
 	}
-	return client.NewClientWithOpts(
+	return client.NewClientWithOpts(ctx,
 		client.WithTLSClientConfig(cacertPath, certPath, keyPath),
 		client.WithDialContext(dialer.DialContext),
 		client.WithHost(host))

--- a/integration/plugin/graphdriver/external_test.go
+++ b/integration/plugin/graphdriver/external_test.go
@@ -423,7 +423,7 @@ func TestGraphdriverPluginV2(t *testing.T) {
 	defer d.Stop(t)
 
 	client := d.NewClientT(t)
-	defer client.Close()
+	defer client.Close(ctx)
 
 	// install the plugin
 	plugin := "cpuguy83/docker-overlay2-graphdriver-plugin"

--- a/integration/plugin/logging/read_test.go
+++ b/integration/plugin/logging/read_test.go
@@ -28,7 +28,7 @@ func TestReadPluginNoRead(t *testing.T) {
 	d.StartWithBusybox(ctx, t, "--iptables=false")
 	defer d.Stop(t)
 
-	client, err := d.NewClient()
+	client, err := d.NewClient(ctx)
 	assert.Assert(t, err)
 	createPlugin(ctx, t, client, "test", "discard", asLogDriver)
 

--- a/integration/secret/secret_test.go
+++ b/integration/secret/secret_test.go
@@ -29,7 +29,7 @@ func TestSecretInspect(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	testName := t.Name()
 	secretID := createSecret(ctx, t, c, testName, []byte("TESTINGDATA"), nil)
@@ -51,7 +51,7 @@ func TestSecretList(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	configs, err := c.SecretList(ctx, types.SecretListOptions{})
 	assert.NilError(t, err)
@@ -130,7 +130,7 @@ func TestSecretsCreateAndDelete(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	testName := "test_secret_" + t.Name()
 	secretID := createSecret(ctx, t, c, testName, []byte("TESTINGDATA"), nil)
@@ -177,7 +177,7 @@ func TestSecretsUpdate(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	testName := "test_secret_" + t.Name()
 	secretID := createSecret(ctx, t, c, testName, []byte("TESTINGDATA"), nil)
@@ -229,7 +229,7 @@ func TestTemplatedSecret(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	referencedSecretName := "referencedsecret_" + t.Name()
 	referencedSecretSpec := swarmtypes.SecretSpec{
@@ -340,7 +340,7 @@ func TestSecretCreateResolve(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	testName := "test_secret_" + t.Name()
 	secretID := createSecret(ctx, t, c, testName, []byte("foo"), nil)

--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -41,7 +41,7 @@ func testServiceCreateInit(ctx context.Context, daemonEnabled bool) func(t *test
 		d := swarm.NewSwarm(ctx, t, testEnv, ops...)
 		defer d.Stop(t)
 		client := d.NewClientT(t)
-		defer client.Close()
+		defer client.Close(ctx)
 
 		booleanTrue := true
 		booleanFalse := false
@@ -84,7 +84,7 @@ func TestCreateServiceMultipleTimes(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	client := d.NewClientT(t)
-	defer client.Close()
+	defer client.Close(ctx)
 
 	overlayName := "overlay1_" + t.Name()
 	overlayID := network.CreateNoError(ctx, t, client, overlayName,
@@ -156,7 +156,7 @@ func TestCreateServiceConflict(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	c := d.NewClientT(t)
-	defer c.Close()
+	defer c.Close(ctx)
 
 	serviceName := "TestService_" + t.Name()
 	serviceSpec := []swarm.ServiceSpecOpt{
@@ -177,7 +177,7 @@ func TestCreateServiceMaxReplicas(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	client := d.NewClientT(t)
-	defer client.Close()
+	defer client.Close(ctx)
 
 	var maxReplicas uint64 = 2
 	serviceSpec := []swarm.ServiceSpecOpt{
@@ -199,7 +199,7 @@ func TestCreateServiceSecretFileMode(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	client := d.NewClientT(t)
-	defer client.Close()
+	defer client.Close(ctx)
 
 	secretName := "TestSecret_" + t.Name()
 	secretResp, err := client.SecretCreate(ctx, swarmtypes.SecretSpec{
@@ -256,7 +256,7 @@ func TestCreateServiceConfigFileMode(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	client := d.NewClientT(t)
-	defer client.Close()
+	defer client.Close(ctx)
 
 	configName := "TestConfig_" + t.Name()
 	configResp, err := client.ConfigCreate(ctx, swarmtypes.ConfigSpec{
@@ -334,7 +334,7 @@ func TestCreateServiceSysctls(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	client := d.NewClientT(t)
-	defer client.Close()
+	defer client.Close(ctx)
 
 	// run thie block twice, so that no matter what the default value of
 	// net.ipv4.ip_nonlocal_bind is, we can verify that setting the sysctl
@@ -409,7 +409,7 @@ func TestCreateServiceCapabilities(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	client := d.NewClientT(t)
-	defer client.Close()
+	defer client.Close(ctx)
 
 	// store the map we're going to be using everywhere.
 	capAdd := []string{"CAP_SYS_CHROOT"}

--- a/integration/service/inspect_test.go
+++ b/integration/service/inspect_test.go
@@ -22,7 +22,7 @@ func TestInspect(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	client := d.NewClientT(t)
-	defer client.Close()
+	defer client.Close(ctx)
 
 	now := time.Now()
 	var instances uint64 = 2

--- a/integration/service/jobs_test.go
+++ b/integration/service/jobs_test.go
@@ -26,7 +26,7 @@ func TestCreateJob(t *testing.T) {
 	defer d.Stop(t)
 
 	client := d.NewClientT(t)
-	defer client.Close()
+	defer client.Close(ctx)
 
 	for _, mode := range []swarmtypes.ServiceMode{
 		{ReplicatedJob: &swarmtypes.ReplicatedJob{}},
@@ -61,7 +61,7 @@ func TestReplicatedJob(t *testing.T) {
 	defer d.Stop(t)
 
 	client := d.NewClientT(t)
-	defer client.Close()
+	defer client.Close(ctx)
 
 	id := swarm.CreateService(ctx, t, d,
 		swarm.ServiceWithMode(swarmtypes.ServiceMode{
@@ -94,7 +94,7 @@ func TestUpdateReplicatedJob(t *testing.T) {
 	defer d.Stop(t)
 
 	client := d.NewClientT(t)
-	defer client.Close()
+	defer client.Close(ctx)
 
 	// Create the job service
 	id := swarm.CreateService(ctx, t, d,

--- a/integration/service/list_test.go
+++ b/integration/service/list_test.go
@@ -34,7 +34,7 @@ func TestServiceListWithStatuses(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	client := d.NewClientT(t)
-	defer client.Close()
+	defer client.Close(ctx)
 
 	serviceCount := 3
 	// create some services.

--- a/integration/service/network_test.go
+++ b/integration/service/network_test.go
@@ -21,7 +21,7 @@ func TestDockerNetworkConnectAliasPreV144(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	client := d.NewClientT(t, client.WithVersion("1.43"))
-	defer client.Close()
+	defer client.Close(ctx)
 
 	name := t.Name() + "test-alias"
 	net.CreateNoError(ctx, t, client, name,
@@ -83,7 +83,7 @@ func TestDockerNetworkReConnect(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	client := d.NewClientT(t)
-	defer client.Close()
+	defer client.Close(ctx)
 
 	name := t.Name() + "dummyNet"
 	net.CreateNoError(ctx, t, client, name,

--- a/integration/service/update_test.go
+++ b/integration/service/update_test.go
@@ -24,7 +24,7 @@ func TestServiceUpdateLabel(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	serviceName := "TestService_" + t.Name()
 	serviceID := swarm.CreateService(ctx, t, d, swarm.ServiceWithName(serviceName))
@@ -80,7 +80,7 @@ func TestServiceUpdateSecrets(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	secretName := "TestSecret_" + t.Name()
 	secretTarget := "targetName"
@@ -142,7 +142,7 @@ func TestServiceUpdateConfigs(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	configName := "TestConfig_" + t.Name()
 	configTarget := "targetName"
@@ -204,7 +204,7 @@ func TestServiceUpdateNetwork(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	// Create a overlay network
 	testNet := "testNet" + t.Name()
@@ -279,7 +279,7 @@ func TestServiceUpdatePidsLimit(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	cli := d.NewClientT(t)
-	defer func() { _ = cli.Close() }()
+	defer func() { _ = cli.Close(ctx) }()
 	var (
 		serviceID string
 		service   swarmtypes.Service

--- a/integration/system/ping_test.go
+++ b/integration/system/ping_test.go
@@ -63,7 +63,7 @@ func TestPingSwarmHeader(t *testing.T) {
 	d.Start(t)
 	defer d.Stop(t)
 	client := d.NewClientT(t)
-	defer client.Close()
+	defer client.Close(ctx)
 
 	t.Run("before swarm init", func(t *testing.T) {
 		ctx := testutil.StartSpan(ctx, t)
@@ -103,7 +103,7 @@ func TestPingBuilderHeader(t *testing.T) {
 	ctx := setupTest(t)
 	d := daemon.New(t)
 	client := d.NewClientT(t)
-	defer client.Close()
+	defer client.Close(ctx)
 
 	t.Run("default config", func(t *testing.T) {
 		testutil.StartSpan(ctx, t)

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -290,10 +290,10 @@ func TestVolumePruneAnonymous(t *testing.T) {
 	assert.Check(t, is.Equal(len(pruneReport.VolumesDeleted), 2))
 
 	// Validate that older API versions still have the old behavior of pruning all local volumes
-	clientOld, err := clientpkg.NewClientWithOpts(clientpkg.FromEnv, clientpkg.WithVersion("1.41"))
+	clientOld, err := clientpkg.NewClientWithOpts(ctx, clientpkg.FromEnv, clientpkg.WithVersion("1.41"))
 	assert.NilError(t, err)
-	defer clientOld.Close()
-	assert.Equal(t, clientOld.ClientVersion(), "1.41")
+	defer clientOld.Close(ctx)
+	assert.Equal(t, clientOld.ClientVersion(ctx), "1.41")
 
 	v, err = client.VolumeCreate(ctx, volume.CreateOptions{})
 	assert.NilError(t, err)

--- a/testutil/daemon/config.go
+++ b/testutil/daemon/config.go
@@ -15,10 +15,13 @@ type ConfigConstructor func(*swarm.Config)
 // CreateConfig creates a config given the specified spec
 func (d *Daemon) CreateConfig(t testing.TB, configSpec swarm.ConfigSpec) string {
 	t.Helper()
-	cli := d.NewClientT(t)
-	defer cli.Close()
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
 
-	scr, err := cli.ConfigCreate(context.Background(), configSpec)
+	cli := d.NewClientT(t)
+	defer cli.Close(ctx)
+
+	scr, err := cli.ConfigCreate(ctx, configSpec)
 	assert.NilError(t, err)
 	return scr.ID
 }
@@ -26,10 +29,13 @@ func (d *Daemon) CreateConfig(t testing.TB, configSpec swarm.ConfigSpec) string 
 // ListConfigs returns the list of the current swarm configs
 func (d *Daemon) ListConfigs(t testing.TB) []swarm.Config {
 	t.Helper()
-	cli := d.NewClientT(t)
-	defer cli.Close()
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
 
-	configs, err := cli.ConfigList(context.Background(), types.ConfigListOptions{})
+	cli := d.NewClientT(t)
+	defer cli.Close(ctx)
+
+	configs, err := cli.ConfigList(ctx, types.ConfigListOptions{})
 	assert.NilError(t, err)
 	return configs
 }
@@ -37,10 +43,13 @@ func (d *Daemon) ListConfigs(t testing.TB) []swarm.Config {
 // GetConfig returns a swarm config identified by the specified id
 func (d *Daemon) GetConfig(t testing.TB, id string) *swarm.Config {
 	t.Helper()
-	cli := d.NewClientT(t)
-	defer cli.Close()
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
 
-	config, _, err := cli.ConfigInspectWithRaw(context.Background(), id)
+	cli := d.NewClientT(t)
+	defer cli.Close(ctx)
+
+	config, _, err := cli.ConfigInspectWithRaw(ctx, id)
 	assert.NilError(t, err)
 	return &config
 }
@@ -48,10 +57,13 @@ func (d *Daemon) GetConfig(t testing.TB, id string) *swarm.Config {
 // DeleteConfig removes the swarm config identified by the specified id
 func (d *Daemon) DeleteConfig(t testing.TB, id string) {
 	t.Helper()
-	cli := d.NewClientT(t)
-	defer cli.Close()
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
 
-	err := cli.ConfigRemove(context.Background(), id)
+	cli := d.NewClientT(t)
+	defer cli.Close(ctx)
+
+	err := cli.ConfigRemove(ctx, id)
 	assert.NilError(t, err)
 }
 
@@ -59,14 +71,17 @@ func (d *Daemon) DeleteConfig(t testing.TB, id string) {
 // Currently, only label update is supported.
 func (d *Daemon) UpdateConfig(t testing.TB, id string, f ...ConfigConstructor) {
 	t.Helper()
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	config := d.GetConfig(t, id)
 	for _, fn := range f {
 		fn(config)
 	}
 
-	err := cli.ConfigUpdate(context.Background(), config.ID, config.Version, config.Spec)
+	err := cli.ConfigUpdate(ctx, config.ID, config.Version, config.Spec)
 	assert.NilError(t, err)
 }

--- a/testutil/daemon/container.go
+++ b/testutil/daemon/container.go
@@ -12,7 +12,7 @@ import (
 func (d *Daemon) ActiveContainers(ctx context.Context, t testing.TB) []string {
 	t.Helper()
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	containers, err := cli.ContainerList(context.Background(), container.ListOptions{})
 	assert.NilError(t, err)
@@ -27,8 +27,11 @@ func (d *Daemon) ActiveContainers(ctx context.Context, t testing.TB) []string {
 // FindContainerIP returns the ip of the specified container
 func (d *Daemon) FindContainerIP(t testing.TB, id string) string {
 	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	i, err := cli.ContainerInspect(context.Background(), id)
 	assert.NilError(t, err)

--- a/testutil/daemon/node.go
+++ b/testutil/daemon/node.go
@@ -18,7 +18,7 @@ type NodeConstructor func(*swarm.Node)
 func (d *Daemon) GetNode(ctx context.Context, t testing.TB, id string, errCheck ...func(error) bool) *swarm.Node {
 	t.Helper()
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	node, _, err := cli.NodeInspectWithRaw(ctx, id)
 	if err != nil {
@@ -37,7 +37,7 @@ func (d *Daemon) GetNode(ctx context.Context, t testing.TB, id string, errCheck 
 func (d *Daemon) RemoveNode(ctx context.Context, t testing.TB, id string, force bool) {
 	t.Helper()
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	options := types.NodeRemoveOptions{
 		Force: force,
@@ -50,7 +50,7 @@ func (d *Daemon) RemoveNode(ctx context.Context, t testing.TB, id string, force 
 func (d *Daemon) UpdateNode(ctx context.Context, t testing.TB, id string, f ...NodeConstructor) {
 	t.Helper()
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	for i := 0; ; i++ {
 		node := d.GetNode(ctx, t, id)
@@ -72,7 +72,7 @@ func (d *Daemon) UpdateNode(ctx context.Context, t testing.TB, id string, f ...N
 func (d *Daemon) ListNodes(ctx context.Context, t testing.TB) []swarm.Node {
 	t.Helper()
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	nodes, err := cli.NodeList(ctx, types.NodeListOptions{})
 	assert.NilError(t, err)

--- a/testutil/daemon/service.go
+++ b/testutil/daemon/service.go
@@ -22,7 +22,7 @@ func (d *Daemon) createServiceWithOptions(ctx context.Context, t testing.TB, opt
 	}
 
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
@@ -42,7 +42,7 @@ func (d *Daemon) CreateService(ctx context.Context, t testing.TB, f ...ServiceCo
 func (d *Daemon) GetService(ctx context.Context, t testing.TB, id string) *swarm.Service {
 	t.Helper()
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	service, _, err := cli.ServiceInspectWithRaw(ctx, id, types.ServiceInspectOptions{})
 	assert.NilError(t, err)
@@ -53,7 +53,7 @@ func (d *Daemon) GetService(ctx context.Context, t testing.TB, id string) *swarm
 func (d *Daemon) GetServiceTasks(ctx context.Context, t testing.TB, service string, additionalFilters ...filters.KeyValuePair) []swarm.Task {
 	t.Helper()
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	filterArgs := filters.NewArgs(
 		filters.Arg("desired-state", "running"),
@@ -76,7 +76,7 @@ func (d *Daemon) GetServiceTasks(ctx context.Context, t testing.TB, service stri
 func (d *Daemon) UpdateService(ctx context.Context, t testing.TB, service *swarm.Service, f ...ServiceConstructor) {
 	t.Helper()
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	for _, fn := range f {
 		fn(service)
@@ -90,7 +90,7 @@ func (d *Daemon) UpdateService(ctx context.Context, t testing.TB, service *swarm
 func (d *Daemon) RemoveService(ctx context.Context, t testing.TB, id string) {
 	t.Helper()
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	err := cli.ServiceRemove(ctx, id)
 	assert.NilError(t, err)
@@ -100,7 +100,7 @@ func (d *Daemon) RemoveService(ctx context.Context, t testing.TB, id string) {
 func (d *Daemon) ListServices(ctx context.Context, t testing.TB) []swarm.Service {
 	t.Helper()
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	services, err := cli.ServiceList(ctx, types.ServiceListOptions{})
 	assert.NilError(t, err)
@@ -111,7 +111,7 @@ func (d *Daemon) ListServices(ctx context.Context, t testing.TB) []swarm.Service
 func (d *Daemon) GetTask(ctx context.Context, t testing.TB, id string) swarm.Task {
 	t.Helper()
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	task, _, err := cli.TaskInspectWithRaw(ctx, id)
 	assert.NilError(t, err)

--- a/testutil/daemon/swarm.go
+++ b/testutil/daemon/swarm.go
@@ -88,7 +88,7 @@ func (d *Daemon) SwarmInit(ctx context.Context, t testing.TB, req swarm.InitRequ
 		req.DataPathPort = d.DataPathPort
 	}
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 	_, err := cli.SwarmInit(ctx, req)
 	assert.NilError(t, err, "initializing swarm")
 	d.CachedInfo = d.Info(t)
@@ -101,7 +101,7 @@ func (d *Daemon) SwarmJoin(ctx context.Context, t testing.TB, req swarm.JoinRequ
 		req.ListenAddr = fmt.Sprintf("%s:%d", d.swarmListenAddr, d.SwarmPort)
 	}
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 	err := cli.SwarmJoin(ctx, req)
 	assert.NilError(t, err, "[%s] joining swarm", d.id)
 	d.CachedInfo = d.Info(t)
@@ -114,7 +114,7 @@ func (d *Daemon) SwarmJoin(ctx context.Context, t testing.TB, req swarm.JoinRequ
 // the error to be returned.
 func (d *Daemon) SwarmLeave(ctx context.Context, t testing.TB, force bool) error {
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 	return cli.SwarmLeave(ctx, force)
 }
 
@@ -133,8 +133,11 @@ func (d *Daemon) SwarmInfo(ctx context.Context, t testing.TB) swarm.Info {
 // Some tests rely on error checking the result of the actual unlock, so allow
 // the error to be returned.
 func (d *Daemon) SwarmUnlock(t testing.TB, req swarm.UnlockRequest) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	err := cli.SwarmUnlock(context.Background(), req)
 	if err != nil {
@@ -146,8 +149,11 @@ func (d *Daemon) SwarmUnlock(t testing.TB, req swarm.UnlockRequest) error {
 // GetSwarm returns the current swarm object
 func (d *Daemon) GetSwarm(t testing.TB) swarm.Swarm {
 	t.Helper()
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	sw, err := cli.SwarmInspect(context.Background())
 	assert.NilError(t, err)
@@ -157,8 +163,11 @@ func (d *Daemon) GetSwarm(t testing.TB) swarm.Swarm {
 // UpdateSwarm updates the current swarm object with the specified spec constructors
 func (d *Daemon) UpdateSwarm(t testing.TB, f ...SpecConstructor) {
 	t.Helper()
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	sw := d.GetSwarm(t)
 	for _, fn := range f {
@@ -172,8 +181,11 @@ func (d *Daemon) UpdateSwarm(t testing.TB, f ...SpecConstructor) {
 // RotateTokens update the swarm to rotate tokens
 func (d *Daemon) RotateTokens(t testing.TB) {
 	t.Helper()
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	sw, err := cli.SwarmInspect(context.Background())
 	assert.NilError(t, err)
@@ -190,8 +202,11 @@ func (d *Daemon) RotateTokens(t testing.TB) {
 // JoinTokens returns the current swarm join tokens
 func (d *Daemon) JoinTokens(t testing.TB) swarm.JoinTokens {
 	t.Helper()
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
 	cli := d.NewClientT(t)
-	defer cli.Close()
+	defer cli.Close(ctx)
 
 	sw, err := cli.SwarmInspect(context.Background())
 	assert.NilError(t, err)

--- a/testutil/environment/environment.go
+++ b/testutil/environment/environment.go
@@ -38,7 +38,7 @@ type PlatformDefaults struct {
 // New creates a new Execution struct
 // This is configured using the env client (see client.FromEnv)
 func New(ctx context.Context) (*Execution, error) {
-	c, err := client.NewClientWithOpts(client.FromEnv)
+	c, err := client.NewClientWithOpts(ctx, client.FromEnv)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create client")
 	}

--- a/testutil/fakestorage/storage.go
+++ b/testutil/fakestorage/storage.go
@@ -108,25 +108,26 @@ func (f *remoteFileServer) CtxDir() string {
 }
 
 func (f *remoteFileServer) Close() error {
+	ctx := context.TODO()
 	defer func() {
 		if f.ctx != nil {
 			f.ctx.Close()
 		}
 		if f.image != "" {
-			if _, err := f.client.ImageRemove(context.Background(), f.image, image.RemoveOptions{
+			if _, err := f.client.ImageRemove(ctx, f.image, image.RemoveOptions{
 				Force: true,
 			}); err != nil {
 				fmt.Fprintf(os.Stderr, "Error closing remote file server : %v\n", err)
 			}
 		}
-		if err := f.client.Close(); err != nil {
+		if err := f.client.Close(ctx); err != nil {
 			fmt.Fprintf(os.Stderr, "Error closing remote file server : %v\n", err)
 		}
 	}()
 	if f.container == "" {
 		return nil
 	}
-	return f.client.ContainerRemove(context.Background(), f.container, containertypes.RemoveOptions{
+	return f.client.ContainerRemove(ctx, f.container, containertypes.RemoveOptions{
 		Force:         true,
 		RemoveVolumes: true,
 	})

--- a/testutil/request/request.go
+++ b/testutil/request/request.go
@@ -24,10 +24,10 @@ import (
 )
 
 // NewAPIClient returns a docker API client configured from environment variables
-func NewAPIClient(t testing.TB, ops ...client.Opt) client.APIClient {
+func NewAPIClient(ctx context.Context, t testing.TB, ops ...client.Opt) client.APIClient {
 	t.Helper()
 	ops = append([]client.Opt{client.FromEnv}, ops...)
-	clt, err := client.NewClientWithOpts(ops...)
+	clt, err := client.NewClientWithOpts(ctx, ops...)
 	assert.NilError(t, err)
 	return clt
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

This is a WIP and a breaking change to the docker client APIs. Most likely required by OTEL for better tracing.

Relates to 
- https://github.com/docker/cli/pull/4698
- https://github.com/docker/cli/pull/4774

**- What I did**

Add context to more of the docker client function calls.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

