### PR TITLE
[25.0 backport] fix: avoid nil dereference on image history Created value

### DIFF
--- a/daemon/images/image_history.go
+++ b/daemon/images/image_history.go
@@ -42,9 +42,14 @@ func (i *ImageService) ImageHistory(ctx context.Context, name string) ([]*image.
 			layerCounter++
 		}
 
+		var created int64
+		if h.Created != nil {
+			created = h.Created.Unix()
+		}
+
 		history = append([]*image.HistoryResponseItem{{
 			ID:        "<missing>",
-			Created:   h.Created.Unix(),
+			Created:   created,
 			CreatedBy: h.CreatedBy,
 			Comment:   h.Comment,
 			Size:      layerSize,


### PR DESCRIPTION
**- What I did**
Backports #47734 to 25.0 branch

Issue was caused by the changes here https://github.com/moby/moby/pull/45504 First released in v25.0.0-beta.1

(cherry picked from commit ab570ab3d62038b3d26f96a9bb585d0b6095b9b4)

**- How I did it**
```
git cherry-pick -xsS ab570ab3d62038b3d26f96a9bb585d0b6095b9b4
```

**- How to verify it**
See #47734

**- Description for the changelog**
```markdown changelog
Fix a nil dereference when getting image history for images having layers without the `Created` value set
```

**- A picture of a cute animal (not mandatory but encouraged)**

