### PR TITLE
builder/mobyexporter: Add missing nil check

### DIFF
--- a/builder/builder-next/exporter/mobyexporter/writer.go
+++ b/builder/builder-next/exporter/mobyexporter/writer.go
@@ -45,6 +45,10 @@ func patchImageConfig(dt []byte, dps []digest.Digest, history []ocispec.History,
 		return nil, errors.Wrap(err, "failed to parse image config for patch")
 	}
 
+	if m == nil {
+		return nil, errors.New("null image config")
+	}
+
 	var rootFS ocispec.RootFS
 	rootFS.Type = "layers"
 	rootFS.DiffIDs = append(rootFS.DiffIDs, dps...)

--- a/builder/builder-next/exporter/mobyexporter/writer_test.go
+++ b/builder/builder-next/exporter/mobyexporter/writer_test.go
@@ -1,0 +1,42 @@
+package mobyexporter
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestPatchImageConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		cfgJSON string
+		err     string
+	}{
+		{
+			name:    "empty",
+			cfgJSON: "{}",
+		},
+		{
+			name:    "history only",
+			cfgJSON: `{"history": []}`,
+		},
+		{
+			name:    "rootfs only",
+			cfgJSON: `{"rootfs": {}}`,
+		},
+		{
+			name:    "null",
+			cfgJSON: "null",
+			err:     "null image config",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := patchImageConfig([]byte(tc.cfgJSON), nil, nil, nil)
+			if tc.err == "" {
+				assert.NilError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tc.err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a nil check to handle a case where the image config JSON would deserialize into a nil map.

**- What I did**

**- How I did it**

**- How to verify it**
TestPatchImageConfig


**- A picture of a cute animal (not mandatory but encouraged)**

