### PR TITLE
[26.1 backport] Changed default value of the startInterval to 5s

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -33,6 +33,10 @@ const (
 	// the container unstable. Defaults to none.
 	defaultStartPeriod = 0 * time.Second
 
+	// defaultStartInterval is the default interval between health checks during
+	// the start period.
+	defaultStartInterval = 5 * time.Second
+
 	// Default number of consecutive failures of the health check
 	// for the container to be considered unhealthy.
 	defaultProbeRetries = 3
@@ -251,7 +255,7 @@ func handleProbeResult(d *Daemon, c *container.Container, result *types.Healthch
 // There is never more than one monitor thread running per container at a time.
 func monitor(d *Daemon, c *container.Container, stop chan struct{}, probe probe) {
 	probeInterval := timeoutWithDefault(c.Config.Healthcheck.Interval, defaultProbeInterval)
-	startInterval := timeoutWithDefault(c.Config.Healthcheck.StartInterval, probeInterval)
+	startInterval := timeoutWithDefault(c.Config.Healthcheck.StartInterval, defaultStartInterval)
 	startPeriod := timeoutWithDefault(c.Config.Healthcheck.StartPeriod, defaultStartPeriod)
 
 	c.Lock()


### PR DESCRIPTION
**- What I did**
Backports https://github.com/moby/moby/pull/47799 to 26.1

(cherry picked from commit c514952774fc1809b05ae7d8ffffa0d5e69bfba4)

**- How I did it**
```
git cherry-pick -xsS c514952774fc1809b05ae7d8ffffa0d5e69bfba4
```

**- How to verify it**
Run the container's monitoring thread and check if the startInterval's default value is 5s instead of the original 30s.

**- Description for the changelog**
```markdown changelog
Fix the `StartInterval` default value of healthcheck to reflect the documented value of 5s.
```

**- A picture of a cute animal (not mandatory but encouraged)**

