### PR TITLE
Add `--feature` to daemon flags

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -4,6 +4,7 @@ import (
 	"runtime"
 
 	"github.com/docker/docker/daemon/config"
+	dopts "github.com/docker/docker/internal/opts"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/registry"
 	"github.com/spf13/pflag"
@@ -28,6 +29,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.StringVar(&conf.ExecRoot, "exec-root", conf.ExecRoot, "Root directory for execution state files")
 	flags.StringVar(&conf.ContainerdAddr, "containerd", "", "containerd grpc address")
 	flags.BoolVar(&conf.CriContainerd, "cri-containerd", false, "start containerd with cri")
+	flags.Var(dopts.NewNamedSetOpts("features", conf.Features), "feature", "Enable feature in the daemon")
 
 	flags.Var(opts.NewNamedMapMapOpts("default-network-opts", conf.DefaultNetworkOpts, nil), "default-network-opt", "Default network options")
 	flags.IntVar(&conf.MTU, "mtu", conf.MTU, `Set the MTU for the default "bridge" network`)

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -305,6 +305,7 @@ func New() (*Config, error) {
 			},
 			ContainerdNamespace:       DefaultContainersNamespace,
 			ContainerdPluginNamespace: DefaultPluginNamespace,
+			Features:                  make(map[string]bool),
 			DefaultRuntime:            StockRuntimeName,
 			MinAPIVersion:             defaultMinAPIVersion,
 		},

--- a/internal/opts/opts.go
+++ b/internal/opts/opts.go
@@ -1,0 +1,80 @@
+package opts
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/docker/docker/opts"
+)
+
+// SetOpts holds a map of values and a validation function.
+type SetOpts struct {
+	values map[string]bool
+}
+
+// Set validates if needed the input value and add it to the
+// internal map, by splitting on '='.
+func (opts *SetOpts) Set(value string) error {
+	k, v, found := strings.Cut(value, "=")
+	var isSet bool
+	if !found {
+		isSet = true
+		k = value
+	} else {
+		var err error
+		isSet, err = strconv.ParseBool(v)
+		if err != nil {
+			return err
+		}
+	}
+	opts.values[k] = isSet
+	return nil
+}
+
+// GetAll returns the values of SetOpts as a map.
+func (opts *SetOpts) GetAll() map[string]bool {
+	return opts.values
+}
+
+func (opts *SetOpts) String() string {
+	return fmt.Sprintf("%v", opts.values)
+}
+
+// Type returns a string name for this Option type
+func (opts *SetOpts) Type() string {
+	return "map"
+}
+
+// NewSetOpts creates a new SetOpts with the specified set of values as a map of string to bool.
+func NewSetOpts(values map[string]bool) *SetOpts {
+	if values == nil {
+		values = make(map[string]bool)
+	}
+	return &SetOpts{
+		values: values,
+	}
+}
+
+// NamedSetOpts is a SetOpts struct with a configuration name.
+// This struct is useful to keep reference to the assigned
+// field name in the internal configuration struct.
+type NamedSetOpts struct {
+	SetOpts
+	name string
+}
+
+var _ opts.NamedOption = &NamedSetOpts{}
+
+// NewNamedSetOpts creates a reference to a new NamedSetOpts struct.
+func NewNamedSetOpts(name string, values map[string]bool) *NamedSetOpts {
+	return &NamedSetOpts{
+		SetOpts: *NewSetOpts(values),
+		name:    name,
+	}
+}
+
+// Name returns the name of the NamedSetOpts in the configuration.
+func (o *NamedSetOpts) Name() string {
+	return o.name
+}

--- a/internal/opts/opts_test.go
+++ b/internal/opts/opts_test.go
@@ -1,0 +1,46 @@
+package opts
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestSetOpts(t *testing.T) {
+	tmpMap := make(map[string]bool)
+	o := NewSetOpts(tmpMap)
+	assert.NilError(t, o.Set("feature-a=1"))
+	assert.NilError(t, o.Set("feature-b=true"))
+	assert.NilError(t, o.Set("feature-c=0"))
+	assert.NilError(t, o.Set("feature-d=false"))
+
+	expected := "map[feature-a:true feature-b:true feature-c:false feature-d:false]"
+	assert.Check(t, is.Equal(expected, o.String()))
+
+	expectedValue := map[string]bool{"feature-a": true, "feature-b": true, "feature-c": false, "feature-d": false}
+	assert.Check(t, is.DeepEqual(expectedValue, o.GetAll()))
+
+	err := o.Set("feature=not-a-bool")
+	assert.Check(t, is.Error(err, `strconv.ParseBool: parsing "not-a-bool": invalid syntax`))
+}
+
+func TestNamedSetOpts(t *testing.T) {
+	tmpMap := make(map[string]bool)
+	o := NewNamedSetOpts("features", tmpMap)
+	assert.Check(t, is.Equal("features", o.Name()))
+
+	assert.NilError(t, o.Set("feature-a=1"))
+	assert.NilError(t, o.Set("feature-b=true"))
+	assert.NilError(t, o.Set("feature-c=0"))
+	assert.NilError(t, o.Set("feature-d=false"))
+
+	expected := "map[feature-a:true feature-b:true feature-c:false feature-d:false]"
+	assert.Check(t, is.Equal(expected, o.String()))
+
+	expectedValue := map[string]bool{"feature-a": true, "feature-b": true, "feature-c": false, "feature-d": false}
+	assert.Check(t, is.DeepEqual(expectedValue, o.GetAll()))
+
+	err := o.Set("feature=not-a-bool")
+	assert.Check(t, is.Error(err, `strconv.ParseBool: parsing "not-a-bool": invalid syntax`))
+}


### PR DESCRIPTION
Adds a `--feature` flag to the daemon options. This allows quickly toggling features when running the daemon directly or writing daemon tests.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Add a `--feature` flag to the daemon options.
```

