### PR TITLE
[27.x backport] volume/mounts: fix anonymous volume not being labeled

### DIFF
--- a/volume/mounts/linux_parser.go
+++ b/volume/mounts/linux_parser.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types/mount"
-	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/volume"
 )
 
@@ -329,9 +328,8 @@ func (p *linuxParser) parseMountSpec(cfg mount.Mount, validateBindSourceExists b
 
 	switch cfg.Type {
 	case mount.TypeVolume:
-		if cfg.Source == "" {
-			mp.Name = stringid.GenerateRandomID()
-		} else {
+		if cfg.Source != "" {
+			// non-anonymous volume
 			mp.Name = cfg.Source
 		}
 		mp.CopyData = p.DefaultCopyMode()

--- a/volume/mounts/windows_parser.go
+++ b/volume/mounts/windows_parser.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types/mount"
-	"github.com/docker/docker/pkg/stringid"
 )
 
 // NewWindowsParser creates a parser with Windows semantics.
@@ -393,9 +392,8 @@ func (p *windowsParser) parseMountSpec(cfg mount.Mount, convertTargetToBackslash
 
 	switch cfg.Type {
 	case mount.TypeVolume:
-		if cfg.Source == "" {
-			mp.Name = stringid.GenerateRandomID()
-		} else {
+		if cfg.Source != "" {
+			// non-anonymous volume
 			mp.Name = cfg.Source
 		}
 		mp.CopyData = p.DefaultCopyMode()

--- a/volume/service/service.go
+++ b/volume/service/service.go
@@ -73,6 +73,9 @@ func (s *VolumesService) Create(ctx context.Context, name, driverName string, op
 	if name == "" {
 		name = stringid.GenerateRandomID()
 		options = append(options, opts.WithCreateLabel(AnonymousLabel, ""))
+		log.G(ctx).WithField("volume-name", name).Error("Creating anonymous volume")
+	} else {
+		log.G(ctx).WithField("volume-name", name).Error("Creating named volume")
 	}
 	v, err := s.vs.Create(ctx, name, driverName, options...)
 	if err != nil {

--- a/volume/service/store.go
+++ b/volume/service/store.go
@@ -732,7 +732,7 @@ func (s *VolumeStore) getVolume(ctx context.Context, name, driverName string) (v
 		return volumeWrapper{vol, meta.Labels, scope, meta.Options}, nil
 	}
 
-	log.G(ctx).Debugf("Probing all drivers for volume with name: %s", name)
+	log.G(ctx).WithField("volume-name", name).Debugf("Probing all drivers for volume")
 	drivers, err := s.drivers.GetAllDrivers()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/48754
- fixes https://github.com/moby/moby/issues/48748
- relates to https://github.com/moby/moby/commit/b3b7eb2723461b1eb4be692f4bced0ae8ea9cb58 / https://github.com/moby/moby/pull/14242
- relates to https://github.com/moby/moby/commit/fc7b904dced4d18d49c8a6c47ae3f415d16d0c43 / https://github.com/moby/moby/pull/22373
- relates to https://github.com/moby/moby/pull/44216

### volume/mounts: fix anonymous volume not being labeled

`Parser.ParseMountRaw()` labels anonymous volumes with a `AnonymousLabel` label (`com.docker.volume.anonymous`) label based on whether a volume has a name (named volume) or no name (anonymous) (see [1]).

However both `VolumesService.Create()` (see [1]) and `Parser.ParseMountRaw()` (see [2], [3]) were generating a random name for anonymous volumes. The latter is called before `VolumesService.Create()` is called, resulting in such volumes not being labeled as anonymous.

Generating the name was originally done in Create (fc7b904dced4d18d49c8a6c47ae3f415d16d0c43), but duplicated in b3b7eb2723461b1eb4be692f4bced0ae8ea9cb58 with the introduction of the new Mounts field in HostConfig. Duplicating this effort didn't have a real effect until (`Create` would just skip generating the name), until 618f26ccbc3b5c314680dae4b09f5d13f9c02570 introduced the `AnonymousLabel` in (v24.0.0, backported to v23.0.0).

Parsing generally should not fill in defaults / generate names, so this patch;

- Removes generating volume names from  `Parser.ParseMountRaw()`
- Adds a debug-log entry to `VolumesService.Create()`
- Touches up some logs to use structured logs for easier correlating logs

With this patch applied:

    docker run --rm --mount=type=volume,target=/toto hello-world

    DEBU[2024-10-24T22:50:36.359990376Z] creating anonymous volume                     volume-name=0cfd63d4df363571e7b3e9c04e37c74054cc16ff1d00d9a005232d83e92eda02
    DEBU[2024-10-24T22:50:36.360069209Z] probing all drivers for volume                volume-name=0cfd63d4df363571e7b3e9c04e37c74054cc16ff1d00d9a005232d83e92eda02
    DEBU[2024-10-24T22:50:36.360341209Z] Registering new volume reference              driver=local volume-name=0cfd63d4df363571e7b3e9c04e37c74054cc16ff1d00d9a005232d83e92eda02

[1]: https://github.com/moby/moby/blob/032721ff75fe4a71a45b4a7a9b7e7c4c80c6431b/volume/service/service.go#L72-L83
[2]: https://github.com/moby/moby/blob/032721ff75fe4a71a45b4a7a9b7e7c4c80c6431b/volume/mounts/linux_parser.go#L330-L336
[3]: https://github.com/moby/moby/blob/032721ff75fe4a71a45b4a7a9b7e7c4c80c6431b/volume/mounts/windows_parser.go#L394-L400

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->


**- How to verify it**

```bash
make TEST_FILTER='TestContainerVolumeAnonymous' TEST_SKIP_INTEGRATION_CLI=1 DOCKER_GRAPHDRIVER=vfs test-integration

=== RUN   TestContainerVolumeAnonymous
--- PASS: TestContainerVolumeAnonymous (0.02s)
PASS

DONE 1 tests in 1.225s
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix anonymous volumes being created through the `--mount` option not being marked as anonymous.
```

**- A picture of a cute animal (not mandatory but encouraged)**

