### PR TITLE
Releases container layer on docker export

### DIFF
--- a/daemon/images/image_exporter.go
+++ b/daemon/images/image_exporter.go
@@ -25,12 +25,11 @@ func (i *ImageService) PerformWithBaseFS(ctx context.Context, c *container.Conta
 	if err != nil {
 		return err
 	}
+
 	defer func() {
+		err := i.ReleaseLayer(rwlayer)
 		if err != nil {
-			err2 := i.ReleaseLayer(rwlayer)
-			if err2 != nil {
-				log.G(ctx).WithError(err2).WithField("container", c.ID).Warn("Failed to release layer")
-			}
+			log.G(ctx).WithError(err).WithField("container", c.ID).Warn("Failed to release layer")
 		}
 	}()
 
@@ -38,6 +37,8 @@ func (i *ImageService) PerformWithBaseFS(ctx context.Context, c *container.Conta
 	if err != nil {
 		return err
 	}
+
+	defer rwlayer.Unmount()
 
 	return fn(basefs)
 }


### PR DESCRIPTION
**Fixes**: https://github.com/moby/moby/issues/48516

**- What I did**

Remove the error check so the layer is always released.

**- How I did it**

As per the [last commit](https://github.com/moby/moby/commit/06619763a25b3f651c198baaebbd5f01a2315976#diff-bd62c107e1a6fdb3e40fc8a184fd025f3420669d393d47416d704729d2fd52b0
) to this file, it seems that previously the layer was always released (in case of error or not).

The current behavior only releases the layer in case of error.
Also I'm concerned about the `rwlayer.Unmount()` which is not done now on errors, but I really
don't know the implications.

**- How to verify it**

~~~bash
root@docker-dev:~# docker info --format='{{json .}}' | jq -Mr '.ServerVersion'
dev

root@docker-dev:~# systemctl stop docker
Warning: Stopping docker.service, but it can still be activated by:
  docker.socket
root@docker-dev:~# rm -r /var/lib/docker
root@docker-dev:~# systemctl start docker

root@docker-dev:~# du -shx /var/lib/docker/overlay2
8.0K    /var/lib/docker/overlay2

root@docker-dev:~# docker pull redis:7.4.0
7.4.0: Pulling from library/redis
a2318d6c47ec: Pull complete
ed7fd66f27f2: Pull complete
410a3d5b3155: Pull complete
9312cf3f6b3e: Pull complete
c39877ab23d0: Pull complete
01394ffc7248: Pull complete
4f4fb700ef54: Pull complete
5a03cb6163ab: Pull complete
Digest: sha256:eadf354977d428e347d93046bb1a5569d701e8deb68f090215534a99dbcb23b9
Status: Downloaded newer image for redis:7.4.0
docker.io/library/redis:7.4.0

root@docker-dev:~# du -shx /var/lib/docker/overlay2
122M    /var/lib/docker/overlay2

root@docker-dev:~# docker create --name test redis:7.4.0
a28b4d9d9328c6d1682e55d7e931870a50522f12c18954eed2ceb35563db9723
root@docker-dev:~# docker export test --output="/tmp/test.tar"
root@docker-dev:~# docker rm test
test
root@docker-dev:~# docker rmi redis:7.4.0
Untagged: redis:7.4.0
Untagged: redis@sha256:eadf354977d428e347d93046bb1a5569d701e8deb68f090215534a99dbcb23b9
Deleted: sha256:590b81f2fea1af9798db4580a6299dafba020c2f5dc7d8d734663e7fa5299ca0
Deleted: sha256:34091e3dcc5223209fe41f1ac689e012032858d081488c15137b8555d63b9818
Deleted: sha256:c4609e7a6099bef7542d93d7b72da926542a48e5a1334d8cbdd014e723d03093
Deleted: sha256:60a5ffcecb4cf73a6ab04a27740bae0122da7771482b784b48656ec7ca58b762
Deleted: sha256:9588e7fd68e322f74150da182b43a865cdcdb7a815e596da2ed5eb72a5b94f23
Deleted: sha256:4ab98545f740fb1eb1395a180fcf2e74f36a39cffa27b83ac35bf4f3f9f1b24b
Deleted: sha256:2df51a972858377a46db224abba6b0ba780a81f9be25b0a1e55ba72ec15f6365
Deleted: sha256:6a37f9e6c319837a554a53039ae0ace140c034812df571d9ddf864f446427cab
Deleted: sha256:8e2ab394fabf557b00041a8f080b10b4e91c7027b7c174f095332c7ebb6501cb

root@docker-dev:~# du -shx /var/lib/docker/overlay2
8.0K    /var/lib/docker/overlay2
root@docker-dev:~# ls -la /var/lib/docker/overlay2/
total 12
drwx--x---  3 root root 4096 Sep 17 09:05 .
drwx--x--- 12 root root 4096 Sep 17 09:04 ..
drwx------  2 root root 4096 Sep 17 09:05 l
~~~


**- Description for the changelog**

```markdown changelog
Fix `docker export` not releasing the container's writable layer after a failure.
```

**- A picture of a cute animal (not mandatory but encouraged)**

<img src="https://github.com/user-attachments/assets/3134eb00-5e34-44a4-ac81-18d4f9ea2e09" width="512">

