### PR TITLE
Remove env-var that allowed startup with IPv6 enabled on an IPv4 interface

### DIFF
--- a/integration/networking/bridge_test.go
+++ b/integration/networking/bridge_test.go
@@ -813,8 +813,7 @@ func TestSetInterfaceSysctl(t *testing.T) {
 
 // With a read-only "/proc/sys/net" filesystem (simulated using env var
 // DOCKER_TEST_RO_DISABLE_IPV6), check that if IPv6 can't be disabled on a
-// container interface, container creation fails - unless the error is ignored by
-// setting env var DOCKER_ALLOW_IPV6_ON_IPV4_INTERFACE=1.
+// container interface, container creation fails.
 // Regression test for https://github.com/moby/moby/issues/47751
 func TestReadOnlySlashProc(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
@@ -830,18 +829,11 @@ func TestReadOnlySlashProc(t *testing.T) {
 			name: "Normality",
 		},
 		{
-			name: "Read only no workaround",
+			name: "Read only",
 			daemonEnv: []string{
 				"DOCKER_TEST_RO_DISABLE_IPV6=1",
 			},
-			expErr: "failed to disable IPv6 on container's interface eth0, set env var DOCKER_ALLOW_IPV6_ON_IPV4_INTERFACE=1 to ignore this error",
-		},
-		{
-			name: "Read only with workaround",
-			daemonEnv: []string{
-				"DOCKER_TEST_RO_DISABLE_IPV6=1",
-				"DOCKER_ALLOW_IPV6_ON_IPV4_INTERFACE=1",
-			},
+			expErr: "failed to disable IPv6 on container's interface eth0",
 		},
 	}
 

--- a/libnetwork/osl/namespace_linux.go
+++ b/libnetwork/osl/namespace_linux.go
@@ -635,14 +635,9 @@ func setIPv6(nspath, iface string, enable bool) error {
 			}
 		}()
 
-		var (
-			action = "disable"
-			value  = byte('1')
-			path   = fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/disable_ipv6", iface)
-		)
-
+		path := "/proc/sys/net/ipv6/conf/" + iface + "/disable_ipv6"
+		value := byte('1')
 		if enable {
-			action = "enable"
 			value = '0'
 		}
 
@@ -673,9 +668,7 @@ func setIPv6(nspath, iface string, enable bool) error {
 				logger.Warn("Cannot enable IPv6 on container interface, continuing.")
 			} else {
 				logger.Error("Cannot disable IPv6 on container interface.")
-				errCh <- fmt.Errorf(
-					"failed to %s IPv6 on container's interface %s",
-					action, iface)
+				errCh <- errors.New("failed to disable IPv6 on container's interface " + iface)
 			}
 			return
 		}

--- a/libnetwork/osl/namespace_linux.go
+++ b/libnetwork/osl/namespace_linux.go
@@ -671,20 +671,10 @@ func setIPv6(nspath, iface string, enable bool) error {
 				// The user asked for IPv6 on the interface, and we can't give it to them.
 				// But, in line with the IsNotExist case above, just log.
 				logger.Warn("Cannot enable IPv6 on container interface, continuing.")
-			} else if os.Getenv("DOCKER_ALLOW_IPV6_ON_IPV4_INTERFACE") == "1" {
-				// TODO(robmry) - remove this escape hatch for https://github.com/moby/moby/issues/47751
-				//   If the "/proc" file exists but isn't writable, we can't disable IPv6, which is
-				//   https://github.com/moby/moby/security/advisories/GHSA-x84c-p2g9-rqv9 ... so,
-				//   the user is required to override the error (or configure IPv6, or disable IPv6
-				//   by default in the OS, or make the "/proc" file writable). Once it's possible
-				//   to enable IPv6 without having to configure IPAM etc, the env var should be
-				//   removed. Then the user will have to explicitly enable IPv6 if it can't be
-				//   disabled on the interface.
-				logger.Info("Cannot disable IPv6 on container interface but DOCKER_ALLOW_IPV6_ON_IPV4_INTERFACE=1, continuing.")
 			} else {
-				logger.Error("Cannot disable IPv6 on container interface. Set env var DOCKER_ALLOW_IPV6_ON_IPV4_INTERFACE=1 to ignore.")
+				logger.Error("Cannot disable IPv6 on container interface.")
 				errCh <- fmt.Errorf(
-					"failed to %s IPv6 on container's interface %s, set env var DOCKER_ALLOW_IPV6_ON_IPV4_INTERFACE=1 to ignore this error",
+					"failed to %s IPv6 on container's interface %s",
 					action, iface)
 			}
 			return


### PR DESCRIPTION
**- What I did**

Remove the option to ignore failure to disable ipv6

- Closes https://github.com/moby/moby/issues/47773

26.1.1 added env var DOCKER_ALLOW_IPV6_ON_IPV4_INTERFACE to make it possible to create an IPv4-only network, even with a read-only "/proc/sys/net" that meant IPv6 could not be disabled on an interface.

In 27.0 it's easier to enable IPv6, just '--ipv6' when creating the network - in particular, there's no need to allocate a subnet, because a unique-local prefix will be assigned by default).

This change removes the env-var workaround. Now, the workarounds are to enable IPv6, mount "/proc/sys/net" read-write, disable IPv6 by default in OS configuration, or remove support for IPv6 from the kernel.

(Second commit, some code tidying.)

**- How I did it**

Partially un-did https://github.com/moby/moby/pull/47769.

**- How to verify it**

Updated test.

**- Description for the changelog**
```markdown changelog
Environment variable `DOCKER_ALLOW_IPV6_ON_IPV4_INTERFACE`, introduced in release
26.1.1, no longer has any effect. If IPv6 could not be disabled on an interface because of a
read-only `/proc/sys/net`, the environment variable allowed the container to start anyway.
IPv6 can now be explicitly enabled simply by using `--ipv6` when creating the network, it
is no longer necessary to allocate a subnet as a unique-local prefix will be selected by
default. Other workarounds are to configure the OS to disable IPv6 by default on new
interfaces, mount `/proc/sys/net` read-write, or use a kernel with no IPv6 support.
```

**- A picture of a cute animal (not mandatory but encouraged)**

