### PR TITLE
c8d/inspect: Add `Manifests` field

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -332,7 +332,18 @@ func (ir *imageRouter) deleteImages(ctx context.Context, w http.ResponseWriter, 
 }
 
 func (ir *imageRouter) getImagesByName(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	imageInspect, err := ir.backend.ImageInspect(ctx, vars["name"], backend.ImageInspectOpts{})
+	if err := httputils.ParseForm(r); err != nil {
+		return err
+	}
+
+	var manifests bool
+	if r.Form.Get("manifests") != "" && versions.GreaterThanOrEqualTo(httputils.VersionFromContext(ctx), "1.48") {
+		manifests = httputils.BoolValue(r, "manifests")
+	}
+
+	imageInspect, err := ir.backend.ImageInspect(ctx, vars["name"], backend.ImageInspectOpts{
+		Manifests: manifests,
+	})
 	if err != nil {
 		return err
 	}

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2016,6 +2016,21 @@ definitions:
           compatibility.
         x-nullable: true
         $ref: "#/definitions/OCIDescriptor"
+      Manifests:
+        description: |
+            Manifests is a list of image manifests available in this image. It
+            provides a more detailed view of the platform-specific image manifests or
+            other image-attached data like build attestations.
+
+            Only available if the daemon provides a multi-platform image store
+            and the `manifests` option is set in the inspect request.
+
+            WARNING: This is experimental and may change at any time without any backward
+            compatibility.
+        type: "array"
+        x-nullable: true
+        items:
+          $ref: "#/definitions/ImageManifestSummary"
       RepoTags:
         description: |
           List of image names/tags in the local image cache that reference this
@@ -9648,6 +9663,12 @@ paths:
           description: "Image name or id"
           type: "string"
           required: true
+        - name: "manifests"
+          in: "query"
+          description: "Include Manifests in the image summary."
+          type: "boolean"
+          default: false
+          required: false
       tags: ["Image"]
   /images/{name}/history:
     get:

--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -151,7 +151,9 @@ type GetImageOpts struct {
 }
 
 // ImageInspectOpts holds parameters to inspect an image.
-type ImageInspectOpts struct{}
+type ImageInspectOpts struct {
+	Manifests bool
+}
 
 // CommitConfig is the configuration for creating an image as part of a build.
 type CommitConfig struct {

--- a/api/types/image/image_inspect.go
+++ b/api/types/image/image_inspect.go
@@ -127,4 +127,14 @@ type InspectResponse struct {
 	// WARNING: This is experimental and may change at any time without any backward
 	// compatibility.
 	Descriptor *ocispec.Descriptor `json:"Descriptor,omitempty"`
+
+	// Manifests is a list of image manifests available in this image.  It
+	// provides a more detailed view of the platform-specific image manifests or
+	// other image-attached data like build attestations.
+	//
+	// Only available if the daemon provides a multi-platform image store.
+	//
+	// WARNING: This is experimental and may change at any time without any backward
+	// compatibility.
+	Manifests []ManifestSummary `json:"Manifests,omitempty"`
 }

--- a/api/types/image/opts.go
+++ b/api/types/image/opts.go
@@ -103,6 +103,11 @@ type LoadOptions struct {
 	Platforms []ocispec.Platform
 }
 
+type InspectOptions struct {
+	// Manifests returns the image manifests.
+	Manifests bool
+}
+
 // SaveOptions holds parameters to save images.
 type SaveOptions struct {
 	// Platforms selects the platforms to save if the image is a

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -115,7 +115,10 @@ type ImageAPIClient interface {
 	ImageCreate(ctx context.Context, parentReference string, options image.CreateOptions) (io.ReadCloser, error)
 	ImageHistory(ctx context.Context, image string, opts image.HistoryOptions) ([]image.HistoryResponseItem, error)
 	ImageImport(ctx context.Context, source image.ImportSource, ref string, options image.ImportOptions) (io.ReadCloser, error)
+	// Deprecated: Use [Client.ImageInspect] instead.
+	// Raw response can be obtained by [ImageInspectWithRawResponse] option.
 	ImageInspectWithRaw(ctx context.Context, image string) (image.InspectResponse, []byte, error)
+	ImageInspect(ctx context.Context, image string, _ ...ImageInspectOption) (image.InspectResponse, error)
 	ImageList(ctx context.Context, options image.ListOptions) ([]image.Summary, error)
 	ImageLoad(ctx context.Context, input io.Reader, opts image.LoadOptions) (image.LoadResponse, error)
 	ImagePull(ctx context.Context, ref string, options image.PullOptions) (io.ReadCloser, error)

--- a/client/image_inspect.go
+++ b/client/image_inspect.go
@@ -4,29 +4,88 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
+	"net/url"
 
 	"github.com/docker/docker/api/types/image"
 )
 
-// ImageInspectWithRaw returns the image information and its raw representation.
-func (cli *Client) ImageInspectWithRaw(ctx context.Context, imageID string) (image.InspectResponse, []byte, error) {
+// ImageInspectOption is a type representing functional options for the image inspect operation.
+type ImageInspectOption interface {
+	Apply(*imageInspectOpts) error
+}
+type imageInspectOptionFunc func(opt *imageInspectOpts) error
+
+func (f imageInspectOptionFunc) Apply(o *imageInspectOpts) error {
+	return f(o)
+}
+
+// ImageInspectWithRawResponse instructs the client to additionally store the
+// raw inspect response in the provided buffer.
+func ImageInspectWithRawResponse(raw *bytes.Buffer) ImageInspectOption {
+	return imageInspectOptionFunc(func(opts *imageInspectOpts) error {
+		opts.raw = raw
+		return nil
+	})
+}
+
+// ImageInspectWithAPIOpts sets the API options for the image inspect operation.
+func ImageInspectWithAPIOpts(opts image.InspectOptions) ImageInspectOption {
+	return imageInspectOptionFunc(func(clientOpts *imageInspectOpts) error {
+		clientOpts.apiOptions = opts
+		return nil
+	})
+}
+
+type imageInspectOpts struct {
+	raw        *bytes.Buffer
+	apiOptions image.InspectOptions
+}
+
+// ImageInspect returns the image information.
+func (cli *Client) ImageInspect(ctx context.Context, imageID string, inspectOpts ...ImageInspectOption) (image.InspectResponse, error) {
 	if imageID == "" {
-		return image.InspectResponse{}, nil, objectNotFoundError{object: "image", id: imageID}
-	}
-	serverResp, err := cli.get(ctx, "/images/"+imageID+"/json", nil, nil)
-	defer ensureReaderClosed(serverResp)
-	if err != nil {
-		return image.InspectResponse{}, nil, err
+		return image.InspectResponse{}, objectNotFoundError{object: "image", id: imageID}
 	}
 
-	body, err := io.ReadAll(serverResp.body)
+	var opts imageInspectOpts
+	for _, opt := range inspectOpts {
+		if err := opt.Apply(&opts); err != nil {
+			return image.InspectResponse{}, fmt.Errorf("error applying image inspect option: %w", err)
+		}
+	}
+
+	query := url.Values{}
+	serverResp, err := cli.get(ctx, "/images/"+imageID+"/json", query, nil)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
-		return image.InspectResponse{}, nil, err
+		return image.InspectResponse{}, err
+	}
+
+	buf := opts.raw
+	if buf == nil {
+		buf = &bytes.Buffer{}
+	}
+
+	if _, err := io.Copy(buf, serverResp.body); err != nil {
+		return image.InspectResponse{}, err
 	}
 
 	var response image.InspectResponse
-	rdr := bytes.NewReader(body)
-	err = json.NewDecoder(rdr).Decode(&response)
-	return response, body, err
+	err = json.Unmarshal(buf.Bytes(), &response)
+	return response, err
+}
+
+// ImageInspectWithRaw returns the image information and its raw representation.
+//
+// Deprecated: Use [Client.ImageInspect] instead.
+// Raw response can be obtained by [ImageInspectWithRawResponse] option.
+func (cli *Client) ImageInspectWithRaw(ctx context.Context, imageID string) (image.InspectResponse, []byte, error) {
+	var buf bytes.Buffer
+	resp, err := cli.ImageInspect(ctx, imageID, ImageInspectWithRawResponse(&buf))
+	if err != nil {
+		return image.InspectResponse{}, nil, err
+	}
+	return resp, buf.Bytes(), err
 }

--- a/client/image_inspect_test.go
+++ b/client/image_inspect_test.go
@@ -23,7 +23,7 @@ func TestImageInspectError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, _, err := client.ImageInspectWithRaw(context.Background(), "nothing")
+	_, err := client.ImageInspect(context.Background(), "nothing")
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
@@ -32,7 +32,7 @@ func TestImageInspectImageNotFound(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusNotFound, "Server error")),
 	}
 
-	_, _, err := client.ImageInspectWithRaw(context.Background(), "unknown")
+	_, err := client.ImageInspect(context.Background(), "unknown")
 	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
@@ -42,7 +42,7 @@ func TestImageInspectWithEmptyID(t *testing.T) {
 			return nil, errors.New("should not make request")
 		}),
 	}
