### PR TITLE
c8d/pull: Keep the replaced image as dangling

### DIFF
--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/pkg/snapshotters"
 	"github.com/containerd/containerd/remotes/docker"
 	cerrdefs "github.com/containerd/errdefs"
@@ -79,10 +80,43 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 	resolver, _ := i.newResolverFromAuthConfig(ctx, authConfig, ref)
 	opts = append(opts, containerd.WithResolver(resolver))
 
-	old, err := i.resolveDescriptor(ctx, ref.String())
+	oldImage, err := i.resolveImage(ctx, ref.String())
 	if err != nil && !errdefs.IsNotFound(err) {
 		return err
 	}
+
+	// Will be set to the new image after pull succeeds.
+	var outNewImg *containerd.Image
+
+	if oldImage.Target.Digest != "" {
+		// Lease the old image content to prevent it from being garbage collected until we keep it as dangling image.
+		lm := i.client.LeasesService()
+		lease, err := lm.Create(ctx, leases.WithRandomID())
+		if err != nil {
+			return errdefs.System(fmt.Errorf("failed to create lease: %w", err))
+		}
+
+		err = leaseContent(ctx, i.content, lm, lease, oldImage.Target)
+		if err != nil {
+			return errdefs.System(fmt.Errorf("failed to lease content: %w", err))
+		}
+
+		// If the pulled image is different than the old image, we will keep the old image as a dangling image.
+		defer func() {
+			if outNewImg != nil {
+				img := *outNewImg
+				if img.Target().Digest != oldImage.Target.Digest {
+					if err := i.ensureDanglingImage(ctx, oldImage); err != nil {
+						log.G(ctx).WithError(err).Warn("failed to keep the previous image as dangling")
+					}
+				}
+			}
+			if err := lm.Delete(ctx, lease); err != nil {
+				log.G(ctx).WithError(err).Warn("failed to delete lease")
+			}
+		}()
+	}
+
 	p := platforms.Default()
 	if platform != nil {
 		p = platforms.Only(*platform)
@@ -100,7 +134,6 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 	pp := pullProgress{store: i.content, showExists: true}
 	finishProgress := jobs.showProgress(ctx, out, pp)
 
-	var outNewImg *containerd.Image
 	defer func() {
 		finishProgress()
 
@@ -116,7 +149,8 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 		if outNewImg != nil {
 			img := *outNewImg
 			progress.Message(out, "", "Digest: "+img.Target().Digest.String())
-			writeStatus(out, reference.FamiliarString(ref), old.Digest != img.Target().Digest)
+			newer := oldImage.Target.Digest != img.Target().Digest
+			writeStatus(out, reference.FamiliarString(ref), newer)
 		}
 	}()
 

--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -86,7 +86,7 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 	}
 
 	// Will be set to the new image after pull succeeds.
-	var outNewImg *containerd.Image
+	var outNewImg containerd.Image
 
 	if oldImage.Target.Digest != "" {
 		// Lease the old image content to prevent it from being garbage collected until we keep it as dangling image.
@@ -104,8 +104,7 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 		// If the pulled image is different than the old image, we will keep the old image as a dangling image.
 		defer func() {
 			if outNewImg != nil {
-				img := *outNewImg
-				if img.Target().Digest != oldImage.Target.Digest {
+				if outNewImg.Target().Digest != oldImage.Target.Digest {
 					if err := i.ensureDanglingImage(ctx, oldImage); err != nil {
 						log.G(ctx).WithError(err).Warn("failed to keep the previous image as dangling")
 					}
@@ -147,7 +146,7 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 		// Status: Downloaded newer image for hello-world:latest
 		// docker.io/library/hello-world:latest
 		if outNewImg != nil {
-			img := *outNewImg
+			img := outNewImg
 			progress.Message(out, "", "Digest: "+img.Target().Digest.String())
 			newer := oldImage.Target.Digest != img.Target().Digest
 			writeStatus(out, reference.FamiliarString(ref), newer)
@@ -236,7 +235,7 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 	}
 
 	i.LogImageEvent(reference.FamiliarString(ref), reference.FamiliarName(ref), events.ActionPull)
-	outNewImg = &img
+	outNewImg = img
 	return nil
 }
 


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/46866

With graphdrivers, the old image was still kept as a dangling image. Keep the same behavior with containerd.


**- How to verify it**
TestImagePullKeepOldAsDangling

**- Description for the changelog**
```markdown changelog
containerd image store: Fix the previous image not being persisted as dangling after `docker pull`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

