### PR TITLE
api/types: remove aliases for deprecated types

### DIFF
--- a/api/types/container/container.go
+++ b/api/types/container/container.go
@@ -130,20 +130,6 @@ type Summary struct {
 	Mounts          []MountPoint
 }
 
-// ContainerNode stores information about the node that a container
-// is running on.  It's only used by the Docker Swarm standalone API.
-//
-// Deprecated: ContainerNode was used for the classic Docker Swarm standalone API. It will be removed in the next release.
-type ContainerNode struct {
-	ID        string
-	IPAddress string `json:"IP"`
-	Addr      string
-	Name      string
-	Cpus      int
-	Memory    int64
-	Labels    map[string]string
-}
-
 // InspectBase contains response of Engine API GET "/containers/{name:.*}/json"
 // for API version 1.18 and older.
 //
@@ -164,7 +150,6 @@ type InspectBase struct {
 	HostnamePath    string
 	HostsPath       string
 	LogPath         string
-	Node            *ContainerNode `json:",omitempty"` // Deprecated: Node was only propagated by Docker Swarm standalone API. It sill be removed in the next release.
 	Name            string
 	RestartCount    int
 	Driver          string

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -9,11 +9,6 @@ import (
 	"github.com/docker/docker/api/types/storage"
 )
 
-// NetworkCreateRequest is the request message sent to the server for network create call.
-//
-// Deprecated: use [network.CreateRequest].
-type NetworkCreateRequest = network.CreateRequest
-
 // NetworkCreate is the expected body of the "create network" http request message
 //
 // Deprecated: use [network.CreateOptions].

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -8,67 +8,6 @@ import (
 	"github.com/docker/docker/api/types/storage"
 )
 
-// ThrottlingData stores CPU throttling stats of one running container.
-// Not used on Windows.
-//
-// Deprecated: use [container.ThrottlingData].
-type ThrottlingData = container.ThrottlingData
-
-// CPUUsage stores All CPU stats aggregated since container inception.
-//
-// Deprecated: use [container.CPUUsage].
-type CPUUsage = container.CPUUsage
-
-// CPUStats aggregates and wraps all CPU related info of container
-//
-// Deprecated: use [container.CPUStats].
-type CPUStats = container.CPUStats
-
-// MemoryStats aggregates all memory stats since container inception on Linux.
-// Windows returns stats for commit and private working set only.
-//
-// Deprecated: use [container.MemoryStats].
-type MemoryStats = container.MemoryStats
-
-// BlkioStatEntry is one small entity to store a piece of Blkio stats
-// Not used on Windows.
-//
-// Deprecated: use [container.BlkioStatEntry].
-type BlkioStatEntry = container.BlkioStatEntry
-
-// BlkioStats stores All IO service stats for data read and write.
-// This is a Linux specific structure as the differences between expressing
-// block I/O on Windows and Linux are sufficiently significant to make
-// little sense attempting to morph into a combined structure.
-//
-// Deprecated: use [container.BlkioStats].
-type BlkioStats = container.BlkioStats
-
-// StorageStats is the disk I/O stats for read/write on Windows.
-//
-// Deprecated: use [container.StorageStats].
-type StorageStats = container.StorageStats
-
-// NetworkStats aggregates the network stats of one container
-//
-// Deprecated: use [container.NetworkStats].
-type NetworkStats = container.NetworkStats
-
-// PidsStats contains the stats of a container's pids
-//
-// Deprecated: use [container.PidsStats].
-type PidsStats = container.PidsStats
-
-// Stats is Ultimate struct aggregating all types of stats of one container
-//
-// Deprecated: use [container.Stats].
-type Stats = container.Stats
-
-// StatsJSON is newly used Networks
-//
-// Deprecated: use [container.StatsResponse].
-type StatsJSON = container.StatsResponse
-
 // EventsOptions holds parameters to filter events with.
 //
 // Deprecated: use [events.ListOptions].

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -7,14 +7,7 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/storage"
-	"github.com/docker/docker/api/types/volume"
 )
