### PR TITLE
Replace dead RFC8878 hyperlink in documentation

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -159,7 +159,7 @@ func magicNumberMatcher(m []byte) matcher {
 // zstdMatcher detects zstd compression algorithm.
 // Zstandard compressed data is made of one or more frames.
 // There are two frame formats defined by Zstandard: Zstandard frames and Skippable frames.
-// See https://tools.ietf.org/id/draft-kucherawy-dispatch-zstd-00.html#rfc.section.2 for more details.
+// See https://datatracker.ietf.org/doc/html/rfc8878#section-3 for more details.
 func zstdMatcher() matcher {
 	return func(source []byte) bool {
 		if bytes.HasPrefix(source, zstdMagic) {


### PR DESCRIPTION
**- What I did**
Replace dead RFC8878 hyperlink in documentation with the current live link at IETF datatracker; seems like the draft RFC expired and the link died.

**- How I did it**
Found the correct link at datatracker and then ctrl+c ctrl+v'd

**- How to verify it**
Check the links within the diff.

**- Description for the changelog**

```markdown changelog
Replace dead RFC8878 hyperlink in documentation
```

Fixes #45952

