### PR TITLE
libcontainerd/supervisor: un-embed and un-export containerd Config

### DIFF
--- a/libcontainerd/supervisor/remote_daemon.go
+++ b/libcontainerd/supervisor/remote_daemon.go
@@ -33,7 +33,7 @@ const (
 )
 
 type remote struct {
-	config.Config
+	config config.Config
 
 	// configFile is the location where the generated containerd configuration
 	// file is saved.
@@ -64,7 +64,7 @@ type DaemonOpt func(c *remote) error
 // Start starts a containerd daemon and monitors it
 func Start(ctx context.Context, rootDir, stateDir string, opts ...DaemonOpt) (Daemon, error) {
 	r := &remote{
-		Config: config.Config{
+		config: config.Config{
 			Version: 2,
 			Root:    filepath.Join(rootDir, "daemon"),
 			State:   filepath.Join(stateDir, "daemon"),
@@ -127,7 +127,7 @@ func (r *remote) WaitTimeout(d time.Duration) error {
 }
 
 func (r *remote) Address() string {
-	return r.GRPC.Address
+	return r.config.GRPC.Address
 }
 
 func (r *remote) getContainerdConfig() (string, error) {
@@ -267,7 +267,7 @@ func (r *remote) monitorDaemon(ctx context.Context) {
 				}
 			}
 
-			if err := os.RemoveAll(r.GRPC.Address); err != nil {
+			if err := os.RemoveAll(r.config.GRPC.Address); err != nil {
 				r.logger.WithError(err).Error("failed to remove old gRPC address")
 			}
 			if err := r.startContainerd(); err != nil {
@@ -282,7 +282,7 @@ func (r *remote) monitorDaemon(ctx context.Context) {
 
 			const connTimeout = 60 * time.Second
 			client, err = containerd.New(
-				r.GRPC.Address,
+				r.config.GRPC.Address,
 				containerd.WithTimeout(connTimeout),
 				containerd.WithDialOpts([]grpc.DialOption{
 					grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -300,7 +300,7 @@ func (r *remote) monitorDaemon(ctx context.Context) {
 				delay = 100 * time.Millisecond
 				continue
 			}
-			r.logger.WithField("address", r.GRPC.Address).Debug("created containerd monitoring client")
+			r.logger.WithField("address", r.config.GRPC.Address).Debug("created containerd monitoring client")
 		}
 
 		if client != nil {

--- a/libcontainerd/supervisor/remote_daemon_options.go
+++ b/libcontainerd/supervisor/remote_daemon_options.go
@@ -16,7 +16,7 @@ func WithLogLevel(lvl string) DaemonOpt {
 			// so don't pass the default.
 			lvl = ""
 		}
-		r.Config.Debug.Level = lvl
+		r.config.Debug.Level = lvl
 		return nil
 	}
 }
@@ -25,7 +25,7 @@ func WithLogLevel(lvl string) DaemonOpt {
 // This only makes sense if WithStartDaemon() was set to true.
 func WithLogFormat(format log.OutputFormat) DaemonOpt {
 	return func(r *remote) error {
-		r.Debug.Format = string(format)
+		r.config.Debug.Format = string(format)
 		return nil
 	}
 }
@@ -33,7 +33,7 @@ func WithLogFormat(format log.OutputFormat) DaemonOpt {
 // WithCRIDisabled disables the CRI plugin.
 func WithCRIDisabled() DaemonOpt {
 	return func(r *remote) error {
-		r.DisabledPlugins = append(r.DisabledPlugins, "io.containerd.grpc.v1.cri")
+		r.config.DisabledPlugins = append(r.config.DisabledPlugins, "io.containerd.grpc.v1.cri")
 		return nil
 	}
 }


### PR DESCRIPTION
Relates to

- https://github.com/moby/moby/pull/45484
- https://github.com/moby/moby/pull/43945


### libcontainerd/supervisor: un-embed and un-export containerd Config

Make it slightly more clear that this struct is only mutated internally
or through `DaemonOpt` options.

