### PR TITLE
Speed up pull with larger buffers while writing to layer tempfile

### DIFF
--- a/distribution/utils/ioutil.go
+++ b/distribution/utils/ioutil.go
@@ -1,0 +1,41 @@
+package utils // import "github.com/docker/docker/distribution/utils"
+
+import (
+	"io"
+)
+
+// CopyBufferDirect is equivalent to `io.CopyBuffer`, but without
+// the optimizations to use WriteTo or ReadFrom.
+func CopyBufferDirect(dst io.Writer, src io.Reader, buf []byte) (written int64, err error) {
+	if buf == nil || len(buf) == 0 {
+		panic("empty buffer in CopyBufferDirect")
+	}
+	for {
+		nr, er := src.Read(buf)
+		if nr > 0 {
+			nw, ew := dst.Write(buf[0:nr])
+			if nw < 0 || nr < nw {
+				nw = 0
+				if ew == nil {
+					ew = io.ErrShortWrite
+				}
+			}
+			written += int64(nw)
+			if ew != nil {
+				err = ew
+				break
+			}
+			if nr != nw {
+				err = io.ErrShortWrite
+				break
+			}
+		}
+		if er != nil {
+			if er != io.EOF {
+				err = er
+			}
+			break
+		}
+	}
+	return written, err
+}


### PR DESCRIPTION
## What I did

I investigated `dockerd` with `strace` and noticed it was doing a lot of rather small (less than 16k) writes to the `GetImageBlob` temporary files.

## How I did it

This PR improves upon that by allocating larger buffers for the copy-to-tempfile operation, so not as much time is spent in tiny little syscalls.

However, due to an apparent quirk in how golang's `io.Copy` works (see comments within), just using a buffered writer as the write target doesn't actually end up filling the buffered writer before it flushes to disk, so there's a (likely misplaced!) copy of [`io.copyBuffer`](https://github.com/golang/go/blob/356ba0f06586a833cd8de9c04af0d2adddf95851/src/io/io.go#L405-L456), sans its `ReadFrom` optimization, vendored in. 

## How to verify it

Empirically, in a `lima` Linux aarch64 virtual machine on my Macbook, this seems to improve `hyperfine 'docker rmi -f quay.io/singularity/singularity:v4.1.0-arm64 && docker system prune -f && docker pull quay.io/singularity/singularity:v4.1.0-arm64'` (image chosen because it's not small, and not local – pulling from a `localhost:5000` `registry` registry, or pulling a more trivial image, does not show as much improvement).

The below seems to show a 2% improvement. I'd love for others to replicate (or prove wrong) these results!

### docker-ce `5:27.3.1-1~ubuntu.24.04~noble`

```
Benchmark 1: docker rmi -f quay.io/singularity/singularity:v4.1.0-arm64 && docker system prune -f && docker pull quay.io/singularity/singularity:v4.1.0-arm64
  Time (mean ± σ):     39.294 s ±  2.167 s    [User: 0.050 s, System: 0.047 s]
  Range (min … max):   37.764 s … 45.146 s    10 runs
```

### This branch

```
Benchmark 1: docker rmi -f quay.io/singularity/singularity:v4.1.0-arm64 && docker system prune -f && docker pull quay.io/singularity/singularity:v4.1.0-arm64
  Time (mean ± σ):     38.288 s ±  0.634 s    [User: 0.041 s, System: 0.038 s]
  Range (min … max):   37.652 s … 39.400 s    10 runs
```

## Description for the changelog

```markdown changelog
Improve layer download speed by using larger write buffers
```

## A picture of a cute animal (not mandatory but encouraged)

A closeup of Saarinen, a cat. From the archives, vintage 2008.

![img](https://github.com/user-attachments/assets/7a515762-1607-45a6-891f-e84453fc1f5e)

