### PR TITLE
container: update confusing GoDoc for Container and State

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -63,11 +63,15 @@ type ExitStatus struct {
 // Container holds the structure defining a container object.
 type Container struct {
 	StreamConfig *stream.Config
-	// embed for Container to support states directly.
-	*State          `json:"State"` // Needed for Engine API version <= 1.11
-	Root            string         `json:"-"` // Path to the "home" of the container, including metadata.
-	BaseFS          string         `json:"-"` // Path to the graphdriver mountpoint
-	RWLayer         layer.RWLayer  `json:"-"`
+	// We embed [State] here so that Container supports states directly,
+	// but marshal it as a struct in JSON.
+	//
+	// State also provides a [sync.Mutex] which is used as lock for both
+	// the Container and State.
+	*State          `json:"State"`
+	Root            string        `json:"-"` // Path to the "home" of the container, including metadata.
+	BaseFS          string        `json:"-"` // Path to the graphdriver mountpoint
+	RWLayer         layer.RWLayer `json:"-"`
 	ID              string
 	Created         time.Time
 	Managed         bool

--- a/container/state.go
+++ b/container/state.go
@@ -13,9 +13,13 @@ import (
 )
 
 // State holds the current container state, and has methods to get and
-// set the state. Container has an embed, which allows all of the
-// functions defined against State to run against Container.
+// set the state. State is embedded in the [Container] struct.
+//
+// State contains an exported [sync.Mutex] which is used as a global lock
+// for both the State and the Container it's embedded in.
 type State struct {
+	// This Mutex is exported by design and is used as a global lock
+	// for both the State and the Container it's embedded in.
 	sync.Mutex
 	// Note that `Running` and `Paused` are not mutually exclusive:
 	// When pausing a container (on Linux), the freezer cgroup is used to suspend


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/issues/7802
- https://github.com/moby/moby/pull/7914
- https://github.com/moby/moby/pull/7775

### container: update confusing GoDoc for Container and State


This comment was added in f49c3f287b0d26dc705940effa0ec03e1de7bb99, following 517ba44e3742c39c4c3fc249b8c40e9b7ddd845f, which embedded the State, which caused the JSON presentation to change.

Referring to a very old (and now removed) API version made this confusing; while it was added to preserve the pre-v1.11 API format, it still applies to current API versions (i.e., we cannot change this unless an explicit API change).

This patch;

- removes the confusing comment
- touches up the comment describing the reason for embedding the State
- also mentions the State's sync.Mutex, which acts as a lock not only for the state itself, but for the container as a whole (which was the motivation for 517ba44e3742c39c4c3fc249b8c40e9b7ddd845f).
- Update GoDoc for the State struct to clarify the purpose of the Mutex.

**- A picture of a cute animal (not mandatory but encouraged)**

