### PR TITLE
daemon/cluster/executor/container: fix error-handling

### DIFF
--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -557,16 +557,3 @@ func (c *containerAdapter) logs(ctx context.Context, options api.LogSubscription
 	}
 	return msgs, nil
 }
-
-// todo: typed/wrapped errors
-func isContainerCreateNameConflict(err error) bool {
-	return strings.Contains(err.Error(), "Conflict. The name")
-}
-
-func isUnknownContainer(err error) bool {
-	return strings.Contains(err.Error(), "No such container:")
-}
-
-func isStoppedContainer(err error) bool {
-	return strings.Contains(err.Error(), "is already stopped")
-}

--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	executorpkg "github.com/docker/docker/daemon/cluster/executor"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork"
 	"github.com/docker/go-connections/nat"
 	gogotypes "github.com/gogo/protobuf/types"
@@ -65,7 +66,7 @@ func (r *controller) Task() (*api.Task, error) {
 func (r *controller) ContainerStatus(ctx context.Context) (*api.ContainerStatus, error) {
 	ctnr, err := r.adapter.inspect(ctx)
 	if err != nil {
-		if isUnknownContainer(err) {
+		if errdefs.IsNotFound(err) {
 			return nil, nil
 		}
 		return nil, err
@@ -76,7 +77,7 @@ func (r *controller) ContainerStatus(ctx context.Context) (*api.ContainerStatus,
 func (r *controller) PortStatus(ctx context.Context) (*api.PortStatus, error) {
 	ctnr, err := r.adapter.inspect(ctx)
 	if err != nil {
-		if isUnknownContainer(err) {
+		if errdefs.IsNotFound(err) {
 			return nil, nil
 		}
 
@@ -178,7 +179,7 @@ func (r *controller) Prepare(ctx context.Context) error {
 		}
 	}
 	if err := r.adapter.create(ctx); err != nil {
-		if isContainerCreateNameConflict(err) {
+		if errdefs.IsConflict(err) {
 			if _, err := r.adapter.inspect(ctx); err != nil {
 				return err
 			}
@@ -379,7 +380,7 @@ func (r *controller) Shutdown(ctx context.Context) error {
 	}
 
 	if err := r.adapter.shutdown(ctx); err != nil {
-		if !(isUnknownContainer(err) || isStoppedContainer(err)) {
+		if !(errdefs.IsNotFound(err) || errdefs.IsNotModified(err)) {
 			return err
 		}
 	}
@@ -387,7 +388,7 @@ func (r *controller) Shutdown(ctx context.Context) error {
 	// Try removing networks referenced in this task in case this
 	// task is the last one referencing it
 	if err := r.adapter.removeNetworks(ctx); err != nil {
-		if !isUnknownContainer(err) {
+		if !errdefs.IsNotFound(err) {
 			return err
 		}
 	}
@@ -406,7 +407,7 @@ func (r *controller) Terminate(ctx context.Context) error {
 	}
 
 	if err := r.adapter.terminate(ctx); err != nil {
-		if isUnknownContainer(err) {
+		if errdefs.IsNotFound(err) {
 			return nil
 		}
 
@@ -428,7 +429,7 @@ func (r *controller) Remove(ctx context.Context) error {
 
 	// It may be necessary to shut down the task before removing it.
 	if err := r.Shutdown(ctx); err != nil {
-		if isUnknownContainer(err) {
+		if errdefs.IsNotFound(err) {
 			return nil
 		}
 		// This may fail if the task was already shut down.
@@ -436,7 +437,7 @@ func (r *controller) Remove(ctx context.Context) error {
 	}
 
 	if err := r.adapter.remove(ctx); err != nil {
-		if isUnknownContainer(err) {
+		if errdefs.IsNotFound(err) {
 			return nil
 		}
 
@@ -459,7 +460,7 @@ func (r *controller) waitReady(pctx context.Context) error {
 
 	ctnr, err := r.adapter.inspect(ctx)
 	if err != nil {
-		if !isUnknownContainer(err) {
+		if !errdefs.IsNotFound(err) {
 			return errors.Wrap(err, "inspect container failed")
 		}
 	} else {


### PR DESCRIPTION
Relates to:

- https://github.com/moby/moby/commit/534a90a99367af6f6bba1ddcc7eb07506e41f774 / https://github.com/moby/moby/pull/23361
- https://github.com/moby/moby/commit/c9d0a77657ccc3be144ed4de12d43c8cfcca8590 / https://github.com/moby/moby/pull/25933
- https://github.com/moby/moby/commit/680d0ba4abfb00c8ac959638c72003dba0826b46 / https://github.com/moby/moby/pull/39174
- https://github.com/moby/moby/commit/70fa7b6a3fd9aaada582ae02c50710f218b54d1a / https://github.com/moby/moby/pull/39242
- https://github.com/moby/moby/commit/ebcb7d6b406fe50ea9a237c73004d75884184c33 / https://github.com/moby/moby/pull/34188



While working on this file, I noticed the `isContainerCreateNameConflict`, `isUnknownContainer`, and `isStoppedContainer` utilities, which are used to perform error-type detection through string-matching.

These utilities were added in 534a90a99367af6f6bba1ddcc7eb07506e41f774, as part of the initial implementation of the Swarm executor in Docker. At that time, the Docker API client did not return typed errors, and various part of the code depended on string matching, which is brittle, and it looks like `isContainerCreateNameConflict` at least is already broken since c9d0a77657ccc3be144ed4de12d43c8cfcca8590, which changed the error-message.

Starting with ebcb7d6b406fe50ea9a237c73004d75884184c33, we use typed errors through the errdefs package, so we can replace these utilities:

The `isUnknownContainer` utility is replace by `errdefs.IsNotFound`, which is returned if the object is not found. Interestingly, this utility was checking for containers only (`No such container`), but was also used for an `removeNetworks` call. Tracking back history of that use to verify if it was _intentionally_ checking for a "container not found" error;

- This check added in the initial implementation 534a90a99367af6f6bba1ddcc7eb07506e41f774
- Moved from `controller.Remove` to `container.Shutdown` to make sure the sandbox was removed in 680d0ba4abfb00c8ac959638c72003dba0826b46
- And finally touched again in 70fa7b6a3fd9aaada582ae02c50710f218b54d1a, which was a follow-up to the previous one, and fixed the conditions to prevent returning early before the network was removed.

None of those patches mention that these errors are related to containers, and checking the codepath that's executed, we can only expect a `libmetwork.ErrNoSuchNetwork` to be returned, so this looks to have been a bug.

The `isStoppedContainer` utility is replaced by `errdefs.IsNotModified`, which is the error (status) returned in situations where the container is already stopped; https://github.com/moby/moby/blob/caf502a0bc44c19b4e1dde50428de07ff756a8d3/daemon/stop.go#L30-L35 This is the only


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix error-handling in swarm executor
```

**- A picture of a cute animal (not mandatory but encouraged)**

