### PR TITLE
volume: use AtomicWriteFile to save volume options

### DIFF
--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/docker/daemon/names"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/idtools"
+	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/quota"
 	"github.com/docker/docker/volume"
 	"github.com/pkg/errors"
@@ -388,7 +389,7 @@ func (v *localVolume) saveOpts() error {
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(filepath.Join(v.rootPath, "opts.json"), b, 0o600)
+	err = ioutils.AtomicWriteFile(filepath.Join(v.rootPath, "opts.json"), b, 0o600)
 	if err != nil {
 		return errdefs.System(errors.Wrap(err, "error while persisting volume options"))
 	}


### PR DESCRIPTION
If the system (or Docker) crashes while saivng the volume options, on restart the daemon will error out when trying to read the options file because it doesn't contain valid JSON.

In such a crash scenario, the new volume will be treated as though it has the default options configuration. This is not ideal, but volumes created on very old Docker versions (pre-1.11[1], circa 2016) do not have opts.json and so doing some kind of cleanup when loading the volume store (even if we take care to only delete empty volumes) could delete existing volumes carried over from very old Docker versions that users would not expect to disappear.

Ultimately, if a user creates a volume and the system crashes, a volume that has the wrong config is better than Docker not being able to start.

1: commit b05b2370757d ("Support mount opts for `local` volume driver")

**- Description for the changelog**
```markdown changelog
daemon: volume: write options JSON atomically to avoid "invalid JSON" errors after system crash
```