### PR TITLE
IPv6 only: changes to bridge driver and gateway Endpoint selection

### DIFF
--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -2,9 +2,11 @@ package networking
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -14,10 +16,12 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/integration/internal/network"
+	n "github.com/docker/docker/integration/network"
 	"github.com/docker/docker/libnetwork/drivers/bridge"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
+	"github.com/docker/go-connections/nat"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -950,4 +954,149 @@ func TestContainerDisabledIPv6(t *testing.T) {
 	assert.Check(t, is.Equal(res.ExitCode, 1))
 	assert.Check(t, is.Equal(res.Stdout(), ""))
 	assert.Check(t, is.Contains(res.Stderr(), "bad address"))
+}
+
+type expProxyCfg struct {
+	proto      string
+	hostIP     string
+	hostPort   string
+	ctrName    string
+	ctrNetName string
+	ctrIPv4    bool
+	ctrPort    string
+}
+
+func TestGatewaySelection(t *testing.T) {
+	skip.If(t, testEnv.IsRootless, "proxies run in child namespace")
+
+	ctx := setupTest(t)
+	d := daemon.New(t, daemon.WithExperimental())
+	d.StartWithBusybox(ctx, t)
+	defer d.Stop(t)
+	c := d.NewClientT(t)
+	defer c.Close()
+
+	const netName4 = "net4"
+	network.CreateNoError(ctx, t, c, netName4)
+	defer network.RemoveNoError(ctx, t, c, netName4)
+
+	const netName6 = "net6"
+	netId6 := network.CreateNoError(ctx, t, c, netName6, network.WithIPv6(), network.WithIPv4(false))
+	defer network.RemoveNoError(ctx, t, c, netName6)
+
+	const netName46 = "net46"
+	netId46 := network.CreateNoError(ctx, t, c, netName46, network.WithIPv6())
+	defer network.RemoveNoError(ctx, t, c, netName46)
+
+	master := "dm-dummy0"
+	n.CreateMasterDummy(ctx, t, master)
+	defer n.DeleteInterface(ctx, t, master)
+	const netNameIpvlan6 = "ipvlan6"
+	netIdIpvlan6 := network.CreateNoError(ctx, t, c, netNameIpvlan6,
+		network.WithIPvlan("dm-dummy0", "l2"),
+		network.WithIPv4(false),
+		network.WithIPv6(),
+	)
+	defer network.RemoveNoError(ctx, t, c, netNameIpvlan6)
+
+	const ctrName = "ctr"
+	ctrId := container.Run(ctx, t, c,
+		container.WithName(ctrName),
+		container.WithNetworkMode(netName4),
+		container.WithExposedPorts("80"),
+		container.WithPortMap(nat.PortMap{"80": {{HostPort: "8080"}}}),
+		container.WithCmd("httpd", "-f"),
+	)
+	defer c.ContainerRemove(ctx, ctrId, containertypes.RemoveOptions{Force: true})
+
+	// The container only has an IPv4 endpoint, it should be the gateway, and
+	// the host-IPv6 should be proxied to container-IPv4.
+	checkProxies(ctx, t, c, d.Pid(), []expProxyCfg{
+		{"tcp", "0.0.0.0", "8080", ctrName, netName4, true, "80"},
+		{"tcp", "::", "8080", ctrName, netName4, true, "80"},
+	})
+
+	// Connect the IPv6-only network. The IPv6 endpoint should become the
+	// gateway for IPv6, the IPv4 endpoint should be reconfigured as the
+	// gateway for IPv4 only.
+	err := c.NetworkConnect(ctx, netId6, ctrId, nil)
+	assert.NilError(t, err)
+	checkProxies(ctx, t, c, d.Pid(), []expProxyCfg{
+		{"tcp", "0.0.0.0", "8080", ctrName, netName4, true, "80"},
+		{"tcp", "::", "8080", ctrName, netName6, false, "80"},
+	})
+
+	// Disconnect the IPv6-only network, the IPv4 should get back the mapping
+	// from host-IPv6.
+	err = c.NetworkDisconnect(ctx, netId6, ctrId, false)
+	assert.NilError(t, err)
+	checkProxies(ctx, t, c, d.Pid(), []expProxyCfg{
+		{"tcp", "0.0.0.0", "8080", ctrName, netName4, true, "80"},
+		{"tcp", "::", "8080", ctrName, netName4, true, "80"},
+	})
+
+	// Connect the dual-stack network, it should become the gateway for v6 and v4.
+	err = c.NetworkConnect(ctx, netId46, ctrId, nil)
+	assert.NilError(t, err)
+	checkProxies(ctx, t, c, d.Pid(), []expProxyCfg{
+		{"tcp", "0.0.0.0", "8080", ctrName, netName46, true, "80"},
+		{"tcp", "::", "8080", ctrName, netName46, false, "80"},
+	})
+
+	// Go back to the IPv4-only gateway, with proxy from host IPv6.
+	err = c.NetworkDisconnect(ctx, netId46, ctrId, false)
+	assert.NilError(t, err)
+	checkProxies(ctx, t, c, d.Pid(), []expProxyCfg{
+		{"tcp", "0.0.0.0", "8080", ctrName, netName4, true, "80"},
+		{"tcp", "::", "8080", ctrName, netName4, true, "80"},
+	})
+
+	// Connect the IPv6-only ipvlan network, its new Endpoint should become the IPv6
+	// gateway, so the IPv4-only bridge is expected to drop its mapping from host IPv6.
+	err = c.NetworkConnect(ctx, netIdIpvlan6, ctrId, nil)
+	assert.NilError(t, err)
+	checkProxies(ctx, t, c, d.Pid(), []expProxyCfg{
+		{"tcp", "0.0.0.0", "8080", ctrName, netName4, true, "80"},
+	})
+}
+
+func checkProxies(ctx context.Context, t *testing.T, c *client.Client, daemonPid int, exp []expProxyCfg) {
+	t.Helper()
+	makeExpStr := func(proto, hostIP, hostPort, ctrIP, ctrPort string) string {
+		return fmt.Sprintf("%s:%s/%s <-> %s:%s", hostIP, hostPort, proto, ctrIP, ctrPort)
+	}
+
+	wantProxies := make([]string, len(exp))
+	for _, e := range exp {
+		inspect := container.Inspect(ctx, t, c, e.ctrName)
+		nw := inspect.NetworkSettings.Networks[e.ctrNetName]
+		ctrIP := nw.GlobalIPv6Address
+		if e.ctrIPv4 {
+			ctrIP = nw.IPAddress
+		}
+		wantProxies = append(wantProxies, makeExpStr(e.proto, e.hostIP, e.hostPort, ctrIP, e.ctrPort))
+	}
+
+	gotProxies := make([]string, len(exp))
+	res, err := exec.Command("ps", "-f", "--ppid", strconv.Itoa(daemonPid)).CombinedOutput()
+	assert.NilError(t, err)
+	for _, line := range strings.Split(string(res), "\n") {
+		_, args, ok := strings.Cut(line, "docker-proxy")
+		if !ok {
+			continue
+		}
+		var proto, hostIP, hostPort, ctrIP, ctrPort string
+		var useListenFd bool
+		fs := flag.NewFlagSet("docker-proxy", flag.ContinueOnError)
+		fs.StringVar(&proto, "proto", "", "Protocol")
+		fs.StringVar(&hostIP, "host-ip", "", "Host IP")
+		fs.StringVar(&hostPort, "host-port", "", "Host Port")
+		fs.StringVar(&ctrIP, "container-ip", "", "Container IP")
+		fs.StringVar(&ctrPort, "container-port", "", "Container Port")
+		fs.BoolVar(&useListenFd, "use-listen-fd", false, "Use listen fd")
+		fs.Parse(strings.Split(strings.TrimSpace(args), " "))
+		gotProxies = append(gotProxies, makeExpStr(proto, hostIP, hostPort, ctrIP, ctrPort))
+	}
+
+	assert.DeepEqual(t, gotProxies, wantProxies)
 }

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -107,6 +107,7 @@ type containerConfiguration struct {
 type connectivityConfiguration struct {
 	PortBindings []types.PortBinding
 	ExposedPorts []types.TransportPort
+	NoProxy6To4  bool
 }
 
 type bridgeEndpoint struct {
@@ -1484,6 +1485,7 @@ func (d *driver) ProgramExternalConnectivity(ctx context.Context, nid, eid strin
 			endpoint.addrv6,
 			endpoint.extConnConfig.PortBindings,
 			network.config.DefaultBindingIP,
+			endpoint.extConnConfig.NoProxy6To4,
 		)
 		if err != nil {
 			return err
@@ -1682,6 +1684,14 @@ func parseConnectivityOptions(cOptions map[string]interface{}) (*connectivityCon
 			cc.ExposedPorts = ports
 		} else {
 			return nil, types.InvalidParameterErrorf("invalid exposed ports data in connectivity configuration: %v", opt)
+		}
+	}
+
+	if opt, ok := cOptions[netlabel.NoProxy6To4]; ok {
+		if noProxy6To4, ok := opt.(bool); ok {
+			cc.NoProxy6To4 = noProxy6To4
+		} else {
+			return nil, types.InvalidParameterErrorf("invalid "+netlabel.NoProxy6To4+" in connectivity configuration: %v", opt)
 		}
 	}
 

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -63,6 +63,7 @@ type configuration struct {
 type networkConfiguration struct {
 	ID                   string
 	BridgeName           string
+	EnableIPv4           bool
 	EnableIPv6           bool
 	EnableIPMasquerade   bool
 	GwModeIPv4           gwMode
@@ -235,8 +236,11 @@ func (c *networkConfiguration) Validate() error {
 		return ErrInvalidMtu(c.Mtu)
 	}
 
-	// If bridge v4 subnet is specified
-	if c.AddressIPv4 != nil {
+	if c.EnableIPv4 {
+		// If IPv4 is enabled, AddressIPv4 must have been configured.
+		if c.AddressIPv4 == nil {
+			return errdefs.System(errors.New("no IPv4 address was allocated for the bridge"))
+		}
 		// If default gw is specified, it must be part of bridge subnet
 		if c.DefaultGatewayIPv4 != nil {
 			if !c.AddressIPv4.Contains(c.DefaultGatewayIPv4) {
@@ -301,6 +305,10 @@ func (c *networkConfiguration) fromLabels(labels map[string]string) error {
 			c.BridgeName = value
 		case netlabel.DriverMTU:
 			if c.Mtu, err = strconv.Atoi(value); err != nil {
+				return parseErr(label, value, err.Error())
+			}
+		case netlabel.EnableIPv4:
+			if c.EnableIPv4, err = strconv.ParseBool(value); err != nil {
 				return parseErr(label, value, err.Error())
 			}
 		case netlabel.EnableIPv6:
@@ -638,16 +646,16 @@ func (c *networkConfiguration) processIPAM(id string, ipamV4Data, ipamV6Data []d
 		return types.ForbiddenErrorf("bridge driver doesn't support multiple subnets")
 	}
 
-	if len(ipamV4Data) == 0 {
-		return types.InvalidParameterErrorf("bridge network %s requires ipv4 configuration", id)
-	}
+	if len(ipamV4Data) > 0 {
+		c.AddressIPv4 = ipamV4Data[0].Pool
 
-	if ipamV4Data[0].Gateway != nil {
-		c.AddressIPv4 = types.GetIPNetCopy(ipamV4Data[0].Gateway)
-	}
+		if ipamV4Data[0].Gateway != nil {
+			c.AddressIPv4 = types.GetIPNetCopy(ipamV4Data[0].Gateway)
+		}
 
-	if gw, ok := ipamV4Data[0].AuxAddresses[DefaultGatewayV4AuxKey]; ok {
-		c.DefaultGatewayIPv4 = gw.IP
+		if gw, ok := ipamV4Data[0].AuxAddresses[DefaultGatewayV4AuxKey]; ok {
+			c.DefaultGatewayIPv4 = gw.IP
+		}
 	}
 
 	if len(ipamV6Data) > 0 {
@@ -679,6 +687,9 @@ func parseNetworkOptions(id string, option options.Generic) (*networkConfigurati
 	}
 
 	// Process well-known labels next
+	if val, ok := option[netlabel.EnableIPv4]; ok {
+		config.EnableIPv4 = val.(bool)
+	}
 	if val, ok := option[netlabel.EnableIPv6]; ok {
 		config.EnableIPv6 = val.(bool)
 	}
@@ -737,9 +748,6 @@ func (d *driver) DecodeTableEntry(tablename string, key string, value []byte) (s
 
 // Create a new network using bridge plugin
 func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
-	if len(ipV4Data) == 0 || ipV4Data[0].Pool.String() == "0.0.0.0/0" {
-		return types.InvalidParameterErrorf("ipv4 pool is empty")
-	}
 	// Sanity checks
 	d.Lock()
 	if _, ok := d.networks[id]; ok {
@@ -752,6 +760,16 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 	config, err := parseNetworkOptions(id, option)
 	if err != nil {
 		return err
+	}
+
+	if !config.EnableIPv4 && !config.EnableIPv6 {
+		return types.InvalidParameterErrorf("IPv4 or IPv6 must be enabled")
+	}
+	if config.EnableIPv4 && (len(ipV4Data) == 0 || ipV4Data[0].Pool.String() == "0.0.0.0/0") {
+		return types.InvalidParameterErrorf("ipv4 pool is empty")
+	}
+	if config.EnableIPv6 && (len(ipV6Data) == 0 || ipV6Data[0].Pool.String() == "::/0") {
+		return types.InvalidParameterErrorf("ipv6 pool is empty")
 	}
 
 	// Add IP addresses/gateways to the configuration.
@@ -871,9 +889,6 @@ func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 		bridgeSetup.queueStep(setupMTU)
 	}
 
-	// Even if a bridge exists try to setup IPv4.
-	bridgeSetup.queueStep(setupBridgeIPv4)
-
 	enableIPv6Forwarding := config.EnableIPv6 && d.config.EnableIPForwarding
 
 	// Module br_netfilter needs to be loaded with net.bridge.bridge-nf-call-ip[6]tables
@@ -885,6 +900,9 @@ func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 		Condition bool
 		Fn        setupStep
 	}{
+		// Even if a bridge exists try to setup IPv4.
+		{config.EnableIPv4, setupBridgeIPv4},
+
 		// Enable IPv6 on the bridge if required. We do this even for a
 		// previously  existing bridge, as it may be here from a previous
 		// installation where IPv6 wasn't supported yet and needs to be
@@ -893,7 +911,7 @@ func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 
 		// Ensure the bridge has the expected IPv4 addresses in the case of a previously
 		// existing device.
-		{bridgeAlreadyExists && !config.InhibitIPv4, setupVerifyAndReconcileIPv4},
+		{config.EnableIPv4 && bridgeAlreadyExists && !config.InhibitIPv4, setupVerifyAndReconcileIPv4},
 
 		// Enable IPv6 Forwarding
 		{enableIPv6Forwarding, setupIPv6Forwarding},
@@ -902,14 +920,14 @@ func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 		{!d.config.EnableUserlandProxy, setupLoopbackAddressesRouting},
 
 		// Setup IPTables.
-		{d.config.EnableIPTables, network.setupIP4Tables},
+		{config.EnableIPv4 && d.config.EnableIPTables, network.setupIP4Tables},
 
 		// Setup IP6Tables.
 		{config.EnableIPv6 && d.config.EnableIP6Tables, network.setupIP6Tables},
 
 		// We want to track firewalld configuration so that
 		// if it is started/reloaded, the rules can be applied correctly
-		{d.config.EnableIPTables, network.setupFirewalld},
+		{config.EnableIPv4 && d.config.EnableIPTables, network.setupFirewalld},
 		// same for IPv6
 		{config.EnableIPv6 && d.config.EnableIP6Tables, network.setupFirewalld6},
 
@@ -1181,7 +1199,13 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 	// that if a container is disconnected and reconnected in a short timeframe,
 	// stale ARP entries will still point to the right container.
 	if endpoint.macAddress == nil {
-		endpoint.macAddress = netutils.GenerateMACFromIP(endpoint.addr.IP)
+		if endpoint.addr != nil {
+			endpoint.macAddress = netutils.GenerateMACFromIP(endpoint.addr.IP)
+		} else {
+			// TODO(robmry) - generate unsolicited Neighbour Advertisement to
+			//  associate this MAC address with the IPv6 address.
+			endpoint.macAddress = netutils.GenerateRandomMAC()
+		}
 		if err := ifInfo.SetMacAddress(endpoint.macAddress); err != nil {
 			return err
 		}

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -1480,7 +1480,7 @@ func (d *driver) ProgramExternalConnectivity(ctx context.Context, nid, eid strin
 	// Program any required port mapping and store them in the endpoint
 	if endpoint.extConnConfig != nil && endpoint.extConnConfig.PortBindings != nil {
 		endpoint.portMapping, err = network.addPortMappings(
-			log.WithLogger(ctx, log.G(ctx).WithFields(log.Fields{"nid": nid, "eid": eid})),
+			ctx,
 			endpoint.addr,
 			endpoint.addrv6,
 			endpoint.extConnConfig.PortBindings,

--- a/libnetwork/drivers/bridge/bridge_store.go
+++ b/libnetwork/drivers/bridge/bridge_store.go
@@ -128,6 +128,7 @@ func (ncfg *networkConfiguration) MarshalJSON() ([]byte, error) {
 	nMap := make(map[string]interface{})
 	nMap["ID"] = ncfg.ID
 	nMap["BridgeName"] = ncfg.BridgeName
+	nMap["EnableIPv4"] = ncfg.EnableIPv4
 	nMap["EnableIPv6"] = ncfg.EnableIPv6
 	nMap["EnableIPMasquerade"] = ncfg.EnableIPMasquerade
 	nMap["GwModeIPv4"] = ncfg.GwModeIPv4
@@ -171,6 +172,8 @@ func (ncfg *networkConfiguration) UnmarshalJSON(b []byte) error {
 		if ncfg.AddressIPv4, err = types.ParseCIDR(v.(string)); err != nil {
 			return types.InternalErrorf("failed to decode bridge network address IPv4 after json unmarshal: %s", v.(string))
 		}
+		// For networks created before EnableIPv4 was added ...
+		ncfg.EnableIPv4 = true
 	}
 
 	if v, ok := nMap["AddressIPv6"]; ok {
@@ -197,6 +200,9 @@ func (ncfg *networkConfiguration) UnmarshalJSON(b []byte) error {
 	ncfg.DefaultGatewayIPv6 = net.ParseIP(nMap["DefaultGatewayIPv6"].(string))
 	ncfg.ID = nMap["ID"].(string)
 	ncfg.BridgeName = nMap["BridgeName"].(string)
+	if v, ok := nMap["EnableIPv4"]; ok {
+		ncfg.EnableIPv4 = v.(bool)
+	}
 	ncfg.EnableIPv6 = nMap["EnableIPv6"].(bool)
 	ncfg.EnableIPMasquerade = nMap["EnableIPMasquerade"].(bool)
 	if v, ok := nMap["GwModeIPv4"]; ok {
@@ -275,7 +281,9 @@ func (ep *bridgeEndpoint) MarshalJSON() ([]byte, error) {
 	epMap["nid"] = ep.nid
 	epMap["SrcName"] = ep.srcName
 	epMap["MacAddress"] = ep.macAddress.String()
-	epMap["Addr"] = ep.addr.String()
+	if ep.addr != nil {
+		epMap["Addr"] = ep.addr.String()
+	}
 	if ep.addrv6 != nil {
 		epMap["Addrv6"] = ep.addrv6.String()
 	}

--- a/libnetwork/drivers/bridge/bridge_store.go
+++ b/libnetwork/drivers/bridge/bridge_store.go
@@ -419,7 +419,7 @@ func (n *bridgeNetwork) restorePortAllocations(ep *bridgeEndpoint) {
 	}
 
 	var err error
-	ep.portMapping, err = n.addPortMappings(context.TODO(), ep.addr, ep.addrv6, cfg, n.config.DefaultBindingIP)
+	ep.portMapping, err = n.addPortMappings(context.TODO(), ep.addr, ep.addrv6, cfg, n.config.DefaultBindingIP, ep.extConnConfig.NoProxy6To4)
 	if err != nil {
 		log.G(context.TODO()).Warnf("Failed to reserve existing port mapping for endpoint %.7s:%v", ep.id, err)
 	}

--- a/libnetwork/drivers/bridge/network_linux_test.go
+++ b/libnetwork/drivers/bridge/network_linux_test.go
@@ -19,16 +19,17 @@ func TestLinkCreate(t *testing.T) {
 	}
 
 	mtu := 1490
-	config := &networkConfiguration{
-		BridgeName: DefaultBridgeName,
-		Mtu:        mtu,
-		EnableIPv6: true,
+	option := map[string]interface{}{
+		netlabel.GenericData: &networkConfiguration{
+			BridgeName: DefaultBridgeName,
+			EnableIPv4: true,
+			EnableIPv6: true,
+			Mtu:        mtu,
+		},
 	}
-	genericOption := make(map[string]interface{})
-	genericOption[netlabel.GenericData] = config
 
 	ipdList := getIPv4Data(t)
-	err := d.CreateNetwork("dummy", genericOption, nil, ipdList, getIPv6Data(t))
+	err := d.CreateNetwork("dummy", option, nil, ipdList, getIPv6Data(t))
 	if err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
@@ -113,15 +114,16 @@ func TestLinkCreateTwo(t *testing.T) {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
 
-	config := &networkConfiguration{
-		BridgeName: DefaultBridgeName,
-		EnableIPv6: true,
+	option := map[string]interface{}{
+		netlabel.GenericData: &networkConfiguration{
+			BridgeName: DefaultBridgeName,
+			EnableIPv4: true,
+			EnableIPv6: true,
+		},
 	}
-	genericOption := make(map[string]interface{})
-	genericOption[netlabel.GenericData] = config
 
 	ipdList := getIPv4Data(t)
-	err := d.CreateNetwork("dummy", genericOption, nil, ipdList, getIPv6Data(t))
+	err := d.CreateNetwork("dummy", option, nil, ipdList, getIPv6Data(t))
 	if err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
@@ -151,14 +153,15 @@ func TestLinkCreateNoEnableIPv6(t *testing.T) {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
 
-	config := &networkConfiguration{
-		BridgeName: DefaultBridgeName,
+	option := map[string]interface{}{
+		netlabel.GenericData: &networkConfiguration{
+			BridgeName: DefaultBridgeName,
+			EnableIPv4: true,
+		},
 	}
-	genericOption := make(map[string]interface{})
-	genericOption[netlabel.GenericData] = config
 
 	ipdList := getIPv4Data(t)
-	err := d.CreateNetwork("dummy", genericOption, nil, ipdList, getIPv6Data(t))
+	err := d.CreateNetwork("dummy", option, nil, ipdList, getIPv6Data(t))
 	if err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
@@ -186,15 +189,16 @@ func TestLinkDelete(t *testing.T) {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
 
-	config := &networkConfiguration{
-		BridgeName: DefaultBridgeName,
-		EnableIPv6: true,
+	option := map[string]interface{}{
+		netlabel.GenericData: &networkConfiguration{
+			BridgeName: DefaultBridgeName,
+			EnableIPv4: true,
+			EnableIPv6: true,
+		},
 	}
-	genericOption := make(map[string]interface{})
-	genericOption[netlabel.GenericData] = config
 
 	ipdList := getIPv4Data(t)
-	err := d.CreateNetwork("dummy", genericOption, nil, ipdList, getIPv6Data(t))
+	err := d.CreateNetwork("dummy", option, nil, ipdList, getIPv6Data(t))
 	if err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}

--- a/libnetwork/drivers/bridge/port_mapping_linux.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux.go
@@ -80,6 +80,7 @@ func (n *bridgeNetwork) addPortMappings(
 	epAddrV4, epAddrV6 *net.IPNet,
 	cfg []types.PortBinding,
 	defHostIP net.IP,
+	noProxy6To4 bool,
 ) (_ []portBinding, retErr error) {
 	if len(defHostIP) == 0 {
 		defHostIP = net.IPv4zero
@@ -132,7 +133,7 @@ func (n *bridgeNetwork) addPortMappings(
 		// by setting up the binding with the IPv4 interface if the userland proxy is enabled
 		// This change was added to keep backward compatibility
 		containerIP := containerIPv6
-		if containerIPv6 == nil {
+		if containerIPv6 == nil && !noProxy6To4 {
 			if proxyPath == "" {
 				// There's no way to map from host-IPv6 to container-IPv4 with the userland proxy
 				// disabled.

--- a/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -47,11 +47,12 @@ func TestPortMappingConfig(t *testing.T) {
 	sbOptions := make(map[string]interface{})
 	sbOptions[netlabel.PortMap] = portBindings
 
-	netConfig := &networkConfiguration{
-		BridgeName: DefaultBridgeName,
+	netOptions := map[string]interface{}{
+		netlabel.GenericData: &networkConfiguration{
+			BridgeName: DefaultBridgeName,
+			EnableIPv4: true,
+		},
 	}
-	netOptions := make(map[string]interface{})
-	netOptions[netlabel.GenericData] = netConfig
 
 	ipdList4 := getIPv4Data(t)
 	err := d.CreateNetwork("dummy", netOptions, nil, ipdList4, getIPv6Data(t))
@@ -810,6 +811,7 @@ func TestAddPortMappings(t *testing.T) {
 			n := &bridgeNetwork{
 				config: &networkConfiguration{
 					BridgeName: "dummybridge",
+					EnableIPv4: tc.epAddrV4 != nil,
 					EnableIPv6: tc.epAddrV6 != nil,
 					GwModeIPv4: tc.gwMode4,
 					GwModeIPv6: tc.gwMode6,

--- a/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -290,6 +290,7 @@ func TestAddPortMappings(t *testing.T) {
 		busyPortIPv4 int
 		rootless     bool
 		hostAddrs    []string
+		noProxy6To4  bool
 
 		expErr          string
 		expLogs         []string
@@ -451,6 +452,18 @@ func TestAddPortMappings(t *testing.T) {
 			expPBs: []types.PortBinding{
 				{Proto: types.TCP, IP: ctrIP4.IP, Port: 80, HostIP: net.IPv4zero, HostPort: firstEphemPort},
 				{Proto: types.TCP, IP: ctrIP4.IP, Port: 80, HostIP: net.IPv6zero, HostPort: firstEphemPort},
+			},
+		},
+		{
+			name:     "map to ipv4 container with proxy but noProxy6To4",
+			epAddrV4: ctrIP4,
+			cfg: []types.PortBinding{
+				{Proto: types.TCP, Port: 80},
+			},
+			proxyPath:   "/dummy/path/to/proxy",
+			noProxy6To4: true,
+			expPBs: []types.PortBinding{
+				{Proto: types.TCP, IP: ctrIP4.IP, Port: 80, HostIP: net.IPv4zero, HostPort: firstEphemPort},
 			},
 		},
 		{
@@ -854,7 +867,7 @@ func TestAddPortMappings(t *testing.T) {
 				}
 			})
 
-			pbs, err := n.addPortMappings(ctx, tc.epAddrV4, tc.epAddrV6, tc.cfg, tc.defHostIP)
+			pbs, err := n.addPortMappings(ctx, tc.epAddrV4, tc.epAddrV6, tc.cfg, tc.defHostIP, tc.noProxy6To4)
 			if tc.expErr != "" {
 				assert.ErrorContains(t, err, tc.expErr)
 				return

--- a/libnetwork/drivers/bridge/setup_verify_linux.go
+++ b/libnetwork/drivers/bridge/setup_verify_linux.go
@@ -11,7 +11,7 @@ import (
 // setupVerifyAndReconcileIPv4 checks what IPv4 addresses the given i interface has
 // and ensures that they match the passed network config.
 func setupVerifyAndReconcileIPv4(config *networkConfiguration, i *bridgeInterface) error {
-	// Fetch a slice of IPv4 addresses and a slice of IPv6 addresses from the bridge.
+	// Fetch a slice of IPv4 addresses from the bridge.
 	addrsv4, err := i.addresses(netlink.FAMILY_V4)
 	if err != nil {
 		return fmt.Errorf("Failed to verify ip addresses: %v", err)

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -557,8 +557,8 @@ func (ep *Endpoint) sbJoin(ctx context.Context, sb *Sandbox, options ...Endpoint
 		return err
 	}
 
-	// Current endpoint providing external connectivity for the sandbox
-	extEp := sb.getGatewayEndpoint()
+	// Current endpoint(s) providing external connectivity for the sandbox
+	gwepBefore4, gwepBefore6 := sb.getGatewayEndpoint()
 
 	sb.addEndpoint(ep)
 	defer func() {
@@ -606,36 +606,103 @@ func (ep *Endpoint) sbJoin(ctx context.Context, sb *Sandbox, options ...Endpoint
 		sb.resolver.SetForwardingPolicy(sb.hasExternalAccess())
 	}
 
-	currentExtEp := sb.getGatewayEndpoint()
-	moveExtConn := currentExtEp != extEp
-	if moveExtConn {
-		if extEp != nil {
-			log.G(ctx).Debugf("Revoking external connectivity on endpoint %s (%s)", extEp.Name(), extEp.ID())
-			extN, err := extEp.getNetworkFromStore()
-			if err != nil {
-				return fmt.Errorf("failed to get network from store for revoking external connectivity during join: %v", err)
+	gwepAfter4, gwepAfter6 := sb.getGatewayEndpoint()
+	if ep == gwepAfter4 || ep == gwepAfter6 {
+		// When the driver programs external connectivity for a Sandbox to use an
+		// IPv4-only Endpoint, it may choose to map ports from host IPv6 addresses (as
+		// well as host IPv4) to the Endpoint's IPv4 address. But, it must not do that if
+		// there is an IPv6-only Endpoint acting as the IPv6 gateway.
+		//
+		// So, for an IPv4-only Endpoint acting as a gateway, "noProxy6To4=true" must be
+		// set if the Sandbox has a different Endpoint acting as IPv6 gateway. And, if ep
+		// becoming the gateway changes noProxy6To4, the IPv4 gateway must be reset.
+		//
+		// This happens naturally in most cases. For example, if ep is dual-stack, sb had
+		// an IPv4-only gateway and no IPv6 gateway - connectivity will be revoked from
+		// the original IPv4-only gateway Endpoint and given to ep. So the old gateway
+		// won't be mapping from the host-IPv6 address.
+		//
+		// But, if ep is IPv6 only, an existing IPv4 only gateway may be proxying 6To4.
+		// So, its connectivity needs to be revoked and re-added with noProxy6To4 set.
+		// Similarly, when an IPv6-only gateway is disconnected from the Sandbox,
+		// gwepAfter6 will become nil and noProxy6To4 needs to be cleared in the
+		// configuration of an IPv4-only gateway.
+		//
+		// Note that revoking/restoring external connectivity will result in the bridge
+		// driver assigning new host ports for port mappings where the host port is not
+		// specified.
+		noProxy6To4Before := gwepBefore4 != nil && gwepBefore6 != nil && gwepBefore4 != gwepBefore6
+		noProxy6To4After := gwepAfter4 != nil && gwepAfter6 != nil && gwepAfter4 != gwepAfter6
+		restartGw4 := ep != gwepAfter4 && noProxy6To4Before != noProxy6To4After
+
+		// If ep is the new IPv4 gateway, remove the old IPv4 gateway.
+		if gwepBefore4 != nil && (ep == gwepAfter4 || restartGw4) {
+			role := "IPv4"
+			if gwepAfter6 == gwepAfter4 {
+				role = "dual-stack"
 			}
-			extD, err := extN.driver(true)
+			log.G(ctx).Debugf("Revoking %s external connectivity on endpoint %s (%s), NoProxy6To4:%v",
+				role, ep.Name(), ep.ID(), noProxy6To4Before)
+			undoFunc, err := gwepBefore4.revokeExternalConnectivity()
 			if err != nil {
-				return fmt.Errorf("failed to get driver for revoking external connectivity during join: %v", err)
+				return err
 			}
-			if err := extD.RevokeExternalConnectivity(extEp.network.ID(), extEp.ID()); err != nil {
-				return types.InternalErrorf(
-					"driver failed revoking external connectivity on endpoint %s (%s): %v",
-					extEp.Name(), extEp.ID(), err)
+			if restartGw4 {
+				// The IPv4 gateway hasn't changed, but its noProxy6To4 setting has. So,
+				// restore it as the gateway with that new setting.
+				log.G(ctx).Debugf("Programming IPv4 gateway endpoint %s (%s) NoProxy6To4:%v",
+					ep.Name(), ep.ID(), noProxy6To4After)
+				labelsAfter := sb.Labels()
+				labelsAfter[netlabel.NoProxy6To4] = noProxy6To4After
+				if err := undoFunc(ctx, labelsAfter); err != nil {
+					log.G(ctx).WithFields(log.Fields{
+						"endpointName": ep.Name(),
+						"endpointId":   ep.ID(),
+						"error":        err,
+					}).Warn("Failed to restore IPv4 connectivity")
+				}
+			} else {
+				defer func() {
+					if retErr != nil {
+						labelsBefore := sb.Labels()
+						labelsBefore[netlabel.NoProxy6To4] = noProxy6To4Before
+						if err := undoFunc(ctx, labelsBefore); err != nil {
+							log.G(ctx).WithFields(log.Fields{
+								"endpointName": ep.Name(),
+								"endpointId":   ep.ID(),
+								"role":         role,
+								"error":        err,
+							}).Warn("Failed to restore connectivity during rollback")
+						}
+					}
+				}()
+			}
+		}
+		// If ep is the new IPv6 gateway, there's an old IPv6 gateway to remove, and it
+		// wasn't also the IPv4 gateway (removed already) - remove the old gateway.
+		if ep == gwepAfter6 && gwepBefore6 != nil && gwepBefore6 != gwepBefore4 {
+			log.G(ctx).Debugf("Programming IPv6 gateway endpoint %s (%s)", ep.Name(), ep.ID())
+			undoFunc, err := gwepBefore6.revokeExternalConnectivity()
+			if err != nil {
+				return err
 			}
 			defer func() {
 				if retErr != nil {
-					if e := extD.ProgramExternalConnectivity(context.WithoutCancel(ctx), extEp.network.ID(), extEp.ID(), sb.Labels()); e != nil {
-						log.G(ctx).Warnf("Failed to roll-back external connectivity on endpoint %s (%s): %v",
-							extEp.Name(), extEp.ID(), e)
+					if err := undoFunc(ctx, sb.Labels()); err != nil {
+						log.G(ctx).WithFields(log.Fields{
+							"endpointName": ep.Name(),
+							"endpointId":   ep.ID(),
+							"error":        err,
+						}).Warn("Failed to restore IPv6 connectivity during rollback")
 					}
 				}
 			}()
 		}
 		if !n.internal {
 			log.G(ctx).Debugf("Programming external connectivity on endpoint %s (%s)", ep.Name(), ep.ID())
-			if err = d.ProgramExternalConnectivity(ctx, n.ID(), ep.ID(), sb.Labels()); err != nil {
+			labels := sb.Labels()
+			labels[netlabel.NoProxy6To4] = noProxy6To4After
+			if err := d.ProgramExternalConnectivity(ctx, n.ID(), ep.ID(), labels); err != nil {
 				return errdefs.System(fmt.Errorf(
 					"driver failed programming external connectivity on endpoint %s (%s): %v",
 					ep.Name(), ep.ID(), err))
@@ -651,6 +718,42 @@ func (ep *Endpoint) sbJoin(ctx context.Context, sb *Sandbox, options ...Endpoint
 	}
 
 	return nil
+}
+
+func (ep *Endpoint) programExternalConnectivity(ctx context.Context, labels map[string]interface{}) error {
+	log.G(ctx).Debugf("Programming external connectivity on endpoint %s (%s)", ep.Name(), ep.ID())
+	extN, err := ep.getNetworkFromStore()
+	if err != nil {
+		return types.InternalErrorf("failed to get network from store for programming external connectivity: %v", err)
+	}
+	extD, err := extN.driver(true)
+	if err != nil {
+		return types.InternalErrorf("failed to get driver for programming external connectivity: %v", err)
+	}
+	if err := extD.ProgramExternalConnectivity(context.WithoutCancel(ctx), ep.network.ID(), ep.ID(), labels); err != nil {
+		return types.InternalErrorf("driver failed programming external connectivity on endpoint %s (%s): %v",
+			ep.Name(), ep.ID(), err)
+	}
+	return nil
+}
+
+func (ep *Endpoint) revokeExternalConnectivity() (func(context.Context, map[string]interface{}) error, error) {
+	extN, err := ep.getNetworkFromStore()
+	if err != nil {
+		return nil, types.InternalErrorf("failed to get network from store for revoking external connectivity: %v", err)
+	}
+	extD, err := extN.driver(true)
+	if err != nil {
+		return nil, types.InternalErrorf("failed to get driver for revoking external connectivity: %v", err)
+	}
+	if err = extD.RevokeExternalConnectivity(ep.network.ID(), ep.ID()); err != nil {
+		return nil, types.InternalErrorf(
+			"driver failed revoking external connectivity on endpoint %s (%s): %v",
+			ep.Name(), ep.ID(), err)
+	}
+	return func(ctx context.Context, labels map[string]interface{}) error {
+		return extD.ProgramExternalConnectivity(context.WithoutCancel(ctx), ep.network.ID(), ep.ID(), labels)
+	}, nil
 }
 
 func (ep *Endpoint) rename(name string) error {
@@ -753,12 +856,13 @@ func (ep *Endpoint) sbLeave(ctx context.Context, sb *Sandbox, force bool) error 
 	ep.network = n
 	ep.mu.Unlock()
 
-	// Current endpoint providing external connectivity to the sandbox
-	extEp := sb.getGatewayEndpoint()
-	moveExtConn := extEp != nil && (extEp.ID() == ep.ID())
+	// Current endpoint(s) providing external connectivity to the sandbox
+	gwepBefore4, gwepBefore6 := sb.getGatewayEndpoint()
+	moveExtConn4 := gwepBefore4 != nil && gwepBefore4.ID() == ep.ID()
+	moveExtConn6 := gwepBefore6 != nil && gwepBefore6.ID() == ep.ID()
 
 	if d != nil {
-		if moveExtConn {
+		if moveExtConn4 || moveExtConn6 {
 			log.G(ctx).Debugf("Revoking external connectivity on endpoint %s (%s)", ep.Name(), ep.ID())
 			if err := d.RevokeExternalConnectivity(n.id, ep.id); err != nil {
 				log.G(ctx).Warnf("driver failed revoking external connectivity on endpoint %s (%s): %v",
@@ -808,21 +912,48 @@ func (ep *Endpoint) sbLeave(ctx context.Context, sb *Sandbox, force bool) error 
 		sb.resolver.SetForwardingPolicy(sb.hasExternalAccess())
 	}
 
-	// New endpoint providing external connectivity for the sandbox
-	extEp = sb.getGatewayEndpoint()
-	if moveExtConn && extEp != nil {
-		log.G(ctx).Debugf("Programming external connectivity on endpoint %s (%s)", extEp.Name(), extEp.ID())
-		extN, err := extEp.getNetworkFromStore()
-		if err != nil {
-			return fmt.Errorf("failed to get network from store for programming external connectivity during leave: %v", err)
+	// New endpoint(s) providing external connectivity for the sandbox
+	if moveExtConn4 || moveExtConn6 {
+		gwepAfter4, gwepAfter6 := sb.getGatewayEndpoint()
+		if gwepAfter4 != nil {
+			// If the IPv4 gateway hasn't changed, and there was no IPv6 gateway before but
+			// there is now, the driver for the IPv4 gateway must not proxy host-IPv6 to
+			// container-IPv4 (6To4). Conversely, if there was an IPv6 gateway before but
+			// there isn't one now, the driver must now be told it can proxy 6To4.
+			//
+			// Note that revoking/restoring external connectivity will result in the bridge
+			// driver assigning new host ports for port mappings where the host port is not
+			// specified.
+			restartGw4 := gwepBefore4 == gwepAfter4 && ((gwepBefore6 == nil) != (gwepAfter6 == nil))
+			noProxy6To4 := gwepAfter6 != nil && gwepAfter6 != gwepAfter4
+			labels := sb.Labels()
+			labels[netlabel.NoProxy6To4] = noProxy6To4
+			if restartGw4 {
+				log.G(ctx).Debugf("Resetting IPv4 endpoint %s (%s) NoProxy6To4:%v",
+					ep.Name(), ep.ID(), noProxy6To4)
+				if undoFunc, err := gwepBefore4.revokeExternalConnectivity(); err != nil {
+					log.G(ctx).WithError(err).Error("Failed to restart IPv4 gateway")
+				} else if err := undoFunc(ctx, labels); err != nil {
+					log.G(ctx).WithError(err).Error("Failed to restore IPv4 gateway")
+				}
+			} else if moveExtConn4 {
+				log.G(ctx).Debugf("Programming IPv6 gateway endpoint %s (%s)", ep.Name(), ep.ID())
+				if err := gwepAfter4.programExternalConnectivity(ctx, labels); err != nil {
+					role := "IPv4"
+					if gwepAfter6 == gwepAfter4 {
+						role = "dual-stack"
+					}
+					log.G(ctx).WithFields(log.Fields{
+						"role":  role,
+						"error": err,
+					}).Error("Failed to set gateway")
+				}
+			}
 		}
-		extD, err := extN.driver(true)
-		if err != nil {
-			return fmt.Errorf("failed to get driver for programming external connectivity during leave: %v", err)
-		}
-		if err := extD.ProgramExternalConnectivity(context.WithoutCancel(ctx), extEp.network.ID(), extEp.ID(), sb.Labels()); err != nil {
-			log.G(ctx).Warnf("driver failed programming external connectivity on endpoint %s: (%s) %v",
-				extEp.Name(), extEp.ID(), err)
+		if gwepAfter6 != nil && moveExtConn6 && gwepAfter6 != gwepAfter4 {
+			if err := gwepAfter6.programExternalConnectivity(ctx, sb.Labels()); err != nil {
+				log.G(ctx).WithError(err).Error("Failed to set IPv6 gateway")
+			}
 		}
 	}
 

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -379,16 +379,14 @@ func TestUpdateSvcRecord(t *testing.T) {
 				{Hosts: "id-ep4", IP: netip.MustParseAddr("172.16.0.2")},
 			},
 		},
-		/* TODO(robmry) - add this test when the bridge driver understands v6-only
 		{
 			name:   "v6only",
 			epName: "ep6",
 			addr6:  "fde6:045d:b2aa::2/64",
 			expSvcRecs: []etchosts.Record{
-				{Hosts: "id-ep6", IP: "fde6:45d:b2aa::2"},
+				{Hosts: "id-ep6", IP: netip.MustParseAddr("fde6:45d:b2aa::2")},
 			},
 		},
-		*/
 		{
 			name:   "dual-stack",
 			epName: "ep46",

--- a/libnetwork/netlabel/labels.go
+++ b/libnetwork/netlabel/labels.go
@@ -59,4 +59,9 @@ const (
 
 	// LocalKVClient constants represents the local kv store client
 	LocalKVClient = DriverPrivatePrefix + "localkv_client"
+
+	// NoProxy6To4 disables proxying from an IPv6 host port to an IPv4-only
+	// container, when the default binding address is 0.0.0.0. This label
+	// is intended for internal use, it may be removed in a future release.
+	NoProxy6To4 = DriverPrivatePrefix + ".no_proxy_6to4"
 )

--- a/libnetwork/network_windows.go
+++ b/libnetwork/network_windows.go
@@ -126,10 +126,7 @@ func addEpToResolverImpl(
 	// Find the resolver for that HNSEndpoint, matching on gateway address.
 	resolver := findResolver(resolvers, hnsEp.GatewayAddress, hnsEp.GatewayAddressV6)
 	if resolver == nil {
-		log.G(ctx).WithFields(log.Fields{
-			"network":  netName,
-			"endpoint": epName,
-		}).Debug("No internal DNS resolver to configure")
+		log.G(ctx).Debug("No internal DNS resolver to configure")
 		return nil
 	}
 
@@ -150,10 +147,7 @@ func addEpToResolverImpl(
 		}
 	}
 	if !foundSelf {
-		log.G(ctx).WithFields(log.Fields{
-			"network":  netName,
-			"endpoint": epName,
-		}).Debug("Endpoint is not configured to use internal DNS resolver")
+		log.G(ctx).Debug("Endpoint is not configured to use internal DNS resolver")
 		return nil
 	}
 

--- a/libnetwork/sandbox_windows.go
+++ b/libnetwork/sandbox_windows.go
@@ -8,7 +8,7 @@ import (
 
 func releaseOSSboxResources(*osl.Namespace, *Endpoint) {}
 
-func (sb *Sandbox) updateGateway(*Endpoint) error {
+func (sb *Sandbox) updateGateway(_, _ *Endpoint) error {
 	// not implemented on Windows (Sandbox.osSbox is always nil)
 	return nil
 }

--- a/libnetwork/service_linux.go
+++ b/libnetwork/service_linux.go
@@ -122,7 +122,7 @@ func (n *Network) addLBBackend(ip net.IP, lb *loadBalancer) {
 
 		if sb.ingress {
 			var gwIP net.IP
-			if ep := sb.getGatewayEndpoint(); ep != nil {
+			if ep, _ := sb.getGatewayEndpoint(); ep != nil {
 				gwIP = ep.Iface().Address().IP
 			}
 			if err := programIngress(gwIP, lb.service.ingressPorts, false); err != nil {
@@ -223,7 +223,7 @@ func (n *Network) rmLBBackend(ip net.IP, lb *loadBalancer, rmService bool, fullR
 
 		if sb.ingress {
 			var gwIP net.IP
-			if gwEP := sb.getGatewayEndpoint(); gwEP != nil {
+			if gwEP, _ := sb.getGatewayEndpoint(); gwEP != nil {
 				gwIP = gwEP.Iface().Address().IP
 			}
 			if err := programIngress(gwIP, lb.service.ingressPorts, true); err != nil {


### PR DESCRIPTION
**- What I did**

- Added `EnableIPv4` to the bridge driver.
- Gave libnetwork control over the bridge's use of docker-proxy to proxy from IPv6 host addresses to IPv4-only containers.
  - (See the notes below.)
- Separated selection of IPv4 and IPv6 gateway Endpoints.
  - When a container's connected to an IPv4-only network and an IPv6-only network, it needs different gateways for each address family.

**- How I did it**

_**Notes on gateway endpoints ...**_

A gateway endpoint gets the default route and, for the bridge driver, port mappings from the host.

Before this change, a dual-stack endpoint was preferred over an IPv4-only endpoint - if there was an IPv6 endpoint, it was always dual-stack. So, there was no way for the IPv4 and IPv6 gateway endpoints to be different.

Now, a container with IPv4-only and IPv6-only endpoints needs two separate gateways. This is further complicated by the bridge driver's use of docker-proxy to map from host IPv6 addresses to an IPv4-only container, when the host address is unspecified in a port mapping.

If an IPv6 Endpoint is added to a Sandbox that only has an IPv4 endpoint, proxying from the host IPv6 address has to stop (so, the IPv4 gateway hasn't changed, but the driver still needs to be reconfigured). And vice-versa, if an IPv6-only endpoint is removed, leaving only IPv4-only endpoints, the host IPv6 proxy needs to be added.

Note that the new IPv6 endpoint may not belong to a bridge network, the bridge driver doesn't have the information it needs to deal with that ... proxying host-IPv6 to container-IPv4 is policy that needs to be handled by libnetwork. So, there's a new (private) driver option `netlabel.NoProxy6To4` that can be passed to the driver's ProgramExternalConnectivity. Its value is calculated by libnetwork when an endpoint is added or removed, true if the IPv4 and IPv6 gateways are different. When its value changes, the IPv4 gateway is removed by RevokeExternalConnectivity, then re-added. So, ongoing connections will be interrupted and, if host ports are not specified in a port mapping, they'll change when the mapping is re-created.

Before this change, when adding a dual-stack macvlan/ipvlan endpoint to a Sandbox that only has IPv4 endpoints, the dual-stack endpoint became the gateway. So, if the existing gateway was an IPv4-only bridge endpoint with port mappings from the host, those port mappings would be removed. With this change, that behaviour is preserved - and the same logic applies when an IPv6-only macvlan/ipvlan is added to a Sandbox with a bridge IPv4-only endpoint; port mappings from host-IPv6 are removed.

_We could offer better control over the way gateway endpoints are selected, default routes, what happens when networks are added/removed, and host port mappings. We could extend the driver interface to add a way to change gateway settings. But, I've treated all that as out-of-scope here._

**- How to verify it**

New and updated tests.

**- Description for the changelog**
```markdown changelog

```

