### PR TITLE
[27.x backport] TestIPRangeAt64BitLimit: remove colon after XFAIL to help grepping

### DIFF
--- a/integration/network/bridge_test.go
+++ b/integration/network/bridge_test.go
@@ -193,7 +193,7 @@ func TestIPRangeAt64BitLimit(t *testing.T) {
 			err := c.ContainerStart(ctx, id, containertypes.StartOptions{})
 			if tc.expCtrFail {
 				assert.Assert(t, err != nil)
-				t.Skipf("XFAIL: Container startup failed with error: %v", err)
+				t.Skipf("XFAIL Container startup failed with error: %v", err)
 			} else {
 				assert.NilError(t, err)
 			}


### PR DESCRIPTION
**- What I did**

* Backports https://github.com/moby/moby/pull/48480 to 27.x

**- How I did it**

```
git cherry-pick -xsS adb00d3d555f9dae37305c872dc32f6b654088d9
```

**- How to verify it**
0 results for "FAIL:" in logs. (hopefully... 😅 )

**- Description for the changelog**
N/A

**- A picture of a cute animal (not mandatory but encouraged)**

