### PR TITLE
daemon/graphdriver: remove Capabilities, CapabilityDriver

### DIFF
--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -94,23 +94,6 @@ type Driver interface {
 	DiffDriver
 }
 
-// Capabilities defines a list of capabilities a driver may implement.
-// These capabilities are not required; however, they do determine how a
-// graphdriver can be used.
-type Capabilities struct {
-	// Flags that this driver is capable of reproducing exactly equivalent
-	// diffs for read-only layers. If set, clients can rely on the driver
-	// for consistent tar streams, and avoid extra processing to account
-	// for potential differences (eg: the layer store's use of tar-split).
-	ReproducesExactDiffs bool
-}
-
-// CapabilityDriver is the interface for layered file system drivers that
-// can report on their Capabilities.
-type CapabilityDriver interface {
-	Capabilities() Capabilities
-}
-
 // DiffGetterDriver is the interface for layered file system drivers that
 // provide a specialized function for getting file contents for tar-split.
 type DiffGetterDriver interface {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/32092
- relates to https://github.com/moby/moby/pull/48072

### daemon/graphdriver: deprecate Capabilities, CapabilityDriver


Capabilities were implemented in aa96c3176bf9dc6e14c6bbcf065ceb3a3870886a, as part of work on an external graphdriver-plugin. Given that none of the builtin graphdrivers use this option, and support for graphdriver- plugins has been removed in 555dac5e14ad4925e020f1a72e8c39b7a316b0dc, we can remove this functionality.

This patch:

- removes the CapabilityDriver interface, which has no implementations
- removes the Capabilities type
- layer: remove layerStore.useTarSplit. This field was previously set through the driver's Capabilities, but always enabled for the builtin graphdrivers,

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

