### PR TITLE
Explicitly disable nvidia device injection for --gpus=0

### DIFF
--- a/daemon/nvidia_linux.go
+++ b/daemon/nvidia_linux.go
@@ -51,12 +51,15 @@ func setNvidiaGPUs(s *specs.Spec, dev *deviceInstance) error {
 		return errConflictCountDeviceIDs
 	}
 
-	if len(req.DeviceIDs) > 0 {
+	switch {
+	case len(req.DeviceIDs) > 0:
 		s.Process.Env = append(s.Process.Env, "NVIDIA_VISIBLE_DEVICES="+strings.Join(req.DeviceIDs, ","))
-	} else if req.Count > 0 {
+	case req.Count > 0:
 		s.Process.Env = append(s.Process.Env, "NVIDIA_VISIBLE_DEVICES="+countToDevices(req.Count))
-	} else if req.Count < 0 {
+	case req.Count < 0:
 		s.Process.Env = append(s.Process.Env, "NVIDIA_VISIBLE_DEVICES=all")
+	case req.Count == 0:
+		s.Process.Env = append(s.Process.Env, "NVIDIA_VISIBLE_DEVICES=void")
 	}
 
 	var nvidiaCaps []string


### PR DESCRIPTION
This change ensures that when --gpus=0 is selected, the injection of NVIDIA device nodes and libraries is disabled by setting the NVIDIA_VISIBLE_DEVICES environment variable to void instead of leaving this unspecfied.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Updated the handling of the `--gpus=0` flag to ensure that the `NVIDIA_VISBLE_DEVICES` envvar in the container is set to `void` instead of being left unspecified.

**- How I did it**

Added a conditional check for `Count == 0` when the `NVIDIA_VISBLE_DEVICES` envvar is being constructed.

**- How to verify it**

Running:

```
docker run --rm -ti --runtime=nvidia --gpus=0 ubuntu bash -c "ls /dev/nvidia*"
```

and

```
docker run --rm -ti --runtime=nvidia --gpus=0 ubuntu bash -c "ldconfig -p | grep libcuda.so"
```

should show no devices or libraries on a system with NVIDIA GPUs.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
* Updated the handling of the `--gpus=0` flag to be consistent with the NVIDIA Container Runtime.
```

**- A picture of a cute animal (not mandatory but encouraged)**

