### PR TITLE
c8d/list: Generate image summary concurrently

### DIFF
--- a/daemon/containerd/image_test.go
+++ b/daemon/containerd/image_test.go
@@ -280,7 +280,7 @@ func digestFor(i int64) digest.Digest {
 	return dgstr.Digest()
 }
 
-func newTestDB(ctx context.Context, t *testing.T) *metadata.DB {
+func newTestDB(ctx context.Context, t testing.TB) *metadata.DB {
 	t.Helper()
 
 	p := filepath.Join(t.TempDir(), "metadata")

--- a/internal/testutils/specialimage/random.go
+++ b/internal/testutils/specialimage/random.go
@@ -1,0 +1,77 @@
+package specialimage
+
+import (
+	"math/rand"
+	"strconv"
+
+	"github.com/distribution/reference"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func RandomSinglePlatform(dir string, platform ocispec.Platform, source rand.Source) (*ocispec.Index, error) {
+	r := rand.New(source) //nolint:gosec // Ignore G404: Use of weak random number generator (math/rand instead of crypto/rand)
+
+	imageRef := "random-" + strconv.FormatInt(r.Int63(), 10) + ":latest"
+
+	layerCount := r.Intn(8)
+
+	var layers []ocispec.Descriptor
+	for i := 0; i < layerCount; i++ {
+		layerDesc, err := writeLayerWithOneFile(dir, "layer-"+strconv.Itoa(i), []byte(strconv.Itoa(i)))
+		if err != nil {
+			return nil, err
+		}
+		layers = append(layers, layerDesc)
+	}
+
+	configDesc, err := writeJsonBlob(dir, ocispec.MediaTypeImageConfig, ocispec.Image{
+		Platform: platform,
+		Config: ocispec.ImageConfig{
+			Env: []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
+		},
+		RootFS: ocispec.RootFS{
+			Type:    "layers",
+			DiffIDs: layersToDigests(layers),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	manifest := ocispec.Manifest{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config:    configDesc,
+		Layers:    layers,
+	}
+
+	legacyManifests := []manifestItem{
+		{
+			Config:   blobPath(configDesc),
+			RepoTags: []string{imageRef},
+			Layers:   blobPaths(layers),
+		},
+	}
+
+	ref, err := reference.ParseNormalizedNamed(imageRef)
+	if err != nil {
+		return nil, err
+	}
+	return singlePlatformImage(dir, ref, manifest, legacyManifests)
+}
+
+func layersToDigests(layers []ocispec.Descriptor) []digest.Digest {
+	var digests []digest.Digest
+	for _, l := range layers {
+		digests = append(digests, l.Digest)
+	}
+	return digests
+}
+
+func blobPaths(descriptors []ocispec.Descriptor) []string {
+	var paths []string
+	for _, d := range descriptors {
+		paths = append(paths, blobPath(d))
+	}
+	return paths
+}


### PR DESCRIPTION
- related to: https://github.com/moby/moby/issues/47564

**- What I did**
### Add `Images` benchmark 
Added a small benchmark that calls `Images`  with image store containing 10, 100 and 1000 random images. Currently the images are single-platform only.

The images are generated randomly, but a fixed seed is used so the actual testing data will be the same across different executions.

Because the content store is not a real containerd image store but a local implementation, a small delay (500us) is added to each content store method call. This is to simulate a real-world usage where each containerd client call requires a gRPC call.

### Generate image summary concurrently
Run `imageSummary` concurrently to avoid being IO blocked on the containerd gRPC.

**- How I did it**

**- How to verify it**
```diff
$ go test -bench=. -benchtime 5s -run BenchmarkImageList
goos: linux
goarch: arm64
pkg: github.com/docker/docker/daemon/containerd
-BenchmarkImageList/10-images-6                16         367278667 ns/op
-BenchmarkImageList/100-images-6                8         688544167 ns/op
-BenchmarkImageList/1000-images-6               4        1337588918 ns/op
+BenchmarkImageList/10-images-6               140          42308378 ns/op
+BenchmarkImageList/100-images-6               81          68406268 ns/op
+BenchmarkImageList/1000-images-6              81          90511519 ns/op
PASS
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
containerd image store: Improve `docker images` performance
```

**- A picture of a cute animal (not mandatory but encouraged)**
![lazy](https://github.com/moby/moby/assets/5046555/3a79f504-7bf5-480a-a00c-90f4c21fbdf6)

