### PR TITLE
Revert "libnet/i/defaultipam: Disambiguate PoolID string format"

### DIFF
--- a/libnetwork/ipams/defaultipam/structures.go
+++ b/libnetwork/ipams/defaultipam/structures.go
@@ -55,22 +55,22 @@ func PoolIDFromString(str string) (pID PoolID, err error) {
 
 func parsePoolIDV1(str string) (pID PoolID, err error) {
 	if str == "" {
-		return pID, types.InternalErrorf("invalid string form for subnetkey: %s", str)
+		return pID, types.InvalidParameterErrorf("invalid string form for subnetkey: %s", str)
 	}
 
 	p := strings.Split(str, "/")
 	if len(p) != 3 && len(p) != 5 {
-		return pID, types.InternalErrorf("invalid string form for subnetkey: %s", str)
+		return pID, types.InvalidParameterErrorf("invalid string form for subnetkey: %s", str)
 	}
 	pID.AddressSpace = p[0]
 	pID.Subnet, err = netip.ParsePrefix(p[1] + "/" + p[2])
 	if err != nil {
-		return pID, types.InternalErrorf("invalid string form for subnetkey: %s", str)
+		return pID, types.InvalidParameterErrorf("invalid string form for subnetkey: %s", str)
 	}
 	if len(p) == 5 {
 		pID.ChildSubnet, err = netip.ParsePrefix(p[3] + "/" + p[4])
 		if err != nil {
-			return pID, types.InternalErrorf("invalid string form for subnetkey: %s", str)
+			return pID, types.InvalidParameterErrorf("invalid string form for subnetkey: %s", str)
 		}
 	}
 
@@ -89,18 +89,18 @@ func parsePoolIDV2(str string) (pID PoolID, err error) {
 
 	if v, ok := fields[subnetField]; ok && v != "" {
 		if pID.Subnet, err = netip.ParsePrefix(v); err != nil {
-			return PoolID{}, types.InternalErrorf("invalid string form for subnetkey %s: %v", str, err)
+			return PoolID{}, types.InvalidParameterErrorf("invalid string form for subnetkey %s: %w", str, err)
 		}
 	}
 
 	if v, ok := fields[childSubnetField]; ok && v != "" {
 		if pID.ChildSubnet, err = netip.ParsePrefix(v); err != nil {
-			return PoolID{}, types.InternalErrorf("invalid string form for subnetkey %s: %v", str, err)
+			return PoolID{}, types.InvalidParameterErrorf("invalid string form for subnetkey %s: %w", str, err)
 		}
 	}
 
 	if pID.AddressSpace == "" || pID.Subnet == (netip.Prefix{}) {
-		return PoolID{}, types.InternalErrorf("invalid string form for subnetkey %s: missing AddressSpace or Subnet", str)
+		return PoolID{}, types.InvalidParameterErrorf("invalid string form for subnetkey %s: missing AddressSpace or Subnet", str)
 	}
 
 	return pID, nil

--- a/libnetwork/ipams/defaultipam/structures.go
+++ b/libnetwork/ipams/defaultipam/structures.go
@@ -1,21 +1,12 @@
 package defaultipam
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/netip"
 	"strings"
 
 	"github.com/docker/docker/libnetwork/bitmap"
 	"github.com/docker/docker/libnetwork/types"
-)
-
-const (
-	poolIDV2Prefix = "PoolID"
-
-	addressSpaceField = "AddressSpace"
-	subnetField       = "Subnet"
-	childSubnetField  = "ChildSubnet"
 )
 
 // PoolID is the pointer to the configured pools in each address space
@@ -45,15 +36,6 @@ func (k SubnetKey) Is6() bool {
 // PoolIDFromString creates a new PoolID and populates the SubnetKey object
 // reading it from the given string.
 func PoolIDFromString(str string) (pID PoolID, err error) {
-	if strings.HasPrefix(str, poolIDV2Prefix) {
-		return parsePoolIDV2(str)
-	}
-
-	// TODO(aker): drop support for this 'v1' format once the next major MCR LTS is released.
-	return parsePoolIDV1(str)
-}
-
-func parsePoolIDV1(str string) (pID PoolID, err error) {
 	if str == "" {
 		return pID, types.InvalidParameterErrorf("invalid string form for subnetkey: %s", str)
 	}
@@ -77,53 +59,13 @@ func parsePoolIDV1(str string) (pID PoolID, err error) {
 	return pID, nil
 }
 
-func parsePoolIDV2(str string) (pID PoolID, err error) {
-	data := strings.TrimPrefix(str, poolIDV2Prefix)
-
-	var fields map[string]string
-	if err := json.Unmarshal([]byte(data), &fields); err != nil {
-		return PoolID{}, err
-	}
-
-	pID.AddressSpace = fields[addressSpaceField]
-
-	if v, ok := fields[subnetField]; ok && v != "" {
-		if pID.Subnet, err = netip.ParsePrefix(v); err != nil {
-			return PoolID{}, types.InvalidParameterErrorf("invalid string form for subnetkey %s: %w", str, err)
-		}
-	}
-
-	if v, ok := fields[childSubnetField]; ok && v != "" {
-		if pID.ChildSubnet, err = netip.ParsePrefix(v); err != nil {
-			return PoolID{}, types.InvalidParameterErrorf("invalid string form for subnetkey %s: %w", str, err)
-		}
-	}
-
-	if pID.AddressSpace == "" || pID.Subnet == (netip.Prefix{}) {
-		return PoolID{}, types.InvalidParameterErrorf("invalid string form for subnetkey %s: missing AddressSpace or Subnet", str)
-	}
-
-	return pID, nil
-}
-
 // String returns the string form of the SubnetKey object
 func (s *PoolID) String() string {
-	fields := map[string]string{
-		addressSpaceField: s.AddressSpace,
-		subnetField:       s.Subnet.String(),
+	if s.ChildSubnet == (netip.Prefix{}) {
+		return s.AddressSpace + "/" + s.Subnet.String()
+	} else {
+		return s.AddressSpace + "/" + s.Subnet.String() + "/" + s.ChildSubnet.String()
 	}
-
-	// ChildSubnet is optional
-	if s.ChildSubnet != (netip.Prefix{}) {
-		fields[childSubnetField] = s.ChildSubnet.String()
-	}
-
-	b, err := json.Marshal(fields)
-	if err != nil {
-		panic(err)
-	}
-
-	return "PoolID" + string(b)
 }
 
 // String returns the string form of the PoolData object


### PR DESCRIPTION
**- What I did**

- This reverts https://github.com/moby/moby/pull/47837. Discussions happened after it was merged, and we dediced to:
    - Implement the critical / anciliary scheme described in this comment: https://github.com/moby/moby/pull/47837#issuecomment-2116064486
    - Keep storing the PoolID v1 format along with the v2 format, to make sure users can downgrade to any previous release.
- This PR was originally made to add proper support for duplicate subnet allocations in a subsequent change. However, this is a low-priority enhancement as compared to other ongoing tasks, so it's postponed until v28.0.
- I'll reapply these commits, with the requested changes, once ready to work on duplicate allocations.
