### PR TITLE
c8d/inspect: Fix duplicate RepoDigests

### DIFF
--- a/daemon/containerd/image_inspect.go
+++ b/daemon/containerd/image_inspect.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types/backend"
 	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/storage"
+	"github.com/docker/docker/internal/sliceutil"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sync/semaphore"
 )
@@ -103,7 +104,7 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, _ backe
 	return &imagetypes.InspectResponse{
 		ID:            img.ImageID(),
 		RepoTags:      repoTags,
-		RepoDigests:   repoDigests,
+		RepoDigests:   sliceutil.Dedup(repoDigests),
 		Parent:        img.Parent.String(),
 		Comment:       comment,
 		Created:       created,


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/48747

Multiple images with the same repository name but different tag caused the `RepoDigests` to contain duplicated entries for each of the image.

Use a set instead of a slice to store the digested references to avoid the duplicated values.

**- How to verify it**
TestImageInspectUniqueRepoDigests

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
containerd image store: Fix `docker image inspect` outputting duplicate references in `RepoDigests`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

