### PR TITLE
hack: explicitly control enabling the journald logging driver

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -83,7 +83,7 @@ if [ ! "$GOPATH" ]; then
 	exit 1
 fi
 
-if ${PKG_CONFIG} 'libsystemd' 2> /dev/null; then
+if [ -z "${EXCLUDE_AUTO_BUILDTAG_JOURNALD:-}" ] && ${PKG_CONFIG} 'libsystemd' 2> /dev/null; then
 	DOCKER_BUILDTAGS+=" journald"
 fi
 


### PR DESCRIPTION
Without this, the dependency on systemd is said to be "automagic", which can lead to breakage, for example, if a binary package of docker is built on a system that has systemd installed then installed on a system that does not have systemd installed.

for example: https://bugs.gentoo.org/914076

closes https://github.com/moby/moby/issues/47770

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

