### PR TITLE
daemon: add IPv6 loopback as insecure registry

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6005,7 +6005,7 @@ definitions:
           accept un-encrypted (HTTP) and/or untrusted (HTTPS with certificates
           from unknown CAs) communication.
 
-          By default, local registries (`127.0.0.0/8`) are configured as
+          By default, local registries (`::1/128` and `127.0.0.0/8`) are configured as
           insecure. All other registries are secure. Communicating with an
           insecure registry is not possible if the daemon assumes that registry
           is secure.

--- a/daemon/reload_test.go
+++ b/daemon/reload_test.go
@@ -82,6 +82,7 @@ func TestDaemonReloadAllowNondistributableArtifacts(t *testing.T) {
 	}
 
 	registries := []string{
+		"::1/128",
 		"127.0.0.0/8",
 		"10.10.1.11:5000",
 		"10.10.1.33:5000", // This will be added during reload.
@@ -225,6 +226,7 @@ func TestDaemonReloadInsecureRegistries(t *testing.T) {
 	// initialize daemon with existing insecure registries: "127.0.0.0/8", "10.10.1.11:5000", "10.10.1.22:5000"
 	daemon.registryService, err = registry.NewService(registry.ServiceOptions{
 		InsecureRegistries: []string{
+			"::1/128",
 			"127.0.0.0/8",
 			"10.10.1.11:5000",
 			"10.10.1.22:5000", // this will be removed when reloading
@@ -237,6 +239,7 @@ func TestDaemonReloadInsecureRegistries(t *testing.T) {
 	}
 
 	insecureRegistries := []string{
+		"::1/128",             // this will be kept
 		"127.0.0.0/8",         // this will be kept
 		"10.10.1.11:5000",     // this will be kept
 		"10.10.1.33:5000",     // this will be newly added

--- a/integration/system/info_test.go
+++ b/integration/system/info_test.go
@@ -101,12 +101,14 @@ func TestInfoInsecureRegistries(t *testing.T) {
 	defer d.Stop(t)
 
 	info := d.Info(t)
-	assert.Assert(t, is.Len(info.RegistryConfig.InsecureRegistryCIDRs, 2))
+	assert.Assert(t, is.Len(info.RegistryConfig.InsecureRegistryCIDRs, 3))
 	cidrs := []string{
 		info.RegistryConfig.InsecureRegistryCIDRs[0].String(),
 		info.RegistryConfig.InsecureRegistryCIDRs[1].String(),
+		info.RegistryConfig.InsecureRegistryCIDRs[2].String(),
 	}
 	assert.Assert(t, is.Contains(cidrs, registryCIDR))
+	assert.Assert(t, is.Contains(cidrs, "::1/128"))
 	assert.Assert(t, is.Contains(cidrs, "127.0.0.0/8"))
 	assert.DeepEqual(t, *info.RegistryConfig.IndexConfigs["docker.io"], registry.IndexInfo{Name: "docker.io", Mirrors: []string{}, Secure: true, Official: true})
 	assert.DeepEqual(t, *info.RegistryConfig.IndexConfigs[registryHost], registry.IndexInfo{Name: registryHost, Mirrors: []string{}, Secure: false, Official: false})

--- a/registry/config.go
+++ b/registry/config.go
@@ -184,7 +184,7 @@ func (config *serviceConfig) loadMirrors(mirrors []string) error {
 func (config *serviceConfig) loadInsecureRegistries(registries []string) error {
 	// Localhost is by default considered as an insecure registry. This is a
 	// stop-gap for people who are running a private registry on localhost.
-	registries = append(registries, "127.0.0.0/8")
+	registries = append(registries, "::1/128", "127.0.0.0/8")
 
 	var (
 		insecureRegistryCIDRs = make([]*registry.NetIPNet, 0)


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/9124
- https://github.com/moby/moby/pull/9100
- also slightly related to, where I noticed it was not in the default list 😂 https://github.com/moby/moby/issues/39033#issuecomment-2368373695


commit 11380a109e53bc5f388b6212c12794609c0241eb updated the daemon to always treat 127.0.0.1 as insecure for all cases anytime anywhere. This was initially a hard-coded list, but later made configurable to allow the user to mark additional CIDRs or registries as insecure in 6aba75db4e7b0151aeb48f450bb43e659ce0ec82.

This patch expands the default list of insecure registries to also include the IPv6 loopback-address (::1); IPv6, unlike IPv4 only has a single loopback address (::1/128).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
daemon: add IPv6 loopback address as insecure registry by default
```

**- A picture of a cute animal (not mandatory but encouraged)**

