### PR TITLE
pkg/dmesg: deprecate, and use internal utility instead

### DIFF
--- a/pkg/dmesg/dmesg_linux.go
+++ b/pkg/dmesg/dmesg_linux.go
@@ -4,7 +4,9 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// Dmesg returns last messages from the kernel log, up to size bytes
+// Dmesg returns last messages from the kernel log, up to size bytes.
+//
+// Deprecated: the dmesg package is no longer used, and will be removed in the next release.
 func Dmesg(size int) []byte {
 	b := make([]byte, size)
 	amt, err := unix.Klogctl(unix.SYSLOG_ACTION_READ_ALL, b)

--- a/pkg/dmesg/dmesg_linux.go
+++ b/pkg/dmesg/dmesg_linux.go
@@ -6,9 +6,8 @@ import (
 
 // Dmesg returns last messages from the kernel log, up to size bytes
 func Dmesg(size int) []byte {
-	t := 3 // SYSLOG_ACTION_READ_ALL
 	b := make([]byte, size)
-	amt, err := unix.Klogctl(t, b)
+	amt, err := unix.Klogctl(unix.SYSLOG_ACTION_READ_ALL, b)
 	if err != nil {
 		return []byte{}
 	}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/32989
- relates to https://github.com/moby/moby/pull/34550
- relates to https://github.com/moby/moby/pull/43637

### pkg/dmesg: use unix.SYSLOG_ACTION_READ_ALL instead of local variable

This value was originally added in 46833ee1c353c247e3ef817a08d5a35a2a43bdf3 (https://github.com/moby/moby/pull/34550),
at which time golang.org/x/sys/unix didn't have utilities for this syscall.
A later patch switched the implementation to use the golang/x/sys/unix
implementation in 2841b05b71095d662ecb47831d88371e9cb033ff, but kept the
local variable.

golang.org/x/sys now has a const for this, so let's use it.


### pkg/dmesg: deprecate, and use internal utility instead

This package was originally added in 46833ee1c353c247e3ef817a08d5a35a2a43bdf3
for use in the devicemapper graphdriver. The devicemapper graphdriver was
deprecated and has been removed. The only remaining consumer is an integration
test.

Deprecate the package and mark it for removal in the next release.



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Deprecate pkg/dmesg. This package was no longer used, and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

