### PR TITLE
deprecate experimental Graphdriver plugins, and disable by default

### DIFF
--- a/daemon/graphdriver/plugin.go
+++ b/daemon/graphdriver/plugin.go
@@ -2,6 +2,7 @@ package graphdriver // import "github.com/docker/docker/daemon/graphdriver"
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/docker/docker/errdefs"
@@ -12,6 +13,9 @@ import (
 )
 
 func lookupPlugin(name string, pg plugingetter.PluginGetter, config Options) (Driver, error) {
+	if os.Getenv("DOCKERD_DEPRECATED_GRAPHDRIVER_PLUGINS") == "" {
+		return nil, fmt.Errorf("DEPRECATED: Experimental graphdriver plugins are deprecated, and disabled by default. This feature will be removed in the next release. See https://docs.docker.com/go/deprecated/")
+	}
 	if !config.ExperimentalEnabled {
 		return nil, fmt.Errorf("graphdriver plugins are only supported with experimental mode")
 	}

--- a/integration/plugin/graphdriver/external_test.go
+++ b/integration/plugin/graphdriver/external_test.go
@@ -60,7 +60,7 @@ func TestExternalGraphDriver(t *testing.T) {
 	sserver := setupPluginViaSpecFile(t, ec)
 	jserver := setupPluginViaJSONFile(t, ec)
 	// Create daemon
-	d := daemon.New(t, daemon.WithExperimental())
+	d := daemon.New(t, daemon.WithExperimental(), daemon.WithEnvVars("DOCKERD_DEPRECATED_GRAPHDRIVER_PLUGINS=1"))
 	c := d.NewClientT(t)
 
 	for _, tc := range []struct {
@@ -418,16 +418,16 @@ func TestGraphdriverPluginV2(t *testing.T) {
 
 	ctx := testutil.StartSpan(baseContext, t)
 
-	d := daemon.New(t, daemon.WithExperimental())
+	d := daemon.New(t, daemon.WithExperimental(), daemon.WithEnvVars("DOCKERD_DEPRECATED_GRAPHDRIVER_PLUGINS=1"))
 	d.Start(t)
 	defer d.Stop(t)
 
-	client := d.NewClientT(t)
-	defer client.Close()
+	apiClient := d.NewClientT(t)
+	defer apiClient.Close()
 
 	// install the plugin
 	plugin := "cpuguy83/docker-overlay2-graphdriver-plugin"
-	responseReader, err := client.PluginInstall(ctx, plugin, types.PluginInstallOptions{
+	responseReader, err := apiClient.PluginInstall(ctx, plugin, types.PluginInstallOptions{
 		RemoteRef:            plugin,
 		AcceptAllPermissions: true,
 	})
@@ -441,7 +441,7 @@ func TestGraphdriverPluginV2(t *testing.T) {
 	d.Stop(t)
 	d.StartWithBusybox(ctx, t, "-s", plugin)
 
-	testGraphDriver(ctx, t, client, plugin, nil)
+	testGraphDriver(ctx, t, apiClient, plugin, nil)
 }
 
 func testGraphDriver(ctx context.Context, t *testing.T, c client.APIClient, driverName string, afterContainerRunFn func(*testing.T)) {


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/5172


Graphdriver plugins] are an experimental feature that allow extending the Docker Engine with custom storage drivers for storing images and containers. This feature was not maintained since its inception, and will no longer be supported in upcoming releases.

Users of this feature are recommended to instead configure the Docker Engine to use the [containerd image store], and a custom [snapshotter].

This patch:

- Disables loading graphdriver plugins by default, producing an error instead.
- Introduces a temporary `DOCKERD_DEPRECATED_GRAPHDRIVER_PLUGINS` environment variable to re-enable the deprecated features; this allows users to still use the feature on a v27.0 daemon, but disabling it by default will give a strong message that it will no longer be supported.

[Graphdriver plugins]: https://github.com/docker/cli/blob/v26.1.4/docs/extend/plugins_graphdriver.md
[containerd image store]: https://docs.docker.com/storage/containerd/
[snapshotter]: https://github.com/containerd/containerd/tree/v1.7.18/docs/snapshotters

Before this patch (ignore the "Unable to load plugin" errors, as there's no plugin);

    dockerd --experimental -s my-driver
    ...
    INFO[2024-06-21T10:42:49.574901255Z] containerd successfully booted in 0.011384s
    INFO[2024-06-21T10:42:50.575891922Z] [graphdriver] trying configured driver: my-driver
    WARN[2024-06-21T10:42:50.576121547Z] Unable to locate plugin: my-driver, retrying in 1s
    WARN[2024-06-21T10:42:51.577131506Z] Unable to locate plugin: my-driver, retrying in 2s
    WARN[2024-06-21T10:42:53.582637715Z] Unable to locate plugin: my-driver, retrying in 4s

With this patch:

    dockerd --experimental -s my-driver
    ...
    INFO[2024-06-21T10:32:35.123078845Z] [graphdriver] trying configured driver: my-driver
    ERRO[2024-06-21T10:32:35.123127012Z] Failed to GetDriver graph                     driver=my-driver error="DEPRECATED: Experimental graphdriver plugins are deprecated, and disabled by default. This feature will be removed in the next release. See https://docs.docker.com/go/deprecated/" home-dir=/var/lib/docker
    INFO[2024-06-21T10:32:35.124735595Z] stopping healthcheck following graceful shutdown  module=libcontainerd
    INFO[2024-06-21T10:32:35.124743137Z] stopping event stream following graceful shutdown  error="context canceled" module=libcontainerd namespace=plugins.moby
    failed to start daemon: error initializing graphdriver: driver not supported: my-driver

With the `DOCKERD_DEPRECATED_GRAPHDRIVER_PLUGINS` env-var set:

    DOCKERD_DEPRECATED_GRAPHDRIVER_PLUGINS=1 dockerd --experimental -s my-driver
    ...
    INFO[2024-06-21T10:35:04.149901970Z] containerd successfully booted in 0.013614s
    INFO[2024-06-21T10:35:05.148195845Z] [graphdriver] trying configured driver: my-driver
    WARN[2024-06-21T10:35:05.150647679Z] Unable to locate plugin: my-driver, retrying in 1s
    WARN[2024-06-21T10:35:06.152531221Z] Unable to locate plugin: my-driver, retrying in 2s
    WARN[2024-06-21T10:35:08.158452389Z] Unable to locate plugin: my-driver, retrying in 4s
    WARN[2024-06-21T10:35:12.163699293Z] Unable to locate plugin: my-driver, retrying in 8s

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
deprecate experimental Graphdriver plugins, and disable by default
```

**- A picture of a cute animal (not mandatory but encouraged)**

