### PR TITLE
cli/debug: move to "cmd/dockerd/debug"

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -36,7 +36,7 @@ import (
 	"github.com/docker/docker/api/server/router/volume"
 	buildkit "github.com/docker/docker/builder/builder-next"
 	"github.com/docker/docker/builder/dockerfile"
-	"github.com/docker/docker/cli/debug"
+	"github.com/docker/docker/cmd/dockerd/debug"
 	"github.com/docker/docker/cmd/dockerd/trap"
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/daemon/cluster"

--- a/cmd/dockerd/debug/debug.go
+++ b/cmd/dockerd/debug/debug.go
@@ -1,4 +1,4 @@
-package debug // import "github.com/docker/docker/cli/debug"
+package debug // import "github.com/docker/docker/cmd/dockerd/debug"
 
 import (
 	"os"

--- a/cmd/dockerd/debug/debug_test.go
+++ b/cmd/dockerd/debug/debug_test.go
@@ -1,4 +1,4 @@
-package debug // import "github.com/docker/docker/cli/debug"
+package debug // import "github.com/docker/docker/cmd/dockerd/debug"
 
 import (
 	"os"

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -16,7 +16,7 @@ import (
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/system"
-	"github.com/docker/docker/cli/debug"
+	"github.com/docker/docker/cmd/dockerd/debug"
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/dockerversion"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**Description**
The "cli/debug" package is a leftover from when the "docker" and "dockerd" cli were both maintained in this repository, and finding a more appropriate home for it has been a roadmap task since "docker/cli" was moved to its own repo – see #44641.

Currently, the primary user is "cmd/dockerd". Accordingly, I made it a subpackage of "cmd/dockerd" – "cmd/dockerd/debug".
In particular, I tried to match styles with "cmd/dockerd/trap", the other subpackage of "cmd/dockerd". Both packages are also imported by the "daemon" package.

Since it's binary-related and not library code, this shouldn't impact any external packages ([all known importers on pkg.go.dev are moby forks](https://pkg.go.dev/github.com/docker/docker@v27.0.0+incompatible/cli/debug?tab=importedby)).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Move the cli/debug package to cmd/dockerd/debug
```

**- A picture of a cute animal (not mandatory but encouraged)**

It's Juicy's world, we're just living in it.
![PHOTO-2022-09-23-16-00-10](https://github.com/moby/moby/assets/10295671/a0206dec-f62f-45e3-8032-ed4237cb28b0)
