### PR TITLE
[25.0 backport] api: adjust health start interval on swarm update

### DIFF
--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -224,14 +224,6 @@ func (sr *swarmRouter) createService(ctx context.Context, w http.ResponseWriter,
 		adjustForAPIVersion(v, &service)
 	}
 
-	version := httputils.VersionFromContext(ctx)
-	if versions.LessThan(version, "1.44") {
-		if service.TaskTemplate.ContainerSpec != nil && service.TaskTemplate.ContainerSpec.Healthcheck != nil {
-			// StartInterval was added in API 1.44
-			service.TaskTemplate.ContainerSpec.Healthcheck.StartInterval = 0
-		}
-	}
-
 	resp, err := sr.backend.CreateService(service, encodedAuth, queryRegistry)
 	if err != nil {
 		log.G(ctx).WithFields(log.Fields{

--- a/api/server/router/swarm/helpers.go
+++ b/api/server/router/swarm/helpers.go
@@ -121,11 +121,17 @@ func adjustForAPIVersion(cliVersion string, service *swarm.ServiceSpec) {
 	}
 
 	if versions.LessThan(cliVersion, "1.44") {
-		// seccomp, apparmor, and no_new_privs were added in 1.44.
-		if service.TaskTemplate.ContainerSpec != nil && service.TaskTemplate.ContainerSpec.Privileges != nil {
-			service.TaskTemplate.ContainerSpec.Privileges.Seccomp = nil
-			service.TaskTemplate.ContainerSpec.Privileges.AppArmor = nil
-			service.TaskTemplate.ContainerSpec.Privileges.NoNewPrivileges = false
+		if service.TaskTemplate.ContainerSpec != nil {
+			// seccomp, apparmor, and no_new_privs were added in 1.44.
+			if service.TaskTemplate.ContainerSpec.Privileges != nil {
+				service.TaskTemplate.ContainerSpec.Privileges.Seccomp = nil
+				service.TaskTemplate.ContainerSpec.Privileges.AppArmor = nil
+				service.TaskTemplate.ContainerSpec.Privileges.NoNewPrivileges = false
+			}
+			if service.TaskTemplate.ContainerSpec.Healthcheck != nil {
+				// StartInterval was added in API 1.44
+				service.TaskTemplate.ContainerSpec.Healthcheck.StartInterval = 0
+			}
 		}
 	}
 }


### PR DESCRIPTION
**- What I did**
Backports https://github.com/moby/moby/pull/47991

The health-check start interval added in API v1.44, and the start interval option is ignored when creating a Swarm service using an older API version. However, due to an oversight, the option is not ignored when older API clients _update_ a Swarm service. Fix this oversight by moving the adjustment code into the adjustForAPIVersion function used by both the createService and updateService handler functions.

(cherry picked from commit c8e7fcf91a3ab6b4e961b97b779fcb77de197360)

**- How I did it**
```
git cherry-pick -xsS c8e7fcf91a3ab6b4e961b97b779fcb77de197360
```

**- How to verify it**

**- Description for the changelog**
```markdown changelog
The Healthcheck.StartInterval property is now correctly ignored when updating a Swarm service using API versions less than v1.44.
```

**- A picture of a cute animal (not mandatory but encouraged)**

