### PR TITLE
gha: check-pr-branch: fix branch check regression

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -57,12 +57,12 @@ jobs:
         id: title_branch
         run: |
           # get the intended major version prefix ("[27.1 backport]" -> "27.") from the PR title.
-          [[ "$PR_TITLE" =~ ^\[\([0-9]*\.\)[^]]*\] ]] && branch="${BASH_REMATCH[1]}"
+          [[ "$PR_TITLE" =~ ^\[([0-9]*\.)[^]]*\] ]] && branch="${BASH_REMATCH[1]}"
 
           # get major version prefix from the release branch ("27.x -> "27.")
-          [[ "$GITHUB_BASE_REF" =~ ^\([0-9]*\.\) ]] && target_branch="${BASH_REMATCH[1]}"
+          [[ "$GITHUB_BASE_REF" =~ ^([0-9]*\.) ]] && target_branch="${BASH_REMATCH[1]}" || target_branch="$GITHUB_BASE_REF"
 
-          if [[ "$GITHUB_BASE_REF" != "$branch" ]] && ! [[ "$GITHUB_BASE_REF" == "master" && "$branch" == "" ]]; then
+          if [[ "$target_branch" != "$branch" ]] && ! [[ "$GITHUB_BASE_REF" == "master" && "$branch" == "" ]]; then
               echo "::error::PR is opened against the $GITHUB_BASE_REF branch, but its title suggests otherwise."
               exit 1
           fi


### PR DESCRIPTION
- follow-up to / introduced in https://github.com/moby/moby/pull/48177
- relates to https://github.com/moby/moby/pull/48191#issuecomment-2237827589


This check was updated in f460110ef571fba172d8962d64e2fc58bdf53e97, but introduced some bugs;

- the regular expressions were meant to define a capturing group, but the braces (`(`, `)`) were escaped (they previously were used by `sed`, which requires different escaping), so no value was captured.
- the check itself was not updated to use the resulting `$target_branch` env-var, so was comparing against the `$GITHUB_BASE_REF` (which is the branch name before stripping minor versions).

