### PR TITLE
add more //go:build directives to prevent downgrading to go1.16

### DIFF
--- a/daemon/logger/loggerutils/logfile.go
+++ b/daemon/logger/loggerutils/logfile.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.21
+
 package loggerutils // import "github.com/docker/docker/daemon/logger/loggerutils"
 
 import (

--- a/libnetwork/networkdb/networkdb.go
+++ b/libnetwork/networkdb/networkdb.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.21
+
 package networkdb
 
 //go:generate protoc -I=. -I=../../vendor/ --gogofaster_out=import_path=github.com/docker/docker/libnetwork/networkdb:. networkdb.proto


### PR DESCRIPTION
- updates https://github.com/moby/moby/pull/48157
- updates https://github.com/moby/moby/pull/47983
- relates to https://github.com/moby/moby/pull/46941


### libnetwork/networkdb: add //go:build directives to prevent downgrading to go1.16

commit 2847c4b7fe8883f7586401ad778ad2959ad45eb4 switched networkdb to use
go-immutable-radix v2, which uses generics, but failed to add the go:build
directives.

    # github.com/docker/docker/libnetwork/networkdb
    ../../libnetwork/networkdb/networkdb.go:47:19: type instantiation requires go1.18 or later (-lang was set to go1.16; check go.mod)
    ../../libnetwork/networkdb/networkdb.go:259:33: type instantiation requires go1.18 or later (-lang was set to go1.16; check go.mod)
    ../../libnetwork/networkdb/networkdb.go:269:25: function instantiation requires go1.18 or later (-lang was set to go1.16; check go.mod)
    ../../libnetwork/networkdb/networkdb.go:270:27: function instantiation requires go1.18 or later (-lang was set to go1.16; check go.mod)


### daemon/logger/loggerutils: add //go:build directives to prevent downgrading to go1.16

commit 77f2d90e2745be81441a45a7fca94c90bcd5cc7c introduced the slices import,
which uses generics, but failed to add the go:build directives.

    # github.com/docker/docker/daemon/logger/loggerutils
    ../../daemon/logger/loggerutils/logfile.go:770:2: implicit function instantiation requires go1.18 or later (-lang was set to go1.16; check go.mod)

