### PR TITLE
image-inspect: remove Config fields that are not part of the image

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1428,63 +1428,10 @@ definitions:
       when starting a container from the image.
     type: "object"
     properties:
-      Hostname:
-        description: |
-          The hostname to use for the container, as a valid RFC 1123 hostname.
-
-          <p><br /></p>
-
-          > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.48.
-        type: "string"
-        example: ""
-      Domainname:
-        description: |
-          The domain name to use for the container.
-
-          <p><br /></p>
-
-          > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.48.
-        type: "string"
-        example: ""
       User:
         description: "The user that commands are run as inside the container."
         type: "string"
         example: "web:web"
-      AttachStdin:
-        description: |
-          Whether to attach to `stdin`.
-
-          <p><br /></p>
-
-          > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
-        type: "boolean"
-        default: false
-        example: false
-      AttachStdout:
-        description: |
-          Whether to attach to `stdout`.
-
-          <p><br /></p>
-
-          > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
-        type: "boolean"
-        default: false
-        example: false
-      AttachStderr:
-        description: |
-          Whether to attach to `stderr`.
-
-          <p><br /></p>
-
-          > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
-        type: "boolean"
-        default: false
-        example: false
       ExposedPorts:
         description: |
           An object mapping ports to an empty object in the form:
@@ -1501,39 +1448,6 @@ definitions:
           "80/tcp": {},
           "443/tcp": {}
         }
-      Tty:
-        description: |
-          Attach standard streams to a TTY, including `stdin` if it is not closed.
-
-          <p><br /></p>
-
-          > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
-        type: "boolean"
-        default: false
-        example: false
-      OpenStdin:
-        description: |
-          Open `stdin`
-
-          <p><br /></p>
-
-          > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
-        type: "boolean"
-        default: false
-        example: false
-      StdinOnce:
-        description: |
-          Close `stdin` after one attached client disconnects.
-
-          <p><br /></p>
-
-          > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
-        type: "boolean"
-        default: false
-        example: false
       Env:
         description: |
           A list of environment variables to set inside the container in the
@@ -1559,18 +1473,6 @@ definitions:
         default: false
         example: false
         x-nullable: true
-      Image:
-        description: |
-          The name (or reference) of the image to use when creating the container,
-          or which was used when the container was created.
-
-          <p><br /></p>
-
-          > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.48.
-        type: "string"
-        default: ""
-        example: ""
       Volumes:
         description: |
           An object mapping mount point paths inside the container to empty
@@ -1599,30 +1501,6 @@ definitions:
         items:
           type: "string"
         example: []
-      NetworkDisabled:
-        description: |
-          Disable networking for the container.
-
-          <p><br /></p>
-
-          > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.48.
-        type: "boolean"
-        default: false
-        example: false
-        x-nullable: true
-      MacAddress:
-        description: |
-          MAC address of the container.
-
-          <p><br /></p>
-
-          > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.48.
-        type: "string"
-        default: ""
-        example: ""
-        x-nullable: true
       OnBuild:
         description: |
           `ONBUILD` metadata that were defined in the image's `Dockerfile`.
@@ -1645,17 +1523,6 @@ definitions:
         type: "string"
         example: "SIGTERM"
         x-nullable: true
-      StopTimeout:
-        description: |
-          Timeout to stop a container in seconds.
-
-          <p><br /></p>
-
-          > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.48.
-        type: "integer"
-        default: 10
-        x-nullable: true
       Shell:
         description: |
           Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell.
@@ -1666,19 +1533,11 @@ definitions:
         example: ["/bin/sh", "-c"]
     # FIXME(thaJeztah): temporarily using a full example to remove some "omitempty" fields. Remove once the fields are removed.
     example:
-      "Hostname": ""
-      "Domainname": ""
       "User": "web:web"
-      "AttachStdin": false
-      "AttachStdout": false
-      "AttachStderr": false
       "ExposedPorts": {
         "80/tcp": {},
         "443/tcp": {}
       }
-      "Tty": false
-      "OpenStdin": false
-      "StdinOnce": false
       "Env": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"]
       "Cmd": ["/bin/sh"]
       "Healthcheck": {
@@ -1690,7 +1549,6 @@ definitions:
         "StartInterval": 0
       }
       "ArgsEscaped": true
