### PR TITLE
[27.x backport] client: prevent idle connections leaking FDs

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -247,6 +247,14 @@ func (cli *Client) tlsConfig() *tls.Config {
 
 func defaultHTTPClient(hostURL *url.URL) (*http.Client, error) {
 	transport := &http.Transport{}
+	// Necessary to prevent long-lived processes using the
+	// client from leaking connections due to idle connections
+	// not being released.
+	// TODO: see if we can also address this from the server side,
+	// or in go-connections.
+	// see: https://github.com/moby/moby/issues/45539
+	transport.MaxIdleConns = 6
+	transport.IdleConnTimeout = 30 * time.Second
 	err := sockets.ConfigureTransport(transport, hostURL.Scheme, hostURL.Host)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- backports https://github.com/moby/moby/pull/48736

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Patch from https://github.com/tonistiigi/docker/commit/af6ada910f04efd695b1670573e137cef269aa85

- fixes https://github.com/moby/moby/issues/45539

**- What I did**

Without this change, if a long-lived process is using the client, idle connections are not released and grow over time.

We can also look into addressing this issue from the server side, but it doesn't hurt for the `client` package to have good defaults and not cause this.

**- How I did it**

Set `MaxIdleConns` and `IdleConnTimeout` on the `defaultHTTPClient`.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

