### PR TITLE
c8d: Add ImageConvert

### DIFF
--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -28,6 +28,7 @@ type imageBackend interface {
 	GetImage(ctx context.Context, refOrID string, options backend.GetImageOpts) (*dockerimage.Image, error)
 	TagImage(ctx context.Context, id dockerimage.ID, newRef reference.Named) error
 	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*image.PruneReport, error)
+	ImageConvert(ctx context.Context, src string, dsts []reference.NamedTagged, options image.ConvertOptions) error
 }
 
 type importExportBackend interface {

--- a/api/server/router/image/image.go
+++ b/api/server/router/image/image.go
@@ -51,6 +51,7 @@ func (ir *imageRouter) initRoutes() {
 		router.NewPostRoute("/images/{name:.*}/push", ir.postImagesPush),
 		router.NewPostRoute("/images/{name:.*}/tag", ir.postImagesTag),
 		router.NewPostRoute("/images/prune", ir.postImagesPrune),
+		router.NewPostRoute("/images/convert", ir.postImagesConvert),
 		// DELETE
 		router.NewDeleteRoute("/images/{name:.*}", ir.deleteImages),
 	}

--- a/api/types/image/opts.go
+++ b/api/types/image/opts.go
@@ -83,3 +83,10 @@ type RemoveOptions struct {
 	Force         bool
 	PruneChildren bool
 }
+
+// ConvertOptions holds parameters to convert images.
+type ConvertOptions struct {
+	OnlyAvailablePlatforms bool
+	Platforms              []ocispec.Platform
+	NoAttestations         bool
+}

--- a/client/image_convert.go
+++ b/client/image_convert.go
@@ -1,0 +1,50 @@
+package client // import "github.com/docker/docker/client"
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"github.com/containerd/containerd/platforms"
+	"github.com/distribution/reference"
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/errdefs"
+	"github.com/pkg/errors"
+)
+
+// ImageList converts image.
+func (cli *Client) ImageConvert(ctx context.Context, src string, dsts []reference.NamedTagged, options image.ConvertOptions) error {
+	query := url.Values{}
+
+	if options.OnlyAvailablePlatforms && len(options.Platforms) > 0 {
+		return errdefs.InvalidParameter(errors.New("specifying both explicit platform list and only-available-platforms is not allowed"))
+	}
+
+	if options.OnlyAvailablePlatforms {
+		query.Set("only-available-platforms", "1")
+	}
+
+	if len(options.Platforms) > 0 {
+		for _, p := range options.Platforms {
+			query.Add("platforms", platforms.Format(p))
+		}
+	}
+
+	if options.NoAttestations {
+		query.Set("no-attestations", "1")
+	}
+
+	query.Set("from", src)
+	for _, dst := range dsts {
+		query.Add("to", dst.String())
+	}
+
+	serverResp, err := cli.post(ctx, "/images/convert", query, nil, nil)
+	ensureReaderClosed(serverResp)
+
+	if serverResp.statusCode != http.StatusCreated {
+		return errdefs.NotFound(errors.Wrapf(err, "failed to convert image %v", src))
+	}
+
+	return err
+}

--- a/client/interface.go
+++ b/client/interface.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
@@ -103,6 +104,7 @@ type ImageAPIClient interface {
 	ImageSave(ctx context.Context, images []string) (io.ReadCloser, error)
 	ImageTag(ctx context.Context, image, ref string) error
 	ImagesPrune(ctx context.Context, pruneFilter filters.Args) (image.PruneReport, error)
+	ImageConvert(ctx context.Context, src string, dst []reference.NamedTagged, options image.ConvertOptions) error
 }
 
 // NetworkAPIClient defines API client methods for the networks

