### PR TITLE
[26.1 backport] gha: buildkit: make sure expected Go version is installed

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -88,6 +88,11 @@ jobs:
         with:
           path: moby
       -
+        name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      -
         name: BuildKit ref
         run: |
           echo "$(./hack/buildkit-ref)" >> $GITHUB_ENV


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/48615

The buildkit workflow uses Go to determine the version of Buildkit to run integration-tests for. It currently uses on the default version that's installed on the GitHub actions runners (1.21.13 currently), but this fails if the go.mod/vendor.mod specify a higher version of Go as required version.

If this fails, the BUILDKIT_REF and REPO env-vars are not set / empty, resulting in the workflow checking out the current (moby) repository instead of buildkit, which fails.

This patch adds a step to explicitly install the expected version of Go.


**- A picture of a cute animal (not mandatory but encouraged)**