### PR TITLE
Add firewalld policy "docker-forwarding".

### DIFF
--- a/libnetwork/iptables/firewalld.go
+++ b/libnetwork/iptables/firewalld.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containerd/log"
 	dbus "github.com/godbus/dbus/v5"
+	"github.com/pkg/errors"
 )
 
 // IPV defines the table string
@@ -22,10 +23,11 @@ const (
 )
 
 const (
-	dbusInterface  = "org.fedoraproject.FirewallD1"
-	dbusPath       = "/org/fedoraproject/FirewallD1"
-	dbusConfigPath = "/org/fedoraproject/FirewallD1/config"
-	dockerZone     = "docker"
+	dbusInterface   = "org.fedoraproject.FirewallD1"
+	dbusPath        = "/org/fedoraproject/FirewallD1"
+	dbusConfigPath  = "/org/fedoraproject/FirewallD1/config"
+	dockerZone      = "docker"
+	dockerFwdPolicy = "docker-forwarding"
 )
 
 // Conn is a connection to firewalld dbus endpoint.
@@ -57,8 +59,20 @@ func firewalldInit() error {
 	}
 	if connection != nil {
 		go signalHandler()
-		if err := setupDockerZone(); err != nil {
+		zoneAdded, err := setupDockerZone()
+		if err != nil {
 			return err
+		}
+		policyAdded, policyAddErr := setupDockerForwardingPolicy()
+		if policyAddErr != nil {
+			// Log the error, but still reload firewalld if necessary.
+			log.G(context.TODO()).WithError(policyAddErr).Warnf("Firewalld: failed to add policy %s", dockerFwdPolicy)
+		}
+		if zoneAdded || policyAdded {
+			// Reload for changes to take effect.
+			if err := connection.sysObj.Call(dbusInterface+".reload", 0).Err; err != nil {
+				return err
+			}
 		}
 	}
 
@@ -186,10 +200,12 @@ type firewalldZone struct {
 	icmpBlockInversion bool
 }
 
-// settings returns the firewalldZone struct as an interface slice,
-// which can be passed to "org.fedoraproject.FirewallD1.config.addZone".
+// settings returns the firewalldZone struct as an interface slice, which can be
+// passed to "org.fedoraproject.FirewallD1.config.addZone". Note that 'addZone',
+// which is deprecated, requires this whole struct. Its replacement, 'addZone2'
+// (introduced in firewalld 0.9.0) accepts a dictionary where only non-default
+// values need to be specified.
 func (z firewalldZone) settings() []interface{} {
-	// TODO(thaJeztah): does D-Bus require optional fields to be passed as well?
 	return []interface{}{
 		z.version,
 		z.name,
@@ -211,16 +227,16 @@ func (z firewalldZone) settings() []interface{} {
 }
 
 // setupDockerZone creates a zone called docker in firewalld which includes docker interfaces to allow
-// container networking
-func setupDockerZone() error {
+// container networking. The bool return value is true if a firewalld reload is required.
+func setupDockerZone() (bool, error) {
 	var zones []string
 	// Check if zone exists
 	if err := connection.sysObj.Call(dbusInterface+".zone.getZones", 0).Store(&zones); err != nil {
-		return err
+		return false, err
 	}
 	if contains(zones, dockerZone) {
 		log.G(context.TODO()).Infof("Firewalld: %s zone already exists, returning", dockerZone)
-		return nil
+		return false, nil
 	}
 	log.G(context.TODO()).Debugf("Firewalld: creating %s zone", dockerZone)
 
@@ -232,14 +248,39 @@ func setupDockerZone() error {
 		target:      "ACCEPT",
 	}
 	if err := connection.sysConfObj.Call(dbusInterface+".config.addZone", 0, dockerZone, dz.settings()).Err; err != nil {
-		return err
+		return false, err
 	}
-	// Reload for change to take effect
-	if err := connection.sysObj.Call(dbusInterface+".reload", 0).Err; err != nil {
-		return err
-	}
+	return true, nil
+}
 
-	return nil
+// setupDockerForwardingPolicy creates a policy to allow forwarding to anywhere to the docker
+// zone (where packets will be dealt with by docker's usual/non-firewalld configuration).
+// The bool return value is true if a firewalld reload is required.
+func setupDockerForwardingPolicy() (bool, error) {
+	// https://firewalld.org/documentation/man-pages/firewalld.dbus.html#FirewallD1.config
+	policy := map[string]interface{}{
+		"version":       "1.0",
+		"description":   "allow forwarding to the docker zone",
+		"ingress_zones": []string{"ANY"},
+		"egress_zones":  []string{dockerZone},
+		"target":        "ACCEPT",
+	}
+	if err := connection.sysConfObj.Call(dbusInterface+".config.addPolicy", 0, dockerFwdPolicy, policy).Err; err != nil {
+		var derr dbus.Error
+		if errors.As(err, &derr) {
+			if derr.Name == dbusInterface+".Exception" && strings.HasPrefix(err.Error(), "NAME_CONFLICT") {
+				log.G(context.TODO()).Debugf("Firewalld: %s policy already exists", dockerFwdPolicy)
+				return false, nil
+			}
+			if derr.Name == dbus.ErrMsgUnknownMethod.Name {
+				log.G(context.TODO()).Debugf("Firewalld: addPolicy %s: unknown method", dockerFwdPolicy)
+				return false, nil
+			}
+		}
+		return false, err
+	}
+	log.G(context.TODO()).Infof("Firewalld: created %s policy", dockerFwdPolicy)
+	return true, nil
 }
 
 // AddInterfaceFirewalld adds the interface to the trusted zone. It is a


### PR DESCRIPTION
**- What I did**

Allow forwarding from any firewalld zone to the 'docker' zone.

This makes it possible to use routable IPv6 addresses on a bridge network, with masquerading disabled, and have the host forward packets to it.

**- How I did it**

Use firewalld's `addPolicy` method ... ignore a NAME_CONFLICT error (policy already exists), and an unknown-method error (because `addPolicy` was added in firewalld 0.9.0, older versions don't need the policy). If something else goes wrong, log the error but still reload firewalld - there's no need to regress existing functionality by bailing out early. *Being cautious, because we don't have good test coverage for firewalld - errors are only logged anyway, normally at debug level.*

**- How to verify it**

Without this change...
```
# docker network create --ipv6 --subnet fd02::/64 -o com.docker.network.bridge.enable_ip_masquerade=false nnn6
# docker run --rm -ti --name c1 --network nnn6 -P nginx

(then, on another host)

# ip -6 route add fd02::/64 via fd48:70ba:de62:0:1d00:31c3:c27b:6d1b
# curl 'http://[fd02::2]'
curl: (7) Failed to connect to fd02::2 port 80: Permission denied
```

**_Using OpenSUSE (firewalld 2.1.1-1.4)_**

Policy created (but not the pre-existing zone) on first run with the change ...
```
INFO[2024-04-23T11:10:48.166745414+01:00] Firewalld: docker zone already exists, returning
INFO[2024-04-23T11:10:48.173292238+01:00] Firewalld: created docker-forwarding policy
```

The policy ends up here ...

```
# cat /etc/firewalld/policies/docker-forwarding.xml
<?xml version="1.0" encoding="utf-8"?>
<policy version="1.0" target="ACCEPT">
  <description>allow forwarding to the docker zone</description>
  <ingress-zone name="ANY"/>
  <egress-zone name="docker"/>
</policy>
```

Repeat the `curl` test ...
```
# curl 'http://[fd02::2]'
<!DOCTYPE html>
...
```

Daemon restart ...
```
INFO[2024-04-23T11:16:30.394677002+01:00] Firewalld: docker zone already exists, returning
DEBU[2024-04-23T11:16:30.397121661+01:00] Firewalld: docker-forwarding policy already exists
```

**_CentOS 7 (firewalld 0.6.3-11.el7) - `addPolicy` doesn't work, but it isn't needed ..._**
```
INFO[2024-04-22T11:26:23.952140185+01:00] Firewalld: docker zone already exists, returning
DEBU[2024-04-22T11:26:23.953287064+01:00] Firewalld: addPolicy docker-forwarding: UnknownMethod
```

**- Description for the changelog**
```markdown changelog
If firewalld is running on the host, create policy `docker-forwarding` to allow forwarding from
any zone to the `docker` zone. This makes it possible to configure a bridge network with a
routable IPv6 address, and no masquerading.
```