### PR TITLE
container: deprecate ErrNameReserved, ErrNameNotReserved, use errdefs instead

### DIFF
--- a/container/view.go
+++ b/container/view.go
@@ -30,8 +30,12 @@ const (
 
 var (
 	// ErrNameReserved is an error which is returned when a name is requested to be reserved that already is reserved
+	//
+	// Deprecated: check for [errdefs.Conflict] errors instead (using [errdefs.IsConflict].
 	ErrNameReserved = errors.New("name is reserved")
 	// ErrNameNotReserved is an error which is returned when trying to find a name that is not reserved
+	//
+	// Deprecated: check for [errdefs.NotFound] errors instead (using [errdefs.IsNotFound].
 	ErrNameNotReserved = errors.New("name is not reserved")
 )
 
@@ -195,7 +199,7 @@ func (db *ViewDB) ReserveName(name, containerID string) error {
 		}
 		if s != nil {
 			if s.(nameAssociation).containerID != containerID {
-				return errdefs.Conflict(ErrNameReserved)
+				return errdefs.Conflict(ErrNameReserved) //nolint:staticcheck  // ignore SA1019: ErrNameReserved is deprecated.
 			}
 			return nil
 		}
@@ -274,7 +278,7 @@ func (v *View) GetID(name string) (string, error) {
 		return "", errdefs.System(err)
 	}
 	if s == nil {
-		return "", errdefs.NotFound(ErrNameNotReserved)
+		return "", errdefs.NotFound(ErrNameNotReserved) //nolint:staticcheck  // ignore SA1019: ErrNameNotReserved is deprecated.
 	}
 	return s.(nameAssociation).containerID, nil
 }

