### PR TITLE
client: fixes bug #48618 "undefined: errors.As" error, which is caus…

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -2,11 +2,11 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 )
 
 // errConnectionFailed implements an error returned when connection failed.


### PR DESCRIPTION
…ed by imported "github.com/pkg/errors" instead of "errors"

For errors.go, I replaced "github.com/pkg/errors" with "error" since only "errors" are used.
For request.go, since both packages are used, so I alias "github.com/pkg/errors" as pkgError.

Signed-off-by: ChocolateAceCream


![Weixin Screenshot_20241009185356](https://github.com/user-attachments/assets/98dcf203-fd53-419d-94c8-7cbe755884e4)
