### PR TITLE
contrib/dockerd-rootless-setuptool.sh: remove special case for CentOS/RHEL 7

### DIFF
--- a/contrib/dockerd-rootless-setuptool.sh
+++ b/contrib/dockerd-rootless-setuptool.sh
@@ -229,22 +229,6 @@ init() {
 		fi
 	fi
 
-	# instruction: RHEL/CentOS 7 requires setting max_user_namespaces
-	if [ -f /proc/sys/user/max_user_namespaces ]; then
-		if [ "0" = "$(cat /proc/sys/user/max_user_namespaces)" ]; then
-			instructions=$(
-				cat <<- EOI
-					${instructions}
-					# Set user.max_user_namespaces
-					cat <<EOT > /etc/sysctl.d/51-rootless.conf
-					user.max_user_namespaces = 28633
-					EOT
-					sysctl --system
-				EOI
-			)
-		fi
-	fi
-
 	# instructions: validate subuid for current user
 	error_subid=
 	if command -v "getsubids" > /dev/null 2>&1; then


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/40950

---

### contrib/dockerd-rootless-setuptool.sh: remove special case for CentOS/RHEL 7

This was added in c696b952693fa6174068e2bd26459a206308c95f to handle CentOS/RHEL 7. As both are now EOL, and we're no longer building packages for them, we can remove this special case.

