### PR TITLE
export unrecognised input header error from stdcopy

### DIFF
--- a/pkg/stdcopy/stdcopy.go
+++ b/pkg/stdcopy/stdcopy.go
@@ -33,6 +33,9 @@ const (
 
 var bufPool = &sync.Pool{New: func() interface{} { return bytes.NewBuffer(nil) }}
 
+// Exported errors
+var ErrInvalidStdHeader = errors.New("Unrecognized input header")
+
 // stdWriter is wrapper of io.Writer with extra customized info.
 type stdWriter struct {
 	io.Writer
@@ -135,7 +138,7 @@ func StdCopy(dstout, dsterr io.Writer, src io.Reader) (written int64, err error)
 			// to outstream if Systemerr is the stream
 			out = nil
 		default:
-			return 0, fmt.Errorf("Unrecognized input header: %d", buf[stdWriterFdIndex])
+			return 0, fmt.Errorf("%w: %d", ErrInvalidStdHeader, buf[stdWriterFdIndex])
 		}
 
 		// Retrieve the size of the frame


### PR DESCRIPTION
**- What I did**

I created `Unrecognized input header` with `errors.New` and exported the error to allow handling the error appropriately within packages importing `stdcopy`.

By exporting the error, I can now handle this error in my code that imports and uses the stdcopy library like so:

```
if err != nil {
    if errors.Is(err, stdcopy.ErrInvalidStdHeader) {
        // Handle the specific error
        fmt.Println("The error is ErrInvalidStdHeader")
    } else {
        // Handle other errors
        fmt.Println("An unexpected error occurred:", err)
    }
}
```

I added this so that I can pass a log stream to the `StdCopy` function and handle multiplexed and non-multiplexed streams. If it returns the invalid header error, I can fall back to my own mechanisms for handling the stream. 

I considered using the header to identify whether it is multiplexed or not, but the Docker SDK (`cli.ContainerLogs(ctx, dockerCmd.ResourceID, options)`) only returns the response body, so I cannot access the headers without an additional query. 

This is not a breaking change as the actual error message has remained the same.

It did once exist like this but was removed. It isn't explained why it was removed, but presumably because it wasn't exported so didn't provide any value at that point. Also because I think `errors.Is` didn't exist back then: https://github.com/moby/moby/commit/443a5c20216b5331b1bb57796140c0178ca44b7d

There may be other ways to address my use case that I will explore, but this change is helpful either way and good error handling practice. 

**- Description for the changelog**
```markdown changelog
Exported ErrInvalidStdHeader from `stdcopy` package to allow error handling.
```
