### PR TITLE
IPv6 only: macvlan and ipvlan drivers

### DIFF
--- a/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
@@ -31,7 +31,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 		addr:   ifInfo.Address(),
 		addrv6: ifInfo.AddressIPv6(),
 	}
-	if ep.addr == nil {
+	if ep.addr == nil && ep.addrv6 == nil {
 		return fmt.Errorf("create endpoint was not passed an IP address")
 	}
 	// disallow port mapping -p

--- a/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/ns"
@@ -20,7 +21,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 	}
 	n, err := d.getNetwork(nid)
 	if err != nil {
-		return fmt.Errorf("network id %q not found", nid)
+		return errdefs.System(fmt.Errorf("network id %q not found", nid))
 	}
 	if ifInfo.MacAddress() != nil {
 		return fmt.Errorf("ipvlan interfaces do not support custom mac address assignment")
@@ -32,7 +33,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 		addrv6: ifInfo.AddressIPv6(),
 	}
 	if ep.addr == nil && ep.addrv6 == nil {
-		return fmt.Errorf("create endpoint was not passed an IP address")
+		return errdefs.InvalidParameter(fmt.Errorf("create endpoint was not passed an IP address"))
 	}
 	// disallow port mapping -p
 	if opt, ok := epOptions[netlabel.PortMap]; ok {

--- a/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
@@ -32,9 +32,6 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 		addr:   ifInfo.Address(),
 		addrv6: ifInfo.AddressIPv6(),
 	}
