### PR TITLE
[23.0 backport] builder-next: fix missing lock in ensurelayer

### DIFF
--- a/builder/builder-next/adapters/snapshot/layer.go
+++ b/builder/builder-next/adapters/snapshot/layer.go
@@ -22,6 +22,9 @@ func (s *snapshotter) GetDiffIDs(ctx context.Context, key string) ([]layer.DiffI
 }
 
 func (s *snapshotter) EnsureLayer(ctx context.Context, key string) ([]layer.DiffID, error) {
+	s.layerCreateLocker.Lock(key)
+	defer s.layerCreateLocker.Unlock(key)
+
 	diffIDs, err := s.GetDiffIDs(ctx, key)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/47523

fixes #46136

When this was called concurrently from the moby image exporter there could be a data race where a layer was written to the refs map when it was already there.

In that case the reference count got mixed up and on release only one of these layers was actually released.

```markdown changelog
- Fix multiple parallel `docker build` runs leaking disk space.
```
