### PR TITLE
[23.0 backport] volume: Don't decrement refcount below 0 

### DIFF
--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime/debug"
 	"strings"
 	"sync"
 
@@ -335,8 +336,15 @@ func (v *localVolume) Unmount(id string) error {
 	// ultimately there's nothing that can be done. If we don't decrement the count
 	// this volume can never be removed until a daemon restart occurs.
 	if v.needsMount() {
-		v.active.count--
-		logger.WithField("active mounts", v.active).Debug("Decremented active mount count")
+		// TODO: Remove once the real bug is fixed: https://github.com/moby/moby/issues/46508
+		if v.active.count > 0 {
+			v.active.count--
+			logger.WithField("active mounts", v.active).Debug("Decremented active mount count")
+		} else {
+			logger.Error("An attempt to decrement a zero mount count")
+			logger.Error(string(debug.Stack()))
+			return nil
+		}
 	}
 
 	if v.active.count > 0 {

--- a/volume/mounts/mounts.go
+++ b/volume/mounts/mounts.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"syscall"
 
 	"github.com/containerd/containerd/log"
@@ -83,11 +84,22 @@ func (m *MountPoint) Cleanup() error {
 		return nil
 	}
 
+	logger := log.G(context.TODO()).WithFields(log.Fields{"active": m.active, "id": m.ID})
+
+	// TODO: Remove once the real bug is fixed: https://github.com/moby/moby/issues/46508
+	if m.active == 0 {
+		logger.Error("An attempt to decrement a zero mount count")
+		logger.Error(string(debug.Stack()))
+		return nil
+	}
+
 	if err := m.Volume.Unmount(m.ID); err != nil {
 		return errors.Wrapf(err, "error unmounting volume %s", m.Volume.Name())
 	}
 
 	m.active--
+	logger.Debug("MountPoint.Cleanup Decrement active count")
+
 	if m.active == 0 {
 		m.ID = ""
 	}


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/47530
- related to: https://github.com/moby/moby/issues/46508

With both rootless and live restore enabled, there's some race condition which causes the container to be `Unmount`ed before the refcount is restored.

This makes sure we don't underflow the refcount (uint64) when decrementing it.

The root cause of this race condition still needs to be investigated and fixed, but at least this unflakies the `TestLiveRestore`.

**- How to verify it**
Check `TestLiveRestore`
The CI is green after running the test 30x times: https://github.com/moby/moby/pull/47530/commits/afa01acc55fe383ac32325bdaa8bfc039b9c1b50

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**

