### PR TITLE
client.ContainerCreate: use container.CreateRequest instead of local type

### DIFF
--- a/client/container_create.go
+++ b/client/container_create.go
@@ -12,12 +12,6 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-type configWrapper struct {
-	*container.Config
-	HostConfig       *container.HostConfig
-	NetworkingConfig *network.NetworkingConfig
-}
-
 // ContainerCreate creates a new container based on the given configuration.
 // It can be associated with a name, but it's not mandatory.
 func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
@@ -74,7 +68,7 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 		query.Set("name", containerName)
 	}
 
-	body := configWrapper{
+	body := container.CreateRequest{
 		Config:           config,
 		HostConfig:       hostConfig,
 		NetworkingConfig: networkingConfig,

--- a/client/container_create_test.go
+++ b/client/container_create_test.go
@@ -77,7 +77,7 @@ func TestContainerCreateWithName(t *testing.T) {
 func TestContainerCreateAutoRemove(t *testing.T) {
 	autoRemoveValidator := func(expectedValue bool) func(req *http.Request) (*http.Response, error) {
 		return func(req *http.Request) (*http.Response, error) {
-			var config configWrapper
+			var config container.CreateRequest
 
 			if err := json.NewDecoder(req.Body).Decode(&config); err != nil {
 				return nil, err


### PR DESCRIPTION
This function used a locally defined `configWrapper`, which was identical to the `container.CreateRequest`, with the exception of `CreateRequest` defining `omitempty` for HostConfig and NetworkingConfig, but this should not impact our use as the same type is used to handle the request on the daemon side.


