### PR TITLE
distribution: Set default compression to zstd/fastest

### DIFF
--- a/distribution/push.go
+++ b/distribution/push.go
@@ -2,7 +2,6 @@ package distribution // import "github.com/docker/docker/distribution"
 
 import (
 	"bufio"
-	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -11,6 +10,7 @@ import (
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/pkg/progress"
+	"github.com/klauspost/compress/zstd"
 )
 
 const compressionBufSize = 32768
@@ -107,7 +107,11 @@ func compress(in io.Reader) (io.ReadCloser, chan struct{}) {
 	pipeReader, pipeWriter := io.Pipe()
 	// Use a bufio.Writer to avoid excessive chunking in HTTP request.
 	bufWriter := bufio.NewWriterSize(pipeWriter, compressionBufSize)
-	compressor := gzip.NewWriter(bufWriter)
+	compressor, err := zstd.NewWriter(bufWriter, zstd.WithEncoderLevel(1))
+	if err != nil {
+		pipeWriter.CloseWithError(err)
+		close(compressionDone)
+	}
 
 	go func() {
 		_, err := io.Copy(compressor, in)


### PR DESCRIPTION
gzip compression is notoriously slow. The compression on skylake happens at 7MiB/s. The push rate is not sustainable for large multi-gigabyte images.

zstd/fastest runs at 81 MiB/s for the same image. That gives tenfold push speedup with default flags.

Resolves: #1266
See also: #48106

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
**- How to verify it**
Use `docker push` with built-in `docker` buildkit driver
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
distribution: change default compression of docker push to zstd/fastest
```
