### PR TITLE
libcontainerd/supervisor: consolidate platform-specific defaults

### DIFF
--- a/libcontainerd/supervisor/remote_daemon_linux.go
+++ b/libcontainerd/supervisor/remote_daemon_linux.go
@@ -6,7 +6,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/containerd/containerd/defaults"
 	"github.com/docker/docker/pkg/process"
 )
 
@@ -15,19 +14,12 @@ const (
 	debugSockFile = "containerd-debug.sock"
 )
 
-func (r *remote) setDefaults() {
-	if r.GRPC.Address == "" {
-		r.GRPC.Address = filepath.Join(r.stateDir, sockFile)
-	}
-	if r.GRPC.MaxRecvMsgSize == 0 {
-		r.GRPC.MaxRecvMsgSize = defaults.DefaultMaxRecvMsgSize
-	}
-	if r.GRPC.MaxSendMsgSize == 0 {
-		r.GRPC.MaxSendMsgSize = defaults.DefaultMaxSendMsgSize
-	}
-	if r.Debug.Address == "" {
-		r.Debug.Address = filepath.Join(r.stateDir, debugSockFile)
-	}
+func defaultGRPCAddress(stateDir string) string {
+	return filepath.Join(stateDir, sockFile)
+}
+
+func defaultDebugAddress(stateDir string) string {
+	return filepath.Join(stateDir, debugSockFile)
 }
 
 func (r *remote) stopDaemon() {

--- a/libcontainerd/supervisor/remote_daemon_windows.go
+++ b/libcontainerd/supervisor/remote_daemon_windows.go
@@ -11,13 +11,12 @@ const (
 	debugPipeName = `\\.\pipe\containerd-debug`
 )
 
-func (r *remote) setDefaults() {
-	if r.GRPC.Address == "" {
-		r.GRPC.Address = grpcPipeName
-	}
-	if r.Debug.Address == "" {
-		r.Debug.Address = debugPipeName
-	}
+func defaultGRPCAddress(stateDir string) string {
+	return grpcPipeName
+}
+
+func defaultDebugAddress(stateDir string) string {
+	return debugPipeName
 }
 
 func (r *remote) stopDaemon() {


### PR DESCRIPTION
- taken from https://github.com/moby/moby/pull/48250


Commit a0009345f51d7a58a2f188d7ffc7e0e837a5238d updated the default MaxRecvMsgSize and MaxSendMsgSize for Linux, but did not modify the defaults for Windows. Those options should not be platform-specific, which means that the only difference between the Linux and Windows config are the addresses for GRPC and Debug (Windows defaulting to a named pipe, whereas Linux sockets within exec-root).

This patch

- implements functions to return the default addresses for each platform
- moves the defaults into `supervisor.Start()`
- removes the now redundant `remote.setDefaults()` method

It's worth noting that prior to this path, `remove.setDefaults()` would be applied _after_ any (custom) `DaemonOpt` was applied. However, none of the existing `DaemonOpt` options currently mutates these options. `remote` is also a non-exported type, so no external implementations can currently be created. It is therefore safe to set these defaults before options are applied.

