### PR TITLE
build: log when build is cancelled

### DIFF
--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -245,7 +245,7 @@ func (br *buildRouter) postBuild(ctx context.Context, w http.ResponseWriter, r *
 		}
 		_, err = output.Write(streamformatter.FormatError(err))
 		if err != nil {
-			log.G(ctx).Warnf("could not write error response: %v", err)
+			log.G(ctx).WithError(err).Warn("could not write error response")
 		}
 		return nil
 	}
@@ -280,6 +280,9 @@ func (br *buildRouter) postBuild(ctx context.Context, w http.ResponseWriter, r *
 		ProgressWriter: buildProgressWriter(out, wantAux, createProgressReader),
 	})
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			log.G(ctx).Debug("build canceled")
+		}
 		return errf(err)
 	}
 


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/48599


While looking at  https://github.com/moby/moby/issues/48599, I noticed that the daemon logs, even in debug, did not give any indication that the build was cancelled. This patch adds some logs to help debugging.

**- A picture of a cute animal (not mandatory but encouraged)**

