### PR TITLE
daemon: NewDaemon: align grpc options with containerd's defaults

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -910,8 +910,11 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		return nil, err
 	}
 
+	// Set the max backoff delay to match our containerd.WithTimeout(),
+	// aligning with how containerd client's defaults sets this;
+	// https://github.com/containerd/containerd/blob/v2.0.2/client/client.go#L129-L136
 	backoffConfig := backoff.DefaultConfig
-	backoffConfig.MaxDelay = 3 * time.Second
+	backoffConfig.MaxDelay = 60 * time.Second
 	connParams := grpc.ConnectParams{
 		Backoff: backoffConfig,
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -947,10 +947,6 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		grpc.WithConnectParams(connParams),
 		grpc.WithContextDialer(dialer.ContextDialer),
 
-		// TODO(stevvooe): We may need to allow configuration of this on the client.
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize)),
-		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(defaults.DefaultMaxSendMsgSize)),
-
 		// ------------------------------------------------------------------
 		// end of options copied from containerd's default
 		// ------------------------------------------------------------------

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -916,8 +916,14 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		Backoff: backoffConfig,
 	}
 	gopts := []grpc.DialOption{
-		// WithBlock makes sure that the following containerd request
-		// is reliable.
+		// ------------------------------------------------------------------
+		// options below are copied from containerd client's default options
+		//
+		// TODO(thaJeztah): update this list once https://github.com/containerd/containerd/pull/10250/commits/63b46881753588624b2eac986660458318581330 is in the 1.7 release.
+		// ------------------------------------------------------------------
+
+		// WithReturnConnectionError makes sure that the following containerd
+		// request is reliable, and that connection errors are returned.
 		//
 		// NOTE: In one edge case with high load pressure, kernel kills
 		// dockerd, containerd and containerd-shims caused by OOM.
@@ -930,11 +936,12 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		// we need to restart dockerd to make sure that anything is OK.
 		//
 		// It is painful. Add WithBlock can prevent the edge case. And
-		// n common case, the containerd will be serving in shortly.
+		// in common cases, containerd will be serving in shortly.
 		// It is not harm to add WithBlock for containerd connection.
 		//
 		// TODO(thaJeztah): update this list once https://github.com/containerd/containerd/pull/10250/commits/63b46881753588624b2eac986660458318581330 is in the 1.7 release.
-		grpc.WithBlock(), //nolint:staticcheck // Ignore SA1019: grpc.WithBlock is deprecated: this DialOption is not supported by NewClient. Will be supported throughout 1.x.
+		grpc.WithReturnConnectionError(),  //nolint:staticcheck // Ignore SA1019: grpc.WithReturnConnectionError is deprecated: this DialOption is not supported by NewClient. Will be supported throughout
+		grpc.FailOnNonTempDialError(true), //nolint:staticcheck // Ignore SA1019: grpc.WithReturnConnectionError is deprecated: this DialOption is not supported by NewClient. Will be supported throughout
 
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithConnectParams(connParams),
@@ -943,6 +950,11 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		// TODO(stevvooe): We may need to allow configuration of this on the client.
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize)),
 		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(defaults.DefaultMaxSendMsgSize)),
+
+		// ------------------------------------------------------------------
+		// end of options copied from containerd's default
+		// ------------------------------------------------------------------
+
 		grpc.WithStatsHandler(tracing.ClientStatsHandler(otelgrpc.WithTracerProvider(otel.GetTracerProvider()))),
 		grpc.WithUnaryInterceptor(grpcerrors.UnaryClientInterceptor),
 		grpc.WithStreamInterceptor(grpcerrors.StreamClientInterceptor),

--- a/libcontainerd/supervisor/remote_daemon.go
+++ b/libcontainerd/supervisor/remote_daemon.go
@@ -283,8 +283,6 @@ func (r *remote) monitorDaemon(ctx context.Context) {
 			gopts := []grpc.DialOption{
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 				grpc.WithContextDialer(dialer.ContextDialer),
-				grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize)),
-				grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(defaults.DefaultMaxSendMsgSize)),
 				grpc.WithUnaryInterceptor(grpcerrors.UnaryClientInterceptor),
 				grpc.WithStreamInterceptor(grpcerrors.StreamClientInterceptor),
 			}

