### PR TITLE
runconfig: validateNetContainerMode: simplify validation

### DIFF
--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -1,42 +1,42 @@
 package runconfig // import "github.com/docker/docker/runconfig"
 
 import (
-	"strings"
-
 	"github.com/docker/docker/api/types/container"
 )
 
 // validateNetContainerMode ensures that the various combinations of requested
 // network settings wrt container mode are valid.
 func validateNetContainerMode(c *container.Config, hc *container.HostConfig) error {
-	parts := strings.Split(string(hc.NetworkMode), ":")
-	if parts[0] == "container" {
-		if len(parts) < 2 || parts[1] == "" {
-			return validationError("Invalid network mode: invalid container format container:<name|id>")
-		}
+	// FIXME(thaJeztah): a network named "container" (without colon) is not seen as "container-mode" network.
+	if string(hc.NetworkMode) != "container" && !hc.NetworkMode.IsContainer() {
+		return nil
 	}
 
-	if hc.NetworkMode.IsContainer() && c.Hostname != "" {
+	if hc.NetworkMode.ConnectedContainer() == "" {
+		return validationError("Invalid network mode: invalid container format container:<name|id>")
+	}
+
+	if c.Hostname != "" {
 		return ErrConflictNetworkHostname
 	}
 
-	if hc.NetworkMode.IsContainer() && len(hc.Links) > 0 {
+	if len(hc.Links) > 0 {
 		return ErrConflictContainerNetworkAndLinks
 	}
 
-	if hc.NetworkMode.IsContainer() && len(hc.DNS) > 0 {
+	if len(hc.DNS) > 0 {
 		return ErrConflictNetworkAndDNS
 	}
 
-	if hc.NetworkMode.IsContainer() && len(hc.ExtraHosts) > 0 {
+	if len(hc.ExtraHosts) > 0 {
 		return ErrConflictNetworkHosts
 	}
 
-	if hc.NetworkMode.IsContainer() && (len(hc.PortBindings) > 0 || hc.PublishAllPorts) {
+	if len(hc.PortBindings) > 0 || hc.PublishAllPorts {
 		return ErrConflictNetworkPublishPorts
 	}
 
-	if hc.NetworkMode.IsContainer() && len(c.ExposedPorts) > 0 {
+	if len(c.ExposedPorts) > 0 {
 		return ErrConflictNetworkExposePorts
 	}
 	return nil


### PR DESCRIPTION
- use an early return if we're not using container-mode, instead of checking multiple times
- use ConnectedContainer() method to check if a container is specified


