### PR TITLE
daemon/cluster: remove Cluster.getRequestContext()

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -233,7 +233,7 @@ func (c *Cluster) newNodeRunner(conf nodeStartConfig) (*nodeRunner, error) {
 			}
 			localHostPort := conn.LocalAddr().String()
 			actualLocalAddr, _, _ = net.SplitHostPort(localHostPort)
-			conn.Close()
+			_ = conn.Close()
 		}
 	}
 
@@ -247,10 +247,6 @@ func (c *Cluster) newNodeRunner(conf nodeStartConfig) (*nodeRunner, error) {
 	c.config.Backend.DaemonJoinsCluster(c)
 
 	return nr, nil
-}
-
-func (c *Cluster) getRequestContext(ctx context.Context) (context.Context, func()) { // TODO: not needed when requests don't block on qourum lost
-	return context.WithTimeout(ctx, swarmRequestTimeout)
 }
 
 // IsManager returns true if Cluster is participating as a manager.
@@ -444,7 +440,7 @@ func (c *Cluster) lockedManagerAction(fn func(ctx context.Context, state nodeSta
 	}
 
 	ctx := context.TODO()
-	ctx, cancel := c.getRequestContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, swarmRequestTimeout)
 	defer cancel()
 
 	return fn(ctx, state)

--- a/daemon/cluster/configs.go
+++ b/daemon/cluster/configs.go
@@ -43,7 +43,7 @@ func (c *Cluster) GetConfigs(options apitypes.ConfigListOptions) ([]types.Config
 	}
 
 	ctx := context.TODO()
-	ctx, cancel := c.getRequestContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, swarmRequestTimeout)
 	defer cancel()
 
 	r, err := state.controlClient.ListConfigs(ctx,

--- a/daemon/cluster/networks.go
+++ b/daemon/cluster/networks.go
@@ -70,7 +70,7 @@ func (c *Cluster) getNetworks(filters *swarmapi.ListNetworksRequest_Filters) ([]
 	}
 
 	ctx := context.TODO()
-	ctx, cancel := c.getRequestContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, swarmRequestTimeout)
 	defer cancel()
 
 	r, err := state.controlClient.ListNetworks(ctx, &swarmapi.ListNetworksRequest{Filters: filters})
@@ -206,7 +206,7 @@ func (c *Cluster) AttachNetwork(target string, containerID string, addresses []s
 	c.mu.Unlock()
 
 	ctx := context.TODO()
-	ctx, cancel := c.getRequestContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, swarmRequestTimeout)
 	defer cancel()
 
 	taskID, err := agent.ResourceAllocator().AttachNetwork(ctx, containerID, target, addresses)
@@ -226,7 +226,7 @@ func (c *Cluster) AttachNetwork(target string, containerID string, addresses []s
 
 	release := func() {
 		ctx := compatcontext.WithoutCancel(ctx)
-		ctx, cancel := c.getRequestContext(ctx)
+		ctx, cancel := context.WithTimeout(ctx, swarmRequestTimeout)
 		defer cancel()
 		if err := agent.ResourceAllocator().DetachNetwork(ctx, taskID); err != nil {
 			log.G(ctx).Errorf("Failed remove network attachment %s to network %s on allocation failure: %v",

--- a/daemon/cluster/nodes.go
+++ b/daemon/cluster/nodes.go
@@ -27,7 +27,7 @@ func (c *Cluster) GetNodes(options apitypes.NodeListOptions) ([]types.Node, erro
 	}
 
 	ctx := context.TODO()
-	ctx, cancel := c.getRequestContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, swarmRequestTimeout)
 	defer cancel()
 
 	r, err := state.controlClient.ListNodes(
@@ -74,7 +74,7 @@ func (c *Cluster) UpdateNode(input string, version uint64, spec types.NodeSpec) 
 		}
 
 		ctx := context.TODO()
-		ctx, cancel := c.getRequestContext(ctx)
+		ctx, cancel := context.WithTimeout(ctx, swarmRequestTimeout)
 		defer cancel()
 
 		currentNode, err := getNode(ctx, state.controlClient, input)

--- a/daemon/cluster/secrets.go
+++ b/daemon/cluster/secrets.go
@@ -43,7 +43,7 @@ func (c *Cluster) GetSecrets(options apitypes.SecretListOptions) ([]types.Secret
 	}
 
 	ctx := context.TODO()
-	ctx, cancel := c.getRequestContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, swarmRequestTimeout)
 	defer cancel()
 
 	r, err := state.controlClient.ListSecrets(ctx,

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -68,7 +68,7 @@ func (c *Cluster) GetServices(options types.ServiceListOptions) ([]swarm.Service
 	}
 
 	ctx := context.TODO()
-	ctx, cancel := c.getRequestContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, swarmRequestTimeout)
 	defer cancel()
 
 	r, err := state.controlClient.ListServices(
@@ -267,7 +267,7 @@ func (c *Cluster) CreateService(s swarm.ServiceSpec, encodedAuth string, queryRe
 				// if the registry is slow or unresponsive.
 				var cancel func()
 				ctx = compatcontext.WithoutCancel(ctx)
-				ctx, cancel = c.getRequestContext(ctx)
+				ctx, cancel = context.WithTimeout(ctx, swarmRequestTimeout)
 				defer cancel()
 			}
 
@@ -383,7 +383,7 @@ func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec swa
 				// if the registry is slow or unresponsive.
 				var cancel func()
 				ctx = compatcontext.WithoutCancel(ctx)
-				ctx, cancel = c.getRequestContext(ctx)
+				ctx, cancel = context.WithTimeout(ctx, swarmRequestTimeout)
 				defer cancel()
 			}
 		}

--- a/daemon/cluster/swarm.go
+++ b/daemon/cluster/swarm.go
@@ -442,7 +442,7 @@ func (c *Cluster) Info(ctx context.Context) types.Info {
 		info.Error = state.err.Error()
 	}
 
-	ctx, cancel := c.getRequestContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, swarmRequestTimeout)
 	defer cancel()
 
 	if state.IsActiveManager() {


### PR DESCRIPTION
This method was added in 534a90a99367af6f6bba1ddcc7eb07506e41f774 as part of adding the Swarm cluster backend, and later updated in commit 85b1fdf15ce2ad1b373748554d3aa218e2eb5a5f to use a swarmRequestTimeout const for the timeout.

Nothing in this utility depends on the Cluster struct, and the abstraction makes it appear as more than it is, which is just a wrapper for context.WithTimeout().

Let's remove the abstraction to make it less magical.


**- A picture of a cute animal (not mandatory but encouraged)**

