### PR TITLE
IPv6 only: gateway, IPAM and address configuration

### DIFF
--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -747,16 +747,18 @@ func (c *Controller) reservePools() {
 		// Construct pseudo configs for the auto IP case
 		autoIPv4 := (len(n.ipamV4Config) == 0 || (len(n.ipamV4Config) == 1 && n.ipamV4Config[0].PreferredPool == "")) && len(n.ipamV4Info) > 0
 		autoIPv6 := (len(n.ipamV6Config) == 0 || (len(n.ipamV6Config) == 1 && n.ipamV6Config[0].PreferredPool == "")) && len(n.ipamV6Info) > 0
-		if autoIPv4 {
+		if n.enableIPv4 && autoIPv4 {
 			n.ipamV4Config = []*IpamConf{{PreferredPool: n.ipamV4Info[0].Pool.String()}}
 		}
 		if n.enableIPv6 && autoIPv6 {
 			n.ipamV6Config = []*IpamConf{{PreferredPool: n.ipamV6Info[0].Pool.String()}}
 		}
 		// Account current network gateways
-		for i, cfg := range n.ipamV4Config {
-			if cfg.Gateway == "" && n.ipamV4Info[i].Gateway != nil {
-				cfg.Gateway = n.ipamV4Info[i].Gateway.IP.String()
+		if n.enableIPv4 {
+			for i, cfg := range n.ipamV4Config {
+				if cfg.Gateway == "" && n.ipamV4Info[i].Gateway != nil {
+					cfg.Gateway = n.ipamV4Info[i].Gateway.IP.String()
+				}
 			}
 		}
 		if n.enableIPv6 {

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -788,7 +788,7 @@ func (c *Controller) reservePools() {
 				log.G(context.TODO()).Warnf("endpoint interface is empty for %q (%s)", ep.Name(), ep.ID())
 				continue
 			}
-			if err := ep.assignAddress(ipam, true, ep.Iface().AddressIPv6() != nil); err != nil {
+			if err := ep.assignAddress(ipam, ep.Iface().Address() != nil, ep.Iface().AddressIPv6() != nil); err != nil {
 				log.G(context.TODO()).Warnf("Failed to reserve current address for endpoint %q (%s) on network %q (%s)",
 					ep.Name(), ep.ID(), n.Name(), n.ID())
 			}

--- a/libnetwork/default_gateway.go
+++ b/libnetwork/default_gateway.go
@@ -129,8 +129,10 @@ func (sb *Sandbox) needDefaultGW() bool {
 		if ep.joinInfo != nil && ep.joinInfo.disableGatewayService {
 			continue
 		}
-		// TODO v6 needs to be handled.
 		if len(ep.Gateway()) > 0 {
+			return false
+		}
+		if len(ep.GatewayIPv6()) > 0 {
 			return false
 		}
 		for _, r := range ep.StaticRoutes() {

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -1119,10 +1119,8 @@ func (ep *Endpoint) assignAddressVersion(ipVer int, ipam ipamapi.Ipam) error {
 	}
 
 	ipInfo := n.getIPInfo(ipVer)
-
-	// ipv6 address is not mandatory
-	if len(ipInfo) == 0 && ipVer == 6 {
-		return nil
+	if len(ipInfo) == 0 {
+		return fmt.Errorf("no IPv%d information available for endpoint %s", ipVer, ep.Name())
 	}
 
 	// The address to program may be chosen by the user or by the network driver in one specific

--- a/libnetwork/endpoint_unix_test.go
+++ b/libnetwork/endpoint_unix_test.go
@@ -25,10 +25,13 @@ ff02::2	ip6-allrouters
 fe90::2	somehost.example.com somehost
 `
 
-	opts := []NetworkOption{NetworkOptionEnableIPv6(true), NetworkOptionIpam(defaultipam.DriverName, "",
-		[]*IpamConf{{PreferredPool: "192.168.222.0/24", Gateway: "192.168.222.1"}},
-		[]*IpamConf{{PreferredPool: "fe90::/64", Gateway: "fe90::1"}},
-		nil)}
+	opts := []NetworkOption{
+		NetworkOptionEnableIPv4(true),
+		NetworkOptionEnableIPv6(true),
+		NetworkOptionIpam(defaultipam.DriverName, "",
+			[]*IpamConf{{PreferredPool: "192.168.222.0/24", Gateway: "192.168.222.1"}},
+			[]*IpamConf{{PreferredPool: "fe90::/64", Gateway: "fe90::1"}}, nil),
+	}
 
 	ctrlr, nws := getTestEnv(t, opts)
 

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -177,6 +177,7 @@ func TestNetworkName(t *testing.T) {
 	controller := newController(t)
 
 	netOption := options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork",
 		},
@@ -212,6 +213,7 @@ func TestNetworkType(t *testing.T) {
 	controller := newController(t)
 
 	netOption := options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork",
 		},
@@ -237,6 +239,7 @@ func TestNetworkID(t *testing.T) {
 	controller := newController(t)
 
 	netOption := options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork",
 		},
@@ -265,6 +268,7 @@ func TestDeleteNetworkWithActiveEndpoints(t *testing.T) {
 		"BridgeName": "testnetwork",
 	}
 	option := options.Generic{
+		netlabel.EnableIPv4:  true,
 		netlabel.GenericData: netOption,
 	}
 
@@ -304,7 +308,8 @@ func TestNetworkConfig(t *testing.T) {
 	// Verify config network cannot inherit another config network
 	_, err := controller.NewNetwork("bridge", "config_network0", "",
 		libnetwork.NetworkOptionConfigOnly(),
-		libnetwork.NetworkOptionConfigFrom("anotherConfigNw"))
+		libnetwork.NetworkOptionConfigFrom("anotherConfigNw"),
+	)
 
 	if err == nil {
 		t.Fatal("Expected to fail. But instead succeeded")
@@ -325,6 +330,7 @@ func TestNetworkConfig(t *testing.T) {
 
 	netOptions := []libnetwork.NetworkOption{
 		libnetwork.NetworkOptionConfigOnly(),
+		libnetwork.NetworkOptionEnableIPv4(true),
 		libnetwork.NetworkOptionEnableIPv6(true),
 		libnetwork.NetworkOptionGeneric(option),
 		libnetwork.NetworkOptionIpam("default", "", ipamV4ConfList, ipamV6ConfList, nil),
@@ -353,6 +359,7 @@ func TestNetworkConfig(t *testing.T) {
 
 	// Verify a network cannot be created with both config-from and network specific configurations
 	for i, opt := range []libnetwork.NetworkOption{
+		libnetwork.NetworkOptionEnableIPv4(true),
 		libnetwork.NetworkOptionEnableIPv6(true),
 		libnetwork.NetworkOptionIpam("my-ipam", "", nil, nil, nil),
 		libnetwork.NetworkOptionIpam("", "", ipamV4ConfList, nil, nil),
@@ -406,6 +413,7 @@ func TestUnknownNetwork(t *testing.T) {
 		"BridgeName": "testnetwork",
 	}
 	option := options.Generic{
+		netlabel.EnableIPv4:  true,
 		netlabel.GenericData: netOption,
 	}
 
@@ -437,6 +445,7 @@ func TestUnknownEndpoint(t *testing.T) {
 		"BridgeName": "testnetwork",
 	}
 	option := options.Generic{
+		netlabel.EnableIPv4:  true,
 		netlabel.GenericData: netOption,
 	}
 	ipamV4ConfList := []*libnetwork.IpamConf{{PreferredPool: "192.168.100.0/24"}}
@@ -476,6 +485,7 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 
 	// Create network 1 and add 2 endpoint: ep11, ep12
 	netOption := options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "network1",
 		},
@@ -549,6 +559,7 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 
 	// Create network 2
 	netOption = options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "network2",
 		},
@@ -605,6 +616,7 @@ func TestDuplicateEndpoint(t *testing.T) {
 	controller := newController(t)
 
 	netOption := options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork",
 		},
@@ -654,6 +666,7 @@ func TestControllerQuery(t *testing.T) {
 
 	// Create network 1
 	netOption := options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "network1",
 		},
@@ -670,6 +683,7 @@ func TestControllerQuery(t *testing.T) {
 
 	// Create network 2
 	netOption = options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "network2",
 		},
@@ -755,6 +769,7 @@ func TestNetworkQuery(t *testing.T) {
 
 	// Create network 1 and add 2 endpoint: ep11, ep12
 	netOption := options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "network1",
 		},
@@ -840,6 +855,7 @@ func TestEndpointDeleteWithActiveContainer(t *testing.T) {
 	controller := newController(t)
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork",
 		},
@@ -854,6 +870,7 @@ func TestEndpointDeleteWithActiveContainer(t *testing.T) {
 	}()
 
 	n2, err := createTestNetwork(controller, bridgeNetType, "testnetwork2", options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork2",
 		},
@@ -914,6 +931,7 @@ func TestEndpointMultipleJoins(t *testing.T) {
 	controller := newController(t)
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testmultiple", options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testmultiple",
 		},
@@ -987,6 +1005,7 @@ func TestLeaveAll(t *testing.T) {
 	controller := newController(t)
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork",
 		},
@@ -1002,6 +1021,7 @@ func TestLeaveAll(t *testing.T) {
 	}()
 
 	n2, err := createTestNetwork(controller, bridgeNetType, "testnetwork2", options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork2",
 		},
@@ -1051,6 +1071,7 @@ func TestContainerInvalidLeave(t *testing.T) {
 	controller := newController(t)
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork",
 		},
@@ -1116,6 +1137,7 @@ func TestEndpointUpdateParent(t *testing.T) {
 	controller := newController(t)
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork",
 		},
@@ -1287,6 +1309,7 @@ func makeTesthostNetwork(t *testing.T, c *libnetwork.Controller) *libnetwork.Net
 func makeTestIPv6Network(t *testing.T, c *libnetwork.Controller) *libnetwork.Network {
 	t.Helper()
 	netOptions := options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.EnableIPv6: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork",
@@ -1423,6 +1446,7 @@ func TestBridgeIpv6FromMac(t *testing.T) {
 
 	network, err := controller.NewNetwork(bridgeNetType, "testipv6mac", "",
 		libnetwork.NetworkOptionGeneric(netOption),
+		libnetwork.NetworkOptionEnableIPv4(true),
 		libnetwork.NetworkOptionEnableIPv6(true),
 		libnetwork.NetworkOptionIpam(defaultipam.DriverName, "", ipamV4ConfList, ipamV6ConfList, nil),
 		libnetwork.NetworkOptionDeferIPv6Alloc(true))
@@ -1497,6 +1521,7 @@ func TestEndpointJoin(t *testing.T) {
 	ipamV6ConfList := []*libnetwork.IpamConf{{PreferredPool: "fe90::/64", Gateway: "fe90::22"}}
 	n1, err := controller.NewNetwork(bridgeNetType, "testnetwork1", "",
 		libnetwork.NetworkOptionGeneric(netOption),
+		libnetwork.NetworkOptionEnableIPv4(true),
 		libnetwork.NetworkOptionEnableIPv6(true),
 		libnetwork.NetworkOptionIpam(defaultipam.DriverName, "", nil, ipamV6ConfList, nil),
 		libnetwork.NetworkOptionDeferIPv6Alloc(true))
@@ -1612,6 +1637,7 @@ func TestEndpointJoin(t *testing.T) {
 	// Now test the container joining another network
 	n2, err := createTestNetwork(controller, bridgeNetType, "testnetwork2",
 		options.Generic{
+			netlabel.EnableIPv4: true,
 			netlabel.GenericData: options.Generic{
 				"BridgeName": "testnetwork2",
 			},
@@ -1662,6 +1688,7 @@ func externalKeyTest(t *testing.T, reexec bool) {
 	controller := newController(t)
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork",
 		},
@@ -1676,6 +1703,7 @@ func externalKeyTest(t *testing.T, reexec bool) {
 	}()
 
 	n2, err := createTestNetwork(controller, bridgeNetType, "testnetwork2", options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "testnetwork2",
 		},
@@ -1973,6 +2001,7 @@ func TestParallel(t *testing.T) {
 	controller := newController(t)
 
 	netOption := options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName": "network",
 		},
@@ -2034,6 +2063,7 @@ func TestBridge(t *testing.T) {
 	controller := newController(t)
 
 	netOption := options.Generic{
+		netlabel.EnableIPv4: true,
 		netlabel.EnableIPv6: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName":         "testnetwork",

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1524,16 +1524,18 @@ func (n *Network) ipamAllocate() error {
 		}
 	}
 
-	err = n.ipamAllocateVersion(4, ipam)
-	if err != nil {
-		return err
-	}
-
-	defer func() {
+	if n.enableIPv4 {
+		err = n.ipamAllocateVersion(4, ipam)
 		if err != nil {
-			n.ipamReleaseVersion(4, ipam)
+			return err
 		}
-	}()
+
+		defer func() {
+			if err != nil {
+				n.ipamReleaseVersion(4, ipam)
+			}
+		}()
+	}
 
 	if !n.enableIPv6 {
 		return nil

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1508,7 +1508,7 @@ func (n *Network) getController() *Controller {
 	return n.ctrlr
 }
 
-func (n *Network) ipamAllocate() error {
+func (n *Network) ipamAllocate() (retErr error) {
 	if n.hasSpecialDriver() {
 		return nil
 	}
@@ -1525,24 +1525,23 @@ func (n *Network) ipamAllocate() error {
 	}
 
 	if n.enableIPv4 {
-		err = n.ipamAllocateVersion(4, ipam)
-		if err != nil {
+		if err := n.ipamAllocateVersion(4, ipam); err != nil {
 			return err
 		}
-
 		defer func() {
-			if err != nil {
+			if retErr != nil {
 				n.ipamReleaseVersion(4, ipam)
 			}
 		}()
 	}
 
-	if !n.enableIPv6 {
-		return nil
+	if n.enableIPv6 {
+		if err := n.ipamAllocateVersion(6, ipam); err != nil {
+			return err
+		}
 	}
 
-	err = n.ipamAllocateVersion(6, ipam)
-	return err
+	return nil
 }
 
 func (n *Network) ipamAllocateVersion(ipVer int, ipam ipamapi.Ipam) error {

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1209,7 +1209,7 @@ func (n *Network) createEndpoint(ctx context.Context, name string, options ...En
 		ep.ipamOptions[netlabel.MacAddress] = ep.iface.mac.String()
 	}
 
-	if err = ep.assignAddress(ipam, true, n.enableIPv6 && !n.postIPv6); err != nil {
+	if err = ep.assignAddress(ipam, n.enableIPv4, n.enableIPv6 && !n.postIPv6); err != nil {
 		return nil, err
 	}
 	defer func() {

--- a/libnetwork/resolver_unix_test.go
+++ b/libnetwork/resolver_unix_test.go
@@ -23,7 +23,7 @@ func TestDNSIPQuery(t *testing.T) {
 	}
 	defer c.Stop()
 
-	n, err := c.NewNetwork("bridge", "dtnet1", "", nil)
+	n, err := c.NewNetwork("bridge", "dtnet1", "", NetworkOptionEnableIPv4(true))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +121,7 @@ func TestDNSProxyServFail(t *testing.T) {
 	}
 	defer c.Stop()
 
-	n, err := c.NewNetwork("bridge", "dtnet2", "", nil)
+	n, err := c.NewNetwork("bridge", "dtnet2", "", NetworkOptionEnableIPv4(true))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/sandbox_unix_test.go
+++ b/libnetwork/sandbox_unix_test.go
@@ -117,9 +117,18 @@ func TestSandboxAddMultiPrio(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 
 	opts := [][]NetworkOption{
-		{NetworkOptionEnableIPv6(true), NetworkOptionIpam(defaultipam.DriverName, "", nil, []*IpamConf{{PreferredPool: "fe90::/64"}}, nil)},
-		{NetworkOptionInternalNetwork()},
-		{},
+		{
+			NetworkOptionEnableIPv4(true),
+			NetworkOptionEnableIPv6(true),
+			NetworkOptionIpam(defaultipam.DriverName, "", nil, []*IpamConf{{PreferredPool: "fe90::/64"}}, nil),
+		},
+		{
+			NetworkOptionEnableIPv4(true),
+			NetworkOptionInternalNetwork(),
+		},
+		{
+			NetworkOptionEnableIPv4(true),
+		},
 	}
 
 	ctrlr, nws := getTestEnv(t, opts...)
@@ -201,10 +210,21 @@ func TestSandboxAddSamePrio(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 
 	opts := [][]NetworkOption{
-		{},
-		{},
-		{NetworkOptionEnableIPv6(true), NetworkOptionIpam(defaultipam.DriverName, "", nil, []*IpamConf{{PreferredPool: "fe90::/64"}}, nil)},
-		{NetworkOptionInternalNetwork()},
+		{
+			NetworkOptionEnableIPv4(true),
+		},
+		{
+			NetworkOptionEnableIPv4(true),
+		},
+		{
+			NetworkOptionEnableIPv4(true),
+			NetworkOptionEnableIPv6(true),
+			NetworkOptionIpam(defaultipam.DriverName, "", nil, []*IpamConf{{PreferredPool: "fe90::/64"}}, nil),
+		},
+		{
+			NetworkOptionEnableIPv4(true),
+			NetworkOptionInternalNetwork(),
+		},
 	}
 
 	ctrlr, nws := getTestEnv(t, opts...)

--- a/libnetwork/service_common_unix_test.go
+++ b/libnetwork/service_common_unix_test.go
@@ -24,11 +24,11 @@ func TestCleanupServiceDiscovery(t *testing.T) {
 			t.Error(err)
 		}
 	}
-	n1, err := c.NewNetwork("bridge", "net1", "", nil)
+	n1, err := c.NewNetwork("bridge", "net1", "", NetworkOptionEnableIPv4(true))
 	assert.NilError(t, err)
 	defer cleanup(n1)
 
-	n2, err := c.NewNetwork("bridge", "net2", "", nil)
+	n2, err := c.NewNetwork("bridge", "net2", "", NetworkOptionEnableIPv4(true))
 	assert.NilError(t, err)
 	defer cleanup(n2)
 


### PR DESCRIPTION
**- What I did**

Top-level `libnetwork` changes for IPv6-only, apart from DNS (which is up-next!).

**- How I did it**

- Make `Sandbox.needDefaultGW` check for an IPv6 gateway.
  - So that `docker_gwbridge` isn't added for an IPv6-only network.
- Set `enableIPv4` in the tests that need it.
  - Without this, after the following commits, most tests fail with `ipv4 pool is empty` because no IPv4 address pools are set up.
- Only set up IPv4 IPAM if `enableIPv4`.
- Only allocate IPv4 addresses if `enableIPv4`.

**- How to verify it**

Updated tests still pass.

**- Description for the changelog**
```markdown changelog
n/a
```