### PR TITLE
rootless: overlay2: support native overlay diff when using rootless-mode in kernel 5.11 and above

### DIFF
--- a/daemon/graphdriver/overlay2/check.go
+++ b/daemon/graphdriver/overlay2/check.go
@@ -22,9 +22,9 @@ import (
 // directory or the kernel enable CONFIG_OVERLAY_FS_REDIRECT_DIR.
 // When these exist naive diff should be used.
 //
-// When running in a user namespace before kernel 5.11, returns
-// errRunningInUserNS immediately. In kernel 5.11 and later, we
-// check support as usual with some user namespace differences.
+// When running in a user namespace it either immediately returns with an error
+// when userxattr is not supported, or performs the native diff checks as usual
+// with some minor user namespace differences, like adding userxattr.
 func doesSupportNativeDiff(d string) error {
 	userxattr := false
 	if userns.RunningInUserNS() {

--- a/daemon/graphdriver/overlay2/check.go
+++ b/daemon/graphdriver/overlay2/check.go
@@ -35,7 +35,7 @@ func doesSupportNativeDiff(d string) error {
 		if needed {
 			userxattr = true
 		} else {
-			return errors.New("not supported in user namespace, consider updating to kernel 5.11 or later to fix")
+			return errors.New("native diff is not supported in user namespace, consider updating to kernel 5.11 or later to fix")
 		}
 	}
 

--- a/daemon/graphdriver/overlay2/check.go
+++ b/daemon/graphdriver/overlay2/check.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/pkg/userns"
 	"github.com/docker/docker/daemon/graphdriver/overlayutils"
+	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/system"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
@@ -22,11 +23,23 @@ import (
 // directory or the kernel enable CONFIG_OVERLAY_FS_REDIRECT_DIR.
 // When these exist naive diff should be used.
 //
-// When running in a user namespace, returns errRunningInUserNS
-// immediately.
+// When running in a user namespace before kernel 5.11, returns
+// errRunningInUserNS immediately. In kernel 5.11 and later, we
+// check support as usual with some user namespace differences.
 func doesSupportNativeDiff(d string) error {
+	userxattr := false
 	if userns.RunningInUserNS() {
-		return errors.New("running in a user namespace")
+		if !kernel.CheckKernelVersion(5, 11, 0) {
+			return errors.New("running in a user namespace")
+		}
+
+		needed, err := overlayutils.NeedsUserXAttr(d)
+		if err != nil {
+			return err
+		}
+		if needed {
+			userxattr = true
+		}
 	}
 
 	td, err := os.MkdirTemp(d, "opaque-bug-check")
@@ -60,11 +73,16 @@ func doesSupportNativeDiff(d string) error {
 	}
 
 	// Mark l2/d as opaque
-	if err := system.Lsetxattr(filepath.Join(td, "l2", "d"), "trusted.overlay.opaque", []byte("y"), 0); err != nil {
+	if err := system.Lsetxattr(filepath.Join(td, "l2", "d"), overlayutils.GetOverlayXattr("opaque"), []byte("y"), 0); err != nil {
 		return errors.Wrap(err, "failed to set opaque flag on middle layer")
 	}
 
-	opts := fmt.Sprintf("lowerdir=%s:%s,upperdir=%s,workdir=%s", path.Join(td, "l2"), path.Join(td, "l1"), path.Join(td, "l3"), path.Join(td, workDirName))
+	mountFlags := "lowerdir=%s:%s,upperdir=%s,workdir=%s"
+	if userxattr {
+		mountFlags = mountFlags + ",userxattr"
+	}
+
+	opts := fmt.Sprintf(mountFlags, path.Join(td, "l2"), path.Join(td, "l1"), path.Join(td, "l3"), path.Join(td, workDirName))
 	if err := unix.Mount("overlay", filepath.Join(td, mergedDirName), "overlay", 0, opts); err != nil {
 		return errors.Wrap(err, "failed to mount overlay")
 	}
@@ -80,7 +98,7 @@ func doesSupportNativeDiff(d string) error {
 	}
 
 	// Check l3/d does not have opaque flag
-	xattrOpaque, err := system.Lgetxattr(filepath.Join(td, "l3", "d"), "trusted.overlay.opaque")
+	xattrOpaque, err := system.Lgetxattr(filepath.Join(td, "l3", "d"), overlayutils.GetOverlayXattr("opaque"))
 	if err != nil {
 		return errors.Wrap(err, "failed to read opaque flag on upper layer")
 	}
@@ -97,7 +115,7 @@ func doesSupportNativeDiff(d string) error {
 		return errors.Wrap(err, "failed to rename dir in merged directory")
 	}
 	// get the xattr of "d2"
-	xattrRedirect, err := system.Lgetxattr(filepath.Join(td, "l3", "d2"), "trusted.overlay.redirect")
+	xattrRedirect, err := system.Lgetxattr(filepath.Join(td, "l3", "d2"), overlayutils.GetOverlayXattr("redirect"))
 	if err != nil {
 		return errors.Wrap(err, "failed to read redirect flag on upper layer")
 	}


### PR DESCRIPTION
Closes #43626 

**- What I did**
I have implemented the changes I have proposed in #43626 to the best of my knowledge. This should hopefully fix native diff detection for the overlay2 storage driver on rootless docker installations.

**- How I did it**
I mostly took inspiration from the [equivalent function in the podman source code](https://github.com/containers/storage/blob/b0c3d9650bfb3b32a312640ae581f9fc7811bb87/drivers/overlay/check.go#L29). Native overlay diff always worked without problems on podman so I thought I'd check what they do differently, and I noticed that Native Overlay Diff is always disabled on rootless docker, even if it is supported by kernel 5.11 and above.
I'm not exactly sure if I did everything correctly since I'm still a beginner when it comes to Go and this is my first PR. It would be great if someone could double check these changes on their machine (my `make test` run failed after an hour with seemingly unrelated issues...).
Although, @AkihiroSuda and @thaJeztah have acknowledged these changes in #43626.

**- How to verify it**
To the best of my knowledge, the `Native Overlay Diff` entry in `docker info` always returns `false` in rootless-mode since it only checks if we are in a user namespace. After the changes I've made `Native Overlay Diff` should be set to `true` in `docker info`, when supported by the kernel version and when rootless-mode is properly set up.
Also, this warning message when starting the docker service should not show up anymore in kernel 5.11 and above, or at least have a different reason for why it's not supported:
```
Not using native diff for overlay2, this may cause degraded performance for building images: running in a user namespace
```
It should also be double checked there aren't any errors when pulling images like `docker --context=rootless pull python:3.9` and `docker --context=rootless pull hello-world`.

**- Description for the changelog**
```markdown changelog
rootless: overlay2: support native overlay diff when using rootless-mode in kernel 5.11 and above
```
(open for better changelog suggestions...)

**- A picture of a cute animal (not mandatory but encouraged)**
:shipit: 