### PR TITLE
daemon/graphdriver/fuse-overlayfs: remove kernel-version check for < 4.18.0

### DIFF
--- a/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs.go
+++ b/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs.go
@@ -22,7 +22,6 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/directory"
 	"github.com/moby/moby/v2/daemon/internal/fstype"
 	"github.com/moby/moby/v2/daemon/internal/mountref"
-	"github.com/moby/moby/v2/pkg/parsers/kernel"
 	"github.com/moby/sys/mount"
 	"github.com/moby/sys/user"
 	"github.com/moby/sys/userns"
@@ -76,9 +75,6 @@ func init() {
 func Init(home string, options []string, idMap user.IdentityMapping) (graphdriver.Driver, error) {
 	if _, err := exec.LookPath(binary); err != nil {
 		logger.Error(err)
-		return nil, graphdriver.ErrNotSupported
-	}
-	if !kernel.CheckKernelVersion(4, 18, 0) {
 		return nil, graphdriver.ErrNotSupported
 	}
 


### PR DESCRIPTION
### daemon/graphdriver/fuse-overlayfs: remove kernel-version check for < 4.18.0

This check was in place for CentOS/RHEL 7, which use kernel 3.10. Now
that both reached EOL, and we stopped packaging for those distros, we
can remove this condition. RHEL 8 uses kernel 4.18, so does not need
this check.
