### PR TITLE
local logs: re-slice buffer to marshalled size

### DIFF
--- a/daemon/logger/local/read_test.go
+++ b/daemon/logger/local/read_test.go
@@ -13,7 +13,7 @@ import (
 func TestDecode(t *testing.T) {
 	buf := make([]byte, 0)
 
-	err := marshal(&logger.Message{Line: []byte("hello")}, &buf)
+	_, err := marshal(&logger.Message{Line: []byte("hello")}, &buf)
 	assert.NilError(t, err)
 
 	for i := 0; i < len(buf); i++ {


### PR DESCRIPTION
The buffer in question is a shared buffer which may have a length that is greater than the actual marshalled value of the current log message.
