### PR TITLE
[26.0 backport] Restore the SetKey prestart hook.

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -24,6 +24,7 @@ import (
 	"github.com/docker/docker/oci/caps"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/rootless/specconv"
+	"github.com/docker/docker/pkg/stringid"
 	volumemounts "github.com/docker/docker/volume/mounts"
 	"github.com/moby/sys/mount"
 	"github.com/moby/sys/mountinfo"
@@ -56,6 +57,28 @@ func withRlimits(daemon *Daemon, daemonCfg *dconfig.Config, c *container.Contain
 			s.Process = &specs.Process{}
 		}
 		s.Process.Rlimits = rlimits
+		return nil
+	}
+}
+
+// withLibnetwork sets the libnetwork hook
+func withLibnetwork(daemon *Daemon, daemonCfg *dconfig.Config, c *container.Container) coci.SpecOpts {
+	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
+		if c.Config.NetworkDisabled {
+			return nil
+		}
+		for _, ns := range s.Linux.Namespaces {
+			if ns.Type == specs.NetworkNamespace && ns.Path == "" {
+				if s.Hooks == nil {
+					s.Hooks = &specs.Hooks{}
+				}
+				shortNetCtlrID := stringid.TruncateID(daemon.netController.ID())
+				s.Hooks.Prestart = append(s.Hooks.Prestart, specs.Hook{
+					Path: filepath.Join("/proc", strconv.Itoa(os.Getpid()), "exe"),
+					Args: []string{"libnetwork-setkey", "-exec-root=" + daemonCfg.GetExecRoot(), c.ID, shortNetCtlrID},
+				})
+			}
+		}
 		return nil
 	}
 }
@@ -1015,6 +1038,7 @@ func (daemon *Daemon) createSpec(ctx context.Context, daemonCfg *configStore, c 
 		WithCapabilities(c),
 		WithSeccomp(daemon, c),
 		withMounts(daemon, daemonCfg, c, mounts),
+		withLibnetwork(daemon, &daemonCfg.Config, c),
 		WithApparmor(c),
 		WithSelinux(c),
 		WithOOMScore(&c.HostConfig.OomScoreAdj),

--- a/daemon/start_linux.go
+++ b/daemon/start_linux.go
@@ -2,14 +2,12 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"context"
-	"fmt"
-
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libcontainerd/types"
 	"github.com/docker/docker/oci"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // initializeCreatedTask performs any initialization that needs to be done to
@@ -22,9 +20,7 @@ func (daemon *Daemon) initializeCreatedTask(ctx context.Context, tsk types.Task,
 			if err != nil {
 				return errdefs.System(err)
 			}
-			if err := sb.SetKey(fmt.Sprintf("/proc/%d/ns/net", tsk.Pid())); err != nil {
-				return errdefs.System(err)
-			}
+			return sb.FinishConfig()
 		}
 	}
 	return nil


### PR DESCRIPTION
- redo: https://github.com/moby/moby/pull/47635 (was accidentally set to `master` as a target)
- backport https://github.com/moby/moby/pull/47621

**- What I did**

- Fix https://github.com/moby/moby/issues/47619
- Partially reverted https://github.com/moby/moby/commit/0046b16d87105d334b72f5e98efd28bbd94d9659 - daemon: set libnetwork sandbox key w/o OCI hook; https://github.com/moby/moby/pull/47062
- Partially reverted https://github.com/moby/moby/pull/47521/commits/ef5295cda40d3d2babb5ce85ffcf67371c3ecb47 - Don't configure IPv6 addr/gw when IPv6 disabled; https://github.com/moby/moby/pull/47521

Running SetKey to store the OCI Sandbox key after task creation, rather than from the OCI prestart hook, meant it happened after sysctl settings were applied by the runtime - which was the intention, we wanted to complete Sandbox configuration after IPv6 had been disabled by a sysctl if that was going to happen.

But, it meant '--sysctl' options for a specfic network interface caused container task creation to fail, because the interface is only moved into the network namespace during SetKey.

**- How I did it**

Restored the SetKey prestart hook.

Regenerate config files that depend on the container's support for IPv6 after the task has been created.

The changes in the second partially-reverted commit, to check IPv6 support before assigning an interface address/gateway would no longer work, but are no longer necessary.  IPv6 addresses applied during the SetKey prestart hook will be removed when the sysctl disabling IPv6 in the container is applied.

**- How to verify it**

Added a regression test, to make sure it's possible to set an interface-specfic sysctl.

The tests for IPv6 addresses in '/etc/hosts' when IPv6 is disabled still work.

**- Description for the changelog**
```markdown changelog
Fix a regression that meant network interface specific `--sysctl` options prevented container startup.
```