### PR TITLE
c8d/list: Fix premature `Images` return

### DIFF
--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -154,8 +154,12 @@ func (i *ImageService) Images(ctx context.Context, opts imagetypes.ListOptions) 
 
 	for _, img := range uniqueImages {
 		image, allChainsIDs, err := i.imageSummary(ctx, img, platformMatcher, opts, tagsByDigest)
-		if err != nil || image == nil {
+		if err != nil {
 			return nil, err
+		}
+		// No error, but image should be skipped.
+		if image == nil {
+			continue
 		}
 
 		summaries = append(summaries, image)

--- a/daemon/containerd/image_list_test.go
+++ b/daemon/containerd/image_list_test.go
@@ -48,6 +48,9 @@ func TestImageList(t *testing.T) {
 	twoplatform, err := specialimage.TwoPlatform(blobsDir)
 	assert.NilError(t, err)
 
+	emptyIndex, err := specialimage.EmptyIndex(blobsDir)
+	assert.NilError(t, err)
+
 	cs := &blobsDirContentStore{blobs: filepath.Join(blobsDir, "blobs/sha256")}
 
 	snapshotter := &testSnapshotterService{}
@@ -90,6 +93,13 @@ func TestImageList(t *testing.T) {
 
 				assert.Check(t, is.Equal(all[1].ID, twoplatform.Manifests[0].Digest.String()))
 				assert.Check(t, is.DeepEqual(all[1].RepoTags, []string{"twoplatform:latest"}))
+			},
+		},
+		{
+			name:   "three images, one is an empty index",
+			images: imagesFromIndex(multilayer, emptyIndex, twoplatform),
+			check: func(t *testing.T, all []*imagetypes.Summary) {
+				assert.Check(t, is.Len(all, 2))
 			},
 		},
 	} {

--- a/internal/testutils/specialimage/emptyindex.go
+++ b/internal/testutils/specialimage/emptyindex.go
@@ -1,0 +1,25 @@
+package specialimage
+
+import (
+	"github.com/distribution/reference"
+	"github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// EmptyIndex creates an image index with no manifests.
+// This is equivalent to `tianon/scratch:index`.
+func EmptyIndex(dir string) (*ocispec.Index, error) {
+	const imageRef = "emptyindex:latest"
+
+	index := ocispec.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: []ocispec.Descriptor{},
+	}
+
+	ref, err := reference.ParseNormalizedNamed(imageRef)
+	if err != nil {
+		return nil, err
+	}
+	return multiPlatformImage(dir, ref, index)
+}


### PR DESCRIPTION

- relates to: https://github.com/moby/moby/issues/47564

52a80b40e25372f6f6c320bbeebe652199a81914 extracted the `imageSummary`
function but introduced a bug causing the whole caller function to
return if the image should be skipped.

`imageSummary` returns a nil error and nil image when the image doesn't
have any platform or all its platforms are not available locally.
In this case that particular image should be skipped, instead of failing
the whole image list operation.

Thanks @rumpl for spotting ❤️ 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
rc2 regression: containerd image store: Fix `image list` not showing images when an image that has no locally available platforms is encountered.
```

**- A picture of a cute animal (not mandatory but encouraged)**

