### PR TITLE
daemon: remove configsSupported, secretsSupported utilities

### DIFF
--- a/daemon/configs.go
+++ b/daemon/configs.go
@@ -1,19 +1,11 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
-	"context"
-
-	"github.com/containerd/log"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 )
 
 // SetContainerConfigReferences sets the container config references needed
 func (daemon *Daemon) SetContainerConfigReferences(name string, refs []*swarmtypes.ConfigReference) error {
-	if !configsSupported() && len(refs) > 0 {
-		log.G(context.TODO()).Warn("configs are not supported on this platform")
-		return nil
-	}
-
 	c, err := daemon.GetContainer(name)
 	if err != nil {
 		return err

--- a/daemon/configs_linux.go
+++ b/daemon/configs_linux.go
@@ -1,5 +1,0 @@
-package daemon // import "github.com/docker/docker/daemon"
-
-func configsSupported() bool {
-	return true
-}

--- a/daemon/configs_unsupported.go
+++ b/daemon/configs_unsupported.go
@@ -1,7 +1,0 @@
-//go:build !linux && !windows
-
-package daemon // import "github.com/docker/docker/daemon"
-
-func configsSupported() bool {
-	return false
-}

--- a/daemon/configs_windows.go
+++ b/daemon/configs_windows.go
@@ -1,5 +1,0 @@
-package daemon // import "github.com/docker/docker/daemon"
-
-func configsSupported() bool {
-	return true
-}

--- a/daemon/secrets.go
+++ b/daemon/secrets.go
@@ -1,25 +1,15 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
-	"context"
-
-	"github.com/containerd/log"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 )
 
 // SetContainerSecretReferences sets the container secret references needed
 func (daemon *Daemon) SetContainerSecretReferences(name string, refs []*swarmtypes.SecretReference) error {
-	if !secretsSupported() && len(refs) > 0 {
-		log.G(context.TODO()).Warn("secrets are not supported on this platform")
-		return nil
-	}
-
 	c, err := daemon.GetContainer(name)
 	if err != nil {
 		return err
 	}
-
 	c.SecretReferences = refs
-
 	return nil
 }

--- a/daemon/secrets_linux.go
+++ b/daemon/secrets_linux.go
@@ -1,5 +1,0 @@
-package daemon // import "github.com/docker/docker/daemon"
-
-func secretsSupported() bool {
-	return true
-}

--- a/daemon/secrets_unsupported.go
+++ b/daemon/secrets_unsupported.go
@@ -1,7 +1,0 @@
-//go:build !linux && !windows
-
-package daemon // import "github.com/docker/docker/daemon"
-
-func secretsSupported() bool {
-	return false
-}

--- a/daemon/secrets_windows.go
+++ b/daemon/secrets_windows.go
@@ -1,5 +1,0 @@
-package daemon // import "github.com/docker/docker/daemon"
-
-func secretsSupported() bool {
-	return true
-}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/32336
- relates to https://github.com/moby/moby/pull/33169
- relates to https://github.com/moby/moby/pull/27794
- relates to https://github.com/moby/moby/pull/32208


### daemon: remove configsSupported utility

This utility was originally added in 9e9fc7b57c1764c008e568ed52bcd1aade7eb40c
at which time it was not yet implemented for Windows, so this utility was
used to print a warning when trying to use it on that platform.

Windows support was added in e0d533b1e8a8dd62ed6dff2dfda3c3220e0474b9, which
kept the utility, but adjusted it to support for both Windows and Linux, and
excluding any other platform.

Let's remove this utility, given that we currently only support Windows and
Linux (there's been some partial support for other platforms, but they are
very likely broken in many ways).



### daemon: remove secretsSupported utility

This utility was originally added in 3716ec25b423d8ff7dfa231a7b3cf0154726ed37
at which time it was not yet implemented for Windows, so this utility was
used to print a warning when trying to use it on that platform.

Windows support was added in bd4e8aa64e5e7dedb60ca6670d7ddb32d5af0db9, which
kept the utility, but adjusted it to support for both Windows and Linux, and
excluding any other platform.

Let's remove this utility, given that we currently only support Windows and
Linux (there's been some partial support for other platforms, but they are
very likely broken in many ways).
