### PR TITLE
[27.0 backport] Fix duplicate subnet allocations

### DIFF
--- a/libnetwork/ipams/defaultipam/address_space.go
+++ b/libnetwork/ipams/defaultipam/address_space.go
@@ -164,8 +164,6 @@ func (aSpace *addrSpace) allocatePredefinedPool(reserved []netip.Prefix) (netip.
 		pdf := aSpace.predefined[pdfID]
 
 		if allocated.Overlaps(pdf.Base) {
-			it.Inc()
-
 			if allocated.Bits() <= pdf.Base.Bits() {
 				// The current 'allocated' prefix is bigger than the 'pdf'
 				// network, thus the block is fully overlapped.
@@ -194,6 +192,8 @@ func (aSpace *addrSpace) allocatePredefinedPool(reserved []netip.Prefix) (netip.
 				// 'prevAlloc' and before 'allocated'.
 				return makeAlloc(afterPrev), nil
 			}
+
+			it.Inc()
 
 			if netiputil.LastAddr(allocated) == netiputil.LastAddr(pdf.Base) {
 				// The last address of the current 'allocated' prefix is the


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/48084

**- What I did**

Keep allocated subnets in-order, so that they're not mistakenly reallocated due to a gap in the list where misplaced subnets should have been.

- fixes https://github.com/moby/moby/issues/48069
- fixes https://github.com/docker/cli/issues/5204
- fixes https://github.com/testcontainers/testcontainers-java/issues/8813
- introduced in https://github.com/moby/moby/pull/47768

**- How I did it**

The iterator over allocated subnets was incremented too early, this change moves it past three clauses in addrSpace.allocatePredefinedPool(). 

**- How to verify it**

The three new unit tests correspond to a separate failure caused by incrementing before each of them.

Without the fix, the three new tests fail like this ...

```
=== FAIL: libnetwork/ipams/defaultipam TestPoolAllocateAndRelease/allocate_after_reserved (0.00s)
    address_space_test.go:475: assertion failed: reserved.Overlaps(subnet) is true: subnet 10.0.1.0/24 allocated in reserved range 10.0.0.0/16

=== FAIL: libnetwork/ipams/defaultipam TestPoolAllocateAndRelease/reallocate_first_subnet (0.00s)
    address_space_test.go:472: assertion failed: exists is true: subnet 10.0.0.0/24 allocated to n4, reallocated for n5

=== FAIL: libnetwork/ipams/defaultipam TestPoolAllocateAndRelease/reallocate_after_release (0.00s)
    address_space_test.go:472: assertion failed: exists is true: subnet 10.0.1.0/24 allocated to n5, reallocated for n6
```

As a follow-up, it might be good to add something to the tests to assert that `allocated` is ordered (and maybe to the production code to log an error if the ordering breaks).

**- Description for the changelog**
```markdown changelog
Fix a regression that caused duplicate subnet allocations when creating networks.
```

