### PR TITLE
api: swagger: Fix lines using deprecated field in `JSONMessage` struct

### DIFF
--- a/pkg/jsonmessage/jsonmessage_test.go
+++ b/pkg/jsonmessage/jsonmessage_test.go
@@ -164,14 +164,6 @@ func TestJSONMessageDisplay(t *testing.T) {
 			"stream",
 			"stream",
 		},
-		// With progress message
-		{
-			Status:          "status",
-			ProgressMessage: "progressMessage",
-		}: {
-			"status progressMessage",
-			"status progressMessage",
-		},
 		// With progress, stream empty
 		{
 			Status:   "status",

--- a/pkg/streamformatter/streamformatter.go
+++ b/pkg/streamformatter/streamformatter.go
@@ -35,7 +35,7 @@ func FormatError(err error) []byte {
 	if !ok {
 		jsonError = &jsonmessage.JSONError{Message: err.Error()}
 	}
-	if b, err := json.Marshal(&jsonmessage.JSONMessage{Error: jsonError, ErrorMessage: err.Error()}); err == nil {
+	if b, err := json.Marshal(&jsonmessage.JSONMessage{Error: jsonError}); err == nil {
 		return appendNewline(b)
 	}
 	return []byte(`{"error":"format error"}` + streamNewline)
@@ -60,11 +60,10 @@ func (sf *jsonProgressFormatter) formatProgress(id, action string, progress *jso
 		*auxJSON = auxJSONBytes
 	}
 	b, err := json.Marshal(&jsonmessage.JSONMessage{
-		Status:          action,
-		ProgressMessage: progress.String(),
-		Progress:        progress,
-		ID:              id,
-		Aux:             auxJSON,
+		Status:   action,
+		Progress: progress,
+		ID:       id,
+		Aux:      auxJSON,
 	})
 	if err != nil {
 		return nil


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

addresses #44783 partially

**- What I did**

1. Fix lines using deprecated field `ErrorMessage` and `ProgressMessage`
2. Remove testing for `ProgressMessage` field

**- How I did it**

used Ripgrep to search lines referencing that field:

**- How to verify it**

https://github.com/search?q=repo%3Amoby%2Fmoby+ErrorMessage&type=code
no other lines using that field

https://github.com/search?q=repo%3Amoby%2Fmoby+ProgressMessage&type=code
i need some care. please refer to next comment

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
remove testing and referencing for deprecated fields

```

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/user-attachments/assets/03a4a628-6f14-4ba2-b982-cf372aaf7bdf)
