### PR TITLE
all: switch to Go 1.19 atomics

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - gosec
     - gosimple
     - govet
+    - forbidigo
     - importas
     - ineffassign
     - misspell
@@ -31,6 +32,12 @@ linters-settings:
       - "true"    # some tests use this as expected output
       - "false"   # some tests use this as expected output
       - "root"    # for tests using "ls" output with files owned by "root:root"
+  forbidigo:
+    forbid:
+      - pkg: ^sync/atomic$
+        p: ^atomic\.(Add|CompareAndSwap|Load|Store|Swap).
+        msg: Go 1.19 atomic types should be used instead.
+    analyze-types: true
   importas:
     # Do not allow unaliased imports of aliased packages.
     no-unaliased: true

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -235,7 +235,7 @@ func (i *ImageService) GetImageManifest(ctx context.Context, refOrID string, opt
 
 // size returns the total size of the image's packed resources.
 func (i *ImageService) size(ctx context.Context, desc ocispec.Descriptor, platform platforms.MatchComparer) (int64, error) {
-	var size int64
+	var size atomic.Int64
 
 	cs := i.content
 	handler := containerdimages.LimitManifests(containerdimages.ChildrenHandler(cs), platform, 1)
@@ -248,7 +248,7 @@ func (i *ImageService) size(ctx context.Context, desc ocispec.Descriptor, platfo
 			}
 		}
 
-		atomic.AddInt64(&size, desc.Size)
+		size.Add(desc.Size)
 
 		return children, nil
 	}
@@ -258,7 +258,7 @@ func (i *ImageService) size(ctx context.Context, desc ocispec.Descriptor, platfo
 		return 0, err
 	}
 
