### PR TITLE
pkg/archive: deprecate NewTempArchive, TempArchive

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -1452,6 +1452,8 @@ func cmdStream(cmd *exec.Cmd, input io.Reader) (io.ReadCloser, error) {
 // NewTempArchive reads the content of src into a temporary file, and returns the contents
 // of that file as an archive. The archive can only be read once - as soon as reading completes,
 // the file will be deleted.
+//
+// Deprecated: NewTempArchive is only used in tests and will be removed in the next release.
 func NewTempArchive(src io.Reader, dir string) (*TempArchive, error) {
 	f, err := os.CreateTemp(dir, "")
 	if err != nil {
@@ -1473,6 +1475,8 @@ func NewTempArchive(src io.Reader, dir string) (*TempArchive, error) {
 
 // TempArchive is a temporary archive. The archive can only be read once - as soon as reading completes,
 // the file will be deleted.
+//
+// Deprecated: TempArchive is only used in tests and will be removed in the next release.
 type TempArchive struct {
 	*os.File
 	Size   int64 // Pre-computed from Stat().Size() as a convenience


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/21700

These were added in baacae8345febd688579ac29832c200c41602ed2, but are currently only used in tests inside pkg/archive. There are no external users of this function, so we should deprecated them.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
pkg/archive: deprecate NewTempArchive, TempArchive. These types were only used in tests and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

