### PR TITLE
cleanup: Remove unnecessary return value

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 // installCommonConfigFlags adds flags to the pflag.FlagSet to configure the daemon
-func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
+func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	var (
 		allowNonDistributable = opts.NewNamedListOptsRef("allow-nondistributable-artifacts", &conf.AllowNondistributableArtifacts, registry.ValidateIndexName)
 		registryMirrors       = opts.NewNamedListOptsRef("registry-mirrors", &conf.Mirrors, registry.ValidateMirror)
@@ -79,6 +79,4 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	_ = flags.MarkDeprecated("api-cors-header", "accessing Docker API through a browser is insecure; use a reverse proxy if you need CORS headers")
 	flags.BoolVarP(&conf.AutoRestart, "restart", "r", true, "--restart on the daemon has been deprecated in favor of --restart policies on docker run")
 	_ = flags.MarkDeprecated("restart", "Please use a restart policy on docker run")
-
-	return nil
 }

--- a/cmd/dockerd/config_unix.go
+++ b/cmd/dockerd/config_unix.go
@@ -15,11 +15,9 @@ import (
 )
 
 // installConfigFlags adds flags to the pflag.FlagSet to configure the daemon
-func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
+func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	// First handle install flags which are consistent cross-platform
-	if err := installCommonConfigFlags(conf, flags); err != nil {
-		return err
-	}
+	installCommonConfigFlags(conf, flags)
 
 	// Then platform-specific install flags
 	flags.Var(opts.NewNamedRuntimeOpt("runtimes", &conf.Runtimes, config.StockRuntimeName), "add-runtime", "Register an additional OCI compatible runtime")
@@ -58,7 +56,6 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	// Note that conf.BridgeConfig.UserlandProxyPath and honorXDG are configured according to the value of rootless.RunningWithRootlessKit, not the value of --rootless.
 	flags.BoolVar(&conf.Rootless, "rootless", conf.Rootless, "Enable rootless mode; typically used with RootlessKit")
 	flags.StringVar(&conf.CgroupNamespaceMode, "default-cgroupns-mode", conf.CgroupNamespaceMode, `Default mode for containers cgroup namespace ("host" | "private")`)
-	return nil
 }
 
 // configureCertsDir configures registry.CertsDir() depending on if the daemon

--- a/cmd/dockerd/config_unix_test.go
+++ b/cmd/dockerd/config_unix_test.go
@@ -16,8 +16,7 @@ func TestDaemonParseShmSize(t *testing.T) {
 
 	conf, err := config.New()
 	assert.NilError(t, err)
-	err = installConfigFlags(conf, flags)
-	assert.NilError(t, err)
+	installConfigFlags(conf, flags)
 	// By default `--default-shm-size=64M`
 	assert.Check(t, is.Equal(int64(64*1024*1024), conf.ShmSize.Value()))
 	assert.Check(t, flags.Set("default-shm-size", "128M"))

--- a/cmd/dockerd/config_windows.go
+++ b/cmd/dockerd/config_windows.go
@@ -6,17 +6,14 @@ import (
 )
 
 // installConfigFlags adds flags to the pflag.FlagSet to configure the daemon
-func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
+func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	// First handle install flags which are consistent cross-platform
-	if err := installCommonConfigFlags(conf, flags); err != nil {
-		return err
-	}
+	installCommonConfigFlags(conf, flags)
 
 	// Then platform-specific install flags.
 	flags.StringVar(&conf.BridgeConfig.FixedCIDR, "fixed-cidr", "", "IPv4 subnet for fixed IPs")
 	flags.StringVarP(&conf.BridgeConfig.Iface, "bridge", "b", "", "Attach containers to a virtual switch")
 	flags.StringVarP(&conf.SocketGroup, "group", "G", "", "Users or groups that can access the named pipe")
-	return nil
 }
 
 // configureCertsDir configures registry.CertsDir() depending on if the daemon

--- a/cmd/dockerd/daemon_test.go
+++ b/cmd/dockerd/daemon_test.go
@@ -18,8 +18,7 @@ func defaultOptions(t *testing.T, configFile string) *daemonOptions {
 	opts := newDaemonOptions(cfg)
 	opts.flags = &pflag.FlagSet{}
 	opts.installFlags(opts.flags)
-	err = installConfigFlags(opts.daemonConfig, opts.flags)
-	assert.NilError(t, err)
+	installConfigFlags(opts.daemonConfig, opts.flags)
 	defaultDaemonConfigFile, err := getDefaultDaemonConfigFile()
 	assert.NilError(t, err)
 	opts.flags.StringVar(&opts.configFile, "config-file", defaultDaemonConfigFile, "")

--- a/cmd/dockerd/docker.go
+++ b/cmd/dockerd/docker.go
@@ -50,9 +50,7 @@ func newDaemonCommand() (*cobra.Command, error) {
 	flags.StringVar(&opts.configFile, "config-file", defaultDaemonConfigFile, "Daemon configuration file")
 	configureCertsDir()
 	opts.installFlags(flags)
-	if err := installConfigFlags(opts.daemonConfig, flags); err != nil {
-		return nil, err
-	}
+	installConfigFlags(opts.daemonConfig, flags)
 	installServiceFlags(flags)
 
 	return cmd, nil


### PR DESCRIPTION
The return error of `installCommonConfigFlags` is unnecessary since it only return nil.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