--- a/libcontainerd/supervisor/remote_daemon.go
+++ b/libcontainerd/supervisor/remote_daemon.go
@@ -280,17 +280,15 @@ func (r *remote) monitorDaemon(ctx context.Context) {
 				continue
 			}
 
-			gopts := []grpc.DialOption{
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-				grpc.WithContextDialer(dialer.ContextDialer),
-				grpc.WithUnaryInterceptor(grpcerrors.UnaryClientInterceptor),
-				grpc.WithStreamInterceptor(grpcerrors.StreamClientInterceptor),
-			}
-
 			client, err = containerd.New(
 				r.GRPC.Address,
 				containerd.WithTimeout(60*time.Second),
-				containerd.WithDialOpts(gopts),
+				containerd.WithDialOpts([]grpc.DialOption{
+					grpc.WithTransportCredentials(insecure.NewCredentials()),
+					grpc.WithContextDialer(dialer.ContextDialer),
+					grpc.WithUnaryInterceptor(grpcerrors.UnaryClientInterceptor),
+					grpc.WithStreamInterceptor(grpcerrors.StreamClientInterceptor),
+				}),
 			)
 			if err != nil {
 				r.logger.WithError(err).Error("failed connecting to containerd")


### PR DESCRIPTION
### daemon: NewDaemon: align grpc options with containerd's defaults

Dial-options passed to containerd _override_ all defaults that are set
in containerd, and containerd does not provide an option to provide
the defaults in other ways, which makes it slightly more complicated
to use the defaults combined with some custom options.
https://github.com/containerd/containerd/blob/v1.7.22/client.go#L122-L132

This patch aligns the options we set with the defaults in containerd.

grpc.FailOnNonTempDialError was added together with WithBlock in [containerd@64bc516],
but it looks like this was not copied to our options when the equivalent was
added in this repository through 9f73396dabf087a8dd5fa74296c2cd4c188ff889.

grpc.WithReturnConnectionError was added in [containerd@73d28dd] to improve
handling of connection errors;

Permission errors:

    % ./bin/ctr t ls
    ctr: failed to dial "/run/containerd/containerd.sock": connection error: desc = "transport: error while dialing: dial unix /run/containerd/containerd.sock: connect: permission denied"
    %

Non-existent sockets:

    % ./bin/ctr -a notfound t ls
    ctr: failed to dial "notfound": context deadline exceeded: connection error: desc = "transport: error while dialing: dial unix://notfound: timeout"
    %

That commit failed to notice that WithReturnConnectionError implies WithBlock,
so removing that option from the list.

Note that both WithBlock and WithReturnConnectionError are deprecated in
newer versions of grpc, so we should remove these once [containerd@63b4688]
makes it into the containerd 1.7 branch (and vendored).

[containerd@64bc516]: https://github.com/containerd/containerd/commit/64bc516bbef03e13ff09d9b40ec2f05f82bb387e
[containerd@73d28dd]: https://github.com/containerd/containerd/commit/73d28ddeb27a5532df084035199c9ad5ed2f69fe
[containerd@63b4688]: https://github.com/containerd/containerd/pull/10250/commits/63b46881753588624b2eac986660458318581330


### daemon: NewDaemon: remove grpc options that are the default

The default message size is set unconditionally in containerd's client,
so unlike Dial-options, there's no risk of implicitly dropping these
options.

TThis patch removes the options, as they were the same as the default
already set in containerd itself.

https://github.com/containerd/containerd/blob/v1.7.22/client.go#L133-L138

### libcontainerd/supervisor: remove grpc options that are the default

The default message size is set unconditionally in containerd's client,
so unlike Dial-options, there's no risk of implicitly dropping these
options.

TThis patch removes the options, as they were the same as the default
already set in containerd itself.

https://github.com/containerd/containerd/blob/v1.7.22/client.go#L133-L138



**- A picture of a cute animal (not mandatory but encouraged)**

