### PR TITLE
daemon: restore: clear net state for stopped containers

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -1019,6 +1019,9 @@ func (daemon *Daemon) releaseNetwork(ctx context.Context, container *container.C
 		return
 	}
 
+	container.NetworkSettings.SandboxID = ""
+	container.NetworkSettings.SandboxKey = ""
+
 	var networks []*libnetwork.Network
 	for n, epSettings := range container.NetworkSettings.Networks {
 		if nw, err := daemon.FindNetwork(getNetworkID(n, epSettings.EndpointSettings)); err == nil {

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -1001,8 +1001,7 @@ func (daemon *Daemon) releaseNetwork(ctx context.Context, container *container.C
 
 	start := time.Now()
 	// If live-restore is enabled, the daemon cleans up dead containers when it starts up. In that case, the
-	// netController hasn't been initialized yet and so we can't proceed.
-	// TODO(aker): If we hit this case, the endpoint state won't be cleaned up (ie. no call to cleanOperationalData).
+	// netController hasn't been initialized yet, and so we can't proceed.
 	if daemon.netController == nil {
 		return
 	}

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -526,7 +526,6 @@ func (s *DockerSwarmSuite) TestAPISwarmManagerRestore(c *testing.T) {
 
 	err := d3.Kill()
 	assert.NilError(c, err)
-	time.Sleep(1 * time.Second) // time to handle signal
 	d3.StartNode(c)
 	d3.GetService(ctx, c, id)
 }

--- a/integration/container/daemon_test.go
+++ b/integration/container/daemon_test.go
@@ -85,6 +85,8 @@ func TestNetworkStateCleanupOnDaemonStart(t *testing.T) {
 
 	inspect, err := apiClient.ContainerInspect(ctx, cid)
 	assert.NilError(t, err)
+	assert.Assert(t, inspect.NetworkSettings.SandboxID != "")
+	assert.Assert(t, inspect.NetworkSettings.SandboxKey != "")
 	assert.Assert(t, inspect.NetworkSettings.Ports["80/tcp"] != nil)
 
 	assert.NilError(t, d.Kill())
@@ -92,5 +94,7 @@ func TestNetworkStateCleanupOnDaemonStart(t *testing.T) {
 
 	inspect, err = apiClient.ContainerInspect(ctx, cid)
 	assert.NilError(t, err)
+	assert.Assert(t, inspect.NetworkSettings.SandboxID == "")
+	assert.Assert(t, inspect.NetworkSettings.SandboxKey == "")
 	assert.Assert(t, inspect.NetworkSettings.Ports["80/tcp"] == nil)
 }

--- a/integration/container/daemon_test.go
+++ b/integration/container/daemon_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
+	"github.com/docker/go-connections/nat"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
@@ -49,4 +50,47 @@ func TestContainerKillOnDaemonStart(t *testing.T) {
 	inspect, err = apiClient.ContainerInspect(ctx, id)
 	assert.Check(t, is.Nil(err))
 	assert.Assert(t, !inspect.State.Running)
+}
+
+// When the daemon doesn't stop in a clean way (eg. it crashes, the host has a power failure, etc..), or if it's started
+// with live-restore enabled, stopped containers should have their NetworkSettings cleaned up the next time the daemon
+// starts.
+func TestNetworkStateCleanupOnDaemonStart(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot start daemon on remote test run")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+	skip.If(t, testEnv.IsRootless, "scenario doesn't work with rootless mode")
+
+	t.Parallel()
+
+	ctx := testutil.StartSpan(baseContext, t)
+
+	d := daemon.New(t)
+	defer d.Cleanup(t)
+
+	d.StartWithBusybox(ctx, t)
+	defer d.Stop(t)
+
+	apiClient := d.NewClientT(t)
+
+	// The intention of this container is to ignore stop signals.
+	// Sadly this means the test will take longer, but at least this test can be parallelized.
+	cid := container.Run(ctx, t, apiClient,
+		container.WithExposedPorts("80/tcp"),
+		container.WithPortMap(nat.PortMap{"80/tcp": {{}}}),
+		container.WithCmd("/bin/sh", "-c", "while true; do echo hello; sleep 1; done"))
+	defer func() {
+		err := apiClient.ContainerRemove(ctx, cid, containertypes.RemoveOptions{Force: true})
+		assert.NilError(t, err)
+	}()
+
+	inspect, err := apiClient.ContainerInspect(ctx, cid)
+	assert.NilError(t, err)
+	assert.Assert(t, inspect.NetworkSettings.Ports["80/tcp"] != nil)
+
+	assert.NilError(t, d.Kill())
+	d.Start(t)
+
+	inspect, err = apiClient.ContainerInspect(ctx, cid)
+	assert.NilError(t, err)
+	assert.Assert(t, inspect.NetworkSettings.Ports["80/tcp"] == nil)
 }

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -618,6 +619,11 @@ func (d *Daemon) Kill() error {
 	}()
 
 	if err := d.cmd.Process.Kill(); err != nil {
+		return err
+	}
+
+	_, err := d.cmd.Process.Wait()
+	if err != nil && !errors.Is(err, syscall.ECHILD) {
 		return err
 	}
 


### PR DESCRIPTION
**- What I did**

**daemon: restore: clear net state for stopped containers**

When the daemon crashes, the host unexpectedly reboot, or the daemon restarts with live-restore enabled, running containers might stop and the on-disk state for containers might diverge from reality. All these situations are currently handled by the daemon's `restore` method.

That method calls `daemon.Cleanup()` for all the dead containers. In turn, `Cleanup` calls `daemon.releaseNetwork()`. However, this last method won't do anything because it expects the `netController` to be initialized when it's called. That's not the case in the `restore` code path -- the `netController` is initialized _after_ cleaning up dead containers.

There's a chicken-egg problem here, and fixing that would require some important architectural changes (eg. change the way libnet's controller is initialized).

Since `releaseNetwork()` early exits, dead containers won't ever have their networking state cleaned. This led to bugs in Docker Desktop among other things.

Fix that by calling `releaseNetwork` after initializing the `netController`.

**daemon: releaseNetwork: clear SandboxID, SandboxKey**

When the container stops or during `restore`, `daemon.releaseNetwork` is used to clear all net-related state carried by a container. However, the fields `SandboxID` and `SandboxKey` are never cleared. On the next start, these fields will be replaced with new values. There's no point in preserving these data since they became invalid as soon as the container stopped.

**- How to verify it**

```console
# Start the daemon with --live-restore
$ docker run -d --name c0 -p 80:80 traefik/whoami
$ docker inspect c0
# Kill the daemon
# Kill the container process
# Restart the daemon
$ docker inspect c0
```

**- Description for the changelog**

```markdown changelog
- Clear the networking state of all stopped / dead containers during daemon start-up.
```

