### PR TITLE
[27.x backport] daemon: use OwnCgroupPath in withCgroups

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -832,15 +832,11 @@ func withCgroups(daemon *Daemon, daemonCfg *dconfig.Config, c *container.Contain
 
 		p := cgroupsPath
 		if useSystemd {
-			initPath, err := cgroups.GetInitCgroup("cpu")
+			path, err := cgroups.GetOwnCgroup("cpu")
 			if err != nil {
 				return errors.Wrap(err, "unable to init CPU RT controller")
 			}
-			_, err = cgroups.GetOwnCgroup("cpu")
-			if err != nil {
-				return errors.Wrap(err, "unable to init CPU RT controller")
-			}
-			p = filepath.Join(initPath, s.Linux.CgroupsPath)
+			p = filepath.Join(path, s.Linux.CgroupsPath)
 		}
 
 		// Clean path to guard against things like ../../../BAD


### PR DESCRIPTION
**- What I did**

* Backports https://github.com/moby/moby/pull/48730

Note: this usage comes from commit 56f77d5ade (part of PR 23430).

cgroups.InitCgroupPath is removed from runc (see [1]), and it is suggested that users use OwnCgroupPath instead, because using init's is problematic when in host PID namespace (see [2]) and is generally not the right thing to do (see [3]).

[1]: https://github.com/opencontainers/runc/commit/fd5debf3
[2]: https://github.com/opencontainers/runc/commit/2b28b3c2
[3]: https://github.com/opencontainers/runc/commit/54e20217

(cherry picked from commit 6be2074aefa60c3301dd728e7f9f6335a372c55a)

**- How I did it**

```
git cherry-pick -xsS 6be2074aefa60c3301dd728e7f9f6335a372c55a
```

**- How to verify it**

**- Description for the changelog**
```markdown changelog
Remove cgroups.InitCgroupPath usage
```

**- A picture of a cute animal (not mandatory but encouraged)**

