### PR TITLE
[27.x backport] seccomp: add riscv64 mapping to seccomp_linux.go

### DIFF
--- a/profiles/seccomp/seccomp_linux.go
+++ b/profiles/seccomp/seccomp_linux.go
@@ -39,6 +39,7 @@ var nativeToSeccomp = map[string]specs.Arch{
 	"ppc":         specs.ArchPPC,
 	"ppc64":       specs.ArchPPC64,
 	"ppc64le":     specs.ArchPPC64LE,
+	"riscv64":     specs.ArchRISCV64,
 	"s390":        specs.ArchS390,
 	"s390x":       specs.ArchS390X,
 }
@@ -57,6 +58,7 @@ var goToNative = map[string]string{
 	"ppc":         "ppc",
 	"ppc64":       "ppc64",
 	"ppc64le":     "ppc64le",
+	"riscv64":     "riscv64",
 	"s390":        "s390",
 	"s390x":       "s390x",
 }


### PR DESCRIPTION
(cherry picked from commit 1161b790cf10bae533533d687c22e05a934049d6)
- backport https://github.com/moby/moby/pull/48455
- fixes https://github.com/moby/moby/issues/48454
- relates to https://github.com/moby/moby/commit/4c2f18f6cca5a89c1e0828a18f01e90ac40fc9b9 / https://github.com/moby/moby/pull/43553


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Add support for RISC-V (riscv64) architecture in Docker's seccomp profile handling.
```

**- A picture of a cute animal (not mandatory but encouraged)**