-	return size, nil
+	return size.Load(), nil
 }
 
 // resolveDescriptor searches for a descriptor based on the given

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -140,7 +140,7 @@ type Daemon struct {
 	usageVolumes    singleflight.Group[struct{}, []*volume.Volume]
 	usageLayer      singleflight.Group[struct{}, int64]
 
-	pruneRunning int32
+	pruneRunning atomic.Bool
 	hosts        map[string]bool // hosts stores the addresses the daemon is listening on
 	startupDone  chan struct{}
 

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -3,6 +3,7 @@ package images // import "github.com/docker/docker/daemon/images"
 import (
 	"context"
 	"os"
+	"sync/atomic"
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/leases"
@@ -71,7 +72,7 @@ type ImageService struct {
 	eventsService             *daemonevents.Events
 	imageStore                image.Store
 	layerStore                layer.Store
-	pruneRunning              int32
+	pruneRunning              atomic.Bool
 	referenceStore            dockerreference.Store
 	registryService           distribution.RegistryResolver
 	uploadManager             *xfer.LayerUploadManager

--- a/daemon/logger/gcplogs/gcplogging.go
+++ b/daemon/logger/gcplogs/gcplogging.go
@@ -31,7 +31,7 @@ const (
 
 var (
 	// The number of logs the gcplogs driver has dropped.
-	droppedLogs uint64
+	droppedLogs atomic.Uint64
 
 	onGCE bool
 
@@ -187,7 +187,7 @@ func New(info logger.Info) (logger.Logger, error) {
 	// we overflow and every 1000th time after.
 	c.OnError = func(err error) {
 		if err == logging.ErrOverflow {
-			if i := atomic.AddUint64(&droppedLogs, 1); i%1000 == 1 {
+			if i := droppedLogs.Add(1); i%1000 == 1 {
 				log.G(context.TODO()).Errorf("gcplogs driver has dropped %v logs", i)
 			}
 		} else {

--- a/daemon/logger/loggerutils/sharedtemp_test.go
+++ b/daemon/logger/loggerutils/sharedtemp_test.go
@@ -89,7 +89,7 @@ func TestSharedTempFileConverter(t *testing.T) {
 		name := filepath.Join(dir, "test.txt")
 		createFile(t, name, "hi there")
 
-		var conversions int32
+		var conversions atomic.Uint32
 		notify := make(chan chan struct{}, 1)
 		firstConversionStarted := make(chan struct{})
 		notify <- firstConversionStarted
@@ -104,7 +104,7 @@ func TestSharedTempFileConverter(t *testing.T) {
 				default:
 				}
 				<-unblock
-				atomic.AddInt32(&conversions, 1)
+				conversions.Add(1)
 				return copyTransform(strings.ToUpper)(dst, src)
 			},
 		)
@@ -143,7 +143,7 @@ func TestSharedTempFileConverter(t *testing.T) {
 			assert.Check(t, c.Close())
 		}
 
-		assert.Check(t, is.Equal(int32(1), conversions))
+		assert.Check(t, is.Equal(uint32(1), conversions.Load()))
 
 		assert.NilError(t, os.Remove(name))
 		checkDirEmpty(t, dir)

--- a/daemon/logger/ring.go
+++ b/daemon/logger/ring.go
@@ -16,7 +16,7 @@ type RingLogger struct {
 	buffer    *messageRing
 	l         Logger
 	logInfo   Info
-	closeFlag int32
+	closeFlag atomic.Bool
 	wg        sync.WaitGroup
 }
 
@@ -82,11 +82,11 @@ func (r *RingLogger) Name() string {
 }
 
 func (r *RingLogger) closed() bool {
-	return atomic.LoadInt32(&r.closeFlag) == 1
+	return r.closeFlag.Load()
 }
 
 func (r *RingLogger) setClosed() {
-	atomic.StoreInt32(&r.closeFlag, 1)
+	r.closeFlag.Store(true)
 }
 
 // Close closes the logger

--- a/daemon/prune.go
+++ b/daemon/prune.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"regexp"
 	"strconv"
-	"sync/atomic"
 	"time"
 
 	"github.com/containerd/log"
@@ -40,10 +39,10 @@ var (
 
 // ContainersPrune removes unused containers
 func (daemon *Daemon) ContainersPrune(ctx context.Context, pruneFilters filters.Args) (*container.PruneReport, error) {
-	if !atomic.CompareAndSwapInt32(&daemon.pruneRunning, 0, 1) {
+	if !daemon.pruneRunning.CompareAndSwap(false, true) {
 		return nil, errPruneRunning
 	}
-	defer atomic.StoreInt32(&daemon.pruneRunning, 0)
+	defer daemon.pruneRunning.Store(false)
 
 	rep := &container.PruneReport{}
 
@@ -189,10 +188,10 @@ func (daemon *Daemon) clusterNetworksPrune(ctx context.Context, pruneFilters fil
 
 // NetworksPrune removes unused networks
 func (daemon *Daemon) NetworksPrune(ctx context.Context, pruneFilters filters.Args) (*network.PruneReport, error) {
-	if !atomic.CompareAndSwapInt32(&daemon.pruneRunning, 0, 1) {
+	if !daemon.pruneRunning.CompareAndSwap(false, true) {
 		return nil, errPruneRunning
 	}
-	defer atomic.StoreInt32(&daemon.pruneRunning, 0)
+	defer daemon.pruneRunning.Store(false)
 
 	// make sure that only accepted filters have been received
 	err := pruneFilters.Validate(networksAcceptedFilters)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Got rid of all instances of old-style atomic operations which operate on pointers to primitive variables. Added a lint rule to forbid old-style atomic operations in the codebase.

**- How I did it**
I replaced each instance with the most semantically-appropriate Go 1.19 atomic type for the situation, with one exception. The libnetwork diagnostic server was using atomics unsoundly. Most of the variable accesses were synchronized through a mutex, so I just replaced the singular atomic operation with a non-atomic operation, synchronized through the aforementioned mutex.

**- How to verify it**
Unit tests

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

