### PR TITLE
Add Rob Murray (@robmry) as maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -38,6 +38,7 @@
 			"laurazard",
 			"mhbauer",
 			"neersighted",
+			"robmry",
 			"rumpl",
 			"runcom",
 			"samuelkarp",
@@ -75,7 +76,6 @@
 			"olljanat",
 			"programmerq",
 			"ripcurld",
-			"robmry",
 			"sam-thibault",
 			"samwhited",
 			"thajeztah"


### PR DESCRIPTION
Rob is currently a curator, and has been actively contributing to this repo for 7 months now.

Beside day-to-day triaging and bug fixing, Rob is an instrumental contributor to libnetwork, and amongst other things, to the ongoing work on IPv6 improvements.

I nominated Rob as maintainer, and votes passed, so opening a PR to make it official.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://imageio.forbes.com/specials-images/imageserve/6592dc01537315bc72f11043/A-racoon-in-the-snow-seemingly-waving-/960x0.jpg?height=711&width=711&fit=bounds)