### PR TITLE
api: swagger: fix definition of TmpFsOptions (API v1.46)

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -449,15 +449,12 @@ definitions:
               should be provided as as 2-length arrays, where the first item is
               the key and the second the value.
             type: "array"
-            properties:
+            items:
+              type: "array"
+              minItems: 1
+              maxItems: 2
               items:
-                type: "array"
-                items:
-                  type: "array"
-                  minItems: 1
-                  maxItems: 2
-                  items:
-                    type: "string"
+                type: "string"
             example:
               [["noexec"]]
 

--- a/docs/api/v1.46.yaml
+++ b/docs/api/v1.46.yaml
@@ -449,15 +449,12 @@ definitions:
               should be provided as as 2-length arrays, where the first item is
               the key and the second the value.
             type: "array"
-            properties:
+            items:
+              type: "array"
+              minItems: 1
+              maxItems: 2
               items:
-                type: "array"
-                items:
-                  type: "array"
-                  minItems: 1
-                  maxItems: 2
-                  items:
-                    type: "string"
+                type: "string"
             example:
               [["noexec"]]
 


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/48048

Since it's a [][]string, there should only be two levels of array in the OpenAPI spec. Also, the outermost level array shouldn't have properties: (it should have items: instead).

**- A picture of a cute animal (not mandatory but encouraged)**

