### PR TITLE
api: postImagesLoad: fix API version for platform

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -272,7 +272,7 @@ func (ir *imageRouter) postImagesLoad(ctx context.Context, w http.ResponseWriter
 	}
 
 	var platform *ocispec.Platform
-	if versions.GreaterThanOrEqualTo(httputils.VersionFromContext(ctx), "1.47") {
+	if versions.GreaterThanOrEqualTo(httputils.VersionFromContext(ctx), "1.48") {
 		if formPlatform := r.Form.Get("platform"); formPlatform != "" {
 			p, err := httputils.DecodePlatform(formPlatform)
 			if err != nil {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/48295
- relates to https://github.com/docker/cli/pull/5331


This option was added in f143f4ec5148e71a10d074ed275af8f63caff339, which changed the minimum API version for "save" but forgot to update the version for "load".


