### PR TITLE
distribution: remove formatPlatform utility

### DIFF
--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -936,7 +936,13 @@ type noMatchesErr struct {
 }
 
 func (e noMatchesErr) Error() string {
-	return fmt.Sprintf("no matching manifest for %s in the manifest list entries", formatPlatform(e.platform))
+	var p string
+	if e.platform.OS == "" {
+		p = platforms.FormatAll(platforms.DefaultSpec())
+	} else {
+		p = platforms.FormatAll(e.platform)
+	}
+	return fmt.Sprintf("no matching manifest for %s in the manifest list entries", p)
 }
 
 func retry(ctx context.Context, maxAttempts int, sleep time.Duration, f func(ctx context.Context) error) (err error) {

--- a/distribution/pull_v2_test.go
+++ b/distribution/pull_v2_test.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"os"
 	"reflect"
-	"regexp"
 	"runtime"
 	"strings"
 	"sync/atomic"
@@ -193,24 +192,17 @@ func TestValidateManifest(t *testing.T) {
 	}
 }
 
-func TestFormatPlatform(t *testing.T) {
-	var platform ocispec.Platform
-	result := formatPlatform(platform)
-	if strings.HasPrefix(result, "unknown") {
-		t.Fatal("expected formatPlatform to show a known platform")
-	}
-	if !strings.HasPrefix(result, runtime.GOOS) {
-		t.Fatal("expected formatPlatform to show the current platform")
-	}
-	if runtime.GOOS == "windows" {
-		if !strings.HasPrefix(result, "windows") {
-			t.Fatal("expected formatPlatform to show windows platform")
-		}
-		matches, _ := regexp.MatchString("windows.* [0-9]", result)
-		if !matches {
-			t.Fatalf("expected formatPlatform to show windows platform with a version, but got '%s'", result)
-		}
-	}
+func TestNoMatchesErr(t *testing.T) {
+	err := noMatchesErr{}
+	assert.Check(t, is.ErrorContains(err, "no matching manifest for "+runtime.GOOS))
+
+	err = noMatchesErr{ocispec.Platform{
+		Architecture: "arm64",
+		OS:           "windows",
+		OSVersion:    "10.0.17763",
+		Variant:      "v8",
+	}}
+	assert.Check(t, is.Error(err, "no matching manifest for windows(10.0.17763)/arm64/v8 in the manifest list entries"))
 }
 
 func TestPullSchema2Config(t *testing.T) {

--- a/distribution/pull_v2_unix.go
+++ b/distribution/pull_v2_unix.go
@@ -63,10 +63,3 @@ func withDefault(p ocispec.Platform) ocispec.Platform {
 	}
 	return p
 }
-
-func formatPlatform(platform ocispec.Platform) string {
-	if platform.OS == "" {
-		platform = platforms.DefaultSpec()
-	}
-	return platforms.Format(platform)
-}

--- a/distribution/pull_v2_windows.go
+++ b/distribution/pull_v2_windows.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/containerd/log"
-	"github.com/containerd/platforms"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/manifest/schema2"
@@ -150,11 +149,4 @@ func checkImageCompatibility(imageOS, imageOSVersion string) error {
 		}
 	}
 	return nil
-}
-
-func formatPlatform(platform ocispec.Platform) string {
-	if platform.OS == "" {
-		platform = platforms.DefaultSpec()
-	}
-	return fmt.Sprintf("%s %s", platforms.Format(platform), osversion.Get().ToString())
 }


### PR DESCRIPTION
It was used in a single place, and the containerd/platforms module now provides a format for a platform including os.version (through FormatAll), which means we no longer have to create our own formatting for this.

**- A picture of a cute animal (not mandatory but encouraged)**

