### PR TITLE
[25.0 backport] volume/mounts: fix anonymous volume not being labeled 

### DIFF
--- a/integration/container/mounts_linux_test.go
+++ b/integration/container/mounts_linux_test.go
@@ -392,6 +392,37 @@ func TestContainerVolumesMountedAsSlave(t *testing.T) {
 	}
 }
 
+// TestContainerVolumeAnonymous verifies that anonymous volumes created through
+// the Mounts API get a random name generated, and have the "AnonymousLabel"
+// (com.docker.volume.anonymous) label set.
+//
+// regression test for https://github.com/moby/moby/issues/48748
+func TestContainerVolumeAnonymous(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon)
+
+	ctx := setupTest(t)
+
+	mntOpts := mounttypes.Mount{Type: mounttypes.TypeVolume, Target: "/foo"}
+
+	apiClient := testEnv.APIClient()
+	cID := container.Create(ctx, t, apiClient, container.WithMount(mntOpts))
+
+	inspect := container.Inspect(ctx, t, apiClient, cID)
+	assert.Assert(t, is.Len(inspect.HostConfig.Mounts, 1))
+	assert.Check(t, is.Equal(inspect.HostConfig.Mounts[0], mntOpts))
+
+	assert.Assert(t, is.Len(inspect.Mounts, 1))
+	volName := inspect.Mounts[0].Name
+	assert.Check(t, is.Len(volName, 64), "volume name should be 64 bytes (from stringid.GenerateRandomID())")
+
+	volInspect, err := apiClient.VolumeInspect(ctx, volName)
+	assert.NilError(t, err)
+
+	// see [daemon.AnonymousLabel]; we don't want to import the daemon package here.
+	const expectedAnonymousLabel = "com.docker.volume.anonymous"
+	assert.Check(t, is.Contains(volInspect.Labels, expectedAnonymousLabel))
+}
+
 // Regression test for #38995 and #43390.
 func TestContainerCopyLeaksMounts(t *testing.T) {
 	ctx := setupTest(t)

--- a/volume/mounts/linux_parser.go
+++ b/volume/mounts/linux_parser.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types/mount"
-	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/volume"
 )
 
@@ -295,9 +294,8 @@ func (p *linuxParser) parseMountSpec(cfg mount.Mount, validateBindSourceExists b
 
 	switch cfg.Type {
 	case mount.TypeVolume:
-		if cfg.Source == "" {
-			mp.Name = stringid.GenerateRandomID()
-		} else {
+		if cfg.Source != "" {
+			// non-anonymous volume
 			mp.Name = cfg.Source
 		}
 		mp.CopyData = p.DefaultCopyMode()

--- a/volume/mounts/windows_parser.go
+++ b/volume/mounts/windows_parser.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types/mount"
-	"github.com/docker/docker/pkg/stringid"
 )
 
 // NewWindowsParser creates a parser with Windows semantics.
@@ -380,9 +379,8 @@ func (p *windowsParser) parseMountSpec(cfg mount.Mount, convertTargetToBackslash
 
 	switch cfg.Type {
 	case mount.TypeVolume:
-		if cfg.Source == "" {
-			mp.Name = stringid.GenerateRandomID()
-		} else {
+		if cfg.Source != "" {
+			// non-anonymous volume
 			mp.Name = cfg.Source
 		}
 		mp.CopyData = p.DefaultCopyMode()

--- a/volume/service/service.go
+++ b/volume/service/service.go
@@ -74,6 +74,9 @@ func (s *VolumesService) Create(ctx context.Context, name, driverName string, op
 	if name == "" {
 		name = stringid.GenerateRandomID()
 		options = append(options, opts.WithCreateLabel(AnonymousLabel, ""))
+		log.G(ctx).WithField("volume-name", name).Error("Creating anonymous volume")
+	} else {
+		log.G(ctx).WithField("volume-name", name).Error("Creating named volume")
 	}
 	v, err := s.vs.Create(ctx, name, driverName, options...)
 	if err != nil {

--- a/volume/service/service.go
+++ b/volume/service/service.go
@@ -74,9 +74,9 @@ func (s *VolumesService) Create(ctx context.Context, name, driverName string, op
 	if name == "" {
 		name = stringid.GenerateRandomID()
 		options = append(options, opts.WithCreateLabel(AnonymousLabel, ""))
-		log.G(ctx).WithField("volume-name", name).Error("Creating anonymous volume")
+		log.G(ctx).WithField("volume-name", name).Debug("Creating anonymous volume")
 	} else {
-		log.G(ctx).WithField("volume-name", name).Error("Creating named volume")
+		log.G(ctx).WithField("volume-name", name).Debug("Creating named volume")
 	}
 	v, err := s.vs.Create(ctx, name, driverName, options...)
 	if err != nil {

--- a/volume/service/store.go
+++ b/volume/service/store.go
@@ -732,7 +732,7 @@ func (s *VolumeStore) getVolume(ctx context.Context, name, driverName string) (v
 		return volumeWrapper{vol, meta.Labels, scope, meta.Options}, nil
 	}
 
-	log.G(ctx).Debugf("Probing all drivers for volume with name: %s", name)
+	log.G(ctx).WithField("volume-name", name).Debugf("Probing all drivers for volume")
 	drvrs, err := s.drivers.GetAllDrivers()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**- What I did**

* Backports https://github.com/moby/moby/pull/48754 to 25.0
  * Requires https://github.com/moby/moby/pull/48675 for clean pick
* Backports https://github.com/moby/moby/pull/48767 to 25.0

### volume/mounts: fix anonymous volume not being labeled
`Parser.ParseMountRaw()` labels anonymous volumes with a AnonymousLabel label (com.docker.volume.anonymous) label based on whether a volume has a name (named volume) or no name (anonymous) (see [1](https://github.com/moby/moby/blob/032721ff75fe4a71a45b4a7a9b7e7c4c80c6431b/volume/service/service.go#L72-L83)).

However both VolumesService.Create() (see [1](https://github.com/moby/moby/blob/032721ff75fe4a71a45b4a7a9b7e7c4c80c6431b/volume/service/service.go#L72-L83)) and Parser.ParseMountRaw() (see [2](https://github.com/moby/moby/blob/032721ff75fe4a71a45b4a7a9b7e7c4c80c6431b/volume/mounts/linux_parser.go#L330-L336), [3](https://github.com/moby/moby/blob/032721ff75fe4a71a45b4a7a9b7e7c4c80c6431b/volume/mounts/windows_parser.go#L394-L400)) were generating a random name for anonymous volumes. The latter is called before VolumesService.Create() is called, resulting in such volumes not being labeled as anonymous.

Generating the name was originally done in Create (https://github.com/moby/moby/commit/fc7b904dced4d18d49c8a6c47ae3f415d16d0c43), but duplicated in https://github.com/moby/moby/commit/b3b7eb2723461b1eb4be692f4bced0ae8ea9cb58 with the introduction of the new Mounts field in HostConfig. Duplicating this effort didn't have a real effect until (Create would just skip generating the name), until https://github.com/moby/moby/commit/618f26ccbc3b5c314680dae4b09f5d13f9c02570 introduced the AnonymousLabel in (v24.0.0, backported to v23.0.0).

Parsing generally should not fill in defaults / generate names, so this patch;

Removes generating volume names from `Parser.ParseMountRaw()`
Adds a debug-log entry to `VolumesService.Create()`
Touches up some logs to use structured logs for easier correlating logs

**- Description for the changelog**
```markdown changelog
Fix anonymous volumes being created through the `--mount` option not being marked as anonymous.
```

**- A picture of a cute animal (not mandatory but encouraged)**

