### PR TITLE
Remove completed projects from ROADMAP.md

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,63 +33,7 @@ issue, in the Slack channel, or in person at the Moby Summits that happen every 
 
 # 1. Features and refactoring
 
-## 1.1 Runtime improvements
-
-Over time we have accumulated a lot of functionality in the container runtime
-aspect of Moby while also growing in other areas. Much of the container runtime
-pieces are now duplicated work available in other, lower level components such
-as [containerd](https://containerd.io).
-
-Moby currently only utilizes containerd for basic runtime state management, e.g. starting
-and stopping a container, which is what the pre-containerd 1.0 daemon provided.
-Now that containerd is a full-fledged container runtime which supports full
-container life-cycle management, we would like to start relying more on containerd
-and removing the bits in Moby which are now duplicated. This will necessitate
-a significant effort to refactor and even remove large parts of Moby's codebase.
-
-Tracking issues:
-
-- [#38043](https://github.com/moby/moby/issues/38043) Proposal: containerd image integration
-
-## 1.2 Image Builder
-
-Work is ongoing to integrate [BuildKit](https://github.com/moby/buildkit) into
-Moby and replace the "v0" build implementation. Buildkit offers better cache
-management, parallelizable build steps, and better extensibility while also
-keeping builds portable, a chief tenent of Moby's builder.
-
-Upon completion of this effort, users will have a builder that performs better
-while also being more extensible, enabling users to provide their own custom
-syntax which can be either Dockerfile-like or something completely different.
-
-See [buildpacks on buildkit](https://github.com/tonistiigi/buildkit-pack) as an
-example of this extensibility.
-
-New features for the builder and Dockerfile should be implemented first in the
-BuildKit backend using an external Dockerfile implementation from the container
-images. This allows everyone to test and evaluate the feature without upgrading
-their daemon. New features should go to the experimental channel first, and can be
-part of the `docker/dockerfile:experimental` image. From there they graduate to
-`docker/dockerfile:latest` and binary releases. The Dockerfile frontend source
-code is temporarily located at
-[https://github.com/moby/buildkit/tree/master/frontend/dockerfile](https://github.com/moby/buildkit/tree/master/frontend/dockerfile)
-with separate new features defined with go build tags.
-
-Tracking issues:
-
-- [#32925](https://github.com/moby/moby/issues/32925) discussion: builder future: buildkit
-
-## 1.3 Rootless Mode
-
-Running the daemon requires elevated privileges for many tasks. We would like to
-support running the daemon as a normal, unprivileged user without requiring `suid`
-binaries.
-
-Tracking issues:
-
-- [#37375](https://github.com/moby/moby/issues/37375) Proposal: allow running `dockerd` as an unprivileged user (aka rootless mode)
-
-## 1.4 Testing
+## 1.1 Testing
 
 Moby has many tests, both unit and integration. Moby needs more tests which can
 cover the full spectrum functionality and edge cases out there.
@@ -103,15 +47,8 @@ Tracking issues:
 
 - [#32866](https://github.com/moby/moby/issues/32866) Replace integration-cli suite with API test suite
 
-## 1.5 Internal decoupling
+## 1.2 Internal decoupling
 
-A lot of work has been done in trying to decouple Moby internals. This process of creating
-standalone projects with a well defined function that attract a dedicated community should continue.
-As well as integrating `containerd` we would like to integrate [BuildKit](https://github.com/moby/buildkit)
-as the next standalone component.
-We see gRPC as the natural communication layer between decoupled components.
-
-In addition to pushing out large components into other projects, much of the
-internal code structure, and in particular the
+Much of the internal code structure, and in particular the
 ["Daemon"](https://godoc.org/github.com/docker/docker/daemon#Daemon) object,
 should be split into smaller, more manageable, and more testable components.


### PR DESCRIPTION
**Description**

As a new contributor, I was looking into more projects I might want to work on and tried to use `ROADMAP.md` as a resource, when I realized that doc is roughly 7 years out-of-date and most listed features have already been implemented.

This PR removes all completed projects from the list, but given that I'm not a maintainer I'm obviously not aware what the current roadmap is / what should be added to it. At the very least, completed projects should be removed since this is a very easy way to get confused / waste time as a new contributor.

Given that it seems there's no appetite to maintain it, we may also want to consider scrapping the `Features and refactoring` section of the roadmap altogether.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Remove completed projects from roadmap
```

**- A picture of a cute animal (not mandatory but encouraged)**

Fun fact: monkeys enjoy eating chips just as much as we do.
![IMG_77D033907AD7-1](https://github.com/moby/moby/assets/10295671/c8291bb7-8389-4c37-b9fd-ee3748941845)
