### PR TITLE
[23.0 backport] ci: update workflow artifacts retention

### DIFF
--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -179,6 +179,7 @@ jobs:
         with:
           name: ${{ inputs.os }}-unit-reports
           path: ${{ env.GOPATH }}\src\github.com\docker\docker\bundles\*
+          retention-days: 1
 
   unit-test-report:
     runs-on: ubuntu-latest
@@ -465,6 +466,7 @@ jobs:
         with:
           name: ${{ inputs.os }}-integration-reports-${{ matrix.runtime }}
           path: ${{ env.GOPATH }}\src\github.com\docker\docker\bundles\*
+          retention-days: 1
 
   integration-test-report:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,14 +53,6 @@ jobs:
         name: Check artifacts
         run: |
           find ${{ env.DESTDIR }} -type f -exec file -e ascii -- {} +
-      -
-        name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ matrix.target }}
-          path: ${{ env.DESTDIR }}
-          if-no-files-found: error
-          retention-days: 7
 
   prepare-cross:
     runs-on: ubuntu-latest
@@ -121,11 +113,3 @@ jobs:
         name: Check artifacts
         run: |
           find ${{ env.DESTDIR }} -type f -exec file -e ascii -- {} +
-      -
-        name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: cross-${{ env.PLATFORM_PAIR }}
-          path: ${{ env.DESTDIR }}
-          if-no-files-found: error
-          retention-days: 7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,6 +163,7 @@ jobs:
         with:
           name: unit-reports
           path: /tmp/reports/*
+          retention-days: 1
 
   unit-report:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
**- What I did**
Backports https://github.com/moby/moby/pull/47636 to 23.0

**- How I did it**
```
git cherry-pick -xsS aff003139c212397e38cc98a834ef9cd8a56e93a
```

**- How to verify it**

**- Description for the changelog**
```markdown changelog
Reduce retention for CI workflow artifacts to 1 day
```

**- A picture of a cute animal (not mandatory but encouraged)**

