### PR TITLE
[26.1 backport] Option to avoid deleting the kernel_ll address from bridges.

### DIFF
--- a/libnetwork/drivers/bridge/setup_ipv6_linux.go
+++ b/libnetwork/drivers/bridge/setup_ipv6_linux.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 
 	"github.com/containerd/log"
@@ -12,6 +13,9 @@ import (
 
 // bridgeIPv6 is the default, link-local IPv6 address for the bridge (fe80::1/64)
 var bridgeIPv6 = &net.IPNet{IP: net.ParseIP("fe80::1"), Mask: net.CIDRMask(64, 128)}
+
+// Standard link local prefix
+var linkLocalPrefix = netip.MustParsePrefix("fe80::/64")
 
 const (
 	ipv6ForwardConfPerm    = 0o644


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/47771

**- What I did**

As discussed in [this Slack thread](https://dockercommunity.slack.com/archives/C24JNLCHJ/p1713356374646619), replacing the kernel-assigned link local address on bridges may be causing issues.

It'd be better not to replace it, and there shouldn't be any consequences but, to avoid the risk of a breaking change in a patch release - this PR introduces an environment variable that only modifies the current behaviour when set.

The kernel-ll address has been removed since https://github.com/moby/moby/pull/46850 - part of an attempt to prevent daemon startup failures following changes in `fixed-cidr-v6`. But, by treating the standard LL prefix as a special case, removal of the kernel-assigned LL address can be avoided.

This will make it possible to experiment and hopefully work around the problem. In 27.0 we should remove the env var and make the new behaviour the default, or revert this change. (I'll create an issue to track that if this change makes it in.)

**- How I did it**

If env var `DOCKER_BRIDGE_PRESERVE_KERNEL_LL=1`, don't assign `fe80::1/64` to a bridge, and don't delete any link local address with prefix `fe80::/64`.

**- How to verify it**

Modified regression test, just to make sure setting the new env var doesn't cause any startup problems for the default bridge, and that it still ends up with a link-local address.

Without the env var set, for a user-defined network ...

```
docker network create n6 --ipv6 --subnet fdaa::/64
docker run --rm --name c1 -dti --network n6 alpine

12: br-6ae7b0edf268: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default
    link/ether 02:42:07:85:54:ba brd ff:ff:ff:ff:ff:ff
    inet 172.19.0.1/16 brd 172.19.255.255 scope global br-6ae7b0edf268
       valid_lft forever preferred_lft forever
    inet6 fdaa::1/64 scope global tentative
       valid_lft forever preferred_lft forever
    inet6 fe80::42:7ff:fe85:54ba/64 scope link tentative
       valid_lft forever preferred_lft forever
    inet6 fe80::1/64 scope link tentative
       valid_lft forever preferred_lft forever

dockerd restart ...

12: br-6ae7b0edf268: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default
    link/ether 02:42:07:85:54:ba brd ff:ff:ff:ff:ff:ff
    inet 172.19.0.1/16 brd 172.19.255.255 scope global br-6ae7b0edf268
       valid_lft forever preferred_lft forever
    inet6 fdaa::1/64 scope global
       valid_lft forever preferred_lft forever
    inet6 fe80::1/64 scope link
       valid_lft forever preferred_lft forever
```

With the env var set ...

```
Initially, and after daemon restart ...

17: br-e476bcfaa2de: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default
    link/ether 02:42:c8:2b:c2:4a brd ff:ff:ff:ff:ff:ff
    inet 172.19.0.1/16 brd 172.19.255.255 scope global br-e476bcfaa2de
       valid_lft forever preferred_lft forever
    inet6 fdaa::1/64 scope global tentative
       valid_lft forever preferred_lft forever
    inet6 fe80::42:c8ff:fe2b:c24a/64 scope link tentative
       valid_lft forever preferred_lft forever
```


**- Description for the changelog**
```markdown changelog
Experimental environment variable `DOCKER_BRIDGE_PRESERVE_KERNEL_LL=1` will prevent the daemon from removing the kernel-assigned link local address on a Linux bridge.
```
