### PR TITLE
integration: Add tests for port mappings

### DIFF
--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -3,8 +3,6 @@ package networking
 import (
 	"context"
 	"fmt"
-	"net"
-	"net/http"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -16,11 +14,9 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/integration/internal/network"
-	"github.com/docker/docker/libnetwork/drivers/bridge"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
-	"github.com/docker/go-connections/nat"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -837,163 +833,4 @@ func TestSetEndpointSysctl(t *testing.T) {
 			})
 		}
 	}
-}
-
-func TestDisableNAT(t *testing.T) {
-	ctx := setupTest(t)
-	d := daemon.New(t)
-	d.StartWithBusybox(ctx, t)
-	defer d.Stop(t)
-
-	c := d.NewClientT(t)
-	defer c.Close()
-
-	testcases := []struct {
-		name       string
-		gwMode4    string
-		gwMode6    string
-		expPortMap nat.PortMap
-	}{
-		{
-			name: "defaults",
-			expPortMap: nat.PortMap{
-				"80/tcp": []nat.PortBinding{
-					{HostIP: "0.0.0.0", HostPort: "8080"},
-					{HostIP: "::", HostPort: "8080"},
-				},
-			},
-		},
-		{
-			name:    "nat4 routed6",
-			gwMode4: "nat",
-			gwMode6: "routed",
-			expPortMap: nat.PortMap{
-				"80/tcp": []nat.PortBinding{
-					{HostIP: "0.0.0.0", HostPort: "8080"},
-					{HostIP: "::", HostPort: ""},
-				},
-			},
-		},
-		{
-			name:    "nat6 routed4",
-			gwMode4: "routed",
-			gwMode6: "nat",
-			expPortMap: nat.PortMap{
-				"80/tcp": []nat.PortBinding{
-					{HostIP: "0.0.0.0", HostPort: ""},
-					{HostIP: "::", HostPort: "8080"},
-				},
-			},
-		},
-	}
-
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := testutil.StartSpan(ctx, t)
-
-			const netName = "testnet"
-			nwOpts := []func(options *networktypes.CreateOptions){
-				network.WithIPv6(),
-				network.WithIPAM("fd2a:a2c3:4448::/64", "fd2a:a2c3:4448::1"),
-			}
-			if tc.gwMode4 != "" {
-				nwOpts = append(nwOpts, network.WithOption(bridge.IPv4GatewayMode, tc.gwMode4))
-			}
-			if tc.gwMode6 != "" {
-				nwOpts = append(nwOpts, network.WithOption(bridge.IPv6GatewayMode, tc.gwMode6))
-			}
-			network.CreateNoError(ctx, t, c, netName, nwOpts...)
-			defer network.RemoveNoError(ctx, t, c, netName)
-
-			id := container.Run(ctx, t, c,
-				container.WithNetworkMode(netName),
-				container.WithExposedPorts("80/tcp"),
-				container.WithPortMap(nat.PortMap{"80/tcp": {{HostPort: "8080"}}}),
-			)
-			defer c.ContainerRemove(ctx, id, containertypes.RemoveOptions{Force: true})
-
-			inspect := container.Inspect(ctx, t, c, id)
-			assert.Check(t, is.DeepEqual(inspect.NetworkSettings.Ports, tc.expPortMap))
-		})
-	}
-}
-
-// Check that a container on one network can reach a service in a container on
-// another network, via a mapped port on the host.
-func TestPortMappedHairpin(t *testing.T) {
-	skip.If(t, testEnv.IsRootless)
-
-	ctx := setupTest(t)
-	d := daemon.New(t)
-	d.StartWithBusybox(ctx, t)
-	defer d.Stop(t)
-	c := d.NewClientT(t)
-	defer c.Close()
-
-	// Find an address on the test host.
-	conn, err := net.Dial("tcp4", "hub.docker.com:80")
-	assert.NilError(t, err)
-	hostAddr := conn.LocalAddr().(*net.TCPAddr).IP.String()
-	conn.Close()
-
-	const serverNetName = "servernet"
-	network.CreateNoError(ctx, t, c, serverNetName)
-	defer network.RemoveNoError(ctx, t, c, serverNetName)
-	const clientNetName = "clientnet"
-	network.CreateNoError(ctx, t, c, clientNetName)
-	defer network.RemoveNoError(ctx, t, c, clientNetName)
-
-	serverId := container.Run(ctx, t, c,
-		container.WithNetworkMode(serverNetName),
-		container.WithExposedPorts("80"),
-		container.WithPortMap(nat.PortMap{"80": {{HostIP: "0.0.0.0"}}}),
-		container.WithCmd("httpd", "-f"),
-	)
-	defer c.ContainerRemove(ctx, serverId, containertypes.RemoveOptions{Force: true})
-
-	inspect := container.Inspect(ctx, t, c, serverId)
-	hostPort := inspect.NetworkSettings.Ports["80/tcp"][0].HostPort
-
-	clientCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	res := container.RunAttach(clientCtx, t, c,
-		container.WithNetworkMode(clientNetName),
-		container.WithCmd("wget", "http://"+hostAddr+":"+hostPort),
-	)
-	defer c.ContainerRemove(ctx, res.ContainerID, containertypes.RemoveOptions{Force: true})
-	assert.Check(t, is.Contains(res.Stderr.String(), "404 Not Found"))
-}
-
-// Check that a container on an IPv4-only network can have a port mapping
-// from a specific IPv6 host address (using docker-proxy).
-// Regression test for https://github.com/moby/moby/issues/48067 (which
-// is about incorrectly reporting this as invalid config).
-func TestProxy4To6(t *testing.T) {
-	skip.If(t, testEnv.IsRootless)
-
-	ctx := setupTest(t)
-	d := daemon.New(t)
-	d.StartWithBusybox(ctx, t)
-	defer d.Stop(t)
-
-	c := d.NewClientT(t)
-	defer c.Close()
-
-	const netName = "ipv4net"
-	network.CreateNoError(ctx, t, c, netName)
-
-	serverId := container.Run(ctx, t, c,
-		container.WithNetworkMode(netName),
-		container.WithExposedPorts("80"),
-		container.WithPortMap(nat.PortMap{"80": {{HostIP: "::1"}}}),
-		container.WithCmd("httpd", "-f"),
-	)
-	defer c.ContainerRemove(ctx, serverId, containertypes.RemoveOptions{Force: true})
-
-	inspect := container.Inspect(ctx, t, c, serverId)
-	hostPort := inspect.NetworkSettings.Ports["80/tcp"][0].HostPort
-
-	resp, err := http.Get("http://[::1]:" + hostPort)
-	assert.NilError(t, err)
-	assert.Check(t, is.Equal(resp.StatusCode, 404))
 }

