### PR TITLE
push: improve performance by 3 to 5 times, use gzip level 1 by default

### DIFF
--- a/distribution/push.go
+++ b/distribution/push.go
@@ -107,7 +107,7 @@ func compress(in io.Reader) (io.ReadCloser, chan struct{}) {
 	pipeReader, pipeWriter := io.Pipe()
 	// Use a bufio.Writer to avoid excessive chunking in HTTP request.
 	bufWriter := bufio.NewWriterSize(pipeWriter, compressionBufSize)
-	compressor := gzip.NewWriter(bufWriter)
+	compressor, _ := gzip.NewWriterLevel(bufWriter, 1)
 
 	go func() {
 		_, err := io.Copy(compressor, in)


### PR DESCRIPTION
Hello,

Could you correct the compression level used by docker push?

There has been open issues about this for 11 years and it's not been fixed. The fix is trivial and takes 1 line of code. https://github.com/moby/moby/issues/1266

If you want to do it very cleanly, you could add a setting to allow specifying a compression level 1-9 or 0-9. 
(Level 0 is no compression, it's debatable whether no compression should be allowed because it affects storage on the container registry, docker hub or internal registry).

`docker push` is compressing the image on the fly during the push using gzip.
gzip compression is slow, the default level 6 is very slow and a poor tradeoff performance/compression. 
I see the gzip compression is limited to 12 MB/s on my servers. 
I see `docker push` is taking whole minutes at the ends of builds, with all the time taken by the gzip compression during the push. It's single threaded compression by the way. 
For people working with GPU and ML, images can approach 10 GB of content these days. It takes 10-20 minutes to push an image. All that time is taken by the inefficient gzip compression. 

Rather than the default level of 6, you should use the level 1, that should make compression 3 to 5 times faster at the cost of 1-2% larger image size.
You may want to run a build of docker with this fix and try a few images to see how much differences you get.

I've had a look into the go compressor in the standard library (gzip/compress). 
From what I have gathered, at the time docker was written and the old tickets were discussed, circa 2015, the go compiler was bugged, setting the compression levels did not work. Levels barely made any difference when levels 9-1 are supposed to be 10-100 MB/s on compression (or that order of magnitude). The go standard library was fixed a few years later. 

(There are other improvements to use lz4/zstd or to compress on multiple threads, but that is outside of the scope of this issue, and a much bigger piece of work.)

fixes: 1266


**- Description for the changelog**
```markdown changelog
push: improve performance, use gzip compression level 1 instead of 6
```

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/moby/moby/assets/13528994/18e56ad8-a060-4661-801d-ab645b40fd8b)

