### PR TITLE
IPv6 only: IPv4 is required for Windows and Swarm networks

### DIFF
--- a/integration/network/nat/main_windows_test.go
+++ b/integration/network/nat/main_windows_test.go
@@ -1,0 +1,56 @@
+package nat // import "github.com/docker/docker/integration/network/nat"
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/docker/docker/testutil"
+	"github.com/docker/docker/testutil/environment"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+)
+
+var (
+	testEnv     *environment.Execution
+	baseContext context.Context
+)
+
+func TestMain(m *testing.M) {
+	shutdown := testutil.ConfigureTracing()
+	ctx, span := otel.Tracer("").Start(context.Background(), "integration/network/nat.TestMain")
+	baseContext = ctx
+
+	var err error
+	testEnv, err = environment.New(ctx)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.End()
+		shutdown(ctx)
+		panic(err)
+	}
+
+	err = environment.EnsureFrozenImagesLinux(ctx, testEnv)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.End()
+		shutdown(ctx)
+		panic(err)
+	}
+
+	testEnv.Print()
+	code := m.Run()
+	if code != 0 {
+		span.SetStatus(codes.Error, "m.Run() returned non-zero exit code")
+	}
+	span.End()
+	shutdown(ctx)
+	os.Exit(code)
+}
+
+func setupTest(t *testing.T) context.Context {
+	ctx := testutil.StartSpan(baseContext, t)
+	environment.ProtectAll(ctx, t, testEnv)
+	t.Cleanup(func() { testEnv.Clean(ctx, t) })
+	return ctx
+}

--- a/integration/network/nat/nat_windows_test.go
+++ b/integration/network/nat/nat_windows_test.go
@@ -1,0 +1,24 @@
+package nat // import "github.com/docker/docker/integration/network/nat"
+
+import (
+	"testing"
+
+	"github.com/docker/docker/integration/internal/network"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestWindowsNoDisableIPv4(t *testing.T) {
+	ctx := setupTest(t)
+	c := testEnv.APIClient()
+
+	_, err := network.Create(ctx, c, "ipv6only",
+		network.WithDriver("nat"),
+		network.WithIPv4(false),
+	)
+	// This error message should change to "IPv4 cannot be disabled on Windows"
+	// when "--experimental" is no longer required to disable IPv4. But, there's
+	// no way to start a second daemon with "--experimental" in Windows CI.
+	assert.Check(t, is.ErrorContains(err,
+		"IPv4 can only be disabled if experimental features are enabled"))
+}

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -550,6 +550,9 @@ func (c *Controller) NewNetwork(networkType, name string, id string, options ...
 	if (caps.DataScope == scope.Global || nw.scope == scope.Swarm) &&
 		c.isSwarmNode() && !nw.dynamic {
 		if c.isManager() {
+			if !nw.enableIPv4 {
+				return nil, types.InvalidParameterErrorf("IPv4 cannot be disabled in a Swarm scoped network")
+			}
 			// For non-distributed controlled environment, globalscoped non-dynamic networks are redirected to Manager
 			return nil, ManagerRedirectError(name)
 		}

--- a/libnetwork/drivers/windows/windows.go
+++ b/libnetwork/drivers/windows/windows.go
@@ -285,6 +285,12 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 		return fmt.Errorf("Unknown generic data option")
 	}
 
+	if v, ok := option[netlabel.EnableIPv4]; ok {
+		if enable_IPv4, ok := v.(bool); ok && !enable_IPv4 {
+			return types.InvalidParameterErrorf("IPv4 cannot be disabled on Windows")
+		}
+	}
+
 	// Parse and validate the config. It should not conflict with existing networks' config
 	config, err := d.parseNetworkOptions(id, genData)
 	if err != nil {


### PR DESCRIPTION
**- What I did**

Don't allow `EnableIPv4:false` for Windows or Swarm networks.

**- How I did it**

Added checks/tests.

**- How to verify it**

New integration tests.

**- Description for the changelog**
```markdown changelog
n/a
```
