### PR TITLE
Add gateway mode "nat-unprotected"

### DIFF
--- a/integration/network/bridge/iptablesdoc/generated/new-daemon.md
+++ b/integration/network/bridge/iptablesdoc/generated/new-daemon.md
@@ -112,7 +112,7 @@ bigger change than it should be._
 
 The DOCKER chain has a single DROP rule for the bridge network, to drop any
 packets routed to the network that have not originated in the network. Added by
-[defaultDrop][21].
+[setDefaultForwardRule][21].
 _This means there is no dependency on the filter-FORWARD chain's default policy.
 Even if it is ACCEPT, packets will be dropped unless container ports/protocols
 are published._

--- a/integration/network/bridge/iptablesdoc/index.md
+++ b/integration/network/bridge/iptablesdoc/index.md
@@ -44,3 +44,4 @@ Scenarios:
   - [Container on a user-defined network with inter-container communication disabled, with a published port](generated/usernet-portmap-noicc.md)
   - [Container on a user-defined --internal network](generated/usernet-internal.md)
   - [Container on a routed-mode network, with a published port](generated/usernet-portmap-routed.md)
+  - [Container on a nat-unprotected network, with a published port](generated/usernet-portmap-natunprot.md)

--- a/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
+++ b/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
@@ -133,6 +133,19 @@ var index = []section{
 			},
 		}},
 	},
+	{
+		name: "usernet-portmap-natunprot.md",
+		networks: []bridgeNetwork{{
+			bridge: "bridge1",
+			gwMode: "nat-unprotected",
+			containers: []ctr{
+				{
+					name:         "c1",
+					portMappings: nat.PortMap{"80/tcp": {{HostPort: "8080"}}},
+				},
+			},
+		}},
+	},
 }
 
 // iptCmdType is used to look up iptCmds in the markdown (can't use an int

--- a/integration/network/bridge/iptablesdoc/templates/new-daemon.md
+++ b/integration/network/bridge/iptablesdoc/templates/new-daemon.md
@@ -65,7 +65,7 @@ bigger change than it should be._
 
 The DOCKER chain has a single DROP rule for the bridge network, to drop any
 packets routed to the network that have not originated in the network. Added by
-[defaultDrop][21].
+[setDefaultForwardRule][21].
 _This means there is no dependency on the filter-FORWARD chain's default policy.
 Even if it is ACCEPT, packets will be dropped unless container ports/protocols
 are published._

--- a/integration/network/bridge/iptablesdoc/templates/usernet-portmap-natunprot.md
+++ b/integration/network/bridge/iptablesdoc/templates/usernet-portmap-natunprot.md
@@ -1,0 +1,48 @@
+## Container on a nat-unprotected network, with a published port
+
+Running the daemon with the userland proxy disable then, as before, adding a network running a container with a mapped port, equivalent to:
+
+	docker network create \
+	  -o com.docker.network.bridge.name=bridge1 \
+	  -o com.docker.network.bridge.gateway_mode_ipv4=nat-unprotected \
+	  --subnet 192.0.2.0/24 --gateway 192.0.2.1 bridge1
+	docker run --network bridge1 -p 8080:80 --name c1 busybox
+
+The filter table is:
+
+    {{index . "LFilter4"}}
+
+<details>
+<summary>iptables commands</summary>
+
+    {{index . "SFilter4"}}
+
+</details>
+
+Differences from [nat mode][400]:
+
+  - In the DOCKER chain:
+    - Where `nat` mode appended a default-DROP rule for any packets not accepted
+      by the per-port/protocol rules, `nat-unprotected` appends a default-ACCEPT
+      rule. [setDefaultForwardRule][402]
+      - The ACCEPT rule is needed in case the filter-FORWARD chain's default
+         policy is DROP.
+    - Because the default for this network is ACCEPT, there is no per-port/protocol
+      rule to ACCEPT packets for the published port `80/tcp`, [setPerPortIptables][401]
+      doesn't set it up.
+      - _If the userland proxy is enabled, it is still started._
+
+The nat table is identical to [nat mode][400].
+
+<details>
+<summary>nat table</summary>
+
+    {{index . "LNat4"}}
+
+    {{index . "SNat4"}}
+
+</details>
+
+[400]: usernet-portmap.md
+[401]: https://github.com/robmry/moby/blob/52c89d467fc5326149e4bbb8903d23589b66ff0d/libnetwork/drivers/bridge/port_mapping_linux.go#L747
+[402]: https://github.com/robmry/moby/blob/52c89d467fc5326149e4bbb8903d23589b66ff0d/libnetwork/drivers/bridge/setup_ip_tables_linux.go#L261-L266

--- a/integration/network/bridge/iptablesdoc/templates/usernet-portmap.md
+++ b/integration/network/bridge/iptablesdoc/templates/usernet-portmap.md
@@ -31,8 +31,8 @@ Note that:
    (unlike all the other rules so-far, which were created during driver or
    network initialisation). [setPerPortForwarding][1]
    - These per-port rules are inserted at the head of the chain, so that they
-     appear before the network's DROP rule [defaultDrop][2] which is always
-     appended to the end of the chain. In this case, because `docker0` was
+     appear before the network's DROP rule [setDefaultForwardRule][2] which is
+     always appended to the end of the chain. In this case, because `docker0` was
      created before `bridge1`, the `bridge1` rules appear above and below the
      `docker0` DROP rule.
 

