### PR TITLE
libnet/d/bridge: port mapping: proxy LL connections 

### DIFF
--- a/libnetwork/drivers/bridge/port_mapping_linux.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux.go
@@ -772,6 +772,9 @@ func setPerPortNAT(b portBinding, ipv iptables.IPVersion, proxyPath string, brid
 	if !hairpinMode {
 		args = append(args, "!", "-i", bridgeName)
 	}
+	if ipv == iptables.IPv6 {
+		args = append(args, "!", "-s", "fe80::/10")
+	}
 	rule := iptRule{ipv: ipv, table: iptables.Nat, chain: DockerChain, args: args}
 	if err := appendOrDelChainRule(rule, "DNAT", enable); err != nil {
 		return err

--- a/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -921,9 +921,12 @@ func TestAddPortMappings(t *testing.T) {
 
 				// Check the DNAT rule.
 				dnatRule := ""
+				if ipv == iptables.IPv6 && !tc.gwMode6.natDisabled() {
+					dnatRule += "! -s fe80::/10 "
+				}
 				if tc.proxyPath != "" {
 					// No docker-proxy, so expect "hairpinMode".
-					dnatRule = "! -i dummybridge "
+					dnatRule += "! -i dummybridge "
 				}
 				dnatRule += fmt.Sprintf("-d %s -p %s -m %s --dport %d -j DNAT --to-destination %s:%d",
 					addrH, expPB.Proto, expPB.Proto, expPB.HostPort, addrD, expPB.Port)


### PR DESCRIPTION
**- What I did**

Link-local connections were DNATed like other non-loopback connections, but the kernel would drop them even before their reach the container.

This PR changes the DNAT rule inserted in ip6tables to exclude link-local addresses. Instead, these connections will be proxied by docker-proxy, at least if --userland-proxy=true.

If dockerd is started with the userland-proxy disabled, link-local port-bindings won't be supported (ie. silently discarded).

**- How I did it**

Debugged the issue with the help of `iptables-tracer` and `pwru`:

- Initial `SYN` packet is DNAT'd to the container
- But no `SYN-ACK` reach `iptables` on the return path
- The initial `SYN` packet doesn't reach `iptables` in the container's netns
- And `pwru` shows that a link-local address is picked as source addr, and a ULA as destination addr.

```
$ iptables-tracer -skip-modprobe -family ipv6 -filter 'tcp port 80'
INFO[0000] Waiting for trace events...
IN= OUT=lo SRC=fe80::42:acff:fe11:2 DST=fe80::42:acff:fe11:2 LEN=40 HOP=64 PROTO=TCP SPT=43178 DPT=80 FLAGS=SYN SEQ=2461312321 CSUM=53db
	raw OUTPUT NFMARK=0x0
		DEFAULT POLICY
		=> ACCEPT
	nat OUTPUT NFMARK=0x0
		MATCH RULE (#1): ! -d ::1/128 -m addrtype --dst-type LOCAL -j DOCKER
		=> DOCKER
	nat DOCKER NFMARK=0x0
		MATCH RULE (#2): ! -i br-a364fa5118cd -p tcp -m tcp --dport 80 -j DNAT --to-destination [fdda:b577:4b05::2]:80
		=> DNAT: --to-destination [fdda:b577:4b05::2]:80

$ conntrack -f ipv6 -L
conntrack v1.4.7 (conntrack-tools): 0 flow entries have been shown.

$ iptables-tracer -skip-modprobe -family ipv6 \
    -netns=$(docker inspect --format='{{ .NetworkSettings.SandboxKey }}' great_ride) \
    -filter 'tcp port 80'

$ docker run --privileged --rm -t --pid=host -v /sys/kernel/debug/:/sys/kernel/debug/ albinkerouanton006/pwru     pwru --filter-func kfree_skb_reason --output-stack --output-tuple 'tcp port 80'
2024/10/02 16:14:15 Attaching kprobes (via kprobe)...
1 / 1 [------------------------------------------------------------------------------------------] 100.00% ? p/s
2024/10/02 16:14:15 Attached (ignored 0)
2024/10/02 16:14:15 Listening for events..
SKB                CPU PROCESS          TUPLE FUNC
0xffff0000c22bd8c0 9   <empty>:4865     [fe80::42:acff:fe11:2]:37582->[fdda:b577:4b05::2]:80(tcp) kfree_skb_reason(SKB_DROP_REASON_NETFILTER_DROP)
kfree_skb_reason
ip6_xmit
inet6_csk_xmit
__tcp_transmit_skb
tcp_connect
tcp_v6_connect
__inet_stream_connect
inet_stream_connect
__sys_connect_file
__sys_connect
__arm64_sys_connect
```

**- How to verify it**

The integration test `TestAccessPublishedPortFromHost` introduced in https://github.com/moby/moby/pull/48545 was skipping LL addrs. That's not the case anymore.

**- Description for the changelog**

```markdown changelog
- Fix connections to published ports using link-local addresses.
```