### PR TITLE
IPv6 only: bug fix - enableIPv4 for old networks

### DIFF
--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -609,7 +609,7 @@ func (n *Network) UnmarshalJSON(b []byte) (err error) {
 		n.enableIPv4 = v.(bool)
 	} else {
 		// Set enableIPv4 for IPv4 networks created before the option was added.
-		n.enableIPv4 = len(n.ipamV4Info) > 0
+		_, n.enableIPv4 = netMap["ipamV4Info"]
 	}
 	n.enableIPv6 = netMap["enableIPv6"].(bool)
 


### PR DESCRIPTION
**- What I did**

Fix a bug introduced in:
- https://github.com/moby/moby/pull/48271

**- How I did it**

The new `Network.enableIPv4` flag needs to be set for IPv4 networks created before it was introduced.

Commit https://github.com/moby/moby/pull/48271/commits/903daa4dc480390a0e85163011526a55bde66a1f attempted to do that in the unmarshalling code by checking `Network.ipamV4Info` - but, that field hadn't been unmarshalled yet, so it was never present.

Instead, check for its presence in the saved map.

**- How to verify it**

Create a bridge network with moby 27.x, update to a version built from master, start a container on the IPv4 network - see that the daemon doesn't crash (the bridge code can't yet cope with `!enableIpv4`).

**- Description for the changelog**
```markdown changelog
n/a
```