### PR TITLE
dockerfile: dind target to build docker image for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,3 +154,23 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ env.DESTDIR }}/govulncheck.out
+
+  build-dind:
+    runs-on: ubuntu-24.04
+    needs:
+      - validate-dco
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: ${{ env.SETUP_BUILDX_VERSION }}
+          driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
+          buildkitd-flags: --debug
+      -
+        name: Build dind image
+        uses: docker/bake-action@v6
+        with:
+          targets: dind
+          set: |
+            *.output=type=cacheonly

--- a/Dockerfile
+++ b/Dockerfile
@@ -658,6 +658,15 @@ COPY --link . .
 COPY --link --from=gopls         /build/ /usr/local/bin/
 
 # usage:
+# > docker buildx bake dind
+# > docker run -d --restart always --privileged --name devdind -p 12375:2375 docker-dind --debug --host=tcp://0.0.0.0:2375 --tlsverify=false
+FROM docker:dind AS dind
+COPY --link --from=dockercli /build/docker /usr/local/bin/
+COPY --link --from=buildx    /buildx /usr/local/libexec/docker/cli-plugins/docker-buildx
+COPY --link --from=compose   /docker-compose /usr/local/libexec/docker/cli-plugins/docker-compose
+COPY --link --from=all       / /usr/local/bin/
+
+# usage:
 # > make shell
 # > SYSTEMD=true make shell
 FROM dev-base AS dev

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -165,6 +165,17 @@ target "bin-image-cross" {
 }
 
 #
+# dind
+#
+
+target "dind" {
+  inherits = ["_common"]
+  target = "dind"
+  tags = ["docker-dind"]
+  output = ["type=docker"]
+}
+
+#
 # dev
 #
 


### PR DESCRIPTION
**- What I did**

I'm currently working on https://github.com/moby/moby/issues/48562 and to test my changes I need a working dind image that I can attach as context on my machine and use it as builder.

**- How I did it**

Add `dind` target to our Dockerfile with its bake target. Most of the code is taken from the docker-library repo: https://github.com/docker-library/docker/tree/97331ed1dd7c07dd5aa852e01aa5deff5d2aed09/27/dind

@tianon Let me know if that's fine with you :pray:

**- How to verify it**

```
$ docker buildx bake dind
...
#89 [dind 15/15] RUN set -eux;     docker --version;     docker buildx version;     docker compose version;     dockerd --version;     containerd --version;     ctr --version;     runc --version
#89 0.318 + docker --version
#89 0.330 Docker version 27.3.1, build ce12230
#89 0.331 + docker buildx version
#89 0.371 github.com/docker/buildx v0.17.1 257815a6fbaee88976808020bf04274388275ae8
#89 0.376 + docker compose version
#89 0.413 Docker Compose version v2.29.7
#89 0.417 + dockerd --version
#89 0.435 Docker version dev, build HEAD
#89 0.436 + containerd --version
#89 0.450 containerd github.com/containerd/containerd v1.7.22 7f7fdf5fed64eb6a7caf99b3e12efcf9d60e311c
#89 0.452 + ctr --version
#89 0.456 ctr github.com/containerd/containerd v1.7.22
#89 0.456 + runc --version
#89 0.460 runc version 1.1.14
#89 0.460 commit: v1.1.14-0-g2c9f560
#89 0.460 spec: 1.0.2-dev
#89 0.460 go: go1.22.7
#89 0.460 libseccomp: 2.5.4
#89 DONE 0.5s

#90 exporting to image
#90 exporting layers
#90 exporting layers 0.5s done
#90 writing image sha256:0ab317d5de7fc91c85c1dcfc8d412722beaac60e4a9c489ea95e31f80beb62d9 done
#90 naming to docker.io/library/docker-dind 0.0s done
#90 DONE 0.6s
```

```
$ docker run -d --restart always --privileged --name devdind -p 12375:2375 docker-dind --debug --host=tcp://0.0.0.0:2375 --tlsverify=false
$ docker context create devdind --docker "host=tcp://localhost:12375,skip-tls-verify=true"
$ DOCKER_CONTEXT=devdind docker info
...
Server:
 Containers: 0
  Running: 0
  Paused: 0
  Stopped: 0
 Images: 1
 Server Version: dev
 Storage Driver: overlay2
  Backing Filesystem: extfs
  Supports d_type: true
  Using metacopy: false
  Native Overlay Diff: true
  userxattr: false
 Logging Driver: json-file
 Cgroup Driver: cgroupfs
 Cgroup Version: 1
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local splunk syslog
 Swarm: inactive
 Runtimes: io.containerd.runc.v2 runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: 7f7fdf5fed64eb6a7caf99b3e12efcf9d60e311c
 runc version: v1.1.14-0-g2c9f560
 init version: de40ad0
 Security Options:
  seccomp
   Profile: builtin
 Kernel Version: xxx
 Operating System: Alpine Linux v3.20 (containerized)
 OSType: linux
 Architecture: x86_64
 CPUs: 32
 Total Memory: 31.3GiB
 Name: efe1362f7d9e
 ID: 5c88d894-d536-41f9-8488-5cb171b44998
 Docker Root Dir: /var/lib/docker
 Debug Mode: true
  File Descriptors: 30
  Goroutines: 56
  System Time: 2024-10-01T08:52:24.223105406Z
  EventsListeners: 0
 Username: crazymax
 Experimental: false
 Insecure Registries:
  ::1/128
  127.0.0.0/8
 Live Restore Enabled: false

[DEPRECATION NOTICE]: API is accessible on https://0.0.0.0:2375 without TLS client verification.
         Access to the remote API is equivalent to root access on the host. Refer
         to the 'Docker daemon attack surface' section in the documentation for
         more information: https://docs.docker.com/go/attack-surface/
In future versions this will be a hard failure preventing the daemon from starting! Learn more at: https://docs.docker.com/go/api-security/
[DEPRECATION NOTICE]: API is accessible on https://0.0.0.0:2376 without TLS client verification.
         Access to the remote API is equivalent to root access on the host. Refer
         to the 'Docker daemon attack surface' section in the documentation for
         more information: https://docs.docker.com/go/attack-surface/
In future versions this will be a hard failure preventing the daemon from starting! Learn more at: https://docs.docker.com/go/api-security/
WARNING: No blkio throttle.read_bps_device support
WARNING: No blkio throttle.write_bps_device support
WARNING: No blkio throttle.read_iops_device support
WARNING: No blkio throttle.write_iops_device support
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

