### PR TITLE
[25.0 backport] don't depend on containerd platform.Parse to return a typed error

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -55,7 +55,7 @@ func (ir *imageRouter) postImagesCreate(ctx context.Context, w http.ResponseWrit
 		if p := r.FormValue("platform"); p != "" {
 			sp, err := platforms.Parse(p)
 			if err != nil {
-				return err
+				return errdefs.InvalidParameter(err)
 			}
 			platform = &sp
 		}

--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker/builder/builder-next/exporter/overrides"
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/daemon/images"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/idtools"
@@ -326,7 +327,7 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 		// TODO: remove once opt.Options.Platform is of type specs.Platform
 		_, err := platforms.Parse(opt.Options.Platform)
 		if err != nil {
-			return nil, err
+			return nil, errdefs.InvalidParameter(err)
 		}
 		frontendAttrs["platform"] = opt.Options.Platform
 	}

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -159,7 +159,7 @@ func newBuilder(ctx context.Context, options builderOptions) (*Builder, error) {
 	if config.Platform != "" {
 		sp, err := platforms.Parse(config.Platform)
 		if err != nil {
-			return nil, err
+			return nil, errdefs.InvalidParameter(err)
 		}
 		b.platform = &sp
 	}

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -166,17 +166,17 @@ func initializeStage(ctx context.Context, d dispatchRequest, cmd *instructions.S
 
 		p, err := platforms.Parse(v)
 		if err != nil {
-			return errors.Wrapf(err, "failed to parse platform %s", v)
+			return errors.Wrapf(errdefs.InvalidParameter(err), "failed to parse platform %s", v)
 		}
 		platform = &p
 	}
 
-	image, err := d.getFromImage(ctx, d.shlex, cmd.BaseName, platform)
+	img, err := d.getFromImage(ctx, d.shlex, cmd.BaseName, platform)
 	if err != nil {
 		return err
 	}
 	state := d.state
-	if err := state.beginStage(cmd.Name, image); err != nil {
+	if err := state.beginStage(cmd.Name, img); err != nil {
 		return err
 	}
 	if len(state.runConfig.OnBuild) > 0 {

--- a/builder/dockerfile/internals_windows.go
+++ b/builder/dockerfile/internals_windows.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"golang.org/x/sys/windows"
@@ -62,7 +63,7 @@ func lookupNTAccount(ctx context.Context, builder *Builder, accountName string, 
 
 	optionsPlatform, err := platforms.Parse(builder.options.Platform)
 	if err != nil {
-		return idtools.Identity{}, err
+		return idtools.Identity{}, errdefs.InvalidParameter(err)
 	}
 
 	runConfig := copyRunConfig(state.runConfig,

--- a/integration/image/import_test.go
+++ b/integration/image/import_test.go
@@ -10,10 +10,12 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
 )
 
@@ -178,7 +180,8 @@ func TestImportWithCustomPlatformReject(t *testing.T) {
 				reference,
 				types.ImageImportOptions{Platform: tc.platform})
 
-			assert.ErrorContains(t, err, tc.expectedErr)
+			assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+			assert.Check(t, is.ErrorContains(err, tc.expectedErr))
 		})
 	}
 }


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/47863

We currently depend on the containerd platform-parsing to return typed errdefs errors; the new containerd platforms module does not return such errors, and documents that errors returned should not be used as sentinel errors; https://github.com/containerd/platforms/blob/c1438e911ac7596426105350652fe267d0fb8a03/errors.go#L21-L30

Let's type these errors ourselves, so that we don't depend on the error-types returned by containerd, and consider that eny platform string that results in an error is an invalid parameter.


(cherry picked from commit cd1ed46d73266b75e5c6dafa2f0c4333bf981a6b)

**- A picture of a cute animal (not mandatory but encouraged)**

