### PR TITLE
dockerd-rootless-setuptool.sh: move RootlessKit smoke test

### DIFF
--- a/contrib/dockerd-rootless-setuptool.sh
+++ b/contrib/dockerd-rootless-setuptool.sh
@@ -269,13 +269,6 @@ init() {
 	# - sysctl: "net.ipv4.ip_unprivileged_port_start"
 	# - external binary: slirp4netns
 	# - external binary: fuse-overlayfs
-
-	# check RootlessKit functionality. RootlessKit will print hints if something is still unsatisfied.
-	# (e.g., `kernel.apparmor_restrict_unprivileged_userns` constraint)
-	if ! rootlesskit true; then
-		ERROR "RootlessKit failed, see the error messages and https://rootlesscontaine.rs/getting-started/common/ ."
-		exit 1
-	fi
 }
 
 # CLI subcommand: "check"
@@ -400,7 +393,16 @@ cli_ctx_rm() {
 # CLI subcommand: "install"
 cmd_entrypoint_install() {
 	init
-	# requirements are already checked in init()
+	# Most requirements are already checked in init(), except the smoke test below for RootlessKit.
+	# https://github.com/docker/docker-install/issues/417
+
+	# check RootlessKit functionality. RootlessKit will print hints if something is still unsatisfied.
+	# (e.g., `kernel.apparmor_restrict_unprivileged_userns` constraint)
+	if ! rootlesskit true; then
+		ERROR "RootlessKit failed, see the error messages and https://rootlesscontaine.rs/getting-started/common/ ."
+		exit 1
+	fi
+
 	if [ -z "$SYSTEMD" ]; then
 		install_nonsystemd
 	else


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix docker/docker-install#417


**- How I did it**
`dockerd-rootless-setuptool.sh check` now skips the smoke test for running RootlessKit.


**- How to verify it**
`dockerd-rootless-setuptool.sh check`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
dockerd-rootless-setuptool.sh: move RootlessKit smoke test
```

**- A picture of a cute animal (not mandatory but encouraged)**
🐧 