### PR TITLE
man: update dockerd man-page to include --feature flag

### DIFF
--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -31,6 +31,7 @@ dockerd - Enable daemon mode
 [**--exec-opt**[=*[]*]]
 [**--exec-root**[=*/var/run/docker*]]
 [**--experimental**[=**false**]]
+[**--feature**[=*NAME*=**true**|**false**]
 [**--fixed-cidr**[=*FIXED-CIDR*]]
 [**--fixed-cidr-v6**[=*FIXED-CIDR-V6*]]
 [**-G**|**--group**[=*docker*]]
@@ -221,6 +222,14 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
 
 **--experimental**=""
   Enable the daemon experimental features.
+
+**--feature**=*NAME*=**true**|**false**
+  Enable or disable feature feature in the daemon. This option corresponds
+  with the "features" field in the daemon.json configuration file. Using
+  both the command-line option and the "features" field in the configuration
+  file produces an error. The feature option can be specified multiple times
+  to configure multiple features.
+  Usage example: `--feature containerd-snapshotter=true`
 
 **--fixed-cidr**=""
   IPv4 subnet for fixed IPs (e.g., 10.20.0.0/16); this subnet must be nested in


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/48167

commit f13c08246d93dd5aae200d5881a3a374e6cac876 introduced this flag, but did not yet update the manpage.


<img width="1031" alt="Screenshot 2024-09-12 at 17 14 38" src="https://github.com/user-attachments/assets/7ab80e88-2b79-4afc-9ed5-3e74b257a5d2">


