### PR TITLE
From 28.0.0, don't migrate per-endpoint sysctls

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -769,14 +769,12 @@ func handleSysctlBC(
 			netIfSysctl := fmt.Sprintf("net.%s.%s.IFNAME.%s=%s", spl[1], spl[2], spl[4], v)
 			// Find the EndpointConfig to migrate settings to, if not already found.
 			if ep == nil {
-				/* TODO(robmry) - apply this to the API version used in 28.0.0
 				// Per-endpoint sysctls were introduced in API version 1.46. Migration is
-				// needed, but refuse to do it automatically for newer versions of the API.
-				if versions.GreaterThan(version, "1.??") {
+				// needed, but refuse to do it automatically for API 1.48 and newer.
+				if versions.GreaterThan(version, "1.47") {
 					return "", fmt.Errorf("interface specific sysctl setting %q must be supplied using driver option '%s'",
 						k, netlabel.EndpointSysctls)
 				}
-				*/
 				var err error
 				ep, err = epConfigForNetMode(version, hostConfig.NetworkMode, netConfig)
 				if err != nil {

--- a/api/server/router/container/container_routes_test.go
+++ b/api/server/router/container/container_routes_test.go
@@ -273,17 +273,15 @@ func TestHandleSysctlBC(t *testing.T) {
 				"net.ipv6.conf.all.disable_ipv6": "0",
 			},
 		},
-		/* TODO(robmry) - enable this test for the API version used in 28.0.0
 		{
 			name:        "migration disabled for newer api",
-			apiVersion:  "1.??",
+			apiVersion:  "1.48",
 			networkMode: "mynet",
 			sysctls: map[string]string{
 				"net.ipv6.conf.eth0.accept_ra": "2",
 			},
 			expError: "must be supplied using driver option 'com.docker.network.endpoint.sysctls'",
 		},
-		*/
 		{
 			name:        "only migrate eth0",
 			apiVersion:  "1.46",

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -27,6 +27,8 @@ keywords: "API, Docker, rcli, REST, documentation"
 * Deprecated: The `ContainerdCommit.Expected`, `RuncCommit.Expected`, and
   `InitCommit.Expected` fields in the `GET /info` endpoint are deprecated
   and will be omitted in API v1.49.
+* `Sysctls` in `HostConfig` (top level `--sysctl` settings) for `eth0` are
+  no longer migrated to `DriverOpts`, as described in the changes for v1.46.
 
 ## v1.47 API changes
 


### PR DESCRIPTION
**- What I did**

 - related to https://github.com/moby/moby/pull/47686
 - related to https://github.com/moby/moby/pull/48281
 - closes https://github.com/moby/moby/issues/48282

Now we know the API version for release 28.0.0, disable migration of per-endpoint sysctls from that version.

**- How I did it**

Re-added checks that were removed until 28.0.0's API version was known, in commit 17adc1478b8cbe2851a64f986d1dd6a473a0de11

**- How to verify it**

Unit test.

**- Description for the changelog**
```markdown changelog
- In API version 1.48 and later, settings for `eth0` in `--sysctl` options will no longer be automatically migrated to the network endpoint. For example, on the command line in a docker run command, `--network mynet --sysctl net.ipv4.conf.eth0.log_martians=1` will be rejected. Instead, you must use `--network name=mynet,driver-opt=com.docker.network.endpoint.sysctls=net.ipv4.conf.IFNAME.log_martians=1`
```
