### PR TITLE
[27.x backport] daemon/containerd: getPushDescriptor: fix formatting of platform in errors

### DIFF
--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -270,7 +270,7 @@ func (i *ImageService) getPushDescriptor(ctx context.Context, img containerdimag
 
 	switch len(presentMatchingManifests) {
 	case 0:
-		return ocispec.Descriptor{}, errdefs.NotFound(fmt.Errorf("no suitable image manifest found for platform %s", *platform))
+		return ocispec.Descriptor{}, errdefs.NotFound(fmt.Errorf("no suitable image manifest found for platform %s", platforms.FormatAll(*platform)))
 	case 1:
 		// Only one manifest is available AND matching the requested platform.
 
@@ -302,7 +302,7 @@ func (i *ImageService) getPushDescriptor(ctx context.Context, img containerdimag
 			return ocispec.Descriptor{}, errdefs.Conflict(errors.Errorf("multiple matching manifests found but no specific platform requested"))
 		}
 
-		return ocispec.Descriptor{}, errdefs.Conflict(errors.Errorf("multiple manifests found for platform %s", *platform))
+		return ocispec.Descriptor{}, errdefs.Conflict(errors.Errorf("multiple manifests found for platform %s", platforms.FormatAll(*platform)))
 	}
 }
 


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/48631


The platform was printed in its raw format, which didn't produce a very readable output;

Before this change:

    $ docker image save --platform=linux/amd64 -o alpine_amd64.tar alpine:latest
    Error response from daemon: no suitable export target found for platform linux/amd64: no suitable image manifest found for platform {amd64 linux  [] }

After this change:

    $ docker image save --platform=linux/amd64 -o alpine_amd64.tar alpine:latest
    Error response from daemon: no suitable export target found for platform linux/amd64: no suitable image manifest found for platform linux/amd64


(cherry picked from commit ad2426213e01f5494ea434a9cb2cf9c5029dda17)


