### PR TITLE
Allow IPv6 only networks

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -3,7 +3,7 @@ package api // import "github.com/docker/docker/api"
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of the current REST API.
-	DefaultVersion = "1.46"
+	DefaultVersion = "1.47"
 
 	// MinSupportedAPIVersion is the minimum API version that can be supported
 	// by the API server, specified as "major.minor". Note that the daemon

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2484,6 +2484,11 @@ definitions:
           `overlay`).
         type: "string"
         example: "overlay"
+      EnableIPv4:
+        description: |
+          Whether the network was created with IPv4 enabled.
+        type: "boolean"
+        example: true
       EnableIPv6:
         description: |
           Whether the network was created with IPv6 enabled.
@@ -10377,6 +10382,7 @@ paths:
                 Created: "2016-10-19T06:21:00.416543526Z"
                 Scope: "local"
                 Driver: "bridge"
+                EnableIPv4: true
                 EnableIPv6: false
                 Internal: false
                 Attachable: false
@@ -10398,6 +10404,7 @@ paths:
                 Created: "0001-01-01T00:00:00Z"
                 Scope: "local"
                 Driver: "null"
+                EnableIPv4: false
                 EnableIPv6: false
                 Internal: false
                 Attachable: false
@@ -10412,6 +10419,7 @@ paths:
                 Created: "0001-01-01T00:00:00Z"
                 Scope: "local"
                 Driver: "host"
+                EnableIPv4: false
                 EnableIPv6: false
                 Internal: false
                 Attachable: false
@@ -10597,6 +10605,10 @@ paths:
               IPAM:
                 description: "Optional custom IP scheme for the network."
                 $ref: "#/definitions/IPAM"
+              EnableIPv4:
+                description: "Enable IPv4 on the network."
+                type: "boolean"
+                example: true
               EnableIPv6:
                 description: "Enable IPv6 on the network."
                 type: "boolean"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -19,10 +19,10 @@ produces:
 consumes:
   - "application/json"
   - "text/plain"
-basePath: "/v1.46"
+basePath: "/v1.47"
 info:
   title: "Docker Engine API"
-  version: "1.46"
+  version: "1.47"
   x-logo:
     url: "https://docs.docker.com/assets/images/logo-docker-main.png"
   description: |
@@ -55,8 +55,8 @@ info:
     the URL is not supported by the daemon, a HTTP `400 Bad Request` error message
     is returned.
 
-    If you omit the version-prefix, the current version of the API (v1.46) is used.
-    For example, calling `/info` is the same as calling `/v1.46/info`. Using the
+    If you omit the version-prefix, the current version of the API (v1.47) is used.
+    For example, calling `/info` is the same as calling `/v1.47/info`. Using the
     API without a version-prefix is deprecated and will be removed in a future release.
 
     Engine releases in the near future should support this version of the API,

