### PR TITLE
Makefile: Add BIND_GIT variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,14 @@ DOCKER_MOUNT := $(if $(DOCKER_MOUNT),$(DOCKER_MOUNT),-v /go/src/github.com/docke
 DOCKER_MOUNT_CACHE := -v docker-dev-cache:/root/.cache -v docker-mod-cache:/go/pkg/mod/
 DOCKER_MOUNT_CLI := $(if $(DOCKER_CLI_PATH),-v $(shell dirname $(DOCKER_CLI_PATH)):/usr/local/cli,)
 DOCKER_MOUNT_BASH_COMPLETION := $(if $(DOCKER_BASH_COMPLETION_PATH),-v $(shell dirname $(DOCKER_BASH_COMPLETION_PATH)):/usr/local/completion/bash,)
-DOCKER_MOUNT := $(DOCKER_MOUNT) $(DOCKER_MOUNT_CACHE) $(DOCKER_MOUNT_CLI) $(DOCKER_MOUNT_BASH_COMPLETION)
+
+ifdef BIND_GIT
+	# Gets the common .git directory (even from inside a git worktree)
+	GITDIR := $(shell realpath $(shell git rev-parse --git-common-dir))
+	MOUNT_GITDIR := $(if $(GITDIR),-v "$(GITDIR):$(GITDIR)")
+endif
+
+DOCKER_MOUNT := $(DOCKER_MOUNT) $(DOCKER_MOUNT_CACHE) $(DOCKER_MOUNT_CLI) $(DOCKER_MOUNT_BASH_COMPLETION) $(MOUNT_GITDIR)
 endif # ifndef DOCKER_MOUNT
 
 # This allows to set the docker-dev container name


### PR DESCRIPTION
Defining BIND_GIT will also bind mount the common .git directory into the dev container.
This makes it possible to run some hack/* scripts which rely on `git` when running the container in a git worktree.

**- How to verify it**
```terminal
$ git worktree add asdf
$ cd asdf
$ make BIND_GIT=1 validate-all
```

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

