### PR TITLE
libnet/driverapi: Introduce `EndpointDriver`

### DIFF
--- a/libnetwork/cnmallocator/manager.go
+++ b/libnetwork/cnmallocator/manager.go
@@ -41,26 +41,6 @@ func (d *manager) DeleteNetwork(nid string) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 
-func (d *manager) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
-func (d *manager) DeleteEndpoint(nid, eid string) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
-func (d *manager) EndpointOperInfo(nid, eid string) (map[string]interface{}, error) {
-	return nil, types.NotImplementedErrorf("not implemented")
-}
-
-func (d *manager) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
-func (d *manager) Leave(nid, eid string) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
 func (d *manager) Type() string {
 	return d.networkType
 }

--- a/libnetwork/driverapi/driverapi.go
+++ b/libnetwork/driverapi/driverapi.go
@@ -31,26 +31,6 @@ type Driver interface {
 	// the network id.
 	DeleteNetwork(nid string) error
 
-	// CreateEndpoint invokes the driver method to create an endpoint
-	// passing the network id, endpoint id endpoint information and driver
-	// specific config. The endpoint information can be either consumed by
-	// the driver or populated by the driver. The config mechanism will
-	// eventually be replaced with labels which are yet to be introduced.
-	CreateEndpoint(nid, eid string, ifInfo InterfaceInfo, options map[string]interface{}) error
-
-	// DeleteEndpoint invokes the driver method to delete an endpoint
-	// passing the network id and endpoint id.
-	DeleteEndpoint(nid, eid string) error
-
-	// EndpointOperInfo retrieves from the driver the operational data related to the specified endpoint
-	EndpointOperInfo(nid, eid string) (map[string]interface{}, error)
-
-	// Join method is invoked when a Sandbox is attached to an endpoint.
-	Join(nid, eid string, sboxKey string, jinfo JoinInfo, options map[string]interface{}) error
-
-	// Leave method is invoked when a Sandbox detaches from an endpoint.
-	Leave(nid, eid string) error
-
 	// ProgramExternalConnectivity invokes the driver method which does the necessary
 	// programming to allow the external connectivity dictated by the passed options
 	ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error
@@ -158,6 +138,7 @@ type Registerer interface {
 type Capability struct {
 	DataScope         string
 	ConnectivityScope string
+	EndpointDriver    bool
 }
 
 // IPAMData represents the per-network ip related

--- a/libnetwork/driverapi/endpoint.go
+++ b/libnetwork/driverapi/endpoint.go
@@ -1,0 +1,26 @@
+package driverapi
+
+// EndpointDriver is a driver managing endpoints.
+type EndpointDriver interface {
+	Driver
+
+	// CreateEndpoint invokes the driver method to create an endpoint
+	// passing the network id, endpoint id endpoint information and driver
+	// specific config. The endpoint information can be either consumed by
+	// the driver or populated by the driver. The config mechanism will
+	// eventually be replaced with labels which are yet to be introduced.
+	CreateEndpoint(nid, eid string, ifInfo InterfaceInfo, options map[string]interface{}) error
+
+	// DeleteEndpoint invokes the driver method to delete an endpoint
+	// passing the network id and endpoint id.
+	DeleteEndpoint(nid, eid string) error
+
+	// EndpointOperInfo retrieves from the driver the operational data related to the specified endpoint
+	EndpointOperInfo(nid, eid string) (map[string]interface{}, error)
+
+	// Join method is invoked when a Sandbox is attached to an endpoint.
+	Join(nid, eid string, sboxKey string, jinfo JoinInfo, options map[string]interface{}) error
+
+	// Leave method is invoked when a Sandbox detaches from an endpoint.
+	Leave(nid, eid string) error
+}

--- a/libnetwork/driverapi/endpoint.go
+++ b/libnetwork/driverapi/endpoint.go
@@ -5,17 +5,17 @@ type EndpointDriver interface {
 	Driver
 
 	// CreateEndpoint invokes the driver method to create an endpoint
-	// passing the network id, endpoint id endpoint information and driver
+	// passing the network id, endpoint id, endpoint information and driver
 	// specific config. The endpoint information can be either consumed by
-	// the driver or populated by the driver. The config mechanism will
-	// eventually be replaced with labels which are yet to be introduced.
+	// the driver or populated by the driver.
 	CreateEndpoint(nid, eid string, ifInfo InterfaceInfo, options map[string]interface{}) error
 
-	// DeleteEndpoint invokes the driver method to delete an endpoint
-	// passing the network id and endpoint id.
+	// DeleteEndpoint invokes the driver method to delete an endpoint passing
+	// the network id and endpoint id.
 	DeleteEndpoint(nid, eid string) error
 
-	// EndpointOperInfo retrieves from the driver the operational data related to the specified endpoint
+	// EndpointOperInfo retrieves from the driver the operational data related
+	// to the specified endpoint.
 	EndpointOperInfo(nid, eid string) (map[string]interface{}, error)
 
 	// Join method is invoked when a Sandbox is attached to an endpoint.

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -28,6 +28,9 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+// bridge driver must implement EndpointDriver API.
+var _ driverapi.EndpointDriver = (*driver)(nil)
+
 const (
 	NetworkType                = "bridge"
 	vethPrefix                 = "veth"
@@ -165,6 +168,7 @@ func Register(r driverapi.Registerer, config map[string]interface{}) error {
 	return r.RegisterDriver(NetworkType, d, driverapi.Capability{
 		DataScope:         scope.Local,
 		ConnectivityScope: scope.Local,
+		EndpointDriver:    true,
 	})
 }
 

--- a/libnetwork/drivers/bridge/brmanager/brmanager.go
+++ b/libnetwork/drivers/bridge/brmanager/brmanager.go
@@ -41,26 +41,6 @@ func (d *driver) DeleteNetwork(nid string) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 
-func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
-func (d *driver) DeleteEndpoint(nid, eid string) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
-func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, error) {
-	return nil, types.NotImplementedErrorf("not implemented")
-}
-
-func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
-func (d *driver) Leave(nid, eid string) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
 func (d *driver) Type() string {
 	return networkType
 }

--- a/libnetwork/drivers/host/host.go
+++ b/libnetwork/drivers/host/host.go
@@ -54,28 +54,6 @@ func (d *driver) DeleteNetwork(nid string) error {
 	return types.ForbiddenErrorf("network of type %q cannot be deleted", NetworkType)
 }
 
-func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
-	return nil
-}
-
-func (d *driver) DeleteEndpoint(nid, eid string) error {
-	return nil
-}
-
-func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, error) {
-	return make(map[string]interface{}), nil
-}
-
-// Join method is invoked when a Sandbox is attached to an endpoint.
-func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
-	return nil
-}
-
-// Leave method is invoked when a Sandbox detaches from an endpoint.
-func (d *driver) Leave(nid, eid string) error {
-	return nil
-}
-
 func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
 	return nil
 }

