### PR TITLE
libnetwork: remove special handling for Windows 14393 (RS1, V1607, LTSC2016)

### DIFF
--- a/libnetwork/drivers/windows/overlay/ov_endpoint_windows.go
+++ b/libnetwork/drivers/windows/overlay/ov_endpoint_windows.go
@@ -77,7 +77,7 @@ func (n *network) removeEndpointWithAddress(addr *net.IPNet) {
 
 	if networkEndpoint != nil {
 		log.G(context.TODO()).Debugf("Removing stale endpoint from HNS")
-		_, err := endpointRequest("DELETE", networkEndpoint.profileID, "")
+		_, err := hcsshim.HNSEndpointRequest("DELETE", networkEndpoint.profileID, "")
 		if err != nil {
 			log.G(context.TODO()).Debugf("Failed to delete stale overlay endpoint (%.7s) from hns", networkEndpoint.id)
 		}
@@ -99,7 +99,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 	if ep != nil {
 		log.G(ctx).Debugf("Deleting stale endpoint %s", eid)
 		n.deleteEndpoint(eid)
-		_, err := endpointRequest("DELETE", ep.profileID, "")
+		_, err := hcsshim.HNSEndpointRequest("DELETE", ep.profileID, "")
 		if err != nil {
 			return err
 		}
@@ -182,7 +182,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 		return err
 	}
 
-	hnsresponse, err := endpointRequest("POST", "", string(configurationb))
+	hnsresponse, err := hcsshim.HNSEndpointRequest("POST", "", string(configurationb))
 	if err != nil {
 		return err
 	}
@@ -202,7 +202,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 
 	ep.portMapping, err = windows.ParsePortBindingPolicies(hnsresponse.Policies)
 	if err != nil {
-		endpointRequest("DELETE", hnsresponse.Id, "")
+		hcsshim.HNSEndpointRequest("DELETE", hnsresponse.Id, "")
 		return err
 	}
 
@@ -230,7 +230,7 @@ func (d *driver) DeleteEndpoint(nid, eid string) error {
 
 	n.deleteEndpoint(eid)
 
-	_, err := endpointRequest("DELETE", ep.profileID, "")
+	_, err := hcsshim.HNSEndpointRequest("DELETE", ep.profileID, "")
 	if err != nil {
 		return err
 	}
@@ -267,8 +267,4 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 	}
 
 	return data, nil
-}
-
-func endpointRequest(method, path, request string) (*hcsshim.HNSEndpoint, error) {
-	return hcsshim.HNSEndpointRequest(method, path, request)
 }

--- a/libnetwork/drivers/windows/overlay/ov_endpoint_windows.go
+++ b/libnetwork/drivers/windows/overlay/ov_endpoint_windows.go
@@ -5,10 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"sync"
 
 	"github.com/Microsoft/hcsshim"
-	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/containerd/log"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/drivers/windows"
@@ -30,13 +28,6 @@ type endpoint struct {
 	disablegateway bool
 	portMapping    []types.PortBinding // Operation port bindings
 }
-
-var (
-	// Server 2016 (RS1) does not support concurrent add/delete of endpoints.  Therefore, we need
-	// to use this mutex and serialize the add/delete of endpoints on RS1.
-	endpointMu   sync.Mutex
-	windowsBuild = osversion.Build()
-)
 
 func validateID(nid, eid string) error {
 	if nid == "" {
@@ -279,12 +270,5 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 }
 
 func endpointRequest(method, path, request string) (*hcsshim.HNSEndpoint, error) {
-	if windowsBuild == 14393 {
-		endpointMu.Lock()
-	}
-	hnsresponse, err := hcsshim.HNSEndpointRequest(method, path, request)
-	if windowsBuild == 14393 {
-		endpointMu.Unlock()
-	}
-	return hnsresponse, err
+	return hcsshim.HNSEndpointRequest(method, path, request)
 }

--- a/libnetwork/drivers/windows/overlay/peerdb_windows.go
+++ b/libnetwork/drivers/windows/overlay/peerdb_windows.go
@@ -63,7 +63,7 @@ func (d *driver) peerAdd(nid, eid string, peerIP net.IP, peerIPMask net.IPMask, 
 		}
 
 		n.removeEndpointWithAddress(addr)
-		hnsresponse, err := endpointRequest("POST", "", string(configurationb))
+		hnsresponse, err := hcsshim.HNSEndpointRequest("POST", "", string(configurationb))
 		if err != nil {
 			return err
 		}
@@ -101,7 +101,7 @@ func (d *driver) peerDelete(nid, eid string, peerIP net.IP, peerIPMask net.IPMas
 	}
 
 	if updateDb {
-		_, err := endpointRequest("DELETE", ep.profileID, "")
+		_, err := hcsshim.HNSEndpointRequest("DELETE", ep.profileID, "")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- relates to https://github.com/moby/libnetwork/pull/2356

### libnetwork: remove special handling for Windows 14393 (RS1, V1607, LTSC2016)

This synchronisation was added in [libnetwork@0a61693]:

> Adding synchronization around peerAdd and peerDelete to prevent network
> connectivity issue
>
> When multiple networks are present in a Swarm Cluster, multiple peerAdd
> or peerDelete calls are an issue for different remote endpoints. These
> threads are updating the remote endpoint to HNS parallelly. In 2016 HNS
> code base, we don't have synchronization around remoteEndpoint addition
> and deletion. So serializing the peerAdd and peerDelete calls from docker
> network driver.

We no longer support and test Windows 2016, as it reached EOL / end of
[standard support][1], so we can remove this special condition.

[libnetwork@0a61693]: https://github.com/moby/libnetwork/commit/c90114ce7caeb8b6feb4bf4663e545b8f1e925c8
[1]: https://en.wikipedia.org/wiki/Windows_10,_version_1607

### libnetwork: windows/overlay: remove endpointRequest wrapper

This wrapper is now a plain alias for hcsshim.HNSEndpointRequest, so let's
remove the extra abstraction.

**- A picture of a cute animal (not mandatory but encouraged)**

