### PR TITLE
Fix vendoring for moby/docker-image-spec

### DIFF
--- a/vendor/github.com/moby/docker-image-spec/specs-go/version.go
+++ b/vendor/github.com/moby/docker-image-spec/specs-go/version.go
@@ -1,7 +1,0 @@
-package specs
-
-const (
-	Version      = "v1.3"
-	VersionMajor = 1
-	VersionMinor = 3
-)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -864,7 +864,6 @@ github.com/moby/buildkit/worker/containerd
 github.com/moby/buildkit/worker/label
 # github.com/moby/docker-image-spec v1.3.1
 ## explicit; go 1.18
-github.com/moby/docker-image-spec/specs-go
 github.com/moby/docker-image-spec/specs-go/v1
 # github.com/moby/ipvs v1.1.0
 ## explicit; go 1.17


### PR DESCRIPTION
**- What I did**

Let `hack/vendor.sh` make changes related to: 
- https://github.com/moby/moby/pull/48460

**- How I did it**

Ran `hack/vendor.sh`.

**- How to verify it**

`hack/validate/all`.

**- Description for the changelog**
```markdown changelog
n/a
```