### PR TITLE
cmd/docker-proxy: UDP: reply to clients with original daddr

### DIFF
--- a/cmd/docker-proxy/proxy_linux.go
+++ b/cmd/docker-proxy/proxy_linux.go
@@ -7,9 +7,9 @@ type ipVersion string
 
 const (
 	// IPv4 is version 4
-	ipv4 ipVersion = "4"
+	ip4 ipVersion = "4"
 	// IPv4 is version 6
-	ipv6 ipVersion = "6"
+	ip6 ipVersion = "6"
 )
 
 // Proxy defines the behavior of a proxy. It forwards traffic back and forth


### PR DESCRIPTION
See:

- https://github.com/moby/libnetwork/issues/1729
- https://github.com/moby/libnetwork/pull/2577
- https://github.com/moby/moby/issues/11998

**- What I did**

When a UDP server is running on a multihomed server, as is the case with pretty much _all_ Docker hosts (eg. eth0 + docker0), the kernel has to choose which source address is used when replying to a UDP client. But that process is based on heuristics and is fallible.

If the address picked doesn't match the original destination address used by the client, it'll drop the datagram and return an ICMP Port Unreachable.

To prevent that, we need to:

- `setsockopt(IP_PKTINFO)` on proxy's sockets.
- Extract the original destination address from an ancillary message every time a new 'UDP connection' is 'established' (ie. every time we insert a new entry into the UDP conntrack table).
- And finally, pass a control message containing the desired source address to the kernel, every time we send a response back to the client.

Also, update the inline comment on read errors in `(*UDPProxy).Run()`. This comment was misleadingly referencing ECONNREFUSED - Linux's UDP implementation never returns this error (see [here](https://github.com/search?q=repo%3Atorvalds%2Flinux+ECONNREFUSED+path%3A%2F%5Enet%5C%2F%28ipv4%7Cipv6%29%5C%2F%28udp%7Ctcp%29%2F&type=code
)). Instead, state why `net.ErrClosed` is perfectly fine and doesn't need to be logged (although, docker-proxy currently logs to nowhere).

**- How to verify it**

A new integration test `TestPortMappedHairpinUDP` has been added.

**- Description for the changelog**

```markdown changelog
- UDP ports published by a container are now reliably accessible by containers on other networks, via the host's public IP address.
```
