### PR TITLE
daemon, daemon/cluster, integration/container: minor linting issues and cleanups 

### DIFF
--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
-	enginecontainer "github.com/docker/docker/api/types/container"
+	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
 	enginemount "github.com/docker/docker/api/types/mount"
@@ -160,7 +160,7 @@ func (c *containerConfig) portBindings() nat.PortMap {
 	return portBindings
 }
 
-func (c *containerConfig) isolation() enginecontainer.Isolation {
+func (c *containerConfig) isolation() containertypes.Isolation {
 	return convert.IsolationFromGRPC(c.spec().Isolation)
 }
 
@@ -190,11 +190,11 @@ func (c *containerConfig) exposedPorts() map[nat.Port]struct{} {
 	return exposedPorts
 }
 
-func (c *containerConfig) config() *enginecontainer.Config {
+func (c *containerConfig) config() *containertypes.Config {
 	genericEnvs := genericresource.EnvFormat(c.task.AssignedGenericResources, "DOCKER_RESOURCE")
 	env := append(c.spec().Env, genericEnvs...)
 
-	config := &enginecontainer.Config{
+	config := &containertypes.Config{
 		Labels:       c.labels(),
 		StopSignal:   c.spec().StopSignal,
 		Tty:          c.spec().TTY,
@@ -375,7 +375,7 @@ func convertMount(m api.Mount) enginemount.Mount {
 	return mount
 }
 
-func (c *containerConfig) healthcheck() *enginecontainer.HealthConfig {
+func (c *containerConfig) healthcheck() *containertypes.HealthConfig {
 	hcSpec := c.spec().Healthcheck
 	if hcSpec == nil {
 		return nil
@@ -384,7 +384,7 @@ func (c *containerConfig) healthcheck() *enginecontainer.HealthConfig {
 	timeout, _ := gogotypes.DurationFromProto(hcSpec.Timeout)
 	startPeriod, _ := gogotypes.DurationFromProto(hcSpec.StartPeriod)
 	startInterval, _ := gogotypes.DurationFromProto(hcSpec.StartInterval)
-	return &enginecontainer.HealthConfig{
+	return &containertypes.HealthConfig{
 		Test:          hcSpec.Test,
 		Interval:      interval,
 		Timeout:       timeout,
@@ -394,8 +394,8 @@ func (c *containerConfig) healthcheck() *enginecontainer.HealthConfig {
 	}
 }
 
-func (c *containerConfig) hostConfig(deps exec.VolumeGetter) *enginecontainer.HostConfig {
-	hc := &enginecontainer.HostConfig{
+func (c *containerConfig) hostConfig(deps exec.VolumeGetter) *containertypes.HostConfig {
+	hc := &containertypes.HostConfig{
 		Resources:      c.resources(),
 		GroupAdd:       c.spec().Groups,
 		PortBindings:   c.portBindings(),
@@ -432,7 +432,7 @@ func (c *containerConfig) hostConfig(deps exec.VolumeGetter) *enginecontainer.Ho
 	}
 
 	if c.task.LogDriver != nil {
-		hc.LogConfig = enginecontainer.LogConfig{
+		hc.LogConfig = containertypes.LogConfig{
 			Type:   c.task.LogDriver.Name,
 			Config: c.task.LogDriver.Options,
 		}
@@ -442,7 +442,7 @@ func (c *containerConfig) hostConfig(deps exec.VolumeGetter) *enginecontainer.Ho
 		labels := c.task.Networks[0].Network.Spec.Annotations.Labels
 		name := c.task.Networks[0].Network.Spec.Annotations.Name
 		if v, ok := labels["com.docker.swarm.predefined"]; ok && v == "true" {
-			hc.NetworkMode = enginecontainer.NetworkMode(name)
+			hc.NetworkMode = containertypes.NetworkMode(name)
 		}
 	}
 
@@ -474,8 +474,8 @@ func (c *containerConfig) volumeCreateRequest(mount *api.Mount) *volume.CreateOp
 	return nil
 }
 
-func (c *containerConfig) resources() enginecontainer.Resources {
-	resources := enginecontainer.Resources{}
+func (c *containerConfig) resources() containertypes.Resources {
+	resources := containertypes.Resources{}
 
 	// set pids limit
 	pidsLimit := c.spec().PidsLimit
@@ -672,7 +672,7 @@ func (c *containerConfig) networkCreateRequest(name string) (clustertypes.Networ
 	}, nil
 }
 
-func (c *containerConfig) applyPrivileges(hc *enginecontainer.HostConfig) {
+func (c *containerConfig) applyPrivileges(hc *containertypes.HostConfig) {
 	privileges := c.spec().Privileges
 	if privileges == nil {
 		return

--- a/daemon/cluster/volumes.go
+++ b/daemon/cluster/volumes.go
@@ -96,11 +96,10 @@ func (c *Cluster) RemoveVolume(nameOrID string, force bool) error {
 			return err
 		}
 
-		req := &swarmapi.RemoveVolumeRequest{
+		_, err = state.controlClient.RemoveVolume(ctx, &swarmapi.RemoveVolumeRequest{
 			VolumeID: volume.ID,
 			Force:    force,
-		}
-		_, err = state.controlClient.RemoveVolume(ctx, req)
+		})
 		return err
 	})
 }
@@ -125,19 +124,18 @@ func (c *Cluster) UpdateVolume(nameOrID string, version uint64, volume volumetyp
 				v.Spec.Availability = swarmapi.VolumeAvailabilityPause
 			case volumetypes.AvailabilityDrain:
 				v.Spec.Availability = swarmapi.VolumeAvailabilityDrain
+			default:
+				// if default empty value, change nothing.
 			}
-			// if default empty value, change nothing.
 		}
 
-		_, err = state.controlClient.UpdateVolume(
-			ctx, &swarmapi.UpdateVolumeRequest{
-				VolumeID: nameOrID,
-				VolumeVersion: &swarmapi.Version{
-					Index: version,
-				},
-				Spec: &v.Spec,
+		_, err = state.controlClient.UpdateVolume(ctx, &swarmapi.UpdateVolumeRequest{
+			VolumeID: nameOrID,
+			VolumeVersion: &swarmapi.Version{
+				Index: version,
 			},
-		)
+			Spec: &v.Spec,
+		})
 		return err
 	})
 }

--- a/integration/container/list_test.go
+++ b/integration/container/list_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	typecontainer "github.com/docker/docker/api/types/container"
+	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/container"
@@ -32,15 +32,12 @@ func TestListAnnotations(t *testing.T) {
 		t.Run(fmt.Sprintf("run with version v%s", tc.apiVersion), func(t *testing.T) {
 			apiClient := request.NewAPIClient(t, client.WithVersion(tc.apiVersion))
 			id := container.Create(ctx, t, apiClient, container.WithAnnotations(annotations))
-			defer container.Remove(ctx, t, apiClient, id, typecontainer.RemoveOptions{Force: true})
+			defer container.Remove(ctx, t, apiClient, id, containertypes.RemoveOptions{Force: true})
 
-			containers, err := apiClient.ContainerList(
-				ctx,
-				typecontainer.ListOptions{
-					All:     true,
-					Filters: filters.NewArgs(filters.Arg("id", id)),
-				},
-			)
+			containers, err := apiClient.ContainerList(ctx, containertypes.ListOptions{
+				All:     true,
+				Filters: filters.NewArgs(filters.Arg("id", id)),
+			})
 			assert.NilError(t, err)
 			assert.Assert(t, is.Len(containers, 1))
 			assert.Equal(t, containers[0].ID, id)


### PR DESCRIPTION
Some leftovers from work on other PRs


### daemon/cluster: minor linting issues and cleanup

- rename variables that shadowed imports
- remove some intermediate vars
- slight reformating for readability

### daemon: updateNetworkSettings: unwrap lines for readability

### daemon/cluster/executor/container: use consistent alias for import

The canonical alias is "containertypes" for this import.


### integration/container: use consistent alias for import

The canonical alias is "containertypes" for this import.



**- A picture of a cute animal (not mandatory but encouraged)**

