### PR TITLE
runconfig/opts: deprecate ConvertKVStringsToMap and move internal

### DIFF
--- a/builder/dockerfile/buildargs.go
+++ b/builder/dockerfile/buildargs.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"io"
 	"sort"
-
-	"github.com/docker/docker/runconfig/opts"
 )
 
 // builtinAllowedBuildArgs is list of built-in allowed build args
@@ -138,7 +136,7 @@ func (b *BuildArgs) getAllFromMapping(source map[string]*string) map[string]stri
 // FilterAllowed returns all allowed args without the filtered args
 func (b *BuildArgs) FilterAllowed(filter []string) []string {
 	envs := []string{}
-	configEnv := opts.ConvertKVStringsToMap(filter)
+	configEnv := convertKVStringsToMap(filter)
 
 	for key, val := range b.GetAllAllowed() {
 		if _, ok := configEnv[key]; !ok {

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -381,3 +381,14 @@ func convertMapToEnvList(m map[string]string) []string {
 	}
 	return result
 }
+
+// convertKVStringsToMap converts ["key=value"] to {"key":"value"}
+func convertKVStringsToMap(values []string) map[string]string {
+	result := make(map[string]string, len(values))
+	for _, value := range values {
+		k, v, _ := strings.Cut(value, "=")
+		result[k] = v
+	}
+
+	return result
+}

--- a/builder/dockerfile/evaluator.go
+++ b/builder/dockerfile/evaluator.go
@@ -30,7 +30,6 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/oci"
-	"github.com/docker/docker/runconfig/opts"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/shell"
 	"github.com/pkg/errors"
@@ -243,7 +242,7 @@ func (s *dispatchState) setDefaultPath() {
 	if defaultPath == "" {
 		return
 	}
-	envMap := opts.ConvertKVStringsToMap(s.runConfig.Env)
+	envMap := convertKVStringsToMap(s.runConfig.Env)
 	if _, ok := envMap["PATH"]; !ok {
 		s.runConfig.Env = append(s.runConfig.Env, "PATH="+defaultPath)
 	}

--- a/daemon/cluster/filters.go
+++ b/daemon/cluster/filters.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types/filters"
-	runconfigopts "github.com/docker/docker/runconfig/opts"
 	swarmapi "github.com/moby/swarmkit/v2/api"
 )
 
@@ -24,8 +23,8 @@ func newListNodesFilters(filter filters.Args) (*swarmapi.ListNodesRequest_Filter
 	f := &swarmapi.ListNodesRequest_Filters{
 		NamePrefixes: filter.Get("name"),
 		IDPrefixes:   filter.Get("id"),
-		Labels:       runconfigopts.ConvertKVStringsToMap(filter.Get("label")),
-		NodeLabels:   runconfigopts.ConvertKVStringsToMap(filter.Get("node.label")),
+		Labels:       convertKVStringsToMap(filter.Get("label")),
+		NodeLabels:   convertKVStringsToMap(filter.Get("node.label")),
 	}
 
 	for _, r := range filter.Get("role") {
@@ -72,7 +71,7 @@ func newListTasksFilters(filter filters.Args, transformFunc func(filters.Args) e
 	f := &swarmapi.ListTasksRequest_Filters{
 		NamePrefixes: filter.Get("name"),
 		IDPrefixes:   filter.Get("id"),
-		Labels:       runconfigopts.ConvertKVStringsToMap(filter.Get("label")),
+		Labels:       convertKVStringsToMap(filter.Get("label")),
 		ServiceIDs:   filter.Get("service"),
 		NodeIDs:      filter.Get("node"),
 		UpToDate:     len(filter.Get("_up-to-date")) != 0,
@@ -104,7 +103,7 @@ func newListSecretsFilters(filter filters.Args) (*swarmapi.ListSecretsRequest_Fi
 		Names:        filter.Get("names"),
 		NamePrefixes: filter.Get("name"),
 		IDPrefixes:   filter.Get("id"),
-		Labels:       runconfigopts.ConvertKVStringsToMap(filter.Get("label")),
+		Labels:       convertKVStringsToMap(filter.Get("label")),
 	}, nil
 }
 
@@ -120,6 +119,6 @@ func newListConfigsFilters(filter filters.Args) (*swarmapi.ListConfigsRequest_Fi
 	return &swarmapi.ListConfigsRequest_Filters{
 		NamePrefixes: filter.Get("name"),
 		IDPrefixes:   filter.Get("id"),
-		Labels:       runconfigopts.ConvertKVStringsToMap(filter.Get("label")),
+		Labels:       convertKVStringsToMap(filter.Get("label")),
 	}, nil
 }

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -21,7 +21,6 @@ import (
 	timetypes "github.com/docker/docker/api/types/time"
 	"github.com/docker/docker/daemon/cluster/convert"
 	"github.com/docker/docker/errdefs"
-	runconfigopts "github.com/docker/docker/runconfig/opts"
 	gogotypes "github.com/gogo/protobuf/types"
 	swarmapi "github.com/moby/swarmkit/v2/api"
 	"github.com/opencontainers/go-digest"
@@ -62,7 +61,7 @@ func (c *Cluster) GetServices(options types.ServiceListOptions) ([]swarm.Service
 	filters := &swarmapi.ListServicesRequest_Filters{
 		NamePrefixes: options.Filters.Get("name"),
 		IDPrefixes:   options.Filters.Get("id"),
-		Labels:       runconfigopts.ConvertKVStringsToMap(options.Filters.Get("label")),
+		Labels:       convertKVStringsToMap(options.Filters.Get("label")),
 		Runtimes:     options.Filters.Get("runtime"),
 	}
 

--- a/daemon/cluster/utils.go
+++ b/daemon/cluster/utils.go
@@ -4,9 +4,21 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/docker/docker/pkg/ioutils"
 )
+
+// convertKVStringsToMap converts ["key=value"] to {"key":"value"}
+func convertKVStringsToMap(values []string) map[string]string {
+	result := make(map[string]string, len(values))
+	for _, value := range values {
+		k, v, _ := strings.Cut(value, "=")
+		result[k] = v
+	}
+
+	return result
+}
 
 func loadPersistentState(root string) (*nodeStartConfig, error) {
 	dt, err := os.ReadFile(filepath.Join(root, stateFile))

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -5,6 +5,8 @@ import (
 )
 
 // ConvertKVStringsToMap converts ["key=value"] to {"key":"value"}
+//
+// Deprecated: this function is no longer used, and will be removed in the next release.
 func ConvertKVStringsToMap(values []string) map[string]string {
 	result := make(map[string]string, len(values))
 	for _, value := range values {


### PR DESCRIPTION
This utility is only used in two places, and simple enough to duplicate. There's no external consumers, and a copy of this utility exists in docker/cli for use on the client side, so we could consider skipping deprecation, but just to be on the safe side ':)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
deprecate runconfig/opts.ConvertKVStringsToMap. This utility is no longer used, and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

