### PR TITLE
pkg/archive, pkg/chrootarchive: remove dependency on pkg/longpath

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -885,7 +885,7 @@ func NewTarballer(srcPath string, options *TarOptions) (*Tarballer, error) {
 	return &Tarballer{
 		// Fix the source path to work with long path names. This is a no-op
 		// on platforms other than Windows.
-		srcPath:           fixVolumePathPrefix(srcPath),
+		srcPath:           addLongPathPrefix(srcPath),
 		options:           options,
 		pm:                pm,
 		pipeReader:        pipeReader,

--- a/pkg/archive/archive_unix.go
+++ b/pkg/archive/archive_unix.go
@@ -21,9 +21,9 @@ func init() {
 	sysStat = statUnix
 }
 
-// fixVolumePathPrefix does platform specific processing to ensure that if
-// the path being passed in is not in a volume path format, convert it to one.
-func fixVolumePathPrefix(srcPath string) string {
+// addLongPathPrefix adds the Windows long path prefix to the path provided if
+// it does not already have it. It is a no-op on platforms other than Windows.
+func addLongPathPrefix(srcPath string) string {
 	return srcPath
 }
 

--- a/pkg/chrootarchive/archive_windows.go
+++ b/pkg/chrootarchive/archive_windows.go
@@ -2,16 +2,34 @@ package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
 
 import (
 	"io"
+	"strings"
 
 	"github.com/docker/docker/pkg/archive"
-	"github.com/docker/docker/pkg/longpath"
 )
+
+// longPathPrefix is the longpath prefix for Windows file paths.
+const longPathPrefix = `\\?\`
+
+// addLongPathPrefix adds the Windows long path prefix to the path provided if
+// it does not already have it. It is a no-op on platforms other than Windows.
+//
+// addLongPathPrefix is a copy of [github.com/docker/docker/pkg/longpath.AddPrefix].
+func addLongPathPrefix(srcPath string) string {
+	if strings.HasPrefix(srcPath, longPathPrefix) {
+		return srcPath
+	}
+	if strings.HasPrefix(srcPath, `\\`) {
+		// This is a UNC path, so we need to add 'UNC' to the path as well.
+		return longPathPrefix + `UNC` + srcPath[1:]
+	}
+	return longPathPrefix + srcPath
+}
 
 func invokeUnpack(decompressedArchive io.ReadCloser, dest string, options *archive.TarOptions, root string) error {
 	// Windows is different to Linux here because Windows does not support
 	// chroot. Hence there is no point sandboxing a chrooted process to
 	// do the unpack. We call inline instead within the daemon process.
-	return archive.Unpack(decompressedArchive, longpath.AddPrefix(dest), options)
+	return archive.Unpack(decompressedArchive, addLongPathPrefix(dest), options)
 }
 
 func invokePack(srcPath string, options *archive.TarOptions, root string) (io.ReadCloser, error) {

--- a/pkg/chrootarchive/diff_unix.go
+++ b/pkg/chrootarchive/diff_unix.go
@@ -14,7 +14,6 @@ import (
 // applies it to the directory `dest`. Returns the size in bytes of the
 // contents of the layer.
 func applyLayerHandler(dest string, layer io.Reader, options *archive.TarOptions, decompress bool) (size int64, err error) {
-	dest = filepath.Clean(dest)
 	if decompress {
 		decompressed, err := archive.DecompressStream(layer)
 		if err != nil {
@@ -33,5 +32,6 @@ func applyLayerHandler(dest string, layer io.Reader, options *archive.TarOptions
 	if options.ExcludePatterns == nil {
 		options.ExcludePatterns = []string{}
 	}
+	dest = filepath.Clean(dest)
 	return doUnpackLayer(dest, layer, options)
 }

--- a/pkg/chrootarchive/diff_windows.go
+++ b/pkg/chrootarchive/diff_windows.go
@@ -6,18 +6,12 @@ import (
 	"path/filepath"
 
 	"github.com/docker/docker/pkg/archive"
-	"github.com/docker/docker/pkg/longpath"
 )
 
 // applyLayerHandler parses a diff in the standard layer format from `layer`, and
 // applies it to the directory `dest`. Returns the size in bytes of the
 // contents of the layer.
 func applyLayerHandler(dest string, layer io.Reader, options *archive.TarOptions, decompress bool) (size int64, err error) {
-	dest = filepath.Clean(dest)
-
-	// Ensure it is a Windows-style volume path
-	dest = longpath.AddPrefix(dest)
-
 	if decompress {
 		decompressed, err := archive.DecompressStream(layer)
 		if err != nil {
@@ -28,6 +22,8 @@ func applyLayerHandler(dest string, layer io.Reader, options *archive.TarOptions
 		layer = decompressed
 	}
 
+	// Ensure it is a Windows-style volume path
+	dest = addLongPathPrefix(filepath.Clean(dest))
 	s, err := archive.UnpackLayer(dest, layer, nil)
 	if err != nil {
 		return 0, fmt.Errorf("ApplyLayer %s failed UnpackLayer to %s: %s", layer, dest, err)


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/21700
- relates to https://github.com/moby/moby/issues/32989


### pkg/archive: remove dependency on pkg/longpath

Copy the function to the package, so that we don't have a dependency
on pkg/longpath.

### pkg/chrootarchive: remove dependency on pkg/longpath

Copy the function to the package, so that we don't have a dependency
on pkg/longpath.


**- A picture of a cute animal (not mandatory but encouraged)**

