### PR TITLE
vendor: github.com/microsoft/hcsshim v0.11.7

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -15,7 +15,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1
 	github.com/Graylog2/go-gelf v0.0.0-20191017102106-1550ee647df0
 	github.com/Microsoft/go-winio v0.6.2
-	github.com/Microsoft/hcsshim v0.11.5
+	github.com/Microsoft/hcsshim v0.11.7
 	github.com/RackSec/srslog v0.0.0-20180709174129-a4725f04ec91
 	github.com/aws/aws-sdk-go-v2 v1.24.1
 	github.com/aws/aws-sdk-go-v2/config v1.26.6

--- a/vendor.sum
+++ b/vendor.sum
@@ -40,8 +40,8 @@ github.com/Graylog2/go-gelf v0.0.0-20191017102106-1550ee647df0 h1:cOjLyhBhe91glg
 github.com/Graylog2/go-gelf v0.0.0-20191017102106-1550ee647df0/go.mod h1:fBaQWrftOD5CrVCUfoYGHs4X4VViTuGOXA8WloCjTY0=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/Microsoft/hcsshim v0.11.5 h1:haEcLNpj9Ka1gd3B3tAEs9CpE0c+1IhoL59w/exYU38=
-github.com/Microsoft/hcsshim v0.11.5/go.mod h1:MV8xMfmECjl5HdO7U/3/hFVnkmSBjAjmA09d4bExKcU=
+github.com/Microsoft/hcsshim v0.11.7 h1:vl/nj3Bar/CvJSYo7gIQPyRWc9f3c6IeSNavBTSZNZQ=
+github.com/Microsoft/hcsshim v0.11.7/go.mod h1:MV8xMfmECjl5HdO7U/3/hFVnkmSBjAjmA09d4bExKcU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/RackSec/srslog v0.0.0-20180709174129-a4725f04ec91 h1:vX+gnvBc56EbWYrmlhYbFYRaeikAke1GL84N4BEYOFE=
 github.com/RackSec/srslog v0.0.0-20180709174129-a4725f04ec91/go.mod h1:cDLGBht23g0XQdLjzn6xOGXDkLK182YfINAaZEQLCHQ=

--- a/vendor/github.com/Microsoft/hcsshim/hcn/hcn.go
+++ b/vendor/github.com/Microsoft/hcsshim/hcn/hcn.go
@@ -264,6 +264,18 @@ func SetPolicySupported() error {
 	return platformDoesNotSupportError("SetPolicy")
 }
 
