### PR TITLE
c8d/list: Don't require `opts.ContainerCount` for manifest containers

### DIFF
--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -353,14 +353,12 @@ func (i *ImageService) imageSummary(ctx context.Context, img images.Image, platf
 
 		allChainsIDs = append(allChainsIDs, chainIDs...)
 
-		if opts.ContainerCount {
-			i.containers.ApplyAll(func(c *container.Container) {
-				if c.ImageManifest != nil && c.ImageManifest.Digest == target.Digest {
-					mfstSummary.ImageData.Containers = append(mfstSummary.ImageData.Containers, c.ID)
-					containersCount++
-				}
-			})
-		}
+		i.containers.ApplyAll(func(c *container.Container) {
+			if c.ImageManifest != nil && c.ImageManifest.Digest == target.Digest {
+				mfstSummary.ImageData.Containers = append(mfstSummary.ImageData.Containers, c.ID)
+				containersCount++
+			}
+		})
 
 		platform := mfstSummary.ImageData.Platform
 		// Filter out platforms that don't match the requested platform.  Do it


### PR DESCRIPTION
- follow up to: https://github.com/moby/moby/pull/47526
- related to: https://github.com/moby/moby/pull/47501
- closes: https://github.com/moby/moby/pull/47501

The `GET /images/json` requires an optional `container-count` parameter which set the `Containers` property of in the ImageSummary to a number of containers using that image.

This was also propagated to the new manifest list property which includes a list of all the container IDs that are using this specific image manifest.

Disconnect the `ImageData.Containers` property from this option and always include it by default without an explicit opt-in.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
https://github.com/moby/moby/pull/47526 wasn't released yet so no changelog needed.

**- A picture of a cute animal (not mandatory but encouraged)**

