### PR TITLE
Fix: #48747

### DIFF
--- a/daemon/containerd/image_inspect.go
+++ b/daemon/containerd/image_inspect.go
@@ -17,6 +17,18 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
+func removeDuplicates(elements []string) []string {
+    encounter := map[string]bool{}
+    final := []string{}
+
+    for _, v := range elements {
+        if !encounter[v] {
+            encounter[v] = true
+            final = append(final, v)
+        }
+    }
+    return final
+}
 func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, _ backend.ImageInspectOpts) (*imagetypes.InspectResponse, error) {
 	img, err := i.GetImage(ctx, refOrID, backend.GetImageOpts{})
 	if err != nil {
@@ -103,7 +115,7 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, _ backe
 	return &imagetypes.InspectResponse{
 		ID:            img.ImageID(),
 		RepoTags:      repoTags,
-		RepoDigests:   repoDigests,
+		RepoDigests:   removeDuplicates(repoDigests),
 		Parent:        img.Parent.String(),
 		Comment:       comment,
 		Created:       created,


### PR DESCRIPTION
fixes #48747
### Pull Request Description

**- What I did**

Fixed the issue where `docker image inspect` contains duplicate `RepoDigests` when using containerd image store.

**- How I did it**

Added a helper function to remove duplicates from `RepoDigests` list in `ImageInspect` function.

**- How to verify it**

1. Build and tag image with multiple tags.
2. Push image to a registry.
3. Inspect image using `docker image inspect`.
4. Verify that `RepoDigests` list does not contain duplicates.

**- Description for the changelog**
```markdown changelog
Fixed duplicate `RepoDigests` in `docker image inspect` when using the containerd image store.
```

**- A picture of a cute animal (not mandatory but encouraged)**
![images](https://github.com/user-attachments/assets/a1279cda-257a-4dfa-a569-7f0477152d56)