### PR TITLE
resolvconf: add //go:build directives to prevent downgrading to go1.16 language

### DIFF
--- a/libnetwork/internal/resolvconf/resolvconf.go
+++ b/libnetwork/internal/resolvconf/resolvconf.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.21
+
 // Package resolvconf is used to generate a container's /etc/resolv.conf file.
 //
 // Constructor Load and Parse read a resolv.conf file from the filesystem or


### PR DESCRIPTION
- introduced in https://github.com/moby/moby/pull/47497
- relates to https://github.com/moby/buildkit/pull/4772

Commit 8921897e3b941202d7d46143fa565008ca242205 introduced the uses of `clear()`, which requires go1.21, but Go is downgrading this file to go1.16 when used in other projects (due to us not yet being a go module);

    0.175 + xx-go build '-gcflags=' -ldflags '-X github.com/moby/buildkit/version.Version=b53a13e -X github.com/moby/buildkit/version.Revision=b53a13e4f5c8d7e82716615e0f23656893df89af -X github.com/moby/buildkit/version.Package=github.com/moby/buildkit -extldflags '"'"'-static'"'" -tags 'osusergo netgo static_build seccomp ' -o /usr/bin/buildkitd ./cmd/buildkitd
    181.8 # github.com/docker/docker/libnetwork/internal/resolvconf
    181.8 vendor/github.com/docker/docker/libnetwork/internal/resolvconf/resolvconf.go:509:2: clear requires go1.21 or later (-lang was set to go1.16; check go.mod)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