-
-// VolumesPruneReport contains the response for Engine API:
-// POST "/volumes/prune".
-//
-// Deprecated: use [volume.PruneReport].
-type VolumesPruneReport = volume.PruneReport
 
 // NetworkCreateRequest is the request message sent to the server for network create call.
 //

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -9,11 +9,6 @@ import (
 	"github.com/docker/docker/api/types/storage"
 )
 
-// NetworkCreateResponse is the response message sent by the server for network create call.
-//
-// Deprecated: use [network.CreateResponse].
-type NetworkCreateResponse = network.CreateResponse
-
 // NetworkInspectOptions holds parameters to inspect network.
 //
 // Deprecated: use [network.InspectOptions].

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -9,11 +9,6 @@ import (
 	"github.com/docker/docker/api/types/storage"
 )
 
-// NetworkDisconnect represents the data to be used to disconnect a container from the network
-//
-// Deprecated: use [network.DisconnectOptions].
-type NetworkDisconnect = network.DisconnectOptions
-
 // EndpointResource contains network resources allocated and used for a container in a network.
 //
 // Deprecated: use [network.EndpointResource].

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -8,12 +8,6 @@ import (
 	"github.com/docker/docker/api/types/storage"
 )
 
-// ExecStartCheck is a temp struct used by execStart
-// Config fields is part of ExecConfig in runconfig package
-//
-// Deprecated: use [container.ExecStartOptions] or [container.ExecAttachOptions].
-type ExecStartCheck = container.ExecStartOptions
-
 // ContainerExecInspect holds information returned by exec inspect.
 //
 // Deprecated: use [container.ExecInspect].

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -8,12 +8,6 @@ import (
 	"github.com/docker/docker/api/types/storage"
 )
 
-// ExecConfig is a small subset of the Config struct that holds the configuration
-// for the exec feature of docker.
-//
-// Deprecated: use [container.ExecOptions].
-type ExecConfig = container.ExecOptions
-
 // ExecStartCheck is a temp struct used by execStart
 // Config fields is part of ExecConfig in runconfig package
 //

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -3,14 +3,8 @@ package types
 import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/storage"
 )
-
-// ImageSearchOptions holds parameters to search images with.
-//
-// Deprecated: use [registry.SearchOptions].
-type ImageSearchOptions = registry.SearchOptions
 
 // ImageImportSource holds source information for ImageImport
 //

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -4,16 +4,9 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/storage"
 )
-
-// NetworksPruneReport contains the response for Engine API:
-// POST "/networks/prune"
-//
-// Deprecated: use [network.PruneReport].
-type NetworksPruneReport = network.PruneReport
 
 // ExecConfig is a small subset of the Config struct that holds the configuration
 // for the exec feature of docker.

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -9,11 +9,6 @@ import (
 	"github.com/docker/docker/api/types/storage"
 )
 
-// EndpointResource contains network resources allocated and used for a container in a network.
-//
-// Deprecated: use [network.EndpointResource].
-type EndpointResource = network.EndpointResource
-
 // NetworkResource is the body of the "get network" http response message/
 //
 // Deprecated: use [network.Inspect] or [network.Summary] (for list operations).

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -18,12 +18,6 @@ type ContainerJSONBase = container.InspectBase
 // Deprecated: use [container.InspectResponse]. It will be removed in the next release.
 type ContainerJSON = container.InspectResponse
 
-// ContainerNode stores information about the node that a container
-// is running on.  It's only used by the Docker Swarm standalone API.
-//
-// Deprecated: ContainerNode was used for the classic Docker Swarm standalone API. It will be removed in the next release.
-type ContainerNode = container.ContainerNode //nolint:staticcheck // Ignore SA1019: container.ContainerNode is deprecated.
-
 // Container contains response of Engine API:
 // GET "/containers/json"
 //

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -8,11 +8,6 @@ import (
 	"github.com/docker/docker/api/types/storage"
 )
 
-// ContainerExecInspect holds information returned by exec inspect.
-//
-// Deprecated: use [container.ExecInspect].
-type ContainerExecInspect = container.ExecInspect
-
 // ContainersPruneReport contains the response for Engine API:
 // POST "/containers/prune"
 //

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -9,11 +9,6 @@ import (
 	"github.com/docker/docker/api/types/storage"
 )
 
