### PR TITLE
builder: Fix `WORKDIR` with a trailing slash causing a cache miss

### DIFF
--- a/builder/dockerfile/dispatchers_unix.go
+++ b/builder/dockerfile/dispatchers_unix.go
@@ -22,7 +22,7 @@ func normalizeWorkdir(_ string, current string, requested string) (string, error
 	if !filepath.IsAbs(requested) {
 		return filepath.Join(string(os.PathSeparator), current, requested), nil
 	}
-	return requested, nil
+	return filepath.Clean(requested), nil
 }
 
 // resolveCmdLine takes a command line arg set and optionally prepends a platform-specific

--- a/container/container.go
+++ b/container/container.go
@@ -299,8 +299,8 @@ func (container *Container) SetupWorkingDirectory(rootIdentity idtools.Identity)
 		return nil
 	}
 
-	container.Config.WorkingDir = filepath.Clean(container.Config.WorkingDir)
-	pth, err := container.GetResourcePath(container.Config.WorkingDir)
+	workdir := filepath.Clean(container.Config.WorkingDir)
+	pth, err := container.GetResourcePath(workdir)
 	if err != nil {
 		return err
 	}

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -364,6 +364,6 @@ func translateWorkingDir(config *containertypes.Config) error {
 	if !system.IsAbs(wd) {
 		return fmt.Errorf("the working directory '%s' is invalid, it needs to be an absolute path", config.WorkingDir)
 	}
-	config.WorkingDir = wd
+	config.WorkingDir = filepath.Clean(wd)
 	return nil
 }

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4296,7 +4296,7 @@ func (s *DockerCLIBuildSuite) TestBuildBuildTimeArgExpansion(c *testing.T) {
 	imgName := "bldvarstest"
 
 	wdVar := "WDIR"
-	wdVal := "/tmp/"
+	wdVal := "/tmp"
 	addVar := "AFILE"
 	addVal := "addFile"
 	copyVar := "CFILE"


### PR DESCRIPTION
- closes: https://github.com/moby/moby/issues/47627

**- What I did**

**- How I did it**
Removed `SetupWorkingDirectory` side effect (mutating the container Config).

**- How to verify it**
`TestBuildWorkdirNoCacheMiss`

**- Description for the changelog**
```markdown changelog
classic builder: Fix cache miss on `WORKDIR <directory>/` build step (workdir with a trailing slash).
```

**- A picture of a cute animal (not mandatory but encouraged)**

