### PR TITLE
pkg/stringid: deprecate ValidateID, IsShortID

### DIFF
--- a/image/v1/imagev1.go
+++ b/image/v1/imagev1.go
@@ -3,20 +3,27 @@ package v1 // import "github.com/docker/docker/image/v1"
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"regexp"
 	"strings"
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
-	"github.com/docker/docker/pkg/stringid"
 	"github.com/opencontainers/go-digest"
 )
 
-// noFallbackMinVersion is the minimum version for which v1compatibility
-// information will not be marshaled through the Image struct to remove
-// blank fields.
-const noFallbackMinVersion = "1.8.3"
+const (
+	// noFallbackMinVersion is the minimum version for which v1compatibility
+	// information will not be marshaled through the Image struct to remove
+	// blank fields.
+	noFallbackMinVersion = "1.8.3"
+
+	fullLen = 64
+)
+
+var validHex = regexp.MustCompile(`^[a-f0-9]{64}$`)
 
 // HistoryFromConfig creates a History struct from v1 configuration JSON
 func HistoryFromConfig(imageJSON []byte, emptyLayer bool) (image.History, error) {
@@ -116,5 +123,11 @@ func rawJSON(value interface{}) *json.RawMessage {
 
 // ValidateID checks whether an ID string is a valid image ID.
 func ValidateID(id string) error {
-	return stringid.ValidateID(id)
+	if len(id) != fullLen {
+		return errors.New("image ID '" + id + "' is invalid")
+	}
+	if !validHex.MatchString(id) {
+		return errors.New("image ID '" + id + "' is invalid")
+	}
+	return nil
 }

--- a/pkg/stringid/stringid.go
+++ b/pkg/stringid/stringid.go
@@ -22,6 +22,8 @@ var (
 
 // IsShortID determines if id has the correct format and length for a short ID.
 // It checks the IDs length and if it consists of valid characters for IDs (a-f0-9).
+//
+// Deprecated: this function is no longer used, and will be removed in the next release.
 func IsShortID(id string) bool {
 	if len(id) != shortLen {
 		return false

--- a/pkg/stringid/stringid.go
+++ b/pkg/stringid/stringid.go
@@ -62,6 +62,8 @@ func GenerateRandomID() string {
 }
 
 // ValidateID checks whether an ID string is a valid, full-length image ID.
+//
+// Deprecated: use [github.com/docker/docker/image/v1.ValidateID] instead. Will be removed in the next release.
 func ValidateID(id string) error {
 	if len(id) != fullLen {
 		return errors.New("image ID '" + id + "' is invalid")


### PR DESCRIPTION
### pkg/stringid: deprecate ValidateID

This function is only used for the legacy v1 image format.

Deprecate the function, and make image/v1 self-contained.

### pkg/stringid: deprecate IsShortID

This function is no longer used, and has no external users. Deprecated
the function and mark if for removal for the next release.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
- deprecate pkg/stringid.ValidateID
- deprecate pkg/stringid.IsShortID
```

**- A picture of a cute animal (not mandatory but encouraged)**

