### PR TITLE
integration/system: remove TestEventsBackwardsCompatible, add TestEventsNonBlocking

### DIFF
--- a/integration/system/event_test.go
+++ b/integration/system/event_test.go
@@ -2,12 +2,9 @@ package system
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
-	"net/url"
-	"strconv"
 	"testing"
 	"time"
 
@@ -16,7 +13,6 @@ import (
 	"github.com/moby/moby/api/types/filters"
 	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/api/types/volume"
-	"github.com/moby/moby/client/pkg/jsonmessage"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/testutil/request"
 	"gotest.tools/v3/assert"
@@ -76,58 +72,6 @@ func TestEventsNonBlocking(t *testing.T) {
 	defer emptyBody.Close()
 	assert.Check(t, is.DeepEqual(http.StatusOK, emptyResp.StatusCode))
 	assert.Check(t, time.Now().Before(expectedTime), "timeout waiting for events api to respond, should have responded immediately")
-}
-
-// Test case for #18888: Events messages have been switched from generic
-// `JSONMessage` to `events.Message` types. The switch does not break the
-// backward compatibility so old `JSONMessage` could still be used.
-// This test verifies that backward compatibility maintains.
-func TestEventsBackwardsCompatible(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "Windows doesn't support back-compat messages")
-	ctx := setupTest(t)
-	apiClient := testEnv.APIClient()
-
-	since := request.DaemonTime(ctx, t, apiClient, testEnv)
-	ts := strconv.FormatInt(since.Unix(), 10)
-
-	cID := container.Create(ctx, t, apiClient)
-
-	// In case there is no events, the API should have responded immediately (not blocking),
-	// The test here makes sure the response time is less than 3 sec.
-	expectedTime := time.Now().Add(3 * time.Second)
-	emptyResp, emptyBody, err := request.Get(ctx, "/events")
-	assert.NilError(t, err)
-	defer emptyBody.Close()
-	assert.Check(t, is.DeepEqual(http.StatusOK, emptyResp.StatusCode))
-	assert.Check(t, time.Now().Before(expectedTime), "timeout waiting for events api to respond, should have responded immediately")
-
-	// We also test to make sure the `events.Message` is compatible with `JSONMessage`
-	q := url.Values{}
-	q.Set("since", ts)
-	_, body, err := request.Get(ctx, "/events?"+q.Encode())
-	assert.NilError(t, err)
-	defer body.Close()
-
-	dec := json.NewDecoder(body)
-	var containerCreateEvent *jsonmessage.JSONMessage
-	for {
-		var event jsonmessage.JSONMessage
-		if err := dec.Decode(&event); err != nil {
-			if err == io.EOF {
-				break
-			}
-			assert.NilError(t, err)
-		}
-		if event.Status == "create" && event.ID == cID {
-			containerCreateEvent = &event
-			break
-		}
-	}
-
-	assert.Assert(t, containerCreateEvent != nil)
-	assert.Check(t, is.Equal("create", containerCreateEvent.Status))
-	assert.Check(t, is.Equal(cID, containerCreateEvent.ID))
-	assert.Check(t, is.Equal("busybox", containerCreateEvent.From))
 }
 
 // TestEventsVolumeCreate verifies that volume create events are only fired

--- a/integration/system/event_test.go
+++ b/integration/system/event_test.go
@@ -63,6 +63,21 @@ func TestEventsExecDie(t *testing.T) {
 	}
 }
 
+// TestEventsNonBlocking verifies that the API responds immediately (not blocking),
+// if there are no events.
+func TestEventsNonBlocking(t *testing.T) {
+	ctx := setupTest(t)
+
+	// makes sure the API responds immediately (we use "less than 3 sec" to
+	// have some grace-period).
+	expectedTime := time.Now().Add(3 * time.Second)
+	emptyResp, emptyBody, err := request.Get(ctx, "/events")
+	assert.NilError(t, err)
+	defer emptyBody.Close()
+	assert.Check(t, is.DeepEqual(http.StatusOK, emptyResp.StatusCode))
+	assert.Check(t, time.Now().Before(expectedTime), "timeout waiting for events api to respond, should have responded immediately")
+}
+
 // Test case for #18888: Events messages have been switched from generic
 // `JSONMessage` to `events.Message` types. The switch does not break the
 // backward compatibility so old `JSONMessage` could still be used.


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/18888
- relates to https://github.com/moby/moby/issues/50575

----

### integration/system: add TestEventsNonBlocking

This adds the "non-blocking" part of the TestEventsBackwardsCompatible
as a separate test, as it's not related to the backward-compatibility
part of that test.

### integration/system: remove TestEventsBackwardsCompatible

This test was added in 72f1881df102fce9ad31e98045b91c204dd44513, which
introduced a dedicated `events.Message` struct for the events endpoints.
Before that change, events would produce a generic `JSONMessage`, and
the test is to verify that an `events.Message` could be successfully
unmarshalled to a `JSONMessage`.

The change above was part of docker 1.10 (API version 1.22), which we
no longer support, so we can remove this test.


**- A picture of a cute animal (not mandatory but encouraged)**

