### PR TITLE
Load image blobs directly from the original location if loading locally

### DIFF
--- a/image/tarexport/load.go
+++ b/image/tarexport/load.go
@@ -79,6 +79,7 @@ func (l *tarexporter) Load(ctx context.Context, inTar io.ReadCloser, outStream i
 	var parentLinks []parentLink
 	var imageIDsStr string
 	var imageRefCount int
+	var safePathRoot string
 
 	for _, m := range manifest {
 		select {
@@ -86,7 +87,12 @@ func (l *tarexporter) Load(ctx context.Context, inTar io.ReadCloser, outStream i
 			return ctx.Err()
 		default:
 		}
-		configPath, err := safePath(tmpDir, m.Config)
+		if len(m.LayersRoot) == 0 {
+			safePathRoot = tmpDir
+		} else {
+			safePathRoot = m.LayersRoot
+		}
+		configPath, err := safePath(safePathRoot, m.Config)
 		if err != nil {
 			return err
 		}
@@ -114,7 +120,7 @@ func (l *tarexporter) Load(ctx context.Context, inTar io.ReadCloser, outStream i
 				return ctx.Err()
 			default:
 			}
-			layerPath, err := safePath(tmpDir, m.Layers[i])
+			layerPath, err := safePath(safePathRoot, m.Layers[i])
 			if err != nil {
 				return err
 			}

--- a/image/tarexport/tarexport.go
+++ b/image/tarexport/tarexport.go
@@ -21,6 +21,7 @@ type manifestItem struct {
 	Layers       []string
 	Parent       image.ID                                 `json:",omitempty"`
 	LayerSources map[layer.DiffID]distribution.Descriptor `json:",omitempty"`
+	LayersRoot   string                                   `json:",omitempty"`
 }
 
 type tarexporter struct {


### PR DESCRIPTION
The change aims at [this optimization request](https://github.com/moby/moby/issues/47968).

This change optimizes the image loading process by avoiding unnecessary copying of blobs when the data is already available on the local filesystem. By directly reading the blobs from their original location, this enhancement speeds up local load operations and reduces resource utilization, including storage, CPU, and memory.

These improvements are especially beneficial for IoT and Edge devices, where resources are often limited. This optimization not only enhances performance but also ensures more efficient use of system resources on constrained devices.

This implementation introduces an additional optional field in the image loading manifest, enabling the specification of a root path for image blobs. When this field is provided, the tar exporter reads blobs directly from the specified location as defined in the manifest. If this field is not included, the exporter defaults to the current approach of reading blobs from the standard temporary directory where transferred blobs are stored.

The following is the enhancement usage example.

Save and extract image in `<work-dir>`.
```
mkdir saved-nginx-image
docker save nginx | tar -x -C saved-nginx-image
```

Add the new field `LayersRoot` to the manifest, pointing to the root directory where the image blobs are located: `<work-dir>/saved-nginx-image`.
```
cat manifest.json
[
  {
    "Config": "blobs/sha256/4f67c83422ec747235357c04556616234e66fc3fa39cb4f40b2d4441ddd8f100",
    "RepoTags": [
      "nginx:latest"
    ],
    "Layers": [
      "blobs/sha256/5d4427064ecc46e3c2add169e9b5eafc7ed2be7861081ec925938ab628ac0e25",
      "blobs/sha256/37719940dcaace7525f183d8dc1ced6e2333a2d0964f8d97ccf7cdc62aeecd4c",
      "blobs/sha256/d58e4a0f297121f6c82ec173996032d600de3a0006c3b5eee616a3e9a7585093",
      "blobs/sha256/10988c108f666810d4694f8aeb609e67e99164a3ce4b2d7c18f33094ac7f8c7f",
      "blobs/sha256/7da4ba4a003036f21f1f0ccd90b72a1beae5ab81c7c579bc786521ab78baa146",
      "blobs/sha256/261a5dc153b432bd319cae43533f15a558027fb642b40af43cb6763ee9938574",
      "blobs/sha256/3f6a3d22b9cebf3cf38e7b74a7da7c2b4476a97d0cec78b8db614591d83500c3"
    ],
    "LayersRoot" : "<work-dir>/saved-nginx-image"
  }
]

```

Then archive the amended manifest into a tarball and upload it to the `images/load` endpoint.
```
tar -cf load-manifest.tar manifest.json

curl -X POST -H "content-type: application/x-tar" --unix-socket /run/user/1000/docker.sock http://localhost/images/load --data-binary @load-manifest.tar
{"stream":"Loaded image: nginx:latest\n"}
```

As a result, the image blobs were NOT transferred through the `POST /images/load` request and temporarily stored in the Docker temporary directory before their extraction and injection into the Docker store.
Instead, blobs are read directly from the original location specified in the `LayersRoot` field of the manifest.