### PR TITLE
[27.0 backport] update golangci-lint to v1.59.1 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -229,7 +229,7 @@ FROM binary-dummy AS containerd-windows
 FROM containerd-${TARGETOS} AS containerd
 
 FROM base AS golangci_lint
-ARG GOLANGCI_LINT_VERSION=v1.55.2
+ARG GOLANGCI_LINT_VERSION=v1.59.1
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
         GOBIN=/build/ GO111MODULE=on go install "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}" \

--- a/builder/remotecontext/remote.go
+++ b/builder/remotecontext/remote.go
@@ -44,8 +44,8 @@ func downloadRemote(remoteURL string) (string, io.ReadCloser, error) {
 // GetWithStatusError does an http.Get() and returns an error if the
 // status code is 4xx or 5xx.
 func GetWithStatusError(address string) (resp *http.Response, err error) {
-	// #nosec G107
-	if resp, err = http.Get(address); err != nil {
+	resp, err = http.Get(address) // #nosec G107 -- ignore G107: Potential HTTP request made with variable url
+	if err != nil {
 		if uerr, ok := err.(*url.Error); ok {
 			if derr, ok := uerr.Err.(*net.DNSError); ok && !derr.IsTimeout {
 				return nil, errdefs.NotFound(err)

--- a/pkg/archive/archive_linux.go
+++ b/pkg/archive/archive_linux.go
@@ -54,7 +54,7 @@ func (overlayWhiteoutConverter) ConvertWrite(hdr *tar.Header, path string, fi os
 			wo = &tar.Header{
 				Typeflag:   tar.TypeReg,
 				Mode:       hdr.Mode & int64(os.ModePerm),
-				Name:       filepath.Join(hdr.Name, WhiteoutOpaqueDir),
+				Name:       filepath.Join(hdr.Name, WhiteoutOpaqueDir), // #nosec G305 -- An archive is being created, not extracted.
 				Size:       0,
 				Uid:        hdr.Uid,
 				Uname:      hdr.Uname,
@@ -62,7 +62,7 @@ func (overlayWhiteoutConverter) ConvertWrite(hdr *tar.Header, path string, fi os
 				Gname:      hdr.Gname,
 				AccessTime: hdr.AccessTime,
 				ChangeTime: hdr.ChangeTime,
-			} // #nosec G305 -- An archive is being created, not extracted.
+			}
 		}
 	}
 


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/48058

### builder/remotecontext: reformat code to make #nosec comment work again

Looks like the way it picks up #nosec comments changed, causing the
linter error to re-appear;

    builder/remotecontext/remote.go:48:17: G107: Potential HTTP request made with variable url (gosec)
        if resp, err = http.Get(address); err != nil {
                       ^

### pkg/archive: reformat code to make #nosec comment work again

Looks like the way it picks up #nosec comments changed, causing the
linter error to re-appear;

    pkg/archive/archive_linux.go:57:17: G305: File traversal when extracting zip/tar archive (gosec)
                    Name:       filepath.Join(hdr.Name, WhiteoutOpaqueDir),
                                ^

### update golangci-lint to v1.59.1

full diff: https://github.com/golangci/golangci-lint/compare/v1.55.2...v1.59.1


