### PR TITLE
volume: VolumesService.Create: fix log-level for debug logs

### DIFF
--- a/volume/service/service.go
+++ b/volume/service/service.go
@@ -73,9 +73,9 @@ func (s *VolumesService) Create(ctx context.Context, name, driverName string, op
 	if name == "" {
 		name = stringid.GenerateRandomID()
 		options = append(options, opts.WithCreateLabel(AnonymousLabel, ""))
-		log.G(ctx).WithField("volume-name", name).Error("Creating anonymous volume")
+		log.G(ctx).WithField("volume-name", name).Debug("Creating anonymous volume")
 	} else {
-		log.G(ctx).WithField("volume-name", name).Error("Creating named volume")
+		log.G(ctx).WithField("volume-name", name).Debug("Creating named volume")
 	}
 	v, err := s.vs.Create(ctx, name, driverName, options...)
 	if err != nil {


### PR DESCRIPTION
- introduced in https://github.com/moby/moby/pull/48754

These log-entries were added in 10d57fde4497fb1e141f2020697528acece38425, but it looks like I accidentally left them as Error-logs following some debugging (whoops!).

**- A picture of a cute animal (not mandatory but encouraged)**


![whoops](https://github.com/user-attachments/assets/d170d6d5-c852-4b84-b847-f18245530c74)

