### PR TITLE
Default to "windows-dns-proxy":true

### DIFF
--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -164,10 +164,10 @@ func serviceDiscoveryOnDefaultNetwork() bool {
 }
 
 func buildSandboxPlatformOptions(container *container.Container, cfg *config.Config, sboxOptions *[]libnetwork.SandboxOption) error {
-	// By default, the Windows internal resolver does not forward requests to
-	// external resolvers - but forwarding can be enabled using feature flag
-	// "windows-dns-proxy":true.
-	if doproxy, exists := cfg.Features["windows-dns-proxy"]; !exists || !doproxy {
+	// By default, the Windows internal resolver forwards requests to external
+	// resolvers - but forwarding can be disabled using feature flag
+	// "windows-dns-proxy":false.
+	if doproxy, exists := cfg.Features["windows-dns-proxy"]; exists && !doproxy {
 		*sboxOptions = append(*sboxOptions, libnetwork.OptionDNSNoProxy())
 	}
 	return nil

--- a/integration/networking/resolvconf_test.go
+++ b/integration/networking/resolvconf_test.go
@@ -150,10 +150,7 @@ func TestNslookupWindows(t *testing.T) {
 	defer c.ContainerRemove(ctx, res.ContainerID, containertypes.RemoveOptions{Force: true})
 
 	assert.Check(t, is.Equal(res.ExitCode, 0))
-	// Current default is to not-forward requests to external servers, which
+	// Current default is to forward requests to external servers, which
 	// can only be changed in daemon.json using feature flag "windows-dns-proxy".
-	// So, expect the lookup to fail...
-	assert.Check(t, is.Contains(res.Stderr.String(), "Server failed"))
-	// When the default behaviour is changed, nslookup should succeed...
-	//assert.Check(t, is.Contains(res.Stdout.String(), "Addresses:"))
+	assert.Check(t, is.Contains(res.Stdout.String(), "Addresses:"))
 }


### PR DESCRIPTION
**- What I did**

In 26.1, https://github.com/moby/moby/pull/47584, we added daemon feature flag `windows-dns-proxy` which could be set to `true` to make `nslookup` work in Windows containers, by forwarding requests from the internal resolver to the container's external DNS servers.

This changes the default to forwarding-enabled - it can be disabled by via daemon.json using ...
  `"features": { "windows-dns-proxy": false }`

(Follow-up ticket https://github.com/moby/moby/issues/47732 is about removing the feature flag if no problems are found with the new default.)

**- How I did it**

Changed the feature flag lookup.

**- How to verify it**

Manually tested an `nslookup` from a `servercore:ltsc2022` container, with no flag in daemon.json, with it explicitly enabled and explicitly disabled.

Updated integration test to expect the feature to be enabled by default.

**- Description for the changelog**
```markdown changelog
The internal DNS resolver used by Windows containers will now forward requests to external DNS servers
by-default, this enables `nslookup` to resolve external hostnames. This behaviour can be disabled via
`daemon.json`, using `"features": { "windows-dns-proxy": false }`, the feature flag will be removed in a
future release.
```