--- a/libnetwork/drivers/ipvlan/ipvlan.go
+++ b/libnetwork/drivers/ipvlan/ipvlan.go
@@ -12,6 +12,9 @@ import (
 	"github.com/docker/docker/libnetwork/types"
 )
 
+// ipvlan driver must implement EndpointDriver API.
+var _ driverapi.EndpointDriver = (*driver)(nil)
+
 const (
 	containerVethPrefix = "eth"
 	vethPrefix          = "veth"
@@ -72,6 +75,7 @@ func Register(r driverapi.Registerer, config map[string]interface{}) error {
 	return r.RegisterDriver(NetworkType, d, driverapi.Capability{
 		DataScope:         scope.Local,
 		ConnectivityScope: scope.Global,
+		EndpointDriver:    true,
 	})
 }
 

--- a/libnetwork/drivers/ipvlan/ivmanager/ivmanager.go
+++ b/libnetwork/drivers/ipvlan/ivmanager/ivmanager.go
@@ -41,26 +41,6 @@ func (d *driver) DeleteNetwork(nid string) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 
-func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
-func (d *driver) DeleteEndpoint(nid, eid string) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
-func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, error) {
-	return nil, types.NotImplementedErrorf("not implemented")
-}
-
-func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
-func (d *driver) Leave(nid, eid string) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
 func (d *driver) Type() string {
 	return networkType
 }

--- a/libnetwork/drivers/macvlan/macvlan.go
+++ b/libnetwork/drivers/macvlan/macvlan.go
@@ -12,6 +12,9 @@ import (
 	"github.com/docker/docker/libnetwork/types"
 )
 
