### PR TITLE
container: remove deprecated ErrNameReserved, ErrNameNotReserved

### DIFF
--- a/container/view.go
+++ b/container/view.go
@@ -28,17 +28,6 @@ const (
 	memdbContainerIDIndex = "containerid"
 )
 
-var (
-	// ErrNameReserved is an error which is returned when a name is requested to be reserved that already is reserved
-	//
-	// Deprecated: check for [errdefs.Conflict] errors instead (using [errdefs.IsConflict].
-	ErrNameReserved = errors.New("name is reserved")
-	// ErrNameNotReserved is an error which is returned when trying to find a name that is not reserved
-	//
-	// Deprecated: check for [errdefs.NotFound] errors instead (using [errdefs.IsNotFound].
-	ErrNameNotReserved = errors.New("name is not reserved")
-)
-
 // Snapshot is a read only view for Containers. It holds all information necessary to serve container queries in a
 // versioned ACID in-memory store.
 type Snapshot struct {
@@ -199,7 +188,7 @@ func (db *ViewDB) ReserveName(name, containerID string) error {
 		}
 		if s != nil {
 			if s.(nameAssociation).containerID != containerID {
-				return errdefs.Conflict(ErrNameReserved) //nolint:staticcheck  // ignore SA1019: ErrNameReserved is deprecated.
+				return errdefs.Conflict(errors.New("name is reserved"))
 			}
 			return nil
 		}
@@ -278,7 +267,7 @@ func (v *View) GetID(name string) (string, error) {
 		return "", errdefs.System(err)
 	}
 	if s == nil {
-		return "", errdefs.NotFound(ErrNameNotReserved) //nolint:staticcheck  // ignore SA1019: ErrNameNotReserved is deprecated.
+		return "", errdefs.NotFound(errors.New("name is not reserved"))
 	}
 	return s.(nameAssociation).containerID, nil
 }

--- a/container/view_test.go
+++ b/container/view_test.go
@@ -118,7 +118,7 @@ func TestNames(t *testing.T) {
 
 	err = db.ReserveName("name2", "containerid3")
 	assert.Check(t, is.ErrorType(err, errdefs.IsConflict))
-	assert.Check(t, is.ErrorIs(err, ErrNameReserved)) //nolint:staticcheck  // ignore SA1019: ErrNameReserved is deprecated.
+	assert.Check(t, is.Error(err, "name is reserved"))
 
 	// Releasing a name allows the name to point to something else later.
 	assert.Check(t, db.ReleaseName("name2"))
@@ -136,7 +136,7 @@ func TestNames(t *testing.T) {
 
 	_, err = view.GetID("notreserved")
 	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
-	assert.Check(t, is.ErrorIs(err, ErrNameNotReserved)) //nolint:staticcheck  // ignore SA1019: ErrNameNotReserved is deprecated.
+	assert.Check(t, is.Error(err, "name is not reserved"))
 
 	// Releasing and re-reserving a name doesn't affect the snapshot.
 	assert.Check(t, db.ReleaseName("name2"))


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/48668

These errors were deprecated in 3cf90ca73f9ddff741bcc3aa50bdc387e4c13932 in favor of using errdefs types. They're no longer used, so we can remove them.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
container: remove deprecated `ErrNameReserved`, `ErrNameNotReserved`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

