### PR TITLE
api: Allow for an empty string for Isolation in Swagger specs 

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1195,6 +1195,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           MaskedPaths:
             type: "array"
             description: |
@@ -4185,6 +4186,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           Init:
             description: |
               Run an init inside the container that forwards signals and reaps
@@ -5755,6 +5757,7 @@ definitions:
           - "default"
           - "hyperv"
           - "process"
+          - ""
       InitBinary:
         description: |
           Name and, optional, path of the `docker-init` binary.


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/47452

**- What I did**
Modified the Swagger specification to allow an empty string to be a valid option for the Isolation field when inspecting a container with code generated with these specifications. On non Windows systems this is always blank, so it should not give an error in those cases. If there is another approach I should take, or do something different please let me know! I am new to contributing to open source. 

**- How I did it**
I updated the api/swagger.yaml to include - "" as an enum value so it no longer throws an error while inspecting the Isolation field. 

**- How to verify it**

    1. generate code e.g. with openapi-generator-cli
    2. Inspect container on non-windows system
    3. get error about invalid value for Isolation ("")

**- Screenshots**
Result of inspecting Container Before Change
<img width="1335" alt="Before" src="https://github.com/user-attachments/assets/8a2a8247-459b-4cd2-a4af-dc0281a00807">
Result of inspecting Container After Change
<img width="190" alt="After" src="https://github.com/user-attachments/assets/83729f06-23dd-45f4-b368-508674ea8451">

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
api: Allow empty string for Isolation field in container inspection
```

