### PR TITLE
Make containers on routed-mode networks accessible from other bridge networks

### DIFF
--- a/integration/network/bridge/iptablesdoc/generated/new-daemon.md
+++ b/integration/network/bridge/iptablesdoc/generated/new-daemon.md
@@ -11,9 +11,9 @@ Table `filter`:
     Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DOCKER-USER  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    3        0     0 ACCEPT     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
-    4        0     0 DOCKER     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
+    2        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
+    3        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    4        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
     5        0     0 ACCEPT     0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
     6        0     0 ACCEPT     0    --  docker0 docker0  0.0.0.0/0            0.0.0.0/0           
     
@@ -48,9 +48,9 @@ Table `filter`:
     -N DOCKER-ISOLATION-STAGE-2
     -N DOCKER-USER
     -A FORWARD -j DOCKER-USER
+    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
     -A FORWARD -j DOCKER-ISOLATION-STAGE-1
-    -A FORWARD -o docker0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-    -A FORWARD -o docker0 -j DOCKER
+    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
     -A FORWARD -i docker0 ! -o docker0 -j ACCEPT
     -A FORWARD -i docker0 -o docker0 -j ACCEPT
     -A DOCKER ! -i docker0 -o docker0 -j DROP
@@ -78,17 +78,19 @@ The FORWARD chain rules are numbered in the output above, they are:
      Docker won't add rules to the DOCKER-USER chain, it's only for user-defined rules.
      It's (mostly) kept at the top of the by deleting it and re-creating after each
      new network is created, while traffic may be running for other networks.
-  2. Unconditional jump to DOCKER-ISOLATION-STAGE-1.
-     Set up during network creation by [setupIPTables][11], which ensures it appears
+  2. Early ACCEPT for any RELATED,ESTABLISHED traffic to a docker bridge. This rule
+     matches against an `ipset` called `docker-ext-bridges-v4` (`v6` for IPv6). The
+     set contains the CIDR address of each docker network, and it is updated as networks
+     are created and deleted.
+     So, this rule could be set up during bridge driver initialisation. But, it is
+     currently set up when a network is created, in [setupIPTables][11].
+  3. Unconditional jump to DOCKER-ISOLATION-STAGE-1.
+     Set up during network creation by [setupIPTables][12], which ensures it appears
      after the jump to DOCKER-USER (by deleting it and re-creating, while traffic
      may be running for other networks).
-  3. ACCEPT RELATED,ESTABLISHED packets into a specific bridge network.
-     Allows responses to outgoing requests, and continuation of incoming requests,
-     without needing to process any further rules.
-     This rule is also added during network creation, but the code to do it
-     is in libnetwork, [ProgramChain][12].
-  4. Jump to DOCKER, for any packet destined for a bridge network. Added when
-     the network is created, in [ProgramChain][13] ("filterChain" is the DOCKER chain).
+  4. Jump to DOCKER, for any packet destined for any bridge network, identified by
+     matching against the `docker-ext-bridge-v[46]` set. Added when the network is
+     created, in [setupIPTables][13].
      The DOCKER chain implements per-port/protocol filtering for each container.
   5. ACCEPT any packet leaving a network, also set up when the network is created, in
      [setupIPTablesInternal][14].
@@ -97,9 +99,9 @@ The FORWARD chain rules are numbered in the output above, they are:
      [setIcc][15].
 
 [10]: https://github.com/moby/moby/blob/e05848c0025b67a16aaafa8cdff95d5e2c064105/libnetwork/firewall_linux.go#L50
-[11]: https://github.com/moby/moby/blob/333cfa640239153477bf635a8131734d0e9d099d/libnetwork/drivers/bridge/setup_ip_tables_linux.go#L201
-[12]: https://github.com/moby/moby/blob/e05848c0025b67a16aaafa8cdff95d5e2c064105/libnetwork/iptables/iptables.go#L270
-[13]: https://github.com/moby/moby/blob/e05848c0025b67a16aaafa8cdff95d5e2c064105/libnetwork/iptables/iptables.go#L251-L255
+[11]: https://github.com/robmry/moby/blob/52c89d467fc5326149e4bbb8903d23589b66ff0d/libnetwork/drivers/bridge/setup_ip_tables_linux.go#L230-L232
+[12]: https://github.com/robmry/moby/blob/52c89d467fc5326149e4bbb8903d23589b66ff0d/libnetwork/drivers/bridge/setup_ip_tables_linux.go#L227-L229
+[13]: https://github.com/robmry/moby/blob/52c89d467fc5326149e4bbb8903d23589b66ff0d/libnetwork/drivers/bridge/setup_ip_tables_linux.go#L223-L226
 [14]: https://github.com/moby/moby/blob/333cfa640239153477bf635a8131734d0e9d099d/libnetwork/drivers/bridge/setup_ip_tables_linux.go#L264
 [15]: https://github.com/moby/moby/blob/333cfa640239153477bf635a8131734d0e9d099d/libnetwork/drivers/bridge/setup_ip_tables_linux.go#L343
 

