### PR TITLE
pkg/longpath: deprecate Prefix const, and use early returns in AddPrefix

### DIFF
--- a/pkg/longpath/longpath.go
+++ b/pkg/longpath/longpath.go
@@ -12,17 +12,22 @@ import (
 )
 
 // Prefix is the longpath prefix for Windows file paths.
-const Prefix = `\\?\`
+//
+// Deprecated: this const is only used internally, and will be removed in the next release
+const Prefix = longPathPrefix
+
+// longPathPrefix is the longpath prefix for Windows file paths.
+const longPathPrefix = `\\?\`
 
 // AddPrefix adds the Windows long path prefix to the path provided if
 // it does not already have it.
 func AddPrefix(path string) string {
-	if !strings.HasPrefix(path, Prefix) {
+	if !strings.HasPrefix(path, longPathPrefix) {
 		if strings.HasPrefix(path, `\\`) {
 			// This is a UNC path, so we need to add 'UNC' to the path as well.
-			path = Prefix + `UNC` + path[1:]
+			path = longPathPrefix + `UNC` + path[1:]
 		} else {
-			path = Prefix + path
+			path = longPathPrefix + path
 		}
 	}
 	return path

--- a/pkg/longpath/longpath.go
+++ b/pkg/longpath/longpath.go
@@ -22,15 +22,14 @@ const longPathPrefix = `\\?\`
 // AddPrefix adds the Windows long path prefix to the path provided if
 // it does not already have it.
 func AddPrefix(path string) string {
-	if !strings.HasPrefix(path, longPathPrefix) {
-		if strings.HasPrefix(path, `\\`) {
-			// This is a UNC path, so we need to add 'UNC' to the path as well.
-			path = longPathPrefix + `UNC` + path[1:]
-		} else {
-			path = longPathPrefix + path
-		}
+	if strings.HasPrefix(path, longPathPrefix) {
+		return path
 	}
-	return path
+	if strings.HasPrefix(path, `\\`) {
+		// This is a UNC path, so we need to add 'UNC' to the path as well.
+		return longPathPrefix + `UNC` + path[1:]
+	}
+	return longPathPrefix + path
 }
 
 // MkdirTemp is the equivalent of [os.MkdirTemp], except that on Windows


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/40648


### pkg/longpath: deprecate Prefix const

This const was exported because it was in use by pkg/symlink. This
dependency was removed in a48c6e30057bed6092ffe82cd1976c7ae0ec227d,
after which this const was only used internally.

This patch deprecates the const and introduces a non-exported const
to use.

There are no known external consumers of this const, so we may skip
deprecating it.

### pkg/longpath: AddPrefix: use early returns

**- What I did**



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
deprecate pkg/longpath.Prefix const
```

**- A picture of a cute animal (not mandatory but encouraged)**

