### PR TITLE
hack/vendor.sh: remove redundant  -compat 1.18

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -10,7 +10,7 @@ SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 tidy() (
 		set -x
-		"${SCRIPTDIR}"/with-go-mod.sh go mod tidy -modfile vendor.mod -compat 1.18
+		"${SCRIPTDIR}"/with-go-mod.sh go mod tidy -modfile vendor.mod
 )
 
 vendor() (


### PR DESCRIPTION
This was added to use a specific format for the vendor.mod/go.mod file, but we should no longer need this, as go1.21 is now the minimum.

**- A picture of a cute animal (not mandatory but encouraged)**

