### PR TITLE
api/types: migrate NetworkListOptions to api/types/network

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -35,11 +35,6 @@ type EventsOptions struct {
 	Filters filters.Args
 }
 
-// NetworkListOptions holds parameters to filter the list of networks with.
-type NetworkListOptions struct {
-	Filters filters.Args
-}
-
 // NewHijackedResponse intializes a HijackedResponse type
 func NewHijackedResponse(conn net.Conn, mediaType string) HijackedResponse {
 	return HijackedResponse{Conn: conn, Reader: bufio.NewReader(conn), mediaType: mediaType}

--- a/api/types/network/network.go
+++ b/api/types/network/network.go
@@ -17,6 +17,11 @@ const (
 	NetworkNat = "nat"
 )
 
+// ListOptions holds parameters to filter the list of networks with.
+type ListOptions struct {
+	Filters filters.Args
+}
+
 // InspectOptions holds parameters to inspect network.
 type InspectOptions struct {
 	Scope   string

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -35,6 +35,11 @@ type ImageListOptions = image.ListOptions
 // Deprecated: use [image.RemoveOptions].
 type ImageRemoveOptions = image.RemoveOptions
 
+// NetworkListOptions holds parameters to filter the list of networks with.
+//
+// Deprecated: use [network.ListOptions].
+type NetworkListOptions = network.ListOptions
+
 // NetworkCreateResponse is the response message sent by the server for network create call.
 //
 // Deprecated: use [network.CreateResponse].

--- a/client/interface.go
+++ b/client/interface.go
@@ -112,7 +112,7 @@ type NetworkAPIClient interface {
 	NetworkDisconnect(ctx context.Context, network, container string, force bool) error
 	NetworkInspect(ctx context.Context, network string, options network.InspectOptions) (types.NetworkResource, error)
 	NetworkInspectWithRaw(ctx context.Context, network string, options network.InspectOptions) (types.NetworkResource, []byte, error)
-	NetworkList(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error)
+	NetworkList(ctx context.Context, options network.ListOptions) ([]types.NetworkResource, error)
 	NetworkRemove(ctx context.Context, network string) error
 	NetworksPrune(ctx context.Context, pruneFilter filters.Args) (types.NetworksPruneReport, error)
 }

--- a/client/network_list.go
+++ b/client/network_list.go
@@ -7,10 +7,11 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/network"
 )
 
 // NetworkList returns the list of networks configured in the docker host.
-func (cli *Client) NetworkList(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error) {
+func (cli *Client) NetworkList(ctx context.Context, options network.ListOptions) ([]types.NetworkResource, error) {
 	query := url.Values{}
 	if options.Filters.Len() > 0 {
 		//nolint:staticcheck // ignore SA1019 for old code

--- a/client/network_list_test.go
+++ b/client/network_list_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -22,7 +23,7 @@ func TestNetworkListError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.NetworkList(context.Background(), types.NetworkListOptions{})
+	_, err := client.NetworkList(context.Background(), network.ListOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
@@ -30,27 +31,27 @@ func TestNetworkList(t *testing.T) {
 	const expectedURL = "/networks"
 
 	listCases := []struct {
-		options         types.NetworkListOptions
+		options         network.ListOptions
 		expectedFilters string
 	}{
 		{
-			options:         types.NetworkListOptions{},
+			options:         network.ListOptions{},
 			expectedFilters: "",
 		},
 		{
-			options: types.NetworkListOptions{
+			options: network.ListOptions{
 				Filters: filters.NewArgs(filters.Arg("dangling", "false")),
 			},
 			expectedFilters: `{"dangling":{"false":true}}`,
 		},
 		{
-			options: types.NetworkListOptions{
+			options: network.ListOptions{
 				Filters: filters.NewArgs(filters.Arg("dangling", "true")),
 			},
 			expectedFilters: `{"dangling":{"true":true}}`,
 		},
 		{
-			options: types.NetworkListOptions{
+			options: network.ListOptions{
 				Filters: filters.NewArgs(
 					filters.Arg("label", "label1"),
 					filters.Arg("label", "label2"),

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/plugin"
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/cli"
@@ -32,7 +32,7 @@ func OnlyDefaultNetworks(ctx context.Context) bool {
 	if err != nil {
 		return false
 	}
-	networks, err := apiClient.NetworkList(ctx, types.NetworkListOptions{})
+	networks, err := apiClient.NetworkList(ctx, network.ListOptions{})
 	if err != nil || len(networks) > 0 {
 		return false
 	}

--- a/integration/network/delete_test.go
+++ b/integration/network/delete_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	networktypes "github.com/docker/docker/api/types/network"
 	dclient "github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/network"
 	"gotest.tools/v3/assert"
@@ -31,7 +32,7 @@ func createAmbiguousNetworks(ctx context.Context, t *testing.T, client dclient.A
 	idPrefixNet := network.CreateNoError(ctx, t, client, testNet[:12])
 	fullIDNet := network.CreateNoError(ctx, t, client, testNet)
 
-	nws, err := client.NetworkList(ctx, types.NetworkListOptions{})
+	nws, err := client.NetworkList(ctx, networktypes.ListOptions{})
 	assert.NilError(t, err)
 
 	assert.Check(t, is.Equal(true, containsNetwork(nws, testNet)), "failed to create network testNet")
@@ -79,7 +80,7 @@ func TestDockerNetworkDeletePreferID(t *testing.T) {
 	assert.NilError(t, err)
 
 	// networks "testNet" and "idPrefixNet" should be removed, but "fullIDNet" should still exist
-	nws, err := client.NetworkList(ctx, types.NetworkListOptions{})
+	nws, err := client.NetworkList(ctx, networktypes.ListOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(false, containsNetwork(nws, testNet)), "Network testNet not removed")
 	assert.Check(t, is.Equal(false, containsNetwork(nws, idPrefixNet)), "Network idPrefixNet not removed")

--- a/integration/network/helpers.go
+++ b/integration/network/helpers.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/testutil"
 	"gotest.tools/v3/assert/cmp"
@@ -45,7 +45,7 @@ func LinkExists(ctx context.Context, t *testing.T, master string) {
 // IsNetworkAvailable provides a comparison to check if a docker network is available
 func IsNetworkAvailable(ctx context.Context, c client.NetworkAPIClient, name string) cmp.Comparison {
 	return func() cmp.Result {
-		networks, err := c.NetworkList(ctx, types.NetworkListOptions{})
+		networks, err := c.NetworkList(ctx, network.ListOptions{})
 		if err != nil {
 			return cmp.ResultFromError(err)
 		}
@@ -61,7 +61,7 @@ func IsNetworkAvailable(ctx context.Context, c client.NetworkAPIClient, name str
 // IsNetworkNotAvailable provides a comparison to check if a docker network is not available
 func IsNetworkNotAvailable(ctx context.Context, c client.NetworkAPIClient, name string) cmp.Comparison {
 	return func() cmp.Result {
-		networks, err := c.NetworkList(ctx, types.NetworkListOptions{})
+		networks, err := c.NetworkList(ctx, network.ListOptions{})
 		if err != nil {
 			return cmp.ResultFromError(err)
 		}

--- a/integration/network/helpers_windows.go
+++ b/integration/network/helpers_windows.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"gotest.tools/v3/assert/cmp"
 )
@@ -12,7 +12,7 @@ import (
 // IsNetworkAvailable provides a comparison to check if a docker network is available
 func IsNetworkAvailable(ctx context.Context, c client.NetworkAPIClient, name string) cmp.Comparison {
 	return func() cmp.Result {
-		networks, err := c.NetworkList(ctx, types.NetworkListOptions{})
+		networks, err := c.NetworkList(ctx, network.ListOptions{})
 		if err != nil {
 			return cmp.ResultFromError(err)
 		}
@@ -28,7 +28,7 @@ func IsNetworkAvailable(ctx context.Context, c client.NetworkAPIClient, name str
 // IsNetworkNotAvailable provides a comparison to check if a docker network is not available
 func IsNetworkNotAvailable(ctx context.Context, c client.NetworkAPIClient, name string) cmp.Comparison {
 	return func() cmp.Result {
-		networks, err := c.NetworkList(ctx, types.NetworkListOptions{})
+		networks, err := c.NetworkList(ctx, network.ListOptions{})
 		if err != nil {
 			return cmp.ResultFromError(err)
 		}

--- a/testutil/environment/clean.go
+++ b/testutil/environment/clean.go
@@ -149,7 +149,7 @@ func deleteAllVolumes(ctx context.Context, t testing.TB, c client.VolumeAPIClien
 
 func deleteAllNetworks(ctx context.Context, t testing.TB, c client.NetworkAPIClient, daemonPlatform string, protectedNetworks map[string]struct{}) {
 	t.Helper()
-	networks, err := c.NetworkList(ctx, types.NetworkListOptions{})
+	networks, err := c.NetworkList(ctx, network.ListOptions{})
 	assert.Check(t, err, "failed to list networks")
 
 	for _, n := range networks {

--- a/testutil/environment/protect.go
+++ b/testutil/environment/protect.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/testutil"
@@ -160,7 +160,7 @@ func ProtectNetworks(ctx context.Context, t testing.TB, testEnv *Execution) {
 func getExistingNetworks(ctx context.Context, t testing.TB, testEnv *Execution) []string {
 	t.Helper()
 	client := testEnv.APIClient()
-	networkList, err := client.NetworkList(ctx, types.NetworkListOptions{})
+	networkList, err := client.NetworkList(ctx, network.ListOptions{})
 	assert.NilError(t, err, "failed to list networks")
 
 	var networks []string


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/47873

small one; I have some more after https://github.com/moby/moby/pull/47881 is merged


**- A picture of a cute animal (not mandatory but encouraged)**

