### PR TITLE
daemon: deprecate Daemon.Register and make it internal

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -236,7 +236,7 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 	}
 
 	daemon.updateContainerNetworkSettings(ctr, endpointsConfigs)
-	if err := daemon.Register(ctr); err != nil {
+	if err := daemon.register(ctx, ctr); err != nil {
 		return nil, err
 	}
 	stateCtr.set(ctr.ID, "stopped")

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -335,7 +335,7 @@ func (daemon *Daemon) restore(cfg *configStore) error {
 				mapLock.Unlock()
 				return
 			}
-			if err := daemon.Register(c); err != nil {
+			if err := daemon.register(context.TODO(), c); err != nil {
 				logger.WithError(err).Error("failed to register container")
 				mapLock.Lock()
 				delete(containers, c.ID)


### PR DESCRIPTION
This function was only used internally in the daemon. This patch splits the implementation to a non-exported version and deprecates the exported one.

While at it, also pass through the context (which is used for tracing), and added a note about the function potentially not being atomic.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
daemon: deprecate `Daemon.Register()`. This function is unused and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

