### PR TITLE
hack/make: suppress "not mounted" message

### DIFF
--- a/hack/make/.integration-daemon-stop
+++ b/hack/make/.integration-daemon-stop
@@ -15,7 +15,7 @@ if [ ! "$(go env GOOS)" = 'windows' ]; then
 		fi
 		root=$(dirname "$pidFile")/root
 		if [ -d "$root" ]; then
-			umount "$root" || true
+			umount -q "$root" || true
 		fi
 	done
 


### PR DESCRIPTION
The "not mounted" error from .integration-daemon-stop is not an error, so let's suppress that one (this is the only effect of -q option, at least according to its man page).

**- What I did**

Added `-q` to `umount` in `hack/make/.integration-daemon-stop`.

**- How I did it**

nvim

**- How to verify it**

ci

**- A picture of a cute animal (not mandatory but encouraged)**

