### PR TITLE
feat: ctx to client API

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -2,6 +2,7 @@ package types // import "github.com/docker/docker/api/types"
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"net"
 
@@ -176,7 +177,7 @@ type ImageLoadResponse struct {
 // This function returns the registry authentication
 // header value in base 64 format, or an error
 // if the privilege request fails.
-type RequestPrivilegeFunc func() (string, error)
+type RequestPrivilegeFunc func(context.Context) (string, error)
 
 // ImageSearchOptions holds parameters to search images with.
 type ImageSearchOptions struct {
@@ -289,7 +290,7 @@ type PluginInstallOptions struct {
 	RegistryAuth          string // RegistryAuth is the base64 encoded credentials for the registry
 	RemoteRef             string // RemoteRef is the plugin name on the registry
 	PrivilegeFunc         RequestPrivilegeFunc
-	AcceptPermissionsFunc func(PluginPrivileges) (bool, error)
+	AcceptPermissionsFunc func(context.Context, PluginPrivileges) (bool, error)
 	Args                  []string
 }
 

--- a/api/types/image/opts.go
+++ b/api/types/image/opts.go
@@ -1,6 +1,10 @@
 package image
 
-import "github.com/docker/docker/api/types/filters"
+import (
+	"context"
+
+	"github.com/docker/docker/api/types/filters"
+)
 
 // ImportOptions holds information to import images from the client host.
 type ImportOptions struct {
@@ -27,7 +31,7 @@ type PullOptions struct {
 	// privilege request fails.
 	//
 	// Also see [github.com/docker/docker/api/types.RequestPrivilegeFunc].
-	PrivilegeFunc func() (string, error)
+	PrivilegeFunc func(context.Context) (string, error)
 	Platform      string
 }
 

--- a/client/image_pull.go
+++ b/client/image_pull.go
@@ -36,7 +36,7 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options image.P
 
 	resp, err := cli.tryImageCreate(ctx, query, options.RegistryAuth)
 	if errdefs.IsUnauthorized(err) && options.PrivilegeFunc != nil {
-		newAuthHeader, privilegeErr := options.PrivilegeFunc()
+		newAuthHeader, privilegeErr := options.PrivilegeFunc(ctx)
 		if privilegeErr != nil {
 			return nil, privilegeErr
 		}

--- a/client/image_pull_test.go
+++ b/client/image_pull_test.go
@@ -49,7 +49,7 @@ func TestImagePullWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")),
 	}
-	privilegeFunc := func() (string, error) {
+	privilegeFunc := func(_ context.Context) (string, error) {
 		return "", fmt.Errorf("Error requesting privilege")
 	}
 	_, err := client.ImagePull(context.Background(), "myimage", image.PullOptions{
@@ -64,7 +64,7 @@ func TestImagePullWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.T)
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")),
 	}
-	privilegeFunc := func() (string, error) {
+	privilegeFunc := func(_ context.Context) (string, error) {
 		return "a-auth-header", nil
 	}
 	_, err := client.ImagePull(context.Background(), "myimage", image.PullOptions{
@@ -105,7 +105,7 @@ func TestImagePullWithPrivilegedFuncNoError(t *testing.T) {
 			}, nil
 		}),
 	}
-	privilegeFunc := func() (string, error) {
+	privilegeFunc := func(_ context.Context) (string, error) {
 		return "IAmValid", nil
 	}
 	resp, err := client.ImagePull(context.Background(), "myimage", image.PullOptions{

--- a/client/image_push.go
+++ b/client/image_push.go
@@ -38,7 +38,7 @@ func (cli *Client) ImagePush(ctx context.Context, image string, options image.Pu
 
 	resp, err := cli.tryImagePush(ctx, name, query, options.RegistryAuth)
 	if errdefs.IsUnauthorized(err) && options.PrivilegeFunc != nil {
-		newAuthHeader, privilegeErr := options.PrivilegeFunc()
+		newAuthHeader, privilegeErr := options.PrivilegeFunc(ctx)
 		if privilegeErr != nil {
 			return nil, privilegeErr
 		}

--- a/client/image_push_test.go
+++ b/client/image_push_test.go
@@ -54,7 +54,7 @@ func TestImagePushWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")),
 	}
-	privilegeFunc := func() (string, error) {
+	privilegeFunc := func(_ context.Context) (string, error) {
 		return "", fmt.Errorf("Error requesting privilege")
 	}
 	_, err := client.ImagePush(context.Background(), "myimage", image.PushOptions{
@@ -69,7 +69,7 @@ func TestImagePushWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.T)
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")),
 	}
-	privilegeFunc := func() (string, error) {
+	privilegeFunc := func(_ context.Context) (string, error) {
 		return "a-auth-header", nil
 	}
 	_, err := client.ImagePush(context.Background(), "myimage", image.PushOptions{
@@ -106,7 +106,7 @@ func TestImagePushWithPrivilegedFuncNoError(t *testing.T) {
 			}, nil
 		}),
 	}
-	privilegeFunc := func() (string, error) {
+	privilegeFunc := func(_ context.Context) (string, error) {
 		return "IAmValid", nil
 	}
 	resp, err := client.ImagePush(context.Background(), "myimage:tag", image.PushOptions{

--- a/client/image_search.go
+++ b/client/image_search.go
@@ -34,7 +34,7 @@ func (cli *Client) ImageSearch(ctx context.Context, term string, options types.I
 	resp, err := cli.tryImageSearch(ctx, query, options.RegistryAuth)
 	defer ensureReaderClosed(resp)
 	if errdefs.IsUnauthorized(err) && options.PrivilegeFunc != nil {
-		newAuthHeader, privilegeErr := options.PrivilegeFunc()
+		newAuthHeader, privilegeErr := options.PrivilegeFunc(ctx)
 		if privilegeErr != nil {
 			return results, privilegeErr
 		}

--- a/client/image_search_test.go
+++ b/client/image_search_test.go
@@ -38,7 +38,7 @@ func TestImageSearchWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")),
 	}
-	privilegeFunc := func() (string, error) {
+	privilegeFunc := func(_ context.Context) (string, error) {
 		return "", fmt.Errorf("Error requesting privilege")
 	}
 	_, err := client.ImageSearch(context.Background(), "some-image", types.ImageSearchOptions{
@@ -53,7 +53,7 @@ func TestImageSearchWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")),
 	}
-	privilegeFunc := func() (string, error) {
+	privilegeFunc := func(_ context.Context) (string, error) {
 		return "a-auth-header", nil
 	}
 	_, err := client.ImageSearch(context.Background(), "some-image", types.ImageSearchOptions{
@@ -98,7 +98,7 @@ func TestImageSearchWithPrivilegedFuncNoError(t *testing.T) {
 			}, nil
 		}),
 	}
-	privilegeFunc := func() (string, error) {
+	privilegeFunc := func(_ context.Context) (string, error) {
 		return "IAmValid", nil
 	}
 	results, err := client.ImageSearch(context.Background(), "some-image", types.ImageSearchOptions{

--- a/client/plugin_install.go
+++ b/client/plugin_install.go
@@ -84,7 +84,7 @@ func (cli *Client) checkPluginPermissions(ctx context.Context, query url.Values,
 	resp, err := cli.tryPluginPrivileges(ctx, query, options.RegistryAuth)
 	if errdefs.IsUnauthorized(err) && options.PrivilegeFunc != nil {
 		// todo: do inspect before to check existing name before checking privileges
-		newAuthHeader, privilegeErr := options.PrivilegeFunc()
+		newAuthHeader, privilegeErr := options.PrivilegeFunc(ctx)
 		if privilegeErr != nil {
 			ensureReaderClosed(resp)
 			return nil, privilegeErr
@@ -105,7 +105,7 @@ func (cli *Client) checkPluginPermissions(ctx context.Context, query url.Values,
 	ensureReaderClosed(resp)
 
 	if !options.AcceptAllPermissions && options.AcceptPermissionsFunc != nil && len(privileges) > 0 {
-		accept, err := options.AcceptPermissionsFunc(privileges)
+		accept, err := options.AcceptPermissionsFunc(ctx, privileges)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

This is a breaking change to the Docker Client APIs as consumers of the API will be forced to add the `ctx` parameter to their callback functions.

This PR is a small piece of https://github.com/moby/moby/pull/47518. 

**- What I did**
Add ctx to the client API functions used inside the Docker CLI.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Client API callback functions `client.RequestPrivilegeFunc`, `client.ImageSearchOptions.AcceptPermissionsFunc` and `image.ImportOptions.PrivilegeFunc` now require a context parameter.
```

**- A picture of a cute animal (not mandatory but encouraged)**