-	_, _, err := client.ImageInspectWithRaw(context.Background(), "")
+	_, err := client.ImageInspect(context.Background(), "")
 	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
@@ -68,7 +68,7 @@ func TestImageInspect(t *testing.T) {
 		}),
 	}
 
-	imageInspect, _, err := client.ImageInspectWithRaw(context.Background(), "image_id")
+	imageInspect, err := client.ImageInspect(context.Background(), "image_id")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/daemon/containerd/image_inspect.go
+++ b/daemon/containerd/image_inspect.go
@@ -17,76 +17,57 @@ import (
 	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/storage"
 	"github.com/docker/docker/internal/sliceutil"
+	imagespec "github.com/moby/docker-image-spec/specs-go/v1"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sync/semaphore"
 )
 
 func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, _ backend.ImageInspectOpts) (*imagetypes.InspectResponse, error) {
-	img, err := i.GetImage(ctx, refOrID, backend.GetImageOpts{})
+	c8dImg, err := i.resolveImage(ctx, refOrID)
 	if err != nil {
 		return nil, err
 	}
 
-	lastUpdated := time.Unix(0, 0)
-
-	tagged, err := i.images.List(ctx, "target.digest=="+img.ImageID())
+	target := c8dImg.Target
+	tagged, err := i.images.List(ctx, "target.digest=="+target.Digest.String())
 	if err != nil {
 		return nil, err
 	}
 
-	// This could happen only if the image was deleted after the GetImage call above.
+	// This could happen only if the image was deleted after the resolveImage call above.
 	if len(tagged) == 0 {
 		return nil, errInconsistentData
 	}
 
-	platform := matchAllWithPreference(platforms.Default())
-
-	size, err := i.size(ctx, tagged[0].Target, platform)
-	if err != nil {
-		return nil, err
-	}
-	target := tagged[0].Target
-
-	repoTags := make([]string, 0, len(tagged))
-	repoDigests := make([]string, 0, len(tagged))
+	lastUpdated := time.Unix(0, 0)
 	for _, i := range tagged {
 		if i.UpdatedAt.After(lastUpdated) {
 			lastUpdated = i.UpdatedAt
 		}
-		if isDanglingImage(i) {
-			if len(tagged) > 1 {
-				// This is unexpected - dangling image should be deleted
-				// as soon as another image with the same target is created.
-				// Log a warning, but don't error out the whole operation.
-				log.G(ctx).WithField("refs", tagged).Warn("multiple images have the same target, but one of them is still dangling")
-			}
-			continue
-		}
+	}
 
-		name, err := reference.ParseNamed(i.Name)
-		if err != nil {
-			log.G(ctx).WithField("name", name).WithError(err).Error("failed to parse image name as reference")
-			// Include the malformed name in RepoTags to be consistent with `docker image ls`.
-			repoTags = append(repoTags, i.Name)
-			continue
-		}
+	platform := matchAllWithPreference(platforms.Default())
+	size, err := i.size(ctx, target, platform)
+	if err != nil {
+		return nil, err
+	}
 
-		repoTags = append(repoTags, reference.FamiliarString(name))
-		if _, ok := name.(reference.Digested); ok {
-			repoDigests = append(repoDigests, reference.FamiliarString(name))
-			// Image name is a digested reference already, so no need to create a digested reference.
-			continue
-		}
+	multi, err := i.multiPlatformSummary(ctx, c8dImg, platform)
+	if err != nil {
+		return nil, err
+	}
 
-		digested, err := reference.WithDigest(reference.TrimNamed(name), target.Digest)
-		if err != nil {
-			// This could only happen if digest is invalid, but considering that
-			// we get it from the Descriptor it's highly unlikely.
-			// Log error just in case.
-			log.G(ctx).WithError(err).Error("failed to create digested reference")
-			continue
+	if multi.Best == nil {
+		return nil, &errPlatformNotFound{
+			wanted:   platforms.DefaultSpec(),
+			imageRef: refOrID,
 		}
-		repoDigests = append(repoDigests, reference.FamiliarString(digested))
+	}
+
+	best := multi.Best
+	var img imagespec.DockerOCIImage
+	if err := best.ReadConfig(ctx, &img); err != nil {
+		return nil, err
 	}
 
 	var comment string
@@ -104,17 +85,24 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, _ backe
 		layers = append(layers, layer.String())
 	}
 
+	parent, err := i.getImageLabelByDigest(ctx, target.Digest, imageLabelClassicBuilderParent)
+	if err != nil {
+		log.G(ctx).WithError(err).Warn("failed to determine Parent property")
+	}
+
+	repoTags, repoDigests := i.collectRepoTagsAndDigests(ctx, tagged)
+
 	return &imagetypes.InspectResponse{
-		ID:            img.ImageID(),
+		ID:            target.Digest.String(),
 		RepoTags:      repoTags,
 		Descriptor:    &target,
 		RepoDigests:   sliceutil.Dedup(repoDigests),
-		Parent:        img.Parent.String(),
+		Parent:        parent,
 		Comment:       comment,
 		Created:       created,
 		DockerVersion: "",
 		Author:        img.Author,
-		Config:        img.Config,
+		Config:        dockerOCIImageConfigToContainerConfig(img.Config),
 		Architecture:  img.Architecture,
 		Variant:       img.Variant,
 		Os:            img.OS,
@@ -132,6 +120,51 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, _ backe
 			LastTagTime: lastUpdated,
 		},
 	}, nil
