### PR TITLE
api/types: remove aliases for deprecated Image types

### DIFF
--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -1,39 +1,8 @@
 package types
 
 import (
-	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 )
-
-// ImageImportOptions holds information to import images from the client host.
-//
-// Deprecated: use [image.ImportOptions].
-type ImageImportOptions = image.ImportOptions
-
-// ImageCreateOptions holds information to create images.
-//
-// Deprecated: use [image.CreateOptions].
-type ImageCreateOptions = image.CreateOptions
-
-// ImagePullOptions holds information to pull images.
-//
-// Deprecated: use [image.PullOptions].
-type ImagePullOptions = image.PullOptions
-
-// ImagePushOptions holds information to push images.
-//
-// Deprecated: use [image.PushOptions].
-type ImagePushOptions = image.PushOptions
-
-// ImageListOptions holds parameters to list images with.
-//
-// Deprecated: use [image.ListOptions].
-type ImageListOptions = image.ListOptions
-
-// ImageRemoveOptions holds parameters to remove images.
-//
-// Deprecated: use [image.RemoveOptions].
-type ImageRemoveOptions = image.RemoveOptions
 
 // NetworkListOptions holds parameters to filter the list of networks with.
 //


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/47139

These aliases were added in ac2a028dcc05532109e14f8af105ca42c0abf1f3, which was part of the v26.0 and v26.1 releases. We can remove the aliases, assuming users that depended on this have migrated to the new location of these types.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Remove deprecated `ImageImportOptions`, `ImageCreateOptions`, `ImagePullOptions`, `ImagePushOptions`, `ImageListOptions`, `ImageRemoveOptions` aliases for Image types.
```

**- A picture of a cute animal (not mandatory but encouraged)**

