### PR TITLE
daemon: Daemon.newContainer: inline Daemon.generateHostname

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -172,7 +172,7 @@ func (daemon *Daemon) newContainer(name string, operatingSystem string, config *
 	base.Name = name
 	base.Driver = daemon.imageService.StorageDriver()
 	base.OS = operatingSystem
-	return base, err
+	return base, nil
 }
 
 // GetByName returns a container given a name.


### PR DESCRIPTION
generateHostname was only used here, and defined as a method on Daemon without depending on the daemon type. Inline the function and simplify the logic (as both the "network=host" and non-host code only had to be executed if no hostname was set).


