### PR TITLE
hack/make/.binary: enable pie mode on windows/arm64

### DIFF
--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -37,13 +37,14 @@ source "${MAKEDIR}/.go-autogen"
 		fi
 	fi
 
-	# -buildmode=pie is not supported on Windows arm64 and Linux mips*, ppc64be
-	# https://github.com/golang/go/blob/go1.19.4/src/cmd/internal/sys/supported.go#L125-L132
 	if ! [ "$DOCKER_STATIC" = "1" ]; then
 		# -buildmode=pie not supported when -race is enabled
 		if [[ " $BUILDFLAGS " != *" -race "* ]]; then
 			case "$(go env GOOS)/$(go env GOARCH)" in
-				windows/arm64 | linux/mips* | linux/ppc64) ;;
+				linux/mips* | linux/ppc64)
+					# -buildmode=pie is not supported on Linux mips*, ppc64be
+					# https://github.com/golang/go/blob/go1.23.0/src/internal/platform/supported.go#L189-L197
+					;;
 				*)
 					BUILDFLAGS+=("-buildmode=pie")
 					;;


### PR DESCRIPTION
pie-mode is supported for windows/arm64 since https://go.dev/cl/452415 (https://github.com/golang/go/commit/3732a178061f44fbde277def693368ce43e5e779), which is part of go1.20. Also update link to Go source for pie-mode support to match the location for current versions of Go because the package was moved in https://go.dev/cl/438475 (https://github.com/golang/go/commit/8bd803fd4ea3a549a9124f5a4e18af9596ef35df).

