### PR TITLE
pkg/archive: assorted minor refactors and cleanups

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -98,24 +98,16 @@ func NewDefaultArchiver() *Archiver {
 type breakoutError error
 
 const (
-	// Uncompressed represents the uncompressed.
-	Uncompressed Compression = iota
-	// Bzip2 is bzip2 compression algorithm.
-	Bzip2
-	// Gzip is gzip compression algorithm.
-	Gzip
-	// Xz is xz compression algorithm.
-	Xz
-	// Zstd is zstd compression algorithm.
-	Zstd
+	Uncompressed Compression = 0 // Uncompressed represents the uncompressed.
+	Bzip2        Compression = 1 // Bzip2 is bzip2 compression algorithm.
+	Gzip         Compression = 2 // Gzip is gzip compression algorithm.
+	Xz           Compression = 3 // Xz is xz compression algorithm.
+	Zstd         Compression = 4 // Zstd is zstd compression algorithm.
 )
 
 const (
-	// AUFSWhiteoutFormat is the default format for whiteouts
-	AUFSWhiteoutFormat WhiteoutFormat = iota
-	// OverlayWhiteoutFormat formats whiteout according to the overlay
-	// standard.
-	OverlayWhiteoutFormat
+	AUFSWhiteoutFormat    WhiteoutFormat = 0 // AUFSWhiteoutFormat is the default format for whiteouts
+	OverlayWhiteoutFormat WhiteoutFormat = 1 // OverlayWhiteoutFormat formats whiteout according to the overlay standard.
 )
 
 // IsArchivePath checks if the (possibly compressed) file at the given path

--- a/pkg/archive/changes.go
+++ b/pkg/archive/changes.go
@@ -23,12 +23,9 @@ import (
 type ChangeType int
 
 const (
-	// ChangeModify represents the modify operation.
-	ChangeModify = iota
-	// ChangeAdd represents the add operation.
-	ChangeAdd
-	// ChangeDelete represents the delete operation.
-	ChangeDelete
+	ChangeModify = 0 // ChangeModify represents the modify operation.
+	ChangeAdd    = 1 // ChangeAdd represents the add operation.
+	ChangeDelete = 2 // ChangeDelete represents the delete operation.
 )
 
 func (c ChangeType) String() string {

--- a/pkg/archive/changes_other.go
+++ b/pkg/archive/changes_other.go
@@ -72,17 +72,17 @@ func collectFileInfo(sourceDir string) (*FileInfo, error) {
 			return fmt.Errorf("collectFileInfo: Unexpectedly no parent for %s", relPath)
 		}
 
-		info := &FileInfo{
-			name:     filepath.Base(relPath),
-			children: make(map[string]*FileInfo),
-			parent:   parent,
-		}
-
 		s, err := system.Lstat(path)
 		if err != nil {
 			return err
 		}
-		info.stat = s
+
+		info := &FileInfo{
+			name:     filepath.Base(relPath),
+			children: make(map[string]*FileInfo),
+			parent:   parent,
+			stat:     s,
+		}
 
 		info.capability, _ = system.Lgetxattr(path, "security.capability")
 

--- a/pkg/archive/changes_other.go
+++ b/pkg/archive/changes_other.go
@@ -84,7 +84,11 @@ func collectFileInfo(sourceDir string) (*FileInfo, error) {
 			stat:     s,
 		}
 
-		info.capability, _ = system.Lgetxattr(path, "security.capability")
+		// system.Lgetxattr is only implemented on Linux and produces an error
+		// on other platforms. This code is intentionally left commented-out
+		// as a reminder to include this code if this would ever be implemented
+		// on other platforms.
+		// info.capability, _ = system.Lgetxattr(path, "security.capability")
 
 		parent.children[info.name] = info
 

--- a/pkg/archive/changes_test.go
+++ b/pkg/archive/changes_test.go
@@ -52,9 +52,9 @@ func copyDir(src, dst string) error {
 type FileType uint32
 
 const (
-	Regular FileType = iota
-	Dir
-	Symlink
+	Regular FileType = 0
+	Dir     FileType = 1
+	Symlink FileType = 2
 )
 
 type FileData struct {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/21700

### pkg/archive: collectFileInfo: don't create FileInfo if unused

The system.Lstat may fail, in which case it would be discarded,
so let's move it later.


### pkg/archive: don't call system.Lgetxattr on unsupported platforms

[pkg/system.Lgetxattr] is only implemented on Linux, and always produces
an ErrNotSupportedPlatform on other platforms.

This patch removes the call to this function, but intentionally leaves
it commented-out as a reminder to include this code if this would ever
be refactored and implemented on other platforms.

[pkg/system.Lgetxattr]: https://github.com/moby/moby/blob/d1273b2b4a1fa511890035fbf75d299f345c5aaa/pkg/system/xattrs_unsupported.go#L1-L8

### pkg/archive: remove uses of iota

While using iota can be convenient, it can also make it harder to grasp
what value is assigned. Use of iota also makes changing values implicit;
changing the order of these consts implicitly means their value changes.

This can be problematic, as some of these consts are a plain `int` and
while golang is strong-typed, it does allow plain `int` values to be
used for such values.

For example, `archive.Tar` accepts a `Compression` as second argument,
but allows a plain int to be passed, so both of these are equivalent;

    archive.Tar(contextDir, archive.Uncompressed)
    archive.Tar(contextDir, 0)

This patch removes the use of `iota`, and instead explicitly setting a
value for each to prevent accidental changes in their value, which can
be hard to discover.





**- A picture of a cute animal (not mandatory but encouraged)**

