### PR TITLE
api/server/router/build: BuilderVersion: allow buildkit on Windows

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -294,6 +294,12 @@ func (cli *daemonCLI) start(ctx context.Context) (err error) {
 		return fmt.Errorf("error initializing buildkit: %w", err)
 	}
 
+	if runtime.GOOS == "windows" {
+		if enabled, ok := d.Features()["buildkit"]; ok && enabled {
+			log.G(ctx).Warn("Buildkit feature is enabled in the daemon.json configuration file. Support for BuildKit on Windows is experimental, and enabling this feature may not work. Use at your own risk!")
+		}
+	}
+
 	routers := buildRouters(routerOptions{
 		features: d.Features,
 		daemon:   d,


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/43657
- relates to https://github.com/docker/cli/pull/5178
- relates to https://github.com/docker/cli/issues/5001
- [x] depends on https://github.com/moby/moby/pull/49740

api/server/router/build: BuilderVersion: allow buildkit on Windows

Commit 7b153b9e28b53779215de209736310f9266b3f2f changed the daemon to
advertise the recommended builder to use to V2 (BuildKit) for Linux
daemons, and V1 (Legacy Builder) for Windows daemons. For Linux daemons
we allowed the default to be overridden through the "features" field
in the daemon config (daemon.json), but for Windows we hard-coded it
to be V1, and no option to override.

With work in progress on implementing support for Windows in BuildKit,
we should remove this hardcoded assumption, and allow the default to
be overridden to advertise that BuildKit is supported.

Note that BuildKit on Windows is still very much a "work in progress",
and enabling it in the daemon may not even work, so users should not
try to enable this feature; a warning-level log is added to make it
visible that the feature is enabled.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

