### PR TITLE
govulncheck to report known vulnerabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,3 +130,35 @@ jobs:
         name: Check artifacts
         run: |
           find ${{ env.DESTDIR }} -type f -exec file -e ascii -- {} +
+
+  govulncheck:
+    runs-on: ubuntu-24.04
+    permissions:
+      # required to write sarif report
+      security-events: write
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: ${{ env.SETUP_BUILDX_VERSION }}
+          driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
+          buildkitd-flags: --debug
+      -
+        name: Run
+        uses: docker/bake-action@v5
+        with:
+          targets: govulncheck
+        env:
+          GOVULNCHECK_FORMAT: sarif
+      -
+        name: Upload SARIF report
+        if: ${{ github.event_name != 'pull_request' && github.repository == 'moby/moby' }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ env.DESTDIR }}/govulncheck.out

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -181,3 +181,22 @@ target "dev" {
   tags = ["docker-dev"]
   output = ["type=docker"]
 }
+
+#
+# govulncheck
+#
+
+variable "GOVULNCHECK_FORMAT" {
+  default = null
+}
+
+target "govulncheck" {
+  inherits = ["_common"]
+  dockerfile = "./hack/dockerfiles/govulncheck.Dockerfile"
+  target = "output"
+  args = {
+    FORMAT = GOVULNCHECK_FORMAT
+  }
+  no-cache-filter = ["run"]
+  output = ["${DESTDIR}"]
+}

--- a/hack/dockerfiles/govulncheck.Dockerfile
+++ b/hack/dockerfiles/govulncheck.Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+
+ARG GO_VERSION=1.21.13
+ARG GOVULNCHECK_VERSION=v1.1.3
+ARG FORMAT=text
+
+FROM golang:${GO_VERSION}-alpine AS base
+WORKDIR /go/src/github.com/docker/docker
+RUN apk add --no-cache jq moreutils
+ARG GOVULNCHECK_VERSION
+RUN --mount=type=cache,target=/root/.cache \
+    --mount=type=cache,target=/go/pkg/mod \
+    go install golang.org/x/vuln/cmd/govulncheck@$GOVULNCHECK_VERSION
+
+FROM base AS run
+ARG FORMAT
+RUN --mount=type=bind,target=.,rw <<EOT
+  set -ex
+  mkdir /out
+  ln -s vendor.mod go.mod
+  ln -s vendor.sum go.sum
+  govulncheck -format ${FORMAT} ./... | tee /out/govulncheck.out
+  if [ "${FORMAT}" = "sarif" ]; then
+    # Make sure "results" field is defined in SARIF output otherwise GitHub Code Scanning
+    # will fail when uploading report with "Invalid SARIF. Missing 'results' array in run."
+    # Relates to https://github.com/golang/vuln/blob/ffdef74cc44d7eb71931d8d414c478b966812488/internal/sarif/sarif.go#L69
+    jq '(.runs[] | select(.results == null) | .results) |= []' /out/govulncheck.out | tee >(sponge /out/govulncheck.out)
+  fi
+EOT
+
+FROM scratch AS output
+COPY --from=run /out /


### PR DESCRIPTION
similar to https://github.com/moby/buildkit/pull/5199

Runs [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) tool in our workflow to report known vulnerabilities that affect Go code using the Go vulnerability database at https://vuln.go.dev/ and output a SARIF report that will be uploaded to [GitHub Code scanning](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning) so we have these issues reported in the [Security tab](https://github.com/moby/moby/security/code-scanning).