### PR TITLE
Make log reading more robust to errors

### DIFF
--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -141,7 +141,7 @@ func (daemon *Daemon) containerAttach(c *container.Container, cfg *stream.Attach
 		if !ok {
 			return logger.ErrReadLogsNotSupported{}
 		}
-		logs := cLog.ReadLogs(logger.ReadConfig{Tail: -1})
+		logs := cLog.ReadLogs(context.TODO(), logger.ReadConfig{Tail: -1})
 		defer logs.ConsumerGone()
 
 	LogLoop:

--- a/daemon/logger/adapter_test.go
+++ b/daemon/logger/adapter_test.go
@@ -1,6 +1,7 @@
 package logger // import "github.com/docker/docker/daemon/logger"
 
 import (
+	"context"
 	"encoding/binary"
 	"io"
 	"sync"
@@ -154,7 +155,7 @@ func TestAdapterReadLogs(t *testing.T) {
 	lr, ok := l.(LogReader)
 	assert.Check(t, ok, "Logger does not implement LogReader")
 
-	lw := lr.ReadLogs(ReadConfig{})
+	lw := lr.ReadLogs(context.TODO(), ReadConfig{})
 
 	for _, x := range testMsg {
 		select {
@@ -173,7 +174,7 @@ func TestAdapterReadLogs(t *testing.T) {
 	}
 	lw.ConsumerGone()
 
-	lw = lr.ReadLogs(ReadConfig{Follow: true})
+	lw = lr.ReadLogs(context.TODO(), ReadConfig{Follow: true})
 	for _, x := range testMsg {
 		select {
 		case msg := <-lw.Msg:

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -192,11 +192,20 @@ func (r *reader) initialSeekTail() (bool, error) {
 
 // wait blocks until the journal has new data to read, the reader's drain
 // deadline is exceeded, or the log reading consumer is gone.
-func (r *reader) wait() (bool, error) {
+func (r *reader) wait(ctx context.Context) (bool, error) {
+	deadline := r.drainDeadline
+	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+		deadline = d
+	}
+
 	for {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+
 		dur := waitInterval
-		if !r.drainDeadline.IsZero() {
-			dur = time.Until(r.drainDeadline)
+		if !deadline.IsZero() {
+			dur = time.Until(deadline)
 			if dur < 0 {
 				// Container is gone but we haven't found the end of the
 				// logs before the deadline. Maybe it was dropped by
@@ -215,6 +224,8 @@ func (r *reader) wait() (bool, error) {
 		select {
 		case <-r.logWatcher.WatchConsumerGone():
 			return false, nil
+		case <-ctx.Done():
+			return false, ctx.Err()
 		case <-r.s.closed:
 			// Container is gone; don't wait indefinitely for journal entries that will never arrive.
 			if r.maxOrdinal >= r.s.ordinal.Load() {
@@ -230,12 +241,15 @@ func (r *reader) wait() (bool, error) {
 
 // nextWait blocks until there is a new journal entry to read, and advances the
 // journal read pointer to it.
-func (r *reader) nextWait() (bool, error) {
+func (r *reader) nextWait(ctx context.Context) (bool, error) {
 	for {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
 		if ok, err := r.j.Next(); err != nil || ok {
 			return ok, err
 		}
-		if ok, err := r.wait(); err != nil || !ok {
+		if ok, err := r.wait(ctx); err != nil || !ok {
 			return false, err
 		}
 	}
@@ -249,7 +263,7 @@ func (r *reader) nextWait() (bool, error) {
 //   - the watch consumer is gone, or
 //   - (if until is nonzero) a log entry is read which has a timestamp after
 //     until
-func (r *reader) drainJournal() (bool, error) {
+func (r *reader) drainJournal(ctx context.Context) (bool, error) {
 	for i := 0; ; i++ {
 		// Read the entry's timestamp.
 		timestamp, err := r.j.Realtime()
@@ -299,6 +313,8 @@ func (r *reader) drainJournal() (bool, error) {
 			select {
 			case <-r.logWatcher.WatchConsumerGone():
 				return false, nil
+			case <-ctx.Done():
+				return false, ctx.Err()
 			case r.logWatcher.Msg <- msg:
 			}
 		}
@@ -308,10 +324,14 @@ func (r *reader) drainJournal() (bool, error) {
 		if i != 0 && i%1024 == 0 {
 			if _, err := r.j.Process(); err != nil {
 				// log a warning but ignore it for now
-				log.G(context.TODO()).WithField("container", r.s.vars[fieldContainerIDFull]).
+				log.G(ctx).WithField("container", r.s.vars[fieldContainerIDFull]).
 					WithField("error", err).
 					Warn("journald: error processing journal")
 			}
+		}
+
+		if err := ctx.Err(); err != nil {
+			return false, err
 		}
 
 		if ok, err := r.j.Next(); err != nil || !ok {
@@ -320,9 +340,9 @@ func (r *reader) drainJournal() (bool, error) {
 	}
 }
 
-func (r *reader) readJournal() error {
+func (r *reader) readJournal(ctx context.Context) error {
 	caughtUp := r.s.ordinal.Load()
-	if more, err := r.drainJournal(); err != nil || !more {
+	if more, err := r.drainJournal(ctx); err != nil || !more {
 		return err
 	}
 
@@ -345,10 +365,10 @@ func (r *reader) readJournal() error {
 		default:
 		}
 
-		if more, err := r.nextWait(); err != nil || !more {
+		if more, err := r.nextWait(ctx); err != nil || !more {
 			return err
 		}
-		if more, err := r.drainJournal(); err != nil || !more {
+		if more, err := r.drainJournal(ctx); err != nil || !more {
 			return err
 		}
 		if !r.config.Follow && r.s.readSyncTimeout > 0 && r.maxOrdinal >= caughtUp {
@@ -357,7 +377,7 @@ func (r *reader) readJournal() error {
 	}
 }
 
-func (r *reader) readLogs() {
+func (r *reader) readLogs(ctx context.Context) {
 	defer close(r.logWatcher.Msg)
 
 	// Make sure the ready channel is closed in the event of an early
@@ -427,7 +447,7 @@ func (r *reader) readLogs() {
 		// which case the position will be unaffected by subsequent logging, or
 		// the read pointer is in the conceptual position corresponding to the
 		// first journal entry to send once it is logged in the future.
-		if more, err := r.nextWait(); err != nil || !more {
+		if more, err := r.nextWait(ctx); err != nil || !more {
 			if err != nil {
 				r.logWatcher.Err <- err
 			}
@@ -435,7 +455,7 @@ func (r *reader) readLogs() {
 		}
 	}
 
-	if err := r.readJournal(); err != nil {
+	if err := r.readJournal(ctx); err != nil {
 		r.logWatcher.Err <- err
 		return
 	}
@@ -456,7 +476,7 @@ func (s *journald) ReadLogs(ctx context.Context, config logger.ReadConfig) *logg
 		config:     config,
 		ready:      make(chan struct{}),
 	}
-	go r.readLogs()
+	go r.readLogs(ctx)
 	// Block until the reader is in position to read from the current config
 	// location to prevent race conditions in tests.
 	<-r.ready

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -20,6 +20,8 @@ const (
 	waitInterval       = 250 * time.Millisecond
 )
 
+var _ logger.LogReader = (*journald)(nil)
+
 // Fields which we know are not user-provided attribute fields.
 var wellKnownFields = map[string]bool{
 	"MESSAGE":             true,
@@ -447,7 +449,7 @@ func (r *reader) signalReady() {
 	}
 }
 
-func (s *journald) ReadLogs(config logger.ReadConfig) *logger.LogWatcher {
+func (s *journald) ReadLogs(ctx context.Context, config logger.ReadConfig) *logger.LogWatcher {
 	r := &reader{
 		s:          s,
 		logWatcher: logger.NewLogWatcher(),

--- a/daemon/logger/jsonfilelog/read.go
+++ b/daemon/logger/jsonfilelog/read.go
@@ -12,10 +12,12 @@ import (
 	"github.com/docker/docker/pkg/tailfile"
 )
 
+var _ logger.LogReader = (*JSONFileLogger)(nil)
+
 // ReadLogs implements the logger's LogReader interface for the logs
 // created by this driver.
-func (l *JSONFileLogger) ReadLogs(config logger.ReadConfig) *logger.LogWatcher {
-	return l.writer.ReadLogs(config)
+func (l *JSONFileLogger) ReadLogs(ctx context.Context, config logger.ReadConfig) *logger.LogWatcher {
+	return l.writer.ReadLogs(ctx, config)
 }
 
 func decodeLogLine(dec *json.Decoder, l *jsonlog.JSONLog) (*logger.Message, error) {

--- a/daemon/logger/jsonfilelog/read.go
+++ b/daemon/logger/jsonfilelog/read.go
@@ -79,6 +79,6 @@ func decodeFunc(rdr io.Reader) loggerutils.Decoder {
 	}
 }
 
-func getTailReader(ctx context.Context, r loggerutils.SizeReaderAt, req int) (io.Reader, int, error) {
+func getTailReader(ctx context.Context, r loggerutils.SizeReaderAt, req int) (loggerutils.SizeReaderAt, int, error) {
 	return tailfile.NewTailReader(ctx, r, req)
 }

--- a/daemon/logger/jsonfilelog/read_test.go
+++ b/daemon/logger/jsonfilelog/read_test.go
@@ -3,6 +3,7 @@ package jsonfilelog // import "github.com/docker/docker/daemon/logger/jsonfilelo
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -62,7 +63,7 @@ func BenchmarkJSONFileLoggerReadLogs(b *testing.B) {
 		}
 	}()
 
-	lw := jsonlogger.(*JSONFileLogger).ReadLogs(logger.ReadConfig{Follow: true})
+	lw := jsonlogger.(*JSONFileLogger).ReadLogs(context.TODO(), logger.ReadConfig{Follow: true})
 	for {
 		select {
 		case _, ok := <-lw.Msg:

--- a/daemon/logger/local/read.go
+++ b/daemon/logger/local/read.go
@@ -18,8 +18,8 @@ import (
 // logger.defaultBufSize caps the size of Line field.
 const maxMsgLen int = 1e6 // 1MB.
 
-func (d *driver) ReadLogs(config logger.ReadConfig) *logger.LogWatcher {
-	return d.logfile.ReadLogs(config)
+func (d *driver) ReadLogs(ctx context.Context, config logger.ReadConfig) *logger.LogWatcher {
+	return d.logfile.ReadLogs(ctx, config)
 }
 
 func getTailReader(ctx context.Context, r loggerutils.SizeReaderAt, req int) (loggerutils.SizeReaderAt, int, error) {

--- a/daemon/logger/local/read.go
+++ b/daemon/logger/local/read.go
@@ -22,7 +22,7 @@ func (d *driver) ReadLogs(config logger.ReadConfig) *logger.LogWatcher {
 	return d.logfile.ReadLogs(config)
 }
 
-func getTailReader(ctx context.Context, r loggerutils.SizeReaderAt, req int) (io.Reader, int, error) {
+func getTailReader(ctx context.Context, r loggerutils.SizeReaderAt, req int) (loggerutils.SizeReaderAt, int, error) {
 	size := r.Size()
 	if req < 0 {
 		return nil, 0, errdefs.InvalidParameter(errors.Errorf("invalid number of lines to tail: %d", req))

--- a/daemon/logger/logger.go
+++ b/daemon/logger/logger.go
@@ -8,6 +8,7 @@
 package logger // import "github.com/docker/docker/daemon/logger"
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -88,7 +89,7 @@ type ReadConfig struct {
 // LogReader is the interface for reading log messages for loggers that support reading.
 type LogReader interface {
 	// ReadLogs reads logs from underlying logging backend.
-	ReadLogs(ReadConfig) *LogWatcher
+	ReadLogs(context.Context, ReadConfig) *LogWatcher
 }
 
 // LogWatcher is used when consuming logs read from the LogReader interface.

--- a/daemon/logger/loggertest/logreader.go
+++ b/daemon/logger/loggertest/logreader.go
@@ -1,6 +1,7 @@
 package loggertest // import "github.com/docker/docker/daemon/logger/loggertest"
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 	"strings"
@@ -93,63 +94,63 @@ func (tr Reader) testTail(t *testing.T, live bool) {
 
 	t.Run("Exact", func(t *testing.T) {
 		t.Parallel()
-		lw := lr.ReadLogs(logger.ReadConfig{Tail: len(mm)})
+		lw := lr.ReadLogs(context.TODO(), logger.ReadConfig{Tail: len(mm)})
 		defer lw.ConsumerGone()
 		assert.DeepEqual(t, readAll(t, lw), expected, compareLog)
 	})
 
 	t.Run("LessThanAvailable", func(t *testing.T) {
 		t.Parallel()
-		lw := lr.ReadLogs(logger.ReadConfig{Tail: 2})
+		lw := lr.ReadLogs(context.TODO(), logger.ReadConfig{Tail: 2})
 		defer lw.ConsumerGone()
 		assert.DeepEqual(t, readAll(t, lw), expected[len(mm)-2:], compareLog)
 	})
 
 	t.Run("MoreThanAvailable", func(t *testing.T) {
 		t.Parallel()
-		lw := lr.ReadLogs(logger.ReadConfig{Tail: 100})
+		lw := lr.ReadLogs(context.TODO(), logger.ReadConfig{Tail: 100})
 		defer lw.ConsumerGone()
 		assert.DeepEqual(t, readAll(t, lw), expected, compareLog)
 	})
 
 	t.Run("All", func(t *testing.T) {
 		t.Parallel()
-		lw := lr.ReadLogs(logger.ReadConfig{Tail: -1})
+		lw := lr.ReadLogs(context.TODO(), logger.ReadConfig{Tail: -1})
 		defer lw.ConsumerGone()
 		assert.DeepEqual(t, readAll(t, lw), expected, compareLog)
 	})
 
 	t.Run("Since", func(t *testing.T) {
 		t.Parallel()
-		lw := lr.ReadLogs(logger.ReadConfig{Tail: -1, Since: mm[1].Timestamp.Truncate(time.Millisecond)})
+		lw := lr.ReadLogs(context.TODO(), logger.ReadConfig{Tail: -1, Since: mm[1].Timestamp.Truncate(time.Millisecond)})
 		defer lw.ConsumerGone()
 		assert.DeepEqual(t, readAll(t, lw), expected[1:], compareLog)
 	})
 
 	t.Run("MoreThanSince", func(t *testing.T) {
 		t.Parallel()
-		lw := lr.ReadLogs(logger.ReadConfig{Tail: len(mm), Since: mm[1].Timestamp.Truncate(time.Millisecond)})
+		lw := lr.ReadLogs(context.TODO(), logger.ReadConfig{Tail: len(mm), Since: mm[1].Timestamp.Truncate(time.Millisecond)})
 		defer lw.ConsumerGone()
 		assert.DeepEqual(t, readAll(t, lw), expected[1:], compareLog)
 	})
 
 	t.Run("LessThanSince", func(t *testing.T) {
 		t.Parallel()
-		lw := lr.ReadLogs(logger.ReadConfig{Tail: len(mm) - 2, Since: mm[1].Timestamp.Truncate(time.Millisecond)})
+		lw := lr.ReadLogs(context.TODO(), logger.ReadConfig{Tail: len(mm) - 2, Since: mm[1].Timestamp.Truncate(time.Millisecond)})
 		defer lw.ConsumerGone()
 		assert.DeepEqual(t, readAll(t, lw), expected[2:], compareLog)
 	})
 
 	t.Run("Until", func(t *testing.T) {
 		t.Parallel()
-		lw := lr.ReadLogs(logger.ReadConfig{Tail: -1, Until: mm[2].Timestamp.Add(-time.Millisecond)})
+		lw := lr.ReadLogs(context.TODO(), logger.ReadConfig{Tail: -1, Until: mm[2].Timestamp.Add(-time.Millisecond)})
 		defer lw.ConsumerGone()
 		assert.DeepEqual(t, readAll(t, lw), expected[:2], compareLog)
 	})
 
 	t.Run("SinceAndUntil", func(t *testing.T) {
 		t.Parallel()
-		lw := lr.ReadLogs(logger.ReadConfig{Tail: -1, Since: mm[1].Timestamp.Truncate(time.Millisecond), Until: mm[1].Timestamp.Add(time.Millisecond)})
+		lw := lr.ReadLogs(context.TODO(), logger.ReadConfig{Tail: -1, Since: mm[1].Timestamp.Truncate(time.Millisecond), Until: mm[1].Timestamp.Add(time.Millisecond)})
 		defer lw.ConsumerGone()
 		assert.DeepEqual(t, readAll(t, lw), expected[1:2], compareLog)
 	})
@@ -182,7 +183,7 @@ func (tr Reader) testTailEmptyLogs(t *testing.T, live bool) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			lw := l.(logger.LogReader).ReadLogs(logger.ReadConfig{})
+			lw := l.(logger.LogReader).ReadLogs(context.TODO(), logger.ReadConfig{})
 			defer lw.ConsumerGone()
 			assert.DeepEqual(t, readAll(t, lw), ([]*logger.Message)(nil), cmpopts.EquateEmpty())
 		})
@@ -204,7 +205,7 @@ func (tr Reader) TestFollow(t *testing.T) {
 				ContainerID:   fmt.Sprintf("followstart%d", i),
 				ContainerName: fmt.Sprintf("logloglog%d", i),
 			})(t)
-			lw := l.(logger.LogReader).ReadLogs(logger.ReadConfig{Tail: tail, Follow: true})
+			lw := l.(logger.LogReader).ReadLogs(context.TODO(), logger.ReadConfig{Tail: tail, Follow: true})
 			defer lw.ConsumerGone()
 
 			doneReading := make(chan struct{})
@@ -232,7 +233,7 @@ func (tr Reader) TestFollow(t *testing.T) {
 		mm := makeTestMessages()
 		expected := logMessages(t, l, mm[0:1])
 
-		lw := l.(logger.LogReader).ReadLogs(logger.ReadConfig{Tail: -1, Follow: true})
+		lw := l.(logger.LogReader).ReadLogs(context.TODO(), logger.ReadConfig{Tail: -1, Follow: true})
 		defer lw.ConsumerGone()
 
 		doneReading := make(chan struct{})
@@ -257,7 +258,7 @@ func (tr Reader) TestFollow(t *testing.T) {
 
 		mm := makeTestMessages()
 
-		lw := l.(logger.LogReader).ReadLogs(logger.ReadConfig{Tail: -1, Follow: true, Since: mm[2].Timestamp.Truncate(time.Millisecond)})
+		lw := l.(logger.LogReader).ReadLogs(context.TODO(), logger.ReadConfig{Tail: -1, Follow: true, Since: mm[2].Timestamp.Truncate(time.Millisecond)})
 		defer lw.ConsumerGone()
 
 		doneReading := make(chan struct{})
@@ -282,7 +283,7 @@ func (tr Reader) TestFollow(t *testing.T) {
 
 		mm := makeTestMessages()
 
-		lw := l.(logger.LogReader).ReadLogs(logger.ReadConfig{Tail: -1, Follow: true, Until: mm[2].Timestamp.Add(-time.Millisecond)})
+		lw := l.(logger.LogReader).ReadLogs(context.TODO(), logger.ReadConfig{Tail: -1, Follow: true, Until: mm[2].Timestamp.Add(-time.Millisecond)})
 		defer lw.ConsumerGone()
 
 		doneReading := make(chan struct{})
@@ -307,7 +308,7 @@ func (tr Reader) TestFollow(t *testing.T) {
 
 		mm := makeTestMessages()
 
-		lw := l.(logger.LogReader).ReadLogs(logger.ReadConfig{Tail: -1, Follow: true, Since: mm[1].Timestamp.Add(-time.Millisecond), Until: mm[2].Timestamp.Add(-time.Millisecond)})
+		lw := l.(logger.LogReader).ReadLogs(context.TODO(), logger.ReadConfig{Tail: -1, Follow: true, Since: mm[1].Timestamp.Add(-time.Millisecond), Until: mm[2].Timestamp.Add(-time.Millisecond)})
 		defer lw.ConsumerGone()
 
 		doneReading := make(chan struct{})
@@ -334,7 +335,7 @@ func (tr Reader) TestFollow(t *testing.T) {
 		logMessages(t, l, mm[0:2])
 		syncLogger(t, l)
 
-		lw := l.(logger.LogReader).ReadLogs(logger.ReadConfig{Tail: 0, Follow: true})
+		lw := l.(logger.LogReader).ReadLogs(context.TODO(), logger.ReadConfig{Tail: 0, Follow: true})
 		defer lw.ConsumerGone()
 
 		doneReading := make(chan struct{})
@@ -361,7 +362,7 @@ func (tr Reader) TestFollow(t *testing.T) {
 		expected := logMessages(t, l, mm[0:2])[1:]
 		syncLogger(t, l)
 
-		lw := l.(logger.LogReader).ReadLogs(logger.ReadConfig{Tail: 1, Follow: true})
+		lw := l.(logger.LogReader).ReadLogs(context.TODO(), logger.ReadConfig{Tail: 1, Follow: true})
 		defer lw.ConsumerGone()
 
 		doneReading := make(chan struct{})
@@ -390,7 +391,7 @@ func (tr Reader) TestFollow(t *testing.T) {
 		assert.NilError(t, l.Close())
 
 		l = factory(t)
-		lw := l.(logger.LogReader).ReadLogs(logger.ReadConfig{Tail: -1, Follow: true})
+		lw := l.(logger.LogReader).ReadLogs(context.TODO(), logger.ReadConfig{Tail: -1, Follow: true})
 		defer lw.ConsumerGone()
 
 		doneReading := make(chan struct{})
@@ -430,7 +431,7 @@ func (tr Reader) TestConcurrent(t *testing.T) {
 	}
 
 	// Follow all logs
-	lw := l.(logger.LogReader).ReadLogs(logger.ReadConfig{Follow: true, Tail: -1})
+	lw := l.(logger.LogReader).ReadLogs(context.TODO(), logger.ReadConfig{Follow: true, Tail: -1})
 	defer lw.ConsumerGone()
 
 	// Log concurrently from two sources and close log

--- a/daemon/logger/loggerutils/cache/local_cache.go
+++ b/daemon/logger/loggerutils/cache/local_cache.go
@@ -24,6 +24,8 @@ var builtInCacheLogOpts = map[string]bool{
 	cacheDisabledKey: true,
 }
 
+var _ logger.LogReader = (*loggerWithCache)(nil)
+
 // WithLocalCache wraps the passed in logger with a logger caches all writes locally
 // in addition to writing to the passed in logger.
 func WithLocalCache(l logger.Logger, info logger.Info) (logger.Logger, error) {
@@ -85,8 +87,8 @@ func (l *loggerWithCache) Name() string {
 	return l.l.Name()
 }
 
-func (l *loggerWithCache) ReadLogs(config logger.ReadConfig) *logger.LogWatcher {
-	return l.cache.(logger.LogReader).ReadLogs(config)
+func (l *loggerWithCache) ReadLogs(ctx context.Context, config logger.ReadConfig) *logger.LogWatcher {
+	return l.cache.(logger.LogReader).ReadLogs(ctx, config)
 }
 
 func (l *loggerWithCache) Close() error {

--- a/daemon/logger/loggerutils/follow.go
+++ b/daemon/logger/loggerutils/follow.go
@@ -22,8 +22,8 @@ type follow struct {
 }
 
 // Do follows the log file as it is written, starting from f at read.
-func (fl *follow) Do(f *os.File, read logPos) {
-	fl.log = log.G(context.TODO()).WithFields(log.Fields{
+func (fl *follow) Do(ctx context.Context, f *os.File, read logPos) {
+	fl.log = log.G(ctx).WithFields(log.Fields{
 		"module": "logger",
 		"file":   f.Name(),
 	})
@@ -49,7 +49,7 @@ func (fl *follow) Do(f *os.File, read logPos) {
 				fl.Watcher.Err <- err
 				return
 			}
-			if !fl.forward(f) {
+			if !fl.forward(ctx, f) {
 				return
 			}
 
@@ -91,7 +91,7 @@ func (fl *follow) Do(f *os.File, read logPos) {
 			read.size = 0
 		}
 
-		if !fl.forward(io.NewSectionReader(f, read.size, wrote.size-read.size)) {
+		if !fl.forward(ctx, io.NewSectionReader(f, read.size, wrote.size-read.size)) {
 			return
 		}
 		read = wrote
@@ -135,7 +135,7 @@ func (fl *follow) nextPos(current logPos) (next logPos, ok bool) {
 // forward decodes log messages from r and forwards them to the log watcher.
 //
 // The return value, cont, signals whether following should continue.
-func (fl *follow) forward(r io.Reader) (cont bool) {
+func (fl *follow) forward(ctx context.Context, r io.Reader) (cont bool) {
 	fl.Decoder.Reset(r)
-	return fl.Forwarder.Do(fl.Watcher, fl.Decoder)
+	return fl.Forwarder.Do(ctx, fl.Watcher, fl.Decoder.Decode)
 }

--- a/daemon/logger/loggerutils/logfile_race_test.go
+++ b/daemon/logger/loggerutils/logfile_race_test.go
@@ -27,7 +27,7 @@ func TestConcurrentLogging(t *testing.T) {
 		maxFiles = 3
 		compress = true
 	)
-	getTailReader := func(ctx context.Context, r SizeReaderAt, lines int) (io.Reader, int, error) {
+	getTailReader := func(ctx context.Context, r SizeReaderAt, lines int) (SizeReaderAt, int, error) {
 		return tailfile.NewTailReader(ctx, r, lines)
 	}
 	createDecoder := func(io.Reader) Decoder {

--- a/daemon/logger/loggerutils/logfile_test.go
+++ b/daemon/logger/loggerutils/logfile_test.go
@@ -150,14 +150,14 @@ func TestTailFiles(t *testing.T) {
 		f3 := bytes.NewBuffer(nil)
 		writeMsg(f3, msg5)
 
-		// [bytes.Buffer] is not a SizeReaderAt, so we need to convert it here
+		// [bytes.Buffer] is not a SizeReaderAt, so we need to convert it here.
 		files := makeOpener(bytes.NewReader(f1.Bytes()), bytes.NewReader(f2.Bytes()), bytes.NewReader(f3.Bytes()))
 
 		// At this point we our log "files" should have 4 log messages in it
-		// intersperesed with some junk that is invalid json
+		// interspersed with some junk that is invalid json.
 
 		// We need a zero size watcher so that we can tell the decoder to give us
-		// a syntax error
+		// a syntax error.
 		watcher := logger.NewLogWatcher()
 
 		config := logger.ReadConfig{Tail: 4}

--- a/daemon/logger/loggerutils/logfile_test.go
+++ b/daemon/logger/loggerutils/logfile_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"text/tabwriter"
@@ -78,8 +79,8 @@ func TestTailFiles(t *testing.T) {
 
 	makeOpener := func(ls ...SizeReaderAt) []fileOpener {
 		out := make([]fileOpener, 0, len(ls))
-		for _, rdr := range ls {
-			out = append(out, &sizeReaderAtOpener{rdr})
+		for i, rdr := range ls {
+			out = append(out, &sizeReaderAtOpener{rdr, strconv.Itoa(i)})
 		}
 		return out
 	}
@@ -98,7 +99,7 @@ func TestTailFiles(t *testing.T) {
 	started := make(chan struct{})
 	go func() {
 		close(started)
-		tailFiles(files, watcher, dec, tailReader, config.Tail, fwd)
+		tailFiles(context.TODO(), files, watcher, dec, tailReader, config.Tail, fwd)
 	}()
 	<-started
 
@@ -166,7 +167,7 @@ func TestTailFiles(t *testing.T) {
 		done := make(chan struct{})
 		go func() {
 			close(started)
-			tailFiles(files, watcher, &testJSONStreamDecoder{}, tailReader, config.Tail, fwd)
+			tailFiles(context.TODO(), files, watcher, &testJSONStreamDecoder{}, tailReader, config.Tail, fwd)
 			close(done)
 		}()
 
@@ -249,7 +250,7 @@ func TestCheckCapacityAndRotate(t *testing.T) {
 
 	t.Run("with log reader", func(t *testing.T) {
 		// Make sure rotate works with an active reader
-		lw := l.ReadLogs(logger.ReadConfig{Follow: true, Tail: 1000})
+		lw := l.ReadLogs(context.TODO(), logger.ReadConfig{Follow: true, Tail: 1000})
 		defer lw.ConsumerGone()
 
 		assert.NilError(t, l.WriteLogEntry(timestamp, []byte("hello world 0!\n")), ls)

--- a/daemon/logger/loggerutils/sharedtemp.go
+++ b/daemon/logger/loggerutils/sharedtemp.go
@@ -76,7 +76,7 @@ func (c *sharedTempFileConverter) Do(f *os.File) (*sharedFileReader, error) {
 		// ModTime, which conveniently also handles the case of true
 		// positives where the file has also been modified since it was
 		// first converted.
-		if os.SameFile(tf.src, stat) && tf.src.ModTime() == stat.ModTime() {
+		if os.SameFile(tf.src, stat) && tf.src.ModTime().Equal(stat.ModTime()) {
 			return c.openExisting(st, id, tf)
 		}
 	}

--- a/daemon/logger/ring.go
+++ b/daemon/logger/ring.go
@@ -1,6 +1,7 @@
 package logger // import "github.com/docker/docker/daemon/logger"
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"sync/atomic"
@@ -20,19 +21,22 @@ type RingLogger struct {
 	wg        sync.WaitGroup
 }
 
-var _ SizedLogger = &RingLogger{}
+var (
+	_ SizedLogger = (*RingLogger)(nil)
+	_ LogReader   = (*ringWithReader)(nil)
+)
 
 type ringWithReader struct {
 	*RingLogger
 }
 
-func (r *ringWithReader) ReadLogs(cfg ReadConfig) *LogWatcher {
+func (r *ringWithReader) ReadLogs(ctx context.Context, cfg ReadConfig) *LogWatcher {
 	reader, ok := r.l.(LogReader)
 	if !ok {
 		// something is wrong if we get here
 		panic("expected log reader")
 	}
-	return reader.ReadLogs(cfg)
+	return reader.ReadLogs(ctx, cfg)
 }
 
 func newRingLogger(driver Logger, logInfo Info, maxSize int64) *RingLogger {

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -27,9 +27,7 @@ import (
 func (daemon *Daemon) ContainerLogs(ctx context.Context, containerName string, config *containertypes.LogsOptions) (messages <-chan *backend.LogMessage, isTTY bool, retErr error) {
 	ctx, span := tracing.StartSpan(ctx, "daemon.ContainerLogs")
 	defer func() {
-		if retErr != nil {
-			span.SetStatus(retErr)
-		}
+		span.SetStatus(retErr)
 		span.End()
 	}()
 

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/containerd/containerd/tracing"
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/types/backend"
 	containertypes "github.com/docker/docker/api/types/container"
@@ -24,6 +25,14 @@ import (
 // if it returns nil, the config channel will be active and return log
 // messages until it runs out or the context is canceled.
 func (daemon *Daemon) ContainerLogs(ctx context.Context, containerName string, config *containertypes.LogsOptions) (messages <-chan *backend.LogMessage, isTTY bool, retErr error) {
+	ctx, span := tracing.StartSpan(ctx, "daemon.ContainerLogs")
+	defer func() {
+		if retErr != nil {
+			span.SetStatus(retErr)
+		}
+		span.End()
+	}()
+
 	lg := log.G(ctx).WithFields(log.Fields{
 		"module":    "daemon",
 		"method":    "(*Daemon).ContainerLogs",
@@ -96,7 +105,7 @@ func (daemon *Daemon) ContainerLogs(ctx context.Context, containerName string, c
 		Follow: follow,
 	}
 
-	logs := logReader.ReadLogs(readConfig)
+	logs := logReader.ReadLogs(ctx, readConfig)
 
 	// past this point, we can't possibly return any errors, so we can just
 	// start a goroutine and return to tell the caller not to expect errors

--- a/pkg/tailfile/tailfile.go
+++ b/pkg/tailfile/tailfile.go
@@ -48,7 +48,7 @@ type SizeReaderAt interface {
 }
 
 // NewTailReader scopes the passed in reader to just the last N lines passed in
-func NewTailReader(ctx context.Context, r SizeReaderAt, reqLines int) (io.Reader, int, error) {
+func NewTailReader(ctx context.Context, r SizeReaderAt, reqLines int) (*io.SectionReader, int, error) {
 	return NewTailReaderWithDelimiter(ctx, r, reqLines, eol)
 }
 
@@ -56,7 +56,7 @@ func NewTailReader(ctx context.Context, r SizeReaderAt, reqLines int) (io.Reader
 // In this case a "line" is defined by the passed in delimiter.
 //
 // Delimiter lengths should be generally small, no more than 12 bytes
-func NewTailReaderWithDelimiter(ctx context.Context, r SizeReaderAt, reqLines int, delimiter []byte) (io.Reader, int, error) {
+func NewTailReaderWithDelimiter(ctx context.Context, r SizeReaderAt, reqLines int, delimiter []byte) (*io.SectionReader, int, error) {
 	if reqLines < 1 {
 		return nil, 0, ErrNonPositiveLinesNumber
 	}
@@ -71,7 +71,7 @@ func NewTailReaderWithDelimiter(ctx context.Context, r SizeReaderAt, reqLines in
 	)
 
 	if int64(len(delimiter)) >= size {
-		return bytes.NewReader(nil), 0, nil
+		return io.NewSectionReader(bytes.NewReader(nil), 0, 0), 0, nil
 	}
 
 	scanner := newScanner(r, delimiter)
@@ -92,7 +92,7 @@ func NewTailReaderWithDelimiter(ctx context.Context, r SizeReaderAt, reqLines in
 	tailStart = scanner.Start(ctx)
 
 	if found == 0 {
-		return bytes.NewReader(nil), 0, nil
+		return io.NewSectionReader(bytes.NewReader(nil), 0, 0), 0, nil
 	}
 
 	if found < reqLines && tailStart != 0 {


### PR DESCRIPTION
- fixes / addresses https://github.com/docker/for-linux/issues/140

Fundamentally this change (beyond the minor refactor and tracing spans) is to not treat errors reading from log files as fatal to providing logs to the client.

The need for this change is because often log files may be corrupted either due to old bugs in dockerd or for other reasons.
One specific thing we have seen seems to be caused by ext4 by default is not doing full journaling. On power loss or kernel panic this can cause the log data to be corrupted.
We see this mostly on IoT devices which are often not on battery backup or frequently hard cut from power.

Instead of erroring out a stream on errors from a particular file this just skips on to the next file.

I had made a previous attempt to be a little more clever and scrub the file to try and find a place where we can start parsing again but realized this can cause serious issues and is generally error prone.

This also takes care of a long-standing todo to handle log files lazily (or at least as lazily as possible) so we only end up decompressing files just-in-time.

Unfortunately we don't have a way to return warnings to the client that we had to skip files, however with the tracing changes at least it could be seen there and in the daemon logs.

```markdown changelog
When reading logs with the `jsonfile` or `local` log drivers, any errors while trying to read or parse underlying log files will cause the rest of the file to be skipped and move to the next log file (if one exists) rather than returning an error to the client and closing the stream.
The errors are viewable in the dockerd logs and exported to traces when tracing is configured.

When reading log files, compressed log files are now only decompressed when needed rather than decompressing all files before starting the log stream.
```