-      "Image": ""
       "Volumes": {
         "/app/data": {},
         "/app/config": {}

--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -160,7 +160,7 @@ type ImageInspectOpts struct {
 type CommitConfig struct {
 	Author              string
 	Comment             string
-	Config              *container.Config
+	Config              *container.Config // TODO(thaJeztah); change this to [dockerspec.DockerOCIImageConfig]
 	ContainerConfig     *container.Config
 	ContainerID         string
 	ContainerMountLabel string

--- a/api/types/image/image_inspect.go
+++ b/api/types/image/image_inspect.go
@@ -3,6 +3,7 @@ package image
 import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/storage"
+	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -84,7 +85,7 @@ type InspectResponse struct {
 	// Author is the name of the author that was specified when committing the
 	// image, or as specified through MAINTAINER (deprecated) in the Dockerfile.
 	Author string
-	Config *container.Config
+	Config *dockerspec.DockerOCIImageConfig
 
 	// Architecture is the hardware CPU architecture that the image runs on.
 	Architecture string

--- a/daemon/containerd/image_inspect.go
+++ b/daemon/containerd/image_inspect.go
@@ -108,8 +108,9 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts ba
 	}
 
 	if multi.Best != nil {
+		imgConfig := img.Config
 		resp.Author = img.Author
-		resp.Config = dockerOCIImageConfigToContainerConfig(img.Config)
+		resp.Config = &imgConfig
 		resp.Architecture = img.Architecture
 		resp.Variant = img.Variant
 		resp.Os = img.OS

--- a/daemon/images/image_inspect.go
+++ b/daemon/images/image_inspect.go
@@ -53,6 +53,7 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts ba
 		layers = append(layers, l.String())
 	}
 
+	imgConfig := containerConfigToDockerOCIImageConfig(img.Config)
 	return &imagetypes.InspectResponse{
 		ID:              img.ID().String(),
 		RepoTags:        repoTags,
@@ -64,7 +65,7 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts ba
 		ContainerConfig: &img.ContainerConfig, //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.45.
 		DockerVersion:   img.DockerVersion,
 		Author:          img.Author,
-		Config:          img.Config,
+		Config:          &imgConfig,
 		Architecture:    img.Architecture,
 		Variant:         img.Variant,
 		Os:              img.OperatingSystem(),

--- a/daemon/images/imagespec.go
+++ b/daemon/images/imagespec.go
@@ -1,0 +1,41 @@
+package images
+
+import (
+	"github.com/docker/docker/api/types/container"
+	imagespec "github.com/moby/docker-image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func containerConfigToDockerOCIImageConfig(cfg *container.Config) imagespec.DockerOCIImageConfig {
+	var ociCfg ocispec.ImageConfig
+	var ext imagespec.DockerOCIImageConfigExt
+
+	if cfg != nil {
+		ociCfg = ocispec.ImageConfig{
+			User:        cfg.User,
+			Env:         cfg.Env,
+			Entrypoint:  cfg.Entrypoint,
+			Cmd:         cfg.Cmd,
+			Volumes:     cfg.Volumes,
+			WorkingDir:  cfg.WorkingDir,
+			Labels:      cfg.Labels,
+			StopSignal:  cfg.StopSignal,
+			ArgsEscaped: cfg.ArgsEscaped, //nolint:staticcheck // Ignore SA1019. Need to keep it in image.
+		}
+
+		if len(cfg.ExposedPorts) > 0 {
+			ociCfg.ExposedPorts = map[string]struct{}{}
+			for k, v := range cfg.ExposedPorts {
+				ociCfg.ExposedPorts[string(k)] = v
+			}
+		}
+		ext.Healthcheck = cfg.Healthcheck
+		ext.OnBuild = cfg.OnBuild
+		ext.Shell = cfg.Shell
+	}
+
+	return imagespec.DockerOCIImageConfig{
+		ImageConfig:             ociCfg,
+		DockerOCIImageConfigExt: ext,
+	}
+}

--- a/docs/api/v1.46.yaml
+++ b/docs/api/v1.46.yaml
@@ -1385,7 +1385,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.48.
+          > always empty. It must not be used, and will be removed in API v1.50.
         type: "string"
         example: ""
       Domainname:
@@ -1395,7 +1395,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.48.
+          > always empty. It must not be used, and will be removed in API v1.50.
         type: "string"
         example: ""
       User:
@@ -1409,7 +1409,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1420,7 +1420,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1431,7 +1431,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1458,7 +1458,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1469,7 +1469,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1480,7 +1480,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1517,7 +1517,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.48.
+          > always empty. It must not be used, and will be removed in API v1.50.
         type: "string"
         default: ""
         example: ""
@@ -1556,7 +1556,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.48.
+          > always omitted. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1568,7 +1568,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.48.
+          > always omitted. It must not be used, and will be removed in API v1.50.
         type: "string"
         default: ""
         example: ""
@@ -1602,7 +1602,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.48.
+          > always omitted. It must not be used, and will be removed in API v1.50.
         type: "integer"
         default: 10
         x-nullable: true

--- a/docs/api/v1.47.yaml
+++ b/docs/api/v1.47.yaml
@@ -1385,7 +1385,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.48.
+          > always empty. It must not be used, and will be removed in API v1.50.
         type: "string"
         example: ""
       Domainname:
@@ -1395,7 +1395,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.48.
+          > always empty. It must not be used, and will be removed in API v1.50.
         type: "string"
         example: ""
       User:
@@ -1409,7 +1409,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1420,7 +1420,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1431,7 +1431,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1458,7 +1458,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1469,7 +1469,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1480,7 +1480,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1517,7 +1517,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.48.
+          > always empty. It must not be used, and will be removed in API v1.50.
         type: "string"
         default: ""
         example: ""
@@ -1556,7 +1556,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.48.
+          > always omitted. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1568,7 +1568,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.48.
+          > always omitted. It must not be used, and will be removed in API v1.50.
         type: "string"
         default: ""
         example: ""
@@ -1602,7 +1602,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.48.
+          > always omitted. It must not be used, and will be removed in API v1.50.
         type: "integer"
         default: 10
         x-nullable: true

--- a/docs/api/v1.48.yaml
+++ b/docs/api/v1.48.yaml
@@ -1435,7 +1435,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.48.
+          > always empty. It must not be used, and will be removed in API v1.50.
         type: "string"
         example: ""
       Domainname:
@@ -1445,7 +1445,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.48.
+          > always empty. It must not be used, and will be removed in API v1.50.
         type: "string"
         example: ""
       User:
@@ -1459,7 +1459,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1470,7 +1470,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1481,7 +1481,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1508,7 +1508,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1519,7 +1519,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1530,7 +1530,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1567,7 +1567,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.48.
+          > always empty. It must not be used, and will be removed in API v1.50.
         type: "string"
         default: ""
         example: ""
@@ -1606,7 +1606,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.48.
+          > always omitted. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1618,7 +1618,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.48.
+          > always omitted. It must not be used, and will be removed in API v1.50.
         type: "string"
         default: ""
         example: ""
@@ -1652,7 +1652,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.48.
+          > always omitted. It must not be used, and will be removed in API v1.50.
         type: "integer"
         default: 10
         x-nullable: true

--- a/docs/api/v1.49.yaml
+++ b/docs/api/v1.49.yaml
@@ -1435,7 +1435,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.48.
+          > always empty. It must not be used, and will be removed in API v1.50.
         type: "string"
         example: ""
       Domainname:
@@ -1445,7 +1445,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.48.
+          > always empty. It must not be used, and will be removed in API v1.50.
         type: "string"
         example: ""
       User:
@@ -1459,7 +1459,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1470,7 +1470,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1481,7 +1481,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1508,7 +1508,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1519,7 +1519,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1530,7 +1530,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.48.
+          > always false. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1567,7 +1567,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.48.
+          > always empty. It must not be used, and will be removed in API v1.50.
         type: "string"
         default: ""
         example: ""
@@ -1606,7 +1606,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.48.
+          > always omitted. It must not be used, and will be removed in API v1.50.
         type: "boolean"
         default: false
         example: false
@@ -1618,7 +1618,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.48.
+          > always omitted. It must not be used, and will be removed in API v1.50.
         type: "string"
         default: ""
         example: ""
@@ -1652,7 +1652,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.48.
+          > always omitted. It must not be used, and will be removed in API v1.50.
         type: "integer"
         default: 10
         x-nullable: true

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -24,6 +24,14 @@ keywords: "API, Docker, rcli, REST, documentation"
 * Deprecated: The `BridgeNfIptables` and `BridgeNfIp6tables` fields in the
   `GET /info` response were deprecated in API v1.48, and are now omitted
   in API v1.50.
+* Deprecated: `GET /images/{name}/json` no longer returns the following `Config`
+  fields; `Hostname`, `Domainname`, `AttachStdin`, `AttachStdout`, `AttachStderr`
+  `Tty`, `OpenStdin`, `StdinOnce`, `Image`, `NetworkDisabled` (already omitted unless set),
+  `MacAddress` (already omitted unless set), `StopTimeout` (already omitted unless set).
+  These additional fields were included in the response due to an implementation
+  detail but not part of the image's Configuration. These fields were marked
+  deprecated in API v1.46, and are now omitted. Older versions of the API still
+  return these fields, but they are always empty.
 
 ## v1.49 API changes
 

--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -22,6 +22,9 @@ if [ -n "$TEST_INTEGRATION_USE_SNAPSHOTTER" ]; then
 	PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/api_build_test.py::BuildTest::test_build_squash"
 fi
 
+# TODO(thaJeztah) re-enable after https://github.com/docker/docker-py/pull/3336 is in the DOCKER_PY_COMMIT release.
+PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/api_build_test.py::BuildTest::test_build_container_with_target"
+
 # TODO(vvoland): re-enable after https://github.com/docker/docker-py/pull/3203 is included in the DOCKER_PY_COMMIT release.
 PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/api_image_test.py::CommitTest::test_commit"
 PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/api_image_test.py::CommitTest::test_commit_with_changes"

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -166,7 +166,6 @@ func (s *DockerRegistrySuite) TestRemoveImageByDigest(c *testing.T) {
 }
 
 func (s *DockerRegistrySuite) TestBuildByDigest(c *testing.T) {
-	skip.If(c, testEnv.UsingSnapshotter(), "Config.Image is not created with containerd, buildkit doesn't set it either")
 	imgDigest, err := setupImage(c)
 	assert.NilError(c, err, "error setting up image")
 
@@ -175,9 +174,6 @@ func (s *DockerRegistrySuite) TestBuildByDigest(c *testing.T) {
 	// pull from the registry using the <name>@<digest> reference
 	cli.DockerCmd(c, "pull", imageReference)
 
-	// get the image id
-	imageID := inspectField(c, imageReference, "Id")
-
 	// do the build
 	const name = "buildbydigest"
 	buildImageSuccessfully(c, name, build.WithDockerfile(fmt.Sprintf(
@@ -185,10 +181,9 @@ func (s *DockerRegistrySuite) TestBuildByDigest(c *testing.T) {
      CMD ["/bin/echo", "Hello World"]`, imageReference)))
 	assert.NilError(c, err)
 
-	// get the build's image id
-	res := inspectField(c, name, "Config.Image")
-	// make sure they match
-	assert.Equal(c, res, imageID)
+	// verify the build was ok
+	res := inspectField(c, name, "Config.Cmd")
+	assert.Equal(c, res, `[/bin/echo Hello World]`)
 }
 
 func (s *DockerRegistrySuite) TestTagByDigest(c *testing.T) {


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/48446
- https://github.com/moby/moby/pull/47941
- https://github.com/docker/cli/pull/5142

commit af0cdc36c7fd07f61717f1226ff0bfb6fc810347 marked these fields as deprecated and to be removed in API v1.47 (which was targeted for v28.0). We shipped v1.47 with the v27.2 release, but did not yet remove the erroneous fields, so the version to deprecate was updated to v1.48 through 3df03d8e669323ecb5397bb070c6b237cdd105d7

This patch removes fields that are not part of the image by replacing the type with the Config struct from the docker image-spec.

    curl -s --unix-socket /var/run/docker.sock http://localhost/v1.47/images/alpine/json | jq .Config
    {
      "Env": [
        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
      ],
      "Cmd": [
        "/bin/sh"
      ]
    }

    curl -s --unix-socket /var/run/docker.sock http://localhost/v1.46/images/alpine/json | jq .Config
    {
      "Hostname": "",
      "Domainname": "",
      "User": "",
      "AttachStdin": false,
      "AttachStdout": false,
      "AttachStderr": false,
      "Tty": false,
      "OpenStdin": false,
      "StdinOnce": false,
      "Env": [
        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
      ],
      "Cmd": [
        "/bin/sh"
      ],
      "Image": "",
      "Volumes": null,
      "WorkingDir": "",
      "Entrypoint": null,
      "OnBuild": null,
      "Labels": null
    }

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
API: Deprecated: `GET /images/{name}/json` no longer returns the following fields: `Config`, `Hostname`, `Domainname`, `AttachStdin`, `AttachStdout`, `AttachStderr`, `Tty`, `OpenStdin`, `StdinOnce`, `Image`, `NetworkDisabled` (already omitted unless set), `MacAddress` (already omitted unless set), `StopTimeout` (already omitted unless set). These additional fields were included in the response due to an implementation detail but not part of the image's Configuration, were marked deprecated in API v1.46, and are now omitted.
```

**- A picture of a cute animal (not mandatory but encouraged)**

