### PR TITLE
builder/dockerfile: assorted linting fixes, and remove LCOW leftover

### DIFF
--- a/builder/dockerfile/copy.go
+++ b/builder/dockerfile/copy.go
@@ -477,7 +477,7 @@ func performCopyForInfo(dest copyInfo, source copyInfo, options copyFileOptions)
 	}
 	// dest.path must be used because destPath has already been cleaned of any
 	// trailing slash
-	if endsInSlash(dest.path) || destExistsAsDir {
+	if destExistsAsDir || strings.HasSuffix(dest.path, string(os.PathSeparator)) {
 		// source.path must be used to get the correct filename when the source
 		// is a symlink
 		destPath = filepath.Join(destPath, filepath.Base(source.path))
@@ -522,10 +522,6 @@ func copyFile(archiver *archive.Archiver, source, dest string, identity *idtools
 		return fixPermissions(source, dest, *identity, false)
 	}
 	return nil
-}
-
-func endsInSlash(path string) bool {
-	return strings.HasSuffix(path, string(filepath.Separator))
 }
 
 // isExistingDirectory returns true if the path exists and is a directory

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -333,7 +333,7 @@ func (b *Builder) probeCache(dispatchState *dispatchState, runConfig *container.
 	if cachedID == "" || err != nil {
 		return false, err
 	}
-	fmt.Fprint(b.Stdout, " ---> Using cache\n")
+	_, _ = fmt.Fprintln(b.Stdout, " ---> Using cache")
 
 	dispatchState.imageID = cachedID
 	return true, nil
@@ -356,11 +356,10 @@ func (b *Builder) create(ctx context.Context, runConfig *container.Config) (stri
 	if err != nil {
 		return "", err
 	}
-	// TODO: could this be moved into containerManager.Create() ?
 	for _, warning := range ctr.Warnings {
-		fmt.Fprintf(b.Stdout, " ---> [Warning] %s\n", warning)
+		_, _ = fmt.Fprintf(b.Stdout, " ---> [Warning] %s\n", warning)
 	}
-	fmt.Fprintf(b.Stdout, " ---> Running in %s\n", stringid.TruncateID(ctr.ID))
+	_, _ = fmt.Fprintf(b.Stdout, " ---> Running in %s\n", stringid.TruncateID(ctr.ID))
 	return ctr.ID, nil
 }
 

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -147,7 +147,7 @@ func (b *Builder) performCopy(ctx context.Context, req dispatchRequest, inst cop
 	}
 	defer rwLayer.Release()
 
-	destInfo, err := createDestInfo(state.runConfig.WorkingDir, inst, rwLayer, state.operatingSystem)
+	destInfo, err := createDestInfo(state.runConfig.WorkingDir, inst, rwLayer)
 	if err != nil {
 		return err
 	}
@@ -182,7 +182,7 @@ func (b *Builder) performCopy(ctx context.Context, req dispatchRequest, inst cop
 	return b.exportImage(ctx, state, rwLayer, imgMount.Image(), runConfigWithCommentCmd)
 }
 
-func createDestInfo(workingDir string, inst copyInstruction, rwLayer builder.RWLayer, platform string) (copyInfo, error) {
+func createDestInfo(workingDir string, inst copyInstruction, rwLayer builder.RWLayer) (copyInfo, error) {
 	// Twiddle the destination when it's a relative path - meaning, make it
 	// relative to the WORKINGDIR
 	dest, err := normalizeDest(workingDir, inst.dest)


### PR DESCRIPTION
### builder/dockerfile: remove endsInSlash utility

It was only used in a single location, and other locations were shadowing
the function through local variables. As it's a one-liner, inlining the
code may be just as transparent.


### builder/dockerfile: rename vars that shadowed types and builtins

- imageMount was shadowing the imageMount type
- copy was shadowing the copy builtin
- container was shadowing the container import


### builder/dockerfile: fix some minor linting issues

- explicitly suppress some errors
- use fmt.Fprintln instead of manually appending a newline
- remove an outdated TODO; looking at the suggestion, it's not a
  realistic option

### builder/dockerfile: createDestInfo: remove platform arg (LCOW left-over)

This was added in 7a7357dae1bcccb17e9b2d4c7c8f5c025fce56ca as part of the
LCOW implementation. LCOW has been removed, and this option was no longer
in use because of that.

- relates to https://github.com/moby/moby/issues/39533
- relates to https://github.com/moby/moby/pull/34252





**- A picture of a cute animal (not mandatory but encouraged)**

