### PR TITLE
container: ViewDB: some refactor and optimization

### DIFF
--- a/daemon/container/view_test.go
+++ b/daemon/container/view_test.go
@@ -444,3 +444,29 @@ func BenchmarkDBGetByPrefix500(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkDBDelete(b *testing.B) {
+	var testSet []string
+	var testKeys []string
+	for i := 0; i < 2500; i++ {
+		testSet = append(testSet, stringid.GenerateRandomID())
+	}
+	db, err := NewViewDB()
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, id := range testSet {
+		if err := db.Save(&Container{ID: id}); err != nil {
+			b.Fatal(err)
+		}
+		l := rand.Intn(12) + 12
+		testKeys = append(testKeys, id[:l])
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, id := range testKeys {
+			db.Delete(&Container{ID: id})
+		}
+	}
+}

--- a/daemon/container/view_test.go
+++ b/daemon/container/view_test.go
@@ -30,7 +30,7 @@ func TestViewSaveDelete(t *testing.T) {
 	tmpDir := t.TempDir()
 	c := newContainer(t, tmpDir)
 	assert.NilError(t, c.CheckpointTo(context.Background(), db))
-	db.Delete(c)
+	db.Delete(c.ID)
 }
 
 func TestViewAll(t *testing.T) {
@@ -130,7 +130,7 @@ func TestNames(t *testing.T) {
 	assert.Check(t, is.DeepEqual(map[string][]string{"containerid1": {"name1", "name3", "name4"}, "containerid4": {"name2"}}, view.GetAllNames()))
 
 	// Release containerid1's names with Delete even though no container exists
-	db.Delete(&Container{ID: "containerid1"})
+	db.Delete("containerid1")
 
 	// Reusing one of those names should work
 	assert.Check(t, db.ReserveName("name1", "containerid4"))
@@ -271,7 +271,7 @@ func TestTruncIndex(t *testing.T) {
 	}
 
 	// Deleting id2 should remove conflicts
-	db.Delete(&Container{ID: id2})
+	db.Delete(id2)
 
 	for _, tc := range []testacase{
 		{
@@ -466,7 +466,7 @@ func BenchmarkDBDelete(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, id := range testKeys {
-			db.Delete(&Container{ID: id})
+			db.Delete(id)
 		}
 	}
 }

--- a/daemon/container/view_test.go
+++ b/daemon/container/view_test.go
@@ -30,7 +30,7 @@ func TestViewSaveDelete(t *testing.T) {
 	tmpDir := t.TempDir()
 	c := newContainer(t, tmpDir)
 	assert.NilError(t, c.CheckpointTo(context.Background(), db))
-	assert.NilError(t, db.Delete(c))
+	db.Delete(c)
 }
 
 func TestViewAll(t *testing.T) {
@@ -130,7 +130,7 @@ func TestNames(t *testing.T) {
 	assert.Check(t, is.DeepEqual(map[string][]string{"containerid1": {"name1", "name3", "name4"}, "containerid4": {"name2"}}, view.GetAllNames()))
 
 	// Release containerid1's names with Delete even though no container exists
-	assert.Check(t, db.Delete(&Container{ID: "containerid1"}))
+	db.Delete(&Container{ID: "containerid1"})
 
 	// Reusing one of those names should work
 	assert.Check(t, db.ReserveName("name1", "containerid4"))
@@ -271,7 +271,7 @@ func TestTruncIndex(t *testing.T) {
 	}
 
 	// Deleting id2 should remove conflicts
-	assert.NilError(t, db.Delete(&Container{ID: id2}))
+	db.Delete(&Container{ID: id2})
 
 	for _, tc := range []testacase{
 		{

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -168,7 +168,7 @@ func (daemon *Daemon) cleanupContainer(ctr *container.Container, config backend.
 	linkNames := daemon.linkIndex.delete(ctr)
 	selinux.ReleaseLabel(ctr.ProcessLabel)
 	daemon.containers.Delete(ctr.ID)
-	daemon.containersReplica.Delete(ctr)
+	daemon.containersReplica.Delete(ctr.ID)
 	if err := daemon.removeMountPoints(ctr, config.RemoveVolume); err != nil {
 		log.G(context.TODO()).Error(err)
 	}


### PR DESCRIPTION
### container: ViewDB.Delete: remove error return

This function never returns an error, so let's remove the return.


### container: add BenchmarkDBDelete


    go test -bench=BenchmarkDBDelete -run=^#
    goos: linux
    goarch: arm64
    pkg: github.com/docker/docker/container
    BenchmarkDBdDelete-10    	     172	   7322767 ns/op	10626564 B/op	  105000 allocs/op
    PASS
    ok  	github.com/docker/docker/container	1.819s


### container: ViewDB.Delete: accept container ID, and optimization

This started because I was working on some changes in NewBaseContainer,
when I noticed that `ViewDb.Delete()` accepted a Container struct as argument,
but then constructed a _new_ Container struct, preserving only the original
container's ID and Root. I noticed that for other parts of the code, we define
a dedicated type, but for Containers, we kept the same to keep it symmetrical,
and because `Save()` expects a container.

Looking at the code, effectively all that's needed is the ID (which is used
as primary key), and for `FromObject` to resolve it from an object that's
passed (for `Save()` that would be a `Container` struct).

So as a fun exercise, I modified `FromObject` to accept either a `Container`
(for the `Save()` case) or a new `containerIDKey` type (a string), so that
we don't have to construct a new `Container` just for sake of being able to
extract its ID.

As we no longer need a `Container` struct for this, I also changed the signature
of `ViewDB.Delete` to accept a string,

I don't expect `Delete()` to be in a very "hot path", but here's benchmarks
before and after;

    go test -bench=BenchmarkDBDelete -run=^#
    BenchmarkDBdDelete-10    	     172	   7322767 ns/op	10626564 B/op	  105000 allocs/op

    go test -bench=BenchmarkDBDelete -run=^#
    BenchmarkDBDelete-10    	     261	   4596451 ns/op	 4546504 B/op	   80000 allocs/op

And diff using `benchstat`:


|             | sec/op    | before       | after         | diff                   |
|-------------|-----------|--------------|---------------|------------------------|
| DBDelete-10 | sec/op    | 6.305m ± 3%  | 4.587m ± 8%   | -27.25% (p=0.000 n=10) |
| DBDelete-10 | B/op      | 7.006Mi ± 0% | 4.336Mi ± 0%  | -38.11% (p=0.000 n=10) |
| DBDelete-10 | allocs/op | 100.00k ± 0% | 80.00k ± 0%   | -20.00% (p=0.000 n=10) |




**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

