### PR TITLE
api: Make EnableIPv6 optional (impl #1 - pointer-based)

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -451,7 +451,7 @@ type NetworkCreate struct {
 	CheckDuplicate bool                     `json:",omitempty"`
 	Driver         string                   // Driver is the driver-name used to create the network (e.g. `bridge`, `overlay`)
 	Scope          string                   // Scope describes the level at which the network exists (e.g. `swarm` for cluster-wide or `local` for machine level).
-	EnableIPv6     bool                     // EnableIPv6 represents whether to enable IPv6.
+	EnableIPv6     *bool                    `json:",omitempty"` // EnableIPv6 represents whether to enable IPv6.
 	IPAM           *network.IPAM            // IPAM is the network's IP Address Management.
 	Internal       bool                     // Internal represents if the network is used internal only.
 	Attachable     bool                     // Attachable represents if the global scope is manually attachable by regular containers from workers in swarm mode.

--- a/client/network_create_test.go
+++ b/client/network_create_test.go
@@ -65,9 +65,10 @@ func TestNetworkCreate(t *testing.T) {
 		}),
 	}
 
+	enableIPv6 := true
 	networkResponse, err := client.NetworkCreate(context.Background(), "mynetwork", types.NetworkCreate{
 		Driver:     "mydriver",
-		EnableIPv6: true,
+		EnableIPv6: &enableIPv6,
 		Internal:   true,
 		Options: map[string]string{
 			"opt-key": "opt-value",

--- a/daemon/cluster/convert/network.go
+++ b/daemon/cluster/convert/network.go
@@ -195,10 +195,12 @@ func BasicNetworkCreateToGRPC(create basictypes.NetworkCreateRequest) swarmapi.N
 			Name:    create.Driver,
 			Options: create.Options,
 		},
-		Ipv6Enabled: create.EnableIPv6,
-		Internal:    create.Internal,
-		Attachable:  create.Attachable,
-		Ingress:     create.Ingress,
+		Internal:   create.Internal,
+		Attachable: create.Attachable,
+		Ingress:    create.Ingress,
+	}
+	if create.EnableIPv6 != nil {
+		ns.Ipv6Enabled = *create.EnableIPv6
 	}
 	if create.IPAM != nil {
 		driver := create.IPAM.Driver

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -621,13 +621,14 @@ func (c *containerConfig) networkCreateRequest(name string) (clustertypes.Networ
 		return clustertypes.NetworkCreateRequest{}, errors.New("container: unknown network referenced")
 	}
 
+	ipv6Enabled := na.Network.Spec.Ipv6Enabled
 	options := types.NetworkCreate{
 		// ID:     na.Network.ID,
 		Labels:     na.Network.Spec.Annotations.Labels,
 		Internal:   na.Network.Spec.Internal,
 		Attachable: na.Network.Spec.Attachable,
 		Ingress:    convert.IsIngressNetwork(na.Network),
-		EnableIPv6: na.Network.Spec.Ipv6Enabled,
+		EnableIPv6: &ipv6Enabled,
 		Scope:      scope.Swarm,
 	}
 

--- a/integration/internal/network/ops.go
+++ b/integration/internal/network/ops.go
@@ -15,7 +15,8 @@ func WithDriver(driver string) func(*types.NetworkCreate) {
 // WithIPv6 Enables IPv6 on the network
 func WithIPv6() func(*types.NetworkCreate) {
 	return func(n *types.NetworkCreate) {
-		n.EnableIPv6 = true
+		enableIPv6 := true
+		n.EnableIPv6 = &enableIPv6
 	}
 }
 

--- a/integration/network/bridge_test.go
+++ b/integration/network/bridge_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types/versions"
 	ctr "github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/integration/internal/network"
+	"github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/skip"
 )
@@ -54,6 +55,34 @@ func TestCreateWithIPv6DefaultsToULAPrefix(t *testing.T) {
 
 	const nwName = "testnetula"
 	network.CreateNoError(ctx, t, apiClient, nwName, network.WithIPv6())
+	defer network.RemoveNoError(ctx, t, apiClient, nwName)
+
+	nw, err := apiClient.NetworkInspect(ctx, "testnetula", networktypes.InspectOptions{})
+	assert.NilError(t, err)
+
+	for _, ipam := range nw.IPAM.Config {
+		ipr := netip.MustParsePrefix(ipam.Subnet)
+		if netip.MustParsePrefix("fd00::/8").Overlaps(ipr) {
+			return
+		}
+	}
+
+	t.Fatalf("Network %s has no ULA prefix, expected one.", nwName)
+}
+
+func TestCreateWithIPv6WithoutEnableIPv6Flag(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows") // d.Start fails on Windows with `protocol not available`
+	ctx := setupTest(t)
+
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t, "-D", "--default-network-opt=bridge=com.docker.network.enable_ipv6=true")
+	defer d.Stop(t)
+
+	apiClient := d.NewClientT(t)
+	defer apiClient.Close()
+
+	const nwName = "testnetula"
+	network.CreateNoError(ctx, t, apiClient, nwName)
 	defer network.RemoveNoError(ctx, t, apiClient, nwName)
 
 	nw, err := apiClient.NetworkInspect(ctx, "testnetula", networktypes.InspectOptions{})


### PR DESCRIPTION
- This is an alternative implementation of https://github.com/moby/moby/pull/47872.
  - This PR uses a bool pointer to make the field `EnableIPv6` optional.
  - #47872 uses a Rust-like `Option` type to make the field optional.

**- What I did**

Currently, starting dockerd with `--default-network-opt=bridge=com.docker.network.enable_ipv6=true` has no effect as `NetworkCreateRequest.EnableIPv6` is a basic bool.

This change makes it a `*bool` to make it optional. If clients don't specify it, the default-network-opt will be applied.

**- How to verify it**

CI -- a new integration test has been added but will fail until #47853 is merged.

**- Description for the changelog**

```markdown changelog
- IPv6 can now be enabled by default on all custom networks using `dockerd --default-network-opt=bridge=com.docker.network.enable_ipv6=true` (and the matching json option).
```

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://www.redfunnel.co.uk/sites/default/files/styles/card/public/images/red-squirrel-spotting-gettyimages-1351743006.jpg?h=e4f440a4&itok=EJgTisQu)