### PR TITLE
builder/builder-next: applySourcePolicies: remove redundant check and vars

### DIFF
--- a/builder/builder-next/adapters/containerimage/pull.go
+++ b/builder/builder-next/adapters/containerimage/pull.go
@@ -953,15 +953,11 @@ func applySourcePolicies(ctx context.Context, str string, spls []*spb.Policy) (s
 	}
 
 	if mut {
-		var (
-			t  string
-			ok bool
-		)
 		t, newRef, ok := strings.Cut(op.GetIdentifier(), "://")
 		if !ok {
 			return "", errors.Errorf("could not parse ref: %s", op.GetIdentifier())
 		}
-		if ok && t != srctypes.DockerImageScheme {
+		if t != srctypes.DockerImageScheme {
 			return "", &imageutil.ResolveToNonImageError{Ref: str, Updated: newRef}
 		}
 		ref, err = cdreference.Parse(newRef)


### PR DESCRIPTION
- the check for `ok` was redundant as the line above it would return early
- the `t` and `ok` variable declaration was redundant, as all variables to the left of the `strings.Cut` were locally scoped variables.


**- A picture of a cute animal (not mandatory but encouraged)**

