### PR TITLE
Fix update memory without memoryswap

### DIFF
--- a/daemon/container/container_unix.go
+++ b/daemon/container/container_unix.go
@@ -292,7 +292,12 @@ func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfi
 		// if memory limit smaller than already set memoryswap limit and doesn't
 		// update the memoryswap limit, then error out.
 		if resources.Memory > cResources.MemorySwap && resources.MemorySwap == 0 {
-			return conflictingUpdateOptions("Memory limit should be smaller than already set memoryswap limit, update the memoryswap at the same time")
+			switch {
+			case cResources.MemorySwap == 0:
+				resources.MemorySwap = resources.Memory * 2
+			case cResources.MemorySwap != -1:
+				return conflictingUpdateOptions("Memory limit should be smaller than already set memoryswap limit, update the memoryswap at the same time")
+			}
 		}
 		cResources.Memory = resources.Memory
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
An attempt to update memory without memoryswap on a UNIX container that has no previous memoryswap setup would cause a confusing warning says
  Memory limit should be smaller than already set memoryswap limit

This commit fixes support for both situations of setting memory constraints:
* specify memory without memory-swap, while the latter one defaults to 0
* specify memory without memory-swap, while the latter one was set to -1

**- How I did it**
Made an additional check for the previous value of the memory-swap limit, to stop sending users confusing warnings.

**- How to verify it**
Refer to:
https://github.com/docker/cli/blob/8ed44f916fa908a04f03f69369bc2a16e0db7cc9/docs/reference/run.md#user-memory-constraints

```shell
docker run --name pause -d registry.k8s.io/pause:latest
docker update -m 10M pause
# Memory should be 10M, and MemorySwap should be 20M
docker inspect pause | grep -F Memory

# This change should be declined
docker update -m 100M pause


docker rm -f pause
docker run --name pause -d registry.k8s.io/pause:latest
docker update --memory-swap -1 pause
docker update -m 10M pause
# Memory should be 10M, and MemorySwap should be -1
docker inspect pause | grep -F Memory
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix update memory without memoryswap
```

**- A picture of a cute animal (not mandatory but encouraged)**
![](https://pbs.twimg.com/media/GOvJKEYbMAARdEz?format=jpg&name=medium)
