### PR TITLE
Dockerfile: update docker CLI to v26.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG XX_VERSION=1.4.0
 ARG VPNKIT_VERSION=0.5.0
 
 ARG DOCKERCLI_REPOSITORY="https://github.com/docker/cli.git"
-ARG DOCKERCLI_VERSION=v26.0.0
+ARG DOCKERCLI_VERSION=v26.1.0
 # cli version used for integration-cli tests
 ARG DOCKERCLI_INTEGRATION_REPOSITORY="https://github.com/docker/cli.git"
 ARG DOCKERCLI_INTEGRATION_VERSION=v17.06.2-ce


### PR DESCRIPTION
Update the CLI that's used in the dev-container

- full diff: https://github.com/docker/cli/compare/v26.0.0...v26.1.0

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>