### PR TITLE
Do not allow the daemon to start when MaxDownloadAttempts <=0

### DIFF
--- a/daemon/config/builder_test.go
+++ b/daemon/config/builder_test.go
@@ -25,8 +25,10 @@ func TestBuilderGC(t *testing.T) {
 }`))
 	defer tempFile.Remove()
 	configFile := tempFile.Path()
+	config, err := New()
+	assert.NilError(t, err)
 
-	cfg, err := MergeDaemonConfigurations(&Config{}, nil, configFile)
+	cfg, err := MergeDaemonConfigurations(config, nil, configFile)
 	assert.NilError(t, err)
 	assert.Assert(t, cfg.Builder.GC.Enabled)
 	f1 := filters.NewArgs()

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -659,17 +659,16 @@ func Validate(config *Config) error {
 		}
 	}
 
-	// TODO(thaJeztah) Validations below should not accept "0" to be valid; see Validate() for a more in-depth description of this problem
-	if config.MTU < 0 {
+	if config.MTU <= 0 {
 		return errors.Errorf("invalid default MTU: %d", config.MTU)
 	}
-	if config.MaxConcurrentDownloads < 0 {
+	if config.MaxConcurrentDownloads <= 0 {
 		return errors.Errorf("invalid max concurrent downloads: %d", config.MaxConcurrentDownloads)
 	}
-	if config.MaxConcurrentUploads < 0 {
+	if config.MaxConcurrentUploads <= 0 {
 		return errors.Errorf("invalid max concurrent uploads: %d", config.MaxConcurrentUploads)
 	}
-	if config.MaxDownloadAttempts < 0 {
+	if config.MaxDownloadAttempts <= 0 {
 		return errors.Errorf("invalid max download attempts: %d", config.MaxDownloadAttempts)
 	}
 

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -32,14 +32,19 @@ func makeConfigFile(t *testing.T, content string) string {
 }
 
 func TestDaemonConfigurationNotFound(t *testing.T) {
-	_, err := MergeDaemonConfigurations(&Config{}, nil, "/tmp/foo-bar-baz-docker")
+	config, err := New()
+	assert.NilError(t, err)
+
+	_, err = MergeDaemonConfigurations(config, nil, "/tmp/foo-bar-baz-docker")
 	assert.Check(t, os.IsNotExist(err), "got: %[1]T: %[1]v", err)
 }
 
 func TestDaemonBrokenConfiguration(t *testing.T) {
 	configFile := makeConfigFile(t, `{"Debug": tru`)
+	config, err := New()
+	assert.NilError(t, err)
 
-	_, err := MergeDaemonConfigurations(&Config{}, nil, configFile)
+	_, err = MergeDaemonConfigurations(config, nil, configFile)
 	assert.ErrorContains(t, err, `invalid character ' ' in literal true`)
 }
 
@@ -74,7 +79,9 @@ func TestDaemonConfigurationUnicodeVariations(t *testing.T) {
 			encodedJson, err := tc.encoding.NewEncoder().String(jsonData)
 			assert.NilError(t, err)
 			configFile := makeConfigFile(t, encodedJson)
-			_, err = MergeDaemonConfigurations(&Config{}, nil, configFile)
+			config, err := New()
+			assert.NilError(t, err)
+			_, err = MergeDaemonConfigurations(config, nil, configFile)
 			assert.NilError(t, err)
 		})
 	}
@@ -84,7 +91,9 @@ func TestDaemonConfigurationUnicodeVariations(t *testing.T) {
 // is provided.
 func TestDaemonConfigurationInvalidUnicode(t *testing.T) {
 	configFileBOM := makeConfigFile(t, "\xef\xbb\xbf{\"debug\": true}\xff")
-	_, err := MergeDaemonConfigurations(&Config{}, nil, configFileBOM)
+	config, err := New()
+	assert.NilError(t, err)
+	_, err = MergeDaemonConfigurations(config, nil, configFileBOM)
 	assert.ErrorIs(t, err, encoding.ErrInvalidUTF8)
 
 	configFileNoBOM := makeConfigFile(t, "{\"debug\": true}\xff")
@@ -119,7 +128,9 @@ func TestDaemonConfigurationMergeConflicts(t *testing.T) {
 	flags.Bool("debug", false, "")
 	assert.Check(t, flags.Set("debug", "false"))
 
-	_, err := MergeDaemonConfigurations(&Config{}, flags, configFile)
+	config, err := New()
+	assert.NilError(t, err)
+	_, err = MergeDaemonConfigurations(config, flags, configFile)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -131,14 +142,18 @@ func TestDaemonConfigurationMergeConflicts(t *testing.T) {
 func TestDaemonConfigurationMergeConcurrent(t *testing.T) {
 	configFile := makeConfigFile(t, `{"max-concurrent-downloads": 1}`)
 
-	_, err := MergeDaemonConfigurations(&Config{}, nil, configFile)
+	config, err := New()
+	assert.NilError(t, err)
+	_, err = MergeDaemonConfigurations(config, nil, configFile)
 	assert.NilError(t, err)
 }
 
 func TestDaemonConfigurationMergeConcurrentError(t *testing.T) {
 	configFile := makeConfigFile(t, `{"max-concurrent-downloads": -1}`)
 
-	_, err := MergeDaemonConfigurations(&Config{}, nil, configFile)
+	config, err := New()
+	assert.NilError(t, err)
+	_, err = MergeDaemonConfigurations(config, nil, configFile)
 	assert.ErrorContains(t, err, `invalid max concurrent downloads: -1`)
 }
 
@@ -149,7 +164,9 @@ func TestDaemonConfigurationMergeConflictsWithInnerStructs(t *testing.T) {
 	flags.String("tlscacert", "", "")
 	assert.Check(t, flags.Set("tlscacert", "~/.docker/ca.pem"))
 
-	_, err := MergeDaemonConfigurations(&Config{}, flags, configFile)
+	config, err := New()
+	assert.NilError(t, err)
+	_, err = MergeDaemonConfigurations(config, flags, configFile)
 	assert.ErrorContains(t, err, `the following directives are specified both as a flag and in the configuration file: tlscacert`)
 }
 
@@ -161,33 +178,36 @@ func TestDaemonConfigurationMergeDefaultAddressPools(t *testing.T) {
 	expected := []*ipamutils.NetworkToSplit{{Base: netip.MustParsePrefix("10.123.0.0/16"), Size: 24}}
 
 	t.Run("empty config file", func(t *testing.T) {
-		conf := Config{}
+		conf, err := New()
+		assert.NilError(t, err)
 		flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 		flags.Var(&conf.NetworkConfig.DefaultAddressPools, "default-address-pool", "")
 		assert.Check(t, flags.Set("default-address-pool", "base=10.123.0.0/16,size=24"))
 
-		config, err := MergeDaemonConfigurations(&conf, flags, emptyConfigFile)
+		config, err := MergeDaemonConfigurations(conf, flags, emptyConfigFile)
 		assert.NilError(t, err)
 		assert.DeepEqual(t, config.DefaultAddressPools.Value(), expected, cmpopts.EquateComparable(netip.Prefix{}))
 	})
 
 	t.Run("config file", func(t *testing.T) {
-		conf := Config{}
+		conf, err := New()
+		assert.NilError(t, err)
 		flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 		flags.Var(&conf.NetworkConfig.DefaultAddressPools, "default-address-pool", "")
 
-		config, err := MergeDaemonConfigurations(&conf, flags, configFile)
+		config, err := MergeDaemonConfigurations(conf, flags, configFile)
 		assert.NilError(t, err)
 		assert.DeepEqual(t, config.DefaultAddressPools.Value(), expected, cmpopts.EquateComparable(netip.Prefix{}))
 	})
 
 	t.Run("with conflicting options", func(t *testing.T) {
-		conf := Config{}
+		conf, err := New()
+		assert.NilError(t, err)
 		flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 		flags.Var(&conf.NetworkConfig.DefaultAddressPools, "default-address-pool", "")
 		assert.Check(t, flags.Set("default-address-pool", "base=10.123.0.0/16,size=24"))
 
-		_, err := MergeDaemonConfigurations(&conf, flags, configFile)
+		_, err = MergeDaemonConfigurations(conf, flags, configFile)
 		assert.ErrorContains(t, err, "the following directives are specified both as a flag and in the configuration file")
 		assert.ErrorContains(t, err, "default-address-pools")
 	})
@@ -303,19 +323,18 @@ func TestValidateConfigurationErrors(t *testing.T) {
 			},
 			expectedErr: "invalid max download attempts: -10",
 		},
-		// TODO(thaJeztah) temporarily excluding this test as it assumes defaults are set before validating and applying updated configs
-		/*
-			{
-				name:  "zero max-download-attempts",
-				field: "MaxDownloadAttempts",
-				config: &Config{
-					CommonConfig: CommonConfig{
-						MaxDownloadAttempts: 0,
-					},
+
+		{
+			name:  "zero max-download-attempts",
+			field: "MaxDownloadAttempts",
+			config: &Config{
+				CommonConfig: CommonConfig{
+					MaxDownloadAttempts: 0,
 				},
-				expectedErr: "invalid max download attempts: 0",
 			},
-		*/
+			expectedErr: "invalid max download attempts: 0",
+		},
+
 		{
 			name: "generic resource without =",
 			config: &Config{
@@ -581,8 +600,10 @@ func TestConfigInvalidDNS(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
-			var cfg Config
-			err := json.Unmarshal([]byte(tc.input), &cfg)
+			var cfg *Config
+			cfg, err := New()
+			assert.NilError(t, err)
+			err = json.Unmarshal([]byte(tc.input), &cfg)
 			assert.Check(t, is.Error(err, tc.expectedErr))
 		})
 	}


### PR DESCRIPTION
**- What I did**

Fixed regression that allows the daemon to be started with max-download-attempts=0 mtu=0 max-concurrent-downloads=0 or max-concurrent-uploads=0

Modified existing test cases to use default initalizer New()

**- How I did it**
Modified config.go

**- How to verify it**
Start a moby container 
`make BIND_DIR=. shell`

**Start the daemon with --max-download-attempts=0**
```
./hack/make.sh binary
make install
/usr/local/bin/dockerd --max-download-attempts=0
```
<img width="1346" alt="Screenshot 2024-06-25 at 11 14 03 AM" src="https://github.com/moby/moby/assets/347096/ff00f957-5bc9-4f29-a633-6eef4a644ae8">

```
mv /etc/docker/daemon.json /etc/docker/daemon.json.bak
/usr/local/bin/dockerd --max-download-attempts=0
```

**Move the daemon.json file temporarily start the daemon again with --max-download-attempts=0**
<img width="1347" alt="Screenshot 2024-06-25 at 11 17 13 AM" src="https://github.com/moby/moby/assets/347096/7c26b38e-641f-4a77-873d-92acc38db9fd">


**- Description for the changelog**

```
Do not allow the daemon to start when MaxDownloadAttempts <=0 fixes regression #44921
```

