### PR TITLE
[27.x backport] gha: more limits, update alpine version, and some minor improvements

### DIFF
--- a/.github/workflows/.dco.yml
+++ b/.github/workflows/.dco.yml
@@ -16,7 +16,7 @@ on:
   workflow_call:
 
 env:
-  ALPINE_VERSION: 3.16
+  ALPINE_VERSION: "3.20"
 
 jobs:
   run:

--- a/.github/workflows/.dco.yml
+++ b/.github/workflows/.dco.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   run:
     runs-on: ubuntu-20.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 10 # guardrails timeout for the whole job
     steps:
       -
         name: Checkout

--- a/.github/workflows/.dco.yml
+++ b/.github/workflows/.dco.yml
@@ -49,10 +49,12 @@ jobs:
         name: Validate
         run: |
           docker run --rm \
-            -v "$(pwd):/workspace" \
+            --quiet \
+            -v ./:/workspace \
+            -w /workspace \
             -e VALIDATE_REPO \
             -e VALIDATE_BRANCH \
-            alpine:${{ env.ALPINE_VERSION }} sh -c 'apk add --no-cache -q bash git openssh-client && git config --system --add safe.directory /workspace && cd /workspace && hack/validate/dco'
+            alpine:${{ env.ALPINE_VERSION }} sh -c 'apk add --no-cache -q bash git openssh-client && git config --system --add safe.directory /workspace && hack/validate/dco'
         env:
           VALIDATE_REPO: ${{ github.server_url }}/${{ github.repository }}.git
           VALIDATE_BRANCH: ${{ steps.base-ref.outputs.result }}

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -204,7 +204,7 @@ jobs:
           retention-days: 1
 
   unit-test-report:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120 # guardrails timeout for the whole job
     if: always()
     needs:
@@ -231,7 +231,7 @@ jobs:
           find /tmp/artifacts -type f -name '*-go-test-report.json' -exec teststat -markdown {} \+ >> $GITHUB_STEP_SUMMARY
 
   integration-test-prepare:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120 # guardrails timeout for the whole job
     outputs:
       matrix: ${{ steps.tests.outputs.matrix }}
@@ -525,7 +525,7 @@ jobs:
           retention-days: 1
 
   integration-test-report:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ inputs.storage == 'snapshotter' && github.event_name != 'pull_request' }}
     if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
   build:
     runs-on: ubuntu-20.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 20 # guardrails timeout for the whole job
     needs:
       - validate-dco
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           find ${{ env.DESTDIR }} -type f -exec file -e ascii -- {} +
 
   prepare-cross:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20 # guardrails timeout for the whole job
     needs:
       - validate-dco

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
 
   validate-prepare:
     runs-on: ubuntu-20.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 10 # guardrails timeout for the whole job
     needs:
       - validate-dco
     outputs:
@@ -109,7 +109,7 @@ jobs:
 
   validate:
     runs-on: ubuntu-20.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 30 # guardrails timeout for the whole job
     needs:
       - validate-prepare
       - build-dev
@@ -147,7 +147,7 @@ jobs:
 
   smoke-prepare:
     runs-on: ubuntu-20.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 10 # guardrails timeout for the whole job
     needs:
       - validate-dco
     outputs:
@@ -169,7 +169,7 @@ jobs:
 
   smoke:
     runs-on: ubuntu-20.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 20 # guardrails timeout for the whole job
     needs:
       - smoke-prepare
     strategy:


### PR DESCRIPTION
**- What I did**
* Backports https://github.com/moby/moby/pull/48654

**- How I did it**

```
git cherry-pick -xsS e75f7aca2fd4562f47d89ba7d29f55276c06d897
git cherry-pick -xsS cfe0d2a1315d666ba5a3f4313c99654410ce049d
git cherry-pick -xsS 3cb98d759d95ac28a3f7c530779a3cd56aaf81aa
git cherry-pick -xsS 9a142995405b5c43c181d91d247caf567b126c01
git cherry-pick -xsS 91c448bfb59405b4543732fa155baf4693db0caf
git cherry-pick -xsS a051aba82e4e58d8b36b2a20148396bb6c99e0ad
```

**- Description for the changelog**
```markdown changelog
n/a
```

**- A picture of a cute animal (not mandatory but encouraged)**

