### PR TITLE
api/types/container: provide alias for github.com/docker/go-units.Ulimit

### DIFF
--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -25,7 +25,6 @@ import (
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
-	units "github.com/docker/go-units"
 	"github.com/pkg/errors"
 )
 
@@ -105,7 +104,7 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 	}
 
 	if ulimitsJSON := r.FormValue("ulimits"); ulimitsJSON != "" {
-		buildUlimits := []*units.Ulimit{}
+		buildUlimits := []*container.Ulimit{}
 		if err := json.Unmarshal([]byte(ulimitsJSON), &buildUlimits); err != nil {
 			return nil, invalidParam{errors.Wrap(err, "error reading ulimit settings")}
 		}

--- a/api/server/router/swarm/helpers_test.go
+++ b/api/server/router/swarm/helpers_test.go
@@ -4,9 +4,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/docker/go-units"
 )
 
 func TestAdjustForAPIVersion(t *testing.T) {
@@ -39,7 +39,7 @@ func TestAdjustForAPIVersion(t *testing.T) {
 						ConfigName: "configRuntime",
 					},
 				},
-				Ulimits: []*units.Ulimit{
+				Ulimits: []*container.Ulimit{
 					{
 						Name: "nofile",
 						Soft: 100,

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/registry"
-	units "github.com/docker/go-units"
 )
 
 // NewHijackedResponse intializes a HijackedResponse type
@@ -74,7 +73,7 @@ type ImageBuildOptions struct {
 	NetworkMode    string
 	ShmSize        int64
 	Dockerfile     string
-	Ulimits        []*units.Ulimit
+	Ulimits        []*container.Ulimit
 	// BuildArgs needs to be a *string instead of just a string so that
 	// we can tell the difference between "" (empty string) and no value
 	// at all (nil). See the parsing of buildArgs in

--- a/api/types/container/hostconfig.go
+++ b/api/types/container/hostconfig.go
@@ -360,6 +360,12 @@ type LogConfig struct {
 	Config map[string]string
 }
 
+// Ulimit is an alias for [units.Ulimit], which may be moving to a different
+// location or become a local type. This alias is to help transitioning.
+//
+// Users are recommended to use this alias instead of using [units.Ulimit] directly.
+type Ulimit = units.Ulimit
+
 // Resources contains container's resources (cgroups config, ulimits...)
 type Resources struct {
 	// Applicable to all platforms
@@ -387,14 +393,14 @@ type Resources struct {
 
 	// KernelMemory specifies the kernel memory limit (in bytes) for the container.
 	// Deprecated: kernel 5.4 deprecated kmem.limit_in_bytes.
-	KernelMemory      int64           `json:",omitempty"`
-	KernelMemoryTCP   int64           `json:",omitempty"` // Hard limit for kernel TCP buffer memory (in bytes)
-	MemoryReservation int64           // Memory soft limit (in bytes)
-	MemorySwap        int64           // Total memory usage (memory + swap); set `-1` to enable unlimited swap
-	MemorySwappiness  *int64          // Tuning container memory swappiness behaviour
-	OomKillDisable    *bool           // Whether to disable OOM Killer or not
-	PidsLimit         *int64          // Setting PIDs limit for a container; Set `0` or `-1` for unlimited, or `null` to not change.
-	Ulimits           []*units.Ulimit // List of ulimits to be set in the container
+	KernelMemory      int64     `json:",omitempty"`
+	KernelMemoryTCP   int64     `json:",omitempty"` // Hard limit for kernel TCP buffer memory (in bytes)
+	MemoryReservation int64     // Memory soft limit (in bytes)
+	MemorySwap        int64     // Total memory usage (memory + swap); set `-1` to enable unlimited swap
+	MemorySwappiness  *int64    // Tuning container memory swappiness behaviour
+	OomKillDisable    *bool     // Whether to disable OOM Killer or not
+	PidsLimit         *int64    // Setting PIDs limit for a container; Set `0` or `-1` for unlimited, or `null` to not change.
+	Ulimits           []*Ulimit // List of ulimits to be set in the container
 
 	// Applicable to Windows
 	CPUCount           int64  `json:"CpuCount"`   // CPU count

--- a/api/types/swarm/container.go
+++ b/api/types/swarm/container.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
-	"github.com/docker/go-units"
 )
 
 // DNSConfig specifies DNS related configurations in resolver configuration file (resolv.conf)
@@ -115,6 +114,6 @@ type ContainerSpec struct {
 	Sysctls        map[string]string   `json:",omitempty"`
 	CapabilityAdd  []string            `json:",omitempty"`
 	CapabilityDrop []string            `json:",omitempty"`
-	Ulimits        []*units.Ulimit     `json:",omitempty"`
+	Ulimits        []*container.Ulimit `json:",omitempty"`
 	OomScoreAdj    int64               `json:",omitempty"`
 }

--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/api/types/container"
 	timetypes "github.com/docker/docker/api/types/time"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builder/builder-next/exporter"
@@ -26,7 +27,6 @@ import (
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/streamformatter"
-	"github.com/docker/go-units"
 	controlapi "github.com/moby/buildkit/api/services/control"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/control"
@@ -613,7 +613,7 @@ func toBuildkitExtraHosts(inp []string, hostGatewayIP net.IP) (string, error) {
 }
 
 // toBuildkitUlimits converts ulimits from docker type=soft:hard format to buildkit's csv format
-func toBuildkitUlimits(inp []*units.Ulimit) (string, error) {
+func toBuildkitUlimits(inp []*container.Ulimit) (string, error) {
 	if len(inp) == 0 {
 		return "", nil
 	}

--- a/client/image_build_test.go
+++ b/client/image_build_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/errdefs"
-	units "github.com/docker/go-units"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -123,7 +122,7 @@ func TestImageBuild(t *testing.T) {
 		},
 		{
 			buildOptions: types.ImageBuildOptions{
-				Ulimits: []*units.Ulimit{
+				Ulimits: []*container.Ulimit{
 					{
 						Name: "nproc",
 						Hard: 65557,

--- a/daemon/cluster/convert/container.go
+++ b/daemon/cluster/convert/container.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	mounttypes "github.com/docker/docker/api/types/mount"
 	types "github.com/docker/docker/api/types/swarm"
-	"github.com/docker/go-units"
 	gogotypes "github.com/gogo/protobuf/types"
 	swarmapi "github.com/moby/swarmkit/v2/api"
 	"github.com/pkg/errors"
@@ -544,11 +543,11 @@ func isolationToGRPC(i container.Isolation) swarmapi.ContainerSpec_Isolation {
 	return swarmapi.ContainerIsolationDefault
 }
 
-func ulimitsFromGRPC(u []*swarmapi.ContainerSpec_Ulimit) []*units.Ulimit {
-	ulimits := make([]*units.Ulimit, len(u))
+func ulimitsFromGRPC(u []*swarmapi.ContainerSpec_Ulimit) []*container.Ulimit {
+	ulimits := make([]*container.Ulimit, len(u))
 
 	for i, ulimit := range u {
-		ulimits[i] = &units.Ulimit{
+		ulimits[i] = &container.Ulimit{
 			Name: ulimit.Name,
 			Soft: ulimit.Soft,
 			Hard: ulimit.Hard,
@@ -558,7 +557,7 @@ func ulimitsFromGRPC(u []*swarmapi.ContainerSpec_Ulimit) []*units.Ulimit {
 	return ulimits
 }
 
-func ulimitsToGRPC(u []*units.Ulimit) []*swarmapi.ContainerSpec_Ulimit {
+func ulimitsToGRPC(u []*container.Ulimit) []*swarmapi.ContainerSpec_Ulimit {
 	ulimits := make([]*swarmapi.ContainerSpec_Ulimit, len(u))
 
 	for i, ulimit := range u {

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -22,7 +22,6 @@ import (
 	clustertypes "github.com/docker/docker/daemon/cluster/provider"
 	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/go-connections/nat"
-	"github.com/docker/go-units"
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/moby/swarmkit/v2/agent/exec"
 	"github.com/moby/swarmkit/v2/api"
@@ -483,9 +482,9 @@ func (c *containerConfig) resources() containertypes.Resources {
 		resources.PidsLimit = &pidsLimit
 	}
 
-	resources.Ulimits = make([]*units.Ulimit, len(c.spec().Ulimits))
+	resources.Ulimits = make([]*containertypes.Ulimit, len(c.spec().Ulimits))
 	for i, ulimit := range c.spec().Ulimits {
-		resources.Ulimits[i] = &units.Ulimit{
+		resources.Ulimits[i] = &containertypes.Ulimit{
 			Name: ulimit.Name,
 			Soft: ulimit.Soft,
 			Hard: ulimit.Hard,

--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -15,7 +15,6 @@ import (
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/homedir"
 	"github.com/docker/docker/pkg/rootless"
-	units "github.com/docker/go-units"
 	"github.com/pkg/errors"
 )
 
@@ -72,21 +71,21 @@ type Config struct {
 	CommonConfig
 
 	// Fields below here are platform specific.
-	Runtimes             map[string]system.Runtime `json:"runtimes,omitempty"`
-	DefaultInitBinary    string                    `json:"default-init,omitempty"`
-	CgroupParent         string                    `json:"cgroup-parent,omitempty"`
-	EnableSelinuxSupport bool                      `json:"selinux-enabled,omitempty"`
-	RemappedRoot         string                    `json:"userns-remap,omitempty"`
-	Ulimits              map[string]*units.Ulimit  `json:"default-ulimits,omitempty"`
-	CPURealtimePeriod    int64                     `json:"cpu-rt-period,omitempty"`
-	CPURealtimeRuntime   int64                     `json:"cpu-rt-runtime,omitempty"`
-	Init                 bool                      `json:"init,omitempty"`
-	InitPath             string                    `json:"init-path,omitempty"`
-	SeccompProfile       string                    `json:"seccomp-profile,omitempty"`
-	ShmSize              opts.MemBytes             `json:"default-shm-size,omitempty"`
-	NoNewPrivileges      bool                      `json:"no-new-privileges,omitempty"`
-	IpcMode              string                    `json:"default-ipc-mode,omitempty"`
-	CgroupNamespaceMode  string                    `json:"default-cgroupns-mode,omitempty"`
+	Runtimes             map[string]system.Runtime    `json:"runtimes,omitempty"`
+	DefaultInitBinary    string                       `json:"default-init,omitempty"`
+	CgroupParent         string                       `json:"cgroup-parent,omitempty"`
+	EnableSelinuxSupport bool                         `json:"selinux-enabled,omitempty"`
+	RemappedRoot         string                       `json:"userns-remap,omitempty"`
+	Ulimits              map[string]*container.Ulimit `json:"default-ulimits,omitempty"`
+	CPURealtimePeriod    int64                        `json:"cpu-rt-period,omitempty"`
+	CPURealtimeRuntime   int64                        `json:"cpu-rt-runtime,omitempty"`
+	Init                 bool                         `json:"init,omitempty"`
+	InitPath             string                       `json:"init-path,omitempty"`
+	SeccompProfile       string                       `json:"seccomp-profile,omitempty"`
+	ShmSize              opts.MemBytes                `json:"default-shm-size,omitempty"`
+	NoNewPrivileges      bool                         `json:"no-new-privileges,omitempty"`
+	IpcMode              string                       `json:"default-ipc-mode,omitempty"`
+	CgroupNamespaceMode  string                       `json:"default-cgroupns-mode,omitempty"`
 	// ResolvConf is the path to the configuration of the host resolver
 	ResolvConf string `json:"resolv-conf,omitempty"`
 	Rootless   bool   `json:"rootless,omitempty"`
@@ -209,7 +208,7 @@ func (conf *Config) IsRootless() bool {
 }
 
 func setPlatformDefaults(cfg *Config) error {
-	cfg.Ulimits = make(map[string]*units.Ulimit)
+	cfg.Ulimits = make(map[string]*container.Ulimit)
 	cfg.ShmSize = opts.MemBytes(DefaultShmSize)
 	cfg.SeccompProfile = SeccompProfileDefault
 	cfg.IpcMode = string(DefaultIpcMode)

--- a/daemon/config/config_linux_test.go
+++ b/daemon/config/config_linux_test.go
@@ -3,8 +3,8 @@ package config // import "github.com/docker/docker/daemon/config"
 import (
 	"testing"
 
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/opts"
-	units "github.com/docker/go-units"
 	"github.com/spf13/pflag"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -43,7 +43,7 @@ func TestGetConflictFreeConfiguration(t *testing.T) {
 
 	assert.Check(t, cc.Debug)
 
-	expectedUlimits := map[string]*units.Ulimit{
+	expectedUlimits := map[string]*container.Ulimit{
 		"nofile": {
 			Name: "nofile",
 			Hard: 2048,
@@ -93,7 +93,7 @@ func TestDaemonConfigurationMerge(t *testing.T) {
 
 	assert.Check(t, is.DeepEqual(expectedLogConfig, cc.LogConfig))
 
-	expectedUlimits := map[string]*units.Ulimit{
+	expectedUlimits := map[string]*container.Ulimit{
 		"nofile": {
 			Name: "nofile",
 			Hard: 2048,

--- a/integration-cli/docker_cli_build_unix_test.go
+++ b/integration-cli/docker_cli_build_unix_test.go
@@ -15,10 +15,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/testutil/fakecontext"
-	units "github.com/docker/go-units"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
 )
@@ -47,7 +47,7 @@ func (s *DockerCLIBuildSuite) TestBuildResourceConstraintsAreUsed(c *testing.T) 
 		CpusetMems string
 		CPUShares  int64
 		CPUQuota   int64
-		Ulimits    []*units.Ulimit
+		Ulimits    []*container.Ulimit
 	}
 
 	cfg := inspectFieldJSON(c, cID, "HostConfig")

--- a/opts/ulimit.go
+++ b/opts/ulimit.go
@@ -3,24 +3,27 @@ package opts // import "github.com/docker/docker/opts"
 import (
 	"fmt"
 
+	"github.com/docker/docker/api/types/container"
 	units "github.com/docker/go-units"
 )
 
 // UlimitOpt defines a map of Ulimits
 type UlimitOpt struct {
-	values *map[string]*units.Ulimit
+	values *map[string]*container.Ulimit
 }
 
 // NewUlimitOpt creates a new UlimitOpt
-func NewUlimitOpt(ref *map[string]*units.Ulimit) *UlimitOpt {
+func NewUlimitOpt(ref *map[string]*container.Ulimit) *UlimitOpt {
+	// TODO(thaJeztah): why do we need a map with pointers here?
 	if ref == nil {
-		ref = &map[string]*units.Ulimit{}
+		ref = &map[string]*container.Ulimit{}
 	}
 	return &UlimitOpt{ref}
 }
 
 // Set validates a Ulimit and sets its name as a key in UlimitOpt
 func (o *UlimitOpt) Set(val string) error {
+	// FIXME(thaJeztah): these functions also need to be moved over from go-units.
 	l, err := units.ParseUlimit(val)
 	if err != nil {
 		return err
@@ -42,8 +45,8 @@ func (o *UlimitOpt) String() string {
 }
 
 // GetList returns a slice of pointers to Ulimits.
-func (o *UlimitOpt) GetList() []*units.Ulimit {
-	var ulimits []*units.Ulimit
+func (o *UlimitOpt) GetList() []*container.Ulimit {
+	var ulimits []*container.Ulimit
 	for _, v := range *o.values {
 		ulimits = append(ulimits, v)
 	}
@@ -65,9 +68,9 @@ type NamedUlimitOpt struct {
 var _ NamedOption = &NamedUlimitOpt{}
 
 // NewNamedUlimitOpt creates a new NamedUlimitOpt
-func NewNamedUlimitOpt(name string, ref *map[string]*units.Ulimit) *NamedUlimitOpt {
+func NewNamedUlimitOpt(name string, ref *map[string]*container.Ulimit) *NamedUlimitOpt {
 	if ref == nil {
-		ref = &map[string]*units.Ulimit{}
+		ref = &map[string]*container.Ulimit{}
 	}
 	return &NamedUlimitOpt{
 		name:      name,

--- a/opts/ulimit_test.go
+++ b/opts/ulimit_test.go
@@ -3,11 +3,11 @@ package opts // import "github.com/docker/docker/opts"
 import (
 	"testing"
 
-	units "github.com/docker/go-units"
+	"github.com/docker/docker/api/types/container"
 )
 
 func TestUlimitOpt(t *testing.T) {
-	ulimitMap := map[string]*units.Ulimit{
+	ulimitMap := map[string]*container.Ulimit{
 		"nofile": {Name: "nofile", Hard: 1024, Soft: 512},
 	}
 


### PR DESCRIPTION
- [x] depends on / stacked on https://github.com/moby/moby/pull/48022


### api/types/container: provide alias for github.com/docker/go-units.Ulimit

This type is included in various types used in the API, but comes from
a separate module. The go-units module may be moving to the moby org,
and it is yet to be decided if the Ulimit type is a good fit for that
module (which deals with more generic units, such as "size" and "duration"
otherwise).

This patch introduces an alias to help during the transition of this type
to it's new location. The alias makes sure that existing code continues
to work (at least for now), but we need to start updating such code after
this PR is merged.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
api/types/container: introduce Ulimit type-alias for github.com/docker/go-units.Ulimit.

The Ulimits type as used in the API is defined in a go-module that will
transition to a new location in future.

A type-alias is added to help transition of this type to it's new location.
The alias makes sure that existing code continues to work, but its definition
may change in future. Users are recommended to use this alias instead of
using `units.Ulimit` directly.
```

**- A picture of a cute animal (not mandatory but encouraged)**

