### PR TITLE
Revert "ci: run integration tests with firewalld enabled"

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -36,12 +36,6 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ github.event_name != 'pull_request' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        mode:
-          - ""
-          - firewalld
     steps:
       -
         name: Checkout
@@ -49,15 +43,6 @@ jobs:
       -
         name: Set up runner
         uses: ./.github/actions/setup-runner
-      -
-        name: Prepare
-        run: |
-          CACHE_DEV_SCOPE=dev
-          if [[ "${{ matrix.mod }}" == *"firewalld"* ]]; then
-            echo "DOCKER_FIREWALLD=true" >> $GITHUB_ENV
-            CACHE_DEV_SCOPE="${CACHE_DEV_SCOPE}firewalld"
-          fi
-          echo "CACHE_DEV_SCOPE=${CACHE_DEV_SCOPE}" >> $GITHUB_ENV
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -80,18 +65,11 @@ jobs:
         name: Prepare reports
         if: always()
         run: |
-          reportsName=$(echo -n "${{ matrix.test }}" | sha256sum | cut -d " " -f 1)
-          if [ -n "${{ matrix.mode }}" ]; then
-            reportsName="$reportsName-${{ matrix.mode }}"
-          fi
-          reportsPath=/tmp/reports/$reportsName
-          echo "TESTREPORTS_NAME=$reportsName" >> $GITHUB_ENV
-
-          mkdir -p bundles $reportsPath
+          mkdir -p bundles /tmp/reports
           find bundles -path '*/root/*overlay2' -prune -o -type f \( -name '*-report.json' -o -name '*.log' -o -name '*.out' -o -name '*.prof' -o -name '*-report.xml' \) -print | xargs sudo tar -czf /tmp/reports.tar.gz
-          tar -xzf /tmp/reports.tar.gz -C $reportsPath
-          sudo chown -R $(id -u):$(id -g) $reportsPath
-          tree -nh $reportsPath
+          tar -xzf /tmp/reports.tar.gz -C /tmp/reports
+          sudo chown -R $(id -u):$(id -g) /tmp/reports
+          tree -nh /tmp/reports
       -
         name: Send to Codecov
         uses: codecov/codecov-action@v4
@@ -105,7 +83,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-reports-unit-${{ inputs.storage }}-${{ env.TESTREPORTS_NAME }}
+          name: test-reports-unit-${{ inputs.storage }}
           path: /tmp/reports/*
           retention-days: 1
 
@@ -127,7 +105,7 @@ jobs:
         name: Download reports
         uses: actions/download-artifact@v4
         with:
-          pattern: test-reports-unit-${{ inputs.storage }}-*
+          name: test-reports-unit-${{ inputs.storage }}
           path: /tmp/reports
       -
         name: Install teststat
@@ -241,7 +219,6 @@ jobs:
           - ""
           - rootless
           - systemd
-          - firewalld
           #- rootless-systemd FIXME: https://github.com/moby/moby/issues/44084
     steps:
       -
@@ -263,10 +240,6 @@ jobs:
           if [[ "${{ matrix.mode }}" == *"systemd"* ]]; then
             echo "SYSTEMD=true" >> $GITHUB_ENV
             CACHE_DEV_SCOPE="${CACHE_DEV_SCOPE}systemd"
-          fi
-          if [[ "${{ matrix.mod }}" == *"firewalld"* ]]; then
-            echo "DOCKER_FIREWALLD=true" >> $GITHUB_ENV
-            CACHE_DEV_SCOPE="${CACHE_DEV_SCOPE}firewalld"
           fi
           echo "CACHE_DEV_SCOPE=${CACHE_DEV_SCOPE}" >> $GITHUB_ENV
       -
@@ -407,9 +380,6 @@ jobs:
       fail-fast: false
       matrix:
         test: ${{ fromJson(needs.integration-cli-prepare.outputs.matrix) }}
-        mode:
-          - ""
-          - firewalld
     steps:
       -
         name: Checkout
@@ -420,15 +390,6 @@ jobs:
       -
         name: Set up tracing
         uses: ./.github/actions/setup-tracing
-      -
-        name: Prepare
-        run: |
-          CACHE_DEV_SCOPE=dev
-          if [[ "${{ matrix.mod }}" == *"firewalld"* ]]; then
-            echo "DOCKER_FIREWALLD=true" >> $GITHUB_ENV
-            CACHE_DEV_SCOPE="${CACHE_DEV_SCOPE}firewalld"
-          fi
-          echo "CACHE_DEV_SCOPE=${CACHE_DEV_SCOPE}" >> $GITHUB_ENV
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -456,9 +417,6 @@ jobs:
         if: always()
         run: |
           reportsName=$(echo -n "${{ matrix.test }}" | sha256sum | cut -d " " -f 1)
-          if [ -n "${{ matrix.mode }}" ]; then
-            reportsName="$reportsName-${{ matrix.mode }}"
-          fi
           reportsPath=/tmp/reports/$reportsName
           echo "TESTREPORTS_NAME=$reportsName" >> $GITHUB_ENV
           

--- a/hack/dind-systemd
+++ b/hack/dind-systemd
@@ -59,7 +59,7 @@ fi
 # Allow connections coming from the host (through eth0). This is needed to
 # access the daemon port (independently of which port is used), or run a
 # 'remote' Delve session, etc...
-if [ "${DOCKER_FIREWALLD:-}" = "true" ]; then
+if [ ${DOCKER_FIREWALLD:-} = "true" ]; then
 	cat > /etc/firewalld/zones/trusted.xml << EOF
 <?xml version="1.0" encoding="utf-8"?>
 <zone target="ACCEPT">
@@ -76,7 +76,7 @@ env > /etc/docker-entrypoint-env
 cat > /etc/systemd/system/docker-entrypoint.target << EOF
 [Unit]
 Description=the target for docker-entrypoint.service
-Requires=docker-entrypoint.service systemd-logind.service systemd-user-sessions.service $([ "${DOCKER_FIREWALLD:-}" = "true" ] && echo firewalld.service)
+Requires=docker-entrypoint.service systemd-logind.service systemd-user-sessions.service $([ ${DOCKER_FIREWALLD:-} = "true" ] && echo firewalld.service)
 EOF
 
 quoted_args="$(printf " %q" "${@}")"


### PR DESCRIPTION
**- What I did**

Partial revert of:

- https://github.com/moby/moby/pull/48603

Temporarily remove firewallds jobs. These are actually not running firewalld due to a typo in GHA definitions. Moreover, these new jobs are putting too much load on the CI, causing GHA cache backend to return 429 for many jobs. This slows down build jobs (as they can't use existing cache), and at least one buildkit test is now failing.


Permanent fix:

- https://github.com/moby/moby/pull/48756, but it still needs some more work.
