### PR TITLE
c8d/push: Support `--platform` switch

### DIFF
--- a/api/server/httputils/form_test.go
+++ b/api/server/httputils/form_test.go
@@ -1,9 +1,16 @@
 package httputils // import "github.com/docker/docker/api/server/httputils"
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/url"
 	"testing"
+
+	"github.com/containerd/containerd/platforms"
+	"github.com/docker/docker/errdefs"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"gotest.tools/v3/assert"
 )
 
 func TestBoolValue(t *testing.T) {
@@ -101,5 +108,25 @@ func TestInt64ValueOrDefaultWithError(t *testing.T) {
 	_, err := Int64ValueOrDefault(r, "test", -1)
 	if err == nil {
 		t.Fatal("Expected an error.")
+	}
+}
+
+func TestParsePlatformInvalid(t *testing.T) {
+	for _, tc := range []ocispec.Platform{
+		{
+			OSVersion:  "1.2.3",
+			OSFeatures: []string{"a", "b"},
+		},
+		{OSVersion: "12.0"},
+		{OS: "linux"},
+		{Architecture: "amd64"},
+	} {
+		t.Run(platforms.Format(tc), func(t *testing.T) {
+			js, err := json.Marshal(tc)
+			assert.NilError(t, err)
+
+			_, err = DecodePlatform(string(js))
+			assert.Check(t, errdefs.IsInvalidParameter(err))
+		})
 	}
 }

--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -39,7 +39,7 @@ type importExportBackend interface {
 
 type registryBackend interface {
 	PullImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
-	PushImage(ctx context.Context, ref reference.Named, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
+	PushImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
 }
 
 type Searcher interface {

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -206,17 +206,21 @@ func (ir *imageRouter) postImagesPush(ctx context.Context, w http.ResponseWriter
 	}
 
 	var platform *ocispec.Platform
-	if formPlatform := r.Form.Get("platform"); formPlatform != "" {
-		if versions.LessThan(httputils.VersionFromContext(ctx), "1.46") {
-			return errdefs.InvalidParameter(errors.New("selecting platform is not supported in API version < 1.46"))
+	// Platform is optional, and only supported in API version 1.46 and later.
+	// However the PushOptions struct previously was an alias for the PullOptions struct
+	// which also contained a Platform field.
+	// This means that older clients may be sending a platform field, even
+	// though it wasn't really supported by the server.
+	// Don't break these clients and just ignore the platform field on older APIs.
+	if versions.GreaterThanOrEqualTo(httputils.VersionFromContext(ctx), "1.46") {
+		if formPlatform := r.Form.Get("platform"); formPlatform != "" {
+			p, err := httputils.DecodePlatform(formPlatform)
+			if err != nil {
+				return err
+			}
+			platform = p
 		}
 
-		p, err := httputils.DecodePlatform(formPlatform)
-		if err != nil {
-			return err
-		}
-
-		platform = p
 	}
 
 	if err := ir.backend.PushImage(ctx, ref, platform, metaHeaders, authConfig, output); err != nil {

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8752,6 +8752,11 @@ paths:
             details.
           type: "string"
           required: true
+        - name: "platform"
+          in: "query"
+          description: "Select a platform-specific manifest to be pushed. OCI platform (JSON encoded)"
+          type: "string"
+          x-nullable: true
       tags: ["Image"]
   /images/{name}/tag:
     post:

--- a/api/types/auxprogress/push.go
+++ b/api/types/auxprogress/push.go
@@ -1,0 +1,26 @@
+package auxprogress
+
+import (
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// ManifestPushedInsteadOfIndex is a note that is sent when a manifest is pushed
+// instead of an index.  It is sent when the pushed image is an multi-platform
+// index, but the whole index couldn't be pushed.
+type ManifestPushedInsteadOfIndex struct {
+	ManifestPushedInsteadOfIndex bool `json:"manifestPushedInsteadOfIndex"` // Always true
+
+	// OriginalIndex is the descriptor of the original image index.
+	OriginalIndex ocispec.Descriptor `json:"originalIndex"`
+
+	// SelectedManifest is the descriptor of the manifest that was pushed instead.
+	SelectedManifest ocispec.Descriptor `json:"selectedManifest"`
+}
+
+// ContentMissing is a note that is sent when push fails because the content is missing.
+type ContentMissing struct {
+	ContentMissing bool `json:"contentMissing"` // Always true
+
+	// Desc is the descriptor of the root object that was attempted to be pushed.
+	Desc ocispec.Descriptor `json:"desc"`
+}

--- a/api/types/image/opts.go
+++ b/api/types/image/opts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/docker/docker/api/types/filters"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // ImportOptions holds information to import images from the client host.
@@ -36,7 +37,23 @@ type PullOptions struct {
 }
 
 // PushOptions holds information to push images.
-type PushOptions PullOptions
+type PushOptions struct {
+	All          bool
+	RegistryAuth string // RegistryAuth is the base64 encoded credentials for the registry
+
+	// PrivilegeFunc is a function that clients can supply to retry operations
+	// after getting an authorization error. This function returns the registry
+	// authentication header value in base64 encoded format, or an error if the
+	// privilege request fails.
+	//
+	// Also see [github.com/docker/docker/api/types.RequestPrivilegeFunc].
+	PrivilegeFunc func(context.Context) (string, error)
+
+	// Platform is an optional field that selects a specific platform to push
+	// when the image is a multi-platform image.
+	// Using this will only push a single platform-specific manifest.
+	Platform *ocispec.Platform `json:",omitempty"`
+}
 
 // ListOptions holds parameters to list images with.
 type ListOptions struct {

--- a/client/image_push.go
+++ b/client/image_push.go
@@ -2,7 +2,9 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -34,6 +36,20 @@ func (cli *Client) ImagePush(ctx context.Context, image string, options image.Pu
 		if tagged, ok := ref.(reference.Tagged); ok {
 			query.Set("tag", tagged.Tag())
 		}
+	}
+
+	if options.Platform != nil {
+		if err := cli.NewVersionError(ctx, "1.46", "platform"); err != nil {
+			return nil, err
+		}
+
+		p := *options.Platform
+		pJson, err := json.Marshal(p)
+		if err != nil {
+			return nil, fmt.Errorf("invalid platform: %v", err)
+		}
+
+		query.Set("platform", string(pJson))
 	}
 
 	resp, err := cli.tryImagePush(ctx, name, query, options.RegistryAuth)

--- a/daemon/containerd/image_manifest.go
+++ b/daemon/containerd/image_manifest.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containerd/containerd/images"
 	containerdimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/errdefs"
 	"github.com/moby/buildkit/util/attestation"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -21,8 +22,7 @@ var (
 )
 
 // walkImageManifests calls the handler for each locally present manifest in
-// the image. The image implements the containerd.Image interface, but all
-// operations act on the specific manifest instead of the index.
+// the image.
 func (i *ImageService) walkImageManifests(ctx context.Context, img containerdimages.Image, handler func(img *ImageManifest) error) error {
 	desc := img.Target
 
@@ -48,6 +48,52 @@ func (i *ImageService) walkImageManifests(ctx context.Context, img containerdima
 	return errors.Wrapf(errNotManifestOrIndex, "error walking manifest for %s", img.Name)
 }
 
+// walkReachableImageManifests calls the handler for each manifest in the
+// multiplatform image that can be reached from the given image.
+// The image might not be present locally, but its descriptor is known.
+func (i *ImageService) walkReachableImageManifests(ctx context.Context, img containerdimages.Image, handler func(img *ImageManifest) error) error {
+	desc := img.Target
+
+	handleManifest := func(ctx context.Context, d ocispec.Descriptor) error {
+		platformImg, err := i.NewImageManifest(ctx, img, d)
+		if err != nil {
+			if err == errNotManifest {
+				return nil
+			}
+			return err
+		}
+		return handler(platformImg)
+	}
+
+	if containerdimages.IsManifestType(desc.MediaType) {
+		return handleManifest(ctx, desc)
+	}
+
+	if containerdimages.IsIndexType(desc.MediaType) {
+		return containerdimages.Walk(ctx, containerdimages.HandlerFunc(
+			func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+				err := handleManifest(ctx, desc)
+				if err != nil {
+					return nil, err
+				}
+
+				descs, err := containerdimages.Children(ctx, i.content, desc)
+				if err != nil {
+					if cerrdefs.IsNotFound(err) {
+						return nil, nil
+					}
+					return nil, err
+				}
+				return descs, nil
+			}), desc)
+	}
+
+	return errNotManifestOrIndex
+}
+
+// ImageManifest implements the containerd.Image interface, but all operations
+// act on the specific manifest instead of the index as opposed to the struct
+// returned by containerd.NewImageWithPlatform.
 type ImageManifest struct {
 	containerd.Image
 
@@ -78,21 +124,29 @@ func (im *ImageManifest) Metadata() containerdimages.Image {
 	return md
 }
 
-// IsPseudoImage returns false if the manifest has no layers or any of its layers is a known image layer.
-// Some manifests use the image media type for compatibility, even if they are not a real image.
-func (im *ImageManifest) IsPseudoImage(ctx context.Context) (bool, error) {
-	desc := im.Target()
-
+func (im *ImageManifest) IsAttestation() bool {
 	// Quick check for buildkit attestation manifests
 	// https://github.com/moby/buildkit/blob/v0.11.4/docs/attestations/attestation-storage.md
 	// This would have also been caught by the layer check below, but it requires
 	// an additional content read and deserialization of Manifest.
-	if _, has := desc.Annotations[attestation.DockerAnnotationReferenceType]; has {
+	if _, has := im.Target().Annotations[attestation.DockerAnnotationReferenceType]; has {
+		return true
+	}
+	return false
+}
+
+// IsPseudoImage returns false if the manifest has no layers or any of its layers is a known image layer.
+// Some manifests use the image media type for compatibility, even if they are not a real image.
+func (im *ImageManifest) IsPseudoImage(ctx context.Context) (bool, error) {
+	if im.IsAttestation() {
 		return true, nil
 	}
 
 	mfst, err := im.Manifest(ctx)
 	if err != nil {
+		if cerrdefs.IsNotFound(err) {
+			return false, errdefs.NotFound(errors.Wrapf(err, "failed to read manifest %v", im.Target().Digest))
+		}
 		return true, err
 	}
 	if len(mfst.Layers) == 0 {
@@ -148,4 +202,22 @@ func readManifest(ctx context.Context, store content.Provider, desc ocispec.Desc
 	}
 
 	return mfst, nil
+}
+
+// ImagePlatform returns the platform of the image manifest.
+// If the manifest list doesn't have a platform filled, it will be read from the config.
+func (m *ImageManifest) ImagePlatform(ctx context.Context) (ocispec.Platform, error) {
+	target := m.Target()
+	if target.Platform != nil {
+		return *target.Platform, nil
+	}
+
+	configDesc, err := m.Config(ctx)
+	if err != nil {
+		return ocispec.Platform{}, err
+	}
+
+	var out ocispec.Platform
+	err = readConfig(ctx, m.ContentStore(), configDesc, &out)
+	return out, err
 }

--- a/daemon/containerd/image_manifest.go
+++ b/daemon/containerd/image_manifest.go
@@ -135,11 +135,22 @@ func (im *ImageManifest) IsAttestation() bool {
 	return false
 }
 
-// IsPseudoImage returns false if the manifest has no layers or any of its layers is a known image layer.
+// IsPseudoImage returns false when any of the below is true:
+// - The manifest has no layers
+// - None of its layers is a known image layer.
+// - The manifest has unknown/unknown platform.
+//
 // Some manifests use the image media type for compatibility, even if they are not a real image.
 func (im *ImageManifest) IsPseudoImage(ctx context.Context) (bool, error) {
 	if im.IsAttestation() {
 		return true, nil
+	}
+
+	plat := im.Target().Platform
+	if plat != nil {
+		if plat.OS == "unknown" && plat.Architecture == "unknown" {
+			return true, nil
+		}
 	}
 
 	mfst, err := im.Manifest(ctx)

--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -41,7 +41,7 @@ import (
 // pointing to the new target repository. This will allow subsequent pushes
 // to perform cross-repo mounts of the shared content when pushing to a different
 // repository on the same registry.
-func (i *ImageService) PushImage(ctx context.Context, sourceRef reference.Named, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) (retErr error) {
+func (i *ImageService) PushImage(ctx context.Context, sourceRef reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) (retErr error) {
 	start := time.Now()
 	defer func() {
 		if retErr == nil {
@@ -76,7 +76,7 @@ func (i *ImageService) PushImage(ctx context.Context, sourceRef reference.Named,
 					continue
 				}
 
-				if err := i.pushRef(ctx, named, metaHeaders, authConfig, out); err != nil {
+				if err := i.pushRef(ctx, named, platform, metaHeaders, authConfig, out); err != nil {
 					return err
 				}
 			}
@@ -85,10 +85,10 @@ func (i *ImageService) PushImage(ctx context.Context, sourceRef reference.Named,
 		}
 	}
 
-	return i.pushRef(ctx, sourceRef, metaHeaders, authConfig, out)
+	return i.pushRef(ctx, sourceRef, platform, metaHeaders, authConfig, out)
 }
 
-func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, metaHeaders map[string][]string, authConfig *registry.AuthConfig, out progress.Output) (retErr error) {
+func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, out progress.Output) (retErr error) {
 	leasedCtx, release, err := i.client.WithLease(ctx)
 	if err != nil {
 		return err
@@ -104,12 +104,18 @@ func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, m
 		if cerrdefs.IsNotFound(err) {
 			return errdefs.NotFound(fmt.Errorf("tag does not exist: %s", reference.FamiliarString(targetRef)))
 		}
-		return errdefs.NotFound(err)
+		return errdefs.System(err)
 	}
 
 	target := img.Target
-	store := i.content
+	if platform != nil {
+		target, err = i.getPushDescriptor(ctx, img, platform)
+		if err != nil {
+			return err
+		}
+	}
 
+	store := i.content
 	resolver, tracker := i.newResolverFromAuthConfig(ctx, authConfig, targetRef)
 	pp := pushProgress{Tracker: tracker}
 	jobsQueue := newJobs()
@@ -121,7 +127,7 @@ func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, m
 		finishProgress()
 		if retErr == nil {
 			if tagged, ok := targetRef.(reference.Tagged); ok {
-				progress.Messagef(out, "", "%s: digest: %s size: %d", tagged.Tag(), target.Digest, img.Target.Size)
+				progress.Messagef(out, "", "%s: digest: %s size: %d", tagged.Tag(), target.Digest, target.Size)
 			}
 		}
 	}()
@@ -164,16 +170,44 @@ func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, m
 
 	err = remotes.PushContent(ctx, pusher, target, store, limiter, platforms.All, handlerWrapper)
 	if err != nil {
-		if containerdimages.IsIndexType(target.MediaType) && cerrdefs.IsNotFound(err) {
+		// If push failed because of a missing content, no specific platform was requested
+		// and the target is an index, select a platform-specific manifest to push instead.
+		if cerrdefs.IsNotFound(err) && containerdimages.IsIndexType(target.MediaType) && platform == nil {
+			var newTarget ocispec.Descriptor
+			newTarget, err = i.getPushDescriptor(ctx, img, nil)
+			if err != nil {
+				return err
+			}
+
+			// Retry only if the new push candidate is different from the previous one.
+			if newTarget.Digest != target.Digest {
+				target = newTarget
+				pp.TurnNotStartedIntoUnavailable()
+				err = remotes.PushContent(ctx, pusher, target, store, limiter, platforms.All, handlerWrapper)
+
+				if err == nil {
+					progress.Aux(out, map[string]string{
+						"Stripped": "true",
+						"Index":    img.Target.Digest.String(),
+						"Manifest": target.Digest.String(),
+					})
+				}
+			}
+		}
+
+		if err != nil {
+			if !cerrdefs.IsNotFound(err) {
+				return errdefs.System(err)
+			}
 			return errdefs.NotFound(fmt.Errorf(
 				"missing content: %w\n"+
 					"Note: You're trying to push a manifest list/index which "+
 					"references multiple platform specific manifests, but not all of them are available locally "+
-					"or available to the remote repository.\n"+
-					"Make sure you have all the referenced content and try again.",
+					"or available to the remote repository.\n\n"+
+					"Make sure you have all the referenced content and try again.\n"+
+					"You can also push only a single platform specific manifest directly by specifying the platform you want to push.",
 				err))
 		}
-		return err
 	}
 
 	appendDistributionSourceLabel(ctx, realStore, targetRef, target)
@@ -181,6 +215,97 @@ func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, m
 	i.LogImageEvent(reference.FamiliarString(targetRef), reference.FamiliarName(targetRef), events.ActionPush)
 
 	return nil
+}
+
+func (i *ImageService) getPushDescriptor(ctx context.Context, img containerdimages.Image, platform *ocispec.Platform) (ocispec.Descriptor, error) {
+	// Allow to override the host platform for testing purposes.
+	hostPlatform := i.defaultPlatformOverride
+	if hostPlatform == nil {
+		hostPlatform = platforms.Default()
+	}
+
+	pm := matchAllWithPreference(hostPlatform)
+	if platform != nil {
+		pm = platforms.OnlyStrict(*platform)
+	}
+
+	anyMissing := false
+
+	var bestMatchPlatform ocispec.Platform
+	var bestMatch *ImageManifest
+	var presentMatchingManifests []*ImageManifest
+	err := i.walkReachableImageManifests(ctx, img, func(im *ImageManifest) error {
+		available, err := im.CheckContentAvailable(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to determine availability of image manifest %s: %w", im.Target().Digest, err)
+		}
+
+		if !available {
+			anyMissing = true
+			return nil
+		}
+
+		if im.IsAttestation() {
+			return nil
+		}
+
+		imgPlatform, err := im.ImagePlatform(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to determine platform of image %s: %w", img.Name, err)
+		}
+
+		if !pm.Match(imgPlatform) {
+			return nil
+		}
+
+		presentMatchingManifests = append(presentMatchingManifests, im)
+		if bestMatch == nil || pm.Less(imgPlatform, bestMatchPlatform) {
+			bestMatchPlatform = imgPlatform
+			bestMatch = im
+		}
+
+		return nil
+	})
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	switch len(presentMatchingManifests) {
+	case 0:
+		return ocispec.Descriptor{}, errdefs.NotFound(fmt.Errorf("no suitable image manifest found for platform %s", *platform))
+	case 1:
+		// Only one manifest is available AND matching the requested platform.
+
+		if platform != nil {
+			// Explicit platform was requested
+			return presentMatchingManifests[0].Target(), nil
+		}
+
+		// No specific platform was requested, but only one manifest is available.
+		if anyMissing {
+			return presentMatchingManifests[0].Target(), nil
+		}
+
+		// Index has only one manifest anyway, select the full index.
+		return img.Target, nil
+	default:
+		if platform == nil {
+			if !anyMissing {
+				// No specific platform requested, and all manifests are available, select the full index.
+				return img.Target, nil
+			}
+
+			// No specific platform requested and not all manifests are available.
+			// Select the manifest that matches the host platform the best.
+			if bestMatch != nil && hostPlatform.Match(bestMatchPlatform) {
+				return bestMatch.Target(), nil
+			}
+
+			return ocispec.Descriptor{}, errdefs.Conflict(errors.Errorf("multiple matching manifests found but no specific platform requested"))
+		}
+
+		return ocispec.Descriptor{}, errdefs.Conflict(errors.Errorf("multiple manifests found for platform %s", *platform))
+	}
 }
 
 func appendDistributionSourceLabel(ctx context.Context, realStore content.Store, targetRef reference.Named, target ocispec.Descriptor) {

--- a/daemon/containerd/image_push_test.go
+++ b/daemon/containerd/image_push_test.go
@@ -1,0 +1,288 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.19
+
+package containerd
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	containerdimages "github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/platforms"
+	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/internal/testutils/specialimage"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/exp/slices"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+type pushTestCase struct {
+	name               string
+	indexPlatforms     []platforms.Platform // all platforms supported by the image
+	availablePlatforms []platforms.Platform // platforms available locally
+	requestPlatform    *platforms.Platform  // platform requested by the client (not the platform selected for push!)
+	check              func(t *testing.T, img containerdimages.Image, pushDescriptor ocispec.Descriptor, err error)
+	daemonPlatform     *platforms.Platform
+}
+
+func TestImagePushIndex(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.TODO(), "testing-"+t.Name())
+
+	csDir := t.TempDir()
+	store := &blobsDirContentStore{blobs: filepath.Join(csDir, "blobs/sha256")}
+
+	linuxAmd64 := platforms.MustParse("linux/amd64")
+	darwinArm64 := platforms.MustParse("darwin/arm64")
+	windowsAmd64 := platforms.MustParse("windows/amd64")
+
+	linuxArm64 := platforms.MustParse("linux/arm64")
+	linuxArmv5 := platforms.MustParse("linux/arm/v5")
+	linuxArmv7 := platforms.MustParse("linux/arm/v7")
+
+	// Image service will have the daemon host platform mocked to linux/amd64.
+	// Unless test cases specify a different platform.
+	defaultDaemonPlatform := linuxAmd64
+
+	for _, tc := range []pushTestCase{
+		// No explicit platform requested
+		{
+			name: "none requested, all present",
+
+			indexPlatforms:     []platforms.Platform{linuxAmd64, darwinArm64, windowsAmd64},
+			availablePlatforms: []platforms.Platform{linuxAmd64, darwinArm64, windowsAmd64},
+			check:              wholeIndexSelected,
+		},
+		{
+			name: "none requested, one present",
+
+			indexPlatforms:     []platforms.Platform{linuxAmd64, darwinArm64, windowsAmd64},
+			availablePlatforms: []platforms.Platform{linuxAmd64},
+			check:              singleManifestSelected(linuxAmd64),
+		},
+		{
+			name: "none requested, two present, daemon platform available",
+
+			indexPlatforms:     []platforms.Platform{linuxAmd64, darwinArm64, windowsAmd64},
+			availablePlatforms: []platforms.Platform{linuxAmd64, darwinArm64},
+			check:              singleManifestSelected(linuxAmd64),
+		},
+		{
+			name: "none requested, two present, daemon platform NOT available",
+
+			indexPlatforms:     []platforms.Platform{linuxAmd64, darwinArm64, windowsAmd64},
+			availablePlatforms: []platforms.Platform{darwinArm64, windowsAmd64},
+			check:              multipleCandidates,
+		},
+
+		// Specific platform requested
+		{
+			name: "linux/amd64 requested, all present",
+
+			indexPlatforms:     []platforms.Platform{linuxAmd64, darwinArm64, windowsAmd64},
+			availablePlatforms: []platforms.Platform{linuxAmd64, darwinArm64, windowsAmd64},
+			requestPlatform:    &linuxAmd64,
+			check:              singleManifestSelected(linuxAmd64),
+		},
+		{
+			name: "linux/amd64 requested, but not present",
+
+			indexPlatforms:     []platforms.Platform{linuxAmd64, darwinArm64, windowsAmd64},
+			availablePlatforms: []platforms.Platform{darwinArm64, windowsAmd64},
+			requestPlatform:    &linuxAmd64,
+			check:              candidateNotFound,
+		},
+
+		// Variant tests
+		{
+			name: "linux/arm/v5 requested, but not in index",
+
+			indexPlatforms:     []platforms.Platform{linuxAmd64, linuxArmv7},
+			availablePlatforms: []platforms.Platform{linuxAmd64, linuxArmv7},
+			requestPlatform:    &linuxArmv5,
+			check:              candidateNotFound,
+		},
+		{
+			name: "linux/arm/v5 requested, but not available",
+
+			indexPlatforms:     []platforms.Platform{linuxArm64, linuxArmv7, linuxArmv5},
+			availablePlatforms: []platforms.Platform{linuxArm64, linuxArmv7},
+			requestPlatform:    &linuxArmv5,
+			check:              candidateNotFound,
+		},
+		{
+			name: "linux/arm/v7 requested, but not available",
+
+			indexPlatforms:     []platforms.Platform{linuxArm64, linuxArmv7, linuxArmv5},
+			availablePlatforms: []platforms.Platform{linuxArm64, linuxArmv5},
+			requestPlatform:    &linuxArmv7,
+			check:              candidateNotFound,
+		},
+		{
+			name: "linux/arm/v7 requested on v7 daemon, but not available",
+
+			indexPlatforms:     []platforms.Platform{linuxArm64, linuxArmv7, linuxArmv5},
+			availablePlatforms: []platforms.Platform{linuxArm64, linuxArmv5},
+			daemonPlatform:     &linuxArmv7,
+			requestPlatform:    &linuxArmv7,
+			check:              candidateNotFound,
+		},
+		{
+			name: "linux/arm/v7 requested on v5 daemon, all available",
+
+			indexPlatforms:     []platforms.Platform{linuxArm64, linuxArmv7, linuxArmv5},
+			availablePlatforms: []platforms.Platform{linuxArm64, linuxArmv7, linuxArmv5},
+			daemonPlatform:     &linuxArmv5,
+			requestPlatform:    &linuxArmv7,
+			check:              singleManifestSelected(linuxArmv7),
+		},
+		{
+			name: "linux/arm/v5 requested on v7 daemon, all available",
+
+			indexPlatforms:     []platforms.Platform{linuxArm64, linuxArmv7, linuxArmv5},
+			availablePlatforms: []platforms.Platform{linuxArm64, linuxArmv7, linuxArmv5},
+			daemonPlatform:     &linuxArmv7,
+			requestPlatform:    &linuxArmv5,
+			check:              singleManifestSelected(linuxArmv5),
+		},
+		{
+			name: "none requested on v5 daemon, arm64 not available",
+
+			indexPlatforms:     []platforms.Platform{linuxArm64, linuxArmv7, linuxArmv5},
+			availablePlatforms: []platforms.Platform{linuxArmv7, linuxArmv5},
+			daemonPlatform:     &linuxArmv5,
+			requestPlatform:    nil,
+			check:              singleManifestSelected(linuxArmv5),
+		},
+		{
+			name: "none requested on v7 daemon, arm64 not available",
+
+			indexPlatforms:     []platforms.Platform{linuxArm64, linuxArmv7, linuxArmv5},
+			availablePlatforms: []platforms.Platform{linuxArmv7, linuxArmv5},
+			daemonPlatform:     &linuxArmv7,
+			requestPlatform:    nil,
+			check:              singleManifestSelected(linuxArmv7),
+		},
+		{
+			name: "none requested on v7 daemon, v7 not available",
+
+			indexPlatforms:     []platforms.Platform{linuxArm64, linuxArmv7, linuxArmv5},
+			availablePlatforms: []platforms.Platform{linuxArm64, linuxArmv5},
+			daemonPlatform:     &linuxArmv7,
+			requestPlatform:    nil,
+			check:              singleManifestSelected(linuxArmv5), // Should it fail, because v5 can't be pushed?
+		},
+
+		{
+			name: "none requested on v7 daemon, v5 in index but not v7, all present",
+
+			indexPlatforms:     []platforms.Platform{linuxArm64, linuxArmv5},
+			availablePlatforms: []platforms.Platform{linuxArm64, linuxArmv5},
+			daemonPlatform:     &linuxArmv7,
+			requestPlatform:    nil,
+			check:              wholeIndexSelected,
+		},
+		{
+			name: "none requested on v7 daemon, v5 in index but not v7, v5 present",
+
+			indexPlatforms:     []platforms.Platform{linuxArm64, linuxArmv5},
+			availablePlatforms: []platforms.Platform{linuxArmv5},
+			daemonPlatform:     &linuxArmv7,
+			requestPlatform:    nil,
+			check:              singleManifestSelected(linuxArmv5),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			imgSvc := fakeImageService(t, ctx, store)
+			// Mock the daemon platform.
+			if tc.daemonPlatform != nil {
+				imgSvc.defaultPlatformOverride = platforms.Only(*tc.daemonPlatform)
+			} else {
+				imgSvc.defaultPlatformOverride = platforms.Only(defaultDaemonPlatform)
+			}
+
+			idx, err := specialimage.MultiPlatform(csDir, "multiplatform:latest", tc.indexPlatforms)
+			assert.NilError(t, err)
+
+			imgs := imagesFromIndex(idx)
+			assert.Assert(t, is.Len(imgs, 1))
+
+			img := imgs[0]
+			_, err = imgSvc.images.Create(ctx, img)
+			assert.NilError(t, err)
+
+			for _, platform := range tc.indexPlatforms {
+				if slices.ContainsFunc(tc.availablePlatforms, platforms.OnlyStrict(platform).Match) {
+					continue
+				}
+				assert.NilError(t, deletePlatform(ctx, imgSvc, img, platform))
+			}
+
+			desc, err := imgSvc.getPushDescriptor(ctx, img, tc.requestPlatform)
+
+			tc.check(t, img, desc, err)
+		})
+	}
+}
+
+func deletePlatform(ctx context.Context, imgSvc *ImageService, img containerdimages.Image, platform platforms.Platform) error {
+	var blobs []ocispec.Descriptor
+	pm := platforms.OnlyStrict(platform)
+	err := imgSvc.walkImageManifests(ctx, img, func(im *ImageManifest) error {
+		imPlatform, err := im.ImagePlatform(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to determine platform of image manifest %v: %w", im.Target(), err)
+		}
+
+		if !pm.Match(imPlatform) {
+			return nil
+		}
+
+		return imgSvc.walkPresentChildren(ctx, im.Target(), func(ctx context.Context, d ocispec.Descriptor) error {
+			blobs = append(blobs, d)
+			return nil
+		})
+	})
+	if err != nil {
+		return fmt.Errorf("failed to walk image manifests: %w", err)
+	}
+
+	for _, d := range blobs {
+		err := imgSvc.content.Delete(ctx, d.Digest)
+		if err != nil {
+			return fmt.Errorf("failed to delete blob %v: %w", d.Digest, err)
+		}
+	}
+
+	return nil
+}
+
+// wholeIndexSelected asserts that the push descriptor candidate is for the whole index.
+func wholeIndexSelected(t *testing.T, img containerdimages.Image, pushDescriptor ocispec.Descriptor, err error) {
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(pushDescriptor.Digest, img.Target.Digest))
+}
+
+// singleManifestSelected asserts that the push descriptor candidate is for a single platform-specific manifest.
+func singleManifestSelected(platform ocispec.Platform) func(t *testing.T, img containerdimages.Image, pushDescriptor ocispec.Descriptor, err error) {
+	pm := platforms.OnlyStrict(platform)
+	return func(t *testing.T, img containerdimages.Image, pushDescriptor ocispec.Descriptor, err error) {
+		assert.NilError(t, err)
+		assert.Assert(t, is.Equal(pushDescriptor.MediaType, ocispec.MediaTypeImageManifest), "the push descriptor isn't for a manifest")
+		assert.Assert(t, pushDescriptor.Platform != nil, "the push descriptor doesn't have a platform")
+		assert.Assert(t, pm.Match(*pushDescriptor.Platform), "the push descriptor isn't for the selected platform")
+	}
+}
+
+// candidateNotFound asserts that the no matching candidate was found.
+func candidateNotFound(t *testing.T, _ containerdimages.Image, desc ocispec.Descriptor, err error) {
+	assert.Check(t, errdefs.IsNotFound(err), "expected NotFound error, got %v, candidate: %v", err, desc.Platform)
+}
+
+// multipleCandidates asserts that multiple matching candidates were found and no decision could be made.
+func multipleCandidates(t *testing.T, _ containerdimages.Image, desc ocispec.Descriptor, err error) {
+	assert.Check(t, errdefs.IsConflict(err), "expected Conflict error, got %v, candidate: %v", err, desc.Platform)
+}

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/containerd/snapshots"
@@ -39,6 +40,9 @@ type ImageService struct {
 	pruneRunning        atomic.Bool
 	refCountMounter     snapshotter.Mounter
 	idMapping           idtools.IdentityMapping
+
+	// defaultPlatformOverride is used in tests to override the host platform.
+	defaultPlatformOverride platforms.MatchComparer
 }
 
 type registryResolver interface {

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -28,7 +28,7 @@ type ImageService interface {
 	// Images
 
 	PullImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
-	PushImage(ctx context.Context, ref reference.Named, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
+	PushImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
 	CreateImage(ctx context.Context, config []byte, parent string, contentStoreDigest digest.Digest) (builder.Image, error)
 	ImageDelete(ctx context.Context, imageRef string, force, prune bool) ([]imagetype.DeleteResponse, error)
 	ExportImage(ctx context.Context, names []string, outStream io.Writer) error

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -26,8 +26,10 @@ keywords: "API, Docker, rcli, REST, documentation"
   `net.ipv4.config.IFNAME.log_martians=1`. In API versions up-to 1.46, top level
   `--sysctl` settings for `eth0` will be migrated to `DriverOpts` when possible. 
   This automatic migration will be removed for API versions 1.47 and greater.
-
 * `GET /containers/json` now returns the annotations of containers.
+* `POST /images/{name}/push` now supports a `platform` parameter (JSON encoded
+  OCI Platform type) that allows selecting a specific platform manifest from
+  the multi-platform image.
 
 ## v1.45 API changes
 

--- a/internal/testutils/specialimage/multiplatform.go
+++ b/internal/testutils/specialimage/multiplatform.go
@@ -1,0 +1,32 @@
+package specialimage
+
+import (
+	"github.com/containerd/containerd/platforms"
+	"github.com/distribution/reference"
+	"github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func MultiPlatform(dir string, imageRef string, imagePlatforms []platforms.Platform) (*ocispec.Index, error) {
+	ref, err := reference.ParseNormalizedNamed(imageRef)
+	if err != nil {
+		return nil, err
+	}
+
+	var descs []ocispec.Descriptor
+
+	for _, platform := range imagePlatforms {
+		ps := platforms.Format(platform)
+		manifestDesc, err := oneLayerPlatformManifest(dir, platform, FileInLayer{Path: "bash", Content: []byte("layer-" + ps)})
+		if err != nil {
+			return nil, err
+		}
+		descs = append(descs, manifestDesc)
+	}
+
+	return multiPlatformImage(dir, ref, ocispec.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: descs,
+	})
+}

--- a/vendor.mod
+++ b/vendor.mod
@@ -99,6 +99,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.21.0
 	go.opentelemetry.io/otel/sdk v1.21.0
 	go.opentelemetry.io/otel/trace v1.21.0
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/mod v0.17.0
 	golang.org/x/net v0.23.0
 	golang.org/x/sync v0.5.0
@@ -216,7 +217,6 @@ require (
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.21.0 // indirect
-	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/oauth2 v0.11.0 // indirect
 	golang.org/x/tools v0.16.0 // indirect
 	google.golang.org/api v0.128.0 // indirect


### PR DESCRIPTION
- addresses https://github.com/docker/cli/issues/4959
- related: https://github.com/docker/cli/pull/4984

Add OCI platform fields as a parameters to the `POST /images/{id}/push` that allow to specify a single-platform manifest to be pushed instead of the whole image index.

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
- containerd image store: `POST /images/{name}/push` now supports a `platform` parameters (JSON encoded OCI Platform type) that allows selecting a specific platform-manifest from the multi-platform image. 
```

**- A picture of a cute animal (not mandatory but encouraged)**

