### PR TITLE
libnet/ds, libnet/config: various cleanups

### DIFF
--- a/libnetwork/config/config.go
+++ b/libnetwork/config/config.go
@@ -39,7 +39,7 @@ type Config struct {
 	ClusterProvider        cluster.Provider
 	NetworkControlPlaneMTU int
 	DefaultAddressPool     []*ipamutils.NetworkToSplit
-	Scope                  datastore.ScopeCfg
+	DatastoreBucket        string
 	ActiveSandboxes        map[string]interface{}
 	PluginGetter           plugingetter.PluginGetter
 }
@@ -47,7 +47,8 @@ type Config struct {
 // New creates a new Config and initializes it with the given Options.
 func New(opts ...Option) *Config {
 	cfg := &Config{
-		driverCfg: make(map[string]map[string]any),
+		driverCfg:       make(map[string]map[string]any),
+		DatastoreBucket: datastore.DefaultBucket,
 	}
 
 	for _, opt := range opts {
@@ -56,10 +57,6 @@ func New(opts ...Option) *Config {
 		}
 	}
 
-	// load default scope configs which don't have explicit user specified configs.
-	if cfg.Scope == (datastore.ScopeCfg{}) {
-		cfg.Scope = datastore.DefaultScope(cfg.DataDir)
-	}
 	return cfg
 }
 

--- a/libnetwork/datastore/datastore_test.go
+++ b/libnetwork/datastore/datastore_test.go
@@ -23,16 +23,6 @@ func TestKey(t *testing.T) {
 	assert.Check(t, is.Equal(sKey, expected))
 }
 
-func TestInvalidDataStore(t *testing.T) {
-	_, err := New(ScopeCfg{
-		Client: ScopeClientCfg{
-			Provider: "invalid",
-			Address:  "localhost:8500",
-		},
-	})
-	assert.Check(t, is.Error(err, "unsupported KV store"))
-}
-
 func TestKVObjectFlatKey(t *testing.T) {
 	store := NewTestDataStore()
 	expected := dummyKVObject("1000", true)

--- a/libnetwork/firewall_linux_test.go
+++ b/libnetwork/firewall_linux_test.go
@@ -55,7 +55,7 @@ func TestUserChain(t *testing.T) {
 			defer resetIptables(t)
 
 			c, err := New(
-				OptionBoltdbWithRandomDBFile(t),
+				config.OptionDataDir(t.TempDir()),
 				config.OptionDriverConfig("bridge", map[string]any{
 					netlabel.GenericData: options.Generic{
 						"EnableIPTables":  tc.iptables,

--- a/libnetwork/internal/kvstore/boltdb/boltdb.go
+++ b/libnetwork/internal/kvstore/boltdb/boltdb.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	store "github.com/docker/docker/libnetwork/internal/kvstore"
 	bolt "go.etcd.io/bbolt"
@@ -26,13 +25,9 @@ type BoltDB struct {
 	boltBucket []byte
 	dbIndex    atomic.Uint64
 	path       string
-	timeout    time.Duration
 }
 
-const (
-	libkvmetadatalen = 8
-	transientTimeout = time.Duration(10) * time.Second
-)
+const libkvmetadatalen = 8
 
 // New opens a new BoltDB connection to the specified path and bucket
 func New(endpoint string, options *store.Config) (store.Store, error) {
@@ -52,16 +47,10 @@ func New(endpoint string, options *store.Config) (store.Store, error) {
 		return nil, err
 	}
 
-	timeout := transientTimeout
-	if options.ConnectionTimeout != 0 {
-		timeout = options.ConnectionTimeout
-	}
-
 	b := &BoltDB{
 		client:     db,
 		path:       endpoint,
 		boltBucket: []byte(options.Bucket),
-		timeout:    timeout,
 	}
 
 	return b, nil

--- a/libnetwork/internal/kvstore/boltdb/boltdb.go
+++ b/libnetwork/internal/kvstore/boltdb/boltdb.go
@@ -3,18 +3,15 @@ package boltdb
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"os"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	store "github.com/docker/docker/libnetwork/internal/kvstore"
 	bolt "go.etcd.io/bbolt"
 )
-
-// ErrBoltBucketOptionMissing is thrown when boltBucket config option is missing
-var ErrBoltBucketOptionMissing = errors.New("boltBucket config option missing")
 
 const filePerm = 0o644
 
@@ -30,18 +27,14 @@ type BoltDB struct {
 const libkvmetadatalen = 8
 
 // New opens a new BoltDB connection to the specified path and bucket
-func New(endpoint string, options *store.Config) (store.Store, error) {
-	if (options == nil) || (len(options.Bucket) == 0) {
-		return nil, ErrBoltBucketOptionMissing
-	}
-
-	dir, _ := filepath.Split(endpoint)
+func New(path, bucket string) (store.Store, error) {
+	dir, _ := filepath.Split(path)
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return nil, err
 	}
 
-	db, err := bolt.Open(endpoint, filePerm, &bolt.Options{
-		Timeout: options.ConnectionTimeout,
+	db, err := bolt.Open(path, filePerm, &bolt.Options{
+		Timeout: time.Minute,
 	})
 	if err != nil {
 		return nil, err
@@ -49,8 +42,8 @@ func New(endpoint string, options *store.Config) (store.Store, error) {
 
 	b := &BoltDB{
 		client:     db,
-		path:       endpoint,
-		boltBucket: []byte(options.Bucket),
+		path:       path,
+		boltBucket: []byte(bucket),
 	}
 
 	return b, nil

--- a/libnetwork/internal/kvstore/kvstore.go
+++ b/libnetwork/internal/kvstore/kvstore.go
@@ -2,7 +2,6 @@ package kvstore
 
 import (
 	"errors"
-	"time"
 )
 
 // Backend represents a KV Store Backend
@@ -23,12 +22,6 @@ var (
 	// ErrKeyExists is thrown when the previous value exists in the case of an AtomicPut
 	ErrKeyExists = errors.New("Previous K/V pair exists, cannot complete Atomic operation")
 )
-
-// Config contains the options for a storage client
-type Config struct {
-	ConnectionTimeout time.Duration
-	Bucket            string
-}
 
 // Store represents the backend K/V storage
 // Each store should support every call listed

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -320,7 +320,7 @@ func compareNwLists(a, b []*net.IPNet) bool {
 func TestAuxAddresses(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 
-	c, err := New(OptionBoltdbWithRandomDBFile(t))
+	c, err := New(config.OptionDataDir(t.TempDir()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -403,7 +403,7 @@ func TestUpdateSvcRecord(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			defer netnsutils.SetupTestOSContext(t)()
-			ctrlr, err := New(OptionBoltdbWithRandomDBFile(t))
+			ctrlr, err := New(config.OptionDataDir(t.TempDir()))
 			assert.NilError(t, err)
 			defer ctrlr.Stop()
 
@@ -449,7 +449,7 @@ func TestSRVServiceQuery(t *testing.T) {
 
 	defer netnsutils.SetupTestOSContext(t)()
 
-	c, err := New(OptionBoltdbWithRandomDBFile(t),
+	c, err := New(config.OptionDataDir(t.TempDir()),
 		config.OptionDefaultAddressPoolConfig(ipamutils.GetLocalScopeDefaultNetworks()))
 	if err != nil {
 		t.Fatal(err)
@@ -550,7 +550,7 @@ func TestServiceVIPReuse(t *testing.T) {
 
 	defer netnsutils.SetupTestOSContext(t)()
 
-	c, err := New(OptionBoltdbWithRandomDBFile(t),
+	c, err := New(config.OptionDataDir(t.TempDir()),
 		config.OptionDefaultAddressPoolConfig(ipamutils.GetLocalScopeDefaultNetworks()))
 	if err != nil {
 		t.Fatal(err)
@@ -671,7 +671,7 @@ func TestIpamReleaseOnNetDriverFailures(t *testing.T) {
 
 	defer netnsutils.SetupTestOSContext(t)()
 
-	c, err := New(OptionBoltdbWithRandomDBFile(t))
+	c, err := New(config.OptionDataDir(t.TempDir()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -53,7 +53,7 @@ func TestMain(m *testing.M) {
 func newController(t *testing.T) *libnetwork.Controller {
 	t.Helper()
 	c, err := libnetwork.New(
-		libnetwork.OptionBoltdbWithRandomDBFile(t),
+		config.OptionDataDir(t.TempDir()),
 		config.OptionDriverConfig(bridgeNetType, map[string]interface{}{
 			netlabel.GenericData: options.Generic{
 				"EnableIPForwarding": true,
@@ -1225,7 +1225,7 @@ func TestInvalidRemoteDriver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctrlr, err := libnetwork.New(libnetwork.OptionBoltdbWithRandomDBFile(t))
+	ctrlr, err := libnetwork.New(config.OptionDataDir(t.TempDir()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork"
 	"github.com/docker/docker/libnetwork/config"
-	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/ipams/defaultipam"
 	"github.com/docker/docker/libnetwork/ipams/null"
@@ -45,7 +44,7 @@ const (
 
 func TestMain(m *testing.M) {
 	// Cleanup local datastore file
-	_ = os.Remove(datastore.DefaultScope("").Client.Address)
+	_ = os.Remove("/var/lib/docker/network/files/local-kv.db")
 
 	os.Exit(m.Run())
 }

--- a/libnetwork/resolver_unix_test.go
+++ b/libnetwork/resolver_unix_test.go
@@ -16,7 +16,7 @@ import (
 // test only works on linux
 func TestDNSIPQuery(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
-	c, err := New(OptionBoltdbWithRandomDBFile(t),
+	c, err := New(config.OptionDataDir(t.TempDir()),
 		config.OptionDefaultAddressPoolConfig(ipamutils.GetLocalScopeDefaultNetworks()))
 	if err != nil {
 		t.Fatal(err)
@@ -114,7 +114,7 @@ func TestDNSProxyServFail(t *testing.T) {
 	osctx := netnsutils.SetupTestOSContextEx(t)
 	defer osctx.Cleanup(t)
 
-	c, err := New(OptionBoltdbWithRandomDBFile(t),
+	c, err := New(config.OptionDataDir(t.TempDir()),
 		config.OptionDefaultAddressPoolConfig(ipamutils.GetLocalScopeDefaultNetworks()))
 	if err != nil {
 		t.Fatal(err)

--- a/libnetwork/sandbox_dns_unix_test.go
+++ b/libnetwork/sandbox_dns_unix_test.go
@@ -6,13 +6,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/docker/docker/libnetwork/config"
 	"github.com/docker/docker/libnetwork/resolvconf"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestDNSOptions(t *testing.T) {
-	c, err := New(OptionBoltdbWithRandomDBFile(t))
+	c, err := New(config.OptionDataDir(t.TempDir()))
 	assert.NilError(t, err)
 
 	sb, err := c.NewSandbox(context.Background(), "cnt1", nil)

--- a/libnetwork/sandbox_unix_test.go
+++ b/libnetwork/sandbox_unix_test.go
@@ -22,7 +22,7 @@ import (
 func getTestEnv(t *testing.T, opts ...[]NetworkOption) (*Controller, []*Network) {
 	const netType = "bridge"
 	c, err := New(
-		OptionBoltdbWithRandomDBFile(t),
+		config.OptionDataDir(t.TempDir()),
 		config.OptionDriverConfig(netType, map[string]any{
 			netlabel.GenericData: options.Generic{"EnableIPForwarding": true},
 		}),

--- a/libnetwork/service_common_unix_test.go
+++ b/libnetwork/service_common_unix_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestCleanupServiceDiscovery(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
-	c, err := New(OptionBoltdbWithRandomDBFile(t),
+	c, err := New(config.OptionDataDir(t.TempDir()),
 		config.OptionDefaultAddressPoolConfig(ipamutils.GetLocalScopeDefaultNetworks()))
 	assert.NilError(t, err)
 	defer c.Stop()

--- a/libnetwork/store_linux_test.go
+++ b/libnetwork/store_linux_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/docker/docker/libnetwork/config"
 	store "github.com/docker/docker/libnetwork/internal/kvstore"
 )
 
@@ -17,7 +18,7 @@ func TestBoltdbBackend(t *testing.T) {
 }
 
 func TestNoPersist(t *testing.T) {
-	configOption := OptionBoltdbWithRandomDBFile(t)
+	configOption := config.OptionDataDir(t.TempDir())
 	testController, err := New(configOption)
 	if err != nil {
 		t.Fatalf("Error creating new controller: %v", err)

--- a/libnetwork/store_linux_test.go
+++ b/libnetwork/store_linux_test.go
@@ -12,9 +12,7 @@ import (
 
 func TestBoltdbBackend(t *testing.T) {
 	tmpPath := filepath.Join(t.TempDir(), "boltdb.db")
-	testLocalBackend(t, "boltdb", tmpPath, &store.Config{
-		Bucket: "testBackend",
-	})
+	testLocalBackend(t, tmpPath, "testBackend")
 }
 
 func TestNoPersist(t *testing.T) {

--- a/libnetwork/store_test.go
+++ b/libnetwork/store_test.go
@@ -5,21 +5,18 @@ import (
 	"testing"
 
 	"github.com/docker/docker/libnetwork/config"
-	store "github.com/docker/docker/libnetwork/internal/kvstore"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/options"
 )
 
-func testLocalBackend(t *testing.T, provider, url string, storeConfig *store.Config) {
-	cfgOptions := []config.Option{func(c *config.Config) {
-		c.Scope.Client.Provider = provider
-		c.Scope.Client.Address = url
-		c.Scope.Client.Config = storeConfig
-	}}
-
-	cfgOptions = append(cfgOptions, config.OptionDriverConfig("host", map[string]interface{}{
-		netlabel.GenericData: options.Generic{},
-	}))
+func testLocalBackend(t *testing.T, path, bucket string) {
+	cfgOptions := []config.Option{
+		config.OptionDataDir(path),
+		func(c *config.Config) { c.DatastoreBucket = bucket },
+		config.OptionDriverConfig("host", map[string]interface{}{
+			netlabel.GenericData: options.Generic{},
+		}),
+	}
 
 	testController, err := New(cfgOptions...)
 	if err != nil {

--- a/libnetwork/store_test.go
+++ b/libnetwork/store_test.go
@@ -2,8 +2,6 @@ package libnetwork
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/docker/docker/libnetwork/config"
@@ -64,20 +62,5 @@ func testLocalBackend(t *testing.T, provider, url string, storeConfig *store.Con
 	defer testController.Stop()
 	if _, err = testController.NetworkByID(nw.ID()); err != nil {
 		t.Errorf("Error getting network %v", err)
-	}
-}
-
-// OptionBoltdbWithRandomDBFile function returns a random dir for local store backend
-func OptionBoltdbWithRandomDBFile(t *testing.T) config.Option {
-	t.Helper()
-	tmp := filepath.Join(t.TempDir(), "bolt.db")
-	if err := os.WriteFile(tmp, nil, 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	return func(c *config.Config) {
-		c.Scope.Client.Provider = "boltdb"
-		c.Scope.Client.Address = tmp
-		c.Scope.Client.Config = &store.Config{Bucket: "testBackend"}
 	}
 }


### PR DESCRIPTION
**- What I did**

**libnet/i/kv/boltdb: remove unused field 'timeout'**

**libnetwork: unit tests: drop OptionBoltdbWithRandomDBFile**

This option fn was defining a custom directory, file name and bucket name for boltdb. Users can only change data-dir through `OptionDataDir`. Better reuse that function instead, that'll make refactorings easier.

It won't set a custom bucket name or file name as `OptionBoltdbWithRandomDBFile` was doing, but that's not needed since every test will use a different temp dir anyway.

**libnet/ds: simplify datastore.New()**

That function was needlessly complex. Instead of relying on a struct and a sub-struct, it now just takes two string params: a path and a bucket name.

Libnetwork config is now initialized with default values. A new struct is introduced in libnetwork/config to let tests customize the path and bucket name.

**libnet/i/kv/boltdb: fail fast in case of contention**

Make sure an error is returned straight away if there's contention on the underlying db file. This makes sure we don't reintroduce the issue fixed in d21d088, and it will help detect contention in parallelized tests if they're badly written. It effectively adds a new error mode to the daemon, but if anyone faces this error, they should fix their process manager.

**- How to verify it**

CI.

**- A picture of a cute animal (not mandatory but encouraged)**

