### PR TITLE
internal/safepath: log some unhandled errors, and remove workaround for ECI / Sysbox

### DIFF
--- a/internal/safepath/join_linux.go
+++ b/internal/safepath/join_linux.go
@@ -44,14 +44,7 @@ func Join(ctx context.Context, path, subpath string) (*SafePath, error) {
 		return nil, errors.Wrap(err, "failed to create temporary file for safe mount")
 	}
 
-	pid := strconv.Itoa(unix.Gettid())
-	// Using explicit pid path, because /proc/self/fd/<fd> fails with EACCES
-	// when running under "Enhanced Container Isolation" in Docker Desktop
-	// which uses sysbox runtime under the hood.
-	// TODO(vvoland): Investigate.
-	mountSource := "/proc/" + pid + "/fd/" + strconv.Itoa(fd)
-
-	if err := unix_noeintr.Mount(mountSource, tmpMount, "none", unix.MS_BIND, ""); err != nil {
+	if err := unix_noeintr.Mount("/proc/self/fd/"+strconv.Itoa(fd), tmpMount, "none", unix.MS_BIND, ""); err != nil {
 		if err := os.Remove(tmpMount); err != nil {
 			log.G(ctx).WithError(err).Warn("failed to remove tmpMount after failed mount")
 		}

--- a/internal/safepath/k8s_safeopen_linux.go
+++ b/internal/safepath/k8s_safeopen_linux.go
@@ -78,7 +78,7 @@ func kubernetesSafeOpen(base, subpath string) (int, error) {
 
 		// Trigger auto mount if it's an auto-mounted directory, ignore error if not a directory.
 		// Notice the trailing slash is mandatory, see "automount" in openat(2) and open_by_handle_at(2).
-		unix_noeintr.Fstatat(parentFD, seg+"/", &deviceStat, unix.AT_SYMLINK_NOFOLLOW)
+		_ = unix_noeintr.Fstatat(parentFD, seg+"/", &deviceStat, unix.AT_SYMLINK_NOFOLLOW)
 
 		log.G(context.TODO()).Debugf("Opening path %s", currentPath)
 		childFD, err = unix_noeintr.Openat(parentFD, seg, openFDFlags|unix.O_CLOEXEC, 0)


### PR DESCRIPTION
- fixes  https://github.com/moby/moby/pull/45687#discussion_r1280867905
- relates to https://github.com/moby/moby/pull/45687#discussion_r1280867905
- relates to https://github.com/nestybox/sysbox-fs/commit/9cf74e4cbf3a61b1881bf5775460463900b55a87 (https://github.com/nestybox/sysbox-fs/pull/86)
- relates to https://github.com/moby/moby/issues/45681
- relates to https://github.com/moby/moby/pull/45682
- relates to https://github.com/nestybox/sysbox/issues/712

### internal/safepath: kubernetesSafeOpen: explicitly suppress unhandled err


### internal/safepath: Join(): log some unhandled errors

Similar to the kubernetesSafeOpen function.


### internal/safepath: Join(): remove workaround for ECI / Sysbox

This workaround was added in 9a0cde66ba6ea04bd7d27fbfdbaefdbb01ad5787 to
work around an issue on Docker Desktop with ECI (Enhanced Container Isolation)
enabled, which uses the Sysbox runtime under the hood.

A comment was added during review of the PR that added it (see [1]), and the
internal discussion on Slack tracked down the issue to code in [nestybox/sysfs].

That issue was resolved Sysbox EE, and upstreamed to Sysbox CE through
[nestybox/sysbox-fs@9cf74e4], which is part of Sysbox CE v0.6.3, so we
can remove this workaround.


[1]: https://github.com/moby/moby/pull/45687#discussion_r1280867905
[nestybox/sysfs]: https://github.com/nestybox/sysbox-fs/blob/30fd49edbd51048fed8b2ad0af327598d30b29eb/process/process.go#L644-L684
[nestybox/sysbox-fs@9cf74e4]: https://github.com/nestybox/sysbox-fs/commit/9cf74e4cbf3a61b1881bf5775460463900b55a87





**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

