### PR TITLE
api/types/container: reformat to align windows and unix implementations

### DIFF
--- a/api/types/container/hostconfig_unix.go
+++ b/api/types/container/hostconfig_unix.go
@@ -11,20 +11,22 @@ func (i Isolation) IsValid() bool {
 
 // NetworkName returns the name of the network stack.
 func (n NetworkMode) NetworkName() string {
-	if n.IsBridge() {
-		return network.NetworkBridge
-	} else if n.IsHost() {
-		return network.NetworkHost
-	} else if n.IsContainer() {
-		return "container"
-	} else if n.IsNone() {
-		return network.NetworkNone
-	} else if n.IsDefault() {
+	switch {
+	case n.IsDefault():
 		return network.NetworkDefault
-	} else if n.IsUserDefined() {
+	case n.IsBridge():
+		return network.NetworkBridge
+	case n.IsHost():
+		return network.NetworkHost
+	case n.IsNone():
+		return network.NetworkNone
+	case n.IsContainer():
+		return "container"
+	case n.IsUserDefined():
 		return n.UserDefined()
+	default:
+		return ""
 	}
-	return ""
 }
 
 // IsBridge indicates whether container uses the bridge network stack

--- a/api/types/container/hostconfig_unix.go
+++ b/api/types/container/hostconfig_unix.go
@@ -9,6 +9,21 @@ func (i Isolation) IsValid() bool {
 	return i.IsDefault()
 }
 
+// IsBridge indicates whether container uses the bridge network stack
+func (n NetworkMode) IsBridge() bool {
+	return n == network.NetworkBridge
+}
+
+// IsHost indicates whether container uses the host network stack.
+func (n NetworkMode) IsHost() bool {
+	return n == network.NetworkHost
+}
+
+// IsUserDefined indicates user-created network
+func (n NetworkMode) IsUserDefined() bool {
+	return !n.IsDefault() && !n.IsBridge() && !n.IsHost() && !n.IsNone() && !n.IsContainer()
+}
+
 // NetworkName returns the name of the network stack.
 func (n NetworkMode) NetworkName() string {
 	switch {
@@ -27,19 +42,4 @@ func (n NetworkMode) NetworkName() string {
 	default:
 		return ""
 	}
-}
-
-// IsBridge indicates whether container uses the bridge network stack
-func (n NetworkMode) IsBridge() bool {
-	return n == network.NetworkBridge
-}
-
-// IsHost indicates whether container uses the host network stack.
-func (n NetworkMode) IsHost() bool {
-	return n == network.NetworkHost
-}
-
-// IsUserDefined indicates user-created network
-func (n NetworkMode) IsUserDefined() bool {
-	return !n.IsDefault() && !n.IsBridge() && !n.IsHost() && !n.IsNone() && !n.IsContainer()
 }

--- a/api/types/container/hostconfig_windows.go
+++ b/api/types/container/hostconfig_windows.go
@@ -26,17 +26,22 @@ func (i Isolation) IsValid() bool {
 
 // NetworkName returns the name of the network stack.
 func (n NetworkMode) NetworkName() string {
-	if n.IsDefault() {
+	switch {
+	case n.IsDefault():
 		return network.NetworkDefault
-	} else if n.IsBridge() {
+	case n.IsBridge():
 		return network.NetworkNat
-	} else if n.IsNone() {
+	case n.IsHost():
+		// Windows currently doesn't support host network-mode, so
+		// this would currently never happen..
+		return network.NetworkHost
+	case n.IsNone():
 		return network.NetworkNone
-	} else if n.IsContainer() {
+	case n.IsContainer():
 		return "container"
-	} else if n.IsUserDefined() {
+	case n.IsUserDefined():
 		return n.UserDefined()
+	default:
+		return ""
 	}
-
-	return ""
 }

--- a/api/types/container/hostconfig_windows.go
+++ b/api/types/container/hostconfig_windows.go
@@ -2,6 +2,11 @@ package container // import "github.com/docker/docker/api/types/container"
 
 import "github.com/docker/docker/api/types/network"
 
+// IsValid indicates if an isolation technology is valid
+func (i Isolation) IsValid() bool {
+	return i.IsDefault() || i.IsHyperV() || i.IsProcess()
+}
+
 // IsBridge indicates whether container uses the bridge network stack
 // in windows it is given the name NAT
 func (n NetworkMode) IsBridge() bool {
@@ -17,11 +22,6 @@ func (n NetworkMode) IsHost() bool {
 // IsUserDefined indicates user-created network
 func (n NetworkMode) IsUserDefined() bool {
 	return !n.IsDefault() && !n.IsNone() && !n.IsBridge() && !n.IsContainer()
-}
-
-// IsValid indicates if an isolation technology is valid
-func (i Isolation) IsValid() bool {
-	return i.IsDefault() || i.IsHyperV() || i.IsProcess()
 }
 
 // NetworkName returns the name of the network stack.


### PR DESCRIPTION
### api/types/container: NetworkMode.NetworkName: use switch

- Use a switch instead of if/else for readability and to reduce
  the risk of duplicates in the checks.
- Align order between Windows and Linux implementation for easier
  comparing of differences in the implementation.
- Add a check for `IsHost()` in the Windows implementation which
  would never occur currently, but is implemented.

### api/types/container: NetworkMode align code between Windows and Linux

Change the order of declarations betwen both implementations for easier
comparing of differences.

**- A picture of a cute animal (not mandatory but encouraged)**

