### PR TITLE
daemon: let it decide when LBs & default gateways are needed

### DIFF
--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -692,12 +692,6 @@ addToStore:
 		}
 	}()
 
-	if nw.hasLoadBalancerEndpoint() {
-		if err := nw.createLoadBalancerSandbox(); err != nil {
-			return nil, err
-		}
-	}
-
 	if c.isSwarmNode() {
 		c.mu.Lock()
 		arrangeIngressFilterRule()

--- a/libnetwork/driverapi/driverapi.go
+++ b/libnetwork/driverapi/driverapi.go
@@ -141,8 +141,10 @@ type JoinInfo interface {
 	// It may be used in addition to or instead of a default gateway (as above).
 	AddStaticRoute(destination *net.IPNet, routeType int, nextHop net.IP) error
 
-	// DisableGatewayService tells libnetwork not to provide Default GW for the container
-	DisableGatewayService()
+	// RequireDefaultGateway instruct libnetwork to connect the associated
+	// sandbox to the 'docker_gwbridge' network to provide a default gateway if
+	// it doesn't have one already.
+	RequireDefaultGateway()
 
 	// AddTableEntry adds a table entry to the gossip layer
 	// passing the table name, key and an opaque value.

--- a/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -632,7 +632,7 @@ func (te *testEndpoint) AddTableEntry(tableName string, key string, value []byte
 	return nil
 }
 
-func (te *testEndpoint) DisableGatewayService() {}
+func (te *testEndpoint) RequireDefaultGateway() {}
 
 func TestQueryEndpointInfo(t *testing.T) {
 	testQueryEndpointInfo(t, true)

--- a/libnetwork/drivers/ipvlan/ipvlan_joinleave.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_joinleave.go
@@ -54,8 +54,6 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 	if !n.config.Internal {
 		switch n.config.IpvlanMode {
 		case modeL3, modeL3S:
-			// disable gateway services to add a default gw using dev eth0 only
-			jinfo.DisableGatewayService()
 			defaultRoute, err := ifaceGateway(defaultV4RouteCidr)
 			if err != nil {
 				return err
@@ -122,10 +120,6 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 			log.G(context.TODO()).Debugf("Ipvlan Endpoint Joined with IPv6_Addr: %s IpVlan_Mode: %s, Parent: %s",
 				ep.addrv6.IP.String(), n.config.IpvlanMode, n.config.Parent)
 		}
-		// If n.config.Internal was set locally by the driver because there's no parent
-		// interface, libnetwork doesn't know the network is internal. So, stop it from
-		// adding a gateway endpoint.
-		jinfo.DisableGatewayService()
 	}
 	iNames := jinfo.InterfaceName()
 	err = iNames.SetNames(vethName, containerVethPrefix)

--- a/libnetwork/drivers/macvlan/macvlan_joinleave.go
+++ b/libnetwork/drivers/macvlan/macvlan_joinleave.go
@@ -83,10 +83,6 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 			log.G(context.TODO()).Debugf("Macvlan Endpoint Joined with IPv6_Addr: %s MacVlan_Mode: %s, Parent: %s",
 				ep.addrv6.IP.String(), n.config.MacvlanMode, n.config.Parent)
 		}
-		// If n.config.Internal was set locally by the driver because there's no parent
-		// interface, libnetwork doesn't know the network is internal. So, stop it from
-		// adding a gateway endpoint.
-		jinfo.DisableGatewayService()
 	}
 	iNames := jinfo.InterfaceName()
 	err = iNames.SetNames(vethName, containerVethPrefix)

--- a/libnetwork/drivers/overlay/joinleave.go
+++ b/libnetwork/drivers/overlay/joinleave.go
@@ -126,6 +126,14 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 		log.G(context.TODO()).Errorf("overlay: Failed adding table entry to joininfo: %v", err)
 	}
 
+	// From a user standpoint, an overlay network provides North-South/East-West connectivity. However, the reality is
+	// that the overlay netdriver only provides East-West connectivity. When a container is connected to a non-internal
+	// overlay network, the daemon will automatically attach the container to a North-South-only network named
+	// 'docker_gwbridge'. This is communicated by the overlay driver through this 'RequireDefaultGateway' flag.
+	if !n.internal {
+		jinfo.RequireDefaultGateway()
+	}
+
 	return nil
 }
 

--- a/libnetwork/drivers/overlay/ov_network.go
+++ b/libnetwork/drivers/overlay/ov_network.go
@@ -57,6 +57,7 @@ type network struct {
 	subnets   []*subnet
 	secure    bool
 	mtu       int
+	internal  bool
 	sync.Mutex
 }
 
@@ -127,6 +128,12 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 		}
 		if n.mtu < 0 {
 			return fmt.Errorf("invalid MTU value: %v", n.mtu)
+		}
+	}
+
+	if val, ok := optMap[netlabel.Internal]; ok {
+		if n.internal, err = strconv.ParseBool(val); err != nil {
+			return fmt.Errorf("failed to parse %s=%s", netlabel.Internal, val)
 		}
 	}
 

--- a/libnetwork/drivers/remote/driver.go
+++ b/libnetwork/drivers/remote/driver.go
@@ -318,8 +318,8 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 			}
 		}
 	}
-	if res.DisableGatewayService {
-		jinfo.DisableGatewayService()
+	if !res.DisableGatewayService {
+		jinfo.RequireDefaultGateway()
 	}
 	return nil
 }

