### PR TITLE
dockerd: fix docs, improve validation and improve coverage of "--feature" flag

### DIFF
--- a/internal/opts/opts.go
+++ b/internal/opts/opts.go
@@ -1,6 +1,7 @@
 package opts
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -17,6 +18,9 @@ type SetOpts struct {
 // internal map, by splitting on '='.
 func (opts *SetOpts) Set(value string) error {
 	k, v, found := strings.Cut(value, "=")
+	if k == "" {
+		return errors.New("invalid option name: " + value)
+	}
 	var isSet bool
 	if !found {
 		isSet = true

--- a/internal/opts/opts.go
+++ b/internal/opts/opts.go
@@ -20,7 +20,6 @@ func (opts *SetOpts) Set(value string) error {
 	var isSet bool
 	if !found {
 		isSet = true
-		k = value
 	} else {
 		var err error
 		isSet, err = strconv.ParseBool(v)

--- a/internal/opts/opts_test.go
+++ b/internal/opts/opts_test.go
@@ -14,11 +14,12 @@ func TestSetOpts(t *testing.T) {
 	assert.NilError(t, o.Set("feature-b=true"))
 	assert.NilError(t, o.Set("feature-c=0"))
 	assert.NilError(t, o.Set("feature-d=false"))
+	assert.NilError(t, o.Set("feature-e"))
 
-	expected := "map[feature-a:true feature-b:true feature-c:false feature-d:false]"
+	expected := "map[feature-a:true feature-b:true feature-c:false feature-d:false feature-e:true]"
 	assert.Check(t, is.Equal(expected, o.String()))
 
-	expectedValue := map[string]bool{"feature-a": true, "feature-b": true, "feature-c": false, "feature-d": false}
+	expectedValue := map[string]bool{"feature-a": true, "feature-b": true, "feature-c": false, "feature-d": false, "feature-e": true}
 	assert.Check(t, is.DeepEqual(expectedValue, o.GetAll()))
 
 	err := o.Set("feature=not-a-bool")
@@ -34,11 +35,12 @@ func TestNamedSetOpts(t *testing.T) {
 	assert.NilError(t, o.Set("feature-b=true"))
 	assert.NilError(t, o.Set("feature-c=0"))
 	assert.NilError(t, o.Set("feature-d=false"))
+	assert.NilError(t, o.Set("feature-e"))
 
-	expected := "map[feature-a:true feature-b:true feature-c:false feature-d:false]"
+	expected := "map[feature-a:true feature-b:true feature-c:false feature-d:false feature-e:true]"
 	assert.Check(t, is.Equal(expected, o.String()))
 
-	expectedValue := map[string]bool{"feature-a": true, "feature-b": true, "feature-c": false, "feature-d": false}
+	expectedValue := map[string]bool{"feature-a": true, "feature-b": true, "feature-c": false, "feature-d": false, "feature-e": true}
 	assert.Check(t, is.DeepEqual(expectedValue, o.GetAll()))
 
 	err := o.Set("feature=not-a-bool")

--- a/internal/opts/opts_test.go
+++ b/internal/opts/opts_test.go
@@ -24,6 +24,10 @@ func TestSetOpts(t *testing.T) {
 
 	err := o.Set("feature=not-a-bool")
 	assert.Check(t, is.Error(err, `strconv.ParseBool: parsing "not-a-bool": invalid syntax`))
+	err = o.Set("feature=")
+	assert.Check(t, is.Error(err, `strconv.ParseBool: parsing "": invalid syntax`))
+	err = o.Set("=true")
+	assert.Check(t, is.Error(err, `invalid option name: =true`))
 }
 
 func TestNamedSetOpts(t *testing.T) {
@@ -45,4 +49,8 @@ func TestNamedSetOpts(t *testing.T) {
 
 	err := o.Set("feature=not-a-bool")
 	assert.Check(t, is.Error(err, `strconv.ParseBool: parsing "not-a-bool": invalid syntax`))
+	err = o.Set("feature=")
+	assert.Check(t, is.Error(err, `strconv.ParseBool: parsing "": invalid syntax`))
+	err = o.Set("=true")
+	assert.Check(t, is.Error(err, `invalid option name: =true`))
 }

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -31,7 +31,7 @@ dockerd - Enable daemon mode
 [**--exec-opt**[=*[]*]]
 [**--exec-root**[=*/var/run/docker*]]
 [**--experimental**[=**false**]]
-[**--feature**[=*NAME*=**true**|**false**]
+[**--feature**[=*NAME*[=**true**|**false**]]
 [**--fixed-cidr**[=*FIXED-CIDR*]]
 [**--fixed-cidr-v6**[=*FIXED-CIDR-V6*]]
 [**-G**|**--group**[=*docker*]]
@@ -223,13 +223,13 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
 **--experimental**=""
   Enable the daemon experimental features.
 
-**--feature**=*NAME*=**true**|**false**
+**--feature**=*NAME*[=**true**|**false**]
   Enable or disable a feature in the daemon. This option corresponds
   with the "features" field in the daemon.json configuration file. Using
   both the command-line option and the "features" field in the configuration
   file produces an error. The feature option can be specified multiple times
   to configure multiple features.
-  Usage example: `--feature containerd-snapshotter=true`
+  Usage example: `--feature containerd-snapshotter` or `--feature containerd-snapshotter=true`.
 
 **--fixed-cidr**=""
   IPv4 subnet for fixed IPs (e.g., 10.20.0.0/16); this subnet must be nested in

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -224,7 +224,7 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
   Enable the daemon experimental features.
 
 **--feature**=*NAME*=**true**|**false**
-  Enable or disable feature feature in the daemon. This option corresponds
+  Enable or disable a feature in the daemon. This option corresponds
   with the "features" field in the daemon.json configuration file. Using
   both the command-line option and the "features" field in the configuration
   file produces an error. The feature option can be specified multiple times


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/48486
- follow-up to https://github.com/moby/moby/pull/48167



### man: fix duplicate word in --feature flag description

### man: dockerd: value is optional for --feature flag

The --feature flag allows the boolean value to be omitted. If only a name is provided, the default is "true".


### internal/opts: SetOpts,NamedSetOpts: test for optional value

The value is optional for SetOpts (and NamedSetOpts), and implied "true" when omitted.

This patch adds a test-case for this.

### internal/opts: SetOpts.Set: remove redundant var assignment

### internal/opts: SetOpts: invalidate empty option-names

