### PR TITLE
Windows: Run containerd as managed process

### DIFF
--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -350,32 +350,11 @@ jobs:
             Write-Host "Service removed"
           }
       -
-        name: Starting containerd
-        if: matrix.runtime == 'containerd'
-        run: |
-          Write-Host "Generating config"
-          & "${{ env.BIN_OUT }}\containerd.exe" config default | Out-File "$env:TEMP\ctn.toml" -Encoding ascii
-          Write-Host "Creating service"
-          New-Item -ItemType Directory "$env:TEMP\ctn-root" -ErrorAction SilentlyContinue | Out-Null
-          New-Item -ItemType Directory "$env:TEMP\ctn-state" -ErrorAction SilentlyContinue | Out-Null
-          Start-Process -Wait "${{ env.BIN_OUT }}\containerd.exe" `
-            -ArgumentList "--log-level=debug", `
-              "--config=$env:TEMP\ctn.toml", `
-              "--address=\\.\pipe\containerd-containerd", `
-              "--root=$env:TEMP\ctn-root", `
-              "--state=$env:TEMP\ctn-state", `
-              "--log-file=$env:TEMP\ctn.log", `
-              "--register-service"
-          Write-Host "Starting service"
-          Start-Service -Name containerd
-          Start-Sleep -Seconds 5
-          Write-Host "Service started successfully!"
-      -
         name: Starting test daemon
         run: |
           Write-Host "Creating service"
           If ("${{ matrix.runtime }}" -eq "containerd") {
-            $runtimeArg="--containerd=\\.\pipe\containerd-containerd"
+            $runtimeArg="--default-runtime=io.containerd.runhcs.v1"
             echo "DOCKER_WINDOWS_CONTAINERD_RUNTIME=1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           }
           New-Item -ItemType Directory "$env:TEMP\moby-root" -ErrorAction SilentlyContinue | Out-Null
@@ -415,6 +394,17 @@ jobs:
             Start-Sleep -Seconds 1
           }
           Write-Host "Test daemon started and replied!"
+          If ("${{ matrix.runtime }}" -eq "containerd") {
+            $containerdProcesses = Get-Process -Name containerd -ErrorAction:SilentlyContinue
+            If (-not $containerdProcesses) {
+              Throw "containerd process is not running"
+            } else {
+              foreach ($process in $containerdProcesses) {
+                $processPath = (Get-Process -Id $process.Id -FileVersionInfo).FileName
+                Write-Output "Running containerd instance binary Path: $($processPath)"
+              }
+            }
+          }
         env:
           DOCKER_HOST: npipe:////./pipe/docker_engine
       -
@@ -479,19 +469,6 @@ jobs:
           & "${{ env.BIN_OUT }}\docker" info
         env:
           DOCKER_HOST: npipe:////./pipe/docker_engine
-      -
-        name: Stop containerd
-        if: always() && matrix.runtime == 'containerd'
-        run: |
-          $ErrorActionPreference = "SilentlyContinue"
-          Stop-Service -Force -Name containerd
-          $ErrorActionPreference = "Stop"
-      -
-        name: Containerd logs
-        if: always() && matrix.runtime == 'containerd'
-        run: |
-          Copy-Item "$env:TEMP\ctn.log" -Destination ".\bundles\containerd.log"
-          Get-Content "$env:TEMP\ctn.log" | Out-Host
       -
         name: Stop daemon
         if: always()

--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -11,10 +11,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/containerd/log"
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/daemon/config"
-	"github.com/docker/docker/libcontainerd/supervisor"
 	"github.com/docker/docker/libnetwork/portallocator"
 	"github.com/docker/docker/pkg/homedir"
 	"github.com/pkg/errors"
@@ -122,28 +120,5 @@ func (cli *daemonCLI) initContainerd(ctx context.Context) (func(time.Duration) e
 		return nil, nil
 	}
 
-	systemContainerdAddr, ok, err := systemContainerdRunning(honorXDG)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not determine whether the system containerd is running")
-	}
-	if ok {
-		// detected a system containerd at the given address.
-		cli.ContainerdAddr = systemContainerdAddr
-		return nil, nil
-	}
-
-	log.G(ctx).Info("containerd not running, starting managed containerd")
-	opts, err := cli.getContainerdDaemonOpts()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate containerd options")
-	}
-
-	r, err := supervisor.Start(ctx, filepath.Join(cli.Root, "containerd"), filepath.Join(cli.ExecRoot, "containerd"), opts...)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to start containerd")
-	}
-	cli.ContainerdAddr = r.Address()
-
-	// Try to wait for containerd to shutdown
-	return r.WaitTimeout, nil
+	return cli.initializeContainerd(ctx)
 }

--- a/cmd/dockerd/daemon_windows.go
+++ b/cmd/dockerd/daemon_windows.go
@@ -100,9 +100,18 @@ func newCgroupParent(config *config.Config) string {
 	return ""
 }
 
-func (cli *daemonCLI) initContainerd(_ context.Context) (func(time.Duration) error, error) {
-	system.InitContainerdRuntime(cli.ContainerdAddr)
-	return nil, nil
+func (cli *daemonCLI) initContainerd(ctx context.Context) (func(time.Duration) error, error) {
+	defer func() { system.EnableContainerdRuntime(cli.ContainerdAddr) }()
+
+	if cli.ContainerdAddr != "" {
+		return nil, nil
+	}
+
+	if cli.DefaultRuntime != config.WindowsV2RuntimeName {
+		return nil, nil
+	}
+
+	return cli.initializeContainerd(ctx)
 }
 
 func validateCPURealtimeOptions(_ *config.Config) error {

--- a/daemon/config/config_windows.go
+++ b/daemon/config/config_windows.go
@@ -13,7 +13,15 @@ const (
 	// default value. On Windows keep this empty so the value is auto-detected
 	// based on other options.
 	StockRuntimeName = ""
+
+	WindowsV1RuntimeName = "com.docker.hcsshim.v1"
+	WindowsV2RuntimeName = "io.containerd.runhcs.v1"
 )
+
+var builtinRuntimes = map[string]bool{
+	WindowsV1RuntimeName: true,
+	WindowsV2RuntimeName: true,
+}
 
 // BridgeConfig is meant to store all the parameters for both the bridge driver and the default bridge network. On
 // Windows: 1. "bridge" in this context reference the nat driver and the default nat network; 2. the nat driver has no

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -40,9 +40,6 @@ const (
 	windowsMaxCPUShares  = 10000
 	windowsMinCPUPercent = 1
 	windowsMaxCPUPercent = 100
-
-	windowsV1RuntimeName = "com.docker.hcsshim.v1"
-	windowsV2RuntimeName = "io.containerd.runhcs.v1"
 )
 
 // Windows containers are much larger than Linux containers and each of them
@@ -563,14 +560,14 @@ func (daemon *Daemon) initLibcontainerd(ctx context.Context, cfg *config.Config)
 	rt := cfg.DefaultRuntime
 	if rt == "" {
 		if cfg.ContainerdAddr == "" {
-			rt = windowsV1RuntimeName
+			rt = config.WindowsV1RuntimeName
 		} else {
-			rt = windowsV2RuntimeName
+			rt = config.WindowsV2RuntimeName
 		}
 	}
 
 	switch rt {
-	case windowsV1RuntimeName:
+	case config.WindowsV1RuntimeName:
 		daemon.containerd, err = local.NewClient(
 			ctx,
 			daemon.containerdClient,
@@ -578,7 +575,7 @@ func (daemon *Daemon) initLibcontainerd(ctx context.Context, cfg *config.Config)
 			cfg.ContainerdNamespace,
 			daemon,
 		)
-	case windowsV2RuntimeName:
+	case config.WindowsV2RuntimeName:
 		if cfg.ContainerdAddr == "" {
 			return fmt.Errorf("cannot use the specified runtime %q without containerd", rt)
 		}

--- a/daemon/start_windows.go
+++ b/daemon/start_windows.go
@@ -3,13 +3,14 @@ package daemon // import "github.com/docker/docker/daemon"
 import (
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/pkg/system"
 )
 
 func (daemon *Daemon) getLibcontainerdCreateOptions(*configStore, *container.Container) (string, interface{}, error) {
 	if system.ContainerdRuntimeSupported() {
 		opts := &options.Options{}
-		return "io.containerd.runhcs.v1", opts, nil
+		return config.WindowsV2RuntimeName, opts, nil
 	}
 	return "", nil, nil
 }

--- a/libcontainerd/supervisor/remote_daemon_linux.go
+++ b/libcontainerd/supervisor/remote_daemon_linux.go
@@ -10,6 +10,7 @@ import (
 )
 
 const (
+	binaryName    = "containerd"
 	sockFile      = "containerd.sock"
 	debugSockFile = "containerd-debug.sock"
 )

--- a/libcontainerd/supervisor/remote_daemon_options.go
+++ b/libcontainerd/supervisor/remote_daemon_options.go
@@ -1,7 +1,11 @@
 package supervisor // import "github.com/docker/docker/libcontainerd/supervisor"
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/containerd/log"
+	"github.com/pkg/errors"
 )
 
 // WithLogLevel defines which log level to start containerd with.
@@ -30,6 +34,34 @@ func WithLogFormat(format log.OutputFormat) DaemonOpt {
 func WithCRIDisabled() DaemonOpt {
 	return func(r *remote) error {
 		r.DisabledPlugins = append(r.DisabledPlugins, "io.containerd.grpc.v1.cri")
+		return nil
+	}
+}
+
+// WithDetectLocalBinary checks if a containerd binary is present in the same
+// directory as the dockerd binary, and overrides the path of the containerd
+// binary to start if found. If no binary is found, no changes are made.
+func WithDetectLocalBinary() DaemonOpt {
+	return func(r *remote) error {
+		dockerdPath, err := os.Executable()
+		if err != nil {
+			return errors.Wrap(err, "looking up binary path")
+		}
+
+		localBinary := filepath.Join(filepath.Dir(dockerdPath), binaryName)
+		fi, err := os.Stat(localBinary)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return err
+			}
+			return nil
+		}
+		if fi.IsDir() {
+			return errors.Errorf("local containerd path found (%s), but is a directory", localBinary)
+		}
+		r.daemonPath = localBinary
+		r.logger.WithField("daemon path", r.daemonPath).Debug("Local containerd daemon found.")
+
 		return nil
 	}
 }

--- a/libcontainerd/supervisor/remote_daemon_windows.go
+++ b/libcontainerd/supervisor/remote_daemon_windows.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	grpcPipeName  = `\\.\pipe\containerd-containerd`
-	debugPipeName = `\\.\pipe\containerd-debug`
+	binaryName    = "containerd.exe"
+	grpcPipeName  = `\\.\pipe\docker-containerd`
+	debugPipeName = `\\.\pipe\docker-containerd-debug`
 )
 
 func defaultGRPCAddress(stateDir string) string {

--- a/pkg/system/init_windows.go
+++ b/pkg/system/init_windows.go
@@ -3,8 +3,8 @@ package system // import "github.com/docker/docker/pkg/system"
 // containerdRuntimeSupported determines if containerd should be the runtime.
 var containerdRuntimeSupported = false
 
-// InitContainerdRuntime sets whether to use containerd for runtime on Windows.
-func InitContainerdRuntime(cdPath string) {
+// EnableContainerdRuntime sets whether to use containerd for runtime on Windows.
+func EnableContainerdRuntime(cdPath string) {
 	if len(cdPath) > 0 {
 		containerdRuntimeSupported = true
 	}


### PR DESCRIPTION
- supersedes / closes https://github.com/moby/moby/pull/43893
- supersedes / closes https://github.com/moby/moby/pull/43951


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Related to pull request: #43893. 

A continuation of #42089, enabling users to switch runtime to `containerd` simply by adding

```
{
  "default-runtime": "io.containerd.runhcs.v1"
}
```
to the `daemon.config` file, without the need to separately install or configure containerd.

**- How I did it**
Copied logic from Linux implementation and updated. In additionally used non-default named pipe so it is possible to that both Docker with containerd and separate containerd instance on same machine.

**- How to verify it**
CI was modified on way that it run Windows 2019 + containerd tests like before and Windows 2022 + containerd tests using this new approach.

Additionally manual tests can be done by

1. Add containerd binaries to same folder with Docker binaries.
2. Add daemon.json configuration
3. Start with `dockerd.exe -D` and check that you see `starting managed containerd` message.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Windows: add support for running containerd as a child process of the daemon, instead of using a system-installed containerd.
```

**- A picture of a cute animal (not mandatory but encouraged)**

