### PR TITLE
client: fix  issue #48618 "undefined: errors.As" error, which is caus…

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -2,11 +2,11 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 )
 
 // errConnectionFailed implements an error returned when connection failed.


### PR DESCRIPTION
…ed by imported "github.com/pkg/errors" instead of "errors"

For errors.go, I replaced "github.com/pkg/errors" with "error" since only "errors" are used.
For request.go, since both packages are used, so I alias "github.com/pkg/errors" as pkgError.
![Weixin Screenshot_20241009185356](https://github.com/user-attachments/assets/73ffcd30-7bbc-40f8-abc8-4a2a78db66b8)


