### PR TITLE
runconfig: deprecate IsPreDefinedNetwork

### DIFF
--- a/daemon/cluster/networks.go
+++ b/daemon/cluster/networks.go
@@ -11,7 +11,6 @@ import (
 	"github.com/docker/docker/daemon/cluster/convert"
 	networkSettings "github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/errdefs"
-	"github.com/docker/docker/runconfig"
 	swarmapi "github.com/moby/swarmkit/v2/api"
 	"github.com/pkg/errors"
 )
@@ -269,7 +268,7 @@ func (c *Cluster) DetachNetwork(target string, containerID string) error {
 
 // CreateNetwork creates a new cluster managed network.
 func (c *Cluster) CreateNetwork(s network.CreateRequest) (string, error) {
-	if runconfig.IsPreDefinedNetwork(s.Name) {
+	if networkSettings.IsPredefined(s.Name) {
 		err := notAllowedError(fmt.Sprintf("%s is a pre-defined network and cannot be created", s.Name))
 		return "", errors.WithStack(err)
 	}
@@ -314,7 +313,7 @@ func (c *Cluster) populateNetworkID(ctx context.Context, client swarmapi.Control
 		apiNetwork, err := getNetwork(ctx, client, nw.Target)
 		if err != nil {
 			ln, _ := c.config.Backend.FindNetwork(nw.Target)
-			if ln != nil && runconfig.IsPreDefinedNetwork(ln.Name()) {
+			if ln != nil && networkSettings.IsPredefined(ln.Name()) {
 				// Need to retrieve the corresponding predefined swarm network
 				// and use its id for the request.
 				apiNetwork, err = getNetwork(ctx, client, ln.Name())

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -31,7 +31,6 @@ import (
 	lntypes "github.com/docker/docker/libnetwork/types"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/plugingetter"
-	"github.com/docker/docker/runconfig"
 	"github.com/docker/go-connections/nat"
 )
 
@@ -290,7 +289,7 @@ func (daemon *Daemon) CreateNetwork(create networktypes.CreateRequest) (*network
 }
 
 func (daemon *Daemon) createNetwork(cfg *config.Config, create networktypes.CreateRequest, id string, agent bool) (*networktypes.CreateResponse, error) {
-	if runconfig.IsPreDefinedNetwork(create.Name) {
+	if network.IsPredefined(create.Name) {
 		return nil, PredefinedNetworkError(create.Name)
 	}
 
@@ -543,13 +542,13 @@ func (daemon *Daemon) DeleteNetwork(networkID string) error {
 }
 
 func (daemon *Daemon) deleteNetwork(nw *libnetwork.Network, dynamic bool) error {
-	if runconfig.IsPreDefinedNetwork(nw.Name()) && !dynamic {
+	if network.IsPredefined(nw.Name()) && !dynamic {
 		err := fmt.Errorf("%s is a pre-defined network and cannot be removed", nw.Name())
 		return errdefs.Forbidden(err)
 	}
 
 	if dynamic && !nw.Dynamic() {
-		if runconfig.IsPreDefinedNetwork(nw.Name()) {
+		if network.IsPredefined(nw.Name()) {
 			// Predefined networks now support swarm services. Make this
 			// a no-op when cluster requests to remove the predefined network.
 			return nil

--- a/daemon/network/filter.go
+++ b/daemon/network/filter.go
@@ -4,7 +4,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/errdefs"
-	"github.com/docker/docker/runconfig"
 	"github.com/pkg/errors"
 )
 
@@ -94,9 +93,9 @@ func filterNetworkByUse(nws []network.Inspect, danglingOnly bool) []network.Insp
 
 	filterFunc := func(nw network.Inspect) bool {
 		if danglingOnly {
-			return !runconfig.IsPreDefinedNetwork(nw.Name) && len(nw.Containers) == 0 && len(nw.Services) == 0
+			return !IsPredefined(nw.Name) && len(nw.Containers) == 0 && len(nw.Services) == 0
 		}
-		return runconfig.IsPreDefinedNetwork(nw.Name) || len(nw.Containers) > 0 || len(nw.Services) > 0
+		return IsPredefined(nw.Name) || len(nw.Containers) > 0 || len(nw.Services) > 0
 	}
 
 	for _, nw := range nws {
@@ -113,13 +112,13 @@ func filterNetworkByType(nws []network.Inspect, netType string) ([]network.Inspe
 	switch netType {
 	case "builtin":
 		for _, nw := range nws {
-			if runconfig.IsPreDefinedNetwork(nw.Name) {
+			if IsPredefined(nw.Name) {
 				retNws = append(retNws, nw)
 			}
 		}
 	case "custom":
 		for _, nw := range nws {
-			if !runconfig.IsPreDefinedNetwork(nw.Name) {
+			if !IsPredefined(nw.Name) {
 				retNws = append(retNws, nw)
 			}
 		}

--- a/daemon/network/network_mode.go
+++ b/daemon/network/network_mode.go
@@ -5,3 +5,9 @@ package network
 // ([network.NetworkBridge]), and "nat" ([network.NetworkNat]) for Windows
 // containers.
 const DefaultNetwork = defaultNetwork
+
+// IsPredefined indicates if a network is predefined by the daemon.
+func IsPredefined(network string) bool {
+	// TODO(thaJeztah): check if we can align the check for both platforms
+	return isPreDefined(network)
+}

--- a/daemon/network/network_mode_unix.go
+++ b/daemon/network/network_mode_unix.go
@@ -2,6 +2,14 @@
 
 package network
 
-import "github.com/docker/docker/api/types/network"
+import (
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+)
 
 const defaultNetwork = network.NetworkBridge
+
+func isPreDefined(network string) bool {
+	n := container.NetworkMode(network)
+	return n.IsBridge() || n.IsHost() || n.IsNone() || n.IsDefault()
+}

--- a/daemon/network/network_mode_windows.go
+++ b/daemon/network/network_mode_windows.go
@@ -1,5 +1,12 @@
 package network
 
-import "github.com/docker/docker/api/types/network"
+import (
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+)
 
 const defaultNetwork = network.NetworkNat
+
+func isPreDefined(network string) bool {
+	return !container.NetworkMode(network).IsUserDefined()
+}

--- a/daemon/prune.go
+++ b/daemon/prune.go
@@ -14,9 +14,9 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
 	timetypes "github.com/docker/docker/api/types/time"
+	networkSettings "github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork"
-	"github.com/docker/docker/runconfig"
 	"github.com/pkg/errors"
 )
 
@@ -121,7 +121,7 @@ func (daemon *Daemon) localNetworksPrune(ctx context.Context, pruneFilters filte
 			return false
 		}
 		nwName := nw.Name()
-		if runconfig.IsPreDefinedNetwork(nwName) {
+		if networkSettings.IsPredefined(nwName) {
 			return false
 		}
 		if len(nw.Endpoints()) > 0 {

--- a/runconfig/hostconfig_unix.go
+++ b/runconfig/hostconfig_unix.go
@@ -20,6 +20,8 @@ func DefaultDaemonNetworkMode() container.NetworkMode {
 }
 
 // IsPreDefinedNetwork indicates if a network is predefined by the daemon
+//
+// Deprecated: this function is no longer used and will be removed in the next release.
 func IsPreDefinedNetwork(network string) bool {
 	n := container.NetworkMode(network)
 	return n.IsBridge() || n.IsHost() || n.IsNone() || n.IsDefault()

--- a/runconfig/hostconfig_windows.go
+++ b/runconfig/hostconfig_windows.go
@@ -16,7 +16,9 @@ func DefaultDaemonNetworkMode() container.NetworkMode {
 	return network.NetworkNat
 }
 
-// IsPreDefinedNetwork indicates if a network is predefined by the daemon
+// IsPreDefinedNetwork indicates if a network is predefined by the daemon.
+//
+// Deprecated: this function is no longer used and will be removed in the next release.
 func IsPreDefinedNetwork(network string) bool {
 	return !container.NetworkMode(network).IsUserDefined()
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/32989


runconfig: deprecate IsPreDefinedNetwork

Move the function internal to the daemon, where it's used. Deliberately
not mentioning the new location, as this function should not be used
externally.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
runconfig: deprecate IsPreDefinedNetwork
```

**- A picture of a cute animal (not mandatory but encouraged)**

