### PR TITLE
[25.0] save: Remove platform from config descriptor

### DIFF
--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -223,8 +223,6 @@ func (s *saveSession) save(outStream io.Writer) error {
 			})
 		}
 
-		imgPlat := imageDescr.image.Platform()
-
 		m := ocispec.Manifest{
 			Versioned: specs.Versioned{
 				SchemaVersion: 2,
@@ -234,7 +232,6 @@ func (s *saveSession) save(outStream io.Writer) error {
 				MediaType: ocispec.MediaTypeImageConfig,
 				Digest:    digest.Digest(imageDescr.image.ID()),
 				Size:      int64(len(imageDescr.image.RawJSON())),
-				Platform:  &imgPlat,
 			},
 			Layers: foreign,
 		}


### PR DESCRIPTION
Cherry-pick of #47661

---

This was brought up by bmitch that its not expected to have a platform object in the config descriptor.
Also checked with tianon who agreed, its not _wrong_ but is unexpected and doesn't necessarily make sense to have it there.

Also, while technically incorrect, ECR is throwing an error when it sees this.


```markdown changelog
- remove erroneous `platform` from image `config` OCI descriptor in `docker save` output
```


(cherry picked from commit 9160b9fda6a75ee68e9e208b32fd7e4fd843a260)

