### PR TITLE
api/images/create: Allow creating image from passed OCI index 

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -3,7 +3,7 @@ package api // import "github.com/docker/docker/api"
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of the current REST API.
-	DefaultVersion = "1.46"
+	DefaultVersion = "1.47"
 
 	// MinSupportedAPIVersion is the minimum API version that can be supported
 	// by the API server, specified as "major.minor". Note that the daemon

--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -28,6 +28,7 @@ type imageBackend interface {
 	GetImage(ctx context.Context, refOrID string, options backend.GetImageOpts) (*dockerimage.Image, error)
 	TagImage(ctx context.Context, id dockerimage.ID, newRef reference.Named) error
 	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*image.PruneReport, error)
+	ImageCreateFromJSON(ctx context.Context, ref reference.NamedTagged, jsonReader io.Reader) (ocispec.Descriptor, error)
 }
 
 type importExportBackend interface {

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -2,6 +2,7 @@ package image // import "github.com/docker/docker/api/server/router/image"
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -60,6 +61,33 @@ func (ir *imageRouter) postImagesCreate(ctx context.Context, w http.ResponseWrit
 			}
 			platform = &sp
 		}
+	}
+
+	if _, ok := r.Form["fromJSON"]; ok {
+		defer r.Body.Close()
+
+		if versions.LessThan(version, "1.47") {
+			return errdefs.InvalidParameter(errors.New("fromJSON is not supported in this API version"))
+		}
+
+		if img != "" {
+			return errdefs.InvalidParameter(errors.New("fromManifests and fromImage cannot be used together"))
+		}
+
+		tagRef, err := httputils.RepoTagReference(repo, tag)
+		if err != nil {
+			return errdefs.InvalidParameter(err)
+		}
+
+		desc, err := ir.backend.ImageCreateFromJSON(ctx, tagRef, r.Body)
+		if err != nil {
+			if !output.Flushed() {
+				return err
+			}
+			_, _ = output.Write(streamformatter.FormatError(err))
+		}
+
+		return json.NewEncoder(output).Encode(desc)
 	}
 
 	if img != "" { // pull

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8879,9 +8879,12 @@ paths:
         - "application/octet-stream"
       produces:
         - "application/json"
+        - "application/vnd.oci.descriptor.v1+json"
       responses:
         200:
           description: "no error"
+        201:
+          description: "returned when image is created (when fromJSON is used), response body will be an OCI descriptor"
         404:
           description: "repository does not exist or no read access"
           schema:
@@ -8894,6 +8897,10 @@ paths:
         - name: "fromImage"
           in: "query"
           description: "Name of the image to pull. The name may include a tag or digest. This parameter may only be used when pulling an image. The pull is cancelled if the HTTP connection is closed."
+          type: "string"
+        - name: "fromJSON"
+          in: "query"
+          description: "OCI Index JSON (application/vnd.oci.image.index.v1+json) of the image to be created."
           type: "string"
         - name: "fromSrc"
           in: "query"

--- a/client/interface.go
+++ b/client/interface.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
@@ -91,6 +92,7 @@ type ImageAPIClient interface {
 	BuildCachePrune(ctx context.Context, opts types.BuildCachePruneOptions) (*types.BuildCachePruneReport, error)
 	BuildCancel(ctx context.Context, id string) error
 	ImageCreate(ctx context.Context, parentReference string, options image.CreateOptions) (io.ReadCloser, error)
+	ImageCreateFromOCIIndex(ctx context.Context, ref reference.NamedTagged, index ocispec.Index) (ocispec.Descriptor, error)
 	ImageHistory(ctx context.Context, image string) ([]image.HistoryResponseItem, error)
 	ImageImport(ctx context.Context, source image.ImportSource, ref string, options image.ImportOptions) (io.ReadCloser, error)
 	ImageInspectWithRaw(ctx context.Context, image string) (image.InspectResponse, []byte, error)

--- a/daemon/containerd/image_create.go
+++ b/daemon/containerd/image_create.go
@@ -1,0 +1,47 @@
+package containerd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/containerd/containerd/images"
+	containerdimages "github.com/containerd/containerd/images"
+	"github.com/distribution/reference"
+	"github.com/docker/docker/errdefs"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// ImageCreateFromJSON parses the JSON stream as an OCI index and creates an image from it.
+// Currently, only OCI indexes are supported.
+func (i *ImageService) ImageCreateFromJSON(ctx context.Context, ref reference.NamedTagged, jsonReader io.Reader) (ocispec.Descriptor, error) {
+	var ociIndex ocispec.Index
+	if err := json.NewDecoder(jsonReader).Decode(&ociIndex); err != nil {
+		return ocispec.Descriptor{}, errdefs.InvalidParameter(fmt.Errorf("failed to decode JSON: %w", err))
+	}
+
+	if !containerdimages.IsIndexType(ociIndex.MediaType) {
+		return ocispec.Descriptor{}, errdefs.InvalidParameter(errors.New("JSON is not an OCI index"))
+	}
+
+	if len(ociIndex.Manifests) == 0 {
+		return ocispec.Descriptor{}, errdefs.InvalidParameter(errors.New("refusing to create an empty image"))
+	}
+
+	newImg := images.Image{
+		Name:      ref.String(),
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	indexDesc, err := storeJson(ctx, i.content, ociIndex.MediaType, ociIndex, nil)
+	if err != nil {
+		return ocispec.Descriptor{}, errdefs.System(fmt.Errorf("failed to write modified image target: %w", err))
+	}
+	newImg.Target = indexDesc
+
+	return indexDesc, i.forceCreateImage(ctx, newImg)
+}

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -43,6 +43,7 @@ type ImageService interface {
 	ImageHistory(ctx context.Context, name string) ([]*imagetype.HistoryResponseItem, error)
 	CommitImage(ctx context.Context, c backend.CommitConfig) (image.ID, error)
 	SquashImage(id, parent string) (string, error)
+	ImageCreateFromJSON(ctx context.Context, ref reference.NamedTagged, jsonReader io.Reader) (ocispec.Descriptor, error)
 
 	// Containerd related methods
 

--- a/daemon/images/image_create.go
+++ b/daemon/images/image_create.go
@@ -1,0 +1,16 @@
+package images
+
+import (
+	"context"
+	"io"
+
+	"errors"
+
+	"github.com/distribution/reference"
+	"github.com/docker/docker/errdefs"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func (i *ImageService) ImageCreateFromJSON(ctx context.Context, ref reference.NamedTagged, jsonReader io.Reader) (ocispec.Descriptor, error) {
+	return ocispec.Descriptor{}, errdefs.NotImplemented(errors.New("not supported in graphdriver backed image store"))
+}

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -13,6 +13,14 @@ keywords: "API, Docker, rcli, REST, documentation"
      will be rejected.
 -->
 
+## v1.47 API changes
+
+[Docker Engine API v1.47](https://docs.docker.com/engine/api/v1.47/) documentation
+
+* `POST /images/create` endpoint now supports `fromJSON` field parameter to
+  specify that the request body will contain an OCI image index of the image.
+  WARNING: This is experimental and may change at any time without any backward
+  compatibility.
 
 ## v1.46 API changes
 


### PR DESCRIPTION
- related to: https://github.com/moby/moby/pull/47678#issuecomment-2211141501

This will allow to implement `docker image convert` on client/CLI side.



**- What I did**

Add `fromJSON` parameter that specifies that the request body contains an OCI index JSON that should be used as an image target.

Only supported by containerd image service backend.

**- Description for the changelog**

```markdown changelog
experimental: `POST /images/create` endpoint now supports `fromJSON` field parameter to specify that the request body will contain an OCI image index of the image.
```

**- A picture of a cute animal (not mandatory but encouraged)**

