### PR TITLE
api/server: ContainerList returns container annotations

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -95,6 +95,15 @@ func (s *containerRouter) getContainersJSON(ctx context.Context, w http.Response
 		return err
 	}
 
+	version := httputils.VersionFromContext(ctx)
+
+	if versions.LessThan(version, "1.46") {
+		for _, c := range containers {
+			// Ignore HostConfig.Annotations because it was added in API v1.46.
+			c.HostConfig.Annotations = nil
+		}
+	}
+
 	return httputils.WriteJSON(w, http.StatusOK, containers)
 }
 

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4741,6 +4741,12 @@ definitions:
         properties:
           NetworkMode:
             type: "string"
+          Annotations:
+            description: "Arbitrary key-value metadata attached to container"
+            type: "object"
+            x-nullable: true
+            additionalProperties:
+              type: "string"
       NetworkSettings:
         description: "A summary of the container's network settings"
         type: "object"
@@ -6390,6 +6396,8 @@ paths:
                 SizeRootFs: 0
                 HostConfig:
                   NetworkMode: "default"
+                  Annotations:
+                    io.kubernetes.docker.type: "container"
                 NetworkSettings:
                   Networks:
                     bridge:
@@ -6425,6 +6433,9 @@ paths:
                 SizeRootFs: 0
                 HostConfig:
                   NetworkMode: "default"
+                  Annotations:
+                    io.kubernetes.docker.type: "container"
+                    io.kubernetes.sandbox.id: "3befe639bed0fd6afdd65fd1fa84506756f59360ec4adc270b0fdac9be22b4d3"
                 NetworkSettings:
                   Networks:
                     bridge:
@@ -6453,6 +6464,9 @@ paths:
                 SizeRootFs: 0
                 HostConfig:
                   NetworkMode: "default"
+                  Annotations:
+                    io.kubernetes.image.id: "d74508fb6632491cea586a1fd7d748dfc5274cd6fdfedee309ecdcbc2bf5cb82"
+                    io.kubernetes.image.name: "ubuntu:latest"
                 NetworkSettings:
                   Networks:
                     bridge:
@@ -6481,6 +6495,8 @@ paths:
                 SizeRootFs: 0
                 HostConfig:
                   NetworkMode: "default"
+                  Annotations:
+                    io.kubernetes.config.source: "api"
                 NetworkSettings:
                   Networks:
                     bridge:

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -155,7 +155,8 @@ type Container struct {
 	State      string
 	Status     string
 	HostConfig struct {
-		NetworkMode string `json:",omitempty"`
+		NetworkMode string            `json:",omitempty"`
+		Annotations map[string]string `json:",omitempty"`
 	}
 	NetworkSettings *SummaryNetworkSettings
 	Mounts          []MountPoint

--- a/container/view.go
+++ b/container/view.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -331,6 +332,7 @@ func (v *View) transform(container *Container) *Snapshot {
 
 	if container.HostConfig != nil {
 		snapshot.Container.HostConfig.NetworkMode = string(container.HostConfig.NetworkMode)
+		snapshot.Container.HostConfig.Annotations = maps.Clone(container.HostConfig.Annotations)
 		snapshot.HostConfig.Isolation = string(container.HostConfig.Isolation)
 		for binding := range container.HostConfig.PortBindings {
 			snapshot.PortBindings[binding] = struct{}{}

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -27,6 +27,8 @@ keywords: "API, Docker, rcli, REST, documentation"
   `--sysctl` settings for `eth0` will be migrated to `DriverOpts` when possible. 
   This automatic migration will be removed for API versions 1.47 and greater.
 
+* `GET /containers/json` now returns the annotations of containers.
+
 ## v1.45 API changes
 
 [Docker Engine API v1.45](https://docs.docker.com/engine/api/v1.45/) documentation

--- a/integration/container/list_test.go
+++ b/integration/container/list_test.go
@@ -1,0 +1,50 @@
+package container
+
+import (
+	"fmt"
+	"testing"
+
+	typecontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/testutil/request"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestListAnnotations(t *testing.T) {
+	ctx := setupTest(t)
+
+	annotations := map[string]string{
+		"foo":                       "bar",
+		"io.kubernetes.docker.type": "container",
+	}
+	testcases := []struct {
+		apiVersion          string
+		expectedAnnotations map[string]string
+	}{
+		{apiVersion: "1.44", expectedAnnotations: nil},
+		{apiVersion: "1.46", expectedAnnotations: annotations},
+	}
+
+	for _, tc := range testcases {
+		t.Run(fmt.Sprintf("run with version v%s", tc.apiVersion), func(t *testing.T) {
+			apiClient := request.NewAPIClient(t, client.WithVersion(tc.apiVersion))
+			id := container.Create(ctx, t, apiClient, container.WithAnnotations(annotations))
+			defer container.Remove(ctx, t, apiClient, id, typecontainer.RemoveOptions{Force: true})
+
+			containers, err := apiClient.ContainerList(
+				ctx,
+				typecontainer.ListOptions{
+					All:     true,
+					Filters: filters.NewArgs(filters.Arg("id", id)),
+				},
+			)
+			assert.NilError(t, err)
+			assert.Assert(t, is.Len(containers, 1))
+			assert.Equal(t, containers[0].ID, id)
+			assert.Check(t, is.DeepEqual(containers[0].HostConfig.Annotations, tc.expectedAnnotations))
+		})
+	}
+}

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -283,6 +283,13 @@ func WithConsoleSize(width, height uint) func(*TestContainerConfig) {
 	}
 }
 
+// WithAnnotations set the annotations for the container.
+func WithAnnotations(annotations map[string]string) func(*TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.HostConfig.Annotations = annotations
+	}
+}
+
 // WithRuntime sets the runtime to use to start the container
 func WithRuntime(name string) func(*TestContainerConfig) {
 	return func(c *TestContainerConfig) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

ContainerList api returns the annotations of containers. That allows clients (e.g. cri-dockerd) to fetch container annotations in ContainerList api what is required by k8s:

- https://github.com/kubernetes/cri-api/blob/05e5d94be17c52632e8fd42dcf0de6e045d91a92/pkg/apis/runtime/v1/api.pb.go#L2405

- https://github.com/kubernetes/cri-api/blob/05e5d94be17c52632e8fd42dcf0de6e045d91a92/pkg/apis/runtime/v1/api.pb.go#L5583

**- How I did it**

Add `Annotations` property in `Container.HostConfig` and assign the original annotations of container to it when deep copying.

**- How to verify it**

Integration test.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
ContainerList api returns container annotations.
```

**- A picture of a cute animal (not mandatory but encouraged)**

