### PR TITLE
[25.0 backport] man: dockerd: add description for --log-format option

### DIFF
--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -52,6 +52,7 @@ dockerd - Enable daemon mode
 [**--label**[=*[]*]]
 [**--live-restore**[=**false**]]
 [**--log-driver**[=*json-file*]]
+[**--log-format**="*text*|*json*"]
 [**--log-opt**[=*map[]*]]
 [**--mtu**[=*0*]]
 [**--max-concurrent-downloads**[=*3*]]
@@ -323,6 +324,9 @@ unix://[/path/to/socket] to use.
 **--log-driver**="**json-file**|**syslog**|**journald**|**gelf**|**fluentd**|**awslogs**|**splunk**|**etwlogs**|**gcplogs**|**none**"
   Default driver for container logs. Default is **json-file**.
   **Warning**: **docker logs** command works only for **json-file** logging driver.
+
+**--log-format**="*text*|*json*"
+  Set the format for logs produced by the daemon. Default is "text".
 
 **--log-opt**=[]
   Logging driver specific options.


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/48505

This option was added in a08abec9f8d59eaa44c375900e254384a68c5a31, as part of Docker v25.0, but did not update the docs and manpage.


(cherry picked from commit 45a9dde660b665ab9bd541ec4b2836cc6755864e)

