### PR TITLE
api, daemon, libnet: Create OTel spans at various places

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -134,6 +134,16 @@ issues:
       linters:
         - staticcheck
 
+    - text: "ineffectual assignment to ctx"
+      source: "ctx[, ].*=.*\\(ctx[,)]"
+      linters:
+        - ineffassign
+
+    - text: "SA4006: this value of `ctx` is never used"
+      source: "ctx[, ].*=.*\\(ctx[,)]"
+      linters:
+        - staticcheck
+
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-issues-per-linter: 0
 

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -28,6 +28,7 @@ import (
 	"github.com/docker/docker/runconfig"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel"
 	"golang.org/x/net/websocket"
 )
 
@@ -188,6 +189,9 @@ func (s *containerRouter) getContainersExport(ctx context.Context, w http.Respon
 }
 
 func (s *containerRouter) postContainersStart(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	ctx, span := otel.Tracer("").Start(ctx, "containerRouter.postContainersStart")
+	defer span.End()
+
 	// If contentLength is -1, we can assumed chunked encoding
 	// or more technically that the length is unknown
 	// https://golang.org/src/pkg/net/http/request.go#L139

--- a/api/server/router/network/backend.go
+++ b/api/server/router/network/backend.go
@@ -13,7 +13,7 @@ import (
 type Backend interface {
 	GetNetworks(filters.Args, backend.NetworkListConfig) ([]network.Inspect, error)
 	CreateNetwork(nc network.CreateRequest) (*network.CreateResponse, error)
-	ConnectContainerToNetwork(containerName, networkName string, endpointConfig *network.EndpointSettings) error
+	ConnectContainerToNetwork(ctx context.Context, containerName, networkName string, endpointConfig *network.EndpointSettings) error
 	DisconnectContainerFromNetwork(containerName string, networkName string, force bool) error
 	DeleteNetwork(networkID string) error
 	NetworksPrune(ctx context.Context, pruneFilters filters.Args) (*network.PruneReport, error)

--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -247,7 +247,7 @@ func (n *networkRouter) postNetworkConnect(ctx context.Context, w http.ResponseW
 	// The reason is that, In case of attachable network in swarm scope, the actual local network
 	// may not be available at the time. At the same time, inside daemon `ConnectContainerToNetwork`
 	// does the ambiguity check anyway. Therefore, passing the name to daemon would be enough.
-	return n.backend.ConnectContainerToNetwork(connect.Container, vars["id"], connect.EndpointConfig)
+	return n.backend.ConnectContainerToNetwork(ctx, connect.Container, vars["id"], connect.EndpointConfig)
 }
 
 func (n *networkRouter) postNetworkDisconnect(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/builder/builder-next/executor_linux.go
+++ b/builder/builder-next/executor_linux.go
@@ -119,7 +119,7 @@ func (iface *lnInterface) init(c *libnetwork.Controller, n *libnetwork.Network) 
 		return
 	}
 
-	sbx, err := c.NewSandbox(id, libnetwork.OptionUseExternalKey(), libnetwork.OptionHostsPath(filepath.Join(iface.provider.Root, id, "hosts")),
+	sbx, err := c.NewSandbox(context.TODO(), id, libnetwork.OptionUseExternalKey(), libnetwork.OptionHostsPath(filepath.Join(iface.provider.Root, id, "hosts")),
 		libnetwork.OptionResolvConfPath(filepath.Join(iface.provider.Root, id, "resolv.conf")))
 	if err != nil {
 		iface.err = err

--- a/builder/builder-next/executor_linux.go
+++ b/builder/builder-next/executor_linux.go
@@ -113,7 +113,7 @@ func (iface *lnInterface) init(c *libnetwork.Controller, n *libnetwork.Network) 
 	defer close(iface.ready)
 	id := identity.NewID()
 
-	ep, err := n.CreateEndpoint(id, libnetwork.CreateOptionDisableResolution())
+	ep, err := n.CreateEndpoint(context.TODO(), id, libnetwork.CreateOptionDisableResolution())
 	if err != nil {
 		iface.err = err
 		return

--- a/builder/builder-next/executor_linux.go
+++ b/builder/builder-next/executor_linux.go
@@ -161,7 +161,7 @@ func (iface *lnInterface) Close() error {
 	<-iface.ready
 	if iface.sbx != nil {
 		go func() {
-			if err := iface.sbx.Delete(); err != nil {
+			if err := iface.sbx.Delete(context.TODO()); err != nil {
 				log.G(context.TODO()).WithError(err).Errorf("failed to delete builder network sandbox")
 			}
 			if err := os.RemoveAll(filepath.Join(iface.provider.Root, iface.sbx.ContainerID())); err != nil {

--- a/builder/builder-next/executor_linux.go
+++ b/builder/builder-next/executor_linux.go
@@ -126,7 +126,7 @@ func (iface *lnInterface) init(c *libnetwork.Controller, n *libnetwork.Network) 
 		return
 	}
 
-	if err := ep.Join(sbx); err != nil {
+	if err := ep.Join(context.TODO(), sbx); err != nil {
 		iface.err = err
 		return
 	}

--- a/container/container.go
+++ b/container/container.go
@@ -42,6 +42,9 @@ import (
 	"github.com/moby/sys/symlink"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -200,7 +203,12 @@ func (container *Container) toDisk() (*Container, error) {
 
 // CheckpointTo makes the Container's current state visible to queries, and persists state.
 // Callers must hold a Container lock.
-func (container *Container) CheckpointTo(store *ViewDB) error {
+func (container *Container) CheckpointTo(ctx context.Context, store *ViewDB) error {
+	ctx, span := otel.Tracer("").Start(ctx, "container.CheckpointTo", trace.WithAttributes(
+		attribute.String("container.ID", container.ID),
+		attribute.String("container.Name", container.Name)))
+	defer span.End()
+
 	deepCopy, err := container.toDisk()
 	if err != nil {
 		return err

--- a/container/view_test.go
+++ b/container/view_test.go
@@ -1,6 +1,7 @@
 package container // import "github.com/docker/docker/container"
 
 import (
+	"context"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -46,7 +47,7 @@ func TestViewSaveDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 	c := newContainer(t)
-	if err := c.CheckpointTo(db); err != nil {
+	if err := c.CheckpointTo(context.Background(), db); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.Delete(c); err != nil {
@@ -61,11 +62,11 @@ func TestViewAll(t *testing.T) {
 		two   = newContainer(t)
 	)
 	one.Pid = 10
-	if err := one.CheckpointTo(db); err != nil {
+	if err := one.CheckpointTo(context.Background(), db); err != nil {
 		t.Fatal(err)
 	}
 	two.Pid = 20
-	if err := two.CheckpointTo(db); err != nil {
+	if err := two.CheckpointTo(context.Background(), db); err != nil {
 		t.Fatal(err)
 	}
 
@@ -94,7 +95,7 @@ func TestViewGet(t *testing.T) {
 		one   = newContainer(t)
 	)
 	one.ImageID = "some-image-123"
-	if err := one.CheckpointTo(db); err != nil {
+	if err := one.CheckpointTo(context.Background(), db); err != nil {
 		t.Fatal(err)
 	}
 	s, err := db.Snapshot().Get(one.ID)
@@ -174,7 +175,7 @@ func TestViewWithHealthCheck(t *testing.T) {
 			Status: "starting",
 		},
 	}
-	if err := one.CheckpointTo(db); err != nil {
+	if err := one.CheckpointTo(context.Background(), db); err != nil {
 		t.Fatal(err)
 	}
 	s, err := db.Snapshot().Get(one.ID)

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -41,7 +41,7 @@ type Backend interface {
 	ContainerStart(ctx context.Context, name string, checkpoint string, checkpointDir string) error
 	ContainerStop(ctx context.Context, name string, config container.StopOptions) error
 	ContainerLogs(ctx context.Context, name string, config *container.LogsOptions) (msgs <-chan *backend.LogMessage, tty bool, err error)
-	ConnectContainerToNetwork(containerName, networkName string, endpointConfig *network.EndpointSettings) error
+	ConnectContainerToNetwork(ctx context.Context, containerName, networkName string, endpointConfig *network.EndpointSettings) error
 	ActivateContainerServiceBinding(containerName string) error
 	DeactivateContainerServiceBinding(containerName string) error
 	UpdateContainerServiceConfig(containerName string, serviceConfig *clustertypes.ServiceConfig) error

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -117,7 +117,7 @@ func (daemon *Daemon) Register(c *container.Container) error {
 	defer c.Unlock()
 
 	daemon.containers.Add(c.ID, c)
-	return c.CheckpointTo(daemon.containersReplica)
+	return c.CheckpointTo(context.TODO(), daemon.containersReplica)
 }
 
 func (daemon *Daemon) newContainer(name string, operatingSystem string, config *containertypes.Config, hostConfig *containertypes.HostConfig, imgID image.ID, managed bool) (*container.Container, error) {

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -797,7 +797,7 @@ func (daemon *Daemon) connectToNetwork(ctx context.Context, cfg *config.Config, 
 		return err
 	}
 
-	if err := ep.Join(sb, joinOptions...); err != nil {
+	if err := ep.Join(ctx, sb, joinOptions...); err != nil {
 		return err
 	}
 

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -1085,7 +1085,7 @@ func (daemon *Daemon) ConnectToNetwork(ctx context.Context, container *container
 		}
 	}
 
-	return container.CheckpointTo(daemon.containersReplica)
+	return container.CheckpointTo(ctx, daemon.containersReplica)
 }
 
 // DisconnectFromNetwork disconnects container from network n.
@@ -1119,7 +1119,7 @@ func (daemon *Daemon) DisconnectFromNetwork(ctx context.Context, container *cont
 		return err
 	}
 
-	if err := container.CheckpointTo(daemon.containersReplica); err != nil {
+	if err := container.CheckpointTo(ctx, daemon.containersReplica); err != nil {
 		return err
 	}
 

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -542,7 +542,7 @@ func (daemon *Daemon) allocateNetwork(ctx context.Context, cfg *config.Config, c
 			if err != nil {
 				return err
 			}
-			sb, err := daemon.netController.NewSandbox(container.ID, sbOptions...)
+			sb, err := daemon.netController.NewSandbox(ctx, container.ID, sbOptions...)
 			if err != nil {
 				return err
 			}
@@ -784,7 +784,7 @@ func (daemon *Daemon) connectToNetwork(ctx context.Context, cfg *config.Config, 
 		if err != nil {
 			return err
 		}
-		sb, err = daemon.netController.NewSandbox(container.ID, sbOptions...)
+		sb, err = daemon.netController.NewSandbox(ctx, container.ID, sbOptions...)
 		if err != nil {
 			return err
 		}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -473,7 +473,7 @@ func (daemon *Daemon) restore(cfg *configStore) error {
 						c.Paused = false
 						daemon.setStateCounter(c)
 						daemon.initHealthMonitor(c)
-						if err := c.CheckpointTo(daemon.containersReplica); err != nil {
+						if err := c.CheckpointTo(context.TODO(), daemon.containersReplica); err != nil {
 							baseLogger.WithError(err).Error("failed to update paused container state")
 						}
 						c.Unlock()
@@ -497,7 +497,7 @@ func (daemon *Daemon) restore(cfg *configStore) error {
 					}
 					c.SetStopped(&ces)
 					daemon.Cleanup(context.TODO(), c)
-					if err := c.CheckpointTo(daemon.containersReplica); err != nil {
+					if err := c.CheckpointTo(context.TODO(), daemon.containersReplica); err != nil {
 						baseLogger.WithError(err).Error("failed to update stopped container state")
 					}
 					c.Unlock()
@@ -564,7 +564,7 @@ func (daemon *Daemon) restore(cfg *configStore) error {
 				// state and leave further processing up to them.
 				c.RemovalInProgress = false
 				c.Dead = true
-				if err := c.CheckpointTo(daemon.containersReplica); err != nil {
+				if err := c.CheckpointTo(context.TODO(), daemon.containersReplica); err != nil {
 					baseLogger.WithError(err).Error("failed to update RemovalInProgress container state")
 				} else {
 					baseLogger.Debugf("reset RemovalInProgress state for container")
@@ -1615,7 +1615,7 @@ func RemapContainerdNamespaces(config *config.Config) (ns string, pluginNs strin
 func (daemon *Daemon) checkpointAndSave(container *container.Container) error {
 	container.Lock()
 	defer container.Unlock()
-	if err := container.CheckpointTo(daemon.containersReplica); err != nil {
+	if err := container.CheckpointTo(context.TODO(), daemon.containersReplica); err != nil {
 		return fmt.Errorf("Error saving container state: %v", err)
 	}
 	return nil

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -128,7 +128,7 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, config ba
 	// Save container state to disk. So that if error happens before
 	// container meta file got removed from disk, then a restart of
 	// docker should not make a dead container alive.
-	if err := container.CheckpointTo(daemon.containersReplica); err != nil && !os.IsNotExist(err) {
+	if err := container.CheckpointTo(context.WithoutCancel(context.TODO()), daemon.containersReplica); err != nil && !os.IsNotExist(err) {
 		log.G(context.TODO()).Errorf("Error saving dying container to disk: %v", err)
 	}
 	container.Unlock()

--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -88,7 +88,7 @@ func (daemon *Daemon) killWithSignal(container *containerpkg.Container, stopSign
 
 	if !daemon.IsShuttingDown() {
 		container.HasBeenManuallyStopped = true
-		if err := container.CheckpointTo(daemon.containersReplica); err != nil {
+		if err := container.CheckpointTo(context.WithoutCancel(context.TODO()), daemon.containersReplica); err != nil {
 			log.G(context.TODO()).WithFields(log.Fields{
 				"error":     err,
 				"container": container.ID,

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -109,7 +109,7 @@ func (daemon *Daemon) handleContainerExit(c *container.Container, e *libcontaine
 	defer c.Unlock() // needs to be called before autoRemove
 
 	daemon.setStateCounter(c)
-	checkpointErr := c.CheckpointTo(daemon.containersReplica)
+	checkpointErr := c.CheckpointTo(context.TODO(), daemon.containersReplica)
 
 	daemon.LogContainerEventWithAttributes(c, events.ActionDie, attributes)
 
@@ -134,7 +134,7 @@ func (daemon *Daemon) handleContainerExit(c *container.Container, e *libcontaine
 				c.Lock()
 				c.SetStopped(&exitStatus)
 				daemon.setStateCounter(c)
-				c.CheckpointTo(daemon.containersReplica)
+				c.CheckpointTo(context.TODO(), daemon.containersReplica)
 				c.Unlock()
 				defer daemon.autoRemove(&cfg.Config, c)
 				if err != restartmanager.ErrRestartCanceled {
@@ -165,7 +165,7 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerdtypes.EventType, ei
 		defer c.Unlock()
 		c.OOMKilled = true
 		daemon.updateHealthMonitor(c)
-		if err := c.CheckpointTo(daemon.containersReplica); err != nil {
+		if err := c.CheckpointTo(context.TODO(), daemon.containersReplica); err != nil {
 			return err
 		}
 
@@ -261,7 +261,7 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerdtypes.EventType, ei
 
 			daemon.initHealthMonitor(c)
 
-			if err := c.CheckpointTo(daemon.containersReplica); err != nil {
+			if err := c.CheckpointTo(context.TODO(), daemon.containersReplica); err != nil {
 				return err
 			}
 			daemon.LogContainerEvent(c, events.ActionStart)
@@ -275,7 +275,7 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerdtypes.EventType, ei
 			c.Paused = true
 			daemon.setStateCounter(c)
 			daemon.updateHealthMonitor(c)
-			if err := c.CheckpointTo(daemon.containersReplica); err != nil {
+			if err := c.CheckpointTo(context.TODO(), daemon.containersReplica); err != nil {
 				return err
 			}
 			daemon.LogContainerEvent(c, events.ActionPause)
@@ -289,7 +289,7 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerdtypes.EventType, ei
 			daemon.setStateCounter(c)
 			daemon.updateHealthMonitor(c)
 
-			if err := c.CheckpointTo(daemon.containersReplica); err != nil {
+			if err := c.CheckpointTo(context.TODO(), daemon.containersReplica); err != nil {
 				return err
 			}
 			daemon.LogContainerEvent(c, events.ActionUnPause)

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -468,12 +468,12 @@ func (daemon *Daemon) UpdateContainerServiceConfig(containerName string, service
 // ConnectContainerToNetwork connects the given container to the given
 // network. If either cannot be found, an err is returned. If the
 // network cannot be set up, an err is returned.
-func (daemon *Daemon) ConnectContainerToNetwork(containerName, networkName string, endpointConfig *network.EndpointSettings) error {
+func (daemon *Daemon) ConnectContainerToNetwork(ctx context.Context, containerName, networkName string, endpointConfig *network.EndpointSettings) error {
 	ctr, err := daemon.GetContainer(containerName)
 	if err != nil {
 		return err
 	}
-	return daemon.ConnectToNetwork(ctr, networkName, endpointConfig)
+	return daemon.ConnectToNetwork(ctx, ctr, networkName, endpointConfig)
 }
 
 // DisconnectContainerFromNetwork disconnects the given container from

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -486,7 +486,7 @@ func (daemon *Daemon) DisconnectContainerFromNetwork(containerName string, netwo
 		}
 		return err
 	}
-	return daemon.DisconnectFromNetwork(ctr, networkName, force)
+	return daemon.DisconnectFromNetwork(context.TODO(), ctr, networkName, force)
 }
 
 // GetNetworkDriverList returns the list of plugins drivers

--- a/daemon/pause.go
+++ b/daemon/pause.go
@@ -49,7 +49,7 @@ func (daemon *Daemon) containerPause(container *container.Container) error {
 	daemon.updateHealthMonitor(container)
 	daemon.LogContainerEvent(container, events.ActionPause)
 
-	if err := container.CheckpointTo(daemon.containersReplica); err != nil {
+	if err := container.CheckpointTo(context.WithoutCancel(context.TODO()), daemon.containersReplica); err != nil {
 		log.G(context.TODO()).WithError(err).Warn("could not save container to disk")
 	}
 

--- a/daemon/rename.go
+++ b/daemon/rename.go
@@ -78,7 +78,7 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) (retErr error) {
 		daemon.linkIndex.unlink(oldName+k, v, container)
 		daemon.containersReplica.ReleaseName(oldName + k)
 	}
-	if err := container.CheckpointTo(daemon.containersReplica); err != nil {
+	if err := container.CheckpointTo(context.TODO(), daemon.containersReplica); err != nil {
 		return err
 	}
 
@@ -92,7 +92,7 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) (retErr error) {
 	defer func() {
 		if retErr != nil {
 			container.Name = oldName
-			if err := container.CheckpointTo(daemon.containersReplica); err != nil {
+			if err := container.CheckpointTo(context.WithoutCancel(context.TODO()), daemon.containersReplica); err != nil {
 				log.G(context.TODO()).WithFields(log.Fields{
 					"containerID": container.ID,
 					"error":       err,

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -208,7 +208,7 @@ func (daemon *Daemon) containerStart(ctx context.Context, daemonCfg *configStore
 		return err
 	}
 
-	if err := tsk.Start(context.TODO()); err != nil { // passing ctx caused integration tests to be stuck in the cleanup phase
+	if err := tsk.Start(context.WithoutCancel(ctx)); err != nil { // passing a cancelable ctx caused integration tests to be stuck in the cleanup phase
 		return setExitCodeFromError(container.SetExitCode, err)
 	}
 

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -189,7 +189,7 @@ func (daemon *Daemon) containerStart(ctx context.Context, daemonCfg *configStore
 
 	startupTime := time.Now()
 	// TODO(mlaventure): we need to specify checkpoint options here
-	tsk, err := ctr.NewTask(context.TODO(), // Passing ctx caused integration tests to be stuck in the cleanup phase
+	tsk, err := ctr.NewTask(context.WithoutCancel(ctx), // passing a cancelable ctx caused integration tests to be stuck in the cleanup phase
 		checkpointDir, container.StreamConfig.Stdin() != nil || container.Config.Tty,
 		container.InitializeStdio)
 	if err != nil {

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -93,7 +93,7 @@ func (daemon *Daemon) containerStart(ctx context.Context, daemonCfg *configStore
 			if container.ExitCode() == 0 {
 				container.SetExitCode(exitUnknown)
 			}
-			if err := container.CheckpointTo(daemon.containersReplica); err != nil {
+			if err := container.CheckpointTo(context.WithoutCancel(ctx), daemon.containersReplica); err != nil {
 				log.G(ctx).Errorf("%s: failed saving state on start failure: %v", container.ID, err)
 			}
 			container.Reset(false)
@@ -211,7 +211,7 @@ func (daemon *Daemon) containerStart(ctx context.Context, daemonCfg *configStore
 
 	daemon.initHealthMonitor(container)
 
-	if err := container.CheckpointTo(daemon.containersReplica); err != nil {
+	if err := container.CheckpointTo(context.WithoutCancel(ctx), daemon.containersReplica); err != nil {
 		log.G(ctx).WithError(err).WithField("container", container.ID).
 			Errorf("failed to store container")
 	}

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -233,7 +233,7 @@ func (daemon *Daemon) Cleanup(ctx context.Context, container *container.Containe
 		}
 	}
 
-	daemon.releaseNetwork(container)
+	daemon.releaseNetwork(ctx, container)
 
 	if err := container.UnmountIpcMount(); err != nil {
 		log.G(ctx).Warnf("%s cleanup: failed to unmount IPC: %s", container.ID, err)

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -114,7 +114,7 @@ func (daemon *Daemon) containerStart(ctx context.Context, daemonCfg *configStore
 		return err
 	}
 
-	if err := daemon.initializeNetworking(&daemonCfg.Config, container); err != nil {
+	if err := daemon.initializeNetworking(ctx, &daemonCfg.Config, container); err != nil {
 		return err
 	}
 

--- a/daemon/start_unix.go
+++ b/daemon/start_unix.go
@@ -3,6 +3,8 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"context"
+
 	"github.com/docker/docker/container"
 )
 
@@ -11,7 +13,7 @@ func (daemon *Daemon) getLibcontainerdCreateOptions(daemonCfg *configStore, cont
 	// Ensure a runtime has been assigned to this container
 	if container.HostConfig.Runtime == "" {
 		container.HostConfig.Runtime = daemonCfg.Runtimes.Default
-		container.CheckpointTo(daemon.containersReplica)
+		container.CheckpointTo(context.WithoutCancel(context.TODO()), daemon.containersReplica)
 	}
 
 	shim, opts, err := daemonCfg.Runtimes.Get(container.HostConfig.Runtime)

--- a/daemon/unpause.go
+++ b/daemon/unpause.go
@@ -41,7 +41,7 @@ func (daemon *Daemon) containerUnpause(ctr *container.Container) error {
 	daemon.updateHealthMonitor(ctr)
 	daemon.LogContainerEvent(ctr, events.ActionUnPause)
 
-	if err := ctr.CheckpointTo(daemon.containersReplica); err != nil {
+	if err := ctr.CheckpointTo(context.WithoutCancel(context.TODO()), daemon.containersReplica); err != nil {
 		log.G(context.TODO()).WithError(err).Warn("could not save container to disk")
 	}
 

--- a/daemon/update.go
+++ b/daemon/update.go
@@ -45,7 +45,7 @@ func (daemon *Daemon) update(name string, hostConfig *container.HostConfig) erro
 			ctr.Lock()
 			if !ctr.RemovalInProgress && !ctr.Dead {
 				ctr.HostConfig = &backupHostConfig
-				ctr.CheckpointTo(daemon.containersReplica)
+				ctr.CheckpointTo(context.WithoutCancel(context.TODO()), daemon.containersReplica)
 			}
 			ctr.Unlock()
 		}
@@ -63,7 +63,7 @@ func (daemon *Daemon) update(name string, hostConfig *container.HostConfig) erro
 		ctr.Unlock()
 		return errCannotUpdate(ctr.ID, err)
 	}
-	if err := ctr.CheckpointTo(daemon.containersReplica); err != nil {
+	if err := ctr.CheckpointTo(context.TODO(), daemon.containersReplica); err != nil {
 		restoreConfig = true
 		ctr.Unlock()
 		return errCannotUpdate(ctr.ID, err)

--- a/internal/otelutil/environ_carrier.go
+++ b/internal/otelutil/environ_carrier.go
@@ -1,0 +1,71 @@
+package otelutil
+
+import (
+	"os"
+)
+
+const (
+	traceParentKey = "traceparent"
+	traceStateKey  = "tracestate"
+
+	// See https://github.com/open-telemetry/opentelemetry-specification/issues/740
+	// and https://github.com/open-telemetry/oteps/pull/258.
+	traceParentEnvVar = "TRACEPARENT"
+	traceStateEnvVar  = "TRACESTATE"
+)
+
+type EnvironCarrier struct {
+	TraceParent, TraceState string
+}
+
+// Get returns the value associated with the passed key.
+func (c *EnvironCarrier) Get(key string) string {
+	switch key {
+	case traceParentKey:
+		return c.TraceParent
+	case traceStateKey:
+		return c.TraceState
+	}
+	return ""
+}
+
+// Set stores the key-value pair.
+func (c *EnvironCarrier) Set(key, value string) {
+	switch key {
+	case traceParentKey:
+		c.TraceParent = value
+	case traceStateKey:
+		c.TraceState = value
+	}
+	// Other keys are not supported at this time.
+}
+
+// Keys lists the keys stored in this carrier.
+func (c *EnvironCarrier) Keys() []string {
+	var k []string
+	if c.TraceParent != "" {
+		k = append(k, traceParentKey)
+	}
+	if c.TraceState != "" {
+		k = append(k, traceStateKey)
+	}
+	return k
+}
+
+func (c *EnvironCarrier) Environ() []string {
+	var env []string
+	if c.TraceParent != "" {
+		env = append(env, traceParentEnvVar+"="+c.TraceParent)
+	}
+	if c.TraceState != "" {
+		env = append(env, traceStateEnvVar+"="+c.TraceState)
+	}
+	return env
+}
+
+func PropagateFromEnvironment() *EnvironCarrier {
+	return &EnvironCarrier{
+		TraceParent: os.Getenv(traceParentEnvVar),
+		TraceState:  os.Getenv(traceStateEnvVar),
+	}
+}

--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -34,6 +34,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -153,6 +154,9 @@ func (c *container) NewTask(ctx context.Context, checkpointDir string, withStdin
 		rio            cio.IO
 		stdinCloseSync = make(chan containerd.Process, 1)
 	)
+
+	ctx, span := otel.Tracer("").Start(ctx, "libcontainerd.remote.NewTask")
+	defer span.End()
 
 	if checkpointDir != "" {
 		// write checkpoint to the content store

--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -244,6 +244,8 @@ func (c *container) NewTask(ctx context.Context, checkpointDir string, withStdin
 }
 
 func (t *task) Start(ctx context.Context) error {
+	ctx, span := otel.Tracer("").Start(ctx, "libcontainerd.remote.task.Start")
+	defer span.End()
 	return wrapError(t.Task.Start(ctx))
 
 }

--- a/libnetwork/cnmallocator/manager.go
+++ b/libnetwork/cnmallocator/manager.go
@@ -55,7 +55,7 @@ func (d *manager) EndpointOperInfo(nid, eid string) (map[string]interface{}, err
 	return nil, types.NotImplementedErrorf("not implemented")
 }
 
-func (d *manager) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (d *manager) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/cnmallocator/manager.go
+++ b/libnetwork/cnmallocator/manager.go
@@ -71,7 +71,7 @@ func (d *manager) IsBuiltIn() bool {
 	return true
 }
 
-func (d *manager) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
+func (d *manager) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/cnmallocator/manager.go
+++ b/libnetwork/cnmallocator/manager.go
@@ -1,6 +1,8 @@
 package cnmallocator
 
 import (
+	"context"
+
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
@@ -41,7 +43,7 @@ func (d *manager) DeleteNetwork(nid string) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 
-func (d *manager) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
+func (d *manager) CreateEndpoint(_ context.Context, nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -73,6 +73,7 @@ import (
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/moby/locker"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel"
 )
 
 // NetworkWalker is a client provided function which will be used to walk the Networks.
@@ -871,10 +872,13 @@ func (c *Controller) NetworkByID(id string) (*Network, error) {
 }
 
 // NewSandbox creates a new sandbox for containerID.
-func (c *Controller) NewSandbox(containerID string, options ...SandboxOption) (_ *Sandbox, retErr error) {
+func (c *Controller) NewSandbox(ctx context.Context, containerID string, options ...SandboxOption) (_ *Sandbox, retErr error) {
 	if containerID == "" {
 		return nil, types.InvalidParameterErrorf("invalid container ID")
 	}
+
+	ctx, span := otel.Tracer("").Start(ctx, "libnetwork.Controller.NewSandbox")
+	defer span.End()
 
 	var sb *Sandbox
 	c.mu.Lock()

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -24,7 +24,7 @@ create network namespaces and allocate interfaces for containers to use.
 	// settings will be used for container infos (inspect and such), as well as
 	// iptables rules for port publishing. This info is contained or accessible
 	// from the returned endpoint.
-	ep, err := network.CreateEndpoint("Endpoint1")
+	ep, err := network.CreateEndpoint(context.TODO(), "Endpoint1")
 	if err != nil {
 		return
 	}

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -949,7 +949,7 @@ func (c *Controller) NewSandbox(ctx context.Context, containerID string, options
 		}
 	}()
 
-	if err := sb.setupResolutionFiles(); err != nil {
+	if err := sb.setupResolutionFiles(ctx); err != nil {
 		return nil, err
 	}
 	if err := c.setupOSLSandbox(sb); err != nil {

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -656,7 +656,7 @@ addToStore:
 	// end up with a datastore containing a network and not an epCnt,
 	// in case of an ungraceful shutdown during this function call.
 	epCnt := &endpointCnt{n: nw}
-	if err := c.updateToStore(epCnt); err != nil {
+	if err := c.updateToStore(context.TODO(), epCnt); err != nil {
 		return nil, err
 	}
 	defer func() {
@@ -668,7 +668,7 @@ addToStore:
 	}()
 
 	nw.epCnt = epCnt
-	if err := c.updateToStore(nw); err != nil {
+	if err := c.updateToStore(context.TODO(), nw); err != nil {
 		return nil, err
 	}
 	defer func() {
@@ -967,7 +967,7 @@ func (c *Controller) NewSandbox(ctx context.Context, containerID string, options
 		}
 	}()
 
-	if err := sb.storeUpdate(); err != nil {
+	if err := sb.storeUpdate(ctx); err != nil {
 		return nil, fmt.Errorf("failed to update the store state of sandbox: %v", err)
 	}
 

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -1016,7 +1016,7 @@ func (c *Controller) SandboxByID(id string) (*Sandbox, error) {
 }
 
 // SandboxDestroy destroys a sandbox given a container ID.
-func (c *Controller) SandboxDestroy(id string) error {
+func (c *Controller) SandboxDestroy(ctx context.Context, id string) error {
 	var sb *Sandbox
 	c.mu.Lock()
 	for _, s := range c.sandboxes {
@@ -1032,7 +1032,7 @@ func (c *Controller) SandboxDestroy(id string) error {
 		return nil
 	}
 
-	return sb.Delete()
+	return sb.Delete(ctx)
 }
 
 func (c *Controller) loadDriver(networkType string) error {

--- a/libnetwork/default_gateway.go
+++ b/libnetwork/default_gateway.go
@@ -78,7 +78,7 @@ func (sb *Sandbox) setupDefaultGW() error {
 
 	defer func() {
 		if err != nil {
-			if err2 := newEp.Delete(true); err2 != nil {
+			if err2 := newEp.Delete(context.WithoutCancel(context.TODO()), true); err2 != nil {
 				log.G(context.TODO()).Warnf("Failed to remove gw endpoint for container %s after failing to join the gateway network: %v",
 					sb.containerID, err2)
 			}
@@ -99,10 +99,10 @@ func (sb *Sandbox) clearDefaultGW() error {
 	if ep = sb.getEndpointInGWNetwork(); ep == nil {
 		return nil
 	}
-	if err := ep.sbLeave(sb, false); err != nil {
+	if err := ep.sbLeave(context.TODO(), sb, false); err != nil {
 		return fmt.Errorf("container %s: endpoint leaving GW Network failed: %v", sb.containerID, err)
 	}
-	if err := ep.Delete(false); err != nil {
+	if err := ep.Delete(context.TODO(), false); err != nil {
 		return fmt.Errorf("container %s: deleting endpoint on GW Network failed: %v", sb.containerID, err)
 	}
 	return nil

--- a/libnetwork/default_gateway.go
+++ b/libnetwork/default_gateway.go
@@ -85,7 +85,7 @@ func (sb *Sandbox) setupDefaultGW() error {
 		}
 	}()
 
-	if err = newEp.sbJoin(sb); err != nil {
+	if err = newEp.sbJoin(context.TODO(), sb); err != nil {
 		return fmt.Errorf("container %s: endpoint join on GW Network failed: %v", sb.containerID, err)
 	}
 

--- a/libnetwork/default_gateway.go
+++ b/libnetwork/default_gateway.go
@@ -71,7 +71,7 @@ func (sb *Sandbox) setupDefaultGW() error {
 		createOptions = append(createOptions, epOption)
 	}
 
-	newEp, err := n.CreateEndpoint(gwName, createOptions...)
+	newEp, err := n.CreateEndpoint(context.TODO(), gwName, createOptions...)
 	if err != nil {
 		return fmt.Errorf("container %s: endpoint create on GW Network failed: %v", sb.containerID, err)
 	}

--- a/libnetwork/driverapi/driverapi.go
+++ b/libnetwork/driverapi/driverapi.go
@@ -49,7 +49,7 @@ type Driver interface {
 	EndpointOperInfo(nid, eid string) (map[string]interface{}, error)
 
 	// Join method is invoked when a Sandbox is attached to an endpoint.
-	Join(nid, eid string, sboxKey string, jinfo JoinInfo, options map[string]interface{}) error
+	Join(ctx context.Context, nid, eid string, sboxKey string, jinfo JoinInfo, options map[string]interface{}) error
 
 	// Leave method is invoked when a Sandbox detaches from an endpoint.
 	Leave(nid, eid string) error

--- a/libnetwork/driverapi/driverapi.go
+++ b/libnetwork/driverapi/driverapi.go
@@ -56,7 +56,7 @@ type Driver interface {
 
 	// ProgramExternalConnectivity invokes the driver method which does the necessary
 	// programming to allow the external connectivity dictated by the passed options
-	ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error
+	ProgramExternalConnectivity(ctx context.Context, nid, eid string, options map[string]interface{}) error
 
 	// RevokeExternalConnectivity asks the driver to remove any external connectivity
 	// programming that was done so far

--- a/libnetwork/driverapi/driverapi.go
+++ b/libnetwork/driverapi/driverapi.go
@@ -1,6 +1,9 @@
 package driverapi
 
-import "net"
+import (
+	"context"
+	"net"
+)
 
 // NetworkPluginEndpointType represents the Endpoint Type used by Plugin system
 const NetworkPluginEndpointType = "NetworkDriver"
@@ -36,7 +39,7 @@ type Driver interface {
 	// specific config. The endpoint information can be either consumed by
 	// the driver or populated by the driver. The config mechanism will
 	// eventually be replaced with labels which are yet to be introduced.
-	CreateEndpoint(nid, eid string, ifInfo InterfaceInfo, options map[string]interface{}) error
+	CreateEndpoint(ctx context.Context, nid, eid string, ifInfo InterfaceInfo, options map[string]interface{}) error
 
 	// DeleteEndpoint invokes the driver method to delete an endpoint
 	// passing the network id and endpoint id.

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -750,7 +750,7 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 		return err
 	}
 
-	return d.storeUpdate(config)
+	return d.storeUpdate(context.TODO(), config)
 }
 
 func (d *driver) checkConflict(config *networkConfiguration) error {
@@ -1183,7 +1183,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 		}
 	}
 
-	if err = d.storeUpdate(endpoint); err != nil {
+	if err = d.storeUpdate(ctx, endpoint); err != nil {
 		return fmt.Errorf("failed to save bridge endpoint %.7s to store: %v", endpoint.id, err)
 	}
 
@@ -1443,7 +1443,7 @@ func (d *driver) ProgramExternalConnectivity(ctx context.Context, nid, eid strin
 	// be bound to the local proxy, or to the host (for UDP packets), and won't be redirected to the new endpoints.
 	clearConntrackEntries(d.nlh, endpoint)
 
-	if err = d.storeUpdate(endpoint); err != nil {
+	if err = d.storeUpdate(ctx, endpoint); err != nil {
 		return fmt.Errorf("failed to update bridge endpoint %.7s to store: %v", endpoint.id, err)
 	}
 
@@ -1481,7 +1481,7 @@ func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
 	// to bad NATing.
 	clearConntrackEntries(d.nlh, endpoint)
 
-	if err = d.storeUpdate(endpoint); err != nil {
+	if err = d.storeUpdate(context.TODO(), endpoint); err != nil {
 		return fmt.Errorf("failed to update bridge endpoint %.7s to store: %v", endpoint.id, err)
 	}
 

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -1319,7 +1319,13 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 }
 
 // Join method is invoked when a Sandbox is attached to an endpoint.
-func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+	ctx, span := otel.Tracer("").Start(ctx, "libnetwork.drivers.bridge.Join", trace.WithAttributes(
+		attribute.String("nid", nid),
+		attribute.String("eid", eid),
+		attribute.String("sboxKey", sboxKey)))
+	defer span.End()
+
 	network, err := d.getNetwork(nid)
 	if err != nil {
 		return err

--- a/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -2,6 +2,7 @@ package bridge
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -282,7 +283,7 @@ func TestCreateFullOptions(t *testing.T) {
 	// Verify the IP address allocated for the endpoint belongs to the container network
 	epOptions := make(map[string]interface{})
 	te := newTestEndpoint(cnw, 10)
-	err = d.CreateEndpoint("dummy", "ep1", te.Interface(), epOptions)
+	err = d.CreateEndpoint(context.Background(), "dummy", "ep1", te.Interface(), epOptions)
 	if err != nil {
 		t.Fatalf("Failed to create an endpoint : %s", err.Error())
 	}
@@ -397,7 +398,7 @@ func TestCreateFullOptionsLabels(t *testing.T) {
 	// plus --mac-address run option
 	te := newTestEndpoint(ipdList[0].Pool, 20)
 	te.iface.mac = netutils.MustParseMAC("aa:bb:cc:dd:ee:ff")
-	err = d.CreateEndpoint("dummy", "ep1", te.Interface(), map[string]interface{}{})
+	err = d.CreateEndpoint(context.Background(), "dummy", "ep1", te.Interface(), map[string]interface{}{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -700,7 +701,7 @@ func testQueryEndpointInfo(t *testing.T, ulPxyEnabled bool) {
 	sbOptions[netlabel.PortMap] = getPortMapping()
 
 	te := newTestEndpoint(ipdList[0].Pool, 11)
-	err = d.CreateEndpoint("net1", "ep1", te.Interface(), nil)
+	err = d.CreateEndpoint(context.Background(), "net1", "ep1", te.Interface(), nil)
 	if err != nil {
 		t.Fatalf("Failed to create an endpoint : %s", err.Error())
 	}
@@ -799,7 +800,7 @@ func TestLinkContainers(t *testing.T) {
 	}
 
 	te1 := newTestEndpoint(ipdList[0].Pool, 11)
-	err = d.CreateEndpoint("net1", "ep1", te1.Interface(), nil)
+	err = d.CreateEndpoint(context.Background(), "net1", "ep1", te1.Interface(), nil)
 	if err != nil {
 		t.Fatalf("Failed to create an endpoint : %s", err.Error())
 	}
@@ -824,7 +825,7 @@ func TestLinkContainers(t *testing.T) {
 	}
 
 	te2 := newTestEndpoint(ipdList[0].Pool, 22)
-	err = d.CreateEndpoint("net1", "ep2", te2.Interface(), nil)
+	err = d.CreateEndpoint(context.Background(), "net1", "ep2", te2.Interface(), nil)
 	if err != nil {
 		t.Fatalf("Failed to create an endpoint : %s", err.Error())
 	}
@@ -1107,7 +1108,7 @@ func TestSetDefaultGw(t *testing.T) {
 	}
 
 	te := newTestEndpoint(ipdList[0].Pool, 10)
-	err = d.CreateEndpoint("dummy", "ep", te.Interface(), nil)
+	err = d.CreateEndpoint(context.Background(), "dummy", "ep", te.Interface(), nil)
 	if err != nil {
 		t.Fatalf("Failed to create endpoint: %v", err)
 	}

--- a/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -706,7 +706,7 @@ func testQueryEndpointInfo(t *testing.T, ulPxyEnabled bool) {
 		t.Fatalf("Failed to create an endpoint : %s", err.Error())
 	}
 
-	err = d.Join("net1", "ep1", "sbox", te, sbOptions)
+	err = d.Join(context.Background(), "net1", "ep1", "sbox", te, sbOptions)
 	if err != nil {
 		t.Fatalf("Failed to join the endpoint: %v", err)
 	}
@@ -809,7 +809,7 @@ func TestLinkContainers(t *testing.T) {
 	sbOptions := make(map[string]interface{})
 	sbOptions[netlabel.ExposedPorts] = exposedPorts
 
-	err = d.Join("net1", "ep1", "sbox", te1, sbOptions)
+	err = d.Join(context.Background(), "net1", "ep1", "sbox", te1, sbOptions)
 	if err != nil {
 		t.Fatalf("Failed to join the endpoint: %v", err)
 	}
@@ -840,7 +840,7 @@ func TestLinkContainers(t *testing.T) {
 		"ChildEndpoints": []string{"ep1"},
 	}
 
-	err = d.Join("net1", "ep2", "", te2, sbOptions)
+	err = d.Join(context.Background(), "net1", "ep2", "", te2, sbOptions)
 	if err != nil {
 		t.Fatal("Failed to link ep1 and ep2")
 	}
@@ -898,7 +898,7 @@ func TestLinkContainers(t *testing.T) {
 		"ChildEndpoints": []string{"ep1", "ep4"},
 	}
 
-	err = d.Join("net1", "ep2", "", te2, sbOptions)
+	err = d.Join(context.Background(), "net1", "ep2", "", te2, sbOptions)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1113,7 +1113,7 @@ func TestSetDefaultGw(t *testing.T) {
 		t.Fatalf("Failed to create endpoint: %v", err)
 	}
 
-	err = d.Join("dummy", "ep", "sbox", te, nil)
+	err = d.Join(context.Background(), "dummy", "ep", "sbox", te, nil)
 	if err != nil {
 		t.Fatalf("Failed to join endpoint: %v", err)
 	}

--- a/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -711,7 +711,7 @@ func testQueryEndpointInfo(t *testing.T, ulPxyEnabled bool) {
 		t.Fatalf("Failed to join the endpoint: %v", err)
 	}
 
-	err = d.ProgramExternalConnectivity("net1", "ep1", sbOptions)
+	err = d.ProgramExternalConnectivity(context.Background(), "net1", "ep1", sbOptions)
 	if err != nil {
 		t.Fatalf("Failed to program external connectivity: %v", err)
 	}
@@ -814,7 +814,7 @@ func TestLinkContainers(t *testing.T) {
 		t.Fatalf("Failed to join the endpoint: %v", err)
 	}
 
-	err = d.ProgramExternalConnectivity("net1", "ep1", sbOptions)
+	err = d.ProgramExternalConnectivity(context.Background(), "net1", "ep1", sbOptions)
 	if err != nil {
 		t.Fatalf("Failed to program external connectivity: %v", err)
 	}
@@ -845,7 +845,7 @@ func TestLinkContainers(t *testing.T) {
 		t.Fatal("Failed to link ep1 and ep2")
 	}
 
-	err = d.ProgramExternalConnectivity("net1", "ep2", sbOptions)
+	err = d.ProgramExternalConnectivity(context.Background(), "net1", "ep2", sbOptions)
 	if err != nil {
 		t.Fatalf("Failed to program external connectivity: %v", err)
 	}
@@ -902,7 +902,7 @@ func TestLinkContainers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = d.ProgramExternalConnectivity("net1", "ep2", sbOptions)
+	err = d.ProgramExternalConnectivity(context.Background(), "net1", "ep2", sbOptions)
 	if err != nil {
 		out, _ = iptable.Raw("-L", DockerChain)
 		for _, pm := range exposedPorts {

--- a/libnetwork/drivers/bridge/brmanager/brmanager.go
+++ b/libnetwork/drivers/bridge/brmanager/brmanager.go
@@ -1,6 +1,8 @@
 package brmanager
 
 import (
+	"context"
+
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
@@ -41,7 +43,7 @@ func (d *driver) DeleteNetwork(nid string) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 
-func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
+func (d *driver) CreateEndpoint(_ context.Context, nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/drivers/bridge/brmanager/brmanager.go
+++ b/libnetwork/drivers/bridge/brmanager/brmanager.go
@@ -55,7 +55,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 	return nil, types.NotImplementedErrorf("not implemented")
 }
 
-func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/drivers/bridge/brmanager/brmanager.go
+++ b/libnetwork/drivers/bridge/brmanager/brmanager.go
@@ -71,7 +71,7 @@ func (d *driver) IsBuiltIn() bool {
 	return true
 }
 
-func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
+func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/drivers/bridge/network_linux_test.go
+++ b/libnetwork/drivers/bridge/network_linux_test.go
@@ -49,7 +49,7 @@ func TestLinkCreate(t *testing.T) {
 		t.Fatalf("Failed to create a link: %s", err.Error())
 	}
 
-	err = d.Join("dummy", "ep", "sbox", te, nil)
+	err = d.Join(context.Background(), "dummy", "ep", "sbox", te, nil)
 	if err != nil {
 		t.Fatalf("Failed to create a link: %s", err.Error())
 	}

--- a/libnetwork/drivers/bridge/network_linux_test.go
+++ b/libnetwork/drivers/bridge/network_linux_test.go
@@ -1,6 +1,7 @@
 package bridge
 
 import (
+	"context"
 	"testing"
 
 	"github.com/docker/docker/internal/testutils/netnsutils"
@@ -33,7 +34,7 @@ func TestLinkCreate(t *testing.T) {
 	}
 
 	te := newTestEndpoint(ipdList[0].Pool, 10)
-	err = d.CreateEndpoint("dummy", "", te.Interface(), nil)
+	err = d.CreateEndpoint(context.Background(), "dummy", "", te.Interface(), nil)
 	if err != nil {
 		if _, ok := err.(InvalidEndpointIDError); !ok {
 			t.Fatalf("Failed with a wrong error :%s", err.Error())
@@ -43,7 +44,7 @@ func TestLinkCreate(t *testing.T) {
 	}
 
 	// Good endpoint creation
-	err = d.CreateEndpoint("dummy", "ep", te.Interface(), nil)
+	err = d.CreateEndpoint(context.Background(), "dummy", "ep", te.Interface(), nil)
 	if err != nil {
 		t.Fatalf("Failed to create a link: %s", err.Error())
 	}
@@ -65,7 +66,7 @@ func TestLinkCreate(t *testing.T) {
 	// then we could check the MTU on hostLnk as well.
 
 	te1 := newTestEndpoint(ipdList[0].Pool, 11)
-	err = d.CreateEndpoint("dummy", "ep", te1.Interface(), nil)
+	err = d.CreateEndpoint(context.Background(), "dummy", "ep", te1.Interface(), nil)
 	if err == nil {
 		t.Fatal("Failed to detect duplicate endpoint id on same network")
 	}
@@ -126,13 +127,13 @@ func TestLinkCreateTwo(t *testing.T) {
 	}
 
 	te1 := newTestEndpoint(ipdList[0].Pool, 11)
-	err = d.CreateEndpoint("dummy", "ep", te1.Interface(), nil)
+	err = d.CreateEndpoint(context.Background(), "dummy", "ep", te1.Interface(), nil)
 	if err != nil {
 		t.Fatalf("Failed to create a link: %s", err.Error())
 	}
 
 	te2 := newTestEndpoint(ipdList[0].Pool, 12)
-	err = d.CreateEndpoint("dummy", "ep", te2.Interface(), nil)
+	err = d.CreateEndpoint(context.Background(), "dummy", "ep", te2.Interface(), nil)
 	if err != nil {
 		if _, ok := err.(driverapi.ErrEndpointExists); !ok {
 			t.Fatalf("Failed with a wrong error: %s", err.Error())
@@ -162,7 +163,7 @@ func TestLinkCreateNoEnableIPv6(t *testing.T) {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
 	te := newTestEndpoint(ipdList[0].Pool, 30)
-	err = d.CreateEndpoint("dummy", "ep", te.Interface(), nil)
+	err = d.CreateEndpoint(context.Background(), "dummy", "ep", te.Interface(), nil)
 	if err != nil {
 		t.Fatalf("Failed to create a link: %s", err.Error())
 	}
@@ -199,7 +200,7 @@ func TestLinkDelete(t *testing.T) {
 	}
 
 	te := newTestEndpoint(ipdList[0].Pool, 30)
-	err = d.CreateEndpoint("dummy", "ep1", te.Interface(), nil)
+	err = d.CreateEndpoint(context.Background(), "dummy", "ep1", te.Interface(), nil)
 	if err != nil {
 		t.Fatalf("Failed to create a link: %s", err.Error())
 	}

--- a/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -58,7 +58,7 @@ func TestPortMappingConfig(t *testing.T) {
 		t.Fatalf("Failed to create the endpoint: %s", err.Error())
 	}
 
-	if err = d.Join("dummy", "ep1", "sbox", te, sbOptions); err != nil {
+	if err = d.Join(context.Background(), "dummy", "ep1", "sbox", te, sbOptions); err != nil {
 		t.Fatalf("Failed to join the endpoint: %v", err)
 	}
 
@@ -143,7 +143,7 @@ func TestPortMappingV6Config(t *testing.T) {
 		t.Fatalf("Failed to create the endpoint: %s", err.Error())
 	}
 
-	if err = d.Join("dummy", "ep1", "sbox", te, sbOptions); err != nil {
+	if err = d.Join(context.Background(), "dummy", "ep1", "sbox", te, sbOptions); err != nil {
 		t.Fatalf("Failed to join the endpoint: %v", err)
 	}
 

--- a/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -62,7 +62,7 @@ func TestPortMappingConfig(t *testing.T) {
 		t.Fatalf("Failed to join the endpoint: %v", err)
 	}
 
-	if err = d.ProgramExternalConnectivity("dummy", "ep1", sbOptions); err != nil {
+	if err = d.ProgramExternalConnectivity(context.Background(), "dummy", "ep1", sbOptions); err != nil {
 		t.Fatalf("Failed to program external connectivity: %v", err)
 	}
 
@@ -147,7 +147,7 @@ func TestPortMappingV6Config(t *testing.T) {
 		t.Fatalf("Failed to join the endpoint: %v", err)
 	}
 
-	if err = d.ProgramExternalConnectivity("dummy", "ep1", sbOptions); err != nil {
+	if err = d.ProgramExternalConnectivity(context.Background(), "dummy", "ep1", sbOptions); err != nil {
 		t.Fatalf("Failed to program external connectivity: %v", err)
 	}
 

--- a/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -1,6 +1,7 @@
 package bridge
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -52,7 +53,7 @@ func TestPortMappingConfig(t *testing.T) {
 	}
 
 	te := newTestEndpoint(ipdList4[0].Pool, 11)
-	err = d.CreateEndpoint("dummy", "ep1", te.Interface(), nil)
+	err = d.CreateEndpoint(context.Background(), "dummy", "ep1", te.Interface(), nil)
 	if err != nil {
 		t.Fatalf("Failed to create the endpoint: %s", err.Error())
 	}
@@ -137,7 +138,7 @@ func TestPortMappingV6Config(t *testing.T) {
 	}
 
 	te := newTestEndpoint(ipdList4[0].Pool, 11)
-	err = d.CreateEndpoint("dummy", "ep1", te.Interface(), nil)
+	err = d.CreateEndpoint(context.Background(), "dummy", "ep1", te.Interface(), nil)
 	if err != nil {
 		t.Fatalf("Failed to create the endpoint: %s", err.Error())
 	}

--- a/libnetwork/drivers/host/host.go
+++ b/libnetwork/drivers/host/host.go
@@ -1,6 +1,7 @@
 package host
 
 import (
+	"context"
 	"sync"
 
 	"github.com/docker/docker/libnetwork/driverapi"
@@ -54,7 +55,7 @@ func (d *driver) DeleteNetwork(nid string) error {
 	return types.ForbiddenErrorf("network of type %q cannot be deleted", NetworkType)
 }
 
-func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
+func (d *driver) CreateEndpoint(_ context.Context, nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
 	return nil
 }
 

--- a/libnetwork/drivers/host/host.go
+++ b/libnetwork/drivers/host/host.go
@@ -68,7 +68,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 }
 
 // Join method is invoked when a Sandbox is attached to an endpoint.
-func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
 	return nil
 }
 

--- a/libnetwork/drivers/host/host.go
+++ b/libnetwork/drivers/host/host.go
@@ -77,7 +77,7 @@ func (d *driver) Leave(nid, eid string) error {
 	return nil
 }
 
-func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
+func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
 	return nil
 }
 

--- a/libnetwork/drivers/ipvlan/ipvlan.go
+++ b/libnetwork/drivers/ipvlan/ipvlan.go
@@ -3,6 +3,7 @@
 package ipvlan
 
 import (
+	"context"
 	"net"
 	"sync"
 
@@ -95,7 +96,7 @@ func (d *driver) IsBuiltIn() bool {
 	return true
 }
 
-func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
+func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
 	return nil
 }
 

--- a/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CreateEndpoint assigns the mac, ip and endpoint id for the new container
-func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
+func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
 	if err := validateID(nid, eid); err != nil {
 		return err
 	}
@@ -38,7 +38,7 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 	if opt, ok := epOptions[netlabel.PortMap]; ok {
 		if _, ok := opt.([]types.PortBinding); ok {
 			if len(opt.([]types.PortBinding)) > 0 {
-				log.G(context.TODO()).Warnf("ipvlan driver does not support port mappings")
+				log.G(ctx).Warnf("ipvlan driver does not support port mappings")
 			}
 		}
 	}
@@ -46,7 +46,7 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 	if opt, ok := epOptions[netlabel.ExposedPorts]; ok {
 		if _, ok := opt.([]types.TransportPort); ok {
 			if len(opt.([]types.TransportPort)) > 0 {
-				log.G(context.TODO()).Warnf("ipvlan driver does not support port exposures")
+				log.G(ctx).Warnf("ipvlan driver does not support port exposures")
 			}
 		}
 	}

--- a/libnetwork/drivers/ipvlan/ivmanager/ivmanager.go
+++ b/libnetwork/drivers/ipvlan/ivmanager/ivmanager.go
@@ -1,6 +1,8 @@
 package ivmanager
 
 import (
+	"context"
+
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
@@ -41,7 +43,7 @@ func (d *driver) DeleteNetwork(nid string) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 
-func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
+func (d *driver) CreateEndpoint(_ context.Context, nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/drivers/ipvlan/ivmanager/ivmanager.go
+++ b/libnetwork/drivers/ipvlan/ivmanager/ivmanager.go
@@ -55,7 +55,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 	return nil, types.NotImplementedErrorf("not implemented")
 }
 
-func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/drivers/ipvlan/ivmanager/ivmanager.go
+++ b/libnetwork/drivers/ipvlan/ivmanager/ivmanager.go
@@ -71,7 +71,7 @@ func (d *driver) IsBuiltIn() bool {
 	return true
 }
 
-func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
+func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/drivers/macvlan/macvlan.go
+++ b/libnetwork/drivers/macvlan/macvlan.go
@@ -3,6 +3,7 @@
 package macvlan
 
 import (
+	"context"
 	"net"
 	"sync"
 
@@ -89,7 +90,7 @@ func (d *driver) IsBuiltIn() bool {
 	return true
 }
 
-func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
+func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
 	return nil
 }
 

--- a/libnetwork/drivers/macvlan/macvlan_endpoint.go
+++ b/libnetwork/drivers/macvlan/macvlan_endpoint.go
@@ -15,7 +15,7 @@ import (
 )
 
 // CreateEndpoint assigns the mac, ip and endpoint id for the new container
-func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
+func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
 	if err := validateID(nid, eid); err != nil {
 		return err
 	}
@@ -43,7 +43,7 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 	if opt, ok := epOptions[netlabel.PortMap]; ok {
 		if _, ok := opt.([]types.PortBinding); ok {
 			if len(opt.([]types.PortBinding)) > 0 {
-				log.G(context.TODO()).Warnf("macvlan driver does not support port mappings")
+				log.G(ctx).Warnf("macvlan driver does not support port mappings")
 			}
 		}
 	}
@@ -51,7 +51,7 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 	if opt, ok := epOptions[netlabel.ExposedPorts]; ok {
 		if _, ok := opt.([]types.TransportPort); ok {
 			if len(opt.([]types.TransportPort)) > 0 {
-				log.G(context.TODO()).Warnf("macvlan driver does not support port exposures")
+				log.G(ctx).Warnf("macvlan driver does not support port exposures")
 			}
 		}
 	}

--- a/libnetwork/drivers/macvlan/mvmanager/mvmanager.go
+++ b/libnetwork/drivers/macvlan/mvmanager/mvmanager.go
@@ -1,6 +1,8 @@
 package mvmanager
 
 import (
+	"context"
+
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
@@ -41,7 +43,7 @@ func (d *driver) DeleteNetwork(nid string) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 
-func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
+func (d *driver) CreateEndpoint(_ context.Context, nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/drivers/macvlan/mvmanager/mvmanager.go
+++ b/libnetwork/drivers/macvlan/mvmanager/mvmanager.go
@@ -55,7 +55,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 	return nil, types.NotImplementedErrorf("not implemented")
 }
 
-func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/drivers/macvlan/mvmanager/mvmanager.go
+++ b/libnetwork/drivers/macvlan/mvmanager/mvmanager.go
@@ -71,7 +71,7 @@ func (d *driver) IsBuiltIn() bool {
 	return true
 }
 
-func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
+func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/drivers/null/null.go
+++ b/libnetwork/drivers/null/null.go
@@ -68,7 +68,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 }
 
 // Join method is invoked when a Sandbox is attached to an endpoint.
-func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
 	return nil
 }
 

--- a/libnetwork/drivers/null/null.go
+++ b/libnetwork/drivers/null/null.go
@@ -1,6 +1,7 @@
 package null
 
 import (
+	"context"
 	"sync"
 
 	"github.com/docker/docker/libnetwork/driverapi"
@@ -54,7 +55,7 @@ func (d *driver) DeleteNetwork(nid string) error {
 	return types.ForbiddenErrorf("network of type %q cannot be deleted", NetworkType)
 }
 
-func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
+func (d *driver) CreateEndpoint(_ context.Context, nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
 	return nil
 }
 

--- a/libnetwork/drivers/null/null.go
+++ b/libnetwork/drivers/null/null.go
@@ -77,7 +77,7 @@ func (d *driver) Leave(nid, eid string) error {
 	return nil
 }
 
-func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
+func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
 	return nil
 }
 

--- a/libnetwork/drivers/overlay/ov_endpoint.go
+++ b/libnetwork/drivers/overlay/ov_endpoint.go
@@ -42,7 +42,7 @@ func (n *network) deleteEndpoint(eid string) {
 	n.Unlock()
 }
 
-func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
+func (d *driver) CreateEndpoint(_ context.Context, nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
 	var err error
 	if err = validateID(nid, eid); err != nil {
 		return err

--- a/libnetwork/drivers/overlay/ov_network.go
+++ b/libnetwork/drivers/overlay/ov_network.go
@@ -235,7 +235,7 @@ func (d *driver) DeleteNetwork(nid string) error {
 	return nil
 }
 
-func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
+func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
 	return nil
 }
 

--- a/libnetwork/drivers/overlay/ov_network.go
+++ b/libnetwork/drivers/overlay/ov_network.go
@@ -426,7 +426,7 @@ func (n *network) setupSubnetSandbox(s *subnet, brName, vxlanName string) error 
 	// create a bridge and vxlan device for this subnet and move it to the sandbox
 	sbox := n.sbox
 
-	if err := sbox.AddInterface(brName, "br", osl.WithIPv4Address(s.gwIP), osl.WithIsBridge(true)); err != nil {
+	if err := sbox.AddInterface(context.TODO(), brName, "br", osl.WithIPv4Address(s.gwIP), osl.WithIsBridge(true)); err != nil {
 		return fmt.Errorf("bridge creation in sandbox failed for subnet %q: %v", s.subnetIP.String(), err)
 	}
 
@@ -438,7 +438,7 @@ func (n *network) setupSubnetSandbox(s *subnet, brName, vxlanName string) error 
 		return err
 	}
 
-	if err := sbox.AddInterface(vxlanName, "vxlan", osl.WithMaster(brName)); err != nil {
+	if err := sbox.AddInterface(context.TODO(), vxlanName, "vxlan", osl.WithMaster(brName)); err != nil {
 		// If adding vxlan device to the overlay namespace fails, remove the bridge interface we
 		// already added to the namespace. This allows the caller to try the setup again.
 		for _, iface := range sbox.Interfaces() {

--- a/libnetwork/drivers/overlay/ovmanager/ovmanager.go
+++ b/libnetwork/drivers/overlay/ovmanager/ovmanager.go
@@ -207,7 +207,7 @@ func (d *driver) IsBuiltIn() bool {
 	return true
 }
 
-func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
+func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/drivers/overlay/ovmanager/ovmanager.go
+++ b/libnetwork/drivers/overlay/ovmanager/ovmanager.go
@@ -190,7 +190,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 }
 
 // Join method is invoked when a Sandbox is attached to an endpoint.
-func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/drivers/overlay/ovmanager/ovmanager.go
+++ b/libnetwork/drivers/overlay/ovmanager/ovmanager.go
@@ -177,7 +177,7 @@ func (d *driver) DeleteNetwork(nid string) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 
-func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
+func (d *driver) CreateEndpoint(_ context.Context, nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/drivers/remote/driver.go
+++ b/libnetwork/drivers/remote/driver.go
@@ -172,7 +172,7 @@ func (d *driver) DeleteNetwork(nid string) error {
 	return d.call("DeleteNetwork", &api.DeleteNetworkRequest{NetworkID: nid}, &api.DeleteNetworkResponse{})
 }
 
-func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) (retErr error) {
+func (d *driver) CreateEndpoint(_ context.Context, nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) (retErr error) {
 	if ifInfo == nil {
 		return errors.New("must not be called with nil InterfaceInfo")
 	}

--- a/libnetwork/drivers/remote/driver.go
+++ b/libnetwork/drivers/remote/driver.go
@@ -334,7 +334,7 @@ func (d *driver) Leave(nid, eid string) error {
 }
 
 // ProgramExternalConnectivity is invoked to program the rules to allow external connectivity for the endpoint.
-func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
+func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
 	data := &api.ProgramExternalConnectivityRequest{
 		NetworkID:  nid,
 		EndpointID: eid,

--- a/libnetwork/drivers/remote/driver.go
+++ b/libnetwork/drivers/remote/driver.go
@@ -258,7 +258,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 }
 
 // Join method is invoked when a Sandbox is attached to an endpoint.
-func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) (retErr error) {
+func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) (retErr error) {
 	join := &api.JoinRequest{
 		NetworkID:  nid,
 		EndpointID: eid,

--- a/libnetwork/drivers/remote/driver_test.go
+++ b/libnetwork/drivers/remote/driver_test.go
@@ -2,6 +2,7 @@ package remote
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -438,7 +439,7 @@ func TestRemoteDriver(t *testing.T) {
 
 	endID := "dummy-endpoint"
 	ifInfo := &testEndpoint{}
-	err = d.CreateEndpoint(netID, endID, ifInfo, map[string]interface{}{})
+	err = d.CreateEndpoint(context.Background(), netID, endID, ifInfo, map[string]interface{}{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -502,7 +503,7 @@ func TestDriverError(t *testing.T) {
 	}
 
 	d := newDriver(plugin, client)
-	if err := d.CreateEndpoint("dummy", "dummy", &testEndpoint{t: t}, map[string]interface{}{}); err == nil {
+	if err := d.CreateEndpoint(context.Background(), "dummy", "dummy", &testEndpoint{t: t}, map[string]interface{}{}); err == nil {
 		t.Fatal("Expected error from driver")
 	}
 }
@@ -539,7 +540,7 @@ func TestMissingValues(t *testing.T) {
 	}
 
 	d := newDriver(plugin, client)
-	if err := d.CreateEndpoint("dummy", "dummy", ep, map[string]interface{}{}); err != nil {
+	if err := d.CreateEndpoint(context.Background(), "dummy", "dummy", ep, map[string]interface{}{}); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -605,7 +606,7 @@ func TestRollback(t *testing.T) {
 
 	d := newDriver(plugin, client)
 	ep := &rollbackEndpoint{}
-	if err := d.CreateEndpoint("dummy", "dummy", ep.Interface(), map[string]interface{}{}); err == nil {
+	if err := d.CreateEndpoint(context.Background(), "dummy", "dummy", ep.Interface(), map[string]interface{}{}); err == nil {
 		t.Fatal("Expected error from driver")
 	}
 	if !rolledback {

--- a/libnetwork/drivers/remote/driver_test.go
+++ b/libnetwork/drivers/remote/driver_test.go
@@ -452,7 +452,7 @@ func TestRemoteDriver(t *testing.T) {
 	}
 
 	joinOpts := map[string]interface{}{"foo": "fooValue"}
-	err = d.Join(netID, endID, "sandbox-key", ep, joinOpts)
+	err = d.Join(context.Background(), netID, endID, "sandbox-key", ep, joinOpts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/drivers/windows/overlay/ov_endpoint_windows.go
+++ b/libnetwork/drivers/windows/overlay/ov_endpoint_windows.go
@@ -93,7 +93,7 @@ func (n *network) removeEndpointWithAddress(addr *net.IPNet) {
 	}
 }
 
-func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
+func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
 	var err error
 	if err = validateID(nid, eid); err != nil {
 		return err
@@ -106,7 +106,7 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 
 	ep := n.endpoint(eid)
 	if ep != nil {
-		log.G(context.TODO()).Debugf("Deleting stale endpoint %s", eid)
+		log.G(ctx).Debugf("Deleting stale endpoint %s", eid)
 		n.deleteEndpoint(eid)
 		_, err := endpointRequest("DELETE", ep.profileID, "")
 		if err != nil {

--- a/libnetwork/drivers/windows/overlay/ov_network_windows.go
+++ b/libnetwork/drivers/windows/overlay/ov_network_windows.go
@@ -211,7 +211,7 @@ func (d *driver) DeleteNetwork(nid string) error {
 	return nil
 }
 
-func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
+func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
 	return nil
 }
 

--- a/libnetwork/drivers/windows/windows.go
+++ b/libnetwork/drivers/windows/windows.go
@@ -835,7 +835,13 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 }
 
 // Join method is invoked when a Sandbox is attached to an endpoint.
-func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+	ctx, span := otel.Tracer("").Start(ctx, fmt.Sprintf("libnetwork.drivers.windows_%s.Join", d.name), trace.WithAttributes(
+		attribute.String("nid", nid),
+		attribute.String("eid", eid),
+		attribute.String("sboxKey", sboxKey)))
+	defer span.End()
+
 	network, err := d.getNetwork(nid)
 	if err != nil {
 		return err

--- a/libnetwork/drivers/windows/windows.go
+++ b/libnetwork/drivers/windows/windows.go
@@ -895,7 +895,7 @@ func (d *driver) Leave(nid, eid string) error {
 	return nil
 }
 
-func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
+func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
 	return nil
 }
 

--- a/libnetwork/drivers/windows/windows_test.go
+++ b/libnetwork/drivers/windows/windows_test.go
@@ -3,6 +3,7 @@
 package windows
 
 import (
+	"context"
 	"net"
 	"testing"
 
@@ -42,7 +43,7 @@ func testNetwork(networkType string, t *testing.T) {
 
 	epOptions := make(map[string]interface{})
 	te := &testEndpoint{}
-	err = d.CreateEndpoint("dummy", "ep1", te.Interface(), epOptions)
+	err = d.CreateEndpoint(context.TODO(), "dummy", "ep1", te.Interface(), epOptions)
 	if err != nil {
 		t.Fatalf("Failed to create an endpoint : %s", err.Error())
 	}

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -613,7 +613,7 @@ func (ep *Endpoint) sbJoin(ctx context.Context, sb *Sandbox, options ...Endpoint
 			}
 			defer func() {
 				if err != nil {
-					if e := extD.ProgramExternalConnectivity(extEp.network.ID(), extEp.ID(), sb.Labels()); e != nil {
+					if e := extD.ProgramExternalConnectivity(context.WithoutCancel(ctx), extEp.network.ID(), extEp.ID(), sb.Labels()); e != nil {
 						log.G(ctx).Warnf("Failed to roll-back external connectivity on endpoint %s (%s): %v",
 							extEp.Name(), extEp.ID(), e)
 					}
@@ -622,7 +622,7 @@ func (ep *Endpoint) sbJoin(ctx context.Context, sb *Sandbox, options ...Endpoint
 		}
 		if !n.internal {
 			log.G(ctx).Debugf("Programming external connectivity on endpoint %s (%s)", ep.Name(), ep.ID())
-			if err = d.ProgramExternalConnectivity(n.ID(), ep.ID(), sb.Labels()); err != nil {
+			if err = d.ProgramExternalConnectivity(ctx, n.ID(), ep.ID(), sb.Labels()); err != nil {
 				return types.InternalErrorf(
 					"driver failed programming external connectivity on endpoint %s (%s): %v",
 					ep.Name(), ep.ID(), err)
@@ -807,7 +807,7 @@ func (ep *Endpoint) sbLeave(sb *Sandbox, force bool) error {
 		if err != nil {
 			return fmt.Errorf("failed to get driver for programming external connectivity during leave: %v", err)
 		}
-		if err := extD.ProgramExternalConnectivity(extEp.network.ID(), extEp.ID(), sb.Labels()); err != nil {
+		if err := extD.ProgramExternalConnectivity(context.WithoutCancel(context.TODO()), extEp.network.ID(), extEp.ID(), sb.Labels()); err != nil {
 			log.G(context.TODO()).Warnf("driver failed programming external connectivity on endpoint %s: (%s) %v",
 				extEp.Name(), extEp.ID(), err)
 		}

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -562,7 +562,7 @@ func (ep *Endpoint) sbJoin(ctx context.Context, sb *Sandbox, options ...Endpoint
 		return errdefs.System(err)
 	}
 
-	if err = n.getController().updateToStore(ep); err != nil {
+	if err = n.getController().updateToStore(ctx, ep); err != nil {
 		return err
 	}
 
@@ -646,7 +646,7 @@ func (ep *Endpoint) rename(name string) error {
 	ep.mu.Unlock()
 
 	// Update the store with the updated name
-	if err := ep.getNetwork().getController().updateToStore(ep); err != nil {
+	if err := ep.getNetwork().getController().updateToStore(context.TODO(), ep); err != nil {
 		return err
 	}
 
@@ -682,7 +682,7 @@ func (ep *Endpoint) UpdateDNSNames(dnsNames []string) error {
 	}
 
 	// Update the store with the updated name
-	if err := c.updateToStore(ep); err != nil {
+	if err := c.updateToStore(context.TODO(), ep); err != nil {
 		return err
 	}
 
@@ -777,7 +777,7 @@ func (ep *Endpoint) sbLeave(sb *Sandbox, force bool) error {
 	// spurious logs when cleaning up the sandbox when the daemon
 	// ungracefully exits and restarts before completing sandbox
 	// detach but after store has been updated.
-	if err := n.getController().updateToStore(ep); err != nil {
+	if err := n.getController().updateToStore(context.TODO(), ep); err != nil {
 		return err
 	}
 
@@ -860,7 +860,7 @@ func (ep *Endpoint) Delete(force bool) error {
 	defer func() {
 		if err != nil && !force {
 			ep.dbExists = false
-			if e := n.getController().updateToStore(ep); e != nil {
+			if e := n.getController().updateToStore(context.WithoutCancel(context.TODO()), ep); e != nil {
 				log.G(context.TODO()).Warnf("failed to recreate endpoint in store %s : %v", name, e)
 			}
 		}

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -697,7 +697,7 @@ func (ep *Endpoint) hasInterface(iName string) bool {
 }
 
 // Leave detaches the network resources populated in the sandbox.
-func (ep *Endpoint) Leave(sb *Sandbox) error {
+func (ep *Endpoint) Leave(ctx context.Context, sb *Sandbox) error {
 	if sb == nil || sb.ID() == "" || sb.Key() == "" {
 		return types.InvalidParameterErrorf("invalid Sandbox passed to endpoint leave: %v", sb)
 	}
@@ -705,10 +705,10 @@ func (ep *Endpoint) Leave(sb *Sandbox) error {
 	sb.joinLeaveStart()
 	defer sb.joinLeaveEnd()
 
-	return ep.sbLeave(sb, false)
+	return ep.sbLeave(ctx, sb, false)
 }
 
-func (ep *Endpoint) sbLeave(sb *Sandbox, force bool) error {
+func (ep *Endpoint) sbLeave(ctx context.Context, sb *Sandbox, force bool) error {
 	n, err := ep.getNetworkFromStore()
 	if err != nil {
 		return fmt.Errorf("failed to get network from store during leave: %v", err)
@@ -746,30 +746,30 @@ func (ep *Endpoint) sbLeave(sb *Sandbox, force bool) error {
 
 	if d != nil {
 		if moveExtConn {
-			log.G(context.TODO()).Debugf("Revoking external connectivity on endpoint %s (%s)", ep.Name(), ep.ID())
+			log.G(ctx).Debugf("Revoking external connectivity on endpoint %s (%s)", ep.Name(), ep.ID())
 			if err := d.RevokeExternalConnectivity(n.id, ep.id); err != nil {
-				log.G(context.TODO()).Warnf("driver failed revoking external connectivity on endpoint %s (%s): %v",
+				log.G(ctx).Warnf("driver failed revoking external connectivity on endpoint %s (%s): %v",
 					ep.Name(), ep.ID(), err)
 			}
 		}
 
 		if err := d.Leave(n.id, ep.id); err != nil {
 			if _, ok := err.(types.MaskableError); !ok {
-				log.G(context.TODO()).Warnf("driver error disconnecting container %s : %v", ep.name, err)
+				log.G(ctx).Warnf("driver error disconnecting container %s : %v", ep.name, err)
 			}
 		}
 	}
 
 	if err := ep.deleteServiceInfoFromCluster(sb, true, "sbLeave"); err != nil {
-		log.G(context.TODO()).Warnf("Failed to clean up service info on container %s disconnect: %v", ep.name, err)
+		log.G(ctx).Warnf("Failed to clean up service info on container %s disconnect: %v", ep.name, err)
 	}
 
 	if err := deleteEpFromResolver(ep.Name(), ep.iface, n.Resolvers()); err != nil {
-		log.G(context.TODO()).Warnf("Failed to clean up resolver info on container %s disconnect: %v", ep.name, err)
+		log.G(ctx).Warnf("Failed to clean up resolver info on container %s disconnect: %v", ep.name, err)
 	}
 
 	if err := sb.clearNetworkResources(ep); err != nil {
-		log.G(context.TODO()).Warnf("Failed to clean up network resources on container %s disconnect: %v", ep.name, err)
+		log.G(ctx).Warnf("Failed to clean up network resources on container %s disconnect: %v", ep.name, err)
 	}
 
 	// Update the store about the sandbox detach only after we
@@ -777,12 +777,12 @@ func (ep *Endpoint) sbLeave(sb *Sandbox, force bool) error {
 	// spurious logs when cleaning up the sandbox when the daemon
 	// ungracefully exits and restarts before completing sandbox
 	// detach but after store has been updated.
-	if err := n.getController().updateToStore(context.TODO(), ep); err != nil {
+	if err := n.getController().updateToStore(ctx, ep); err != nil {
 		return err
 	}
 
 	if e := ep.deleteDriverInfoFromCluster(); e != nil {
-		log.G(context.TODO()).Errorf("Failed to delete endpoint state for endpoint %s from cluster: %v", ep.Name(), e)
+		log.G(ctx).Errorf("Failed to delete endpoint state for endpoint %s from cluster: %v", ep.Name(), e)
 	}
 
 	sb.deleteHostsEntries(n.getSvcRecords(ep))
@@ -798,7 +798,7 @@ func (ep *Endpoint) sbLeave(sb *Sandbox, force bool) error {
 	// New endpoint providing external connectivity for the sandbox
 	extEp = sb.getGatewayEndpoint()
 	if moveExtConn && extEp != nil {
-		log.G(context.TODO()).Debugf("Programming external connectivity on endpoint %s (%s)", extEp.Name(), extEp.ID())
+		log.G(ctx).Debugf("Programming external connectivity on endpoint %s (%s)", extEp.Name(), extEp.ID())
 		extN, err := extEp.getNetworkFromStore()
 		if err != nil {
 			return fmt.Errorf("failed to get network from store for programming external connectivity during leave: %v", err)
@@ -807,15 +807,15 @@ func (ep *Endpoint) sbLeave(sb *Sandbox, force bool) error {
 		if err != nil {
 			return fmt.Errorf("failed to get driver for programming external connectivity during leave: %v", err)
 		}
-		if err := extD.ProgramExternalConnectivity(context.WithoutCancel(context.TODO()), extEp.network.ID(), extEp.ID(), sb.Labels()); err != nil {
-			log.G(context.TODO()).Warnf("driver failed programming external connectivity on endpoint %s: (%s) %v",
+		if err := extD.ProgramExternalConnectivity(context.WithoutCancel(ctx), extEp.network.ID(), extEp.ID(), sb.Labels()); err != nil {
+			log.G(ctx).Warnf("driver failed programming external connectivity on endpoint %s: (%s) %v",
 				extEp.Name(), extEp.ID(), err)
 		}
 	}
 
 	if !sb.needDefaultGW() {
 		if err := sb.clearDefaultGW(); err != nil {
-			log.G(context.TODO()).Warnf("Failure while disconnecting sandbox %s (%s) from gateway network: %v",
+			log.G(ctx).Warnf("Failure while disconnecting sandbox %s (%s) from gateway network: %v",
 				sb.ID(), sb.ContainerID(), err)
 		}
 	}
@@ -824,7 +824,7 @@ func (ep *Endpoint) sbLeave(sb *Sandbox, force bool) error {
 }
 
 // Delete deletes and detaches this endpoint from the network.
-func (ep *Endpoint) Delete(force bool) error {
+func (ep *Endpoint) Delete(ctx context.Context, force bool) error {
 	var err error
 	n, err := ep.getNetworkFromStore()
 	if err != nil {
@@ -848,8 +848,8 @@ func (ep *Endpoint) Delete(force bool) error {
 	}
 
 	if sb != nil {
-		if e := ep.sbLeave(sb, force); e != nil {
-			log.G(context.TODO()).Warnf("failed to leave sandbox for endpoint %s : %v", name, e)
+		if e := ep.sbLeave(context.WithoutCancel(ctx), sb, force); e != nil {
+			log.G(ctx).Warnf("failed to leave sandbox for endpoint %s : %v", name, e)
 		}
 	}
 
@@ -860,14 +860,14 @@ func (ep *Endpoint) Delete(force bool) error {
 	defer func() {
 		if err != nil && !force {
 			ep.dbExists = false
-			if e := n.getController().updateToStore(context.WithoutCancel(context.TODO()), ep); e != nil {
-				log.G(context.TODO()).Warnf("failed to recreate endpoint in store %s : %v", name, e)
+			if e := n.getController().updateToStore(context.WithoutCancel(ctx), ep); e != nil {
+				log.G(ctx).Warnf("failed to recreate endpoint in store %s : %v", name, e)
 			}
 		}
 	}()
 
 	if !n.getController().isSwarmNode() || n.Scope() != scope.Swarm || !n.driverIsMultihost() {
-		n.updateSvcRecord(context.WithoutCancel(context.TODO()), ep, false)
+		n.updateSvcRecord(context.WithoutCancel(ctx), ep, false)
 	}
 
 	if err = ep.deleteEndpoint(force); err != nil && !force {
@@ -877,7 +877,7 @@ func (ep *Endpoint) Delete(force bool) error {
 	ep.releaseAddress()
 
 	if err := n.getEpCnt().DecEndpointCnt(); err != nil {
-		log.G(context.TODO()).Warnf("failed to decrement endpoint count for ep %s: %v", ep.ID(), err)
+		log.G(ctx).Warnf("failed to decrement endpoint count for ep %s: %v", ep.ID(), err)
 	}
 
 	return nil
@@ -1208,7 +1208,7 @@ func (c *Controller) cleanupLocalEndpoints() error {
 				continue
 			}
 			log.G(context.TODO()).Infof("Removing stale endpoint %s (%s)", ep.name, ep.id)
-			if err := ep.Delete(true); err != nil {
+			if err := ep.Delete(context.WithoutCancel(context.TODO()), true); err != nil {
 				log.G(context.TODO()).Warnf("Could not delete local endpoint %s during endpoint cleanup: %v", ep.name, err)
 			}
 		}

--- a/libnetwork/endpoint_cnt.go
+++ b/libnetwork/endpoint_cnt.go
@@ -1,6 +1,7 @@
 package libnetwork
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -110,7 +111,7 @@ func (ec *endpointCnt) updateStore() error {
 	count := ec.EndpointCnt()
 	n := ec.n
 	for {
-		if err := c.updateToStore(ec); err == nil || err != datastore.ErrKeyModified {
+		if err := c.updateToStore(context.TODO(), ec); err == nil || err != datastore.ErrKeyModified {
 			return err
 		}
 		if err := c.store.GetObject(ec); err != nil {
@@ -148,7 +149,7 @@ retry:
 	}
 	ec.Unlock()
 
-	if err := ec.n.getController().updateToStore(ec); err != nil {
+	if err := ec.n.getController().updateToStore(context.TODO(), ec); err != nil {
 		if err == datastore.ErrKeyModified {
 			if err := store.GetObject(ec); err != nil {
 				return fmt.Errorf("could not update the kvobject to latest when trying to atomic add endpoint count: %v", err)

--- a/libnetwork/endpoint_unix_test.go
+++ b/libnetwork/endpoint_unix_test.go
@@ -48,7 +48,7 @@ fe90::2	somehost.example.com somehost
 		t.Fatal(err)
 	}
 
-	if err := ep1.Join(sbx, JoinOptionPriority(1)); err != nil {
+	if err := ep1.Join(context.Background(), sbx, JoinOptionPriority(1)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/libnetwork/endpoint_unix_test.go
+++ b/libnetwork/endpoint_unix_test.go
@@ -3,6 +3,7 @@
 package libnetwork
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -42,7 +43,7 @@ fe90::2	somehost.example.com somehost
 		t.Fatal(err)
 	}
 
-	ep1, err := nws[0].CreateEndpoint("ep1")
+	ep1, err := nws[0].CreateEndpoint(context.Background(), "ep1")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/endpoint_unix_test.go
+++ b/libnetwork/endpoint_unix_test.go
@@ -61,7 +61,7 @@ fe90::2	somehost.example.com somehost
 		t.Fatalf("expected the hosts file to read:\n%q\nbut instead got the following:\n%q\n", expectedHostsFile, string(data))
 	}
 
-	if err := sbx.Delete(); err != nil {
+	if err := sbx.Delete(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 

--- a/libnetwork/endpoint_unix_test.go
+++ b/libnetwork/endpoint_unix_test.go
@@ -38,7 +38,7 @@ fe90::2	somehost.example.com somehost
 	}
 	defer os.Remove(hostsFile.Name())
 
-	sbx, err := ctrlr.NewSandbox("sandbox1", OptionHostsPath(hostsFile.Name()), OptionHostname("somehost.example.com"))
+	sbx, err := ctrlr.NewSandbox(context.Background(), "sandbox1", OptionHostsPath(hostsFile.Name()), OptionHostname("somehost.example.com"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -382,7 +382,7 @@ func TestSRVServiceQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := sb.Delete(); err != nil {
+		if err := sb.Delete(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -481,7 +481,7 @@ func TestServiceVIPReuse(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := sb.Delete(); err != nil {
+		if err := sb.Delete(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 	}()

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -689,7 +689,7 @@ func (b *badDriver) IsBuiltIn() bool {
 	return false
 }
 
-func (b *badDriver) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
+func (b *badDriver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
 	return nil
 }
 

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -372,7 +372,7 @@ func TestSRVServiceQuery(t *testing.T) {
 		}
 	}()
 
-	ep, err := n.CreateEndpoint("testep")
+	ep, err := n.CreateEndpoint(context.Background(), "testep")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -471,7 +471,7 @@ func TestServiceVIPReuse(t *testing.T) {
 		}
 	}()
 
-	ep, err := n.CreateEndpoint("testep")
+	ep, err := n.CreateEndpoint(context.Background(), "testep")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -610,7 +610,7 @@ func TestIpamReleaseOnNetDriverFailures(t *testing.T) {
 		}
 	}()
 
-	if _, err := bnw.CreateEndpoint("ep0"); err == nil {
+	if _, err := bnw.CreateEndpoint(context.Background(), "ep0"); err == nil {
 		t.Fatalf("bad network driver should have failed endpoint creation")
 	}
 
@@ -626,7 +626,7 @@ func TestIpamReleaseOnNetDriverFailures(t *testing.T) {
 		}
 	}()
 
-	ep, err := gnw.CreateEndpoint("ep1")
+	ep, err := gnw.CreateEndpoint(context.Background(), "ep1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -661,7 +661,7 @@ func (b *badDriver) DeleteNetwork(nid string) error {
 	return nil
 }
 
-func (b *badDriver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, options map[string]interface{}) error {
+func (b *badDriver) CreateEndpoint(_ context.Context, nid, eid string, ifInfo driverapi.InterfaceInfo, options map[string]interface{}) error {
 	return fmt.Errorf("I will not create any endpoint")
 }
 

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -630,7 +630,7 @@ func TestIpamReleaseOnNetDriverFailures(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ep.Delete(false) //nolint:errcheck
+	defer ep.Delete(context.Background(), false) //nolint:errcheck
 
 	expectedIP, _ := types.ParseCIDR("10.35.0.1/16")
 	if !types.CompareIPNet(ep.Info().Iface().Address(), expectedIP) {

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -377,7 +377,7 @@ func TestSRVServiceQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sb, err := c.NewSandbox("c1")
+	sb, err := c.NewSandbox(context.Background(), "c1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -476,7 +476,7 @@ func TestServiceVIPReuse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sb, err := c.NewSandbox("c1")
+	sb, err := c.NewSandbox(context.Background(), "c1")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -387,7 +387,7 @@ func TestSRVServiceQuery(t *testing.T) {
 		}
 	}()
 
-	err = ep.Join(sb)
+	err = ep.Join(context.Background(), sb)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -486,7 +486,7 @@ func TestServiceVIPReuse(t *testing.T) {
 		}
 	}()
 
-	err = ep.Join(sb)
+	err = ep.Join(context.Background(), sb)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -673,7 +673,7 @@ func (b *badDriver) EndpointOperInfo(nid, eid string) (map[string]interface{}, e
 	return nil, nil
 }
 
-func (b *badDriver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (b *badDriver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
 	return fmt.Errorf("I will not allow any join")
 }
 

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -110,7 +110,7 @@ func TestNull(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ep, err := network.CreateEndpoint("testep")
+	ep, err := network.CreateEndpoint(context.Background(), "testep")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -273,7 +273,7 @@ func TestDeleteNetworkWithActiveEndpoints(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ep, err := network.CreateEndpoint("testep")
+	ep, err := network.CreateEndpoint(context.Background(), "testep")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -446,7 +446,7 @@ func TestUnknownEndpoint(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = network.CreateEndpoint("")
+	_, err = network.CreateEndpoint(context.Background(), "")
 	if err == nil {
 		t.Fatal("Expected to fail. But instead succeeded")
 	}
@@ -454,7 +454,7 @@ func TestUnknownEndpoint(t *testing.T) {
 		t.Fatalf("Expected to fail with ErrInvalidName error. Actual error: %v", err)
 	}
 
-	ep, err := network.CreateEndpoint("testep")
+	ep, err := network.CreateEndpoint(context.Background(), "testep")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -491,7 +491,7 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 		}
 	}()
 
-	ep11, err := net1.CreateEndpoint("ep11")
+	ep11, err := net1.CreateEndpoint(context.Background(), "ep11")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -501,7 +501,7 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 		}
 	}()
 
-	ep12, err := net1.CreateEndpoint("ep12")
+	ep12, err := net1.CreateEndpoint(context.Background(), "ep12")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -619,7 +619,7 @@ func TestDuplicateEndpoint(t *testing.T) {
 		}
 	}()
 
-	ep, err := n.CreateEndpoint("ep1")
+	ep, err := n.CreateEndpoint(context.Background(), "ep1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -629,7 +629,7 @@ func TestDuplicateEndpoint(t *testing.T) {
 		}
 	}()
 
-	ep2, err := n.CreateEndpoint("ep1")
+	ep2, err := n.CreateEndpoint(context.Background(), "ep1")
 	defer func() {
 		// Cleanup ep2 as well, else network cleanup might fail for failure cases
 		if ep2 != nil {
@@ -769,7 +769,7 @@ func TestNetworkQuery(t *testing.T) {
 		}
 	}()
 
-	ep11, err := net1.CreateEndpoint("ep11")
+	ep11, err := net1.CreateEndpoint(context.Background(), "ep11")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -779,7 +779,7 @@ func TestNetworkQuery(t *testing.T) {
 		}
 	}()
 
-	ep12, err := net1.CreateEndpoint("ep12")
+	ep12, err := net1.CreateEndpoint(context.Background(), "ep12")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -867,7 +867,7 @@ func TestEndpointDeleteWithActiveContainer(t *testing.T) {
 		}
 	}()
 
-	ep, err := n.CreateEndpoint("ep1")
+	ep, err := n.CreateEndpoint(context.Background(), "ep1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -927,7 +927,7 @@ func TestEndpointMultipleJoins(t *testing.T) {
 		}
 	}()
 
-	ep, err := n.CreateEndpoint("ep1")
+	ep, err := n.CreateEndpoint(context.Background(), "ep1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1015,12 +1015,12 @@ func TestLeaveAll(t *testing.T) {
 		}
 	}()
 
-	ep1, err := n.CreateEndpoint("ep1")
+	ep1, err := n.CreateEndpoint(context.Background(), "ep1")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	ep2, err := n2.CreateEndpoint("ep2")
+	ep2, err := n2.CreateEndpoint(context.Background(), "ep2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1064,7 +1064,7 @@ func TestContainerInvalidLeave(t *testing.T) {
 		}
 	}()
 
-	ep, err := n.CreateEndpoint("ep1")
+	ep, err := n.CreateEndpoint(context.Background(), "ep1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1129,12 +1129,12 @@ func TestEndpointUpdateParent(t *testing.T) {
 		}
 	}()
 
-	ep1, err := n.CreateEndpoint("ep1")
+	ep1, err := n.CreateEndpoint(context.Background(), "ep1")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	ep2, err := n.CreateEndpoint("ep2")
+	ep2, err := n.CreateEndpoint(context.Background(), "ep2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1339,7 +1339,7 @@ func TestHost(t *testing.T) {
 	}()
 
 	network := makeTesthostNetwork(t, controller)
-	ep1, err := network.CreateEndpoint("testep1")
+	ep1, err := network.CreateEndpoint(context.Background(), "testep1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1348,7 +1348,7 @@ func TestHost(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ep2, err := network.CreateEndpoint("testep2")
+	ep2, err := network.CreateEndpoint(context.Background(), "testep2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1388,7 +1388,7 @@ func TestHost(t *testing.T) {
 		}
 	}()
 
-	ep3, err := network.CreateEndpoint("testep3")
+	ep3, err := network.CreateEndpoint(context.Background(), "testep3")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1433,7 +1433,7 @@ func TestBridgeIpv6FromMac(t *testing.T) {
 	mac := net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}
 	epOption := options.Generic{netlabel.MacAddress: mac}
 
-	ep, err := network.CreateEndpoint("testep", libnetwork.EndpointOptionGeneric(epOption))
+	ep, err := network.CreateEndpoint(context.Background(), "testep", libnetwork.EndpointOptionGeneric(epOption))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1509,7 +1509,7 @@ func TestEndpointJoin(t *testing.T) {
 		}
 	}()
 
-	ep1, err := n1.CreateEndpoint("ep1")
+	ep1, err := n1.CreateEndpoint(context.Background(), "ep1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1625,7 +1625,7 @@ func TestEndpointJoin(t *testing.T) {
 		}
 	}()
 
-	ep2, err := n2.CreateEndpoint("ep2")
+	ep2, err := n2.CreateEndpoint(context.Background(), "ep2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1689,7 +1689,7 @@ func externalKeyTest(t *testing.T, reexec bool) {
 		}
 	}()
 
-	ep, err := n.CreateEndpoint("ep1")
+	ep, err := n.CreateEndpoint(context.Background(), "ep1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1700,7 +1700,7 @@ func externalKeyTest(t *testing.T, reexec bool) {
 		}
 	}()
 
-	ep2, err := n2.CreateEndpoint("ep2")
+	ep2, err := n2.CreateEndpoint(context.Background(), "ep2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1880,7 +1880,7 @@ func TestResolvConf(t *testing.T) {
 				assert.Check(t, err)
 			}()
 
-			ep, err := n.CreateEndpoint("ep", tc.epOpts...)
+			ep, err := n.CreateEndpoint(context.Background(), "ep", tc.epOpts...)
 			assert.NilError(t, err)
 			defer func() {
 				err := ep.Delete(false)
@@ -1986,17 +1986,17 @@ func TestParallel(t *testing.T) {
 	}
 	defer net2.Delete()
 
-	_, err = net1.CreateEndpoint("pep1")
+	_, err = net1.CreateEndpoint(context.Background(), "pep1")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = net2.CreateEndpoint("pep2")
+	_, err = net2.CreateEndpoint(context.Background(), "pep2")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = net2.CreateEndpoint("pep3")
+	_, err = net2.CreateEndpoint(context.Background(), "pep3")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2054,7 +2054,7 @@ func TestBridge(t *testing.T) {
 		}
 	}()
 
-	ep, err := network.CreateEndpoint("testep")
+	ep, err := network.CreateEndpoint(context.Background(), "testep")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -115,7 +115,7 @@ func TestNull(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = ep.Join(cnt)
+	err = ep.Join(context.Background(), cnt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -888,7 +888,7 @@ func TestEndpointDeleteWithActiveContainer(t *testing.T) {
 		}
 	}()
 
-	err = ep.Join(cnt)
+	err = ep.Join(context.Background(), cnt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -961,7 +961,7 @@ func TestEndpointMultipleJoins(t *testing.T) {
 		}
 	}()
 
-	err = ep.Join(sbx1)
+	err = ep.Join(context.Background(), sbx1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -972,7 +972,7 @@ func TestEndpointMultipleJoins(t *testing.T) {
 		}
 	}()
 
-	err = ep.Join(sbx2)
+	err = ep.Join(context.Background(), sbx2)
 	if err == nil {
 		t.Fatal("Expected to fail multiple joins for the same endpoint")
 	}
@@ -1030,12 +1030,12 @@ func TestLeaveAll(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = ep1.Join(cnt)
+	err = ep1.Join(context.Background(), cnt)
 	if err != nil {
 		t.Fatalf("Failed to join ep1: %v", err)
 	}
 
-	err = ep2.Join(cnt)
+	err = ep2.Join(context.Background(), cnt)
 	if err != nil {
 		t.Fatalf("Failed to join ep2: %v", err)
 	}
@@ -1166,12 +1166,12 @@ func TestEndpointUpdateParent(t *testing.T) {
 		}
 	}()
 
-	err = ep1.Join(sbx1)
+	err = ep1.Join(context.Background(), sbx1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = ep2.Join(sbx2)
+	err = ep2.Join(context.Background(), sbx2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1344,7 +1344,7 @@ func TestHost(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ep1.Join(sbx1); err != nil {
+	if err := ep1.Join(context.Background(), sbx1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1353,7 +1353,7 @@ func TestHost(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ep2.Join(sbx2); err != nil {
+	if err := ep2.Join(context.Background(), sbx2); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1393,7 +1393,7 @@ func TestHost(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ep3.Join(sbx2); err != nil {
+	if err := ep3.Join(context.Background(), sbx2); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1541,7 +1541,7 @@ func TestEndpointJoin(t *testing.T) {
 	}
 
 	// test invalid joins
-	err = ep1.Join(nil)
+	err = ep1.Join(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected to fail join with nil Sandbox")
 	}
@@ -1550,7 +1550,7 @@ func TestEndpointJoin(t *testing.T) {
 	}
 
 	fsbx := &libnetwork.Sandbox{}
-	if err = ep1.Join(fsbx); err == nil {
+	if err = ep1.Join(context.Background(), fsbx); err == nil {
 		t.Fatalf("Expected to fail join with invalid Sandbox")
 	}
 	if _, ok := err.(types.InvalidParameterError); !ok {
@@ -1571,7 +1571,7 @@ func TestEndpointJoin(t *testing.T) {
 		}
 	}()
 
-	err = ep1.Join(sb)
+	err = ep1.Join(context.Background(), sb)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1635,7 +1635,7 @@ func TestEndpointJoin(t *testing.T) {
 		}
 	}()
 
-	err = ep2.Join(sb)
+	err = ep2.Join(context.Background(), sb)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1724,7 +1724,7 @@ func externalKeyTest(t *testing.T, reexec bool) {
 	}()
 
 	// Join endpoint to sandbox before SetKey
-	err = ep.Join(cnt)
+	err = ep.Join(context.Background(), cnt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1775,7 +1775,7 @@ func externalKeyTest(t *testing.T, reexec bool) {
 	}
 
 	// Join endpoint to sandbox after SetKey
-	err = ep2.Join(sbox)
+	err = ep2.Join(context.Background(), sbox)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1887,7 +1887,7 @@ func TestResolvConf(t *testing.T) {
 				assert.Check(t, err)
 			}()
 
-			err = ep.Join(sb)
+			err = ep.Join(context.Background(), sb)
 			assert.NilError(t, err)
 			defer func() {
 				err := ep.Leave(sb)
@@ -1942,7 +1942,7 @@ func (pt parallelTester) Do(t *testing.T, thrNumber int) error {
 	}
 
 	for i := 0; i < pt.iterCnt; i++ {
-		if err := ep.Join(sb); err != nil {
+		if err := ep.Join(context.Background(), sb); err != nil {
 			if _, ok := err.(types.ForbiddenError); !ok {
 				return errors.Wrapf(err, "thread %d", thrNumber)
 			}
@@ -2069,7 +2069,7 @@ func TestBridge(t *testing.T) {
 		}
 	}()
 
-	err = ep.Join(sb)
+	err = ep.Join(context.Background(), sb)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -120,12 +120,12 @@ func TestNull(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = ep.Leave(cnt)
+	err = ep.Leave(context.Background(), cnt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := ep.Delete(false); err != nil {
+	if err := ep.Delete(context.Background(), false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -288,7 +288,7 @@ func TestDeleteNetworkWithActiveEndpoints(t *testing.T) {
 	}
 
 	// Done testing. Now cleanup.
-	if err := ep.Delete(false); err != nil {
+	if err := ep.Delete(context.Background(), false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -459,7 +459,7 @@ func TestUnknownEndpoint(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = ep.Delete(false)
+	err = ep.Delete(context.Background(), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -496,7 +496,7 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := ep11.Delete(false); err != nil {
+		if err := ep11.Delete(context.Background(), false); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -506,7 +506,7 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := ep12.Delete(false); err != nil {
+		if err := ep12.Delete(context.Background(), false); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -624,7 +624,7 @@ func TestDuplicateEndpoint(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := ep.Delete(false); err != nil {
+		if err := ep.Delete(context.Background(), false); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -633,7 +633,7 @@ func TestDuplicateEndpoint(t *testing.T) {
 	defer func() {
 		// Cleanup ep2 as well, else network cleanup might fail for failure cases
 		if ep2 != nil {
-			if err := ep2.Delete(false); err != nil {
+			if err := ep2.Delete(context.Background(), false); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -774,7 +774,7 @@ func TestNetworkQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := ep11.Delete(false); err != nil {
+		if err := ep11.Delete(context.Background(), false); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -784,7 +784,7 @@ func TestNetworkQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := ep12.Delete(false); err != nil {
+		if err := ep12.Delete(context.Background(), false); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -872,7 +872,7 @@ func TestEndpointDeleteWithActiveContainer(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		err = ep.Delete(false)
+		err = ep.Delete(context.Background(), false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -893,13 +893,13 @@ func TestEndpointDeleteWithActiveContainer(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		err = ep.Leave(cnt)
+		err = ep.Leave(context.Background(), cnt)
 		if err != nil {
 			t.Fatal(err)
 		}
 	}()
 
-	err = ep.Delete(false)
+	err = ep.Delete(context.Background(), false)
 	if err == nil {
 		t.Fatal("Expected to fail. But instead succeeded")
 	}
@@ -932,7 +932,7 @@ func TestEndpointMultipleJoins(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := ep.Delete(false); err != nil {
+		if err := ep.Delete(context.Background(), false); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -966,7 +966,7 @@ func TestEndpointMultipleJoins(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		err = ep.Leave(sbx1)
+		err = ep.Leave(context.Background(), sbx1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1069,7 +1069,7 @@ func TestContainerInvalidLeave(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := ep.Delete(false); err != nil {
+		if err := ep.Delete(context.Background(), false); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -1087,7 +1087,7 @@ func TestContainerInvalidLeave(t *testing.T) {
 		}
 	}()
 
-	err = ep.Leave(cnt)
+	err = ep.Leave(context.Background(), cnt)
 	if err == nil {
 		t.Fatal("Expected to fail leave from an endpoint which has no active join")
 	}
@@ -1095,7 +1095,7 @@ func TestContainerInvalidLeave(t *testing.T) {
 		t.Fatalf("Failed with unexpected error type: %T. Desc: %s", err, err.Error())
 	}
 
-	if err = ep.Leave(nil); err == nil {
+	if err = ep.Leave(context.Background(), nil); err == nil {
 		t.Fatalf("Expected to fail leave nil Sandbox")
 	}
 	if _, ok := err.(types.InvalidParameterError); !ok {
@@ -1103,7 +1103,7 @@ func TestContainerInvalidLeave(t *testing.T) {
 	}
 
 	fsbx := &libnetwork.Sandbox{}
-	if err = ep.Leave(fsbx); err == nil {
+	if err = ep.Leave(context.Background(), fsbx); err == nil {
 		t.Fatalf("Expected to fail leave with invalid Sandbox")
 	}
 	if _, ok := err.(types.InvalidParameterError); !ok {
@@ -1357,19 +1357,19 @@ func TestHost(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ep1.Leave(sbx1); err != nil {
+	if err := ep1.Leave(context.Background(), sbx1); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := ep2.Leave(sbx2); err != nil {
+	if err := ep2.Leave(context.Background(), sbx2); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := ep1.Delete(false); err != nil {
+	if err := ep1.Delete(context.Background(), false); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := ep2.Delete(false); err != nil {
+	if err := ep2.Delete(context.Background(), false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1397,11 +1397,11 @@ func TestHost(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ep3.Leave(sbx2); err != nil {
+	if err := ep3.Leave(context.Background(), sbx2); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := ep3.Delete(false); err != nil {
+	if err := ep3.Delete(context.Background(), false); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1449,7 +1449,7 @@ func TestBridgeIpv6FromMac(t *testing.T) {
 		t.Fatalf("Expected %v. Got: %v", expIP, iface.AddressIPv6())
 	}
 
-	if err := ep.Delete(false); err != nil {
+	if err := ep.Delete(context.Background(), false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1514,7 +1514,7 @@ func TestEndpointJoin(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := ep1.Delete(false); err != nil {
+		if err := ep1.Delete(context.Background(), false); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -1576,7 +1576,7 @@ func TestEndpointJoin(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		err = ep1.Leave(sb)
+		err = ep1.Leave(context.Background(), sb)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1630,7 +1630,7 @@ func TestEndpointJoin(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := ep2.Delete(false); err != nil {
+		if err := ep2.Delete(context.Background(), false); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -1640,7 +1640,7 @@ func TestEndpointJoin(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		err = ep2.Leave(sb)
+		err = ep2.Leave(context.Background(), sb)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1694,7 +1694,7 @@ func externalKeyTest(t *testing.T, reexec bool) {
 		t.Fatal(err)
 	}
 	defer func() {
-		err = ep.Delete(false)
+		err = ep.Delete(context.Background(), false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1705,7 +1705,7 @@ func externalKeyTest(t *testing.T, reexec bool) {
 		t.Fatal(err)
 	}
 	defer func() {
-		err = ep2.Delete(false)
+		err = ep2.Delete(context.Background(), false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1729,7 +1729,7 @@ func externalKeyTest(t *testing.T, reexec bool) {
 		t.Fatal(err)
 	}
 	defer func() {
-		err = ep.Leave(cnt)
+		err = ep.Leave(context.Background(), cnt)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1780,7 +1780,7 @@ func externalKeyTest(t *testing.T, reexec bool) {
 		t.Fatal(err)
 	}
 	defer func() {
-		err = ep2.Leave(sbox)
+		err = ep2.Leave(context.Background(), sbox)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1883,14 +1883,14 @@ func TestResolvConf(t *testing.T) {
 			ep, err := n.CreateEndpoint(context.Background(), "ep", tc.epOpts...)
 			assert.NilError(t, err)
 			defer func() {
-				err := ep.Delete(false)
+				err := ep.Delete(context.Background(), false)
 				assert.Check(t, err)
 			}()
 
 			err = ep.Join(context.Background(), sb)
 			assert.NilError(t, err)
 			defer func() {
-				err := ep.Leave(sb)
+				err := ep.Leave(context.Background(), sb)
 				assert.Check(t, err)
 			}()
 
@@ -1947,7 +1947,7 @@ func (pt parallelTester) Do(t *testing.T, thrNumber int) error {
 				return errors.Wrapf(err, "thread %d", thrNumber)
 			}
 		}
-		if err := ep.Leave(sb); err != nil {
+		if err := ep.Leave(context.Background(), sb); err != nil {
 			if _, ok := err.(types.ForbiddenError); !ok {
 				return errors.Wrapf(err, "thread %d", thrNumber)
 			}
@@ -1957,7 +1957,7 @@ func (pt parallelTester) Do(t *testing.T, thrNumber int) error {
 	if err := errors.WithStack(sb.Delete()); err != nil {
 		return err
 	}
-	return errors.WithStack(ep.Delete(false))
+	return errors.WithStack(ep.Delete(context.Background(), false))
 }
 
 func TestParallel(t *testing.T) {

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -129,7 +129,7 @@ func TestNull(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := cnt.Delete(); err != nil {
+	if err := cnt.Delete(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -883,7 +883,7 @@ func TestEndpointDeleteWithActiveContainer(t *testing.T) {
 		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionExtraHost("web", "192.168.0.1"))
 	defer func() {
-		if err := cnt.Delete(); err != nil {
+		if err := cnt.Delete(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -946,7 +946,7 @@ func TestEndpointMultipleJoins(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := sbx1.Delete(); err != nil {
+		if err := sbx1.Delete(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -956,7 +956,7 @@ func TestEndpointMultipleJoins(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := sbx2.Delete(); err != nil {
+		if err := sbx2.Delete(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -1040,7 +1040,7 @@ func TestLeaveAll(t *testing.T) {
 		t.Fatalf("Failed to join ep2: %v", err)
 	}
 
-	err = cnt.Delete()
+	err = cnt.Delete(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1082,7 +1082,7 @@ func TestContainerInvalidLeave(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := cnt.Delete(); err != nil {
+		if err := cnt.Delete(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -1147,7 +1147,7 @@ func TestEndpointUpdateParent(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := sbx1.Delete(); err != nil {
+		if err := sbx1.Delete(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -1161,7 +1161,7 @@ func TestEndpointUpdateParent(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := sbx2.Delete(); err != nil {
+		if err := sbx2.Delete(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -1319,7 +1319,7 @@ func TestHost(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := sbx1.Delete(); err != nil {
+		if err := sbx1.Delete(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -1333,7 +1333,7 @@ func TestHost(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := sbx2.Delete(); err != nil {
+		if err := sbx2.Delete(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -1383,7 +1383,7 @@ func TestHost(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := cnt3.Delete(); err != nil {
+		if err := cnt3.Delete(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -1566,7 +1566,7 @@ func TestEndpointJoin(t *testing.T) {
 	}
 
 	defer func() {
-		if err := sb.Delete(); err != nil {
+		if err := sb.Delete(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -1717,7 +1717,7 @@ func externalKeyTest(t *testing.T, reexec bool) {
 		libnetwork.OptionUseExternalKey(),
 		libnetwork.OptionExtraHost("web", "192.168.0.1"))
 	defer func() {
-		if err := cnt.Delete(); err != nil {
+		if err := cnt.Delete(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 		osl.GC()
@@ -1876,7 +1876,7 @@ func TestResolvConf(t *testing.T) {
 			sb, err := c.NewSandbox(context.Background(), containerID, sbOpts...)
 			assert.NilError(t, err)
 			defer func() {
-				err := sb.Delete()
+				err := sb.Delete(context.Background())
 				assert.Check(t, err)
 			}()
 
@@ -1954,7 +1954,7 @@ func (pt parallelTester) Do(t *testing.T, thrNumber int) error {
 		}
 	}
 
-	if err := errors.WithStack(sb.Delete()); err != nil {
+	if err := errors.WithStack(sb.Delete(context.Background())); err != nil {
 		return err
 	}
 	return errors.WithStack(ep.Delete(context.Background(), false))
@@ -2064,7 +2064,7 @@ func TestBridge(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := sb.Delete(); err != nil {
+		if err := sb.Delete(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 	}()

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -97,7 +97,7 @@ func TestNull(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
-	cnt, err := controller.NewSandbox("null_container",
+	cnt, err := controller.NewSandbox(context.Background(), "null_container",
 		libnetwork.OptionHostname("test"),
 		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionExtraHost("web", "192.168.0.1"))
@@ -878,7 +878,7 @@ func TestEndpointDeleteWithActiveContainer(t *testing.T) {
 		}
 	}()
 
-	cnt, err := controller.NewSandbox(containerID,
+	cnt, err := controller.NewSandbox(context.Background(), containerID,
 		libnetwork.OptionHostname("test"),
 		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionExtraHost("web", "192.168.0.1"))
@@ -937,7 +937,7 @@ func TestEndpointMultipleJoins(t *testing.T) {
 		}
 	}()
 
-	sbx1, err := controller.NewSandbox(containerID,
+	sbx1, err := controller.NewSandbox(context.Background(), containerID,
 		libnetwork.OptionHostname("test"),
 		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionExtraHost("web", "192.168.0.1"),
@@ -951,7 +951,7 @@ func TestEndpointMultipleJoins(t *testing.T) {
 		}
 	}()
 
-	sbx2, err := controller.NewSandbox("c2")
+	sbx2, err := controller.NewSandbox(context.Background(), "c2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1025,7 +1025,7 @@ func TestLeaveAll(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cnt, err := controller.NewSandbox("leaveall")
+	cnt, err := controller.NewSandbox(context.Background(), "leaveall")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1074,7 +1074,7 @@ func TestContainerInvalidLeave(t *testing.T) {
 		}
 	}()
 
-	cnt, err := controller.NewSandbox(containerID,
+	cnt, err := controller.NewSandbox(context.Background(), containerID,
 		libnetwork.OptionHostname("test"),
 		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionExtraHost("web", "192.168.0.1"))
@@ -1139,7 +1139,7 @@ func TestEndpointUpdateParent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sbx1, err := controller.NewSandbox(containerID,
+	sbx1, err := controller.NewSandbox(context.Background(), containerID,
 		libnetwork.OptionHostname("test"),
 		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionExtraHost("web", "192.168.0.1"))
@@ -1152,7 +1152,7 @@ func TestEndpointUpdateParent(t *testing.T) {
 		}
 	}()
 
-	sbx2, err := controller.NewSandbox("c2",
+	sbx2, err := controller.NewSandbox(context.Background(), "c2",
 		libnetwork.OptionHostname("test2"),
 		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionHostsPath("/var/lib/docker/test_network/container2/hosts"),
@@ -1310,7 +1310,7 @@ func TestHost(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
-	sbx1, err := controller.NewSandbox("host_c1",
+	sbx1, err := controller.NewSandbox(context.Background(), "host_c1",
 		libnetwork.OptionHostname("test1"),
 		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionExtraHost("web", "192.168.0.1"),
@@ -1324,7 +1324,7 @@ func TestHost(t *testing.T) {
 		}
 	}()
 
-	sbx2, err := controller.NewSandbox("host_c2",
+	sbx2, err := controller.NewSandbox(context.Background(), "host_c2",
 		libnetwork.OptionHostname("test2"),
 		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionExtraHost("web", "192.168.0.1"),
@@ -1374,7 +1374,7 @@ func TestHost(t *testing.T) {
 	}
 
 	// Try to create another host endpoint and join/leave that.
-	cnt3, err := controller.NewSandbox("host_c3",
+	cnt3, err := controller.NewSandbox(context.Background(), "host_c3",
 		libnetwork.OptionHostname("test3"),
 		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionExtraHost("web", "192.168.0.1"),
@@ -1557,7 +1557,7 @@ func TestEndpointJoin(t *testing.T) {
 		t.Fatalf("Unexpected error type returned: %T", err)
 	}
 
-	sb, err := controller.NewSandbox(containerID,
+	sb, err := controller.NewSandbox(context.Background(), containerID,
 		libnetwork.OptionHostname("test"),
 		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionExtraHost("web", "192.168.0.1"))
@@ -1711,7 +1711,7 @@ func externalKeyTest(t *testing.T, reexec bool) {
 		}
 	}()
 
-	cnt, err := controller.NewSandbox(containerID,
+	cnt, err := controller.NewSandbox(context.Background(), containerID,
 		libnetwork.OptionHostname("test"),
 		libnetwork.OptionDomainname("example.com"),
 		libnetwork.OptionUseExternalKey(),
@@ -1873,7 +1873,7 @@ func TestResolvConf(t *testing.T) {
 				libnetwork.OptionResolvConfPath(resolvConfPath),
 				libnetwork.OptionOriginResolvConfPath(originResolvConfPath),
 			)
-			sb, err := c.NewSandbox(containerID, sbOpts...)
+			sb, err := c.NewSandbox(context.Background(), containerID, sbOpts...)
 			assert.NilError(t, err)
 			defer func() {
 				err := sb.Delete()
@@ -2002,11 +2002,11 @@ func TestParallel(t *testing.T) {
 	}
 
 	sboxes := make([]*libnetwork.Sandbox, numThreads)
-	if sboxes[first-1], err = controller.NewSandbox(fmt.Sprintf("%drace", first), libnetwork.OptionUseDefaultSandbox()); err != nil {
+	if sboxes[first-1], err = controller.NewSandbox(context.Background(), fmt.Sprintf("%drace", first), libnetwork.OptionUseDefaultSandbox()); err != nil {
 		t.Fatal(err)
 	}
 	for thd := first + 1; thd <= last; thd++ {
-		if sboxes[thd-1], err = controller.NewSandbox(fmt.Sprintf("%drace", thd)); err != nil {
+		if sboxes[thd-1], err = controller.NewSandbox(context.Background(), fmt.Sprintf("%drace", thd)); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -2059,7 +2059,7 @@ func TestBridge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sb, err := controller.NewSandbox(containerID, libnetwork.OptionPortMapping(getPortMapping()))
+	sb, err := controller.NewSandbox(context.Background(), containerID, libnetwork.OptionPortMapping(getPortMapping()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -1747,7 +1747,7 @@ func externalKeyTest(t *testing.T, reexec bool) {
 		}
 	} else {
 		// Setting an non-existing key (namespace) must fail
-		if err := sbox.SetKey("this-must-fail"); err == nil {
+		if err := sbox.SetKey(context.Background(), "this-must-fail"); err == nil {
 			t.Fatalf("Setkey must fail if the corresponding namespace is not created")
 		}
 	}
@@ -1769,7 +1769,7 @@ func externalKeyTest(t *testing.T, reexec bool) {
 			t.Fatalf("libnetwork-setkey failed with %v", err)
 		}
 	} else {
-		if err := sbox.SetKey("ValidKey"); err != nil {
+		if err := sbox.SetKey(context.Background(), "ValidKey"); err != nil {
 			t.Fatalf("Setkey failed with %v", err)
 		}
 	}

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -2122,7 +2122,7 @@ func (n *Network) createLoadBalancerSandbox() (retErr error) {
 	}
 	defer func() {
 		if retErr != nil {
-			if e := n.ctrlr.SandboxDestroy(sandboxName); e != nil {
+			if e := n.ctrlr.SandboxDestroy(context.WithoutCancel(context.TODO()), sandboxName); e != nil {
 				log.G(context.TODO()).Warnf("could not delete sandbox %s on failure on failure (%v): %v", sandboxName, retErr, e)
 			}
 		}
@@ -2182,7 +2182,7 @@ func (n *Network) deleteLoadBalancerSandbox() error {
 		}
 	}
 
-	if err := c.SandboxDestroy(sandboxName); err != nil {
+	if err := c.SandboxDestroy(context.TODO(), sandboxName); err != nil {
 		return fmt.Errorf("Failed to delete %s sandbox: %v", sandboxName, err)
 	}
 	return nil

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1016,7 +1016,7 @@ func (n *Network) delete(force bool, rmLBEndpoint bool) error {
 
 	// Mark the network for deletion
 	n.inDelete = true
-	if err = c.updateToStore(n); err != nil {
+	if err = c.updateToStore(context.TODO(), n); err != nil {
 		return fmt.Errorf("error marking network %s (%s) for deletion: %v", n.Name(), n.ID(), err)
 	}
 
@@ -1211,7 +1211,7 @@ func (n *Network) createEndpoint(ctx context.Context, name string, options ...En
 
 	// We should perform updateToStore call right after addEndpoint
 	// in order to have iface properly configured
-	if err = n.getController().updateToStore(ep); err != nil {
+	if err = n.getController().updateToStore(ctx, ep); err != nil {
 		return nil, err
 	}
 	defer func() {

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -2139,7 +2139,7 @@ func (n *Network) createLoadBalancerSandbox() (retErr error) {
 	}
 	defer func() {
 		if retErr != nil {
-			if e := ep.Delete(true); e != nil {
+			if e := ep.Delete(context.WithoutCancel(context.TODO()), true); e != nil {
 				log.G(context.TODO()).Warnf("could not delete endpoint %s on failure on failure (%v): %v", endpointName, retErr, e)
 			}
 		}
@@ -2176,7 +2176,7 @@ func (n *Network) deleteLoadBalancerSandbox() error {
 			}
 		}
 
-		if err := endpoint.Delete(true); err != nil {
+		if err := endpoint.Delete(context.TODO(), true); err != nil {
 			log.G(context.TODO()).Warnf("Failed to delete endpoint %s (%s) in %s: %v", endpoint.Name(), endpoint.ID(), sandboxName, err)
 			// Ignore error and attempt to delete the sandbox.
 		}

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -2116,7 +2116,7 @@ func (n *Network) createLoadBalancerSandbox() (retErr error) {
 	if n.ingress {
 		sbOptions = append(sbOptions, OptionIngress())
 	}
-	sb, err := n.ctrlr.NewSandbox(sandboxName, sbOptions...)
+	sb, err := n.ctrlr.NewSandbox(context.TODO(), sandboxName, sbOptions...)
 	if err != nil {
 		return err
 	}

--- a/libnetwork/osl/sandbox_linux_test.go
+++ b/libnetwork/osl/sandbox_linux_test.go
@@ -1,6 +1,7 @@
 package osl
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"io"
@@ -393,7 +394,7 @@ func TestSandboxCreate(t *testing.T) {
 	}
 
 	for _, i := range tbox.Interfaces() {
-		err = s.AddInterface(i.SrcName(), i.DstName(),
+		err = s.AddInterface(context.Background(), i.SrcName(), i.DstName(),
 			WithIsBridge(i.Bridge()),
 			WithIPv4Address(i.Address()),
 			WithIPv6Address(i.AddressIPv6()))
@@ -492,7 +493,7 @@ func TestAddRemoveInterface(t *testing.T) {
 	}
 
 	for _, i := range tbox.Interfaces() {
-		err = s.AddInterface(i.SrcName(), i.DstName(),
+		err = s.AddInterface(context.Background(), i.SrcName(), i.DstName(),
 			WithIsBridge(i.Bridge()),
 			WithIPv4Address(i.Address()),
 			WithIPv6Address(i.AddressIPv6()),
@@ -512,7 +513,7 @@ func TestAddRemoveInterface(t *testing.T) {
 	verifySandbox(t, s, []string{"1", "2"})
 
 	i := tbox.Interfaces()[0]
-	err = s.AddInterface(i.SrcName(), i.DstName(),
+	err = s.AddInterface(context.Background(), i.SrcName(), i.DstName(),
 		WithIsBridge(i.Bridge()),
 		WithIPv4Address(i.Address()),
 		WithIPv6Address(i.AddressIPv6()),

--- a/libnetwork/osl/sandbox_linux_test.go
+++ b/libnetwork/osl/sandbox_linux_test.go
@@ -193,7 +193,7 @@ func TestDisableIPv6DAD(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = setInterfaceIPv6(nlh, link, iface)
+	err = setInterfaceIPv6(context.Background(), nlh, link, iface)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,15 +259,15 @@ func TestSetInterfaceIP(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := setInterfaceIP(nlh, linkA, iface); err != nil {
+	if err := setInterfaceIP(context.Background(), nlh, linkA, iface); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := setInterfaceIPv6(nlh, linkA, iface); err != nil {
+	if err := setInterfaceIPv6(context.Background(), nlh, linkA, iface); err != nil {
 		t.Fatal(err)
 	}
 
-	err = setInterfaceIP(nlh, linkB, iface)
+	err = setInterfaceIP(context.Background(), nlh, linkB, iface)
 	if err == nil {
 		t.Fatalf("Expected route conflict error, but succeeded")
 	}
@@ -275,7 +275,7 @@ func TestSetInterfaceIP(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	err = setInterfaceIPv6(nlh, linkB, iface)
+	err = setInterfaceIPv6(context.Background(), nlh, linkB, iface)
 	if err == nil {
 		t.Fatalf("Expected route conflict error, but succeeded")
 	}
@@ -329,15 +329,15 @@ func TestLiveRestore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := setInterfaceIP(nlh, linkA, iface); err != nil {
+	if err := setInterfaceIP(context.Background(), nlh, linkA, iface); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := setInterfaceIPv6(nlh, linkA, iface); err != nil {
+	if err := setInterfaceIPv6(context.Background(), nlh, linkA, iface); err != nil {
 		t.Fatal(err)
 	}
 
-	err = setInterfaceIP(nlh, linkB, iface)
+	err = setInterfaceIP(context.Background(), nlh, linkB, iface)
 	if err == nil {
 		t.Fatalf("Expected route conflict error, but succeeded")
 	}
@@ -345,7 +345,7 @@ func TestLiveRestore(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	err = setInterfaceIPv6(nlh, linkB, iface)
+	err = setInterfaceIPv6(context.Background(), nlh, linkB, iface)
 	if err == nil {
 		t.Fatalf("Expected route conflict error, but succeeded")
 	}
@@ -363,10 +363,10 @@ func TestLiveRestore(t *testing.T) {
 	// Check if the IPV4 & IPV6 entry present
 	// If present , we should get error in below call
 	// It shows us , we don't delete any config in live-restore case
-	if err := setInterfaceIPv6(nlh, linkA, iface); err == nil {
+	if err := setInterfaceIPv6(context.Background(), nlh, linkA, iface); err == nil {
 		t.Fatalf("Expected route conflict error, but succeeded for IPV6 ")
 	}
-	if err := setInterfaceIP(nlh, linkA, iface); err == nil {
+	if err := setInterfaceIP(context.Background(), nlh, linkA, iface); err == nil {
 		t.Fatalf("Expected route conflict error, but succeeded for IPV4 ")
 	}
 }

--- a/libnetwork/resolver_unix_test.go
+++ b/libnetwork/resolver_unix_test.go
@@ -51,7 +51,7 @@ func TestDNSIPQuery(t *testing.T) {
 
 	// we need the endpoint only to populate ep_list for the sandbox as part of resolve_name
 	// it is not set as a target for name resolution and does not serve any other purpose
-	err = ep.Join(sb)
+	err = ep.Join(context.Background(), sb)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/resolver_unix_test.go
+++ b/libnetwork/resolver_unix_test.go
@@ -44,7 +44,7 @@ func TestDNSIPQuery(t *testing.T) {
 	}
 
 	defer func() {
-		if err := sb.Delete(); err != nil {
+		if err := sb.Delete(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -137,7 +137,7 @@ func TestDNSProxyServFail(t *testing.T) {
 	}
 
 	defer func() {
-		if err := sb.Delete(); err != nil {
+		if err := sb.Delete(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 	}()

--- a/libnetwork/resolver_unix_test.go
+++ b/libnetwork/resolver_unix_test.go
@@ -38,7 +38,7 @@ func TestDNSIPQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sb, err := c.NewSandbox("c1")
+	sb, err := c.NewSandbox(context.Background(), "c1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +131,7 @@ func TestDNSProxyServFail(t *testing.T) {
 		}
 	}()
 
-	sb, err := c.NewSandbox("c1")
+	sb, err := c.NewSandbox(context.Background(), "c1")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/resolver_unix_test.go
+++ b/libnetwork/resolver_unix_test.go
@@ -3,6 +3,7 @@
 package libnetwork
 
 import (
+	"context"
 	"net"
 	"testing"
 
@@ -32,7 +33,7 @@ func TestDNSIPQuery(t *testing.T) {
 		}
 	}()
 
-	ep, err := n.CreateEndpoint("testep")
+	ep, err := n.CreateEndpoint(context.Background(), "testep")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -638,7 +638,7 @@ func (sb *Sandbox) clearNetworkResources(origEp *Endpoint) error {
 	// not bother updating the store. The sandbox object will be
 	// deleted anyway
 	if !inDelete {
-		return sb.storeUpdate()
+		return sb.storeUpdate(context.TODO())
 	}
 
 	return nil

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -171,12 +171,12 @@ func (sb *Sandbox) delete(force bool) error {
 		}
 
 		if !force {
-			if err := ep.Leave(sb); err != nil {
+			if err := ep.Leave(context.WithoutCancel(context.TODO()), sb); err != nil {
 				log.G(context.TODO()).Warnf("Failed detaching sandbox %s from endpoint %s: %v\n", sb.ID(), ep.ID(), err)
 			}
 		}
 
-		if err := ep.Delete(force); err != nil {
+		if err := ep.Delete(context.WithoutCancel(context.TODO()), force); err != nil {
 			log.G(context.TODO()).Warnf("Failed deleting endpoint %s: %v\n", ep.ID(), err)
 		}
 	}
@@ -244,14 +244,14 @@ func (sb *Sandbox) Rename(name string) error {
 
 // Refresh leaves all the endpoints, resets and re-applies the options,
 // re-joins all the endpoints without destroying the osl sandbox
-func (sb *Sandbox) Refresh(options ...SandboxOption) error {
+func (sb *Sandbox) Refresh(ctx context.Context, options ...SandboxOption) error {
 	// Store connected endpoints
 	epList := sb.Endpoints()
 
 	// Detach from all endpoints
 	for _, ep := range epList {
-		if err := ep.Leave(sb); err != nil {
-			log.G(context.TODO()).Warnf("Failed detaching sandbox %s from endpoint %s: %v\n", sb.ID(), ep.ID(), err)
+		if err := ep.Leave(context.WithoutCancel(ctx), sb); err != nil {
+			log.G(ctx).Warnf("Failed detaching sandbox %s from endpoint %s: %v\n", sb.ID(), ep.ID(), err)
 		}
 	}
 
@@ -266,8 +266,8 @@ func (sb *Sandbox) Refresh(options ...SandboxOption) error {
 
 	// Re-connect to all endpoints
 	for _, ep := range epList {
-		if err := ep.Join(context.WithoutCancel(context.TODO()), sb); err != nil {
-			log.G(context.TODO()).Warnf("Failed attach sandbox %s to endpoint %s: %v\n", sb.ID(), ep.ID(), err)
+		if err := ep.Join(context.WithoutCancel(ctx), sb); err != nil {
+			log.G(ctx).Warnf("Failed attach sandbox %s to endpoint %s: %v\n", sb.ID(), ep.ID(), err)
 		}
 	}
 

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -260,7 +260,7 @@ func (sb *Sandbox) Refresh(ctx context.Context, options ...SandboxOption) error 
 	sb.processOptions(options...)
 
 	// Setup discovery files
-	if err := sb.setupResolutionFiles(); err != nil {
+	if err := sb.setupResolutionFiles(ctx); err != nil {
 		return err
 	}
 

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -266,7 +266,7 @@ func (sb *Sandbox) Refresh(options ...SandboxOption) error {
 
 	// Re-connect to all endpoints
 	for _, ep := range epList {
-		if err := ep.Join(sb); err != nil {
+		if err := ep.Join(context.WithoutCancel(context.TODO()), sb); err != nil {
 			log.G(context.TODO()).Warnf("Failed attach sandbox %s to endpoint %s: %v\n", sb.ID(), ep.ID(), err)
 		}
 	}

--- a/libnetwork/sandbox_dns_unix.go
+++ b/libnetwork/sandbox_dns_unix.go
@@ -81,7 +81,10 @@ func (sb *Sandbox) startResolver(restore bool) {
 	})
 }
 
-func (sb *Sandbox) setupResolutionFiles() error {
+func (sb *Sandbox) setupResolutionFiles(ctx context.Context) error {
+	_, span := otel.Tracer("").Start(ctx, "libnetwork.Sandbox.setupResolutionFiles")
+	defer span.End()
+
 	// Create a hosts file that can be mounted during container setup. For most
 	// networking modes (not host networking) it will be re-created before the
 	// container start, once its support for IPv6 is known.

--- a/libnetwork/sandbox_dns_unix_test.go
+++ b/libnetwork/sandbox_dns_unix_test.go
@@ -3,6 +3,7 @@
 package libnetwork
 
 import (
+	"context"
 	"runtime"
 	"testing"
 
@@ -18,7 +19,7 @@ func TestDNSOptions(t *testing.T) {
 	c, err := New(OptionBoltdbWithRandomDBFile(t))
 	assert.NilError(t, err)
 
-	sb, err := c.NewSandbox("cnt1", nil)
+	sb, err := c.NewSandbox(context.Background(), "cnt1", nil)
 	assert.NilError(t, err)
 
 	cleanup := func(s *Sandbox) {
@@ -57,7 +58,7 @@ func TestDNSOptions(t *testing.T) {
 	assert.Check(t, is.Len(dnsOptionsList, 1))
 	assert.Check(t, is.Equal("ndots:5", dnsOptionsList[0]))
 
-	sb2, err := c.NewSandbox("cnt2", nil)
+	sb2, err := c.NewSandbox(context.Background(), "cnt2", nil)
 	assert.NilError(t, err)
 	defer cleanup(sb2)
 	sb2.startResolver(false)

--- a/libnetwork/sandbox_dns_unix_test.go
+++ b/libnetwork/sandbox_dns_unix_test.go
@@ -23,7 +23,7 @@ func TestDNSOptions(t *testing.T) {
 	assert.NilError(t, err)
 
 	cleanup := func(s *Sandbox) {
-		if err := s.Delete(); err != nil {
+		if err := s.Delete(context.Background()); err != nil {
 			t.Error(err)
 		}
 	}

--- a/libnetwork/sandbox_dns_windows.go
+++ b/libnetwork/sandbox_dns_windows.go
@@ -16,7 +16,7 @@ func (sb *Sandbox) restoreHostsPath() {}
 
 func (sb *Sandbox) restoreResolvConfPath() {}
 
-func (sb *Sandbox) updateHostsFile(ifaceIP []string) error {
+func (sb *Sandbox) updateHostsFile(_ context.Context, ifaceIP []string) error {
 	return nil
 }
 

--- a/libnetwork/sandbox_dns_windows.go
+++ b/libnetwork/sandbox_dns_windows.go
@@ -3,12 +3,14 @@
 package libnetwork
 
 import (
+	"context"
+
 	"github.com/docker/docker/libnetwork/etchosts"
 )
 
 // Stub implementations for DNS related functions
 
-func (sb *Sandbox) setupResolutionFiles() error {
+func (sb *Sandbox) setupResolutionFiles(_ context.Context) error {
 	return nil
 }
 

--- a/libnetwork/sandbox_externalkey_unix.go
+++ b/libnetwork/sandbox_externalkey_unix.go
@@ -13,10 +13,14 @@ import (
 	"path/filepath"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/internal/otelutil"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -33,6 +37,7 @@ func init() {
 type setKeyData struct {
 	ContainerID string
 	Key         string
+	OTelTrace   propagation.MapCarrier
 }
 
 // processSetKeyReexec is a private function that must be called only on an reexec path
@@ -41,13 +46,21 @@ type setKeyData struct {
 // Refer to https://github.com/opencontainers/runc/pull/160/ for more information
 // The docker exec-root can be specified as "-exec-root" flag. The default value is "/run/docker".
 func processSetKeyReexec() {
-	if err := setKey(); err != nil {
+	tc := propagation.TraceContext{}
+	otel.SetTextMapPropagator(tc)
+	carrier := otelutil.PropagateFromEnvironment()
+	ctx := tc.Extract(context.Background(), carrier)
+
+	if err := setKey(ctx); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }
 
-func setKey() error {
+func setKey(ctx context.Context) error {
+	ctx, span := otel.Tracer("").Start(ctx, "libnetwork.setKey", trace.WithSpanKind(trace.SpanKindServer))
+	defer span.End()
+
 	execRoot := flag.String("exec-root", defaultExecRoot, "docker exec root")
 	flag.Parse()
 
@@ -65,11 +78,11 @@ func setKey() error {
 		return err
 	}
 
-	return setExternalKey(shortCtlrID, containerID, fmt.Sprintf("/proc/%d/ns/net", state.Pid), *execRoot)
+	return setExternalKey(ctx, shortCtlrID, containerID, fmt.Sprintf("/proc/%d/ns/net", state.Pid), *execRoot)
 }
 
 // setExternalKey provides a convenient way to set an External key to a sandbox
-func setExternalKey(shortCtlrID string, containerID string, key string, execRoot string) error {
+func setExternalKey(ctx context.Context, shortCtlrID string, containerID string, key string, execRoot string) error {
 	uds := filepath.Join(execRoot, execSubdir, shortCtlrID+".sock")
 	c, err := net.Dial("unix", uds)
 	if err != nil {
@@ -77,11 +90,14 @@ func setExternalKey(shortCtlrID string, containerID string, key string, execRoot
 	}
 	defer c.Close()
 
-	err = json.NewEncoder(c).Encode(setKeyData{
+	d := setKeyData{
 		ContainerID: containerID,
 		Key:         key,
-	})
-	if err != nil {
+		OTelTrace:   propagation.MapCarrier{},
+	}
+	otel.GetTextMapPropagator().Inject(ctx, d.OTelTrace)
+
+	if err := json.NewEncoder(c).Encode(d); err != nil {
 		return fmt.Errorf("sendKey failed with : %v", err)
 	}
 	return processReturn(c)
@@ -165,11 +181,12 @@ func (c *Controller) processExternalKey(conn net.Conn) error {
 	if err = json.Unmarshal(buf[0:nr], &s); err != nil {
 		return err
 	}
+	ctx := otel.GetTextMapPropagator().Extract(context.Background(), s.OTelTrace)
 	sb, err := c.GetSandbox(s.ContainerID)
 	if err != nil {
 		return types.InvalidParameterErrorf("failed to get sandbox for %s", s.ContainerID)
 	}
-	return sb.SetKey(context.TODO(), s.Key)
+	return sb.SetKey(ctx, s.Key)
 }
 
 func (c *Controller) stopExternalKeyListener() {

--- a/libnetwork/sandbox_externalkey_unix.go
+++ b/libnetwork/sandbox_externalkey_unix.go
@@ -169,7 +169,7 @@ func (c *Controller) processExternalKey(conn net.Conn) error {
 	if err != nil {
 		return types.InvalidParameterErrorf("failed to get sandbox for %s", s.ContainerID)
 	}
-	return sb.SetKey(s.Key)
+	return sb.SetKey(context.TODO(), s.Key)
 }
 
 func (c *Controller) stopExternalKeyListener() {

--- a/libnetwork/sandbox_linux.go
+++ b/libnetwork/sandbox_linux.go
@@ -375,7 +375,7 @@ func (sb *Sandbox) populateNetworkResources(ctx context.Context, ep *Endpoint) e
 	// not bother updating the store. The sandbox object will be
 	// deleted anyway
 	if !inDelete {
-		return sb.storeUpdate()
+		return sb.storeUpdate(ctx)
 	}
 
 	return nil

--- a/libnetwork/sandbox_linux.go
+++ b/libnetwork/sandbox_linux.go
@@ -114,10 +114,10 @@ func (sb *Sandbox) ExecFunc(f func()) error {
 }
 
 // SetKey updates the Sandbox Key.
-func (sb *Sandbox) SetKey(basePath string) error {
+func (sb *Sandbox) SetKey(ctx context.Context, basePath string) error {
 	start := time.Now()
 	defer func() {
-		log.G(context.TODO()).Debugf("sandbox set key processing took %s for container %s", time.Since(start), sb.ContainerID())
+		log.G(ctx).Debugf("sandbox set key processing took %s for container %s", time.Since(start), sb.ContainerID())
 	}()
 
 	if basePath == "" {
@@ -137,7 +137,7 @@ func (sb *Sandbox) SetKey(basePath string) error {
 		// and destroy the OS snab. We are moving into a new home further down. Note that none
 		// of the network resources gets destroyed during the move.
 		if err := sb.releaseOSSbox(); err != nil {
-			log.G(context.TODO()).WithError(err).Error("Error destroying os sandbox")
+			log.G(ctx).WithError(err).Error("Error destroying os sandbox")
 		}
 	}
 
@@ -157,10 +157,10 @@ func (sb *Sandbox) SetKey(basePath string) error {
 
 		if err := sb.osSbox.InvokeFunc(sb.resolver.SetupFunc(0)); err == nil {
 			if err := sb.resolver.Start(); err != nil {
-				log.G(context.TODO()).Errorf("Resolver Start failed for container %s, %q", sb.ContainerID(), err)
+				log.G(ctx).Errorf("Resolver Start failed for container %s, %q", sb.ContainerID(), err)
 			}
 		} else {
-			log.G(context.TODO()).Errorf("Resolver Setup Function failed for container %s, %q", sb.ContainerID(), err)
+			log.G(ctx).Errorf("Resolver Setup Function failed for container %s, %q", sb.ContainerID(), err)
 		}
 	}
 
@@ -168,12 +168,12 @@ func (sb *Sandbox) SetKey(basePath string) error {
 	// determined yet, as sysctls haven't been applied by the runtime. Calling
 	// FinishInit after the container task has been created, when sysctls have been
 	// applied will regenerate these files.
-	if err := sb.finishInitDNS(context.TODO()); err != nil {
+	if err := sb.finishInitDNS(ctx); err != nil {
 		return err
 	}
 
 	for _, ep := range sb.Endpoints() {
-		if err = sb.populateNetworkResources(context.TODO(), ep); err != nil {
+		if err = sb.populateNetworkResources(ctx, ep); err != nil {
 			return err
 		}
 	}

--- a/libnetwork/sandbox_store.go
+++ b/libnetwork/sandbox_store.go
@@ -249,7 +249,7 @@ func (c *Controller) sandboxCleanup(activeSandboxes map[string]interface{}) erro
 
 		if _, ok := activeSandboxes[sb.ID()]; !ok {
 			log.G(context.TODO()).Infof("Removing stale sandbox %s (%s)", sb.id, sb.containerID)
-			if err := sb.delete(true); err != nil {
+			if err := sb.delete(context.WithoutCancel(context.TODO()), true); err != nil {
 				log.G(context.TODO()).Errorf("Failed to delete sandbox %s while trying to cleanup: %v", sb.id, err)
 			}
 			continue

--- a/libnetwork/sandbox_store.go
+++ b/libnetwork/sandbox_store.go
@@ -272,7 +272,7 @@ func (c *Controller) sandboxCleanup(activeSandboxes map[string]interface{}) erro
 			if !c.isAgent() {
 				n := ep.getNetwork()
 				if !c.isSwarmNode() || n.Scope() != scope.Swarm || !n.driverIsMultihost() {
-					n.updateSvcRecord(ep, true)
+					n.updateSvcRecord(context.WithoutCancel(context.TODO()), ep, true)
 				}
 			}
 		}

--- a/libnetwork/sandbox_store.go
+++ b/libnetwork/sandbox_store.go
@@ -122,7 +122,7 @@ func (sbs *sbState) CopyTo(o datastore.KVObject) error {
 	return nil
 }
 
-func (sb *Sandbox) storeUpdate() error {
+func (sb *Sandbox) storeUpdate(ctx context.Context) error {
 	sbs := &sbState{
 		c:          sb.controller,
 		ID:         sb.id,
@@ -146,7 +146,7 @@ retry:
 		})
 	}
 
-	err := sb.controller.updateToStore(sbs)
+	err := sb.controller.updateToStore(ctx, sbs)
 	if err == datastore.ErrKeyModified {
 		// When we get ErrKeyModified it is sufficient to just
 		// go back and retry.  No need to get the object from

--- a/libnetwork/sandbox_unix_test.go
+++ b/libnetwork/sandbox_unix_test.go
@@ -74,7 +74,7 @@ func TestControllerGetSandbox(t *testing.T) {
 	})
 	t.Run("existing sandbox", func(t *testing.T) {
 		const cID = "test-container-id"
-		expected, err := ctrlr.NewSandbox(cID)
+		expected, err := ctrlr.NewSandbox(context.Background(), cID)
 		assert.Check(t, err)
 
 		sb, err := ctrlr.GetSandbox(cID)
@@ -96,7 +96,7 @@ func TestControllerGetSandbox(t *testing.T) {
 func TestSandboxAddEmpty(t *testing.T) {
 	ctrlr, _ := getTestEnv(t)
 
-	sbx, err := ctrlr.NewSandbox("sandbox0")
+	sbx, err := ctrlr.NewSandbox(context.Background(), "sandbox0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +124,7 @@ func TestSandboxAddMultiPrio(t *testing.T) {
 
 	ctrlr, nws := getTestEnv(t, opts...)
 
-	sbx, err := ctrlr.NewSandbox("sandbox1")
+	sbx, err := ctrlr.NewSandbox(context.Background(), "sandbox1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +209,7 @@ func TestSandboxAddSamePrio(t *testing.T) {
 
 	ctrlr, nws := getTestEnv(t, opts...)
 
-	sbx, err := ctrlr.NewSandbox("sandbox1")
+	sbx, err := ctrlr.NewSandbox(context.Background(), "sandbox1")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/sandbox_unix_test.go
+++ b/libnetwork/sandbox_unix_test.go
@@ -3,6 +3,7 @@
 package libnetwork
 
 import (
+	"context"
 	"strconv"
 	"testing"
 
@@ -129,15 +130,15 @@ func TestSandboxAddMultiPrio(t *testing.T) {
 	}
 	sid := sbx.ID()
 
-	ep1, err := nws[0].CreateEndpoint("ep1")
+	ep1, err := nws[0].CreateEndpoint(context.Background(), "ep1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	ep2, err := nws[1].CreateEndpoint("ep2")
+	ep2, err := nws[1].CreateEndpoint(context.Background(), "ep2")
 	if err != nil {
 		t.Fatal(err)
 	}
-	ep3, err := nws[2].CreateEndpoint("ep3")
+	ep3, err := nws[2].CreateEndpoint(context.Background(), "ep3")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -214,21 +215,21 @@ func TestSandboxAddSamePrio(t *testing.T) {
 	}
 	sid := sbx.ID()
 
-	epNw1, err := nws[1].CreateEndpoint("ep1")
+	epNw1, err := nws[1].CreateEndpoint(context.Background(), "ep1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	epIPv6, err := nws[2].CreateEndpoint("ep2")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	epInternal, err := nws[3].CreateEndpoint("ep3")
+	epIPv6, err := nws[2].CreateEndpoint(context.Background(), "ep2")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	epNw0, err := nws[0].CreateEndpoint("ep4")
+	epInternal, err := nws[3].CreateEndpoint(context.Background(), "ep3")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	epNw0, err := nws[0].CreateEndpoint(context.Background(), "ep4")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/sandbox_unix_test.go
+++ b/libnetwork/sandbox_unix_test.go
@@ -163,14 +163,14 @@ func TestSandboxAddMultiPrio(t *testing.T) {
 		t.Fatal("Expected 3 endpoints to be connected to the sandbox.")
 	}
 
-	if err := ep3.Leave(sbx); err != nil {
+	if err := ep3.Leave(context.Background(), sbx); err != nil {
 		t.Fatal(err)
 	}
 	if ctrlr.sandboxes[sid].endpoints[0].ID() != ep2.ID() {
 		t.Fatal("Expected ep2 to be at the top of the heap after removing ep3. But did not find ep2 at the top of the heap")
 	}
 
-	if err := ep2.Leave(sbx); err != nil {
+	if err := ep2.Leave(context.Background(), sbx); err != nil {
 		t.Fatal(err)
 	}
 	if ctrlr.sandboxes[sid].endpoints[0].ID() != ep1.ID() {
@@ -265,7 +265,7 @@ func TestSandboxAddSamePrio(t *testing.T) {
 		t.Fatal("Expected epInternal to be at the bottom of the heap. But did not find epInternal at the bottom of the heap")
 	}
 
-	if err := epIPv6.Leave(sbx); err != nil {
+	if err := epIPv6.Leave(context.Background(), sbx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -274,7 +274,7 @@ func TestSandboxAddSamePrio(t *testing.T) {
 		t.Fatal("Expected epNw0 to be at the top of the heap after removing epIPv6. But did not find epNw0 at the top of the heap")
 	}
 
-	if err := epNw1.Leave(sbx); err != nil {
+	if err := epNw1.Leave(context.Background(), sbx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/libnetwork/sandbox_unix_test.go
+++ b/libnetwork/sandbox_unix_test.go
@@ -84,7 +84,7 @@ func TestControllerGetSandbox(t *testing.T) {
 		assert.Check(t, is.Equal(sb.Key(), expected.Key()))
 		assert.Check(t, is.Equal(sb.ContainerID(), expected.ContainerID()))
 
-		err = sb.Delete()
+		err = sb.Delete(context.Background())
 		assert.Check(t, err)
 
 		sb, err = ctrlr.GetSandbox(cID)
@@ -101,7 +101,7 @@ func TestSandboxAddEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := sbx.Delete(); err != nil {
+	if err := sbx.Delete(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -186,7 +186,7 @@ func TestSandboxAddMultiPrio(t *testing.T) {
 		t.Fatal("Expected ep3 to be at the top of the heap after adding ep3 back. But did not find ep3 at the top of the heap")
 	}
 
-	if err := sbx.Delete(); err != nil {
+	if err := sbx.Delete(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -278,7 +278,7 @@ func TestSandboxAddSamePrio(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := sbx.Delete(); err != nil {
+	if err := sbx.Delete(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 

--- a/libnetwork/sandbox_unix_test.go
+++ b/libnetwork/sandbox_unix_test.go
@@ -143,15 +143,15 @@ func TestSandboxAddMultiPrio(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ep1.Join(sbx, JoinOptionPriority(1)); err != nil {
+	if err := ep1.Join(context.Background(), sbx, JoinOptionPriority(1)); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := ep2.Join(sbx, JoinOptionPriority(2)); err != nil {
+	if err := ep2.Join(context.Background(), sbx, JoinOptionPriority(2)); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := ep3.Join(sbx, JoinOptionPriority(3)); err != nil {
+	if err := ep3.Join(context.Background(), sbx, JoinOptionPriority(3)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -178,7 +178,7 @@ func TestSandboxAddMultiPrio(t *testing.T) {
 	}
 
 	// Re-add ep3 back
-	if err := ep3.Join(sbx, JoinOptionPriority(3)); err != nil {
+	if err := ep3.Join(context.Background(), sbx, JoinOptionPriority(3)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -234,19 +234,19 @@ func TestSandboxAddSamePrio(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := epNw1.Join(sbx); err != nil {
+	if err := epNw1.Join(context.Background(), sbx); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := epIPv6.Join(sbx); err != nil {
+	if err := epIPv6.Join(context.Background(), sbx); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := epInternal.Join(sbx); err != nil {
+	if err := epInternal.Join(context.Background(), sbx); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := epNw0.Join(sbx); err != nil {
+	if err := epNw0.Join(context.Background(), sbx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/libnetwork/sandbox_windows.go
+++ b/libnetwork/sandbox_windows.go
@@ -1,6 +1,10 @@
 package libnetwork
 
-import "github.com/docker/docker/libnetwork/osl"
+import (
+	"context"
+
+	"github.com/docker/docker/libnetwork/osl"
+)
 
 // Windows-specific container configuration flags.
 type containerConfigOS struct {
@@ -29,7 +33,7 @@ func (sb *Sandbox) restoreOslSandbox() error {
 	return nil
 }
 
-func (sb *Sandbox) populateNetworkResources(*Endpoint) error {
+func (sb *Sandbox) populateNetworkResources(context.Context, *Endpoint) error {
 	// not implemented on Windows (Sandbox.osSbox is always nil)
 	return nil
 }

--- a/libnetwork/store.go
+++ b/libnetwork/store.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/scope"
+	"go.opentelemetry.io/otel"
 )
 
 func (c *Controller) getNetworkFromStore(nid string) (*Network, error) {
@@ -114,7 +115,10 @@ func (n *Network) getEndpointsFromStore() ([]*Endpoint, error) {
 	return epl, nil
 }
 
-func (c *Controller) updateToStore(kvObject datastore.KVObject) error {
+func (c *Controller) updateToStore(ctx context.Context, kvObject datastore.KVObject) error {
+	ctx, span := otel.Tracer("").Start(ctx, "libnetwork.Controller.updateToStore")
+	defer span.End()
+
 	if err := c.store.PutObjectAtomic(kvObject); err != nil {
 		if err == datastore.ErrKeyModified {
 			return err

--- a/libnetwork/store_linux_test.go
+++ b/libnetwork/store_linux_test.go
@@ -1,6 +1,7 @@
 package libnetwork
 
 import (
+	"context"
 	"errors"
 	"path/filepath"
 	"testing"
@@ -26,7 +27,7 @@ func TestNoPersist(t *testing.T) {
 	if err != nil {
 		t.Fatalf(`Error creating default "host" network: %v`, err)
 	}
-	ep, err := nw.CreateEndpoint("newendpoint", []EndpointOption{}...)
+	ep, err := nw.CreateEndpoint(context.Background(), "newendpoint", []EndpointOption{}...)
 	if err != nil {
 		t.Fatalf("Error creating endpoint: %v", err)
 	}

--- a/libnetwork/store_test.go
+++ b/libnetwork/store_test.go
@@ -1,6 +1,7 @@
 package libnetwork
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,7 +32,7 @@ func testLocalBackend(t *testing.T, provider, url string, storeConfig *store.Con
 	if err != nil {
 		t.Fatalf(`Error creating default "host" network: %v`, err)
 	}
-	ep, err := nw.CreateEndpoint("newendpoint", []EndpointOption{}...)
+	ep, err := nw.CreateEndpoint(context.Background(), "newendpoint", []EndpointOption{}...)
 	if err != nil {
 		t.Fatalf("Error creating endpoint: %v", err)
 	}


### PR DESCRIPTION
**- What I did**

This PR creates OTel spans at various places in the API, the daemon and libnetwork. This will help us better understand where performance bottlenecks are, measure the impact of future changes, etc...

**- How to verify it**

Using this branch, starting a container should produce the following spans:

![image](https://github.com/moby/moby/assets/557933/7ce2fa85-592f-41b6-a1ad-55988377949b)

**- A picture of a cute animal (not mandatory but encouraged)**

