### PR TITLE
Makefile: bundles is not PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,6 @@ dynbinary: bundles ## build dynamically linked linux binaries
 cross: bundles ## cross build the binaries
 	$(BAKE_CMD) binary-cross
 
-.PHONY: bundles
 bundles:
 	mkdir bundles
 


### PR DESCRIPTION
This was changed recently so that the bundles target is always run, but `mkdir bundles` fails when bundles exists...
