### PR TITLE
By-default, don't create an iptables rule to checksum SCTP

### DIFF
--- a/libnetwork/drivers/bridge/port_mapping_linux.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"os"
 	"slices"
 	"strconv"
 
@@ -545,7 +546,7 @@ func setPerPortForwarding(b portBinding, ipv iptables.IPVersion, bridgeName stri
 		return err
 	}
 
-	if b.Proto == types.SCTP {
+	if b.Proto == types.SCTP && os.Getenv("DOCKER_IPTABLES_SCTP_CHECKSUM") == "1" {
 		// Linux kernel v4.9 and below enables NETIF_F_SCTP_CRC for veth by
 		// the following commit.
 		// This introduces a problem when combined with a physical NIC without


### PR DESCRIPTION
**- What I did**

- fix https://github.com/moby/moby/issues/47952

For SCTP port mappings, an iptables mangle rule was create to fix the checksum. The code comment says it was done to fix a problem caused by the veth driver reporting NETIF_F_SCTP_CRC since kernel 4.9, when used with NICs that do not support NETIF_F_SCTP_CRC.

But the checksum rule fills in the checksum in the IP header, not an SCTP checksum, so it doesn't seem related. And, quoting from the github issue, "since kernel v4.19, the xt_CHECKSUM.c explicitly states it should only be used for UDP and only in the OUTPUT chain - while docker is using it for SCTP in the PREROUTING chain".

Furthermore, the rule is reported to be causing errors for SCTP between containers.

**- How I did it**

Because we don't entirely understand why the rule exists, it is now only added if the daemon's env has
DOCKER_IPTABLES_SCTP_CHECKSUM=1. If no problems are reported, that escape-hatch and the code to add the rule will be removed in a future release.

**- How to verify it**

Use `iptables -nvL -t mangle` to check that the rule is only created when the env-var `DOCKER_IPTABLES_SCTP_CHECKSUM=1`.

**- Description for the changelog**
```markdown changelog
Removed an `iptables` mangle rule for checksumming SCTP. The rule can be re-enabled by setting
`DOCKER_IPTABLES_SCTP_CHECKSUM=1` in the daemon's environment. This override will be
removed in a future release.
```
