### PR TITLE
[27.x backport] Dockerfile: update RootlessKit to v2.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -356,7 +356,7 @@ FROM base AS rootlesskit-src
 WORKDIR /usr/src/rootlesskit
 RUN git init . && git remote add origin "https://github.com/rootless-containers/rootlesskit.git"
 # When updating, also update vendor.mod and hack/dockerfile/install/rootlesskit.installer accordingly.
-ARG ROOTLESSKIT_VERSION=v2.0.2
+ARG ROOTLESSKIT_VERSION=v2.3.1
 RUN git fetch -q --depth 1 origin "${ROOTLESSKIT_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS rootlesskit-build

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # When updating, also update vendor.mod and Dockerfile accordingly.
-: "${ROOTLESSKIT_VERSION:=v2.0.2}"
+: "${ROOTLESSKIT_VERSION:=v2.3.1}"
 
 install_rootlesskit() {
 	case "$1" in


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/48172
- Fix #48257 (for pasta, via https://github.com/rootless-containers/rootlesskit/pull/458)


https://github.com/rootless-containers/rootlesskit/compare/v2.0.2...v2.3.1

Depends on:
- https://github.com/moby/moby/pull/48174
- https://github.com/moby/moby/pull/48398




**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Update rootlesskit to [v2.3.1](https://github.com/rootless-containers/rootlesskit/releases/tag/v2.3.1) 
```

**- A picture of a cute animal (not mandatory but encouraged)**

