### PR TITLE
chore: fix mismatched function names in godoc

### DIFF
--- a/libnetwork/drivers/remote/driver.go
+++ b/libnetwork/drivers/remote/driver.go
@@ -406,7 +406,7 @@ func parseStaticRoutes(r api.JoinResponse) ([]*types.StaticRoute, error) {
 	return routes, nil
 }
 
-// parseInterfaces validates all the parameters of an Interface and returns them.
+// parseInterface validates all the parameters of an Interface and returns them.
 func parseInterface(r api.CreateEndpointResponse) (*api.Interface, error) {
 	var outIf *api.Interface
 

--- a/profiles/apparmor/apparmor.go
+++ b/profiles/apparmor/apparmor.go
@@ -48,7 +48,7 @@ func (p *profileData) generateDefault(out io.Writer) error {
 	return compiled.Execute(out, p)
 }
 
-// macrosExists checks if the passed macro exists.
+// macroExists checks if the passed macro exists.
 func macroExists(m string) bool {
 	_, err := os.Stat(path.Join(profileDirectory, m))
 	return err == nil


### PR DESCRIPTION
fix mismatched function names in godoc