### PR TITLE
client: imageBuildOptionsToQuery: omit empty and default values from query

### DIFF
--- a/client/image_build.go
+++ b/client/image_build.go
@@ -63,9 +63,11 @@ func (cli *Client) imageBuildOptionsToQuery(ctx context.Context, options types.I
 	if options.NoCache {
 		query.Set("nocache", "1")
 	}
-	if options.Remove {
-		query.Set("rm", "1")
-	} else {
+	if !options.Remove {
+		// only send value when opting out because the daemon's default is
+		// to remove intermediate containers after a successful build,
+		//
+		// TODO(thaJeztah): deprecate "Remove" option, and provide a "NoRemove" or "Keep" option instead.
 		query.Set("rm", "0")
 	}
 

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -44,10 +44,15 @@ func (cli *Client) ImageBuild(ctx context.Context, buildContext io.Reader, optio
 }
 
 func (cli *Client) imageBuildOptionsToQuery(ctx context.Context, options types.ImageBuildOptions) (url.Values, error) {
-	query := url.Values{
-		"t":           options.Tags,
-		"securityopt": options.SecurityOpt,
-		"extrahosts":  options.ExtraHosts,
+	query := url.Values{}
+	if len(options.Tags) > 0 {
+		query["t"] = options.Tags
+	}
+	if len(options.SecurityOpt) > 0 {
+		query["securityopt"] = options.SecurityOpt
+	}
+	if len(options.ExtraHosts) > 0 {
+		query["extrahosts"] = options.ExtraHosts
 	}
 	if options.SuppressOutput {
 		query.Set("q", "1")
@@ -83,42 +88,70 @@ func (cli *Client) imageBuildOptionsToQuery(ctx context.Context, options types.I
 		query.Set("isolation", string(options.Isolation))
 	}
 
-	query.Set("cpusetcpus", options.CPUSetCPUs)
-	query.Set("networkmode", options.NetworkMode)
-	query.Set("cpusetmems", options.CPUSetMems)
-	query.Set("cpushares", strconv.FormatInt(options.CPUShares, 10))
-	query.Set("cpuquota", strconv.FormatInt(options.CPUQuota, 10))
-	query.Set("cpuperiod", strconv.FormatInt(options.CPUPeriod, 10))
-	query.Set("memory", strconv.FormatInt(options.Memory, 10))
-	query.Set("memswap", strconv.FormatInt(options.MemorySwap, 10))
-	query.Set("cgroupparent", options.CgroupParent)
-	query.Set("shmsize", strconv.FormatInt(options.ShmSize, 10))
-	query.Set("dockerfile", options.Dockerfile)
-	query.Set("target", options.Target)
-
-	ulimitsJSON, err := json.Marshal(options.Ulimits)
-	if err != nil {
-		return query, err
+	if options.CPUSetCPUs != "" {
+		query.Set("cpusetcpus", options.CPUSetCPUs)
 	}
-	query.Set("ulimits", string(ulimitsJSON))
-
-	buildArgsJSON, err := json.Marshal(options.BuildArgs)
-	if err != nil {
-		return query, err
+	if options.NetworkMode != "" {
+		query.Set("networkmode", options.NetworkMode)
 	}
-	query.Set("buildargs", string(buildArgsJSON))
-
-	labelsJSON, err := json.Marshal(options.Labels)
-	if err != nil {
-		return query, err
+	if options.CPUSetMems != "" {
+		query.Set("cpusetmems", options.CPUSetMems)
 	}
-	query.Set("labels", string(labelsJSON))
-
-	cacheFromJSON, err := json.Marshal(options.CacheFrom)
-	if err != nil {
-		return query, err
+	if options.CPUShares != 0 {
+		query.Set("cpushares", strconv.FormatInt(options.CPUShares, 10))
 	}
-	query.Set("cachefrom", string(cacheFromJSON))
+	if options.CPUQuota != 0 {
+		query.Set("cpuquota", strconv.FormatInt(options.CPUQuota, 10))
+	}
+	if options.CPUPeriod != 0 {
+		query.Set("cpuperiod", strconv.FormatInt(options.CPUPeriod, 10))
+	}
+	if options.Memory != 0 {
+		query.Set("memory", strconv.FormatInt(options.Memory, 10))
+	}
+	if options.MemorySwap != 0 {
+		query.Set("memswap", strconv.FormatInt(options.MemorySwap, 10))
+	}
+	if options.CgroupParent != "" {
+		query.Set("cgroupparent", options.CgroupParent)
+	}
+	if options.ShmSize != 0 {
+		query.Set("shmsize", strconv.FormatInt(options.ShmSize, 10))
+	}
+	if options.Dockerfile != "" {
+		query.Set("dockerfile", options.Dockerfile)
+	}
+	if options.Target != "" {
+		query.Set("target", options.Target)
+	}
+	if len(options.Ulimits) != 0 {
+		ulimitsJSON, err := json.Marshal(options.Ulimits)
+		if err != nil {
+			return query, err
+		}
+		query.Set("ulimits", string(ulimitsJSON))
+	}
+	if len(options.BuildArgs) != 0 {
+		buildArgsJSON, err := json.Marshal(options.BuildArgs)
+		if err != nil {
+			return query, err
+		}
+		query.Set("buildargs", string(buildArgsJSON))
+	}
+	if len(options.Labels) != 0 {
+		labelsJSON, err := json.Marshal(options.Labels)
+		if err != nil {
+			return query, err
+		}
+		query.Set("labels", string(labelsJSON))
+	}
+	if len(options.CacheFrom) != 0 {
+		cacheFromJSON, err := json.Marshal(options.CacheFrom)
+		if err != nil {
+			return query, err
+		}
+		query.Set("cachefrom", string(cacheFromJSON))
+	}
 	if options.SessionID != "" {
 		query.Set("session", options.SessionID)
 	}
@@ -131,7 +164,9 @@ func (cli *Client) imageBuildOptionsToQuery(ctx context.Context, options types.I
 	if options.BuildID != "" {
 		query.Set("buildid", options.BuildID)
 	}
-	query.Set("version", string(options.Version))
+	if options.Version != "" {
+		query.Set("version", string(options.Version))
+	}
 
 	if options.Outputs != nil {
 		outputsJSON, err := json.Marshal(options.Outputs)

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
 )
 
 // ImageBuild sends a request to the daemon to build images.
@@ -93,7 +94,7 @@ func (cli *Client) imageBuildOptionsToQuery(ctx context.Context, options types.I
 	if options.CPUSetCPUs != "" {
 		query.Set("cpusetcpus", options.CPUSetCPUs)
 	}
-	if options.NetworkMode != "" {
+	if options.NetworkMode != "" && options.NetworkMode != network.NetworkDefault {
 		query.Set("networkmode", options.NetworkMode)
 	}
 	if options.CPUSetMems != "" {

--- a/client/image_build_test.go
+++ b/client/image_build_test.go
@@ -47,7 +47,6 @@ func TestImageBuild(t *testing.T) {
 			expectedQueryParams: map[string]string{
 				"q":       "1",
 				"nocache": "1",
-				"rm":      "1",
 				"forcerm": "1",
 				"pull":    "1",
 			},


### PR DESCRIPTION
### client: imageBuildOptionsToQuery: omit empty values from query

Before:

    DEBU[2024-10-12T11:26:55.791312715Z] Calling POST /v1.47/build?buildargs=%7B%7D&cachefrom=%5B%5D&cgroupparent=&cpuperiod=0&cpuquota=0&cpusetcpus=&cpusetmems=&cpushares=0&dockerfile=Dockerfile&labels=%7B%7D&memory=0&memswap=0&networkmode=default&rm=1&shmsize=0&target=&ulimits=%5B%5D&version=1  spanID=893f850bd8bda19d traceID=e7ab3b76fd7a9c27a7aa7b25f4528fb8

After:
    
    DEBU[2024-10-12T11:30:47.716478170Z] Calling POST /v1.47/build?dockerfile=Dockerfile&networkmode=default&rm=1&version=1  spanID=893f850bd8bda19d traceID=e7ab3b76fd7a9c27a7aa7b25f4528fb8


### client: imageBuildOptionsToQuery: only send "rm" when disabling

The "rm" option was made the default in API version 1.12  in commit
b60d6471721bc914dca179a4372303d41913cc4c, so the query-parameter can be
omitted unless the user opted to disable removing intermediate containers.

Before:

    DEBU[2024-10-12T11:30:47.716478170Z] Calling POST /v1.47/build?dockerfile=Dockerfile&networkmode=default&rm=1&version=1  spanID=893f850bd8bda19d traceID=e7ab3b76fd7a9c27a7aa7b25f4528fb8

After:

    DEBU[2024-10-12T11:30:47.716478170Z] Calling POST /v1.47/build?dockerfile=Dockerfile&networkmode=default&version=1  spanID=893f850bd8bda19d traceID=e7ab3b76fd7a9c27a7aa7b25f4528fb8


### client: imageBuildOptionsToQuery: omit "default" networkmode

Both the classic builder and buildkit treat empty value and "default"
as equivalent;

classic builder: https://github.com/moby/moby/blob/c9619248d04439c29fc10c19031bd3754e39b323/builder/dockerfile/internals.go#L379-L386
buildkit: https://github.com/moby/moby/blob/c9619248d04439c29fc10c19031bd3754e39b323/builder/builder-next/builder.go#L350-L356

Before:

    DEBU[2024-10-12T11:30:47.716478170Z] Calling POST /v1.47/build?dockerfile=Dockerfile&networkmode=default&version=1  spanID=893f850bd8bda19d traceID=e7ab3b76fd7a9c27a7aa7b25f4528fb8

After:

    DEBU[2024-10-12T13:42:56.799531715Z] Calling POST /v1.47/build?dockerfile=Dockerfile&version=1  spanID=d37f36ca6325422e traceID=a5eb4637fc3d0acf56cbb6a0a1d4a5ca



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
client.Client.ImageBuild() now omits default values from the API request's query string
```

**- A picture of a cute animal (not mandatory but encouraged)**

