### PR TITLE
fix: make digest warning more compact

### DIFF
--- a/client/service_create.go
+++ b/client/service_create.go
@@ -176,7 +176,7 @@ func imageWithTagString(image string) string {
 // image name that could not be pinned by digest. The formatting
 // is hardcoded, but could me made smarter in the future
 func digestWarning(image string) string {
-	return fmt.Sprintf("image %s could not be accessed on a registry to record\nits digest. Each node will access %s independently,\npossibly leading to different nodes running different\nversions of the image.\n", image, image)
+	return fmt.Sprintf("image %s could not be accessed on a registry to record\nits digest. Each node will access %s independently,\npossibly leading to different nodes running different versions of the image.\n", image, image)
 }
 
 func validateServiceSpec(s swarm.ServiceSpec) error {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I've addressed this new line issue
![image](https://github.com/moby/moby/assets/1770529/4ecb89fe-22dd-4a0e-8937-fd3bbb110cb0)

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
More compact digest warning
```

**- A picture of a cute animal (not mandatory but encouraged)**

