### PR TITLE
demon: ImageService.Mount: use structured logs

### DIFF
--- a/daemon/containerd/mount.go
+++ b/daemon/containerd/mount.go
@@ -23,7 +23,7 @@ func (i *ImageService) Mount(ctx context.Context, container *container.Container
 		return fmt.Errorf("failed to mount %s: %w", root, err)
 	}
 
-	log.G(ctx).WithField("container", container.ID).Debugf("container mounted via snapshotter: %v", root)
+	log.G(ctx).WithFields(log.Fields{"container": container.ID, "root": root, "snapshotter": container.Driver}).Debug("container mounted via snapshotter")
 
 	container.BaseFS = root
 	return nil

--- a/daemon/images/mount.go
+++ b/daemon/images/mount.go
@@ -20,7 +20,7 @@ func (i *ImageService) Mount(ctx context.Context, container *container.Container
 	if err != nil {
 		return err
 	}
-	log.G(ctx).WithField("container", container.ID).Debugf("container mounted via layerStore: %v", dir)
+	log.G(ctx).WithFields(log.Fields{"container": container.ID, "root": dir, "storage-driver": container.Driver}).Debug("container mounted via layerStore")
 
 	if container.BaseFS != "" && container.BaseFS != dir {
 		// The mount path reported by the graph driver should always be trusted on Windows, since the


### PR DESCRIPTION
Before this patch:

    DEBU[2024-10-26T15:51:12.666160042Z] stat snapshot                                 key="sha256:12660636fe55438cc3ae7424da7ac56e845cdb52493ff9cf949c47a7f57f8b43"
    DEBU[2024-10-26T15:51:12.669595334Z] prepare snapshot                              key=7e947822249514b6239657a0c54d091d90e0fed4b09da472f3f6258f2b4920bc-init-key parent="sha256:12660636fe55438cc3ae7424da7ac56e845cdb52493ff9cf949c47a7f57f8b43"
    DEBU[2024-10-26T15:51:12.678485001Z] commit snapshot                               key=7e947822249514b6239657a0c54d091d90e0fed4b09da472f3f6258f2b4920bc-init-key name=7e947822249514b6239657a0c54d091d90e0fed4b09da472f3f6258f2b4920bc-init
    DEBU[2024-10-26T15:51:12.679995167Z] prepare snapshot                              key=7e947822249514b6239657a0c54d091d90e0fed4b09da472f3f6258f2b4920bc parent=7e947822249514b6239657a0c54d091d90e0fed4b09da472f3f6258f2b4920bc-init
    DEBU[2024-10-26T15:51:12.681101209Z] get snapshot mounts                           key=7e947822249514b6239657a0c54d091d90e0fed4b09da472f3f6258f2b4920bc
    DEBU[2024-10-26T15:51:12.681547126Z] container mounted via snapshotter: /var/lib/docker/rootfs/overlayfs/7e947822249514b6239657a0c54d091d90e0fed4b09da472f3f6258f2b4920bc  container=7e947822249514b6239657a0c54d091d90e0fed4b09da472f3f6258f2b4920bc
    ...

With this patch:

    DEBU[2024-10-26T16:43:40.724448597Z] stat snapshot                                 key="sha256:12660636fe55438cc3ae7424da7ac56e845cdb52493ff9cf949c47a7f57f8b43"
    DEBU[2024-10-26T16:43:40.728187889Z] prepare snapshot                              key=3d6442ad828a043c5bd3a466aae17946da9df9c89d5aeeb7b5af160491e8a6fa-init-key parent="sha256:12660636fe55438cc3ae7424da7ac56e845cdb52493ff9cf949c47a7f57f8b43"
    DEBU[2024-10-26T16:43:40.734372930Z] commit snapshot                               key=3d6442ad828a043c5bd3a466aae17946da9df9c89d5aeeb7b5af160491e8a6fa-init-key name=3d6442ad828a043c5bd3a466aae17946da9df9c89d5aeeb7b5af160491e8a6fa-init
    DEBU[2024-10-26T16:43:40.735592180Z] prepare snapshot                              key=3d6442ad828a043c5bd3a466aae17946da9df9c89d5aeeb7b5af160491e8a6fa parent=3d6442ad828a043c5bd3a466aae17946da9df9c89d5aeeb7b5af160491e8a6fa-init
    DEBU[2024-10-26T16:43:40.736778055Z] get snapshot mounts                           key=3d6442ad828a043c5bd3a466aae17946da9df9c89d5aeeb7b5af160491e8a6fa
    DEBU[2024-10-26T16:43:40.737387847Z] container mounted via snapshotter             container=3d6442ad828a043c5bd3a466aae17946da9df9c89d5aeeb7b5af160491e8a6fa root=/var/lib/docker/rootfs/overlayfs/3d6442ad828a043c5bd3a466aae17946da9df9c89d5aeeb7b5af160491e8a6fa snapshotter=overlayfs
    ...

And for graphdrivers:

    DEBU[2024-10-26T16:51:21.612155255Z] container mounted via layerStore              container=a339b74e0d90fc31dea2b79ba7478a0acf4172e6d7bc11ee4a0053531fa5455f storage-driver=overlay2 root=/var/lib/docker/overlay2/35132769364e5d139d8e52f5b6e3d6a8826649c9ad99b843199b3525645f52d2/merged
    DEBU[2024-10-26T16:51:21.620449046Z] attach: stdout: begin
    DEBU[2024-10-26T16:51:21.620482380Z] attach: stderr: begin
    DEBU[2024-10-26T16:51:21.622254796Z] container mounted via layerStore              container=a339b74e0d90fc31dea2b79ba7478a0acf4172e6d7bc11ee4a0053531fa5455f storage-driver=overlay2 root=/var/lib/docker/overlay2/35132769364e5d139d8e52f5b6e3d6a8826649c9ad99b843199b3525645f52d2/merged
    ...

**- A picture of a cute animal (not mandatory but encouraged)**

