### PR TITLE
seccomp: add riscv64 mapping to seccomp_linux.go

### DIFF
--- a/profiles/seccomp/seccomp_linux.go
+++ b/profiles/seccomp/seccomp_linux.go
@@ -39,6 +39,7 @@ var nativeToSeccomp = map[string]specs.Arch{
 	"ppc":         specs.ArchPPC,
 	"ppc64":       specs.ArchPPC64,
 	"ppc64le":     specs.ArchPPC64LE,
+	"riscv64":     specs.ArchRISCV64,
 	"s390":        specs.ArchS390,
 	"s390x":       specs.ArchS390X,
 }
@@ -57,6 +58,7 @@ var goToNative = map[string]string{
 	"ppc":         "ppc",
 	"ppc64":       "ppc64",
 	"ppc64le":     "ppc64le",
+	"riscv64":     "riscv64",
 	"s390":        "s390",
 	"s390x":       "s390x",
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- fixes: https://github.com/moby/moby/issues/48454
- relates to https://github.com/moby/moby/commit/4c2f18f6cca5a89c1e0828a18f01e90ac40fc9b9 / https://github.com/moby/moby/pull/43553

**- What I did**

I added support for the `riscv64` architecture in Docker's seccomp profile by updating the architecture mappings. Specifically, I included `riscv64` in the `nativeToSeccomp` and `goToNative` maps in Docker's seccomp profile handling code.

**- How I did it**

- Updated the `nativeToSeccomp` map to include `"riscv64": specs.ArchRISC_V64` for proper architecture mapping.
- Updated the `goToNative` map to include `"riscv64": "riscv64"` for correct runtime architecture detection.
- Ensured that Docker’s seccomp profile now correctly applies for RISC-V-based containers.

**- How to verify it**

1. Run a Docker container on a native `riscv64` system.
2. Confirm that the `riscv_flush_icache` system call and other RISC-V-specific syscalls are correctly applied in the seccomp profile.
3. Ensure that no architecture mismatch errors or seccomp-related syscall restrictions occur for the RISC-V architecture.
4. Test the functionality of other architectures to ensure no regressions in behavior.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Add support for RISC-V (riscv64) architecture in Docker's seccomp profile handling.
```

**- A picture of a cute animal (not mandatory but encouraged)**

