### PR TITLE
Remove libnetwork_test.TestMain

### DIFF
--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -42,13 +42,6 @@ const (
 	bridgeNetType = "bridge"
 )
 
-func TestMain(m *testing.M) {
-	// Cleanup local datastore file
-	_ = os.Remove("/var/lib/docker/network/files/local-kv.db")
-
-	os.Exit(m.Run())
-}
-
 func newController(t *testing.T) *libnetwork.Controller {
 	t.Helper()
 	c, err := libnetwork.New(


### PR DESCRIPTION
**- What I did**

- Follow up on https://github.com/moby/moby/pull/48793#issuecomment-2445033718

**- How I did it**

Remove `libnetwork_test.TestMain`.

It only removed the test host's libnet Bolt db file, and didn't need to do that because the tests use a TempDir for it.

**- How to verify it**

With the `TestMain` in place, the tests didn't create `/var/lib/docker/network/files/local-kv.db`. And, with it gone, the file is not modified by the tests.

**- Description for the changelog**
```markdown changelog
n/a
```