-// NetworkConnect represents the data to be used to connect a container to the network
-//
-// Deprecated: use [network.ConnectOptions].
-type NetworkConnect = network.ConnectOptions
-
 // NetworkDisconnect represents the data to be used to disconnect a container from the network
 //
 // Deprecated: use [network.DisconnectOptions].

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -8,12 +8,6 @@ import (
 	"github.com/docker/docker/api/types/storage"
 )
 
-// ContainersPruneReport contains the response for Engine API:
-// POST "/containers/prune"
-//
-// Deprecated: use [container.PruneReport].
-type ContainersPruneReport = container.PruneReport
-
 // ContainerPathStat is used to encode the header from
 // GET "/containers/{name:.*}/archive"
 // "Name" is the file or directory name.

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -9,11 +9,6 @@ import (
 	"github.com/docker/docker/api/types/storage"
 )
 
-// NetworkListOptions holds parameters to filter the list of networks with.
-//
-// Deprecated: use [network.ListOptions].
-type NetworkListOptions = network.ListOptions
-
 // NetworkCreateResponse is the response message sent by the server for network create call.
 //
 // Deprecated: use [network.CreateResponse].

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -8,12 +8,6 @@ import (
 	"github.com/docker/docker/api/types/storage"
 )
 
-// CopyToContainerOptions holds information
-// about files to copy into a container.
-//
-// Deprecated: use [container.CopyToContainerOptions],
-type CopyToContainerOptions = container.CopyToContainerOptions
-
 // ContainerStats contains response of Engine API:
 // GET "/stats"
 //

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -6,11 +6,6 @@ import (
 	"github.com/docker/docker/api/types/storage"
 )
 
-// ImageImportSource holds source information for ImageImport
-//
-// Deprecated: use [image.ImportSource].
-type ImageImportSource image.ImportSource
-
 // ImageLoadResponse returns information to the client about a load process.
 //
 // Deprecated: use [image.LoadResponse].

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -2,16 +2,10 @@ package types
 
 import (
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/storage"
 )
-
-// EventsOptions holds parameters to filter events with.
-//
-// Deprecated: use [events.ListOptions].
-type EventsOptions = events.ListOptions
 
 // ImageSearchOptions holds parameters to search images with.
 //

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -6,11 +6,6 @@ import (
 	"github.com/docker/docker/api/types/storage"
 )
 
-// ImageLoadResponse returns information to the client about a load process.
-//
-// Deprecated: use [image.LoadResponse].
-type ImageLoadResponse = image.LoadResponse
-
 // ContainerJSONBase contains response of Engine API GET "/containers/{name:.*}/json"
 // for API version 1.18 and older.
 //

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -8,13 +8,6 @@ import (
 	"github.com/docker/docker/api/types/storage"
 )
 
-// ContainerPathStat is used to encode the header from
-// GET "/containers/{name:.*}/archive"
-// "Name" is the file or directory name.
-//
-// Deprecated: use [container.PathStat].
-type ContainerPathStat = container.PathStat
-
 // CopyToContainerOptions holds information
 // about files to copy into a container.
 //

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -8,12 +8,6 @@ import (
 	"github.com/docker/docker/api/types/storage"
 )
 
-// ContainerStats contains response of Engine API:
-// GET "/stats"
-//
-// Deprecated: use [container.StatsResponseReader].
-type ContainerStats = container.StatsResponseReader
-
 // ThrottlingData stores CPU throttling stats of one running container.
 // Not used on Windows.
 //

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -10,12 +10,6 @@ import (
 	"github.com/docker/docker/api/types/volume"
 )
 
-// ImagesPruneReport contains the response for Engine API:
-// POST "/images/prune"
-//
-// Deprecated: use [image.PruneReport].
-type ImagesPruneReport = image.PruneReport
-
 // VolumesPruneReport contains the response for Engine API:
 // POST "/volumes/prune".
 //

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -9,11 +9,6 @@ import (
 	"github.com/docker/docker/api/types/storage"
 )
 
