### PR TITLE
Fix hairpin between networks with mapped port

### DIFF
--- a/integration/networking/bridge_test.go
+++ b/integration/networking/bridge_test.go
@@ -3,14 +3,17 @@ package networking
 import (
 	"context"
 	"fmt"
+	"net"
 	"os/exec"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
 	containertypes "github.com/docker/docker/api/types/container"
 	networktypes "github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/integration/internal/network"
 	"github.com/docker/docker/libnetwork/drivers/bridge"
@@ -994,4 +997,61 @@ func TestDisableNAT(t *testing.T) {
 			assert.Check(t, is.DeepEqual(inspect.NetworkSettings.Ports, tc.expPortMap))
 		})
 	}
+}
+
+// Check that a container on one network (bridge or Windows nat) can reach a
+// service in a container on another network, via a mapped port on the host.
+func TestPortMappedHairpin(t *testing.T) {
+	skip.If(t, testEnv.IsRootless)
+
+	ctx := setupTest(t)
+
+	var c client.APIClient
+	var driverName string
+
+	if runtime.GOOS == "windows" {
+		c = testEnv.APIClient()
+		driverName = "nat"
+	} else {
+		d := daemon.New(t)
+		d.StartWithBusybox(ctx, t)
+		defer d.Stop(t)
+
+		c = d.NewClientT(t)
+		defer c.Close()
+		driverName = "bridge"
+	}
+
+	// Find an address on the test host.
+	conn, err := net.Dial("tcp4", "hub.docker.com:80")
+	assert.NilError(t, err)
+	hostAddr := conn.LocalAddr().(*net.TCPAddr).IP.String()
+	conn.Close()
+
+	const serverNetName = "servernet"
+	network.CreateNoError(ctx, t, c, serverNetName, network.WithDriver(driverName))
+	defer network.RemoveNoError(ctx, t, c, serverNetName)
+	const clientNetName = "clientnet"
+	network.CreateNoError(ctx, t, c, clientNetName, network.WithDriver(driverName))
+	defer network.RemoveNoError(ctx, t, c, clientNetName)
+
+	serverId := container.Run(ctx, t, c,
+		container.WithNetworkMode(serverNetName),
+		container.WithExposedPorts("80"),
+		container.WithPortMap(nat.PortMap{"80": {{HostIP: "0.0.0.0"}}}),
+		container.WithCmd("httpd", "-f"),
+	)
+	defer c.ContainerRemove(ctx, serverId, containertypes.RemoveOptions{Force: true})
+
+	inspect := container.Inspect(ctx, t, c, serverId)
+	hostPort := inspect.NetworkSettings.Ports["80/tcp"][0].HostPort
+
+	clientCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	res := container.RunAttach(clientCtx, t, c,
+		container.WithNetworkMode(clientNetName),
+		container.WithCmd("wget", "http://"+hostAddr+":"+hostPort),
+	)
+	defer c.ContainerRemove(ctx, res.ContainerID, containertypes.RemoveOptions{Force: true})
+	assert.Check(t, is.Contains(res.Stderr.String(), "404 Not Found"))
 }

--- a/libnetwork/drivers/bridge/port_mapping_linux.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux.go
@@ -509,7 +509,7 @@ func setPerPortNAT(b portBinding, ipv iptables.IPVersion, proxyPath string, brid
 		args = append(args, "!", "-i", bridgeName)
 	}
 	rule := iptRule{ipv: ipv, table: iptables.Nat, chain: DockerChain, args: args}
-	if err := programChainRule(rule, "DNAT", enable); err != nil {
+	if err := appendOrDelChainRule(rule, "DNAT", enable); err != nil {
 		return err
 	}
 
@@ -521,7 +521,7 @@ func setPerPortNAT(b portBinding, ipv iptables.IPVersion, proxyPath string, brid
 		"-j", "MASQUERADE",
 	}
 	rule = iptRule{ipv: ipv, table: iptables.Nat, chain: "POSTROUTING", args: args}
-	if err := programChainRule(rule, "MASQUERADE", enable); err != nil {
+	if err := appendOrDelChainRule(rule, "MASQUERADE", enable); err != nil {
 		return err
 	}
 
@@ -538,7 +538,7 @@ func setPerPortForwarding(b portBinding, ipv iptables.IPVersion, bridgeName stri
 		"-j", "ACCEPT",
 	}
 	rule := iptRule{ipv: ipv, table: iptables.Filter, chain: DockerChain, args: args}
-	if err := programChainRule(rule, "MASQUERADE", enable); err != nil {
+	if err := appendOrDelChainRule(rule, "MASQUERADE", enable); err != nil {
 		return err
 	}
 
@@ -557,7 +557,7 @@ func setPerPortForwarding(b portBinding, ipv iptables.IPVersion, bridgeName stri
 			"--checksum-fill",
 		}
 		rule := iptRule{ipv: ipv, table: iptables.Mangle, chain: "POSTROUTING", args: args}
-		if err := programChainRule(rule, "MASQUERADE", enable); err != nil {
+		if err := appendOrDelChainRule(rule, "MASQUERADE", enable); err != nil {
 			return err
 		}
 	}

--- a/libnetwork/drivers/bridge/setup_ip_tables_linux.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux.go
@@ -314,6 +314,19 @@ func programChainRule(rule iptRule, ruleDescr string, insert bool) error {
 	return nil
 }
 
+func appendOrDelChainRule(rule iptRule, ruleDescr string, append bool) error {
+	operation := "disable"
+	fn := rule.Delete
+	if append {
+		operation = "enable"
+		fn = rule.Append
+	}
+	if err := fn(); err != nil {
+		return fmt.Errorf("Unable to %s %s rule: %s", operation, ruleDescr, err.Error())
+	}
+	return nil
+}
+
 func setIcc(version iptables.IPVersion, bridgeIface string, iccEnable, insert bool) error {
 	args := []string{"-i", bridgeIface, "-o", bridgeIface, "-j"}
 	acceptRule := iptRule{ipv: version, table: iptables.Filter, chain: "FORWARD", args: append(args, "ACCEPT")}


### PR DESCRIPTION
**- What I did**

Following changes to the port mapping code in https://github.com/moby/moby/pull/47871, the DNAT iptables rule was inserted into the nat table rather than appended.

This meant DNAT was applied before the rule that should have skipped it when a packet was from a bridge network.

So, packets sent from a container on one network to a mapped port on the host's address were DNAT'd before docker-proxy could pick them up, then they were dropped by a rule intended to isolate the networks.

**- How I did it**

Append rather than insert the rules that moved from the portmapper to the bridge driver.

This is intended to be a minimal fix ... the bridge driver's iptables code needs a cleanup.

**- How to verify it**

New integration test.

**- Description for the changelog**
```markdown changelog
n/a
```
