### PR TITLE
contrib/check-config.sh: remove special case for userns on CentOS/RHEL 7

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -128,27 +128,6 @@ check_device() {
 	fi
 }
 
-check_distro_userns() {
-	if [ ! -e /etc/os-release ]; then
-		return
-	fi
-	. /etc/os-release 2> /dev/null || /bin/true
-	case "$ID" in
-		centos | rhel)
-			case "$VERSION_ID" in
-				7*)
-					# this is a CentOS7 or RHEL7 system
-					grep -q 'user_namespace.enable=1' /proc/cmdline || {
-						# no user namespace support enabled
-						wrap_bad "  (RHEL7/CentOS7" "User namespaces disabled; add 'user_namespace.enable=1' to boot command line)"
-						EXITCODE=1
-					}
-					;;
-			esac
-			;;
-	esac
-}
-
 if [ ! -e "$CONFIG" ]; then
 	wrap_warning "warning: $CONFIG does not exist, searching other paths for kernel config ..."
 	for tryConfig in $possibleConfigs; do
@@ -256,7 +235,6 @@ echo
 echo 'Optional Features:'
 {
 	check_flags USER_NS
-	check_distro_userns
 }
 {
 	check_flags SECCOMP


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/20643
- relates to https://github.com/moby/moby/issues/20193


---

### contrib/check-config.sh: remove special case for userns on CentOS/RHEL 7

This check was added in 23551515564b54128e882dda5eae659883947d39 to handle non-standard behavior in CentOS/RHEL 7;

> Add check for RHEL7/CentOS7 experimental userns disabled
>
> Add a check in `check-config.sh` to see if we are running on a RHEL7 or
> CentOS7 system, which may report that CONFIG_USERNS is OK/enabled, but
> user namespaces still won't work because of the experimental feature
> flag added by Redhat.
>
> This will add a warning if it is actually disabled and notes what has to
> be added to the grub/boot command line to enable it.

Now that CentOS/RHEL 7 reached EOL, we can remove this special case.

**- A picture of a cute animal (not mandatory but encouraged)**

![il_1588xN 6041058883_oquq](https://github.com/user-attachments/assets/63310c0e-d6fe-46ed-84af-69472a1626da)

