### PR TITLE
c8d/prune: Keep the last tagged image instead of creating dangling image

### DIFF
--- a/daemon/containerd/image_prune.go
+++ b/daemon/containerd/image_prune.go
@@ -10,6 +10,7 @@ import (
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
 	"github.com/hashicorp/go-multierror"
 	"github.com/opencontainers/go-digest"
@@ -60,9 +61,20 @@ func (i *ImageService) ImagesPrune(ctx context.Context, fltrs filters.Args) (*im
 	return i.pruneUnused(ctx, filterFunc, danglingOnly)
 }
 
+// pruneUnused deletes images that are dangling or unused by any container.
+// The behavior is controlled by the danglingOnly parameter.
+// If danglingOnly is true, only dangling images are deleted.
+// Otherwise, all images unused by any container are deleted.
+//
+// Additionally, the filterFunc parameter is used to filter images that should
+// be considered for deletion.
+//
+// Container created with images specified by an ID only (e.g. `docker run 82d1e9d`)
+// will keep at least one image tag with that ID.
+//
+// In case a digested and tagged reference was used (e.g. `docker run alpine:latest@sha256:82d1e9d7ed48a7523bdebc18cf6290bdb97b82302a8a9c27d4fe885949ea94d1`),
+// the alpine:latest image will be kept.
 func (i *ImageService) pruneUnused(ctx context.Context, filterFunc imageFilterFunc, danglingOnly bool) (*image.PruneReport, error) {
-	report := image.PruneReport{}
-
 	allImages, err := i.images.List(ctx)
 	if err != nil {
 		return nil, err
@@ -85,16 +97,40 @@ func (i *ImageService) pruneUnused(ctx context.Context, filterFunc imageFilterFu
 			if canBePruned {
 				imagesToPrune[img.Name] = img
 			}
-
 		}
 	}
 
+	usedDigests := filterImagesUsedByContainers(ctx, i.containers.List(), imagesToPrune)
+
+	// Make sure we don't delete the last image of a particular digest used by any container.
+	for name, img := range imagesToPrune {
+		dgst := img.Target.Digest
+
+		if digestRefCount[dgst] > 1 {
+			digestRefCount[dgst] -= 1
+			continue
+		}
+
+		if _, isUsed := usedDigests[dgst]; isUsed {
+			delete(imagesToPrune, name)
+		}
+	}
+
+	return i.pruneAll(ctx, imagesToPrune)
+}
+
+// filterImagesUsedByContainers removes image names that are used by containers
+// and returns a map of used image digests.
+func filterImagesUsedByContainers(ctx context.Context,
+	allContainers []*container.Container,
+	imagesToPrune map[string]containerdimages.Image,
+) (usedDigests map[digest.Digest]struct{}) {
 	// Image specified by digests that are used by containers.
-	usedDigests := map[digest.Digest]struct{}{}
+	usedDigests = map[digest.Digest]struct{}{}
 
 	// Exclude images used by existing containers
-	for _, ctr := range i.containers.List() {
-		// If the original image was deleted, make sure we don't delete the dangling image
+	for _, ctr := range allContainers {
+		// If the original image was force deleted, make sure we don't delete the dangling image
 		delete(imagesToPrune, danglingImageName(ctr.ImageID.Digest()))
 
 		// Config.Image is the image reference passed by user.
@@ -105,40 +141,43 @@ func (i *ImageService) pruneUnused(ctx context.Context, filterFunc imageFilterFu
 		// but both will have ImageID="sha256:82d1e9d7ed48a7523bdebc18cf6290bdb97b82302a8a9c27d4fe885949ea94d1"
 		imageDgst := ctr.ImageID.Digest()
 
-		// If user didn't specify an explicit image, mark the digest as used.
+		// If user used an full or truncated ID instead of an explicit image name, mark the digest as used.
 		normalizedImageID := "sha256:" + strings.TrimPrefix(ctr.Config.Image, "sha256:")
-		if strings.HasPrefix(imageDgst.String(), normalizedImageID) {
+		fullOrTruncatedID := strings.HasPrefix(imageDgst.String(), normalizedImageID)
+		digestedRef := strings.HasSuffix(ctr.Config.Image, "@"+imageDgst.String())
+		if fullOrTruncatedID || digestedRef {
 			usedDigests[imageDgst] = struct{}{}
-			continue
 		}
 
 		ref, err := reference.ParseNormalizedNamed(ctr.Config.Image)
 		log.G(ctx).WithFields(log.Fields{
 			"ctr":          ctr.ID,
-			"image":        ref,
+			"imageRef":     ref,
+			"imageID":      imageDgst,
 			"nameParseErr": err,
 		}).Debug("filtering container's image")
-
 		if err == nil {
 			// If user provided a specific image name, exclude that image.
 			name := reference.TagNameOnly(ref)
 			delete(imagesToPrune, name.String())
-		}
-	}
 
-	// Create dangling images for images that will be deleted but are still in use.
-	for _, img := range imagesToPrune {
-		dgst := img.Target.Digest
-
-		digestRefCount[dgst] -= 1
-		if digestRefCount[dgst] == 0 {
-			if _, isUsed := usedDigests[dgst]; isUsed {
-				if err := i.ensureDanglingImage(ctx, img); err != nil {
-					return &report, errors.Wrapf(err, "failed to create ensure dangling image for %s", img.Name)
-				}
+			// Also exclude repo:tag image if repo:tag@sha256:digest reference was used.
+			_, isDigested := name.(reference.Digested)
+			tagged, isTagged := name.(reference.NamedTagged)
+			if isDigested && isTagged {
+				named, _ := reference.ParseNormalizedNamed(tagged.Name())
+				namedTagged, _ := reference.WithTag(named, tagged.Tag())
+				delete(imagesToPrune, namedTagged.String())
 			}
 		}
 	}
+
+	return usedDigests
+}
+
+// pruneAll deletes all images in the imagesToPrune map.
+func (i *ImageService) pruneAll(ctx context.Context, imagesToPrune map[string]containerdimages.Image) (*image.PruneReport, error) {
+	report := image.PruneReport{}
 
 	possiblyDeletedConfigs := map[digest.Digest]struct{}{}
 	var errs error

--- a/integration/image/prune_test.go
+++ b/integration/image/prune_test.go
@@ -4,11 +4,16 @@ import (
 	"strings"
 	"testing"
 
+	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/internal/testutils/specialimage"
+	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
 )
 
@@ -46,4 +51,133 @@ func TestPruneDontDeleteUsedDangling(t *testing.T) {
 
 	_, _, err = client.ImageInspectWithRaw(ctx, danglingID)
 	assert.NilError(t, err, "Test dangling image should still exist")
+}
+
+// Regression test for https://github.com/moby/moby/issues/48063
+func TestPruneDontDeleteUsedImage(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "cannot start multiple daemons on windows")
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+
+	ctx := setupTest(t)
+
+	for _, env := range []struct {
+		name    string
+		prepare func(t *testing.T, client *daemon.Daemon, apiClient *client.Client) error
+		check   func(t *testing.T, apiClient *client.Client, pruned image.PruneReport)
+	}{
+		{
+			// Container uses the busybox:latest image and it's the only image
+			// tag with the same target.
+			name: "single tag",
+			check: func(t *testing.T, apiClient *client.Client, pruned image.PruneReport) {
+				assert.Check(t, is.Len(pruned.ImagesDeleted, 0))
+
+				_, _, err := apiClient.ImageInspectWithRaw(ctx, "busybox:latest")
+				assert.NilError(t, err, "Busybox image should still exist")
+			},
+		},
+		{
+			// Container uses the busybox:latest image and there's also a second
+			// busybox:other tag pointing to the same image.
+			name: "two tags",
+			prepare: func(t *testing.T, d *daemon.Daemon, apiClient *client.Client) error {
+				return apiClient.ImageTag(ctx, "busybox:latest", "busybox:other")
+			},
+			check: func(t *testing.T, apiClient *client.Client, pruned image.PruneReport) {
+				if assert.Check(t, is.Len(pruned.ImagesDeleted, 1)) {
+					assert.Check(t, is.Equal(pruned.ImagesDeleted[0].Deleted, ""))
+					t.Log("Untagged", pruned.ImagesDeleted[0].Untagged)
+				}
+
+				_, _, err1 := apiClient.ImageInspectWithRaw(ctx, "busybox:latest")
+				_, _, err2 := apiClient.ImageInspectWithRaw(ctx, "busybox:other")
+
+				assert.Check(t, err1 != err2 && (err1 == nil || err2 == nil), "One of the images should still exist")
+			},
+		},
+	} {
+		for _, tc := range []struct {
+			name    string
+			imageID func(t *testing.T, inspect image.InspectResponse) string
+		}{
+			{
+				name: "full id",
+				imageID: func(t *testing.T, inspect image.InspectResponse) string {
+					return inspect.ID
+				},
+			},
+			{
+				name: "full id without sha256 prefix",
+				imageID: func(t *testing.T, inspect image.InspectResponse) string {
+					return strings.TrimPrefix(inspect.ID, "sha256:")
+				},
+			},
+			{
+				name: "truncated id (without sha256 prefix)",
+				imageID: func(t *testing.T, inspect image.InspectResponse) string {
+					return strings.TrimPrefix(inspect.ID, "sha256:")[:8]
+				},
+			},
+			{
+				name: "repo and digest without tag",
+				imageID: func(t *testing.T, inspect image.InspectResponse) string {
+					skip.If(t, !testEnv.UsingSnapshotter())
+
+					return "busybox@" + inspect.ID
+				},
+			},
+			{
+				name: "tagged and digested",
+				imageID: func(t *testing.T, inspect image.InspectResponse) string {
+					skip.If(t, !testEnv.UsingSnapshotter())
+
+					return "busybox:latest@" + inspect.ID
+				},
+			},
+			{
+				name: "repo digest",
+				imageID: func(t *testing.T, inspect image.InspectResponse) string {
+					// graphdriver won't have a repo digest
+					skip.If(t, len(inspect.RepoDigests) == 0, "no repo digest")
+
+					return inspect.RepoDigests[0]
+				},
+			},
+		} {
+			tc := tc
+			t.Run(env.name+"/"+tc.name, func(t *testing.T) {
+				ctx := testutil.StartSpan(ctx, t)
+				d := daemon.New(t)
+				d.Start(t)
+				defer d.Stop(t)
+
+				apiClient := d.NewClientT(t)
+				defer apiClient.Close()
+
+				d.LoadBusybox(ctx, t)
+
+				if env.prepare != nil {
+					err := env.prepare(t, d, apiClient)
+					assert.NilError(t, err, "prepare failed")
+				}
+
+				inspect, _, err := apiClient.ImageInspectWithRaw(ctx, "busybox:latest")
+				assert.NilError(t, err)
+
+				image := tc.imageID(t, inspect)
+				t.Log(image)
+
+				cid := container.Run(ctx, t, apiClient,
+					container.WithImage(image),
+					container.WithCmd("sleep", "60"))
+				defer container.Remove(ctx, t, apiClient, cid, containertypes.RemoveOptions{Force: true})
+
+				// dangling=false also prunes unused images
+				pruned, err := apiClient.ImagesPrune(ctx, filters.NewArgs(filters.Arg("dangling", "false")))
+				assert.NilError(t, err)
+
+				env.check(t, apiClient, pruned)
+			})
+		}
+	}
 }


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/48063

Don't turn images into dangling when they are used by containers created with an image specified by an ID only (e.g. `docker run 82d1e9d`).

Keep the last image reference with the same target when all other references would be pruned.

If the container was created with a digested and tagged reference (e.g. `docker run alpine:latest@sha256:82d1e9d7ed48a7523bdebc18cf6290bdb97b82302a8a9c27d4fe885949ea94d1`), the `alpine:latest` image won't get untagged.

This change makes the behavior consistent with the graphdriver implementation.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
TestPruneDontDeleteUsedImage

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
containerd integration: Fix `docker image prune -a` untagging images used by containers started from images referenced by a digested reference.
```

**- A picture of a cute animal (not mandatory but encouraged)**

