### PR TITLE
integration/system: rename vars to prevent shadowing imports

### DIFF
--- a/integration/system/disk_usage_test.go
+++ b/integration/system/disk_usage_test.go
@@ -25,7 +25,7 @@ func TestDiskUsage(t *testing.T) {
 	defer d.Cleanup(t)
 	d.Start(t, "--iptables=false", "--ip6tables=false")
 	defer d.Stop(t)
-	client := d.NewClientT(t)
+	apiClient := d.NewClientT(t)
 
 	var stepDU types.DiskUsage
 	for _, step := range []struct {
@@ -35,7 +35,7 @@ func TestDiskUsage(t *testing.T) {
 		{
 			doc: "empty",
 			next: func(t *testing.T, _ types.DiskUsage) types.DiskUsage {
-				du, err := client.DiskUsage(ctx, types.DiskUsageOptions{})
+				du, err := apiClient.DiskUsage(ctx, types.DiskUsageOptions{})
 				assert.NilError(t, err)
 
 				expectedLayersSize := int64(0)
@@ -62,7 +62,7 @@ func TestDiskUsage(t *testing.T) {
 			next: func(t *testing.T, _ types.DiskUsage) types.DiskUsage {
 				d.LoadBusybox(ctx, t)
 
-				du, err := client.DiskUsage(ctx, types.DiskUsageOptions{})
+				du, err := apiClient.DiskUsage(ctx, types.DiskUsageOptions{})
 				assert.NilError(t, err)
 				assert.Assert(t, du.LayersSize > 0)
 				assert.Equal(t, len(du.Images), 1)
@@ -84,9 +84,9 @@ func TestDiskUsage(t *testing.T) {
 		{
 			doc: "after container.Run",
 			next: func(t *testing.T, prev types.DiskUsage) types.DiskUsage {
-				cID := container.Run(ctx, t, client)
+				cID := container.Run(ctx, t, apiClient)
 
-				du, err := client.DiskUsage(ctx, types.DiskUsageOptions{})
+				du, err := apiClient.DiskUsage(ctx, types.DiskUsageOptions{})
 				assert.NilError(t, err)
 				assert.Equal(t, len(du.Containers), 1)
 				assert.Equal(t, len(du.Containers[0].Names), 1)
@@ -263,7 +263,7 @@ func TestDiskUsage(t *testing.T) {
 					ctx := testutil.StartSpan(ctx, t)
 					// TODO: Run in parallel once https://github.com/moby/moby/pull/42560 is merged.
 
-					du, err := client.DiskUsage(ctx, tc.options)
+					du, err := apiClient.DiskUsage(ctx, tc.options)
 					assert.NilError(t, err)
 					assert.DeepEqual(t, du, tc.expected)
 				})

--- a/integration/system/info_linux_test.go
+++ b/integration/system/info_linux_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestInfoBinaryCommits(t *testing.T) {
 	ctx := setupTest(t)
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
-	info, err := client.Info(ctx)
+	info, err := apiClient.Info(ctx)
 	assert.NilError(t, err)
 
 	assert.Check(t, "N/A" != info.ContainerdCommit.ID)

--- a/integration/system/info_test.go
+++ b/integration/system/info_test.go
@@ -15,9 +15,9 @@ import (
 
 func TestInfoAPI(t *testing.T) {
 	ctx := setupTest(t)
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
-	info, err := client.Info(ctx)
+	info, err := apiClient.Info(ctx)
 	assert.NilError(t, err)
 
 	// TODO(thaJeztah): make sure we have other tests that run a local daemon and check other fields based on known state.

--- a/integration/system/login_test.go
+++ b/integration/system/login_test.go
@@ -17,13 +17,12 @@ func TestLoginFailsWithBadCredentials(t *testing.T) {
 	skip.If(t, !requirement.HasHubConnectivity(t))
 
 	ctx := setupTest(t)
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
-	config := registry.AuthConfig{
+	_, err := apiClient.RegistryLogin(ctx, registry.AuthConfig{
 		Username: "no-user",
 		Password: "no-password",
-	}
-	_, err := client.RegistryLogin(ctx, config)
+	})
 	assert.Assert(t, err != nil)
 	assert.Check(t, is.ErrorContains(err, "unauthorized: incorrect username or password"))
 	assert.Check(t, is.ErrorContains(err, fmt.Sprintf("https://%s/v2/", registrypkg.DefaultRegistryHost)))

--- a/integration/system/ping_test.go
+++ b/integration/system/ping_test.go
@@ -62,34 +62,34 @@ func TestPingSwarmHeader(t *testing.T) {
 	d := daemon.New(t)
 	d.Start(t)
 	defer d.Stop(t)
-	client := d.NewClientT(t)
-	defer client.Close()
+	apiClient := d.NewClientT(t)
+	defer apiClient.Close()
 
 	t.Run("before swarm init", func(t *testing.T) {
 		ctx := testutil.StartSpan(ctx, t)
-		p, err := client.Ping(ctx)
+		p, err := apiClient.Ping(ctx)
 		assert.NilError(t, err)
 		assert.Equal(t, p.SwarmStatus.NodeState, swarm.LocalNodeStateInactive)
 		assert.Equal(t, p.SwarmStatus.ControlAvailable, false)
 	})
 
-	_, err := client.SwarmInit(ctx, swarm.InitRequest{ListenAddr: "127.0.0.1", AdvertiseAddr: "127.0.0.1:2377"})
+	_, err := apiClient.SwarmInit(ctx, swarm.InitRequest{ListenAddr: "127.0.0.1", AdvertiseAddr: "127.0.0.1:2377"})
 	assert.NilError(t, err)
 
 	t.Run("after swarm init", func(t *testing.T) {
 		ctx := testutil.StartSpan(ctx, t)
-		p, err := client.Ping(ctx)
+		p, err := apiClient.Ping(ctx)
 		assert.NilError(t, err)
 		assert.Equal(t, p.SwarmStatus.NodeState, swarm.LocalNodeStateActive)
 		assert.Equal(t, p.SwarmStatus.ControlAvailable, true)
 	})
 
-	err = client.SwarmLeave(ctx, true)
+	err = apiClient.SwarmLeave(ctx, true)
 	assert.NilError(t, err)
 
 	t.Run("after swarm leave", func(t *testing.T) {
 		ctx := testutil.StartSpan(ctx, t)
-		p, err := client.Ping(ctx)
+		p, err := apiClient.Ping(ctx)
 		assert.NilError(t, err)
 		assert.Equal(t, p.SwarmStatus.NodeState, swarm.LocalNodeStateInactive)
 		assert.Equal(t, p.SwarmStatus.ControlAvailable, false)
@@ -102,8 +102,8 @@ func TestPingBuilderHeader(t *testing.T) {
 
 	ctx := setupTest(t)
 	d := daemon.New(t)
-	client := d.NewClientT(t)
-	defer client.Close()
+	apiClient := d.NewClientT(t)
+	defer apiClient.Close()
 
 	t.Run("default config", func(t *testing.T) {
 		testutil.StartSpan(ctx, t)
@@ -115,7 +115,7 @@ func TestPingBuilderHeader(t *testing.T) {
 			expected = types.BuilderV1
 		}
 
-		p, err := client.Ping(ctx)
+		p, err := apiClient.Ping(ctx)
 		assert.NilError(t, err)
 		assert.Equal(t, p.BuilderVersion, expected)
 	})
@@ -129,7 +129,7 @@ func TestPingBuilderHeader(t *testing.T) {
 		defer d.Stop(t)
 
 		expected := types.BuilderV1
-		p, err := client.Ping(ctx)
+		p, err := apiClient.Ping(ctx)
 		assert.NilError(t, err)
 		assert.Equal(t, p.BuilderVersion, expected)
 	})

--- a/integration/system/version_test.go
+++ b/integration/system/version_test.go
@@ -9,9 +9,9 @@ import (
 
 func TestVersion(t *testing.T) {
 	ctx := setupTest(t)
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
-	version, err := client.ServerVersion(ctx)
+	version, err := apiClient.ServerVersion(ctx)
 	assert.NilError(t, err)
 
 	assert.Check(t, version.APIVersion != "")


### PR DESCRIPTION


**- A picture of a cute animal (not mandatory but encouraged)**