--- a/api/types/network/network.go
+++ b/api/types/network/network.go
@@ -33,6 +33,7 @@ type CreateRequest struct {
 type CreateOptions struct {
 	Driver     string            // Driver is the driver-name used to create the network (e.g. `bridge`, `overlay`)
 	Scope      string            // Scope describes the level at which the network exists (e.g. `swarm` for cluster-wide or `local` for machine level).
+	EnableIPv4 *bool             `json:",omitempty"` // EnableIPv4 represents whether to enable IPv4.
 	EnableIPv6 *bool             `json:",omitempty"` // EnableIPv6 represents whether to enable IPv6.
 	IPAM       *IPAM             // IPAM is the network's IP Address Management.
 	Internal   bool              // Internal represents if the network is used internal only.
@@ -76,7 +77,8 @@ type Inspect struct {
 	Created    time.Time                   // Created is the time the network created
 	Scope      string                      // Scope describes the level at which the network exists (e.g. `swarm` for cluster-wide or `local` for machine level)
 	Driver     string                      // Driver is the Driver name used to create the network (e.g. `bridge`, `overlay`)
-	EnableIPv6 bool                        // EnableIPv6 represents whether to enable IPv6
+	EnableIPv4 bool                        // EnableIPv4 represents whether IPv4 is enabled
+	EnableIPv6 bool                        // EnableIPv6 represents whether IPv6 is enabled
 	IPAM       IPAM                        // IPAM is the network's IP Address Management
 	Internal   bool                        // Internal represents if the network is used internal only
 	Attachable bool                        // Attachable represents if the global scope is manually attachable by regular containers from workers in swarm mode.

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -626,6 +626,7 @@ func (c *containerConfig) networkCreateRequest(name string) (clustertypes.Networ
 		return clustertypes.NetworkCreateRequest{}, errors.New("container: unknown network referenced")
 	}
 
+	ipv4Enabled := true
 	ipv6Enabled := na.Network.Spec.Ipv6Enabled
 	options := network.CreateOptions{
 		// ID:     na.Network.ID,
@@ -633,6 +634,7 @@ func (c *containerConfig) networkCreateRequest(name string) (clustertypes.Networ
 		Internal:   na.Network.Spec.Internal,
 		Attachable: na.Network.Spec.Attachable,
 		Ingress:    convert.IsIngressNetwork(na.Network),
+		EnableIPv4: &ipv4Enabled,
 		EnableIPv6: &ipv6Enabled,
 		Scope:      scope.Swarm,
 	}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1051,6 +1051,7 @@ func initBridgeDriver(controller *libnetwork.Controller, cfg config.BridgeConfig
 	}
 	// Initialize default network on "bridge" with the same name
 	_, err = controller.NewNetwork("bridge", network.NetworkBridge, "",
+		libnetwork.NetworkOptionEnableIPv4(true),
 		libnetwork.NetworkOptionEnableIPv6(cfg.EnableIPv6),
 		libnetwork.NetworkOptionDriverOpts(netOption),
 		libnetwork.NetworkOptionIpam("default", "", v4Conf, v6Conf, nil),

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -386,6 +386,7 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 		_, err := daemon.netController.NewNetwork(strings.ToLower(v.Type), name, nid,
 			libnetwork.NetworkOptionGeneric(options.Generic{
 				netlabel.GenericData: netOption,
+				netlabel.EnableIPv4:  true,
 			}),
 			libnetwork.NetworkOptionIpam("default", "", v4Conf, v6Conf, nil),
 		)
@@ -430,6 +431,7 @@ func initBridgeDriver(controller *libnetwork.Controller, config config.BridgeCon
 	_, err := controller.NewNetwork(network.DefaultNetwork, network.DefaultNetwork, "",
 		libnetwork.NetworkOptionGeneric(options.Generic{
 			netlabel.GenericData: netOption,
+			netlabel.EnableIPv4:  true,
 		}),
 		ipamOption,
 	)

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -19,6 +19,11 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 * `Sysctls` in `HostConfig` (top level `--sysctl` settings) for `eth0` are no
   longer migrated to `DriverOpts`, as described in the changes for v1.46.
+* `POST /networks/create` now has an `EnableIPv4` field. Setting it to `false`
+  disables IPv4 IPAM for the network. It can only be set to `false` if the
+  daemon has experimental features enabled.
+* `GET /networks/{id}` now returns an `EnableIPv4` field showing whether the
+  network has IPv4 IPAM enabled.
 
 ## v1.46 API changes
 

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -13,6 +13,12 @@ keywords: "API, Docker, rcli, REST, documentation"
      will be rejected.
 -->
 
+## v1.47 API changes
+
+[Docker Engine API v1.47](https://docs.docker.com/engine/api/v1.47/) documentation
+
+* `Sysctls` in `HostConfig` (top level `--sysctl` settings) for `eth0` are no
+  longer migrated to `DriverOpts`, as described in the changes for v1.46.
 
 ## v1.46 API changes
 

--- a/integration/internal/network/ops.go
+++ b/integration/internal/network/ops.go
@@ -11,6 +11,14 @@ func WithDriver(driver string) func(*network.CreateOptions) {
 	}
 }
 
+// WithIPv4 enables/disables IPv4 on the network
+func WithIPv4(enable bool) func(*network.CreateOptions) {
+	return func(n *network.CreateOptions) {
+		enableIPv4 := enable
+		n.EnableIPv4 = &enableIPv4
+	}
+}
+
 // WithIPv6 Enables IPv6 on the network
 func WithIPv6() func(*network.CreateOptions) {
 	return func(n *network.CreateOptions) {

--- a/integration/network/ipvlan/ipvlan_test.go
+++ b/integration/network/ipvlan/ipvlan_test.go
@@ -95,8 +95,8 @@ func TestDockerNetworkIpvlan(t *testing.T) {
 			name: "L3Addressing",
 			test: testIpvlanL3Addressing,
 		}, {
-			name: "NoIPv6",
-			test: testIpvlanNoIPv6,
+			name: "IpvlanExperimentalV4Only",
+			test: testIpvlanExperimentalV4Only,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -443,26 +443,108 @@ func testIpvlanL3Addressing(t *testing.T, ctx context.Context, client dclient.AP
 	assert.Check(t, is.Contains(result.Combined(), "default dev eth0"))
 }
 
+// Check that '--ipv4=false' is only allowed with '--experimental'.
+// (Remember to remove `--experimental' from TestMacvlanIPAM when it's
+// no longer needed, and maybe use a single daemon for all of its tests.)
+func testIpvlanExperimentalV4Only(t *testing.T, ctx context.Context, client dclient.APIClient) {
+	_, err := net.Create(ctx, client, "testnet",
+		net.WithIPvlan("", "l3"),
+		net.WithIPv4(false),
+	)
+	defer client.NetworkRemove(ctx, "testnet")
+	assert.Assert(t, is.ErrorContains(err, "IPv4 can only be disabled if experimental features are enabled"))
+}
+
 // Check that an ipvlan interface with '--ipv6=false' doesn't get kernel-assigned
 // IPv6 addresses, but the loopback interface does still have an IPv6 address ('::1').
-func testIpvlanNoIPv6(t *testing.T, ctx context.Context, client dclient.APIClient) {
-	const netName = "ipvlannet"
-	net.CreateNoError(ctx, t, client, netName, net.WithIPvlan("", "l3"))
-	assert.Check(t, n.IsNetworkAvailable(ctx, client, netName))
+// Also check that with '--ipv4=false', there's no IPAM-assigned IPv4 address.
+func TestIpvlanIPAM(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon)
+	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
 
-	id := container.Run(ctx, t, client, container.WithNetworkMode(netName))
+	ctx := testutil.StartSpan(baseContext, t)
 
-	loRes := container.ExecT(ctx, t, client, id, []string{"ip", "a", "show", "dev", "lo"})
-	assert.Check(t, is.Contains(loRes.Combined(), " inet "))
-	assert.Check(t, is.Contains(loRes.Combined(), " inet6 "))
+	testcases := []struct {
+		name       string
+		enableIPv4 bool
+		enableIPv6 bool
+	}{
+		{
+			name:       "dual stack",
+			enableIPv4: true,
+			enableIPv6: true,
+		},
+		{
+			name:       "v4 only",
+			enableIPv4: true,
+		},
+		{
+			name:       "v6 only",
+			enableIPv6: true,
+		},
+		{
+			name: "no ipam",
+		},
+	}
 
-	eth0Res := container.ExecT(ctx, t, client, id, []string{"ip", "a", "show", "dev", "eth0"})
-	assert.Check(t, is.Contains(eth0Res.Combined(), " inet "))
-	assert.Check(t, !strings.Contains(eth0Res.Combined(), " inet6 "),
-		"result.Combined(): %s", eth0Res.Combined())
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testutil.StartSpan(ctx, t)
 
-	sysctlRes := container.ExecT(ctx, t, client, id, []string{"sysctl", "-n", "net.ipv6.conf.eth0.disable_ipv6"})
-	assert.Check(t, is.Equal(strings.TrimSpace(sysctlRes.Combined()), "1"))
+			var daemonOpts []daemon.Option
+			if !tc.enableIPv4 {
+				daemonOpts = append(daemonOpts, daemon.WithExperimental())
+			}
+			d := daemon.New(t, daemonOpts...)
+			d.StartWithBusybox(ctx, t)
+			t.Cleanup(func() { d.Stop(t) })
+			c := d.NewClientT(t)
+
+			netOpts := []func(*network.CreateOptions){
+				net.WithIPvlan("", "l3"),
+				net.WithIPv4(tc.enableIPv4),
+			}
+			if tc.enableIPv6 {
+				netOpts = append(netOpts, net.WithIPv6())
+			}
+
+			const netName = "ipvlannet"
+			net.CreateNoError(ctx, t, c, netName, netOpts...)
+			defer c.NetworkRemove(ctx, netName)
+			assert.Check(t, n.IsNetworkAvailable(ctx, c, netName))
+
+			id := container.Run(ctx, t, c, container.WithNetworkMode(netName))
+			defer c.ContainerRemove(ctx, id, containertypes.RemoveOptions{Force: true})
+
+			loRes := container.ExecT(ctx, t, c, id, []string{"ip", "a", "show", "dev", "lo"})
+			assert.Check(t, is.Contains(loRes.Combined(), " inet "))
+			assert.Check(t, is.Contains(loRes.Combined(), " inet6 "))
+
+			eth0Res := container.ExecT(ctx, t, c, id, []string{"ip", "a", "show", "dev", "eth0"})
+			if tc.enableIPv4 {
+				assert.Check(t, is.Contains(eth0Res.Combined(), " inet "),
+					"Expected IPv4 in: %s", eth0Res.Combined())
+			} else {
+				assert.Check(t, !strings.Contains(eth0Res.Combined(), " inet "),
+					"Expected no IPv4 in: %s", eth0Res.Combined())
+			}
+			if tc.enableIPv6 {
+				assert.Check(t, is.Contains(eth0Res.Combined(), " inet6 "),
+					"Expected IPv6 in: %s", eth0Res.Combined())
+			} else {
+				assert.Check(t, !strings.Contains(eth0Res.Combined(), " inet6 "),
+					"Expected no IPv6 in: %s", eth0Res.Combined())
+			}
+
+			sysctlRes := container.ExecT(ctx, t, c, id, []string{"sysctl", "-n", "net.ipv6.conf.eth0.disable_ipv6"})
+			expDisableIPv6 := "1"
+			if tc.enableIPv6 {
+				expDisableIPv6 = "0"
+			}
+			assert.Check(t, is.Equal(strings.TrimSpace(sysctlRes.Combined()), expDisableIPv6))
+		})
+	}
 }
 
 // TestIPVlanDNS checks whether DNS is forwarded, for combinations of l2/l3 mode,

--- a/integration/network/macvlan/macvlan_test.go
+++ b/integration/network/macvlan/macvlan_test.go
@@ -90,8 +90,8 @@ func TestDockerNetworkMacvlan(t *testing.T) {
 			name: "Addressing",
 			test: testMacvlanAddressing,
 		}, {
-			name: "NoIPv6",
-			test: testMacvlanNoIPv6,
+			name: "MacvlanExperimentalV4Only",
+			test: testMacvlanExperimentalV4Only,
 		},
 	} {
 		tc := tc
@@ -440,30 +440,109 @@ func testMacvlanAddressing(t *testing.T, ctx context.Context, client client.APIC
 	assert.Check(t, strings.Contains(result.Combined(), "default via 2001:db8:abca::254 dev eth0"))
 }
 
+// Check that '--ipv4=false' is only allowed with '--experimental'.
+// (Remember to remove `--experimental' from TestMacvlanIPAM when it's
+// no longer needed, and maybe use a single daemon for all of its tests.)
+func testMacvlanExperimentalV4Only(t *testing.T, ctx context.Context, client client.APIClient) {
+	_, err := net.Create(ctx, client, "testnet",
+		net.WithMacvlan(""),
+		net.WithIPv4(false),
+	)
+	defer client.NetworkRemove(ctx, "testnet")
+	assert.Assert(t, is.ErrorContains(err, "IPv4 can only be disabled if experimental features are enabled"))
+}
+
 // Check that a macvlan interface with '--ipv6=false' doesn't get kernel-assigned
 // IPv6 addresses, but the loopback interface does still have an IPv6 address ('::1').
-func testMacvlanNoIPv6(t *testing.T, ctx context.Context, client client.APIClient) {
-	const netName = "macvlannet"
+// Also check that with '--ipv4=false', there's no IPAM-assigned IPv4 address.
+func TestMacvlanIPAM(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon)
+	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
 
-	net.CreateNoError(ctx, t, client, netName,
-		net.WithMacvlan(""),
-		net.WithOption("macvlan_mode", "bridge"),
-	)
-	assert.Check(t, n.IsNetworkAvailable(ctx, client, netName))
+	ctx := testutil.StartSpan(baseContext, t)
 
-	id := container.Run(ctx, t, client, container.WithNetworkMode(netName))
+	testcases := []struct {
+		name       string
+		enableIPv4 bool
+		enableIPv6 bool
+	}{
+		{
+			name:       "dual stack",
+			enableIPv4: true,
+			enableIPv6: true,
+		},
+		{
+			name:       "v4 only",
+			enableIPv4: true,
+		},
+		{
+			name:       "v6 only",
+			enableIPv6: true,
+		},
+		{
+			name: "no ipam",
+		},
+	}
 
-	loRes := container.ExecT(ctx, t, client, id, []string{"ip", "a", "show", "dev", "lo"})
-	assert.Check(t, is.Contains(loRes.Combined(), " inet "))
-	assert.Check(t, is.Contains(loRes.Combined(), " inet6 "))
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testutil.StartSpan(ctx, t)
 
-	eth0Res := container.ExecT(ctx, t, client, id, []string{"ip", "a", "show", "dev", "eth0"})
-	assert.Check(t, is.Contains(eth0Res.Combined(), " inet "))
-	assert.Check(t, !strings.Contains(eth0Res.Combined(), " inet6 "),
-		"result.Combined(): %s", eth0Res.Combined())
+			var daemonOpts []daemon.Option
+			if !tc.enableIPv4 {
+				daemonOpts = append(daemonOpts, daemon.WithExperimental())
+			}
+			d := daemon.New(t, daemonOpts...)
+			d.StartWithBusybox(ctx, t)
+			t.Cleanup(func() { d.Stop(t) })
+			c := d.NewClientT(t)
 
-	sysctlRes := container.ExecT(ctx, t, client, id, []string{"sysctl", "-n", "net.ipv6.conf.eth0.disable_ipv6"})
-	assert.Check(t, is.Equal(strings.TrimSpace(sysctlRes.Combined()), "1"))
+			netOpts := []func(*network.CreateOptions){
+				net.WithMacvlan(""),
+				net.WithOption("macvlan_mode", "bridge"),
+				net.WithIPv4(tc.enableIPv4),
+			}
+			if tc.enableIPv6 {
+				netOpts = append(netOpts, net.WithIPv6())
+			}
+
+			const netName = "macvlannet"
+			net.CreateNoError(ctx, t, c, netName, netOpts...)
+			defer c.NetworkRemove(ctx, netName)
+			assert.Check(t, n.IsNetworkAvailable(ctx, c, netName))
+
+			id := container.Run(ctx, t, c, container.WithNetworkMode(netName))
+			defer c.ContainerRemove(ctx, id, containertypes.RemoveOptions{Force: true})
+
+			loRes := container.ExecT(ctx, t, c, id, []string{"ip", "a", "show", "dev", "lo"})
+			assert.Check(t, is.Contains(loRes.Combined(), " inet "))
+			assert.Check(t, is.Contains(loRes.Combined(), " inet6 "))
+
+			eth0Res := container.ExecT(ctx, t, c, id, []string{"ip", "a", "show", "dev", "eth0"})
+			if tc.enableIPv4 {
+				assert.Check(t, is.Contains(eth0Res.Combined(), " inet "),
+					"Expected IPv4 in: %s", eth0Res.Combined())
+			} else {
+				assert.Check(t, !strings.Contains(eth0Res.Combined(), " inet "),
+					"Expected no IPv4 in: %s", eth0Res.Combined())
+			}
+			if tc.enableIPv6 {
+				assert.Check(t, is.Contains(eth0Res.Combined(), " inet6 "),
+					"Expected IPv6 in: %s", eth0Res.Combined())
+			} else {
+				assert.Check(t, !strings.Contains(eth0Res.Combined(), " inet6 "),
+					"Expected no IPv6 in: %s", eth0Res.Combined())
+			}
+
+			sysctlRes := container.ExecT(ctx, t, c, id, []string{"sysctl", "-n", "net.ipv6.conf.eth0.disable_ipv6"})
+			expDisableIPv6 := "1"
+			if tc.enableIPv6 {
+				expDisableIPv6 = "0"
+			}
+			assert.Check(t, is.Equal(strings.TrimSpace(sysctlRes.Combined()), expDisableIPv6))
+		})
+	}
 }
 
 // TestMACVlanDNS checks whether DNS is forwarded, with/without a parent

--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -619,6 +619,37 @@ func TestDisableIPv6Addrs(t *testing.T) {
 	}
 }
 
+// Check that a container in a network with IPv4 disabled doesn't get
+// IPv4 addresses.
+func TestNonIPv4Network(t *testing.T) {
+	ctx := setupTest(t)
+	d := daemon.New(t, daemon.WithExperimental())
+	d.StartWithBusybox(ctx, t)
+	defer d.Stop(t)
+
+	c := d.NewClientT(t)
+	defer c.Close()
+
+	const netName = "testnet"
+	network.CreateNoError(ctx, t, c, netName,
+		network.WithIPv4(false),
+		network.WithIPv6(),
+	)
+	defer network.RemoveNoError(ctx, t, c, netName)
+
+	id := container.Run(ctx, t, c, container.WithNetworkMode(netName))
+	defer c.ContainerRemove(ctx, id, containertypes.RemoveOptions{Force: true})
+
+	loRes := container.ExecT(ctx, t, c, id, []string{"ip", "a", "show", "dev", "lo"})
+	assert.Check(t, is.Contains(loRes.Combined(), " inet ")) // 127.0.0.1
+	assert.Check(t, is.Contains(loRes.Combined(), " inet6 "))
+
+	eth0Res := container.ExecT(ctx, t, c, id, []string{"ip", "a", "show", "dev", "eth0"})
+	assert.Check(t, !strings.Contains(eth0Res.Combined(), " inet "),
+		"result.Combined(): %s", eth0Res.Combined())
+	assert.Check(t, is.Contains(eth0Res.Combined(), " inet6 "))
+}
+
 // Check that an interface to an '--ipv6=false' network has no IPv6
 // address - either IPAM assigned, or kernel-assigned LL, but the loopback
 // interface does still have an IPv6 address ('::1').

--- a/integration/networking/nat_windows_test.go
+++ b/integration/networking/nat_windows_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/docker/docker/integration/internal/network"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/go-connections/nat"
-	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
 )
 
 // TestNatNetworkICC tries to ping container ctr1 from container ctr2 using its hostname.
@@ -111,4 +109,19 @@ func TestPortMappedHairpinWindows(t *testing.T) {
 	)
 	defer c.ContainerRemove(ctx, res.ContainerID, containertypes.RemoveOptions{Force: true})
 	assert.Check(t, is.Contains(res.Stderr.String(), "404 Not Found"))
+}
+
+func TestWindowsNoDisableIPv4(t *testing.T) {
+	ctx := setupTest(t)
+	c := testEnv.APIClient()
+
+	_, err := network.Create(ctx, c, "ipv6only",
+		network.WithDriver("nat"),
+		network.WithIPv4(false),
+	)
+	// This error message should change to "IPv4 cannot be disabled on Windows"
+	// when "--experimental" is no longer required to disable IPv4. But, there's
+	// no way to start a second daemon with "--experimental" in Windows CI.
+	assert.Check(t, is.ErrorContains(err,
+		"IPv4 can only be disabled if experimental features are enabled"))
 }

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -785,7 +785,7 @@ func (c *Controller) reservePools() {
 				log.G(context.TODO()).Warnf("endpoint interface is empty for %q (%s)", ep.Name(), ep.ID())
 				continue
 			}
