### PR TITLE
daemon/graphdriver: deprecate GetDriver(), and remove its use

### DIFF
--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -158,7 +158,7 @@ func Register(name string, initFunc InitFunc) error {
 
 // GetDriver initializes and returns the registered driver.
 //
-// It is exported for use in (integration-)tests, but should be considered internal.
+// Deprecated: this function was exported for (integration-)tests, but no longer used, and will be removed in the next release.
 func GetDriver(name string, config Options) (Driver, error) {
 	return getDriver(name, config)
 }

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -187,6 +187,16 @@ type Options struct {
 }
 
 // New creates the driver and initializes it at the specified root.
+//
+// It is recommended to pass a name for the driver to use, but If no name
+// is provided, it attempts to detect the prior storage driver based on
+// existing state, or otherwise selects a storage driver based on a priority
+// list and the underlying filesystem.
+//
+// It returns an error if the requested storage driver is not supported,
+// if scanning prior drivers is ambiguous (i.e., if state is found for
+// multiple drivers), or if no compatible driver is available for the
+// platform and underlying filesystem.
 func New(name string, config Options) (Driver, error) {
 	ctx := context.TODO()
 	if name != "" {
@@ -198,6 +208,8 @@ func New(name string, config Options) (Driver, error) {
 	}
 
 	// Guess for prior driver
+	//
+	// TODO(thaJeztah): move detecting prior drivers separate from New(), and make "name" a required argument.
 	driversMap := scanPriorDrivers(config.Root)
 	priorityList := strings.Split(priority, ",")
 	log.G(ctx).Debugf("[graphdriver] priority list: %v", priorityList)

--- a/daemon/graphdriver/graphtest/graphtest_unix.go
+++ b/daemon/graphdriver/graphtest/graphtest_unix.go
@@ -30,11 +30,16 @@ type Driver struct {
 }
 
 func newDriver(t testing.TB, name string, options []string) *Driver {
+	if name == "" {
+		// Prevent graphdriver.New() from auto-detecting / picking a storage driver.
+		t.Fatal("newDriver requires a name for the storage driver to use")
+	}
+
 	root, err := os.MkdirTemp("", "docker-graphtest-")
 	assert.NilError(t, err)
 
 	assert.NilError(t, os.MkdirAll(root, 0o755))
-	d, err := graphdriver.GetDriver(name, graphdriver.Options{DriverOptions: options, Root: root})
+	d, err := graphdriver.New(name, graphdriver.Options{DriverOptions: options, Root: root})
 	if err != nil {
 		t.Logf("graphdriver: %v\n", err)
 		if graphdriver.IsDriverNotSupported(err) {

--- a/daemon/graphdriver/vfs/vfs_test.go
+++ b/daemon/graphdriver/vfs/vfs_test.go
@@ -92,7 +92,7 @@ func TestXattrUnsupportedByBackingFS(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			subdir := filepath.Join(rootdir, tt.name)
 			assert.NilError(t, os.Mkdir(subdir, 0o755))
-			d, err := graphdriver.GetDriver("vfs", graphdriver.Options{
+			d, err := graphdriver.New("vfs", graphdriver.Options{
 				DriverOptions: tt.opts,
 				Root:          subdir,
 			})

--- a/layer/layer_test.go
+++ b/layer/layer_test.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 func newVFSGraphDriver(td string) (graphdriver.Driver, error) {
-	return graphdriver.GetDriver("vfs", graphdriver.Options{
+	return graphdriver.New("vfs", graphdriver.Options{
 		Root: td,
 		IDMap: idtools.IdentityMapping{
 			UIDMaps: []idtools.IDMap{{


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/48072

### daemon/graphdriver: combine GetDriver and getBuiltinDriver

Now that support for external graphdriver-plugins is removed, these functions
are now identical in functionality; combine them, but use a non-exported
variant for internal use to get visibility into where it's used.


### daemon/graphdriver: New(): update GoDoc

Better describe what this function does (currently), and add a TODO for
consideration to extract some of its magic.

### daemon/graphdriver: deprecate GetDriver(), and remove its use

The exported function was only used in tests, and identical in use when
using New with a name provided. Deprecate it, and remove the uses of it
in our (integration-)tests.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
daemon/graphdriver: deprecate GetDriver()
```

**- A picture of a cute animal (not mandatory but encouraged)**

