### PR TITLE
Per-interface sysctls

### DIFF
--- a/api/server/router/container/container_routes_test.go
+++ b/api/server/router/container/container_routes_test.go
@@ -1,10 +1,12 @@
 package container
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/libnetwork/netlabel"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -224,6 +226,124 @@ func TestEpConfigForNetMode(t *testing.T) {
 				assert.Assert(t, err)
 				assert.Check(t, is.Equal(ep.EndpointID, tc.expEpId))
 				assert.Check(t, is.Len(netConfig.EndpointsConfig, tc.expNumEps))
+			}
+		})
+	}
+}
+
+func TestHandleSysctlBC(t *testing.T) {
+	testcases := []struct {
+		name               string
+		apiVersion         string
+		networkMode        string
+		sysctls            map[string]string
+		epConfig           map[string]*network.EndpointSettings
+		expEpSysctls       []string
+		expSysctls         map[string]string
+		expWarningContains []string
+		expError           string
+	}{
+		{
+			name:        "migrate to new ep",
+			apiVersion:  "1.46",
+			networkMode: "mynet",
+			sysctls: map[string]string{
+				"net.ipv6.conf.all.disable_ipv6": "0",
+				"net.ipv6.conf.eth0.accept_ra":   "2",
+				"net.ipv6.conf.eth0.forwarding":  "1",
+			},
+			expSysctls: map[string]string{
+				"net.ipv6.conf.all.disable_ipv6": "0",
+			},
+			expEpSysctls: []string{"net.ipv6.conf.IFNAME.forwarding=1", "net.ipv6.conf.IFNAME.accept_ra=2"},
+			expWarningContains: []string{
+				"Migrated",
+				"net.ipv6.conf.eth0.accept_ra", "net.ipv6.conf.IFNAME.accept_ra=2",
+				"net.ipv6.conf.eth0.forwarding", "net.ipv6.conf.IFNAME.forwarding=1",
+			},
+		},
+		{
+			name:        "migrate nothing",
+			apiVersion:  "1.46",
+			networkMode: "mynet",
+			sysctls: map[string]string{
+				"net.ipv6.conf.all.disable_ipv6": "0",
+			},
+			expSysctls: map[string]string{
+				"net.ipv6.conf.all.disable_ipv6": "0",
+			},
+		},
+		{
+			name:        "migration disabled for newer api",
+			apiVersion:  "1.47",
+			networkMode: "mynet",
+			sysctls: map[string]string{
+				"net.ipv6.conf.eth0.accept_ra": "2",
+			},
+			expError: "must be supplied using driver option 'com.docker.network.endpoint.sysctls'",
+		},
+		{
+			name:        "only migrate eth0",
+			apiVersion:  "1.46",
+			networkMode: "mynet",
+			sysctls: map[string]string{
+				"net.ipv6.conf.eth1.accept_ra": "2",
+			},
+			expError: "unable to determine network endpoint",
+		},
+		{
+			name:        "net name mismatch",
+			apiVersion:  "1.46",
+			networkMode: "mynet",
+			epConfig: map[string]*network.EndpointSettings{
+				"shortid": {EndpointID: "epone"},
+			},
+			sysctls: map[string]string{
+				"net.ipv6.conf.eth1.accept_ra": "2",
+			},
+			expError: "unable to find a network for sysctl",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			hostCfg := &container.HostConfig{
+				NetworkMode: container.NetworkMode(tc.networkMode),
+				Sysctls:     map[string]string{},
+			}
+			for k, v := range tc.sysctls {
+				hostCfg.Sysctls[k] = v
+			}
+			netCfg := &network.NetworkingConfig{
+				EndpointsConfig: tc.epConfig,
+			}
+
+			warnings, err := handleSysctlBC(hostCfg, netCfg, tc.apiVersion)
+
+			for _, s := range tc.expWarningContains {
+				assert.Check(t, is.Contains(warnings, s))
+			}
+
+			if tc.expError != "" {
+				assert.Check(t, is.ErrorContains(err, tc.expError))
+			} else {
+				assert.Check(t, err)
+
+				assert.Check(t, is.DeepEqual(hostCfg.Sysctls, tc.expSysctls))
+
+				ep := netCfg.EndpointsConfig[tc.networkMode]
+				if ep == nil {
+					assert.Check(t, is.Nil(tc.expEpSysctls))
+				} else {
+					got, ok := ep.DriverOpts[netlabel.EndpointSysctls]
+					assert.Check(t, ok)
+					// Check for expected ep-sysctls.
+					for _, want := range tc.expEpSysctls {
+						assert.Check(t, is.Contains(got, want))
+					}
+					// Check for unexpected ep-sysctls.
+					assert.Check(t, is.Len(got, len(strings.Join(tc.expEpSysctls, ","))))
+				}
 			}
 		})
 	}

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2495,6 +2495,17 @@ definitions:
         example:
           - "server_x"
           - "server_y"
