### PR TITLE
ci: dump context when job ends

### DIFF
--- a/.github/actions/dump-context/action.yml
+++ b/.github/actions/dump-context/action.yml
@@ -1,0 +1,76 @@
+# https://help.github.com/en/articles/metadata-syntax-for-github-actions
+name: 'Dump context'
+description: 'GitHub Action composite to dump context'
+
+runs:
+  using: "composite"
+  steps:
+    -
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+
+          await core.group(`Env vars`, async () => {
+            const envs = Object.keys(process.env).sort().reduce(
+              (obj, key) => {
+                obj[key] = process.env[key];
+                return obj;
+              }, {}
+            );
+            core.info(JSON.stringify(Object.fromEntries(Object.entries(envs).filter(([key]) => !key.startsWith('GHACTION_DCTX_') && !key.startsWith('INPUT_'))), null, 2));
+          });
+
+          await core.group(`GitHub context`, async () => {
+            core.info(JSON.stringify(JSON.parse(`${process.env.GHACTION_DCTX_GITHUB_CONTEXT}`), null, 2));
+          });
+          await core.group(`Job context`, async () => {
+            core.info(JSON.stringify(JSON.parse(`${process.env.GHACTION_DCTX_JOB_CONTEXT}`), null, 2));
+          });
+          await core.group(`Steps context`, async () => {
+            core.info(JSON.stringify(JSON.parse(`${process.env.GHACTION_DCTX_STEPS_CONTEXT}`), null, 2));
+          });
+          await core.group(`Runner context`, async () => {
+            core.info(JSON.stringify(JSON.parse(`${process.env.GHACTION_DCTX_RUNNER_CONTEXT}`), null, 2));
+          });
+          await core.group(`Strategy context`, async () => {
+            core.info(JSON.stringify(JSON.parse(`${process.env.GHACTION_DCTX_STRATEGY_CONTEXT}`), null, 2));
+          });
+          await core.group(`Matrix context`, async () => {
+            core.info(JSON.stringify(JSON.parse(`${process.env.GHACTION_DCTX_MATRIX_CONTEXT}`), null, 2));
+          });
+
+          if (`${process.env.RUNNER_OS}` == 'Linux') {
+            await core.group(`Print cpuinfo`, async () => {
+              await exec.exec('cat /proc/cpuinfo');
+            });
+            await core.group(`Print cpuid`, async () => {
+              const cpuid = await exec.getExecOutput('which cpuid', [], {silent: true, ignoreReturnCode: true})
+              if (cpuid.stdout != "") {
+                await exec.exec('cpuid');
+              } else {
+                core.info('cpuid not found')
+              }
+            });
+            await core.group(`File system`, async () => {
+              await exec.exec('df -ah');
+            });
+            await core.group(`Mounts`, async () => {
+              await exec.exec('mount');
+            });
+            await core.group(`Docker daemon conf`, async () => {
+              if ((fs.statSync('/etc/docker', {throwIfNoEntry: false}) != undefined) &&
+                  (fs.statSync('/etc/docker/daemon.json', {throwIfNoEntry: false}) != undefined)) {
+                core.info(JSON.stringify(JSON.parse(fs.readFileSync('/etc/docker/daemon.json', {encoding: 'utf-8'}).trim()), null, 2));
+              } else {
+                core.info('/etc/docker/daemon.json not present')
+              }
+            });
+          }
+      env:
+        GHACTION_DCTX_GITHUB_CONTEXT: ${{ toJson(github) }}
+        GHACTION_DCTX_JOB_CONTEXT: ${{ toJson(job) }}
+        GHACTION_DCTX_STEPS_CONTEXT: ${{ toJson(steps) }}
+        GHACTION_DCTX_RUNNER_CONTEXT: ${{ toJson(runner) }}
+        GHACTION_DCTX_STRATEGY_CONTEXT: ${{ toJson(strategy) }}
+        GHACTION_DCTX_MATRIX_CONTEXT: ${{ toJson(matrix) }}

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -35,6 +35,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
       -
         name: Build dev image
         uses: docker/bake-action@v4
