### PR TITLE
[25.0 backport] Dockerfile: update runc to v1.1.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -283,7 +283,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged. When updating RUNC_VERSION,
 # consider updating runc in vendor.mod accordingly.
-ARG RUNC_VERSION=v1.1.13
+ARG RUNC_VERSION=v1.1.14
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -283,7 +283,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged. When updating RUNC_VERSION,
 # consider updating runc in vendor.mod accordingly.
-ARG RUNC_VERSION=v1.1.12
+ARG RUNC_VERSION=v1.1.13
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=v1.1.12}"
+: "${RUNC_VERSION:=v1.1.13}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=v1.1.13}"
+: "${RUNC_VERSION:=v1.1.14}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"


### PR DESCRIPTION
**- What I did**

Split from https://github.com/moby/moby/pull/48452

* Partial backport of https://github.com/moby/moby/pull/47976
* Backports https://github.com/moby/moby/pull/48424

**- How to verify it**
CI must be successful

**- Description for the changelog**
```markdown changelog
Upgrade `runc` (static binaries only) to  [v1.1.14](https://github.com/opencontainers/runc/releases/tag/v1.1.14)
```

**- A picture of a cute animal (not mandatory but encouraged)**

