### PR TITLE
[27.1 backport] Fix API version in TestSetInterfaceSysctl

### DIFF
--- a/integration/networking/bridge_test.go
+++ b/integration/networking/bridge_test.go
@@ -789,7 +789,9 @@ func TestNoIP6Tables(t *testing.T) {
 	}
 }
 
-// Test that it's possible to set a sysctl on an interface in the container.
+// Test that it's possible to set a sysctl on an interface in the container
+// when using API 1.46 (in later versions of the API, per-interface sysctls
+// must be set using driver option 'com.docker.network.endpoint.sysctls').
 // Regression test for https://github.com/moby/moby/issues/47619
 func TestSetInterfaceSysctl(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "no sysctl on Windows")
@@ -799,7 +801,7 @@ func TestSetInterfaceSysctl(t *testing.T) {
 	d.StartWithBusybox(ctx, t)
 	defer d.Stop(t)
 
-	c := d.NewClientT(t)
+	c := d.NewClientT(t, client.WithVersion("1.46"))
 	defer c.Close()
 
 	const scName = "net.ipv4.conf.eth0.forwarding"


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/48156

**- What I did**

Fix API version in TestSetInterfaceSysctl

The test checks that it's possible to set a per-interface sysctl using '--sysctl' - but, after API v1.46, it's not (and driver option 'com.docker.network.endpoint.sysctls' must be used instead).

- Test added in:
  - https://github.com/moby/moby/pull/47621
  - commit https://github.com/moby/moby/commit/fde80fe2e731f04ce029dc93fcdadeccabe2921b
- Per-interface sysctls added, with API changes, in:
  - https://github.com/moby/moby/pull/47686
  - commit https://github.com/moby/moby/commit/0071832226b42dbb12bc01bf1c668dca891b2d33

**- How I did it**

Use API `1.46` in the test.

**- How to verify it**

Run the test when the default API has been bumped to `1.47`.

**- Description for the changelog**