--- a/integration/network/bridge/iptablesdoc/generated/new-daemon.md
+++ b/integration/network/bridge/iptablesdoc/generated/new-daemon.md
@@ -27,12 +27,10 @@ Table `filter`:
     Chain DOCKER-ISOLATION-STAGE-1 (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DOCKER-ISOLATION-STAGE-2  0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
-    2        0     0 RETURN     0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-ISOLATION-STAGE-2 (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DROP       0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
-    2        0     0 RETURN     0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-USER (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -57,9 +55,7 @@ Table `filter`:
     -A FORWARD -i docker0 -o docker0 -j ACCEPT
     -A DOCKER ! -i docker0 -o docker0 -j DROP
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
-    -A DOCKER-ISOLATION-STAGE-1 -j RETURN
     -A DOCKER-ISOLATION-STAGE-2 -o docker0 -j DROP
-    -A DOCKER-ISOLATION-STAGE-2 -j RETURN
     -A DOCKER-USER -j RETURN
     
 

--- a/integration/network/bridge/iptablesdoc/generated/usernet-internal.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-internal.md
@@ -35,12 +35,10 @@ The filter table is updated as follows:
     1        0     0 DROP       0    --  *      bridge1 !192.0.2.0/24         0.0.0.0/0           
     2        0     0 DROP       0    --  bridge1 *       0.0.0.0/0           !192.0.2.0/24        
     3        0     0 DOCKER-ISOLATION-STAGE-2  0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
-    4        0     0 RETURN     0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-ISOLATION-STAGE-2 (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DROP       0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
-    2        0     0 RETURN     0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-USER (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -68,9 +66,7 @@ The filter table is updated as follows:
     -A DOCKER-ISOLATION-STAGE-1 ! -s 192.0.2.0/24 -o bridge1 -j DROP
     -A DOCKER-ISOLATION-STAGE-1 ! -d 192.0.2.0/24 -i bridge1 -j DROP
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
-    -A DOCKER-ISOLATION-STAGE-1 -j RETURN
     -A DOCKER-ISOLATION-STAGE-2 -o docker0 -j DROP
-    -A DOCKER-ISOLATION-STAGE-2 -j RETURN
     -A DOCKER-USER -j RETURN
     
 

--- a/integration/network/bridge/iptablesdoc/generated/usernet-internal.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-internal.md
@@ -16,10 +16,10 @@ The filter table is updated as follows:
     Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DOCKER-USER  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    3        0     0 ACCEPT     0    --  bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
-    4        0     0 ACCEPT     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
-    5        0     0 DOCKER     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
+    2        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
+    3        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    4        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
+    5        0     0 ACCEPT     0    --  bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
     6        0     0 ACCEPT     0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
     7        0     0 ACCEPT     0    --  docker0 docker0  0.0.0.0/0            0.0.0.0/0           
     
@@ -56,10 +56,10 @@ The filter table is updated as follows:
     -N DOCKER-ISOLATION-STAGE-2
     -N DOCKER-USER
     -A FORWARD -j DOCKER-USER
+    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
     -A FORWARD -j DOCKER-ISOLATION-STAGE-1
+    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
     -A FORWARD -i bridge1 -o bridge1 -j ACCEPT
-    -A FORWARD -o docker0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-    -A FORWARD -o docker0 -j DOCKER
     -A FORWARD -i docker0 ! -o docker0 -j ACCEPT
     -A FORWARD -i docker0 -o docker0 -j ACCEPT
     -A DOCKER ! -i docker0 -o docker0 -j DROP

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noicc.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noicc.md
@@ -39,13 +39,11 @@ The filter table is:
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DOCKER-ISOLATION-STAGE-2  0    --  bridge1 !bridge1  0.0.0.0/0            0.0.0.0/0           
     2        0     0 DOCKER-ISOLATION-STAGE-2  0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
-    3        0     0 RETURN     0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-ISOLATION-STAGE-2 (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DROP       0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
     2        0     0 DROP       0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
-    3        0     0 RETURN     0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-USER (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -77,10 +75,8 @@ The filter table is:
     -A DOCKER ! -i bridge1 -o bridge1 -j DROP
     -A DOCKER-ISOLATION-STAGE-1 -i bridge1 ! -o bridge1 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
-    -A DOCKER-ISOLATION-STAGE-1 -j RETURN
     -A DOCKER-ISOLATION-STAGE-2 -o bridge1 -j DROP
     -A DOCKER-ISOLATION-STAGE-2 -o docker0 -j DROP
-    -A DOCKER-ISOLATION-STAGE-2 -j RETURN
     -A DOCKER-USER -j RETURN
     
 

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noicc.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noicc.md
@@ -16,20 +16,18 @@ The filter table is:
     Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DOCKER-USER  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    3        0     0 ACCEPT     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
-    4        0     0 DOCKER     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
+    2        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
+    3        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    4        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
     5        0     0 ACCEPT     0    --  bridge1 !bridge1  0.0.0.0/0            0.0.0.0/0           
-    6        0     0 ACCEPT     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
-    7        0     0 DOCKER     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
-    8        0     0 ACCEPT     0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
-    9        0     0 ACCEPT     0    --  docker0 docker0  0.0.0.0/0            0.0.0.0/0           
-    10       0     0 DROP       0    --  bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
+    6        0     0 ACCEPT     0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
+    7        0     0 ACCEPT     0    --  docker0 docker0  0.0.0.0/0            0.0.0.0/0           
+    8        0     0 DROP       0    --  bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
-    Chain DOCKER (2 references)
+    Chain DOCKER (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
     2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
@@ -37,8 +35,8 @@ The filter table is:
     
     Chain DOCKER-ISOLATION-STAGE-1 (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-ISOLATION-STAGE-2  0    --  bridge1 !bridge1  0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-ISOLATION-STAGE-2  0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER-ISOLATION-STAGE-2  0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
+    2        0     0 DOCKER-ISOLATION-STAGE-2  0    --  bridge1 !bridge1  0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-ISOLATION-STAGE-2 (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -61,20 +59,18 @@ The filter table is:
     -N DOCKER-ISOLATION-STAGE-2
     -N DOCKER-USER
     -A FORWARD -j DOCKER-USER
+    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
     -A FORWARD -j DOCKER-ISOLATION-STAGE-1
-    -A FORWARD -o bridge1 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-    -A FORWARD -o bridge1 -j DOCKER
+    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
     -A FORWARD -i bridge1 ! -o bridge1 -j ACCEPT
-    -A FORWARD -o docker0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-    -A FORWARD -o docker0 -j DOCKER
     -A FORWARD -i docker0 ! -o docker0 -j ACCEPT
     -A FORWARD -i docker0 -o docker0 -j ACCEPT
     -A FORWARD -i bridge1 -o bridge1 -j DROP
     -A DOCKER -d 192.0.2.2/32 ! -i bridge1 -o bridge1 -p tcp -m tcp --dport 80 -j ACCEPT
     -A DOCKER ! -i docker0 -o docker0 -j DROP
     -A DOCKER ! -i bridge1 -o bridge1 -j DROP
-    -A DOCKER-ISOLATION-STAGE-1 -i bridge1 ! -o bridge1 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
+    -A DOCKER-ISOLATION-STAGE-1 -i bridge1 ! -o bridge1 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-2 -o bridge1 -j DROP
     -A DOCKER-ISOLATION-STAGE-2 -o docker0 -j DROP
     -A DOCKER-USER -j RETURN
@@ -84,7 +80,7 @@ The filter table is:
 
 By comparison with [ICC=true][1]:
 
-  - Rule 10 in the FORWARD chain replaces an ACCEPT rule that would have followed rule 5, matching the same packets.
+  - Rule 8 in the FORWARD chain replaces an ACCEPT rule that would have followed rule 5, matching the same packets.
     - Added in [setIcc][2]
 
 [1]: usernet-portmap.md

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noproxy.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noproxy.md
@@ -19,20 +19,18 @@ The filter table is the same as with the userland proxy enabled.
     Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DOCKER-USER  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    3        0     0 ACCEPT     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
-    4        0     0 DOCKER     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
+    2        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
+    3        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    4        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
     5        0     0 ACCEPT     0    --  bridge1 !bridge1  0.0.0.0/0            0.0.0.0/0           
     6        0     0 ACCEPT     0    --  bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
-    7        0     0 ACCEPT     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
-    8        0     0 DOCKER     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
-    9        0     0 ACCEPT     0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
-    10       0     0 ACCEPT     0    --  docker0 docker0  0.0.0.0/0            0.0.0.0/0           
+    7        0     0 ACCEPT     0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
+    8        0     0 ACCEPT     0    --  docker0 docker0  0.0.0.0/0            0.0.0.0/0           
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
-    Chain DOCKER (2 references)
+    Chain DOCKER (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
     2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
@@ -40,8 +38,8 @@ The filter table is the same as with the userland proxy enabled.
     
     Chain DOCKER-ISOLATION-STAGE-1 (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-ISOLATION-STAGE-2  0    --  bridge1 !bridge1  0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-ISOLATION-STAGE-2  0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER-ISOLATION-STAGE-2  0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
+    2        0     0 DOCKER-ISOLATION-STAGE-2  0    --  bridge1 !bridge1  0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-ISOLATION-STAGE-2 (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -61,20 +59,18 @@ The filter table is the same as with the userland proxy enabled.
     -N DOCKER-ISOLATION-STAGE-2
     -N DOCKER-USER
     -A FORWARD -j DOCKER-USER
+    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
     -A FORWARD -j DOCKER-ISOLATION-STAGE-1
-    -A FORWARD -o bridge1 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-    -A FORWARD -o bridge1 -j DOCKER
+    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
     -A FORWARD -i bridge1 ! -o bridge1 -j ACCEPT
     -A FORWARD -i bridge1 -o bridge1 -j ACCEPT
-    -A FORWARD -o docker0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-    -A FORWARD -o docker0 -j DOCKER
     -A FORWARD -i docker0 ! -o docker0 -j ACCEPT
     -A FORWARD -i docker0 -o docker0 -j ACCEPT
     -A DOCKER -d 192.0.2.2/32 ! -i bridge1 -o bridge1 -p tcp -m tcp --dport 80 -j ACCEPT
     -A DOCKER ! -i docker0 -o docker0 -j DROP
     -A DOCKER ! -i bridge1 -o bridge1 -j DROP
-    -A DOCKER-ISOLATION-STAGE-1 -i bridge1 ! -o bridge1 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
+    -A DOCKER-ISOLATION-STAGE-1 -i bridge1 ! -o bridge1 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-2 -o bridge1 -j DROP
     -A DOCKER-ISOLATION-STAGE-2 -o docker0 -j DROP
     -A DOCKER-USER -j RETURN

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noproxy.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noproxy.md
@@ -42,13 +42,11 @@ The filter table is the same as with the userland proxy enabled.
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DOCKER-ISOLATION-STAGE-2  0    --  bridge1 !bridge1  0.0.0.0/0            0.0.0.0/0           
     2        0     0 DOCKER-ISOLATION-STAGE-2  0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
-    3        0     0 RETURN     0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-ISOLATION-STAGE-2 (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DROP       0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
     2        0     0 DROP       0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
-    3        0     0 RETURN     0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-USER (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -77,10 +75,8 @@ The filter table is the same as with the userland proxy enabled.
     -A DOCKER ! -i bridge1 -o bridge1 -j DROP
     -A DOCKER-ISOLATION-STAGE-1 -i bridge1 ! -o bridge1 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
-    -A DOCKER-ISOLATION-STAGE-1 -j RETURN
     -A DOCKER-ISOLATION-STAGE-2 -o bridge1 -j DROP
     -A DOCKER-ISOLATION-STAGE-2 -o docker0 -j DROP
-    -A DOCKER-ISOLATION-STAGE-2 -j RETURN
     -A DOCKER-USER -j RETURN
     
 

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-routed.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-routed.md
@@ -8,15 +8,7 @@ Running the daemon with the userland proxy disabled then, as before, adding a ne
 	  --subnet 192.0.2.0/24 --gateway 192.0.2.1 bridge1
 	docker run --network bridge1 -p 8080:80 --name c1 busybox
 
-The filter table is largely the same as with the userland proxy enabled.
-
-_Note that this means inter-network communication is disabled as-normal so,
-although published ports will be directly accessible from a remote host
-they are not accessible from containers in neighbouring docker networks
-on the same host._
-
-<details>
-<summary>Filter table</summary>
+The filter table is:
 
     Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -24,20 +16,18 @@ on the same host._
     Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DOCKER-USER  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    3        0     0 ACCEPT     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
-    4        0     0 DOCKER     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
+    2        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
+    3        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    4        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
     5        0     0 ACCEPT     0    --  bridge1 !bridge1  0.0.0.0/0            0.0.0.0/0           
     6        0     0 ACCEPT     0    --  bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
-    7        0     0 ACCEPT     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
-    8        0     0 DOCKER     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
-    9        0     0 ACCEPT     0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
-    10       0     0 ACCEPT     0    --  docker0 docker0  0.0.0.0/0            0.0.0.0/0           
+    7        0     0 ACCEPT     0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
+    8        0     0 ACCEPT     0    --  docker0 docker0  0.0.0.0/0            0.0.0.0/0           
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
-    Chain DOCKER (2 references)
+    Chain DOCKER (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
     2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
@@ -46,8 +36,10 @@ on the same host._
     
     Chain DOCKER-ISOLATION-STAGE-1 (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-ISOLATION-STAGE-2  0    --  bridge1 !bridge1  0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-ISOLATION-STAGE-2  0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 ACCEPT     0    --  bridge1 *       0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
+    2        0     0 RETURN     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
+    3        0     0 DOCKER-ISOLATION-STAGE-2  0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
+    4        0     0 DOCKER-ISOLATION-STAGE-2  0    --  bridge1 !bridge1  0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-ISOLATION-STAGE-2 (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -59,6 +51,9 @@ on the same host._
     1        0     0 RETURN     0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     
 
+<details>
+<summary>iptables commands</summary>
+
     -P INPUT ACCEPT
     -P FORWARD ACCEPT
     -P OUTPUT ACCEPT
@@ -67,21 +62,21 @@ on the same host._
     -N DOCKER-ISOLATION-STAGE-2
     -N DOCKER-USER
     -A FORWARD -j DOCKER-USER
+    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
     -A FORWARD -j DOCKER-ISOLATION-STAGE-1
-    -A FORWARD -o bridge1 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-    -A FORWARD -o bridge1 -j DOCKER
+    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
     -A FORWARD -i bridge1 ! -o bridge1 -j ACCEPT
     -A FORWARD -i bridge1 -o bridge1 -j ACCEPT
-    -A FORWARD -o docker0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-    -A FORWARD -o docker0 -j DOCKER
     -A FORWARD -i docker0 ! -o docker0 -j ACCEPT
     -A FORWARD -i docker0 -o docker0 -j ACCEPT
     -A DOCKER -d 192.0.2.2/32 ! -i bridge1 -o bridge1 -p tcp -m tcp --dport 80 -j ACCEPT
     -A DOCKER ! -i docker0 -o docker0 -j DROP
     -A DOCKER -o bridge1 -p icmp -j ACCEPT
     -A DOCKER ! -i bridge1 -o bridge1 -j DROP
-    -A DOCKER-ISOLATION-STAGE-1 -i bridge1 ! -o bridge1 -j DOCKER-ISOLATION-STAGE-2
+    -A DOCKER-ISOLATION-STAGE-1 -i bridge1 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A DOCKER-ISOLATION-STAGE-1 -o bridge1 -j RETURN
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
+    -A DOCKER-ISOLATION-STAGE-1 -i bridge1 ! -o bridge1 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-2 -o bridge1 -j DROP
     -A DOCKER-ISOLATION-STAGE-2 -o docker0 -j DROP
     -A DOCKER-USER -j RETURN
@@ -89,17 +84,25 @@ on the same host._
 
 </details>
 
-However, a rule is added by [setICMP][5] to the DOCKER chain (shown below) to
-allow ICMP. The equivalent IPv6 rule uses `-p icmpv6` rather than `-p icmp`,
-so *ALL* ICMP message types are allowed.
+Compared to the equivalent [nat mode network][1]:
 
-_The ACCEPT rule as shown by `iptables -L` looks alarming until you spot that it's
-for `prot 1`._
-
-Because the ICMP rule (rule 3) is per-network, it is appended to the chain along
-with the default-DROP rule (rule 4). So, it is likely to be separated from
-per-port/protocol ACCEPT rules for published ports on the same network. But it
-will always appear before the default-DROP.
+- In DOCKER-ISOLATION-STAGE-1:
+  - Rule 1 accepts outgoing packets related to established connections. This
+    is for responses to containers on NAT networks that would not normally
+    accept packets from another network, and may have port/protocol filtering
+    rules in place that would otherwise drop these responses.
+  - Rule 2 skips the jump to DOCKER-ISOLATION-STAGE-2 for any packet routed
+    to the routed-mode network. So, it will accept packets from other networks,
+    if they make it through the port/protocol filtering rules in the DOCKER
+    chain.
+- In the DOCKER chain:
+  - A rule is added by [setICMP][5] to allow ICMP.
+    *ALL* ICMP message types are allowed.
+    The equivalent IPv6 rule uses `-p icmpv6` rather than `-p icmp`. 
+    - Because the ICMP rule (rule 3) is per-network, it is appended to the chain along
+      with the default-DROP rule (rule 4). So, it is likely to be separated from
+      per-port/protocol ACCEPT rules for published ports on the same network. But it
+      will always appear before the default-DROP.
 
 _[RFC 4890 section 4.3][6] makes recommendations for filtering ICMPv6. These
 have been considered, but the host firewall is not a network boundary in the
@@ -107,7 +110,10 @@ sense used by the RFC. So, Node Information and Router Renumbering messages are
 not discarded, and experimental/unused types are allowed because they may be
 needed._
 
-    Chain DOCKER (2 references)
+The ICMP rule, as shown by `iptables -L`, looks alarming until you spot that it's
+for `prot 1`:
+
+    Chain DOCKER (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
     2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
@@ -141,7 +147,8 @@ The nat table is:
     
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 RETURN     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
+    1        0     0 RETURN     0    --  bridge1 *       0.0.0.0/0            0.0.0.0/0           
+    2        0     0 RETURN     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
     
 
 <details>
@@ -155,6 +162,7 @@ The nat table is:
     -A PREROUTING -m addrtype --dst-type LOCAL -j DOCKER
     -A OUTPUT ! -d 127.0.0.0/8 -m addrtype --dst-type LOCAL -j DOCKER
     -A POSTROUTING -s 172.17.0.0/16 ! -o docker0 -j MASQUERADE
+    -A DOCKER -i bridge1 -j RETURN
     -A DOCKER -i docker0 -j RETURN
     
 

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-routed.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-routed.md
@@ -48,13 +48,11 @@ on the same host._
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DOCKER-ISOLATION-STAGE-2  0    --  bridge1 !bridge1  0.0.0.0/0            0.0.0.0/0           
     2        0     0 DOCKER-ISOLATION-STAGE-2  0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
-    3        0     0 RETURN     0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-ISOLATION-STAGE-2 (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DROP       0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
     2        0     0 DROP       0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
-    3        0     0 RETURN     0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-USER (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -84,10 +82,8 @@ on the same host._
     -A DOCKER ! -i bridge1 -o bridge1 -j DROP
     -A DOCKER-ISOLATION-STAGE-1 -i bridge1 ! -o bridge1 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
-    -A DOCKER-ISOLATION-STAGE-1 -j RETURN
     -A DOCKER-ISOLATION-STAGE-2 -o bridge1 -j DROP
     -A DOCKER-ISOLATION-STAGE-2 -o docker0 -j DROP
-    -A DOCKER-ISOLATION-STAGE-2 -j RETURN
     -A DOCKER-USER -j RETURN
     
 

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap.md
@@ -38,13 +38,11 @@ The filter table is updated as follows:
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DOCKER-ISOLATION-STAGE-2  0    --  bridge1 !bridge1  0.0.0.0/0            0.0.0.0/0           
     2        0     0 DOCKER-ISOLATION-STAGE-2  0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
-    3        0     0 RETURN     0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-ISOLATION-STAGE-2 (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DROP       0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
     2        0     0 DROP       0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
-    3        0     0 RETURN     0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-USER (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -76,10 +74,8 @@ The filter table is updated as follows:
     -A DOCKER ! -i bridge1 -o bridge1 -j DROP
     -A DOCKER-ISOLATION-STAGE-1 -i bridge1 ! -o bridge1 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
-    -A DOCKER-ISOLATION-STAGE-1 -j RETURN
     -A DOCKER-ISOLATION-STAGE-2 -o bridge1 -j DROP
     -A DOCKER-ISOLATION-STAGE-2 -o docker0 -j DROP
-    -A DOCKER-ISOLATION-STAGE-2 -j RETURN
     -A DOCKER-USER -j RETURN
     
 

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap.md
@@ -15,20 +15,18 @@ The filter table is updated as follows:
     Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DOCKER-USER  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    3        0     0 ACCEPT     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
-    4        0     0 DOCKER     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
+    2        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
+    3        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    4        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
     5        0     0 ACCEPT     0    --  bridge1 !bridge1  0.0.0.0/0            0.0.0.0/0           
     6        0     0 ACCEPT     0    --  bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
-    7        0     0 ACCEPT     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
-    8        0     0 DOCKER     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
-    9        0     0 ACCEPT     0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
-    10       0     0 ACCEPT     0    --  docker0 docker0  0.0.0.0/0            0.0.0.0/0           
+    7        0     0 ACCEPT     0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
+    8        0     0 ACCEPT     0    --  docker0 docker0  0.0.0.0/0            0.0.0.0/0           
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
-    Chain DOCKER (2 references)
+    Chain DOCKER (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
     2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
@@ -36,8 +34,8 @@ The filter table is updated as follows:
     
     Chain DOCKER-ISOLATION-STAGE-1 (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-ISOLATION-STAGE-2  0    --  bridge1 !bridge1  0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-ISOLATION-STAGE-2  0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER-ISOLATION-STAGE-2  0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
+    2        0     0 DOCKER-ISOLATION-STAGE-2  0    --  bridge1 !bridge1  0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-ISOLATION-STAGE-2 (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -60,20 +58,18 @@ The filter table is updated as follows:
     -N DOCKER-ISOLATION-STAGE-2
     -N DOCKER-USER
     -A FORWARD -j DOCKER-USER
+    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
     -A FORWARD -j DOCKER-ISOLATION-STAGE-1
-    -A FORWARD -o bridge1 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-    -A FORWARD -o bridge1 -j DOCKER
+    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
     -A FORWARD -i bridge1 ! -o bridge1 -j ACCEPT
     -A FORWARD -i bridge1 -o bridge1 -j ACCEPT
-    -A FORWARD -o docker0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-    -A FORWARD -o docker0 -j DOCKER
     -A FORWARD -i docker0 ! -o docker0 -j ACCEPT
     -A FORWARD -i docker0 -o docker0 -j ACCEPT
     -A DOCKER -d 192.0.2.2/32 ! -i bridge1 -o bridge1 -p tcp -m tcp --dport 80 -j ACCEPT
     -A DOCKER ! -i docker0 -o docker0 -j DROP
     -A DOCKER ! -i bridge1 -o bridge1 -j DROP
-    -A DOCKER-ISOLATION-STAGE-1 -i bridge1 ! -o bridge1 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
+    -A DOCKER-ISOLATION-STAGE-1 -i bridge1 ! -o bridge1 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-2 -o bridge1 -j DROP
     -A DOCKER-ISOLATION-STAGE-2 -o docker0 -j DROP
     -A DOCKER-USER -j RETURN
@@ -83,9 +79,9 @@ The filter table is updated as follows:
 
 Note that:
 
- - In the FORWARD chain, rules 3-6 for the new network have been inserted at
+ - In the FORWARD chain, rules 5-6 for the new network have been inserted at
    the top of the chain, pushing the equivalent docker0 rules down to positions
-   7-10. (Rules 3-6 were inserted at the top of the chain, then rules 1-2 were
+   7-8. (Rules 5-6 were inserted at the top of the chain, then rules 1-4 were
    shuffled back to the top by deleting/recreating, as described above.)
  - In the DOCKER-ISOLATION chains, rules equivalent to the docker0 rules have
    also been inserted for the new bridge.

--- a/integration/network/bridge/iptablesdoc/templates/usernet-portmap-noicc.md
+++ b/integration/network/bridge/iptablesdoc/templates/usernet-portmap-noicc.md
@@ -21,7 +21,7 @@ The filter table is:
 
 By comparison with [ICC=true][1]:
 
-  - Rule 10 in the FORWARD chain replaces an ACCEPT rule that would have followed rule 5, matching the same packets.
+  - Rule 8 in the FORWARD chain replaces an ACCEPT rule that would have followed rule 5, matching the same packets.
     - Added in [setIcc][2]
 
 [1]: usernet-portmap.md

--- a/integration/network/bridge/iptablesdoc/templates/usernet-portmap.md
+++ b/integration/network/bridge/iptablesdoc/templates/usernet-portmap.md
@@ -20,9 +20,9 @@ The filter table is updated as follows:
 
 Note that:
 
- - In the FORWARD chain, rules 3-6 for the new network have been inserted at
+ - In the FORWARD chain, rules 5-6 for the new network have been inserted at
    the top of the chain, pushing the equivalent docker0 rules down to positions
-   7-10. (Rules 3-6 were inserted at the top of the chain, then rules 1-2 were
+   7-8. (Rules 5-6 were inserted at the top of the chain, then rules 1-4 were
    shuffled back to the top by deleting/recreating, as described above.)
  - In the DOCKER-ISOLATION chains, rules equivalent to the docker0 rules have
    also been inserted for the new bridge.

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -371,7 +371,7 @@ func newGwMode(gwMode string) (gwMode, error) {
 	return gwModeDefault, fmt.Errorf("unknown gateway mode %s", gwMode)
 }
 
-func (m gwMode) natDisabled() bool {
+func (m gwMode) routed() bool {
 	return m == gwModeRouted
 }
 
@@ -424,7 +424,7 @@ func (n *bridgeNetwork) getNetworkBridgeName() string {
 func (n *bridgeNetwork) getNATDisabled() (ipv4, ipv6 bool) {
 	n.Lock()
 	defer n.Unlock()
-	return n.config.GwModeIPv4.natDisabled(), n.config.GwModeIPv6.natDisabled()
+	return n.config.GwModeIPv4.routed(), n.config.GwModeIPv6.routed()
 }
 
 func (n *bridgeNetwork) userlandProxyPath() string {

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -471,16 +471,17 @@ func (n *bridgeNetwork) isolateNetwork(enable bool) error {
 	}
 
 	// Install the rules to isolate this network against each of the other networks
+	if n.driver.config.EnableIPTables {
+		if err := setINC(iptables.IPv4, thisConfig.BridgeName, enable); err != nil {
+			return err
+		}
+	}
 	if n.driver.config.EnableIP6Tables {
-		err := setINC(iptables.IPv6, thisConfig.BridgeName, enable)
-		if err != nil {
+		if err := setINC(iptables.IPv6, thisConfig.BridgeName, enable); err != nil {
 			return err
 		}
 	}
 
-	if n.driver.config.EnableIPTables {
-		return setINC(iptables.IPv4, thisConfig.BridgeName, enable)
-	}
 	return nil
 }
 

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -847,10 +847,10 @@ func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 	// Add inter-network communication rules.
 	setupNetworkIsolationRules := func(config *networkConfiguration, i *bridgeInterface) error {
 		if err := network.isolateNetwork(true); err != nil {
-			if err = network.isolateNetwork(false); err != nil {
-				log.G(context.TODO()).Warnf("Failed on removing the inter-network iptables rules on cleanup: %v", err)
+			if errRollback := network.isolateNetwork(false); errRollback != nil {
+				log.G(context.TODO()).WithError(errRollback).Warnf("Failed on removing the inter-network iptables rules on cleanup")
 			}
-			return err
+			return errdefs.System(err)
 		}
 		// register the cleanup function
 		network.registerIptCleanFunc(func() error {

--- a/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -884,13 +884,13 @@ func TestAddPortMappings(t *testing.T) {
 				var ipv iptables.IPVersion
 				hip := expChildIP(expPB.HostIP)
 				if expPB.IP.To4() == nil {
-					disableNAT = tc.gwMode6.natDisabled()
+					disableNAT = tc.gwMode6.routed()
 					ipv = iptables.IPv6
 					addrM = ctrIP6.IP.String() + "/128"
 					addrD = "[" + ctrIP6.IP.String() + "]"
 					addrH = hip.String() + "/128"
 				} else {
-					disableNAT = tc.gwMode4.natDisabled()
+					disableNAT = tc.gwMode4.routed()
 					ipv = iptables.IPv4
 					addrM = ctrIP4.IP.String() + "/32"
 					addrD = ctrIP4.IP.String()
@@ -912,7 +912,7 @@ func TestAddPortMappings(t *testing.T) {
 
 				// Check the DNAT rule.
 				dnatRule := ""
-				if ipv == iptables.IPv6 && !tc.gwMode6.natDisabled() {
+				if ipv == iptables.IPv6 && !tc.gwMode6.routed() {
 					dnatRule += "! -s fe80::/10 "
 				}
 				if tc.proxyPath != "" {
@@ -949,7 +949,7 @@ func TestAddPortMappings(t *testing.T) {
 				for _, expPB := range tc.expPBs {
 					hip := expChildIP(expPB.HostIP)
 					is4 := hip.To4() != nil
-					if (is4 && tc.gwMode4.natDisabled()) || (!is4 && tc.gwMode6.natDisabled()) {
+					if (is4 && tc.gwMode4.routed()) || (!is4 && tc.gwMode6.routed()) {
 						continue
 					}
 					p := newProxyCall(expPB.Proto.String(),

--- a/libnetwork/drivers/bridge/setup_ip_tables_linux.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux.go
@@ -297,10 +297,10 @@ func setupIPTablesInternal(ipVer iptables.IPVersion, config *networkConfiguratio
 		hpNatArgs []string
 	)
 	hostIP := config.HostIPv4
-	nat := !config.GwModeIPv4.natDisabled()
+	nat := !config.GwModeIPv4.routed()
 	if ipVer == iptables.IPv6 {
 		hostIP = config.HostIPv6
-		nat = !config.GwModeIPv6.natDisabled()
+		nat = !config.GwModeIPv6.routed()
 	}
 	// If hostIP is set, the user wants IPv4/IPv6 SNAT with the given address.
 	if hostIP != nil {

--- a/libnetwork/drivers/bridge/setup_ip_tables_linux.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux.go
@@ -98,14 +98,6 @@ func setupIPChains(config configuration, version iptables.IPVersion) (natChain *
 		}
 	}()
 
-	if err := iptable.AddReturnRule(IsolationChain1); err != nil {
-		return nil, nil, nil, nil, err
-	}
-
-	if err := iptable.AddReturnRule(IsolationChain2); err != nil {
-		return nil, nil, nil, nil, err
-	}
-
 	if err := mirroredWSL2Workaround(config, version); err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/libnetwork/iptables/firewalld_test.go
+++ b/libnetwork/iptables/firewalld_test.go
@@ -38,12 +38,15 @@ func TestReloaded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer fwdChain.Remove()
 
-	err = iptable.ProgramChain(fwdChain, bridgeName, false, true)
+	// This jump from the FORWARD chain prevents FWD from being deleted by
+	// "iptables -X", called from fwdChain.Remove().
+	err = iptable.EnsureJumpRule("FORWARD", "FWD")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer fwdChain.Remove()
+	defer iptable.Raw("-D", "FORWARD", "-j", "FWD")
 
 	// copy-pasted from iptables_test:TestLink
 	ip1 := net.ParseIP("192.168.1.1")

--- a/libnetwork/iptables/iptables_test.go
+++ b/libnetwork/iptables/iptables_test.go
@@ -212,19 +212,6 @@ func addSomeRules(c *ChainInfo, ip net.IP, port int, proto, destAddr string, des
 func TestCleanup(t *testing.T) {
 	iptable, _, filterChain := createNewChain(t)
 
-	var rules []byte
-
-	// Cleanup filter/FORWARD first otherwise output of iptables-save is dirty
-	link := []string{
-		"-t", string(filterChain.Table),
-		string(Delete), "FORWARD",
-		"-o", bridgeName,
-		"-j", filterChain.Name,
-	}
-
-	if _, err := iptable.Raw(link...); err != nil {
-		t.Fatal(err)
-	}
 	filterChain.Remove()
 
 	err := iptable.RemoveExistingChain(chainName, Nat)
@@ -232,7 +219,7 @@ func TestCleanup(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rules, err = exec.Command("iptables-save").Output()
+	rules, err := exec.Command("iptables-save").Output()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**- What I did**

- fix https://github.com/moby/moby/issues/48526

Containers on a network with option `com.docker.network.bridge.gateway_mode_ipv[46]=routed` do not have NAT set up for port-mappings from the host - but mapped ports are opened in the container's iptables/ip6tables rules, and they can be accessed from a remote host that has routing to the container network (via the host).

However, those ports were not accessible from containers on other networks on the same host.

**- How I did it**

Introduce the use of `ipset`, with sets containing the subnets of each of the externally-accessible docker networks.
- This is a new depdendency, `ipset` needs to be available in the kernel.
  - No userspace tools are needed, the daemon uses netlink to manage the sets.
  - It's been available since kernel 3.11, Sept 2013 (https://ipset.netfilter.org/install.html).
- We should document the new dependency.
- The Docker-in-Docker image might need to modprobe it (so that a host with an old dockerd that hasn't loaded the module can run a new image). **Edit:** this isn't necessary, netlink calls from the inner-docker take care of it.

Use those sets in rules matching packets routed to those docker networks so that:
- only one conntrack `RELATED,ESTABLISHED` rule is needed in the filter-`FORWARD` chain
  - previously there was a rule per-bridge
  - the rule can be placed second in the chain (after the unconditional jump to `DOCKER-USER`), so that related packets don't need to be checked against any other rules.
- similarly, only one rule is needed for the jump to the `DOCKER` chain, rather than a rule per-bridge
- in `DOCKER-ISOLATION-STAGE-1`:
  - accept conntrack `RELATED,ESTABLISED` packets coming from the routed network, so that responses make it back to the network that made the request
  - return early for routed networks as they're not isolated in the same way as nat networks, port/protocol filtering will still happen in the `DOCKER` chain.

Also:
- remove unconditional `RETURN` rules from the end of the `DOCKER-ISOLATION` chains
  - they're unnecessary, because the return happens anyway
  - removing them makes it possible to insert rules that accept packets (the conntrack rules allowing responses from routed networks), and append rules that return early or drop packets (the early return for routed networks).
- Related code-tidying.

**- How to verify it**

New tests.

**- Description for the changelog**
```markdown changelog
- dockerd requires `ipset` support in the Linux kernel
- allow access to `gateway_mode_ipv[46]=routed` networks from other networks on the same docker host
```
