### PR TITLE
api: document changed behavior of the `Aliases` field in v1.45

### DIFF
--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -25,6 +25,11 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `GET /images/{name}/json` no longer includes the `Container` and
   `ContainerConfig` fields. To access image configuration, use `Config` field
   instead.
+* The `Aliases` field returned in calls to `GET /containers/{name:.*}/json` no
+  longer contains the short container ID, but instead will reflect exactly the
+  values originally submitted to the `POST /containers/create` endpoint. The
+  newly introduced `DNSNames` should now be used instead when short container
+  IDs are needed.
 
 ## v1.44 API changes
 
@@ -83,9 +88,9 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `GET /info` now includes `status` properties in `Runtimes`.
 * A new field named `DNSNames` and containing all non-fully qualified DNS names
   a container takes on a specific network has been added to `GET /containers/{name:.*}/json`.
-* The `Aliases` field returned in calls to `GET /containers/{name:.*}/json` in v1.44  and older
-  versions contains the short container ID. This will change in the next API version,  v1.45.
-  Starting with that API version, this specific value will  be removed from the `Aliases` field
+* The `Aliases` field returned in calls to `GET /containers/{name:.*}/json` in v1.44 and older
+  versions contains the short container ID. This will change in the next API version, v1.45.
+  Starting with that API version, this specific value will be removed from the `Aliases` field
   such that this field will reflect exactly the values originally submitted to the
   `POST /containers/create` endpoint. The newly introduced `DNSNames` should now be used instead.
 * The fields `HairpinMode`, `LinkLocalIPv6Address`, `LinkLocalIPv6PrefixLen`, `SecondaryIPAddresses`,


### PR DESCRIPTION
**- What I did**

Address my concerns with the deprecations in https://github.com/docker/cli/pull/4949#pullrequestreview-1948948034

