### PR TITLE
integration/internal/swarm, testutil/fakestorage: fix minor (linting) issues

### DIFF
--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -38,16 +38,6 @@ func NetworkPoll(config *poll.Settings) {
 	}
 }
 
-// ContainerPoll tweaks the pollSettings for `container`
-func ContainerPoll(config *poll.Settings) {
-	// Override the default pollSettings for `container` resource here ...
-
-	if runtime.GOARCH == "arm64" || runtime.GOARCH == "arm" {
-		config.Timeout = 30 * time.Second
-		config.Delay = 100 * time.Millisecond
-	}
-}
-
 // NewSwarm creates a swarm daemon for testing
 func NewSwarm(ctx context.Context, t *testing.T, testEnv *environment.Execution, ops ...daemon.Option) *daemon.Daemon {
 	t.Helper()

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -69,11 +69,11 @@ type ServiceSpecOpt func(*swarmtypes.ServiceSpec)
 func CreateService(ctx context.Context, t *testing.T, d *daemon.Daemon, opts ...ServiceSpecOpt) string {
 	t.Helper()
 
-	client := d.NewClientT(t)
-	defer client.Close()
+	apiClient := d.NewClientT(t)
+	defer apiClient.Close()
 
 	spec := CreateServiceSpec(t, opts...)
-	resp, err := client.ServiceCreate(ctx, spec, types.ServiceCreateOptions{})
+	resp, err := apiClient.ServiceCreate(ctx, spec, types.ServiceCreateOptions{})
 	assert.NilError(t, err, "error creating service")
 	return resp.ID
 }
@@ -223,14 +223,13 @@ func GetRunningTasks(ctx context.Context, t *testing.T, c client.ServiceAPIClien
 // ExecTask runs the passed in exec config on the given task
 func ExecTask(ctx context.Context, t *testing.T, d *daemon.Daemon, task swarmtypes.Task, config types.ExecConfig) types.HijackedResponse {
 	t.Helper()
-	client := d.NewClientT(t)
-	defer client.Close()
+	apiClient := d.NewClientT(t)
+	defer apiClient.Close()
 
-	resp, err := client.ContainerExecCreate(ctx, task.Status.ContainerStatus.ContainerID, config)
+	resp, err := apiClient.ContainerExecCreate(ctx, task.Status.ContainerStatus.ContainerID, config)
 	assert.NilError(t, err, "error creating exec")
 
-	startCheck := types.ExecStartCheck{}
-	attach, err := client.ContainerExecAttach(ctx, resp.ID, startCheck)
+	attach, err := apiClient.ContainerExecAttach(ctx, resp.ID, types.ExecStartCheck{})
 	assert.NilError(t, err, "error attaching to exec")
 	return attach
 }

--- a/testutil/fakestorage/storage.go
+++ b/testutil/fakestorage/storage.go
@@ -39,7 +39,7 @@ func SetTestEnvironment(env *environment.Execution) {
 	testEnv = env
 }
 
-// New returns a static file server that will be use as build context.
+// New returns a static file server that is used as build context.
 func New(t testing.TB, dir string, modifiers ...func(*fakecontext.Fake) error) Fake {
 	t.Helper()
 	if testEnv == nil {
@@ -110,17 +110,17 @@ func (f *remoteFileServer) CtxDir() string {
 func (f *remoteFileServer) Close() error {
 	defer func() {
 		if f.ctx != nil {
-			f.ctx.Close()
+			if err := f.ctx.Close(); err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "Error closing remote file server: closing context: %v\n", err)
+			}
 		}
 		if f.image != "" {
-			if _, err := f.client.ImageRemove(context.Background(), f.image, image.RemoveOptions{
-				Force: true,
-			}); err != nil {
-				fmt.Fprintf(os.Stderr, "Error closing remote file server : %v\n", err)
+			if _, err := f.client.ImageRemove(context.Background(), f.image, image.RemoveOptions{Force: true}); err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "Error closing remote file server: removing image: %v\n", err)
 			}
 		}
 		if err := f.client.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Error closing remote file server : %v\n", err)
+			_, _ = fmt.Fprintf(os.Stderr, "Error closing remote file server: closing client: %v\n", err)
 		}
 	}()
 	if f.container == "" {
@@ -134,7 +134,7 @@ func (f *remoteFileServer) Close() error {
 
 func newRemoteFileServer(t testing.TB, ctx *fakecontext.Fake, c client.APIClient) *remoteFileServer {
 	var (
-		image     = fmt.Sprintf("fileserver-img-%s", strings.ToLower(testutil.GenerateRandomAlphaOnlyString(10)))
+		imgName   = fmt.Sprintf("fileserver-img-%s", strings.ToLower(testutil.GenerateRandomAlphaOnlyString(10)))
 		container = fmt.Sprintf("fileserver-cnt-%s", strings.ToLower(testutil.GenerateRandomAlphaOnlyString(10)))
 	)
 
@@ -147,7 +147,7 @@ COPY . /static`); err != nil {
 	}
 	resp, err := c.ImageBuild(context.Background(), ctx.AsTarReader(t), types.ImageBuildOptions{
 		NoCache: true,
-		Tags:    []string{image},
+		Tags:    []string{imgName},
 	})
 	assert.NilError(t, err)
 	_, err = io.Copy(io.Discard, resp.Body)
@@ -155,7 +155,7 @@ COPY . /static`); err != nil {
 
 	// Start the container
 	b, err := c.ContainerCreate(context.Background(), &containertypes.Config{
-		Image: image,
+		Image: imgName,
 	}, &containertypes.HostConfig{}, nil, nil, container)
 	assert.NilError(t, err)
 	err = c.ContainerStart(context.Background(), b.ID, containertypes.StartOptions{})
@@ -175,7 +175,7 @@ COPY . /static`); err != nil {
 
 	return &remoteFileServer{
 		container: container,
-		image:     image,
+		image:     imgName,
 		host:      fmt.Sprintf("%s:%s", host, port),
 		ctx:       ctx,
 		client:    c,


### PR DESCRIPTION


### integration/internal/swarm: rename vars that collided with imports

- rename the client var to not collide with the imported client package
- remove an intermediate startCheck variable

### integration/internal/swarm: remove unused ContainerPoll

This was added in ee6959addc5664a5c55765f2c721f84414ea4779 (https://github.com/moby/moby/pull/36706) to account for arm (32) requiring a longer timeout at the time, but it was never used.

### testutil/fakestorage: fix minor (linting) issues

- fix typo in comment
- rename variable that collided with an import
- add log for an unhandled error
- slightly improve error-logs



**- A picture of a cute animal (not mandatory but encouraged)**

