### PR TITLE
image/tarexport: fix some minor linting issues 

### DIFF
--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -237,7 +237,7 @@ func (s *saveSession) save(ctx context.Context, outStream io.Writer) error {
 			})
 		}
 
-		m := ocispec.Manifest{
+		data, err := json.Marshal(ocispec.Manifest{
 			Versioned: specs.Versioned{
 				SchemaVersion: 2,
 			},
@@ -248,9 +248,7 @@ func (s *saveSession) save(ctx context.Context, outStream io.Writer) error {
 				Size:      int64(len(imageDescr.image.RawJSON())),
 			},
 			Layers: foreign,
-		}
-
-		data, err := json.Marshal(m)
+		})
 		if err != nil {
 			return errors.Wrap(err, "error marshaling manifest")
 		}
@@ -269,12 +267,11 @@ func (s *saveSession) save(ctx context.Context, outStream io.Writer) error {
 		if err := system.Chtimes(mFile, time.Unix(0, 0), time.Unix(0, 0)); err != nil {
 			return errors.Wrap(err, "error setting blob directory timestamps")
 		}
-		size := int64(len(data))
 
 		untaggedMfstDesc := ocispec.Descriptor{
 			MediaType: ocispec.MediaTypeImageManifest,
 			Digest:    dgst,
-			Size:      size,
+			Size:      int64(len(data)),
 		}
 		for _, ref := range imageDescr.refs {
 			familiarName := reference.FamiliarName(ref)

--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -275,7 +275,6 @@ func (s *saveSession) save(ctx context.Context, outStream io.Writer) error {
 			MediaType: ocispec.MediaTypeImageManifest,
 			Digest:    dgst,
 			Size:      size,
-			Platform:  m.Config.Platform,
 		}
 		for _, ref := range imageDescr.refs {
 			familiarName := reference.FamiliarName(ref)

--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -45,14 +45,14 @@ type saveSession struct {
 }
 
 func (l *tarexporter) Save(ctx context.Context, names []string, outStream io.Writer) error {
-	images, err := l.parseNames(ctx, names)
+	imgDescriptors, err := l.parseNames(ctx, names)
 	if err != nil {
 		return err
 	}
 
 	// Release all the image top layer references
-	defer l.releaseLayerReferences(images)
-	return (&saveSession{tarexporter: l, images: images}).save(ctx, outStream)
+	defer l.releaseLayerReferences(imgDescriptors)
+	return (&saveSession{tarexporter: l, images: imgDescriptors}).save(ctx, outStream)
 }
 
 // parseNames will parse the image names to a map which contains image.ID to *imageDescriptor.
@@ -169,11 +169,11 @@ func (l *tarexporter) takeLayerReference(id image.ID, imgDescr *imageDescriptor)
 	if topLayerID == "" {
 		return nil
 	}
-	layer, err := l.lss.Get(topLayerID)
+	topLayer, err := l.lss.Get(topLayerID)
 	if err != nil {
 		return err
 	}
-	imgDescr.layerRef = layer
+	imgDescr.layerRef = topLayer
 	return nil
 }
 


### PR DESCRIPTION
### image/tarexport: rename variables that shadowed imports

### image/tarexport: saveSession.save: remove redundant Platform

- relates to https://github.com/moby/moby/pull/47661

Commit 9160b9fda6a75ee68e9e208b32fd7e4fd843a260 removed the platform from
the descriptor, but this field was still used further in the code, and now
always taking an empty platform.

### image/tarexport: saveSession.save: inline variables

Remove some intermediate variables that were only used in a single place.
