### PR TITLE
[27.x] c8d/httpfallback: Handle connection errors

### DIFF
--- a/daemon/containerd/resolver.go
+++ b/daemon/containerd/resolver.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"net"
 	"net/http"
+	"os"
+	"strings"
+	"syscall"
 
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
@@ -118,9 +122,7 @@ type httpFallback struct {
 
 func (f httpFallback) RoundTrip(r *http.Request) (*http.Response, error) {
 	resp, err := f.super.RoundTrip(r)
-	var tlsErr tls.RecordHeaderError
-	if errors.As(err, &tlsErr) && string(tlsErr.RecordHeader[:]) == "HTTP/" {
-		// server gave HTTP response to HTTPS client
+	if err != nil && (isTLSError(err) || isPortError(err, r.URL.Host)) {
 		plainHttpUrl := *r.URL
 		plainHttpUrl.Scheme = "http"
 
@@ -131,4 +133,29 @@ func (f httpFallback) RoundTrip(r *http.Request) (*http.Response, error) {
 	}
 
 	return resp, err
+}
+
+func isTLSError(err error) bool {
+	var tlsErr tls.RecordHeaderError
+	if errors.As(err, &tlsErr) && string(tlsErr.RecordHeader[:]) == "HTTP/" {
+		// server gave HTTP response to HTTPS client
+		return true
+	}
+	if strings.Contains(err.Error(), "TLS handshake timeout") {
+		return true
+	}
+
+	return false
+}
+
+func isPortError(err error, host string) bool {
+	if errors.Is(err, syscall.ECONNREFUSED) || os.IsTimeout(err) {
+		if _, port, _ := net.SplitHostPort(host); port != "" {
+			// Port is specified, will not retry on different port with scheme change
+			return false
+		}
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
Note: This only targets the 27.x branch, as https://github.com/moby/moby/pull/47380 (for master branch) will remove our httpFallback and use the one from containerd.

This is a minimal patch that aligns the httpFallback implementation to support the same fallback conditions as the containerd one.

**- What I did**
Adjust the httpFallback implementation to also handle non-TLS related errors which can also happen when issuing a HTTPS requested to HTTP-only registries.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
containerd image store: Fix not being able to connect to some insecure registries in cases where the HTTPS request failed due to a non-TLS related error.
```

**- A picture of a cute animal (not mandatory but encouraged)**