-// NetworkCreate is the expected body of the "create network" http request message
-//
-// Deprecated: use [network.CreateOptions].
-type NetworkCreate = network.CreateOptions
-
 // NetworkListOptions holds parameters to filter the list of networks with.
 //
 // Deprecated: use [network.ListOptions].

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -9,11 +9,6 @@ import (
 	"github.com/docker/docker/api/types/storage"
 )
 
-// NetworkResource is the body of the "get network" http response message/
-//
-// Deprecated: use [network.Inspect] or [network.Summary] (for list operations).
-type NetworkResource = network.Inspect
-
 // NetworksPruneReport contains the response for Engine API:
 // POST "/networks/prune"
 //

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -9,11 +9,6 @@ import (
 	"github.com/docker/docker/api/types/storage"
 )
 
-// NetworkInspectOptions holds parameters to inspect network.
-//
-// Deprecated: use [network.InspectOptions].
-type NetworkInspectOptions = network.InspectOptions
-
 // NetworkConnect represents the data to be used to connect a container to the network
 //
 // Deprecated: use [network.ConnectOptions].


### PR DESCRIPTION
- [x] depends on / stacked on https://github.com/moby/moby/pull/48057


relates to:

- https://github.com/moby/moby/pull/47936
- https://github.com/moby/moby/pull/47921
- https://github.com/moby/moby/pull/47882
- https://github.com/moby/moby/pull/47873
- https://github.com/moby/moby/pull/47921
- https://github.com/moby/moby/pull/47936
- https://github.com/moby/moby/pull/48040
- https://github.com/moby/moby/pull/47936
- https://github.com/moby/moby/pull/48055
- https://github.com/moby/moby/pull/48060



### api/types: remove deprecated ImagesPruneReport

It moved to api/types/image in ecb24afaafa27a2bbbdd22cb2dd169a61ea5f8a4.
This patch removes the temporary alias.

### api/types: remove deprecated VolumesPruneReport

It moved to api/types/volume in 162ef4f8d1f043d93d9079c53d5c5bc0e1c8be46.
This patch removes the temporary alias.

### api/types: remove deprecated NetworkCreateRequest

It moved to api/types/network.CreateRequest in 162ef4f8d1f043d93d9079c53d5c5bc0e1c8be46.
This patch removes the temporary alias.

### api/types: remove deprecated NetworkCreate

It moved to api/types/network.CreateOptions in 162ef4f8d1f043d93d9079c53d5c5bc0e1c8be46.
This patch removes the temporary alias.

### api/types: remove deprecated NetworkListOptions

It moved to api/types/network.ListOptions in f78dac35e596924f131e32f44cfd73455cdd6bed.
This patch removes the temporary alias.

### api/types: remove deprecated NetworkCreateResponse

It moved to api/types/network.CreateResponse in 89624e09e640ff72e8e936cd1fc4e81c02b03655.
This patch removes the temporary alias.

### api/types: remove deprecated NetworkCreateResponse

It moved to api/types/network.CreateResponse in 89624e09e640ff72e8e936cd1fc4e81c02b03655.
This patch removes the temporary alias.


### api/types: remove deprecated NetworkInspectOptions

It moved to api/types/network.InspectOptions in 5bea0c38bc2c851d1a574942624b59825c0c29bb.
This patch removes the temporary alias.

### api/types: remove deprecated NetworkConnect

It moved to api/types/network.ConnectOptions in 245d12175f05e0e40e23cd353762f8577b68ae89.
This patch removes the temporary alias.


### api/types: remove deprecated NetworkDisconnect

It moved to api/types/network.DisconnectOptions in 245d12175f05e0e40e23cd353762f8577b68ae89.
This patch removes the temporary alias.

### api/types: remove deprecated EndpointResource

It moved to api/types/network.EndpointResource in 68bf0e7625119127806418c70c8ffe8aad237e71.
This patch removes the temporary alias.

### api/types: remove deprecated NetworkResource

It's replaced by api/types/network.Inspect and api/types/network.Summary in
68bf0e7625119127806418c70c8ffe8aad237e71. This patch removes the temporary alias.

### api/types: remove deprecated NetworksPruneReport

It moved to api/types/network.PruneReport in e5f9484ab60bea625de33f10a345d29fab369d35.
This patch removes the temporary alias.

