### PR TITLE
[25.0 backport] gha: add guardrails timeouts on all jobs

### DIFF
--- a/.github/workflows/.dco.yml
+++ b/.github/workflows/.dco.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   run:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120 # guardrails timeout for the whole job
     steps:
       -
         name: Checkout

--- a/.github/workflows/.test-prepare.yml
+++ b/.github/workflows/.test-prepare.yml
@@ -22,6 +22,7 @@ on:
 jobs:
   run:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120 # guardrails timeout for the whole job
     outputs:
       matrix: ${{ steps.set.outputs.matrix }}
     steps:

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -32,8 +32,8 @@ env:
 jobs:
   unit:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ github.event_name != 'pull_request' }}
-    timeout-minutes: 120
     steps:
       -
         name: Checkout
@@ -83,8 +83,8 @@ jobs:
 
   unit-report:
     runs-on: ubuntu-20.04
-    continue-on-error: ${{ github.event_name != 'pull_request' }}
     timeout-minutes: 10
+    continue-on-error: ${{ github.event_name != 'pull_request' }}
     if: always()
     needs:
       - unit
@@ -111,8 +111,8 @@ jobs:
 
   docker-py:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ github.event_name != 'pull_request' }}
-    timeout-minutes: 120
     steps:
       -
         name: Checkout
@@ -164,8 +164,8 @@ jobs:
 
   integration-flaky:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ github.event_name != 'pull_request' }}
-    timeout-minutes: 120
     steps:
       -
         name: Checkout
@@ -192,8 +192,8 @@ jobs:
 
   integration:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ github.event_name != 'pull_request' }}
-    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -286,8 +286,8 @@ jobs:
 
   integration-report:
     runs-on: ubuntu-20.04
-    continue-on-error: ${{ github.event_name != 'pull_request' }}
     timeout-minutes: 10
+    continue-on-error: ${{ github.event_name != 'pull_request' }}
     if: always()
     needs:
       - integration
@@ -315,6 +315,7 @@ jobs:
 
   integration-cli-prepare:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     outputs:
       matrix: ${{ steps.tests.outputs.matrix }}
@@ -350,8 +351,8 @@ jobs:
 
   integration-cli:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ github.event_name != 'pull_request' }}
-    timeout-minutes: 120
     needs:
       - integration-cli-prepare
     strategy:
@@ -426,8 +427,8 @@ jobs:
 
   integration-cli-report:
     runs-on: ubuntu-20.04
-    continue-on-error: ${{ github.event_name != 'pull_request' }}
     timeout-minutes: 10
+    continue-on-error: ${{ github.event_name != 'pull_request' }}
     if: always()
     needs:
       - integration-cli

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -12,7 +12,6 @@ name: .windows
 permissions:
   contents: read
 
-
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -12,6 +12,7 @@ name: .windows
 permissions:
   contents: read
 
+
 on:
   workflow_call:
     inputs:
@@ -42,6 +43,7 @@ env:
 jobs:
   build:
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 120 # guardrails timeout for the whole job
     env:
       GOPATH: ${{ github.workspace }}\go
       GOBIN: ${{ github.workspace }}\go\bin
@@ -121,7 +123,7 @@ jobs:
 
   unit-test:
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 120
+    timeout-minutes: 120 # guardrails timeout for the whole job
     env:
       GOPATH: ${{ github.workspace }}\go
       GOBIN: ${{ github.workspace }}\go\bin
@@ -203,6 +205,7 @@ jobs:
 
   unit-test-report:
     runs-on: ubuntu-latest
+    timeout-minutes: 120 # guardrails timeout for the whole job
     if: always()
     needs:
       - unit-test
@@ -229,6 +232,7 @@ jobs:
 
   integration-test-prepare:
     runs-on: ubuntu-latest
+    timeout-minutes: 120 # guardrails timeout for the whole job
     outputs:
       matrix: ${{ steps.tests.outputs.matrix }}
     steps:
@@ -262,8 +266,8 @@ jobs:
 
   integration-test:
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ inputs.storage == 'snapshotter' && github.event_name != 'pull_request' }}
-    timeout-minutes: 120
     needs:
       - build
       - integration-test-prepare
@@ -522,6 +526,7 @@ jobs:
 
   integration-test-report:
     runs-on: ubuntu-latest
+    timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ inputs.storage == 'snapshotter' && github.event_name != 'pull_request' }}
     if: always()
     needs:

