### PR TITLE
volume/service: use local driver as default for anonymous volumes

### DIFF
--- a/volume/service/service.go
+++ b/volume/service/service.go
@@ -72,8 +72,11 @@ const AnonymousLabel = "com.docker.volume.anonymous"
 func (s *VolumesService) Create(ctx context.Context, name, driverName string, options ...opts.CreateOption) (*volumetypes.Volume, error) {
 	if name == "" {
 		name = stringid.GenerateRandomID()
+		if driverName == "" {
+			driverName = volume.DefaultDriverName
+		}
 		options = append(options, opts.WithCreateLabel(AnonymousLabel, ""))
-		log.G(ctx).WithField("volume-name", name).Debug("Creating anonymous volume")
+		log.G(ctx).WithFields(log.Fields{"volume-name": name, "driver": driverName}).Debug("Creating anonymous volume")
 	} else {
 		log.G(ctx).WithField("volume-name", name).Debug("Creating named volume")
 	}


### PR DESCRIPTION
Anonymous volumes get a unique, 64-character name, and intended to be a new volume (not an existing one). While it's theoretically possible for this name to exist in other volume drivers, this would be very unlikely, so we should not need to check other drivers to have this volume.

This patch uses the default ("local") volume-driver for anonymous volumes, unless the user explicitly asked for a specific driver to use. Setting the driver skips looking up existing volumes in other drivers.

Before this patch:

    DEBU[2024-10-26T15:51:12.681547126Z] container mounted via snapshotter: /var/lib/docker/rootfs/overlayfs/7e947822249514b6239657a0c54d091d90e0fed4b09da472f3f6258f2b4920bc  container=7e947822249514b6239657a0c54d091d90e0fed4b09da472f3f6258f2b4920bc
    DEBU[2024-10-26T15:51:12.681616084Z] Creating anonymous volume                     volume-name=fd46d688247c3e7d39d9bae4532d6b2dc69e82e354c4a3bf305c50bbfb9ebc6c
    DEBU[2024-10-26T15:51:12.681638959Z] Probing all drivers for volume                volume-name=fd46d688247c3e7d39d9bae4532d6b2dc69e82e354c4a3bf305c50bbfb9ebc6c
    DEBU[2024-10-26T15:51:12.681688917Z] Registering new volume reference              driver=local volume-name=fd46d688247c3e7d39d9bae4532d6b2dc69e82e354c4a3bf305c50bbfb9ebc6c

With this patch:

    DEBU[2024-10-27T17:28:28.574956716Z] container mounted via snapshotter: /var/lib/docker/rootfs/overlayfs/7085cb3991b61cbb79edffcb6980ad926f99f6b6b3be617cc3e3b92673cc2eb8  container=7085cb3991b61cbb79edffcb6980ad926f99f6b6b3be617cc3e3b92673cc2eb8
    DEBU[2024-10-27T17:28:28.575002549Z] Creating anonymous volume                     driver=local volume-name=db11c053566362499103213542402af2770a6622fe7a90b9a938a5bed84ca937
    DEBU[2024-10-27T17:28:28.575016299Z] Registering new volume reference              driver=local volume-name=db11c053566362499103213542402af2770a6622fe7a90b9a938a5bed84ca937

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

