### PR TITLE
[27.1 backport] README: replace obsolete Docker EE mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ New projects can be added if they fit with the community goals. Docker is commit
 However, other projects are also encouraged to use Moby as an upstream, and to reuse the components in diverse ways, and all these uses will be treated in the same way. External maintainers and contributors are welcomed.
 
 The Moby project is not intended as a location for support or feature requests for Docker products, but as a place for contributors to work on open source code, fix bugs, and make the code more useful.
-The releases are supported by the maintainers, community and users, on a best efforts basis only, and are not intended for customers who want enterprise or commercial support; Docker EE is the appropriate product for these use cases.
+The releases are supported by the maintainers, community and users, on a best efforts basis only. For customers who want enterprise or commercial support, [Docker Desktop](https://www.docker.com/products/docker-desktop/) and [Mirantis Container Runtime](https://www.mirantis.com/software/mirantis-container-runtime/) are the appropriate products for these use cases.
 
 -----
 


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/48176

Docker EE is no more. Point users looking for commercial support at the currently-maintained commercial products based on the Moby project: Docker Desktop and Mirantis Container Runtime.


(cherry picked from commit b37c983d316f4023d27a0494fc26e2dc3bba9eca)