--- a/daemon/containerd/image_convert.go
+++ b/daemon/containerd/image_convert.go
@@ -1,0 +1,184 @@
+package containerd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/log"
+	"github.com/distribution/reference"
+	imagetypes "github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/errdefs"
+	"github.com/moby/buildkit/util/attestation"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func (i *ImageService) ImageConvert(ctx context.Context, src string, dsts []reference.NamedTagged, opts imagetypes.ConvertOptions) error {
+	log.G(ctx).Debugf("converting: %+v", opts)
+
+	srcImg, err := i.resolveImage(ctx, src)
+	if err != nil {
+		return err
+	}
+
+	if opts.OnlyAvailablePlatforms && len(opts.Platforms) > 0 {
+		return errdefs.InvalidParameter(errors.New("specifying both explicit platform list and only-available-platforms is not allowed"))
+	}
+
+	srcMediaType := srcImg.Target.MediaType
+	if !images.IsIndexType(srcMediaType) {
+		return errdefs.InvalidParameter(errors.New("cannot convert non-index image"))
+	}
+
+	oldIndex, info, err := readIndex(ctx, i.content, srcImg.Target)
+	if err != nil {
+		return err
+	}
+
+	newImg := srcImg
+	newManifests, err := i.convertManifests(ctx, srcImg, opts)
+	if err != nil {
+		return err
+	}
+	if len(newManifests) == 0 {
+		return errdefs.InvalidParameter(errors.New("refusing to create an empty image"))
+	}
+
+	newImg.Target = newManifests[0]
+	if len(newManifests) > 1 {
+		newIndex := oldIndex
+		newIndex.Manifests = newManifests
+		t, err := storeJson(ctx, i.content, newIndex.MediaType, newIndex, info.Labels)
+		if err != nil {
+			return errdefs.System(fmt.Errorf("failed to write modified image target: %w", err))
+		}
+		newImg.Target = t
+	}
+
+	newImg.CreatedAt = time.Now()
+	newImg.UpdatedAt = newImg.CreatedAt
+
+	for _, dst := range dsts {
+		newImg.Name = dst.String()
+
+		if err := i.forceCreateImage(ctx, newImg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var errConvertNoop = errors.New("no conversion performed")
+
+func (i *ImageService) convertManifests(ctx context.Context, srcImg images.Image, opts imagetypes.ConvertOptions) ([]ocispec.Descriptor, error) {
+	changed := false
+	pm := platforms.All
+	if len(opts.Platforms) > 0 {
+		pm = platforms.Any(opts.Platforms...)
+	}
+
+	var newManifests []ocispec.Descriptor
+	walker := i.walkReachableImageManifests
+	if opts.OnlyAvailablePlatforms {
+		walker = i.walkImageManifests
+		changed = true
+	}
+
+	// Key: Manifest digest, Value: OCI descriptor of the attestation
+	manifestToAttestationDesc := map[string]ocispec.Descriptor{}
+
+	// Collect attestation descriptors
+	if !opts.NoAttestations {
+		err := walker(ctx, srcImg, func(im *ImageManifest) error {
+			if im.IsAttestation() {
+				desc := im.Target()
+				typ := desc.Annotations[attestation.DockerAnnotationReferenceType]
+				if typ != attestation.DockerAnnotationReferenceTypeDefault {
+					log.G(ctx).WithFields(log.Fields{
+						"digest": desc.Digest,
+						"type":   typ,
+					}).Debug("skipping attestation manifest with unknown type")
+					return images.ErrSkipDesc
+				}
+
+				mfstDgst := im.Target().Annotations[attestation.DockerAnnotationReferenceDigest]
+				manifestToAttestationDesc[mfstDgst] = desc
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	err := walker(ctx, srcImg, func(m *ImageManifest) error {
+		if m.IsAttestation() {
+			return images.ErrSkipDesc
+		} else {
+			mtarget := m.Target()
+			mplatform, err := m.ImagePlatform(ctx)
+			if err != nil {
+				return err
+			}
+			if !pm.Match(mplatform) {
+				changed = true
+				log.G(ctx).WithFields(log.Fields{
+					"platform": mplatform,
+					"digest":   mtarget.Digest,
+				}).Debugf("skipping manifest %s due to platform mismatch", mtarget.Digest)
+				return images.ErrSkipDesc
+			}
+
+			newManifests = append(newManifests, mtarget)
+			log.G(ctx).WithFields(log.Fields{
+				"platform": mplatform,
+				"digest":   mtarget.Digest,
+			}).Debug("add platform-specific image manifest")
+
+			attestation, hasAttestation := manifestToAttestationDesc[mtarget.Digest.String()]
+			if hasAttestation {
+				newManifests = append(newManifests, attestation)
+				log.G(ctx).WithFields(log.Fields{
+					"platform":    mplatform,
+					"manifest":    mtarget.Digest,
+					"attestation": attestation.Digest,
+				}).Debug("add attestation")
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if !changed {
+		return newManifests, errConvertNoop
+	}
+
+	return newManifests, nil
+}
+
+func readIndex(ctx context.Context, store content.InfoReaderProvider, desc ocispec.Descriptor) (ocispec.Index, content.Info, error) {
+	info, err := store.Info(ctx, desc.Digest)
+	if err != nil {
+		return ocispec.Index{}, content.Info{}, err
+	}
+
+	p, err := content.ReadBlob(ctx, store, desc)
+	if err != nil {
+		return ocispec.Index{}, info, err
+	}
+
+	var idx ocispec.Index
+	if err := json.Unmarshal(p, &idx); err != nil {
+		return ocispec.Index{}, info, err
+	}
+
+	return idx, info, nil
+}

--- a/daemon/containerd/image_convert_test.go
+++ b/daemon/containerd/image_convert_test.go
@@ -1,0 +1,105 @@
+package containerd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containerd/containerd/content/local"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/log/logtest"
+	"github.com/distribution/reference"
+	imagetypes "github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/internal/testutils/specialimage"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestImageConvert(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.TODO(), "testing")
+
+	blobsDir := t.TempDir()
+
+	twoplatform, err := specialimage.TwoPlatform(blobsDir)
+	assert.NilError(t, err)
+
+	dstRef := func(s string) reference.NamedTagged {
+		ref, err := reference.ParseNormalizedNamed(s)
+		assert.NilError(t, err)
+		return reference.TagNameOnly(ref).(reference.NamedTagged)
+	}
+
+	cs, err := local.NewStore(blobsDir)
+	assert.NilError(t, err)
+
+	for _, tc := range []struct {
+		name  string
+		src   *ocispec.Index
+		err   error
+		opts  imagetypes.ConvertOptions
+		check func(t *testing.T, src, dst images.Image)
+	}{
+		{
+			src:  twoplatform,
+			name: "twoplatform-to-noop",
+			opts: imagetypes.ConvertOptions{},
+			err:  errConvertNoop,
+		},
+		{
+			src:  twoplatform,
+			name: "twoplatform-to-available",
+			opts: imagetypes.ConvertOptions{
+				OnlyAvailablePlatforms: true,
+			},
+			// All are available so should be the same
+			check: func(t *testing.T, src, dst images.Image) {
+				assert.Check(t, is.Equal(src.Target.Digest, dst.Target.Digest))
+			},
+		},
+		{
+			src:  twoplatform,
+			name: "twoplatform-to-one",
+			opts: imagetypes.ConvertOptions{
+				Platforms: []ocispec.Platform{platforms.MustParse("linux/amd64")},
+			},
+			check: func(t *testing.T, src, dst images.Image) {
+				assert.Assert(t, src.Target.Digest != dst.Target.Digest)
+
+				assert.Check(t, is.Equal(dst.Target.MediaType, ocispec.MediaTypeImageManifest))
+				mfst, err := readManifest(ctx, cs, dst.Target)
+				assert.NilError(t, err)
+
+				var cfg ocispec.Image
+				assert.NilError(t, readConfig(ctx, cs, mfst.Config, &cfg))
+
+				assert.Check(t, is.Equal(cfg.Platform.OS, "linux"))
+				assert.Check(t, is.Equal(cfg.Platform.Architecture, "amd64"))
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := logtest.WithT(ctx, t)
+			service := fakeImageService(t, ctx, cs)
+
+			srcImg, err := service.images.Create(ctx, imagesFromIndex(tc.src)[0])
+			assert.NilError(t, err)
+
+			dst := dstRef(tc.name)
+			err = service.ImageConvert(ctx, srcImg.Name, []reference.NamedTagged{dst}, tc.opts)
+
+			if tc.err != nil {
+				assert.ErrorIs(t, err, tc.err)
+				return
+			} else {
+				assert.NilError(t, err)
+			}
+
+			newImg, err := service.images.Get(ctx, dst.String())
+			assert.NilError(t, err)
+			tc.check(t, srcImg, newImg)
+		})
+	}
+
+}

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -43,6 +43,7 @@ type ImageService interface {
 	ImageHistory(ctx context.Context, name string) ([]*imagetype.HistoryResponseItem, error)
 	CommitImage(ctx context.Context, c backend.CommitConfig) (image.ID, error)
 	SquashImage(id, parent string) (string, error)
+	ImageConvert(ctx context.Context, src string, dsts []reference.NamedTagged, options imagetype.ConvertOptions) error
 
 	// Containerd related methods
 

--- a/daemon/images/image_convert.go
+++ b/daemon/images/image_convert.go
@@ -1,0 +1,15 @@
+package images
+
+import (
+	"context"
+
+	"errors"
+
+	"github.com/distribution/reference"
+	imagetypes "github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/errdefs"
+)
+
+func (i *ImageService) ImageConvert(ctx context.Context, src string, dsts []reference.NamedTagged, opts imagetypes.ConvertOptions) error {
+	return errdefs.NotImplemented(errors.New("not supported in graphdriver backed image store"))
+}

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -13,6 +13,19 @@ keywords: "API, Docker, rcli, REST, documentation"
      will be rejected.
 -->
 
+## v1.47 API changes
+
+[Docker Engine API v1.47](https://docs.docker.com/engine/api/v1.47/) documentation
+
+* Add `POST /images/convert` endpoint that allows to create new images by
+  filtering the index of the source image. Supported options are:
+  - `OnlyAvailablePlatforms` - discard image manifests for platforms that are
+	not available locally
+  - `Platforms` - discard image manifests that don't match any of the selected
+  - `NoAttestations` - discard any build attestations
+  WARNING: This is experimental and may change at any time without any backward
+  compatibility.
+
 
 ## v1.46 API changes
 


### PR DESCRIPTION
Introduce a new `ImageConvert` operation to the image service (only supported by the containerd image store) to convert multi-platform image indexes.

The intent behind adding a new operation is to make the reduction of a multi-platform image to a single-platform image explicit to the user and not force operation like push to create a new image index with a different image digest if user wants to operate only on a subset of the original multi-platform image.

**- How to verify it**
`TestImageConvert` unit test.

Manual test with https://github.com/docker/cli/pull/4983:
<img width="574" alt="image" src="https://github.com/moby/moby/assets/5046555/15632476-e358-47cc-8a4a-c172a04d1e03" />



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
containerd image store: Add `POST /images/convert` endpoint that allows to create new images by filtering the index of the source image. Supported options are:
  - `OnlyAvailablePlatforms` - discard image manifests for platforms that are not available locally
  - `Platforms` - discard image manifests that don't match any of the selected
  - `NoAttestations` - discard any build attestations
WARNING: This is experimental and may change at any time without any backward compatibility.
```

**- A picture of a cute animal (not mandatory but encouraged)**

