### PR TITLE
api/types: move more types to sub-packages

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -23,10 +23,10 @@ type execBackend interface {
 
 // copyBackend includes functions to implement to provide container copy functionality.
 type copyBackend interface {
-	ContainerArchivePath(name string, path string) (content io.ReadCloser, stat *types.ContainerPathStat, err error)
+	ContainerArchivePath(name string, path string) (content io.ReadCloser, stat *container.PathStat, err error)
 	ContainerExport(ctx context.Context, name string, out io.Writer) error
 	ContainerExtractToDir(name, path string, copyUIDGID, noOverwriteDirNonDir bool, content io.Reader) error
-	ContainerStatPath(name string, path string) (stat *types.ContainerPathStat, err error)
+	ContainerStatPath(name string, path string) (stat *container.PathStat, err error)
 }
 
 // stateBackend includes functions to implement to provide container state lifecycle functionality.

--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -62,7 +62,7 @@ type attachBackend interface {
 
 // systemBackend includes functions to implement to provide system wide containers functionality
 type systemBackend interface {
-	ContainersPrune(ctx context.Context, pruneFilters filters.Args) (*types.ContainersPruneReport, error)
+	ContainersPrune(ctx context.Context, pruneFilters filters.Args) (*container.PruneReport, error)
 }
 
 type commitBackend interface {

--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -14,7 +14,7 @@ import (
 
 // execBackend includes functions to implement to provide exec functionality.
 type execBackend interface {
-	ContainerExecCreate(name string, config *types.ExecConfig) (string, error)
+	ContainerExecCreate(name string, options *container.ExecOptions) (string, error)
 	ContainerExecInspect(id string) (*backend.ExecInspect, error)
 	ContainerExecResize(name string, height, width int) error
 	ContainerExecStart(ctx context.Context, name string, options container.ExecStartOptions) error

--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -17,7 +17,7 @@ type execBackend interface {
 	ContainerExecCreate(name string, options *container.ExecOptions) (string, error)
 	ContainerExecInspect(id string) (*backend.ExecInspect, error)
 	ContainerExecResize(name string, height, width int) error
-	ContainerExecStart(ctx context.Context, name string, options container.ExecStartOptions) error
+	ContainerExecStart(ctx context.Context, name string, options backend.ExecStartConfig) error
 	ExecExists(name string) (bool, error)
 }
 

--- a/api/server/router/container/copy.go
+++ b/api/server/router/container/copy.go
@@ -10,12 +10,12 @@ import (
 	"net/http"
 
 	"github.com/docker/docker/api/server/httputils"
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	gddohttputil "github.com/golang/gddo/httputil"
 )
 
 // setContainerPathStatHeader encodes the stat to JSON, base64 encode, and place in a header.
-func setContainerPathStatHeader(stat *types.ContainerPathStat, header http.Header) error {
+func setContainerPathStatHeader(stat *container.PathStat, header http.Header) error {
 	statJSON, err := json.Marshal(stat)
 	if err != nil {
 		return err

--- a/api/server/router/container/exec.go
+++ b/api/server/router/container/exec.go
@@ -78,7 +78,7 @@ func (s *containerRouter) postContainerExecStart(ctx context.Context, w http.Res
 		stdout, stderr, outStream io.Writer
 	)
 
-	options := &types.ExecStartCheck{}
+	options := &container.ExecStartOptions{}
 	if err := httputils.ReadJSON(r, options); err != nil {
 		return err
 	}

--- a/api/server/router/container/exec.go
+++ b/api/server/router/container/exec.go
@@ -38,7 +38,7 @@ func (s *containerRouter) postContainerExecCreate(ctx context.Context, w http.Re
 		return err
 	}
 
-	execConfig := &types.ExecConfig{}
+	execConfig := &container.ExecOptions{}
 	if err := httputils.ReadJSON(r, execConfig); err != nil {
 		return err
 	}

--- a/api/server/router/container/exec.go
+++ b/api/server/router/container/exec.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/errdefs"
@@ -137,7 +138,7 @@ func (s *containerRouter) postContainerExecStart(ctx context.Context, w http.Res
 	// Now run the user process in container.
 	//
 	// TODO: Maybe we should we pass ctx here if we're not detaching?
-	err := s.backend.ContainerExecStart(context.Background(), execName, container.ExecStartOptions{
+	err := s.backend.ContainerExecStart(context.Background(), execName, backend.ExecStartConfig{
 		Stdin:       stdin,
 		Stdout:      stdout,
 		Stderr:      stderr,

--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -5,7 +5,6 @@ import (
 	"io"
 
 	"github.com/distribution/reference"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
@@ -28,7 +27,7 @@ type imageBackend interface {
 	Images(ctx context.Context, opts image.ListOptions) ([]*image.Summary, error)
 	GetImage(ctx context.Context, refOrID string, options backend.GetImageOpts) (*dockerimage.Image, error)
 	TagImage(ctx context.Context, id dockerimage.ID, newRef reference.Named) error
-	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*types.ImagesPruneReport, error)
+	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*image.PruneReport, error)
 }
 
 type importExportBackend interface {

--- a/api/server/router/volume/backend.go
+++ b/api/server/router/volume/backend.go
@@ -3,11 +3,9 @@ package volume // import "github.com/docker/docker/api/server/router/volume"
 import (
 	"context"
 
-	"github.com/docker/docker/volume/service/opts"
-	// TODO return types need to be refactored into pkg
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/volume/service/opts"
 )
 
 // Backend is the methods that need to be implemented to provide
@@ -17,7 +15,7 @@ type Backend interface {
 	Get(ctx context.Context, name string, opts ...opts.GetOption) (*volume.Volume, error)
 	Create(ctx context.Context, name, driverName string, opts ...opts.CreateOption) (*volume.Volume, error)
 	Remove(ctx context.Context, name string, opts ...opts.RemoveOption) error
-	Prune(ctx context.Context, pruneFilters filters.Args) (*types.VolumesPruneReport, error)
+	Prune(ctx context.Context, pruneFilters filters.Args) (*volume.PruneReport, error)
 }
 
 // ClusterBackend is the backend used for Swarm Cluster Volumes. Regular

--- a/api/server/router/volume/volume_routes_test.go
+++ b/api/server/router/volume/volume_routes_test.go
@@ -11,7 +11,6 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/docker/docker/api/server/httputils"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/errdefs"
@@ -636,7 +635,7 @@ func (b *fakeVolumeBackend) Remove(_ context.Context, name string, o ...opts.Rem
 	return nil
 }
 
-func (b *fakeVolumeBackend) Prune(_ context.Context, _ filters.Args) (*types.VolumesPruneReport, error) {
+func (b *fakeVolumeBackend) Prune(_ context.Context, _ filters.Args) (*volume.PruneReport, error) {
 	return nil, nil
 }
 

--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -92,6 +92,14 @@ type ContainerStatsConfig struct {
 	OutStream func() io.Writer
 }
 
+// ExecStartConfig holds the options to start container's exec.
+type ExecStartConfig struct {
+	Stdin       io.Reader
+	Stdout      io.Writer
+	Stderr      io.Writer
+	ConsoleSize *[2]uint `json:",omitempty"`
+}
+
 // ExecInspect holds information about a running process started
 // with docker exec.
 type ExecInspect struct {

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -130,12 +130,6 @@ type ImageBuildResponse struct {
 	OSType string
 }
 
-// ImageImportSource holds source information for ImageImport
-type ImageImportSource struct {
-	Source     io.Reader // Source is the data to send to the server to create this image from. You must set SourceName to "-" to leverage this.
-	SourceName string    // SourceName is the name of the image to pull. Set to "-" to leverage the Source attribute.
-}
-
 // ImageLoadResponse returns information to the client about a load process.
 type ImageLoadResponse struct {
 	// Body must be closed to avoid a resource leak

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -12,13 +12,6 @@ import (
 	units "github.com/docker/go-units"
 )
 
-// EventsOptions holds parameters to filter events with.
-type EventsOptions struct {
-	Since   string
-	Until   string
-	Filters filters.Args
-}
-
 // NewHijackedResponse intializes a HijackedResponse type
 func NewHijackedResponse(conn net.Conn, mediaType string) HijackedResponse {
 	return HijackedResponse{Conn: conn, Reader: bufio.NewReader(conn), mediaType: mediaType}

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -130,13 +130,6 @@ type ImageBuildResponse struct {
 	OSType string
 }
 
-// ImageLoadResponse returns information to the client about a load process.
-type ImageLoadResponse struct {
-	// Body must be closed to avoid a resource leak
-	Body io.ReadCloser
-	JSON bool
-}
-
 // RequestPrivilegeFunc is a function interface that
 // clients can supply to retry operations after
 // getting an authorization error.

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -12,15 +12,6 @@ import (
 	units "github.com/docker/go-units"
 )
 
-// ContainerExecInspect holds information returned by exec inspect.
-type ContainerExecInspect struct {
-	ExecID      string `json:"ID"`
-	ContainerID string
-	Running     bool
-	ExitCode    int
-	Pid         int
-}
-
 // CopyToContainerOptions holds information
 // about files to copy into a container
 type CopyToContainerOptions struct {

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -12,13 +12,6 @@ import (
 	units "github.com/docker/go-units"
 )
 
-// CopyToContainerOptions holds information
-// about files to copy into a container
-type CopyToContainerOptions struct {
-	AllowOverwriteDirWithFile bool
-	CopyUIDGID                bool
-}
-
 // EventsOptions holds parameters to filter events with.
 type EventsOptions struct {
 	Since   string

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -151,14 +151,6 @@ type ImageLoadResponse struct {
 // if the privilege request fails.
 type RequestPrivilegeFunc func(context.Context) (string, error)
 
-// ImageSearchOptions holds parameters to search images with.
-type ImageSearchOptions struct {
-	RegistryAuth  string
-	PrivilegeFunc RequestPrivilegeFunc
-	Filters       filters.Args
-	Limit         int
-}
-
 // NodeListOptions holds parameters to list nodes with.
 type NodeListOptions struct {
 	Filters filters.Args

--- a/api/types/container/config.go
+++ b/api/types/container/config.go
@@ -1,7 +1,6 @@
 package container // import "github.com/docker/docker/api/types/container"
 
 import (
-	"io"
 	"time"
 
 	"github.com/docker/docker/api/types/strslice"
@@ -35,14 +34,6 @@ type StopOptions struct {
 
 // HealthConfig holds configuration settings for the HEALTHCHECK feature.
 type HealthConfig = dockerspec.HealthcheckConfig
-
-// ExecStartOptions holds the options to start container's exec.
-type ExecStartOptions struct {
-	Stdin       io.Reader
-	Stdout      io.Writer
-	Stderr      io.Writer
-	ConsoleSize *[2]uint `json:",omitempty"`
-}
 
 // Config contains the configuration data about a container.
 // It should hold only portable information about the container.

--- a/api/types/container/container.go
+++ b/api/types/container/container.go
@@ -22,3 +22,10 @@ type PathStat struct {
 	Mtime      time.Time   `json:"mtime"`
 	LinkTarget string      `json:"linkTarget"`
 }
+
+// CopyToContainerOptions holds information
+// about files to copy into a container
+type CopyToContainerOptions struct {
+	AllowOverwriteDirWithFile bool
+	CopyUIDGID                bool
+}

--- a/api/types/container/container.go
+++ b/api/types/container/container.go
@@ -1,0 +1,8 @@
+package container
+
+// PruneReport contains the response for Engine API:
+// POST "/containers/prune"
+type PruneReport struct {
+	ContainersDeleted []string
+	SpaceReclaimed    uint64
+}

--- a/api/types/container/container.go
+++ b/api/types/container/container.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"io"
 	"os"
 	"time"
 )
@@ -28,4 +29,11 @@ type PathStat struct {
 type CopyToContainerOptions struct {
 	AllowOverwriteDirWithFile bool
 	CopyUIDGID                bool
+}
+
+// StatsResponse contains response of Engine API:
+// GET "/stats"
+type StatsResponse struct {
+	Body   io.ReadCloser `json:"body"`
+	OSType string        `json:"ostype"`
 }

--- a/api/types/container/container.go
+++ b/api/types/container/container.go
@@ -1,8 +1,24 @@
 package container
 
+import (
+	"os"
+	"time"
+)
+
 // PruneReport contains the response for Engine API:
 // POST "/containers/prune"
 type PruneReport struct {
 	ContainersDeleted []string
 	SpaceReclaimed    uint64
+}
+
+// PathStat is used to encode the header from
+// GET "/containers/{name:.*}/archive"
+// "Name" is the file or directory name.
+type PathStat struct {
+	Name       string      `json:"name"`
+	Size       int64       `json:"size"`
+	Mode       os.FileMode `json:"mode"`
+	Mtime      time.Time   `json:"mtime"`
+	LinkTarget string      `json:"linkTarget"`
 }

--- a/api/types/container/exec.go
+++ b/api/types/container/exec.go
@@ -16,3 +16,19 @@ type ExecOptions struct {
 	WorkingDir   string   // Working directory
 	Cmd          []string // Execution commands and args
 }
+
+// ExecStartOptions is a temp struct used by execStart
+// Config fields is part of ExecConfig in runconfig package
+type ExecStartOptions struct {
+	// ExecStart will first check if it's detached
+	Detach bool
+	// Check if there's a tty
+	Tty bool
+	// Terminal size [height, width], unused if Tty == false
+	ConsoleSize *[2]uint `json:",omitempty"`
+}
+
+// ExecAttachOptions is a temp struct used by execAttach.
+//
+// TODO(thaJeztah): make this a separate type; ContainerExecAttach does not use the Detach option, and cannot run detached.
+type ExecAttachOptions = ExecStartOptions

--- a/api/types/container/exec.go
+++ b/api/types/container/exec.go
@@ -32,3 +32,12 @@ type ExecStartOptions struct {
 //
 // TODO(thaJeztah): make this a separate type; ContainerExecAttach does not use the Detach option, and cannot run detached.
 type ExecAttachOptions = ExecStartOptions
+
+// ExecInspect holds information returned by exec inspect.
+type ExecInspect struct {
+	ExecID      string `json:"ID"`
+	ContainerID string
+	Running     bool
+	ExitCode    int
+	Pid         int
+}

--- a/api/types/container/exec.go
+++ b/api/types/container/exec.go
@@ -1,8 +1,8 @@
-package types // import "github.com/docker/docker/api/types"
+package container
 
-// ExecConfig is a small subset of the Config struct that holds the configuration
+// ExecOptions is a small subset of the Config struct that holds the configuration
 // for the exec feature of docker.
-type ExecConfig struct {
+type ExecOptions struct {
 	User         string   // User that will run the command
 	Privileged   bool     // Is the container in privileged mode
 	Tty          bool     // Attach standard streams to a tty.

--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -1,4 +1,5 @@
 package events // import "github.com/docker/docker/api/types/events"
+import "github.com/docker/docker/api/types/filters"
 
 // Type is used for event-types.
 type Type string
@@ -124,4 +125,11 @@ type Message struct {
 
 	Time     int64 `json:"time,omitempty"`
 	TimeNano int64 `json:"timeNano,omitempty"`
+}
+
+// ListOptions holds parameters to filter events with.
+type ListOptions struct {
+	Since   string
+	Until   string
+	Filters filters.Args
 }

--- a/api/types/image/image.go
+++ b/api/types/image/image.go
@@ -7,3 +7,10 @@ type Metadata struct {
 	// LastTagTime is the date and time at which the image was last tagged.
 	LastTagTime time.Time `json:",omitempty"`
 }
+
+// PruneReport contains the response for Engine API:
+// POST "/images/prune"
+type PruneReport struct {
+	ImagesDeleted  []DeleteResponse
+	SpaceReclaimed uint64
+}

--- a/api/types/image/image.go
+++ b/api/types/image/image.go
@@ -1,6 +1,9 @@
 package image
 
-import "time"
+import (
+	"io"
+	"time"
+)
 
 // Metadata contains engine-local data about the image.
 type Metadata struct {
@@ -13,4 +16,32 @@ type Metadata struct {
 type PruneReport struct {
 	ImagesDeleted  []DeleteResponse
 	SpaceReclaimed uint64
+}
+
+// LoadResponse returns information to the client about a load process.
+//
+// TODO(thaJeztah): remove this type, and just use an io.ReadCloser
+//
+// This type was added in https://github.com/moby/moby/pull/18878, related
+// to https://github.com/moby/moby/issues/19177;
+//
+// Make docker load to output json when the response content type is json
+// Swarm hijacks the response from docker load and returns JSON rather
+// than plain text like the Engine does. This makes the API library to return
+// information to figure that out.
+//
+// However the "load" endpoint unconditionally returns JSON;
+// https://github.com/moby/moby/blob/7b9d2ef6e5518a3d3f3cc418459f8df786cfbbd1/api/server/router/image/image_routes.go#L248-L255
+//
+// PR https://github.com/moby/moby/pull/21959 made the response-type depend
+// on whether "quiet" was set, but this logic got changed in a follow-up
+// https://github.com/moby/moby/pull/25557, which made the JSON response-type
+// unconditionally, but the output produced depend on whether"quiet" was set.
+//
+// We should deprecated the "quiet" option, as it's really a client
+// responsibility.
+type LoadResponse struct {
+	// Body must be closed to avoid a resource leak
+	Body io.ReadCloser
+	JSON bool
 }

--- a/api/types/image/opts.go
+++ b/api/types/image/opts.go
@@ -2,9 +2,16 @@ package image
 
 import (
 	"context"
+	"io"
 
 	"github.com/docker/docker/api/types/filters"
 )
+
+// ImportSource holds source information for ImageImport
+type ImportSource struct {
+	Source     io.Reader // Source is the data to send to the server to create this image from. You must set SourceName to "-" to leverage this.
+	SourceName string    // SourceName is the name of the image to pull. Set to "-" to leverage the Source attribute.
+}
 
 // ImportOptions holds information to import images from the client host.
 type ImportOptions struct {

--- a/api/types/registry/registry.go
+++ b/api/types/registry/registry.go
@@ -84,32 +84,6 @@ type IndexInfo struct {
 	Official bool
 }
 
-// SearchResult describes a search result returned from a registry
-type SearchResult struct {
-	// StarCount indicates the number of stars this repository has
-	StarCount int `json:"star_count"`
-	// IsOfficial is true if the result is from an official repository.
-	IsOfficial bool `json:"is_official"`
-	// Name is the name of the repository
-	Name string `json:"name"`
-	// IsAutomated indicates whether the result is automated.
-	//
-	// Deprecated: the "is_automated" field is deprecated and will always be "false".
-	IsAutomated bool `json:"is_automated"`
-	// Description is a textual description of the repository
-	Description string `json:"description"`
-}
-
-// SearchResults lists a collection search results returned from a registry
-type SearchResults struct {
-	// Query contains the query string that generated the search results
-	Query string `json:"query"`
-	// NumResults indicates the number of results the query returned
-	NumResults int `json:"num_results"`
-	// Results is a slice containing the actual results for the search
-	Results []SearchResult `json:"results"`
-}
-
 // DistributionInspect describes the result obtained from contacting the
 // registry to retrieve image metadata
 type DistributionInspect struct {

--- a/api/types/registry/search.go
+++ b/api/types/registry/search.go
@@ -1,0 +1,47 @@
+package registry
+
+import (
+	"context"
+
+	"github.com/docker/docker/api/types/filters"
+)
+
+// SearchOptions holds parameters to search images with.
+type SearchOptions struct {
+	RegistryAuth string
+
+	// PrivilegeFunc is a [types.RequestPrivilegeFunc] the client can
+	// supply to retry operations after getting an authorization error.
+	//
+	// It must return the registry authentication header value in base64
+	// format, or an error if the privilege request fails.
+	PrivilegeFunc func(context.Context) (string, error)
+	Filters       filters.Args
+	Limit         int
+}
+
+// SearchResult describes a search result returned from a registry
+type SearchResult struct {
+	// StarCount indicates the number of stars this repository has
+	StarCount int `json:"star_count"`
+	// IsOfficial is true if the result is from an official repository.
+	IsOfficial bool `json:"is_official"`
+	// Name is the name of the repository
+	Name string `json:"name"`
+	// IsAutomated indicates whether the result is automated.
+	//
+	// Deprecated: the "is_automated" field is deprecated and will always be "false".
+	IsAutomated bool `json:"is_automated"`
+	// Description is a textual description of the repository
+	Description string `json:"description"`
+}
+
+// SearchResults lists a collection search results returned from a registry
+type SearchResults struct {
+	// Query contains the query string that generated the search results
+	Query string `json:"query"`
+	// NumResults indicates the number of results the query returned
+	NumResults int `json:"num_results"`
+	// Results is a slice containing the actual results for the search
+	Results []SearchResult `json:"results"`
+}

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -1,7 +1,6 @@
 package types // import "github.com/docker/docker/api/types"
 
 import (
-	"io"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
@@ -159,13 +158,6 @@ type Container struct {
 	}
 	NetworkSettings *SummaryNetworkSettings
 	Mounts          []MountPoint
-}
-
-// ContainerStats contains response of Engine API:
-// GET "/stats"
-type ContainerStats struct {
-	Body   io.ReadCloser `json:"body"`
-	OSType string        `json:"ostype"`
 }
 
 // Ping contains response of Engine API:

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -2,7 +2,6 @@ package types // import "github.com/docker/docker/api/types"
 
 import (
 	"io"
-	"os"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
@@ -160,17 +159,6 @@ type Container struct {
 	}
 	NetworkSettings *SummaryNetworkSettings
 	Mounts          []MountPoint
-}
-
-// ContainerPathStat is used to encode the header from
-// GET "/containers/{name:.*}/archive"
-// "Name" is the file or directory name.
-type ContainerPathStat struct {
-	Name       string      `json:"name"`
-	Size       int64       `json:"size"`
-	Mode       os.FileMode `json:"mode"`
-	Mtime      time.Time   `json:"mtime"`
-	LinkTarget string      `json:"linkTarget"`
 }
 
 // ContainerStats contains response of Engine API:

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -419,13 +419,6 @@ type DiskUsage struct {
 	BuilderSize int64 `json:",omitempty"` // Deprecated: deprecated in API 1.38, and no longer used since API 1.40.
 }
 
-// ImagesPruneReport contains the response for Engine API:
-// POST "/images/prune"
-type ImagesPruneReport struct {
-	ImagesDeleted  []image.DeleteResponse
-	SpaceReclaimed uint64
-}
-
 // BuildCachePruneReport contains the response for Engine API:
 // POST "/build/prune"
 type BuildCachePruneReport struct {

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -419,13 +419,6 @@ type DiskUsage struct {
 	BuilderSize int64 `json:",omitempty"` // Deprecated: deprecated in API 1.38, and no longer used since API 1.40.
 }
 
-// VolumesPruneReport contains the response for Engine API:
-// POST "/volumes/prune"
-type VolumesPruneReport struct {
-	VolumesDeleted []string
-	SpaceReclaimed uint64
-}
-
 // ImagesPruneReport contains the response for Engine API:
 // POST "/images/prune"
 type ImagesPruneReport struct {

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -225,17 +225,6 @@ type Version struct {
 	BuildTime     string `json:",omitempty"`
 }
 
-// ExecStartCheck is a temp struct used by execStart
-// Config fields is part of ExecConfig in runconfig package
-type ExecStartCheck struct {
-	// ExecStart will first check if it's detached
-	Detach bool
-	// Check if there's a tty
-	Tty bool
-	// Terminal size [height, width], unused if Tty == false
-	ConsoleSize *[2]uint `json:",omitempty"`
-}
-
 // HealthcheckResult stores information about a single run of a healthcheck probe
 type HealthcheckResult struct {
 	Start    time.Time // Start is the time this check started

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -439,13 +439,6 @@ type DiskUsage struct {
 	BuilderSize int64 `json:",omitempty"` // Deprecated: deprecated in API 1.38, and no longer used since API 1.40.
 }
 
-// ContainersPruneReport contains the response for Engine API:
-// POST "/containers/prune"
-type ContainersPruneReport struct {
-	ContainersDeleted []string
-	SpaceReclaimed    uint64
-}
-
 // VolumesPruneReport contains the response for Engine API:
 // POST "/volumes/prune"
 type VolumesPruneReport struct {

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 )
 
@@ -54,3 +55,9 @@ type NetworkResource = network.Inspect
 //
 // Deprecated: use [network.PruneReport].
 type NetworksPruneReport = network.PruneReport
+
+// ExecConfig is a small subset of the Config struct that holds the configuration
+// for the exec feature of docker.
+//
+// Deprecated: use [container.ExecOptions].
+type ExecConfig = container.ExecOptions

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -128,3 +128,8 @@ type ImageSearchOptions = registry.SearchOptions
 //
 // Deprecated: use [image.ImportSource].
 type ImageImportSource image.ImportSource
+
+// ImageLoadResponse returns information to the client about a load process.
+//
+// Deprecated: use [image.LoadResponse].
+type ImageLoadResponse = image.LoadResponse

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -3,7 +3,14 @@ package types
 import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/api/types/volume"
 )
+
+// VolumesPruneReport contains the response for Engine API:
+// POST "/volumes/prune".
+//
+// Deprecated: use [volume.PruneReport].
+type VolumesPruneReport = volume.PruneReport
 
 // NetworkCreateRequest is the request message sent to the server for network create call.
 //

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -67,3 +67,8 @@ type ExecConfig = container.ExecOptions
 //
 // Deprecated: use [container.ExecStartOptions] or [container.ExecAttachOptions].
 type ExecStartCheck = container.ExecStartOptions
+
+// ContainerExecInspect holds information returned by exec inspect.
+//
+// Deprecated: use [container.ExecInspect].
+type ContainerExecInspect = container.ExecInspect

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -61,3 +61,9 @@ type NetworksPruneReport = network.PruneReport
 //
 // Deprecated: use [container.ExecOptions].
 type ExecConfig = container.ExecOptions
+
+// ExecStartCheck is a temp struct used by execStart
+// Config fields is part of ExecConfig in runconfig package
+//
+// Deprecated: use [container.ExecStartOptions] or [container.ExecAttachOptions].
+type ExecStartCheck = container.ExecStartOptions

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -85,3 +85,9 @@ type ContainersPruneReport = container.PruneReport
 //
 // Deprecated: use [container.PathStat].
 type ContainerPathStat = container.PathStat
+
+// CopyToContainerOptions holds information
+// about files to copy into a container.
+//
+// Deprecated: use [container.CopyToContainerOptions],
+type CopyToContainerOptions = container.CopyToContainerOptions

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/volume"
@@ -111,3 +112,8 @@ type CopyToContainerOptions = container.CopyToContainerOptions
 //
 // Deprecated: use [container.StatsResponse].
 type ContainerStats = container.StatsResponse
+
+// EventsOptions holds parameters to filter events with.
+//
+// Deprecated: use [events.ListOptions].
+type EventsOptions = events.ListOptions

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -72,3 +72,9 @@ type ExecStartCheck = container.ExecStartOptions
 //
 // Deprecated: use [container.ExecInspect].
 type ContainerExecInspect = container.ExecInspect
+
+// ContainersPruneReport contains the response for Engine API:
+// POST "/containers/prune"
+//
+// Deprecated: use [container.PruneReport].
+type ContainersPruneReport = container.PruneReport

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -78,3 +78,10 @@ type ContainerExecInspect = container.ExecInspect
 //
 // Deprecated: use [container.PruneReport].
 type ContainersPruneReport = container.PruneReport
+
+// ContainerPathStat is used to encode the header from
+// GET "/containers/{name:.*}/archive"
+// "Name" is the file or directory name.
+//
+// Deprecated: use [container.PathStat].
+type ContainerPathStat = container.PathStat

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -91,3 +91,9 @@ type ContainerPathStat = container.PathStat
 //
 // Deprecated: use [container.CopyToContainerOptions],
 type CopyToContainerOptions = container.CopyToContainerOptions
+
+// ContainerStats contains response of Engine API:
+// GET "/stats"
+//
+// Deprecated: use [container.StatsResponse].
+type ContainerStats = container.StatsResponse

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -5,6 +5,7 @@ import (
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/volume"
 )
 
@@ -117,3 +118,8 @@ type ContainerStats = container.StatsResponse
 //
 // Deprecated: use [events.ListOptions].
 type EventsOptions = events.ListOptions
+
+// ImageSearchOptions holds parameters to search images with.
+//
+// Deprecated: use [registry.SearchOptions].
+type ImageSearchOptions = registry.SearchOptions

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -123,3 +123,8 @@ type EventsOptions = events.ListOptions
 //
 // Deprecated: use [registry.SearchOptions].
 type ImageSearchOptions = registry.SearchOptions
+
+// ImageImportSource holds source information for ImageImport
+//
+// Deprecated: use [image.ImportSource].
+type ImageImportSource image.ImportSource

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -2,9 +2,16 @@ package types
 
 import (
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/volume"
 )
+
+// ImagesPruneReport contains the response for Engine API:
+// POST "/images/prune"
+//
+// Deprecated: use [image.PruneReport].
+type ImagesPruneReport = image.PruneReport
 
 // VolumesPruneReport contains the response for Engine API:
 // POST "/volumes/prune".

--- a/api/types/volume/options.go
+++ b/api/types/volume/options.go
@@ -6,3 +6,10 @@ import "github.com/docker/docker/api/types/filters"
 type ListOptions struct {
 	Filters filters.Args
 }
+
+// PruneReport contains the response for Engine API:
+// POST "/volumes/prune"
+type PruneReport struct {
+	VolumesDeleted []string
+	SpaceReclaimed uint64
+}

--- a/client/container_copy.go
+++ b/client/container_copy.go
@@ -12,10 +12,11 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 )
 
 // ContainerStatPath returns stat information about a path inside the container filesystem.
-func (cli *Client) ContainerStatPath(ctx context.Context, containerID, path string) (types.ContainerPathStat, error) {
+func (cli *Client) ContainerStatPath(ctx context.Context, containerID, path string) (container.PathStat, error) {
 	query := url.Values{}
 	query.Set("path", filepath.ToSlash(path)) // Normalize the paths used in the API.
 
@@ -23,7 +24,7 @@ func (cli *Client) ContainerStatPath(ctx context.Context, containerID, path stri
 	response, err := cli.head(ctx, urlStr, query, nil)
 	defer ensureReaderClosed(response)
 	if err != nil {
-		return types.ContainerPathStat{}, err
+		return container.PathStat{}, err
 	}
 	return getContainerPathStatFromHeader(response.header)
 }
@@ -55,14 +56,14 @@ func (cli *Client) CopyToContainer(ctx context.Context, containerID, dstPath str
 
 // CopyFromContainer gets the content from the container and returns it as a Reader
 // for a TAR archive to manipulate it in the host. It's up to the caller to close the reader.
-func (cli *Client) CopyFromContainer(ctx context.Context, containerID, srcPath string) (io.ReadCloser, types.ContainerPathStat, error) {
+func (cli *Client) CopyFromContainer(ctx context.Context, containerID, srcPath string) (io.ReadCloser, container.PathStat, error) {
 	query := make(url.Values, 1)
 	query.Set("path", filepath.ToSlash(srcPath)) // Normalize the paths used in the API.
 
 	apiPath := "/containers/" + containerID + "/archive"
 	response, err := cli.get(ctx, apiPath, query, nil)
 	if err != nil {
-		return nil, types.ContainerPathStat{}, err
+		return nil, container.PathStat{}, err
 	}
 
 	// In order to get the copy behavior right, we need to know information
@@ -78,8 +79,8 @@ func (cli *Client) CopyFromContainer(ctx context.Context, containerID, srcPath s
 	return response.body, stat, err
 }
 
-func getContainerPathStatFromHeader(header http.Header) (types.ContainerPathStat, error) {
-	var stat types.ContainerPathStat
+func getContainerPathStatFromHeader(header http.Header) (container.PathStat, error) {
+	var stat container.PathStat
 
 	encodedStat := header.Get("X-Docker-Container-Path-Stat")
 	statDecoder := base64.NewDecoder(base64.StdEncoding, strings.NewReader(encodedStat))

--- a/client/container_copy.go
+++ b/client/container_copy.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 )
 
@@ -31,7 +30,7 @@ func (cli *Client) ContainerStatPath(ctx context.Context, containerID, path stri
 
 // CopyToContainer copies content into the container filesystem.
 // Note that `content` must be a Reader for a TAR archive
-func (cli *Client) CopyToContainer(ctx context.Context, containerID, dstPath string, content io.Reader, options types.CopyToContainerOptions) error {
+func (cli *Client) CopyToContainer(ctx context.Context, containerID, dstPath string, content io.Reader, options container.CopyToContainerOptions) error {
 	query := url.Values{}
 	query.Set("path", filepath.ToSlash(dstPath)) // Normalize the paths used in the API.
 	// Do not allow for an existing directory to be overwritten by a non-directory and vice versa.

--- a/client/container_copy_test.go
+++ b/client/container_copy_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -64,7 +65,7 @@ func TestContainerStatPath(t *testing.T) {
 			if path != expectedPath {
 				return nil, fmt.Errorf("path not set in URL query properly")
 			}
-			content, err := json.Marshal(types.ContainerPathStat{
+			content, err := json.Marshal(container.PathStat{
 				Name: "name",
 				Mode: 0o700,
 			})
@@ -188,7 +189,7 @@ func TestCopyFromContainerNotFoundError(t *testing.T) {
 func TestCopyFromContainerEmptyResponse(t *testing.T) {
 	client := &Client{
 		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			content, err := json.Marshal(types.ContainerPathStat{
+			content, err := json.Marshal(container.PathStat{
 				Name: "path/to/file",
 				Mode: 0o700,
 			})
@@ -242,7 +243,7 @@ func TestCopyFromContainer(t *testing.T) {
 				return nil, fmt.Errorf("path not set in URL query properly, expected '%s', got %s", expectedPath, path)
 			}
 
-			headercontent, err := json.Marshal(types.ContainerPathStat{
+			headercontent, err := json.Marshal(container.PathStat{
 				Name: "name",
 				Mode: 0o700,
 			})

--- a/client/container_copy_test.go
+++ b/client/container_copy_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
@@ -98,7 +97,7 @@ func TestCopyToContainerError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.CopyToContainer(context.Background(), "container_id", "path/to/file", bytes.NewReader([]byte("")), types.CopyToContainerOptions{})
+	err := client.CopyToContainer(context.Background(), "container_id", "path/to/file", bytes.NewReader([]byte("")), container.CopyToContainerOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
@@ -106,7 +105,7 @@ func TestCopyToContainerNotFoundError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusNotFound, "Not found")),
 	}
-	err := client.CopyToContainer(context.Background(), "container_id", "path/to/file", bytes.NewReader([]byte("")), types.CopyToContainerOptions{})
+	err := client.CopyToContainer(context.Background(), "container_id", "path/to/file", bytes.NewReader([]byte("")), container.CopyToContainerOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
@@ -116,7 +115,7 @@ func TestCopyToContainerEmptyResponse(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusNoContent, "No content")),
 	}
-	err := client.CopyToContainer(context.Background(), "container_id", "path/to/file", bytes.NewReader([]byte("")), types.CopyToContainerOptions{})
+	err := client.CopyToContainer(context.Background(), "container_id", "path/to/file", bytes.NewReader([]byte("")), container.CopyToContainerOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -160,7 +159,7 @@ func TestCopyToContainer(t *testing.T) {
 			}, nil
 		}),
 	}
-	err := client.CopyToContainer(context.Background(), "container_id", expectedPath, bytes.NewReader([]byte("content")), types.CopyToContainerOptions{
+	err := client.CopyToContainer(context.Background(), "container_id", expectedPath, bytes.NewReader([]byte("content")), container.CopyToContainerOptions{
 		AllowOverwriteDirWithFile: false,
 	})
 	if err != nil {

--- a/client/container_exec.go
+++ b/client/container_exec.go
@@ -6,11 +6,12 @@ import (
 	"net/http"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/versions"
 )
 
 // ContainerExecCreate creates a new exec configuration to run an exec process.
-func (cli *Client) ContainerExecCreate(ctx context.Context, container string, config types.ExecConfig) (types.IDResponse, error) {
+func (cli *Client) ContainerExecCreate(ctx context.Context, container string, options container.ExecOptions) (types.IDResponse, error) {
 	var response types.IDResponse
 
 	// Make sure we negotiated (if the client is configured to do so),
@@ -22,14 +23,14 @@ func (cli *Client) ContainerExecCreate(ctx context.Context, container string, co
 		return response, err
 	}
 
-	if err := cli.NewVersionError(ctx, "1.25", "env"); len(config.Env) != 0 && err != nil {
+	if err := cli.NewVersionError(ctx, "1.25", "env"); len(options.Env) != 0 && err != nil {
 		return response, err
 	}
 	if versions.LessThan(cli.ClientVersion(), "1.42") {
-		config.ConsoleSize = nil
+		options.ConsoleSize = nil
 	}
 
-	resp, err := cli.post(ctx, "/containers/"+container+"/exec", nil, config, nil)
+	resp, err := cli.post(ctx, "/containers/"+container+"/exec", nil, options, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
 		return response, err

--- a/client/container_exec.go
+++ b/client/container_exec.go
@@ -40,7 +40,7 @@ func (cli *Client) ContainerExecCreate(ctx context.Context, container string, op
 }
 
 // ContainerExecStart starts an exec process already created in the docker host.
-func (cli *Client) ContainerExecStart(ctx context.Context, execID string, config types.ExecStartCheck) error {
+func (cli *Client) ContainerExecStart(ctx context.Context, execID string, config container.ExecStartOptions) error {
 	if versions.LessThan(cli.ClientVersion(), "1.42") {
 		config.ConsoleSize = nil
 	}
@@ -53,7 +53,7 @@ func (cli *Client) ContainerExecStart(ctx context.Context, execID string, config
 // It returns a types.HijackedConnection with the hijacked connection
 // and the a reader to get output. It's up to the called to close
 // the hijacked connection by calling types.HijackedResponse.Close.
-func (cli *Client) ContainerExecAttach(ctx context.Context, execID string, config types.ExecStartCheck) (types.HijackedResponse, error) {
+func (cli *Client) ContainerExecAttach(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error) {
 	if versions.LessThan(cli.ClientVersion(), "1.42") {
 		config.ConsoleSize = nil
 	}

--- a/client/container_exec.go
+++ b/client/container_exec.go
@@ -63,8 +63,8 @@ func (cli *Client) ContainerExecAttach(ctx context.Context, execID string, confi
 }
 
 // ContainerExecInspect returns information about a specific exec process on the docker host.
-func (cli *Client) ContainerExecInspect(ctx context.Context, execID string) (types.ContainerExecInspect, error) {
-	var response types.ContainerExecInspect
+func (cli *Client) ContainerExecInspect(ctx context.Context, execID string) (container.ExecInspect, error) {
+	var response container.ExecInspect
 	resp, err := cli.get(ctx, "/exec/"+execID+"/json", nil, nil)
 	if err != nil {
 		return response, err

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -139,7 +139,7 @@ func TestContainerExecInspect(t *testing.T) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
-			b, err := json.Marshal(types.ContainerExecInspect{
+			b, err := json.Marshal(container.ExecInspect{
 				ExecID:      "exec_id",
 				ContainerID: "container_id",
 			})

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -20,7 +21,7 @@ func TestContainerExecCreateError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.ContainerExecCreate(context.Background(), "container_id", types.ExecConfig{})
+	_, err := client.ContainerExecCreate(context.Background(), "container_id", container.ExecOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
@@ -32,7 +33,7 @@ func TestContainerExecCreateConnectionError(t *testing.T) {
 	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
-	_, err = client.ContainerExecCreate(context.Background(), "", types.ExecConfig{})
+	_, err = client.ContainerExecCreate(context.Background(), "", container.ExecOptions{})
 	assert.Check(t, is.ErrorType(err, IsErrConnectionFailed))
 }
 
@@ -50,7 +51,7 @@ func TestContainerExecCreate(t *testing.T) {
 			if err := req.ParseForm(); err != nil {
 				return nil, err
 			}
-			execConfig := &types.ExecConfig{}
+			execConfig := &container.ExecOptions{}
 			if err := json.NewDecoder(req.Body).Decode(execConfig); err != nil {
 				return nil, err
 			}
@@ -70,7 +71,7 @@ func TestContainerExecCreate(t *testing.T) {
 		}),
 	}
 
-	r, err := client.ContainerExecCreate(context.Background(), "container_id", types.ExecConfig{
+	r, err := client.ContainerExecCreate(context.Background(), "container_id", container.ExecOptions{
 		User: "user",
 	})
 	if err != nil {

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -86,7 +86,7 @@ func TestContainerExecStartError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerExecStart(context.Background(), "nothing", types.ExecStartCheck{})
+	err := client.ContainerExecStart(context.Background(), "nothing", container.ExecStartOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
@@ -100,12 +100,12 @@ func TestContainerExecStart(t *testing.T) {
 			if err := req.ParseForm(); err != nil {
 				return nil, err
 			}
-			execStartCheck := &types.ExecStartCheck{}
-			if err := json.NewDecoder(req.Body).Decode(execStartCheck); err != nil {
+			options := &container.ExecStartOptions{}
+			if err := json.NewDecoder(req.Body).Decode(options); err != nil {
 				return nil, err
 			}
-			if execStartCheck.Tty || !execStartCheck.Detach {
-				return nil, fmt.Errorf("expected execStartCheck{Detach:true,Tty:false}, got %v", execStartCheck)
+			if options.Tty || !options.Detach {
+				return nil, fmt.Errorf("expected ExecStartOptions{Detach:true,Tty:false}, got %v", options)
 			}
 
 			return &http.Response{
@@ -115,7 +115,7 @@ func TestContainerExecStart(t *testing.T) {
 		}),
 	}
 
-	err := client.ContainerExecStart(context.Background(), "exec_id", types.ExecStartCheck{
+	err := client.ContainerExecStart(context.Background(), "exec_id", container.ExecStartOptions{
 		Detach: true,
 		Tty:    false,
 	})

--- a/client/container_prune.go
+++ b/client/container_prune.go
@@ -5,13 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 )
 
 // ContainersPrune requests the daemon to delete unused data
-func (cli *Client) ContainersPrune(ctx context.Context, pruneFilters filters.Args) (types.ContainersPruneReport, error) {
-	var report types.ContainersPruneReport
+func (cli *Client) ContainersPrune(ctx context.Context, pruneFilters filters.Args) (container.PruneReport, error) {
+	var report container.PruneReport
 
 	if err := cli.NewVersionError(ctx, "1.25", "container prune"); err != nil {
 		return report, err

--- a/client/container_prune_test.go
+++ b/client/container_prune_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
@@ -93,7 +93,7 @@ func TestContainersPrune(t *testing.T) {
 					actual := query.Get(key)
 					assert.Check(t, is.Equal(expected, actual))
 				}
-				content, err := json.Marshal(types.ContainersPruneReport{
+				content, err := json.Marshal(container.PruneReport{
 					ContainersDeleted: []string{"container_id1", "container_id2"},
 					SpaceReclaimed:    9999,
 				})

--- a/client/container_stats.go
+++ b/client/container_stats.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"net/url"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 )
 
 // ContainerStats returns near realtime stats for a given container.
 // It's up to the caller to close the io.ReadCloser returned.
-func (cli *Client) ContainerStats(ctx context.Context, containerID string, stream bool) (types.ContainerStats, error) {
+func (cli *Client) ContainerStats(ctx context.Context, containerID string, stream bool) (container.StatsResponse, error) {
 	query := url.Values{}
 	query.Set("stream", "0")
 	if stream {
@@ -18,10 +18,10 @@ func (cli *Client) ContainerStats(ctx context.Context, containerID string, strea
 
 	resp, err := cli.get(ctx, "/containers/"+containerID+"/stats", query, nil)
 	if err != nil {
-		return types.ContainerStats{}, err
+		return container.StatsResponse{}, err
 	}
 
-	return types.ContainerStats{
+	return container.StatsResponse{
 		Body:   resp.body,
 		OSType: getDockerOS(resp.header.Get("Server")),
 	}, nil
@@ -29,17 +29,17 @@ func (cli *Client) ContainerStats(ctx context.Context, containerID string, strea
 
 // ContainerStatsOneShot gets a single stat entry from a container.
 // It differs from `ContainerStats` in that the API should not wait to prime the stats
-func (cli *Client) ContainerStatsOneShot(ctx context.Context, containerID string) (types.ContainerStats, error) {
+func (cli *Client) ContainerStatsOneShot(ctx context.Context, containerID string) (container.StatsResponse, error) {
 	query := url.Values{}
 	query.Set("stream", "0")
 	query.Set("one-shot", "1")
 
 	resp, err := cli.get(ctx, "/containers/"+containerID+"/stats", query, nil)
 	if err != nil {
-		return types.ContainerStats{}, err
+		return container.StatsResponse{}, err
 	}
 
-	return types.ContainerStats{
+	return container.StatsResponse{
 		Body:   resp.body,
 		OSType: getDockerOS(resp.header.Get("Server")),
 	}, nil

--- a/client/events.go
+++ b/client/events.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
 	timetypes "github.com/docker/docker/api/types/time"
@@ -16,7 +15,7 @@ import (
 // by cancelling the context. Once the stream has been completely read an io.EOF error will
 // be sent over the error channel. If an error is sent all processing will be stopped. It's up
 // to the caller to reopen the stream in the event of an error by reinvoking this method.
-func (cli *Client) Events(ctx context.Context, options types.EventsOptions) (<-chan events.Message, <-chan error) {
+func (cli *Client) Events(ctx context.Context, options events.ListOptions) (<-chan events.Message, <-chan error) {
 	messages := make(chan events.Message)
 	errs := make(chan error, 1)
 
@@ -68,7 +67,7 @@ func (cli *Client) Events(ctx context.Context, options types.EventsOptions) (<-c
 	return messages, errs
 }
 
-func buildEventsQueryParams(cliVersion string, options types.EventsOptions) (url.Values, error) {
+func buildEventsQueryParams(cliVersion string, options events.ListOptions) (url.Values, error) {
 	query := url.Values{}
 	ref := time.Now()
 

--- a/client/events_test.go
+++ b/client/events_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/errdefs"
@@ -20,17 +19,17 @@ import (
 
 func TestEventsErrorInOptions(t *testing.T) {
 	errorCases := []struct {
-		options       types.EventsOptions
+		options       events.ListOptions
 		expectedError string
 	}{
 		{
-			options: types.EventsOptions{
+			options: events.ListOptions{
 				Since: "2006-01-02TZ",
 			},
 			expectedError: `parsing time "2006-01-02TZ"`,
 		},
 		{
-			options: types.EventsOptions{
+			options: events.ListOptions{
 				Until: "2006-01-02TZ",
 			},
 			expectedError: `parsing time "2006-01-02TZ"`,
@@ -52,7 +51,7 @@ func TestEventsErrorFromServer(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, errs := client.Events(context.Background(), types.EventsOptions{})
+	_, errs := client.Events(context.Background(), events.ListOptions{})
 	err := <-errs
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
@@ -64,13 +63,13 @@ func TestEvents(t *testing.T) {
 	expectedFiltersJSON := fmt.Sprintf(`{"type":{"%s":true}}`, events.ContainerEventType)
 
 	eventsCases := []struct {
-		options             types.EventsOptions
+		options             events.ListOptions
 		events              []events.Message
 		expectedEvents      map[string]bool
 		expectedQueryParams map[string]string
 	}{
 		{
-			options: types.EventsOptions{
+			options: events.ListOptions{
 				Filters: fltrs,
 			},
 			expectedQueryParams: map[string]string{
@@ -80,7 +79,7 @@ func TestEvents(t *testing.T) {
 			expectedEvents: make(map[string]bool),
 		},
 		{
-			options: types.EventsOptions{
+			options: events.ListOptions{
 				Filters: fltrs,
 			},
 			expectedQueryParams: map[string]string{

--- a/client/image_import.go
+++ b/client/image_import.go
@@ -7,13 +7,12 @@ import (
 	"strings"
 
 	"github.com/distribution/reference"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/image"
 )
 
 // ImageImport creates a new image based on the source options.
 // It returns the JSON content in the response body.
-func (cli *Client) ImageImport(ctx context.Context, source types.ImageImportSource, ref string, options image.ImportOptions) (io.ReadCloser, error) {
+func (cli *Client) ImageImport(ctx context.Context, source image.ImportSource, ref string, options image.ImportOptions) (io.ReadCloser, error) {
 	if ref != "" {
 		// Check if the given image name can be resolved
 		if _, err := reference.ParseNormalizedNamed(ref); err != nil {

--- a/client/image_import_test.go
+++ b/client/image_import_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
@@ -21,7 +20,7 @@ func TestImageImportError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.ImageImport(context.Background(), types.ImageImportSource{}, "image:tag", image.ImportOptions{})
+	_, err := client.ImageImport(context.Background(), image.ImportSource{}, "image:tag", image.ImportOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
@@ -61,7 +60,7 @@ func TestImageImport(t *testing.T) {
 			}, nil
 		}),
 	}
-	importResponse, err := client.ImageImport(context.Background(), types.ImageImportSource{
+	importResponse, err := client.ImageImport(context.Background(), image.ImportSource{
 		Source:     strings.NewReader("source"),
 		SourceName: "image_source",
 	}, "repository_name:imported", image.ImportOptions{

--- a/client/image_load.go
+++ b/client/image_load.go
@@ -6,13 +6,13 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/image"
 )
 
 // ImageLoad loads an image in the docker host from the client host.
 // It's up to the caller to close the io.ReadCloser in the
 // ImageLoadResponse returned by this function.
-func (cli *Client) ImageLoad(ctx context.Context, input io.Reader, quiet bool) (types.ImageLoadResponse, error) {
+func (cli *Client) ImageLoad(ctx context.Context, input io.Reader, quiet bool) (image.LoadResponse, error) {
 	v := url.Values{}
 	v.Set("quiet", "0")
 	if quiet {
@@ -22,9 +22,9 @@ func (cli *Client) ImageLoad(ctx context.Context, input io.Reader, quiet bool) (
 		"Content-Type": {"application/x-tar"},
 	})
 	if err != nil {
-		return types.ImageLoadResponse{}, err
+		return image.LoadResponse{}, err
 	}
-	return types.ImageLoadResponse{
+	return image.LoadResponse{
 		Body: resp.body,
 		JSON: resp.header.Get("Content-Type") == "application/json",
 	}, nil

--- a/client/image_prune.go
+++ b/client/image_prune.go
@@ -5,13 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
 )
 
 // ImagesPrune requests the daemon to delete unused data
-func (cli *Client) ImagesPrune(ctx context.Context, pruneFilters filters.Args) (types.ImagesPruneReport, error) {
-	var report types.ImagesPruneReport
+func (cli *Client) ImagesPrune(ctx context.Context, pruneFilters filters.Args) (image.PruneReport, error) {
+	var report image.PruneReport
 
 	if err := cli.NewVersionError(ctx, "1.25", "image prune"); err != nil {
 		return report, err

--- a/client/image_prune_test.go
+++ b/client/image_prune_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/errdefs"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -84,7 +83,7 @@ func TestImagesPrune(t *testing.T) {
 					actual := query.Get(key)
 					assert.Check(t, is.Equal(expected, actual))
 				}
-				content, err := json.Marshal(types.ImagesPruneReport{
+				content, err := json.Marshal(image.PruneReport{
 					ImagesDeleted: []image.DeleteResponse{
 						{
 							Deleted: "image_id1",

--- a/client/image_search.go
+++ b/client/image_search.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/errdefs"
@@ -15,7 +14,7 @@ import (
 
 // ImageSearch makes the docker host search by a term in a remote registry.
 // The list of results is not sorted in any fashion.
-func (cli *Client) ImageSearch(ctx context.Context, term string, options types.ImageSearchOptions) ([]registry.SearchResult, error) {
+func (cli *Client) ImageSearch(ctx context.Context, term string, options registry.SearchOptions) ([]registry.SearchResult, error) {
 	var results []registry.SearchResult
 	query := url.Values{}
 	query.Set("term", term)

--- a/client/image_search_test.go
+++ b/client/image_search_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/errdefs"
@@ -22,7 +21,7 @@ func TestImageSearchAnyError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.ImageSearch(context.Background(), "some-image", types.ImageSearchOptions{})
+	_, err := client.ImageSearch(context.Background(), "some-image", registry.SearchOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
@@ -30,7 +29,7 @@ func TestImageSearchStatusUnauthorizedError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")),
 	}
-	_, err := client.ImageSearch(context.Background(), "some-image", types.ImageSearchOptions{})
+	_, err := client.ImageSearch(context.Background(), "some-image", registry.SearchOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsUnauthorized))
 }
 
@@ -41,7 +40,7 @@ func TestImageSearchWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
 	privilegeFunc := func(_ context.Context) (string, error) {
 		return "", fmt.Errorf("Error requesting privilege")
 	}
-	_, err := client.ImageSearch(context.Background(), "some-image", types.ImageSearchOptions{
+	_, err := client.ImageSearch(context.Background(), "some-image", registry.SearchOptions{
 		PrivilegeFunc: privilegeFunc,
 	})
 	if err == nil || err.Error() != "Error requesting privilege" {
@@ -56,7 +55,7 @@ func TestImageSearchWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.
 	privilegeFunc := func(_ context.Context) (string, error) {
 		return "a-auth-header", nil
 	}
-	_, err := client.ImageSearch(context.Background(), "some-image", types.ImageSearchOptions{
+	_, err := client.ImageSearch(context.Background(), "some-image", registry.SearchOptions{
 		PrivilegeFunc: privilegeFunc,
 	})
 	assert.Check(t, is.ErrorType(err, errdefs.IsUnauthorized))
@@ -101,7 +100,7 @@ func TestImageSearchWithPrivilegedFuncNoError(t *testing.T) {
 	privilegeFunc := func(_ context.Context) (string, error) {
 		return "IAmValid", nil
 	}
-	results, err := client.ImageSearch(context.Background(), "some-image", types.ImageSearchOptions{
+	results, err := client.ImageSearch(context.Background(), "some-image", registry.SearchOptions{
 		RegistryAuth:  "NotValid",
 		PrivilegeFunc: privilegeFunc,
 	})
@@ -145,7 +144,7 @@ func TestImageSearchWithoutErrors(t *testing.T) {
 			}, nil
 		}),
 	}
-	results, err := client.ImageSearch(context.Background(), "some-image", types.ImageSearchOptions{
+	results, err := client.ImageSearch(context.Background(), "some-image", registry.SearchOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("is-automated", "true"),
 			filters.Arg("stars", "3"),

--- a/client/interface.go
+++ b/client/interface.go
@@ -99,7 +99,7 @@ type ImageAPIClient interface {
 	ImagePull(ctx context.Context, ref string, options image.PullOptions) (io.ReadCloser, error)
 	ImagePush(ctx context.Context, ref string, options image.PushOptions) (io.ReadCloser, error)
 	ImageRemove(ctx context.Context, image string, options image.RemoveOptions) ([]image.DeleteResponse, error)
-	ImageSearch(ctx context.Context, term string, options types.ImageSearchOptions) ([]registry.SearchResult, error)
+	ImageSearch(ctx context.Context, term string, options registry.SearchOptions) ([]registry.SearchResult, error)
 	ImageSave(ctx context.Context, images []string) (io.ReadCloser, error)
 	ImageTag(ctx context.Context, image, ref string) error
 	ImagesPrune(ctx context.Context, pruneFilter filters.Args) (image.PruneReport, error)

--- a/client/interface.go
+++ b/client/interface.go
@@ -67,8 +67,8 @@ type ContainerAPIClient interface {
 	ContainerResize(ctx context.Context, container string, options container.ResizeOptions) error
 	ContainerRestart(ctx context.Context, container string, options container.StopOptions) error
 	ContainerStatPath(ctx context.Context, container, path string) (container.PathStat, error)
-	ContainerStats(ctx context.Context, container string, stream bool) (types.ContainerStats, error)
-	ContainerStatsOneShot(ctx context.Context, container string) (types.ContainerStats, error)
+	ContainerStats(ctx context.Context, container string, stream bool) (container.StatsResponse, error)
+	ContainerStatsOneShot(ctx context.Context, container string) (container.StatsResponse, error)
 	ContainerStart(ctx context.Context, container string, options container.StartOptions) error
 	ContainerStop(ctx context.Context, container string, options container.StopOptions) error
 	ContainerTop(ctx context.Context, container string, arguments []string) (container.ContainerTopOKBody, error)

--- a/client/interface.go
+++ b/client/interface.go
@@ -66,7 +66,7 @@ type ContainerAPIClient interface {
 	ContainerRename(ctx context.Context, container, newContainerName string) error
 	ContainerResize(ctx context.Context, container string, options container.ResizeOptions) error
 	ContainerRestart(ctx context.Context, container string, options container.StopOptions) error
-	ContainerStatPath(ctx context.Context, container, path string) (types.ContainerPathStat, error)
+	ContainerStatPath(ctx context.Context, container, path string) (container.PathStat, error)
 	ContainerStats(ctx context.Context, container string, stream bool) (types.ContainerStats, error)
 	ContainerStatsOneShot(ctx context.Context, container string) (types.ContainerStats, error)
 	ContainerStart(ctx context.Context, container string, options container.StartOptions) error
@@ -75,7 +75,7 @@ type ContainerAPIClient interface {
 	ContainerUnpause(ctx context.Context, container string) error
 	ContainerUpdate(ctx context.Context, container string, updateConfig container.UpdateConfig) (container.ContainerUpdateOKBody, error)
 	ContainerWait(ctx context.Context, container string, condition container.WaitCondition) (<-chan container.WaitResponse, <-chan error)
-	CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, types.ContainerPathStat, error)
+	CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, container.PathStat, error)
 	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error
 	ContainersPrune(ctx context.Context, pruneFilters filters.Args) (container.PruneReport, error)
 }

--- a/client/interface.go
+++ b/client/interface.go
@@ -76,7 +76,7 @@ type ContainerAPIClient interface {
 	ContainerUpdate(ctx context.Context, container string, updateConfig container.UpdateConfig) (container.ContainerUpdateOKBody, error)
 	ContainerWait(ctx context.Context, container string, condition container.WaitCondition) (<-chan container.WaitResponse, <-chan error)
 	CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, container.PathStat, error)
-	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error
+	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options container.CopyToContainerOptions) error
 	ContainersPrune(ctx context.Context, pruneFilters filters.Args) (container.PruneReport, error)
 }
 

--- a/client/interface.go
+++ b/client/interface.go
@@ -52,7 +52,7 @@ type ContainerAPIClient interface {
 	ContainerDiff(ctx context.Context, container string) ([]container.FilesystemChange, error)
 	ContainerExecAttach(ctx context.Context, execID string, options container.ExecAttachOptions) (types.HijackedResponse, error)
 	ContainerExecCreate(ctx context.Context, container string, options container.ExecOptions) (types.IDResponse, error)
-	ContainerExecInspect(ctx context.Context, execID string) (types.ContainerExecInspect, error)
+	ContainerExecInspect(ctx context.Context, execID string) (container.ExecInspect, error)
 	ContainerExecResize(ctx context.Context, execID string, options container.ResizeOptions) error
 	ContainerExecStart(ctx context.Context, execID string, options container.ExecStartOptions) error
 	ContainerExport(ctx context.Context, container string) (io.ReadCloser, error)

--- a/client/interface.go
+++ b/client/interface.go
@@ -102,7 +102,7 @@ type ImageAPIClient interface {
 	ImageSearch(ctx context.Context, term string, options types.ImageSearchOptions) ([]registry.SearchResult, error)
 	ImageSave(ctx context.Context, images []string) (io.ReadCloser, error)
 	ImageTag(ctx context.Context, image, ref string) error
-	ImagesPrune(ctx context.Context, pruneFilter filters.Args) (types.ImagesPruneReport, error)
+	ImagesPrune(ctx context.Context, pruneFilter filters.Args) (image.PruneReport, error)
 }
 
 // NetworkAPIClient defines API client methods for the networks

--- a/client/interface.go
+++ b/client/interface.go
@@ -50,11 +50,11 @@ type ContainerAPIClient interface {
 	ContainerCommit(ctx context.Context, container string, options container.CommitOptions) (types.IDResponse, error)
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
 	ContainerDiff(ctx context.Context, container string) ([]container.FilesystemChange, error)
-	ContainerExecAttach(ctx context.Context, execID string, config types.ExecStartCheck) (types.HijackedResponse, error)
+	ContainerExecAttach(ctx context.Context, execID string, options container.ExecAttachOptions) (types.HijackedResponse, error)
 	ContainerExecCreate(ctx context.Context, container string, options container.ExecOptions) (types.IDResponse, error)
 	ContainerExecInspect(ctx context.Context, execID string) (types.ContainerExecInspect, error)
 	ContainerExecResize(ctx context.Context, execID string, options container.ResizeOptions) error
-	ContainerExecStart(ctx context.Context, execID string, config types.ExecStartCheck) error
+	ContainerExecStart(ctx context.Context, execID string, options container.ExecStartOptions) error
 	ContainerExport(ctx context.Context, container string) (io.ReadCloser, error)
 	ContainerInspect(ctx context.Context, container string) (types.ContainerJSON, error)
 	ContainerInspectWithRaw(ctx context.Context, container string, getSize bool) (types.ContainerJSON, []byte, error)

--- a/client/interface.go
+++ b/client/interface.go
@@ -77,7 +77,7 @@ type ContainerAPIClient interface {
 	ContainerWait(ctx context.Context, container string, condition container.WaitCondition) (<-chan container.WaitResponse, <-chan error)
 	CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, types.ContainerPathStat, error)
 	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error
-	ContainersPrune(ctx context.Context, pruneFilters filters.Args) (types.ContainersPruneReport, error)
+	ContainersPrune(ctx context.Context, pruneFilters filters.Args) (container.PruneReport, error)
 }
 
 // DistributionAPIClient defines API client methods for the registry

--- a/client/interface.go
+++ b/client/interface.go
@@ -92,7 +92,7 @@ type ImageAPIClient interface {
 	BuildCancel(ctx context.Context, id string) error
 	ImageCreate(ctx context.Context, parentReference string, options image.CreateOptions) (io.ReadCloser, error)
 	ImageHistory(ctx context.Context, image string) ([]image.HistoryResponseItem, error)
-	ImageImport(ctx context.Context, source types.ImageImportSource, ref string, options image.ImportOptions) (io.ReadCloser, error)
+	ImageImport(ctx context.Context, source image.ImportSource, ref string, options image.ImportOptions) (io.ReadCloser, error)
 	ImageInspectWithRaw(ctx context.Context, image string) (types.ImageInspect, []byte, error)
 	ImageList(ctx context.Context, options image.ListOptions) ([]image.Summary, error)
 	ImageLoad(ctx context.Context, input io.Reader, quiet bool) (types.ImageLoadResponse, error)

--- a/client/interface.go
+++ b/client/interface.go
@@ -165,7 +165,7 @@ type SwarmAPIClient interface {
 
 // SystemAPIClient defines API client methods for the system
 type SystemAPIClient interface {
-	Events(ctx context.Context, options types.EventsOptions) (<-chan events.Message, <-chan error)
+	Events(ctx context.Context, options events.ListOptions) (<-chan events.Message, <-chan error)
 	Info(ctx context.Context) (system.Info, error)
 	RegistryLogin(ctx context.Context, auth registry.AuthConfig) (registry.AuthenticateOKBody, error)
 	DiskUsage(ctx context.Context, options types.DiskUsageOptions) (types.DiskUsage, error)

--- a/client/interface.go
+++ b/client/interface.go
@@ -51,7 +51,7 @@ type ContainerAPIClient interface {
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
 	ContainerDiff(ctx context.Context, container string) ([]container.FilesystemChange, error)
 	ContainerExecAttach(ctx context.Context, execID string, config types.ExecStartCheck) (types.HijackedResponse, error)
-	ContainerExecCreate(ctx context.Context, container string, config types.ExecConfig) (types.IDResponse, error)
+	ContainerExecCreate(ctx context.Context, container string, options container.ExecOptions) (types.IDResponse, error)
 	ContainerExecInspect(ctx context.Context, execID string) (types.ContainerExecInspect, error)
 	ContainerExecResize(ctx context.Context, execID string, options container.ResizeOptions) error
 	ContainerExecStart(ctx context.Context, execID string, config types.ExecStartCheck) error

--- a/client/interface.go
+++ b/client/interface.go
@@ -179,7 +179,7 @@ type VolumeAPIClient interface {
 	VolumeInspectWithRaw(ctx context.Context, volumeID string) (volume.Volume, []byte, error)
 	VolumeList(ctx context.Context, options volume.ListOptions) (volume.ListResponse, error)
 	VolumeRemove(ctx context.Context, volumeID string, force bool) error
-	VolumesPrune(ctx context.Context, pruneFilter filters.Args) (types.VolumesPruneReport, error)
+	VolumesPrune(ctx context.Context, pruneFilter filters.Args) (volume.PruneReport, error)
 	VolumeUpdate(ctx context.Context, volumeID string, version swarm.Version, options volume.UpdateOptions) error
 }
 

--- a/client/interface.go
+++ b/client/interface.go
@@ -95,7 +95,7 @@ type ImageAPIClient interface {
 	ImageImport(ctx context.Context, source image.ImportSource, ref string, options image.ImportOptions) (io.ReadCloser, error)
 	ImageInspectWithRaw(ctx context.Context, image string) (types.ImageInspect, []byte, error)
 	ImageList(ctx context.Context, options image.ListOptions) ([]image.Summary, error)
-	ImageLoad(ctx context.Context, input io.Reader, quiet bool) (types.ImageLoadResponse, error)
+	ImageLoad(ctx context.Context, input io.Reader, quiet bool) (image.LoadResponse, error)
 	ImagePull(ctx context.Context, ref string, options image.PullOptions) (io.ReadCloser, error)
 	ImagePush(ctx context.Context, ref string, options image.PushOptions) (io.ReadCloser, error)
 	ImageRemove(ctx context.Context, image string, options image.RemoveOptions) ([]image.DeleteResponse, error)

--- a/client/volume_prune.go
+++ b/client/volume_prune.go
@@ -5,13 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/volume"
 )
 
 // VolumesPrune requests the daemon to delete unused data
-func (cli *Client) VolumesPrune(ctx context.Context, pruneFilters filters.Args) (types.VolumesPruneReport, error) {
-	var report types.VolumesPruneReport
+func (cli *Client) VolumesPrune(ctx context.Context, pruneFilters filters.Args) (volume.PruneReport, error) {
+	var report volume.PruneReport
 
 	if err := cli.NewVersionError(ctx, "1.25", "volume prune"); err != nil {
 		return report, err

--- a/container/archive_windows.go
+++ b/container/archive_windows.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/docker/docker/api/types"
+	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/pkg/errors"
 )
@@ -45,7 +45,7 @@ func (container *Container) ResolvePath(path string) (resolvedPath, absPath stri
 // be acquired before calling this method and the given path should be fully
 // resolved to a path on the host corresponding to the given absolute path
 // inside the container.
-func (container *Container) StatPath(resolvedPath, absPath string) (stat *types.ContainerPathStat, err error) {
+func (container *Container) StatPath(resolvedPath, absPath string) (stat *containertypes.PathStat, err error) {
 	if container.BaseFS == "" {
 		return nil, errors.New("StatPath: BaseFS of container " + container.ID + " is unexpectedly empty")
 	}
@@ -72,7 +72,7 @@ func (container *Container) StatPath(resolvedPath, absPath string) (stat *types.
 		linkTarget = filepath.Join(string(filepath.Separator), linkTarget)
 	}
 
-	return &types.ContainerPathStat{
+	return &containertypes.PathStat{
 		Name:       filepath.Base(absPath),
 		Size:       lstat.Size(),
 		Mode:       lstat.Mode(),

--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -4,13 +4,13 @@ import (
 	"io"
 	"os"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
 )
 
 // ContainerStatPath stats the filesystem resource at the specified path in the
 // container identified by the given name.
-func (daemon *Daemon) ContainerStatPath(name string, path string) (stat *types.ContainerPathStat, err error) {
+func (daemon *Daemon) ContainerStatPath(name string, path string) (stat *container.PathStat, err error) {
 	ctr, err := daemon.GetContainer(name)
 	if err != nil {
 		return nil, err
@@ -30,7 +30,7 @@ func (daemon *Daemon) ContainerStatPath(name string, path string) (stat *types.C
 // ContainerArchivePath creates an archive of the filesystem resource at the
 // specified path in the container identified by the given name. Returns a
 // tar archive of the resource and whether it was a directory or a single file.
-func (daemon *Daemon) ContainerArchivePath(name string, path string) (content io.ReadCloser, stat *types.ContainerPathStat, err error) {
+func (daemon *Daemon) ContainerArchivePath(name string, path string) (content io.ReadCloser, stat *container.PathStat, err error) {
 	ctr, err := daemon.GetContainer(name)
 	if err != nil {
 		return nil, nil, err

--- a/daemon/archive_unix.go
+++ b/daemon/archive_unix.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/docker/docker/api/types"
+	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
@@ -20,7 +20,7 @@ import (
 
 // containerStatPath stats the filesystem resource at the specified path in this
 // container. Returns stat info about the resource.
-func (daemon *Daemon) containerStatPath(container *container.Container, path string) (stat *types.ContainerPathStat, err error) {
+func (daemon *Daemon) containerStatPath(container *container.Container, path string) (stat *containertypes.PathStat, err error) {
 	container.Lock()
 	defer container.Unlock()
 
@@ -36,7 +36,7 @@ func (daemon *Daemon) containerStatPath(container *container.Container, path str
 // containerArchivePath creates an archive of the filesystem resource at the specified
 // path in this container. Returns a tar archive of the resource and stat info
 // about the resource.
-func (daemon *Daemon) containerArchivePath(container *container.Container, path string) (content io.ReadCloser, stat *types.ContainerPathStat, err error) {
+func (daemon *Daemon) containerArchivePath(container *container.Container, path string) (content io.ReadCloser, stat *containertypes.PathStat, err error) {
 	container.Lock()
 
 	defer func() {

--- a/daemon/archive_windows.go
+++ b/daemon/archive_windows.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/container"
@@ -19,7 +18,7 @@ import (
 
 // containerStatPath stats the filesystem resource at the specified path in this
 // container. Returns stat info about the resource.
-func (daemon *Daemon) containerStatPath(container *container.Container, path string) (stat *types.ContainerPathStat, err error) {
+func (daemon *Daemon) containerStatPath(container *container.Container, path string) (stat *containertypes.PathStat, err error) {
 	container.Lock()
 	defer container.Unlock()
 
@@ -53,7 +52,7 @@ func (daemon *Daemon) containerStatPath(container *container.Container, path str
 // containerArchivePath creates an archive of the filesystem resource at the specified
 // path in this container. Returns a tar archive of the resource and stat info
 // about the resource.
-func (daemon *Daemon) containerArchivePath(container *container.Container, path string) (content io.ReadCloser, stat *types.ContainerPathStat, err error) {
+func (daemon *Daemon) containerArchivePath(container *container.Container, path string) (content io.ReadCloser, stat *containertypes.PathStat, err error) {
 	container.Lock()
 
 	defer func() {

--- a/daemon/containerd/image_prune.go
+++ b/daemon/containerd/image_prune.go
@@ -8,7 +8,6 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/errdefs"
@@ -31,7 +30,7 @@ var imagesAcceptedFilters = map[string]bool{
 var errPruneRunning = errdefs.Conflict(errors.New("a prune operation is already running"))
 
 // ImagesPrune removes unused images
-func (i *ImageService) ImagesPrune(ctx context.Context, fltrs filters.Args) (*types.ImagesPruneReport, error) {
+func (i *ImageService) ImagesPrune(ctx context.Context, fltrs filters.Args) (*image.PruneReport, error) {
 	if !i.pruneRunning.CompareAndSwap(false, true) {
 		return nil, errPruneRunning
 	}
@@ -62,8 +61,8 @@ func (i *ImageService) ImagesPrune(ctx context.Context, fltrs filters.Args) (*ty
 	return i.pruneUnused(ctx, filterFunc, danglingOnly)
 }
 
-func (i *ImageService) pruneUnused(ctx context.Context, filterFunc imageFilterFunc, danglingOnly bool) (*types.ImagesPruneReport, error) {
-	report := types.ImagesPruneReport{}
+func (i *ImageService) pruneUnused(ctx context.Context, filterFunc imageFilterFunc, danglingOnly bool) (*image.PruneReport, error) {
+	report := image.PruneReport{}
 
 	allImages, err := i.images.List(ctx)
 	if err != nil {

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/log"
+	"github.com/docker/docker/api/types/backend"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/strslice"
@@ -147,7 +148,7 @@ func (daemon *Daemon) ContainerExecCreate(name string, options *containertypes.E
 // ContainerExecStart starts a previously set up exec instance. The
 // std streams are set up.
 // If ctx is cancelled, the process is terminated.
-func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, options containertypes.ExecStartOptions) (err error) {
+func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, options backend.ExecStartConfig) (err error) {
 	var (
 		cStdin           io.ReadCloser
 		cStdout, cStderr io.Writer

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/log"
-	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/strslice"
@@ -94,42 +93,42 @@ func (daemon *Daemon) getActiveContainer(name string) (*container.Container, err
 }
 
 // ContainerExecCreate sets up an exec in a running container.
-func (daemon *Daemon) ContainerExecCreate(name string, config *types.ExecConfig) (string, error) {
+func (daemon *Daemon) ContainerExecCreate(name string, options *containertypes.ExecOptions) (string, error) {
 	cntr, err := daemon.getActiveContainer(name)
 	if err != nil {
 		return "", err
 	}
 
-	cmd := strslice.StrSlice(config.Cmd)
+	cmd := strslice.StrSlice(options.Cmd)
 	entrypoint, args := daemon.getEntrypointAndArgs(strslice.StrSlice{}, cmd)
 
 	keys := []byte{}
-	if config.DetachKeys != "" {
-		keys, err = term.ToBytes(config.DetachKeys)
+	if options.DetachKeys != "" {
+		keys, err = term.ToBytes(options.DetachKeys)
 		if err != nil {
-			err = fmt.Errorf("Invalid escape keys (%s) provided", config.DetachKeys)
+			err = fmt.Errorf("Invalid escape keys (%s) provided", options.DetachKeys)
 			return "", err
 		}
 	}
 
 	execConfig := container.NewExecConfig(cntr)
-	execConfig.OpenStdin = config.AttachStdin
-	execConfig.OpenStdout = config.AttachStdout
-	execConfig.OpenStderr = config.AttachStderr
+	execConfig.OpenStdin = options.AttachStdin
+	execConfig.OpenStdout = options.AttachStdout
+	execConfig.OpenStderr = options.AttachStderr
 	execConfig.DetachKeys = keys
 	execConfig.Entrypoint = entrypoint
 	execConfig.Args = args
-	execConfig.Tty = config.Tty
-	execConfig.ConsoleSize = config.ConsoleSize
-	execConfig.Privileged = config.Privileged
-	execConfig.User = config.User
-	execConfig.WorkingDir = config.WorkingDir
+	execConfig.Tty = options.Tty
+	execConfig.ConsoleSize = options.ConsoleSize
+	execConfig.Privileged = options.Privileged
+	execConfig.User = options.User
+	execConfig.WorkingDir = options.WorkingDir
 
 	linkedEnv, err := daemon.setupLinkedContainers(cntr)
 	if err != nil {
 		return "", err
 	}
-	execConfig.Env = container.ReplaceOrAppendEnvValues(cntr.CreateDaemonEnvironment(config.Tty, linkedEnv), config.Env)
+	execConfig.Env = container.ReplaceOrAppendEnvValues(cntr.CreateDaemonEnvironment(options.Tty, linkedEnv), options.Env)
 	if len(execConfig.User) == 0 {
 		execConfig.User = cntr.Config.User
 	}

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/types"
-	containertypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/container"
@@ -97,7 +97,7 @@ func (p *cmdProbe) run(ctx context.Context, d *Daemon, cntr *container.Container
 	defer cancelProbe()
 	execErr := make(chan error, 1)
 
-	options := containertypes.ExecStartOptions{
+	options := backend.ExecStartConfig{
 		Stdout: output,
 		Stderr: output,
 	}

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -5,7 +5,6 @@ import (
 	"io"
 
 	"github.com/distribution/reference"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
@@ -37,7 +36,7 @@ type ImageService interface {
 	Images(ctx context.Context, opts imagetype.ListOptions) ([]*imagetype.Summary, error)
 	LogImageEvent(imageID, refName string, action events.Action)
 	CountImages(ctx context.Context) int
-	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*types.ImagesPruneReport, error)
+	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*imagetype.PruneReport, error)
 	ImportImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, msg string, layerReader io.Reader, changes []string) (image.ID, error)
 	TagImage(ctx context.Context, imageID image.ID, newTag reference.Named) error
 	GetImage(ctx context.Context, refOrID string, options backend.GetImageOpts) (*image.Image, error)

--- a/daemon/images/image_prune.go
+++ b/daemon/images/image_prune.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
 	imagetypes "github.com/docker/docker/api/types/image"
@@ -33,7 +32,7 @@ var imagesAcceptedFilters = map[string]bool{
 var errPruneRunning = errdefs.Conflict(errors.New("a prune operation is already running"))
 
 // ImagesPrune removes unused images
-func (i *ImageService) ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*types.ImagesPruneReport, error) {
+func (i *ImageService) ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*imagetypes.PruneReport, error) {
 	if !atomic.CompareAndSwapInt32(&i.pruneRunning, 0, 1) {
 		return nil, errPruneRunning
 	}
@@ -45,7 +44,7 @@ func (i *ImageService) ImagesPrune(ctx context.Context, pruneFilters filters.Arg
 		return nil, err
 	}
 
-	rep := &types.ImagesPruneReport{}
+	rep := &imagetypes.PruneReport{}
 
 	danglingOnly, err := pruneFilters.GetBoolOrDefault("dangling", true)
 	if err != nil {

--- a/daemon/prune.go
+++ b/daemon/prune.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/containerd/log"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
@@ -39,13 +39,13 @@ var (
 )
 
 // ContainersPrune removes unused containers
-func (daemon *Daemon) ContainersPrune(ctx context.Context, pruneFilters filters.Args) (*types.ContainersPruneReport, error) {
+func (daemon *Daemon) ContainersPrune(ctx context.Context, pruneFilters filters.Args) (*container.PruneReport, error) {
 	if !atomic.CompareAndSwapInt32(&daemon.pruneRunning, 0, 1) {
 		return nil, errPruneRunning
 	}
 	defer atomic.StoreInt32(&daemon.pruneRunning, 0)
 
-	rep := &types.ContainersPruneReport{}
+	rep := &container.PruneReport{}
 
 	// make sure that only accepted filters have been received
 	err := pruneFilters.Validate(containersAcceptedFilters)

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -151,7 +151,7 @@ func (s *DockerAPISuite) TestGetContainerStats(c *testing.T) {
 	runSleepingContainer(c, "--name", name)
 
 	type b struct {
-		stats types.ContainerStats
+		stats container.StatsResponse
 		err   error
 	}
 
@@ -255,7 +255,7 @@ func (s *DockerAPISuite) TestGetContainerStatsStream(c *testing.T) {
 	runSleepingContainer(c, "--name", name)
 
 	type b struct {
-		stats types.ContainerStats
+		stats container.StatsResponse
 		err   error
 	}
 
@@ -296,7 +296,7 @@ func (s *DockerAPISuite) TestGetContainerStatsNoStream(c *testing.T) {
 	runSleepingContainer(c, "--name", name)
 
 	type b struct {
-		stats types.ContainerStats
+		stats container.StatsResponse
 		err   error
 	}
 
@@ -1417,7 +1417,7 @@ func (s *DockerAPISuite) TestContainerAPIStatsWithNetworkDisabled(c *testing.T) 
 	cli.WaitRun(c, name)
 
 	type b struct {
-		stats types.ContainerStats
+		stats container.StatsResponse
 		err   error
 	}
 	bc := make(chan b, 1)

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1188,7 +1188,7 @@ func (s *DockerAPISuite) TestPutContainerArchiveErrSymlinkInVolumeToReadOnlyRoot
 	apiClient, err := client.NewClientWithOpts(client.FromEnv)
 	assert.NilError(c, err)
 
-	err = apiClient.CopyToContainer(testutil.GetContext(c), cID, "/vol2/symlinkToAbsDir", nil, types.CopyToContainerOptions{})
+	err = apiClient.CopyToContainer(testutil.GetContext(c), cID, "/vol2/symlinkToAbsDir", nil, container.CopyToContainerOptions{})
 	assert.ErrorContains(c, err, "container rootfs is marked read-only")
 }
 

--- a/integration/config/config_test.go
+++ b/integration/config/config_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
@@ -313,7 +314,7 @@ func TestTemplatedConfig(t *testing.T) {
 	tasks := swarm.GetRunningTasks(ctx, t, c, serviceID)
 	assert.Assert(t, len(tasks) > 0, "no running tasks found for service %s", serviceID)
 
-	attach := swarm.ExecTask(ctx, t, d, tasks[0], types.ExecConfig{
+	attach := swarm.ExecTask(ctx, t, d, tasks[0], container.ExecOptions{
 		Cmd:          []string{"/bin/cat", "/templated_config"},
 		AttachStdout: true,
 		AttachStderr: true,
@@ -324,7 +325,7 @@ func TestTemplatedConfig(t *testing.T) {
 		"this is a config\n"
 	assertAttachedStream(t, attach, expect)
 
-	attach = swarm.ExecTask(ctx, t, d, tasks[0], types.ExecConfig{
+	attach = swarm.ExecTask(ctx, t, d, tasks[0], container.ExecOptions{
 		Cmd:          []string{"mount"},
 		AttachStdout: true,
 		AttachStderr: true,

--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/pkg/archive"
@@ -54,7 +55,7 @@ func TestCopyToContainerPathDoesNotExist(t *testing.T) {
 	apiClient := testEnv.APIClient()
 	cid := container.Create(ctx, t, apiClient)
 
-	err := apiClient.CopyToContainer(ctx, cid, "/dne", nil, types.CopyToContainerOptions{})
+	err := apiClient.CopyToContainer(ctx, cid, "/dne", nil, containertypes.CopyToContainerOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 	assert.Check(t, is.ErrorContains(err, "Could not find the file /dne in container "+cid))
 }
@@ -67,17 +68,17 @@ func TestCopyEmptyFile(t *testing.T) {
 
 	// empty content
 	dstDir, _ := makeEmptyArchive(t)
-	err := apiClient.CopyToContainer(ctx, cid, dstDir, bytes.NewReader([]byte("")), types.CopyToContainerOptions{})
+	err := apiClient.CopyToContainer(ctx, cid, dstDir, bytes.NewReader([]byte("")), containertypes.CopyToContainerOptions{})
 	assert.NilError(t, err)
 
 	// tar with empty file
 	dstDir, preparedArchive := makeEmptyArchive(t)
-	err = apiClient.CopyToContainer(ctx, cid, dstDir, preparedArchive, types.CopyToContainerOptions{})
+	err = apiClient.CopyToContainer(ctx, cid, dstDir, preparedArchive, containertypes.CopyToContainerOptions{})
 	assert.NilError(t, err)
 
 	// tar with empty file archive mode
 	dstDir, preparedArchive = makeEmptyArchive(t)
-	err = apiClient.CopyToContainer(ctx, cid, dstDir, preparedArchive, types.CopyToContainerOptions{
+	err = apiClient.CopyToContainer(ctx, cid, dstDir, preparedArchive, containertypes.CopyToContainerOptions{
 		CopyUIDGID: true,
 	})
 	assert.NilError(t, err)
@@ -125,7 +126,7 @@ func TestCopyToContainerPathIsNotDir(t *testing.T) {
 	if testEnv.DaemonInfo.OSType == "windows" {
 		path = "c:/windows/system32/drivers/etc/hosts/"
 	}
-	err := apiClient.CopyToContainer(ctx, cid, path, nil, types.CopyToContainerOptions{})
+	err := apiClient.CopyToContainer(ctx, cid, path, nil, containertypes.CopyToContainerOptions{})
 	assert.Check(t, is.ErrorContains(err, "not a directory"))
 }
 

--- a/integration/container/exec_linux_test.go
+++ b/integration/container/exec_linux_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration/internal/container"
 	"gotest.tools/v3/assert"
@@ -21,7 +21,7 @@ func TestExecConsoleSize(t *testing.T) {
 	cID := container.Run(ctx, t, apiClient, container.WithImage("busybox"))
 
 	result, err := container.Exec(ctx, apiClient, cID, []string{"stty", "size"},
-		func(ec *types.ExecConfig) {
+		func(ec *containertypes.ExecOptions) {
 			ec.Tty = true
 			ec.ConsoleSize = &[2]uint{57, 123}
 		},

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/integration/internal/container"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -24,7 +25,7 @@ func TestExecWithCloseStdin(t *testing.T) {
 	cID := container.Run(ctx, t, apiClient)
 
 	const expected = "closeIO"
-	execResp, err := apiClient.ContainerExecCreate(ctx, cID, types.ExecConfig{
+	execResp, err := apiClient.ContainerExecCreate(ctx, cID, containertypes.ExecOptions{
 		AttachStdin:  true,
 		AttachStdout: true,
 		Cmd:          []string{"sh", "-c", "cat && echo " + expected},
@@ -79,7 +80,7 @@ func TestExec(t *testing.T) {
 
 	cID := container.Run(ctx, t, apiClient, container.WithTty(true), container.WithWorkingDir("/root"))
 
-	id, err := apiClient.ContainerExecCreate(ctx, cID, types.ExecConfig{
+	id, err := apiClient.ContainerExecCreate(ctx, cID, containertypes.ExecOptions{
 		WorkingDir:   "/tmp",
 		Env:          []string{"FOO=BAR"},
 		AttachStdout: true,

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/integration/internal/container"
 	"gotest.tools/v3/assert"
@@ -32,7 +31,7 @@ func TestExecWithCloseStdin(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
-	resp, err := apiClient.ContainerExecAttach(ctx, execResp.ID, types.ExecStartCheck{})
+	resp, err := apiClient.ContainerExecAttach(ctx, execResp.ID, containertypes.ExecAttachOptions{})
 	assert.NilError(t, err)
 	defer resp.Close()
 
@@ -92,7 +91,7 @@ func TestExec(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(inspect.ExecID, id.ID))
 
-	resp, err := apiClient.ContainerExecAttach(ctx, id.ID, types.ExecStartCheck{})
+	resp, err := apiClient.ContainerExecAttach(ctx, id.ID, containertypes.ExecAttachOptions{})
 	assert.NilError(t, err)
 	defer resp.Close()
 	r, err := io.ReadAll(resp.Reader)

--- a/integration/container/export_test.go
+++ b/integration/container/export_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/integration/internal/container"
@@ -32,7 +31,7 @@ func TestExportContainerAndImportImage(t *testing.T) {
 	reference := "repo/" + strings.ToLower(t.Name()) + ":v1"
 	exportResp, err := apiClient.ContainerExport(ctx, cID)
 	assert.NilError(t, err)
-	importResp, err := apiClient.ImageImport(ctx, types.ImageImportSource{
+	importResp, err := apiClient.ImageImport(ctx, image.ImportSource{
 		Source:     exportResp,
 		SourceName: "-",
 	}, reference, image.ImportOptions{})

--- a/integration/container/overlayfs_linux_test.go
+++ b/integration/container/overlayfs_linux_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/dmesg"
@@ -42,7 +42,7 @@ func TestNoOverlayfsWarningsAboutUndefinedBehaviors(t *testing.T) {
 		{name: "cp to container", operation: func(t *testing.T) error {
 			archive, err := archive.Generate("new-file", "hello-world")
 			assert.NilError(t, err, "failed to create a temporary archive")
-			return client.CopyToContainer(ctx, cID, "/", archive, types.CopyToContainerOptions{})
+			return client.CopyToContainer(ctx, cID, "/", archive, containertypes.CopyToContainerOptions{})
 		}},
 		{name: "cp from container", operation: func(*testing.T) error {
 			rc, _, err := client.CopyFromContainer(ctx, cID, "/file")

--- a/integration/container/pause_test.go
+++ b/integration/container/pause_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	cerrdefs "github.com/containerd/errdefs"
-	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
@@ -41,7 +40,7 @@ func TestPause(t *testing.T) {
 
 	until := request.DaemonUnixTime(ctx, t, apiClient, testEnv)
 
-	messages, errs := apiClient.Events(ctx, types.EventsOptions{
+	messages, errs := apiClient.Events(ctx, events.ListOptions{
 		Since:   since,
 		Until:   until,
 		Filters: filters.NewArgs(filters.Arg(string(events.ContainerEventType), cID)),

--- a/integration/container/restart_test.go
+++ b/integration/container/restart_test.go
@@ -244,7 +244,7 @@ func TestContainerRestartWithCancelledRequest(t *testing.T) {
 	}()
 
 	// Start listening for events.
-	messages, errs := apiClient.Events(ctx, types.EventsOptions{
+	messages, errs := apiClient.Events(ctx, events.ListOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("container", cID),
 			filters.Arg("event", string(events.ActionRestart)),

--- a/integration/image/import_test.go
+++ b/integration/image/import_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
@@ -48,7 +47,7 @@ func TestImportExtremelyLargeImageWorks(t *testing.T) {
 	reference := strings.ToLower(t.Name()) + ":v42"
 
 	_, err = client.ImageImport(ctx,
-		types.ImageImportSource{Source: imageRdr, SourceName: "-"},
+		imagetypes.ImportSource{Source: imageRdr, SourceName: "-"},
 		reference,
 		imagetypes.ImportOptions{})
 	assert.NilError(t, err)
@@ -111,7 +110,7 @@ func TestImportWithCustomPlatform(t *testing.T) {
 			reference := "import-with-platform:tc-" + strconv.Itoa(i)
 
 			_, err = client.ImageImport(ctx,
-				types.ImageImportSource{Source: imageRdr, SourceName: "-"},
+				imagetypes.ImportSource{Source: imageRdr, SourceName: "-"},
 				reference,
 				imagetypes.ImportOptions{Platform: tc.platform})
 			assert.NilError(t, err)
@@ -177,7 +176,7 @@ func TestImportWithCustomPlatformReject(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
 			reference := "import-with-platform:tc-" + strconv.Itoa(i)
 			_, err = client.ImageImport(ctx,
-				types.ImageImportSource{Source: imageRdr, SourceName: "-"},
+				imagetypes.ImportSource{Source: imageRdr, SourceName: "-"},
 				reference,
 				imagetypes.ImportOptions{Platform: tc.platform})
 

--- a/integration/internal/container/exec.go
+++ b/integration/internal/container/exec.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 )
 
@@ -47,19 +48,19 @@ func (res ExecResult) AssertSuccess(t testing.TB) {
 // containing stdout, stderr, and exit code. Note:
 //   - this is a synchronous operation;
 //   - cmd stdin is closed.
-func Exec(ctx context.Context, apiClient client.APIClient, id string, cmd []string, ops ...func(*types.ExecConfig)) (ExecResult, error) {
+func Exec(ctx context.Context, apiClient client.APIClient, id string, cmd []string, ops ...func(*container.ExecOptions)) (ExecResult, error) {
 	// prepare exec
-	execConfig := types.ExecConfig{
+	execOptions := container.ExecOptions{
 		AttachStdout: true,
 		AttachStderr: true,
 		Cmd:          cmd,
 	}
 
 	for _, op := range ops {
-		op(&execConfig)
+		op(&execOptions)
 	}
 
-	cresp, err := apiClient.ContainerExecCreate(ctx, id, execConfig)
+	cresp, err := apiClient.ContainerExecCreate(ctx, id, execOptions)
 	if err != nil {
 		return ExecResult{}, err
 	}
@@ -87,7 +88,7 @@ func Exec(ctx context.Context, apiClient client.APIClient, id string, cmd []stri
 }
 
 // ExecT calls Exec() and aborts the test if an error occurs.
-func ExecT(ctx context.Context, t testing.TB, apiClient client.APIClient, id string, cmd []string, ops ...func(*types.ExecConfig)) ExecResult {
+func ExecT(ctx context.Context, t testing.TB, apiClient client.APIClient, id string, cmd []string, ops ...func(*container.ExecOptions)) ExecResult {
 	t.Helper()
 	res, err := Exec(ctx, apiClient, id, cmd, ops...)
 	if err != nil {

--- a/integration/internal/container/exec.go
+++ b/integration/internal/container/exec.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 )
@@ -67,7 +66,7 @@ func Exec(ctx context.Context, apiClient client.APIClient, id string, cmd []stri
 	execID := cresp.ID
 
 	// run it, with stdout/stderr attached
-	aresp, err := apiClient.ContainerExecAttach(ctx, execID, types.ExecStartCheck{})
+	aresp, err := apiClient.ContainerExecAttach(ctx, execID, container.ExecAttachOptions{})
 	if err != nil {
 		return ExecResult{}, err
 	}

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
@@ -211,12 +212,12 @@ func GetRunningTasks(ctx context.Context, t *testing.T, c client.ServiceAPIClien
 }
 
 // ExecTask runs the passed in exec config on the given task
-func ExecTask(ctx context.Context, t *testing.T, d *daemon.Daemon, task swarmtypes.Task, config types.ExecConfig) types.HijackedResponse {
+func ExecTask(ctx context.Context, t *testing.T, d *daemon.Daemon, task swarmtypes.Task, options container.ExecOptions) types.HijackedResponse {
 	t.Helper()
 	apiClient := d.NewClientT(t)
 	defer apiClient.Close()
 
-	resp, err := apiClient.ContainerExecCreate(ctx, task.Status.ContainerStatus.ContainerID, config)
+	resp, err := apiClient.ContainerExecCreate(ctx, task.Status.ContainerStatus.ContainerID, options)
 	assert.NilError(t, err, "error creating exec")
 
 	attach, err := apiClient.ContainerExecAttach(ctx, resp.ID, types.ExecStartCheck{})

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -220,7 +220,7 @@ func ExecTask(ctx context.Context, t *testing.T, d *daemon.Daemon, task swarmtyp
 	resp, err := apiClient.ContainerExecCreate(ctx, task.Status.ContainerStatus.ContainerID, options)
 	assert.NilError(t, err, "error creating exec")
 
-	attach, err := apiClient.ContainerExecAttach(ctx, resp.ID, types.ExecStartCheck{})
+	attach, err := apiClient.ContainerExecAttach(ctx, resp.ID, container.ExecAttachOptions{})
 	assert.NilError(t, err, "error attaching to exec")
 	return attach
 }

--- a/integration/plugin/authz/authz_plugin_test.go
+++ b/integration/plugin/authz/authz_plugin_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	eventtypes "github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/image"
@@ -463,7 +462,7 @@ func imageImport(ctx context.Context, client client.APIClient, path string) erro
 	defer file.Close()
 	options := image.ImportOptions{}
 	ref := ""
-	source := types.ImageImportSource{
+	source := image.ImportSource{
 		Source:     file,
 		SourceName: "-",
 	}

--- a/integration/plugin/authz/authz_plugin_test.go
+++ b/integration/plugin/authz/authz_plugin_test.go
@@ -416,7 +416,7 @@ func TestAuthzPluginEnsureContainerCopyToFrom(t *testing.T) {
 	dstDir, preparedArchive, err := archive.PrepareArchiveCopy(srcArchive, srcInfo, archive.CopyInfo{Path: "/test"})
 	assert.NilError(t, err)
 
-	err = c.CopyToContainer(ctx, cID, dstDir, preparedArchive, types.CopyToContainerOptions{})
+	err = c.CopyToContainer(ctx, cID, dstDir, preparedArchive, containertypes.CopyToContainerOptions{})
 	assert.NilError(t, err)
 
 	rdr, _, err := c.CopyFromContainer(ctx, cID, "/test")

--- a/integration/plugin/authz/authz_plugin_test.go
+++ b/integration/plugin/authz/authz_plugin_test.go
@@ -287,7 +287,7 @@ func systemTime(ctx context.Context, t *testing.T, client client.APIClient, test
 }
 
 func systemEventsSince(ctx context.Context, client client.APIClient, since string) (<-chan eventtypes.Message, <-chan error, func()) {
-	eventOptions := types.EventsOptions{
+	eventOptions := eventtypes.ListOptions{
 		Since: since,
 	}
 	ctx, cancel := context.WithCancel(ctx)

--- a/integration/secret/secret_test.go
+++ b/integration/secret/secret_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
@@ -313,7 +314,7 @@ func TestTemplatedSecret(t *testing.T) {
 	tasks := swarm.GetRunningTasks(ctx, t, c, serviceID)
 	assert.Assert(t, len(tasks) > 0, "no running tasks found for service %s", serviceID)
 
-	attach := swarm.ExecTask(ctx, t, d, tasks[0], types.ExecConfig{
+	attach := swarm.ExecTask(ctx, t, d, tasks[0], container.ExecOptions{
 		Cmd:          []string{"/bin/cat", "/run/secrets/templated_secret"},
 		AttachStdout: true,
 		AttachStderr: true,
@@ -324,7 +325,7 @@ func TestTemplatedSecret(t *testing.T) {
 		"this is a config\n"
 	assertAttachedStream(t, attach, expect)
 
-	attach = swarm.ExecTask(ctx, t, d, tasks[0], types.ExecConfig{
+	attach = swarm.ExecTask(ctx, t, d, tasks[0], container.ExecOptions{
 		Cmd:          []string{"mount"},
 		AttachStdout: true,
 		AttachStderr: true,

--- a/integration/system/event_test.go
+++ b/integration/system/event_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
@@ -38,7 +37,7 @@ func TestEventsExecDie(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
-	msg, errs := client.Events(ctx, types.EventsOptions{
+	msg, errs := client.Events(ctx, events.ListOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("container", cID),
 			filters.Arg("event", string(events.ActionExecDie)),
@@ -156,7 +155,7 @@ func TestEventsVolumeCreate(t *testing.T) {
 		filters.Arg("event", "create"),
 		filters.Arg("volume", volName),
 	)
-	messages, errs := client.Events(ctx, types.EventsOptions{
+	messages, errs := client.Events(ctx, events.ListOptions{
 		Since:   since,
 		Until:   request.DaemonUnixTime(ctx, t, client, testEnv),
 		Filters: filter,
@@ -172,7 +171,7 @@ func TestEventsVolumeCreate(t *testing.T) {
 		Target: "/tmp/foo",
 	}))
 
-	messages, errs = client.Events(ctx, types.EventsOptions{
+	messages, errs = client.Events(ctx, events.ListOptions{
 		Since:   since,
 		Until:   request.DaemonUnixTime(ctx, t, client, testEnv),
 		Filters: filter,

--- a/integration/system/event_test.go
+++ b/integration/system/event_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/mount"
@@ -32,11 +33,9 @@ func TestEventsExecDie(t *testing.T) {
 
 	cID := container.Run(ctx, t, client)
 
-	id, err := client.ContainerExecCreate(ctx, cID,
-		types.ExecConfig{
-			Cmd: []string{"echo", "hello"},
-		},
-	)
+	id, err := client.ContainerExecCreate(ctx, cID, containertypes.ExecOptions{
+		Cmd: []string{"echo", "hello"},
+	})
 	assert.NilError(t, err)
 
 	msg, errs := client.Events(ctx, types.EventsOptions{

--- a/integration/system/event_test.go
+++ b/integration/system/event_test.go
@@ -45,7 +45,7 @@ func TestEventsExecDie(t *testing.T) {
 		),
 	})
 
-	err = client.ContainerExecStart(ctx, id.ID, types.ExecStartCheck{
+	err = client.ContainerExecStart(ctx, id.ID, containertypes.ExecStartOptions{
 		Detach: true,
 		Tty:    false,
 	})

--- a/volume/service/service.go
+++ b/volume/service/service.go
@@ -6,7 +6,6 @@ import (
 	"sync/atomic"
 
 	"github.com/containerd/log"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
 	volumetypes "github.com/docker/docker/api/types/volume"
@@ -204,7 +203,7 @@ func (s *VolumesService) LocalVolumesSize(ctx context.Context) ([]*volumetypes.V
 // Prune removes (local) volumes which match the past in filter arguments.
 // Note that this intentionally skips volumes with mount options as there would
 // be no space reclaimed in this case.
-func (s *VolumesService) Prune(ctx context.Context, filter filters.Args) (*types.VolumesPruneReport, error) {
+func (s *VolumesService) Prune(ctx context.Context, filter filters.Args) (*volumetypes.PruneReport, error) {
 	if !atomic.CompareAndSwapInt32(&s.pruneRunning, 0, 1) {
 		return nil, errdefs.Conflict(errors.New("a prune operation is already running"))
 	}
@@ -226,7 +225,7 @@ func (s *VolumesService) Prune(ctx context.Context, filter filters.Args) (*types
 		return nil, err
 	}
 
-	rep := &types.VolumesPruneReport{VolumesDeleted: make([]string, 0, len(ls))}
+	rep := &volumetypes.PruneReport{VolumesDeleted: make([]string, 0, len(ls))}
 	for _, v := range ls {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
### api/types: move ExecConfig to api/types/container

### api/types: move ExecStartOptions to api/types/backend

It's a type used by the backend, so moving it there.

### api/types: move ExecStartCheck to api/types/container

This moves the type to api/types/container and creates an alias for
exec attach; ContainerExecAttach currently uses the same type as
ContainerExecStart, but does not all the same options (and some
options cannot be used).

- relates to https://github.com/moby/moby/issues/47772

We need to split the actual types, but lets start with aliasing.

### api/types: move ContainerExecInspect to api/types/container

### api/types: move ContainersPruneReport to api/types/container

### api/types: move ContainerPathStat to api/types/container

### api/types: move CopyToContainerOptions to api/types/container

### api/types: move ContainerStats to api/types/container

This is the response type; other types related to stats are left
for now, but should be moved (as well as utilities ported from
the CLI repository).

### api/types: move VolumesPruneReport to api/types/volume

### api/types: move ImagesPruneReport to api/types/image

### api/types: move EventsOptions to api/types/events

### api/types: move ImageSearchOptions to api/types/registry

Note that RequestPrivilegeFunc could not be referenced, as it would
introduce a circular import, so copying the definition instead.

Also combining the other search-related types in the package to be in
the same file.


### api/types: move ImageImportSource to api/types/image

### api/types: move ImageLoadResponse to api/types/image

This moves the type, but we should consider removing this type, and just
returning an io.ReadCloser

This type was added in 9fd2c0feb0c131d01d727d50baa7183b976c7bdc;

> Make docker load to output json when the response content type is json
> Swarm hijacks the response from docker load and returns JSON rather
> than plain text like the Engine does. This makes the API library to return
> information to figure that out.

However the "load" endpoint unconditionally returns JSON;
https://github.com/moby/moby/blob/7b9d2ef6e5518a3d3f3cc418459f8df786cfbbd1/api/server/router/image/image_routes.go#L248-L255

Commit 96d7db665b06cc0bbede22d818c69dc5f6921f66 made the response-type depend
on whether "quiet" was set, but this logic got changed in a follow-up
2f27632cde2f0e514bd3a8de77cc1934e5193a83, which made the JSON response-type
unconditionally, but the output produced depend on whether"quiet" was set.

We should deprecated the "quiet" option, as it's really a client
responsibility.



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
api/types: Move `ExecConfig`, `ContainerExecInspect`, `ContainersPruneReport`, `ContainerPathStat`, `CopyToContainerOptions`, `ExecStartCheck` and `ContainerStats` to api/types/container
           Move `ImagesPruneReport`, `ImageImportSource` and `ImageLoadResponse` to api/types/image
           Move `ExecStartOptions` to api/types/backend
           Move `VolumesPruneReport` to api/types/volume
           Move `EventsOptions` to api/types/events
           Move `ImageSearchOptions` to api/types/registry

```

**- A picture of a cute animal (not mandatory but encouraged)**

