### PR TITLE
TestIPRangeAt64BitLimit: remove colon after XFAIL to help grepping

### DIFF
--- a/integration/network/bridge_test.go
+++ b/integration/network/bridge_test.go
@@ -193,7 +193,7 @@ func TestIPRangeAt64BitLimit(t *testing.T) {
 			err := c.ContainerStart(ctx, id, containertypes.StartOptions{})
 			if tc.expCtrFail {
 				assert.Assert(t, err != nil)
-				t.Skipf("XFAIL: Container startup failed with error: %v", err)
+				t.Skipf("XFAIL Container startup failed with error: %v", err)
 			} else {
 				assert.NilError(t, err)
 			}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/48322
- relates to https://github.com/moby/moby/pull/48326


When looking for failures in CI, I always search for `FAIL:` (with a trailing colon) to find tests that fail. This test has some test-cases that are currently expected to fail, but due to the colon would also be included when searching;

    === RUN   TestIPRangeAt64BitLimit/ipRange_at_end_of_64-bit_subnet
        bridge_test.go:196: XFAIL: Container startup failed with error: Error response from daemon: no available IPv6 addresses on this network's address pools: test64bl (b014e28c35c14cc34514430a8cfe1c97632c7988c56d89cea46abb10fa32229d)
    === RUN   TestIPRangeAt64BitLimit/ipRange_at_64-bit_boundary_inside_56-bit_subnet
        bridge_test.go:196: XFAIL: Container startup failed with error: Error response from daemon: no available IPv6 addresses on this network's address pools: test64bl (fb70301550d7a2d1d3425f5c1010a9ef487a9a251221a2d68ac49d257b249013)

Remove the trailing `:` so that searching for unexpected failures does not include these tests.


