### PR TITLE
Disable bridge n/w masquerading for IPv4, IPv6, or both.

### DIFF
--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -61,7 +61,9 @@ type networkConfiguration struct {
 	ID                   string
 	BridgeName           string
 	EnableIPv6           bool
-	EnableIPMasquerade   bool
+	EnableIPMasquerade   bool // false => no v4 or v6 masquerading
+	EnableIP4Masquerade  bool
+	EnableIP6Masquerade  bool
 	EnableICC            bool
 	InhibitIPv4          bool
 	Mtu                  int
@@ -290,6 +292,14 @@ func (c *networkConfiguration) fromLabels(labels map[string]string) error {
 			if c.EnableIPMasquerade, err = strconv.ParseBool(value); err != nil {
 				return parseErr(label, value, err.Error())
 			}
+		case EnableIP4Masquerade:
+			if c.EnableIP4Masquerade, err = strconv.ParseBool(value); err != nil {
+				return parseErr(label, value, err.Error())
+			}
+		case EnableIP6Masquerade:
+			if c.EnableIP6Masquerade, err = strconv.ParseBool(value); err != nil {
+				return parseErr(label, value, err.Error())
+			}
 		case EnableICC:
 			if c.EnableICC, err = strconv.ParseBool(value); err != nil {
 				return parseErr(label, value, err.Error())
@@ -512,8 +522,10 @@ func parseNetworkGenericOptions(data interface{}) (*networkConfiguration, error)
 		config = opt
 	case map[string]string:
 		config = &networkConfiguration{
-			EnableICC:          true,
-			EnableIPMasquerade: true,
+			EnableICC:           true,
+			EnableIPMasquerade:  true,
+			EnableIP4Masquerade: true,
+			EnableIP6Masquerade: true,
 		}
 		err = config.fromLabels(opt)
 	case options.Generic:

--- a/libnetwork/drivers/bridge/bridge_store.go
+++ b/libnetwork/drivers/bridge/bridge_store.go
@@ -123,6 +123,8 @@ func (ncfg *networkConfiguration) MarshalJSON() ([]byte, error) {
 	nMap["BridgeName"] = ncfg.BridgeName
 	nMap["EnableIPv6"] = ncfg.EnableIPv6
 	nMap["EnableIPMasquerade"] = ncfg.EnableIPMasquerade
+	nMap["EnableIP4Masquerade"] = ncfg.EnableIP4Masquerade
+	nMap["EnableIP6Masquerade"] = ncfg.EnableIP6Masquerade
 	nMap["EnableICC"] = ncfg.EnableICC
 	nMap["InhibitIPv4"] = ncfg.InhibitIPv4
 	nMap["Mtu"] = ncfg.Mtu
@@ -190,6 +192,14 @@ func (ncfg *networkConfiguration) UnmarshalJSON(b []byte) error {
 	ncfg.BridgeName = nMap["BridgeName"].(string)
 	ncfg.EnableIPv6 = nMap["EnableIPv6"].(bool)
 	ncfg.EnableIPMasquerade = nMap["EnableIPMasquerade"].(bool)
+	ncfg.EnableIP4Masquerade = true
+	if v, ok := nMap["EnableIP4Masquerade"]; ok {
+		ncfg.EnableIP4Masquerade = v.(bool)
+	}
+	ncfg.EnableIP6Masquerade = true
+	if v, ok := nMap["EnableIP6Masquerade"]; ok {
+		ncfg.EnableIP6Masquerade = v.(bool)
+	}
 	ncfg.EnableICC = nMap["EnableICC"].(bool)
 	if v, ok := nMap["InhibitIPv4"]; ok {
 		ncfg.InhibitIPv4 = v.(bool)

--- a/libnetwork/drivers/bridge/labels.go
+++ b/libnetwork/drivers/bridge/labels.go
@@ -5,7 +5,9 @@ const (
 	BridgeName = "com.docker.network.bridge.name"
 
 	// EnableIPMasquerade label for bridge driver
-	EnableIPMasquerade = "com.docker.network.bridge.enable_ip_masquerade"
+	EnableIPMasquerade  = "com.docker.network.bridge.enable_ip_masquerade"
+	EnableIP4Masquerade = "com.docker.network.bridge.enable_ip4_masquerade"
+	EnableIP6Masquerade = "com.docker.network.bridge.enable_ip6_masquerade"
 
 	// EnableICC label
 	EnableICC = "com.docker.network.bridge.enable_icc"

--- a/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
@@ -1,6 +1,7 @@
 package bridge
 
 import (
+	"fmt"
 	"net"
 	"testing"
 
@@ -214,13 +215,15 @@ func TestOutgoingNATRules(t *testing.T) {
 	hostIPv4 := net.ParseIP("192.0.2.2")
 	hostIPv6 := net.ParseIP("2001:db8:1::1")
 	for _, tc := range []struct {
-		desc               string
-		enableIPTables     bool
-		enableIP6Tables    bool
-		enableIPv6         bool
-		enableIPMasquerade bool
-		hostIPv4           net.IP
-		hostIPv6           net.IP
+		desc                string
+		enableIPTables      bool
+		enableIP6Tables     bool
+		enableIPv6          bool
+		enableIPMasquerade  bool
+		enableIP4Masquerade bool
+		enableIP6Masquerade bool
+		hostIPv4            net.IP
+		hostIPv6            net.IP
 		// Hairpin NAT rules are not tested here because they are orthogonal to outgoing NAT.  They
 		// exist to support the port forwarding DNAT rules: without any port forwarding there would be
 		// no need for any hairpin NAT rules, and when there is port forwarding then hairpin NAT rules
@@ -235,16 +238,18 @@ func TestOutgoingNATRules(t *testing.T) {
 			desc: "everything disabled",
 		},
 		{
-			desc:               "iptables/ip6tables disabled",
-			enableIPv6:         true,
-			enableIPMasquerade: true,
+			desc:                "iptables/ip6tables disabled",
+			enableIPv6:          true,
+			enableIPMasquerade:  true,
+			enableIP4Masquerade: true,
 		},
 		{
-			desc:               "host IP with iptables/ip6tables disabled",
-			enableIPv6:         true,
-			enableIPMasquerade: true,
-			hostIPv4:           hostIPv4,
-			hostIPv6:           hostIPv6,
+			desc:                "host IP with iptables/ip6tables disabled",
+			enableIPv6:          true,
+			enableIPMasquerade:  true,
+			enableIP4Masquerade: true,
+			hostIPv4:            hostIPv4,
+			hostIPv6:            hostIPv6,
 		},
 		{
 			desc:            "masquerade disabled, no host IP",
@@ -261,57 +266,85 @@ func TestOutgoingNATRules(t *testing.T) {
 			hostIPv6:        hostIPv6,
 		},
 		{
-			desc:               "IPv4 masquerade, IPv6 disabled",
-			enableIPTables:     true,
-			enableIPMasquerade: true,
-			wantIPv4Masq:       true,
+			desc:                "IPv4 masquerade, IPv6 disabled",
+			enableIPTables:      true,
+			enableIPMasquerade:  true,
+			enableIP4Masquerade: true,
+			wantIPv4Masq:        true,
 		},
 		{
-			desc:               "IPv4 SNAT, IPv6 disabled",
-			enableIPTables:     true,
-			enableIPMasquerade: true,
-			hostIPv4:           hostIPv4,
-			wantIPv4Snat:       true,
+			desc:                "IPv4 SNAT, IPv6 disabled",
+			enableIPTables:      true,
+			enableIPMasquerade:  true,
+			enableIP4Masquerade: true,
+			hostIPv4:            hostIPv4,
+			wantIPv4Snat:        true,
 		},
 		{
-			desc:               "IPv4 masquerade, IPv6 masquerade",
-			enableIPTables:     true,
-			enableIP6Tables:    true,
-			enableIPv6:         true,
-			enableIPMasquerade: true,
-			wantIPv4Masq:       true,
-			wantIPv6Masq:       true,
+			desc:                "IPv4 masquerade, IPv6 masquerade",
+			enableIPTables:      true,
+			enableIP6Tables:     true,
+			enableIPv6:          true,
+			enableIPMasquerade:  true,
+			enableIP4Masquerade: true,
+			enableIP6Masquerade: true,
+			wantIPv4Masq:        true,
+			wantIPv6Masq:        true,
 		},
 		{
-			desc:               "IPv4 masquerade, IPv6 SNAT",
-			enableIPTables:     true,
-			enableIP6Tables:    true,
-			enableIPv6:         true,
-			enableIPMasquerade: true,
-			hostIPv6:           hostIPv6,
-			wantIPv4Masq:       true,
-			wantIPv6Snat:       true,
+			desc:                "IPv4 masquerade, IPv6 SNAT",
+			enableIPTables:      true,
+			enableIP6Tables:     true,
+			enableIPv6:          true,
+			enableIPMasquerade:  true,
+			enableIP4Masquerade: true,
+			enableIP6Masquerade: true,
+			hostIPv6:            hostIPv6,
+			wantIPv4Masq:        true,
+			wantIPv6Snat:        true,
 		},
 		{
-			desc:               "IPv4 SNAT, IPv6 masquerade",
-			enableIPTables:     true,
-			enableIP6Tables:    true,
-			enableIPv6:         true,
-			enableIPMasquerade: true,
-			hostIPv4:           hostIPv4,
-			wantIPv4Snat:       true,
-			wantIPv6Masq:       true,
+			desc:                "IPv4 SNAT, IPv6 masquerade",
+			enableIPTables:      true,
+			enableIP6Tables:     true,
+			enableIPv6:          true,
+			enableIPMasquerade:  true,
+			enableIP4Masquerade: true,
+			enableIP6Masquerade: true,
+			hostIPv4:            hostIPv4,
+			wantIPv4Snat:        true,
+			wantIPv6Masq:        true,
 		},
 		{
-			desc:               "IPv4 SNAT, IPv6 SNAT",
-			enableIPTables:     true,
-			enableIP6Tables:    true,
-			enableIPv6:         true,
-			enableIPMasquerade: true,
-			hostIPv4:           hostIPv4,
-			hostIPv6:           hostIPv6,
-			wantIPv4Snat:       true,
-			wantIPv6Snat:       true,
+			desc:                "IPv4 SNAT, IPv6 SNAT",
+			enableIPTables:      true,
+			enableIP6Tables:     true,
+			enableIPv6:          true,
+			enableIPMasquerade:  true,
+			enableIP4Masquerade: true,
+			enableIP6Masquerade: true,
+			hostIPv4:            hostIPv4,
+			hostIPv6:            hostIPv6,
+			wantIPv4Snat:        true,
+			wantIPv6Snat:        true,
+		},
+		{
+			desc:                "IPv4 masquerade, IPv6 none",
+			enableIPTables:      true,
+			enableIP6Tables:     true,
+			enableIPv6:          true,
+			enableIPMasquerade:  true,
+			enableIP4Masquerade: true,
+			wantIPv4Masq:        true,
+		},
+		{
+			desc:                "IPv4 none, IPv6 masquerade",
+			enableIPTables:      true,
+			enableIP6Tables:     true,
+			enableIPv6:          true,
+			enableIPMasquerade:  true,
+			enableIP6Masquerade: true,
+			wantIPv6Masq:        true,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -328,13 +361,15 @@ func TestOutgoingNATRules(t *testing.T) {
 				t.Fatal("testRegisterer.RegisterDriver never called")
 			}
 			nc := &networkConfiguration{
-				BridgeName:         br,
-				AddressIPv4:        brIPv4,
-				AddressIPv6:        brIPv6,
-				EnableIPv6:         tc.enableIPv6,
-				EnableIPMasquerade: tc.enableIPMasquerade,
-				HostIPv4:           tc.hostIPv4,
-				HostIPv6:           tc.hostIPv6,
+				BridgeName:          br,
+				AddressIPv4:         brIPv4,
+				AddressIPv6:         brIPv6,
+				EnableIPv6:          tc.enableIPv6,
+				EnableIPMasquerade:  tc.enableIPMasquerade,
+				EnableIP4Masquerade: tc.enableIP4Masquerade,
+				EnableIP6Masquerade: tc.enableIP6Masquerade,
+				HostIPv4:            tc.hostIPv4,
+				HostIPv6:            tc.hostIPv6,
 			}
 			ipv4Data := []driverapi.IPAMData{{Pool: maskedBrIPv4, Gateway: brIPv4}}
 			ipv6Data := []driverapi.IPAMData{{Pool: maskedBrIPv6, Gateway: brIPv6}}
@@ -372,7 +407,7 @@ func TestOutgoingNATRules(t *testing.T) {
 				{tc.wantIPv6Masq, iptRule{iptables.IPv6, iptables.Nat, "POSTROUTING", []string{"-s", maskedBrIPv6.String(), "!", "-o", br, "-j", "MASQUERADE"}}},
 				{tc.wantIPv6Snat, iptRule{iptables.IPv6, iptables.Nat, "POSTROUTING", []string{"-s", maskedBrIPv6.String(), "!", "-o", br, "-j", "SNAT", "--to-source", hostIPv6.String()}}},
 			} {
-				assert.Equal(t, rc.rule.Exists(), rc.want)
+				assert.Equal(t, rc.rule.Exists(), rc.want, fmt.Sprintf("Rule: %v", rc.rule))
 			}
 		})
 	}


### PR DESCRIPTION
**- What I did**

Make it possible to disable NAT/masquerading for IPv6 but not IPv4 in a bridge network.

**- How I did it**

New bridge options:

```
com.docker.network.bridge.enable_ip4_masquerade
com.docker.network.bridge.enable_ip6_masquerade
```

The option `com.docker.network.bridge.enable_ip_masquerade` still exists, if it's `false` masquerading is disabled for IPv4 and IPv6. If `true`, the individual options are used.

They're stored as three separate flags - the original option must be present in the store for a rollback, because the old code will panic if it's not present, and there's no no need to discard an existing setting.

**- How to verify it**

New integration test.

**- Description for the changelog**
```markdown changelog
Add bridge options to make it possible to disable NAT/masquerading for IPv4 and IPv6
separately:
- `com.docker.network.bridge.enable_ip4_masquerade`
- `com.docker.network.bridge.enable_ip6_masquerade`
Existing option `com.docker.network.bridge.enable_ip_masquerade=false` still disables
masquerading for both IPv4 and IPv6.
```

