### PR TITLE
Use saner default address pools

### DIFF
--- a/libnetwork/ipamutils/utils.go
+++ b/libnetwork/ipamutils/utils.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	// predefinedLocalScopeDefaultNetworks contains a list of 31 IPv4 private networks with host size 16 and 12
-	// (172.17-31.x.x/16, 192.168.x.x/20) which do not overlap with the networks in `PredefinedGlobalScopeDefaultNetworks`
+	// predefinedLocalScopeDefaultNetworks contains a list of 257 IPv4 private networks with host size 16 and 24
+	// (172.17.x.x/16, 172.18.x.x/24) which do not overlap with the networks in `PredefinedGlobalScopeDefaultNetworks`
 	predefinedLocalScopeDefaultNetworks []*net.IPNet
 	// predefinedGlobalScopeDefaultNetworks contains a list of 64K IPv4 private networks with host size 8
 	// (10.x.x.x/24) which do not overlap with the networks in `PredefinedLocalScopeDefaultNetworks`
@@ -17,12 +17,7 @@ var (
 	mutex                                sync.Mutex
 	localScopeDefaultNetworks            = []*NetworkToSplit{
 		{"172.17.0.0/16", 16},
-		{"172.18.0.0/16", 16},
-		{"172.19.0.0/16", 16},
-		{"172.20.0.0/14", 16},
-		{"172.24.0.0/14", 16},
-		{"172.28.0.0/14", 16},
-		{"192.168.0.0/16", 20},
+		{"172.18.0.0/16", 24},
 	}
 	globalScopeDefaultNetworks = []*NetworkToSplit{{"10.0.0.0/8", 24}}
 )

--- a/libnetwork/ipamutils/utils.go
+++ b/libnetwork/ipamutils/utils.go
@@ -16,8 +16,11 @@ var (
 	predefinedGlobalScopeDefaultNetworks []*net.IPNet
 	mutex                                sync.Mutex
 	localScopeDefaultNetworks            = []*NetworkToSplit{
-		{"172.17.0.0/16", 16},
-		{"172.18.0.0/16", 24},
+		{"172.17.0.0/16", 22},
+		{"172.18.0.0/15", 22},
+		{"172.20.0.0/14", 22},
+		{"172.24.0.0/13", 22},
+		{"192.168.0.0/16", 22},
 	}
 	globalScopeDefaultNetworks = []*NetworkToSplit{{"10.0.0.0/8", 24}}
 )

--- a/libnetwork/ipamutils/utils_test.go
+++ b/libnetwork/ipamutils/utils_test.go
@@ -9,14 +9,15 @@ import (
 )
 
 func initBroadPredefinedNetworks() []*net.IPNet {
-	pl := make([]*net.IPNet, 0, 257)
-	mask16 := []byte{255, 255, 0, 0}
-	for i := 17; i < 18; i++ {
-		pl = append(pl, &net.IPNet{IP: []byte{172, byte(i), 0, 0}, Mask: mask16})
+	pl := make([]*net.IPNet, 0, 1024)
+	mask22 := []byte{255, 255, 252, 0}
+	for i := 17; i < 32; i++ {
+		for j := 0; j < 256; j += 4 {
+			pl = append(pl, &net.IPNet{IP: []byte{172, byte(i), byte(j), 0}, Mask: mask22})
+		}
 	}
-	mask24 := []byte{255, 255, 255, 0}
-	for i := 0; i < 256; i++ {
-		pl = append(pl, &net.IPNet{IP: []byte{172, 18, byte(i), 0}, Mask: mask24})
+	for j := 0; j < 256; j += 4 {
+		pl = append(pl, &net.IPNet{IP: []byte{192, 168, byte(j), 0}, Mask: mask22})
 	}
 	return pl
 }

--- a/libnetwork/ipamutils/utils_test.go
+++ b/libnetwork/ipamutils/utils_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 func initBroadPredefinedNetworks() []*net.IPNet {
-	pl := make([]*net.IPNet, 0, 31)
-	mask := []byte{255, 255, 0, 0}
-	for i := 17; i < 32; i++ {
-		pl = append(pl, &net.IPNet{IP: []byte{172, byte(i), 0, 0}, Mask: mask})
+	pl := make([]*net.IPNet, 0, 257)
+	mask16 := []byte{255, 255, 0, 0}
+	for i := 17; i < 18; i++ {
+		pl = append(pl, &net.IPNet{IP: []byte{172, byte(i), 0, 0}, Mask: mask16})
 	}
-	mask20 := []byte{255, 255, 240, 0}
-	for i := 0; i < 16; i++ {
-		pl = append(pl, &net.IPNet{IP: []byte{192, 168, byte(i << 4), 0}, Mask: mask20})
+	mask24 := []byte{255, 255, 255, 0}
+	for i := 0; i < 256; i++ {
+		pl = append(pl, &net.IPNet{IP: []byte{172, 18, byte(i), 0}, Mask: mask24})
 	}
 	return pl
 }
@@ -51,7 +51,7 @@ func TestDefaultNetwork(t *testing.T) {
 	}
 
 	for _, nw := range GetLocalScopeDefaultNetworks() {
-		if ones, bits := nw.Mask.Size(); bits != 32 || (ones != 20 && ones != 16) {
+		if ones, bits := nw.Mask.Size(); bits != 32 || (ones != 24 && ones != 16) {
 			t.Fatalf("Unexpected size for network in broad list: %v", nw)
 		}
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

Replaced the default address pools with a saner set.

Previously the default pools covered literally the entire `172.16.0.0/12` range and the entire `192.168.0.0/16` range, creating subnets as large as /16 or /20 from these spaces. In reality, few use cases could use up even a tiny portion of such large address spaces. Not to mention that Linux bridge [has a 1024-port limit](https://forum.proxmox.com/threads/limitations-of-network-bridge.84974/), rendering any subnet larger than /22 impractical.

In actual cases, the previous default pools are more likely to cause trouble when users spin up multiple Docker Compose projects, as by default each Compose project creates (at least) one network from these pools, and the `172.16.0.0/12` range is quickly exhausted after just a few Compose projects. This is already sufficient to cause breakage if the ranges overlap with VPN or corporate network ([1](https://stackoverflow.com/q/55943660/5958455), [2](https://www.lullabot.com/articles/fixing-docker-and-vpn-ip-address-conflicts), ...).

This PR changes the default address pools to `172.18.0.0/16` split to /24, rendering 256 available networks for Compose projects (and others that let `docker network create` allocate subnets) while minimizing conflict with existing network facilities.

I understand that there's already `"default-address-pools"` in `daemon.json`, but why not provide a sane default value that works better for most people, instead of forcing every sysadmin to repeat the setting for every Docker daemon installation?

### How I did it

Replaced the default address pools with a saner set.

### How to verify it

Unit tests are also updated and they should pass.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Replaced the default address pools with a saner set.
```

### A picture of a cute animal (not mandatory but encouraged)

![image](https://github.com/moby/moby/assets/7273074/47552e12-b645-4df5-bc72-e0e030e7f7ca)


