### PR TITLE
c8d/list: Don't setup label filter if it's not specified

### DIFF
--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -551,6 +551,10 @@ func setupLabelFilter(store content.Store, fltrs filters.Args) (func(image image
 		}
 	}
 
+	if len(checks) == 0 {
+		return nil, nil
+	}
+
 	return func(image images.Image) bool {
 		ctx := context.TODO()
 

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -568,6 +568,9 @@ func setupLabelFilter(store content.Store, fltrs filters.Args) (func(image image
 			}
 			var cfg configLabels
 			if err := readConfig(ctx, store, desc, &cfg); err != nil {
+				if errdefs.IsNotFound(err) {
+					return nil, nil
+				}
 				return nil, err
 			}
 

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -467,7 +467,7 @@ func (i *ImageService) setupFilters(ctx context.Context, imageFilters filters.Ar
 		return nil, err
 	}
 
-	labelFn, err := setupLabelFilter(i.content, imageFilters)
+	labelFn, err := setupLabelFilter(ctx, i.content, imageFilters)
 	if err != nil {
 		return nil, err
 	}
@@ -517,7 +517,7 @@ func (i *ImageService) setupFilters(ctx context.Context, imageFilters filters.Ar
 // setupLabelFilter parses filter args for "label" and "label!" and returns a
 // filter func which will check if any image config from the given image has
 // labels that match given predicates.
-func setupLabelFilter(store content.Store, fltrs filters.Args) (func(image images.Image) bool, error) {
+func setupLabelFilter(ctx context.Context, store content.Store, fltrs filters.Args) (func(image images.Image) bool, error) {
 	type labelCheck struct {
 		key        string
 		value      string
@@ -556,12 +556,11 @@ func setupLabelFilter(store content.Store, fltrs filters.Args) (func(image image
 	}
 
 	return func(image images.Image) bool {
-		ctx := context.TODO()
-
 		// This is not an error, but a signal to Dispatch that it should stop
 		// processing more content (otherwise it will run for all children).
 		// It will be returned once a matching config is found.
 		errFoundConfig := errors.New("success, found matching config")
+
 		err := images.Dispatch(ctx, presentChildrenHandler(store, images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) (subdescs []ocispec.Descriptor, err error) {
 			if !images.IsConfigType(desc.MediaType) {
 				return nil, nil


### PR DESCRIPTION
- relates to: https://github.com/moby/moby/issues/47564

### c8d/list: Don't setup label filter if it's not specified

Don't run filter function which would only run through the images reading theirs config without checking any label anyway.

This also allows us to save a few containerd RPC calls when label filter is not used (https://github.com/moby/moby/issues/47564).

### c8d/list: Handle missing configs in label filter

Don't error out the filter if an image config is missing.

### c8d/list: Pass ctx to setupLabelFilter

Allows tracing c8d calls.