### PR TITLE
hack/unit: Rerun failed flaky libnetwork tests

### DIFF
--- a/hack/test/unit
+++ b/hack/test/unit
@@ -38,15 +38,38 @@ if [ -n "${base_pkg_list}" ]; then
 		${base_pkg_list}
 fi
 if [ -n "${libnetwork_pkg_list}" ]; then
+	rerun_flaky=1
+
+	gotest_extra_flags="-skip=TestFlaky.*"
+	# Custom -run passed, don't run flaky tests separately.
+	if echo "$TESTFLAGS" | grep -Eq '(-run|-test.run)[= ]'; then
+		rerun_flaky=0
+		gotest_extra_flags=""
+	fi
+
 	# libnetwork tests invoke iptables, and cannot be run in parallel. Execute
 	# tests within /libnetwork with '-p=1' to run them sequentially. See
 	# https://github.com/moby/moby/issues/42458#issuecomment-873216754 for details.
-	gotestsum --format=standard-quiet --jsonfile=bundles/go-test-report-libnetwork.json --junitfile=bundles/junit-report-libnetwork.xml -- \
-		"${BUILDFLAGS[@]}" \
+	gotestsum --format=standard-quiet --jsonfile=bundles/go-test-report-libnetwork.json --junitfile=bundles/junit-report-libnetwork.xml \
+		-- "${BUILDFLAGS[@]}" \
 		-cover \
 		-coverprofile=bundles/coverage-libnetwork.out \
 		-covermode=atomic \
 		-p=1 \
+		${gotest_extra_flags} \
 		${TESTFLAGS} \
 		${libnetwork_pkg_list}
+
+	if [ $rerun_flaky -eq 1 ]; then
+		gotestsum --format=standard-quiet --jsonfile=bundles/go-test-report-libnetwork-flaky.json --junitfile=bundles/junit-report-libnetwork-flaky.xml \
+			--packages "${libnetwork_pkg_list}" \
+			--rerun-fails=4 \
+			-- "${BUILDFLAGS[@]}" \
+			-cover \
+			-coverprofile=bundles/coverage-libnetwork-flaky.out \
+			-covermode=atomic \
+			-p=1 \
+			-test.run 'TestFlaky.*' \
+			${TESTFLAGS}
+	fi
 fi

--- a/libnetwork/networkdb/networkdb_test.go
+++ b/libnetwork/networkdb/networkdb_test.go
@@ -240,7 +240,7 @@ func TestNetworkDBJoinLeaveNetworks(t *testing.T) {
 	closeNetworkDBInstances(t, dbs)
 }
 
-func TestNetworkDBCRUDTableEntry(t *testing.T) {
+func TestFlakyNetworkDBCRUDTableEntry(t *testing.T) {
 	dbs := createNetworkDBInstances(t, 3, "node", DefaultConfig())
 
 	err := dbs[0].JoinNetwork("network1")
@@ -270,7 +270,7 @@ func TestNetworkDBCRUDTableEntry(t *testing.T) {
 	closeNetworkDBInstances(t, dbs)
 }
 
-func TestNetworkDBCRUDTableEntries(t *testing.T) {
+func TestFlakyNetworkDBCRUDTableEntries(t *testing.T) {
 	dbs := createNetworkDBInstances(t, 2, "node", DefaultConfig())
 
 	err := dbs[0].JoinNetwork("network1")
@@ -340,7 +340,7 @@ func TestNetworkDBCRUDTableEntries(t *testing.T) {
 	closeNetworkDBInstances(t, dbs)
 }
 
-func TestNetworkDBNodeLeave(t *testing.T) {
+func TestFlakyNetworkDBNodeLeave(t *testing.T) {
 	dbs := createNetworkDBInstances(t, 2, "node", DefaultConfig())
 
 	err := dbs[0].JoinNetwork("network1")
@@ -826,7 +826,7 @@ func TestParallelDelete(t *testing.T) {
 	closeNetworkDBInstances(t, dbs)
 }
 
-func TestNetworkDBIslands(t *testing.T) {
+func TestFlakyNetworkDBIslands(t *testing.T) {
 	pollTimeout := func() time.Duration {
 		const defaultTimeout = 120 * time.Second
 		dl, ok := t.Deadline()


### PR DESCRIPTION
libnetwork tests tend to be flaky (namely `TestNetworkDBIslands` and `TestNetworkDBCRUDTableEntries`).

Move execution of tests which name has `TestFlaky` prefix to a separate gotestsum pass which allows them to be reran 4 times.

On Windows, the libnetwork test execution is not split into a separate pass.


**- What I did**
Restored joy in creating PRs (hopefully).

**- How I did it**

**- How to verify it**
CI

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**

