### PR TITLE
gha: govulncheck: make sure read permissions are set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,8 @@ jobs:
     permissions:
       # required to write sarif report
       security-events: write
+      # required to check out the repository
+      contents: read
     steps:
       -
         name: Checkout


### PR DESCRIPTION
- relates to https://github.com/moby/buildkit/pull/5326
- relates to https://github.com/moby/moby/pull/48311

If any permission is set, any permission not included in the list is implicitly set to "none".

see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

The govulncheck check need read permissions, which is not problematic for public repositories, but may be needed when running in a private fork (such as those used for security releases).