--- a/libnetwork/drivers/remote/driver_test.go
+++ b/libnetwork/drivers/remote/driver_test.go
@@ -92,7 +92,7 @@ type testEndpoint struct {
 	nextHop               string
 	destination           string
 	routeType             int
-	disableGatewayService bool
+	requireDefaultGateway bool
 }
 
 func (test *testEndpoint) Address() *net.IPNet {
@@ -203,8 +203,8 @@ func (test *testEndpoint) AddStaticRoute(destination *net.IPNet, routeType int, 
 	return nil
 }
 
-func (test *testEndpoint) DisableGatewayService() {
-	test.disableGatewayService = true
+func (test *testEndpoint) RequireDefaultGateway() {
+	test.requireDefaultGateway = true
 }
 
 func (test *testEndpoint) AddTableEntry(tableName string, key string, value []byte) error {

--- a/libnetwork/drivers/windows/overlay/joinleave_windows.go
+++ b/libnetwork/drivers/windows/overlay/joinleave_windows.go
@@ -40,10 +40,6 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 		log.G(context.TODO()).Errorf("overlay: Failed adding table entry to joininfo: %v", err)
 	}
 
-	if ep.disablegateway {
-		jinfo.DisableGatewayService()
-	}
-
 	return nil
 }
 

--- a/libnetwork/drivers/windows/overlay/ov_endpoint_windows.go
+++ b/libnetwork/drivers/windows/overlay/ov_endpoint_windows.go
@@ -184,8 +184,6 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 	}
 	hnsEndpoint.Policies = append(hnsEndpoint.Policies, pbPolicy...)
 
-	ep.disablegateway = true
-
 	configurationb, err := json.Marshal(hnsEndpoint)
 	if err != nil {
 		return err

--- a/libnetwork/drivers/windows/windows.go
+++ b/libnetwork/drivers/windows/windows.go
@@ -854,7 +854,6 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 		}
 	}
 
-	jinfo.DisableGatewayService()
 	return nil
 }
 


### PR DESCRIPTION
**- What I did**

NOTE: Prior to these changes, the `docker_gwbridge` was created as soon as the daemon joined/formed a cluster. This was due to the following calls being made:

- `executor.Configure()`
- -> `Controller.setupIngress()`
- -> `Network.createLoadBalancer()`
- -> `Endpoint.sbJoin()`
- -> `Sandbox.setupDefaultGW()`

Because of the changes made in this PR, `docker_gwbridge` won't be created automatically anymore. It will be created whenever a container needs a default gateway (either because of a remote netdriver, or because a container connected only to overlay networks starts).

**daemon: move LB creation out of libnet**

Prior to this commit, libnet `Controller.NewNetwork` was in charge of creating a load-balancer sandbox and connecting it to the network being created, if `NetworkOptionLBEndpoint` was passed.

This commit transfers this responsibility to the daemon.

**libnet: default_gwbridge: drop chan procGwNetwork**

This channel was used in `defaultGwNetwork` like a global mutex to ensure no two concurrent calls to `setupDefaultGW` would race against each other to create the 'docker_gwbridge'.

With this commit, if concurrent calls are made, the first call winning the race will create the network and other calls will return a 'NetworkNameError'. `defaultGwNetwork` is updated to detect that error and retrieve the `*Network` from the datastore.

**libnet: EndpointInfo: replace DisableGatewayService**

Replace it with a new `RequireDefaultGateway` and set it in overlay and remote netdrivers.

**daemon: move docker_gwbridge mgmt out of libnet**

Prior to this commit, `(*Endpoint).sbJoin()` was connecting the sandbox to the `docker_gwbridge` network when needed. When doing so, the `docker_gwbridge` network was created if it didn't exist yet. This is last case where libnetwork is driving itself.

This commit transfers the responsibility of connecting a sandbox to the 'docker_gwbridge' nw to the daemon.

**- How to verify it**

CI and manually...

1st commit:

```console
$ docker network create -d overlay --attachable testnet-swarm
$ docker run -d --name c0 --network testnet-swarm alpine top
$ docker network inspect --format='{{ json (index .Containers "lb-testnet-swarm") }}' testnet-swarm # Show a lb
$ docker rm -f c0
$ docker network inspect --format='{{ json (index .Containers "lb-testnet-swarm") }}' testnet-swarm # Shows an empty lb sandbox
{"Name":"","EndpointID":"","MacAddress":"","IPv4Address":"","IPv6Address":""}
```

2nd, 3rd and 4th commit:

```console
$ docker network create -d bridge testnet
$ docker network create -d overlay --attachable testnet-swarm-1
$ docker network create -d overlay --attachable testnet-swarm-2
$ docker run -d --name c0 --network testnet --network testnet-swarm-1 nicolaka/netshoot top
$ docker network inspect --format='{{ (index .IPAM.Config 0).Gateway }}' testnet
$ docker network inspect --format='{{ (index .IPAM.Config 0).Gateway }}' docker_gwbridge # Should fail
$ docker exec c0 ip -brief route show default # Should show testnet gateway
$ docker network disconnect testnet c0
$ docker network inspect --format='{{ (index .IPAM.Config 0).Gateway }}' docker_gwbridge
$ docker exec c0 ip -brief route show default # Should show docker_gwbridge gateway
$ docker network connect testnet-swarm-2 c0
$ docker exec c0 ip -brief route show default # Should show docker_gwbridge gateway
$ docker network disconnect testnet-swarm-2 c0
$ docker exec c0 ip -brief route show default # Should show docker_gwbridge gateway
$ docker network connect testnet c0
$ docker exec c0 ip -brief route show default # Should show testnet gateway
```

**- A picture of a cute animal (not mandatory but encouraged)**