+// ModifyLoadbalancerSupported returns an error if the HCN version does not support ModifyLoadbalancer.
+func ModifyLoadbalancerSupported() error {
+	supported, err := GetCachedSupportedFeatures()
+	if err != nil {
+		return err
+	}
+	if supported.ModifyLoadbalancer {
+		return nil
+	}
+	return platformDoesNotSupportError("ModifyLoadbalancer")
+}
+
 // VxlanPortSupported returns an error if the HCN version does not support configuring the VXLAN TCP port.
 func VxlanPortSupported() error {
 	supported, err := GetCachedSupportedFeatures()

--- a/vendor/github.com/Microsoft/hcsshim/hcn/hcnerrors.go
+++ b/vendor/github.com/Microsoft/hcsshim/hcn/hcnerrors.go
@@ -51,6 +51,7 @@ type ErrorCode uint32
 const (
 	ERROR_NOT_FOUND                     = ErrorCode(windows.ERROR_NOT_FOUND)
 	HCN_E_PORT_ALREADY_EXISTS ErrorCode = ErrorCode(windows.HCN_E_PORT_ALREADY_EXISTS)
+	HCN_E_NOTIMPL             ErrorCode = ErrorCode(windows.E_NOTIMPL)
 )
 
 type HcnError struct {
@@ -76,6 +77,10 @@ func IsElementNotFoundError(err error) bool {
 
 func IsPortAlreadyExistsError(err error) bool {
 	return CheckErrorWithCode(err, HCN_E_PORT_ALREADY_EXISTS)
+}
+
+func IsNotImplemented(err error) bool {
+	return CheckErrorWithCode(err, HCN_E_NOTIMPL)
 }
 
 func new(hr error, title string, rest string) error {

--- a/vendor/github.com/Microsoft/hcsshim/hcn/hcnglobals.go
+++ b/vendor/github.com/Microsoft/hcsshim/hcn/hcnglobals.go
@@ -84,6 +84,11 @@ var (
 
 	//HNS 15.0 allows for NestedIpSet support
 	NestedIpSetVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 15, Minor: 0}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
+
+	//HNS 15.1 allows support for DisableHostPort flag.
+	DisableHostPortVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 15, Minor: 1}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
+	// HNS 15.4 allows for Modify Loadbalancer support
+	ModifyLoadbalancerVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 15, Minor: 4}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
 )
 
 // GetGlobals returns the global properties of the HCN Service.

--- a/vendor/github.com/Microsoft/hcsshim/hcn/hcnloadbalancer.go
+++ b/vendor/github.com/Microsoft/hcsshim/hcn/hcnloadbalancer.go
@@ -163,6 +163,49 @@ func createLoadBalancer(settings string) (*HostComputeLoadBalancer, error) {
 	return &outputLoadBalancer, nil
 }
 
+func updateLoadBalancer(loadbalancerId string, settings string) (*HostComputeLoadBalancer, error) {
+	loadBalancerGuid, err := guid.FromString(loadbalancerId)
+	if err != nil {
+		return nil, errInvalidLoadBalancerID
+	}
+	// Update loadBalancer.
+	var (
+		loadBalancerHandle hcnLoadBalancer
+		resultBuffer       *uint16
+		propertiesBuffer   *uint16
+	)
+	hr := hcnOpenLoadBalancer(&loadBalancerGuid, &loadBalancerHandle, &resultBuffer)
+	if err := checkForErrors("hcnOpenLoadBalancer", hr, resultBuffer); err != nil {
+		return nil, err
+	}
+	hr = hcnModifyLoadBalancer(loadBalancerHandle, settings, &resultBuffer)
+	if err := checkForErrors("hcnModifyLoadBalancer", hr, resultBuffer); err != nil {
+		return nil, err
+	}
+	// Query loadBalancer.
+	hcnQuery := defaultQuery()
+	query, err := json.Marshal(hcnQuery)
+	if err != nil {
+		return nil, err
+	}
+	hr = hcnQueryLoadBalancerProperties(loadBalancerHandle, string(query), &propertiesBuffer, &resultBuffer)
+	if err := checkForErrors("hcnQueryLoadBalancerProperties", hr, resultBuffer); err != nil {
+		return nil, err
+	}
+	properties := interop.ConvertAndFreeCoTaskMemString(propertiesBuffer)
+	// Close loadBalancer.
+	hr = hcnCloseLoadBalancer(loadBalancerHandle)
+	if err := checkForErrors("hcnCloseLoadBalancer", hr, nil); err != nil {
+		return nil, err
+	}
+	// Convert output to HostComputeLoadBalancer
+	var outputLoadBalancer HostComputeLoadBalancer
+	if err := json.Unmarshal([]byte(properties), &outputLoadBalancer); err != nil {
+		return nil, err
+	}
+	return &outputLoadBalancer, nil
+}
+
 func deleteLoadBalancer(loadBalancerID string) error {
 	loadBalancerGUID, err := guid.FromString(loadBalancerID)
 	if err != nil {
@@ -231,6 +274,23 @@ func (loadBalancer *HostComputeLoadBalancer) Create() (*HostComputeLoadBalancer,
 
 	logrus.Debugf("hcn::HostComputeLoadBalancer::Create JSON: %s", jsonString)
 	loadBalancer, hcnErr := createLoadBalancer(string(jsonString))
+	if hcnErr != nil {
+		return nil, hcnErr
+	}
+	return loadBalancer, nil
+}
+
+// Update Loadbalancer.
+func (loadBalancer *HostComputeLoadBalancer) Update(hnsLoadbalancerID string) (*HostComputeLoadBalancer, error) {
+	logrus.Debugf("hcn::HostComputeLoadBalancer::Create id=%s", hnsLoadbalancerID)
+
+	jsonString, err := json.Marshal(loadBalancer)
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Debugf("hcn::HostComputeLoadBalancer::Update JSON: %s", jsonString)
+	loadBalancer, hcnErr := updateLoadBalancer(hnsLoadbalancerID, string(jsonString))
 	if hcnErr != nil {
 		return nil, hcnErr
 	}

--- a/vendor/github.com/Microsoft/hcsshim/hcn/hcnpolicy.go
+++ b/vendor/github.com/Microsoft/hcsshim/hcn/hcnpolicy.go
@@ -144,10 +144,11 @@ type QosPolicySetting struct {
 
 // OutboundNatPolicySetting sets outbound Network Address Translation on an Endpoint.
 type OutboundNatPolicySetting struct {
-	VirtualIP    string   `json:",omitempty"`
-	Exceptions   []string `json:",omitempty"`
-	Destinations []string `json:",omitempty"`
-	Flags        NatFlags `json:",omitempty"`
+	VirtualIP        string   `json:",omitempty"`
+	Exceptions       []string `json:",omitempty"`
+	Destinations     []string `json:",omitempty"`
+	Flags            NatFlags `json:",omitempty"`
+	MaxPortPoolUsage uint16   `json:",omitempty"`
 }
 
 // SDNRoutePolicySetting sets SDN Route on an Endpoint.

--- a/vendor/github.com/Microsoft/hcsshim/hcn/hcnsupport.go
+++ b/vendor/github.com/Microsoft/hcsshim/hcn/hcnsupport.go
@@ -37,6 +37,8 @@ type SupportedFeatures struct {
 	TierAcl                  bool        `json:"TierAcl"`
 	NetworkACL               bool        `json:"NetworkACL"`
 	NestedIpSet              bool        `json:"NestedIpSet"`
+	DisableHostPort          bool        `json:"DisableHostPort"`
+	ModifyLoadbalancer       bool        `json:"ModifyLoadbalancer"`
 }
 
 // AclFeatures are the supported ACL possibilities.
@@ -114,6 +116,8 @@ func getSupportedFeatures() (SupportedFeatures, error) {
 	features.TierAcl = isFeatureSupported(globals.Version, TierAclPolicyVersion)
 	features.NetworkACL = isFeatureSupported(globals.Version, NetworkACLPolicyVersion)
 	features.NestedIpSet = isFeatureSupported(globals.Version, NestedIpSetVersion)
+	features.DisableHostPort = isFeatureSupported(globals.Version, DisableHostPortVersion)
+	features.ModifyLoadbalancer = isFeatureSupported(globals.Version, ModifyLoadbalancerVersion)
 
 	log.L.WithFields(logrus.Fields{
 		"version":           globals.Version,

--- a/vendor/github.com/Microsoft/hcsshim/internal/hns/hnsendpoint.go
+++ b/vendor/github.com/Microsoft/hcsshim/internal/hns/hnsendpoint.go
@@ -10,6 +10,28 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// EndpointState represents the states of an HNS Endpoint lifecycle.
+type EndpointState uint16
+
+// EndpointState const
+// The lifecycle of an Endpoint goes through created, attached, AttachedSharing - endpoint is being shared with other containers,
+// detached, after being attached, degraded and finally destroyed.
+// Note: This attribute is used by calico to define stale containers and is dependent on HNS v1 api, if we move to HNS v2 api we will need
+// to update the current calico code and cordinate the change with calico. Reach out to Microsoft to facilate the change via HNS.
+const (
+	Uninitialized   EndpointState = iota
+	Created         EndpointState = 1
+	Attached        EndpointState = 2
+	AttachedSharing EndpointState = 3
+	Detached        EndpointState = 4
+	Degraded        EndpointState = 5
+	Destroyed       EndpointState = 6
+)
+
+func (es EndpointState) String() string {
+	return [...]string{"Uninitialized", "Attached", "AttachedSharing", "Detached", "Degraded", "Destroyed"}[es]
+}
+
 // HNSEndpoint represents a network endpoint in HNS
 type HNSEndpoint struct {
 	Id                 string            `json:"ID,omitempty"`
@@ -34,6 +56,7 @@ type HNSEndpoint struct {
 	Namespace          *Namespace        `json:",omitempty"`
 	EncapOverhead      uint16            `json:",omitempty"`
 	SharedContainers   []string          `json:",omitempty"`
+	State              EndpointState     `json:",omitempty"`
 }
 
 // SystemType represents the type of the system on which actions are done

--- a/vendor/github.com/Microsoft/hcsshim/internal/hns/hnspolicy.go
+++ b/vendor/github.com/Microsoft/hcsshim/internal/hns/hnspolicy.go
@@ -57,9 +57,10 @@ type PaPolicy struct {
 
 type OutboundNatPolicy struct {
 	Policy
-	VIP          string   `json:"VIP,omitempty"`
-	Exceptions   []string `json:"ExceptionList,omitempty"`
-	Destinations []string `json:",omitempty"`
+	VIP              string   `json:"VIP,omitempty"`
+	Exceptions       []string `json:"ExceptionList,omitempty"`
+	Destinations     []string `json:",omitempty"`
+	MaxPortPoolUsage uint16   `json:",omitempty"`
 }
 
 type ProxyPolicy struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -51,7 +51,7 @@ github.com/Microsoft/go-winio/pkg/etwlogrus
 github.com/Microsoft/go-winio/pkg/fs
 github.com/Microsoft/go-winio/pkg/guid
 github.com/Microsoft/go-winio/vhd
-# github.com/Microsoft/hcsshim v0.11.5
+# github.com/Microsoft/hcsshim v0.11.7
 ## explicit; go 1.21
 github.com/Microsoft/hcsshim
 github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options


### PR DESCRIPTION
- needed for https://github.com/moby/moby/pull/47142


### vendor: github.com/microsoft/hcsshim v0.11.7

- Fix process handle leak when launching a job container
- Add EndpointState attribute to the HNSEndpoint struct to support hyperv containers for k8s
- Add support for loadbalancer policy update in hns
- Changes for checking the global version for modify policy version support
- OutBoundNATPolicy Schema changes (add MaxPortPoolUsage to OutboundNatPolicySetting)

full diff: https://github.com/microsoft/hcsshim/compare/v0.11.5...v0.11.7

**- A picture of a cute animal (not mandatory but encouraged)**

