### PR TITLE
fix(errdefs): support Wrap() []errors

### DIFF
--- a/errdefs/is.go
+++ b/errdefs/is.go
@@ -17,7 +17,7 @@ type wrapErrs interface {
 	Unwrap() []error
 }
 
-func getImplementer(err error) error {
+func getImplementer(err error) (bool, error) {
 	switch e := err.(type) {
 	case
 		ErrNotFound,
@@ -33,124 +33,162 @@ func getImplementer(err error) error {
 		ErrDeadline,
 		ErrDataLoss,
 		ErrUnknown:
-		return err
+		return true, err
 	case causer:
 		return getImplementer(e.Cause())
 	case wrapErr:
 		return getImplementer(e.Unwrap())
 	case wrapErrs:
 		for _, err := range e.Unwrap() {
-			switch err := getImplementer(err).(type) {
-			case
-				ErrNotFound,
-				ErrInvalidParameter,
-				ErrConflict,
-				ErrUnauthorized,
-				ErrUnavailable,
-				ErrForbidden,
-				ErrSystem,
-				ErrNotModified,
-				ErrNotImplemented,
-				ErrCancelled,
-				ErrDeadline,
-				ErrDataLoss,
-				ErrUnknown:
-				return err
+			if ok, err := getImplementer(err); ok {
+				return true, err
 			}
 		}
-		return err
+		return false, err
 	default:
-		return err
+		return false, err
 	}
 }
 
-// IsNotFound returns true if the first instances of one of the expected types
+// IsNotFound returns true if the first instance of one of the expected types
 // implements ErrNotFound, otherwise false.
 func IsNotFound(err error) bool {
-	_, ok := getImplementer(err).(ErrNotFound)
+	ok, err := getImplementer(err)
+	if !ok {
+		return false
+	}
+	_, ok = err.(ErrNotFound)
 	return ok
 }
 
-// IsInvalidParameter true if the first instances of one of the expected types
+// IsInvalidParameter true if the first instance of one of the expected types
 // implements ErrInvalidParameter, otherwise false.
 func IsInvalidParameter(err error) bool {
-	_, ok := getImplementer(err).(ErrInvalidParameter)
+	ok, err := getImplementer(err)
+	if !ok {
+		return false
+	}
+	_, ok = err.(ErrInvalidParameter)
 	return ok
 }
 
-// IsConflict true if the first instances of one of the expected types
+// IsConflict true if the first instance of one of the expected types
 // implements ErrConflict, otherwise false.
 func IsConflict(err error) bool {
-	_, ok := getImplementer(err).(ErrConflict)
+	ok, err := getImplementer(err)
+	if !ok {
+		return false
+	}
+	_, ok = err.(ErrConflict)
 	return ok
 }
 
-// IsUnauthorized true if the first instances of one of the expected types
+// IsUnauthorized true if the first instance of one of the expected types
 // implements ErrUnauthorized, otherwise false.
 func IsUnauthorized(err error) bool {
-	_, ok := getImplementer(err).(ErrUnauthorized)
+	ok, err := getImplementer(err)
+	if !ok {
+		return false
+	}
+	_, ok = err.(ErrUnauthorized)
 	return ok
 }
 
-// IsUnavailable true if the first instances of one of the expected types
+// IsUnavailable true if the first instance of one of the expected types
 // implements ErrUnavailable, otherwise false.
 func IsUnavailable(err error) bool {
-	_, ok := getImplementer(err).(ErrUnavailable)
+	ok, err := getImplementer(err)
+	if !ok {
+		return false
+	}
+	_, ok = err.(ErrUnavailable)
 	return ok
 }
 
-// IsForbidden true if the first instances of one of the expected types
+// IsForbidden true if the first instance of one of the expected types
 // implements ErrForbidden, otherwise false.
 func IsForbidden(err error) bool {
-	_, ok := getImplementer(err).(ErrForbidden)
+	ok, err := getImplementer(err)
+	if !ok {
+		return false
+	}
+	_, ok = err.(ErrForbidden)
 	return ok
 }
 
-// IsSystem true if the first instances of one of the expected types
+// IsSystem true if the first instance of one of the expected types
 // implements ErrSystem, otherwise false.
 func IsSystem(err error) bool {
-	_, ok := getImplementer(err).(ErrSystem)
+	ok, err := getImplementer(err)
+	if !ok {
+		return false
+	}
+	_, ok = err.(ErrSystem)
 	return ok
 }
 
 // IsNotModified returns if the passed in error is a NotModified error
 func IsNotModified(err error) bool {
-	_, ok := getImplementer(err).(ErrNotModified)
+	ok, err := getImplementer(err)
+	if !ok {
+		return false
+	}
+	_, ok = err.(ErrNotModified)
 	return ok
 }
 
-// IsNotImplemented true if the first instances of one of the expected types
+// IsNotImplemented true if the first instance of one of the expected types
 // implements ErrNotImplemented, otherwise false.
 func IsNotImplemented(err error) bool {
-	_, ok := getImplementer(err).(ErrNotImplemented)
+	ok, err := getImplementer(err)
+	if !ok {
+		return false
+	}
+	_, ok = err.(ErrNotImplemented)
 	return ok
 }
 
-// IsUnknown true if the first instances of one of the expected types
+// IsUnknown true if the first instance of one of the expected types
 // implements ErrUnknown, otherwise false.
 func IsUnknown(err error) bool {
-	_, ok := getImplementer(err).(ErrUnknown)
+	ok, err := getImplementer(err)
+	if !ok {
+		return false
+	}
+	_, ok = err.(ErrUnknown)
 	return ok
 }
 
-// IsCancelled true if the first instances of one of the expected types
+// IsCancelled true if the first instance of one of the expected types
 // implements ErrCancelled, otherwise false.
 func IsCancelled(err error) bool {
-	_, ok := getImplementer(err).(ErrCancelled)
+	ok, err := getImplementer(err)
+	if !ok {
+		return false
+	}
+	_, ok = err.(ErrCancelled)
 	return ok
 }
 
-// IsDeadline true if the first instances of one of the expected types
+// IsDeadline true if the first instance of one of the expected types
 // implements ErrDeadline, otherwise false.
 func IsDeadline(err error) bool {
-	_, ok := getImplementer(err).(ErrDeadline)
+	ok, err := getImplementer(err)
+	if !ok {
+		return false
+	}
+	_, ok = err.(ErrDeadline)
 	return ok
 }
 
-// IsDataLoss true if the first instances of one of the expected types
+// IsDataLoss true if the first instance of one of the expected types
 // implements ErrDataLoss, otherwise false.
 func IsDataLoss(err error) bool {
-	_, ok := getImplementer(err).(ErrDataLoss)
+	ok, err := getImplementer(err)
+	if !ok {
+		return false
+	}
+	_, ok = err.(ErrDataLoss)
 	return ok
 }
 

--- a/errdefs/is.go
+++ b/errdefs/is.go
@@ -13,6 +13,10 @@ type wrapErr interface {
 	Unwrap() error
 }
 
+type wrapErrs interface {
+	Unwrap() []error
+}
+
 func getImplementer(err error) error {
 	switch e := err.(type) {
 	case
@@ -34,48 +38,76 @@ func getImplementer(err error) error {
 		return getImplementer(e.Cause())
 	case wrapErr:
 		return getImplementer(e.Unwrap())
+	case wrapErrs:
+		for _, err := range e.Unwrap() {
+			switch err := getImplementer(err).(type) {
+			case
+				ErrNotFound,
+				ErrInvalidParameter,
+				ErrConflict,
+				ErrUnauthorized,
+				ErrUnavailable,
+				ErrForbidden,
+				ErrSystem,
+				ErrNotModified,
+				ErrNotImplemented,
+				ErrCancelled,
+				ErrDeadline,
+				ErrDataLoss,
+				ErrUnknown:
+				return err
+			}
+		}
+		return err
 	default:
 		return err
 	}
 }
 
-// IsNotFound returns if the passed in error is an ErrNotFound
+// IsNotFound returns true if the first instances of one of the expected types
+// implements ErrNotFound, otherwise false.
 func IsNotFound(err error) bool {
 	_, ok := getImplementer(err).(ErrNotFound)
 	return ok
 }
 
-// IsInvalidParameter returns if the passed in error is an ErrInvalidParameter
+// IsInvalidParameter true if the first instances of one of the expected types
+// implements ErrInvalidParameter, otherwise false.
 func IsInvalidParameter(err error) bool {
 	_, ok := getImplementer(err).(ErrInvalidParameter)
 	return ok
 }
 
-// IsConflict returns if the passed in error is an ErrConflict
+// IsConflict true if the first instances of one of the expected types
+// implements ErrConflict, otherwise false.
 func IsConflict(err error) bool {
 	_, ok := getImplementer(err).(ErrConflict)
 	return ok
 }
 
-// IsUnauthorized returns if the passed in error is an ErrUnauthorized
+// IsUnauthorized true if the first instances of one of the expected types
+// implements ErrUnauthorized, otherwise false.
 func IsUnauthorized(err error) bool {
 	_, ok := getImplementer(err).(ErrUnauthorized)
 	return ok
 }
 
-// IsUnavailable returns if the passed in error is an ErrUnavailable
+// IsUnavailable true if the first instances of one of the expected types
+// implements ErrUnavailable, otherwise false.
 func IsUnavailable(err error) bool {
 	_, ok := getImplementer(err).(ErrUnavailable)
 	return ok
 }
 
-// IsForbidden returns if the passed in error is an ErrForbidden
+// IsForbidden true if the first instances of one of the expected types
+// implements ErrForbidden, otherwise false.
 func IsForbidden(err error) bool {
 	_, ok := getImplementer(err).(ErrForbidden)
 	return ok
 }
 
-// IsSystem returns if the passed in error is an ErrSystem
+// IsSystem true if the first instances of one of the expected types
+// implements ErrSystem, otherwise false.
 func IsSystem(err error) bool {
 	_, ok := getImplementer(err).(ErrSystem)
 	return ok
@@ -87,31 +119,36 @@ func IsNotModified(err error) bool {
 	return ok
 }
 
-// IsNotImplemented returns if the passed in error is an ErrNotImplemented
+// IsNotImplemented true if the first instances of one of the expected types
+// implements ErrNotImplemented, otherwise false.
 func IsNotImplemented(err error) bool {
 	_, ok := getImplementer(err).(ErrNotImplemented)
 	return ok
 }
 
-// IsUnknown returns if the passed in error is an ErrUnknown
+// IsUnknown true if the first instances of one of the expected types
+// implements ErrUnknown, otherwise false.
 func IsUnknown(err error) bool {
 	_, ok := getImplementer(err).(ErrUnknown)
 	return ok
 }
 
-// IsCancelled returns if the passed in error is an ErrCancelled
+// IsCancelled true if the first instances of one of the expected types
+// implements ErrCancelled, otherwise false.
 func IsCancelled(err error) bool {
 	_, ok := getImplementer(err).(ErrCancelled)
 	return ok
 }
 
-// IsDeadline returns if the passed in error is an ErrDeadline
+// IsDeadline true if the first instances of one of the expected types
+// implements ErrDeadline, otherwise false.
 func IsDeadline(err error) bool {
 	_, ok := getImplementer(err).(ErrDeadline)
 	return ok
 }
 
-// IsDataLoss returns if the passed in error is an ErrDataLoss
+// IsDataLoss true if the first instances of one of the expected types
+// implements ErrDataLoss, otherwise false.
 func IsDataLoss(err error) bool {
 	_, ok := getImplementer(err).(ErrDataLoss)
 	return ok

--- a/errdefs/is_test.go
+++ b/errdefs/is_test.go
@@ -1,0 +1,92 @@
+package errdefs
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+type errCause struct {
+	err error
+}
+
+func newErrCause(err error) errCause {
+	return errCause{err: err}
+}
+
+func (e errCause) Error() string {
+	return e.err.Error()
+}
+
+func (e errCause) Cause() error {
+	return e.err
+}
+
+func TestImplements(t *testing.T) {
+	var errorNotFound errNotFound
+	var errorInvalidParameter errInvalidParameter
+	errOther := errors.New("other")
+	tests := map[string]struct {
+		err      error
+		expected bool
+	}{
+
+		"nil": {
+			err: nil,
+		},
+		"direct-not-found": {
+			err:      errorNotFound,
+			expected: true,
+		},
+		"direct-other": {
+			err: errOther,
+		},
+		"wrapped-not-found": {
+			err:      fmt.Errorf("wrap: %w", errorNotFound),
+			expected: true,
+		},
+		"wrapped-other": {
+			err: fmt.Errorf("wrap: %w", errOther),
+		},
+		"multi-wrapped-not-found": {
+			err:      fmt.Errorf("wrap: %w", fmt.Errorf("wrap: %w", errorNotFound)),
+			expected: true,
+		},
+		"multi-wrapped-other": {
+			err: fmt.Errorf("wrap: %w", fmt.Errorf("wrap: %w", errOther)),
+		},
+		"join-not-found": {
+			err:      errors.Join(errOther, errorNotFound),
+			expected: true,
+		},
+		"join-other": {
+			err: errors.Join(errOther, errOther),
+		},
+		"join-invalid-param": {
+			err: errors.Join(errOther, errorInvalidParameter, errorNotFound),
+		},
+		"cause-not-found": {
+			err:      newErrCause(errorNotFound),
+			expected: true,
+		},
+		"join-cause-not-found": {
+			err:      errors.Join(errOther, newErrCause(errorNotFound)),
+			expected: true,
+		},
+		"join-cause-invalid-param": {
+			err: errors.Join(errOther, newErrCause(errorInvalidParameter), newErrCause(errorNotFound)),
+		},
+		"join-cause-other": {
+			err: errors.Join(errOther, newErrCause(errOther)),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, ok := getImplementer(tc.err).(ErrNotFound)
+			assert.Equal(t, ok, tc.expected)
+		})
+	}
+}

--- a/errdefs/is_test.go
+++ b/errdefs/is_test.go
@@ -8,6 +8,12 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+var (
+	errorNotFound         errNotFound
+	errorInvalidParameter errInvalidParameter
+	errOther              = errors.New("other")
+)
+
 type errCause struct {
 	err error
 }
@@ -24,69 +30,75 @@ func (e errCause) Cause() error {
 	return e.err
 }
 
-func TestImplements(t *testing.T) {
-	var errorNotFound errNotFound
-	var errorInvalidParameter errInvalidParameter
-	errOther := errors.New("other")
-	tests := map[string]struct {
-		err      error
-		expected bool
-	}{
+var tests = map[string]struct {
+	err      error
+	expected bool
+}{
 
-		"nil": {
-			err: nil,
-		},
-		"direct-not-found": {
-			err:      errorNotFound,
-			expected: true,
-		},
-		"direct-other": {
-			err: errOther,
-		},
-		"wrapped-not-found": {
-			err:      fmt.Errorf("wrap: %w", errorNotFound),
-			expected: true,
-		},
-		"wrapped-other": {
-			err: fmt.Errorf("wrap: %w", errOther),
-		},
-		"multi-wrapped-not-found": {
-			err:      fmt.Errorf("wrap: %w", fmt.Errorf("wrap: %w", errorNotFound)),
-			expected: true,
-		},
-		"multi-wrapped-other": {
-			err: fmt.Errorf("wrap: %w", fmt.Errorf("wrap: %w", errOther)),
-		},
-		"join-not-found": {
-			err:      errors.Join(errOther, errorNotFound),
-			expected: true,
-		},
-		"join-other": {
-			err: errors.Join(errOther, errOther),
-		},
-		"join-invalid-param": {
-			err: errors.Join(errOther, errorInvalidParameter, errorNotFound),
-		},
-		"cause-not-found": {
-			err:      newErrCause(errorNotFound),
-			expected: true,
-		},
-		"join-cause-not-found": {
-			err:      errors.Join(errOther, newErrCause(errorNotFound)),
-			expected: true,
-		},
-		"join-cause-invalid-param": {
-			err: errors.Join(errOther, newErrCause(errorInvalidParameter), newErrCause(errorNotFound)),
-		},
-		"join-cause-other": {
-			err: errors.Join(errOther, newErrCause(errOther)),
-		},
-	}
+	"nil": {
+		err: nil,
+	},
+	"direct-not-found": {
+		err:      errorNotFound,
+		expected: true,
+	},
+	"direct-other": {
+		err: errOther,
+	},
+	"wrapped-not-found": {
+		err:      fmt.Errorf("wrap: %w", errorNotFound),
+		expected: true,
+	},
+	"wrapped-other": {
+		err: fmt.Errorf("wrap: %w", errOther),
+	},
+	"multi-wrapped-not-found": {
+		err:      fmt.Errorf("wrap: %w", fmt.Errorf("wrap: %w", errorNotFound)),
+		expected: true,
+	},
+	"multi-wrapped-other": {
+		err: fmt.Errorf("wrap: %w", fmt.Errorf("wrap: %w", errOther)),
+	},
+	"join-not-found": {
+		err:      errors.Join(errOther, errorNotFound),
+		expected: true,
+	},
+	"join-other": {
+		err: errors.Join(errOther, errOther),
+	},
+	"join-invalid-param": {
+		err: errors.Join(errOther, errorInvalidParameter, errorNotFound),
+	},
+	"cause-not-found": {
+		err:      newErrCause(errorNotFound),
+		expected: true,
+	},
+	"join-cause-not-found": {
+		err:      errors.Join(errOther, newErrCause(errorNotFound)),
+		expected: true,
+	},
+	"join-cause-invalid-param": {
+		err: errors.Join(errOther, newErrCause(errorInvalidParameter), newErrCause(errorNotFound)),
+	},
+	"join-cause-other": {
+		err: errors.Join(errOther, newErrCause(errOther)),
+	},
+}
 
+func TestIsNotFound(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			_, ok := getImplementer(tc.err).(ErrNotFound)
-			assert.Equal(t, ok, tc.expected)
+			assert.Equal(t, IsNotFound(tc.err), tc.expected)
+		})
+	}
+}
+
+func BenchmarkIsNotFound(b *testing.B) {
+	for name, tc := range tests {
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				IsNotFound(tc.err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Add support for `Wrap() []errors` as provided by `errors.Join` so that all `IsXXX` methods work correctly when provided with an error returned by `errors.Join`.

Also clarified that the search stops at the first match to a expected type in contrast to stdlib `errors.Is` which is exhaustive.

Fixes #48211