### PR TITLE
api/types/filters: GetBoolOrDefault: remove unreachableCode

### DIFF
--- a/api/types/filters/errors.go
+++ b/api/types/filters/errors.go
@@ -22,16 +22,3 @@ func (e invalidFilter) Error() string {
 
 // InvalidParameter marks this error as ErrInvalidParameter
 func (e invalidFilter) InvalidParameter() {}
-
-// unreachableCode is an error indicating that the code path was not expected to be reached.
-type unreachableCode struct {
-	Filter string
-	Value  []string
-}
-
-// System marks this error as ErrSystem
-func (e unreachableCode) System() {}
-
-func (e unreachableCode) Error() string {
-	return fmt.Sprintf("unreachable code reached for filter: %q with values: %s", e.Filter, e.Value)
-}

--- a/api/types/filters/parse.go
+++ b/api/types/filters/parse.go
@@ -200,7 +200,6 @@ func (args Args) Match(field, source string) bool {
 // Error is not nil only if the filter values are not valid boolean or are conflicting.
 func (args Args) GetBoolOrDefault(key string, defaultValue bool) (bool, error) {
 	fieldValues, ok := args.fields[key]
-
 	if !ok {
 		return defaultValue, nil
 	}
@@ -211,20 +210,11 @@ func (args Args) GetBoolOrDefault(key string, defaultValue bool) (bool, error) {
 
 	isFalse := fieldValues["0"] || fieldValues["false"]
 	isTrue := fieldValues["1"] || fieldValues["true"]
-
-	conflicting := isFalse && isTrue
-	invalid := !isFalse && !isTrue
-
-	if conflicting || invalid {
+	if isFalse == isTrue {
+		// Either no or conflicting truthy/falsy value were provided
 		return defaultValue, &invalidFilter{key, args.Get(key)}
-	} else if isFalse {
-		return false, nil
-	} else if isTrue {
-		return true, nil
 	}
-
-	// This code shouldn't be reached.
-	return defaultValue, &unreachableCode{Filter: key, Value: args.Get(key)}
+	return isTrue, nil
 }
 
 // ExactMatch returns true if the source matches exactly one of the values.


### PR DESCRIPTION
We already check if

- the key is set (otherwise default)
- a value is set (otherwise default and error)

This check can be simplified to check if they're equal (boolean cannot be both true and false), or both false (boolean must be either true or false), although the latter could be considered for a tri-state boolean (but we already do this through the "not set" case).

We may need some additional checks, for example, currently it ignores invalid values if the filter contains at least one valid one (e.g. ["true", "bananas"]).

**- A picture of a cute animal (not mandatory but encouraged)**

