### PR TITLE
Change multierror module name in api/types/network/endpoint.go

### DIFF
--- a/api/types/network/endpoint.go
+++ b/api/types/network/endpoint.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/docker/docker/internal/multierror"
+	"github.com/moby/moby/internal/multierror"
 )
 
 // EndpointSettings stores the network endpoint details


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Change multierror module name in api/types/network/endpoint.go

**- How I did it**

Just...Type some words.

**- How to verify it**

Change it and update checksum

**- Description for the changelog**
Uh, you know.
Changing the name of a Golang module is troublesome.

```bash
../../../go/pkg/mod/github.com/moby/moby@v26.0.0+incompatible/api/types/network/endpoint.go:8:2: use of internal package github.com/docker/docker/internal/multierror not allowed
```
