### PR TITLE
builder-next: Add env-var to override runc used by buildkit

### DIFF
--- a/builder/builder-next/executor_linux.go
+++ b/builder/builder-next/executor_linux.go
@@ -56,9 +56,16 @@ func newExecutor(root, cgroupParent string, net *libnetwork.Controller, dnsConfi
 		return nil, err
 	}
 
+	runcCmds := []string{"runc"}
+
+	// TODO: FIXME: testing env var, replace with something better or remove in a major version or two
+	if runcOverride := os.Getenv("DOCKER_BUILDKIT_RUNC_COMMAND"); runcOverride != "" {
+		runcCmds = []string{runcOverride}
+	}
+
 	return runcexecutor.New(runcexecutor.Opt{
 		Root:                filepath.Join(root, "executor"),
-		CommandCandidates:   []string{"runc"},
+		CommandCandidates:   runcCmds,
 		DefaultCgroupParent: cgroupParent,
 		Rootless:            rootless,
 		NoPivot:             os.Getenv("DOCKER_RAMDISK") != "",


### PR DESCRIPTION
Adds an experimental `DOCKER_BUILDKIT_RUNC_COMMAND` variable that allows to specify different runc-compatible binary to be used by the buildkit's runc executor.

This allows runtimes like sysbox be used for the containers spawned by buildkit.

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
**- A picture of a cute animal (not mandatory but encouraged)**

