### PR TITLE
c8d/pull: Same error message for non-matching platform

### DIFF
--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -208,12 +208,7 @@ func (s *DockerCLIPullSuite) TestPullLinuxImageFailsOnWindows(c *testing.T) {
 	testRequires(c, DaemonIsWindows, Network)
 	_, _, err := dockerCmdWithError("pull", "ubuntu")
 
-	errorMessage := "no matching manifest for windows"
-	if testEnv.UsingSnapshotter() {
-		errorMessage = "no match for platform in manifest"
-	}
-
-	assert.ErrorContains(c, err, errorMessage)
+	assert.ErrorContains(c, err, "no matching manifest for windows")
 }
 
 // Regression test for https://github.com/docker/docker/issues/28892
@@ -221,10 +216,5 @@ func (s *DockerCLIPullSuite) TestPullWindowsImageFailsOnLinux(c *testing.T) {
 	testRequires(c, DaemonIsLinux, Network)
 	_, _, err := dockerCmdWithError("pull", "mcr.microsoft.com/windows/servercore:ltsc2022")
 
-	errorMessage := "no matching manifest for linux"
-	if testEnv.UsingSnapshotter() {
-		errorMessage = "no match for platform in manifest"
-	}
-
-	assert.ErrorContains(c, err, errorMessage)
+	assert.ErrorContains(c, err, "no matching manifest for linux")
 }


### PR DESCRIPTION
- relates to: https://github.com/moby/moby/issues/46765
- reverts: https://github.com/moby/moby/pull/46517

Use the same error message as the graphdrivers image store backend. It's more informative as it also includes the requested platform and won't break clients checking doing error check with string-matching.


**- What I did**

**- How I did it**

**- How to verify it**
CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
containerd image store: Improve `docker pull` error message when the image platform doesn't match 
```

**- A picture of a cute animal (not mandatory but encouraged)**

