### PR TITLE
Fix: setup user chains during libnetwork controller initialization

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -851,6 +851,10 @@ func (daemon *Daemon) initNetworkController(cfg *config.Config, activeSandboxes 
 		return err
 	}
 
+	if err := daemon.netController.SetupUserChains(); err != nil {
+		log.G(context.TODO()).WithError(err).Warnf("initNetworkController")
+	}
+
 	// Set HostGatewayIP to the default bridge's IP if it is empty
 	setHostGatewayIP(daemon.netController, cfg)
 	return nil

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -706,15 +706,22 @@ addToStore:
 		c.mu.Unlock()
 	}
 
-	// Sets up the DOCKER-USER chain for each iptables version (IPv4, IPv6)
-	// that's enabled in the controller's configuration.
-	for _, ipVersion := range c.enabledIptablesVersions() {
-		if err := setupUserChain(ipVersion); err != nil {
-			log.G(context.TODO()).WithError(err).Warnf("Controller.NewNetwork %s:", name)
-		}
+	if err := c.SetupUserChains(); err != nil {
+		log.G(context.TODO()).WithError(err).Warnf("Controller.NewNetwork %s:", name)
 	}
 
 	return nw, nil
+}
+
+// Sets up the DOCKER-USER chain for each iptables version (IPv4, IPv6) that's
+// enabled in the controller's configuration.
+func (c *Controller) SetupUserChains() error {
+	for _, ipVersion := range c.enabledIptablesVersions() {
+		if err := setupUserChain(ipVersion); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 var joinCluster NetworkWalker = func(nw *Network) bool {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->



fixes #48560 

Currently, the `DOCKER-USER` chains are set up when the firewall is reloaded or when a network is created: https://github.com/moby/moby/blob/4001d0704ba38a82e1dbc26f0593fca66db1cb98/libnetwork/controller.go#L709-L715

During a normal startup, the daemon creates the `bridge` network, so the `DOCKER-USER` chains are set up. 

But when `live-restore` is enabled, there may be running containers when the daemon starts. If that's the case, the `configureNetworking` function will not be called: https://github.com/moby/moby/blob/4001d0704ba38a82e1dbc26f0593fca66db1cb98/daemon/daemon_unix.go#L848-L852

`configureNetworking` calls `initBridgeDriver`, which calls `NewNetwork`, which calls `setupUserChain`, so if `configureNetworking` isn't called the user chains won't be set up.

This is a problem if the iptables rules change while the daemon is stopped. 

**- What I did**

I made sure the user chains are set up on startup, even if the `configureNetworking` function is not called

**- How I did it**

I put the logic for setting up user chains for IPv4 and IPv6 in a separate function, which is called in the original place in `NewNetwork`, but also in `initNetworkController` even if there are running containers.

**- How to verify it**

I still didn't write an integration test, I'll add it when I have some time.

To manually test:

- `dockerd --live-restore`
- Create a dummy container: `docker run -d busybox sleep 300`
- Stop dockerd
- Flush the `FORWARD` chain: `iptables -F FORWARD`
- Run again `dockerd --live-restore`
- List the rules: `iptables -S FORWARD`

`-A FORWARD -j DOCKER-USER` should be there

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
After a daemon restart with live-restore, ensure an iptables jump to the DOCKER-USER chain is placed before other rules.
```

**- A picture of a cute animal (not mandatory but encouraged)**

![undo](https://github.com/user-attachments/assets/1e63da4d-5fac-470f-8cb4-26c7863bb989)


