### PR TITLE
github/ci: Check if backport is opened against the expected branch

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -44,3 +44,19 @@ jobs:
 
           echo "This PR will be included in the release notes with the following note:"
           echo "$desc"
+
+  check-pr-branch:
+    runs-on: ubuntu-20.04
+    env:
+      PR_TITLE: ${{ github.event.pull_request.title }}
+    steps:
+      # Backports or PR that target a release branch directly should mention the target branch in the title, for example:
+      # [X.Y backport] Some change that needs backporting to X.Y
+      # [X.Y] Change directly targeting the X.Y branch
+      - name: Get branch from PR title
+        id: title_branch
+        run: echo "$PR_TITLE" | sed -n 's/^\[\([0-9]*\.[0-9]*\)[^]]*\].*/branch=\1/p' >> $GITHUB_OUTPUT
+
+      - name: Check release branch
+        if: github.event.pull_request.base.ref != steps.title_branch.outputs.branch && !(github.event.pull_request.base.ref == 'master' && steps.title_branch.outputs.branch == '')
+        run: echo "::error::PR title suggests targetting the ${{ steps.title_branch.outputs.branch }} branch, but is opened against ${{ github.event.pull_request.base.ref }}" && exit 1


### PR DESCRIPTION
- related: https://github.com/moby/moby/pull/47635

**- What I did**
Added a GHA check for the expected target branch on backport PRs.

**- How to verify it**
CI: https://github.com/moby/moby/actions/runs/8466474413/job/23195302313?pr=47647
Tested with this PR titled as `[1337.0 backport] github/ci: Check if backport is opened against the expected branch`
```
Run branch=$(echo "[1337.0 backport] github/ci: Check if backport is opened against the expected branch" | sed -n 's/^\[\([0-9]*\.[0-9]*\) backport\].*/\1/p')
PR title suggests backport to 1337.0, but PR is opened against master
Error: Process completed with exit code 1.
```

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**

