### PR TITLE
[27.x backport] c8d/list: Don't exclude non-container images

### DIFF
--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -393,17 +393,25 @@ func (i *ImageService) imageSummary(ctx context.Context, img images.Image, platf
 				"error": err,
 				"image": img.Name,
 			}).Warn("unexpected image target (neither a manifest nor index)")
-			return nil, nil, nil
+		} else {
+			return nil, nil, err
 		}
-		return nil, nil, err
 	}
 
 	if best == nil {
-		// TODO we should probably show *something* for images we've pulled
-		// but are 100% shallow or an empty manifest list/index
-		// ("tianon/scratch:index" is an empty example image index and
-		// "tianon/scratch:list" is an empty example manifest list)
-		return nil, nil, nil
+		target := img.Target
+		return &imagetypes.Summary{
+			ID:          target.Digest.String(),
+			RepoDigests: []string{target.Digest.String()},
+			RepoTags:    tagsByDigest[target.Digest],
+			Size:        totalSize,
+			// -1 indicates that the value has not been set (avoids ambiguity
+			// between 0 (default) and "not set". We cannot use a pointer (nil)
+			// for this, as the JSON representation uses "omitempty", which would
+			// consider both "0" and "nil" to be "empty".
+			SharedSize: -1,
+			Containers: -1,
+		}, nil, nil
 	}
 
 	image, err := i.singlePlatformImage(ctx, i.content, tagsByDigest[best.RealTarget.Digest], best)

--- a/internal/testutils/specialimage/textplain.go
+++ b/internal/testutils/specialimage/textplain.go
@@ -1,0 +1,39 @@
+package specialimage
+
+import (
+	"strings"
+
+	"github.com/distribution/reference"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// TextPlain creates an non-container image that only contains a text/plain blob.
+func TextPlain(dir string) (*ocispec.Index, error) {
+	ref, err := reference.ParseNormalizedNamed("tianon/test:text-plain")
+	if err != nil {
+		return nil, err
+	}
+
+	emptyJsonDesc, err := writeBlob(dir, "text/plain", strings.NewReader("{}"))
+	if err != nil {
+		return nil, err
+	}
+
+	configDesc := emptyJsonDesc
+	configDesc.MediaType = "application/vnd.oci.empty.v1+json"
+
+	desc, err := writeJsonBlob(dir, ocispec.MediaTypeImageManifest, ocispec.Manifest{
+		Config: configDesc,
+		Layers: []ocispec.Descriptor{
+			emptyJsonDesc,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	desc.Annotations = map[string]string{
+		"io.containerd.image.name": ref.String(),
+	}
+
+	return ociImage(dir, nil, desc)
+}


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/48399

Before this, the image list would not show images that are not a valid container image, but could be a valid artifact.

While they're not directly usable by docker, we should still show them so the user can still discover them and at least be able to delete them.

**- What I did**

**- How I did it**

**- How to verify it**
TestImageList

and

```bash
$ docker pull tianon/test:text-plain
$ docker images
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
containerd image store: Fix non-container images being hidden in the `docker images` output
```

**- A picture of a cute animal (not mandatory but encouraged)**

