### PR TITLE
api/types/network: make CheckDuplicate optional

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -10197,11 +10197,6 @@ paths:
                 description: "The network's name."
                 type: "string"
                 example: "my_network"
-              CheckDuplicate:
-                description: |
-                  Deprecated: CheckDuplicate is now always enabled.
-                type: "boolean"
-                example: true
               Driver:
                 description: "Name of the network driver plugin to use."
                 type: "string"

--- a/api/types/network/network.go
+++ b/api/types/network/network.go
@@ -23,14 +23,14 @@ const (
 type CreateRequest struct {
 	CreateOptions
 	Name string // Name is the requested name of the network.
+
+	// Deprecated: CheckDuplicate is deprecated since API v1.44, but it defaults to true when sent by the client
+	// package to older daemons.
+	CheckDuplicate *bool `json:",omitempty"`
 }
 
 // CreateOptions holds options to create a network.
 type CreateOptions struct {
-	// Deprecated: CheckDuplicate is deprecated since API v1.44, but it defaults to true when sent by the client
-	// package to older daemons.
-	CheckDuplicate bool `json:",omitempty"`
-
 	Driver     string            // Driver is the driver-name used to create the network (e.g. `bridge`, `overlay`)
 	Scope      string            // Scope describes the level at which the network exists (e.g. `swarm` for cluster-wide or `local` for machine level).
 	EnableIPv6 *bool             `json:",omitempty"` // EnableIPv6 represents whether to enable IPv6.

--- a/client/network_create.go
+++ b/client/network_create.go
@@ -26,7 +26,8 @@ func (cli *Client) NetworkCreate(ctx context.Context, name string, options netwo
 		Name:          name,
 	}
 	if versions.LessThan(cli.version, "1.44") {
-		networkCreateRequest.CheckDuplicate = true //nolint:staticcheck // ignore SA1019: CheckDuplicate is deprecated since API v1.44.
+		enabled := true
+		networkCreateRequest.CheckDuplicate = &enabled //nolint:staticcheck // ignore SA1019: CheckDuplicate is deprecated since API v1.44.
 	}
 
 	serverResp, err := cli.post(ctx, "/networks/create", nil, networkCreateRequest, nil)


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/46251
- [x] depends on / stacked on https://github.com/moby/moby/pull/47921


The CheckDuplicate option is no longer part of the current API; it's
only used by the client when connecting to old API versions, which need
to have this field set.

This patch:

- Removes the CheckDuplicate from the API documentation, as the API
  describes the current version of the API (which does not have this
  field).
- Moves the CheckDuplicate field to the CreateRequest type; this is
  the type used for the network create request. The CheckDuplicate
  is not an option that's set by the user, and set internally by
  the client, so removing it from the CreateOptions struct moves
  it entirely internal.
- Change the CheckDuplicate field to be a pointer; this makes the
  "omitempty" become active, and the client will no longer include
  the field in the request JSON unless it's set (API < 1.44).


**- A picture of a cute animal (not mandatory but encouraged)**

