### PR TITLE
Add resolver for default bridge, remove default nameservers

### DIFF
--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -87,9 +87,7 @@ type Config struct {
 	NoNewPrivileges      bool                      `json:"no-new-privileges,omitempty"`
 	IpcMode              string                    `json:"default-ipc-mode,omitempty"`
 	CgroupNamespaceMode  string                    `json:"default-cgroupns-mode,omitempty"`
-	// ResolvConf is the path to the configuration of the host resolver
-	ResolvConf string `json:"resolv-conf,omitempty"`
-	Rootless   bool   `json:"rootless,omitempty"`
+	Rootless             bool                      `json:"rootless,omitempty"`
 }
 
 // GetExecRoot returns the user configured Exec-root
@@ -134,12 +132,6 @@ func (conf *Config) LookupInitPath() (string, error) {
 
 	// if we checked all the "libexec" directories and found no matches, fall back to PATH
 	return exec.LookPath(binary)
-}
-
-// GetResolvConf returns the appropriate resolv.conf
-// Check setupResolvConf on how this is selected
-func (conf *Config) GetResolvConf() string {
-	return conf.ResolvConf
 }
 
 // IsSwarmCompatible defines if swarm mode can be enabled in this config

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -825,9 +825,6 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	// Do we have a disabled network?
 	config.DisableBridge = isBridgeNetworkDisabled(config)
 
