### PR TITLE
pkg/stringid: remove deprecated IsShortID, ValidateID

### DIFF
--- a/pkg/stringid/stringid.go
+++ b/pkg/stringid/stringid.go
@@ -4,8 +4,6 @@ package stringid // import "github.com/docker/docker/pkg/stringid"
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"errors"
-	"regexp"
 	"strconv"
 	"strings"
 )
@@ -14,22 +12,6 @@ const (
 	shortLen = 12
 	fullLen  = 64
 )
-
-var (
-	validShortID = regexp.MustCompile("^[a-f0-9]{12}$")
-	validHex     = regexp.MustCompile(`^[a-f0-9]{64}$`)
-)
-
-// IsShortID determines if id has the correct format and length for a short ID.
-// It checks the IDs length and if it consists of valid characters for IDs (a-f0-9).
-//
-// Deprecated: this function is no longer used, and will be removed in the next release.
-func IsShortID(id string) bool {
-	if len(id) != shortLen {
-		return false
-	}
-	return validShortID.MatchString(id)
-}
 
 // TruncateID returns a shorthand version of a string identifier for convenience.
 // A collision with other shorthands is very unlikely, but possible.
@@ -61,17 +43,4 @@ func GenerateRandomID() string {
 		}
 		return id
 	}
-}
-
-// ValidateID checks whether an ID string is a valid, full-length image ID.
-//
-// Deprecated: use [github.com/docker/docker/image/v1.ValidateID] instead. Will be removed in the next release.
-func ValidateID(id string) error {
-	if len(id) != fullLen {
-		return errors.New("image ID '" + id + "' is invalid")
-	}
-	if !validHex.MatchString(id) {
-		return errors.New("image ID '" + id + "' is invalid")
-	}
-	return nil
 }

--- a/pkg/stringid/stringid_test.go
+++ b/pkg/stringid/stringid_test.go
@@ -1,7 +1,6 @@
 package stringid // import "github.com/docker/docker/pkg/stringid"
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -42,48 +41,5 @@ func TestShortenIdInvalid(t *testing.T) {
 	truncID := TruncateID(id)
 	if len(truncID) != len(id) {
 		t.Fatalf("Id returned is incorrect: truncate on %s returned %s", id, truncID)
-	}
-}
-
-func TestIsShortIDNonHex(t *testing.T) {
-	id := "some non-hex value"
-	if IsShortID(id) {
-		t.Fatalf("%s is not a short ID", id)
-	}
-}
-
-func TestIsShortIDNotCorrectSize(t *testing.T) {
-	id := strings.Repeat("a", shortLen+1)
-	if IsShortID(id) {
-		t.Fatalf("%s is not a short ID", id)
-	}
-	id = strings.Repeat("a", shortLen-1)
-	if IsShortID(id) {
-		t.Fatalf("%s is not a short ID", id)
-	}
-}
-
-var testIDs = []string{
-	"4e38e38c8ce0",
-	strings.Repeat("a", shortLen+1),
-	strings.Repeat("a", 16000),
-	"90435eec5c4e124e741ef731e118be2fc799a68aba0466ec17717f24ce2ae6a2",
-}
-
-func BenchmarkIsShortID(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, id := range testIDs {
-			_ = IsShortID(id)
-		}
-	}
-}
-
-func BenchmarkValidateID(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, id := range testIDs {
-			_ = ValidateID(id)
-		}
 	}
 }


### PR DESCRIPTION
- relates to - relates to https://github.com/moby/moby/pull/47995

---

- `IsShortID` was deprecated in 2100a707410ca7b44983ffe2bfb166f9c96abbf4
- `ValidateID` was deprecated in e19e6cf7f45280fa0f6567142ae4d8de9229bfc7

Both are part of 27.0, so we can remove these.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
pkg/stringid: remove deprecated `IsShortID` and  `ValidateID` functions
```

**- A picture of a cute animal (not mandatory but encouraged)**

