### PR TITLE
api/types/system: remove deprecated Info.ExecutionDriver

### DIFF
--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -81,7 +81,6 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 				nameOnly = append(nameOnly, so.Name)
 			}
 			info.SecurityOptions = nameOnly
-			info.ExecutionDriver = "<not supported>" //nolint:staticcheck // ignore SA1019 (ExecutionDriver is deprecated)
 		}
 		if versions.LessThan(version, "1.39") {
 			if info.KernelVersion == "" {

--- a/api/types/system/info.go
+++ b/api/types/system/info.go
@@ -77,9 +77,6 @@ type Info struct {
 
 	Containerd *ContainerdInfo `json:",omitempty"`
 
-	// Legacy API fields for older API versions.
-	legacyFields
-
 	// Warnings contains a slice of warnings that occurred  while collecting
 	// system information. These warnings are intended to be informational
 	// messages for the user, and are not intended to be parsed / used for
@@ -122,10 +119,6 @@ type ContainerdNamespaces struct {
 	// user-namespaces are enabled and the containerd image-store
 	// is used.
 	Plugins string
-}
-
-type legacyFields struct {
-	ExecutionDriver string `json:",omitempty"` // Deprecated: deprecated since API v1.25, but returned for older versions.
 }
 
 // PluginsInfo is a temp struct holding Plugins name

--- a/integration/system/info_linux_test.go
+++ b/integration/system/info_linux_test.go
@@ -3,11 +3,8 @@
 package system // import "github.com/docker/docker/integration/system"
 
 import (
-	"net/http"
 	"testing"
 
-	"github.com/docker/docker/testutil"
-	req "github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -27,21 +24,4 @@ func TestInfoBinaryCommits(t *testing.T) {
 
 	assert.Check(t, "N/A" != info.RuncCommit.ID)
 	assert.Check(t, is.Equal(info.RuncCommit.Expected, info.RuncCommit.ID))
-}
-
-func TestInfoAPIVersioned(t *testing.T) {
-	ctx := testutil.StartSpan(baseContext, t)
-
-	res, body, err := req.Get(ctx, "/v1.24/info")
-	assert.NilError(t, err)
-	assert.Check(t, is.DeepEqual(res.StatusCode, http.StatusOK))
-
-	b, err := req.ReadBody(body)
-	assert.NilError(t, err)
-
-	// Verify the old response on API 1.24 and older before commit
-	// 6d98e344c7702a8a713cb9e02a19d83a79d3f930.
-	out := string(b)
-	assert.Check(t, is.Contains(out, "ExecutionDriver"))
-	assert.Check(t, is.Contains(out, "not supported"))
 }


### PR DESCRIPTION
The execution-driver was replaced with containerd since docker 1.11 (API v1.23) in 9c4570a958df42d1ad19364b1a8da55b891d850a, after which the value was no longer set. The field was left in the type definition. Commit 1fb1136fecfd761300a38f64ac9178979cc0b270 removed its use from the CLI and [docker/engine-api@39c7d7e] removed it from the API type, followed by an update to the API docs in 3c6ef4c29d28e92ea29816d6117412162d829c60.

Changes to the API types were not pulled into the engine until v1.13, and probably because of that gated it on API version < 1.25 instead of < 1.24 (see 6d98e344c7702a8a713cb9e02a19d83a79d3f930); setting a "not supported" value for older versions.

Based on the above; this field was deprecated in API v1.23, and empty since then. Given that the minimum API version supported by the engine is not v1.24, we can safely remove it.

[docker/engine-api@39c7d7e]: https://github.com/docker/engine-api/commit/39c7d7ec192b065f757ffdb85b36a7b3ede4e10b


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
api/types/system: remove deprecated Info.ExecutionDriver
```

**- A picture of a cute animal (not mandatory but encouraged)**