-	// Setup the resolv.conf
-	setupResolvConf(config)
-
 	idMapping, err := setupRemappedRoot(config)
 	if err != nil {
 		return nil, err

--- a/daemon/daemon_linux.go
+++ b/daemon/daemon_linux.go
@@ -14,7 +14,6 @@ import (
 	"github.com/containerd/log"
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/libnetwork/ns"
-	"github.com/docker/docker/libnetwork/resolvconf"
 	"github.com/moby/sys/mount"
 	"github.com/moby/sys/mountinfo"
 	"github.com/pkg/errors"
@@ -134,18 +133,6 @@ func shouldUnmountRoot(root string, info *mountinfo.Info) bool {
 		return false
 	}
 	return hasMountInfoOption(info.Optional, sharedPropagationOption)
-}
-
-// setupResolvConf sets the appropriate resolv.conf file if not specified
-// When systemd-resolved is running the default /etc/resolv.conf points to
-// localhost. In this case fetch the alternative config file that is in a
-// different path so that containers can use it
-// In all the other cases fallback to the default one
-func setupResolvConf(config *config.Config) {
-	if config.ResolvConf != "" {
-		return
-	}
-	config.ResolvConf = resolvconf.Path()
 }
 
 // ifaceAddrs returns the IPv4 and IPv6 addresses assigned to the network

--- a/daemon/daemon_unsupported.go
+++ b/daemon/daemon_unsupported.go
@@ -12,8 +12,6 @@ func checkSystem() error {
 	return errors.New("the Docker daemon is not supported on this platform")
 }
 
-func setupResolvConf(_ *interface{}) {}
-
 func getSysInfo(_ *Daemon) *sysinfo.SysInfo {
 	return sysinfo.New()
 }

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -555,8 +555,6 @@ func (daemon *Daemon) setupSeccompProfile(*config.Config) error {
 	return nil
 }
 
-func setupResolvConf(config *config.Config) {}
-
 func getSysInfo(*config.Config) *sysinfo.SysInfo {
 	return sysinfo.New()
 }

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -870,7 +870,8 @@ func buildCreateEndpointOptions(c *container.Container, n *libnetwork.Network, e
 		createOptions = append(createOptions, libnetwork.CreateOptionService(svcCfg.Name, svcCfg.ID, vip, portConfigs, svcCfg.Aliases[nwID]))
 	}
 
-	if !containertypes.NetworkMode(nwName).IsUserDefined() {
+	// Don't run an internal DNS resolver for host/container/none networks.
+	if nm := containertypes.NetworkMode(nwName); nm.IsHost() || nm.IsContainer() || nm.IsNone() {
 		createOptions = append(createOptions, libnetwork.CreateOptionDisableResolution())
 	}
 

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -974,14 +974,16 @@ func (s *DockerSwarmSuite) TestDNSConfig(c *testing.T) {
 	id := strings.TrimSpace(out)
 
 	// Compare against expected output.
-	expectedOutput1 := "nameserver 1.2.3.4"
+	expectedOutput1 := "nameserver 127.0.0.11"
 	expectedOutput2 := "search example.com"
 	expectedOutput3 := "options timeout:3"
+	expectedOutput4 := "ExtServers: [1.2.3.4]"
 	out, err = d.Cmd("exec", id, "cat", "/etc/resolv.conf")
 	assert.NilError(c, err, out)
 	assert.Assert(c, strings.Contains(out, expectedOutput1), "Expected '%s', but got %q", expectedOutput1, out)
 	assert.Assert(c, strings.Contains(out, expectedOutput2), "Expected '%s', but got %q", expectedOutput2, out)
 	assert.Assert(c, strings.Contains(out, expectedOutput3), "Expected '%s', but got %q", expectedOutput3, out)
+	assert.Assert(c, strings.Contains(out, expectedOutput4), "Expected '%s', but got %q", expectedOutput4, out)
 }
 
 func (s *DockerSwarmSuite) TestDNSConfigUpdate(c *testing.T) {

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -526,9 +526,6 @@ func (ep *Endpoint) sbJoin(sb *Sandbox, options ...EndpointOption) (err error) {
 	if err := sb.updateHostsFile(ep.getEtcHostsAddrs()); err != nil {
 		return err
 	}
-	if err = sb.updateDNS(n.enableIPv6); err != nil {
-		return err
-	}
 
 	// Current endpoint providing external connectivity for the sandbox
 	extEp := sb.getGatewayEndpoint()

--- a/libnetwork/internal/resolvconf/resolvconf.go
+++ b/libnetwork/internal/resolvconf/resolvconf.go
@@ -270,16 +270,6 @@ func (rc *ResolvConf) TransformForIntNS(
 	}
 	rc.nameServers = newNSs
 
-	// If there are no external nameservers, and the only nameserver left is the
-	// internal resolver, use the defaults as ext nameservers.
-	if len(rc.md.ExtNameServers) == 0 && len(rc.nameServers) == 1 {
-		log.G(context.TODO()).Info("No non-localhost DNS nameservers are left in resolv.conf. Using default external servers")
-		for _, addr := range defaultNSAddrs(ipv6) {
-			rc.md.ExtNameServers = append(rc.md.ExtNameServers, ExtDNSEntry{Addr: addr})
-		}
-		rc.md.UsedDefaultNS = true
-	}
-
 	// For each option required by the nameserver, add it if not already present. If
 	// the option is already present, don't override it. Apart from ndots - if the
 	// ndots value is invalid and an ndots option is required, replace the existing

--- a/libnetwork/internal/resolvconf/resolvconf_test.go
+++ b/libnetwork/internal/resolvconf/resolvconf_test.go
@@ -432,24 +432,9 @@ func TestRCTransformForIntNS(t *testing.T) {
 			},
 		},
 		{
-			name:  "No host nameserver, no iv6",
-			input: "",
-			ipv6:  false,
-			expExtServers: []ExtDNSEntry{
-				mke("8.8.8.8", false),
-				mke("8.8.4.4", false),
-			},
-		},
-		{
-			name:  "No host nameserver, iv6",
+			name:  "No host nameserver",
 			input: "",
 			ipv6:  true,
-			expExtServers: []ExtDNSEntry{
-				mke("8.8.8.8", false),
-				mke("8.8.4.4", false),
-				mke("2001:4860:4860::8888", false),
-				mke("2001:4860:4860::8844", false),
-			},
 		},
 		{
 			name:          "ndots present and required",

--- a/libnetwork/internal/resolvconf/testdata/TestRCTransformForIntNS/No_host_nameserver,_iv6.golden
+++ b/libnetwork/internal/resolvconf/testdata/TestRCTransformForIntNS/No_host_nameserver,_iv6.golden
@@ -1,6 +1,0 @@
-nameserver 127.0.0.11
-
-# Based on host file: '/etc/resolv.conf' (internal resolver)
-# Used default nameservers.
-# ExtServers: [8.8.8.8 8.8.4.4 2001:4860:4860::8888 2001:4860:4860::8844]
-# Overrides: []

--- a/libnetwork/internal/resolvconf/testdata/TestRCTransformForIntNS/No_host_nameserver.golden
+++ b/libnetwork/internal/resolvconf/testdata/TestRCTransformForIntNS/No_host_nameserver.golden
@@ -1,6 +1,4 @@
 nameserver 127.0.0.11
 
 # Based on host file: '/etc/resolv.conf' (internal resolver)
-# Used default nameservers.
-# ExtServers: [8.8.8.8 8.8.4.4]
 # Overrides: []

--- a/libnetwork/sandbox_dns_unix.go
+++ b/libnetwork/sandbox_dns_unix.go
@@ -295,27 +295,6 @@ func (sb *Sandbox) setupDNS() error {
 	return rc.WriteFile(sb.config.resolvConfPath, sb.config.resolvConfHashFile, filePerm)
 }
 
-// Called when an endpoint has joined the sandbox.
-func (sb *Sandbox) updateDNS(ipv6Enabled bool) error {
-	if mod, err := resolvconf.UserModified(sb.config.resolvConfPath, sb.config.resolvConfHashFile); err != nil || mod {
-		return err
-	}
-
-	// Load the host's resolv.conf as a starting point.
-	rc, err := sb.loadResolvConf(sb.config.getOriginResolvConfPath())
-	if err != nil {
-		return err
-	}
-	// For host-networking, no further change is needed.
-	if !sb.config.useDefaultSandBox {
-		// The legacy bridge network has no internal nameserver. So, strip localhost
-		// nameservers from the host's config, then add default nameservers if there
-		// are none remaining.
-		rc.TransformForLegacyNw(ipv6Enabled)
-	}
-	return rc.WriteFile(sb.config.resolvConfPath, sb.config.resolvConfHashFile, filePerm)
-}
-
 // Embedded DNS server has to be enabled for this sandbox. Rebuild the container's resolv.conf.
 func (sb *Sandbox) rebuildDNS() error {
 	// Don't touch the file if the user has modified it.
@@ -361,14 +340,14 @@ func (sb *Sandbox) rebuildDNS() error {
 	// upstream nameservers.
 	sb.setExternalResolvers(extNameServers)
 
-	// Write the file for the container - preserving old behaviour, not updating the
-	// hash file (so, no further updates will be made).
-	// TODO(robmry) - I think that's probably accidental, I can't find a reason for it,
-	//  and the old resolvconf.Build() function wrote the file but not the hash, which
-	//  is surprising. But, before fixing it, a guard/flag needs to be added to
-	//  sb.updateDNS() to make sure that when an endpoint joins a sandbox that already
-	//  has an internal resolver, the container's resolv.conf is still (re)configured
-	//  for an internal resolver.
+	// Write the file for the container - not updating the hash file (so, no further
+	// updates will be made).
+	//
+	// Once the default resolver is configured, there's not normally any need to change
+	// the container's resolv.conf. A possible exception is if an IPv6 endpoint is added
+	// late, so it becomes possible to make upstream requests to IPv6 resolvers from
+	// the container's network namespace. But, the resolver's ext-servers won't currently
+	// be reconfigured once it's started.
 	return rc.WriteFile(sb.config.resolvConfPath, "", filePerm)
 }
 

--- a/libnetwork/sandbox_dns_windows.go
+++ b/libnetwork/sandbox_dns_windows.go
@@ -21,7 +21,3 @@ func (sb *Sandbox) updateHostsFile(ifaceIP []string) error {
 }
 
 func (sb *Sandbox) deleteHostsEntries(recs []etchosts.Record) {}
-
-func (sb *Sandbox) updateDNS(ipv6Enabled bool) error {
-	return nil
-}


### PR DESCRIPTION
- **Reverted until we sort out buildkit's DNS...**
  - see https://github.com/moby/moby/pull/48020

---

- addresses https://github.com/moby/moby/issues/47541

**- What I did**

**_Internal resolver for default bridge network_**

Until now, containers on the default bridge network have been configured to talk directly to external DNS servers - their resolv.conf files have either been populated with nameservers from the host's resolv.conf, or with servers from '--dns' (or with Google's nameservers as a fallback).

This change makes the internal bridge more like other networks by using the internal resolver.  But, the internal resolver is not populated with container names or aliases - it's only for external DNS lookups.

Containers on the default network, on a host that has a loopback resolver (like systemd's on 127.0.0.53) will now use that resolver via the internal resolver. So, the logic used to find systemd's current set of resolvers is no longer needed by the daemon.

Legacy links work just as they did before, using '/etc/hosts' and magic.

**_No default nameservers for internal resolver_**

Don't fall-back to Google's DNS servers in a network that has an internal resolver.

Now the default bridge uses the internal resolver, the only reason a network started by the daemon should end up without any upstream servers is if the host's resolv.conf doesn't list any.  In this case, the '--dns' option can be used to explicitly configure nameservers for a container if necessary.

(Note that buildkit's containers do not have an internal resolver, so they will still set up Google's nameservers if the host has no resolvers that can be used in the container's namespace.)

**- How I did it**

Start the internal resolver, unless the network is 'host', 'container' or 'none'.

Deleted a bunch of code - but not the 'resolvconf' code that configures the resolver for a no-internal-resolver network, because that's still needed by buildkit.

**- How to verify it**

Now the default bridge has an internal resolver, there's a danger we could accidentally populate DNS names for its containers - added a regression test to catch that.

**- Description for the changelog**
```markdown changelog
Run an internal resolver on the default bridge network to forward DNS requests
to external resolvers, even if they are on localhost addresses, or IPv6 addresses when
the default bridge does not have IPv6 connectivity. To preserve existing behavior, the
internal resolver on the default bridge will not resolve container names, unlike the
resolver on user-defined networks.

Do not use Google's DNS servers as a fallback when no external DNS servers are
supplied in configuration via `--dns` or available from the host's `resolv.conf`.
```
