### PR TITLE
distribution: use hcsshim's CheckHostAndContainerCompat

### DIFF
--- a/distribution/pull_v2_windows.go
+++ b/distribution/pull_v2_windows.go
@@ -2,7 +2,6 @@ package distribution // import "github.com/docker/docker/distribution"
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -91,8 +90,8 @@ func filterManifests(manifests []manifestlist.ManifestDescriptor, p ocispec.Plat
 			continue
 		}
 		// TODO(thaJeztah): should we also take the user-provided platform into account (if any)?
-		if strings.EqualFold("windows", manifestDescriptor.Platform.OS) {
-			if err := checkImageCompatibility("windows", manifestDescriptor.Platform.OSVersion); err != nil {
+		if manifestDescriptor.Platform.OS == "windows" {
+			if err := checkImageCompatibility(manifestDescriptor.Platform.OS, manifestDescriptor.Platform.OSVersion); err != nil {
 				skip()
 				continue
 			}
@@ -133,21 +132,43 @@ func (mbv manifestsByVersion) Swap(i, j int) {
 	mbv.list[i], mbv.list[j] = mbv.list[j], mbv.list[i]
 }
 
-// checkImageCompatibility blocks pulling incompatible images based on a later OS build
+// checkImageCompatibility tries to check whether a Windows image is incompatible
+// with the host's OS version. It is a no-op for non-Windows images. It returns
+// an error if the image is incompatible, but ignores failures when parsing
+// imageOSVersion.
+//
 // Fixes https://github.com/moby/moby/issues/36184.
 func checkImageCompatibility(imageOS, imageOSVersion string) error {
-	if imageOS == "windows" {
-		hostOSV := osversion.Get()
-		splitImageOSVersion := strings.Split(imageOSVersion, ".") // eg 10.0.16299.nnnn
-		if len(splitImageOSVersion) >= 3 {
-			if imageOSBuild, err := strconv.Atoi(splitImageOSVersion[2]); err == nil {
-				if imageOSBuild > int(hostOSV.Build) {
-					errMsg := fmt.Sprintf("a Windows version %s.%s.%s-based image is incompatible with a %s host", splitImageOSVersion[0], splitImageOSVersion[1], splitImageOSVersion[2], hostOSV.ToString())
-					log.G(context.TODO()).Debugf(errMsg)
-					return errors.New(errMsg)
-				}
-			}
-		}
+	if imageOS != "windows" {
+		return nil
+	}
+
+	splitImageOSVersion := strings.SplitN(imageOSVersion, ".", 4) // eg 10.0.16299.nnnn
+	if len(splitImageOSVersion) < 3 {
+		return nil
+	}
+	imgMajor, err := strconv.ParseUint(splitImageOSVersion[0], 10, 8)
+	if err != nil {
+		return nil
+	}
+	imgMinor, err := strconv.ParseUint(splitImageOSVersion[1], 10, 8)
+	if err != nil {
+		return nil
+	}
+	imgBuild, err := strconv.ParseUint(splitImageOSVersion[2], 10, 16)
+	if err != nil {
+		return nil
+	}
+	imgOSV := osversion.OSVersion{
+		MajorVersion: uint8(imgMajor),
+		MinorVersion: uint8(imgMinor),
+		Build:        uint16(imgBuild),
+	}
+
+	if hostOSV := osversion.Get(); !osversion.CheckHostAndContainerCompat(hostOSV, imgOSV) {
+		err = fmt.Errorf("a Windows version %s-based image is incompatible with a %s host", imgOSV, hostOSV)
+		log.G(context.TODO()).WithError(err).Debug("image is incompatible with host")
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Checking whether a Windows image is compatible with the host requires knowledge about kernel-compatibility. Previously, there was no canonical implementation for such a check, but one is now provided by  hcsshim's osversion package.

Replace our own compatibility-check with the canonical implementation, so that we don't flag images as "incompatible" (where they actually are), or vice-versa.

Also remove uses of the deprecated `.ToString()` method, as it now implements a stringer interface (`.String()`).


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Improve compatiblity-check for Windows images. The check now uses the canonical implementation as provided by Microsoft.
```

**- A picture of a cute animal (not mandatory but encouraged)**

