### PR TITLE
client: Make version negotiation thread-safe

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -49,6 +49,8 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/docker/docker/api"
@@ -131,7 +133,10 @@ type Client struct {
 	negotiateVersion bool
 
 	// negotiated indicates that API version negotiation took place
-	negotiated bool
+	negotiated atomic.Bool
+
+	// negotiateLock is used to single-flight the version negotiation process
+	negotiateLock sync.Mutex
 
 	tp trace.TracerProvider
 
@@ -266,7 +271,16 @@ func (cli *Client) Close() error {
 // be negotiated when making the actual requests, and for which cases
 // we cannot do the negotiation lazily.
 func (cli *Client) checkVersion(ctx context.Context) error {
-	if !cli.manualOverride && cli.negotiateVersion && !cli.negotiated {
+	if !cli.manualOverride && cli.negotiateVersion && !cli.negotiated.Load() {
+		// Ensure exclusive write access to version and negotiated fields
+		cli.negotiateLock.Lock()
+		defer cli.negotiateLock.Unlock()
+
+		// May have been set during last execution of critical zone
+		if cli.negotiated.Load() {
+			return nil
+		}
+
 		ping, err := cli.Ping(ctx)
 		if err != nil {
 			return err
@@ -312,6 +326,10 @@ func (cli *Client) ClientVersion() string {
 // added (1.24).
 func (cli *Client) NegotiateAPIVersion(ctx context.Context) {
 	if !cli.manualOverride {
+		// Avoid concurrent modification of version-related fields
+		cli.negotiateLock.Lock()
+		defer cli.negotiateLock.Unlock()
+
 		ping, err := cli.Ping(ctx)
 		if err != nil {
 			// FIXME(thaJeztah): Ping returns an error when failing to connect to the API; we should not swallow the error here, and instead returning it.
@@ -336,6 +354,10 @@ func (cli *Client) NegotiateAPIVersion(ctx context.Context) {
 // added (1.24).
 func (cli *Client) NegotiateAPIVersionPing(pingResponse types.Ping) {
 	if !cli.manualOverride {
+		// Avoid concurrent modification of version-related fields
+		cli.negotiateLock.Lock()
+		defer cli.negotiateLock.Unlock()
+
 		cli.negotiateAPIVersionPing(pingResponse)
 	}
 }
@@ -361,7 +383,7 @@ func (cli *Client) negotiateAPIVersionPing(pingResponse types.Ping) {
 	// Store the results, so that automatic API version negotiation (if enabled)
 	// won't be performed on the next request.
 	if cli.negotiateVersion {
-		cli.negotiated = true
+		cli.negotiated.Store(true)
 	}
 }
 


### PR DESCRIPTION
* Fixes #43729
* Closes #42379

**- What I did**
Currently, `*client.Client` is not safe for concurrent use due to a data race in the version negotiator.

This has been a known issue for three years, and there have been multiple attempts to fix this. I have reviewed the relevant PRs and their discussions and attempt to address the issues the reviewers brought up. 
* #42379: stops the Go race detector from triggering, but will still attempt to negotiate API version multiple times (i.e., doesn't solve the logical data race)
* #43738: had a very large blast area and is very hard to test/review

The key differences are that this PR attempts to maintain very minimal footprint and it **ensures that `NegotiateAPIVersion` is called exactly once**, except in two circumstances:
* when the previous attempt failed
* when manually triggered by the user

**- How I did it**
I introduce `cli.negotiateLock`, a `sync.Mutex` to single-flight the version negotiation process. Additionally, `atomic.Bool` is used to protect the `cli.negotiated` field from data races. This approach ensures synchronisation is only required before negotiation completes.

**- How to verify it**
Minimal working example, which fails before this PR and now passes (call with `go run -race main.go`):
```go
package main

import (
  "context"
  "github.com/docker/docker/api/types/container"
  "github.com/docker/docker/client"
  "sync"
)

func main() {
  var wg sync.WaitGroup
  
  ctx := context.Background()
  cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
  if err != nil {
    panic(err)
  }
  
  for i := 0; i < 2; i++ {
    wg.Add(1)
    go func() {
      defer wg.Done()
      _, err := cli.ContainerCreate(
        ctx,
        &container.Config{
	        Image: "hello-world",
        },
        &container.HostConfig{
	        RestartPolicy: container.RestartPolicy{Name: "no"},
      }, nil, nil, "")
      
      if err != nil {
      panic(err)
      }
    }()
  }
  
  wg.Wait()
  println("success")
}
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
`*client.Client` instances are now always safe for concurrent use by multiple goroutines. Previously, this could lead to data races when the `WithAPIVersionNegotiation()` option is used.
```

**- A picture of a cute animal (not mandatory but encouraged)**

Meet Bailey (in a jacket)!

![IMG_3236](https://github.com/moby/moby/assets/10295671/7c014539-f9a7-416b-80cc-30cb54152194)

**EDIT (2024-06-13):** Update description to match final, approved version of PR; provide stronger concurrency guarantee following review of #43738 + thorough testing