### PR TITLE
tarexport: Plumb ctx, add OTEL spans, handle cancellation

### DIFF
--- a/daemon/images/image_exporter.go
+++ b/daemon/images/image_exporter.go
@@ -16,7 +16,7 @@ import (
 // outStream is the writer which the images are written to.
 func (i *ImageService) ExportImage(ctx context.Context, names []string, outStream io.Writer) error {
 	imageExporter := tarexport.NewTarExporter(i.imageStore, i.layerStore, i.referenceStore, i)
-	return imageExporter.Save(names, outStream)
+	return imageExporter.Save(ctx, names, outStream)
 }
 
 func (i *ImageService) PerformWithBaseFS(ctx context.Context, c *container.Container, fn func(root string) error) error {
@@ -46,5 +46,5 @@ func (i *ImageService) PerformWithBaseFS(ctx context.Context, c *container.Conta
 // ball containing images and metadata.
 func (i *ImageService) LoadImage(ctx context.Context, inTar io.ReadCloser, outStream io.Writer, quiet bool) error {
 	imageExporter := tarexport.NewTarExporter(i.imageStore, i.layerStore, i.referenceStore, i)
-	return imageExporter.Load(inTar, outStream, quiet)
+	return imageExporter.Load(ctx, inTar, outStream, quiet)
 }

--- a/image/image.go
+++ b/image/image.go
@@ -1,6 +1,7 @@
 package image // import "github.com/docker/docker/image"
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -279,9 +280,9 @@ func NewHistory(author, comment, createdBy string, isEmptyLayer bool) History {
 
 // Exporter provides interface for loading and saving images
 type Exporter interface {
-	Load(io.ReadCloser, io.Writer, bool) error
+	Load(context.Context, io.ReadCloser, io.Writer, bool) error
 	// TODO: Load(net.Context, io.ReadCloser, <- chan StatusMessage) error
-	Save([]string, io.Writer) error
+	Save(context.Context, []string, io.Writer) error
 }
 
 // NewFromJSON creates an Image configuration from json.

--- a/internal/ioutils/copy.go
+++ b/internal/ioutils/copy.go
@@ -1,0 +1,57 @@
+package ioutils
+
+import (
+	"context"
+	"io"
+)
+
+// CopyCtx copies from src to dst until either EOF is reached on src or a context is cancelled.
+// The writer is not closed when the context is cancelled.
+//
+// After CopyCtx exits due to context cancellation, the goroutine that performed
+// the copy may still be running if either the reader or writer blocks.
+func CopyCtx(ctx context.Context, dst io.Writer, src io.Reader) (n int64, err error) {
+	copyDone := make(chan struct{})
+
+	src = &readerCtx{ctx: ctx, r: src}
+
+	go func() {
+		n, err = io.Copy(dst, src)
+		close(copyDone)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return -1, ctx.Err()
+	case <-copyDone:
+	}
+
+	return n, err
+}
+
+type readerCtx struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+// NewCtxReader wraps the given reader with a reader that doesn't proceed with
+// reading if the context is done.
+//
+// Note: Read will still block if the underlying reader blocks.
+func NewCtxReader(ctx context.Context, r io.Reader) io.Reader {
+	return &readerCtx{ctx: ctx, r: r}
+}
+
+func (r *readerCtx) Read(p []byte) (n int, err error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	n, outErr := r.r.Read(p)
+
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	return n, outErr
+}

--- a/internal/ioutils/copy_test.go
+++ b/internal/ioutils/copy_test.go
@@ -1,0 +1,35 @@
+package ioutils
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+)
+
+type blockingReader struct{}
+
+func (r blockingReader) Read(p []byte) (int, error) {
+	time.Sleep(time.Second)
+	return 0, nil
+}
+
+func TestCopyCtx(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*5)
+	defer cancel()
+
+	dst := new(bytes.Buffer)
+
+	finished := make(chan struct{})
+
+	go func() {
+		CopyCtx(ctx, dst, blockingReader{})
+		close(finished)
+	}()
+
+	select {
+	case <-finished:
+	case <-time.After(time.Millisecond * 100):
+		t.Fatal("CopyCtx did not return after context was cancelled")
+	}
+}


### PR DESCRIPTION
Pass `context.Context` through `tarexport.Load` and `tarexport.Save`. Create OTEL spans for the most time consuming operations.

Also, handle context cancellations to actually end saving/loading when the operation is cancelled - before this PR the daemon would still be performing the operation even though the user already cancelled it.


**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix `docker save` and `docker load` not ending on the daemon side when the operation was cancelled (eg. Ctrl+C)
```

**- A picture of a cute animal (not mandatory but encouraged)**

