### PR TITLE
Minor fix for illumos support

### DIFF
--- a/pkg/system/stat_illumos.go
+++ b/pkg/system/stat_illumos.go
@@ -1,0 +1,15 @@
+package system // import "github.com/docker/docker/pkg/system"
+
+import "syscall"
+
+// fromStatT converts a syscall.Stat_t type to a system.Stat_t type
+func fromStatT(s *syscall.Stat_t) (*StatT, error) {
+	return &StatT{
+		size: s.Size,
+		mode: uint32(s.Mode),
+		uid:  s.Uid,
+		gid:  s.Gid,
+		rdev: uint64(s.Rdev),
+		mtim: s.Mtim,
+	}, nil
+}


### PR DESCRIPTION
illumos is the opensource continuation of OpenSolaris after Oracle closed to source it (again).

This change fixes builds breaking when trying to build illumos binaries which import this package.

For example use see: https://github.com/openbao/openbao/pull/205.
