### PR TITLE
Fix merge problem

### DIFF
--- a/libnetwork/drivers/bridge/setup_ip_tables_linux.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/internal/nlwrap"
 	"github.com/docker/docker/libnetwork/iptables"
 	"github.com/docker/docker/libnetwork/types"
+	"github.com/vishvananda/netlink"
 )
 
 // DockerChain: DOCKER iptable chain name
@@ -569,7 +570,7 @@ func insertMirroredWSL2Rule(config configuration) bool {
 	if !config.EnableUserlandProxy || config.UserlandProxyPath == "" {
 		return false
 	}
-	if _, err := netlink.LinkByName("loopback0"); err != nil {
+	if _, err := nlwrap.LinkByName("loopback0"); err != nil {
 		if !errors.As(err, &netlink.LinkNotFoundError{}) {
 			log.G(context.TODO()).WithError(err).Warn("Failed to check for WSL interface")
 		}

--- a/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/iptables"
 	"github.com/docker/docker/libnetwork/netlabel"
+	"github.com/vishvananda/netlink"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/48075

**- What I did**

Commit f9c0103 (WSL2 mirrored-mode loopback) uses netlink funcs that were removed/wrapped by commit 00bf437.

(The `vishvananda/netlink` import was removed from `setup_ip_tables_linux.go`, but was still used in the merged WSL2 code.)

**- How I did it**

Fix the merged code.

**- How to verify it**

It compiles.

**- Description for the changelog**
```markdown changelog
n/a
```