### PR TITLE
Remove dependency on the filter-FORWARD policy

### DIFF
--- a/integration/network/bridge/iptablesdoc/generated/new-daemon.md
+++ b/integration/network/bridge/iptablesdoc/generated/new-daemon.md
@@ -22,6 +22,7 @@ Table `filter`:
     
     Chain DOCKER (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-ISOLATION-STAGE-1 (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -54,6 +55,7 @@ Table `filter`:
     -A FORWARD -o docker0 -j DOCKER
     -A FORWARD -i docker0 ! -o docker0 -j ACCEPT
     -A FORWARD -i docker0 -o docker0 -j ACCEPT
+    -A DOCKER ! -i docker0 -o docker0 -j DROP
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-1 -j RETURN
     -A DOCKER-ISOLATION-STAGE-2 -o docker0 -j DROP
@@ -108,7 +110,12 @@ But, when ICC is disabled, rule 6 is DROP, so it would need to be placed before
 rule 5. Because the rules are generated in different places, that's a slightly
 bigger change than it should be._
 
-The DOCKER chain is empty, because there are no containers with port mappings yet.
+The DOCKER chain has a single DROP rule for the bridge network, to drop any
+packets routed to the network that have not originated in the network. Added by
+[defaultDrop][21].
+_This means there is no dependency on the filter-FORWARD chain's default policy.
+Even if it is ACCEPT, packets will be dropped unless container ports/protocols
+are published._
 
 The DOCKER-ISOLATION chains implement inter-network isolation, all (unrelated)
 packets are processed by these chains. The rule are inserted at the head of the
@@ -119,6 +126,7 @@ chain when a network is created, in [setINC][20].
     packets that are destined for any other network are dropped.
 
 [20]: https://github.com/moby/moby/blob/333cfa640239153477bf635a8131734d0e9d099d/libnetwork/drivers/bridge/setup_ip_tables_linux.go#L369
+[21]: https://github.com/robmry/moby/blob/52c89d467fc5326149e4bbb8903d23589b66ff0d/libnetwork/drivers/bridge/setup_ip_tables_linux.go#L252
 
 Table nat:
 

--- a/integration/network/bridge/iptablesdoc/generated/usernet-internal.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-internal.md
@@ -28,6 +28,7 @@ The filter table is updated as follows:
     
     Chain DOCKER (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-ISOLATION-STAGE-1 (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -63,6 +64,7 @@ The filter table is updated as follows:
     -A FORWARD -o docker0 -j DOCKER
     -A FORWARD -i docker0 ! -o docker0 -j ACCEPT
     -A FORWARD -i docker0 -o docker0 -j ACCEPT
+    -A DOCKER ! -i docker0 -o docker0 -j DROP
     -A DOCKER-ISOLATION-STAGE-1 ! -s 192.0.2.0/24 -o bridge1 -j DROP
     -A DOCKER-ISOLATION-STAGE-1 ! -d 192.0.2.0/24 -i bridge1 -j DROP
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noicc.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noicc.md
@@ -32,6 +32,8 @@ The filter table is:
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
+    2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
+    3        0     0 DROP       0    --  !bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-ISOLATION-STAGE-1 (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -71,6 +73,8 @@ The filter table is:
     -A FORWARD -i docker0 -o docker0 -j ACCEPT
     -A FORWARD -i bridge1 -o bridge1 -j DROP
     -A DOCKER -d 192.0.2.2/32 ! -i bridge1 -o bridge1 -p tcp -m tcp --dport 80 -j ACCEPT
+    -A DOCKER ! -i docker0 -o docker0 -j DROP
+    -A DOCKER ! -i bridge1 -o bridge1 -j DROP
     -A DOCKER-ISOLATION-STAGE-1 -i bridge1 ! -o bridge1 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-1 -j RETURN

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noproxy.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noproxy.md
@@ -35,6 +35,8 @@ The filter table is the same as with the userland proxy enabled.
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
+    2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
+    3        0     0 DROP       0    --  !bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-ISOLATION-STAGE-1 (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -71,6 +73,8 @@ The filter table is the same as with the userland proxy enabled.
     -A FORWARD -i docker0 ! -o docker0 -j ACCEPT
     -A FORWARD -i docker0 -o docker0 -j ACCEPT
     -A DOCKER -d 192.0.2.2/32 ! -i bridge1 -o bridge1 -p tcp -m tcp --dport 80 -j ACCEPT
+    -A DOCKER ! -i docker0 -o docker0 -j DROP
+    -A DOCKER ! -i bridge1 -o bridge1 -j DROP
     -A DOCKER-ISOLATION-STAGE-1 -i bridge1 ! -o bridge1 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-1 -j RETURN

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap.md
@@ -31,6 +31,8 @@ The filter table is updated as follows:
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
+    2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
+    3        0     0 DROP       0    --  !bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-ISOLATION-STAGE-1 (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -70,6 +72,8 @@ The filter table is updated as follows:
     -A FORWARD -i docker0 ! -o docker0 -j ACCEPT
     -A FORWARD -i docker0 -o docker0 -j ACCEPT
     -A DOCKER -d 192.0.2.2/32 ! -i bridge1 -o bridge1 -p tcp -m tcp --dport 80 -j ACCEPT
+    -A DOCKER ! -i docker0 -o docker0 -j DROP
+    -A DOCKER ! -i bridge1 -o bridge1 -j DROP
     -A DOCKER-ISOLATION-STAGE-1 -i bridge1 ! -o bridge1 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-1 -j RETURN
@@ -93,8 +97,14 @@ Note that:
    to the container's address. This rule is added when the container is created
    (unlike all the other rules so-far, which were created during driver or
    network initialisation). [setPerPortForwarding][1]
+   - These per-port rules are inserted at the head of the chain, so that they
+     appear before the network's DROP rule [defaultDrop][2] which is always
+     appended to the end of the chain. In this case, because `docker0` was
+     created before `bridge1`, the `bridge1` rules appear above and below the
+     `docker0` DROP rule.
 
 [1]: https://github.com/moby/moby/blob/675c2ac2db93e38bb9c5a6615d4155a969535fd9/libnetwork/drivers/bridge/port_mapping_linux.go#L795
+[2]: https://github.com/robmry/moby/blob/52c89d467fc5326149e4bbb8903d23589b66ff0d/libnetwork/drivers/bridge/setup_ip_tables_linux.go#L252
 
 And the corresponding nat table:
 

--- a/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
+++ b/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
@@ -142,6 +142,7 @@ type iptCmdType = string
 const (
 	iptCmdLFilter4        iptCmdType = "LFilter4"
 	iptCmdSFilter4        iptCmdType = "SFilter4"
+	iptCmdLFilterDocker4  iptCmdType = "LFilterDocker4"
 	iptCmdSFilterForward4 iptCmdType = "SFilterForward4"
 	iptCmdSFilterDocker4  iptCmdType = "SFilterDocker4"
 	iptCmdLNat4           iptCmdType = "LNat4"
@@ -152,6 +153,7 @@ var iptCmds = map[iptCmdType][]string{
 	iptCmdLFilter4:        {"iptables", "-nvL", "--line-numbers", "-t", "filter"},
 	iptCmdSFilter4:        {"iptables", "-S", "-t", "filter"},
 	iptCmdSFilterForward4: {"iptables", "-S", "FORWARD"},
+	iptCmdLFilterDocker4:  {"iptables", "-nvL", "DOCKER", "--line-numbers", "-t", "filter"},
 	iptCmdSFilterDocker4:  {"iptables", "-S", "DOCKER"},
 	iptCmdLNat4:           {"iptables", "-nvL", "--line-numbers", "-t", "nat"},
 	iptCmdSNat4:           {"iptables", "-S", "-t", "nat"},

--- a/integration/network/bridge/iptablesdoc/templates/new-daemon.md
+++ b/integration/network/bridge/iptablesdoc/templates/new-daemon.md
@@ -59,7 +59,12 @@ But, when ICC is disabled, rule 6 is DROP, so it would need to be placed before
 rule 5. Because the rules are generated in different places, that's a slightly
 bigger change than it should be._
 
-The DOCKER chain is empty, because there are no containers with port mappings yet.
+The DOCKER chain has a single DROP rule for the bridge network, to drop any
+packets routed to the network that have not originated in the network. Added by
+[defaultDrop][21].
+_This means there is no dependency on the filter-FORWARD chain's default policy.
+Even if it is ACCEPT, packets will be dropped unless container ports/protocols
+are published._
 
 The DOCKER-ISOLATION chains implement inter-network isolation, all (unrelated)
 packets are processed by these chains. The rule are inserted at the head of the
@@ -70,6 +75,7 @@ chain when a network is created, in [setINC][20].
     packets that are destined for any other network are dropped.
 
 [20]: https://github.com/moby/moby/blob/333cfa640239153477bf635a8131734d0e9d099d/libnetwork/drivers/bridge/setup_ip_tables_linux.go#L369
+[21]: https://github.com/robmry/moby/blob/52c89d467fc5326149e4bbb8903d23589b66ff0d/libnetwork/drivers/bridge/setup_ip_tables_linux.go#L252
 
 Table nat:
 

--- a/integration/network/bridge/iptablesdoc/templates/usernet-portmap-routed.md
+++ b/integration/network/bridge/iptablesdoc/templates/usernet-portmap-routed.md
@@ -31,6 +31,11 @@ so *ALL* ICMP message types are allowed.
 _The ACCEPT rule as shown by `iptables -L` looks alarming until you spot that it's
 for `prot 1`._
 
+Because the ICMP rule (rule 3) is per-network, it is appended to the chain along
+with the default-DROP rule (rule 4). So, it is likely to be separated from
+per-port/protocol ACCEPT rules for published ports on the same network. But it
+will always appear before the default-DROP.
+
 _[RFC 4890 section 4.3][6] makes recommendations for filtering ICMPv6. These
 have been considered, but the host firewall is not a network boundary in the
 sense used by the RFC. So, Node Information and Router Renumbering messages are

--- a/integration/network/bridge/iptablesdoc/templates/usernet-portmap-routed.md
+++ b/integration/network/bridge/iptablesdoc/templates/usernet-portmap-routed.md
@@ -8,7 +8,7 @@ Running the daemon with the userland proxy disabled then, as before, adding a ne
 	  --subnet 192.0.2.0/24 --gateway 192.0.2.1 bridge1
 	docker run --network bridge1 -p 8080:80 --name c1 busybox
 
-The filter table is the same as with the userland proxy enabled.
+The filter table is largely the same as with the userland proxy enabled.
 
 _Note that this means inter-network communication is disabled as-normal so,
 although published ports will be directly accessible from a remote host
@@ -23,6 +23,23 @@ on the same host._
     {{index . "SFilter4"}}
 
 </details>
+
+However, a rule is added by [setICMP][5] to the DOCKER chain (shown below) to
+allow ICMP. The equivalent IPv6 rule uses `-p icmpv6` rather than `-p icmp`,
+so *ALL* ICMP message types are allowed.
+
+_The ACCEPT rule as shown by `iptables -L` looks alarming until you spot that it's
+for `prot 1`._
+
+_[RFC 4890 section 4.3][6] makes recommendations for filtering ICMPv6. These
+have been considered, but the host firewall is not a network boundary in the
+sense used by the RFC. So, Node Information and Router Renumbering messages are
+not discarded, and experimental/unused types are allowed because they may be
+needed._
+
+    {{index . "LFilterDocker4"}}
+
+    {{index . "SFilterDocker4"}}
 
 The nat table is:
 
@@ -51,3 +68,5 @@ _And, the userland proxy won't be started for mapped ports._
 [2]: https://github.com/moby/moby/blob/333cfa640239153477bf635a8131734d0e9d099d/libnetwork/drivers/bridge/setup_ip_tables_linux.go#L294
 [3]: https://github.com/moby/moby/blob/675c2ac2db93e38bb9c5a6615d4155a969535fd9/libnetwork/drivers/bridge/port_mapping_linux.go#L477-L479
 [4]: https://github.com/moby/moby/blob/333cfa640239153477bf635a8131734d0e9d099d/libnetwork/drivers/bridge/setup_ip_tables_linux.go#L290
+[5]: https://github.com/robmry/moby/blob/d456d79cfc12cd7c801eebce0550b645c5343ca6/libnetwork/drivers/bridge/setup_ip_tables_linux.go#L390-L395
+[6]: https://www.rfc-editor.org/rfc/rfc4890#section-4.3

--- a/integration/network/bridge/iptablesdoc/templates/usernet-portmap.md
+++ b/integration/network/bridge/iptablesdoc/templates/usernet-portmap.md
@@ -30,8 +30,14 @@ Note that:
    to the container's address. This rule is added when the container is created
    (unlike all the other rules so-far, which were created during driver or
    network initialisation). [setPerPortForwarding][1]
+   - These per-port rules are inserted at the head of the chain, so that they
+     appear before the network's DROP rule [defaultDrop][2] which is always
+     appended to the end of the chain. In this case, because `docker0` was
+     created before `bridge1`, the `bridge1` rules appear above and below the
+     `docker0` DROP rule.
 
 [1]: https://github.com/moby/moby/blob/675c2ac2db93e38bb9c5a6615d4155a969535fd9/libnetwork/drivers/bridge/port_mapping_linux.go#L795
+[2]: https://github.com/robmry/moby/blob/52c89d467fc5326149e4bbb8903d23589b66ff0d/libnetwork/drivers/bridge/setup_ip_tables_linux.go#L252
 
 And the corresponding nat table:
 

--- a/internal/testutils/networking/iptables.go
+++ b/internal/testutils/networking/iptables.go
@@ -1,0 +1,45 @@
+package networking
+
+import (
+	"os/exec"
+	"regexp"
+	"testing"
+)
+
+// Find the policy in, for example "Chain FORWARD (policy ACCEPT)".
+var rePolicy = regexp.MustCompile("policy ([A-Z]+)")
+
+// SetFilterForwardPolicies sets the default policy for the FORWARD chain in
+// the filter tables for both IPv4 and IPv6. The original policy is restored
+// using t.Cleanup().
+//
+// There's only one filter-FORWARD policy, so this won't behave well if used by
+// tests running in parallel in a single network namespace that expect different
+// behaviour.
+func SetFilterForwardPolicies(t *testing.T, policy string) {
+	t.Helper()
+
+	for _, iptablesCmd := range []string{"iptables", "ip6tables"} {
+		cmd := exec.Command(iptablesCmd, "-L", "FORWARD")
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("Failed to get %s FORWARD policy: %v", iptablesCmd, err)
+		}
+		opMatch := rePolicy.FindSubmatch(out)
+		if len(opMatch) != 2 {
+			t.Fatalf("Failed to find %s FORWARD policy in: %s", iptablesCmd, out)
+		}
+		origPolicy := string(opMatch[1])
+		if origPolicy == policy {
+			continue
+		}
+		if err := exec.Command(iptablesCmd, "-P", "FORWARD", policy).Run(); err != nil {
+			t.Fatalf("Failed to set %s FORWARD policy: %v", iptablesCmd, err)
+		}
+		t.Cleanup(func() {
+			if err := exec.Command(iptablesCmd, "-P", "FORWARD", origPolicy).Run(); err != nil {
+				t.Logf("Failed to restore %s FORWARD policy: %v", iptablesCmd, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**- What I did**

There are rules in the iptables `DOCKER` chain accept packets routed to published container ports/protocols.

Until now, there has not been any `DROP` rule for un-published ports/protocols. So, if the filter-FORWARD chain's default policy was `ACCEPT`, there was no per-port/proctocol filtering for packets routed directly to the container's address. (A remote host with a route to the container's network, via the docker host, could access any port. And, for IPv4, docker only sets the filter-FORWARD policy to DROP if it enables IP forwarding itself.)

This PR removes the dependency on the filter-FORWARD policy.

(Docs impact - need to improve description of gateway modes, as per changelog comment, various other PRs will also feed in to this.)

**- How I did it**

Add rules to the `DOCKER` chain to explicitly drop packets routed to docker bridge networks, when the packet hasn't been `ACCEPT`ed by a rule for an open port/protocol.

Allow ICMP in gateway-mode `routed`, because it would previously have been allowed in nat mode with a default policy of `ACCEPT` (for IPv4), and it may be needed for IPv6 connectivity.

**- How to verify it**

New integration test.

**- Description for the changelog**
```markdown changelog
- Docker no longer depends on the iptables filter-FORWARD chain's default policy being `DROP`
  in order to restrict access to unpublished container ports from remote hosts.
  - Direct routed access to container ports that are not exposed using `-p`/`--publish` is now blocked
     in the `DOCKER` chain.
  - If the default filter-FORWARD policy was previously left at `ACCEPT` on your host, and direct routed
    access to a container's unpublished ports from a remote host is still required, options are:
    - Publish the ports you need.
    - Re-create the network with `--gateway_mode_ipv4=routed` and/or `--gateway_mode_ipv6=routed`.
      - No NAT rules will be set up to map host addresses/ports to containers, but published ports will
        be accessible from remote hosts if routing has been set up in the network.
    - **FIXME** - mention `nat-unprotected`, to be implemented in an upcoming PR.
  - Container ports that are published to host addresses will continue to be accessible via those host
    addresses, using NAT or the userland proxy.
  - Unpublished container ports continue to be directly accessible from the docker host via the
    container's IP address.
```