### PR TITLE
integration-cli: remove DockerAPISuite.TestContainerAPICopyNotExistsAnyMore

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -162,12 +162,6 @@ type Container struct {
 	Mounts          []MountPoint
 }
 
-// CopyConfig contains request body of Engine API:
-// POST "/containers/"+containerID+"/copy"
-type CopyConfig struct {
-	Resource string
-}
-
 // ContainerPathStat is used to encode the header from
 // GET "/containers/{name:.*}/archive"
 // "Name" is the file or directory name.

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -945,19 +945,6 @@ func (s *DockerAPISuite) TestContainerAPIWait(c *testing.T) {
 	}
 }
 
-func (s *DockerAPISuite) TestContainerAPICopyNotExistsAnyMore(c *testing.T) {
-	const name = "test-container-api-copy"
-	cli.DockerCmd(c, "run", "--name", name, "busybox", "touch", "/test.txt")
-
-	postData := types.CopyConfig{
-		Resource: "/test.txt",
-	}
-	// no copy in client/
-	res, _, err := request.Post(testutil.GetContext(c), "/containers/"+name+"/copy", request.JSONBody(postData))
-	assert.NilError(c, err)
-	assert.Equal(c, res.StatusCode, http.StatusNotFound)
-}
-
 func (s *DockerAPISuite) TestContainerAPIDelete(c *testing.T) {
 	id := runSleepingContainer(c)
 	cli.WaitRun(c, id)


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/22149


This test was added in 428328908dc529b1678fb3d8b033fb0591a294e3;

> Deprecate /containers/(id or name)/copy endpoint
> This endpoint has been deprecated since 1.8. Return an error starting
> from this API version (1.24) in order to make sure it's not used for the
> next API version and so that we can remove it sometimes later.

We deprecated and removed those older API versions, and the test was effectively only verifying that a non-existing endpoint returns a 404, so let's remove it.

This also removes api/types.CopyConfig, which was only used in this test.


**- A picture of a cute animal (not mandatory but encouraged)**

