### PR TITLE
libnet/d/bridge: don't parse the MacAddress netlabel

### DIFF
--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -91,11 +91,6 @@ const (
 	ifaceCreatedByUser
 )
 
-// endpointConfiguration represents the user specified configuration for the sandbox endpoint
-type endpointConfiguration struct {
-	MacAddress net.HardwareAddr
-}
-
 // containerConfiguration represents the user specified configuration for a container
 type containerConfiguration struct {
 	ParentEndpoints []string
@@ -115,7 +110,6 @@ type bridgeEndpoint struct {
 	addr            *net.IPNet
 	addrv6          *net.IPNet
 	macAddress      net.HardwareAddr
-	config          *endpointConfiguration // User specified parameters
 	containerConfig *containerConfiguration
 	extConnConfig   *connectivityConfiguration
 	portMapping     []types.PortBinding // Operation port bindings
@@ -926,7 +920,7 @@ func setHairpinMode(nlh *netlink.Handle, link netlink.Link, enable bool) error {
 	return nil
 }
 
-func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
+func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, _ map[string]interface{}) error {
 	if ifInfo == nil {
 		return errors.New("invalid interface info passed")
 	}
@@ -963,15 +957,9 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 		return driverapi.ErrEndpointExists(eid)
 	}
 
-	// Try to convert the options to endpoint configuration
-	epConfig, err := parseEndpointOptions(epOptions)
-	if err != nil {
-		return err
-	}
-
 	// Create and add the endpoint
 	n.Lock()
-	endpoint := &bridgeEndpoint{id: eid, nid: nid, config: epConfig}
+	endpoint := &bridgeEndpoint{id: eid, nid: nid}
 	n.endpoints[eid] = endpoint
 	n.Unlock()
 
@@ -1065,10 +1053,12 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 	endpoint.addr = ifInfo.Address()
 	endpoint.addrv6 = ifInfo.AddressIPv6()
 
-	// Set the sbox's MAC if not provided. If specified, use the one configured by user, otherwise generate one based on IP.
+	// We assign a default MAC address derived from the IP address to make sure
+	// that if a container is disconnected and reconnected in a short timeframe,
+	// stale ARP entries will still point to the right container.
 	if endpoint.macAddress == nil {
-		endpoint.macAddress = electMacAddress(epConfig, endpoint.addr.IP)
-		if err = ifInfo.SetMacAddress(endpoint.macAddress); err != nil {
+		endpoint.macAddress = netutils.GenerateMACFromIP(endpoint.addr.IP)
+		if err := ifInfo.SetMacAddress(endpoint.macAddress); err != nil {
 			return err
 		}
 	}
@@ -1463,24 +1453,6 @@ func (d *driver) IsBuiltIn() bool {
 	return true
 }
 
-func parseEndpointOptions(epOptions map[string]interface{}) (*endpointConfiguration, error) {
-	if epOptions == nil {
-		return nil, nil
-	}
-
-	ec := &endpointConfiguration{}
-
-	if opt, ok := epOptions[netlabel.MacAddress]; ok {
-		if mac, ok := opt.(net.HardwareAddr); ok {
-			ec.MacAddress = mac
-		} else {
-			return nil, &ErrInvalidEndpointConfig{}
-		}
-	}
-
-	return ec, nil
-}
-
 func parseContainerOptions(cOptions map[string]interface{}) (*containerConfiguration, error) {
 	if cOptions == nil {
 		return nil, nil
@@ -1527,11 +1499,4 @@ func parseConnectivityOptions(cOptions map[string]interface{}) (*connectivityCon
 	}
 
 	return cc, nil
-}
-
-func electMacAddress(epConfig *endpointConfiguration, ip net.IP) net.HardwareAddr {
-	if epConfig != nil && epConfig.MacAddress != nil {
-		return epConfig.MacAddress
-	}
-	return netutils.GenerateMACFromIP(ip)
 }

--- a/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -35,7 +35,6 @@ func TestEndpointMarshalling(t *testing.T) {
 		addrv6:     ip2,
 		macAddress: mac,
 		srcName:    "veth123456",
-		config:     &endpointConfiguration{MacAddress: mac},
 		containerConfig: &containerConfiguration{
 			ParentEndpoints: []string{"one", "due", "three"},
 			ChildEndpoints:  []string{"four", "five", "six"},
@@ -90,22 +89,11 @@ func TestEndpointMarshalling(t *testing.T) {
 
 	if e.id != ee.id || e.nid != ee.nid || e.srcName != ee.srcName || !bytes.Equal(e.macAddress, ee.macAddress) ||
 		!types.CompareIPNet(e.addr, ee.addr) || !types.CompareIPNet(e.addrv6, ee.addrv6) ||
-		!compareEpConfig(e.config, ee.config) ||
 		!compareContainerConfig(e.containerConfig, ee.containerConfig) ||
 		!compareConnConfig(e.extConnConfig, ee.extConnConfig) ||
 		!compareBindings(e.portMapping, ee.portMapping) {
 		t.Fatalf("JSON marsh/unmarsh failed.\nOriginal:\n%#v\nDecoded:\n%#v", e, ee)
 	}
-}
-
-func compareEpConfig(a, b *endpointConfiguration) bool {
-	if a == b {
-		return true
-	}
-	if a == nil || b == nil {
-		return false
-	}
-	return bytes.Equal(a.MacAddress, b.MacAddress)
 }
 
 func compareContainerConfig(a, b *containerConfiguration) bool {
@@ -385,10 +373,9 @@ func TestCreateFullOptionsLabels(t *testing.T) {
 
 	// In short here we are testing --fixed-cidr-v6 daemon option
 	// plus --mac-address run option
-	mac, _ := net.ParseMAC("aa:bb:cc:dd:ee:ff")
-	epOptions := map[string]interface{}{netlabel.MacAddress: mac}
 	te := newTestEndpoint(ipdList[0].Pool, 20)
-	err = d.CreateEndpoint("dummy", "ep1", te.Interface(), epOptions)
+	te.iface.mac = netutils.MustParseMAC("aa:bb:cc:dd:ee:ff")
+	err = d.CreateEndpoint("dummy", "ep1", te.Interface(), map[string]interface{}{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/drivers/bridge/bridge_store.go
+++ b/libnetwork/drivers/bridge/bridge_store.go
@@ -264,7 +264,6 @@ func (ep *bridgeEndpoint) MarshalJSON() ([]byte, error) {
 	if ep.addrv6 != nil {
 		epMap["Addrv6"] = ep.addrv6.String()
 	}
-	epMap["Config"] = ep.config
 	epMap["ContainerConfig"] = ep.containerConfig
 	epMap["ExternalConnConfig"] = ep.extConnConfig
 	epMap["PortMapping"] = ep.portMapping
@@ -300,11 +299,7 @@ func (ep *bridgeEndpoint) UnmarshalJSON(b []byte) error {
 	ep.id = epMap["id"].(string)
 	ep.nid = epMap["nid"].(string)
 	ep.srcName = epMap["SrcName"].(string)
-	d, _ := json.Marshal(epMap["Config"])
-	if err := json.Unmarshal(d, &ep.config); err != nil {
-		log.G(context.TODO()).Warnf("Failed to decode endpoint config %v", err)
-	}
-	d, _ = json.Marshal(epMap["ContainerConfig"])
+	d, _ := json.Marshal(epMap["ContainerConfig"])
 	if err := json.Unmarshal(d, &ep.containerConfig); err != nil {
 		log.G(context.TODO()).Warnf("Failed to decode endpoint container config %v", err)
 	}

--- a/libnetwork/netutils/utils.go
+++ b/libnetwork/netutils/utils.go
@@ -149,3 +149,12 @@ func IsV6Listenable() bool {
 	})
 	return v6ListenableCached
 }
+
+// MustParseMAC returns a net.HardwareAddr or panic.
+func MustParseMAC(s string) net.HardwareAddr {
+	mac, err := net.ParseMAC(s)
+	if err != nil {
+		panic(err)
+	}
+	return mac
+}


### PR DESCRIPTION
**- What I did**

Libnet's method `(*Network).createEndpoint()` is already parsing this netlabel to set the field `ep.iface.mac`. Later on, this same method invoke the driver's method `CreateEndpoint` with an `InterfaceInfo` arg and an `options` arg (an opaque map of driver opts).

The `InterfaceInfo` interface contains a `MacAddress()` method that returns `ep.iface.mac`. And the opaque map may contain the key `netlabel.MacAddress`.

Prior to this change, the bridge driver was calling `MacAddress()`. If no value was returned, it'd fall back to the option set in the `options` map, or generate a MAC address based on the IP address.

However, the expected type of the `options` value is a `net.HardwareAddr`. This is what's set by the daemon when handing over the endpoint config to libnet controller. If the value is a string, as is the case if the MAC address is provided through `EndpointsSettings.DriverOpts`, it produces an error.

As such, the opaque option and the `MacAddress()` are necessarily the same -- either nothing or a `net.HardwareAddr`. No need to keep both.

Moreover, the struct `endpointConfiguration` was only used to store that netlabel value. Drop it too.

**- How I did it**

Careful static code analysis.

**- How to verify it**

CI and tests.

Or manually:

```shell
$ docker run --rm -it --network testnet --mac-address 02:42:ac:13:00:12 nicolaka/netshoot ip -brief link show
$ docker run --rm -it --network=name=testnet,driver-opt=com.docker.network.endpoint.macaddress=60:3e:5f:35:9a:e4 nicolaka/netshoot ip -brief link show
```

**- A picture of a cute animal (not mandatory but encouraged)**

<img src="https://i.pinimg.com/originals/0c/54/20/0c5420d3a78e8e46dbbd981f6c691b29.jpg" width=50% height=50% />