### PR TITLE
[27.x] c8d/inspect: Fix duplicate RepoDigests

### DIFF
--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
+	"github.com/docker/docker/internal/sliceutil"
 	imagespec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -109,7 +110,7 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options bac
 		}
 
 		img.Details = &image.Details{
-			References:  refs,
+			References:  sliceutil.Dedup(refs),
 			Size:        size,
 			Metadata:    nil,
 			Driver:      i.snapshotter,

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -22,6 +22,7 @@ import (
 	imagetypes "github.com/docker/docker/api/types/image"
 	timetypes "github.com/docker/docker/api/types/time"
 	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/internal/sliceutil"
 	"github.com/moby/buildkit/util/attestation"
 	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/opencontainers/go-digest"
@@ -501,7 +502,7 @@ func (i *ImageService) singlePlatformImage(ctx context.Context, contentStore con
 	summary := &imagetypes.Summary{
 		ParentID:    rawImg.Labels[imageLabelClassicBuilderParent],
 		ID:          target.String(),
-		RepoDigests: repoDigests,
+		RepoDigests: sliceutil.Dedup(repoDigests),
 		RepoTags:    repoTags,
 		Size:        totalSize,
 		Labels:      cfg.Config.Labels,


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/48777

- fixes: https://github.com/moby/moby/issues/48747

Multiple images with the same repository name but different tag caused the `RepoDigests` to contain duplicated entries for each of the image.

Use a set instead of a slice to store the digested references to avoid the duplicated values.

**- How to verify it**
TestImageInspectUniqueRepoDigests

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
containerd image store: Fix `docker image inspect` outputting duplicate references in `RepoDigests`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

