### PR TITLE
Include more details in errNotManifestOrIndex

### DIFF
--- a/daemon/containerd/image_manifest.go
+++ b/daemon/containerd/image_manifest.go
@@ -45,7 +45,7 @@ func (i *ImageService) walkImageManifests(ctx context.Context, img containerdima
 		return i.walkPresentChildren(ctx, desc, handleManifest)
 	}
 
-	return errNotManifestOrIndex
+	return errors.Wrapf(errNotManifestOrIndex, "error walking manifest for %s", img.Name)
 }
 
 type ImageManifest struct {


### PR DESCRIPTION
This error is returned when attempting to walk a descriptor that *should* be an index or a manifest.
Without this the error is not very helpful sicne there's no way to tell what triggered it.


