### PR TITLE
use lazyregexp to compile regexes on first use

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,6 +61,9 @@ linters-settings:
       - pkg: ^sync/atomic$
         p: ^atomic\.(Add|CompareAndSwap|Load|Store|Swap).
         msg: Go 1.19 atomic types should be used instead.
+      - pkg: ^regexp$
+        p: ^regexp\.MustCompile
+        msg: Use internal/lazyregexp.New instead.
       - pkg: github.com/vishvananda/netlink$
         p: ^netlink\.(Handle\.)?(AddrList|BridgeVlanList|ChainList|ClassList|ConntrackTableList|ConntrackDeleteFilter$|ConntrackDeleteFilters|DevLinkGetDeviceList|DevLinkGetAllPortList|DevlinkGetDeviceParams|FilterList|FouList|GenlFamilyList|GTPPDPList|LinkByName|LinkByAlias|LinkList|LinkSubscribeWithOptions|NeighList$|NeighProxyList|NeighListExecute|NeighSubscribeWithOptions|LinkGetProtinfo|QdiscList|RdmaLinkList|RdmaLinkByName|RdmaLinkDel|RouteList|RouteListFilteredIter|RuleListFiltered$|RouteSubscribeWithOptions|RuleList$|RuleListFiltered|SocketGet|SocketDiagTCPInfo|SocketDiagTCP|SocketDiagUDPInfo|SocketDiagUDP|UnixSocketDiagInfo|UnixSocketDiag|VDPAGetDevConfigList|VDPAGetDevList|VDPAGetMGMTDevList|XfrmPolicyList|XfrmStateList)
         msg: Use internal nlwrap package for EINTR handling.
@@ -176,6 +179,18 @@ issues:
       path: _test\.go
       linters:
         - govet
+    - text: 'use of `regexp.MustCompile` forbidden'
+      path: _test\.go
+      linters:
+        - forbidigo
+    - text: 'use of `regexp.MustCompile` forbidden'
+      path: "internal/lazyregexp"
+      linters:
+        - forbidigo
+    - text: 'use of `regexp.MustCompile` forbidden'
+      path: "libnetwork/cmd/networkdb-test/dbclient"
+      linters:
+        - forbidigo
 
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-issues-per-linter: 0

--- a/builder/dockerfile/dispatchers_windows.go
+++ b/builder/dockerfile/dispatchers_windows.go
@@ -6,15 +6,15 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/internal/lazyregexp"
 	"github.com/docker/docker/pkg/system"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 )
 
-var pattern = regexp.MustCompile(`^[a-zA-Z]:\.$`)
+var pattern = lazyregexp.New(`^[a-zA-Z]:\.$`)
 
 // normalizeWorkdir normalizes a user requested working directory in a
 // platform semantically consistent way.

--- a/builder/remotecontext/remote.go
+++ b/builder/remotecontext/remote.go
@@ -7,9 +7,9 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"regexp"
 
 	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/internal/lazyregexp"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/pkg/errors"
 )
@@ -20,7 +20,7 @@ const maxPreambleLength = 100
 
 const acceptableRemoteMIME = `(?:application/(?:(?:x\-)?tar|octet\-stream|((?:x\-)?(?:gzip|bzip2?|xz)))|(?:text/plain))`
 
