### PR TITLE
[WIP] Add IPv6 support to Windows netdrivers

### DIFF
--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -179,7 +179,7 @@ Function Execute-Build($type, $additionalBuildTags, $directory, $ldflags) {
     if ($Noisy)                     { $verboseParm=" -v" }
     if ($Race)                      { Write-Warning "Using race detector"; $raceParm=" -race"}
     if ($ForceBuildAll)             { $allParm=" -a" }
-    if ($NoOpt)                     { $optParm=" -gcflags "+""""+"-N -l"+"""" }
+    if ($NoOpt)                     { $optParm=" -gcflags "+""""+"all=-N -l"+"""" }
     if ($additionalBuildTags -ne "") { $buildTags += $(" " + $additionalBuildTags) }
 
     # Do the go build in the appropriate directory

--- a/integration/network/nat/nat_windows_test.go
+++ b/integration/network/nat/nat_windows_test.go
@@ -1,8 +1,10 @@
 package nat // import "github.com/docker/docker/integration/network/nat"
 
 import (
+	"net/netip"
 	"testing"
 
+	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/integration/internal/network"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -21,4 +23,32 @@ func TestWindowsNoDisableIPv4(t *testing.T) {
 	// no way to start a second daemon with "--experimental" in Windows CI.
 	assert.Check(t, is.ErrorContains(err,
 		"IPv4 can only be disabled if experimental features are enabled"))
+}
+
+func TestCreateIPv6NATNetwork(t *testing.T) {
+	ctx := setupTest(t)
+	c := testEnv.APIClient()
+
+	nid, err := network.Create(ctx, c, "ipv6only",
+		network.WithDriver("nat"),
+		network.WithIPv6(),
+	)
+	assert.NilError(t, err)
+
+	nw, err := c.NetworkInspect(ctx, nid, networktypes.InspectOptions{})
+	assert.NilError(t, err)
+
+	// HNS automatically adds an IPv4 subnet if none is provided, so we should
+	// have one IPv4 and one IPv6 here.
+	assert.Equal(t, len(nw.IPAM.Config), 2, "nat network should have two subnets")
+
+	var hasIPv6Subnet bool
+	for _, subnet := range nw.IPAM.Config {
+		if netip.MustParseAddr(subnet.Subnet).Is6() {
+			hasIPv6Subnet = true
+			break
+		}
+	}
+
+	assert.Equal(t, hasIPv6Subnet, true)
 }

--- a/libnetwork/drivers/windows/windows.go
+++ b/libnetwork/drivers/windows/windows.go
@@ -275,7 +275,7 @@ func (d *driver) createNetwork(config *networkConfiguration) *hnsNetwork {
 }
 
 // Create a new network
-func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
+func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) (retErr error) {
 	if _, err := d.getNetwork(id); err == nil {
 		return types.ForbiddenErrorf("network %s exists", id)
 	}
@@ -377,7 +377,7 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 		n.created = true
 
 		defer func() {
-			if err != nil {
+			if retErr != nil {
 				d.DeleteNetwork(n.id)
 			}
 		}()

--- a/libnetwork/drivers/windows/windows.go
+++ b/libnetwork/drivers/windows/windows.go
@@ -86,7 +86,7 @@ type hnsEndpoint struct {
 	epConnectivity *EndpointConnectivity // User specified parameters
 	portMapping    []types.PortBinding   // Operation port bindings
 	addr           *net.IPNet
-	gateway        net.IP
+	gatewayV4      net.IP
 	dbIndex        uint64
 	dbExists       bool
 }
@@ -240,10 +240,6 @@ func (d *driver) parseNetworkOptions(id string, genericOptions map[string]string
 }
 
 func (c *networkConfiguration) processIPAM(id string, ipamV4Data, ipamV6Data []driverapi.IPAMData) error {
-	if len(ipamV6Data) > 0 {
-		return types.ForbiddenErrorf("windowsshim driver doesn't support v6 subnets")
-	}
-
 	if len(ipamV4Data) == 0 {
 		return types.InvalidParameterErrorf("network %s requires ipv4 configuration", id)
 	}
@@ -737,7 +733,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 	}
 
 	if hnsresponse.GatewayAddress != "" {
-		endpoint.gateway = net.ParseIP(hnsresponse.GatewayAddress)
+		endpoint.gatewayV4 = net.ParseIP(hnsresponse.GatewayAddress)
 	}
 
 	endpoint.profileID = hnsresponse.Id
@@ -858,7 +854,7 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 		return err
 	}
 
-	err = jinfo.SetGateway(endpoint.gateway)
+	err = jinfo.SetGateway(endpoint.gatewayV4)
 	if err != nil {
 		return err
 	}

--- a/libnetwork/drivers/windows/windows_store.go
+++ b/libnetwork/drivers/windows/windows_store.go
@@ -214,8 +214,8 @@ func (ep *hnsEndpoint) MarshalJSON() ([]byte, error) {
 	if ep.addr.IP != nil {
 		epMap["Addr"] = ep.addr.String()
 	}
-	if ep.gateway != nil {
-		epMap["gateway"] = ep.gateway.String()
+	if ep.gatewayV4 != nil {
+		epMap["gateway"] = ep.gatewayV4.String()
 	}
 	epMap["epOption"] = ep.epOption
 	epMap["epConnectivity"] = ep.epConnectivity
@@ -244,7 +244,7 @@ func (ep *hnsEndpoint) UnmarshalJSON(b []byte) error {
 		}
 	}
 	if v, ok := epMap["gateway"]; ok {
-		ep.gateway = net.ParseIP(v.(string))
+		ep.gatewayV4 = net.ParseIP(v.(string))
 	}
 	ep.id = epMap["id"].(string)
 	ep.Type = epMap["Type"].(string)

--- a/libnetwork/ipams/windowsipam/windowsipam_test.go
+++ b/libnetwork/ipams/windowsipam/windowsipam_test.go
@@ -71,8 +71,15 @@ func TestRequestPool(t *testing.T) {
 		{
 			req: ipamapi.PoolRequest{AddressSpace: localAddressSpace},
 			expAlloc: ipamapi.AllocatedPool{
-				PoolID: defaultPool.String(),
-				Pool:   defaultPool,
+				PoolID: defaultPoolV4.String(),
+				Pool:   defaultPoolV4,
+			},
+		},
+		{
+			req: ipamapi.PoolRequest{AddressSpace: localAddressSpace, V6: true},
+			expAlloc: ipamapi.AllocatedPool{
+				PoolID: defaultPoolV6.String(),
+				Pool:   defaultPoolV6,
 			},
 		},
 		{
@@ -83,11 +90,18 @@ func TestRequestPool(t *testing.T) {
 			},
 		},
 		{
+			req: ipamapi.PoolRequest{AddressSpace: localAddressSpace, Pool: "fdf7:50::/64", V6: true},
+			expAlloc: ipamapi.AllocatedPool{
+				PoolID: "fdf7:50::/64",
+				Pool:   netip.MustParsePrefix("fdf7:50::/64"),
+			},
+		},
+		{
 			req:    ipamapi.PoolRequest{AddressSpace: localAddressSpace, Pool: "192.168.0.0/16", SubPool: "192.168.0.0/16"},
 			expErr: errors.New("this request is not supported by the 'windows' ipam driver"),
 		},
 		{
-			req:    ipamapi.PoolRequest{AddressSpace: localAddressSpace, V6: true},
+			req:    ipamapi.PoolRequest{AddressSpace: localAddressSpace, Pool: "fdf7:50::/64", SubPool: "fdf7:50::/64", V6: true},
 			expErr: errors.New("this request is not supported by the 'windows' ipam driver"),
 		},
 	}

--- a/libnetwork/ipams/windowsipam/windowsipam_test.go
+++ b/libnetwork/ipams/windowsipam/windowsipam_test.go
@@ -3,12 +3,16 @@
 package windowsipam
 
 import (
+	"errors"
+	"fmt"
 	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/docker/docker/libnetwork/ipamapi"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/types"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -16,31 +20,13 @@ import (
 func TestWindowsIPAM(t *testing.T) {
 	a := &allocator{}
 
-	alloc, err := a.RequestPool(ipamapi.PoolRequest{AddressSpace: localAddressSpace})
-	assert.NilError(t, err)
-	assert.Check(t, is.Equal(alloc.PoolID, defaultPool.String()))
-	assert.Check(t, is.Equal(alloc.Pool, defaultPool))
-
-	alloc, err = a.RequestPool(ipamapi.PoolRequest{
+	alloc, err := a.RequestPool(ipamapi.PoolRequest{
 		AddressSpace: localAddressSpace,
 		Pool:         "192.168.0.0/16",
 	})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(alloc.PoolID, "192.168.0.0/16"))
 	assert.Check(t, is.Equal(alloc.Pool.String(), "192.168.0.0/16"))
-
-	_, err = a.RequestPool(ipamapi.PoolRequest{
-		AddressSpace: localAddressSpace,
-		Pool:         "192.168.0.0/16",
-		SubPool:      "192.168.0.0/16",
-	})
-	assert.ErrorContains(t, err, "this request is not supported by the 'windows' ipam driver")
-
-	_, err = a.RequestPool(ipamapi.PoolRequest{
-		AddressSpace: localAddressSpace,
-		V6:           true,
-	})
-	assert.ErrorContains(t, err, "this request is not supported by the 'windows' ipam driver")
 
 	requestPool, _ := types.ParseCIDR("192.168.0.0/16")
 	requestAddress := net.ParseIP("192.168.1.1")
@@ -82,5 +68,53 @@ func TestWindowsIPAM(t *testing.T) {
 	err = a.ReleaseAddress(requestPool.String(), requestAddress)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestRequestPool(t *testing.T) {
+	testcases := []struct {
+		req      ipamapi.PoolRequest
+		expAlloc ipamapi.AllocatedPool
+		expErr   error
+	}{
+		{
+			req: ipamapi.PoolRequest{AddressSpace: localAddressSpace},
+			expAlloc: ipamapi.AllocatedPool{
+				PoolID: defaultPool.String(),
+				Pool:   defaultPool,
+			},
+		},
+		{
+			req: ipamapi.PoolRequest{AddressSpace: localAddressSpace, Pool: "192.168.0.0/16"},
+			expAlloc: ipamapi.AllocatedPool{
+				PoolID: "192.168.0.0/16",
+				Pool:   netip.MustParsePrefix("192.168.0.0/16"),
+			},
+		},
+		{
+			req:    ipamapi.PoolRequest{AddressSpace: localAddressSpace, Pool: "192.168.0.0/16", SubPool: "192.168.0.0/16"},
+			expErr: errors.New("this request is not supported by the 'windows' ipam driver"),
+		},
+		{
+			req:    ipamapi.PoolRequest{AddressSpace: localAddressSpace, V6: true},
+			expErr: errors.New("this request is not supported by the 'windows' ipam driver"),
+		},
+	}
+
+	a := &allocator{}
+
+	for _, tc := range testcases {
+		t.Run(fmt.Sprintf("%+v", tc.req), func(t *testing.T) {
+			alloc, err := a.RequestPool(tc.req)
+
+			if tc.expErr != nil {
+				assert.Error(t, err, tc.expErr.Error())
+			} else {
+				assert.NilError(t, err)
+			}
+
+			assert.DeepEqual(t, alloc.Pool, tc.expAlloc.Pool, cmpopts.EquateComparable(netip.Prefix{}))
+			assert.Equal(t, alloc.PoolID, tc.expAlloc.PoolID)
+		})
 	}
 }

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1921,19 +1921,25 @@ func (n *Network) TableEventRegister(tableName string, objType driverapi.ObjectT
 	return nil
 }
 
-func (n *Network) UpdateIpamConfig(ipV4Data []driverapi.IPAMData) {
-	ipamV4Config := make([]*IpamConf, len(ipV4Data))
+func (n *Network) UpdateIpamConfig(ipams []driverapi.IPAMData) {
+	var ipamV4Config, ipamV6Config []*IpamConf
 
-	for i, data := range ipV4Data {
+	for _, data := range ipams {
 		ic := &IpamConf{}
 		ic.PreferredPool = data.Pool.String()
 		ic.Gateway = data.Gateway.IP.String()
-		ipamV4Config[i] = ic
+
+		if len(data.Pool.IP) == 4 {
+			ipamV4Config = append(ipamV4Config, ic)
+		} else {
+			ipamV6Config = append(ipamV6Config, ic)
+		}
 	}
 
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	n.ipamV4Config = ipamV4Config
+	n.ipamV6Config = ipamV6Config
 }
 
 // Special drivers are ones which do not need to perform any Network plumbing

--- a/libnetwork/network_windows.go
+++ b/libnetwork/network_windows.go
@@ -62,21 +62,34 @@ func (n *Network) startResolver() {
 		}
 
 		for _, subnet := range hnsresponse.Subnets {
-			if subnet.GatewayAddress != "" {
-				for i := 0; i < 3; i++ {
-					resolver := NewResolver(subnet.GatewayAddress, true, n)
-					log.G(context.TODO()).Debugf("Binding a resolver on network %s gateway %s", n.Name(), subnet.GatewayAddress)
-					n.dnsCompartment = hnsresponse.DNSServerCompartment
-					n.ExecFunc(resolver.SetupFunc(53))
+			if subnet.GatewayAddress == "" {
+				continue
+			}
 
-					if err = resolver.Start(); err != nil {
-						log.G(context.TODO()).Errorf("Resolver Setup/Start failed for container %s, %q", n.Name(), err)
-						time.Sleep(1 * time.Second)
-					} else {
-						log.G(context.TODO()).Debugf("Resolver bound successfully for network %s", n.Name())
-						n.resolver = append(n.resolver, resolver)
-						break
-					}
+			gwAddr, err := netip.ParseAddr(subnet.GatewayAddress)
+			if err != nil {
+				log.G(context.TODO()).Warnf("HNS returned an invalid gateway address while starting the DNS resolver: %v", err)
+				continue
+			}
+
+			// HNS always appends a zone ID to GatewayAddress, even for non-LL
+			// addresses. We need to delete it otherwise the resolver won't
+			// start.
+			gwAddr = gwAddr.WithZone("")
+
+			for i := 0; i < 3; i++ {
+				resolver := NewResolver(gwAddr.String(), true, n)
+				log.G(context.TODO()).Debugf("Binding a resolver on network %s gateway %s", n.Name(), gwAddr)
+				n.dnsCompartment = hnsresponse.DNSServerCompartment
+				n.ExecFunc(resolver.SetupFunc(53))
+
+				if err = resolver.Start(); err != nil {
+					log.G(context.TODO()).Errorf("Resolver Setup/Start failed for container %s, %q", n.Name(), err)
+					time.Sleep(1 * time.Second)
+				} else {
+					log.G(context.TODO()).Debugf("Resolver bound successfully for network %s", n.Name())
+					n.resolver = append(n.resolver, resolver)
+					break
 				}
 			}
 		}

--- a/libnetwork/network_windows.go
+++ b/libnetwork/network_windows.go
@@ -236,8 +236,8 @@ func deleteEpFromResolverImpl(
 
 func findHNSEp(ip4, ip6 *net.IPNet, hnsEndpoints []hcsshim.HNSEndpoint) *hcsshim.HNSEndpoint {
 	for _, hnsEp := range hnsEndpoints {
-		if (hnsEp.IPAddress != nil && hnsEp.IPAddress.Equal(ip4.IP)) ||
-			(hnsEp.IPv6Address != nil && hnsEp.IPv6Address.Equal(ip6.IP)) {
+		if (hnsEp.IPAddress != nil && ip4 != nil && hnsEp.IPAddress.Equal(ip4.IP)) ||
+			(hnsEp.IPv6Address != nil && ip6 != nil && hnsEp.IPv6Address.Equal(ip6.IP)) {
 			return &hnsEp
 		}
 	}


### PR DESCRIPTION
**- What I did**

For now, I'm focusing on the default `nat` driver.

Creating IPv6 `nat` networks works correctly. Containers attached to such networks get an IPv6 address assigned, but it's not provisioned inside the container, and doing so manually doesn't work either.

Unlike IPv4, HNS doesn't dynamically allocate IPv6 subnets:

```
$ docker network create -d nat --ipv6 testnet-ipv6
Error response from daemon: failed during hnsCallRawResponse: hnsCall failed in Win32: Element not found. (0x490)
$ docker network create -d nat --ipv6 --subnet fdf7:50::/64 testnet-ipv6
6e493b380660188b2e2d6d7b193da6331876a915f0cacdb984b3bfc568374833
```

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

