### PR TITLE
[25.0 backport] Explicitly disable nvidia device injection for --gpus=0

### DIFF
--- a/daemon/nvidia_linux.go
+++ b/daemon/nvidia_linux.go
@@ -51,12 +51,15 @@ func setNvidiaGPUs(s *specs.Spec, dev *deviceInstance) error {
 		return errConflictCountDeviceIDs
 	}
 
-	if len(req.DeviceIDs) > 0 {
+	switch {
+	case len(req.DeviceIDs) > 0:
 		s.Process.Env = append(s.Process.Env, "NVIDIA_VISIBLE_DEVICES="+strings.Join(req.DeviceIDs, ","))
-	} else if req.Count > 0 {
+	case req.Count > 0:
 		s.Process.Env = append(s.Process.Env, "NVIDIA_VISIBLE_DEVICES="+countToDevices(req.Count))
-	} else if req.Count < 0 {
+	case req.Count < 0:
 		s.Process.Env = append(s.Process.Env, "NVIDIA_VISIBLE_DEVICES=all")
+	case req.Count == 0:
+		s.Process.Env = append(s.Process.Env, "NVIDIA_VISIBLE_DEVICES=void")
 	}
 
 	var nvidiaCaps []string


### PR DESCRIPTION
**- What I did**
* Backports https://github.com/moby/moby/pull/48482

**- How I did it**
```
git cherry-pick -xsS 51280071161a2319efae8e02a4373bb70e170587
```

**- How to verify it**
See details in https://github.com/moby/moby/pull/48482

**- Description for the changelog**
```markdown changelog
* Updated the handling of the `--gpus=0` flag to be consistent with the NVIDIA Container Runtime.
```

**- A picture of a cute animal (not mandatory but encouraged)**