--- a/integration/networking/port_mapping_linux_test.go
+++ b/integration/networking/port_mapping_linux_test.go
@@ -1,0 +1,180 @@
+package networking
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	containertypes "github.com/docker/docker/api/types/container"
+	networktypes "github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/integration/internal/network"
+	"github.com/docker/docker/libnetwork/drivers/bridge"
+	"github.com/docker/docker/testutil"
+	"github.com/docker/docker/testutil/daemon"
+	"github.com/docker/go-connections/nat"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/skip"
+)
+
+func TestDisableNAT(t *testing.T) {
+	ctx := setupTest(t)
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t)
+	defer d.Stop(t)
+
+	c := d.NewClientT(t)
+	defer c.Close()
+
+	testcases := []struct {
+		name       string
+		gwMode4    string
+		gwMode6    string
+		expPortMap nat.PortMap
+	}{
+		{
+			name: "defaults",
+			expPortMap: nat.PortMap{
+				"80/tcp": []nat.PortBinding{
+					{HostIP: "0.0.0.0", HostPort: "8080"},
+					{HostIP: "::", HostPort: "8080"},
+				},
+			},
+		},
+		{
+			name:    "nat4 routed6",
+			gwMode4: "nat",
+			gwMode6: "routed",
+			expPortMap: nat.PortMap{
+				"80/tcp": []nat.PortBinding{
+					{HostIP: "0.0.0.0", HostPort: "8080"},
+					{HostIP: "::", HostPort: ""},
+				},
+			},
+		},
+		{
+			name:    "nat6 routed4",
+			gwMode4: "routed",
+			gwMode6: "nat",
+			expPortMap: nat.PortMap{
+				"80/tcp": []nat.PortBinding{
+					{HostIP: "0.0.0.0", HostPort: ""},
+					{HostIP: "::", HostPort: "8080"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testutil.StartSpan(ctx, t)
+
+			const netName = "testnet"
+			nwOpts := []func(options *networktypes.CreateOptions){
+				network.WithIPv6(),
+				network.WithIPAM("fd2a:a2c3:4448::/64", "fd2a:a2c3:4448::1"),
+			}
+			if tc.gwMode4 != "" {
+				nwOpts = append(nwOpts, network.WithOption(bridge.IPv4GatewayMode, tc.gwMode4))
+			}
+			if tc.gwMode6 != "" {
+				nwOpts = append(nwOpts, network.WithOption(bridge.IPv6GatewayMode, tc.gwMode6))
+			}
+			network.CreateNoError(ctx, t, c, netName, nwOpts...)
+			defer network.RemoveNoError(ctx, t, c, netName)
+
+			id := container.Run(ctx, t, c,
+				container.WithNetworkMode(netName),
+				container.WithExposedPorts("80/tcp"),
+				container.WithPortMap(nat.PortMap{"80/tcp": {{HostPort: "8080"}}}),
+			)
+			defer c.ContainerRemove(ctx, id, containertypes.RemoveOptions{Force: true})
+
+			inspect := container.Inspect(ctx, t, c, id)
+			assert.Check(t, is.DeepEqual(inspect.NetworkSettings.Ports, tc.expPortMap))
+		})
+	}
+}
+
+// Check that a container on one network can reach a service in a container on
+// another network, via a mapped port on the host.
+func TestPortMappedHairpin(t *testing.T) {
+	skip.If(t, testEnv.IsRootless)
+
+	ctx := setupTest(t)
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t)
+	defer d.Stop(t)
+	c := d.NewClientT(t)
+	defer c.Close()
+
+	// Find an address on the test host.
+	conn, err := net.Dial("tcp4", "hub.docker.com:80")
+	assert.NilError(t, err)
+	hostAddr := conn.LocalAddr().(*net.TCPAddr).IP.String()
+	conn.Close()
+
+	const serverNetName = "servernet"
+	network.CreateNoError(ctx, t, c, serverNetName)
+	defer network.RemoveNoError(ctx, t, c, serverNetName)
+	const clientNetName = "clientnet"
+	network.CreateNoError(ctx, t, c, clientNetName)
+	defer network.RemoveNoError(ctx, t, c, clientNetName)
+
+	serverId := container.Run(ctx, t, c,
+		container.WithNetworkMode(serverNetName),
+		container.WithExposedPorts("80"),
+		container.WithPortMap(nat.PortMap{"80": {{HostIP: "0.0.0.0"}}}),
+		container.WithCmd("httpd", "-f"),
+	)
+	defer c.ContainerRemove(ctx, serverId, containertypes.RemoveOptions{Force: true})
+
+	inspect := container.Inspect(ctx, t, c, serverId)
+	hostPort := inspect.NetworkSettings.Ports["80/tcp"][0].HostPort
+
+	clientCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	res := container.RunAttach(clientCtx, t, c,
+		container.WithNetworkMode(clientNetName),
+		container.WithCmd("wget", "http://"+hostAddr+":"+hostPort),
+	)
+	defer c.ContainerRemove(ctx, res.ContainerID, containertypes.RemoveOptions{Force: true})
+	assert.Check(t, is.Contains(res.Stderr.String(), "404 Not Found"))
+}
+
+// Check that a container on an IPv4-only network can have a port mapping
+// from a specific IPv6 host address (using docker-proxy).
+// Regression test for https://github.com/moby/moby/issues/48067 (which
+// is about incorrectly reporting this as invalid config).
+func TestProxy4To6(t *testing.T) {
+	skip.If(t, testEnv.IsRootless)
+
+	ctx := setupTest(t)
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t)
+	defer d.Stop(t)
+
+	c := d.NewClientT(t)
+	defer c.Close()
+
+	const netName = "ipv4net"
+	network.CreateNoError(ctx, t, c, netName)
+
+	serverId := container.Run(ctx, t, c,
+		container.WithNetworkMode(netName),
+		container.WithExposedPorts("80"),
+		container.WithPortMap(nat.PortMap{"80": {{HostIP: "::1"}}}),
+		container.WithCmd("httpd", "-f"),
+	)
+	defer c.ContainerRemove(ctx, serverId, containertypes.RemoveOptions{Force: true})
+
+	inspect := container.Inspect(ctx, t, c, serverId)
+	hostPort := inspect.NetworkSettings.Ports["80/tcp"][0].HostPort
+
+	resp, err := http.Get("http://[::1]:" + hostPort)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(resp.StatusCode, 404))
+}