--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -38,6 +38,7 @@ jobs:
 
   prepare:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120 # guardrails timeout for the whole job
     outputs:
       platforms: ${{ steps.platforms.outputs.matrix }}
     steps:
@@ -90,6 +91,7 @@ jobs:
 
   build:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120 # guardrails timeout for the whole job
     needs:
       - validate-dco
       - prepare
@@ -160,6 +162,7 @@ jobs:
 
   merge:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120 # guardrails timeout for the whole job
     needs:
       - build
     if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && github.event_name != 'pull_request' && github.repository == 'moby/moby'

--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -38,7 +38,7 @@ jobs:
 
   prepare:
     runs-on: ubuntu-20.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 20 # guardrails timeout for the whole job
     outputs:
       platforms: ${{ steps.platforms.outputs.matrix }}
     steps:

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -32,6 +32,7 @@ jobs:
 
   build:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120 # guardrails timeout for the whole job
     needs:
       - validate-dco
     steps:
@@ -57,7 +58,7 @@ jobs:
 
   test:
     runs-on: ubuntu-20.04
-    timeout-minutes: 120
+    timeout-minutes: 120 # guardrails timeout for the whole job
     needs:
       - build
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
 
   build:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120 # guardrails timeout for the whole job
     needs:
       - validate-dco
     strategy:
@@ -63,6 +64,7 @@ jobs:
 
   prepare-cross:
     runs-on: ubuntu-latest
+    timeout-minutes: 120 # guardrails timeout for the whole job
     needs:
       - validate-dco
     outputs:
@@ -84,6 +86,7 @@ jobs:
 
   cross:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120 # guardrails timeout for the whole job
     needs:
       - validate-dco
       - prepare-cross

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
   prepare-cross:
     runs-on: ubuntu-latest
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 20 # guardrails timeout for the whole job
     needs:
       - validate-dco
     outputs:
@@ -86,7 +86,7 @@ jobs:
 
   cross:
     runs-on: ubuntu-20.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 20 # guardrails timeout for the whole job
     needs:
       - validate-dco
       - prepare-cross

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
 
   build-dev:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120 # guardrails timeout for the whole job
     needs:
       - validate-dco
     strategy:
@@ -80,6 +81,7 @@ jobs:
 
   validate-prepare:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120 # guardrails timeout for the whole job
     needs:
       - validate-dco
     outputs:
@@ -101,7 +103,7 @@ jobs:
 
   validate:
     runs-on: ubuntu-20.04
-    timeout-minutes: 120
+    timeout-minutes: 120 # guardrails timeout for the whole job
     needs:
       - validate-prepare
       - build-dev
@@ -135,6 +137,7 @@ jobs:
 
   smoke-prepare:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120 # guardrails timeout for the whole job
     needs:
       - validate-dco
     outputs:
@@ -156,6 +159,7 @@ jobs:
 
   smoke:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120 # guardrails timeout for the whole job
     needs:
       - smoke-prepare
     strategy:

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   check-area-label:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120 # guardrails timeout for the whole job
     steps:
       - name: Missing `area/` label
         if: contains(join(github.event.pull_request.labels.*.name, ','), 'impact/') && !contains(join(github.event.pull_request.labels.*.name, ','), 'area/')
@@ -28,6 +29,7 @@ jobs:
   check-changelog:
     if: contains(join(github.event.pull_request.labels.*.name, ','), 'impact/')
     runs-on: ubuntu-20.04
+    timeout-minutes: 120 # guardrails timeout for the whole job
     env:
       PR_BODY: |
         ${{ github.event.pull_request.body }}
@@ -56,6 +58,7 @@ jobs:
 
   check-pr-branch:
     runs-on: ubuntu-20.04
+    timeout-minutes: 120 # guardrails timeout for the whole job
     env:
       PR_TITLE: ${{ github.event.pull_request.title }}
     steps:


### PR DESCRIPTION
**- What I did**
* Backports https://github.com/moby/moby/pull/48629 to 25.0
* Backports https://github.com/moby/moby/pull/48645 to 25.0
* Backports https://github.com/moby/moby/pull/48636 to 25.0

**- How I did it**

```
git cherry-pick -xsS 6b7e2783d1e68c4da3764525e3e8e74b85d0d8c8
git cherry-pick -xsS c68c9aed8cb3916669de6d7f2c564279ec83663f
git cherry-pick -xsS 037bac89fcebb4eb085fb679590663f067dd9aac
```

**- Description for the changelog**
```markdown changelog
n/a
```

**- A picture of a cute animal (not mandatory but encouraged)**
