### PR TITLE
fix: avoid nil dereference on image history `Created` value

### DIFF
--- a/daemon/images/image_history.go
+++ b/daemon/images/image_history.go
@@ -43,9 +43,14 @@ func (i *ImageService) ImageHistory(ctx context.Context, name string) ([]*image.
 			layerCounter++
 		}
 
+		var created int64
+		if h.Created != nil {
+			created = h.Created.Unix()
+		}
+
 		history = append([]*image.HistoryResponseItem{{
 			ID:        "<missing>",
-			Created:   h.Created.Unix(),
+			Created:   created,
 			CreatedBy: h.CreatedBy,
 			Comment:   h.Comment,
 			Size:      layerSize,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix nil dereference of `Created` in image history.

closes https://github.com/moby/moby/issues/47729

**- How I did it**
checked for nil ;)

**- How to verify it**
repo from [this issue](https://github.com/moby/moby/issues/47729) no longer causes issues

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix a nil dereference when getting image history for images having layers without the `Created` value set
```

**- A picture of a cute animal (not mandatory but encouraged)**
![](https://media3.giphy.com/media/L1FJH5qxESFwpuTgIB/giphy.gif)

