### PR TITLE
golangci-lint: alias: always alias github.com/containerd/errdefs module

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,8 @@ linters-settings:
       # own errdefs package (or vice-versa).
       - pkg: github.com/containerd/containerd/errdefs
         alias: cerrdefs
+      - pkg: github.com/containerd/errdefs
+        alias: cerrdefs
       - pkg: github.com/opencontainers/image-spec/specs-go/v1
         alias: ocispec
 


### PR DESCRIPTION
Follow-up to f66374f6a87f8c2d67932d6b0249bae358b70f93 (https://github.com/moby/moby/pull/45300). The containerd errdefs package was moved to a separate module; make sure we check that both the package and the module is using an alias.


**- A picture of a cute animal (not mandatory but encouraged)**

