### PR TITLE
api/swagger: fix x-nullable for SystemInfo.Containerd (api v1.46)

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5830,13 +5830,13 @@ definitions:
           - "/var/run/cdi"
       Containerd:
         $ref: "#/definitions/ContainerdInfo"
-        x-nullable: true
 
   ContainerdInfo:
     description: |
       Information for connecting to the containerd instance that is used by the daemon.
       This is included for debugging purposes only.
     type: "object"
+    x-nullable: true
     properties:
       Address:
         description: "The address of the containerd socket."

--- a/docs/api/v1.46.yaml
+++ b/docs/api/v1.46.yaml
@@ -5830,13 +5830,13 @@ definitions:
           - "/var/run/cdi"
       Containerd:
         $ref: "#/definitions/ContainerdInfo"
-        x-nullable: true
 
   ContainerdInfo:
     description: |
       Information for connecting to the containerd instance that is used by the daemon.
       This is included for debugging purposes only.
     type: "object"
+    x-nullable: true
     properties:
       Address:
         description: "The address of the containerd socket."


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/47239

This field was added in 812f319a578ebec5987ee261410c149cbf841ba6, but it
looks like redoc doesn't like the field in this location, producing a
warning.

Rendering the docs (`make swagger-docs`) showed a warning:

> Warning: Other properties are defined at the same level as $ref at 
> "#/definitions/SystemInfo/properties/Containerd". They are IGNORED
> according to the JsonSchema spec
