### PR TITLE
client: explicitly return zero-type on failures in prune functions

### DIFF
--- a/client/build_prune.go
+++ b/client/build_prune.go
@@ -17,8 +17,6 @@ func (cli *Client) BuildCachePrune(ctx context.Context, opts types.BuildCachePru
 		return nil, err
 	}
 
-	report := types.BuildCachePruneReport{}
-
 	query := url.Values{}
 	if opts.All {
 		query.Set("all", "1")
@@ -37,6 +35,7 @@ func (cli *Client) BuildCachePrune(ctx context.Context, opts types.BuildCachePru
 		return nil, err
 	}
 
+	report := types.BuildCachePruneReport{}
 	if err := json.NewDecoder(serverResp.body).Decode(&report); err != nil {
 		return nil, errors.Wrap(err, "error retrieving disk usage")
 	}

--- a/client/container_prune.go
+++ b/client/container_prune.go
@@ -11,25 +11,24 @@ import (
 
 // ContainersPrune requests the daemon to delete unused data
 func (cli *Client) ContainersPrune(ctx context.Context, pruneFilters filters.Args) (container.PruneReport, error) {
-	var report container.PruneReport
-
 	if err := cli.NewVersionError(ctx, "1.25", "container prune"); err != nil {
-		return report, err
+		return container.PruneReport{}, err
 	}
 
 	query, err := getFiltersQuery(pruneFilters)
 	if err != nil {
-		return report, err
+		return container.PruneReport{}, err
 	}
 
 	serverResp, err := cli.post(ctx, "/containers/prune", query, nil, nil)
 	defer ensureReaderClosed(serverResp)
 	if err != nil {
-		return report, err
+		return container.PruneReport{}, err
 	}
 
+	var report container.PruneReport
 	if err := json.NewDecoder(serverResp.body).Decode(&report); err != nil {
-		return report, fmt.Errorf("Error retrieving disk usage: %v", err)
+		return container.PruneReport{}, fmt.Errorf("Error retrieving disk usage: %v", err)
 	}
 
 	return report, nil

--- a/client/image_prune.go
+++ b/client/image_prune.go
@@ -11,25 +11,24 @@ import (
 
 // ImagesPrune requests the daemon to delete unused data
 func (cli *Client) ImagesPrune(ctx context.Context, pruneFilters filters.Args) (image.PruneReport, error) {
-	var report image.PruneReport
-
 	if err := cli.NewVersionError(ctx, "1.25", "image prune"); err != nil {
-		return report, err
+		return image.PruneReport{}, err
 	}
 
 	query, err := getFiltersQuery(pruneFilters)
 	if err != nil {
-		return report, err
+		return image.PruneReport{}, err
 	}
 
 	serverResp, err := cli.post(ctx, "/images/prune", query, nil, nil)
 	defer ensureReaderClosed(serverResp)
 	if err != nil {
-		return report, err
+		return image.PruneReport{}, err
 	}
 
+	var report image.PruneReport
 	if err := json.NewDecoder(serverResp.body).Decode(&report); err != nil {
-		return report, fmt.Errorf("Error retrieving disk usage: %v", err)
+		return image.PruneReport{}, fmt.Errorf("Error retrieving disk usage: %v", err)
 	}
 
 	return report, nil

--- a/client/network_prune.go
+++ b/client/network_prune.go
@@ -11,25 +11,24 @@ import (
 
 // NetworksPrune requests the daemon to delete unused networks
 func (cli *Client) NetworksPrune(ctx context.Context, pruneFilters filters.Args) (network.PruneReport, error) {
-	var report network.PruneReport
-
 	if err := cli.NewVersionError(ctx, "1.25", "network prune"); err != nil {
-		return report, err
+		return network.PruneReport{}, err
 	}
 
 	query, err := getFiltersQuery(pruneFilters)
 	if err != nil {
-		return report, err
+		return network.PruneReport{}, err
 	}
 
 	serverResp, err := cli.post(ctx, "/networks/prune", query, nil, nil)
 	defer ensureReaderClosed(serverResp)
 	if err != nil {
-		return report, err
+		return network.PruneReport{}, err
 	}
 
+	var report network.PruneReport
 	if err := json.NewDecoder(serverResp.body).Decode(&report); err != nil {
-		return report, fmt.Errorf("Error retrieving network prune report: %v", err)
+		return network.PruneReport{}, fmt.Errorf("Error retrieving network prune report: %v", err)
 	}
 
 	return report, nil

--- a/client/volume_prune.go
+++ b/client/volume_prune.go
@@ -11,25 +11,24 @@ import (
 
 // VolumesPrune requests the daemon to delete unused data
 func (cli *Client) VolumesPrune(ctx context.Context, pruneFilters filters.Args) (volume.PruneReport, error) {
-	var report volume.PruneReport
-
 	if err := cli.NewVersionError(ctx, "1.25", "volume prune"); err != nil {
-		return report, err
+		return volume.PruneReport{}, err
 	}
 
 	query, err := getFiltersQuery(pruneFilters)
 	if err != nil {
-		return report, err
+		return volume.PruneReport{}, err
 	}
 
 	serverResp, err := cli.post(ctx, "/volumes/prune", query, nil, nil)
 	defer ensureReaderClosed(serverResp)
 	if err != nil {
-		return report, err
+		return volume.PruneReport{}, err
 	}
 
+	var report volume.PruneReport
 	if err := json.NewDecoder(serverResp.body).Decode(&report); err != nil {
-		return report, fmt.Errorf("Error retrieving volume prune report: %v", err)
+		return volume.PruneReport{}, fmt.Errorf("Error retrieving volume prune report: %v", err)
 	}
 
 	return report, nil


### PR DESCRIPTION
Mostly a "nit", but it makes it clearer that we're returning an empty result, and not a (partially) propagated struct.


**- A picture of a cute animal (not mandatory but encouraged)**

🙈 