### PR TITLE
[27.x backport] c8d/load: Multi-platform fixes

### DIFF
--- a/daemon/containerd/image_exporter.go
+++ b/daemon/containerd/image_exporter.go
@@ -290,6 +290,17 @@ func (i *ImageService) LoadImage(ctx context.Context, inTar io.ReadCloser, outSt
 				return nil
 			}
 
+			imgPlat, err := platformImg.ImagePlatform(ctx)
+			if err != nil {
+				logger.WithError(err).Warn("failed to read image platform, skipping unpack")
+				return nil
+			}
+
+			// Only unpack the image if it matches the host platform
+			if !i.hostPlatformMatcher().Match(imgPlat) {
+				return nil
+			}
+
 			unpacked, err := platformImg.IsUnpacked(ctx, i.snapshotter)
 			if err != nil {
 				logger.WithError(err).Warn("failed to check if image is unpacked")

--- a/daemon/containerd/image_exporter.go
+++ b/daemon/containerd/image_exporter.go
@@ -305,12 +305,14 @@ func (i *ImageService) LoadImage(ctx context.Context, inTar io.ReadCloser, outSt
 			logger.WithField("alreadyUnpacked", unpacked).WithError(err).Debug("unpack")
 			return nil
 		})
-		if err != nil {
-			return errors.Wrap(err, "failed to unpack loaded image")
-		}
 
 		fmt.Fprintf(progress, "%s: %s\n", loadedMsg, name)
 		i.LogImageEvent(img.Target.Digest.String(), img.Target.Digest.String(), events.ActionLoad)
+
+		if err != nil {
+			// The image failed to unpack, but is already imported, log the error but don't fail the whole load.
+			fmt.Fprintf(progress, "Error unpacking image %s: %v\n", name, err)
+		}
 	}
 
 	return nil

--- a/daemon/containerd/platform_matchers.go
+++ b/daemon/containerd/platform_matchers.go
@@ -24,3 +24,11 @@ func (c allPlatformsWithPreferenceMatcher) Match(_ ocispec.Platform) bool {
 func (c allPlatformsWithPreferenceMatcher) Less(p1, p2 ocispec.Platform) bool {
 	return c.preferred.Less(p1, p2)
 }
+
+func (i *ImageService) hostPlatformMatcher() platforms.MatchComparer {
+	// Allow to override the host platform for testing purposes.
+	if i.defaultPlatformOverride != nil {
+		return i.defaultPlatformOverride
+	}
+	return platforms.Default()
+}


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/48293


**- What I did**
Fixed some cases of `docker load` failing when loading a multi-platform image that contains platform incompatible with the host OS.

**- How I did it**
See commits.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
- containerd image store: Fix early error exit from `docker load` in cases where unpacking the image would fail
```

**- A picture of a cute animal (not mandatory but encouraged)**

