### PR TITLE
Touch-up some errors for missing platforms

### DIFF
--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -31,9 +31,9 @@ type errPlatformNotFound struct {
 
 func (e *errPlatformNotFound) NotFound() {}
 func (e *errPlatformNotFound) Error() string {
-	msg := "image with reference " + e.imageRef + " was found but does not match the specified platform"
+	msg := "image with reference " + e.imageRef + " was found but does not provide the specified platform"
 	if e.wanted.OS != "" {
-		msg += ": wanted " + platforms.FormatAll(e.wanted)
+		msg += " (" + platforms.FormatAll(e.wanted) + ")"
 	}
 	return msg
 }

--- a/daemon/containerd/image_exporter.go
+++ b/daemon/containerd/image_exporter.go
@@ -89,7 +89,7 @@ func (i *ImageService) ExportImage(ctx context.Context, names []string, platform
 		if platform != nil {
 			newTarget, err := i.getPushDescriptor(ctx, img, platform)
 			if err != nil {
-				return errors.Wrap(err, "no suitable export target found for platform "+platforms.FormatAll(*platform))
+				return errors.Wrap(err, "no suitable export target found")
 			}
 			target = newTarget
 		}

--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -261,7 +261,11 @@ func (i *ImageService) getPushDescriptor(ctx context.Context, img containerdimag
 
 	switch len(presentMatchingManifests) {
 	case 0:
-		return ocispec.Descriptor{}, errdefs.NotFound(fmt.Errorf("no suitable image manifest found for platform %s", *platform))
+		err := &errPlatformNotFound{imageRef: imageFamiliarName(img)}
+		if pm.Requested != nil {
+			err.wanted = *pm.Requested
+		}
+		return ocispec.Descriptor{}, err
 	case 1:
 		// Only one manifest is available AND matching the requested platform.
 
@@ -293,7 +297,7 @@ func (i *ImageService) getPushDescriptor(ctx context.Context, img containerdimag
 			return ocispec.Descriptor{}, errdefs.Conflict(errors.Errorf("multiple matching manifests found but no specific platform requested"))
 		}
 
-		return ocispec.Descriptor{}, errdefs.Conflict(errors.Errorf("multiple manifests found for platform %s", *platform))
+		return ocispec.Descriptor{}, errdefs.Conflict(errors.Errorf("multiple manifests found for platform %s", platforms.FormatAll(*platform)))
 	}
 }
 

--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -200,7 +200,11 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options bac
 		//   This may be confusing.
 		//   The alternative to this is to return an errdefs.Conflict error with a helpful message, but clients will not be
 		//   able to automatically tell what causes the conflict.
-		retErr = errdefs.NotFound(errors.Errorf("image with reference %s was found but does not match the specified platform: wanted %s, actual: %s", refOrID, platforms.Format(p), platforms.Format(imgPlat)))
+		imgName := refOrID
+		if ref, err := reference.ParseNamed(refOrID); err == nil {
+			imgName = reference.FamiliarString(ref)
+		}
+		retErr = errdefs.NotFound(errors.Errorf("image with reference %s was found but its platform (%s) does not match the specified platform (%s)", imgName, platforms.Format(imgPlat), platforms.Format(p)))
 	}()
 	ref, err := reference.ParseAnyReference(refOrID)
 	if err != nil {

--- a/daemon/images/image_push.go
+++ b/daemon/images/image_push.go
@@ -2,7 +2,6 @@ package images // import "github.com/docker/docker/daemon/images"
 
 import (
 	"context"
-	"errors"
 	"io"
 	"time"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/distribution"
 	progressutils "github.com/docker/docker/distribution/utils"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/progress"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -23,7 +21,7 @@ func (i *ImageService) PushImage(ctx context.Context, ref reference.Named, platf
 		// Check if the image is actually the platform we want to push.
 		_, err := i.GetImage(ctx, ref.String(), backend.GetImageOpts{Platform: platform})
 		if err != nil {
-			return errdefs.InvalidParameter(errors.New("graphdriver backed image store doesn't support multiplatform images"))
+			return err
 		}
 	}
 	start := time.Now()


### PR DESCRIPTION
- related to https://github.com/docker/cli/pull/5331

### PushImage: remove misleading error about --platform without containerd

Without containerd store enabled, we were discarding underlying errors,
and instead informing the user that `--platform` is not suported;

    docker pull --quiet --platform=linux/riscv64 alpine:latest
    docker image push --platform=linux/amd64 alpine:latest
    Error response from daemon: graphdriver backed image store doesn't support multiplatform images

However, that's not the case; platform filtering works, but if the image
is not the right platform, the push fails (which is the same as would
happen with the containerd image store enabled).

    docker image push --platform=linux/amd64 alpine:latest
    Error response from daemon: image with reference docker.io/library/alpine:latest was found but does not match the specified platform: wanted linux/amd64, actual: linux/riscv64

When specifying the platform and that platform matches, it finds the image,
and the push continue;


    docker image push --platform=linux/riscv64 alpine:latest
    The push refers to repository [docker.io/library/alpine]
    3fd4750fd687: Layer already exists
    ...

(The above example obviously fails because I don't have permissions to
push official images).


### images: GetImage: touch-up error message for missing platform

Slightly touching up the error message, because the "wanted/actual" output
felt too much like a assertion failure in a test-case.

- Format the image-reference using "familiar" format, which shows the
  image's short name for official images.
- Move the actual and requested platforms to be a part of the sentence,
  but within braces.
 

Before this patch:

    docker image push --platform=linux/amd64 alpine:latest
    Error response from daemon: image with reference docker.io/library/alpine:latest was found but does not match the specified platform: wanted linux/amd64, actual: linux/riscv64

With this patch:

    docker image push --platform=linux/amd64 alpine:latest
    Error response from daemon: image with reference alpine:latest was found but its platform (linux/riscv64) does not match the specified platform (linux/amd64)


### daemon/containerd: touch-up errPlatformNotFound error

- Changed "match" to "provide", in an attempt to indicate that the image is
  a multi-platform image that doesn't contain the given platform.
- Remove the "wanted" and instead make the requested platforms to be a part
  of the sentence, but within braces.


Before this patch:

    docker pull --quiet --platform=linux/riscv64 alpine:latest
    docker image history --platform=linux/amd64 alpine
    Error response from daemon: image with reference alpine:latest was found but does not match the specified platform: wanted linux/nosuch

With this patch:

    docker pull --quiet --platform=linux/riscv64 alpine:latest
    docker image history --platform=linux/amd64 alpine
    Error response from daemon: image with reference alpine:latest was found but does not provide the specified platform (linux/amd64)



### daemon/containerd: getPushDescriptor: fix formatting of platform in errors

The platform was printed in its raw format, which didn't produce a very
readable output;

Before this change:

    $ docker image save --platform=linux/amd64 -o alpine_amd64.tar alpine:latest
    Error response from daemon: no suitable export target found for platform linux/amd64: no suitable image manifest found for platform {amd64 linux [] }

After this change:

    $ docker image save --platform=linux/amd64 -o alpine_amd64.tar alpine:latest
    Error response from daemon: no suitable export target found: image with reference alpine:latest was found but does not provide the specified platform (linux/amd64)

