### PR TITLE
Fixes Incorrect documentation docker volume create - Issue #47606

### DIFF
--- a/api/types/container/hostconfig.go
+++ b/api/types/container/hostconfig.go
@@ -409,8 +409,6 @@ type UpdateConfig struct {
 	// Contains container's resources (cgroups, ulimits)
 	Resources
 	RestartPolicy RestartPolicy
-	// Added portbindings to the container
-	PortBindings nat.PortMap // Port mapping between the exposed port (container) and the host
 }
 
 // HostConfig the non-portable Config structure of a container.

--- a/api/types/container/hostconfig.go
+++ b/api/types/container/hostconfig.go
@@ -409,6 +409,8 @@ type UpdateConfig struct {
 	// Contains container's resources (cgroups, ulimits)
 	Resources
 	RestartPolicy RestartPolicy
+	// Added portbindings to the container
+	PortBindings nat.PortMap // Port mapping between the exposed port (container) and the host
 }
 
 // HostConfig the non-portable Config structure of a container.

--- a/volume/drivers/adapter.go
+++ b/volume/drivers/adapter.go
@@ -12,7 +12,6 @@ import (
 
 var errNoSuchVolume = errors.New("no such volume")
 
-
 type volumeDriverAdapter struct {
 	name         string
 	scopePath    func(s string) string

--- a/volume/drivers/adapter.go
+++ b/volume/drivers/adapter.go
@@ -25,8 +25,8 @@ func (a *volumeDriverAdapter) Name() string {
 
 func (a *volumeDriverAdapter) Create(name string, opts map[string]string) (volume.Volume, error) {
 	v, err := a.proxy.Get(name)
-	if err == nil {
-		return nil, errors.New("A volume named " + name + " already exists with the " + v.Driver.Name() + " driver. Choose a different volume name.")
+	if err == nil && v.DriverName() != a.Name() {
+		return nil, errors.New("A volume named " + name + " already exists with the " + v.DriverName() + " driver. Choose a different volume name.")
 	}
 
 	if err := a.proxy.Create(name, opts); err != nil {

--- a/volume/drivers/adapter.go
+++ b/volume/drivers/adapter.go
@@ -12,6 +12,7 @@ import (
 
 var errNoSuchVolume = errors.New("no such volume")
 
+
 type volumeDriverAdapter struct {
 	name         string
 	scopePath    func(s string) string
@@ -24,6 +25,11 @@ func (a *volumeDriverAdapter) Name() string {
 }
 
 func (a *volumeDriverAdapter) Create(name string, opts map[string]string) (volume.Volume, error) {
+	v, err := a.proxy.Get(name)
+	if err == nil {
+		return nil, errors.New("A volume named " + name + " already exists with the " + v.Driver.Name() + " driver. Choose a different volume name.")
+	}
+
 	if err := a.proxy.Create(name, opts); err != nil {
 		return nil, err
 	}

--- a/volume/service/service.go
+++ b/volume/service/service.go
@@ -76,7 +76,6 @@ func (s *VolumesService) Create(ctx context.Context, name, driverName string, op
 		options = append(options, opts.WithCreateLabel(AnonymousLabel, ""))
 	}
 
-
 	v, err := s.vs.Create(ctx, name, driverName, options...)
 	if err != nil {
 		return nil, err

--- a/volume/service/service.go
+++ b/volume/service/service.go
@@ -75,6 +75,8 @@ func (s *VolumesService) Create(ctx context.Context, name, driverName string, op
 		name = stringid.GenerateRandomID()
 		options = append(options, opts.WithCreateLabel(AnonymousLabel, ""))
 	}
+
+
 	v, err := s.vs.Create(ctx, name, driverName, options...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
fixes #47606
**- What I did**
I changed the adapter.go file to throw an error if a container with the name already exists

**- How I did it**
I get the volume based on the name, and if the volume is returned (i.e. err is null) it means that a volume of the given name exists. Since err is null, this means such a volume exists, which means an error and corresponding error message according to the docker documentation outlined in the issue is thrown.

**- How to verify it**

Run the docker volume create [NAME] and use the name of an already existing volume.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Anish Mankal <anish.mankal@gmail.com>