+      DriverOpts:
+        description: |
+          DriverOpts is a mapping of driver options and values. These options
+          are passed directly to the driver and are driver specific.
+        type: "object"
+        x-nullable: true
+        additionalProperties:
+          type: "string"
+        example:
+          com.example.some-label: "some-value"
+          com.example.some-other-label: "some-other-value"
 
       # Operational data
       NetworkID:
@@ -2538,17 +2549,6 @@ definitions:
         type: "integer"
         format: "int64"
         example: 64
-      DriverOpts:
-        description: |
-          DriverOpts is a mapping of driver options and values. These options
-          are passed directly to the driver and are driver specific.
-        type: "object"
-        x-nullable: true
-        additionalProperties:
-          type: "string"
-        example:
-          com.example.some-label: "some-value"
-          com.example.some-other-label: "some-other-value"
       DNSNames:
         description: |
           List of all DNS names an endpoint has on a specific network. This

--- a/api/types/network/endpoint.go
+++ b/api/types/network/endpoint.go
@@ -18,6 +18,7 @@ type EndpointSettings struct {
 	// Once the container is running, it becomes operational data (it may contain a
 	// generated address).
 	MacAddress string
+	DriverOpts map[string]string
 	// Operational data
 	NetworkID           string
 	EndpointID          string
@@ -27,7 +28,6 @@ type EndpointSettings struct {
 	IPv6Gateway         string
 	GlobalIPv6Address   string
 	GlobalIPv6PrefixLen int
-	DriverOpts          map[string]string
 	// DNSNames holds all the (non fully qualified) DNS names associated to this endpoint. First entry is used to
 	// generate PTR records.
 	DNSNames []string

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -15,6 +15,18 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 ## v1.46 API changes
 
+[Docker Engine API v1.46](https://docs.docker.com/engine/api/v1.46/) documentation
+
+* `POST /containers/create` field `NetworkingConfig.EndpointsConfig.DriverOpts`,
+  and `POST /networks/{id}/connect` field `EndpointsConfig.DriverOpts`, now
+  support label `com.docker.network.endpoint.sysctls` for setting per-interface
+  sysctls. The value is a comma separated list of sysctl assignments, the
+  interface name must be "IFNAME". For example, to set
+  `net.ipv4.config.eth0.log_martians=1`, use
+  `net.ipv4.config.IFNAME.log_martians=1`. In API versions up-to 1.46, top level
+  `--sysctl` settings for `eth0` will be migrated to `DriverOpts` when possible. 
+  This automatic migration will be removed for API versions 1.47 and greater.
+
 ## v1.45 API changes
 
 [Docker Engine API v1.45](https://docs.docker.com/engine/api/v1.45/) documentation

--- a/integration/networking/bridge_test.go
+++ b/integration/networking/bridge_test.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
+	apinetwork "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/integration/internal/network"
+	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -826,5 +828,40 @@ func TestReadOnlySlashProc(t *testing.T) {
 			)
 			defer c.ContainerRemove(ctx, id6, containertypes.RemoveOptions{Force: true})
 		})
+	}
+}
+
+// Test that it's possible to set a sysctl on an interface in the container
+// using DriverOpts.
+func TestSetEndpointSysctl(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "no sysctl on Windows")
+
+	ctx := setupTest(t)
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t)
+	defer d.Stop(t)
+
+	c := d.NewClientT(t)
+	defer c.Close()
+
+	const scName = "net.ipv4.conf.eth0.forwarding"
+	for _, ifname := range []string{"IFNAME", "ifname"} {
+		for _, val := range []string{"0", "1"} {
+			t.Run("ifname="+ifname+"/val="+val, func(t *testing.T) {
+				ctx := testutil.StartSpan(ctx, t)
+				runRes := container.RunAttach(ctx, t, c,
+					container.WithCmd("sysctl", "-qn", scName),
+					container.WithEndpointSettings(apinetwork.NetworkBridge, &apinetwork.EndpointSettings{
+						DriverOpts: map[string]string{
+							netlabel.EndpointSysctls: "net.ipv4.conf." + ifname + ".forwarding=" + val,
+						},
+					}),
+				)
+				defer c.ContainerRemove(ctx, runRes.ContainerID, containertypes.RemoveOptions{Force: true})
+
+				stdout := runRes.Stdout.String()
+				assert.Check(t, is.Equal(strings.TrimSpace(stdout), val))
+			})
+		}
 	}
 }

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 
 	"github.com/containerd/log"
