### PR TITLE
[27.x backport] daemon: deprecate Daemon.Exists and Daemon.IsPaused

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -78,6 +78,8 @@ func (daemon *Daemon) Exists(id string) bool {
 }
 
 // IsPaused returns a bool indicating if the specified container is paused.
+//
+// Deprecated: use [Daemon.GetContainer] to look up a container by ID, Name, or ID-prefix, and use [container.State.IsPaused]. This function will be removed in the next release.
 func (daemon *Daemon) IsPaused(id string) bool {
 	c, _ := daemon.GetContainer(id)
 	return c.State.IsPaused()

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -70,6 +70,8 @@ func (daemon *Daemon) GetContainer(prefixOrName string) (*container.Container, e
 
 // Exists returns a true if a container of the specified ID or name exists,
 // false otherwise.
+//
+// Deprecated: use [Daemon.GetContainer] to look up a container by ID, Name, or ID-prefix. This function will be removed in the next release.
 func (daemon *Daemon) Exists(id string) bool {
 	c, _ := daemon.GetContainer(id)
 	return c != nil


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/48670

### daemon: deprecate Daemon.Exists

This function was poorly documented as it uses fuzzy matching under the hood,
and it's no longer used. Mark it as deprecated, and to be removed in the
next release.

### daemon: deprecate Daemon.IsPaused

This function was poorly documented as it uses fuzzy matching under the hood,
and it's no longer used. Mark it as deprecated, and to be removed in the
next release.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
daemon: deprecate `Daemon.Exists()` and `Daemon.IsPaused()`. These functions are no longer used and will be removed  in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**
