### PR TITLE
[27.x backport] Only enable bridge netfiltering when needed

### DIFF
--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
-	"os"
-	"os/exec"
 	"strconv"
 	"sync"
 
@@ -480,14 +478,6 @@ func (d *driver) configure(option map[string]interface{}) error {
 		// No GenericData option set. Use defaults.
 	default:
 		return &ErrInvalidDriverConfig{}
-	}
-
-	if config.EnableIPTables || config.EnableIP6Tables {
-		if _, err := os.Stat("/proc/sys/net/bridge"); err != nil {
-			if out, err := exec.Command("modprobe", "-va", "bridge", "br_netfilter").CombinedOutput(); err != nil {
-				log.G(context.TODO()).Warnf("Running modprobe bridge br_netfilter failed with message: %s, error: %v", out, err)
-			}
-		}
 	}
 
 	if config.EnableIPTables {


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/48492

**- What I did**

- fixes https://github.com/moby/moby/issues/48375
- fixes https://github.com/moby/moby/issues/48411

**- How I did it**

Kernel module br_netfilter is loaded when the daemon starts with either iptables or ip6tables enabled. That automatically sets:
```
net.bridge.bridge-nf-call-arptables = 1
net.bridge.bridge-nf-call-ip6tables = 1
net.bridge.bridge-nf-call-iptables = 1
```

So, when:
- docker was running happily with iptables=false, and
- no explicit ip6tables=false, and
- br_netfilter was not loaded

... the change in moby 27.0 to enable ip6tables by default, resulted in `net.bridge.bridge-nf-call-iptables` being enabled, where it wasn't before.

If the host also had a firewall with default-drop on its forward chain - that resulted in packets getting dropped between containers on a bridge network.

So, only try to load br_netfilter when it's needed - it's only needed to implement `--icc=false`, which only works when `iptables` / `ip6tables` are enabled.

**- How to verify it**

- On a freshly booted system (or at-least without `br_netfilter` loaded).
- With iptables/nftables rules set up with a default DROP for forwarding.
- Start dockerd with `"iptables":false`, and `"ip6tables"` left as default.
- Create an IPv4-only network, `docker network create br4`.
- With 26.x:
  - Check that containers on network `br4` can communicate. For example:
  - `docker run --rm -d --name c1 --network br4 nginx; docker run --rm -ti --network br4 alpine wget -O- http://c1`
- Upgrade to 27.x to repro the bug or a build with this fix, re-run the nginx/wget commands.
  - Note that the fix will not work once `br_netfilter` has been loaded, `rmmod br_netfilter` or reboot to get rid of it.
- With this fix:
  - Check that `br_netfilter` hasn't been loaded.
    - For example `sysctl -a | grep net.bridge.bridge-nf-call`.
  - Create a no-icc network...
    - For example `docker network create --ipv6 -o com.docker.network.bridge.enable_icc=false iccf`.
    - Check that `br_netfilter` has been loaded.

**- Description for the changelog**
```markdown changelog
Fix an issue that prevented communication between containers on an IPv4 bridge network
when running with `--iptables=false`, `--ip6tables=true` (the default), a firewall with a
DROP rule for forwarded packets on hosts where the `br_netfilter` kernel module was not
normally loaded.
```
