### PR TITLE
pkg/archive: deprecate CanonicalTarNameForPath

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -541,8 +541,10 @@ func newTarAppender(idMapping idtools.IdentityMapping, writer io.Writer, chownOp
 }
 
 // CanonicalTarNameForPath canonicalizes relativePath to a POSIX-style path using
-// forward slashes. It is an alias for filepath.ToSlash, which is a no-op on
+// forward slashes. It is an alias for [filepath.ToSlash], which is a no-op on
 // Linux and Unix.
+//
+// Deprecated: use [filepath.ToSlash]. This function will be removed in the next release.
 func CanonicalTarNameForPath(relativePath string) string {
 	return filepath.ToSlash(relativePath)
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/44060
- relates to https://github.com/docker/compose/pull/11910
- relates to https://github.com/moby/moby/issues/21700


Commit d59758450b6bb876867beadc5cd7be2d1805687c changed this function to be a wrapper for `filepath.ToSlash`. It was used in the CLI for the classic builder, but is no longer used in our codebase.

However, there may still be some consumers that copied the CLI code for the classic builder that didn't synchronise their implementation yet, so let's deprecate this function to give them a warning that they should no longer use this.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
pkg/archive: deprecate CanonicalTarNameForPath
```

**- A picture of a cute animal (not mandatory but encouraged)**