+// macvlan driver must implement EndpointDriver API.
+var _ driverapi.EndpointDriver = (*driver)(nil)
+
 const (
 	containerVethPrefix = "eth"
 	vethPrefix          = "veth"
@@ -66,6 +69,7 @@ func Register(r driverapi.Registerer, config map[string]interface{}) error {
 	return r.RegisterDriver(NetworkType, d, driverapi.Capability{
 		DataScope:         scope.Local,
 		ConnectivityScope: scope.Global,
+		EndpointDriver:    true,
 	})
 }
 

--- a/libnetwork/drivers/macvlan/mvmanager/mvmanager.go
+++ b/libnetwork/drivers/macvlan/mvmanager/mvmanager.go
@@ -41,26 +41,6 @@ func (d *driver) DeleteNetwork(nid string) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 
-func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
-func (d *driver) DeleteEndpoint(nid, eid string) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
-func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, error) {
-	return nil, types.NotImplementedErrorf("not implemented")
-}
-
-func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
-func (d *driver) Leave(nid, eid string) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
 func (d *driver) Type() string {
 	return networkType
 }

--- a/libnetwork/drivers/null/null.go
+++ b/libnetwork/drivers/null/null.go
@@ -54,28 +54,6 @@ func (d *driver) DeleteNetwork(nid string) error {
 	return types.ForbiddenErrorf("network of type %q cannot be deleted", NetworkType)
 }
 
-func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
-	return nil
-}
-
-func (d *driver) DeleteEndpoint(nid, eid string) error {
-	return nil
-}
-
-func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, error) {
-	return make(map[string]interface{}), nil
-}
-
-// Join method is invoked when a Sandbox is attached to an endpoint.
-func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
-	return nil
-}
-
-// Leave method is invoked when a Sandbox detaches from an endpoint.
-func (d *driver) Leave(nid, eid string) error {
-	return nil
-}
-
 func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
 	return nil
 }

--- a/libnetwork/drivers/overlay/overlay.go
+++ b/libnetwork/drivers/overlay/overlay.go
@@ -16,6 +16,9 @@ import (
 	"github.com/docker/docker/libnetwork/scope"
 )
 
+// Overlay driver must implement the EndpointDriver API.
+var _ driverapi.EndpointDriver = (*driver)(nil)
+
 const (
 	NetworkType  = "overlay"
 	vethPrefix   = "veth"
@@ -54,6 +57,7 @@ func Register(r driverapi.Registerer, config map[string]interface{}) error {
 	return r.RegisterDriver(NetworkType, d, driverapi.Capability{
 		DataScope:         scope.Global,
 		ConnectivityScope: scope.Global,
+		EndpointDriver:    true,
 	})
 }
 

--- a/libnetwork/drivers/overlay/ovmanager/ovmanager.go
+++ b/libnetwork/drivers/overlay/ovmanager/ovmanager.go
@@ -177,28 +177,6 @@ func (d *driver) DeleteNetwork(nid string) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 
-func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
-func (d *driver) DeleteEndpoint(nid, eid string) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
-func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, error) {
-	return nil, types.NotImplementedErrorf("not implemented")
-}
-
-// Join method is invoked when a Sandbox is attached to an endpoint.
-func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
-// Leave method is invoked when a Sandbox detaches from an endpoint.
-func (d *driver) Leave(nid, eid string) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
 func (d *driver) Type() string {
 	return networkType
 }