-			if err := ep.assignAddress(ipam, true, ep.Iface().AddressIPv6() != nil); err != nil {
+			if err := ep.assignAddress(ipam, ep.Iface().Address() != nil, ep.Iface().AddressIPv6() != nil); err != nil {
 				log.G(context.TODO()).Warnf("Failed to reserve current address for endpoint %q (%s) on network %q (%s)",
 					ep.Name(), ep.ID(), n.Name(), n.ID())
 			}

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -744,16 +744,18 @@ func (c *Controller) reservePools() {
 		// Construct pseudo configs for the auto IP case
 		autoIPv4 := (len(n.ipamV4Config) == 0 || (len(n.ipamV4Config) == 1 && n.ipamV4Config[0].PreferredPool == "")) && len(n.ipamV4Info) > 0
 		autoIPv6 := (len(n.ipamV6Config) == 0 || (len(n.ipamV6Config) == 1 && n.ipamV6Config[0].PreferredPool == "")) && len(n.ipamV6Info) > 0
-		if autoIPv4 {
+		if n.enableIPv4 && autoIPv4 {
 			n.ipamV4Config = []*IpamConf{{PreferredPool: n.ipamV4Info[0].Pool.String()}}
 		}
 		if n.enableIPv6 && autoIPv6 {
 			n.ipamV6Config = []*IpamConf{{PreferredPool: n.ipamV6Info[0].Pool.String()}}
 		}
 		// Account current network gateways
-		for i, cfg := range n.ipamV4Config {
-			if cfg.Gateway == "" && n.ipamV4Info[i].Gateway != nil {
-				cfg.Gateway = n.ipamV4Info[i].Gateway.IP.String()
+		if n.enableIPv4 {
+			for i, cfg := range n.ipamV4Config {
+				if cfg.Gateway == "" && n.ipamV4Info[i].Gateway != nil {
+					cfg.Gateway = n.ipamV4Info[i].Gateway.IP.String()
+				}
 			}
 		}
 		if n.enableIPv6 {

--- a/libnetwork/default_gateway.go
+++ b/libnetwork/default_gateway.go
@@ -129,8 +129,10 @@ func (sb *Sandbox) needDefaultGW() bool {
 		if ep.joinInfo != nil && ep.joinInfo.disableGatewayService {
 			continue
 		}
-		// TODO v6 needs to be handled.
 		if len(ep.Gateway()) > 0 {
+			return false
+		}
+		if len(ep.GatewayIPv6()) > 0 {
 			return false
 		}
 		for _, r := range ep.StaticRoutes() {

--- a/libnetwork/default_gateway_linux.go
+++ b/libnetwork/default_gateway_linux.go
@@ -20,6 +20,7 @@ func (c *Controller) createGWNetwork() (*Network, error) {
 			bridge.EnableICC:          strconv.FormatBool(false),
 			bridge.EnableIPMasquerade: strconv.FormatBool(true),
 		}),
+		NetworkOptionEnableIPv4(true),
 		NetworkOptionEnableIPv6(false),
 	)
 	if err != nil {

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -106,6 +106,7 @@ type containerConfiguration struct {
 type connectivityConfiguration struct {
 	PortBindings []types.PortBinding
 	ExposedPorts []types.TransportPort
+	NoProxy6To4  bool
 }
 
 type bridgeEndpoint struct {
@@ -1446,6 +1447,7 @@ func (d *driver) ProgramExternalConnectivity(ctx context.Context, nid, eid strin
 			endpoint.addrv6,
 			endpoint.extConnConfig.PortBindings,
 			network.config.DefaultBindingIP,
+			endpoint.extConnConfig.NoProxy6To4,
 		)
 		if err != nil {
 			return err
@@ -1635,6 +1637,14 @@ func parseConnectivityOptions(cOptions map[string]interface{}) (*connectivityCon
 			cc.ExposedPorts = ports
 		} else {
 			return nil, types.InvalidParameterErrorf("invalid exposed ports data in connectivity configuration: %v", opt)
+		}
+	}
+
+	if opt, ok := cOptions[netlabel.NoProxy6To4]; ok {
+		if noProxy6To4, ok := opt.(bool); ok {
+			cc.NoProxy6To4 = noProxy6To4
+		} else {
+			return nil, types.InvalidParameterErrorf("invalid "+netlabel.NoProxy6To4+" in connectivity configuration: %v", opt)
 		}
 	}
 

--- a/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -263,6 +263,7 @@ func TestCreateFullOptions(t *testing.T) {
 	}
 
 	netOption := make(map[string]interface{})
+	netOption[netlabel.EnableIPv4] = true
 	netOption[netlabel.EnableIPv6] = true
 	netOption[netlabel.GenericData] = &networkConfiguration{
 		BridgeName: DefaultBridgeName,
@@ -297,7 +298,7 @@ func TestCreateNoConfig(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver()
 
-	netconfig := &networkConfiguration{BridgeName: DefaultBridgeName}
+	netconfig := &networkConfiguration{BridgeName: DefaultBridgeName, EnableIPv4: true}
 	genericOption := make(map[string]interface{})
 	genericOption[netlabel.GenericData] = netconfig
 
@@ -337,6 +338,7 @@ func TestCreateFullOptionsLabels(t *testing.T) {
 	}
 
 	netOption := make(map[string]interface{})
+	netOption[netlabel.EnableIPv4] = true
 	netOption[netlabel.EnableIPv6] = true
 	netOption[netlabel.GenericData] = labels
 
@@ -362,6 +364,10 @@ func TestCreateFullOptionsLabels(t *testing.T) {
 
 	if nw.config.BridgeName != DefaultBridgeName {
 		t.Fatal("incongruent name in bridge network")
+	}
+
+	if !nw.config.EnableIPv4 {
+		t.Fatal("incongruent EnableIPv4 in bridge network")
 	}
 
 	if !nw.config.EnableIPv6 {
@@ -420,7 +426,7 @@ func TestCreate(t *testing.T) {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
 
-	netconfig := &networkConfiguration{BridgeName: DefaultBridgeName}
+	netconfig := &networkConfiguration{BridgeName: DefaultBridgeName, EnableIPv4: true}
 	genericOption := make(map[string]interface{})
 	genericOption[netlabel.GenericData] = netconfig
 
@@ -470,7 +476,7 @@ func TestCreateMultipleNetworks(t *testing.T) {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
 
-	config1 := &networkConfiguration{BridgeName: "net_test_1"}
+	config1 := &networkConfiguration{BridgeName: "net_test_1", EnableIPv4: true}
 	genericOption = make(map[string]interface{})
 	genericOption[netlabel.GenericData] = config1
 	if err := d.CreateNetwork("1", genericOption, nil, getIPv4Data(t), nil); err != nil {
@@ -479,7 +485,7 @@ func TestCreateMultipleNetworks(t *testing.T) {
 
 	verifyV4INCEntries(d.networks, t)
 
-	config2 := &networkConfiguration{BridgeName: "net_test_2"}
+	config2 := &networkConfiguration{BridgeName: "net_test_2", EnableIPv4: true}
 	genericOption[netlabel.GenericData] = config2
 	if err := d.CreateNetwork("2", genericOption, nil, getIPv4Data(t), nil); err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
@@ -487,7 +493,7 @@ func TestCreateMultipleNetworks(t *testing.T) {
 
 	verifyV4INCEntries(d.networks, t)
 
-	config3 := &networkConfiguration{BridgeName: "net_test_3"}
+	config3 := &networkConfiguration{BridgeName: "net_test_3", EnableIPv4: true}
 	genericOption[netlabel.GenericData] = config3
 	if err := d.CreateNetwork("3", genericOption, nil, getIPv4Data(t), nil); err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
@@ -495,7 +501,7 @@ func TestCreateMultipleNetworks(t *testing.T) {
 
 	verifyV4INCEntries(d.networks, t)
 
-	config4 := &networkConfiguration{BridgeName: "net_test_4"}
+	config4 := &networkConfiguration{BridgeName: "net_test_4", EnableIPv4: true}
 	genericOption[netlabel.GenericData] = config4
 	if err := d.CreateNetwork("4", genericOption, nil, getIPv4Data(t), nil); err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
@@ -686,6 +692,7 @@ func testQueryEndpointInfo(t *testing.T, ulPxyEnabled bool) {
 
 	netconfig := &networkConfiguration{
 		BridgeName: DefaultBridgeName,
+		EnableIPv4: true,
 		EnableICC:  false,
 	}
 	genericOption = make(map[string]interface{})
@@ -788,6 +795,7 @@ func TestLinkContainers(t *testing.T) {
 
 	netconfig := &networkConfiguration{
 		BridgeName: DefaultBridgeName,
+		EnableIPv4: true,
 		EnableICC:  false,
 	}
 	genericOption = make(map[string]interface{})
@@ -927,23 +935,27 @@ func TestLinkContainers(t *testing.T) {
 func TestValidateConfig(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 
-	// Test mtu
-	c := networkConfiguration{Mtu: -2}
+	// Bridge network
+	_, network, _ := net.ParseCIDR("172.28.0.0/16")
+	c := networkConfiguration{
+		AddressIPv4: network,
+		EnableIPv4:  true,
+	}
 	err := c.Validate()
+	if err != nil {
+		t.Fatal("unexpected validation error:", err)
+	}
+
+	// Test mtu
+	c.Mtu = -2
+	err = c.Validate()
 	if err == nil {
 		t.Fatal("Failed to detect invalid MTU number")
 	}
-
 	c.Mtu = 9000
 	err = c.Validate()
 	if err != nil {
-		t.Fatal("unexpected validation error on MTU number")
-	}
-
-	// Bridge network
-	_, network, _ := net.ParseCIDR("172.28.0.0/16")
-	c = networkConfiguration{
-		AddressIPv4: network,
+		t.Fatal("unexpected validation error on MTU number:", err)
 	}
 
 	err = c.Validate()
@@ -1084,30 +1096,29 @@ func TestSetDefaultGw(t *testing.T) {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
 
-	_, subnetv6, _ := net.ParseCIDR("2001:db8:ea9:9abc:b0c4::/80")
-
-	ipdList := getIPv4Data(t)
-	gw4 := types.GetIPCopy(ipdList[0].Pool.IP).To4()
+	ipam4 := getIPv4Data(t)
+	gw4 := types.GetIPCopy(ipam4[0].Pool.IP).To4()
 	gw4[3] = 254
-	gw6 := net.ParseIP("2001:db8:ea9:9abc:b0c4::254")
+	ipam6 := getIPv6Data(t)
+	gw6 := types.GetIPCopy(ipam6[0].Pool.IP)
+	gw6[15] = 0x42
 
-	config := &networkConfiguration{
-		BridgeName:         DefaultBridgeName,
-		AddressIPv6:        subnetv6,
-		DefaultGatewayIPv4: gw4,
-		DefaultGatewayIPv6: gw6,
+	option := map[string]interface{}{
+		netlabel.EnableIPv4: true,
+		netlabel.EnableIPv6: true,
+		netlabel.GenericData: &networkConfiguration{
+			BridgeName:         DefaultBridgeName,
+			DefaultGatewayIPv4: gw4,
+			DefaultGatewayIPv6: gw6,
+		},
 	}
 
-	genericOption := make(map[string]interface{})
-	genericOption[netlabel.EnableIPv6] = true
-	genericOption[netlabel.GenericData] = config
-
-	err := d.CreateNetwork("dummy", genericOption, nil, ipdList, nil)
+	err := d.CreateNetwork("dummy", option, nil, ipam4, ipam6)
 	if err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
 
-	te := newTestEndpoint(ipdList[0].Pool, 10)
+	te := newTestEndpoint(ipam4[0].Pool, 10)
 	err = d.CreateEndpoint(context.Background(), "dummy", "ep", te.Interface(), nil)
 	if err != nil {
 		t.Fatalf("Failed to create endpoint: %v", err)
@@ -1192,7 +1203,7 @@ func TestCreateWithExistingBridge(t *testing.T) {
 		t.Fatalf("Failed to add IP address to bridge: %v", err)
 	}
 
-	netconfig := &networkConfiguration{BridgeName: brName}
+	netconfig := &networkConfiguration{BridgeName: brName, EnableIPv4: true}
 	genericOption := make(map[string]interface{})
 	genericOption[netlabel.GenericData] = netconfig
 
@@ -1248,7 +1259,7 @@ func TestCreateParallel(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		name := "net" + strconv.Itoa(i)
 		c.Go(t, func() {
-			config := &networkConfiguration{BridgeName: name}
+			config := &networkConfiguration{BridgeName: name, EnableIPv4: true}
 			genericOption := make(map[string]interface{})
 			genericOption[netlabel.GenericData] = config
 			if err := d.CreateNetwork(name, genericOption, nil, ipV4Data, nil); err != nil {

--- a/libnetwork/drivers/bridge/bridge_store.go
+++ b/libnetwork/drivers/bridge/bridge_store.go
@@ -128,6 +128,7 @@ func (ncfg *networkConfiguration) MarshalJSON() ([]byte, error) {
 	nMap := make(map[string]interface{})
 	nMap["ID"] = ncfg.ID
 	nMap["BridgeName"] = ncfg.BridgeName
+	nMap["EnableIPv4"] = ncfg.EnableIPv4
 	nMap["EnableIPv6"] = ncfg.EnableIPv6
 	nMap["EnableIPMasquerade"] = ncfg.EnableIPMasquerade
 	nMap["GwModeIPv4"] = ncfg.GwModeIPv4
@@ -171,6 +172,8 @@ func (ncfg *networkConfiguration) UnmarshalJSON(b []byte) error {
 		if ncfg.AddressIPv4, err = types.ParseCIDR(v.(string)); err != nil {
 			return types.InternalErrorf("failed to decode bridge network address IPv4 after json unmarshal: %s", v.(string))
 		}
+		// For networks created before EnableIPv4 was added ...
+		ncfg.EnableIPv4 = true
 	}
 
 	if v, ok := nMap["AddressIPv6"]; ok {
@@ -197,6 +200,9 @@ func (ncfg *networkConfiguration) UnmarshalJSON(b []byte) error {
 	ncfg.DefaultGatewayIPv6 = net.ParseIP(nMap["DefaultGatewayIPv6"].(string))
 	ncfg.ID = nMap["ID"].(string)
 	ncfg.BridgeName = nMap["BridgeName"].(string)
+	if v, ok := nMap["EnableIPv4"]; ok {
+		ncfg.EnableIPv4 = v.(bool)
+	}
 	ncfg.EnableIPv6 = nMap["EnableIPv6"].(bool)
 	ncfg.EnableIPMasquerade = nMap["EnableIPMasquerade"].(bool)
 	if v, ok := nMap["GwModeIPv4"]; ok {
@@ -275,7 +281,9 @@ func (ep *bridgeEndpoint) MarshalJSON() ([]byte, error) {
 	epMap["nid"] = ep.nid
 	epMap["SrcName"] = ep.srcName
 	epMap["MacAddress"] = ep.macAddress.String()
-	epMap["Addr"] = ep.addr.String()
+	if ep.addr != nil {
+		epMap["Addr"] = ep.addr.String()
+	}
 	if ep.addrv6 != nil {
 		epMap["Addrv6"] = ep.addrv6.String()
 	}

--- a/libnetwork/drivers/bridge/bridge_store.go
+++ b/libnetwork/drivers/bridge/bridge_store.go
@@ -419,7 +419,7 @@ func (n *bridgeNetwork) restorePortAllocations(ep *bridgeEndpoint) {
 	}
 
 	var err error
-	ep.portMapping, err = n.addPortMappings(ep.addr, ep.addrv6, cfg, n.config.DefaultBindingIP)
+	ep.portMapping, err = n.addPortMappings(ep.addr, ep.addrv6, cfg, n.config.DefaultBindingIP, ep.extConnConfig.NoProxy6To4)
 	if err != nil {
 		log.G(context.TODO()).Warnf("Failed to reserve existing port mapping for endpoint %.7s:%v", ep.id, err)
 	}

--- a/libnetwork/drivers/bridge/network_linux_test.go
+++ b/libnetwork/drivers/bridge/network_linux_test.go
@@ -19,16 +19,17 @@ func TestLinkCreate(t *testing.T) {
 	}
 
 	mtu := 1490
-	config := &networkConfiguration{
-		BridgeName: DefaultBridgeName,
-		Mtu:        mtu,
-		EnableIPv6: true,
+	option := map[string]interface{}{
+		netlabel.GenericData: &networkConfiguration{
+			BridgeName: DefaultBridgeName,
+			EnableIPv4: true,
+			EnableIPv6: true,
+			Mtu:        mtu,
+		},
 	}
-	genericOption := make(map[string]interface{})
-	genericOption[netlabel.GenericData] = config
 
 	ipdList := getIPv4Data(t)
-	err := d.CreateNetwork("dummy", genericOption, nil, ipdList, getIPv6Data(t))
+	err := d.CreateNetwork("dummy", option, nil, ipdList, getIPv6Data(t))
 	if err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
@@ -113,15 +114,16 @@ func TestLinkCreateTwo(t *testing.T) {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
 
-	config := &networkConfiguration{
-		BridgeName: DefaultBridgeName,
-		EnableIPv6: true,
+	option := map[string]interface{}{
+		netlabel.GenericData: &networkConfiguration{
+			BridgeName: DefaultBridgeName,
+			EnableIPv4: true,
+			EnableIPv6: true,
+		},
 	}
-	genericOption := make(map[string]interface{})
-	genericOption[netlabel.GenericData] = config
 
 	ipdList := getIPv4Data(t)
-	err := d.CreateNetwork("dummy", genericOption, nil, ipdList, getIPv6Data(t))
+	err := d.CreateNetwork("dummy", option, nil, ipdList, getIPv6Data(t))
 	if err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
@@ -151,14 +153,15 @@ func TestLinkCreateNoEnableIPv6(t *testing.T) {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
 
-	config := &networkConfiguration{
-		BridgeName: DefaultBridgeName,
+	option := map[string]interface{}{
+		netlabel.GenericData: &networkConfiguration{
+			BridgeName: DefaultBridgeName,
+			EnableIPv4: true,
+		},
 	}
-	genericOption := make(map[string]interface{})
-	genericOption[netlabel.GenericData] = config
 
 	ipdList := getIPv4Data(t)
-	err := d.CreateNetwork("dummy", genericOption, nil, ipdList, getIPv6Data(t))
+	err := d.CreateNetwork("dummy", option, nil, ipdList, getIPv6Data(t))
 	if err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
@@ -186,15 +189,16 @@ func TestLinkDelete(t *testing.T) {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
 
-	config := &networkConfiguration{
-		BridgeName: DefaultBridgeName,
-		EnableIPv6: true,
+	option := map[string]interface{}{
+		netlabel.GenericData: &networkConfiguration{
+			BridgeName: DefaultBridgeName,
+			EnableIPv4: true,
+			EnableIPv6: true,
+		},
 	}
-	genericOption := make(map[string]interface{})
-	genericOption[netlabel.GenericData] = config
 
 	ipdList := getIPv4Data(t)
-	err := d.CreateNetwork("dummy", genericOption, nil, ipdList, getIPv6Data(t))
+	err := d.CreateNetwork("dummy", option, nil, ipdList, getIPv6Data(t))
 	if err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}

--- a/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -40,11 +40,12 @@ func TestPortMappingConfig(t *testing.T) {
 	sbOptions := make(map[string]interface{})
 	sbOptions[netlabel.PortMap] = portBindings
 
-	netConfig := &networkConfiguration{
-		BridgeName: DefaultBridgeName,
+	netOptions := map[string]interface{}{
+		netlabel.GenericData: &networkConfiguration{
+			BridgeName: DefaultBridgeName,
+			EnableIPv4: true,
+		},
 	}
-	netOptions := make(map[string]interface{})
-	netOptions[netlabel.GenericData] = netConfig
 
 	ipdList4 := getIPv4Data(t)
 	err := d.CreateNetwork("dummy", netOptions, nil, ipdList4, getIPv6Data(t))
@@ -759,6 +760,7 @@ func TestAddPortMappings(t *testing.T) {
 			n := &bridgeNetwork{
 				config: &networkConfiguration{
 					BridgeName: "dummybridge",
+					EnableIPv4: tc.epAddrV4 != nil,
 					EnableIPv6: tc.epAddrV6 != nil,
 					GwModeIPv4: tc.gwMode4,
 					GwModeIPv6: tc.gwMode6,

--- a/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -421,6 +421,7 @@ func TestAddPortMappings(t *testing.T) {
 		defHostIP    net.IP
 		proxyPath    string
 		busyPortIPv4 int
+		noProxy6To4  bool
 
 		expErr          string
 		expPBs          []types.PortBinding
@@ -571,6 +572,18 @@ func TestAddPortMappings(t *testing.T) {
 			expPBs: []types.PortBinding{
 				{Proto: types.TCP, IP: ctrIP4.IP, Port: 80, HostIP: net.IPv4zero, HostPort: firstEphemPort},
 				{Proto: types.TCP, IP: ctrIP4.IP, Port: 80, HostIP: net.IPv6zero, HostPort: firstEphemPort},
+			},
+		},
+		{
+			name:     "map host ipv6 to ipv4 container with proxy but noProxy6To4",
+			epAddrV4: ctrIP4,
+			cfg: []types.PortBinding{
+				{Proto: types.TCP, HostIP: net.IPv4zero, Port: 80},
+			},
+			proxyPath:   "/dummy/path/to/proxy",
+			noProxy6To4: true,
+			expPBs: []types.PortBinding{
+				{Proto: types.TCP, IP: ctrIP4.IP, Port: 80, HostIP: net.IPv4zero, HostPort: firstEphemPort},
 			},
 		},
 		{
@@ -781,7 +794,7 @@ func TestAddPortMappings(t *testing.T) {
 			err = portallocator.Get().ReleaseAll()
 			assert.NilError(t, err)
 
-			pbs, err := n.addPortMappings(tc.epAddrV4, tc.epAddrV6, tc.cfg, tc.defHostIP)
+			pbs, err := n.addPortMappings(tc.epAddrV4, tc.epAddrV6, tc.cfg, tc.defHostIP, tc.noProxy6To4)
 			if tc.expErr != "" {
 				assert.ErrorContains(t, err, tc.expErr)
 				return

--- a/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
@@ -100,6 +100,7 @@ func TestSetupIPChains(t *testing.T) {
 func getBasicTestConfig() *networkConfiguration {
 	config := &networkConfiguration{
 		BridgeName:  DefaultBridgeName,
+		EnableIPv4:  true,
 		AddressIPv4: &net.IPNet{IP: net.ParseIP(iptablesTestBridgeIP), Mask: net.CIDRMask(16, 32)},
 	}
 	return config
@@ -189,6 +190,7 @@ func TestSetupIP6TablesWithHostIPv4(t *testing.T) {
 		BridgeName:         DefaultBridgeName,
 		AddressIPv4:        &net.IPNet{IP: net.ParseIP(iptablesTestBridgeIP), Mask: net.CIDRMask(16, 32)},
 		EnableIPMasquerade: true,
+		EnableIPv4:         true,
 		EnableIPv6:         true,
 		AddressIPv6:        &net.IPNet{IP: net.ParseIP("2001:db8::1"), Mask: net.CIDRMask(64, 128)},
 		HostIPv4:           net.ParseIP("192.0.2.2"),
@@ -214,6 +216,7 @@ func TestOutgoingNATRules(t *testing.T) {
 		desc               string
 		enableIPTables     bool
 		enableIP6Tables    bool
+		enableIPv4         bool
 		enableIPv6         bool
 		enableIPMasquerade bool
 		hostIPv4           net.IP
@@ -229,15 +232,22 @@ func TestOutgoingNATRules(t *testing.T) {
 		wantIPv6Snat bool
 	}{
 		{
-			desc: "everything disabled",
+			desc:       "everything disabled except ipv4",
+			enableIPv4: true, // one of IPv4 or IPv6 must be enabled
+		},
+		{
+			desc:       "everything disabled except ipv6",
+			enableIPv6: true,
 		},
 		{
 			desc:               "iptables/ip6tables disabled",
+			enableIPv4:         true,
 			enableIPv6:         true,
 			enableIPMasquerade: true,
 		},
 		{
 			desc:               "host IP with iptables/ip6tables disabled",
+			enableIPv4:         true,
 			enableIPv6:         true,
 			enableIPMasquerade: true,
 			hostIPv4:           hostIPv4,
@@ -247,33 +257,53 @@ func TestOutgoingNATRules(t *testing.T) {
 			desc:            "masquerade disabled, no host IP",
 			enableIPTables:  true,
 			enableIP6Tables: true,
+			enableIPv4:      true,
 			enableIPv6:      true,
 		},
 		{
 			desc:            "masquerade disabled, with host IP",
 			enableIPTables:  true,
 			enableIP6Tables: true,
+			enableIPv4:      true,
 			enableIPv6:      true,
 			hostIPv4:        hostIPv4,
 			hostIPv6:        hostIPv6,
 		},
 		{
 			desc:               "IPv4 masquerade, IPv6 disabled",
+			enableIPv4:         true,
 			enableIPTables:     true,
 			enableIPMasquerade: true,
 			wantIPv4Masq:       true,
 		},
 		{
+			desc:               "IPv6 masquerade, IPv4 disabled",
+			enableIPv6:         true,
+			enableIP6Tables:    true,
+			enableIPMasquerade: true,
+			wantIPv6Masq:       true,
+		},
+		{
 			desc:               "IPv4 SNAT, IPv6 disabled",
+			enableIPv4:         true,
 			enableIPTables:     true,
 			enableIPMasquerade: true,
 			hostIPv4:           hostIPv4,
 			wantIPv4Snat:       true,
 		},
 		{
+			desc:               "IPv6 SNAT, IPv4 disabled",
+			enableIPv6:         true,
+			enableIP6Tables:    true,
+			enableIPMasquerade: true,
+			hostIPv6:           hostIPv6,
+			wantIPv6Snat:       true,
+		},
+		{
 			desc:               "IPv4 masquerade, IPv6 masquerade",
 			enableIPTables:     true,
 			enableIP6Tables:    true,
+			enableIPv4:         true,
 			enableIPv6:         true,
 			enableIPMasquerade: true,
 			wantIPv4Masq:       true,
@@ -283,6 +313,7 @@ func TestOutgoingNATRules(t *testing.T) {
 			desc:               "IPv4 masquerade, IPv6 SNAT",
 			enableIPTables:     true,
 			enableIP6Tables:    true,
+			enableIPv4:         true,
 			enableIPv6:         true,
 			enableIPMasquerade: true,
 			hostIPv6:           hostIPv6,
@@ -293,6 +324,7 @@ func TestOutgoingNATRules(t *testing.T) {
 			desc:               "IPv4 SNAT, IPv6 masquerade",
 			enableIPTables:     true,
 			enableIP6Tables:    true,
+			enableIPv4:         true,
 			enableIPv6:         true,
 			enableIPMasquerade: true,
 			hostIPv4:           hostIPv4,
@@ -303,6 +335,7 @@ func TestOutgoingNATRules(t *testing.T) {
 			desc:               "IPv4 SNAT, IPv6 SNAT",
 			enableIPTables:     true,
 			enableIP6Tables:    true,
+			enableIPv4:         true,
 			enableIPv6:         true,
 			enableIPMasquerade: true,
 			hostIPv4:           hostIPv4,
@@ -328,6 +361,7 @@ func TestOutgoingNATRules(t *testing.T) {
 				BridgeName:         br,
 				AddressIPv4:        brIPv4,
 				AddressIPv6:        brIPv6,
+				EnableIPv4:         tc.enableIPv4,
 				EnableIPv6:         tc.enableIPv6,
 				EnableIPMasquerade: tc.enableIPMasquerade,
 				HostIPv4:           tc.hostIPv4,
@@ -335,6 +369,10 @@ func TestOutgoingNATRules(t *testing.T) {
 			}
 			ipv4Data := []driverapi.IPAMData{{Pool: maskedBrIPv4, Gateway: brIPv4}}
 			ipv6Data := []driverapi.IPAMData{{Pool: maskedBrIPv6, Gateway: brIPv6}}
+			if !nc.EnableIPv4 {
+				nc.AddressIPv4 = nil
+				ipv4Data = nil
+			}
 			if !nc.EnableIPv6 {
 				nc.AddressIPv6 = nil
 				ipv6Data = nil

--- a/libnetwork/drivers/bridge/setup_verify_linux.go
+++ b/libnetwork/drivers/bridge/setup_verify_linux.go
@@ -11,7 +11,7 @@ import (
 // setupVerifyAndReconcileIPv4 checks what IPv4 addresses the given i interface has
 // and ensures that they match the passed network config.
 func setupVerifyAndReconcileIPv4(config *networkConfiguration, i *bridgeInterface) error {
-	// Fetch a slice of IPv4 addresses and a slice of IPv6 addresses from the bridge.
+	// Fetch a slice of IPv4 addresses from the bridge.
 	addrsv4, err := i.addresses(netlink.FAMILY_V4)
 	if err != nil {
 		return fmt.Errorf("Failed to verify ip addresses: %v", err)

--- a/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
@@ -31,7 +31,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 		addr:   ifInfo.Address(),
 		addrv6: ifInfo.AddressIPv6(),
 	}
-	if ep.addr == nil {
+	if ep.addr == nil && ep.addrv6 == nil {
 		return fmt.Errorf("create endpoint was not passed an IP address")
 	}
 	// disallow port mapping -p

--- a/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/ns"
@@ -20,7 +21,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 	}
 	n, err := d.getNetwork(nid)
 	if err != nil {
-		return fmt.Errorf("network id %q not found", nid)
+		return errdefs.System(fmt.Errorf("network id %q not found", nid))
 	}
 	if ifInfo.MacAddress() != nil {
 		return fmt.Errorf("ipvlan interfaces do not support custom mac address assignment")
@@ -32,7 +33,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 		addrv6: ifInfo.AddressIPv6(),
 	}
 	if ep.addr == nil && ep.addrv6 == nil {
-		return fmt.Errorf("create endpoint was not passed an IP address")
+		return errdefs.InvalidParameter(fmt.Errorf("create endpoint was not passed an IP address"))
 	}
 	// disallow port mapping -p
 	if opt, ok := epOptions[netlabel.PortMap]; ok {

--- a/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
@@ -32,9 +32,6 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 		addr:   ifInfo.Address(),
 		addrv6: ifInfo.AddressIPv6(),
 	}
-	if ep.addr == nil && ep.addrv6 == nil {
-		return errdefs.InvalidParameter(fmt.Errorf("create endpoint was not passed an IP address"))
-	}
 	// disallow port mapping -p
 	if opt, ok := epOptions[netlabel.PortMap]; ok {
 		if _, ok := opt.([]types.PortBinding); ok {

--- a/libnetwork/drivers/ipvlan/ipvlan_joinleave.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_joinleave.go
@@ -123,6 +123,10 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 				log.G(ctx).Debugf("Ipvlan Endpoint Joined with IPv6_Addr: %s, Gateway: %s, Ipvlan_Mode: %s, Parent: %s",
 					ep.addrv6.IP.String(), v6gw.String(), n.config.IpvlanMode, n.config.Parent)
 			}
+			if len(n.config.Ipv4Subnets) == 0 && len(n.config.Ipv6Subnets) == 0 {
+				// With no addresses, don't need a gateway.
+				jinfo.DisableGatewayService()
+			}
 		}
 	} else {
 		if len(n.config.Ipv4Subnets) > 0 {

--- a/libnetwork/drivers/ipvlan/ipvlan_joinleave.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_joinleave.go
@@ -65,15 +65,17 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 		case modeL3, modeL3S:
 			// disable gateway services to add a default gw using dev eth0 only
 			jinfo.DisableGatewayService()
-			defaultRoute, err := ifaceGateway(defaultV4RouteCidr)
-			if err != nil {
-				return err
+			if ep.addr != nil {
+				defaultRoute, err := ifaceGateway(defaultV4RouteCidr)
+				if err != nil {
+					return err
+				}
+				if err := jinfo.AddStaticRoute(defaultRoute.Destination, defaultRoute.RouteType, defaultRoute.NextHop); err != nil {
+					return fmt.Errorf("failed to set an ipvlan l3/l3s mode ipv4 default gateway: %v", err)
+				}
+				log.G(ctx).Debugf("Ipvlan Endpoint Joined with IPv4_Addr: %s, Ipvlan_Mode: %s, Parent: %s",
+					ep.addr.IP.String(), n.config.IpvlanMode, n.config.Parent)
 			}
-			if err := jinfo.AddStaticRoute(defaultRoute.Destination, defaultRoute.RouteType, defaultRoute.NextHop); err != nil {
-				return fmt.Errorf("failed to set an ipvlan l3/l3s mode ipv4 default gateway: %v", err)
-			}
-			log.G(ctx).Debugf("Ipvlan Endpoint Joined with IPv4_Addr: %s, Ipvlan_Mode: %s, Parent: %s",
-				ep.addr.IP.String(), n.config.IpvlanMode, n.config.Parent)
 			// If the endpoint has a v6 address, set a v6 default route
 			if ep.addrv6 != nil {
 				default6Route, err := ifaceGateway(defaultV6RouteCidr)

--- a/libnetwork/drivers/ipvlan/ipvlan_network.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_network.go
@@ -7,12 +7,14 @@ import (
 	"fmt"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/ns"
 	"github.com/docker/docker/libnetwork/options"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/docker/docker/pkg/parsers/kernel"
+	"github.com/pkg/errors"
 )
 
 // CreateNetwork the network for the specified driver type
@@ -29,7 +31,7 @@ func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo 
 	// reject a null v4 network if ipv4 is required
 	if v, ok := option[netlabel.EnableIPv4]; ok && v.(bool) {
 		if len(ipV4Data) == 0 || ipV4Data[0].Pool.String() == "0.0.0.0/0" {
-			return fmt.Errorf("ipv4 pool is empty")
+			return errdefs.InvalidParameter(errors.New("ipv4 pool is empty"))
 		}
 	}
 	// reject a null v6 network if ipv6 is required

--- a/libnetwork/drivers/macvlan/macvlan_endpoint.go
+++ b/libnetwork/drivers/macvlan/macvlan_endpoint.go
@@ -30,11 +30,17 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 		addrv6: ifInfo.AddressIPv6(),
 		mac:    ifInfo.MacAddress(),
 	}
-	if ep.addr == nil {
+	if ep.addr == nil && ep.addrv6 == nil {
 		return fmt.Errorf("create endpoint was not passed an IP address")
 	}
 	if ep.mac == nil {
-		ep.mac = netutils.GenerateMACFromIP(ep.addr.IP)
+		if ep.addr != nil {
+			ep.mac = netutils.GenerateMACFromIP(ep.addr.IP)
+		} else {
+			// TODO(robmry) - generate an unsolicited ARP to associate this MAC
+			//  address with the IP.
+			ep.mac = netutils.GenerateRandomMAC()
+		}
 		if err := ifInfo.SetMacAddress(ep.mac); err != nil {
 			return err
 		}

--- a/libnetwork/drivers/macvlan/macvlan_endpoint.go
+++ b/libnetwork/drivers/macvlan/macvlan_endpoint.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/docker/libnetwork/netutils"
 	"github.com/docker/docker/libnetwork/ns"
 	"github.com/docker/docker/libnetwork/types"
-	"github.com/pkg/errors"
 )
 
 // CreateEndpoint assigns the mac, ip and endpoint id for the new container
@@ -31,9 +30,6 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 		addr:   ifInfo.Address(),
 		addrv6: ifInfo.AddressIPv6(),
 		mac:    ifInfo.MacAddress(),
-	}
-	if ep.addr == nil && ep.addrv6 == nil {
-		return errdefs.InvalidParameter(errors.New("create endpoint was not passed an IP address"))
 	}
 	if ep.mac == nil {
 		if ep.addr != nil {

--- a/libnetwork/drivers/macvlan/macvlan_endpoint.go
+++ b/libnetwork/drivers/macvlan/macvlan_endpoint.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/netutils"
 	"github.com/docker/docker/libnetwork/ns"
 	"github.com/docker/docker/libnetwork/types"
+	"github.com/pkg/errors"
 )
 
 // CreateEndpoint assigns the mac, ip and endpoint id for the new container
@@ -21,7 +23,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 	}
 	n, err := d.getNetwork(nid)
 	if err != nil {
-		return fmt.Errorf("network id %q not found", nid)
+		return errdefs.System(fmt.Errorf("network id %q not found", nid))
 	}
 	ep := &endpoint{
 		id:     eid,
@@ -31,7 +33,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 		mac:    ifInfo.MacAddress(),
 	}
 	if ep.addr == nil && ep.addrv6 == nil {
-		return fmt.Errorf("create endpoint was not passed an IP address")
+		return errdefs.InvalidParameter(errors.New("create endpoint was not passed an IP address"))
 	}
 	if ep.mac == nil {
 		if ep.addr != nil {

--- a/libnetwork/drivers/macvlan/macvlan_joinleave.go
+++ b/libnetwork/drivers/macvlan/macvlan_joinleave.go
@@ -83,6 +83,10 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 			log.G(ctx).Debugf("Macvlan Endpoint Joined with IPv6_Addr: %s Gateway: %s MacVlan_Mode: %s, Parent: %s",
 				ep.addrv6.IP.String(), v6gw.String(), n.config.MacvlanMode, n.config.Parent)
 		}
+		if len(n.config.Ipv4Subnets) == 0 && len(n.config.Ipv6Subnets) == 0 {
+			// With no addresses, don't need a gateway.
+			jinfo.DisableGatewayService()
+		}
 	} else {
 		if len(n.config.Ipv4Subnets) > 0 {
 			log.G(ctx).Debugf("Macvlan Endpoint Joined with IPv4_Addr: %s, MacVlan_Mode: %s, Parent: %s",

--- a/libnetwork/drivers/macvlan/macvlan_network.go
+++ b/libnetwork/drivers/macvlan/macvlan_network.go
@@ -16,10 +16,19 @@ import (
 
 // CreateNetwork the network for the specified driver type
 func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
-	// reject a null v4 network
-	if len(ipV4Data) == 0 || ipV4Data[0].Pool.String() == "0.0.0.0/0" {
-		return fmt.Errorf("ipv4 pool is empty")
+	// reject a null v4 network if ipv4 is required
+	if v, ok := option[netlabel.EnableIPv4]; ok && v.(bool) {
+		if len(ipV4Data) == 0 || ipV4Data[0].Pool.String() == "0.0.0.0/0" {
+			return fmt.Errorf("ipv4 pool is empty")
+		}
 	}
+	// reject a null v6 network if ipv6 is required
+	if v, ok := option[netlabel.EnableIPv6]; ok && v.(bool) {
+		if len(ipV6Data) == 0 || ipV6Data[0].Pool.String() == "::/0" {
+			return errdefs.InvalidParameter(errors.New("ipv6 pool is empty"))
+		}
+	}
+
 	// parse and validate the config and bind to networkConfiguration
 	config, err := parseNetworkOptions(nid, option)
 	if err != nil {

--- a/libnetwork/drivers/macvlan/macvlan_network.go
+++ b/libnetwork/drivers/macvlan/macvlan_network.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/ns"
 	"github.com/docker/docker/libnetwork/options"
 	"github.com/docker/docker/libnetwork/types"
+	"github.com/pkg/errors"
 )
 
 // CreateNetwork the network for the specified driver type
@@ -19,7 +21,7 @@ func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo 
 	// reject a null v4 network if ipv4 is required
 	if v, ok := option[netlabel.EnableIPv4]; ok && v.(bool) {
 		if len(ipV4Data) == 0 || ipV4Data[0].Pool.String() == "0.0.0.0/0" {
-			return fmt.Errorf("ipv4 pool is empty")
+			return errdefs.InvalidParameter(errors.New("ipv4 pool is empty"))
 		}
 	}
 	// reject a null v6 network if ipv6 is required

--- a/libnetwork/drivers/windows/windows.go
+++ b/libnetwork/drivers/windows/windows.go
@@ -28,6 +28,7 @@ import (
 	"github.com/docker/docker/libnetwork/portmapper"
 	"github.com/docker/docker/libnetwork/scope"
 	"github.com/docker/docker/libnetwork/types"
+	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -283,6 +284,12 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 	genData, ok := option[netlabel.GenericData].(map[string]string)
 	if !ok {
 		return fmt.Errorf("Unknown generic data option")
+	}
+
+	if v, ok := option[netlabel.EnableIPv4]; ok {
+		if enable_IPv4, ok := v.(bool); ok && !enable_IPv4 {
+			return errors.New("IPv4 cannot be disabled on Windows")
+		}
 	}
 
 	// Parse and validate the config. It should not conflict with existing networks' config

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -1119,10 +1119,8 @@ func (ep *Endpoint) assignAddressVersion(ipVer int, ipam ipamapi.Ipam) error {
 	}
 
 	ipInfo := n.getIPInfo(ipVer)
-
-	// ipv6 address is not mandatory
-	if len(ipInfo) == 0 && ipVer == 6 {
-		return nil
+	if len(ipInfo) == 0 {
+		return fmt.Errorf("no IPv%d information available for endpoint %s", ipVer, ep.Name())
 	}
 
 	// The address to program may be chosen by the user or by the network driver in one specific

--- a/libnetwork/endpoint_unix_test.go
+++ b/libnetwork/endpoint_unix_test.go
@@ -25,10 +25,13 @@ ff02::2	ip6-allrouters
 fe90::2	somehost.example.com somehost
 `
 
-	opts := []NetworkOption{NetworkOptionEnableIPv6(true), NetworkOptionIpam(defaultipam.DriverName, "",
-		[]*IpamConf{{PreferredPool: "192.168.222.0/24", Gateway: "192.168.222.1"}},
-		[]*IpamConf{{PreferredPool: "fe90::/64", Gateway: "fe90::1"}},
-		nil)}
+	opts := []NetworkOption{
+		NetworkOptionEnableIPv4(true),
+		NetworkOptionEnableIPv6(true),
+		NetworkOptionIpam(defaultipam.DriverName, "",
+			[]*IpamConf{{PreferredPool: "192.168.222.0/24", Gateway: "192.168.222.1"}},
+			[]*IpamConf{{PreferredPool: "fe90::/64", Gateway: "fe90::1"}}, nil),
+	}
 
 	ctrlr, nws := getTestEnv(t, opts)
 

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -29,6 +29,7 @@ func TestNetworkMarshalling(t *testing.T) {
 		ipamType:    "default",
 		addrSpace:   "viola",
 		networkType: "bridge",
+		enableIPv4:  true,
 		enableIPv6:  true,
 		persist:     true,
 		configOnly:  true,
@@ -138,7 +139,7 @@ func TestNetworkMarshalling(t *testing.T) {
 	}
 
 	if n.name != nn.name || n.id != nn.id || n.networkType != nn.networkType || n.ipamType != nn.ipamType ||
-		n.addrSpace != nn.addrSpace || n.enableIPv6 != nn.enableIPv6 ||
+		n.addrSpace != nn.addrSpace || n.enableIPv4 != nn.enableIPv4 || n.enableIPv6 != nn.enableIPv6 ||
 		n.persist != nn.persist || !compareIpamConfList(n.ipamV4Config, nn.ipamV4Config) ||
 		!compareIpamInfoList(n.ipamV4Info, nn.ipamV4Info) || !compareIpamConfList(n.ipamV6Config, nn.ipamV6Config) ||
 		!compareIpamInfoList(n.ipamV6Info, nn.ipamV6Info) ||

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -177,6 +177,7 @@ func TestNetworkName(t *testing.T) {
 	controller := newController(t)
 
 	netOption := options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork",
 		},
@@ -212,6 +213,7 @@ func TestNetworkType(t *testing.T) {
 	controller := newController(t)
 
 	netOption := options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork",
 		},
@@ -237,6 +239,7 @@ func TestNetworkID(t *testing.T) {
 	controller := newController(t)
 
 	netOption := options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork",
 		},
@@ -265,6 +268,7 @@ func TestDeleteNetworkWithActiveEndpoints(t *testing.T) {
 		"BridgeName": "testnetwork",
 	}
 	option := options.Generic{
+		netlabel.EnableIPv4:  true,
 		netlabel.GenericData: netOption,
 	}
 
@@ -304,7 +308,8 @@ func TestNetworkConfig(t *testing.T) {
 	// Verify config network cannot inherit another config network
 	_, err := controller.NewNetwork("bridge", "config_network0", "",
 		libnetwork.NetworkOptionConfigOnly(),
-		libnetwork.NetworkOptionConfigFrom("anotherConfigNw"))
+		libnetwork.NetworkOptionConfigFrom("anotherConfigNw"),
+	)
 
 	if err == nil {
 		t.Fatal("Expected to fail. But instead succeeded")
@@ -325,6 +330,7 @@ func TestNetworkConfig(t *testing.T) {
 
 	netOptions := []libnetwork.NetworkOption{
 		libnetwork.NetworkOptionConfigOnly(),
+		libnetwork.NetworkOptionEnableIPv4(true),
 		libnetwork.NetworkOptionEnableIPv6(true),
 		libnetwork.NetworkOptionGeneric(option),
 		libnetwork.NetworkOptionIpam("default", "", ipamV4ConfList, ipamV6ConfList, nil),
@@ -353,6 +359,7 @@ func TestNetworkConfig(t *testing.T) {
 
 	// Verify a network cannot be created with both config-from and network specific configurations
 	for i, opt := range []libnetwork.NetworkOption{
+		libnetwork.NetworkOptionEnableIPv4(true),
 		libnetwork.NetworkOptionEnableIPv6(true),
 		libnetwork.NetworkOptionIpam("my-ipam", "", nil, nil, nil),
 		libnetwork.NetworkOptionIpam("", "", ipamV4ConfList, nil, nil),
@@ -406,6 +413,7 @@ func TestUnknownNetwork(t *testing.T) {
 		"BridgeName": "testnetwork",
 	}
 	option := options.Generic{
+		netlabel.EnableIPv4:  true,
 		netlabel.GenericData: netOption,
 	}
 
@@ -437,6 +445,7 @@ func TestUnknownEndpoint(t *testing.T) {
 		"BridgeName": "testnetwork",
 	}
 	option := options.Generic{
+		netlabel.EnableIPv4:  true,
 		netlabel.GenericData: netOption,
 	}
 	ipamV4ConfList := []*libnetwork.IpamConf{{PreferredPool: "192.168.100.0/24"}}
@@ -476,6 +485,7 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 
 	// Create network 1 and add 2 endpoint: ep11, ep12
 	netOption := options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "network1",
 		},
@@ -549,6 +559,7 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 
 	// Create network 2
 	netOption = options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "network2",
 		},
@@ -605,6 +616,7 @@ func TestDuplicateEndpoint(t *testing.T) {
 	controller := newController(t)
 
 	netOption := options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork",
 		},
@@ -654,6 +666,7 @@ func TestControllerQuery(t *testing.T) {
 
 	// Create network 1
 	netOption := options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "network1",
 		},
@@ -670,6 +683,7 @@ func TestControllerQuery(t *testing.T) {
 
 	// Create network 2
 	netOption = options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "network2",
 		},
@@ -755,6 +769,7 @@ func TestNetworkQuery(t *testing.T) {
 
 	// Create network 1 and add 2 endpoint: ep11, ep12
 	netOption := options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "network1",
 		},
@@ -840,6 +855,7 @@ func TestEndpointDeleteWithActiveContainer(t *testing.T) {
 	controller := newController(t)
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork",
 		},
@@ -854,6 +870,7 @@ func TestEndpointDeleteWithActiveContainer(t *testing.T) {
 	}()
 
 	n2, err := createTestNetwork(controller, bridgeNetType, "testnetwork2", options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork2",
 		},
@@ -914,6 +931,7 @@ func TestEndpointMultipleJoins(t *testing.T) {
 	controller := newController(t)
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testmultiple", options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testmultiple",
 		},
@@ -987,6 +1005,7 @@ func TestLeaveAll(t *testing.T) {
 	controller := newController(t)
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork",
 		},
@@ -1002,6 +1021,7 @@ func TestLeaveAll(t *testing.T) {
 	}()
 
 	n2, err := createTestNetwork(controller, bridgeNetType, "testnetwork2", options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork2",
 		},
@@ -1051,6 +1071,7 @@ func TestContainerInvalidLeave(t *testing.T) {
 	controller := newController(t)
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork",
 		},
@@ -1116,6 +1137,7 @@ func TestEndpointUpdateParent(t *testing.T) {
 	controller := newController(t)
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork",
 		},
@@ -1287,6 +1309,7 @@ func makeTesthostNetwork(t *testing.T, c *libnetwork.Controller) *libnetwork.Net
 func makeTestIPv6Network(t *testing.T, c *libnetwork.Controller) *libnetwork.Network {
 	t.Helper()
 	netOptions := options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.EnableIPv6: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork",
@@ -1423,6 +1446,7 @@ func TestBridgeIpv6FromMac(t *testing.T) {
 
 	network, err := controller.NewNetwork(bridgeNetType, "testipv6mac", "",
 		libnetwork.NetworkOptionGeneric(netOption),
+		libnetwork.NetworkOptionEnableIPv4(true),
 		libnetwork.NetworkOptionEnableIPv6(true),
 		libnetwork.NetworkOptionIpam(defaultipam.DriverName, "", ipamV4ConfList, ipamV6ConfList, nil),
 		libnetwork.NetworkOptionDeferIPv6Alloc(true))
@@ -1497,6 +1521,7 @@ func TestEndpointJoin(t *testing.T) {
 	ipamV6ConfList := []*libnetwork.IpamConf{{PreferredPool: "fe90::/64", Gateway: "fe90::22"}}
 	n1, err := controller.NewNetwork(bridgeNetType, "testnetwork1", "",
 		libnetwork.NetworkOptionGeneric(netOption),
+		libnetwork.NetworkOptionEnableIPv4(true),
 		libnetwork.NetworkOptionEnableIPv6(true),
 		libnetwork.NetworkOptionIpam(defaultipam.DriverName, "", nil, ipamV6ConfList, nil),
 		libnetwork.NetworkOptionDeferIPv6Alloc(true))
@@ -1612,6 +1637,7 @@ func TestEndpointJoin(t *testing.T) {
 	// Now test the container joining another network
 	n2, err := createTestNetwork(controller, bridgeNetType, "testnetwork2",
 		options.Generic{
+			netlabel.EnableIPv4: true,
 			netlabel.GenericData: options.Generic{
 				"BridgeName": "testnetwork2",
 			},
@@ -1662,6 +1688,7 @@ func externalKeyTest(t *testing.T, reexec bool) {
 	controller := newController(t)
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork",
 		},
@@ -1676,6 +1703,7 @@ func externalKeyTest(t *testing.T, reexec bool) {
 	}()
 
 	n2, err := createTestNetwork(controller, bridgeNetType, "testnetwork2", options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork2",
 		},
@@ -1973,6 +2001,7 @@ func TestParallel(t *testing.T) {
 	controller := newController(t)
 
 	netOption := options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "network",
 		},
@@ -2034,6 +2063,7 @@ func TestBridge(t *testing.T) {
 	controller := newController(t)
 
 	netOption := options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.EnableIPv6: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName":         "testnetwork",

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -2147,12 +2147,42 @@ func isV6Listenable() bool {
 	return v6ListenableCached
 }
 
+func TestBridgeRequiresIPAM(t *testing.T) {
+	defer netnsutils.SetupTestOSContext(t)()
+	controller := newController(t)
+
+	_, err := controller.NewNetwork(bridgeNetType, "testnetwork", "",
+		libnetwork.NetworkOptionIpam(null.DriverName, "", nil, nil, nil),
+	)
+	assert.Check(t, is.ErrorContains(err, "IPv4 or IPv6 must be enabled"))
+}
+
 func TestNullIpam(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
-	_, err := controller.NewNetwork(bridgeNetType, "testnetworkinternal", "", libnetwork.NetworkOptionIpam(null.DriverName, "", nil, nil, nil))
-	if err == nil || err.Error() != "ipv4 pool is empty" {
-		t.Fatal("bridge network should complain empty pool")
+	tests := []struct {
+		networkType string
+	}{
+		{networkType: bridgeNetType},
+		{networkType: "macvlan"},
+		{networkType: "ipvlan"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.networkType, func(t *testing.T) {
+			_, err := controller.NewNetwork(tc.networkType, "tnet1-"+tc.networkType, "",
+				libnetwork.NetworkOptionEnableIPv4(true),
+				libnetwork.NetworkOptionIpam(null.DriverName, "", nil, nil, nil),
+			)
+			assert.Check(t, is.ErrorContains(err, "ipv4 pool is empty"))
+
+			_, err = controller.NewNetwork(tc.networkType, "tnet2-"+tc.networkType, "",
+				libnetwork.NetworkOptionEnableIPv6(true),
+				libnetwork.NetworkOptionIpam(null.DriverName, "", nil, nil, nil),
+			)
+			assert.Check(t, is.ErrorContains(err, "ipv6 pool is empty"))
+		})
 	}
 }

--- a/libnetwork/netlabel/labels.go
+++ b/libnetwork/netlabel/labels.go
@@ -30,6 +30,9 @@ const (
 	// where the interface name is represented by the string "IFNAME".
 	EndpointSysctls = Prefix + ".endpoint.sysctls"
 
+	// EnableIPv4 constant represents enabling IPV4 at network level
+	EnableIPv4 = Prefix + ".enable_ipv4"
+
 	// EnableIPv6 constant represents enabling IPV6 at network level
 	EnableIPv6 = Prefix + ".enable_ipv6"
 

--- a/libnetwork/netlabel/labels.go
+++ b/libnetwork/netlabel/labels.go
@@ -59,4 +59,8 @@ const (
 
 	// LocalKVClient constants represents the local kv store client
 	LocalKVClient = DriverPrivatePrefix + "localkv_client"
+
+	// NoProxy6To4 disables proxying from an IPv6 host port to an IPv4-only
+	// container, when the default binding address is 0.0.0.0.
+	NoProxy6To4 = DriverPrivatePrefix + ".no_proxy_6to4"
 )

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1525,16 +1525,18 @@ func (n *Network) ipamAllocate() error {
 		}
 	}
 
-	err = n.ipamAllocateVersion(4, ipam)
-	if err != nil {
-		return err
-	}
-
-	defer func() {
+	if n.enableIPv4 {
+		err = n.ipamAllocateVersion(4, ipam)
 		if err != nil {
-			n.ipamReleaseVersion(4, ipam)
+			return err
 		}
-	}()
+
+		defer func() {
+			if err != nil {
+				n.ipamReleaseVersion(4, ipam)
+			}
+		}()
+	}
 
 	if !n.enableIPv6 {
 		return nil

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1210,7 +1210,7 @@ func (n *Network) createEndpoint(ctx context.Context, name string, options ...En
 		ep.ipamOptions[netlabel.MacAddress] = ep.iface.mac.String()
 	}
 
-	if err = ep.assignAddress(ipam, true, n.enableIPv6 && !n.postIPv6); err != nil {
+	if err = ep.assignAddress(ipam, n.enableIPv4, n.enableIPv6 && !n.postIPv6); err != nil {
 		return nil, err
 	}
 	defer func() {

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -187,6 +187,7 @@ type Network struct {
 	ipamV6Config     []*IpamConf
 	ipamV4Info       []*IpamInfo
 	ipamV6Info       []*IpamInfo
+	enableIPv4       bool
 	enableIPv6       bool
 	postIPv6         bool
 	epCnt            *endpointCnt
@@ -368,7 +369,7 @@ func (n *Network) validateConfiguration() error {
 		}
 		if n.ipamType != "" &&
 			n.ipamType != defaultIpamForNetworkType(n.networkType) ||
-			n.enableIPv6 ||
+			n.enableIPv4 || n.enableIPv6 ||
 			len(n.labels) > 0 || len(n.ipamOptions) > 0 ||
 			len(n.ipamV4Config) > 0 || len(n.ipamV6Config) > 0 {
 			return types.ForbiddenErrorf("user specified configurations are not supported if the network depends on a configuration network")
@@ -401,6 +402,7 @@ func (n *Network) validateConfiguration() error {
 
 // applyConfigurationTo applies network specific configurations.
 func (n *Network) applyConfigurationTo(to *Network) error {
+	to.enableIPv4 = n.enableIPv4
 	to.enableIPv6 = n.enableIPv6
 	if len(n.labels) > 0 {
 		to.labels = make(map[string]string, len(n.labels))
@@ -450,6 +452,7 @@ func (n *Network) CopyTo(o datastore.KVObject) error {
 	dstN.scope = n.scope
 	dstN.dynamic = n.dynamic
 	dstN.ipamType = n.ipamType
+	dstN.enableIPv4 = n.enableIPv4
 	dstN.enableIPv6 = n.enableIPv6
 	dstN.persist = n.persist
 	dstN.postIPv6 = n.postIPv6
@@ -539,6 +542,7 @@ func (n *Network) MarshalJSON() ([]byte, error) {
 	netMap["ipamType"] = n.ipamType
 	netMap["ipamOptions"] = n.ipamOptions
 	netMap["addrSpace"] = n.addrSpace
+	netMap["enableIPv4"] = n.enableIPv4
 	netMap["enableIPv6"] = n.enableIPv6
 	if n.generic != nil {
 		netMap["generic"] = n.generic
@@ -601,6 +605,9 @@ func (n *Network) UnmarshalJSON(b []byte) (err error) {
 		}
 	}
 	n.networkType = netMap["networkType"].(string)
+	if v, ok := netMap["enableIPv4"]; ok {
+		n.enableIPv4 = v.(bool)
+	}
 	n.enableIPv6 = netMap["enableIPv6"].(bool)
 
 	// if we weren't unmarshaling to netMap we could simply set n.labels
@@ -698,6 +705,10 @@ func (n *Network) UnmarshalJSON(b []byte) (err error) {
 	if v, ok := netMap["loadBalancerMode"]; ok {
 		n.loadBalancerMode = v.(string)
 	}
+	// Set enableIPv4 for IPv4 networks created before the flag was added.
+	if _, ok := netMap["enableIPv4"]; !ok {
+		n.enableIPv4 = len(n.ipamV4Info) > 0
+	}
 	return nil
 }
 
@@ -712,6 +723,9 @@ func NetworkOptionGeneric(generic map[string]interface{}) NetworkOption {
 	return func(n *Network) {
 		if n.generic == nil {
 			n.generic = make(map[string]interface{})
+		}
+		if val, ok := generic[netlabel.EnableIPv4]; ok {
+			n.enableIPv4 = val.(bool)
 		}
 		if val, ok := generic[netlabel.EnableIPv6]; ok {
 			n.enableIPv6 = val.(bool)
@@ -737,6 +751,17 @@ func NetworkOptionIngress(ingress bool) NetworkOption {
 func NetworkOptionPersist(persist bool) NetworkOption {
 	return func(n *Network) {
 		n.persist = persist
+	}
+}
+
+// NetworkOptionEnableIPv4 returns an option setter to explicitly configure IPv4
+func NetworkOptionEnableIPv4(enableIPv4 bool) NetworkOption {
+	return func(n *Network) {
+		if n.generic == nil {
+			n.generic = make(map[string]interface{})
+		}
+		n.enableIPv4 = enableIPv4
+		n.generic[netlabel.EnableIPv4] = enableIPv4
 	}
 }
 
@@ -1840,6 +1865,13 @@ func (n *Network) Dynamic() bool {
 	defer n.mu.Unlock()
 
 	return n.dynamic
+}
+
+func (n *Network) IPv4Enabled() bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	return n.enableIPv4
 }
 
 func (n *Network) IPv6Enabled() bool {

--- a/libnetwork/resolver_unix_test.go
+++ b/libnetwork/resolver_unix_test.go
@@ -23,7 +23,7 @@ func TestDNSIPQuery(t *testing.T) {
 	}
 	defer c.Stop()
 
-	n, err := c.NewNetwork("bridge", "dtnet1", "", nil)
+	n, err := c.NewNetwork("bridge", "dtnet1", "", NetworkOptionEnableIPv4(true))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +121,7 @@ func TestDNSProxyServFail(t *testing.T) {
 	}
 	defer c.Stop()
 
-	n, err := c.NewNetwork("bridge", "dtnet2", "", nil)
+	n, err := c.NewNetwork("bridge", "dtnet2", "", NetworkOptionEnableIPv4(true))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -595,40 +596,21 @@ func (sb *Sandbox) clearNetworkResources(origEp *Endpoint) error {
 		return nil
 	}
 
-	var (
-		gwepBefore, gwepAfter *Endpoint
-		index                 = -1
-	)
-	for i, e := range sb.endpoints {
-		if e == ep {
-			index = i
-		}
-		if len(e.Gateway()) > 0 && gwepBefore == nil {
-			gwepBefore = e
-		}
-		if index != -1 && gwepBefore != nil {
-			break
-		}
-	}
-
-	if index == -1 {
+	if !slices.Contains(sb.endpoints, ep) {
 		log.G(context.TODO()).Warnf("Endpoint %s has already been deleted", ep.Name())
 		sb.mu.Unlock()
 		return nil
 	}
 
+	gwepBefore4, gwepBefore6 := selectGatewayEndpoint(sb.endpoints)
 	sb.removeEndpointRaw(ep)
-	for _, e := range sb.endpoints {
-		if len(e.Gateway()) > 0 {
-			gwepAfter = e
-			break
-		}
-	}
+	gwepAfter4, gwepAfter6 := selectGatewayEndpoint(sb.endpoints)
 	delete(sb.epPriority, ep.ID())
+
 	sb.mu.Unlock()
 
-	if gwepAfter != nil && gwepBefore != gwepAfter {
-		if err := sb.updateGateway(gwepAfter); err != nil {
+	if (gwepAfter4 != nil && gwepBefore4 != gwepAfter4) || (gwepAfter6 != nil && gwepBefore6 != gwepAfter6) {
+		if err := sb.updateGateway(gwepAfter4, gwepAfter6); err != nil {
 			return err
 		}
 	}

--- a/libnetwork/sandbox_linux.go
+++ b/libnetwork/sandbox_linux.go
@@ -74,9 +74,16 @@ func (sb *Sandbox) Statistics() (map[string]*types.InterfaceStatistics, error) {
 	return m, nil
 }
 
-func (sb *Sandbox) updateGateway(ep *Endpoint) error {
+func (sb *Sandbox) updateGateway(ep4, ep6 *Endpoint) error {
+	var populated4, populated6 bool
 	sb.mu.Lock()
 	osSbox := sb.osSbox
+	if ep4 != nil {
+		_, populated4 = sb.populatedEndpoints[ep4.ID()]
+	}
+	if ep6 != nil {
+		_, populated6 = sb.populatedEndpoints[ep6.ID()]
+	}
 	sb.mu.Unlock()
 	if osSbox == nil {
 		return nil
@@ -84,20 +91,24 @@ func (sb *Sandbox) updateGateway(ep *Endpoint) error {
 	osSbox.UnsetGateway()     //nolint:errcheck
 	osSbox.UnsetGatewayIPv6() //nolint:errcheck
 
-	if ep == nil {
-		return nil
+	if populated4 {
+		ep4.mu.Lock()
+		joinInfo := ep4.joinInfo
+		ep4.mu.Unlock()
+
+		if err := osSbox.SetGateway(joinInfo.gw); err != nil {
+			return fmt.Errorf("failed to set gateway while updating gateway: %v", err)
+		}
 	}
 
-	ep.mu.Lock()
-	joinInfo := ep.joinInfo
-	ep.mu.Unlock()
+	if populated6 {
+		ep6.mu.Lock()
+		joinInfo := ep6.joinInfo
+		ep6.mu.Unlock()
 
-	if err := osSbox.SetGateway(joinInfo.gw); err != nil {
-		return fmt.Errorf("failed to set gateway while updating gateway: %v", err)
-	}
-
-	if err := osSbox.SetGatewayIPv6(joinInfo.gw6); err != nil {
-		return fmt.Errorf("failed to set IPv6 gateway while updating gateway: %v", err)
+		if err := osSbox.SetGatewayIPv6(joinInfo.gw6); err != nil {
+			return fmt.Errorf("failed to set IPv6 gateway while updating gateway: %v", err)
+		}
 	}
 
 	return nil
@@ -277,13 +288,19 @@ func (sb *Sandbox) restoreOslSandbox() error {
 		}
 	}
 
-	gwep := sb.getGatewayEndpoint()
-	if gwep == nil {
-		return nil
+	gwep4, gwep6 := sb.getGatewayEndpoint()
+	if gwep4 != nil {
+		if err := sb.osSbox.Restore(interfaces, routes, gwep4.joinInfo.gw, gwep4.joinInfo.gw6); err != nil {
+			return err
+		}
+	}
+	if gwep6 != nil {
+		if err := sb.osSbox.Restore(interfaces, routes, gwep6.joinInfo.gw, gwep6.joinInfo.gw6); err != nil {
+			return err
+		}
 	}
 
-	// restore osl sandbox
-	return sb.osSbox.Restore(interfaces, routes, gwep.joinInfo.gw, gwep.joinInfo.gw6)
+	return nil
 }
 
 func (sb *Sandbox) populateNetworkResources(ctx context.Context, ep *Endpoint) error {
@@ -352,17 +369,17 @@ func (sb *Sandbox) populateNetworkResources(ctx context.Context, ep *Endpoint) e
 		}
 	}
 
-	if ep == sb.getGatewayEndpoint() {
-		if err := sb.updateGateway(ep); err != nil {
-			return err
-		}
-	}
-
 	// Make sure to add the endpoint to the populated endpoint set
-	// before populating loadbalancers.
+	// before updating gateways or populating loadbalancers.
 	sb.mu.Lock()
 	sb.populatedEndpoints[ep.ID()] = struct{}{}
 	sb.mu.Unlock()
+
+	if gw4, gw6 := sb.getGatewayEndpoint(); ep == gw4 || ep == gw6 {
+		if err := sb.updateGateway(gw4, gw6); err != nil {
+			return err
+		}
+	}
 
 	// Populate load balancer only after updating all the other
 	// information including gateway and other routes so that

--- a/libnetwork/sandbox_unix_test.go
+++ b/libnetwork/sandbox_unix_test.go
@@ -117,9 +117,18 @@ func TestSandboxAddMultiPrio(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 
 	opts := [][]NetworkOption{
-		{NetworkOptionEnableIPv6(true), NetworkOptionIpam(defaultipam.DriverName, "", nil, []*IpamConf{{PreferredPool: "fe90::/64"}}, nil)},
-		{NetworkOptionInternalNetwork()},
-		{},
+		{
+			NetworkOptionEnableIPv4(true),
+			NetworkOptionEnableIPv6(true),
+			NetworkOptionIpam(defaultipam.DriverName, "", nil, []*IpamConf{{PreferredPool: "fe90::/64"}}, nil),
+		},
+		{
+			NetworkOptionEnableIPv4(true),
+			NetworkOptionInternalNetwork(),
+		},
+		{
+			NetworkOptionEnableIPv4(true),
+		},
 	}
 
 	ctrlr, nws := getTestEnv(t, opts...)
@@ -201,10 +210,21 @@ func TestSandboxAddSamePrio(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 
 	opts := [][]NetworkOption{
-		{},
-		{},
-		{NetworkOptionEnableIPv6(true), NetworkOptionIpam(defaultipam.DriverName, "", nil, []*IpamConf{{PreferredPool: "fe90::/64"}}, nil)},
-		{NetworkOptionInternalNetwork()},
+		{
+			NetworkOptionEnableIPv4(true),
+		},
+		{
+			NetworkOptionEnableIPv4(true),
+		},
+		{
+			NetworkOptionEnableIPv4(true),
+			NetworkOptionEnableIPv6(true),
+			NetworkOptionIpam(defaultipam.DriverName, "", nil, []*IpamConf{{PreferredPool: "fe90::/64"}}, nil),
+		},
+		{
+			NetworkOptionEnableIPv4(true),
+			NetworkOptionInternalNetwork(),
+		},
 	}
 
 	ctrlr, nws := getTestEnv(t, opts...)

--- a/libnetwork/sandbox_windows.go
+++ b/libnetwork/sandbox_windows.go
@@ -13,7 +13,7 @@ type containerConfigOS struct {
 
 func releaseOSSboxResources(*osl.Namespace, *Endpoint) {}
 
-func (sb *Sandbox) updateGateway(*Endpoint) error {
+func (sb *Sandbox) updateGateway(_, _ *Endpoint) error {
 	// not implemented on Windows (Sandbox.osSbox is always nil)
 	return nil
 }

--- a/libnetwork/service_common_unix_test.go
+++ b/libnetwork/service_common_unix_test.go
@@ -24,11 +24,11 @@ func TestCleanupServiceDiscovery(t *testing.T) {
 			t.Error(err)
 		}
 	}
-	n1, err := c.NewNetwork("bridge", "net1", "", nil)
+	n1, err := c.NewNetwork("bridge", "net1", "", NetworkOptionEnableIPv4(true))
 	assert.NilError(t, err)
 	defer cleanup(n1)
 
-	n2, err := c.NewNetwork("bridge", "net2", "", nil)
+	n2, err := c.NewNetwork("bridge", "net2", "", NetworkOptionEnableIPv4(true))
 	assert.NilError(t, err)
 	defer cleanup(n2)
 

--- a/libnetwork/service_linux.go
+++ b/libnetwork/service_linux.go
@@ -122,7 +122,7 @@ func (n *Network) addLBBackend(ip net.IP, lb *loadBalancer) {
 
 		if sb.ingress {
 			var gwIP net.IP
-			if ep := sb.getGatewayEndpoint(); ep != nil {
+			if ep, _ := sb.getGatewayEndpoint(); ep != nil {
 				gwIP = ep.Iface().Address().IP
 			}
 			if err := programIngress(gwIP, lb.service.ingressPorts, false); err != nil {
@@ -223,7 +223,7 @@ func (n *Network) rmLBBackend(ip net.IP, lb *loadBalancer, rmService bool, fullR
 
 		if sb.ingress {
 			var gwIP net.IP
-			if ep := sb.getGatewayEndpoint(); ep != nil {
+			if ep, _ := sb.getGatewayEndpoint(); ep != nil {
 				gwIP = ep.Iface().Address().IP
 			}
 			if err := programIngress(gwIP, lb.service.ingressPorts, true); err != nil {


### PR DESCRIPTION
**DRAFT!!! - running tests and still adding words ...**

**- What I did**

- Add option `com.docker.network.enable_ipv4`, and `EnableIPv6` to the API.
- Disabling IPv4 currently requires `--experimental`
  - ... and it's not allowed for swarm-scoped or Windows networks.
- The default (shown in `inspect` output for the predefined `host`, `bridge` and `none` networks is `EnableIPv6: false`, for other networks it's `true`.
- IPv4 and IPv6 (IPAM) can both be disabled for ipvlan and macvlan networks, but one or the other must be enabled for a bridge network.
- **Note:** Once an network with no IPv4 has been created, if the daemon is downgraded it'll fail to start because of the missing IPv4 configuration.

TODOs...
- Add a top-level CLI option `--ipv4`, equivalent to `--ipv6` but with different default behaviour.
- IPv6 only endpoints can't have a MAC address derived from an IPv4 address, so they get a random MAC. In order to support quick recycling of IP addresses, we should send a gratuitous ARP.
- IPv6-only default bridge (if we want that).

**- How I did it**

Mostly mechanical changes.

**_Notes on gateway endpoints ..._**

A gateway endpoint gets the default route and, for the bridge driver, port mappings from the host.

Before this change, a dual-stack endpoint was preferred over an IPv4-only endpoint - if there was an IPv6 endpoint, it was always dual-stack. So, there was no way for the IPv4 and IPv6 gateway endpoints to be different.

Now, a container with IPv4-only and IPv6-only endpoints needs two separate gateways. This is further complicated by the bridge driver's use of `docker-proxy` to map from host IPv6 addresses to an IPv4-only container, when the host address is unspecified in a port mapping.

If an IPv6 Endpoint is added to a Sandbox that only has an IPv4 endpoint, proxying from the host IPv6 address has to stop (so, the IPv4 gateway hasn't changed, but the driver still needs to be reconfigured). And vice-versa, if an IPv6-only endpoint is removed, leaving only IPv4-only endpoints, the host IPv6 proxy needs to be added.

Note that the new IPv6 endpoint may not belong to a bridge network, the bridge driver doesn't have the information it needs to deal with that ... proxying host-IPv6 to container-IPv4 is policy that needs to be handled by libnetwork. So, there's a new (private) driver option `netlabel.NoProxy6To4` that can be passed to the driver's `ProgramExternalConnectivity`. Its value is calculated by libnetwork when an endpoint is added or removed, `true` if the IPv4 and IPv6 gateways are different. When its value changes, the IPv4 gateway is removed by `RevokeExternalConnectivity`, then re-added. So, ongoing connections will be interrupted and, if host ports are not specified in a port mapping, they'll change when the mapping is re-created.

Before this change, when adding a dual-stack macvlan/ipvlan endpoint to a Sandbox that only has IPv4 endpoints, the dual-stack endpoint became the gateway. So, if the existing gateway was an IPv4-only bridge endpoint with port mappings from the host, those port mappings would be removed. With this change, that behaviour is preserved - and the same logic applies when an IPv6-only macvlan/ipvlan is added to a Sandbox with a bridge IPv4-only endpoint; port mappings from host-IPv6 are removed.

_We could offer better control over the way gateway endpoints are selected, default routes, what happens when networks are added/removed, and host port mappings. We could extend the driver interface to add a way to change gateway settings. But, I've treated all that as out-of-scope here._

**- How to verify it**

TODO

**- Description for the changelog**
```markdown changelog
- Add experimental support for IPv6-only `bridge`, `macvlan`, and `ipvlan` networks.
  - To disable IPv4 address assignment for a network, the daemon must be started with `experimental` features enabled.
  - New driver option for `network create`, `-o com.docker.network.enable_ipv4=[true|false]`.
  - API 1.47 adds `EnableIPv4` fields for `POST /networks/create` and `GET /networks/{id}`.
  - `macvlan` and `ipvlan` networks can have IPv4 and IPv6 address assignment disabled, `bridge` must have one or the other.
  - *Note:* once a network has been created without IPv4 network has been created, it is not possible to downgrade the daemon without resetting configuration.
```
