### PR TITLE
[23.0 backport] Fix cases where we are wrapping a nil error

### DIFF
--- a/daemon/logger/local/read.go
+++ b/daemon/logger/local/read.go
@@ -66,7 +66,7 @@ func getTailReader(ctx context.Context, r loggerutils.SizeReaderAt, req int) (io
 		}
 
 		if msgLen != binary.BigEndian.Uint32(buf) {
-			return nil, 0, errdefs.DataLoss(errors.Wrap(err, "log message header and footer indicate different message sizes"))
+			return nil, 0, errdefs.DataLoss(errors.New("log message header and footer indicate different message sizes"))
 		}
 
 		found++


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/47658

This was using `errors.Wrap` when there was no error to wrap, meanwhile we are supposed to be creating a new error.

Found this while investigating some log corruption issues and unexpectedly getting a nil reader and a nil error from `getTailReader`.