### PR TITLE
runc: `git bisect start v1.2.0-rc.2 v1.1.0` (manually)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -287,7 +287,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged. When updating RUNC_VERSION,
 # consider updating runc in vendor.mod accordingly.
-ARG RUNC_VERSION=f8ad20f500bf75edd86041657ee762bce116f8f5
+ARG RUNC_VERSION=321aa20c49568ea2e2a3f708a50ccffb1bd67c79
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -287,7 +287,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged. When updating RUNC_VERSION,
 # consider updating runc in vendor.mod accordingly.
-ARG RUNC_VERSION=823636c3ddd07241e586e44ea5e6fa9c0546b34b
+ARG RUNC_VERSION=ab146f23357d867f3ed9a15c4e15507f78eba3b2
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -287,7 +287,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged. When updating RUNC_VERSION,
 # consider updating runc in vendor.mod accordingly.
-ARG RUNC_VERSION=1950892f69597aa844cbf000fbdf77610dda3a44
+ARG RUNC_VERSION=823636c3ddd07241e586e44ea5e6fa9c0546b34b
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build
@@ -309,9 +309,7 @@ RUN --mount=from=runc-src,src=/usr/src/runc,rw \
   export CC=$(xx-info)-gcc
   export STRIP=$(xx-info)-strip
   xx-go --wrap
-  CGO_ENABLED=1 make "$([ "$DOCKER_STATIC" = "1" ] && echo "static" || echo "runc")"
-  # Only verify runc-dmz, no need to copy (already embedded into runc). Must always be static.
-  xx-verify --static libcontainer/dmz/binary/runc-dmz
+  CGO_ENABLED=1 EXTRA_BUILDTAGS="runc_nodmz" make "$([ "$DOCKER_STATIC" = "1" ] && echo "static" || echo "runc")"
   xx-verify $([ "$DOCKER_STATIC" = "1" ] && echo "--static") runc
   mkdir /build
   mv runc /build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -287,7 +287,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged. When updating RUNC_VERSION,
 # consider updating runc in vendor.mod accordingly.
-ARG RUNC_VERSION=8454bbb6132e972a1fc8d34598ef84712208858d
+ARG RUNC_VERSION=ee73091a8d28692fa4868bac81aa40a0b05f9780
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -287,7 +287,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged. When updating RUNC_VERSION,
 # consider updating runc in vendor.mod accordingly.
-ARG RUNC_VERSION=7c004d8e058ac385aa32cc35e0f872ea0302c071
+ARG RUNC_VERSION=4baaf18cfd85bc6e91219e3fa3af75aa0a1e4794
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -287,7 +287,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged. When updating RUNC_VERSION,
 # consider updating runc in vendor.mod accordingly.
-ARG RUNC_VERSION=321aa20c49568ea2e2a3f708a50ccffb1bd67c79
+ARG RUNC_VERSION=1950892f69597aa844cbf000fbdf77610dda3a44
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build
@@ -305,8 +305,13 @@ ARG DOCKER_STATIC
 RUN --mount=from=runc-src,src=/usr/src/runc,rw \
     --mount=type=cache,target=/root/.cache/go-build,id=runc-build-$TARGETPLATFORM <<EOT
   set -e
+  # Need CC and STRIP set to build runc-dmz.
+  export CC=$(xx-info)-gcc
+  export STRIP=$(xx-info)-strip
   xx-go --wrap
   CGO_ENABLED=1 make "$([ "$DOCKER_STATIC" = "1" ] && echo "static" || echo "runc")"
+  # Only verify runc-dmz, no need to copy (already embedded into runc). Must always be static.
+  xx-verify --static libcontainer/dmz/binary/runc-dmz
   xx-verify $([ "$DOCKER_STATIC" = "1" ] && echo "--static") runc
   mkdir /build
   mv runc /build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -287,7 +287,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged. When updating RUNC_VERSION,
 # consider updating runc in vendor.mod accordingly.
-ARG RUNC_VERSION=ab146f23357d867f3ed9a15c4e15507f78eba3b2
+ARG RUNC_VERSION=7c004d8e058ac385aa32cc35e0f872ea0302c071
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -287,7 +287,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged. When updating RUNC_VERSION,
 # consider updating runc in vendor.mod accordingly.
-ARG RUNC_VERSION=4baaf18cfd85bc6e91219e3fa3af75aa0a1e4794
+ARG RUNC_VERSION=8454bbb6132e972a1fc8d34598ef84712208858d
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -287,7 +287,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged. When updating RUNC_VERSION,
 # consider updating runc in vendor.mod accordingly.
-ARG RUNC_VERSION=v1.1.13
+ARG RUNC_VERSION=f8ad20f500bf75edd86041657ee762bce116f8f5
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -287,7 +287,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged. When updating RUNC_VERSION,
 # consider updating runc in vendor.mod accordingly.
-ARG RUNC_VERSION=ee73091a8d28692fa4868bac81aa40a0b05f9780
+ARG RUNC_VERSION=f2f16213e174fb63e931fe0546bbbad1d9bbed6f
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -287,7 +287,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged. When updating RUNC_VERSION,
 # consider updating runc in vendor.mod accordingly.
