### PR TITLE
Fix image listing to show tag and digest where available

### DIFF
--- a/daemon/images/image_list.go
+++ b/daemon/images/image_list.go
@@ -158,28 +158,35 @@ func (i *ImageService) Images(ctx context.Context, opts imagetypes.ListOptions) 
 
 		summary := newImageSummary(img, size)
 
+		var matchedFilter bool
 		for _, ref := range i.referenceStore.References(id.Digest()) {
 			if opts.Filters.Contains("reference") {
-				var found bool
-				var matchErr error
 				for _, pattern := range opts.Filters.Get("reference") {
-					found, matchErr = reference.FamiliarMatch(pattern, ref)
+					found, matchErr := reference.FamiliarMatch(pattern, ref)
 					if matchErr != nil {
 						return nil, matchErr
 					}
 					if found {
+						matchedFilter = true
 						break
 					}
 				}
-				if !found {
-					continue
+				if matchedFilter {
+					break
 				}
+			} else {
+				matchedFilter = true
+				break
 			}
-			if _, ok := ref.(reference.Canonical); ok {
-				summary.RepoDigests = append(summary.RepoDigests, reference.FamiliarString(ref))
-			}
-			if _, ok := ref.(reference.NamedTagged); ok {
-				summary.RepoTags = append(summary.RepoTags, reference.FamiliarString(ref))
+		}
+		if matchedFilter {
+			for _, ref := range i.referenceStore.References(id.Digest()) {
+				if tagged, ok := ref.(reference.NamedTagged); ok {
+					summary.RepoTags = append(summary.RepoTags, reference.FamiliarString(tagged))
+				}
+				if canonical, ok := ref.(reference.Canonical); ok {
+					summary.RepoDigests = append(summary.RepoDigests, reference.FamiliarString(canonical))
+				}
 			}
 		}
 		if summary.RepoDigests == nil && summary.RepoTags == nil {


### PR DESCRIPTION
When filtering images by reference (tag or digest), both are returned in the response if they are available. This change will fix an issue where only one was shown when filtering. Fixes #48612 This was the cleanest way I could think to add both, but open to feedback to improve.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I changed the display of tags and digests to always be shown if they exist. Previously if filtering with a reference eg 
`reference=redis:6.2` only the tag would display, the digest would be `<none>`.

**- How I did it**
I modified the loop that previously applied either a tag or digest based on the reference to now evaluate if there was a reference, and if so apply both tag and digest to the image if they exist. 

**- How to verify it**
Run through the steps outlined in moby/moby/issues/48612. Now when running either a 
`docker image ls -f reference=name:tag --digests` or
`docker image ls -f  reference=name@shaxxx` 
Both the tag and digest are visible in the output, not only the one filtering for. 
All current tests passed after the change. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Closes #48612 by outputting tag and digest whenever available. 
```

