### PR TITLE
integration/network: remove used of deprecated NetworkInspectOptions

### DIFF
--- a/integration/network/bridge_test.go
+++ b/integration/network/bridge_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
 	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/versions"
 	ctr "github.com/docker/docker/integration/internal/container"
@@ -57,7 +56,7 @@ func TestCreateWithIPv6DefaultsToULAPrefix(t *testing.T) {
 	network.CreateNoError(ctx, t, apiClient, nwName, network.WithIPv6())
 	defer network.RemoveNoError(ctx, t, apiClient, nwName)
 
-	nw, err := apiClient.NetworkInspect(ctx, "testnetula", types.NetworkInspectOptions{})
+	nw, err := apiClient.NetworkInspect(ctx, "testnetula", networktypes.InspectOptions{})
 	assert.NilError(t, err)
 
 	for _, ipam := range nw.IPAM.Config {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/47873
- relates to https://github.com/moby/moby/pull/47853


The types.NetworkInspectOptions type was moved to the networks package in 5bea0c38bc2c851d1a574942624b59825c0c29bb and deprecated, but use of it was re-introduced in cd3804655a252117742a2987df15630a61ce334e, which was merged out-of-order.


**- A picture of a cute animal (not mandatory but encouraged)**

