### PR TITLE
api/types/container, runconfig: NetworkMode align Windows and Unix implementations

### DIFF
--- a/api/types/container/hostconfig.go
+++ b/api/types/container/hostconfig.go
@@ -160,6 +160,11 @@ func (n NetworkMode) ConnectedContainer() (idOrName string) {
 	return idOrName
 }
 
+// IsUserDefined indicates user-created network
+func (n NetworkMode) IsUserDefined() bool {
+	return !n.IsDefault() && !n.IsBridge() && !n.IsHost() && !n.IsNone() && !n.IsContainer()
+}
+
 // UserDefined indicates user-created network
 func (n NetworkMode) UserDefined() string {
 	if n.IsUserDefined() {

--- a/api/types/container/hostconfig_unix.go
+++ b/api/types/container/hostconfig_unix.go
@@ -19,11 +19,6 @@ func (n NetworkMode) IsHost() bool {
 	return n == network.NetworkHost
 }
 
-// IsUserDefined indicates user-created network
-func (n NetworkMode) IsUserDefined() bool {
-	return !n.IsDefault() && !n.IsBridge() && !n.IsHost() && !n.IsNone() && !n.IsContainer()
-}
-
 // NetworkName returns the name of the network stack.
 func (n NetworkMode) NetworkName() string {
 	switch {

--- a/api/types/container/hostconfig_windows.go
+++ b/api/types/container/hostconfig_windows.go
@@ -19,11 +19,6 @@ func (n NetworkMode) IsHost() bool {
 	return false
 }
 
-// IsUserDefined indicates user-created network
-func (n NetworkMode) IsUserDefined() bool {
-	return !n.IsDefault() && !n.IsNone() && !n.IsBridge() && !n.IsContainer()
-}
-
 // NetworkName returns the name of the network stack.
 func (n NetworkMode) NetworkName() string {
 	switch {

--- a/daemon/network/network_mode.go
+++ b/daemon/network/network_mode.go
@@ -1,5 +1,7 @@
 package network
 
+import "github.com/docker/docker/api/types/container"
+
 // DefaultNetwork is the name of the default network driver to use for containers
 // on the daemon platform. The default for Linux containers is "bridge"
 // ([network.NetworkBridge]), and "nat" ([network.NetworkNat]) for Windows
@@ -8,6 +10,5 @@ const DefaultNetwork = defaultNetwork
 
 // IsPredefined indicates if a network is predefined by the daemon.
 func IsPredefined(network string) bool {
-	// TODO(thaJeztah): check if we can align the check for both platforms
-	return isPreDefined(network)
+	return !container.NetworkMode(network).IsUserDefined()
 }

--- a/daemon/network/network_mode_unix.go
+++ b/daemon/network/network_mode_unix.go
@@ -3,13 +3,7 @@
 package network
 
 import (
-	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 )
 
 const defaultNetwork = network.NetworkBridge
-
-func isPreDefined(network string) bool {
-	n := container.NetworkMode(network)
-	return n.IsBridge() || n.IsHost() || n.IsNone() || n.IsDefault()
-}

--- a/daemon/network/network_mode_windows.go
+++ b/daemon/network/network_mode_windows.go
@@ -1,12 +1,7 @@
 package network
 
 import (
-	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 )
 
 const defaultNetwork = network.NetworkNat
-
-func isPreDefined(network string) bool {
-	return !container.NetworkMode(network).IsUserDefined()
-}


### PR DESCRIPTION
- [x] stacked on https://github.com/moby/moby/pull/48013

### api/tpes/container: unify NetworkMode.IsUserDefined

The Windows and non-Windows implementations where identical, with the
exception of the Windows variant not checking for IsHost() (which is
always "false" on Windows, so a redundant check).

This patch unifies them to prevent them from getting out of sync.

### runconfig: use single implementation for IsPreDefinedNetwork

The Windows and non-Windows implementations used a different approach;
the Unix implementation checked for any of the known pre-defined networks,
whereas the Windows implementation checked for the network not being
a user-defined one.

While both are valid, and the Unix approach ever-so-slightly more
performant in case additional parsing was needed ("container:<id>"),
the performance differences are likely neglectable, and the Windows
implementation makes it less likely to diverge from "IsUserDefined".


**- A picture of a cute animal (not mandatory but encouraged)**

