### PR TITLE
 Verify status of firewalld via dbus org.fedoraproject.FirewallD1.state

### DIFF
--- a/libnetwork/iptables/firewalld_test.go
+++ b/libnetwork/iptables/firewalld_test.go
@@ -17,10 +17,17 @@ func skipIfNoFirewalld(t *testing.T) {
 		t.Skipf("cannot connect to D-bus system bus: %v", err)
 	}
 	defer conn.Close()
+	currentState, err := connection.sysObj.GetProperty(dbusInterface + ".state")
 
-	var zone string
-	err = conn.Object(dbusInterface, dbusPath).Call(dbusInterface+".getDefaultZone", 0).Store(&zone)
-	if err != nil {
+	var running bool
+	if err == nil {
+		value, ok := currentState.Value().(string)
+
+		if ok && (value == "RUNNING" || value == "FAILED") {
+			running = true
+		}
+	}
+	if err != nil || !running {
 		t.Skipf("firewalld is not running: %v", err)
 	}
 }

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -442,7 +442,7 @@ func filterOutput(start time.Time, output []byte, args ...string) []byte {
 
 // Raw calls 'iptables' system command, passing supplied arguments.
 func (iptable IPTable) Raw(args ...string) ([]byte, error) {
-	if firewalldRunning {
+	if firewalldReady {
 		// select correct IP version for firewalld
 		ipv := Iptables
 		if iptable.ipVersion == IPv6 {


### PR DESCRIPTION
**- What I did**
Modified libnetwork/iptables checkRunning to utilize the interface property org.fedoraproject.FirewallD1.state instead of inferring the state of firewalld from the interface method org.fedoraproject.FirewallD1.GetZones()

https://github.com/moby/moby/issues/46658

https://firewalld.org/documentation/man-pages/firewalld.dbus.html

**- How I did it**

I modified the checkRunning function of libnetwork/iptables

**- How to verify it**

### Case 1: Moby w/o systemd

Start Moby
`make BIND_DIR=. shell`

Start the daemon
```
./hack/make.sh binary
make install
./hack/make.sh run
```

Look for raw iptables output in the dockerd initalization logs

<img width="1150" alt="raw_iptables_output" src="https://github.com/moby/moby/assets/347096/62ae8be0-7061-4a70-8054-830d5aef1c4a">



### Case 2: Moby w/ systemd

Start the moby container with systemd 

Start Moby
`make BIND_DIR=. DOCKER_SYSTEMD=1 shell`

Install firewalld

`apt-get install firewalld`

Configure firewalled to use iptables instead of the default nftables as the Backend

`vim /etc/firewalld/firewalld.conf`
<img width="1135" alt="Screenshot 2024-06-20 at 12 09 55 PM" src="https://github.com/moby/moby/assets/347096/4a9f4d96-62f1-4e20-a4fa-bb4387826db7">


Restart dbus, polkit and firewall

```
systemctl restart dbus
systemctl restart polkit
systemctl restart firewalld
```

Start the daemon
```
./hack/make.sh binary
make install
./hack/make.sh run
```

Look for firewalld output in the dockerd initalization logs

<img width="1148" alt="firewalld_ouput" src="https://github.com/moby/moby/assets/347096/c80c858f-626d-4330-9c96-67545505c49c">


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Verify status of firewall via dbus org.fedoraproject.FirewallD1.state   
https://github.com/moby/moby/issues/46658
```