--- a/internal/testutils/networking/l3_segment_linux.go
+++ b/internal/testutils/networking/l3_segment_linux.go
@@ -1,0 +1,160 @@
+package networking
+
+import (
+	"bytes"
+	"net/netip"
+	"os/exec"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/vishvananda/netns"
+)
+
+// CurrentNetns can be passed to L3Segment.AddHost to indicate that the
+// host lives in the current network namespace (eg. where dockerd runs).
+const CurrentNetns = ""
+
+func runCommand(t *testing.T, cmd string, args ...string) {
+	t.Log(strings.Join(append([]string{cmd}, args...), " "))
+
+	var b bytes.Buffer
+	c := exec.Command(cmd, args...)
+	c.Stdout = &b
+	c.Stderr = &b
+	err := c.Run()
+	if err != nil {
+		t.Log(b.String())
+		t.Fatalf("Error: %v", err)
+	}
+}
+
+// L3Segment simulates a switched, dual-stack capable network that
+// interconnects multiple hosts running in their own network namespace.
+type L3Segment struct {
+	Hosts  map[string]Host
+	bridge Host
+}
+
+// NewL3Segment creates a new L3Segment. The bridge interface interconnecting
+// all the hosts is created in a new network namespace named nsName and it's
+// assigned one or more IP addresses. Those need to be unmasked netip.Prefix.
+func NewL3Segment(t *testing.T, nsName string, addrs ...netip.Prefix) *L3Segment {
+	t.Helper()
+
+	l3 := &L3Segment{
+		Hosts: map[string]Host{},
+	}
+
+	l3.bridge = newHost(t, nsName, "br0")
+	defer func() {
+		if t.Failed() {
+			l3.Destroy(t)
+		}
+	}()
+
+	l3.bridge.Run(t, "ip", "link", "add", l3.bridge.Iface, "type", "bridge")
+	for _, addr := range addrs {
+		l3.bridge.Run(t, "ip", "addr", "add", addr.String(), "dev", l3.bridge.Iface, "nodad")
+		l3.bridge.Run(t, "ip", "link", "set", l3.bridge.Iface, "up")
+	}
+
+	return l3
+}
+
+func (l3 *L3Segment) AddHost(t *testing.T, hostname, nsName, ifname string, addrs ...netip.Prefix) {
+	t.Helper()
+
+	if len(hostname) >= syscall.IFNAMSIZ {
+		// hostname is reused as the name for the veth interface added to the
+		// bridge. Hence, it needs to be shorter than ifnamsiz.
+		t.Fatalf("hostname too long")
+	}
+
+	host := newHost(t, nsName, ifname)
+	l3.Hosts[hostname] = host
+
+	host.Run(t, "ip", "link", "add", hostname, "netns", l3.bridge.ns, "type", "veth", "peer", "name", host.Iface)
+	l3.bridge.Run(t, "ip", "link", "set", hostname, "up", "master", l3.bridge.Iface)
+	host.Run(t, "ip", "link", "set", host.Iface, "up")
+
+	for _, addr := range addrs {
+		host.Run(t, "ip", "addr", "add", addr.String(), "dev", host.Iface, "nodad")
+	}
+}
+
+func (l3 *L3Segment) Destroy(t *testing.T) {
+	for _, host := range l3.Hosts {
+		host.Destroy(t)
+	}
+	l3.bridge.Destroy(t)
+}
+
+type Host struct {
+	Iface string // Iface is the interface name in the host network namespace.
+	ns    string // ns is the network namespace name.
+}
+
+func newHost(t *testing.T, nsName, ifname string) Host {
+	t.Helper()
+
+	if len(ifname) >= syscall.IFNAMSIZ {
+		t.Fatalf("ifname too long")
+	}
+
+	if nsName != CurrentNetns {
+		runCommand(t, "ip", "netns", "add", nsName)
+	}
+
+	return Host{
+		Iface: ifname,
+		ns:    nsName,
+	}
+}
+
+// Run executes the provided command in the host's network namespace.
+func (h Host) Run(t *testing.T, cmd string, args ...string) {
+	t.Helper()
+
+	if h.ns != CurrentNetns {
+		args = append([]string{"netns", "exec", h.ns, cmd}, args...)
+		cmd = "ip"
+	}
+	runCommand(t, cmd, args...)
+}
+
+// Do run the provided function in the host's network namespace.
+func (h Host) Do(t *testing.T, fn func()) {
+	t.Helper()
+
+	targetNs, err := netns.GetFromName(h.ns)
+	if err != nil {
+		t.Fatalf("failed to get netns handle: %v", err)
+	}
+	defer targetNs.Close()
+
+	origNs, err := netns.Get()
+	if err != nil {
+		t.Fatalf("failed to get current netns: %v", err)
+	}
+	defer origNs.Close()
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	if err := netns.Set(targetNs); err != nil {
+		t.Fatalf("failed to enter netns: %v", err)
+	}
+	defer netns.Set(origNs)
+
+	fn()
+}
+
+func (h Host) Destroy(t *testing.T) {
+	t.Helper()
+
+	if h.ns != CurrentNetns {
+		runCommand(t, "ip", "netns", "delete", h.ns)
+	}
+}


