### PR TITLE
Update GoDoc for ioutils on atomic writers

### DIFF
--- a/pkg/ioutils/fswriters.go
+++ b/pkg/ioutils/fswriters.go
@@ -9,6 +9,7 @@ import (
 // NewAtomicFileWriter returns WriteCloser so that writing to it writes to a
 // temporary file and closing it atomically changes the temporary file to
 // destination path. Writing and closing concurrently is not allowed.
+// NOTE: umask is not considered for the file's permissions.
 func NewAtomicFileWriter(filename string, perm os.FileMode) (io.WriteCloser, error) {
 	f, err := os.CreateTemp(filepath.Dir(filename), ".tmp-"+filepath.Base(filename))
 	if err != nil {
@@ -26,7 +27,8 @@ func NewAtomicFileWriter(filename string, perm os.FileMode) (io.WriteCloser, err
 	}, nil
 }
 
-// AtomicWriteFile atomically writes data to a file named by filename.
+// AtomicWriteFile atomically writes data to a file named by filename and with the specified permission bits.
+// NOTE: umask is not considered for the file's permissions.
 func AtomicWriteFile(filename string, data []byte, perm os.FileMode) error {
 	f, err := NewAtomicFileWriter(filename, perm)
 	if err != nil {


### PR DESCRIPTION
Unlike its stdlib counterparts, AtomicFileWriter does not take into consideration umask due to its use of chmod. Failure to recognize this may cause subtle problems like the one described in #47498.

Therefore the documentation has been updated to let users know that umask is not taken into consideration when using AtomicFileWriter.

Closes #47516.

