### PR TITLE
man: create parent directories in install recipe

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -35,7 +35,9 @@ man%:
 
 .PHONY: install
 install: all
+	@set -ex; \
 	for sec in $(sections); do \
+		$(INSTALL) -d $(DESTDIR)$(mandir)/man$$sec && \
 		$(INSTALL_DATA) man$$sec/* $(DESTDIR)$(mandir)/man$$sec; \
 	done
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Support the use of `make install` in packaging scripts, where the $mandir tree might not exist under $DESTDIR.

**- How I did it**
For portability, create the parent directories using a separate install command instead of relying on the non-portable `-D` flag.

**- How to verify it**
```console
$ rm -r fakeroot
$ make -C man DESTDIR=$(pwd)/fakeroot install
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

