### PR TITLE
Changed default value of the startInterval to 5s

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -33,6 +33,10 @@ const (
 	// the container unstable. Defaults to none.
 	defaultStartPeriod = 0 * time.Second
 
+	// defaultStartInterval is the default interval between health checks during
+	// the start period.
+	defaultStartInterval = 5 * time.Second
+
 	// Default number of consecutive failures of the health check
 	// for the container to be considered unhealthy.
 	defaultProbeRetries = 3
@@ -251,7 +255,7 @@ func handleProbeResult(d *Daemon, c *container.Container, result *types.Healthch
 // There is never more than one monitor thread running per container at a time.
 func monitor(d *Daemon, c *container.Container, stop chan struct{}, probe probe) {
 	probeInterval := timeoutWithDefault(c.Config.Healthcheck.Interval, defaultProbeInterval)
-	startInterval := timeoutWithDefault(c.Config.Healthcheck.StartInterval, probeInterval)
+	startInterval := timeoutWithDefault(c.Config.Healthcheck.StartInterval, defaultStartInterval)
 	startPeriod := timeoutWithDefault(c.Config.Healthcheck.StartPeriod, defaultStartPeriod)
 
 	c.Lock()


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/47648#issuecomment-2088839488

**- What I did**
Changed the startInterval default value to be 5s

**- How I did it**
Added a new variable named `defaultStartInterval` and set it to 5s. Before, the default value was set to proveInterval by accident.

**- How to verify it**
Run the container's monitoring thread and check if the startInterval's default value is 5s instead of the original 30s.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix the `StartInterval` default value of healthcheck to reflect the documented value of 5s.
```

**- A picture of a cute animal (not mandatory but encouraged)**

