### PR TITLE
daemon/logger/journald: add //nolint:unused for readSyncTimeout

### DIFF
--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -62,8 +62,8 @@ type journald struct {
 	// Overrides for unit tests.
 
 	sendToJournal   func(message string, priority journal.Priority, vars map[string]string) error
-	journalReadDir  string //nolint:unused // Referenced in read.go, which has more restrictive build constraints.
-	readSyncTimeout time.Duration
+	journalReadDir  string        //nolint:unused // Referenced in read.go, which has more restrictive build constraints.
+	readSyncTimeout time.Duration //nolint:unused // Referenced in read.go, which has more restrictive build constraints.
 }
 
 func init() {


### PR DESCRIPTION
Same applies to this field as for journalReadDir above it.

    daemon/logger/journald/journald.go:66:2: field `readSyncTimeout` is unused (unused)
        readSyncTimeout time.Duration
        ^

