### PR TITLE
daemon: remove unused import

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -42,7 +42,6 @@ import (
 	"github.com/docker/docker/runconfig"
 	volumemounts "github.com/docker/docker/volume/mounts"
 	"github.com/moby/sys/mount"
-	"github.com/moby/sys/user/userns"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/opencontainers/selinux/go-selinux/label"


### PR DESCRIPTION
This probably broke because 2ce811e632f1b17a9c6786603231e6957942363e and 6d0b508699f39501e0ac2c31652c36e26bf28bbc were merged out of order.

**- A picture of a cute animal (not mandatory but encouraged)**

