### PR TITLE
fix: create container with a non-existing volume driver triggers docker pull

### DIFF
--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -64,6 +64,15 @@ func (daemon *Daemon) createContainerOSSpecificSettings(ctx context.Context, con
 
 		v, err := daemon.volumes.Create(context.TODO(), "", hostConfig.VolumeDriver, volumeopts.WithCreateReference(container.ID))
 		if err != nil {
+			if errdefs.IsNotFound(err) {
+				// Using a non-existing plugin is an invalid parameter, and should
+				// not return a "notfound" error on container create, because that
+				// error is used to indicate the container's image isn't found and
+				// must be pulled.
+				//
+				// See https://github.com/moby/moby/issues/48772
+				return errdefs.InvalidParameter(err)
+			}
 			return err
 		}
 

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -158,6 +158,15 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 			// create the volume
 			v, err := daemon.volumes.Create(ctx, bind.Name, bind.Driver, volumeopts.WithCreateReference(container.ID))
 			if err != nil {
+				if errdefs.IsNotFound(err) {
+					// Using a non-existing plugin is an invalid parameter, and should
+					// not return a "notfound" error on container create, because that
+					// error is used to indicate the container's image isn't found and
+					// must be pulled.
+					//
+					// See https://github.com/moby/moby/issues/48772
+					return errdefs.InvalidParameter(err)
+				}
 				return err
 			}
 			bind.Volume = &volumeWrapper{v: v, s: daemon.volumes}
@@ -218,6 +227,15 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 				v, err = daemon.volumes.Create(ctx, mp.Name, mp.Driver, volumeopts.WithCreateReference(container.ID))
 			}
 			if err != nil {
+				if errdefs.IsNotFound(err) {
+					// Using a non-existing plugin is an invalid parameter, and should
+					// not return a "notfound" error on container create, because that
+					// error is used to indicate the container's image isn't found and
+					// must be pulled.
+					//
+					// See https://github.com/moby/moby/issues/48772
+					return errdefs.InvalidParameter(err)
+				}
 				return err
 			}
 