-ARG RUNC_VERSION=f2f16213e174fb63e931fe0546bbbad1d9bbed6f
+ARG RUNC_VERSION=8e1cd2f56d518f8d6292b8bb39f0d0932e4b6c2a
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=f8ad20f500bf75edd86041657ee762bce116f8f5}"
+: "${RUNC_VERSION:=321aa20c49568ea2e2a3f708a50ccffb1bd67c79}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=v1.1.13}"
+: "${RUNC_VERSION:=f8ad20f500bf75edd86041657ee762bce116f8f5}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=f2f16213e174fb63e931fe0546bbbad1d9bbed6f}"
+: "${RUNC_VERSION:=8e1cd2f56d518f8d6292b8bb39f0d0932e4b6c2a}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"runc_nodmz"}"

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=7c004d8e058ac385aa32cc35e0f872ea0302c071}"
+: "${RUNC_VERSION:=4baaf18cfd85bc6e91219e3fa3af75aa0a1e4794}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"runc_nodmz"}"

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,12 +9,12 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=321aa20c49568ea2e2a3f708a50ccffb1bd67c79}"
+: "${RUNC_VERSION:=1950892f69597aa844cbf000fbdf77610dda3a44}"
 
 install_runc() {
-	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"
+	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-""}"
 
-	echo "Install runc version $RUNC_VERSION (build tags: $RUNC_BUILDTAGS)"
+	echo "Install runc version $RUNC_VERSION (extra build tags: $RUNC_BUILDTAGS)"
 	git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc"
 	cd "$GOPATH/src/github.com/opencontainers/runc"
 	git checkout -q "$RUNC_VERSION"
@@ -23,7 +23,7 @@ install_runc() {
 	else
 		target="$1"
 	fi
-	make BUILDTAGS="$RUNC_BUILDTAGS" "$target"
+	make EXTRA_BUILDTAGS="$RUNC_BUILDTAGS" "$target"
 	mkdir -p "${PREFIX}"
 	cp runc "${PREFIX}/runc"
 }

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=823636c3ddd07241e586e44ea5e6fa9c0546b34b}"
+: "${RUNC_VERSION:=ab146f23357d867f3ed9a15c4e15507f78eba3b2}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"runc_nodmz"}"

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=ee73091a8d28692fa4868bac81aa40a0b05f9780}"
+: "${RUNC_VERSION:=f2f16213e174fb63e931fe0546bbbad1d9bbed6f}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"runc_nodmz"}"

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,10 +9,10 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=1950892f69597aa844cbf000fbdf77610dda3a44}"
+: "${RUNC_VERSION:=823636c3ddd07241e586e44ea5e6fa9c0546b34b}"
 
 install_runc() {
-	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-""}"
+	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"runc_nodmz"}"
 
 	echo "Install runc version $RUNC_VERSION (extra build tags: $RUNC_BUILDTAGS)"
 	git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc"

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=4baaf18cfd85bc6e91219e3fa3af75aa0a1e4794}"
+: "${RUNC_VERSION:=8454bbb6132e972a1fc8d34598ef84712208858d}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"runc_nodmz"}"

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=8454bbb6132e972a1fc8d34598ef84712208858d}"
+: "${RUNC_VERSION:=ee73091a8d28692fa4868bac81aa40a0b05f9780}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"runc_nodmz"}"

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=ab146f23357d867f3ed9a15c4e15507f78eba3b2}"
+: "${RUNC_VERSION:=7c004d8e058ac385aa32cc35e0f872ea0302c071}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"runc_nodmz"}"


### PR DESCRIPTION
Trying to find out the regression commit that is causing the compatibility issue of runc v1.2 RC.

Related:
- https://github.com/moby/moby/pull/47666 (thaJeztah)
- https://github.com/moby/moby/pull/48160 (kolyshkin)
- https://github.com/moby/moby/pull/48336 (rata)

>  Full(er) list of test failures:
> 
> - TestBuildUserNamespaceValidateCapabilitiesAreV2
> - TestNetworkNat
> - TestNetworkLocalhostTCPNat
> - TestBuildSquashParent
> - TestDiff
> - TestUsernsCommit
> - TestReadPluginNoRead/explicitly_enabled_caching
> 
> Most failures are related to not getting output from a container run. As I can't repro this locally I'm not sure how to bisect it.

_Originally posted by @kolyshkin in https://github.com/moby/moby/issues/48160#issuecomment-2237801422_
            

- - -

- 🔴 v1.2.0-rc.2
- 🔴 v1.1.0-974-g1950892f (The (merge) commit to disable dmz by default, although it still compiles dmz by default)
- 🔴 v1.1.0-941-g7c004d8e w/ `runc_nodmz`
- 🔴  v1.1.0-931-gee73091a w/ `runc_nodmz`
- 🔴  v1.1.0-929-gf2f16213 w/ `runc_nodmz` 🔥 causing stdio regression
- ⚪  v1.1.0-928-g8e1cd2f5 w/ `runc_nodmz` (failures are similar to v1.1.0-753-g321aa20c)
- ⚪  v1.1.0-924-g4baaf18c w/ `runc_nodmz` (failures are similar to v1.1.0-753-g321aa20c)
- ⚪  v1.1.0-909-gab146f23 w/ `runc_nodmz` (failures are similar to v1.1.0-753-g321aa20c)
- ⚪ v1.1.0-843-g823636c3 w/ `runc_nodmz` (failures are similar to v1.1.0-753-g321aa20c)
- ⚪ v1.1.0-753-g321aa20c (the last commit before the introduction of dmz; failures are different from OP https://github.com/moby/moby/pull/48366#issuecomment-2307333117)
- 🟢 v1.1.0-562-gf8ad20f5
- 🟢 v1.1.0

(🟢=Good, 🟡=Pending, 🔴=Bad for the same reason as @kolyshkin reported, ⚪=CI fails due to another reason)