### PR TITLE
(blocked) Enforce requirement for iptables/ip6tables to implement ICC=false

### DIFF
--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -339,6 +339,72 @@ func TestBridgeINC(t *testing.T) {
 	}
 }
 
+// Check that Inter-Container Communication can be disabled in a user-defined
+// network, but only if iptables/ip6tables are enabled.
+func TestBridgeDisableICC(t *testing.T) {
+	ctx := setupTest(t)
+	testcases := []struct {
+		name           string
+		daemonOpts     []string
+		networkOpts    []string
+		expNwCreateErr string
+	}{
+		{
+			name: "no icc",
+		},
+		{
+			name:           "no iptables",
+			daemonOpts:     []string{"--iptables=false"},
+			expNwCreateErr: "icc=false requires iptables=true",
+		},
+		{
+			name:           "no ip6tables",
+			daemonOpts:     []string{"--ip6tables=false"},
+			expNwCreateErr: "icc=false requires ip6tables=true",
+		},
+	}
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			d := daemon.New(t)
+			d.StartWithBusybox(ctx, t, tc.daemonOpts...)
+			defer d.Stop(t)
+
+			c := d.NewClientT(t)
+			defer c.Close()
+
+			const netName = "iccDisabledNet"
+			_, err := network.Create(ctx, c, netName,
+				network.WithDriver("bridge"),
+				network.WithOption(bridge.EnableICC, "false"),
+				network.WithIPv6(),
+			)
+			if tc.expNwCreateErr != "" {
+				assert.Check(t, is.ErrorContains(err, tc.expNwCreateErr))
+				return
+			}
+			assert.NilError(t, err)
+
+			id1 := container.Run(ctx, t, c,
+				container.WithName("c1"),
+				container.WithNetworkMode(netName),
+			)
+			defer c.ContainerRemove(ctx, id1, containertypes.RemoveOptions{Force: true})
+
+			attachCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+			res := container.RunAttach(attachCtx, t, c,
+				container.WithCmd("ping", "-c1", "-W3", "c1"),
+				container.WithNetworkMode(netName),
+			)
+			defer c.ContainerRemove(ctx, res.ContainerID, containertypes.RemoveOptions{Force: true})
+
+			assert.Check(t, is.Equal(res.ExitCode, 1))
+			assert.Check(t, is.Contains(res.Stdout.String(), "100% packet loss"))
+		})
+	}
+}
+
 func TestDefaultBridgeIPv6(t *testing.T) {
 	ctx := setupTest(t)
 

--- a/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -256,17 +256,19 @@ func TestCreateFullOptions(t *testing.T) {
 	br, _ := types.ParseCIDR("172.16.0.1/16")
 	defgw, _ := types.ParseCIDR("172.16.0.100/16")
 
-	genericOption := make(map[string]interface{})
-	genericOption[netlabel.GenericData] = config
+	genericOption := map[string]interface{}{
+		netlabel.GenericData: config,
+	}
 
 	if err := d.configure(genericOption); err != nil {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
 
-	netOption := make(map[string]interface{})
-	netOption[netlabel.EnableIPv6] = true
-	netOption[netlabel.GenericData] = &networkConfiguration{
-		BridgeName: DefaultBridgeName,
+	netOption := map[string]interface{}{
+		netlabel.EnableIPv6: true,
+		netlabel.GenericData: map[string]string{
+			BridgeName: DefaultBridgeName,
+		},
 	}
 
 	ipdList := []driverapi.IPAMData{
@@ -298,9 +300,11 @@ func TestCreateNoConfig(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver()
 
-	netconfig := &networkConfiguration{BridgeName: DefaultBridgeName}
-	genericOption := make(map[string]interface{})
-	genericOption[netlabel.GenericData] = netconfig
+	genericOption := map[string]interface{}{
+		netlabel.GenericData: map[string]string{
+			BridgeName: DefaultBridgeName,
+		},
+	}
 
 	if err := d.CreateNetwork("dummy", genericOption, nil, getIPv4Data(t), nil); err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
@@ -421,9 +425,11 @@ func TestCreate(t *testing.T) {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
 
-	netconfig := &networkConfiguration{BridgeName: DefaultBridgeName}
-	genericOption := make(map[string]interface{})
-	genericOption[netlabel.GenericData] = netconfig
+	genericOption := map[string]interface{}{
+		netlabel.GenericData: map[string]string{
+			BridgeName: DefaultBridgeName,
+		},
+	}
 
 	if err := d.CreateNetwork("dummy", genericOption, nil, getIPv4Data(t), nil); err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
@@ -1097,11 +1103,13 @@ func TestSetDefaultGw(t *testing.T) {
 		AddressIPv6:        subnetv6,
 		DefaultGatewayIPv4: gw4,
 		DefaultGatewayIPv6: gw6,
+		EnableICC:          true,
 	}
 
-	genericOption := make(map[string]interface{})
-	genericOption[netlabel.EnableIPv6] = true
-	genericOption[netlabel.GenericData] = config
+	genericOption := map[string]interface{}{
+		netlabel.EnableIPv6:  true,
+		netlabel.GenericData: config,
+	}
 
 	err := d.CreateNetwork("dummy", genericOption, nil, ipdList, nil)
 	if err != nil {
@@ -1193,9 +1201,11 @@ func TestCreateWithExistingBridge(t *testing.T) {
 		t.Fatalf("Failed to add IP address to bridge: %v", err)
 	}
 
-	netconfig := &networkConfiguration{BridgeName: brName}
-	genericOption := make(map[string]interface{})
-	genericOption[netlabel.GenericData] = netconfig
+	genericOption := map[string]interface{}{
+		netlabel.GenericData: map[string]string{
+			BridgeName: brName,
+		},
+	}
 
 	ipv4Data := []driverapi.IPAMData{{
 		AddressSpace: "full",
@@ -1249,9 +1259,11 @@ func TestCreateParallel(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		name := "net" + strconv.Itoa(i)
 		c.Go(t, func() {
-			config := &networkConfiguration{BridgeName: name}
-			genericOption := make(map[string]interface{})
-			genericOption[netlabel.GenericData] = config
+			genericOption := map[string]interface{}{
+				netlabel.GenericData: map[string]string{
+					BridgeName: name,
+				},
+			}
 			if err := d.CreateNetwork(name, genericOption, nil, ipV4Data, nil); err != nil {
 				ch <- fmt.Errorf("failed to create %s", name)
 				return

--- a/libnetwork/drivers/bridge/network_linux_test.go
+++ b/libnetwork/drivers/bridge/network_linux_test.go
@@ -21,6 +21,7 @@ func TestLinkCreate(t *testing.T) {
 	mtu := 1490
 	config := &networkConfiguration{
 		BridgeName: DefaultBridgeName,
+		EnableICC:  true,
 		Mtu:        mtu,
 		EnableIPv6: true,
 	}
@@ -116,6 +117,7 @@ func TestLinkCreateTwo(t *testing.T) {
 	config := &networkConfiguration{
 		BridgeName: DefaultBridgeName,
 		EnableIPv6: true,
+		EnableICC:  true,
 	}
 	genericOption := make(map[string]interface{})
 	genericOption[netlabel.GenericData] = config
@@ -151,11 +153,11 @@ func TestLinkCreateNoEnableIPv6(t *testing.T) {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
 
-	config := &networkConfiguration{
-		BridgeName: DefaultBridgeName,
+	genericOption := map[string]interface{}{
+		netlabel.GenericData: map[string]string{
+			BridgeName: DefaultBridgeName,
+		},
 	}
-	genericOption := make(map[string]interface{})
-	genericOption[netlabel.GenericData] = config
 
 	ipdList := getIPv4Data(t)
 	err := d.CreateNetwork("dummy", genericOption, nil, ipdList, getIPv6Data(t))
@@ -189,6 +191,7 @@ func TestLinkDelete(t *testing.T) {
 	config := &networkConfiguration{
 		BridgeName: DefaultBridgeName,
 		EnableIPv6: true,
+		EnableICC:  true,
 	}
 	genericOption := make(map[string]interface{})
 	genericOption[netlabel.GenericData] = config

--- a/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
@@ -336,6 +336,7 @@ func TestOutgoingNATRules(t *testing.T) {
 				EnableIPMasquerade: tc.enableIPMasquerade,
 				HostIPv4:           tc.hostIPv4,
 				HostIPv6:           tc.hostIPv6,
+				EnableICC:          true,
 			}
 			ipv4Data := []driverapi.IPAMData{{Pool: maskedBrIPv4, Gateway: brIPv4}}
 			ipv6Data := []driverapi.IPAMData{{Pool: maskedBrIPv6, Gateway: brIPv6}}

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/docker/docker/libnetwork/config"
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/driverapi"
+	"github.com/docker/docker/libnetwork/drivers/bridge"
 	"github.com/docker/docker/libnetwork/ipams/defaultipam"
 	"github.com/docker/docker/libnetwork/ipams/null"
 	"github.com/docker/docker/libnetwork/ipamutils"
@@ -56,6 +57,8 @@ func newController(t *testing.T) *libnetwork.Controller {
 		libnetwork.OptionBoltdbWithRandomDBFile(t),
 		config.OptionDriverConfig(bridgeNetType, map[string]interface{}{
 			netlabel.GenericData: options.Generic{
+				"EnableIPTables":     true,
+				"EnableIP6Tables":    true,
 				"EnableIPForwarding": true,
 			},
 		}),
@@ -178,8 +181,8 @@ func TestNetworkName(t *testing.T) {
 
 	netOption := options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
 		},
 	}
 
@@ -214,8 +217,8 @@ func TestNetworkType(t *testing.T) {
 
 	netOption := options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
 		},
 	}
 
@@ -240,8 +243,8 @@ func TestNetworkID(t *testing.T) {
 
 	netOption := options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
 		},
 	}
 
@@ -264,12 +267,11 @@ func TestDeleteNetworkWithActiveEndpoints(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
-	netOption := options.Generic{
-		"BridgeName": "testnetwork",
-	}
 	option := options.Generic{
-		netlabel.EnableIPv4:  true,
-		netlabel.GenericData: netOption,
+		netlabel.EnableIPv4: true,
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
+		},
 	}
 
 	network, err := createTestNetwork(controller, bridgeNetType, "testnetwork", option, nil, nil)
@@ -319,11 +321,10 @@ func TestNetworkConfig(t *testing.T) {
 	}
 
 	// Create supported config network
-	netOption := options.Generic{
-		"EnableICC": false,
-	}
 	option := options.Generic{
-		netlabel.GenericData: netOption,
+		netlabel.GenericData: map[string]string{
+			bridge.EnableICC: "false",
+		},
 	}
 	ipamV4ConfList := []*libnetwork.IpamConf{{PreferredPool: "192.168.100.0/24", SubPool: "192.168.100.128/25", Gateway: "192.168.100.1"}}
 	ipamV6ConfList := []*libnetwork.IpamConf{{PreferredPool: "2001:db8:abcd::/64", SubPool: "2001:db8:abcd::ef99/80", Gateway: "2001:db8:abcd::22"}}
@@ -409,12 +410,11 @@ func TestUnknownNetwork(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
-	netOption := options.Generic{
-		"BridgeName": "testnetwork",
-	}
 	option := options.Generic{
-		netlabel.EnableIPv4:  true,
-		netlabel.GenericData: netOption,
+		netlabel.EnableIPv4: true,
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
+		},
 	}
 
 	network, err := createTestNetwork(controller, bridgeNetType, "testnetwork", option, nil, nil)
@@ -441,12 +441,11 @@ func TestUnknownEndpoint(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
-	netOption := options.Generic{
-		"BridgeName": "testnetwork",
-	}
 	option := options.Generic{
-		netlabel.EnableIPv4:  true,
-		netlabel.GenericData: netOption,
+		netlabel.EnableIPv4: true,
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
+		},
 	}
 	ipamV4ConfList := []*libnetwork.IpamConf{{PreferredPool: "192.168.100.0/24"}}
 
@@ -486,8 +485,8 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 	// Create network 1 and add 2 endpoint: ep11, ep12
 	netOption := options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "network1",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "network1",
 		},
 	}
 
@@ -560,8 +559,8 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 	// Create network 2
 	netOption = options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "network2",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "network2",
 		},
 	}
 
@@ -617,8 +616,8 @@ func TestDuplicateEndpoint(t *testing.T) {
 
 	netOption := options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
 		},
 	}
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", netOption, nil, nil)
@@ -667,8 +666,8 @@ func TestControllerQuery(t *testing.T) {
 	// Create network 1
 	netOption := options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "network1",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "network1",
 		},
 	}
 	net1, err := createTestNetwork(controller, bridgeNetType, "network1", netOption, nil, nil)
@@ -684,8 +683,8 @@ func TestControllerQuery(t *testing.T) {
 	// Create network 2
 	netOption = options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "network2",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "network2",
 		},
 	}
 	net2, err := createTestNetwork(controller, bridgeNetType, "network2", netOption, nil, nil)
@@ -770,8 +769,8 @@ func TestNetworkQuery(t *testing.T) {
 	// Create network 1 and add 2 endpoint: ep11, ep12
 	netOption := options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "network1",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "network1",
 		},
 	}
 	net1, err := createTestNetwork(controller, bridgeNetType, "network1", netOption, nil, nil)
@@ -856,8 +855,8 @@ func TestEndpointDeleteWithActiveContainer(t *testing.T) {
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
 		},
 	}, nil, nil)
 	if err != nil {
@@ -871,8 +870,8 @@ func TestEndpointDeleteWithActiveContainer(t *testing.T) {
 
 	n2, err := createTestNetwork(controller, bridgeNetType, "testnetwork2", options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork2",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork2",
 		},
 	}, nil, nil)
 	if err != nil {
@@ -932,8 +931,8 @@ func TestEndpointMultipleJoins(t *testing.T) {
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testmultiple", options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testmultiple",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testmultiple",
 		},
 	}, nil, nil)
 	if err != nil {
@@ -1006,8 +1005,8 @@ func TestLeaveAll(t *testing.T) {
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
 		},
 	}, nil, nil)
 	if err != nil {
@@ -1022,8 +1021,8 @@ func TestLeaveAll(t *testing.T) {
 
 	n2, err := createTestNetwork(controller, bridgeNetType, "testnetwork2", options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork2",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork2",
 		},
 	}, nil, nil)
 	if err != nil {
@@ -1072,8 +1071,8 @@ func TestContainerInvalidLeave(t *testing.T) {
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
 		},
 	}, nil, nil)
 	if err != nil {
@@ -1138,8 +1137,8 @@ func TestEndpointUpdateParent(t *testing.T) {
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
 		},
 	}, nil, nil)
 	if err != nil {
@@ -1311,8 +1310,8 @@ func makeTestIPv6Network(t *testing.T, c *libnetwork.Controller) *libnetwork.Net
 	netOptions := options.Generic{
 		netlabel.EnableIPv4: true,
 		netlabel.EnableIPv6: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
 		},
 	}
 	ipamV6ConfList := []*libnetwork.IpamConf{
@@ -1435,10 +1434,8 @@ func TestBridgeIpv6FromMac(t *testing.T) {
 	controller := newController(t)
 
 	netOption := options.Generic{
-		netlabel.GenericData: options.Generic{
-			"BridgeName":         "testipv6mac",
-			"EnableICC":          true,
-			"EnableIPMasquerade": true,
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testipv6mac",
 		},
 	}
 	ipamV4ConfList := []*libnetwork.IpamConf{{PreferredPool: "192.168.100.0/24", Gateway: "192.168.100.1"}}
@@ -1512,10 +1509,8 @@ func TestEndpointJoin(t *testing.T) {
 
 	// Create network 1 and add 2 endpoint: ep11, ep12
 	netOption := options.Generic{
-		netlabel.GenericData: options.Generic{
-			"BridgeName":         "testnetwork1",
-			"EnableICC":          true,
-			"EnableIPMasquerade": true,
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork1",
 		},
 	}
 	ipamV6ConfList := []*libnetwork.IpamConf{{PreferredPool: "fe90::/64", Gateway: "fe90::22"}}
@@ -1638,8 +1633,8 @@ func TestEndpointJoin(t *testing.T) {
 	n2, err := createTestNetwork(controller, bridgeNetType, "testnetwork2",
 		options.Generic{
 			netlabel.EnableIPv4: true,
-			netlabel.GenericData: options.Generic{
-				"BridgeName": "testnetwork2",
+			netlabel.GenericData: map[string]string{
+				bridge.BridgeName: "testnetwork2",
 			},
 		}, nil, nil)
 	if err != nil {
@@ -1689,8 +1684,8 @@ func externalKeyTest(t *testing.T, reexec bool) {
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
 		},
 	}, nil, nil)
 	if err != nil {
@@ -1704,8 +1699,8 @@ func externalKeyTest(t *testing.T, reexec bool) {
 
 	n2, err := createTestNetwork(controller, bridgeNetType, "testnetwork2", options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork2",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork2",
 		},
 	}, nil, nil)
 	if err != nil {
@@ -2002,8 +1997,8 @@ func TestParallel(t *testing.T) {
 
 	netOption := options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "network",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "network",
 		},
 	}
 
@@ -2065,10 +2060,8 @@ func TestBridge(t *testing.T) {
 	netOption := options.Generic{
 		netlabel.EnableIPv4: true,
 		netlabel.EnableIPv6: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName":         "testnetwork",
-			"EnableICC":          true,
-			"EnableIPMasquerade": true,
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
 		},
 	}
 	ipamV4ConfList := []*libnetwork.IpamConf{{PreferredPool: "192.168.100.0/24", Gateway: "192.168.100.1"}}

--- a/libnetwork/sandbox_unix_test.go
+++ b/libnetwork/sandbox_unix_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/config"
+	"github.com/docker/docker/libnetwork/drivers/bridge"
 	"github.com/docker/docker/libnetwork/ipams/defaultipam"
 	"github.com/docker/docker/libnetwork/ipamutils"
 	"github.com/docker/docker/libnetwork/netlabel"
@@ -20,6 +21,7 @@ import (
 )
 
 func getTestEnv(t *testing.T, opts ...[]NetworkOption) (*Controller, []*Network) {
+	t.Helper()
 	const netType = "bridge"
 	c, err := New(
 		OptionBoltdbWithRandomDBFile(t),
@@ -42,7 +44,9 @@ func getTestEnv(t *testing.T, opts ...[]NetworkOption) (*Controller, []*Network)
 		name := "test_nw_" + strconv.Itoa(i)
 		newOptions := []NetworkOption{
 			NetworkOptionGeneric(options.Generic{
-				netlabel.GenericData: options.Generic{"BridgeName": name},
+				netlabel.GenericData: map[string]string{
+					bridge.BridgeName: name,
+				},
 			}),
 		}
 		newOptions = append(newOptions, opt...)

--- a/testutil/daemon/swarm.go
+++ b/testutil/daemon/swarm.go
@@ -16,7 +16,7 @@ const (
 	defaultSwarmListenAddr = "0.0.0.0"
 )
 
-var startArgs = []string{"--iptables=false", "--swarm-default-advertise-addr=lo"}
+var startArgs = []string{"--swarm-default-advertise-addr=lo"}
 
 // StartNode (re)starts the daemon
 func (d *Daemon) StartNode(t testing.TB) {


### PR DESCRIPTION
### Blocked

We need to figure out how to run Swarm tests (which need ICC=false for gateway networks) - but also need to run multiple daemons on the same host, so trample each other's iptables.

**- What I did**

With "--icc=false" (no inter-container comms on the default bridge), the daemon will produce an error and fail to start if iptables/ip6tables are disabled and ipv4/ipv6 are enabled for the network.

There's no such check for user-defined networks. (And I don't think we test ICC=false in user-defined networks.)

**- How I did it**

Make "network create" fail if ICC=false can't be implemented.

**- How to verify it**

New tests.

**- Description for the changelog**
```markdown changelog
Bridge driver option `com.docker.network.bridge.enable_icc=false` is implemented using iptables
rules, "network create" now fails with an error if the option is used when iptables or ip6tables is
required but disabled.
```
