### PR TITLE
client: minor cleanup, linting- and bug-fixes

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -184,10 +184,10 @@ func (cli *Client) doRequest(req *http.Request) (serverResponse, error) {
 		// `open //./pipe/docker_engine: Le fichier spécifié est introuvable.`
 		if strings.Contains(err.Error(), `open //./pipe/docker_engine`) {
 			// Checks if client is running with elevated privileges
-			if f, elevatedErr := os.Open("\\\\.\\PHYSICALDRIVE0"); elevatedErr == nil {
+			if f, elevatedErr := os.Open(`\\.\PHYSICALDRIVE0`); elevatedErr != nil {
 				err = errors.Wrap(err, "in the default daemon configuration on Windows, the docker client must be run with elevated privileges to connect")
 			} else {
-				f.Close()
+				_ = f.Close()
 				err = errors.Wrap(err, "this error may indicate that the docker daemon is not running")
 			}
 		}

--- a/client/request.go
+++ b/client/request.go
@@ -278,7 +278,7 @@ func encodeData(data interface{}) (*bytes.Buffer, error) {
 func ensureReaderClosed(response serverResponse) {
 	if response.body != nil {
 		// Drain up to 512 bytes and close the body to let the Transport reuse the connection
-		io.CopyN(io.Discard, response.body, 512)
-		response.body.Close()
+		_, _ = io.CopyN(io.Discard, response.body, 512)
+		_ = response.body.Close()
 	}
 }


### PR DESCRIPTION
### client: Client.NetworkInspectWithRaw: minor cleanup

Make this code slightly more idiomatic, and make it clear in what cases
we don't return an actual response, but an empty / default struct.

### client: ensureReaderClosed: make linters happier

### client: Client.doRequest: fix closing filehandle and reversed errors

commit 1a5dafb31eed7a44115f13595b54eaf109c4f388 (https://github.com/moby/moby/pull/39588) improved the error messages
produced by adding a check if the client is using as an elevated user. For
this, it attempts to open `\\.\PHYSICALDRIVE0`.

However, it looks like closing the file landed in the wrong branch of the
condition, so the file-handle would not be closed when the os.Open succeeded.

Looking further into this check, it appears the conditions were reversed;
if the check _fails_, it means the user is not running with elevated
permissions, but the check would use elevatedErr == nil.

Fix both by changing the condition to `elevatedErr != nil`.

While at it, also changing the string to use a string-literal, to reduce
the amount of escaping needed.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