@@ -399,6 +400,18 @@ func (ep *Endpoint) Value() []byte {
 		return nil
 	}
 	return b
+}
+
+func (ep *Endpoint) getSysctls() []string {
+	ep.mu.Lock()
+	defer ep.mu.Unlock()
+
+	if s, ok := ep.generic[netlabel.EndpointSysctls]; ok {
+		if ss, ok := s.(string); ok {
+			return strings.Split(ss, ",")
+		}
+	}
+	return nil
 }
 
 func (ep *Endpoint) SetValue(value []byte) error {

--- a/libnetwork/netlabel/labels.go
+++ b/libnetwork/netlabel/labels.go
@@ -26,6 +26,10 @@ const (
 	// DNSServers A list of DNS servers associated with the endpoint
 	DNSServers = Prefix + ".endpoint.dnsservers"
 
+	// EndpointSysctls is a comma separated list interface-specific sysctls
+	// where the interface name is represented by the string "IFNAME".
+	EndpointSysctls = Prefix + ".endpoint.sysctls"
+
 	// EnableIPv6 constant represents enabling IPV6 at network level
 	EnableIPv6 = Prefix + ".enable_ipv6"
 

--- a/libnetwork/osl/options_linux.go
+++ b/libnetwork/osl/options_linux.go
@@ -81,3 +81,11 @@ func WithRoutes(routes []*net.IPNet) IfaceOption {
 		return nil
 	}
 }
+
+// WithSysctls sets the interface sysctls.
+func WithSysctls(sysctls []string) IfaceOption {
+	return func(i *Interface) error {
+		i.sysctls = sysctls
+		return nil
+	}
+}

--- a/libnetwork/sandbox_linux.go
+++ b/libnetwork/sandbox_linux.go
@@ -315,6 +315,9 @@ func (sb *Sandbox) populateNetworkResources(ep *Endpoint) error {
 		if i.mac != nil {
 			ifaceOptions = append(ifaceOptions, osl.WithMACAddress(i.mac))
 		}
+		if sysctls := ep.getSysctls(); len(sysctls) > 0 {
+			ifaceOptions = append(ifaceOptions, osl.WithSysctls(sysctls))
+		}
 
 		if err := sb.osSbox.AddInterface(i.srcName, i.dstPrefix, ifaceOptions...); err != nil {
 			return fmt.Errorf("failed to add interface %s to sandbox: %v", i.srcName, err)


### PR DESCRIPTION
**- What I did**

- Closes https://github.com/moby/moby/issues/47639

Until now it's been possible to set per-interface sysctls using, for example, `--sysctl net.ipv6.conf.eth0.accept_ra=2`. But, the index in the interface name is allocated serially, and the numbering in a container with more than one interface may change when a container is restarted.  The change to make it possible to connect a container to more than one network when it's created increased the ambiguity.

This change adds label `com.docker.network.endpoint.sysctls` to the DriverOpts in EndpointSettings. This option is explicitly associated with the interface.

Settings in `--sysctl` for `eth0` are migrated to `EndpointSettings.DriverOpts`.

Because using `--sysctl` with any interface apart from `eth0` would have unpredictable results, it is now an error to use any other interface name in the top level `--sysctl` option. The error message includes a hint at how to use the new per-interface setting.

The per-endpoint sysctl name has the interface name replaced by the string `IFNAME`, for example:
    `net.ipv6.conf.eth0.accept_ra=2`
becomes:
    `net.ipv6.conf.IFNAME.accept_ra=2`

(The string `ifname` is also accepted because, for some reason, the CLI converts names to lower-case.)

The value of `DriverOpts["com.docker.network.endpoint.sysctls"]` is a comma separated list of these sysctls.

Settings from `--sysctl` are applied by the runtime lib during task creation. So, task creation fails if the endpoint does not exist.  Applying per-endpoint settings during interface configuration means the endpoint can be created later, which paves the way for removal of the SetKey OCI prestart hook.

Unlike other DriverOpts, the sysctl label itself is not driver-specific, but each driver has a chance to check settings/values and raise an error if a setting would cause it a problem - no such checks have been added in this initial version. As a future extension, if required, it would be possible for the driver to echo back valid/extended/modified settings to libnetwork for it to apply to the interface. (At that point, the syntax for the options could become driver specific to allow, for example, a driver to create more than one interface.)

**- How I did it**

- migrate per-endpoint sysctls from the top-level into per-interface DriverOpts
- pass those per-interface sysctls to the osl.Network, along with other config values for the interface
- apply those sysctls during interface configuration (which currently still happens during the SetKey prestart callback, but needn't)

**- How to verify it**

New unit and integration tests.

And ...

Migration of one or two top level `--sysctl` settings ...
```
# docker run --rm -ti --name c1 --network mynet --sysctl=net.ipv6.conf.eth0.accept_ra=2 alpine
WARNING: Migrated sysctl "net.ipv6.conf.eth0.accept_ra" to DriverOpts{"com.docker.network.endpoint.sysctls":"net.ipv6.conf.IFNAME.accept_ra=2"}.
/ #

# docker run --rm -ti --name c1 --network mynet --sysctl=net.ipv6.conf.eth0.accept_ra=2 --sysctl=net.ipv6.conf.eth0.forwarding=1 alpine
WARNING: Migrated sysctl "net.ipv6.conf.eth0.accept_ra,net.ipv6.conf.eth0.forwarding" to DriverOpts{"com.docker.network.endpoint.sysctls":"net.ipv6.conf.IFNAME.accept_ra=2,net.ipv6.conf.IFNAME.forwarding=1"}.
/ #
```

Inspect output ...
```
# docker run --rm -ti --name c1 --network mynet --sysctl=net.ipv6.conf.eth0.accept_ra=2 --sysctl=net.ipv6.conf.eth0.forwarding=1 --sysctl=net.ipv6.conf.default.disable_ipv6=0 alpine
...

# docker inspect c1
[
    {
        ...
        "HostConfig": {
            ...
            "Sysctls": {
                "net.ipv6.conf.default.disable_ipv6": "0"
            },
        ...
        "NetworkSettings": {
             ...
            "Networks": {
                "mynet": {
                ...
                    "DriverOpts": {
                        "com.docker.network.endpoint.sysctls": "net.ipv6.conf.IFNAME.accept_ra=2,net.ipv6.conf.IFNAME.forwarding=1"
                    },
                ...
]
```

No migration for `eth1` ...
```
# docker run --rm -ti --name c1 --network mynet --sysctl=net.ipv6.conf.eth1.accept_ra=2 alpine
docker: Error response from daemon: unable to determine network endpoint for sysctl net.ipv6.conf.eth1.accept_ra, use driver option 'com.docker.network.endpoint.sysctls' to set per-interface sysctls.
See 'docker run --help'.
```

Attempt to set a per-interface sysctl for an unknown protocol ...
```
# docker run --rm -ti --name c1 --network mynet --sysctl=net.blah.conf.eth0.input=1 alpine
docker: Error response from daemon: invalid config for network mynet: invalid endpoint settings:
unrecognised network interface sysctl 'net.blah.conf.IFNAME.input=1'; represent 'net.X.Y.ethN.Z=V' as 'net.X.Y.IFNAME.Z=V', 'X' must be 'ipv4', 'ipv6' or 'mpls'.
See 'docker run --help'.
```

Nonexistent `sysctl` (very verbose error message at the moment) ...
```
# docker run --rm -ti --name c1 --network mynet --sysctl=net.ipv6.conf.eth0.foo=1 alpine
WARNING: Migrated sysctl "net.ipv6.conf.eth0.foo" to DriverOpts{"com.docker.network.endpoint.sysctls":"net.ipv6.conf.IFNAME.foo=1"}.
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error running hook #0: error running hook: exit status 1, stdout: , stderr: failed to add interface veth93624eb to sandbox: /proc/sys/net/ipv6/conf/eth0/foo is not a sysctl file: unknown.
```

But, a lot of that waffle will go-away once the prestart hook is removed and settings are applied after task creation. It'll be more like ...
```
# docker run --rm -ti --name c1 --network mynet --sysctl=net.ipv6.conf.eth0.foo=1 alpine
WARNING: Migrated net.ipv6.conf.eth0.foo to DriverOpts{"com.docker.network.endpoint.sysctls":"ipv6.conf.foo=1"}.
docker: Error response from daemon: unable to write to '/proc/sys/net/ipv6/conf/eth0/foo': /proc/sys/net/ipv6/conf/eth0/foo is not a sysctl file: unknown.
```

**- Description for the changelog**
```markdown changelog
Allow sysctls to be set per-interface during container creation and network connection.
```

