### PR TITLE
layer: layerStore.deleteLayer(): remove redundant error-check

### DIFF
--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -408,9 +408,6 @@ func (ls *layerStore) deleteLayer(layer *roLayer, metadata *Metadata) error {
 	metadata.DiffID = layer.diffID
 	metadata.ChainID = layer.chainID
 	metadata.Size = layer.Size()
-	if err != nil {
-		return err
-	}
 	metadata.DiffSize = layer.size
 
 	return nil


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/43182

Commit e1ea911abac7fa446cece83caf9649910fe624a1 removed the error return from .Size() and .DiffSize(), but forgot to remove this error-check.

