### PR TITLE
[27.0 backport] daemon/graphdriver/overlay2: set TarOptions.InUserNS for native differ (fix "failed to Lchown "/dev/console")

### DIFF
--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/containerd/containerd/pkg/userns"
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/log"
 	"github.com/docker/docker/daemon/graphdriver"
@@ -678,7 +679,6 @@ func (d *Driver) ApplyDiff(id string, parent string, diff io.Reader) (size int64
 		return d.naiveDiff.ApplyDiff(id, parent, diff)
 	}
 
-	// never reach here if we are running in UserNS
 	applyDir := d.getDiffPath(id)
 
 	logger.Debugf("Applying tar in %s", applyDir)
@@ -686,6 +686,7 @@ func (d *Driver) ApplyDiff(id string, parent string, diff io.Reader) (size int64
 	if err := untar(diff, applyDir, &archive.TarOptions{
 		IDMap:          d.idMap,
 		WhiteoutFormat: archive.OverlayWhiteoutFormat,
+		InUserNS:       userns.RunningInUserNS(),
 	}); err != nil {
 		return 0, err
 	}

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -871,11 +871,6 @@ func NewTarballer(srcPath string, options *TarOptions) (*Tarballer, error) {
 		return nil, err
 	}
 
-	whiteoutConverter, err := getWhiteoutConverter(options.WhiteoutFormat, options.InUserNS)
-	if err != nil {
-		return nil, err
-	}
-
 	return &Tarballer{
 		// Fix the source path to work with long path names. This is a no-op
 		// on platforms other than Windows.
@@ -885,7 +880,7 @@ func NewTarballer(srcPath string, options *TarOptions) (*Tarballer, error) {
 		pipeReader:        pipeReader,
 		pipeWriter:        pipeWriter,
 		compressWriter:    compressWriter,
-		whiteoutConverter: whiteoutConverter,
+		whiteoutConverter: getWhiteoutConverter(options.WhiteoutFormat),
 	}, nil
 }
 
@@ -1080,10 +1075,7 @@ func Unpack(decompressedArchive io.Reader, dest string, options *TarOptions) err
 	defer pools.BufioReader32KPool.Put(trBuf)
 
 	var dirs []*tar.Header
-	whiteoutConverter, err := getWhiteoutConverter(options.WhiteoutFormat, options.InUserNS)
-	if err != nil {
-		return err
-	}
+	whiteoutConverter := getWhiteoutConverter(options.WhiteoutFormat)
 
 	// Iterate through the files in the archive.
 loop:

--- a/pkg/archive/archive_linux.go
+++ b/pkg/archive/archive_linux.go
@@ -12,14 +12,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func getWhiteoutConverter(format WhiteoutFormat, inUserNS bool) (tarWhiteoutConverter, error) {
+func getWhiteoutConverter(format WhiteoutFormat) tarWhiteoutConverter {
 	if format == OverlayWhiteoutFormat {
-		if inUserNS {
-			return nil, errors.New("specifying OverlayWhiteoutFormat is not allowed in userns")
-		}
-		return overlayWhiteoutConverter{}, nil
+		return overlayWhiteoutConverter{}
 	}
-	return nil, nil
+	return nil
 }
 
 type overlayWhiteoutConverter struct{}

--- a/pkg/archive/archive_other.go
+++ b/pkg/archive/archive_other.go
@@ -2,6 +2,6 @@
 
 package archive // import "github.com/docker/docker/pkg/archive"
 
-func getWhiteoutConverter(format WhiteoutFormat, inUserNS bool) (tarWhiteoutConverter, error) {
-	return nil, nil
+func getWhiteoutConverter(format WhiteoutFormat) tarWhiteoutConverter {
+	return nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- backport https://github.com/moby/moby/pull/48083
- fixes https://github.com/moby/moby/issues/48064
- fixes https://github.com/docker/for-linux/issues/1497
- relates to / introduced in https://github.com/moby/moby/pull/47605

### pkg/archive: getWhiteoutConverter: don't error with userns enabled

Since 838047a1f5bf47aa65eb6901a20abdb5ab9b640a, the overlayWhiteoutConverter
is supported with userns enabled, so we no longer need this check.


### pkg/archive: handleTarTypeBlockCharFifo: don't discard EPERM errors

This function was discarding EPERM errors if it detected that userns was
enabled; move such checks to the caller-site, so that they can decide
how to handle the error (which, in case of userns may be to log and ignore).


### pkg/archive: createTarFile: consistently use the same value for userns

createTarFile accepts a opts (TarOptions) argument to specify whether
userns is enabled; whe should consider always detecting locally, but
at least make sure we're consistently working with the same value within
this function.

### daemon/graphdriver/overlay2: set TarOptions.InUserNS for native differ

Commits b2fd67de77be8692ff343d26a9819a3c42ef8c2f (and the follow-up commit
f6b80253b8bfc04b9a6ef0e6bd73e44d36778046) updated doesSupportNativeDiff to
detect whether the host can support native overlay diffing with userns
enabled.

As a result, [useNaiveDiff] would now return "false" in cases where it
previously would return "true" (and thus skip). However, [overlay2],
unlike [fuse-overlay] did not take user namespaces into account, when
using the native differ, and it therefore did not set the InUserNS option
in TarOptions.

As a result pkg/archive.createTarFile would attempt tocreate [device-nodes]
through [handleTarTypeBlockCharFifo] which would fail, but the resulting
error `EPERM` would be discarded, and `createTarFile` would not return
early, therefor attempting to [os.LChown] the missing file, ultimately
resulting in an error:

    failed to Lchown "/dev/console" for UID 0, GID 0: lchown /dev/console: no such file or directory

This patch fixes the missing option in overlay.



[useNaiveDiff]: https://github.com/moby/moby/blob/47eebd718f332f29a38455b61ee879ced5bc219b/daemon/graphdriver/overlay2/overlay.go#L248-L256
[overlay2]: https://github.com/moby/moby/blob/47eebd718f332f29a38455b61ee879ced5bc219b/daemon/graphdriver/overlay2/overlay.go#L684-L689
[fuse-overlay]: https://github.com/moby/moby/blob/47eebd718f332f29a38455b61ee879ced5bc219b/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs.go#L456-L462
[device-nodes]: https://github.com/moby/moby/blob/ff1e2c0de72a1bbbe4cdbe1558da57d327899df5/pkg/archive/archive.go#L713-L720
[handleTarTypeBlockCharFifo]: https://github.com/moby/moby/blob/47eebd718f332f29a38455b61ee879ced5bc219b/pkg/archive/archive_unix.go#L110-L114
[os.LChown]: https://github.com/moby/moby/blob/ff1e2c0de72a1bbbe4cdbe1558da57d327899df5/pkg/archive/archive.go#L762-L773


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix "fail to register layer: failed to Lchown" errors when trying to pull an image with rootless enabled on a system that supports native overlay with user-namespaces.
```

**- A picture of a cute animal (not mandatory but encouraged)**

