### PR TITLE
daemon/exec: don't overwrite exit code if set

### DIFF
--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -183,8 +183,12 @@ func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, optio
 			ec.Lock()
 			ec.Container.ExecCommands.Delete(ec.ID)
 			ec.Running = false
-			exitCode := 126
-			ec.ExitCode = &exitCode
+			if ec.ExitCode == nil {
+				// default to `126` (`EACCES`) if we fail to start
+				// the exec without setting an exit code.
+				exitCode := exitEaccess
+				ec.ExitCode = &exitCode
+			}
 			if err := ec.CloseStreams(); err != nil {
 				log.G(ctx).Errorf("failed to cleanup exec %s streams: %s", ec.Container.ID, err)
 			}

--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -25,6 +25,9 @@ fi
 # TODO(vvoland): re-enable after https://github.com/docker/docker-py/pull/3203 is included in the DOCKER_PY_COMMIT release.
 PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/api_image_test.py::CommitTest::test_commit"
 PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/api_image_test.py::CommitTest::test_commit_with_changes"
+
+# TODO(laurazard): re-enable after https://github.com/docker/docker-py/pull/3290 is included in the DOCKER_PY_COMMIT release.
+PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/models_containers_test.py::ContainerTest::test_exec_run_failed"
 (
 	bundle .integration-daemon-start
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Related: https://github.com/moby/moby/issues/45795

If an exec fails to start, the code in this deferred block sets the exit code `126` (it wasn't possible to start the exec): https://github.com/moby/moby/blob/c7e42d855ec41c28702a1f6f6c2c28ecc7bd9424/daemon/exec.go#L181-L193

However, if we get far enough along attempting to start the exec, we also set the exit code from the error returned trying to start the exec: https://github.com/moby/moby/blob/c7e42d855ec41c28702a1f6f6c2c28ecc7bd9424/daemon/exec.go#L288-L291

For some situations (such as when the containers cmd/executable can't be found), the 2nd block returns the correct exit code (`127`) – https://github.com/moby/moby/blob/c7e42d855ec41c28702a1f6f6c2c28ecc7bd9424/daemon/errors.go#L164-L170

But then that error code is overwritten by 1st deferred block with `126`.

**- How I did it**

Change https://github.com/laurazard/moby/blob/c866a7e5f8caa882641cbba59102f457221314dc/daemon/exec.go#L181-L197 to in order to only set `126` if an error code has not already been set.

This change does not prevent the race between the deferred block locking/deleting the exec and setting the exit code race with `daemon.ProcessEvent`, if containerd publishes an exit event – I think that requires a more significant refactor of `daemon.ContainerExecStart` to split out the error handling for "pre-trying-to-start-the-exec" and "actually-started-the-exec". In the latter, we should set the error code explicitly and make sure to sync with `daemon.ProcessEvent`.

**- How to verify it**

```console
make TEST_FILTER=TestExecExitCode TEST_IGNORE_CGROUP_CHECK=1 test-integration
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

