### PR TITLE
Refactor MountPoint IDs

### DIFF
--- a/container/mounts_unix.go
+++ b/container/mounts_unix.go
@@ -4,6 +4,9 @@ package container // import "github.com/docker/docker/container"
 
 // Mount contains information for a mount operation.
 type Mount struct {
+	// ID is the unique identifier of this mount
+	// TODO Q: should this field be exported to json?
+	ID                     string `json:"-"`
 	Source                 string `json:"source"`
 	Destination            string `json:"destination"`
 	Writable               bool   `json:"writable"`

--- a/container/mounts_windows.go
+++ b/container/mounts_windows.go
@@ -2,6 +2,7 @@ package container // import "github.com/docker/docker/container"
 
 // Mount contains information for a mount operation.
 type Mount struct {
+	// TODO: fix windows
 	Source      string `json:"source"`
 	Destination string `json:"destination"`
 	Writable    bool   `json:"writable"`

--- a/daemon/archive_windows.go
+++ b/daemon/archive_windows.go
@@ -19,6 +19,8 @@ import (
 // containerStatPath stats the filesystem resource at the specified path in this
 // container. Returns stat info about the resource.
 func (daemon *Daemon) containerStatPath(container *container.Container, path string) (stat *containertypes.PathStat, err error) {
+	// TODO: fix windows
+
 	container.Lock()
 	defer container.Unlock()
 

--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -108,7 +108,7 @@ func (daemon *Daemon) populateVolume(ctx context.Context, c *container.Container
 		return err
 	}
 
-	volumePath, cleanup, err := mnt.Setup(ctx, c.MountLabel, daemon.idMapping.RootPair(), nil)
+	volumePath, mountID, cleanup, err := mnt.Setup(ctx, c.MountLabel, daemon.idMapping.RootPair(), nil, false /* temporary mount */)
 	if err != nil {
 		if errdefs.IsNotFound(err) {
 			return nil
@@ -119,7 +119,7 @@ func (daemon *Daemon) populateVolume(ctx context.Context, c *container.Container
 	defer func() {
 		ctx := context.WithoutCancel(ctx)
 		_ = cleanup(ctx)
-		_ = mnt.Cleanup(ctx)
+		_ = mnt.Cleanup(ctx, mountID)
 	}()
 
 	log.G(ctx).Debugf("copying image data from %s:%s, to %s", c.ID, mnt.Destination, volumePath)

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -71,21 +71,21 @@ func (daemon *Daemon) ContainerStart(ctx context.Context, name string, checkpoin
 // container needs, such as storage and networking, as well as links
 // between containers. The container is left waiting for a signal to
 // begin running.
-func (daemon *Daemon) containerStart(ctx context.Context, daemonCfg *configStore, container *container.Container, checkpoint string, checkpointDir string, resetRestartManager bool) (retErr error) {
+func (daemon *Daemon) containerStart(ctx context.Context, daemonCfg *configStore, ctr *container.Container, checkpoint string, checkpointDir string, resetRestartManager bool) (retErr error) {
 	ctx, span := otel.Tracer("").Start(ctx, "daemon.containerStart", trace.WithAttributes(
-		attribute.String("container.ID", container.ID),
-		attribute.String("container.Name", container.Name)))
+		attribute.String("container.ID", ctr.ID),
+		attribute.String("container.Name", ctr.Name)))
 	defer span.End()
 
 	start := time.Now()
-	container.Lock()
-	defer container.Unlock()
+	ctr.Lock()
+	defer ctr.Unlock()
 
-	if resetRestartManager && container.Running { // skip this check if already in restarting step and resetRestartManager==false
+	if resetRestartManager && ctr.Running { // skip this check if already in restarting step and resetRestartManager==false
 		return nil
 	}
 
-	if container.RemovalInProgress || container.Dead {
+	if ctr.RemovalInProgress || ctr.Dead {
 		return errdefs.Conflict(errors.New("container is marked for removal and cannot be started"))
 	}
 
@@ -98,49 +98,49 @@ func (daemon *Daemon) containerStart(ctx context.Context, daemonCfg *configStore
 	// setup has been cleaned up properly
 	defer func() {
 		if retErr != nil {
-			container.SetError(retErr)
+			ctr.SetError(retErr)
 			// if no one else has set it, make sure we don't leave it at zero
-			if container.ExitCode() == 0 {
-				container.SetExitCode(exitUnknown)
+			if ctr.ExitCode() == 0 {
+				ctr.SetExitCode(exitUnknown)
 			}
-			if err := container.CheckpointTo(context.WithoutCancel(ctx), daemon.containersReplica); err != nil {
-				log.G(ctx).Errorf("%s: failed saving state on start failure: %v", container.ID, err)
+			if err := ctr.CheckpointTo(context.WithoutCancel(ctx), daemon.containersReplica); err != nil {
+				log.G(ctx).Errorf("%s: failed saving state on start failure: %v", ctr.ID, err)
 			}
-			container.Reset(false)
+			ctr.Reset(false)
 
-			daemon.Cleanup(context.WithoutCancel(ctx), container)
+			daemon.Cleanup(context.WithoutCancel(ctx), ctr)
 			// if containers AutoRemove flag is set, remove it after clean up
-			if container.HostConfig.AutoRemove {
-				container.Unlock()
-				if err := daemon.containerRm(&daemonCfg.Config, container.ID, &backend.ContainerRmConfig{ForceRemove: true, RemoveVolume: true}); err != nil {
-					log.G(ctx).Errorf("can't remove container %s: %v", container.ID, err)
+			if ctr.HostConfig.AutoRemove {
+				ctr.Unlock()
+				if err := daemon.containerRm(&daemonCfg.Config, ctr.ID, &backend.ContainerRmConfig{ForceRemove: true, RemoveVolume: true}); err != nil {
+					log.G(ctx).Errorf("can't remove container %s: %v", ctr.ID, err)
 				}
-				container.Lock()
+				ctr.Lock()
 			}
 		}
 	}()
 
-	if err := daemon.conditionalMountOnStart(container); err != nil {
+	if err := daemon.conditionalMountOnStart(ctr); err != nil {
 		return err
 	}
 
-	if err := daemon.initializeNetworking(ctx, &daemonCfg.Config, container); err != nil {
+	if err := daemon.initializeNetworking(ctx, &daemonCfg.Config, ctr); err != nil {
 		return err
 	}
 
-	mnts, err := daemon.setupContainerDirs(container)
+	mnts, err := daemon.setupContainerDirs(ctr)
 	if err != nil {
 		return err
 	}
 
-	m, cleanup, err := daemon.setupMounts(ctx, container)
+	m, cleanup, err := daemon.setupMounts(ctx, ctr)
 	if err != nil {
 		return err
 	}
 	mnts = append(mnts, m...)
 	defer cleanup(context.WithoutCancel(ctx))
 
-	spec, err := daemon.createSpec(ctx, daemonCfg, container, mnts)
+	spec, err := daemon.createSpec(ctx, daemonCfg, ctr, mnts)
 	if err != nil {
 		// Any error that occurs while creating the spec, even if it's the
 		// result of an invalid container config, must be considered a System
@@ -156,27 +156,27 @@ func (daemon *Daemon) containerStart(ctx context.Context, daemonCfg *configStore
 	}
 
 	if resetRestartManager {
-		container.ResetRestartManager(true)
-		container.HasBeenManuallyStopped = false
+		ctr.ResetRestartManager(true)
+		ctr.HasBeenManuallyStopped = false
 	}
 
-	if err := daemon.saveAppArmorConfig(container); err != nil {
+	if err := daemon.saveAppArmorConfig(ctr); err != nil {
 		return err
 	}
 
 	if checkpoint != "" {
-		checkpointDir, err = getCheckpointDir(checkpointDir, checkpoint, container.Name, container.ID, container.CheckpointDir(), false)
+		checkpointDir, err = getCheckpointDir(checkpointDir, checkpoint, ctr.Name, ctr.ID, ctr.CheckpointDir(), false)
 		if err != nil {
 			return err
 		}
 	}
 
-	shim, createOptions, err := daemon.getLibcontainerdCreateOptions(daemonCfg, container)
+	shim, createOptions, err := daemon.getLibcontainerdCreateOptions(daemonCfg, ctr)
 	if err != nil {
 		return err
 	}
 
-	ctr, err := libcontainerd.ReplaceContainer(ctx, daemon.containerd, container.ID, spec, shim, createOptions, func(ctx context.Context, client *containerd.Client, c *containers.Container) error {
+	c8dCtr, err := libcontainerd.ReplaceContainer(ctx, daemon.containerd, ctr.ID, spec, shim, createOptions, func(ctx context.Context, client *containerd.Client, c *containers.Container) error {
 		// Only set the image if we are using containerd for image storage.
 		// This is for metadata purposes only.
 		// Other lower-level components may make use of this information.
@@ -184,21 +184,21 @@ func (daemon *Daemon) containerStart(ctx context.Context, daemonCfg *configStore
 		if !ok {
 			return nil
 		}
-		img, err := is.ResolveImage(ctx, container.Config.Image)
+		img, err := is.ResolveImage(ctx, ctr.Config.Image)
 		if err != nil {
-			log.G(ctx).WithError(err).WithField("container", container.ID).Warn("Failed to resolve containerd image reference")
+			log.G(ctx).WithError(err).WithField("container", ctr.ID).Warn("Failed to resolve containerd image reference")
 			return nil
 		}
 		c.Image = img.Name
 		return nil
 	})
 	if err != nil {
-		return setExitCodeFromError(container.SetExitCode, err)
+		return setExitCodeFromError(ctr.SetExitCode, err)
 	}
 	defer func() {
 		if retErr != nil {
-			if err := ctr.Delete(context.WithoutCancel(ctx)); err != nil {
-				log.G(ctx).WithError(err).WithField("container", container.ID).
+			if err := c8dCtr.Delete(context.WithoutCancel(ctx)); err != nil {
+				log.G(ctx).WithError(err).WithField("container", ctr.ID).
 					Error("failed to delete failed start container")
 			}
 		}
@@ -206,42 +206,42 @@ func (daemon *Daemon) containerStart(ctx context.Context, daemonCfg *configStore
 
 	startupTime := time.Now()
 	// TODO(mlaventure): we need to specify checkpoint options here
-	tsk, err := ctr.NewTask(context.WithoutCancel(ctx), // passing a cancelable ctx caused integration tests to be stuck in the cleanup phase
-		checkpointDir, container.StreamConfig.Stdin() != nil || container.Config.Tty,
-		container.InitializeStdio)
+	tsk, err := c8dCtr.NewTask(context.WithoutCancel(ctx), // passing a cancelable ctx caused integration tests to be stuck in the cleanup phase
+		checkpointDir, ctr.StreamConfig.Stdin() != nil || ctr.Config.Tty,
+		ctr.InitializeStdio)
 	if err != nil {
-		return setExitCodeFromError(container.SetExitCode, err)
+		return setExitCodeFromError(ctr.SetExitCode, err)
 	}
 	defer func() {
 		if retErr != nil {
 			if err := tsk.ForceDelete(context.WithoutCancel(ctx)); err != nil {
-				log.G(ctx).WithError(err).WithField("container", container.ID).
+				log.G(ctx).WithError(err).WithField("container", ctr.ID).
 					Error("failed to delete task after fail start")
 			}
 		}
 	}()
 
-	if err := daemon.initializeCreatedTask(ctx, tsk, container, spec); err != nil {
+	if err := daemon.initializeCreatedTask(ctx, tsk, ctr, spec); err != nil {
 		return err
 	}
 
 	if err := tsk.Start(context.WithoutCancel(ctx)); err != nil { // passing a cancelable ctx caused integration tests to be stuck in the cleanup phase
-		return setExitCodeFromError(container.SetExitCode, err)
+		return setExitCodeFromError(ctr.SetExitCode, err)
 	}
 
-	container.HasBeenManuallyRestarted = false
-	container.SetRunning(ctr, tsk, startupTime)
-	container.HasBeenStartedBefore = true
-	daemon.setStateCounter(container)
+	ctr.HasBeenManuallyRestarted = false
+	ctr.SetRunning(c8dCtr, tsk, startupTime)
+	ctr.HasBeenStartedBefore = true
+	daemon.setStateCounter(ctr)
 
-	daemon.initHealthMonitor(container)
+	daemon.initHealthMonitor(ctr)
 
-	if err := container.CheckpointTo(context.WithoutCancel(ctx), daemon.containersReplica); err != nil {
-		log.G(ctx).WithError(err).WithField("container", container.ID).
+	if err := ctr.CheckpointTo(context.WithoutCancel(ctx), daemon.containersReplica); err != nil {
+		log.G(ctx).WithError(err).WithField("container", ctr.ID).
 			Errorf("failed to store container")
 	}
 
-	daemon.LogContainerEvent(container, events.ActionStart)
+	daemon.LogContainerEvent(ctr, events.ActionStart)
 	containerActions.WithValues("start").UpdateSince(start)
 
 	return nil
@@ -249,46 +249,46 @@ func (daemon *Daemon) containerStart(ctx context.Context, daemonCfg *configStore
 
 // Cleanup releases any network resources allocated to the container along with any rules
 // around how containers are linked together.  It also unmounts the container's root filesystem.
-func (daemon *Daemon) Cleanup(ctx context.Context, container *container.Container) {
+func (daemon *Daemon) Cleanup(ctx context.Context, ctr *container.Container) {
 	// Microsoft HCS containers get in a bad state if host resources are
 	// released while the container still exists.
-	if ctr, ok := container.C8dContainer(); ok {
-		if err := ctr.Delete(context.Background()); err != nil {
-			log.G(ctx).Errorf("%s cleanup: failed to delete container from containerd: %v", container.ID, err)
+	if c8dCtr, ok := ctr.C8dContainer(); ok {
+		if err := c8dCtr.Delete(context.Background()); err != nil {
+			log.G(ctx).Errorf("%s cleanup: failed to delete container from containerd: %v", ctr.ID, err)
 		}
 	}
 
-	daemon.releaseNetwork(ctx, container)
+	daemon.releaseNetwork(ctx, ctr)
 
-	if err := container.UnmountIpcMount(); err != nil {
-		log.G(ctx).Warnf("%s cleanup: failed to unmount IPC: %s", container.ID, err)
+	if err := ctr.UnmountIpcMount(); err != nil {
+		log.G(ctx).Warnf("%s cleanup: failed to unmount IPC: %s", ctr.ID, err)
 	}
 
-	if err := daemon.conditionalUnmountOnCleanup(container); err != nil {
+	if err := daemon.conditionalUnmountOnCleanup(ctr); err != nil {
 		// FIXME: remove once reference counting for graphdrivers has been refactored
 		// Ensure that all the mounts are gone
-		if mountid, err := daemon.imageService.GetLayerMountID(container.ID); err == nil {
+		if mountid, err := daemon.imageService.GetLayerMountID(ctr.ID); err == nil {
 			daemon.cleanupMountsByID(mountid)
 		}
 	}
 
-	if err := container.UnmountSecrets(); err != nil {
-		log.G(ctx).Warnf("%s cleanup: failed to unmount secrets: %s", container.ID, err)
+	if err := ctr.UnmountSecrets(); err != nil {
+		log.G(ctx).Warnf("%s cleanup: failed to unmount secrets: %s", ctr.ID, err)
 	}
 
-	if err := recursiveUnmount(container.Root); err != nil {
-		log.G(ctx).WithError(err).WithField("container", container.ID).Warn("Error while cleaning up container resource mounts.")
+	if err := recursiveUnmount(ctr.Root); err != nil {
+		log.G(ctx).WithError(err).WithField("container", ctr.ID).Warn("Error while cleaning up container resource mounts.")
 	}
 
-	for _, eConfig := range container.ExecCommands.Commands() {
-		daemon.unregisterExecCommand(container, eConfig)
+	for _, eConfig := range ctr.ExecCommands.Commands() {
+		daemon.unregisterExecCommand(ctr, eConfig)
 	}
 
-	if container.BaseFS != "" {
-		if err := container.UnmountVolumes(ctx, daemon.LogVolumeEvent); err != nil {
-			log.G(ctx).Warnf("%s cleanup: Failed to umount volumes: %v", container.ID, err)
+	if ctr.BaseFS != "" {
+		if err := ctr.UnmountVolumes(ctx, daemon.LogVolumeEvent); err != nil {
+			log.G(ctx).Warnf("%s cleanup: Failed to umount volumes: %v", ctr.ID, err)
 		}
 	}
 
-	container.CancelAttachContext()
+	ctr.CancelAttachContext()
 }

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -133,7 +133,8 @@ func (daemon *Daemon) containerStart(ctx context.Context, daemonCfg *configStore
 		return err
 	}
 
-	m, cleanup, err := daemon.setupMounts(ctx, ctr)
+	m, cleanup, err := daemon.setupMounts(ctx, ctr, true /* container start => mount as primary */)
+	ctr.PrimaryUnmountIDs = toUnmountIDs(m)
 	if err != nil {
 		return err
 	}
@@ -285,7 +286,7 @@ func (daemon *Daemon) Cleanup(ctx context.Context, ctr *container.Container) {
 	}
 
 	if ctr.BaseFS != "" {
-		if err := ctr.UnmountVolumes(ctx, daemon.LogVolumeEvent); err != nil {
+		if err := ctr.UnmountVolumes(ctx, daemon.LogVolumeEvent, ctr.PrimaryUnmountIDs); err != nil {
 			log.G(ctx).Warnf("%s cleanup: Failed to umount volumes: %v", ctr.ID, err)
 		}
 	}

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -25,7 +25,7 @@ import (
 //
 // The cleanup function should be called as soon as the container has been
 // started.
-func (daemon *Daemon) setupMounts(ctx context.Context, c *container.Container) ([]container.Mount, func(context.Context) error, error) {
+func (daemon *Daemon) setupMounts(ctx context.Context, c *container.Container, mountAsPrimary bool) ([]container.Mount, func(context.Context) error, error) {
 	var mounts []container.Mount
 	// TODO: tmpfs mounts should be part of Mountpoints
 	tmpfsMounts := make(map[string]bool)
@@ -62,7 +62,7 @@ func (daemon *Daemon) setupMounts(ctx context.Context, c *container.Container) (
 			return nil
 		}
 
-		path, clean, err := m.Setup(ctx, c.MountLabel, daemon.idMapping.RootPair(), checkfunc)
+		path, mountID, clean, err := m.Setup(ctx, c.MountLabel, daemon.idMapping.RootPair(), checkfunc, mountAsPrimary)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -70,6 +70,7 @@ func (daemon *Daemon) setupMounts(ctx context.Context, c *container.Container) (
 
 		if !c.TrySetNetworkMount(m.Destination, path) {
 			mnt := container.Mount{
+				ID:          mountID,
 				Source:      path,
 				Destination: m.Destination,
 				Writable:    m.RW,

--- a/volume/mounts/mounts.go
+++ b/volume/mounts/mounts.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime/debug"
 	"syscall"
 
 	"github.com/containerd/log"
@@ -59,9 +58,21 @@ type MountPoint struct {
 	// Use a pointer here so we can tell if the user set this value explicitly
 	// This allows us to error out when the user explicitly enabled copy but we can't copy due to the volume being populated
 	CopyData bool `json:"-"`
-	// ID is the opaque ID used to pass to the volume driver.
-	// This should be set by calls to `Mount` and unset by calls to `Unmount`
-	ID string `json:",omitempty"`
+
+	// MountedIDs contains opaque IDs corresponding to mounts of this mountpoint (used to pass to a volume driver).
+	// There may be more than one mount of a mountpoint during a `docker cp`.
+	//
+	// If `mnt.MountedIDs[someId]` is true, `mnt` is currently mounted under the id `someId`.
+	MountedIDs map[string]bool `json:"-"`
+
+	// PrimaryID is the ID of the primary mount of the mountpoint (a primary mount is the one created for the container
+	// to operate; a secondary mount is a mount created for other purposes, such as `docker cp`).
+	//
+	// If `PrimaryID` is an empty string, there is no primary mount for the mountpoint at the moment; if `PrimaryID` is
+	// set to a non-empty value, the primary mount of this mountpoint has that ID
+	// (thus, `mnt.MountedIDs[mnt.PrimaryID]` shall be true).
+	// TODO Q: I don't think this field should be exported. Why is it?
+	PrimaryID string `json:"ID,omitempty"`
 
 	// Spec is a copy of the API request that created this mount.
 	Spec mounttypes.Mount
@@ -72,11 +83,6 @@ type MountPoint struct {
 	// where a bind dir existed during validation was removed before reaching the setup code.
 	SkipMountpointCreation bool
 
-	// Track usage of this mountpoint
-	// Specifically needed for containers which are running and calls to `docker cp`
-	// because both these actions require mounting the volumes.
-	active int
-
 	// SafePaths created by Setup that should be cleaned up before unmounting
 	// the volume.
 	safePaths []*safepath.SafePath
@@ -84,19 +90,15 @@ type MountPoint struct {
 
 // Cleanup frees resources used by the mountpoint and cleans up all the paths
 // returned by Setup that hasn't been cleaned up by the caller.
-func (m *MountPoint) Cleanup(ctx context.Context) error {
-	if m.Volume == nil || m.ID == "" {
+func (m *MountPoint) Cleanup(ctx context.Context, id string) error {
+	mounted := m.MountedIDs[id]
+	if !mounted || m.Volume == nil {
+		// TODO Q: attempting to cleanup a mountpoint that is not mounted should be an error, shouldn't it?
+		//         Why `return nil`?
 		return nil
 	}
 
-	logger := log.G(ctx).WithFields(log.Fields{"active": m.active, "id": m.ID})
-
-	// TODO: Remove once the real bug is fixed: https://github.com/moby/moby/issues/46508
-	if m.active == 0 {
-		logger.Error("An attempt to decrement a zero mount count")
-		logger.Error(string(debug.Stack()))
-		return nil
-	}
+	logger := log.G(ctx).WithFields(log.Fields{"primaryID": m.PrimaryID, "mountedIDs": m.MountedIDs})
 
 	for _, p := range m.safePaths {
 		if !p.IsValid() {
@@ -113,15 +115,16 @@ func (m *MountPoint) Cleanup(ctx context.Context) error {
 		}).Warn("cleaning up SafePath that hasn't been cleaned up by the caller")
 	}
 
-	if err := m.Volume.Unmount(m.ID); err != nil {
+	if err := m.Volume.Unmount(id); err != nil {
 		return errors.Wrapf(err, "error unmounting volume %s", m.Volume.Name())
 	}
 
-	m.active--
-	logger.Debug("MountPoint.Cleanup Decrement active count")
-
-	if m.active == 0 {
-		m.ID = ""
+	m.MountedIDs[id] = false
+	if id == m.PrimaryID {
+		m.PrimaryID = ""
+		logger.Debugf("MountPoint.Cleanup: %s unmounted (primary mount)", id)
+	} else {
+		logger.Debugf("MountPoint.Cleanup: %s unmounted (non-primary mount)", id)
 	}
 	return nil
 }
@@ -138,9 +141,26 @@ func (m *MountPoint) Cleanup(ctx context.Context) error {
 // still points to the same target (to avoid TOCTOU attack).
 //
 // Cleanup function doesn't need to be called when error is returned.
-func (m *MountPoint) Setup(ctx context.Context, mountLabel string, rootIDs idtools.Identity, checkFun func(m *MountPoint) error) (path string, cleanup func(context.Context) error, retErr error) {
+func (m *MountPoint) Setup(ctx context.Context, mountLabel string, rootIDs idtools.Identity, checkFun func(m *MountPoint) error, asPrimary bool) (path string, mountID string, cleanup func(context.Context) error, retErr error) {
+	if m.MountedIDs == nil {
+		log.G(ctx).Debug("Initializing m.MountedIDs")
+		m.MountedIDs = make(map[string]bool)
+	}
+
+	// Generate the mount ID but only set it at the end of the Setup operation if it succeeds.
+	id := stringid.GenerateRandomID()
+	defer func() {
+		log.G(ctx).Debugf("Setting id=%s for a new mount. Source=%s", id, m.Source)
+		if retErr == nil {
+			m.MountedIDs[id] = true
+			if asPrimary {
+				m.PrimaryID = id
+			}
+		}
+	}()
+
 	if m.SkipMountpointCreation {
-		return m.Source, noCleanup, nil
+		return m.Source, id, noCleanup, nil
 	}
 
 	defer func() {
@@ -169,17 +189,16 @@ func (m *MountPoint) Setup(ctx context.Context, mountLabel string, rootIDs idtoo
 		}
 	}()
 
+	if asPrimary && m.PrimaryID != "" {
+		return "", "", noCleanup, fmt.Errorf("mountpoint is already mounted with PrimaryID=%s", m.PrimaryID)
+	}
+
 	if m.Volume != nil {
-		id := m.ID
-		if id == "" {
-			id = stringid.GenerateRandomID()
-		}
 		volumePath, err := m.Volume.Mount(id)
 		if err != nil {
-			return "", noCleanup, errors.Wrapf(err, "error while mounting volume '%s'", m.Source)
+			return "", "", noCleanup, errors.Wrapf(err, "error while mounting volume '%s'", m.Source)
 		}
 
-		m.ID = id
 		clean := noCleanup
 		if m.Spec.VolumeOptions != nil && m.Spec.VolumeOptions.Subpath != "" {
 			subpath := m.Spec.VolumeOptions.Subpath
@@ -189,7 +208,7 @@ func (m *MountPoint) Setup(ctx context.Context, mountLabel string, rootIDs idtoo
 				if err := m.Volume.Unmount(id); err != nil {
 					log.G(ctx).WithError(err).Error("failed to unmount after safepath.Join failed")
 				}
-				return "", noCleanup, err
+				return "", "", noCleanup, err
 			}
 			m.safePaths = append(m.safePaths, safePath)
 			log.G(ctx).Debugf("mounting (%s|%s) via %s", volumePath, subpath, safePath.Path())
@@ -198,12 +217,11 @@ func (m *MountPoint) Setup(ctx context.Context, mountLabel string, rootIDs idtoo
 			volumePath = safePath.Path()
 		}
 
-		m.active++
-		return volumePath, clean, nil
+		return volumePath, id, clean, nil
 	}
 
 	if len(m.Source) == 0 {
-		return "", noCleanup, fmt.Errorf("Unable to setup mount point, neither source nor volume defined")
+		return "", "", noCleanup, fmt.Errorf("Unable to setup mount point, neither source nor volume defined")
 	}
 
 	if m.Type == mounttypes.TypeBind {
@@ -212,7 +230,7 @@ func (m *MountPoint) Setup(ctx context.Context, mountLabel string, rootIDs idtoo
 		// the process of shutting down.
 		if checkFun != nil {
 			if err := checkFun(m); err != nil {
-				return "", noCleanup, err
+				return "", "", noCleanup, err
 			}
 		}
 
@@ -221,12 +239,12 @@ func (m *MountPoint) Setup(ctx context.Context, mountLabel string, rootIDs idtoo
 		if err := idtools.MkdirAllAndChownNew(m.Source, 0o755, rootIDs); err != nil {
 			if perr, ok := err.(*os.PathError); ok {
 				if perr.Err != syscall.ENOTDIR {
-					return "", noCleanup, errors.Wrapf(err, "error while creating mount source path '%s'", m.Source)
+					return "", "", noCleanup, errors.Wrapf(err, "error while creating mount source path '%s'", m.Source)
 				}
 			}
 		}
 	}
-	return m.Source, noCleanup, nil
+	return m.Source, id, noCleanup, nil
 }
 
 func (m *MountPoint) LiveRestore(ctx context.Context) error {
@@ -241,7 +259,15 @@ func (m *MountPoint) LiveRestore(ctx context.Context) error {
 		return nil
 	}
 
-	id := m.ID
+	// TODO Q: I didn't figure out how `LiveRestore` is used. E.g., in what scenario may it happen that a volume is
+	//         being restored and already has a mount id?
+	//         Could you give more context on when `LiveRestore` is used and what it should do?
+	//        (would it make sense to commit your answer as a docstring for the function?)
+	//
+	// Note: right now `MountPoint.LiveRestore` is the only place that depends on `MountPoint.PrimaryID`. If we fix
+	// that, there's no need to treat primary and secondary mounts separately at all!  :party:
+
+	id := m.PrimaryID
 	if id == "" {
 		id = stringid.GenerateRandomID()
 	}
@@ -250,8 +276,8 @@ func (m *MountPoint) LiveRestore(ctx context.Context) error {
 		return errors.Wrapf(err, "error while restoring volume '%s'", m.Source)
 	}
 
-	m.ID = id
-	m.active++
+	m.PrimaryID = id
+	m.MountedIDs[id] = true
 	return nil
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Context: there used to be the pair of `MountPoint.ID` and
`MountPoint.active` to track mounts of a mountpoint (which there is
usually just one but may be more, e.g., when doing `docker cp`). This is
not conceptually right, as an ID shall correspond to a mount, rather
than a mountpoint, which led to incorrect behavior (e.g., #47964).

Here IDs are reworked such that every mountpoint tracks the list of
mounts, each with its own id, with (up to) one mount being considered
the primary mount (the one used for container operation, rather than
`docker cp`).

As a side effect, now all `MountPoint`s are assigned an ID during setup and are freed of the id when cleaned up (at first, I did this intentionally to simplify the code flow. If you dislike this, I can revert it).

Fixes #47964.

**- How to verify it**

Try mounting a plugin volume in a container and interact with it, as described in #47964. With the patch, mount IDs should be unique for every mount.

**- TODO Qs**

The work on the PR is not finished yet, but I'd like to receive a review anyway: both the code review and, more importantly, discuss if you agree with the conceptual solution.

I have tried starting a discussion in the corresponding issue but didn't get a response (maybe that's because I was pinging the wrong maintainer but I couldn't find a list of maintainers corresponding to certain codebase areas).

- There are a couple of `TODO Q`s in the code (Q for question), where I asked some things I didn't understand and would like a maintainer to shed light and provide more context on;
- Things are fixed for linux but windows version doesn't compile yet;
- Currently, for compatibility with the previous code, `MountPoint`s keep separate track of the primary mount (which is for the normal container operation) and secondary mounts (for `docker cp` or such). This is a little awkward. I propose to get rid of the separation. At the moment, the only obstacle on the way is the `LiveRestore` method which I couldn't figure out very well, so I'm asking for help and context;
- Some `LiveRestore` tests seem to be failing 😢
- I suppose, it would make sense to introduce an integration test for the #47964 issue (which involves mounting a volume provided by a plugin). Could you help me with directions on how to do that?

**- Description for the changelog**
```markdown changelog
todo...
```

**- A picture of a cute animal (not mandatory but encouraged)**
https://youtu.be/Wnc4ybM3-ac
