### PR TITLE
api/server/router/grpc: NewRouter: set correct MaxRecvMsgSize, MaxSendMsgSize

### DIFF
--- a/api/server/router/grpc/grpc.go
+++ b/api/server/router/grpc/grpc.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/server/router"
 	"github.com/moby/buildkit/util/grpcerrors"
@@ -32,6 +33,8 @@ func NewRouter(backends ...Backend) router.Router {
 		grpc.StatsHandler(tracing.ServerStatsHandler(otelgrpc.WithTracerProvider(otel.GetTracerProvider()))),
 		grpc.ChainUnaryInterceptor(unaryInterceptor, grpcerrors.UnaryServerInterceptor),
 		grpc.StreamInterceptor(grpcerrors.StreamServerInterceptor),
+		grpc.MaxRecvMsgSize(defaults.DefaultMaxRecvMsgSize),
+		grpc.MaxSendMsgSize(defaults.DefaultMaxSendMsgSize),
 	}
 
 	r := &grpcRouter{


### PR DESCRIPTION
- relates to https://github.com/moby/buildkit/pull/4969
- relates to https://github.com/moby/moby/pull/47683
- fixes https://github.com/moby/buildkit/issues/4948
- fixes https://github.com/docker/buildx/issues/2453
- fixes https://github.com/moby/moby/issues/48164
- possibly related to https://github.com/docker/buildx/issues/2208



### api/server/router/grpc: NewRouter: set correct MaxRecvMsgSize, MaxSendMsgSize

[buildkit@29b4b1a537][1] applied changes to `buildkitd` to set the correct defaults, which should be 16MB, but used the library defaults. Without that change, builds using large Dockerfiles would fail with a `ResourceExhausted` error;

    => [internal] load build definition from Dockerfile
     => => transferring dockerfile: 896.44kB
    ERROR: failed to receive status: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (44865299 vs. 16777216)

However those changes were applied to the `buildkitd` code, which is the daemon when running BuildKit standalone (or in a container through the `container` driver). When running a build with the BuildKit builder compiled into the Docker Engine, that code is not used, so the BuildKit changes did not fix the issue.

This patch applies the same changes as were made in [buildkit@29b4b1a537][1] to the gRPC endpoint provided by the dockerd daemon.

[1]: https://github.com/moby/buildkit/commit/29b4b1a53795c5f2e4469a2ead7891ba0d704bca

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix a regression that could result in a `ResourceExhausted desc = grpc: received message larger than max` error when building from a large Dockerfile
```

**- A picture of a cute animal (not mandatory but encouraged)**

