### PR TITLE
dockerd-rootless-setuptool.sh: let --force ignore smoke test errors

### DIFF
--- a/contrib/dockerd-rootless-setuptool.sh
+++ b/contrib/dockerd-rootless-setuptool.sh
@@ -399,8 +399,12 @@ cmd_entrypoint_install() {
 	# check RootlessKit functionality. RootlessKit will print hints if something is still unsatisfied.
 	# (e.g., `kernel.apparmor_restrict_unprivileged_userns` constraint)
 	if ! rootlesskit true; then
-		ERROR "RootlessKit failed, see the error messages and https://rootlesscontaine.rs/getting-started/common/ ."
-		exit 1
+		if [ -z "$OPT_FORCE" ]; then
+			ERROR "RootlessKit failed, see the error messages and https://rootlesscontaine.rs/getting-started/common/ . Set --force to ignore."
+			exit 1
+		else
+			WARNING "RootlessKit failed, see the error messages and https://rootlesscontaine.rs/getting-started/common/ ."
+		fi
 	fi
 
 	if [ -z "$SYSTEMD" ]; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Fix #48678

Now `dockerd-rootless-setuptool.sh install --force` ignores errors from `rootlesskit`.

This might be useful when installing Rootless Docker into a container image with `RUN` instructions.


**- How I did it**
Check `--force`

**- How to verify it**
`dockerd-rootless-setuptool.sh install --force`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
dockerd-rootless-setuptool.sh: let --force ignore smoke test errors
```

**- A picture of a cute animal (not mandatory but encouraged)**
🐧 
