### PR TITLE
Set NODAD on bridge IPv6 addresses

### DIFF
--- a/libnetwork/drivers/bridge/interface_linux.go
+++ b/libnetwork/drivers/bridge/interface_linux.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"syscall"
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/errdefs"
@@ -134,7 +135,10 @@ func (i *bridgeInterface) programIPv6Addresses(config *networkConfiguration) err
 	// doesn't update the prefix length. This is a cosmetic problem, the prefix
 	// length of an assigned address is not used to determine whether an address is
 	// "on-link" (RFC-5942).
-	if err := i.nlh.AddrReplace(i.Link, &netlink.Addr{IPNet: netiputil.ToIPNet(addrPrefix)}); err != nil {
+	if err := i.nlh.AddrReplace(i.Link, &netlink.Addr{
+		IPNet: netiputil.ToIPNet(addrPrefix),
+		Flags: syscall.IFA_F_NODAD,
+	}); err != nil {
 		return errdefs.System(fmt.Errorf("failed to add IPv6 address %s to bridge: %v", i.bridgeIPv6, err))
 	}
 	return nil


### PR DESCRIPTION
**- What I did**

New test `TestAccessPublishedPortFromHost/userland-proxy=true/IPv6=true` has been flaky.

It seems `docker-proxy` tends to bind to a link-local bridge address for its container-side connection when the bridge's unique-local address is (also) marked as tentative ... that means http requests from the host's netns fail. When the bridge addresses are no longer tentative, it works as expected.

**- How I did it**

Add bridge addresses with `IFA_F_NODAD`.

**- How to verify it**

`TestAccessPublishedPortFromHost/userland-proxy=true/IPv6=true` passes reliably.

**- Description for the changelog**
```markdown changelog
- disable IPv6 duplicate address detection (DAD) for addresses assigned to the bridges belonging to bridge networks
```