-var mimeRe = regexp.MustCompile(acceptableRemoteMIME)
+var mimeRe = lazyregexp.New(acceptableRemoteMIME)
 
 // downloadRemote context from a url and returns it, along with the parsed content type
 func downloadRemote(remoteURL string) (string, io.ReadCloser, error) {

--- a/builder/remotecontext/urlutil/urlutil.go
+++ b/builder/remotecontext/urlutil/urlutil.go
@@ -6,13 +6,14 @@
 package urlutil // import "github.com/docker/docker/builder/remotecontext/urlutil"
 
 import (
-	"regexp"
 	"strings"
+
+	"github.com/docker/docker/internal/lazyregexp"
 )
 
 // urlPathWithFragmentSuffix matches fragments to use as Git reference and build
 // context from the Git repository. See IsGitURL for details.
-var urlPathWithFragmentSuffix = regexp.MustCompile(`\.git(?:#.+)?$`)
+var urlPathWithFragmentSuffix = lazyregexp.New(`\.git(?:#.+)?$`)
 
 // IsURL returns true if the provided str is an HTTP(S) URL by checking if it
 // has a http:// or https:// scheme. No validation is performed to verify if the

--- a/client/utils.go
+++ b/client/utils.go
@@ -4,14 +4,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"regexp"
 
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/internal/lazyregexp"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-var headerRegexp = regexp.MustCompile(`\ADocker/.+\s\((.+)\)\z`)
+var headerRegexp = lazyregexp.New(`\ADocker/.+\s\((.+)\)\z`)
 
 // getDockerOS returns the operating system based on the server header from the daemon.
 func getDockerOS(serverHeader string) string {

--- a/daemon/events/testutils/testutils.go
+++ b/daemon/events/testutils/testutils.go
@@ -2,25 +2,24 @@ package testutils // import "github.com/docker/docker/daemon/events/testutils"
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types/events"
 	timetypes "github.com/docker/docker/api/types/time"
+	"github.com/docker/docker/internal/lazyregexp"
 )
 
-var (
+const (
 	reTimestamp  = `(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{9}(:?(:?(:?-|\+)\d{2}:\d{2})|Z))`
 	reEventType  = `(?P<eventType>\w+)`
 	reAction     = `(?P<action>\w+)`
 	reID         = `(?P<id>[^\s]+)`
 	reAttributes = `(\s\((?P<attributes>[^\)]+)\))?`
-	reString     = fmt.Sprintf(`\A%s\s%s\s%s\s%s%s\z`, reTimestamp, reEventType, reAction, reID, reAttributes)
-
-	// eventCliRegexp is a regular expression that matches all possible event outputs in the cli
-	eventCliRegexp = regexp.MustCompile(reString)
 )
+
+// eventCliRegexp is a regular expression that matches all possible event outputs in the cli
+var eventCliRegexp = lazyregexp.New(fmt.Sprintf(`\A%s\s%s\s%s\s%s%s\z`, reTimestamp, reEventType, reAction, reID, reAttributes))
 
 // ScanMap turns an event string like the default ones formatted in the cli output
 // and turns it into map.

--- a/daemon/logger/journald/internal/fake/sender.go
+++ b/daemon/logger/journald/internal/fake/sender.go
@@ -15,13 +15,13 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"regexp"
 	"strconv"
 	"testing"
 	"time"
 
 	"code.cloudfoundry.org/clock"
 	"github.com/coreos/go-systemd/v22/journal"
+	"github.com/docker/docker/internal/lazyregexp"
 	"github.com/google/uuid"
 	"gotest.tools/v3/assert"
 
@@ -109,7 +109,7 @@ func NewT(t *testing.T, outpath string) *Sender {
 	return s
 }
 
-var validVarName = regexp.MustCompile("^[A-Z0-9][A-Z0-9_]*$")
+var validVarName = lazyregexp.New("^[A-Z0-9][A-Z0-9_]*$")
 
 // Send is a drop-in replacement for
 // github.com/coreos/go-systemd/v22/journal.Send.

--- a/daemon/names/names.go
+++ b/daemon/names/names.go
@@ -1,9 +1,9 @@
 package names // import "github.com/docker/docker/daemon/names"
 
-import "regexp"
+import "github.com/docker/docker/internal/lazyregexp"
 
 // RestrictedNameChars collects the characters allowed to represent a name, normally used to validate container and volume names.
 const RestrictedNameChars = `[a-zA-Z0-9][a-zA-Z0-9_.-]`
 
 // RestrictedNamePattern is a regular expression to validate names against the collection of restricted characters.
-var RestrictedNamePattern = regexp.MustCompile(`^` + RestrictedNameChars + `+$`)
+var RestrictedNamePattern = lazyregexp.New(`^` + RestrictedNameChars + `+$`)

--- a/daemon/prune.go
+++ b/daemon/prune.go
@@ -2,7 +2,6 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"context"
-	"regexp"
 	"strconv"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 	timetypes "github.com/docker/docker/api/types/time"
 	networkSettings "github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/internal/lazyregexp"
 	"github.com/docker/docker/libnetwork"
 	"github.com/pkg/errors"
 )
@@ -136,6 +136,8 @@ func (daemon *Daemon) localNetworksPrune(ctx context.Context, pruneFilters filte
 	return rep
 }
 
+var networkIsInUse = lazyregexp.New(`network ([[:alnum:]]+) is in use`)
+
 // clusterNetworksPrune removes unused cluster networks
 func (daemon *Daemon) clusterNetworksPrune(ctx context.Context, pruneFilters filters.Args) (*network.PruneReport, error) {
 	rep := &network.PruneReport{}
@@ -152,7 +154,7 @@ func (daemon *Daemon) clusterNetworksPrune(ctx context.Context, pruneFilters fil
 	if err != nil {
 		return rep, err
 	}
-	networkIsInUse := regexp.MustCompile(`network ([[:alnum:]]+) is in use`)
+
 	for _, nw := range networks {
 		select {
 		case <-ctx.Done():

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
+	"github.com/docker/docker/internal/lazyregexp"
 	"github.com/opencontainers/go-digest"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -26,8 +27,8 @@ const (
 )
 
 var (
-	pushDigestRegex = regexp.MustCompile(`[\S]+: digest: ([\S]+) size: [0-9]+`)
-	digestRegex     = regexp.MustCompile(`Digest: ([\S]+)`)
+	pushDigestRegex = lazyregexp.New(`[\S]+: digest: ([\S]+) size: [0-9]+`)
+	digestRegex     = lazyregexp.New(`Digest: ([\S]+)`)
 )
 
 func setupImage(c *testing.T) (digest.Digest, error) {

--- a/internal/lazyregexp/lazyregexp.go
+++ b/internal/lazyregexp/lazyregexp.go
@@ -1,0 +1,90 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Code below was largely copied from golang.org/x/mod@v0.22;
+// https://github.com/golang/mod/blob/v0.22.0/internal/lazyregexp/lazyre.go
+// with some additional methods added.
+
+// Package lazyregexp is a thin wrapper over regexp, allowing the use of global
+// regexp variables without forcing them to be compiled at init.
+package lazyregexp
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// Regexp is a wrapper around [regexp.Regexp], where the underlying regexp will be
+// compiled the first time it is needed.
+type Regexp struct {
+	str  string
+	once sync.Once
+	rx   *regexp.Regexp
+}
+
+func (r *Regexp) re() *regexp.Regexp {
+	r.once.Do(r.build)
+	return r.rx
+}
+
+func (r *Regexp) build() {
+	r.rx = regexp.MustCompile(r.str)
+	r.str = ""
+}
+
+func (r *Regexp) FindSubmatch(s []byte) [][]byte {
+	return r.re().FindSubmatch(s)
+}
+
+func (r *Regexp) FindAllStringSubmatch(s string, n int) [][]string {
+	return r.re().FindAllStringSubmatch(s, n)
+}
+
+func (r *Regexp) FindStringSubmatch(s string) []string {
+	return r.re().FindStringSubmatch(s)
+}
+
+func (r *Regexp) FindStringSubmatchIndex(s string) []int {
+	return r.re().FindStringSubmatchIndex(s)
+}
+
+func (r *Regexp) ReplaceAllString(src, repl string) string {
+	return r.re().ReplaceAllString(src, repl)
+}
+
+func (r *Regexp) FindString(s string) string {
+	return r.re().FindString(s)
+}
+
+func (r *Regexp) FindAllString(s string, n int) []string {
+	return r.re().FindAllString(s, n)
+}
+
+func (r *Regexp) MatchString(s string) bool {
+	return r.re().MatchString(s)
+}
+
+func (r *Regexp) ReplaceAllStringFunc(src string, repl func(string) string) string {
+	return r.re().ReplaceAllStringFunc(src, repl)
+}
+
+func (r *Regexp) SubexpNames() []string {
+	return r.re().SubexpNames()
+}
+
+var inTest = len(os.Args) > 0 && strings.HasSuffix(strings.TrimSuffix(os.Args[0], ".exe"), ".test")
+
+// New creates a new lazy regexp, delaying the compiling work until it is first
+// needed. If the code is being run as part of tests, the regexp compiling will
+// happen immediately.
+func New(str string) *Regexp {
+	lr := &Regexp{str: str}
+	if inTest {
+		// In tests, always compile the regexps early.
+		lr.re()
+	}
+	return lr
+}

--- a/internal/lazyregexp/lazyregexp_test.go
+++ b/internal/lazyregexp/lazyregexp_test.go
@@ -1,0 +1,23 @@
+package lazyregexp
+
+import (
+	"testing"
+)
+
+func TestCompileOnce(t *testing.T) {
+	t.Run("invalid regexp", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("expected a panic")
+			}
+		}()
+		_ = New("[")
+	})
+	t.Run("valid regexp", func(t *testing.T) {
+		re := New("[a-z]")
+		ok := re.MatchString("hello")
+		if !ok {
+			t.Errorf("expected a match")
+		}
+	})
+}

--- a/internal/testutils/networking/iptables.go
+++ b/internal/testutils/networking/iptables.go
@@ -2,12 +2,13 @@ package networking
 
 import (
 	"os/exec"
-	"regexp"
 	"testing"
+
+	"github.com/docker/docker/internal/lazyregexp"
 )
 
 // Find the policy in, for example "Chain FORWARD (policy ACCEPT)".
-var rePolicy = regexp.MustCompile("policy ([A-Z]+)")
+var rePolicy = lazyregexp.New("policy ([A-Z]+)")
 
 // SetFilterForwardPolicies sets the default policy for the FORWARD chain in
 // the filter tables for both IPv4 and IPv6. The original policy is restored

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -2,9 +2,9 @@ package oci // import "github.com/docker/docker/oci"
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 
+	"github.com/docker/docker/internal/lazyregexp"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -15,7 +15,7 @@ import (
 // that *only* passes `a` as value: `echo a > /sys/fs/cgroup/1/devices.allow, which would be
 // the "implicit" equivalent of "a *:* rwm". Source-code also looks to confirm this, and returns
 // early for "a" (all); https://github.com/torvalds/linux/blob/v5.10/security/device_cgroup.c#L614-L642
-var deviceCgroupRuleRegex = regexp.MustCompile("^([acb]) ([0-9]+|\\*):([0-9]+|\\*) ([rwm]{1,3})$") //nolint: gosimple
+var deviceCgroupRuleRegex = lazyregexp.New("^([acb]) ([0-9]+|\\*):([0-9]+|\\*) ([rwm]{1,3})$") //nolint: gosimple
 
 // SetCapabilities sets the provided capabilities on the spec
 // All capabilities are added if privileged is true.

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -4,15 +4,15 @@ import (
 	"fmt"
 	"net"
 	"path"
-	"regexp"
 	"strings"
 
+	"github.com/docker/docker/internal/lazyregexp"
 	"github.com/docker/go-units"
 )
 
 var (
-	alphaRegexp  = regexp.MustCompile(`[a-zA-Z]`)
-	domainRegexp = regexp.MustCompile(`^(:?(:?[a-zA-Z0-9]|(:?[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9]))(:?\.(:?[a-zA-Z0-9]|(:?[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])))*)\.?\s*$`)
+	alphaRegexp  = lazyregexp.New(`[a-zA-Z]`)
+	domainRegexp = lazyregexp.New(`^(:?(:?[a-zA-Z0-9]|(:?[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9]))(:?\.(:?[a-zA-Z0-9]|(:?[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])))*)\.?\s*$`)
 )
 
 // ListOpts holds a list of values and a validation function.

--- a/pkg/idtools/usergroupadd_linux.go
+++ b/pkg/idtools/usergroupadd_linux.go
@@ -3,11 +3,12 @@ package idtools // import "github.com/docker/docker/pkg/idtools"
 import (
 	"fmt"
 	"os/exec"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/docker/docker/internal/lazyregexp"
 )
 
 // add a user and/or group to Linux /etc/passwd, /etc/group using standard
@@ -18,7 +19,7 @@ import (
 var (
 	once        sync.Once
 	userCommand string
-	idOutRegexp = regexp.MustCompile(`uid=([0-9]+).*gid=([0-9]+)`)
+	idOutRegexp = lazyregexp.New(`uid=([0-9]+).*gid=([0-9]+)`)
 )
 
 const (

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -19,6 +18,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/internal/containerfs"
+	"github.com/docker/docker/internal/lazyregexp"
 	"github.com/docker/docker/pkg/authorization"
 	"github.com/docker/docker/pkg/ioutils"
 	v2 "github.com/docker/docker/plugin/v2"
@@ -35,7 +35,7 @@ const (
 	rootFSFileName = "rootfs"
 )
 
-var validFullID = regexp.MustCompile(`^([a-f0-9]{64})$`)
+var validFullID = lazyregexp.New(`^([a-f0-9]{64})$`)
 
 // Executor is the interface that the plugin manager uses to interact with for starting/stopping plugins
 type Executor interface {

--- a/registry/config.go
+++ b/registry/config.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"net"
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/internal/lazyregexp"
 )
 
 // ServiceOptions holds command line options.
@@ -57,7 +57,7 @@ var (
 	}
 
 	emptyServiceConfig, _ = newServiceConfig(ServiceOptions{})
-	validHostPortRegex    = regexp.MustCompile(`^` + reference.DomainRegexp.String() + `$`)
+	validHostPortRegex    = lazyregexp.New(`^` + reference.DomainRegexp.String() + `$`)
 
 	// certsDir is used to override defaultCertsDir.
 	certsDir string

--- a/testutil/environment/clean.go
+++ b/testutil/environment/clean.go
@@ -2,7 +2,6 @@ package environment // import "github.com/docker/docker/testutil/environment"
 
 import (
 	"context"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/internal/lazyregexp"
 	"go.opentelemetry.io/otel"
 	"gotest.tools/v3/assert"
 )
@@ -63,7 +63,8 @@ func getPausedContainers(ctx context.Context, t testing.TB, client client.Contai
 	return containers
 }
 
-var alreadyExists = regexp.MustCompile(`Error response from daemon: removal of container (\w+) is already in progress`)
+// FIXME(thaJeztah): can we rewrite this check to not do string-matching, and instead detect error-type?
+var alreadyExists = lazyregexp.New(`Error response from daemon: removal of container (\w+) is already in progress`)
 
 func deleteAllContainers(ctx context.Context, t testing.TB, apiclient client.ContainerAPIClient, protectedContainers map[string]struct{}) {
 	t.Helper()

--- a/volume/mounts/lcow_parser.go
+++ b/volume/mounts/lcow_parser.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"path"
-	"regexp"
 	"strings"
 
 	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/internal/lazyregexp"
 )
 
 // NewLCOWParser creates a parser with Linux Containers on Windows semantics.
@@ -28,8 +28,8 @@ func NewLCOWParser() Parser {
 const rxLCOWDestination = `(?P<destination>/(?:[^\\/:*?"<>\r\n]+[/]?)*)`
 
 var (
-	lcowMountDestinationRegex = regexp.MustCompile(`^` + rxLCOWDestination + `$`)
-	lcowSplitRawSpec          = regexp.MustCompile(`^` + rxSource + rxLCOWDestination + rxMode + `$`)
+	lcowMountDestinationRegex = lazyregexp.New(`^` + rxLCOWDestination + `$`)
+	lcowSplitRawSpec          = lazyregexp.New(`^` + rxSource + rxLCOWDestination + rxMode + `$`)
 )
 
 var lcowValidators mountValidator = func(m *mount.Mount) error {

--- a/volume/mounts/windows_parser.go
+++ b/volume/mounts/windows_parser.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/internal/lazyregexp"
 )
 
 // NewWindowsParser creates a parser with Windows semantics.
@@ -78,16 +78,16 @@ const (
 )
 
 var (
-	volumeNameRegexp          = regexp.MustCompile(`^` + rxName + `$`)
-	reservedNameRegexp        = regexp.MustCompile(`^` + rxReservedNames + `$`)
-	hostDirRegexp             = regexp.MustCompile(`^` + rxHostDir + `$`)
-	mountDestinationRegexp    = regexp.MustCompile(`^` + rxDestination + `$`)
-	windowsSplitRawSpecRegexp = regexp.MustCompile(`^` + rxSource + rxDestination + rxMode + `$`)
+	volumeNameRegexp          = lazyregexp.New(`^` + rxName + `$`)
+	reservedNameRegexp        = lazyregexp.New(`^` + rxReservedNames + `$`)
+	hostDirRegexp             = lazyregexp.New(`^` + rxHostDir + `$`)
+	mountDestinationRegexp    = lazyregexp.New(`^` + rxDestination + `$`)
+	windowsSplitRawSpecRegexp = lazyregexp.New(`^` + rxSource + rxDestination + rxMode + `$`)
 )
 
 type mountValidator func(mnt *mount.Mount) error
 
-func (p *windowsParser) splitRawSpec(raw string, splitRegexp *regexp.Regexp) ([]string, error) {
+func (p *windowsParser) splitRawSpec(raw string, splitRegexp *lazyregexp.Regexp) ([]string, error) {
 	match := splitRegexp.FindStringSubmatch(strings.ToLower(raw))
 	if len(match) == 0 {
 		return nil, errInvalidSpec(raw)


### PR DESCRIPTION
implement lazyregexp package based on the "lazyregexp" package in golang.org/x/mod;
https://cs.opensource.google/go/x/mod/+/refs/tags/v0.19.0:internal/lazyregexp/lazyre.go;l=66-78

This package allows defining regular expressions that should not be
compiled until used, but still providing validation to prevent
invalid regular expressions from producing a panic at runtime.

This is largely a copy of the package from golang.org/x/mod,
with FindAllStringSubmatch and  ReplaceAllLiteralString,
and ReplaceAllStringFunc added


**- A picture of a cute animal (not mandatory but encouraged)**

