### PR TITLE
c8d/push: don't automatically pick platform if multiple candidates

### DIFF
--- a/daemon/containerd/image_push_test.go
+++ b/daemon/containerd/image_push_test.go
@@ -68,7 +68,7 @@ func TestImagePushIndex(t *testing.T) {
 
 			indexPlatforms:     []ocispec.Platform{linuxAmd64, darwinArm64, windowsAmd64},
 			availablePlatforms: []ocispec.Platform{linuxAmd64, darwinArm64},
-			check:              singleManifestSelected(linuxAmd64),
+			check:              multipleCandidates,
 		},
 		{
 			name: "none requested, two present, daemon platform NOT available",
@@ -155,7 +155,7 @@ func TestImagePushIndex(t *testing.T) {
 			availablePlatforms: []ocispec.Platform{linuxArmv7, linuxArmv5},
 			daemonPlatform:     &linuxArmv5,
 			requestPlatform:    nil,
-			check:              singleManifestSelected(linuxArmv5),
+			check:              multipleCandidates,
 		},
 		{
 			name: "none requested on v7 daemon, arm64 not available",
@@ -164,7 +164,7 @@ func TestImagePushIndex(t *testing.T) {
 			availablePlatforms: []ocispec.Platform{linuxArmv7, linuxArmv5},
 			daemonPlatform:     &linuxArmv7,
 			requestPlatform:    nil,
-			check:              singleManifestSelected(linuxArmv7),
+			check:              multipleCandidates,
 		},
 		{
 			name: "none requested on v7 daemon, v7 not available",
@@ -173,7 +173,7 @@ func TestImagePushIndex(t *testing.T) {
 			availablePlatforms: []ocispec.Platform{linuxArm64, linuxArmv5},
 			daemonPlatform:     &linuxArmv7,
 			requestPlatform:    nil,
-			check:              singleManifestSelected(linuxArmv5), // Should it fail, because v5 can't be pushed?
+			check:              multipleCandidates,
 		},
 
 		{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Related: https://github.com/moby/moby/issues/48731

**- What I did**

Previously, when pushing an image that contains more than a single platform, if no platform was specified and there are more than one but not all platforms available, we either
- "automatically" pick the host/engine's platform, if available, or
- error out if there are multiple candidates but none are the host/engine's platform.

This commit drops the special handling for the case where the engine's platform image is available, instead always returning an error in the case that not all platforms are available and there are multiple candidates for pushing.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

