### PR TITLE
Disable iptables/ip6tables in two tests to remove conflict

### DIFF
--- a/integration/container/attach_test.go
+++ b/integration/container/attach_test.go
@@ -77,7 +77,7 @@ func TestAttachDisconnectLeak(t *testing.T) {
 	d := daemon.New(t)
 	defer d.Cleanup(t)
 
-	d.StartWithBusybox(ctx, t, "--iptables=false")
+	d.StartWithBusybox(ctx, t, "--iptables=false", "--ip6tables=false")
 
 	client := d.NewClientT(t)
 

--- a/integration/container/daemon_test.go
+++ b/integration/container/daemon_test.go
@@ -67,7 +67,7 @@ func TestNetworkStateCleanupOnDaemonStart(t *testing.T) {
 	d := daemon.New(t)
 	defer d.Cleanup(t)
 
-	d.StartWithBusybox(ctx, t)
+	d.StartWithBusybox(ctx, t, "--iptables=false", "--ip6tables=false")
 	defer d.Stop(t)
 
 	apiClient := d.NewClientT(t)


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/42358

**- What I did**

Fix a flaky test ...

`TestAttachDisconnectLeak` starts its own daemon with iptables disabled, but disabling ip6tables was missed when we enabled ip6tables by default.

`TestNetworkStateCleanupOnDaemonStart` also starts its own daemon, with iptables and ip6tables both enabled. It isn't trying to test anything iptables related.

These tests run in parallel, so they both modify ip6tables in the host namespace - and could break each other by adding/removing chains at awkward moments.

From a CI run ...
```
=== CONT  TestNetworkStateCleanupOnDaemonStart
=== CONT  TestAttachDisconnectLeak
=== CONT  TestStopContainerWithTimeoutCancel
=== CONT  TestRestartDaemonWithRestartingContainer
    daemon.go:318: [dc1726334a0ab] time="2024-10-11T11:05:22.627702530Z" level=debug msg="Request address PoolID:172.18.0.0/16 Bits: 65536, Unselected: 65534, Sequence: (0x80000000, 1)->(0x0, 2046)->(0x1, 1)->end Curr:0 Serial:false PrefAddress:172.18.0.1 "
[...]
    daemon.go:318: [dc1726334a0ab] time="2024-10-11T11:05:22.636698297Z" level=debug msg="Cleaning up old mountid : done."
    daemon.go:318: [dc1726334a0ab] failed to start daemon: Error initializing network controller: error creating default "bridge" network: add inter-network communication rule:  (iptables failed: ip6tables --wait -t filter -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2: ip6tables v1.8.9 (legacy): Couldn't load target `DOCKER-ISOLATION-STAGE-2':No such file or directory
    daemon.go:318: [dc1726334a0ab] 
    daemon.go:318: [dc1726334a0ab] Try `ip6tables -h' or 'ip6tables --help' for more information.
    daemon.go:318: [dc1726334a0ab]  (exit status 2))
    attach_test.go:80: [dc1726334a0ab] failed to start daemon with arguments [--data-root /go/src/github.com/docker/docker/bundles/test-integration/TestAttachDisconnectLeak/dc1726334a0ab/root --exec-root /tmp/dxr/dc1726334a0ab --pidfile /go/src/github.com/docker/docker/bundles/test-integration/TestAttachDisconnectLeak/dc1726334a0ab/docker.pid --userland-proxy=true --containerd-namespace dc1726334a0ab --containerd-plugins-namespace dc1726334a0abp --containerd /var/run/docker/containerd/containerd.sock --host unix:///tmp/docker-integration/dc1726334a0ab.sock --debug --storage-driver overlayfs --iptables=false] : [dc1726334a0ab] daemon exited during startup: exit status 1
--- FAIL: TestAttachDisconnectLeak (0.50s)
```

**- How I did it**

Disable iptables and ip6tables in both tests.

**- How to verify it**

n/a

**- Description for the changelog**
```markdown changelog
n/a
```