### PR TITLE
[23.0 backport] Fix issue where node promotion could fail

### DIFF
--- a/daemon/cluster/noderunner.go
+++ b/daemon/cluster/noderunner.go
@@ -279,6 +279,19 @@ func (n *nodeRunner) handleNodeExit(node *swarmnode.Node) {
 	close(n.done)
 	select {
 	case <-n.ready:
+		// there is a case where a node can be promoted to manager while
+		// another node is leaving the cluster. the node being promoted, by
+		// random chance, picks the IP of the node being demoted as the one it
+		// tries to connect to. in this case, the promotion will fail, and the
+		// whole swarm Node object packs it in.
+		//
+		// when the Node object is relaunched by this code, because it has
+		// joinAddr in the config, it attempts again to connect to the same
+		// no-longer-manager node, and crashes again. this continues forever.
+		//
+		// to avoid this case, in this block, we remove JoinAddr from the
+		// config.
+		n.config.joinAddr = ""
 		n.enableReconnectWatcher()
 	default:
 		if n.repeatedRun {


### PR DESCRIPTION
* backport #47854 
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
**- What I did**

Fix a minor race condition that could cause a node promotion to fail if it happened right after another node was demoted.

**- How I did it**

If a node is promoted right after another node is demoted, there exists the possibility of a race, by which the newly promoted manager attempts to connect to the newly demoted manager for its initial Raft membership. This connection fails, and the whole swarm Node object exits.

At this point, the daemon nodeRunner sees the exit and restarts the Node.

However, if the address of the no-longer-manager is recorded in the nodeRunner's config.joinAddr, the Node again attempts to connect to the no-longer-manager, and crashes again. This repeats. The workaround is to remove the node entirely and rejoin the Swarm as a new node.

This change erases config.joinAddr from the restart of the nodeRunner, if the node has previously become Ready. The node becoming Ready indicates that at some point, it did successfully join the cluster, in some fashion. If it has successfully joined the cluster, then Swarm has its own persistent record of known manager addresses.

If no joinAddr is provided, then Swarm will choose from its persisted list of managers to join, and will join a functioning manager.

**- How to verify it**

I'm unsure where we would stick an integration test, and the implementation thereof would probably be a nightmare.

To verify manually:

1. Create a cluster with 3 Manager nodes.
2. Add a worker node. This we will call "The Worker". Note which node the IP of the join command will send the worker to. This we will call "The Target"
3. On a node that is *not* The Target, run the command `docker node demote [The Target's node id] && sleep 0.1 && docker node promote [The Worker's node id]`.
4. Without this patch, the promotion will fail. The node will get stuck. With this patch, the promotion will succeed.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
* Fixed an issue where rapidly promoting a node after another node was demoted could cause the promoted node to fail its promotion.
```

