### PR TITLE
api/types: rename container.StatsResponse to StatsResponseReader

### DIFF
--- a/api/types/container/container.go
+++ b/api/types/container/container.go
@@ -31,9 +31,14 @@ type CopyToContainerOptions struct {
 	CopyUIDGID                bool
 }
 
-// StatsResponse contains response of Engine API:
-// GET "/stats"
-type StatsResponse struct {
+// StatsResponseReader wraps an io.ReadCloser to read (a stream of) stats
+// for a container, as produced by the GET "/stats" endpoint.
+//
+// The OSType field is set to the server's platform to allow
+// platform-specific handling of the response.
+//
+// TODO(thaJeztah): remove this wrapper, and make OSType part of [StatsJSON].
+type StatsResponseReader struct {
 	Body   io.ReadCloser `json:"body"`
 	OSType string        `json:"ostype"`
 }

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -111,8 +111,8 @@ type CopyToContainerOptions = container.CopyToContainerOptions
 // ContainerStats contains response of Engine API:
 // GET "/stats"
 //
-// Deprecated: use [container.StatsResponse].
-type ContainerStats = container.StatsResponse
+// Deprecated: use [container.StatsResponseReader].
+type ContainerStats = container.StatsResponseReader
 
 // EventsOptions holds parameters to filter events with.
 //

--- a/client/container_stats.go
+++ b/client/container_stats.go
@@ -9,7 +9,7 @@ import (
 
 // ContainerStats returns near realtime stats for a given container.
 // It's up to the caller to close the io.ReadCloser returned.
-func (cli *Client) ContainerStats(ctx context.Context, containerID string, stream bool) (container.StatsResponse, error) {
+func (cli *Client) ContainerStats(ctx context.Context, containerID string, stream bool) (container.StatsResponseReader, error) {
 	query := url.Values{}
 	query.Set("stream", "0")
 	if stream {
@@ -18,10 +18,10 @@ func (cli *Client) ContainerStats(ctx context.Context, containerID string, strea
 
 	resp, err := cli.get(ctx, "/containers/"+containerID+"/stats", query, nil)
 	if err != nil {
-		return container.StatsResponse{}, err
+		return container.StatsResponseReader{}, err
 	}
 
-	return container.StatsResponse{
+	return container.StatsResponseReader{
 		Body:   resp.body,
 		OSType: getDockerOS(resp.header.Get("Server")),
 	}, nil
@@ -29,17 +29,17 @@ func (cli *Client) ContainerStats(ctx context.Context, containerID string, strea
 
 // ContainerStatsOneShot gets a single stat entry from a container.
 // It differs from `ContainerStats` in that the API should not wait to prime the stats
-func (cli *Client) ContainerStatsOneShot(ctx context.Context, containerID string) (container.StatsResponse, error) {
+func (cli *Client) ContainerStatsOneShot(ctx context.Context, containerID string) (container.StatsResponseReader, error) {
 	query := url.Values{}
 	query.Set("stream", "0")
 	query.Set("one-shot", "1")
 
 	resp, err := cli.get(ctx, "/containers/"+containerID+"/stats", query, nil)
 	if err != nil {
-		return container.StatsResponse{}, err
+		return container.StatsResponseReader{}, err
 	}
 
-	return container.StatsResponse{
+	return container.StatsResponseReader{
 		Body:   resp.body,
 		OSType: getDockerOS(resp.header.Get("Server")),
 	}, nil

--- a/client/interface.go
+++ b/client/interface.go
@@ -67,8 +67,8 @@ type ContainerAPIClient interface {
 	ContainerResize(ctx context.Context, container string, options container.ResizeOptions) error
 	ContainerRestart(ctx context.Context, container string, options container.StopOptions) error
 	ContainerStatPath(ctx context.Context, container, path string) (container.PathStat, error)
-	ContainerStats(ctx context.Context, container string, stream bool) (container.StatsResponse, error)
-	ContainerStatsOneShot(ctx context.Context, container string) (container.StatsResponse, error)
+	ContainerStats(ctx context.Context, container string, stream bool) (container.StatsResponseReader, error)
+	ContainerStatsOneShot(ctx context.Context, container string) (container.StatsResponseReader, error)
 	ContainerStart(ctx context.Context, container string, options container.StartOptions) error
 	ContainerStop(ctx context.Context, container string, options container.StopOptions) error
 	ContainerTop(ctx context.Context, container string, arguments []string) (container.ContainerTopOKBody, error)

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -151,7 +151,7 @@ func (s *DockerAPISuite) TestGetContainerStats(c *testing.T) {
 	runSleepingContainer(c, "--name", name)
 
 	type b struct {
-		stats container.StatsResponse
+		stats container.StatsResponseReader
 		err   error
 	}
 
@@ -255,7 +255,7 @@ func (s *DockerAPISuite) TestGetContainerStatsStream(c *testing.T) {
 	runSleepingContainer(c, "--name", name)
 
 	type b struct {
-		stats container.StatsResponse
+		stats container.StatsResponseReader
 		err   error
 	}
 
@@ -296,7 +296,7 @@ func (s *DockerAPISuite) TestGetContainerStatsNoStream(c *testing.T) {
 	runSleepingContainer(c, "--name", name)
 
 	type b struct {
-		stats container.StatsResponse
+		stats container.StatsResponseReader
 		err   error
 	}
 
@@ -1419,7 +1419,7 @@ func (s *DockerAPISuite) TestContainerAPIStatsWithNetworkDisabled(c *testing.T) 
 	cli.WaitRun(c, name)
 
 	type b struct {
-		stats container.StatsResponse
+		stats container.StatsResponseReader
 		err   error
 	}
 	bc := make(chan b, 1)


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/47936
- relates to https://github.com/moby/moby/pull/48040

### api/types: move stats-types to api/types/container

commit 17c3269a370331d32d153d67975501caf6f0f29b moved the ContainerStats type to the container package, and renamed it to StatsResponse. However, this name is chosen poorly, as it documents it to be the response of the API endpoint, but is more accurately a wrapper around a reader, used to read a (stream of) StatsJSON. We want to change StatsJSON to StatsResponse, as it's more consistent with other response types.

As 17c3269a370331d32d153d67975501caf6f0f29b did not make it into a non-pre-release, we can still change this.

```markdown changelog
api/types: rename container.StatsResponse to StatsResponseReader
```

**- A picture of a cute animal (not mandatory but encouraged)**

