### PR TITLE
ci/gha: enable go caching

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -122,6 +122,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: vendor.sum
       -
         name: Download reports
         uses: actions/download-artifact@v4
@@ -342,6 +343,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: vendor.sum
       -
         name: Download reports
         uses: actions/download-artifact@v4
@@ -373,6 +375,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: vendor.sum
       -
         name: Install gotestlist
         run:
@@ -502,6 +505,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: vendor.sum
       -
         name: Download reports
         uses: actions/download-artifact@v4

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -214,6 +214,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: vendor.sum
       -
         name: Download artifacts
         uses: actions/download-artifact@v4
@@ -243,6 +244,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: vendor.sum
       -
         name: Install gotestlist
         run:
@@ -441,6 +443,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: vendor.sum
       -
         name: Test integration
         if: matrix.test == './...'
@@ -547,6 +550,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: vendor.sum
       -
         name: Download reports
         uses: actions/download-artifact@v4

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -108,6 +108,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: vendor.sum
       -
         name: BuildKit ref
         run: |


### PR DESCRIPTION
**- What I did**

actions/setup-go complains:

> Restore cache failed: Dependencies file is not found in
> /home/runner/work/moby/moby. Supported file pattern: go.sum

Let's give it one to chew.

**- How I did it**

**- How to verify it**

Look in GHA warnings, the one quoted above should be gone.

Some CI jobs might suddenly become faster thanks to go caches.

**- Description for the changelog**
```markdown changelog
ci/gha: fix go caching
```

**- A picture of a cute animal (not mandatory but encouraged)**

