### PR TITLE
[24.0 backport] plugin: fix mounting /etc/hosts when running in UserNS

### DIFF
--- a/plugin/v2/plugin_linux.go
+++ b/plugin/v2/plugin_linux.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.19
+
 package v2 // import "github.com/docker/docker/plugin/v2"
 
 import (
@@ -6,7 +9,10 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/containerd/containerd/pkg/userns"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/internal/rootless/mountopts"
+	"github.com/docker/docker/internal/sliceutil"
 	"github.com/docker/docker/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -134,6 +140,36 @@ func (p *Plugin) InitSpec(execRoot string) (*specs.Spec, error) {
 
 	if p.modifyRuntimeSpec != nil {
 		p.modifyRuntimeSpec(&s)
+	}
+
+	// Rootless mode requires modifying the mount flags
+	// https://github.com/moby/moby/issues/47248#issuecomment-1927776700
+	// https://github.com/moby/moby/pull/47558
+	if userns.RunningInUserNS() {
+		for i := range s.Mounts {
+			m := &s.Mounts[i]
+			for _, o := range m.Options {
+				switch o {
+				case "bind", "rbind":
+					if _, err := os.Lstat(m.Source); err != nil {
+						if errors.Is(err, os.ErrNotExist) {
+							continue
+						}
+						return nil, err
+					}
+					// UnprivilegedMountFlags gets the set of mount flags that are set on the mount that contains the given
+					// path and are locked by CL_UNPRIVILEGED. This is necessary to ensure that
+					// bind-mounting "with options" will not fail with user namespaces, due to
+					// kernel restrictions that require user namespace mounts to preserve
+					// CL_UNPRIVILEGED locked flags.
+					unpriv, err := mountopts.UnprivilegedMountFlags(m.Source)
+					if err != nil {
+						return nil, errors.Wrapf(err, "failed to get unprivileged mount flags for %+v", m)
+					}
+					m.Options = sliceutil.Dedup(append(m.Options, unpriv...))
+				}
+			}
+		}
 	}
 
 	return &s, nil


### PR DESCRIPTION
Backport #47558 to 24.0

---

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix `error mounting "/etc/hosts" to rootfs at "/etc/hosts": mount /etc/hosts:/etc/hosts (via /proc/self/fd/6), flags: 0x5021: operation not permitted`.

This error was introduced in 7d08d84b039d2f4661a2242e765a141e65943920 (`dockerd-rootless.sh: set rootlesskit --state-dir=DIR`) that changed the filesystem of the state dir from /tmp to /run (in a typical setup).

Fixes #47248

**- How I did it**

Applied `mountsopts.FixUpOCI`

**- How to verify it**
```
docker plugin install ghcr.io/ibm/docker-logdna:1.0.1
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
plugin: fix mounting /etc/hosts when running in UserNS
```

**- A picture of a cute animal (not mandatory but encouraged)**

🐧 
