### PR TITLE
man: remove docs for deprecated --api-cors-header

### DIFF
--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -7,7 +7,6 @@ dockerd - Enable daemon mode
 **dockerd**
 [**--add-runtime**[=*[]*]]
 [**--allow-nondistributable-artifacts**[=*[]*]]
-[**--api-cors-header**=[=*API-CORS-HEADER*]]
 [**--authorization-plugin**[=*[]*]]
 [**-b**|**--bridge**[=*BRIDGE*]]
 [**--bip**[=*BIP*]]
@@ -136,10 +135,6 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
   and where they can be distributed and shared. Only use this feature to push
   artifacts to private registries and ensure that you are in compliance with
   any terms that cover redistributing nondistributable artifacts.
-
-**--api-cors-header**=""
-  Set CORS headers in the Engine API. Default is cors disabled. Give urls like
-  "http://foo, http://bar, ...". Give "\*" to allow all.
 
 **--authorization-plugin**=""
   Set authorization plugins to load


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/45313
- https://github.com/moby/moby/pull/48209


It was deprecated in 27.0x through 7ea9acc97f4c884ecdaebd06ed0353b28263d118, and removed in ae96ce866f4b3dc09dc4eab019d7725a63623d94.

