### PR TITLE
[27.1 backport] docs/api: Add missing `

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -9563,7 +9563,7 @@ paths:
 
         Containers report these events: `attach`, `commit`, `copy`, `create`, `destroy`, `detach`, `die`, `exec_create`, `exec_detach`, `exec_start`, `exec_die`, `export`, `health_status`, `kill`, `oom`, `pause`, `rename`, `resize`, `restart`, `start`, `stop`, `top`, `unpause`, `update`, and `prune`
 
-        Images report these events: `create, `delete`, `import`, `load`, `pull`, `push`, `save`, `tag`, `untag`, and `prune`
+        Images report these events: `create`, `delete`, `import`, `load`, `pull`, `push`, `save`, `tag`, `untag`, and `prune`
 
         Volumes report these events: `create`, `mount`, `unmount`, `destroy`, and `prune`
 

--- a/docs/api/v1.46.yaml
+++ b/docs/api/v1.46.yaml
@@ -9563,7 +9563,7 @@ paths:
 
         Containers report these events: `attach`, `commit`, `copy`, `create`, `destroy`, `detach`, `die`, `exec_create`, `exec_detach`, `exec_start`, `exec_die`, `export`, `health_status`, `kill`, `oom`, `pause`, `rename`, `resize`, `restart`, `start`, `stop`, `top`, `unpause`, `update`, and `prune`
 
-        Images report these events: `create, `delete`, `import`, `load`, `pull`, `push`, `save`, `tag`, `untag`, and `prune`
+        Images report these events: `create`, `delete`, `import`, `load`, `pull`, `push`, `save`, `tag`, `untag`, and `prune`
 
         Volumes report these events: `create`, `mount`, `unmount`, `destroy`, and `prune`
 


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/48154

