### PR TITLE
[26.0 backport] ci: update workflow artifacts retention

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -70,6 +70,7 @@ jobs:
         with:
           name: test-reports-unit-${{ inputs.storage }}
           path: /tmp/reports/*
+          retention-days: 1
 
   unit-report:
     runs-on: ubuntu-20.04
@@ -150,6 +151,7 @@ jobs:
         with:
           name: test-reports-docker-py-${{ inputs.storage }}
           path: /tmp/reports/*
+          retention-days: 1
 
   integration-flaky:
     runs-on: ubuntu-20.04
@@ -271,6 +273,7 @@ jobs:
         with:
           name: test-reports-integration-${{ inputs.storage }}-${{ env.TESTREPORTS_NAME }}
           path: /tmp/reports/*
+          retention-days: 1
 
   integration-report:
     runs-on: ubuntu-20.04
@@ -410,6 +413,7 @@ jobs:
         with:
           name: test-reports-integration-cli-${{ inputs.storage }}-${{ env.TESTREPORTS_NAME }}
           path: /tmp/reports/*
+          retention-days: 1
 
   integration-cli-report:
     runs-on: ubuntu-20.04

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -190,6 +190,7 @@ jobs:
         with:
           name: ${{ inputs.os }}-${{ inputs.storage }}-unit-reports
           path: ${{ env.GOPATH }}\src\github.com\docker\docker\bundles\*
+          retention-days: 1
 
   unit-test-report:
     runs-on: ubuntu-latest
@@ -508,6 +509,7 @@ jobs:
         with:
           name: ${{ inputs.os }}-${{ inputs.storage }}-integration-reports-${{ matrix.runtime }}-${{ env.TESTREPORTS_NAME }}
           path: ${{ env.GOPATH }}\src\github.com\docker\docker\bundles\*
+          retention-days: 1
 
   integration-test-report:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,14 +51,6 @@ jobs:
         name: Check artifacts
         run: |
           find ${{ env.DESTDIR }} -type f -exec file -e ascii -- {} +
-      -
-        name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.target }}
-          path: ${{ env.DESTDIR }}
-          if-no-files-found: error
-          retention-days: 7
 
   prepare-cross:
     runs-on: ubuntu-latest
@@ -119,11 +111,3 @@ jobs:
         name: Check artifacts
         run: |
           find ${{ env.DESTDIR }} -type f -exec file -e ascii -- {} +
-      -
-        name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: cross-${{ env.PLATFORM_PAIR }}
-          path: ${{ env.DESTDIR }}
-          if-no-files-found: error
-          retention-days: 7


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/47636

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

As reported by @thaJeztah, we are using 90% (46GB/51GB) of the shared storage in the org:

<img src='https://github.com/moby/moby/assets/1951866/ecebfc93-869f-4e6d-b255-e8aded70eb1b' width='300'>

We don't have a clear understanding of what "Shared storage" stands for but this looks to be related to workflow artifacts.

In this case we are using the `actions/upload-artifact` to upload binaries and test results in this repo. Atm there was no retention for test results so set it to `1` day (defaults to 90). In ci workflow just remove the upload artifacts steps that are not used in subsequent jobs. This was put there just to download and test binaries locally but don't think we need them anymore.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

