### PR TITLE
api/server/router/container: move API adjustments to API

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -47,7 +47,7 @@ type stateBackend interface {
 // monitorBackend includes functions to implement to provide containers monitoring functionality.
 type monitorBackend interface {
 	ContainerChanges(ctx context.Context, name string) ([]archive.Change, error)
-	ContainerInspect(ctx context.Context, name string, size bool, version string) (interface{}, error)
+	ContainerInspect(ctx context.Context, name string, options backend.ContainerInspectOptions) (*container.InspectResponse, error)
 	ContainerLogs(ctx context.Context, name string, config *container.LogsOptions) (msgs <-chan *backend.LogMessage, tty bool, err error)
 	ContainerStats(ctx context.Context, name string, config *backend.ContainerStatsConfig) error
 	ContainerTop(name string, psArgs string) (*container.ContainerTopOKBody, error)

--- a/api/server/router/container/container.go
+++ b/api/server/router/container/container.go
@@ -25,47 +25,47 @@ func NewRouter(b Backend, decoder httputils.ContainerDecoder, cgroup2 bool) rout
 }
 
 // Routes returns the available routes to the container controller
-func (r *containerRouter) Routes() []router.Route {
-	return r.routes
+func (c *containerRouter) Routes() []router.Route {
+	return c.routes
 }
 
 // initRoutes initializes the routes in container router
-func (r *containerRouter) initRoutes() {
-	r.routes = []router.Route{
+func (c *containerRouter) initRoutes() {
+	c.routes = []router.Route{
 		// HEAD
-		router.NewHeadRoute("/containers/{name:.*}/archive", r.headContainersArchive),
+		router.NewHeadRoute("/containers/{name:.*}/archive", c.headContainersArchive),
 		// GET
-		router.NewGetRoute("/containers/json", r.getContainersJSON),
-		router.NewGetRoute("/containers/{name:.*}/export", r.getContainersExport),
-		router.NewGetRoute("/containers/{name:.*}/changes", r.getContainersChanges),
-		router.NewGetRoute("/containers/{name:.*}/json", r.getContainersByName),
-		router.NewGetRoute("/containers/{name:.*}/top", r.getContainersTop),
-		router.NewGetRoute("/containers/{name:.*}/logs", r.getContainersLogs),
-		router.NewGetRoute("/containers/{name:.*}/stats", r.getContainersStats),
-		router.NewGetRoute("/containers/{name:.*}/attach/ws", r.wsContainersAttach),
-		router.NewGetRoute("/exec/{id:.*}/json", r.getExecByID),
-		router.NewGetRoute("/containers/{name:.*}/archive", r.getContainersArchive),
+		router.NewGetRoute("/containers/json", c.getContainersJSON),
+		router.NewGetRoute("/containers/{name:.*}/export", c.getContainersExport),
+		router.NewGetRoute("/containers/{name:.*}/changes", c.getContainersChanges),
+		router.NewGetRoute("/containers/{name:.*}/json", c.getContainersByName),
+		router.NewGetRoute("/containers/{name:.*}/top", c.getContainersTop),
+		router.NewGetRoute("/containers/{name:.*}/logs", c.getContainersLogs),
+		router.NewGetRoute("/containers/{name:.*}/stats", c.getContainersStats),
+		router.NewGetRoute("/containers/{name:.*}/attach/ws", c.wsContainersAttach),
+		router.NewGetRoute("/exec/{id:.*}/json", c.getExecByID),
+		router.NewGetRoute("/containers/{name:.*}/archive", c.getContainersArchive),
 		// POST
-		router.NewPostRoute("/containers/create", r.postContainersCreate),
-		router.NewPostRoute("/containers/{name:.*}/kill", r.postContainersKill),
-		router.NewPostRoute("/containers/{name:.*}/pause", r.postContainersPause),
-		router.NewPostRoute("/containers/{name:.*}/unpause", r.postContainersUnpause),
-		router.NewPostRoute("/containers/{name:.*}/restart", r.postContainersRestart),
-		router.NewPostRoute("/containers/{name:.*}/start", r.postContainersStart),
-		router.NewPostRoute("/containers/{name:.*}/stop", r.postContainersStop),
-		router.NewPostRoute("/containers/{name:.*}/wait", r.postContainersWait),
-		router.NewPostRoute("/containers/{name:.*}/resize", r.postContainersResize),
-		router.NewPostRoute("/containers/{name:.*}/attach", r.postContainersAttach),
-		router.NewPostRoute("/containers/{name:.*}/exec", r.postContainerExecCreate),
-		router.NewPostRoute("/exec/{name:.*}/start", r.postContainerExecStart),
-		router.NewPostRoute("/exec/{name:.*}/resize", r.postContainerExecResize),
-		router.NewPostRoute("/containers/{name:.*}/rename", r.postContainerRename),
-		router.NewPostRoute("/containers/{name:.*}/update", r.postContainerUpdate),
-		router.NewPostRoute("/containers/prune", r.postContainersPrune),
-		router.NewPostRoute("/commit", r.postCommit),
+		router.NewPostRoute("/containers/create", c.postContainersCreate),
+		router.NewPostRoute("/containers/{name:.*}/kill", c.postContainersKill),
+		router.NewPostRoute("/containers/{name:.*}/pause", c.postContainersPause),
+		router.NewPostRoute("/containers/{name:.*}/unpause", c.postContainersUnpause),
+		router.NewPostRoute("/containers/{name:.*}/restart", c.postContainersRestart),
+		router.NewPostRoute("/containers/{name:.*}/start", c.postContainersStart),
+		router.NewPostRoute("/containers/{name:.*}/stop", c.postContainersStop),
+		router.NewPostRoute("/containers/{name:.*}/wait", c.postContainersWait),
+		router.NewPostRoute("/containers/{name:.*}/resize", c.postContainersResize),
+		router.NewPostRoute("/containers/{name:.*}/attach", c.postContainersAttach),
+		router.NewPostRoute("/containers/{name:.*}/exec", c.postContainerExecCreate),
+		router.NewPostRoute("/exec/{name:.*}/start", c.postContainerExecStart),
+		router.NewPostRoute("/exec/{name:.*}/resize", c.postContainerExecResize),
+		router.NewPostRoute("/containers/{name:.*}/rename", c.postContainerRename),
+		router.NewPostRoute("/containers/{name:.*}/update", c.postContainerUpdate),
+		router.NewPostRoute("/containers/prune", c.postContainersPrune),
+		router.NewPostRoute("/commit", c.postCommit),
 		// PUT
-		router.NewPutRoute("/containers/{name:.*}/archive", r.putContainersArchive),
+		router.NewPutRoute("/containers/{name:.*}/archive", c.putContainersArchive),
 		// DELETE
-		router.NewDeleteRoute("/containers/{name:.*}", r.deleteContainers),
+		router.NewDeleteRoute("/containers/{name:.*}", c.deleteContainers),
 	}
 }

--- a/api/server/router/container/copy.go
+++ b/api/server/router/container/copy.go
@@ -29,13 +29,13 @@ func setContainerPathStatHeader(stat *container.PathStat, header http.Header) er
 	return nil
 }
 
-func (s *containerRouter) headContainersArchive(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (c *containerRouter) headContainersArchive(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	v, err := httputils.ArchiveFormValues(r, vars)
 	if err != nil {
 		return err
 	}
 
-	stat, err := s.backend.ContainerStatPath(v.Name, v.Path)
+	stat, err := c.backend.ContainerStatPath(v.Name, v.Path)
 	if err != nil {
 		return err
 	}
@@ -66,13 +66,13 @@ func writeCompressedResponse(w http.ResponseWriter, r *http.Request, body io.Rea
 	return err
 }
 
-func (s *containerRouter) getContainersArchive(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (c *containerRouter) getContainersArchive(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	v, err := httputils.ArchiveFormValues(r, vars)
 	if err != nil {
 		return err
 	}
 
-	tarArchive, stat, err := s.backend.ContainerArchivePath(v.Name, v.Path)
+	tarArchive, stat, err := c.backend.ContainerArchivePath(v.Name, v.Path)
 	if err != nil {
 		return err
 	}
@@ -86,7 +86,7 @@ func (s *containerRouter) getContainersArchive(ctx context.Context, w http.Respo
 	return writeCompressedResponse(w, r, tarArchive)
 }
 
-func (s *containerRouter) putContainersArchive(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (c *containerRouter) putContainersArchive(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	v, err := httputils.ArchiveFormValues(r, vars)
 	if err != nil {
 		return err
@@ -95,5 +95,5 @@ func (s *containerRouter) putContainersArchive(ctx context.Context, w http.Respo
 	noOverwriteDirNonDir := httputils.BoolValue(r, "noOverwriteDirNonDir")
 	copyUIDGID := httputils.BoolValue(r, "copyUIDGID")
 
-	return s.backend.ContainerExtractToDir(v.Name, v.Path, copyUIDGID, noOverwriteDirNonDir, r.Body)
+	return c.backend.ContainerExtractToDir(v.Name, v.Path, copyUIDGID, noOverwriteDirNonDir, r.Body)
 }

--- a/api/server/router/container/exec.go
+++ b/api/server/router/container/exec.go
@@ -17,8 +17,8 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 )
 
-func (s *containerRouter) getExecByID(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	eConfig, err := s.backend.ContainerExecInspect(vars["id"])
+func (c *containerRouter) getExecByID(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	eConfig, err := c.backend.ContainerExecInspect(vars["id"])
 	if err != nil {
 		return err
 	}
@@ -34,7 +34,7 @@ func (execCommandError) Error() string {
 
 func (execCommandError) InvalidParameter() {}
 
-func (s *containerRouter) postContainerExecCreate(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (c *containerRouter) postContainerExecCreate(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func (s *containerRouter) postContainerExecCreate(ctx context.Context, w http.Re
 	}
 
 	// Register an instance of Exec in container.
-	id, err := s.backend.ContainerExecCreate(vars["name"], execConfig)
+	id, err := c.backend.ContainerExecCreate(vars["name"], execConfig)
 	if err != nil {
 		log.G(ctx).Errorf("Error setting up exec command in container %s: %v", vars["name"], err)
 		return err
@@ -67,7 +67,7 @@ func (s *containerRouter) postContainerExecCreate(ctx context.Context, w http.Re
 }
 
 // TODO(vishh): Refactor the code to avoid having to specify stream config as part of both create and start.
-func (s *containerRouter) postContainerExecStart(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (c *containerRouter) postContainerExecStart(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
@@ -83,7 +83,7 @@ func (s *containerRouter) postContainerExecStart(ctx context.Context, w http.Res
 		return err
 	}
 
-	if exists, err := s.backend.ExecExists(execName); !exists {
+	if exists, err := c.backend.ExecExists(execName); !exists {
 		return err
 	}
 
@@ -138,7 +138,7 @@ func (s *containerRouter) postContainerExecStart(ctx context.Context, w http.Res
 	// Now run the user process in container.
 	//
 	// TODO: Maybe we should we pass ctx here if we're not detaching?
-	err := s.backend.ContainerExecStart(context.Background(), execName, backend.ExecStartConfig{
+	err := c.backend.ContainerExecStart(context.Background(), execName, backend.ExecStartConfig{
 		Stdin:       stdin,
 		Stdout:      stdout,
 		Stderr:      stderr,
@@ -154,7 +154,7 @@ func (s *containerRouter) postContainerExecStart(ctx context.Context, w http.Res
 	return nil
 }
 
-func (s *containerRouter) postContainerExecResize(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (c *containerRouter) postContainerExecResize(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
@@ -167,5 +167,5 @@ func (s *containerRouter) postContainerExecResize(ctx context.Context, w http.Re
 		return errdefs.InvalidParameter(err)
 	}
 
-	return s.backend.ContainerExecResize(vars["name"], height, width)
+	return c.backend.ContainerExecResize(vars["name"], height, width)
 }

--- a/api/server/router/container/inspect.go
+++ b/api/server/router/container/inspect.go
@@ -5,17 +5,31 @@ import (
 	"net/http"
 
 	"github.com/docker/docker/api/server/httputils"
+	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/internal/sliceutil"
+	"github.com/docker/docker/pkg/stringid"
 )
 
 // getContainersByName inspects container's configuration and serializes it as json.
 func (c *containerRouter) getContainersByName(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	displaySize := httputils.BoolValue(r, "size")
-
-	version := httputils.VersionFromContext(ctx)
-	json, err := c.backend.ContainerInspect(ctx, vars["name"], displaySize, version)
+	ctr, err := c.backend.ContainerInspect(ctx, vars["name"], backend.ContainerInspectOptions{
+		Size: httputils.BoolValue(r, "size"),
+	})
 	if err != nil {
 		return err
 	}
 
-	return httputils.WriteJSON(w, http.StatusOK, json)
+	version := httputils.VersionFromContext(ctx)
+	if versions.LessThan(version, "1.45") {
+		shortCID := stringid.TruncateID(ctr.ID)
+		for nwName, ep := range ctr.NetworkSettings.Networks {
+			if container.NetworkMode(nwName).IsUserDefined() {
+				ep.Aliases = sliceutil.Dedup(append(ep.Aliases, shortCID, ctr.Config.Hostname))
+			}
+		}
+	}
+
+	return httputils.WriteJSON(w, http.StatusOK, ctr)
 }

--- a/api/server/router/container/inspect.go
+++ b/api/server/router/container/inspect.go
@@ -8,11 +8,11 @@ import (
 )
 
 // getContainersByName inspects container's configuration and serializes it as json.
-func (s *containerRouter) getContainersByName(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (c *containerRouter) getContainersByName(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	displaySize := httputils.BoolValue(r, "size")
 
 	version := httputils.VersionFromContext(ctx)
-	json, err := s.backend.ContainerInspect(ctx, vars["name"], displaySize, version)
+	json, err := c.backend.ContainerInspect(ctx, vars["name"], displaySize, version)
 	if err != nil {
 		return err
 	}

--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -92,6 +92,13 @@ type ContainerStatsConfig struct {
 	OutStream func() io.Writer
 }
 
+// ContainerInspectOptions defines options for the backend.ContainerInspect
+// call.
+type ContainerInspectOptions struct {
+	// Size controls whether to propagate the container's size fields.
+	Size bool
+}
+
 // ExecStartConfig holds the options to start container's exec.
 type ExecStartConfig struct {
 	Stdin       io.Reader

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -44,7 +44,7 @@ type Backend interface {
 	ActivateContainerServiceBinding(containerName string) error
 	DeactivateContainerServiceBinding(containerName string) error
 	UpdateContainerServiceConfig(containerName string, serviceConfig *clustertypes.ServiceConfig) error
-	ContainerInspectCurrent(ctx context.Context, name string, size bool) (*container.InspectResponse, error)
+	ContainerInspect(ctx context.Context, name string, options backend.ContainerInspectOptions) (*container.InspectResponse, error)
 	ContainerWait(ctx context.Context, name string, condition containerpkg.WaitCondition) (<-chan containerpkg.StateStatus, error)
 	ContainerRm(name string, config *backend.ContainerRmConfig) error
 	ContainerKill(name string, sig string) error

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -372,7 +372,7 @@ func (c *containerAdapter) start(ctx context.Context) error {
 }
 
 func (c *containerAdapter) inspect(ctx context.Context) (containertypes.InspectResponse, error) {
-	cs, err := c.backend.ContainerInspectCurrent(ctx, c.container.name(), false)
+	cs, err := c.backend.ContainerInspect(ctx, c.container.name(), backend.ContainerInspectOptions{})
 	if ctx.Err() != nil {
 		return containertypes.InspectResponse{}, ctx.Err()
 	}


### PR DESCRIPTION
### api/server/router/container: fix inconsistent receiver name

It's good practice to use a consistent name; we couldn't use `r` as name,
as it's used for the request argument, and `s` honestly didn't make much
sense as name, so changing it to `c`.


### api/server/router/container: move API adjustments to API

The daemon used to have various implementation to adjust the container-inspect
output for different API versions, which could return different go structs,
and because of that required a function with a `interface{}` output type.

Most of those adjustments have been removed, and we no longer need separate
types for backward compatibility with old API versions.

This patch;

- Removes the Daemon.ContainerInspectCurrent method
- Introduces a backend.ContainerInspectOptions struct
- Updates the Daemon.ContainerInspect method's signature to accept the above
- Moves API-version specific adjustments to api/server/router/container,
  similar to how such adjustments are made for other endpoints.

Note that we should probably change the backend's signature further,
and define separate types for the backend's inspect and the API's
inspect response. Considering that the Backend signatures should be
considered "internal", we can do that in a future change.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
- daemon: remove `Daemon.ContainerInspectCurrent()` method
- daemon: change `Daemon.ContainerInspect()` signature to accept a `backend.ContainerInspectOptions` struct
```

**- A picture of a cute animal (not mandatory but encouraged)**

