### PR TITLE
gha: restrict cross and bin-image to 20 minutes

### DIFF
--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -41,7 +41,7 @@ jobs:
 
   prepare:
     runs-on: ubuntu-20.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 20 # guardrails timeout for the whole job
     outputs:
       platforms: ${{ steps.platforms.outputs.matrix }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
 
   prepare-cross:
     runs-on: ubuntu-latest
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 20 # guardrails timeout for the whole job
     needs:
       - validate-dco
     outputs:
@@ -92,7 +92,7 @@ jobs:
 
   cross:
     runs-on: ubuntu-20.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 20 # guardrails timeout for the whole job
     needs:
       - validate-dco
       - prepare-cross


### PR DESCRIPTION
- addresses https://github.com/moby/moby/issues/45233
- relates to https://github.com/moby/moby/pull/48631#issuecomment-2408116551
- relates to https://github.com/moby/moby/pull/48634#issuecomment-2408008744
- follow-up to https://github.com/moby/moby/pull/48629


We had a couple of runs where these jobs got stuck and github actions didn't allow terminating them, so that they were only terminated after 120 minutes.

These jobs usually complete in 5 minutes, so let's give them a shorter timeout. 20 minutes should be enough (don't @ me).

**- A picture of a cute animal (not mandatory but encouraged)**

![5069a4a943a9bcf09b2e37350f998ca6db08a830_hq](https://github.com/user-attachments/assets/0e3a56dd-ad7a-4e86-b14b-020a550bea2c)
