### PR TITLE
Use `pools.Copy` for archive file copy operations

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -654,7 +654,7 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 
 		ta.Buffer.Reset(ta.TarWriter)
 		defer ta.Buffer.Reset(nil)
-		_, err = io.Copy(ta.Buffer, file)
+		_, err = pools.Copy(ta.Buffer, file)
 		file.Close()
 		if err != nil {
 			return err
@@ -705,7 +705,7 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, o
 		if err != nil {
 			return err
 		}
-		if _, err := io.Copy(file, reader); err != nil {
+		if _, err := pools.Copy(file, reader); err != nil {
 			file.Close()
 			return err
 		}
@@ -1375,7 +1375,7 @@ func (archiver *Archiver) CopyFileWithTar(src, dst string) (err error) {
 			if err := tw.WriteHeader(hdr); err != nil {
 				return err
 			}
-			if _, err := io.Copy(tw, srcF); err != nil {
+			if _, err := pools.Copy(tw, srcF); err != nil {
 				return err
 			}
 			return nil


### PR DESCRIPTION
## What I did

While investigating #48601, I looked at what `io.Copy` does, and found that it allocates a fresh buffer for each operation by default. This sounds wasteful e.g. when copying small files (Python files, for one, can often be < 32k in size) from tar streams to disk or vice versa.

## How I did it

I found https://github.com/moby/moby/pull/14268 had introduced `pools.Copy`, which uses a pool of 32k buffers (the default for `io.Copy` when you don't pass in a buffer), so this switches the use of `io.Copy` to that implementation. 

## How to verify it

Using the same Hyperfining as in the sibling PR #48602...

Very small improvement, but not a lot of code for it either.

On 367c9100c8d32114bb2533fc47ec6da0d6afa7b9 (`master`):

```
Benchmark 1: docker rmi -f quay.io/singularity/singularity:v4.1.0-arm64 && docker system prune -f && docker pull quay.io/singularity/singularity:v4.1.0-arm64
  Time (mean ± σ):     39.036 s ±  0.775 s    [User: 0.051 s, System: 0.047 s]
  Range (min … max):   37.866 s … 40.025 s    10 runs
```

On 367125e0cc22c87a13f0ad60079458acaee10a50 (this HEAD):

```
Benchmark 1: docker rmi -f quay.io/singularity/singularity:v4.1.0-arm64 && docker system prune -f && docker pull quay.io/singularity/singularity:v4.1.0-arm64
  Time (mean ± σ):     38.651 s ±  0.851 s    [User: 0.053 s, System: 0.044 s]
  Range (min … max):   37.266 s … 40.369 s    10 runs
```

## Description for the changelog

```markdown changelog
Use buffer pool when copying from/to tar
```

## A picture of a cute animal (not mandatory but encouraged)

Some sort of cat, drawn by me just now.
![catsnek](https://github.com/user-attachments/assets/0e7dac47-81ef-4b9d-ac63-bd5a40c49291)

