### PR TITLE
API: bump version to 1.46

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -3,7 +3,7 @@ package api // import "github.com/docker/docker/api"
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of the current REST API.
-	DefaultVersion = "1.45"
+	DefaultVersion = "1.46"
 
 	// MinSupportedAPIVersion is the minimum API version that can be supported
 	// by the API server, specified as "major.minor". Note that the daemon

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -19,10 +19,10 @@ produces:
 consumes:
   - "application/json"
   - "text/plain"
-basePath: "/v1.45"
+basePath: "/v1.46"
 info:
   title: "Docker Engine API"
-  version: "1.45"
+  version: "1.46"
   x-logo:
     url: "https://docs.docker.com/assets/images/logo-docker-main.png"
   description: |
@@ -55,8 +55,8 @@ info:
     the URL is not supported by the daemon, a HTTP `400 Bad Request` error message
     is returned.
 
-    If you omit the version-prefix, the current version of the API (v1.45) is used.
-    For example, calling `/info` is the same as calling `/v1.45/info`. Using the
+    If you omit the version-prefix, the current version of the API (v1.46) is used.
+    For example, calling `/info` is the same as calling `/v1.46/info`. Using the
     API without a version-prefix is deprecated and will be removed in a future release.
 
     Engine releases in the near future should support this version of the API,

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -13,6 +13,8 @@ keywords: "API, Docker, rcli, REST, documentation"
      will be rejected.
 -->
 
+## v1.46 API changes
+
 ## v1.45 API changes
 
 [Docker Engine API v1.45](https://docs.docker.com/engine/api/v1.45/) documentation


### PR DESCRIPTION
Docker 26.0 was released with API v1.45, so any change in the API should now target v1.46.

**- Description for the changelog**
```markdown changelog
Update API to v1.46.
```