### PR TITLE
docs: api: image inspect: remove Container and ContainerConfig

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1198,13 +1198,6 @@ definitions:
   ContainerConfig:
     description: |
       Configuration for a container that is portable between hosts.
-
-      When used as `ContainerConfig` field in an image, `ContainerConfig` is an
-      optional field containing the configuration of the container that was last
-      committed when creating the image.
-
-      Previous versions of Docker builder used this field to store build cache,
-      and it is not in active use anymore.
     type: "object"
     properties:
       Hostname:
@@ -1758,21 +1751,6 @@ definitions:
         format: "dateTime"
         x-nullable: true
         example: "2022-02-04T21:20:12.497794809Z"
-      Container:
-        description: |
-          The ID of the container that was used to create the image.
-
-          Depending on how the image was created, this field may be empty.
-
-          **Deprecated**: this field is kept for backward compatibility, but
-          will be removed in API v1.45.
-        type: "string"
-        example: "65974bc86f1770ae4bff79f651ebdbce166ae9aada632ee3fa9af3a264911735"
-      ContainerConfig:
-        description: |
-          **Deprecated**: this field is kept for backward compatibility, but
-          will be removed in API v1.45.
-        $ref: "#/definitions/ContainerConfig"
       DockerVersion:
         description: |
           The version of Docker that was used to build the image.

--- a/docs/api/v1.45.yaml
+++ b/docs/api/v1.45.yaml
@@ -1198,13 +1198,6 @@ definitions:
   ContainerConfig:
     description: |
       Configuration for a container that is portable between hosts.
-
-      When used as `ContainerConfig` field in an image, `ContainerConfig` is an
-      optional field containing the configuration of the container that was last
-      committed when creating the image.
-
-      Previous versions of Docker builder used this field to store build cache,
-      and it is not in active use anymore.
     type: "object"
     properties:
       Hostname:
@@ -1758,21 +1751,6 @@ definitions:
         format: "dateTime"
         x-nullable: true
         example: "2022-02-04T21:20:12.497794809Z"
-      Container:
-        description: |
-          The ID of the container that was used to create the image.
-
-          Depending on how the image was created, this field may be empty.
-
-          **Deprecated**: this field is kept for backward compatibility, but
-          will be removed in API v1.45.
-        type: "string"
-        example: "65974bc86f1770ae4bff79f651ebdbce166ae9aada632ee3fa9af3a264911735"
-      ContainerConfig:
-        description: |
-          **Deprecated**: this field is kept for backward compatibility, but
-          will be removed in API v1.45.
-        $ref: "#/definitions/ContainerConfig"
       DockerVersion:
         description: |
           The version of Docker that was used to build the image.


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/47430

The Container and ContainerConfig fields have been deprecated, and removed since API v1.45 in commit 03cddc62f4bcd48fbc3a31dd94f2bf84e44840dd.

This patch fixes the swagger and documentation to no longer mention them as they are no longer returned by API v1.45 and higher.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Remove `Container` and `ContainerConfig` fields from the `GET /images/{name}/json` response in swagger and documentation.
```

**- A picture of a cute animal (not mandatory but encouraged)**

