### PR TITLE
libnet/i/defaultipam: Disambiguate PoolID string format

### DIFF
--- a/libnetwork/ipams/defaultipam/allocator_test.go
+++ b/libnetwork/ipams/defaultipam/allocator_test.go
@@ -24,33 +24,101 @@ import (
 )
 
 func TestKeyString(t *testing.T) {
-	k := &PoolID{AddressSpace: "default", SubnetKey: SubnetKey{Subnet: netip.MustParsePrefix("172.27.0.0/16")}}
-	expected := "default/172.27.0.0/16"
-	if expected != k.String() {
-		t.Fatalf("Unexpected key string: %s", k.String())
-	}
+	k := PoolID{AddressSpace: "default", SubnetKey: SubnetKey{Subnet: netip.MustParsePrefix("172.27.0.0/16")}}
+	expected := `PoolID{"AddressSpace":"default","Subnet":"172.27.0.0/16"}`
+	assert.Equal(t, k.String(), expected)
 
 	k2, err := PoolIDFromString(expected)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if k2.AddressSpace != k.AddressSpace || k2.Subnet != k.Subnet {
-		t.Fatalf("SubnetKey.FromString() failed. Expected %v. Got %v", k, k2)
-	}
+	assert.NilError(t, err)
 
-	expected = fmt.Sprintf("%s/%s", expected, "172.27.3.0/24")
+	assert.Check(t, is.Equal(k, k2))
+
 	k.ChildSubnet = netip.MustParsePrefix("172.27.3.0/24")
-	if expected != k.String() {
-		t.Fatalf("Unexpected key string: %s", k.String())
+	assert.Check(t, is.Contains(k.String(), `"AddressSpace":"default"`))
+	assert.Check(t, is.Contains(k.String(), `"Subnet":"172.27.0.0/16"`))
+	assert.Check(t, is.Contains(k.String(), `"ChildSubnet":"172.27.3.0/24"`))
+
+	k2, err = PoolIDFromString(`PoolID{"AddressSpace":"default","Subnet":"172.27.0.0/16","ChildSubnet":"172.27.3.0/24"}`)
+	assert.NilError(t, err)
+
+	assert.Check(t, is.Equal(k, k2))
+}
+
+// TestPoolIDV2FormatDeserialization tests a few instances of PoolID's V2
+// serialization format.
+func TestPoolIDV2FormatDeserialization(t *testing.T) {
+	testcases := []struct {
+		serialized string
+		expPoolID  PoolID
+		expErr     string
+	}{
+		{
+			serialized: `PoolID{"AddressSpace":"default"}`,
+			expErr:     `invalid string form for subnetkey PoolID{"AddressSpace":"default"}: missing AddressSpace or Subnet`,
+		},
+		{
+			serialized: `PoolID{"AddressSpace":"default","Subnet":""}`,
+			expErr:     `invalid string form for subnetkey PoolID{"AddressSpace":"default","Subnet":""}: missing AddressSpace or Subnet`,
+		},
+		{
+			serialized: `PoolID{"AddressSpace":"default","ChildSubnet":"172.27.0.0/16"}`,
+			expErr:     `invalid string form for subnetkey PoolID{"AddressSpace":"default","ChildSubnet":"172.27.0.0/16"}: missing AddressSpace or Subnet`,
+		},
+		{
+			serialized: `PoolID{"AddressSpace":"default","Subnet":"172.16.0.0/12"}`,
+			expPoolID: PoolID{
+				AddressSpace: "default",
+				SubnetKey:    SubnetKey{Subnet: netip.MustParsePrefix("172.16.0.0/12")},
+			},
+		},
+		{
+			serialized: `PoolID{"AddressSpace":"default","Subnet":"172.16.0.0/12","ChildSubnet":"172.16.10.0/16"}`,
+			expPoolID: PoolID{
+				AddressSpace: "default",
+				SubnetKey: SubnetKey{
+					Subnet:      netip.MustParsePrefix("172.16.0.0/12"),
+					ChildSubnet: netip.MustParsePrefix("172.16.10.0/16"),
+				},
+			},
+		},
 	}
 
-	k2, err = PoolIDFromString(expected)
-	if err != nil {
-		t.Fatal(err)
+	for _, tc := range testcases {
+		pID, err := PoolIDFromString(tc.serialized)
+
+		if tc.expErr != "" {
+			assert.Check(t, is.Error(err, tc.expErr))
+		} else {
+			assert.Check(t, is.Equal(pID, tc.expPoolID))
+		}
 	}
-	if k2.AddressSpace != k.AddressSpace || k2.Subnet != k.Subnet || k2.ChildSubnet != k.ChildSubnet {
-		t.Fatalf("SubnetKey.FromString() failed. Expected %v. Got %v", k, k2)
-	}
+}
+
+// TestPoolIDFormatCompatibility tests whether PoolIDFromString correctly deserializes the 'v1' format correctly.
+func TestPoolIDFormatCompatibility(t *testing.T) {
+	k, err := PoolIDFromString("default/172.27.0.0/16")
+	assert.NilError(t, err)
+	assert.Check(t, is.Contains(k.String(), `"AddressSpace":"default"`))
+	assert.Check(t, is.Contains(k.String(), `"Subnet":"172.27.0.0/16"`))
+	assert.Equal(t, k, PoolID{
+		AddressSpace: "default",
+		SubnetKey: SubnetKey{
+			Subnet: netip.MustParsePrefix("172.27.0.0/16"),
+		},
+	})
+
+	k, err = PoolIDFromString("default/172.27.0.0/16/172.27.10.0/24")
+	assert.NilError(t, err)
+	assert.Check(t, is.Contains(k.String(), `"AddressSpace":"default"`))
+	assert.Check(t, is.Contains(k.String(), `"Subnet":"172.27.0.0/16"`))
+	assert.Check(t, is.Contains(k.String(), `"ChildSubnet":"172.27.10.0/24"`))
+	assert.Equal(t, k, PoolID{
+		AddressSpace: "default",
+		SubnetKey: SubnetKey{
+			Subnet:      netip.MustParsePrefix("172.27.0.0/16"),
+			ChildSubnet: netip.MustParsePrefix("172.27.10.0/24"),
+		},
+	})
 }
 
 func TestAddSubnets(t *testing.T) {

--- a/libnetwork/ipams/defaultipam/structures.go
+++ b/libnetwork/ipams/defaultipam/structures.go
@@ -55,22 +55,22 @@ func PoolIDFromString(str string) (pID PoolID, err error) {
 
 func parsePoolIDV1(str string) (pID PoolID, err error) {
 	if str == "" {
-		return pID, types.InvalidParameterErrorf("invalid string form for subnetkey: %s", str)
+		return pID, types.InternalErrorf("invalid string form for subnetkey: %s", str)
 	}
 
 	p := strings.Split(str, "/")
 	if len(p) != 3 && len(p) != 5 {
-		return pID, types.InvalidParameterErrorf("invalid string form for subnetkey: %s", str)
+		return pID, types.InternalErrorf("invalid string form for subnetkey: %s", str)
 	}
 	pID.AddressSpace = p[0]
 	pID.Subnet, err = netip.ParsePrefix(p[1] + "/" + p[2])
 	if err != nil {
-		return pID, types.InvalidParameterErrorf("invalid string form for subnetkey: %s", str)
+		return pID, types.InternalErrorf("invalid string form for subnetkey: %s", str)
 	}
 	if len(p) == 5 {
 		pID.ChildSubnet, err = netip.ParsePrefix(p[3] + "/" + p[4])
 		if err != nil {
-			return pID, types.InvalidParameterErrorf("invalid string form for subnetkey: %s", str)
+			return pID, types.InternalErrorf("invalid string form for subnetkey: %s", str)
 		}
 	}
 
@@ -89,18 +89,18 @@ func parsePoolIDV2(str string) (pID PoolID, err error) {
 
 	if v, ok := fields[subnetField]; ok && v != "" {
 		if pID.Subnet, err = netip.ParsePrefix(v); err != nil {
-			return PoolID{}, types.InvalidParameterErrorf("invalid string form for subnetkey %s: %w", str, err)
+			return PoolID{}, types.InternalErrorf("invalid string form for subnetkey %s: %v", str, err)
 		}
 	}
 
 	if v, ok := fields[childSubnetField]; ok && v != "" {
 		if pID.ChildSubnet, err = netip.ParsePrefix(v); err != nil {
-			return PoolID{}, types.InvalidParameterErrorf("invalid string form for subnetkey %s: %w", str, err)
+			return PoolID{}, types.InternalErrorf("invalid string form for subnetkey %s: %v", str, err)
 		}
 	}
 
 	if pID.AddressSpace == "" || pID.Subnet == (netip.Prefix{}) {
-		return PoolID{}, types.InvalidParameterErrorf("invalid string form for subnetkey %s: missing AddressSpace or Subnet", str)
+		return PoolID{}, types.InternalErrorf("invalid string form for subnetkey %s: missing AddressSpace or Subnet", str)
 	}
 
 	return pID, nil


### PR DESCRIPTION
**- What I did**

Prior to this change PoolID microformat was using slashes to separate fields. Those fields include subnet prefixes in CIDR notation, which also includes a slash. This makes future evolution harder than it should be.

This change introduces a 'v2' microformat which uses: 1. named fields to disambiguate which field each value is associated to; 2. semicolons as a separator.

The 'v1' encoding will be kept until the next major MCR LTS is released after v27.

**- How to verify it**

- CI & tests.
- Manual testing -- create a network on master, check out this branch, restart the daemon.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://s3.amazonaws.com/mongabay-images/12/DSC_0595.reticulatedgiraffe.boy.568.jpg)