### PR TITLE
daemon: killWithSignal: use more structured logs

### DIFF
--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -62,7 +62,10 @@ func (daemon *Daemon) ContainerKill(name, stopSignal string) error {
 // or not running, or if there is a problem returned from the
 // underlying kill command.
 func (daemon *Daemon) killWithSignal(container *containerpkg.Container, stopSignal syscall.Signal) error {
-	log.G(context.TODO()).Debugf("Sending kill signal %d to container %s", stopSignal, container.ID)
+	log.G(context.TODO()).WithFields(log.Fields{
+		"signal":    int(stopSignal),
+		"container": container.ID,
+	}).Debugf("sending signal %[1]d (%[1]s) to container", stopSignal)
 	container.Lock()
 	defer container.Unlock()
 
@@ -106,7 +109,11 @@ func (daemon *Daemon) killWithSignal(container *containerpkg.Container, stopSign
 	if err := task.Kill(context.Background(), stopSignal); err != nil {
 		if errdefs.IsNotFound(err) {
 			unpause = false
-			log.G(context.TODO()).WithError(err).WithField("container", container.ID).WithField("action", "kill").Debug("container kill failed because of 'container not found' or 'no such process'")
+			log.G(context.TODO()).WithFields(log.Fields{
+				"error":     err,
+				"container": container.ID,
+				"action":    "kill",
+			}).Debug("container kill failed because of 'container not found' or 'no such process'")
 			go func() {
 				// We need to clean up this container but it is possible there is a case where we hit here before the exit event is processed
 				// but after it was fired off.
@@ -134,7 +141,11 @@ func (daemon *Daemon) killWithSignal(container *containerpkg.Container, stopSign
 	if unpause {
 		// above kill signal will be sent once resume is finished
 		if err := task.Resume(context.Background()); err != nil {
-			log.G(context.TODO()).Warnf("Cannot unpause container %s: %s", container.ID, err)
+			log.G(context.TODO()).WithFields(log.Fields{
+				"error":     err,
+				"container": container.ID,
+				"action":    "kill",
+			}).Warn("cannot unpause container")
 		}
 	}
 


### PR DESCRIPTION
Use more structured logs, and provide a human-readable presentation of the signal that's sent. For the human-readable presentation, we should probably look at converting back to the signal _names_ (e.g. `SIGWINCH` or `SIGKILL`), which may be easier to interpret, but we currently don't have a utility for that.

Before:

    DEBU[2024-10-14T10:24:51.538705343Z] Sending kill signal 28 to container 7e9e99e52fc69ef1038b2fd212c8dc18948a56e6f024fbe46192f43006a229aa
    DEBU[2024-10-14T10:24:51.740502218Z] Calling POST /v1.47/containers/7e9e99e52fc69ef1038b2fd212c8dc18948a56e6f024fbe46192f43006a229aa/kill?signal=WINCH  spanID=9b993a93d28479f3 traceID=a37022e0429abaf9fb8b66a6cd4e4a19
    DEBU[2024-10-14T10:24:51.740874218Z] Sending kill signal 28 to container 7e9e99e52fc69ef1038b2fd212c8dc18948a56e6f024fbe46192f43006a229aa
    DEBU[2024-10-14T10:24:51.740501843Z] Calling POST /v1.47/containers/7e9e99e52fc69ef1038b2fd212c8dc18948a56e6f024fbe46192f43006a229aa/resize?h=39&w=127  spanID=f1563bdd86230804 traceID=9c25ff5910b30a4a04b774c8f5d0160e

After:

    DEBU[2024-10-15T17:17:18.988605173Z] Calling POST /v1.47/containers/cafc94ca93a8e10eb79ce86235c4510d6bba1dab9cf4827abe490328148418c8/kill?signal=WINCH  spanID=491d75545f89902a traceID=de72bdd1130bfc010ff1172ac23695b3
    DEBU[2024-10-15T17:17:18.988763173Z] sending signal 28 (window changed) to container  container=cafc94ca93a8e10eb79ce86235c4510d6bba1dab9cf4827abe490328148418c8 signal=28
    DEBU[2024-10-15T17:17:18.988605214Z] Calling POST /v1.47/containers/cafc94ca93a8e10eb79ce86235c4510d6bba1dab9cf4827abe490328148418c8/resize?h=46&w=152  spanID=8b18f64b12931da2 traceID=0a38e4a16dbbfda72172209382faec91
    ...
    ...
    DEBU[2024-10-15T20:26:16.863097005Z] sending signal 1 (hangup) to container        container=824197a9af794c4bcda13914021f13d702954114d3410c9db629a51bf685bdc7 signal=1
    DEBU[2024-10-15T20:26:31.431432554Z] sending signal 10 (user defined signal 1) to container  container=824197a9af794c4bcda13914021f13d702954114d3410c9db629a51bf685bdc7 signal=10
    DEBU[2024-10-15T19:52:41.717507211Z] shutting down container                       container=824197a9af794c4bcda13914021f13d702954114d3410c9db629a51bf685bdc7
    DEBU[2024-10-15T19:52:41.717681920Z] sending signal 15 (terminated) to container   container=824197a9af794c4bcda13914021f13d702954114d3410c9db629a51bf685bdc7 signal=15

Or in JSON format:

    {"level":"debug","msg":"Calling POST /v1.47/containers/6a62783bc6a591381dd625b8dca20bebf6b0f6e927956b92a4c8ea0438f2ff76/kill?signal=WINCH","spanID":"d7622e49d248a2e5","time":"2024-10-15T19:54:36.258464042Z","traceID":"8dcc62a38b0289c9eeb7d9fa7f9a485d"}
    {"container":"6a62783bc6a591381dd625b8dca20bebf6b0f6e927956b92a4c8ea0438f2ff76","level":"debug","msg":"sending signal 28 (window changed) to container","signal":28,"time":"2024-10-15T19:54:36.258546167Z"}
    {"level":"debug","msg":"Calling POST /v1.47/containers/6a62783bc6a591381dd625b8dca20bebf6b0f6e927956b92a4c8ea0438f2ff76/kill?signal=WINCH","spanID":"0c908cb6fe55a921","time":"2024-10-15T19:54:36.458532084Z","traceID":"a0225edfaa0b3c3b0ce93e3d2c98f326"}
    {"container":"6a62783bc6a591381dd625b8dca20bebf6b0f6e927956b92a4c8ea0438f2ff76","level":"debug","msg":"sending signal 28 (window changed) to container","signal":28,"time":"2024-10-15T19:54:36.458614126Z"}
    {"level":"debug","msg":"Calling POST /v1.47/containers/6a62783bc6a591381dd625b8dca20bebf6b0f6e927956b92a4c8ea0438f2ff76/resize?h=50\u0026w=167","spanID":"1679a419b3f8b5e4","time":"2024-10-15T19:54:36.458560459Z","traceID":"cad46e855dc5975799a7c82bdbed1b81"}

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

