### PR TITLE
pkg/archive. pkg/tarsum: format #nosec comments to standard format

### DIFF
--- a/pkg/archive/archive_linux.go
+++ b/pkg/archive/archive_linux.go
@@ -62,7 +62,7 @@ func (overlayWhiteoutConverter) ConvertWrite(hdr *tar.Header, path string, fi os
 				Gname:      hdr.Gname,
 				AccessTime: hdr.AccessTime,
 				ChangeTime: hdr.ChangeTime,
-			} //#nosec G305 -- An archive is being created, not extracted.
+			} // #nosec G305 -- An archive is being created, not extracted.
 		}
 	}
 

--- a/pkg/archive/diff.go
+++ b/pkg/archive/diff.go
@@ -102,7 +102,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				continue
 			}
 		}
-		//#nosec G305 -- The joined path is guarded against path traversal.
+		// #nosec G305 -- The joined path is guarded against path traversal.
 		path := filepath.Join(dest, hdr.Name)
 		rel, err := filepath.Rel(dest, path)
 		if err != nil {
@@ -198,7 +198,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 	}
 
 	for _, hdr := range dirs {
-		//#nosec G305 -- The header was checked for path traversal before it was appended to the dirs slice.
+		// #nosec G305 -- The header was checked for path traversal before it was appended to the dirs slice.
 		path := filepath.Join(dest, hdr.Name)
 		if err := system.Chtimes(path, hdr.AccessTime, hdr.ModTime); err != nil {
 			return 0, err

--- a/pkg/tarsum/tarsum.go
+++ b/pkg/tarsum/tarsum.go
@@ -242,7 +242,7 @@ func (ts *tarSum) Read(buf []byte) (int, error) {
 				return 0, err
 			}
 
-			//#nosec G305 -- The joined path is not passed to any filesystem APIs.
+			// #nosec G305 -- The joined path is not passed to any filesystem APIs.
 			ts.currentFile = path.Join(".", path.Join("/", currentHeader.Name))
 			if err := ts.encodeHeader(currentHeader); err != nil {
 				return 0, err


### PR DESCRIPTION
- relates to https://github.com/securego/gosec/issues/1106

---

gosec uses a non-standard format for "automated" comments to suppress
false positives (such comments should not have a leading space, but
are not allowed to start with a non-alphabetical character). However,
current versions of gosec do allow a leading space.

This patch reformats the comments to prevent them from being changed
by IDEs when reformating code.


**- A picture of a cute animal (not mandatory but encouraged)**

