### PR TITLE
Remove feature flag "windows-dns-proxy"

### DIFF
--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -208,10 +208,6 @@ func (conf *Config) ValidatePlatformConfig() error {
 		return errors.Wrap(err, "invalid fixed-cidr-v6")
 	}
 
-	if _, ok := conf.Features["windows-dns-proxy"]; ok {
-		return errors.New("feature option 'windows-dns-proxy' is only available on Windows")
-	}
-
 	return verifyDefaultCgroupNsMode(conf.CgroupNamespaceMode)
 }
 

--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -164,12 +164,6 @@ func serviceDiscoveryOnDefaultNetwork() bool {
 }
 
 func buildSandboxPlatformOptions(ctr *container.Container, cfg *config.Config, sboxOptions *[]libnetwork.SandboxOption) error {
-	// By default, the Windows internal resolver forwards requests to external
-	// resolvers - but forwarding can be disabled using feature flag
-	// "windows-dns-proxy":false.
-	if doproxy, exists := cfg.Features["windows-dns-proxy"]; exists && !doproxy {
-		*sboxOptions = append(*sboxOptions, libnetwork.OptionDNSNoProxy())
-	}
 	return nil
 }
 

--- a/daemon/info_windows.go
+++ b/daemon/info_windows.go
@@ -11,6 +11,10 @@ import (
 
 // fillPlatformInfo fills the platform related info.
 func (daemon *Daemon) fillPlatformInfo(ctx context.Context, v *system.Info, sysInfo *sysinfo.SysInfo, cfg *configStore) error {
+	if _, ok := cfg.Features["windows-dns-proxy"]; ok {
+		v.Warnings = append(v.Warnings, `
+WARNING: Feature flag "windows-dns-proxy" has been removed, forwarding to external DNS resolvers is enabled.`)
+	}
 	return nil
 }
 

--- a/libnetwork/network_windows.go
+++ b/libnetwork/network_windows.go
@@ -103,9 +103,6 @@ func addEpToResolver(
 	epIface *EndpointInterface,
 	resolvers []*Resolver,
 ) error {
-	if config.dnsNoProxy {
-		return nil
-	}
 	hnsEndpoints, err := hcsshim.HNSListEndpointRequest()
 	if err != nil {
 		return nil

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -92,7 +92,6 @@ type resolvConfPathConfig struct {
 }
 
 type containerConfig struct {
-	containerConfigOS //nolint:nolintlint,unused // only populated on windows
 	hostsPathConfig
 	resolvConfPathConfig
 	generic           map[string]interface{}

--- a/libnetwork/sandbox_options_windows.go
+++ b/libnetwork/sandbox_options_windows.go
@@ -1,7 +1,0 @@
-package libnetwork
-
-func OptionDNSNoProxy() SandboxOption {
-	return func(sb *Sandbox) {
-		sb.config.dnsNoProxy = true
-	}
-}

--- a/libnetwork/sandbox_windows.go
+++ b/libnetwork/sandbox_windows.go
@@ -6,11 +6,6 @@ import (
 	"github.com/docker/docker/libnetwork/osl"
 )
 
-// Windows-specific container configuration flags.
-type containerConfigOS struct {
-	dnsNoProxy bool
-}
-
 func releaseOSSboxResources(*osl.Namespace, *Endpoint) {}
 
 func (sb *Sandbox) updateGateway(*Endpoint) error {


### PR DESCRIPTION
**- What I did**

- fix https://github.com/moby/moby/issues/47732

Added in 26.1.0, commit 6c68be24a2e6a4dea621b82ab4245e4ed363158e
Default changed to true in 27.0.0, commit 33f9a5329a9259bc361f925a09633674878650be

**- How I did it**

No sign of problems so, removed.

**- How to verify it**

It doesn't do anything now.

**- Description for the changelog**
```markdown changelog
- Removed feature flag `windows-dns-proxy`, which was introduced in release 26.1.0 to enable forwarding
  to external DNS resolvers from Windows containers, to make `nslookup` work. It was enabled by default
  in release 27.0.0.
```