### PR TITLE
Fix/remove broken integration-cli IPv6 tests

### DIFF
--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -130,13 +130,15 @@ func (s *DockerSwarmSuite) TestSwarmInit(c *testing.T) {
 }
 
 func (s *DockerSwarmSuite) TestSwarmInitIPv6(c *testing.T) {
-	testRequires(c, IPv6)
 	ctx := testutil.GetContext(c)
 	d1 := s.AddDaemon(ctx, c, false, false)
-	cli.Docker(cli.Args("swarm", "init", "--listen-add", "::1"), cli.Daemon(d1)).Assert(c, icmd.Success)
+	cli.Docker(cli.Args("swarm", "init", "--listen-addr", "::1"),
+		cli.Daemon(d1)).Assert(c, icmd.Success)
 
+	token := s.daemons[0].JoinTokens(c).Worker
 	d2 := s.AddDaemon(ctx, c, false, false)
-	cli.Docker(cli.Args("swarm", "join", "::1"), cli.Daemon(d2)).Assert(c, icmd.Success)
+	cli.Docker(cli.Args("swarm", "join", "[::1]", "--token", token),
+		cli.Daemon(d2)).Assert(c, icmd.Success)
 
 	out := cli.Docker(cli.Args("info"), cli.Daemon(d2)).Assert(c, icmd.Success).Combined()
 	assert.Assert(c, strings.Contains(out, "Swarm: active"))

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -97,11 +97,6 @@ func containerdSnapshotterEnabled() bool {
 	return false
 }
 
-func IPv6() bool {
-	cmd := exec.Command("test", "-f", "/proc/net/if_inet6")
-	return cmd.Run() != nil
-}
-
 func UserNamespaceROMount() bool {
 	// quick case--userns not enabled in this test run
 	if os.Getenv("DOCKER_REMAP_ROOT") == "" {


### PR DESCRIPTION
**- What I did**

Found two `integration-cli` tests that didn't run, because the "requires IPv6" test they used was wrong (it'd only return true on a host with no IPv6), and sorted that out.

**- How I did it**

Fixed one test, deleted the other, deleted associated/broken helper functions - see the individual commit messages.

**- How to verify it**

It's tests.

**- Description for the changelog**
```markdown changelog

```