--- a/container/view.go
+++ b/container/view.go
@@ -152,7 +152,7 @@ func (db *ViewDB) withTxn(cb func(*memdb.Txn) error) error {
 	err := cb(txn)
 	if err != nil {
 		txn.Abort()
-		return errdefs.System(err)
+		return err
 	}
 	txn.Commit()
 	return nil

--- a/container/view.go
+++ b/container/view.go
@@ -112,6 +112,7 @@ func NewViewDB() (*ViewDB, error) {
 
 // GetByPrefix returns a container with the given ID prefix. It returns an
 // error if an empty prefix was given or if multiple containers match the prefix.
+// It returns an [errdefs.NotFound] if the given s yielded no results.
 func (db *ViewDB) GetByPrefix(s string) (string, error) {
 	if s == "" {
 		return "", errdefs.InvalidParameter(errors.New("prefix can't be empty"))
@@ -183,10 +184,9 @@ func (db *ViewDB) Delete(c *Container) error {
 	})
 }
 
-// ReserveName registers a container ID to a name
-// ReserveName is idempotent
-// Attempting to reserve a container ID to a name that already exists results in an `ErrNameReserved`
-// A name reservation is globally unique
+// ReserveName registers a container ID to a name. ReserveName is idempotent,
+// but returns an [errdefs.Conflict] when attempting to reserve a container ID
+// to a name that already is reserved.
 func (db *ViewDB) ReserveName(name, containerID string) error {
 	return db.withTxn(func(txn *memdb.Txn) error {
 		s, err := txn.First(memdbNamesTable, memdbIDIndex, name)
@@ -195,7 +195,7 @@ func (db *ViewDB) ReserveName(name, containerID string) error {
 		}
 		if s != nil {
 			if s.(nameAssociation).containerID != containerID {
-				return ErrNameReserved
+				return errdefs.Conflict(ErrNameReserved)
 			}
 			return nil
 		}
@@ -235,6 +235,7 @@ func (v *View) All() ([]Snapshot, error) {
 }
 
 // Get returns an item by id. Returned objects must never be modified.
+// It returns an [errdefs.NotFound] if the given id was not found.
 func (v *View) Get(id string) (*Snapshot, error) {
 	s, err := v.txn.First(memdbContainersTable, memdbIDIndex, id)
 	if err != nil {
@@ -266,13 +267,14 @@ func (v *View) getNames(containerID string) []string {
 }
 
 // GetID returns the container ID that the passed in name is reserved to.
+// It returns an [errdefs.NotFound] if the given id was not found.
 func (v *View) GetID(name string) (string, error) {
 	s, err := v.txn.First(memdbNamesTable, memdbIDIndex, name)
 	if err != nil {
 		return "", errdefs.System(err)
 	}
 	if s == nil {
-		return "", ErrNameNotReserved
+		return "", errdefs.NotFound(ErrNameNotReserved)
 	}
 	return s.(nameAssociation).containerID, nil
 }

--- a/container/view_test.go
+++ b/container/view_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/google/uuid"
 	"gotest.tools/v3/assert"
@@ -116,6 +117,7 @@ func TestNames(t *testing.T) {
 	assert.Check(t, db.ReserveName("name2", "containerid2"))
 
 	err = db.ReserveName("name2", "containerid3")
+	assert.Check(t, is.ErrorType(err, errdefs.IsConflict))
 	assert.Check(t, is.ErrorIs(err, ErrNameReserved))
 
 	// Releasing a name allows the name to point to something else later.
@@ -133,6 +135,7 @@ func TestNames(t *testing.T) {
 	assert.Check(t, is.Equal("containerid3", id))
 
 	_, err = view.GetID("notreserved")
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 	assert.Check(t, is.ErrorIs(err, ErrNameNotReserved))
 
 	// Releasing and re-reserving a name doesn't affect the snapshot.

--- a/container/view_test.go
+++ b/container/view_test.go
@@ -114,7 +114,9 @@ func TestNames(t *testing.T) {
 	assert.Check(t, db.ReserveName("name1", "containerid1"))
 	assert.Check(t, db.ReserveName("name1", "containerid1")) // idempotent
 	assert.Check(t, db.ReserveName("name2", "containerid2"))
-	assert.Check(t, is.Error(db.ReserveName("name2", "containerid3"), ErrNameReserved.Error()))
+
+	err = db.ReserveName("name2", "containerid3")
+	assert.Check(t, is.ErrorIs(err, ErrNameReserved))
 
 	// Releasing a name allows the name to point to something else later.
 	assert.Check(t, db.ReleaseName("name2"))
@@ -131,7 +133,7 @@ func TestNames(t *testing.T) {
 	assert.Check(t, is.Equal("containerid3", id))
 
 	_, err = view.GetID("notreserved")
-	assert.Check(t, is.Error(err, ErrNameNotReserved.Error()))
+	assert.Check(t, is.ErrorIs(err, ErrNameNotReserved))
 
 	// Releasing and re-reserving a name doesn't affect the snapshot.
 	assert.Check(t, db.ReleaseName("name2"))

--- a/container/view_test.go
+++ b/container/view_test.go
@@ -118,7 +118,7 @@ func TestNames(t *testing.T) {
 
 	err = db.ReserveName("name2", "containerid3")
 	assert.Check(t, is.ErrorType(err, errdefs.IsConflict))
-	assert.Check(t, is.ErrorIs(err, ErrNameReserved))
+	assert.Check(t, is.ErrorIs(err, ErrNameReserved)) //nolint:staticcheck  // ignore SA1019: ErrNameReserved is deprecated.
 
 	// Releasing a name allows the name to point to something else later.
 	assert.Check(t, db.ReleaseName("name2"))
@@ -136,7 +136,7 @@ func TestNames(t *testing.T) {
 
 	_, err = view.GetID("notreserved")
 	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
-	assert.Check(t, is.ErrorIs(err, ErrNameNotReserved))
+	assert.Check(t, is.ErrorIs(err, ErrNameNotReserved)) //nolint:staticcheck  // ignore SA1019: ErrNameNotReserved is deprecated.
 
 	// Releasing and re-reserving a name doesn't affect the snapshot.
 	assert.Check(t, db.ReleaseName("name2"))

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -761,7 +761,7 @@ func (daemon *Daemon) parents(c *container.Container) map[string]*container.Cont
 func (daemon *Daemon) registerLink(parent, child *container.Container, alias string) error {
 	fullName := path.Join(parent.Name, alias)
 	if err := daemon.containersReplica.ReserveName(fullName, child.ID); err != nil {
-		if errors.Is(err, container.ErrNameReserved) {
+		if errdefs.IsConflict(err) {
 			log.G(context.TODO()).Warnf("error registering link for %s, to %s, as alias %s, ignoring: %v", parent.ID, child.ID, alias, err)
 			return nil
 		}

--- a/daemon/names.go
+++ b/daemon/names.go
@@ -66,7 +66,7 @@ func (daemon *Daemon) reserveName(id, name string) (string, error) {
 	}
 
 	if err := daemon.containersReplica.ReserveName(name, id); err != nil {
-		if errors.Is(err, container.ErrNameReserved) {
+		if errdefs.IsConflict(err) {
 			id, err := daemon.containersReplica.Snapshot().GetID(name)
 			if err != nil {
 				log.G(context.TODO()).Errorf("got unexpected error while looking up reserved name: %v", err)
@@ -92,7 +92,7 @@ func (daemon *Daemon) generateAndReserveName(id string) (string, error) {
 		}
 
 		if err := daemon.containersReplica.ReserveName(name, id); err != nil {
-			if errors.Is(err, container.ErrNameReserved) {
+			if errdefs.IsConflict(err) {
 				continue
 			}
 			return "", err


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/43787

### container: TestNames: don't string-match error assertions

### container: viewDB.withTxn: don't wrap errors

The withTxn function takes a custom function to execute; we should not
wrap those errors as the only responsibility of this function is to
execute the given function in a transaction.

This was introduced in 6549a270e962dba0e24033367ec328b586444c92, and
an oversight of me.


### container: viewDB.ReserveName, view.GetID: return errdefs errors

Follow-up to 94dea2018e6e9b4836af610b68293f81bb5adb62. Change these to return
errdefs types, which could allow us to move away from the sentinel errors
defined in the package, and instead use errdefs definitions.

### container: deprecate ErrNameReserved, ErrNameNotReserved

Use errdefs definitions instead.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
container: deprecate ErrNameReserved, ErrNameNotReserved
```

**- A picture of a cute animal (not mandatory but encouraged)**

