### PR TITLE
pkg/capabilities move to daemon/internal

### DIFF
--- a/daemon/devices.go
+++ b/daemon/devices.go
@@ -2,7 +2,7 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/pkg/capabilities"
+	"github.com/docker/docker/daemon/internal/capabilities"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 

--- a/daemon/internal/capabilities/caps.go
+++ b/daemon/internal/capabilities/caps.go
@@ -1,5 +1,5 @@
 // Package capabilities allows to generically handle capabilities.
-package capabilities // import "github.com/docker/docker/pkg/capabilities"
+package capabilities
 
 // Set represents a set of capabilities.
 type Set map[string]struct{}

--- a/daemon/internal/capabilities/caps_test.go
+++ b/daemon/internal/capabilities/caps_test.go
@@ -1,4 +1,4 @@
-package capabilities // import "github.com/docker/docker/pkg/capabilities"
+package capabilities
 
 import (
 	"fmt"

--- a/daemon/nvidia_linux.go
+++ b/daemon/nvidia_linux.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd/contrib/nvidia"
-	"github.com/docker/docker/pkg/capabilities"
+	"github.com/docker/docker/daemon/internal/capabilities"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/32989

This package was added in 8f936ae8cf6c39bf3ce21a25b231383dac3212e6 (https://github.com/moby/moby/pull/38828), and never had external consumers. Let's move it internal.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
pkg/capabilities move to daemon/internal
```

**- A picture of a cute animal (not mandatory but encouraged)**

