### PR TITLE
api/types/container: InspectResponse: keep old name for embedded type

### DIFF
--- a/api/types/container/container.go
+++ b/api/types/container/container.go
@@ -91,7 +91,7 @@ type MountPoint struct {
 }
 
 // State stores container's running state
-// it's part of InspectBase and returned by "inspect" command
+// it's part of ContainerJSONBase and returned by "inspect" command
 type State struct {
 	Status     string // String representation of the container state. Can be one of "created", "running", "paused", "restarting", "removing", "exited", or "dead"
 	Running    bool
@@ -130,16 +130,16 @@ type Summary struct {
 	Mounts          []MountPoint
 }
 
-// InspectBase contains response of Engine API GET "/containers/{name:.*}/json"
+// ContainerJSONBase contains response of Engine API GET "/containers/{name:.*}/json"
 // for API version 1.18 and older.
 //
-// TODO(thaJeztah): combine InspectBase and InspectResponse into a single struct.
-// The split between InspectBase (ContainerJSONBase) and InspectResponse (InspectResponse)
+// TODO(thaJeztah): combine ContainerJSONBase and InspectResponse into a single struct.
+// The split between ContainerJSONBase (ContainerJSONBase) and InspectResponse (InspectResponse)
 // was done in commit 6deaa58ba5f051039643cedceee97c8695e2af74 (https://github.com/moby/moby/pull/13675).
 // ContainerJSONBase contained all fields for API < 1.19, and InspectResponse
 // held fields that were added in API 1.19 and up. Given that the minimum
 // supported API version is now 1.24, we no longer use the separate type.
-type InspectBase struct {
+type ContainerJSONBase struct {
 	ID              string `json:"Id"`
 	Created         string
 	Path            string
@@ -167,7 +167,7 @@ type InspectBase struct {
 // InspectResponse is the response for the GET "/containers/{name:.*}/json"
 // endpoint.
 type InspectResponse struct {
-	*InspectBase
+	*ContainerJSONBase
 	Mounts          []MountPoint
 	Config          *Config
 	NetworkSettings *NetworkSettings

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -9,8 +9,8 @@ import (
 // ContainerJSONBase contains response of Engine API GET "/containers/{name:.*}/json"
 // for API version 1.18 and older.
 //
-// Deprecated: use [container.InspectResponse] or [container.InspectBase]. It will be removed in the next release.
-type ContainerJSONBase = container.InspectBase
+// Deprecated: use [container.InspectResponse] or [container.ContainerJSONBase]. It will be removed in the next release.
+type ContainerJSONBase = container.ContainerJSONBase
 
 // ContainerJSON is the response for the GET "/containers/{name:.*}/json"
 // endpoint.

--- a/client/container_inspect_test.go
+++ b/client/container_inspect_test.go
@@ -53,7 +53,7 @@ func TestContainerInspect(t *testing.T) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
 			content, err := json.Marshal(container.InspectResponse{
-				InspectBase: &container.InspectBase{
+				ContainerJSONBase: &container.ContainerJSONBase{
 					ID:    "container_id",
 					Image: "image",
 					Name:  "name",

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -104,14 +104,14 @@ func (daemon *Daemon) ContainerInspectCurrent(ctx context.Context, name string, 
 	}
 
 	return &containertypes.InspectResponse{
-		InspectBase:     base,
-		Mounts:          mountPoints,
-		Config:          ctr.Config,
-		NetworkSettings: networkSettings,
+		ContainerJSONBase: base,
+		Mounts:            mountPoints,
+		Config:            ctr.Config,
+		NetworkSettings:   networkSettings,
 	}, nil
 }
 
-func (daemon *Daemon) getInspectData(daemonCfg *config.Config, container *container.Container) (*containertypes.InspectBase, error) {
+func (daemon *Daemon) getInspectData(daemonCfg *config.Config, container *container.Container) (*containertypes.ContainerJSONBase, error) {
 	// make a copy to play with
 	hostConfig := *container.HostConfig
 
@@ -160,7 +160,7 @@ func (daemon *Daemon) getInspectData(daemonCfg *config.Config, container *contai
 		Health:     containerHealth,
 	}
 
-	contJSONBase := &containertypes.InspectBase{
+	contJSONBase := &containertypes.ContainerJSONBase{
 		ID:           container.ID,
 		Created:      container.Created.Format(time.RFC3339Nano),
 		Path:         container.Path,

--- a/daemon/inspect_linux.go
+++ b/daemon/inspect_linux.go
@@ -7,7 +7,7 @@ import (
 )
 
 // This sets platform-specific fields
-func setPlatformSpecificContainerFields(container *containerpkg.Container, contJSONBase *container.InspectBase) *container.InspectBase {
+func setPlatformSpecificContainerFields(container *containerpkg.Container, contJSONBase *container.ContainerJSONBase) *container.ContainerJSONBase {
 	contJSONBase.AppArmorProfile = container.AppArmorProfile
 	contJSONBase.ResolvConfPath = container.ResolvConfPath
 	contJSONBase.HostnamePath = container.HostnamePath

--- a/daemon/inspect_windows.go
+++ b/daemon/inspect_windows.go
@@ -7,7 +7,7 @@ import (
 )
 
 // This sets platform-specific fields
-func setPlatformSpecificContainerFields(container *containerpkg.Container, contJSONBase *container.InspectBase) *container.InspectBase {
+func setPlatformSpecificContainerFields(container *containerpkg.Container, contJSONBase *container.ContainerJSONBase) *container.ContainerJSONBase {
 	return contJSONBase
 }
 


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/48057

This is a follow-up to 1abc8f6158aa1f27b0270df772b498618f19abbb (https://github.com/moby/moby/pull/48057), which moved the ContainerJSONBase to api/types/container, but also renamed it to container.InspectBase. This field is embedded into the InspectResponse type, which meant that renaming the type also implicitly renamed the field when creating this type from a struct-literal.

While we're planning to merge these types (which would be a breaking change for users constructing it through struct-literals), let's keep it backward-compatible for now (other than deprecating the old names).

We can continue the other changes separately.


**- A picture of a cute animal (not mandatory but encouraged)**

