### PR TITLE
[27.x backport] c8d/list: Fix race condition when traversing containers

### DIFF
--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -21,7 +21,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	imagetypes "github.com/docker/docker/api/types/image"
 	timetypes "github.com/docker/docker/api/types/time"
-	"github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
 	"github.com/moby/buildkit/util/attestation"
 	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
@@ -365,12 +364,12 @@ func (i *ImageService) imageSummary(ctx context.Context, img images.Image, platf
 
 		allChainsIDs = append(allChainsIDs, chainIDs...)
 
-		i.containers.ApplyAll(func(c *container.Container) {
+		for _, c := range i.containers.List() {
 			if c.ImageManifest != nil && c.ImageManifest.Digest == target.Digest {
 				mfstSummary.ImageData.Containers = append(mfstSummary.ImageData.Containers, c.ID)
 				containersCount++
 			}
-		})
+		}
 
 		platform := mfstSummary.ImageData.Platform
 		// Filter out platforms that don't match the requested platform.  Do it

--- a/integration/image/list_test.go
+++ b/integration/image/list_test.go
@@ -255,6 +255,12 @@ func TestAPIImagesListManifests(t *testing.T) {
 		return idx, err
 	})
 
+	containerPlatform := testPlatforms[1]
+
+	cid := container.Create(ctx, t, apiClient,
+		container.WithImage("multiplatform:latest"),
+		container.WithPlatform(&containerPlatform))
+
 	t.Run("unsupported before 1.47", func(t *testing.T) {
 		// TODO: Remove when MinSupportedAPIVersion >= 1.47
 		c := d.NewClientT(t, client.WithVersion(api.MinSupportedAPIVersion))
@@ -298,6 +304,13 @@ func TestAPIImagesListManifests(t *testing.T) {
 				op := mfst.ImageData.Platform
 				return p.OS == op.OS && p.Architecture == op.Architecture && p.Variant == op.Variant
 			})
+		}
+
+		if mfst.ImageData.Platform.OS == containerPlatform.OS &&
+			mfst.ImageData.Platform.Architecture == containerPlatform.Architecture &&
+			mfst.ImageData.Platform.Variant == containerPlatform.Variant {
+
+			assert.Check(t, is.DeepEqual(mfst.ImageData.Containers, []string{cid}))
 		}
 	}
 }


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/48367

**- What I did**
Fix a panic spotted in https://github.com/moby/moby/pull/47983#issuecomment-2306706264.

Shared state is mutated inside a function which is called asynchronously:
https://github.com/moby/moby/blob/4f0d95fa6ee7f865597c03b9e63702cdcb0f7067/container/memory_store.go#L69-L83

Unfortunately, it looks like the race detector doesn't pick this up for some reason.

**- How I did it**


**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

