### PR TITLE
builder/builder-next: gofmt

### DIFF
--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -392,7 +392,7 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 	req := &controlapi.SolveRequest{
 		Ref: id,
 		Exporters: []*controlapi.Exporter{
-			&controlapi.Exporter{Type: exporterName, Attrs: exporterAttrs},
+			{Type: exporterName, Attrs: exporterAttrs},
 		},
 		Frontend:      "dockerfile.v0",
 		FrontendAttrs: frontendAttrs,

--- a/builder/builder-next/executor_nolinux.go
+++ b/builder/builder-next/executor_nolinux.go
@@ -22,11 +22,11 @@ func newExecutor(_, _ string, _ *libnetwork.Controller, _ *oci.DNSConfig, _ bool
 type stubExecutor struct{}
 
 func (w *stubExecutor) Run(ctx context.Context, id string, root executor.Mount, mounts []executor.Mount, process executor.ProcessInfo, started chan<- struct{}) (resourcetypes.Recorder, error) {
-	return nil, errors.New("buildkit executor not implemented for "+runtime.GOOS)
+	return nil, errors.New("buildkit executor not implemented for " + runtime.GOOS)
 }
 
 func (w *stubExecutor) Exec(ctx context.Context, id string, process executor.ProcessInfo) error {
-	return errors.New("buildkit executor not implemented for "+runtime.GOOS)
+	return errors.New("buildkit executor not implemented for " + runtime.GOOS)
 }
 
 func getDNSConfig(config.DNSConfig) *oci.DNSConfig {


### PR DESCRIPTION
I noticed that go scorecard showed that we didn't gofmt this; https://goreportcard.com/report/github.com/docker/docker

**- A picture of a cute animal (not mandatory but encouraged)**

