### PR TITLE
daemon: use OwnCgroupPath in withCgroups

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -829,15 +829,11 @@ func withCgroups(daemon *Daemon, daemonCfg *dconfig.Config, c *container.Contain
 
 		p := cgroupsPath
 		if useSystemd {
-			initPath, err := cgroups.GetInitCgroup("cpu")
+			path, err := cgroups.GetOwnCgroup("cpu")
 			if err != nil {
 				return errors.Wrap(err, "unable to init CPU RT controller")
 			}
-			_, err = cgroups.GetOwnCgroup("cpu")
-			if err != nil {
-				return errors.Wrap(err, "unable to init CPU RT controller")
-			}
-			p = filepath.Join(initPath, s.Linux.CgroupsPath)
+			p = filepath.Join(path, s.Linux.CgroupsPath)
 		}
 
 		// Clean path to guard against things like ../../../BAD


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/23430
- relates to https://github.com/opencontainers/runc/pull/3810

**- What I did**

cgroups.InitCgroupPath is removed from runc (see [1]), and it is suggested that users use OwnCgroupPath instead, because using init's is problematic when in host PID namespace (see [2]) and is generally not the right thing to do (see [3]).

Note: the code in question comes from commit 56f77d5ade (part of PR #23430).

[1]: https://github.com/opencontainers/runc/commit/fd5debf3
[2]: https://github.com/opencontainers/runc/commit/2b28b3c2
[3]: https://github.com/opencontainers/runc/commit/54e20217

_(This is included in PR #48160, and is needed to bump runc/libcontainer dependency to v1.2.0)_

**- How I did it**

**- How to verify it**

Fingers crossed there are some tests in this repository.

**- Description for the changelog**
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

