### PR TITLE
Preserve kernel-assigned IPv6 link-local addresses on a bridge network's bridge

### DIFF
--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -1,10 +1,10 @@
 package bridge
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"os/exec"
 	"strconv"
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/driverapi"
+	"github.com/docker/docker/libnetwork/internal/netiputil"
 	"github.com/docker/docker/libnetwork/iptables"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/netutils"
@@ -188,9 +189,12 @@ func Register(r driverapi.Registerer, config map[string]interface{}) error {
 // added to the interface's Prefix List (RFC-5942), differing prefix lengths
 // would be confusing and have been disallowed by earlier implementations of
 // bridge address assignment.
-func validateIPv6Subnet(addr *net.IPNet) error {
-	if addr != nil && bridgeIPv6.Contains(addr.IP) && !bytes.Equal(bridgeIPv6.Mask, addr.Mask) {
-		return errdefs.InvalidParameter(errors.New("clash with the Link-Local prefix 'fe80::/64'"))
+func validateIPv6Subnet(addr netip.Prefix) error {
+	if !addr.Addr().Is6() || addr.Addr().Is4In6() {
+		return fmt.Errorf("'%s' is not a valid IPv6 subnet", addr)
+	}
+	if addr.Masked() != linkLocalPrefix && linkLocalPrefix.Overlaps(addr) {
+		return fmt.Errorf("'%s' clashes with the Link-Local prefix 'fe80::/64'", addr)
 	}
 	return nil
 }
@@ -201,14 +205,11 @@ func ValidateFixedCIDRV6(val string) error {
 	if val == "" {
 		return nil
 	}
-	ip, ipNet, err := net.ParseCIDR(val)
-	if err != nil {
-		return errdefs.InvalidParameter(err)
+	prefix, err := netip.ParsePrefix(val)
+	if err == nil {
+		err = validateIPv6Subnet(prefix)
 	}
-	if ip.To4() != nil {
-		return errdefs.InvalidParameter(errors.New("fixed-cidr-v6 is not an IPv6 subnet"))
-	}
-	return validateIPv6Subnet(ipNet)
+	return errdefs.InvalidParameter(errors.Wrap(err, "invalid fixed-cidr-v6"))
 }
 
 // Validate performs a static validation on the network configuration parameters.
@@ -234,8 +235,12 @@ func (c *networkConfiguration) Validate() error {
 			return errdefs.System(errors.New("no IPv6 address was allocated for the bridge"))
 		}
 		// AddressIPv6 must be IPv6, and not overlap with the LL subnet prefix.
-		if err := validateIPv6Subnet(c.AddressIPv6); err != nil {
-			return err
+		addr, ok := netiputil.ToPrefix(c.AddressIPv6)
+		if !ok {
+			return errdefs.InvalidParameter(fmt.Errorf("invalid IPv6 address '%s'", c.AddressIPv6))
+		}
+		if err := validateIPv6Subnet(addr); err != nil {
+			return errdefs.InvalidParameter(err)
 		}
 		// If a default gw is specified, it must belong to AddressIPv6's subnet
 		if c.DefaultGatewayIPv6 != nil && !c.AddressIPv6.Contains(c.DefaultGatewayIPv6) {

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -193,6 +193,9 @@ func validateIPv6Subnet(addr netip.Prefix) error {
 	if !addr.Addr().Is6() || addr.Addr().Is4In6() {
 		return fmt.Errorf("'%s' is not a valid IPv6 subnet", addr)
 	}
+	if addr.Addr().IsMulticast() {
+		return fmt.Errorf("multicast subnet '%s' is not allowed", addr)
+	}
 	if addr.Masked() != linkLocalPrefix && linkLocalPrefix.Overlaps(addr) {
 		return fmt.Errorf("'%s' clashes with the Link-Local prefix 'fe80::/64'", addr)
 	}

--- a/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -1046,6 +1046,11 @@ func TestValidateFixedCIDRV6(t *testing.T) {
 			input:       "nonsense",
 			expectedErr: "invalid fixed-cidr-v6: netip.ParsePrefix(\"nonsense\"): no '/'",
 		},
+		{
+			doc:         "multicast IPv6 subnet",
+			input:       "ff05::/64",
+			expectedErr: "invalid fixed-cidr-v6: multicast subnet 'ff05::/64' is not allowed",
+		},
 	}
 	for _, tc := range tests {
 		tc := tc

--- a/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -1012,39 +1012,39 @@ func TestValidateFixedCIDRV6(t *testing.T) {
 			// Overlapping with the standard LL prefix isn't allowed.
 			doc:         "overlapping link-local prefix fe80::/63",
 			input:       "fe80::/63",
-			expectedErr: "clash with the Link-Local prefix 'fe80::/64'",
+			expectedErr: "invalid fixed-cidr-v6: 'fe80::/63' clashes with the Link-Local prefix 'fe80::/64'",
 		},
 		{
 			// Overlapping with the standard LL prefix isn't allowed.
 			doc:         "overlapping link-local subnet fe80::/65",
 			input:       "fe80::/65",
-			expectedErr: "clash with the Link-Local prefix 'fe80::/64'",
+			expectedErr: "invalid fixed-cidr-v6: 'fe80::/65' clashes with the Link-Local prefix 'fe80::/64'",
 		},
 		{
 			// The address has to be valid IPv6 subnet.
 			doc:         "invalid IPv6 subnet",
 			input:       "2000:db8::",
-			expectedErr: "invalid CIDR address: 2000:db8::",
+			expectedErr: "invalid fixed-cidr-v6: netip.ParsePrefix(\"2000:db8::\"): no '/'",
 		},
 		{
 			doc:         "non-IPv6 subnet",
 			input:       "10.3.4.5/24",
-			expectedErr: "fixed-cidr-v6 is not an IPv6 subnet",
+			expectedErr: "invalid fixed-cidr-v6: '10.3.4.5/24' is not a valid IPv6 subnet",
 		},
 		{
 			doc:         "IPv4-mapped subnet 1",
 			input:       "::ffff:10.2.4.0/24",
-			expectedErr: "fixed-cidr-v6 is not an IPv6 subnet",
+			expectedErr: "invalid fixed-cidr-v6: '::ffff:10.2.4.0/24' is not a valid IPv6 subnet",
 		},
 		{
 			doc:         "IPv4-mapped subnet 2",
 			input:       "::ffff:a01:203/24",
-			expectedErr: "fixed-cidr-v6 is not an IPv6 subnet",
+			expectedErr: "invalid fixed-cidr-v6: '::ffff:10.1.2.3/24' is not a valid IPv6 subnet",
 		},
 		{
 			doc:         "invalid subnet",
 			input:       "nonsense",
-			expectedErr: "invalid CIDR address: nonsense",
+			expectedErr: "invalid fixed-cidr-v6: netip.ParsePrefix(\"nonsense\"): no '/'",
 		},
 	}
 	for _, tc := range tests {

--- a/libnetwork/drivers/bridge/interface_linux.go
+++ b/libnetwork/drivers/bridge/interface_linux.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
-	"os"
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/errdefs"
@@ -71,90 +70,66 @@ func (i *bridgeInterface) addresses(family int) ([]netlink.Addr, error) {
 	return addrs, nil
 }
 
-func getRequiredIPv6Addrs(config *networkConfiguration) (requiredAddrs map[netip.Addr]netip.Prefix, err error) {
-	requiredAddrs = make(map[netip.Addr]netip.Prefix)
-
-	if os.Getenv("DOCKER_BRIDGE_PRESERVE_KERNEL_LL") != "1" {
-		// Always give the bridge 'fe80::1' - every interface is required to have an
-		// address in 'fe80::/64'. Linux may assign an address, but we'll replace it with
-		// 'fe80::1'. Then, if the configured prefix is 'fe80::/64', the IPAM pool
-		// assigned address will not be a second address in the LL subnet.
-		ra, ok := netiputil.ToPrefix(bridgeIPv6)
-		if !ok {
-			err = fmt.Errorf("Failed to convert Link-Local IPv6 address to netip.Prefix")
-			return nil, err
-		}
-		requiredAddrs[ra.Addr()] = ra
-	}
-
-	ra, ok := netiputil.ToPrefix(config.AddressIPv6)
-	if !ok {
-		err = fmt.Errorf("failed to convert bridge IPv6 address '%s' to netip.Prefix", config.AddressIPv6.String())
-		return nil, err
-	}
-	requiredAddrs[ra.Addr()] = ra
-
-	return requiredAddrs, nil
-}
-
 func (i *bridgeInterface) programIPv6Addresses(config *networkConfiguration) error {
+	// Remember the configured addresses.
+	i.bridgeIPv6 = config.AddressIPv6
+	i.gatewayIPv6 = config.AddressIPv6.IP
+
+	addrPrefix, ok := netiputil.ToPrefix(config.AddressIPv6)
+	if !ok {
+		return errdefs.System(
+			fmt.Errorf("failed to convert bridge IPv6 address '%s' to netip.Prefix",
+				config.AddressIPv6.String()))
+	}
+
 	// Get the IPv6 addresses currently assigned to the bridge, if any.
 	existingAddrs, err := i.addresses(netlink.FAMILY_V6)
 	if err != nil {
 		return errdefs.System(err)
 	}
-
-	// Get the list of required IPv6 addresses for this bridge.
-	var requiredAddrs map[netip.Addr]netip.Prefix
-	requiredAddrs, err = getRequiredIPv6Addrs(config)
-	if err != nil {
-		return errdefs.System(err)
-	}
-	i.bridgeIPv6 = config.AddressIPv6
-	i.gatewayIPv6 = config.AddressIPv6.IP
-
 	// Remove addresses that aren't required.
 	for _, existingAddr := range existingAddrs {
 		ea, ok := netip.AddrFromSlice(existingAddr.IP)
 		if !ok {
-			return errdefs.System(fmt.Errorf("Failed to convert IPv6 address '%s' to netip.Addr", config.AddressIPv6))
+			return errdefs.System(
+				fmt.Errorf("Failed to convert IPv6 address '%s' to netip.Addr", config.AddressIPv6))
 		}
-		// Optionally, avoid deleting the kernel-assigned link local address.
-		// (Don't delete fe80::1 either - if it was previously assigned to the bridge, and the
-		// kernel_ll address was deleted, the bridge won't get a new kernel_ll address.)
-		if os.Getenv("DOCKER_BRIDGE_PRESERVE_KERNEL_LL") == "1" {
-			if p, _ := ea.Prefix(64); p == linkLocalPrefix {
-				continue
-			}
+		// Don't delete the kernel-assigned link local address (or fe80::1 - if it was
+		// assigned to the bridge by an older version of the daemon that deleted the
+		// kernel_ll address, the bridge won't get a new kernel_ll address.) But, do
+		// delete unexpected link-local addresses (fe80::/10) that aren't in fe80::/64,
+		// those have been IPAM-assigned.
+		if p, _ := ea.Prefix(64); p == linkLocalPrefix {
+			continue
 		}
 		// Ignore the prefix length when comparing addresses, it's informational
 		// (RFC-5942 section 4), and removing/re-adding an address that's still valid
 		// would disrupt traffic on live-restore.
-		if _, required := requiredAddrs[ea]; !required {
+		if ea != addrPrefix.Addr() {
 			err := i.nlh.AddrDel(i.Link, &existingAddr) //#nosec G601 -- Memory aliasing is not an issue in practice as the &existingAddr pointer is not retained by the callee after the AddrDel() call returns.
 			if err != nil {
-				log.G(context.TODO()).WithFields(log.Fields{"error": err, "address": existingAddr.IPNet}).Warnf("Failed to remove residual IPv6 address from bridge")
+				log.G(context.TODO()).WithFields(log.Fields{
+					"error":   err,
+					"address": existingAddr.IPNet},
+				).Warnf("Failed to remove residual IPv6 address from bridge")
 			}
 		}
 	}
-	// Add or update required addresses.
-	for _, addrPrefix := range requiredAddrs {
-		// Using AddrReplace(), rather than AddrAdd(). When the subnet is changed for an
-		// existing bridge in a way that doesn't affect the bridge's assigned address,
-		// the old address has not been removed at this point - because that would be
-		// service-affecting for a running container.
-		//
-		// But if, for example, 'fixed-cidr-v6' is changed from '2000:dbe::/64' to
-		// '2000:dbe::/80', the default bridge will still be assigned address
-		// '2000:dbe::1'. In the output of 'ip a', the prefix length is displayed - and
-		// the user is likely to expect to see it updated from '64' to '80'.
-		// Unfortunately, 'netlink.AddrReplace()' ('RTM_NEWADDR' with 'NLM_F_REPLACE')
-		// doesn't update the prefix length. This is a cosmetic problem, the prefix
-		// length of an assigned address is not used to determine whether an address is
-		// "on-link" (RFC-5942).
-		if err := i.nlh.AddrReplace(i.Link, &netlink.Addr{IPNet: netiputil.ToIPNet(addrPrefix)}); err != nil {
-			return errdefs.System(fmt.Errorf("failed to add IPv6 address %s to bridge: %v", i.bridgeIPv6, err))
-		}
+	// Using AddrReplace(), rather than AddrAdd(). When the subnet is changed for an
+	// existing bridge in a way that doesn't affect the bridge's assigned address,
+	// the old address has not been removed at this point - because that would be
+	// service-affecting for a running container.
+	//
+	// But if, for example, 'fixed-cidr-v6' is changed from '2000:dbe::/64' to
+	// '2000:dbe::/80', the default bridge will still be assigned address
+	// '2000:dbe::1'. In the output of 'ip a', the prefix length is displayed - and
+	// the user is likely to expect to see it updated from '64' to '80'.
+	// Unfortunately, 'netlink.AddrReplace()' ('RTM_NEWADDR' with 'NLM_F_REPLACE')
+	// doesn't update the prefix length. This is a cosmetic problem, the prefix
+	// length of an assigned address is not used to determine whether an address is
+	// "on-link" (RFC-5942).
+	if err := i.nlh.AddrReplace(i.Link, &netlink.Addr{IPNet: netiputil.ToIPNet(addrPrefix)}); err != nil {
+		return errdefs.System(fmt.Errorf("failed to add IPv6 address %s to bridge: %v", i.bridgeIPv6, err))
 	}
 	return nil
 }

--- a/libnetwork/drivers/bridge/interface_linux.go
+++ b/libnetwork/drivers/bridge/interface_linux.go
@@ -102,6 +102,10 @@ func (i *bridgeInterface) programIPv6Addresses(config *networkConfiguration) err
 		if p, _ := ea.Prefix(64); p == linkLocalPrefix {
 			continue
 		}
+		// Don't delete multicast addresses as they're never added by the daemon.
+		if ea.IsMulticast() {
+			continue
+		}
 		// Ignore the prefix length when comparing addresses, it's informational
 		// (RFC-5942 section 4), and removing/re-adding an address that's still valid
 		// would disrupt traffic on live-restore.

--- a/libnetwork/drivers/bridge/network_linux_test.go
+++ b/libnetwork/drivers/bridge/network_linux_test.go
@@ -90,7 +90,7 @@ func TestLinkCreate(t *testing.T) {
 
 	ip6 := te.iface.addrv6.IP
 	if !n.bridge.bridgeIPv6.Contains(ip6) {
-		t.Fatalf("IP %s is not a valid ip in the subnet %s", ip6.String(), bridgeIPv6.String())
+		t.Fatalf("IP %s is not a valid ip in the subnet %s", ip6.String(), n.bridge.bridgeIPv6.String())
 	}
 
 	if !te.gw.Equal(n.bridge.bridgeIPv4.IP) {

--- a/libnetwork/drivers/bridge/setup_ipv6_linux.go
+++ b/libnetwork/drivers/bridge/setup_ipv6_linux.go
@@ -3,16 +3,12 @@ package bridge
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/netip"
 	"os"
 
 	"github.com/containerd/log"
 	"github.com/vishvananda/netlink"
 )
-
-// bridgeIPv6 is the default, link-local IPv6 address for the bridge (fe80::1/64)
-var bridgeIPv6 = &net.IPNet{IP: net.ParseIP("fe80::1"), Mask: net.CIDRMask(64, 128)}
 
 // Standard link local prefix
 var linkLocalPrefix = netip.MustParsePrefix("fe80::/64")

--- a/libnetwork/drivers/bridge/setup_ipv6_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_ipv6_linux_test.go
@@ -43,14 +43,14 @@ func TestSetupIPv6(t *testing.T) {
 
 	var found bool
 	for _, addr := range addrsv6 {
-		if bridgeIPv6.String() == addr.IPNet.String() {
+		if config.AddressIPv6.String() == addr.IPNet.String() {
 			found = true
 			break
 		}
 	}
 
 	if !found {
-		t.Fatalf("Bridge device does not have requested IPv6 address %v", bridgeIPv6)
+		t.Fatalf("Bridge device does not have requested IPv6 address %v", config.AddressIPv6)
 	}
 }
 


### PR DESCRIPTION
**- What I did**

Before release 25.0.0, an IPv6-enabled bridge network's bridge was always assigned address `fe80::1` as well as an IPAM-assigned address from `fixed-cidr-v6` or the network's `--subnet/--ip-range`. It then deleted any other routable addresses. When the bridge came `up` because a container got linked to it, the kernel assigned a link-local address in `fe80::/64`.

In 25.0.0, https://github.com/moby/moby/pull/46850 tried to reconcile expected addresses on a bridge network's bridge with addresses with those on the bridge, before deciding which addresses to add/remove. That solved a problem where changes in `fixed-cidr-v6` prevented the daemon from starting, if the new and old subnets overlapped. But, it was more aggressive about removing addresses, and would remove the kernel-assigned link local address. In most circumstances, `fe80::1` seems to be used for NDP etc - but, it could cause problems as discussed in [this Slack thread](https://dockercommunity.slack.com/archives/C24JNLCHJ/p1713356374646619) (repro steps from that chat are copied into a comment below).

In 26.1.1, https://github.com/moby/moby/pull/47771 added env var `DOCKER_BRIDGE_PRESERVE_KERNEL_LL` which, if set to `1`, prevented the daemon from adding the `fe80::1` address and from deleting any address in `fe80::/64` - preserving the kernel-assigned link local address, and `fe80::1` (because if an earlier version of the daemon had replaced the kernel-ll address, the bridge wouldn't get a new one). That solved the problem discussed in the Slack thread.

This change updates the daemon to use the 26.1.1 env-var controlled behaviour in all cases ... it removes the env-var, never tries to assign `fe80::1`, and doesn't remove addresses in `fe80::/64`.

**Please note** that not-assigning `fe80::1` is new in this release (apart from the optional behaviour in 26.1.1). All previous releases would assign that address. I don't think there's any reason to add that extra LL address, the kernel will always set one up. Nothing set up by the daemon uses it, and it's not documented.

Closes https://github.com/moby/moby/issues/47778

In separate commits, this PR also:
- Improves error reporting for invalid subnets.
- Adds a check that `fixed-cidr-v6` / `--subnet` is not a multicast address.
- Prevents the daemon from removing multicast addresses from a bridge (because, if there's one there, it was added by the user so it's not the daemon's to delete).

**- How I did it**

Simplified the code a little, now `fe80::1` isn't added, there's only one IPv6 address to add to the bridge (the IPAM assigned address), so there was no longer any need for a map of wanted-addresses.

**- How to verify it**

Updated/added tests.

**- Description for the changelog**
```markdown changelog
For IPv6-enabled bridge networks, do not attempt to replace the bridge's kernel-assigned link local address with `fe80::1`.
```