### PR DESCRIPTION
**- What I did**

Introduce new integration tests that ensure port mappings are correctly accessible from the host, and from a remote host. This is another attempt at upstreaming some of the tests introduced in:

- https://github.com/moby/moby/pull/45850

These tests should help ensure nothing breaks when we'll modify iptables rules, or when we'll add nftables support.

**- How I did it**

I added a new `L3Segment` struct that simulates (using netns) a LAN segment where arbitrary `Host`s live. That's what makes `TestAccessPublishedPortFromRemoteHost` possible.

That specific test simulates two hosts: one is the 'current' netns where the daemon-under-test and the tests themselves are executed. The other is the 'remote host'. Each host gets a pair of veth. A third network namespace is used to isolate the bridge from any network programming the engine does.

To create all these objects (netns, veth, etc...), simple iproute2 invocations are made. The previous attempt was using netlink calls, which was an horrendously bad idea since there was no way to recreate the same env for manual debugging. All iproute2 invocations are logged, so now it's just a matter of copy / pasting logs into a shell script, tidying them up a bit, and then running the script.

The `L3Segment` struct has one important method: `AddHost`.

And `Host` has two important methods:

- `Run`, which runs a command in the host's netns. That command is logged too.
- `Do`, which runs a callback in the host's netns.

Both `Host`s and `L3Segment` can take any number of IP addrs, making it easy to test v4/v6-only, as well as, dual-stack scenarios in one go.

This should be enough to cover all use-cases.

**- How to verify it**

CI is green.
