### PR TITLE
c8d/push: include aux information if multiple candidates considered

### DIFF
--- a/api/types/auxprogress/push.go
+++ b/api/types/auxprogress/push.go
@@ -1,6 +1,7 @@
 package auxprogress
 
 import (
+	"github.com/docker/docker/api/types/image"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -12,6 +13,8 @@ type ManifestPushedInsteadOfIndex struct {
 
 	// OriginalIndex is the descriptor of the original image index.
 	OriginalIndex ocispec.Descriptor `json:"originalIndex"`
+
+	ImageSummary *image.Summary
 
 	// SelectedManifest is the descriptor of the manifest that was pushed instead.
 	SelectedManifest ocispec.Descriptor `json:"selectedManifest"`

--- a/daemon/containerd/image_exporter.go
+++ b/daemon/containerd/image_exporter.go
@@ -87,7 +87,7 @@ func (i *ImageService) ExportImage(ctx context.Context, names []string, platform
 		target := img.Target
 
 		if platform != nil {
-			newTarget, err := i.getPushDescriptor(ctx, img, platform)
+			newTarget, _, err := i.getPushDescriptor(ctx, img, platform)
 			if err != nil {
 				return errors.Wrap(err, "no suitable export target found")
 			}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

When using the containerd image store, if a client initiates a push of a multi-platform image for which not all platforms are locally available (without specifying a platform), the engine will not error out if at least it's platform's manifest is available, and will instead automatically select that (without user input), which can result in unexpected outcomes for users.

However, simply erroring out if all the content is not locally available and a platform is not selected isn't desirable either.

This patch enriches the aux progress information during push to include more details about which manifests were considered/chosen, in order to allow clients to output more meaningful messaging when this happens.

**- How I did it**

Changed `getPushDescriptor` to collect more information while walking the image store to find/list locally available manifests to push, which is returned from the caller in the case that multiple candidates are found.

Changed `pushRef` to send this information over in the `auxprogress.ManifestPushedInsteadOfIndex`, so that clients can use it.

See an example of how this might be used over in https://github.com/docker/cli/pull/5574:

![Screenshot 2024-10-25 at 16 34 14](https://github.com/user-attachments/assets/db6a09e2-4207-42f1-b4a1-e88934c5715c)

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