-	if ep.addr == nil && ep.addrv6 == nil {
-		return errdefs.InvalidParameter(fmt.Errorf("create endpoint was not passed an IP address"))
-	}
 	// disallow port mapping -p
 	if opt, ok := epOptions[netlabel.PortMap]; ok {
 		if _, ok := opt.([]types.PortBinding); ok {

--- a/libnetwork/drivers/ipvlan/ipvlan_joinleave.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_joinleave.go
@@ -123,6 +123,10 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 				log.G(ctx).Debugf("Ipvlan Endpoint Joined with IPv6_Addr: %s, Gateway: %s, Ipvlan_Mode: %s, Parent: %s",
 					ep.addrv6.IP.String(), v6gw.String(), n.config.IpvlanMode, n.config.Parent)
 			}
+			if len(n.config.Ipv4Subnets) == 0 && len(n.config.Ipv6Subnets) == 0 {
+				// With no addresses, don't need a gateway.
+				jinfo.DisableGatewayService()
+			}
 		}
 	} else {
 		if len(n.config.Ipv4Subnets) > 0 {

--- a/libnetwork/drivers/ipvlan/ipvlan_joinleave.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_joinleave.go
@@ -65,15 +65,17 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 		case modeL3, modeL3S:
 			// disable gateway services to add a default gw using dev eth0 only
 			jinfo.DisableGatewayService()
-			defaultRoute, err := ifaceGateway(defaultV4RouteCidr)
-			if err != nil {
-				return err
+			if ep.addr != nil {
+				defaultRoute, err := ifaceGateway(defaultV4RouteCidr)
+				if err != nil {
+					return err
+				}
+				if err := jinfo.AddStaticRoute(defaultRoute.Destination, defaultRoute.RouteType, defaultRoute.NextHop); err != nil {
+					return fmt.Errorf("failed to set an ipvlan l3/l3s mode ipv4 default gateway: %v", err)
+				}
+				log.G(ctx).Debugf("Ipvlan Endpoint Joined with IPv4_Addr: %s, Ipvlan_Mode: %s, Parent: %s",
+					ep.addr.IP.String(), n.config.IpvlanMode, n.config.Parent)
 			}
-			if err := jinfo.AddStaticRoute(defaultRoute.Destination, defaultRoute.RouteType, defaultRoute.NextHop); err != nil {
-				return fmt.Errorf("failed to set an ipvlan l3/l3s mode ipv4 default gateway: %v", err)
-			}
-			log.G(ctx).Debugf("Ipvlan Endpoint Joined with IPv4_Addr: %s, Ipvlan_Mode: %s, Parent: %s",
-				ep.addr.IP.String(), n.config.IpvlanMode, n.config.Parent)
 			// If the endpoint has a v6 address, set a v6 default route
 			if ep.addrv6 != nil {
 				default6Route, err := ifaceGateway(defaultV6RouteCidr)

--- a/libnetwork/drivers/ipvlan/ipvlan_network.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_network.go
@@ -30,7 +30,7 @@ func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo 
 	// reject a null v4 network if ipv4 is required
 	if v, ok := option[netlabel.EnableIPv4]; ok && v.(bool) {
 		if len(ipV4Data) == 0 || ipV4Data[0].Pool.String() == "0.0.0.0/0" {
-			return fmt.Errorf("ipv4 pool is empty")
+			return errdefs.InvalidParameter(fmt.Errorf("ipv4 pool is empty"))
 		}
 	}
 	// reject a null v6 network if ipv6 is required

--- a/libnetwork/drivers/ipvlan/ipvlan_network.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_network.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/ns"
@@ -26,9 +27,17 @@ func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo 
 		return fmt.Errorf("kernel version failed to meet the minimum ipvlan kernel requirement of %d.%d, found %d.%d.%d",
 			ipvlanKernelVer, ipvlanMajorVer, kv.Kernel, kv.Major, kv.Minor)
 	}
-	// reject a null v4 network
-	if len(ipV4Data) == 0 || ipV4Data[0].Pool.String() == "0.0.0.0/0" {
-		return fmt.Errorf("ipv4 pool is empty")
+	// reject a null v4 network if ipv4 is required
+	if v, ok := option[netlabel.EnableIPv4]; ok && v.(bool) {
+		if len(ipV4Data) == 0 || ipV4Data[0].Pool.String() == "0.0.0.0/0" {
+			return fmt.Errorf("ipv4 pool is empty")
+		}
+	}
+	// reject a null v6 network if ipv6 is required
+	if v, ok := option[netlabel.EnableIPv6]; ok && v.(bool) {
+		if len(ipV6Data) == 0 || ipV6Data[0].Pool.String() == "::/0" {
+			return errdefs.InvalidParameter(fmt.Errorf("ipv6 pool is empty"))
+		}
 	}
 	// parse and validate the config and bind to networkConfiguration
 	config, err := parseNetworkOptions(nid, option)

--- a/libnetwork/drivers/macvlan/macvlan_endpoint.go
+++ b/libnetwork/drivers/macvlan/macvlan_endpoint.go
@@ -30,11 +30,17 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 		addrv6: ifInfo.AddressIPv6(),
 		mac:    ifInfo.MacAddress(),
 	}
-	if ep.addr == nil {
+	if ep.addr == nil && ep.addrv6 == nil {
 		return fmt.Errorf("create endpoint was not passed an IP address")
 	}
 	if ep.mac == nil {
-		ep.mac = netutils.GenerateMACFromIP(ep.addr.IP)
+		if ep.addr != nil {
+			ep.mac = netutils.GenerateMACFromIP(ep.addr.IP)
+		} else {
+			// TODO(robmry) - generate an unsolicited Neighbor Advertisement to
+			//  associate this MAC address with the IP.
+			ep.mac = netutils.GenerateRandomMAC()
+		}
 		if err := ifInfo.SetMacAddress(ep.mac); err != nil {
 			return err
 		}

--- a/libnetwork/drivers/macvlan/macvlan_endpoint.go
+++ b/libnetwork/drivers/macvlan/macvlan_endpoint.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/netutils"
@@ -21,7 +22,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 	}
 	n, err := d.getNetwork(nid)
 	if err != nil {
-		return fmt.Errorf("network id %q not found", nid)
+		return errdefs.System(fmt.Errorf("network id %q not found", nid))
 	}
 	ep := &endpoint{
 		id:     eid,
@@ -31,7 +32,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 		mac:    ifInfo.MacAddress(),
 	}
 	if ep.addr == nil && ep.addrv6 == nil {
-		return fmt.Errorf("create endpoint was not passed an IP address")
+		return errdefs.InvalidParameter(fmt.Errorf("create endpoint was not passed an IP address"))
 	}
 	if ep.mac == nil {
 		if ep.addr != nil {

--- a/libnetwork/drivers/macvlan/macvlan_endpoint.go
+++ b/libnetwork/drivers/macvlan/macvlan_endpoint.go
@@ -31,9 +31,6 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 		addrv6: ifInfo.AddressIPv6(),
 		mac:    ifInfo.MacAddress(),
 	}
-	if ep.addr == nil && ep.addrv6 == nil {
-		return errdefs.InvalidParameter(fmt.Errorf("create endpoint was not passed an IP address"))
-	}
 	if ep.mac == nil {
 		if ep.addr != nil {
 			ep.mac = netutils.GenerateMACFromIP(ep.addr.IP)

--- a/libnetwork/drivers/macvlan/macvlan_joinleave.go
+++ b/libnetwork/drivers/macvlan/macvlan_joinleave.go
@@ -83,6 +83,10 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 			log.G(ctx).Debugf("Macvlan Endpoint Joined with IPv6_Addr: %s Gateway: %s MacVlan_Mode: %s, Parent: %s",
 				ep.addrv6.IP.String(), v6gw.String(), n.config.MacvlanMode, n.config.Parent)
 		}
+		if len(n.config.Ipv4Subnets) == 0 && len(n.config.Ipv6Subnets) == 0 {
+			// With no addresses, don't need a gateway.
+			jinfo.DisableGatewayService()
+		}
 	} else {
 		if len(n.config.Ipv4Subnets) > 0 {
 			log.G(ctx).Debugf("Macvlan Endpoint Joined with IPv4_Addr: %s, MacVlan_Mode: %s, Parent: %s",

--- a/libnetwork/drivers/macvlan/macvlan_network.go
+++ b/libnetwork/drivers/macvlan/macvlan_network.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/ns"
@@ -16,10 +17,19 @@ import (
 
 // CreateNetwork the network for the specified driver type
 func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
-	// reject a null v4 network
-	if len(ipV4Data) == 0 || ipV4Data[0].Pool.String() == "0.0.0.0/0" {
-		return fmt.Errorf("ipv4 pool is empty")
+	// reject a null v4 network if ipv4 is required
+	if v, ok := option[netlabel.EnableIPv4]; ok && v.(bool) {
+		if len(ipV4Data) == 0 || ipV4Data[0].Pool.String() == "0.0.0.0/0" {
+			return fmt.Errorf("ipv4 pool is empty")
+		}
 	}
+	// reject a null v6 network if ipv6 is required
+	if v, ok := option[netlabel.EnableIPv6]; ok && v.(bool) {
+		if len(ipV6Data) == 0 || ipV6Data[0].Pool.String() == "::/0" {
+			return errdefs.InvalidParameter(fmt.Errorf("ipv6 pool is empty"))
+		}
+	}
+
 	// parse and validate the config and bind to networkConfiguration
 	config, err := parseNetworkOptions(nid, option)
 	if err != nil {

--- a/libnetwork/drivers/macvlan/macvlan_network.go
+++ b/libnetwork/drivers/macvlan/macvlan_network.go
@@ -20,7 +20,7 @@ func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo 
 	// reject a null v4 network if ipv4 is required
 	if v, ok := option[netlabel.EnableIPv4]; ok && v.(bool) {
 		if len(ipV4Data) == 0 || ipV4Data[0].Pool.String() == "0.0.0.0/0" {
-			return fmt.Errorf("ipv4 pool is empty")
+			return errdefs.InvalidParameter(fmt.Errorf("ipv4 pool is empty"))
 		}
 	}
 	// reject a null v6 network if ipv6 is required


### PR DESCRIPTION
**- What I did**

Allow creation of macvlan/ipvlan networks with no IPv4 address, and with no IPv4 or IPv6 address.

**- How I did it**

For each driver:
- Only check for IPv4 IPAM if IPv4 is needed.
- If there's no IPv4 address, use a random mac address (as it's not possible to base a MAC address on an IPv6 address).
- Stop `docker_gwbridge` from being created/connected if no address is assigned.
- Add integration tests for v6-only and no address.
- (Fix some error types for the API.)

**- How to verify it**

New tests.

With `--experimental` ...
```
# docker network create -d macvlan -o parent=eth0 --ipv6 -o com.docker.network.enable_ipv4=false mvnet
```

**- Description for the changelog**
```markdown changelog
- Allow creation of macvlan and ipvlan networks without IPv4 address assignment, and with no IP address assignment.
```

