### PR TITLE
[26.1 backport] Do not forward DNS requests to self.

### DIFF
--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -47,6 +47,13 @@ func WithNetworkMode(mode string) func(*TestContainerConfig) {
 	}
 }
 
+// WithDNS sets external DNS servers for the container
+func WithDNS(dns []string) func(*TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.HostConfig.DNS = append([]string(nil), dns...)
+	}
+}
+
 // WithSysctls sets sysctl options for the container
 func WithSysctls(sysctls map[string]string) func(*TestContainerConfig) {
 	return func(c *TestContainerConfig) {

--- a/integration/network/dns_test.go
+++ b/integration/network/dns_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/docker/docker/integration/internal/network"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
@@ -32,4 +34,60 @@ func TestDaemonDNSFallback(t *testing.T) {
 	defer c.ContainerRemove(ctx, cid, containertypes.RemoveOptions{Force: true})
 
 	poll.WaitOn(t, container.IsSuccessful(ctx, c, cid), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(10*time.Second))
+}
+
+// Check that, when the internal DNS server's address is supplied as an external
+// DNS server, the daemon doesn't start talking to itself.
+func TestIntDNSAsExtDNS(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "cannot start daemon on Windows test run")
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot start daemon on remote test run")
+
+	ctx := setupTest(t)
+
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t)
+	defer d.Stop(t)
+
+	c := d.NewClientT(t)
+	defer c.Close()
+
+	testcases := []struct {
+		name        string
+		extServers  []string
+		expExitCode int
+		expStdout   string
+	}{
+		{
+			name:        "only self",
+			extServers:  []string{"127.0.0.11"},
+			expExitCode: 1,
+			expStdout:   "SERVFAIL",
+		},
+		{
+			name:        "self then ext",
+			extServers:  []string{"127.0.0.11", "8.8.8.8"},
+			expExitCode: 0,
+			expStdout:   "Non-authoritative answer",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testutil.StartSpan(ctx, t)
+
+			const netName = "testnet"
+			network.CreateNoError(ctx, t, c, netName)
+			defer network.RemoveNoError(ctx, t, c, netName)
+
+			res := container.RunAttach(ctx, t, c,
+				container.WithNetworkMode(netName),
+				container.WithDNS(tc.extServers),
+				container.WithCmd("nslookup", "docker.com"),
+			)
+			defer c.ContainerRemove(ctx, res.ContainerID, containertypes.RemoveOptions{Force: true})
+
+			assert.Check(t, is.Equal(res.ExitCode, tc.expExitCode))
+			assert.Check(t, is.Contains(res.Stdout.String(), tc.expStdout))
+		})
+	}
 }


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/47744

**- What I did**

Make it safe to supply the internal DNS server's own address as an external DNS server.

Fix https://github.com/moby/moby/issues/47716

**- How I did it**

The internal resolver removes its own address from the list of ext-servers it's given, and logs a message.

**- How to verify it**

New integration test.

**- Description for the changelog**
```markdown changelog
When the internal DNS server's own address is supplied as an external server address, ignore it to avoid unproductive recursion.
```