### PR TITLE
runconfig: deprecate DefaultDaemonNetworkMode, move to daemon/network

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/versions"
 	containerpkg "github.com/docker/docker/container"
+	networkSettings "github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/pkg/ioutils"
@@ -501,7 +502,7 @@ func (s *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 	// Note that this is not the only place where this conversion has to be
 	// done (as there are various other places where containers get created).
 	if hostConfig.NetworkMode == "" || hostConfig.NetworkMode.IsDefault() {
-		hostConfig.NetworkMode = runconfig.DefaultDaemonNetworkMode()
+		hostConfig.NetworkMode = networkSettings.DefaultNetwork
 		if nw, ok := networkingConfig.EndpointsConfig[network.NetworkDefault]; ok {
 			networkingConfig.EndpointsConfig[hostConfig.NetworkMode.NetworkName()] = nw
 			delete(networkingConfig.EndpointsConfig, network.NetworkDefault)

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -17,11 +17,11 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/builder"
+	networkSettings "github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/stringid"
-	"github.com/docker/docker/runconfig"
 	"github.com/docker/go-connections/nat"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -382,7 +382,7 @@ func hostConfigFromOptions(options *types.ImageBuildOptions) *container.HostConf
 	// This is in line with what the ContainerCreate API endpoint does.
 	networkMode := options.NetworkMode
 	if networkMode == "" || networkMode == network.NetworkDefault {
-		networkMode = runconfig.DefaultDaemonNetworkMode().NetworkName()
+		networkMode = networkSettings.DefaultNetwork
 	}
 
 	hc := &container.HostConfig{

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -23,8 +23,8 @@ import (
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/daemon/cluster/convert"
 	executorpkg "github.com/docker/docker/daemon/cluster/executor"
+	networkSettings "github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/libnetwork"
-	"github.com/docker/docker/runconfig"
 	volumeopts "github.com/docker/docker/volume/service/opts"
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/moby/swarmkit/v2/agent/exec"
@@ -305,10 +305,10 @@ func (c *containerAdapter) create(ctx context.Context) error {
 	// need to make this normalization happen once we're sure we won't make a
 	// cross-OS API call.
 	if hostConfig.NetworkMode == "" || hostConfig.NetworkMode.IsDefault() {
-		hostConfig.NetworkMode = runconfig.DefaultDaemonNetworkMode()
+		hostConfig.NetworkMode = networkSettings.DefaultNetwork
 		if v, ok := netConfig.EndpointsConfig[network.NetworkDefault]; ok {
 			delete(netConfig.EndpointsConfig, network.NetworkDefault)
-			netConfig.EndpointsConfig[runconfig.DefaultDaemonNetworkMode().NetworkName()] = v
+			netConfig.EndpointsConfig[networkSettings.DefaultNetwork] = v
 		}
 	}
 

--- a/daemon/cluster/networks.go
+++ b/daemon/cluster/networks.go
@@ -9,7 +9,7 @@ import (
 	"github.com/docker/docker/api/types/network"
 	types "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/daemon/cluster/convert"
-	internalnetwork "github.com/docker/docker/daemon/network"
+	networkSettings "github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/runconfig"
 	swarmapi "github.com/moby/swarmkit/v2/api"
@@ -39,7 +39,7 @@ func (c *Cluster) GetNetworks(filter filters.Args) ([]network.Inspect, error) {
 	}
 	filterPredefinedNetworks(&list)
 
-	return internalnetwork.FilterNetworks(list, filter)
+	return networkSettings.FilterNetworks(list, filter)
 }
 
 func filterPredefinedNetworks(networks *[]network.Inspect) {

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -160,7 +160,7 @@ func (daemon *Daemon) buildSandboxOptions(cfg *config.Config, ctr *container.Con
 	// Legacy Link feature is supported only for the default bridge network.
 	// return if this call to build join options is not for default bridge network
 	// Legacy Link is only supported by docker run --link
-	defaultNetName := runconfig.DefaultDaemonNetworkMode().NetworkName()
+	defaultNetName := network.DefaultNetwork
 	bridgeSettings, ok := ctr.NetworkSettings.Networks[defaultNetName]
 	if !ok || bridgeSettings.EndpointSettings == nil || bridgeSettings.EndpointID == "" {
 		return sboxOptions, nil
@@ -268,7 +268,7 @@ func (daemon *Daemon) updateEndpointNetworkSettings(cfg *config.Config, ctr *con
 		return err
 	}
 
-	if ctr.HostConfig.NetworkMode == runconfig.DefaultDaemonNetworkMode() {
+	if ctr.HostConfig.NetworkMode == network.DefaultNetwork {
 		ctr.NetworkSettings.Bridge = cfg.BridgeConfig.Iface
 	}
 
@@ -296,7 +296,7 @@ func (daemon *Daemon) updateNetwork(cfg *config.Config, ctr *container.Container
 		if err != nil {
 			continue
 		}
-		if sn.Name() == runconfig.DefaultDaemonNetworkMode().NetworkName() {
+		if sn.Name() == network.DefaultNetwork {
 			n = sn
 			break
 		}
@@ -505,7 +505,7 @@ func (daemon *Daemon) allocateNetwork(ctx context.Context, cfg *config.Config, c
 	// network mode support link and we need do some setting
 	// on sandbox initialize for link, but the sandbox only be initialized
 	// on first network connecting.
-	defaultNetName := runconfig.DefaultDaemonNetworkMode().NetworkName()
+	defaultNetName := network.DefaultNetwork
 	if nConf, ok := ctr.NetworkSettings.Networks[defaultNetName]; ok {
 		cleanOperationalData(nConf)
 		if err := daemon.connectToNetwork(ctx, cfg, ctr, defaultNetName, nConf, updateSettings); err != nil {

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -14,12 +14,12 @@ import (
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/daemon/links"
+	"github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/process"
 	"github.com/docker/docker/pkg/stringid"
-	"github.com/docker/docker/runconfig"
 	"github.com/moby/sys/mount"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
@@ -30,7 +30,7 @@ func (daemon *Daemon) setupLinkedContainers(ctr *container.Container) ([]string,
 	var env []string
 	children := daemon.children(ctr)
 
-	bridgeSettings := ctr.NetworkSettings.Networks[runconfig.DefaultDaemonNetworkMode().NetworkName()]
+	bridgeSettings := ctr.NetworkSettings.Networks[network.DefaultNetwork]
 	if bridgeSettings == nil || bridgeSettings.EndpointSettings == nil {
 		return nil, nil
 	}
@@ -40,7 +40,7 @@ func (daemon *Daemon) setupLinkedContainers(ctr *container.Container) ([]string,
 			return nil, fmt.Errorf("Cannot link to a non running container: %s AS %s", child.Name, linkAlias)
 		}
 
-		childBridgeSettings := child.NetworkSettings.Networks[runconfig.DefaultDaemonNetworkMode().NetworkName()]
+		childBridgeSettings := child.NetworkSettings.Networks[network.DefaultNetwork]
 		if childBridgeSettings == nil || childBridgeSettings.EndpointSettings == nil {
 			return nil, fmt.Errorf("container %s not attached to default bridge network", child.ID)
 		}
@@ -402,7 +402,7 @@ func killProcessDirectly(ctr *container.Container) error {
 
 func isLinkable(child *container.Container) bool {
 	// A container is linkable only if it belongs to the default network
-	_, ok := child.NetworkSettings.Networks[runconfig.DefaultDaemonNetworkMode().NetworkName()]
+	_, ok := child.NetworkSettings.Networks[network.DefaultNetwork]
 	return ok
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -75,7 +75,6 @@ import (
 	pluginexec "github.com/docker/docker/plugin/executor/containerd"
 	refstore "github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
-	"github.com/docker/docker/runconfig"
 	volumesservice "github.com/docker/docker/volume/service"
 	"github.com/moby/buildkit/util/grpcerrors"
 	"github.com/moby/buildkit/util/resolver"
@@ -391,7 +390,7 @@ func (daemon *Daemon) restore(cfg *configStore) error {
 				//
 				// TODO(aker): remove this migration code once the next LTM version of MCR is released.
 				if c.HostConfig.NetworkMode.IsDefault() {
-					c.HostConfig.NetworkMode = runconfig.DefaultDaemonNetworkMode()
+					c.HostConfig.NetworkMode = network.DefaultNetwork
 					if nw, ok := c.NetworkSettings.Networks[networktypes.NetworkDefault]; ok {
 						c.NetworkSettings.Networks[c.HostConfig.NetworkMode.NetworkName()] = nw
 						delete(c.NetworkSettings.Networks, networktypes.NetworkDefault)
@@ -1486,13 +1485,11 @@ func isBridgeNetworkDisabled(conf *config.Config) bool {
 }
 
 func (daemon *Daemon) networkOptions(conf *config.Config, pg plugingetter.PluginGetter, hostID string, activeSandboxes map[string]interface{}) ([]nwconfig.Option, error) {
-	dd := runconfig.DefaultDaemonNetworkMode()
-
 	options := []nwconfig.Option{
 		nwconfig.OptionDataDir(conf.Root),
 		nwconfig.OptionExecRoot(conf.GetExecRoot()),
-		nwconfig.OptionDefaultDriver(string(dd)),
-		nwconfig.OptionDefaultNetwork(dd.NetworkName()),
+		nwconfig.OptionDefaultDriver(network.DefaultNetwork),
+		nwconfig.OptionDefaultNetwork(network.DefaultNetwork),
 		nwconfig.OptionLabels(conf.Labels),
 		nwconfig.OptionNetworkControlPlaneMTU(conf.NetworkControlPlaneMTU),
 		driverOptions(conf),

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -15,11 +15,11 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/api/types/network"
+	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/container"
 	clustertypes "github.com/docker/docker/daemon/cluster/provider"
 	"github.com/docker/docker/daemon/config"
-	internalnetwork "github.com/docker/docker/daemon/network"
+	"github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork"
 	lncluster "github.com/docker/docker/libnetwork/cluster"
@@ -28,7 +28,7 @@ import (
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/networkdb"
 	"github.com/docker/docker/libnetwork/options"
-	networktypes "github.com/docker/docker/libnetwork/types"
+	lntypes "github.com/docker/docker/libnetwork/types"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/docker/runconfig"
@@ -246,7 +246,7 @@ func (daemon *Daemon) releaseIngress(id string) {
 }
 
 // SetNetworkBootstrapKeys sets the bootstrap keys.
-func (daemon *Daemon) SetNetworkBootstrapKeys(keys []*networktypes.EncryptionKey) error {
+func (daemon *Daemon) SetNetworkBootstrapKeys(keys []*lntypes.EncryptionKey) error {
 	if err := daemon.netController.SetKeys(keys); err != nil {
 		return err
 	}
@@ -256,7 +256,7 @@ func (daemon *Daemon) SetNetworkBootstrapKeys(keys []*networktypes.EncryptionKey
 }
 
 // UpdateAttachment notifies the attacher about the attachment config.
-func (daemon *Daemon) UpdateAttachment(networkName, networkID, containerID string, config *network.NetworkingConfig) error {
+func (daemon *Daemon) UpdateAttachment(networkName, networkID, containerID string, config *networktypes.NetworkingConfig) error {
 	if daemon.clusterProvider == nil {
 		return fmt.Errorf("cluster provider is not initialized")
 	}
@@ -285,11 +285,11 @@ func (daemon *Daemon) CreateManagedNetwork(create clustertypes.NetworkCreateRequ
 }
 
 // CreateNetwork creates a network with the given name, driver and other optional parameters
-func (daemon *Daemon) CreateNetwork(create network.CreateRequest) (*network.CreateResponse, error) {
+func (daemon *Daemon) CreateNetwork(create networktypes.CreateRequest) (*networktypes.CreateResponse, error) {
 	return daemon.createNetwork(&daemon.config().Config, create, "", false)
 }
 
-func (daemon *Daemon) createNetwork(cfg *config.Config, create network.CreateRequest, id string, agent bool) (*network.CreateResponse, error) {
+func (daemon *Daemon) createNetwork(cfg *config.Config, create networktypes.CreateRequest, id string, agent bool) (*networktypes.CreateResponse, error) {
 	if runconfig.IsPreDefinedNetwork(create.Name) {
 		return nil, PredefinedNetworkError(create.Name)
 	}
@@ -341,7 +341,7 @@ func (daemon *Daemon) createNetwork(cfg *config.Config, create network.CreateReq
 		nwOptions = append(nwOptions, libnetwork.NetworkOptionConfigOnly())
 	}
 
-	if err := network.ValidateIPAM(create.IPAM, enableIPv6); err != nil {
+	if err := networktypes.ValidateIPAM(create.IPAM, enableIPv6); err != nil {
 		if agent {
 			// This function is called with agent=false for all networks. For swarm-scoped
 			// networks, the configuration is validated but ManagerRedirectError is returned
@@ -406,7 +406,7 @@ func (daemon *Daemon) createNetwork(cfg *config.Config, create network.CreateReq
 	}
 	daemon.LogNetworkEvent(n, events.ActionCreate)
 
-	return &network.CreateResponse{ID: n.ID()}, nil
+	return &networktypes.CreateResponse{ID: n.ID()}, nil
 }
 
 func (daemon *Daemon) pluginRefCount(driver, capability string, mode int) {
@@ -432,7 +432,7 @@ func (daemon *Daemon) pluginRefCount(driver, capability string, mode int) {
 	}
 }
 
-func getIpamConfig(data []network.IPAMConfig) ([]*libnetwork.IpamConf, []*libnetwork.IpamConf, error) {
+func getIpamConfig(data []networktypes.IPAMConfig) ([]*libnetwork.IpamConf, []*libnetwork.IpamConf, error) {
 	ipamV4Cfg := []*libnetwork.IpamConf{}
 	ipamV6Cfg := []*libnetwork.IpamConf{}
 	for _, d := range data {
@@ -468,7 +468,7 @@ func (daemon *Daemon) UpdateContainerServiceConfig(containerName string, service
 // ConnectContainerToNetwork connects the given container to the given
 // network. If either cannot be found, an err is returned. If the
 // network cannot be set up, an err is returned.
-func (daemon *Daemon) ConnectContainerToNetwork(ctx context.Context, containerName, networkName string, endpointConfig *network.EndpointSettings) error {
+func (daemon *Daemon) ConnectContainerToNetwork(ctx context.Context, containerName, networkName string, endpointConfig *networktypes.EndpointSettings) error {
 	ctr, err := daemon.GetContainer(containerName)
 	if err != nil {
 		return err
@@ -575,14 +575,14 @@ func (daemon *Daemon) deleteNetwork(nw *libnetwork.Network, dynamic bool) error 
 }
 
 // GetNetworks returns a list of all networks
-func (daemon *Daemon) GetNetworks(filter filters.Args, config backend.NetworkListConfig) (networks []network.Inspect, err error) {
+func (daemon *Daemon) GetNetworks(filter filters.Args, config backend.NetworkListConfig) (networks []networktypes.Inspect, err error) {
 	var idx map[string]*libnetwork.Network
 	if config.Detailed {
 		idx = make(map[string]*libnetwork.Network)
 	}
 
 	allNetworks := daemon.getAllNetworks()
-	networks = make([]network.Inspect, 0, len(allNetworks))
+	networks = make([]networktypes.Inspect, 0, len(allNetworks))
 	for _, n := range allNetworks {
 		nr := buildNetworkResource(n)
 		networks = append(networks, nr)
@@ -591,7 +591,7 @@ func (daemon *Daemon) GetNetworks(filter filters.Args, config backend.NetworkLis
 		}
 	}
 
-	networks, err = internalnetwork.FilterNetworks(networks, filter)
+	networks, err = network.FilterNetworks(networks, filter)
 	if err != nil {
 		return nil, err
 	}
@@ -610,12 +610,12 @@ func (daemon *Daemon) GetNetworks(filter filters.Args, config backend.NetworkLis
 
 // buildNetworkResource builds a [types.NetworkResource] from the given
 // [libnetwork.Network], to be returned by the API.
-func buildNetworkResource(nw *libnetwork.Network) network.Inspect {
+func buildNetworkResource(nw *libnetwork.Network) networktypes.Inspect {
 	if nw == nil {
-		return network.Inspect{}
+		return networktypes.Inspect{}
 	}
 
-	return network.Inspect{
+	return networktypes.Inspect{
 		Name:       nw.Name(),
 		ID:         nw.ID(),
 		Created:    nw.Created(),
@@ -626,9 +626,9 @@ func buildNetworkResource(nw *libnetwork.Network) network.Inspect {
 		Internal:   nw.Internal(),
 		Attachable: nw.Attachable(),
 		Ingress:    nw.Ingress(),
-		ConfigFrom: network.ConfigReference{Network: nw.ConfigFrom()},
+		ConfigFrom: networktypes.ConfigReference{Network: nw.ConfigFrom()},
 		ConfigOnly: nw.ConfigOnly(),
-		Containers: map[string]network.EndpointResource{},
+		Containers: map[string]networktypes.EndpointResource{},
 		Options:    nw.DriverOptions(),
 		Labels:     nw.Labels(),
 		Peers:      buildPeerInfoResources(nw.Peers()),
@@ -638,8 +638,8 @@ func buildNetworkResource(nw *libnetwork.Network) network.Inspect {
 // buildContainerAttachments creates a [types.EndpointResource] map of all
 // containers attached to the network. It is used when listing networks in
 // detailed mode.
-func buildContainerAttachments(nw *libnetwork.Network) map[string]network.EndpointResource {
-	containers := make(map[string]network.EndpointResource)
+func buildContainerAttachments(nw *libnetwork.Network) map[string]networktypes.EndpointResource {
+	containers := make(map[string]networktypes.EndpointResource)
 	for _, e := range nw.Endpoints() {
 		ei := e.Info()
 		if ei == nil {
@@ -656,19 +656,19 @@ func buildContainerAttachments(nw *libnetwork.Network) map[string]network.Endpoi
 
 // buildServiceAttachments creates a [network.ServiceInfo] map of all services
 // attached to the network. It is used when listing networks in "verbose" mode.
-func buildServiceAttachments(nw *libnetwork.Network) map[string]network.ServiceInfo {
-	services := make(map[string]network.ServiceInfo)
+func buildServiceAttachments(nw *libnetwork.Network) map[string]networktypes.ServiceInfo {
+	services := make(map[string]networktypes.ServiceInfo)
 	for name, service := range nw.Services() {
-		tasks := make([]network.Task, 0, len(service.Tasks))
+		tasks := make([]networktypes.Task, 0, len(service.Tasks))
 		for _, t := range service.Tasks {
-			tasks = append(tasks, network.Task{
+			tasks = append(tasks, networktypes.Task{
 				Name:       t.Name,
 				EndpointID: t.EndpointID,
 				EndpointIP: t.EndpointIP,
 				Info:       t.Info,
 			})
 		}
-		services[name] = network.ServiceInfo{
+		services[name] = networktypes.ServiceInfo{
 			VIP:          service.VIP,
 			Ports:        service.Ports,
 			Tasks:        tasks,
@@ -681,21 +681,21 @@ func buildServiceAttachments(nw *libnetwork.Network) map[string]network.ServiceI
 // buildPeerInfoResources converts a list of [networkdb.PeerInfo] to a
 // [network.PeerInfo] for inclusion in API responses. It returns nil if
 // the list of peers is empty.
-func buildPeerInfoResources(peers []networkdb.PeerInfo) []network.PeerInfo {
+func buildPeerInfoResources(peers []networkdb.PeerInfo) []networktypes.PeerInfo {
 	if len(peers) == 0 {
 		return nil
 	}
-	peerInfo := make([]network.PeerInfo, 0, len(peers))
+	peerInfo := make([]networktypes.PeerInfo, 0, len(peers))
 	for _, peer := range peers {
-		peerInfo = append(peerInfo, network.PeerInfo(peer))
+		peerInfo = append(peerInfo, networktypes.PeerInfo(peer))
 	}
 	return peerInfo
 }
 
 // buildIPAMResources constructs a [network.IPAM] from the network's
 // IPAM information for inclusion in API responses.
-func buildIPAMResources(nw *libnetwork.Network) network.IPAM {
-	var ipamConfig []network.IPAMConfig
+func buildIPAMResources(nw *libnetwork.Network) networktypes.IPAM {
+	var ipamConfig []networktypes.IPAMConfig
 
 	ipamDriver, ipamOptions, ipv4Conf, ipv6Conf := nw.IpamConfig()
 
@@ -705,7 +705,7 @@ func buildIPAMResources(nw *libnetwork.Network) network.IPAM {
 			continue
 		}
 		hasIPv4Config = true
-		ipamConfig = append(ipamConfig, network.IPAMConfig{
+		ipamConfig = append(ipamConfig, networktypes.IPAMConfig{
 			Subnet:     cfg.PreferredPool,
 			IPRange:    cfg.SubPool,
 			Gateway:    cfg.Gateway,
@@ -719,7 +719,7 @@ func buildIPAMResources(nw *libnetwork.Network) network.IPAM {
 			continue
 		}
 		hasIPv6Config = true
-		ipamConfig = append(ipamConfig, network.IPAMConfig{
+		ipamConfig = append(ipamConfig, networktypes.IPAMConfig{
 			Subnet:     cfg.PreferredPool,
 			IPRange:    cfg.SubPool,
 			Gateway:    cfg.Gateway,
@@ -735,7 +735,7 @@ func buildIPAMResources(nw *libnetwork.Network) network.IPAM {
 				if info.IPAMData.Gateway != nil {
 					gw = info.IPAMData.Gateway.IP.String()
 				}
-				ipamConfig = append(ipamConfig, network.IPAMConfig{
+				ipamConfig = append(ipamConfig, networktypes.IPAMConfig{
 					Subnet:  info.IPAMData.Pool.String(),
 					Gateway: gw,
 				})
@@ -747,7 +747,7 @@ func buildIPAMResources(nw *libnetwork.Network) network.IPAM {
 				if info.IPAMData.Pool == nil {
 					continue
 				}
-				ipamConfig = append(ipamConfig, network.IPAMConfig{
+				ipamConfig = append(ipamConfig, networktypes.IPAMConfig{
 					Subnet:  info.IPAMData.Pool.String(),
 					Gateway: info.IPAMData.Gateway.String(),
 				})
@@ -755,7 +755,7 @@ func buildIPAMResources(nw *libnetwork.Network) network.IPAM {
 		}
 	}
 
-	return network.IPAM{
+	return networktypes.IPAM{
 		Driver:  ipamDriver,
 		Options: ipamOptions,
 		Config:  ipamConfig,
@@ -764,8 +764,8 @@ func buildIPAMResources(nw *libnetwork.Network) network.IPAM {
 
 // buildEndpointResource combines information from the endpoint and additional
 // endpoint-info into a [types.EndpointResource].
-func buildEndpointResource(ep *libnetwork.Endpoint, info libnetwork.EndpointInfo) network.EndpointResource {
-	er := network.EndpointResource{
+func buildEndpointResource(ep *libnetwork.Endpoint, info libnetwork.EndpointInfo) networktypes.EndpointResource {
+	er := networktypes.EndpointResource{
 		EndpointID: ep.ID(),
 		Name:       ep.Name(),
 	}
@@ -812,7 +812,7 @@ func (daemon *Daemon) clearAttachableNetworks() {
 }
 
 // buildCreateEndpointOptions builds endpoint options from a given network.
-func buildCreateEndpointOptions(c *container.Container, n *libnetwork.Network, epConfig *internalnetwork.EndpointSettings, sb *libnetwork.Sandbox, daemonDNS []string) ([]libnetwork.EndpointOption, error) {
+func buildCreateEndpointOptions(c *container.Container, n *libnetwork.Network, epConfig *network.EndpointSettings, sb *libnetwork.Sandbox, daemonDNS []string) ([]libnetwork.EndpointOption, error) {
 	var createOptions []libnetwork.EndpointOption
 	var genericOptions = make(options.Generic)
 
@@ -883,11 +883,11 @@ func buildCreateEndpointOptions(c *container.Container, n *libnetwork.Network, e
 		createOptions = append(createOptions, libnetwork.CreateOptionDisableResolution())
 	}
 
-	opts, err := buildPortsRelatedCreateEndpointOptions(c, n, sb)
+	epOpts, err := buildPortsRelatedCreateEndpointOptions(c, n, sb)
 	if err != nil {
 		return nil, err
 	}
-	createOptions = append(createOptions, opts...)
+	createOptions = append(createOptions, epOpts...)
 
 	// On Windows, DNS config is a per-adapter config option whereas on Linux, it's a sandbox-wide parameter; hence why
 	// we're dealing with DNS config both here and in buildSandboxOptions. Following DNS options are only honored by
@@ -936,13 +936,13 @@ func buildPortsRelatedCreateEndpointOptions(c *container.Container, n *libnetwor
 	nat.SortPortMap(ports, bindings)
 
 	var (
-		exposedPorts   []networktypes.TransportPort
-		publishedPorts []networktypes.PortBinding
+		exposedPorts   []lntypes.TransportPort
+		publishedPorts []lntypes.PortBinding
 	)
 	for _, port := range ports {
-		portProto := networktypes.ParseProtocol(port.Proto())
+		portProto := lntypes.ParseProtocol(port.Proto())
 		portNum := uint16(port.Int())
-		exposedPorts = append(exposedPorts, networktypes.TransportPort{
+		exposedPorts = append(exposedPorts, lntypes.TransportPort{
 			Proto: portProto,
 			Port:  portNum,
 		})
@@ -956,7 +956,7 @@ func buildPortsRelatedCreateEndpointOptions(c *container.Container, n *libnetwor
 			if err != nil {
 				return nil, fmt.Errorf("error parsing HostPort value (%s): %w", binding.HostPort, err)
 			}
-			publishedPorts = append(publishedPorts, networktypes.PortBinding{
+			publishedPorts = append(publishedPorts, lntypes.PortBinding{
 				Proto:       portProto,
 				Port:        portNum,
 				HostIP:      net.ParseIP(binding.HostIP),
@@ -966,7 +966,7 @@ func buildPortsRelatedCreateEndpointOptions(c *container.Container, n *libnetwor
 		}
 
 		if c.HostConfig.PublishAllPorts && len(bindings[port]) == 0 {
-			publishedPorts = append(publishedPorts, networktypes.PortBinding{
+			publishedPorts = append(publishedPorts, lntypes.PortBinding{
 				Proto: portProto,
 				Port:  portNum,
 			})
@@ -1008,7 +1008,7 @@ func getEndpointPortMapInfo(ep *libnetwork.Endpoint) (nat.PortMap, error) {
 	}
 
 	if expData, ok := driverInfo[netlabel.ExposedPorts]; ok {
-		if exposedPorts, ok := expData.([]networktypes.TransportPort); ok {
+		if exposedPorts, ok := expData.([]lntypes.TransportPort); ok {
 			for _, tp := range exposedPorts {
 				natPort, err := nat.NewPort(tp.Proto.String(), strconv.Itoa(int(tp.Port)))
 				if err != nil {
@@ -1024,7 +1024,7 @@ func getEndpointPortMapInfo(ep *libnetwork.Endpoint) (nat.PortMap, error) {
 		return pm, nil
 	}
 
-	if portMapping, ok := mapData.([]networktypes.PortBinding); ok {
+	if portMapping, ok := mapData.([]lntypes.PortBinding); ok {
 		for _, pp := range portMapping {
 			// Use an empty string for the host port if there's no port assigned.
 			natPort, err := nat.NewPort(pp.Proto.String(), strconv.Itoa(int(pp.Port)))
@@ -1044,7 +1044,7 @@ func getEndpointPortMapInfo(ep *libnetwork.Endpoint) (nat.PortMap, error) {
 }
 
 // buildEndpointInfo sets endpoint-related fields on container.NetworkSettings based on the provided network and endpoint.
-func buildEndpointInfo(networkSettings *internalnetwork.Settings, n *libnetwork.Network, ep *libnetwork.Endpoint) error {
+func buildEndpointInfo(networkSettings *network.Settings, n *libnetwork.Network, ep *libnetwork.Endpoint) error {
 	if ep == nil {
 		return errors.New("endpoint cannot be nil")
 	}
@@ -1061,8 +1061,8 @@ func buildEndpointInfo(networkSettings *internalnetwork.Settings, n *libnetwork.
 
 	nwName := n.Name()
 	if _, ok := networkSettings.Networks[nwName]; !ok {
-		networkSettings.Networks[nwName] = &internalnetwork.EndpointSettings{
-			EndpointSettings: &network.EndpointSettings{},
+		networkSettings.Networks[nwName] = &network.EndpointSettings{
+			EndpointSettings: &networktypes.EndpointSettings{},
 		}
 	}
 	networkSettings.Networks[nwName].NetworkID = n.ID()
@@ -1093,9 +1093,9 @@ func buildEndpointInfo(networkSettings *internalnetwork.Settings, n *libnetwork.
 }
 
 // buildJoinOptions builds endpoint Join options from a given network.
-func buildJoinOptions(networkSettings *internalnetwork.Settings, n interface{ Name() string }) ([]libnetwork.EndpointOption, error) {
+func buildJoinOptions(settings *network.Settings, n interface{ Name() string }) ([]libnetwork.EndpointOption, error) {
 	var joinOptions []libnetwork.EndpointOption
-	if epConfig, ok := networkSettings.Networks[n.Name()]; ok {
+	if epConfig, ok := settings.Networks[n.Name()]; ok {
 		for _, str := range epConfig.Links {
 			name, alias, err := opts.ParseLink(str)
 			if err != nil {

--- a/daemon/network/network_mode.go
+++ b/daemon/network/network_mode.go
@@ -1,0 +1,7 @@
+package network
+
+// DefaultNetwork is the name of the default network driver to use for containers
+// on the daemon platform. The default for Linux containers is "bridge"
+// ([network.NetworkBridge]), and "nat" ([network.NetworkNat]) for Windows
+// containers.
+const DefaultNetwork = defaultNetwork

--- a/daemon/network/network_mode_unix.go
+++ b/daemon/network/network_mode_unix.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package network
+
+import "github.com/docker/docker/api/types/network"
+
+const defaultNetwork = network.NetworkBridge

--- a/daemon/network/network_mode_windows.go
+++ b/daemon/network/network_mode_windows.go
@@ -1,0 +1,5 @@
+package network
+
+import "github.com/docker/docker/api/types/network"
+
+const defaultNetwork = network.NetworkNat

--- a/runconfig/hostconfig_unix.go
+++ b/runconfig/hostconfig_unix.go
@@ -13,6 +13,8 @@ import (
 
 // DefaultDaemonNetworkMode returns the default network stack the daemon should
 // use.
+//
+// Deprecated: this function is no longer in use and will be removed in the next release.
 func DefaultDaemonNetworkMode() container.NetworkMode {
 	return network.NetworkBridge
 }

--- a/runconfig/hostconfig_windows.go
+++ b/runconfig/hostconfig_windows.go
@@ -10,6 +10,8 @@ import (
 
 // DefaultDaemonNetworkMode returns the default network stack the daemon should
 // use.
+//
+// Deprecated: this function is no longer in use and will be removed in the next release.
 func DefaultDaemonNetworkMode() container.NetworkMode {
 	return network.NetworkNat
 }


### PR DESCRIPTION
- [x] depends on / stacked on https://github.com/moby/moby/pull/48012
- [x] depends on / stacked on https://github.com/moby/moby/pull/48014

### runconfig: deprecate DefaultDaemonNetworkMode, move to daemon/network

This function returns the default network to use for the daemon platform;
moving this to a location separate from runconfig, which is planned to
be dismantled and moved to the API.

While it might be convenient to move this utility inside api/types/container,
we don't want to advertise this function too widely, as the default returned
can ONLY be considered correct when ran on the daemon-side. An alternative
would be to introduce an argument (daemonPlatform), which isn't very convenient
to use.



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
runconfig: deprecate DefaultDaemonNetworkMode, move to daemon/network
```

**- A picture of a cute animal (not mandatory but encouraged)**

