### PR TITLE
c8d/image: Simplify `presentImages` and better "platform not found" error

### DIFF
--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -45,10 +45,7 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options bac
 		return nil, err
 	}
 
-	pm := matchAllWithPreference(platforms.Default())
-	if options.Platform != nil {
-		pm = platforms.OnlyStrict(*options.Platform)
-	}
+	pm := i.matchRequestedOrDefault(platforms.OnlyStrict, options.Platform)
 
 	imgV1, err := i.getImageV1(ctx, img, pm)
 	if err != nil {
@@ -96,20 +93,14 @@ func (i *ImageService) GetImageManifest(ctx context.Context, refOrID string, opt
 		return nil, err
 	}
 
-	platform := options.Platform
-	var pm platforms.MatchComparer
-	if platform != nil {
-		pm = platforms.Only(*platform)
-	} else {
-		pm = matchAllWithPreference(platforms.Default())
-	}
+	pm := i.matchRequestedOrDefault(platforms.Only, options.Platform)
 
 	im, err := i.getBestPresentImageManifest(ctx, img, pm)
 	if err != nil {
 		var e *errPlatformNotFound
 		if errors.As(err, &e) {
-			if platform != nil {
-				e.wanted = *platform
+			if options.Platform != nil {
+				e.wanted = *options.Platform
 			} else {
 				e.wanted = platforms.DefaultSpec()
 			}

--- a/daemon/containerd/image_history.go
+++ b/daemon/containerd/image_history.go
@@ -9,9 +9,7 @@ import (
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
 	imagetype "github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/daemon/images"
 	dimages "github.com/docker/docker/daemon/images"
-	"github.com/docker/docker/errdefs"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
 	"github.com/pkg/errors"
@@ -31,9 +29,9 @@ func (i *ImageService) ImageHistory(ctx context.Context, name string) ([]*imaget
 
 	presentImages, err := i.presentImages(ctx, img, platform)
 	if err != nil {
-		if errdefs.IsNotFound(err) {
-			r, _ := reference.ParseAnyReference(name)
-			return nil, images.ErrImageDoesNotExist{Ref: r}
+		var e *errPlatformNotFound
+		if errors.As(err, &e) {
+			e.wanted = platforms.DefaultSpec()
 		}
 		return nil, err
 	}

--- a/daemon/containerd/image_history.go
+++ b/daemon/containerd/image_history.go
@@ -2,7 +2,6 @@ package containerd
 
 import (
 	"context"
-	v1 "github.com/moby/docker-image-spec/specs-go/v1"
 	"time"
 
 	containerdimages "github.com/containerd/containerd/images"
@@ -13,6 +12,7 @@ import (
 	dimages "github.com/docker/docker/daemon/images"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -37,7 +37,11 @@ func (i *ImageService) ImageHistory(ctx context.Context, name string) ([]*imaget
 		return nil, err
 	}
 
-	var ociImage v1.DockerOCIImage
+	// Subset of ocispec.Image
+	var ociImage struct {
+		RootFS  ocispec.RootFS    `json:"rootfs"`
+		History []ocispec.History `json:"history,omitempty"`
+	}
 	err = im.ReadConfig(ctx, &ociImage)
 	if err != nil {
 		return nil, err

--- a/daemon/containerd/image_history.go
+++ b/daemon/containerd/image_history.go
@@ -30,10 +30,6 @@ func (i *ImageService) ImageHistory(ctx context.Context, name string) ([]*imaget
 
 	im, err := i.getBestPresentImageManifest(ctx, img, pm)
 	if err != nil {
-		var e *errPlatformNotFound
-		if errors.As(err, &e) {
-			e.wanted = platforms.DefaultSpec()
-		}
 		return nil, err
 	}
 

--- a/daemon/containerd/image_history.go
+++ b/daemon/containerd/image_history.go
@@ -26,9 +26,9 @@ func (i *ImageService) ImageHistory(ctx context.Context, name string) ([]*imaget
 	}
 
 	// TODO: pass platform in from the CLI
-	platform := matchAllWithPreference(platforms.Default())
+	pm := matchAllWithPreference(platforms.Default())
 
-	im, err := i.getBestPresentImageManifest(ctx, img, platform)
+	im, err := i.getBestPresentImageManifest(ctx, img, pm)
 	if err != nil {
 		var e *errPlatformNotFound
 		if errors.As(err, &e) {

--- a/daemon/containerd/image_manifest.go
+++ b/daemon/containerd/image_manifest.go
@@ -223,12 +223,18 @@ func (m *ImageManifest) ImagePlatform(ctx context.Context) (ocispec.Platform, er
 		return *target.Platform, nil
 	}
 
+	var out ocispec.Platform
+	err := m.ReadConfig(ctx, &out)
+	return out, err
+}
+
+// ReadConfig gets the image config and unmarshals it into the provided struct.
+// The provided struct should be a pointer to the config struct or its subset.
+func (m *ImageManifest) ReadConfig(ctx context.Context, outConfig interface{}) error {
 	configDesc, err := m.Config(ctx)
 	if err != nil {
-		return ocispec.Platform{}, err
+		return err
 	}
 
-	var out ocispec.Platform
-	err = readConfig(ctx, m.ContentStore(), configDesc, &out)
-	return out, err
+	return readConfig(ctx, m.ContentStore(), configDesc, outConfig)
 }

--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -216,16 +216,7 @@ func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, p
 }
 
 func (i *ImageService) getPushDescriptor(ctx context.Context, img containerdimages.Image, platform *ocispec.Platform) (ocispec.Descriptor, error) {
-	// Allow to override the host platform for testing purposes.
-	hostPlatform := i.defaultPlatformOverride
-	if hostPlatform == nil {
-		hostPlatform = platforms.Default()
-	}
-
-	pm := matchAllWithPreference(hostPlatform)
-	if platform != nil {
-		pm = platforms.OnlyStrict(*platform)
-	}
+	pm := i.matchRequestedOrDefault(platforms.OnlyStrict, platform)
 
 	anyMissing := false
 
@@ -295,7 +286,7 @@ func (i *ImageService) getPushDescriptor(ctx context.Context, img containerdimag
 
 			// No specific platform requested and not all manifests are available.
 			// Select the manifest that matches the host platform the best.
-			if bestMatch != nil && hostPlatform.Match(bestMatchPlatform) {
+			if bestMatch != nil && i.hostPlatformMatcher().Match(bestMatchPlatform) {
 				return bestMatch.Target(), nil
 			}
 

--- a/daemon/containerd/image_snapshot.go
+++ b/daemon/containerd/image_snapshot.go
@@ -28,10 +28,7 @@ func (i *ImageService) PrepareSnapshot(ctx context.Context, id string, parentIma
 
 		cs := i.content
 
-		matcher := matchAllWithPreference(platforms.Default())
-		if platform != nil {
-			matcher = platforms.Only(*platform)
-		}
+		matcher := i.matchRequestedOrDefault(platforms.Only, platform)
 
 		platformImg := containerd.NewImageWithPlatform(i.client, img, matcher)
 		unpacked, err := platformImg.IsUnpacked(ctx, i.snapshotter)

--- a/daemon/containerd/platform_matchers.go
+++ b/daemon/containerd/platform_matchers.go
@@ -24,3 +24,23 @@ func (c allPlatformsWithPreferenceMatcher) Match(_ ocispec.Platform) bool {
 func (c allPlatformsWithPreferenceMatcher) Less(p1, p2 ocispec.Platform) bool {
 	return c.preferred.Less(p1, p2)
 }
+
+type matchComparerProvider func(ocispec.Platform) platforms.MatchComparer
+
+func (i *ImageService) matchRequestedOrDefault(
+	fpm matchComparerProvider, // function to create a platform matcher if platform is not nil
+	platform *ocispec.Platform, // input platform, nil if not specified
+) platforms.MatchComparer {
+	if platform == nil {
+		return matchAllWithPreference(i.hostPlatformMatcher())
+	}
+	return fpm(*platform)
+}
+
+func (i *ImageService) hostPlatformMatcher() platforms.MatchComparer {
+	// Allow to override the host platform for testing purposes.
+	if i.defaultPlatformOverride != nil {
+		return i.defaultPlatformOverride
+	}
+	return platforms.Default()
+}

--- a/daemon/containerd/platform_matchers.go
+++ b/daemon/containerd/platform_matchers.go
@@ -25,16 +25,32 @@ func (c allPlatformsWithPreferenceMatcher) Less(p1, p2 ocispec.Platform) bool {
 	return c.preferred.Less(p1, p2)
 }
 
+// platformMatcherWithRequestedPlatform is a platform matcher that also
+// contains the platform that was requested by the user in the context
+// in which the matcher was created.
+type platformMatcherWithRequestedPlatform struct {
+	Requested *ocispec.Platform
+
+	platforms.MatchComparer
+}
+
 type matchComparerProvider func(ocispec.Platform) platforms.MatchComparer
 
 func (i *ImageService) matchRequestedOrDefault(
 	fpm matchComparerProvider, // function to create a platform matcher if platform is not nil
 	platform *ocispec.Platform, // input platform, nil if not specified
-) platforms.MatchComparer {
+) platformMatcherWithRequestedPlatform {
+	var inner platforms.MatchComparer
 	if platform == nil {
-		return matchAllWithPreference(i.hostPlatformMatcher())
+		inner = matchAllWithPreference(i.hostPlatformMatcher())
+	} else {
+		inner = fpm(*platform)
 	}
-	return fpm(*platform)
+
+	return platformMatcherWithRequestedPlatform{
+		Requested:     platform,
+		MatchComparer: inner,
+	}
 }
 
 func (i *ImageService) hostPlatformMatcher() platforms.MatchComparer {

--- a/daemon/containerd/platform_matchers_test.go
+++ b/daemon/containerd/platform_matchers_test.go
@@ -1,0 +1,173 @@
+package containerd
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/containerd/platforms"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/skip"
+)
+
+var (
+	pLinuxAmd64 = ocispec.Platform{
+		OS:           "linux",
+		Architecture: "amd64",
+	}
+
+	pLinuxArmv5 = ocispec.Platform{
+		OS:           "linux",
+		Architecture: "arm",
+		Variant:      "v5",
+	}
+
+	pLinuxArmv6 = ocispec.Platform{
+		OS:           "linux",
+		Architecture: "arm",
+		Variant:      "v6",
+	}
+
+	pLinuxArm64 = ocispec.Platform{
+		OS:           "linux",
+		Architecture: "arm64",
+		Variant:      "v8",
+	}
+
+	pWindowsAmd64 = ocispec.Platform{
+		OS:           "windows",
+		Architecture: "amd64",
+		OSVersion:    "10.0.14393",
+	}
+)
+
+type requestedAndFirst struct {
+	// Whether platforms.Only or OnlyStrict should be used
+	// Nil means both should be the same
+	strict    *bool
+	requested *ocispec.Platform
+	first     *ocispec.Platform
+}
+
+type indexTestCase struct {
+	name  string
+	index []ocispec.Platform
+	tc    []requestedAndFirst
+}
+
+func TestMatcherOnLinuxArm64v8(t *testing.T) {
+	daemonPlatform := platforms.Only(ocispec.Platform{
+		OS:           "linux",
+		Architecture: "arm64",
+		Variant:      "v8",
+	})
+
+	yes := true
+	no := false
+
+	for _, indexTc := range []indexTestCase{
+		{
+			name:  "linux_amd64_armv5_armv6_arm64-windows_amd64",
+			index: []ocispec.Platform{pLinuxAmd64, pLinuxArmv5, pLinuxArmv6, pLinuxArm64, pWindowsAmd64},
+			tc: []requestedAndFirst{
+				{requested: nil, first: &pLinuxArm64},
+				{requested: &ocispec.Platform{OS: "linux", Architecture: "amd64"}, first: &pLinuxAmd64},
+				{requested: &ocispec.Platform{OS: "windows", Architecture: "amd64"}, first: &pWindowsAmd64},
+
+				// Select highest possible arm variant
+				{strict: &yes, requested: &ocispec.Platform{OS: "linux", Architecture: "arm"}, first: nil},
+				{strict: &no, requested: &ocispec.Platform{OS: "linux", Architecture: "arm"}, first: &pLinuxArmv6},
+
+				{requested: &ocispec.Platform{OS: "linux", Architecture: "arm", Variant: "v5"}, first: &pLinuxArmv5},
+
+				// Variant not present
+				{strict: &yes, requested: &ocispec.Platform{OS: "linux", Architecture: "arm", Variant: "v8"}, first: nil},
+				{strict: &no, requested: &ocispec.Platform{OS: "linux", Architecture: "arm", Variant: "v8"}, first: &pLinuxArmv6},
+
+				{requested: &ocispec.Platform{OS: "linux", Architecture: "s390x"}, first: nil},
+			},
+		},
+	} {
+		testOnlyAndOnlyStrict(t, daemonPlatform, indexTc)
+	}
+}
+
+func TestMatcherOnWindowsAmd64(t *testing.T) {
+	skip.If(t, runtime.GOOS != "windows", "TODO: containerd matcher only matches OSVersion when on Windows")
+	daemonPlatform := platforms.Only(ocispec.Platform{
+		OS:           "windows",
+		Architecture: "amd64",
+		OSVersion:    "10.0.18362",
+	})
+
+	for _, indexTc := range []indexTestCase{
+		{
+			name: "various windows",
+			index: []ocispec.Platform{
+				{OS: "windows", Architecture: "amd64", OSVersion: "10.0.14393"},
+				{OS: "windows", Architecture: "amd64", OSVersion: "10.0.17763"},
+				{OS: "windows", Architecture: "amd64", OSVersion: "10.0.18362"},
+				{OS: "windows", Architecture: "amd64", OSVersion: "10.0.19041"},
+			},
+			tc: []requestedAndFirst{
+				{requested: nil, first: &ocispec.Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.18362"}},
+				{requested: &ocispec.Platform{OS: "windows", Architecture: "amd64"}, first: &ocispec.Platform{OS: "windows", Architecture: "amd64", OSVersion: "10.0.14393"}},
+			},
+		},
+	} {
+		testOnlyAndOnlyStrict(t, daemonPlatform, indexTc)
+	}
+}
+
+func testOnlyAndOnlyStrict(t *testing.T, daemonPlatform platforms.MatchComparer, indexTc indexTestCase) {
+	imgSvc := ImageService{}
+	imgSvc.defaultPlatformOverride = daemonPlatform
+
+	t.Run(indexTc.name, func(t *testing.T) {
+		indexTc := indexTc
+		idx := indexTc.index
+		for _, tc := range indexTc.tc {
+			tc := tc
+
+			for _, strict := range []bool{false, true} {
+				strict := strict
+				s := "non-strict"
+				if strict {
+					s = "strict"
+				}
+				if tc.strict != nil && *tc.strict != strict {
+					continue
+				}
+
+				req := "default"
+				if tc.requested != nil {
+					req = platforms.FormatAll(*tc.requested)
+				}
+				wanted := "none"
+				if tc.first != nil {
+					wanted = platforms.FormatAll(*tc.first)
+				}
+				t.Run(s+"/"+req+"=>"+wanted, func(t *testing.T) {
+					pm := imgSvc.matchRequestedOrDefault(platforms.Only, tc.requested)
+					if strict {
+						pm = imgSvc.matchRequestedOrDefault(platforms.OnlyStrict, tc.requested)
+					}
+
+					var first *ocispec.Platform
+					for _, p := range idx {
+						p := p
+						if !pm.Match(p) {
+							continue
+						}
+						if first == nil || pm.Less(p, *first) {
+							first = &p
+						}
+					}
+
+					assert.Check(t, is.DeepEqual(first, tc.first))
+				})
+			}
+		}
+	})
+}


### PR DESCRIPTION
**- What I did**
A minor refactor, best to review commit by commit.
Summary:
- Simplify `presentImages` to  `getBestPresentImageManifest` - all usages were only using the first sorted result
- Add `errPlatformNotFound` which produces a better error message in case where the image exists, but the requested platform is not present
- Extract `matchRequestedOrDefault` function to refactor a common pattern of creating a platform matcher from `*ocispec.Platform`

**- How to verify it**

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

