### PR TITLE
Restore 27.x path for libnet's Bolt database

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -64,6 +64,9 @@ const (
 	// SeccompProfileUnconfined is a special profile name for seccomp to use an
 	// "unconfined" seccomp profile.
 	SeccompProfileUnconfined = "unconfined"
+	// LibnetDataPath is the path to libnetwork's data directory, relative to cfg.Root.
+	// Windows tolerates the "/".
+	LibnetDataPath = "network/files"
 )
 
 // flatOptions contains configuration keys

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1486,7 +1486,7 @@ func isBridgeNetworkDisabled(conf *config.Config) bool {
 
 func (daemon *Daemon) networkOptions(conf *config.Config, pg plugingetter.PluginGetter, hostID string, activeSandboxes map[string]interface{}) ([]nwconfig.Option, error) {
 	options := []nwconfig.Option{
-		nwconfig.OptionDataDir(conf.Root),
+		nwconfig.OptionDataDir(filepath.Join(conf.Root, config.LibnetDataPath)),
 		nwconfig.OptionExecRoot(conf.GetExecRoot()),
 		nwconfig.OptionDefaultDriver(network.DefaultNetwork),
 		nwconfig.OptionDefaultNetwork(network.DefaultNetwork),

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -941,8 +941,8 @@ func (c *Controller) NewSandbox(ctx context.Context, containerID string, options
 
 	if sb.ingress {
 		c.ingressSandbox = sb
-		sb.config.hostsPath = filepath.Join(c.cfg.DataDir, "/network/files/hosts")
-		sb.config.resolvConfPath = filepath.Join(c.cfg.DataDir, "/network/files/resolv.conf")
+		sb.config.hostsPath = filepath.Join(c.cfg.DataDir, "hosts")
+		sb.config.resolvConfPath = filepath.Join(c.cfg.DataDir, "resolv.conf")
 		sb.id = "ingress_sbox"
 	} else if sb.loadBalancerNID != "" {
 		sb.id = "lb_" + sb.loadBalancerNID


### PR DESCRIPTION
**- What I did**

In 27.x and earlier releases, libnetwork's database file was in a sub-directory `network/files` under the daemon's root data dir (`/var/lib/docker/network/files/local-kv.db`).

That part of the path got lost during refactoring in https://github.com/moby/moby/pull/47992 (https://github.com/moby/moby/pull/47992/commits/ed08486ec79b1d79dd6408d57086883501ffae52).

So, libnet data ended up in the daemon's main Bolt db (`/var/lib/docker/local-kv.db`). Then, on upgrade from 27.x, config in the original file was no longer accessible.

**- How I did it**

libnet doesn't need access to any data outside its sub-dir, so change the meaning of its OptionDataDir - it now points at libnet's sub-dir, so the db will be created in the right place. Also, update other uses of that data dir to match.

Note that:
- upgrade from a version of master before this change to one after will mean networks disappear, and
- libnet config won't be removed from the daemon's main bolt db.

**- How to verify it**

Create a network with a 27.x daemon, upgrade to master, check the network is still there.

Tested in a Linux dev container, and on Windows.

Start a Linux swarm service with a port mapping (`docker swarm init; docker service create -p 8080:80 nginx`) and checked its `hosts`, `resolv.conf` and `resolv.conf.hash` files were still created in `/var/lib/docker/network/files`.

**- Description for the changelog**
```markdown changelog
n/a
```