### PR TITLE
touch-up security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,42 @@
-# Reporting security issues
+# Security Policy
 
-The Moby maintainers take security seriously. If you discover a security issue, please bring it to their attention right away!
+The maintainers of the Moby project take security seriously. If you discover
+a security issue, please bring it to their attention right away!
 
-### Reporting a Vulnerability
+## Reporting a Vulnerability
 
-Please **DO NOT** file a public issue, instead send your report privately to security@docker.com.
+Please **DO NOT** file a public issue, instead send your report privately
+to [security@docker.com](mailto:security@docker.com).
 
-Security reports are greatly appreciated and we will publicly thank you for it, although we keep your name confidential if you request it. We also like to send gifts—if you're into schwag, make sure to let us know. We currently do not offer a paid security bounty program, but are not ruling it out in the future.
+Reporter(s) can expect a response within 72 hours, acknowledging the issue was
+received.
+
+## Review Process
+
+After receiving the report, an initial triage and technical analysis is
+performed to confirm the report and determine its scope. We may request
+additional information in this stage of the process.
+
+Once a reviewer has confirmed the relevance of the report, a draft security
+advisory will be created on GitHub. The draft advisory will be used to discuss
+the issue with maintainers, the reporter(s), and where applicable, other
+affected parties under embargo.
+
+If the vulnerability is accepted, a timeline for developing a patch, public
+disclosure, and patch release will be determined. If there is an embargo period
+on public disclosure before the patch release, the reporter(s) are expected to
+participate in the discussion of the timeline and abide by agreed upon dates
+for public disclosure.
+
+## Accreditation
+
+Security reports are greatly appreciated and we will publicly thank you,
+although we will keep your name confidential if you request it. We also like to
+send gifts - if you're into swag, make sure to let us know. We do not currently
+offer a paid security bounty program at this time.
+
+## Supported Versions
+
+This project uses long-lived branches to maintain releases. Refer to
+[BRANCHES-AND-TAGS.md](project/BRANCHES-AND-TAGS.md) in the default branch to
+learn about the current maintenance status of each branch.


### PR DESCRIPTION
I noticed the OpenSSF scorecard (https://securityscorecards.dev/viewer/?uri=github.com/docker/docker) ranked a 9 out of 10 for the policy, as it had some warnings:

```
Info: security policy file detected: SECURITY.md:1
Info: Found linked content: SECURITY.md:1
Warn: One or no descriptive hints of disclosure, vulnerability, and/or timelines in security policy
Info: Found text in security policy: SECURITY.md:1
```

This PR slightly touch-up the security policy in this repository to describe the process in more details.

- Describe process around reporting, triage, and review.
- Describe timelines for acknowledging reports.
- Refer to supported versions / branches.

Some of this wording was adopted from containerd's policy (https://github.com/containerd/project/blob/main/SECURITY.md), adjusting where needed (e.g. the project currently does not have an embargoed security announce list, and no formal definition of security advisors).