--- a/libnetwork/drivers/remote/driver.go
+++ b/libnetwork/drivers/remote/driver.go
@@ -19,6 +19,9 @@ import (
 // remote driver must implement the discover-API.
 var _ discoverapi.Discover = (*driver)(nil)
 
+// remote driver must implement the EndpointDriver API.
+var _ driverapi.EndpointDriver = (*driver)(nil)
+
 type driver struct {
 	endpoint    *plugins.Client
 	networkType string
@@ -43,6 +46,7 @@ func Register(r driverapi.Registerer, pg plugingetter.PluginGetter) error {
 			log.G(context.TODO()).Errorf("error getting capability for %s due to %v", name, err)
 			return
 		}
+		c.EndpointDriver = true
 		if err = r.RegisterDriver(name, d, *c); err != nil {
 			log.G(context.TODO()).Errorf("error registering driver for %s due to %v", name, err)
 		}

--- a/libnetwork/drivers/windows/overlay/overlay_windows.go
+++ b/libnetwork/drivers/windows/overlay/overlay_windows.go
@@ -14,6 +14,9 @@ import (
 	"github.com/docker/docker/libnetwork/scope"
 )
 
+// Windows overlay driver must implement the EndpointDriver API.
+var _ driverapi.EndpointDriver = (*driver)(nil)
+
 const (
 	NetworkType = "overlay"
 )
@@ -34,6 +37,7 @@ func Register(r driverapi.Registerer) error {
 	return r.RegisterDriver(NetworkType, d, driverapi.Capability{
 		DataScope:         scope.Global,
 		ConnectivityScope: scope.Global,
+		EndpointDriver:    true,
 	})
 }
 

--- a/libnetwork/drivers/windows/windows.go
+++ b/libnetwork/drivers/windows/windows.go
@@ -30,6 +30,9 @@ import (
 	"github.com/docker/docker/libnetwork/types"
 )
 
+// Windows driver must implement the EndpointDriver API.
+var _ driverapi.EndpointDriver = (*driver)(nil)
+
 // networkConfiguration for network specific configuration
 type networkConfiguration struct {
 	ID                    string
@@ -142,6 +145,7 @@ func RegisterBuiltinLocalDrivers(r driverapi.Registerer, driverConfig func(strin
 		err = r.RegisterDriver(networkType, d, driverapi.Capability{
 			DataScope:         scope.Local,
 			ConnectivityScope: scope.Local,
+			EndpointDriver:    true,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to register %q driver: %w", networkType, err)

--- a/libnetwork/endpoint_info_unix.go
+++ b/libnetwork/endpoint_info_unix.go
@@ -22,7 +22,11 @@ func (ep *Endpoint) DriverInfo() (map[string]interface{}, error) {
 		return nil, fmt.Errorf("could not find network in store for driver info: %v", err)
 	}
 
-	driver, err := n.driver(true)
+	if !n.hasEndpointCapability() {
+		return nil, nil
+	}
+
+	driver, err := ep.driver(true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get driver info: %v", err)
 	}

--- a/libnetwork/endpoint_info_windows.go
+++ b/libnetwork/endpoint_info_windows.go
@@ -27,7 +27,11 @@ func (ep *Endpoint) DriverInfo() (map[string]interface{}, error) {
 		return nil, fmt.Errorf("could not find network in store for driver info: %v", err)
 	}
 
-	driver, err := n.driver(true)
+	if !n.hasEndpointCapability() {
+		return nil, nil
+	}
+
+	driver, err := ep.driver(true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get driver info: %v", err)
 	}

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -640,10 +640,16 @@ type badDriver struct {
 	failNetworkCreation bool
 }
 
+// badDriver must implement EndpointDriver API.
+var _ driverapi.EndpointDriver = (*badDriver)(nil)
+
 var bd = badDriver{failNetworkCreation: true}
 
 func badDriverRegister(reg driverapi.Registerer) error {
-	return reg.RegisterDriver(badDriverName, &bd, driverapi.Capability{DataScope: scope.Local})
+	return reg.RegisterDriver(badDriverName, &bd, driverapi.Capability{
+		DataScope:      scope.Local,
+		EndpointDriver: true,
+	})
 }
 
 func (b *badDriver) CreateNetwork(nid string, options map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {

--- a/libnetwork/network_capability.go
+++ b/libnetwork/network_capability.go
@@ -1,0 +1,11 @@
+package libnetwork
+
+import "github.com/docker/docker/libnetwork/driverapi"
+
+func (n *Network) hasEndpointCapability() bool {
+	// TODO(aker): remove after the next MCR LTS has been released
+	if n.driverCaps == (driverapi.Capability{}) {
+		return n.Type() != "host" && n.Type() != "null"
+	}
+	return n.driverCaps.EndpointDriver
+}

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -327,8 +327,9 @@ func (sb *Sandbox) removeEndpoint(ep *Endpoint) {
 }
 
 func (sb *Sandbox) removeEndpointRaw(ep *Endpoint) {
+	epID := ep.ID()
 	for i, e := range sb.endpoints {
-		if e == ep {
+		if e.ID() == epID {
 			sb.endpoints = append(sb.endpoints[:i], sb.endpoints[i+1:]...)
 			return
 		}


### PR DESCRIPTION
**- What I did**

This new interface embeds the Driver interface and defines all four methods related to Endpoint management: CreateEndpoint, Join, Leave and EndpointOperInfo.

Drivers implementing this new interface also return a new capability named 'EndpointDriver'. When libnetwork wants to call one of the `EndpointDriver` method, it first checks whether the network driver has this capability. If it doesn't, it early returns.

Because of that, libnet's `Endpoint` isn't necessarily backed by a driver Endpoint. In such case, it represents an endpoint-less 'network attachment'.

Also note that the logic in `(*Sandbox).removeEndpointRaw()` is modified to look for an endpoint by its ID instead of comparing struct instances are the same. The old logic is quite weird as libnetwork tends to create multiple copies of the same 'object' into memory. How / why this worked is unclear, but this commit made a few tests fail exactly because of that.

**- How to verify it**

CI. There are already a number of unit tests that check that everything works okay with both EndpointDriver and non-EndpointDriver drivers.

**- A picture of a cute animal (not mandatory but encouraged)**

