### PR TITLE
daemon: rename some inconsistent import aliases

### DIFF
--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -19,7 +19,7 @@ import (
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/registry"
-	containerpkg "github.com/docker/docker/container"
+	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/daemon/cluster/convert"
 	executorpkg "github.com/docker/docker/daemon/cluster/executor"
@@ -324,8 +324,8 @@ func (c *containerAdapter) create(ctx context.Context) error {
 		return err
 	}
 
-	container := c.container.task.Spec.GetContainer()
-	if container == nil {
+	ctr := c.container.task.Spec.GetContainer()
+	if ctr == nil {
 		return errors.New("unable to get container from task spec")
 	}
 
@@ -334,12 +334,12 @@ func (c *containerAdapter) create(ctx context.Context) error {
 	}
 
 	// configure secrets
-	secretRefs := convert.SecretReferencesFromGRPC(container.Secrets)
+	secretRefs := convert.SecretReferencesFromGRPC(ctr.Secrets)
 	if err := c.backend.SetContainerSecretReferences(cr.ID, secretRefs); err != nil {
 		return err
 	}
 
-	configRefs := convert.ConfigReferencesFromGRPC(container.Configs)
+	configRefs := convert.ConfigReferencesFromGRPC(ctr.Configs)
 	if err := c.backend.SetContainerConfigReferences(cr.ID, configRefs); err != nil {
 		return err
 	}
@@ -419,8 +419,8 @@ func (c *containerAdapter) events(ctx context.Context) <-chan events.Message {
 	return eventsq
 }
 
-func (c *containerAdapter) wait(ctx context.Context) (<-chan containerpkg.StateStatus, error) {
-	return c.backend.ContainerWait(ctx, c.container.nameOrID(), containerpkg.WaitConditionNotRunning)
+func (c *containerAdapter) wait(ctx context.Context) (<-chan container.StateStatus, error) {
+	return c.backend.ContainerWait(ctx, c.container.nameOrID(), container.WaitConditionNotRunning)
 }
 
 func (c *containerAdapter) shutdown(ctx context.Context) error {


### PR DESCRIPTION
These used aliases that weren't used elsewhere, so renaming / removing to keep some consistency. Some local variables were renamed to prevent shadowing.


