### PR TITLE
[27.x backport] api/swagger: update deprecation version for erroneous fields

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1384,7 +1384,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.47.
+          > always empty. It must not be used, and will be removed in API v1.48.
         type: "string"
         example: ""
       Domainname:
@@ -1394,7 +1394,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.47.
+          > always empty. It must not be used, and will be removed in API v1.48.
         type: "string"
         example: ""
       User:
@@ -1408,7 +1408,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.47.
+          > always false. It must not be used, and will be removed in API v1.48.
         type: "boolean"
         default: false
         example: false
@@ -1419,7 +1419,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.47.
+          > always false. It must not be used, and will be removed in API v1.48.
         type: "boolean"
         default: false
         example: false
@@ -1430,7 +1430,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.47.
+          > always false. It must not be used, and will be removed in API v1.48.
         type: "boolean"
         default: false
         example: false
@@ -1457,7 +1457,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.47.
+          > always false. It must not be used, and will be removed in API v1.48.
         type: "boolean"
         default: false
         example: false
@@ -1468,7 +1468,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.47.
+          > always false. It must not be used, and will be removed in API v1.48.
         type: "boolean"
         default: false
         example: false
@@ -1479,7 +1479,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.47.
+          > always false. It must not be used, and will be removed in API v1.48.
         type: "boolean"
         default: false
         example: false
@@ -1516,7 +1516,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.47.
+          > always empty. It must not be used, and will be removed in API v1.48.
         type: "string"
         default: ""
         example: ""
@@ -1555,7 +1555,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.47.
+          > always omitted. It must not be used, and will be removed in API v1.48.
         type: "boolean"
         default: false
         example: false
@@ -1567,7 +1567,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.47.
+          > always omitted. It must not be used, and will be removed in API v1.48.
         type: "string"
         default: ""
         example: ""
@@ -1601,7 +1601,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.47.
+          > always omitted. It must not be used, and will be removed in API v1.48.
         type: "integer"
         default: 10
         x-nullable: true

--- a/docs/api/v1.46.yaml
+++ b/docs/api/v1.46.yaml
@@ -1384,7 +1384,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.47.
+          > always empty. It must not be used, and will be removed in API v1.48.
         type: "string"
         example: ""
       Domainname:
@@ -1394,7 +1394,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.47.
+          > always empty. It must not be used, and will be removed in API v1.48.
         type: "string"
         example: ""
       User:
@@ -1408,7 +1408,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.47.
+          > always false. It must not be used, and will be removed in API v1.48.
         type: "boolean"
         default: false
         example: false
@@ -1419,7 +1419,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.47.
+          > always false. It must not be used, and will be removed in API v1.48.
         type: "boolean"
         default: false
         example: false
@@ -1430,7 +1430,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.47.
+          > always false. It must not be used, and will be removed in API v1.48.
         type: "boolean"
         default: false
         example: false
@@ -1457,7 +1457,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.47.
+          > always false. It must not be used, and will be removed in API v1.48.
         type: "boolean"
         default: false
         example: false
@@ -1468,7 +1468,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.47.
+          > always false. It must not be used, and will be removed in API v1.48.
         type: "boolean"
         default: false
         example: false
@@ -1479,7 +1479,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.47.
+          > always false. It must not be used, and will be removed in API v1.48.
         type: "boolean"
         default: false
         example: false
@@ -1516,7 +1516,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.47.
+          > always empty. It must not be used, and will be removed in API v1.48.
         type: "string"
         default: ""
         example: ""
@@ -1555,7 +1555,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.47.
+          > always omitted. It must not be used, and will be removed in API v1.48.
         type: "boolean"
         default: false
         example: false
@@ -1567,7 +1567,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.47.
+          > always omitted. It must not be used, and will be removed in API v1.48.
         type: "string"
         default: ""
         example: ""
@@ -1601,7 +1601,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.47.
+          > always omitted. It must not be used, and will be removed in API v1.48.
         type: "integer"
         default: 10
         x-nullable: true

--- a/docs/api/v1.47.yaml
+++ b/docs/api/v1.47.yaml
@@ -1384,7 +1384,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.47.
+          > always empty. It must not be used, and will be removed in API v1.48.
         type: "string"
         example: ""
       Domainname:
@@ -1394,7 +1394,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.47.
+          > always empty. It must not be used, and will be removed in API v1.48.
         type: "string"
         example: ""
       User:
@@ -1408,7 +1408,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.47.
+          > always false. It must not be used, and will be removed in API v1.48.
         type: "boolean"
         default: false
         example: false
@@ -1419,7 +1419,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.47.
+          > always false. It must not be used, and will be removed in API v1.48.
         type: "boolean"
         default: false
         example: false
@@ -1430,7 +1430,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.47.
+          > always false. It must not be used, and will be removed in API v1.48.
         type: "boolean"
         default: false
         example: false
@@ -1457,7 +1457,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.47.
+          > always false. It must not be used, and will be removed in API v1.48.
         type: "boolean"
         default: false
         example: false
@@ -1468,7 +1468,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.47.
+          > always false. It must not be used, and will be removed in API v1.48.
         type: "boolean"
         default: false
         example: false
@@ -1479,7 +1479,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always false. It must not be used, and will be removed in API v1.47.
+          > always false. It must not be used, and will be removed in API v1.48.
         type: "boolean"
         default: false
         example: false
@@ -1516,7 +1516,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always empty. It must not be used, and will be removed in API v1.47.
+          > always empty. It must not be used, and will be removed in API v1.48.
         type: "string"
         default: ""
         example: ""
@@ -1555,7 +1555,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.47.
+          > always omitted. It must not be used, and will be removed in API v1.48.
         type: "boolean"
         default: false
         example: false
@@ -1567,7 +1567,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.47.
+          > always omitted. It must not be used, and will be removed in API v1.48.
         type: "string"
         default: ""
         example: ""
@@ -1601,7 +1601,7 @@ definitions:
           <p><br /></p>
 
           > **Deprecated**: this field is not part of the image specification and is
-          > always omitted. It must not be used, and will be removed in API v1.47.
+          > always omitted. It must not be used, and will be removed in API v1.48.
         type: "integer"
         default: 10
         x-nullable: true


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/48446

relates to:

- https://github.com/moby/moby/pull/47941
- https://github.com/docker/cli/pull/5142


### api/swagger: update deprecation version for erroneous fields

commit af0cdc36c7fd07f61717f1226ff0bfb6fc810347 officially marked these
fields as deprecated and to be removed in API v1.47 (which was targeted
for v28.0). We shipped v1.47 with the v27.2 release, but did not yet
remove the erroneous fields.

This patch updates the version to v1.48.



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

