### PR TITLE
set-up-git.md: clarify URL in git clone command

### DIFF
--- a/docs/contributing/set-up-git.md
+++ b/docs/contributing/set-up-git.md
@@ -66,9 +66,10 @@ target="_blank">moby/moby repository</a>.
 8. Clone the fork to your local host into a repository called `moby-fork`.
 
    ```bash
-   $ git clone https://github.com/moxiegirl/moby.git moby-fork
+   $ git clone https://github.com/YOUR_ACCOUNT/moby.git moby-fork
    ```
 
+    In the command above replace `YOUR_ACCOUNT` with your GitHub username.
     Naming your local repo `moby-fork` should help make these instructions
     easier to follow; experienced coders don't typically change the name.
 


### PR DESCRIPTION
Fixes https://github.com/moby/moby/issues/47407

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I clarified which URL to use in the git clone command in the documentation  
for forking and cloning the Moby code.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Clarify which URL to use when forking and cloning the Moby code
```

(Probably no changelog entry for this small fix is needed though)

**- A picture of a cute animal (not mandatory but encouraged)**

