### PR TITLE
libnet/i/defaultipam: use ULA prefix by default

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -60,6 +60,7 @@ import (
 	"github.com/docker/docker/libnetwork"
 	"github.com/docker/docker/libnetwork/cluster"
 	nwconfig "github.com/docker/docker/libnetwork/config"
+	"github.com/docker/docker/libnetwork/ipamutils"
 	"github.com/docker/docker/pkg/authorization"
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/idtools"
@@ -1474,9 +1475,12 @@ func (daemon *Daemon) networkOptions(conf *config.Config, pg plugingetter.Plugin
 		driverOptions(conf),
 	}
 
+	defaultAddressPools := ipamutils.GetLocalScopeDefaultNetworks()
 	if len(conf.NetworkConfig.DefaultAddressPools.Value()) > 0 {
-		options = append(options, nwconfig.OptionDefaultAddressPoolConfig(conf.NetworkConfig.DefaultAddressPools.Value()))
+		defaultAddressPools = conf.NetworkConfig.DefaultAddressPools.Value()
 	}
+	options = append(options, nwconfig.OptionDefaultAddressPoolConfig(defaultAddressPools))
+
 	if conf.LiveRestoreEnabled && len(activeSandboxes) != 0 {
 		options = append(options, nwconfig.OptionActiveSandboxes(activeSandboxes))
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -10,12 +10,16 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"path"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -61,6 +65,7 @@ import (
 	"github.com/docker/docker/libnetwork/cluster"
 	nwconfig "github.com/docker/docker/libnetwork/config"
 	"github.com/docker/docker/libnetwork/ipamutils"
+	"github.com/docker/docker/libnetwork/ipbits"
 	"github.com/docker/docker/pkg/authorization"
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/idtools"
@@ -1462,7 +1467,7 @@ func isBridgeNetworkDisabled(conf *config.Config) bool {
 	return conf.BridgeConfig.Iface == config.DisableNetworkBridge
 }
 
-func (daemon *Daemon) networkOptions(conf *config.Config, pg plugingetter.PluginGetter, activeSandboxes map[string]interface{}) ([]nwconfig.Option, error) {
+func (daemon *Daemon) networkOptions(conf *config.Config, pg plugingetter.PluginGetter, hostID string, activeSandboxes map[string]interface{}) ([]nwconfig.Option, error) {
 	dd := runconfig.DefaultDaemonNetworkMode()
 
 	options := []nwconfig.Option{
@@ -1479,6 +1484,15 @@ func (daemon *Daemon) networkOptions(conf *config.Config, pg plugingetter.Plugin
 	if len(conf.NetworkConfig.DefaultAddressPools.Value()) > 0 {
 		defaultAddressPools = conf.NetworkConfig.DefaultAddressPools.Value()
 	}
+	// If the Engine admin don't configure default-address-pools or if they
+	// don't provide any IPv6 prefix, we derive a ULA prefix from the daemon's
+	// hostID and add it to the pools. This makes dynamic IPv6 subnet
+	// allocation possible out-of-the-box.
+	if !slices.ContainsFunc(defaultAddressPools, func(nw *ipamutils.NetworkToSplit) bool {
+		return nw.Base.Addr().Is6() && !nw.Base.Addr().Is4In6()
+	}) {
+		defaultAddressPools = append(defaultAddressPools, deriveULABaseNetwork(hostID))
+	}
 	options = append(options, nwconfig.OptionDefaultAddressPoolConfig(defaultAddressPools))
 
 	if conf.LiveRestoreEnabled && len(activeSandboxes) != 0 {
@@ -1489,6 +1503,23 @@ func (daemon *Daemon) networkOptions(conf *config.Config, pg plugingetter.Plugin
 	}
 
 	return options, nil
+}
+
+// deriveULABaseNetwork derives a Global ID from the provided hostID and
+// appends it to the ULA prefix (with L bit set) to generate a ULA prefix
+// unique to this host. The returned ipamutils.NetworkToSplit is stable over
+// time if hostID doesn't change.
+//
+// This is loosely based on the algorithm described in https://datatracker.ietf.org/doc/html/rfc4193#section-3.2.2.
+func deriveULABaseNetwork(hostID string) *ipamutils.NetworkToSplit {
+	sha := sha256.Sum256([]byte(hostID))
+	gid := binary.BigEndian.Uint64(sha[:]) & (1<<40 - 1) // Keep the 40 least significant bits.
+	addr := ipbits.Add(netip.MustParseAddr("fd00::"), gid, 80)
+
+	return &ipamutils.NetworkToSplit{
+		Base: netip.PrefixFrom(addr, 48),
+		Size: 64,
+	}
 }
 
 // GetCluster returns the cluster

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -835,7 +835,7 @@ func configureKernelSecuritySupport(config *config.Config, driverName string) er
 // network settings. If there's active sandboxes, configuration changes will not
 // take effect.
 func (daemon *Daemon) initNetworkController(cfg *config.Config, activeSandboxes map[string]interface{}) error {
-	netOptions, err := daemon.networkOptions(cfg, daemon.PluginStore, activeSandboxes)
+	netOptions, err := daemon.networkOptions(cfg, daemon.PluginStore, daemon.id, activeSandboxes)
 	if err != nil {
 		return err
 	}

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -234,7 +234,7 @@ func configureMaxThreads(config *config.Config) error {
 }
 
 func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSandboxes map[string]interface{}) error {
-	netOptions, err := daemon.networkOptions(daemonCfg, nil, nil)
+	netOptions, err := daemon.networkOptions(daemonCfg, nil, daemon.id, nil)
 	if err != nil {
 		return err
 	}

--- a/daemon/reload_test.go
+++ b/daemon/reload_test.go
@@ -360,7 +360,7 @@ func TestDaemonReloadNetworkDiagnosticPort(t *testing.T) {
 		},
 	}
 
-	netOptions, err := daemon.networkOptions(&config.Config{CommonConfig: config.CommonConfig{Root: t.TempDir()}}, nil, nil)
+	netOptions, err := daemon.networkOptions(&config.Config{CommonConfig: config.CommonConfig{Root: t.TempDir()}}, nil, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/network/bridge_test.go
+++ b/integration/network/bridge_test.go
@@ -2,10 +2,12 @@ package network
 
 import (
 	"context"
+	"net/netip"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/docker/docker/api/types"
 	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/versions"
 	ctr "github.com/docker/docker/integration/internal/container"
@@ -42,4 +44,28 @@ func TestCreateWithMultiNetworks(t *testing.T) {
 	// interfaces for testnet1 and testnet2, plus lo.
 	ifacesWithAddress := strings.Count(res.Stdout.String(), "\n")
 	assert.Equal(t, ifacesWithAddress, 3)
+}
+
+func TestCreateWithIPv6DefaultsToULAPrefix(t *testing.T) {
+	// On Windows, network creation fails with this error message: Error response from daemon: this request is not supported by the 'windows' ipam driver
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	const nwName = "testnetula"
+	network.CreateNoError(ctx, t, apiClient, nwName, network.WithIPv6())
+	defer network.RemoveNoError(ctx, t, apiClient, nwName)
+
+	nw, err := apiClient.NetworkInspect(ctx, "testnetula", types.NetworkInspectOptions{})
+	assert.NilError(t, err)
+
+	for _, ipam := range nw.IPAM.Config {
+		ipr := netip.MustParsePrefix(ipam.Subnet)
+		if netip.MustParsePrefix("fd00::/8").Overlaps(ipr) {
+			return
+		}
+	}
+
+	t.Fatalf("Network %s has no ULA prefix, expected one.", nwName)
 }

--- a/libnetwork/ipams/defaultipam/allocator.go
+++ b/libnetwork/ipams/defaultipam/allocator.go
@@ -27,10 +27,6 @@ const (
 // two optional address pools respectively containing the list of user-defined
 // address pools for 'local' and 'global' address spaces.
 func Register(ic ipamapi.Registerer, lAddrPools, gAddrPools []*ipamutils.NetworkToSplit) error {
-	if len(lAddrPools) == 0 {
-		lAddrPools = ipamutils.GetLocalScopeDefaultNetworks()
-	}
-
 	if len(gAddrPools) == 0 {
 		gAddrPools = ipamutils.GetGlobalScopeDefaultNetworks()
 	}

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -11,8 +11,10 @@ import (
 	"time"
 
 	"github.com/docker/docker/internal/testutils/netnsutils"
+	"github.com/docker/docker/libnetwork/config"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/ipams/defaultipam"
+	"github.com/docker/docker/libnetwork/ipamutils"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/netutils"
 	"github.com/docker/docker/libnetwork/scope"
@@ -353,13 +355,14 @@ func TestSRVServiceQuery(t *testing.T) {
 
 	defer netnsutils.SetupTestOSContext(t)()
 
-	c, err := New(OptionBoltdbWithRandomDBFile(t))
+	c, err := New(OptionBoltdbWithRandomDBFile(t),
+		config.OptionDefaultAddressPoolConfig(ipamutils.GetLocalScopeDefaultNetworks()))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer c.Stop()
 
-	n, err := c.NewNetwork("bridge", "net1", "", nil)
+	n, err := c.NewNetwork("bridge", "net1", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -451,7 +454,8 @@ func TestServiceVIPReuse(t *testing.T) {
 
 	defer netnsutils.SetupTestOSContext(t)()
 
-	c, err := New(OptionBoltdbWithRandomDBFile(t))
+	c, err := New(OptionBoltdbWithRandomDBFile(t),
+		config.OptionDefaultAddressPoolConfig(ipamutils.GetLocalScopeDefaultNetworks()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/ipams/defaultipam"
 	"github.com/docker/docker/libnetwork/ipams/null"
+	"github.com/docker/docker/libnetwork/ipamutils"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/options"
 	"github.com/docker/docker/libnetwork/osl"
@@ -58,6 +59,7 @@ func newController(t *testing.T) *libnetwork.Controller {
 				"EnableIPForwarding": true,
 			},
 		}),
+		config.OptionDefaultAddressPoolConfig(ipamutils.GetLocalScopeDefaultNetworks()),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/libnetwork/resolver_unix_test.go
+++ b/libnetwork/resolver_unix_test.go
@@ -7,13 +7,16 @@ import (
 	"testing"
 
 	"github.com/docker/docker/internal/testutils/netnsutils"
+	"github.com/docker/docker/libnetwork/config"
+	"github.com/docker/docker/libnetwork/ipamutils"
 	"github.com/miekg/dns"
 )
 
 // test only works on linux
 func TestDNSIPQuery(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
-	c, err := New(OptionBoltdbWithRandomDBFile(t))
+	c, err := New(OptionBoltdbWithRandomDBFile(t),
+		config.OptionDefaultAddressPoolConfig(ipamutils.GetLocalScopeDefaultNetworks()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +113,8 @@ func TestDNSProxyServFail(t *testing.T) {
 	osctx := netnsutils.SetupTestOSContextEx(t)
 	defer osctx.Cleanup(t)
 
-	c, err := New(OptionBoltdbWithRandomDBFile(t))
+	c, err := New(OptionBoltdbWithRandomDBFile(t),
+		config.OptionDefaultAddressPoolConfig(ipamutils.GetLocalScopeDefaultNetworks()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/sandbox_unix_test.go
+++ b/libnetwork/sandbox_unix_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/config"
 	"github.com/docker/docker/libnetwork/ipams/defaultipam"
+	"github.com/docker/docker/libnetwork/ipamutils"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/options"
 	"github.com/docker/docker/libnetwork/osl"
@@ -24,6 +25,7 @@ func getTestEnv(t *testing.T, opts ...[]NetworkOption) (*Controller, []*Network)
 		config.OptionDriverConfig(netType, map[string]any{
 			netlabel.GenericData: options.Generic{"EnableIPForwarding": true},
 		}),
+		config.OptionDefaultAddressPoolConfig(ipamutils.GetLocalScopeDefaultNetworks()),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/libnetwork/service_common_unix_test.go
+++ b/libnetwork/service_common_unix_test.go
@@ -7,12 +7,15 @@ import (
 	"testing"
 
 	"github.com/docker/docker/internal/testutils/netnsutils"
+	"github.com/docker/docker/libnetwork/config"
+	"github.com/docker/docker/libnetwork/ipamutils"
 	"gotest.tools/v3/assert"
 )
 
 func TestCleanupServiceDiscovery(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
-	c, err := New(OptionBoltdbWithRandomDBFile(t))
+	c, err := New(OptionBoltdbWithRandomDBFile(t),
+		config.OptionDefaultAddressPoolConfig(ipamutils.GetLocalScopeDefaultNetworks()))
 	assert.NilError(t, err)
 	defer c.Stop()
 


### PR DESCRIPTION
**- What I did**

So far, Moby only had IPv4 prefixes in its 'default-address-pools'. To get dynamic IPv6 subnet allocations, users have to redefine this parameter to include IPv6 base network(s). This is needlessly complex and against Moby's 'batteries-included' principle.

This change generates a ULA base network by deriving a ULA Global ID from the Engine's Host ID and put that base network into the 'default-address-pools'. This Host ID is stable over time (except if users remove the file '/var/lib/docker/engine-id') and thus the GID is stable too.

This ULA base network won't be put into 'default-address-pools' if users
have manually configured it.

This is loosely based on https://datatracker.ietf.org/doc/html/rfc4193#section-3.2.2.

**- How to verify it**

CI -- a unit test has been added to make sure the GID is stable over time.

```console
$ docker network create --ipv6 testnet
$ docker network inspect --format='{{ (index .IPAM.Config 1).Subnet }}' testnet
```

**- Description for the changelog**

```markdown changelog
- A ULA base prefix is automatically added to `default-address-pools` if this parameter wasn't manually configured, or if it contains no IPv6 prefixes. This ULA prefix is derived from the Engine host ID such that it's unique across hosts and over time.
```

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://i.pinimg.com/736x/c5/68/dc/c568dcf4ba7eefc78d6562b418bd06c7.jpg)