### PR TITLE
runc-1.2.0 merge followups

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,8 +47,6 @@ linters-settings:
             desc: The logs package has moved to a separate module, https://github.com/containerd/log
           - pkg: "github.com/containerd/containerd/pkg/userns"
             desc: Use github.com/moby/sys/userns instead.
-          - pkg: "github.com/opencontainers/runc/libcontainer/userns"
-            desc: Use github.com/moby/sys/userns instead.
           - pkg: "github.com/tonistiigi/fsutil"
             desc: The fsutil module does not have a stable API, so we should not have a direct dependency unless necessary.
 

--- a/integration/container/nat_test.go
+++ b/integration/container/nat_test.go
@@ -40,6 +40,7 @@ func TestNetworkNat(t *testing.T) {
 
 func TestNetworkLocalhostTCPNat(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon)
+	skip.If(t, testEnv.GitHubActions, "FIXME: https://github.com/moby/moby/issues/41561")
 
 	ctx := setupTest(t)
 


### PR DESCRIPTION
A few cherry-picks from my and @rata work on using runc v1.2.0 here which did not make it.

There are [some more commits from @rata here](https://github.com/rata/moby/tree/runc-1.2-test-fixes) fixing some of the test flakiness we observed when trying to bump runc. Apparently they are no longer needed, but maybe some of them still make sense.