### PR TITLE
Bump GitHub Actions runners to ubuntu-24.04

### DIFF
--- a/.github/workflows/.dco.yml
+++ b/.github/workflows/.dco.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   run:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       -
         name: Checkout

--- a/.github/workflows/.test-prepare.yml
+++ b/.github/workflows/.test-prepare.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   run:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.set.outputs.matrix }}
     steps:

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   unit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     timeout-minutes: 120
     steps:
@@ -88,7 +88,7 @@ jobs:
           retention-days: 1
 
   unit-report:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     timeout-minutes: 10
     if: always()
@@ -116,7 +116,7 @@ jobs:
           find /tmp/reports -type f -name '*-go-test-report.json' -exec teststat -markdown {} \+ >> $GITHUB_STEP_SUMMARY
 
   docker-py:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     timeout-minutes: 120
     steps:
@@ -173,7 +173,7 @@ jobs:
           retention-days: 1
 
   integration-flaky:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     timeout-minutes: 120
     steps:
@@ -212,8 +212,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
           - ubuntu-22.04
+          - ubuntu-24.04
         mode:
           - ""
           - rootless
@@ -303,7 +303,7 @@ jobs:
           retention-days: 1
 
   integration-report:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     timeout-minutes: 10
     if: always()
@@ -332,7 +332,7 @@ jobs:
           find /tmp/reports -type f -name '*-go-test-report.json' -exec teststat -markdown {} \+ >> $GITHUB_STEP_SUMMARY
 
   integration-cli-prepare:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     outputs:
       matrix: ${{ steps.tests.outputs.matrix }}
@@ -367,7 +367,7 @@ jobs:
           echo ${{ steps.tests.outputs.matrix }}
 
   integration-cli:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     timeout-minutes: 120
     needs:
@@ -447,7 +447,7 @@ jobs:
           retention-days: 1
 
   integration-cli-report:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     timeout-minutes: 10
     if: always()

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -202,7 +202,7 @@ jobs:
           retention-days: 1
 
   unit-test-report:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: always()
     needs:
       - unit-test
@@ -228,7 +228,7 @@ jobs:
           find /tmp/artifacts -type f -name '*-go-test-report.json' -exec teststat -markdown {} \+ >> $GITHUB_STEP_SUMMARY
 
   integration-test-prepare:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.tests.outputs.matrix }}
     steps:
@@ -521,7 +521,7 @@ jobs:
           retention-days: 1
 
   integration-test-report:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     continue-on-error: ${{ inputs.storage == 'snapshotter' && github.event_name != 'pull_request' }}
     if: always()
     needs:

--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -39,7 +39,7 @@ jobs:
     uses: ./.github/workflows/.dco.yml
 
   prepare:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       platforms: ${{ steps.platforms.outputs.matrix }}
     steps:
@@ -91,7 +91,7 @@ jobs:
           echo "matrix=$(docker buildx bake bin-image-cross --print | jq -cr '.target."bin-image-cross".platforms')" >>${GITHUB_OUTPUT}
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - validate-dco
       - prepare
@@ -165,7 +165,7 @@ jobs:
           retention-days: 1
 
   merge:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - build
     if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && github.event_name != 'pull_request' && github.repository == 'moby/moby'

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -32,7 +32,7 @@ jobs:
     uses: ./.github/workflows/.dco.yml
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - validate-dco
     steps:
@@ -61,7 +61,7 @@ jobs:
           retention-days: 1
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     needs:
       - build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     uses: ./.github/workflows/.dco.yml
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - validate-dco
     strategy:
@@ -68,7 +68,7 @@ jobs:
           find ${{ env.DESTDIR }} -type f -exec file -e ascii -- {} +
 
   prepare-cross:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - validate-dco
     outputs:
@@ -89,7 +89,7 @@ jobs:
           echo ${{ steps.platforms.outputs.matrix }}
 
   cross:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - validate-dco
       - prepare-cross

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     uses: ./.github/workflows/.dco.yml
 
   build-dev:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - validate-dco
     strategy:
@@ -85,7 +85,7 @@ jobs:
       storage: ${{ matrix.storage }}
 
   validate-prepare:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - validate-dco
     outputs:
@@ -106,7 +106,7 @@ jobs:
           echo ${{ steps.scripts.outputs.matrix }}
 
   validate:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     needs:
       - validate-prepare
@@ -144,7 +144,7 @@ jobs:
           make -o build validate-${{ matrix.script }}
 
   smoke-prepare:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - validate-dco
     outputs:
@@ -165,7 +165,7 @@ jobs:
           echo ${{ steps.platforms.outputs.matrix }}
 
   smoke:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - smoke-prepare
     strategy:

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   check-area-label:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Missing `area/` label
         if: contains(join(github.event.pull_request.labels.*.name, ','), 'impact/') && !contains(join(github.event.pull_request.labels.*.name, ','), 'area/')
@@ -27,7 +27,7 @@ jobs:
 
   check-changelog:
     if: contains(join(github.event.pull_request.labels.*.name, ','), 'impact/')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       PR_BODY: |
         ${{ github.event.pull_request.body }}
@@ -55,7 +55,7 @@ jobs:
           echo "$desc"
 
   check-pr-branch:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       PR_TITLE: ${{ github.event.pull_request.title }}
     steps:


### PR DESCRIPTION
Follow-up on [thread](https://github.com/moby/moby/pull/48311#discussion_r1709439522) regarding Ubuntu version in GitHub Actions.

**- What I did**
This change bumps the GitHub Actions runners to ubuntu-24.04 and pins a few occurrences of ubuntu-latest for build reproducibility.

**- How I did it**
Mostly just find+replace `ubuntu-20.04` and `ubuntu-latest` with `ubuntu-24.04`

**- How to verify it**
CI must be successful

**- Description for the changelog**
```markdown changelog
Update GitHub Actions runners to Ubuntu 24.04
```

**- Trade-offs**
Expect this to be changing (soon?) 24.04 is still marked beta. [[Reference](https://github.com/actions/runner-images/issues/9848)]

Alternatively considered upgrading runner images to 22.04 to prepare for 20.04 (upcoming?) deprecation.

**- A picture of a cute animal (not mandatory but encouraged)**

