### PR TITLE
Migrate per-endpoint sysctls until 28.0.0

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -769,12 +769,14 @@ func handleSysctlBC(
 			netIfSysctl := fmt.Sprintf("net.%s.%s.IFNAME.%s=%s", spl[1], spl[2], spl[4], v)
 			// Find the EndpointConfig to migrate settings to, if not already found.
 			if ep == nil {
+				/* TODO(robmry) - apply this to the API version used in 28.0.0
 				// Per-endpoint sysctls were introduced in API version 1.46. Migration is
 				// needed, but refuse to do it automatically for newer versions of the API.
-				if versions.GreaterThan(version, "1.46") {
+				if versions.GreaterThan(version, "1.??") {
 					return "", fmt.Errorf("interface specific sysctl setting %q must be supplied using driver option '%s'",
 						k, netlabel.EndpointSysctls)
 				}
+				*/
 				var err error
 				ep, err = epConfigForNetMode(version, hostConfig.NetworkMode, netConfig)
 				if err != nil {

--- a/api/server/router/container/container_routes_test.go
+++ b/api/server/router/container/container_routes_test.go
@@ -273,15 +273,17 @@ func TestHandleSysctlBC(t *testing.T) {
 				"net.ipv6.conf.all.disable_ipv6": "0",
 			},
 		},
+		/* TODO(robmry) - enable this test for the API version used in 28.0.0
 		{
 			name:        "migration disabled for newer api",
-			apiVersion:  "1.47",
+			apiVersion:  "1.??",
 			networkMode: "mynet",
 			sysctls: map[string]string{
 				"net.ipv6.conf.eth0.accept_ra": "2",
 			},
 			expError: "must be supplied using driver option 'com.docker.network.endpoint.sysctls'",
 		},
+		*/
 		{
 			name:        "only migrate eth0",
 			apiVersion:  "1.46",

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -17,8 +17,6 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.47](https://docs.docker.com/engine/api/v1.47/) documentation
 
-* `Sysctls` in `HostConfig` (top level `--sysctl` settings) for `eth0` are no
-  longer migrated to `DriverOpts`, as described in the changes for v1.46.
 * `POST /networks/create` now has an `EnableIPv4` field. Setting it to `false`
   disables IPv4 IPAM for the network. It can only be set to `false` if the
   daemon has experimental features enabled.

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -38,7 +38,7 @@ keywords: "API, Docker, rcli, REST, documentation"
   `net.ipv4.config.eth0.log_martians=1`, use
   `net.ipv4.config.IFNAME.log_martians=1`. In API versions up-to 1.46, top level
   `--sysctl` settings for `eth0` will be migrated to `DriverOpts` when possible. 
-  This automatic migration will be removed for API versions 1.47 and greater.
+  This automatic migration will be removed in a future release.
 * `GET /containers/json` now returns the annotations of containers.
 * `POST /images/{name}/push` now supports a `platform` parameter (JSON encoded
   OCI Platform type) that allows selecting a specific platform manifest from


### PR DESCRIPTION
**- What I did**

Introduced in:
- https://github.com/moby/moby/pull/47686

Commit 0071832226b42dbb12bc01bf1c668dca891b2d33 introduced per-endpoint sysctls, and migration to them from the top-level `--sysctl` option.

The migration was intended to be short-term, disabled in the next major release, https://github.com/moby/moby/pull/47686#discussion_r1565943098. So, code was added to check for the next API version.

But now, the API version will be bumped in a minor release - this breaking change needs to wait until the next major release, and we don't yet know the API version number for that.

**- How I did it**

Commented out the code and its unit test.

Issue blocking 28.0, to put-back this code:
- https://github.com/moby/moby/issues/48282

**- How to verify it**

The commented-out unit test failed until it was commented out.

Migration will still works in master, with API version 1.47.

**- Description for the changelog**
```markdown changelog
n/a
```