### PR TITLE
libnet: don't check if ctrler store is nil

### DIFF
--- a/libnetwork/endpoint_cnt.go
+++ b/libnetwork/endpoint_cnt.go
@@ -106,9 +106,6 @@ func (ec *endpointCnt) EndpointCnt() uint64 {
 
 func (ec *endpointCnt) updateStore() error {
 	store := ec.n.getController().getStore()
-	if store == nil {
-		return fmt.Errorf("store not found on endpoint count update")
-	}
 	// make a copy of count and n to avoid being overwritten by store.GetObject
 	count := ec.EndpointCnt()
 	n := ec.n
@@ -135,9 +132,6 @@ func (ec *endpointCnt) setCnt(cnt uint64) error {
 
 func (ec *endpointCnt) atomicIncDecEpCnt(inc bool) error {
 	store := ec.n.getController().getStore()
-	if store == nil {
-		return fmt.Errorf("store not found on endpoint count atomic inc/dec")
-	}
 
 	tmp := &endpointCnt{n: ec.n}
 	if err := store.GetObject(tmp); err != nil {

--- a/libnetwork/sandbox_store.go
+++ b/libnetwork/sandbox_store.go
@@ -174,9 +174,6 @@ func (sb *Sandbox) storeDelete() error {
 
 func (c *Controller) sandboxCleanup(activeSandboxes map[string]interface{}) error {
 	store := c.getStore()
-	if store == nil {
-		return fmt.Errorf("could not find local scope store")
-	}
 
 	sandboxStates, err := store.List(&sbState{c: c})
 	if err != nil {

--- a/libnetwork/store.go
+++ b/libnetwork/store.go
@@ -46,9 +46,6 @@ func (c *Controller) getNetworks() ([]*Network, error) {
 	var nl []*Network
 
 	store := c.getStore()
-	if store == nil {
-		return nil, nil
-	}
 
 	kvol, err := store.List(&Network{ctrlr: c})
 	if err != nil && err != datastore.ErrKeyNotFound {
@@ -147,9 +144,6 @@ func (n *Network) getEndpointsFromStore() ([]*Endpoint, error) {
 
 func (c *Controller) updateToStore(kvObject datastore.KVObject) error {
 	cs := c.getStore()
-	if cs == nil {
-		return fmt.Errorf("datastore is not initialized")
-	}
 
 	if err := cs.PutObjectAtomic(kvObject); err != nil {
 		if err == datastore.ErrKeyModified {
@@ -163,9 +157,6 @@ func (c *Controller) updateToStore(kvObject datastore.KVObject) error {
 
 func (c *Controller) deleteFromStore(kvObject datastore.KVObject) error {
 	cs := c.getStore()
-	if cs == nil {
-		return fmt.Errorf("datastore is not initialized")
-	}
 
 retry:
 	if err := cs.DeleteObjectAtomic(kvObject); err != nil {


### PR DESCRIPTION
**- What I did**

Since commit befff0e1, `(*Controller).getStore()` never returns nil except if `c.store` isn't initialized yet. This can't happen unless `New()` returned an error and it wasn't proper caught.

**- How to verify it**

CI
