### PR TITLE
fix: default InsecureSkipVerify Config

### DIFF
--- a/client/options.go
+++ b/client/options.go
@@ -168,14 +168,11 @@ func WithTLSClientConfig(cacertPath, certPath, keyPath string) Opt {
 func WithTLSClientConfigFromEnv() Opt {
 	return func(c *Client) error {
 		c.client = &http.Client{
-			Transport:     &http.Transport{TLSClientConfig: 
-						       tlsconfig.Client(tlsconfig.Options{
-			CAFile:             filepath.Join(dockerCertPath, "ca.pem"),
-			CertFile:           filepath.Join(dockerCertPath, "cert.pem"),
-			KeyFile:            filepath.Join(dockerCertPath, "key.pem"),
-			InsecureSkipVerify: os.Getenv(EnvTLSVerify) == "",
-		})},
-			CheckRedirect: CheckRedirect,
+			Transport:     &http.Transport{
+				TLSClientConfig: tlsconfig.Options{
+					InsecureSkipVerify: os.Getenv(EnvTLSVerify) == "",
+				}
+			}
 		}
 		dockerCertPath := os.Getenv(EnvOverrideCertPath)
 		if dockerCertPath == "" {

--- a/client/options.go
+++ b/client/options.go
@@ -167,13 +167,17 @@ func WithTLSClientConfig(cacertPath, certPath, keyPath string) Opt {
 //     (off by default).
 func WithTLSClientConfigFromEnv() Opt {
 	return func(c *Client) error {
-		c.client = &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: tlsconfig.Options{
-					InsecureSkipVerify: os.Getenv(EnvTLSVerify) == "",
+		EnvTLSVerifyValue, isSet := os.LookupEnv(EnvTLSVerify)
+		if isSet {
+			c.client = &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: tlsconfig.Options{
+						InsecureSkipVerify: EnvTLSVerifyValue == "",
+					},
 				},
-			},
+			}
 		}
+
 		dockerCertPath := os.Getenv(EnvOverrideCertPath)
 		if dockerCertPath == "" {
 			return nil

--- a/client/options.go
+++ b/client/options.go
@@ -168,11 +168,11 @@ func WithTLSClientConfig(cacertPath, certPath, keyPath string) Opt {
 func WithTLSClientConfigFromEnv() Opt {
 	return func(c *Client) error {
 		c.client = &http.Client{
-			Transport:     &http.Transport{
+			Transport: &http.Transport{
 				TLSClientConfig: tlsconfig.Options{
 					InsecureSkipVerify: os.Getenv(EnvTLSVerify) == "",
-				}
-			}
+				},
+			},
 		}
 		dockerCertPath := os.Getenv(EnvOverrideCertPath)
 		if dockerCertPath == "" {

--- a/client/options.go
+++ b/client/options.go
@@ -167,6 +167,16 @@ func WithTLSClientConfig(cacertPath, certPath, keyPath string) Opt {
 //     (off by default).
 func WithTLSClientConfigFromEnv() Opt {
 	return func(c *Client) error {
+		c.client = &http.Client{
+			Transport:     &http.Transport{TLSClientConfig: 
+						       tlsconfig.Client(tlsconfig.Options{
+			CAFile:             filepath.Join(dockerCertPath, "ca.pem"),
+			CertFile:           filepath.Join(dockerCertPath, "cert.pem"),
+			KeyFile:            filepath.Join(dockerCertPath, "key.pem"),
+			InsecureSkipVerify: os.Getenv(EnvTLSVerify) == "",
+		})},
+			CheckRedirect: CheckRedirect,
+		}
 		dockerCertPath := os.Getenv(EnvOverrideCertPath)
 		if dockerCertPath == "" {
 			return nil
@@ -183,7 +193,6 @@ func WithTLSClientConfigFromEnv() Opt {
 
 		c.client = &http.Client{
 			Transport:     &http.Transport{TLSClientConfig: tlsc},
-			CheckRedirect: CheckRedirect,
 		}
 		return nil
 	}

--- a/client/options.go
+++ b/client/options.go
@@ -190,6 +190,7 @@ func WithTLSClientConfigFromEnv() Opt {
 
 		c.client = &http.Client{
 			Transport:     &http.Transport{TLSClientConfig: tlsc},
+			CheckRedirect: CheckRedirect,
 		}
 		return nil
 	}


### PR DESCRIPTION
fix https://github.com/moby/moby/issues/46598

**- What I did**
initialize the default transport with InsecureSkipVerify

**- How to verify it**

local testing and unittest

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
initialize the default transport with `InsecureSkipVerify`
```

