### PR TITLE
[27.x backport] gha: restrict cross and bin-image to 20 minutes

### DIFF
--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -41,7 +41,7 @@ jobs:
 
   prepare:
     runs-on: ubuntu-20.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 20 # guardrails timeout for the whole job
     outputs:
       platforms: ${{ steps.platforms.outputs.matrix }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
 
   prepare-cross:
     runs-on: ubuntu-latest
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 20 # guardrails timeout for the whole job
     needs:
       - validate-dco
     outputs:
@@ -92,7 +92,7 @@ jobs:
 
   cross:
     runs-on: ubuntu-20.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 20 # guardrails timeout for the whole job
     needs:
       - validate-dco
       - prepare-cross


### PR DESCRIPTION
**- What I did**
* Backports https://github.com/moby/moby/pull/48645 to 27.x

We had a couple of runs where these jobs got stuck and github actions didn't allow terminating them, so that they were only terminated after 120 minutes.

These jobs usually complete in 5 minutes, so let's give them a shorter timeout. 20 minutes should be enough (don't @ me).

(cherry picked from commit c68c9aed8cb3916669de6d7f2c564279ec83663f)

**- How I did it**
```
git cherry-pick -xsS c68c9aed8cb3916669de6d7f2c564279ec83663f
```

**- Description for the changelog**
```markdown changelog
n/a
```

**- A picture of a cute animal (not mandatory but encouraged)**

