### PR TITLE
registry: minor cleanups

### DIFF
--- a/registry/auth.go
+++ b/registry/auth.go
@@ -108,16 +108,18 @@ func v2AuthHTTPClient(endpoint *url.URL, authTransport http.RoundTripper, modifi
 		return nil, err
 	}
 
-	tokenHandlerOptions := auth.TokenHandlerOptions{
-		Transport:     authTransport,
-		Credentials:   creds,
-		OfflineAccess: true,
-		ClientID:      AuthClientID,
-		Scopes:        scopes,
+	authHandlers := []auth.AuthenticationHandler{
+		auth.NewTokenHandlerWithOptions(auth.TokenHandlerOptions{
+			Transport:     authTransport,
+			Credentials:   creds,
+			OfflineAccess: true,
+			ClientID:      AuthClientID,
+			Scopes:        scopes,
+		}),
+		auth.NewBasicHandler(creds),
 	}
-	tokenHandler := auth.NewTokenHandlerWithOptions(tokenHandlerOptions)
-	basicHandler := auth.NewBasicHandler(creds)
-	modifiers = append(modifiers, auth.NewAuthorizer(challengeManager, tokenHandler, basicHandler))
+
+	modifiers = append(modifiers, auth.NewAuthorizer(challengeManager, authHandlers...))
 
 	return &http.Client{
 		Transport: transport.NewTransport(authTransport, modifiers...),

--- a/registry/search.go
+++ b/registry/search.go
@@ -112,16 +112,12 @@ func (s *Service) searchUnfiltered(ctx context.Context, term string, limit int, 
 	var client *http.Client
 	if authConfig != nil && authConfig.IdentityToken != "" && authConfig.Username != "" {
 		creds := NewStaticCredentialStore(authConfig)
-		scopes := []auth.Scope{
-			auth.RegistryScope{
-				Name:    "catalog",
-				Actions: []string{"search"},
-			},
-		}
 
 		// TODO(thaJeztah); is there a reason not to include other headers here? (originally added in 19d48f0b8ba59eea9f2cac4ad1c7977712a6b7ac)
 		modifiers := Headers(headers.Get("User-Agent"), nil)
-		v2Client, err := v2AuthHTTPClient(endpoint.URL, endpoint.client.Transport, modifiers, creds, scopes)
+		v2Client, err := v2AuthHTTPClient(endpoint.URL, endpoint.client.Transport, modifiers, creds, []auth.Scope{
+			auth.RegistryScope{Name: "catalog", Actions: []string{"search"}},
+		})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### registry: v2AuthHTTPClient: inline some vars and slight refactor

- inline the auth.TokenHandlerOptions in the auth.NewTokenHandlerWithOptions call
- construct a authHandlers slice to make it more clear that this is a variadic
  list of authentication-handlers.

### registry: Search.searchUnfiltered: inline variable

The scopes variable was used in one location; inline it where it's used.

**- A picture of a cute animal (not mandatory but encouraged)**

