### PR TITLE
ci/validate-pr: Use `::error::` command to print errors

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Missing `area/` label
         if: contains(join(github.event.pull_request.labels.*.name, ','), 'impact/') && !contains(join(github.event.pull_request.labels.*.name, ','), 'area/')
         run: |
-          echo "Every PR with an \`impact/*\` label should also have an \`area/*\` label"
+          echo "::error::Every PR with an 'impact/*' label should also have an 'area/*' label"
           exit 1
       - name: OK
         run: exit 0
@@ -32,13 +32,13 @@ jobs:
           desc=$(echo "$block" |  awk NF)
 
           if [ -z "$desc" ]; then
-            echo "Changelog section is empty. Please provide a description for the changelog."
+            echo "::error::Changelog section is empty. Please provide a description for the changelog."
             exit 1
           fi
 
           len=$(echo -n "$desc" | wc -c)
           if [[ $len -le 6 ]]; then
-            echo "Description looks too short: $desc"
+            echo "::error::Description looks too short: $desc"
             exit 1
           fi
 


### PR DESCRIPTION
This will make Github render the log line as an error.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**

