### PR TITLE
[25.0 backport] ci: update workflow artifacts retention

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -70,6 +70,7 @@ jobs:
         with:
           name: test-reports-unit-${{ inputs.storage }}
           path: /tmp/reports/*
+          retention-days: 1
 
   unit-report:
     runs-on: ubuntu-20.04
@@ -150,6 +151,7 @@ jobs:
         with:
           name: test-reports-docker-py-${{ inputs.storage }}
           path: /tmp/reports/*
+          retention-days: 1
 
   integration-flaky:
     runs-on: ubuntu-20.04
@@ -271,6 +273,7 @@ jobs:
         with:
           name: test-reports-integration-${{ inputs.storage }}-${{ env.TESTREPORTS_NAME }}
           path: /tmp/reports/*
+          retention-days: 1
 
   integration-report:
     runs-on: ubuntu-20.04
@@ -410,6 +413,7 @@ jobs:
         with:
           name: test-reports-integration-cli-${{ inputs.storage }}-${{ env.TESTREPORTS_NAME }}
           path: /tmp/reports/*
+          retention-days: 1
 
   integration-cli-report:
     runs-on: ubuntu-20.04

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -190,6 +190,7 @@ jobs:
         with:
           name: ${{ inputs.os }}-${{ inputs.storage }}-unit-reports
           path: ${{ env.GOPATH }}\src\github.com\docker\docker\bundles\*
+          retention-days: 1
 
   unit-test-report:
     runs-on: ubuntu-latest
@@ -508,6 +509,7 @@ jobs:
         with:
           name: ${{ inputs.os }}-${{ inputs.storage }}-integration-reports-${{ matrix.runtime }}-${{ env.TESTREPORTS_NAME }}
           path: ${{ env.GOPATH }}\src\github.com\docker\docker\bundles\*
+          retention-days: 1
 
   integration-test-report:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,14 +51,6 @@ jobs:
         name: Check artifacts
         run: |
           find ${{ env.DESTDIR }} -type f -exec file -e ascii -- {} +
-      -
-        name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.target }}
-          path: ${{ env.DESTDIR }}
-          if-no-files-found: error
-          retention-days: 7
 
   prepare-cross:
     runs-on: ubuntu-latest
@@ -119,11 +111,3 @@ jobs:
         name: Check artifacts
         run: |
           find ${{ env.DESTDIR }} -type f -exec file -e ascii -- {} +
-      -
-        name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: cross-${{ env.PLATFORM_PAIR }}
-          path: ${{ env.DESTDIR }}
-          if-no-files-found: error
-          retention-days: 7


### PR DESCRIPTION
**- What I did**
Backports https://github.com/moby/moby/pull/47636 to 25.0

**- How I did it**
```
git cherry-pick -xsS aff003139c212397e38cc98a834ef9cd8a56e93a
```

**- How to verify it**

**- Description for the changelog**
```markdown changelog
Reduce retention for CI workflow artifacts to 1 day
```

**- A picture of a cute animal (not mandatory but encouraged)**

