### PR TITLE
api: container, exec resize: improve errors for invalid width/height

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -34,7 +34,7 @@ type stateBackend interface {
 	ContainerKill(name string, signal string) error
 	ContainerPause(name string) error
 	ContainerRename(oldName, newName string) error
-	ContainerResize(name string, height, width int) error
+	ContainerResize(ctx context.Context, name string, height, width uint32) error
 	ContainerRestart(ctx context.Context, name string, options container.StopOptions) error
 	ContainerRm(name string, config *backend.ContainerRmConfig) error
 	ContainerStart(ctx context.Context, name string, checkpoint string, checkpointDir string) error

--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -15,7 +15,7 @@ import (
 type execBackend interface {
 	ContainerExecCreate(name string, options *container.ExecOptions) (string, error)
 	ContainerExecInspect(id string) (*backend.ExecInspect, error)
-	ContainerExecResize(name string, height, width int) error
+	ContainerExecResize(ctx context.Context, name string, height, width uint32) error
 	ContainerExecStart(ctx context.Context, name string, options backend.ExecStartConfig) error
 	ExecExists(name string) (bool, error)
 }

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -908,7 +908,7 @@ func (c *containerRouter) postContainersResize(ctx context.Context, w http.Respo
 		return errdefs.InvalidParameter(errors.Wrapf(err, "invalid resize width %q", r.Form.Get("w")))
 	}
 
-	return c.backend.ContainerResize(vars["name"], int(height), int(width))
+	return c.backend.ContainerResize(ctx, vars["name"], height, width)
 }
 
 func (c *containerRouter) postContainersAttach(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -899,16 +899,16 @@ func (c *containerRouter) postContainersResize(ctx context.Context, w http.Respo
 		return err
 	}
 
-	height, err := strconv.Atoi(r.Form.Get("h"))
+	height, err := httputils.Uint32Value(r, "h")
 	if err != nil {
-		return errdefs.InvalidParameter(err)
+		return errdefs.InvalidParameter(errors.Wrapf(err, "invalid resize height %q", r.Form.Get("h")))
 	}
-	width, err := strconv.Atoi(r.Form.Get("w"))
+	width, err := httputils.Uint32Value(r, "w")
 	if err != nil {
-		return errdefs.InvalidParameter(err)
+		return errdefs.InvalidParameter(errors.Wrapf(err, "invalid resize width %q", r.Form.Get("w")))
 	}
 
-	return c.backend.ContainerResize(vars["name"], height, width)
+	return c.backend.ContainerResize(vars["name"], int(height), int(width))
 }
 
 func (c *containerRouter) postContainersAttach(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/api/server/router/container/exec.go
+++ b/api/server/router/container/exec.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/server/httputils"
@@ -15,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/pkg/errors"
 )
 
 func (c *containerRouter) getExecByID(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
@@ -158,14 +158,14 @@ func (c *containerRouter) postContainerExecResize(ctx context.Context, w http.Re
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
-	height, err := strconv.Atoi(r.Form.Get("h"))
+	height, err := httputils.Uint32Value(r, "h")
 	if err != nil {
-		return errdefs.InvalidParameter(err)
+		return errdefs.InvalidParameter(errors.Wrapf(err, "invalid resize height %q", r.Form.Get("h")))
 	}
-	width, err := strconv.Atoi(r.Form.Get("w"))
+	width, err := httputils.Uint32Value(r, "w")
 	if err != nil {
-		return errdefs.InvalidParameter(err)
+		return errdefs.InvalidParameter(errors.Wrapf(err, "invalid resize width %q", r.Form.Get("w")))
 	}
 
-	return c.backend.ContainerExecResize(vars["name"], height, width)
+	return c.backend.ContainerExecResize(vars["name"], int(height), int(width))
 }

--- a/api/server/router/container/exec.go
+++ b/api/server/router/container/exec.go
@@ -167,5 +167,5 @@ func (c *containerRouter) postContainerExecResize(ctx context.Context, w http.Re
 		return errdefs.InvalidParameter(errors.Wrapf(err, "invalid resize width %q", r.Form.Get("w")))
 	}
 
-	return c.backend.ContainerExecResize(vars["name"], int(height), int(width))
+	return c.backend.ContainerExecResize(ctx, vars["name"], height, width)
 }

--- a/client/container_resize.go
+++ b/client/container_resize.go
@@ -19,9 +19,10 @@ func (cli *Client) ContainerExecResize(ctx context.Context, execID string, optio
 }
 
 func (cli *Client) resize(ctx context.Context, basePath string, height, width uint) error {
+	// FIXME(thaJeztah): the API / backend accepts uint32, but container.ResizeOptions uses uint.
 	query := url.Values{}
-	query.Set("h", strconv.Itoa(int(height)))
-	query.Set("w", strconv.Itoa(int(width)))
+	query.Set("h", strconv.FormatUint(uint64(height), 10))
+	query.Set("w", strconv.FormatUint(uint64(width), 10))
 
 	resp, err := cli.post(ctx, basePath+"/resize", query, nil, nil)
 	ensureReaderClosed(resp)

--- a/daemon/resize.go
+++ b/daemon/resize.go
@@ -37,7 +37,7 @@ func (daemon *Daemon) ContainerResize(ctx context.Context, name string, height, 
 // ContainerExecResize changes the size of the TTY of the process
 // running in the exec with the given name to the given height and
 // width.
-func (daemon *Daemon) ContainerExecResize(name string, height, width int) error {
+func (daemon *Daemon) ContainerExecResize(ctx context.Context, name string, height, width uint32) error {
 	ec, err := daemon.getExecConfig(name)
 	if err != nil {
 		return err
@@ -54,7 +54,7 @@ func (daemon *Daemon) ContainerExecResize(name string, height, width int) error 
 		if ec.Process == nil {
 			return errdefs.InvalidParameter(errors.New("exec process is not started"))
 		}
-		return ec.Process.Resize(context.Background(), uint32(width), uint32(height))
+		return ec.Process.Resize(context.WithoutCancel(ctx), width, height)
 	case <-timeout.C:
 		return errors.New("timeout waiting for exec session ready")
 	}

--- a/daemon/resize.go
+++ b/daemon/resize.go
@@ -12,7 +12,7 @@ import (
 
 // ContainerResize changes the size of the TTY of the process running
 // in the container with the given name to the given height and width.
-func (daemon *Daemon) ContainerResize(name string, height, width int) error {
+func (daemon *Daemon) ContainerResize(ctx context.Context, name string, height, width uint32) error {
 	container, err := daemon.GetContainer(name)
 	if err != nil {
 		return err
@@ -25,10 +25,10 @@ func (daemon *Daemon) ContainerResize(name string, height, width int) error {
 		return err
 	}
 
-	if err = tsk.Resize(context.Background(), uint32(width), uint32(height)); err == nil {
+	if err = tsk.Resize(context.WithoutCancel(ctx), width, height); err == nil {
 		daemon.LogContainerEventWithAttributes(container, events.ActionResize, map[string]string{
-			"height": strconv.Itoa(height),
-			"width":  strconv.Itoa(width),
+			"height": strconv.FormatUint(uint64(height), 10),
+			"width":  strconv.FormatUint(uint64(width), 10),
 		})
 	}
 	return err

--- a/daemon/resize_test.go
+++ b/daemon/resize_test.go
@@ -13,7 +13,11 @@ import (
 
 // This test simply verify that when a wrong ID used, a specific error should be returned for exec resize.
 func TestExecResizeNoSuchExec(t *testing.T) {
-	n := "TestExecResize"
+	n := t.Name()
+	const (
+		width  = 24
+		height = 8
+	)
 	d := &Daemon{
 		execCommands: container.NewExecStore(),
 	}
@@ -25,7 +29,7 @@ func TestExecResizeNoSuchExec(t *testing.T) {
 		Container: c,
 	}
 	d.registerExecCommand(c, ec)
-	err := d.ContainerExecResize("nil", 24, 8)
+	err := d.ContainerExecResize(context.TODO(), "no-such-exec", height, width)
 	assert.ErrorContains(t, err, "No such exec instance")
 }
 
@@ -42,9 +46,11 @@ func (p *execResizeMockProcess) Resize(ctx context.Context, width, height uint32
 
 // This test is to make sure that when exec context is ready, resize should call ResizeTerminal via containerd client.
 func TestExecResize(t *testing.T) {
-	n := "TestExecResize"
-	width := 24
-	height := 8
+	n := t.Name()
+	const (
+		width  = 24
+		height = 8
+	)
 	mp := &execResizeMockProcess{}
 	d := &Daemon{
 		execCommands: container.NewExecStore(),
@@ -64,25 +70,28 @@ func TestExecResize(t *testing.T) {
 	close(ec.Started)
 	d.containers.Add(n, c)
 	d.registerExecCommand(c, ec)
-	err := d.ContainerExecResize(n, height, width)
+	err := d.ContainerExecResize(context.TODO(), n, height, width)
 	assert.NilError(t, err)
 	assert.Equal(t, mp.Width, width)
 	assert.Equal(t, mp.Height, height)
 }
 
 // This test is to make sure that when exec context is not ready, a timeout error should happen.
+//
 // TODO: the expect running time for this test is 10s, which would be too long for unit test.
 func TestExecResizeTimeout(t *testing.T) {
-	n := "TestExecResize"
-	width := 24
-	height := 8
+	n := t.Name()
+	const (
+		width  = 24
+		height = 8
+	)
 	mp := &execResizeMockProcess{}
 	d := &Daemon{
 		execCommands: container.NewExecStore(),
 		containers:   container.NewMemoryStore(),
 	}
 	c := &container.Container{
-		ID:           n,
+		ID:           t.Name(),
 		ExecCommands: container.NewExecStore(),
 		State:        &container.State{Running: true},
 	}
@@ -94,6 +103,6 @@ func TestExecResizeTimeout(t *testing.T) {
 	}
 	d.containers.Add(n, c)
 	d.registerExecCommand(c, ec)
-	err := d.ContainerExecResize(n, height, width)
+	err := d.ContainerExecResize(context.TODO(), n, height, width)
 	assert.ErrorContains(t, err, "timeout waiting for exec session ready")
 }

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -159,35 +159,59 @@ func TestExecResize(t *testing.T) {
 				doc:    "unset height",
 				height: valueNotSet,
 				width:  "100",
-				expErr: `strconv.Atoi: parsing "": invalid syntax`,
+				expErr: `invalid resize height "": invalid syntax`,
 			},
 			{
 				doc:    "unset width",
 				height: "100",
 				width:  valueNotSet,
-				expErr: `strconv.Atoi: parsing "": invalid syntax`,
+				expErr: `invalid resize width "": invalid syntax`,
 			},
 			{
 				doc:    "empty height",
 				width:  "100",
-				expErr: `strconv.Atoi: parsing "": invalid syntax`,
+				expErr: `invalid resize height "": invalid syntax`,
 			},
 			{
 				doc:    "empty width",
 				height: "100",
-				expErr: `strconv.Atoi: parsing "": invalid syntax`,
+				expErr: `invalid resize width "": invalid syntax`,
 			},
 			{
 				doc:    "non-numeric height",
 				height: "not-a-number",
 				width:  "100",
-				expErr: `strconv.Atoi: parsing "not-a-number": invalid syntax`,
+				expErr: `invalid resize height "not-a-number": invalid syntax`,
 			},
 			{
 				doc:    "non-numeric width",
 				height: "100",
 				width:  "not-a-number",
-				expErr: `strconv.Atoi: parsing "not-a-number": invalid syntax`,
+				expErr: `invalid resize width "not-a-number": invalid syntax`,
+			},
+			{
+				doc:    "negative height",
+				height: "-100",
+				width:  "100",
+				expErr: `invalid resize height "-100": value out of range`,
+			},
+			{
+				doc:    "negative width",
+				height: "100",
+				width:  "-100",
+				expErr: `invalid resize width "-100": value out of range`,
+			},
+			{
+				doc:    "out of range height",
+				height: "4294967296", // math.MaxUint32+1
+				width:  "100",
+				expErr: `invalid resize height "4294967296": value out of range`,
+			},
+			{
+				doc:    "out of range width",
+				height: "100",
+				width:  "4294967296", // math.MaxUint32+1
+				expErr: `invalid resize width "4294967296": value out of range`,
 			},
 		}
 		for _, tc := range sizes {

--- a/integration/container/resize_test.go
+++ b/integration/container/resize_test.go
@@ -48,35 +48,59 @@ func TestResize(t *testing.T) {
 				doc:    "unset height",
 				height: valueNotSet,
 				width:  "100",
-				expErr: `strconv.Atoi: parsing "": invalid syntax`,
+				expErr: `invalid resize height "": invalid syntax`,
 			},
 			{
 				doc:    "unset width",
 				height: "100",
 				width:  valueNotSet,
-				expErr: `strconv.Atoi: parsing "": invalid syntax`,
+				expErr: `invalid resize width "": invalid syntax`,
 			},
 			{
 				doc:    "empty height",
 				width:  "100",
-				expErr: `strconv.Atoi: parsing "": invalid syntax`,
+				expErr: `invalid resize height "": invalid syntax`,
 			},
 			{
 				doc:    "empty width",
 				height: "100",
-				expErr: `strconv.Atoi: parsing "": invalid syntax`,
+				expErr: `invalid resize width "": invalid syntax`,
 			},
 			{
 				doc:    "non-numeric height",
 				height: "not-a-number",
 				width:  "100",
-				expErr: `strconv.Atoi: parsing "not-a-number": invalid syntax`,
+				expErr: `invalid resize height "not-a-number": invalid syntax`,
 			},
 			{
 				doc:    "non-numeric width",
 				height: "100",
 				width:  "not-a-number",
-				expErr: `strconv.Atoi: parsing "not-a-number": invalid syntax`,
+				expErr: `invalid resize width "not-a-number": invalid syntax`,
+			},
+			{
+				doc:    "negative height",
+				height: "-100",
+				width:  "100",
+				expErr: `invalid resize height "-100": value out of range`,
+			},
+			{
+				doc:    "negative width",
+				height: "100",
+				width:  "-100",
+				expErr: `invalid resize width "-100": value out of range`,
+			},
+			{
+				doc:    "out of range height",
+				height: "4294967296", // math.MaxUint32+1
+				width:  "100",
+				expErr: `invalid resize height "4294967296": value out of range`,
+			},
+			{
+				doc:    "out of range width",
+				height: "100",
+				width:  "4294967296", // math.MaxUint32+1
+				expErr: `invalid resize width "4294967296": value out of range`,
 			},
 		}
 		for _, tc := range sizes {


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/48665

### api/server/httputils: add Uint32Value utility

### api: container resize: improve errors for invalid width/height


### api: backend.ContainerResize: pass context and use uint32 for width, height

Containerd accepts uints for these, so make the backend signature  align
with that, so that we don't have to cast values. Also pass the context
along.


### api: exec resize: improve errors for invalid width/height


### api: backend.ContainerExecResize: pass context and use uint32 for width, height

Containerd accepts uints for these, so make the backend signature align
with that, so that we don't have to cast values. Also pass the context
along.


### client: ContainerResize, ContainerExecResize: don't overflow width/height

Mostly theoretical, but let's be correct here. It's worth noting that the API
(backend) accepts uint32, but container.ResizeOptions uses uint (uint64). We
could decide to add checks for this on the client side, or to change the
type (but that would be a breaking change).


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
api: improve errors for invalid width/height on container resize and exec resize
```

**- A picture of a cute animal (not mandatory but encouraged)**

