### PR TITLE
Add option com.docker.network.bridge.host_binding_ip

### DIFF
--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -279,6 +279,15 @@ func (c *networkConfiguration) Conflicts(o *networkConfiguration) error {
 }
 
 func (c *networkConfiguration) fromLabels(labels map[string]string) error {
+	// DefaultBindingIPv4 is a synonym for DefaultBindingIP. Don't
+	// allow both to be specified.
+	if _, ok := labels[DefaultBindingIPv4]; ok {
+		if _, ok := labels[DefaultBindingIP]; ok {
+			return errdefs.InvalidParameter(errors.New(
+				DefaultBindingIPv4 + " is a synonym for " + DefaultBindingIP + ", use one or the other"))
+		}
+	}
+
 	var err error
 	for label, value := range labels {
 		switch label {
@@ -317,6 +326,10 @@ func (c *networkConfiguration) fromLabels(labels map[string]string) error {
 				return parseErr(label, value, err.Error())
 			}
 		case DefaultBindingIP:
+			if c.DefaultBindingIP = net.ParseIP(value); c.DefaultBindingIP == nil {
+				return parseErr(label, value, "nil ip")
+			}
+		case DefaultBindingIPv4:
 			if c.DefaultBindingIP = net.ParseIP(value); c.DefaultBindingIP == nil {
 				return parseErr(label, value, "nil ip")
 			}

--- a/libnetwork/drivers/bridge/labels.go
+++ b/libnetwork/drivers/bridge/labels.go
@@ -19,7 +19,13 @@ const (
 	InhibitIPv4 = "com.docker.network.bridge.inhibit_ipv4"
 
 	// DefaultBindingIP label
-	DefaultBindingIP = "com.docker.network.bridge.host_binding_ipv4"
+	DefaultBindingIP = "com.docker.network.bridge.host_binding_ip"
+
+	// DefaultBindingIPv4 label
+	// 'host_binding_ipv4' existed before 'host_binding_ip', despite the name
+	// it accepted IPv6 addresses. The options are now synonyms, and it is an
+	// error to specify both.
+	DefaultBindingIPv4 = "com.docker.network.bridge.host_binding_ipv4"
 
 	// DefaultBridge label
 	DefaultBridge = "com.docker.network.bridge.default_bridge"


### PR DESCRIPTION
**- What I did**

Noticed that existing bridge driver option `com.docker.network.bridge.host_binding_ipv4` accepts IPv6 addresses.

**- How I did it**

Added synonym `com.docker.network.bridge.host_binding_ip` - and made it an error to specify both.

`com.docker.network.bridge.host_binding_ipv4` appears in examples in `swagger.yaml`. Driver options aren't part of the API, and the API isn't changing in release 27.0 ... so the examples need to apply to 26.0 too, I haven't updated them.

I'll follow up this change with a docs PR that makes `com.docker.network.bridge.host_binding_ip` the primary option, and explains that `com.docker.network.bridge.host_binding_ipv4` is a synonym.

**- How to verify it**

Apart from accepting v6 in an option named v4, the existing handling is a bit surprising - `0.0.0.0` means "any v4 or v6 address" but `::` means "any v6 address". So, added an integration test to illustrate that, and to make sure it's not "fixed" in passing.

**- Description for the changelog**
```markdown changelog
Added bridge network driver option `com.docker.network.bridge.host_binding_ip` as a
synonym for `com.docker.network.bridge.host_binding_ipv4`. Both accept an IPv4 or
an IPv6 address. It is an error to specify both options for the same network.
```
