### PR TITLE
[27.1 backport] rootless: add `Requires=dbus.socket`

### DIFF
--- a/contrib/dockerd-rootless-setuptool.sh
+++ b/contrib/dockerd-rootless-setuptool.sh
@@ -314,6 +314,7 @@ install_systemd() {
 			[Unit]
 			Description=Docker Application Container Engine (Rootless)
 			Documentation=https://docs.docker.com/go/rootless/
+			Requires=dbus.socket
 
 			[Service]
 			Environment=PATH=$BIN:/sbin:/usr/sbin:$PATH


### PR DESCRIPTION
Cherry-pick (clean):
- #48134 
- relates to https://github.com/moby/moby/issues/42793

> **- What I did**
> 
> Added a dependency for dbus.
> 
> On a cgroup v2 host with systemd, dbus is needed to avoid the following error:
> 
> ```
> docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed
> : unable to start container process: unable to apply cgroup configuration: unable to start unit "docker-170a4183e351e69835b82cc3134b97c8cbb0e6d3a6
> 16d5a0fb0ea473075062ad.scope" (properties [{Name:Description Value:"libcontainer container 170a4183e351e69835b82cc3134b97c8cbb0e6d3a616d5a0fb0ea47
> 3075062ad"} {Name:Slice Value:"user.slice"} {Name:Delegate Value:true} {Name:PIDs Value:@au [2872]} {Name:MemoryAccounting Value:true} {Name:CPUAc
> counting Value:true} {Name:IOAccounting Value:true} {Name:TasksAccounting Value:true} {Name:DefaultDependencies Value:false}]): Interactive authen
> tication required.: unknown.
> ```
> 
> **- How I did it**
> 
> See the code
> 
> **- How to verify it**
> 
> ```
> $ systemctl --user stop dbus.socket
> $ systemctl --user is-active dbus.socket
> inactive
> $ systemctl --user start docker
> $ systemctl --user is-active dbus.socket
> active
> ```
> 
> **- Description for the changelog**
> 
> ```
> rootless: add `Requires=dbus.socket`
> ```
> 
> **- A picture of a cute animal (not mandatory but encouraged)** 🐧

