### PR TITLE
Update dlv in the dev-env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,7 +147,7 @@ RUN git init . && git remote add origin "https://github.com/go-delve/delve.git"
 # from the https://github.com/go-delve/delve repository.
 # It can be used to run Docker with a possibility of
 # attaching debugger to it.
-ARG DELVE_VERSION=v1.21.1
+ARG DELVE_VERSION=v1.23.0
 RUN git fetch -q --depth 1 origin "${DELVE_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS delve-supported


### PR DESCRIPTION
**- What I did**

Got rid of `WARNING: undefined behavior - version of Delve is too old for Go version go1.22.7 (maximum supported version 1.21)`.

**- How I did it**

Updated to https://github.com/go-delve/delve/releases/tag/v1.23.0

**- How to verify it**

Run dlv in the dev env.

**- Description for the changelog**
```markdown changelog
n/a
```
