### PR TITLE
daemon/graphdriver: remove redundant Mounted function

### DIFF
--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -69,8 +69,8 @@ type ProtoDriver interface {
 	// Status returns a set of key-value pairs which give low
 	// level diagnostic status about this driver.
 	Status() [][2]string
-	// Returns a set of key-value pairs which give low level information
-	// about the image/container driver is managing.
+	// GetMetadata returns a set of key-value pairs which give driver-specific
+	// low-level information about the image/container that the driver is managing.
 	GetMetadata(id string) (map[string]string, error)
 	// Cleanup performs necessary tasks to release resources
 	// held by the driver, e.g., unmounting all layered filesystems

--- a/daemon/graphdriver/driver_freebsd.go
+++ b/daemon/graphdriver/driver_freebsd.go
@@ -1,19 +1,4 @@
 package graphdriver // import "github.com/docker/docker/daemon/graphdriver"
 
-import (
-	"syscall"
-
-	"golang.org/x/sys/unix"
-)
-
 // List of drivers that should be used in an order
 var priority = "zfs"
-
-// Mounted checks if the given path is mounted as the fs type
-func Mounted(fsType FsMagic, mountPath string) (bool, error) {
-	var buf unix.Statfs_t
-	if err := syscall.Statfs(mountPath, &buf); err != nil {
-		return false, err
-	}
-	return FsMagic(buf.Type) == fsType, nil
-}

--- a/daemon/graphdriver/driver_linux.go
+++ b/daemon/graphdriver/driver_linux.go
@@ -99,8 +99,8 @@ type fsChecker struct {
 }
 
 func (c *fsChecker) IsMounted(path string) bool {
-	m, _ := Mounted(c.t, path)
-	return m
+	fsType, _ := GetFSMagic(path)
+	return fsType == c.t
 }
 
 // NewDefaultChecker returns a check that parses /proc/mountinfo to check
@@ -114,16 +114,4 @@ type defaultChecker struct{}
 func (c *defaultChecker) IsMounted(path string) bool {
 	m, _ := mountinfo.Mounted(path)
 	return m
-}
-
-// Mounted checks if the given path is mounted as the fs type
-func Mounted(fsType FsMagic, mountPath string) (bool, error) {
-	var buf unix.Statfs_t
-	if err := unix.Statfs(mountPath, &buf); err != nil {
-		if err == unix.ENOENT { // not exist, thus not mounted
-			err = nil
-		}
-		return false, err
-	}
-	return FsMagic(buf.Type) == fsType, nil
 }


### PR DESCRIPTION
### daemon/graphdriver: remove redundant Mounted function

This function largely identical to GetFSMagic, except for suppressing
ENOENT errors. The only consumer of this function was fsChecker.IsMounted,
which would ignore errors either way, and only use the "success" case to
check if the detected filesystem-type was the expected one.

This patch;

- rewrites fsChecker.IsMounted to use GetFSMagic instead
- removes the now unused Mounted function

As we consider daemon/graphdriver to be "internal", and as there are no
public consumers of this, we can remove this function without deprecating
first.

The freebsd implementation also seemed to be broken, as it mixed syscall
with golang.org/x/sys/unix, which used incompatible types. I left the file
in place for now, but we can consider removing it altogether as there's no
active development on making freebsd functional.


### daemon/graphdriver: fix GoDoc for ProtoDriver.GetMetadata


**- A picture of a cute animal (not mandatory but encouraged)**

