### PR TITLE
c8d/push: Fix small whoopsies

### DIFF
--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -182,6 +182,7 @@ func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, p
 
 			// Retry only if the new push candidate is different from the previous one.
 			if newTarget.Digest != target.Digest {
+				orgTarget := target
 				target = newTarget
 				pp.TurnNotStartedIntoUnavailable()
 				err = remotes.PushContent(ctx, pusher, target, store, limiter, platforms.All, handlerWrapper)
@@ -189,7 +190,7 @@ func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, p
 				if err == nil {
 					progress.Aux(out, auxprogress.ManifestPushedInsteadOfIndex{
 						ManifestPushedInsteadOfIndex: true,
-						OriginalIndex:                target,
+						OriginalIndex:                orgTarget,
 						SelectedManifest:             newTarget,
 					})
 				}

--- a/daemon/containerd/progress.go
+++ b/daemon/containerd/progress.go
@@ -195,7 +195,6 @@ func (p *pushProgress) UpdateProgress(ctx context.Context, ongoing *jobs, out pr
 		if err != nil || notStarted {
 			if p.notStartedWaitingAreUnavailable.Load() {
 				progress.Update(out, id, "Unavailable")
-				ongoing.Remove(j)
 				continue
 			}
 			if cerrdefs.IsNotFound(err) {


### PR DESCRIPTION
- follow up to: https://github.com/moby/moby/pull/47679

**- What I did**
Fixed some small whoopsies made when addressing review comments in the original PR and noticed them while testing the rebased CLI PR 🙈 

###  c8d/push: Fix wrong Originalindex descriptor in aux error

The target variable was already overwritten with the new value. Use the
original value instead.

### c8d/progress: Allow updating "Unavailable" ids

They might still change to "Mounted from" or "Already exists" when
containerd updates the status in tracker.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

