### PR TITLE
libcontainerd/supervisor: set log-level through the config-file

### DIFF
--- a/libcontainerd/supervisor/remote_daemon.go
+++ b/libcontainerd/supervisor/remote_daemon.go
@@ -47,10 +47,6 @@ type remote struct {
 	daemonWaitCh  chan struct{}
 	daemonStartCh chan error
 	daemonStopCh  chan struct{}
-
-	// logLevel overrides the containerd logging-level through the --log-level
-	// command-line option.
-	logLevel string
 }
 
 // Daemon represents a running containerd daemon
@@ -159,13 +155,8 @@ func (r *remote) startContainerd() error {
 	if err != nil {
 		return err
 	}
-	args := []string{"--config", cfgFile}
 
-	if r.logLevel != "" {
-		args = append(args, "--log-level", r.logLevel)
-	}
-
-	cmd := exec.Command(binaryName, args...)
+	cmd := exec.Command(binaryName, "--config", cfgFile)
 	// redirect containerd logs to docker logs
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/libcontainerd/supervisor/remote_daemon_options.go
+++ b/libcontainerd/supervisor/remote_daemon_options.go
@@ -12,7 +12,7 @@ func WithLogLevel(lvl string) DaemonOpt {
 			// so don't pass the default.
 			lvl = ""
 		}
-		r.logLevel = lvl
+		r.Config.Debug.Level = lvl
 		return nil
 	}
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/43945
- extracted from https://github.com/moby/moby/pull/48250

The config.logLevel field, when set, is used to set the `--log-level` flag when starting the managed `containerd` binary. This flag is the equivalent to setting the `Config.Debug.Level` field, as can be seen in the [`md/containerd/command.setLogLevel()`][1] function.

As we're already producing a generated containerd configuration file, and this file already includes `Debug` options, we might as well include the option in that file, instead of using the `--log-level` flag.

For entertainment of whoever reads this commit-message, it's worth noting that previously we were writing this option to the config-file, and yours truly removed that part in b6b0b0a05fe51c50e63d0149e6d070fbb3e0af8d, but to my defence, we were _also_ setting the `--log-level` flag at the time :)

[1]: https://github.com/containerd/containerd/blob/v1.7.20/cmd/containerd/command/main.go#L348-L357

