### PR TITLE
Do not allow the daemon to start when MaxDownloadAttempts <=0 fixes regression #44921

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -601,7 +601,7 @@ func loadDaemonCliConfig(opts *daemonOptions) (*config.Config, error) {
 		return nil, err
 	}
 
-	if err := config.Validate(conf); err != nil {
+	if err := config.Validate(conf, nil, "", false); err != nil {
 		return nil, err
 	}
 

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -304,18 +304,18 @@ func TestValidateConfigurationErrors(t *testing.T) {
 			expectedErr: "invalid max download attempts: -10",
 		},
 		// TODO(thaJeztah) temporarily excluding this test as it assumes defaults are set before validating and applying updated configs
-		/*
-			{
-				name:  "zero max-download-attempts",
-				field: "MaxDownloadAttempts",
-				config: &Config{
-					CommonConfig: CommonConfig{
-						MaxDownloadAttempts: 0,
-					},
+
+		{
+			name:  "zero max-download-attempts",
+			field: "MaxDownloadAttempts",
+			config: &Config{
+				CommonConfig: CommonConfig{
+					MaxDownloadAttempts: 0,
 				},
-				expectedErr: "invalid max download attempts: 0",
 			},
-		*/
+			expectedErr: "invalid max download attempts: 0",
+		},
+
 		{
 			name: "generic resource without =",
 			config: &Config{
@@ -362,7 +362,7 @@ func TestValidateConfigurationErrors(t *testing.T) {
 			} else {
 				assert.Check(t, mergo.Merge(cfg, tc.config, mergo.WithOverride))
 			}
-			err = Validate(cfg)
+			err = Validate(cfg, nil, "", false)
 			assert.Error(t, err, tc.expectedErr)
 		})
 	}
@@ -498,7 +498,7 @@ func TestValidateConfiguration(t *testing.T) {
 
 			// Check that the override happened :)
 			assert.Check(t, is.DeepEqual(cfg, tc.config, field(tc.field)))
-			err = Validate(cfg)
+			err = Validate(cfg, nil, "", false)
 			assert.NilError(t, err)
 		})
 	}


### PR DESCRIPTION
**- What I did**

Fixed regression that allows the daemon to be started with max-download-attempts=0

**- How I did it**
Modified the config.go

**- How to verify it**
Start a moby container 
`make BIND_DIR=. shell`

**Start the daemon with --max-download-attempts=0**
```
./hack/make.sh binary
make install
/usr/local/bin/dockerd --max-download-attempts=0
```
<img width="1346" alt="Screenshot 2024-06-25 at 11 14 03 AM" src="https://github.com/moby/moby/assets/347096/ff00f957-5bc9-4f29-a633-6eef4a644ae8">

```
mv /etc/docker/daemon.json /etc/docker/daemon.json.bak
/usr/local/bin/dockerd --max-download-attempts=0
```

**Move the daemon.json file temporarily start the daemon again with --max-download-attempts=0**
<img width="1347" alt="Screenshot 2024-06-25 at 11 17 13 AM" src="https://github.com/moby/moby/assets/347096/7c26b38e-641f-4a77-873d-92acc38db9fd">


**- Description for the changelog**

```
Do not allow the daemon to start when MaxDownloadAttempts <=0 fixes regression #44921
```


