### PR TITLE
api: Make EnableIPv6 optional (impl #2 - Option-based)

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/go-connections/nat"
+	"github.com/moznion/go-optional"
 )
 
 const (
@@ -451,7 +452,7 @@ type NetworkCreate struct {
 	CheckDuplicate bool                     `json:",omitempty"`
 	Driver         string                   // Driver is the driver-name used to create the network (e.g. `bridge`, `overlay`)
 	Scope          string                   // Scope describes the level at which the network exists (e.g. `swarm` for cluster-wide or `local` for machine level).
-	EnableIPv6     bool                     // EnableIPv6 represents whether to enable IPv6.
+	EnableIPv6     optional.Option[bool]    `json:",omitempty"` // EnableIPv6 represents whether to enable IPv6.
 	IPAM           *network.IPAM            // IPAM is the network's IP Address Management.
 	Internal       bool                     // Internal represents if the network is used internal only.
 	Attachable     bool                     // Attachable represents if the global scope is manually attachable by regular containers from workers in swarm mode.

--- a/client/network_create_test.go
+++ b/client/network_create_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/errdefs"
+	"github.com/moznion/go-optional"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -67,7 +68,7 @@ func TestNetworkCreate(t *testing.T) {
 
 	networkResponse, err := client.NetworkCreate(context.Background(), "mynetwork", types.NetworkCreate{
 		Driver:     "mydriver",
-		EnableIPv6: true,
+		EnableIPv6: optional.Some(true),
 		Internal:   true,
 		Options: map[string]string{
 			"opt-key": "opt-value",

--- a/daemon/cluster/convert/network.go
+++ b/daemon/cluster/convert/network.go
@@ -195,7 +195,7 @@ func BasicNetworkCreateToGRPC(create basictypes.NetworkCreateRequest) swarmapi.N
 			Name:    create.Driver,
 			Options: create.Options,
 		},
-		Ipv6Enabled: create.EnableIPv6,
+		Ipv6Enabled: create.EnableIPv6.TakeOr(false),
 		Internal:    create.Internal,
 		Attachable:  create.Attachable,
 		Ingress:     create.Ingress,

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -28,6 +28,7 @@ import (
 	"github.com/moby/swarmkit/v2/api"
 	"github.com/moby/swarmkit/v2/api/genericresource"
 	"github.com/moby/swarmkit/v2/template"
+	"github.com/moznion/go-optional"
 )
 
 const (
@@ -627,7 +628,7 @@ func (c *containerConfig) networkCreateRequest(name string) (clustertypes.Networ
 		Internal:   na.Network.Spec.Internal,
 		Attachable: na.Network.Spec.Attachable,
 		Ingress:    convert.IsIngressNetwork(na.Network),
-		EnableIPv6: na.Network.Spec.Ipv6Enabled,
+		EnableIPv6: optional.Some(na.Network.Spec.Ipv6Enabled),
 		Scope:      scope.Swarm,
 	}
 

--- a/integration/internal/network/ops.go
+++ b/integration/internal/network/ops.go
@@ -3,6 +3,7 @@ package network
 import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
+	"github.com/moznion/go-optional"
 )
 
 // WithDriver sets the driver of the network
@@ -15,7 +16,7 @@ func WithDriver(driver string) func(*types.NetworkCreate) {
 // WithIPv6 Enables IPv6 on the network
 func WithIPv6() func(*types.NetworkCreate) {
 	return func(n *types.NetworkCreate) {
-		n.EnableIPv6 = true
+		n.EnableIPv6 = optional.Some(true)
 	}
 }
 

--- a/integration/network/bridge_test.go
+++ b/integration/network/bridge_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types/versions"
 	ctr "github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/integration/internal/network"
+	"github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/skip"
 )
@@ -54,6 +55,35 @@ func TestCreateWithIPv6DefaultsToULAPrefix(t *testing.T) {
 
 	const nwName = "testnetula"
 	network.CreateNoError(ctx, t, apiClient, nwName, network.WithIPv6())
+	defer network.RemoveNoError(ctx, t, apiClient, nwName)
+
+	nw, err := apiClient.NetworkInspect(ctx, "testnetula", networktypes.InspectOptions{})
+	assert.NilError(t, err)
+
+	for _, ipam := range nw.IPAM.Config {
+		ipr := netip.MustParsePrefix(ipam.Subnet)
+		if netip.MustParsePrefix("fd00::/8").Overlaps(ipr) {
+			return
+		}
+	}
+
+	t.Fatalf("Network %s has no ULA prefix, expected one.", nwName)
+}
+
+func TestCreateWithIPv6WithoutEnableIPv6Flag(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows") // d.Start fails on Windows with `protocol not available`
+
+	ctx := setupTest(t)
+
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t, "-D", "--default-network-opt=bridge=com.docker.network.enable_ipv6=true")
+	defer d.Stop(t)
+
+	apiClient := d.NewClientT(t)
+	defer apiClient.Close()
+
+	const nwName = "testnetula"
+	network.CreateNoError(ctx, t, apiClient, nwName)
 	defer network.RemoveNoError(ctx, t, apiClient, nwName)
 
 	nw, err := apiClient.NetworkInspect(ctx, "testnetula", networktypes.InspectOptions{})

--- a/vendor.mod
+++ b/vendor.mod
@@ -75,6 +75,7 @@ require (
 	github.com/moby/sys/user v0.1.0
 	github.com/moby/term v0.5.0
 	github.com/morikuni/aec v1.0.0
+	github.com/moznion/go-optional v0.11.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/opencontainers/runc v1.1.12

--- a/vendor.sum
+++ b/vendor.sum
@@ -453,6 +453,8 @@ github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/mattn/go-sqlite3 v1.14.17 h1:mCRHCLDUBXgpKAqIKsaAaAsrAlbkeomtRFKXh2L6YIM=
+github.com/mattn/go-sqlite3 v1.14.17/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
@@ -513,6 +515,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
+github.com/moznion/go-optional v0.11.0 h1:5UcbqhXo0P34gcVlQ5IwYcqW6t8rCyxOfVWS+9zCpc8=
+github.com/moznion/go-optional v0.11.0/go.mod h1:VLENS2WxeppZH4cTCQswYCznMRtFDXfaBjAKbmuz6s0=
 github.com/mreiferson/go-httpclient v0.0.0-20160630210159-31f0106b4474/go.mod h1:OQA4XLvDbMgS8P0CevmM4m9Q3Jq4phKUzcocxuGJ5m8=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/vendor/github.com/moznion/go-optional/.gitignore
+++ b/vendor/github.com/moznion/go-optional/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+/coverage.txt

--- a/vendor/github.com/moznion/go-optional/LICENSE
+++ b/vendor/github.com/moznion/go-optional/LICENSE
@@ -1,0 +1,8 @@
+Copyright 2021 Taiki Kawakami (a.k.a. moznion) https://moznion.net
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/vendor/github.com/moznion/go-optional/Makefile
+++ b/vendor/github.com/moznion/go-optional/Makefile
@@ -1,0 +1,19 @@
+.PHONY: check ci-check test fmt fmt-check lint
+
+check: fmt-check lint test
+ci-check: fmt-check test
+
+test:
+	go test ./... -race -v -coverprofile="coverage.txt" -covermode=atomic
+
+fmt:
+	gofmt -w -s *.go && goimports -w *.go
+
+fmt-check:
+	goimports -l *.go | grep [^*][.]go$$; \
+		EXIT_CODE=$$?; \
+		if [ $$EXIT_CODE -eq 0 ]; then exit 1; fi \
+
+lint:
+	golangci-lint run ./...
+

--- a/vendor/github.com/moznion/go-optional/README.md
+++ b/vendor/github.com/moznion/go-optional/README.md
@@ -1,0 +1,213 @@
+# go-optional [![.github/workflows/check.yml](https://github.com/moznion/go-optional/actions/workflows/check.yml/badge.svg)](https://github.com/moznion/go-optional/actions/workflows/check.yml) [![codecov](https://codecov.io/gh/moznion/go-optional/branch/main/graph/badge.svg?token=0HCVy6COy4)](https://codecov.io/gh/moznion/go-optional) [![GoDoc](https://godoc.org/github.com/moznion/go-optional?status.svg)](https://godoc.org/github.com/moznion/go-optional)
+
+A library that provides [Go Generics](https://go.dev/blog/generics-proposal) friendly "optional" features.
+
+## Synopsis
+
+```go
+some := optional.Some[int](123)
+fmt.Printf("%v\n", some.IsSome()) // => true
+fmt.Printf("%v\n", some.IsNone()) // => false
+
+v, err := some.Take()
+fmt.Printf("err is nil: %v\n", err == nil) // => err is nil: true
+fmt.Printf("%d\n", v) // => 123
+
+mapped := optional.Map(some, func (v int) int {
+    return v * 2
+})
+fmt.Printf("%v\n", mapped.IsSome()) // => true
+
+mappedValue, _ := some.Take()
+fmt.Printf("%d\n", mappedValue) // => 246
+```
+
+```go
+none := optional.None[int]()
+fmt.Printf("%v\n", none.IsSome()) // => false
+fmt.Printf("%v\n", none.IsNone()) // => true
+
+_, err := none.Take()
+fmt.Printf("err is nil: %v\n", err == nil) // => err is nil: false
+// the error must be `ErrNoneValueTaken`
+
+mapped := optional.Map(none, func (v int) int {
+    return v * 2
+})
+fmt.Printf("%v\n", mapped.IsNone()) // => true
+```
+
+and more detailed examples are here: [./examples_test.go](./examples_test.go).
+
+## Docs
+
+[![GoDoc](https://godoc.org/github.com/moznion/go-optional?status.svg)](https://godoc.org/github.com/moznion/go-optional)
+
+### Supported Operations
+
+#### Value Factory Methods
+
+- [Some[T]\() Option[T]](https://pkg.go.dev/github.com/moznion/go-optional#Some)
+- [None[T]\() Option[T]](https://pkg.go.dev/github.com/moznion/go-optional#None)
+- [FromNillable[T]\() Option[T]](https://pkg.go.dev/github.com/moznion/go-optional#FromNillable)
+- [PtrFromNillable[T]\() Option[T]](https://pkg.go.dev/github.com/moznion/go-optional#PtrFromNillable)
+
+#### Option value handler methods
+
+- [Option[T]#IsNone() bool](https://pkg.go.dev/github.com/moznion/go-optional#Option.IsNone)
+- [Option[T]#IsSome() bool](https://pkg.go.dev/github.com/moznion/go-optional#Option.IsSome)
+- [Option[T]#Unwrap() T](https://pkg.go.dev/github.com/moznion/go-optional#Option.Unwrap)
+- [Option[T]#UnwrapAsPtr() T](https://pkg.go.dev/github.com/moznion/go-optional#Option.UnwrapAsPtr)
+- [Option[T]#Take() (T, error)](https://pkg.go.dev/github.com/moznion/go-optional#Option.Take)
+- [Option[T]#TakeOr(fallbackValue T) T](https://pkg.go.dev/github.com/moznion/go-optional#Option.TakeOr)
+- [Option[T]#TakeOrElse(fallbackFunc func() T) T](https://pkg.go.dev/github.com/moznion/go-optional#Option.TakeOrElse)
+- [Option[T]#Or(fallbackOptionValue Option[T]) Option[T]](https://pkg.go.dev/github.com/moznion/go-optional#Option.Or)
+- [Option[T]#OrElse(fallbackOptionFunc func() Option[T]) Option[T]](https://pkg.go.dev/github.com/moznion/go-optional#Option.OrElse)
+- [Option[T]#Filter(predicate func(v T) bool) Option[T]](https://pkg.go.dev/github.com/moznion/go-optional#Option.Filter)
+- [Option[T]#IfSome(f func(v T))](https://pkg.go.dev/github.com/moznion/go-optional#Option.IfSome)
+- [Option[T]#IfSomeWithError(f func(v T) error) error](https://pkg.go.dev/github.com/moznion/go-optional#Option.IfSomeWithError)
+- [Option[T]#IfNone(f func())](https://pkg.go.dev/github.com/moznion/go-optional#Option.IfNone)
+- [Option[T]#IfNoneWithError(f func() error) error](https://pkg.go.dev/github.com/moznion/go-optional#Option.IfNoneWithError)
+- [Option.Map[T, U any](option Option[T], mapper func(v T) U) Option[U]](https://pkg.go.dev/github.com/moznion/go-optional#Map)
+- [Option.MapOr[T, U any](option Option[T], fallbackValue U, mapper func(v T) U) U](https://pkg.go.dev/github.com/moznion/go-optional#MapOr)
+- [Option.MapWithError[T, U any](option Option[T], mapper func(v T) (U, error)) (Option[U], error)](https://pkg.go.dev/github.com/moznion/go-optional#MapWithError)
+- [Option.MapOrWithError[T, U any](option Option[T], fallbackValue U, mapper func(v T) (U, error)) (U, error)](https://pkg.go.dev/github.com/moznion/go-optional#MapOrWithError)
+- [Option.FlatMap[T, U any](option Option[T], mapper func(v T) Option[U]) Option[U]](https://pkg.go.dev/github.com/moznion/go-optional#FlatMap)
+- [Option.FlatMapOr[T, U any](option Option[T], fallbackValue U, mapper func(v T) Option[U]) U](https://pkg.go.dev/github.com/moznion/go-optional#FlatMapOr)
+- [Option.FlatMapWithError[T, U any](option Option[T], mapper func(v T) (Option[U], error)) (Option[U], error)](https://pkg.go.dev/github.com/moznion/go-optional#FlatMapWithError)
+- [Option.FlatMapOrWithError[T, U any](option Option[T], fallbackValue U, mapper func(v T) (Option[U], error)) (U, error)](https://pkg.go.dev/github.com/moznion/go-optional#FlatMapOrWithError)
+- [Option.Zip[T, U any](opt1 Option[T], opt2 Option[U]) Option[Pair[T, U]]](https://pkg.go.dev/github.com/moznion/go-optional#Zip)
+- [Option.ZipWith[T, U, V any](opt1 Option[T], opt2 Option[U], zipper func(opt1 T, opt2 U) V) Option[V]](https://pkg.go.dev/github.com/moznion/go-optional#ZipWith)
+- [Option.Unzip[T, U any](zipped Option[Pair[T, U]]) (Option[T], Option[U])](https://pkg.go.dev/github.com/moznion/go-optional#Unzip)
+- [Option.UnzipWith[T, U, V any](zipped Option[V], unzipper func(zipped V) (T, U)) (Option[T], Option[U])](https://pkg.go.dev/github.com/moznion/go-optional#UnzipWith)
+
+### nil == None[T]
+
+This library deals with `nil` as same as `None[T]`. So it works with like the following example:
+
+```go
+var nilValue Option[int] = nil
+fmt.Printf("%v\n", nilValue.IsNone()) // => true
+fmt.Printf("%v\n", nilValue.IsSome()) // => false
+```
+
+### JSON marshal/unmarshal support
+
+This `Option[T]` type supports JSON marshal and unmarshal.
+
+If the value wanted to marshal is `Some[T]` then it marshals that value into the JSON bytes simply, and in unmarshaling, if the given JSON string/bytes has the actual value on corresponded property, it unmarshals that value into `Some[T]` value.
+
+example:
+
+```go
+type JSONStruct struct {
+	Val Option[int] `json:"val"`
+}
+
+some := Some[int](123)
+jsonStruct := &JSONStruct{Val: some}
+
+marshal, err := json.Marshal(jsonStruct)
+if err != nil {
+	return err
+}
+fmt.Printf("%s\n", marshal) // => {"val":123}
+
+var unmarshalJSONStruct JSONStruct
+err = json.Unmarshal(marshal, &unmarshalJSONStruct)
+if err != nil {
+	return err
+}
+// unmarshalJSONStruct.Val == Some[int](123)
+```
+
+Elsewise, when the value is `None[T]`, the marshaller serializes that value as `null`. And if the unmarshaller gets the JSON `null` value on a property corresponding to the `Optional[T]` value, or the value of a property is missing, that deserializes that value as `None[T]`.
+
+example:
+
+```go
+type JSONStruct struct {
+	Val Option[int] `json:"val"`
+}
+
+none := None[int]()
+jsonStruct := &JSONStruct{Val: none}
+
+marshal, err := json.Marshal(jsonStruct)
+if err != nil {
+	return err
+}
+fmt.Printf("%s\n", marshal) // => {"val":null}
+
+var unmarshalJSONStruct JSONStruct
+err = json.Unmarshal(marshal, &unmarshalJSONStruct)
+if err != nil {
+	return err
+}
+// unmarshalJSONStruct.Val == None[int]()
+```
+
+And this also supports `omitempty` option for JSON unmarshaling. If the value of the property is `None[T]` and that property has `omitempty` option, it omits that property.
+
+ref:
+
+> The "omitempty" option specifies that the field should be omitted from the encoding if the field has an empty value, defined as false, 0, a nil pointer, a nil interface value, and any empty array, slice, map, or string.
+> https://pkg.go.dev/encoding/json#Marshal
+
+example:
+
+```go
+type JSONStruct struct {
+	OmitemptyVal Option[string] `json:"omitemptyVal,omitempty"` // this should be omitted
+}
+
+jsonStruct := &JSONStruct{OmitemptyVal: None[string]()}
+marshal, err := json.Marshal(jsonStruct)
+if err != nil {
+	return err
+}
+fmt.Printf("%s\n", marshal) // => {}
+```
+
+### SQL Driver Support
+
+`Option[T]` satisfies [sql/driver.Valuer](https://pkg.go.dev/database/sql/driver#Valuer) and [sql.Scanner](https://pkg.go.dev/database/sql#Scanner), so this type can be used by SQL interface on Golang.
+
+example of the primitive usage:
+
+```go
+sqlStmt := "CREATE TABLE tbl (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(32));"
+db.Exec(sqlStmt)
+
+tx, _ := db.Begin()
+func() {
+    stmt, _ := tx.Prepare("INSERT INTO tbl(id, name) values(?, ?)")
+    defer stmt.Close()
+    stmt.Exec(1, "foo")
+}()
+func() {
+    stmt, _ := tx.Prepare("INSERT INTO tbl(id) values(?)")
+    defer stmt.Close()
+    stmt.Exec(2) // name is NULL
+}()
+tx.Commit()
+
+var maybeName Option[string]
+
+row := db.QueryRow("SELECT name FROM tbl WHERE id = 1")
+row.Scan(&maybeName)
+fmt.Println(maybeName) // Some[foo]
+
+row := db.QueryRow("SELECT name FROM tbl WHERE id = 2")
+row.Scan(&maybeName)
+fmt.Println(maybeName) // None[]
+```
+
+## Known Issues
+
+The runtime raises a compile error like "methods cannot have type parameters", so `Map()`, `MapOr()`, `MapWithError()`, `MapOrWithError()`, `Zip()`, `ZipWith()`, `Unzip()` and `UnzipWith()` have been providing as functions. Basically, it would be better to provide them as the methods, but currently, it compromises with the limitation.
+
+## Author
+
+moznion (<moznion@mail.moznion.net>)
+

--- a/vendor/github.com/moznion/go-optional/option.go
+++ b/vendor/github.com/moznion/go-optional/option.go
@@ -1,0 +1,367 @@
+package optional
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrNoneValueTaken represents the error that is raised when None value is taken.
+	ErrNoneValueTaken = errors.New("none value taken")
+)
+
+// Option is a data type that must be Some (i.e. having a value) or None (i.e. doesn't have a value).
+// This type implements database/sql/driver.Valuer and database/sql.Scanner.
+type Option[T any] []T
+
+const (
+	value = iota
+)
+
+// Some is a function to make an Option type value with the actual value.
+func Some[T any](v T) Option[T] {
+	return Option[T]{
+		value: v,
+	}
+}
+
+// None is a function to make an Option type value that doesn't have a value.
+func None[T any]() Option[T] {
+	return nil
+}
+
+// FromNillable is a function to make an Option type value with the nillable value with value de-referencing.
+// If the given value is not nil, this returns Some[T] value. On the other hand, if the value is nil, this returns None[T].
+// This function does "dereference" for the value on packing that into Option value. If this value is not preferable, please consider using PtrFromNillable() instead.
+func FromNillable[T any](v *T) Option[T] {
+	if v == nil {
+		return None[T]()
+	}
+	return Some[T](*v)
+}
+
+// PtrFromNillable is a function to make an Option type value with the nillable value without value de-referencing.
+// If the given value is not nil, this returns Some[*T] value. On the other hand, if the value is nil, this returns None[*T].
+// This function doesn't "dereference" the value on packing that into the Option value; in other words, this puts the as-is pointer value into the Option envelope.
+// This behavior contrasts with the FromNillable() function's one.
+func PtrFromNillable[T any](v *T) Option[*T] {
+	if v == nil {
+		return None[*T]()
+	}
+	return Some[*T](v)
+}
+
+// IsNone returns whether the Option *doesn't* have a value or not.
+func (o Option[T]) IsNone() bool {
+	return o == nil
+}
+
+// IsSome returns whether the Option has a value or not.
+func (o Option[T]) IsSome() bool {
+	return o != nil
+}
+
+// Unwrap returns the value regardless of Some/None status.
+// If the Option value is Some, this method returns the actual value.
+// On the other hand, if the Option value is None, this method returns the *default* value according to the type.
+func (o Option[T]) Unwrap() T {
+	if o.IsNone() {
+		var defaultValue T
+		return defaultValue
+	}
+	return o[value]
+}
+
+// UnwrapAsPtr returns the contained value in receiver Option as a pointer.
+// This is similar to `Unwrap()` method but the difference is this method returns a pointer value instead of the actual value.
+// If the receiver Option value is None, this method returns nil.
+func (o Option[T]) UnwrapAsPtr() *T {
+	if o.IsNone() {
+		return nil
+	}
+	return &o[value]
+}
+
+// Take takes the contained value in Option.
+// If Option value is Some, this returns the value that is contained in Option.
+// On the other hand, this returns an ErrNoneValueTaken as the second return value.
+func (o Option[T]) Take() (T, error) {
+	if o.IsNone() {
+		var defaultValue T
+		return defaultValue, ErrNoneValueTaken
+	}
+	return o[value], nil
+}
+
+// TakeOr returns the actual value if the Option has a value.
+// On the other hand, this returns fallbackValue.
+func (o Option[T]) TakeOr(fallbackValue T) T {
+	if o.IsNone() {
+		return fallbackValue
+	}
+	return o[value]
+}
+
+// TakeOrElse returns the actual value if the Option has a value.
+// On the other hand, this executes fallbackFunc and returns the result value of that function.
+func (o Option[T]) TakeOrElse(fallbackFunc func() T) T {
+	if o.IsNone() {
+		return fallbackFunc()
+	}
+	return o[value]
+}
+
+// Or returns the Option value according to the actual value existence.
+// If the receiver's Option value is Some, this function pass-through that to return. Otherwise, this value returns the `fallbackOptionValue`.
+func (o Option[T]) Or(fallbackOptionValue Option[T]) Option[T] {
+	if o.IsNone() {
+		return fallbackOptionValue
+	}
+	return o
+}
+
+// OrElse returns the Option value according to the actual value existence.
+// If the receiver's Option value is Some, this function pass-through that to return. Otherwise, this executes `fallbackOptionFunc` and returns the result value of that function.
+func (o Option[T]) OrElse(fallbackOptionFunc func() Option[T]) Option[T] {
+	if o.IsNone() {
+		return fallbackOptionFunc()
+	}
+	return o
+}
+
+// Filter returns self if the Option has a value and the value matches the condition of the predicate function.
+// In other cases (i.e. it doesn't match with the predicate or the Option is None), this returns None value.
+func (o Option[T]) Filter(predicate func(v T) bool) Option[T] {
+	if o.IsNone() || !predicate(o[value]) {
+		return None[T]()
+	}
+	return o
+}
+
+// IfSome calls given function with the value of Option if the receiver value is Some.
+func (o Option[T]) IfSome(f func(v T)) {
+	if o.IsNone() {
+		return
+	}
+	f(o[value])
+}
+
+// IfSomeWithError calls given function with the value of Option if the receiver value is Some.
+// This method propagates the error of given function, and if the receiver value is None, this returns nil error.
+func (o Option[T]) IfSomeWithError(f func(v T) error) error {
+	if o.IsNone() {
+		return nil
+	}
+	return f(o[value])
+}
+
+// IfNone calls given function if the receiver value is None.
+func (o Option[T]) IfNone(f func()) {
+	if o.IsSome() {
+		return
+	}
+	f()
+}
+
+// IfNoneWithError calls given function if the receiver value is None.
+// This method propagates the error of given function, and if the receiver value is Some, this returns nil error.
+func (o Option[T]) IfNoneWithError(f func() error) error {
+	if o.IsSome() {
+		return nil
+	}
+	return f()
+}
+
+func (o Option[T]) String() string {
+	if o.IsNone() {
+		return "None[]"
+	}
+
+	v := o.Unwrap()
+	if stringer, ok := interface{}(v).(fmt.Stringer); ok {
+		return fmt.Sprintf("Some[%s]", stringer)
+	}
+	return fmt.Sprintf("Some[%v]", v)
+}
+
+// Map converts given Option value to another Option value according to the mapper function.
+// If given Option value is None, this also returns None.
+func Map[T, U any](option Option[T], mapper func(v T) U) Option[U] {
+	if option.IsNone() {
+		return None[U]()
+	}
+
+	return Some(mapper(option[value]))
+}
+
+// MapOr converts given Option value to another *actual* value according to the mapper function.
+// If given Option value is None, this returns fallbackValue.
+func MapOr[T, U any](option Option[T], fallbackValue U, mapper func(v T) U) U {
+	if option.IsNone() {
+		return fallbackValue
+	}
+	return mapper(option[value])
+}
+
+// MapWithError converts given Option value to another Option value according to the mapper function that has the ability to return the value with an error.
+// If given Option value is None, this returns (None, nil). Else if the mapper returns an error then this returns (None, error).
+// Unless of them, i.e. given Option value is Some and the mapper doesn't return the error, this returns (Some[U], nil).
+func MapWithError[T, U any](option Option[T], mapper func(v T) (U, error)) (Option[U], error) {
+	if option.IsNone() {
+		return None[U](), nil
+	}
+
+	u, err := mapper(option[value])
+	if err != nil {
+		return None[U](), err
+	}
+	return Some(u), nil
+}
+
+// MapOrWithError converts given Option value to another *actual* value according to the mapper function that has the ability to return the value with an error.
+// If given Option value is None, this returns (fallbackValue, nil). Else if the mapper returns an error then returns (_, error).
+// Unless of them, i.e. given Option value is Some and the mapper doesn't return the error, this returns (U, nil).
+func MapOrWithError[T, U any](option Option[T], fallbackValue U, mapper func(v T) (U, error)) (U, error) {
+	if option.IsNone() {
+		return fallbackValue, nil
+	}
+	return mapper(option[value])
+}
+
+// FlatMap converts give Option value to another Option value according to the mapper function.
+// The difference from the Map is the mapper function returns an Option value instead of the bare value.
+// If given Option value is None, this also returns None.
+func FlatMap[T, U any](option Option[T], mapper func(v T) Option[U]) Option[U] {
+	if option.IsNone() {
+		return None[U]()
+	}
+
+	return mapper(option[value])
+}
+
+// FlatMapOr converts given Option value to another *actual* value according to the mapper function.
+// The difference from the MapOr is the mapper function returns an Option value instead of the bare value.
+// If given Option value is None or mapper function returns None, this returns fallbackValue.
+func FlatMapOr[T, U any](option Option[T], fallbackValue U, mapper func(v T) Option[U]) U {
+	if option.IsNone() {
+		return fallbackValue
+	}
+
+	return (mapper(option[value])).TakeOr(fallbackValue)
+}
+
+// FlatMapWithError converts given Option value to another Option value according to the mapper function that has the ability to return the value with an error.
+// The difference from the MapWithError is the mapper function returns an Option value instead of the bare value.
+// If given Option value is None, this returns (None, nil). Else if the mapper returns an error then this returns (None, error).
+// Unless of them, i.e. given Option value is Some and the mapper doesn't return the error, this returns (Some[U], nil).
+func FlatMapWithError[T, U any](option Option[T], mapper func(v T) (Option[U], error)) (Option[U], error) {
+	if option.IsNone() {
+		return None[U](), nil
+	}
+
+	mapped, err := mapper(option[value])
+	if err != nil {
+		return None[U](), err
+	}
+	return mapped, nil
+}
+
+// FlatMapOrWithError converts given Option value to another *actual* value according to the mapper function that has the ability to return the value with an error.
+// The difference from the MapOrWithError is the mapper function returns an Option value instead of the bare value.
+// If given Option value is None, this returns (fallbackValue, nil). Else if the mapper returns an error then returns ($zero_value_of_type, error).
+// Unless of them, i.e. given Option value is Some and the mapper doesn't return the error, this returns (U, nil).
+func FlatMapOrWithError[T, U any](option Option[T], fallbackValue U, mapper func(v T) (Option[U], error)) (U, error) {
+	if option.IsNone() {
+		return fallbackValue, nil
+	}
+
+	maybe, err := mapper(option[value])
+	if err != nil {
+		var zeroValue U
+		return zeroValue, err
+	}
+
+	return maybe.TakeOr(fallbackValue), nil
+}
+
+// Pair is a data type that represents a tuple that has two elements.
+type Pair[T, U any] struct {
+	Value1 T
+	Value2 U
+}
+
+// Zip zips two Options into a Pair that has each Option's value.
+// If either one of the Options is None, this also returns None.
+func Zip[T, U any](opt1 Option[T], opt2 Option[U]) Option[Pair[T, U]] {
+	if opt1.IsSome() && opt2.IsSome() {
+		return Some(Pair[T, U]{
+			Value1: opt1[value],
+			Value2: opt2[value],
+		})
+	}
+
+	return None[Pair[T, U]]()
+}
+
+// ZipWith zips two Options into a typed value according to the zipper function.
+// If either one of the Options is None, this also returns None.
+func ZipWith[T, U, V any](opt1 Option[T], opt2 Option[U], zipper func(opt1 T, opt2 U) V) Option[V] {
+	if opt1.IsSome() && opt2.IsSome() {
+		return Some(zipper(opt1[value], opt2[value]))
+	}
+	return None[V]()
+}
+
+// Unzip extracts the values from a Pair and pack them into each Option value.
+// If the given zipped value is None, this returns None for all return values.
+func Unzip[T, U any](zipped Option[Pair[T, U]]) (Option[T], Option[U]) {
+	if zipped.IsNone() {
+		return None[T](), None[U]()
+	}
+
+	pair := zipped[value]
+	return Some(pair.Value1), Some(pair.Value2)
+}
+
+// UnzipWith extracts the values from the given value according to the unzipper function and pack the into each Option value.
+// If the given zipped value is None, this returns None for all return values.
+func UnzipWith[T, U, V any](zipped Option[V], unzipper func(zipped V) (T, U)) (Option[T], Option[U]) {
+	if zipped.IsNone() {
+		return None[T](), None[U]()
+	}
+
+	v1, v2 := unzipper(zipped[value])
+	return Some(v1), Some(v2)
+}
+
+var jsonNull = []byte("null")
+
+func (o Option[T]) MarshalJSON() ([]byte, error) {
+	if o.IsNone() {
+		return jsonNull, nil
+	}
+
+	marshal, err := json.Marshal(o.Unwrap())
+	if err != nil {
+		return nil, err
+	}
+	return marshal, nil
+}
+
+func (o *Option[T]) UnmarshalJSON(data []byte) error {
+	if len(data) <= 0 || bytes.Equal(data, jsonNull) {
+		*o = None[T]()
+		return nil
+	}
+
+	var v T
+	err := json.Unmarshal(data, &v)
+	if err != nil {
+		return err
+	}
+	*o = Some(v)
+
+	return nil
+}

--- a/vendor/github.com/moznion/go-optional/renovate.json
+++ b/vendor/github.com/moznion/go-optional/renovate.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "config:base"
+  ]
+}

--- a/vendor/github.com/moznion/go-optional/sql_driver.go
+++ b/vendor/github.com/moznion/go-optional/sql_driver.go
@@ -1,0 +1,46 @@
+package optional
+
+import (
+	"database/sql/driver"
+	"errors"
+	"time"
+)
+
+var (
+	ErrSQLScannerIncompatibleDataType      = errors.New("incompatible data type for SQL scanner on Option[T]")
+	ErrSQLDriverValuerIncompatibleDataType = errors.New("incompatible data type for SQL driver Valuer on Option[T]")
+)
+
+// Scan assigns a value from a database driver.
+// This method is required from database/sql.Scanner interface.
+func (o *Option[T]) Scan(src any) error {
+	if src == nil {
+		*o = None[T]()
+		return nil
+	}
+
+	switch src.(type) {
+	case string, []byte, int64, float64, bool, time.Time:
+		*o = Some[T](src.(T))
+	default:
+		return ErrSQLScannerIncompatibleDataType
+	}
+
+	return nil
+}
+
+// Value returns a driver Value.
+// This method is required from database/sql/driver.Valuer interface.
+func (o Option[T]) Value() (driver.Value, error) {
+	if o.IsNone() {
+		return nil, nil
+	}
+
+	v := o.Unwrap()
+	switch (interface{})(v).(type) {
+	case string, []byte, int64, float64, bool, time.Time:
+		return v, nil
+	default:
+		return nil, ErrSQLDriverValuerIncompatibleDataType
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -977,6 +977,9 @@ github.com/moby/term/windows
 # github.com/morikuni/aec v1.0.0
 ## explicit
 github.com/morikuni/aec
+# github.com/moznion/go-optional v0.11.0
+## explicit; go 1.19
+github.com/moznion/go-optional
 # github.com/opencontainers/go-digest v1.0.0
 ## explicit; go 1.13
 github.com/opencontainers/go-digest


### PR DESCRIPTION
- This is an alternative implementation of https://github.com/moby/moby/pull/47867.
  - #47867 uses a bool pointer to make the field `EnableIPv6` optional.
  - This PR uses a Rust-like `Option` type to make the field optional.

**- What I did**

Currently, starting dockerd with `--default-network-opt=bridge=com.docker.network.enable_ipv6=true` has no effect as `NetworkCreateRequest.EnableIPv6` is a basic bool.

This change uses a Rust-like `Option` type to mark the field as optional. If clients don't specify it, the default-network-opt will be applied if it's specified, otherwise it defaults to false.

**- How to verify it**

CI -- a new integration test has been added but will fail until https://github.com/moby/moby/pull/47853 is merged.

**- Description for the changelog**

```markdown changelog
- IPv6 can now be enabled by default on all custom networks using `dockerd --default-network-opt=bridge=com.docker.network.enable_ipv6=true` (and the matching json option).
```

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://camo.githubusercontent.com/b084f2b5b064659ed8f2f69d8a1dcdef6bbcd28facede620175b50ab26d1afae/68747470733a2f2f7777772e72656466756e6e656c2e636f2e756b2f73697465732f64656661756c742f66696c65732f7374796c65732f636172642f7075626c69632f696d616765732f7265642d737175697272656c2d73706f7474696e672d6765747479696d616765732d313335313734333030362e6a70673f683d65346634343061342669746f6b3d454a675469735175)