### PR TITLE
AUTHORS,.mailmap: update with recent contributors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -173,6 +173,8 @@ Dattatraya Kumbhar <dattatraya.kumbhar@gslab.com>
 Dave Goodchild <buddhamagnet@gmail.com>
 Dave Henderson <dhenderson@gmail.com> <Dave.Henderson@ca.ibm.com>
 Dave Tucker <dt@docker.com> <dave@dtucker.co.uk>
+David Dooling <dooling@gmail.com>
+David Dooling <dooling@gmail.com> <david.dooling@docker.com>
 David M. Karr <davidmichaelkarr@gmail.com>
 David Sheets <dsheets@docker.com> <sheets@alum.mit.edu>
 David Sissitka <me@dsissitka.com>
@@ -219,6 +221,8 @@ Felix Hupfeld <felix@quobyte.com> <quofelix@users.noreply.github.com>
 Felix Ruess <felix.ruess@gmail.com> <felix.ruess@roboception.de>
 Feng Yan <fy2462@gmail.com>
 Fengtu Wang <wangfengtu@huawei.com> <wangfengtu@huawei.com>
+Filipe Pina <hzlu1ot0@duck.com>
+Filipe Pina <hzlu1ot0@duck.com> <636320+fopina@users.noreply.github.com>
 Francisco Carriedo <fcarriedo@gmail.com>
 Frank Rosquin <frank.rosquin+github@gmail.com> <frank.rosquin@gmail.com>
 Frank Yang <yyb196@gmail.com>
@@ -270,6 +274,7 @@ Hollie Teal <hollie@docker.com> <hollie.teal@docker.com>
 Hollie Teal <hollie@docker.com> <hollietealok@users.noreply.github.com>
 hsinko <21551195@zju.edu.cn> <hsinko@users.noreply.github.com>
 Hu Keping <hukeping@huawei.com>
+Huajin Tong <fliterdashen@gmail.com>
 Hui Kang <hkang.sunysb@gmail.com>
 Hui Kang <hkang.sunysb@gmail.com> <kangh@us.ibm.com>
 Huu Nguyen <huu@prismskylabs.com> <whoshuu@gmail.com>
@@ -563,6 +568,7 @@ Sebastiaan van Stijn <github@gone.nl> <sebastiaan@ws-key-sebas3.dpi1.dpi>
 Sebastiaan van Stijn <github@gone.nl> <thaJeztah@users.noreply.github.com>
 Sebastian Thomschke <sebthom@users.noreply.github.com>
 Seongyeol Lim <seongyeol37@gmail.com>
+Serhii Nakon <serhii.n@thescimus.com>
 Shaun Kaasten <shaunk@gmail.com>
 Shawn Landden <shawn@churchofgit.com> <shawnlandden@gmail.com>
 Shengbo Song <thomassong@tencent.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -669,6 +669,7 @@ Erik Hollensbe <github@hollensbe.org>
 Erik Inge Bolsø <knan@redpill-linpro.com>
 Erik Kristensen <erik@erikkristensen.com>
 Erik Sipsma <erik@sipsma.dev>
+Erik Sjölund <erik.sjolund@gmail.com>
 Erik St. Martin <alakriti@gmail.com>
 Erik Weathers <erikdw@gmail.com>
 Erno Hopearuoho <erno.hopearuoho@gmail.com>
@@ -731,6 +732,7 @@ Feroz Salam <feroz.salam@sourcegraph.com>
 Ferran Rodenas <frodenas@gmail.com>
 Filipe Brandenburger <filbranden@google.com>
 Filipe Oliveira <contato@fmoliveira.com.br>
+Filipe Pina <hzlu1ot0@duck.com>
 Flavio Castelli <fcastelli@suse.com>
 Flavio Crisciani <flavio.crisciani@docker.com>
 Florian <FWirtz@users.noreply.github.com>
@@ -875,6 +877,8 @@ Hsing-Yu (David) Chen <davidhsingyuchen@gmail.com>
 hsinko <21551195@zju.edu.cn>
 Hu Keping <hukeping@huawei.com>
 Hu Tao <hutao@cn.fujitsu.com>
+Huajin Tong <fliterdashen@gmail.com>
+huang-jl <1046678590@qq.com>
 HuanHuan Ye <logindaveye@gmail.com>
 Huanzhong Zhang <zhanghuanzhong90@gmail.com>
 Huayi Zhang <irachex@gmail.com>
@@ -969,6 +973,7 @@ Jannick Fahlbusch <git@jf-projects.de>
 Januar Wayong <januar@gmail.com>
 Jared Biel <jared.biel@bolderthinking.com>
 Jared Hocutt <jaredh@netapp.com>
+Jaroslav Jindrak <dzejrou@gmail.com>
 Jaroslaw Zabiello <hipertracker@gmail.com>
 Jasmine Hegman <jasmine@jhegman.com>
 Jason A. Donenfeld <Jason@zx2c4.com>
@@ -1012,6 +1017,7 @@ Jeffrey Bolle <jeffreybolle@gmail.com>
 Jeffrey Morgan <jmorganca@gmail.com>
 Jeffrey van Gogh <jvg@google.com>
 Jenny Gebske <jennifer@gebske.de>
+Jeongseok Kang <piono623@naver.com>
 Jeremy Chambers <jeremy@thehipbot.com>
 Jeremy Grosser <jeremy@synack.me>
 Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
@@ -1029,6 +1035,7 @@ Jezeniel Zapanta <jpzapanta22@gmail.com>
 Jhon Honce <jhonce@redhat.com>
 Ji.Zhilong <zhilongji@gmail.com>
 Jian Liao <jliao@alauda.io>
+Jian Zeng <anonymousknight96@gmail.com>
 Jian Zhang <zhangjian.fnst@cn.fujitsu.com>
 Jiang Jinyang <jjyruby@gmail.com>
 Jianyong Wu <jianyong.wu@arm.com>
@@ -1967,6 +1974,7 @@ Sergey Evstifeev <sergey.evstifeev@gmail.com>
 Sergii Kabashniuk <skabashnyuk@codenvy.com>
 Sergio Lopez <slp@redhat.com>
 Serhat Gülçiçek <serhat25@gmail.com>
+Serhii Nakon <serhii.n@thescimus.com>
 SeungUkLee <lsy931106@gmail.com>
 Sevki Hasirci <s@sevki.org>
 Shane Canon <scanon@lbl.gov>
@@ -2253,6 +2261,7 @@ VladimirAus <v_roudakov@yahoo.com>
 Vladislav Kolesnikov <vkolesnikov@beget.ru>
 Vlastimil Zeman <vlastimil.zeman@diffblue.com>
 Vojtech Vitek (V-Teq) <vvitek@redhat.com>
+voloder <110066198+voloder@users.noreply.github.com>
 Walter Leibbrandt <github@wrl.co.za>
 Walter Stanish <walter@pratyeka.org>
 Wang Chao <chao.wang@ucloud.cn>


### PR DESCRIPTION
**- What I did**

Regenerate `AUTHORS` and update `.mailmap`, using GitHub profile data when it appeared higher quality than Git metadata.