### PR TITLE
pkg/archive: TestChangesDirsEmpty, TestChangesDirsMutated: no kernel-version check

### DIFF
--- a/pkg/archive/changes_test.go
+++ b/pkg/archive/changes_test.go
@@ -7,15 +7,11 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
-	"strconv"
-	"strings"
 	"syscall"
 	"testing"
 	"time"
 
-	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/docker/docker/pkg/idtools"
-	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/system"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/skip"
@@ -250,16 +246,8 @@ func TestChangesWithChangesGH13590(t *testing.T) {
 
 // Create a directory, copy it, make sure we report no changes between the two
 func TestChangesDirsEmpty(t *testing.T) {
-	// Note we parse kernel.GetKernelVersion rather than system.GetOSVersion
-	// as test binaries aren't manifested, so would otherwise report the wrong
-	// build number.
 	if runtime.GOOS == "windows" {
-		v, err := kernel.GetKernelVersion()
-		assert.NilError(t, err)
-		build, _ := strconv.Atoi(strings.Split(strings.SplitN(v.String(), " ", 3)[2][1:], ".")[0])
-		if build >= osversion.V19H1 {
-			t.Skip("FIXME: broken on Windows 1903 and up; see #39846")
-		}
+		t.Skip("FIXME: broken on Windows 1903 and up; see https://github.com/moby/moby/pull/39846")
 	}
 
 	src, err := os.MkdirTemp("", "docker-changes-test")
@@ -344,16 +332,8 @@ func mutateSampleDir(t *testing.T, root string) {
 }
 
 func TestChangesDirsMutated(t *testing.T) {
-	// Note we parse kernel.GetKernelVersion rather than system.GetOSVersion
-	// as test binaries aren't manifested, so would otherwise report the wrong
-	// build number.
 	if runtime.GOOS == "windows" {
-		v, err := kernel.GetKernelVersion()
-		assert.NilError(t, err)
-		build, _ := strconv.Atoi(strings.Split(strings.SplitN(v.String(), " ", 3)[2][1:], ".")[0])
-		if build >= osversion.V19H1 {
-			t.Skip("FIXME: broken on Windows 1903 and up; see #39846")
-		}
+		t.Skip("FIXME: broken on Windows 1903 and up; see https://github.com/moby/moby/pull/39846")
 	}
 
 	src, err := os.MkdirTemp("", "docker-changes-test")


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/39846
- relates to https://github.com/moby/moby/issues/21700
- relates to https://github.com/moby/moby/pull/48004

TestChangesDirsEmpty and TestChangesDirsMutated fail on Windows V19H1 (1903) and up, possibly due to changes in the kernel:

    === FAIL: github.com/docker/docker/pkg/archive TestChangesDirsEmpty (0.21s)
    changes_test.go:261: Reported changes for identical dirs: [{\dirSymlink C}]

    === FAIL: github.com/docker/docker/pkg/archive TestChangesDirsMutated (0.14s)
    changes_test.go:391: unexpected change "C \\dirSymlink" "\\dirnew"

commit 8f4b3b0ad41a5e3a29e57f0a8c55cb49e7a0b44f added a version-dependent skip for those tests, but as we no longer run CI on versions before V19H1, we can remove the kernel-version check, and skip it on Windows unconditionally.

**- A picture of a cute animal (not mandatory but encouraged)**

