### PR TITLE
api: info: omit deprecated "Commit.Expected" fields on API >= 1.49

### DIFF
--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -116,11 +116,13 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 			info.FirewallBackend = nil
 		}
 
-		// TODO(thaJeztah): Expected commits are deprecated, and should no longer be set in API 1.49.
-		info.ContainerdCommit.Expected = info.ContainerdCommit.ID //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.49.
-		info.RuncCommit.Expected = info.RuncCommit.ID             //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.49.
-		info.InitCommit.Expected = info.InitCommit.ID             //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.49.
-
+		if versions.LessThan(version, "1.49") {
+			// Expected commits are omitted in API 1.49, but should still be
+			// included in older versions.
+			info.ContainerdCommit.Expected = info.ContainerdCommit.ID //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.49.
+			info.RuncCommit.Expected = info.RuncCommit.ID             //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.49.
+			info.InitCommit.Expected = info.InitCommit.ID             //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.49.
+		}
 		if versions.GreaterThanOrEqualTo(version, "1.42") {
 			info.KernelMemory = false
 		}

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -7186,13 +7186,6 @@ definitions:
         description: "Actual commit ID of external tool."
         type: "string"
         example: "cfb82a876ecc11b5ca0977d1733adbe58599088a"
-      Expected:
-        description: |
-          Commit ID of external tool expected by dockerd as set at build time.
-
-          **Deprecated**: This field is deprecated and will be omitted in a API v1.49.
-        type: "string"
-        example: "2d41c047c83e09a6d61d464906feb2a2f3c52aa4"
 
   SwarmInfo:
     description: |

--- a/api/types/system/info.go
+++ b/api/types/system/info.go
@@ -144,7 +144,7 @@ type Commit struct {
 	// Expected is the commit ID of external tool expected by dockerd as set at build time.
 	//
 	// Deprecated: this field is no longer used in API v1.49, but kept for backward-compatibility with older API versions.
-	Expected string
+	Expected string `json:",omitempty"`
 }
 
 // NetworkAddressPool is a temp struct used by [Info] struct.

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -26,6 +26,9 @@ keywords: "API, Docker, rcli, REST, documentation"
 * Deprecated: The  `AllowNondistributableArtifactsCIDRs` and `AllowNondistributableArtifactsHostnames`
   fields in the `RegistryConfig` struct in the `GET /info` response are omitted
   in API v1.49.
+* Deprecated: The `ContainerdCommit.Expected`, `RuncCommit.Expected`, and
+  `InitCommit.Expected` fields in the `GET /info` endpoint were deprecated
+  in API v1.48, and are now omitted in API v1.49.
 
 ## v1.48 API changes
 

--- a/integration/system/info_linux_test.go
+++ b/integration/system/info_linux_test.go
@@ -5,23 +5,45 @@ package system // import "github.com/docker/docker/integration/system"
 import (
 	"testing"
 
+	"github.com/docker/docker/client"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestInfoBinaryCommits(t *testing.T) {
 	ctx := setupTest(t)
-	apiClient := testEnv.APIClient()
 
-	info, err := apiClient.Info(ctx)
-	assert.NilError(t, err)
+	t.Run("current", func(t *testing.T) {
+		apiClient := testEnv.APIClient()
 
-	assert.Check(t, "N/A" != info.ContainerdCommit.ID)
-	assert.Check(t, is.Equal(info.ContainerdCommit.Expected, info.ContainerdCommit.ID)) //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.49.
+		info, err := apiClient.Info(ctx)
+		assert.NilError(t, err)
 
-	assert.Check(t, "N/A" != info.InitCommit.ID)
-	assert.Check(t, is.Equal(info.InitCommit.Expected, info.InitCommit.ID)) //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.49.
+		assert.Check(t, "N/A" != info.ContainerdCommit.ID)
+		assert.Check(t, is.Equal(info.ContainerdCommit.Expected, "")) //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.49.
 
-	assert.Check(t, "N/A" != info.RuncCommit.ID)
-	assert.Check(t, is.Equal(info.RuncCommit.Expected, info.RuncCommit.ID)) //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.49.
+		assert.Check(t, "N/A" != info.InitCommit.ID)
+		assert.Check(t, is.Equal(info.InitCommit.Expected, "")) //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.49.
+
+		assert.Check(t, "N/A" != info.RuncCommit.ID)
+		assert.Check(t, is.Equal(info.RuncCommit.Expected, "")) //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.49.
+	})
+
+	// Expected commits are omitted in API 1.49, but should still be included in older versions.
+	t.Run("1.48", func(t *testing.T) {
+		apiClient, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.48"))
+		assert.NilError(t, err)
+
+		info, err := apiClient.Info(ctx)
+		assert.NilError(t, err)
+
+		assert.Check(t, "N/A" != info.ContainerdCommit.ID)
+		assert.Check(t, is.Equal(info.ContainerdCommit.Expected, info.ContainerdCommit.ID)) //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.49.
+
+		assert.Check(t, "N/A" != info.InitCommit.ID)
+		assert.Check(t, is.Equal(info.InitCommit.Expected, info.InitCommit.ID)) //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.49.
+
+		assert.Check(t, "N/A" != info.RuncCommit.ID)
+		assert.Check(t, is.Equal(info.RuncCommit.Expected, info.RuncCommit.ID)) //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.49.
+	})
 }


### PR DESCRIPTION
- [x] follow-up to / stacked on https://github.com/moby/moby/pull/48478
- [x] requires API version bump https://github.com/moby/moby/pull/49718


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
API: Deprecated: The `ContainerdCommit.Expected`, `RuncCommit.Expected`, and `InitCommit.Expected` fields in the `GET /info` endpoint were deprecated in API v1.48, and are now omitted in API v1.49.
```

**- A picture of a cute animal (not mandatory but encouraged)**

