### PR TITLE
daemon: remove setMayDetachMounts (set may_detach_mounts=1 on startup)

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -857,9 +857,6 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		return nil, err
 	}
 	rootIDs := idMapping.RootPair()
-	if err := setMayDetachMounts(); err != nil {
-		log.G(ctx).WithError(err).Warn("Could not set may_detach_mounts kernel parameter")
-	}
 
 	// set up the tmpDir to use a canonical path
 	tmp, err := prepareTempDir(config.Root)

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/containerd/cgroups/v3"
-	"github.com/containerd/containerd/pkg/userns"
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/types/blkiodev"
 	pblkiodev "github.com/docker/docker/api/types/blkiodev"
@@ -1401,35 +1400,6 @@ func (daemon *Daemon) conditionalUnmountOnCleanup(container *container.Container
 // daemon to run in. This is only applicable on Windows
 func (daemon *Daemon) setDefaultIsolation(*config.Config) error {
 	return nil
-}
-
-// This is used to allow removal of mountpoints that may be mounted in other
-// namespaces on RHEL based kernels starting from RHEL 7.4.
-// Without this setting, removals on these RHEL based kernels may fail with
-// "device or resource busy".
-// This setting is not available in upstream kernels as it is not configurable,
-// but has been in the upstream kernels since 3.15.
-func setMayDetachMounts() error {
-	f, err := os.OpenFile("/proc/sys/fs/may_detach_mounts", os.O_WRONLY, 0)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return errors.Wrap(err, "error opening may_detach_mounts kernel config file")
-	}
-	defer f.Close()
-
-	_, err = f.WriteString("1")
-	if os.IsPermission(err) {
-		// Setting may_detach_mounts does not work in an
-		// unprivileged container. Ignore the error, but log
-		// it if we appear not to be in that situation.
-		if !userns.RunningInUserNS() {
-			log.G(context.TODO()).Debugf("Permission denied writing %q to /proc/sys/fs/may_detach_mounts", "1")
-		}
-		return nil
-	}
-	return err
 }
 
 func (daemon *Daemon) initCPURtController(cfg *config.Config, mnt, path string) error {

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -545,10 +545,6 @@ func (daemon *Daemon) setDefaultIsolation(config *config.Config) error {
 	return nil
 }
 
-func setMayDetachMounts() error {
-	return nil
-}
-
 func (daemon *Daemon) setupSeccompProfile(*config.Config) error {
 	return nil
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/34886
- relates to https://github.com/moby/moby/pull/35172



This function was added in 83c2152de503012195bd26069fd8fbd2dea4b32f to automatically set `/proc/sys/fs/may_detach_mounts=1` on startup.

This is a kernel config available in RHEL7.4 based kernels that enables mountpoint removal where the mountpoint exists in other namespaces. This setting is the default, and non-configurable, on upstream kernels since 3.15.

As this option was only supported in RHEL 7.x systems, which reached EOL, we can remove this code, as it's not doing anything on current kernels.


**- A picture of a cute animal (not mandatory but encouraged)**

