### PR TITLE
[26.1 backport] Explicity write http headers on streaming endpoints

### DIFF
--- a/api/server/httputils/write_log_stream.go
+++ b/api/server/httputils/write_log_stream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"sort"
 
@@ -16,7 +17,11 @@ import (
 
 // WriteLogStream writes an encoded byte stream of log messages from the
 // messages channel, multiplexing them with a stdcopy.Writer if mux is true
-func WriteLogStream(_ context.Context, w io.Writer, msgs <-chan *backend.LogMessage, config *container.LogsOptions, mux bool) {
+func WriteLogStream(_ context.Context, w http.ResponseWriter, msgs <-chan *backend.LogMessage, config *container.LogsOptions, mux bool) {
+	// See https://github.com/moby/moby/issues/47448
+	// Trigger headers to be written immediately.
+	w.WriteHeader(http.StatusOK)
+
 	wf := ioutils.NewWriteFlusher(w)
 	defer wf.Close()
 

--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -263,6 +263,7 @@ func (s *systemRouter) getEvents(ctx context.Context, w http.ResponseWriter, r *
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	output := ioutils.NewWriteFlusher(w)
 	defer output.Close()
 	output.Flush()

--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -89,7 +89,7 @@ type LogSelector struct {
 type ContainerStatsConfig struct {
 	Stream    bool
 	OneShot   bool
-	OutStream io.Writer
+	OutStream func() io.Writer
 }
 
 // ExecInspect holds information about a running process started


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/47796
- fixes https://github.com/moby/moby/issues/47448


This works around issues with the otel http handler wrapper causing multiple calls to `WriteHeader` when a `Flush` is called before `Write`.

```markdown changelog
Prevent daemon log being spammed with `superfluous response.WriteHeader call ...` message.
```
