### PR TITLE
daemon: remove deprecated Daemon.Exists and Daemon.IsPaused

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -68,14 +68,6 @@ func (daemon *Daemon) GetContainer(prefixOrName string) (*container.Container, e
 	return ctr, nil
 }
 
-// IsPaused returns a bool indicating if the specified container is paused.
-//
-// Deprecated: use [Daemon.GetContainer] to look up a container by ID, Name, or ID-prefix, and use [container.State.IsPaused]. This function will be removed in the next release.
-func (daemon *Daemon) IsPaused(id string) bool {
-	c, _ := daemon.GetContainer(id)
-	return c.State.IsPaused()
-}
-
 func (daemon *Daemon) containerRoot(id string) string {
 	return filepath.Join(daemon.repository, id)
 }

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -68,15 +68,6 @@ func (daemon *Daemon) GetContainer(prefixOrName string) (*container.Container, e
 	return ctr, nil
 }
 
-// Exists returns a true if a container of the specified ID or name exists,
-// false otherwise.
-//
-// Deprecated: use [Daemon.GetContainer] to look up a container by ID, Name, or ID-prefix. This function will be removed in the next release.
-func (daemon *Daemon) Exists(id string) bool {
-	c, _ := daemon.GetContainer(id)
-	return c != nil
-}
-
 // IsPaused returns a bool indicating if the specified container is paused.
 //
 // Deprecated: use [Daemon.GetContainer] to look up a container by ID, Name, or ID-prefix, and use [container.State.IsPaused]. This function will be removed in the next release.


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/48670

### daemon: remove deprecated Daemon.Exists

This was deprecated in d47c31ffdd4977ea63cffb8aa97d316dae6fa998, and
no longer used.


### daemon: remove deprecated Daemon.IsPaused

This was deprecated in ac6e32cb5c2cc0620f260c671529c6df445a03df, and
no longer used.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
daemon: remove deprecated `Daemon.Exists()` and `Daemon.IsPaused()`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

