### PR TITLE
[26.1 backport] Update dlv in the dev-env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,7 +147,7 @@ RUN git init . && git remote add origin "https://github.com/go-delve/delve.git"
 # from the https://github.com/go-delve/delve repository.
 # It can be used to run Docker with a possibility of
 # attaching debugger to it.
-ARG DELVE_VERSION=v1.21.1
+ARG DELVE_VERSION=v1.23.0
 RUN git fetch -q --depth 1 origin "${DELVE_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS delve-supported


### PR DESCRIPTION
**- What I did**
* Backports https://github.com/moby/moby/pull/48497 to 26.1 branch

**- How I did it**
```
git cherry-pick -xsS 8b0e94ffaf7ea7d42391a3961e795b33976256c9
```

**- How to verify it**
Run dlv in dlv env.

**- Description for the changelog**
```markdown changelog
n/a
```

**- A picture of a cute animal (not mandatory but encouraged)**

