### PR TITLE
Fix `superfluous response.WriteHeader call`

### DIFF
--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"runtime"
 	"time"
 
@@ -46,6 +47,12 @@ func (daemon *Daemon) ContainerStats(ctx context.Context, prefixOrName string, c
 
 	outStream := config.OutStream
 	if config.Stream {
+		// Used before the Flush(), so we don't set the header twice because of the otel wrapper
+		// see here: https://github.com/moby/moby/issues/47448
+		if rw, ok := outStream.(http.ResponseWriter); ok {
+			rw.WriteHeader(http.StatusOK)
+		}
+
 		wf := ioutils.NewWriteFlusher(outStream)
 		defer wf.Close()
 		wf.Flush()


### PR DESCRIPTION
- Fixes #47448
- replaces https://github.com/moby/moby/pull/47796

**- What I did**
Edited the endpoints for container stats and logs to avoid  `superfluous response.WriteHeader call` being logged by the stdlib because we call `WriteHeader()` too many times.  

**- How I did it**
Writing the response headers manually for streaming response writers instead of calling `Flush()`.  

OTEL instrumentation doesn't seem to wrap the `Flush()` func of `http.ResponseWriter`, so if we call `Flush()` on `ioutils.WriteFlusher` we directly hit the underlying stdlib implementation of `Write()`/`WriteHeader()` instead of the OTEL wrapped one.  
If we then call `Write()` on the OTEL wrapper, after manually calling `Flush()` from `ioutils`, the wrapper will not know that headers have been written already and will therefore call the stdlib `WriteHeaders()` again, causing the warning log

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fixes the `superfluous response.WriteHeader call` warning log when executing `docker logs ...` or `docker compose stats`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

