### PR TITLE
libnetwork: ipvlan, macvlan: cleanup getDummyName utility

### DIFF
--- a/libnetwork/drivers/ipvlan/ipvlan_network.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_network.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/docker/libnetwork/options"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/docker/docker/pkg/parsers/kernel"
-	"github.com/docker/docker/pkg/stringid"
 )
 
 // CreateNetwork the network for the specified driver type
@@ -40,7 +39,7 @@ func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo 
 
 	// if parent interface not specified, create a dummy type link to use named dummy+net_id
 	if config.Parent == "" {
-		config.Parent = getDummyName(stringid.TruncateID(config.ID))
+		config.Parent = getDummyName(config.ID)
 		config.Internal = true
 	}
 	foundExisting, err := d.createNetwork(config)
@@ -71,7 +70,7 @@ func (d *driver) createNetwork(config *configuration) (bool, error) {
 		if config.Parent == nw.config.Parent {
 			if config.ID != nw.config.ID {
 				return false, fmt.Errorf("network %s is already using parent interface %s",
-					getDummyName(stringid.TruncateID(nw.config.ID)), config.Parent)
+					getDummyName(nw.config.ID), config.Parent)
 			}
 			log.G(context.TODO()).Debugf("Create Network for the same ID %s\n", config.ID)
 			foundExisting = true
@@ -80,7 +79,7 @@ func (d *driver) createNetwork(config *configuration) (bool, error) {
 	}
 	if !parentExists(config.Parent) {
 		// Create a dummy link if a dummy name is set for parent
-		if dummyName := getDummyName(stringid.TruncateID(config.ID)); dummyName == config.Parent {
+		if dummyName := getDummyName(config.ID); dummyName == config.Parent {
 			err := createDummyLink(config.Parent, dummyName)
 			if err != nil {
 				return false, err
@@ -126,7 +125,7 @@ func (d *driver) DeleteNetwork(nid string) error {
 		// if the interface exists, only delete if it matches iface.vlan or dummy.net_id naming
 		if ok := parentExists(n.config.Parent); ok {
 			// only delete the link if it is named the net_id
-			if n.config.Parent == getDummyName(stringid.TruncateID(nid)) {
+			if n.config.Parent == getDummyName(nid) {
 				err := delDummyLink(n.config.Parent)
 				if err != nil {
 					log.G(context.TODO()).Debugf("link %s was not deleted, continuing the delete network operation: %v",

--- a/libnetwork/drivers/ipvlan/ipvlan_setup.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_setup.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/libnetwork/ns"
+	"github.com/docker/docker/pkg/stringid"
 	"github.com/vishvananda/netlink"
 )
 
@@ -222,5 +223,5 @@ func delDummyLink(linkName string) error {
 
 // getDummyName returns the name of a dummy parent with truncated net ID and driver prefix
 func getDummyName(netID string) string {
-	return dummyPrefix + netID
+	return dummyPrefix + stringid.TruncateID(netID)
 }

--- a/libnetwork/drivers/ipvlan/ipvlan_setup.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_setup.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/libnetwork/ns"
-	"github.com/docker/docker/pkg/stringid"
 	"github.com/vishvananda/netlink"
 )
 
 const (
-	dummyPrefix     = "di-" // ipvlan prefix for dummy parent interface
+	dummyPrefix     = "di-" // prefix for dummy ipvlan parent interfaces.
+	dummyIDLength   = 12    // length for dummy parent interface IDs.
 	ipvlanKernelVer = 4     // minimum ipvlan kernel support
 	ipvlanMajorVer  = 2     // minimum ipvlan major kernel support
 )
@@ -223,5 +223,8 @@ func delDummyLink(linkName string) error {
 
 // getDummyName returns the name of a dummy parent with truncated net ID and driver prefix
 func getDummyName(netID string) string {
-	return dummyPrefix + stringid.TruncateID(netID)
+	if len(netID) > dummyIDLength {
+		netID = netID[:dummyIDLength]
+	}
+	return dummyPrefix + netID
 }

--- a/libnetwork/drivers/macvlan/macvlan_setup.go
+++ b/libnetwork/drivers/macvlan/macvlan_setup.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/libnetwork/ns"
+	"github.com/docker/docker/pkg/stringid"
 	"github.com/vishvananda/netlink"
 )
 
@@ -202,5 +203,5 @@ func delDummyLink(linkName string) error {
 
 // getDummyName returns the name of a dummy parent with truncated net ID and driver prefix
 func getDummyName(netID string) string {
-	return dummyPrefix + netID
+	return dummyPrefix + stringid.TruncateID(netID)
 }

--- a/libnetwork/drivers/macvlan/macvlan_setup.go
+++ b/libnetwork/drivers/macvlan/macvlan_setup.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/libnetwork/ns"
-	"github.com/docker/docker/pkg/stringid"
 	"github.com/vishvananda/netlink"
 )
 
 const (
-	dummyPrefix = "dm-" // macvlan prefix for dummy parent interface
+	dummyPrefix   = "dm-" // prefix for dummy macvlan parent interfaces.
+	dummyIDLength = 12    // length for dummy parent interface IDs.
 )
 
 // Create the macvlan slave specifying the source name
@@ -203,5 +203,8 @@ func delDummyLink(linkName string) error {
 
 // getDummyName returns the name of a dummy parent with truncated net ID and driver prefix
 func getDummyName(netID string) string {
-	return dummyPrefix + stringid.TruncateID(netID)
+	if len(netID) > dummyIDLength {
+		netID = netID[:dummyIDLength]
+	}
+	return dummyPrefix + netID
 }


### PR DESCRIPTION
- ⚠️ this will conflict with https://github.com/moby/moby/pull/47318, so we can merge this after.

### libnetwork/drivers/ipvlan: move truncating ID to getDummyName

The function description mentions that the returned value will contain
a truncated ID, but the function was only prepending the prefix, which
meant that callers had to be aware that truncating is necessary.

This patch moves truncating the ID into the utility to make its use
less error-prone, and to make the code a bite more DRY.

### libnetwork/drivers/ipvlan: getDummyName don't use stringid.TruncateID

The stringid.TruncateID utility is used to provide a consistent length
for "short IDs" (containers, networks). While the dummy interfaces need
a short identifier, they use their own format and don't have to follow
the same length as is used for "short IDs" elsewhere.

In addition, stringid.TruncateID has an additional check for the given
ID to contain colons (":"), which won't be the case for network-IDs that
are passed to it, so this check is redundant.

This patch moves the truncating local to the getDummyName function, so
that it can define its own semantics, independent of changes elsewhere.


### libnetwork/drivers/macvlan: move truncating ID to getDummyName

The function description mentions that the returned value will contain
a truncated ID, but the function was only prepending the prefix, which
meant that callers had to be aware that truncating is necessary.

This patch moves truncating the ID into the utility to make its use
less error-prone, and to make the code a bite more DRY.

### libnetwork/drivers/macvlan: getDummyName don't use stringid.TruncateID

The stringid.TruncateID utility is used to provide a consistent length
for "short IDs" (containers, networks). While the dummy interfaces need
a short identifier, they use their own format and don't have to follow
the same length as is used for "short IDs" elsewhere.

In addition, stringid.TruncateID has an additional check for the given
ID to contain colons (":"), which won't be the case for network-IDs that
are passed to it, so this check is redundant.

This patch moves the truncating local to the getDummyName function, so
that it can define its own semantics, independent of changes elsewhere.



**- A picture of a cute animal (not mandatory but encouraged)**

