### PR TITLE
[27.x backport] gha/bin-image: Also run on branches like `27.x`

### DIFF
--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -19,6 +19,7 @@ on:
     branches:
       - 'master'
       - '[0-9]+.[0-9]+'
+      - '[0-9]+.x'
     tags:
       - 'v*'
   pull_request:


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/48450

We moved to the major release branches with a `.x` suffix and forgot to adjust this workflow.