--- a/integration/container/mounts_linux_test.go
+++ b/integration/container/mounts_linux_test.go
@@ -13,10 +13,13 @@ import (
 	mounttypes "github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/versions"
+	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/testutil"
+	"github.com/docker/docker/volume"
 	"github.com/moby/sys/mount"
 	"github.com/moby/sys/mountinfo"
 	"gotest.tools/v3/assert"
@@ -25,6 +28,10 @@ import (
 	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
+
+// testNonExistingPlugin is a special plugin-name, which overrides defaultTimeOut in tests.
+// this is a copy of https://github.com/moby/moby/blob/9e00a63d65434cdedc444e79a2b33a7c202b10d8/pkg/plugins/client.go#L253-L254
+const testNonExistingPlugin = "this-plugin-does-not-exist"
 
 func TestContainerNetworkMountsNoChown(t *testing.T) {
 	// chown only applies to Linux bind mounted volumes; must be same host to verify
@@ -422,6 +429,61 @@ func TestContainerVolumeAnonymous(t *testing.T) {
 	// see [daemon.AnonymousLabel]; we don't want to import the daemon package here.
 	const expectedAnonymousLabel = "com.docker.volume.anonymous"
 	assert.Check(t, is.Contains(volInspect.Labels, expectedAnonymousLabel))
+}
+
+// TestContainerVolumeInvalidDriver verifies that a volume-mount created
+// using a non-existing driver returns a "invalid parameter", not a "not found",
+// as a "not found" error is used by the CLI to consider the container's
+// image to be missing, and triggers a "docker pull".
+//
+// regression test for https://github.com/moby/moby/issues/48772
+func TestContainerVolumeInvalidDriver(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon)
+
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	t.Run("new volume", func(t *testing.T) {
+		config := container.NewTestConfig(container.WithMount(mounttypes.Mount{
+			Type:   mounttypes.TypeVolume,
+			Source: "new-volume",
+			Target: "/foo",
+			VolumeOptions: &mounttypes.VolumeOptions{
+				DriverConfig: &mounttypes.Driver{
+					Name: testNonExistingPlugin,
+				},
+			},
+		}))
+		ctr, err := apiClient.ContainerCreate(ctx, config.Config, config.HostConfig, config.NetworkingConfig, config.Platform, config.Name)
+		assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+		assert.Check(t, is.ErrorContains(err, fmt.Sprintf(`plugin %q not found`, testNonExistingPlugin)))
+		assert.Check(t, is.DeepEqual(ctr, containertypes.CreateResponse{}))
+	})
+
+	// Second code-path is during volumestore.checkConflict(), which checks
+	// if the given volume is conflicting with a volume in the local driver.
+	t.Run("conflicting volume", func(t *testing.T) {
+		conflictingVolume, err := apiClient.VolumeCreate(ctx, volumetypes.CreateOptions{
+			Name:   "conflicting-volume",
+			Driver: volume.DefaultDriverName,
+		})
+		assert.NilError(t, err)
+
+		config := container.NewTestConfig(container.WithMount(mounttypes.Mount{
+			Type:   mounttypes.TypeVolume,
+			Source: conflictingVolume.Name,
+			Target: "/foo",
+			VolumeOptions: &mounttypes.VolumeOptions{
+				DriverConfig: &mounttypes.Driver{
+					Name: testNonExistingPlugin,
+				},
+			},
+		}))
+		ctr, err := apiClient.ContainerCreate(ctx, config.Config, config.HostConfig, config.NetworkingConfig, config.Platform, config.Name)
+		assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+		assert.Check(t, is.ErrorContains(err, fmt.Sprintf(`plugin %q not found`, testNonExistingPlugin)))
+		assert.Check(t, is.DeepEqual(ctr, containertypes.CreateResponse{}))
+	})
 }
 
 // Regression test for #38995 and #43390.

--- a/volume/drivers/extpoint.go
+++ b/volume/drivers/extpoint.go
@@ -87,7 +87,7 @@ func (s *Store) lookup(name string, mode int) (volume.Driver, error) {
 	if s.pluginGetter != nil {
 		p, err := s.pluginGetter.Get(name, extName, mode)
 		if err != nil {
-			return nil, errors.Wrap(err, "error looking up volume plugin "+name)
+			return nil, errors.Wrap(err, "error looking up volume plugin")
 		}
 
 		d, err := makePluginAdapter(p)

--- a/volume/service/service.go
+++ b/volume/service/service.go
@@ -79,6 +79,15 @@ func (s *VolumesService) Create(ctx context.Context, name, driverName string, op
 	}
 	v, err := s.vs.Create(ctx, name, driverName, options...)
 	if err != nil {
+		if errdefs.IsNotFound(err) {
+			// Using a non-existing plugin is an invalid parameter, and should
+			// not return a "notfound" error on container create, because that
+			// error is used to indicate the container's image isn't found and
+			// must be pulled.
+			//
+			// See https://github.com/moby/moby/issues/48772
+			return nil, errdefs.InvalidParameter(err)
+		}
 		return nil, err
 	}
 

--- a/volume/service/service.go
+++ b/volume/service/service.go
@@ -79,15 +79,6 @@ func (s *VolumesService) Create(ctx context.Context, name, driverName string, op
 	}
 	v, err := s.vs.Create(ctx, name, driverName, options...)
 	if err != nil {
-		if errdefs.IsNotFound(err) {
-			// Using a non-existing plugin is an invalid parameter, and should
-			// not return a "notfound" error on container create, because that
-			// error is used to indicate the container's image isn't found and
-			// must be pulled.
-			//
-			// See https://github.com/moby/moby/issues/48772
-			return nil, errdefs.InvalidParameter(err)
-		}
 		return nil, err
 	}
 

--- a/volume/service/store.go
+++ b/volume/service/store.go
@@ -613,11 +613,9 @@ func (s *VolumeStore) create(ctx context.Context, name, driverName string, opts,
 		if v != nil {
 			return v, false, nil
 		}
-	}
-
-	if driverName == "" {
 		driverName = volume.DefaultDriverName
 	}
+
 	vd, err := s.drivers.CreateDriver(driverName)
 	if err != nil {
 		return nil, false, &OpErr{Op: "create", Name: name, Err: err}


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/48772

### fix: create container with a non-existing volume driver triggers docker pull

The docker CLI uses a "not found" (404) response on `docker create` and `docker run`
as indication that the specified image doesn't exist. Currently, specifying a
volume-driver that is not found also returns a "not found" error, resulting in
the image to be pulled, even if it already exists.

To reproduce:

Pull the image to make sure it's present;

    docker pull busybox
    Using default tag: latest
    latest: Pulling from library/busybox
    Digest: sha256:768e5c6f5cb6db0794eec98dc7a967f40631746c32232b78a3105fb946f3ab83
    Status: Image is up to date for busybox:latest
    docker.io/library/busybox:latest

Before this patch, an image pull was triggered;

    docker run --rm --volume-driver nosuchdriver -v /something busybox
    Unable to find image 'busybox:latest' locally
    latest: Pulling from library/busybox
    Digest: sha256:768e5c6f5cb6db0794eec98dc7a967f40631746c32232b78a3105fb946f3ab83
    Status: Image is up to date for busybox:latest
    docker: Error response from daemon: create 0f4f0e066f5e10b5de0fd794e4e28dc7b5e496d68af291df6c6204a06fbe1599: error looking up volume plugin nosuchdriver: plugin "nosuchdriver" not found.
    See 'docker run --help'.

Same, but using the `--mount` flag;

    docker run  --rm --mount=type=volume,volume-driver=nosuchdriver,target=/something busybox
    Unable to find image 'busybox:latest' locally
    latest: Pulling from library/busybox
    Digest: sha256:768e5c6f5cb6db0794eec98dc7a967f40631746c32232b78a3105fb946f3ab83
    Status: Image is up to date for busybox:latest
    docker: Error response from daemon: create e80e831b8e1db83febdc4af534d33607face62d8e661de1eeb3ed8b7d4ab5c47: error looking up volume plugin nosuchdriver: plugin "nosuchdriver" not found.
    See 'docker run --help'.


After this patch, no pull happens, and the error is returned about the missing
driver;

    docker run --rm --volume-driver nosuchdriver -v /something busybox
    docker: Error response from daemon: create 21890da7f789fa4e8ce3864284b4c62c3e387373c44c35238048d4e05d17999e: error looking up volume plugin something: plugin "nosuchdriver" not found.
    See 'docker run --help'.
    
    docker run  --rm --mount=type=volume,volume-driver=nosuchdriver,target=/something busybox
    docker: Error response from daemon: create 21890da7f789fa4e8ce3864284b4c62c3e387373c44c35238048d4e05d17999e: error looking up volume plugin something: plugin "nosuchdriver" not found.
    See 'docker run --help'.


### volume/drivers: Store.lookup: touch-up error for looking up plugins

The error was duplicating the name of the plugin, showing it twice;

Before this patch:

    Error response from daemon: create new-volume: error looking up volume plugin this-plugin-does-not-exist: plugin "this-plugin-does-not-exist" not found

After this patch:

    Error response from daemon: create new-volume: error looking up volume plugin: plugin "this-plugin-does-not-exist" not found


### volume/service: VolumeStore.create: remove redundant check

We already checked whether driverName was empty above, in which case
we try if there's a driver providing the volume and return early. We
only need to set the default driver if no volume was found in that branch
so let's move this code there.


**- How to verify it**

A test was added to verify the behavior:

    make TEST_FILTER='TestContainerVolumeInvalidDriver' TEST_SKIP_INTEGRATION_CLI=1 DOCKER_GRAPHDRIVER=vfs test-integration
    === RUN   TestContainerVolumeInvalidDriver
    === RUN   TestContainerVolumeInvalidDriver/new_volume
    === RUN   TestContainerVolumeInvalidDriver/conflicting_volume
    --- PASS: TestContainerVolumeInvalidDriver (2.05s)
        --- PASS: TestContainerVolumeInvalidDriver/new_volume (1.02s)
        --- PASS: TestContainerVolumeInvalidDriver/conflicting_volume (1.03s)
    PASS



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix a bug where creating a container with a volume that uses a non-existing driver causing an image-pull to be triggered.
```

**- A picture of a cute animal (not mandatory but encouraged)**

