### PR TITLE
daemon: assorted cleanups and minor improvements

### DIFF
--- a/daemon/containerfs_linux.go
+++ b/daemon/containerfs_linux.go
@@ -53,14 +53,14 @@ type containerFSView struct {
 }
 
 // openContainerFS opens a new view of the container's filesystem.
-func (daemon *Daemon) openContainerFS(ctr *container.Container) (_ *containerFSView, err error) {
+func (daemon *Daemon) openContainerFS(ctr *container.Container) (_ *containerFSView, retErr error) {
 	ctx := context.TODO()
 
 	if err := daemon.Mount(ctr); err != nil {
 		return nil, err
 	}
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			_ = daemon.Unmount(ctr)
 		}
 	}()
@@ -72,7 +72,7 @@ func (daemon *Daemon) openContainerFS(ctr *container.Container) (_ *containerFSV
 	defer func() {
 		ctx := context.WithoutCancel(ctx)
 		cleanup(ctx)
-		if err != nil {
+		if retErr != nil {
 			_ = ctr.UnmountVolumes(ctx, daemon.LogVolumeEvent)
 		}
 	}()

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -506,11 +506,9 @@ func inSlice(slice []string, s string) bool {
 }
 
 // withMounts sets the container's mounts
-func withMounts(daemon *Daemon, daemonCfg *configStore, c *container.Container, ms []container.Mount) coci.SpecOpts {
+func withMounts(daemon *Daemon, daemonCfg *configStore, c *container.Container, mounts []container.Mount) coci.SpecOpts {
 	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) (err error) {
-		sortMounts(ms)
-
-		mounts := ms
+		sortMounts(mounts)
 
 		userMounts := make(map[string]struct{})
 		for _, m := range mounts {

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -509,7 +508,7 @@ func inSlice(slice []string, s string) bool {
 // withMounts sets the container's mounts
 func withMounts(daemon *Daemon, daemonCfg *configStore, c *container.Container, ms []container.Mount) coci.SpecOpts {
 	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) (err error) {
-		sort.Sort(mounts(ms))
+		sortMounts(ms)
 
 		mounts := ms
 

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -24,27 +24,29 @@ import (
 
 var _ volume.LiveRestorer = (*volumeWrapper)(nil)
 
-type mounts []container.Mount
+// mountSort implements [sort.Interface] to sort an array of mounts in
+// lexicographic order.
+type mountSort []container.Mount
 
 // Len returns the number of mounts. Used in sorting.
-func (m mounts) Len() int {
+func (m mountSort) Len() int {
 	return len(m)
 }
 
 // Less returns true if the number of parts (a/b/c would be 3 parts) in the
 // mount indexed by parameter 1 is less than that of the mount indexed by
 // parameter 2. Used in sorting.
-func (m mounts) Less(i, j int) bool {
+func (m mountSort) Less(i, j int) bool {
 	return m.parts(i) < m.parts(j)
 }
 
 // Swap swaps two items in an array of mounts. Used in sorting
-func (m mounts) Swap(i, j int) {
+func (m mountSort) Swap(i, j int) {
 	m[i], m[j] = m[j], m[i]
 }
 
 // parts returns the number of parts in the destination of a mount. Used in sorting.
-func (m mounts) parts(i int) int {
+func (m mountSort) parts(i int) int {
 	return strings.Count(filepath.Clean(m[i].Destination), string(os.PathSeparator))
 }
 
@@ -52,7 +54,7 @@ func (m mounts) parts(i int) int {
 // when mounting, the mounts don't shadow other mounts. For example, if mounting
 // /etc and /etc/resolv.conf, /etc/resolv.conf must not be mounted first.
 func sortMounts(m []container.Mount) []container.Mount {
-	sort.Sort(mounts(m))
+	sort.Sort(mountSort(m))
 	return m
 }
 

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -45,6 +46,14 @@ func (m mounts) Swap(i, j int) {
 // parts returns the number of parts in the destination of a mount. Used in sorting.
 func (m mounts) parts(i int) int {
 	return strings.Count(filepath.Clean(m[i].Destination), string(os.PathSeparator))
+}
+
+// sortMounts sorts an array of mounts in lexicographic order. This ensure that
+// when mounting, the mounts don't shadow other mounts. For example, if mounting
+// /etc and /etc/resolv.conf, /etc/resolv.conf must not be mounted first.
+func sortMounts(m []container.Mount) []container.Mount {
+	sort.Sort(mounts(m))
+	return m
 }
 
 // registerMountPoints initializes the container mount points with the configured volumes and bind mounts.

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -36,9 +36,9 @@ func (daemon *Daemon) setupMounts(ctx context.Context, c *container.Container) (
 		tmpfsMounts[m.Destination] = true
 	}
 
-	cleanups := cleanups.Composite{}
+	mntCleanups := cleanups.Composite{}
 	defer func() {
-		if err := cleanups.Call(context.WithoutCancel(ctx)); err != nil {
+		if err := mntCleanups.Call(context.WithoutCancel(ctx)); err != nil {
 			log.G(ctx).WithError(err).Warn("failed to cleanup temporary mounts created by MountPoint.Setup")
 		}
 	}()
@@ -65,7 +65,7 @@ func (daemon *Daemon) setupMounts(ctx context.Context, c *container.Container) (
 		if err != nil {
 			return nil, nil, err
 		}
-		cleanups.Add(clean)
+		mntCleanups.Add(clean)
 
 		if !c.TrySetNetworkMount(m.Destination, path) {
 			mnt := container.Mount{
@@ -117,7 +117,7 @@ func (daemon *Daemon) setupMounts(ctx context.Context, c *container.Container) (
 			}
 		}
 	}
-	return append(mounts, netMounts...), cleanups.Release(), nil
+	return append(mounts, netMounts...), mntCleanups.Release(), nil
 }
 
 // setBindModeIfNull is platform specific processing to ensure the

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -119,14 +118,6 @@ func (daemon *Daemon) setupMounts(ctx context.Context, c *container.Container) (
 		}
 	}
 	return append(mounts, netMounts...), cleanups.Release(), nil
-}
-
-// sortMounts sorts an array of mounts in lexicographic order. This ensure that
-// when mounting, the mounts don't shadow other mounts. For example, if mounting
-// /etc and /etc/resolv.conf, /etc/resolv.conf must not be mounted first.
-func sortMounts(m []container.Mount) []container.Mount {
-	sort.Sort(mounts(m))
-	return m
 }
 
 // setBindModeIfNull is platform specific processing to ensure the

--- a/daemon/volumes_windows.go
+++ b/daemon/volumes_windows.go
@@ -2,7 +2,6 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"context"
-	"sort"
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/types/mount"
@@ -49,8 +48,7 @@ func (daemon *Daemon) setupMounts(ctx context.Context, c *container.Container) (
 		})
 	}
 
-	sort.Sort(mounts(mnts))
-	return mnts, mntCleanups.Release(), nil
+	return sortMounts(mnts), mntCleanups.Release(), nil
 }
 
 // setBindModeIfNull is platform specific processing which is a no-op on


### PR DESCRIPTION
### daemon: move sortMounts to a platform-agnostic file

The same code was used both on Linux and Windows; move it to a platform-
agnostic file so that both can use this function, which contains GoDoc
describing the functionality.

### daemon: rename "mounts" type to reduce shadowing

Use a more distinct name, so that local variables can use it. While
at it, also added GoDoc to describe its functionality.


### daemon: setupMounts: rename var that shadowed import

The cleanups var collided with the cleanups import; rename it to use
the same name as is used in the Windows implementation.


### daemon: openContainerFS: rename output var

### daemon: openContainerFS: log cleanup errors

These errors were unhandled; log them (at debug level for now).
