### PR TITLE
Return error when AppArmor profile is specified but unsupported on host

### DIFF
--- a/daemon/exec_linux.go
+++ b/daemon/exec_linux.go
@@ -2,6 +2,7 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"context"
+	"errors"
 
 	"github.com/containerd/containerd"
 	coci "github.com/containerd/containerd/oci"
@@ -90,7 +91,13 @@ func (daemon *Daemon) execSetPlatformOpt(ctx context.Context, daemonCfg *config.
 			}
 		}
 		p.ApparmorProfile = appArmorProfile
+	} else {
+		// If AppArmor is not supported but a profile was specified, return an error
+		if ec.Container.AppArmorProfile != "" {
+			return errors.New("AppArmor is not supported on this host, but the profile '" + ec.Container.AppArmorProfile + "' was specified")
+		}
 	}
+
 	s := &specs.Spec{Process: p}
 	return withRlimits(daemon, daemonCfg, ec.Container)(ctx, nil, nil, s)
 }

--- a/daemon/exec_linux_test.go
+++ b/daemon/exec_linux_test.go
@@ -67,6 +67,7 @@ func TestExecSetPlatformOptAppArmor(t *testing.T) {
 			if !appArmorEnabled {
 				// no profile should be set if the host does not support AppArmor
 				doc += " (apparmor disabled)"
+				tc.appArmorProfile = ""
 				tc.expectedProfile = ""
 			}
 			if execPrivileged {

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -179,7 +179,13 @@ func WithApparmor(c *container.Container) coci.SpecOpts {
 				s.Process = &specs.Process{}
 			}
 			s.Process.ApparmorProfile = appArmorProfile
+		} else {
+			// If AppArmor is not supported but a profile was specified, return an error
+			if c.AppArmorProfile != "" {
+				return errors.New("AppArmor is not supported on this host, but the profile '" + c.AppArmorProfile + "' was specified")
+			}
 		}
+
 		return nil
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Description for the changelog**
A few days ago, I was working with the AppArmor feature and noticed that the profiles I set for my containers were not being applied. After some investigation, I realized that the AppArmor service on my host was inactive and had encountered issues, which caused the profiles to fail.

Once I fixed the service, the profiles were correctly applied to the containers. During further testing, I found that if AppArmor is active on the host and I specify a non-existent profile, Docker returns an error as expected. However, if the AppArmor service is entirely inactive, no error is returned, and the container runs without applying any profile.

To avoid confusion for users relying on AppArmor, I’ve made these changes. This ensures they are notified when their profiles are not applied, preventing them from mistakenly assuming the profiles are in place, which could lead to serious issues.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->

