### PR TITLE
Fix: Duplicate event on network disconnect

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -1125,12 +1125,6 @@ func (daemon *Daemon) DisconnectFromNetwork(ctx context.Context, ctr *container.
 		return err
 	}
 
-	if n != nil {
-		daemon.LogNetworkEventWithAttributes(n, events.ActionDisconnect, map[string]string{
-			"container": ctr.ID,
-		})
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
-  This fixes #48797

**- What I did**
I modified the `DisconnectFromNetwork` function in `daemon/container_operations.go` to remove redundant code that was causing duplicate network disconnect events.

**- How I did it**
By identifying and removing the part of the code that was generating an additional event when a network disconnection occurred.

**- How to verify it**
1. Build the modified Docker from my branch.
2. Run a container and disconnect it from a network.
3. Use the `docker events` command to check that only one `network disconnect` event is generated for each disconnection.

**- Description for the changelog**
```markdown changelog
Fix duplicate network disconnect events
```