+}
+
+// collectRepoTagsAndDigests returns repoTags and repoDigests for images with the same target.
+func (i *ImageService) collectRepoTagsAndDigests(ctx context.Context, tagged []c8dimages.Image) (
+	repoTags []string, repoDigests []string,
+) {
+	repoTags = make([]string, 0, len(tagged))
+	repoDigests = make([]string, 0, len(tagged))
+	for _, img := range tagged {
+		if isDanglingImage(img) {
+			if len(tagged) > 1 {
+				// This is unexpected - dangling image should be deleted
+				// as soon as another image with the same target is created.
+				// Log a warning, but don't error out the whole operation.
+				log.G(ctx).WithField("refs", tagged).Warn("multiple images have the same target, but one of them is still dangling")
+			}
+			continue
+		}
+
+		name, err := reference.ParseNamed(img.Name)
+		if err != nil {
+			log.G(ctx).WithField("name", name).WithError(err).Error("failed to parse image name as reference")
+			// Include the malformed name in RepoTags to be consistent with `docker image ls`.
+			repoTags = append(repoTags, img.Name)
+			continue
+		}
+
+		repoTags = append(repoTags, reference.FamiliarString(name))
+		if _, ok := name.(reference.Digested); ok {
+			repoDigests = append(repoDigests, reference.FamiliarString(name))
+			// Image name is a digested reference already, so no need to create a digested reference.
+			continue
+		}
+
+		digested, err := reference.WithDigest(reference.TrimNamed(name), img.Target.Digest)
+		if err != nil {
+			// This could only happen if digest is invalid, but considering that
+			// we get it from the Descriptor it's highly unlikely.
+			// Log error just in case.
+			log.G(ctx).WithError(err).Error("failed to create digested reference")
+			continue
+		}
+		repoDigests = append(repoDigests, reference.FamiliarString(digested))
+	}
+	return repoTags, repoDigests
 }
 
 // size returns the total size of the image's packed resources.

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -160,7 +160,7 @@ func (i *ImageService) Images(ctx context.Context, opts imagetypes.ListOptions) 
 
 	for _, img := range uniqueImages {
 		eg.Go(func() error {
-			image, allChainsIDs, err := i.imageSummary(egCtx, img, platformMatcher, opts, tagsByDigest)
+			image, multiSummary, err := i.imageSummary(egCtx, img, platformMatcher, opts, tagsByDigest)
 			if err != nil {
 				return err
 			}
@@ -173,8 +173,8 @@ func (i *ImageService) Images(ctx context.Context, opts imagetypes.ListOptions) 
 			summaries = append(summaries, image)
 
 			if opts.SharedSize {
-				root = append(root, &allChainsIDs)
-				for _, id := range allChainsIDs {
+				root = append(root, &multiSummary.AllChainIDs)
+				for _, id := range multiSummary.AllChainIDs {
 					layers[id] = layers[id] + 1
 				}
 			}
@@ -202,27 +202,31 @@ func (i *ImageService) Images(ctx context.Context, opts imagetypes.ListOptions) 
 	return summaries, nil
 }
 
-// imageSummary returns a summary of the image, including the total size of the image and all its platforms.
-// It also returns the chainIDs of all the layers of the image (including all its platforms).
-// All return values will be nil if the image should be skipped.
-func (i *ImageService) imageSummary(ctx context.Context, img c8dimages.Image, platformMatcher platforms.MatchComparer,
-	opts imagetypes.ListOptions, tagsByDigest map[digest.Digest][]string,
-) (_ *imagetypes.Summary, allChainIDs []digest.Digest, _ error) {
-	var manifestSummaries []imagetypes.ManifestSummary
+type multiPlatformSummary struct {
+	// Image is the containerd image object.
+	Image c8dimages.Image
 
-	// Total size of the image including all its platform
-	var totalSize int64
+	// Manifests contains the summaries of manifests present in this image.
+	Manifests []imagetypes.ManifestSummary
 
-	// ChainIDs of all the layers of the image (including all its platform)
-	var allChainsIDs []digest.Digest
+	// AllChainIDs contains the chainIDs of all the layers of the image (including all its platforms).
+	AllChainIDs []digest.Digest
 
-	// Count of containers using the image
-	var containersCount int64
+	// TotalSize is the total size of the image including all its platform.
+	TotalSize int64
 
-	// Single platform image manifest preferred by the platform matcher
-	var best *ImageManifest
-	var bestPlatform ocispec.Platform
+	// ContainersCount is the count of containers using the image.
+	ContainersCount int64
 
+	// Best is the single platform image manifest preferred by the platform matcher.
+	Best *ImageManifest
+
+	// BestPlatform is the platform of the best image.
+	BestPlatform ocispec.Platform
+}
+
+func (i *ImageService) multiPlatformSummary(ctx context.Context, img c8dimages.Image, platformMatcher platforms.MatchComparer) (*multiPlatformSummary, error) {
+	var summary multiPlatformSummary
 	err := i.walkReachableImageManifests(ctx, img, func(img *ImageManifest) error {
 		target := img.Target()
 
@@ -245,11 +249,9 @@ func (i *ImageService) imageSummary(ctx context.Context, img c8dimages.Image, pl
 			Kind:       imagetypes.ManifestKindUnknown,
 		}
 
-		if opts.Manifests {
-			defer func() {
-				manifestSummaries = append(manifestSummaries, mfstSummary)
-			}()
-		}
+		defer func() {
+			summary.Manifests = append(summary.Manifests, mfstSummary)
+		}()
 
 		contentSize, err := img.Size(ctx)
 		if err != nil {
@@ -258,7 +260,7 @@ func (i *ImageService) imageSummary(ctx context.Context, img c8dimages.Image, pl
 			}
 		} else {
 			mfstSummary.Size.Content = contentSize
-			totalSize += contentSize
+			summary.TotalSize += contentSize
 			mfstSummary.Size.Total += contentSize
 		}
 
@@ -335,20 +337,20 @@ func (i *ImageService) imageSummary(ctx context.Context, img c8dimages.Image, pl
 			// contentSize was already added to total, adjust it by the difference
 			// between the newly calculated size and the old size.
 			d := imgContentSize - contentSize
-			totalSize += d
+			summary.TotalSize += d
 			mfstSummary.Size.Total += d
 		}
 
 		mfstSummary.ImageData.Size.Unpacked = unpackedSize
 		mfstSummary.Size.Total += unpackedSize
-		totalSize += unpackedSize
+		summary.TotalSize += unpackedSize
 
-		allChainsIDs = append(allChainsIDs, chainIDs...)
+		summary.AllChainIDs = append(summary.AllChainIDs, chainIDs...)
 
 		for _, c := range i.containers.List() {
 			if c.ImageManifest != nil && c.ImageManifest.Digest == target.Digest {
 				mfstSummary.ImageData.Containers = append(mfstSummary.ImageData.Containers, c.ID)
-				containersCount++
+				summary.ContainersCount++
 			}
 		}
 
@@ -361,9 +363,9 @@ func (i *ImageService) imageSummary(ctx context.Context, img c8dimages.Image, pl
 			return nil
 		}
 
-		if best == nil || platformMatcher.Less(platform, bestPlatform) {
-			best = img
-			bestPlatform = platform
+		if summary.Best == nil || platformMatcher.Less(platform, summary.BestPlatform) {
+			summary.Best = img
+			summary.BestPlatform = platform
 		}
 
 		return nil
@@ -375,17 +377,32 @@ func (i *ImageService) imageSummary(ctx context.Context, img c8dimages.Image, pl
 				"image": img.Name,
 			}).Warn("unexpected image target (neither a manifest nor index)")
 		} else {
-			return nil, nil, err
+			return nil, err
 		}
 	}
 
+	return &summary, nil
+}
+
+// imageSummary returns a summary of the image, including the total size of the image and all its platforms.
+// It also returns the chainIDs of all the layers of the image (including all its platforms).
+// All return values will be nil if the image should be skipped.
+func (i *ImageService) imageSummary(ctx context.Context, img c8dimages.Image, platformMatcher platforms.MatchComparer,
+	opts imagetypes.ListOptions, tagsByDigest map[digest.Digest][]string,
+) (*imagetypes.Summary, *multiPlatformSummary, error) {
+	summary, err := i.multiPlatformSummary(ctx, img, platformMatcher)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	best := summary.Best
 	if best == nil {
 		target := img.Target
 		return &imagetypes.Summary{
 			ID:          target.Digest.String(),
 			RepoDigests: []string{target.Digest.String()},
 			RepoTags:    tagsByDigest[target.Digest],
-			Size:        totalSize,
+			Size:        summary.TotalSize,
 			// -1 indicates that the value has not been set (avoids ambiguity
 			// between 0 (default) and "not set". We cannot use a pointer (nil)
 			// for this, as the JSON representation uses "omitempty", which would
@@ -400,15 +417,15 @@ func (i *ImageService) imageSummary(ctx context.Context, img c8dimages.Image, pl
 	if err != nil {
 		return nil, nil, err
 	}
-	image.Size = totalSize
-	image.Manifests = manifestSummaries
+	image.Size = summary.TotalSize
+	image.Manifests = summary.Manifests
 	target := img.Target
 	image.Descriptor = &target
 
 	if opts.ContainerCount {
-		image.Containers = containersCount
+		image.Containers = summary.ContainersCount
 	}
-	return image, allChainsIDs, nil
+	return image, summary, nil
 }
 
 func (i *ImageService) singlePlatformSize(ctx context.Context, imgMfst *ImageManifest) (unpackedSize int64, contentSize int64, _ error) {

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -169,6 +169,9 @@ func (i *ImageService) Images(ctx context.Context, opts imagetypes.ListOptions) 
 				return nil
 			}
 
+			if !opts.Manifests {
+				image.Manifests = nil
+			}
 			resultsMut.Lock()
 			summaries = append(summaries, image)
 

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -51,6 +51,13 @@ keywords: "API, Docker, rcli, REST, documentation"
   image store.
   WARNING: This is experimental and may change at any time without any backward
   compatibility.
+* `GET /images/{name}/json` response now will return the `Manifests` field
+  containing information about the sub-manifests contained in the image index.
+  This includes things like platform-specific manifests and build attestations.
+  The new field will only be populated if the request also sets the `manifests`
+  query parameter to `true`.
+  This acts the same as in the `GET /images/json` endpoint.
+  WARNING: This is experimental and may change at any time without any backward compatibility.
 * `GET /containers/{name}/json` now returns an `ImageManifestDescriptor` field
   containing the OCI descriptor of the platform-specific image manifest of the
   image that was used to create the container.

--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -320,7 +320,7 @@ func (s *DockerAPISuite) TestBuildOnBuildCache(c *testing.T) {
 	// check parentID is correct
 	// Parent is graphdriver-only
 	if !testEnv.UsingSnapshotter() {
-		image, _, err := client.ImageInspectWithRaw(ctx, childID)
+		image, err := client.ImageInspect(ctx, childID)
 		assert.NilError(c, err)
 
 		assert.Check(c, is.Equal(parentID, image.Parent))

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -76,7 +76,7 @@ func (s *DockerAPISuite) TestInspectAPIImageResponse(c *testing.T) {
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
-	imageJSON, _, err := apiClient.ImageInspectWithRaw(testutil.GetContext(c), "busybox")
+	imageJSON, err := apiClient.ImageInspect(testutil.GetContext(c), "busybox")
 	assert.NilError(c, err)
 
 	assert.Check(c, len(imageJSON.RepoTags) == 2)

--- a/integration/build/build_squash_test.go
+++ b/integration/build/build_squash_test.go
@@ -65,7 +65,7 @@ func TestBuildSquashParent(t *testing.T) {
 	resp.Body.Close()
 	assert.NilError(t, err)
 
-	inspect, _, err := client.ImageInspectWithRaw(ctx, name)
+	inspect, err := client.ImageInspect(ctx, name)
 	assert.NilError(t, err)
 	origID := inspect.ID
 
@@ -114,7 +114,7 @@ func TestBuildSquashParent(t *testing.T) {
 	testHistory, err := client.ImageHistory(ctx, name, image.HistoryOptions{})
 	assert.NilError(t, err)
 
-	inspect, _, err = client.ImageInspectWithRaw(ctx, name)
+	inspect, err = client.ImageInspect(ctx, name)
 	assert.NilError(t, err)
 	assert.Check(t, is.Len(testHistory, len(origHistory)+1))
 	assert.Check(t, is.Len(inspect.RootFS.Layers, 2))

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -181,7 +181,7 @@ func TestBuildMultiStageCopy(t *testing.T) {
 			assert.NilError(t, err)
 
 			// verify the image was successfully built
-			_, _, err = apiclient.ImageInspectWithRaw(ctx, imgName)
+			_, err = apiclient.ImageInspect(ctx, imgName)
 			if err != nil {
 				t.Log(out)
 			}
@@ -222,7 +222,7 @@ func TestBuildMultiStageParentConfig(t *testing.T) {
 	assert.Check(t, resp.Body.Close())
 	assert.NilError(t, err)
 
-	img, _, err := apiclient.ImageInspectWithRaw(ctx, imgName)
+	img, err := apiclient.ImageInspect(ctx, imgName)
 	assert.NilError(t, err)
 
 	expected := "/foo/sub2"
@@ -271,7 +271,7 @@ func TestBuildLabelWithTargets(t *testing.T) {
 	assert.Check(t, resp.Body.Close())
 	assert.NilError(t, err)
 
-	img, _, err := apiclient.ImageInspectWithRaw(ctx, imgName)
+	img, err := apiclient.ImageInspect(ctx, imgName)
 	assert.NilError(t, err)
 
 	testLabels["label-a"] = "inline-a"
@@ -298,7 +298,7 @@ func TestBuildLabelWithTargets(t *testing.T) {
 	assert.Check(t, resp.Body.Close())
 	assert.NilError(t, err)
 
-	img, _, err = apiclient.ImageInspectWithRaw(ctx, imgName)
+	img, err = apiclient.ImageInspect(ctx, imgName)
 	assert.NilError(t, err)
 
 	testLabels["label-b"] = "inline-b"
@@ -380,7 +380,7 @@ RUN cat somefile`
 	assert.NilError(t, err)
 	assert.Assert(t, is.Equal(3, len(imageIDs)))
 
-	img, _, err := apiclient.ImageInspectWithRaw(ctx, imageIDs[2])
+	img, err := apiclient.ImageInspect(ctx, imageIDs[2])
 	assert.NilError(t, err)
 	assert.Check(t, is.Contains(img.Config.Env, "bar=baz"))
 }

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -75,7 +75,7 @@ func TestCreateByImageID(t *testing.T) {
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()
 
-	img, _, err := apiClient.ImageInspectWithRaw(ctx, "busybox")
+	img, err := apiClient.ImageInspect(ctx, "busybox")
 	assert.NilError(t, err)
 
 	imgIDWithAlgorithm := img.ID
@@ -547,7 +547,7 @@ func TestCreateDifferentPlatform(t *testing.T) {
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()
 
-	img, _, err := apiClient.ImageInspectWithRaw(ctx, "busybox:latest")
+	img, err := apiClient.ImageInspect(ctx, "busybox:latest")
 	assert.NilError(t, err)
 	assert.Assert(t, img.Architecture != "")
 

--- a/integration/container/inspect_test.go
+++ b/integration/container/inspect_test.go
@@ -122,7 +122,7 @@ func TestInspectImageManifestPlatform(t *testing.T) {
 			ctr := container.Create(ctx, t, apiClient, container.WithImage(tc.image))
 			defer apiClient.ContainerRemove(ctx, ctr, containertypes.RemoveOptions{Force: true})
 
-			img, _, err := apiClient.ImageInspectWithRaw(ctx, tc.image)
+			img, err := apiClient.ImageInspect(ctx, tc.image)
 			assert.NilError(t, err)
 
 			hostPlatform := platforms.Platform{

--- a/integration/image/commit_test.go
+++ b/integration/image/commit_test.go
@@ -29,7 +29,7 @@ func TestCommitInheritsEnv(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
-	image1, _, err := client.ImageInspectWithRaw(ctx, commitResp1.ID)
+	image1, err := client.ImageInspect(ctx, commitResp1.ID)
 	assert.NilError(t, err)
 
 	expectedEnv1 := []string{"PATH=/bin"}
@@ -43,7 +43,7 @@ func TestCommitInheritsEnv(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
-	image2, _, err := client.ImageInspectWithRaw(ctx, commitResp2.ID)
+	image2, err := client.ImageInspect(ctx, commitResp2.ID)
 	assert.NilError(t, err)
 	expectedEnv2 := []string{"PATH=/usr/bin:/bin"}
 	assert.Check(t, is.DeepEqual(expectedEnv2, image2.Config.Env))

--- a/integration/image/import_test.go
+++ b/integration/image/import_test.go
@@ -114,7 +114,7 @@ func TestImportWithCustomPlatform(t *testing.T) {
 				imagetypes.ImportOptions{Platform: tc.platform})
 			assert.NilError(t, err)
 
-			inspect, _, err := client.ImageInspectWithRaw(ctx, reference)
+			inspect, err := client.ImageInspect(ctx, reference)
 			assert.NilError(t, err)
 			assert.Equal(t, inspect.Os, tc.expected.OS)
 			assert.Equal(t, inspect.Architecture, tc.expected.Architecture)

--- a/integration/image/list_test.go
+++ b/integration/image/list_test.go
@@ -81,11 +81,11 @@ func TestImagesFilterUntil(t *testing.T) {
 		imgs[i] = id.ID
 	}
 
-	olderImage, _, err := client.ImageInspectWithRaw(ctx, imgs[2])
+	olderImage, err := client.ImageInspect(ctx, imgs[2])
 	assert.NilError(t, err)
 	olderUntil := olderImage.Created
 
-	laterImage, _, err := client.ImageInspectWithRaw(ctx, imgs[3])
+	laterImage, err := client.ImageInspect(ctx, imgs[3])
 	assert.NilError(t, err)
 	laterUntil := laterImage.Created
 

--- a/integration/image/prune_test.go
+++ b/integration/image/prune_test.go
@@ -33,7 +33,7 @@ func TestPruneDontDeleteUsedDangling(t *testing.T) {
 
 	danglingID := specialimage.Load(ctx, t, client, specialimage.Dangling)
 
-	_, _, err := client.ImageInspectWithRaw(ctx, danglingID)
+	_, err := client.ImageInspect(ctx, danglingID)
 	assert.NilError(t, err, "Test dangling image doesn't exist")
 
 	container.Create(ctx, t, client,
@@ -49,7 +49,7 @@ func TestPruneDontDeleteUsedDangling(t *testing.T) {
 		}
 	}
 
-	_, _, err = client.ImageInspectWithRaw(ctx, danglingID)
+	_, err = client.ImageInspect(ctx, danglingID)
 	assert.NilError(t, err, "Test dangling image should still exist")
 }
 
@@ -68,7 +68,7 @@ func TestPruneLexographicalOrder(t *testing.T) {
 
 	d.LoadBusybox(ctx, t)
 
-	inspect, _, err := apiClient.ImageInspectWithRaw(ctx, "busybox:latest")
+	inspect, err := apiClient.ImageInspect(ctx, "busybox:latest")
 	assert.NilError(t, err)
 
 	id := inspect.ID
@@ -117,7 +117,7 @@ func TestPruneDontDeleteUsedImage(t *testing.T) {
 			check: func(t *testing.T, apiClient *client.Client, pruned image.PruneReport) {
 				assert.Check(t, is.Len(pruned.ImagesDeleted, 0))
 
-				_, _, err := apiClient.ImageInspectWithRaw(ctx, "busybox:latest")
+				_, err := apiClient.ImageInspect(ctx, "busybox:latest")
 				assert.NilError(t, err, "Busybox image should still exist")
 			},
 		},
@@ -134,10 +134,10 @@ func TestPruneDontDeleteUsedImage(t *testing.T) {
 					assert.Check(t, is.Equal(pruned.ImagesDeleted[0].Untagged, "busybox:a"))
 				}
 
-				_, _, err := apiClient.ImageInspectWithRaw(ctx, "busybox:a")
+				_, err := apiClient.ImageInspect(ctx, "busybox:a")
 				assert.Check(t, err != nil, "Busybox:a image should be deleted")
 
-				_, _, err = apiClient.ImageInspectWithRaw(ctx, "busybox:latest")
+				_, err = apiClient.ImageInspect(ctx, "busybox:latest")
 				assert.Check(t, err == nil, "Busybox:latest image should still exist")
 			},
 		},
@@ -206,7 +206,7 @@ func TestPruneDontDeleteUsedImage(t *testing.T) {
 					assert.NilError(t, err, "prepare failed")
 				}
 
-				inspect, _, err := apiClient.ImageInspectWithRaw(ctx, "busybox:latest")
+				inspect, err := apiClient.ImageInspect(ctx, "busybox:latest")
 				assert.NilError(t, err)
 
 				image := tc.imageID(t, inspect)

--- a/integration/image/pull_test.go
+++ b/integration/image/pull_test.go
@@ -209,7 +209,7 @@ func TestImagePullKeepOldAsDangling(t *testing.T) {
 
 	apiClient := d.NewClientT(t)
 
-	inspect1, _, err := apiClient.ImageInspectWithRaw(ctx, "busybox:latest")
+	inspect1, err := apiClient.ImageInspect(ctx, "busybox:latest")
 	assert.NilError(t, err)
 
 	prevID := inspect1.ID
@@ -231,6 +231,6 @@ func TestImagePullKeepOldAsDangling(t *testing.T) {
 
 	t.Log(b.String())
 
-	_, _, err = apiClient.ImageInspectWithRaw(ctx, prevID)
+	_, err = apiClient.ImageInspect(ctx, prevID)
 	assert.NilError(t, err)
 }

--- a/integration/image/remove_test.go
+++ b/integration/image/remove_test.go
@@ -29,7 +29,7 @@ func TestRemoveImageOrphaning(t *testing.T) {
 	assert.NilError(t, err)
 
 	// verifies that reference now points to first image
-	resp, _, err := client.ImageInspectWithRaw(ctx, imgName)
+	resp, err := client.ImageInspect(ctx, imgName)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(resp.ID, commitResp1.ID))
 
@@ -42,7 +42,7 @@ func TestRemoveImageOrphaning(t *testing.T) {
 	assert.NilError(t, err)
 
 	// verifies that reference now points to second image
-	resp, _, err = client.ImageInspectWithRaw(ctx, imgName)
+	resp, err = client.ImageInspect(ctx, imgName)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(resp.ID, commitResp2.ID))
 
@@ -51,12 +51,12 @@ func TestRemoveImageOrphaning(t *testing.T) {
 	assert.NilError(t, err)
 
 	// check if the first image is still there
-	resp, _, err = client.ImageInspectWithRaw(ctx, commitResp1.ID)
+	resp, err = client.ImageInspect(ctx, commitResp1.ID)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(resp.ID, commitResp1.ID))
 
 	// check if the second image has been deleted
-	_, _, err = client.ImageInspectWithRaw(ctx, commitResp2.ID)
+	_, err = client.ImageInspect(ctx, commitResp2.ID)
 	assert.Check(t, is.ErrorContains(err, "No such image:"))
 }
 
@@ -69,7 +69,7 @@ func TestRemoveByDigest(t *testing.T) {
 	err := client.ImageTag(ctx, "busybox", "test-remove-by-digest:latest")
 	assert.NilError(t, err)
 
-	inspect, _, err := client.ImageInspectWithRaw(ctx, "test-remove-by-digest")
+	inspect, err := client.ImageInspect(ctx, "test-remove-by-digest")
 	assert.NilError(t, err)
 
 	id := ""
@@ -85,9 +85,9 @@ func TestRemoveByDigest(t *testing.T) {
 	_, err = client.ImageRemove(ctx, id, image.RemoveOptions{})
 	assert.NilError(t, err)
 
-	inspect, _, err = client.ImageInspectWithRaw(ctx, "busybox")
+	inspect, err = client.ImageInspect(ctx, "busybox")
 	assert.Check(t, err, "busybox image got deleted")
 
-	inspect, _, err = client.ImageInspectWithRaw(ctx, "test-remove-by-digest")
+	inspect, err = client.ImageInspect(ctx, "test-remove-by-digest")
 	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }

--- a/integration/image/remove_unix_test.go
+++ b/integration/image/remove_unix_test.go
@@ -76,7 +76,7 @@ func TestRemoveImageGarbageCollector(t *testing.T) {
 	_, err = io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
 	assert.NilError(t, err)
-	img, _, err := client.ImageInspectWithRaw(ctx, imgName)
+	img, err := client.ImageInspect(ctx, imgName)
 	assert.NilError(t, err)
 
 	// Mark latest image layer to immutable

--- a/integration/image/save_test.go
+++ b/integration/image/save_test.go
@@ -62,7 +62,7 @@ func TestSaveCheckTimes(t *testing.T) {
 	client := testEnv.APIClient()
 
 	const repoName = "busybox:latest"
-	img, _, err := client.ImageInspectWithRaw(ctx, repoName)
+	img, err := client.ImageInspect(ctx, repoName)
 	assert.NilError(t, err)
 
 	rdr, err := client.ImageSave(ctx, []string{repoName}, image.SaveOptions{})
@@ -99,7 +99,7 @@ func TestSaveOCI(t *testing.T) {
 	client := testEnv.APIClient()
 
 	const busybox = "busybox:latest"
-	inspectBusybox, _, err := client.ImageInspectWithRaw(ctx, busybox)
+	inspectBusybox, err := client.ImageInspect(ctx, busybox)
 	assert.NilError(t, err)
 
 	type testCase struct {
@@ -136,7 +136,7 @@ func TestSaveOCI(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.image, func(t *testing.T) {
 			// Get information about the original image.
-			inspect, _, err := client.ImageInspectWithRaw(ctx, tc.image)
+			inspect, err := client.ImageInspect(ctx, tc.image)
 			assert.NilError(t, err)
 
 			rdr, err := client.ImageSave(ctx, []string{tc.image}, image.SaveOptions{})
@@ -221,7 +221,7 @@ func TestSavePlatform(t *testing.T) {
 	client := testEnv.APIClient()
 
 	const repoName = "busybox:latest"
-	_, _, err := client.ImageInspectWithRaw(ctx, repoName)
+	_, err := client.ImageInspect(ctx, repoName)
 	assert.NilError(t, err)
 
 	_, err = client.ImageSave(ctx, []string{repoName}, image.SaveOptions{
@@ -253,7 +253,7 @@ func TestSaveRepoWithMultipleImages(t *testing.T) {
 		return res.ID
 	}
 
-	busyboxImg, _, err := client.ImageInspectWithRaw(ctx, "busybox:latest")
+	busyboxImg, err := client.ImageInspect(ctx, "busybox:latest")
 	assert.NilError(t, err)
 
 	const repoName = "foobar-save-multi-images-test"

--- a/integration/image/tag_test.go
+++ b/integration/image/tag_test.go
@@ -19,7 +19,7 @@ func TestTagUnprefixedRepoByNameOrName(t *testing.T) {
 	assert.NilError(t, err)
 
 	// By ID
-	insp, _, err := client.ImageInspectWithRaw(ctx, "busybox")
+	insp, err := client.ImageInspect(ctx, "busybox")
 	assert.NilError(t, err)
 	err = client.ImageTag(ctx, insp.ID, "testfoobarbaz")
 	assert.NilError(t, err)
@@ -78,7 +78,7 @@ func TestTagOfficialNames(t *testing.T) {
 			assert.NilError(t, err)
 
 			// ensure we don't have multiple tag names.
-			insp, _, err := client.ImageInspectWithRaw(ctx, "busybox")
+			insp, err := client.ImageInspect(ctx, "busybox")
 			assert.NilError(t, err)
 			// TODO(vvoland): Not sure what's actually being tested here. Is is still doing anything useful?
 			assert.Assert(t, !is.Contains(insp.RepoTags, name)().Success())
@@ -100,6 +100,6 @@ func TestTagMatchesDigest(t *testing.T) {
 	assert.Check(t, is.ErrorContains(err, "refusing to create a tag with a digest reference"))
 
 	// check that no new image matches the digest
-	_, _, err = client.ImageInspectWithRaw(ctx, digest)
+	_, err = client.ImageInspect(ctx, digest)
 	assert.Check(t, is.ErrorContains(err, fmt.Sprintf("No such image: %s", digest)))
 }

--- a/integration/volume/mount_test.go
+++ b/integration/volume/mount_test.go
@@ -195,7 +195,7 @@ func TestRunMountImage(t *testing.T) {
 
 			// Test image mounted is in use logic
 			if tc.name == "image_remove" {
-				img, _, _ := apiClient.ImageInspectWithRaw(ctx, testImage)
+				img, _ := apiClient.ImageInspect(ctx, testImage)
 				imgId := strings.Split(img.ID, ":")[1]
 				_, removeErr := apiClient.ImageRemove(ctx, testImage, image.RemoveOptions{})
 				assert.ErrorContains(t, removeErr, fmt.Sprintf(`container %s is using its referenced image %s`, id[:12], imgId[:12]))
@@ -298,7 +298,7 @@ func setupTestVolume(t *testing.T, client client.APIClient) string {
 	return volumeName
 }
 
-func setupTestImage(t *testing.T, ctx context.Context, client client.APIClient, test string, snapshotter bool) string {
+func setupTestImage(t *testing.T, ctx context.Context, apiClient client.APIClient, test string, snapshotter bool) string {
 	imgName := "test-image"
 
 	if test == "image_tag" {
@@ -334,7 +334,7 @@ func setupTestImage(t *testing.T, ctx context.Context, client client.APIClient, 
 	)
 	defer source.Close()
 
-	resp, err := client.ImageBuild(ctx,
+	resp, err := apiClient.ImageBuild(ctx,
 		source.AsTarReader(t),
 		types.ImageBuildOptions{
 			Remove:      false,
@@ -348,7 +348,7 @@ func setupTestImage(t *testing.T, ctx context.Context, client client.APIClient, 
 	assert.Check(t, resp.Body.Close())
 	assert.NilError(t, err)
 
-	_, _, err = client.ImageInspectWithRaw(ctx, imgName)
+	_, err = apiClient.ImageInspect(ctx, imgName)
 	if err != nil {
 		t.Log(out)
 	}

--- a/testutil/fixtures/load/frozen.go
+++ b/testutil/fixtures/load/frozen.go
@@ -85,7 +85,7 @@ func FrozenImagesLinux(ctx context.Context, client client.APIClient, images ...s
 func imageExists(ctx context.Context, client client.APIClient, name string) bool {
 	ctx, span := otel.Tracer("").Start(ctx, "check image exists: "+name)
 	defer span.End()
-	_, _, err := client.ImageInspectWithRaw(ctx, name)
+	_, err := client.ImageInspect(ctx, name)
 	if err != nil {
 		span.RecordError(err)
 	}


### PR DESCRIPTION
- needs: https://github.com/moby/moby/pull/47526
- needs: https://github.com/moby/moby/pull/48330
- follow up to: https://github.com/moby/moby/pull/47526

Add `Manifests` field to image inspect (`/images/{name}/json`) response.
This is the same as in `/images/json`.


**- How to verify it**
```
curl --unix-socket /var/run/docker.sock http://localhost/images/busybox/json?manifests=1
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
API: `GET /images/{name}/json` response now will return the `Manifests` field containing information about the sub-manifests contained in the image index. This includes things like platform-specific manifests and build attestations.
The new field will only be populated if the request also sets the `manifests` query parameter to `true`.
This acts the same as in the `GET /images/json` endpoint.
WARNING: This is experimental and may change at any time without any backward compatibility.
SDK: Deprecate `client.ImageInspectWithRaw` function in favor of the new `client.ImageInspect`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

