### PR TITLE
c8d/list: Fix shared size calculation

### DIFF
--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -255,10 +255,12 @@ func (i *ImageService) imageSummary(ctx context.Context, img images.Image, platf
 
 		target := img.Target()
 
-		chainIDs, err := img.RootFS(ctx)
+		diffIDs, err := img.RootFS(ctx)
 		if err != nil {
 			return err
 		}
+
+		chainIDs := identity.ChainIDs(diffIDs)
 
 		ts, _, err := i.singlePlatformSize(ctx, img)
 		if err != nil {

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -650,6 +650,11 @@ func computeSharedSize(chainIDs []digest.Digest, layers map[digest.Digest]int, s
 		}
 		size, err := sizeFn(chainID)
 		if err != nil {
+			// Several images might share the same layer and neither of them
+			// might be unpacked (for example if it's a non-host platform).
+			if cerrdefs.IsNotFound(err) {
+				continue
+			}
 			return 0, err
 		}
 		sharedSize += size

--- a/internal/testutils/specialimage/multilayer.go
+++ b/internal/testutils/specialimage/multilayer.go
@@ -16,20 +16,32 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-func MultiLayer(dir string) (*ocispec.Index, error) {
-	const imageRef = "multilayer:latest"
+type SingleFileLayer struct {
+	Name    string
+	Content []byte
+}
 
-	layer1Desc, err := writeLayerWithOneFile(dir, "foo", []byte("1"))
-	if err != nil {
-		return nil, err
-	}
-	layer2Desc, err := writeLayerWithOneFile(dir, "bar", []byte("2"))
-	if err != nil {
-		return nil, err
-	}
-	layer3Desc, err := writeLayerWithOneFile(dir, "hello", []byte("world"))
-	if err != nil {
-		return nil, err
+func MultiLayer(dir string) (*ocispec.Index, error) {
+	return MultiLayerCustom(dir, "multilayer:latest", []SingleFileLayer{
+		{Name: "foo", Content: []byte("1")},
+		{Name: "bar", Content: []byte("2")},
+		{Name: "hello", Content: []byte("world")},
+	})
+}
+
+func MultiLayerCustom(dir string, imageRef string, layers []SingleFileLayer) (*ocispec.Index, error) {
+	var layerDescs []ocispec.Descriptor
+	var layerDgsts []digest.Digest
+	var layerBlobs []string
+	for _, layer := range layers {
+		layerDesc, err := writeLayerWithOneFile(dir, layer.Name, layer.Content)
+		if err != nil {
+			return nil, err
+		}
+
+		layerDescs = append(layerDescs, layerDesc)
+		layerDgsts = append(layerDgsts, layerDesc.Digest)
+		layerBlobs = append(layerBlobs, blobPath(layerDesc))
 	}
 
 	configDesc, err := writeJsonBlob(dir, ocispec.MediaTypeImageConfig, ocispec.Image{
@@ -39,7 +51,7 @@ func MultiLayer(dir string) (*ocispec.Index, error) {
 		},
 		RootFS: ocispec.RootFS{
 			Type:    "layers",
-			DiffIDs: []digest.Digest{layer1Desc.Digest, layer2Desc.Digest, layer3Desc.Digest},
+			DiffIDs: layerDgsts,
 		},
 	})
 	if err != nil {
@@ -49,14 +61,14 @@ func MultiLayer(dir string) (*ocispec.Index, error) {
 	manifest := ocispec.Manifest{
 		MediaType: ocispec.MediaTypeImageManifest,
 		Config:    configDesc,
-		Layers:    []ocispec.Descriptor{layer1Desc, layer2Desc, layer3Desc},
+		Layers:    layerDescs,
 	}
 
 	legacyManifests := []manifestItem{
 		{
 			Config:   blobPath(configDesc),
 			RepoTags: []string{imageRef},
-			Layers:   []string{blobPath(layer1Desc), blobPath(layer2Desc), blobPath(layer3Desc)},
+			Layers:   layerBlobs,
 		},
 	}
 
@@ -128,6 +140,7 @@ func writeLayerWithOneFile(dir string, filename string, content []byte) (ocispec
 	if err != nil {
 		return ocispec.Descriptor{}, err
 	}
+	defer rd.Close()
 
 	return writeBlob(dir, ocispec.MediaTypeImageLayer, rd)
 }


### PR DESCRIPTION
- related to: https://github.com/moby/moby/pull/47449

###  Fix diffIDs being outputted instead of chainIDs

The `identity.ChainIDs` call was accidentally removed in b37ced255103c2dfd36c42685bdd9390f74eb10f.

This broke the shared size calculation for images with more than one layer that were sharing the same compressed layer.

### Handle unpacked layers when calculating shared size

After a535a65c4bbd056760128835a63fa172a935d321 the size reported by the image list was changed to include all platforms of that image.

This made the "shared size" calculation consider all diff ids of all the platforms available in the image which caused "snapshot not found" errors when multiple images were sharing the same layer which wasn't
unpacked.

Found by @milas 

**- What I did**

**- How I did it**

**- How to verify it**
This was could be reproduced with:
```
$ docker pull docker.io/docker/desktop-kubernetes-coredns:v1.11.1
$ docker pull docker.io/docker/desktop-kubernetes-etcd:3.5.10-0
$ docker system df
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
rc3 regression: containerd image store: Fix `docker system df` failing with `snapshot ... does not exist` message when multiple images which share the same layers are present in the image store.
```

**- A picture of a cute animal (not mandatory but encouraged)**

