### PR TITLE
Makefile: generate-files: fix check for empty TMP_OUT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,9 +255,10 @@ swagger-docs: ## preview the API documentation
 .PHONY: generate-files
 generate-files:
 	$(eval $@_TMP_OUT := $(shell mktemp -d -t moby-output.XXXXXXXXXX))
-	ifeq ($($@_TMP_OUT),)
-		$(error Could not create temp directory.)
-	endif
+	@if [ -z "$($@_TMP_OUT)" ]; then \
+		echo "Temp dir is not set"; \
+		exit 1; \
+	fi
 	$(BUILD_CMD) --target "update" \
 		--output "type=local,dest=$($@_TMP_OUT)" \
 		--file "./hack/dockerfiles/generate-files.Dockerfile" .


### PR DESCRIPTION
- relates to / introduced in https://github.com/moby/moby/pull/47121

commit c655b7dc78b3a0773f33f92e9c923a2e48e9c62b added a check to make sure the TMP_OUT variable was not set to an empty value, as such a situation would perform an `rm -rf /**` during cleanup.

However, it was a bit too eager, because Makefile conditionals (`ifeq`) are evaluated when parsing the Makefile, which happens _before_ the make target is executed.

As a result `$@_TMP_OUT` was always empty when the `ifeq` was evaluated, making it not possible to execute the `generate-files` target.

This patch changes the check to use a shell command to evaluate if the var is set to an empty value.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

