### PR TITLE
cmd/docker-proxy: re-add SO_REUSEADDR

### DIFF
--- a/libnetwork/drivers/bridge/port_mapping_linux.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux.go
@@ -598,6 +598,10 @@ func bindTCPOrUDP(cfg portBindingReq, port, typ, proto int) (_ portBinding, retE
 		}
 	}()
 
+	if err := syscall.SetsockoptInt(sd, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1); err != nil {
+		return portBinding{}, fmt.Errorf("failed to setsockopt(SO_REUSEADDR) for %s: %w", cfg, err)
+	}
+
 	if domain == syscall.AF_INET6 {
 		syscall.SetsockoptInt(sd, syscall.IPPROTO_IPV6, syscall.IPV6_V6ONLY, 1)
 	}


### PR DESCRIPTION
Related to:

- https://github.com/moby/moby/pull/48132

**- What I did**

Since commit https://github.com/moby/moby/commit/b3fabedecc0f408f674972d87803f41faedf4de8, the Engine creates the listening sockets used by docker-proxy by making raw syscalls (ie. socket, setsockopt, bind). Before that commit, those sockets were created by docker-proxy through Go's `net.ListenX` functions.

Unlike `net.ListenX` functions, the raw syscall code doesn't set the `SO_REUSEADDR` option. This option is typically used by TCP servers to make sure that they can be restarted even if there are client sockets referencing that sport (eg. in TIME_WAIT state, or any other state).

Citing UNIX Network Programming, Section 7.5 (p210):

> By default, when the listening server is restarted by calling socket,
> bind, and listen, the call to bind fails because the listening server
> is trying to bind a port that is part of an existing connection [...]
> _All_ TCP servers should specify this socket option to allow the
> server to be restarted in this situation.

**- How to verify it**

The new integration test `TestRestartUserlandProxyUnder2MSL` should be enough.

**- Description for the changelog**

```markdown changelog
- Fix a bug that was preventing containers exposing a TCP port on the host to be restarted if it was accessed by another container (or from the host) shortly before.
```