@@ -121,6 +123,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
       -
         name: Build dev image
         uses: docker/bake-action@v4
@@ -175,6 +179,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
       -
         name: Build dev image
         uses: docker/bake-action@v4
@@ -229,6 +235,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
       -
         name: Build dev image
         uses: docker/bake-action@v4
@@ -374,6 +382,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
       -
         name: Build dev image
         uses: docker/bake-action@v4

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -71,6 +71,10 @@ jobs:
           name: test-reports-unit-${{ inputs.storage }}
           path: /tmp/reports/*
           retention-days: 1
+      -
+        name: Dump context
+        if: always()
+        uses: ./.github/actions/dump-context
 
   unit-report:
     runs-on: ubuntu-20.04
@@ -152,6 +156,10 @@ jobs:
           name: test-reports-docker-py-${{ inputs.storage }}
           path: /tmp/reports/*
           retention-days: 1
+      -
+        name: Dump context
+        if: always()
+        uses: ./.github/actions/dump-context
 
   integration-flaky:
     runs-on: ubuntu-20.04
@@ -274,6 +282,10 @@ jobs:
           name: test-reports-integration-${{ inputs.storage }}-${{ env.TESTREPORTS_NAME }}
           path: /tmp/reports/*
           retention-days: 1
+      -
+        name: Dump context
+        if: always()
+        uses: ./.github/actions/dump-context
 
   integration-report:
     runs-on: ubuntu-20.04
@@ -414,6 +426,10 @@ jobs:
           name: test-reports-integration-cli-${{ inputs.storage }}-${{ env.TESTREPORTS_NAME }}
           path: /tmp/reports/*
           retention-days: 1
+      -
+        name: Dump context
+        if: always()
+        uses: ./.github/actions/dump-context
 
   integration-cli-report:
     runs-on: ubuntu-20.04

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -109,6 +109,10 @@ jobs:
           path: ${{ env.BIN_OUT }}/*
           if-no-files-found: error
           retention-days: 2
+      -
+        name: Dump context
+        if: always()
+        uses: ./.github/actions/dump-context
 
   unit-test:
     runs-on: ${{ inputs.os }}
@@ -191,6 +195,10 @@ jobs:
           name: ${{ inputs.os }}-${{ inputs.storage }}-unit-reports
           path: ${{ env.GOPATH }}\src\github.com\docker\docker\bundles\*
           retention-days: 1
+      -
+        name: Dump context
+        if: always()
+        uses: ./.github/actions/dump-context
 
   unit-test-report:
     runs-on: ubuntu-latest
@@ -510,6 +518,10 @@ jobs:
           name: ${{ inputs.os }}-${{ inputs.storage }}-integration-reports-${{ matrix.runtime }}-${{ env.TESTREPORTS_NAME }}
           path: ${{ env.GOPATH }}\src\github.com\docker\docker\bundles\*
           retention-days: 1
+      -
+        name: Dump context
+        if: always()
+        uses: ./.github/actions/dump-context
 
   integration-test-report:
     runs-on: ubuntu-latest

--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -78,6 +78,10 @@ jobs:
         id: platforms
         run: |
           echo "matrix=$(docker buildx bake bin-image-cross --print | jq -cr '.target."bin-image-cross".platforms')" >>${GITHUB_OUTPUT}
+      -
+        name: Dump context
+        if: always()
+        uses: ./.github/actions/dump-context
 
   build:
     runs-on: ubuntu-20.04
@@ -148,6 +152,10 @@ jobs:
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
+      -
+        name: Dump context
+        if: always()
+        uses: ./.github/actions/dump-context
 
   merge:
     runs-on: ubuntu-20.04
@@ -189,3 +197,7 @@ jobs:
         run: |
           set -x
           docker buildx imagetools inspect ${{ env.MOBYBIN_REPO_SLUG }}:$(jq -cr '.target."docker-metadata-action".args.DOCKER_META_VERSION' /tmp/bake-meta.json)
+      -
+        name: Dump context
+        if: always()
+        uses: ./.github/actions/dump-context

--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -116,6 +116,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
       -
         name: Login to Docker Hub
         if: github.event_name != 'pull_request' && github.repository == 'moby/moby'
@@ -179,6 +181,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
       -
         name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -31,6 +31,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
       -
         name: Build
         uses: docker/bake-action@v4
@@ -105,6 +107,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
       -
         name: Download binary artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -137,3 +137,7 @@ jobs:
           TESTPKGS: "./${{ matrix.pkg }}"
           TESTFLAGS: "-v --parallel=1 --timeout=30m --run=//worker=${{ matrix.worker }}$"
         working-directory: buildkit
+      -
+        name: Dump context
+        if: always()
+        uses: ./.github/actions/dump-context

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
       -
         name: Build
         uses: docker/bake-action@v4
@@ -100,6 +102,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
       -
         name: Build
         uses: docker/bake-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
         name: Check artifacts
         run: |
           find ${{ env.DESTDIR }} -type f -exec file -e ascii -- {} +
+      -
+        name: Dump context
+        if: always()
+        uses: ./.github/actions/dump-context
 
   prepare-cross:
     runs-on: ubuntu-latest
@@ -111,3 +115,7 @@ jobs:
         name: Check artifacts
         run: |
           find ${{ env.DESTDIR }} -type f -exec file -e ascii -- {} +
+      -
+        name: Dump context
+        if: always()
+        uses: ./.github/actions/dump-context

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,10 @@ jobs:
             *.cache-from=type=gha,scope=dev${{ matrix.mode }}
             *.cache-to=type=gha,scope=dev${{ matrix.mode }},mode=max
             *.output=type=cacheonly
+      -
+        name: Dump context
+        if: always()
+        uses: ./.github/actions/dump-context
 
   test:
     needs:
@@ -123,6 +127,10 @@ jobs:
         name: Validate
         run: |
           make -o build validate-${{ matrix.script }}
+      -
+        name: Dump context
+        if: always()
+        uses: ./.github/actions/dump-context
 
   smoke-prepare:
     runs-on: ubuntu-20.04
@@ -175,3 +183,7 @@ jobs:
           targets: binary-smoketest
           set: |
             *.platform=${{ matrix.platform }}
+      -
+        name: Dump context
+        if: always()
+        uses: ./.github/actions/dump-context

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
       -
         name: Build dev image
         uses: docker/bake-action@v4
@@ -116,6 +118,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
       -
         name: Build dev image
         uses: docker/bake-action@v4
@@ -176,6 +180,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
       -
         name: Test
         uses: docker/bake-action@v4


### PR DESCRIPTION
**- What I did**

related to recent issues on ci when building: https://github.com/moby/moby/actions/runs/8571772790/job/23492886675?pr=47683#step:6:193

```
#5 docker-image://docker.io/docker/dockerfile:1.7@sha256:dbbd5e059e8a07ff7ea6233b213b36aa516b4c53c645f1817a4dd18b83cbea56
#5 resolve docker.io/docker/dockerfile:1.7@sha256:dbbd5e059e8a07ff7ea6233b213b36aa516b4c53c645f1817a4dd18b83cbea56 done
#5 sha256:ccef65a67ab38a038c615e74c797b11a43d36505710abe93c87b021401bebd81 11.98MB / 11.98MB 0.1s done
#5 extracting sha256:ccef65a67ab38a038c615e74c797b11a43d36505710abe93c87b021401bebd81 0.1s done
#5 DONE 0.2s
Dockerfile:1
--------------------
   1 | >>> # syntax=docker/dockerfile:1.7
   2 |     
   3 |     ARG GO_VERSION=1.21.9
--------------------
ERROR: failed to solve: fork/exec /usr/bin/buildkit-runc: exec format error
```

**- How I did it**

Adds `Dump context` step across our workflows to help debugging this issue. Also enable debug for builder.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

