### PR TITLE
Update errdefs package to use containerd/errdefs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -245,6 +245,11 @@ linters:
         linters:
           - forbidigo
 
+        # FIXME(dmcgowan): ignoring while transitioning to containerd/errdefs
+      - text: "SA1019: errdefs\\.(.*) is deprecated"
+        linters:
+          - staticcheck
+
     # Log a warning if an exclusion rule is unused.
     # Default: false
     warn-unused: true

--- a/api/server/httpstatus/status.go
+++ b/api/server/httpstatus/status.go
@@ -8,7 +8,6 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/docker/distribution/registry/api/errcode"
-	"github.com/docker/docker/errdefs"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -25,23 +24,23 @@ func FromError(err error) int {
 
 	// Note that the below functions are already checking the error causal chain for matches.
 	switch {
-	case errdefs.IsNotFound(err):
+	case cerrdefs.IsNotFound(err):
 		return http.StatusNotFound
-	case errdefs.IsInvalidParameter(err):
+	case cerrdefs.IsInvalidArgument(err):
 		return http.StatusBadRequest
-	case errdefs.IsConflict(err):
+	case cerrdefs.IsConflict(err):
 		return http.StatusConflict
-	case errdefs.IsUnauthorized(err):
+	case cerrdefs.IsUnauthorized(err):
 		return http.StatusUnauthorized
-	case errdefs.IsUnavailable(err):
+	case cerrdefs.IsUnavailable(err):
 		return http.StatusServiceUnavailable
-	case errdefs.IsForbidden(err):
+	case cerrdefs.IsPermissionDenied(err):
 		return http.StatusForbidden
-	case errdefs.IsNotModified(err):
+	case cerrdefs.IsNotModified(err):
 		return http.StatusNotModified
-	case errdefs.IsNotImplemented(err):
+	case cerrdefs.IsNotImplemented(err):
 		return http.StatusNotImplemented
-	case errdefs.IsSystem(err) || errdefs.IsUnknown(err) || errdefs.IsDataLoss(err) || errdefs.IsDeadline(err) || errdefs.IsCancelled(err):
+	case cerrdefs.IsInternal(err) || cerrdefs.IsUnknown(err) || cerrdefs.IsDataLoss(err) || cerrdefs.IsDeadlineExceeded(err) || cerrdefs.IsCanceled(err):
 		return http.StatusInternalServerError
 	default:
 		if statusCode := statusCodeFromGRPCError(err); statusCode != http.StatusInternalServerError {

--- a/errdefs/doc.go
+++ b/errdefs/doc.go
@@ -4,5 +4,5 @@
 // Packages should not reference these interfaces directly, only implement them.
 // To check if a particular error implements one of these interfaces, there are helper
 // functions provided (e.g. `Is<SomeError>`) which can be used rather than asserting the interfaces directly.
-// If you must assert on these interfaces, be sure to check the causal chain (`err.Cause()`).
+// If you must assert on these interfaces, be sure to check the causal chain (`err.Unwrap()`).
 package errdefs // import "github.com/docker/docker/errdefs"

--- a/errdefs/helpers_test.go
+++ b/errdefs/helpers_test.go
@@ -8,6 +8,10 @@ import (
 
 var errTest = errors.New("this is a test")
 
+type wrapped interface {
+	Unwrap() error
+}
+
 func TestNotFound(t *testing.T) {
 	if IsNotFound(errTest) {
 		t.Fatalf("did not expect not found error, got %T", errTest)
@@ -16,7 +20,7 @@ func TestNotFound(t *testing.T) {
 	if !IsNotFound(e) {
 		t.Fatalf("expected not found error, got: %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -37,7 +41,7 @@ func TestConflict(t *testing.T) {
 	if !IsConflict(e) {
 		t.Fatalf("expected conflict error, got: %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -58,7 +62,7 @@ func TestForbidden(t *testing.T) {
 	if !IsForbidden(e) {
 		t.Fatalf("expected forbidden error, got: %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -79,7 +83,7 @@ func TestInvalidParameter(t *testing.T) {
 	if !IsInvalidParameter(e) {
 		t.Fatalf("expected invalid argument error, got %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -100,7 +104,7 @@ func TestNotImplemented(t *testing.T) {
 	if !IsNotImplemented(e) {
 		t.Fatalf("expected not implemented error, got %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -121,7 +125,7 @@ func TestNotModified(t *testing.T) {
 	if !IsNotModified(e) {
 		t.Fatalf("expected not modified error, got %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -142,7 +146,7 @@ func TestUnauthorized(t *testing.T) {
 	if !IsUnauthorized(e) {
 		t.Fatalf("expected unauthorized error, got %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -163,7 +167,7 @@ func TestUnknown(t *testing.T) {
 	if !IsUnknown(e) {
 		t.Fatalf("expected unknown error, got %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -184,7 +188,7 @@ func TestCancelled(t *testing.T) {
 	if !IsCancelled(e) {
 		t.Fatalf("expected cancelled error, got %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -205,7 +209,7 @@ func TestDeadline(t *testing.T) {
 	if !IsDeadline(e) {
 		t.Fatalf("expected deadline error, got %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -226,7 +230,7 @@ func TestDataLoss(t *testing.T) {
 	if !IsDataLoss(e) {
 		t.Fatalf("expected data loss error, got %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -247,7 +251,7 @@ func TestUnavailable(t *testing.T) {
 	if !IsUnavailable(e) {
 		t.Fatalf("expected unavaillable error, got %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -268,7 +272,7 @@ func TestSystem(t *testing.T) {
 	if !IsSystem(e) {
 		t.Fatalf("expected system error, got %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {

--- a/errdefs/is.go
+++ b/errdefs/is.go
@@ -3,119 +3,74 @@ package errdefs
 import (
 	"context"
 	"errors"
+
+	cerrdefs "github.com/containerd/errdefs"
 )
 
-type causer interface {
-	Cause() error
-}
-
-type wrapErr interface {
-	Unwrap() error
-}
-
-func getImplementer(err error) error {
-	switch e := err.(type) {
-	case
-		ErrNotFound,
-		ErrInvalidParameter,
-		ErrConflict,
-		ErrUnauthorized,
-		ErrUnavailable,
-		ErrForbidden,
-		ErrSystem,
-		ErrNotModified,
-		ErrNotImplemented,
-		ErrCancelled,
-		ErrDeadline,
-		ErrDataLoss,
-		ErrUnknown:
-		return err
-	case causer:
-		return getImplementer(e.Cause())
-	case wrapErr:
-		return getImplementer(e.Unwrap())
-	default:
-		return err
-	}
-}
-
 // IsNotFound returns if the passed in error is an [ErrNotFound],
-func IsNotFound(err error) bool {
-	_, ok := getImplementer(err).(ErrNotFound)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsNotFound]
+var IsNotFound = cerrdefs.IsNotFound
 
 // IsInvalidParameter returns if the passed in error is an [ErrInvalidParameter].
-func IsInvalidParameter(err error) bool {
-	_, ok := getImplementer(err).(ErrInvalidParameter)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsInvalidArgument]
+var IsInvalidParameter = cerrdefs.IsInvalidArgument
 
 // IsConflict returns if the passed in error is an [ErrConflict].
-func IsConflict(err error) bool {
-	_, ok := getImplementer(err).(ErrConflict)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsConflict]
+var IsConflict = cerrdefs.IsConflict
 
 // IsUnauthorized returns if the passed in error is an [ErrUnauthorized].
-func IsUnauthorized(err error) bool {
-	_, ok := getImplementer(err).(ErrUnauthorized)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsUnauthorized]
+var IsUnauthorized = cerrdefs.IsUnauthorized
 
 // IsUnavailable returns if the passed in error is an [ErrUnavailable].
-func IsUnavailable(err error) bool {
-	_, ok := getImplementer(err).(ErrUnavailable)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsUnavailable]
+var IsUnavailable = cerrdefs.IsUnavailable
 
 // IsForbidden returns if the passed in error is an [ErrForbidden].
-func IsForbidden(err error) bool {
-	_, ok := getImplementer(err).(ErrForbidden)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsPermissionDenied]
+var IsForbidden = cerrdefs.IsPermissionDenied
 
 // IsSystem returns if the passed in error is an [ErrSystem].
-func IsSystem(err error) bool {
-	_, ok := getImplementer(err).(ErrSystem)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsInternal]
+var IsSystem = cerrdefs.IsInternal
 
 // IsNotModified returns if the passed in error is an [ErrNotModified].
-func IsNotModified(err error) bool {
-	_, ok := getImplementer(err).(ErrNotModified)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsNotModified]
+var IsNotModified = cerrdefs.IsNotModified
 
 // IsNotImplemented returns if the passed in error is an [ErrNotImplemented].
-func IsNotImplemented(err error) bool {
-	_, ok := getImplementer(err).(ErrNotImplemented)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsNotImplemented]
+var IsNotImplemented = cerrdefs.IsNotImplemented
 
 // IsUnknown returns if the passed in error is an [ErrUnknown].
-func IsUnknown(err error) bool {
-	_, ok := getImplementer(err).(ErrUnknown)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsUnknown]
+var IsUnknown = cerrdefs.IsUnknown
 
 // IsCancelled returns if the passed in error is an [ErrCancelled].
-func IsCancelled(err error) bool {
-	_, ok := getImplementer(err).(ErrCancelled)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsCanceled]
+var IsCancelled = cerrdefs.IsCanceled
 
 // IsDeadline returns if the passed in error is an [ErrDeadline].
-func IsDeadline(err error) bool {
-	_, ok := getImplementer(err).(ErrDeadline)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsDeadlineExceeded]
+var IsDeadline = cerrdefs.IsDeadlineExceeded
 
 // IsDataLoss returns if the passed in error is an [ErrDataLoss].
-func IsDataLoss(err error) bool {
-	_, ok := getImplementer(err).(ErrDataLoss)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsDataLoss]
+var IsDataLoss = cerrdefs.IsDataLoss
 
 // IsContext returns if the passed in error is due to context cancellation or deadline exceeded.
 func IsContext(err error) bool {

--- a/volume/service/errors.go
+++ b/volume/service/errors.go
@@ -85,22 +85,21 @@ func IsNameConflict(err error) bool {
 	return isErr(err, errNameConflict)
 }
 
-type causal interface {
-	Cause() error
-}
-
-type wrapErr interface {
-	Unwrap() error
-}
-
 func isErr(err error, expected error) bool {
 	switch pe := err.(type) {
 	case nil:
 		return false
-	case wrapErr:
-		return isErr(pe.Unwrap(), expected)
-	case causal:
+	case interface{ Cause() error }:
 		return isErr(pe.Cause(), expected)
+	case interface{ Unwrap() error }:
+		return isErr(pe.Unwrap(), expected)
+	case interface{ Unwrap() []error }:
+		for _, ue := range pe.Unwrap() {
+			if isErr(ue, expected) {
+				return true
+			}
+		}
+		return false
 	}
 	return err == expected
 }


### PR DESCRIPTION
This is the first step in unifying the error handling with containerd. The containerd/errdefs package has been updated to support all the error types and interfaces used within moby today.

If this looks good and testing passes, two items remain to get this in...
- Replace deprecated checks with containerd/errdefs
- Followup to can unify the use of the error types and http error conversion.

Related to #49873 