### PR TITLE
[27.x backport] Do not DNAT packets from WSL2's loopback0

### DIFF
--- a/libnetwork/drivers/bridge/setup_ip_tables_linux.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 
 	"github.com/containerd/log"
@@ -31,6 +32,11 @@ const (
 	IsolationChain1 = "DOCKER-ISOLATION-STAGE-1"
 	IsolationChain2 = "DOCKER-ISOLATION-STAGE-2"
 )
+
+// Path to the executable installed in Linux under WSL2 that reports on
+// WSL config. https://github.com/microsoft/WSL/releases/tag/2.0.4
+// Can be modified by tests.
+var wslinfoPath = "/usr/bin/wslinfo"
 
 func setupIPChains(config configuration, version iptables.IPVersion) (natChain *iptables.ChainInfo, filterChain *iptables.ChainInfo, isolationChain1 *iptables.ChainInfo, isolationChain2 *iptables.ChainInfo, retErr error) {
 	// Sanity check.
@@ -96,6 +102,10 @@ func setupIPChains(config configuration, version iptables.IPVersion) (natChain *
 	}
 
 	if err := iptable.AddReturnRule(IsolationChain2); err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	if err := mirroredWSL2Workaround(config, version); err != nil {
 		return nil, nil, nil, nil, err
 	}
 
@@ -501,4 +511,82 @@ func clearConntrackEntries(nlh *netlink.Handle, ep *bridgeEndpoint) {
 
 	iptables.DeleteConntrackEntries(nlh, ipv4List, ipv6List)
 	iptables.DeleteConntrackEntriesByPort(nlh, types.UDP, udpPorts)
+}
+
+// mirroredWSL2Workaround adds or removes an IPv4 NAT rule, depending on whether
+// docker's host Linux appears to be a guest running under WSL2 in with mirrored
+// mode networking.
+// https://learn.microsoft.com/en-us/windows/wsl/networking#mirrored-mode-networking
+//
+// Without mirrored mode networking, or for a packet sent from Linux, packets
+// sent to 127.0.0.1 are processed as outgoing - they hit the nat-OUTPUT chain,
+// which does not jump to the nat-DOCKER chain because the rule has an exception
+// for "-d 127.0.0.0/8". The default action on the nat-OUTPUT chain is ACCEPT (by
+// default), so the packet is delivered to 127.0.0.1 on lo, where docker-proxy
+// picks it up and acts as a man-in-the-middle; it receives the packet and
+// re-sends it to the container (or acks a SYN and sets up a second TCP
+// connection to the container). So, the container sees packets arrive with a
+// source address belonging to the network's bridge, and it is able to reply to
+// that address.
+//
+// In WSL2's mirrored networking mode, Linux has a loopback0 device as well as lo
+// (which owns 127.0.0.1 as normal). Packets sent to 127.0.0.1 from Windows to a
+// server listening on Linux's 127.0.0.1 are delivered via loopback0, and
+// processed as packets arriving from outside the Linux host (which they are).
+//
+// So, these packets hit the nat-PREROUTING chain instead of nat-OUTPUT. It would
+// normally be impossible for a packet ->127.0.0.1 to arrive from outside the
+// host, so the nat-PREROUTING jump to nat-DOCKER has no exception for it. The
+// packet is processed by a per-bridge DNAT rule in that chain, so it is
+// delivered directly to the container (not via docker-proxy) with source address
+// 127.0.0.1, so the container can't respond.
+//
+// DNAT is normally skipped by RETURN rules in the nat-DOCKER chain for packets
+// arriving from any other bridge network. Similarly, this function adds (or
+// removes) a rule to RETURN early for packets delivered via loopback0 with
+// destination 127.0.0.0/8.
+func mirroredWSL2Workaround(config configuration, ipv iptables.IPVersion) error {
+	// WSL2 does not (currently) support Windows<->Linux communication via ::1.
+	if ipv != iptables.IPv4 {
+		return nil
+	}
+	return programChainRule(mirroredWSL2Rule(), "WSL2 loopback", insertMirroredWSL2Rule(config))
+}
+
+// insertMirroredWSL2Rule returns true if the NAT rule for mirrored WSL2 workaround
+// is required. It is required if:
+//   - the userland proxy is running. If not, there's nothing on the host to catch
+//     the packet, so the loopback0 rule as wouldn't be useful. However, without
+//     the workaround, with improvements in WSL2 v2.3.11, and without userland proxy
+//     running - no workaround is needed, the normal DNAT/masquerading works.
+//   - and, the host Linux appears to be running under Windows WSL2 with mirrored
+//     mode networking. If a loopback0 device exists, and there's an executable at
+//     /usr/bin/wslinfo, infer that this is WSL2 with mirrored networking. ("wslinfo
+//     --networking-mode" reports "mirrored", but applying the workaround for WSL2's
+//     loopback device when it's not needed is low risk, compared with executing
+//     wslinfo with dockerd's elevated permissions.)
+func insertMirroredWSL2Rule(config configuration) bool {
+	if !config.EnableUserlandProxy || config.UserlandProxyPath == "" {
+		return false
+	}
+	if _, err := netlink.LinkByName("loopback0"); err != nil {
+		if !errors.As(err, &netlink.LinkNotFoundError{}) {
+			log.G(context.TODO()).WithError(err).Warn("Failed to check for WSL interface")
+		}
+		return false
+	}
+	stat, err := os.Stat(wslinfoPath)
+	if err != nil {
+		return false
+	}
+	return stat.Mode().IsRegular() && (stat.Mode().Perm()&0111) != 0
+}
+
+func mirroredWSL2Rule() iptRule {
+	return iptRule{
+		ipv:   iptables.IPv4,
+		table: iptables.Nat,
+		chain: DockerChain,
+		args:  []string{"-i", "loopback0", "-d", "127.0.0.0/8", "-j", "RETURN"},
+	}
 }


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/48075

**- What I did**

When running WSL2 with mirrored mode networking, add an iptables rule to skip DNAT for packets arriving on interface loopback0 that are addressed to a localhost address - they're from the Windows host.

- fixes https://github.com/moby/moby/issues/48056
- related to https://github.com/microsoft/WSL/issues/10494

WSL2's mirrored mode networking is [outlined here](https://learn.microsoft.com/en-us/windows/wsl/networking#mirrored-mode-networking).

**- How I did it**

Detect WSL2 mirrored mode by the presence of interface `loopback0`, and (inspired by [this workaround](https://gist.github.com/shigenobuokamoto/b565d468541fc8be7d7d76a0434496a0) linked from the WSL ticket) `/usr/bin/wslinfo --networking-mode` reporting `mirrored`, see [wslinfo release note](https://github.com/microsoft/WSL/releases/tag/2.0.4).

If needed, create a rule in the nat-DOCKER chain to return early for packets arriving on `loopback0` for `127.0.0.0/8`.

There's no IPv6 rule, because WSL2 mirrored mode [doesn't support it](https://learn.microsoft.com/en-us/windows/wsl/networking#mirrored-mode-networking:~:text=IPv6%20localhost%20address%20%3A%3A1%20is%20not%20supported).

**- How to verify it**

As described on the ticket, with docker-ce installed in an instance of Linux (Ubuntu) running under WSL2 with `networkingMode=mirrored`  - run an nginx container with `-p 8080:80`, check that the Windows host can connect to it via `http://localhost:8080`.

Also checked that the new iptables rule is not created unless it's needed.

Access from Linux to a service running on the Windows localhost address worked before and after this change.

(`--userland-proxy=true`, the default, is required for this to work.)

New unit test, just to check the conditions for adding the rule.

**- Description for the changelog**
```markdown changelog
Support WSL2 mirrored-mode networking's use of interface `loopback0` for packets from the Windows host.
```
