### PR TITLE
integration: Remove Parallel from TestDiskUsage

### DIFF
--- a/integration/system/disk_usage_test.go
+++ b/integration/system/disk_usage_test.go
@@ -18,7 +18,9 @@ import (
 func TestDiskUsage(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows") // d.Start fails on Windows with `protocol not available`
 
-	t.Parallel()
+	// TODO: If this helps, then fix the root cause.
+	// See: https://github.com/moby/moby/issues/47119
+	// t.Parallel()
 
 	ctx := testutil.StartSpan(baseContext, t)
 


### PR DESCRIPTION
- related to: https://github.com/moby/moby/issues/47119

Check if removing the Parallel execution from that test fixes its flakiness.


**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

