### PR TITLE
api/types: move stats-types to api/types/container

### DIFF
--- a/api/types/container/container.go
+++ b/api/types/container/container.go
@@ -37,7 +37,7 @@ type CopyToContainerOptions struct {
 // The OSType field is set to the server's platform to allow
 // platform-specific handling of the response.
 //
-// TODO(thaJeztah): remove this wrapper, and make OSType part of [StatsJSON].
+// TODO(thaJeztah): remove this wrapper, and make OSType part of [StatsResponse].
 type StatsResponseReader struct {
 	Body   io.ReadCloser `json:"body"`
 	OSType string        `json:"ostype"`

--- a/api/types/container/stats.go
+++ b/api/types/container/stats.go
@@ -1,6 +1,4 @@
-// Package types is used for API stability in the types and response to the
-// consumers of the API stats endpoint.
-package types // import "github.com/docker/docker/api/types"
+package container
 
 import "time"
 
@@ -169,8 +167,10 @@ type Stats struct {
 	MemoryStats MemoryStats `json:"memory_stats,omitempty"`
 }
 
-// StatsJSON is newly used Networks
-type StatsJSON struct {
+// StatsResponse is newly used Networks.
+//
+// TODO(thaJeztah): unify with [Stats]. This wrapper was to account for pre-api v1.21 changes, see https://github.com/moby/moby/commit/d3379946ec96fb6163cb8c4517d7d5a067045801
+type StatsResponse struct {
 	Stats
 
 	Name string `json:"name,omitempty"`

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -114,6 +114,67 @@ type CopyToContainerOptions = container.CopyToContainerOptions
 // Deprecated: use [container.StatsResponseReader].
 type ContainerStats = container.StatsResponseReader
 
+// ThrottlingData stores CPU throttling stats of one running container.
+// Not used on Windows.
+//
+// Deprecated: use [container.ThrottlingData].
+type ThrottlingData = container.ThrottlingData
+
+// CPUUsage stores All CPU stats aggregated since container inception.
+//
+// Deprecated: use [container.CPUUsage].
+type CPUUsage = container.CPUUsage
+
+// CPUStats aggregates and wraps all CPU related info of container
+//
+// Deprecated: use [container.CPUStats].
+type CPUStats = container.CPUStats
+
+// MemoryStats aggregates all memory stats since container inception on Linux.
+// Windows returns stats for commit and private working set only.
+//
+// Deprecated: use [container.MemoryStats].
+type MemoryStats = container.MemoryStats
+
+// BlkioStatEntry is one small entity to store a piece of Blkio stats
+// Not used on Windows.
+//
+// Deprecated: use [container.BlkioStatEntry].
+type BlkioStatEntry = container.BlkioStatEntry
+
+// BlkioStats stores All IO service stats for data read and write.
+// This is a Linux specific structure as the differences between expressing
+// block I/O on Windows and Linux are sufficiently significant to make
+// little sense attempting to morph into a combined structure.
+//
+// Deprecated: use [container.BlkioStats].
+type BlkioStats = container.BlkioStats
+
+// StorageStats is the disk I/O stats for read/write on Windows.
+//
+// Deprecated: use [container.StorageStats].
+type StorageStats = container.StorageStats
+
+// NetworkStats aggregates the network stats of one container
+//
+// Deprecated: use [container.NetworkStats].
+type NetworkStats = container.NetworkStats
+
+// PidsStats contains the stats of a container's pids
+//
+// Deprecated: use [container.PidsStats].
+type PidsStats = container.PidsStats
+
+// Stats is Ultimate struct aggregating all types of stats of one container
+//
+// Deprecated: use [container.Stats].
+type Stats = container.Stats
+
+// StatsJSON is newly used Networks
+//
+// Deprecated: use [container.StatsResponse].
+type StatsJSON = container.StatsResponse
+
 // EventsOptions holds parameters to filter events with.
 //
 // Deprecated: use [events.ListOptions].

--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/containerd/log"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
+	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
 )
@@ -30,7 +30,7 @@ func (daemon *Daemon) ContainerStats(ctx context.Context, prefixOrName string, c
 
 	// If the container is either not running or restarting and requires no stream, return an empty stats.
 	if (!ctr.IsRunning() || ctr.IsRestarting()) && !config.Stream {
-		return enc.Encode(&types.StatsJSON{
+		return enc.Encode(&containertypes.StatsResponse{
 			Name: ctr.Name,
 			ID:   ctr.ID,
 		})
@@ -45,10 +45,10 @@ func (daemon *Daemon) ContainerStats(ctx context.Context, prefixOrName string, c
 		return enc.Encode(stats)
 	}
 
-	var preCPUStats types.CPUStats
+	var preCPUStats containertypes.CPUStats
 	var preRead time.Time
-	getStatJSON := func(v interface{}) *types.StatsJSON {
-		ss := v.(types.StatsJSON)
+	getStatJSON := func(v interface{}) *containertypes.StatsResponse {
+		ss := v.(containertypes.StatsResponse)
 		ss.Name = ctr.Name
 		ss.ID = ctr.ID
 		ss.PreCPUStats = preCPUStats
@@ -99,7 +99,7 @@ func (daemon *Daemon) unsubscribeToContainerStats(c *container.Container, ch cha
 }
 
 // GetContainerStats collects all the stats published by a container
-func (daemon *Daemon) GetContainerStats(container *container.Container) (*types.StatsJSON, error) {
+func (daemon *Daemon) GetContainerStats(container *container.Container) (*containertypes.StatsResponse, error) {
 	stats, err := daemon.stats(container)
 	if err != nil {
 		goto done
@@ -124,7 +124,7 @@ done:
 		return stats, nil
 	case errdefs.ErrConflict, errdefs.ErrNotFound:
 		// return empty stats containing only name and ID if not running or not found
-		return &types.StatsJSON{
+		return &containertypes.StatsResponse{
 			Name: container.Name,
 			ID:   container.ID,
 		}, nil

--- a/daemon/stats/collector.go
+++ b/daemon/stats/collector.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/docker/docker/api/types"
+	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
 	"github.com/moby/pubsub"
 )
@@ -31,7 +31,7 @@ func NewCollector(supervisor supervisor, interval time.Duration) *Collector {
 
 type supervisor interface {
 	// GetContainerStats collects all the stats related to a container
-	GetContainerStats(container *container.Container) (*types.StatsJSON, error)
+	GetContainerStats(container *container.Container) (*containertypes.StatsResponse, error)
 }
 
 // Collect registers the container with the collector and adds it to
@@ -105,7 +105,7 @@ func (s *Collector) Run() {
 		for _, pair := range pairs {
 			stats, err := s.supervisor.GetContainerStats(pair.container)
 			if err != nil {
-				stats = &types.StatsJSON{
+				stats = &containertypes.StatsResponse{
 					Name: pair.container.Name,
 					ID:   pair.container.ID,
 				}

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -178,7 +178,7 @@ func (s *DockerAPISuite) TestGetContainerStats(c *testing.T) {
 	case sr := <-bc:
 		dec := json.NewDecoder(sr.stats.Body)
 		defer sr.stats.Body.Close()
-		var s *types.Stats
+		var s *container.Stats
 		// decode only one object from the stream
 		assert.NilError(c, dec.Decode(&s))
 	}

--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/system"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/cli"
@@ -34,7 +34,7 @@ func (s *DockerAPISuite) TestAPIStatsNoStreamGetCpu(c *testing.T) {
 	assert.Equal(c, resp.Header.Get("Content-Type"), "application/json")
 	assert.Equal(c, resp.Header.Get("Content-Type"), "application/json")
 
-	var v *types.Stats
+	var v *container.Stats
 	err = json.NewDecoder(body).Decode(&v)
 	assert.NilError(c, err)
 	body.Close()
@@ -173,8 +173,8 @@ func (s *DockerAPISuite) TestAPIStatsNetworkStatsVersioning(c *testing.T) {
 	assert.Assert(c, jsonBlobHasGTE121NetworkStats(statsJSONBlob), "Stats JSON blob from API does not look like a >=v1.21 API stats structure", statsJSONBlob)
 }
 
-func getNetworkStats(c *testing.T, id string) map[string]types.NetworkStats {
-	var st *types.StatsJSON
+func getNetworkStats(c *testing.T, id string) map[string]container.NetworkStats {
+	var st *container.StatsResponse
 
 	_, body, err := request.Get(testutil.GetContext(c), "/containers/"+id+"/stats?stream=false")
 	assert.NilError(c, err)
@@ -263,7 +263,7 @@ func (s *DockerAPISuite) TestAPIStatsNoStreamConnectedContainers(c *testing.T) {
 		if resp.Header.Get("Content-Type") != "application/json" {
 			ch <- fmt.Errorf("Invalid 'Content-Type' %v", resp.Header.Get("Content-Type"))
 		}
-		var v *types.Stats
+		var v *container.Stats
 		if err := json.NewDecoder(body).Decode(&v); err != nil {
 			ch <- err
 		}

--- a/integration-cli/docker_cli_update_unix_test.go
+++ b/integration-cli/docker_cli_update_unix_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/creack/pty"
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/testutil"
@@ -185,7 +185,7 @@ func (s *DockerCLIUpdateSuite) TestUpdateStats(c *testing.T) {
 		assert.NilError(c, err)
 		assert.Equal(c, resp.Header.Get("Content-Type"), "application/json")
 
-		var v *types.Stats
+		var v *container.Stats
 		err = json.NewDecoder(body).Decode(&v)
 		assert.NilError(c, err)
 		body.Close()

--- a/integration/container/stats_test.go
+++ b/integration/container/stats_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/integration/internal/container"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -28,11 +28,11 @@ func TestStats(t *testing.T) {
 	assert.NilError(t, err)
 	defer resp.Body.Close()
 
-	var v types.Stats
+	var v containertypes.Stats
 	err = json.NewDecoder(resp.Body).Decode(&v)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(int64(v.MemoryStats.Limit), info.MemTotal))
-	assert.Check(t, !reflect.DeepEqual(v.PreCPUStats, types.CPUStats{}))
+	assert.Check(t, !reflect.DeepEqual(v.PreCPUStats, containertypes.CPUStats{}))
 	err = json.NewDecoder(resp.Body).Decode(&v)
 	assert.Assert(t, is.ErrorContains(err, ""), io.EOF)
 
@@ -40,11 +40,11 @@ func TestStats(t *testing.T) {
 	assert.NilError(t, err)
 	defer resp.Body.Close()
 
-	v = types.Stats{}
+	v = containertypes.Stats{}
 	err = json.NewDecoder(resp.Body).Decode(&v)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(int64(v.MemoryStats.Limit), info.MemTotal))
-	assert.Check(t, is.DeepEqual(v.PreCPUStats, types.CPUStats{}))
+	assert.Check(t, is.DeepEqual(v.PreCPUStats, containertypes.CPUStats{}))
 	err = json.NewDecoder(resp.Body).Decode(&v)
 	assert.Assert(t, is.ErrorContains(err, ""), io.EOF)
 }


### PR DESCRIPTION
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
api/types: move `BlkioStatEntry`, `BlkioStats`, `CPUStats`, `CPUUsage`, `MemoryStats`,
`NetworkStats`, `PidsStats`, `Stats`, `StatsJSON`, `StorageStats`, `ThrottlingData`
to api/types/container package.
```

**- A picture of a cute animal (not mandatory but encouraged)**