--- a/libnetwork/drivers/bridge/port_mapping_linux.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux.go
@@ -776,8 +776,11 @@ func (n *bridgeNetwork) setPerPortIptables(b portBinding, enable bool) error {
 	if err := setPerPortNAT(b, v, proxyPath, bridgeName, enable); err != nil {
 		return err
 	}
-	if err := setPerPortForwarding(b, v, bridgeName, enable); err != nil {
-		return err
+
+	if !n.gwMode(v).unprotected() {
+		if err := setPerPortForwarding(b, v, bridgeName, enable); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/libnetwork/drivers/bridge/setup_ip_tables_linux.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux.go
@@ -166,14 +166,14 @@ func (n *bridgeNetwork) setupIPTables(ipVersion iptables.IPVersion, maskedAddr *
 
 	if config.Internal {
 		if err = setupInternalNetworkRules(config.BridgeName, maskedAddr, config.EnableICC, true); err != nil {
-			return fmt.Errorf("Failed to Setup IP tables: %s", err.Error())
+			return fmt.Errorf("Failed to Setup IP tables: %w", err)
 		}
 		n.registerIptCleanFunc(func() error {
 			return setupInternalNetworkRules(config.BridgeName, maskedAddr, config.EnableICC, false)
 		})
 	} else {
 		if err = setupIPTablesInternal(ipVersion, config, maskedAddr, hairpinMode, true); err != nil {
-			return fmt.Errorf("Failed to Setup IP tables: %s", err.Error())
+			return fmt.Errorf("Failed to Setup IP tables: %w", err)
 		}
 		n.registerIptCleanFunc(func() error {
 			return setupIPTablesInternal(ipVersion, config, maskedAddr, hairpinMode, false)
@@ -181,17 +181,17 @@ func (n *bridgeNetwork) setupIPTables(ipVersion iptables.IPVersion, maskedAddr *
 
 		natChain, filterChain, _, _, err := n.getDriverChains(ipVersion)
 		if err != nil {
-			return fmt.Errorf("Failed to setup IP tables, cannot acquire chain info %s", err.Error())
+			return fmt.Errorf("Failed to setup IP tables, cannot acquire chain info %w", err)
 		}
 
 		err = iptable.ProgramChain(natChain, config.BridgeName, hairpinMode, true)
 		if err != nil {
-			return fmt.Errorf("Failed to program NAT chain: %s", err.Error())
+			return fmt.Errorf("Failed to program NAT chain: %w", err)
 		}
 
 		err = iptable.ProgramChain(filterChain, config.BridgeName, hairpinMode, true)
 		if err != nil {
-			return fmt.Errorf("Failed to program FILTER chain: %s", err.Error())
+			return fmt.Errorf("Failed to program FILTER chain: %w", err)
 		}
 		n.registerIptCleanFunc(func() error {
 			return iptable.ProgramChain(filterChain, config.BridgeName, hairpinMode, false)
@@ -387,7 +387,7 @@ func programChainRule(rule iptRule, ruleDescr string, insert bool) error {
 		fn = rule.Insert
 	}
 	if err := fn(); err != nil {
-		return fmt.Errorf("Unable to %s %s rule: %s", operation, ruleDescr, err.Error())
+		return fmt.Errorf("Unable to %s %s rule: %w", operation, ruleDescr, err)
 	}
 	return nil
 }
@@ -400,7 +400,7 @@ func appendOrDelChainRule(rule iptRule, ruleDescr string, append bool) error {
 		fn = rule.Append
 	}
 	if err := fn(); err != nil {
-		return fmt.Errorf("Unable to %s %s rule: %s", operation, ruleDescr, err.Error())
+		return fmt.Errorf("Unable to %s %s rule: %w", operation, ruleDescr, err)
 	}
 	return nil
 }
@@ -413,12 +413,12 @@ func setIcc(version iptables.IPVersion, bridgeIface string, iccEnable, insert bo
 		if !iccEnable {
 			acceptRule.Delete()
 			if err := dropRule.Append(); err != nil {
-				return fmt.Errorf("Unable to prevent intercontainer communication: %s", err.Error())
+				return fmt.Errorf("Unable to prevent intercontainer communication: %w", err)
 			}
 		} else {
 			dropRule.Delete()
 			if err := acceptRule.Insert(); err != nil {
-				return fmt.Errorf("Unable to allow intercontainer communication: %s", err.Error())
+				return fmt.Errorf("Unable to allow intercontainer communication: %w", err)
 			}
 		}
 	} else {


### PR DESCRIPTION
**- What I did**

Add gateway mode `nat-unprotected` for use in option `com.docker.network.bridge.gateway_mode_ipv[46]`.

A `nat-unprotected` network:
- has masquerading and port publishing to the host (like the default `nat` gateway mode).
- has no port/protocol filtering for direct access to the container's address from remote hosts (unlike `nat`).

`nat-unprotected` mode can be used to restore the old default behaviour for IPv4 when the filter-`FORWARD` chain's default policy was "ACCEPT". (Before https://github.com/moby/moby/pull/48594, the daemon would only set the policy to "DROP" when it set sysctl "ip_forward" itself. Now, it never touches the default policy.)

https://docs.docker.com/engine/network/packet-filtering-firewalls/#direct-routing will need an update.

**- How I did it**

In the `DOCKER` chain, where `nat` mode appends a default-DROP rule for any packets not accepted by the per-port/protocol rules, `nat-unprotected` appends a default-ACCEPT rule (needed in case the filter-FORWARD chain's default policy is DROP).

Because the default is ACCEPT, no per-port/protocol rules to ACCEPT packets for the published ports are created. (If the userland proxy is enabled, it is still started.)

**- How to verify it**

New tests.

**- Description for the changelog**
```markdown changelog
- bridge driver options `com.docker.network.bridge.gateway_mode_ipv4` and `com.docker.network.bridge.gateway_mode_ipv6` now accept mode `nat-unprotected`.
  - `nat-unprotected` is similar to the default `nat` mode, but no per port/protocol iptables rules are set up.
  - this means any port on a container can be accessed by direct-routing from a remote host.
```