### api/types: remove deprecated ExecConfig

It moved to api/types/container.ExecOptions in cd76e3e7f8d07f8a2d102948500fd17e9a45208b.
This patch removes the temporary alias.

### api/types: remove deprecated ExecStartCheck

It's replaced by api/types/container.ExecStartOptions and ExecAttachOptions
in cd76e3e7f8d07f8a2d102948500fd17e9a45208b. This patch removes the temporary
alias.

### api/types: remove deprecated ContainerExecInspect

It moved to api/types/container.ExecInspect in 5b27e715213a5a7e9c3a3c6c0876d4c1334200eb.
This patch removes the temporary alias.

### api/types: remove deprecated ContainersPruneReport

It moved to api/types/container.PruneReport in db2f1acd5d982bbe2c0315d398a4fbb428bfcf9f.
This patch removes the temporary alias.

### api/types: remove deprecated ContainerPathStat

It moved to api/types/container.PathStat in 47d7c9e31dcb5e83e763536afa55937cdf0f2a74.
This patch removes the temporary alias.

### api/types: remove deprecated CopyToContainerOptions

It moved to api/types/container.CopyToContainerOptions in fd1d8f323bf18f942ed0f22163c7cc91492b7b17.
This patch removes the temporary alias.

### api/types: remove deprecated ContainerStats

It moved to api/types/container.StatsResponseReader in 17c3269a370331d32d153d67975501caf6f0f29b.
This patch removes the temporary alias.

### api/types: remove deprecated container stats types

These types were moved to api/types/container in 0a4277abf487c6ecbfaedfcf731bce6140e68678.

This removes the temporary aliases for:

- ThrottlingData
- CPUUsage
- CPUStats
- MemoryStats
- BlkioStatEntry
- BlkioStats
- StorageStats
- NetworkStats
- PidsStats
- Stats
- StatsJSON (moved/renamed to api/types/container.StatsResponse)


### api/types: remove deprecated EventsOptions

It moved to api/types/events.ListOptions in b5f15bc0aaa49a8bd8d6462e70242be3eb0b21aa.
This patch removes the temporary alias.

### api/types: remove deprecated ImageSearchOptions

It moved to api/types/registry.SearchOptions in f6cc76ceb919e7c46f05cd178eb1239d8dd7c493.
This patch removes the temporary alias.

### api/types: remove deprecated ImageSearchOptions

It moved to api/types/registry.SearchOptions in f6cc76ceb919e7c46f05cd178eb1239d8dd7c493.
This patch removes the temporary alias.

### api/types: remove deprecated ImageImportSource

It moved to api/types/image.ImportSource in eb675cce717fd290edf5fb3770cfa9bdf0608b52.
This patch removes the temporary alias.

### api/types: remove deprecated ImageLoadResponse

It moved to api/types/image.LoadResponse in 6c2934f373105e2bd55275ef5277176695fa7769.
This patch removes the temporary alias.

### api/types: remove deprecated ContainerNode, ContainerJSONBase.Node

It was moved and deprecated in 1fc92361190bc77c44d76e68bd55018a29eb74d5
(45876882585554409191c2f3b4089ec8cdee8ed0 for v27.0). This patch removes the
temporary alias and removes the relocated  api/types/container.ContainerNode
as well as the Node field on the api/types/container.Base struct.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
api/types: Remove deprecated aliases:
- ImagesPruneReport
- VolumesPruneReport
- NetworkCreateRequest
- NetworkCreate
- NetworkListOptions
- NetworkCreateResponse
- NetworkCreateResponse
- NetworkInspectOptions
- NetworkConnect
- NetworkDisconnect
- EndpointResource
- NetworkResource
- NetworksPruneReport
- ExecConfig
- ExecStartCheck
- ContainerExecInspect
- ContainersPruneReport
- ContainerPathStat
- CopyToContainerOptions
- ContainerStats
- ImageSearchOptions
- ImageSearchOptions
- ImageImportSource
- ImageLoadResponse
- ContainerNode

api/types: Remove deprecated `container.ContainerNode` and `ContainerJSONBase.Node` field.

```

**- A picture of a cute animal (not mandatory but encouraged)**

