### PR TITLE
Use iptables-nft in the dev container / CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -538,6 +538,7 @@ RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,target=/var/lib/apt \
             inetutils-ping \
             iproute2 \
             iptables \
+            nftables \
             jq \
             libcap2-bin \
             libnet1 \
@@ -558,11 +559,6 @@ RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,target=/var/lib/apt \
             xz-utils \
             zip \
             zstd
-# Switch to use iptables instead of nftables (to match the CI hosts)
-# TODO use some kind of runtime auto-detection instead if/when nftables is supported (https://github.com/moby/moby/issues/26824)
-RUN update-alternatives --set iptables  /usr/sbin/iptables-legacy  || true \
- && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy || true \
- && update-alternatives --set arptables /usr/sbin/arptables-legacy || true
 RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,target=/var/lib/apt \
     --mount=type=cache,sharing=locked,id=moby-dev-aptcache,target=/var/cache/apt \
         apt-get update && apt-get install --no-install-recommends -y \

--- a/libnetwork/firewall_linux_test.go
+++ b/libnetwork/firewall_linux_test.go
@@ -2,6 +2,7 @@ package libnetwork
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker/internal/testutils/netnsutils"
@@ -12,6 +13,7 @@ import (
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"
+	"gotest.tools/v3/icmd"
 )
 
 const (
@@ -22,6 +24,15 @@ const (
 func TestUserChain(t *testing.T) {
 	iptable4 := iptables.GetIptable(iptables.IPv4)
 	iptable6 := iptables.GetIptable(iptables.IPv6)
+
+	res := icmd.RunCommand("iptables", "--version")
+	assert.NilError(t, res.Error)
+	noChainErr := "No chain/target/match by that name"
+	if strings.Contains(res.Combined(), "nf_tables") {
+		// For a non-existent chain, iptables-nft "-S <chain>" reports:
+		//  ip6tables v1.8.9 (nf_tables): chain `<chain>' in table `filter' is incompatible, use 'nft' tool.
+		noChainErr = "incompatible, use 'nft' tool"
+	}
 
 	tests := []struct {
 		iptables bool
@@ -83,9 +94,9 @@ func TestUserChain(t *testing.T) {
 					fmt.Sprintf("TestUserChain_iptables-%v_append-%v_usrafter6", tc.iptables, tc.append))
 			} else {
 				_, err := iptable4.Raw("-S", usrChainName)
-				assert.Check(t, is.ErrorContains(err, "No chain/target/match by that name"), "ipv4 chain %v: created unexpectedly", usrChainName)
+				assert.Check(t, is.ErrorContains(err, noChainErr), "ipv4 chain %v: created unexpectedly", usrChainName)
 				_, err = iptable6.Raw("-S", usrChainName)
-				assert.Check(t, is.ErrorContains(err, "No chain/target/match by that name"), "ipv6 chain %v: created unexpectedly", usrChainName)
+				assert.Check(t, is.ErrorContains(err, noChainErr), "ipv6 chain %v: created unexpectedly", usrChainName)
 			}
 		})
 	}


### PR DESCRIPTION
**- What I did**

Moby's development container uses `iptables-legacy`. So, that's what we're testing with in CI.

Most of the world has moved on from `xtables`. For them, Docker is already using `iptables-nft` (as a front end for creating nftables rules). Let's test that instead.

Switching to `iptables-nft` also makes `nft` available in the dev container, which will make development of native nftables support easier.

**- How I did it**

Updated the config, fixed a unit test.

In the Dockerfile, we set the firewalld backend to `iptables` ... I tried leaving it at `nftables`, but firewalld's not able to start (it loses all hope!). Not sure why, but it can be a separate problem ...

> ERROR: COMMAND_FAILED: 'python-nftables' failed: internal:0:0-0: Error: Could not process rule: No such file or directory
> \<massive JSON blob>
> ERROR: Failed to load full stock configuration. This likely indicates a system level issue, e.g. the firewall backend (nftables, iptables) is broken. All hope is lost. Exiting.

**- How to verify it**

CI

**- Description for the changelog**
```markdown changelog

```