### PR TITLE
Dev container: try to load kernel module ip6_tables

### DIFF
--- a/hack/make/run
+++ b/hack/make/run
@@ -91,6 +91,19 @@ if [ -n "$DOCKER_ROOTLESS" ]; then
 	)
 fi
 
+# On a host using nftables, the ip6_tables kernel module may need to be loaded.
+# This trick is borrowed from the docker (dind) official image ...
+# "modprobe" without modprobe
+#   https://twitter.com/lucabruno/status/902934379835662336
+# This isn't 100% fool-proof, but it'll have a much higher success rate than
+# simply using the "real" modprobe (which isn't installed in the dev container).
+if ! ip6tables -nL > /dev/null 2>&1; then
+	ip link show ip6_tables > /dev/null 2>&1 || true
+	if ! ip6tables -nL > /dev/null 2>&1; then
+		echo >&2 'ip6tables is not available'
+	fi
+fi
+
 set -x
 # shellcheck disable=SC2086
 exec "${dockerd[@]}" "${args[@]}"


### PR DESCRIPTION
**- What I did**

On an nftables host, the `ip6_tables` kernel module may not be loaded, but it needs to be for dockerd to run (with `ip6tables` now enabled by default).

Related to:
- https://github.com/moby/moby/issues/47895
- https://github.com/moby/moby/pull/47918

**- How I did it**

If `ip6tables` doesn't work, try the dind official image's trick for loading the module using `ip link show`.

**- How to verify it**

On a Debian 12.5 host, with nftables - dockerd starts in a dev container without this fix (following https://github.com/moby/moby/pull/47918), but it's not possible to create a `--ipv6` network. This change sorts it out.

In a dev container on MacOS, it doesn't do anything (as expected).

**- Description for the changelog**
```markdown changelog

```
